### PR TITLE
Add Newtonian Euler numerical characteristics

### DIFF
--- a/src/Evolution/Systems/NewtonianEuler/Characteristics.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Characteristics.cpp
@@ -21,6 +21,100 @@
 // IWYU pragma: no_forward_declare Tensor
 
 namespace NewtonianEuler {
+namespace detail {
+template <>
+Matrix flux_jacobian<1>(const tnsr::I<double, 1>& velocity,
+                        const double kappa_over_density,
+                        const double b_times_theta,
+                        const double specific_enthalpy,
+                        const tnsr::i<double, 1>& unit_normal) noexcept {
+  const double n_x = get<0>(unit_normal);
+  const double u = get<0>(velocity);
+  const Matrix a_x = blaze::DynamicMatrix<double>{
+      {0., 1., 0.},
+      {b_times_theta - square(u), u * (2. - kappa_over_density),
+       kappa_over_density},
+      {u * (b_times_theta - specific_enthalpy),
+       specific_enthalpy - kappa_over_density * square(u),
+       u * (kappa_over_density + 1.)}};
+  return n_x * a_x;
+}
+
+template <>
+Matrix flux_jacobian<2>(const tnsr::I<double, 2>& velocity,
+                        const double kappa_over_density,
+                        const double b_times_theta,
+                        const double specific_enthalpy,
+                        const tnsr::i<double, 2>& unit_normal) noexcept {
+  const double n_x = get<0>(unit_normal);
+  const double n_y = get<1>(unit_normal);
+  const double u = get<0>(velocity);
+  const double v = get<1>(velocity);
+  const Matrix a_x = blaze::DynamicMatrix<double>{
+      {0., 1., 0., 0.},
+      {b_times_theta - square(u), u * (2. - kappa_over_density),
+       -v * kappa_over_density, kappa_over_density},
+      {-u * v, v, u, 0.},
+      {u * (b_times_theta - specific_enthalpy),
+       specific_enthalpy - kappa_over_density * square(u),
+       -u * v * kappa_over_density, u * (kappa_over_density + 1.)}};
+  const Matrix a_y = blaze::DynamicMatrix<double>{
+      {0., 0., 1., 0.},
+      {-u * v, v, u, 0.},
+      {b_times_theta - square(v), -u * kappa_over_density,
+       v * (2. - kappa_over_density), kappa_over_density},
+      {v * (b_times_theta - specific_enthalpy), -u * v * kappa_over_density,
+       specific_enthalpy - kappa_over_density * square(v),
+       v * (kappa_over_density + 1.)}};
+  return n_x * a_x + n_y * a_y;
+}
+
+template <>
+Matrix flux_jacobian<3>(const tnsr::I<double, 3>& velocity,
+                        const double kappa_over_density,
+                        const double b_times_theta,
+                        const double specific_enthalpy,
+                        const tnsr::i<double, 3>& unit_normal) noexcept {
+  const double n_x = get<0>(unit_normal);
+  const double n_y = get<1>(unit_normal);
+  const double n_z = get<2>(unit_normal);
+  const double u = get<0>(velocity);
+  const double v = get<1>(velocity);
+  const double w = get<2>(velocity);
+  const Matrix a_x = blaze::DynamicMatrix<double>{
+      {0., 1., 0., 0., 0.},
+      {b_times_theta - square(u), u * (2. - kappa_over_density),
+       -v * kappa_over_density, -w * kappa_over_density, kappa_over_density},
+      {-u * v, v, u, 0., 0.},
+      {-u * w, w, 0., u, 0.},
+      {u * (b_times_theta - specific_enthalpy),
+       specific_enthalpy - kappa_over_density * square(u),
+       -u * v * kappa_over_density, -u * w * kappa_over_density,
+       u * (kappa_over_density + 1.)}};
+  const Matrix a_y = blaze::DynamicMatrix<double>{
+      {0., 0., 1., 0., 0.},
+      {-u * v, v, u, 0., 0.},
+      {b_times_theta - square(v), -u * kappa_over_density,
+       v * (2. - kappa_over_density), -w * kappa_over_density,
+       kappa_over_density},
+      {-v * w, 0., w, v, 0.},
+      {v * (b_times_theta - specific_enthalpy), -u * v * kappa_over_density,
+       specific_enthalpy - kappa_over_density * square(v),
+       -v * w * kappa_over_density, v * (kappa_over_density + 1.)}};
+  const Matrix a_z = blaze::DynamicMatrix<double>{
+      {0., 0., 0., 1., 0.},
+      {-u * w, w, 0., u, 0.},
+      {-v * w, 0., w, v, 0.},
+      {b_times_theta - square(w), -u * kappa_over_density,
+       -v * kappa_over_density, w * (2. - kappa_over_density),
+       kappa_over_density},
+      {w * (b_times_theta - specific_enthalpy), -u * w * kappa_over_density,
+       -v * w * kappa_over_density,
+       specific_enthalpy - kappa_over_density * square(w),
+       w * (kappa_over_density + 1.)}};
+  return n_x * a_x + n_y * a_y + n_z * a_z;
+}
+}  // namespace detail
 
 template <size_t Dim>
 void characteristic_speeds(

--- a/src/Evolution/Systems/NewtonianEuler/Characteristics.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Characteristics.hpp
@@ -130,6 +130,25 @@ Matrix left_eigenvectors(const tnsr::I<double, Dim>& velocity,
                          const tnsr::i<double, Dim>& unit_normal) noexcept;
 /// @}
 
+/*!
+ * \brief Compute the transform matrices between the conserved variables and
+ * the characteristic variables of the NewtonianEuler system.
+ *
+ * See `right_eigenvectors` and `left_eigenvectors` for more details.
+ *
+ * However, note that this function computes the transformation (i.e., the
+ * eigenvectors of the flux Jacobian) numerically, instead of using the analytic
+ * expressions. This is useful as a proof-of-concept for more complicated
+ * systems where the analytic expressions may not be known.
+ */
+template <size_t Dim>
+std::pair<DataVector, std::pair<Matrix, Matrix>> numerical_eigensystem(
+    const tnsr::I<double, Dim>& velocity,
+    const Scalar<double>& sound_speed_squared,
+    const Scalar<double>& specific_enthalpy,
+    const Scalar<double>& kappa_over_density,
+    const tnsr::i<double, Dim>& unit_normal) noexcept;
+
 namespace Tags {
 
 template <size_t Dim>

--- a/src/Evolution/Systems/NewtonianEuler/Characteristics.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Characteristics.hpp
@@ -32,6 +32,22 @@ class DataVector;
 
 namespace NewtonianEuler {
 
+namespace detail {
+// Compute the flux Jacobian for the NewtonianEuler system
+//
+// The flux Jacobian is \f$n_i A^i = n_i \partial F^i / \partial U\f$.
+// The input `b_times_theta` is \f$b\theta = \kappa/\rho (v^2 - h) + c_s^2\f$.
+//
+// This is used for:
+// - testing the analytic characteristic transformation
+// - as input for the numerical characteristic transformation
+template <size_t Dim>
+Matrix flux_jacobian(const tnsr::I<double, Dim>& velocity,
+                     double kappa_over_density, double b_times_theta,
+                     double specific_enthalpy,
+                     const tnsr::i<double, Dim>& unit_normal) noexcept;
+}  // namespace detail
+
 /// @{
 /*!
  * \brief Compute the characteristic speeds of NewtonianEuler system

--- a/src/Evolution/Systems/NewtonianEuler/Limiters/CharacteristicHelpers.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Limiters/CharacteristicHelpers.hpp
@@ -41,7 +41,8 @@ std::pair<Matrix, Matrix> right_and_left_eigenvectors(
     const Scalar<double>& mean_energy,
     const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
         equation_of_state,
-    const tnsr::i<double, VolumeDim>& unit_vector) noexcept;
+    const tnsr::i<double, VolumeDim>& unit_vector,
+    bool compute_char_transformation_numerically = false) noexcept;
 
 /// @{
 /// \brief Compute characteristic fields from conserved fields
@@ -145,7 +146,8 @@ bool apply_limiter_to_characteristic_fields_in_all_directions(
     const Mesh<VolumeDim>& mesh,
     const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
         equation_of_state,
-    const LimiterLambda& prepare_and_apply_limiter) noexcept {
+    const LimiterLambda& prepare_and_apply_limiter,
+    const bool compute_char_transformation_numerically = false) noexcept {
   // Temp variables for calculations
   // There are quite a few tensors in this allocation because in general we need
   // to preserve the input (cons field) tensors until they are overwritten at
@@ -205,7 +207,7 @@ bool apply_limiter_to_characteristic_fields_in_all_directions(
     const auto right_and_left =
         NewtonianEuler::Limiters::right_and_left_eigenvectors(
             mean_density, mean_momentum, mean_energy, equation_of_state,
-            unit_vector);
+            unit_vector, compute_char_transformation_numerically);
     const auto& right = right_and_left.first;
     const auto& left = right_and_left.second;
 

--- a/src/Evolution/Systems/NewtonianEuler/Limiters/VariablesToLimit.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Limiters/VariablesToLimit.cpp
@@ -18,6 +18,8 @@ std::ostream& NewtonianEuler::Limiters::operator<<(
       return os << "Conserved";
     case NewtonianEuler::Limiters::VariablesToLimit::Characteristic:
       return os << "Characteristic";
+    case NewtonianEuler::Limiters::VariablesToLimit::NumericalCharacteristic:
+      return os << "NumericalCharacteristic";
     default:  // LCOV_EXCL_LINE
       // LCOV_EXCL_START
       ERROR("Missing a case for operator<<(VariablesToLimit)");
@@ -34,10 +36,12 @@ Options::create_from_yaml<NewtonianEuler::Limiters::VariablesToLimit>::create<
     return NewtonianEuler::Limiters::VariablesToLimit::Conserved;
   } else if (vars_to_limit_read_type == "Characteristic") {
     return NewtonianEuler::Limiters::VariablesToLimit::Characteristic;
+  } else if (vars_to_limit_read_type == "NumericalCharacteristic") {
+    return NewtonianEuler::Limiters::VariablesToLimit::NumericalCharacteristic;
   }
   PARSE_ERROR(options.context(),
               "Failed to convert \""
                   << vars_to_limit_read_type
                   << "\" to VariablesToLimit. Expected one of: "
-                     "{Conserved, Characteristic}.");
+                     "{Conserved, Characteristic, NumericalCharacteristic}.");
 }

--- a/src/Evolution/Systems/NewtonianEuler/Limiters/VariablesToLimit.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Limiters/VariablesToLimit.hpp
@@ -17,7 +17,23 @@ namespace NewtonianEuler {
 namespace Limiters {
 /// \ingroup LimitersGroup
 /// \brief Type of NewtonianEuler variables to apply limiter to
-enum class VariablesToLimit { Conserved, Characteristic };
+///
+/// \note The option `Characteristic` denotes the characteristic fields computed
+/// from the analytic expression, whereas the option `NumericalCharacteristic`
+/// denotes the fields as computed numerically by solving for the eigenvectors
+/// of the flux Jacobian.
+///
+/// Initial experiments with limiting in a Reimann problem by FH suggest the
+/// numerical eigenvectors can sometimes produce more accurate results than the
+/// analytic ones (does the numerical solution give a better linear combination
+/// of the degenerate eigenvectors?), and is not too much more expensive
+/// (probably the expense of the limiter as a whole dominates). More testing is
+/// needed to verify and understand this...
+enum class VariablesToLimit {
+  Conserved,
+  Characteristic,
+  NumericalCharacteristic
+};
 
 std::ostream& operator<<(std::ostream& os,
                          VariablesToLimit vars_to_limit) noexcept;

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Limiters/Test_VariablesToLimit.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Limiters/Test_VariablesToLimit.cpp
@@ -18,12 +18,17 @@ SPECTRE_TEST_CASE(
   CHECK(NewtonianEuler::Limiters::VariablesToLimit::Characteristic ==
         TestHelpers::test_creation<NewtonianEuler::Limiters::VariablesToLimit>(
             "Characteristic"));
+  CHECK(NewtonianEuler::Limiters::VariablesToLimit::NumericalCharacteristic ==
+        TestHelpers::test_creation<NewtonianEuler::Limiters::VariablesToLimit>(
+            "NumericalCharacteristic"));
 
   CHECK(get_output(NewtonianEuler::Limiters::VariablesToLimit::Conserved) ==
         "Conserved");
   CHECK(
       get_output(NewtonianEuler::Limiters::VariablesToLimit::Characteristic) ==
       "Characteristic");
+  CHECK(get_output(NewtonianEuler::Limiters::VariablesToLimit::
+                       NumericalCharacteristic) == "NumericalCharacteristic");
 }
 
 // [[OutputRegex, Failed to convert "BadVars" to VariablesToLimit]]

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Test_Characteristics.cpp
@@ -261,6 +261,101 @@ void test_right_and_left_eigenvectors() noexcept {
   }
 }
 
+template <size_t Dim>
+void test_numerical_eigenvectors() noexcept {
+  // This test verifies that the eigenvectors satisfy the conditions by which
+  // they are defined:
+  // - the right and left eigenvectors are matrix inverses of each other, i.e.,
+  //   left * right == right * left == identity
+  // - the right and left eigenvectors diagonalize the flux Jacobian, i.e.
+  //   right * eigenvalues * left == flux
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> distribution(-1., 1.);
+  std::uniform_real_distribution<> distribution_positive(1e-3, 1.);
+
+  const auto nn_generator = make_not_null(&generator);
+  const auto nn_distribution = make_not_null(&distribution);
+  const auto nn_distribution_positive = make_not_null(&distribution_positive);
+
+  const double used_for_size = 0.;
+  // This computes a unit normal. It is NOT uniformly distributed in angle,
+  // but for this test the distribution is not important.
+  const auto unit_normal = [&]() noexcept {
+    auto result = make_with_random_values<tnsr::i<double, Dim>>(
+        nn_generator, nn_distribution, used_for_size);
+    const double normal_magnitude = get(magnitude(result));
+    for (auto& n_i : result) {
+      n_i /= normal_magnitude;
+    }
+    return result;
+  }
+  ();
+
+  // To check the diagonalization of the Jacobian, we need a self consistent set
+  // of primitive and derived-from-primitive variables -- so generate everything
+  // from the primitives
+  const auto density = make_with_random_values<Scalar<double>>(
+      nn_generator, nn_distribution_positive, used_for_size);
+  const auto velocity = make_with_random_values<tnsr::I<double, Dim>>(
+      nn_generator, nn_distribution, used_for_size);
+  const auto specific_internal_energy = make_with_random_values<Scalar<double>>(
+      nn_generator, nn_distribution_positive, used_for_size);
+
+  const Scalar<double> v_squared{{{get(dot_product(velocity, velocity))}}};
+  const Scalar<double> energy_density{
+      {{get(density) * get(specific_internal_energy) +
+        0.5 * get(density) * get(v_squared)}}};
+
+  const EquationsOfState::IdealFluid<false> equation_of_state{5. / 3.};
+  const auto pressure = equation_of_state.pressure_from_density_and_energy(
+      density, specific_internal_energy);
+  const Scalar<double> specific_enthalpy{
+      {{(get(energy_density) + get(pressure)) / get(density)}}};
+  const auto sound_speed_squared = NewtonianEuler::sound_speed_squared(
+      density, specific_internal_energy, equation_of_state);
+  const auto kappa_over_density = Scalar<double>{
+      {{get(equation_of_state
+                .kappa_times_p_over_rho_squared_from_density_and_energy(
+                    density, specific_internal_energy)) *
+        get(density) / get(pressure)}}};
+  const double b_times_theta =
+      get(kappa_over_density) * (get(v_squared) - get(specific_enthalpy)) +
+      get(sound_speed_squared);
+
+  const auto expected_flux_jacobian = NewtonianEuler::detail::flux_jacobian(
+      velocity, get(kappa_over_density), b_times_theta, get(specific_enthalpy),
+      unit_normal);
+
+  const auto vals_and_vecs = NewtonianEuler::numerical_eigensystem(
+      velocity, sound_speed_squared, specific_enthalpy, kappa_over_density,
+      unit_normal);
+  const Matrix num_eigenvalues = [&vals_and_vecs]() noexcept {
+    Matrix result(Dim + 2, Dim + 2, 0.);
+    for (size_t i = 0; i < Dim + 2; ++i) {
+      result(i, i) = vals_and_vecs.first[i];
+    }
+    return result;
+  }
+  ();
+  const Matrix& num_right = vals_and_vecs.second.first;
+  const Matrix& num_left = vals_and_vecs.second.second;
+  const Matrix id1 = num_right * num_left;
+  const Matrix id2 = num_left * num_right;
+  const Matrix num_flux_jacobian = num_right * num_eigenvalues * num_left;
+
+  // Numerically-obtained eigenvectors may lead to slightly larger errors
+  Approx local_approx = Approx::custom().epsilon(1e-11).scale(1.0);
+  for (size_t i = 0; i < Dim + 2; ++i) {
+    for (size_t j = 0; j < Dim + 2; ++j) {
+      const double delta_ij = (i == j) ? 1. : 0.;
+      CHECK(id1(i, j) == local_approx(delta_ij));
+      CHECK(id2(i, j) == local_approx(delta_ij));
+      CHECK(num_flux_jacobian(i, j) ==
+            local_approx(expected_flux_jacobian(i, j)));
+    }
+  }
+}
+
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.NewtonianEuler.Characteristics",
@@ -275,4 +370,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.NewtonianEuler.Characteristics",
   test_right_and_left_eigenvectors<1>();
   test_right_and_left_eigenvectors<2>();
   test_right_and_left_eigenvectors<3>();
+
+  test_numerical_eigenvectors<1>();
+  test_numerical_eigenvectors<2>();
+  test_numerical_eigenvectors<3>();
 }


### PR DESCRIPTION
## Proposed changes

In the NewtonianEuler system, the characteristic transformation can be written down analytically.

Here we add an additional implementation that computes the characteristic transformation numerically, by numerically finding the eigenvectors of the flux jacobian. This isn't necessarily useful for NewtonianEuler, but will serve as a model implementation that more complicated systems without an easy characteristic transformation can follow.

The NewtonianEuler limiters are updated to be able to request the numerical characteristics with `VariablesToLimit: NumericalCharacteristic`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
