### PR TITLE
Horizon finder in grid frame

### DIFF
--- a/src/DataStructures/Tensor/Metafunctions.hpp
+++ b/src/DataStructures/Tensor/Metafunctions.hpp
@@ -119,4 +119,24 @@ using remove_first_index =
 template <typename NewType, typename Tensor>
 using swap_type =
     ::Tensor<NewType, typename Tensor::symmetry, typename Tensor::index_list>;
+
+namespace detail {
+template <typename T, typename Frame>
+using frame_is_the_same = std::is_same<typename T::Frame, Frame>;
+}  // namespace detail
+
+/// \ingroup TensorGroup
+/// \brief Return tmpl::true_type if any indices of the Tensor are in the
+/// frame Frame.
+template <typename Tensor, typename Frame>
+using any_index_in_frame =
+    tmpl::any<typename Tensor::index_list,
+              tmpl::bind<detail::frame_is_the_same, tmpl::_1, Frame>>;
+
+/// \ingroup TensorGroup
+/// \brief Return true if any indices of the Tensor are in the
+/// frame Frame.
+template <typename Tensor, typename Frame>
+constexpr bool any_index_in_frame_v = any_index_in_frame<Tensor, Frame>::value;
+
 }  // namespace TensorMetafunctions

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
@@ -6,6 +6,8 @@
 #include <cstdint>
 #include <vector>
 
+#include "ApparentHorizons/ComputeHorizonVolumeQuantities.hpp"
+#include "ApparentHorizons/ComputeHorizonVolumeQuantities.tpp"
 #include "ApparentHorizons/ComputeItems.hpp"
 #include "ApparentHorizons/Tags.hpp"
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
@@ -61,11 +63,7 @@ struct EvolutionMetavars
     using tags_to_observe =
         tmpl::list<StrahlkorperGr::Tags::AreaCompute<frame>,
                    StrahlkorperGr::Tags::IrreducibleMassCompute<frame>>;
-    using compute_items_on_source = tmpl::list<
-        gr::Tags::SpatialMetricCompute<volume_dim, frame, DataVector>,
-        ah::Tags::InverseSpatialMetricCompute<volume_dim, frame>,
-        ah::Tags::ExtrinsicCurvatureCompute<volume_dim, frame>,
-        ah::Tags::SpatialChristoffelSecondKindCompute<volume_dim, frame>>;
+    using compute_vars_to_interpolate = ah::ComputeHorizonVolumeQuantities;
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::SpatialMetric<volume_dim, frame, DataVector>,
                    gr::Tags::InverseSpatialMetric<volume_dim, frame>,

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizon.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizon.hpp
@@ -5,6 +5,8 @@
 
 #include <vector>
 
+#include "ApparentHorizons/ComputeHorizonVolumeQuantities.hpp"
+#include "ApparentHorizons/ComputeHorizonVolumeQuantities.tpp"
 #include "ApparentHorizons/ComputeItems.hpp"
 #include "ApparentHorizons/Tags.hpp"
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
@@ -62,12 +64,7 @@ struct EvolutionMetavars
   struct AhA {
     using tags_to_observe =
         tmpl::list<StrahlkorperGr::Tags::AreaCompute<domain_frame>>;
-    using compute_items_on_source = tmpl::list<
-        gr::Tags::SpatialMetricCompute<volume_dim, domain_frame, DataVector>,
-        ah::Tags::InverseSpatialMetricCompute<volume_dim, domain_frame>,
-        ah::Tags::ExtrinsicCurvatureCompute<volume_dim, domain_frame>,
-        ah::Tags::SpatialChristoffelSecondKindCompute<volume_dim,
-                                                      domain_frame>>;
+    using compute_vars_to_interpolate = ah::ComputeHorizonVolumeQuantities;
     using vars_to_interpolate_to_target = tmpl::list<
         gr::Tags::SpatialMetric<volume_dim, domain_frame, DataVector>,
         gr::Tags::InverseSpatialMetric<volume_dim, domain_frame>,

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTarget.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTarget.hpp
@@ -41,10 +41,33 @@ namespace intrp {
 /// - vars_to_interpolate_to_target:
 ///      A `tmpl::list` of tags describing variables to interpolate.
 ///      Will be used to construct a `Variables`.
+/// - compute_vars_to_interpolate:
+///      A struct with at least one of the functions
+///```
+/// static void apply(const gsl::not_null<
+///                  Variables<vars_to_interpolate_to_target>*>,
+///                  const Variables<Metavariables::interpolator_source_vars>&,
+///                  const Mesh<Dim>&);
+/// static void apply(const gsl::not_null<
+///                  Variables<vars_to_interpolate_to_target>*>,
+///                  const Variables<Metavariables::interpolator_source_vars>&,
+///                  const Mesh<Dim>&,
+///                  const Jacobian<DataVector, Dim, TargetFrame, SrcFrame>&,
+///                  const InverseJacobian<DataVector, Dim,
+///                  ::Frame::Logical, TargetFrame>&);
+///```
+///     that fills `vars_to_interpolate_to_target`.  Here Dim is
+///     `Metavariables::volume_dim`, SrcFrame is the frame of
+///     `Metavariables::interpolator_source_vars` and
+///      TargetFrame is the frame of `vars_to_interpolate_to_target`.
+///      The overload without Jacobians treats the case in which
+///      TargetFrame is the same as SrcFrame.
+///      Used only *with* the Interpolator ParallelComponent.
 /// - compute_items_on_source:
 ///      A `tmpl::list` of compute items that uses
 ///      `Metavariables::interpolator_source_vars` as input and computes the
 ///      `Variables` defined by `vars_to_interpolate_to_target`.
+///      Used only *without* the Interpolator ParallelComponent.
 /// - compute_items_on_target:
 ///      A `tmpl::list` of compute items that uses
 ///      `vars_to_interpolate_to_target` as input.

--- a/src/NumericalAlgorithms/Interpolation/InterpolatorReceiveVolumeData.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolatorReceiveVolumeData.hpp
@@ -66,7 +66,7 @@ struct InterpolatorReceiveVolumeData {
               .emplace(std::make_pair(
                   element_id,
                   typename Tags::VolumeVarsInfo<Metavariables>::Info{
-                      mesh, std::move(vars)}));
+                      mesh, std::move(vars), {}}));
         });
 
     // Try to interpolate data for all InterpolationTargets.

--- a/tests/Unit/DataStructures/Tensor/Test_Tensor.cpp
+++ b/tests/Unit/DataStructures/Tensor/Test_Tensor.cpp
@@ -74,6 +74,25 @@ static_assert(std::is_same_v<tnsr::iJ<double, 3, Frame::Grid>,
                                  Frame::Grid>>,
               "Failed testing prepend_spatial_index");
 
+// Test any_index_in_frame_v
+static_assert(TensorMetafunctions::any_index_in_frame_v<
+                  tnsr::iJ<double, 3, Frame::Grid>, Frame::Grid>,
+              "Failed testing any_index_in_frame_v where it should match");
+static_assert(not TensorMetafunctions::any_index_in_frame_v<
+                  tnsr::iJ<double, 3, Frame::Grid>, Frame::Inertial>,
+              "Failed testing any_index_in_frame_v where it should not match");
+static_assert(
+    TensorMetafunctions::any_index_in_frame_v<
+        Tensor<
+            double, tmpl::integral_list<std::int32_t, 2, 1>,
+            index_list<Tensor_detail::TensorIndexType<
+                           3, UpLo::Lo, Frame::Inertial, IndexType::Spacetime>,
+                       Tensor_detail::TensorIndexType<3, UpLo::Lo, Frame::Grid,
+                                                      IndexType::Spacetime>>>,
+        Frame::Inertial>,
+    "Failed testing any_index_in_frame_v for a tensor with different frames "
+    "for different indices");
+
 // Test remove_first_index
 static_assert(
     std::is_same_v<Scalar<double>, TensorMetafunctions::remove_first_index<

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
@@ -100,6 +100,16 @@ struct SquareCompute : Square, db::ComputeTag {
 };
 }  // namespace Tags
 
+struct ComputeSquare {
+  template <typename SrcTag, typename DestTag>
+  static void apply(
+      const gsl::not_null<Variables<tmpl::list<DestTag>>*> target_vars,
+      const Variables<tmpl::list<SrcTag>>& src_vars,
+      const Mesh<3>& /* mesh */) noexcept {
+    get(get<DestTag>(*target_vars)) = square(get(get<SrcTag>(src_vars)));
+  }
+};
+
 template <typename InterpolationTargetTag>
 struct MockInterpolationTargetReceiveVars {
   template <typename ParallelComponent, typename DbTags, typename Metavariables,
@@ -205,7 +215,7 @@ struct mock_interpolator {
 struct MockMetavariables {
   struct InterpolationTargetA {
     using vars_to_interpolate_to_target = tmpl::list<Tags::Square>;
-    using compute_items_on_source = tmpl::list<Tags::SquareCompute>;
+    using compute_vars_to_interpolate = ComputeSquare;
     using compute_items_on_target = tmpl::list<>;
   };
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
@@ -198,7 +198,6 @@ struct MockInterpolator {
 
 struct MockMetavariables {
   struct SurfaceA {
-    using compute_items_on_source = tmpl::list<>;
     using vars_to_interpolate_to_target =
         tmpl::list<Tags::TestSolution,
                    gr::Tags::SpatialMetric<3, Frame::Inertial>>;
@@ -216,7 +215,6 @@ struct MockMetavariables {
             SurfaceA, SurfaceA>;
   };
   struct SurfaceB {
-    using compute_items_on_source = tmpl::list<>;
     using vars_to_interpolate_to_target =
         tmpl::list<Tags::TestSolution,
                    gr::Tags::SpatialMetric<3, Frame::Inertial>>;
@@ -238,7 +236,6 @@ struct MockMetavariables {
             SurfaceB, SurfaceB>;
   };
   struct SurfaceC {
-    using compute_items_on_source = tmpl::list<>;
     using vars_to_interpolate_to_target =
         tmpl::list<Tags::TestSolution,
                    gr::Tags::SpatialMetric<3, Frame::Inertial>>;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
@@ -99,6 +99,27 @@ struct NegateCompute : Negate, db::ComputeTag {
 };
 }  // namespace Tags
 
+
+// Structs for compute_vars_to_interpolate.
+struct ComputeSquare {
+  template <typename SrcTag, typename DestTag>
+  static void apply(
+      const gsl::not_null<Variables<tmpl::list<DestTag>>*> target_vars,
+      const Variables<tmpl::list<SrcTag>>& src_vars,
+      const Mesh<3>& /* mesh */) noexcept {
+    get(get<DestTag>(*target_vars)) = square(get(get<SrcTag>(src_vars)));
+  }
+};
+struct ComputeNegate {
+  template <typename SrcTag, typename DestTag>
+  static void apply(
+      const gsl::not_null<Variables<tmpl::list<DestTag>>*> target_vars,
+      const Variables<tmpl::list<SrcTag>>& src_vars,
+      const Mesh<3>& /* mesh */) noexcept {
+    get(get<DestTag>(*target_vars)) = -get(get<SrcTag>(src_vars));
+  }
+};
+
 // Functions for testing whether we have
 // interpolated correctly.  These encode the
 // number of points and the coordinates (chosen by hand to
@@ -215,7 +236,7 @@ struct mock_interpolator {
 
 struct MockMetavariables {
   struct InterpolationTargetA {
-    using compute_items_on_source = tmpl::list<Tags::SquareCompute>;
+    using compute_vars_to_interpolate = ComputeSquare;
     using vars_to_interpolate_to_target = tmpl::list<Tags::Square>;
     using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
@@ -224,7 +245,7 @@ struct MockMetavariables {
         TestFunction<InterpolationTargetA, Tags::Square>;
   };
   struct InterpolationTargetB {
-    using compute_items_on_source = tmpl::list<Tags::SquareCompute>;
+    using compute_vars_to_interpolate = ComputeSquare;
     using vars_to_interpolate_to_target = tmpl::list<Tags::Square>;
     using compute_items_on_target = tmpl::list<Tags::NegateCompute>;
     using compute_target_points =
@@ -233,7 +254,6 @@ struct MockMetavariables {
         TestFunction<InterpolationTargetB, Tags::Negate>;
   };
   struct InterpolationTargetC {
-    using compute_items_on_source = tmpl::list<>;
     using vars_to_interpolate_to_target = tmpl::list<Tags::TestSolution>;
     using compute_items_on_target = tmpl::list<Tags::SquareCompute>;
     using compute_target_points =


### PR DESCRIPTION
## Proposed changes

This PR does two things:
1. Changes the interpolation (when using an Interpolator parallel component) to use `compute_vars_to_interpolate` instead of `compute_items_on_source`, and propagates this change to all Interpolator functions and tests.  This has a few advantages:
   - The metavariables now specifies a functor to compute the volume quantities that are interpolated, so the user no longer needs to add a long list of ComputeItems to the metavariables (and this list would have been really long with dual frames). 
   - Because `compute_vars_to_interpolate` has a single function and not ComputeItems, it can dramatically reduce memory allocations (and the function added in #3261 does a single allocation of a Variables containing all the temporaries).
   - `compute_vars_to_interpolate` is evaluated only once per relevant Element and this evaluation applies to all horizon finder iterations; previously the ComputeItems were evaluated on each horizon finder iteration, which was wasteful.
2. Adds the logic so that one can interpolate to points in the Grid frame when there are time-dependent maps; this includes adding a test to Test_ApparentHorizonFinder that adds horizon finding in the Grid frame.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
One must now specify `compute_vars_to_interpolate` instead of `compute_items_on_source` for interpolation that uses the Interpolator ParallelComponent.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
