### PR TITLE
Don't cancel repeated CI runs on develop

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -40,10 +40,13 @@ on:
         default: ''
 
 # Cancel all other queued or in-progress runs of this workflow when it is
-# scheduled, so repeated pushes to a branch or a PR don't block CI.
+# scheduled, so repeated pushes to a branch or a PR don't block CI. Repeated
+# pushes to 'develop' and 'release' are not canceled, so every merge commit is
+# tested.
 concurrency:
   group: ${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/develop'
+    && github.ref != 'refs/heads/release' }}
 
 jobs:
   # Make sure no commits are prefixed with `fixup` or similar keywords. See


### PR DESCRIPTION
## Proposed changes

Adjusts the configuration introduced in #3351 to exclude pushes to `develop` and `release`, so every merge commit is tested.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
