### PR TITLE
Add ValenciaDivClean Outflow BC

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/BoundaryCondition.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/BoundaryCondition.hpp
@@ -12,6 +12,7 @@
 /// \cond
 namespace grmhd::ValenciaDivClean::BoundaryConditions {
 class DirichletAnalytic;
+class Outflow;
 }  // namespace grmhd::ValenciaDivClean::BoundaryConditions
 /// \endcond
 
@@ -21,7 +22,7 @@ namespace grmhd::ValenciaDivClean::BoundaryConditions {
 class BoundaryCondition : public domain::BoundaryConditions::BoundaryCondition {
  public:
   using creatable_classes =
-      tmpl::list<DirichletAnalytic,
+      tmpl::list<DirichletAnalytic, Outflow,
                  domain::BoundaryConditions::Periodic<BoundaryCondition>>;
 
   BoundaryCondition() = default;

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/CMakeLists.txt
@@ -6,6 +6,7 @@ spectre_target_sources(
   PRIVATE
   BoundaryCondition.cpp
   DirichletAnalytic.cpp
+  Outflow.cpp
   RegisterDerivedWithCharm.cpp
   )
 
@@ -16,5 +17,6 @@ spectre_target_headers(
   BoundaryCondition.hpp
   DirichletAnalytic.hpp
   Factory.hpp
+  Outflow.hpp
   RegisterDerivedWithCharm.hpp
   )

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Factory.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Factory.hpp
@@ -5,3 +5,4 @@
 
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/BoundaryCondition.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/DirichletAnalytic.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Outflow.hpp"

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Outflow.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Outflow.cpp
@@ -1,0 +1,72 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Outflow.hpp"
+
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <pup.h>
+#include <string>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/BoundaryCondition.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace grmhd::ValenciaDivClean::BoundaryConditions {
+Outflow::Outflow(CkMigrateMessage* const msg) noexcept
+    : BoundaryCondition(msg) {}
+
+std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+Outflow::get_clone() const noexcept {
+  return std::make_unique<Outflow>(*this);
+}
+
+void Outflow::pup(PUP::er& p) { BoundaryCondition::pup(p); }
+
+std::optional<std::string> Outflow::dg_outflow(
+    const std::optional<tnsr::I<DataVector, 3, Frame::Inertial>>&
+        face_mesh_velocity,
+    const tnsr::i<DataVector, 3, Frame::Inertial>&
+        outward_directed_normal_covector,
+    const tnsr::I<DataVector, 3, Frame::Inertial>&
+    /*outward_directed_normal_vector*/,
+
+    const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
+    const Scalar<DataVector>& lapse) noexcept {
+  double min_speed = std::numeric_limits<double>::signaling_NaN();
+  Variables<tmpl::list<::Tags::TempScalar<0>, ::Tags::TempScalar<1>>> buffer{
+      get(lapse).size()};
+  auto& normal_dot_shift = get<::Tags::TempScalar<0>>(buffer);
+  dot_product(make_not_null(&normal_dot_shift),
+              outward_directed_normal_covector, shift);
+  if (face_mesh_velocity.has_value()) {
+    auto& normal_dot_mesh_velocity = get<::Tags::TempScalar<1>>(buffer);
+    dot_product(make_not_null(&normal_dot_mesh_velocity),
+                outward_directed_normal_covector, face_mesh_velocity.value());
+    get(normal_dot_shift) += get(normal_dot_mesh_velocity);
+  }
+  // The characteristic speeds are bounded by \pm \alpha - \beta_n, and
+  // saturate that bound, so there is no need to check the hydro-dependent
+  // characteristic speeds.
+  min_speed = std::min(min(-get(lapse) - get(normal_dot_shift)),
+                       min(get(lapse) - get(normal_dot_shift)));
+  if (min_speed < 0.0) {
+    return {MakeString{} << "Outflow boundary condition violated. Speed: "
+                         << min_speed << "\nn_i: "
+                         << outward_directed_normal_covector << "\n"};
+  }
+  return std::nullopt;
+}
+
+// NOLINTNEXTLINE
+PUP::able::PUP_ID Outflow::my_PUP_ID = 0;
+}  // namespace grmhd::ValenciaDivClean::BoundaryConditions

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Outflow.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Outflow.hpp
@@ -1,0 +1,72 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <pup.h>
+#include <string>
+#include <type_traits>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/BoundaryConditions/Type.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/BoundaryCondition.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace grmhd::ValenciaDivClean::BoundaryConditions {
+/// A `BoundaryCondition` that only verifies that all characteristic speeds are
+/// directed out of the domain; no boundary data is altered by this boundary
+/// condition.
+class Outflow final : public BoundaryCondition {
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help{
+      "Outflow boundary condition that only verifies the characteristic speeds "
+      "are all directed out of the domain."};
+
+  Outflow() = default;
+  Outflow(Outflow&&) noexcept = default;
+  Outflow& operator=(Outflow&&) noexcept = default;
+  Outflow(const Outflow&) = default;
+  Outflow& operator=(const Outflow&) = default;
+  ~Outflow() override = default;
+
+  explicit Outflow(CkMigrateMessage* msg) noexcept;
+
+  WRAPPED_PUPable_decl_base_template(
+      domain::BoundaryConditions::BoundaryCondition, Outflow);
+
+  auto get_clone() const noexcept -> std::unique_ptr<
+      domain::BoundaryConditions::BoundaryCondition> override;
+
+  static constexpr evolution::BoundaryConditions::Type bc_type =
+      evolution::BoundaryConditions::Type::Outflow;
+
+  void pup(PUP::er& p) override;
+
+  using dg_interior_evolved_variables_tags = tmpl::list<>;
+  using dg_interior_temporary_tags =
+      tmpl::list<gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+                 gr::Tags::Lapse<DataVector>>;
+  using dg_gridless_tags = tmpl::list<>;
+  using dg_interior_primitive_variables_tags = tmpl::list<>;
+
+  static std::optional<std::string> dg_outflow(
+      const std::optional<tnsr::I<DataVector, 3, Frame::Inertial>>&
+          face_mesh_velocity,
+      const tnsr::i<DataVector, 3, Frame::Inertial>&
+          outward_directed_normal_covector,
+      const tnsr::I<DataVector, 3, Frame::Inertial>&
+      /*outward_directed_normal_vector*/,
+
+      const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
+      const Scalar<DataVector>& lapse) noexcept;
+};
+}  // namespace grmhd::ValenciaDivClean::BoundaryConditions

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/RegisterDerivedWithCharm.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/RegisterDerivedWithCharm.cpp
@@ -5,6 +5,7 @@
 
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/BoundaryCondition.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/DirichletAnalytic.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Outflow.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 
 namespace grmhd::ValenciaDivClean::BoundaryConditions {

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Outflow.py
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Outflow.py
@@ -1,0 +1,24 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def characteristic_speeds(lapse, shift, outward_directed_normal_covector):
+    return [
+        lapse - np.dot(outward_directed_normal_covector, shift),
+        -lapse - np.dot(outward_directed_normal_covector, shift)
+    ]
+
+
+def error(face_mesh_velocity, outward_directed_normal_covector,
+          outward_directed_normal_vector, shift, lapse):
+    speeds = characteristic_speeds(lapse, shift,
+                                   outward_directed_normal_covector)
+    for i in range(2):
+        if face_mesh_velocity is not None:
+            speeds[i] -= np.dot(outward_directed_normal_covector,
+                                face_mesh_velocity)
+        if speeds[i] < 0.0:
+            return ("Outflow boundary condition violated. .*")
+    return None

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Test_Outflow.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Test_Outflow.cpp
@@ -1,0 +1,44 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Index.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Factory.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Outflow.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Rusanov.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace helpers = TestHelpers::evolution::dg;
+
+SPECTRE_TEST_CASE("Unit.GrMhd.BoundaryConditions.Outflow", "[Unit][GrMhd]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/"};
+  MAKE_GENERATOR(gen);
+  const std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+      boundary_condition = TestHelpers::test_creation<std::unique_ptr<
+          grmhd::ValenciaDivClean::BoundaryConditions::BoundaryCondition>>(
+          "Outflow:\n");
+
+  helpers::test_boundary_condition_with_python<
+      grmhd::ValenciaDivClean::BoundaryConditions::Outflow,
+      grmhd::ValenciaDivClean::BoundaryConditions::BoundaryCondition,
+      grmhd::ValenciaDivClean::System,
+      tmpl::list<grmhd::ValenciaDivClean::BoundaryCorrections::Rusanov>>(
+      make_not_null(&gen), "Outflow",
+      tuples::TaggedTuple<helpers::Tags::PythonFunctionForErrorMessage<>>{
+          "error"},
+      "Outflow:\n", Index<2>{5}, db::DataBox<tmpl::list<>>{},
+      tuples::TaggedTuple<>{});
+}

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_ValenciaDivClean")
 
 set(LIBRARY_SOURCES
   BoundaryConditions/Test_DirichletAnalytic.cpp
+  BoundaryConditions/Test_Outflow.cpp
   BoundaryConditions/Test_Periodic.cpp
   BoundaryCorrections/Test_Rusanov.cpp
   Subcell/Test_InitialDataTci.cpp


### PR DESCRIPTION
## Proposed changes

Adds the outflow `BoundaryCondition` to the `ValenciaDivClean` system -- this boundary condition just checks that the characteristic speeds are directed out of the domain, without altering any of the evolved variables or their time derivatives.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.
