### PR TITLE
Convert MathFunction to use factory map

### DIFF
--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -68,6 +68,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/MathFunctions/Factory.hpp"
 #include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
 #include "Time/Actions/AdvanceTime.hpp"                // IWYU pragma: keep
 #include "Time/Actions/ChangeSlabSize.hpp"             // IWYU pragma: keep
@@ -138,6 +139,8 @@ struct EvolutionMetavars {
                                   volume_dim, Tags::Time, observe_fields,
                                   analytic_solution_fields>,
                               Events::time_events<system>>>>,
+        tmpl::pair<MathFunction<1, Frame::Inertial>,
+                   MathFunctions::all_math_functions<1, Frame::Inertial>>,
         tmpl::pair<
             StepChooser<StepChooserUse::LtsStep>,
             tmpl::push_back<
@@ -321,8 +324,6 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &domain::FunctionsOfTime::register_derived_with_charm,
     &ScalarWave::BoundaryConditions::register_derived_with_charm,
     &ScalarWave::BoundaryCorrections::register_derived_with_charm,
-    &Parallel::register_derived_classes_with_charm<
-        MathFunction<1, Frame::Inertial>>,
     &Parallel::register_derived_classes_with_charm<TimeStepper>,
     &Parallel::register_derived_classes_with_charm<
         PhaseChange<metavariables::phase_changes>>,

--- a/src/PointwiseFunctions/MathFunctions/CMakeLists.txt
+++ b/src/PointwiseFunctions/MathFunctions/CMakeLists.txt
@@ -18,6 +18,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  Factory.hpp
   Gaussian.hpp
   MathFunction.hpp
   PowX.hpp

--- a/src/PointwiseFunctions/MathFunctions/Factory.hpp
+++ b/src/PointwiseFunctions/MathFunctions/Factory.hpp
@@ -1,0 +1,31 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "PointwiseFunctions/MathFunctions/Gaussian.hpp"
+#include "PointwiseFunctions/MathFunctions/PowX.hpp"
+#include "PointwiseFunctions/MathFunctions/Sinusoid.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace MathFunctions {
+namespace Factory_detail {
+template <size_t VolumeDim, typename Fr>
+struct all_math_functions {
+  using type = tmpl::list<MathFunctions::Gaussian<VolumeDim, Fr>>;
+};
+
+template <typename Fr>
+struct all_math_functions<1, Fr> {
+  using type =
+      tmpl::list<MathFunctions::Gaussian<1, Fr>, MathFunctions::PowX<1, Fr>,
+                 MathFunctions::Sinusoid<1, Fr>>;
+};
+}  // namespace Factory_detail
+
+template <size_t VolumeDim, typename Fr>
+using all_math_functions =
+    typename Factory_detail::all_math_functions<VolumeDim, Fr>::type;
+}  // namespace MathFunctions

--- a/src/PointwiseFunctions/MathFunctions/MathFunction.hpp
+++ b/src/PointwiseFunctions/MathFunctions/MathFunction.hpp
@@ -15,14 +15,7 @@
 
 /// \ingroup MathFunctionsGroup
 /// Holds classes implementing MathFunction (functions \f$R^n \to R\f$).
-namespace MathFunctions {
-template <size_t VolumeDim, typename Fr>
-class Gaussian;
-template <size_t VolumeDim, typename Fr>
-class PowX;
-template <size_t VolumeDim, typename Fr>
-class Sinusoid;
-}  // namespace MathFunctions
+namespace MathFunctions {}
 
 /*!
  * \ingroup MathFunctionsGroup
@@ -39,7 +32,6 @@ class MathFunction;
 template <size_t VolumeDim, typename Fr>
 class MathFunction : public PUP::able {
  public:
-  using creatable_classes = tmpl::list<MathFunctions::Gaussian<VolumeDim, Fr>>;
   constexpr static size_t volume_dim = VolumeDim;
   using frame = Fr;
 
@@ -94,9 +86,6 @@ class MathFunction : public PUP::able {
 template <typename Fr>
 class MathFunction<1, Fr> : public PUP::able {
  public:
-  using creatable_classes =
-      tmpl::list<MathFunctions::Gaussian<1, Fr>, MathFunctions::PowX<1, Fr>,
-                 MathFunctions::Sinusoid<1, Fr>>;
   constexpr static size_t volume_dim = 1;
   using frame = Fr;
 
@@ -168,7 +157,3 @@ class MathFunction<1, Fr> : public PUP::able {
     return result;
   }
 };
-
-#include "PointwiseFunctions/MathFunctions/Gaussian.hpp"
-#include "PointwiseFunctions/MathFunctions/PowX.hpp"
-#include "PointwiseFunctions/MathFunctions/Sinusoid.hpp"

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_PlaneWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_PlaneWave.cpp
@@ -15,12 +15,14 @@
 #include "Evolution/Systems/ScalarWave/Tags.hpp"  // IWYU pragma: keep
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"
 #include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
 #include "PointwiseFunctions/MathFunctions/PowX.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -28,6 +30,14 @@
 // IWYU pragma: no_forward_declare Tensor
 
 namespace {
+struct Metavariables {
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<MathFunction<1, Frame::Inertial>,
+                   tmpl::list<MathFunctions::PowX<1, Frame::Inertial>>>>;
+  };
+};
 
 inline tnsr::I<double, 1, Frame::Inertial> extract_point_from_coords(
     const size_t offset, const tnsr::I<DataVector, 1>& x) {
@@ -150,8 +160,7 @@ void test_1d() {
       std::array<DataVector, 2>{{-6.0 * omega * kx * u, 6.0 * square(kx) * u}},
       pw, x, t);
 
-  Parallel::register_derived_classes_with_charm<
-      MathFunction<1, Frame::Inertial>>();
+  Parallel::register_factory_classes_with_charm<Metavariables>();
   const auto deserialized_pw = serialize_and_deserialize(pw);
   check_solution<1>(
       cube(u), -3.0 * omega * square(u), 6.0 * square(omega) * u,
@@ -160,7 +169,8 @@ void test_1d() {
       deserialized_pw, x, t);
 
   const auto created_solution =
-      TestHelpers::test_creation<ScalarWave::Solutions::PlaneWave<1>>(
+      TestHelpers::test_creation<ScalarWave::Solutions::PlaneWave<1>,
+                                 Metavariables>(
           "WaveVector: [-1.5]\n"
           "Center: [2.4]\n"
           "Profile:\n"
@@ -205,8 +215,7 @@ void test_2d() {
           {-6.0 * omega * ky * u, 6.0 * kx * ky * u, 6.0 * square(ky) * u}},
       pw, x, t);
 
-  Parallel::register_derived_classes_with_charm<
-      MathFunction<1, Frame::Inertial>>();
+  Parallel::register_factory_classes_with_charm<Metavariables>();
   const auto deserialized_pw = serialize_and_deserialize(pw);
   check_solution<1>(
       cube(u), -3.0 * omega * square(u), 6.0 * square(omega) * u,
@@ -221,7 +230,8 @@ void test_2d() {
       deserialized_pw, x, t);
 
   const auto created_solution =
-      TestHelpers::test_creation<ScalarWave::Solutions::PlaneWave<2>>(
+      TestHelpers::test_creation<ScalarWave::Solutions::PlaneWave<2>,
+                                 Metavariables>(
           "WaveVector: [1.5, -7.2]\n"
           "Center: [2.4, -4.8]\n"
           "Profile:\n"
@@ -278,8 +288,7 @@ void test_3d() {
                                  6.0 * ky * kz * u, 6.0 * square(kz) * u}},
       pw, x, t);
 
-  Parallel::register_derived_classes_with_charm<
-      MathFunction<1, Frame::Inertial>>();
+  Parallel::register_factory_classes_with_charm<Metavariables>();
   const auto deserialized_pw = serialize_and_deserialize(pw);
   check_solution<1>(
       cube(u), -3.0 * omega * square(u), 6.0 * square(omega) * u,
@@ -300,7 +309,8 @@ void test_3d() {
       deserialized_pw, x, t);
 
   const auto created_solution =
-      TestHelpers::test_creation<ScalarWave::Solutions::PlaneWave<3>>(
+      TestHelpers::test_creation<ScalarWave::Solutions::PlaneWave<3>,
+                                 Metavariables>(
           "WaveVector: [1.5, -7.2, 2.7]\n"
           "Center: [2.4, -4.8, 8.4]\n"
           "Profile:\n"

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_RegularSphericalWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_RegularSphericalWave.cpp
@@ -11,11 +11,24 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/Systems/ScalarWave/Tags.hpp"  // IWYU pragma: keep
 #include "Framework/TestCreation.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp"
 #include "PointwiseFunctions/MathFunctions/Gaussian.hpp"
 #include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
+
+namespace {
+struct Metavariables {
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<MathFunction<1, Frame::Inertial>,
+                   tmpl::list<MathFunctions::Gaussian<1, Frame::Inertial>>>>;
+  };
+};
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.AnalyticSolutions.WaveEquation.RegularSphericalWave",
                   "[PointwiseFunctions][Unit]") {
@@ -65,7 +78,8 @@ SPECTRE_TEST_CASE("Unit.AnalyticSolutions.WaveEquation.RegularSphericalWave",
                         DataVector({{0., 0., 0., 0.}}));
 
   const auto created_solution =
-      TestHelpers::test_creation<ScalarWave::Solutions::RegularSphericalWave>(
+      TestHelpers::test_creation<ScalarWave::Solutions::RegularSphericalWave,
+                                 Metavariables>(
           "Profile:\n"
           "  Gaussian:\n"
           "    Amplitude: 1.\n"

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_Gaussian.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_Gaussian.cpp
@@ -30,7 +30,7 @@ struct Inertial;
 namespace {
 template <size_t VolumeDim, typename DataType, typename Fr>
 void test_gaussian_random(const DataType& used_for_size) noexcept {
-  Parallel::register_derived_classes_with_charm<
+  Parallel::register_classes_with_charm<
       MathFunctions::Gaussian<VolumeDim, Fr>>();
 
   // Generate the amplitude and width
@@ -78,7 +78,9 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.Gaussian",
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.Gaussian.Factory",
                   "[PointwiseFunctions][Unit]") {
-  TestHelpers::test_creation<std::unique_ptr<MathFunction<1, Frame::Inertial>>>(
+  TestHelpers::test_factory_creation<
+      MathFunction<1, Frame::Inertial>,
+      MathFunctions::Gaussian<1, Frame::Inertial>>(
       "Gaussian:\n"
       "  Amplitude: 3\n"
       "  Width: 2\n"
@@ -95,8 +97,9 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.Gaussian.Factory",
           "Width: 1.5\n"
           "Center: [1.1, -2.2, 3.3]");
   CHECK(created_gauss == gauss_3d);
-  const auto created_gauss_mathfunction = TestHelpers::test_creation<
-      std::unique_ptr<MathFunction<3, Frame::Inertial>>>(
+  const auto created_gauss_mathfunction = TestHelpers::test_factory_creation<
+      MathFunction<3, Frame::Inertial>,
+      MathFunctions::Gaussian<3, Frame::Inertial>>(
       "Gaussian:\n"
       "  Amplitude: 4.0\n"
       "  Width: 1.5\n"

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_PowX.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_PowX.cpp
@@ -29,8 +29,7 @@ struct Inertial;
 namespace {
 template <size_t VolumeDim, typename DataType, typename Fr>
 void test_pow_x_random(const DataType& used_for_size) noexcept {
-  Parallel::register_derived_classes_with_charm<
-      MathFunctions::PowX<VolumeDim, Fr>>();
+  Parallel::register_classes_with_charm<MathFunctions::PowX<VolumeDim, Fr>>();
 
   for (int power = -5; power < 6; ++power) {
     MathFunctions::PowX<VolumeDim, Fr> pow_x{power};
@@ -58,9 +57,11 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.PowX",
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.PowX.Factory",
                   "[PointwiseFunctions][Unit]") {
-  TestHelpers::test_creation<std::unique_ptr<MathFunction<1, Frame::Inertial>>>(
+  TestHelpers::test_factory_creation<MathFunction<1, Frame::Inertial>,
+                                     MathFunctions::PowX<1, Frame::Inertial>>(
       "PowX:\n    Power: 3");
-  TestHelpers::test_creation<std::unique_ptr<MathFunction<1, Frame::Inertial>>>(
+  TestHelpers::test_factory_creation<MathFunction<1, Frame::Inertial>,
+                                     MathFunctions::PowX<1, Frame::Inertial>>(
       "PowX:\n    Power: 3");
   // Catch requires us to have at least one CHECK in each test
   // The Unit.PointwiseFunctions.MathFunctions.PowX.Factory does not need to

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_Sinusoid.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_Sinusoid.cpp
@@ -27,7 +27,7 @@ struct Inertial;
 namespace {
 template <size_t VolumeDim, typename DataType, typename Fr>
 void test_sinusoid_random(const DataType& used_for_size) noexcept {
-  Parallel::register_derived_classes_with_charm<
+  Parallel::register_classes_with_charm<
       MathFunctions::Sinusoid<VolumeDim, Fr>>();
 
   // Generate the amplitude and width
@@ -67,12 +67,16 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.Sinusoid",
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.Sinusoid.Factory",
                   "[PointwiseFunctions][Unit]") {
-  TestHelpers::test_creation<std::unique_ptr<MathFunction<1, Frame::Inertial>>>(
+  TestHelpers::test_factory_creation<
+      MathFunction<1, Frame::Inertial>,
+      MathFunctions::Sinusoid<1, Frame::Inertial>>(
       "Sinusoid:\n"
       "  Amplitude: 3\n"
       "  Wavenumber: 2\n"
       "  Phase: -9");
-  TestHelpers::test_creation<std::unique_ptr<MathFunction<1, Frame::Inertial>>>(
+  TestHelpers::test_factory_creation<
+      MathFunction<1, Frame::Inertial>,
+      MathFunctions::Sinusoid<1, Frame::Inertial>>(
       "Sinusoid:\n"
       "  Amplitude: 3\n"
       "  Wavenumber: 2\n"


### PR DESCRIPTION
I don't think any specialization of this class except `MathFunction<1, Frame::Inertial>` is used.  We may want to consider dropping some of the other functionality, such as higher-dimensional functions.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
