### PR TITLE
Add multigrid to elliptic executables

### DIFF
--- a/src/Elliptic/Executables/Elasticity/CMakeLists.txt
+++ b/src/Elliptic/Executables/Elasticity/CMakeLists.txt
@@ -24,6 +24,7 @@ set(LIBS_TO_LINK
   Options
   Parallel
   ParallelLinearSolver
+  ParallelMultigrid
   ParallelSchwarz
   Utilities
   )

--- a/src/Elliptic/Executables/Poisson/CMakeLists.txt
+++ b/src/Elliptic/Executables/Poisson/CMakeLists.txt
@@ -18,6 +18,7 @@ set(LIBS_TO_LINK
   Options
   Parallel
   ParallelLinearSolver
+  ParallelMultigrid
   ParallelSchwarz
   Poisson
   PoissonBoundaryConditions

--- a/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
@@ -45,6 +45,8 @@
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
 #include "ParallelAlgorithms/LinearSolver/Actions/MakeIdentityIfSkipped.hpp"
 #include "ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp"
+#include "ParallelAlgorithms/LinearSolver/Multigrid/ElementsAllocator.hpp"
+#include "ParallelAlgorithms/LinearSolver/Multigrid/Multigrid.hpp"
 #include "ParallelAlgorithms/LinearSolver/Schwarz/Schwarz.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
 #include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
@@ -81,6 +83,11 @@ struct GmresGroup {
 struct SchwarzSmootherGroup {
   static std::string name() noexcept { return "SchwarzSmoother"; }
   static constexpr Options::String help = "Options for the Schwarz smoother";
+  using group = LinearSolverGroup;
+};
+struct MultigridGroup {
+  static std::string name() noexcept { return "Multigrid"; }
+  static constexpr Options::String help = "Options for the multigrid";
   using group = LinearSolverGroup;
 };
 }  // namespace SolvePoisson::OptionTags
@@ -131,21 +138,25 @@ struct Metavariables {
   // The linear solver algorithm. We must use GMRES since the operator is
   // not guaranteed to be symmetric. It can be made symmetric by multiplying by
   // the DG mass matrix.
-  using linear_solver =
-      LinearSolver::gmres::Gmres<Metavariables, fields_tag,
-                                 SolvePoisson::OptionTags::LinearSolverGroup,
-                                 true>;
+  using linear_solver = LinearSolver::gmres::Gmres<
+      Metavariables, fields_tag, SolvePoisson::OptionTags::LinearSolverGroup,
+      true, fixed_sources_tag, LinearSolver::multigrid::Tags::IsFinestGrid>;
   using linear_solver_iteration_id =
       Convergence::Tags::IterationId<typename linear_solver::options_group>;
-  // Precondition each linear solver iteration with a number of Schwarz
-  // smoothing steps
+  // Precondition each linear solver iteration with a multigrid V-cycle
+  using multigrid = LinearSolver::multigrid::Multigrid<
+      volume_dim, typename linear_solver::operand_tag,
+      SolvePoisson::OptionTags::MultigridGroup, elliptic::dg::Tags::Massive,
+      typename linear_solver::preconditioner_source_tag>;
+  // Smooth each multigrid level with a number of Schwarz smoothing steps
   using subdomain_operator =
       elliptic::dg::subdomain_operator::SubdomainOperator<
           system, SolvePoisson::OptionTags::SchwarzSmootherGroup>;
   using schwarz_smoother = LinearSolver::Schwarz::Schwarz<
-      typename linear_solver::operand_tag,
+      typename multigrid::smooth_fields_tag,
       SolvePoisson::OptionTags::SchwarzSmootherGroup, subdomain_operator,
-      tmpl::list<>, typename linear_solver::preconditioner_source_tag>;
+      tmpl::list<>, typename multigrid::smooth_source_tag,
+      LinearSolver::multigrid::Tags::MultigridLevel>;
   // For the GMRES linear solver we need to apply the DG operator to its
   // internal "operand" in every iteration of the algorithm.
   using vars_tag = typename linear_solver::operand_tag;
@@ -169,11 +180,13 @@ struct Metavariables {
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes = tmpl::map<
         tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
-        tmpl::pair<Event, tmpl::flatten<tmpl::list<
-                              Events::Completion,
-                              dg::Events::field_observations<
-                                  volume_dim, linear_solver_iteration_id,
-                                  observe_fields, analytic_solution_fields>>>>,
+        tmpl::pair<Event,
+                   tmpl::flatten<tmpl::list<
+                       Events::Completion,
+                       dg::Events::field_observations<
+                           volume_dim, linear_solver_iteration_id,
+                           observe_fields, analytic_solution_fields,
+                           LinearSolver::multigrid::Tags::IsFinestGrid>>>>,
         tmpl::pair<Trigger,
                    tmpl::push_back<Triggers::logical_triggers,
                                    elliptic::Triggers::EveryNIterations<
@@ -184,7 +197,7 @@ struct Metavariables {
   using observed_reduction_data_tags =
       observers::collect_reduction_data_tags<tmpl::flatten<tmpl::list<
           tmpl::at<typename factory_creation::factory_classes, Event>,
-          linear_solver, schwarz_smoother>>>;
+          linear_solver, multigrid, schwarz_smoother>>>;
 
   // Specify all global synchronization points.
   enum class Phase { Initialization, RegisterWithObserver, Solve, Exit };
@@ -193,6 +206,7 @@ struct Metavariables {
       Actions::SetupDataBox,
       elliptic::dg::Actions::InitializeDomain<volume_dim>,
       typename linear_solver::initialize_element,
+      typename multigrid::initialize_element,
       typename schwarz_smoother::initialize_element,
       elliptic::Actions::InitializeFields<system, initial_guess_tag>,
       elliptic::Actions::InitializeFixedSources<system, analytic_solution_tag>,
@@ -218,15 +232,22 @@ struct Metavariables {
   using register_actions =
       tmpl::list<observers::Actions::RegisterEventsWithObservers,
                  typename schwarz_smoother::register_element,
+                 typename multigrid::register_element,
                  Parallel::Actions::TerminatePhase>;
 
+  template <typename Label>
+  using smooth_actions = tmpl::list<build_linear_operator_actions,
+                                    typename schwarz_smoother::template solve<
+                                        build_linear_operator_actions, Label>>;
+
   using solve_actions = tmpl::list<
-      typename linear_solver::template solve<
-          tmpl::list<Actions::RunEventsAndTriggers,
-                     typename schwarz_smoother::template solve<
-                         build_linear_operator_actions>,
-                     ::LinearSolver::Actions::make_identity_if_skipped<
-                         schwarz_smoother, build_linear_operator_actions>>>,
+      typename linear_solver::template solve<tmpl::list<
+          Actions::RunEventsAndTriggers,
+          typename multigrid::template solve<
+              smooth_actions<LinearSolver::multigrid::VcycleDownLabel>,
+              smooth_actions<LinearSolver::multigrid::VcycleUpLabel>>,
+          ::LinearSolver::Actions::make_identity_if_skipped<
+              multigrid, build_linear_operator_actions>>>,
       Actions::RunEventsAndTriggers, Parallel::Actions::TerminatePhase>;
 
   using dg_element_array = elliptic::DgElementArray<
@@ -235,11 +256,14 @@ struct Metavariables {
                                         initialization_actions>,
                  Parallel::PhaseActions<Phase, Phase::RegisterWithObserver,
                                         register_actions>,
-                 Parallel::PhaseActions<Phase, Phase::Solve, solve_actions>>>;
+                 Parallel::PhaseActions<Phase, Phase::Solve, solve_actions>>,
+      LinearSolver::multigrid::ElementsAllocator<
+          volume_dim, typename multigrid::options_group>>;
 
   // Specify all parallel components that will execute actions at some point.
   using component_list = tmpl::flatten<
       tmpl::list<dg_element_array, typename linear_solver::component_list,
+                 typename multigrid::component_list,
                  typename schwarz_smoother::component_list,
                  observers::Observer<Metavariables>,
                  observers::ObserverWriter<Metavariables>>>;

--- a/src/Elliptic/Executables/Xcts/CMakeLists.txt
+++ b/src/Elliptic/Executables/Xcts/CMakeLists.txt
@@ -23,6 +23,7 @@ set(LIBS_TO_LINK
   Options
   Parallel
   ParallelLinearSolver
+  ParallelMultigrid
   ParallelNonlinearSolver
   ParallelSchwarz
   Utilities

--- a/src/ParallelAlgorithms/Events/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Events/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(
   ErrorHandling
   EventsAndTriggers
   Interpolation
+  LinearOperators
   Options
   Time
   Utilities

--- a/src/ParallelAlgorithms/Events/Factory.hpp
+++ b/src/ParallelAlgorithms/Events/Factory.hpp
@@ -14,12 +14,13 @@
 
 namespace dg::Events {
 template <size_t VolumeDim, typename TimeTag, typename Fields,
-          typename SolutionFields>
+          typename SolutionFields, typename ArraySectionIdTag = void>
 using field_observations = tmpl::flatten<tmpl::list<
-    ObserveFields<VolumeDim, TimeTag, Fields, SolutionFields>,
-    tmpl::conditional_t<std::is_same_v<SolutionFields, tmpl::list<>>,
-                        tmpl::list<>,
-                        ObserveErrorNorms<TimeTag, SolutionFields>>>>;
+    ObserveFields<VolumeDim, TimeTag, Fields, SolutionFields,
+                  ArraySectionIdTag>,
+    tmpl::conditional_t<
+        std::is_same_v<SolutionFields, tmpl::list<>>, tmpl::list<>,
+        ObserveErrorNorms<TimeTag, SolutionFields, ArraySectionIdTag>>>>;
 }  // namespace dg::Events
 
 namespace Events {

--- a/src/ParallelAlgorithms/Events/ObserveVolumeIntegrals.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveVolumeIntegrals.hpp
@@ -9,10 +9,12 @@
 #include <utility>
 #include <vector>
 
+#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "Domain/Tags.hpp"
 #include "IO/Observer/ArrayComponentId.hpp"
+#include "IO/Observer/GetSectionObservationKey.hpp"
 #include "IO/Observer/Helpers.hpp"
 #include "IO/Observer/ObservationId.hpp"
 #include "IO/Observer/ObserverComponent.hpp"
@@ -39,7 +41,8 @@ struct Inertial;
 
 namespace dg {
 namespace Events {
-template <size_t VolumeDim, typename ObservationValueTag, typename Tensors>
+template <size_t VolumeDim, typename ObservationValueTag, typename Tensors,
+          typename ArraySectionIdTag = void>
 class ObserveVolumeIntegrals;
 
 /*!
@@ -50,10 +53,19 @@ class ObserveVolumeIntegrals;
  * - `ObservationValueTag`
  * - `Volume` = volume of the domain
  * - `VolumeIntegral(*)` = volume integral of the tensor
+ *
+ * \par Array sections
+ * This event supports sections (see `Parallel::Section`). Set the
+ * `ArraySectionIdTag` template parameter to split up observations into subsets
+ * of elements. The `observers::Tags::ObservationKey<ArraySectionIdTag>` must be
+ * available in the DataBox. It identifies the section and is used as a suffix
+ * for the path in the output file.
  */
-template <size_t VolumeDim, typename ObservationValueTag, typename... Tensors>
+template <size_t VolumeDim, typename ObservationValueTag, typename... Tensors,
+          typename ArraySectionIdTag>
 class ObserveVolumeIntegrals<VolumeDim, ObservationValueTag,
-                             tmpl::list<Tensors...>> : public Event {
+                             tmpl::list<Tensors...>, ArraySectionIdTag>
+    : public Event {
  private:
   using VolumeIntegralDatum =
       Parallel::ReductionDatum<std::vector<double>, funcl::VectorPlus>;
@@ -99,19 +111,28 @@ class ObserveVolumeIntegrals<VolumeDim, ObservationValueTag,
       observers::make_reduction_data_tags<tmpl::list<ReductionData>>;
 
   using argument_tags =
-      tmpl::list<ObservationValueTag, domain::Tags::Mesh<VolumeDim>,
+      tmpl::list<::Tags::DataBox, ObservationValueTag,
+                 domain::Tags::Mesh<VolumeDim>,
                  domain::Tags::DetInvJacobian<Frame::Logical, Frame::Inertial>,
                  Tensors...>;
 
-  template <typename Metavariables, typename ArrayIndex,
+  template <typename DbTagsList, typename Metavariables, typename ArrayIndex,
             typename ParallelComponent>
-  void operator()(const typename ObservationValueTag::type& observation_value,
+  void operator()(const db::DataBox<DbTagsList>& box,
+                  const typename ObservationValueTag::type& observation_value,
                   const Mesh<VolumeDim>& mesh,
                   const Scalar<DataVector>& det_inv_jacobian,
                   const typename Tensors::type&... tensors,
                   Parallel::GlobalCache<Metavariables>& cache,
                   const ArrayIndex& array_index,
                   const ParallelComponent* const /*meta*/) const noexcept {
+    // Skip observation on elements that are not part of a section
+    const std::optional<std::string> section_observation_key =
+        observers::get_section_observation_key<ArraySectionIdTag>(box);
+    if (not section_observation_key.has_value()) {
+      return;
+    }
+
     // Determinant of Jacobian is needed because integral is performed in
     // logical coords.
     const DataVector det_jacobian = 1.0 / get(det_inv_jacobian);
@@ -141,22 +162,34 @@ class ObserveVolumeIntegrals<VolumeDim, ObservationValueTag,
         *Parallel::get_parallel_component<observers::Observer<Metavariables>>(
              cache)
              .ckLocalBranch();
+    const std::string subfile_path_with_suffix =
+        subfile_path_ + section_observation_key.value();
     Parallel::simple_action<observers::Actions::ContributeReductionData>(
         local_observer,
-        observers::ObservationId(observation_value, subfile_path_ + ".dat"),
+        observers::ObservationId(observation_value, subfile_path_with_suffix),
         observers::ArrayComponentId{
             std::add_pointer_t<ParallelComponent>{nullptr},
             Parallel::ArrayIndex<ArrayIndex>(array_index)},
-        subfile_path_, reduction_names,
+        subfile_path_with_suffix, reduction_names,
         ReductionData{static_cast<double>(observation_value), local_volume,
                       local_volume_integrals});
   }
 
-  using observation_registration_tags = tmpl::list<>;
-  std::pair<observers::TypeOfObservation, observers::ObservationKey>
-  get_observation_type_and_key_for_registration() const noexcept {
-    return {observers::TypeOfObservation::Reduction,
-            observers::ObservationKey(subfile_path_ + ".dat")};
+  using observation_registration_tags = tmpl::list<::Tags::DataBox>;
+
+  template <typename DbTagsList>
+  std::optional<
+      std::pair<observers::TypeOfObservation, observers::ObservationKey>>
+  get_observation_type_and_key_for_registration(
+      const db::DataBox<DbTagsList>& box) const noexcept {
+    const std::optional<std::string> section_observation_key =
+        observers::get_section_observation_key<ArraySectionIdTag>(box);
+    if (not section_observation_key.has_value()) {
+      return std::nullopt;
+    }
+    return {{observers::TypeOfObservation::Reduction,
+             observers::ObservationKey(subfile_path_ +
+                                       section_observation_key.value())}};
   }
 
   using is_ready_argument_tags = tmpl::list<>;
@@ -180,15 +213,19 @@ class ObserveVolumeIntegrals<VolumeDim, ObservationValueTag,
   std::string subfile_path_;
 };
 
-template <size_t VolumeDim, typename ObservationValueTag, typename... Tensors>
-ObserveVolumeIntegrals<VolumeDim, ObservationValueTag, tmpl::list<Tensors...>>::
+template <size_t VolumeDim, typename ObservationValueTag, typename... Tensors,
+          typename ArraySectionIdTag>
+ObserveVolumeIntegrals<VolumeDim, ObservationValueTag, tmpl::list<Tensors...>,
+                       ArraySectionIdTag>::
     ObserveVolumeIntegrals(const std::string& subfile_name) noexcept
     : subfile_path_("/" + subfile_name) {}
 
 /// \cond
-template <size_t VolumeDim, typename ObservationValueTag, typename... Tensors>
+template <size_t VolumeDim, typename ObservationValueTag, typename... Tensors,
+          typename ArraySectionIdTag>
 PUP::able::PUP_ID ObserveVolumeIntegrals<VolumeDim, ObservationValueTag,
-                                         tmpl::list<Tensors...>>::my_PUP_ID =
+                                         tmpl::list<Tensors...>,
+                                         ArraySectionIdTag>::my_PUP_ID =
     0;  // NOLINT
 /// \endcond
 }  // namespace Events

--- a/src/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/ElementActions.hpp
@@ -187,7 +187,7 @@ struct RegisterObservers {
     // Get the observation key, or "Unused" if the element does not belong
     // to a section with this tag. In the latter case, no observations will
     // ever be contributed.
-    const std::optional<std::string>& section_observation_key =
+    const std::optional<std::string> section_observation_key =
         observers::get_section_observation_key<ArraySectionIdTag>(box);
     ASSERT(section_observation_key != "Unused",
            "The identifier 'Unused' is reserved to indicate that no "

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/ElementActions.hpp
@@ -536,7 +536,7 @@ struct NormalizeOperandAndUpdateField {
         });
 
     // Elements that are not part of the section jump directly to the
-    // `ApplyOperationActions` for the next step.`
+    // `ApplyOperationActions` for the next step.
     constexpr size_t this_action_index =
         tmpl::index_of<ActionList, NormalizeOperandAndUpdateField>::value;
     constexpr size_t prepare_step_index =

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp
@@ -88,7 +88,7 @@ namespace LinearSolver::gmres {
  * elements in the array. Note that the actions in the `ApplyOperatorActions`
  * list passed to `solve` will _not_ be restricted to run only on section
  * elements, so all elements in the array may participate in preconditioning
- * (see LinearSolver::Multigrid::Multigrid).
+ * (see LinearSolver::multigrid::Multigrid).
  *
  * \see ConjugateGradient for a linear solver that is more efficient when the
  * linear operator \f$A\f$ is symmetric.

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementActions.hpp
@@ -110,7 +110,7 @@ struct RegisterObservers {
     // Get the observation key, or "Unused" if the element does not belong
     // to a section with this tag. In the latter case, no observations will
     // ever be contributed.
-    const std::optional<std::string>& section_observation_key =
+    const std::optional<std::string> section_observation_key =
         observers::get_section_observation_key<ArraySectionIdTag>(box);
     ASSERT(section_observation_key != "Unused",
            "The identifier 'Unused' is reserved to indicate that no "

--- a/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/ElementActions.hpp
+++ b/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/ElementActions.hpp
@@ -18,10 +18,12 @@
 #include "NumericalAlgorithms/Convergence/Tags.hpp"
 #include "NumericalAlgorithms/LinearSolver/InnerProduct.hpp"
 #include "Parallel/AlgorithmMetafunctions.hpp"
+#include "Parallel/GetSection.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Printf.hpp"
 #include "Parallel/Reduction.hpp"
+#include "Parallel/Tags/Section.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
 #include "ParallelAlgorithms/NonlinearSolver/NewtonRaphson/ResidualMonitorActions.hpp"
@@ -39,9 +41,17 @@
 namespace NonlinearSolver::newton_raphson::detail {
 template <typename Metavariables, typename FieldsTag, typename OptionsGroup>
 struct ResidualMonitor;
-template <typename FieldsTag, typename OptionsGroup, typename Label>
+template <typename FieldsTag, typename OptionsGroup, typename Label,
+          typename ArraySectionIdTag>
+struct ReceiveInitialHasConverged;
+template <typename FieldsTag, typename OptionsGroup, typename Label,
+          typename ArraySectionIdTag>
 struct PrepareStep;
-template <typename FieldsTag, typename OptionsGroup, typename Label>
+template <typename FieldsTag, typename OptionsGroup, typename Label,
+          typename ArraySectionIdTag>
+struct Globalize;
+template <typename FieldsTag, typename OptionsGroup, typename Label,
+          typename ArraySectionIdTag>
 struct CompleteStep;
 }  // namespace NonlinearSolver::newton_raphson::detail
 /// \endcond
@@ -103,10 +113,9 @@ struct InitializeElement {
   }
 };
 
-// Reset to the initial state of the algorithm. To determine the initial
-// residual magnitude and to check if the algorithm has already converged, we
-// perform a global reduction to the `ResidualMonitor`.
-template <typename FieldsTag, typename OptionsGroup, typename Label>
+// Reset to the initial state of the algorithm.
+template <typename FieldsTag, typename OptionsGroup, typename Label,
+          typename ArraySectionIdTag>
 struct PrepareSolve {
  private:
   using fields_tag = FieldsTag;
@@ -120,37 +129,81 @@ struct PrepareSolve {
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>
-  static std::tuple<db::DataBox<DbTagsList>&&> apply(
-      db::DataBox<DbTagsList>& box,
-      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-      Parallel::GlobalCache<Metavariables>& cache,
-      const ArrayIndex& array_index, const ActionList /*meta*/,
-      const ParallelComponent* const /*meta*/) noexcept {
-    if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
-                 ::Verbosity::Debug)) {
-      Parallel::printf("%s %s: Prepare solve\n", get_output(array_index),
-                       Options::name<OptionsGroup>());
-    }
-
+  static std::tuple<db::DataBox<DbTagsList>&&, Parallel::AlgorithmExecution,
+                    size_t>
+  apply(db::DataBox<DbTagsList>& box,
+        const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+        const Parallel::GlobalCache<Metavariables>& /*cache*/,
+        const ArrayIndex& array_index, const ActionList /*meta*/,
+        const ParallelComponent* const /*meta*/) noexcept {
     db::mutate<Convergence::Tags::IterationId<OptionsGroup>>(
         make_not_null(&box),
         [](const gsl::not_null<size_t*> iteration_id) noexcept {
           *iteration_id = 0;
         });
 
+    // Skip the initial reduction on elements that are not part of the section
+    if constexpr (not std::is_same_v<ArraySectionIdTag, void>) {
+      if (not db::get<Parallel::Tags::Section<ParallelComponent,
+                                              ArraySectionIdTag>>(box)
+                  .has_value()) {
+        constexpr size_t receive_initial_index = tmpl::index_of<
+            ActionList,
+            ReceiveInitialHasConverged<FieldsTag, OptionsGroup, Label,
+                                       ArraySectionIdTag>>::value;
+        return {std::move(box), Parallel::AlgorithmExecution::Continue,
+                receive_initial_index};
+      }
+    }
+
+    if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
+                 ::Verbosity::Debug)) {
+      Parallel::printf("%s %s: Prepare solve\n", get_output(array_index),
+                       Options::name<OptionsGroup>());
+    }
+
+    constexpr size_t this_action_index =
+        tmpl::index_of<ActionList, PrepareSolve>::value;
+    return {std::move(box), Parallel::AlgorithmExecution::Continue,
+            this_action_index + 1};
+  }
+};
+
+// To determine the initial residual magnitude and to check if the algorithm has
+// already converged, we perform a global reduction to the `ResidualMonitor`.
+template <typename FieldsTag, typename OptionsGroup, typename Label,
+          typename ArraySectionIdTag>
+struct SendInitialResidualMagnitude {
+ private:
+  using fields_tag = FieldsTag;
+  using nonlinear_residual_tag =
+      db::add_tag_prefix<NonlinearSolver::Tags::Residual, fields_tag>;
+
+ public:
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& array_index, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
     // Perform a global reduction to compute the initial residual magnitude
     const auto& residual = db::get<nonlinear_residual_tag>(box);
     const double local_residual_magnitude_square =
         LinearSolver::inner_product(residual, residual);
     ResidualReductionData reduction_data{0, 0, local_residual_magnitude_square,
                                          1.};
+    auto& section = Parallel::get_section<ParallelComponent, ArraySectionIdTag>(
+        make_not_null(&box));
     Parallel::contribute_to_reduction<
         CheckResidualMagnitude<FieldsTag, OptionsGroup, ParallelComponent>>(
         std::move(reduction_data),
         Parallel::get_parallel_component<ParallelComponent>(cache)[array_index],
         Parallel::get_parallel_component<
-            ResidualMonitor<Metavariables, FieldsTag, OptionsGroup>>(cache));
-
+            ResidualMonitor<Metavariables, FieldsTag, OptionsGroup>>(cache),
+        make_not_null(&section));
     return {std::move(box)};
   }
 };
@@ -158,7 +211,8 @@ struct PrepareSolve {
 // Wait for the broadcast from the `ResidualMonitor` to complete the preparation
 // for the solve. We skip the solve altogether if the algorithm has already
 // converged.
-template <typename FieldsTag, typename OptionsGroup, typename Label>
+template <typename FieldsTag, typename OptionsGroup, typename Label,
+          typename ArraySectionIdTag>
 struct ReceiveInitialHasConverged {
   using inbox_tags = tmpl::list<Tags::GlobalizationResult<OptionsGroup>>;
 
@@ -172,6 +226,8 @@ struct ReceiveInitialHasConverged {
         const Parallel::GlobalCache<Metavariables>& /*cache*/,
         const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
         const ParallelComponent* const /*meta*/) noexcept {
+    const size_t iteration_id =
+        db::get<Convergence::Tags::IterationId<OptionsGroup>>(box);
     auto& inbox = get<Tags::GlobalizationResult<OptionsGroup>>(inboxes);
     if (inbox.find(db::get<Convergence::Tags::IterationId<OptionsGroup>>(
             box)) == inbox.end()) {
@@ -180,16 +236,12 @@ struct ReceiveInitialHasConverged {
     }
 
     // Retrieve reduction data from inbox
-    auto globalization_result = std::move(
-        inbox
-            .extract(db::get<Convergence::Tags::IterationId<OptionsGroup>>(box))
-            .mapped());
+    auto globalization_result = std::move(inbox.extract(iteration_id).mapped());
     ASSERT(
         std::holds_alternative<Convergence::HasConverged>(globalization_result),
         "No globalization should occur for the initial residual. This is a "
         "bug, so please file an issue.");
     auto& has_converged = get<Convergence::HasConverged>(globalization_result);
-
     db::mutate<Convergence::Tags::HasConverged<OptionsGroup>>(
         make_not_null(&box),
         [&has_converged](const gsl::not_null<Convergence::HasConverged*>
@@ -199,14 +251,40 @@ struct ReceiveInitialHasConverged {
 
     // Skip steps entirely if the solve has already converged
     constexpr size_t complete_step_index =
-        tmpl::index_of<ActionList,
-                       CompleteStep<FieldsTag, OptionsGroup, Label>>::value;
+        tmpl::index_of<ActionList, CompleteStep<FieldsTag, OptionsGroup, Label,
+                                                ArraySectionIdTag>>::value;
+    if (get<Convergence::Tags::HasConverged<OptionsGroup>>(box)) {
+      return {std::move(box), Parallel::AlgorithmExecution::Continue,
+              complete_step_index + 1};
+    }
+
+    // Skip the solve entirely on elements that are not part of the section. To
+    // do so, we skip ahead to the `SolveLinearization` action list between
+    // `PrepareStep` and `PerformStep`. Those actions need a chance to run even
+    // on elements that are not part of the section, because they may take part
+    // in preconditioning (see Multigrid preconditioner).
+    if constexpr (not std::is_same_v<ArraySectionIdTag, void>) {
+      if (not db::get<Parallel::Tags::Section<ParallelComponent,
+                                              ArraySectionIdTag>>(box)
+                  .has_value()) {
+        db::mutate<Convergence::Tags::IterationId<OptionsGroup>>(
+            make_not_null(&box),
+            [](const gsl::not_null<size_t*> local_iteration_id) noexcept {
+              *local_iteration_id = 1;
+            });
+        constexpr size_t prepare_step_index =
+            tmpl::index_of<ActionList,
+                           PrepareStep<FieldsTag, OptionsGroup, Label,
+                                       ArraySectionIdTag>>::value;
+        return {std::move(box), Parallel::AlgorithmExecution::Continue,
+                prepare_step_index + 1};
+      }
+    }
+
     constexpr size_t this_action_index =
         tmpl::index_of<ActionList, ReceiveInitialHasConverged>::value;
     return {std::move(box), Parallel::AlgorithmExecution::Continue,
-            get<Convergence::Tags::HasConverged<OptionsGroup>>(box)
-                ? complete_step_index
-                : (this_action_index + 1)};
+            this_action_index + 1};
   }
 };
 
@@ -222,7 +300,8 @@ struct ReceiveInitialHasConverged {
 //
 // The algorithm jumps back to this action from `CompleteStep` to continue
 // iterating the nonlinear solve.
-template <typename FieldsTag, typename OptionsGroup, typename Label>
+template <typename FieldsTag, typename OptionsGroup, typename Label,
+          typename ArraySectionIdTag>
 struct PrepareStep {
  private:
   using fields_tag = FieldsTag;
@@ -296,7 +375,8 @@ struct PrepareStep {
 // The `Globalize` action will jump back here in case the step turned out to not
 // decrease the residual sufficiently. It will have adjusted the step length, so
 // we can just try again with a step of that length.
-template <typename FieldsTag, typename OptionsGroup, typename Label>
+template <typename FieldsTag, typename OptionsGroup, typename Label,
+          typename ArraySectionIdTag>
 struct PerformStep {
  private:
   using fields_tag = FieldsTag;
@@ -312,12 +392,26 @@ struct PerformStep {
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>
-  static std::tuple<db::DataBox<DbTagsList>&&> apply(
-      db::DataBox<DbTagsList>& box,
-      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-      const Parallel::GlobalCache<Metavariables>& /*cache*/,
-      const ArrayIndex& array_index, const ActionList /*meta*/,
-      const ParallelComponent* const /*meta*/) noexcept {
+  static std::tuple<db::DataBox<DbTagsList>&&, Parallel::AlgorithmExecution,
+                    size_t>
+  apply(db::DataBox<DbTagsList>& box,
+        const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+        const Parallel::GlobalCache<Metavariables>& /*cache*/,
+        const ArrayIndex& array_index, const ActionList /*meta*/,
+        const ParallelComponent* const /*meta*/) noexcept {
+    // Skip to the end of the step on elements that are not part of the section
+    if constexpr (not std::is_same_v<ArraySectionIdTag, void>) {
+      if (not db::get<
+              Parallel::Tags::Section<ParallelComponent, ArraySectionIdTag>>(
+              box)) {
+        constexpr size_t globalize_index =
+            tmpl::index_of<ActionList, Globalize<FieldsTag, OptionsGroup, Label,
+                                                 ArraySectionIdTag>>::value;
+        return {std::move(box), Parallel::AlgorithmExecution::Continue,
+                globalize_index};
+      }
+    }
+
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                  ::Verbosity::Debug)) {
       Parallel::printf(
@@ -339,7 +433,10 @@ struct PerformStep {
         db::get<NonlinearSolver::Tags::StepLength<OptionsGroup>>(box),
         db::get<globalization_fields_tag>(box));
 
-    return {std::move(box)};
+    constexpr size_t this_action_index =
+        tmpl::index_of<ActionList, PerformStep>::value;
+    return {std::move(box), Parallel::AlgorithmExecution::Continue,
+            this_action_index + 1};
   }
 };
 
@@ -348,7 +445,8 @@ struct PerformStep {
 // tag, so at this point we need to check if the step has sufficiently reduced
 // the residual. We perform a global reduction to the `ResidualMonitor` for this
 // purpose.
-template <typename FieldsTag, typename OptionsGroup, typename Label>
+template <typename FieldsTag, typename OptionsGroup, typename Label,
+          typename ArraySectionIdTag>
 struct ContributeToResidualMagnitudeReduction {
  private:
   using fields_tag = FieldsTag;
@@ -374,12 +472,15 @@ struct ContributeToResidualMagnitudeReduction {
             Convergence::Tags::IterationId<OptionsGroup>>>(box),
         local_residual_magnitude_square,
         db::get<NonlinearSolver::Tags::StepLength<OptionsGroup>>(box)};
+    auto& section = Parallel::get_section<ParallelComponent, ArraySectionIdTag>(
+        make_not_null(&box));
     Parallel::contribute_to_reduction<
         CheckResidualMagnitude<FieldsTag, OptionsGroup, ParallelComponent>>(
         std::move(reduction_data),
         Parallel::get_parallel_component<ParallelComponent>(cache)[array_index],
         Parallel::get_parallel_component<
-            ResidualMonitor<Metavariables, FieldsTag, OptionsGroup>>(cache));
+            ResidualMonitor<Metavariables, FieldsTag, OptionsGroup>>(cache),
+        make_not_null(&section));
     return {std::move(box)};
   }
 };
@@ -389,7 +490,8 @@ struct ContributeToResidualMagnitudeReduction {
 // to `CompleteStep`. If it hasn't, the `ResidualMonitor` has also sent the new
 // step length along, so we mutate it in the DataBox and jump back to
 // `PerformStep` to try again with the updated step length.
-template <typename FieldsTag, typename OptionsGroup, typename Label>
+template <typename FieldsTag, typename OptionsGroup, typename Label,
+          typename ArraySectionIdTag>
 struct Globalize {
   using const_global_cache_tags =
       tmpl::list<logging::Tags::Verbosity<OptionsGroup>>;
@@ -406,17 +508,56 @@ struct Globalize {
         const ArrayIndex& array_index, const ActionList /*meta*/,
         const ParallelComponent* const /*meta*/) noexcept {
     auto& inbox = get<Tags::GlobalizationResult<OptionsGroup>>(inboxes);
-    if (inbox.find(db::get<Convergence::Tags::IterationId<OptionsGroup>>(
-            box)) == inbox.end()) {
+    const size_t iteration_id =
+        db::get<Convergence::Tags::IterationId<OptionsGroup>>(box);
+    if (inbox.find(iteration_id) == inbox.end()) {
       return {std::move(box), Parallel::AlgorithmExecution::Retry,
               std::numeric_limits<size_t>::max()};
     }
 
     // Retrieve reduction data from inbox
-    auto globalization_result = std::move(
-        inbox
-            .extract(db::get<Convergence::Tags::IterationId<OptionsGroup>>(box))
-            .mapped());
+    auto globalization_result = std::move(inbox.extract(iteration_id).mapped());
+
+    // Elements that are not part of the section jump directly to the
+    // `SolveLinearization` for the next step.
+    constexpr size_t complete_step_index =
+        tmpl::index_of<ActionList, CompleteStep<FieldsTag, OptionsGroup, Label,
+                                                ArraySectionIdTag>>::value;
+    constexpr size_t prepare_step_index =
+        tmpl::index_of<ActionList, PrepareStep<FieldsTag, OptionsGroup, Label,
+                                               ArraySectionIdTag>>::value;
+    if constexpr (not std::is_same_v<ArraySectionIdTag, void>) {
+      if (not db::get<
+              Parallel::Tags::Section<ParallelComponent, ArraySectionIdTag>>(
+              box)) {
+        const bool globalization_is_complete =
+            std::holds_alternative<Convergence::HasConverged>(
+                globalization_result);
+        // Wait until globalization is complete
+        if (not globalization_is_complete) {
+          return {std::move(box), Parallel::AlgorithmExecution::Retry,
+                  std::numeric_limits<size_t>::max()};
+        }
+        auto& has_converged =
+            get<Convergence::HasConverged>(globalization_result);
+
+        db::mutate<Convergence::Tags::HasConverged<OptionsGroup>,
+                   Convergence::Tags::IterationId<OptionsGroup>>(
+            make_not_null(&box),
+            [&has_converged](
+                const gsl::not_null<Convergence::HasConverged*>
+                    local_has_converged,
+                const gsl::not_null<size_t*> local_iteration_id) noexcept {
+              *local_has_converged = std::move(has_converged);
+              ++(*local_iteration_id);
+            });
+
+        return {std::move(box), Parallel::AlgorithmExecution::Continue,
+                get<Convergence::Tags::HasConverged<OptionsGroup>>(box)
+                    ? (complete_step_index + 1)
+                    : (prepare_step_index + 1)};
+      }
+    }
 
     if (std::holds_alternative<double>(globalization_result)) {
       if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
@@ -443,8 +584,8 @@ struct Globalize {
       // Continue globalization by taking a step with the updated step length
       // and checking the residual again
       constexpr size_t perform_step_index =
-          tmpl::index_of<ActionList,
-                         PerformStep<FieldsTag, OptionsGroup, Label>>::value;
+          tmpl::index_of<ActionList, PerformStep<FieldsTag, OptionsGroup, Label,
+                                                 ArraySectionIdTag>>::value;
       return {std::move(box), Parallel::AlgorithmExecution::Continue,
               perform_step_index};
     }
@@ -470,7 +611,8 @@ struct Globalize {
 // converged, or complete the solve and proceed with the action list if it has
 // converged. This is a separate action because the user has the opportunity to
 // insert actions before the step completes, for example to do observations.
-template <typename FieldsTag, typename OptionsGroup, typename Label>
+template <typename FieldsTag, typename OptionsGroup, typename Label,
+          typename ArraySectionIdTag>
 struct CompleteStep {
   using const_global_cache_tags =
       tmpl::list<logging::Tags::Verbosity<OptionsGroup>>;
@@ -494,8 +636,8 @@ struct CompleteStep {
 
     // Repeat steps until the solve has converged
     constexpr size_t prepare_step_index =
-        tmpl::index_of<ActionList,
-                       PrepareStep<FieldsTag, OptionsGroup, Label>>::value;
+        tmpl::index_of<ActionList, PrepareStep<FieldsTag, OptionsGroup, Label,
+                                               ArraySectionIdTag>>::value;
     constexpr size_t this_action_index =
         tmpl::index_of<ActionList, CompleteStep>::value;
     return {std::move(box), false,

--- a/tests/InputFiles/Elasticity/BentBeam.yaml
+++ b/tests/InputFiles/Elasticity/BentBeam.yaml
@@ -49,10 +49,16 @@ Observers:
 LinearSolver:
   GMRES:
     ConvergenceCriteria:
-      MaxIterations: 2
+      MaxIterations: 1
       RelativeResidual: 1.e-8
       AbsoluteResidual: 1.e-14
     Verbosity: Verbose
+
+  Multigrid:
+    Iterations: 1
+    MaxLevels: Auto
+    Verbosity: Quiet
+    OutputVolumeData: False
 
   SchwarzSmoother:
     Iterations: 3

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -3,7 +3,7 @@
 
 # Executable: SolveElasticity3D
 # Check: parse;execute_check_output
-# Timeout: 10
+# Timeout: 30
 # ExpectedOutput:
 #   ElasticHalfSpaceMirrorReductions.h5
 #   ElasticHalfSpaceMirrorVolume0.h5
@@ -12,7 +12,7 @@
 #     Subfile: /ErrorNorms.dat
 #     FileGlob: ElasticHalfSpaceMirrorReductions.h5
 #     SkipColumns: [0, 1]
-#     AbsoluteTolerance: 6.e-4
+#     AbsoluteTolerance: 5.e-4
 
 Background:
   HalfSpaceMirror:
@@ -34,8 +34,8 @@ DomainCreator:
     OuterRadius: 0.6
     LowerBound: 0
     UpperBound: 0.3
-    InitialRefinement: 0
-    InitialGridPoints: [3, 3, 4]
+    InitialRefinement: [1, 0, 0]
+    InitialGridPoints: [2, 3, 3]
     UseEquiangularMap: True
     RadialPartitioning: []
     HeightPartitioning: []
@@ -67,6 +67,12 @@ LinearSolver:
       RelativeResidual: 1.e-4
       AbsoluteResidual: 1.e-12
     Verbosity: Verbose
+
+  Multigrid:
+    Iterations: 1
+    MaxLevels: Auto
+    Verbosity: Quiet
+    OutputVolumeData: False
 
   SchwarzSmoother:
     Iterations: 3

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -46,10 +46,16 @@ Observers:
 
 LinearSolver:
   ConvergenceCriteria:
-    MaxIterations: 4
+    MaxIterations: 3
     RelativeResidual: 1.e-10
     AbsoluteResidual: 1.e-10
   Verbosity: Verbose
+
+  Multigrid:
+    Iterations: 1
+    MaxLevels: Auto
+    Verbosity: Quiet
+    OutputVolumeData: True
 
   SchwarzSmoother:
     Iterations: 3

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -42,10 +42,16 @@ Observers:
 
 LinearSolver:
   ConvergenceCriteria:
-    MaxIterations: 2
+    MaxIterations: 1
     RelativeResidual: 1.e-10
     AbsoluteResidual: 1.e-10
   Verbosity: Verbose
+
+  Multigrid:
+    Iterations: 1
+    MaxLevels: Auto
+    Verbosity: Verbose
+    OutputVolumeData: False
 
   SchwarzSmoother:
     Iterations: 3

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -47,6 +47,12 @@ LinearSolver:
     AbsoluteResidual: 1.e-6
   Verbosity: Verbose
 
+  Multigrid:
+    Iterations: 1
+    MaxLevels: Auto
+    Verbosity: Verbose
+    OutputVolumeData: False
+
   SchwarzSmoother:
     Iterations: 3
     MaxOverlap: 2

--- a/tests/InputFiles/Xcts/Schwarzschild.yaml
+++ b/tests/InputFiles/Xcts/Schwarzschild.yaml
@@ -73,6 +73,12 @@ LinearSolver:
       AbsoluteResidual: 1.e-12
     Verbosity: Quiet
 
+  Multigrid:
+    Iterations: 1
+    MaxLevels: Auto
+    Verbosity: Verbose
+    OutputVolumeData: False
+
   SchwarzSmoother:
     Iterations: 3
     MaxOverlap: 2

--- a/tests/Unit/Helpers/ParallelAlgorithms/Events/ObserveFields.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Events/ObserveFields.hpp
@@ -51,6 +51,8 @@ struct ObservationTimeTag : db::SimpleTag {
   using type = double;
 };
 
+struct TestSectionIdTag {};
+
 struct MockContributeVolumeData {
   struct Results {
     observers::ObservationId observation_id{};
@@ -139,8 +141,11 @@ struct Metavariables {
 
 // Test systems
 
-template <template <size_t, class...> class ObservationEvent>
+template <template <size_t, class...> class ObservationEvent,
+          typename... ExtraArgs>
 struct ScalarSystem {
+  using extra_args = tmpl::list<ExtraArgs...>;
+
   struct ScalarVar : db::SimpleTag {
     static std::string name() noexcept { return "Scalar"; }
     using type = Scalar<DataVector>;
@@ -174,7 +179,7 @@ struct ScalarSystem {
 
   using ObserveEvent =
       ObservationEvent<volume_dim, ObservationTimeTag, all_vars_for_test,
-                       typename solution_for_test::vars_for_test>;
+                       typename solution_for_test::vars_for_test, ExtraArgs...>;
   static constexpr auto creation_string_for_test =
       "ObserveFields:\n"
       "  SubfileName: element_data\n"
@@ -191,8 +196,11 @@ struct ScalarSystem {
   }
 };
 
-template <template <size_t, class...> class ObservationEvent>
+template <template <size_t, class...> class ObservationEvent,
+          typename... ExtraArgs>
 struct ComplicatedSystem {
+  using extra_args = tmpl::list<ExtraArgs...>;
+
   struct ScalarVar : db::SimpleTag {
     static std::string name() noexcept { return "Scalar"; }
     using type = Scalar<DataVector>;
@@ -277,7 +285,7 @@ struct ComplicatedSystem {
 
   using ObserveEvent =
       ObservationEvent<volume_dim, ObservationTimeTag, all_vars_for_test,
-                       typename solution_for_test::vars_for_test>;
+                       typename solution_for_test::vars_for_test, ExtraArgs...>;
   static constexpr auto creation_string_for_test =
       "ObserveFields:\n"
       "  SubfileName: element_data\n"

--- a/tests/Unit/ParallelAlgorithms/Events/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Events/CMakeLists.txt
@@ -15,10 +15,20 @@ add_test_library(
   ${LIBRARY}
   "ParallelAlgorithms/Events/"
   "${LIBRARY_SOURCES}"
-  "DataStructures;Domain;ErrorHandling;EventsAndTriggers;IO;Spectral;Time;Utilities"
+  ""
   )
 
-add_dependencies(
+target_link_libraries(
   ${LIBRARY}
-  module_GlobalCache
+  PRIVATE
+  DataStructures
+  Domain
+  ErrorHandling
+  Events
+  EventsAndTriggers
+  Interpolation
+  IO
+  Spectral
+  Time
+  Utilities
   )

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/CMakeLists.txt
@@ -49,6 +49,7 @@ target_link_libraries(
   Test_MultigridPreconditionedGmresAlgorithm
   PRIVATE
   ParallelMultigrid
+  ParallelNonlinearSolver
   )
 
 add_subdirectory(Actions)

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithm.cpp
@@ -87,13 +87,17 @@ struct Metavariables {
                                       typename smoother::register_element,
                                       Parallel::Actions::TerminatePhase>;
 
+  template <typename OperandTag>
+  using compute_operator_action = helpers_mg::ComputeOperatorAction<
+      OperandTag,
+      db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo, OperandTag>>;
+
   // [action_list]
   template <typename Label>
   using smooth_actions = tmpl::list<
-      helpers_mg::ComputeOperatorAction<typename smoother::fields_tag>,
+      compute_operator_action<typename smoother::fields_tag>,
       typename smoother::template solve<
-          helpers_mg::ComputeOperatorAction<typename smoother::operand_tag>,
-          Label>>;
+          compute_operator_action<typename smoother::operand_tag>, Label>>;
 
   using solve_actions =
       tmpl::list<typename multigrid::template solve<

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridPreconditionedGmresAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridPreconditionedGmresAlgorithm.yaml
@@ -44,11 +44,21 @@ Observers:
   VolumeFileName: "Test_MultigridPreconditionedGmresAlgorithm_Volume"
   ReductionFileName: "Test_MultigridPreconditionedGmresAlgorithm_Reductions"
 
-KrylovSolver:
+NewtonRaphsonSolver:
   ConvergenceCriteria:
     MaxIterations: 2
-    AbsoluteResidual: 1e-14
+    AbsoluteResidual: 1.e-14
     RelativeResidual: 0
+  Verbosity: Verbose
+  SufficientDecrease: 1.e-4
+  MaxGlobalizationSteps: 40
+  DampingFactor: 1
+
+KrylovSolver:
+  ConvergenceCriteria:
+    MaxIterations: 1
+    AbsoluteResidual: 1.e-14
+    RelativeResidual: 1.e-8
   Verbosity: Verbose
 
 MultigridSolver:


### PR DESCRIPTION
## Proposed changes

Adds multigrid-preconditioning to the elliptic executables. With this PR the elliptic solver is pretty much complete<s>, only #3378 is left to speed it up significantly</s>.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
