### PR TITLE
Add FixConservativesAndComputePrims mutator to ValenciaDivClean

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/CMakeLists.txt
@@ -4,6 +4,7 @@
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  FixConservativesAndComputePrims.cpp
   InitialDataTci.cpp
   PrimitiveGhostData.cpp
   ResizeAndComputePrimitives.cpp
@@ -17,6 +18,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  FixConservativesAndComputePrims.hpp
   GrTagsForHydro.hpp
   InitialDataTci.hpp
   PrimitiveGhostData.hpp

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/FixConservativesAndComputePrims.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/FixConservativesAndComputePrims.cpp
@@ -1,0 +1,105 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/FixConservativesAndComputePrims.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/FixConservatives.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace grmhd::ValenciaDivClean::subcell {
+template <typename OrderedListOfRecoverySchemes>
+template <size_t ThermodynamicDim>
+void FixConservativesAndComputePrims<OrderedListOfRecoverySchemes>::apply(
+    const gsl::not_null<bool*> needed_fixing,
+    const gsl::not_null<typename System::variables_tag::type*>
+        conserved_vars_ptr,
+    const gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*>
+        primitive_vars_ptr,
+    const grmhd::ValenciaDivClean::FixConservatives& fix_conservatives,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+    const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
+    const Scalar<DataVector>& sqrt_det_spatial_metric) noexcept {
+  *needed_fixing = fix_conservatives(
+      make_not_null(&get<Tags::TildeD>(*conserved_vars_ptr)),
+      make_not_null(&get<Tags::TildeTau>(*conserved_vars_ptr)),
+      make_not_null(&get<Tags::TildeS<Frame::Inertial>>(*conserved_vars_ptr)),
+      get<Tags::TildeB<Frame::Inertial>>(*conserved_vars_ptr), spatial_metric,
+      inv_spatial_metric, sqrt_det_spatial_metric);
+  grmhd::ValenciaDivClean::
+      PrimitiveFromConservative<OrderedListOfRecoverySchemes, true>::apply(
+          make_not_null(&get<hydro::Tags::RestMassDensity<DataVector>>(
+              *primitive_vars_ptr)),
+          make_not_null(&get<hydro::Tags::SpecificInternalEnergy<DataVector>>(
+              *primitive_vars_ptr)),
+          make_not_null(&get<hydro::Tags::SpatialVelocity<DataVector, 3>>(
+              *primitive_vars_ptr)),
+          make_not_null(&get<hydro::Tags::MagneticField<DataVector, 3>>(
+              *primitive_vars_ptr)),
+          make_not_null(&get<hydro::Tags::DivergenceCleaningField<DataVector>>(
+              *primitive_vars_ptr)),
+          make_not_null(&get<hydro::Tags::LorentzFactor<DataVector>>(
+              *primitive_vars_ptr)),
+          make_not_null(
+              &get<hydro::Tags::Pressure<DataVector>>(*primitive_vars_ptr)),
+          make_not_null(&get<hydro::Tags::SpecificEnthalpy<DataVector>>(
+              *primitive_vars_ptr)),
+          get<Tags::TildeD>(*conserved_vars_ptr),
+          get<Tags::TildeTau>(*conserved_vars_ptr),
+          get<Tags::TildeS<Frame::Inertial>>(*conserved_vars_ptr),
+          get<Tags::TildeB<Frame::Inertial>>(*conserved_vars_ptr),
+          get<Tags::TildePhi>(*conserved_vars_ptr), spatial_metric,
+          inv_spatial_metric, sqrt_det_spatial_metric, eos);
+}
+
+namespace {
+using NewmanThenPalenzuela =
+    tmpl::list<PrimitiveRecoverySchemes::NewmanHamlin,
+               PrimitiveRecoverySchemes::PalenzuelaEtAl>;
+using KastaunThenNewmanThenPalenzuela =
+    tmpl::list<PrimitiveRecoverySchemes::KastaunEtAl,
+               PrimitiveRecoverySchemes::NewmanHamlin,
+               PrimitiveRecoverySchemes::PalenzuelaEtAl>;
+}  // namespace
+
+#define RECOVERY(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATION(r, data)                                              \
+  template void                                                             \
+  FixConservativesAndComputePrims<RECOVERY(data)>::apply<THERMO_DIM(data)>( \
+      const gsl::not_null<bool*> needed_fixing,                             \
+      const gsl::not_null<typename System::variables_tag::type*>            \
+          conserved_vars_ptr,                                               \
+      const gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*>        \
+          primitive_vars_ptr,                                               \
+      const grmhd::ValenciaDivClean::FixConservatives& fix_conservatives,   \
+      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos, \
+      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,       \
+      const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,   \
+      const Scalar<DataVector>& sqrt_det_spatial_metric) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION,
+                        (tmpl::list<PrimitiveRecoverySchemes::KastaunEtAl>,
+                         tmpl::list<PrimitiveRecoverySchemes::NewmanHamlin>,
+                         tmpl::list<PrimitiveRecoverySchemes::PalenzuelaEtAl>,
+                         NewmanThenPalenzuela, KastaunThenNewmanThenPalenzuela),
+                        (1, 2))
+
+#undef INSTANTIATION
+#undef THERMO_DIM
+#undef RECOVERY
+}  // namespace grmhd::ValenciaDivClean::subcell

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/FixConservativesAndComputePrims.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/FixConservativesAndComputePrims.hpp
@@ -1,0 +1,62 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/FixConservatives.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+#include "Evolution/VariableFixing/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace EquationsOfState {
+template <bool IsRelativistic, size_t ThermodynamicDim>
+class EquationOfState;
+}  // namespace EquationsOfState
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+template <typename TagsList>
+class Variables;
+/// \endcond
+
+namespace grmhd::ValenciaDivClean::subcell {
+/*!
+ * \brief Fix the conservative variables and compute the primitive variables.
+ *
+ * Sets `ValenciaDivClean::Tags::VariablesNeededFixing` to `true` if the
+ * conservative variables needed fixing, otherwise sets the tag to `false`.
+ */
+template <typename OrderedListOfRecoverySchemes>
+struct FixConservativesAndComputePrims {
+  using return_tags = tmpl::list<ValenciaDivClean::Tags::VariablesNeededFixing,
+                                 typename System::variables_tag,
+                                 typename System::primitive_variables_tag>;
+  using argument_tags = tmpl::list<
+      ::Tags::VariableFixer<grmhd::ValenciaDivClean::FixConservatives>,
+      hydro::Tags::EquationOfStateBase,
+      gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+      gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>,
+      gr::Tags::SqrtDetSpatialMetric<DataVector>>;
+
+  template <size_t ThermodynamicDim>
+  static void apply(
+      gsl::not_null<bool*> needed_fixing,
+      gsl::not_null<typename System::variables_tag::type*> conserved_vars_ptr,
+      gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*>
+          primitive_vars_ptr,
+      const grmhd::ValenciaDivClean::FixConservatives& fix_conservatives,
+      const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+      const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
+      const Scalar<DataVector>& sqrt_det_spatial_metric) noexcept;
+};
+}  // namespace grmhd::ValenciaDivClean::subcell

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   BoundaryConditions/Test_Periodic.cpp
   BoundaryCorrections/Test_Hll.cpp
   BoundaryCorrections/Test_Rusanov.cpp
+  Subcell/Test_FixConservativesAndComputePrims.cpp
   Subcell/Test_GrTagsForHydro.cpp
   Subcell/Test_InitialDataTci.cpp
   Subcell/Test_PrimitiveGhostData.cpp

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_FixConservativesAndComputePrims.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_FixConservativesAndComputePrims.cpp
@@ -1,0 +1,98 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/FixConservatives.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/FixConservativesAndComputePrims.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+#include "Evolution/VariableFixing/Tags.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.ValenciaDivClean.Subcell.FixConsAndComputePrims",
+    "[Unit][Evolution]") {
+  using System = grmhd::ValenciaDivClean::System;
+
+  // Only use 1 grid point to see that we correctly flagged the point as being
+  // fixed. We're really only testing that the mutator calls the correct
+  // functions.
+  const size_t num_pts = 1;
+  tnsr::ii<DataVector, 3, Frame::Inertial> spatial_metric{num_pts, 0.0};
+  tnsr::II<DataVector, 3, Frame::Inertial> inverse_spatial_metric{num_pts, 0.0};
+  for (size_t i = 0; i < 3; ++i) {
+    spatial_metric.get(i, i) = 1.0;
+    inverse_spatial_metric.get(i, i) = 1.0;
+  }
+  const Scalar<DataVector> sqrt_det_spatial_metric{num_pts, 1.0};
+  const grmhd::ValenciaDivClean::FixConservatives variable_fixer{1.e-7, 1.0e-7,
+                                                                 0.0, 0.0};
+  typename System::variables_tag::type cons_vars{num_pts, 0.0};
+  get(get<grmhd::ValenciaDivClean::Tags::TildeD>(cons_vars))[0] = 2.e-12;
+  get(get<grmhd::ValenciaDivClean::Tags::TildeTau>(cons_vars))[0] = 1.e-7;
+
+  const EquationsOfState::PolytropicFluid<true> eos{100.0, 2.0};
+
+  auto box = db::create<db::AddSimpleTags<
+      grmhd::ValenciaDivClean::Tags::VariablesNeededFixing,
+      typename System::variables_tag, typename System::primitive_variables_tag,
+      ::Tags::VariableFixer<grmhd::ValenciaDivClean::FixConservatives>,
+      hydro::Tags::EquationOfState<
+          std::unique_ptr<EquationsOfState::EquationOfState<true, 1>>>,
+      gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+      gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>,
+      gr::Tags::SqrtDetSpatialMetric<DataVector>>>(
+      false, cons_vars,
+      typename System::primitive_variables_tag::type{num_pts, 1.0e-4},
+      variable_fixer,
+      std::unique_ptr<EquationsOfState::EquationOfState<true, 1>>{
+          std::make_unique<EquationsOfState::PolytropicFluid<true>>(eos)},
+      spatial_metric, inverse_spatial_metric, sqrt_det_spatial_metric);
+
+  using recovery_schemes = tmpl::list<
+      grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl>;
+  db::mutate_apply<grmhd::ValenciaDivClean::subcell::
+                       FixConservativesAndComputePrims<recovery_schemes>>(
+      make_not_null(&box));
+
+  // Verify that the conserved variables were fixed
+  CHECK(db::get<grmhd::ValenciaDivClean::Tags::VariablesNeededFixing>(box));
+
+  // Manually do a primitive recovery and see that the values match what's in
+  // the DataBox.
+  typename System::primitive_variables_tag::type expected_prims{num_pts,
+                                                                1.0e-4};
+  grmhd::ValenciaDivClean::PrimitiveFromConservative<recovery_schemes, true>::
+      apply(
+          make_not_null(
+              &get<hydro::Tags::RestMassDensity<DataVector>>(expected_prims)),
+          make_not_null(&get<hydro::Tags::SpecificInternalEnergy<DataVector>>(
+              expected_prims)),
+          make_not_null(&get<hydro::Tags::SpatialVelocity<DataVector, 3>>(
+              expected_prims)),
+          make_not_null(
+              &get<hydro::Tags::MagneticField<DataVector, 3>>(expected_prims)),
+          make_not_null(&get<hydro::Tags::DivergenceCleaningField<DataVector>>(
+              expected_prims)),
+          make_not_null(
+              &get<hydro::Tags::LorentzFactor<DataVector>>(expected_prims)),
+          make_not_null(
+              &get<hydro::Tags::Pressure<DataVector>>(expected_prims)),
+          make_not_null(
+              &get<hydro::Tags::SpecificEnthalpy<DataVector>>(expected_prims)),
+          db::get<grmhd::ValenciaDivClean::Tags::TildeD>(box),
+          db::get<grmhd::ValenciaDivClean::Tags::TildeTau>(box),
+          db::get<grmhd::ValenciaDivClean::Tags::TildeS<Frame::Inertial>>(box),
+          db::get<grmhd::ValenciaDivClean::Tags::TildeB<Frame::Inertial>>(box),
+          db::get<grmhd::ValenciaDivClean::Tags::TildePhi>(box), spatial_metric,
+          inverse_spatial_metric, sqrt_det_spatial_metric, eos);
+  CHECK_VARIABLES_APPROX(db::get<typename System::primitive_variables_tag>(box),
+                         expected_prims);
+}


### PR DESCRIPTION
## Proposed changes

Add a mutator that fixes the conserved variables, records whether or not they needed fixing in `Tags::VariablesNeededFixing`, and then computes the primitives on the subcells.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
