### PR TITLE
Add overload for GH f_constraint that includes the stress energy contribution

### DIFF
--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
@@ -16,6 +16,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  Constraints.hpp
   System.hpp
   StressEnergy.hpp
   Tags.hpp

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Constraints.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Constraints.hpp
@@ -1,0 +1,70 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Constraints.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace grmhd::GhValenciaDivClean::Tags {
+/*!
+ * \brief Compute item to get the F-constraint for the generalized harmonic
+ * evolution system with an MHD stress-energy source.
+ *
+ * \details See `GeneralizedHarmonic::f_constraint()`. Can be retrieved using
+ * `GeneralizedHarmonic::Tags::FConstraint`.
+ */
+template <size_t SpatialDim, typename Frame>
+struct FConstraintCompute
+    : GeneralizedHarmonic::Tags::FConstraint<SpatialDim, Frame>,
+      db::ComputeTag {
+  using argument_tags = tmpl::list<
+      GeneralizedHarmonic::Tags::GaugeH<SpatialDim, Frame>,
+      GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>,
+      gr::Tags::SpacetimeNormalOneForm<SpatialDim, Frame, DataVector>,
+      gr::Tags::SpacetimeNormalVector<SpatialDim, Frame, DataVector>,
+      gr::Tags::InverseSpatialMetric<SpatialDim, Frame, DataVector>,
+      gr::Tags::InverseSpacetimeMetric<SpatialDim, Frame, DataVector>,
+      GeneralizedHarmonic::Tags::Pi<SpatialDim, Frame>,
+      GeneralizedHarmonic::Tags::Phi<SpatialDim, Frame>,
+      ::Tags::deriv<GeneralizedHarmonic::Tags::Pi<SpatialDim, Frame>,
+                    tmpl::size_t<SpatialDim>, Frame>,
+      ::Tags::deriv<GeneralizedHarmonic::Tags::Phi<SpatialDim, Frame>,
+                    tmpl::size_t<SpatialDim>, Frame>,
+      ::GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma2,
+      GeneralizedHarmonic::Tags::ThreeIndexConstraint<SpatialDim, Frame>,
+      Tags::TraceReversedStressEnergy>;
+
+  using return_type = tnsr::a<DataVector, SpatialDim, Frame>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<tnsr::a<DataVector, SpatialDim, Frame>*>,
+      const tnsr::a<DataVector, SpatialDim, Frame>&,
+      const tnsr::ab<DataVector, SpatialDim, Frame>&,
+      const tnsr::a<DataVector, SpatialDim, Frame>&,
+      const tnsr::A<DataVector, SpatialDim, Frame>&,
+      const tnsr::II<DataVector, SpatialDim, Frame>&,
+      const tnsr::AA<DataVector, SpatialDim, Frame>&,
+      const tnsr::aa<DataVector, SpatialDim, Frame>&,
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&,
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&,
+      const tnsr::ijaa<DataVector, SpatialDim, Frame>&,
+      const Scalar<DataVector>&,
+      const tnsr::iaa<DataVector, SpatialDim, Frame>&,
+      const tnsr::aa<DataVector, SpatialDim, Frame>&) noexcept>(
+      &GeneralizedHarmonic::f_constraint<SpatialDim, Frame, DataVector>);
+
+  using base = GeneralizedHarmonic::Tags::FConstraint<SpatialDim, Frame>;
+};
+}  // namespace grmhd::GhValenciaDivClean::Tags

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/TestFunctions.py
@@ -492,6 +492,33 @@ def f_constraint_term_25_of_25(spacetime_normal_one_form,
                            inverse_spacetime_metric)
 
 
+def f_constraint_stress_energy_term(inverse_spacetime_metric,
+                                    spacetime_normal_vector,
+                                    spacetime_normal_one_form,
+                                    trace_reversed_stress_energy):
+    return -16.0 * np.pi * (
+        np.einsum("b, ab", spacetime_normal_vector,
+                  trace_reversed_stress_energy) -
+        0.5 * spacetime_normal_one_form * np.einsum(
+            "ab, ab", inverse_spacetime_metric, trace_reversed_stress_energy))
+
+
+def f_constraint_with_stress_energy(
+    gauge_function, d_gauge_function, spacetime_normal_one_form,
+    spacetime_normal_vector, inverse_spatial_metric, inverse_spacetime_metric,
+    pi, phi, d_pi, d_phi, gamma2, three_index_constraint,
+    trace_reversed_stress_energy):
+    constraint = f_constraint(gauge_function, d_gauge_function,
+                              spacetime_normal_one_form,
+                              spacetime_normal_vector, inverse_spatial_metric,
+                              inverse_spacetime_metric, pi, phi, d_pi, d_phi,
+                              gamma2, three_index_constraint)
+    constraint += f_constraint_stress_energy_term(
+        inverse_spacetime_metric, spacetime_normal_vector,
+        spacetime_normal_one_form, trace_reversed_stress_energy)
+    return constraint
+
+
 def f_constraint(gauge_function, d_gauge_function, spacetime_normal_one_form,
                  spacetime_normal_vector, inverse_spatial_metric,
                  inverse_spacetime_metric, pi, phi, d_pi, d_phi, gamma2,

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
@@ -427,6 +427,24 @@ void test_f_constraint_random(const DataType& used_for_size) noexcept {
           const tnsr::iaa<DataType, SpatialDim, Frame>&)>(
           &GeneralizedHarmonic::f_constraint<SpatialDim, Frame, DataType>),
       "TestFunctions", "f_constraint", {{{-1.0, 1.0}}}, used_for_size);
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::a<DataType, SpatialDim, Frame> (*)(
+          const tnsr::a<DataType, SpatialDim, Frame>&,
+          const tnsr::ab<DataType, SpatialDim, Frame>&,
+          const tnsr::a<DataType, SpatialDim, Frame>&,
+          const tnsr::A<DataType, SpatialDim, Frame>&,
+          const tnsr::II<DataType, SpatialDim, Frame>&,
+          const tnsr::AA<DataType, SpatialDim, Frame>&,
+          const tnsr::aa<DataType, SpatialDim, Frame>&,
+          const tnsr::iaa<DataType, SpatialDim, Frame>&,
+          const tnsr::iaa<DataType, SpatialDim, Frame>&,
+          const tnsr::ijaa<DataType, SpatialDim, Frame>&,
+          const Scalar<DataType>&,
+          const tnsr::iaa<DataType, SpatialDim, Frame>&,
+          const tnsr::aa<DataType, SpatialDim, Frame>&)>(
+          &GeneralizedHarmonic::f_constraint<SpatialDim, Frame, DataType>),
+      "TestFunctions", "f_constraint_with_stress_energy", {{{-1.0, 1.0}}},
+      used_for_size);
 }
 
 // Test the return-by-reference F constraint

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_GhValenciaDivClean")
 set(LIBRARY_SOURCES
   BoundaryConditions/Test_ProductOfConditions.cpp
   BoundaryCorrections/Test_ProductOfCorrections.cpp
+  Test_Constraints.cpp
   Test_Tags.cpp
   Test_StressEnergy.cpp
   Test_TimeDerivativeTerms.cpp

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Test_Constraints.cpp
@@ -1,0 +1,14 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/Constraints.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.GrMhd.GhValenciaDivClean.Constraints",
+                  "[Unit][Evolution]") {
+  TestHelpers::db::test_compute_tag<
+      grmhd::GhValenciaDivClean::Tags::FConstraintCompute<3, Frame::Inertial>>(
+      "FConstraint");
+}


### PR DESCRIPTION
## Proposed changes

Adds an overload for `f_constraint` that includes the stress energy contribution, and adds a compute tag to the GhValenciaDivClean system that uses the stress-energy overload. 


### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.
