### PR TITLE
Update Gh Bjorhus BC to freeze VPlus if char speed becomes negative

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.hpp
@@ -62,9 +62,12 @@ namespace GeneralizedHarmonic::BoundaryConditions {
  * portion of the boundary conditions is designed to prevent the influx of
  * constraint violations from external faces of the evolution domain, by damping
  * them away on a controlled and short time-scale. These conditions are imposed
- * as corrections to the projections of the right-hand-sides of the GH evolution
- * equations (i.e. using Bjorhus' method \cite Bjorhus1995), and are
- * written down in Eq. (63) - (65) of \cite Lindblom2005qh . The gauge degrees
+ * as corrections to the characteristic projections of the right-hand-sides of
+ * the GH evolution equations (i.e. using Bjorhus' method \cite Bjorhus1995),
+ * as written down in Eq. (63) - (65) of \cite Lindblom2005qh . In addition to
+ * these equations, the fourth projection is simply frozen in the unlikely case
+ * its coordinate speed becomes negative, i.e. \f$d_t u^{\hat{1}+}{}_{ab}=0\f$
+ * (in the notation of \cite Lindblom2005qh). The gauge degrees
  * of freedom are controlled by imposing a Sommerfeld-type condition (\f$L=0\f$
  * member of the hierarchy derived in \cite BaylissTurkel) that allow gauge
  * perturbations to pass through the boundary without strong reflections. These
@@ -235,6 +238,8 @@ class ConstraintPreservingBjorhus final : public BoundaryCondition<Dim> {
           char_projected_rhs_dt_v_psi,
       gsl::not_null<tnsr::iaa<DataVector, Dim, Frame::Inertial>*>
           char_projected_rhs_dt_v_zero,
+      gsl::not_null<tnsr::aa<DataVector, Dim, Frame::Inertial>*>
+          char_projected_rhs_dt_v_plus,
       gsl::not_null<tnsr::aa<DataVector, Dim, Frame::Inertial>*>
           char_projected_rhs_dt_v_minus,
       gsl::not_null<tnsr::a<DataVector, Dim, Frame::Inertial>*>

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.py
@@ -270,6 +270,9 @@ def compute_intermediate_vars(
     char_projected_rhs_dt_v_zero = ght.char_field_uzero(
         gamma2, inverse_spatial_metric, dt_spacetime_metric, dt_pi, dt_phi,
         normal_covector)
+    char_projected_rhs_dt_v_plus = ght.char_field_uplus(
+        gamma2, inverse_spatial_metric, dt_spacetime_metric, dt_pi, dt_phi,
+        normal_covector)
     char_projected_rhs_dt_v_minus = ght.char_field_uminus(
         gamma2, inverse_spatial_metric, dt_spacetime_metric, dt_pi, dt_phi,
         normal_covector)
@@ -301,8 +304,9 @@ def compute_intermediate_vars(
             incoming_null_one_form, outgoing_null_one_form,
             incoming_null_vector, outgoing_null_vector, projection_ab,
             projection_Ab, projection_AB, char_projected_rhs_dt_v_psi,
-            char_projected_rhs_dt_v_zero, char_projected_rhs_dt_v_minus,
-            constraint_char_zero_plus, constraint_char_zero_minus, char_speeds)
+            char_projected_rhs_dt_v_zero, char_projected_rhs_dt_v_plus,
+            char_projected_rhs_dt_v_minus, constraint_char_zero_plus,
+            constraint_char_zero_minus, char_speeds)
 
 
 def error(face_mesh_velocity, normal_covector, normal_vector, spacetime_metric,
@@ -317,8 +321,9 @@ def error(face_mesh_velocity, normal_covector, normal_vector, spacetime_metric,
          outgoing_null_one_form, incoming_null_vector, outgoing_null_vector,
          projection_ab, projection_Ab, projection_AB,
          char_projected_rhs_dt_v_psi, char_projected_rhs_dt_v_zero,
-         char_projected_rhs_dt_v_minus, constraint_char_zero_plus,
-         constraint_char_zero_minus, char_speeds) = compute_intermediate_vars(
+         char_projected_rhs_dt_v_plus, char_projected_rhs_dt_v_minus,
+         constraint_char_zero_plus, constraint_char_zero_minus,
+         char_speeds) = compute_intermediate_vars(
              face_mesh_velocity, normal_covector, pi, phi, spacetime_metric,
              coords, gamma1, gamma2, lapse, shift, inverse_spacetime_metric,
              spacetime_unit_normal_vector, spacetime_unit_normal_one_form,
@@ -352,8 +357,8 @@ def dt_corrs_ConstraintPreserving(
      inverse_spatial_metric, extrinsic_curvature, incoming_null_one_form,
      outgoing_null_one_form, incoming_null_vector, outgoing_null_vector,
      projection_ab, projection_Ab, projection_AB, char_projected_rhs_dt_v_psi,
-     char_projected_rhs_dt_v_zero, char_projected_rhs_dt_v_minus,
-     constraint_char_zero_plus,
+     char_projected_rhs_dt_v_zero, char_projected_rhs_dt_v_plus,
+     char_projected_rhs_dt_v_minus, constraint_char_zero_plus,
      constraint_char_zero_minus, char_speeds) = compute_intermediate_vars(
          face_mesh_velocity, normal_covector, pi, phi, spacetime_metric,
          coords, gamma1, gamma2, lapse, shift, inverse_spacetime_metric,
@@ -368,7 +373,7 @@ def dt_corrs_ConstraintPreserving(
         unit_interface_normal_vector, three_index_constraint, char_speeds)
     dt_v_zero = constraint_preserving_bjorhus_corrections_dt_v_zero(
         unit_interface_normal_vector, four_index_constraint, char_speeds)
-    dt_v_plus = dt_v_psi * 0
+    dt_v_plus = -1. * char_projected_rhs_dt_v_plus
     dt_v_minus = constraint_preserving_bjorhus_corrections_dt_v_minus(
         gamma2, coords, incoming_null_one_form, outgoing_null_one_form,
         incoming_null_vector, outgoing_null_vector, projection_ab,
@@ -379,6 +384,8 @@ def dt_corrs_ConstraintPreserving(
         dt_v_psi, char_speeds[0])
     dt_v_zero = set_bc_corr_zero_when_char_speed_is_positive(
         dt_v_zero, char_speeds[1])
+    dt_v_plus = set_bc_corr_zero_when_char_speed_is_positive(
+        dt_v_plus, char_speeds[2])
     dt_v_minus = set_bc_corr_zero_when_char_speed_is_positive(
         dt_v_minus, char_speeds[3])
     return dt_v_psi, dt_v_zero, dt_v_plus, dt_v_minus
@@ -394,8 +401,8 @@ def dt_corrs_ConstraintPreservingPhysical(
      inverse_spatial_metric, extrinsic_curvature, incoming_null_one_form,
      outgoing_null_one_form, incoming_null_vector, outgoing_null_vector,
      projection_ab, projection_Ab, projection_AB, char_projected_rhs_dt_v_psi,
-     char_projected_rhs_dt_v_zero, char_projected_rhs_dt_v_minus,
-     constraint_char_zero_plus,
+     char_projected_rhs_dt_v_zero, char_projected_rhs_dt_v_plus,
+     char_projected_rhs_dt_v_minus, constraint_char_zero_plus,
      constraint_char_zero_minus, char_speeds) = compute_intermediate_vars(
          face_mesh_velocity, normal_covector, pi, phi, spacetime_metric,
          coords, gamma1, gamma2, lapse, shift, inverse_spacetime_metric,
@@ -410,7 +417,7 @@ def dt_corrs_ConstraintPreservingPhysical(
         unit_interface_normal_vector, three_index_constraint, char_speeds)
     dt_v_zero = constraint_preserving_bjorhus_corrections_dt_v_zero(
         unit_interface_normal_vector, four_index_constraint, char_speeds)
-    dt_v_plus = dt_v_psi * 0
+    dt_v_plus = -1. * char_projected_rhs_dt_v_plus
     dt_v_minus = constraint_preserving_physical_bjorhus_corrections_dt_v_minus(
         gamma2, coords, normal_covector, unit_interface_normal_vector,
         spacetime_unit_normal_vector, incoming_null_one_form,
@@ -424,6 +431,8 @@ def dt_corrs_ConstraintPreservingPhysical(
         dt_v_psi, char_speeds[0])
     dt_v_zero = set_bc_corr_zero_when_char_speed_is_positive(
         dt_v_zero, char_speeds[1])
+    dt_v_plus = set_bc_corr_zero_when_char_speed_is_positive(
+        dt_v_plus, char_speeds[2])
     dt_v_minus = set_bc_corr_zero_when_char_speed_is_positive(
         dt_v_minus, char_speeds[3])
     return dt_v_psi, dt_v_zero, dt_v_plus, dt_v_minus


### PR DESCRIPTION
## Proposed changes

This PR updates the Bjorhus BC class to freeze the characteristic field `VPlus` if somehow it is incoming on the outer boundary, [as SpEC does](https://github.com/sxs-collaboration/spec/blob/41454f1ed5be916facbb00ff31a593a215a2e7c5/EvolutionSystems/GeneralizedHarmonic/GeneralizedHarmonicFoshConstraintBcDtU.cpp#L1150). This might happen with large enough mesh velocities at the outer boundary.


### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
