### PR TITLE
Overlay options on restart from checkpoint

### DIFF
--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -171,6 +171,7 @@ struct EvolutionMetavars {
     Initialization,
     LoadBalancing,
     WriteCheckpoint,
+    UpdateOptionsAtRestartFromCheckpoint,
     RegisterWithObserver,
     InitializeTimeStepperHistory,
     Evolve,

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -169,6 +169,7 @@ struct GeneralizedHarmonicDefaults {
     Register,
     LoadBalancing,
     WriteCheckpoint,
+    UpdateOptionsAtRestartFromCheckpoint,
     Evolve,
     Exit
   };

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -249,6 +249,7 @@ struct EvolutionMetavars {
     Register,
     LoadBalancing,
     WriteCheckpoint,
+    UpdateOptionsAtRestartFromCheckpoint,
     Evolve,
     Exit
   };

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -210,6 +210,7 @@ struct EvolutionMetavars {
     RegisterWithObserver,
     LoadBalancing,
     WriteCheckpoint,
+    UpdateOptionsAtRestartFromCheckpoint,
     Evolve,
     Exit
   };

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -196,6 +196,7 @@ struct EvolutionMetavars {
     RegisterWithObserver,
     LoadBalancing,
     WriteCheckpoint,
+    UpdateOptionsAtRestartFromCheckpoint,
     Evolve,
     Exit
   };

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -208,6 +208,7 @@ struct EvolutionMetavars {
     RegisterWithObserver,
     LoadBalancing,
     WriteCheckpoint,
+    UpdateOptionsAtRestartFromCheckpoint,
     Evolve,
     Exit
   };

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -195,6 +195,7 @@ struct EvolutionMetavars {
     InitializeTimeStepperHistory,
     LoadBalancing,
     WriteCheckpoint,
+    UpdateOptionsAtRestartFromCheckpoint,
     Evolve,
     Exit
   };

--- a/src/Parallel/AlgorithmMetafunctions.hpp
+++ b/src/Parallel/AlgorithmMetafunctions.hpp
@@ -164,6 +164,8 @@ CREATE_HAS_STATIC_MEMBER_VARIABLE(LoadBalancing)
 CREATE_HAS_STATIC_MEMBER_VARIABLE_V(LoadBalancing)
 CREATE_HAS_STATIC_MEMBER_VARIABLE(WriteCheckpoint)
 CREATE_HAS_STATIC_MEMBER_VARIABLE_V(WriteCheckpoint)
+CREATE_HAS_STATIC_MEMBER_VARIABLE(UpdateOptionsAtRestartFromCheckpoint)
+CREATE_HAS_STATIC_MEMBER_VARIABLE_V(UpdateOptionsAtRestartFromCheckpoint)
 
 // for checking the DataBox return of an iterable action
 template <typename FirstIterableActionType>

--- a/src/Parallel/GlobalCache.ci
+++ b/src/Parallel/GlobalCache.ci
@@ -32,6 +32,10 @@ module GlobalCache {
         const CkCallback&);
     template <typename GlobalCacheTag, typename Function, typename... Args>
     entry void mutate(std::tuple<Args...> & args);
+
+    entry void overlay_cache_data(
+        tuples::tagged_tuple_from_typelist<
+            Parallel::get_overlayable_option_list<Metavariables>>&);
   }
   }
 }

--- a/src/Parallel/Main.hpp
+++ b/src/Parallel/Main.hpp
@@ -532,11 +532,8 @@ void Main<Metavariables>::pup(PUP::er& p) noexcept {  // NOLINT
   p | at_sync_indicator_proxy_;
   p | input_file_;
   p | parser_;
-  // Note: we do NOT serialize the options.
-  // This is because options are only used in the initialization phase when
-  // the executable first starts up. Thereafter, the information from the
-  // options will be held in various code objects that will themselves be
-  // serialized.
+  // Note: we don't serialize options_, because it's used as a temporary in
+  // startup only (see comment in class definition).
   p | phase_change_decision_data_;
 
   p | checkpoint_dir_counter_;

--- a/src/Parallel/Main.hpp
+++ b/src/Parallel/Main.hpp
@@ -145,6 +145,7 @@ class Main : public CBase_Main<Metavariables> {
   CProxy_MutableGlobalCache<Metavariables> mutable_global_cache_proxy_;
   CProxy_GlobalCache<Metavariables> global_cache_proxy_;
   detail::CProxy_AtSyncIndicator<Metavariables> at_sync_indicator_proxy_;
+  std::string input_file_{};
   Options::Parser<option_list> parser_{Metavariables::help};
   // This is only used during startup, and will be cleared after all
   // the chares are created.  It is a member variable because passing
@@ -334,13 +335,12 @@ Main<Metavariables>::Main(CkArgMsg* msg) noexcept {
       sys::exit();
     }
 
-    std::string input_file;
     if (has_options) {
       if (parsed_command_line_options.count("input-file") == 0) {
         ERROR("No default input file name.  Pass --input-file.");
       }
-      input_file = parsed_command_line_options["input-file"].as<std::string>();
-      parser_.parse_file(input_file);
+      input_file_ = parsed_command_line_options["input-file"].as<std::string>();
+      parser_.parse_file(input_file_);
     } else {
       parser_.parse("");
     }
@@ -351,7 +351,7 @@ Main<Metavariables>::Main(CkArgMsg* msg) noexcept {
         (void)std::initializer_list<char>{((void)args, '0')...};
       });
       if (has_options) {
-        Parallel::printf("\n%s parsed successfully!\n", input_file);
+        Parallel::printf("\n%s parsed successfully!\n", input_file_);
       } else {
         // This is still considered successful, since it means the
         // program would have started.
@@ -524,6 +524,7 @@ void Main<Metavariables>::pup(PUP::er& p) noexcept {  // NOLINT
   p | mutable_global_cache_proxy_;
   p | global_cache_proxy_;
   p | at_sync_indicator_proxy_;
+  p | input_file_;
   p | parser_;
   // Note: we do NOT serialize the options.
   // This is because options are only used in the initialization phase when

--- a/src/Parallel/Main.hpp
+++ b/src/Parallel/Main.hpp
@@ -767,6 +767,7 @@ void contribute_to_phase_change_reduction(
         "reduction.");
   }
 }
+/// @}
 
 template <typename Metavariables>
 std::tuple<std::string, std::string, size_t>
@@ -823,7 +824,6 @@ void Main<Metavariables>::check_future_checkpoint_dirs_available()
   }
 }
 
-/// @}
 }  // namespace Parallel
 
 #define CK_TEMPLATES_ONLY

--- a/src/Parallel/ParallelComponentHelpers.hpp
+++ b/src/Parallel/ParallelComponentHelpers.hpp
@@ -300,11 +300,7 @@ struct is_tag_overlayable : std::false_type {};
 
 template <typename Tag>
 struct is_tag_overlayable<Tag, std::void_t<decltype(Tag::is_overlayable)>>
-    : std::bool_constant<Tag::is_overlayable> {
-  static_assert(tmpl::size<typename Tag::option_tags>::value == 1,
-                "The current implementation can only reparse tags constructed "
-                "from a single option tag.");
-};
+    : std::bool_constant<Tag::is_overlayable> {};
 
 template <typename Tag>
 struct GetUniqueOptionTag {

--- a/src/Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp
+++ b/src/Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp
@@ -106,6 +106,10 @@ struct CheckpointAndExitRequested {
  * the computation to be continued, while minimizing the disc space taken up by
  * checkpoint files.
  *
+ * When restarting from the checkpoint, this phase control sends the control
+ * flow to a UpdateOptionsAtRestartFromCheckpoint phase, allowing the user to
+ * update (some) simulation parameters for the continuation of the run.
+ *
  * Note that this phase control is not a trigger on wallclock time. Rather,
  * it checks the elapsed wallclock time when called, likely from a global sync
  * point triggered by some other mechanism, e.g., at some slab boundary.
@@ -134,6 +138,12 @@ struct CheckpointAndExitAfterWallclock
                     typename Metavariables::Phase>,
                 "Requested to write checkpoints but Metavariables::Phase "
                 "doesn't have a WriteCheckpoint phase");
+  static_assert(
+      Parallel::Algorithm_detail::has_UpdateOptionsAtRestartFromCheckpoint_v<
+          typename Metavariables::Phase>,
+      "CheckpointAndExitAfterWallclock enables updating options on restarts "
+      "but Metavariables::Phase "
+      "doesn't have a UpdateOptionsAtRestartFromCheckpoint phase");
 
   CheckpointAndExitAfterWallclock(const std::optional<double> wallclock_hours,
                                   const Options::Context& context = {})
@@ -238,6 +248,12 @@ struct CheckpointAndExitAfterWallclock
         return std::make_pair(Metavariables::Phase::Exit,
                               ArbitrationStrategy::RunPhaseImmediately);
       } else {
+        // if current_phase is WriteCheckpoint, we follow with updating options
+        if (current_phase == Metavariables::Phase::WriteCheckpoint) {
+          return std::make_pair(
+              Metavariables::Phase::UpdateOptionsAtRestartFromCheckpoint,
+              ArbitrationStrategy::PermitAdditionalJumps);
+        }
         // Reset restart_phase until it is needed for the next checkpoint
         const auto result = restart_phase;
         restart_phase.reset();

--- a/src/ParallelAlgorithms/EventsAndTriggers/Tags.hpp
+++ b/src/ParallelAlgorithms/EventsAndTriggers/Tags.hpp
@@ -51,6 +51,7 @@ namespace Tags {
 struct EventsAndTriggers : db::SimpleTag {
   using type = ::EventsAndTriggers;
   using option_tags = tmpl::list<::OptionTags::EventsAndTriggers>;
+  static constexpr bool is_overlayable = true;
 
   static constexpr bool pass_metavariables = false;
   static type create_from_options(const type& events_and_triggers) noexcept {

--- a/tests/InputFiles/Burgers/Step.overlay000001.yaml
+++ b/tests/InputFiles/Burgers/Step.overlay000001.yaml
@@ -1,0 +1,15 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Executable: EvolveBurgersStep
+# CommandLineArgs: +balancer RandCentLB +p2
+# Timeout: 5
+# Check: parse;execute
+
+EventsAndTriggers:
+  ? Slabs:
+      EvenlySpaced:
+        Interval: 10
+        Offset: 0
+  : - ObserveErrorNorms:
+        SubfileName: Errors

--- a/tests/InputFiles/Burgers/Step.overlay000002.yaml
+++ b/tests/InputFiles/Burgers/Step.overlay000002.yaml
@@ -1,0 +1,15 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Executable: EvolveBurgersStep
+# CommandLineArgs: +balancer RandCentLB +p2
+# Timeout: 5
+# Check: parse;execute
+
+EventsAndTriggers:
+  ? Slabs:
+      EvenlySpaced:
+        Interval: 50
+        Offset: 0
+  : - ObserveErrorNorms:
+        SubfileName: Errors

--- a/tests/InputFiles/Burgers/Step.yaml
+++ b/tests/InputFiles/Burgers/Step.yaml
@@ -14,7 +14,7 @@ AnalyticSolution:
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.001
+  InitialTimeStep: 0.0001
   TimeStepper:
     AdamsBashforthN:
       Order: 3
@@ -24,13 +24,14 @@ PhaseChangeAndTriggers:
         EvenlySpaced:
           Interval: 10
           Offset: 0
-    - - VisitAndReturn(LoadBalancing)
+    - - CheckpointAndExitAfterWallclock:
+          WallclockHours: 0.01667  # 1 min
 
 DomainCreator:
   Interval:
     LowerBound: [-1.0]
     UpperBound: [1.0]
-    InitialRefinement: [2]
+    InitialRefinement: [10]
     InitialGridPoints: [7]
     TimeDependence: None
     BoundaryConditions:
@@ -53,19 +54,17 @@ Limiter:
     DisableForDebugging: false
 
 EventsAndTriggers:
-  ? Always
-  : - ChangeSlabSize:
-        DelayChange: 5
-        StepChoosers:
-          - Cfl:
-              SafetyFactor: 0.5
-          - Increase:
-              Factor: 2.0
+  ? Slabs:
+      EvenlySpaced:
+        Interval: 100
+        Offset: 0
+  : - ObserveErrorNorms:
+        SubfileName: Errors
 
 EventsAndDenseTriggers:
   ? Times:
       Specified:
-        Values: [0.123456]
+        Values: [1.0]
   : - Completion
 
 Observers:


### PR DESCRIPTION
## Proposed changes

Adds support for updating simulation parameters at restarts from checkpoint.

The interface is fairly rigid, but should be sufficient for a first pass:
- Looks for file `OriginalInputFile.overlay000123.yaml` when restarting from checkpoint `000123`.
- Allows certain GlobalCache tags only to be updated

Things I'm not sure about:
- The names of everything. The word "overlay" makes good sense at the file parser level, but not at the user-level when describing the feature "let's update parameters when restarting from checkpoint". I picked some names for the phase and functions but probably they can be improved on.
- The way Charm++ restarts work, the code doesn't know it's restarting from checkpoint vs just continuing as part of a longer run. In other words the phase sequence "WriteCheckpoint -> UpdateOptions -> Evolve" looks the same whether it's happening 10 hours into a run or 0 hours into a run. Right now I've added the reparsing phase into the wallclock-aware phase control, which lets us reparse only when restarting. But if someone writes `VisitAndReturn(WriteCheckpoint), VisitAndReturn(UpdateOptions)` phase control, the code might try to reparse input file every N slabs for example. I don't love it, but maybe this is just how the feature works...

The code isn't totally done: some tests still need to be written. I'm putting in this draft PR so we can start discussing the design, and because I will likely not have time to write the tests in the next few days anyway... In this draft the tests will fail because I've tweaked the Burgers input files to demonstrate how the feature works, but this is not currently in a "good state".

To try the feature yourself:
- compile `EvolveBurgersStep`
- `bin/EvolveBurgersStep ../tests/InputFiles/Burgers/Step.yaml`<- runs for ~1 minute, checkpoints and exits
- `bin/EvolveBurgersStep +restart SpectreCheckpoint000000` <- no overlay file, proceeds without changes
- `bin/EvolveBurgersStep +restart SpectreCheckpoint000001` <- overlay file changes obs frequency
- `bin/EvolveBurgersStep +restart SpectreCheckpoint000002` <- overlay file changes obs frequency again
- continue ad nauseum <- no more overlay files, proceeds without changes

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
