### PR TITLE
Add Krivodonova and Kuzmin analytic solution to ScalarAdvection 

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -1013,6 +1013,19 @@ eprint = {https://doi.org/10.1137/0916035}
   publisher  = "CRC Press"
 }
 
+@article{Kuzmin2014,
+  title    = "Hierarchical slope limiting in explicit and implicit discontinuous
+              Galerkin methods",
+  author   = "Kuzmin, Dmitri",
+  journal  = "Journal of Computational Physics",
+  volume   = "257",
+  pages    = "1140-1162",
+  year     = "2014",
+  issn     = "0021-9991",
+  doi      = "https://doi.org/10.1016/j.jcp.2013.04.032",
+  url      = "https://www.sciencedirect.com/science/article/pii/S0021999113003161",
+}
+
 @article{Lehner2010pn,
   author =       "Lehner, Luis and Pretorius, Frans",
   title =        "{Black Strings, Low Viscosity Fluids, and Violation of Cosmic

--- a/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   Krivodonova.cpp
+  Kuzmin.cpp
   Sinusoid.cpp
   )
 
@@ -17,6 +18,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Krivodonova.hpp
+  Kuzmin.hpp
   Sinusoid.hpp
   Solutions.hpp
   )

--- a/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/CMakeLists.txt
@@ -8,6 +8,7 @@ add_spectre_library(${LIBRARY})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  Krivodonova.cpp
   Sinusoid.cpp
   )
 
@@ -15,6 +16,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  Krivodonova.hpp
   Sinusoid.hpp
   Solutions.hpp
   )

--- a/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Krivodonova.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Krivodonova.cpp
@@ -1,0 +1,105 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Krivodonova.hpp"
+
+#include <cmath>
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace ScalarAdvection::Solutions {
+
+template <typename DataType>
+tuples::TaggedTuple<ScalarAdvection::Tags::U> Krivodonova::variables(
+    const tnsr::I<DataType, 1>& x, double t,
+    tmpl::list<ScalarAdvection::Tags::U> /*meta*/) const noexcept {
+  // map each grid points x(t) back to its initial position within [-1, 1] at
+  // t=0
+  auto x0 = make_with_value<tnsr::I<DataType, 1>>(x, 0.0);
+  get<0>(x0) = get<0>(x) - t;
+  for (size_t i = 0; i < get_size(get<0>(x)); ++i) {
+    auto& xi = get<0>(x0)[i];
+    // Since we are using the periodic boundary condition with the domain
+    // [-1.0, 1.0], we need to do a 'modulo' operation:
+    //
+    //  x - vt = 2.0 * N + x0
+    //
+    // and get the value of x0, where N is an integer and x0 is a real number in
+    // [-1.0, 1.0). Then x0 corresponds to the initial position of the point
+    // (x,t). We use the value of x0 to compute U(x,t) = U(x0,0).
+    xi = xi - 2.0 * floor(0.5 * (xi + 1.0));
+  }
+
+  // parameters for the initial profile (from the Krivodonova paper)
+  const double a{0.5};
+  const double z{-0.7};
+  const double delta{0.005};
+  const double alpha{10.0};
+  const double beta{log(2.0) / (36.0 * square(delta))};
+
+  const auto F = [](const double x_var, const double alpha_var,
+                    const double a_var) noexcept {
+    return sqrt(fmax(1.0 - pow(alpha_var, 2.0) * pow(x_var - a_var, 2.0), 0.0));
+  };
+  const auto G = [](const double x_var, const double beta_var,
+                    const double z_var) noexcept {
+    return exp(-beta_var * pow(x_var - z_var, 2.0));
+  };
+
+  // evaluate U(x,t) = U(x0,0)
+  auto u_variable = make_with_value<Scalar<DataType>>(x0, 0.0);
+  for (size_t i = 0; i < get_size(get<0>(x0)); ++i) {
+    const auto& xi = get<0>(x0)[i];
+    auto& ui = get(u_variable)[i];
+
+    if ((-0.8 <= xi) and (xi <= -0.6)) {
+      ui = (G(xi, beta, z - delta) + G(xi, beta, z + delta) +
+            4.0 * G(xi, beta, z)) /
+           6.0;
+    } else if ((-0.4 <= xi) and (xi <= -0.2)) {
+      ui = 1.0;
+    } else if ((0.0 <= xi) and (xi <= 0.2)) {
+      ui = 1.0 - fabs(10.0 * xi - 1.0);
+    } else if ((0.4 <= xi) and (xi <= 0.6)) {
+      ui = (F(xi, alpha, a - delta) + F(xi, alpha, a + delta) +
+            4.0 * F(xi, alpha, a)) /
+           6.0;
+    } else {
+      ui = 0.0;
+    }
+  }
+  return u_variable;
+}
+
+void Krivodonova::pup(PUP::er& /*p*/) noexcept {}
+
+bool operator==(const Krivodonova& /*lhs*/,
+                const Krivodonova& /*rhs*/) noexcept {
+  return true;
+}
+
+bool operator!=(const Krivodonova& lhs, const Krivodonova& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+}  // namespace ScalarAdvection::Solutions
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                             \
+  template tuples::TaggedTuple<ScalarAdvection::Tags::U> \
+  ScalarAdvection::Solutions::Krivodonova::variables(    \
+      const tnsr::I<DTYPE(data), 1>& x, double t,        \
+      tmpl::list<ScalarAdvection::Tags::U> /*meta*/) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (DataVector))
+
+#undef DTYPE
+#undef INSTANTIATE

--- a/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Krivodonova.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Krivodonova.hpp
@@ -1,0 +1,86 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/ScalarAdvection/Tags.hpp"
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+class DataVector;
+// IWYU pragma: no_forward_declare Tensor
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace ScalarAdvection {
+namespace Solutions {
+/*!
+ * \brief Initial data for the 1D scalar advection problem adopted from
+ * \cite Krivodonova2007 and its analytic solution.
+ *
+ * The initial proﬁle consists of a combination of Gaussians, a square pulse,
+ * a sharp triangle, and a combination of half-ellipses.
+ *
+ * \f{align*}
+ * u(x,t=0) = \left\{\begin{array}{lcl}
+ *  (G(x,\beta,z-\delta) + G(x,\beta,z+\delta) + 4G(x,\beta,z))/6 & \text{if} &
+ *   -0.8 \leq x \leq -0.6 \\
+ *  1 & \text{if} & -0.4 \leq x \leq -0.2 \\
+ *  1 - |10(x-0.1)| & \text{if} & 0 \leq x \leq 0.2 \\
+ *  (F(x,\alpha,a-\delta) + F(x,\alpha,a+\delta) + 4F(x,\alpha,a))/6 & \text{if}
+ *  & 0.4 \leq x \leq 0.6 \\
+ *  0 & \text{otherwise} & \\
+ *  \end{array}\right\},
+ * \f}
+ *
+ * where
+ *
+ * \f{align*}
+ * G(x,\beta, z)  & = e^{-\beta(x-z)^2} \\
+ * F(x,\alpha, a) & = \sqrt{\max(1-\alpha^2(x-a)^2, 0)}
+ * \f}
+ *
+ * with \f$a=0.5, z=-0.7, \delta=0.005, \alpha=10, \text{and }\beta =
+ * \log2/(36\delta^2)\f$.
+ *
+ * The system is evolved over the 1D domain \f$[-1, 1]\f$ with the constant
+ * advection velocity field \f$v(x) = 1.0\f$ and with the periodic boundary
+ * condition. The initial profile is simply advected (translated) to +x
+ * direction, going over cycles in the domain every 2.0 time unit.
+ */
+class Krivodonova : public MarkAsAnalyticSolution {
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help{
+      "An advecting 1D profile adopted from Krivodonova2007 paper, periodic "
+      "over the interval [-1, 1]"};
+
+  Krivodonova() = default;
+  Krivodonova(const Krivodonova&) noexcept = default;
+  Krivodonova& operator=(const Krivodonova&) noexcept = default;
+  Krivodonova(Krivodonova&&) noexcept = default;
+  Krivodonova& operator=(Krivodonova&&) noexcept = default;
+  ~Krivodonova() noexcept = default;
+
+  template <typename DataType>
+  tuples::TaggedTuple<ScalarAdvection::Tags::U> variables(
+      const tnsr::I<DataType, 1>& x, double t,
+      tmpl::list<ScalarAdvection::Tags::U> /*meta*/) const noexcept;
+
+  // clang-tidy: no pass by reference
+  void pup(PUP::er& p) noexcept;  // NOLINT
+};
+
+bool operator==(const Krivodonova& /*lhs*/,
+                const Krivodonova& /*rhs*/) noexcept;
+
+bool operator!=(const Krivodonova& lhs, const Krivodonova& rhs) noexcept;
+
+}  // namespace Solutions
+}  // namespace ScalarAdvection

--- a/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Kuzmin.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Kuzmin.cpp
@@ -1,0 +1,101 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Kuzmin.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <limits>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace ScalarAdvection::Solutions {
+
+template <typename DataType>
+tuples::TaggedTuple<ScalarAdvection::Tags::U> Kuzmin::variables(
+    const tnsr::I<DataType, 2>& x, double t,
+    tmpl::list<ScalarAdvection::Tags::U> /*meta*/) const noexcept {
+  auto coords_init = make_with_value<tnsr::I<DataType, 2>>(x, 0.0);
+  auto& x0 = get<0>(coords_init);
+  auto& y0 = get<1>(coords_init);
+
+  // Map each grid points [x(t),y(t)] back to its initial position at t=0:
+  // applying 2D rotation to translated coordinates, and translate them back.
+  // Note that in this analytic solution, all the regions with nonzero values of
+  // U lies within the circle centered at (0.5, 0.5) with radius 0.5. Therefore
+  // we do not need to take care of a specific boundary condition and it is
+  // sufficient to simply rotate all the coordinates back to t=0.
+  x0 = (get<0>(x) - 0.5) * cos(t) + (get<1>(x) - 0.5) * sin(t) + 0.5;
+  y0 = -(get<0>(x) - 0.5) * sin(t) + (get<1>(x) - 0.5) * cos(t) + 0.5;
+
+  // parameters and functions for the initial profile (from the Kuzmin paper)
+  const double r0{0.15};
+  const auto r_xy = [&r0](const double x_var, const double x0_var,
+                          const double y_var, const double y0_var) noexcept {
+    return sqrt(pow(x_var - x0_var, 2.0) + pow(y_var - y0_var, 2.0)) / r0;
+  };
+
+  double r_cylinder = std::numeric_limits<double>::signaling_NaN();
+  double r_cone = std::numeric_limits<double>::signaling_NaN();
+  double r_hump = std::numeric_limits<double>::signaling_NaN();
+
+  // evaluate u(x,y,t) = u(x0,y0,0)
+  auto u_variable = make_with_value<Scalar<DataType>>(coords_init, 0.0);
+  for (size_t i = 0; i < get_size(get<0>(x)); ++i) {
+    const auto& xi = x0[i];
+    const auto& yi = y0[i];
+    auto& ui = get(u_variable)[i];
+
+    // slotted cylinder centered at (0.5, 0.75)
+    r_cylinder = r_xy(xi, 0.5, yi, 0.75);
+    // cone centered at (0.5, 0.25)
+    r_cone = r_xy(xi, 0.5, yi, 0.25);
+    // hump centered at (0.25, 0.5)
+    r_hump = r_xy(xi, 0.25, yi, 0.5);
+
+    if (r_cylinder <= 1.0) {
+      if ((abs(xi - 0.5) >= 0.025) or (yi >= 0.85)) {
+        ui = 1.0;
+      } else {
+        ui = 0.0;
+      }
+    } else if (r_cone <= 1.0) {
+      ui = 1.0 - r_cone;
+    } else if (r_hump <= 1.0) {
+      ui = 0.25 * (1.0 + cos(M_PI * r_hump));
+    } else {
+      ui = 0.0;
+    }
+  }
+  return u_variable;
+}
+
+void Kuzmin::pup(PUP::er& /*p*/) noexcept {}
+
+bool operator==(const Kuzmin& /*lhs*/, const Kuzmin& /*rhs*/) noexcept {
+  return true;
+}
+
+bool operator!=(const Kuzmin& lhs, const Kuzmin& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+}  // namespace ScalarAdvection::Solutions
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                             \
+  template tuples::TaggedTuple<ScalarAdvection::Tags::U> \
+  ScalarAdvection::Solutions::Kuzmin::variables(         \
+      const tnsr::I<DTYPE(data), 2>& x, double t,        \
+      tmpl::list<ScalarAdvection::Tags::U> /*meta*/) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (DataVector))
+
+#undef DTYPE
+#undef INSTANTIATE

--- a/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Kuzmin.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Kuzmin.hpp
@@ -1,0 +1,81 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/ScalarAdvection/Tags.hpp"
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+class DataVector;
+// IWYU pragma: no_forward_declare Tensor
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace ScalarAdvection {
+namespace Solutions {
+/*!
+ * \brief Initial data for the 2D scalar advection problem adopted from
+ * \cite Kuzmin2014 and its analytic solution.
+ *
+ * Let \f$r(x,y) = \sqrt{(x-x_0)^2 + (y-y_0)^2}/r_0\f$ be the normalized
+ * distance from a point \f$(x_0,y_0)\f$ within a circle with the radius
+ * \f$r_0=0.15\f$. The initial proﬁle consists of three bodies:
+ *
+ * - a slotted cylinder centered at \f$(0.5, 0.75)\f$
+ * \f{align*}
+ * u(x,y) = \left\{\begin{array}{ll}
+ *  1 & \text{if } |x-x_0| \geq 0.025 \text{ or } y \geq 0.85 \\
+ *  0 & \text{otherwise} \\
+ * \end{array}\right\},
+ * \f}
+ *
+ * - a cone centered at \f$(0.5, 0.25)\f$
+ * \f{align*}
+ * u(x,y) = 1 - r(x,y) ,
+ * \f}
+ *
+ * - and a hump centered at \f$(0.25, 0.5)\f$
+ * \f{align*}
+ * u(x,y) = \frac{1 + \cos(\pi r(x,y))}{4} .
+ * \f}
+ *
+ * The system is evolved over the domain \f$[0,1]\times[0,1]\f$ with the
+ * advection velocity field \f$v(x,y) = (0.5-y,-0.5+x)\f$, which causes a solid
+ * rotation about \f$(x,y)=(0.5,0.5)\f$ with angular velocity being 1.0. We use
+ * the periodic boundary condition for evolving this problem.
+ */
+class Kuzmin : public MarkAsAnalyticSolution {
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help{
+      "A rotating 2D scalar advecting problem adopted from Kuzmin2014 paper"};
+
+  Kuzmin() = default;
+  Kuzmin(const Kuzmin&) noexcept = default;
+  Kuzmin& operator=(const Kuzmin&) noexcept = default;
+  Kuzmin(Kuzmin&&) noexcept = default;
+  Kuzmin& operator=(Kuzmin&&) noexcept = default;
+  ~Kuzmin() noexcept = default;
+
+  template <typename DataType>
+  tuples::TaggedTuple<ScalarAdvection::Tags::U> variables(
+      const tnsr::I<DataType, 2>& x, double t,
+      tmpl::list<ScalarAdvection::Tags::U> /*meta*/) const noexcept;
+
+  // clang-tidy: no pass by reference
+  void pup(PUP::er& p) noexcept;  // NOLINT
+};
+
+bool operator==(const Kuzmin& /*lhs*/, const Kuzmin& /*rhs*/) noexcept;
+
+bool operator!=(const Kuzmin& lhs, const Kuzmin& rhs) noexcept;
+
+}  // namespace Solutions
+}  // namespace ScalarAdvection

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_ScalarAdvectionSolutions")
 
 set(LIBRARY_SOURCES
+  Test_Krivodonova.cpp
   Test_Sinusoid.cpp
   )
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_ScalarAdvectionSolutions")
 
 set(LIBRARY_SOURCES
   Test_Krivodonova.cpp
+  Test_Kuzmin.cpp
   Test_Sinusoid.cpp
   )
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Krivodonova.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Krivodonova.py
@@ -1,0 +1,42 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def func_F(x, alpha, a):
+    return np.sqrt(max(1.0 - alpha**2.0 * (x - a)**2.0, 0.0))
+
+
+def func_G(x, beta, z):
+    return np.exp(-beta * (x - z)**2.0)
+
+
+def u_initial(x_grid):
+    a = 0.5
+    z = -0.7
+    delta = 0.005
+    alpha = 10.0
+    beta = np.log(2.0) / (36.0 * delta**2)
+
+    x0 = x_grid[0]
+    if ((-0.8 <= x0) and (x0 <= -0.6)):
+        u = (func_G(x0, beta, z - delta) + func_G(x0, beta, z + delta) +
+             4.0 * func_G(x0, beta, z)) / 6.0
+    elif ((-0.4 <= x0) and (x0 <= -0.2)):
+        u = 1.0
+    elif ((0.0 <= x0) and (x0 <= 0.2)):
+        u = 1.0 - np.abs(10.0 * x0 - 1.0)
+    elif ((0.4 <= x0) and (x0 <= 0.6)):
+        u = (func_F(x0, alpha, a - delta) + func_F(x0, alpha, a + delta) +
+             4.0 * func_F(x0, alpha, a)) / 6.0
+    else:
+        u = 0.0
+
+    return u
+
+
+def u(x, t):
+    xt = x - t
+    x0 = xt - 2. * np.floor((xt + 1.) * 0.5)
+    return u_initial(x0)

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Kuzmin.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Kuzmin.py
@@ -1,0 +1,38 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+r0 = 0.15
+
+
+def r_xy(x, x0, y, y0):
+    return np.sqrt((x - x0)**2.0 + (y - y0)**2.0) / r0
+
+
+def u_initial(x_grid):
+    x, y = x_grid
+
+    r_cylinder = r_xy(x, 0.5, y, 0.75)
+    r_cone = r_xy(x, 0.5, y, 0.25)
+    r_hump = r_xy(x, 0.25, y, 0.5)
+
+    if r_cylinder <= 1.0:
+        if ((np.abs(x - 0.5) >= 0.025) or (y >= 0.85)):
+            u = 1.0
+        else:
+            u = 0.0
+    elif r_cone <= 1.0:
+        u = 1.0 - r_cone
+    elif r_hump <= 1.0:
+        u = 0.25 * (1.0 + np.cos(np.pi * r_hump))
+    else:
+        u = 0.0
+
+    return u
+
+
+def u(x, t):
+    x0 = (x[0] - 0.5) * np.cos(t) + (x[1] - 0.5) * np.sin(t) + 0.5
+    y0 = -(x[0] - 0.5) * np.sin(t) + (x[1] - 0.5) * np.cos(t) + 0.5
+    return u_initial([x0, y0])

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Test_Krivodonova.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Test_Krivodonova.cpp
@@ -1,0 +1,117 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/ScalarAdvection/Tags.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Krivodonova.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+
+void test_create() noexcept {
+  const auto sol =
+      TestHelpers::test_creation<ScalarAdvection::Solutions::Krivodonova>("");
+  CHECK(sol == ScalarAdvection::Solutions::Krivodonova());
+}
+
+void test_serialize() noexcept {
+  ScalarAdvection::Solutions::Krivodonova sol;
+  test_serialization(sol);
+}
+
+void test_move() noexcept {
+  ScalarAdvection::Solutions::Krivodonova sol;
+  ScalarAdvection::Solutions::Krivodonova sol_copy;
+  test_move_semantics(std::move(sol), sol_copy);  //  NOLINT
+}
+
+struct KrivodonovaProxy : ScalarAdvection::Solutions::Krivodonova {
+  using ScalarAdvection::Solutions::Krivodonova::Krivodonova;
+
+  using variables_tags = tmpl::list<ScalarAdvection::Tags::U>;
+
+  template <typename DataType>
+  tuples::tagged_tuple_from_typelist<variables_tags> retrieve_variables(
+      const tnsr::I<DataType, 1>& x, double t) const noexcept {
+    return this->variables(x, t, variables_tags{});
+  }
+};
+
+void verify_solution(const gsl::not_null<std::mt19937*> generator,
+                     const size_t number_of_pts_per_subinterval) {
+  // DataVectors to store values
+  Scalar<DataVector> u_sol{9 * number_of_pts_per_subinterval};
+  Scalar<DataVector> u_test{9 * number_of_pts_per_subinterval};
+
+  // generate random 1D grid points within each of 9 subintervals.
+  // - u = 0        : [-1.0, -0.8], [-0.6, -0.4], [-0.2, 0.0], [0.2, 0.4],
+  //                  [0.6, 1.0]
+  // - Gaussian     : [-0.8, -0.6]
+  // - square pulse : [-0.4, -0.2]
+  // - triangle     : [0.0, 0.2]
+  // - half-ellipse : [0.4, 0.6]
+  // Rather than generating random points for [-1.0, 1.0] without any rules,
+  // patching the random grid points of these subintervals together allows for
+  // this test to always 'hit' every on one of the shapes on the initial data,
+  // which also helps for code coverage checks.
+  std::uniform_real_distribution<> distribution_coords(-1.0, 1.0);
+  auto x = make_with_random_values<tnsr::I<DataVector, 1>>(
+      generator, make_not_null(&distribution_coords),
+      9 * number_of_pts_per_subinterval);
+
+  for (size_t i = 0; i < 9; ++i) {
+    const auto x_sub = make_with_random_values<Scalar<DataVector>>(
+        generator, make_not_null(&distribution_coords),
+        number_of_pts_per_subinterval);
+    if (i < 8) {
+      // first 8 subintervals
+      for (size_t j = 0; j < number_of_pts_per_subinterval; ++j) {
+        get<0>(x)[i * number_of_pts_per_subinterval + j] =
+            0.1 * get(x_sub)[j] - 0.9 + 0.2 * i;
+      }
+    } else {
+      // handling the last subinterval [0.6, 1.0]
+      for (size_t j = 0; j < number_of_pts_per_subinterval; ++j) {
+        get<0>(x)[i * number_of_pts_per_subinterval + j] =
+            0.2 * get(x_sub)[j] + 0.8;
+      }
+    }
+  }
+
+  // generate random time and shift coordinates
+  std::uniform_real_distribution<> distribution_time(0.0, 10.0);
+  double t{make_with_random_values<double>(generator,
+                                           make_not_null(&distribution_time))};
+  get<0>(x) = get<0>(x) + t;
+
+  // test the solution
+  KrivodonovaProxy sol;
+  u_sol = get<ScalarAdvection::Tags::U>(sol.retrieve_variables(x, t));
+  u_test = pypp::call<Scalar<DataVector>>("Krivodonova", "u", x, t);
+  CHECK_ITERABLE_APPROX(u_sol, u_test);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticSolutions.ScalarAdvection.Krivodonova",
+    "[Unit][PointwiseFunctions]") {
+  test_create();
+  test_serialize();
+  test_move();
+
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/AnalyticSolutions/ScalarAdvection"};
+  MAKE_GENERATOR(gen);
+  verify_solution(make_not_null(&gen), 5);
+}

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Test_Kuzmin.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Test_Kuzmin.cpp
@@ -1,0 +1,129 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/ScalarAdvection/Tags.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Kuzmin.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+
+void test_create() noexcept {
+  const auto sol =
+      TestHelpers::test_creation<ScalarAdvection::Solutions::Kuzmin>("");
+  CHECK(sol == ScalarAdvection::Solutions::Kuzmin());
+}
+
+void test_serialize() noexcept {
+  ScalarAdvection::Solutions::Kuzmin sol;
+  test_serialization(sol);
+}
+
+void test_move() noexcept {
+  ScalarAdvection::Solutions::Kuzmin sol;
+  ScalarAdvection::Solutions::Kuzmin sol_copy;
+  test_move_semantics(std::move(sol), sol_copy);  //  NOLINT
+}
+
+struct KuzminProxy : ScalarAdvection::Solutions::Kuzmin {
+  using ScalarAdvection::Solutions::Kuzmin::Kuzmin;
+
+  using variables_tags = tmpl::list<ScalarAdvection::Tags::U>;
+
+  template <typename DataType>
+  tuples::tagged_tuple_from_typelist<variables_tags> retrieve_variables(
+      const tnsr::I<DataType, 2>& x, double t) const noexcept {
+    return this->variables(x, t, variables_tags{});
+  }
+};
+
+void verify_solution(const gsl::not_null<std::mt19937*> generator,
+                     const size_t number_of_pts_per_region) {
+  // we need to distribute random points for 5 different regions (see the for
+  // loop below)
+  const size_t num_pts = 5 * number_of_pts_per_region;
+
+  // DataVectors to store values
+  Scalar<DataVector> u_sol{num_pts};
+  Scalar<DataVector> u_test{num_pts};
+  auto coords_init = make_with_value<tnsr::I<DataVector, 2>>(
+      5 * number_of_pts_per_region, 0.0);
+  auto& x0 = get<0>(coords_init);
+  auto& y0 = get<1>(coords_init);
+
+  // random displacements within a circle of radius 0.15
+  std::uniform_real_distribution<> distribution_radius(0.0, 0.15);
+  std::uniform_real_distribution<> distribution_angle(0.0, 2 * M_PI);
+  const auto radius = make_with_random_values<Scalar<DataVector>>(
+      generator, make_not_null(&distribution_radius), number_of_pts_per_region);
+  const auto angle = make_with_random_values<Scalar<DataVector>>(
+      generator, make_not_null(&distribution_angle), number_of_pts_per_region);
+  auto x_circle =
+      make_with_value<tnsr::I<DataVector, 2>>(number_of_pts_per_region, 0.0);
+  auto& xc = get<0>(x_circle);
+  auto& yc = get<1>(x_circle);
+  xc = get(radius) * cos(get(angle));
+  yc = get(radius) * sin(get(angle));
+
+  // random displacements within a square [0, 1] x [0, 1]
+  std::uniform_real_distribution<> distribution_xy(0.0, 1.0);
+  const auto x_square = make_with_random_values<tnsr::I<DataVector, 2>>(
+      generator, make_not_null(&distribution_xy), number_of_pts_per_region);
+
+  for (size_t i = 0; i < number_of_pts_per_region; ++i) {
+    // a cylinder centered at (0.5, 0.75)
+    x0[i] = xc[i] + 0.5;
+    y0[i] = yc[i] + 0.75;
+    // and the slot inside the cylinder
+    x0[number_of_pts_per_region + i] = 0.05 * get<0>(x_square)[i] + 0.475;
+    y0[number_of_pts_per_region + i] = 0.3 * get<1>(x_square)[i] + 0.6;
+    // cone centered at (0.5, 0.25)
+    x0[2 * number_of_pts_per_region + i] = xc[i] + 0.5;
+    y0[2 * number_of_pts_per_region + i] = yc[i] + 0.25;
+    // hump centered at (0.25, 0.5)
+    x0[3 * number_of_pts_per_region + i] = xc[i] + 0.25;
+    y0[3 * number_of_pts_per_region + i] = yc[i] + 0.5;
+    // other regions with u=0; some of pts may overlap with previous ones
+    x0[4 * number_of_pts_per_region + i] = get<0>(x_square)[i];
+    y0[4 * number_of_pts_per_region + i] = get<1>(x_square)[i];
+  }
+
+  // generate random time and shift coordinates
+  std::uniform_real_distribution<> distribution_time(0.0, 10.0);
+  double t{make_with_random_values<double>(generator,
+                                           make_not_null(&distribution_time))};
+  auto x = make_with_value<tnsr::I<DataVector, 2>>(num_pts, 0.0);
+  get<0>(x) = (x0 - 0.5) * cos(t) - (y0 - 0.5) * sin(t) + 0.5;
+  get<1>(x) = (x0 - 0.5) * sin(t) + (y0 - 0.5) * cos(t) + 0.5;
+
+  // test the solution
+  KuzminProxy sol;
+  u_sol = get<ScalarAdvection::Tags::U>(sol.retrieve_variables(x, t));
+  u_test = pypp::call<Scalar<DataVector>>("Kuzmin", "u", x, t);
+  CHECK_ITERABLE_APPROX(u_sol, u_test);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticSolutions.ScalarAdvection.Kuzmin",
+    "[Unit][PointwiseFunctions]") {
+  test_create();
+  test_serialize();
+  test_move();
+
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/AnalyticSolutions/ScalarAdvection"};
+  MAKE_GENERATOR(gen);
+  verify_solution(make_not_null(&gen), 10);
+}


### PR DESCRIPTION
## Proposed changes

Add [Krivodonova (1D)](https://www.sciencedirect.com/science/article/pii/S0021999107002136?via%3Dihub) and [Kuzmin (2D)](https://www.sciencedirect.com/science/article/pii/S0021999113003161) initial data and analytic solution to ScalarAdvection system.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
