### PR TITLE
Add Krivodonova and Kuzmin executable to ScalarAdvection

### DIFF
--- a/src/Evolution/Executables/ScalarAdvection/CMakeLists.txt
+++ b/src/Evolution/Executables/ScalarAdvection/CMakeLists.txt
@@ -46,5 +46,14 @@ function(add_krivodonova_executable)
     )
 endfunction(add_krivodonova_executable)
 
+function(add_kuzmin_executable)
+  add_scalar_advection_executable(
+    Kuzmin
+    2
+    ScalarAdvection::Solutions::Kuzmin
+    )
+endfunction(add_kuzmin_executable)
+
 add_sinusoid_executable()
 add_krivodonova_executable()
+add_kuzmin_executable()

--- a/src/Evolution/Executables/ScalarAdvection/CMakeLists.txt
+++ b/src/Evolution/Executables/ScalarAdvection/CMakeLists.txt
@@ -38,4 +38,13 @@ function(add_sinusoid_executable)
     )
 endfunction(add_sinusoid_executable)
 
+function(add_krivodonova_executable)
+  add_scalar_advection_executable(
+    Krivodonova
+    1
+    ScalarAdvection::Solutions::Krivodonova
+    )
+endfunction(add_krivodonova_executable)
+
 add_sinusoid_executable()
+add_krivodonova_executable()

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -60,6 +60,7 @@
 #include "ParallelAlgorithms/EventsAndTriggers/Trigger.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/AddComputeTags.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Krivodonova.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Sinusoid.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "Time/Actions/AdvanceTime.hpp"            // IWYU pragma: keep

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "Domain/Creators/Factory1D.hpp"
+#include "Domain/Creators/Factory2D.hpp"
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
 #include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
@@ -61,6 +62,7 @@
 #include "ParallelAlgorithms/Initialization/Actions/AddComputeTags.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Krivodonova.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Kuzmin.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Sinusoid.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "Time/Actions/AdvanceTime.hpp"            // IWYU pragma: keep

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvectionFwd.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvectionFwd.hpp
@@ -8,6 +8,7 @@
 namespace ScalarAdvection {
 namespace Solutions {
 class Krivodonova;
+class Kuzmin;
 class Sinusoid;
 }  // namespace Solutions
 }  // namespace ScalarAdvection

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvectionFwd.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvectionFwd.hpp
@@ -7,6 +7,7 @@
 
 namespace ScalarAdvection {
 namespace Solutions {
+class Krivodonova;
 class Sinusoid;
 }  // namespace Solutions
 }  // namespace ScalarAdvection

--- a/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
@@ -1,0 +1,66 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Executable: EvolveScalarAdvectionKrivodonova1D
+# Check: parse;execute
+# ExpectedOutput:
+#   ScalarAdvectionKrivodonova1DVolume0.h5
+
+
+Evolution:
+  InitialTime: 0.0
+  InitialTimeStep: 0.001
+  TimeStepper: RungeKutta3
+
+PhaseChangeAndTriggers:
+
+DomainCreator:
+  Interval:
+    LowerBound: [-1.0]
+    UpperBound: [1.0]
+    InitialRefinement: [1]
+    InitialGridPoints: [2]
+    TimeDependence: None
+    BoundaryConditions:
+      LowerBoundary: Periodic
+      UpperBoundary: Periodic
+
+SpatialDiscretization:
+  BoundaryCorrection:
+    Rusanov:
+  DiscontinuousGalerkin:
+    Formulation: StrongInertial
+    Quadrature: GaussLobatto
+
+AnalyticSolution:
+  Krivodonova:
+
+Limiter:
+  Minmod:
+    Type: LambdaPi1
+    # The optimal value of the TVB constant is problem-dependent.
+    # This test uses 0 to favor robustness over accuracy.
+    TvbConstant: 0.0
+    DisableForDebugging: false
+
+EventsAndTriggers:
+  ? Slabs:
+      Specified:
+        Values: [100]
+  : - Completion
+  ? Slabs:
+      EvenlySpaced:
+        Interval: 10
+        Offset: 0
+  : - ObserveFields:
+        SubfileName: VolumeData
+        VariablesToObserve: [U, VelocityField]
+        InterpolateToMesh: None
+        CoordinatesFloatingPointType: Double
+        FloatingPointTypes: [Double, Double]
+
+EventsAndDenseTriggers:
+
+Observers:
+  VolumeFileName: "ScalarAdvectionKrivodonova1DVolume"
+  ReductionFileName: "ScalarAdvectionKrivodonova1DReductions"

--- a/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
@@ -2,14 +2,20 @@
 # See LICENSE.txt for details.
 
 # Executable: EvolveScalarAdvectionKrivodonova1D
-# Check: parse;execute
+# Check: parse;execute_check_output
 # ExpectedOutput:
 #   ScalarAdvectionKrivodonova1DVolume0.h5
-
+#   ScalarAdvectionKrivodonova1DReductions.h5
+# OutputFileChecks:
+#   - Label: check_analytic_solution
+#     Subfile: /ErrorNorms.dat
+#     FileGlob: ScalarAdvectionKrivodonova1DReductions.h5
+#     SkipColumns: [0,1]
+#     AbsoluteTolerance: 0.2
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.001
+  InitialTimeStep: 0.005
   TimeStepper: RungeKutta3
 
 PhaseChangeAndTriggers:
@@ -18,7 +24,7 @@ DomainCreator:
   Interval:
     LowerBound: [-1.0]
     UpperBound: [1.0]
-    InitialRefinement: [1]
+    InitialRefinement: [5]
     InitialGridPoints: [2]
     TimeDependence: None
     BoundaryConditions:
@@ -46,8 +52,14 @@ Limiter:
 EventsAndTriggers:
   ? Slabs:
       Specified:
-        Values: [100]
+        Values: [10]
   : - Completion
+  ? Slabs:
+      EvenlySpaced:
+        Interval: 5
+        Offset: 0
+  : - ObserveErrorNorms:
+        SubfileName: ErrorNorms
   ? Slabs:
       EvenlySpaced:
         Interval: 10

--- a/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
@@ -1,0 +1,63 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Executable: EvolveScalarAdvectionKuzmin2D
+# Check: parse;execute
+# ExpectedOutput:
+#   ScalarAdvectionKuzmin2DVolume0.h5
+
+Evolution:
+  InitialTime: 0.0
+  InitialTimeStep: 0.001
+  TimeStepper: RungeKutta3
+
+PhaseChangeAndTriggers:
+
+DomainCreator:
+  Rectangle:
+    LowerBound: [0.0, 0.0]
+    UpperBound: [1.0, 1.0]
+    InitialRefinement: [1, 1]
+    InitialGridPoints: [2, 2]
+    TimeDependence: None
+    BoundaryCondition: Periodic
+
+SpatialDiscretization:
+  BoundaryCorrection:
+    Rusanov:
+  DiscontinuousGalerkin:
+    Formulation: StrongInertial
+    Quadrature: GaussLobatto
+
+AnalyticSolution:
+  Kuzmin:
+
+Limiter:
+  Minmod:
+    Type: LambdaPi1
+    # The optimal value of the TVB constant is problem-dependent.
+    # This test uses 0 to favor robustness over accuracy.
+    TvbConstant: 0.0
+    DisableForDebugging: false
+
+EventsAndTriggers:
+  ? Slabs:
+      Specified:
+        Values: [100]
+  : - Completion
+  ? Slabs:
+      EvenlySpaced:
+        Interval: 10
+        Offset: 0
+  : - ObserveFields:
+        SubfileName: VolumeData
+        VariablesToObserve: [U, VelocityField]
+        InterpolateToMesh: None
+        CoordinatesFloatingPointType: Double
+        FloatingPointTypes: [Double, Double]
+
+EventsAndDenseTriggers:
+
+Observers:
+  VolumeFileName: "ScalarAdvectionKuzmin2DVolume"
+  ReductionFileName: "ScalarAdvectionKuzmin2DReductions"

--- a/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
@@ -2,13 +2,21 @@
 # See LICENSE.txt for details.
 
 # Executable: EvolveScalarAdvectionKuzmin2D
-# Check: parse;execute
+# Check: parse;execute_check_output
+# Timeout: 10
 # ExpectedOutput:
 #   ScalarAdvectionKuzmin2DVolume0.h5
+#   ScalarAdvectionKuzmin2DReductions.h5
+# OutputFileChecks:
+#   - Label: check_analytic_solution
+#     Subfile: /ErrorNorms.dat
+#     FileGlob: ScalarAdvectionKuzmin2DReductions.h5
+#     SkipColumns: [0,1]
+#     AbsoluteTolerance: 0.2
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.001
+  InitialTimeStep: 0.01
   TimeStepper: RungeKutta3
 
 PhaseChangeAndTriggers:
@@ -17,8 +25,8 @@ DomainCreator:
   Rectangle:
     LowerBound: [0.0, 0.0]
     UpperBound: [1.0, 1.0]
-    InitialRefinement: [1, 1]
-    InitialGridPoints: [2, 2]
+    InitialRefinement: [3, 3]
+    InitialGridPoints: [3, 3]
     TimeDependence: None
     BoundaryCondition: Periodic
 
@@ -43,8 +51,14 @@ Limiter:
 EventsAndTriggers:
   ? Slabs:
       Specified:
-        Values: [100]
+        Values: [10]
   : - Completion
+  ? Slabs:
+      EvenlySpaced:
+        Interval: 5
+        Offset: 0
+  : - ObserveErrorNorms:
+        SubfileName: ErrorNorms
   ? Slabs:
       EvenlySpaced:
         Interval: 10

--- a/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
@@ -2,13 +2,20 @@
 # See LICENSE.txt for details.
 
 # Executable: EvolveScalarAdvectionSinusoid1D
-# Check: parse;execute
+# Check: parse;execute_check_output
 # ExpectedOutput:
 #   ScalarAdvectionSinusoid1DVolume0.h5
+#   ScalarAdvectionSinusoid1DReductions.h5
+# OutputFileChecks:
+#   - Label: check_analytic_solution
+#     Subfile: /ErrorNorms.dat
+#     FileGlob: ScalarAdvectionSinusoid1DReductions.h5
+#     SkipColumns: [0,1]
+#     AbsoluteTolerance: 0.02
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.001
+  InitialTimeStep: 0.0001
   TimeStepper: RungeKutta3
 
 PhaseChangeAndTriggers:
@@ -17,8 +24,8 @@ DomainCreator:
   Interval:
     LowerBound: [-1.0]
     UpperBound: [1.0]
-    InitialRefinement: [1]
-    InitialGridPoints: [2]
+    InitialRefinement: [4]
+    InitialGridPoints: [3]
     TimeDependence: None
     BoundaryConditions:
       LowerBoundary: Periodic
@@ -45,8 +52,14 @@ Limiter:
 EventsAndTriggers:
   ? Slabs:
       Specified:
-        Values: [100]
+        Values: [10]
   : - Completion
+  ? Slabs:
+      EvenlySpaced:
+        Interval: 5
+        Offset: 0
+  : - ObserveErrorNorms:
+        SubfileName: ErrorNorms
   ? Slabs:
       EvenlySpaced:
         Interval: 10


### PR DESCRIPTION
## Proposed changes

Add [Krivodonova (1D)](https://www.sciencedirect.com/science/article/pii/S0021999107002136?via%3Dihub) and [Kuzmin (2D)](https://www.sciencedirect.com/science/article/pii/S0021999113003161) executables to the ScalarAdvection system.
- [x] ~~Dependent on #3386, where the first two commits are from.~~

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.