### PR TITLE
Logarithmic cylinder

### DIFF
--- a/src/Domain/CoordinateMaps/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/CMakeLists.txt
@@ -26,6 +26,7 @@ spectre_target_sources(
   FocallyLiftedSide.cpp
   Frustum.cpp
   Identity.cpp
+  Interval.cpp
   KerrHorizonConforming.cpp
   Rotation.cpp
   SpecialMobius.cpp
@@ -57,6 +58,7 @@ spectre_target_headers(
   FocallyLiftedSide.hpp
   Frustum.hpp
   Identity.hpp
+  Interval.hpp
   KerrHorizonConforming.hpp
   MapInstantiationMacros.hpp
   ProductMaps.hpp

--- a/src/Domain/CoordinateMaps/Distribution.cpp
+++ b/src/Domain/CoordinateMaps/Distribution.cpp
@@ -17,6 +17,8 @@ std::ostream& operator<<(std::ostream& os,
   switch (distribution) {
     case Distribution::Linear:
       return os << "Linear";
+    case Distribution::Equiangular:
+      return os << "Equiangular";
     case Distribution::Logarithmic:
       return os << "Logarithmic";
     case Distribution::Inverse:
@@ -35,6 +37,8 @@ Options::create_from_yaml<domain::CoordinateMaps::Distribution>::create<void>(
   const auto distribution = options.parse_as<std::string>();
   if (distribution == "Linear") {
     return domain::CoordinateMaps::Distribution::Linear;
+  } else if (distribution == "Equiangular") {
+    return domain::CoordinateMaps::Distribution::Equiangular;
   } else if (distribution == "Logarithmic") {
     return domain::CoordinateMaps::Distribution::Logarithmic;
   } else if (distribution == "Inverse") {

--- a/src/Domain/CoordinateMaps/Distribution.hpp
+++ b/src/Domain/CoordinateMaps/Distribution.hpp
@@ -22,7 +22,7 @@ namespace domain::CoordinateMaps {
  *
  * \see domain::CoordinateMaps::Wedge
  */
-enum class Distribution { Linear, Logarithmic, Inverse };
+enum class Distribution { Linear, Equiangular, Logarithmic, Inverse };
 
 std::ostream& operator<<(std::ostream& os, Distribution distribution) noexcept;
 

--- a/src/Domain/CoordinateMaps/Interval.cpp
+++ b/src/Domain/CoordinateMaps/Interval.cpp
@@ -1,0 +1,265 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/Interval.hpp"
+
+#include <cmath>
+#include <optional>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"     // IWYU pragma: keep
+#include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
+#include "Domain/CoordinateMaps/Distribution.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace domain::CoordinateMaps {
+
+Interval::Interval(const double A, const double B, const double a,
+                   const double b, const Distribution distribution,
+                   const std::optional<double> singularity_pos) noexcept
+    : A_(A),
+      B_(B),
+      a_(a),
+      b_(b),
+      distribution_(distribution),
+      singularity_pos_(singularity_pos) {
+  ASSERT(
+      A != B and a != b,
+      "The left and right boundaries for both source and target interval must "
+      "differ, but are; ["
+          << A << ", " << B << "] -> [" << a << ", " << b << "]");
+  if (distribution == domain::CoordinateMaps::Distribution::Logarithmic or
+      distribution == domain::CoordinateMaps::Distribution::Inverse) {
+    ASSERT(singularity_pos.has_value(),
+           "Both the logarithmic and inverse distribution require "
+           "`singularity_pos` to be specified explicitly.");
+    ASSERT(std::min(a, b) > singularity_pos.value() or
+               std::max(a, b) < singularity_pos.value(),
+           "The singularity for the logarithmic and inverse Interval falls "
+           "inside the domain with ["
+               << std::min(a, b) << ", " << std::max(a, b) << "], but is"
+               << singularity_pos.value());
+  }
+  is_identity_ =
+      distribution == domain::CoordinateMaps::Distribution::Linear and
+      A == a and B == b;
+}
+
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, 1> Interval::operator()(
+    const std::array<T, 1>& source_coords) const noexcept {
+  switch (distribution_) {
+    case Distribution::Linear: {
+      return {{((b_ - a_) * source_coords[0] + a_ * B_ - b_ * A_) / (B_ - A_)}};
+    }
+    case Distribution::Equiangular: {
+      return {
+          {0.5 * (a_ + b_ +
+                  (b_ - a_) * tan(M_PI_4 * (2.0 * source_coords[0] - B_ - A_) /
+                                  (B_ - A_)))}};
+    }
+    case Distribution::Logarithmic: {
+      const double singularity_pos = singularity_pos_.value();
+      const double logarithmic_zero =
+          0.5 * (log((b_ - singularity_pos) * (a_ - singularity_pos)));
+      const double logarithmic_rate =
+          0.5 * (log((b_ - singularity_pos) / (a_ - singularity_pos)));
+      const double singularity_sign =
+          std::min(a_, b_) > singularity_pos ? 1. : -1.;
+      return {{singularity_sign *
+                   exp(logarithmic_zero +
+                       logarithmic_rate * (2.0 * source_coords[0] - B_ - A_) /
+                           (B_ - A_)) +
+               singularity_pos}};
+    }
+    case Distribution::Inverse: {
+      const double singularity_pos = singularity_pos_.value();
+      return {
+          {2.0 * (a_ - singularity_pos) * (b_ - singularity_pos) /
+               (a_ + b_ - 2.0 * singularity_pos -
+                (b_ - a_) / (B_ - A_) * (2.0 * source_coords[0] - B_ - A_)) +
+           singularity_pos}};
+    }
+    default:
+      ERROR("Unknown domain::CoordinateMaps::Distribution type for Interval");
+  }
+}
+
+std::optional<std::array<double, 1>> Interval::inverse(
+    const std::array<double, 1>& target_coords) const noexcept {
+  switch (distribution_) {
+    case Distribution::Linear: {
+      return {
+          {{((B_ - A_) * target_coords[0] - a_ * B_ + b_ * A_) / (b_ - a_)}}};
+    }
+    case Distribution::Equiangular: {
+      return {
+          {{0.5 * (A_ + B_ +
+                   (B_ - A_) / M_PI_4 *
+                       atan((2.0 * target_coords[0] - a_ - b_) / (b_ - a_)))}}};
+    }
+    case Distribution::Logarithmic: {
+      const double singularity_pos = singularity_pos_.value();
+      const double logarithmic_zero =
+          0.5 * (log((b_ - singularity_pos) * (a_ - singularity_pos)));
+      const double logarithmic_rate =
+          0.5 * (log((b_ - singularity_pos) / (a_ - singularity_pos)));
+      const double singularity_sign =
+          std::min(a_, b_) > singularity_pos ? 1. : -1.;
+      return {{{0.5 * ((B_ - A_) *
+                           (log(singularity_sign *
+                                (target_coords[0] - singularity_pos)) -
+                            logarithmic_zero) /
+                           logarithmic_rate +
+                       B_ + A_)}}};
+    }
+    case Distribution::Inverse: {
+      const double singularity_pos = singularity_pos_.value();
+      return {
+          {{0.5 * (A_ + B_ +
+                   (B_ - A_) / (b_ - a_) *
+                       ((a_ - singularity_pos) + (b_ - singularity_pos) -
+                        2. * (a_ - singularity_pos) * (b_ - singularity_pos) /
+                            (target_coords[0] - singularity_pos)))}}};
+    }
+    default:
+      ERROR("Unknown domain::CoordinateMaps::Distribution type for Interval");
+  }
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> Interval::jacobian(
+    const std::array<T, 1>& source_coords) const noexcept {
+  auto jacobian_matrix =
+      make_with_value<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame>>(
+          dereference_wrapper(source_coords[0]), 0.0);
+  switch (distribution_) {
+    case Distribution::Linear: {
+      get<0, 0>(jacobian_matrix) = (b_ - a_) / (B_ - A_);
+      return jacobian_matrix;
+    }
+    case Distribution::Equiangular: {
+      const tt::remove_cvref_wrap_t<T> tan_variable =
+          tan((2.0 * source_coords[0] - B_ - A_) * M_PI_4 / (B_ - A_));
+      get<0, 0>(jacobian_matrix) =
+          M_PI_4 * (b_ - a_) / (B_ - A_) * (1.0 + square(tan_variable));
+      return jacobian_matrix;
+    }
+    case Distribution::Logarithmic: {
+      const double singularity_pos = singularity_pos_.value();
+      const double logarithmic_zero =
+          0.5 * (log((b_ - singularity_pos) * (a_ - singularity_pos)));
+      const double logarithmic_rate =
+          0.5 * (log((b_ - singularity_pos) / (a_ - singularity_pos)));
+      const double singularity_sign =
+          std::min(a_, b_) > singularity_pos ? 1. : -1.;
+      get<0, 0>(jacobian_matrix) =
+          2.0 / (B_ - A_) * logarithmic_rate * singularity_sign *
+          exp(logarithmic_zero + logarithmic_rate *
+                                     (2.0 * source_coords[0] - B_ - A_) /
+                                     (B_ - A_));
+      return jacobian_matrix;
+    }
+    case Distribution::Inverse: {
+      const double singularity_pos = singularity_pos_.value();
+      get<0, 0>(jacobian_matrix) =
+          (a_ - singularity_pos) * (b_ - singularity_pos) * (b_ - a_) *
+          (B_ - A_) /
+          square((b_ - a_) * source_coords[0] + a_ * A_ - b_ * B_ +
+                 singularity_pos * (B_ - A_));
+      return jacobian_matrix;
+    }
+    default:
+      ERROR("Unknown domain::CoordinateMaps::Distribution type for Interval");
+  }
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> Interval::inv_jacobian(
+    const std::array<T, 1>& source_coords) const noexcept {
+  auto inv_jacobian_matrix =
+      make_with_value<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame>>(
+          dereference_wrapper(source_coords[0]), 0.0);
+  switch (distribution_) {
+    case Distribution::Linear: {
+      get<0, 0>(inv_jacobian_matrix) = (B_ - A_) / (b_ - a_);
+      return inv_jacobian_matrix;
+    }
+    case Distribution::Equiangular: {
+      const tt::remove_cvref_wrap_t<T> tan_variable =
+          tan(M_PI_4 * (2.0 * source_coords[0] - B_ - A_) / (B_ - A_));
+      get<0, 0>(inv_jacobian_matrix) =
+          (B_ - A_) / (M_PI_4 * (b_ - a_) * (1.0 + square(tan_variable)));
+      return inv_jacobian_matrix;
+    }
+    case Distribution::Logarithmic: {
+      const double singularity_pos = singularity_pos_.value();
+      const double logarithmic_zero =
+          0.5 * (log((b_ - singularity_pos) * (a_ - singularity_pos)));
+      const double logarithmic_rate =
+          0.5 * (log((b_ - singularity_pos) / (a_ - singularity_pos)));
+      const double singularity_sign =
+          std::min(a_, b_) > singularity_pos ? 1. : -1.;
+      get<0, 0>(inv_jacobian_matrix) =
+          0.5 * (B_ - A_) / logarithmic_rate * singularity_sign *
+          exp(-logarithmic_zero - logarithmic_rate *
+                                      (2.0 * source_coords[0] - B_ - A_) /
+                                      (B_ - A_));
+      return inv_jacobian_matrix;
+    }
+    case Distribution::Inverse: {
+      const double singularity_pos = singularity_pos_.value();
+      get<0, 0>(inv_jacobian_matrix) =
+          square((b_ - a_) * source_coords[0] + a_ * A_ - b_ * B_ +
+                 singularity_pos * (B_ - A_)) /
+          ((a_ - singularity_pos) * (b_ - singularity_pos) * (b_ - a_) *
+           (B_ - A_));
+      return inv_jacobian_matrix;
+    }
+    default:
+      ERROR("Unknown domain::CoordinateMaps::Distribution type for Interval");
+  }
+}
+
+void Interval::pup(PUP::er& p) noexcept {
+  p | A_;
+  p | B_;
+  p | a_;
+  p | b_;
+  p | distribution_;
+  p | singularity_pos_;
+  p | is_identity_;
+}
+
+bool operator==(const CoordinateMaps::Interval& lhs,
+                const CoordinateMaps::Interval& rhs) noexcept {
+  return lhs.A_ == rhs.A_ and lhs.B_ == rhs.B_ and lhs.a_ == rhs.a_ and
+         lhs.b_ == rhs.b_ and lhs.distribution_ == rhs.distribution_ and
+         lhs.singularity_pos_ == rhs.singularity_pos_;
+}
+
+// Explicit instantiations
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                 \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1>               \
+  Interval::operator()(const std::array<DTYPE(data), 1>& source_coords)      \
+      const noexcept;                                                        \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame> \
+  Interval::jacobian(const std::array<DTYPE(data), 1>& source_coords)        \
+      const noexcept;                                                        \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame> \
+  Interval::inv_jacobian(const std::array<DTYPE(data), 1>& source_coords)    \
+      const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
+                                      std::reference_wrapper<const double>,
+                                      std::reference_wrapper<const DataVector>))
+#undef DTYPE
+#undef INSTANTIATE
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/Interval.hpp
+++ b/src/Domain/CoordinateMaps/Interval.hpp
@@ -1,0 +1,128 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <optional>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/CoordinateMaps/Distribution.hpp"
+#include "Parallel/PupStlCpp17.hpp"
+#include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace domain::CoordinateMaps {
+
+/*!
+ * \ingroup CoordinateMapsGroup
+ * \brief Maps \f$\xi\f$ in the 1D interval \f$[A, B]\f$ to \f$x\f$ in the
+ * interval \f$[a, b]\f$ according to a `domain::CoordinateMaps::Distribution`.
+ *
+ * \details The mapping takes a `domain::CoordinateMaps::Distribution` and
+ * distributes the grid points accordingly.
+ *
+ * The formula for the mapping is, in case of a `Linear` distribution
+ * \f{align}
+ * x &= \frac{b}{B-A} (\xi-A) + \frac{a}{B-A} (B-\xi)\\
+ * \xi &=\frac{B}{b-a} (x-a) + \frac{A}{b-a} (b-x)
+ * \f}
+ *
+ * For every other distribution we use this linear mapping to map onto an
+ * interval \f$[-1, 1]\f$, so we define:
+ * \f{align}
+ * f(\xi) &:= \frac{A+B-2\xi}{A-B} \in [-1, 1]\\
+ * g(x) &:= \frac{a+b-2x}{a-b} \in [-1, 1]
+ * \f}
+ *
+ * With this an `Equiangular` distribution is described by
+ *
+ * \f{align}
+ * x &= \frac{a}{2} \left(1-\mathrm{tan}\left(\frac{\pi}{4}f(\xi)\right)\right)
+ * + \frac{b}{2} \left(1+\mathrm{tan}\left(\frac{\pi}{4}f(\xi)\right)\right)\\
+ * \xi &=
+ * \frac{A}{2} \left(1-\frac{4}{\pi}\mathrm{arctan}\left(g(x)\right)\right) +
+ * \frac{B}{2} \left(1+\frac{4}{\pi}\mathrm{arctan}\left(g(x)\right)\right)
+ * \f}
+ *
+ * \note The equiangular distribution is intended to be used with the `Wedge`
+ * map when equiangular coordinates are chosen for those maps. For more
+ * information on this choice of coordinates, see the documentation for `Wedge`.
+ *
+ *
+ * For both the `Logarithmic` and `Inverse` distribution, we first specify a
+ * position for the singularity \f$c:=\f$`singularity_pos` outside the target
+ * interval \f$[a, b]\f$.
+ *
+ * The `Logarithmic` distribution further requires the introduction of a
+ * variable \f$\sigma\f$ dependent on whether \f$c\f$ is left (\f$ \sigma =
+ * 1\f$) or right (\f$ \sigma = -1\f$) of the target interval. With this, the
+ * `Logarithmic` distribution is described by
+ *
+ * \f{align}
+ * x &= \sigma\, {\rm exp}\left(\frac{\ln(b-c)+\ln(a-c)}{2} + f(\xi)
+ * \frac{\ln(b-c)-\ln(a-c)}{2}\right) + c\\
+ * \xi &= \frac{B-A}{2}\frac{2\ln(\sigma [x-c]) - \ln(b-c) - \ln(a-c)}{\ln(b-c)
+ * - \ln(a-c)} + \frac{B+A}{2} \f}
+ *
+ * and the `Inverse` distribution by
+ *
+ * \f{align}
+ * x &= \frac{2(a-c)(b-c)}{a+b-2c+(a-b)f(\xi)} + c\\
+ * \xi &= -\frac{A-B}{2(a-b)} \left(\frac{2(a-c)(b-c)}{x-c} - (a-c) -
+ * (b-c)\right) + \frac{A+B}{2}
+ * \f}
+ */
+class Interval {
+ public:
+  static constexpr size_t dim = 1;
+
+  Interval(double A, double B, double a, double b, Distribution distribution,
+           std::optional<double> singularity_pos = std::nullopt) noexcept;
+
+  Interval() = default;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, 1> operator()(
+      const std::array<T, 1>& source_coords) const noexcept;
+
+  std::optional<std::array<double, 1>> inverse(
+      const std::array<double, 1>& target_coords) const noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> jacobian(
+      const std::array<T, 1>& source_coords) const noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> inv_jacobian(
+      const std::array<T, 1>& source_coords) const noexcept;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) noexcept;
+
+  bool is_identity() const noexcept { return is_identity_; }
+
+ private:
+  friend bool operator==(const Interval& lhs, const Interval& rhs) noexcept;
+
+  double A_{std::numeric_limits<double>::signaling_NaN()};
+  double B_{std::numeric_limits<double>::signaling_NaN()};
+  double a_{std::numeric_limits<double>::signaling_NaN()};
+  double b_{std::numeric_limits<double>::signaling_NaN()};
+  Distribution distribution_{Distribution::Linear};
+  std::optional<double> singularity_pos_{std::nullopt};
+  bool is_identity_{false};
+};
+
+inline bool operator!=(const CoordinateMaps::Interval& lhs,
+                       const CoordinateMaps::Interval& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/Creators/Cylinder.cpp
+++ b/src/Domain/Creators/Cylinder.cpp
@@ -27,22 +27,22 @@ struct Inertial;
 namespace domain::creators {
 Cylinder::Cylinder(
     const double inner_radius, const double outer_radius,
-    const double lower_bound, const double upper_bound,
+    const double lower_z_bound, const double upper_z_bound,
     const bool is_periodic_in_z,
     const typename InitialRefinement::type& initial_refinement,
     const typename InitialGridPoints::type& initial_number_of_grid_points,
     const bool use_equiangular_map, std::vector<double> radial_partitioning,
-    std::vector<double> height_partitioning,
+    std::vector<double> partitioning_in_z,
     std::vector<domain::CoordinateMaps::Distribution> radial_distribution,
     const Options::Context& context)
     : inner_radius_(inner_radius),
       outer_radius_(outer_radius),
-      lower_bound_(lower_bound),
-      upper_bound_(upper_bound),
+      lower_z_bound_(lower_z_bound),
+      upper_z_bound_(upper_z_bound),
       is_periodic_in_z_(is_periodic_in_z),
       use_equiangular_map_(use_equiangular_map),
       radial_partitioning_(std::move(radial_partitioning)),
-      height_partitioning_(std::move(height_partitioning)),
+      partitioning_in_z_(std::move(partitioning_in_z)),
       radial_distribution_(std::move(radial_distribution)) {
   if (inner_radius_ > outer_radius_) {
     PARSE_ERROR(context,
@@ -51,12 +51,12 @@ Cylinder::Cylinder(
                     std::to_string(inner_radius_) + " and outer radius is " +
                     std::to_string(outer_radius_) + ".");
   }
-  if (lower_bound_ > upper_bound_) {
+  if (lower_z_bound_ > upper_z_bound_) {
     PARSE_ERROR(context,
-                "Lower bound must be smaller than upper bound, but lower "
+                "Lower z-bound must be smaller than upper z-bound, but lower "
                 "bound is " +
-                    std::to_string(lower_bound_) + " and upper bound is " +
-                    std::to_string(upper_bound_) + ".");
+                    std::to_string(lower_z_bound_) + " and upper bound is " +
+                    std::to_string(upper_z_bound_) + ".");
   }
   if (not std::is_sorted(radial_partitioning_.begin(),
                          radial_partitioning_.end())) {
@@ -79,29 +79,29 @@ Cylinder::Cylinder(
               std::to_string(outer_radius_));
     }
   }
-  if (not std::is_sorted(height_partitioning_.begin(),
-                         height_partitioning_.end())) {
+  if (not std::is_sorted(partitioning_in_z_.begin(),
+                         partitioning_in_z_.end())) {
     PARSE_ERROR(context,
-                "Specify height partitioning in ascending order. Specified "
-                "height partitioning is: " +
-                    get_output(height_partitioning_));
+                "Specify partitioning in z in ascending order. Specified "
+                "partitioning is: " +
+                    get_output(partitioning_in_z_));
   }
-  if (not height_partitioning_.empty()) {
-    if (height_partitioning_.front() <= lower_bound_) {
+  if (not partitioning_in_z_.empty()) {
+    if (partitioning_in_z_.front() <= lower_z_bound_) {
       PARSE_ERROR(
           context,
-          "First height partition must be larger than lower bound, but is: " +
-              std::to_string(lower_bound_));
+          "First partition in z must be larger than lower z-bound, but is: " +
+              std::to_string(lower_z_bound_));
     }
-    if (height_partitioning_.back() >= upper_bound_) {
+    if (partitioning_in_z_.back() >= upper_z_bound_) {
       PARSE_ERROR(
           context,
-          "Last height partition must be smaller than upper bound, but is: " +
-              std::to_string(upper_bound_));
+          "Last partition in z must be smaller than upper z-bound, but is: " +
+              std::to_string(upper_z_bound_));
     }
   }
   const size_t num_shells = 1 + radial_partitioning_.size();
-  const size_t num_layers = 1 + height_partitioning_.size();
+  const size_t num_layers = 1 + partitioning_in_z_.size();
   if (radial_distribution_.size() != num_shells) {
     PARSE_ERROR(
         context,
@@ -171,40 +171,40 @@ Cylinder::Cylinder(
 
 Cylinder::Cylinder(
     const double inner_radius, const double outer_radius,
-    const double lower_bound, const double upper_bound,
+    const double lower_z_bound, const double upper_z_bound,
     std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
-        lower_boundary_condition,
+        lower_z_boundary_condition,
     std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
-        upper_boundary_condition,
+        upper_z_boundary_condition,
     std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
         mantle_boundary_condition,
     const typename InitialRefinement::type& initial_refinement,
     const typename InitialGridPoints::type& initial_number_of_grid_points,
     const bool use_equiangular_map, std::vector<double> radial_partitioning,
-    std::vector<double> height_partitioning,
+    std::vector<double> partitioning_in_z,
     std::vector<domain::CoordinateMaps::Distribution> radial_distribution,
     const Options::Context& context)
-    : Cylinder(inner_radius, outer_radius, lower_bound, upper_bound, false,
+    : Cylinder(inner_radius, outer_radius, lower_z_bound, upper_z_bound, false,
                initial_refinement, initial_number_of_grid_points,
                use_equiangular_map, std::move(radial_partitioning),
-               std::move(height_partitioning), std::move(radial_distribution),
+               std::move(partitioning_in_z), std::move(radial_distribution),
                context) {
-  lower_boundary_condition_ = std::move(lower_boundary_condition);
-  upper_boundary_condition_ = std::move(upper_boundary_condition);
+  lower_z_boundary_condition_ = std::move(lower_z_boundary_condition);
+  upper_z_boundary_condition_ = std::move(upper_z_boundary_condition);
   mantle_boundary_condition_ = std::move(mantle_boundary_condition);
 
   using domain::BoundaryConditions::is_periodic;
-  if (is_periodic(lower_boundary_condition_) xor
-      is_periodic(upper_boundary_condition_)) {
+  if (is_periodic(lower_z_boundary_condition_) xor
+      is_periodic(upper_z_boundary_condition_)) {
     PARSE_ERROR(context,
-                "Either both lower and upper boundary condition must be "
+                "Either both lower and upper z-boundary condition must be "
                 "periodic, or neither.");
   }
-  if (is_periodic(lower_boundary_condition_) and
-      is_periodic(upper_boundary_condition_)) {
+  if (is_periodic(lower_z_boundary_condition_) and
+      is_periodic(upper_z_boundary_condition_)) {
     is_periodic_in_z_ = true;
-    lower_boundary_condition_ = nullptr;
-    upper_boundary_condition_ = nullptr;
+    lower_z_boundary_condition_ = nullptr;
+    upper_z_boundary_condition_ = nullptr;
   }
   if (is_periodic(mantle_boundary_condition_)) {
     PARSE_ERROR(context,
@@ -212,8 +212,8 @@ Cylinder::Cylinder(
                 "radial direction.");
   }
   using domain::BoundaryConditions::is_none;
-  if (is_none(lower_boundary_condition_) or
-      is_none(upper_boundary_condition_) or
+  if (is_none(lower_z_boundary_condition_) or
+      is_none(upper_z_boundary_condition_) or
       is_none(mantle_boundary_condition_)) {
     PARSE_ERROR(
         context,
@@ -221,18 +221,18 @@ Cylinder::Cylinder(
         "outflow boundary condition, you must use that.");
   }
   if (mantle_boundary_condition_ == nullptr or
-      (not is_periodic_in_z_ and (lower_boundary_condition_ == nullptr or
-                                  upper_boundary_condition_ == nullptr))) {
-    PARSE_ERROR(
-        context,
-        "Boundary conditions must not be 'nullptr'. Use the other constructor "
-        "to specify 'is_periodic_in_z' instead of boundary conditions.");
+      (not is_periodic_in_z_ and (lower_z_boundary_condition_ == nullptr or
+                                  upper_z_boundary_condition_ == nullptr))) {
+    PARSE_ERROR(context,
+                "z-boundary conditions must not be 'nullptr'. Use the other "
+                "constructor to specify 'is_periodic_in_z' instead of boundary "
+                "conditions.");
   }
 }
 
 Domain<3> Cylinder::create_domain() const noexcept {
   const size_t number_of_shells = 1 + radial_partitioning_.size();
-  const size_t number_of_discs = 1 + height_partitioning_.size();
+  const size_t number_of_discs = 1 + partitioning_in_z_.size();
   std::vector<PairOfFaces> pairs_of_faces{};
   if (is_periodic_in_z_) {
     // connect faces of end caps in the periodic z-direction
@@ -276,12 +276,12 @@ Domain<3> Cylinder::create_domain() const noexcept {
          ++block_id) {
       if (block_id < (1 + number_of_shells * 4)) {
         boundary_conditions_all_blocks[block_id][Direction<3>::lower_zeta()] =
-            lower_boundary_condition_->get_clone();
+            lower_z_boundary_condition_->get_clone();
       }
       if (block_id >=
           boundary_conditions_all_blocks.size() - (1 + number_of_shells * 4)) {
         boundary_conditions_all_blocks[block_id][Direction<3>::upper_zeta()] =
-            upper_boundary_condition_->get_clone();
+            upper_z_boundary_condition_->get_clone();
       }
     }
     // Radial boundary conditions
@@ -299,21 +299,22 @@ Domain<3> Cylinder::create_domain() const noexcept {
     }
   }
 
-  return Domain<3>{cyl_wedge_coordinate_maps<Frame::Inertial>(
-                       inner_radius_, outer_radius_, lower_bound_, upper_bound_,
-                       use_equiangular_map_, radial_partitioning_,
-                       height_partitioning_, radial_distribution_),
-                   corners_for_cylindrical_layered_domains(number_of_shells,
-                                                           number_of_discs),
-                   pairs_of_faces, std::move(boundary_conditions_all_blocks)};
+  return Domain<3>{
+      cyl_wedge_coordinate_maps<Frame::Inertial>(
+          inner_radius_, outer_radius_, lower_z_bound_, upper_z_bound_,
+          use_equiangular_map_, radial_partitioning_, partitioning_in_z_,
+          radial_distribution_),
+      corners_for_cylindrical_layered_domains(number_of_shells,
+                                              number_of_discs),
+      pairs_of_faces, std::move(boundary_conditions_all_blocks)};
 }
 
 std::vector<std::array<size_t, 3>> Cylinder::initial_extents() const noexcept {
   return initial_number_of_grid_points_;
 }
 
-std::vector<std::array<size_t, 3>> Cylinder::initial_refinement_levels() const
-    noexcept {
+std::vector<std::array<size_t, 3>> Cylinder::initial_refinement_levels()
+    const noexcept {
   return initial_refinement_;
 }
 }  // namespace domain::creators

--- a/src/Domain/Creators/Cylinder.hpp
+++ b/src/Domain/Creators/Cylinder.hpp
@@ -20,8 +20,7 @@
 /// \cond
 namespace domain {
 namespace CoordinateMaps {
-class Affine;
-class Equiangular;
+class Interval;
 template <typename Map1, typename Map2>
 class ProductOf2Maps;
 template <typename Map1, typename Map2, typename Map3>
@@ -48,20 +47,16 @@ namespace domain::creators {
 /// \image html Cylinder.png "The Cylinder Domain."
 class Cylinder : public DomainCreator<3> {
  public:
-  using maps_list = tmpl::list<
-      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
-                            CoordinateMaps::ProductOf3Maps<
-                                CoordinateMaps::Affine, CoordinateMaps::Affine,
-                                CoordinateMaps::Affine>>,
-      domain::CoordinateMap<
-          Frame::BlockLogical, Frame::Inertial,
-          CoordinateMaps::ProductOf3Maps<CoordinateMaps::Equiangular,
-                                         CoordinateMaps::Equiangular,
-                                         CoordinateMaps::Affine>>,
-      domain::CoordinateMap<
-          Frame::BlockLogical, Frame::Inertial,
-          CoordinateMaps::ProductOf2Maps<CoordinateMaps::Wedge<2>,
-                                         CoordinateMaps::Affine>>>;
+  using maps_list =
+      tmpl::list<domain::CoordinateMap<
+                     Frame::BlockLogical, Frame::Inertial,
+                     CoordinateMaps::ProductOf3Maps<CoordinateMaps::Interval,
+                                                    CoordinateMaps::Interval,
+                                                    CoordinateMaps::Interval>>,
+                 domain::CoordinateMap<
+                     Frame::BlockLogical, Frame::Inertial,
+                     CoordinateMaps::ProductOf2Maps<CoordinateMaps::Wedge<2>,
+                                                    CoordinateMaps::Interval>>>;
 
   struct InnerRadius {
     using type = double;

--- a/src/Domain/Creators/Cylinder.hpp
+++ b/src/Domain/Creators/Cylinder.hpp
@@ -129,7 +129,7 @@ class Cylinder : public DomainCreator<3> {
   struct PartitioningInZ {
     using type = std::vector<double>;
     static constexpr Options::String help = {
-        "z-coordinates of the boundaries splitting the domain into discs "
+        "z-coordinates of the boundaries splitting the domain into layers "
         "between LowerZBound and UpperZBound."};
   };
 
@@ -140,6 +140,17 @@ class Cylinder : public DomainCreator<3> {
         "shell. The innermost shell must have a 'Linear' distribution because "
         "it changes in circularity. The 'RadialPartitioning' determines the "
         "number of shells."};
+    static size_t lower_bound_on_size() noexcept { return 1; }
+  };
+
+  struct DistributionInZ {
+    using type = std::vector<domain::CoordinateMaps::Distribution>;
+    static constexpr Options::String help = {
+        "Select the distribution of grid points along the z-axis in each "
+        "layer. The lowermost layer must have a 'Linear' distribution, because "
+        "both a 'Logarithmic' and 'Inverse' distribution places its "
+        "singularity at 'LowerZBound'. The 'PartitioningInZ' determines the "
+        "number of layers."};
     static size_t lower_bound_on_size() noexcept { return 1; }
   };
 
@@ -196,14 +207,15 @@ class Cylinder : public DomainCreator<3> {
                       typename Metavariables::system>>>,
           tmpl::list<IsPeriodicInZ>>,
       tmpl::list<InitialRefinement, InitialGridPoints, UseEquiangularMap,
-                 RadialPartitioning, PartitioningInZ, RadialDistribution>>;
+                 RadialPartitioning, PartitioningInZ, RadialDistribution,
+                 DistributionInZ>>;
 
   static constexpr Options::String help{
       "Creates a right circular Cylinder with a square prism surrounded by \n"
       "wedges. \n"
       "The cylinder can be partitioned radially into multiple cylindrical \n"
       "shells as well as partitioned along the cylinder's height into \n"
-      "multiple disks. Including this partitioning, the number of Blocks is \n"
+      "multiple layers. Including this partitioning, the number of Blocks is \n"
       "given by (1 + 4*(1+n_s)) * (1+n_z), where n_s is the \n"
       "length of RadialPartitioning and n_z the length of \n"
       "HeightPartitioning. The block numbering starts at the inner square \n"
@@ -229,6 +241,8 @@ class Cylinder : public DomainCreator<3> {
       std::vector<double> partitioning_in_z = {},
       std::vector<domain::CoordinateMaps::Distribution> radial_distribution =
           {domain::CoordinateMaps::Distribution::Linear},
+      std::vector<domain::CoordinateMaps::Distribution> distribution_in_z =
+          {domain::CoordinateMaps::Distribution::Linear},
       const Options::Context& context = {});
 
   Cylinder(
@@ -245,6 +259,8 @@ class Cylinder : public DomainCreator<3> {
       bool use_equiangular_map, std::vector<double> radial_partitioning = {},
       std::vector<double> partitioning_in_z = {},
       std::vector<domain::CoordinateMaps::Distribution> radial_distribution =
+          {domain::CoordinateMaps::Distribution::Linear},
+      std::vector<domain::CoordinateMaps::Distribution> distribution_in_z =
           {domain::CoordinateMaps::Distribution::Linear},
       const Options::Context& context = {});
 
@@ -274,6 +290,7 @@ class Cylinder : public DomainCreator<3> {
   std::vector<double> radial_partitioning_{};
   std::vector<double> partitioning_in_z_{};
   std::vector<domain::CoordinateMaps::Distribution> radial_distribution_{};
+  std::vector<domain::CoordinateMaps::Distribution> distribution_in_z_{};
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
       lower_z_boundary_condition_{};
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>

--- a/src/Domain/Creators/Cylinder.hpp
+++ b/src/Domain/Creators/Cylinder.hpp
@@ -71,13 +71,13 @@ class Cylinder : public DomainCreator<3> {
     static double lower_bound() noexcept { return 0.; }
   };
 
-  struct LowerBound {
+  struct LowerZBound {
     using type = double;
     static constexpr Options::String help = {
         "z-coordinate of the base of the cylinder."};
   };
 
-  struct UpperBound {
+  struct UpperZBound {
     using type = double;
     static constexpr Options::String help = {
         "z-coordinate of the top of the cylinder."};
@@ -126,11 +126,11 @@ class Cylinder : public DomainCreator<3> {
         "between InnerRadius and OuterRadius."};
   };
 
-  struct HeightPartitioning {
+  struct PartitioningInZ {
     using type = std::vector<double>;
     static constexpr Options::String help = {
         "z-coordinates of the boundaries splitting the domain into discs "
-        "between LowerBound and UpperBound."};
+        "between LowerZBound and UpperZBound."};
   };
 
   struct RadialDistribution {
@@ -149,22 +149,22 @@ class Cylinder : public DomainCreator<3> {
   };
 
   template <typename BoundaryConditionsBase>
-  struct LowerBoundaryCondition {
+  struct LowerZBoundaryCondition {
     using group = BoundaryConditions;
-    static std::string name() noexcept { return "Lower"; }
+    static std::string name() noexcept { return "LowerZ"; }
     static constexpr Options::String help =
         "The boundary condition to be imposed on the lower base of the "
-        "cylinder, i.e. at the `LowerBound` in the z-direction.";
+        "cylinder, i.e. at the `LowerZBound` in the z-direction.";
     using type = std::unique_ptr<BoundaryConditionsBase>;
   };
 
   template <typename BoundaryConditionsBase>
-  struct UpperBoundaryCondition {
+  struct UpperZBoundaryCondition {
     using group = BoundaryConditions;
-    static std::string name() noexcept { return "Upper"; }
+    static std::string name() noexcept { return "UpperZ"; }
     static constexpr Options::String help =
         "The boundary condition to be imposed on the upper base of the "
-        "cylinder, i.e. at the `UpperBound` in the z-direction.";
+        "cylinder, i.e. at the `UpperZBound` in the z-direction.";
     using type = std::unique_ptr<BoundaryConditionsBase>;
   };
 
@@ -180,15 +180,15 @@ class Cylinder : public DomainCreator<3> {
 
   template <typename Metavariables>
   using options = tmpl::append<
-      tmpl::list<InnerRadius, OuterRadius, LowerBound, UpperBound>,
+      tmpl::list<InnerRadius, OuterRadius, LowerZBound, UpperZBound>,
       tmpl::conditional_t<
           domain::BoundaryConditions::has_boundary_conditions_base_v<
               typename Metavariables::system>,
           tmpl::list<
-              LowerBoundaryCondition<
+              LowerZBoundaryCondition<
                   domain::BoundaryConditions::get_boundary_conditions_base<
                       typename Metavariables::system>>,
-              UpperBoundaryCondition<
+              UpperZBoundaryCondition<
                   domain::BoundaryConditions::get_boundary_conditions_base<
                       typename Metavariables::system>>,
               MantleBoundaryCondition<
@@ -196,7 +196,7 @@ class Cylinder : public DomainCreator<3> {
                       typename Metavariables::system>>>,
           tmpl::list<IsPeriodicInZ>>,
       tmpl::list<InitialRefinement, InitialGridPoints, UseEquiangularMap,
-                 RadialPartitioning, HeightPartitioning, RadialDistribution>>;
+                 RadialPartitioning, PartitioningInZ, RadialDistribution>>;
 
   static constexpr Options::String help{
       "Creates a right circular Cylinder with a square prism surrounded by \n"
@@ -221,29 +221,29 @@ class Cylinder : public DomainCreator<3> {
       "spacings in the center block."};
 
   Cylinder(
-      double inner_radius, double outer_radius, double lower_bound,
-      double upper_bound, bool is_periodic_in_z,
+      double inner_radius, double outer_radius, double lower_z_bound,
+      double upper_z_bound, bool is_periodic_in_z,
       const typename InitialRefinement::type& initial_refinement,
       const typename InitialGridPoints::type& initial_number_of_grid_points,
       bool use_equiangular_map, std::vector<double> radial_partitioning = {},
-      std::vector<double> height_partitioning = {},
+      std::vector<double> partitioning_in_z = {},
       std::vector<domain::CoordinateMaps::Distribution> radial_distribution =
           {domain::CoordinateMaps::Distribution::Linear},
       const Options::Context& context = {});
 
   Cylinder(
-      double inner_radius, double outer_radius, double lower_bound,
-      double upper_bound,
+      double inner_radius, double outer_radius, double lower_z_bound,
+      double upper_z_bound,
       std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
-          lower_boundary_condition,
+          lower_z_boundary_condition,
       std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
-          upper_boundary_condition,
+          upper_z_boundary_condition,
       std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
           mantle_boundary_condition,
       const typename InitialRefinement::type& initial_refinement,
       const typename InitialGridPoints::type& initial_number_of_grid_points,
       bool use_equiangular_map, std::vector<double> radial_partitioning = {},
-      std::vector<double> height_partitioning = {},
+      std::vector<double> partitioning_in_z = {},
       std::vector<domain::CoordinateMaps::Distribution> radial_distribution =
           {domain::CoordinateMaps::Distribution::Linear},
       const Options::Context& context = {});
@@ -265,19 +265,19 @@ class Cylinder : public DomainCreator<3> {
  private:
   double inner_radius_{std::numeric_limits<double>::signaling_NaN()};
   double outer_radius_{std::numeric_limits<double>::signaling_NaN()};
-  double lower_bound_{std::numeric_limits<double>::signaling_NaN()};
-  double upper_bound_{std::numeric_limits<double>::signaling_NaN()};
+  double lower_z_bound_{std::numeric_limits<double>::signaling_NaN()};
+  double upper_z_bound_{std::numeric_limits<double>::signaling_NaN()};
   bool is_periodic_in_z_{true};
   std::vector<std::array<size_t, 3>> initial_refinement_{};
   std::vector<std::array<size_t, 3>> initial_number_of_grid_points_{};
   bool use_equiangular_map_{false};
   std::vector<double> radial_partitioning_{};
-  std::vector<double> height_partitioning_{};
+  std::vector<double> partitioning_in_z_{};
   std::vector<domain::CoordinateMaps::Distribution> radial_distribution_{};
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
-      lower_boundary_condition_{};
+      lower_z_boundary_condition_{};
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
-      upper_boundary_condition_{};
+      upper_z_boundary_condition_{};
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
       mantle_boundary_condition_{};
 };

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
@@ -6,7 +6,6 @@
 #include <cmath>
 
 #include "Domain/BoundaryConditions/Periodic.hpp"
-#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/CylindricalEndcap.hpp"
@@ -14,6 +13,7 @@
 #include "Domain/CoordinateMaps/CylindricalFlatSide.hpp"
 #include "Domain/CoordinateMaps/CylindricalSide.hpp"
 #include "Domain/CoordinateMaps/DiscreteRotation.hpp"
+#include "Domain/CoordinateMaps/Interval.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/Wedge.hpp"
@@ -359,17 +359,17 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const noexcept {
   const double cylinder_lower_bound_z = -1.0;
   const double cylinder_upper_bound_z = 1.0;
   const auto logical_to_cylinder_center_maps =
-      cyl_wedge_coord_map_center_blocks<false>(cylinder_inner_radius,
-                                               cylinder_lower_bound_z,
-                                               cylinder_upper_bound_z);
+      cyl_wedge_coord_map_center_blocks(cylinder_inner_radius,
+                                        cylinder_lower_bound_z,
+                                        cylinder_upper_bound_z, false);
   const auto logical_to_cylinder_surrounding_maps =
       cyl_wedge_coord_map_surrounding_blocks(
           cylinder_inner_radius, cylinder_outer_radius, cylinder_lower_bound_z,
           cylinder_upper_bound_z, false, 0.0);
   const auto logical_to_cylinder_center_maps_flip_z =
-      cyl_wedge_coord_map_center_blocks<false>(
+      cyl_wedge_coord_map_center_blocks(
           cylinder_inner_radius, cylinder_lower_bound_z, cylinder_upper_bound_z,
-          {}, CylindricalDomainParityFlip::z_direction);
+          false, {}, CylindricalDomainParityFlip::z_direction);
   const auto logical_to_cylinder_surrounding_maps_flip_z =
       cyl_wedge_coord_map_surrounding_blocks(
           cylinder_inner_radius, cylinder_outer_radius, cylinder_lower_bound_z,

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
@@ -369,11 +369,13 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const noexcept {
   const auto logical_to_cylinder_center_maps_flip_z =
       cyl_wedge_coord_map_center_blocks(
           cylinder_inner_radius, cylinder_lower_bound_z, cylinder_upper_bound_z,
-          false, {}, CylindricalDomainParityFlip::z_direction);
+          false, {}, {domain::CoordinateMaps::Distribution::Linear},
+          CylindricalDomainParityFlip::z_direction);
   const auto logical_to_cylinder_surrounding_maps_flip_z =
       cyl_wedge_coord_map_surrounding_blocks(
           cylinder_inner_radius, cylinder_outer_radius, cylinder_lower_bound_z,
           cylinder_upper_bound_z, false, 0.0, {}, {},
+          {domain::CoordinateMaps::Distribution::Linear},
           {domain::CoordinateMaps::Distribution::Linear},
           CylindricalDomainParityFlip::z_direction);
 
@@ -515,6 +517,7 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const noexcept {
           cylindrical_shell_inner_radius, cylindrical_shell_outer_radius,
           cylindrical_shell_lower_bound_z, cylindrical_shell_upper_bound_z,
           false, 1.0, {}, {}, {domain::CoordinateMaps::Distribution::Linear},
+          {domain::CoordinateMaps::Distribution::Linear},
           CylindricalDomainParityFlip::z_direction);
 
   // Lambda that takes a CylindricalSide map and a DiscreteRotation

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
@@ -23,7 +23,7 @@
 /// \cond
 namespace domain {
 namespace CoordinateMaps {
-class Affine;
+class Interval;
 template <typename Map1, typename Map2>
 class ProductOf2Maps;
 template <typename Map1, typename Map2, typename Map3>
@@ -115,43 +115,45 @@ namespace domain::creators {
  */
 class CylindricalBinaryCompactObject : public DomainCreator<3> {
  public:
-  using maps_list = tmpl::list<
-      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
-                            CoordinateMaps::ProductOf3Maps<
-                                CoordinateMaps::Affine, CoordinateMaps::Affine,
-                                CoordinateMaps::Affine>,
-                            CoordinateMaps::CylindricalEndcap,
-                            CoordinateMaps::DiscreteRotation<3>>,
-      domain::CoordinateMap<
-          Frame::BlockLogical, Frame::Inertial,
-          CoordinateMaps::ProductOf2Maps<CoordinateMaps::Wedge<2>,
-                                         CoordinateMaps::Affine>,
-          CoordinateMaps::CylindricalEndcap,
-          CoordinateMaps::DiscreteRotation<3>>,
-      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
-                            CoordinateMaps::ProductOf3Maps<
-                                CoordinateMaps::Affine, CoordinateMaps::Affine,
-                                CoordinateMaps::Affine>,
-                            CoordinateMaps::CylindricalFlatEndcap,
-                            CoordinateMaps::DiscreteRotation<3>>,
-      domain::CoordinateMap<
-          Frame::BlockLogical, Frame::Inertial,
-          CoordinateMaps::ProductOf2Maps<CoordinateMaps::Wedge<2>,
-                                         CoordinateMaps::Affine>,
-          CoordinateMaps::CylindricalFlatEndcap,
-          CoordinateMaps::DiscreteRotation<3>>,
-      domain::CoordinateMap<
-          Frame::BlockLogical, Frame::Inertial,
-          CoordinateMaps::ProductOf2Maps<CoordinateMaps::Wedge<2>,
-                                         CoordinateMaps::Affine>,
-          CoordinateMaps::CylindricalFlatSide,
-          CoordinateMaps::DiscreteRotation<3>>,
-      domain::CoordinateMap<
-          Frame::BlockLogical, Frame::Inertial,
-          CoordinateMaps::ProductOf2Maps<CoordinateMaps::Wedge<2>,
-                                         CoordinateMaps::Affine>,
-          CoordinateMaps::CylindricalSide,
-          CoordinateMaps::DiscreteRotation<3>>>;
+  using maps_list =
+      tmpl::list<domain::CoordinateMap<
+                     Frame::BlockLogical, Frame::Inertial,
+                     CoordinateMaps::ProductOf3Maps<CoordinateMaps::Interval,
+                                                    CoordinateMaps::Interval,
+                                                    CoordinateMaps::Interval>,
+                     CoordinateMaps::CylindricalEndcap,
+                     CoordinateMaps::DiscreteRotation<3>>,
+                 domain::CoordinateMap<
+                     Frame::BlockLogical, Frame::Inertial,
+                     CoordinateMaps::ProductOf2Maps<CoordinateMaps::Wedge<2>,
+                                                    CoordinateMaps::Interval>,
+                     CoordinateMaps::CylindricalEndcap,
+                     CoordinateMaps::DiscreteRotation<3>>,
+                 domain::CoordinateMap<
+                     Frame::BlockLogical, Frame::Inertial,
+                     CoordinateMaps::ProductOf3Maps<CoordinateMaps::Interval,
+                                                    CoordinateMaps::Interval,
+                                                    CoordinateMaps::Interval>,
+                     CoordinateMaps::CylindricalFlatEndcap,
+                     CoordinateMaps::DiscreteRotation<3>>,
+                 domain::CoordinateMap<
+                     Frame::BlockLogical, Frame::Inertial,
+                     CoordinateMaps::ProductOf2Maps<CoordinateMaps::Wedge<2>,
+                                                    CoordinateMaps::Interval>,
+                     CoordinateMaps::CylindricalFlatEndcap,
+                     CoordinateMaps::DiscreteRotation<3>>,
+                 domain::CoordinateMap<
+                     Frame::BlockLogical, Frame::Inertial,
+                     CoordinateMaps::ProductOf2Maps<CoordinateMaps::Wedge<2>,
+                                                    CoordinateMaps::Interval>,
+                     CoordinateMaps::CylindricalFlatSide,
+                     CoordinateMaps::DiscreteRotation<3>>,
+                 domain::CoordinateMap<
+                     Frame::BlockLogical, Frame::Inertial,
+                     CoordinateMaps::ProductOf2Maps<CoordinateMaps::Wedge<2>,
+                                                    CoordinateMaps::Interval>,
+                     CoordinateMaps::CylindricalSide,
+                     CoordinateMaps::DiscreteRotation<3>>>;
 
   struct CenterA {
     using type = std::array<double, 3>;

--- a/src/Domain/Creators/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/Creators/RegisterDerivedWithCharm.cpp
@@ -16,6 +16,7 @@
 #include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/Frustum.hpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/Interval.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/TimeDependent/CubicScale.hpp"

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -938,9 +938,9 @@ std::vector<domain::CoordinateMaps::ProductOf3Maps<
     domain::CoordinateMaps::Interval, domain::CoordinateMaps::Interval,
     domain::CoordinateMaps::Interval>>
 cyl_wedge_coord_map_center_blocks(
-    const double inner_radius, const double lower_bound,
-    const double upper_bound, const bool use_equiangular_map,
-    const std::vector<double>& height_partitioning,
+    const double inner_radius, const double lower_z_bound,
+    const double upper_z_bound, const bool use_equiangular_map,
+    const std::vector<double>& partitioning_in_z,
     const CylindricalDomainParityFlip parity_flip) noexcept {
   using Interval = domain::CoordinateMaps::Interval;
   using Interval3D =
@@ -950,16 +950,16 @@ cyl_wedge_coord_map_center_blocks(
       parity_flip == CylindricalDomainParityFlip::z_direction ? 1.0 : -1.0;
   const double upper_logical_zeta =
       parity_flip == CylindricalDomainParityFlip::z_direction ? -1.0 : 1.0;
-  double temp_lower_bound = lower_bound;
-  double temp_upper_bound{};
+  double temp_lower_z_bound = lower_z_bound;
+  double temp_upper_z_bound{};
   const auto angular_distribution =
       use_equiangular_map ? domain::CoordinateMaps::Distribution::Equiangular
                           : domain::CoordinateMaps::Distribution::Linear;
-  for (size_t layer = 0; layer < 1 + height_partitioning.size(); layer++) {
-    if (layer != height_partitioning.size()) {
-      temp_upper_bound = height_partitioning.at(layer);
+  for (size_t layer = 0; layer < 1 + partitioning_in_z.size(); layer++) {
+    if (layer != partitioning_in_z.size()) {
+      temp_upper_z_bound = partitioning_in_z.at(layer);
     } else {
-      temp_upper_bound = upper_bound;
+      temp_upper_z_bound = upper_z_bound;
     }
     maps.emplace_back(
         Interval3D{Interval(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
@@ -967,11 +967,11 @@ cyl_wedge_coord_map_center_blocks(
                    Interval(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
                             inner_radius / sqrt(2.0), angular_distribution),
                    Interval{lower_logical_zeta, upper_logical_zeta,
-                            temp_lower_bound, temp_upper_bound,
+                            temp_lower_z_bound, temp_upper_z_bound,
                             domain::CoordinateMaps::Distribution::Linear}});
 
-    if (layer != height_partitioning.size()) {
-      temp_lower_bound = height_partitioning.at(layer);
+    if (layer != partitioning_in_z.size()) {
+      temp_lower_z_bound = partitioning_in_z.at(layer);
     }
   }
   return maps;
@@ -981,10 +981,10 @@ std::vector<domain::CoordinateMaps::ProductOf2Maps<
     domain::CoordinateMaps::Wedge<2>, domain::CoordinateMaps::Interval>>
 cyl_wedge_coord_map_surrounding_blocks(
     const double inner_radius, const double outer_radius,
-    const double lower_bound, const double upper_bound,
+    const double lower_z_bound, const double upper_z_bound,
     const bool use_equiangular_map, const double inner_circularity,
     const std::vector<double>& radial_partitioning,
-    const std::vector<double>& height_partitioning,
+    const std::vector<double>& partitioning_in_z,
     const std::vector<domain::CoordinateMaps::Distribution>&
         radial_distribution,
     const CylindricalDomainParityFlip parity_flip) noexcept {
@@ -1005,25 +1005,25 @@ cyl_wedge_coord_map_surrounding_blocks(
   double temp_inner_circularity{};
   double temp_inner_radius{};
   double temp_outer_radius{};
-  double temp_lower_bound = lower_bound;
-  double temp_upper_bound{};
+  double temp_lower_z_bound = lower_z_bound;
+  double temp_upper_z_bound{};
   const auto use_both_halves = Wedge2D::WedgeHalves::Both;
   const std::array<OrientationMap<2>, 4> wedge_orientations = {
       OrientationMap<2>{std::array<Direction<2>, 2>{
-          {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}},  // east
+          {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}},  //+x wedge
       OrientationMap<2>{std::array<Direction<2>, 2>{
-          {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}},  // north
+          {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}},  //+y wedge
       OrientationMap<2>{std::array<Direction<2>, 2>{
-          {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}},  // west
+          {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}},  //-x wedge
       OrientationMap<2>{std::array<Direction<2>, 2>{
-          {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}}  // south
+          {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}}  //-y wedge
   };
-  for (size_t layer = 0; layer < 1 + height_partitioning.size(); layer++) {
+  for (size_t layer = 0; layer < 1 + partitioning_in_z.size(); layer++) {
     temp_inner_radius = inner_radius;
-    if (layer != height_partitioning.size()) {
-      temp_upper_bound = height_partitioning.at(layer);
+    if (layer != partitioning_in_z.size()) {
+      temp_upper_z_bound = partitioning_in_z.at(layer);
     } else {
-      temp_upper_bound = upper_bound;
+      temp_upper_z_bound = upper_z_bound;
     }
     temp_inner_circularity = inner_circularity;
     for (size_t shell = 0; shell < 1 + radial_partitioning.size(); shell++) {
@@ -1037,7 +1037,7 @@ cyl_wedge_coord_map_surrounding_blocks(
       auto z_map = Interval{
           parity_flip == CylindricalDomainParityFlip::z_direction ? 1.0 : -1.0,
           parity_flip == CylindricalDomainParityFlip::z_direction ? -1.0 : 1.0,
-          temp_lower_bound, temp_upper_bound,
+          temp_lower_z_bound, temp_upper_z_bound,
           domain::CoordinateMaps::Distribution::Linear};
       for (const auto& cardinal_direction : wedge_orientations) {
         maps.emplace_back(Wedge3DPrism{
@@ -1052,8 +1052,8 @@ cyl_wedge_coord_map_surrounding_blocks(
         temp_inner_radius = radial_partitioning.at(shell);
       }
     }
-    if (layer != height_partitioning.size()) {
-      temp_lower_bound = height_partitioning.at(layer);
+    if (layer != partitioning_in_z.size()) {
+      temp_lower_z_bound = partitioning_in_z.at(layer);
     }
   }
   return maps;
@@ -1064,29 +1064,29 @@ std::vector<std::unique_ptr<
     domain::CoordinateMapBase<Frame::BlockLogical, TargetFrame, 3>>>
 cyl_wedge_coordinate_maps(
     const double inner_radius, const double outer_radius,
-    const double lower_bound, const double upper_bound,
+    const double lower_z_bound, const double upper_z_bound,
     const bool use_equiangular_map,
     const std::vector<double>& radial_partitioning,
-    const std::vector<double>& height_partitioning,
+    const std::vector<double>& partitioning_in_z,
     const std::vector<domain::CoordinateMaps::Distribution>&
         radial_distribution) noexcept {
   std::vector<std::unique_ptr<
       domain::CoordinateMapBase<Frame::BlockLogical, TargetFrame, 3>>>
       cylinder_mapping;
   const auto maps_surrounding = cyl_wedge_coord_map_surrounding_blocks(
-      inner_radius, outer_radius, lower_bound, upper_bound, use_equiangular_map,
-      0.0, radial_partitioning, height_partitioning, radial_distribution,
-      CylindricalDomainParityFlip::none);
+      inner_radius, outer_radius, lower_z_bound, upper_z_bound,
+      use_equiangular_map, 0.0, radial_partitioning, partitioning_in_z,
+      radial_distribution, CylindricalDomainParityFlip::none);
 
   // add_to_cylinder_mapping adds the maps for individual blocks in
   // the correct order.  This order is a center block at each height
   // partition and then the surrounding blocks at that height
   // partition.
-  auto add_to_cylinder_mapping = [&cylinder_mapping, &height_partitioning,
+  auto add_to_cylinder_mapping = [&cylinder_mapping, &partitioning_in_z,
                                   &radial_partitioning, &maps_surrounding](
                                      const auto& maps_center) noexcept {
     size_t surrounding_block_index = 0;
-    for (size_t height = 0; height < 1 + height_partitioning.size(); ++height) {
+    for (size_t height = 0; height < 1 + partitioning_in_z.size(); ++height) {
       cylinder_mapping.emplace_back(
           domain::make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
               maps_center.at(height)));
@@ -1105,8 +1105,8 @@ cyl_wedge_coordinate_maps(
   };
 
   add_to_cylinder_mapping(cyl_wedge_coord_map_center_blocks(
-      inner_radius, lower_bound, upper_bound, use_equiangular_map,
-      height_partitioning, CylindricalDomainParityFlip::none));
+      inner_radius, lower_z_bound, upper_z_bound, use_equiangular_map,
+      partitioning_in_z, CylindricalDomainParityFlip::none));
   return cylinder_mapping;
 }
 
@@ -1449,20 +1449,20 @@ template std::vector<std::unique_ptr<
     domain::CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 3>>>
 cyl_wedge_coordinate_maps(
     const double inner_radius, const double outer_radius,
-    const double lower_bound, const double upper_bound,
+    const double lower_z_bound, const double upper_z_bound,
     const bool use_equiangular_map,
     const std::vector<double>& radial_partitioning,
-    const std::vector<double>& height_partitioning,
+    const std::vector<double>& partitioning_in_z,
     const std::vector<domain::CoordinateMaps::Distribution>&
         radial_distribution) noexcept;
 template std::vector<std::unique_ptr<
     domain::CoordinateMapBase<Frame::BlockLogical, Frame::Grid, 3>>>
 cyl_wedge_coordinate_maps(
     const double inner_radius, const double outer_radius,
-    const double lower_bound, const double upper_bound,
+    const double lower_z_bound, const double upper_z_bound,
     const bool use_equiangular_map,
     const std::vector<double>& radial_partitioning,
-    const std::vector<double>& height_partitioning,
+    const std::vector<double>& partitioning_in_z,
     const std::vector<domain::CoordinateMaps::Distribution>&
         radial_distribution) noexcept;
 // Explicit instantiations

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -230,7 +230,8 @@ std::vector<std::array<size_t, 8>> corners_for_biradially_layered_domains(
 /// Set the `radial_distribution` to select the radial distribution of grid
 /// points in the cylindrical shells. The innermost shell must have
 /// `domain::CoordinateMaps::Distribution::Linear` because it changes the
-/// circularity.
+/// circularity. The distribution along the z-axis for each circular
+/// disc is specified through `distribution_in_z`.
 template <typename TargetFrame>
 auto cyl_wedge_coordinate_maps(
     double inner_radius, double outer_radius, double lower_z_bound,
@@ -238,8 +239,9 @@ auto cyl_wedge_coordinate_maps(
     const std::vector<double>& radial_partitioning = {},
     const std::vector<double>& partitioning_in_z = {},
     const std::vector<domain::CoordinateMaps::Distribution>&
-        radial_distribution =
-            {domain::CoordinateMaps::Distribution::Linear}) noexcept
+        radial_distribution = {domain::CoordinateMaps::Distribution::Linear},
+    const std::vector<domain::CoordinateMaps::Distribution>& distribution_in_z =
+        {domain::CoordinateMaps::Distribution::Linear}) noexcept
     -> std::vector<std::unique_ptr<
         domain::CoordinateMapBase<Frame::BlockLogical, TargetFrame, 3>>>;
 
@@ -262,6 +264,8 @@ enum class CylindricalDomainParityFlip { none, z_direction };
 auto cyl_wedge_coord_map_center_blocks(
     double inner_radius, double lower_z_bound, double upper_z_bound,
     bool use_equiangular_map, const std::vector<double>& partitioning_in_z = {},
+    const std::vector<domain::CoordinateMaps::Distribution>& distribution_in_z =
+        {domain::CoordinateMaps::Distribution::Linear},
     CylindricalDomainParityFlip parity_flip =
         CylindricalDomainParityFlip::none) noexcept
     -> std::vector<domain::CoordinateMaps::ProductOf3Maps<
@@ -289,6 +293,8 @@ auto cyl_wedge_coord_map_surrounding_blocks(
     const std::vector<double>& partitioning_in_z = {},
     const std::vector<domain::CoordinateMaps::Distribution>&
         radial_distribution = {domain::CoordinateMaps::Distribution::Linear},
+    const std::vector<domain::CoordinateMaps::Distribution>& distribution_in_z =
+        {domain::CoordinateMaps::Distribution::Linear},
     CylindricalDomainParityFlip parity_flip =
         CylindricalDomainParityFlip::none) noexcept
     -> std::vector<domain::CoordinateMaps::ProductOf2Maps<

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -222,7 +222,7 @@ std::vector<std::array<size_t, 8>> corners_for_biradially_layered_domains(
 /// These are the CoordinateMaps used in the Cylinder DomainCreator.
 ///
 /// The `radial_partitioning` specifies the radial boundaries of sub-shells
-/// between `inner_radius` and `outer_radius`, while `height_partitioning`
+/// between `inner_radius` and `outer_radius`, while `partitioning_in_z`
 /// specifies the z-boundaries, splitting the cylinder into stacked
 /// 3-dimensional disks. The circularity of the shell wedges changes from 0 to 1
 /// within the innermost sub-shell.
@@ -233,10 +233,10 @@ std::vector<std::array<size_t, 8>> corners_for_biradially_layered_domains(
 /// circularity.
 template <typename TargetFrame>
 auto cyl_wedge_coordinate_maps(
-    double inner_radius, double outer_radius, double lower_bound,
-    double upper_bound, bool use_equiangular_map,
+    double inner_radius, double outer_radius, double lower_z_bound,
+    double upper_z_bound, bool use_equiangular_map,
     const std::vector<double>& radial_partitioning = {},
-    const std::vector<double>& height_partitioning = {},
+    const std::vector<double>& partitioning_in_z = {},
     const std::vector<domain::CoordinateMaps::Distribution>&
         radial_distribution =
             {domain::CoordinateMaps::Distribution::Linear}) noexcept
@@ -249,8 +249,8 @@ enum class CylindricalDomainParityFlip { none, z_direction };
 /// Same as `cyl_wedge_coordinate_maps`, but only the center square blocks,
 ///
 /// If `CylindricalDomainParityFlip::z_direction` is specified, then
-/// the returned maps describe a cylinder with `lower_bound`
-/// corresponding to logical coordinate `upper_zeta` and `upper_bound`
+/// the returned maps describe a cylinder with `lower_z_bound`
+/// corresponding to logical coordinate `upper_zeta` and `upper_z_bound`
 /// corresponding to logical coordinate `lower_zeta`, and thus the
 /// resulting maps are left-handed.
 /// `CylindricalDomainParityFlip::z_direction` is therefore useful
@@ -260,9 +260,8 @@ enum class CylindricalDomainParityFlip { none, z_direction };
 /// Returned as a vector of the coordinate maps so that they can
 /// be composed with other maps later.
 auto cyl_wedge_coord_map_center_blocks(
-    double inner_radius, double lower_bound, double upper_bound,
-    bool use_equiangular_map,
-    const std::vector<double>& height_partitioning = {},
+    double inner_radius, double lower_z_bound, double upper_z_bound,
+    bool use_equiangular_map, const std::vector<double>& partitioning_in_z = {},
     CylindricalDomainParityFlip parity_flip =
         CylindricalDomainParityFlip::none) noexcept
     -> std::vector<domain::CoordinateMaps::ProductOf3Maps<
@@ -273,8 +272,8 @@ auto cyl_wedge_coord_map_center_blocks(
 /// Same as cyl_wedge_coordinate_maps, but only the surrounding wedge blocks.
 ///
 /// If `CylindricalDomainParityFlip::z_direction` is specified, then
-/// the returned maps describe a cylinder with `lower_bound`
-/// corresponding to logical coordinate `upper_zeta` and `upper_bound`
+/// the returned maps describe a cylinder with `lower_z_bound`
+/// corresponding to logical coordinate `upper_zeta` and `upper_z_bound`
 /// corresponding to logical coordinate `lower_zeta`, and thus the
 /// resulting maps are left-handed.
 /// `CylindricalDomainParityFlip::z_direction` is therefore useful
@@ -284,10 +283,10 @@ auto cyl_wedge_coord_map_center_blocks(
 /// Returned as a vector of the coordinate maps so that they can
 /// be composed with other maps later.
 auto cyl_wedge_coord_map_surrounding_blocks(
-    double inner_radius, double outer_radius, double lower_bound,
-    double upper_bound, bool use_equiangular_map, double inner_circularity,
+    double inner_radius, double outer_radius, double lower_z_bound,
+    double upper_z_bound, bool use_equiangular_map, double inner_circularity,
     const std::vector<double>& radial_partitioning = {},
-    const std::vector<double>& height_partitioning = {},
+    const std::vector<double>& partitioning_in_z = {},
     const std::vector<domain::CoordinateMaps::Distribution>&
         radial_distribution = {domain::CoordinateMaps::Distribution::Linear},
     CylindricalDomainParityFlip parity_flip =

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -42,13 +42,12 @@ template <typename T>
 struct create_from_yaml;
 }  // namespace Options
 namespace domain::CoordinateMaps {
-template<typename Map1, typename Map2>
+template <typename Map1, typename Map2>
 class ProductOf2Maps;
-template<typename Map1, typename Map2, typename Map3>
+template <typename Map1, typename Map2, typename Map3>
 class ProductOf3Maps;
-class Affine;
-class Equiangular;
-template<size_t Dim>
+class Interval;
+template <size_t Dim>
 class Wedge;
 }  // namespace domain::CoordinateMaps
 /// \endcond
@@ -260,21 +259,15 @@ enum class CylindricalDomainParityFlip { none, z_direction };
 ///
 /// Returned as a vector of the coordinate maps so that they can
 /// be composed with other maps later.
-template <bool UseEquiangularMap>
 auto cyl_wedge_coord_map_center_blocks(
     double inner_radius, double lower_bound, double upper_bound,
+    bool use_equiangular_map,
     const std::vector<double>& height_partitioning = {},
     CylindricalDomainParityFlip parity_flip =
         CylindricalDomainParityFlip::none) noexcept
-    -> tmpl::conditional_t<
-        UseEquiangularMap,
-        std::vector<domain::CoordinateMaps::ProductOf3Maps<
-            domain::CoordinateMaps::Equiangular,
-            domain::CoordinateMaps::Equiangular,
-            domain::CoordinateMaps::Affine>>,
-        std::vector<domain::CoordinateMaps::ProductOf3Maps<
-            domain::CoordinateMaps::Affine, domain::CoordinateMaps::Affine,
-            domain::CoordinateMaps::Affine>>>;
+    -> std::vector<domain::CoordinateMaps::ProductOf3Maps<
+        domain::CoordinateMaps::Interval, domain::CoordinateMaps::Interval,
+        domain::CoordinateMaps::Interval>>;
 
 /// \ingroup ComputationalDomainGroup
 /// Same as cyl_wedge_coordinate_maps, but only the surrounding wedge blocks.
@@ -300,7 +293,7 @@ auto cyl_wedge_coord_map_surrounding_blocks(
     CylindricalDomainParityFlip parity_flip =
         CylindricalDomainParityFlip::none) noexcept
     -> std::vector<domain::CoordinateMaps::ProductOf2Maps<
-        domain::CoordinateMaps::Wedge<2>, domain::CoordinateMaps::Affine>>;
+        domain::CoordinateMaps::Wedge<2>, domain::CoordinateMaps::Interval>>;
 
 /// \ingroup ComputationalDomainGroup
 /// \brief The corners for a cylindrical domain split into discs with radial

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -32,19 +32,19 @@ DomainCreator:
   Cylinder:
     InnerRadius: 0.08
     OuterRadius: 0.6
-    LowerBound: 0
-    UpperBound: 0.3
+    LowerZBound: 0
+    UpperZBound: 0.3
     InitialRefinement: [1, 0, 0]
     InitialGridPoints: [2, 3, 3]
     UseEquiangularMap: True
     RadialPartitioning: []
-    HeightPartitioning: []
+    PartitioningInZ: []
     RadialDistribution: [Linear]
     BoundaryConditions:
-      Lower:
+      LowerZ:
         AnalyticSolution:
           Displacement: Dirichlet
-      Upper:
+      UpperZ:
         AnalyticSolution:
           Displacement: Dirichlet
       Mantle:

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -40,6 +40,7 @@ DomainCreator:
     RadialPartitioning: []
     PartitioningInZ: []
     RadialDistribution: [Linear]
+    DistributionInZ: [Linear]
     BoundaryConditions:
       LowerZ:
         AnalyticSolution:

--- a/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
@@ -17,6 +17,7 @@ set(LIBRARY_SOURCES
   Test_Equiangular.cpp
   Test_Frustum.cpp
   Test_Identity.cpp
+  Test_Interval.cpp
   Test_KerrHorizonConforming.cpp
   Test_ProductMaps.cpp
   Test_Rotation.cpp

--- a/tests/Unit/Domain/CoordinateMaps/Test_Distribution.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Distribution.cpp
@@ -13,10 +13,13 @@ namespace domain::CoordinateMaps {
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Distribution", "[Domain][Unit]") {
   CHECK(get_output(Distribution::Linear) == "Linear");
+  CHECK(get_output(Distribution::Equiangular) == "Equiangular");
   CHECK(get_output(Distribution::Logarithmic) == "Logarithmic");
   CHECK(get_output(Distribution::Inverse) == "Inverse");
   CHECK(TestHelpers::test_creation<Distribution>("Linear") ==
         Distribution::Linear);
+  CHECK(TestHelpers::test_creation<Distribution>("Equiangular") ==
+        Distribution::Equiangular);
   CHECK(TestHelpers::test_creation<Distribution>("Logarithmic") ==
         Distribution::Logarithmic);
   CHECK(TestHelpers::test_creation<Distribution>("Inverse") ==

--- a/tests/Unit/Domain/CoordinateMaps/Test_Interval.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Interval.cpp
@@ -1,0 +1,102 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <optional>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/Interval.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp"
+
+namespace domain {
+namespace {
+void test_coordinate_map(
+    const double xA, const double xB, const double xa, const double xb,
+    const CoordinateMaps::Distribution distribution,
+    const std::optional<double> singularity_pos = std::nullopt) {
+  CoordinateMaps::Interval map(xA, xB, xa, xb, distribution, singularity_pos);
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> dist(xA, xB);
+  const auto sample_points = make_with_random_values<std::array<double, 10>>(
+      make_not_null(&generator), make_not_null(&dist));
+  for (double scalar : sample_points) {
+    const std::array<double, 1> random_point{{scalar}};
+    test_coordinate_map_argument_types(map, random_point);
+    test_inverse_map(map, random_point);
+    test_jacobian(map, random_point);
+    test_inv_jacobian(map, random_point);
+  }
+  const std::array<double, 1> point_xA{{xA}};
+  const std::array<double, 1> point_xB{{xB}};
+  CHECK(get<0>(map(point_xA)) == approx(xa));
+  CHECK(get<0>(map(point_xB)) == approx(xb));
+
+  // Check inequivalence operator
+  CHECK_FALSE(map != map);
+  test_serialization(map);
+  CHECK(not map.is_identity());
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Interval", "[Domain][Unit]") {
+  const std::array<double, 1> point_1{{-0.5}};
+  const std::array<double, 1> point_2{{1 / 3.}};
+  const std::array<double, 1> point_3{{12 / 7.}};
+
+  test_coordinate_map(-1.0, 2.0, -3.1, 2.7,
+                      CoordinateMaps::Distribution::Linear);
+  CoordinateMaps::Interval linear_map(-1.0, 2.0, -3.1, 2.7,
+                                      CoordinateMaps::Distribution::Linear);
+  CHECK(get<0>(linear_map(point_1)) == approx(-6.4 / 3.));
+  CHECK(get<0>(linear_map(point_2)) == approx(-4.7 / 9.));
+  CHECK(get<0>(linear_map(point_3)) == approx(90.2 / 42.));
+
+  test_coordinate_map(-1.0, 2.0, -3.1, 2.7,
+                      CoordinateMaps::Distribution::Equiangular);
+  CoordinateMaps::Interval equiangular_map(
+      -1.0, 2.0, -3.1, 2.7, CoordinateMaps::Distribution::Equiangular);
+  CHECK(get<0>(equiangular_map(point_1)) == approx(-1.87431578064991));
+  CHECK(get<0>(equiangular_map(point_2)) == approx(-0.45371712422518));
+  CHECK(get<0>(equiangular_map(point_3)) == approx(1.9402974025886));
+
+  test_coordinate_map(-1.0, 2.0, -3.1, 2.7,
+                      CoordinateMaps::Distribution::Logarithmic, -3.2);
+  CoordinateMaps::Interval logarithmic_map_left(
+      -1.0, 2.0, -3.1, 2.7, CoordinateMaps::Distribution::Logarithmic, -3.2);
+  CHECK(get<0>(logarithmic_map_left(point_1)) == approx(-3.0026932232316066));
+  CHECK(get<0>(logarithmic_map_left(point_2)) == approx(-2.5875856781465209));
+  CHECK(get<0>(logarithmic_map_left(point_3)) == approx(0.80128456770888800));
+
+  test_coordinate_map(-1.0, 2.0, -3.1, 2.7,
+                      CoordinateMaps::Distribution::Logarithmic, 2.8);
+  CoordinateMaps::Interval logarithmic_map_right(
+      -1.0, 2.0, -3.1, 2.7, CoordinateMaps::Distribution::Logarithmic, 2.8);
+  CHECK(get<0>(logarithmic_map_right(point_1)) == approx(-0.190267286625263));
+  CHECK(get<0>(logarithmic_map_right(point_2)) == approx(1.836599930886074));
+  CHECK(get<0>(logarithmic_map_right(point_3)) == approx(2.652547353227159));
+
+  test_coordinate_map(-1.0, 2.0, -3.1, 2.7,
+                      CoordinateMaps::Distribution::Inverse, -3.2);
+  CoordinateMaps::Interval inverse_map_left(
+      -1.0, 2.0, -3.1, 2.7, CoordinateMaps::Distribution::Inverse, -3.2);
+  CHECK(get<0>(inverse_map_left(point_1)) == approx(-3.080405405405405));
+  CHECK(get<0>(inverse_map_left(point_2)) == approx(-3.022408026755852));
+  CHECK(get<0>(inverse_map_left(point_3)) == approx(-2.295620437956204));
+
+  test_coordinate_map(-1.0, 2.0, -3.1, 2.7,
+                      CoordinateMaps::Distribution::Inverse, 2.8);
+  CoordinateMaps::Interval inverse_map_right(
+      -1.0, 2.0, -3.1, 2.7, CoordinateMaps::Distribution::Inverse, 2.8);
+  CHECK(get<0>(inverse_map_right(point_1)) == approx(2.246875));
+  CHECK(get<0>(inverse_map_right(point_2)) == approx(2.579668049792531120));
+  CHECK(get<0>(inverse_map_right(point_3)) == approx(2.6896705253784505788));
+
+  check_if_map_is_identity(CoordinateMaps::Interval{
+      -1.5, 1.0, -1.5, 1.0, CoordinateMaps::Distribution::Linear});
+}
+}  // namespace domain

--- a/tests/Unit/Domain/Creators/Test_Cylinder.cpp
+++ b/tests/Unit/Domain/Creators/Test_Cylinder.cpp
@@ -45,14 +45,14 @@ using NoneBc =
     TestHelpers::domain::BoundaryConditions::TestNoneBoundaryCondition<3>;
 
 std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
-create_lower_boundary_condition() {
+create_lower_z_boundary_condition() {
   return std::make_unique<
       TestHelpers::domain::BoundaryConditions::TestBoundaryCondition<3>>(
       Direction<3>::lower_zeta(), 50);
 }
 
 std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
-create_upper_boundary_condition() {
+create_upper_z_boundary_condition() {
   return std::make_unique<
       TestHelpers::domain::BoundaryConditions::TestBoundaryCondition<3>>(
       Direction<3>::upper_zeta(), 50);
@@ -67,12 +67,12 @@ create_mantle_boundary_condition() {
 
 std::string boundary_conditions_string(const bool is_periodic_in_z) {
   return "  BoundaryConditions:\n"
-         "    Lower:\n" +
+         "    LowerZ:\n" +
          std::string{is_periodic_in_z ? "      Periodic\n"
                                       : "      TestBoundaryCondition:\n"
                                         "        Direction: lower-zeta\n"
                                         "        BlockId: 50\n"} +
-         "    Upper:\n" +
+         "    UpperZ:\n" +
          std::string{is_periodic_in_z ? "      Periodic\n"
                                       : "      TestBoundaryCondition:\n"
                                         "        Direction: upper-zeta\n"
@@ -88,9 +88,9 @@ auto create_boundary_conditions(const bool periodic_in_z) {
   // z-direction
   for (size_t block_id = 0; not periodic_in_z and block_id < 5; ++block_id) {
     boundary_conditions_all_blocks[block_id][Direction<3>::lower_zeta()] =
-        create_lower_boundary_condition();
+        create_lower_z_boundary_condition();
     boundary_conditions_all_blocks[block_id][Direction<3>::upper_zeta()] =
-        create_upper_boundary_condition();
+        create_upper_z_boundary_condition();
   }
   // radial direction
   for (size_t block_id = 1; block_id < 5; ++block_id) {
@@ -102,8 +102,8 @@ auto create_boundary_conditions(const bool periodic_in_z) {
 
 void test_cylinder_construction(
     const creators::Cylinder& cylinder, const double inner_radius,
-    const double outer_radius, const double lower_bound,
-    const double upper_bound, const bool is_periodic_in_z,
+    const double outer_radius, const double lower_z_bound,
+    const double upper_z_bound, const bool is_periodic_in_z,
     const std::vector<std::array<size_t, 3>>& expected_extents,
     const std::vector<std::array<size_t, 3>>& expected_refinement_level,
     const bool use_equiangular_map,
@@ -209,7 +209,7 @@ void test_cylinder_construction(
                               inner_radius / sqrt(2.0), angular_distribution),
                      Interval(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
                               inner_radius / sqrt(2.0), angular_distribution),
-                     Interval{-1.0, 1.0, lower_bound, upper_bound,
+                     Interval{-1.0, 1.0, lower_z_bound, upper_z_bound,
                               Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -217,7 +217,7 @@ void test_cylinder_construction(
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}},
                   use_equiangular_map},
-          Interval{-1.0, 1.0, lower_bound, upper_bound,
+          Interval{-1.0, 1.0, lower_z_bound, upper_z_bound,
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -225,7 +225,7 @@ void test_cylinder_construction(
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}},
                   use_equiangular_map},
-          Interval{-1.0, 1.0, lower_bound, upper_bound,
+          Interval{-1.0, 1.0, lower_z_bound, upper_z_bound,
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -233,7 +233,7 @@ void test_cylinder_construction(
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}},
                   use_equiangular_map},
-          Interval{-1.0, 1.0, lower_bound, upper_bound,
+          Interval{-1.0, 1.0, lower_z_bound, upper_z_bound,
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -241,7 +241,7 @@ void test_cylinder_construction(
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}},
                   use_equiangular_map},
-          Interval{-1.0, 1.0, lower_bound, upper_bound,
+          Interval{-1.0, 1.0, lower_z_bound, upper_z_bound,
                    Distribution::Linear}}));
 
   test_domain_construction(domain, expected_block_neighbors,
@@ -268,8 +268,8 @@ void test_cylinder_no_refinement() {
         CAPTURE(periodic_in_z);
         const double inner_radius = 1.0;
         const double outer_radius = 2.0;
-        const double lower_bound = -2.5;
-        const double upper_bound = 5.0;
+        const double lower_z_bound = -2.5;
+        const double upper_z_bound = 5.0;
         const size_t refinement_level = 2;
         const std::array<size_t, 3> grid_points{{4, 4, 3}};
 
@@ -281,14 +281,14 @@ void test_cylinder_no_refinement() {
             with_boundary_conditions
                 ? creators::Cylinder{inner_radius,
                                      outer_radius,
-                                     lower_bound,
-                                     upper_bound,
+                                     lower_z_bound,
+                                     upper_z_bound,
                                      periodic_in_z
                                          ? std::make_unique<PeriodicBc>()
-                                         : create_lower_boundary_condition(),
+                                         : create_lower_z_boundary_condition(),
                                      periodic_in_z
                                          ? std::make_unique<PeriodicBc>()
-                                         : create_upper_boundary_condition(),
+                                         : create_upper_z_boundary_condition(),
                                      create_mantle_boundary_condition(),
                                      refinement_level,
                                      grid_points,
@@ -297,8 +297,8 @@ void test_cylinder_no_refinement() {
                                      {}}
                 : creators::Cylinder{inner_radius,
                                      outer_radius,
-                                     lower_bound,
-                                     upper_bound,
+                                     lower_z_bound,
+                                     upper_z_bound,
                                      periodic_in_z,
                                      refinement_level,
                                      grid_points,
@@ -307,7 +307,7 @@ void test_cylinder_no_refinement() {
                                      {}};
         test_physical_separation(cylinder.create_domain().blocks());
         test_cylinder_construction(
-            cylinder, inner_radius, outer_radius, lower_bound, upper_bound,
+            cylinder, inner_radius, outer_radius, lower_z_bound, upper_z_bound,
             periodic_in_z, {5, grid_points},
             {5, make_array<3>(refinement_level)}, equiangular_map,
             expected_boundary_conditions);
@@ -316,15 +316,15 @@ void test_cylinder_no_refinement() {
             "Cylinder:\n"
             "  InnerRadius: 1.0\n"
             "  OuterRadius: 2.0\n"
-            "  LowerBound: -2.5\n"
-            "  UpperBound: 5.0\n"
+            "  LowerZBound: -2.5\n"
+            "  UpperZBound: 5.0\n"
             "  InitialRefinement: 2\n"
             "  InitialGridPoints: [4,4,3]\n"
             "  UseEquiangularMap: " +
             std::string{equiangular_map ? "true" : "false"} +
             "\n"
             "  RadialPartitioning: []\n"
-            "  HeightPartitioning: []\n"
+            "  PartitioningInZ: []\n"
             "  RadialDistribution: [Linear]\n" +
             std::string{
                 with_boundary_conditions
@@ -351,18 +351,19 @@ void test_cylinder_no_refinement() {
         }();
         test_cylinder_construction(
             dynamic_cast<const creators::Cylinder&>(*cylinder_factory),
-            inner_radius, outer_radius, lower_bound, upper_bound, periodic_in_z,
-            {5, grid_points}, {5, make_array<3>(refinement_level)},
-            equiangular_map, expected_boundary_conditions);
+            inner_radius, outer_radius, lower_z_bound, upper_z_bound,
+            periodic_in_z, {5, grid_points},
+            {5, make_array<3>(refinement_level)}, equiangular_map,
+            expected_boundary_conditions);
 
         if (with_boundary_conditions) {
           CHECK_THROWS_WITH(
               creators::Cylinder(
-                  inner_radius, outer_radius, lower_bound, upper_bound,
+                  inner_radius, outer_radius, lower_z_bound, upper_z_bound,
                   periodic_in_z ? std::make_unique<PeriodicBc>()
-                                : create_lower_boundary_condition(),
+                                : create_lower_z_boundary_condition(),
                   periodic_in_z ? std::make_unique<PeriodicBc>()
-                                : create_upper_boundary_condition(),
+                                : create_upper_z_boundary_condition(),
                   std::make_unique<PeriodicBc>(), refinement_level, grid_points,
                   equiangular_map, {}, {}, radial_distribution,
                   Options::Context{false, {}, 1, 1}),
@@ -370,31 +371,43 @@ void test_cylinder_no_refinement() {
                   "A Cylinder can't have periodic boundary conditions in the "
                   "radial direction."));
           CHECK_THROWS_WITH(
-              creators::Cylinder(inner_radius, outer_radius, lower_bound,
-                                 upper_bound, std::make_unique<PeriodicBc>(),
-                                 create_lower_boundary_condition(),
+              creators::Cylinder(inner_radius, outer_radius, lower_z_bound,
+                                 upper_z_bound, std::make_unique<PeriodicBc>(),
+                                 create_lower_z_boundary_condition(),
                                  create_mantle_boundary_condition(),
                                  refinement_level, grid_points, equiangular_map,
                                  {}, {}, radial_distribution,
                                  Options::Context{false, {}, 1, 1}),
               Catch::Matchers::Contains(
-                  "Either both lower and upper boundary condition must be "
-                  "periodic, or neither."));
-          CHECK_THROWS_WITH(
-              creators::Cylinder(inner_radius, outer_radius, lower_bound,
-                                 upper_bound, create_lower_boundary_condition(),
-                                 std::make_unique<PeriodicBc>(),
-                                 create_mantle_boundary_condition(),
-                                 refinement_level, grid_points, equiangular_map,
-                                 {}, {}, radial_distribution,
-                                 Options::Context{false, {}, 1, 1}),
-              Catch::Matchers::Contains(
-                  "Either both lower and upper boundary condition must be "
+                  "Either both lower and upper z-boundary condition must be "
                   "periodic, or neither."));
           CHECK_THROWS_WITH(
               creators::Cylinder(
-                  inner_radius, outer_radius, lower_bound, upper_bound,
-                  std::make_unique<NoneBc>(), create_upper_boundary_condition(),
+                  inner_radius, outer_radius, lower_z_bound, upper_z_bound,
+                  create_lower_z_boundary_condition(),
+                  std::make_unique<PeriodicBc>(),
+                  create_mantle_boundary_condition(), refinement_level,
+                  grid_points, equiangular_map, {}, {}, radial_distribution,
+                  Options::Context{false, {}, 1, 1}),
+              Catch::Matchers::Contains(
+                  "Either both lower and upper z-boundary condition must be "
+                  "periodic, or neither."));
+          CHECK_THROWS_WITH(
+              creators::Cylinder(inner_radius, outer_radius, lower_z_bound,
+                                 upper_z_bound, std::make_unique<NoneBc>(),
+                                 create_upper_z_boundary_condition(),
+                                 create_mantle_boundary_condition(),
+                                 refinement_level, grid_points, equiangular_map,
+                                 {}, {}, radial_distribution,
+                                 Options::Context{false, {}, 1, 1}),
+              Catch::Matchers::Contains(
+                  "None boundary condition is not supported. If you would like "
+                  "an outflow boundary condition, you must use that."));
+          CHECK_THROWS_WITH(
+              creators::Cylinder(
+                  inner_radius, outer_radius, lower_z_bound, upper_z_bound,
+                  create_lower_z_boundary_condition(),
+                  std::make_unique<NoneBc>(),
                   create_mantle_boundary_condition(), refinement_level,
                   grid_points, equiangular_map, {}, {}, radial_distribution,
                   Options::Context{false, {}, 1, 1}),
@@ -403,21 +416,12 @@ void test_cylinder_no_refinement() {
                   "an outflow boundary condition, you must use that."));
           CHECK_THROWS_WITH(
               creators::Cylinder(
-                  inner_radius, outer_radius, lower_bound, upper_bound,
-                  create_lower_boundary_condition(), std::make_unique<NoneBc>(),
-                  create_mantle_boundary_condition(), refinement_level,
-                  grid_points, equiangular_map, {}, {}, radial_distribution,
+                  inner_radius, outer_radius, lower_z_bound, upper_z_bound,
+                  create_lower_z_boundary_condition(),
+                  create_upper_z_boundary_condition(),
+                  std::make_unique<NoneBc>(), refinement_level, grid_points,
+                  equiangular_map, {}, {}, radial_distribution,
                   Options::Context{false, {}, 1, 1}),
-              Catch::Matchers::Contains(
-                  "None boundary condition is not supported. If you would like "
-                  "an outflow boundary condition, you must use that."));
-          CHECK_THROWS_WITH(
-              creators::Cylinder(
-                  inner_radius, outer_radius, lower_bound, upper_bound,
-                  create_lower_boundary_condition(),
-                  create_upper_boundary_condition(), std::make_unique<NoneBc>(),
-                  refinement_level, grid_points, equiangular_map, {}, {},
-                  radial_distribution, Options::Context{false, {}, 1, 1}),
               Catch::Matchers::Contains(
                   "None boundary condition is not supported. If you would like "
                   "an outflow boundary condition, you must use that."));
@@ -435,15 +439,15 @@ void test_refined_cylinder_boundaries(
   // definition of an arbitrary refined cylinder
   const double inner_radius = 0.3;
   const double outer_radius = 1.0;
-  const double lower_bound = -1.5;
-  const double upper_bound = 5.0;
+  const double lower_z_bound = -1.5;
+  const double upper_z_bound = 5.0;
   const std::vector<double> radial_partitioning = {0.7};
-  const std::vector<double> height_partitioning = {1.5};
+  const std::vector<double> partitioning_in_z = {1.5};
   const std::array<size_t, 3> refinement_level{1, 2, 3};
   const std::array<size_t, 3> expected_wedge_extents{{5, 4, 3}};
   std::vector<std::array<size_t, 3>> expected_refinement_level{
       (1 + 4 * (1 + radial_partitioning.size())) *
-          (1 + height_partitioning.size()),
+          (1 + partitioning_in_z.size()),
       refinement_level};
   // The central cubes share refinement level in x and y direction
   expected_refinement_level[0][0] = expected_refinement_level[0][1];
@@ -451,16 +455,16 @@ void test_refined_cylinder_boundaries(
   const creators::Cylinder refined_cylinder{
       inner_radius,
       outer_radius,
-      lower_bound,
-      upper_bound,
-      create_lower_boundary_condition(),
-      create_upper_boundary_condition(),
+      lower_z_bound,
+      upper_z_bound,
+      create_lower_z_boundary_condition(),
+      create_upper_z_boundary_condition(),
       create_mantle_boundary_condition(),
       refinement_level,
       expected_wedge_extents,
       use_equiangular_map,
       radial_partitioning,
-      height_partitioning,
+      partitioning_in_z,
       {domain::CoordinateMaps::Distribution::Linear,
        outer_radial_distribution}};
   test_physical_separation(refined_cylinder.create_domain().blocks());
@@ -614,10 +618,10 @@ void test_refined_cylinder_boundaries(
     for (const auto& direction_in_block : external_boundaries_in_block) {
       if (direction_in_block == Direction<3>::lower_zeta()) {
         boundary_conditions_in_block[direction_in_block] =
-            create_lower_boundary_condition();
+            create_lower_z_boundary_condition();
       } else if (direction_in_block == Direction<3>::upper_zeta()) {
         boundary_conditions_in_block[direction_in_block] =
-            create_upper_boundary_condition();
+            create_upper_z_boundary_condition();
       } else if (direction_in_block == Direction<3>::upper_xi()) {
         boundary_conditions_in_block[direction_in_block] =
             create_mantle_boundary_condition();
@@ -667,15 +671,15 @@ void test_refined_cylinder_boundaries(
   // (inner_radius, radial_partitioning.at(0)) and circularity changing from 0
   // to 1 is generated, secondly a further shell with radial boundaries
   // (radial_partitioning.at(0), outer_radius) and uniform circularity is added.
-  // this is then repeated for (lower_bound, height_partitioning.at(0)) and
-  // (height_partitioning.at(0), upper_bound)
+  // this is then repeated for (lower_z_bound, partitioning_in_z.at(0)) and
+  // (partitioning_in_z.at(0), upper_z_bound)
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
           Interval3D{Interval(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
                               inner_radius / sqrt(2.0), angular_distribution),
                      Interval(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
                               inner_radius / sqrt(2.0), angular_distribution),
-                     Interval{-1.0, 1.0, lower_bound, height_partitioning.at(0),
+                     Interval{-1.0, 1.0, lower_z_bound, partitioning_in_z.at(0),
                               Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -683,7 +687,7 @@ void test_refined_cylinder_boundaries(
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}},
                   use_equiangular_map},
-          Interval{-1.0, 1.0, lower_bound, height_partitioning.at(0),
+          Interval{-1.0, 1.0, lower_z_bound, partitioning_in_z.at(0),
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -691,7 +695,7 @@ void test_refined_cylinder_boundaries(
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}},
                   use_equiangular_map},
-          Interval{-1.0, 1.0, lower_bound, height_partitioning.at(0),
+          Interval{-1.0, 1.0, lower_z_bound, partitioning_in_z.at(0),
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -699,7 +703,7 @@ void test_refined_cylinder_boundaries(
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}},
                   use_equiangular_map},
-          Interval{-1.0, 1.0, lower_bound, height_partitioning.at(0),
+          Interval{-1.0, 1.0, lower_z_bound, partitioning_in_z.at(0),
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -707,7 +711,7 @@ void test_refined_cylinder_boundaries(
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}},
                   use_equiangular_map},
-          Interval{-1.0, 1.0, lower_bound, height_partitioning.at(0),
+          Interval{-1.0, 1.0, lower_z_bound, partitioning_in_z.at(0),
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -716,7 +720,7 @@ void test_refined_cylinder_boundaries(
                       {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}},
                   use_equiangular_map, use_both_halves,
                   outer_radial_distribution},
-          Interval{-1.0, 1.0, lower_bound, height_partitioning.at(0),
+          Interval{-1.0, 1.0, lower_z_bound, partitioning_in_z.at(0),
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -725,7 +729,7 @@ void test_refined_cylinder_boundaries(
                       {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}},
                   use_equiangular_map, use_both_halves,
                   outer_radial_distribution},
-          Interval{-1.0, 1.0, lower_bound, height_partitioning.at(0),
+          Interval{-1.0, 1.0, lower_z_bound, partitioning_in_z.at(0),
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -734,7 +738,7 @@ void test_refined_cylinder_boundaries(
                       {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}},
                   use_equiangular_map, use_both_halves,
                   outer_radial_distribution},
-          Interval{-1.0, 1.0, lower_bound, height_partitioning.at(0),
+          Interval{-1.0, 1.0, lower_z_bound, partitioning_in_z.at(0),
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -743,7 +747,7 @@ void test_refined_cylinder_boundaries(
                       {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}},
                   use_equiangular_map, use_both_halves,
                   outer_radial_distribution},
-          Interval{-1.0, 1.0, lower_bound, height_partitioning.at(0),
+          Interval{-1.0, 1.0, lower_z_bound, partitioning_in_z.at(0),
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
@@ -751,7 +755,7 @@ void test_refined_cylinder_boundaries(
                               inner_radius / sqrt(2.0), angular_distribution),
                      Interval(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
                               inner_radius / sqrt(2.0), angular_distribution),
-                     Interval{-1.0, 1.0, height_partitioning.at(0), upper_bound,
+                     Interval{-1.0, 1.0, partitioning_in_z.at(0), upper_z_bound,
                               Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -759,7 +763,7 @@ void test_refined_cylinder_boundaries(
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}},
                   use_equiangular_map},
-          Interval{-1.0, 1.0, height_partitioning.at(0), upper_bound,
+          Interval{-1.0, 1.0, partitioning_in_z.at(0), upper_z_bound,
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -767,7 +771,7 @@ void test_refined_cylinder_boundaries(
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}},
                   use_equiangular_map},
-          Interval{-1.0, 1.0, height_partitioning.at(0), upper_bound,
+          Interval{-1.0, 1.0, partitioning_in_z.at(0), upper_z_bound,
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -775,7 +779,7 @@ void test_refined_cylinder_boundaries(
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}},
                   use_equiangular_map},
-          Interval{-1.0, 1.0, height_partitioning.at(0), upper_bound,
+          Interval{-1.0, 1.0, partitioning_in_z.at(0), upper_z_bound,
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -783,7 +787,7 @@ void test_refined_cylinder_boundaries(
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}},
                   use_equiangular_map},
-          Interval{-1.0, 1.0, height_partitioning.at(0), upper_bound,
+          Interval{-1.0, 1.0, partitioning_in_z.at(0), upper_z_bound,
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -792,7 +796,7 @@ void test_refined_cylinder_boundaries(
                       {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}},
                   use_equiangular_map, use_both_halves,
                   outer_radial_distribution},
-          Interval{-1.0, 1.0, height_partitioning.at(0), upper_bound,
+          Interval{-1.0, 1.0, partitioning_in_z.at(0), upper_z_bound,
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -801,7 +805,7 @@ void test_refined_cylinder_boundaries(
                       {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}},
                   use_equiangular_map, use_both_halves,
                   outer_radial_distribution},
-          Interval{-1.0, 1.0, height_partitioning.at(0), upper_bound,
+          Interval{-1.0, 1.0, partitioning_in_z.at(0), upper_z_bound,
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -810,7 +814,7 @@ void test_refined_cylinder_boundaries(
                       {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}},
                   use_equiangular_map, use_both_halves,
                   outer_radial_distribution},
-          Interval{-1.0, 1.0, height_partitioning.at(0), upper_bound,
+          Interval{-1.0, 1.0, partitioning_in_z.at(0), upper_z_bound,
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -819,7 +823,7 @@ void test_refined_cylinder_boundaries(
                       {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}},
                   use_equiangular_map, use_both_halves,
                   outer_radial_distribution},
-          Interval{-1.0, 1.0, height_partitioning.at(0), upper_bound,
+          Interval{-1.0, 1.0, partitioning_in_z.at(0), upper_z_bound,
                    Distribution::Linear}}));
 
   test_domain_construction(domain, expected_block_neighbors,
@@ -840,10 +844,10 @@ void test_refined_cylinder_periodic_boundaries(const bool use_equiangular_map) {
   // definition of an arbitrary refined cylinder
   const double inner_radius = 0.3;
   const double outer_radius = 1.0;
-  const double lower_bound = -1.5;
-  const double upper_bound = 5.0;
+  const double lower_z_bound = -1.5;
+  const double upper_z_bound = 5.0;
   const std::vector<double> radial_partitioning = {0.7};
-  const std::vector<double> height_partitioning = {1.5};
+  const std::vector<double> partitioning_in_z = {1.5};
   const std::vector<domain::CoordinateMaps::Distribution> radial_distribution{
       domain::CoordinateMaps::Distribution::Linear,
       domain::CoordinateMaps::Distribution::Linear};
@@ -851,12 +855,12 @@ void test_refined_cylinder_periodic_boundaries(const bool use_equiangular_map) {
   const std::array<size_t, 3> expected_wedge_extents{{5, 4, 3}};
   const std::vector<std::array<size_t, 3>> expected_refinement_level{
       (1 + 4 * (1 + radial_partitioning.size())) *
-          (1 + height_partitioning.size()),
+          (1 + partitioning_in_z.size()),
       make_array<3>(refinement_level)};
   const creators::Cylinder refined_cylinder{inner_radius,
                                             outer_radius,
-                                            lower_bound,
-                                            upper_bound,
+                                            lower_z_bound,
+                                            upper_z_bound,
                                             std::make_unique<PeriodicBc>(),
                                             std::make_unique<PeriodicBc>(),
                                             create_mantle_boundary_condition(),
@@ -864,7 +868,7 @@ void test_refined_cylinder_periodic_boundaries(const bool use_equiangular_map) {
                                             expected_wedge_extents,
                                             use_equiangular_map,
                                             radial_partitioning,
-                                            height_partitioning,
+                                            partitioning_in_z,
                                             radial_distribution};
 
   const auto domain = refined_cylinder.create_domain();
@@ -1079,15 +1083,15 @@ void test_refined_cylinder_periodic_boundaries(const bool use_equiangular_map) {
   // (inner_radius, radial_partitioning.at(0)) and circularity changing from 0
   // to 1 is generated, secondly a further shell with radial boundaries
   // (radial_partitioning.at(0), outer_radius) and uniform circularity is added.
-  // this is then repeated for (lower_bound, height_partitioning.at(0)) and
-  // (height_partitioning.at(0), upper_bound)
+  // this is then repeated for (lower_z_bound, partitioning_in_z.at(0)) and
+  // (partitioning_in_z.at(0), upper_z_bound)
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
           Interval3D{Interval(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
                               inner_radius / sqrt(2.0), angular_distribution),
                      Interval(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
                               inner_radius / sqrt(2.0), angular_distribution),
-                     Interval{-1.0, 1.0, lower_bound, height_partitioning.at(0),
+                     Interval{-1.0, 1.0, lower_z_bound, partitioning_in_z.at(0),
                               Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -1095,7 +1099,7 @@ void test_refined_cylinder_periodic_boundaries(const bool use_equiangular_map) {
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}},
                   use_equiangular_map},
-          Interval{-1.0, 1.0, lower_bound, height_partitioning.at(0),
+          Interval{-1.0, 1.0, lower_z_bound, partitioning_in_z.at(0),
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -1103,7 +1107,7 @@ void test_refined_cylinder_periodic_boundaries(const bool use_equiangular_map) {
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}},
                   use_equiangular_map},
-          Interval{-1.0, 1.0, lower_bound, height_partitioning.at(0),
+          Interval{-1.0, 1.0, lower_z_bound, partitioning_in_z.at(0),
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -1111,7 +1115,7 @@ void test_refined_cylinder_periodic_boundaries(const bool use_equiangular_map) {
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}},
                   use_equiangular_map},
-          Interval{-1.0, 1.0, lower_bound, height_partitioning.at(0),
+          Interval{-1.0, 1.0, lower_z_bound, partitioning_in_z.at(0),
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -1119,7 +1123,7 @@ void test_refined_cylinder_periodic_boundaries(const bool use_equiangular_map) {
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}},
                   use_equiangular_map},
-          Interval{-1.0, 1.0, lower_bound, height_partitioning.at(0),
+          Interval{-1.0, 1.0, lower_z_bound, partitioning_in_z.at(0),
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -1127,7 +1131,7 @@ void test_refined_cylinder_periodic_boundaries(const bool use_equiangular_map) {
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}},
                   use_equiangular_map},
-          Interval{-1.0, 1.0, lower_bound, height_partitioning.at(0),
+          Interval{-1.0, 1.0, lower_z_bound, partitioning_in_z.at(0),
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -1135,7 +1139,7 @@ void test_refined_cylinder_periodic_boundaries(const bool use_equiangular_map) {
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}},
                   use_equiangular_map},
-          Interval{-1.0, 1.0, lower_bound, height_partitioning.at(0),
+          Interval{-1.0, 1.0, lower_z_bound, partitioning_in_z.at(0),
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -1143,7 +1147,7 @@ void test_refined_cylinder_periodic_boundaries(const bool use_equiangular_map) {
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}},
                   use_equiangular_map},
-          Interval{-1.0, 1.0, lower_bound, height_partitioning.at(0),
+          Interval{-1.0, 1.0, lower_z_bound, partitioning_in_z.at(0),
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -1151,7 +1155,7 @@ void test_refined_cylinder_periodic_boundaries(const bool use_equiangular_map) {
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}},
                   use_equiangular_map},
-          Interval{-1.0, 1.0, lower_bound, height_partitioning.at(0),
+          Interval{-1.0, 1.0, lower_z_bound, partitioning_in_z.at(0),
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
@@ -1159,7 +1163,7 @@ void test_refined_cylinder_periodic_boundaries(const bool use_equiangular_map) {
                               inner_radius / sqrt(2.0), angular_distribution),
                      Interval(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
                               inner_radius / sqrt(2.0), angular_distribution),
-                     Interval{-1.0, 1.0, height_partitioning.at(0), upper_bound,
+                     Interval{-1.0, 1.0, partitioning_in_z.at(0), upper_z_bound,
                               Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -1167,7 +1171,7 @@ void test_refined_cylinder_periodic_boundaries(const bool use_equiangular_map) {
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}},
                   use_equiangular_map},
-          Interval{-1.0, 1.0, height_partitioning.at(0), upper_bound,
+          Interval{-1.0, 1.0, partitioning_in_z.at(0), upper_z_bound,
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -1175,7 +1179,7 @@ void test_refined_cylinder_periodic_boundaries(const bool use_equiangular_map) {
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}},
                   use_equiangular_map},
-          Interval{-1.0, 1.0, height_partitioning.at(0), upper_bound,
+          Interval{-1.0, 1.0, partitioning_in_z.at(0), upper_z_bound,
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -1183,7 +1187,7 @@ void test_refined_cylinder_periodic_boundaries(const bool use_equiangular_map) {
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}},
                   use_equiangular_map},
-          Interval{-1.0, 1.0, height_partitioning.at(0), upper_bound,
+          Interval{-1.0, 1.0, partitioning_in_z.at(0), upper_z_bound,
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -1191,7 +1195,7 @@ void test_refined_cylinder_periodic_boundaries(const bool use_equiangular_map) {
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}},
                   use_equiangular_map},
-          Interval{-1.0, 1.0, height_partitioning.at(0), upper_bound,
+          Interval{-1.0, 1.0, partitioning_in_z.at(0), upper_z_bound,
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -1199,7 +1203,7 @@ void test_refined_cylinder_periodic_boundaries(const bool use_equiangular_map) {
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}},
                   use_equiangular_map},
-          Interval{-1.0, 1.0, height_partitioning.at(0), upper_bound,
+          Interval{-1.0, 1.0, partitioning_in_z.at(0), upper_z_bound,
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -1207,7 +1211,7 @@ void test_refined_cylinder_periodic_boundaries(const bool use_equiangular_map) {
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}},
                   use_equiangular_map},
-          Interval{-1.0, 1.0, height_partitioning.at(0), upper_bound,
+          Interval{-1.0, 1.0, partitioning_in_z.at(0), upper_z_bound,
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -1215,7 +1219,7 @@ void test_refined_cylinder_periodic_boundaries(const bool use_equiangular_map) {
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}},
                   use_equiangular_map},
-          Interval{-1.0, 1.0, height_partitioning.at(0), upper_bound,
+          Interval{-1.0, 1.0, partitioning_in_z.at(0), upper_z_bound,
                    Distribution::Linear}}));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
@@ -1223,7 +1227,7 @@ void test_refined_cylinder_periodic_boundaries(const bool use_equiangular_map) {
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}},
                   use_equiangular_map},
-          Interval{-1.0, 1.0, height_partitioning.at(0), upper_bound,
+          Interval{-1.0, 1.0, partitioning_in_z.at(0), upper_z_bound,
                    Distribution::Linear}}));
 
   test_domain_construction(domain, expected_block_neighbors,


### PR DESCRIPTION
## Proposed changes
The commits in this PR first add a new 1D-CoordinateMap that encompasses the `Affine` and `Equiangular` CoordinateMap, and introduces both an `Logarithmic `and `Inverse` mapping in accordance with the `Wedge` CoordinateMap. 
This map then replaces the 1D-CoordinateMaps in `DomainHelpers` for both `Cylinder` and `CylindricalBinaryCompactObject` and allows to choose any distribution type from the `CoordinateMaps::Distribution` for the z-axis of the `Cylinder`.
<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
The `Cylinder` now allows to choose the distribution of grid points along the z-axis for each layer. To keep the behaviors the same as before for a single layer, specify `DistributionInZ: [Linear]`.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments
This PR contains to standalone commits, namely
- "loop over directions in DomainHelpers" that exchanges huge blocks of nearly identical code for a loop
- "rename parse options in cylinder" that makes their name more consistent
<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
