### PR TITLE
Use history order in dense output

### DIFF
--- a/src/Evolution/Systems/Cce/InterfaceManagers/GhLocalTimeStepping.cpp
+++ b/src/Evolution/Systems/Cce/InterfaceManagers/GhLocalTimeStepping.cpp
@@ -135,6 +135,10 @@ void GhLocalTimeStepping::insert_next_gh_time(
         boundary_history_.begin() +
         static_cast<ptrdiff_t>(boundary_history_.size() - order_));
   }
+  if (boundary_history_.integration_order() < boundary_history_.size()) {
+    boundary_history_.integration_order(
+        std::min(boundary_history_.size(), order_));
+  }
 }
 
 void GhLocalTimeStepping::request_gh_data(const TimeStepId& time_id) noexcept {
@@ -164,6 +168,10 @@ void GhLocalTimeStepping::update_history() noexcept {
     boundary_history_.mark_unneeded(
         boundary_history_.begin() +
         static_cast<ptrdiff_t>(boundary_history_.size() - order_));
+  }
+  if (boundary_history_.integration_order() < boundary_history_.size()) {
+    boundary_history_.integration_order(
+        std::min(boundary_history_.size(), order_));
   }
 }
 

--- a/src/Evolution/Systems/Cce/InterfaceManagers/GhLocalTimeStepping.hpp
+++ b/src/Evolution/Systems/Cce/InterfaceManagers/GhLocalTimeStepping.hpp
@@ -66,7 +66,7 @@ class GhLocalTimeStepping : public GhInterfaceManager {
   GhLocalTimeStepping() = default;
 
   explicit GhLocalTimeStepping(const size_t order)
-      : order_{order}, boundary_history_{order}, time_stepper_{order} {}
+      : order_{order}, boundary_history_{1_st}, time_stepper_{order} {}
 
   explicit GhLocalTimeStepping(CkMigrateMessage* /*unused*/) noexcept {}
 

--- a/src/Time/TimeSteppers/AdamsBashforthN.hpp
+++ b/src/Time/TimeSteppers/AdamsBashforthN.hpp
@@ -409,10 +409,8 @@ template <typename Vars, typename DerivVars>
 bool AdamsBashforthN::dense_update_u(const gsl::not_null<Vars*> u,
                                      const History<Vars, DerivVars>& history,
                                      const double time) const noexcept {
-  ASSERT(history.integration_order() == order_,
-         "Dense output is only supported at full order");
   const ApproximateTimeDelta time_step{time - history.back().value()};
-  update_u_impl(u, history, time_step, order_);
+  update_u_impl(u, history, time_step, history.integration_order());
   return true;
 }
 

--- a/tests/Unit/Helpers/Time/TimeSteppers/TimeStepperTestUtils.hpp
+++ b/tests/Unit/Helpers/Time/TimeSteppers/TimeStepperTestUtils.hpp
@@ -77,7 +77,8 @@ void equal_rate_boundary(const LtsTimeStepper& stepper, size_t order,
 
 void check_convergence_order(const TimeStepper& stepper) noexcept;
 
-void check_dense_output(const TimeStepper& stepper) noexcept;
+void check_dense_output(const TimeStepper& stepper,
+                        const size_t history_integration_order) noexcept;
 
 void check_boundary_dense_output(const LtsTimeStepper& stepper) noexcept;
 }  // namespace TimeStepperTestUtils

--- a/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
@@ -50,7 +50,10 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN", "[Unit][Time]") {
           1.0e-4);
     }
     TimeStepperTestUtils::check_convergence_order(stepper);
-    TimeStepperTestUtils::check_dense_output(stepper);
+    for(size_t history_order = 1; history_order <= order; ++history_order){
+      CAPTURE(history_order);
+      TimeStepperTestUtils::check_dense_output(stepper, history_order);
+    }
 
     CHECK(stepper.order() == order);
     CHECK(stepper.error_estimate_order() == order - 1);

--- a/tests/Unit/Time/TimeSteppers/Test_DormandPrince5.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_DormandPrince5.cpp
@@ -24,7 +24,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.DormandPrince5", "[Unit][Time]") {
   TimeStepperTestUtils::integrate_variable_test(stepper, 5, 0, 1.0e-9);
   TimeStepperTestUtils::check_convergence_order(stepper);
   TimeStepperTestUtils::stability_test(stepper);
-  TimeStepperTestUtils::check_dense_output(stepper);
+  TimeStepperTestUtils::check_dense_output(stepper, 5_st);
 
   CHECK(stepper.order() == 5_st);
   CHECK(stepper.error_estimate_order() == 4_st);

--- a/tests/Unit/Time/TimeSteppers/Test_RungeKutta3.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_RungeKutta3.cpp
@@ -24,7 +24,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta3", "[Unit][Time]") {
   TimeStepperTestUtils::integrate_variable_test(stepper, 3, 0, 1e-9);
   TimeStepperTestUtils::stability_test(stepper);
   TimeStepperTestUtils::check_convergence_order(stepper);
-  TimeStepperTestUtils::check_dense_output(stepper);
+  TimeStepperTestUtils::check_dense_output(stepper, 3_st);
 
   CHECK(stepper.order() == 3_st);
   CHECK(stepper.error_estimate_order() == 2_st);

--- a/tests/Unit/Time/TimeSteppers/Test_RungeKutta4.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_RungeKutta4.cpp
@@ -24,7 +24,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta4", "[Unit][Time]") {
   TimeStepperTestUtils::integrate_variable_test(stepper, 4, 0, 1.0e-9);
   TimeStepperTestUtils::check_convergence_order(stepper);
   TimeStepperTestUtils::stability_test(stepper);
-  TimeStepperTestUtils::check_dense_output(stepper);
+  TimeStepperTestUtils::check_dense_output(stepper, 4_st);
 
   CHECK(stepper.order() == 4_st);
   CHECK(stepper.error_estimate_order() == 3_st);


### PR DESCRIPTION
## Proposed changes

It allows a bit more flexibility in the use of the dense output routines if they make computations based on the history order rather than insisting on the stepper order.

This also updates the `GhLocalTimeStepping` interface manager to correctly update the order so that the first couple of steps in the coupled system are correct.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.
