### PR TITLE
Document stable step sizes for different time steppers

### DIFF
--- a/src/Time/TimeSteppers/DormandPrince5.hpp
+++ b/src/Time/TimeSteppers/DormandPrince5.hpp
@@ -57,6 +57,7 @@ namespace TimeSteppers {
  * Here the coefficients \f$a_{ij}\f$, \f$b_i\f$, and \f$c_i\f$ are given
  * in e.g. Sec. 7.2 of \cite NumericalRecipes. Note that \f$c_1 = 0\f$.
  *
+ * The CFL factor/stable step size is 1.6532839463174733.
  */
 class DormandPrince5 : public TimeStepper::Inherit {
  public:

--- a/src/Time/TimeSteppers/RungeKutta3.hpp
+++ b/src/Time/TimeSteppers/RungeKutta3.hpp
@@ -37,6 +37,8 @@ namespace TimeSteppers {
 /// A "strong stability-preserving" 3rd-order Runge-Kutta
 /// time-stepper, as described in \cite HesthavenWarburton section
 /// 5.7.
+///
+/// The CFL factor/stable step size is 1.25637266330916.
 class RungeKutta3 : public TimeStepper::Inherit {
  public:
   using options = tmpl::list<>;

--- a/src/Time/TimeSteppers/RungeKutta4.hpp
+++ b/src/Time/TimeSteppers/RungeKutta4.hpp
@@ -56,6 +56,8 @@ namespace TimeSteppers {
  * Note that in the implementation, the expression for \f$u^{n+1}\f$ is
  * computed simultaneously with \f$v^{(4)}\f$, so that there are
  * actually only four substeps per step.
+ *
+ * The CFL factor/stable step size is 1.3926467817026411.
  */
 class RungeKutta4 : public TimeStepper::Inherit {
  public:


### PR DESCRIPTION
## Proposed changes

When choosing step sizes manually I found it useful to be able to quickly look up what the stable step size for a particular stepper is, so this PR just adds the step size factor into the documentation. The Adams-Bashforth stepper already has a table.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
