### PR TITLE
Use Frame::BlockLogical as source frame for CoordinateMap in a Block

### DIFF
--- a/src/DataStructures/Tensor/IndexType.hpp
+++ b/src/DataStructures/Tensor/IndexType.hpp
@@ -39,6 +39,8 @@ namespace Frame {
 /// evaluate an analytic solution in that frame.
 struct FrameIsPhysical {};
 
+struct BlockLogical {};
+struct ElementLogical {};
 struct Logical {};
 struct Grid {};
 struct Inertial : FrameIsPhysical {};
@@ -73,6 +75,14 @@ constexpr bool is_frame_physical_v = is_frame_physical<CheckFrame>::value;
 
 /// \cond HIDDEN_SYMBOLS
 inline std::ostream& operator<<(std::ostream& os,
+                                const Frame::BlockLogical& /*meta*/) noexcept {
+  return os << "BlockLogical";
+}
+inline std::ostream& operator<<(
+    std::ostream& os, const Frame::ElementLogical& /*meta*/) noexcept {
+  return os << "ElementLogical";
+}
+inline std::ostream& operator<<(std::ostream& os,
                                 const Frame::Logical& /*meta*/) noexcept {
   return os << "Logical";
 }
@@ -106,6 +116,16 @@ template <typename Fr>
 inline std::string prefix() noexcept;
 
 /// \cond HIDDEN_SYMBOLS
+template <>
+inline std::string prefix<Frame::BlockLogical>() noexcept {
+  return "BlockLogical_";
+}
+
+template <>
+inline std::string prefix<Frame::ElementLogical>() noexcept {
+  return "ElementLogical_";
+}
+
 template <>
 inline std::string prefix<Frame::Logical>() noexcept {
   return "Logical_";

--- a/src/Domain/Block.cpp
+++ b/src/Domain/Block.cpp
@@ -26,12 +26,12 @@ struct Logical;
 
 template <size_t VolumeDim>
 Block<VolumeDim>::Block(
-    std::unique_ptr<domain::CoordinateMapBase<Frame::Logical, Frame::Inertial,
-                                              VolumeDim>>&& stationary_map,
+    std::unique_ptr<domain::CoordinateMapBase<
+        Frame::BlockLogical, Frame::Inertial, VolumeDim>>&& stationary_map,
     const size_t id,
     DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbors,
-    DirectionMap<VolumeDim, std::unique_ptr<
-                                domain::BoundaryConditions::BoundaryCondition>>
+    DirectionMap<VolumeDim,
+                 std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>
         external_boundary_conditions) noexcept
     : stationary_map_(std::move(stationary_map)),
       id_(id),
@@ -73,7 +73,8 @@ Block<VolumeDim>::Block(
 }
 
 template <size_t VolumeDim>
-const domain::CoordinateMapBase<Frame::Logical, Frame::Inertial, VolumeDim>&
+const domain::CoordinateMapBase<Frame::BlockLogical, Frame::Inertial,
+                                VolumeDim>&
 Block<VolumeDim>::stationary_map() const noexcept {
   ASSERT(stationary_map_ != nullptr,
          "The stationary map is set to nullptr and so cannot be retrieved. "
@@ -83,7 +84,7 @@ Block<VolumeDim>::stationary_map() const noexcept {
 }
 
 template <size_t VolumeDim>
-const domain::CoordinateMapBase<Frame::Logical, Frame::Grid, VolumeDim>&
+const domain::CoordinateMapBase<Frame::BlockLogical, Frame::Grid, VolumeDim>&
 Block<VolumeDim>::moving_mesh_logical_to_grid_map() const noexcept {
   ASSERT(moving_mesh_grid_map_ != nullptr,
          "The moving mesh Logical to Grid map is set to nullptr and so cannot "

--- a/src/Domain/Block.hpp
+++ b/src/Domain/Block.hpp
@@ -19,7 +19,7 @@
 
 /// \cond
 namespace Frame {
-struct Logical;
+struct BlockLogical;
 struct Inertial;
 }  // namespace Frame
 namespace PUP {
@@ -51,7 +51,7 @@ class Block {
   ///        at external boundaries. Can be either empty or one per each
   ///        external boundary
   Block(std::unique_ptr<domain::CoordinateMapBase<
-            Frame::Logical, Frame::Inertial, VolumeDim>>&& stationary_map,
+            Frame::BlockLogical, Frame::Inertial, VolumeDim>>&& stationary_map,
         size_t id, DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbors,
         DirectionMap<
             VolumeDim,
@@ -68,14 +68,15 @@ class Block {
   /// \brief The map used when the coordinate map is time-independent.
   ///
   /// \see is_time_dependent()
-  const domain::CoordinateMapBase<Frame::Logical, Frame::Inertial, VolumeDim>&
+  const domain::CoordinateMapBase<Frame::BlockLogical, Frame::Inertial,
+                                  VolumeDim>&
   stationary_map() const noexcept;
 
   /// \brief The map going from the block logical frame to the last time
   /// independent frame. Only used when the coordinate map is time-dependent.
   ///
   /// \see is_time_dependent() moving_mesh_grid_to_inertial_map()
-  const domain::CoordinateMapBase<Frame::Logical, Frame::Grid, VolumeDim>&
+  const domain::CoordinateMapBase<Frame::BlockLogical, Frame::Grid, VolumeDim>&
   moving_mesh_logical_to_grid_map() const noexcept;
 
   /// \brief The map going from the last time independent frame to the frame in
@@ -130,11 +131,11 @@ class Block {
   friend bool operator==(const Block<LocalVolumeDim>& lhs,
                          const Block<LocalVolumeDim>& rhs) noexcept;
 
-  std::unique_ptr<
-      domain::CoordinateMapBase<Frame::Logical, Frame::Inertial, VolumeDim>>
+  std::unique_ptr<domain::CoordinateMapBase<Frame::BlockLogical,
+                                            Frame::Inertial, VolumeDim>>
       stationary_map_{nullptr};
   std::unique_ptr<
-      domain::CoordinateMapBase<Frame::Logical, Frame::Grid, VolumeDim>>
+      domain::CoordinateMapBase<Frame::BlockLogical, Frame::Grid, VolumeDim>>
       moving_mesh_grid_map_{nullptr};
   std::unique_ptr<
       domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, VolumeDim>>

--- a/src/Domain/BlockLogicalCoordinates.cpp
+++ b/src/Domain/BlockLogicalCoordinates.cpp
@@ -17,8 +17,9 @@
 namespace {
 // Define this alias so we don't need to keep typing this monster.
 template <size_t Dim>
-using block_logical_coord_holder = std::optional<
-    IdPair<domain::BlockId, tnsr::I<double, Dim, typename ::Frame::Logical>>>;
+using block_logical_coord_holder =
+    std::optional<IdPair<domain::BlockId,
+                         tnsr::I<double, Dim, typename ::Frame::BlockLogical>>>;
 using functions_of_time_type = std::unordered_map<
     std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>;
 }  // namespace
@@ -35,7 +36,7 @@ std::vector<block_logical_coord_holder<Dim>> block_logical_coordinates(
     for (size_t d = 0; d < Dim; ++d) {
       x_frame.get(d) = x.get(d)[s];
     }
-    tnsr::I<double, Dim, typename ::Frame::Logical> x_logical{};
+    tnsr::I<double, Dim, typename ::Frame::BlockLogical> x_logical{};
     // Check which block this point is in. Each point will be in one
     // and only one block, unless it is on a shared boundary.  In that
     // case, choose the first matching block (and this block will have

--- a/src/Domain/BlockLogicalCoordinates.hpp
+++ b/src/Domain/BlockLogicalCoordinates.hpp
@@ -49,4 +49,4 @@ auto block_logical_coordinates(
             std::unique_ptr<
                 domain::FunctionsOfTime::FunctionOfTime>>{}) noexcept
     -> std::vector<std::optional<
-        IdPair<domain::BlockId, tnsr::I<double, Dim, ::Frame::Logical>>>>;
+        IdPair<domain::BlockId, tnsr::I<double, Dim, ::Frame::BlockLogical>>>>;

--- a/src/Domain/CoordinateMaps/MapInstantiationMacros.hpp
+++ b/src/Domain/CoordinateMaps/MapInstantiationMacros.hpp
@@ -58,7 +58,7 @@
  *                                             domain::CoordinateMaps::Affine>;
  *
  *  GENERATE_INSTANTIATIONS(INSTANTIATE_MAPS_SIMPLE_FUNCTIONS,
- *                          ((Affine2d), (Affine3d)), (Frame::Logical),
+ *                          ((Affine2d), (Affine3d)), (Frame::BlockLogical),
  *                          (Frame::Grid, Frame::Inertial))
  * \endcode
  *
@@ -126,7 +126,7 @@
  *                                             domain::CoordinateMaps::Affine>;
  *
  *  GENERATE_INSTANTIATIONS(INSTANTIATE_MAPS_DATA_TYPE_FUNCTIONS,
- *                          ((Affine2d), (Affine3d)), (Frame::Logical),
+ *                          ((Affine2d), (Affine3d)), (Frame::BlockLogical),
  *                          (Frame::Grid, Frame::Inertial),
  *                          (double, DataVector))
  * \endcode
@@ -242,7 +242,7 @@
  *                                             domain::CoordinateMaps::Affine,
  *                                             domain::CoordinateMaps::Affine>;
  *
- *  INSTANTIATE_MAPS_FUNCTIONS(((Affine2d), (Affine3d)), (Frame::Logical),
+ *  INSTANTIATE_MAPS_FUNCTIONS(((Affine2d), (Affine3d)), (Frame::BlockLogical),
  *                             (Frame::Grid, Frame::Inertial),
  *                             (double, DataVector))
  * \endcode

--- a/src/Domain/Creators/AlignedLattice.hpp
+++ b/src/Domain/Creators/AlignedLattice.hpp
@@ -96,13 +96,13 @@ template <size_t VolumeDim>
 class AlignedLattice : public DomainCreator<VolumeDim> {
  public:
   using maps_list = tmpl::list<
-      domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                             CoordinateMaps::Affine>,
       domain::CoordinateMap<
-          Frame::Logical, Frame::Inertial,
+          Frame::BlockLogical, Frame::Inertial,
           CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
                                          CoordinateMaps::Affine>>,
-      domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                             CoordinateMaps::ProductOf3Maps<
                                 CoordinateMaps::Affine, CoordinateMaps::Affine,
                                 CoordinateMaps::Affine>>>;

--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -38,7 +38,7 @@
 #include "Utilities/MakeArray.hpp"
 
 namespace Frame {
-struct Logical;
+struct BlockLogical;
 }  // namespace Frame
 
 namespace domain::creators {
@@ -248,8 +248,8 @@ Domain<3> BinaryCompactObject::create_domain() const noexcept {
   const double inner_sphericity_A = object_A_.is_excised() ? 1.0 : 0.0;
   const double inner_sphericity_B = object_B_.is_excised() ? 1.0 : 0.0;
 
-  using Maps = std::vector<
-      std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 3>>>;
+  using Maps = std::vector<std::unique_ptr<
+      CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 3>>>;
   using BcMap = DirectionMap<
       3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>;
 
@@ -403,7 +403,7 @@ Domain<3> BinaryCompactObject::create_domain() const noexcept {
     const double scaled_r_inner_A = object_A_.inner_radius / sqrt(3.0);
     if (use_equiangular_map_) {
       maps.emplace_back(
-          make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
               Equiangular3D{Equiangular(-1.0, 1.0, -1.0 * scaled_r_inner_A,
                                         scaled_r_inner_A),
                             Equiangular(-1.0, 1.0, -1.0 * scaled_r_inner_A,
@@ -413,7 +413,7 @@ Domain<3> BinaryCompactObject::create_domain() const noexcept {
               translation_A));
     } else {
       maps.emplace_back(
-          make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
               Affine3D{
                   Affine(-1.0, 1.0, -1.0 * scaled_r_inner_A, scaled_r_inner_A),
                   Affine(-1.0, 1.0, -1.0 * scaled_r_inner_A, scaled_r_inner_A),
@@ -434,7 +434,7 @@ Domain<3> BinaryCompactObject::create_domain() const noexcept {
     const double scaled_r_inner_B = object_B_.inner_radius / sqrt(3.0);
     if (use_equiangular_map_) {
       maps.emplace_back(
-          make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
               Equiangular3D{Equiangular(-1.0, 1.0, -1.0 * scaled_r_inner_B,
                                         scaled_r_inner_B),
                             Equiangular(-1.0, 1.0, -1.0 * scaled_r_inner_B,
@@ -444,7 +444,7 @@ Domain<3> BinaryCompactObject::create_domain() const noexcept {
               translation_B));
     } else {
       maps.emplace_back(
-          make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
               Affine3D{
                   Affine(-1.0, 1.0, -1.0 * scaled_r_inner_B, scaled_r_inner_B),
                   Affine(-1.0, 1.0, -1.0 * scaled_r_inner_B, scaled_r_inner_B),

--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -61,7 +61,7 @@ class FunctionOfTime;
 
 namespace Frame {
 struct Inertial;
-struct Logical;
+struct BlockLogical;
 }  // namespace Frame
 
 namespace BinaryCompactObject_detail {
@@ -150,42 +150,42 @@ namespace creators {
 class BinaryCompactObject : public DomainCreator<3> {
  public:
   using maps_list = tmpl::list<
-      domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                             CoordinateMaps::ProductOf3Maps<
                                 CoordinateMaps::Affine, CoordinateMaps::Affine,
                                 CoordinateMaps::Affine>>,
       domain::CoordinateMap<
-          Frame::Logical, Frame::Inertial,
+          Frame::BlockLogical, Frame::Inertial,
           CoordinateMaps::ProductOf3Maps<CoordinateMaps::Equiangular,
                                          CoordinateMaps::Equiangular,
                                          CoordinateMaps::Equiangular>>,
       domain::CoordinateMap<
-          Frame::Logical, Frame::Inertial,
+          Frame::BlockLogical, Frame::Inertial,
           CoordinateMaps::ProductOf3Maps<CoordinateMaps::Affine,
                                          CoordinateMaps::Affine,
                                          CoordinateMaps::Affine>,
           CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
                                          CoordinateMaps::Identity<2>>>,
-      domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                             CoordinateMaps::DiscreteRotation<3>,
                             CoordinateMaps::ProductOf3Maps<
                                 CoordinateMaps::Affine, CoordinateMaps::Affine,
                                 CoordinateMaps::Affine>>,
       domain::CoordinateMap<
-          Frame::Logical, Frame::Inertial,
+          Frame::BlockLogical, Frame::Inertial,
           CoordinateMaps::ProductOf3Maps<CoordinateMaps::Equiangular,
                                          CoordinateMaps::Equiangular,
                                          CoordinateMaps::Equiangular>>,
       domain::CoordinateMap<
-          Frame::Logical, Frame::Inertial,
+          Frame::BlockLogical, Frame::Inertial,
           CoordinateMaps::ProductOf3Maps<CoordinateMaps::Equiangular,
                                          CoordinateMaps::Equiangular,
                                          CoordinateMaps::Equiangular>,
           CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
                                          CoordinateMaps::Identity<2>>>,
-      domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                             CoordinateMaps::Frustum>,
-      domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                             CoordinateMaps::Wedge<3>>,
       domain::CoordinateMap<
           Frame::Grid, Frame::Inertial,

--- a/src/Domain/Creators/Brick.cpp
+++ b/src/Domain/Creators/Brick.cpp
@@ -23,7 +23,7 @@
 #include "Domain/Structure/BlockNeighbor.hpp"  // IWYU pragma: keep
 
 namespace Frame {
-struct Logical;
+struct BlockLogical;
 struct Inertial;
 }  // namespace Frame
 
@@ -118,7 +118,7 @@ Domain<3> Brick::create_domain() const noexcept {
   }
 
   Domain<3> domain{
-      make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Affine3D{Affine{-1., 1., lower_xyz_[0], upper_xyz_[0]},
                    Affine{-1., 1., lower_xyz_[1], upper_xyz_[1]},
                    Affine{-1., 1., lower_xyz_[2], upper_xyz_[2]}}),

--- a/src/Domain/Creators/Brick.hpp
+++ b/src/Domain/Creators/Brick.hpp
@@ -40,7 +40,7 @@ namespace creators {
 class Brick : public DomainCreator<3> {
  public:
   using maps_list = tmpl::list<
-      domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                             CoordinateMaps::ProductOf3Maps<
                                 CoordinateMaps::Affine, CoordinateMaps::Affine,
                                 CoordinateMaps::Affine>>>;

--- a/src/Domain/Creators/Cylinder.cpp
+++ b/src/Domain/Creators/Cylinder.cpp
@@ -21,7 +21,6 @@
 #include "Utilities/MakeArray.hpp"
 
 namespace Frame {
-struct Logical;
 struct Inertial;
 }  // namespace Frame
 

--- a/src/Domain/Creators/Cylinder.hpp
+++ b/src/Domain/Creators/Cylinder.hpp
@@ -49,17 +49,17 @@ namespace domain::creators {
 class Cylinder : public DomainCreator<3> {
  public:
   using maps_list = tmpl::list<
-      domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                             CoordinateMaps::ProductOf3Maps<
                                 CoordinateMaps::Affine, CoordinateMaps::Affine,
                                 CoordinateMaps::Affine>>,
       domain::CoordinateMap<
-          Frame::Logical, Frame::Inertial,
+          Frame::BlockLogical, Frame::Inertial,
           CoordinateMaps::ProductOf3Maps<CoordinateMaps::Equiangular,
                                          CoordinateMaps::Equiangular,
                                          CoordinateMaps::Affine>>,
       domain::CoordinateMap<
-          Frame::Logical, Frame::Inertial,
+          Frame::BlockLogical, Frame::Inertial,
           CoordinateMaps::ProductOf2Maps<CoordinateMaps::Wedge<2>,
                                          CoordinateMaps::Affine>>>;
 

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
@@ -308,7 +308,7 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const noexcept {
       3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>;
 
   std::vector<std::unique_ptr<
-      domain::CoordinateMapBase<Frame::Logical, Frame::Inertial, 3>>>
+      domain::CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 3>>>
       coordinate_maps{};
 
   std::vector<BcMap> boundary_conditions_all_blocks{};
@@ -398,7 +398,7 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const noexcept {
              const CylindricalDomainParityFlip parity_flip =
                  CylindricalDomainParityFlip::none) noexcept {
         auto new_logical_to_cylinder_center_maps =
-            domain::make_vector_coordinate_map_base<Frame::Logical,
+            domain::make_vector_coordinate_map_base<Frame::BlockLogical,
                                                     Frame::Inertial, 3>(
                 parity_flip == CylindricalDomainParityFlip::z_direction
                     ? logical_to_cylinder_center_maps_flip_z
@@ -410,7 +410,7 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const noexcept {
                 new_logical_to_cylinder_center_maps.begin()),
             std::make_move_iterator(new_logical_to_cylinder_center_maps.end()));
         auto new_logical_to_cylinder_surrounding_maps =
-            domain::make_vector_coordinate_map_base<Frame::Logical,
+            domain::make_vector_coordinate_map_base<Frame::BlockLogical,
                                                     Frame::Inertial, 3>(
                 parity_flip == CylindricalDomainParityFlip::z_direction
                     ? logical_to_cylinder_surrounding_maps_flip_z
@@ -460,7 +460,7 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const noexcept {
        this](const CoordinateMaps::CylindricalFlatEndcap& endcap_map,
              const CoordinateMaps::DiscreteRotation<3>& rotation_map) noexcept {
         auto new_logical_to_cylinder_center_maps =
-            domain::make_vector_coordinate_map_base<Frame::Logical,
+            domain::make_vector_coordinate_map_base<Frame::BlockLogical,
                                                     Frame::Inertial, 3>(
                 logical_to_cylinder_center_maps, endcap_map, rotation_map);
         coordinate_maps.insert(
@@ -469,7 +469,7 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const noexcept {
                 new_logical_to_cylinder_center_maps.begin()),
             std::make_move_iterator(new_logical_to_cylinder_center_maps.end()));
         auto new_logical_to_cylinder_surrounding_maps =
-            domain::make_vector_coordinate_map_base<Frame::Logical,
+            domain::make_vector_coordinate_map_base<Frame::BlockLogical,
                                                     Frame::Inertial, 3>(
                 logical_to_cylinder_surrounding_maps, endcap_map, rotation_map);
         coordinate_maps.insert(
@@ -534,7 +534,7 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const noexcept {
              const CylindricalDomainParityFlip parity_flip =
                  CylindricalDomainParityFlip::none) noexcept {
         auto new_logical_to_cylindrical_shell_maps =
-            domain::make_vector_coordinate_map_base<Frame::Logical,
+            domain::make_vector_coordinate_map_base<Frame::BlockLogical,
                                                     Frame::Inertial, 3>(
                 parity_flip == CylindricalDomainParityFlip::z_direction
                     ? logical_to_cylindrical_shell_maps_flip_z

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
@@ -48,7 +48,7 @@ class FunctionOfTime;
 
 namespace Frame {
 struct Inertial;
-struct Logical;
+struct BlockLogical;
 }  // namespace Frame
 /// \endcond
 
@@ -116,38 +116,38 @@ namespace domain::creators {
 class CylindricalBinaryCompactObject : public DomainCreator<3> {
  public:
   using maps_list = tmpl::list<
-      domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                             CoordinateMaps::ProductOf3Maps<
                                 CoordinateMaps::Affine, CoordinateMaps::Affine,
                                 CoordinateMaps::Affine>,
                             CoordinateMaps::CylindricalEndcap,
                             CoordinateMaps::DiscreteRotation<3>>,
       domain::CoordinateMap<
-          Frame::Logical, Frame::Inertial,
+          Frame::BlockLogical, Frame::Inertial,
           CoordinateMaps::ProductOf2Maps<CoordinateMaps::Wedge<2>,
                                          CoordinateMaps::Affine>,
           CoordinateMaps::CylindricalEndcap,
           CoordinateMaps::DiscreteRotation<3>>,
-      domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                             CoordinateMaps::ProductOf3Maps<
                                 CoordinateMaps::Affine, CoordinateMaps::Affine,
                                 CoordinateMaps::Affine>,
                             CoordinateMaps::CylindricalFlatEndcap,
                             CoordinateMaps::DiscreteRotation<3>>,
       domain::CoordinateMap<
-          Frame::Logical, Frame::Inertial,
+          Frame::BlockLogical, Frame::Inertial,
           CoordinateMaps::ProductOf2Maps<CoordinateMaps::Wedge<2>,
                                          CoordinateMaps::Affine>,
           CoordinateMaps::CylindricalFlatEndcap,
           CoordinateMaps::DiscreteRotation<3>>,
       domain::CoordinateMap<
-          Frame::Logical, Frame::Inertial,
+          Frame::BlockLogical, Frame::Inertial,
           CoordinateMaps::ProductOf2Maps<CoordinateMaps::Wedge<2>,
                                          CoordinateMaps::Affine>,
           CoordinateMaps::CylindricalFlatSide,
           CoordinateMaps::DiscreteRotation<3>>,
       domain::CoordinateMap<
-          Frame::Logical, Frame::Inertial,
+          Frame::BlockLogical, Frame::Inertial,
           CoordinateMaps::ProductOf2Maps<CoordinateMaps::Wedge<2>,
                                          CoordinateMaps::Affine>,
           CoordinateMaps::CylindricalSide,

--- a/src/Domain/Creators/Disk.cpp
+++ b/src/Domain/Creators/Disk.cpp
@@ -24,7 +24,7 @@
 
 namespace Frame {
 struct Inertial;
-struct Logical;
+struct BlockLogical;
 }  // namespace Frame
 
 namespace domain::creators {
@@ -76,7 +76,7 @@ Domain<2> Disk::create_domain() const noexcept {
                                              block2_corners, block3_corners,
                                              block4_corners};
 
-  auto coord_maps = make_vector_coordinate_map_base<Frame::Logical,
+  auto coord_maps = make_vector_coordinate_map_base<Frame::BlockLogical,
                                                     Frame::Inertial>(
       Wedge2DMap{inner_radius_, outer_radius_, 0.0, 1.0,
                  OrientationMap<2>{std::array<Direction<2>, 2>{
@@ -97,14 +97,15 @@ Domain<2> Disk::create_domain() const noexcept {
 
   if (use_equiangular_map_) {
     coord_maps.emplace_back(
-        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(Equiangular2D{
-            Equiangular(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(2.0),
-                        inner_radius_ / sqrt(2.0)),
-            Equiangular(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(2.0),
-                        inner_radius_ / sqrt(2.0))}));
+        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+            Equiangular2D{
+                Equiangular(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(2.0),
+                            inner_radius_ / sqrt(2.0)),
+                Equiangular(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(2.0),
+                            inner_radius_ / sqrt(2.0))}));
   } else {
     coord_maps.emplace_back(
-        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             Affine2D{Affine(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(2.0),
                             inner_radius_ / sqrt(2.0)),
                      Affine(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(2.0),

--- a/src/Domain/Creators/Disk.hpp
+++ b/src/Domain/Creators/Disk.hpp
@@ -39,14 +39,14 @@ class Disk : public DomainCreator<2> {
  public:
   using maps_list =
       tmpl::list<domain::CoordinateMap<
-                     Frame::Logical, Frame::Inertial,
+                     Frame::BlockLogical, Frame::Inertial,
                      CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
                                                     CoordinateMaps::Affine>>,
-                 domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+                 domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                                        CoordinateMaps::ProductOf2Maps<
                                            CoordinateMaps::Equiangular,
                                            CoordinateMaps::Equiangular>>,
-                 domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+                 domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                                        CoordinateMaps::Wedge<2>>>;
 
   struct InnerRadius {

--- a/src/Domain/Creators/FrustalCloak.cpp
+++ b/src/Domain/Creators/FrustalCloak.cpp
@@ -19,7 +19,7 @@
 
 namespace Frame {
 struct Inertial;
-struct Logical;
+struct BlockLogical;
 }  // namespace Frame
 namespace domain {
 template <typename, typename, size_t>
@@ -65,8 +65,8 @@ FrustalCloak::FrustalCloak(
 }
 
 Domain<3> FrustalCloak::create_domain() const noexcept {
-  std::vector<
-      std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 3>>>
+  std::vector<std::unique_ptr<
+      CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 3>>>
       coord_maps = frustum_coordinate_maps<Frame::Inertial>(
           length_inner_cube_, length_outer_cube_, use_equiangular_map_,
           origin_preimage_, projection_factor_);

--- a/src/Domain/Creators/FrustalCloak.hpp
+++ b/src/Domain/Creators/FrustalCloak.hpp
@@ -40,7 +40,7 @@ namespace creators {
 class FrustalCloak : public DomainCreator<3> {
  public:
   using maps_list =
-      tmpl::list<domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+      tmpl::list<domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                                        domain::CoordinateMaps::Frustum>>;
 
   struct InitialRefinement {

--- a/src/Domain/Creators/Interval.cpp
+++ b/src/Domain/Creators/Interval.cpp
@@ -22,7 +22,7 @@
 
 namespace Frame {
 struct Inertial;
-struct Logical;
+struct BlockLogical;
 }  // namespace Frame
 
 namespace domain::creators {
@@ -117,7 +117,7 @@ Domain<1> Interval::create_domain() const noexcept {
   }
 
   Domain<1> domain{
-      make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           CoordinateMaps::Affine{-1., 1., lower_x_[0], upper_x_[0]}),
       std::vector<std::array<size_t, 2>>{{{1, 2}}},
       is_periodic_in_x_[0] ? std::vector<PairOfFaces>{{{1}, {2}}}

--- a/src/Domain/Creators/Interval.hpp
+++ b/src/Domain/Creators/Interval.hpp
@@ -37,7 +37,7 @@ namespace creators {
 class Interval : public DomainCreator<1> {
  public:
   using maps_list =
-      tmpl::list<domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+      tmpl::list<domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                                        CoordinateMaps::Affine>>;
 
   struct LowerBound {

--- a/src/Domain/Creators/Rectangle.cpp
+++ b/src/Domain/Creators/Rectangle.cpp
@@ -25,7 +25,7 @@
 
 namespace Frame {
 struct Inertial;
-struct Logical;
+struct BlockLogical;
 }  // namespace Frame
 
 namespace domain::creators {
@@ -115,7 +115,7 @@ Domain<2> Rectangle::create_domain() const noexcept {
   }
 
   Domain<2> domain{
-      make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Affine2D{Affine{-1., 1., lower_xy_[0], upper_xy_[0]},
                    Affine{-1., 1., lower_xy_[1], upper_xy_[1]}}),
       std::vector<std::array<size_t, 4>>{{{0, 1, 2, 3}}}, identifications,

--- a/src/Domain/Creators/Rectangle.hpp
+++ b/src/Domain/Creators/Rectangle.hpp
@@ -39,7 +39,7 @@ namespace creators {
 class Rectangle : public DomainCreator<2> {
  public:
   using maps_list = tmpl::list<domain::CoordinateMap<
-      Frame::Logical, Frame::Inertial,
+      Frame::BlockLogical, Frame::Inertial,
       CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
                                      CoordinateMaps::Affine>>>;
 

--- a/src/Domain/Creators/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/Creators/RegisterDerivedWithCharm.cpp
@@ -44,8 +44,9 @@ struct to_grid_map {
 };
 
 template <typename... Maps>
-struct to_grid_map<CoordinateMap<Frame::Logical, Frame::Inertial, Maps...>> {
-  using type = CoordinateMap<Frame::Logical, Frame::Grid, Maps...>;
+struct to_grid_map<
+    CoordinateMap<Frame::BlockLogical, Frame::Inertial, Maps...>> {
+  using type = CoordinateMap<Frame::BlockLogical, Frame::Grid, Maps...>;
 };
 
 template <size_t Dim>

--- a/src/Domain/Creators/RotatedBricks.hpp
+++ b/src/Domain/Creators/RotatedBricks.hpp
@@ -91,11 +91,11 @@ namespace creators {
 class RotatedBricks : public DomainCreator<3> {
  public:
   using maps_list = tmpl::list<
-      domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                             CoordinateMaps::ProductOf3Maps<
                                 CoordinateMaps::Affine, CoordinateMaps::Affine,
                                 CoordinateMaps::Affine>>,
-      domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                             CoordinateMaps::DiscreteRotation<3>,
                             CoordinateMaps::ProductOf3Maps<
                                 CoordinateMaps::Affine, CoordinateMaps::Affine,

--- a/src/Domain/Creators/RotatedIntervals.hpp
+++ b/src/Domain/Creators/RotatedIntervals.hpp
@@ -41,7 +41,7 @@ namespace creators {
 class RotatedIntervals : public DomainCreator<1> {
  public:
   using maps_list = tmpl::list<domain::CoordinateMap<
-      Frame::Logical, Frame::Inertial,
+      Frame::BlockLogical, Frame::Inertial,
       domain::CoordinateMaps::DiscreteRotation<1>, CoordinateMaps::Affine>>;
 
   struct LowerBound {

--- a/src/Domain/Creators/RotatedRectangles.hpp
+++ b/src/Domain/Creators/RotatedRectangles.hpp
@@ -50,15 +50,16 @@ namespace creators {
 /// unaligned blocks.
 class RotatedRectangles : public DomainCreator<2> {
  public:
-  using maps_list = tmpl::list<
-      domain::CoordinateMap<
-          Frame::Logical, Frame::Inertial,
-          CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
-                                         CoordinateMaps::Affine>>,
-      domain::CoordinateMap<
-          Frame::Logical, Frame::Inertial, CoordinateMaps::DiscreteRotation<2>,
-          CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
-                                         CoordinateMaps::Affine>>>;
+  using maps_list =
+      tmpl::list<domain::CoordinateMap<
+                     Frame::BlockLogical, Frame::Inertial,
+                     CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
+                                                    CoordinateMaps::Affine>>,
+                 domain::CoordinateMap<
+                     Frame::BlockLogical, Frame::Inertial,
+                     CoordinateMaps::DiscreteRotation<2>,
+                     CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
+                                                    CoordinateMaps::Affine>>>;
 
   struct LowerBound {
     using type = std::array<double, 2>;

--- a/src/Domain/Creators/Shell.cpp
+++ b/src/Domain/Creators/Shell.cpp
@@ -21,7 +21,7 @@
 
 namespace Frame {
 struct Inertial;
-struct Logical;
+struct BlockLogical;
 }  // namespace Frame
 
 namespace domain::creators {
@@ -123,8 +123,8 @@ Shell::Shell(
 }
 
 Domain<3> Shell::create_domain() const noexcept {
-  std::vector<
-      std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 3>>>
+  std::vector<std::unique_ptr<
+      CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 3>>>
       coord_maps = sph_wedge_coordinate_maps<Frame::Inertial>(
           inner_radius_, outer_radius_, 1.0, 1.0, use_equiangular_map_, 0.0,
           false, aspect_ratio_, radial_partitioning_, radial_distribution_,

--- a/src/Domain/Creators/Shell.hpp
+++ b/src/Domain/Creators/Shell.hpp
@@ -44,7 +44,7 @@ namespace domain::creators {
 class Shell : public DomainCreator<3> {
  public:
   using maps_list = tmpl::list<domain::CoordinateMap<
-      Frame::Logical, Frame::Inertial, CoordinateMaps::Wedge<3>,
+      Frame::BlockLogical, Frame::Inertial, CoordinateMaps::Wedge<3>,
       CoordinateMaps::EquatorialCompression,
       CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
                                      CoordinateMaps::Identity<2>>>>;

--- a/src/Domain/Creators/Sphere.cpp
+++ b/src/Domain/Creators/Sphere.cpp
@@ -24,7 +24,7 @@
 
 namespace Frame {
 struct Inertial;  // IWYU pragma: keep
-struct Logical;   // IWYU pragma: keep
+struct BlockLogical;  // IWYU pragma: keep
 }  // namespace Frame
 
 namespace domain::creators {
@@ -68,22 +68,23 @@ Domain<3> Sphere::create_domain() const noexcept {
   std::vector<std::array<size_t, 8>> corners =
       corners_for_radially_layered_domains(1, true);
 
-  std::vector<
-      std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 3>>>
+  std::vector<std::unique_ptr<
+      CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 3>>>
       coord_maps = sph_wedge_coordinate_maps<Frame::Inertial>(
           inner_radius_, outer_radius_, 0.0, 1.0, use_equiangular_map_);
   if (use_equiangular_map_) {
     coord_maps.emplace_back(
-        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(Equiangular3D{
-            Equiangular(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(3.0),
-                        inner_radius_ / sqrt(3.0)),
-            Equiangular(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(3.0),
-                        inner_radius_ / sqrt(3.0)),
-            Equiangular(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(3.0),
-                        inner_radius_ / sqrt(3.0))}));
+        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+            Equiangular3D{
+                Equiangular(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(3.0),
+                            inner_radius_ / sqrt(3.0)),
+                Equiangular(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(3.0),
+                            inner_radius_ / sqrt(3.0)),
+                Equiangular(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(3.0),
+                            inner_radius_ / sqrt(3.0))}));
   } else {
     coord_maps.emplace_back(
-        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             Affine3D{Affine(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(3.0),
                             inner_radius_ / sqrt(3.0)),
                      Affine(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(3.0),

--- a/src/Domain/Creators/Sphere.hpp
+++ b/src/Domain/Creators/Sphere.hpp
@@ -50,17 +50,17 @@ namespace creators {
 class Sphere : public DomainCreator<3> {
  public:
   using maps_list = tmpl::list<
-      domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                             CoordinateMaps::ProductOf3Maps<
                                 CoordinateMaps::Affine, CoordinateMaps::Affine,
                                 CoordinateMaps::Affine>>,
       domain::CoordinateMap<
-          Frame::Logical, Frame::Inertial,
+          Frame::BlockLogical, Frame::Inertial,
           CoordinateMaps::ProductOf3Maps<CoordinateMaps::Equiangular,
                                          CoordinateMaps::Equiangular,
                                          CoordinateMaps::Equiangular>>,
       domain::CoordinateMap<
-          Frame::Logical, Frame::Inertial, CoordinateMaps::Wedge<3>,
+          Frame::BlockLogical, Frame::Inertial, CoordinateMaps::Wedge<3>,
           CoordinateMaps::EquatorialCompression,
           CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
                                          CoordinateMaps::Identity<2>>>>;

--- a/src/Domain/Domain.cpp
+++ b/src/Domain/Domain.cpp
@@ -16,7 +16,7 @@
 
 namespace Frame {
 struct Inertial;
-struct Logical;
+struct BlockLogical;
 }  // namespace Frame
 
 template <size_t VolumeDim>
@@ -25,8 +25,8 @@ Domain<VolumeDim>::Domain(std::vector<Block<VolumeDim>> blocks) noexcept
 
 template <size_t VolumeDim>
 Domain<VolumeDim>::Domain(
-    std::vector<std::unique_ptr<
-        domain::CoordinateMapBase<Frame::Logical, Frame::Inertial, VolumeDim>>>
+    std::vector<std::unique_ptr<domain::CoordinateMapBase<
+        Frame::BlockLogical, Frame::Inertial, VolumeDim>>>
         maps,
     std::vector<DirectionMap<
         VolumeDim,
@@ -54,8 +54,8 @@ Domain<VolumeDim>::Domain(
 
 template <size_t VolumeDim>
 Domain<VolumeDim>::Domain(
-    std::vector<std::unique_ptr<
-        domain::CoordinateMapBase<Frame::Logical, Frame::Inertial, VolumeDim>>>
+    std::vector<std::unique_ptr<domain::CoordinateMapBase<
+        Frame::BlockLogical, Frame::Inertial, VolumeDim>>>
         maps,
     const std::vector<std::array<size_t, two_to_the(VolumeDim)>>&
         corners_of_all_blocks,

--- a/src/Domain/Domain.hpp
+++ b/src/Domain/Domain.hpp
@@ -19,7 +19,7 @@
 #include "Utilities/ConstantExpressions.hpp"
 
 namespace Frame {
-struct Logical;
+struct BlockLogical;
 }  // namespace Frame
 namespace PUP {
 class er;
@@ -59,7 +59,7 @@ class Domain {
    */
   explicit Domain(
       std::vector<std::unique_ptr<domain::CoordinateMapBase<
-          Frame::Logical, Frame::Inertial, VolumeDim>>>
+          Frame::BlockLogical, Frame::Inertial, VolumeDim>>>
           maps,
       std::vector<DirectionMap<
           VolumeDim,
@@ -87,7 +87,7 @@ class Domain {
    * boundary conditions at all.
    */
   Domain(std::vector<std::unique_ptr<domain::CoordinateMapBase<
-             Frame::Logical, Frame::Inertial, VolumeDim>>>
+             Frame::BlockLogical, Frame::Inertial, VolumeDim>>>
              maps,
          const std::vector<std::array<size_t, two_to_the(VolumeDim)>>&
              corners_of_all_blocks,

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -138,16 +138,16 @@ std::array<size_t, two_to_the(VolumeDim - 1)> get_common_local_corners(
 }
 
 template <size_t VolumeDim>
-std::array<tnsr::I<double, VolumeDim, Frame::Logical>,
+std::array<tnsr::I<double, VolumeDim, Frame::BlockLogical>,
            two_to_the(VolumeDim - 1)>
 logical_coords_of_corners(
     const std::array<size_t, two_to_the(VolumeDim - 1)>& local_ids) noexcept {
-  std::array<tnsr::I<double, VolumeDim, Frame::Logical>,
+  std::array<tnsr::I<double, VolumeDim, Frame::BlockLogical>,
              two_to_the(VolumeDim - 1)>
       result{};
   std::transform(local_ids.begin(), local_ids.end(), result.begin(),
                  [](const size_t id) noexcept {
-                   tnsr::I<double, VolumeDim, Frame::Logical> point{};
+                   tnsr::I<double, VolumeDim, Frame::BlockLogical> point{};
                    for (size_t i = 0; i < VolumeDim; i++) {
                      point[i] = 2.0 * get_nth_bit(id, i) - 1.0;
                    };
@@ -158,12 +158,13 @@ logical_coords_of_corners(
 
 template <size_t VolumeDim>
 Direction<VolumeDim> get_direction_normal_to_face(
-    const std::array<tnsr::I<double, VolumeDim, Frame::Logical>,
+    const std::array<tnsr::I<double, VolumeDim, Frame::BlockLogical>,
                      two_to_the(VolumeDim - 1)>& face_pts) noexcept {
   const auto summed_point = alg::accumulate(
-      face_pts, tnsr::I<double, VolumeDim, Frame::Logical>(0.0),
-      [](tnsr::I<double, VolumeDim, Frame::Logical>& prior,
-         const tnsr::I<double, VolumeDim, Frame::Logical>& point) noexcept {
+      face_pts, tnsr::I<double, VolumeDim, Frame::BlockLogical>(0.0),
+      [](tnsr::I<double, VolumeDim, Frame::BlockLogical>& prior,
+         const tnsr::I<double, VolumeDim, Frame::BlockLogical>&
+             point) noexcept {
         for (size_t i = 0; i < prior.size(); i++) {
           prior[i] += point[i];
         }
@@ -267,10 +268,9 @@ obtain_correspondence_between_blocks(
 template <size_t VolumeDim>
 std::vector<std::array<size_t, two_to_the(VolumeDim)>> corners_from_two_maps(
     const std::unique_ptr<domain::CoordinateMapBase<
-        Frame::Logical, Frame::Inertial, VolumeDim>>& map1,
-    const std::unique_ptr<
-        domain::CoordinateMapBase<Frame::Logical, Frame::Inertial, VolumeDim>>&
-        map2) noexcept {
+        Frame::BlockLogical, Frame::Inertial, VolumeDim>>& map1,
+    const std::unique_ptr<domain::CoordinateMapBase<
+        Frame::BlockLogical, Frame::Inertial, VolumeDim>>& map2) noexcept {
   std::array<size_t, two_to_the(VolumeDim)> corners_for_block1{};
   std::array<size_t, two_to_the(VolumeDim)> corners_for_block2{};
   for (VolumeCornerIterator<VolumeDim> vci{}; vci; ++vci) {
@@ -280,7 +280,7 @@ std::vector<std::array<size_t, two_to_the(VolumeDim)>> corners_from_two_maps(
   // Fill corners_for_block2 based off which corners are shared with map1.
   for (VolumeCornerIterator<VolumeDim> vci_map2{}; vci_map2; ++vci_map2) {
     const auto mapped_coords2 =
-        (*map2)(tnsr::I<double, VolumeDim, Frame::Logical>{
+        (*map2)(tnsr::I<double, VolumeDim, Frame::BlockLogical>{
             vci_map2.coords_of_corner()});
 
     // Set num_unshared_corners to zero because we only need a local corner
@@ -290,7 +290,7 @@ std::vector<std::array<size_t, two_to_the(VolumeDim)>> corners_from_two_maps(
     // Check each corner of map1 to see if it shares any corners with map2.
     for (VolumeCornerIterator<VolumeDim> vci_map1{}; vci_map1; ++vci_map1) {
       const auto mapped_coords1 =
-          (*map1)(tnsr::I<double, VolumeDim, Frame::Logical>{
+          (*map1)(tnsr::I<double, VolumeDim, Frame::BlockLogical>{
               vci_map1.coords_of_corner()});
       double max_separation = 0.0;
       for (size_t j = 0; j < VolumeDim; j++) {
@@ -326,9 +326,8 @@ std::pair<std::array<Direction<VolumeDim>, VolumeDim>,
           std::array<Direction<VolumeDim>, VolumeDim>>
 obtain_correspondence_between_maps(
     const size_t map_id1, const size_t map_id2,
-    const std::vector<std::unique_ptr<
-        domain::CoordinateMapBase<Frame::Logical, Frame::Inertial, VolumeDim>>>&
-        maps) noexcept {
+    const std::vector<std::unique_ptr<domain::CoordinateMapBase<
+        Frame::BlockLogical, Frame::Inertial, VolumeDim>>>& maps) noexcept {
   return obtain_correspondence_between_blocks<VolumeDim>(
       0, 1, corners_from_two_maps(maps[map_id1], maps[map_id2]));
 }
@@ -478,9 +477,8 @@ void set_internal_boundaries(
     const gsl::not_null<
         std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>*>
         neighbors_of_all_blocks,
-    const std::vector<std::unique_ptr<
-        domain::CoordinateMapBase<Frame::Logical, Frame::Inertial, VolumeDim>>>&
-        maps) noexcept {
+    const std::vector<std::unique_ptr<domain::CoordinateMapBase<
+        Frame::BlockLogical, Frame::Inertial, VolumeDim>>>& maps) noexcept {
   for (size_t block1_index = 0; block1_index < maps.size(); block1_index++) {
     DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbor;
     for (size_t block2_index = 0; block2_index < maps.size(); block2_index++) {
@@ -604,8 +602,8 @@ size_t which_wedge_index(const ShellWedges& which_wedges) {
 }  // namespace
 
 template <typename TargetFrame>
-std::vector<
-    std::unique_ptr<domain::CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>
+std::vector<std::unique_ptr<
+    domain::CoordinateMapBase<Frame::BlockLogical, TargetFrame, 3>>>
 sph_wedge_coordinate_maps(
     const double inner_radius, const double outer_radius,
     const double inner_sphericity, const double outer_sphericity,
@@ -698,14 +696,14 @@ sph_wedge_coordinate_maps(
   const auto compression =
       domain::CoordinateMaps::EquatorialCompression{aspect_ratio};
 
-  return domain::make_vector_coordinate_map_base<Frame::Logical, TargetFrame,
-                                                 3>(
+  return domain::make_vector_coordinate_map_base<Frame::BlockLogical,
+                                                 TargetFrame, 3>(
       std::move(wedges_for_all_layers), compression, translation);
 }
 
 template <typename TargetFrame>
-std::vector<
-    std::unique_ptr<domain::CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>
+std::vector<std::unique_ptr<
+    domain::CoordinateMapBase<Frame::BlockLogical, TargetFrame, 3>>>
 frustum_coordinate_maps(const double length_inner_cube,
                         const double length_outer_cube,
                         const bool use_equiangular_map,
@@ -788,7 +786,8 @@ frustum_coordinate_maps(const double length_inner_cube,
                                 projective_scale_factor});
 
   // clang-tidy: trivially copyable
-  return domain::make_vector_coordinate_map_base<Frame::Logical, TargetFrame,
+  return domain::make_vector_coordinate_map_base<Frame::BlockLogical,
+                                                 TargetFrame,
                                                  3>(
       std::move(frustums));  // NOLINT
 }
@@ -1088,8 +1087,8 @@ cyl_wedge_coord_map_surrounding_blocks(
 }
 
 template <typename TargetFrame>
-std::vector<
-    std::unique_ptr<domain::CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>
+std::vector<std::unique_ptr<
+    domain::CoordinateMapBase<Frame::BlockLogical, TargetFrame, 3>>>
 cyl_wedge_coordinate_maps(
     const double inner_radius, const double outer_radius,
     const double lower_bound, const double upper_bound,
@@ -1099,7 +1098,7 @@ cyl_wedge_coordinate_maps(
     const std::vector<domain::CoordinateMaps::Distribution>&
         radial_distribution) noexcept {
   std::vector<std::unique_ptr<
-      domain::CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>
+      domain::CoordinateMapBase<Frame::BlockLogical, TargetFrame, 3>>>
       cylinder_mapping;
   const auto maps_surrounding = cyl_wedge_coord_map_surrounding_blocks(
       inner_radius, outer_radius, lower_bound, upper_bound, use_equiangular_map,
@@ -1117,7 +1116,8 @@ cyl_wedge_coordinate_maps(
         for (size_t height = 0; height < 1 + height_partitioning.size();
              ++height) {
           cylinder_mapping.emplace_back(
-              domain::make_coordinate_map_base<Frame::Logical, TargetFrame>(
+              domain::make_coordinate_map_base<Frame::BlockLogical,
+                                               TargetFrame>(
                   maps_center.at(height)));
           for (size_t radius = 0; radius < 1 + radial_partitioning.size();
                ++radius) {
@@ -1125,7 +1125,8 @@ cyl_wedge_coordinate_maps(
             for (size_t block_at_this_radius = 0; block_at_this_radius < 4;
                  ++block_at_this_radius, ++surrounding_block_index) {
               cylinder_mapping.emplace_back(
-                  domain::make_coordinate_map_base<Frame::Logical, TargetFrame>(
+                  domain::make_coordinate_map_base<Frame::BlockLogical,
+                                                   TargetFrame>(
                       maps_surrounding.at(surrounding_block_index)));
             }
           }
@@ -1213,40 +1214,40 @@ corners_for_rectilinear_domains(
 }
 
 template <typename TargetFrame, typename Map>
-std::unique_ptr<domain::CoordinateMapBase<Frame::Logical, TargetFrame, 1>>
+std::unique_ptr<domain::CoordinateMapBase<Frame::BlockLogical, TargetFrame, 1>>
 product_of_1d_maps(std::array<Map, 1>& maps,
                    const OrientationMap<1>& rotation = {}) noexcept {
   if (rotation == OrientationMap<1>{}) {
-    return domain::make_coordinate_map_base<Frame::Logical, TargetFrame>(
+    return domain::make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
         maps[0]);
   }
-  return domain::make_coordinate_map_base<Frame::Logical, TargetFrame>(
+  return domain::make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
       domain::CoordinateMaps::DiscreteRotation<1>{rotation}, maps[0]);
 }
 
 template <typename TargetFrame, typename Map>
-std::unique_ptr<domain::CoordinateMapBase<Frame::Logical, TargetFrame, 2>>
+std::unique_ptr<domain::CoordinateMapBase<Frame::BlockLogical, TargetFrame, 2>>
 product_of_1d_maps(std::array<Map, 2>& maps,
                    const OrientationMap<2>& rotation = {}) noexcept {
   if (rotation == OrientationMap<2>{}) {
-    return domain::make_coordinate_map_base<Frame::Logical, TargetFrame>(
+    return domain::make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
         domain::CoordinateMaps::ProductOf2Maps<Map, Map>(maps[0], maps[1]));
   }
-  return domain::make_coordinate_map_base<Frame::Logical, TargetFrame>(
+  return domain::make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
       domain::CoordinateMaps::DiscreteRotation<2>{rotation},
       domain::CoordinateMaps::ProductOf2Maps<Map, Map>(maps[0], maps[1]));
 }
 
 template <typename TargetFrame, typename Map>
-std::unique_ptr<domain::CoordinateMapBase<Frame::Logical, TargetFrame, 3>>
+std::unique_ptr<domain::CoordinateMapBase<Frame::BlockLogical, TargetFrame, 3>>
 product_of_1d_maps(std::array<Map, 3>& maps,
                    const OrientationMap<3>& rotation = {}) noexcept {
   if (rotation == OrientationMap<3>{}) {
-    return domain::make_coordinate_map_base<Frame::Logical, TargetFrame>(
+    return domain::make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
         domain::CoordinateMaps::ProductOf3Maps<Map, Map, Map>(maps[0], maps[1],
                                                               maps[2]));
   }
-  return domain::make_coordinate_map_base<Frame::Logical, TargetFrame>(
+  return domain::make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
       domain::CoordinateMaps::DiscreteRotation<3>{rotation},
       domain::CoordinateMaps::ProductOf3Maps<Map, Map, Map>(maps[0], maps[1],
                                                             maps[2]));
@@ -1254,7 +1255,7 @@ product_of_1d_maps(std::array<Map, 3>& maps,
 
 template <typename TargetFrame, size_t VolumeDim>
 std::vector<std::unique_ptr<
-    domain::CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>>>
+    domain::CoordinateMapBase<Frame::BlockLogical, TargetFrame, VolumeDim>>>
 maps_for_rectilinear_domains(
     const Index<VolumeDim>& domain_extents,
     const std::array<std::vector<double>, VolumeDim>& block_demarcations,
@@ -1266,7 +1267,7 @@ maps_for_rectilinear_domains(
            "If there are N blocks, there must be N+1 demarcations.");
   }
   std::vector<std::unique_ptr<
-      domain::CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>>>
+      domain::CoordinateMapBase<Frame::BlockLogical, TargetFrame, VolumeDim>>>
       maps{};
   size_t block_orientation_index = 0;
   for (const auto& block_index : indices_for_rectilinear_domains(
@@ -1444,18 +1445,7 @@ ShellWedges Options::create_from_yaml<ShellWedges>::create<void>(
 }
 
 template std::vector<std::unique_ptr<
-    domain::CoordinateMapBase<Frame::Logical, Frame::Inertial, 3>>>
-sph_wedge_coordinate_maps(
-    const double inner_radius, const double outer_radius,
-    const double inner_sphericity, const double outer_sphericity,
-    const bool use_equiangular_map, const double x_coord_of_shell_center,
-    const bool use_wedge_halves, const double aspect_ratio,
-    const std::vector<double>& radial_partitioning,
-    const std::vector<domain::CoordinateMaps::Distribution>&
-        radial_distribution,
-    const ShellWedges which_wedges) noexcept;
-template std::vector<
-    std::unique_ptr<domain::CoordinateMapBase<Frame::Logical, Frame::Grid, 3>>>
+    domain::CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 3>>>
 sph_wedge_coordinate_maps(
     const double inner_radius, const double outer_radius,
     const double inner_sphericity, const double outer_sphericity,
@@ -1466,21 +1456,32 @@ sph_wedge_coordinate_maps(
         radial_distribution,
     const ShellWedges which_wedges) noexcept;
 template std::vector<std::unique_ptr<
-    domain::CoordinateMapBase<Frame::Logical, Frame::Inertial, 3>>>
-frustum_coordinate_maps(const double length_inner_cube,
-                        const double length_outer_cube,
-                        const bool use_equiangular_map,
-                        const std::array<double, 3>& origin_preimage,
-                        const double projective_scale_factor) noexcept;
-template std::vector<
-    std::unique_ptr<domain::CoordinateMapBase<Frame::Logical, Frame::Grid, 3>>>
+    domain::CoordinateMapBase<Frame::BlockLogical, Frame::Grid, 3>>>
+sph_wedge_coordinate_maps(
+    const double inner_radius, const double outer_radius,
+    const double inner_sphericity, const double outer_sphericity,
+    const bool use_equiangular_map, const double x_coord_of_shell_center,
+    const bool use_wedge_halves, const double aspect_ratio,
+    const std::vector<double>& radial_partitioning,
+    const std::vector<domain::CoordinateMaps::Distribution>&
+        radial_distribution,
+    const ShellWedges which_wedges) noexcept;
+template std::vector<std::unique_ptr<
+    domain::CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 3>>>
 frustum_coordinate_maps(const double length_inner_cube,
                         const double length_outer_cube,
                         const bool use_equiangular_map,
                         const std::array<double, 3>& origin_preimage,
                         const double projective_scale_factor) noexcept;
 template std::vector<std::unique_ptr<
-    domain::CoordinateMapBase<Frame::Logical, Frame::Inertial, 3>>>
+    domain::CoordinateMapBase<Frame::BlockLogical, Frame::Grid, 3>>>
+frustum_coordinate_maps(const double length_inner_cube,
+                        const double length_outer_cube,
+                        const bool use_equiangular_map,
+                        const std::array<double, 3>& origin_preimage,
+                        const double projective_scale_factor) noexcept;
+template std::vector<std::unique_ptr<
+    domain::CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 3>>>
 cyl_wedge_coordinate_maps(
     const double inner_radius, const double outer_radius,
     const double lower_bound, const double upper_bound,
@@ -1489,8 +1490,8 @@ cyl_wedge_coordinate_maps(
     const std::vector<double>& height_partitioning,
     const std::vector<domain::CoordinateMaps::Distribution>&
         radial_distribution) noexcept;
-template std::vector<
-    std::unique_ptr<domain::CoordinateMapBase<Frame::Logical, Frame::Grid, 3>>>
+template std::vector<std::unique_ptr<
+    domain::CoordinateMapBase<Frame::BlockLogical, Frame::Grid, 3>>>
 cyl_wedge_coordinate_maps(
     const double inner_radius, const double outer_radius,
     const double lower_bound, const double upper_bound,
@@ -1526,12 +1527,12 @@ template class domain::CoordinateMaps::ProductOf3Maps<
 template class domain::CoordinateMaps::ProductOf2Maps<
     domain::CoordinateMaps::Affine, domain::CoordinateMaps::Identity<2>>;
 
-INSTANTIATE_MAPS_FUNCTIONS(((Affine2d), (Affine3d), (Equiangular3d),
-                            (domain::CoordinateMaps::Wedge<3>,
-                             domain::CoordinateMaps::EquatorialCompression,
-                             AffineIdentity)),
-                           (Frame::Logical), (Frame::Grid, Frame::Inertial),
-                           (double, DataVector))
+INSTANTIATE_MAPS_FUNCTIONS(
+    ((Affine2d), (Affine3d), (Equiangular3d),
+     (domain::CoordinateMaps::Wedge<3>,
+      domain::CoordinateMaps::EquatorialCompression, AffineIdentity)),
+    (Frame::BlockLogical, Frame::ElementLogical, Frame::Logical),
+    (Frame::Grid, Frame::Inertial), (double, DataVector))
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
@@ -1548,7 +1549,7 @@ INSTANTIATE_MAPS_FUNCTIONS(((Affine2d), (Affine3d), (Equiangular3d),
           std::vector<DirectionMap<DIM(data), BlockNeighbor<DIM(data)>>>*>     \
           neighbors_of_all_blocks,                                             \
       const std::vector<std::unique_ptr<domain::CoordinateMapBase<             \
-          Frame::Logical, Frame::Inertial, DIM(data)>>>& maps) noexcept;       \
+          Frame::BlockLogical, Frame::Inertial, DIM(data)>>>& maps) noexcept;  \
   template void set_identified_boundaries(                                     \
       const std::vector<PairOfFaces>& identifications,                         \
       const std::vector<std::array<size_t, two_to_the(DIM(data))>>&            \
@@ -1564,8 +1565,8 @@ INSTANTIATE_MAPS_FUNCTIONS(((Affine2d), (Affine3d), (Equiangular3d),
   corners_for_rectilinear_domains(                                             \
       const Index<DIM(data)>& domain_extents,                                  \
       const std::vector<Index<DIM(data)>>& block_indices_to_exclude) noexcept; \
-  template std::vector<std::unique_ptr<                                        \
-      domain::CoordinateMapBase<Frame::Logical, Frame::Inertial, DIM(data)>>>  \
+  template std::vector<std::unique_ptr<domain::CoordinateMapBase<              \
+      Frame::BlockLogical, Frame::Inertial, DIM(data)>>>                       \
   maps_for_rectilinear_domains(                                                \
       const Index<DIM(data)>& domain_extents,                                  \
       const std::array<std::vector<double>, DIM(data)>& block_demarcations,    \

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -85,9 +85,8 @@ void set_internal_boundaries(
     gsl::not_null<
         std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>*>
         neighbors_of_all_blocks,
-    const std::vector<std::unique_ptr<
-        domain::CoordinateMapBase<Frame::Logical, Frame::Inertial, VolumeDim>>>&
-        maps) noexcept;
+    const std::vector<std::unique_ptr<domain::CoordinateMapBase<
+        Frame::BlockLogical, Frame::Inertial, VolumeDim>>>& maps) noexcept;
 
 /// \ingroup ComputationalDomainGroup
 /// Sets up additional BlockNeighbors corresponding to any
@@ -163,7 +162,7 @@ auto sph_wedge_coordinate_maps(
         radial_distribution = {domain::CoordinateMaps::Distribution::Linear},
     ShellWedges which_wedges = ShellWedges::All) noexcept
     -> std::vector<std::unique_ptr<
-        domain::CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>;
+        domain::CoordinateMapBase<Frame::BlockLogical, TargetFrame, 3>>>;
 
 /// \ingroup ComputationalDomainGroup
 /// These are the ten Frustums used in the DomainCreators for binary compact
@@ -183,7 +182,7 @@ auto frustum_coordinate_maps(
     const std::array<double, 3>& origin_preimage = {{0.0, 0.0, 0.0}},
     double projective_scale_factor = 1.0) noexcept
     -> std::vector<std::unique_ptr<
-        domain::CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>;
+        domain::CoordinateMapBase<Frame::BlockLogical, TargetFrame, 3>>>;
 
 /// \ingroup ComputationalDomainGroup
 /// \brief The corners for a domain with radial layers.
@@ -243,7 +242,7 @@ auto cyl_wedge_coordinate_maps(
         radial_distribution =
             {domain::CoordinateMaps::Distribution::Linear}) noexcept
     -> std::vector<std::unique_ptr<
-        domain::CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>;
+        domain::CoordinateMapBase<Frame::BlockLogical, TargetFrame, 3>>>;
 
 enum class CylindricalDomainParityFlip { none, z_direction };
 
@@ -345,8 +344,8 @@ auto maps_for_rectilinear_domains(
     const std::vector<OrientationMap<VolumeDim>>& orientations_of_all_blocks =
         {},
     bool use_equiangular_map = false) noexcept
-    -> std::vector<std::unique_ptr<
-        domain::CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>>>;
+    -> std::vector<std::unique_ptr<domain::CoordinateMapBase<
+        Frame::BlockLogical, TargetFrame, VolumeDim>>>;
 
 /// \ingroup ComputationalDomainGroup
 /// \brief Create a rectilinear Domain of multicubes.
@@ -488,11 +487,11 @@ class FaceCornerIterator {
     return face_index_ < two_to_the(VolumeDim - 1);
   }
 
-  tnsr::I<double, VolumeDim, Frame::Logical> operator()() const noexcept {
+  tnsr::I<double, VolumeDim, Frame::BlockLogical> operator()() const noexcept {
     return corner_;
   }
 
-  tnsr::I<double, VolumeDim, Frame::Logical> operator*() const noexcept {
+  tnsr::I<double, VolumeDim, Frame::BlockLogical> operator*() const noexcept {
     return corner_;
   }
 
@@ -506,7 +505,7 @@ class FaceCornerIterator {
   const Direction<VolumeDim> direction_;
   size_t index_;
   size_t face_index_ = 0;
-  tnsr::I<double, VolumeDim, Frame::Logical> corner_;
+  tnsr::I<double, VolumeDim, Frame::BlockLogical> corner_;
 };
 
 template <size_t VolumeDim>

--- a/src/Domain/ElementLogicalCoordinates.cpp
+++ b/src/Domain/ElementLogicalCoordinates.cpp
@@ -22,8 +22,9 @@
 namespace {
 // Define this alias so we don't need to keep typing this monster.
 template <size_t Dim>
-using block_logical_coord_holder = std::optional<
-    IdPair<domain::BlockId, tnsr::I<double, Dim, typename ::Frame::Logical>>>;
+using block_logical_coord_holder =
+    std::optional<IdPair<domain::BlockId,
+                         tnsr::I<double, Dim, typename ::Frame::BlockLogical>>>;
 }  // namespace
 
 template <size_t Dim>

--- a/src/Domain/ElementLogicalCoordinates.hpp
+++ b/src/Domain/ElementLogicalCoordinates.hpp
@@ -89,6 +89,6 @@ template <size_t Dim>
 auto element_logical_coordinates(
     const std::vector<ElementId<Dim>>& element_ids,
     const std::vector<std::optional<IdPair<
-        domain::BlockId, tnsr::I<double, Dim, typename Frame::Logical>>>>&
+        domain::BlockId, tnsr::I<double, Dim, typename Frame::BlockLogical>>>>&
         block_coord_holders) noexcept
     -> std::unordered_map<ElementId<Dim>, ElementLogicalCoordHolder<Dim>>;

--- a/src/Domain/ElementMap.cpp
+++ b/src/Domain/ElementMap.cpp
@@ -11,7 +11,8 @@
 template <size_t Dim, typename TargetFrame>
 ElementMap<Dim, TargetFrame>::ElementMap(
     ElementId<Dim> element_id,
-    std::unique_ptr<domain::CoordinateMapBase<Frame::Logical, TargetFrame, Dim>>
+    std::unique_ptr<
+        domain::CoordinateMapBase<Frame::BlockLogical, TargetFrame, Dim>>
         block_map) noexcept
     : block_map_(std::move(block_map)),
       element_id_(std::move(element_id)),

--- a/src/Evolution/Systems/Cce/Actions/SendNextTimeToCce.hpp
+++ b/src/Evolution/Systems/Cce/Actions/SendNextTimeToCce.hpp
@@ -67,8 +67,9 @@ struct SendNextTimeToCce {
             db::get<intrp::Tags::InterpPointInfo<Metavariables>>(box));
     const std::vector<ElementId<Metavariables::volume_dim>> element_ids{
         {array_index}};
-    std::vector<std::optional<IdPair<
-        domain::BlockId, tnsr::I<double, 3_st, typename ::Frame::Logical>>>>
+    std::vector<std::optional<
+        IdPair<domain::BlockId,
+               tnsr::I<double, 3_st, typename ::Frame::BlockLogical>>>>
         first_valid_block_logical_coords;
     for (const auto& coordinate : block_logical_coords) {
       if (coordinate.has_value()) {

--- a/src/NumericalAlgorithms/Interpolation/Actions/ElementReceiveInterpPoints.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Actions/ElementReceiveInterpPoints.hpp
@@ -35,12 +35,11 @@ struct ElementReceiveInterpPoints {
             Requires<tmpl::list_contains_v<
                 DbTags, intrp::Tags::InterpPointInfo<Metavariables>>> = nullptr>
   static void apply(
-      db::DataBox<DbTags>& box,
-      Parallel::GlobalCache<Metavariables>& /*cache*/,
+      db::DataBox<DbTags>& box, Parallel::GlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/,
       std::vector<std::optional<
           IdPair<domain::BlockId, tnsr::I<double, Metavariables::volume_dim,
-                                          typename ::Frame::Logical>>>>&&
+                                          typename ::Frame::BlockLogical>>>>&&
           block_logical_coords) noexcept {
     db::mutate<intrp::Tags::InterpPointInfo<Metavariables>>(
         make_not_null(&box),

--- a/src/NumericalAlgorithms/Interpolation/InterpolatedVars.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolatedVars.hpp
@@ -40,8 +40,9 @@ struct Info {
   /// `block_coord_holders` even after all `Element`s have sent their
   /// data (this is because this `Info` lives only on a single core,
   /// and this core will have access only to the local `Element`s).
-  std::vector<std::optional<IdPair<
-      domain::BlockId, tnsr::I<double, VolumeDim, typename ::Frame::Logical>>>>
+  std::vector<std::optional<
+      IdPair<domain::BlockId,
+             tnsr::I<double, VolumeDim, typename ::Frame::BlockLogical>>>>
       block_coord_holders;
   /// `vars` holds the interpolated `Variables` on some subset of the
   /// points in `block_coord_holders`.  The grid points inside vars

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetDetail.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetDetail.hpp
@@ -560,7 +560,7 @@ void set_up_interpolation(
     const TemporalId& temporal_id,
     const std::vector<std::optional<
         IdPair<domain::BlockId,
-               tnsr::I<double, VolumeDim, typename ::Frame::Logical>>>>&
+               tnsr::I<double, VolumeDim, typename ::Frame::BlockLogical>>>>&
         block_logical_coords) noexcept {
   db::mutate<Tags::IndicesOfFilledInterpPoints<TemporalId>,
              Tags::IndicesOfInvalidInterpPoints<TemporalId>,

--- a/src/NumericalAlgorithms/Interpolation/InterpolatorReceivePoints.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolatorReceivePoints.hpp
@@ -71,15 +71,14 @@ struct ReceivePoints {
       const typename InterpolationTargetTag::temporal_id::type& temporal_id,
       std::vector<std::optional<
           IdPair<domain::BlockId,
-                 tnsr::I<double, VolumeDim, typename ::Frame::Logical>>>>&&
+                 tnsr::I<double, VolumeDim, typename ::Frame::BlockLogical>>>>&&
           block_logical_coords) noexcept {
     db::mutate<intrp::Tags::InterpolatedVarsHolders<Metavariables>>(
         make_not_null(&box),
-        [
-          &temporal_id, &block_logical_coords
-        ](const gsl::not_null<
-            typename intrp::Tags::InterpolatedVarsHolders<Metavariables>::type*>
-              vars_holders) noexcept {
+        [&temporal_id, &block_logical_coords](
+            const gsl::not_null<typename intrp::Tags::InterpolatedVarsHolders<
+                Metavariables>::type*>
+                vars_holders) noexcept {
           auto& vars_infos =
               get<intrp::Vars::HolderTag<InterpolationTargetTag,
                                          Metavariables>>(*vars_holders)

--- a/src/NumericalAlgorithms/Interpolation/PointInfoTag.hpp
+++ b/src/NumericalAlgorithms/Interpolation/PointInfoTag.hpp
@@ -21,8 +21,9 @@ struct PointInfoTag {
   /// logical coordinates) that need to be interpolated onto for a
   /// given `InterpolationTarget`.  Only a subset of those points
   /// will be contained in the `Element` that uses this Tag.
-  using type = std::vector<std::optional<IdPair<
-      domain::BlockId, tnsr::I<double, VolumeDim, typename ::Frame::Logical>>>>;
+  using type = std::vector<std::optional<
+      IdPair<domain::BlockId,
+             tnsr::I<double, VolumeDim, typename ::Frame::BlockLogical>>>>;
 };
 }  // namespace Vars
 

--- a/tests/Unit/DataStructures/Tensor/Test_Tensor.cpp
+++ b/tests/Unit/DataStructures/Tensor/Test_Tensor.cpp
@@ -36,6 +36,10 @@ static_assert(std::is_same_v<UpIndex, SpatialIndex<3, UpLo::Up, Frame::Grid>>,
 // [change_up_lo]
 
 // [is_frame_physical]
+static_assert(not Frame::is_frame_physical_v<Frame::BlockLogical>,
+              "Failed testing Frame::is_frame_physical");
+static_assert(not Frame::is_frame_physical_v<Frame::ElementLogical>,
+              "Failed testing Frame::is_frame_physical");
 static_assert(not Frame::is_frame_physical_v<Frame::Logical>,
               "Failed testing Frame::is_frame_physical");
 static_assert(not Frame::is_frame_physical_v<Frame::Distorted>,
@@ -1353,14 +1357,6 @@ SPECTRE_TEST_CASE("Unit.Serialization.Tensor",
 #endif
 }
 
-SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.IndexType",
-                  "[Unit][DataStructures]") {
-  CHECK(get_output(Frame::Logical{}) == "Logical");
-  CHECK(get_output(Frame::Grid{}) == "Grid");
-  CHECK(get_output(Frame::Distorted{}) == "Distorted");
-  CHECK(get_output(Frame::Inertial{}) == "Inertial");
-}
-
 SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.GetVectorOfData",
                   "[Unit][DataStructures]") {
   // NOTE: This test depends on the implementation of serialize and Tensor,
@@ -1392,6 +1388,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.GetVectorOfData",
 // [example_spectre_test_case]
 SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Frames",
                   "[Unit][DataStructures]") {
+  CHECK("BlockLogical" == get_output(Frame::BlockLogical{}));
+  CHECK("ElementLogical" == get_output(Frame::ElementLogical{}));
   CHECK("Logical" == get_output(Frame::Logical{}));
   CHECK("Grid" == get_output(Frame::Grid{}));
   CHECK("Inertial" == get_output(Frame::Inertial{}));

--- a/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
+++ b/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
@@ -292,7 +292,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
       const auto location =
           blocks[i]
               .stationary_map()(
-                  tnsr::I<double, 2, Frame::Logical>{{{-1.0, -1.0}}})
+                  tnsr::I<double, 2, Frame::BlockLogical>{{{-1.0, -1.0}}})
               .get_vector_of_data()
               .second;
       INFO("Unexpected block");
@@ -345,7 +345,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
       const auto location =
           blocks[i]
               .stationary_map()(
-                  tnsr::I<double, 2, Frame::Logical>{{{-1.0, -1.0}}})
+                  tnsr::I<double, 2, Frame::BlockLogical>{{{-1.0, -1.0}}})
               .get_vector_of_data()
               .second;
       INFO("Unexpected block");

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -226,7 +226,7 @@ void test_connectivity() {
                              .blocks()[44]
                              .stationary_map()
                              .get_clone()};
-          tnsr::I<double, 3, Frame::Logical> logical_point(
+          tnsr::I<double, 3, Frame::BlockLogical> logical_point(
               std::array<double, 3>{{0.0, 0.0, -1.0}});
           const double layer_5_inner_radius =
               get(magnitude(std::move(map)->operator()(logical_point)));

--- a/tests/Unit/Domain/Creators/Test_Brick.cpp
+++ b/tests/Unit/Domain/Creators/Test_Brick.cpp
@@ -75,7 +75,7 @@ void test_brick_construction(
   test_domain_construction(
       domain, expected_block_neighbors, expected_external_boundaries,
       make_vector(make_coordinate_map_base<
-                  Frame::Logical,
+                  Frame::BlockLogical,
                   tmpl::conditional_t<sizeof...(FuncsOfTime) == 0,
                                       Frame::Inertial, Frame::Grid>>(
           Affine3D{Affine{-1., 1., lower_bound[0], upper_bound[0]},
@@ -274,11 +274,11 @@ void test_brick() {
   creators::register_derived_with_charm();
 
   const auto base_map =
-      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Affine3D{Affine{-1., 1., lower_bound[0], upper_bound[0]},
                    Affine{-1., 1., lower_bound[1], upper_bound[1]},
                    Affine{-1., 1., lower_bound[2], upper_bound[2]}});
-  are_maps_equal(make_coordinate_map<Frame::Logical, Frame::Inertial>(
+  are_maps_equal(make_coordinate_map<Frame::BlockLogical, Frame::Inertial>(
                      Affine3D{Affine{-1., 1., lower_bound[0], upper_bound[0]},
                               Affine{-1., 1., lower_bound[1], upper_bound[1]},
                               Affine{-1., 1., lower_bound[2], upper_bound[2]}}),

--- a/tests/Unit/Domain/Creators/Test_Cylinder.cpp
+++ b/tests/Unit/Domain/Creators/Test_Cylinder.cpp
@@ -124,7 +124,7 @@ void test_cylinder_construction(
   std::vector<std::unordered_set<Direction<3>>> expected_external_boundaries{};
   using TargetFrame = Frame::Inertial;
   std::vector<std::unique_ptr<
-      domain::CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>
+      domain::CoordinateMapBase<Frame::BlockLogical, TargetFrame, 3>>>
       coord_maps{};
   if (not is_periodic_in_z) {
     expected_block_neighbors = std::vector<DirectionMap<3, BlockNeighbor<3>>>{
@@ -206,7 +206,7 @@ void test_cylinder_construction(
 
   if (use_equiangular_map) {
     coord_maps.emplace_back(
-        make_coordinate_map_base<Frame::Logical, TargetFrame>(
+        make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
             Equiangular3DPrism{
                 Equiangular(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
                             inner_radius / sqrt(2.0)),
@@ -215,7 +215,7 @@ void test_cylinder_construction(
                 Affine{-1.0, 1.0, lower_bound, upper_bound}}));
   } else {
     coord_maps.emplace_back(
-        make_coordinate_map_base<Frame::Logical, TargetFrame>(
+        make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
             Affine3D{Affine(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
                             inner_radius / sqrt(2.0)),
                      Affine(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
@@ -223,28 +223,28 @@ void test_cylinder_construction(
                      Affine{-1.0, 1.0, lower_bound, upper_bound}}));
   }
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{inner_radius, outer_radius, 0.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}},
                   use_equiangular_map},
           Affine{-1.0, 1.0, lower_bound, upper_bound}}));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{inner_radius, outer_radius, 0.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}},
                   use_equiangular_map},
           Affine{-1.0, 1.0, lower_bound, upper_bound}}));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{inner_radius, outer_radius, 0.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}},
                   use_equiangular_map},
           Affine{-1.0, 1.0, lower_bound, upper_bound}}));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{inner_radius, outer_radius, 0.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}},
@@ -487,7 +487,7 @@ void test_refined_cylinder_boundaries(
   std::vector<std::unordered_set<Direction<3>>> expected_external_boundaries{};
   using TargetFrame = Frame::Inertial;
   std::vector<std::unique_ptr<
-      domain::CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>
+      domain::CoordinateMapBase<Frame::BlockLogical, TargetFrame, 3>>>
       coord_maps{};
   // This specific domain consists of two stacked discs with 9 blocks each.
   expected_block_neighbors = std::vector<DirectionMap<3, BlockNeighbor<3>>>{
@@ -677,7 +677,7 @@ void test_refined_cylinder_boundaries(
   // (height_partitioning.at(0), upper_bound)
   if (use_equiangular_map) {
     coord_maps.emplace_back(
-        make_coordinate_map_base<Frame::Logical, TargetFrame>(
+        make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
             Equiangular3DPrism{
                 Equiangular(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
                             inner_radius / sqrt(2.0)),
@@ -686,7 +686,7 @@ void test_refined_cylinder_boundaries(
                 Affine{-1.0, 1.0, lower_bound, height_partitioning.at(0)}}));
   } else {
     coord_maps.emplace_back(
-        make_coordinate_map_base<Frame::Logical, TargetFrame>(Affine3D{
+        make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Affine3D{
             Affine(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
                    inner_radius / sqrt(2.0)),
             Affine(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
@@ -694,35 +694,35 @@ void test_refined_cylinder_boundaries(
             Affine{-1.0, 1.0, lower_bound, height_partitioning.at(0)}}));
   }
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{inner_radius, radial_partitioning.at(0), 0.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}},
                   use_equiangular_map},
           Affine{-1.0, 1.0, lower_bound, height_partitioning.at(0)}}));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{inner_radius, radial_partitioning.at(0), 0.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}},
                   use_equiangular_map},
           Affine{-1.0, 1.0, lower_bound, height_partitioning.at(0)}}));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{inner_radius, radial_partitioning.at(0), 0.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}},
                   use_equiangular_map},
           Affine{-1.0, 1.0, lower_bound, height_partitioning.at(0)}}));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{inner_radius, radial_partitioning.at(0), 0.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}},
                   use_equiangular_map},
           Affine{-1.0, 1.0, lower_bound, height_partitioning.at(0)}}));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{radial_partitioning.at(0), outer_radius, 1.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}},
@@ -730,7 +730,7 @@ void test_refined_cylinder_boundaries(
                   outer_radial_distribution},
           Affine{-1.0, 1.0, lower_bound, height_partitioning.at(0)}}));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{radial_partitioning.at(0), outer_radius, 1.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}},
@@ -738,7 +738,7 @@ void test_refined_cylinder_boundaries(
                   outer_radial_distribution},
           Affine{-1.0, 1.0, lower_bound, height_partitioning.at(0)}}));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{radial_partitioning.at(0), outer_radius, 1.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}},
@@ -746,7 +746,7 @@ void test_refined_cylinder_boundaries(
                   outer_radial_distribution},
           Affine{-1.0, 1.0, lower_bound, height_partitioning.at(0)}}));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{radial_partitioning.at(0), outer_radius, 1.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}},
@@ -755,7 +755,7 @@ void test_refined_cylinder_boundaries(
           Affine{-1.0, 1.0, lower_bound, height_partitioning.at(0)}}));
   if (use_equiangular_map) {
     coord_maps.emplace_back(
-        make_coordinate_map_base<Frame::Logical, TargetFrame>(
+        make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
             Equiangular3DPrism{
                 Equiangular(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
                             inner_radius / sqrt(2.0)),
@@ -764,7 +764,7 @@ void test_refined_cylinder_boundaries(
                 Affine{-1.0, 1.0, height_partitioning.at(0), upper_bound}}));
   } else {
     coord_maps.emplace_back(
-        make_coordinate_map_base<Frame::Logical, TargetFrame>(Affine3D{
+        make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Affine3D{
             Affine(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
                    inner_radius / sqrt(2.0)),
             Affine(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
@@ -772,35 +772,35 @@ void test_refined_cylinder_boundaries(
             Affine{-1.0, 1.0, height_partitioning.at(0), upper_bound}}));
   }
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{inner_radius, radial_partitioning.at(0), 0.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}},
                   use_equiangular_map},
           Affine{-1.0, 1.0, height_partitioning.at(0), upper_bound}}));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{inner_radius, radial_partitioning.at(0), 0.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}},
                   use_equiangular_map},
           Affine{-1.0, 1.0, height_partitioning.at(0), upper_bound}}));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{inner_radius, radial_partitioning.at(0), 0.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}},
                   use_equiangular_map},
           Affine{-1.0, 1.0, height_partitioning.at(0), upper_bound}}));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{inner_radius, radial_partitioning.at(0), 0.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}},
                   use_equiangular_map},
           Affine{-1.0, 1.0, height_partitioning.at(0), upper_bound}}));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{radial_partitioning.at(0), outer_radius, 1.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}},
@@ -808,7 +808,7 @@ void test_refined_cylinder_boundaries(
                   outer_radial_distribution},
           Affine{-1.0, 1.0, height_partitioning.at(0), upper_bound}}));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{radial_partitioning.at(0), outer_radius, 1.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}},
@@ -816,7 +816,7 @@ void test_refined_cylinder_boundaries(
                   outer_radial_distribution},
           Affine{-1.0, 1.0, height_partitioning.at(0), upper_bound}}));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{radial_partitioning.at(0), outer_radius, 1.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}},
@@ -824,7 +824,7 @@ void test_refined_cylinder_boundaries(
                   outer_radial_distribution},
           Affine{-1.0, 1.0, height_partitioning.at(0), upper_bound}}));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{radial_partitioning.at(0), outer_radius, 1.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}},
@@ -892,7 +892,7 @@ void test_refined_cylinder_periodic_boundaries(const bool use_equiangular_map) {
   std::vector<std::unordered_set<Direction<3>>> expected_external_boundaries{};
   using TargetFrame = Frame::Inertial;
   std::vector<std::unique_ptr<
-      domain::CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>
+      domain::CoordinateMapBase<Frame::BlockLogical, TargetFrame, 3>>>
       coord_maps{};
   expected_block_neighbors = std::vector<DirectionMap<3, BlockNeighbor<3>>>{
       // Block 0 - layer 0 center 0
@@ -1092,7 +1092,7 @@ void test_refined_cylinder_periodic_boundaries(const bool use_equiangular_map) {
   // (height_partitioning.at(0), upper_bound)
   if (use_equiangular_map) {
     coord_maps.emplace_back(
-        make_coordinate_map_base<Frame::Logical, TargetFrame>(
+        make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
             Equiangular3DPrism{
                 Equiangular(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
                             inner_radius / sqrt(2.0)),
@@ -1101,7 +1101,7 @@ void test_refined_cylinder_periodic_boundaries(const bool use_equiangular_map) {
                 Affine{-1.0, 1.0, lower_bound, height_partitioning.at(0)}}));
   } else {
     coord_maps.emplace_back(
-        make_coordinate_map_base<Frame::Logical, TargetFrame>(Affine3D{
+        make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Affine3D{
             Affine(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
                    inner_radius / sqrt(2.0)),
             Affine(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
@@ -1109,56 +1109,56 @@ void test_refined_cylinder_periodic_boundaries(const bool use_equiangular_map) {
             Affine{-1.0, 1.0, lower_bound, height_partitioning.at(0)}}));
   }
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{inner_radius, radial_partitioning.at(0), 0.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}},
                   use_equiangular_map},
           Affine{-1.0, 1.0, lower_bound, height_partitioning.at(0)}}));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{inner_radius, radial_partitioning.at(0), 0.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}},
                   use_equiangular_map},
           Affine{-1.0, 1.0, lower_bound, height_partitioning.at(0)}}));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{inner_radius, radial_partitioning.at(0), 0.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}},
                   use_equiangular_map},
           Affine{-1.0, 1.0, lower_bound, height_partitioning.at(0)}}));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{inner_radius, radial_partitioning.at(0), 0.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}},
                   use_equiangular_map},
           Affine{-1.0, 1.0, lower_bound, height_partitioning.at(0)}}));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{radial_partitioning.at(0), outer_radius, 1.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}},
                   use_equiangular_map},
           Affine{-1.0, 1.0, lower_bound, height_partitioning.at(0)}}));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{radial_partitioning.at(0), outer_radius, 1.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}},
                   use_equiangular_map},
           Affine{-1.0, 1.0, lower_bound, height_partitioning.at(0)}}));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{radial_partitioning.at(0), outer_radius, 1.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}},
                   use_equiangular_map},
           Affine{-1.0, 1.0, lower_bound, height_partitioning.at(0)}}));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{radial_partitioning.at(0), outer_radius, 1.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}},
@@ -1166,7 +1166,7 @@ void test_refined_cylinder_periodic_boundaries(const bool use_equiangular_map) {
           Affine{-1.0, 1.0, lower_bound, height_partitioning.at(0)}}));
   if (use_equiangular_map) {
     coord_maps.emplace_back(
-        make_coordinate_map_base<Frame::Logical, TargetFrame>(
+        make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
             Equiangular3DPrism{
                 Equiangular(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
                             inner_radius / sqrt(2.0)),
@@ -1175,7 +1175,7 @@ void test_refined_cylinder_periodic_boundaries(const bool use_equiangular_map) {
                 Affine{-1.0, 1.0, height_partitioning.at(0), upper_bound}}));
   } else {
     coord_maps.emplace_back(
-        make_coordinate_map_base<Frame::Logical, TargetFrame>(Affine3D{
+        make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Affine3D{
             Affine(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
                    inner_radius / sqrt(2.0)),
             Affine(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
@@ -1183,56 +1183,56 @@ void test_refined_cylinder_periodic_boundaries(const bool use_equiangular_map) {
             Affine{-1.0, 1.0, height_partitioning.at(0), upper_bound}}));
   }
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{inner_radius, radial_partitioning.at(0), 0.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}},
                   use_equiangular_map},
           Affine{-1.0, 1.0, height_partitioning.at(0), upper_bound}}));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{inner_radius, radial_partitioning.at(0), 0.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}},
                   use_equiangular_map},
           Affine{-1.0, 1.0, height_partitioning.at(0), upper_bound}}));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{inner_radius, radial_partitioning.at(0), 0.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}},
                   use_equiangular_map},
           Affine{-1.0, 1.0, height_partitioning.at(0), upper_bound}}));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{inner_radius, radial_partitioning.at(0), 0.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}},
                   use_equiangular_map},
           Affine{-1.0, 1.0, height_partitioning.at(0), upper_bound}}));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{radial_partitioning.at(0), outer_radius, 1.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}},
                   use_equiangular_map},
           Affine{-1.0, 1.0, height_partitioning.at(0), upper_bound}}));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{radial_partitioning.at(0), outer_radius, 1.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}},
                   use_equiangular_map},
           Affine{-1.0, 1.0, height_partitioning.at(0), upper_bound}}));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{radial_partitioning.at(0), outer_radius, 1.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}},
                   use_equiangular_map},
           Affine{-1.0, 1.0, height_partitioning.at(0), upper_bound}}));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, TargetFrame>(Wedge3DPrism{
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(Wedge3DPrism{
           Wedge2D{radial_partitioning.at(0), outer_radius, 1.0, 1.0,
                   OrientationMap<2>{std::array<Direction<2>, 2>{
                       {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}},

--- a/tests/Unit/Domain/Creators/Test_Disk.cpp
+++ b/tests/Unit/Domain/Creators/Test_Disk.cpp
@@ -95,7 +95,7 @@ void test_disk_construction(
   using Equiangular2D =
       CoordinateMaps::ProductOf2Maps<Equiangular, Equiangular>;
 
-  auto coord_maps = make_vector_coordinate_map_base<Frame::Logical,
+  auto coord_maps = make_vector_coordinate_map_base<Frame::BlockLogical,
                                                     TargetFrame>(
       Wedge2DMap{inner_radius, outer_radius, 0.0, 1.0,
                  OrientationMap<2>{std::array<Direction<2>, 2>{
@@ -116,14 +116,15 @@ void test_disk_construction(
 
   if (use_equiangular_map) {
     coord_maps.emplace_back(
-        make_coordinate_map_base<Frame::Logical, TargetFrame>(Equiangular2D{
-            Equiangular(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
-                        inner_radius / sqrt(2.0)),
-            Equiangular(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
-                        inner_radius / sqrt(2.0))}));
+        make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
+            Equiangular2D{
+                Equiangular(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
+                            inner_radius / sqrt(2.0)),
+                Equiangular(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
+                            inner_radius / sqrt(2.0))}));
   } else {
     coord_maps.emplace_back(
-        make_coordinate_map_base<Frame::Logical, TargetFrame>(
+        make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
             Affine2D{Affine(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
                             inner_radius / sqrt(2.0)),
                      Affine(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),

--- a/tests/Unit/Domain/Creators/Test_Interval.cpp
+++ b/tests/Unit/Domain/Creators/Test_Interval.cpp
@@ -66,7 +66,7 @@ void test_interval_construction(
   test_domain_construction(
       domain, expected_block_neighbors, expected_external_boundaries,
       make_vector(make_coordinate_map_base<
-                  Frame::Logical,
+                  Frame::BlockLogical,
                   tmpl::conditional_t<sizeof...(FuncsOfTime) == 0,
                                       Frame::Inertial, Frame::Grid>>(
           CoordinateMaps::Affine{-1., 1., lower_bound[0], upper_bound[0]})),

--- a/tests/Unit/Domain/Creators/Test_Rectangle.cpp
+++ b/tests/Unit/Domain/Creators/Test_Rectangle.cpp
@@ -75,7 +75,7 @@ void test_rectangle_construction(
   test_domain_construction(
       domain, expected_block_neighbors, expected_external_boundaries,
       make_vector(make_coordinate_map_base<
-                  Frame::Logical,
+                  Frame::BlockLogical,
                   tmpl::conditional_t<sizeof...(FuncsOfTime) == 0,
                                       Frame::Inertial, Frame::Grid>>(
           Affine2D{Affine{-1., 1., lower_bound[0], upper_bound[0]},

--- a/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
@@ -106,50 +106,50 @@ void test_rotated_bricks_construction(
   const Affine lower_z_map(-1.0, 1.0, lower_bound[2], midpoint[2]);
   const Affine upper_z_map(-1.0, 1.0, midpoint[2], upper_bound[2]);
 
-  std::vector<
-      std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 3>>>
+  std::vector<std::unique_ptr<
+      CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 3>>>
       coord_maps;
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Affine3D(lower_x_map, lower_y_map, lower_z_map)));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           DiscreteRotation3D{OrientationMap<3>{std::array<Direction<3>, 3>{
               {Direction<3>::upper_zeta(), Direction<3>::upper_eta(),
                Direction<3>::lower_xi()}}}},
           Affine3D(upper_x_map, lower_y_map, lower_z_map)));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           DiscreteRotation3D{OrientationMap<3>{std::array<Direction<3>, 3>{
               {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
                Direction<3>::lower_eta()}}}},
           Affine3D(lower_x_map, upper_y_map, lower_z_map)));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           DiscreteRotation3D{OrientationMap<3>{std::array<Direction<3>, 3>{
               {Direction<3>::upper_zeta(), Direction<3>::lower_xi(),
                Direction<3>::lower_eta()}}}},
           Affine3D(upper_x_map, upper_y_map, lower_z_map)));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           DiscreteRotation3D{OrientationMap<3>{std::array<Direction<3>, 3>{
               {Direction<3>::upper_eta(), Direction<3>::lower_xi(),
                Direction<3>::upper_zeta()}}}},
           Affine3D(lower_x_map, lower_y_map, upper_z_map)));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           DiscreteRotation3D{OrientationMap<3>{std::array<Direction<3>, 3>{
               {Direction<3>::upper_eta(), Direction<3>::lower_zeta(),
                Direction<3>::lower_xi()}}}},
           Affine3D(upper_x_map, lower_y_map, upper_z_map)));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           DiscreteRotation3D{OrientationMap<3>{std::array<Direction<3>, 3>{
               {Direction<3>::upper_zeta(), Direction<3>::lower_xi(),
                Direction<3>::lower_eta()}}}},
           Affine3D(lower_x_map, upper_y_map, upper_z_map)));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Affine3D(upper_x_map, upper_y_map, upper_z_map)));
 
   test_domain_construction(domain, expected_block_neighbors,

--- a/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
@@ -70,12 +70,12 @@ void test_rotated_intervals_construction(
       domain, expected_block_neighbors, expected_external_boundaries,
       make_vector(
           make_coordinate_map_base<
-              Frame::Logical,
+              Frame::BlockLogical,
               tmpl::conditional_t<sizeof...(FuncsOfTime) == 0, Frame::Inertial,
                                   Frame::Grid>>(
               CoordinateMaps::Affine{-1., 1., lower_bound[0], midpoint[0]}),
           make_coordinate_map_base<
-              Frame::Logical,
+              Frame::BlockLogical,
               tmpl::conditional_t<sizeof...(FuncsOfTime) == 0, Frame::Inertial,
                                   Frame::Grid>>(
               CoordinateMaps::DiscreteRotation<1>{OrientationMap<1>{

--- a/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
@@ -63,24 +63,24 @@ void test_rotated_rectangles_construction(
   const Affine upper_x_map(-1.0, 1.0, midpoint[0], upper_bound[0]);
   const Affine lower_y_map(-1.0, 1.0, lower_bound[1], midpoint[1]);
   const Affine upper_y_map(-1.0, 1.0, midpoint[1], upper_bound[1]);
-  std::vector<
-      std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 2>>>
+  std::vector<std::unique_ptr<
+      CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 2>>>
       coord_maps;
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Affine2D(lower_x_map, lower_y_map)));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           DiscreteRotation2D{OrientationMap<2>{std::array<Direction<2>, 2>{
               {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}}},
           Affine2D(upper_x_map, lower_y_map)));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           DiscreteRotation2D{OrientationMap<2>{std::array<Direction<2>, 2>{
               {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}}},
           Affine2D(lower_x_map, upper_y_map)));
   coord_maps.emplace_back(
-      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           DiscreteRotation2D{OrientationMap<2>{std::array<Direction<2>, 2>{
               {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}}},
           Affine2D(upper_x_map, upper_y_map)));

--- a/tests/Unit/Domain/Creators/Test_Shell.cpp
+++ b/tests/Unit/Domain/Creators/Test_Shell.cpp
@@ -222,8 +222,8 @@ void test_shell_construction(
                           : domain::CoordinateMaps::Distribution::Linear;
   if (aspect_ratio == 1.0) {
     auto vector_of_maps = make_vector_coordinate_map_base<
-        Frame::Logical, tmpl::conditional_t<sizeof...(FuncsOfTime) == 0,
-                                            Frame::Inertial, Frame::Grid>>(
+        Frame::BlockLogical, tmpl::conditional_t<sizeof...(FuncsOfTime) == 0,
+                                                 Frame::Inertial, Frame::Grid>>(
         Wedge3DMap{inner_radius, outer_radius, 1.0, 1.0, OrientationMap<3>{},
                    use_equiangular_map, Halves::Both, radial_distribution},
         Wedge3DMap{inner_radius, outer_radius, 1.0, 1.0,
@@ -267,7 +267,7 @@ void test_shell_construction(
     if constexpr(sizeof...(FuncsOfTime) == 0) {
       // We turn off the domain_no_corners test for time-dependent
       // maps because Domain doesn't have a constructor that takes
-      // maps from Logical to Grid.
+      // maps from BlockLogical to Grid.
       const auto vector_of_maps_copy = clone_unique_ptrs(vector_of_maps);
 
       Domain<3> domain_no_corners =
@@ -301,19 +301,19 @@ void test_shell_construction(
     using TargetFrame = tmpl::conditional_t<sizeof...(FuncsOfTime) == 0,
                                             Frame::Inertial, Frame::Grid>;
     auto vector_of_maps = make_vector(
-        make_coordinate_map_base<Frame::Logical, TargetFrame>(
+        make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
             Wedge3DMap{inner_radius, outer_radius, 1.0, 1.0,
                        OrientationMap<3>{}, use_equiangular_map, Halves::Both,
                        radial_distribution},
             compression, translation),
-        make_coordinate_map_base<Frame::Logical, TargetFrame>(
+        make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
             Wedge3DMap{inner_radius, outer_radius, 1.0, 1.0,
                        OrientationMap<3>{std::array<Direction<3>, 3>{
                            {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
                             Direction<3>::lower_zeta()}}},
                        use_equiangular_map, Halves::Both, radial_distribution},
             compression, translation),
-        make_coordinate_map_base<Frame::Logical, TargetFrame>(
+        make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
             Wedge3DMap{
                 inner_radius, outer_radius, 1.0, 1.0,
                 OrientationMap<3>{std::array<Direction<3>, 3>{
@@ -321,7 +321,7 @@ void test_shell_construction(
                      Direction<3>::lower_eta()}}},
                 use_equiangular_map, Halves::Both, radial_distribution},
             compression, translation),
-        make_coordinate_map_base<Frame::Logical, TargetFrame>(
+        make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
             Wedge3DMap{
                 inner_radius, outer_radius, 1.0, 1.0,
                 OrientationMap<3>{std::array<Direction<3>, 3>{
@@ -329,7 +329,7 @@ void test_shell_construction(
                      Direction<3>::upper_eta()}}},
                 use_equiangular_map, Halves::Both, radial_distribution},
             compression, translation),
-        make_coordinate_map_base<Frame::Logical, TargetFrame>(
+        make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
             Wedge3DMap{
                 inner_radius, outer_radius, 1.0, 1.0,
                 OrientationMap<3>{std::array<Direction<3>, 3>{
@@ -337,7 +337,7 @@ void test_shell_construction(
                      Direction<3>::upper_eta()}}},
                 use_equiangular_map, Halves::Both, radial_distribution},
             compression, translation),
-        make_coordinate_map_base<Frame::Logical, TargetFrame>(
+        make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
             Wedge3DMap{
                 inner_radius, outer_radius, 1.0, 1.0,
                 OrientationMap<3>{std::array<Direction<3>, 3>{
@@ -362,7 +362,7 @@ void test_shell_construction(
     if constexpr (sizeof...(FuncsOfTime) == 0) {
       // We turn off the domain_no_corners test for time-dependent
       // maps because Domain doesn't have a constructor that takes
-      // maps from Logical to Grid.
+      // maps from BlockLogical to Grid.
       const auto vector_of_maps_copy = clone_unique_ptrs(vector_of_maps);
       Domain<3> domain_no_corners =
           expected_boundary_conditions.empty()

--- a/tests/Unit/Domain/Creators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/Creators/Test_Sphere.cpp
@@ -177,7 +177,7 @@ void test_sphere_construction(
       CoordinateMaps::ProductOf3Maps<Equiangular, Equiangular, Equiangular>;
 
   auto coord_maps =
-      make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Wedge3DMap{inner_radius, outer_radius, 0.0, 1.0, OrientationMap<3>{},
                      use_equiangular_map},
           Wedge3DMap{inner_radius, outer_radius, 0.0, 1.0,
@@ -207,16 +207,17 @@ void test_sphere_construction(
                      use_equiangular_map});
   if (use_equiangular_map) {
     coord_maps.emplace_back(
-        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(Equiangular3D{
-            Equiangular(-1.0, 1.0, -1.0 * inner_radius / sqrt(3.0),
-                        inner_radius / sqrt(3.0)),
-            Equiangular(-1.0, 1.0, -1.0 * inner_radius / sqrt(3.0),
-                        inner_radius / sqrt(3.0)),
-            Equiangular(-1.0, 1.0, -1.0 * inner_radius / sqrt(3.0),
-                        inner_radius / sqrt(3.0))}));
+        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+            Equiangular3D{
+                Equiangular(-1.0, 1.0, -1.0 * inner_radius / sqrt(3.0),
+                            inner_radius / sqrt(3.0)),
+                Equiangular(-1.0, 1.0, -1.0 * inner_radius / sqrt(3.0),
+                            inner_radius / sqrt(3.0)),
+                Equiangular(-1.0, 1.0, -1.0 * inner_radius / sqrt(3.0),
+                            inner_radius / sqrt(3.0))}));
   } else {
     coord_maps.emplace_back(
-        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             Affine3D{Affine(-1.0, 1.0, -1.0 * inner_radius / sqrt(3.0),
                             inner_radius / sqrt(3.0)),
                      Affine(-1.0, 1.0, -1.0 * inner_radius / sqrt(3.0),

--- a/tests/Unit/Domain/Test_Block.cpp
+++ b/tests/Unit/Domain/Test_Block.cpp
@@ -50,10 +50,10 @@ auto create_external_bcs() {
 template <size_t Dim>
 void test_block_time_independent() {
   CAPTURE(Dim);
-  PUPable_reg(SINGLE_ARG(CoordinateMap<Frame::Logical, Frame::Inertial,
+  PUPable_reg(SINGLE_ARG(CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                                        CoordinateMaps::Identity<Dim>>));
 
-  using coordinate_map = CoordinateMap<Frame::Logical, Frame::Inertial,
+  using coordinate_map = CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                                        CoordinateMaps::Identity<Dim>>;
   const coordinate_map identity_map{CoordinateMaps::Identity<Dim>{}};
 
@@ -73,7 +73,7 @@ void test_block_time_independent() {
 
     // Test that the block's coordinate_map is Identity:
     const auto& map = block.stationary_map();
-    const tnsr::I<double, Dim, Frame::Logical> xi(1.0);
+    const tnsr::I<double, Dim, Frame::BlockLogical> xi(1.0);
     const tnsr::I<double, Dim, Frame::Inertial> x(1.0);
     CHECK(map(xi) == x);
     CHECK(map.inverse(x).value() == xi);
@@ -146,11 +146,11 @@ void test_block_time_dependent() {
               domain::CoordinateMaps::TimeDependent::ProductOf3Maps<
                   Translation, Translation, Translation>>>>;
   using logical_to_grid_coordinate_map =
-      CoordinateMap<Frame::Logical, Frame::Inertial,
+      CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                     CoordinateMaps::Identity<Dim>>;
   using grid_to_inertial_coordinate_map = TranslationDimD;
   PUPable_reg(logical_to_grid_coordinate_map);
-  PUPable_reg(SINGLE_ARG(CoordinateMap<Frame::Logical, Frame::Grid,
+  PUPable_reg(SINGLE_ARG(CoordinateMap<Frame::BlockLogical, Frame::Grid,
                                        CoordinateMaps::Identity<Dim>>));
   PUPable_reg(grid_to_inertial_coordinate_map);
   const logical_to_grid_coordinate_map identity_map{
@@ -186,7 +186,7 @@ void test_block_time_dependent() {
     // Test that the block's coordinate_map is Identity:
     const auto& grid_to_inertial_map = block.moving_mesh_grid_to_inertial_map();
     const auto& logical_to_grid_map = block.moving_mesh_logical_to_grid_map();
-    const tnsr::I<double, Dim, Frame::Logical> xi(1.0);
+    const tnsr::I<double, Dim, Frame::BlockLogical> xi(1.0);
     const tnsr::I<double, Dim, Frame::Inertial> x(1.0 + time);
     CHECK(grid_to_inertial_map(logical_to_grid_map(xi), time,
                                functions_of_time) == x);
@@ -241,7 +241,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Block", "[Domain][Unit]") {
   DirectionMap<2, BlockNeighbor<2>> neighbors = {
       {Direction<2>::upper_xi(), block_neighbor1},
       {Direction<2>::lower_eta(), block_neighbor2}};
-  using coordinate_map = CoordinateMap<Frame::Logical, Frame::Inertial,
+  using coordinate_map = CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                                        CoordinateMaps::Identity<2>>;
   const coordinate_map identity_map{CoordinateMaps::Identity<2>{}};
   auto external_boundary_conditions = create_external_bcs<2>();

--- a/tests/Unit/Domain/Test_BlockAndElementLogicalCoordinates.cpp
+++ b/tests/Unit/Domain/Test_BlockAndElementLogicalCoordinates.cpp
@@ -205,7 +205,7 @@ void fuzzy_test_block_and_element_logical_coordinates_unrefined(
     // Assumes logical coords go from -1 to 1.
     std::uniform_real_distribution<double> ran(-1.0, 1.0);
     MAKE_GENERATOR(gen);
-    std::vector<tnsr::I<double, Dim, Frame::Logical>> coords(n_pts);
+    std::vector<tnsr::I<double, Dim, Frame::BlockLogical>> coords(n_pts);
     for (size_t s = 0; s < n_pts; ++s) {
       for (size_t d = 0; d < Dim; ++d) {
         coords[s].get(d) = ran(gen);
@@ -370,8 +370,8 @@ void test_block_and_element_logical_coordinates(
     const std::vector<std::vector<std::array<double, Dim>>>&
         expected_element_logical) noexcept {
   tnsr::I<DataVector, Dim, Frame::Inertial> inertial_coords(x_inertial.size());
-  std::vector<tnsr::I<double, Dim, Frame::Logical>> expected_logical_coords(
-      x_inertial.size());
+  std::vector<tnsr::I<double, Dim, Frame::BlockLogical>>
+      expected_logical_coords(x_inertial.size());
   for (size_t s = 0; s < x_inertial.size(); ++s) {
     for (size_t d = 0; d < Dim; ++d) {
       inertial_coords.get(d)[s] = gsl::at(x_inertial[s], d);

--- a/tests/Unit/Domain/Test_CoordinatesTag.cpp
+++ b/tests/Unit/Domain/Test_CoordinatesTag.cpp
@@ -21,7 +21,7 @@
 namespace Frame {
 struct Grid;
 struct Inertial;
-struct Logical;
+struct BlockLogical;
 }  // namespace Frame
 
 namespace domain {
@@ -34,9 +34,10 @@ void test_coordinates_compute_item(const Mesh<Dim>& mesh, T map) noexcept {
       db::AddComputeTags<
           Tags::LogicalCoordinates<Dim>,
           Tags::MappedCoordinates<map_tag, Tags::LogicalCoordinates<Dim>>>>(
-      mesh, ElementMap<Dim, Frame::Grid>(
-                ElementId<Dim>(0),
-                make_coordinate_map_base<Frame::Logical, Frame::Grid>(map)));
+      mesh,
+      ElementMap<Dim, Frame::Grid>(
+          ElementId<Dim>(0),
+          make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(map)));
   CHECK_ITERABLE_APPROX(
       (db::get<Tags::Coordinates<Dim, Frame::Grid>>(box)),
       (make_coordinate_map<Frame::Logical, Frame::Grid>(map)(

--- a/tests/Unit/Domain/Test_CreateInitialElement.cpp
+++ b/tests/Unit/Domain/Test_CreateInitialElement.cpp
@@ -54,7 +54,8 @@ void test_h_refinement() noexcept {
       CAPTURE(neighbor_orientation);
       CAPTURE(neighbor_refinement);
       const Block<3> self_block(
-          domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          domain::make_coordinate_map_base<Frame::BlockLogical,
+                                           Frame::Inertial>(
               domain::CoordinateMaps::Identity<3>{}),
           0, {{neighbor_direction, {1, neighbor_orientation}}});
       const std::vector<std::array<size_t, 3>> refinement_levels{
@@ -399,7 +400,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CreateInitialElement", "[Domain][Unit]") {
   OrientationMap<2> unaligned(
       make_array(Direction<2>::lower_eta(), Direction<2>::upper_xi()));
   Block<2> test_block(
-      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           domain::CoordinateMaps::Identity<2>{}),
       0,
       {{Direction<2>::upper_xi(), BlockNeighbor<2>{1, aligned}},

--- a/tests/Unit/Domain/Test_Domain.cpp
+++ b/tests/Unit/Domain/Test_Domain.cpp
@@ -45,37 +45,37 @@ namespace helpers = ::TestHelpers::domain::BoundaryConditions;
 void test_1d_domains() {
   using Translation = domain::CoordinateMaps::TimeDependent::Translation;
   {
-    PUPable_reg(SINGLE_ARG(CoordinateMap<Frame::Logical, Frame::Inertial,
+    PUPable_reg(SINGLE_ARG(CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                                          CoordinateMaps::Affine>));
-    PUPable_reg(SINGLE_ARG(
-        CoordinateMap<Frame::Logical, Frame::Grid, CoordinateMaps::Affine>));
+    PUPable_reg(SINGLE_ARG(CoordinateMap<Frame::BlockLogical, Frame::Grid,
+                                         CoordinateMaps::Affine>));
     PUPable_reg(
         SINGLE_ARG(CoordinateMap<Frame::Grid, Frame::Inertial, Translation>));
 
     // Test construction of two intervals which have anti-aligned logical axes.
     Domain<1> domain_from_corners(
         make_vector<std::unique_ptr<
-            CoordinateMapBase<Frame::Logical, Frame::Inertial, 1>>>(
-            std::make_unique<CoordinateMap<Frame::Logical, Frame::Inertial,
+            CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 1>>>(
+            std::make_unique<CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                                            CoordinateMaps::Affine>>(
-                make_coordinate_map<Frame::Logical, Frame::Inertial>(
+                make_coordinate_map<Frame::BlockLogical, Frame::Inertial>(
                     CoordinateMaps::Affine{-1., 1., -2., 0.})),
-            std::make_unique<CoordinateMap<Frame::Logical, Frame::Inertial,
+            std::make_unique<CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                                            CoordinateMaps::Affine>>(
-                make_coordinate_map<Frame::Logical, Frame::Inertial>(
+                make_coordinate_map<Frame::BlockLogical, Frame::Inertial>(
                     CoordinateMaps::Affine{-1., 1., 0., 2.}))),
         std::vector<std::array<size_t, 2>>{{{1, 2}}, {{3, 2}}});
 
     Domain<1> domain_no_corners(
         make_vector<std::unique_ptr<
-            CoordinateMapBase<Frame::Logical, Frame::Inertial, 1>>>(
-            std::make_unique<CoordinateMap<Frame::Logical, Frame::Inertial,
+            CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 1>>>(
+            std::make_unique<CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                                            CoordinateMaps::Affine>>(
-                make_coordinate_map<Frame::Logical, Frame::Inertial>(
+                make_coordinate_map<Frame::BlockLogical, Frame::Inertial>(
                     CoordinateMaps::Affine{-1., 1., -2., 0.})),
-            std::make_unique<CoordinateMap<Frame::Logical, Frame::Inertial,
+            std::make_unique<CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                                            CoordinateMaps::Affine>>(
-                make_coordinate_map<Frame::Logical, Frame::Inertial>(
+                make_coordinate_map<Frame::BlockLogical, Frame::Inertial>(
                     CoordinateMaps::Affine{-1., 1., 2., 0.}))));
 
     const OrientationMap<1> unaligned_orientation{{{Direction<1>::lower_xi()}},
@@ -90,17 +90,17 @@ void test_1d_domains() {
     const std::vector<std::unordered_set<Direction<1>>> expected_boundaries{
         {Direction<1>::lower_xi()}, {Direction<1>::lower_xi()}};
 
-    const auto expected_stationary_maps =
-        make_vector(make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-                        CoordinateMaps::Affine{-1., 1., -2., 0.}),
-                    make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-                        CoordinateMaps::Affine{-1., 1., 0., 2.}));
+    const auto expected_stationary_maps = make_vector(
+        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+            CoordinateMaps::Affine{-1., 1., -2., 0.}),
+        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+            CoordinateMaps::Affine{-1., 1., 0., 2.}));
 
-    const auto expected_stationary_maps_no_corners =
-        make_vector(make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-                        CoordinateMaps::Affine{-1., 1., -2., 0.}),
-                    make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-                        CoordinateMaps::Affine{-1., 1., 2., 0.}));
+    const auto expected_stationary_maps_no_corners = make_vector(
+        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+            CoordinateMaps::Affine{-1., 1., -2., 0.}),
+        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+            CoordinateMaps::Affine{-1., 1., 2., 0.}));
 
     test_domain_construction(domain_from_corners, expected_neighbors,
                              expected_boundaries, expected_stationary_maps);
@@ -135,14 +135,14 @@ void test_1d_domains() {
                Translation{"Translation1"}));
 
     const auto expected_logical_to_grid_maps =
-        make_vector(make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+        make_vector(make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
                         CoordinateMaps::Affine{-1., 1., -2., 0.}),
-                    make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+                    make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
                         CoordinateMaps::Affine{-1., 1., 0., 2.}));
     const auto expected_logical_to_grid_maps_no_corners =
-        make_vector(make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+        make_vector(make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
                         CoordinateMaps::Affine{-1., 1., -2., 0.}),
-                    make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+                    make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
                         CoordinateMaps::Affine{-1., 1., 2., 0.}));
     const auto expected_grid_to_inertial_maps =
         make_vector_coordinate_map_base<Frame::Grid, Frame::Inertial>(
@@ -180,15 +180,15 @@ void test_1d_domains() {
     auto vector_of_blocks = [&expected_neighbors]() {
       std::vector<Block<1>> vec;
       vec.emplace_back(Block<1>{
-          std::make_unique<CoordinateMap<Frame::Logical, Frame::Inertial,
+          std::make_unique<CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                                          CoordinateMaps::Affine>>(
-              make_coordinate_map<Frame::Logical, Frame::Inertial>(
+              make_coordinate_map<Frame::BlockLogical, Frame::Inertial>(
                   CoordinateMaps::Affine{-1., 1., -2., 0.})),
           0, expected_neighbors[0]});
       vec.emplace_back(Block<1>{
-          std::make_unique<CoordinateMap<Frame::Logical, Frame::Inertial,
+          std::make_unique<CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                                          CoordinateMaps::Affine>>(
-              make_coordinate_map<Frame::Logical, Frame::Inertial>(
+              make_coordinate_map<Frame::BlockLogical, Frame::Inertial>(
                   CoordinateMaps::Affine{-1., 1., 0., 2.})),
           1, expected_neighbors[1]});
       return vec;
@@ -211,16 +211,16 @@ void test_1d_domains() {
 
   {
     // Test construction of a periodic domain
-    const auto expected_maps =
-        make_vector(make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+    const auto expected_maps = make_vector(
+        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             CoordinateMaps::Affine{-1., 1., -2., 2.}));
 
     const Domain<1> domain{
         make_vector<std::unique_ptr<
-            CoordinateMapBase<Frame::Logical, Frame::Inertial, 1>>>(
-            std::make_unique<CoordinateMap<Frame::Logical, Frame::Inertial,
+            CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 1>>>(
+            std::make_unique<CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                                            CoordinateMaps::Affine>>(
-                make_coordinate_map<Frame::Logical, Frame::Inertial>(
+                make_coordinate_map<Frame::BlockLogical, Frame::Inertial>(
                     CoordinateMaps::Affine{-1., 1., -2., 2.}))),
         std::vector<std::array<size_t, 2>>{{{1, 2}}},
         std::vector<PairOfFaces>{{{1}, {2}}}};
@@ -428,12 +428,12 @@ SPECTRE_TEST_CASE("Unit.Domain.Domain", "[Domain][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   // NOLINTNEXTLINE(bugprone-unused-raii)
-  Domain<1>(
-      make_vector(make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-                      CoordinateMaps::Affine{-1., 1., -1., 1.}),
-                  make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-                      CoordinateMaps::Affine{-1., 1., -1., 1.})),
-      std::vector<std::array<size_t, 2>>{{{1, 2}}});
+  Domain<1>(make_vector(
+                make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+                    CoordinateMaps::Affine{-1., 1., -1., 1.}),
+                make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+                    CoordinateMaps::Affine{-1., 1., -1., 1.})),
+            std::vector<std::array<size_t, 2>>{{{1, 2}}});
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -129,7 +129,7 @@ void test_periodic_different_blocks() noexcept {
 }
 
 std::vector<
-    std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 3>>>
+    std::unique_ptr<CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 3>>>
 test_wedge_map_generation(double inner_radius, double outer_radius,
                           double inner_sphericity, double outer_sphericity,
                           bool use_equiangular_map,
@@ -148,17 +148,17 @@ test_wedge_map_generation(double inner_radius, double outer_radius,
   if (use_half_wedges) {
     using Halves = Wedge3DMap::WedgeHalves;
     return make_vector(
-        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
                        outer_sphericity, OrientationMap<3>{},
                        use_equiangular_map, Halves::LowerOnly},
             compression, translation),
-        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
                        outer_sphericity, OrientationMap<3>{},
                        use_equiangular_map, Halves::UpperOnly},
             compression, translation),
-        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
                        outer_sphericity,
                        OrientationMap<3>{std::array<Direction<3>, 3>{
@@ -166,7 +166,7 @@ test_wedge_map_generation(double inner_radius, double outer_radius,
                             Direction<3>::lower_zeta()}}},
                        use_equiangular_map, Halves::LowerOnly},
             compression, translation),
-        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
                        outer_sphericity,
                        OrientationMap<3>{std::array<Direction<3>, 3>{
@@ -174,7 +174,7 @@ test_wedge_map_generation(double inner_radius, double outer_radius,
                             Direction<3>::lower_zeta()}}},
                        use_equiangular_map, Halves::UpperOnly},
             compression, translation),
-        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             Wedge3DMap{
                 inner_radius, outer_radius, inner_sphericity, outer_sphericity,
                 OrientationMap<3>{std::array<Direction<3>, 3>{
@@ -182,7 +182,7 @@ test_wedge_map_generation(double inner_radius, double outer_radius,
                      Direction<3>::lower_eta()}}},
                 use_equiangular_map, Halves::LowerOnly},
             compression, translation),
-        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             Wedge3DMap{
                 inner_radius, outer_radius, inner_sphericity, outer_sphericity,
                 OrientationMap<3>{std::array<Direction<3>, 3>{
@@ -190,7 +190,7 @@ test_wedge_map_generation(double inner_radius, double outer_radius,
                      Direction<3>::lower_eta()}}},
                 use_equiangular_map, Halves::UpperOnly},
             compression, translation),
-        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             Wedge3DMap{
                 inner_radius, outer_radius, inner_sphericity, outer_sphericity,
                 OrientationMap<3>{std::array<Direction<3>, 3>{
@@ -198,7 +198,7 @@ test_wedge_map_generation(double inner_radius, double outer_radius,
                      Direction<3>::upper_eta()}}},
                 use_equiangular_map, Halves::LowerOnly},
             compression, translation),
-        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             Wedge3DMap{
                 inner_radius, outer_radius, inner_sphericity, outer_sphericity,
                 OrientationMap<3>{std::array<Direction<3>, 3>{
@@ -206,7 +206,7 @@ test_wedge_map_generation(double inner_radius, double outer_radius,
                      Direction<3>::upper_eta()}}},
                 use_equiangular_map, Halves::UpperOnly},
             compression, translation),
-        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             Wedge3DMap{
                 inner_radius, outer_radius, inner_sphericity, outer_sphericity,
                 OrientationMap<3>{std::array<Direction<3>, 3>{
@@ -214,7 +214,7 @@ test_wedge_map_generation(double inner_radius, double outer_radius,
                      Direction<3>::upper_eta()}}},
                 use_equiangular_map},
             compression, translation),
-        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             Wedge3DMap{
                 inner_radius, outer_radius, inner_sphericity, outer_sphericity,
                 OrientationMap<3>{std::array<Direction<3>, 3>{
@@ -225,12 +225,12 @@ test_wedge_map_generation(double inner_radius, double outer_radius,
   }
 
   return make_vector(
-      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
                      outer_sphericity, OrientationMap<3>{},
                      use_equiangular_map},
           compression, translation),
-      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
                      outer_sphericity,
                      OrientationMap<3>{std::array<Direction<3>, 3>{
@@ -238,7 +238,7 @@ test_wedge_map_generation(double inner_radius, double outer_radius,
                           Direction<3>::lower_zeta()}}},
                      use_equiangular_map},
           compression, translation),
-      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
                      outer_sphericity,
                      OrientationMap<3>{std::array<Direction<3>, 3>{
@@ -246,7 +246,7 @@ test_wedge_map_generation(double inner_radius, double outer_radius,
                           Direction<3>::lower_eta()}}},
                      use_equiangular_map},
           compression, translation),
-      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
                      outer_sphericity,
                      OrientationMap<3>{std::array<Direction<3>, 3>{
@@ -254,7 +254,7 @@ test_wedge_map_generation(double inner_radius, double outer_radius,
                           Direction<3>::upper_eta()}}},
                      use_equiangular_map},
           compression, translation),
-      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
                      outer_sphericity,
                      OrientationMap<3>{std::array<Direction<3>, 3>{
@@ -262,7 +262,7 @@ test_wedge_map_generation(double inner_radius, double outer_radius,
                           Direction<3>::upper_eta()}}},
                      use_equiangular_map},
           compression, translation),
-      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
                      outer_sphericity,
                      OrientationMap<3>{std::array<Direction<3>, 3>{
@@ -598,7 +598,7 @@ void test_all_frustum_directions() noexcept {
   const double projective_scale_factor = 0.3;
   for (const bool use_equiangular_map : {true, false}) {
     const auto expected_coord_maps =
-        make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+        make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             FrustumMap{{{{{-2.0 * lower - displacement1[0],
                            -lower - displacement1[1]}},
                          {{-displacement1[0], lower - displacement1[1]}},
@@ -1415,41 +1415,41 @@ void test_maps_for_rectilinear_domains() noexcept {
   using Equiangular3D =
       CoordinateMaps::ProductOf3Maps<Equiangular, Equiangular, Equiangular>;
 
-  const std::vector<
-      std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 1>>>
+  const std::vector<std::unique_ptr<
+      CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 1>>>
       affine_maps_1d = maps_for_rectilinear_domains<Frame::Inertial>(
           Index<1>{3},
           std::array<std::vector<double>, 1>{{{0.0, 0.5, 1.7, 2.0}}},
           {Index<1>{0}}, {}, false);
   const auto expected_affine_maps_1d =
-      make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Affine{-1., 1., 0.5, 1.7}, Affine{-1., 1., 1.7, 2.0});
   for (size_t i = 0; i < affine_maps_1d.size(); i++) {
     CHECK(*affine_maps_1d[i] == *expected_affine_maps_1d[i]);
   }
 
-  const std::vector<
-      std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 1>>>
+  const std::vector<std::unique_ptr<
+      CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 1>>>
       equiangular_maps_1d = maps_for_rectilinear_domains<Frame::Inertial>(
           Index<1>{3},
           std::array<std::vector<double>, 1>{{{0.0, 0.5, 1.7, 2.0}}},
           {Index<1>{1}}, {}, true);
   const auto expected_equiangular_maps_1d =
-      make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Equiangular{-1., 1., 0.0, 0.5}, Equiangular{-1., 1., 1.7, 2.0});
   for (size_t i = 0; i < equiangular_maps_1d.size(); i++) {
     CHECK(*equiangular_maps_1d[i] == *expected_equiangular_maps_1d[i]);
   }
 
-  const std::vector<
-      std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 2>>>
+  const std::vector<std::unique_ptr<
+      CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 2>>>
       affine_maps_2d = maps_for_rectilinear_domains<Frame::Inertial>(
           Index<2>{3, 2},
           std::array<std::vector<double>, 2>{
               {{0.0, 0.5, 1.7, 2.0}, {0.0, 1.0, 2.0}}},
           {Index<2>{}}, {}, false);
   const auto expected_affine_maps_2d =
-      make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Affine2D{Affine{-1., 1., 0.0, 0.5}, Affine{-1., 1., 0.0, 1.0}},
           Affine2D{Affine{-1., 1., 0.5, 1.7}, Affine{-1., 1., 0.0, 1.0}},
           Affine2D{Affine{-1., 1., 1.7, 2.0}, Affine{-1., 1., 0.0, 1.0}},
@@ -1460,15 +1460,15 @@ void test_maps_for_rectilinear_domains() noexcept {
     CHECK(*affine_maps_2d[i] == *expected_affine_maps_2d[i]);
   }
 
-  const std::vector<
-      std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 2>>>
+  const std::vector<std::unique_ptr<
+      CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 2>>>
       equiangular_maps_2d = maps_for_rectilinear_domains<Frame::Inertial>(
           Index<2>{3, 2},
           std::array<std::vector<double>, 2>{
               {{0.0, 0.5, 1.7, 2.0}, {0.0, 1.0, 2.0}}},
           {Index<2>{2, 1}}, {}, true);
   const auto expected_equiangular_maps_2d =
-      make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Equiangular2D{Equiangular{-1., 1., 0.0, 0.5},
                         Equiangular{-1., 1., 0.0, 1.0}},
           Equiangular2D{Equiangular{-1., 1., 0.5, 1.7},
@@ -1484,8 +1484,8 @@ void test_maps_for_rectilinear_domains() noexcept {
   }
 
   // [show_maps_for_rectilinear_domains]
-  const std::vector<
-      std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 3>>>
+  const std::vector<std::unique_ptr<
+      CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 3>>>
       affine_maps_3d = maps_for_rectilinear_domains<Frame::Inertial>(
           Index<3>{2, 2, 1},
           std::array<std::vector<double>, 3>{
@@ -1493,7 +1493,7 @@ void test_maps_for_rectilinear_domains() noexcept {
           {Index<3>{}}, {}, false);
   // [show_maps_for_rectilinear_domains]
   const auto expected_affine_maps_3d =
-      make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Affine3D{Affine{-1., 1., 0.0, 0.5}, Affine{-1., 1., 0.0, 1.0},
                    Affine{-1., 1., -0.4, 0.3}},
           Affine3D{Affine{-1., 1., 0.5, 2.0}, Affine{-1., 1., 0.0, 1.0},
@@ -1506,15 +1506,15 @@ void test_maps_for_rectilinear_domains() noexcept {
     CHECK(*affine_maps_3d[i] == *expected_affine_maps_3d[i]);
   }
 
-  const std::vector<
-      std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 3>>>
+  const std::vector<std::unique_ptr<
+      CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 3>>>
       equiangular_maps_3d = maps_for_rectilinear_domains<Frame::Inertial>(
           Index<3>{2, 2, 1},
           std::array<std::vector<double>, 3>{
               {{0.0, 0.5, 2.0}, {0.0, 1.0, 2.0}, {-0.4, 0.3}}},
           {Index<3>{0, 0, 0}}, {}, true);
   const auto expected_equiangular_maps_3d =
-      make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Equiangular3D{Equiangular{-1., 1., 0.5, 2.0},
                         Equiangular{-1., 1., 0.0, 1.0},
                         Equiangular{-1., 1., -0.4, 0.3}},
@@ -1598,8 +1598,8 @@ void test_set_cartesian_periodic_boundaries_1() noexcept {
   // of `OrientationMaps`. In this case no indexing is done, so if an incorrect
   // map is created via incorrect indexing, the maps created by the two
   // function calls will differ.
-  const std::vector<
-      std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 3>>>
+  const std::vector<std::unique_ptr<
+      CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 3>>>
       expected_coordinate_maps = maps_for_rectilinear_domains<Frame::Inertial>(
           Index<3>{3, 3, 3},
           std::array<std::vector<double>, 3>{{{0.0, 1.0, 2.0, 3.0},
@@ -1644,8 +1644,8 @@ void test_set_cartesian_periodic_boundaries_2() noexcept {
       orientations_of_all_blocks, std::array<bool, 2>{{true, false}}, {},
       false);
 
-  const std::vector<
-      std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 2>>>
+  const std::vector<std::unique_ptr<
+      CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 2>>>
       expected_coordinate_maps = maps_for_rectilinear_domains<Frame::Inertial>(
           Index<2>{2, 2},
           std::array<std::vector<double>, 2>{
@@ -1708,8 +1708,8 @@ void test_set_cartesian_periodic_boundaries_3() noexcept {
        {Direction<2>::upper_eta(), {2, flipped}},
        {Direction<2>::upper_xi(), {1, quarter_turn_ccw}},
        {Direction<2>::lower_eta(), {2, flipped}}}};
-  const std::vector<
-      std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 2>>>
+  const std::vector<std::unique_ptr<
+      CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 2>>>
       expected_coordinate_maps = maps_for_rectilinear_domains<Frame::Inertial>(
           Index<2>{2, 2},
           std::array<std::vector<double>, 2>{

--- a/tests/Unit/Domain/Test_ElementMap.cpp
+++ b/tests/Unit/Domain/Test_ElementMap.cpp
@@ -37,14 +37,16 @@ void test_element_impl(
     const T& first_map, const U& second_map,
     const tnsr::I<double, Dim, Frame::Logical>& logical_point_double,
     const tnsr::I<DV, Dim, Frame::Logical>& logical_point_dv) {
-  PUPable_reg(SINGLE_ARG(CoordinateMap<Frame::Logical, Frame::Inertial, T, U>));
+  PUPable_reg(
+      SINGLE_ARG(CoordinateMap<Frame::BlockLogical, Frame::Inertial, T, U>));
   const auto composed_map =
       make_coordinate_map<Frame::Logical, Frame::Inertial>(
           affine_map, first_map, second_map);
 
   ElementMap<Dim, Frame::Inertial> element_map{
-      element_id, make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-                      first_map, second_map)};
+      element_id,
+      make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+          first_map, second_map)};
   ElementMap<Dim, Frame::Inertial> element_map_deserialized =
       serialize_and_deserialize(element_map);
 
@@ -88,7 +90,7 @@ void test_element_impl(
                         composed_map.jacobian(logical_point_double));
 
   CHECK(element_map.block_map() ==
-        *(make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+        *(make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             first_map, second_map)));
 }
 

--- a/tests/Unit/Domain/Test_FaceNormal.cpp
+++ b/tests/Unit/Domain/Test_FaceNormal.cpp
@@ -233,8 +233,9 @@ template <typename TargetFrame>
 void test_face_normal_element_map() {
   const Mesh<0> mesh_0d;
   const auto map_1d = ElementMap<1, TargetFrame>(
-      ElementId<1>{0}, make_coordinate_map_base<Frame::Logical, TargetFrame>(
-                           CoordinateMaps::Affine(-1.0, 1.0, -3.0, 7.0)));
+      ElementId<1>{0},
+      make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
+          CoordinateMaps::Affine(-1.0, 1.0, -3.0, 7.0)));
   const auto normal_1d_lower =
       unnormalized_face_normal(mesh_0d, map_1d, Direction<1>::lower_xi());
 
@@ -247,13 +248,13 @@ void test_face_normal_element_map() {
 
   check(ElementMap<2, TargetFrame>(
             ElementId<2>(0),
-            make_coordinate_map_base<Frame::Logical, TargetFrame>(
+            make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
                 CoordinateMaps::Rotation<2>(atan2(4., 3.)))),
         {{{{0.6, 0.8}}, {{-0.8, 0.6}}}});
 
   check(ElementMap<3, TargetFrame>(
             ElementId<3>(0),
-            make_coordinate_map_base<Frame::Logical, TargetFrame>(
+            make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
                 CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
                                                CoordinateMaps::Rotation<2>>(
                     {-1., 1., 2., 7.},
@@ -284,8 +285,9 @@ void test_face_normal_moving_mesh() {
   {
     INFO("1d");
     const ElementMap<1, Frame::Grid> logical_to_grid_map(
-        ElementId<1>(0), make_coordinate_map_base<Frame::Logical, Frame::Grid>(
-                             CoordinateMaps::Affine(-1.0, 1.0, 2.0, 7.8)));
+        ElementId<1>(0),
+        make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
+            CoordinateMaps::Affine(-1.0, 1.0, 2.0, 7.8)));
     const auto grid_to_inertial_map =
         make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
             CoordinateMaps::TimeDependent::CubicScale<1>{
@@ -306,8 +308,9 @@ void test_face_normal_moving_mesh() {
   {
     INFO("2d");
     const ElementMap<2, Frame::Grid> logical_to_grid_map(
-        ElementId<2>(0), make_coordinate_map_base<Frame::Logical, Frame::Grid>(
-                             CoordinateMaps::Rotation<2>(atan2(4., 3.))));
+        ElementId<2>(0),
+        make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
+            CoordinateMaps::Rotation<2>(atan2(4., 3.))));
     const auto grid_to_inertial_map =
         make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
             CoordinateMaps::TimeDependent::CubicScale<2>{
@@ -329,7 +332,7 @@ void test_face_normal_moving_mesh() {
     INFO("3d");
     const ElementMap<3, Frame::Grid> logical_to_grid_map(
         ElementId<3>(0),
-        make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+        make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
             CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
                                            CoordinateMaps::Rotation<2>>(
                 {-1., 1., 2., 7.},
@@ -378,7 +381,7 @@ void test_compute_item() {
       Mesh<2>{2, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto},
       ElementMap<2, Frame::Inertial>(
           ElementId<2>(0),
-          make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
               CoordinateMaps::Rotation<2>(atan2(4., 3.)))));
 
   TestHelpers::db::test_compute_tag<
@@ -435,7 +438,7 @@ void test_compute_item() {
       Mesh<2>{2, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto},
       ElementMap<2, Frame::Inertial>(
           ElementId<2>(0),
-          make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
               CoordinateMaps::Wedge<2>(1., 2., 0., 1., OrientationMap<2>{},
                                        false))));
 

--- a/tests/Unit/Domain/Test_InterfaceItems.cpp
+++ b/tests/Unit/Domain/Test_InterfaceItems.cpp
@@ -502,7 +502,7 @@ void test_interface_slice(){
 
   ElementMap<2, Frame::Inertial> element_map(
       ElementId<2>(0),
-      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           domain::CoordinateMaps::Rotation<2>(atan2(4., 3.))));
 
   const std::unordered_map<Direction<dim>, Mesh<dim - 1>>
@@ -680,8 +680,9 @@ void test_boundary_coordinates_moving_mesh() {
     const ElementMap<std::decay_t<decltype(element_id)>::volume_dim,
                      Frame::Grid>
         logical_to_grid_map(
-            element_id, make_coordinate_map_base<Frame::Logical, Frame::Grid>(
-                            time_independent_map));
+            element_id,
+            make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
+                time_independent_map));
     const auto grid_to_inertial_map =
         make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
             time_dependent_map);

--- a/tests/Unit/Domain/Test_SizeOfElement.cpp
+++ b/tests/Unit/Domain/Test_SizeOfElement.cpp
@@ -36,8 +36,9 @@
 namespace {
 void test_1d() noexcept {
   INFO("1d");
-  auto map = domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-      domain::CoordinateMaps::Affine(-1.0, 1.0, 0.3, 1.2));
+  auto map =
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+          domain::CoordinateMaps::Affine(-1.0, 1.0, 0.3, 1.2));
   const ElementId<1> element_id(0, {{{2, 3}}});
   const ElementMap<1, Frame::Inertial> element_map(element_id, std::move(map));
   const auto size = size_of_element(element_map);
@@ -50,11 +51,12 @@ void test_2d() noexcept {
   INFO("2d");
   using Affine = domain::CoordinateMaps::Affine;
   using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
-  auto map = domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-      Affine2D{Affine(-1.0, 1.0, 0.3, 0.4), Affine(-1.0, 1.0, -0.5, 1.2)},
-      domain::CoordinateMaps::DiscreteRotation<2>(
-          OrientationMap<2>{std::array<Direction<2>, 2>{
-              {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}}));
+  auto map =
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+          Affine2D{Affine(-1.0, 1.0, 0.3, 0.4), Affine(-1.0, 1.0, -0.5, 1.2)},
+          domain::CoordinateMaps::DiscreteRotation<2>(
+              OrientationMap<2>{std::array<Direction<2>, 2>{
+                  {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}}));
   const ElementId<2> element_id(0, {{{1, 1}, {2, 0}}});
   const ElementMap<2, Frame::Inertial> element_map(element_id, std::move(map));
   const auto size = size_of_element(element_map);
@@ -67,10 +69,11 @@ void test_3d() noexcept {
   using Affine = domain::CoordinateMaps::Affine;
   using Affine3D =
       domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
-  auto map = domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-      Affine3D{Affine(-1.0, 1.0, 0.3, 0.4), Affine(-1.0, 1.0, -0.5, 1.2),
-               Affine(-1.0, 1.0, 12.0, 12.5)},
-      domain::CoordinateMaps::Rotation<3>(0.7, 2.3, -0.4));
+  auto map =
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+          Affine3D{Affine(-1.0, 1.0, 0.3, 0.4), Affine(-1.0, 1.0, -0.5, 1.2),
+                   Affine(-1.0, 1.0, 12.0, 12.5)},
+          domain::CoordinateMaps::Rotation<3>(0.7, 2.3, -0.4));
   const ElementId<3> element_id(0, {{{3, 5}, {1, 0}, {2, 3}}});
   const ElementMap<3, Frame::Inertial> element_map(element_id, std::move(map));
   const auto size = size_of_element(element_map);
@@ -99,7 +102,7 @@ make_single_expansion_functions_of_time() noexcept {
 
 void test_1d_moving_mesh(const std::array<double, 4>& times_to_check) noexcept {
   INFO("1d with moving mesh");
-  auto map = domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+  auto map = domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
       domain::CoordinateMaps::Affine(-1.0, 1.0, 0.3, 1.2));
   const ElementId<1> element_id(0, {{{2, 3}}});
   const ElementMap<1, Frame::Grid> logical_to_grid_map(element_id,
@@ -125,7 +128,7 @@ void test_2d_moving_mesh(const std::array<double, 4>& times_to_check) noexcept {
   INFO("2d with moving mesh");
   using Affine = domain::CoordinateMaps::Affine;
   using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
-  auto map = domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+  auto map = domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
       Affine2D{Affine(-1.0, 1.0, 0.3, 0.4), Affine(-1.0, 1.0, -0.5, 1.2)},
       domain::CoordinateMaps::DiscreteRotation<2>(
           OrientationMap<2>{std::array<Direction<2>, 2>{
@@ -153,7 +156,7 @@ void test_3d_moving_mesh(const std::array<double, 4>& times_to_check) noexcept {
   using Affine = domain::CoordinateMaps::Affine;
   using Affine3D =
       domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
-  auto map = domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+  auto map = domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
       Affine3D{Affine(-1.0, 1.0, 0.3, 0.4), Affine(-1.0, 1.0, -0.5, 1.2),
                Affine(-1.0, 1.0, 12.0, 12.5)},
       domain::CoordinateMaps::Rotation<3>(0.7, 2.3, -0.4));
@@ -180,7 +183,7 @@ void test_compute_tag(const std::array<double, 4>& times_to_check) noexcept {
   INFO("compute tag in 2d, with moving mesh");
   using Affine = domain::CoordinateMaps::Affine;
   using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
-  auto map = domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+  auto map = domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
       Affine2D{Affine(-1.0, 1.0, 0.3, 0.4), Affine(-1.0, 1.0, -0.5, 1.2)},
       domain::CoordinateMaps::DiscreteRotation<2>(
           OrientationMap<2>{std::array<Direction<2>, 2>{

--- a/tests/Unit/Domain/Test_Tags.cpp
+++ b/tests/Unit/Domain/Test_Tags.cpp
@@ -70,7 +70,7 @@ ElementMap<1, Frame::Grid> element_map() noexcept {
   const CoordinateMaps::Affine second_map{1.0, 8.0, -2.5, -1.0};
   const ElementId<dim> element_id(0, segment_ids);
   return ElementMap<dim, Frame::Grid>{
-      element_id, make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+      element_id, make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
                       first_map, second_map)};
 }
 
@@ -83,7 +83,7 @@ ElementMap<2, Frame::Grid> element_map() noexcept {
   const CoordinateMaps::Rotation<dim> second_map(3.1);
   const ElementId<dim> element_id(0, segment_ids);
   return ElementMap<dim, Frame::Grid>{
-      element_id, make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+      element_id, make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
                       first_map, second_map)};
 }
 
@@ -96,7 +96,7 @@ ElementMap<3, Frame::Grid> element_map() noexcept {
   const CoordinateMaps::Rotation<dim> second_map{M_PI_4, M_PI_2, M_PI_2};
   const ElementId<dim> element_id(0, segment_ids);
   return ElementMap<dim, Frame::Grid>{
-      element_id, make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+      element_id, make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
                       first_map, second_map)};
 }
 

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Actions/Test_InitializeDomain.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Actions/Test_InitializeDomain.cpp
@@ -70,7 +70,7 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeDomain", "[Unit][Actions]") {
         {{-0.5}}, {{1.5}}, {{2}}, {{4}}, {{false}}, nullptr};
     // Register the coordinate map for serialization
     PUPable_reg(
-        SINGLE_ARG(domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+        SINGLE_ARG(domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                                          domain::CoordinateMaps::Affine>));
 
     using metavariables = Metavariables<1>;
@@ -137,7 +137,7 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeDomain", "[Unit][Actions]") {
         {{-0.5, 0.}}, {{1.5, 2.}}, {{2, 0}}, {{4, 3}}, {{false, false}}};
     // Register the coordinate map for serialization
     PUPable_reg(
-        SINGLE_ARG(domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+        SINGLE_ARG(domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                                          domain::CoordinateMaps::ProductOf2Maps<
                                              domain::CoordinateMaps::Affine,
                                              domain::CoordinateMaps::Affine>>));
@@ -209,7 +209,7 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeDomain", "[Unit][Actions]") {
     // Register the coordinate map for serialization
     PUPable_reg(SINGLE_ARG(
         domain::CoordinateMap<
-            Frame::Logical, Frame::Inertial,
+            Frame::BlockLogical, Frame::Inertial,
             domain::CoordinateMaps::ProductOf3Maps<
                 domain::CoordinateMaps::Affine, domain::CoordinateMaps::Affine,
                 domain::CoordinateMaps::Affine>>));

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_Initialize.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_Initialize.cpp
@@ -186,8 +186,9 @@ void test(const bool always_use_subcell, const bool interior_element) {
   const Element<Dim> element{self_id, neighbors};
   const auto logical_coords = logical_coordinates(dg_mesh);
   ElementMap<Dim, Frame::Grid> logical_to_grid_map{
-      self_id, domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
-                   domain::CoordinateMaps::Identity<Dim>{})};
+      self_id,
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
+          domain::CoordinateMaps::Identity<Dim>{})};
   const auto grid_to_inertial_map =
       domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
           domain::CoordinateMaps::Identity<Dim>{});
@@ -286,11 +287,11 @@ void test(const bool always_use_subcell, const bool interior_element) {
 SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Actions.Initialize",
                   "[Evolution][Unit]") {
   Parallel::register_classes_with_charm<
-      domain::CoordinateMap<Frame::Logical, Frame::Grid,
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Grid,
                             domain::CoordinateMaps::Identity<1>>,
-      domain::CoordinateMap<Frame::Logical, Frame::Grid,
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Grid,
                             domain::CoordinateMaps::Identity<2>>,
-      domain::CoordinateMap<Frame::Logical, Frame::Grid,
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Grid,
                             domain::CoordinateMaps::Identity<3>>,
       domain::CoordinateMap<Frame::Grid, Frame::Inertial,
                             domain::CoordinateMaps::Identity<1>>,

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_TakeTimeStep.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_TakeTimeStep.cpp
@@ -111,17 +111,17 @@ auto make_grid_map() {
   using domain::make_coordinate_map_base;
   using domain::CoordinateMaps::Affine;
   if constexpr (Dim == 1) {
-    return make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+    return make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
         Affine(-1.0, 1.0, 2.0, 5.0));
   } else if constexpr (Dim == 2) {
     using domain::CoordinateMaps::ProductOf2Maps;
-    return make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+    return make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
         ProductOf2Maps<Affine, Affine>(Affine(-1.0, 1.0, -1.0, -0.8),
                                        Affine(-1.0, 1.0, -1.0, -0.8)),
         domain::CoordinateMaps::Wedge<2>(0.5, 0.75, 1.0, 1.0, {}, false));
   } else {
     using domain::CoordinateMaps::ProductOf3Maps;
-    return make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+    return make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
         ProductOf3Maps<Affine, Affine, Affine>(Affine(-1.0, 1.0, -1.0, -0.8),
                                                Affine(-1.0, 1.0, -1.0, -0.8),
                                                Affine(-1.0, 1.0, 0.8, 1.0)),
@@ -186,15 +186,15 @@ void test() {
 SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Fd.Actions.TakeTimeStep",
                   "[Evolution][Unit]") {
   using Affine = domain::CoordinateMaps::Affine;
-  PUPable_reg(
-      SINGLE_ARG(domain::CoordinateMap<Frame::Logical, Frame::Grid, Affine>));
+  PUPable_reg(SINGLE_ARG(
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Grid, Affine>));
   PUPable_reg(SINGLE_ARG(domain::CoordinateMap<
-                         Frame::Logical, Frame::Grid,
+                         Frame::BlockLogical, Frame::Grid,
                          domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>,
                          domain::CoordinateMaps::Wedge<2>>));
   PUPable_reg(
       SINGLE_ARG(domain::CoordinateMap<
-                 Frame::Logical, Frame::Grid,
+                 Frame::BlockLogical, Frame::Grid,
                  domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>,
                  domain::CoordinateMaps::Wedge<3>>));
   PUPable_reg(

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_BoundaryConditions.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_BoundaryConditions.cpp
@@ -2134,8 +2134,9 @@ void test_1d(const bool moving_mesh, const dg::Formulation formulation,
   const ElementId<Dim> self_id{0, {{{1, 0}}}};
   const Element<Dim> element{self_id, {}};
   ElementMap<Dim, Frame::Grid> element_map{
-      self_id, domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
-                   domain::CoordinateMaps::Identity<Dim>{})};
+      self_id,
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
+          domain::CoordinateMaps::Identity<Dim>{})};
   auto grid_to_inertial_map =
       domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
           domain::CoordinateMaps::Identity<Dim>{});
@@ -2216,7 +2217,7 @@ void test_1d(const bool moving_mesh, const dg::Formulation formulation,
     boundary_conditions[Direction<Dim>::upper_xi()] =
         std::make_unique<Outflow<System>>(moving_mesh);
     domain = Domain<Dim>{make_vector(Block<Dim>{
-        domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+        domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             domain::CoordinateMaps::Identity<Dim>{}),
         0,
         {},
@@ -2339,12 +2340,13 @@ void test_1d(const bool moving_mesh, const dg::Formulation formulation,
               std::make_unique<Ghost<System>>(moving_mesh);
           boundary_conditions[outflow_direction] =
               std::make_unique<Outflow<System>>(moving_mesh);
-          *domain_ptr = Domain<Dim>{make_vector(Block<Dim>{
-              domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-                  domain::CoordinateMaps::Identity<Dim>{}),
-              0,
-              {},
-              std::move(boundary_conditions)})};
+          *domain_ptr = Domain<Dim>{make_vector(
+              Block<Dim>{domain::make_coordinate_map_base<Frame::BlockLogical,
+                                                          Frame::Inertial>(
+                             domain::CoordinateMaps::Identity<Dim>{}),
+                         0,
+                         {},
+                         std::move(boundary_conditions)})};
 
           fill_variables(dt_vars_ptr, offset_dt_evolved_vars);
         });
@@ -2421,12 +2423,13 @@ void test_1d(const bool moving_mesh, const dg::Formulation formulation,
                                                        offset_dt_evolved_vars);
           boundary_conditions[outflow_direction] =
               std::make_unique<Outflow<System>>(moving_mesh);
-          *domain_ptr = Domain<Dim>{make_vector(Block<Dim>{
-              domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-                  domain::CoordinateMaps::Identity<Dim>{}),
-              0,
-              {},
-              std::move(boundary_conditions)})};
+          *domain_ptr = Domain<Dim>{make_vector(
+              Block<Dim>{domain::make_coordinate_map_base<Frame::BlockLogical,
+                                                          Frame::Inertial>(
+                             domain::CoordinateMaps::Identity<Dim>{}),
+                         0,
+                         {},
+                         std::move(boundary_conditions)})};
 
           fill_variables(dt_vars_ptr, offset_dt_evolved_vars);
         });
@@ -2492,13 +2495,13 @@ void test_1d(const bool moving_mesh, const dg::Formulation formulation,
                       moving_mesh, get(expected_dt_var1)[0]);
               boundary_conditions[ghost_direction] =
                   std::make_unique<Ghost<System>>(moving_mesh);
-              *domain_ptr = Domain<Dim>{make_vector(
-                  Block<Dim>{domain::make_coordinate_map_base<Frame::Logical,
-                                                              Frame::Inertial>(
-                                 domain::CoordinateMaps::Identity<Dim>{}),
-                             0,
-                             {},
-                             std::move(boundary_conditions)})};
+              *domain_ptr = Domain<Dim>{make_vector(Block<Dim>{
+                  domain::make_coordinate_map_base<Frame::BlockLogical,
+                                                   Frame::Inertial>(
+                      domain::CoordinateMaps::Identity<Dim>{}),
+                  0,
+                  {},
+                  std::move(boundary_conditions)})};
 
               fill_variables(dt_vars_ptr, offset_dt_evolved_vars);
             });
@@ -2549,13 +2552,13 @@ void test_1d(const bool moving_mesh, const dg::Formulation formulation,
                   std::make_unique<GhostAndTimeDerivative<System>>(moving_mesh);
               boundary_conditions[outflow_direction] =
                   std::make_unique<Outflow<System>>(moving_mesh);
-              *domain_ptr = Domain<Dim>{make_vector(
-                  Block<Dim>{domain::make_coordinate_map_base<Frame::Logical,
-                                                              Frame::Inertial>(
-                                 domain::CoordinateMaps::Identity<Dim>{}),
-                             0,
-                             {},
-                             std::move(boundary_conditions)})};
+              *domain_ptr = Domain<Dim>{make_vector(Block<Dim>{
+                  domain::make_coordinate_map_base<Frame::BlockLogical,
+                                                   Frame::Inertial>(
+                      domain::CoordinateMaps::Identity<Dim>{}),
+                  0,
+                  {},
+                  std::move(boundary_conditions)})};
 
               fill_variables(dt_vars_ptr, offset_dt_evolved_vars);
             });

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ComputeTimeDerivative.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ComputeTimeDerivative.cpp
@@ -173,22 +173,22 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.ComputeTimeDerivative",
       SINGLE_ARG(domain::CoordinateMap<Frame::Grid, Frame::Inertial,
                                        domain::CoordinateMaps::Identity<3>>));
   PUPable_reg(
-      SINGLE_ARG(domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+      SINGLE_ARG(domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                                        domain::CoordinateMaps::Identity<1>>));
   PUPable_reg(
-      SINGLE_ARG(domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+      SINGLE_ARG(domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                                        domain::CoordinateMaps::Identity<2>>));
   PUPable_reg(
-      SINGLE_ARG(domain::CoordinateMap<Frame::Logical, Frame::Inertial,
+      SINGLE_ARG(domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                                        domain::CoordinateMaps::Identity<3>>));
   PUPable_reg(
-      SINGLE_ARG(domain::CoordinateMap<Frame::Logical, Frame::Grid,
+      SINGLE_ARG(domain::CoordinateMap<Frame::BlockLogical, Frame::Grid,
                                        domain::CoordinateMaps::Identity<1>>));
   PUPable_reg(
-      SINGLE_ARG(domain::CoordinateMap<Frame::Logical, Frame::Grid,
+      SINGLE_ARG(domain::CoordinateMap<Frame::BlockLogical, Frame::Grid,
                                        domain::CoordinateMaps::Identity<2>>));
   PUPable_reg(
-      SINGLE_ARG(domain::CoordinateMap<Frame::Logical, Frame::Grid,
+      SINGLE_ARG(domain::CoordinateMap<Frame::BlockLogical, Frame::Grid,
                                        domain::CoordinateMaps::Identity<3>>));
 
   // The test is designed to test the `ComputeTimeDerivative` action for DG.

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActions.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActions.cpp
@@ -168,12 +168,12 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.LimiterActions.Generic",
   using Affine = domain::CoordinateMaps::Affine;
   using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
   PUPable_reg(SINGLE_ARG(
-      domain::CoordinateMap<Frame::Logical, Frame::Inertial, Affine2D>));
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial, Affine2D>));
   const Affine xi_map{-1., 1., 3., 7.};
   const Affine eta_map{-1., 1., 7., 3.};
 
   const auto coordmap =
-      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Affine2D(xi_map, eta_map));
 
   const struct {
@@ -319,12 +319,12 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.LimiterActions.NoNeighbors",
   using Affine = domain::CoordinateMaps::Affine;
   using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
   PUPable_reg(SINGLE_ARG(
-      domain::CoordinateMap<Frame::Logical, Frame::Inertial, Affine2D>));
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial, Affine2D>));
   const Affine xi_map{-1., 1., 3., 7.};
   const Affine eta_map{-1., 1., 7., 3.};
   auto map = ElementMap<2, Frame::Inertial>(
       self_id,
-      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Affine2D(xi_map, eta_map)));
 
   ActionTesting::MockRuntimeSystem<metavariables> runner{

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActionsWithMinmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActionsWithMinmod.cpp
@@ -119,8 +119,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.LimiterActions.Minmod",
   using Affine = domain::CoordinateMaps::Affine;
   using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
   using CubicScaleMap = domain::CoordinateMaps::TimeDependent::CubicScale<2>;
-  PUPable_reg(
-      SINGLE_ARG(domain::CoordinateMap<Frame::Logical, Frame::Grid, Affine2D>));
+  PUPable_reg(SINGLE_ARG(
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Grid, Affine2D>));
   PUPable_reg(SINGLE_ARG(
       domain::CoordinateMap<Frame::Grid, Frame::Inertial, CubicScaleMap>));
   domain::FunctionsOfTime::register_derived_with_charm();
@@ -128,8 +128,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.LimiterActions.Minmod",
   const Affine xi_map{-1., 1., 3., 7.};
   const Affine eta_map{-1., 1., 7., 3.};
   auto logical_to_grid_map = ElementMap<2, Frame::Grid>(
-      self_id, domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
-                   Affine2D(xi_map, eta_map)));
+      self_id,
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
+          Affine2D(xi_map, eta_map)));
   std::unique_ptr<domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, 2>>
       grid_to_inertial_map =
           domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(

--- a/tests/Unit/Evolution/Initialization/Test_SetVariables.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_SetVariables.cpp
@@ -212,7 +212,7 @@ auto emplace_component(
       5, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto});
   ElementMap<Dim, Frame::Grid> logical_to_grid_map{
       ElementId<Dim>{0},
-      domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
           domain::CoordinateMaps::Identity<Dim>{})};
   const std::string expansion_factor = "Expansion";
   const auto grid_to_inertial_map =
@@ -348,11 +348,11 @@ SPECTRE_TEST_CASE("Unit.Evolution.Initialization.SetVariables",
                   "[Unit][Evolution][Actions]") {
   domain::FunctionsOfTime::register_derived_with_charm();
   Parallel::register_classes_with_charm<
-      domain::CoordinateMap<Frame::Logical, Frame::Grid,
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Grid,
                             domain::CoordinateMaps::Identity<1>>,
-      domain::CoordinateMap<Frame::Logical, Frame::Grid,
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Grid,
                             domain::CoordinateMaps::Identity<2>>,
-      domain::CoordinateMap<Frame::Logical, Frame::Grid,
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Grid,
                             domain::CoordinateMaps::Identity<3>>,
       domain::CoordinateMap<
           Frame::Grid, Frame::Inertial,

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_InitializeDampedHarmonic.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_InitializeDampedHarmonic.cpp
@@ -118,7 +118,7 @@ void test(const gsl::not_null<std::mt19937*> generator) noexcept {
       SINGLE_ARG(domain::CoordinateMap<Frame::Grid, Frame::Inertial,
                                        domain::CoordinateMaps::Identity<Dim>>));
   PUPable_reg(
-      SINGLE_ARG(domain::CoordinateMap<Frame::Logical, Frame::Grid,
+      SINGLE_ARG(domain::CoordinateMap<Frame::BlockLogical, Frame::Grid,
                                        domain::CoordinateMaps::Identity<Dim>>));
 
   std::uniform_real_distribution<> pdist(0.1, 1.);
@@ -251,7 +251,7 @@ void test(const gsl::not_null<std::mt19937*> generator) noexcept {
         {time, time, mesh, logical_coords, inertial_coords,
          ElementMap<Dim, Frame::Grid>{
              ElementId<Dim>{0},
-             domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+             domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
                  domain::CoordinateMaps::Identity<Dim>{})},
          domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
              domain::CoordinateMaps::Identity<Dim>{}),

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_GrTagsForHydro.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_GrTagsForHydro.cpp
@@ -83,7 +83,7 @@ SPECTRE_TEST_CASE(
       time, subcell_mesh,
       ElementMap<3, Frame::Grid>{
           ElementId<3>{0},
-          domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+          domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
               domain::CoordinateMaps::Identity<3>{})},
       domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
           domain::CoordinateMaps::TimeDependent::ProductOf2Maps<Translation,
@@ -98,7 +98,7 @@ SPECTRE_TEST_CASE(
 
   const ElementMap<3, Frame::Grid> logical_to_grid_map{
       ElementId<3>{0},
-      domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
           domain::CoordinateMaps::Identity<3>{})};
   const auto grid_to_inertial_map =
       domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
@@ -94,12 +94,12 @@ double test(const size_t num_dg_pts) {
           domain::CoordinateMaps::Identity<3>{});
   const auto element = domain::Initialization::create_initial_element(
       ElementId<3>{0, {SegmentId{3, 4}, SegmentId{3, 4}, SegmentId{3, 4}}},
-      Block<3>{
-          domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-              Affine3D{affine_map, affine_map, affine_map}),
-          0,
-          {},
-          {}},
+      Block<3>{domain::make_coordinate_map_base<Frame::BlockLogical,
+                                                Frame::Inertial>(
+                   Affine3D{affine_map, affine_map, affine_map}),
+               0,
+               {},
+               {}},
       std::vector<std::array<size_t, 3>>{std::array<size_t, 3>{{3, 3, 3}}});
 
   const grmhd::Solutions::BondiMichel soln{1.0, 5.0, 0.05, 1.4, 2.0};

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TimeDerivative.cpp
@@ -83,12 +83,12 @@ std::array<double, 4> test(const size_t num_dg_pts) {
           Affine3D{affine_map, affine_map, affine_map});
   const auto element = domain::Initialization::create_initial_element(
       ElementId<3>{0, {SegmentId{3, 4}, SegmentId{3, 4}, SegmentId{3, 4}}},
-      Block<3>{
-          domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-              Affine3D{affine_map, affine_map, affine_map}),
-          0,
-          {},
-          {}},
+      Block<3>{domain::make_coordinate_map_base<Frame::BlockLogical,
+                                                Frame::Inertial>(
+                   Affine3D{affine_map, affine_map, affine_map}),
+               0,
+               {},
+               {}},
       std::vector<std::array<size_t, 3>>{std::array<size_t, 3>{{3, 3, 3}}});
 
   const grmhd::Solutions::BondiMichel soln{1.0, 5.0, 0.05, 1.4, 2.0};

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Limiters/Test_KxrcfTci.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Limiters/Test_KxrcfTci.cpp
@@ -138,7 +138,8 @@ void test_kxrcf_1d() noexcept {
   using Affine = domain::CoordinateMaps::Affine;
   const Affine xi_map{-1., 1., 3., 4.2};
   const auto coordmap =
-      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(xi_map);
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+          xi_map);
   const ElementMap<1, Frame::Inertial> element_map(element.id(),
                                                    coordmap->get_clone());
 
@@ -213,7 +214,7 @@ void test_kxrcf_2d() noexcept {
   const Affine xi_map{-1., 1., 3., 4.2};
   const Affine eta_map{-1., 1., 3., 7.};
   const auto coordmap =
-      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Affine2D(xi_map, eta_map));
   const ElementMap<2, Frame::Inertial> element_map(element.id(),
                                                    coordmap->get_clone());
@@ -300,7 +301,7 @@ void test_kxrcf_3d() noexcept {
   const Affine eta_map{-1., 1., -3., -2.4};
   const Affine zeta_map{-1., 1., 3., 7.};
   const auto coordmap =
-      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Affine3D(xi_map, eta_map, zeta_map));
   const ElementMap<3, Frame::Inertial> element_map(element.id(),
                                                    coordmap->get_clone());

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Limiters/Test_Minmod.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Limiters/Test_Minmod.cpp
@@ -340,7 +340,8 @@ void test_neuler_vs_generic_minmod_1d() noexcept {
   using Affine = domain::CoordinateMaps::Affine;
   const Affine xi_map{-1., 1., 3.7, 4.2};
   const auto coordmap =
-      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(xi_map);
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+          xi_map);
   const ElementMap<1, Frame::Inertial> element_map(element.id(),
                                                    coordmap->get_clone());
   const auto element_size = size_of_element(element_map);
@@ -398,7 +399,8 @@ void test_neuler_vs_generic_minmod_2d() noexcept {
   const Affine eta_map{-1., 1., 3.2, 4.2};
   const Affine2D map2d{xi_map, eta_map};
   const auto coordmap =
-      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(map2d);
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+          map2d);
   const ElementMap<2, Frame::Inertial> element_map(element.id(),
                                                    coordmap->get_clone());
   const auto element_size = size_of_element(element_map);
@@ -465,7 +467,8 @@ void test_neuler_vs_generic_minmod_3d() noexcept {
   const Affine zeta_map{-1., 1., 1.3, 2.1};
   const Affine3D map3d{xi_map, eta_map, zeta_map};
   const auto coordmap =
-      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(map3d);
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+          map3d);
   const ElementMap<3, Frame::Inertial> element_map(element.id(),
                                                    coordmap->get_clone());
   const auto element_size = size_of_element(element_map);

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Limiters/Test_Weno.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Limiters/Test_Weno.cpp
@@ -460,7 +460,8 @@ void test_neuler_vs_generic_weno_1d() noexcept {
   using Affine = domain::CoordinateMaps::Affine;
   const Affine xi_map{-1., 1., 3.7, 4.2};
   const auto coordmap =
-      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(xi_map);
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+          xi_map);
   const ElementMap<1, Frame::Inertial> element_map(element.id(),
                                                    coordmap->get_clone());
   const auto element_size = size_of_element(element_map);
@@ -542,7 +543,8 @@ void test_neuler_vs_generic_weno_2d() noexcept {
   const Affine eta_map{-1., 1., 3.2, 4.2};
   const Affine2D map2d{xi_map, eta_map};
   const auto coordmap =
-      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(map2d);
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+          map2d);
   const ElementMap<2, Frame::Inertial> element_map(element.id(),
                                                    coordmap->get_clone());
   const auto element_size = size_of_element(element_map);
@@ -619,7 +621,8 @@ void test_neuler_vs_generic_weno_3d() noexcept {
   const Affine zeta_map{-1., 1., 1.3, 2.1};
   const Affine3D map3d{xi_map, eta_map, zeta_map};
   const auto coordmap =
-      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(map3d);
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+          map3d);
   const ElementMap<3, Frame::Inertial> element_map(element.id(),
                                                    coordmap->get_clone());
   const auto element_size = size_of_element(element_map);

--- a/tests/Unit/Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp
+++ b/tests/Unit/Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp
@@ -42,8 +42,8 @@
 template <typename Map>
 bool are_maps_equal(
     const Map& map,
-    const domain::CoordinateMapBase<Frame::Logical, Frame::Inertial, Map::dim>&
-        map_base) noexcept {
+    const domain::CoordinateMapBase<Frame::BlockLogical, Frame::Inertial,
+                                    Map::dim>& map_base) noexcept {
   const auto* map_derived = dynamic_cast<const Map*>(&map_base);
   return map_derived == nullptr ? false : (*map_derived == map);
 }

--- a/tests/Unit/Helpers/Domain/DomainTestHelpers.hpp
+++ b/tests/Unit/Helpers/Domain/DomainTestHelpers.hpp
@@ -54,7 +54,8 @@ void test_domain_construction(
     const std::vector<std::unordered_set<Direction<VolumeDim>>>&
         expected_external_boundaries,
     const std::vector<std::unique_ptr<domain::CoordinateMapBase<
-        Frame::Logical, TargetFrameGridOrInertial, VolumeDim>>>& expected_maps,
+        Frame::BlockLogical, TargetFrameGridOrInertial, VolumeDim>>>&
+        expected_maps,
     double time = std::numeric_limits<double>::quiet_NaN(),
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -987,11 +987,11 @@ void test_impl(const Spectral::Quadrature quadrature,
       }
     }
     blocks[0] = Block<Dim>{
-        domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+        domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             domain::CoordinateMaps::Identity<Dim>{}),
         0, neighbors_block0, std::move(boundary_conditions[0])};
     blocks[1] = Block<Dim>{
-        domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+        domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             domain::CoordinateMaps::Identity<Dim>{}),
         1, neighbors_block1, std::move(boundary_conditions[1])};
     Domain<Dim> domain{std::move(blocks)};
@@ -1183,7 +1183,7 @@ void test_impl(const Spectral::Quadrature quadrature,
          div_mesh_velocity,
          ElementMap<Dim, Frame::Grid>{
              self_id,
-             domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+             domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
                  domain::CoordinateMaps::Identity<Dim>{})},
          false,
          static_cast<std::unique_ptr<StepController>>(
@@ -1216,7 +1216,8 @@ void test_impl(const Spectral::Quadrature quadrature,
              div_mesh_velocity,
              ElementMap<Dim, Frame::Grid>{
                  neighbor_id,
-                 domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+                 domain::make_coordinate_map_base<Frame::BlockLogical,
+                                                  Frame::Grid>(
                      domain::CoordinateMaps::Identity<Dim>{})},
              false,
              static_cast<std::unique_ptr<StepController>>(
@@ -1249,7 +1250,7 @@ void test_impl(const Spectral::Quadrature quadrature,
          div_mesh_velocity,
          ElementMap<Dim, Frame::Grid>{
              self_id,
-             domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+             domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
                  domain::CoordinateMaps::Identity<Dim>{})},
          false,
          static_cast<std::unique_ptr<LtsTimeStepper>>(
@@ -1279,7 +1280,8 @@ void test_impl(const Spectral::Quadrature quadrature,
              div_mesh_velocity,
              ElementMap<Dim, Frame::Grid>{
                  neighbor_id,
-                 domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+                 domain::make_coordinate_map_base<Frame::BlockLogical,
+                                                  Frame::Grid>(
                      domain::CoordinateMaps::Identity<Dim>{})},
              false,
              static_cast<std::unique_ptr<LtsTimeStepper>>(

--- a/tests/Unit/Helpers/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
+++ b/tests/Unit/Helpers/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
@@ -97,7 +97,7 @@ struct MockReceivePoints {
           temporal_id,
       std::vector<std::optional<
           IdPair<domain::BlockId,
-                 tnsr::I<double, VolumeDim, typename Frame::Logical>>>>&&
+                 tnsr::I<double, VolumeDim, typename Frame::BlockLogical>>>>&&
           block_coord_holders) noexcept {
     db::mutate<intrp::Tags::InterpolatedVarsHolders<Metavariables>>(
         make_not_null(&box),

--- a/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/GrMhd/VerifyGrMhdSolution.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/GrMhd/VerifyGrMhdSolution.hpp
@@ -127,7 +127,9 @@ void verify_grmhd_solution(const Solution& solution, const Block<3>& block,
   if (block.is_time_dependent()) {
     ERROR("The block must be time-independent");
   }
-  const auto x = block.stationary_map()(x_logical);
+  const ElementMap<3, Frame::Inertial> element_map{
+      ElementId<3>{0}, block.stationary_map().get_clone()};
+  const auto x = element_map(x_logical);
 
   // Evaluate analytic solution
   using solution_tags = tmpl::list<
@@ -242,7 +244,7 @@ void verify_grmhd_solution(const Solution& solution, const Block<3>& block,
     ERROR("The block must be time-independent");
   }
   const auto div_of_fluxes = divergence<flux_tags, 3, Frame::Inertial>(
-      fluxes, mesh, block.stationary_map().inv_jacobian(x_logical));
+      fluxes, mesh, element_map.inv_jacobian(x_logical));
 
   const auto& div_flux_tilde_d =
       get<Tags::div<Tags::Flux<grmhd::ValenciaDivClean::Tags::TildeD,

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ElementReceiveInterpPoints.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ElementReceiveInterpPoints.cpp
@@ -152,7 +152,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ElementReceivePoints",
 
   using point_info_type = std::vector<std::optional<
       IdPair<domain::BlockId, tnsr::I<double, metavars::volume_dim,
-                                      typename ::Frame::Logical>>>>;
+                                      typename ::Frame::BlockLogical>>>>;
 
   // element should contain an intrp::Tags::InterpPointInfo<Metavariables>
   // that has an empty point_info for InterpolationTargetA and

--- a/tests/Unit/Time/StepChoosers/Test_ElementSizeCfl.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_ElementSizeCfl.cpp
@@ -130,8 +130,9 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.ElementSizeCfl", "[Unit][Time]") {
 
   {
     INFO("Test 1D element size CFL step chooser");
-    auto map = domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
-        domain::CoordinateMaps::Affine(-1.0, 1.0, 0.3, 1.1));
+    auto map =
+        domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
+            domain::CoordinateMaps::Affine(-1.0, 1.0, 0.3, 1.1));
     const ElementId<1> element_id(0, {{{2, 3}}});
     ElementMap<1, Frame::Grid> logical_to_grid_map(element_id, std::move(map));
     CHECK(approx(
@@ -142,8 +143,10 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.ElementSizeCfl", "[Unit][Time]") {
     INFO("Test 2D element size CFL step chooser");
     using Affine = domain::CoordinateMaps::Affine;
     using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
-    auto map = domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
-        Affine2D{Affine(-1.0, 1.0, 0.3, 0.4), Affine(-1.0, 1.0, -0.5, 1.1)});
+    auto map =
+        domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
+            Affine2D{Affine(-1.0, 1.0, 0.3, 0.4),
+                     Affine(-1.0, 1.0, -0.5, 1.1)});
     const ElementId<2> element_id(0, {{{1, 0}, {2, 3}}});
     ElementMap<2, Frame::Grid> logical_to_grid_map(element_id, std::move(map));
     CHECK(approx(
@@ -155,9 +158,10 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.ElementSizeCfl", "[Unit][Time]") {
     using Affine = domain::CoordinateMaps::Affine;
     using Affine3D =
         domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
-    auto map = domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
-        Affine3D{Affine(-1.0, 1.0, 0.3, 0.4), Affine(-1.0, 1.0, -0.5, 1.1),
-                 Affine(-1.0, 1.0, 12.0, 12.4)});
+    auto map =
+        domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
+            Affine3D{Affine(-1.0, 1.0, 0.3, 0.4), Affine(-1.0, 1.0, -0.5, 1.1),
+                     Affine(-1.0, 1.0, 12.0, 12.4)});
     const ElementId<3> element_id(0, {{{2, 3}, {1, 0}, {3, 4}}});
     ElementMap<3, Frame::Grid> logical_to_grid_map(element_id, std::move(map));
     CHECK(approx(


### PR DESCRIPTION
## Proposed changes

We currently use Frame::Logical to denote two different coordinate frames:
- The logical coordinates in an Element which run from [-1,1] in each dimension and is the reference frame in which linear operations such as differentiation is done
-  The logical coordinates in a Block which define the source frame for the coordinate mapping that specifies how the Block is embedded in the Domain.

The two logical frames are related by a simple affine map determined by the location of the Element inside its Block (which is specified by Dim SegementIds).

This PR introduces Frame::BlockLogical and Frame::ElementLogical to distinguish between them.

As a first step, this PR switches the source frame of the CoordinateMap in a Block to use Frame::BlockLogical.  Future PRs will examine each remaining use of Frame::Logical and switch them to the appropriate Frame.  Ultimately, Frame::Logical will be removed.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

- DomainCreators will need to switch the source frame of their CoordinateMaps to use Frame::BlockLogical
- If you use BlockLogicalCoordinates for interpolation, they will need to be defined in Frame::BlockLogical
- If you create a CoordinateMap to construct a Block, it will need to use Frame::BlockLogical as the source frame

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
