### PR TITLE
Add outflowing boundary conditions to CurvedScalarWave system

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/BoundaryCondition.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/BoundaryCondition.cpp
@@ -1,0 +1,29 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/CurvedScalarWave/BoundaryConditions/BoundaryCondition.hpp"
+
+#include <pup.h>
+
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace CurvedScalarWave::BoundaryConditions {
+template <size_t Dim>
+BoundaryCondition<Dim>::BoundaryCondition(CkMigrateMessage* const msg) noexcept
+    : domain::BoundaryConditions::BoundaryCondition(msg) {}
+
+template <size_t Dim>
+void BoundaryCondition<Dim>::pup(PUP::er& p) {
+  domain::BoundaryConditions::BoundaryCondition::pup(p);
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data) template class BoundaryCondition<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+#undef DIM
+}  // namespace CurvedScalarWave::BoundaryConditions

--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/BoundaryCondition.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/BoundaryCondition.hpp
@@ -1,0 +1,40 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pup.h>
+
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Domain/BoundaryConditions/Periodic.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace CurvedScalarWave::BoundaryConditions {
+
+/// \cond
+template <size_t Dim>
+class Outflow;
+/// \endcond
+}  // namespace CurvedScalarWave::BoundaryConditions
+
+/// \brief Boundary conditions for the curved scalar wave system
+namespace CurvedScalarWave::BoundaryConditions {
+/// \brief The base class off of which all boundary conditions must inherit
+template <size_t Dim>
+class BoundaryCondition : public domain::BoundaryConditions::BoundaryCondition {
+ public:
+  using creatable_classes =
+      tmpl::list<Outflow<Dim>,
+                 domain::BoundaryConditions::Periodic<BoundaryCondition<Dim>>>;
+
+  BoundaryCondition() = default;
+  BoundaryCondition(BoundaryCondition&&) noexcept = default;
+  BoundaryCondition& operator=(BoundaryCondition&&) noexcept = default;
+  BoundaryCondition(const BoundaryCondition&) = default;
+  BoundaryCondition& operator=(const BoundaryCondition&) = default;
+  ~BoundaryCondition() override = default;
+  explicit BoundaryCondition(CkMigrateMessage* msg) noexcept;
+
+  void pup(PUP::er& p) override;
+};
+}  // namespace CurvedScalarWave::BoundaryConditions

--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/CMakeLists.txt
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  BoundaryCondition.cpp
+  Outflow.cpp
+  RegisterDerivedWithCharm.cpp
+)
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  BoundaryCondition.hpp
+  Factory.hpp
+  Outflow.hpp
+  RegisterDerivedWithCharm.hpp
+)

--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/Factory.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/Factory.hpp
@@ -1,0 +1,7 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Evolution/Systems/CurvedScalarWave/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/CurvedScalarWave/BoundaryConditions/Outflow.hpp"

--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/Outflow.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/Outflow.cpp
@@ -1,0 +1,79 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/CurvedScalarWave/BoundaryConditions/Outflow.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Characteristics.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeString.hpp"
+
+namespace CurvedScalarWave::BoundaryConditions {
+
+template <size_t Dim>
+std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+Outflow<Dim>::get_clone() const noexcept {
+  return std::make_unique<Outflow>(*this);
+}
+
+template <size_t Dim>
+void Outflow<Dim>::pup(PUP::er& p) {
+  BoundaryCondition<Dim>::pup(p);
+}
+
+template <size_t Dim>
+Outflow<Dim>::Outflow(CkMigrateMessage* const msg) noexcept
+    : BoundaryCondition<Dim>(msg) {}
+
+template <size_t Dim>
+std::optional<std::string> Outflow<Dim>::dg_outflow(
+    const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+        face_mesh_velocity,
+    const tnsr::i<DataVector, Dim>& normal_covector,
+    const tnsr::I<DataVector, Dim>& /*normal_vector*/,
+    const Scalar<DataVector>& gamma1, const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim>& shift) const noexcept {
+  tnsr::a<DataVector, 3, Frame::Inertial> char_speeds{lapse.size()};
+  characteristic_speeds(make_not_null(&char_speeds), gamma1, lapse, shift,
+                        normal_covector);
+
+  if (face_mesh_velocity.has_value()) {
+    const auto face_speed = dot_product(normal_covector, *face_mesh_velocity);
+    for (auto& char_speed : char_speeds) {
+      char_speed -= get(face_speed);
+    }
+  }
+  for (size_t i = 0; i < char_speeds.size(); ++i) {
+    if (min(char_speeds[i]) < 0.) {
+      return MakeString{}
+             << "Detected negative characteristic speed at boundary with "
+                "outflowing boundary conditions specified. The speed is "
+             << min(char_speeds[i]) << " for index " << i
+             << ". To see which characteristic field this corresponds to, "
+                "check the function `characteristic_speeds` in "
+                "Evolution/Systems/CurvedScalarWave/Characteristics.hpp.";
+    }
+  }
+  return std::nullopt;  // LCOV_EXCL_LINE
+}
+
+template <size_t Dim>
+// NOLINTNEXTLINE
+PUP::able::PUP_ID Outflow<Dim>::my_PUP_ID = 0;
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data) template class Outflow<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+#undef DIM
+}  // namespace CurvedScalarWave::BoundaryConditions

--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/Outflow.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/Outflow.hpp
@@ -1,0 +1,78 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <pup.h>
+#include <string>
+#include <type_traits>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Evolution/BoundaryConditions/Type.hpp"
+#include "Evolution/Systems/CurvedScalarWave/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace domain::Tags {
+template <size_t Dim, typename Frame>
+struct Coordinates;
+}  // namespace domain::Tags
+/// \endcond
+
+namespace CurvedScalarWave::BoundaryConditions {
+/// A `BoundaryCondition` that only verifies that all characteristic speeds are
+/// directed out of the domain; no boundary data is altered by this boundary
+/// condition.
+template <size_t Dim>
+class Outflow final : public BoundaryCondition<Dim> {
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help{
+      "Boundary conditions which check that all characteristic "
+      "fields are outflowing."};
+  Outflow() = default;
+  /// \cond
+  Outflow(Outflow&&) noexcept = default;
+  Outflow& operator=(Outflow&&) noexcept = default;
+  Outflow(const Outflow&) = default;
+  Outflow& operator=(const Outflow&) = default;
+  /// \endcond
+  ~Outflow() override = default;
+
+  explicit Outflow(CkMigrateMessage* msg) noexcept;
+
+  WRAPPED_PUPable_decl_base_template(
+      domain::BoundaryConditions::BoundaryCondition, Outflow);
+
+  auto get_clone() const noexcept -> std::unique_ptr<
+      domain::BoundaryConditions::BoundaryCondition> override;
+
+  static constexpr evolution::BoundaryConditions::Type bc_type =
+      evolution::BoundaryConditions::Type::Outflow;
+
+  void pup(PUP::er& p) override;
+
+  using dg_interior_evolved_variables_tags = tmpl::list<>;
+  using dg_interior_temporary_tags =
+      tmpl::list<Tags::ConstraintGamma1, gr::Tags::Lapse<DataVector>,
+                 gr::Tags::Shift<Dim, Frame::Inertial, DataVector>>;
+  using dg_interior_dt_vars_tags = tmpl::list<>;
+  using dg_interior_deriv_vars_tags = tmpl::list<>;
+  using dg_gridless_tags = tmpl::list<>;
+
+  std::optional<std::string> dg_outflow(
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+          face_mesh_velocity,
+      const tnsr::i<DataVector, Dim>& normal_covector,
+      const tnsr::I<DataVector, Dim>& /*normal_vector*/,
+      const Scalar<DataVector>& gamma1, const Scalar<DataVector>& lapse,
+      const tnsr::I<DataVector, Dim>& shift) const noexcept;
+};
+}  // namespace CurvedScalarWave::BoundaryConditions

--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/RegisterDerivedWithCharm.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/RegisterDerivedWithCharm.cpp
@@ -1,0 +1,18 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/CurvedScalarWave/BoundaryConditions/RegisterDerivedWithCharm.hpp"
+
+#include "Evolution/Systems/CurvedScalarWave/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/CurvedScalarWave/BoundaryConditions/Outflow.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+
+namespace CurvedScalarWave::BoundaryConditions {
+// LCOV_EXCL_START
+void register_derived_with_charm() noexcept {
+  Parallel::register_derived_classes_with_charm<BoundaryCondition<1>>();
+  Parallel::register_derived_classes_with_charm<BoundaryCondition<2>>();
+  Parallel::register_derived_classes_with_charm<BoundaryCondition<3>>();
+}
+// LCOV_EXCL_STOP
+}  // namespace CurvedScalarWave::BoundaryConditions

--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/RegisterDerivedWithCharm.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/RegisterDerivedWithCharm.hpp
@@ -1,0 +1,8 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace CurvedScalarWave::BoundaryConditions {
+void register_derived_with_charm() noexcept;
+}  // namespace CurvedScalarWave::BoundaryConditions

--- a/src/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
+++ b/src/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
@@ -38,4 +38,5 @@ target_link_libraries(
   Utilities
   )
 
+add_subdirectory(BoundaryConditions)
 add_subdirectory(BoundaryCorrections)

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/BoundaryConditions/Outflow.py
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/BoundaryConditions/Outflow.py
@@ -1,0 +1,26 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+from Evolution.Systems.CurvedScalarWave.Characteristics import (
+    char_speed_vpsi, char_speed_vzero, char_speed_vplus, char_speed_vminus)
+
+
+def error(face_mesh_velocity, outward_directed_normal_covector,
+          outward_directed_normal_vector, gamma_1, lapse, shift):
+    speeds = np.zeros(4)
+    speeds[0] = char_speed_vpsi(gamma_1, lapse, shift,
+                                outward_directed_normal_covector)
+    speeds[1] = char_speed_vzero(gamma_1, lapse, shift,
+                                 outward_directed_normal_covector)
+    speeds[2] = char_speed_vplus(gamma_1, lapse, shift,
+                                 outward_directed_normal_covector)
+    speeds[3] = char_speed_vminus(gamma_1, lapse, shift,
+                                  outward_directed_normal_covector)
+    for speed in speeds:
+        if face_mesh_velocity is not None:
+            speed -= np.dot(outward_directed_normal_covector,
+                            face_mesh_velocity)
+        if speed < 0.0:
+            return ("Detected negative characteristic speed *")
+    return None

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/BoundaryConditions/Test_Outflow.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/BoundaryConditions/Test_Outflow.cpp
@@ -1,0 +1,52 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Index.hpp"
+#include "Evolution/Systems/CurvedScalarWave/BoundaryConditions/Outflow.hpp"
+#include "Evolution/Systems/CurvedScalarWave/BoundaryCorrections/UpwindPenalty.hpp"
+#include "Evolution/Systems/CurvedScalarWave/System.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace helpers = TestHelpers::evolution::dg;
+namespace {
+
+template <size_t Dim>
+void test() noexcept {
+  MAKE_GENERATOR(gen);
+  const std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+      boundary_condition = TestHelpers::test_creation<std::unique_ptr<
+          CurvedScalarWave::BoundaryConditions::BoundaryCondition<Dim>>>(
+          "Outflow:\n");
+
+  helpers::test_boundary_condition_with_python<
+      CurvedScalarWave::BoundaryConditions::Outflow<Dim>,
+      CurvedScalarWave::BoundaryConditions::BoundaryCondition<Dim>,
+      CurvedScalarWave::System<Dim>,
+      tmpl::list<CurvedScalarWave::BoundaryCorrections::UpwindPenalty<Dim>>>(
+      make_not_null(&gen),
+      "Evolution.Systems.CurvedScalarWave.BoundaryConditions.Outflow",
+      tuples::TaggedTuple<helpers::Tags::PythonFunctionForErrorMessage<>>{
+          "error"},
+      "Outflow:\n", Index<Dim - 1>{Dim == 1 ? 0 : 5},
+      db::DataBox<tmpl::list<>>{}, tuples::TaggedTuple<>{});
+}
+}  // namespace
+SPECTRE_TEST_CASE("Unit.CurvedScalarWave.BoundaryConditions.Outflow",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{""};
+  test<1>();
+  test<2>();
+  test<3>();
+}

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/BoundaryConditions/__init__.py
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/BoundaryConditions/__init__.py
@@ -1,0 +1,2 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_CurvedScalarWave")
 
 set(LIBRARY_SOURCES
   BoundaryCorrections/Test_UpwindPenalty.cpp
+  BoundaryConditions/Test_Outflow.cpp
   Test_Constraints.cpp
   Test_Characteristics.cpp
   Test_Tags.cpp


### PR DESCRIPTION
## Proposed changes

These check that all characteristic speeds are outflowing at the boundary.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
