### PR TITLE
Move QuaternionHelpers definitions to source file

### DIFF
--- a/src/Domain/FunctionsOfTime/CMakeLists.txt
+++ b/src/Domain/FunctionsOfTime/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   FixedSpeedCubic.cpp
   PiecewisePolynomial.cpp
+  QuaternionHelpers.cpp
   ReadSpecPiecewisePolynomial.cpp
   RegisterDerivedWithCharm.cpp
   SettleToConstant.cpp

--- a/src/Domain/FunctionsOfTime/QuaternionHelpers.cpp
+++ b/src/Domain/FunctionsOfTime/QuaternionHelpers.cpp
@@ -1,0 +1,36 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/FunctionsOfTime/QuaternionHelpers.hpp"
+
+#include <boost/math/quaternion.hpp>
+
+#include "DataStructures/DataVector.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+
+DataVector quaternion_to_datavector(
+    const boost::math::quaternion<double>& input) noexcept {
+  return DataVector{input.R_component_1(), input.R_component_2(),
+                    input.R_component_3(), input.R_component_4()};
+}
+
+boost::math::quaternion<double> datavector_to_quaternion(
+    const DataVector& input) noexcept {
+  ASSERT(input.size() == 3 or input.size() == 4,
+         "To form a quaternion, a DataVector can either have 3 or 4 components "
+         "only. This DataVector has "
+             << input.size() << " components.");
+  if (input.size() == 3) {
+    return boost::math::quaternion<double>(0.0, input[0], input[1], input[2]);
+  } else {
+    return boost::math::quaternion<double>(input[0], input[1], input[2],
+                                           input[3]);
+  }
+}
+
+// Normalize a `boost::math::quaternion`
+void normalize_quaternion(
+    const gsl::not_null<boost::math::quaternion<double>*> input) noexcept {
+  *input /= abs(*input);
+}

--- a/src/Domain/FunctionsOfTime/QuaternionHelpers.hpp
+++ b/src/Domain/FunctionsOfTime/QuaternionHelpers.hpp
@@ -10,15 +10,17 @@
 #include <boost/math/quaternion.hpp>
 
 #include "DataStructures/DataVector.hpp"
-#include "Utilities/ErrorHandling/Assert.hpp"
-#include "Utilities/Gsl.hpp"
+
+/// \cond
+namespace gsl {
+template <class T>
+class not_null;
+}  // namespace gsl
+/// \endcond
 
 /// Convert a `boost::math::quaternion` to a `DataVector`
 DataVector quaternion_to_datavector(
-    const boost::math::quaternion<double>& input) noexcept {
-  return DataVector{input.R_component_1(), input.R_component_2(),
-                    input.R_component_3(), input.R_component_4()};
-}
+    const boost::math::quaternion<double>& input) noexcept;
 
 /// \brief Convert a `DataVector` to a `boost::math::quaternion`
 ///
@@ -27,21 +29,8 @@ DataVector quaternion_to_datavector(
 /// 0 scalar part while the vector part is the `DataVector`. If the `DataVector`
 /// has 4 components, the quaternion is just the `DataVector` itself.
 boost::math::quaternion<double> datavector_to_quaternion(
-    const DataVector& input) noexcept {
-  ASSERT(input.size() == 3 or input.size() == 4,
-         "To form a quaternion, a DataVector can either have 3 or 4 components "
-         "only. This DataVector has "
-             << input.size() << " components.");
-  if (input.size() == 3) {
-    return boost::math::quaternion<double>(0.0, input[0], input[1], input[2]);
-  } else {
-    return boost::math::quaternion<double>(input[0], input[1], input[2],
-                                           input[3]);
-  }
-}
+    const DataVector& input) noexcept;
+
 /// Normalize a `boost::math::quaternion`
-template <typename T>
 void normalize_quaternion(
-    const gsl::not_null<boost::math::quaternion<T>*> input) noexcept {
-  *input /= abs(*input);
-}
+    gsl::not_null<boost::math::quaternion<double>*> input) noexcept;


### PR DESCRIPTION
Update to #3310. Having the definitions in the header file caused duplicate symbol linker errors when trying to include QuaternionHelpers in multiple places.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
