### PR TITLE
Add Bayliss-Turkel boundary conditions to CurvedScalarWave system

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/CMakeLists.txt
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/CMakeLists.txt
@@ -4,6 +4,7 @@
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  ConstraintPreservingSphericalRadiation.cpp
   BoundaryCondition.cpp
   Outflow.cpp
 )
@@ -12,6 +13,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  ConstraintPreservingSphericalRadiation.hpp
   BoundaryCondition.hpp
   Factory.hpp
   Outflow.hpp

--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.cpp
@@ -1,0 +1,129 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/CurvedScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Characteristics.hpp"
+#include "Options/ParseOptions.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace CurvedScalarWave::BoundaryConditions {
+
+template <size_t Dim>
+std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+ConstraintPreservingSphericalRadiation<Dim>::get_clone() const noexcept {
+  return std::make_unique<ConstraintPreservingSphericalRadiation>(*this);
+}
+
+template <size_t Dim>
+void ConstraintPreservingSphericalRadiation<Dim>::pup(PUP::er& p) {
+  BoundaryCondition<Dim>::pup(p);
+}
+
+template <size_t Dim>
+ConstraintPreservingSphericalRadiation<Dim>::
+    ConstraintPreservingSphericalRadiation(CkMigrateMessage* const msg) noexcept
+    : BoundaryCondition<Dim>(msg) {}
+
+template <size_t Dim>
+std::optional<std::string>
+ConstraintPreservingSphericalRadiation<Dim>::dg_time_derivative(
+    const gsl::not_null<Scalar<DataVector>*> dt_pi_correction,
+    const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+        dt_phi_correction,
+    const gsl::not_null<Scalar<DataVector>*> dt_psi_correction,
+    const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+        face_mesh_velocity,
+    const tnsr::i<DataVector, Dim>& normal_covector,
+    const tnsr::I<DataVector, Dim>& normal_vector,
+    const tnsr::i<DataVector, Dim>& phi, const Scalar<DataVector>& psi,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& coords,
+    const Scalar<DataVector>& gamma1, const Scalar<DataVector>& gamma2,
+    const Scalar<DataVector>& lapse, const tnsr::I<DataVector, Dim>& shift,
+    const Scalar<DataVector>& dt_pi, const tnsr::i<DataVector, Dim>& dt_phi,
+    const Scalar<DataVector>& dt_psi, const tnsr::i<DataVector, Dim>& d_psi,
+    const tnsr::ij<DataVector, Dim>& d_phi) const noexcept {
+  Variables<tmpl::list<::Tags::Tempa<0, 3>, ::Tags::TempScalar<1>,
+                       ::Tags::TempScalar<2>>>
+      buffer{get<0>(coords).size()};
+
+  auto& char_speeds = get<::Tags::Tempa<0, 3>>(buffer);
+  auto& inv_radius = get<::Tags::TempScalar<1>>(buffer);
+  auto& face_speed = get<::Tags::TempScalar<2>>(buffer);
+
+  get(inv_radius) = 1. / get(magnitude(coords));
+  characteristic_speeds(make_not_null(&char_speeds), gamma1, lapse, shift,
+                        normal_covector);
+
+  if (face_mesh_velocity.has_value()) {
+    face_speed = dot_product(normal_covector, *face_mesh_velocity);
+    for (size_t i = 0; i < 4; ++i) {
+      char_speeds.get(i) -= get(face_speed);
+    }
+  }
+
+  get(*dt_psi_correction) =
+      get<0>(normal_vector) * (get<0>(d_psi) - get<0>(phi));
+  for (size_t i = 1; i < Dim; ++i) {
+    get(*dt_psi_correction) +=
+        normal_vector.get(i) * (d_psi.get(i) - phi.get(i));
+  }
+
+  for (size_t i = 0; i < Dim; ++i) {
+    dt_phi_correction->get(i) =
+        get<0>(normal_vector) * (d_phi.get(0, i) - d_phi.get(i, 0));
+    for (size_t j = 1; j < Dim; ++j) {
+      dt_phi_correction->get(i) +=
+          normal_vector.get(j) * (d_phi.get(j, i) - d_phi.get(i, j));
+    }
+  }
+
+  for (size_t i = 0; i < get(*dt_psi_correction).size(); ++i) {
+    get(*dt_psi_correction)[i] *= std::min(0., gsl::at(char_speeds[0], i));
+    for (size_t j = 0; j < Dim; ++j) {
+      dt_phi_correction->get(j)[i] *=
+          0.5 * std::min(0., gsl::at(char_speeds[1], i));
+    }
+  }
+
+  get(*dt_pi_correction) =
+      (2.0 * get(inv_radius) * get(psi) + 4.0 * get(dt_psi)) * get(inv_radius);
+  for (size_t i = 0; i < Dim; ++i) {
+    get(*dt_pi_correction) +=
+        normal_vector.get(i) *
+            (2. * dt_phi.get(i) + 4.0 * get(inv_radius) * phi.get(i)) +
+        shift.get(i) * dt_phi.get(i);
+    for (size_t j = 0; j < Dim; ++j) {
+      get(*dt_pi_correction) +=
+          normal_vector.get(i) * normal_vector.get(j) * d_phi.get(i, j);
+    }
+  }
+  get(*dt_pi_correction) /= get(lapse);
+  get(*dt_pi_correction) += get(gamma2) * get(*dt_psi_correction) - get(dt_pi);
+  return {};
+}
+
+template <size_t Dim>
+// NOLINTNEXTLINE
+PUP::able::PUP_ID ConstraintPreservingSphericalRadiation<Dim>::my_PUP_ID = 0;
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data) \
+  template class ConstraintPreservingSphericalRadiation<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+#undef DIM
+}  // namespace CurvedScalarWave::BoundaryConditions

--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.hpp
@@ -1,0 +1,165 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <pup.h>
+#include <string>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/BoundaryConditions/Type.hpp"
+#include "Evolution/Systems/CurvedScalarWave/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace domain::Tags {
+template <size_t Dim, typename Frame>
+struct Coordinates;
+}  // namespace domain::Tags
+/// \endcond
+
+namespace CurvedScalarWave::BoundaryConditions {
+
+/*!
+ * \brief Implements constraint-preserving boundary conditions with a second
+ * order Bayliss-Turkel radiation boundary condition.
+ *
+ * \details The Bayliss-Turkel boundary conditions are technically only valid in
+ * flat space and should therefore only be used at boundaries where the
+ * background spacetime is approximately Minkwoski such as (sufficiently far
+ * out) outer boundaries for asymptotically flat spacetimes. Small reflections
+ * are still likely to occur.
+ *
+ * The constraint-preserving part of the boundary conditions are set on the time
+ * derivatives of the evolved fields according to \cite Holst2004wt . The
+ * physical Bayliss-Turkel boundary conditions are additionally set onto the
+ * time derivative of \f$\Pi\f$.
+ *
+ * The constraints are defined as follows:
+ *
+ * \f{align*}{
+ *  \mathcal{C}_i&=\partial_i\Psi - \Phi_i=0, \\
+ *  \mathcal{C}_{ij}&=\partial_{[i}\Phi_{j]}=0
+ * \f}
+ *
+ * The boundary conditions are then given by:
+ *
+ * \f{align*}{
+ * \partial_{t} \Psi&\to\partial_{t}\Psi +
+ *                    \lambda_\Psi n^i \mathcal{C}_i, \\
+ * \partial_{t}\Pi&\to\partial_{t}\Pi-\left(\partial_t\Pi
+ *                  - \partial_t\Pi^{\mathrm{BC}}\right)
+ *                  +\gamma_2\lambda_\Psi n^i \mathcal{C}_i
+ *                  =\partial_t\Pi^{\mathrm{BC}}
+ *                  +\gamma_2\lambda_\Psi n^i \mathcal{C}_i, \\
+ * \partial_{t}\Phi_i&\to\partial_{t}\Phi_i+
+ *                     \lambda_0n^jP^k{}_i\mathcal{C}_{jk}
+ *   = \partial_{t}\Phi_i+ \lambda_0n^j \mathcal{C}_{ji}.
+ * \f}
+ *
+ * These conditions are equivalent to equations (40) and (41) of
+ * \cite Holst2004wt if the shift vector is parallel to the normal of the outer
+ * boundary. The Bayliss-Turkel boundary conditions are given by:
+ *
+ * \f{align*}{
+ *  \prod_{l=1}^m\left(\partial_t + \partial_r + \frac{2l-1}{r}\right)\Psi=0,
+ * \f}
+ *
+ * which we expand here to second order (\f$m=2\f$) to derive conditions for
+ * \f$\partial_t\Pi^{\mathrm{BC}}\f$:
+ *
+ * \f{align*}{
+ *  \partial_t\Pi^{\mathrm{BC}}
+ *   &=\left(\partial_t\partial_r + \partial_r\partial_t +
+ *     \partial_r^2+\frac{4}{r}\partial_t
+ *     +\frac{4}{r}\partial_r + \frac{2}{r^2}\right)\Psi \notag \\
+ *     &=\left((2n^i + \beta^i) \partial_t \Phi_i + n^i n^j\partial_i\Phi_j +
+ *     \frac{4}{r}\partial_t\Psi + \frac{4}{r}n^i\Phi_i + \frac{2}{r^2}\Psi
+ * \right) / \alpha.
+ * \f}
+ *
+ *
+ * This derivation makes the following assumptions:
+ *
+ * - The lapse, shift, normal vector and radius are time-independent,
+ * \f$\partial_t \alpha = \partial_t \beta^i = \partial_t n^i = \partial_t r =
+ * 0\f$. If necessary, these time derivatives can be accounted for in the future
+ * by inserting the appropriate terms in a straightforward manner.
+ *
+ * - The outer boundary is spherical. It might be possible to generalize this
+ * condition but we have not tried this.
+ */
+template <size_t Dim>
+class ConstraintPreservingSphericalRadiation final
+    : public BoundaryCondition<Dim> {
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help{
+      "Constraint-preserving boundary conditions with a second order "
+      "Bayliss-Turkel radiation boundary condition."};
+  ConstraintPreservingSphericalRadiation() = default;
+  ConstraintPreservingSphericalRadiation(
+      ConstraintPreservingSphericalRadiation&&) noexcept = default;
+  ConstraintPreservingSphericalRadiation& operator=(
+      ConstraintPreservingSphericalRadiation&&) noexcept = default;
+  ConstraintPreservingSphericalRadiation(
+      const ConstraintPreservingSphericalRadiation&) = default;
+  ConstraintPreservingSphericalRadiation& operator=(
+      const ConstraintPreservingSphericalRadiation&) = default;
+  ~ConstraintPreservingSphericalRadiation() override = default;
+
+  explicit ConstraintPreservingSphericalRadiation(
+      CkMigrateMessage* msg) noexcept;
+
+  WRAPPED_PUPable_decl_base_template(
+      domain::BoundaryConditions::BoundaryCondition,
+      ConstraintPreservingSphericalRadiation);
+
+  auto get_clone() const noexcept -> std::unique_ptr<
+      domain::BoundaryConditions::BoundaryCondition> override;
+
+  static constexpr evolution::BoundaryConditions::Type bc_type =
+      evolution::BoundaryConditions::Type::TimeDerivative;
+
+  void pup(PUP::er& p) override;
+
+  using dg_interior_evolved_variables_tags = tmpl::list<Phi<Dim>, Psi>;
+  using dg_interior_temporary_tags =
+      tmpl::list<domain::Tags::Coordinates<Dim, Frame::Inertial>,
+                 Tags::ConstraintGamma1, Tags::ConstraintGamma2,
+                 gr::Tags::Lapse<DataVector>,
+                 gr::Tags::Shift<Dim, Frame::Inertial, DataVector>>;
+  using dg_interior_dt_vars_tags =
+      tmpl::list<::Tags::dt<Pi>, ::Tags::dt<Phi<Dim>>, ::Tags::dt<Psi>>;
+  using dg_interior_deriv_vars_tags =
+      tmpl::list<::Tags::deriv<Psi, tmpl::size_t<Dim>, Frame::Inertial>,
+                 ::Tags::deriv<Phi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>>;
+  using dg_gridless_tags = tmpl::list<>;
+
+  std::optional<std::string> dg_time_derivative(
+      gsl::not_null<Scalar<DataVector>*> dt_pi_correction,
+      gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+          dt_phi_correction,
+      gsl::not_null<Scalar<DataVector>*> dt_psi_correction,
+      const std::optional<tnsr::I<DataVector, Dim>>& face_mesh_velocity,
+      const tnsr::i<DataVector, Dim>& normal_covector,
+      const tnsr::I<DataVector, Dim>& normal_vector,
+      const tnsr::i<DataVector, Dim>& phi, const Scalar<DataVector>& psi,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& coords,
+      const Scalar<DataVector>& gamma1, const Scalar<DataVector>& gamma2,
+      const Scalar<DataVector>& lapse, const tnsr::I<DataVector, Dim>& shift,
+      const Scalar<DataVector>& dt_pi, const tnsr::i<DataVector, Dim>& dt_phi,
+      const Scalar<DataVector>& dt_psi, const tnsr::i<DataVector, Dim>& d_psi,
+      const tnsr::ij<DataVector, Dim>& d_phi) const noexcept;
+};
+}  // namespace CurvedScalarWave::BoundaryConditions

--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/Factory.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/Factory.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 
 #include "Domain/BoundaryConditions/Periodic.hpp"
+#include "Evolution/Systems/CurvedScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.hpp"
 #include "Evolution/Systems/CurvedScalarWave/BoundaryConditions/Outflow.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -13,6 +14,6 @@ namespace CurvedScalarWave::BoundaryConditions {
 /// Typelist of standard BoundaryConditions
 template <size_t Dim>
 using standard_boundary_conditions =
-    tmpl::list<Outflow<Dim>,
+    tmpl::list<Outflow<Dim>, ConstraintPreservingSphericalRadiation<Dim>,
                domain::BoundaryConditions::Periodic<BoundaryCondition<Dim>>>;
 }  // namespace CurvedScalarWave::BoundaryConditions

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.py
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.py
@@ -1,0 +1,52 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+from Evolution.Systems.CurvedScalarWave.Characteristics import (
+    char_speed_vpsi, char_speed_vzero, char_speed_vplus, char_speed_vminus)
+
+
+def error(face_mesh_velocity, normal_covector, normal_vector, phi, psi,
+          inertial_coords, gamma1, gamma2, lapse, shift, dt_pi, dt_phi, dt_psi,
+          d_psi, d_phi):
+    return None
+
+
+def dt_psi_constraint_preserving_spherical_radiation(
+    face_mesh_velocity, normal_covector, normal_vector, phi, psi,
+    inertial_coords, gamma1, gamma2, lapse, shift, dt_pi, dt_phi, dt_psi,
+    d_psi, d_phi):
+    char_speed_psi = char_speed_vpsi(gamma1, lapse, shift, normal_covector)
+
+    if face_mesh_velocity is not None:
+        char_speed_psi -= np.dot(normal_covector, face_mesh_velocity)
+
+    return np.dot(normal_vector, d_psi - phi) * min(0., char_speed_psi)
+
+
+def dt_phi_constraint_preserving_spherical_radiation(
+    face_mesh_velocity, normal_covector, normal_vector, phi, psi,
+    inertial_coords, gamma1, gamma2, lapse, shift, dt_pi, dt_phi, dt_psi,
+    d_psi, d_phi):
+    char_speed_zero = char_speed_vzero(gamma1, lapse, shift, normal_covector)
+    if face_mesh_velocity is not None:
+        char_speed_zero -= np.dot(normal_covector, face_mesh_velocity)
+    return 0.5 * np.einsum("ij,j", d_phi.T - d_phi, normal_vector) * min(
+        0, char_speed_zero)
+
+
+def dt_pi_constraint_preserving_spherical_radiation(
+    face_mesh_velocity, normal_covector, normal_vector, phi, psi,
+    inertial_coords, gamma1, gamma2, lapse, shift, dt_pi, dt_phi, dt_psi,
+    d_psi, d_phi):
+    dt_psi_correction = dt_psi_constraint_preserving_spherical_radiation(
+        face_mesh_velocity, normal_covector, normal_vector, phi, psi,
+        inertial_coords, gamma1, gamma2, lapse, shift, dt_pi, dt_phi, dt_psi,
+        d_psi, d_phi)
+    inv_radius = 1. / np.linalg.norm(inertial_coords)
+    bc_dt_pi = (2. * inv_radius**2 * psi + 4. * inv_radius * dt_psi +
+                4. * inv_radius * np.dot(normal_vector, phi) +
+                2. * np.dot(normal_vector, dt_phi) + np.dot(shift, dt_phi) +
+                np.einsum("i,j,ij", normal_vector, normal_vector, d_phi))
+    bc_dt_pi /= lapse
+    return bc_dt_pi - dt_pi + gamma2 * dt_psi_correction

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/BoundaryConditions/Test_ConstraintPreservingSphericalRadiation.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/BoundaryConditions/Test_ConstraintPreservingSphericalRadiation.cpp
@@ -1,0 +1,62 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Index.hpp"
+#include "Evolution/Systems/CurvedScalarWave/BoundaryConditions/Factory.hpp"
+#include "Evolution/Systems/CurvedScalarWave/BoundaryCorrections/UpwindPenalty.hpp"
+#include "Evolution/Systems/CurvedScalarWave/System.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace helpers = TestHelpers::evolution::dg;
+namespace {
+
+template <size_t Dim>
+void test() {
+  CAPTURE(Dim);
+  MAKE_GENERATOR(gen);
+
+  helpers::test_boundary_condition_with_python<
+      CurvedScalarWave::BoundaryConditions::
+          ConstraintPreservingSphericalRadiation<Dim>,
+      CurvedScalarWave::BoundaryConditions::BoundaryCondition<Dim>,
+      CurvedScalarWave::System<Dim>,
+      tmpl::list<CurvedScalarWave::BoundaryCorrections::UpwindPenalty<Dim>>>(
+      make_not_null(&gen),
+      "Evolution.Systems.CurvedScalarWave.BoundaryConditions."
+      "ConstraintPreservingSphericalRadiation",
+      tuples::TaggedTuple<
+          helpers::Tags::PythonFunctionForErrorMessage<>,
+          helpers::Tags::PythonFunctionName<::Tags::dt<CurvedScalarWave::Pi>>,
+          helpers::Tags::PythonFunctionName<
+              ::Tags::dt<CurvedScalarWave::Phi<Dim>>>,
+          helpers::Tags::PythonFunctionName<::Tags::dt<CurvedScalarWave::Psi>>>{
+          "error", "dt_pi_constraint_preserving_spherical_radiation",
+          "dt_phi_constraint_preserving_spherical_radiation",
+          "dt_psi_constraint_preserving_spherical_radiation"},
+      "ConstraintPreservingSphericalRadiation:\n",
+      Index<Dim - 1>{Dim == 1 ? 1 : 5}, db::DataBox<tmpl::list<>>{},
+      tuples::TaggedTuple<>{});
+}
+}  // namespace
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.CurvedScalarWave.ConstraintPreservingRadiation",
+    "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{""};
+  test<1>();
+  test<2>();
+  test<3>();
+}

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_CurvedScalarWave")
 
 set(LIBRARY_SOURCES
   BoundaryCorrections/Test_UpwindPenalty.cpp
+  BoundaryConditions/Test_ConstraintPreservingSphericalRadiation.cpp
   BoundaryConditions/Test_Outflow.cpp
   Test_Constraints.cpp
   Test_Characteristics.cpp
@@ -22,9 +23,9 @@ add_test_library(
 target_link_libraries(
   ${LIBRARY}
   PRIVATE
-  DataStructures
   CurvedScalarWave
   CurvedScalarWaveHelpers
+  DataStructures
   GeneralRelativityHelpers
   Utilities
   )


### PR DESCRIPTION
## Proposed changes

This PR adds second-order Bayliss Turkel boundary conditions to the CurvedScalarWave system. These are pretty analogous to the Bayliss Turkel condition for the ScalarWave systems with a few extra terms. 

Unfortunately, most of the tensor calculation in the boundary condition calculation have to be done manually which should be changed once tensor expressions can handle this.

depends on #3407 

At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
