### PR TITLE
Ease code coverage target for random-value tests

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -10,6 +10,8 @@ coverage:
     project:
       default:
         target: auto
+        # Account for random-value tests sometimes taking different code paths
+        threshold: 0.3%
     # Check that PRs are fully tested
     patch:
       default:


### PR DESCRIPTION
## Proposed changes

The random-value tests sometimes take different code paths,
e.g. when `equal_within_roundoff` is involved.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
