### PR TITLE
Add self-start procedure to CCE

### DIFF
--- a/src/Evolution/Executables/Cce/CharacteristicExtract.hpp
+++ b/src/Evolution/Executables/Cce/CharacteristicExtract.hpp
@@ -118,7 +118,12 @@ struct EvolutionMetavars {
       "Perform Cauchy Characteristic Extraction using .h5 input data.\n"
       "Uses regularity-preserving formulation."};
 
-  enum class Phase { Initialization, Evolve, Exit };
+  enum class Phase {
+    Initialization,
+    InitializeTimeStepperHistory,
+    Evolve,
+    Exit
+  };
 
   template <typename... Tags>
   static Phase determine_next_phase(
@@ -128,6 +133,8 @@ struct EvolutionMetavars {
       const Parallel::CProxy_GlobalCache<
           EvolutionMetavars>& /*cache_proxy*/) noexcept {
     if (current_phase == Phase::Initialization) {
+      return Phase::InitializeTimeStepperHistory;
+    } else if (current_phase == Phase::InitializeTimeStepperHistory) {
       return Phase::Evolve;
     } else {
       return Phase::Exit;

--- a/src/Evolution/Systems/Cce/Actions/BoundaryComputeAndSendToEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Actions/BoundaryComputeAndSendToEvolution.hpp
@@ -229,8 +229,7 @@ struct BoundaryComputeAndSendToEvolution<GhWorldtubeBoundary<Metavariables>,
                     Parallel::GlobalCache<Metavariables>& cache,
                     const ArrayIndex& /*array_index*/,
                     const TimeStepId& time) noexcept {
-    db::mutate<Tags::GhInterfaceManager>(
-        make_not_null(&box),
+    auto retrieve_data_and_send_to_evolution =
         [&time, &cache](const gsl::not_null<
                         std::unique_ptr<InterfaceManagers::GhInterfaceManager>*>
                             interface_manager) noexcept {
@@ -244,7 +243,14 @@ struct BoundaryComputeAndSendToEvolution<GhWorldtubeBoundary<Metavariables>,
                     GhWorldtubeBoundary<Metavariables>>(cache),
                 get<0>(*gh_data), get<1>(*gh_data));
           }
-        });
+        };
+    if (SelfStart::is_self_starting(time)) {
+      db::mutate<Tags::SelfStartGhInterfaceManager>(
+          make_not_null(&box), retrieve_data_and_send_to_evolution);
+    } else {
+      db::mutate<Tags::GhInterfaceManager>(make_not_null(&box),
+                                           retrieve_data_and_send_to_evolution);
+    }
   }
 };
 

--- a/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
@@ -88,10 +88,7 @@ struct InitializeCharacteristicEvolutionTime {
     const Time initial_time = single_step_slab.start();
     const TimeDelta fixed_time_step =
         TimeDelta{single_step_slab, Rational{1, 1}};
-    TimeStepId initial_time_id{true, 0, initial_time};
     const auto& time_stepper = db::get<::Tags::TimeStepper<TimeStepper>>(box);
-    TimeStepId second_time_id =
-        time_stepper.next_time_id(initial_time_id, fixed_time_step);
 
     const size_t starting_order =
         time_stepper.number_of_past_steps() == 0 ? time_stepper.order() : 1;
@@ -102,9 +99,10 @@ struct InitializeCharacteristicEvolutionTime {
     typename ::Tags::HistoryEvolvedVariables<evolved_swsh_variables_tag>::type
         swsh_history(starting_order);
     Initialization::mutate_assign<simple_tags>(
-        make_not_null(&box),
-        std::move(initial_time_id),  // NOLINT
-        std::move(second_time_id),   // NOLINT
+        make_not_null(&box), TimeStepId{},
+        TimeStepId{true,
+                   -static_cast<int64_t>(time_stepper.number_of_past_steps()),
+                   initial_time},
         fixed_time_step, fixed_time_step, initial_time_value,
         std::move(coordinate_history), std::move(swsh_history));
     return std::make_tuple(std::move(box));

--- a/src/Evolution/Systems/Cce/AnalyticBoundaryDataManager.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticBoundaryDataManager.hpp
@@ -68,6 +68,10 @@ class AnalyticBoundaryDataManager {
 
   size_t get_l_max() const noexcept { return l_max_; }
 
+  const Solutions::WorldtubeData& get_generator() const noexcept {
+    return *generator_;
+  }
+
   /// Serialization for Charm++.
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p) noexcept;

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/RobinsonTrautman.cpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/RobinsonTrautman.cpp
@@ -57,7 +57,7 @@ RobinsonTrautman::RobinsonTrautman(
   initialize_stepper_from_start();
 }
 
-void RobinsonTrautman::initialize_stepper_from_start() noexcept {
+void RobinsonTrautman::initialize_stepper_from_start() const noexcept {
   // create the initial data
   SpinWeighted<ComplexModalVector, 0> goldberg_modes{square(l_max_ + 1), 0.0};
   for (size_t i = 0; i < std::min(initial_modes_.size(), goldberg_modes.size());
@@ -140,11 +140,7 @@ void RobinsonTrautman::prepare_solution(const size_t l_max,
          "specified at construction, as it must internally store the evolved "
          "scalar at the desired resolution");
   if (step_range_.first > time) {
-    ERROR(
-        "The Robinson-Trautman solution does not support stepping backwards in "
-        "time during the internal evolution. This error likely means that the "
-        "corresponding evolution test should be using a multistep time-stepper "
-        "so that the requested boundary data is monotonic.");
+    initialize_stepper_from_start();
   }
   // step until the target time is within the current timestep
   const auto rt_system = [this](const ComplexDataVector& local_rt_scalar,

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/RobinsonTrautman.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/RobinsonTrautman.hpp
@@ -41,6 +41,20 @@ namespace Solutions {
  * is imposed by the solution itself, any modes specified in the input file are
  * treated as perturbations to the leading value of 1.0 for the
  * Robinson-Trautman scalar \f$\omega_{\text{RT}}\f$.
+ *
+ * \note The use of substep time-steppers in conjunction with `RobinsonTrautman`
+ * analytic data is explictly forbidden by checks in
+ * `Cce::Actions::InitializeWorldtubeBoundary`. The reason is that any time the
+ * `RobinsonTrautman` receives a request for data at a time in the past of its
+ * current state, it must re-start its internal time stepper from the beginning
+ * of the evolution. This is a reasonable cost for multistep methods that only
+ * have non-ordered time steps during self-start, but will lead to
+ * \f$\mathcal O(N^2)\f$ internal steps in the `RobinsonTrautman` solution if a
+ * substep method is used, where \f$N\f$ is the number of steps performed by the
+ * substep method. If you find an unavoidable need to use `RobinsonTrautman`
+ * with a substep method, you will either need to only do so for very short
+ * evolutions, or need to write more sophisticated caching of the internal time
+ * step data.
  */
 struct RobinsonTrautman : public SphericalMetricData {
   struct InitialModes {
@@ -134,7 +148,7 @@ struct RobinsonTrautman : public SphericalMetricData {
       const Scalar<SpinWeighted<ComplexDataVector, 0>>& rt_scalar)
       const noexcept;
 
-  void initialize_stepper_from_start() noexcept;
+  void initialize_stepper_from_start() const noexcept;
 
  protected:
   /*!

--- a/src/Evolution/Systems/Cce/System.hpp
+++ b/src/Evolution/Systems/Cce/System.hpp
@@ -114,6 +114,10 @@
 namespace Cce {
 
 struct System {
-  using variables_tag = ::Tags::Variables<Tags::BondiJ>;
+  using variables_tag = tmpl::list<
+      ::Tags::Variables<tmpl::list<Tags::BondiJ>>,
+      ::Tags::Variables<tmpl::list<Cce::Tags::CauchyCartesianCoords,
+                                   Cce::Tags::InertialRetardedTime>>>;
+  static constexpr bool has_primitive_and_conservative_vars = false;
 };
 }

--- a/src/Evolution/Systems/Cce/Tags.hpp
+++ b/src/Evolution/Systems/Cce/Tags.hpp
@@ -9,6 +9,8 @@
 #include "DataStructures/SpinWeighted.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/Cce/InterfaceManagers/GhInterfaceManager.hpp"
+#include "Evolution/Systems/Cce/InterfaceManagers/GhLockstep.hpp"
 #include "NumericalAlgorithms/Spectral/SwshTags.hpp"
 #include "Time/TimeStepId.hpp"
 
@@ -368,6 +370,19 @@ struct InterpolationManager : db::SimpleTag {
   using type = ScriPlusInterpolationManager<ToInterpolate, ObservationTag>;
   static std::string name() noexcept {
     return "InterpolationManager(" + db::tag_name<ObservationTag>() + ")";
+  }
+};
+
+/// During self-start, we must be in lockstep with the GH system (if running
+/// concurrently), because the step size is unchangable during self-start.
+struct SelfStartGhInterfaceManager : db::SimpleTag {
+  using type = std::unique_ptr<InterfaceManagers::GhInterfaceManager>;
+  using option_tags = tmpl::list<>;
+
+  static constexpr bool pass_metavariables = false;
+  static std::unique_ptr<InterfaceManagers::GhInterfaceManager>
+  create_from_options() noexcept {
+    return std::make_unique<Cce::InterfaceManagers::GhLockstep>();
   }
 };
 }  // namespace Tags

--- a/src/Time/Actions/SelfStartActions.hpp
+++ b/src/Time/Actions/SelfStartActions.hpp
@@ -256,7 +256,7 @@ struct Initialize {
 /// - Adds: nothing
 /// - Removes: nothing
 /// - Modifies: nothing
-template <typename ExitTag>
+template <typename ExitTag, typename System>
 struct CheckForCompletion {
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
@@ -267,13 +267,12 @@ struct CheckForCompletion {
       const Parallel::GlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) noexcept {
-    using system = typename Metavariables::system;
 
     const bool done_with_order =
         db::get<::Tags::Next<::Tags::TimeStepId>>(box).is_at_slab_boundary();
 
     if (done_with_order) {
-      tmpl::for_each<detail::vars_to_save<system>>([&box](auto tag) noexcept {
+      tmpl::for_each<detail::vars_to_save<System>>([&box](auto tag) noexcept {
         using Tag = tmpl::type_from<decltype(tag)>;
         db::mutate<Tag>(
             make_not_null(&box),
@@ -466,7 +465,7 @@ using self_start_procedure = tmpl::flatten<tmpl::list<
 // clang-format off
     SelfStart::Actions::Initialize<System>,
     ::Actions::Label<detail::PhaseStart>,
-    SelfStart::Actions::CheckForCompletion<detail::PhaseEnd>,
+    SelfStart::Actions::CheckForCompletion<detail::PhaseEnd, System>,
     ::Actions::AdvanceTime,
     SelfStart::Actions::CheckForOrderIncrease,
     StepActions,

--- a/src/Time/Actions/SelfStartActions.hpp
+++ b/src/Time/Actions/SelfStartActions.hpp
@@ -113,18 +113,24 @@ namespace Actions {
 namespace detail {
 template <typename System, bool HasPrimitives>
 struct vars_to_save_impl {
-  using type = tmpl::list<typename System::variables_tag>;
+  using type = tmpl::flatten<tmpl::list<typename System::variables_tag>>;
 };
 
 template <typename System>
 struct vars_to_save_impl<System, true> {
-  using type = tmpl::list<typename System::variables_tag,
-                          typename System::primitive_variables_tag>;
+  using type =
+      tmpl::flatten<tmpl::list<typename System::variables_tag,
+                               typename System::primitive_variables_tag>>;
 };
 
 template <typename System>
 using vars_to_save = typename vars_to_save_impl<
     System, System::has_primitive_and_conservative_vars>::type;
+
+template <typename TagList>
+using get_all_history_tags =
+    tmpl::filter<TagList,
+                 tt::is_a_lambda<::Tags::HistoryEvolvedVariables, tmpl::_1>>;
 }  // namespace detail
 
 /// \ingroup ActionsGroup
@@ -322,20 +328,19 @@ struct CheckForOrderIncrease {
       const ParallelComponent* const /*meta*/) noexcept {  // NOLINT const
     const auto& time = db::get<::Tags::SubstepTime>(box);
     const auto& time_step = db::get<::Tags::TimeStep>(box);
-    const auto& history = db::get<::Tags::HistoryEvolvedVariables<>>(box);
+    using history_tags = detail::get_all_history_tags<DbTags>;
+    const size_t history_integration_order =
+        db::get<tmpl::front<history_tags>>(box).integration_order();
 
     const Time required_time =
         (time_step.is_positive() ? time.slab().start() : time.slab().end()) +
-        history.integration_order() * time_step;
+        history_integration_order * time_step;
     const bool done_with_order = time == required_time;
 
     if (done_with_order) {
-      db::mutate<::Tags::Next<::Tags::TimeStepId>,
-                 ::Tags::HistoryEvolvedVariables<>>(
+      db::mutate<::Tags::Next<::Tags::TimeStepId>>(
           make_not_null(&box),
           [](const gsl::not_null<::TimeStepId*> next_time_id,
-             const gsl::not_null<std::decay_t<decltype(history)>*>
-                 mutable_history,
              const ::TimeStepId& current_time_id) noexcept {
             const Slab slab = current_time_id.step_time().slab();
             *next_time_id =
@@ -343,12 +348,27 @@ struct CheckForOrderIncrease {
                            current_time_id.slab_number() + 1,
                            current_time_id.time_runs_forward() ? slab.start()
                                                                : slab.end());
-            mutable_history->integration_order(
-                mutable_history->integration_order() + 1);
           },
           db::get<::Tags::TimeStepId>(box));
+      tmpl::for_each<history_tags>([&box, &history_integration_order](
+                                       auto tag_v) noexcept {
+        using history_tag = typename decltype(tag_v)::type;
+        db::mutate<history_tag>(
+            make_not_null(&box),
+            [&history_integration_order](
+                const gsl::not_null<typename history_tag::type*>
+                    mutable_history) noexcept {
+              ASSERT(mutable_history->integration_order() ==
+                         history_integration_order,
+                     "Using multiple histories of different integration "
+                     "orders. When using multiple histories sharing the same "
+                     "time stepper, all histories must maintain identical "
+                     "integration order.");
+              mutable_history->integration_order(
+                  mutable_history->integration_order() + 1);
+            });
+      });
     }
-
     return {std::move(box)};
   }
 };
@@ -411,16 +431,18 @@ struct Cleanup {
             *tag_value = std::decay_t<decltype(*tag_value)>{};
           });
         });
-    ASSERT(
-        db::get<::Tags::HistoryEvolvedVariables<>>(box).integration_order() ==
-            db::get<::Tags::TimeStepper<>>(box).order(),
-        "Volume history order is: "
-            << db::get<::Tags::HistoryEvolvedVariables<>>(box)
-                   .integration_order()
-            << " but time stepper requires order: "
-            << db::get<::Tags::TimeStepper<>>(box).order()
-            << ". This may indicate that the step size has varied during "
-               "self-start, which should not be permitted.");
+    using history_tags = detail::get_all_history_tags<DbTags>;
+    tmpl::for_each<history_tags>([&box](auto tag_v) noexcept {
+      using tag = typename decltype(tag_v)::type;
+      ASSERT(db::get<tag>(box).integration_order() ==
+                 db::get<::Tags::TimeStepper<>>(box).order(),
+             "Volume history order is: "
+                 << db::get<tag>(box).integration_order()
+                 << " but time stepper requires order: "
+                 << db::get<::Tags::TimeStepper<>>(box).order()
+                 << ". This may indicate that the step size has varied during "
+                    "self-start, which should not be permitted.");
+    });
     return std::make_tuple(std::move(box));
   }
 };

--- a/src/Utilities/TypeTraits/IsA.hpp
+++ b/src/Utilities/TypeTraits/IsA.hpp
@@ -55,16 +55,16 @@ using is_a_t = typename is_a<U, Args...>::type;
 /// @}
 
 namespace detail {
-template <template <typename> class U>
+template <template <typename...> class U>
 struct is_a_wrapper;
 
 template <typename U, typename T>
 struct wrapped_is_a;
 
-template <template <typename> class U, typename T>
+template <template <typename...> class U, typename T>
 struct wrapped_is_a<is_a_wrapper<U>, T> : tt::is_a<U, T> {};
 }  // namespace detail
 
-template <template <typename> class U, typename T>
+template <template <typename...> class U, typename T>
 using is_a_lambda = detail::wrapped_is_a<detail::is_a_wrapper<U>, T>;
 }  // namespace tt

--- a/tests/InputFiles/Cce/AnalyticTestRobinsonTrautman.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestRobinsonTrautman.yaml
@@ -4,6 +4,8 @@
 # Executable: AnalyticTestCharacteristicExtract
 # Check: parse;execute_check_output
 # Timeout: 8
+# ExpectedOutput:
+#   CharacteristicExtractVolume0.h5
 # OutputFileChecks:
 #   - Label: "check_news"
 #     Subfile: "/News_Noninertial.dat"
@@ -21,12 +23,12 @@ Observers:
   ReductionFileName: "CharacteristicExtractUnusedReduction"
 
 Cce:
-  LMax: 12
-  NumberOfRadialPoints: 12
+  LMax: 10
+  NumberOfRadialPoints: 8
   ObservationLMax: 8
 
   StartTime: 0.0
-  EndTime: 0.6
+  EndTime: 0.5
   TargetStepSize: 0.1
   ExtractionRadius: 40.0
 
@@ -42,14 +44,14 @@ Cce:
         # l = 2
         - [0.01, 0.005]
       ExtractionRadius: 40.0
-      LMax: 12
+      LMax: 10
       Tolerance: 1e-10
       StartTime: 0.0
 
   Filtering:
     RadialFilterHalfPower: 24
     RadialFilterAlpha: 35.0
-    FilterLMax: 10
+    FilterLMax: 8
 
-  ScriInterpOrder: 5
+  ScriInterpOrder: 4
   ScriOutputDensity: 1

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
@@ -28,6 +28,7 @@
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
 #include "NumericalAlgorithms/Spectral/SwshTags.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Time/Actions/AdvanceTime.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/DormandPrince5.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
@@ -72,6 +73,9 @@ struct mock_characteristic_evolution {
       Actions::InitializeCharacteristicEvolutionTime<
           typename Metavariables::evolved_coordinates_variables_tag,
           typename Metavariables::evolved_swsh_tag>,
+      // advance the time so that the current `TimeStepId` is valid without
+      // having to perform self-start.
+      ::Actions::AdvanceTime,
       Actions::InitializeCharacteristicEvolutionScri<
           typename Metavariables::scri_values_to_observe,
           typename Metavariables::cce_boundary_component>,
@@ -188,7 +192,7 @@ SPECTRE_TEST_CASE(
       &runner, 0, serialize_and_deserialize(analytic_manager));
 
   // Run the initializations
-  for (size_t i = 0; i < 5; ++i) {
+  for (size_t i = 0; i < 6; ++i) {
     ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);
   }
   for (size_t i = 0; i < 3; ++i) {

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
@@ -170,8 +170,9 @@ SPECTRE_TEST_CASE(
   ActionTesting::MockRuntimeSystem<test_metavariables> runner{
       tuples::tagged_tuple_from_typelist<
           Parallel::get_const_global_cache_tags<test_metavariables>>{
-          l_max, end_time, start_time, number_of_radial_points,
-          std::make_unique<::TimeSteppers::DormandPrince5>()}};
+          l_max, end_time, start_time,
+          std::make_unique<::TimeSteppers::DormandPrince5>(),
+          number_of_radial_points}};
 
   const AnalyticBoundaryDataManager analytic_manager{
       l_max, extraction_radius,

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
@@ -38,6 +38,7 @@
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "Time/Actions/AdvanceTime.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/RungeKutta3.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
@@ -106,6 +107,9 @@ struct mock_characteristic_evolution {
       Actions::InitializeCharacteristicEvolutionTime<
           typename Metavariables::evolved_coordinates_variables_tag,
           typename Metavariables::evolved_swsh_tag>,
+      // advance the time so that the current `TimeStepId` is valid without
+      // having to perform self-start.
+      ::Actions::AdvanceTime,
       Initialization::Actions::RemoveOptionsAndTerminatePhase>;
   using initialization_tags =
       Parallel::get_initialization_tags<initialize_action_list>;
@@ -241,7 +245,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.H5BoundaryCommunication",
           false, false, std::optional<double>{}));
 
   // this should run the initializations
-  for (size_t i = 0; i < 4; ++i) {
+  for (size_t i = 0; i < 5; ++i) {
     ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);
   }
   for (size_t i = 0; i < 2; ++i) {

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
@@ -30,6 +30,7 @@
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "Time/Actions/AdvanceTime.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/RungeKutta3.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
@@ -52,6 +53,9 @@ struct mock_characteristic_evolution {
       Actions::InitializeCharacteristicEvolutionTime<
           typename Metavariables::evolved_coordinates_variables_tag,
           typename Metavariables::evolved_swsh_tag>,
+      // advance the time so that the current `TimeStepId` is valid without
+      // having to perform self-start.
+      ::Actions::AdvanceTime,
       Actions::InitializeCharacteristicEvolutionScri<
           typename Metavariables::scri_values_to_observe, NoSuchType>,
       Initialization::Actions::RemoveOptionsAndTerminatePhase>;
@@ -170,7 +174,7 @@ SPECTRE_TEST_CASE(
                                               scri_plus_interpolation_order);
 
   // this should run the initialization
-  for(size_t i = 0; i < 5; ++i) {
+  for (size_t i = 0; i < 6; ++i) {
     ActionTesting::next_action<component>(make_not_null(&runner), 0);
   }
   ActionTesting::set_phase(make_not_null(&runner),

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeFirstHypersurface.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeFirstHypersurface.cpp
@@ -116,7 +116,7 @@ SPECTRE_TEST_CASE(
   Variables<swsh_volume_tags_to_compute> swsh_volume_variables{
       Spectral::Swsh::number_of_swsh_collocation_points(l_max) *
       number_of_radial_points};
-  TimeStepId time_step_id{true, 0, Time{Slab{1.0, 2.0}, {1, 2}}};
+  TimeStepId time_step_id{true, 0, Time{Slab{1.0, 2.0}, {0, 1}}};
 
   tmpl::for_each<swsh_boundary_tags_to_generate>([&swsh_variables, &gen,
                                                   &coefficient_distribution,
@@ -165,7 +165,7 @@ SPECTRE_TEST_CASE(
       Tags::GaugeC, Tags::GaugeD, Tags::CauchyAngularCoords,
       Tags::CauchyCartesianCoords>>(make_not_null(&expected_box));
   db::mutate_apply<InitializeScriPlusValue<Tags::InertialRetardedTime>>(
-      make_not_null(&expected_box), 1.5);
+      make_not_null(&expected_box), 1.0);
 
   tmpl::for_each<
       tmpl::append<real_boundary_tags_to_compute, swsh_boundary_tags_to_compute,

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
@@ -174,6 +174,8 @@ void test_gh_initialization() noexcept {
   ActionTesting::emplace_component<component>(
       &runner, 0,
       Tags::GhInterfaceManager::create_from_options(
+          std::make_unique<InterfaceManagers::GhLockstep>()),
+      Tags::GhInterfaceManager::create_from_options(
           std::make_unique<InterfaceManagers::GhLockstep>()));
 
   // this should run the initialization

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
@@ -143,6 +143,9 @@ struct MockCharacteristicEvolution {
       Actions::InitializeCharacteristicEvolutionTime<
           typename Metavariables::evolved_coordinates_variables_tag,
           typename Metavariables::evolved_swsh_tag>,
+      // advance the time so that the current `TimeStepId` is valid without
+      // having to perform self-start.
+      ::Actions::AdvanceTime,
       Actions::InitializeCharacteristicEvolutionScri<
           typename Metavariables::scri_values_to_observe,
           typename Metavariables::cce_boundary_component>,
@@ -273,7 +276,7 @@ SPECTRE_TEST_CASE(
   ActionTesting::emplace_component<MockObserver<test_metavariables>>(&runner,
                                                                       0);
   // the initialization actions
-  for (size_t i = 0; i < 5; ++i) {
+  for (size_t i = 0; i < 6; ++i) {
     ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);
   }
   runner.set_phase(test_metavariables::Phase::Evolve);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
@@ -26,6 +26,7 @@
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "Time/Actions/AdvanceTime.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/RungeKutta3.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
@@ -69,6 +70,9 @@ struct mock_characteristic_evolution {
       Actions::InitializeCharacteristicEvolutionTime<
           typename Metavariables::evolved_coordinates_variables_tag,
           typename Metavariables::evolved_swsh_tag>,
+      // advance the time so that the current `TimeStepId` is valid without
+      // having to perform self-start.
+      ::Actions::AdvanceTime,
       Initialization::Actions::RemoveOptionsAndTerminatePhase>;
   using initialization_tags =
       Parallel::get_initialization_tags<initialize_action_list>;
@@ -200,7 +204,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.RequestBoundaryData",
           false, false, std::optional<double>{}));
 
   // this should run the initializations
-  for (size_t i = 0; i < 4; ++i) {
+  for (size_t i = 0; i < 5; ++i) {
     ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);
   }
   for(size_t i = 0; i < 3; ++i) {


### PR DESCRIPTION
## Proposed changes

Previously, CCE did not participate in self-start. We seem to have 'gotten away' with it in cases of multistep methods on the rare standalone run that used it, but it's definitely not the right way to do things.
This makes a few tweaks to the self start procedure necessary to support CCE, and includes the self start procedure in the CCE actions.

### Upgrade instructions

<!-- UPGRADE INSTRUCTIONS -->
Any changes to the CCE initialization procedure involving the time step will likely need to be rethought in light of these changes.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.
