### PR TITLE
Add FixedSpeedCubic to BinaryCompactObject

### DIFF
--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -448,29 +448,42 @@ class BinaryCompactObject : public DomainCreator<3> {
     using group = ExpansionMap;
     static std::string name() noexcept { return "OuterBoundary"; }
   };
-  /// \brief The initial values of the expansion factors.
+  /// \brief The initial value of the expansion factor.
   struct InitialExpansion {
-    using type = std::array<double, 2>;
+    using type = double;
     static constexpr Options::String help = {
-        "Expansion values at initial time."};
+        "Expansion value at initial time."};
     using group = ExpansionMap;
   };
-  /// \brief The velocity of the expansion factors.
+  /// \brief The velocity of the expansion factor.
   struct InitialExpansionVelocity {
-    using type = std::array<double, 2>;
+    using type = double;
     static constexpr Options::String help = {"The rate of expansion."};
     using group = ExpansionMap;
   };
-  /// \brief The names of the functions of times to be added to the DataBox for
+  /// \brief The asymptotic radial velocity of the outer boundary.
+  struct AsymptoticVelocityOuterBoundary {
+    using type = double;
+    static constexpr Options::String help = {
+        "The asymptotic velocity of the outer boundary."};
+    using group = ExpansionMap;
+  };
+  /// \brief The timescale for how fast the outer boundary velocity approaches
+  /// its asymptotic value.
+  struct DecayTimescaleOuterBoundaryVelocity {
+    using type = double;
+    static constexpr Options::String help = {
+        "The timescale for how fast the outer boundary velocity approaches its "
+        "asymptotic value."};
+    using group = ExpansionMap;
+  };
+  /// \brief The name of the function of time to be added to the DataBox for
   /// the expansion map.
-  ///
-  /// If the two names are same then a linear radial scaling is used instead of
-  /// a cubic scaling.
-  struct ExpansionFunctionOfTimeNames {
-    using type = std::array<std::string, 2>;
+  struct ExpansionFunctionOfTimeName {
+    using type = std::string;
     static constexpr Options::String help = {"Names of the functions of time."};
     using group = ExpansionMap;
-    static std::string name() noexcept { return "FunctionOfTimeNames"; }
+    static std::string name() noexcept { return "FunctionOfTimeName"; }
   };
 
   struct RotationAboutZAxisMap {
@@ -582,11 +595,12 @@ class BinaryCompactObject : public DomainCreator<3> {
   using time_dependent_options =
       tmpl::list<InitialTime, InitialExpirationDeltaT,
                  ExpansionMapOuterBoundary, InitialExpansion,
-                 InitialExpansionVelocity, ExpansionFunctionOfTimeNames,
-                 InitialRotationAngle, InitialAngularVelocity,
-                 RotationAboutZAxisFunctionOfTimeName, InitialSizeMapValues,
-                 InitialSizeMapVelocities, InitialSizeMapAccelerations,
-                 SizeMapFunctionOfTimeNames>;
+                 InitialExpansionVelocity, ExpansionFunctionOfTimeName,
+                 AsymptoticVelocityOuterBoundary,
+                 DecayTimescaleOuterBoundaryVelocity, InitialRotationAngle,
+                 InitialAngularVelocity, RotationAboutZAxisFunctionOfTimeName,
+                 InitialSizeMapValues, InitialSizeMapVelocities,
+                 InitialSizeMapAccelerations, SizeMapFunctionOfTimeNames>;
 
   template <typename Metavariables>
   using options = tmpl::conditional_t<
@@ -650,10 +664,11 @@ class BinaryCompactObject : public DomainCreator<3> {
   // with parameters corresponding to the additional options
   BinaryCompactObject(
       double initial_time, std::optional<double> initial_expiration_delta_t,
-      double expansion_map_outer_boundary,
-      std::array<double, 2> initial_expansion,
-      std::array<double, 2> initial_expansion_velocity,
-      std::array<std::string, 2> expansion_function_of_time_names,
+      double expansion_map_outer_boundary, double initial_expansion,
+      double initial_expansion_velocity,
+      std::string expansion_function_of_time_name,
+      double asymptotic_velocity_outer_boundary,
+      double decay_timescale_outer_boundary_velocity,
       double initial_rotation_angle, double initial_angular_velocity,
       std::string rotation_about_z_axis_function_of_time_name,
       std::array<double, 2> initial_size_map_values,
@@ -715,9 +730,11 @@ class BinaryCompactObject : public DomainCreator<3> {
   double initial_time_;
   std::optional<double> initial_expiration_delta_t_;
   double expansion_map_outer_boundary_;
-  std::array<double, 2> initial_expansion_;
-  std::array<double, 2> initial_expansion_velocity_;
-  std::array<std::string, 2> expansion_function_of_time_names_;
+  double initial_expansion_;
+  double initial_expansion_velocity_;
+  std::string expansion_function_of_time_name_;
+  double asymptotic_velocity_outer_boundary_;
+  double decay_timescale_outer_boundary_velocity_;
   double initial_rotation_angle_;
   double initial_angular_velocity_;
   std::string rotation_about_z_axis_function_of_time_name_;

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -40,9 +40,11 @@ DomainCreator:
       InitialExpirationDeltaT: Auto
       ExpansionMap:
         OuterBoundary: 590.0
-        InitialExpansion: [1.0, 1.0]
-        InitialExpansionVelocity: [0.01, 0.02]
-        FunctionOfTimeNames: ['ExpansionFactor',  'Unity']
+        InitialExpansion: 1.0
+        InitialExpansionVelocity: 0.01
+        FunctionOfTimeName: 'ExpansionFactor'
+        AsymptoticVelocityOuterBoundary: -0.1
+        DecayTimescaleOuterBoundaryVelocity: 5.0
       RotationAboutZAxisMap:
         InitialRotationAngle: 0.0
         InitialAngularVelocity: 0.0

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -24,6 +24,7 @@
 #include "Domain/Creators/BinaryCompactObject.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Domain.hpp"
+#include "Domain/FunctionsOfTime/FixedSpeedCubic.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Domain/OptionTags.hpp"
 #include "Domain/Protocols/Metavariables.hpp"
@@ -357,10 +358,11 @@ std::string create_option_string(const bool excise_A, const bool excise_B,
                             "    InitialExpirationDeltaT: 9.0\n"
                             "    ExpansionMap: \n"
                             "      OuterBoundary: 25.0\n"
-                            "      InitialExpansion: [1.0, 1.0]\n"
-                            "      InitialExpansionVelocity: [-0.1, -0.1]\n"
-                            "      FunctionOfTimeNames: ['ExpansionFactor', "
-                            "'ExpansionFactor']\n"
+                            "      InitialExpansion: 1.0\n"
+                            "      InitialExpansionVelocity: -0.1\n"
+                            "      FunctionOfTimeName: 'ExpansionFactor'\n"
+                            "      AsymptoticVelocityOuterBoundary: -0.1\n"
+                            "      DecayTimescaleOuterBoundaryVelocity: 5.0\n"
                             "    RotationAboutZAxisMap:\n"
                             "      InitialRotationAngle: 2.0\n"
                             "      InitialAngularVelocity: -0.2\n"
@@ -454,6 +456,12 @@ void test_bbh_time_dependent_factory(const bool with_boundary_conditions) {
   constexpr double expected_time = 1.0; // matches InitialTime: 1.0 above
   constexpr double expected_update_delta_t =
       9.0;  // matches InitialExpirationDeltaT: 9.0 above
+  constexpr double expected_initial_function_value =
+      1.0;  // hard-coded in BinaryCompactObject.cpp
+  constexpr double expected_asymptotic_velocity_outer_boundary =
+      -0.1;  // matches AsymptoticVelocityOuterBoundary: -0.1 above
+  constexpr double expected_decay_timescale_outer_boundary_velocity =
+      5.0;  // matches DecayTimescaleOuterBoundaryVelocity: 5.0 above
   std::array<DataVector, 3> expansion_factor_coefs{{{1.0}, {-0.1}, {0.0}}};
   std::array<DataVector, 4> rotation_angle_coefs{{{2.0}, {-0.2}, {0.0}, {0.0}}};
   std::array<DataVector, 4> lambda_factor_a0_coefs{
@@ -465,6 +473,7 @@ void test_bbh_time_dependent_factory(const bool with_boundary_conditions) {
       std::pair<std::string, domain::FunctionsOfTime::PiecewisePolynomial<3>>,
       std::pair<std::string, domain::FunctionsOfTime::PiecewisePolynomial<3>>,
       std::pair<std::string, domain::FunctionsOfTime::PiecewisePolynomial<2>>,
+      std::pair<std::string, domain::FunctionsOfTime::FixedSpeedCubic>,
       std::pair<std::string, domain::FunctionsOfTime::PiecewisePolynomial<3>>>
       expected_functions_of_time = std::make_tuple(
           std::pair<std::string,
@@ -482,6 +491,11 @@ void test_bbh_time_dependent_factory(const bool with_boundary_conditions) {
               "ExpansionFactor"s,
               {expected_time, expansion_factor_coefs,
                expected_time + expected_update_delta_t}},
+          std::pair<std::string, domain::FunctionsOfTime::FixedSpeedCubic>{
+              "ExpansionFactorOuterBoundary"s,
+              {expected_initial_function_value, expected_time,
+               expected_asymptotic_velocity_outer_boundary,
+               expected_decay_timescale_outer_boundary_velocity}},
           std::pair<std::string,
                     domain::FunctionsOfTime::PiecewisePolynomial<3>>{
               "RotationAngle"s,
@@ -493,6 +507,11 @@ void test_bbh_time_dependent_factory(const bool with_boundary_conditions) {
   functions_of_time["ExpansionFactor"] =
       std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
           initial_time, expansion_factor_coefs, expiration_time);
+  functions_of_time["ExpansionFactorOuterBoundary"] =
+      std::make_unique<domain::FunctionsOfTime::FixedSpeedCubic>(
+          expected_initial_function_value, initial_time,
+          expected_asymptotic_velocity_outer_boundary,
+          expected_decay_timescale_outer_boundary_velocity);
   functions_of_time["RotationAngle"] =
       std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<3>>(
           initial_time, rotation_angle_coefs, expiration_time);


### PR DESCRIPTION
## Proposed changes

Hard-codes one of the FixedSpeedCubic FunctionOfTimes in the BinaryCompactObject domain to a FixedSpeedCubic FunctionOfTime, instead of hard-coding two FunctionOfTimes for CubicScale. This is typically used to move the outer boundary radially inward at a small, constant velocity, to avoid buildup of constraint violation on the outer boundary.

### Upgrade instructions

<!-- UPGRADE INSTRUCTIONS -->

When time dependence is enabled in the BinaryCompactObject domain, previously, the options for the ExpansionFactor included options to specify the two FunctionOfTimes used by the CubicScale map, e.g.

~~~yaml
ExpansionMap:
  OuterBoundary: 25.0
  InitialExpansion: [1.0, 1.0]
  InitialExpansionVelocity: [-0.1, -0.01]
  FunctionOfTimeNames: ['ExpansionFactor', 'ExpansionFactorOuterBdry']
~~~

After this PR, instead specify one FunctionOfTime and the desired asymptotic velocity (and timescale for approaching that velocity) for the outer boundary, e.g.

~~~yaml
ExpansionMap:
  OuterBoundary: 25.0
  InitialExpansion: 1.0
  InitialExpansionVelocity: -0.1
  FunctionOfTimeName: 'ExpansionFactor'
  AsymptoticVelocityOuterBoundary: -1.0e-6
  DecayTimescaleOuterBoundaryVelocity: 50.0
~~~

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
