### PR TITLE
Add EnergyDensity function and tags for the scalar wave system

### DIFF
--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -31,6 +31,7 @@
 #include "Evolution/Systems/ScalarWave/BoundaryConditions/RegisterDerivedWithCharm.hpp"
 #include "Evolution/Systems/ScalarWave/BoundaryCorrections/Factory.hpp"
 #include "Evolution/Systems/ScalarWave/BoundaryCorrections/RegisterDerived.hpp"
+#include "Evolution/Systems/ScalarWave/EnergyDensity.hpp"
 #include "Evolution/Systems/ScalarWave/Equations.hpp"
 #include "Evolution/Systems/ScalarWave/Initialize.hpp"
 #include "Evolution/Systems/ScalarWave/System.hpp"
@@ -235,8 +236,9 @@ struct EvolutionMetavars {
                  ScalarWave::Actions::InitializeConstraints<volume_dim>,
                  Initialization::Actions::AddComputeTags<tmpl::push_back<
                      StepChoosers::step_chooser_compute_tags<EvolutionMetavars>,
-                     evolution::Tags::AnalyticCompute<
-                         Dim, initial_data_tag, analytic_solution_fields>>>,
+                     evolution::Tags::AnalyticCompute<Dim, initial_data_tag,
+                                                      analytic_solution_fields>,
+                     ScalarWave::Tags::EnergyDensityCompute<volume_dim>>>,
                  ::evolution::dg::Initialization::Mortars<volume_dim, system>,
                  evolution::Actions::InitializeRunEventsAndDenseTriggers,
                  Initialization::Actions::RemoveOptionsAndTerminatePhase>;

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -57,6 +57,7 @@
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
 #include "ParallelAlgorithms/Events/Factory.hpp"  // IWYU pragma: keep
+#include "ParallelAlgorithms/Events/ObserveVolumeIntegrals.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp"  // IWYU pragma: keep
 #include "ParallelAlgorithms/EventsAndTriggers/Completion.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
@@ -71,12 +72,12 @@
 #include "PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/MathFunctions/Factory.hpp"
 #include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
-#include "Time/Actions/AdvanceTime.hpp"                // IWYU pragma: keep
-#include "Time/Actions/ChangeSlabSize.hpp"             // IWYU pragma: keep
-#include "Time/Actions/ChangeStepSize.hpp"             // IWYU pragma: keep
-#include "Time/Actions/RecordTimeStepperData.hpp"      // IWYU pragma: keep
-#include "Time/Actions/SelfStartActions.hpp"           // IWYU pragma: keep
-#include "Time/Actions/UpdateU.hpp"                    // IWYU pragma: keep
+#include "Time/Actions/AdvanceTime.hpp"            // IWYU pragma: keep
+#include "Time/Actions/ChangeSlabSize.hpp"         // IWYU pragma: keep
+#include "Time/Actions/ChangeStepSize.hpp"         // IWYU pragma: keep
+#include "Time/Actions/RecordTimeStepperData.hpp"  // IWYU pragma: keep
+#include "Time/Actions/SelfStartActions.hpp"       // IWYU pragma: keep
+#include "Time/Actions/UpdateU.hpp"                // IWYU pragma: keep
 #include "Time/StepChoosers/ByBlock.hpp"
 #include "Time/StepChoosers/Factory.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
@@ -139,14 +140,16 @@ struct EvolutionMetavars {
                               dg::Events::field_observations<
                                   volume_dim, Tags::Time, observe_fields,
                                   analytic_solution_fields>,
+                                  dg::Events::ObserveVolumeIntegrals<
+                    volume_dim, Tags::Time,
+                    tmpl::list<ScalarWave::Tags::EnergyDensity<volume_dim>>>,
                               Events::time_events<system>>>>,
         tmpl::pair<MathFunction<1, Frame::Inertial>,
                    MathFunctions::all_math_functions<1, Frame::Inertial>>,
-        tmpl::pair<
-            StepChooser<StepChooserUse::LtsStep>,
-            tmpl::push_back<
-                StepChoosers::standard_step_choosers<system>,
-                StepChoosers::ByBlock<StepChooserUse::LtsStep, volume_dim>>>,
+        tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
+                   tmpl::push_back<StepChoosers::standard_step_choosers<system>,
+                                   StepChoosers::ByBlock<
+                                       StepChooserUse::LtsStep, volume_dim>>>,
         tmpl::pair<StepChooser<StepChooserUse::Slab>,
                    tmpl::push_back<StepChoosers::standard_slab_choosers<
                                        system, local_time_stepping>,
@@ -259,16 +262,16 @@ struct EvolutionMetavars {
 
           Parallel::PhaseActions<
               Phase, Phase::Evolve,
-              tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
-                         step_actions, Actions::AdvanceTime,
-                         PhaseControl::Actions::ExecutePhaseChange<
-                             phase_changes>>>>>;
+              tmpl::list<
+                  Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
+                  step_actions, Actions::AdvanceTime,
+                  PhaseControl::Actions::ExecutePhaseChange<phase_changes>>>>>;
 
   template <typename ParallelComponent>
   struct registration_list {
     using type =
         std::conditional_t<std::is_same_v<ParallelComponent, dg_element_array>,
-      dg_registration_list, tmpl::list<>>;
+                           dg_registration_list, tmpl::list<>>;
   };
 
   using component_list =
@@ -287,10 +290,9 @@ struct EvolutionMetavars {
       const Phase& current_phase,
       const Parallel::CProxy_GlobalCache<EvolutionMetavars>&
           cache_proxy) noexcept {
-    const auto next_phase =
-        PhaseControl::arbitrate_phase_change<phase_changes>(
-            phase_change_decision_data, current_phase,
-            *(cache_proxy.ckLocalBranch()));
+    const auto next_phase = PhaseControl::arbitrate_phase_change<phase_changes>(
+        phase_change_decision_data, current_phase,
+        *(cache_proxy.ckLocalBranch()));
     if (next_phase.has_value()) {
       return next_phase.value();
     }
@@ -319,7 +321,8 @@ struct EvolutionMetavars {
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{
-    &setup_error_handling, &setup_memory_allocation_failure_reporting,
+    &setup_error_handling,
+    &setup_memory_allocation_failure_reporting,
     &disable_openblas_multithreading,
     &domain::creators::register_derived_with_charm,
     &domain::creators::time_dependence::register_derived_with_charm,

--- a/src/Evolution/Systems/ScalarWave/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarWave/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   Characteristics.cpp
   Constraints.cpp
+  EnergyDensity.cpp
   Equations.cpp
   TimeDerivative.cpp
   UpwindPenaltyCorrection.cpp
@@ -22,6 +23,7 @@ spectre_target_headers(
   HEADERS
   Characteristics.hpp
   Constraints.hpp
+  EnergyDensity.hpp
   Equations.hpp
   Initialize.hpp
   System.hpp

--- a/src/Evolution/Systems/ScalarWave/EnergyDensity.cpp
+++ b/src/Evolution/Systems/ScalarWave/EnergyDensity.cpp
@@ -1,0 +1,44 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarWave/EnergyDensity.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace ScalarWave {
+template <size_t SpatialDim>
+void energy_density(
+    gsl::not_null<Scalar<DataVector>*> result, const Scalar<DataVector>& pi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi) noexcept {
+  dot_product(result, phi, phi);
+  get(*result) += square(get(pi));
+  get(*result) *= 0.5;
+}
+
+template <size_t SpatialDim>
+Scalar<DataVector> energy_density(
+    const Scalar<DataVector>& pi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi) noexcept {
+  Scalar<DataVector> result{get(pi).size()};
+  energy_density(make_not_null(&result), pi, phi);
+  return result;
+}
+
+}  // namespace ScalarWave
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                   \
+  template void ScalarWave::energy_density(                                    \
+      gsl::not_null<Scalar<DataVector>*> result, const Scalar<DataVector>& pi, \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& phi) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATE
+#undef DIM

--- a/src/Evolution/Systems/ScalarWave/EnergyDensity.hpp
+++ b/src/Evolution/Systems/ScalarWave/EnergyDensity.hpp
@@ -1,0 +1,40 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace ScalarWave {
+/// @{
+/*!
+ * \brief Computes the energy density of the scalar wave system.
+ *
+ * Below is the function used to calculate the energy density.
+ *
+ * \f{align*}
+ * \epsilon = \frac{1}{2}\left( \Pi^{2} + \abs{\Phi}^{2} \right)
+ * \f}
+ */
+template <size_t SpatialDim>
+void energy_density(
+    gsl::not_null<Scalar<DataVector>*> result, const Scalar<DataVector>& pi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi) noexcept;
+
+template <size_t SpatialDim>
+Scalar<DataVector> energy_density(
+    const Scalar<DataVector>& pi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi) noexcept;
+/// @}
+}  // namespace ScalarWave

--- a/src/Evolution/Systems/ScalarWave/EnergyDensity.hpp
+++ b/src/Evolution/Systems/ScalarWave/EnergyDensity.hpp
@@ -5,7 +5,9 @@
 
 #include <cstddef>
 
+#include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -37,4 +39,21 @@ Scalar<DataVector> energy_density(
     const Scalar<DataVector>& pi,
     const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi) noexcept;
 /// @}
+
+namespace Tags {
+/// \brief Computes the energy density using ScalarWave::energy_density()
+template <size_t SpatialDim>
+struct EnergyDensityCompute : EnergyDensity<SpatialDim>, db::ComputeTag {
+  using argument_tags = tmpl::list<ScalarWave::Pi, ScalarWave::Phi<SpatialDim>>;
+
+  using return_type = Scalar<DataVector>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<Scalar<DataVector>*> result, const Scalar<DataVector>&,
+      const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&) noexcept>(
+      &energy_density<SpatialDim>);
+
+  using base = EnergyDensity<SpatialDim>;
+};
+}  // namespace Tags
 }  // namespace ScalarWave

--- a/src/Evolution/Systems/ScalarWave/Tags.hpp
+++ b/src/Evolution/Systems/ScalarWave/Tags.hpp
@@ -104,5 +104,11 @@ struct EvolvedFieldsFromCharacteristicFields : db::SimpleTag {
     return "EvolvedFieldsFromCharacteristicFields";
   }
 };
+
+/// The energy density of the scalar wave
+template <size_t Dim>
+struct EnergyDensity : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
 }  // namespace Tags
 }  // namespace ScalarWave

--- a/src/Evolution/Systems/ScalarWave/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/ScalarWave/TagsDeclarations.hpp
@@ -32,5 +32,7 @@ template <size_t Dim>
 struct CharacteristicFields;
 template <size_t Dim>
 struct EvolvedFieldsFromCharacteristicFields;
+template <size_t Dim>
+struct EnergyDensity;
 }  // namespace Tags
 }  // namespace ScalarWave

--- a/tests/Unit/Evolution/Systems/ScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarWave/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIBRARY_SOURCES
   BoundaryCorrections/Test_UpwindPenalty.cpp
   Test_Characteristics.cpp
   Test_Constraints.cpp
+  Test_EnergyDensity.cpp
   Test_Equations.cpp
   Test_TimeDerivative.cpp
   Test_UpwindPenaltyCorrection.cpp

--- a/tests/Unit/Evolution/Systems/ScalarWave/EnergyDensity.py
+++ b/tests/Unit/Evolution/Systems/ScalarWave/EnergyDensity.py
@@ -1,0 +1,13 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+# Functions for testing EnergyDensity.cpp
+
+
+def energy_density(pi, phi):
+    return 0.5 * (pi * pi + np.linalg.norm(phi) * np.linalg.norm(phi))
+
+
+# End functions for testing EnergyDensity.cpp

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_EnergyDensity.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_EnergyDensity.cpp
@@ -1,0 +1,36 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <random>
+#include <string>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/ScalarWave/EnergyDensity.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+
+namespace {
+template <size_t SpatialDim>
+void test_energy_density(const DataVector& used_for_size) {
+  void (*f)(const gsl::not_null<Scalar<DataVector>*>, const Scalar<DataVector>&,
+            const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&) =
+      &ScalarWave::energy_density<SpatialDim>;
+  pypp::check_with_random_values<1>(f, "EnergyDensity", {"energy_density"},
+                                    {{{-1., 1.}}}, used_for_size);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarWave.EnergyDensity",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env(
+      "Evolution/Systems/ScalarWave/");
+
+  const DataVector used_for_size(5);
+  test_energy_density<1>(used_for_size);
+  test_energy_density<2>(used_for_size);
+  test_energy_density<3>(used_for_size);
+}

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_EnergyDensity.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_EnergyDensity.cpp
@@ -7,13 +7,42 @@
 #include <random>
 #include <string>
 
+#include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/Systems/ScalarWave/EnergyDensity.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 
 namespace {
+template <size_t SpatialDim, typename DataType>
+void test_compute_item_in_databox(const DataType& used_for_size) noexcept {
+  TestHelpers::db::test_compute_tag<
+      ScalarWave::Tags::EnergyDensityCompute<SpatialDim>>("EnergyDensity");
+
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> dist(-1., 1.);
+
+  const Scalar<DataVector> pi = make_with_random_values<Scalar<DataVector>>(
+      make_not_null(&generator), dist, used_for_size);
+  const tnsr::i<DataVector, SpatialDim, Frame::Inertial> phi =
+      make_with_random_values<tnsr::i<DataVector, SpatialDim, Frame::Inertial>>(
+          make_not_null(&generator), dist, used_for_size);
+
+  const auto box = db::create<
+      db::AddSimpleTags<ScalarWave::Pi, ScalarWave::Phi<SpatialDim>>,
+      db::AddComputeTags<ScalarWave::Tags::EnergyDensityCompute<SpatialDim>>>(
+      pi, phi);
+
+  const auto expected = ScalarWave::energy_density(pi, phi);
+
+  CHECK_ITERABLE_APPROX(
+      (db::get<ScalarWave::Tags::EnergyDensity<SpatialDim>>(box)), expected);
+}
+
 template <size_t SpatialDim>
 void test_energy_density(const DataVector& used_for_size) {
   void (*f)(const gsl::not_null<Scalar<DataVector>*>, const Scalar<DataVector>&,

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_Tags.cpp
@@ -28,4 +28,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarWave.Tags",
   TestHelpers::db::test_simple_tag<
       ScalarWave::Tags::EvolvedFieldsFromCharacteristicFields<3>>(
       "EvolvedFieldsFromCharacteristicFields");
+  TestHelpers::db::test_simple_tag<ScalarWave::Tags::EnergyDensity<SpatialDim>>(
+      "EnergyDensity");
 }


### PR DESCRIPTION
## Proposed changes

Add in the `EnergyDensity.cpp` and `EnergyDensity.hpp` that provides the `energy_density` function that calculates the energy density over the domain of a scalar wave system. Add the `EnergyDensityCompute` to `Tags.hpp` that calculates the energy density using the `energy_density` function. 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
