### PR TITLE
Add subcell GrTagsForHydro

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/CMakeLists.txt
@@ -16,6 +16,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  GrTagsForHydro.hpp
   InitialDataTci.hpp
   PrimitiveGhostData.hpp
   Subcell.hpp

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/GrTagsForHydro.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/GrTagsForHydro.hpp
@@ -1,0 +1,161 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/Tags.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/Tags/Coordinates.hpp"
+#include "Evolution/DgSubcell/Tags/Inactive.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/OnSubcellFaces.hpp"
+#include "Evolution/Initialization/InitialData.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Initialization {
+namespace Tags {
+struct InitialTime;
+}  // namespace Tags
+}  // namespace Initialization
+namespace Tags {
+struct AnalyticSolutionOrData;
+}  // namespace Tags
+namespace domain {
+namespace Tags {
+template <size_t Dim, typename Frame>
+struct Coordinates;
+template <size_t VolumeDim>
+struct Mesh;
+}  // namespace Tags
+}  // namespace domain
+// IWYU pragma: no_forward_declare db::DataBox
+/// \endcond
+
+namespace Initialization {
+/// Generic initialization actions and mutators for the subcell solver.
+namespace subcell {
+/*!
+ * \ingroup InitializationGroup
+ * \brief Allocate and set general relativity quantities needed for evolution
+ * of hydro systems when using a DG-subcell hybrid scheme.
+ *
+ * Uses:
+ * - DataBox:
+ *   * `evolution::dg::subcell::Tags::Mesh<Dim>`
+ *   * `domain::Tags::ElementMap<Dim, Frame::Grid>`
+ *   * `Tags::CoordinateMap<Dim, Frame::Grid, Frame::Inertial>`
+ *   * `domain::Tags::FunctionsOfTime`
+ *   * `evolution::dg::subcell::Tags::Coordinates<Dim, Frame::Logical>`
+ *   * `::Tags::AnalyticSolutionOrData`
+ *
+ * DataBox changes:
+ * - Adds:
+ *   * `dg::subcell::Tags::Inactive<System::spacetime_variables_tag>`
+ *   * `Tags::OnSubcellFaces<System::flux_spacetime_variables_tag, Dim>`
+ *
+ * - Removes: nothing
+ * - Modifies: nothing
+ *
+ * \note This action relies on the `SetupDataBox` aggregated initialization
+ * mechanism, so `Actions::SetupDataBox` must be present in the
+ * `Initialization` phase action list prior to this action.
+ */
+template <typename System, size_t Dim>
+struct GrTagsForHydro {
+  using initialization_tags = tmpl::list<Initialization::Tags::InitialTime>;
+
+  using gr_tag = typename System::spacetime_variables_tag;
+  using subcell_gr_tag = evolution::dg::subcell::Tags::Inactive<gr_tag>;
+  using subcell_faces_gr_tag = evolution::dg::subcell::Tags::OnSubcellFaces<
+      typename System::flux_spacetime_variables_tag, Dim>;
+  using GrVars = typename gr_tag::type;
+  using SubcellGrVars = typename subcell_gr_tag::type;
+  using FaceGrVars = typename subcell_faces_gr_tag::type::value_type;
+
+  using return_tags = tmpl::list<subcell_gr_tag, subcell_faces_gr_tag>;
+  using argument_tags =
+      tmpl::list<Initialization::Tags::InitialTime,
+                 evolution::dg::subcell::Tags::Mesh<Dim>,
+                 domain::Tags::ElementMap<Dim, Frame::Grid>,
+                 domain::CoordinateMaps::Tags::CoordinateMap<Dim, Frame::Grid,
+                                                             Frame::Inertial>,
+                 domain::Tags::FunctionsOfTime,
+                 evolution::dg::subcell::Tags::Coordinates<Dim, Frame::Logical>,
+                 ::Tags::AnalyticSolutionOrData>;
+
+  template <typename AnalyticDataOrSolution>
+  static void apply(
+      const gsl::not_null<SubcellGrVars*> cell_centered_gr_vars,
+      const gsl::not_null<std::array<FaceGrVars, Dim>*> face_centered_gr_vars,
+      const double initial_time, const Mesh<Dim>& subcell_mesh,
+      const ElementMap<Dim, Frame::Grid>& logical_to_grid_map,
+      const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, Dim>&
+          grid_to_inertial_map,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time,
+      const tnsr::I<DataVector, Dim, Frame::Logical>&
+          subcell_logical_coordinates,
+      const AnalyticDataOrSolution& analytic_data_or_solution) noexcept {
+    const size_t num_grid_points = subcell_mesh.number_of_grid_points();
+    const auto cell_centered_inertial_coords =
+        grid_to_inertial_map(logical_to_grid_map(subcell_logical_coordinates),
+                             initial_time, functions_of_time);
+
+    // Set cell-centered vars. Need to first do without prefix then move into
+    // prefixed Variables.
+    GrVars no_prefix_cell_centered_gr_vars{num_grid_points};
+    no_prefix_cell_centered_gr_vars.assign_subset(evolution::initial_data(
+        analytic_data_or_solution, cell_centered_inertial_coords, initial_time,
+        typename GrVars::tags_list{}));
+    *cell_centered_gr_vars = std::move(no_prefix_cell_centered_gr_vars);
+
+    // Set GR variables needed for computing the fluxes on the faces.
+    ASSERT(Mesh<Dim>(subcell_mesh.extents(0), subcell_mesh.basis(0),
+                     subcell_mesh.quadrature(0)) == subcell_mesh,
+           "The subcell mesh must have isotropic basis, quadrature. and "
+           "extents but got "
+               << subcell_mesh);
+    for (size_t d = 0; d < Dim; ++d) {
+      const auto basis = make_array<Dim>(subcell_mesh.basis(0));
+      auto quadrature = make_array<Dim>(subcell_mesh.quadrature(0));
+      auto extents = make_array<Dim>(subcell_mesh.extents(0));
+      gsl::at(extents, d) = subcell_mesh.extents(0) + 1;
+      gsl::at(quadrature, d) = Spectral::Quadrature::FaceCentered;
+      const Mesh<Dim> face_centered_mesh{extents, basis, quadrature};
+      const auto face_centered_logical_coords =
+          logical_coordinates(face_centered_mesh);
+      const auto face_centered_inertial_coords = grid_to_inertial_map(
+          logical_to_grid_map(face_centered_logical_coords), initial_time,
+          functions_of_time);
+
+      gsl::at(*face_centered_gr_vars, d)
+          .initialize(face_centered_mesh.number_of_grid_points());
+      gsl::at(*face_centered_gr_vars, d)
+          .assign_subset(evolution::initial_data(
+              analytic_data_or_solution, face_centered_inertial_coords,
+              initial_time, typename FaceGrVars::tags_list{}));
+    }
+  }
+};
+}  // namespace subcell
+}  // namespace Initialization

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   BoundaryConditions/Test_Periodic.cpp
   BoundaryCorrections/Test_Hll.cpp
   BoundaryCorrections/Test_Rusanov.cpp
+  Subcell/Test_GrTagsForHydro.cpp
   Subcell/Test_InitialDataTci.cpp
   Subcell/Test_PrimitiveGhostData.cpp
   Subcell/Test_SwapGrTags.cpp

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_GrTagsForHydro.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_GrTagsForHydro.cpp
@@ -1,0 +1,141 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/Tags.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/ProductMaps.tpp"
+#include "Domain/CoordinateMaps/TimeDependent/Translation.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/Tags/Coordinates.hpp"
+#include "Evolution/DgSubcell/Tags/Inactive.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/OnSubcellFaces.hpp"
+#include "Evolution/Initialization/InitialData.hpp"
+#include "Evolution/Initialization/Tags.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/GrTagsForHydro.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Tov.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "Utilities/CloneUniquePtrs.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.ValenciaDivClean.Subcell.GrTagsForHydro",
+    "[Unit][Evolution]") {
+  using System = grmhd::ValenciaDivClean::System;
+  using gr_tag = typename System::spacetime_variables_tag;
+  using subcell_gr_tag = evolution::dg::subcell::Tags::Inactive<gr_tag>;
+  using subcell_faces_gr_tag = evolution::dg::subcell::Tags::OnSubcellFaces<
+      typename System::flux_spacetime_variables_tag, 3>;
+  using GrVars = typename gr_tag::type;
+  using SubcellGrVars = typename subcell_gr_tag::type;
+  using FaceGrVars = typename subcell_faces_gr_tag::type::value_type;
+
+  using Translation = domain::CoordinateMaps::TimeDependent::Translation;
+  using Identity2D = domain::CoordinateMaps::Identity<2>;
+  using Solution =
+      RelativisticEuler::Solutions::TovStar<gr::Solutions::TovSolution>;
+  const Mesh<3> subcell_mesh{5, Spectral::Basis::FiniteDifference,
+                             Spectral::Quadrature::CellCentered};
+  const double time = 0.1;
+  const auto logical_coords = logical_coordinates(subcell_mesh);
+  constexpr double central_density = 1.28e-3;
+  constexpr double polytropic_constant = 100.0;
+  constexpr double polytropic_exponent = 2.0;
+  const Solution solution{central_density, polytropic_constant,
+                          polytropic_exponent};
+
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time{};
+  functions_of_time["Translation"] =
+      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+          0.0, std::array<DataVector, 3>{{{0.0}, {2.3}, {0.0}}}, 10.0);
+
+  auto box = db::create<db::AddSimpleTags<
+      Initialization::Tags::InitialTime, evolution::dg::subcell::Tags::Mesh<3>,
+      domain::Tags::ElementMap<3, Frame::Grid>,
+      domain::CoordinateMaps::Tags::CoordinateMap<3, Frame::Grid,
+                                                  Frame::Inertial>,
+      domain::Tags::FunctionsOfTime,
+      evolution::dg::subcell::Tags::Coordinates<3, Frame::Logical>,
+      Tags::AnalyticSolution<Solution>, subcell_gr_tag, subcell_faces_gr_tag>>(
+      time, subcell_mesh,
+      ElementMap<3, Frame::Grid>{
+          ElementId<3>{0},
+          domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+              domain::CoordinateMaps::Identity<3>{})},
+      domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+          domain::CoordinateMaps::TimeDependent::ProductOf2Maps<Translation,
+                                                                Identity2D>(
+              Translation{"Translation"}, Identity2D{})),
+      clone_unique_ptrs(functions_of_time), logical_coords,
+      Solution{central_density, polytropic_constant, polytropic_exponent},
+      SubcellGrVars{}, std::array<FaceGrVars, 3>{});
+
+  db::mutate_apply<Initialization::subcell::GrTagsForHydro<System, 3>>(
+      make_not_null(&box));
+
+  const ElementMap<3, Frame::Grid> logical_to_grid_map{
+      ElementId<3>{0},
+      domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+          domain::CoordinateMaps::Identity<3>{})};
+  const auto grid_to_inertial_map =
+      domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+          domain::CoordinateMaps::TimeDependent::ProductOf2Maps<Translation,
+                                                                Identity2D>(
+              Translation{"Translation"}, Identity2D{}));
+
+  // Check cell-centered values
+  const auto cell_centered_inertial_coords = (*grid_to_inertial_map)(
+      logical_to_grid_map(logical_coords), time, functions_of_time);
+
+  GrVars expected_no_prefix_cell_centered_gr_vars{
+      subcell_mesh.number_of_grid_points()};
+  expected_no_prefix_cell_centered_gr_vars.assign_subset(solution.variables(
+      cell_centered_inertial_coords, time, GrVars::tags_list{}));
+  const SubcellGrVars expected_centered_gr_vars{
+      std::move(expected_no_prefix_cell_centered_gr_vars)};
+
+  CHECK_VARIABLES_APPROX(db::get<subcell_gr_tag>(box),
+                         expected_centered_gr_vars);
+
+  // Check face-centered values
+  for (size_t i = 0; i < 3; ++i) {
+    const auto basis = subcell_mesh.basis();
+    auto quadrature = subcell_mesh.quadrature();
+    auto extents = make_array<3>(subcell_mesh.extents(0));
+    gsl::at(extents, i) += 1;
+    gsl::at(quadrature, i) = Spectral::Quadrature::FaceCentered;
+    const Mesh<3> face_centered_mesh{extents, basis, quadrature};
+    const auto face_logical_coords = logical_coordinates(face_centered_mesh);
+    const auto face_inertial_coords = (*grid_to_inertial_map)(
+        logical_to_grid_map(face_logical_coords), time, functions_of_time);
+    FaceGrVars expected_face_vars{face_centered_mesh.number_of_grid_points()};
+    expected_face_vars.assign_subset(solution.variables(
+        face_inertial_coords, time, typename FaceGrVars::tags_list{}));
+
+    CHECK_VARIABLES_APPROX(gsl::at(db::get<subcell_faces_gr_tag>(box), i),
+                           expected_face_vars);
+  }
+}


### PR DESCRIPTION
## Proposed changes

Add an initialization mutator (see #3286 for the action that enables using these) to initialize the GR tags needed for GRMHD evolutions. This mutator is strictly more general, I think, but I haven't tested it beyond GRMHD.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
