### PR TITLE
Rename "new feature" label for release notes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,7 @@ lines below.
 - [ ] The code follows the stylistic and code quality guidelines listed in the
   [code review guide](https://spectre-code.org/code_review_guide.html).
 - [ ] The PR lists upgrade instructions and is labeled `bugfix` or
-  `major new feature` if appropriate.
+  `new feature` if appropriate.
 
 ### Further comments
 

--- a/docs/DevGuide/AutomaticVersioning.md
+++ b/docs/DevGuide/AutomaticVersioning.md
@@ -27,7 +27,7 @@ matches the date at the time the "Release version" job runs.
 
 The release notes are compiled automatically based on the activity in the
 repository since the last release. They will contain a list of merged
-pull-requests. Pull-requests labeled "major new feature" or "bugfix" on GitHub
+pull-requests. Pull-requests labeled "new feature" or "bugfix" on GitHub
 will be classified as such in the release notes.
 
 The script `tools/CompileReleaseNotes.py` generates the release notes and can

--- a/tests/tools/Test_CompileReleaseNotes.py
+++ b/tests/tools/Test_CompileReleaseNotes.py
@@ -109,12 +109,12 @@ class TestCompileReleaseNotes(unittest.TestCase):
         major_pr1 = PullRequest(id=3,
                                 title="This is big",
                                 author="author2",
-                                group='major new feature',
+                                group='new feature',
                                 upgrade_instructions="- Do this.\n- And that.")
         major_pr2 = PullRequest(id=4,
                                 title="Another feature",
                                 author="author3",
-                                group='major new feature')
+                                group='new feature')
         bugfix_pr1 = PullRequest(
             id=5,
             title="Fixed this bug",
@@ -143,7 +143,7 @@ class TestCompileReleaseNotes(unittest.TestCase):
 
                 ## Merged pull-requests (6)
 
-                **Major new features (2):**
+                **New features (2):**
 
                 - This is big (#3)
                 - Another feature (#4)

--- a/tools/CompileReleaseNotes.py
+++ b/tools/CompileReleaseNotes.py
@@ -53,7 +53,7 @@ class PullRequest:
 
 
 # These should correspond to labels on GitHub
-PULL_REQUEST_GROUPS = ['major new feature', None, 'bugfix']
+PULL_REQUEST_GROUPS = ['new feature', None, 'bugfix']
 
 
 def get_merged_pull_requests(repo: git.Repo, from_rev: Revision,
@@ -159,7 +159,7 @@ def compile_release_notes(merged_prs: List[PullRequest]) -> str:
     if len(merged_prs) > 0:
         for group, prs_iterator in grouped_prs:
             group_header = {
-                'major new feature': "Major new features",
+                'new feature': "New features",
                 'bugfix': "Bugfixes",
                 None: "General changes",
             }[group]


### PR DESCRIPTION
## Proposed changes

Drop "major" from the label. Use the "new feature" label to highlight a
PR in the release notes. Add the label whenever you think it would be
useful to announce the feature to the spectre community.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
