### PR TITLE
Load updated git module on Caltech HPC

### DIFF
--- a/support/Environments/caltech_hpc_gcc.sh
+++ b/support/Environments/caltech_hpc_gcc.sh
@@ -12,6 +12,7 @@ spectre_load_sys_modules() {
     module load boost/1_68_0-gcc730
     module load cmake/3.18.0
     module load python3/3.8.5
+    module load git/2.26.0
 }
 
 # Unload system modules
@@ -23,6 +24,7 @@ spectre_unload_sys_modules() {
     module unload gcc/9.2.0
     module unload cmake/3.18.0
     module unload python3/3.8.5
+    module unload git/2.26.0
 }
 
 


### PR DESCRIPTION
## Proposed changes

The latest develop doesn't build on Caltech HPC: it fails with an error about an unknown git option. This is fixed by using a newer version of git (here, I chose the newest available on the system, 2.26.0) than the system default (1.8.3.1). This PR just updates the Caltech HPC environment to include git 2.26.0 among the system modules.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
