### PR TITLE
Add ResizeAndComputePrimitives to ValenciaDivClean

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/CMakeLists.txt
@@ -6,6 +6,7 @@ spectre_target_sources(
   PRIVATE
   InitialDataTci.cpp
   PrimitiveGhostData.cpp
+  ResizeAndComputePrimitives.cpp
   SwapGrTags.cpp
   TciOnDgGrid.cpp
   TciOnFdGrid.cpp
@@ -18,6 +19,7 @@ spectre_target_headers(
   HEADERS
   InitialDataTci.hpp
   PrimitiveGhostData.hpp
+  ResizeAndComputePrimitives.hpp
   Subcell.hpp
   SwapGrTags.hpp
   TciOnDgGrid.hpp

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ResizeAndComputePrimitives.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ResizeAndComputePrimitives.cpp
@@ -1,0 +1,123 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ResizeAndComputePrimitives.hpp"
+
+#include <algorithm>
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/DgSubcell/Reconstruction.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace grmhd::ValenciaDivClean::subcell {
+template <typename OrderedListOfRecoverySchemes>
+template <size_t ThermodynamicDim>
+void ResizeAndComputePrims<OrderedListOfRecoverySchemes>::apply(
+    const gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*> prim_vars,
+    const evolution::dg::subcell::ActiveGrid active_grid,
+    const Mesh<3>& dg_mesh, const Mesh<3>& subcell_mesh,
+    const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
+    const Scalar<DataVector>& tilde_phi,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+    const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+        eos) noexcept {
+  if (active_grid == evolution::dg::subcell::ActiveGrid::Dg) {
+    ASSERT(prim_vars->number_of_grid_points() ==
+               subcell_mesh.number_of_grid_points(),
+           "The number of grid points of the primitive variables should also "
+           "be the number of grid points the subcell mesh has ("
+               << subcell_mesh.number_of_grid_points() << ") but got "
+               << prim_vars->number_of_grid_points() << ". The DG grid has "
+               << dg_mesh.number_of_grid_points() << " grid points");
+    const size_t num_grid_points =
+        (active_grid == evolution::dg::subcell::ActiveGrid::Dg ? dg_mesh
+                                                               : subcell_mesh)
+            .number_of_grid_points();
+    // Reconstruct a copy of the pressure from the FD grid to the DG grid to
+    // provide a high-order initial guess.
+    const Scalar<DataVector> fd_pressure =
+        get<hydro::Tags::Pressure<DataVector>>(*prim_vars);
+    prim_vars->initialize(num_grid_points);
+    evolution::dg::subcell::fd::reconstruct(
+        make_not_null(&get(get<hydro::Tags::Pressure<DataVector>>(*prim_vars))),
+        get(fd_pressure), dg_mesh, subcell_mesh.extents());
+
+    // We only need to compute the prims if we switched to the DG grid because
+    // otherwise we computed the prims during the FD TCI.
+    grmhd::ValenciaDivClean::
+        PrimitiveFromConservative<OrderedListOfRecoverySchemes, true>::apply(
+            make_not_null(
+                &get<hydro::Tags::RestMassDensity<DataVector>>(*prim_vars)),
+            make_not_null(&get<hydro::Tags::SpecificInternalEnergy<DataVector>>(
+                *prim_vars)),
+            make_not_null(
+                &get<hydro::Tags::SpatialVelocity<DataVector, 3>>(*prim_vars)),
+            make_not_null(
+                &get<hydro::Tags::MagneticField<DataVector, 3>>(*prim_vars)),
+            make_not_null(
+                &get<hydro::Tags::DivergenceCleaningField<DataVector>>(
+                    *prim_vars)),
+            make_not_null(
+                &get<hydro::Tags::LorentzFactor<DataVector>>(*prim_vars)),
+            make_not_null(&get<hydro::Tags::Pressure<DataVector>>(*prim_vars)),
+            make_not_null(
+                &get<hydro::Tags::SpecificEnthalpy<DataVector>>(*prim_vars)),
+            tilde_d, tilde_tau, tilde_s, tilde_b, tilde_phi, spatial_metric,
+            inv_spatial_metric, sqrt_det_spatial_metric, eos);
+  }
+}
+
+namespace {
+using NewmanThenPalenzuela =
+    tmpl::list<PrimitiveRecoverySchemes::NewmanHamlin,
+               PrimitiveRecoverySchemes::PalenzuelaEtAl>;
+using KastaunThenNewmanThenPalenzuela =
+    tmpl::list<PrimitiveRecoverySchemes::KastaunEtAl,
+               PrimitiveRecoverySchemes::NewmanHamlin,
+               PrimitiveRecoverySchemes::PalenzuelaEtAl>;
+}  // namespace
+
+#define RECOVERY(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define INSTANTIATION(r, data)                                                \
+  template void                                                               \
+  ResizeAndComputePrims<RECOVERY(data)>::apply<THERMO_DIM(data)>(             \
+      const gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*>          \
+          prim_vars,                                                          \
+      const evolution::dg::subcell::ActiveGrid active_grid,                   \
+      const Mesh<3>& dg_mesh, const Mesh<3>& subcell_mesh,                    \
+      const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau, \
+      const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,                 \
+      const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,                 \
+      const Scalar<DataVector>& tilde_phi,                                    \
+      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,         \
+      const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,     \
+      const Scalar<DataVector>& sqrt_det_spatial_metric,                      \
+      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>&        \
+          eos) noexcept;
+GENERATE_INSTANTIATIONS(INSTANTIATION,
+                        (tmpl::list<PrimitiveRecoverySchemes::KastaunEtAl>,
+                         tmpl::list<PrimitiveRecoverySchemes::NewmanHamlin>,
+                         tmpl::list<PrimitiveRecoverySchemes::PalenzuelaEtAl>,
+                         NewmanThenPalenzuela, KastaunThenNewmanThenPalenzuela),
+                        (1, 2))
+#undef INSTANTIATION
+#undef THERMO_DIM
+#undef RECOVERY
+}  // namespace grmhd::ValenciaDivClean::subcell

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ResizeAndComputePrimitives.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ResizeAndComputePrimitives.hpp
@@ -1,0 +1,86 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace EquationsOfState {
+template <bool IsRelativistic, size_t ThermodynamicDim>
+class EquationOfState;
+}  // namespace EquationsOfState
+template <size_t Dim>
+class Mesh;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+template <typename TagsList>
+class Variables;
+/// \endcond
+
+namespace grmhd::ValenciaDivClean::subcell {
+/*!
+ * \brief Mutator that, if the active mesh is subcell, resizes the primitive
+ * variables to have the size of the subcell and then computes the primitive
+ * variables.
+ *
+ * In the DG-subcell `step_actions` list this will normally be called using the
+ * `::Actions::MutateApply` action in the following way in the action list:
+ * - `TciAndSwitchToDg<TciOnFdGrid>`
+ * - `Actions::MutateApply<grmhd::ValenciaDivClean::subcell::SwapGrTags>`
+ * - `Actions::MutateApply<ResizeAndComputePrims<primitive_recovery_schemes>>`
+ * Note that the GR tags are swapped before this action is called.
+ *
+ * If the active grid is DG (we are switching from subcell back to DG) then this
+ * mutator computes the primitive variables on the active grid. We reconstruct
+ * the pressure to the DG grid to give a high-order initial guess for the
+ * primitive recovery. A possible future optimization would be to avoid this
+ * reconstruction when all recovery schemes don't need an initial guess.
+ * Finally, we perform the primitive recovery on the DG grid.
+ */
+template <typename OrderedListOfRecoverySchemes>
+struct ResizeAndComputePrims {
+  using return_tags =
+      tmpl::list<::Tags::Variables<hydro::grmhd_tags<DataVector>>>;
+  using argument_tags =
+      tmpl::list<evolution::dg::subcell::Tags::ActiveGrid,
+                 domain::Tags::Mesh<3>, evolution::dg::subcell::Tags::Mesh<3>,
+                 grmhd::ValenciaDivClean::Tags::TildeD,
+                 grmhd::ValenciaDivClean::Tags::TildeTau,
+                 grmhd::ValenciaDivClean::Tags::TildeS<>,
+                 grmhd::ValenciaDivClean::Tags::TildeB<>,
+                 grmhd::ValenciaDivClean::Tags::TildePhi,
+                 gr::Tags::SpatialMetric<3>, gr::Tags::InverseSpatialMetric<3>,
+                 gr::Tags::SqrtDetSpatialMetric<>,
+                 hydro::Tags::EquationOfStateBase>;
+
+  template <size_t ThermodynamicDim>
+  static void apply(
+      gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*> prim_vars,
+      evolution::dg::subcell::ActiveGrid active_grid, const Mesh<3>& dg_mesh,
+      const Mesh<3>& subcell_mesh, const Scalar<DataVector>& tilde_d,
+      const Scalar<DataVector>& tilde_tau,
+      const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
+      const Scalar<DataVector>& tilde_phi,
+      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+      const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
+      const Scalar<DataVector>& sqrt_det_spatial_metric,
+      const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+          eos) noexcept;
+};
+}  // namespace grmhd::ValenciaDivClean::subcell

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBRARY_SOURCES
   BoundaryCorrections/Test_Rusanov.cpp
   Subcell/Test_InitialDataTci.cpp
   Subcell/Test_PrimitiveGhostData.cpp
+  Subcell/Test_ResizeAndComputePrimitives.cpp
   Subcell/Test_SwapGrTags.cpp
   Subcell/Test_TciOnDgGrid.cpp
   Subcell/Test_TciOnFdGrid.cpp

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_ResizeAndComputePrimitives.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_ResizeAndComputePrimitives.cpp
@@ -1,0 +1,191 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <random>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Determinant.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
+#include "Evolution/DgSubcell/Projection.hpp"
+#include "Evolution/DgSubcell/Reconstruction.hpp"
+#include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ResizeAndComputePrimitives.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
+#include "PointwiseFunctions/Hydro/SpecificEnthalpy.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+
+namespace grmhd::ValenciaDivClean {
+namespace {
+void test(const gsl::not_null<std::mt19937*> gen,
+          const gsl::not_null<std::uniform_real_distribution<>*> dist,
+          const evolution::dg::subcell::ActiveGrid active_grid) {
+  CAPTURE(active_grid);
+  const Mesh<3> dg_mesh{5, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto};
+  const Mesh<3> subcell_mesh = evolution::dg::subcell::fd::mesh(dg_mesh);
+
+  using cons_tag = typename grmhd::ValenciaDivClean::System::variables_tag;
+  using prim_tag =
+      typename grmhd::ValenciaDivClean::System::primitive_variables_tag;
+  using ConsVars = typename cons_tag::type;
+  using PrimVars = typename prim_tag::type;
+
+  const size_t active_num_pts =
+      active_grid == evolution::dg::subcell::ActiveGrid::Dg
+          ? dg_mesh.number_of_grid_points()
+          : subcell_mesh.number_of_grid_points();
+  tnsr::ii<DataVector, 3, Frame::Inertial> spatial_metric{active_num_pts, 0.0};
+  for (size_t i = 0; i < 3; ++i) {
+    spatial_metric.get(i, i) = 1.0 + 0.01 * i;
+  }
+  tnsr::II<DataVector, 3, Frame::Inertial> inv_spatial_metric{active_num_pts,
+                                                              0.0};
+  for (size_t i = 0; i < 3; ++i) {
+    inv_spatial_metric.get(i, i) = 1.0 / spatial_metric.get(i, i);
+  }
+  const Scalar<DataVector> sqrt_det_spatial_metric{
+      sqrt(get(determinant(spatial_metric)))};
+
+  std::unique_ptr<EquationsOfState::EquationOfState<true, 1>> eos =
+      std::make_unique<EquationsOfState::PolytropicFluid<true>>(1.4, 5.0 / 3.0);
+  auto prim_vars = make_with_random_values<PrimVars>(
+      gen, dist, subcell_mesh.number_of_grid_points());
+  get<hydro::Tags::Pressure<DataVector>>(prim_vars) =
+      eos->pressure_from_density(
+          get<hydro::Tags::RestMassDensity<DataVector>>(prim_vars));
+  get<hydro::Tags::SpecificInternalEnergy<DataVector>>(prim_vars) =
+      eos->specific_internal_energy_from_density(
+          get<hydro::Tags::RestMassDensity<DataVector>>(prim_vars));
+  get<hydro::Tags::SpecificEnthalpy<DataVector>>(prim_vars) =
+      hydro::relativistic_specific_enthalpy(
+          get<hydro::Tags::RestMassDensity<DataVector>>(prim_vars),
+          get<hydro::Tags::SpecificInternalEnergy<DataVector>>(prim_vars),
+          get<hydro::Tags::Pressure<DataVector>>(prim_vars));
+  {
+    const auto& spatial_velocity =
+        get<hydro::Tags::SpatialVelocity<DataVector, 3, Frame::Inertial>>(
+            prim_vars);
+    tnsr::ii<DataVector, 3, Frame::Inertial> subcell_spatial_metric{
+        subcell_mesh.number_of_grid_points(), 0.0};
+    for (size_t i = 0; i < 3; ++i) {
+      subcell_spatial_metric.get(i, i) = 1.0 + 0.01 * i;
+    }
+    get(get<hydro::Tags::LorentzFactor<DataVector>>(prim_vars)) =
+        1.0 / sqrt(1.0 - get(dot_product(spatial_velocity, spatial_velocity,
+                                         subcell_spatial_metric)));
+  }
+  ConsVars cons_vars{};
+  const auto compute_cons = [&cons_vars, &spatial_metric,
+                             &sqrt_det_spatial_metric](const auto& prims) {
+    cons_vars.initialize(prims.number_of_grid_points());
+    ConservativeFromPrimitive::apply(
+        make_not_null(&get<Tags::TildeD>(cons_vars)),
+        make_not_null(&get<Tags::TildeTau>(cons_vars)),
+        make_not_null(&get<Tags::TildeS<Frame::Inertial>>(cons_vars)),
+        make_not_null(&get<Tags::TildeB<Frame::Inertial>>(cons_vars)),
+        make_not_null(&get<Tags::TildePhi>(cons_vars)),
+        get<hydro::Tags::RestMassDensity<DataVector>>(prims),
+        get<hydro::Tags::SpecificInternalEnergy<DataVector>>(prims),
+        get<hydro::Tags::SpecificEnthalpy<DataVector>>(prims),
+        get<hydro::Tags::Pressure<DataVector>>(prims),
+        get<hydro::Tags::SpatialVelocity<DataVector, 3, Frame::Inertial>>(
+            prims),
+        get<hydro::Tags::LorentzFactor<DataVector>>(prims),
+        get<hydro::Tags::MagneticField<DataVector, 3, Frame::Inertial>>(prims),
+        sqrt_det_spatial_metric, spatial_metric,
+        get<hydro::Tags::DivergenceCleaningField<DataVector>>(prims));
+  };
+  if (active_grid == evolution::dg::subcell::ActiveGrid::Dg) {
+    const auto dg_prims = evolution::dg::subcell::fd::reconstruct(
+        prim_vars, dg_mesh, subcell_mesh.extents());
+    compute_cons(dg_prims);
+  } else {
+    compute_cons(prim_vars);
+  }
+
+  auto box = db::create<db::AddSimpleTags<
+      evolution::dg::subcell::Tags::ActiveGrid, cons_tag, prim_tag,
+      gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+      gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>,
+      gr::Tags::SqrtDetSpatialMetric<DataVector>, ::domain::Tags::Mesh<3>,
+      evolution::dg::subcell::Tags::Mesh<3>,
+      hydro::Tags::EquationOfState<
+          std::unique_ptr<EquationsOfState::EquationOfState<true, 1>>>>>(
+      active_grid, cons_vars, prim_vars, spatial_metric, inv_spatial_metric,
+      sqrt_det_spatial_metric, dg_mesh, subcell_mesh, std::move(eos));
+
+  using recovery_schemes = tmpl::list<
+      grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl,
+      grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin,
+      grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::PalenzuelaEtAl>;
+  db::mutate_apply<grmhd::ValenciaDivClean::subcell::ResizeAndComputePrims<
+      recovery_schemes>>(make_not_null(&box));
+
+  REQUIRE(db::get<prim_tag>(box).number_of_grid_points() == active_num_pts);
+  if (active_grid == evolution::dg::subcell::ActiveGrid::Dg) {
+    prim_vars.initialize(cons_vars.number_of_grid_points());
+    grmhd::ValenciaDivClean::PrimitiveFromConservative<recovery_schemes>::apply(
+        make_not_null(
+            &get<hydro::Tags::RestMassDensity<DataVector>>(prim_vars)),
+        make_not_null(
+            &get<hydro::Tags::SpecificInternalEnergy<DataVector>>(prim_vars)),
+        make_not_null(
+            &get<hydro::Tags::SpatialVelocity<DataVector, 3>>(prim_vars)),
+        make_not_null(
+            &get<hydro::Tags::MagneticField<DataVector, 3>>(prim_vars)),
+        make_not_null(
+            &get<hydro::Tags::DivergenceCleaningField<DataVector>>(prim_vars)),
+        make_not_null(&get<hydro::Tags::LorentzFactor<DataVector>>(prim_vars)),
+        make_not_null(&get<hydro::Tags::Pressure<DataVector>>(prim_vars)),
+        make_not_null(
+            &get<hydro::Tags::SpecificEnthalpy<DataVector>>(prim_vars)),
+        get<grmhd::ValenciaDivClean::Tags::TildeD>(cons_vars),
+        get<grmhd::ValenciaDivClean::Tags::TildeTau>(cons_vars),
+        get<grmhd::ValenciaDivClean::Tags::TildeS<Frame::Inertial>>(cons_vars),
+        get<grmhd::ValenciaDivClean::Tags::TildeB<Frame::Inertial>>(cons_vars),
+        get<grmhd::ValenciaDivClean::Tags::TildePhi>(cons_vars), spatial_metric,
+        inv_spatial_metric, sqrt_det_spatial_metric,
+        db::get<hydro::Tags::EquationOfStateBase>(box));
+  }
+  CHECK_VARIABLES_APPROX(db::get<prim_tag>(box), prim_vars);
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.ValenciaDivClean.Subcell.ResizeAndComputePrims",
+    "[Unit][Evolution]") {
+  MAKE_GENERATOR(gen);
+  // Use a small range of random values since we need recovery to succeed and we
+  // also reconstruct to the DG grid from the FD grid and need to maintain a
+  // somewhat reasonable state on both grids.
+  std::uniform_real_distribution<> dist(0.5, 0.505);
+  for (const auto active_grid : {evolution::dg::subcell::ActiveGrid::Dg,
+                                 evolution::dg::subcell::ActiveGrid::Subcell}) {
+    test(make_not_null(&gen), make_not_null(&dist), active_grid);
+  }
+}
+}  // namespace
+}  // namespace grmhd::ValenciaDivClean


### PR DESCRIPTION
## Proposed changes

Add mutator used to resize and compute the prims on the DG grid when switching from DG back to FD

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
