### PR TITLE
Store elliptic internal and external face data in unified map

### DIFF
--- a/src/Domain/Tags/FaceNormal.hpp
+++ b/src/Domain/Tags/FaceNormal.hpp
@@ -1,0 +1,25 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/Tags.hpp"
+
+namespace domain::Tags {
+
+/// The _normalized_ face normal
+template <size_t Dim, typename LocalFrame = Frame::Inertial>
+using FaceNormal =
+    ::Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim, LocalFrame>>;
+
+/// The magnitude of the _unnormalized_ face normal, see
+/// `::unnormalized_face_normal`
+template <size_t Dim, typename LocalFrame = Frame::Inertial>
+using UnnormalizedFaceNormalMagnitude =
+    ::Tags::Magnitude<Tags::UnnormalizedFaceNormal<Dim, LocalFrame>>;
+
+}  // namespace domain::Tags

--- a/src/Domain/Tags/Faces.hpp
+++ b/src/Domain/Tags/Faces.hpp
@@ -1,0 +1,103 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <type_traits>
+
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+/// \endcond
+
+namespace domain {
+namespace Tags {
+
+/// The `Tag` on element faces
+template <size_t Dim, typename Tag>
+struct Faces : db::PrefixTag, db::SimpleTag {
+  using tag = Tag;
+  using type = DirectionMap<Dim, typename Tag::type>;
+};
+
+}  // namespace Tags
+
+/// Wrap `Tag` in `domain::Tags::Faces`, unless `Tag` is in the `VolumeTags`
+/// list
+template <typename Dim, typename Tag, typename VolumeTags = tmpl::list<>>
+struct make_faces_tag {
+  using type = tmpl::conditional_t<tmpl::list_contains_v<VolumeTags, Tag>, Tag,
+                                   domain::Tags::Faces<Dim::value, Tag>>;
+};
+
+/// Wrap all tags in `TagsList` in `domain::Tags::Faces`, except those in the
+/// `VolumeTags` list
+template <size_t Dim, typename TagsList, typename VolumeTags = tmpl::list<>>
+using make_faces_tags =
+    tmpl::transform<TagsList, make_faces_tag<tmpl::pin<tmpl::size_t<Dim>>,
+                                             tmpl::_1, tmpl::pin<VolumeTags>>>;
+
+}  // namespace domain
+
+namespace db {
+template <size_t Dim, typename VariablesTag>
+struct Subitems<domain::Tags::Faces<Dim, VariablesTag>,
+                Requires<tt::is_a_v<Variables, typename VariablesTag::type>>> {
+  template <typename LocalTag>
+  using faces_tag = domain::Tags::Faces<Dim, LocalTag>;
+
+  using tag = faces_tag<VariablesTag>;
+  using type =
+      db::wrap_tags_in<faces_tag, typename VariablesTag::type::tags_list>;
+
+  template <typename Subtag>
+  static void create_item(
+      const gsl::not_null<typename tag::type*> parent_value,
+      const gsl::not_null<typename Subtag::type*> sub_value) noexcept {
+    sub_value->clear();
+    for (auto& [direction, all_parent_vars] : *parent_value) {
+      auto& parent_var = get<typename Subtag::tag>(all_parent_vars);
+      auto& sub_var = (*sub_value)[direction];
+      for (auto vars_it = parent_var.begin(), sub_var_it = sub_var.begin();
+           vars_it != parent_var.end(); ++vars_it, ++sub_var_it) {
+        sub_var_it->set_data_ref(&*vars_it);
+      }
+    }
+  }
+
+  // The `return_type` can be anything for Subitems because the DataBox figures
+  // out the correct return type, we just use the `return_type` type alias to
+  // signal to the DataBox we want mutating behavior.
+  using return_type = NoSuchType;
+
+  template <typename Subtag>
+  static void create_compute_item(
+      const gsl::not_null<typename Subtag::type*> sub_value,
+      const typename tag::type& parent_value) noexcept {
+    for (const auto& [direction, all_parent_vars] : parent_value) {
+      const auto& parent_var = get<typename Subtag::tag>(all_parent_vars);
+      auto& sub_var = (*sub_value)[direction];
+      auto sub_var_it = sub_var.begin();
+      for (auto vars_it = parent_var.begin(); vars_it != parent_var.end();
+           ++vars_it, ++sub_var_it) {
+        // clang-tidy: do not use const_cast
+        // The DataBox will only give out a const reference to the
+        // result of a compute item.  Here, that is a reference to a
+        // const map to Tensors of DataVectors.  There is no (publicly
+        // visible) indirection there, so having the map const will
+        // allow only allow const access to the contained DataVectors,
+        // so no modification through the pointer cast here is
+        // possible.
+        sub_var_it->set_data_ref(const_cast<DataVector*>(&*vars_it));  // NOLINT
+      }
+    }
+  }
+};
+}  // namespace db

--- a/src/Elliptic/BoundaryConditions/ApplyBoundaryCondition.hpp
+++ b/src/Elliptic/BoundaryConditions/ApplyBoundaryCondition.hpp
@@ -7,9 +7,9 @@
 #include <type_traits>
 
 #include "DataStructures/DataBox/DataBox.hpp"
-#include "Domain/InterfaceHelpers.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Tags.hpp"
+#include "Domain/Tags/Faces.hpp"
 #include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
 #include "Elliptic/Utilities/ApplyAt.hpp"
 #include "Utilities/FakeVirtual.hpp"
@@ -22,9 +22,8 @@ namespace elliptic {
  * arguments from interface tags in the DataBox.
  *
  * This functions assumes the arguments for the `boundary_condition` are stored
- * in the DataBox in tags
- * `domain::Tags::Interface<domain::Tags::BoundaryDirectionsInterior<Dim>,
- * Tag>`. This may turn out not to be the most efficient setup, so code that
+ * in the DataBox in tags `domain::Tags::Faces<Dim, Tag>`.
+ * This may turn out not to be the most efficient setup, so code that
  * uses the boundary conditions doesn't have to use this function but can
  * procure the arguments differently. For example, future optimizations may
  * involve storing a subset of arguments that don't change during an elliptic
@@ -55,14 +54,12 @@ void apply_boundary_condition(
             tmpl::conditional_t<Linearized,
                                 typename Derived::volume_tags_linearized,
                                 typename Derived::volume_tags>;
-        using argument_tags = tmpl::transform<
+        using argument_tags = domain::make_faces_tags<
+            Dim,
             tmpl::conditional_t<Linearized,
                                 typename Derived::argument_tags_linearized,
                                 typename Derived::argument_tags>,
-            make_interface_tag<
-                tmpl::_1,
-                tmpl::pin<domain::Tags::BoundaryDirectionsInterior<Dim>>,
-                tmpl::pin<volume_tags>>>;
+            volume_tags>;
         using argument_tags_transformed =
             tmpl::conditional_t<std::is_same_v<ArgsTransform, void>,
                                 argument_tags,

--- a/src/Elliptic/Systems/Poisson/Equations.hpp
+++ b/src/Elliptic/Systems/Poisson/Equations.hpp
@@ -78,6 +78,7 @@ void auxiliary_fluxes(
 template <size_t Dim>
 struct Fluxes<Dim, Geometry::FlatCartesian> {
   using argument_tags = tmpl::list<>;
+  using volume_tags = tmpl::list<>;
   static void apply(gsl::not_null<tnsr::I<DataVector, Dim>*> flux_for_field,
                     const tnsr::i<DataVector, Dim>& field_gradient) noexcept;
   static void apply(gsl::not_null<tnsr::Ij<DataVector, Dim>*> flux_for_gradient,
@@ -96,6 +97,7 @@ template <size_t Dim>
 struct Fluxes<Dim, Geometry::Curved> {
   using argument_tags = tmpl::list<
       gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>>;
+  using volume_tags = tmpl::list<>;
   static void apply(gsl::not_null<tnsr::I<DataVector, Dim>*> flux_for_field,
                     const tnsr::II<DataVector, Dim>& inv_spatial_metric,
                     const tnsr::i<DataVector, Dim>& field_gradient) noexcept;

--- a/src/Elliptic/Systems/Xcts/FluxesAndSources.hpp
+++ b/src/Elliptic/Systems/Xcts/FluxesAndSources.hpp
@@ -42,6 +42,7 @@ struct Fluxes;
 template <>
 struct Fluxes<Equations::Hamiltonian, Geometry::FlatCartesian> {
   using argument_tags = tmpl::list<>;
+  using volume_tags = tmpl::list<>;
   static void apply(
       gsl::not_null<tnsr::I<DataVector, 3>*> flux_for_conformal_factor,
       const tnsr::i<DataVector, 3>& conformal_factor_gradient) noexcept;
@@ -54,6 +55,7 @@ template <>
 struct Fluxes<Equations::Hamiltonian, Geometry::Curved> {
   using argument_tags =
       tmpl::list<Tags::InverseConformalMetric<DataVector, 3, Frame::Inertial>>;
+  using volume_tags = tmpl::list<>;
   static void apply(
       gsl::not_null<tnsr::I<DataVector, 3>*> flux_for_conformal_factor,
       const tnsr::II<DataVector, 3>& inv_conformal_metric,
@@ -67,6 +69,7 @@ struct Fluxes<Equations::Hamiltonian, Geometry::Curved> {
 template <>
 struct Fluxes<Equations::HamiltonianAndLapse, Geometry::FlatCartesian> {
   using argument_tags = tmpl::list<>;
+  using volume_tags = tmpl::list<>;
   static void apply(
       gsl::not_null<tnsr::I<DataVector, 3>*> flux_for_conformal_factor,
       gsl::not_null<tnsr::I<DataVector, 3>*>
@@ -87,6 +90,7 @@ template <>
 struct Fluxes<Equations::HamiltonianAndLapse, Geometry::Curved> {
   using argument_tags =
       tmpl::list<Tags::InverseConformalMetric<DataVector, 3, Frame::Inertial>>;
+  using volume_tags = tmpl::list<>;
   static void apply(
       gsl::not_null<tnsr::I<DataVector, 3>*> flux_for_conformal_factor,
       gsl::not_null<tnsr::I<DataVector, 3>*>
@@ -108,6 +112,7 @@ struct Fluxes<Equations::HamiltonianAndLapse, Geometry::Curved> {
 template <>
 struct Fluxes<Equations::HamiltonianLapseAndShift, Geometry::FlatCartesian> {
   using argument_tags = tmpl::list<>;
+  using volume_tags = tmpl::list<>;
   static void apply(
       gsl::not_null<tnsr::I<DataVector, 3>*> flux_for_conformal_factor,
       gsl::not_null<tnsr::I<DataVector, 3>*>
@@ -132,6 +137,7 @@ struct Fluxes<Equations::HamiltonianLapseAndShift, Geometry::Curved> {
   using argument_tags =
       tmpl::list<Tags::ConformalMetric<DataVector, 3, Frame::Inertial>,
                  Tags::InverseConformalMetric<DataVector, 3, Frame::Inertial>>;
+  using volume_tags = tmpl::list<>;
   static void apply(
       gsl::not_null<tnsr::I<DataVector, 3>*> flux_for_conformal_factor,
       gsl::not_null<tnsr::I<DataVector, 3>*>

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 add_subdirectory(FunctionsOfTime)
 add_subdirectory(Python)
+add_subdirectory(Tags)
 
 set(LIBRARY "Test_Domain")
 

--- a/tests/Unit/Domain/Tags/CMakeLists.txt
+++ b/tests/Unit/Domain/Tags/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_DomainTags")
+
+set(LIBRARY_SOURCES
+  Test_Faces.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "Domain/Tags"
+  "${LIBRARY_SOURCES}"
+  ""
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  DataStructures
+  Domain
+  DomainHelpers
+  DomainStructure
+  Utilities
+  )

--- a/tests/Unit/Domain/Tags/Test_Faces.cpp
+++ b/tests/Unit/Domain/Tags/Test_Faces.cpp
@@ -1,0 +1,60 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <type_traits>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Tags/Faces.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace domain {
+
+SPECTRE_TEST_CASE("Unit.Domain.Tags.Faces", "[Unit][Domain]") {
+  constexpr size_t Dim = 1;
+  TestHelpers::db::test_prefix_tag<Tags::Faces<Dim, ::Tags::TempScalar<0>>>(
+      "Faces(TempTensor0)");
+  static_assert(
+      std::is_same_v<
+          make_faces_tags<
+              Dim, tmpl::list<::Tags::TempScalar<0>, ::Tags::TempScalar<1>>,
+              tmpl::list<::Tags::TempScalar<1>>>,
+          tmpl::list<Tags::Faces<Dim, ::Tags::TempScalar<0>>,
+                     ::Tags::TempScalar<1>>>);
+  using vars_on_faces_tag =
+      Tags::Faces<Dim, ::Tags::Variables<tmpl::list<::Tags::TempScalar<0>>>>;
+  using Vars = Variables<tmpl::list<::Tags::TempScalar<0>>>;
+  using scalar_on_faces_tag = Tags::Faces<Dim, ::Tags::TempScalar<0>>;
+  auto box = db::create<db::AddSimpleTags<vars_on_faces_tag>>(
+      DirectionMap<Dim, Vars>{});
+  CHECK(db::get<scalar_on_faces_tag>(box).empty());
+  db::mutate<vars_on_faces_tag>(
+      make_not_null(&box),
+      [](const gsl::not_null<DirectionMap<Dim, Vars>*> vars_on_faces) noexcept {
+        vars_on_faces->emplace(Direction<Dim>::lower_xi(), Vars{size_t{3}, 0.});
+      });
+  CHECK(db::get<scalar_on_faces_tag>(box).at(Direction<Dim>::lower_xi()) ==
+        Scalar<DataVector>{size_t{3}, 0.});
+  db::mutate<scalar_on_faces_tag>(
+      make_not_null(&box),
+      [](const gsl::not_null<DirectionMap<Dim, Scalar<DataVector>>*>
+             scalar_on_faces) noexcept {
+        get(scalar_on_faces->at(Direction<Dim>::lower_xi())) = 1.;
+      });
+  CHECK(db::get<vars_on_faces_tag>(box).at(Direction<Dim>::lower_xi()) ==
+        Vars{size_t{3}, 1.});
+}
+
+}  // namespace domain

--- a/tests/Unit/Elliptic/BoundaryConditions/Test_AnalyticSolution.cpp
+++ b/tests/Unit/Elliptic/BoundaryConditions/Test_AnalyticSolution.cpp
@@ -18,7 +18,10 @@
 #include "DataStructures/Variables.hpp"
 #include "Domain/FaceNormal.hpp"
 #include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Tags.hpp"
+#include "Domain/Tags/FaceNormal.hpp"
+#include "Domain/Tags/Faces.hpp"
 #include "Elliptic/BoundaryConditions/AnalyticSolution.hpp"
 #include "Elliptic/BoundaryConditions/ApplyBoundaryCondition.hpp"
 #include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
@@ -98,17 +101,11 @@ void test_analytic_solution() noexcept {
         ::Tags::AnalyticSolutions<
             tmpl::list<ScalarFieldTag<1>, ScalarFieldTag<2>, FluxTag<Dim, 1>,
                        FluxTag<Dim, 2>>>,
-        domain::Tags::Interface<domain::Tags::BoundaryDirectionsInterior<Dim>,
-                                domain::Tags::Direction<Dim>>,
-        domain::Tags::Interface<
-            domain::Tags::BoundaryDirectionsInterior<Dim>,
-            ::Tags::Normalized<
-                domain::Tags::UnnormalizedFaceNormal<Dim, Frame::Inertial>>>>>(
+        domain::Tags::Faces<Dim, domain::Tags::Direction<Dim>>,
+        domain::Tags::Faces<Dim, domain::Tags::FaceNormal<Dim>>>>(
         volume_mesh, std::move(analytic_solutions),
-        std::unordered_map<Direction<Dim>, Direction<Dim>>{
-            {direction, direction}},
-        std::unordered_map<Direction<Dim>, tnsr::i<DataVector, Dim>>{
-            {direction, face_normal}});
+        DirectionMap<Dim, Direction<Dim>>{{direction, direction}},
+        DirectionMap<Dim, tnsr::i<DataVector, Dim>>{{direction, face_normal}});
     Variables<tmpl::list<ScalarFieldTag<1>, ScalarFieldTag<2>,
                          ::Tags::NormalDotFlux<ScalarFieldTag<1>>,
                          ::Tags::NormalDotFlux<ScalarFieldTag<2>>>>

--- a/tests/Unit/Elliptic/BoundaryConditions/Test_BoundaryCondition.cpp
+++ b/tests/Unit/Elliptic/BoundaryConditions/Test_BoundaryCondition.cpp
@@ -13,7 +13,9 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Tags.hpp"
+#include "Domain/Tags/Faces.hpp"
 #include "Elliptic/BoundaryConditions/ApplyBoundaryCondition.hpp"
 #include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
 #include "Framework/TestCreation.hpp"
@@ -117,15 +119,11 @@ SPECTRE_TEST_CASE("Unit.Elliptic.BoundaryConditions.Base", "[Unit][Elliptic]") {
       dynamic_cast<const BoundaryConditionType&>(*boundary_condition_base);
 
   // Test applying boundary conditions
-  const auto box = db::create<db::AddSimpleTags<
-      domain::Tags::Interface<domain::Tags::BoundaryDirectionsInterior<1>,
-                              ArgumentTag>,
-      VolumeArgumentTag,
-      domain::Tags::Interface<domain::Tags::BoundaryDirectionsInterior<1>,
-                              NonlinearArgumentTag>>>(
-      std::unordered_map<Direction<1>, int>{{Direction<1>::lower_xi(), 1}},
-      true,
-      std::unordered_map<Direction<1>, int>{{Direction<1>::lower_xi(), 2}});
+  const auto box = db::create<
+      db::AddSimpleTags<domain::Tags::Faces<1, ArgumentTag>, VolumeArgumentTag,
+                        domain::Tags::Faces<1, NonlinearArgumentTag>>>(
+      DirectionMap<1, int>{{Direction<1>::lower_xi(), 1}}, true,
+      DirectionMap<1, int>{{Direction<1>::lower_xi(), 2}});
   const size_t num_points = 3;
   Scalar<DataVector> boundary_field{num_points};
   Scalar<DataVector> boundary_n_dot_flux{num_points};

--- a/tests/Unit/Elliptic/Systems/Elasticity/BoundaryConditions/Test_LaserBeam.cpp
+++ b/tests/Unit/Elliptic/Systems/Elasticity/BoundaryConditions/Test_LaserBeam.cpp
@@ -13,7 +13,10 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/FaceNormal.hpp"
 #include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Tags.hpp"
+#include "Domain/Tags/FaceNormal.hpp"
+#include "Domain/Tags/Faces.hpp"
 #include "Elliptic/BoundaryConditions/ApplyBoundaryCondition.hpp"
 #include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
 #include "Elliptic/Systems/Elasticity/BoundaryConditions/LaserBeam.hpp"
@@ -41,15 +44,10 @@ void apply_boundary_condition(
     face_normal.get(d) /= get(face_normal_magnitude);
   }
   const auto box = db::create<db::AddSimpleTags<
-      domain::Tags::Interface<domain::Tags::BoundaryDirectionsInterior<3>,
-                              domain::Tags::Coordinates<3, Frame::Inertial>>,
-      domain::Tags::Interface<
-          domain::Tags::BoundaryDirectionsInterior<3>,
-          ::Tags::Normalized<
-              domain::Tags::UnnormalizedFaceNormal<3, Frame::Inertial>>>>>(
-      std::unordered_map<Direction<3>, tnsr::I<DataVector, 3>>{{direction, x}},
-      std::unordered_map<Direction<3>, tnsr::i<DataVector, 3>>{
-          {direction, face_normal}});
+      domain::Tags::Faces<3, domain::Tags::Coordinates<3, Frame::Inertial>>,
+      domain::Tags::Faces<3, domain::Tags::FaceNormal<3>>>>(
+      DirectionMap<3, tnsr::I<DataVector, 3>>{{direction, x}},
+      DirectionMap<3, tnsr::i<DataVector, 3>>{{direction, face_normal}});
   tnsr::I<DataVector, 3> displacement{x.begin()->size(),
                                       std::numeric_limits<double>::max()};
   elliptic::apply_boundary_condition<Linearized>(laser_beam, box, direction,


### PR DESCRIPTION
## Proposed changes

Remove `domain::Tags::Interface<Internal/ExternalDirections>` from the elliptic code, replacing it with a single `domain::Tags::Faces`. This makes the code a lot simpler, reduces the compile time of the executable translation unit by ~5% and compiler memory usage by ~10% for the `SolveXcts` executable, which I think is quite significant given this small change.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
