### PR TITLE
Make Matrix a type alias

### DIFF
--- a/src/DataStructures/Matrix.hpp
+++ b/src/DataStructures/Matrix.hpp
@@ -16,8 +16,4 @@
  * [Blaze documentation](https://bitbucket.org/blaze-lib/blaze/wiki/Matrices)
  * for information on how to use it.
  */
-class Matrix : public DenseMatrix<double, blaze::columnMajor> {
- public:
-  // Inherit constructors
-  using DenseMatrix<double, blaze::columnMajor>::DenseMatrix;
-};
+using Matrix = DenseMatrix<double, blaze::columnMajor>;

--- a/src/Evolution/DgSubcell/Matrices.hpp
+++ b/src/Evolution/DgSubcell/Matrices.hpp
@@ -4,11 +4,12 @@
 
 #include <cstddef>
 
+#include "DataStructures/Matrix.hpp"
+
 /// \cond
 class DataVector;
 template <size_t Dim>
 class Index;
-class Matrix;
 template <size_t Dim>
 class Mesh;
 /// \endcond

--- a/src/Evolution/Systems/Cce/LinearSolve.hpp
+++ b/src/Evolution/Systems/Cce/LinearSolve.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "DataStructures/Matrix.hpp"
 #include "DataStructures/SpinWeighted.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/Cce/OptionTags.hpp"
@@ -11,7 +12,6 @@
 
 /// \cond
 class ComplexDataVector;
-class Matrix;
 /// \endcond
 
 namespace Cce {

--- a/src/IO/H5/Dat.hpp
+++ b/src/IO/H5/Dat.hpp
@@ -13,12 +13,9 @@
 #include <string>
 #include <vector>
 
+#include "DataStructures/Matrix.hpp"
 #include "IO/H5/Object.hpp"
 #include "IO/H5/OpenGroup.hpp"
-
-/// \cond
-class Matrix;
-/// \endcond
 
 namespace h5 {
 /*!

--- a/src/NumericalAlgorithms/LinearAlgebra/FindGeneralizedEigenvalues.hpp
+++ b/src/NumericalAlgorithms/LinearAlgebra/FindGeneralizedEigenvalues.hpp
@@ -6,9 +6,10 @@
 
 #pragma once
 
+#include "DataStructures/Matrix.hpp"
+
 /// \cond
 class DataVector;
-class Matrix;
 namespace gsl {
 template <typename T>
 class not_null;

--- a/src/NumericalAlgorithms/LinearOperators/ExponentialFilter.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/ExponentialFilter.hpp
@@ -7,14 +7,13 @@
 #include <pup.h>
 #include <string>
 
+#include "DataStructures/Matrix.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
-class Matrix;
 template <size_t Dim>
 class Mesh;
-
 /// \endcond
 
 namespace Filters {

--- a/src/NumericalAlgorithms/LinearSolver/Lapack.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Lapack.hpp
@@ -3,11 +3,11 @@
 
 #pragma once
 
+#include "DataStructures/Matrix.hpp"
 #include "Utilities/Gsl.hpp"
 
 /// \cond
 class DataVector;
-class Matrix;
 /// \endcond
 
 /// LAPACK wrappers

--- a/src/NumericalAlgorithms/Spectral/Filtering.hpp
+++ b/src/NumericalAlgorithms/Spectral/Filtering.hpp
@@ -5,8 +5,9 @@
 
 #include <cstddef>
 
+#include "DataStructures/Matrix.hpp"
+
 /// \cond
-class Matrix;
 template <size_t>
 class Mesh;
 /// \endcond

--- a/src/NumericalAlgorithms/Spectral/Projection.hpp
+++ b/src/NumericalAlgorithms/Spectral/Projection.hpp
@@ -8,8 +8,9 @@
 #include <functional>
 #include <ostream>
 
+#include "DataStructures/Matrix.hpp"
+
 /// \cond
-class Matrix;
 template <size_t Dim>
 class Mesh;
 /// \endcond

--- a/src/NumericalAlgorithms/Spectral/Spectral.hpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.hpp
@@ -14,8 +14,9 @@
 #include <limits>
 #include <utility>
 
+#include "DataStructures/Matrix.hpp"
+
 /// \cond
-class Matrix;
 class DataVector;
 template <size_t>
 class Mesh;


### PR DESCRIPTION
## Proposed changes

`Matrix` is just a `DenseMatrix<double, columnMajor`. Making it a type alias instead of a derived class allows using `Matrix` with option parsing (which is implemented for any DenseMatrix), and `DenseMatrix<double, columnMajor>` with `apply_matrices`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
