### PR TITLE
Enable HDF5 compression

### DIFF
--- a/src/IO/H5/Helpers.cpp
+++ b/src/IO/H5/Helpers.cpp
@@ -125,6 +125,9 @@ void write_data(const hid_t group_id, const std::vector<T>& data,
                         ? extents[i]
                         : target_number_of_bytes_per_chunk / sizeof(T);
   }
+  ASSERT(alg::none_of(extents,
+                      [](const size_t extent) noexcept { return extent == 0; }),
+         "Got zero extent when trying to write data.");
 
   const std::vector<hsize_t> dims(extents.begin(), extents.end());
   const hid_t space_id = H5Screate_simple(dims.size(), dims.data(), nullptr);

--- a/src/IO/H5/VolumeData.cpp
+++ b/src/IO/H5/VolumeData.cpp
@@ -41,6 +41,9 @@ void append_element_extents_and_connectivity(
     const ExtentsAndTensorVolumeData& element) noexcept {
   // Process the element extents
   const auto& extents = element.extents;
+  ASSERT(alg::none_of(extents,
+                      [](const size_t extent) noexcept { return extent == 1; }),
+         "We cannot generate connectivity for any single grid point elements.");
   if (extents.size() != dim) {
     ERROR("Trying to write data of dimensionality"
           << extents.size() << "but the VolumeData file has dimensionality"


### PR DESCRIPTION
## Proposed changes

- Add some checks to avoid writing data with zero extent
- enable HDF5 GZIP compression and a shuffle filter. The amount of compression depends on the data (constant data being the easiest to compress), but I typically see between 2x and 5x compression in the data. Sometimes I'll get a bit more, but that's unusual. The compression is disabled if it's unavailable for some reason, but the GZIP and shuffle filters are standard in HDF5, which is why I chose them.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
