### PR TITLE
Move index reordering higher up in TensorExpression syntax trees

### DIFF
--- a/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
+++ b/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
@@ -16,6 +16,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Expressions/NumberAsExpression.hpp"
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "DataStructures/Tensor/Expressions/TensorIndexTransformation.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/MakeArray.hpp"
@@ -128,14 +129,14 @@ struct AddSubSymmetry<SymmList1<Symm1...>, SymmList2<Symm2...>,
                            TensorIndexList1<TensorIndices1...>,
                            TensorIndexList2<TensorIndices2...>, NumIndices,
                            std::index_sequence<Ints...>> {
-  static constexpr std::array<size_t, NumIndices> lhs_tensorindex_values = {
+  static constexpr std::array<size_t, NumIndices> tensorindex_values1 = {
       {TensorIndices1::value...}};
-  static constexpr std::array<size_t, NumIndices> rhs_tensorindex_values = {
+  static constexpr std::array<size_t, NumIndices> tensorindex_values2 = {
       {TensorIndices2::value...}};
-  static constexpr std::array<size_t, NumIndices> lhs_to_rhs_map = {
+  static constexpr std::array<size_t, NumIndices> op2_to_op1_map = {
       {std::distance(
-          rhs_tensorindex_values.begin(),
-          alg::find(rhs_tensorindex_values, lhs_tensorindex_values[Ints]))...}};
+          tensorindex_values2.begin(),
+          alg::find(tensorindex_values2, tensorindex_values1[Ints]))...}};
 
   static constexpr std::array<std::int32_t, NumIndices> symm1 = {
       {Symm1::value...}};
@@ -145,7 +146,7 @@ struct AddSubSymmetry<SymmList1<Symm1...>, SymmList2<Symm2...>,
   // so that the two symmetry arguments to `get_addsub_symm` are aligned
   // w.r.t. their generic index orders
   static constexpr std::array<std::int32_t, NumIndices> addsub_symm =
-      get_addsub_symm(symm1, {{symm2[lhs_to_rhs_map[Ints]]...}});
+      get_addsub_symm(symm1, {{symm2[op2_to_op1_map[Ints]]...}});
 
   using type = tmpl::integral_list<std::int32_t, addsub_symm[Ints]...>;
 };
@@ -227,19 +228,52 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
   using index_list = typename detail::AddSubType<T1, T2>::index_list;
   static constexpr auto num_tensor_indices = tmpl::size<index_list>::value;
   using args_list = typename T1::args_list;
+  static constexpr std::array<size_t, num_tensor_indices>
+      operand_index_transformation =
+          compute_tensorindex_transformation<num_tensor_indices>(
+              {{Args1::value...}}, {{Args2::value...}});
 
   AddSub(T1 t1, T2 t2) : t1_(std::move(t1)), t2_(std::move(t2)) {}
   ~AddSub() override = default;
 
-  template <typename... LhsIndices>
-  SPECTRE_ALWAYS_INLINE decltype(auto) get(
-      const std::array<size_t, num_tensor_indices>& lhs_multi_index) const {
+  /// \brief Helper function for computing the sum of or difference between
+  /// components at given multi-indices from both operands of the expression
+  ///
+  /// \details Both multi-index arguments must be ordered according to their
+  /// operand's respective generic index ordering
+  ///
+  /// \param op1_multi_index the multi-index of the component of the first
+  /// operand
+  /// \param op2_multi_index the multi-index of the component of the second
+  /// operand
+  /// \return the sum of or difference between the two components' values
+  SPECTRE_ALWAYS_INLINE decltype(auto) add_or_subtract(
+      const std::array<size_t, num_tensor_indices>& op1_multi_index,
+      const std::array<size_t, num_tensor_indices>& op2_multi_index)
+      const noexcept {
     if constexpr (Sign == 1) {
-      return t1_.template get<LhsIndices...>(lhs_multi_index) +
-             t2_.template get<LhsIndices...>(lhs_multi_index);
+      return t1_.get(op1_multi_index) + t2_.get(op2_multi_index);
     } else {
-      return t1_.template get<LhsIndices...>(lhs_multi_index) -
-             t2_.template get<LhsIndices...>(lhs_multi_index);
+      return t1_.get(op1_multi_index) - t2_.get(op2_multi_index);
+    }
+  }
+
+  /// \brief Return the value of the component at the given multi-index of the
+  /// tensor resulting from addition or subtraction
+  ///
+  /// \param result_multi_index the multi-index of the component of the result
+  /// tensor to retrieve
+  /// \return the value of the component at `result_multi_index` in the result
+  /// tensor
+  SPECTRE_ALWAYS_INLINE decltype(auto) get(
+      const std::array<size_t, num_tensor_indices>& result_multi_index) const {
+    if constexpr (std::is_same_v<tmpl::list<Args1...>, tmpl::list<Args2...>>) {
+      return add_or_subtract(result_multi_index, result_multi_index);
+    } else {
+      return add_or_subtract(
+          result_multi_index,
+          transform_multi_index(result_multi_index,
+                                operand_index_transformation));
     }
   }
 

--- a/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
+++ b/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
@@ -243,14 +243,6 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
     }
   }
 
-  SPECTRE_ALWAYS_INLINE typename T1::type operator[](size_t i) const {
-    if constexpr (Sign == 1) {
-      return t1_[i] + t2_[i];
-    } else {
-      return t1_[i] - t2_[i];
-    }
-  }
-
  private:
   T1 t1_;
   T2 t2_;

--- a/src/DataStructures/Tensor/Expressions/Evaluate.hpp
+++ b/src/DataStructures/Tensor/Expressions/Evaluate.hpp
@@ -231,9 +231,7 @@ void evaluate(
                 gsl::at(rhs_spatial_spacetime_index_positions, j)) += 1;
       }
 
-      (*lhs_tensor)[i] =
-          (~rhs_tensorexpression)
-              .template get<RhsTensorIndices...>(rhs_multi_index);
+      (*lhs_tensor)[i] = (~rhs_tensorexpression).get(rhs_multi_index);
 
     } else {
       // either:
@@ -260,9 +258,7 @@ void evaluate(
                   gsl::at(rhs_spatial_spacetime_index_positions, j)) += 1;
         }
 
-        (*lhs_tensor)[i] =
-            (~rhs_tensorexpression)
-                .template get<RhsTensorIndices...>(rhs_multi_index);
+        (*lhs_tensor)[i] = (~rhs_tensorexpression).get(rhs_multi_index);
       }
     }
   }

--- a/src/DataStructures/Tensor/Expressions/NumberAsExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/NumberAsExpression.hpp
@@ -8,7 +8,6 @@
 
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "Utilities/ForceInline.hpp"
-#include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace TensorExpressions {
@@ -30,16 +29,13 @@ struct NumberAsExpression
   ///
   /// \details
   /// While a NumberAsExpression does not store a rank 0 Tensor, it does
-  /// represent one. This is why this template is only defined for the case
-  /// where `TensorIndices` is empty.
+  /// represent one. This is why the multi-index argument is always an array of
+  /// size 0.
   ///
-  /// \tparam TensorIndices the TensorIndexs of the LHS tensor and RHS tensor
-  /// expression
   /// \return the number represented by this expression
-  template <typename... TensorIndices,
-            Requires<sizeof...(TensorIndices) == 0> = nullptr>
   SPECTRE_ALWAYS_INLINE double get(
-      const std::array<size_t, 0>& /*multi_index*/) const noexcept {
+      const std::array<size_t, num_tensor_indices>& /*multi_index*/)
+      const noexcept {
     return number_;
   }
 

--- a/src/DataStructures/Tensor/Expressions/Product.hpp
+++ b/src/DataStructures/Tensor/Expressions/Product.hpp
@@ -8,7 +8,6 @@
 
 #include <array>
 #include <cstddef>
-#include <iterator>
 #include <type_traits>
 #include <utility>
 
@@ -16,7 +15,6 @@
 #include "DataStructures/Tensor/Expressions/NumberAsExpression.hpp"
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/Symmetry.hpp"
-#include "Utilities/Algorithm.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -79,113 +77,47 @@ struct OuterProduct<T1, T2, IndexList1<Indices1...>, IndexList2<Indices2...>,
   using index_list = typename detail::OuterProductType<T1, T2>::index_list;
   using args_list = typename detail::OuterProductType<T1, T2>::tensorindex_list;
   static constexpr auto num_tensor_indices = tmpl::size<index_list>::value;
-  static constexpr auto num_tensor_indices_first_operand =
+  static constexpr auto op1_num_tensor_indices =
       tmpl::size<typename T1::index_list>::value;
-  static constexpr auto num_tensor_indices_second_operand =
-      num_tensor_indices - num_tensor_indices_first_operand;
+  static constexpr auto op2_num_tensor_indices =
+      num_tensor_indices - op1_num_tensor_indices;
 
   OuterProduct(T1 t1, T2 t2) : t1_(std::move(t1)), t2_(std::move(t2)) {}
   ~OuterProduct() override = default;
-
-  /// \ingroup TensorExpressionsGroup
-  /// \brief Helper struct for computing the multi-index of a component of an
-  /// operand of the outer product from the multi-index of a component of the
-  /// outer product
-  ///
-  /// \details
-  /// While `OperandTensorIndexList` will either be the first operand's generic
-  /// indices, `ArgsList1<Args1...>`, or the second operand's generic indices,
-  /// `ArgsList2<Args2...>`, and both of these are accessible within the class,
-  /// this struct wraps the core functionality and is templated with
-  /// `OperandTensorIndexList` so that the functionality can be reused for each
-  /// operand's generic index list.
-  ///
-  /// \tparam OperandTensorIndexList the operand's list of TensorIndexs
-  template <typename OperandTensorIndexList>
-  struct GetOpTensorMultiIndex;
-
-  template <typename... OperandTensorIndices>
-  struct GetOpTensorMultiIndex<tmpl::list<OperandTensorIndices...>> {
-    /// \ingroup TensorExpressionsGroup
-    /// \brief Computes the multi-index of a component of an operand of the
-    /// outer product from the multi-index of a component of the outer product
-    ///
-    /// \details
-    /// Example: Let's say we are evaluating \f$L_abc = R_{b} * S_{ca}\f$. Let
-    /// `ti_a_t` denote the type of `ti_a`, and apply the same convention for
-    /// other generic indices. Let `LhsTensorIndices == ti_a_t, ti_b_t, ti_c_t`,
-    /// and `OperandTensorIndices` is either `ti_b_t` or `ti_c_t, ti_a_t`. Let
-    /// `lhs_tensor_multi_index == [0, 1, 2]`, representing the multi-index of
-    /// the component \f$L_{012}\f$. If
-    /// `OperandTensorIndices == ti_c_t, ti_a_t`, this function will return the
-    /// tensor multi-index representing the component \f$S_{20}\f$, which is
-    /// `[2, 0]`.
-    ///
-    /// \tparam LhsTensorIndices the TensorIndexs of the outer product tensor
-    /// \param lhs_tensor_multi_index the tensor multi-index of a component in
-    /// the outer product tensor
-    /// \return the tensor multi-index of an operand of the outer product
-    template <typename... LhsTensorIndices>
-    static SPECTRE_ALWAYS_INLINE constexpr std::array<
-        size_t, sizeof...(OperandTensorIndices)>
-    apply(
-        const std::array<size_t, num_tensor_indices>& lhs_tensor_multi_index) {
-      constexpr size_t operand_num_tensor_indices =
-          sizeof...(OperandTensorIndices);
-      constexpr std::array<size_t, sizeof...(LhsTensorIndices)>
-          lhs_tensorindex_vals = {{LhsTensorIndices::value...}};
-      constexpr std::array<size_t, operand_num_tensor_indices>
-          operand_tensorindex_vals = {{OperandTensorIndices::value...}};
-
-      // the operand component's tensor multi-index to compute
-      std::array<size_t, operand_num_tensor_indices>
-          operand_tensor_multi_index{};
-      for (size_t i = 0; i < operand_num_tensor_indices; i++) {
-        gsl::at(operand_tensor_multi_index, i) =
-            gsl::at(lhs_tensor_multi_index,
-                    static_cast<size_t>(std::distance(
-                        lhs_tensorindex_vals.begin(),
-                        alg::find(lhs_tensorindex_vals,
-                                  gsl::at(operand_tensorindex_vals, i)))));
-      }
-      return operand_tensor_multi_index;
-    }
-  };
 
   /// \brief Return the value of the component of the outer product tensor at a
   /// given multi-index
   ///
   /// \details
-  /// This function takes the multi-index of some component of the LHS outer
-  /// product to compute. The function first computes the multi-indices of the
-  /// pair of components in the two RHS operand expressions, then multiplies the
-  /// values at these multi-indices to obtain the value of the LHS outer product
-  /// component. For example, say we are evaluating
-  /// \f$L_abc = R_{b} * S_{ca}\f$. Let `lhs_multi_index == {0, 1, 2}`, which
+  /// This function takes the multi-index of some component of the resultant
+  /// outer product to compute. The function first computes the multi-indices of
+  /// the pair of components in the two operand expressions, then multiplies the
+  /// values at these multi-indices to obtain the value of the resultant outer
+  /// product component. For example, say we are evaluating
+  /// \f$L_abc = R_{b} * S_{ca}\f$. Let `result_multi_index == {0, 1, 2}`, which
   /// refers to the component \f$L_{012}\f$, the component we wish to compute.
   /// This function will compute the multi-indices of the operands that
   /// correspond to \f$R_{1}\f$ and \f$S_{20}\f$, retrieve their values, and
   /// return their product.
   ///
-  /// \tparam LhsIndices the TensorIndexs of the outer product tensor
-  /// \param lhs_multi_index the multi-index of the component of the outer
+  /// \param result_multi_index the multi-index of the component of the outer
   /// product tensor to retrieve
-  /// \return the value of the component at `lhs_multi_index` in the outer
+  /// \return the value of the component at `result_multi_index` in the outer
   /// product tensor
-  template <typename... LhsIndices>
   SPECTRE_ALWAYS_INLINE decltype(auto) get(
-      const std::array<size_t, num_tensor_indices>& lhs_multi_index) const {
-    const std::array<size_t, num_tensor_indices_first_operand>
-        first_op_tensor_multi_index =
-            GetOpTensorMultiIndex<ArgsList1<Args1...>>::template apply<
-                LhsIndices...>(lhs_multi_index);
-    const std::array<size_t, num_tensor_indices_second_operand>
-        second_op_tensor_multi_index =
-            GetOpTensorMultiIndex<ArgsList2<Args2...>>::template apply<
-                LhsIndices...>(lhs_multi_index);
+      const std::array<size_t, num_tensor_indices>& result_multi_index) const {
+    std::array<size_t, op1_num_tensor_indices> op1_multi_index{};
+    for (size_t i = 0; i < op1_num_tensor_indices; i++) {
+      gsl::at(op1_multi_index, i) = gsl::at(result_multi_index, i);
+    }
 
-    return t1_.template get<Args1...>(first_op_tensor_multi_index) *
-           t2_.template get<Args2...>(second_op_tensor_multi_index);
+    std::array<size_t, op2_num_tensor_indices> op2_multi_index{};
+    for (size_t i = 0; i < op2_num_tensor_indices; i++) {
+      gsl::at(op2_multi_index, i) =
+          gsl::at(result_multi_index, op1_num_tensor_indices + i);
+    }
+
+    return t1_.get(op1_multi_index) * t2_.get(op2_multi_index);
   }
 
  private:

--- a/src/DataStructures/Tensor/Expressions/SquareRoot.hpp
+++ b/src/DataStructures/Tensor/Expressions/SquareRoot.hpp
@@ -11,7 +11,6 @@
 
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "Utilities/ForceInline.hpp"
-#include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace TensorExpressions {
@@ -41,24 +40,20 @@ struct SquareRoot
   ~SquareRoot() override = default;
 
   /// \brief Returns the square root of the component of the tensor evaluated
-  /// from the RHS tensor expression
+  /// from the contained tensor expression
   ///
   /// \details
   /// SquareRoot only supports tensor expressions that evaluate to a rank 0
-  /// Tensor. This is why this template is only defined for the case where
-  /// `TensorIndices` is empty.
+  /// Tensor. This is why `multi_index` is always an array of size 0.
   ///
-  /// \tparam TensorIndices the TensorIndexs of the LHS tensor and RHS tensor
-  /// expression
   /// \param multi_index the multi-index of the component of which to take the
   /// square root
   /// \return the square root of the component of the tensor evaluated from the
-  /// RHS tensor expression
-  template <typename... TensorIndices,
-            Requires<sizeof...(TensorIndices) == 0> = nullptr>
+  /// contained tensor expression
   SPECTRE_ALWAYS_INLINE decltype(auto) get(
-      const std::array<size_t, 0>& multi_index) const noexcept {
-    return sqrt(t_.template get(multi_index));
+      const std::array<size_t, num_tensor_indices>& multi_index)
+      const noexcept {
+    return sqrt(t_.get(multi_index));
   }
 
  private:

--- a/src/DataStructures/Tensor/Expressions/TensorAsExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorAsExpression.hpp
@@ -11,7 +11,6 @@
 #include <type_traits>
 
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
-#include "DataStructures/Tensor/Expressions/TensorIndexTransformation.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/TMPL.hpp"
@@ -55,36 +54,14 @@ struct TensorAsExpression<Tensor<X, Symm, IndexList<Indices...>>,
       : t_(&t) {}
   ~TensorAsExpression() override = default;
 
-  /// \brief Returns the value of a left hand side tensor's multi-index
+  /// \brief Returns the value of the contained tensor's multi-index
   ///
-  /// \details
-  /// One big challenge with TensorExpression implementation is the reordering
-  /// of the indices on the left hand side (LHS) and right hand side (RHS) of
-  /// the expression. The algorithms implemented in
-  /// `compute_index_transformation` and `compute_rhs_multi_index` handle the
-  /// index sorting by mapping between the generic index orders of the LHS and
-  /// RHS tensors.
-  ///
-  /// \tparam LhsIndices the TensorIndexs of the Tensor on the LHS of the tensor
-  /// expression
-  /// \param lhs_multi_index the multi-index of the LHS tensor component to
-  /// retrieve
-  /// \return the value of the DataType of the component at `lhs_multi_index` in
-  /// the LHS tensor
-  template <typename... LhsIndices>
+  /// \param multi_index the multi-index of the tensor component to retrieve
+  /// \return the value of the component at `multi_index` in the tensor
   SPECTRE_ALWAYS_INLINE decltype(auto) get(
-      const std::array<size_t, num_tensor_indices>& lhs_multi_index)
+      const std::array<size_t, num_tensor_indices>& multi_index)
       const noexcept {
-    if constexpr (std::is_same_v<tmpl::list<LhsIndices...>,
-                                 tmpl::list<Args...>>) {
-      return t_->get(lhs_multi_index);
-    } else {
-      constexpr std::array<size_t, num_tensor_indices> index_transformation =
-          compute_tensorindex_transformation<num_tensor_indices>(
-              {{LhsIndices::value...}}, {{Args::value...}});
-      return t_->get(
-          transform_multi_index(lhs_multi_index, index_transformation));
-    }
+    return t_->get(multi_index);
   }
 
   /// Retrieve the i'th entry of the Tensor being held

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Contract.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Contract.cpp
@@ -34,6 +34,8 @@ void create_tensor(gsl::not_null<Tensor<DataVector, Ts...>*> tensor) noexcept {
   }
 }
 
+const size_t contracted_value_placeholder = std::numeric_limits<size_t>::max();
+
 template <typename DataType>
 void test_contractions_rank2(const DataType& used_for_size) noexcept {
   // Contract (upper, lower) tensor
@@ -46,8 +48,9 @@ void test_contractions_rank2(const DataType& used_for_size) noexcept {
   create_tensor(make_not_null(&Rul));
 
   const auto RIi_expr = Rul(ti_I, ti_i);
-  const std::array<size_t, 2> expected_multi_index{{0, 0}};
-  CHECK(RIi_expr.get_first_uncontracted_lhs_multi_index_to_sum({{}}) ==
+  const std::array<size_t, 2> expected_multi_index{
+      {contracted_value_placeholder, contracted_value_placeholder}};
+  CHECK(RIi_expr.get_uncontracted_multi_index_with_uncontracted_values({{}}) ==
         expected_multi_index);
 
   const Tensor<DataType> RIi_contracted = TensorExpressions::evaluate(RIi_expr);
@@ -66,7 +69,7 @@ void test_contractions_rank2(const DataType& used_for_size) noexcept {
   create_tensor(make_not_null(&Rlu));
 
   const auto RgG_expr = Rlu(ti_g, ti_G);
-  CHECK(RgG_expr.get_first_uncontracted_lhs_multi_index_to_sum({{}}) ==
+  CHECK(RgG_expr.get_uncontracted_multi_index_with_uncontracted_values({{}}) ==
         expected_multi_index);
 
   const Tensor<DataType> RgG_contracted = TensorExpressions::evaluate(RgG_expr);
@@ -96,9 +99,10 @@ void test_contractions_rank3(const DataType& used_for_size) noexcept {
       RiIj_contracted = TensorExpressions::evaluate<ti_j>(RiIj_expr);
 
   for (size_t j = 0; j < 4; j++) {
-    const std::array<size_t, 3> expected_multi_index{{0, 0, j}};
-    CHECK(RiIj_expr.get_first_uncontracted_lhs_multi_index_to_sum({{j}}) ==
-          expected_multi_index);
+    const std::array<size_t, 3> expected_multi_index{
+        {contracted_value_placeholder, contracted_value_placeholder, j}};
+    CHECK(RiIj_expr.get_uncontracted_multi_index_with_uncontracted_values(
+              {{j}}) == expected_multi_index);
 
     DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
     for (size_t i = 0; i < 3; i++) {
@@ -121,9 +125,10 @@ void test_contractions_rank3(const DataType& used_for_size) noexcept {
       RJLj_contracted = TensorExpressions::evaluate<ti_L>(RJLj_expr);
 
   for (size_t l = 0; l < 3; l++) {
-    const std::array<size_t, 3> expected_multi_index{{0, l, 0}};
-    CHECK(RJLj_expr.get_first_uncontracted_lhs_multi_index_to_sum({{l}}) ==
-          expected_multi_index);
+    const std::array<size_t, 3> expected_multi_index{
+        {contracted_value_placeholder, l, contracted_value_placeholder}};
+    CHECK(RJLj_expr.get_uncontracted_multi_index_with_uncontracted_values(
+              {{l}}) == expected_multi_index);
 
     DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
     for (size_t j = 0; j < 3; j++) {
@@ -146,9 +151,10 @@ void test_contractions_rank3(const DataType& used_for_size) noexcept {
       RBfF_contracted = TensorExpressions::evaluate<ti_B>(RBfF_expr);
 
   for (size_t b = 0; b < 4; b++) {
-    const std::array<size_t, 3> expected_multi_index{{b, 0, 0}};
-    CHECK(RBfF_expr.get_first_uncontracted_lhs_multi_index_to_sum({{b}}) ==
-          expected_multi_index);
+    const std::array<size_t, 3> expected_multi_index{
+        {b, contracted_value_placeholder, contracted_value_placeholder}};
+    CHECK(RBfF_expr.get_uncontracted_multi_index_with_uncontracted_values(
+              {{b}}) == expected_multi_index);
 
     DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
     for (size_t f = 0; f < 4; f++) {
@@ -172,9 +178,10 @@ void test_contractions_rank3(const DataType& used_for_size) noexcept {
       RiaI_contracted = TensorExpressions::evaluate<ti_a>(RiaI_expr);
 
   for (size_t a = 0; a < 4; a++) {
-    const std::array<size_t, 3> expected_multi_index{{0, a, 0}};
-    CHECK(RiaI_expr.get_first_uncontracted_lhs_multi_index_to_sum({{a}}) ==
-          expected_multi_index);
+    const std::array<size_t, 3> expected_multi_index{
+        {contracted_value_placeholder, a, contracted_value_placeholder}};
+    CHECK(RiaI_expr.get_uncontracted_multi_index_with_uncontracted_values(
+              {{a}}) == expected_multi_index);
 
     DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
     for (size_t i = 0; i < 3; i++) {
@@ -207,8 +214,9 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
 
   for (size_t k = 0; k < 4; k++) {
     for (size_t j = 0; j < 3; j++) {
-      const std::array<size_t, 4> expected_multi_index{{0, 0, k, j}};
-      CHECK(RiIKj_expr.get_first_uncontracted_lhs_multi_index_to_sum(
+      const std::array<size_t, 4> expected_multi_index{
+          {contracted_value_placeholder, contracted_value_placeholder, k, j}};
+      CHECK(RiIKj_expr.get_uncontracted_multi_index_with_uncontracted_values(
                 {{k, j}}) == expected_multi_index);
 
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
@@ -238,8 +246,9 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
 
   for (size_t b = 0; b < 4; b++) {
     for (size_t c = 0; c < 5; c++) {
-      const std::array<size_t, 4> expected_multi_index{{0, b, 0, c}};
-      CHECK(RABac_expr.get_first_uncontracted_lhs_multi_index_to_sum(
+      const std::array<size_t, 4> expected_multi_index{
+          {contracted_value_placeholder, b, contracted_value_placeholder, c}};
+      CHECK(RABac_expr.get_uncontracted_multi_index_with_uncontracted_values(
                 {{b, c}}) == expected_multi_index);
 
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
@@ -269,8 +278,9 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
 
   for (size_t j = 0; j < 4; j++) {
     for (size_t i = 0; i < 3; i++) {
-      const std::array<size_t, 4> expected_multi_index{{0, j, i, 0}};
-      CHECK(RLJIl_expr.get_first_uncontracted_lhs_multi_index_to_sum(
+      const std::array<size_t, 4> expected_multi_index{
+          {contracted_value_placeholder, j, i, contracted_value_placeholder}};
+      CHECK(RLJIl_expr.get_uncontracted_multi_index_with_uncontracted_values(
                 {{j, i}}) == expected_multi_index);
 
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
@@ -300,8 +310,9 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
 
   for (size_t e = 0; e < 4; e++) {
     for (size_t a = 0; a < 4; a++) {
-      const std::array<size_t, 4> expected_multi_index{{e, 0, 0, a}};
-      CHECK(REDdA_expr.get_first_uncontracted_lhs_multi_index_to_sum(
+      const std::array<size_t, 4> expected_multi_index{
+          {e, contracted_value_placeholder, contracted_value_placeholder, a}};
+      CHECK(REDdA_expr.get_uncontracted_multi_index_with_uncontracted_values(
                 {{e, a}}) == expected_multi_index);
 
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
@@ -331,8 +342,9 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
 
   for (size_t k = 0; k < 3; k++) {
     for (size_t i = 0; i < 4; i++) {
-      const std::array<size_t, 4> expected_multi_index{{k, 0, i, 0}};
-      CHECK(RkJij_expr.get_first_uncontracted_lhs_multi_index_to_sum(
+      const std::array<size_t, 4> expected_multi_index{
+          {k, contracted_value_placeholder, i, contracted_value_placeholder}};
+      CHECK(RkJij_expr.get_uncontracted_multi_index_with_uncontracted_values(
                 {{k, i}}) == expected_multi_index);
 
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
@@ -362,8 +374,9 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
 
   for (size_t f = 0; f < 5; f++) {
     for (size_t c = 0; c < 4; c++) {
-      const std::array<size_t, 4> expected_multi_index{{f, c, 0, 0}};
-      CHECK(RFcgG_expr.get_first_uncontracted_lhs_multi_index_to_sum(
+      const std::array<size_t, 4> expected_multi_index{
+          {f, c, contracted_value_placeholder, contracted_value_placeholder}};
+      CHECK(RFcgG_expr.get_uncontracted_multi_index_with_uncontracted_values(
                 {{f, c}}) == expected_multi_index);
 
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
@@ -393,8 +406,9 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
 
   for (size_t j = 0; j < 2; j++) {
     for (size_t i = 0; i < 3; i++) {
-      const std::array<size_t, 4> expected_multi_index{{0, 0, j, i}};
-      CHECK(RKkIJ_expr.get_first_uncontracted_lhs_multi_index_to_sum(
+      const std::array<size_t, 4> expected_multi_index{
+          {contracted_value_placeholder, contracted_value_placeholder, j, i}};
+      CHECK(RKkIJ_expr.get_uncontracted_multi_index_with_uncontracted_values(
                 {{j, i}}) == expected_multi_index);
 
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
@@ -424,8 +438,9 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
 
   for (size_t e = 0; e < 3; e++) {
     for (size_t c = 0; c < 3; c++) {
-      const std::array<size_t, 4> expected_multi_index{{0, e, 0, c}};
-      CHECK(RbCBE_expr.get_first_uncontracted_lhs_multi_index_to_sum(
+      const std::array<size_t, 4> expected_multi_index{
+          {contracted_value_placeholder, e, contracted_value_placeholder, c}};
+      CHECK(RbCBE_expr.get_uncontracted_multi_index_with_uncontracted_values(
                 {{e, c}}) == expected_multi_index);
 
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
@@ -455,8 +470,9 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
 
   for (size_t b = 0; b < 4; b++) {
     for (size_t d = 0; d < 4; d++) {
-      const std::array<size_t, 4> expected_multi_index{{0, b, d, 0}};
-      CHECK(RAdba_expr.get_first_uncontracted_lhs_multi_index_to_sum(
+      const std::array<size_t, 4> expected_multi_index{
+          {contracted_value_placeholder, b, d, contracted_value_placeholder}};
+      CHECK(RAdba_expr.get_uncontracted_multi_index_with_uncontracted_values(
                 {{b, d}}) == expected_multi_index);
 
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
@@ -486,8 +502,9 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
 
   for (size_t i = 0; i < 4; i++) {
     for (size_t l = 0; l < 3; l++) {
-      const std::array<size_t, 4> expected_multi_index{{i, 0, 0, l}};
-      CHECK(RljJi_expr.get_first_uncontracted_lhs_multi_index_to_sum(
+      const std::array<size_t, 4> expected_multi_index{
+          {i, contracted_value_placeholder, contracted_value_placeholder, l}};
+      CHECK(RljJi_expr.get_uncontracted_multi_index_with_uncontracted_values(
                 {{i, l}}) == expected_multi_index);
 
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
@@ -517,8 +534,9 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
 
   for (size_t d = 0; d < 4; d++) {
     for (size_t a = 0; a < 4; a++) {
-      const std::array<size_t, 4> expected_multi_index{{d, 0, a, 0}};
-      CHECK(RagDG_expr.get_first_uncontracted_lhs_multi_index_to_sum(
+      const std::array<size_t, 4> expected_multi_index{
+          {d, contracted_value_placeholder, a, contracted_value_placeholder}};
+      CHECK(RagDG_expr.get_uncontracted_multi_index_with_uncontracted_values(
                 {{d, a}}) == expected_multi_index);
 
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
@@ -548,8 +566,9 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
 
   for (size_t j = 0; j < 3; j++) {
     for (size_t l = 0; l < 3; l++) {
-      const std::array<size_t, 4> expected_multi_index{{j, l, 0, 0}};
-      CHECK(RlJiI_expr.get_first_uncontracted_lhs_multi_index_to_sum(
+      const std::array<size_t, 4> expected_multi_index{
+          {j, l, contracted_value_placeholder, contracted_value_placeholder}};
+      CHECK(RlJiI_expr.get_uncontracted_multi_index_with_uncontracted_values(
                 {{j, l}}) == expected_multi_index);
 
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
@@ -576,14 +595,16 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
   // indices, representing contracting the 3rd and 4th indices of the rank 4
   // tensor `Rulul` to a rank 2 tensor. The "outer" expression will then
   // contract the K/k indices, representing contracting the rank 2 tensor to
-  // the resulting scalar. This `get_first_uncontracted_lhs_multi_index_to_sum`
-  // test checks this outer contraction of the K/k indices. Because the inner
-  // expression is private, a similar check for it is not done.
+  // the resulting scalar. This
+  // `get_uncontracted_multi_index_with_uncontracted_values` test checks this
+  // outer contraction of the K/k indices. Because the inner expression is
+  // private, a similar check for it is not done.
   //
   // This also applies to similar rank 4 -> rank 0 contraction cases below
-  const std::array<size_t, 2> expected_multi_index{{0, 0}};
-  CHECK(RKkLl_expr.get_first_uncontracted_lhs_multi_index_to_sum({{}}) ==
-        expected_multi_index);
+  const std::array<size_t, 2> expected_multi_index{
+      {contracted_value_placeholder, contracted_value_placeholder}};
+  CHECK(RKkLl_expr.get_uncontracted_multi_index_with_uncontracted_values(
+            {{}}) == expected_multi_index);
 
   const Tensor<DataType> RKkLl_contracted =
       TensorExpressions::evaluate(RKkLl_expr);
@@ -599,8 +620,8 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
   // Contract first and third indices and second and fourth indices to rank 0
   // tensor
   const auto RcaCA_expr = Rlluu(ti_c, ti_a, ti_C, ti_A);
-  CHECK(RcaCA_expr.get_first_uncontracted_lhs_multi_index_to_sum({{}}) ==
-        expected_multi_index);
+  CHECK(RcaCA_expr.get_uncontracted_multi_index_with_uncontracted_values(
+            {{}}) == expected_multi_index);
 
   const Tensor<DataType> RcaCA_contracted =
       TensorExpressions::evaluate(RcaCA_expr);
@@ -616,8 +637,8 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
   // Contract first and fourth indices and second and third indices to rank 0
   // tensor
   const auto RjIiJ_expr = Rlulu(ti_j, ti_I, ti_i, ti_J);
-  CHECK(RjIiJ_expr.get_first_uncontracted_lhs_multi_index_to_sum({{}}) ==
-        expected_multi_index);
+  CHECK(RjIiJ_expr.get_uncontracted_multi_index_with_uncontracted_values(
+            {{}}) == expected_multi_index);
 
   const Tensor<DataType> RjIiJ_contracted =
       TensorExpressions::evaluate(RjIiJ_expr);
@@ -632,144 +653,10 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
 }
 
 template <typename DataType>
-void test_spatial_spacetime_index(const DataType& used_for_size) noexcept {
-  // Contract (spatial, spacetime) tensor
-  // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
-  // return type of `evaluate`
-  Tensor<DataType, Symmetry<2, 1>,
-         index_list<SpatialIndex<3, UpLo::Up, Frame::Inertial>,
-                    SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>
-
-      R(used_for_size);
-  create_tensor(make_not_null(&R));
-  const Tensor<DataType> R_contracted =
-      TensorExpressions::evaluate(R(ti_I, ti_i));
-
-  // Contract (spacetime, spatial) tensor
-  Tensor<DataType, Symmetry<2, 1>,
-         index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
-                    SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>
-      S(used_for_size);
-  create_tensor(make_not_null(&S));
-  const Tensor<DataType> S_contracted =
-      TensorExpressions::evaluate(S(ti_K, ti_k));
-
-  // Contract (spacetime, spacetime) tensor using generic spatial indices
-  Tensor<DataType, Symmetry<2, 1>,
-         index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>
-      T(used_for_size);
-  create_tensor(make_not_null(&T));
-  const Tensor<DataType> T_contracted =
-      TensorExpressions::evaluate(T(ti_j, ti_J));
-
-  DataType expected_R_sum = make_with_value<DataType>(used_for_size, 0.0);
-  DataType expected_S_sum = make_with_value<DataType>(used_for_size, 0.0);
-  DataType expected_T_sum = make_with_value<DataType>(used_for_size, 0.0);
-  for (size_t i = 0; i < 3; i++) {
-    expected_R_sum += R.get(i, i + 1);
-    expected_S_sum += S.get(i + 1, i);
-    expected_T_sum += T.get(i + 1, i + 1);
-  }
-  CHECK_ITERABLE_APPROX(R_contracted.get(), expected_R_sum);
-  CHECK_ITERABLE_APPROX(S_contracted.get(), expected_S_sum);
-  CHECK_ITERABLE_APPROX(T_contracted.get(), expected_T_sum);
-
-  Tensor<DataType, Symmetry<4, 3, 2, 1>,
-         index_list<SpatialIndex<3, UpLo::Up, Frame::Grid>,
-                    SpatialIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>
-      G(used_for_size);
-  create_tensor(make_not_null(&G));
-
-  // Contract one (spatial, spacetime) pair of indices of a tensor that also
-  // takes a generic spatial index for a single non-contracted spacetime index
-  // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
-  // return type of `evaluate`
-  const Tensor<DataType, Symmetry<2, 1>,
-               index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
-                          SpatialIndex<3, UpLo::Up, Frame::Grid>>>
-      G_contracted_1 =
-          TensorExpressions::evaluate<ti_i, ti_K>(G(ti_K, ti_j, ti_i, ti_J));
-
-  for (size_t i = 0; i < 3; i++) {
-    for (size_t k = 0; k < 3; k++) {
-      DataType expected_G_sum_1 = make_with_value<DataType>(used_for_size, 0.0);
-      for (size_t j = 0; j < 3; j++) {
-        expected_G_sum_1 += G.get(k, j, i + 1, j + 1);
-      }
-      CHECK_ITERABLE_APPROX(G_contracted_1.get(i, k), expected_G_sum_1);
-    }
-  }
-
-  // Contract one (spacetime, spacetime) pair of indices using generic spatial
-  // indices and then one (spatial, spatial) pair of indices
-  const Tensor<DataType> G_contracted_2 =
-      TensorExpressions::evaluate(G(ti_I, ti_i, ti_j, ti_J));
-
-  DataType expected_G_sum_2 = make_with_value<DataType>(used_for_size, 0.0);
-  for (size_t i = 0; i < 3; i++) {
-    for (size_t j = 0; j < 3; j++) {
-      expected_G_sum_2 += G.get(i, i, j + 1, j + 1);
-    }
-  }
-  CHECK_ITERABLE_APPROX(G_contracted_2.get(), expected_G_sum_2);
-
-  // Contract two (spatial, spacetime) pairs of indices
-  const Tensor<DataType> G_contracted_3 =
-      TensorExpressions::evaluate(G(ti_I, ti_j, ti_i, ti_J));
-
-  DataType expected_G_sum_3 = make_with_value<DataType>(used_for_size, 0.0);
-  for (size_t i = 0; i < 3; i++) {
-    for (size_t j = 0; j < 3; j++) {
-      expected_G_sum_3 += G.get(i, j, i + 1, j + 1);
-    }
-  }
-  CHECK_ITERABLE_APPROX(G_contracted_3.get(), expected_G_sum_3);
-
-  Tensor<DataType, Symmetry<4, 3, 2, 1>,
-         index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>
-      H(used_for_size);
-  create_tensor(make_not_null(&H));
-
-  // Contract one (spacetime, spacetime) pair of indices using generic spacetime
-  // indices and then one (spacetime, spacetime) pair of indices using generic
-  // spatial indices
-  const Tensor<DataType> H_contracted_1 =
-      TensorExpressions::evaluate(H(ti_i, ti_I, ti_a, ti_A));
-
-  DataType expected_H_sum_1 = make_with_value<DataType>(used_for_size, 0.0);
-  for (size_t i = 0; i < 3; i++) {
-    for (size_t a = 0; a < 4; a++) {
-      expected_H_sum_1 += H.get(i + 1, i + 1, a, a);
-    }
-  }
-  CHECK_ITERABLE_APPROX(H_contracted_1.get(), expected_H_sum_1);
-
-  // Contract two (spacetime, spacetime) pair of indices using generic spatial
-  // indices
-  const Tensor<DataType> H_contracted_2 =
-      TensorExpressions::evaluate(H(ti_j, ti_I, ti_i, ti_J));
-
-  DataType expected_H_sum_2 = make_with_value<DataType>(used_for_size, 0.0);
-  for (size_t j = 0; j < 3; j++) {
-    for (size_t i = 0; i < 3; i++) {
-      expected_H_sum_2 += H.get(j + 1, i + 1, i + 1, j + 1);
-    }
-  }
-  CHECK_ITERABLE_APPROX(H_contracted_2.get(), expected_H_sum_2);
-}
-
-template <typename DataType>
 void test_contractions(const DataType& used_for_size) noexcept {
   test_contractions_rank2(used_for_size);
   test_contractions_rank3(used_for_size);
   test_contractions_rank4(used_for_size);
-  test_spatial_spacetime_index(used_for_size);
 }
 }  // namespace
 


### PR DESCRIPTION
## Proposed changes

With `TensorExpression`s, multi-index reordering is necessary to evaluate expressions such as `L_cab = R_abc + S_bca`.

This PR moves index reorderings in `TensorExpression`s to be higher up in their syntax trees so that less index orderings are done, overall. Currently, index reordering is done as we recurse down the trees, both in `evaluate` (top of the tree) and at the leaves of the tree in `TensorAsExpression::get`, where the actual individual tensor components are retrieved. With the changes in this PR, index reordering only happens at the top of the tree (in `evaluate`) and when the index orders of the two operands in an `AddSub` expression differs. In all other `get` functions for each derived `TensorExpression` type, index reordering while recursing down the tree is not necessary, as the generic index orders of the operand(s) is/are propagated up the tree and preserved.

This both simplifies the implementation and should mean less index transformations need to happen when evaluating an expression (recursing down the syntax tree) since the transformations occur higher up in the tree.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
