### PR TITLE
Installing Arpack in the containers

### DIFF
--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -46,7 +46,8 @@ RUN apt-get update -y \
                           lcov cppcheck \
                           libboost-dev libboost-program-options-dev \
                           libboost-thread-dev libboost-tools-dev libssl-dev \
-                          libbenchmark-dev
+                          libbenchmark-dev \
+                          libarpack2-dev
 
 # Install clang-11
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \

--- a/containers/Dockerfile.buildenv1804
+++ b/containers/Dockerfile.buildenv1804
@@ -56,7 +56,8 @@ RUN apt-get update -y \
                           lcov cppcheck \
                           libboost-dev libboost-program-options-dev \
                           libboost-thread-dev libboost-tools-dev libssl-dev \
-                          libbenchmark-dev
+                          libbenchmark-dev \
+                          libarpack2-dev
 
 # Add clang 8 and 9
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \


### PR DESCRIPTION
## Proposed changes

Installs Arpack in the containers

## Why we need Arpack

### Short version
Using Arpack makes the finding the spin of black hole with highly deformed horizons much faster.

### Slightly longer version
StrahlkorperGr needs to solve a generalized eigenvalue problem (M x =  \lambda B x) to find the spin of a Black Hole. Right now we are using Lapack's dggev to solve this but dggev has a very bad scaling O(L^6), where L is the highest degree spherical harmonic used to describe the horizon. The reason dggev is not ideal for us is because it finds all the eigenvectors of the system while we only need those corresponding to the three smallest eigenvalues.

In Arpack we can specify the eigenvectors that we want and it will solve only for those. Because the matrices that we are working with can get quite large (number of rows = L^2) there is a significant time difference in finding all the eigenvectors and finding just the three that we need.

Two most costly steps in finding the spin are generation of the matrices (M and B) and then solving the eigenvalue problem.

When L is around 80, dggev takes close to 30minutes to run and the matrix generation takes around 2mins. If we use Arpack then the time to find the three eigenvectors goes below 10seconds (majority of this is doing the LU decomposition required by Arpack) and the matrix generation still takes 2mins. Thus, we reduce the total time from 30mins to 2mins.

Note that this becomes relevant only when L goes beyond 60-70. Before that the generation of the matrices is the slowest step. Another advantage is that the matrix generation, which is the bottleneck when using Arpack, scales as O(L^4) unlike dggev which scales as O(L^6). 

#3211 is the PR which replaces dggev with Arpack