### PR TITLE
Add FixedSpeedCubic FunctionOfTime

### DIFF
--- a/src/Domain/FunctionsOfTime/CMakeLists.txt
+++ b/src/Domain/FunctionsOfTime/CMakeLists.txt
@@ -8,6 +8,7 @@ add_spectre_library(${LIBRARY})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  FixedSpeedCubic.cpp
   PiecewisePolynomial.cpp
   ReadSpecPiecewisePolynomial.cpp
   RegisterDerivedWithCharm.cpp
@@ -18,6 +19,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  FixedSpeedCubic.hpp
   FunctionOfTime.hpp
   OptionTags.hpp
   PiecewisePolynomial.hpp

--- a/src/Domain/FunctionsOfTime/FixedSpeedCubic.cpp
+++ b/src/Domain/FunctionsOfTime/FixedSpeedCubic.cpp
@@ -1,0 +1,92 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/FunctionsOfTime/FixedSpeedCubic.hpp"
+
+#include <cmath>
+#include <memory>
+
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+
+namespace domain::FunctionsOfTime {
+FixedSpeedCubic::FixedSpeedCubic(const double initial_function_value,
+                                 const double initial_time,
+                                 const double velocity,
+                                 const double decay_timescale) noexcept
+    : initial_function_value_(initial_function_value),
+      initial_time_(initial_time),
+      velocity_(velocity),
+      squared_decay_timescale_(square(decay_timescale)) {}
+
+std::unique_ptr<FunctionOfTime> FixedSpeedCubic::get_clone() const noexcept {
+  return std::make_unique<FixedSpeedCubic>(*this);
+}
+
+template <size_t MaxDerivReturned>
+std::array<DataVector, MaxDerivReturned + 1> FixedSpeedCubic::func_and_derivs(
+    const double t) const noexcept {
+  static_assert(MaxDerivReturned < 3, "The maximum available derivative is 2.");
+
+  // initialize result for the number of derivs requested
+  std::array<DataVector, MaxDerivReturned + 1> result =
+      make_array<MaxDerivReturned + 1>(DataVector(1, 0.0));
+
+  const double dt = t - initial_time_;
+  const double denom = squared_decay_timescale_ + square(dt);
+  ASSERT(fabs(denom) > 0.0,
+         "FixedSpeedCubic denominator should not be zero; if evaluating at "
+         "t == t0, then do not set the decay timescale tau to 0.");
+  const double one_over_denom = 1.0 / (squared_decay_timescale_ + square(dt));
+
+  gsl::at(result, 0)[0] =
+      initial_function_value_ + velocity_ * cube(dt) * one_over_denom;
+  if (MaxDerivReturned > 0) {
+    gsl::at(result, 1)[0] = (3.0 * squared_decay_timescale_ + square(dt)) *
+                            square(dt) * velocity_ * square(one_over_denom);
+    if (MaxDerivReturned > 1) {
+      gsl::at(result, 2)[0] = -2.0 * squared_decay_timescale_ *
+                              (3.0 * squared_decay_timescale_ - square(dt)) *
+                              dt * velocity_ * cube(one_over_denom);
+    }
+  }
+
+  return result;
+}
+
+void FixedSpeedCubic::pup(PUP::er& p) {
+  FunctionOfTime::pup(p);
+  p | initial_function_value_;
+  p | initial_time_;
+  p | velocity_;
+  p | squared_decay_timescale_;
+}
+
+bool operator==(const FixedSpeedCubic& lhs,
+                const FixedSpeedCubic& rhs) noexcept {
+  return lhs.initial_function_value_ == rhs.initial_function_value_ and
+         lhs.initial_time_ == rhs.initial_time_ and
+         lhs.velocity_ == rhs.velocity_ and
+         lhs.squared_decay_timescale_ == rhs.squared_decay_timescale_;
+}
+
+bool operator!=(const FixedSpeedCubic& lhs,
+                const FixedSpeedCubic& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+PUP::able::PUP_ID FixedSpeedCubic::my_PUP_ID = 0;  // NOLINT
+
+#define DERIV(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                       \
+  template std::array<DataVector, DERIV(data) + 1> \
+  FixedSpeedCubic::func_and_derivs<DERIV(data)>(const double) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (0, 1, 2))
+
+#undef DERIV
+#undef INSTANTIATE
+}  // namespace domain::FunctionsOfTime

--- a/src/Domain/FunctionsOfTime/FixedSpeedCubic.hpp
+++ b/src/Domain/FunctionsOfTime/FixedSpeedCubic.hpp
@@ -1,0 +1,94 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Parallel/CharmPupable.hpp"
+
+namespace domain {
+namespace FunctionsOfTime {
+/*!
+ * \ingroup ControlSystemGroup
+ * \brief Sets \f$f(t)\f$ and derivatives using cubic rational functions,
+ * such that the first derivative approaches a constant and the second
+ * derivative approaches zero.
+ *
+ * The resultant function of time is
+ *
+ * \f{align*}{
+ *   f(t) &= f_0 + \frac{v(t-t_0)^3}{\tau^2+(t-t_0)^2},
+ * \f}
+ *
+ * where \f$f_0\f$ is the value of the function \f$f\f$ at the initial time
+ * \f$t_0\f$, and \f$v\f$ is the velocity that \f$f^\prime(t)\f$ approaches on a
+ * timescale of \f$\tau\f$.
+ */
+class FixedSpeedCubic : public FunctionOfTime {
+ public:
+  FixedSpeedCubic() = default;
+  FixedSpeedCubic(double initial_function_value, double initial_time,
+                  double velocity, double decay_timescale) noexcept;
+
+  ~FixedSpeedCubic() override = default;
+  FixedSpeedCubic(FixedSpeedCubic&&) noexcept = default;
+  FixedSpeedCubic& operator=(FixedSpeedCubic&&) noexcept = default;
+  FixedSpeedCubic(const FixedSpeedCubic&) = default;
+  FixedSpeedCubic& operator=(const FixedSpeedCubic&) = default;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  WRAPPED_PUPable_decl_template(FixedSpeedCubic);
+
+  explicit FixedSpeedCubic(CkMigrateMessage* /*unused*/) {}
+
+  auto get_clone() const noexcept -> std::unique_ptr<FunctionOfTime> override;
+
+  /// Returns the function at an arbitrary time `t`.
+  std::array<DataVector, 1> func(const double t) const noexcept override {
+    return func_and_derivs<0>(t);
+  }
+  /// Returns the function and its first derivative at an arbitrary time `t`.
+  std::array<DataVector, 2> func_and_deriv(
+      const double t) const noexcept override {
+    return func_and_derivs<1>(t);
+  }
+  /// Returns the function and the first two derivatives at an arbitrary time
+  /// `t`.
+  std::array<DataVector, 3> func_and_2_derivs(
+      const double t) const noexcept override {
+    return func_and_derivs<2>(t);
+  }
+
+  /// Returns the domain of validity of the function.
+  std::array<double, 2> time_bounds() const noexcept override {
+    return {{initial_time_, std::numeric_limits<double>::max()}};
+  }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override;
+
+ private:
+  friend bool operator==(const FixedSpeedCubic& lhs,
+                         const FixedSpeedCubic& rhs) noexcept;
+
+  template <size_t MaxDerivReturned = 2>
+  std::array<DataVector, MaxDerivReturned + 1> func_and_derivs(
+      double t) const noexcept;
+
+  double initial_function_value_{std::numeric_limits<double>::signaling_NaN()};
+  double initial_time_{std::numeric_limits<double>::signaling_NaN()};
+  double velocity_{std::numeric_limits<double>::signaling_NaN()};
+  double squared_decay_timescale_{std::numeric_limits<double>::signaling_NaN()};
+};
+
+bool operator!=(const FixedSpeedCubic& lhs,
+                const FixedSpeedCubic& rhs) noexcept;
+}  // namespace FunctionsOfTime
+}  // namespace domain

--- a/src/Domain/FunctionsOfTime/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/FunctionsOfTime/RegisterDerivedWithCharm.cpp
@@ -6,19 +6,19 @@
 #include <pup.h>
 #include <string>
 
+#include "Domain/FunctionsOfTime/FixedSpeedCubic.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Domain/FunctionsOfTime/SettleToConstant.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/TMPL.hpp"
 
-namespace domain {
-namespace FunctionsOfTime {
+namespace domain::FunctionsOfTime {
 void register_derived_with_charm() noexcept {
-  Parallel::register_classes_with_charm<FunctionsOfTime::PiecewisePolynomial<2>,
+  Parallel::register_classes_with_charm<FunctionsOfTime::FixedSpeedCubic,
+                                        FunctionsOfTime::PiecewisePolynomial<2>,
                                         FunctionsOfTime::PiecewisePolynomial<3>,
                                         FunctionsOfTime::PiecewisePolynomial<4>,
                                         FunctionsOfTime::SettleToConstant>();
 }
-}  // namespace FunctionsOfTime
-}  // namespace domain
+}  // namespace domain::FunctionsOfTime

--- a/tests/Unit/Domain/FunctionsOfTime/CMakeLists.txt
+++ b/tests/Unit/Domain/FunctionsOfTime/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_FunctionsOfTime")
 
 set(LIBRARY_SOURCES
+  Test_FixedSpeedCubic.cpp
   Test_PiecewisePolynomial.cpp
   Test_ReadSpecPiecewisePolynomial.cpp
   Test_SettleToConstant.cpp

--- a/tests/Unit/Domain/FunctionsOfTime/Test_FixedSpeedCubic.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_FixedSpeedCubic.cpp
@@ -1,0 +1,143 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <limits>
+#include <memory>
+
+#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "Domain/FunctionsOfTime/FixedSpeedCubic.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+
+namespace {
+void test(
+    const std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>& f_of_t,
+    const double initial_function_value, const double initial_time,
+    const double velocity, const double decay_timescale) noexcept {
+  // Check that at t == initial time, f == initial_function_value,
+  // df = 0, and d2f = 0
+  const auto lambdas0 = f_of_t->func_and_2_derivs(initial_time);
+  CHECK(approx(lambdas0[0][0]) == initial_function_value);
+  CHECK(approx(lambdas0[1][0]) == 0.0);
+  CHECK(approx(lambdas0[2][0]) == 0.0);
+
+  const auto lambdas1 = f_of_t->func_and_deriv(initial_time);
+  CHECK(approx(lambdas1[0][0]) == initial_function_value);
+  CHECK(approx(lambdas1[1][0]) == 0.0);
+
+  const auto lambdas2 = f_of_t->func(initial_time);
+  CHECK(approx(lambdas2[0][0]) == initial_function_value);
+
+  // Check that asymptotic values approach df == velocity, d2f == 0
+  const auto lambdas3 = f_of_t->func_and_2_derivs(decay_timescale * 1.0e7);
+  CHECK(approx(lambdas3[1][0]) == velocity);
+  CHECK(approx(lambdas3[2][0]) == 0.0);
+
+  const auto lambdas4 = f_of_t->func_and_deriv(decay_timescale * 1.0e7);
+  CHECK(approx(lambdas4[1][0]) == velocity);
+
+  // test time_bounds function
+  const auto t_bounds = f_of_t->time_bounds();
+  CHECK(t_bounds[0] == initial_time);
+  CHECK(t_bounds[1] == std::numeric_limits<double>::max());
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.FixedSpeedCubic",
+                  "[Domain][Unit]") {
+  using FixedSpeedCubic = domain::FunctionsOfTime::FixedSpeedCubic;
+
+  domain::FunctionsOfTime::register_derived_with_charm();
+
+  constexpr double initial_function_value{1.0};
+  constexpr double initial_time{10.0};
+  constexpr double velocity{0.4};
+  constexpr double decay_timescale{5.0};
+
+  INFO("Test with base class construction.");
+  const std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> f_of_t =
+      std::make_unique<domain::FunctionsOfTime::FixedSpeedCubic>(
+          initial_function_value, initial_time, velocity, decay_timescale);
+  test(f_of_t, initial_function_value, initial_time, velocity, decay_timescale);
+
+  const std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> f_of_t2 =
+      serialize_and_deserialize(f_of_t);
+  test(f_of_t2, initial_function_value, initial_time, velocity,
+       decay_timescale);
+
+  const std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> f_of_t3 =
+      f_of_t->get_clone();
+  test(f_of_t3, initial_function_value, initial_time, velocity,
+       decay_timescale);
+
+  {
+    INFO("Test operator==");
+    CHECK(FixedSpeedCubic{initial_function_value, initial_time, velocity,
+                          decay_timescale} ==
+          FixedSpeedCubic{initial_function_value, initial_time, velocity,
+                          decay_timescale});
+    CHECK_FALSE(FixedSpeedCubic{initial_function_value, initial_time, velocity,
+                                decay_timescale} !=
+                FixedSpeedCubic{initial_function_value, initial_time, velocity,
+                                decay_timescale});
+
+    CHECK(FixedSpeedCubic{initial_function_value, initial_time, velocity,
+                          decay_timescale} !=
+          FixedSpeedCubic{initial_function_value, initial_time, velocity,
+                          2.0 * decay_timescale});
+    CHECK_FALSE(FixedSpeedCubic{initial_function_value, initial_time, velocity,
+                                decay_timescale} ==
+                FixedSpeedCubic{initial_function_value, initial_time, velocity,
+                                2.0 * decay_timescale});
+
+    CHECK(FixedSpeedCubic{initial_function_value, initial_time, velocity,
+                          decay_timescale} !=
+          FixedSpeedCubic{initial_function_value, initial_time, 2.0 * velocity,
+                          decay_timescale});
+    CHECK_FALSE(FixedSpeedCubic{initial_function_value, initial_time, velocity,
+                                decay_timescale} ==
+                FixedSpeedCubic{initial_function_value, initial_time,
+                                2.0 * velocity, decay_timescale});
+
+    CHECK(FixedSpeedCubic{initial_function_value, initial_time, velocity,
+                          decay_timescale} !=
+          FixedSpeedCubic{initial_function_value, 2.0 * initial_time, velocity,
+                          decay_timescale});
+    CHECK_FALSE(FixedSpeedCubic{initial_function_value, initial_time, velocity,
+                                decay_timescale} ==
+                FixedSpeedCubic{initial_function_value, 2.0 * initial_time,
+                                velocity, decay_timescale});
+
+    CHECK(FixedSpeedCubic{initial_function_value, initial_time, velocity,
+                          decay_timescale} !=
+          FixedSpeedCubic{2.0 * initial_function_value, initial_time, velocity,
+                          decay_timescale});
+    CHECK_FALSE(FixedSpeedCubic{initial_function_value, initial_time, velocity,
+                                decay_timescale} ==
+                FixedSpeedCubic{2.0 * initial_function_value, initial_time,
+                                velocity, decay_timescale});
+  }
+}
+
+// [[OutputRegex, FixedSpeedCubic denominator should not be zero]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Domain.FunctionsOfTime.FixedSpeedCubic.CheckDenom",
+    "[Domain][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  constexpr double initial_function_value = 1.0;
+  constexpr double initial_time = 0.0;
+  constexpr double velocity = -0.1;
+  constexpr double decay_timescale = 0.0;
+  const std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> f_of_t =
+      std::make_unique<domain::FunctionsOfTime::FixedSpeedCubic>(
+          initial_function_value, initial_time, velocity, decay_timescale);
+  test(f_of_t, initial_function_value, initial_time, velocity, decay_timescale);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}


### PR DESCRIPTION
## Proposed changes

Ports the FixedSpeedCubic FunctionOfTime from SpEC. This FunctionOfTime uses cubic polynomials to start out with a given initial value and zero first and second derivatives and asymptote to a given first derivative and zero second derivative. I based the function and its test on SettleToConstant, a similar FunctionOfTime that was ported a while ago.

This function of time is used to make the outer boundary of a domain move slightly inward, avoiding zero-speed modes on the outer boundary.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
