### PR TITLE
Change stride argument type from `float` to `int` in InterpolateVolumeData

### DIFF
--- a/src/Visualization/Python/InterpolateVolumeData.py
+++ b/src/Visualization/Python/InterpolateVolumeData.py
@@ -264,7 +264,7 @@ def parse_args(sys_args):
 
     parser.add_argument(
         "--stride",
-        type=float,
+        type=int,
         default=1,
         help=("Stride through observations with this step size."))
 


### PR DESCRIPTION
currently throws when using stride argument from command line

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
