### PR TITLE
Add the IrreducibleMassTag to EvolveGeneralizedHarmonicWithHorizon.hpp

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
@@ -59,7 +59,8 @@ struct EvolutionMetavars
 
   struct AhA {
     using tags_to_observe =
-        tmpl::list<StrahlkorperGr::Tags::AreaCompute<frame>>;
+        tmpl::list<StrahlkorperGr::Tags::AreaCompute<frame>,
+                   StrahlkorperGr::Tags::IrreducibleMassCompute<frame>>;
     using compute_items_on_source = tmpl::list<
         gr::Tags::SpatialMetricCompute<volume_dim, frame, DataVector>,
         ah::Tags::InverseSpatialMetricCompute<volume_dim, frame>,


### PR DESCRIPTION
## Proposed changes

Add the irreducible mass tag that computes the irreducible mass of a Strahlkorper to the `EvolveGeneralizedHarmonicWithHorizon.hpp` executable file.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
