### PR TITLE
Add output operators for DataBox and AlgorithmImpl

### DIFF
--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -12,6 +12,8 @@
 #include <limits>
 #include <ostream>
 #include <pup.h>
+#include <sstream>
+#include <string>
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
@@ -195,6 +197,18 @@ class AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>
 
   /// Charm++ migration constructor, used after a chare is migrated
   explicit AlgorithmImpl(CkMigrateMessage* /*msg*/) noexcept;
+
+  /// Print the expanded type aliases
+  std::string print_types() const noexcept;
+
+  /// Print the current state of the algorithm
+  std::string print_state() const noexcept;
+
+  /// Print the current contents of the inboxes
+  std::string print_inbox() const noexcept;
+
+  /// Print the current contents of the DataBox
+  std::string print_databox() const noexcept;
 
   void pup(PUP::er& p) noexcept override {  // NOLINT
 #ifdef SPECTRE_CHARM_PROJECTIONS
@@ -702,6 +716,77 @@ class AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>
 
 /// \cond
 template <typename ParallelComponent, typename... PhaseDepActionListsPack>
+std::string AlgorithmImpl<ParallelComponent,
+                          tmpl::list<PhaseDepActionListsPack...>>::print_types()
+    const noexcept {
+  std::ostringstream os;
+  os << "Algorithm type aliases:\n";
+  os << "using all_actions_list = " << pretty_type::get_name<all_actions_list>()
+     << ";\n";
+
+  os << "using metavariables = " << pretty_type::get_name<metavariables>()
+     << ";\n";
+  os << "using inbox_tags_list = " << pretty_type::get_name<inbox_tags_list>()
+     << ";\n";
+  os << "using array_index = " << pretty_type::get_name<array_index>() << ";\n";
+  os << "using parallel_component = "
+     << pretty_type::get_name<parallel_component>() << ";\n";
+  os << "using chare_type = " << pretty_type::get_name<chare_type>() << ";\n";
+  os << "using cproxy_type = " << pretty_type::get_name<cproxy_type>() << ";\n";
+  os << "using cbase_type = " << pretty_type::get_name<cbase_type>() << ";\n";
+  os << "using PhaseType = " << pretty_type::get_name<PhaseType>() << ";\n";
+  os << "using phase_dependent_action_lists = "
+     << pretty_type::get_name<phase_dependent_action_lists>() << ";\n";
+  os << "using all_cache_tags = " << pretty_type::get_name<all_cache_tags>()
+     << ";\n";
+  os << "using initial_databox = " << pretty_type::get_name<initial_databox>()
+     << ";\n";
+  os << "using databox_phase_types = "
+     << pretty_type::get_name<databox_phase_types>() << ";\n";
+  os << "using databox_types = " << pretty_type::get_name<databox_types>()
+     << ";\n";
+  os << "using variant_boxes = " << pretty_type::get_name<variant_boxes>()
+     << ";\n";
+  return os.str();
+}
+
+template <typename ParallelComponent, typename... PhaseDepActionListsPack>
+std::string AlgorithmImpl<ParallelComponent,
+                          tmpl::list<PhaseDepActionListsPack...>>::print_state()
+    const noexcept {
+  std::ostringstream os;
+  os << "State:\n";
+  os << "performing_action_ = " << std::boolalpha << performing_action_
+     << ";\n";
+  os << "phase_ = " << phase_ << ";\n";
+  os << "phase_bookmarks_ = " << phase_bookmarks_ << ";\n";
+  os << "algorithm_step_ = " << algorithm_step_ << ";\n";
+  os << "terminate_ = " << terminate_ << ";\n";
+  os << "halt_algorithm_until_next_phase_ = "
+     << halt_algorithm_until_next_phase_ << ";\n";
+  os << "array_index_ = " << array_index_ << ";\n";
+  return os.str();
+}
+
+template <typename ParallelComponent, typename... PhaseDepActionListsPack>
+std::string AlgorithmImpl<ParallelComponent,
+                          tmpl::list<PhaseDepActionListsPack...>>::print_inbox()
+    const noexcept {
+  std::ostringstream os;
+  os << "inboxes_ = " << inboxes_ << ";\n";
+  return os.str();
+}
+
+template <typename ParallelComponent, typename... PhaseDepActionListsPack>
+std::string AlgorithmImpl<
+    ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>::print_databox()
+    const noexcept {
+  std::ostringstream os;
+  os << "box_:\n" << box_;
+  return os.str();
+}
+
+  template <typename ParallelComponent, typename... PhaseDepActionListsPack>
 AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>::
     AlgorithmImpl() noexcept {
   set_array_index();
@@ -974,5 +1059,17 @@ AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>::
   // This is a template for loop for Is
   EXPAND_PACK_LEFT_TO_RIGHT(helper(std::integral_constant<size_t, Is>{}));
   return take_next_action;
+}
+
+template <typename ParallelComponent, typename PhaseDepActionLists>
+std::ostream& operator<<(
+    std::ostream& os,
+    const AlgorithmImpl<ParallelComponent, PhaseDepActionLists>&
+        algorithm_impl) noexcept {
+  os << algorithm_impl.print_types() << "\n";
+  os << algorithm_impl.print_state() << "\n";
+  os << algorithm_impl.print_inbox() << "\n";
+  os << algorithm_impl.print_databox() << "\n";
+  return os;
 }
 }  // namespace Parallel

--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -2715,6 +2715,81 @@ void test_get_mutable_reference() noexcept {
   // db::get_mutable_reference<Parent<0>>(make_not_null(&box));
   // db::get_mutable_reference<First<0>>(make_not_null(&box));
 }
+
+void test_output() noexcept {
+  INFO("test output");
+  auto box = db::create<
+      db::AddSimpleTags<test_databox_tags::Tag0, test_databox_tags::Tag1,
+                        test_databox_tags::Tag2>,
+      db::AddComputeTags<test_databox_tags::Tag4Compute,
+                         test_databox_tags::Tag5Compute>>(
+      3.14, std::vector<double>{8.7, 93.2, 84.7}, "My Sample String"s);
+  std::string output_types = box.print_types();
+  std::string expected_types =
+      "DataBox type aliases:\n"
+      "using tags_list = brigand::list<(anonymous "
+      "namespace)::test_databox_tags::Tag0, (anonymous "
+      "namespace)::test_databox_tags::Tag1, (anonymous "
+      "namespace)::test_databox_tags::Tag2, (anonymous "
+      "namespace)::test_databox_tags::Tag4Compute, (anonymous "
+      "namespace)::test_databox_tags::Tag5Compute>;\n"
+      "using immutable_item_tags "
+      "= brigand::list<(anonymous namespace)::test_databox_tags::Tag4Compute, "
+      "(anonymous namespace)::test_databox_tags::Tag5Compute>;\n"
+      "using immutable_item_creation_tags = brigand::list<(anonymous "
+      "namespace)::test_databox_tags::Tag4Compute, (anonymous "
+      "namespace)::test_databox_tags::Tag5Compute>;\n"
+      "using mutable_item_tags = brigand::list<(anonymous "
+      "namespace)::test_databox_tags::Tag0, (anonymous "
+      "namespace)::test_databox_tags::Tag1, (anonymous "
+      "namespace)::test_databox_tags::Tag2>;\n"
+      "using mutable_subitem_tags = brigand::list<>;\n"
+      "using compute_item_tags = brigand::list<(anonymous "
+      "namespace)::test_databox_tags::Tag4Compute, (anonymous "
+      "namespace)::test_databox_tags::Tag5Compute>;\n"
+      "using edge_list = "
+      "brigand::list<brigand::edge<(anonymous "
+      "namespace)::test_databox_tags::Tag0, (anonymous "
+      "namespace)::test_databox_tags::Tag4Compute, "
+      "brigand::integral_constant<int, 1> >, brigand::edge<(anonymous "
+      "namespace)::test_databox_tags::Tag2, (anonymous "
+      "namespace)::test_databox_tags::Tag5Compute, "
+      "brigand::integral_constant<int, 1> >, brigand::edge<(anonymous "
+      "namespace)::test_databox_tags::Tag4Compute, (anonymous "
+      "namespace)::test_databox_tags::Tag5Compute, "
+      "brigand::integral_constant<int, 1> > >;\n";
+  CHECK(output_types == expected_types);
+
+  std::string output_items = box.print_items();
+  std::string expected_items =
+      "Items:\n"
+      "----------\n"
+      "Name:  (anonymous namespace)::test_databox_tags::Tag0\n"
+      "Type:  double\n"
+      "Value: 3.14\n"
+      "----------\n"
+      "Name:  (anonymous namespace)::test_databox_tags::Tag1\n"
+      "Type:  std::vector<double>\n"
+      "Value: (8.7,93.2,84.7)\n"
+      "----------\n"
+      "Name:  (anonymous namespace)::test_databox_tags::Tag2\n"
+      "Type:  std::string\n"
+      "Value: My Sample String\n"
+      "----------\n"
+      "Name:  (anonymous namespace)::test_databox_tags::Tag4Compute\n"
+      "Type:  double\n"
+      "Value: 6.28\n"
+      "----------\n"
+      "Name:  (anonymous namespace)::test_databox_tags::Tag5Compute\n"
+      "Type:  std::string\n"
+      "Value: My Sample String6.28\n";
+  CHECK(output_items == expected_items);
+  std::ostringstream os;
+  os << box;
+  std::string output_stream = os.str();
+  std::string expected_stream = expected_types + "\n" + expected_items+ "\n";
+  CHECK(output_stream == expected_stream);
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.DataStructures.DataBox", "[Unit][DataStructures]") {
@@ -2737,6 +2812,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox", "[Unit][DataStructures]") {
   test_serialization();
   test_reference_item();
   test_get_mutable_reference();
+  test_output();
 }
 
 // Test`tag_is_retrievable_v`


### PR DESCRIPTION
These are useful for debugging and exploring.
For DataBox, adds two print functions, one that prints the expanded
type aliases, the other prints the items (but not subitems) held.
For AlgorithmImp, adds four print functions, one for the expanded type
aliases, the second for the state, the third for the contents of the
inbox, and the fourth for the contents of the DataBox.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
