### PR TITLE
Restore missing assignment in BjorhusImpl.cpp

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.cpp
@@ -482,8 +482,9 @@ void add_physical_terms_to_dt_v_minus(
         for (size_t c = 0; c <= VolumeDim; ++c) {
           for (size_t d = 0; d <= VolumeDim; ++d) {
             if constexpr (mu_phys == 0.) {
-              (projection_Ab.get(c, a) * projection_Ab.get(d, b) -
-               0.5 * projection_ab.get(a, b) * projection_AB.get(c, d)) *
+              bc_dt_v_minus->get(a, b) +=
+                  (projection_Ab.get(c, a) * projection_Ab.get(d, b) -
+                   0.5 * projection_ab.get(a, b) * projection_AB.get(c, d)) *
                   (char_projected_rhs_dt_v_minus.get(c, d) +
                    char_speeds[3] * (U3m.get(c, d)));
             } else {


### PR DESCRIPTION
## Proposed changes

There's a syntax typo in a (currently unused) branch of the `if` in BjorhusImpl.cpp.
This part of the implementation is ported over from SpEC and the current implementation assumes we do not use the extra parameters to match the SpEC implementation, and so doesn't test the if branches that depend on those unused parameters.

An alternative could be to just comment or remove the code that doesn't get used or tested.


### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.
