### PR TITLE
Add Quaternion FunctionOfTime

### DIFF
--- a/src/Domain/FunctionsOfTime/CMakeLists.txt
+++ b/src/Domain/FunctionsOfTime/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_sources(
   FixedSpeedCubic.cpp
   FunctionOfTimeHelpers.cpp
   PiecewisePolynomial.cpp
+  QuaternionFunctionOfTime.cpp
   QuaternionHelpers.cpp
   ReadSpecPiecewisePolynomial.cpp
   RegisterDerivedWithCharm.cpp
@@ -26,6 +27,7 @@ spectre_target_headers(
   FunctionOfTimeHelpers.hpp
   OptionTags.hpp
   PiecewisePolynomial.hpp
+  QuaternionFunctionOfTime.hpp
   QuaternionHelpers.hpp
   ReadSpecPiecewisePolynomial.hpp
   RegisterDerivedWithCharm.hpp

--- a/src/Domain/FunctionsOfTime/PiecewisePolynomial.hpp
+++ b/src/Domain/FunctionsOfTime/PiecewisePolynomial.hpp
@@ -78,6 +78,14 @@ class PiecewisePolynomial : public FunctionOfTime {
     return {{deriv_info_at_update_times_.front().time, expiration_time_}};
   }
 
+  /// Return a const reference to the stored deriv info so external classes can
+  /// read the stored times and derivatives (mostly for
+  /// QuaternionFunctionOfTime).
+  const std::vector<FunctionOfTimeHelpers::StoredInfo<MaxDeriv + 1>>&
+  get_deriv_info() const {
+    return deriv_info_at_update_times_;
+  }
+
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p) override;
 

--- a/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.cpp
+++ b/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.cpp
@@ -1,0 +1,192 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
+
+// BoostMultiArray is used internally in odeint, so BoostMultiArray MUST be
+// included before odeint
+#include "DataStructures/BoostMultiArray.hpp"
+
+#include <boost/numeric/odeint.hpp>
+#include <pup_stl.h>
+
+#include "Domain/FunctionsOfTime/QuaternionHelpers.hpp"
+#include "NumericalAlgorithms/OdeIntegration/OdeIntegration.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/StdHelpers.hpp"
+
+namespace domain::FunctionsOfTime {
+template <size_t MaxDeriv>
+QuaternionFunctionOfTime<MaxDeriv>::QuaternionFunctionOfTime(
+    const double t, std::array<DataVector, 1> initial_quat_func,
+    std::array<DataVector, MaxDeriv + 1> initial_omega_func,
+    const double expiration_time) noexcept
+    : stored_quaternions_and_times_{{t, std::move(initial_quat_func)}},
+      omega_f_of_t_(t, std::move(initial_omega_func), expiration_time) {}
+
+template <size_t MaxDeriv>
+std::unique_ptr<FunctionOfTime> QuaternionFunctionOfTime<MaxDeriv>::get_clone()
+    const noexcept {
+  return std::make_unique<QuaternionFunctionOfTime>(*this);
+}
+
+template <size_t MaxDeriv>
+void QuaternionFunctionOfTime<MaxDeriv>::pup(PUP::er& p) {
+  FunctionOfTime::pup(p);
+  p | stored_quaternions_and_times_;
+  p | omega_f_of_t_;
+}
+
+template <size_t MaxDeriv>
+void QuaternionFunctionOfTime<MaxDeriv>::update(
+    const double time_of_update, DataVector updated_max_deriv,
+    const double next_expiration_time) noexcept {
+  omega_f_of_t_.update(time_of_update, std::move(updated_max_deriv),
+                       next_expiration_time);
+  update_stored_info();
+}
+
+template <size_t MaxDeriv>
+void QuaternionFunctionOfTime<MaxDeriv>::update_stored_info() noexcept {
+  const auto& omega_deriv_info = omega_f_of_t_.get_deriv_info();
+
+  ASSERT(
+      omega_deriv_info.size() == stored_quaternions_and_times_.size() + 1,
+      "The number of stored quaternions is not one less than the number of "
+      "stored omegas (which it should be after an update). Currently there are "
+          << omega_deriv_info.size() << " stored omegas and "
+          << stored_quaternions_and_times_.size() << " stored quaternions.");
+
+  const size_t last_index = stored_quaternions_and_times_.size();
+  // Final time, initial time, and quaternion
+  const double t = omega_deriv_info[last_index].time;
+  const double t0 = omega_deriv_info[last_index - 1].time;
+  boost::math::quaternion<double> quaternion_to_integrate =
+      datavector_to_quaternion(
+          stored_quaternions_and_times_[last_index - 1].stored_quantities[0]);
+
+  solve_quaternion_ode(make_not_null(&quaternion_to_integrate), t0, t);
+
+  // normalize quaternion
+  normalize_quaternion(make_not_null(&quaternion_to_integrate));
+
+  stored_quaternions_and_times_.emplace_back(
+      t, std::array<DataVector, 1>{
+             quaternion_to_datavector(quaternion_to_integrate)});
+
+  ASSERT(omega_deriv_info.size() == stored_quaternions_and_times_.size(),
+         "The number of stored omegas must be the same as the number of stored "
+         "quaternions after updating the missing quaternion. Now there are "
+             << omega_deriv_info.size() << " stored omegas and "
+             << stored_quaternions_and_times_.size() << " stored quaternions.");
+}
+
+template <size_t MaxDeriv>
+void QuaternionFunctionOfTime<MaxDeriv>::solve_quaternion_ode(
+    const gsl::not_null<boost::math::quaternion<double>*>
+        quaternion_to_integrate,
+    const double t0, const double t) const noexcept {
+  // lambda that stores the internals of the ode
+  const auto quaternion_ode_system =
+      [this](const boost::math::quaternion<double>& state,
+             boost::math::quaternion<double>& dt_state,
+             const double time) noexcept {
+        const boost::math::quaternion<double> omega =
+            datavector_to_quaternion(omega_f_of_t_.func(time)[0]);
+        dt_state = 0.5 * state * omega;
+      };
+
+  // Dense stepper
+  auto dense_stepper = boost::numeric::odeint::make_dense_output(
+      1.0e-15, 1.0e-14,
+      boost::numeric::odeint::runge_kutta_dopri5<
+          boost::math::quaternion<double>, double,
+          boost::math::quaternion<double>, double,
+          boost::numeric::odeint::vector_space_algebra>{});
+
+  // Integrate from t0 to t, storing result in quaternion_to_integrate
+  boost::numeric::odeint::integrate_adaptive(
+      dense_stepper, quaternion_ode_system, *quaternion_to_integrate, t0, t,
+      1e-4);
+}
+
+template <size_t MaxDeriv>
+boost::math::quaternion<double> QuaternionFunctionOfTime<MaxDeriv>::setup_func(
+    const double t) const noexcept {
+  // Get quaternion and time at closest time before t
+  const auto& stored_info_at_t0 =
+      stored_info_from_upper_bound(t, stored_quaternions_and_times_);
+  boost::math::quaternion<double> quat_to_integrate =
+      datavector_to_quaternion(stored_info_at_t0.stored_quantities[0]);
+
+  // Solve the ode and store the result in quat_to_integrate
+  solve_quaternion_ode(make_not_null(&quat_to_integrate),
+                       stored_info_at_t0.time, t);
+
+  // Make unit quaternion
+  normalize_quaternion(make_not_null(&quat_to_integrate));
+
+  return quat_to_integrate;
+}
+
+template <size_t MaxDeriv>
+std::array<DataVector, 1> QuaternionFunctionOfTime<MaxDeriv>::quat_func(
+    const double t) const noexcept {
+  return std::array<DataVector, 1>{quaternion_to_datavector(setup_func(t))};
+}
+
+template <size_t MaxDeriv>
+std::array<DataVector, 2>
+QuaternionFunctionOfTime<MaxDeriv>::quat_func_and_deriv(
+    const double t) const noexcept {
+  boost::math::quaternion<double> quat = setup_func(t);
+
+  // Get omega and however many derivatives we need
+  std::array<DataVector, 1> omega_func = omega_f_of_t_.func(t);
+
+  boost::math::quaternion<double> omega =
+      datavector_to_quaternion(omega_func[0]);
+
+  boost::math::quaternion<double> dtquat = 0.5 * quat * omega;
+
+  return std::array<DataVector, 2>{quaternion_to_datavector(quat),
+                                   quaternion_to_datavector(dtquat)};
+}
+
+template <size_t MaxDeriv>
+std::array<DataVector, 3>
+QuaternionFunctionOfTime<MaxDeriv>::quat_func_and_2_derivs(
+    const double t) const noexcept {
+  boost::math::quaternion<double> quat = setup_func(t);
+
+  // Get omega and however many derivatives we need
+  std::array<DataVector, 2> omega_func_and_deriv =
+      omega_f_of_t_.func_and_deriv(t);
+
+  boost::math::quaternion<double> omega =
+      datavector_to_quaternion(omega_func_and_deriv[0]);
+  boost::math::quaternion<double> dtomega =
+      datavector_to_quaternion(omega_func_and_deriv[1]);
+
+  boost::math::quaternion<double> dtquat = 0.5 * quat * omega;
+  boost::math::quaternion<double> dt2quat =
+      0.5 * (dtquat * omega + quat * dtomega);
+
+  return std::array<DataVector, 3>{quaternion_to_datavector(quat),
+                                   quaternion_to_datavector(dtquat),
+                                   quaternion_to_datavector(dt2quat)};
+}
+
+// do explicit instantiation of MaxDeriv = {2,3,4}
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data) template class QuaternionFunctionOfTime<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3, 4))
+
+#undef DIM
+#undef INSTANTIATE
+}  // namespace domain::FunctionsOfTime

--- a/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp
+++ b/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp
@@ -1,0 +1,176 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <boost/math/quaternion.hpp>
+#include <cmath>
+#include <limits>
+#include <pup.h>
+#include <string>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTimeHelpers.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace domain::FunctionsOfTime {
+/// \ingroup ComputationalDomainGroup
+/// \brief A FunctionOfTime that stores quaternions for the rotation map
+///
+/// \details This FunctionOfTime stores quaternions that will be used in the
+/// time-dependent rotation map as well as the orbital angular velocity that
+/// will be controlled by the rotation control sytem. To get the quaternion, an
+/// ODE is solved of the form \f$ \dot{q} = \frac{1}{2} q \times \omega \f$
+/// where \f$ \omega \f$ is the orbital angular velocity which is stored
+/// internally in a `PiecewisePolynomial`, and \f$ \times \f$ here is quaternion
+/// multiplication.
+///
+/// Different from a `PiecewisePolynomial`, only the quaternion
+/// itself is stored, not any of the derivatives because the derivatives must be
+/// calculated from the solved ODE at every function call. Because
+/// derivatives of the quaternion are not stored, the template parameter
+/// `MaxDeriv` refers to both the max derivative of the stored omega
+/// PiecewisePolynomial and the max derivative returned by the
+/// QuaternionFunctionOfTime. The `update` function is then just a wrapper
+/// around the internal `PiecewisePolynomial::update` function with the addition
+/// that it then updates the stored quaternions as well.
+///
+/// The omega PiecewisePolynomial is accessible through the `omega_func`,
+/// `omega_func_and_deriv`, and `omega_func_and_2_derivs` functions which
+/// correspond to the function calls of a normal PiecewisePolynomial except
+/// without the `omega_` prefix.
+///
+/// It is encouraged to use `quat_func` and `omega_func` when you want the
+/// specific values of the functions to avoid ambiguity in what you are
+/// calling. However, the original three `func` functions inherited from the
+/// FunctionOfTime base class are necessary because the maps use the generic
+/// `func` functions, thus they return the quaternion and its derivatives (which
+/// are needed for the map). This is all to keep the symmetry of naming
+/// `omega_func` and `quat_func` so that function calls won't be ambiguous.
+template <size_t MaxDeriv>
+class QuaternionFunctionOfTime : public FunctionOfTime {
+ public:
+  QuaternionFunctionOfTime() = default;
+  QuaternionFunctionOfTime(
+      double t, std::array<DataVector, 1> initial_quat_func,
+      std::array<DataVector, MaxDeriv + 1> initial_omega_func,
+      double expiration_time) noexcept;
+
+  ~QuaternionFunctionOfTime() override = default;
+  QuaternionFunctionOfTime(QuaternionFunctionOfTime&&) noexcept = default;
+  QuaternionFunctionOfTime& operator=(QuaternionFunctionOfTime&&) noexcept =
+      default;
+  QuaternionFunctionOfTime(const QuaternionFunctionOfTime&) = default;
+  QuaternionFunctionOfTime& operator=(const QuaternionFunctionOfTime&) =
+      default;
+
+  // LCOV_EXCL_START
+  explicit QuaternionFunctionOfTime(CkMigrateMessage* /*unused*/) {}
+  // LCOV_EXCL_STOP
+
+  auto get_clone() const noexcept -> std::unique_ptr<FunctionOfTime> override;
+
+  // clang-tidy: google-runtime-references
+  // clang-tidy: cppcoreguidelines-owning-memory,-warnings-as-errors
+  WRAPPED_PUPable_decl_template(QuaternionFunctionOfTime<MaxDeriv>);  // NOLINT
+
+  void reset_expiration_time(const double next_expiration_time) noexcept {
+    omega_f_of_t_.reset_expiration_time(next_expiration_time);
+  }
+
+  /// Returns domain of validity for the function of time
+  std::array<double, 2> time_bounds() const noexcept override {
+    return omega_f_of_t_.time_bounds();
+  }
+
+  /// Updates the `MaxDeriv`th derivative of the omega piecewisepolynomial at
+  /// the given time, then updates the stored quaternions.
+  ///
+  /// `updated_max_deriv` is a datavector of the `MaxDeriv`s for each component.
+  /// `next_expiration_time` is the next expiration time.
+  void update(double time_of_update, DataVector updated_max_deriv,
+              double next_expiration_time) noexcept;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override;
+
+  /// Returns the quaternion at an arbitrary time `t`.
+  std::array<DataVector, 1> func(const double t) const noexcept override {
+    return quat_func(t);
+  }
+
+  /// Returns the quaternion and its first derivative at an arbitrary time `t`.
+  std::array<DataVector, 2> func_and_deriv(
+      const double t) const noexcept override {
+    return quat_func_and_deriv(t);
+  }
+
+  /// Returns the quaternion and the first two derivatives at an arbitrary
+  /// time `t`.
+  std::array<DataVector, 3> func_and_2_derivs(
+      const double t) const noexcept override {
+    return quat_func_and_2_derivs(t);
+  }
+
+  /// Returns the quaternion at an arbitrary time `t`.
+  std::array<DataVector, 1> quat_func(double t) const noexcept;
+
+  /// Returns the quaternion and its first derivative at an arbitrary time `t`.
+  std::array<DataVector, 2> quat_func_and_deriv(double t) const noexcept;
+
+  /// Returns the quaternion and the first two derivatives at an arbitrary
+  /// time `t`.
+  std::array<DataVector, 3> quat_func_and_2_derivs(double t) const noexcept;
+
+  /// Returns stored omega at an arbitrary time `t`.
+  std::array<DataVector, 1> omega_func(const double t) const noexcept {
+    return omega_f_of_t_.func(t);
+  }
+
+  /// Returns stored omega and its first derivative at an arbitrary time `t`.
+  std::array<DataVector, 2> omega_func_and_deriv(
+      const double t) const noexcept {
+    return omega_f_of_t_.func_and_deriv(t);
+  }
+
+  /// Returns stored omega and the first two derivatives at an arbitrary
+  /// time `t`.
+  std::array<DataVector, 3> omega_func_and_2_derivs(
+      const double t) const noexcept {
+    return omega_f_of_t_.func_and_2_derivs(t);
+  }
+
+ private:
+  std::vector<FunctionOfTimeHelpers::StoredInfo<1, false>>
+      stored_quaternions_and_times_;
+
+  domain::FunctionsOfTime::PiecewisePolynomial<MaxDeriv> omega_f_of_t_;
+
+  /// Integrates the ODE \f$ \dot{q} = \frac{1}{2} q \times \omega \f$ from time
+  /// `t0` to time `t`. On input, `quaternion_to_integrate` is the initial
+  /// quaternion at time `t0` and on output, it stores the result at time `t`
+  void solve_quaternion_ode(
+      gsl::not_null<boost::math::quaternion<double>*> quaternion_to_integrate,
+      double t0, double t) const noexcept;
+
+  /// Updates the `std::vector<StoredInfo>` to have the same number of stored
+  /// quaternions as the `omega_f_of_t_ptr` has stored omegas. This is necessary
+  /// to ensure we can solve the ODE at any time `t`
+  void update_stored_info() noexcept;
+
+  /// Does common operations to all the `func` functions such as updating stored
+  /// info, solving the ODE, and returning the normalized quaternion as a boost
+  /// quaternion for easy calculations
+  boost::math::quaternion<double> setup_func(double t) const noexcept;
+};
+
+/// \cond
+template <size_t MaxDeriv>
+PUP::able::PUP_ID QuaternionFunctionOfTime<MaxDeriv>::my_PUP_ID = 0;  // NOLINT
+/// \endcond
+}  // namespace domain::FunctionsOfTime

--- a/src/Domain/FunctionsOfTime/QuaternionHelpers.hpp
+++ b/src/Domain/FunctionsOfTime/QuaternionHelpers.hpp
@@ -7,7 +7,10 @@
 
 #pragma once
 
+#include "DataStructures/BoostMultiArray.hpp"
+
 #include <boost/math/quaternion.hpp>
+#include <boost/numeric/odeint.hpp>
 
 #include "DataStructures/DataVector.hpp"
 
@@ -34,3 +37,14 @@ boost::math::quaternion<double> datavector_to_quaternion(
 /// Normalize a `boost::math::quaternion`
 void normalize_quaternion(
     gsl::not_null<boost::math::quaternion<double>*> input) noexcept;
+
+// Necessary for odeint to be able to integrate boost quaternions
+namespace boost::numeric::odeint {
+template <>
+struct vector_space_norm_inf<boost::math::quaternion<double>> {
+  using result_type = double;
+  result_type operator()(const boost::math::quaternion<double>& q) const {
+    return sup(q);
+  }
+};
+}  // namespace boost::numeric::odeint

--- a/tests/Unit/Domain/FunctionsOfTime/CMakeLists.txt
+++ b/tests/Unit/Domain/FunctionsOfTime/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_FixedSpeedCubic.cpp
   Test_FunctionOfTimeHelpers.cpp
   Test_PiecewisePolynomial.cpp
+  Test_QuaternionFunctionOfTime.cpp
   Test_QuaternionHelpers.cpp
   Test_ReadSpecPiecewisePolynomial.cpp
   Test_SettleToConstant.cpp

--- a/tests/Unit/Domain/FunctionsOfTime/Test_QuaternionFunctionOfTime.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_QuaternionFunctionOfTime.cpp
@@ -1,0 +1,303 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cmath>
+
+#include "DataStructures/DataVector.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+
+SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.QuaternionFunctionOfTime",
+                  "[Unit][Domain]") {
+  {
+    INFO("QuaternionFunctionOfTime: Expiration time and time bounds");
+    domain::FunctionsOfTime::QuaternionFunctionOfTime<2> qfot{
+        0.0, std::array<DataVector, 1>{DataVector{4, 0.0}},
+        std::array<DataVector, 3>{DataVector{3, 0.0}, DataVector{3, 0.0},
+                                  DataVector{3, 0.0}},
+        0.5};
+    CHECK(qfot.time_bounds() == std::array<double, 2>({0.0, 0.5}));
+    qfot.reset_expiration_time(0.6);
+    CHECK(qfot.time_bounds() == std::array<double, 2>({0.0, 0.6}));
+  }
+
+  {
+    INFO("QuaternionFunctionOfTime: Internal PiecewisePolynomial");
+    DataVector init_omega{0.0, 0.0, 3.78};
+    domain::FunctionsOfTime::QuaternionFunctionOfTime<2> qfot{
+        0.0, std::array<DataVector, 1>{DataVector{{1.0, 0.0, 0.0, 0.0}}},
+        std::array<DataVector, 3>{init_omega, DataVector{3, 0.0},
+                                  DataVector{3, 0.0}},
+        0.5};
+    domain::FunctionsOfTime::PiecewisePolynomial<2> pp{
+        0.0,
+        std::array<DataVector, 3>{init_omega, DataVector{3, 0.0},
+                                  DataVector{3, 0.0}},
+        0.5};
+    qfot.update(0.6, DataVector{3, 0.0}, 1.0);
+    pp.update(0.6, DataVector{3, 0.0}, 1.0);
+
+    CHECK(qfot.omega_func(0.4) == pp.func(0.4));
+    CHECK(qfot.omega_func_and_deriv(0.4) == pp.func_and_deriv(0.4));
+    CHECK(qfot.omega_func_and_2_derivs(0.4) == pp.func_and_2_derivs(0.4));
+  }
+
+  {
+    INFO("QuaternionFunctionOfTime: pup, cloning, extra functions");
+    DataVector init_omega{0.0, 0.0, 1.0};
+    domain::FunctionsOfTime::QuaternionFunctionOfTime<2> qfot{
+        0.0, std::array<DataVector, 1>{DataVector{{1.0, 0.0, 0.0, 0.0}}},
+        std::array<DataVector, 3>{init_omega, DataVector{3, 0.0},
+                                  DataVector{3, 0.0}},
+        2.5};
+
+    auto qfot_ptr = qfot.get_clone();
+    domain::FunctionsOfTime::QuaternionFunctionOfTime<2>
+        qfot_serialized_deserialized = serialize_and_deserialize(qfot);
+
+    std::array<DataVector, 1> expected_func{
+        DataVector{{cos(1.0), 0.0, 0.0, sin(1.0)}}};
+    std::array<DataVector, 2> expected_func_and_deriv{
+        DataVector{{cos(1.0), 0.0, 0.0, sin(1.0)}},
+        DataVector{{-0.5 * sin(1.0), 0.0, 0.0, 0.5 * cos(1.0)}}};
+
+    CHECK_ITERABLE_APPROX(qfot.quat_func(2.0), expected_func);
+    CHECK_ITERABLE_APPROX(qfot.quat_func_and_deriv(2.0),
+                          expected_func_and_deriv);
+    CHECK_ITERABLE_APPROX(qfot.func(2.0), expected_func);
+    CHECK_ITERABLE_APPROX(qfot.func_and_deriv(2.0), expected_func_and_deriv);
+    CHECK_ITERABLE_APPROX(qfot_ptr->func(2.0), qfot.func(2.0));
+    CHECK_ITERABLE_APPROX(qfot_ptr->func_and_deriv(2.0),
+                          qfot.func_and_deriv(2.0));
+    CHECK_ITERABLE_APPROX(qfot_serialized_deserialized.func(2.0),
+                          qfot.func(2.0));
+    CHECK_ITERABLE_APPROX(qfot_serialized_deserialized.func_and_deriv(2.0),
+                          qfot.func_and_deriv(2.0));
+  }
+
+  {
+    INFO("QuaternionFunctionOfTime: Constant omega");
+    double t = 0.0;
+    double expir_time = 0.5;
+    const double omega_z = 1.3333;
+    DataVector init_quat{1.0, 0.0, 0.0, 0.0};
+    DataVector init_omega{0.0, 0.0, omega_z};
+    DataVector init_dtomega{0.0, 0.0, 0.0};
+    DataVector init_dt2omega{0.0, 0.0, 0.0};
+
+    // Construct QuaternionFunctionOfTime
+    domain::FunctionsOfTime::QuaternionFunctionOfTime<2> qfot{
+        t, std::array<DataVector, 1>{init_quat},
+        std::array<DataVector, 3>{init_omega, init_dtomega, init_dt2omega},
+        expir_time};
+
+    // Update stored PiecewisePolynomial with 0 2nd derivative so it's
+    // constant. This will automatically update the stored quaternions as well
+    const double time_step = 0.5;
+    for (int i = 0; i < 15; i++) {
+      t += time_step;
+      expir_time += time_step;
+      qfot.update(t, DataVector{3, 0.0}, expir_time);
+    }
+
+    // Get the quaternion and 2 derivatives at a certain time.
+    double check_time = 5.398;
+    const std::array<DataVector, 3> quat_func_and_2_derivs =
+        qfot.quat_func_and_2_derivs(check_time);
+    const std::array<DataVector, 3> quat_func_and_2_derivs2 =
+        qfot.func_and_2_derivs(check_time);
+    for (size_t i = 0; i < 3; i++) {
+      CHECK_ITERABLE_APPROX(gsl::at(quat_func_and_2_derivs, i),
+                            gsl::at(quat_func_and_2_derivs2, i));
+    }
+
+    // Analytic solution for constant omega
+    // quat = ( cos(omega*t/2), 0, 0, sin(omega*t/2) )
+    DataVector a_quat{{cos(0.5 * omega_z * check_time), 0.0, 0.0,
+                       sin(0.5 * omega_z * check_time)}};
+    DataVector a_dtquat{{-0.5 * omega_z * sin(0.5 * omega_z * check_time), 0.0,
+                         0.0, 0.5 * omega_z * cos(0.5 * omega_z * check_time)}};
+    DataVector a_dt2quat{
+        {-0.25 * omega_z * omega_z * cos(0.5 * omega_z * check_time), 0.0, 0.0,
+         -0.25 * omega_z * omega_z * sin(0.5 * omega_z * check_time)}};
+
+    // Compare analytic solution to numerical
+    Approx custom_approx = Approx::custom().epsilon(1e-12).scale(1.0);
+    {
+      INFO("  Compare quaternion");
+      CHECK_ITERABLE_CUSTOM_APPROX(quat_func_and_2_derivs[0], a_quat,
+                                   custom_approx);
+    }
+    {
+      INFO("  Compare derivative of quaternion");
+      CHECK_ITERABLE_CUSTOM_APPROX(quat_func_and_2_derivs[1], a_dtquat,
+                                   custom_approx);
+    }
+    {
+      INFO("  Compare second derivative of quaternion");
+      CHECK_ITERABLE_CUSTOM_APPROX(quat_func_and_2_derivs[2], a_dt2quat,
+                                   custom_approx);
+    }
+  }
+
+  {
+    INFO("QuaternionFunctionOfTime: Linear Omega");
+    double t = 0.0;
+    double expir_time = 0.5;
+    // phi(t) = fac1 * t^2 + fac2 * t + fac3
+    const double fac1 = 0.25;
+    const double fac2 = 0.5;
+    const double fac3 = 0.0;
+    // omega(t) = 2*fac1 * t + fac2
+    // dtomega(t) = 2 * fac1 (constant)
+    // dt2omega(t) = 0.0
+
+    DataVector init_quat{1.0, 0.0, 0.0, 0.0};
+    DataVector init_omega{{0.0, 0.0, fac2}};
+    DataVector init_dtomega{{0.0, 0.0, 2 * fac1}};
+    DataVector init_dt2omega{3, 0.0};
+    // Construct QuaternionFunctionOfTime
+    domain::FunctionsOfTime::QuaternionFunctionOfTime<2> qfot{
+        t, std::array<DataVector, 1>{init_quat},
+        std::array<DataVector, 3>{init_omega, init_dtomega, init_dt2omega},
+        expir_time};
+
+    // Update internal PiecewisePolynomial with constant 2nd derivative so
+    // it's linear. This will automatically update the stored quaternions as
+    // well
+    const double time_step = 0.5;
+    for (int i = 0; i < 15; i++) {
+      t += time_step;
+      expir_time += time_step;
+      qfot.update(t, DataVector{{0.0, 0.0, 0.0}}, expir_time);
+    }
+
+    // Get the quaternion and 2 derivatives at a certain time.
+    double check_time = 5.398;
+    const std::array<DataVector, 3> quat_func_and_2_derivs =
+        qfot.quat_func_and_2_derivs(check_time);
+    const std::array<DataVector, 3> quat_func_and_2_derivs2 =
+        qfot.func_and_2_derivs(check_time);
+    for (size_t i = 0; i < 3; i++) {
+      CHECK_ITERABLE_APPROX(gsl::at(quat_func_and_2_derivs, i),
+                            gsl::at(quat_func_and_2_derivs2, i));
+    }
+
+    // phi(t) = fac1 * t^2 + fac2 * t + fac3
+    const double phi =
+        fac1 * check_time * check_time + fac2 * check_time + fac3;
+    // omega(t) = 2*fac1 * t + fac2
+    const double omega = 2 * fac1 * check_time + fac2;
+    const double dtomega = 2 * fac1;
+
+    DataVector a_quat{{cos(0.5 * phi), 0.0, 0.0, sin(0.5 * phi)}};
+    DataVector a_dtquat{
+        {-0.5 * a_quat[3] * omega, 0.0, 0.0, 0.5 * a_quat[0] * omega}};
+    DataVector a_dt2quat{{-0.5 * (a_dtquat[3] * omega + a_quat[3] * dtomega),
+                          0.0, 0.0,
+                          0.5 * (a_dtquat[0] * omega + a_quat[0] * dtomega)}};
+
+    // Compare analytic solution to numerical
+    Approx custom_approx = Approx::custom().epsilon(5e-12).scale(1.0);
+    {
+      INFO("  Compare quaternion");
+      CHECK_ITERABLE_CUSTOM_APPROX(quat_func_and_2_derivs[0], a_quat,
+                                   custom_approx);
+    }
+    {
+      INFO("  Compare derivative of quaternion");
+      CHECK_ITERABLE_CUSTOM_APPROX(quat_func_and_2_derivs[1], a_dtquat,
+                                   custom_approx);
+    }
+    {
+      INFO("  Compare second derivative of quaternion");
+      CHECK_ITERABLE_CUSTOM_APPROX(quat_func_and_2_derivs[2], a_dt2quat,
+                                   custom_approx);
+    }
+  }
+
+  {
+    INFO("QuaternionFunctionOfTime: Quadratic Omega");
+    double t = 0.0;
+    double expir_time = 0.5;
+    // phi(t) = fac1 * t^3 + fac2 * t^2 + fac3 * t + fac4;
+    const double fac1 = 0.2;
+    const double fac2 = 0.3;
+    const double fac3 = 0.4;
+    const double fac4 = 0.0;
+    // omega(t) = 3*fac1 * t^2 + 2*fac2 * t + fac3
+    // dtomega(t) = 6*fac1 * t + 2* fac2
+    // dt2omega(t) = 6 * fac1 (constant)
+
+    DataVector init_quat{1.0, 0.0, 0.0, 0.0};
+    DataVector init_omega{{0.0, 0.0, fac3}};
+    DataVector init_dtomega{{0.0, 0.0, 2 * fac2}};
+    DataVector init_dt2omega{{0.0, 0.0, 6 * fac1}};
+    // Construct QuaternionFunctionOfTime
+    domain::FunctionsOfTime::QuaternionFunctionOfTime<2> qfot{
+        t, std::array<DataVector, 1>{init_quat},
+        std::array<DataVector, 3>{init_omega, init_dtomega, init_dt2omega},
+        expir_time};
+
+    // Update PiecewisePolynomial with constant 2nd derivative so it's
+    // quadratic. This will automatically update the stored quaternions as
+    // well
+    const double time_step = 0.5;
+    for (int i = 0; i < 15; i++) {
+      t += time_step;
+      expir_time += time_step;
+      qfot.update(t, DataVector{{0.0, 0.0, 6 * fac1}}, expir_time);
+    }
+
+    // Get the quaternion and 2 derivatives at a certain time.
+    double check_time = 5.398;
+    const std::array<DataVector, 3> quat_func_and_2_derivs =
+        qfot.quat_func_and_2_derivs(check_time);
+    const std::array<DataVector, 3> quat_func_and_2_derivs2 =
+        qfot.func_and_2_derivs(check_time);
+    for (size_t i = 0; i < 3; i++) {
+      CHECK_ITERABLE_APPROX(gsl::at(quat_func_and_2_derivs, i),
+                            gsl::at(quat_func_and_2_derivs2, i));
+    }
+
+    // phi(t) = fac1 * t^3 + fac2 * t^2 + fac3 * t + fac4;
+    const double phi = fac1 * check_time * check_time * check_time +
+                       fac2 * check_time * check_time + fac3 * check_time +
+                       fac4;
+    // omega(t) = 3*fac1 * t^2 + 2*fac2 * t + fac3
+    // dtomega(t) = 6*fac1 * t + 2* fac2
+    // dt2omega(t) = 6 * fac1 (constant)
+    const double omega =
+        3 * fac1 * check_time * check_time + 2 * fac2 * check_time + fac3;
+    const double dtomega = 6 * fac1 * check_time + 2 * fac2;
+
+    DataVector a_quat{{cos(0.5 * phi), 0.0, 0.0, sin(0.5 * phi)}};
+    DataVector a_dtquat{
+        {-0.5 * a_quat[3] * omega, 0.0, 0.0, 0.5 * a_quat[0] * omega}};
+    DataVector a_dt2quat{{-0.5 * (a_dtquat[3] * omega + a_quat[3] * dtomega),
+                          0.0, 0.0,
+                          0.5 * (a_dtquat[0] * omega + a_quat[0] * dtomega)}};
+
+    // Compare analytic solution to numerical
+    Approx custom_approx = Approx::custom().epsilon(1e-12).scale(1.0);
+    {
+      INFO("  Compare quaternion");
+      CHECK_ITERABLE_CUSTOM_APPROX(quat_func_and_2_derivs[0], a_quat,
+                                   custom_approx);
+    }
+    {
+      INFO("  Compare derivative of quaternion");
+      CHECK_ITERABLE_CUSTOM_APPROX(quat_func_and_2_derivs[1], a_dtquat,
+                                   custom_approx);
+    }
+    {
+      INFO("  Compare second derivative of quaternion");
+      CHECK_ITERABLE_CUSTOM_APPROX(quat_func_and_2_derivs[2], a_dt2quat,
+                                   custom_approx);
+    }
+  }
+}


### PR DESCRIPTION
## Proposed changes

Adds a new `FunctionOfTime` that stores quaternions which will be used in the time-dependent rotation maps. To get the quaternion, an ODE is solved of the form `dtquat = 0.5 * quat x omega` where `omega` is the orbital angular velocity which is retreived from a `PiecewisePolynomial` in the global cache, and `x` here is quaternion multiplication. Different from a `PiecewisePolynomial`, only the quaternion itself is stored, not any of the derivatives because the derivatives just be calculated from the solved ODE at every function call. Also because derivatives are not stored, what would be the `MaxDeriv` cannot be updated. Before any function call, the `QuaternionFunctionOfTime` checks if it has the same number of stored quaternions as the angular velocity `PiecewisePolynomial` has stored omegas. This is to ensure we have all the data necessary to solve the ODE at any time `t`. Other than these few, but important, differences, the `QuaternionFuntionOfTime` is essentially identical to the `PiecewisePolynomial`.

Also had to add another member to `PiecewisePolynomial` that returns its stored derivative info because `QuaternionFunctionOfTime` needs access to this to solve the ODE so it can populate its missing quaternions at the same times as the stored omegas in the `PiecewisePolynomail`.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Dependencies

- [x] PR #3310 
- [x] PR #3321 

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
