### PR TITLE
Add Freezing boundary conditions for Gh

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BoundaryCondition.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BoundaryCondition.hpp
@@ -16,6 +16,8 @@ class ConstraintPreservingBjorhus;
 template <size_t Dim>
 class DirichletAnalytic;
 template <size_t Dim>
+class FreezingBjorhus;
+template <size_t Dim>
 class Outflow;
 }  // namespace GeneralizedHarmonic::BoundaryConditions
 /// \endcond
@@ -28,7 +30,7 @@ class BoundaryCondition : public domain::BoundaryConditions::BoundaryCondition {
  public:
   using creatable_classes =
       tmpl::list<ConstraintPreservingBjorhus<Dim>, DirichletAnalytic<Dim>,
-                 Outflow<Dim>,
+                 FreezingBjorhus<Dim>, Outflow<Dim>,
                  domain::BoundaryConditions::Periodic<BoundaryCondition<Dim>>>;
 
   BoundaryCondition() = default;

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/CMakeLists.txt
@@ -8,6 +8,7 @@ spectre_target_sources(
   BjorhusImpl.cpp
   BoundaryCondition.cpp
   DirichletAnalytic.cpp
+  Freezing.cpp
   Outflow.cpp
   RegisterDerivedWithCharm.cpp
   )
@@ -21,6 +22,7 @@ spectre_target_headers(
   BoundaryCondition.hpp
   DirichletAnalytic.hpp
   Factory.hpp
+  Freezing.hpp
   Outflow.hpp
   RegisterDerivedWithCharm.hpp
   )

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Factory.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Factory.hpp
@@ -6,4 +6,5 @@
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BoundaryCondition.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DirichletAnalytic.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Freezing.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Outflow.hpp"

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Freezing.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Freezing.cpp
@@ -1,0 +1,205 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Freezing.hpp"
+
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/TempBuffer.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Options/ParseOptions.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace GeneralizedHarmonic::BoundaryConditions {
+namespace helpers {
+template <typename T>
+void set_bc_corr_zero_when_char_speed_is_positive(
+    const gsl::not_null<T*> dt_v_corr,
+    const DataVector& char_speed_u) noexcept {
+  for (DataVector& component : *dt_v_corr) {
+    for (size_t i = 0; i < component.size(); ++i) {
+      if (char_speed_u[i] > 0.) {
+        component[i] = 0.;
+      }
+    }
+  }
+}
+}  // namespace helpers
+
+template <size_t Dim>
+FreezingBjorhus<Dim>::FreezingBjorhus(CkMigrateMessage* const msg) noexcept
+    : BoundaryCondition<Dim>(msg) {}
+
+template <size_t Dim>
+std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+FreezingBjorhus<Dim>::get_clone() const noexcept {
+  return std::make_unique<FreezingBjorhus>(*this);
+}
+
+template <size_t Dim>
+void FreezingBjorhus<Dim>::pup(PUP::er& p) {
+  BoundaryCondition<Dim>::pup(p);
+}
+
+template <size_t Dim>
+std::optional<std::string> FreezingBjorhus<Dim>::dg_time_derivative(
+    const gsl::not_null<tnsr::aa<DataVector, Dim, Frame::Inertial>*>
+        dt_spacetime_metric_correction,
+    const gsl::not_null<tnsr::aa<DataVector, Dim, Frame::Inertial>*>
+        dt_pi_correction,
+    const gsl::not_null<tnsr::iaa<DataVector, Dim, Frame::Inertial>*>
+        dt_phi_correction,
+    const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+        face_mesh_velocity,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& /*normal_vector*/,
+    const Scalar<DataVector>& gamma1, const Scalar<DataVector>& gamma2,
+    const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& shift,
+    const tnsr::AA<DataVector, Dim, Frame::Inertial>& inverse_spacetime_metric,
+    const tnsr::aa<DataVector, Dim, Frame::Inertial>& dt_spacetime_metric,
+    const tnsr::aa<DataVector, Dim, Frame::Inertial>& dt_pi,
+    const tnsr::iaa<DataVector, Dim, Frame::Inertial>& dt_phi) const noexcept {
+  TempBuffer<tmpl::list<::Tags::TempScalar<0, DataVector>,
+                        ::Tags::TempII<0, Dim, Frame::Inertial, DataVector>,
+                        ::Tags::Tempaa<0, Dim, Frame::Inertial, DataVector>,
+                        ::Tags::Tempiaa<0, Dim, Frame::Inertial, DataVector>,
+                        ::Tags::Tempaa<1, Dim, Frame::Inertial, DataVector>,
+                        ::Tags::Tempaa<2, Dim, Frame::Inertial, DataVector>,
+                        ::Tags::Tempaa<3, Dim, Frame::Inertial, DataVector>,
+                        ::Tags::Tempiaa<1, Dim, Frame::Inertial, DataVector>,
+                        ::Tags::Tempaa<4, Dim, Frame::Inertial, DataVector>,
+                        ::Tags::Tempaa<5, Dim, Frame::Inertial, DataVector>>>
+      local_buffer(get_size(get<0>(normal_covector)), 0.);
+
+  auto& temp_scalar = get<::Tags::TempScalar<0, DataVector>>(local_buffer);
+  auto& inverse_spatial_metric =
+      get<::Tags::TempII<0, Dim, Frame::Inertial, DataVector>>(local_buffer);
+  auto& char_projected_rhs_dt_v_psi =
+      get<::Tags::Tempaa<0, Dim, Frame::Inertial, DataVector>>(local_buffer);
+  auto& char_projected_rhs_dt_v_zero =
+      get<::Tags::Tempiaa<0, Dim, Frame::Inertial, DataVector>>(local_buffer);
+  auto& char_projected_rhs_dt_v_minus =
+      get<::Tags::Tempaa<1, Dim, Frame::Inertial, DataVector>>(local_buffer);
+  auto& char_projected_rhs_dt_v_plus =
+      get<::Tags::Tempaa<2, Dim, Frame::Inertial, DataVector>>(local_buffer);
+
+  auto& bc_dt_v_psi =
+      get<::Tags::Tempaa<3, Dim, Frame::Inertial, DataVector>>(local_buffer);
+  auto& bc_dt_v_zero =
+      get<::Tags::Tempiaa<1, Dim, Frame::Inertial, DataVector>>(local_buffer);
+  auto& bc_dt_v_plus =
+      get<::Tags::Tempaa<4, Dim, Frame::Inertial, DataVector>>(local_buffer);
+  auto& bc_dt_v_minus =
+      get<::Tags::Tempaa<5, Dim, Frame::Inertial, DataVector>>(local_buffer);
+
+  // Calculate char speeds
+  typename Tags::CharacteristicSpeeds<Dim, Frame::Inertial>::type char_speeds;
+  characteristic_speeds(make_not_null(&char_speeds), gamma1, lapse, shift,
+                        normal_covector);
+
+  // Account for moving mesh: char speeds -> cher speeds - n_i v^i_g
+  if (face_mesh_velocity.has_value()) {
+    get(temp_scalar) = get(dot_product(normal_covector, *face_mesh_velocity));
+    for (size_t a = 0; a < 4; ++a) {
+      char_speeds.at(a) -= get(temp_scalar);
+    }
+  }
+
+  // Initialize with zeros
+  std::fill(dt_spacetime_metric_correction->begin(),
+            dt_spacetime_metric_correction->end(), 0.);
+  std::fill(dt_pi_correction->begin(), dt_pi_correction->end(), 0.);
+  std::fill(dt_phi_correction->begin(), dt_phi_correction->end(), 0.);
+
+  // Calculate char projections of RHS
+  get(temp_scalar) = 1. / (get(lapse) * get(lapse));
+  for (size_t i = 0; i < Dim; ++i) {
+    for (size_t j = i; j < Dim; ++j) {
+      inverse_spatial_metric.get(i, j) =
+          inverse_spacetime_metric.get(1 + i, 1 + j) +
+          (shift.get(i) * shift.get(j) * get(temp_scalar));
+    }
+  }
+  const auto dt_char_fields =
+      characteristic_fields(gamma2, inverse_spatial_metric, dt_spacetime_metric,
+                            dt_pi, dt_phi, normal_covector);
+  char_projected_rhs_dt_v_psi =
+      get<Tags::VSpacetimeMetric<Dim, Frame::Inertial>>(dt_char_fields);
+  char_projected_rhs_dt_v_zero =
+      get<Tags::VZero<Dim, Frame::Inertial>>(dt_char_fields);
+  char_projected_rhs_dt_v_plus =
+      get<Tags::VPlus<Dim, Frame::Inertial>>(dt_char_fields);
+  char_projected_rhs_dt_v_minus =
+      get<Tags::VMinus<Dim, Frame::Inertial>>(dt_char_fields);
+
+  // unconditionally freeze char fields, where needed
+  for (size_t a = 0; a <= Dim; ++a) {
+    for (size_t b = a; b <= Dim; ++b) {
+      bc_dt_v_psi.get(a, b) = -char_projected_rhs_dt_v_psi.get(a, b);
+      bc_dt_v_plus.get(a, b) = -char_projected_rhs_dt_v_plus.get(a, b);
+      bc_dt_v_minus.get(a, b) = -char_projected_rhs_dt_v_minus.get(a, b);
+      for (size_t i = 0; i < Dim; ++i) {
+        bc_dt_v_zero.get(i, a, b) = -char_projected_rhs_dt_v_zero.get(i, a, b);
+      }
+    }
+  }
+
+  // Only add corrections at grid points where the char speeds are negative
+  helpers::set_bc_corr_zero_when_char_speed_is_positive(
+      make_not_null(&bc_dt_v_psi), char_speeds[0]);
+  helpers::set_bc_corr_zero_when_char_speed_is_positive(
+      make_not_null(&bc_dt_v_zero), char_speeds[1]);
+  helpers::set_bc_corr_zero_when_char_speed_is_positive(
+      make_not_null(&bc_dt_v_plus), char_speeds[2]);
+  helpers::set_bc_corr_zero_when_char_speed_is_positive(
+      make_not_null(&bc_dt_v_minus), char_speeds[3]);
+
+  // The boundary conditions here are imposed using Bjorhus' method
+  // see, e.g. Bjorhus.hpp for details
+  auto dt_evolved_vars = evolved_fields_from_characteristic_fields(
+      gamma2, bc_dt_v_psi, bc_dt_v_zero, bc_dt_v_plus, bc_dt_v_minus,
+      normal_covector);
+
+  *dt_pi_correction = get<Tags::Pi<Dim, Frame::Inertial>>(dt_evolved_vars);
+  *dt_phi_correction = get<Tags::Phi<Dim, Frame::Inertial>>(dt_evolved_vars);
+  *dt_spacetime_metric_correction =
+      get<gr::Tags::SpacetimeMetric<Dim, Frame::Inertial, DataVector>>(
+          dt_evolved_vars);
+
+  if (face_mesh_velocity.has_value()) {
+    get(temp_scalar) = get(dot_product(normal_covector, *face_mesh_velocity));
+    // we use 1e-10 instead of 0 below to allow for purely tangentially
+    // moving grids, eg a rotating sphere, with some leeway for
+    // floating-point errors.
+    if (max(get(temp_scalar)) > 1.e-10) {
+      return {
+          "We found the radial mesh velocity points in the direction "
+          "of the outward normal, i.e. we possibly have an expanding "
+          "domain. Its unclear if proper boundary conditions are "
+          "imposed in this case."};
+    }
+  }
+
+  return {};
+}
+
+template <size_t Dim>
+// NOLINTNEXTLINE
+PUP::able::PUP_ID FreezingBjorhus<Dim>::my_PUP_ID = 0;
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data) template class FreezingBjorhus<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+#undef DIM
+}  // namespace GeneralizedHarmonic::BoundaryConditions

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Freezing.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Freezing.hpp
@@ -1,0 +1,113 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <pup.h>
+#include <string>
+#include <type_traits>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/BoundaryConditions/Type.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace GeneralizedHarmonic::BoundaryConditions {
+/*!
+ * \brief Sets freezing boundary conditions using the Bjorhus method.
+ *
+ * \details Bjorhus \cite Bjorhus1995 prescribes imposing boundary conditions,
+ * on external boundaries, as corrections to the characteristic projections of
+ * the right-hand-sides of the evolution equations. In this class we freeze the
+ * characteristic projections by setting their time derivatives to zero,
+ * whenever these projections have incoming speeds on the external boundary.
+ * These corrections to time-derivatives are subsequently projected back to get
+ * corrections to the time-derivatives of the evolved fields \f$\Psi_{ab},
+ * \Pi_{ab}, \Phi_{iab}\f$.
+ */
+template <size_t Dim>
+class FreezingBjorhus final : public BoundaryCondition<Dim> {
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help{
+      "Freezing boundary conditions setting the value of the"
+      "time derivatives of the spacetime metric, Phi and Pi to expressions that"
+      "freeze any incoming characteristic modes."};
+  static std::string name() noexcept { return "FreezingBjorhus"; }
+
+  FreezingBjorhus() = default;
+  /// \cond
+  FreezingBjorhus(FreezingBjorhus&&) noexcept = default;
+  FreezingBjorhus& operator=(FreezingBjorhus&&) noexcept = default;
+  FreezingBjorhus(const FreezingBjorhus&) = default;
+  FreezingBjorhus& operator=(const FreezingBjorhus&) = default;
+  /// \endcond
+  ~FreezingBjorhus() override = default;
+
+  explicit FreezingBjorhus(CkMigrateMessage* msg) noexcept;
+
+  WRAPPED_PUPable_decl_base_template(
+      domain::BoundaryConditions::BoundaryCondition, FreezingBjorhus);
+
+  auto get_clone() const noexcept -> std::unique_ptr<
+      domain::BoundaryConditions::BoundaryCondition> override;
+
+  static constexpr evolution::BoundaryConditions::Type bc_type =
+      evolution::BoundaryConditions::Type::TimeDerivative;
+
+  void pup(PUP::er& p) override;
+
+  using dg_interior_evolved_variables_tags = tmpl::list<>;
+  using dg_interior_temporary_tags = tmpl::list<
+      ConstraintDamping::Tags::ConstraintGamma1,
+      ConstraintDamping::Tags::ConstraintGamma2, gr::Tags::Lapse<DataVector>,
+      gr::Tags::Shift<Dim, Frame::Inertial, DataVector>,
+      gr::Tags::InverseSpacetimeMetric<Dim, Frame::Inertial, DataVector>>;
+  using dg_interior_dt_vars_tags = tmpl::list<
+      ::Tags::dt<gr::Tags::SpacetimeMetric<Dim, Frame::Inertial, DataVector>>,
+      ::Tags::dt<Tags::Pi<Dim, Frame::Inertial>>,
+      ::Tags::dt<Tags::Phi<Dim, Frame::Inertial>>>;
+  using dg_interior_deriv_vars_tags = tmpl::list<>;
+  using dg_gridless_tags = tmpl::list<>;
+
+  std::optional<std::string> dg_time_derivative(
+      gsl::not_null<tnsr::aa<DataVector, Dim, Frame::Inertial>*>
+          dt_spacetime_metric_correction,
+      gsl::not_null<tnsr::aa<DataVector, Dim, Frame::Inertial>*>
+          dt_pi_correction,
+      gsl::not_null<tnsr::iaa<DataVector, Dim, Frame::Inertial>*>
+          dt_phi_correction,
+
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+          face_mesh_velocity,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& /*normal_vector*/,
+      // c.f. dg_interior_evolved_variables_tags
+      // c.f. dg_interior_temporary_tags
+      const Scalar<DataVector>& gamma1, const Scalar<DataVector>& gamma2,
+      const Scalar<DataVector>& lapse,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& shift,
+      const tnsr::AA<DataVector, Dim, Frame::Inertial>&
+          inverse_spacetime_metric,
+      // c.f. dg_interior_dt_vars_tags
+      const tnsr::aa<DataVector, Dim, Frame::Inertial>& dt_spacetime_metric,
+      const tnsr::aa<DataVector, Dim, Frame::Inertial>& dt_pi,
+      const tnsr::iaa<DataVector, Dim, Frame::Inertial>& dt_phi
+      // c.f. dg_interior_deriv_vars_tags
+  ) const noexcept;
+};
+}  // namespace GeneralizedHarmonic::BoundaryConditions

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/RegisterDerivedWithCharm.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/RegisterDerivedWithCharm.cpp
@@ -6,6 +6,7 @@
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BoundaryCondition.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DirichletAnalytic.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Freezing.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Outflow.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Freezing.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Freezing.py
@@ -1,0 +1,111 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+import Evolution.Systems.GeneralizedHarmonic.TestFunctions as ght
+import Evolution.Systems.GeneralizedHarmonic.BoundaryConditions.Bjorhus as bjh
+
+
+def error(face_mesh_velocity, normal_covector, normal_vector, gamma1, gamma2,
+          lapse, shift, inverse_spacetime_metric, dt_spacetime_metric, dt_pi,
+          dt_phi):
+    # get char speeds
+    char_speeds = [
+        ght.char_speed_upsi(gamma1, lapse, shift, normal_covector),
+        ght.char_speed_uzero(gamma1, lapse, shift, normal_covector),
+        ght.char_speed_uplus(gamma1, lapse, shift, normal_covector),
+        ght.char_speed_uminus(gamma1, lapse, shift, normal_covector)
+    ]
+    if face_mesh_velocity is not None:
+        char_speeds = char_speeds - np.dot(normal_covector, face_mesh_velocity)
+        if (np.dot(face_mesh_velocity, normal_covector) > 0.0):
+            return (
+                "We found the radial mesh velocity points in the direction "
+                "of the outward normal, i.e. we possibly have an expanding "
+                "domain. Its unclear if proper boundary conditions are "
+                "imposed in this case.")
+    return None
+
+
+def dt_corrs_Freezing(face_mesh_velocity, normal_covector, normal_vector,
+                      gamma1, gamma2, lapse, shift, inverse_spacetime_metric,
+                      dt_spacetime_metric, dt_pi, dt_phi):
+    # get char speeds
+    char_speeds = [
+        ght.char_speed_upsi(gamma1, lapse, shift, normal_covector),
+        ght.char_speed_uzero(gamma1, lapse, shift, normal_covector),
+        ght.char_speed_uplus(gamma1, lapse, shift, normal_covector),
+        ght.char_speed_uminus(gamma1, lapse, shift, normal_covector)
+    ]
+    if face_mesh_velocity is not None:
+        char_speeds = char_speeds - np.dot(normal_covector, face_mesh_velocity)
+    # get char projections of dt<RHS>
+    inverse_spatial_metric = (inverse_spacetime_metric[1:, 1:] +
+                              (np.einsum('i,j->ij', shift, shift) /
+                               (lapse * lapse)))
+    char_projected_rhs_dt_v_psi = ght.char_field_upsi(gamma2,
+                                                      inverse_spatial_metric,
+                                                      dt_spacetime_metric,
+                                                      dt_pi, dt_phi,
+                                                      normal_covector)
+    char_projected_rhs_dt_v_zero = ght.char_field_uzero(
+        gamma2, inverse_spatial_metric, dt_spacetime_metric, dt_pi, dt_phi,
+        normal_covector)
+    char_projected_rhs_dt_v_plus = ght.char_field_uplus(
+        gamma2, inverse_spatial_metric, dt_spacetime_metric, dt_pi, dt_phi,
+        normal_covector)
+    char_projected_rhs_dt_v_minus = ght.char_field_uminus(
+        gamma2, inverse_spatial_metric, dt_spacetime_metric, dt_pi, dt_phi,
+        normal_covector)
+    # freezing corrections
+    dt_v_psi = -1 * char_projected_rhs_dt_v_psi
+    dt_v_zero = -1 * char_projected_rhs_dt_v_zero
+    dt_v_plus = -1 * char_projected_rhs_dt_v_plus
+    dt_v_minus = -1 * char_projected_rhs_dt_v_minus
+    # set only if incoming
+    dt_v_psi = bjh.set_bc_corr_zero_when_char_speed_is_positive(
+        dt_v_psi, char_speeds[0])
+    dt_v_zero = bjh.set_bc_corr_zero_when_char_speed_is_positive(
+        dt_v_zero, char_speeds[1])
+    dt_v_plus = bjh.set_bc_corr_zero_when_char_speed_is_positive(
+        dt_v_plus, char_speeds[2])
+    dt_v_minus = bjh.set_bc_corr_zero_when_char_speed_is_positive(
+        dt_v_minus, char_speeds[3])
+    return (dt_v_psi, dt_v_zero, dt_v_plus, dt_v_minus)
+
+
+def dt_spacetime_metric_Freezing(face_mesh_velocity, normal_covector,
+                                 normal_vector, gamma1, gamma2, lapse, shift,
+                                 inverse_spacetime_metric, dt_spacetime_metric,
+                                 dt_pi, dt_phi):
+    (dt_v_psi, _, _, _) = dt_corrs_Freezing(face_mesh_velocity,
+                                            normal_covector, normal_vector,
+                                            gamma1, gamma2, lapse, shift,
+                                            inverse_spacetime_metric,
+                                            dt_spacetime_metric, dt_pi, dt_phi)
+    return dt_v_psi
+
+
+def dt_pi_Freezing(face_mesh_velocity, normal_covector, normal_vector, gamma1,
+                   gamma2, lapse, shift, inverse_spacetime_metric,
+                   dt_spacetime_metric, dt_pi, dt_phi):
+    (dt_v_psi, dt_v_zero, dt_v_plus,
+     dt_v_minus) = dt_corrs_Freezing(face_mesh_velocity, normal_covector,
+                                     normal_vector, gamma1, gamma2, lapse,
+                                     shift, inverse_spacetime_metric,
+                                     dt_spacetime_metric, dt_pi, dt_phi)
+    return ght.evol_field_pi(gamma2, dt_v_psi, dt_v_zero, dt_v_plus,
+                             dt_v_minus, normal_covector)
+
+
+def dt_phi_Freezing(face_mesh_velocity, normal_covector, normal_vector, gamma1,
+                    gamma2, lapse, shift, inverse_spacetime_metric,
+                    dt_spacetime_metric, dt_pi, dt_phi):
+    (dt_v_psi, dt_v_zero, dt_v_plus,
+     dt_v_minus) = dt_corrs_Freezing(face_mesh_velocity, normal_covector,
+                                     normal_vector, gamma1, gamma2, lapse,
+                                     shift, inverse_spacetime_metric,
+                                     dt_spacetime_metric, dt_pi, dt_phi)
+    return ght.evol_field_phi(gamma2, dt_v_psi, dt_v_zero, dt_v_plus,
+                              dt_v_minus, normal_covector)

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_Freezing.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_Freezing.cpp
@@ -1,0 +1,74 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Index.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Factory.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Freezing.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/UpwindPenalty.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace helpers = TestHelpers::evolution::dg;
+
+namespace {
+using frame = Frame::Inertial;
+
+template <size_t Dim>
+void test() {
+  CAPTURE(Dim);
+  MAKE_GENERATOR(gen);
+
+  for (const std::string& bc_string : {"Freezing"}) {
+    CAPTURE(bc_string);
+
+    helpers::test_boundary_condition_with_python<
+        GeneralizedHarmonic::BoundaryConditions::FreezingBjorhus<Dim>,
+        GeneralizedHarmonic::BoundaryConditions::BoundaryCondition<Dim>,
+        GeneralizedHarmonic::System<Dim>,
+        tmpl::list<
+            GeneralizedHarmonic::BoundaryCorrections::UpwindPenalty<Dim>>>(
+        make_not_null(&gen),
+        "Evolution.Systems.GeneralizedHarmonic.BoundaryConditions.Freezing",
+        tuples::TaggedTuple<
+            helpers::Tags::PythonFunctionForErrorMessage<>,
+            helpers::Tags::PythonFunctionName<
+                ::Tags::dt<gr::Tags::SpacetimeMetric<Dim, frame, DataVector>>>,
+            helpers::Tags::PythonFunctionName<
+                ::Tags::dt<GeneralizedHarmonic::Tags::Pi<Dim, frame>>>,
+            helpers::Tags::PythonFunctionName<
+                ::Tags::dt<GeneralizedHarmonic::Tags::Phi<Dim, frame>>>>{
+            "error", "dt_spacetime_metric_" + bc_string, "dt_pi_" + bc_string,
+            "dt_phi_" + bc_string},
+        "FreezingBjorhus:\n", Index<Dim - 1>{Dim == 1 ? 1 : 5},
+        db::DataBox<tmpl::list<>>{},
+        tuples::TaggedTuple<
+            helpers::Tags::Range<gr::Tags::Lapse<DataVector>>,
+            helpers::Tags::Range<gr::Tags::Shift<Dim, frame, DataVector>>>{
+            std::array<double, 2>{{0.8, 1.}}, std::array<double, 2>{{0.1, 0.2}}}
+        //,
+        // 1.e-6
+    );
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.BCFreezing",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{""};
+
+  test<1>();
+  test<2>();
+  test<3>();
+}

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBRARY_SOURCES
   BoundaryConditions/Test_Bjorhus.cpp
   BoundaryConditions/Test_BjorhusImpl.cpp
   BoundaryConditions/Test_DirichletAnalytic.cpp
+  BoundaryConditions/Test_Freezing.cpp
   BoundaryConditions/Test_Outflow.cpp
   BoundaryConditions/Test_Periodic.cpp
   BoundaryCorrections/Test_UpwindPenalty.cpp


### PR DESCRIPTION
## Proposed changes

This adds freezing boundary conditions, where the characteristic projections of the RHS of evolution equations are set to 0 if the corresponding characteristic speed indicates an incoming mode.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.