### PR TITLE
Fix dimensionality bug in GenerateXdmf script

### DIFF
--- a/src/Visualization/Python/GenerateXdmf.py
+++ b/src/Visualization/Python/GenerateXdmf.py
@@ -214,7 +214,11 @@ def generate_xdmf(file_prefix, output, subfile_name, start_time, stop_time,
                         "AttributeType=\"Vector\" Center=\"Node\">\n" %
                         (vector))
                     xdmf_output += data_item_vec
-                    for index in ["_x", "_y", "_z"]:
+
+                    index_list = ["_x", "_y"]
+                    if dimensionality == 3:
+                        index_list.append("_z")
+                    for index in index_list:
                         xdmf_output += (
                             data_item(h5temporal.get(vector + index).dtype) +
                             Grid_path + "/%s" % (vector) + index + "\n" +


### PR DESCRIPTION
## Proposed changes

Quick fix for `GenerateXdmf.py` script to incorporate 2D volume files.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
