### PR TITLE
Fix exponential filter input file example dox

### DIFF
--- a/src/NumericalAlgorithms/LinearOperators/ExponentialFilter.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/ExponentialFilter.hpp
@@ -51,13 +51,7 @@ namespace Filters {
  * are desired for filtering different tensors, then multiple filters must be
  * inserted into the GlobalCache with different `FilterIndex` values. In
  * the input file these will be specified as `ExpFilterFILTER_INDEX`, e.g.
- * -  Filtering:
- * -    ExpFilter0:
- * -      Alpha: 12
- * -      HalfPower: 32
- * -    ExpFilter1:
- * -      Alpha: 36
- * -      HalfPower: 32
+ * \snippet LinearOperators/Test_Filtering.cpp multiple_exponential_filters
  */
 template <size_t FilterIndex>
 class Exponential {

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Filtering.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Filtering.cpp
@@ -219,11 +219,24 @@ void invoke_test_exponential_filter_action(
 template <size_t Dim>
 void test_exponential_filter_creation() noexcept {
   using Filter = Filters::Exponential<0>;
+  using AnotherFilter = Filters::Exponential<1>;
 
-  const auto filter = TestHelpers::test_creation<Filter>(
-      "Alpha: 36\n"
-      "HalfPower: 32\n"
-      "DisableForDebugging: False\n");
+  using tags =
+      tmpl::list<OptionTags::Filter<Filter>, OptionTags::Filter<AnotherFilter>>;
+  Options::Parser<tags> options("");
+  // [multiple_exponential_filters]
+  options.parse(
+      "Filtering:\n"
+      "  ExpFilter0:\n"
+      "    Alpha: 36\n"
+      "    HalfPower: 32\n"
+      "    DisableForDebugging: False\n"
+      "  ExpFilter1:\n"
+      "    Alpha: 36\n"
+      "    HalfPower: 12\n"
+      "    DisableForDebugging: False\n");
+  // [multiple_exponential_filters]
+  const auto filter = options.get<OptionTags::Filter<Filter>>();
 
   CHECK(filter == Filter{36.0, 32, false});
   CHECK_FALSE(filter == Filter{35.0, 32, false});


### PR DESCRIPTION
## Proposed changes

Previously the dox rendered the input file information as bullets, which is less readable than just a code block representing the text that would appear in the input yaml.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

