### PR TITLE
Update python on ocean

### DIFF
--- a/support/Environments/ocean_clang.sh
+++ b/support/Environments/ocean_clang.sh
@@ -35,13 +35,13 @@ spectre_unload_modules() {
     module unload boost-1.68.0-gcc-7.3.0-vgl6ofr
     module unload hdf5-1.12.0-gcc-7.3.0-mknp6xv
     module unload openblas-0.3.4-gcc-7.3.0-tt2coe7
-    module unload python/3.7.0
+    module unload python/3.9.5
     module unload charm-6.10.2-libs
 }
 
 spectre_load_modules() {
     module load ohpc
-    module load python/3.7.0
+    module load python/3.9.5
     module load gnu7/7.3.0
     module load openmpi/1.10.7
     module load prun/1.2

--- a/support/Environments/ocean_gcc.sh
+++ b/support/Environments/ocean_gcc.sh
@@ -35,13 +35,13 @@ spectre_unload_modules() {
     module unload boost-1.68.0-gcc-7.3.0-vgl6ofr
     module unload hdf5-1.12.0-gcc-7.3.0-mknp6xv
     module unload openblas-0.3.4-gcc-7.3.0-tt2coe7
-    module unload python/3.7.0
+    module unload python/3.9.5
     module unload charm-6.10.2-libs
 }
 
 spectre_load_modules() {
     module load ohpc
-    module load python/3.7.0
+    module load python/3.9.5
     module load gnu7/7.3.0
     module load openmpi/1.10.7
     module load prun/1.2


### PR DESCRIPTION
## Proposed changes

Update python on ocean to version 3.9.5, a new module on ocean that doesn't use anaconda, as previous python modules on ocean did.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
