### PR TITLE
GRMHD subcell TCI check positivity of TildeD and TildeTau

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/InitialDataTci.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/InitialDataTci.cpp
@@ -25,12 +25,22 @@ bool DgInitialDataTci::apply(
                                Inactive<ValenciaDivClean::Tags::TildePhi>>>&
         subcell_vars,
     double rdmp_delta0, double rdmp_epsilon, double persson_exponent,
-    const Mesh<3>& dg_mesh) noexcept {
-  return evolution::dg::subcell::two_mesh_rdmp_tci(dg_vars, subcell_vars,
+    const Mesh<3>& dg_mesh, const TciOptions& tci_options) noexcept {
+  return min(get(get<ValenciaDivClean::Tags::TildeD>(dg_vars))) <
+             tci_options.minimum_rest_mass_density_times_lorentz_factor or
+         min(get(get<Inactive<ValenciaDivClean::Tags::TildeD>>(subcell_vars))) <
+             tci_options.minimum_rest_mass_density_times_lorentz_factor or
+         min(get(get<ValenciaDivClean::Tags::TildeTau>(dg_vars))) <
+             tci_options.minimum_tilde_tau or
+         min(get(get<Inactive<ValenciaDivClean::Tags::TildeTau>>(
+             subcell_vars))) < tci_options.minimum_tilde_tau or
+         evolution::dg::subcell::two_mesh_rdmp_tci(dg_vars, subcell_vars,
                                                    rdmp_delta0, rdmp_epsilon) or
          evolution::dg::subcell::persson_tci(
-             get<Tags::TildeD>(dg_vars), dg_mesh, persson_exponent, 1.0e-18) or
+             get<ValenciaDivClean::Tags::TildeD>(dg_vars), dg_mesh,
+             persson_exponent, 1.0e-18) or
          evolution::dg::subcell::persson_tci(
-             get<Tags::TildeTau>(dg_vars), dg_mesh, persson_exponent, 1.0e-18);
+             get<ValenciaDivClean::Tags::TildeTau>(dg_vars), dg_mesh,
+             persson_exponent, 1.0e-18);
 }
 }  // namespace grmhd::ValenciaDivClean::subcell

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/InitialDataTci.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/InitialDataTci.hpp
@@ -8,6 +8,7 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/Tags/Inactive.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOptions.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
 #include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
 #include "Utilities/TMPL.hpp"
@@ -26,7 +27,11 @@ namespace grmhd::ValenciaDivClean::subcell {
  * to switch to subcell.
  *
  * Uses the two-mesh relaxed discrete maximum principle as well as the Persson
- * TCI applied to \f$\tilde{D}\f$ and \f$\tilde{\tau}\f$.
+ * TCI applied to \f$\tilde{D}\f$ and \f$\tilde{\tau}\f$. If `TildeD`
+ * (`TildeTau`) on the DG or subcell grid (projected from the DG grid, not
+ * initialized to the initial data) is less than
+ * `tci_options.minimum_rest_mass_density_times_lorentz_factor`
+ * (`tci_options.minimum_tilde_tau`), then the element is flagged as troubled.
  */
 struct DgInitialDataTci {
  private:
@@ -34,12 +39,12 @@ struct DgInitialDataTci {
   using Inactive = evolution::dg::subcell::Tags::Inactive<Tag>;
 
  public:
-  using argument_tags = tmpl::list<domain::Tags::Mesh<3>>;
+  using argument_tags = tmpl::list<domain::Tags::Mesh<3>, Tags::TciOptions>;
 
   static bool apply(
       const Variables<tmpl::list<
           ValenciaDivClean::Tags::TildeD, ValenciaDivClean::Tags::TildeTau,
-          ValenciaDivClean::Tags::TildeS<>, Tags::TildeB<>,
+          ValenciaDivClean::Tags::TildeS<>, ValenciaDivClean::Tags::TildeB<>,
           ValenciaDivClean::Tags::TildePhi>>& dg_vars,
       const Variables<tmpl::list<Inactive<ValenciaDivClean::Tags::TildeD>,
                                  Inactive<ValenciaDivClean::Tags::TildeTau>,
@@ -48,6 +53,6 @@ struct DgInitialDataTci {
                                  Inactive<ValenciaDivClean::Tags::TildePhi>>>&
           subcell_vars,
       double rdmp_delta0, double rdmp_epsilon, double persson_exponent,
-      const Mesh<3>& dg_mesh) noexcept;
+      const Mesh<3>& dg_mesh, const TciOptions& tci_options) noexcept;
 };
 }  // namespace grmhd::ValenciaDivClean::subcell

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.cpp
@@ -26,6 +26,7 @@ template <typename RecoveryScheme>
 template <size_t ThermodynamicDim>
 bool TciOnDgGrid<RecoveryScheme>::apply(
     const gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*> dg_prim_vars,
+    const Scalar<DataVector>& subcell_tilde_d,
     const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau,
     const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
@@ -42,7 +43,9 @@ bool TciOnDgGrid<RecoveryScheme>::apply(
 
   // require: tilde_d/sqrt{gamma} >= 0.0 (or some positive user-specified value)
   if (min(get(tilde_d) / get(sqrt_det_spatial_metric)) <
-      tci_options.minimum_rest_mass_density_times_lorentz_factor) {
+          tci_options.minimum_rest_mass_density_times_lorentz_factor or
+      min(get(subcell_tilde_d)) <
+          tci_options.minimum_rest_mass_density_times_lorentz_factor) {
     return true;
   }
 
@@ -148,6 +151,7 @@ GENERATE_INSTANTIATIONS(
   template bool TciOnDgGrid<RECOVERY(data)>::apply<THERMO_DIM(data)>(         \
       const gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*>          \
           dg_prim_vars,                                                       \
+      const Scalar<DataVector>& subcell_tilde_d,                              \
       const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau, \
       const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,                 \
       const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,                 \

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.cpp
@@ -27,6 +27,7 @@ template <size_t ThermodynamicDim>
 bool TciOnDgGrid<RecoveryScheme>::apply(
     const gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*> dg_prim_vars,
     const Scalar<DataVector>& subcell_tilde_d,
+    const Scalar<DataVector>& subcell_tilde_tau,
     const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau,
     const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
@@ -46,6 +47,12 @@ bool TciOnDgGrid<RecoveryScheme>::apply(
           tci_options.minimum_rest_mass_density_times_lorentz_factor or
       min(get(subcell_tilde_d)) <
           tci_options.minimum_rest_mass_density_times_lorentz_factor) {
+    return true;
+  }
+
+  // require: tilde_tau >= 0.0 (or some positive user-specified value)
+  if (min(get(tilde_tau)) < tci_options.minimum_tilde_tau or
+      min(get(subcell_tilde_tau)) < tci_options.minimum_tilde_tau) {
     return true;
   }
 
@@ -152,6 +159,7 @@ GENERATE_INSTANTIATIONS(
       const gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*>          \
           dg_prim_vars,                                                       \
       const Scalar<DataVector>& subcell_tilde_d,                              \
+      const Scalar<DataVector>& subcell_tilde_tau,                            \
       const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau, \
       const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,                 \
       const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,                 \

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.hpp
@@ -47,6 +47,8 @@ namespace grmhd::ValenciaDivClean::subcell {
  *   negative (or extremely small) density and the cell is troubled. Note that
  *   if this `tci_option` is approximately equal to or larger than the
  *   `atmosphere_density`, the atmosphere will be flagged as troubled.
+ * - if \f$\tilde{\tau}\f$ is less than `tci_options.minimum_tilde_tau` then we
+ *   have a negative (or extremely small) energy and the cell is troubled.
  * - if \f$\max(\tilde{D}^{n+1}/(\sqrt{\gamma^n}W^n))\f$ and \f$\max(\rho^n)\f$
  *   are less than `tci_options.atmosphere_density` then the entire DG element
  *   is in atmosphere and it is _not_ troubled.
@@ -72,6 +74,8 @@ class TciOnDgGrid {
   using argument_tags =
       tmpl::list<evolution::dg::subcell::Tags::Inactive<
                      grmhd::ValenciaDivClean::Tags::TildeD>,
+                 evolution::dg::subcell::Tags::Inactive<
+                     grmhd::ValenciaDivClean::Tags::TildeTau>,
                  grmhd::ValenciaDivClean::Tags::TildeD,
                  grmhd::ValenciaDivClean::Tags::TildeTau,
                  grmhd::ValenciaDivClean::Tags::TildeS<>,
@@ -86,6 +90,7 @@ class TciOnDgGrid {
   static bool apply(
       gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*> dg_prim_vars,
       const Scalar<DataVector>& subcell_tilde_d,
+      const Scalar<DataVector>& subcell_tilde_tau,
       const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau,
       const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,
       const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.hpp
@@ -8,6 +8,7 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/Tags/Inactive.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOptions.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
@@ -69,7 +70,9 @@ class TciOnDgGrid {
   using return_tags =
       tmpl::list<::Tags::Variables<hydro::grmhd_tags<DataVector>>>;
   using argument_tags =
-      tmpl::list<grmhd::ValenciaDivClean::Tags::TildeD,
+      tmpl::list<evolution::dg::subcell::Tags::Inactive<
+                     grmhd::ValenciaDivClean::Tags::TildeD>,
+                 grmhd::ValenciaDivClean::Tags::TildeD,
                  grmhd::ValenciaDivClean::Tags::TildeTau,
                  grmhd::ValenciaDivClean::Tags::TildeS<>,
                  grmhd::ValenciaDivClean::Tags::TildeB<>,
@@ -82,6 +85,7 @@ class TciOnDgGrid {
   template <size_t ThermodynamicDim>
   static bool apply(
       gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*> dg_prim_vars,
+      const Scalar<DataVector>& subcell_tilde_d,
       const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau,
       const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,
       const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.cpp
@@ -14,8 +14,12 @@ namespace grmhd::ValenciaDivClean::subcell {
 bool TciOnFdGrid::apply(const Scalar<DataVector>& tilde_d,
                         const Scalar<DataVector>& tilde_tau,
                         const bool vars_needed_fixing, const Mesh<3>& dg_mesh,
+                        const TciOptions& tci_options,
                         const double persson_exponent) noexcept {
   return vars_needed_fixing or
+         min(get(tilde_d)) <
+             tci_options.minimum_rest_mass_density_times_lorentz_factor or
+         min(get(tilde_tau)) < tci_options.minimum_tilde_tau or
          evolution::dg::subcell::persson_tci(tilde_d, dg_mesh, persson_exponent,
                                              1.0e-18) or
          evolution::dg::subcell::persson_tci(tilde_tau, dg_mesh,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.hpp
@@ -8,6 +8,7 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/Tags/Inactive.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOptions.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
 #include "Evolution/VariableFixing/Tags.hpp"
 #include "Utilities/TMPL.hpp"
@@ -29,6 +30,10 @@ namespace grmhd::ValenciaDivClean::subcell {
  *   remain on FD. (Note: this could be relaxed in the future if we need to
  *   allow switching from FD to DG in the atmosphere and the current approach
  *   isn't working.)
+ * - if `min(tilde_d)` is less than
+ *   `tci_options.minimum_rest_mass_density_times_lorentz_factor` or if
+ *   `min(tilde_tau)` is less than `tci_options.minimum_tilde_tau` then the we
+ *   remain on FD.
  * - apply the Persson TCI to \f$\tilde{D}\f$ and \f$\tilde{\tau}\f$
  */
 struct TciOnFdGrid {
@@ -39,10 +44,11 @@ struct TciOnFdGrid {
                  evolution::dg::subcell::Tags::Inactive<
                      grmhd::ValenciaDivClean::Tags::TildeTau>,
                  grmhd::ValenciaDivClean::Tags::VariablesNeededFixing,
-                 domain::Tags::Mesh<3>>;
+                 domain::Tags::Mesh<3>, Tags::TciOptions>;
   static bool apply(const Scalar<DataVector>& tilde_d,
                     const Scalar<DataVector>& tilde_tau,
                     bool vars_needed_fixing, const Mesh<3>& dg_mesh,
+                    const TciOptions& tci_options,
                     double persson_exponent) noexcept;
 };
 }  // namespace grmhd::ValenciaDivClean::subcell

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOptions.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOptions.cpp
@@ -8,6 +8,7 @@
 namespace grmhd::ValenciaDivClean::subcell {
 void TciOptions::pup(PUP::er& p) noexcept {
   p | minimum_rest_mass_density_times_lorentz_factor;
+  p | minimum_tilde_tau;
   p | atmosphere_density;
   p | safety_factor_for_magnetic_field;
 }

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOptions.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOptions.hpp
@@ -33,6 +33,14 @@ struct TciOptions {
         "Minimum value of rest-mass density times Lorentz factor before we "
         "switch to subcell."};
   };
+  /// \brief Minimum value of \f$\tilde{\tau}\f$ before we switch to subcell.
+  /// Used to identify places where the energy has suddenly become negative
+  struct MinimumValueOfTildeTau {
+    using type = double;
+    static type lower_bound() noexcept { return 0.0; }
+    static constexpr Options::String help = {
+        "Minimum value of tilde tau before we switch to subcell."};
+  };
   /// \brief The density cutoff where if the maximum value of the density in the
   /// DG element is below this value we skip primitive recovery and treat the
   /// cell as atmosphere.
@@ -55,8 +63,8 @@ struct TciOptions {
         "Safety factor for magnetic field bound."};
   };
 
-  using options =
-      tmpl::list<MinimumValueOfD, AtmosphereDensity, SafetyFactorForB>;
+  using options = tmpl::list<MinimumValueOfD, MinimumValueOfTildeTau,
+                             AtmosphereDensity, SafetyFactorForB>;
   static constexpr Options::String help = {
       "Options for the troubled-cell indicator."};
 
@@ -65,6 +73,7 @@ struct TciOptions {
 
   double minimum_rest_mass_density_times_lorentz_factor{
       std::numeric_limits<double>::signaling_NaN()};
+  double minimum_tilde_tau{std::numeric_limits<double>::signaling_NaN()};
   double atmosphere_density{std::numeric_limits<double>::signaling_NaN()};
   double safety_factor_for_magnetic_field{
       std::numeric_limits<double>::signaling_NaN()};

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_InitialDataTci.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_InitialDataTci.cpp
@@ -35,13 +35,16 @@ SPECTRE_TEST_CASE(
   const double delta0 = 1.0e-4;
   const double epsilon = 1.0e-3;
   const double exponent = 4.0;
+  const grmhd::ValenciaDivClean::subcell::TciOptions tci_options{
+      1.0e-20, 1.0e-40, 1.1e-12, 1.0e-12};
 
   {
     INFO("TCI is happy");
     const InactiveConsVars subcell_vars{subcell_mesh.number_of_grid_points(),
                                         1.0};
     CHECK_FALSE(grmhd::ValenciaDivClean::subcell::DgInitialDataTci::apply(
-        dg_vars, subcell_vars, delta0, epsilon, exponent, dg_mesh));
+        dg_vars, subcell_vars, delta0, epsilon, exponent, dg_mesh,
+        tci_options));
   }
 
   {
@@ -49,7 +52,8 @@ SPECTRE_TEST_CASE(
     const InactiveConsVars subcell_vars{subcell_mesh.number_of_grid_points(),
                                         2.0};
     CHECK(grmhd::ValenciaDivClean::subcell::DgInitialDataTci::apply(
-        dg_vars, subcell_vars, delta0, epsilon, exponent, dg_mesh));
+        dg_vars, subcell_vars, delta0, epsilon, exponent, dg_mesh,
+        tci_options));
   }
 
   {
@@ -59,7 +63,8 @@ SPECTRE_TEST_CASE(
     get(get<grmhd::ValenciaDivClean::Tags::TildeD>(
         dg_vars))[dg_mesh.number_of_grid_points() / 2] += 2.0e10;
     CHECK(grmhd::ValenciaDivClean::subcell::DgInitialDataTci::apply(
-        dg_vars, subcell_vars, 1.0e100, epsilon, exponent, dg_mesh));
+        dg_vars, subcell_vars, 1.0e100, epsilon, exponent, dg_mesh,
+        tci_options));
     get(get<grmhd::ValenciaDivClean::Tags::TildeD>(
         dg_vars))[dg_mesh.number_of_grid_points() / 2] = 1.0;
   }
@@ -71,8 +76,51 @@ SPECTRE_TEST_CASE(
     get(get<grmhd::ValenciaDivClean::Tags::TildeTau>(
         dg_vars))[dg_mesh.number_of_grid_points() / 2] += 2.0e10;
     CHECK(grmhd::ValenciaDivClean::subcell::DgInitialDataTci::apply(
-        dg_vars, subcell_vars, 1.0e100, epsilon, exponent, dg_mesh));
+        dg_vars, subcell_vars, 1.0e100, epsilon, exponent, dg_mesh,
+        tci_options));
     get(get<grmhd::ValenciaDivClean::Tags::TildeTau>(
         dg_vars))[dg_mesh.number_of_grid_points() / 2] = 1.0;
+  }
+
+  {
+    INFO("Negative TildeD");
+    InactiveConsVars subcell_vars{subcell_mesh.number_of_grid_points(), 1.0};
+
+    get(get<grmhd::ValenciaDivClean::Tags::TildeD>(
+        dg_vars))[dg_mesh.number_of_grid_points() / 2] = -1.0e-20;
+    CHECK(grmhd::ValenciaDivClean::subcell::DgInitialDataTci::apply(
+        dg_vars, subcell_vars, 1.0e100, epsilon, exponent, dg_mesh,
+        tci_options));
+    get(get<grmhd::ValenciaDivClean::Tags::TildeD>(
+        dg_vars))[dg_mesh.number_of_grid_points() / 2] = 1.0;
+
+    get(get<Inactive<grmhd::ValenciaDivClean::Tags::TildeD>>(
+        subcell_vars))[subcell_mesh.number_of_grid_points() / 2] = -1.0e-20;
+    CHECK(grmhd::ValenciaDivClean::subcell::DgInitialDataTci::apply(
+        dg_vars, subcell_vars, 1.0e100, epsilon, exponent, dg_mesh,
+        tci_options));
+    get(get<Inactive<grmhd::ValenciaDivClean::Tags::TildeD>>(
+        subcell_vars))[subcell_mesh.number_of_grid_points() / 2] = 1.0;
+  }
+
+  {
+    INFO("Negative TildeTau");
+    InactiveConsVars subcell_vars{subcell_mesh.number_of_grid_points(), 1.0};
+
+    get(get<grmhd::ValenciaDivClean::Tags::TildeTau>(
+        dg_vars))[dg_mesh.number_of_grid_points() / 2] = -1.0e-20;
+    CHECK(grmhd::ValenciaDivClean::subcell::DgInitialDataTci::apply(
+        dg_vars, subcell_vars, 1.0e100, epsilon, exponent, dg_mesh,
+        tci_options));
+    get(get<grmhd::ValenciaDivClean::Tags::TildeTau>(
+        dg_vars))[dg_mesh.number_of_grid_points() / 2] = 1.0;
+
+    get(get<Inactive<grmhd::ValenciaDivClean::Tags::TildeTau>>(
+        subcell_vars))[subcell_mesh.number_of_grid_points() / 2] = -1.0e-20;
+    CHECK(grmhd::ValenciaDivClean::subcell::DgInitialDataTci::apply(
+        dg_vars, subcell_vars, 1.0e100, epsilon, exponent, dg_mesh,
+        tci_options));
+    get(get<Inactive<grmhd::ValenciaDivClean::Tags::TildeTau>>(
+        subcell_vars))[subcell_mesh.number_of_grid_points() / 2] = 1.0;
   }
 }

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnDgGrid.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnDgGrid.cpp
@@ -82,7 +82,7 @@ void test(const TestThis test_this) {
                                                    1.0};
 
   const grmhd::ValenciaDivClean::subcell::TciOptions tci_options{
-      1.0e-20, 1.1e-12, 1.0e-12};
+      1.0e-20, 1.0e-40, 1.1e-12, 1.0e-12};
 
   auto box = db::create<db::AddSimpleTags<
       ::Tags::Variables<typename ConsVars::tags_list>,

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnDgGrid.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnDgGrid.cpp
@@ -36,7 +36,9 @@ enum class TestThis {
   PrimRecoveryFailed,
   PerssonTildeD,
   PerssonTildeTau,
-  NegativeTildeDSubcell
+  NegativeTildeDSubcell,
+  NegativeTildeTauSubcell,
+  NegativeTildeTau
 };
 
 void test(const TestThis test_this) {
@@ -89,6 +91,8 @@ void test(const TestThis test_this) {
   auto box = db::create<db::AddSimpleTags<
       evolution::dg::subcell::Tags::Inactive<
           grmhd::ValenciaDivClean::Tags::TildeD>,
+      evolution::dg::subcell::Tags::Inactive<
+          grmhd::ValenciaDivClean::Tags::TildeTau>,
       ::Tags::Variables<typename ConsVars::tags_list>,
       ::Tags::Variables<typename PrimVars::tags_list>, ::domain::Tags::Mesh<3>,
       hydro::Tags::EquationOfState<
@@ -96,6 +100,7 @@ void test(const TestThis test_this) {
       gr::Tags::SqrtDetSpatialMetric<>, gr::Tags::SpatialMetric<3>,
       gr::Tags::InverseSpatialMetric<3>,
       grmhd::ValenciaDivClean::subcell::Tags::TciOptions>>(
+      Scalar<DataVector>(subcell_mesh.number_of_grid_points(), 1.0),
       Scalar<DataVector>(subcell_mesh.number_of_grid_points(), 1.0),
       ConsVars{mesh.number_of_grid_points()}, prim_vars, mesh,
       std::unique_ptr<EquationsOfState::EquationOfState<true, 1>>{
@@ -168,6 +173,17 @@ void test(const TestThis test_this) {
         make_not_null(&box), [point_to_change](const auto tilde_d_ptr) {
           get(*tilde_d_ptr)[point_to_change] = -1.0e-20;
         });
+  } else if (test_this == TestThis::NegativeTildeTauSubcell) {
+    db::mutate<evolution::dg::subcell::Tags::Inactive<
+        grmhd::ValenciaDivClean::Tags::TildeTau>>(
+        make_not_null(&box), [point_to_change](const auto tilde_d_ptr) {
+          get(*tilde_d_ptr)[point_to_change] = -1.0e-20;
+        });
+  } else if (test_this == TestThis::NegativeTildeTau) {
+    db::mutate<grmhd::ValenciaDivClean::Tags::TildeTau>(
+        make_not_null(&box), [point_to_change](const auto tilde_d_ptr) {
+          get(*tilde_d_ptr)[point_to_change] = -1.0e-20;
+        });
   }
 
   const bool result =
@@ -195,7 +211,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ValenciaDivClean.Subcell.TciOnDgGrid",
        {TestThis::AllGood, TestThis::SmallTildeD, TestThis::InAtmosphere,
         TestThis::TildeB2TooBig, TestThis::PrimRecoveryFailed,
         TestThis::PerssonTildeD, TestThis::PerssonTildeTau,
-        TestThis::NegativeTildeDSubcell}) {
+        TestThis::NegativeTildeDSubcell, TestThis::NegativeTildeTauSubcell,
+        TestThis::NegativeTildeTau}) {
     test(test_this);
   }
 }

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOptions.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOptions.cpp
@@ -12,10 +12,12 @@ SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.Subcell.TciOptions",
   const auto tci_options_from_opts = TestHelpers::test_option_tag<
       grmhd::ValenciaDivClean::subcell::OptionTags::TciOptions>(
       "MinimumValueOfD: 1.0e-18\n"
+      "MinimumValueOfTildeTau: 1.0e-38\n"
       "AtmosphereDensity: 1.1e-12\n"
       "SafetyFactorForB: 1.0e-12\n");
   const auto tci_options = serialize_and_deserialize(tci_options_from_opts);
   CHECK(tci_options.minimum_rest_mass_density_times_lorentz_factor == 1.0e-18);
+  CHECK(tci_options.minimum_tilde_tau == 1.0e-38);
   CHECK(tci_options.atmosphere_density == 1.1e-12);
   CHECK(tci_options.safety_factor_for_magnetic_field == 1.0e-12);
 }


### PR DESCRIPTION
## Proposed changes

Add positivity of TildeD and TildeTau as a requirement to the three TCI cases. I found this necessary for high-resolution TOV evolutions. Specifically, the FD solver tried to switch back to DG but the reconstructed TildeD had negative values but did pass the RDMP and Persson TCIs. The min values of TildeD and TildeTau are controlled separately since TildeTau ~ TildeD^2, though this is EOS-dependent.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
