### PR TITLE
Add the Apparent Horizon tags to EvolveGeneralizedHarmonicWithHorizon.hpp

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
@@ -72,7 +72,20 @@ struct EvolutionMetavars
                    gr::Tags::ExtrinsicCurvature<volume_dim, frame>,
                    gr::Tags::SpatialChristoffelSecondKind<volume_dim, frame>>;
     using compute_items_on_target = tmpl::append<
-        tmpl::list<StrahlkorperGr::Tags::AreaElementCompute<frame>>,
+        tmpl::list<StrahlkorperGr::Tags::AreaElementCompute<frame>,
+                   StrahlkorperTags::ThetaPhiCompute<frame>,
+                   StrahlkorperTags::RadiusCompute<frame>,
+                   StrahlkorperTags::RhatCompute<frame>,
+                   StrahlkorperTags::InvJacobianCompute<frame>,
+                   StrahlkorperTags::DxRadiusCompute<frame>,
+                   StrahlkorperTags::OneOverOneFormMagnitudeCompute<
+                       volume_dim, frame, DataVector>,
+                   StrahlkorperTags::NormalOneFormCompute<frame>,
+                   StrahlkorperTags::UnitNormalOneFormCompute<frame>,
+                   StrahlkorperTags::UnitNormalVectorCompute<frame>,
+                   StrahlkorperTags::GradUnitNormalOneFormCompute<frame>,
+                   StrahlkorperTags::ExtrinsicCurvatureCompute<frame>,
+                   StrahlkorperGr::Tags::SpinFunctionCompute<frame>>,
         tags_to_observe>;
     using compute_target_points =
         intrp::TargetPoints::ApparentHorizon<AhA, ::Frame::Inertial>;


### PR DESCRIPTION
## Proposed changes

Add the horizon compute tags to the EvolveGeneralizedHarmonicWithHorizon.hpp executable that will add the capability to calculate the black hole's mass and spin. 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
