### PR TITLE
Revive code coverage reports on CI

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,0 +1,16 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Disable PR comments
+comment: false
+
+coverage:
+  status:
+    # Check that PRs increase overall coverage
+    project:
+      default:
+        target: auto
+    # Check that PRs are fully tested
+    patch:
+      default:
+        target: 100%

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -289,6 +289,11 @@ jobs:
         build_type: [Debug, Release]
         use_pch: [ON]
         include:
+          # Generate code coverage report for a single build
+          - compiler: gcc-10
+            build_type: Debug
+            COVERAGE: ON
+            TEST_TIMEOUT_FACTOR: 3
           # Test with ASAN
           - compiler: clang-8
             build_type: Debug
@@ -406,6 +411,8 @@ ${{ env.CACHE_KEY_SUFFIX }}"
           UBSAN_UNDEFINED=${{ matrix.UBSAN_UNDEFINED }}
           UBSAN_INTEGER=${{ matrix.UBSAN_INTEGER }}
           USE_PCH=${{ matrix.use_pch }}
+          COVERAGE=${{ matrix.COVERAGE }}
+          TEST_TIMEOUT_FACTOR=${{ matrix.TEST_TIMEOUT_FACTOR }}
 
           cmake
           -D CMAKE_C_COMPILER=${CC}
@@ -422,6 +429,7 @@ ${{ env.CACHE_KEY_SUFFIX }}"
           -D STUB_LIBRARY_OBJECT_FILES=ON
           -D USE_PCH=${USE_PCH}
           -D USE_CCACHE=ON
+          -D COVERAGE=${COVERAGE:-'OFF'}
           -D BUILD_PYTHON_BINDINGS=${BUILD_PYTHON_BINDINGS:-'ON'}
           -D Python_EXECUTABLE=${PYTHON_EXECUTABLE:-'/usr/bin/python3'}
           -D BUILD_SHARED_LIBS=${BUILD_SHARED_LIBS:-'ON'}
@@ -429,19 +437,22 @@ ${{ env.CACHE_KEY_SUFFIX }}"
           -D UBSAN_UNDEFINED=${UBSAN_UNDEFINED:-'OFF'}
           -D UBSAN_INTEGER=${UBSAN_INTEGER:-'OFF'}
           -D MEMORY_ALLOCATOR=${MEMORY_ALLOCATOR:-'SYSTEM'}
+          -D SPECTRE_UNIT_TEST_TIMEOUT_FACTOR=${TEST_TIMEOUT_FACTOR:-'1'}
+          -D SPECTRE_INPUT_FILE_TEST_TIMEOUT_FACTOR=${TEST_TIMEOUT_FACTOR:-'1'}
+          -D SPECTRE_PYTHON_TEST_TIMEOUT_FACTOR=${TEST_TIMEOUT_FACTOR:-'1'}
           --warn-uninitialized
           $GITHUB_WORKSPACE 2>&1 | tee CMakeOutput.txt 2>&1
       - name: Check for CMake warnings
         working-directory: /work/build
         run: |
           ! grep -A 6 "CMake Warning" ./CMakeOutput.txt
-      - name: Build tests
+      - name: Build unit tests
         if: matrix.use_pch == 'ON'
         working-directory: /work/build
         run: |
           make -j2 unit-tests
       - name: Run unit tests
-        if: matrix.use_pch == 'ON'
+        if: matrix.use_pch == 'ON' && matrix.COVERAGE != 'ON'
         working-directory: /work/build
         run: |
           # We get occasional random timeouts, repeat tests to see if
@@ -451,6 +462,22 @@ ${{ env.CACHE_KEY_SUFFIX }}"
           # sure that all the unit tests are actually built by the
           # unit-tests target.
           ctest -j2 -L unit --output-on-failure --repeat after-timeout:3
+      - name: Run unit tests with coverage reporting
+        if: matrix.COVERAGE == 'ON'
+        working-directory: /work/build
+        run: |
+          make unit-test-coverage
+      - name: Upload coverage report to codecov.io
+        if: matrix.COVERAGE == 'ON'
+        uses: codecov/codecov-action@v1
+        with:
+          file: /work/build/tmp/coverage.info
+      - name: Upload coverage report to coveralls.io
+        if: matrix.COVERAGE == 'ON'
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: /work/build/tmp/coverage.info
       # Build the executables in a single thread to reduce memory usage
       # sufficiently so they compile on the GitHub-hosted runners
       - name: Build executables

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -9,6 +9,8 @@
 # Modifications:
 # 1) Change "Quinoa" to "SpECTRE" and "quinoa" to "spectre"
 # 2) Split lines to make commands more legible
+# 3) Silence CMake warnings on uninitialized variables in
+#    `cmake_parse_arguments`
 ################################################################################
 
 # ##############################################################################
@@ -57,7 +59,7 @@ function(SETUP_TARGET_FOR_COVERAGE
 
   set(multiValueArgs TESTRUNNER_ARGS DEPENDS IGNORE_COV)
   cmake_parse_arguments(
-      ARG "${options}" "${oneValueArgs}" "${multiValueArgs}"
+      ARG "" "" "${multiValueArgs}"
       ${ARGN})
 
   if(NOT LCOV)

--- a/cmake/CodeCoverageDetection.cmake
+++ b/cmake/CodeCoverageDetection.cmake
@@ -55,7 +55,7 @@ if(COVERAGE AND GCOV AND LCOV AND GENHTML AND SED)
   # Make flag enabling code coverage analysis available in parent cmake scope
   mark_as_advanced(CODE_COVERAGE)
 
-  # Only include code coverage cmake functions if all prerequsites are met
+  # Only include code coverage cmake functions if all prerequisites are met
   include(CodeCoverage)
 elseif(COVERAGE)
   message(FATAL_ERROR "Failed to enable code coverage analysis. Not all "

--- a/cmake/SetupFormaline.cmake
+++ b/cmake/SetupFormaline.cmake
@@ -6,9 +6,9 @@
 # directory that are tracked by Git. I.e.
 #   git ls-tree --full-tree --name-only HEAD
 set(SPECTRE_FORMALINE_LOCATIONS
-  ".clang-format;.clang-tidy;cmake;CMakeLists.txt;containers;docs;external;"
-  ".github;.gitignore;LICENSE.txt;Metadata.yaml;README.md;src;.style.yapf;"
-  "support;tests;tools;.travis;.travis.yml")
+  ".clang-format;.clang-tidy;cmake;CMakeLists.txt;.codecov.yaml;containers;"
+  "docs;external;.github;.gitignore;LICENSE.txt;Metadata.yaml;README.md;src;"
+  ".style.yapf;support;tests;tools;.travis;.travis.yml")
 
 find_package(Git)
 

--- a/tests/Unit/CMakeLists.txt
+++ b/tests/Unit/CMakeLists.txt
@@ -84,12 +84,16 @@ if(COVERAGE)
       ${CMAKE_BINARY_DIR}/docs/html
       unit-test-coverage
       ${CMAKE_CTEST_COMMAND}
-      DEPENDS ${executable}
+      DEPENDS unit-tests
       TESTRUNNER_ARGS
-      "--output-on-failure"
+      -j2 -L unit --output-on-failure --repeat after-timeout:3
       IGNORE_COV
       '${CMAKE_BINARY_DIR}/Informer/InfoAtLink.cpp'
       '${CMAKE_SOURCE_DIR}/tests/*'
+      # The functions in CharmCompatibility.cpp are not intended to be called
+      '${CMAKE_SOURCE_DIR}/src/PythonBindings/CharmCompatibility.cpp'
+      # Ignore generated source files in build directory in coverage reporting
+      '${CMAKE_BINARY_DIR}/*'
   )
 endif()
 


### PR DESCRIPTION
## Proposed changes

Generate coverage reports and upload them to codecov.io and coveralls.io. The coverage generation is actually quite slow (ca. 30min) so we may want to try and speed it up (maybe https://github.com/RPGillespie6/fastcov could help, it's used by https://github.com/quinoacomputing/quinoa now which our coverage cmake config is copied from).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
