### PR TITLE
Add compute fluxes helpers to GRMHD for subcell

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -49,6 +49,7 @@ target_link_libraries(
   Boost::boost
   DataStructures
   DgSubcell
+  DiscontinuousGalerkin
   ErrorHandling
   GeneralRelativity
   Hydro

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/CMakeLists.txt
@@ -18,6 +18,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  ComputeFluxes.hpp
   FixConservativesAndComputePrims.hpp
   GrTagsForHydro.hpp
   InitialDataTci.hpp

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ComputeFluxes.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ComputeFluxes.hpp
@@ -1,0 +1,32 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace grmhd::ValenciaDivClean::subcell {
+namespace detail {
+template <typename TagsList, typename... ReturnTags, typename... ArgumentTags>
+void compute_fluxes_impl(const gsl::not_null<Variables<TagsList>*> vars,
+                         tmpl::list<ReturnTags...> /*meta*/,
+                         tmpl::list<ArgumentTags...> /*meta*/) noexcept {
+  grmhd::ValenciaDivClean::ComputeFluxes::apply(
+      make_not_null(&get<ReturnTags>(*vars))..., get<ArgumentTags>(*vars)...);
+}
+}  // namespace detail
+
+/*!
+ * \brief Helper function that calls `ComputeFluxes` by retrieving the return
+ * and argument tags from `vars`.
+ */
+template <typename TagsList>
+void compute_fluxes(const gsl::not_null<Variables<TagsList>*> vars) noexcept {
+  detail::compute_fluxes_impl(
+      vars, typename grmhd::ValenciaDivClean::ComputeFluxes::return_tags{},
+      typename grmhd::ValenciaDivClean::ComputeFluxes::argument_tags{});
+}
+}  // namespace grmhd::ValenciaDivClean::subcell

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   BoundaryConditions/Test_Periodic.cpp
   BoundaryCorrections/Test_Hll.cpp
   BoundaryCorrections/Test_Rusanov.cpp
+  Subcell/Test_ComputeFluxes.cpp
   Subcell/Test_FixConservativesAndComputePrims.cpp
   Subcell/Test_GrTagsForHydro.cpp
   Subcell/Test_InitialDataTci.cpp

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_ComputeFluxes.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_ComputeFluxes.cpp
@@ -1,0 +1,76 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <random>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ComputeFluxes.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace grmhd::ValenciaDivClean {
+namespace {
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.ValenciaDivClean.Subcell.ComputeFluxes",
+    "[Unit][Evolution]") {
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<double> dist(0.0, 1.0);
+  const size_t num_pts = 5;
+
+  auto vars = make_with_random_values<Variables<
+      tmpl::append<ComputeFluxes::return_tags, ComputeFluxes::argument_tags>>>(
+      make_not_null(&gen), make_not_null(&dist), num_pts);
+
+  Variables<ComputeFluxes::return_tags> expected_fluxes{num_pts};
+  ComputeFluxes::apply(
+      make_not_null(&get<::Tags::Flux<grmhd::ValenciaDivClean::Tags::TildeD,
+                                      tmpl::size_t<3>, Frame::Inertial>>(
+          expected_fluxes)),
+      make_not_null(&get<::Tags::Flux<grmhd::ValenciaDivClean::Tags::TildeTau,
+                                      tmpl::size_t<3>, Frame::Inertial>>(
+          expected_fluxes)),
+      make_not_null(&get<::Tags::Flux<grmhd::ValenciaDivClean::Tags::TildeS<>,
+                                      tmpl::size_t<3>, Frame::Inertial>>(
+          expected_fluxes)),
+      make_not_null(&get<::Tags::Flux<grmhd::ValenciaDivClean::Tags::TildeB<>,
+                                      tmpl::size_t<3>, Frame::Inertial>>(
+          expected_fluxes)),
+      make_not_null(&get<::Tags::Flux<grmhd::ValenciaDivClean::Tags::TildePhi,
+                                      tmpl::size_t<3>, Frame::Inertial>>(
+          expected_fluxes)),
+      get<grmhd::ValenciaDivClean::Tags::TildeD>(vars),
+      get<grmhd::ValenciaDivClean::Tags::TildeTau>(vars),
+      get<grmhd::ValenciaDivClean::Tags::TildeS<>>(vars),
+      get<grmhd::ValenciaDivClean::Tags::TildeB<>>(vars),
+      get<grmhd::ValenciaDivClean::Tags::TildePhi>(vars),
+      get<gr::Tags::Lapse<>>(vars), get<gr::Tags::Shift<3>>(vars),
+      get<gr::Tags::SqrtDetSpatialMetric<>>(vars),
+      get<gr::Tags::SpatialMetric<3>>(vars),
+      get<gr::Tags::InverseSpatialMetric<3>>(vars),
+      get<hydro::Tags::Pressure<DataVector>>(vars),
+      get<hydro::Tags::SpatialVelocity<DataVector, 3>>(vars),
+      get<hydro::Tags::LorentzFactor<DataVector>>(vars),
+      get<hydro::Tags::MagneticField<DataVector, 3>>(vars));
+
+  subcell::compute_fluxes(make_not_null(&vars));
+
+  tmpl::for_each<ComputeFluxes::return_tags>(
+      [&expected_fluxes, &vars](auto tag_v) {
+        using tag = tmpl::type_from<decltype(tag_v)>;
+        CHECK_ITERABLE_APPROX(get<tag>(vars), get<tag>(expected_fluxes));
+      });
+}
+}  // namespace
+}  // namespace grmhd::ValenciaDivClean


### PR DESCRIPTION
## Proposed changes

The subcell code needs to call the `ComputeFluxes::apply` a few times, and manually doing all the tag retrieval is rather tedious. This short forwarding function is quite useful.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
