### PR TITLE
Add SetVariablesNeededFixingToFalse initialization mutator

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -16,6 +16,7 @@ spectre_target_sources(
   NewmanHamlin.cpp
   PalenzuelaEtAl.cpp
   PrimitiveFromConservative.cpp
+  SetVariablesNeededFixingToFalse.cpp
   Sources.cpp
   TimeDerivativeTerms.cpp
   VolumeTermsInstantiation.cpp
@@ -34,6 +35,7 @@ spectre_target_headers(
   PalenzuelaEtAl.hpp
   PrimitiveFromConservative.hpp
   PrimitiveRecoveryData.hpp
+  SetVariablesNeededFixingToFalse.hpp
   Sources.hpp
   System.hpp
   Tags.hpp

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/SetVariablesNeededFixingToFalse.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/SetVariablesNeededFixingToFalse.cpp
@@ -1,0 +1,13 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/SetVariablesNeededFixingToFalse.hpp"
+
+#include "Utilities/Gsl.hpp"
+
+namespace grmhd::ValenciaDivClean {
+void SetVariablesNeededFixingToFalse::apply(
+    const gsl::not_null<bool*> variables_needed_fixing) noexcept {
+  *variables_needed_fixing = false;
+}
+}  // namespace grmhd::ValenciaDivClean

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/SetVariablesNeededFixingToFalse.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/SetVariablesNeededFixingToFalse.hpp
@@ -1,0 +1,27 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace grmhd::ValenciaDivClean {
+/*!
+ * \brief Mutator used with `Initialization::Actions::AddSimpleTags` to
+ * initialize the `VariablesNeededFixing` to `false`
+ */
+struct SetVariablesNeededFixingToFalse {
+  using return_tags = tmpl::list<Tags::VariablesNeededFixing>;
+  using argument_tags = tmpl::list<>;
+
+  static void apply(gsl::not_null<bool*> variables_needed_fixing) noexcept;
+};
+}  // namespace grmhd::ValenciaDivClean

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -19,6 +19,7 @@ set(LIBRARY_SOURCES
   Test_FixConservatives.cpp
   Test_Fluxes.cpp
   Test_PrimitiveFromConservative.cpp
+  Test_SetVariablesNeededFixingToFalse.cpp
   Test_Sources.cpp
   Test_Tags.cpp
   Test_TimeDerivativeTerms.cpp

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_SetVariablesNeededFixingToFalse.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_SetVariablesNeededFixingToFalse.cpp
@@ -1,0 +1,20 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/SetVariablesNeededFixingToFalse.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.ValenciaDivClean.SetVariablesNeededFixingToFalse",
+    "[Unit][Evolution]") {
+  auto box = db::create<
+      db::AddSimpleTags<grmhd::ValenciaDivClean::Tags::VariablesNeededFixing>>(
+      true);
+  db::mutate_apply<grmhd::ValenciaDivClean::SetVariablesNeededFixingToFalse>(
+      make_not_null(&box));
+  CHECK_FALSE(
+      db::get<grmhd::ValenciaDivClean::Tags::VariablesNeededFixing>(box));
+}


### PR DESCRIPTION
## Proposed changes

Uses the action being added in #3286 to initialize the `VariablesNeededFixing` GRMHD tag

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
