### PR TITLE
Add local time-stepping for CCE

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
@@ -288,14 +288,9 @@ struct ComputeTimeDerivative {
   using inbox_tags =
       tmpl::list<evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<
           Metavariables::volume_dim>>;
-  using const_global_cache_tags = tmpl::append<
-      tmpl::list<::dg::Tags::Formulation, evolution::Tags::BoundaryCorrection<
-                                              typename Metavariables::system>>,
-      tmpl::conditional_t<
-          Metavariables::local_time_stepping,
-          tmpl::list<::Tags::StepChoosers, ::Tags::StepController,
-                     ::Tags::TimeStepper<LtsTimeStepper>>,
-          tmpl::list<>>>;
+  using const_global_cache_tags = tmpl::append<tmpl::list<
+      ::dg::Tags::Formulation,
+      evolution::Tags::BoundaryCorrection<typename Metavariables::system>>>;
 
   template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
             typename ActionList, typename ParallelComponent>

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -205,7 +205,7 @@ struct EvolutionMetavars {
       PhaseControl::get_phase_change_tags<phase_changes>;
 
   using const_global_cache_tags =
-      tmpl::list<initial_data_tag, time_stepper_tag, Tags::EventsAndTriggers,
+      tmpl::list<initial_data_tag, Tags::EventsAndTriggers,
                  PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes>>;
 
   using dg_registration_list =

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
@@ -105,7 +105,7 @@ struct EvolutionMetavars
   using const_global_cache_tags = tmpl::list<
       typename GeneralizedHarmonicTemplateBase<
           EvolutionMetavars>::analytic_solution_tag,
-      time_stepper_tag, Tags::EventsAndTriggers,
+      Tags::EventsAndTriggers,
       GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma0<
           volume_dim, frame>,
       GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma1<

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -271,7 +271,7 @@ struct GeneralizedHarmonicTemplateBase<
   // A tmpl::list of tags to be added to the GlobalCache by the
   // metavariables
   using const_global_cache_tags = tmpl::list<
-      analytic_solution_tag, time_stepper_tag, Tags::EventsAndTriggers,
+      analytic_solution_tag, Tags::EventsAndTriggers,
       GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma0<
           volume_dim, frame>,
       GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma1<

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizon.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizon.hpp
@@ -115,7 +115,6 @@ struct EvolutionMetavars
   using const_global_cache_tags = tmpl::flatten<tmpl::list<
       tmpl::conditional_t<evolution::is_numeric_initial_data_v<initial_data>,
                           tmpl::list<>, initial_data_tag>,
-      time_stepper_tag,
       grmhd::ValenciaDivClean::Tags::ConstraintDampingParameter,
       Tags::EventsAndTriggers,
       GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma0<

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -346,7 +346,6 @@ struct GhValenciaDivCleanTemplateBase<
   using const_global_cache_tags = tmpl::flatten<tmpl::list<
       tmpl::conditional_t<evolution::is_numeric_initial_data_v<initial_data>,
                           tmpl::list<>, initial_data_tag>,
-      time_stepper_tag,
       grmhd::ValenciaDivClean::Tags::ConstraintDampingParameter,
       Tags::EventsAndTriggers,
       GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma0<

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -348,7 +348,7 @@ struct EvolutionMetavars {
       dg_element_array_component>;
 
   using const_global_cache_tags =
-      tmpl::list<initial_data_tag, time_stepper_tag,
+      tmpl::list<initial_data_tag,
                  grmhd::ValenciaDivClean::Tags::ConstraintDampingParameter,
                  Tags::EventsAndTriggers,
                  PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes>>;

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -302,7 +302,7 @@ struct EvolutionMetavars {
   using const_global_cache_tags = tmpl::list<
       initial_data_tag,
       tmpl::conditional_t<has_source_terms, source_term_tag, tmpl::list<>>,
-      time_stepper_tag, Tags::EventsAndTriggers,
+      Tags::EventsAndTriggers,
       PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes>>;
 
   static constexpr Options::String help{

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -286,7 +286,7 @@ struct EvolutionMetavars {
                  dg_element_array>;
 
   using const_global_cache_tags =
-      tmpl::list<initial_data_tag, time_stepper_tag, Tags::EventsAndTriggers,
+      tmpl::list<initial_data_tag, Tags::EventsAndTriggers,
                  PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes>>;
 
   static constexpr Options::String help{

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -302,7 +302,7 @@ struct EvolutionMetavars {
                  dg_element_array>;
 
   using const_global_cache_tags =
-      tmpl::list<initial_data_tag, time_stepper_tag, Tags::EventsAndTriggers,
+      tmpl::list<initial_data_tag, Tags::EventsAndTriggers,
                  PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes>>;
 
   static constexpr Options::String help{

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -215,7 +215,7 @@ struct EvolutionMetavars {
       PhaseControl::get_phase_change_tags<phase_changes>;
 
   using const_global_cache_tags =
-      tmpl::list<initial_data_tag, time_stepper_tag, Tags::EventsAndTriggers,
+      tmpl::list<initial_data_tag, Tags::EventsAndTriggers,
                  PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes>>;
 
   using dg_registration_list =

--- a/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
@@ -9,6 +9,7 @@
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/VariablesTag.hpp"
+#include "Evolution/Initialization/Tags.hpp"
 #include "Evolution/Systems/Cce/OptionTags.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "Time/Tags.hpp"
@@ -58,7 +59,8 @@ namespace Actions {
  */
 template <typename EvolvedCoordinatesVariablesTag, typename EvolvedSwshTag>
 struct InitializeCharacteristicEvolutionTime {
-  using initialization_tags = tmpl::list<InitializationTags::TargetStepSize>;
+  using initialization_tags =
+      tmpl::list<::Initialization::Tags::InitialSlabSize<false>>;
   using const_global_cache_tags =
       tmpl::list<::Tags::TimeStepper<TimeStepper>>;
 
@@ -81,7 +83,8 @@ struct InitializeCharacteristicEvolutionTime {
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
     const double initial_time_value = db::get<Tags::StartTime>(box);
-    const double step_size = db::get<InitializationTags::TargetStepSize>(box);
+    const double step_size =
+        db::get<::Initialization::Tags::InitialSlabSize<false>>(box);
 
     const Slab single_step_slab{initial_time_value,
                                 initial_time_value + step_size};

--- a/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
@@ -57,12 +57,30 @@ namespace Actions {
  * mechanism, so `Actions::SetupDataBox` must be present in the `Initialization`
  * phase action list prior to this action.
  */
-template <typename EvolvedCoordinatesVariablesTag, typename EvolvedSwshTag>
+template <typename EvolvedCoordinatesVariablesTag, typename EvolvedSwshTag,
+          bool local_time_stepping>
 struct InitializeCharacteristicEvolutionTime {
-  using initialization_tags =
-      tmpl::list<::Initialization::Tags::InitialSlabSize<false>>;
-  using const_global_cache_tags =
-      tmpl::list<::Tags::TimeStepper<TimeStepper>>;
+  using initialization_tags = tmpl::flatten<tmpl::list<
+      Tags::CceEvolutionPrefix<
+          Initialization::Tags::InitialSlabSize<local_time_stepping>>,
+      tmpl::conditional_t<
+          local_time_stepping,
+          tmpl::list<
+              Tags::CceEvolutionPrefix<::Tags::TimeStepper<LtsTimeStepper>>,
+              Tags::CceEvolutionPrefix<::Tags::StepChoosers>,
+              Tags::CceEvolutionPrefix<::Tags::StepController>,
+              ::Initialization::Tags::InitialTimeDelta>,
+          Tags::CceEvolutionPrefix<::Tags::TimeStepper<TimeStepper>>>>>;
+
+  using initialization_tags_to_keep = tmpl::conditional_t<
+      local_time_stepping,
+      tmpl::list<Tags::CceEvolutionPrefix<::Tags::TimeStepper<LtsTimeStepper>>,
+                 Tags::CceEvolutionPrefix<::Tags::StepChoosers>,
+                 Tags::CceEvolutionPrefix<::Tags::StepController>,
+                 ::Initialization::Tags::InitialTimeDelta>,
+      tmpl::list<Tags::CceEvolutionPrefix<::Tags::TimeStepper<TimeStepper>>>>;
+
+  using const_global_cache_tags = tmpl::list<>;
 
   using evolved_swsh_variables_tag =
       ::Tags::Variables<tmpl::list<EvolvedSwshTag>>;
@@ -83,15 +101,25 @@ struct InitializeCharacteristicEvolutionTime {
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
     const double initial_time_value = db::get<Tags::StartTime>(box);
-    const double step_size =
-        db::get<::Initialization::Tags::InitialSlabSize<false>>(box);
+    const double slab_size =
+        db::get<::Initialization::Tags::InitialSlabSize<local_time_stepping>>(
+            box);
 
     const Slab single_step_slab{initial_time_value,
-                                initial_time_value + step_size};
+                                initial_time_value + slab_size};
     const Time initial_time = single_step_slab.start();
-    const TimeDelta fixed_time_step =
-        TimeDelta{single_step_slab, Rational{1, 1}};
-    const auto& time_stepper = db::get<::Tags::TimeStepper<TimeStepper>>(box);
+    TimeDelta initial_time_step;
+    if constexpr (local_time_stepping) {
+      const double initial_time_delta =
+          db::get<Initialization::Tags::InitialTimeDelta>(box);
+      initial_time_step =
+          db::get<Tags::CceEvolutionPrefix<::Tags::StepController>>(box)
+              .choose_step(initial_time, initial_time_delta);
+    } else {
+      initial_time_step = TimeDelta{initial_time.slab().duration()};
+    }
+
+    const auto& time_stepper = db::get<::Tags::TimeStepper<>>(box);
 
     const size_t starting_order =
         time_stepper.number_of_past_steps() == 0 ? time_stepper.order() : 1;
@@ -106,7 +134,7 @@ struct InitializeCharacteristicEvolutionTime {
         TimeStepId{true,
                    -static_cast<int64_t>(time_stepper.number_of_past_steps()),
                    initial_time},
-        fixed_time_step, fixed_time_step, initial_time_value,
+        initial_time_step, initial_time_step, initial_time_value,
         std::move(coordinate_history), std::move(swsh_history));
     return std::make_tuple(std::move(box));
   }

--- a/src/Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp
@@ -205,17 +205,22 @@ template <typename Metavariables>
 struct InitializeWorldtubeBoundary<AnalyticWorldtubeBoundary<Metavariables>>
     : public detail::InitializeWorldtubeBoundaryBase<
           InitializeWorldtubeBoundary<AnalyticWorldtubeBoundary<Metavariables>>,
-          tmpl::list<Tags::AnalyticBoundaryDataManager>,
+          tmpl::list<Tags::AnalyticBoundaryDataManager,
+                     Tags::CceEvolutionPrefix<::Tags::TimeStepper<
+                         tmpl::conditional_t<Metavariables::local_time_stepping,
+                                             LtsTimeStepper, TimeStepper>>>>,
           typename Metavariables::cce_boundary_communication_tags> {
   using base_type = detail::InitializeWorldtubeBoundaryBase<
       InitializeWorldtubeBoundary<AnalyticWorldtubeBoundary<Metavariables>>,
-      tmpl::list<Tags::AnalyticBoundaryDataManager>,
+      tmpl::list<Tags::AnalyticBoundaryDataManager,
+                 Tags::CceEvolutionPrefix<::Tags::TimeStepper<
+                     tmpl::conditional_t<Metavariables::local_time_stepping,
+                                         LtsTimeStepper, TimeStepper>>>>,
       typename Metavariables::cce_boundary_communication_tags>;
   using base_type::apply;
   using typename base_type::simple_tags;
   using const_global_cache_tags =
-      tmpl::list<Tags::LMax, Tags::SpecifiedEndTime, Tags::SpecifiedStartTime,
-                 ::Tags::TimeStepper<TimeStepper>>;
+      tmpl::list<Tags::LMax, Tags::SpecifiedEndTime, Tags::SpecifiedStartTime>;
   using typename base_type::initialization_tags;
   using typename base_type::initialization_tags_to_keep;
 };

--- a/src/Evolution/Systems/Cce/Actions/SendNextTimeToCce.hpp
+++ b/src/Evolution/Systems/Cce/Actions/SendNextTimeToCce.hpp
@@ -52,7 +52,6 @@ struct ReceiveNextElementTime;
  */
 template <typename InterpolationTargetTag>
 struct SendNextTimeToCce {
-  using const_global_cache_tags = tmpl::list<::Tags::TimeStepper<TimeStepper>>;
   template <typename DbTags, typename Metavariables, typename... InboxTags,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -195,8 +195,7 @@ struct Metavariables {
     static constexpr bool enable_time_dependent_maps = EnableTimeDependentMaps;
   };
 
-  using const_global_cache_tags =
-      tmpl::list<Tags::TimeStepper<TimeStepper>, Tags::EventsAndTriggers>;
+  using const_global_cache_tags = tmpl::list<Tags::EventsAndTriggers>;
 
   static constexpr Options::String help{
       "Export the inertial coordinates of the Domain specified in the input "

--- a/src/Time/Actions/ChangeStepSize.hpp
+++ b/src/Time/Actions/ChangeStepSize.hpp
@@ -31,12 +31,6 @@ struct Next;
 
 /// Adjust the step size for local time stepping, returning true if the step
 /// just completed is accepted, and false if it is rejected.
-///
-/// \note this is a free function version of `Actions::ChangeStepSize`.
-/// This free function alternative permits the inclusion of the time step
-/// procedure in the middle of another action. When used as a free function, the
-/// calling action is responsible for specifying the const global cache tags
-/// needed by this function (`Tags::StepChoosers`, `Tags::StepController`).
 template <typename DbTags, typename Metavariables>
 bool change_step_size(
     const gsl::not_null<db::DataBox<DbTags>*> box,
@@ -112,10 +106,9 @@ namespace Actions {
 /// \brief Adjust the step size for local time stepping
 ///
 /// Uses:
-/// - GlobalCache:
+/// - DataBox:
 ///   - Tags::StepChoosers<StepChooserRegistrars>
 ///   - Tags::StepController
-/// - DataBox:
 ///   - Tags::HistoryEvolvedVariables
 ///   - Tags::TimeStep
 ///   - Tags::TimeStepId
@@ -126,9 +119,6 @@ namespace Actions {
 /// - Removes: nothing
 /// - Modifies: Tags::Next<Tags::TimeStepId>, Tags::TimeStep
 struct ChangeStepSize {
-  using const_global_cache_tags =
-      tmpl::list<Tags::StepChoosers, Tags::StepController>;
-
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>

--- a/src/Time/Actions/ChangeStepSize.hpp
+++ b/src/Time/Actions/ChangeStepSize.hpp
@@ -140,7 +140,7 @@ struct ChangeStepSize {
     const bool step_successful = change_step_size(make_not_null(&box), cache);
     if (step_successful) {
       return {std::move(box), false,
-              tmpl::index_of<ActionList, ChangeStepSize>::value};
+              tmpl::index_of<ActionList, ChangeStepSize>::value + 1};
     } else {
       return {
           std::move(box), false,

--- a/src/Time/Actions/SelfStartActions.hpp
+++ b/src/Time/Actions/SelfStartActions.hpp
@@ -126,11 +126,6 @@ struct vars_to_save_impl<System, true> {
 template <typename System>
 using vars_to_save = typename vars_to_save_impl<
     System, System::has_primitive_and_conservative_vars>::type;
-
-template <typename TagList>
-using get_all_history_tags =
-    tmpl::filter<TagList,
-                 tt::is_a_lambda<::Tags::HistoryEvolvedVariables, tmpl::_1>>;
 }  // namespace detail
 
 /// \ingroup ActionsGroup
@@ -327,7 +322,7 @@ struct CheckForOrderIncrease {
       const ParallelComponent* const /*meta*/) noexcept {  // NOLINT const
     const auto& time = db::get<::Tags::SubstepTime>(box);
     const auto& time_step = db::get<::Tags::TimeStep>(box);
-    using history_tags = detail::get_all_history_tags<DbTags>;
+    using history_tags = ::Tags::get_all_history_tags<DbTags>;
     const size_t history_integration_order =
         db::get<tmpl::front<history_tags>>(box).integration_order();
 
@@ -430,7 +425,7 @@ struct Cleanup {
             *tag_value = std::decay_t<decltype(*tag_value)>{};
           });
         });
-    using history_tags = detail::get_all_history_tags<DbTags>;
+    using history_tags = ::Tags::get_all_history_tags<DbTags>;
     tmpl::for_each<history_tags>([&box](auto tag_v) noexcept {
       using tag = typename decltype(tag_v)::type;
       ASSERT(db::get<tag>(box).integration_order() ==

--- a/src/Time/StepChoosers/Cfl.hpp
+++ b/src/Time/StepChoosers/Cfl.hpp
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/MinimumGridSpacing.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"  // IWYU pragma: keep

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -103,6 +103,14 @@ struct HistoryEvolvedVariables : HistoryEvolvedVariables<>, db::SimpleTag {
 };
 /// \endcond
 
+/// \ingroup TimeGroup
+/// From a list of tags `TagList`, extract all tags that are template
+/// specializations of `HistoryEvolvedVariables`.
+template <typename TagList>
+using get_all_history_tags =
+    tmpl::filter<TagList,
+                 tt::is_a_lambda<::Tags::HistoryEvolvedVariables, tmpl::_1>>;
+
 /// \ingroup DataBoxTagsGroup
 /// \ingroup TimeGroup
 /// \brief Tag for the stepper error measure.

--- a/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
@@ -14,20 +14,31 @@
 #     AbsoluteTolerance: 5e-5
 
 Evolution:
-  TimeStepper: RungeKutta3
+  InitialTimeStep: 0.01
 
 Observers:
   VolumeFileName: "CharacteristicExtractVolume"
   ReductionFileName: "CharacteristicExtractUnusedReduction"
 
 Cce:
+  Evolution:
+    TimeStepper:
+      AdamsBashforthN:
+        Order: 3
+    InitialSlabSize: 0.8
+    StepChoosers:
+      - Constant: 0.1
+      - Increase:
+          Factor: 2
+    StepController:
+      BinaryFraction
+
   LMax: 8
   NumberOfRadialPoints: 8
   ObservationLMax: 8
 
   StartTime: 0.0
   EndTime: 0.8
-  TargetStepSize: 0.1
   ExtractionRadius: 30.0
 
   AnalyticSolution:

--- a/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
@@ -14,20 +14,31 @@
 #     AbsoluteTolerance: 5e-10
 
 Evolution:
-  TimeStepper: RungeKutta3
+  InitialTimeStep: 0.1
 
 Observers:
   VolumeFileName: "CharacteristicExtractVolume"
   ReductionFileName: "CharacteristicExtractUnusedReduction"
 
 Cce:
+  Evolution:
+    TimeStepper:
+      AdamsBashforthN:
+        Order: 3
+    InitialSlabSize: 0.8
+    StepChoosers:
+      - Constant: 0.4
+      - Increase:
+          Factor: 2
+    StepController:
+      BinaryFraction
+
   LMax: 8
   NumberOfRadialPoints: 8
   ObservationLMax: 8
 
   StartTime: 0.0
   EndTime: 4.0
-  TargetStepSize: 0.4
   ExtractionRadius: 40.0
 
   AnalyticSolution:

--- a/tests/InputFiles/Cce/AnalyticTestLinearizedBondiSachs.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestLinearizedBondiSachs.yaml
@@ -14,20 +14,31 @@
 #     AbsoluteTolerance: 1e-2
 
 Evolution:
-  TimeStepper: RungeKutta3
+  InitialTimeStep: 0.1
 
 Observers:
   VolumeFileName: "CharacteristicExtractVolume"
   ReductionFileName: "CharacteristicExtractUnusedReduction"
 
 Cce:
+  Evolution:
+    TimeStepper:
+      AdamsBashforthN:
+        Order: 3
+    InitialSlabSize: 0.8
+    StepChoosers:
+      - Constant: 0.4
+      - Increase:
+          Factor: 2
+    StepController:
+      BinaryFraction
+
   LMax: 8
   NumberOfRadialPoints: 8
   ObservationLMax: 8
 
   StartTime: 0.0
   EndTime: 5.0
-  TargetStepSize: 0.4
   ExtractionRadius: 40.0
 
   AnalyticSolution:

--- a/tests/InputFiles/Cce/AnalyticTestRobinsonTrautman.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestRobinsonTrautman.yaml
@@ -3,7 +3,7 @@
 
 # Executable: AnalyticTestCharacteristicExtract
 # Check: parse;execute_check_output
-# Timeout: 8
+# Timeout: 10
 # ExpectedOutput:
 #   CharacteristicExtractVolume0.h5
 # OutputFileChecks:
@@ -14,22 +14,31 @@
 #     AbsoluteTolerance: 5e-11
 
 Evolution:
-  TimeStepper:
-    AdamsBashforthN:
-      Order: 3
+  InitialTimeStep: 0.1
 
 Observers:
   VolumeFileName: "CharacteristicExtractVolume"
   ReductionFileName: "CharacteristicExtractUnusedReduction"
 
 Cce:
+  Evolution:
+    TimeStepper:
+      AdamsBashforthN:
+        Order: 3
+    InitialSlabSize: 0.6
+    StepChoosers:
+      - Constant: 0.1
+      - Increase:
+          Factor: 2
+    StepController:
+      BinaryFraction
+
   LMax: 10
   NumberOfRadialPoints: 8
   ObservationLMax: 8
 
   StartTime: 0.0
   EndTime: 0.5
-  TargetStepSize: 0.1
   ExtractionRadius: 40.0
 
   AnalyticSolution:

--- a/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
@@ -14,20 +14,31 @@
 #     AbsoluteTolerance: 1e-11
 
 Evolution:
-  TimeStepper: RungeKutta3
+  InitialTimeStep: 0.1
 
 Observers:
   VolumeFileName: "CharacteristicExtractVolume"
   ReductionFileName: "CharacteristicExtractUnusedReduction"
 
 Cce:
+  Evolution:
+    TimeStepper:
+      AdamsBashforthN:
+        Order: 3
+    InitialSlabSize: 0.8
+    StepChoosers:
+      - Constant: 0.2
+      - Increase:
+          Factor: 2
+    StepController:
+      BinaryFraction
+
   LMax: 8
   NumberOfRadialPoints: 8
   ObservationLMax: 8
 
   StartTime: 0.0
   EndTime: 2.4
-  TargetStepSize: 0.2
   ExtractionRadius: 20.0
 
   AnalyticSolution:

--- a/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
@@ -14,20 +14,31 @@
 #     AbsoluteTolerance: 5e-10
 
 Evolution:
-  TimeStepper: RungeKutta3
+  InitialTimeStep: 0.1
 
 Observers:
   VolumeFileName: "CharacteristicExtractVolume"
   ReductionFileName: "CharacteristicExtractUnusedReduction"
 
 Cce:
+  Evolution:
+    TimeStepper:
+      AdamsBashforthN:
+        Order: 3
+    InitialSlabSize: 1.0
+    StepChoosers:
+      - Constant: 0.5
+      - Increase:
+          Factor: 2
+    StepController:
+      BinaryFraction
+
   LMax: 8
   NumberOfRadialPoints: 8
   ObservationLMax: 8
 
   StartTime: -6.0
   EndTime: -1.0
-  TargetStepSize: 0.5
   ExtractionRadius: 40.0
 
   AnalyticSolution:

--- a/tests/InputFiles/Cce/CharacteristicExtract.yaml
+++ b/tests/InputFiles/Cce/CharacteristicExtract.yaml
@@ -5,13 +5,25 @@
 # Check: parse
 
 Evolution:
-  TimeStepper: RungeKutta3
+  InitialTimeStep: 0.25
 
 Observers:
   VolumeFileName: "CharacteristicExtractVolume"
   ReductionFileName: "CharacteristicExtractUnusedReduction"
 
 Cce:
+  Evolution:
+    TimeStepper:
+      AdamsBashforthN:
+        Order: 3
+    InitialSlabSize: 10.0
+    StepChoosers:
+      - Constant: 1.0
+      - Increase:
+          Factor: 2
+    StepController:
+      BinaryFraction
+
   LMax: 12
   NumberOfRadialPoints: 12
   ObservationLMax: 8
@@ -21,7 +33,6 @@ Cce:
 
   StartTime: 0.0
   EndTime: 1000.0
-  TargetStepSize: 1.0
   BoundaryDataFilename: CceR0257.h5
   H5IsBondiData: false
   H5Interpolator:

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
@@ -57,7 +57,7 @@ struct mock_characteristic_evolution {
       Actions::InitializeCharacteristicEvolutionVariables<Metavariables>,
       Actions::InitializeCharacteristicEvolutionTime<
           typename Metavariables::evolved_coordinates_variables_tag,
-          typename Metavariables::evolved_swsh_tag>,
+          typename Metavariables::evolved_swsh_tag, false>,
       // advance the time so that the current `TimeStepId` is valid without
       // having to perform self-start.
       ::Actions::AdvanceTime, Actions::ReceiveWorldtubeData<Metavariables>,
@@ -193,12 +193,14 @@ SPECTRE_TEST_CASE(
 
   ActionTesting::MockRuntimeSystem<metavariables> runner{
       {start_time, std::make_unique<InitializeJ::InverseCubic>(), l_max,
-       number_of_radial_points,
-       std::make_unique<::TimeSteppers::RungeKutta3>()}};
+       number_of_radial_points}};
 
   ActionTesting::set_phase(make_not_null(&runner),
                            metavariables::Phase::Initialization);
-  ActionTesting::emplace_component<component>(&runner, 0, target_step_size);
+  ActionTesting::emplace_component<component>(
+      &runner, 0, target_step_size,
+      static_cast<std::unique_ptr<TimeStepper>>(
+          std::make_unique<::TimeSteppers::RungeKutta3>()));
 
   // this should run the initialization
   for(size_t i = 0; i < 2; ++i) {

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
@@ -87,7 +87,7 @@ struct mock_characteristic_evolution {
       Actions::InitializeCharacteristicEvolutionVariables<Metavariables>,
       Actions::InitializeCharacteristicEvolutionTime<
           typename Metavariables::evolved_coordinates_variables_tag,
-          typename Metavariables::evolved_swsh_tag>,
+          typename Metavariables::evolved_swsh_tag, false>,
       // advance the time so that the current `TimeStepId` is valid without
       // having to perform self-start.
       ::Actions::AdvanceTime,
@@ -191,8 +191,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.GhBoundaryCommunication",
           Parallel::get_const_global_cache_tags<test_metavariables>>{
           l_max, extraction_radius, end_time, start_time,
           InterfaceManagers::InterpolationStrategy::EveryStep,
-          number_of_radial_points,
-          std::make_unique<::TimeSteppers::DormandPrince5>()}};
+          number_of_radial_points}};
 
   // first prepare the input for the modal version
   const double mass = value_dist(gen);
@@ -208,7 +207,10 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.GhBoundaryCommunication",
 
   runner.set_phase(test_metavariables::Phase::Initialization);
   ActionTesting::emplace_component<evolution_component>(
-      &runner, 0, target_step_size, scri_plus_interpolation_order);
+      &runner, 0, target_step_size,
+      static_cast<std::unique_ptr<TimeStepper>>(
+          std::make_unique<::TimeSteppers::DormandPrince5>()),
+      scri_plus_interpolation_order);
   ActionTesting::emplace_component<worldtube_component>(
       &runner, 0,
       Tags::GhInterfaceManager::create_from_options(

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
@@ -52,7 +52,7 @@ struct mock_characteristic_evolution {
       Actions::InitializeCharacteristicEvolutionVariables<Metavariables>,
       Actions::InitializeCharacteristicEvolutionTime<
           typename Metavariables::evolved_coordinates_variables_tag,
-          typename Metavariables::evolved_swsh_tag>,
+          typename Metavariables::evolved_swsh_tag, false>,
       // advance the time so that the current `TimeStepId` is valid without
       // having to perform self-start.
       ::Actions::AdvanceTime,
@@ -165,13 +165,15 @@ SPECTRE_TEST_CASE(
   const double target_step_size = 0.01 * value_dist(gen);
   const size_t scri_plus_interpolation_order = 3;
   ActionTesting::MockRuntimeSystem<metavariables> runner{
-      {start_time, l_max, number_of_radial_points,
-       std::make_unique<::TimeSteppers::RungeKutta3>()}};
+      {start_time, l_max, number_of_radial_points}};
 
   ActionTesting::set_phase(make_not_null(&runner),
                            metavariables::Phase::Initialization);
-  ActionTesting::emplace_component<component>(&runner, 0, target_step_size,
-                                              scri_plus_interpolation_order);
+  ActionTesting::emplace_component<component>(
+      &runner, 0, target_step_size,
+      static_cast<std::unique_ptr<TimeStepper>>(
+          std::make_unique<::TimeSteppers::RungeKutta3>()),
+      scri_plus_interpolation_order);
 
   // this should run the initialization
   for (size_t i = 0; i < 6; ++i) {

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
@@ -79,6 +79,7 @@ struct GhMetavariables {
 };
 
 struct AnalyticMetavariables {
+  static constexpr bool local_time_stepping = false;
   using cce_boundary_communication_tags =
       Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>;
   using component_list =
@@ -207,13 +208,15 @@ void test_analytic_initialization() noexcept {
   const size_t l_max = 8;
   Parallel::register_derived_classes_with_charm<TimeStepper>();
   ActionTesting::MockRuntimeSystem<AnalyticMetavariables> runner{
-      {l_max, 100.0, 0.0, std::make_unique<::TimeSteppers::RungeKutta3>()}};
+      {l_max, 100.0, 0.0}};
 
   runner.set_phase(AnalyticMetavariables::Phase::Initialization);
   ActionTesting::emplace_component<component>(
       &runner, 0,
       AnalyticBoundaryDataManager{
-          12_st, 20.0, std::make_unique<Solutions::RotatingSchwarzschild>()});
+          12_st, 20.0, std::make_unique<Solutions::RotatingSchwarzschild>()},
+      static_cast<std::unique_ptr<TimeStepper>>(
+          std::make_unique<::TimeSteppers::RungeKutta3>()));
   // this should run the initialization
   for (size_t i = 0; i < 3; ++i) {
     ActionTesting::next_action<component>(make_not_null(&runner), 0);
@@ -249,12 +252,14 @@ SPECTRE_TEST_CASE("Unit.Cce.Actions.InitializeWorldtubeBoundary.RtFail",
   using component = mock_analytic_worldtube_boundary<AnalyticMetavariables>;
   const size_t l_max = 8;
   ActionTesting::MockRuntimeSystem<AnalyticMetavariables> runner{
-      {l_max, 100.0, 0.0, std::make_unique<::TimeSteppers::RungeKutta3>()}};
+      {l_max, 100.0, 0.0}};
   runner.set_phase(AnalyticMetavariables::Phase::Initialization);
   ActionTesting::emplace_component<component>(
       &runner, 0,
       AnalyticBoundaryDataManager{
-          12_st, 20.0, std::make_unique<Solutions::RobinsonTrautman>()});
+          12_st, 20.0, std::make_unique<Solutions::RobinsonTrautman>()},
+      static_cast<std::unique_ptr<TimeStepper>>(
+          std::make_unique<::TimeSteppers::RungeKutta3>()));
   // this should run the initialization
   for (size_t i = 0; i < 3; ++i) {
     ActionTesting::next_action<component>(make_not_null(&runner), 0);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
@@ -69,7 +69,7 @@ struct mock_characteristic_evolution {
       Actions::InitializeCharacteristicEvolutionVariables<Metavariables>,
       Actions::InitializeCharacteristicEvolutionTime<
           typename Metavariables::evolved_coordinates_variables_tag,
-          typename Metavariables::evolved_swsh_tag>,
+          typename Metavariables::evolved_swsh_tag, false>,
       // advance the time so that the current `TimeStepId` is valid without
       // having to perform self-start.
       ::Actions::AdvanceTime,
@@ -188,13 +188,14 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.RequestBoundaryData",
   ActionTesting::MockRuntimeSystem<test_metavariables> runner{
       {l_max,
        Tags::EndTimeFromFile::create_from_options(end_time, filename, false),
-       start_time, number_of_radial_points,
-       std::make_unique<::TimeSteppers::RungeKutta3>()}};
+       start_time, number_of_radial_points}};
 
   ActionTesting::set_phase(make_not_null(&runner),
                            test_metavariables::Phase::Initialization);
-  ActionTesting::emplace_component<evolution_component>(&runner, 0,
-                                                        target_step_size);
+  ActionTesting::emplace_component<evolution_component>(
+      &runner, 0, target_step_size,
+      static_cast<std::unique_ptr<TimeStepper>>(
+          std::make_unique<::TimeSteppers::RungeKutta3>()));
   ActionTesting::emplace_component<worldtube_component>(
       &runner, 0,
       Tags::H5WorldtubeBoundaryDataManager::create_from_options(

--- a/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
@@ -38,8 +38,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
   TestHelpers::db::test_simple_tag<
       Cce::InitializationTags::ScriInterpolationOrder>(
       "ScriInterpolationOrder");
-  TestHelpers::db::test_simple_tag<Cce::InitializationTags::TargetStepSize>(
-      "TargetStepSize");
   TestHelpers::db::test_simple_tag<Cce::InitializationTags::ExtractionRadius>(
       "ExtractionRadius");
   TestHelpers::db::test_simple_tag<Cce::InitializationTags::ScriOutputDensity>(
@@ -77,6 +75,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
       "AnalyticInitializeJ");
   TestHelpers::db::test_simple_tag<Cce::Tags::OutputNoninertialNews>(
       "OutputNoninertialNews");
+  TestHelpers::db::test_simple_tag<
+      Cce::Tags::CceEvolutionPrefix<::Tags::TimeStepper<TimeStepper>>>(
+      "TimeStepper");
 
   CHECK(TestHelpers::test_option_tag<Cce::OptionTags::LMax>("8") == 8_st);
   CHECK(TestHelpers::test_option_tag<Cce::OptionTags::FilterLMax>("7") == 7_st);
@@ -99,8 +100,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
         Options::Auto<double>{2.0});
   CHECK(TestHelpers::test_option_tag<Cce::OptionTags::StartTime>("Auto") ==
         Options::Auto<double>{});
-  CHECK(TestHelpers::test_option_tag<Cce::OptionTags::TargetStepSize>("0.5") ==
-        0.5);
   CHECK(TestHelpers::test_option_tag<Cce::OptionTags::BoundaryDataFilename>(
             "OptionTagsCceR0100.h5") == "OptionTagsCceR0100.h5");
   CHECK(TestHelpers::test_option_tag<Cce::OptionTags::H5LookaheadTimes>("5") ==
@@ -160,6 +159,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
       "  ExtractionRadius: 40.0\n"
       "  Amplitude: 0.1\n"
       "  Duration: 3.0");
+  TestHelpers::test_option_tag<Cce::OptionTags::CceEvolutionPrefix<
+      ::OptionTags::TimeStepper<TimeStepper>>>("RungeKutta3:");
 
   const std::string filename = "OptionTagsTestCceR0100.h5";
   if (file_system::check_if_file_exists(filename)) {
@@ -196,8 +197,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
             std::optional<double>(40.0)) == 40.0);
 
   CHECK(Cce::Tags::ObservationLMax::create_from_options(5_st) == 5_st);
-  CHECK(Cce::InitializationTags::TargetStepSize::create_from_options(0.2) ==
-        0.2);
 
   CHECK(Cce::InitializationTags::ScriInterpolationOrder::create_from_options(
             6_st) == 6_st);
@@ -205,8 +204,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
   CHECK(Cce::InitializationTags::ScriOutputDensity::create_from_options(4_st) ==
         4_st);
 
-  CHECK(Cce::InitializationTags::TargetStepSize::create_from_options(0.2) ==
-        0.2);
   CHECK(Cce::Tags::AnalyticBoundaryDataManager::create_from_options(
             10.0, 8,
             std::make_unique<Cce::Solutions::RotatingSchwarzschild>(10.0, 1.0,


### PR DESCRIPTION
## Proposed changes

Performs some restructuring of the storage of time-stepper related tags -- moving several from the global cache to the DataBox, and enables the use of step choosers for the CCE system.
I anticipate that most of the time-related tags have sufficiently small memory footprints that it doesn't make much of a difference that they are in the DataBox, but I'm happy to consider alternative methods of approaching the structuring of the systems -- my main design constraint was that CCE evolution and DG element array should be able to simultaneously access the time-stepping architecture with their own respective time steppers and step choosers.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Dependencies

- [x] PR #3304
