### PR TITLE
Add GeneralizedHarmonic Outflow BC

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BoundaryCondition.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BoundaryCondition.hpp
@@ -13,6 +13,8 @@
 namespace GeneralizedHarmonic::BoundaryConditions {
 template <size_t Dim>
 class DirichletAnalytic;
+template <size_t Dim>
+class Outflow;
 }  // namespace GeneralizedHarmonic::BoundaryConditions
 /// \endcond
 
@@ -23,7 +25,7 @@ template <size_t Dim>
 class BoundaryCondition : public domain::BoundaryConditions::BoundaryCondition {
  public:
   using creatable_classes =
-      tmpl::list<DirichletAnalytic<Dim>,
+      tmpl::list<DirichletAnalytic<Dim>, Outflow<Dim>,
                  domain::BoundaryConditions::Periodic<BoundaryCondition<Dim>>>;
 
   BoundaryCondition() = default;

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/CMakeLists.txt
@@ -7,6 +7,7 @@ spectre_target_sources(
   BjorhusImpl.cpp
   BoundaryCondition.cpp
   DirichletAnalytic.cpp
+  Outflow.cpp
   RegisterDerivedWithCharm.cpp
   )
 
@@ -18,5 +19,6 @@ spectre_target_headers(
   BoundaryCondition.hpp
   DirichletAnalytic.hpp
   Factory.hpp
+  Outflow.hpp
   RegisterDerivedWithCharm.hpp
   )

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Factory.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Factory.hpp
@@ -5,3 +5,4 @@
 
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BoundaryCondition.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DirichletAnalytic.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Outflow.hpp"

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Outflow.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Outflow.cpp
@@ -1,0 +1,90 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Outflow.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <pup.h>
+#include <string>
+
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace GeneralizedHarmonic::BoundaryConditions {
+template <size_t Dim>
+Outflow<Dim>::Outflow(CkMigrateMessage* const msg) noexcept
+    : BoundaryCondition<Dim>(msg) {}
+
+template <size_t Dim>
+std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+Outflow<Dim>::get_clone() const noexcept {
+  return std::make_unique<Outflow>(*this);
+}
+
+template <size_t Dim>
+void Outflow<Dim>::pup(PUP::er& p) {
+  BoundaryCondition<Dim>::pup(p);
+}
+
+template <size_t Dim>
+std::optional<std::string> Outflow<Dim>::dg_outflow(
+    const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+        face_mesh_velocity,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>&
+        outward_directed_normal_covector,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>&
+    /*outward_directed_normal_vector*/,
+
+    const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& shift) noexcept {
+  const auto char_speeds = characteristic_speeds(
+      gamma_1, lapse, shift, outward_directed_normal_covector);
+  Scalar<DataVector> normal_dot_mesh_velocity;
+  if (face_mesh_velocity.has_value()) {
+    normal_dot_mesh_velocity = dot_product(outward_directed_normal_covector,
+                                           face_mesh_velocity.value());
+  }
+  double min_speed = std::numeric_limits<double>::signaling_NaN();
+  for (size_t i = 0; i < char_speeds.size(); ++i) {
+    if (face_mesh_velocity.has_value()) {
+      min_speed = min(gsl::at(char_speeds, i) - get(normal_dot_mesh_velocity));
+    } else {
+      min_speed = min(gsl::at(char_speeds, i));
+    }
+    if (min_speed < 0.0) {
+      return {MakeString{}
+              << "Outflow boundary condition violated with speed index " << i
+              << " ingoing: " << min_speed
+              << "\n speed: " << gsl::at(char_speeds, i)
+              << "\nn_i: " << outward_directed_normal_covector
+              << "\n"
+                 "See GeneralizedHarmonic::characteristic_speeds for the "
+                 "index ordering of characteristic speeds\n"};
+    }
+  }
+  return std::nullopt;
+}
+
+// NOLINTNEXTLINE
+template <size_t Dim>
+PUP::able::PUP_ID Outflow<Dim>::my_PUP_ID = 0;
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data) template class Outflow<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+#undef DIM
+}  // namespace GeneralizedHarmonic::BoundaryConditions

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Outflow.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Outflow.hpp
@@ -1,0 +1,76 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <pup.h>
+#include <string>
+#include <type_traits>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/BoundaryConditions/Type.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace GeneralizedHarmonic::BoundaryConditions {
+/// A `BoundaryCondition` that only verifies that all characteristic speeds are
+/// directed out of the domain; no boundary data is altered by this boundary
+/// condition.
+template <size_t Dim>
+class Outflow final : public BoundaryCondition<Dim> {
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help{
+      "Outflow boundary condition that only verifies the characteristic speeds "
+      "are all directed out of the domain."};
+
+  Outflow() = default;
+  Outflow(Outflow&&) noexcept = default;
+  Outflow& operator=(Outflow&&) noexcept = default;
+  Outflow(const Outflow&) = default;
+  Outflow& operator=(const Outflow&) = default;
+  ~Outflow() override = default;
+
+  explicit Outflow(CkMigrateMessage* msg) noexcept;
+
+  WRAPPED_PUPable_decl_base_template(
+      domain::BoundaryConditions::BoundaryCondition, Outflow);
+
+  auto get_clone() const noexcept -> std::unique_ptr<
+      domain::BoundaryConditions::BoundaryCondition> override;
+
+  static constexpr evolution::BoundaryConditions::Type bc_type =
+      evolution::BoundaryConditions::Type::Outflow;
+
+  void pup(PUP::er& p) override;
+
+  using dg_interior_evolved_variables_tags = tmpl::list<>;
+  using dg_interior_temporary_tags = tmpl::list<
+      ::GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1,
+      gr::Tags::Lapse<DataVector>,
+      gr::Tags::Shift<Dim, Frame::Inertial, DataVector>>;
+  using dg_gridless_tags = tmpl::list<>;
+  using dg_interior_primitive_variables_tags = tmpl::list<>;
+
+  static std::optional<std::string> dg_outflow(
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+          face_mesh_velocity,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>&
+          outward_directed_normal_covector,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>&
+      /*outward_directed_normal_vector*/,
+
+      const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& shift) noexcept;
+};
+}  // namespace GeneralizedHarmonic::BoundaryConditions

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/RegisterDerivedWithCharm.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/RegisterDerivedWithCharm.cpp
@@ -5,6 +5,7 @@
 
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BoundaryCondition.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DirichletAnalytic.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Outflow.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 
 namespace GeneralizedHarmonic::BoundaryConditions {

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Outflow.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Outflow.py
@@ -1,0 +1,27 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def characteristic_speeds(gamma_1, lapse, shift, unit_normal_one_form):
+    shift_dot_normal = np.dot(shift, unit_normal_one_form)
+    return [
+        -(1.0 + gamma_1) * shift_dot_normal, -shift_dot_normal,
+        -shift_dot_normal + lapse, -shift_dot_normal - lapse
+    ]
+
+
+def error(face_mesh_velocity, outward_directed_normal_covector,
+          outward_directed_normal_vector, gamma_1, lapse, shift):
+    speeds = characteristic_speeds(gamma_1, lapse, shift,
+                                   outward_directed_normal_covector)
+    for i in range(4):
+        if face_mesh_velocity is not None:
+            speeds[i] -= np.dot(outward_directed_normal_covector,
+                                face_mesh_velocity)
+        if speeds[i] < 0.0:
+            return ("Outflow boundary condition violated with speed index .*")
+    return None
+
+    pass

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_Outflow.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_Outflow.cpp
@@ -1,0 +1,56 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Index.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Factory.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Outflow.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/UpwindPenalty.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace helpers = TestHelpers::evolution::dg;
+namespace {
+
+template <size_t Dim>
+void test() noexcept {
+  MAKE_GENERATOR(gen);
+  const std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+      boundary_condition = TestHelpers::test_creation<std::unique_ptr<
+          GeneralizedHarmonic::BoundaryConditions::BoundaryCondition<Dim>>>(
+          "Outflow:\n");
+
+  helpers::test_boundary_condition_with_python<
+      GeneralizedHarmonic::BoundaryConditions::Outflow<Dim>,
+      GeneralizedHarmonic::BoundaryConditions::BoundaryCondition<Dim>,
+      GeneralizedHarmonic::System<Dim>,
+      tmpl::list<GeneralizedHarmonic::BoundaryCorrections::UpwindPenalty<Dim>>>(
+      make_not_null(&gen), "Outflow",
+      tuples::TaggedTuple<helpers::Tags::PythonFunctionForErrorMessage<>>{
+          "error"},
+      "Outflow:\n", Index<Dim - 1>{Dim == 1 ? 0 : 5},
+      db::DataBox<tmpl::list<>>{},
+      tuples::TaggedTuple<helpers::Tags::Range<
+          GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1>>{
+          std::array{0.0, 1.0}});
+}
+}  // namespace
+SPECTRE_TEST_CASE("Unit.GeneralizedHarmonic.BoundaryConditions.Outflow",
+                  "[Unit][GrMhd]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/"};
+  test<1>();
+  test<2>();
+  test<3>();
+}

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY "Test_GeneralizedHarmonic")
 set(LIBRARY_SOURCES
   BoundaryConditions/Test_BjorhusImpl.cpp
   BoundaryConditions/Test_DirichletAnalytic.cpp
+  BoundaryConditions/Test_Outflow.cpp
   BoundaryConditions/Test_Periodic.cpp
   BoundaryCorrections/Test_UpwindPenalty.cpp
   Test_Characteristics.cpp


### PR DESCRIPTION
## Proposed changes

Adds the outflow boundary correction, which simply checks that all characteristic speeds are directed out of the domain, to the generalized harmonic system.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.
