### PR TITLE
Add a missing cache flag on CI

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -541,6 +541,9 @@ ${{ env.CACHE_KEY_SUFFIX }}"
           make EvolveBurgersStep -j2
 
           ctest -j2 -R InputFiles.Burgers.Step.yaml
+      - name: Diagnose ccache
+        run: |
+          ccache -s
       # Retain the cache only on the 'develop' branch. We discard caches on
       # other branches so they don't fill up the available storage space. This
       # means that all jobs share the caches from 'develop'.

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -317,6 +317,7 @@ jobs:
           - compiler: clang-9
             build_type: Debug
             use_pch: OFF
+            ccache_max_size: 350M
           # Configure ccache sizes. The cache becomes ineffective if it can't
           # hold at least one full build. The sizes for the build configurations
           # are determined empirically by running the workflow with no cache

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -303,12 +303,11 @@ jobs:
           - compiler: gcc-8
             build_type: Debug
             PYTHON_EXECUTABLE: /usr/bin/python2
-          # Test a single build with shared libs
+          # Test building with static libraries. Do so with clang in release
+          # mode because these builds use up little disk space compared to GCC
+          # builds or clang Debug builds
           - compiler: clang-9
             build_type: Release
-            # Test building with static libraries. Do so with clang in release
-            # mode because these builds use up little disk space compared to GCC
-            # builds or clang Debug builds
             BUILD_SHARED_LIBS: OFF
             MEMORY_ALLOCATOR: JEMALLOC
           # Add a test without PCH to the build matrix, which only builds core


### PR DESCRIPTION
## Proposed changes

In #3366 I missed adding the `ccache_max_size` flag to a build that's added to the matrix by an `include` directive.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
