### PR TITLE
Fix compilation error when the inertial coordinates are evolved in CCE

### DIFF
--- a/src/Evolution/Executables/Cce/CharacteristicExtract.hpp
+++ b/src/Evolution/Executables/Cce/CharacteristicExtract.hpp
@@ -53,10 +53,9 @@ class er;
 
 template <template <typename> class BoundaryComponent>
 struct EvolutionMetavars {
-  using system = Cce::System;
-  static constexpr bool local_time_stepping = true;
-
   static constexpr bool uses_partially_flat_cartesian_coordinates = false;
+  using system = Cce::System<uses_partially_flat_cartesian_coordinates>;
+  static constexpr bool local_time_stepping = true;
 
   using evolved_swsh_tag = Cce::Tags::BondiJ;
   using evolved_swsh_dt_tag = Cce::Tags::BondiH;

--- a/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
@@ -219,10 +219,13 @@ struct CharacteristicEvolution {
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Initialization,
                              initialize_action_list>,
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::InitializeTimeStepperHistory,
-                             SelfStart::self_start_procedure<
-                                 self_start_extract_action_list, Cce::System>>,
+      Parallel::PhaseActions<
+          typename Metavariables::Phase,
+          Metavariables::Phase::InitializeTimeStepperHistory,
+          SelfStart::self_start_procedure<
+              self_start_extract_action_list,
+              Cce::System<
+                  Metavariables::uses_partially_flat_cartesian_coordinates>>>,
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Evolve,
                              extract_action_list>>;

--- a/src/Evolution/Systems/Cce/System.hpp
+++ b/src/Evolution/Systems/Cce/System.hpp
@@ -114,11 +114,18 @@
  */
 namespace Cce {
 
+template <bool EvolvePartiallyFlatCartesianCoordinates>
 struct System {
-  using variables_tag = tmpl::list<
-      ::Tags::Variables<tmpl::list<Tags::BondiJ>>,
-      ::Tags::Variables<tmpl::list<Cce::Tags::CauchyCartesianCoords,
-                                   Cce::Tags::InertialRetardedTime>>>;
+  using variables_tag =
+      tmpl::list<::Tags::Variables<tmpl::list<Tags::BondiJ>>,
+                 ::Tags::Variables<std::conditional_t<
+                     EvolvePartiallyFlatCartesianCoordinates,
+                     tmpl::list<Cce::Tags::CauchyCartesianCoords,
+                                Cce::Tags::PartiallyFlatCartesianCoords,
+                                Cce::Tags::InertialRetardedTime>,
+                     tmpl::list<Cce::Tags::CauchyCartesianCoords,
+                                Cce::Tags::InertialRetardedTime>>>>;
+
   static constexpr bool has_primitive_and_conservative_vars = false;
 };
 }


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

This fixes the compilation error when the partially flat Cartesian coordinates are allowed to evolve, namely `uses_partially_flat_cartesian_coordinates=true` (see features from #2805 ).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
