### PR TITLE
Test_CylindricalSide: Don't put proj point near edge.

### DIFF
--- a/tests/Unit/Domain/CoordinateMaps/Test_CylindricalSide.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CylindricalSide.cpp
@@ -67,8 +67,8 @@ void test_cylindrical_side_sphere_two_encloses_sphere_one() {
   ]() noexcept {
     // Need proj_center between or on the z_planes.
     const double z = z_planes[0] + (z_planes[1] - z_planes[0]) * unit_dis(gen);
-    // choose 0.95 so that proj_center is not on edge of sphere_one.
-    const double rho_max = 0.95 * radius_one *
+    // choose 0.9 so that proj_center is not on edge of sphere_one.
+    const double rho_max = 0.9 * radius_one *
                            sqrt(1.0 - square((z - center_one[2]) / radius_one));
     const double rho = unit_dis(gen) * rho_max;
     const double phi = angle_dis(gen);


### PR DESCRIPTION
## Proposed changes
The test was able to put the projection point very close to the edge of Sphere1, so that roundoff differences
made the test fail.

Passed tests on my machine with --repeat-until-fail 10000

Fixes #3294

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
