### PR TITLE
Clarify DataBox error for cases with incorrect member functions

### DIFF
--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -1040,13 +1040,19 @@ CREATE_IS_CALLABLE_V(apply)
 
 template <typename Func, typename... Args>
 constexpr void error_function_not_callable() noexcept {
-  static_assert(std::is_same_v<Func, void>,
-                "The function is not callable with the expected arguments.  "
-                "See the first template parameter of "
-                "error_function_not_callable for the function type and "
-                "the remaining arguments for the parameters that cannot be "
-                "passed. If all the argument types match, it could be that you "
-                "have a template parameter that cannot be deduced.");
+  static_assert(
+      std::is_same_v<Func, void>,
+      "The function is not callable with the expected arguments.  "
+      "See the first template parameter of "
+      "error_function_not_callable for the function or object type and "
+      "the remaining arguments for the parameters that cannot be "
+      "passed. If all the argument types match, it could be that you "
+      "have a template parameter that cannot be deduced."
+      "Note that for most DataBox functions, you must pass either "
+      "a function pointer, a lambda, or a class with a call operator "
+      "or static apply function, and this error will also arise if "
+      "the provided entity does not satisfy that requirement (e.g. "
+      "if the provided class defines a function with the incorrect name).");
 }
 
 template <typename DataBoxTags, typename... TagsToRetrieve>


### PR DESCRIPTION
## Proposed changes

The current compiler error for `db::mutate_apply` and `db::apply` talks only about parameters, which is a possible failure mechanism, but if the user has simply defined the wrong function name (e.g. is trying to pass an object with a function name `function`), the error can seem misleading -- the user will likely check their arguments without realizing that the function name is malformed.

This updates the error with some clarifying text that will hopefully encourage users to more easily find mistakes in which they have defined a function of the wrong name.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.