### PR TITLE
fix slicing `inverse_spatial_metric` onto boundary for systems with curved backgrounds

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/BoundaryConditionsImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/BoundaryConditionsImpl.hpp
@@ -196,12 +196,12 @@ void apply_boundary_condition_on_face(
                           db::wrap_tags_in<::Tags::Flux, flux_variables,
                                            tmpl::size_t<Dim>, Frame::Inertial>,
                           tmpl::list<>>;
-  using tags_on_interior_face = tmpl::append<
+  using tags_on_interior_face = tmpl::remove_duplicates<tmpl::append<
       fluxes_tags, interior_temp_tags, interior_prim_tags,
       interior_evolved_vars_tags, bcondition_interior_dt_evolved_vars_tags,
       bcondition_interior_deriv_evolved_vars_tags, inverse_spatial_metric_list,
       tmpl::list<detail::OneOverNormalVectorMagnitude,
-                 detail::NormalVector<Dim>>>;
+                 detail::NormalVector<Dim>>>>;
 
   Variables<tags_on_interior_face> interior_face_fields{
       number_of_points_on_face};


### PR DESCRIPTION

fixes #3306

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
