### PR TITLE
Factor out TensorExpression::evaluate rank 3 and 4 tests to own files

### DIFF
--- a/tests/Unit/DataStructures/Tensor/Expressions/CMakeLists.txt
+++ b/tests/Unit/DataStructures/Tensor/Expressions/CMakeLists.txt
@@ -7,6 +7,8 @@ set(LIBRARY_SOURCES
   Test_AddSubtract.cpp
   Test_Contract.cpp
   Test_Evaluate.cpp
+  Test_EvaluateRank3.cpp
+  Test_EvaluateRank4.cpp
   Test_MixedOperations.cpp
   Test_Product.cpp
   Test_ProductHighRankIntermediate.cpp

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Evaluate.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Evaluate.cpp
@@ -9,12 +9,9 @@
 #include "DataStructures/Tensor/Expressions/Evaluate.hpp"
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
-#include "DataStructures/Tensor/Symmetry.hpp"
 #include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank0TestHelpers.hpp"
 #include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank1TestHelpers.hpp"
 #include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank2TestHelpers.hpp"
-#include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank3TestHelpers.hpp"
-#include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank4TestHelpers.hpp"
 
 namespace {
 template <auto&... TensorIndices>
@@ -146,124 +143,4 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Evaluate",
   // Rank 2: DataVector; symmetric
   TestHelpers::TensorExpressions::test_evaluate_rank_2_symmetric<
       DataVector, SpatialIndex, UpLo::Lo, ti_j, ti_i>();
-
-  // Rank 3: double; nonsymmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_3_no_symmetry<
-      double, SpacetimeIndex, SpatialIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo,
-      UpLo::Up, ti_D, ti_j, ti_B>();
-
-  // Rank 3: double; first and second indices symmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_3_ab_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti_b, ti_a,
-      ti_C>();
-
-  // Rank 3: double; first and third indices symmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_3_ac_symmetry<
-      double, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo, ti_i, ti_f,
-      ti_j>();
-
-  // Rank 3: double; second and third indices symmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_3_bc_symmetry<
-      double, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Up, ti_d, ti_J,
-      ti_I>();
-
-  // Rank 3: double; symmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_3_abc_symmetry<
-      double, SpacetimeIndex, UpLo::Lo, ti_f, ti_d, ti_a>();
-
-  // Rank 3: DataVector; nonsymmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_3_no_symmetry<
-      DataVector, SpacetimeIndex, SpatialIndex, SpacetimeIndex, UpLo::Up,
-      UpLo::Lo, UpLo::Up, ti_D, ti_j, ti_B>();
-
-  // Rank 3: DataVector; first and second indices symmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_3_ab_symmetry<
-      DataVector, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti_b,
-      ti_a, ti_C>();
-
-  // Rank 3: DataVector; first and third indices symmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_3_ac_symmetry<
-      DataVector, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo, ti_i, ti_f,
-      ti_j>();
-
-  // Rank 3: DataVector; second and third indices symmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_3_bc_symmetry<
-      DataVector, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Up, ti_d, ti_J,
-      ti_I>();
-
-  // Rank 3: DataVector; symmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_3_abc_symmetry<
-      DataVector, SpacetimeIndex, UpLo::Lo, ti_f, ti_d, ti_a>();
-
-  // Rank 4: double; nonsymmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_4<
-      double, Symmetry<4, 3, 2, 1>,
-      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
-                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
-                 SpatialIndex<1, UpLo::Lo, Frame::Inertial>,
-                 SpatialIndex<2, UpLo::Lo, Frame::Inertial>>,
-      ti_b, ti_A, ti_k, ti_l>();
-
-  // Rank 4: double; second and third indices symmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_4<
-      double, Symmetry<3, 2, 2, 1>,
-      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
-                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                 SpatialIndex<1, UpLo::Lo, Frame::Grid>>,
-      ti_G, ti_d, ti_a, ti_j>();
-
-  // Rank 4: double; first, second, and fourth indices symmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_4<
-      double, Symmetry<2, 2, 1, 2>,
-      index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
-                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
-                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
-                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>>,
-      ti_j, ti_i, ti_k, ti_l>();
-
-  // Rank 4: double; symmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_4<
-      double, Symmetry<1, 1, 1, 1>,
-      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
-                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
-                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
-                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>>,
-      ti_F, ti_A, ti_C, ti_D>();
-
-  // Rank 4: DataVector; nonsymmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_4<
-      DataVector, Symmetry<4, 3, 2, 1>,
-      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
-                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
-                 SpatialIndex<1, UpLo::Lo, Frame::Inertial>,
-                 SpatialIndex<2, UpLo::Lo, Frame::Inertial>>,
-      ti_b, ti_A, ti_k, ti_l>();
-
-  // Rank 4: DataVector; second and third indices symmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_4<
-      DataVector, Symmetry<3, 2, 2, 1>,
-      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
-                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                 SpatialIndex<1, UpLo::Lo, Frame::Grid>>,
-      ti_G, ti_d, ti_a, ti_j>();
-
-  // Rank 4: DataVector; first, second, and fourth indices symmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_4<
-      DataVector, Symmetry<2, 2, 1, 2>,
-      index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
-                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
-                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
-                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>>,
-      ti_j, ti_i, ti_k, ti_l>();
-
-  // Rank 4: DataVector; symmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_4<
-      DataVector, Symmetry<1, 1, 1, 1>,
-      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
-                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
-                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
-                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>>,
-      ti_F, ti_A, ti_C, ti_D>();
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3.cpp
@@ -1,0 +1,60 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank3TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateRank3",
+                  "[DataStructures][Unit]") {
+  // Rank 3: double; nonsymmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_3_no_symmetry<
+      double, SpacetimeIndex, SpatialIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo,
+      UpLo::Up, ti_D, ti_j, ti_B>();
+
+  // Rank 3: double; first and second indices symmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_3_ab_symmetry<
+      double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti_b, ti_a,
+      ti_C>();
+
+  // Rank 3: double; first and third indices symmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_3_ac_symmetry<
+      double, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo, ti_i, ti_f,
+      ti_j>();
+
+  // Rank 3: double; second and third indices symmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_3_bc_symmetry<
+      double, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Up, ti_d, ti_J,
+      ti_I>();
+
+  // Rank 3: double; symmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_3_abc_symmetry<
+      double, SpacetimeIndex, UpLo::Lo, ti_f, ti_d, ti_a>();
+
+  // Rank 3: DataVector; nonsymmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_3_no_symmetry<
+      DataVector, SpacetimeIndex, SpatialIndex, SpacetimeIndex, UpLo::Up,
+      UpLo::Lo, UpLo::Up, ti_D, ti_j, ti_B>();
+
+  // Rank 3: DataVector; first and second indices symmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_3_ab_symmetry<
+      DataVector, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti_b,
+      ti_a, ti_C>();
+
+  // Rank 3: DataVector; first and third indices symmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_3_ac_symmetry<
+      DataVector, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo, ti_i, ti_f,
+      ti_j>();
+
+  // Rank 3: DataVector; second and third indices symmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_3_bc_symmetry<
+      DataVector, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Up, ti_d, ti_J,
+      ti_I>();
+
+  // Rank 3: DataVector; symmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_3_abc_symmetry<
+      DataVector, SpacetimeIndex, UpLo::Lo, ti_f, ti_d, ti_a>();
+}

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank4.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank4.cpp
@@ -1,0 +1,85 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Symmetry.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank4TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateRank4",
+                  "[DataStructures][Unit]") {
+  // Rank 4: double; nonsymmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_4<
+      double, Symmetry<4, 3, 2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpatialIndex<1, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<2, UpLo::Lo, Frame::Inertial>>,
+      ti_b, ti_A, ti_k, ti_l>();
+
+  // Rank 4: double; second and third indices symmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_4<
+      double, Symmetry<3, 2, 2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpatialIndex<1, UpLo::Lo, Frame::Grid>>,
+      ti_G, ti_d, ti_a, ti_j>();
+
+  // Rank 4: double; first, second, and fourth indices symmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_4<
+      double, Symmetry<2, 2, 1, 2>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti_j, ti_i, ti_k, ti_l>();
+
+  // Rank 4: double; symmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_4<
+      double, Symmetry<1, 1, 1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>>,
+      ti_F, ti_A, ti_C, ti_D>();
+
+  // Rank 4: DataVector; nonsymmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_4<
+      DataVector, Symmetry<4, 3, 2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpatialIndex<1, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<2, UpLo::Lo, Frame::Inertial>>,
+      ti_b, ti_A, ti_k, ti_l>();
+
+  // Rank 4: DataVector; second and third indices symmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_4<
+      DataVector, Symmetry<3, 2, 2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpatialIndex<1, UpLo::Lo, Frame::Grid>>,
+      ti_G, ti_d, ti_a, ti_j>();
+
+  // Rank 4: DataVector; first, second, and fourth indices symmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_4<
+      DataVector, Symmetry<2, 2, 1, 2>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti_j, ti_i, ti_k, ti_l>();
+
+  // Rank 4: DataVector; symmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_4<
+      DataVector, Symmetry<1, 1, 1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>>,
+      ti_F, ti_A, ti_C, ti_D>();
+}


### PR DESCRIPTION
## Proposed changes

This PR factors out the rank 3 and rank 4 `TensorExpressions::evaluate` test cases into their own files.

Recently, a gcc-7 build showed that the compilation of the `Test_Expressions` target, which includes the unit tests for `TensorExpression`s, is being killed:
- [Example build output](https://github.com/sxs-collaboration/spectre/pull/3269/checks?check_run_id=2807865915)

One believed possible cause of this is that having all of the `evaluate` unit tests (for ranks 0, 1, 2, 3, and 4) in one test file, `Test_Evaluate.cpp`, may be overwhelming the CI build due to the memory usage. This PR is meant to reduce the memory usage per cpp test file for compiling `evaluate` unit tests by factoring out the higher rank test cases into their own test cpps to see if this fixes the CI build issue.

For documentation purposes, note [this](https://github.com/sxs-collaboration/spectre/pull/3012) related previous `TensorExpression` unit test refactoring.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
