### PR TITLE
Make the Krivodonova limiter copyable

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Krivodonova.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Krivodonova.hpp
@@ -472,8 +472,8 @@ class Krivodonova<VolumeDim, tmpl::list<Tags...>> {
       bool disable_for_debugging = false, const Options::Context& context = {});
 
   Krivodonova() = default;
-  Krivodonova(const Krivodonova&) = delete;
-  Krivodonova& operator=(const Krivodonova&) = delete;
+  Krivodonova(const Krivodonova&) = default;
+  Krivodonova& operator=(const Krivodonova&) = default;
   Krivodonova(Krivodonova&&) = default;
   Krivodonova& operator=(Krivodonova&&) = default;
   ~Krivodonova() = default;


### PR DESCRIPTION
## Proposed changes

This is necessary in order to use it in some executables.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
