### PR TITLE
Support skipping the preconditioner in elliptic solves

### DIFF
--- a/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
+++ b/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
@@ -48,6 +48,7 @@
 #include "ParallelAlgorithms/EventsAndTriggers/Trigger.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/AddComputeTags.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
+#include "ParallelAlgorithms/LinearSolver/Actions/MakeIdentityIfSkipped.hpp"
 #include "ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp"
 #include "ParallelAlgorithms/LinearSolver/Schwarz/Schwarz.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
@@ -237,13 +238,14 @@ struct Metavariables {
                  typename schwarz_smoother::register_element,
                  Parallel::Actions::TerminatePhase>;
 
-  using solve_actions =
-      tmpl::list<typename linear_solver::template solve<
-                     tmpl::list<Actions::RunEventsAndTriggers,
-                                typename schwarz_smoother::template solve<
-                                    build_linear_operator_actions>>>,
-                 Actions::RunEventsAndTriggers,
-                 Parallel::Actions::TerminatePhase>;
+  using solve_actions = tmpl::list<
+      typename linear_solver::template solve<
+          tmpl::list<Actions::RunEventsAndTriggers,
+                     typename schwarz_smoother::template solve<
+                         build_linear_operator_actions>,
+                     ::LinearSolver::Actions::make_identity_if_skipped<
+                         schwarz_smoother, build_linear_operator_actions>>>,
+      Actions::RunEventsAndTriggers, Parallel::Actions::TerminatePhase>;
 
   using dg_element_array = elliptic::DgElementArray<
       Metavariables,

--- a/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
@@ -43,6 +43,7 @@
 #include "ParallelAlgorithms/EventsAndTriggers/Tags.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Trigger.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
+#include "ParallelAlgorithms/LinearSolver/Actions/MakeIdentityIfSkipped.hpp"
 #include "ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp"
 #include "ParallelAlgorithms/LinearSolver/Schwarz/Schwarz.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
@@ -219,13 +220,14 @@ struct Metavariables {
                  typename schwarz_smoother::register_element,
                  Parallel::Actions::TerminatePhase>;
 
-  using solve_actions =
-      tmpl::list<typename linear_solver::template solve<
-                     tmpl::list<Actions::RunEventsAndTriggers,
-                                typename schwarz_smoother::template solve<
-                                    build_linear_operator_actions>>>,
-                 Actions::RunEventsAndTriggers,
-                 Parallel::Actions::TerminatePhase>;
+  using solve_actions = tmpl::list<
+      typename linear_solver::template solve<
+          tmpl::list<Actions::RunEventsAndTriggers,
+                     typename schwarz_smoother::template solve<
+                         build_linear_operator_actions>,
+                     ::LinearSolver::Actions::make_identity_if_skipped<
+                         schwarz_smoother, build_linear_operator_actions>>>,
+      Actions::RunEventsAndTriggers, Parallel::Actions::TerminatePhase>;
 
   using dg_element_array = elliptic::DgElementArray<
       Metavariables,

--- a/src/Elliptic/Executables/Xcts/SolveXcts.hpp
+++ b/src/Elliptic/Executables/Xcts/SolveXcts.hpp
@@ -42,6 +42,7 @@
 #include "ParallelAlgorithms/EventsAndTriggers/Trigger.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/AddComputeTags.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
+#include "ParallelAlgorithms/LinearSolver/Actions/MakeIdentityIfSkipped.hpp"
 #include "ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp"
 #include "ParallelAlgorithms/LinearSolver/Schwarz/Actions/ResetSubdomainSolver.hpp"
 #include "ParallelAlgorithms/LinearSolver/Schwarz/Schwarz.hpp"
@@ -246,9 +247,11 @@ struct Metavariables {
                          typename schwarz_smoother::options_group>,
                      LinearSolver::Schwarz::Actions::ResetSubdomainSolver<
                          typename schwarz_smoother::options_group>,
-                     typename linear_solver::template solve<
+                     typename linear_solver::template solve<tmpl::list<
                          typename schwarz_smoother::template solve<
-                             build_operator_actions<true>>>>,
+                             build_operator_actions<true>>,
+                         ::LinearSolver::Actions::make_identity_if_skipped<
+                             schwarz_smoother, build_operator_actions<true>>>>>,
           Actions::RunEventsAndTriggers>,
       Parallel::Actions::TerminatePhase>;
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Actions/Test_MakeIdentityIfSkipped.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Actions/Test_MakeIdentityIfSkipped.cpp
@@ -3,6 +3,11 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <cstddef>
+#include <tuple>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DenseVector.hpp"
 #include "Framework/ActionTesting.hpp"
@@ -10,6 +15,7 @@
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/LinearSolver/Actions/MakeIdentityIfSkipped.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -25,13 +31,36 @@ struct SourceTag : db::SimpleTag {
   using type = DenseVector<double>;
 };
 
+struct CheckRunIfSkippedTag : db::SimpleTag {
+  using type = bool;
+};
+
+struct TestLabel {};
+
 struct TestLinearSolver {
   using options_group = TestOptionsGroup;
   using fields_tag = FieldsTag;
   using source_tag = SourceTag;
 };
 
-template <typename Metavariables>
+struct RunIfSkipped {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    db::mutate<CheckRunIfSkippedTag>(
+        make_not_null(&box),
+        [](const gsl::not_null<bool*> flag) { *flag = true; });
+    return {std::move(box)};
+  }
+};
+
+template <typename Metavariables, typename TestActions>
 struct ElementArray {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
@@ -41,31 +70,36 @@ struct ElementArray {
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<
               tmpl::list<Convergence::Tags::HasConverged<TestOptionsGroup>,
-                         FieldsTag, SourceTag>>>>,
+                         FieldsTag, SourceTag, CheckRunIfSkippedTag>>>>,
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Testing,
-          tmpl::list<
-              LinearSolver::Actions::MakeIdentityIfSkipped<TestLinearSolver>,
-              Parallel::Actions::TerminatePhase>>>;
+          tmpl::list<TestActions, Parallel::Actions::TerminatePhase>>>;
 };
 
+template <typename TestActions>
 struct Metavariables {
-  using element_array = ElementArray<Metavariables>;
+  using element_array = ElementArray<Metavariables, TestActions>;
   using component_list = tmpl::list<element_array>;
   enum class Phase { Initialization, Testing, Exit };
 };
 
-void test_make_identity_if_skipped(const bool skipped) {
+template <typename TestActions>
+void test_make_identity_if_skipped(const bool skipped,
+                                   const bool check_run_if_skipped = false) {
   CAPTURE(skipped);
   Convergence::HasConverged has_converged{skipped ? 0_st : 1_st, 0};
-  using element_array = typename Metavariables::element_array;
-  ActionTesting::MockRuntimeSystem<Metavariables> runner{{}};
+  using metavariables = Metavariables<TestActions>;
+  using element_array = typename Metavariables<TestActions>::element_array;
+  ActionTesting::MockRuntimeSystem<metavariables> runner{{}};
   ActionTesting::emplace_component_and_initialize<element_array>(
       make_not_null(&runner), 0,
-      {has_converged, DenseVector<double>{3, 1.}, DenseVector<double>{3, 2.}});
+      {has_converged, DenseVector<double>{3, 1.}, DenseVector<double>{3, 2.},
+       false});
   ActionTesting::set_phase(make_not_null(&runner),
-                           Metavariables::Phase::Testing);
-  ActionTesting::next_action<element_array>(make_not_null(&runner), 0);
+                           metavariables::Phase::Testing);
+  while (not ActionTesting::get_terminate<element_array>(runner, 0)) {
+    ActionTesting::next_action<element_array>(make_not_null(&runner), 0);
+  }
   const auto get_tag = [&runner](auto tag_v) -> decltype(auto) {
     using tag = std::decay_t<decltype(tag_v)>;
     return ActionTesting::get_databox_tag<element_array, tag>(runner, 0);
@@ -73,12 +107,29 @@ void test_make_identity_if_skipped(const bool skipped) {
   CHECK(get_tag(SourceTag{}) == DenseVector<double>{3, 2.});
   CHECK(get_tag(FieldsTag{}) ==
         (skipped ? DenseVector<double>{3, 2.} : DenseVector<double>{3, 1.}));
+  if (check_run_if_skipped) {
+    CHECK(get_tag(CheckRunIfSkippedTag{}) == skipped);
+  }
 }
 
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.ParallelLinearSolver.Actions.MakeIdentityIfSkipped",
                   "[Unit][ParallelAlgorithms][LinearSolver][Actions]") {
-  test_make_identity_if_skipped(false);
-  test_make_identity_if_skipped(true);
+  test_make_identity_if_skipped<
+      LinearSolver::Actions::MakeIdentityIfSkipped<TestLinearSolver>>(false);
+  test_make_identity_if_skipped<
+      LinearSolver::Actions::MakeIdentityIfSkipped<TestLinearSolver>>(true);
+  static_assert(
+      std::is_same_v<
+          LinearSolver::Actions::make_identity_if_skipped<TestLinearSolver>,
+          LinearSolver::Actions::MakeIdentityIfSkipped<TestLinearSolver>>);
+  test_make_identity_if_skipped<LinearSolver::Actions::make_identity_if_skipped<
+      TestLinearSolver, RunIfSkipped>>(false, true);
+  test_make_identity_if_skipped<LinearSolver::Actions::make_identity_if_skipped<
+      TestLinearSolver, RunIfSkipped>>(true, true);
+  test_make_identity_if_skipped<LinearSolver::Actions::make_identity_if_skipped<
+      TestLinearSolver, RunIfSkipped, TestLabel>>(false, true);
+  test_make_identity_if_skipped<LinearSolver::Actions::make_identity_if_skipped<
+      TestLinearSolver, RunIfSkipped, TestLabel>>(true, true);
 }


### PR DESCRIPTION
## Proposed changes

Sometimes it's useful to skip the preconditioner of the parallel linear solver, e.g. to run with no overhead on small test cases or to compare preconditioned vs un-preconditioned solves. With this change, the preconditioner can be disabled by just setting the number of iterations in the input file to zero.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
