### PR TITLE
Add GRMHD FD time derivative computation

### DIFF
--- a/src/Evolution/DgSubcell/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/CMakeLists.txt
@@ -33,6 +33,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   ActiveGrid.cpp
+  CartesianFluxDivergence.cpp
   Matrices.cpp
   Mesh.cpp
   NeighborData.cpp

--- a/src/Evolution/DgSubcell/CartesianFluxDivergence.cpp
+++ b/src/Evolution/DgSubcell/CartesianFluxDivergence.cpp
@@ -1,0 +1,83 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/DgSubcell/CartesianFluxDivergence.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace evolution::dg::subcell {
+void add_cartesian_flux_divergence(const gsl::not_null<DataVector*> dt_var,
+                                   const double one_over_delta,
+                                   const DataVector& inv_jacobian,
+                                   const DataVector& boundary_correction,
+                                   const Index<1>& subcell_extents,
+                                   const size_t dimension) noexcept {
+  (void)dimension;
+  ASSERT(dimension == 0, "dimension must be 0 but is " << dimension);
+  for (size_t i = 0; i < subcell_extents[0]; ++i) {
+    (*dt_var)[i] += one_over_delta * inv_jacobian[i] *
+                    (boundary_correction[i + 1] - boundary_correction[i]);
+  }
+}
+
+void add_cartesian_flux_divergence(const gsl::not_null<DataVector*> dt_var,
+                                   const double one_over_delta,
+                                   const DataVector& inv_jacobian,
+                                   const DataVector& boundary_correction,
+                                   const Index<2>& subcell_extents,
+                                   const size_t dimension) noexcept {
+  ASSERT(dimension == 0 or dimension == 1,
+         "dimension must be 0 or 1 but is " << dimension);
+  Index<2> subcell_face_extents = subcell_extents;
+  ++subcell_face_extents[dimension];
+  for (size_t j = 0; j < subcell_extents[1]; ++j) {
+    for (size_t i = 0; i < subcell_extents[0]; ++i) {
+      Index<2> index(i, j);
+      const size_t volume_index = collapsed_index(index, subcell_extents);
+      const size_t boundary_correction_lower_index =
+          collapsed_index(index, subcell_face_extents);
+      ++index[dimension];
+      const size_t boundary_correction_upper_index =
+          collapsed_index(index, subcell_face_extents);
+      (*dt_var)[volume_index] +=
+          one_over_delta * inv_jacobian[volume_index] *
+          (boundary_correction[boundary_correction_upper_index] -
+           boundary_correction[boundary_correction_lower_index]);
+    }
+  }
+}
+
+void add_cartesian_flux_divergence(const gsl::not_null<DataVector*> dt_var,
+                                   const double one_over_delta,
+                                   const DataVector& inv_jacobian,
+                                   const DataVector& boundary_correction,
+                                   const Index<3>& subcell_extents,
+                                   const size_t dimension) noexcept {
+  ASSERT(dimension == 0 or dimension == 1 or dimension == 2,
+         "dimension must be 0, 1, or 2 but is " << dimension);
+  Index<3> subcell_face_extents = subcell_extents;
+  ++subcell_face_extents[dimension];
+  for (size_t k = 0; k < subcell_extents[2]; ++k) {
+    for (size_t j = 0; j < subcell_extents[1]; ++j) {
+      for (size_t i = 0; i < subcell_extents[0]; ++i) {
+        Index<3> index(i, j, k);
+        const size_t volume_index = collapsed_index(index, subcell_extents);
+        const size_t boundary_correction_lower_index =
+            collapsed_index(index, subcell_face_extents);
+        ++index[dimension];
+        const size_t boundary_correction_upper_index =
+            collapsed_index(index, subcell_face_extents);
+        (*dt_var)[volume_index] +=
+            one_over_delta * inv_jacobian[volume_index] *
+            (boundary_correction[boundary_correction_upper_index] -
+             boundary_correction[boundary_correction_lower_index]);
+      }
+    }
+  }
+}
+}  // namespace evolution::dg::subcell

--- a/src/Evolution/DgSubcell/CartesianFluxDivergence.hpp
+++ b/src/Evolution/DgSubcell/CartesianFluxDivergence.hpp
@@ -5,10 +5,15 @@
 
 #include <cstddef>
 
-#include "DataStructures/DataVector.hpp"
-#include "DataStructures/Index.hpp"
-#include "Utilities/ErrorHandling/Assert.hpp"
-#include "Utilities/Gsl.hpp"
+/// \cond
+class DataVector;
+template <size_t Dim>
+class Index;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
 
 namespace evolution::dg::subcell {
 /// @{
@@ -16,74 +21,25 @@ namespace evolution::dg::subcell {
  * \brief Compute and add the 2nd-order flux divergence on a Cartesian mesh to
  * the cell-centered time derivatives.
  */
-void add_cartesian_flux_divergence(const gsl::not_null<DataVector*> dt_var,
-                                   const double one_over_delta,
+void add_cartesian_flux_divergence(gsl::not_null<DataVector*> dt_var,
+                                   double one_over_delta,
                                    const DataVector& inv_jacobian,
                                    const DataVector& boundary_correction,
                                    const Index<1>& subcell_extents,
-                                   const size_t dimension) noexcept {
-  (void)dimension;
-  ASSERT(dimension == 0, "dimension must be 0 but is " << dimension);
-  for (size_t i = 0; i < subcell_extents[0]; ++i) {
-    (*dt_var)[i] += one_over_delta * inv_jacobian[i] *
-                    (boundary_correction[i + 1] - boundary_correction[i]);
-  }
-}
+                                   size_t dimension) noexcept;
 
-void add_cartesian_flux_divergence(const gsl::not_null<DataVector*> dt_var,
-                                   const double one_over_delta,
+void add_cartesian_flux_divergence(gsl::not_null<DataVector*> dt_var,
+                                   double one_over_delta,
                                    const DataVector& inv_jacobian,
                                    const DataVector& boundary_correction,
                                    const Index<2>& subcell_extents,
-                                   const size_t dimension) noexcept {
-  ASSERT(dimension == 0 or dimension == 1,
-         "dimension must be 0 or 1 but is " << dimension);
-  Index<2> subcell_face_extents = subcell_extents;
-  ++subcell_face_extents[dimension];
-  for (size_t j = 0; j < subcell_extents[1]; ++j) {
-    for (size_t i = 0; i < subcell_extents[0]; ++i) {
-      Index<2> index(i, j);
-      const size_t volume_index = collapsed_index(index, subcell_extents);
-      const size_t boundary_correction_lower_index =
-          collapsed_index(index, subcell_face_extents);
-      ++index[dimension];
-      const size_t boundary_correction_upper_index =
-          collapsed_index(index, subcell_face_extents);
-      (*dt_var)[volume_index] +=
-          one_over_delta * inv_jacobian[volume_index] *
-          (boundary_correction[boundary_correction_upper_index] -
-           boundary_correction[boundary_correction_lower_index]);
-    }
-  }
-}
+                                   size_t dimension) noexcept;
 
-void add_cartesian_flux_divergence(const gsl::not_null<DataVector*> dt_var,
-                                   const double one_over_delta,
+void add_cartesian_flux_divergence(gsl::not_null<DataVector*> dt_var,
+                                   double one_over_delta,
                                    const DataVector& inv_jacobian,
                                    const DataVector& boundary_correction,
                                    const Index<3>& subcell_extents,
-                                   const size_t dimension) noexcept {
-  ASSERT(dimension == 0 or dimension == 1 or dimension == 2,
-         "dimension must be 0, 1, or 2 but is " << dimension);
-  Index<3> subcell_face_extents = subcell_extents;
-  ++subcell_face_extents[dimension];
-  for (size_t k = 0; k < subcell_extents[2]; ++k) {
-    for (size_t j = 0; j < subcell_extents[1]; ++j) {
-      for (size_t i = 0; i < subcell_extents[0]; ++i) {
-        Index<3> index(i, j, k);
-        const size_t volume_index = collapsed_index(index, subcell_extents);
-        const size_t boundary_correction_lower_index =
-            collapsed_index(index, subcell_face_extents);
-        ++index[dimension];
-        const size_t boundary_correction_upper_index =
-            collapsed_index(index, subcell_face_extents);
-        (*dt_var)[volume_index] +=
-            one_over_delta * inv_jacobian[volume_index] *
-            (boundary_correction[boundary_correction_upper_index] -
-             boundary_correction[boundary_correction_lower_index]);
-      }
-    }
-  }
-}
+                                   size_t dimension) noexcept;
 /// @}
 }  // namespace evolution::dg::subcell

--- a/src/Evolution/DgSubcell/Tags/Mesh.hpp
+++ b/src/Evolution/DgSubcell/Tags/Mesh.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstddef>
+#include <string>
 
 #include "DataStructures/DataBox/Tag.hpp"
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/CMakeLists.txt
@@ -31,4 +31,5 @@ spectre_target_headers(
   TciOnDgGrid.hpp
   TciOnFdGrid.hpp
   TciOptions.hpp
+  TimeDerivative.hpp
   )

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TimeDerivative.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TimeDerivative.hpp
@@ -1,0 +1,347 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <optional>
+#include <type_traits>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/BoundaryCorrectionTags.hpp"
+#include "Evolution/DgSubcell/CartesianFluxDivergence.hpp"
+#include "Evolution/DgSubcell/ComputeBoundaryTerms.hpp"
+#include "Evolution/DgSubcell/CorrectPackagedData.hpp"
+#include "Evolution/DgSubcell/Tags/Coordinates.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/OnSubcellFaces.hpp"
+#include "Evolution/DiscontinuousGalerkin/Actions/NormalCovectorAndMagnitude.hpp"
+#include "Evolution/DiscontinuousGalerkin/Actions/PackageDataImpl.hpp"
+#include "Evolution/DiscontinuousGalerkin/MortarTags.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/BoundaryCorrection.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Reconstructor.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Tag.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Sources.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ComputeFluxes.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/FakeVirtual.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace grmhd::ValenciaDivClean::subcell {
+/*!
+ * \brief Compute the time derivative on the subcell grid using FD
+ * reconstruction.
+ *
+ * The code makes the following unchecked assumptions:
+ * - Assumes Cartesian coordinates with a diagonal Jacobian matrix
+ * from the logical to the inertial frame
+ * - Assumes the mesh is not moving (grid and inertial frame are the same)
+ */
+struct TimeDerivative {
+  template <typename DbTagsList>
+  static void apply(
+      const gsl::not_null<db::DataBox<DbTagsList>*> box,
+      const InverseJacobian<DataVector, 3, Frame::Logical, Frame::Grid>&
+          cell_centered_logical_to_grid_inv_jacobian,
+      const Scalar<DataVector>& /*cell_centered_det_inv_jacobian*/) noexcept {
+    using evolved_vars_tag = typename System::variables_tag;
+    using evolved_vars_tags = typename evolved_vars_tag::tags_list;
+    using prim_tags = typename System::primitive_variables_tag::tags_list;
+    using recons_prim_tags = tmpl::push_back<
+        prim_tags,
+        hydro::Tags::LorentzFactorTimesSpatialVelocity<DataVector, 3>>;
+    using fluxes_tags = db::wrap_tags_in<::Tags::Flux, evolved_vars_tags,
+                                         tmpl::size_t<3>, Frame::Inertial>;
+
+    // The copy of Mesh is intentional to avoid a GCC-7 internal compiler error.
+    const Mesh<3> subcell_mesh =
+        db::get<evolution::dg::subcell::Tags::Mesh<3>>(*box);
+    ASSERT(
+        subcell_mesh == Mesh<3>(subcell_mesh.extents(0), subcell_mesh.basis(0),
+                                subcell_mesh.quadrature(0)),
+        "The subcell/FD mesh must be isotropic for the FD time derivative but "
+        "got "
+            << subcell_mesh);
+    const size_t num_pts = subcell_mesh.number_of_grid_points();
+    const size_t reconstructed_num_pts =
+        (subcell_mesh.extents(0) + 1) *
+        subcell_mesh.extents().slice_away(0).product();
+
+    const tnsr::I<DataVector, 3, Frame::Logical>& cell_centered_logical_coords =
+        db::get<evolution::dg::subcell::Tags::Coordinates<3, Frame::Logical>>(
+            *box);
+    std::array<double, 3> one_over_delta_xi{};
+    for (size_t i = 0; i < 3; ++i) {
+      // Note: assumes isotropic extents
+      gsl::at(one_over_delta_xi, i) =
+          1.0 / (get<0>(cell_centered_logical_coords)[1] -
+                 get<0>(cell_centered_logical_coords)[0]);
+    }
+
+    const grmhd::ValenciaDivClean::fd::Reconstructor& recons =
+        db::get<grmhd::ValenciaDivClean::fd::Tags::Reconstructor>(*box);
+
+    const Element<3>& element = db::get<domain::Tags::Element<3>>(*box);
+    ASSERT(element.external_boundaries().size() == 0,
+           "Can't have external boundaries right now with subcell. ElementID "
+               << element.id());
+
+    // Now package the data and compute the correction
+    const auto& boundary_correction =
+        db::get<evolution::Tags::BoundaryCorrection<System>>(*box);
+    using derived_boundary_corrections =
+        typename std::decay_t<decltype(boundary_correction)>::creatable_classes;
+    std::array<Variables<evolved_vars_tags>, 3> boundary_corrections{};
+    tmpl::for_each<
+        derived_boundary_corrections>([&](auto derived_correction_v) noexcept {
+      using DerivedCorrection = tmpl::type_from<decltype(derived_correction_v)>;
+      if (typeid(boundary_correction) == typeid(DerivedCorrection)) {
+        using dg_package_data_temporary_tags =
+            typename DerivedCorrection::dg_package_data_temporary_tags;
+        using dg_package_data_argument_tags = tmpl::append<
+            evolved_vars_tags, recons_prim_tags, fluxes_tags,
+            tmpl::remove_duplicates<tmpl::push_back<
+                dg_package_data_temporary_tags, gr::Tags::SpatialMetric<3>,
+                gr::Tags::SqrtDetSpatialMetric<DataVector>,
+                gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>,
+                evolution::dg::Actions::detail::NormalVector<3>>>>;
+        // Computed prims and cons on face via reconstruction
+        auto vars_on_lower_face = make_array<3>(
+            Variables<dg_package_data_argument_tags>(reconstructed_num_pts));
+        auto vars_on_upper_face = make_array<3>(
+            Variables<dg_package_data_argument_tags>(reconstructed_num_pts));
+        // Copy over the face values of the metric quantities.
+        using spacetime_vars_to_copy = tmpl::list<
+            gr::Tags::Lapse<DataVector>,
+            gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+            gr::Tags::SpatialMetric<3>,
+            gr::Tags::SqrtDetSpatialMetric<DataVector>,
+            gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>>;
+        tmpl::for_each<spacetime_vars_to_copy>(
+            [&vars_on_lower_face, &vars_on_upper_face,
+             &spacetime_vars_on_face =
+                 db::get<evolution::dg::subcell::Tags::OnSubcellFaces<
+                     typename System::flux_spacetime_variables_tag, 3>>(*box)](
+                auto tag_v) noexcept {
+              using tag = tmpl::type_from<decltype(tag_v)>;
+              for (size_t d = 0; d < 3; ++d) {
+                get<tag>(gsl::at(vars_on_lower_face, d)) =
+                    get<tag>(gsl::at(spacetime_vars_on_face, d));
+                get<tag>(gsl::at(vars_on_upper_face, d)) =
+                    get<tag>(gsl::at(spacetime_vars_on_face, d));
+              }
+            });
+
+        // Reconstruct data to the face
+        call_with_dynamic_type<void, typename grmhd::ValenciaDivClean::fd::
+                                         Reconstructor::creatable_classes>(
+            &recons, [&box, &vars_on_lower_face,
+                      &vars_on_upper_face](const auto& reconstructor) noexcept {
+              db::apply<typename std::decay_t<decltype(
+                  *reconstructor)>::reconstruction_argument_tags>(
+                  [&vars_on_lower_face, &vars_on_upper_face,
+                   &reconstructor](const auto&... args) noexcept {
+                    reconstructor->reconstruct(
+                        make_not_null(&vars_on_lower_face),
+                        make_not_null(&vars_on_upper_face), args...);
+                  },
+                  *box);
+            });
+
+        using dg_package_field_tags =
+            typename DerivedCorrection::dg_package_field_tags;
+        // Allocated outside for loop to reduce allocations
+        Variables<dg_package_field_tags> upper_packaged_data{
+            reconstructed_num_pts};
+        Variables<dg_package_field_tags> lower_packaged_data{
+            reconstructed_num_pts};
+
+        // Compute fluxes on faces
+        for (size_t i = 0; i < 3; ++i) {
+          auto& vars_upper_face = gsl::at(vars_on_upper_face, i);
+          auto& vars_lower_face = gsl::at(vars_on_lower_face, i);
+          grmhd::ValenciaDivClean::subcell::compute_fluxes(
+              make_not_null(&vars_upper_face));
+          grmhd::ValenciaDivClean::subcell::compute_fluxes(
+              make_not_null(&vars_lower_face));
+
+          // Normal vectors in curved spacetime normalized by inverse
+          // spatial metric. Since we assume a Cartesian grid, this is
+          // relatively easy. Note that we use the sign convention on
+          // the normal vectors to be compatible with DG.
+          //
+          // Note that these normal vectors are on all faces inside the DG
+          // element since there are a bunch of subcells. We don't use the
+          // NormalCovectorAndMagnitude tag in the DataBox right now to avoid
+          // conflicts with the DG solver. We can explore in the future if it's
+          // possible to reuse that allocation.
+          const Scalar<DataVector> normalization{sqrt(
+              get<gr::Tags::InverseSpatialMetric<3, Frame::Inertial,
+                                                 DataVector>>(vars_upper_face)
+                  .get(i, i))};
+
+          tnsr::i<DataVector, 3, Frame::Inertial> lower_outward_conormal{
+              reconstructed_num_pts, 0.0};
+          lower_outward_conormal.get(i) = 1.0 / get(normalization);
+
+          tnsr::i<DataVector, 3, Frame::Inertial> upper_outward_conormal{
+              reconstructed_num_pts, 0.0};
+          upper_outward_conormal.get(i) = -lower_outward_conormal.get(i);
+          // Note: we probably should compute the normal vector in addition to
+          // the co-vector. Not a huge issue since we'll get an FPE right now if
+          // it's used by a Riemann solver.
+
+          // Compute the packaged data
+          using dg_package_data_projected_tags = tmpl::append<
+              evolved_vars_tags, fluxes_tags, dg_package_data_temporary_tags,
+              typename DerivedCorrection::dg_package_data_primitive_tags>;
+          evolution::dg::Actions::detail::dg_package_data<System>(
+              make_not_null(&upper_packaged_data),
+              dynamic_cast<const DerivedCorrection&>(boundary_correction),
+              vars_upper_face, upper_outward_conormal, {std::nullopt}, *box,
+              typename DerivedCorrection::dg_package_data_volume_tags{},
+              dg_package_data_projected_tags{});
+
+          evolution::dg::Actions::detail::dg_package_data<System>(
+              make_not_null(&lower_packaged_data),
+              dynamic_cast<const DerivedCorrection&>(boundary_correction),
+              vars_lower_face, lower_outward_conormal, {std::nullopt}, *box,
+              typename DerivedCorrection::dg_package_data_volume_tags{},
+              dg_package_data_projected_tags{});
+
+          // Now need to check if any of our neighbors are doing DG,
+          // because if so then we need to use whatever boundary data
+          // they sent instead of what we computed locally.
+          //
+          // Note: We could check this beforehand to avoid the extra
+          // work of reconstruction and flux computations at the
+          // boundaries.
+          evolution::dg::subcell::correct_package_data<true>(
+              make_not_null(&lower_packaged_data),
+              make_not_null(&upper_packaged_data), i, element, subcell_mesh,
+              db::get<evolution::dg::Tags::MortarData<3>>(*box));
+
+          // Compute the corrections on the faces. We only need to
+          // compute this once because we can just flip the normal
+          // vectors then
+          gsl::at(boundary_corrections, i).initialize(reconstructed_num_pts);
+          evolution::dg::subcell::compute_boundary_terms(
+              make_not_null(&gsl::at(boundary_corrections, i)),
+              dynamic_cast<const DerivedCorrection&>(boundary_correction),
+              upper_packaged_data, lower_packaged_data);
+          // We need to multiply by the normal vector normalization
+          gsl::at(boundary_corrections, i) *= get(normalization);
+        }
+      }
+    });
+
+    // Now compute the actual time derivatives.
+    using variables_tag = typename System::variables_tag;
+    using dt_variables_tag = db::add_tag_prefix<::Tags::dt, variables_tag>;
+    db::mutate_apply<
+        tmpl::list<dt_variables_tag>,
+        tmpl::list<
+            grmhd::ValenciaDivClean::Tags::TildeD,
+            grmhd::ValenciaDivClean::Tags::TildeTau,
+            grmhd::ValenciaDivClean::Tags::TildeS<>,
+            grmhd::ValenciaDivClean::Tags::TildeB<>,
+            grmhd::ValenciaDivClean::Tags::TildePhi,
+            hydro::Tags::SpatialVelocity<DataVector, 3>,
+            hydro::Tags::MagneticField<DataVector, 3>,
+            hydro::Tags::RestMassDensity<DataVector>,
+            hydro::Tags::SpecificEnthalpy<DataVector>,
+            hydro::Tags::LorentzFactor<DataVector>,
+            hydro::Tags::Pressure<DataVector>, gr::Tags::Lapse<>,
+            ::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<3>,
+                          Frame::Inertial>,
+            ::Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+                          tmpl::size_t<3>, Frame::Inertial>,
+            gr::Tags::SpatialMetric<3>,
+            ::Tags::deriv<
+                gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+                tmpl::size_t<3>, Frame::Inertial>,
+            gr::Tags::InverseSpatialMetric<3>, gr::Tags::SqrtDetSpatialMetric<>,
+            gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>,
+            grmhd::ValenciaDivClean::Tags::ConstraintDampingParameter>>(
+        [&cell_centered_logical_to_grid_inv_jacobian, &num_pts,
+         &boundary_corrections, &subcell_mesh, &one_over_delta_xi](
+            const auto dt_vars_ptr, const auto&... source_args) noexcept {
+          dt_vars_ptr->initialize(num_pts, 0.0);
+          using TildeD = grmhd::ValenciaDivClean::Tags::TildeD;
+          using TildeTau = grmhd::ValenciaDivClean::Tags::TildeTau;
+          using TildeS = grmhd::ValenciaDivClean::Tags::TildeS<Frame::Inertial>;
+          using TildeB = grmhd::ValenciaDivClean::Tags::TildeB<Frame::Inertial>;
+          using TildePhi = grmhd::ValenciaDivClean::Tags::TildePhi;
+
+          auto& dt_tilde_d = get<::Tags::dt<TildeD>>(*dt_vars_ptr);
+          auto& dt_tilde_tau = get<::Tags::dt<TildeTau>>(*dt_vars_ptr);
+          auto& dt_tilde_s = get<::Tags::dt<TildeS>>(*dt_vars_ptr);
+          auto& dt_tilde_b = get<::Tags::dt<TildeB>>(*dt_vars_ptr);
+          auto& dt_tilde_phi = get<::Tags::dt<TildePhi>>(*dt_vars_ptr);
+
+          grmhd::ValenciaDivClean::ComputeSources::apply(
+              make_not_null(&dt_tilde_tau), make_not_null(&dt_tilde_s),
+              make_not_null(&dt_tilde_b), make_not_null(&dt_tilde_phi),
+              source_args...);
+
+          for (size_t dim = 0; dim < 3; ++dim) {
+            Scalar<DataVector>& tilde_d_density_correction =
+                get<TildeD>(gsl::at(boundary_corrections, dim));
+            Scalar<DataVector>& tilde_tau_density_correction =
+                get<TildeTau>(gsl::at(boundary_corrections, dim));
+            tnsr::i<DataVector, 3, Frame::Inertial>&
+                tilde_s_density_correction =
+                    get<TildeS>(gsl::at(boundary_corrections, dim));
+            tnsr::I<DataVector, 3, Frame::Inertial>&
+                tilde_b_density_correction =
+                    get<TildeB>(gsl::at(boundary_corrections, dim));
+            Scalar<DataVector>& tilde_phi_density_correction =
+                get<TildePhi>(gsl::at(boundary_corrections, dim));
+            evolution::dg::subcell::add_cartesian_flux_divergence(
+                make_not_null(&get(dt_tilde_d)),
+                gsl::at(one_over_delta_xi, dim),
+                cell_centered_logical_to_grid_inv_jacobian.get(dim, dim),
+                get(tilde_d_density_correction), subcell_mesh.extents(), dim);
+            evolution::dg::subcell::add_cartesian_flux_divergence(
+                make_not_null(&get(dt_tilde_tau)),
+                gsl::at(one_over_delta_xi, dim),
+                cell_centered_logical_to_grid_inv_jacobian.get(dim, dim),
+                get(tilde_tau_density_correction), subcell_mesh.extents(), dim);
+            for (size_t d = 0; d < 3; ++d) {
+              evolution::dg::subcell::add_cartesian_flux_divergence(
+                  make_not_null(&dt_tilde_s.get(d)),
+                  gsl::at(one_over_delta_xi, dim),
+                  cell_centered_logical_to_grid_inv_jacobian.get(dim, dim),
+                  tilde_s_density_correction.get(d), subcell_mesh.extents(),
+                  dim);
+              evolution::dg::subcell::add_cartesian_flux_divergence(
+                  make_not_null(&dt_tilde_b.get(d)),
+                  gsl::at(one_over_delta_xi, dim),
+                  cell_centered_logical_to_grid_inv_jacobian.get(dim, dim),
+                  tilde_b_density_correction.get(d), subcell_mesh.extents(),
+                  dim);
+            }
+            evolution::dg::subcell::add_cartesian_flux_divergence(
+                make_not_null(&get(dt_tilde_phi)),
+                gsl::at(one_over_delta_xi, dim),
+                cell_centered_logical_to_grid_inv_jacobian.get(dim, dim),
+                get(tilde_phi_density_correction), subcell_mesh.extents(), dim);
+          }
+        },
+        box);
+  }
+};
+}  // namespace grmhd::ValenciaDivClean::subcell

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -22,6 +22,7 @@ set(LIBRARY_SOURCES
   Subcell/Test_TciOnDgGrid.cpp
   Subcell/Test_TciOnFdGrid.cpp
   Subcell/Test_TciOptions.cpp
+  Subcell/Test_TimeDerivative.cpp
   Test_Characteristics.cpp
   Test_ConservativeFromPrimitive.cpp
   Test_FixConservatives.cpp

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TimeDerivative.cpp
@@ -1,0 +1,242 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Tensor/EagerMath/Determinant.hpp"
+#include "Domain/Block.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CreateInitialElement.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/BoundaryCorrectionTags.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
+#include "Evolution/DgSubcell/SliceData.hpp"
+#include "Evolution/DgSubcell/Tags/Coordinates.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/OnSubcellFaces.hpp"
+#include "Evolution/DiscontinuousGalerkin/MortarTags.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/BoundaryCorrection.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Factory.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotisedCentral.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Tag.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TimeDerivative.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+
+namespace grmhd::ValenciaDivClean {
+namespace {
+template <size_t Dim, typename... Maps, typename Solution>
+auto face_centered_gr_tags(
+    const Mesh<Dim>& subcell_mesh, const double time,
+    const domain::CoordinateMap<Frame::Logical, Frame::Inertial, Maps...>& map,
+    const Solution& soln) {
+  std::array<typename System::flux_spacetime_variables_tag::type, Dim>
+      face_centered_gr_vars{};
+
+  for (size_t d = 0; d < Dim; ++d) {
+    const auto basis = make_array<Dim>(subcell_mesh.basis(0));
+    auto quadrature = make_array<Dim>(subcell_mesh.quadrature(0));
+    auto extents = make_array<Dim>(subcell_mesh.extents(0));
+    gsl::at(extents, d) = subcell_mesh.extents(0) + 1;
+    gsl::at(quadrature, d) = Spectral::Quadrature::FaceCentered;
+    const Mesh<Dim> face_centered_mesh{extents, basis, quadrature};
+    const auto face_centered_logical_coords =
+        logical_coordinates(face_centered_mesh);
+    const auto face_centered_inertial_coords =
+        map(face_centered_logical_coords);
+
+    gsl::at(face_centered_gr_vars, d)
+        .initialize(face_centered_mesh.number_of_grid_points());
+    gsl::at(face_centered_gr_vars, d)
+        .assign_subset(soln.variables(
+            face_centered_inertial_coords, time,
+            typename System::flux_spacetime_variables_tag::tags_list{}));
+  }
+  return face_centered_gr_vars;
+}
+
+std::array<double, 4> test(const size_t num_dg_pts) {
+  using Affine = domain::CoordinateMaps::Affine;
+  using Affine3D =
+      domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  const Affine affine_map{-1.0, 1.0, 8.0, 9.0};
+  const auto coordinate_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
+          Affine3D{affine_map, affine_map, affine_map});
+  const auto element = domain::Initialization::create_initial_element(
+      ElementId<3>{0, {SegmentId{3, 4}, SegmentId{3, 4}, SegmentId{3, 4}}},
+      Block<3>{
+          domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+              Affine3D{affine_map, affine_map, affine_map}),
+          0,
+          {},
+          {}},
+      std::vector<std::array<size_t, 3>>{std::array<size_t, 3>{{3, 3, 3}}});
+
+  const grmhd::Solutions::BondiMichel soln{1.0, 5.0, 0.05, 1.4, 2.0};
+
+  const double time = 0.0;
+  const Mesh<3> dg_mesh{num_dg_pts, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto};
+  const Mesh<3> subcell_mesh = evolution::dg::subcell::fd::mesh(dg_mesh);
+  const auto cell_centered_coords =
+      coordinate_map(logical_coordinates(subcell_mesh));
+
+  Variables<typename System::spacetime_variables_tag::tags_list>
+      cell_centered_spacetime_vars{subcell_mesh.number_of_grid_points()};
+  cell_centered_spacetime_vars.assign_subset(
+      soln.variables(cell_centered_coords, time,
+                     typename System::spacetime_variables_tag::tags_list{}));
+  Variables<typename System::primitive_variables_tag::tags_list>
+      cell_centered_prim_vars{subcell_mesh.number_of_grid_points()};
+  cell_centered_prim_vars.assign_subset(
+      soln.variables(cell_centered_coords, time,
+                     typename System::primitive_variables_tag::tags_list{}));
+  using variables_tag = typename System::variables_tag;
+  using dt_variables_tag = db::add_tag_prefix<::Tags::dt, variables_tag>;
+
+  // Neighbor data for reconstruction.
+  //
+  // 0. neighbors coords (our logical coords +2)
+  // 1. compute prims from solution
+  // 2. compute prims needed for reconstruction
+  // 3. set neighbor data
+  evolution::dg::subcell::Tags::NeighborDataForReconstructionAndRdmpTci<3>::type
+      neighbor_data{};
+  using prims_to_reconstruct_tags =
+      tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
+                 hydro::Tags::Pressure<DataVector>,
+                 hydro::Tags::LorentzFactorTimesSpatialVelocity<DataVector, 3>,
+                 hydro::Tags::MagneticField<DataVector, 3>,
+                 hydro::Tags::DivergenceCleaningField<DataVector>>;
+  for (const Direction<3>& direction : Direction<3>::all_directions()) {
+    auto neighbor_logical_coords = logical_coordinates(subcell_mesh);
+    neighbor_logical_coords.get(direction.dimension()) +=
+        2.0 * direction.sign();
+    auto neighbor_coords = coordinate_map(neighbor_logical_coords);
+    const auto neighbor_prims =
+        soln.variables(neighbor_coords, time,
+                       typename System::primitive_variables_tag::tags_list{});
+    Variables<prims_to_reconstruct_tags> prims_to_reconstruct{
+        subcell_mesh.number_of_grid_points()};
+    get<hydro::Tags::RestMassDensity<DataVector>>(prims_to_reconstruct) =
+        get<hydro::Tags::RestMassDensity<DataVector>>(neighbor_prims);
+    get<hydro::Tags::Pressure<DataVector>>(prims_to_reconstruct) =
+        get<hydro::Tags::Pressure<DataVector>>(neighbor_prims);
+    get<hydro::Tags::LorentzFactorTimesSpatialVelocity<DataVector, 3>>(
+        prims_to_reconstruct) =
+        get<hydro::Tags::SpatialVelocity<DataVector, 3>>(neighbor_prims);
+    for (auto& component :
+         get<hydro::Tags::LorentzFactorTimesSpatialVelocity<DataVector, 3>>(
+             prims_to_reconstruct)) {
+      component *=
+          get(get<hydro::Tags::LorentzFactor<DataVector>>(neighbor_prims));
+    }
+    get<hydro::Tags::MagneticField<DataVector, 3>>(prims_to_reconstruct) =
+        get<hydro::Tags::MagneticField<DataVector, 3>>(neighbor_prims);
+    get<hydro::Tags::DivergenceCleaningField<DataVector>>(
+        prims_to_reconstruct) =
+        get<hydro::Tags::DivergenceCleaningField<DataVector>>(neighbor_prims);
+
+    // Slice data so we can add it to the element's neighbor data
+    DirectionMap<3, bool> directions_to_slice{};
+    directions_to_slice[direction.opposite()] = true;
+    evolution::dg::subcell::NeighborData neighbor_data_in_direction{};
+    neighbor_data_in_direction.data_for_reconstruction =
+        evolution::dg::subcell::slice_data(
+            prims_to_reconstruct, subcell_mesh.extents(),
+            grmhd::ValenciaDivClean::fd::MonotisedCentralPrim{}
+                .ghost_zone_size(),
+            directions_to_slice)
+            .at(direction.opposite());
+    neighbor_data[std::pair{direction,
+                            *element.neighbors().at(direction).begin()}] =
+        neighbor_data_in_direction;
+  }
+
+  auto box = db::create<
+      db::AddSimpleTags<
+          domain::Tags::Element<3>, evolution::dg::subcell::Tags::Mesh<3>,
+          fd::Tags::Reconstructor,
+          evolution::Tags::BoundaryCorrection<grmhd::ValenciaDivClean::System>,
+          hydro::Tags::EquationOfState<EquationsOfState::PolytropicFluid<true>>,
+          typename System::spacetime_variables_tag,
+          typename System::primitive_variables_tag, dt_variables_tag,
+          variables_tag,
+          evolution::dg::subcell::Tags::OnSubcellFaces<
+              typename System::flux_spacetime_variables_tag, 3>,
+          evolution::dg::subcell::Tags::NeighborDataForReconstructionAndRdmpTci<
+              3>,
+          Tags::ConstraintDampingParameter, evolution::dg::Tags::MortarData<3>>,
+      db::AddComputeTags<
+          evolution::dg::subcell::Tags::LogicalCoordinatesCompute<3>>>(
+      element, subcell_mesh,
+      std::unique_ptr<grmhd::ValenciaDivClean::fd::Reconstructor>{
+          std::make_unique<
+              grmhd::ValenciaDivClean::fd::MonotisedCentralPrim>()},
+      std::unique_ptr<
+          grmhd::ValenciaDivClean::BoundaryCorrections::BoundaryCorrection>{
+          std::make_unique<
+              grmhd::ValenciaDivClean::BoundaryCorrections::Hll>()},
+      soln.equation_of_state(), cell_centered_spacetime_vars,
+      cell_centered_prim_vars,
+      Variables<typename dt_variables_tag::tags_list>{
+          subcell_mesh.number_of_grid_points()},
+      typename variables_tag::type{},
+      face_centered_gr_tags(subcell_mesh, time, coordinate_map, soln),
+      neighbor_data, 1.0, evolution::dg::Tags::MortarData<3>::type{});
+  db::mutate_apply<ConservativeFromPrimitive>(make_not_null(&box));
+
+  InverseJacobian<DataVector, 3, Frame::Logical, Frame::Grid>
+      cell_centered_logical_to_grid_inv_jacobian{};
+  const auto cell_centered_logical_to_inertial_inv_jacobian =
+      coordinate_map.inv_jacobian(logical_coordinates(subcell_mesh));
+  for (size_t i = 0; i < cell_centered_logical_to_grid_inv_jacobian.size();
+       ++i) {
+    cell_centered_logical_to_grid_inv_jacobian[i] =
+        cell_centered_logical_to_inertial_inv_jacobian[i];
+  }
+  subcell::TimeDerivative::apply(
+      make_not_null(&box), cell_centered_logical_to_grid_inv_jacobian,
+      determinant(cell_centered_logical_to_grid_inv_jacobian));
+
+  const auto& dt_vars = db::get<dt_variables_tag>(box);
+  return {{max(abs(get(get<::Tags::dt<Tags::TildeD>>(dt_vars)))),
+           max(abs(get(get<::Tags::dt<Tags::TildeTau>>(dt_vars)))),
+           max(get(magnitude(get<::Tags::dt<Tags::TildeS<>>>(dt_vars)))),
+           max(get(magnitude(get<::Tags::dt<Tags::TildeB<>>>(dt_vars))))}};
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.ValenciaDivClean.Subcell.TimeDerivative",
+    "[Unit][Evolution]") {
+  // This tests sets up a cube [2,3]^3 in a Bondi-Michel spacetime and verifies
+  // that the time derivative vanishes. Or, more specifically, that the time
+  // derivative decreases with increasing resolution.
+  const auto four_pts_data = test(4);
+  const auto eight_pts_data = test(8);
+
+  for (size_t i = 0; i < four_pts_data.size(); ++i) {
+    CHECK(gsl::at(eight_pts_data, i) < gsl::at(four_pts_data, i));
+  }
+}
+}  // namespace
+}  // namespace grmhd::ValenciaDivClean


### PR DESCRIPTION
## Proposed changes

Add class with member function that performs the FD time derivative computation on a static Cartesian grid. 

**Note:** the following commits are new:
- Add missing include to subcell::Mesh tag file
- Move CartesianFluxDivergence to cpp file 
- Add subcell TimeDerivative struct for ValenciaDivClean

Depends on:
- [x] #3319

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
