### PR TITLE
Add 3d time dependent rotation matrix

### DIFF
--- a/src/Domain/CoordinateMaps/TimeDependent/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/TimeDependent/CMakeLists.txt
@@ -6,6 +6,7 @@ spectre_target_sources(
   PRIVATE
   CubicScale.cpp
   Rotation.cpp
+  RotationMatrixHelpers.cpp
   Shape.cpp
   SphericalCompression.cpp
   Translation.cpp
@@ -19,6 +20,7 @@ spectre_target_headers(
   ProductMaps.hpp
   ProductMaps.tpp
   Rotation.hpp
+  RotationMatrixHelpers.hpp
   Shape.hpp
   SphericalCompression.hpp
   Translation.hpp

--- a/src/Domain/CoordinateMaps/TimeDependent/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/TimeDependent/CMakeLists.txt
@@ -6,6 +6,7 @@ spectre_target_sources(
   PRIVATE
   CubicScale.cpp
   Rotation.cpp
+  Rotation3D.cpp
   RotationMatrixHelpers.cpp
   Shape.cpp
   SphericalCompression.cpp
@@ -20,6 +21,7 @@ spectre_target_headers(
   ProductMaps.hpp
   ProductMaps.tpp
   Rotation.hpp
+  Rotation3D.hpp
   RotationMatrixHelpers.hpp
   Shape.hpp
   SphericalCompression.hpp

--- a/src/Domain/CoordinateMaps/TimeDependent/Rotation3D.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Rotation3D.cpp
@@ -1,0 +1,213 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/TimeDependent/Rotation3D.hpp"
+
+#include <cmath>
+#include <ostream>
+#include <pup.h>
+#include <pup_stl.h>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/RotationMatrixHelpers.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/StdHelpers.hpp"
+
+namespace domain::CoordinateMaps::TimeDependent {
+
+Rotation3D::Rotation3D(std::string function_of_time_name) noexcept
+    : f_of_t_name_(std::move(function_of_time_name)) {}
+
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, 3> Rotation3D::operator()(
+    const std::array<T, 3>& source_coords, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const noexcept {
+  ASSERT(functions_of_time.find(f_of_t_name_) != functions_of_time.end(),
+         "Could not find function of time: '"
+             << f_of_t_name_ << "' in functions of time. Known functions are "
+             << keys_of(functions_of_time));
+
+  const Matrix rot_matrix =
+      get_rotation_matrix(time, *(functions_of_time.at(f_of_t_name_)));
+
+  std::array<tt::remove_cvref_wrap_t<T>, 3> result{};
+  for (size_t i = 0; i < 3; i++) {
+    gsl::at(result, i) = rot_matrix(i, 0) * source_coords[0];
+    for (size_t j = 1; j < 3; j++) {
+      gsl::at(result, i) += rot_matrix(i, j) * gsl::at(source_coords, j);
+    }
+  }
+  return result;
+}
+
+std::optional<std::array<double, 3>> Rotation3D::inverse(
+    const std::array<double, 3>& target_coords, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const noexcept {
+  ASSERT(functions_of_time.find(f_of_t_name_) != functions_of_time.end(),
+         "Could not find function of time: '"
+             << f_of_t_name_ << "' in functions of time. Known functions are "
+             << keys_of(functions_of_time));
+
+  const Matrix rot_matrix =
+      get_rotation_matrix(time, *(functions_of_time.at(f_of_t_name_)));
+
+  // The inverse map uses the inverse rotation matrix, which is just the
+  // transpose of the rotation matrix
+  std::array<double, 3> result{};
+  for (size_t i = 0; i < 3; i++) {
+    gsl::at(result, i) = rot_matrix(0, i) * target_coords[0];
+    for (size_t j = 1; j < 3; j++) {
+      gsl::at(result, i) += rot_matrix(j, i) * gsl::at(target_coords, j);
+    }
+  }
+  return result;
+}
+
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, 3> Rotation3D::frame_velocity(
+    const std::array<T, 3>& source_coords, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const noexcept {
+  ASSERT(functions_of_time.find(f_of_t_name_) != functions_of_time.end(),
+         "Could not find function of time: '"
+             << f_of_t_name_ << "' in functions of time. Known functions are "
+             << keys_of(functions_of_time));
+
+  // The mapped coordinates (x,y,z) are related to the unmapped
+  // coordinates (\xi, \eta, \zeta) by
+  // (x,y,z) = dtR * (\xi, \eta, \zeta)
+  // where dtR is the derivative of the rotation matrix
+  const Matrix rot_matrix_deriv =
+      get_rotation_matrix_deriv(time, *(functions_of_time.at(f_of_t_name_)));
+
+  std::array<tt::remove_cvref_wrap_t<T>, 3> result{};
+  for (size_t i = 0; i < 3; i++) {
+    gsl::at(result, i) = rot_matrix_deriv(i, 0) * source_coords[0];
+    for (size_t j = 1; j < 3; j++) {
+      gsl::at(result, i) += rot_matrix_deriv(i, j) * gsl::at(source_coords, j);
+    }
+  }
+  return result;
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> Rotation3D::jacobian(
+    const std::array<T, 3>& source_coords, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const noexcept {
+  ASSERT(functions_of_time.find(f_of_t_name_) != functions_of_time.end(),
+         "Could not find function of time: '"
+             << f_of_t_name_ << "' in functions of time. Known functions are "
+             << keys_of(functions_of_time));
+
+  const Matrix rot_matrix =
+      get_rotation_matrix(time, *(functions_of_time.at(f_of_t_name_)));
+
+  // Make tensor of zeros with correct type
+  auto jacobian_matrix =
+      make_with_value<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>>(
+          dereference_wrapper(source_coords[0]), 0.0);
+
+  for (size_t i = 0; i < 3; i++) {
+    for (size_t j = 0; j < 3; j++) {
+      jacobian_matrix.get(i, j) = rot_matrix(i, j);
+    }
+  }
+
+  return jacobian_matrix;
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>
+Rotation3D::inv_jacobian(
+    const std::array<T, 3>& source_coords, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const noexcept {
+  ASSERT(functions_of_time.find(f_of_t_name_) != functions_of_time.end(),
+         "Could not find function of time: '"
+             << f_of_t_name_ << "' in functions of time. Known functions are "
+             << keys_of(functions_of_time));
+
+  const Matrix rot_matrix =
+      get_rotation_matrix(time, *(functions_of_time.at(f_of_t_name_)));
+
+  auto inv_jacobian_matrix =
+      make_with_value<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>>(
+          dereference_wrapper(source_coords[0]), 0.0);
+
+  // The inverse jacobian is just the inverse rotation matrix, which is the
+  // transpose of the rotation matrix.
+  for (size_t i = 0; i < 3; i++) {
+    for (size_t j = 0; j < 3; j++) {
+      inv_jacobian_matrix.get(i, j) = rot_matrix(j, i);
+    }
+  }
+
+  return inv_jacobian_matrix;
+}
+
+void Rotation3D::pup(PUP::er& p) noexcept { p | f_of_t_name_; }
+
+bool operator==(const Rotation3D& lhs, const Rotation3D& rhs) noexcept {
+  return lhs.f_of_t_name_ == rhs.f_of_t_name_;
+}
+
+bool operator!=(const Rotation3D& lhs, const Rotation3D& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                 \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>               \
+  Rotation3D::operator()(                                                    \
+      const std::array<DTYPE(data), 3>& source_coords, double time,          \
+      const std::unordered_map<                                              \
+          std::string,                                                       \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&         \
+          functions_of_time) const noexcept;                                 \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>               \
+  Rotation3D::frame_velocity(                                                \
+      const std::array<DTYPE(data), 3>& source_coords, const double time,    \
+      const std::unordered_map<                                              \
+          std::string,                                                       \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&         \
+          functions_of_time) const noexcept;                                 \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame> \
+  Rotation3D::jacobian(                                                      \
+      const std::array<DTYPE(data), 3>& source_coords, double time,          \
+      const std::unordered_map<                                              \
+          std::string,                                                       \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&         \
+          functions_of_time) const noexcept;                                 \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame> \
+  Rotation3D::inv_jacobian(                                                  \
+      const std::array<DTYPE(data), 3>& source_coords, double time,          \
+      const std::unordered_map<                                              \
+          std::string,                                                       \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&         \
+          functions_of_time) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
+                                      std::reference_wrapper<const double>,
+                                      std::reference_wrapper<const DataVector>))
+#undef DTYPE
+#undef INSTANTIATE
+
+}  // namespace domain::CoordinateMaps::TimeDependent

--- a/src/Domain/CoordinateMaps/TimeDependent/Rotation3D.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Rotation3D.hpp
@@ -1,0 +1,101 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
+
+/// \cond
+namespace domain {
+namespace FunctionsOfTime {
+class FunctionOfTime;
+}  // namespace FunctionsOfTime
+}  // namespace domain
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace domain {
+namespace CoordinateMaps {
+namespace TimeDependent {
+
+/*!
+ * \ingroup CoordMapsTimeDependentGroup
+ * \brief Time-dependent spatial rotation in three dimensions.
+ *
+ * Uses quaternions to construct the rotation matrices.
+ */
+class Rotation3D {
+ public:
+  static constexpr size_t dim = 3;
+
+  explicit Rotation3D(std::string function_of_time_name) noexcept;
+  Rotation3D() = default;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(
+      const std::array<T, 3>& source_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
+
+  /// The inverse function is only callable with doubles because the inverse
+  /// might fail if called for a point out of range, and it is unclear
+  /// what should happen if the inverse were to succeed for some points in a
+  /// DataVector but fail for other points.
+  std::optional<std::array<double, 3>> inverse(
+      const std::array<double, 3>& target_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, 3> frame_velocity(
+      const std::array<T, 3>& source_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> jacobian(
+      const std::array<T, 3>& source_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> inv_jacobian(
+      const std::array<T, 3>& source_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
+
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+  static bool is_identity() noexcept { return false; }
+
+ private:
+  friend bool operator==(const Rotation3D& lhs, const Rotation3D& rhs) noexcept;
+  std::string f_of_t_name_;
+};
+
+bool operator!=(const Rotation3D& lhs, const Rotation3D& rhs) noexcept;
+
+}  // namespace TimeDependent
+}  // namespace CoordinateMaps
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/TimeDependent/RotationMatrixHelpers.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/RotationMatrixHelpers.cpp
@@ -1,0 +1,53 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/TimeDependent/RotationMatrixHelpers.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+void add_bilinear_term(const gsl::not_null<Matrix*> rot_matrix,
+                       const DataVector& q1, const DataVector& q2,
+                       const double coef = 1.0) {
+  (*rot_matrix)(0, 0) +=
+      coef * (q1[0] * q2[0] + q1[1] * q2[1] - q1[2] * q2[2] - q1[3] * q2[3]);
+  (*rot_matrix)(1, 1) +=
+      coef * (q1[0] * q2[0] + q1[2] * q2[2] - q1[1] * q2[1] - q1[3] * q2[3]);
+  (*rot_matrix)(2, 2) +=
+      coef * (q1[0] * q2[0] + q1[3] * q2[3] - q1[1] * q2[1] - q1[2] * q2[2]);
+
+  (*rot_matrix)(0, 1) += coef * (2.0 * (q1[1] * q2[2] - q1[0] * q2[3]));
+  (*rot_matrix)(0, 2) += coef * (2.0 * (q1[0] * q2[2] + q1[1] * q2[3]));
+  (*rot_matrix)(1, 0) += coef * (2.0 * (q1[1] * q2[2] + q1[0] * q2[3]));
+  (*rot_matrix)(1, 2) += coef * (2.0 * (q1[2] * q2[3] - q1[0] * q2[1]));
+  (*rot_matrix)(2, 0) += coef * (2.0 * (q1[1] * q2[3] - q1[0] * q2[2]));
+  (*rot_matrix)(2, 1) += coef * (2.0 * (q1[0] * q2[1] + q1[2] * q2[3]));
+}
+}  // namespace
+
+Matrix get_rotation_matrix(
+    const double t,
+    const domain::FunctionsOfTime::FunctionOfTime& fot) noexcept {
+  std::array<DataVector, 1> quat = fot.func(t);
+  Matrix rot_matrix{{0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}};
+
+  add_bilinear_term(make_not_null(&rot_matrix), quat[0], quat[0]);
+
+  return rot_matrix;
+}
+
+Matrix get_rotation_matrix_deriv(
+    const double t,
+    const domain::FunctionsOfTime::FunctionOfTime& fot) noexcept {
+  std::array<DataVector, 2> quat_and_deriv = fot.func_and_deriv(t);
+  Matrix rot_matrix_deriv{{0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}};
+
+  add_bilinear_term(make_not_null(&rot_matrix_deriv), quat_and_deriv[0],
+                    quat_and_deriv[1]);
+  add_bilinear_term(make_not_null(&rot_matrix_deriv), quat_and_deriv[1],
+                    quat_and_deriv[0]);
+
+  return rot_matrix_deriv;
+}

--- a/src/Domain/CoordinateMaps/TimeDependent/RotationMatrixHelpers.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/RotationMatrixHelpers.hpp
@@ -1,0 +1,25 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines rotation matrices using quaternions.
+
+#pragma once
+
+#include <array>
+
+#include "DataStructures/Matrix.hpp"
+
+/// \cond
+namespace domain {
+namespace FunctionsOfTime {
+class FunctionOfTime;
+}  // namespace FunctionsOfTime
+}  // namespace domain
+/// \endcond
+
+Matrix get_rotation_matrix(
+    double t, const domain::FunctionsOfTime::FunctionOfTime& fot) noexcept;
+
+Matrix get_rotation_matrix_deriv(
+    double t, const domain::FunctionsOfTime::FunctionOfTime& fot) noexcept;

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_CubicScale.cpp
   Test_ProductMaps.cpp
   Test_Rotation.cpp
+  Test_Rotation3D.cpp
   Test_RotationMatrixHelpers.cpp
   Test_Shape.cpp
   Test_SphericalCompression.cpp

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_CubicScale.cpp
   Test_ProductMaps.cpp
   Test_Rotation.cpp
+  Test_RotationMatrixHelpers.cpp
   Test_Shape.cpp
   Test_SphericalCompression.cpp
   Test_Translation.cpp

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_Rotation3D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_Rotation3D.cpp
@@ -1,0 +1,208 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/Rotation3D.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+
+namespace {
+std::array<double, 3> mapped_point(const std::array<double, 3> ipt,
+                                   const double t) {
+  const double c = cos(square(t));  // rotation angle = t^2
+  const double s = sin(square(t));  // rotation angle = t^2
+  const double vx = 1 / sqrt(3);
+  const double vy = -vx;
+  const double vz = vx;
+  // rotate about (1, -1, 1) /root(3)
+  return {{(c + vx * vx * (1 - c)) * ipt[0] +
+               (vx * vy * (1 - c) - vz * s) * ipt[1] +
+               (vx * vz * (1 - c) + vy * s) * ipt[2],
+           (vy * vx * (1 - c) + vz * s) * ipt[0] +
+               (c + vy * vy * (1 - c)) * ipt[1] +
+               (vy * vz * (1 - c) - vx * s) * ipt[2],
+           (vz * vx * (1 - c) - vy * s) * ipt[0] +
+               (vz * vy * (1 - c) + vx * s) * ipt[1] +
+               (c + vz * vz * (1 - c)) * ipt[2]}};
+}
+
+std::array<double, 3> frame_vel(const std::array<double, 3> ipt,
+                                const double t) {
+  const double c = cos(square(t));  // rotation angle = t^2
+  const double s = sin(square(t));  // rotation angle = t^2
+  const double omega = 2 * t;
+  const double vx = 1 / sqrt(3);
+  const double vy = -vx;
+  const double vz = vx;
+  // rotate about (1, -1, 1) /root(3)
+  return {{((vz * vz - 1) * s * ipt[0] + (vx * vy * s - vz * c) * ipt[1] +
+            (vx * vz * s + vy * c) * ipt[2]) *
+               omega,
+           ((vx * vy * s + vz * c) * ipt[0] + (vy * vy - 1) * s * ipt[1] +
+            (vy * vz * s - vx * c) * ipt[2]) *
+               omega,
+           ((vx * vz * s - vy * c) * ipt[0] + (vy * vz * s + vx * c) * ipt[1] +
+            (vz * vz - 1) * s * ipt[2]) *
+               omega}};
+}
+}  // namespace
+
+namespace domain {
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.TimeDependent.Rotation3D",
+                  "[Domain][Unit]") {
+  double t{0.0};
+  double dt{0.6};
+  double final_time{4.0};
+  constexpr size_t deriv_order{2};
+
+  using QuatFoft =
+      domain::FunctionsOfTime::QuaternionFunctionOfTime<deriv_order>;
+  using FoftPtr = std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>;
+
+  const std::string f_of_t_name{"test_quaternion"};
+  // rotation about (1,-1,1)/root(3) by angle theta = t^2
+  const std::array<DataVector, deriv_order + 1> init_omega{
+      DataVector{3, 0.0},
+      DataVector{{2.0 / sqrt(3), -2.0 / sqrt(3), 2.0 / sqrt(3)}},
+      DataVector{3, 0.0}};
+  const std::array<DataVector, 1> init_quat{DataVector{{1.0, 0.0, 0.0, 0.0}}};
+
+  std::unordered_map<std::string, FoftPtr> f_of_t_list{};
+  f_of_t_list[f_of_t_name] =
+      std::make_unique<QuatFoft>(t, init_quat, init_omega, final_time + dt);
+
+  const CoordinateMaps::TimeDependent::Rotation3D rotation_map{f_of_t_name};
+  const auto rotation_map_deserialized =
+      serialize_and_deserialize(rotation_map);
+
+  const std::array<double, 3> initial_unmapped_point{{8.1, 5.9, 2.3}};
+  Approx custom_approx1 = Approx::custom().epsilon(3e-11).scale(1.0);
+
+  while (t < final_time) {
+    const std::array<double, 3> expected{
+        mapped_point(initial_unmapped_point, t)};
+    CHECK_ITERABLE_CUSTOM_APPROX(
+        rotation_map(initial_unmapped_point, t, f_of_t_list), expected,
+        custom_approx1);
+    CHECK_ITERABLE_CUSTOM_APPROX(
+        rotation_map.inverse(expected, t, f_of_t_list).value(),
+        initial_unmapped_point, custom_approx1);
+    CHECK_ITERABLE_CUSTOM_APPROX(
+        rotation_map.frame_velocity(initial_unmapped_point, t, f_of_t_list),
+        frame_vel(initial_unmapped_point, t), custom_approx1);
+
+    CHECK_ITERABLE_CUSTOM_APPROX(
+        rotation_map_deserialized(initial_unmapped_point, t, f_of_t_list),
+        expected, custom_approx1);
+    CHECK_ITERABLE_CUSTOM_APPROX(
+        rotation_map_deserialized.inverse(expected, t, f_of_t_list).value(),
+        initial_unmapped_point, custom_approx1);
+    CHECK_ITERABLE_CUSTOM_APPROX(rotation_map_deserialized.frame_velocity(
+                                     initial_unmapped_point, t, f_of_t_list),
+                                 frame_vel(initial_unmapped_point, t),
+                                 custom_approx1);
+
+    const auto jac{
+        rotation_map.jacobian(initial_unmapped_point, t, f_of_t_list)};
+    const auto inv_jac{
+        rotation_map.inv_jacobian(initial_unmapped_point, t, f_of_t_list)};
+    const double c = cos(square(t));  // rotation angle = t^2
+    const double s = sin(square(t));  // rotation angle = t^2
+    const double vx = 1 / sqrt(3);
+    const double vy = -vx;
+    const double vz = vx;
+    // rotate about (1, -1, 1) /root(3)
+    Approx custom_approx2 = Approx::custom().epsilon(1e-12).scale(1.0);
+
+    CHECK(get<0, 0>(jac) == custom_approx2(c + vx * vx * (1 - c)));
+    CHECK(get<0, 1>(jac) == custom_approx2(vx * vy * (1 - c) - vz * s));
+    CHECK(get<0, 2>(jac) == custom_approx2(vx * vz * (1 - c) + vy * s));
+    CHECK(get<1, 0>(jac) == custom_approx2(vy * vx * (1 - c) + vz * s));
+    CHECK(get<1, 1>(jac) == custom_approx2(c + vy * vy * (1 - c)));
+    CHECK(get<1, 2>(jac) == custom_approx2(vy * vz * (1 - c) - vx * s));
+    CHECK(get<2, 0>(jac) == custom_approx2(vz * vx * (1 - c) - vy * s));
+    CHECK(get<2, 1>(jac) == custom_approx2(vz * vy * (1 - c) + vx * s));
+    CHECK(get<2, 2>(jac) == custom_approx2(c + vz * vz * (1 - c)));
+
+    CHECK(get<0, 0>(inv_jac) == custom_approx2(c + vx * vx * (1 - c)));
+    CHECK(get<0, 1>(inv_jac) == custom_approx2(vx * vy * (1 - c) + vz * s));
+    CHECK(get<0, 2>(inv_jac) == custom_approx2(vx * vz * (1 - c) - vy * s));
+    CHECK(get<1, 0>(inv_jac) == custom_approx2(vy * vx * (1 - c) - vz * s));
+    CHECK(get<1, 1>(inv_jac) == custom_approx2(c + vy * vy * (1 - c)));
+    CHECK(get<1, 2>(inv_jac) == custom_approx2(vy * vz * (1 - c) + vx * s));
+    CHECK(get<2, 0>(inv_jac) == custom_approx2(vz * vx * (1 - c) + vy * s));
+    CHECK(get<2, 1>(inv_jac) == custom_approx2(vz * vy * (1 - c) - vx * s));
+    CHECK(get<2, 2>(inv_jac) == custom_approx2(c + vz * vz * (1 - c)));
+
+    const auto jac_deserialized{rotation_map_deserialized.jacobian(
+        initial_unmapped_point, t, f_of_t_list)};
+    const auto inv_jac_deserialized{rotation_map_deserialized.inv_jacobian(
+        initial_unmapped_point, t, f_of_t_list)};
+    CHECK(get<0, 0>(jac_deserialized) == custom_approx2(c + vx * vx * (1 - c)));
+    CHECK(get<0, 1>(jac_deserialized) ==
+          custom_approx2(vx * vy * (1 - c) - vz * s));
+    CHECK(get<0, 2>(jac_deserialized) ==
+          custom_approx2(vx * vz * (1 - c) + vy * s));
+    CHECK(get<1, 0>(jac_deserialized) ==
+          custom_approx2(vy * vx * (1 - c) + vz * s));
+    CHECK(get<1, 1>(jac_deserialized) == custom_approx2(c + vy * vy * (1 - c)));
+    CHECK(get<1, 2>(jac_deserialized) ==
+          custom_approx2(vy * vz * (1 - c) - vx * s));
+    CHECK(get<2, 0>(jac_deserialized) ==
+          custom_approx2(vz * vx * (1 - c) - vy * s));
+    CHECK(get<2, 1>(jac_deserialized) ==
+          custom_approx2(vz * vy * (1 - c) + vx * s));
+    CHECK(get<2, 2>(jac_deserialized) == custom_approx2(c + vz * vz * (1 - c)));
+
+    CHECK(get<0, 0>(inv_jac_deserialized) ==
+          custom_approx2(c + vx * vx * (1 - c)));
+    CHECK(get<0, 1>(inv_jac_deserialized) ==
+          custom_approx2(vx * vy * (1 - c) + vz * s));
+    CHECK(get<0, 2>(inv_jac_deserialized) ==
+          custom_approx2(vx * vz * (1 - c) - vy * s));
+    CHECK(get<1, 0>(inv_jac_deserialized) ==
+          custom_approx2(vy * vx * (1 - c) - vz * s));
+    CHECK(get<1, 1>(inv_jac_deserialized) ==
+          custom_approx2(c + vy * vy * (1 - c)));
+    CHECK(get<1, 2>(inv_jac_deserialized) ==
+          custom_approx2(vy * vz * (1 - c) + vx * s));
+    CHECK(get<2, 0>(inv_jac_deserialized) ==
+          custom_approx2(vz * vx * (1 - c) + vy * s));
+    CHECK(get<2, 1>(inv_jac_deserialized) ==
+          custom_approx2(vz * vy * (1 - c) - vx * s));
+    CHECK(get<2, 2>(inv_jac_deserialized) ==
+          custom_approx2(c + vz * vz * (1 - c)));
+
+    t += dt;
+  }
+
+  const std::string f_of_t_name_2{"Different name"};
+  const CoordinateMaps::TimeDependent::Rotation3D rotation_map_2{f_of_t_name_2};
+  // Check inequivalence operator
+  CHECK_FALSE(rotation_map != rotation_map);
+  CHECK_FALSE(rotation_map_deserialized != rotation_map_deserialized);
+  CHECK(rotation_map != rotation_map_2);
+  CHECK_FALSE(rotation_map == rotation_map_2);
+
+  // Check serialization
+  CHECK(rotation_map == rotation_map_deserialized);
+  CHECK_FALSE(rotation_map != rotation_map_deserialized);
+
+  test_coordinate_map_argument_types(rotation_map, initial_unmapped_point, t,
+                                     f_of_t_list);
+  CHECK(not CoordinateMaps::TimeDependent::Rotation3D{}.is_identity());
+}
+}  // namespace domain

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_RotationMatrixHelpers.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_RotationMatrixHelpers.cpp
@@ -1,0 +1,101 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/RotationMatrixHelpers.hpp"
+#include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
+
+void check_rotation_matrix_helpers(const std::array<DataVector, 3>& init_omega,
+                                   const Matrix& expected_rot_matrix,
+                                   const Matrix& expected_rot_matrix_deriv,
+                                   const double check_time) {
+  using QuatFoft = domain::FunctionsOfTime::QuaternionFunctionOfTime<2>;
+
+  const double t = 0.0;
+  const std::array<DataVector, 1> init_quat{DataVector{{1.0, 0.0, 0.0, 0.0}}};
+
+  QuatFoft quat_fot(t, init_quat, init_omega, t + 5.0);
+
+  const Matrix rot_matrix =
+      get_rotation_matrix(check_time, quat_fot);
+  const Matrix rot_matrix_deriv =
+      get_rotation_matrix_deriv(check_time, quat_fot);
+
+  Approx custom_approx = Approx::custom().epsilon(5e-12).scale(1.0);
+  CHECK_MATRIX_CUSTOM_APPROX(rot_matrix, expected_rot_matrix, custom_approx);
+  CHECK_MATRIX_CUSTOM_APPROX(rot_matrix_deriv, expected_rot_matrix_deriv,
+                             custom_approx);
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.Domain.CoordinateMaps.TimeDepenent.RotationMatrixHelpers",
+    "[Unit][Domain]") {
+  {
+    INFO("Rotation about z")
+    const double omega = 2.0;
+    const double check_time = 1.0;
+
+    const std::array<DataVector, 3> init_omega{
+        DataVector{{0.0, 0.0, omega}}, DataVector{3, 0.0}, DataVector{3, 0.0}};
+
+    const double theta = omega * check_time;
+    const Matrix expected_rot_matrix_z{{cos(theta), -sin(theta), 0.0},
+                                       {sin(theta), cos(theta), 0.0},
+                                       {0.0, 0.0, 1.0}};
+    const Matrix expected_rot_matrix_deriv_z{
+        {-2.0 * sin(theta), -2.0 * cos(theta), 0.0},
+        {2.0 * cos(theta), -2.0 * sin(theta), 0.0},
+        {0.0, 0.0, 0.0}};
+
+    check_rotation_matrix_helpers(init_omega, expected_rot_matrix_z,
+                                  expected_rot_matrix_deriv_z, check_time);
+  }
+
+  {
+    INFO("Rotation about x")
+    const double omega = 2.0;
+    const double check_time = 1.0;
+
+    const std::array<DataVector, 3> init_omega{
+        DataVector{{omega, 0.0, 0.0}}, DataVector{3, 0.0}, DataVector{3, 0.0}};
+
+    const double theta = omega * check_time;
+    const Matrix expected_rot_matrix_x{{1.0, 0.0, 0.0},
+                                       {0.0, cos(theta), -sin(theta)},
+                                       {0.0, sin(theta), cos(theta)}};
+    const Matrix expected_rot_matrix_deriv_x{
+        {0.0, 0.0, 0.0},
+        {0.0, -2.0 * sin(theta), -2.0 * cos(theta)},
+        {0.0, 2.0 * cos(theta), -2.0 * sin(theta)}};
+
+    check_rotation_matrix_helpers(init_omega, expected_rot_matrix_x,
+                                  expected_rot_matrix_deriv_x, check_time);
+  }
+
+  {
+    INFO("Rotation about y")
+    const double omega = 2.0;
+    const double check_time = 1.0;
+
+    const std::array<DataVector, 3> init_omega{
+        DataVector{{0.0, omega, 0.0}}, DataVector{3, 0.0}, DataVector{3, 0.0}};
+
+    const double theta = omega * check_time;
+    const Matrix expected_rot_matrix_y{{cos(theta), 0.0, sin(theta)},
+                                       {0.0, 1.0, 0.0},
+                                       {-sin(theta), 0.0, cos(theta)}};
+    const Matrix expected_rot_matrix_deriv_y{
+        {-2.0 * sin(theta), 0.0, 2.0 * cos(theta)},
+        {0.0, 0.0, 0.0},
+        {-2.0 * cos(theta), 0.0, -2.0 * sin(theta)}};
+
+    check_rotation_matrix_helpers(init_omega, expected_rot_matrix_y,
+                                  expected_rot_matrix_deriv_y, check_time);
+  }
+}


### PR DESCRIPTION
## Proposed changes
Adds a time dependent 3d rotation map that uses quaternions along with a helper function that actually calculates the rotation matrices.

As of right now the rotation matrix is recalculated every function call ~unless the time it's being evaluated at is equal (within round-off) to the previous time it was updated. This can be modified later to a better caching system.~

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Dependencies

- [x] PR #3327 
- [x] PR #3321 (included in above PR as well)

(This is a long PR because of the included dependent PRs. The three actual commits total about +680)
<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->