### PR TITLE
Add TimeDependence to RotatedIntervals

### DIFF
--- a/src/Elliptic/DiscontinuousGalerkin/DgOperator.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/DgOperator.hpp
@@ -465,11 +465,15 @@ struct DgOperatorImpl<System, Linearized, tmpl::list<PrimalFields...>,
             const ::dg::MortarId<Dim> mortar_id{direction, neighbor_id};
             const auto& mortar_mesh = all_mortar_meshes.at(mortar_id);
             const auto& mortar_size = all_mortar_sizes.at(mortar_id);
+            // When no projection is necessary we can safely move the boundary
+            // data from the face as there is only a single neighbor in this
+            // direction
             auto projected_boundary_data =
                 Spectral::needs_projection(face_mesh, mortar_mesh, mortar_size)
+                    // NOLINTNEXTLINE
                     ? boundary_data.project_to_mortar(face_mesh, mortar_mesh,
                                                       mortar_size)
-                    : std::move(boundary_data);
+                    : std::move(boundary_data);  // NOLINT
             (*all_mortar_data)[mortar_id].local_insert(
                 temporal_id, std::move(projected_boundary_data));
           }

--- a/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
@@ -38,6 +38,7 @@ DomainCreator:
     UpperBound: [6.283185307179586]
     InitialRefinement: [1]
     InitialGridPoints: [[7, 3]]
+    TimeDependence: None
     BoundaryConditions:
       LowerBoundary: DirichletAnalytic
       UpperBoundary: DirichletAnalytic

--- a/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
@@ -16,9 +16,13 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/DiscreteRotation.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/Translation.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/RotatedIntervals.hpp"
+#include "Domain/Creators/TimeDependence/None.hpp"
+#include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
 #include "Domain/Domain.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Domain/OptionTags.hpp"
 #include "Domain/Structure/BlockNeighbor.hpp"  // IWYU pragma: keep
 #include "Domain/Structure/Direction.hpp"
@@ -27,12 +31,14 @@
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Helpers/Domain/Creators/TestHelpers.hpp"
 #include "Helpers/Domain/DomainTestHelpers.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/MakeVector.hpp"
 
 namespace domain {
 namespace {
+template <typename... FuncsOfTime>
 void test_rotated_intervals_construction(
     const creators::RotatedIntervals& rotated_intervals,
     const std::array<double, 1>& lower_bound,
@@ -44,6 +50,11 @@ void test_rotated_intervals_construction(
         expected_block_neighbors,
     const std::vector<std::unordered_set<Direction<1>>>&
         expected_external_boundaries,
+    const std::tuple<std::pair<std::string, FuncsOfTime>...>&
+        expected_functions_of_time,
+    const std::vector<std::unique_ptr<
+        domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, 1>>>&
+        expected_grid_to_inertial_maps,
     const std::vector<DirectionMap<
         1, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>&
         expected_boundary_conditions) noexcept {
@@ -58,17 +69,27 @@ void test_rotated_intervals_construction(
   test_domain_construction(
       domain, expected_block_neighbors, expected_external_boundaries,
       make_vector(
-          make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          make_coordinate_map_base<
+              Frame::Logical,
+              tmpl::conditional_t<sizeof...(FuncsOfTime) == 0, Frame::Inertial,
+                                  Frame::Grid>>(
               CoordinateMaps::Affine{-1., 1., lower_bound[0], midpoint[0]}),
-          make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          make_coordinate_map_base<
+              Frame::Logical,
+              tmpl::conditional_t<sizeof...(FuncsOfTime) == 0, Frame::Inertial,
+                                  Frame::Grid>>(
               CoordinateMaps::DiscreteRotation<1>{OrientationMap<1>{
                   std::array<Direction<1>, 1>{{Direction<1>::lower_xi()}}}},
               CoordinateMaps::Affine{-1., 1., midpoint[0], upper_bound[0]})),
-      0.0, {}, {}, expected_boundary_conditions);
+      10.0, rotated_intervals.functions_of_time(),
+      expected_grid_to_inertial_maps, expected_boundary_conditions);
   test_initial_domain(domain, rotated_intervals.initial_refinement_levels());
+  TestHelpers::domain::creators::test_functions_of_time(
+      rotated_intervals, expected_functions_of_time);
 
   Parallel::register_classes_with_charm(
       typename domain::creators::RotatedIntervals::maps_list{});
+  domain::creators::time_dependence::register_derived_with_charm();
   test_serialization(domain);
 }
 
@@ -96,7 +117,7 @@ void test_rotated_intervals() {
                 {{Direction<1>::upper_xi(), {0, flipped}}}},
             std::vector<std::unordered_set<Direction<1>>>{
                 {Direction<1>::lower_xi()}, {Direction<1>::lower_xi()}},
-            expected_bcs);
+            std::tuple<>{}, {}, expected_bcs);
         test_physical_separation(rotated_intervals.create_domain().blocks());
       };
 
@@ -111,7 +132,8 @@ void test_rotated_intervals() {
                  {Direction<1>::upper_xi(), {1, flipped}}},
                 {{Direction<1>::lower_xi(), {0, flipped}},
                  {Direction<1>::upper_xi(), {0, flipped}}}},
-            std::vector<std::unordered_set<Direction<1>>>{{}, {}}, {});
+            std::vector<std::unordered_set<Direction<1>>>{{}, {}},
+            std::tuple<>{}, {}, {});
       };
 
   {
@@ -121,7 +143,7 @@ void test_rotated_intervals() {
                        upper_bound,
                        refinement_level[0],
                        {{{{grid_points[0][0], grid_points[1][0]}}}},
-                       std::array<bool, 1>{{false}}},
+                       std::array<bool, 1>{{false}}, nullptr},
                       {});
   }
 
@@ -132,7 +154,7 @@ void test_rotated_intervals() {
                     upper_bound,
                     refinement_level[0],
                     {{{{grid_points[0][0], grid_points[1][0]}}}},
-                    std::array<bool, 1>{{true}}});
+                    std::array<bool, 1>{{true}}, nullptr});
   }
 
   // Test with boundary conditions
@@ -152,8 +174,8 @@ void test_rotated_intervals() {
          refinement_level[0],
          {{{{grid_points[0][0], grid_points[1][0]}}}},
          expected_boundary_conditions[0][Direction<1>::lower_xi()]->get_clone(),
-         expected_boundary_conditions[1][Direction<1>::lower_xi()]
-             ->get_clone()},
+         expected_boundary_conditions[1][Direction<1>::lower_xi()]->get_clone(),
+         nullptr},
         expected_boundary_conditions);
   }
 
@@ -168,7 +190,8 @@ void test_rotated_intervals() {
                     refinement_level[0],
                     {{{{grid_points[0][0], grid_points[1][0]}}}},
                     periodic->get_clone(),
-                    periodic->get_clone()});
+                    periodic->get_clone(),
+                    nullptr});
   }
 
   // Test parse error
@@ -178,7 +201,7 @@ void test_rotated_intervals() {
           {{{{grid_points[0][0], grid_points[1][0]}}}},
           expected_boundary_conditions[0][Direction<1>::lower_xi()]
               ->get_clone(),
-          periodic->get_clone(), Options::Context{false, {}, 1, 1}),
+          periodic->get_clone(), nullptr, Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains("Both the upper and lower boundary condition "
                                 "must be set to periodic if"));
   CHECK_THROWS_WITH(
@@ -187,7 +210,7 @@ void test_rotated_intervals() {
           {{{{grid_points[0][0], grid_points[1][0]}}}}, periodic->get_clone(),
           expected_boundary_conditions[0][Direction<1>::lower_xi()]
               ->get_clone(),
-          Options::Context{false, {}, 1, 1}),
+          nullptr, Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains("Both the upper and lower boundary condition "
                                 "must be set to periodic if"));
   CHECK_THROWS_WITH(
@@ -198,7 +221,7 @@ void test_rotated_intervals() {
                                TestNoneBoundaryCondition<3>>(),
           expected_boundary_conditions[0][Direction<1>::lower_xi()]
               ->get_clone(),
-          Options::Context{false, {}, 1, 1}),
+          nullptr, Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "None boundary condition is not supported. If you would like "
           "an outflow boundary condition, you must use that."));
@@ -210,7 +233,7 @@ void test_rotated_intervals() {
               ->get_clone(),
           std::make_unique<TestHelpers::domain::BoundaryConditions::
                                TestNoneBoundaryCondition<3>>(),
-          Options::Context{false, {}, 1, 1}),
+          nullptr, Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "None boundary condition is not supported. If you would like "
           "an outflow boundary condition, you must use that."));
@@ -219,8 +242,20 @@ void test_rotated_intervals() {
 void test_rotated_intervals_factory() {
   const OrientationMap<1> flipped{
       std::array<Direction<1>, 1>{{Direction<1>::lower_xi()}}};
+  std::vector<DirectionMap<
+      1, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
+      expected_boundary_conditions{2};
+  expected_boundary_conditions[0][Direction<1>::lower_xi()] = std::make_unique<
+      TestHelpers::domain::BoundaryConditions::TestBoundaryCondition<1>>(
+      Direction<1>::lower_xi(), 0);
+  expected_boundary_conditions[1][Direction<1>::lower_xi()] = std::make_unique<
+      TestHelpers::domain::BoundaryConditions::TestBoundaryCondition<1>>(
+      Direction<1>::lower_xi(), 1);
+  const std::vector<std::unordered_set<Direction<1>>>
+      expected_external_boundaries{{Direction<1>::lower_xi()},
+                                   {Direction<1>::lower_xi()}};
   {
-    INFO("Rotated intervals factory, no boundary condition");
+    INFO("Rotated intervals factory time independent, no boundary condition");
     const auto domain_creator = TestHelpers::test_option_tag<
         domain::OptionTags::DomainCreator<1>,
         TestHelpers::domain::BoundaryConditions::
@@ -232,7 +267,8 @@ void test_rotated_intervals_factory() {
         "  UpperBound: [1.0]\n"
         "  IsPeriodicIn: [True]\n"
         "  InitialGridPoints: [[3,2]]\n"
-        "  InitialRefinement: [2]\n");
+        "  InitialRefinement: [2]\n"
+        "  TimeDependence: None\n");
     const auto* rotated_intervals_creator =
         dynamic_cast<const creators::RotatedIntervals*>(domain_creator.get());
     test_rotated_intervals_construction(
@@ -243,10 +279,11 @@ void test_rotated_intervals_factory() {
              {Direction<1>::upper_xi(), {1, flipped}}},
             {{Direction<1>::lower_xi(), {0, flipped}},
              {Direction<1>::upper_xi(), {0, flipped}}}},
-        std::vector<std::unordered_set<Direction<1>>>{{}, {}}, {});
+        std::vector<std::unordered_set<Direction<1>>>{{}, {}}, {},
+        {}, {});
   }
   {
-    INFO("Rotated intervals factory, with boundary condition");
+    INFO("Rotated intervals factory time independent, with boundary condition");
     const auto domain_creator = TestHelpers::test_option_tag<
         domain::OptionTags::DomainCreator<1>,
         TestHelpers::domain::BoundaryConditions::
@@ -258,6 +295,7 @@ void test_rotated_intervals_factory() {
         "  UpperBound: [1.0]\n"
         "  InitialGridPoints: [[3,2]]\n"
         "  InitialRefinement: [2]\n"
+        "  TimeDependence: None\n"
         "  BoundaryConditions:\n"
         "    LowerBoundary:\n"
         "      TestBoundaryCondition:\n"
@@ -265,34 +303,104 @@ void test_rotated_intervals_factory() {
         "        BlockId: 0\n"
         "    UpperBoundary:\n"
         "      TestBoundaryCondition:\n"
-        "        Direction: upper-xi\n"  // Direction and BlockId can be
-                                         // anything and are used to ensure
-                                         // different BCs don't compare equal.
+        "        Direction: lower-xi\n"
         "        BlockId: 1\n");
     const auto* rotated_intervals_creator =
         dynamic_cast<const creators::RotatedIntervals*>(domain_creator.get());
-    std::vector<DirectionMap<
-        1, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
-        expected_boundary_conditions{2};
-    expected_boundary_conditions[0][Direction<1>::lower_xi()] =
-        std::make_unique<
-            TestHelpers::domain::BoundaryConditions::TestBoundaryCondition<1>>(
-            Direction<1>::lower_xi(), 0);
-    expected_boundary_conditions[1][Direction<1>::lower_xi()] =
-        std::make_unique<
-            TestHelpers::domain::BoundaryConditions::TestBoundaryCondition<1>>(
-            Direction<1>::upper_xi(), 1);
-    const std::vector<std::unordered_set<Direction<1>>>
-        expected_external_boundaries{
-            {Direction<1>::lower_xi(), Direction<1>::upper_xi()}};
     test_rotated_intervals_construction(
         *rotated_intervals_creator, {{0.0}}, {{0.5}}, {{1.0}}, {{{3}}, {{2}}},
         {{{2}}, {{2}}},
         std::vector<DirectionMap<1, BlockNeighbor<1>>>{
             {{Direction<1>::upper_xi(), {1, flipped}}},
             {{Direction<1>::upper_xi(), {0, flipped}}}},
-        std::vector<std::unordered_set<Direction<1>>>{
-            {Direction<1>::lower_xi()}, {Direction<1>::lower_xi()}},
+        expected_external_boundaries, {}, {}, expected_boundary_conditions);
+  }
+  {
+    INFO("Rotated intervals factory time dependent, no boundary condition");
+    const auto domain_creator = TestHelpers::test_option_tag<
+        domain::OptionTags::DomainCreator<1>,
+        TestHelpers::domain::BoundaryConditions::
+            MetavariablesWithoutBoundaryConditions<
+                1, domain::creators::RotatedIntervals>>(
+        "RotatedIntervals:\n"
+        "  LowerBound: [0.0]\n"
+        "  Midpoint:   [0.5]\n"
+        "  UpperBound: [1.0]\n"
+        "  IsPeriodicIn: [True]\n"
+        "  InitialGridPoints: [[3,2]]\n"
+        "  InitialRefinement: [2]\n"
+        "  TimeDependence:\n"
+        "    UniformTranslation:\n"
+        "      InitialTime: 1.0\n"
+        "      InitialExpirationDeltaT: 9.0\n"
+        "      Velocity: [2.3]\n"
+        "      FunctionOfTimeNames: [TranslationX]\n");
+    const auto* rotated_intervals_creator =
+        dynamic_cast<const creators::RotatedIntervals*>(domain_creator.get());
+    test_rotated_intervals_construction(
+        *rotated_intervals_creator, {{0.0}}, {{0.5}}, {{1.0}}, {{{3}}, {{2}}},
+        {{{2}}, {{2}}},
+        std::vector<DirectionMap<1, BlockNeighbor<1>>>{
+            {{Direction<1>::lower_xi(), {1, flipped}},
+             {Direction<1>::upper_xi(), {1, flipped}}},
+            {{Direction<1>::lower_xi(), {0, flipped}},
+             {Direction<1>::upper_xi(), {0, flipped}}}},
+        std::vector<std::unordered_set<Direction<1>>>{{}, {}},
+        std::make_tuple(
+            std::pair<std::string,
+                      domain::FunctionsOfTime::PiecewisePolynomial<2>>{
+                "TranslationX",
+                {1.0, std::array<DataVector, 3>{{{0.0}, {2.3}, {0.0}}}, 10.0}}),
+        make_vector_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+            CoordinateMaps::TimeDependent::Translation{"TranslationX"},
+            CoordinateMaps::TimeDependent::Translation{"TranslationX"}),
+        {});
+  }
+  {
+    INFO("Rotated intervals factory time dependent, with boundary condition");
+    const auto domain_creator = TestHelpers::test_option_tag<
+        domain::OptionTags::DomainCreator<1>,
+        TestHelpers::domain::BoundaryConditions::
+            MetavariablesWithBoundaryConditions<
+                1, domain::creators::RotatedIntervals>>(
+        "RotatedIntervals:\n"
+        "  LowerBound: [0.0]\n"
+        "  Midpoint:   [0.5]\n"
+        "  UpperBound: [1.0]\n"
+        "  InitialGridPoints: [[3,2]]\n"
+        "  InitialRefinement: [2]\n"
+        "  TimeDependence:\n"
+        "    UniformTranslation:\n"
+        "      InitialTime: 1.0\n"
+        "      InitialExpirationDeltaT: 9.0\n"
+        "      Velocity: [2.3]\n"
+        "      FunctionOfTimeNames: [TranslationX]\n"
+        "  BoundaryConditions:\n"
+        "    LowerBoundary:\n"
+        "      TestBoundaryCondition:\n"
+        "        Direction: lower-xi\n"
+        "        BlockId: 0\n"
+        "    UpperBoundary:\n"
+        "      TestBoundaryCondition:\n"
+        "        Direction: lower-xi\n"
+        "        BlockId: 1\n");
+    const auto* rotated_intervals_creator =
+        dynamic_cast<const creators::RotatedIntervals*>(domain_creator.get());
+    test_rotated_intervals_construction(
+        *rotated_intervals_creator, {{0.0}}, {{0.5}}, {{1.0}}, {{{3}}, {{2}}},
+        {{{2}}, {{2}}},
+        std::vector<DirectionMap<1, BlockNeighbor<1>>>{
+            {{Direction<1>::upper_xi(), {1, flipped}}},
+            {{Direction<1>::upper_xi(), {0, flipped}}}},
+        expected_external_boundaries,
+        std::make_tuple(
+            std::pair<std::string,
+                      domain::FunctionsOfTime::PiecewisePolynomial<2>>{
+                "TranslationX",
+                {1.0, std::array<DataVector, 3>{{{0.0}, {2.3}, {0.0}}}, 10.0}}),
+        make_vector_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+            CoordinateMaps::TimeDependent::Translation{"TranslationX"},
+            CoordinateMaps::TimeDependent::Translation{"TranslationX"}),
         expected_boundary_conditions);
   }
 }

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
@@ -595,7 +595,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.SubdomainOperator", "[Unit][Elliptic]") {
           make_boundary_condition<system>(
               elliptic::BoundaryConditionType::Dirichlet),
           make_boundary_condition<system>(
-              elliptic::BoundaryConditionType::Neumann)};
+              elliptic::BoundaryConditionType::Neumann),
+          nullptr};
       test_subdomain_operator<system>(domain_creator);
     }
     {


### PR DESCRIPTION
## Proposed changes

- Add TimeDependence to RotatedIntervals
- Fix a clang-tidy error in src/Elliptic/DiscontinuousGalerkin/DgOperator.hpp 

### Upgrade instructions

If using a RotatedIntervals DomainCreator, you now need to add a TimeDependence option with a value of None to reproduce previous behavior.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
