### PR TITLE
Improve compiler error for bad tmpl::transform

### DIFF
--- a/src/Utilities/TMPL.hpp
+++ b/src/Utilities/TMPL.hpp
@@ -26,6 +26,42 @@
 namespace brigand {
 /// \cond
 namespace detail {
+
+// specializations to catch attempts to transform a non-sequence
+template <typename NotSeq, class Func>
+struct transform<0, NotSeq, Func> {
+  static_assert(
+      std::is_same_v<list<>, NotSeq>,
+      "Cannot transform a non-sequence (the second argument of is_same_v).");
+  using type = std::void_t<>;
+};
+
+template <typename NotSeq, template <class...> class Seq, class... T,
+          class Func>
+struct transform<1, NotSeq, Seq<T...>, Func> {
+  static_assert(
+      std::is_same_v<list<>, NotSeq>,
+      "Cannot transform a non-sequence (the second argument of is_same_v).");
+  using type = std::void_t<>;
+};
+
+template <template <class...> class Seq, class... T, typename NotSeq,
+          class Func>
+struct transform<1, Seq<T...>, NotSeq, Func> {
+  static_assert(
+      std::is_same_v<list<>, NotSeq>,
+      "Cannot transform a non-sequence (the second argument of is_same_v).");
+  using type = std::void_t<>;
+};
+
+template <typename NotSeq1, typename NotSeq2, class Func>
+struct transform<1, NotSeq1, NotSeq2, Func> {
+  static_assert(
+      std::is_same_v<list<>, NotSeq1>,
+      "Cannot transform a non-sequence (the second argument of is_same_v).");
+  using type = std::void_t<>;
+};
+
 template <bool b, typename O, typename L, std::size_t I, typename R,
           typename U = void>
 struct replace_at_impl;

--- a/tests/Unit/Utilities/Test_TMPL.cpp
+++ b/tests/Unit/Utilities/Test_TMPL.cpp
@@ -102,6 +102,29 @@ void test_as_pack() noexcept {
   CHECK(result == 6);
   // [as_pack]
 }
+
+struct Type1;
+
+template <typename... T>
+struct make_list {
+  using type = tmpl::list<T...>;
+};
+
+void test_transform() noexcept {
+  using new_list = tmpl::transform<tmpl::list<Type1>, make_list<tmpl::_1>>;
+  static_assert(std::is_same_v<new_list, tmpl::list<tmpl::list<Type1>>>);
+  using new_list_2 = tmpl::transform<tmpl::list<Type1>, tmpl::list<Type1>,
+                                     make_list<tmpl::_1, tmpl::_2>>;
+  static_assert(
+      std::is_same_v<new_list_2, tmpl::list<tmpl::list<Type1, Type1>>>);
+  // using bad_list_1 = tmpl::transform<double, make_list<tmpl::_1>>;
+  // using bad_list_2 =
+  //     tmpl::transform<int, tmpl::list<Type1>, make_list<tmpl::_1, tmpl::_2>>;
+  // using bad_list_3 =
+  //     tmpl::transform<tmpl::list<Type1>, int, make_list<tmpl::_1, tmpl::_2>>;
+  // using bad_list_4 =
+  //     tmpl::transform<double, double, make_list<tmpl::_1, tmpl::_2>>;
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Utilities.TMPL", "[Unit][Utilities]") {
@@ -113,4 +136,5 @@ SPECTRE_TEST_CASE("Unit.Utilities.TMPL", "[Unit][Utilities]") {
                      std::integral_constant<size_t, 1>,
                      std::integral_constant<size_t, 3>>{});
   test_as_pack();
+  test_transform();
 }


### PR DESCRIPTION
## Proposed changes

Prompted by clang crashing (after several minutes) because of a misspelled type alias (`phase_dependent_action_list`), I've added several specializations to `brigand::detail::transform` in an attempt to catch the error with a static_assert (which triggers after  several seconds).  

In a separate commit, I added a minimal test example including commented-out code that will trigger either a compiler crash or less than helpful compiler errors to make it easier to compare the behavior before and after the main change.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
