### PR TITLE
Move stored deriv info to helper in PiecewisePolynomial

### DIFF
--- a/src/Domain/FunctionsOfTime/CMakeLists.txt
+++ b/src/Domain/FunctionsOfTime/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   FixedSpeedCubic.cpp
+  FunctionOfTimeHelpers.cpp
   PiecewisePolynomial.cpp
   ReadSpecPiecewisePolynomial.cpp
   RegisterDerivedWithCharm.cpp
@@ -21,6 +22,7 @@ spectre_target_headers(
   HEADERS
   FixedSpeedCubic.hpp
   FunctionOfTime.hpp
+  FunctionOfTimeHelpers.hpp
   OptionTags.hpp
   PiecewisePolynomial.hpp
   QuaternionHelpers.hpp

--- a/src/Domain/FunctionsOfTime/FunctionOfTimeHelpers.cpp
+++ b/src/Domain/FunctionsOfTime/FunctionOfTimeHelpers.cpp
@@ -1,0 +1,142 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/FunctionsOfTime/FunctionOfTimeHelpers.hpp"
+
+#include <pup.h>
+#include <pup_stl.h>
+
+#include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace domain::FunctionsOfTime::FunctionOfTimeHelpers {
+template <size_t MaxDerivPlusOne, bool StoreCoefs>
+StoredInfo<MaxDerivPlusOne, StoreCoefs>::StoredInfo(
+    const double t,
+    std::array<DataVector, MaxDerivPlusOne> init_quantities) noexcept
+    : time(t), stored_quantities{std::move(init_quantities)} {
+  // Convert derivs to coefficients for polynomial evaluation
+  // The coefficient of x^N is the Nth deriv rescaled by 1/factorial(N)
+  double fact = 1.0;
+  if (MaxDerivPlusOne > 2) {
+    for (size_t j = 2; j < MaxDerivPlusOne; j++) {
+      fact *= j;
+      gsl::at(stored_quantities, j) /= fact;
+    }
+  }
+}
+
+template <size_t MaxDerivPlusOne>
+StoredInfo<MaxDerivPlusOne, false>::StoredInfo(
+    const double t,
+    std::array<DataVector, MaxDerivPlusOne> init_quantities) noexcept
+    : time(t), stored_quantities{std::move(init_quantities)} {}
+
+template <size_t MaxDerivPlusOne, bool StoreCoefs>
+void StoredInfo<MaxDerivPlusOne, StoreCoefs>::pup(PUP::er& p) noexcept {
+  p | time;
+  p | stored_quantities;
+}
+
+template <size_t MaxDerivPlusOne>
+void StoredInfo<MaxDerivPlusOne, false>::pup(PUP::er& p) noexcept {
+  p | time;
+  p | stored_quantities;
+}
+
+void reset_expiration_time(const gsl::not_null<double*> prev_expiration_time,
+                           const double next_expiration_time) noexcept {
+  if (next_expiration_time < *prev_expiration_time) {
+    ERROR("Attempted to change expiration time to "
+          << next_expiration_time
+          << ", which precedes the previous expiration time of "
+          << *prev_expiration_time << ".");
+  }
+  *prev_expiration_time = next_expiration_time;
+}
+
+template <size_t MaxDerivPlusOne, bool StoreCoefs>
+const StoredInfo<MaxDerivPlusOne, StoreCoefs>& stored_info_from_upper_bound(
+    const double t, const std::vector<StoredInfo<MaxDerivPlusOne, StoreCoefs>>&
+                        all_stored_infos) noexcept {
+  // this function assumes that the times in stored_info_at_update_times is
+  // sorted, which is enforced by the update function of a piecewise polynomial.
+
+  ASSERT(not all_stored_infos.empty(),
+         "Vector of StoredInfos you are trying to access is empty. Was it "
+         "constructed properly?");
+
+  const auto upper_bound_stored_info = std::upper_bound(
+      all_stored_infos.begin(), all_stored_infos.end(), t,
+      [](double t0, const StoredInfo<MaxDerivPlusOne, StoreCoefs>& d) {
+        return d.time > t0;
+      });
+
+  if (upper_bound_stored_info == all_stored_infos.begin()) {
+    // all elements of times are greater than t
+    // check if t is just less than the min element by roundoff
+    if (not equal_within_roundoff(upper_bound_stored_info->time, t)) {
+      ERROR("requested time " << t << " precedes earliest time "
+                              << all_stored_infos.begin()->time
+                              << " of times.");
+    }
+    return *upper_bound_stored_info;
+  }
+  // t is either greater than all elements of times
+  // or t is within the range of times.
+  // In both cases, 'upper_bound_deriv_info' currently points to one index past
+  // the desired index.
+  return *std::prev(upper_bound_stored_info, 1);
+}
+
+template <size_t MaxDerivPlusOne, bool StoreCoefs>
+bool operator==(
+    const domain::FunctionsOfTime::FunctionOfTimeHelpers::StoredInfo<
+        MaxDerivPlusOne, StoreCoefs>& lhs,
+    const domain::FunctionsOfTime::FunctionOfTimeHelpers::StoredInfo<
+        MaxDerivPlusOne, StoreCoefs>& rhs) noexcept {
+  return lhs.time == rhs.time and
+         lhs.stored_quantities == rhs.stored_quantities;
+}
+
+template <size_t MaxDerivPlusOne, bool StoreCoefs>
+bool operator!=(
+    const domain::FunctionsOfTime::FunctionOfTimeHelpers::StoredInfo<
+        MaxDerivPlusOne, StoreCoefs>& lhs,
+    const domain::FunctionsOfTime::FunctionOfTimeHelpers::StoredInfo<
+        MaxDerivPlusOne, StoreCoefs>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+// explicit instantiation of StoredInfo class and stored_info_from_upper_bound
+// function for MaxDerivPlusOne = {1,2,3,4,5}
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define STORECOEF(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                                   \
+  template class StoredInfo<DIM(data), STORECOEF(data)>;       \
+  template bool operator==<DIM(data), STORECOEF(data)>(        \
+      const StoredInfo<DIM(data), STORECOEF(data)>&,           \
+      const StoredInfo<DIM(data), STORECOEF(data)>&) noexcept; \
+  template bool operator!=<DIM(data), STORECOEF(data)>(        \
+      const StoredInfo<DIM(data), STORECOEF(data)>&,           \
+      const StoredInfo<DIM(data), STORECOEF(data)>&) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3, 4, 5), (true, false))
+
+#undef INSTANTIATE
+
+#define INSTANTIATE(_, data)                             \
+  template const StoredInfo<DIM(data), STORECOEF(data)>& \
+  stored_info_from_upper_bound(                          \
+      const double,                                      \
+      const std::vector<StoredInfo<DIM(data), STORECOEF(data)>>&) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3, 4, 5), (true, false))
+
+#undef INSTANTIATE
+#undef STORECOEF
+#undef DIM
+}  // namespace domain::FunctionsOfTime::FunctionOfTimeHelpers

--- a/src/Domain/FunctionsOfTime/FunctionOfTimeHelpers.hpp
+++ b/src/Domain/FunctionsOfTime/FunctionOfTimeHelpers.hpp
@@ -1,0 +1,85 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// \brief Helper struct and functions for FunctionsOfTime
+
+#pragma once
+
+#include <array>
+#include <limits>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace domain::FunctionsOfTime::FunctionOfTimeHelpers {
+/// \brief Stores info at a particlar time about a function and its derivatives
+///
+/// \details `MaxDerivPlusOne` template parameter is intended to be related to
+/// the maximum derivative that a FunctionOfTime is supposed to store. For a
+/// generic PiecewisePolynomial this will be the MaxDeriv + 1 (because we store
+/// the function as well as its derivatives).
+/// `StoreCoefs` template parameter indicates that the coefficients of the
+/// polynomial used for evaluation are stored instead of the polynomial itself.
+/// The coefficient of \f$ x^N \f$ is the Nth deriv rescaled by 1/factorial(N)
+template <size_t MaxDerivPlusOne, bool StoreCoefs = true>
+struct StoredInfo {
+  double time{std::numeric_limits<double>::signaling_NaN()};
+  std::array<DataVector, MaxDerivPlusOne> stored_quantities;
+
+  StoredInfo() = default;
+
+  StoredInfo(double t,
+             std::array<DataVector, MaxDerivPlusOne> init_quantities) noexcept;
+  ~StoredInfo() = default;
+  StoredInfo(StoredInfo&&) noexcept = default;
+  StoredInfo& operator=(StoredInfo&&) noexcept = default;
+  StoredInfo(const StoredInfo&) = default;
+  StoredInfo& operator=(const StoredInfo&) = default;
+
+  void pup(PUP::er& p) noexcept;
+};
+
+template <size_t MaxDerivPlusOne>
+struct StoredInfo<MaxDerivPlusOne, false> {
+  double time{std::numeric_limits<double>::signaling_NaN()};
+  std::array<DataVector, MaxDerivPlusOne> stored_quantities;
+
+  StoredInfo() = default;
+
+  StoredInfo(double t,
+             std::array<DataVector, MaxDerivPlusOne> init_quantities) noexcept;
+
+  void pup(PUP::er& p) noexcept;
+};
+
+/// Resets the previous expiration time if the next expiration time is after,
+/// otherwise throws an error
+void reset_expiration_time(const gsl::not_null<double*> prev_expiration_time,
+                           const double next_expiration_time) noexcept;
+
+/// Returns a StoredInfo corresponding to the closest element in the range of
+/// `StoredInfo.time`s that is less than or equal to `t`. The function throws an
+/// error if `t` is less than all `StoredInfo.time`s (unless `t` is just less
+/// than the earliest `StoredInfo.time` by roundoff, in which case it returns
+/// the earliest StoredInfo.)
+template <size_t MaxDerivPlusOne, bool StoreCoefs>
+const StoredInfo<MaxDerivPlusOne, StoreCoefs>& stored_info_from_upper_bound(
+    const double t, const std::vector<StoredInfo<MaxDerivPlusOne, StoreCoefs>>&
+                        all_stored_infos) noexcept;
+
+template <size_t MaxDerivPlusOne, bool StoreCoefs>
+bool operator==(
+    const domain::FunctionsOfTime::FunctionOfTimeHelpers::StoredInfo<
+        MaxDerivPlusOne, StoreCoefs>& lhs,
+    const domain::FunctionsOfTime::FunctionOfTimeHelpers::StoredInfo<
+        MaxDerivPlusOne, StoreCoefs>& rhs) noexcept;
+
+template <size_t MaxDerivPlusOne, bool StoreCoefs>
+bool operator!=(
+    const domain::FunctionsOfTime::FunctionOfTimeHelpers::StoredInfo<
+        MaxDerivPlusOne, StoreCoefs>& lhs,
+    const domain::FunctionsOfTime::FunctionOfTimeHelpers::StoredInfo<
+        MaxDerivPlusOne, StoreCoefs>& rhs) noexcept;
+}  // namespace domain::FunctionsOfTime::FunctionOfTimeHelpers

--- a/tests/Unit/Domain/FunctionsOfTime/CMakeLists.txt
+++ b/tests/Unit/Domain/FunctionsOfTime/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_FunctionsOfTime")
 
 set(LIBRARY_SOURCES
   Test_FixedSpeedCubic.cpp
+  Test_FunctionOfTimeHelpers.cpp
   Test_PiecewisePolynomial.cpp
   Test_QuaternionHelpers.cpp
   Test_ReadSpecPiecewisePolynomial.cpp

--- a/tests/Unit/Domain/FunctionsOfTime/Test_FunctionOfTimeHelpers.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_FunctionOfTimeHelpers.cpp
@@ -1,0 +1,139 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTimeHelpers.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace domain::FunctionsOfTime {
+SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.FunctionOfTimeHelpers",
+                  "[Domain][Unit]") {
+  INFO("StoredInfo Construction") {
+    // mdp1 = MaxDerivPlusOne
+    constexpr size_t mdp1 = 3;
+    constexpr double time = 5.4;
+    DataVector init_func{{1.1, 1.2, 1.3}};
+    DataVector init_deriv{{2.4, 2.5, 2.6}};
+    DataVector init_2deriv{{3.7, 3.8, 3.9}};
+    std::array<DataVector, mdp1> init_arr =
+        std::array<DataVector, mdp1>{{init_func, init_deriv, init_2deriv}};
+
+    FunctionOfTimeHelpers::StoredInfo<mdp1> si1{time, init_arr};
+    FunctionOfTimeHelpers::StoredInfo<mdp1, true> si2{time, init_arr};
+    CHECK(si1 == si2);
+    CHECK(si1.time == time);
+    CHECK(si2.time == time);
+    CHECK(gsl::at(si1.stored_quantities, 0) == init_func);
+    CHECK(gsl::at(si2.stored_quantities, 0) == init_func);
+    CHECK(gsl::at(si1.stored_quantities, 1) == init_deriv);
+    CHECK(gsl::at(si2.stored_quantities, 1) == init_deriv);
+    CHECK(gsl::at(si1.stored_quantities, 2) == init_2deriv / 2.0);
+    CHECK(gsl::at(si2.stored_quantities, 2) == init_2deriv / 2.0);
+
+    const auto si1_serialize_and_deserialize = serialize_and_deserialize(si1);
+    const auto si2_serialize_and_deserialize = serialize_and_deserialize(si2);
+    CHECK(si1_serialize_and_deserialize == si2_serialize_and_deserialize);
+
+    FunctionOfTimeHelpers::StoredInfo<mdp1, false> si3{time, init_arr};
+    CHECK(si3.time == time);
+    CHECK(gsl::at(si3.stored_quantities, 0) == init_func);
+    CHECK(gsl::at(si3.stored_quantities, 1) == init_deriv);
+    CHECK(gsl::at(si3.stored_quantities, 2) == init_2deriv);
+
+    const auto si3_serialize_and_deserialize = serialize_and_deserialize(si3);
+    CHECK(si3_serialize_and_deserialize.time == time);
+    CHECK(gsl::at(si3_serialize_and_deserialize.stored_quantities, 0) ==
+          init_func);
+    CHECK(gsl::at(si3_serialize_and_deserialize.stored_quantities, 1) ==
+          init_deriv);
+    CHECK(gsl::at(si3_serialize_and_deserialize.stored_quantities, 2) ==
+          init_2deriv);
+  }
+
+  INFO("StoredInfo From Upper Bound") {
+    constexpr size_t mdp1 = 1;
+    std::vector<FunctionOfTimeHelpers::StoredInfo<mdp1>> all_stored_info{
+        FunctionOfTimeHelpers::StoredInfo<mdp1>{
+            0.0, std::array<DataVector, mdp1>{DataVector{1, 0.0}}}};
+    for (int t = 1; t < 10; t++) {
+      all_stored_info.emplace_back(
+          static_cast<double>(t),
+          std::array<DataVector, mdp1>{DataVector{3, 0.0}});
+    }
+
+    const auto& upper_bound_stored_info1 =
+        FunctionOfTimeHelpers::stored_info_from_upper_bound(4.5,
+                                                            all_stored_info);
+    CHECK(upper_bound_stored_info1 == gsl::at(all_stored_info, 4));
+
+    const auto& upper_bound_stored_info2 =
+        FunctionOfTimeHelpers::stored_info_from_upper_bound(4.0,
+                                                            all_stored_info);
+    CHECK(upper_bound_stored_info2 == gsl::at(all_stored_info, 4));
+
+    const auto& upper_bound_stored_info3 =
+        FunctionOfTimeHelpers::stored_info_from_upper_bound(-1.e-15,
+                                                            all_stored_info);
+    CHECK(upper_bound_stored_info3 == gsl::at(all_stored_info, 0));
+
+    const auto& upper_bound_stored_info4 =
+        FunctionOfTimeHelpers::stored_info_from_upper_bound(10.5,
+                                                            all_stored_info);
+    CHECK(upper_bound_stored_info4 ==
+          gsl::at(all_stored_info, all_stored_info.size() - 1));
+  }
+}
+
+// [[OutputRegex, Attempted to change expiration time to
+// 3\.5, which precedes the previous expiration time of 4.]]
+SPECTRE_TEST_CASE(
+    "Unit.Domain.FunctionsOfTime.FunctionOfTimeHelpers.BadResetExpr",
+    "[Domain][Unit]") {
+  ERROR_TEST();
+  double expr_time = 4.0;
+  double next_expr_time = 3.5;
+  FunctionOfTimeHelpers::reset_expiration_time(make_not_null(&expr_time),
+                                               next_expr_time);
+}
+
+// [[OutputRegex, requested time -1 precedes earliest time 0 of times.]]
+SPECTRE_TEST_CASE(
+    "Unit.Domain.FunctionsOfTime.FunctionOfTimeHelpers.BadSIFromUpperBound",
+    "[Domain][Unit]") {
+  ERROR_TEST();
+  constexpr size_t mdp1 = 1;
+  std::vector<FunctionOfTimeHelpers::StoredInfo<mdp1>> all_stored_info{
+      FunctionOfTimeHelpers::StoredInfo<mdp1>{
+          0.0, std::array<DataVector, mdp1>{DataVector{1, 0.0}}}};
+  for (int t = 1; t < 10; t++) {
+    all_stored_info.emplace_back(
+        static_cast<double>(t),
+        std::array<DataVector, mdp1>{DataVector{1, 0.0}});
+  }
+
+  (void)FunctionOfTimeHelpers::stored_info_from_upper_bound(-1.0,
+                                                            all_stored_info);
+}
+
+// [[OutputRegex, Vector of StoredInfos you are trying to access is empty. Was
+// it constructed properly?]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Domain.FunctionsOfTime.FunctionOfTimeHelpers.BadEmptyVectorOfSI",
+    "[Domain][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  constexpr size_t mdp1 = 3;
+  std::vector<FunctionOfTimeHelpers::StoredInfo<mdp1>> all_stored_info;
+
+  (void)FunctionOfTimeHelpers::stored_info_from_upper_bound(1.0,
+                                                            all_stored_info);
+  ERROR("Failed to trigger ASSERT in assertion test.");
+#endif
+}
+}  // namespace domain::FunctionsOfTime


### PR DESCRIPTION
## Proposed changes
Move some functions inside PiecewisePolynomial to a helper file. This is in anticipation of adding a new Quaternion FunctionOfTime which will be similar to but slightly different that PiecewisePolynomial and will share several functions. The helpers can also be used for additional FunctionsOfTime in the future.
<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
