### PR TITLE
Cancel redundant builds on CI

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -39,6 +39,12 @@ on:
         required: false
         default: ''
 
+# Cancel all other queued or in-progress runs of this workflow when it is
+# scheduled, so repeated pushes to a branch or a PR don't block CI.
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Make sure no commits are prefixed with `fixup` or similar keywords. See
   # `tools/CheckCommits.sh` for details.


### PR DESCRIPTION
## Proposed changes

Our CI is backed up quite a bit, so this PR enables a recently-added GitHub feature to cancel old runs when pushing to a PR or a branch: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
The feature is still in beta, but hasn't changed in a few months and it would be nice to speed up CI.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
