### PR TITLE
Add AddSimpleTags initialization action

### DIFF
--- a/src/ParallelAlgorithms/Initialization/Actions/AddSimpleTags.hpp
+++ b/src/ParallelAlgorithms/Initialization/Actions/AddSimpleTags.hpp
@@ -1,0 +1,69 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <tuple>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace Parallel {
+template <typename Metavariables>
+class GlobalCache;
+}  // namespace Parallel
+/// \endcond
+
+namespace Initialization {
+namespace Actions {
+/*!
+ * \ingroup ActionsGroup
+ * \brief Initialize the list of simple tags in `Mutators::return_tags` by
+ * calling each mutator in the order they are specified
+ *
+ * There's a specialization for `AddSimpleTags<tmpl::list<Mutators...>>` that
+ * can also be used if a `tmpl::list` is available.
+ *
+ * Uses: nothing
+ *
+ * DataBox changes:
+ * - Adds:
+ *   - Each simple tag in the list `Mutators::return_tags`
+ * - Removes:
+ *   - nothing
+ * - Modifies:
+ *   - Each simple tag in the list `Mutators::return_tags`
+ *
+ * \note This action relies on the `SetupDataBox` aggregated initialization
+ * mechanism, so `Actions::SetupDataBox` must be present in the `Initialization`
+ * phase action list prior to this action.
+ */
+template <typename... Mutators>
+struct AddSimpleTags {
+  using simple_tags =
+      tmpl::flatten<tmpl::append<typename Mutators::return_tags...>>;
+  using compute_tags = tmpl::list<>;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/, ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    EXPAND_PACK_LEFT_TO_RIGHT(db::mutate_apply<Mutators>(make_not_null(&box)));
+    return std::make_tuple(std::move(box));
+  }
+};
+
+/// \cond
+template <typename... Mutators>
+struct AddSimpleTags<tmpl::list<Mutators...>>
+    : public AddSimpleTags<Mutators...> {};
+/// \endcond
+}  // namespace Actions
+}  // namespace Initialization

--- a/src/ParallelAlgorithms/Initialization/Actions/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Initialization/Actions/CMakeLists.txt
@@ -6,5 +6,6 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   AddComputeTags.hpp
+  AddSimpleTags.hpp
   RemoveOptionsAndTerminatePhase.hpp
   )

--- a/tests/Unit/ParallelAlgorithms/Initialization/Actions/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Initialization/Actions/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_InitializationActions")
 
 set(LIBRARY_SOURCES
   Test_AddComputeTags.cpp
+  Test_AddSimpleTags.cpp
   Test_RemoveOptionsAndTerminatePhase.cpp
   )
 

--- a/tests/Unit/ParallelAlgorithms/Initialization/Actions/Test_AddSimpleTags.cpp
+++ b/tests/Unit/ParallelAlgorithms/Initialization/Actions/Test_AddSimpleTags.cpp
@@ -1,0 +1,95 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "ParallelAlgorithms/Initialization/Actions/AddSimpleTags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct SomeNumber : db::SimpleTag {
+  using type = double;
+};
+
+struct SomeOtherNumber : db::SimpleTag {
+  using type = double;
+};
+
+struct SquareNumber : db::SimpleTag {
+  using type = double;
+};
+
+struct AddSomeAndOtherNumber {
+  using return_tags = tmpl::list<SomeNumber, SomeOtherNumber>;
+  using argument_tags = tmpl::list<>;
+
+  static void apply(const gsl::not_null<double*> some_number,
+                    const gsl::not_null<double*> some_other_number) {
+    *some_number = 2.;
+    *some_other_number = 3.;
+  }
+};
+
+struct AddSquareNumber {
+  using return_tags = tmpl::list<SquareNumber>;
+  using argument_tags = tmpl::list<SomeNumber>;
+  static void apply(const gsl::not_null<double*> square_number,
+                    const double some_number) {
+    *square_number = some_number * some_number;
+  }
+};
+
+template <typename Metavariables>
+struct Component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      typename Metavariables::Phase, Metavariables::Phase::Testing,
+      tmpl::list<Actions::SetupDataBox,
+                 Initialization::Actions::AddSimpleTags<
+                     tmpl::list<AddSomeAndOtherNumber, AddSquareNumber>>>>>;
+};
+
+struct Metavariables {
+  using component_list = tmpl::list<Component<Metavariables>>;
+
+  enum class Phase { Initialization, Testing, Exit };
+};
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.Initialization.AddSimpleTags",
+                  "[Unit][ParallelAlgorithms]") {
+  using component = Component<Metavariables>;
+
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{{}};
+  ActionTesting::emplace_array_component<component>(make_not_null(&runner), {0},
+                                                    {0}, 0);
+
+  ActionTesting::set_phase(make_not_null(&runner),
+                           Metavariables::Phase::Testing);
+  for (size_t i = 0; i < 2; ++i) {
+    runner.template next_action<component>(0);
+  }
+
+  CHECK(ActionTesting::tag_is_retrievable<component, SomeNumber>(runner, 0));
+  CHECK(
+      ActionTesting::tag_is_retrievable<component, SomeOtherNumber>(runner, 0));
+  CHECK(ActionTesting::tag_is_retrievable<component, SquareNumber>(runner, 0));
+  CHECK(ActionTesting::get_databox_tag<component, SomeNumber>(runner, 0) == 2.);
+  CHECK(ActionTesting::get_databox_tag<component, SomeOtherNumber>(runner, 0) ==
+        3.);
+  CHECK(ActionTesting::get_databox_tag<component, SquareNumber>(runner, 0) ==
+        4.);
+}


### PR DESCRIPTION
## Proposed changes

Allows adding simple tags to the DataBox using mutators, which cuts down on a lot of the action boilerplate for code that doesn't need to do communication anyway.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
