### PR TITLE
Add error-based step chooser to executables

### DIFF
--- a/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
@@ -61,22 +61,6 @@ namespace Actions {
 template <typename EvolvedCoordinatesVariablesTag, typename EvolvedSwshTag,
           bool local_time_stepping>
 struct InitializeCharacteristicEvolutionTime {
-  using initialization_tags = tmpl::flatten<tmpl::list<
-      Tags::CceEvolutionPrefix<
-          Initialization::Tags::InitialSlabSize<local_time_stepping>>,
-      tmpl::conditional_t<
-          local_time_stepping,
-          tmpl::list<
-              ::Tags::IsUsingTimeSteppingErrorControl<
-                  OptionTags::CceEvolutionPrefix>,
-              Tags::CceEvolutionPrefix<::Tags::TimeStepper<LtsTimeStepper>>,
-              Tags::CceEvolutionPrefix<::Tags::StepChoosers>,
-              Tags::CceEvolutionPrefix<::Tags::StepController>,
-              ::Initialization::Tags::InitialTimeDelta>,
-          tmpl::list<
-              ::Tags::NeverUsingTimeSteppingErrorControl,
-              Tags::CceEvolutionPrefix<::Tags::TimeStepper<TimeStepper>>>>>>;
-
   using initialization_tags_to_keep =
       tmpl::flatten<tmpl::list<tmpl::conditional_t<
           local_time_stepping,
@@ -90,6 +74,11 @@ struct InitializeCharacteristicEvolutionTime {
           tmpl::list<
               ::Tags::NeverUsingTimeSteppingErrorControl,
               Tags::CceEvolutionPrefix<::Tags::TimeStepper<TimeStepper>>>>>>;
+
+  using initialization_tags = tmpl::push_front<
+      initialization_tags_to_keep,
+      Tags::CceEvolutionPrefix<
+          Initialization::Tags::InitialSlabSize<local_time_stepping>>>;
 
   using const_global_cache_tags = tmpl::list<>;
 

--- a/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
@@ -189,17 +189,19 @@ struct CharacteristicEvolution {
           CharacteristicEvolution<Metavariables>>,
       Actions::ReceiveWorldtubeData<Metavariables>,
       Actions::InitializeFirstHypersurface,
-      ::Actions::Label<CceEvolutionLabelTag>,
-      Actions::RequestNextBoundaryData<
-          typename Metavariables::cce_boundary_component,
-          CharacteristicEvolution<Metavariables>>,
-      Actions::UpdateGauge, Actions::PrecomputeGlobalCceDependencies,
+      ::Actions::Label<CceEvolutionLabelTag>, Actions::UpdateGauge,
+      Actions::PrecomputeGlobalCceDependencies,
       tmpl::transform<bondi_hypersurface_step_tags,
                       tmpl::bind<hypersurface_computation, tmpl::_1>>,
       Actions::FilterSwshVolumeQuantity<Tags::BondiH>,
       compute_scri_quantities_and_observe, record_time_stepper_data_and_step,
-      ::Actions::ChangeStepSize, ::Actions::AdvanceTime,
-      Actions::ExitIfEndTimeReached,
+      ::Actions::ChangeStepSize,
+      // We cannot know our next step for certain until after we've performed
+      // step size selection, as we may need to reject a step.
+      Actions::RequestNextBoundaryData<
+          typename Metavariables::cce_boundary_component,
+          CharacteristicEvolution<Metavariables>>,
+      ::Actions::AdvanceTime, Actions::ExitIfEndTimeReached,
       Actions::ReceiveWorldtubeData<Metavariables>,
       ::Actions::Goto<CceEvolutionLabelTag>>;
 

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -208,9 +208,11 @@ struct Metavariables {
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes = tmpl::map<
         tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
+        tmpl::pair<StepChooser<StepChooserUse::LtsStep>, tmpl::list<>>,
+        tmpl::pair<StepChooser<StepChooserUse::Slab>, tmpl::list<>>,
         tmpl::pair<Event, tmpl::list<Events::Completion>>,
-        tmpl::pair<Trigger, tmpl::list<Triggers::SlabCompares,
-                                       Triggers::TimeCompares>>>;
+        tmpl::pair<Trigger,
+                   tmpl::list<Triggers::SlabCompares, Triggers::TimeCompares>>>;
   };
 
   enum class Phase { Initialization, RegisterWithObserver, Export, Exit };

--- a/src/Time/StepChoosers/CMakeLists.txt
+++ b/src/Time/StepChoosers/CMakeLists.txt
@@ -15,6 +15,7 @@ spectre_target_headers(
   ByBlock.hpp
   Cfl.hpp
   Constant.hpp
+  ElementSizeCfl.hpp
   ErrorControl.hpp
   Factory.hpp
   Increase.hpp

--- a/src/Time/StepChoosers/ElementSizeCfl.hpp
+++ b/src/Time/StepChoosers/ElementSizeCfl.hpp
@@ -1,0 +1,105 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <limits>
+#include <pup.h>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Time/StepChoosers/StepChooser.hpp"
+#include "Domain/SizeOfElement.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Parallel {
+template <typename Metavariables>
+class GlobalCache;
+}  // namespace Parallel
+namespace domain {
+namespace Tags {
+template <size_t Dim>
+struct SizeOfElement;
+}  // namespace Tags
+}  // namespace domain
+// IWYU pragma: no_forward_declare db::DataBox
+/// \endcond
+
+namespace StepChoosers {
+/// Suggests a step size based on the CFL stability criterion, but uses the full
+/// size of the element as the length scale in question.
+///
+/// This is useful as a coarse estimate for slabs, or to place a ceiling on
+/// another dynamically-adjusted step chooser.
+template <typename StepChooserUse, size_t Dim, typename System>
+class ElementSizeCfl : public StepChooser<StepChooserUse> {
+ public:
+  /// \cond
+  ElementSizeCfl() = default;
+  explicit ElementSizeCfl(CkMigrateMessage* /*unused*/) noexcept {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(ElementSizeCfl);  // NOLINT
+  /// \endcond
+
+  struct SafetyFactor {
+    using type = double;
+    static constexpr Options::String help{"Multiplier for computed step"};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+
+  static constexpr Options::String help{
+      "Suggests a step size based on the CFL stability criterion, but in which "
+      "the entire size of the element is used as the spacing in the "
+      "computation. This is useful primarily for placing a ceiling on another "
+      "dynamically-adjusted step chooser"};
+  using options = tmpl::list<SafetyFactor>;
+
+  explicit ElementSizeCfl(const double safety_factor) noexcept
+      : safety_factor_(safety_factor) {}
+
+  using argument_tags =
+      tmpl::list<::Tags::TimeStepper<>, domain::Tags::SizeOfElement<Dim>,
+                 typename System::compute_largest_characteristic_speed>;
+  using return_tags = tmpl::list<>;
+  using compute_tags =
+      tmpl::list<domain::Tags::SizeOfElementCompute<Dim>,
+                 typename System::compute_largest_characteristic_speed>;
+
+  template <typename Metavariables>
+  std::pair<double, bool> operator()(
+      const typename Metavariables::time_stepper_tag::type::element_type&
+          time_stepper,
+      const std::array<double, Dim>& element_size, const double speed,
+      const double last_step_magnitude,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/) const noexcept {
+    double min_size_of_element = std::numeric_limits<double>::infinity();
+    for (auto face_to_face_dimension : element_size) {
+      if (face_to_face_dimension < min_size_of_element) {
+        min_size_of_element = face_to_face_dimension;
+      }
+    }
+    const double time_stepper_stability_factor = time_stepper.stable_step();
+    const double step_size = safety_factor_ * time_stepper_stability_factor *
+                             min_size_of_element / (speed * Dim);
+    // Reject the step if the CFL condition is violated.
+    return std::make_pair(step_size, last_step_magnitude <= step_size);
+  }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) noexcept override { p | safety_factor_; }
+
+ private:
+  double safety_factor_ = std::numeric_limits<double>::signaling_NaN();
+};
+
+/// \cond
+template <typename StepChooserUse, size_t Dim, typename System>
+PUP::able::PUP_ID ElementSizeCfl<StepChooserUse, Dim, System>::my_PUP_ID =
+    0;  // NOLINT
+/// \endcond
+}  // namespace StepChoosers

--- a/src/Time/StepChoosers/ErrorControl.hpp
+++ b/src/Time/StepChoosers/ErrorControl.hpp
@@ -269,6 +269,9 @@ class ErrorControl : public StepChooser<StepChooserUse::LtsStep> {
             }
           });
       return result;
+    } else if constexpr (is_any_spin_weighted_v<
+                             std::remove_cv_t<EvolvedType>>) {
+      return error_calc_impl(values.data(), errors.data());
     }
   }
 

--- a/src/Time/StepChoosers/ErrorControl.hpp
+++ b/src/Time/StepChoosers/ErrorControl.hpp
@@ -277,13 +277,25 @@ PUP::able::PUP_ID
 }  // namespace StepChoosers
 
 namespace Tags {
+namespace detail {
+template <typename Tag>
+using NoPrefix = Tag;
+}  // detail
+
+/// \ingroup TimeGroup
+/// \brief Base tag for reporting whether the `ErrorControl` step chooser is in
+/// use.
+struct IsUsingTimeSteppingErrorControlBase : db::BaseTag {};
+
 /// \ingroup TimeGroup
 /// \brief A tag that is true if the `ErrorControl` step chooser is one of the
 /// option-created `Event`s.
-struct IsUsingTimeSteppingErrorControl : db::SimpleTag {
+template <template <typename> typename Prefix = detail::NoPrefix>
+struct IsUsingTimeSteppingErrorControl : db::SimpleTag,
+                                         IsUsingTimeSteppingErrorControlBase {
   using type = bool;
   template <typename Metavariables>
-  using option_tags = tmpl::list<::OptionTags::StepChoosers>;
+  using option_tags = tmpl::list<Prefix<::OptionTags::StepChoosers>>;
 
   static constexpr bool pass_metavariables = true;
   template <typename Metavariables>
@@ -317,5 +329,21 @@ struct IsUsingTimeSteppingErrorControl : db::SimpleTag {
         });
     return is_using_error_control;
   }
+};
+
+/// \ingroup TimeGroup
+/// \brief Tag indicating that the `ErrorControl` step chooser will not be used.
+///
+/// \details This can be useful when e.g. local time stepping is disabled and it
+/// is known at compile-time that the `ErrorControl` step chooser cannot be
+/// used.
+struct NeverUsingTimeSteppingErrorControl
+    : db::SimpleTag,
+      IsUsingTimeSteppingErrorControlBase {
+  using type = bool;
+  using option_tags = tmpl::list<>;
+
+  static constexpr bool pass_metavariables = false;
+  static bool create_from_options() noexcept { return false; }
 };
 }  // namespace Tags

--- a/src/Time/StepChoosers/ErrorControl.hpp
+++ b/src/Time/StepChoosers/ErrorControl.hpp
@@ -26,6 +26,14 @@ class GlobalCache;
 
 namespace StepChoosers {
 namespace Tags {
+/// \brief The stepper error measure computed in the previous application of the
+/// `StepChooser::ErrorControl` step chooser.
+///
+/// \details This tag is templated on `EvolvedVariableTag`, as a separate error
+/// measure should be stored for each evolved variables and corresponding
+/// `TimeSteppers::History` in the system, because the stepper is separately
+/// applied to each `TimeSteppers::History` object.
+template <typename EvolvedVariableTag>
 struct PreviousStepError : db::SimpleTag {
   using type = std::optional<double>;
 };
@@ -72,9 +80,11 @@ struct PreviousStepError : db::SimpleTag {
  * calculation. Intuitively, we should change the step less drastically for a
  * higher order stepper.
  *
- * After the first error calculation, the error \f$E\f$ is recorded, and
- * subsequent error calculations use a simple PI scheme suggested in
- * \cite NumericalRecipes section 17.2.1:
+ * After the first error calculation, the error \f$E\f$ is recorded in the \ref
+ * DataBoxGroup "DataBox" using tag
+ * `StepChoosers::Tags::PreviousStepError<EvolvedVariablesTag>`, and subsequent
+ * error calculations use a simple PI scheme suggested in \cite NumericalRecipes
+ * section 17.2.1:
  *
  * \f[
  * h_{\text{new}} = h \cdot \min\left(F_{\text{max}},
@@ -169,9 +179,9 @@ class ErrorControl : public StepChooser<StepChooserUse::LtsStep> {
                  db::add_tag_prefix<::Tags::StepperError, EvolvedVariableTag>,
                  ::Tags::StepperErrorUpdated, ::Tags::TimeStepper<>>;
 
-  using return_tags = tmpl::list<Tags::PreviousStepError>;
+  using return_tags = tmpl::list<Tags::PreviousStepError<EvolvedVariableTag>>;
 
-  using simple_tags = tmpl::list<Tags::PreviousStepError>;
+  using simple_tags = tmpl::list<Tags::PreviousStepError<EvolvedVariableTag>>;
 
   template <typename Metavariables, typename History, typename TimeStepper>
   std::pair<double, bool> operator()(

--- a/src/Time/StepChoosers/Factory.hpp
+++ b/src/Time/StepChoosers/Factory.hpp
@@ -7,6 +7,8 @@
 
 #include "Time/StepChoosers/Cfl.hpp"
 #include "Time/StepChoosers/Constant.hpp"
+#include "Time/StepChoosers/ElementSizeCfl.hpp"
+#include "Time/StepChoosers/ErrorControl.hpp"
 #include "Time/StepChoosers/Increase.hpp"
 #include "Time/StepChoosers/PreventRapidIncrease.hpp"
 #include "Time/StepChoosers/StepToTimes.hpp"
@@ -24,7 +26,9 @@ template <typename Use, typename System, bool HasCharSpeedFunctions>
 using common_step_choosers = tmpl::push_back<
     tmpl::conditional_t<
         HasCharSpeedFunctions,
-        tmpl::list<StepChoosers::Cfl<Use, Frame::Inertial, System>>,
+        tmpl::list<
+            StepChoosers::Cfl<Use, Frame::Inertial, System>,
+            StepChoosers::ElementSizeCfl<Use, System::volume_dim, System>>,
         tmpl::list<>>,
     StepChoosers::Constant<Use>, StepChoosers::Increase<Use>>;
 template <typename Use>
@@ -42,7 +46,8 @@ template <typename System, bool HasCharSpeedFunctions = true>
 using standard_step_choosers = tmpl::append<
     Factory_detail::common_step_choosers<StepChooserUse::LtsStep, System,
                                          HasCharSpeedFunctions>,
-    Factory_detail::step_choosers_for_step_only<StepChooserUse::LtsStep>>;
+    Factory_detail::step_choosers_for_step_only<StepChooserUse::LtsStep>,
+    tmpl::list<StepChoosers::ErrorControl<typename System::variables_tag>>>;
 
 template <typename System, bool LocalTimeStepping,
           bool HasCharSpeedFunctions = true>

--- a/tests/InputFiles/Cce/CharacteristicExtract.yaml
+++ b/tests/InputFiles/Cce/CharacteristicExtract.yaml
@@ -21,6 +21,18 @@ Cce:
       - Constant: 1.0
       - Increase:
           Factor: 2
+      - ErrorControl(SwshVars):
+          AbsoluteTolerance: 1e-8
+          RelativeTolerance: 1e-6
+          MaxFactor: 2
+          MinFactor: 0.25
+          SafetyFactor: 0.9
+      - ErrorControl(CoordVars):
+          AbsoluteTolerance: 1e-8
+          RelativeTolerance: 1e-7
+          MaxFactor: 2
+          MinFactor: 0.25
+          SafetyFactor: 0.9
     StepController:
       BinaryFraction
 

--- a/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
@@ -28,8 +28,15 @@ Evolution:
     - Constant: 0.05
     - Increase:
         Factor: 2
-    - Cfl:
-        SafetyFactor: 0.2
+    - ElementSizeCfl:
+        SafetyFactor: 0.5
+    - ErrorControl:
+        AbsoluteTolerance: 1e-8
+        RelativeTolerance: 1e-6
+        MaxFactor: 2
+        MinFactor: 0.25
+        SafetyFactor: 0.95
+
 
 DomainCreator:
   Rectangle:

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
@@ -183,7 +183,7 @@ SPECTRE_TEST_CASE(
                                                               1.0, frequency)};
   runner.set_phase(test_metavariables::Phase::Initialization);
   ActionTesting::emplace_component<evolution_component>(
-      &runner, 0, target_step_size,
+      &runner, 0, target_step_size, false,
       static_cast<std::unique_ptr<TimeStepper>>(
           std::make_unique<::TimeSteppers::DormandPrince5>()),
       scri_plus_interpolation_order,

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
@@ -27,12 +27,15 @@
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
 #include "NumericalAlgorithms/Spectral/SwshTags.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
+#include "Time/StepChoosers/Factory.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/DormandPrince5.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace Cce {
@@ -121,6 +124,13 @@ struct test_metavariables {
       Tags::Du<Tags::GaugeOmega>,
       Spectral::Swsh::Tags::Derivative<Tags::GaugeOmega,
                                        Spectral::Swsh::Tags::Eth>>>;
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<tmpl::pair<
+        StepChooser<StepChooserUse::LtsStep>,
+        tmpl::list<StepChoosers::Constant<StepChooserUse::LtsStep>,
+                   StepChoosers::Increase<StepChooserUse::LtsStep>>>>;
+  };
 
   using scri_values_to_observe = tmpl::list<>;
   using cce_integrand_tags = tmpl::flatten<tmpl::transform<

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
@@ -198,7 +198,7 @@ SPECTRE_TEST_CASE(
   ActionTesting::set_phase(make_not_null(&runner),
                            metavariables::Phase::Initialization);
   ActionTesting::emplace_component<component>(
-      &runner, 0, target_step_size,
+      &runner, 0, target_step_size, false,
       static_cast<std::unique_ptr<TimeStepper>>(
           std::make_unique<::TimeSteppers::RungeKutta3>()));
 

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
@@ -32,15 +32,18 @@
 #include "NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.hpp"
 #include "NumericalAlgorithms/Spectral/SwshInterpolation.hpp"
 #include "NumericalAlgorithms/Spectral/SwshTags.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
+#include "Time/StepChoosers/Factory.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/RungeKutta3.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace Cce {
@@ -113,6 +116,14 @@ struct metavariables {
 
   using const_global_cache_tags =
       tmpl::list<Tags::SpecifiedStartTime, Tags::InitializeJ>;
+
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<tmpl::pair<
+        StepChooser<StepChooserUse::LtsStep>,
+        tmpl::list<StepChoosers::Constant<StepChooserUse::LtsStep>,
+                   StepChoosers::Increase<StepChooserUse::LtsStep>>>>;
+  };
 
   using scri_values_to_observe = tmpl::list<>;
   using cce_integrand_tags = tmpl::flatten<tmpl::transform<

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
@@ -207,7 +207,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.GhBoundaryCommunication",
 
   runner.set_phase(test_metavariables::Phase::Initialization);
   ActionTesting::emplace_component<evolution_component>(
-      &runner, 0, target_step_size,
+      &runner, 0, target_step_size, false,
       static_cast<std::unique_ptr<TimeStepper>>(
           std::make_unique<::TimeSteppers::DormandPrince5>()),
       scri_plus_interpolation_order);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
@@ -37,15 +37,18 @@
 #include "NumericalAlgorithms/Spectral/SwshCoefficients.hpp"
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
 #include "NumericalAlgorithms/Spectral/SwshTags.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
+#include "Time/StepChoosers/Factory.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/RungeKutta3.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/FileSystem.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace Cce {
@@ -138,6 +141,14 @@ struct test_metavariables {
       Tags::Du<Tags::GaugeOmega>,
       Spectral::Swsh::Tags::Derivative<Tags::GaugeOmega,
                                        Spectral::Swsh::Tags::Eth>>>;
+
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<tmpl::pair<
+        StepChooser<StepChooserUse::LtsStep>,
+        tmpl::list<StepChoosers::Constant<StepChooserUse::LtsStep>,
+                   StepChoosers::Increase<StepChooserUse::LtsStep>>>>;
+  };
 
   using scri_values_to_observe = tmpl::list<>;
   using cce_integrand_tags = tmpl::flatten<tmpl::transform<

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
@@ -35,15 +35,18 @@
 #include "NumericalAlgorithms/Spectral/SwshCoefficients.hpp"
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
 #include "NumericalAlgorithms/Spectral/SwshTags.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
+#include "Time/StepChoosers/Factory.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/RungeKutta3.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/FileSystem.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace Cce {
@@ -155,6 +158,14 @@ struct test_metavariables {
       Tags::Du<Tags::GaugeOmega>,
       Spectral::Swsh::Tags::Derivative<Tags::GaugeOmega,
                                        Spectral::Swsh::Tags::Eth>>>;
+
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<tmpl::pair<
+        StepChooser<StepChooserUse::LtsStep>,
+        tmpl::list<StepChoosers::Constant<StepChooserUse::LtsStep>,
+                   StepChoosers::Increase<StepChooserUse::LtsStep>>>>;
+  };
 
   using scri_values_to_observe = tmpl::list<>;
   using cce_integrand_tags = tmpl::flatten<tmpl::transform<

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
@@ -235,7 +235,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.H5BoundaryCommunication",
   ActionTesting::emplace_component_and_initialize<writer_component>(
       &runner, 0, {Parallel::NodeLock{}});
   ActionTesting::emplace_component<evolution_component>(
-      &runner, 0, target_step_size,
+      &runner, 0, target_step_size, false,
       static_cast<std::unique_ptr<TimeStepper>>(
           std::make_unique<::TimeSteppers::RungeKutta3>()));
   ActionTesting::emplace_component<worldtube_component>(

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
@@ -26,16 +26,20 @@
 #include "NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.hpp"
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
 #include "NumericalAlgorithms/Spectral/SwshTags.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
+#include "Time/StepChoosers/Factory.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/RungeKutta3.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/FileSystem.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/NoSuchType.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -97,6 +101,14 @@ struct metavariables {
                                        Spectral::Swsh::Tags::Eth>>>;
 
   using const_global_cache_tags = tmpl::list<Tags::SpecifiedStartTime>;
+
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<tmpl::pair<
+        StepChooser<StepChooserUse::LtsStep>,
+        tmpl::list<StepChoosers::Constant<StepChooserUse::LtsStep>,
+                   StepChoosers::Increase<StepChooserUse::LtsStep>>>>;
+  };
 
   using scri_values_to_observe = tmpl::list<>;
   using cce_integrand_tags = tmpl::flatten<tmpl::transform<

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
@@ -170,7 +170,7 @@ SPECTRE_TEST_CASE(
   ActionTesting::set_phase(make_not_null(&runner),
                            metavariables::Phase::Initialization);
   ActionTesting::emplace_component<component>(
-      &runner, 0, target_step_size,
+      &runner, 0, target_step_size, false,
       static_cast<std::unique_ptr<TimeStepper>>(
           std::make_unique<::TimeSteppers::RungeKutta3>()),
       scri_plus_interpolation_order);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
@@ -269,7 +269,7 @@ SPECTRE_TEST_CASE(
   // Serialize and deserialize to get around the lack of implicit copy
   // constructor.
   ActionTesting::emplace_component<evolution_component>(
-      &runner, 0, target_step_size,
+      &runner, 0, target_step_size, false,
       static_cast<std::unique_ptr<TimeStepper>>(
           std::make_unique<::TimeSteppers::RungeKutta3>()),
       buffer_size, serialize_and_deserialize(analytic_manager));

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
@@ -21,13 +21,17 @@
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Helpers/Evolution/Systems/Cce/BoundaryTestHelpers.hpp"
 #include "NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "Time/StepChoosers/Factory.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/RungeKutta3.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/NoSuchType.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 
 namespace Cce {
 namespace {
@@ -193,6 +197,14 @@ struct test_metavariables {
                                        Spectral::Swsh::Tags::Eth>>>;
 
   using const_global_cache_tags = tmpl::list<Tags::SpecifiedStartTime>;
+
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<tmpl::pair<
+        StepChooser<StepChooserUse::LtsStep>,
+        tmpl::list<StepChoosers::Constant<StepChooserUse::LtsStep>,
+                   StepChoosers::Increase<StepChooserUse::LtsStep>>>>;
+  };
 
   using cce_integrand_tags = tmpl::flatten<tmpl::transform<
       bondi_hypersurface_step_tags,

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
@@ -193,7 +193,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.RequestBoundaryData",
   ActionTesting::set_phase(make_not_null(&runner),
                            test_metavariables::Phase::Initialization);
   ActionTesting::emplace_component<evolution_component>(
-      &runner, 0, target_step_size,
+      &runner, 0, target_step_size, false,
       static_cast<std::unique_ptr<TimeStepper>>(
           std::make_unique<::TimeSteppers::RungeKutta3>()));
   ActionTesting::emplace_component<worldtube_component>(

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
@@ -23,16 +23,19 @@
 #include "Helpers/Evolution/Systems/Cce/Actions/WorldtubeBoundaryMocking.hpp"
 #include "Helpers/Evolution/Systems/Cce/BoundaryTestHelpers.hpp"
 #include "NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
+#include "Time/StepChoosers/Factory.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/RungeKutta3.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/FileSystem.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace Cce {
@@ -116,6 +119,14 @@ struct test_metavariables {
       Tags::Du<Tags::GaugeOmega>,
       Spectral::Swsh::Tags::Derivative<Tags::GaugeOmega,
                                        Spectral::Swsh::Tags::Eth>>>;
+
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<tmpl::pair<
+        StepChooser<StepChooserUse::LtsStep>,
+        tmpl::list<StepChoosers::Constant<StepChooserUse::LtsStep>,
+                   StepChoosers::Increase<StepChooserUse::LtsStep>>>>;
+  };
 
   using scri_values_to_observe = tmpl::list<>;
   using cce_integrand_tags = tmpl::flatten<tmpl::transform<

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
@@ -34,9 +34,11 @@
 #include "NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.hpp"
 #include "NumericalAlgorithms/Spectral/SwshCoefficients.hpp"
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "Time/StepChoosers/Factory.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/RungeKutta3.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
@@ -44,6 +46,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
 #include "Utilities/Numeric.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 
 namespace Cce {
 namespace {
@@ -168,6 +171,14 @@ struct test_metavariables {
       Tags::Du<Tags::GaugeOmega>,
       Spectral::Swsh::Tags::Derivative<Tags::GaugeOmega,
                                        Spectral::Swsh::Tags::Eth>>>;
+
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<tmpl::pair<
+        StepChooser<StepChooserUse::LtsStep>,
+        tmpl::list<StepChoosers::Constant<StepChooserUse::LtsStep>,
+                   StepChoosers::Increase<StepChooserUse::LtsStep>>>>;
+  };
 
   using const_global_cache_tags = tmpl::list<Tags::SpecifiedStartTime>;
   using cce_integrand_tags = tmpl::flatten<tmpl::transform<

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
@@ -268,7 +268,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.ScriObserveInterpolated",
   // Serialize and deserialize to get around the lack of implicit copy
   // constructor.
   ActionTesting::emplace_component<evolution_component>(
-      &runner, 0, target_step_size,
+      &runner, 0, target_step_size, false,
       static_cast<std::unique_ptr<TimeStepper>>(
           std::make_unique<::TimeSteppers::RungeKutta3>()),
       scri_interpolation_size, serialize_and_deserialize(analytic_manager));

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -60,6 +60,7 @@
 #include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeMortars.hpp"
 #include "Time/Slab.hpp"
 #include "Time/StepChoosers/Constant.hpp"
+#include "Time/StepChoosers/ErrorControl.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/StepControllers/SplitRemaining.hpp"
 #include "Time/StepControllers/StepController.hpp"
@@ -777,9 +778,11 @@ struct component {
       domain::Tags::ElementMap<Metavariables::volume_dim, Frame::Grid>,
       tmpl::conditional_t<
           Metavariables::local_time_stepping,
-          tmpl::list<::Tags::StepController, ::Tags::StepChoosers,
+          tmpl::list<::Tags::IsUsingTimeSteppingErrorControl<>,
+                     ::Tags::StepController, ::Tags::StepChoosers,
                      ::Tags::TimeStepper<LtsTimeStepper>>,
-          tmpl::list<::Tags::TimeStepper<TimeStepper>>>>>;
+          tmpl::list<::Tags::NeverUsingTimeSteppingErrorControl,
+                     ::Tags::TimeStepper<TimeStepper>>>>>;
   using common_compute_tags = tmpl::list<
       domain::Tags::JacobianCompute<Metavariables::volume_dim, Frame::Logical,
                                     Frame::Inertial>,
@@ -1183,6 +1186,7 @@ void test_impl(const Spectral::Quadrature quadrature,
              self_id,
              domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
                  domain::CoordinateMaps::Identity<Dim>{})},
+         false,
          static_cast<std::unique_ptr<StepController>>(
              std::make_unique<StepControllers::SplitRemaining>()),
          std::move(step_choosers),
@@ -1215,6 +1219,7 @@ void test_impl(const Spectral::Quadrature quadrature,
                  neighbor_id,
                  domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
                      domain::CoordinateMaps::Identity<Dim>{})},
+             false,
              static_cast<std::unique_ptr<StepController>>(
                  std::make_unique<StepControllers::SplitRemaining>()),
              std::move(step_choosers),
@@ -1247,6 +1252,7 @@ void test_impl(const Spectral::Quadrature quadrature,
              self_id,
              domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
                  domain::CoordinateMaps::Identity<Dim>{})},
+         false,
          static_cast<std::unique_ptr<LtsTimeStepper>>(
              std::make_unique<TimeSteppers::AdamsBashforthN>(5))});
     for (const auto& [direction, neighbor_ids] : neighbors) {
@@ -1276,6 +1282,7 @@ void test_impl(const Spectral::Quadrature quadrature,
                  neighbor_id,
                  domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
                      domain::CoordinateMaps::Identity<Dim>{})},
+             false,
              static_cast<std::unique_ptr<LtsTimeStepper>>(
                  std::make_unique<TimeSteppers::AdamsBashforthN>(5))});
       }

--- a/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
+++ b/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
@@ -19,6 +19,7 @@
 #include "Time/History.hpp"
 #include "Time/Slab.hpp"
 #include "Time/StepChoosers/Constant.hpp"
+#include "Time/StepChoosers/ErrorControl.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/StepControllers/BinaryFraction.hpp"
 #include "Time/Tags.hpp"
@@ -79,10 +80,12 @@ struct Component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using const_global_cache_tags = tmpl::list<Tags::TimeStepper<LtsTimeStepper>>;
+  using const_global_cache_tags =
+      tmpl::list<Tags::TimeStepper<LtsTimeStepper>>;
   using simple_tags = tmpl::list<Tags::TimeStepId, Tags::Next<Tags::TimeStepId>,
                                  Tags::TimeStep, Tags::Next<Tags::TimeStep>,
                                  ::Tags::StepChoosers, ::Tags::StepController,
+                                 Tags::IsUsingTimeSteppingErrorControl<>,
                                  history_tag, typename System::variables_tag>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
@@ -143,7 +146,7 @@ void check(const bool time_runs_forward,
                  std::make_unique<Constant>(2. * request),
                  std::make_unique<Constant>(request),
                  std::make_unique<Constant>(2. * request)),
-       std::make_unique<StepControllers::BinaryFraction>(),
+       std::make_unique<StepControllers::BinaryFraction>(), false,
        typename history_tag::type{}, 1.});
 
   ActionTesting::set_phase(make_not_null(&runner),

--- a/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
+++ b/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
@@ -27,6 +27,7 @@
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/Actions/UpdateU.hpp"  // IWYU pragma: keep
 #include "Time/Slab.hpp"
+#include "Time/StepChoosers/ErrorControl.hpp"
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
 #include "Time/TimeStepId.hpp"
@@ -141,7 +142,8 @@ struct Component {
       tmpl::conditional_t<Metavariables::multiple_histories,
                           additional_history_tag, tmpl::list<>>,
       Tags::TimeStepId, Tags::Next<Tags::TimeStepId>, Tags::TimeStep,
-      Tags::Next<Tags::TimeStep>, Tags::Time>>;
+      Tags::Next<Tags::TimeStep>, Tags::Time,
+      Tags::IsUsingTimeSteppingErrorControl<>>>;
   using compute_tags = db::AddComputeTags<Tags::SubstepTimeCompute>;
 
   static constexpr bool has_primitives = Metavariables::has_primitives;
@@ -186,7 +188,7 @@ void emplace_component_and_initialize(
        TimeStepId(forward_in_time, 1 - static_cast<int64_t>(order),
                   initial_time),
        initial_time_step, initial_time_step,
-       std::numeric_limits<double>::signaling_NaN()});
+       std::numeric_limits<double>::signaling_NaN(), false});
 }
 
 template <>
@@ -203,7 +205,7 @@ void emplace_component_and_initialize<true, false>(
        TimeStepId(forward_in_time, 1 - static_cast<int64_t>(order),
                   initial_time),
        initial_time_step, initial_time_step,
-       std::numeric_limits<double>::signaling_NaN()});
+       std::numeric_limits<double>::signaling_NaN(), false});
 }
 
 template <>
@@ -220,7 +222,7 @@ void emplace_component_and_initialize<false, true>(
        TimeStepId(forward_in_time, 1 - static_cast<int64_t>(order),
                   initial_time),
        initial_time_step, initial_time_step,
-       std::numeric_limits<double>::signaling_NaN()});
+       std::numeric_limits<double>::signaling_NaN(), false});
 }
 
 template <>
@@ -237,7 +239,7 @@ void emplace_component_and_initialize<true, true>(
        TimeStepId(forward_in_time, 1 - static_cast<int64_t>(order),
                   initial_time),
        initial_time_step, initial_time_step,
-       std::numeric_limits<double>::signaling_NaN()});
+       std::numeric_limits<double>::signaling_NaN(), false});
 }
 
 using not_self_start_action = std::negation<std::disjunction<

--- a/tests/Unit/Time/Actions/Test_UpdateU.cpp
+++ b/tests/Unit/Time/Actions/Test_UpdateU.cpp
@@ -19,6 +19,7 @@
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Time/Actions/UpdateU.hpp"  // IWYU pragma: keep
 #include "Time/Slab.hpp"
+#include "Time/StepChoosers/ErrorControl.hpp"
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
 #include "Time/TimeStepId.hpp"
@@ -61,7 +62,8 @@ struct Component {
   using array_index = int;
   using const_global_cache_tags = tmpl::list<Tags::TimeStepper<TimeStepper>>;
   using simple_tags =
-      db::AddSimpleTags<Tags::TimeStep, variables_tag, history_tag>;
+      db::AddSimpleTags<Tags::TimeStep, variables_tag, history_tag,
+                        ::Tags::IsUsingTimeSteppingErrorControl<>>;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
@@ -79,7 +81,8 @@ struct ComponentWithTemplateSpecifiedVariables {
   using array_index = int;
   using simple_tags =
       db::AddSimpleTags<Tags::TimeStep, alternative_variables_tag,
-                        alternative_history_tag>;
+                        alternative_history_tag,
+                        ::Tags::IsUsingTimeSteppingErrorControl<>>;
   using compute_tags = db::AddComputeTags<>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
@@ -118,11 +121,11 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.UpdateU", "[Unit][Time][Actions]") {
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   MockRuntimeSystem runner{{std::make_unique<TimeSteppers::RungeKutta3>()}};
   ActionTesting::emplace_component_and_initialize<component>(
-      &runner, 0, {time_step, 1., history_tag::type{3}});
+      &runner, 0, {time_step, 1., history_tag::type{3}, false});
 
   ActionTesting::emplace_component_and_initialize<
       component_with_template_specified_variables>(
-      &runner, 0, {time_step, 1., alternative_history_tag::type{3}});
+      &runner, 0, {time_step, 1., alternative_history_tag::type{3}, false});
   ActionTesting::set_phase(make_not_null(&runner),
                            Metavariables::Phase::Testing);
 

--- a/tests/Unit/Time/StepChoosers/CMakeLists.txt
+++ b/tests/Unit/Time/StepChoosers/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY_SOURCES
   StepChoosers/Test_ByBlock.cpp
   StepChoosers/Test_Cfl.cpp
   StepChoosers/Test_Constant.cpp
+  StepChoosers/Test_ElementSizeCfl.cpp
   StepChoosers/Test_ErrorControl.cpp
   StepChoosers/Test_Increase.cpp
   StepChoosers/Test_PreventRapidIncrease.cpp

--- a/tests/Unit/Time/StepChoosers/Test_ElementSizeCfl.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_ElementSizeCfl.cpp
@@ -1,0 +1,180 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/SizeOfElement.hpp"
+#include "Domain/Tags.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "Time/StepChoosers/ElementSizeCfl.hpp"
+#include "Time/StepChoosers/StepChooser.hpp"
+#include "Time/Tags.hpp"
+#include "Time/TimeSteppers/AdamsBashforthN.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct CharacteristicSpeed : db::SimpleTag {
+  using type = double;
+};
+
+template <size_t Dim>
+struct Metavariables {
+  using component_list = tmpl::list<>;
+  using time_stepper_tag = Tags::TimeStepper<TimeStepper>;
+  struct system {
+    struct largest_characteristic_speed : db::SimpleTag {
+      using type = double;
+    };
+    struct compute_largest_characteristic_speed : db::ComputeTag,
+                                                  largest_characteristic_speed {
+      using base = largest_characteristic_speed;
+      using argument_tags = tmpl::list<CharacteristicSpeed>;
+      using return_type = double;
+      static void function(const gsl::not_null<double*> return_speed,
+                           const double& speed) noexcept {
+        *return_speed = speed;
+      }
+    };
+  };
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes =
+        tmpl::map<tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
+                             tmpl::list<StepChoosers::ElementSizeCfl<
+                                 StepChooserUse::LtsStep, Dim, system>>>,
+                  tmpl::pair<StepChooser<StepChooserUse::Slab>,
+                             tmpl::list<StepChoosers::ElementSizeCfl<
+                                 StepChooserUse::Slab, Dim, system>>>>;
+  };
+};
+
+template <size_t Dim>
+std::pair<double, bool> get_suggestion(
+    const double safety_factor, const double characteristic_speed,
+    ElementMap<Dim, Frame::Grid>&& element_map) noexcept {
+  const Parallel::GlobalCache<Metavariables<Dim>> cache{};
+  auto box = db::create<
+      db::AddSimpleTags<Parallel::Tags::MetavariablesImpl<Metavariables<Dim>>,
+                        CharacteristicSpeed, Tags::TimeStepper<TimeStepper>,
+                        domain::Tags::ElementMap<Dim, Frame::Grid>,
+                        domain::CoordinateMaps::Tags::CoordinateMap<
+                            Dim, Frame::Grid, Frame::Inertial>,
+                        ::Tags::Time, domain::Tags::FunctionsOfTime>,
+      db::AddComputeTags<domain::Tags::SizeOfElementCompute<Dim>,
+                         typename Metavariables<Dim>::system::
+                             compute_largest_characteristic_speed>>(
+      Metavariables<Dim>{}, characteristic_speed,
+      std::unique_ptr<TimeStepper>{
+          std::make_unique<TimeSteppers::AdamsBashforthN>(2)},
+      std::move(element_map),
+      ::domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+          ::domain::CoordinateMaps::Identity<Dim>{}),
+      0.0, typename domain::Tags::FunctionsOfTime::type{});
+  const StepChoosers::ElementSizeCfl<StepChooserUse::LtsStep, Dim,
+                                     typename Metavariables<Dim>::system>
+      element_size_cfl{safety_factor};
+  const std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>
+      element_size_base = std::make_unique<StepChoosers::ElementSizeCfl<
+          StepChooserUse::LtsStep, Dim, typename Metavariables<Dim>::system>>(
+          element_size_cfl);
+
+  const double speed = get<typename Metavariables<
+      Dim>::system::compute_largest_characteristic_speed>(box);
+  const std::array<double, Dim> element_size =
+      db::get<domain::Tags::SizeOfElement<Dim>>(box);
+  const auto& time_stepper = get<Tags::TimeStepper<>>(box);
+
+  const double current_step = std::numeric_limits<double>::infinity();
+  const std::pair<double, bool> result =
+      element_size_cfl(time_stepper, element_size, speed, current_step, cache);
+  CHECK_FALSE(result.second);
+  const auto accepted_step_result = element_size_cfl(
+      time_stepper, element_size, speed, result.first * 0.7, cache);
+  CHECK(accepted_step_result.second);
+  CHECK(element_size_base->desired_step(make_not_null(&box), current_step,
+                                        cache) == result);
+  CHECK(serialize_and_deserialize(element_size_cfl)(
+            time_stepper, element_size, speed, current_step, cache) == result);
+  CHECK(serialize_and_deserialize(element_size_base)
+            ->desired_step(make_not_null(&box), current_step, cache) == result);
+  return result;
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Time.StepChoosers.ElementSizeCfl", "[Unit][Time]") {
+  Parallel::register_factory_classes_with_charm<Metavariables<1>>();
+  Parallel::register_factory_classes_with_charm<Metavariables<2>>();
+  Parallel::register_factory_classes_with_charm<Metavariables<3>>();
+
+  {
+    INFO("Test 1D element size CFL step chooser");
+    auto map = domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+        domain::CoordinateMaps::Affine(-1.0, 1.0, 0.3, 1.1));
+    const ElementId<1> element_id(0, {{{2, 3}}});
+    ElementMap<1, Frame::Grid> logical_to_grid_map(element_id, std::move(map));
+    CHECK(approx(
+              get_suggestion(0.8, 2.0, std::move(logical_to_grid_map)).first) ==
+          0.04);
+  }
+  {
+    INFO("Test 2D element size CFL step chooser");
+    using Affine = domain::CoordinateMaps::Affine;
+    using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
+    auto map = domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+        Affine2D{Affine(-1.0, 1.0, 0.3, 0.4), Affine(-1.0, 1.0, -0.5, 1.1)});
+    const ElementId<2> element_id(0, {{{1, 0}, {2, 3}}});
+    ElementMap<2, Frame::Grid> logical_to_grid_map(element_id, std::move(map));
+    CHECK(approx(
+              get_suggestion(0.8, 2.0, std::move(logical_to_grid_map)).first) ==
+          0.005);
+  }
+  {
+    INFO("Test 3D element size CFL step chooser");
+    using Affine = domain::CoordinateMaps::Affine;
+    using Affine3D =
+        domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+    auto map = domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+        Affine3D{Affine(-1.0, 1.0, 0.3, 0.4), Affine(-1.0, 1.0, -0.5, 1.1),
+                 Affine(-1.0, 1.0, 12.0, 12.4)});
+    const ElementId<3> element_id(0, {{{2, 3}, {1, 0}, {3, 4}}});
+    ElementMap<3, Frame::Grid> logical_to_grid_map(element_id, std::move(map));
+    CHECK(approx(
+              get_suggestion(0.8, 2.0, std::move(logical_to_grid_map)).first) ==
+          0.005 / 3.0);
+  }
+
+  TestHelpers::test_creation<
+      std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>, Metavariables<1>>(
+      "ElementSizeCfl:\n"
+      "  SafetyFactor: 5.0");
+  TestHelpers::test_creation<
+      std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>, Metavariables<2>>(
+      "ElementSizeCfl:\n"
+      "  SafetyFactor: 5.0");
+  TestHelpers::test_creation<
+      std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>, Metavariables<3>>(
+      "ElementSizeCfl:\n"
+      "  SafetyFactor: 5.0");
+}

--- a/tests/Unit/Time/StepChoosers/Test_ErrorControl.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_ErrorControl.cpp
@@ -91,7 +91,7 @@ std::pair<double, bool> get_suggestion(
           Tags::HistoryEvolvedVariables<EvolvedVariablesTag>,
           db::add_tag_prefix<Tags::StepperError, EvolvedVariablesTag>,
           Tags::StepperErrorUpdated, Tags::TimeStepper<TimeStepper>,
-          StepChoosers::Tags::PreviousStepError>,
+          StepChoosers::Tags::PreviousStepError<EvolvedVariablesTag>>,
       db::AddComputeTags<>>(
       Metavariables<true>{}, std::move(history), error, false,
       std::unique_ptr<TimeStepper>{
@@ -111,8 +111,9 @@ std::pair<double, bool> get_suggestion(
             previous_step_error,
             db::get<Tags::HistoryEvolvedVariables<EvolvedVariablesTag>>(box),
             error, false, time_stepper, previous_step, cache));
-  CHECK(*previous_step_error ==
-        db::get<StepChoosers::Tags::PreviousStepError>(box));
+  CHECK(
+      *previous_step_error ==
+      db::get<StepChoosers::Tags::PreviousStepError<EvolvedVariablesTag>>(box));
   CHECK(std::make_pair(std::numeric_limits<double>::infinity(), true) ==
         error_control_base->desired_step(make_not_null(&box), previous_step,
                                          cache));
@@ -128,10 +129,11 @@ std::pair<double, bool> get_suggestion(
       true, time_stepper, previous_step, cache);
   // reset the previous step error so we can reuse the former state on the next
   // re-application
-  *previous_step_error = db::get<StepChoosers::Tags::PreviousStepError>(box);
+  *previous_step_error =
+      db::get<StepChoosers::Tags::PreviousStepError<EvolvedVariablesTag>>(box);
   CHECK(error_control_base->desired_step(make_not_null(&box), previous_step,
                                          cache) == result);
-  db::mutate<StepChoosers::Tags::PreviousStepError>(
+  db::mutate<StepChoosers::Tags::PreviousStepError<EvolvedVariablesTag>>(
       make_not_null(&box),
       [previous_step_error](const gsl::not_null<std::optional<double>*>
                                 previous_step_error_from_box) noexcept {

--- a/tests/Unit/Time/StepChoosers/Test_ErrorControl.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_ErrorControl.cpp
@@ -314,13 +314,13 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.ErrorControl", "[Unit][Time]") {
             "- Increase:\n"
             "    Factor: 2\n"
             "- Constant: 0.5");
-    CHECK(Tags::IsUsingTimeSteppingErrorControl::create_from_options<
+    CHECK(Tags::IsUsingTimeSteppingErrorControl<>::create_from_options<
           Metavariables<true>>(step_choosers_collection_0));
-    CHECK_FALSE(Tags::IsUsingTimeSteppingErrorControl::create_from_options<
+    CHECK_FALSE(Tags::IsUsingTimeSteppingErrorControl<>::create_from_options<
                 Metavariables<true>>(step_choosers_collection_1));
-    CHECK_FALSE(Tags::IsUsingTimeSteppingErrorControl::create_from_options<
+    CHECK_FALSE(Tags::IsUsingTimeSteppingErrorControl<>::create_from_options<
                 Metavariables<false>>(step_choosers_collection_2));
-    CHECK_FALSE(Tags::IsUsingTimeSteppingErrorControl::create_from_options<
+    CHECK_FALSE(Tags::IsUsingTimeSteppingErrorControl<>::create_from_options<
                 Metavariables<true>>({}));
   }
 }


### PR DESCRIPTION
## Proposed changes

Adds the last pieces necessary to use error-based step choices in most evolution executables, includes usage in CCE which has the clearest use-case.
Also addes a CFL-based step chooser that can be used to set a reasonably high ceiling on step sizes to avoid the step being chosen so large that a wave can cross an entire element and 'sneak up' on an element with step sizes too large.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Dependencies
- [x]  #3304
- [x]  #3326
