### PR TITLE
Add helper functions for boost quaternions

### DIFF
--- a/src/Domain/FunctionsOfTime/CMakeLists.txt
+++ b/src/Domain/FunctionsOfTime/CMakeLists.txt
@@ -23,6 +23,7 @@ spectre_target_headers(
   FunctionOfTime.hpp
   OptionTags.hpp
   PiecewisePolynomial.hpp
+  QuaternionHelpers.hpp
   ReadSpecPiecewisePolynomial.hpp
   RegisterDerivedWithCharm.hpp
   SettleToConstant.hpp

--- a/src/Domain/FunctionsOfTime/QuaternionHelpers.hpp
+++ b/src/Domain/FunctionsOfTime/QuaternionHelpers.hpp
@@ -1,0 +1,47 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines helper functions for converting between `DataVector`s and boost
+/// quaternions.
+
+#pragma once
+
+#include <boost/math/quaternion.hpp>
+
+#include "DataStructures/DataVector.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// Convert a `boost::math::quaternion` to a `DataVector`
+DataVector quaternion_to_datavector(
+    const boost::math::quaternion<double>& input) noexcept {
+  return DataVector{input.R_component_1(), input.R_component_2(),
+                    input.R_component_3(), input.R_component_4()};
+}
+
+/// \brief Convert a `DataVector` to a `boost::math::quaternion`
+///
+/// \details To convert to a quaternion, a `DataVector` must have either 3 or 4
+/// components. If it has 3 components, the quaternion will be constructed with
+/// 0 scalar part while the vector part is the `DataVector`. If the `DataVector`
+/// has 4 components, the quaternion is just the `DataVector` itself.
+boost::math::quaternion<double> datavector_to_quaternion(
+    const DataVector& input) noexcept {
+  ASSERT(input.size() == 3 or input.size() == 4,
+         "To form a quaternion, a DataVector can either have 3 or 4 components "
+         "only. This DataVector has "
+             << input.size() << " components.");
+  if (input.size() == 3) {
+    return boost::math::quaternion<double>(0.0, input[0], input[1], input[2]);
+  } else {
+    return boost::math::quaternion<double>(input[0], input[1], input[2],
+                                           input[3]);
+  }
+}
+/// Normalize a `boost::math::quaternion`
+template <typename T>
+void normalize_quaternion(
+    const gsl::not_null<boost::math::quaternion<T>*> input) noexcept {
+  *input /= abs(*input);
+}

--- a/tests/Unit/Domain/FunctionsOfTime/CMakeLists.txt
+++ b/tests/Unit/Domain/FunctionsOfTime/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_FunctionsOfTime")
 set(LIBRARY_SOURCES
   Test_FixedSpeedCubic.cpp
   Test_PiecewisePolynomial.cpp
+  Test_QuaternionHelpers.cpp
   Test_ReadSpecPiecewisePolynomial.cpp
   Test_SettleToConstant.cpp
   Test_Tags.cpp

--- a/tests/Unit/Domain/FunctionsOfTime/Test_QuaternionHelpers.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_QuaternionHelpers.cpp
@@ -1,0 +1,32 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <boost/math/quaternion.hpp>
+
+#include "DataStructures/DataVector.hpp"
+#include "Domain/FunctionsOfTime/QuaternionHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+
+SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.QuaternionHelpers",
+                  "[Unit][Domain]") {
+  using quaternion = boost::math::quaternion<double>;
+
+  quaternion quat1(1.0, 2.0, 3.0, -4.0);
+  DataVector dv{1.0, 2.0, 3.0, -4.0};
+  DataVector dv_short{9.9, 9.8, 9.7};
+
+  DataVector dv2 = quaternion_to_datavector(quat1);
+  CHECK(dv2 == dv);
+
+  quaternion quat2 = datavector_to_quaternion(dv2);
+  CHECK(quat2 == quat1);
+
+  quaternion quat3 = datavector_to_quaternion(dv_short);
+  CHECK(quat3 == quaternion{0.0, 9.9, 9.8, 9.7});
+
+  normalize_quaternion(make_not_null(&quat2));
+  CHECK(norm(quat2) == approx(1.0));
+  CHECK(abs(quat2) == approx(1.0));
+}


### PR DESCRIPTION
## Proposed changes
Adds a few helper functions for converting between boost quaternions and `std::array`s.

Also add a function that will make a quaternion a unit quaternion, because the boost quaternions don't have this built in.
<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
