### PR TITLE
Add NeighborPackagedData to GRMHD

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/CMakeLists.txt
@@ -23,6 +23,7 @@ spectre_target_headers(
   FixConservativesAndComputePrims.hpp
   GrTagsForHydro.hpp
   InitialDataTci.hpp
+  NeighborPackagedData.hpp
   PrimitiveGhostData.hpp
   PrimsAfterRollback.hpp
   ResizeAndComputePrimitives.hpp

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/NeighborPackagedData.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/NeighborPackagedData.hpp
@@ -1,0 +1,238 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <boost/functional/hash.hpp>
+#include <cstddef>
+#include <optional>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/FixedHashMap.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/MaxNumberOfNeighbors.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/TagsTimeDependent.hpp"
+#include "Evolution/BoundaryCorrectionTags.hpp"
+#include "Evolution/DgSubcell/NeighborData.hpp"
+#include "Evolution/DgSubcell/Projection.hpp"
+#include "Evolution/DgSubcell/Reconstruction.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/NeighborData.hpp"
+#include "Evolution/DgSubcell/Tags/OnSubcellFaces.hpp"
+#include "Evolution/DiscontinuousGalerkin/Actions/NormalCovectorAndMagnitude.hpp"
+#include "Evolution/DiscontinuousGalerkin/Actions/PackageDataImpl.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/BoundaryCorrection.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Factory.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Reconstructor.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Tag.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ComputeFluxes.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/FakeVirtual.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace grmhd::ValenciaDivClean::subcell {
+/*!
+ * \brief On elements using DG, reconstructs the interface data from a
+ * neighboring element doing subcell.
+ *
+ * The neighbor's packaged data needed by the boundary correction is computed
+ * and returned so that it can be used for solving the Riemann problem on the
+ * interfaces.
+ *
+ * Note that for strict conservation the Riemann solve should be done on the
+ * subcells, with the correction being projected back to the DG interface.
+ * However, in practice such strict conservation doesn't seem to be necessary
+ * and can be explained by that we only need strict conservation at shocks, and
+ * if one element is doing DG, then we aren't at a shock.
+ */
+struct NeighborPackagedData {
+  template <typename DbTagsList>
+  static FixedHashMap<
+      maximum_number_of_neighbors(3), std::pair<Direction<3>, ElementId<3>>,
+      std::vector<double>, boost::hash<std::pair<Direction<3>, ElementId<3>>>>
+  apply(const db::DataBox<DbTagsList>& box,
+        const std::vector<std::pair<Direction<3>, ElementId<3>>>&
+            mortars_to_reconstruct_to) noexcept {
+    using evolved_vars_tag = typename System::variables_tag;
+    using evolved_vars_tags = typename evolved_vars_tag::tags_list;
+    using prim_tags = typename System::primitive_variables_tag::tags_list;
+    using recons_prim_tags = tmpl::push_back<
+        prim_tags,
+        hydro::Tags::LorentzFactorTimesSpatialVelocity<DataVector, 3>>;
+    using fluxes_tags = db::wrap_tags_in<::Tags::Flux, evolved_vars_tags,
+                                         tmpl::size_t<3>, Frame::Inertial>;
+
+    ASSERT(not db::get<domain::Tags::MeshVelocity<3>>(box).has_value(),
+           "Haven't yet added support for moving mesh to DG-subcell. This "
+           "should be easy to generalize, but we will want to consider "
+           "storing the mesh velocity on the faces instead of "
+           "re-slicing/projecting.");
+
+    FixedHashMap<maximum_number_of_neighbors(3),
+                 std::pair<Direction<3>, ElementId<3>>, std::vector<double>,
+                 boost::hash<std::pair<Direction<3>, ElementId<3>>>>
+        nhbr_package_data{};
+
+    const auto& nhbr_subcell_data =
+        db::get<evolution::dg::subcell::Tags::
+                    NeighborDataForReconstructionAndRdmpTci<3>>(box);
+    const Mesh<3>& subcell_mesh =
+        db::get<evolution::dg::subcell::Tags::Mesh<3>>(box);
+    const Mesh<3>& dg_mesh = db::get<domain::Tags::Mesh<3>>(box);
+
+    const auto volume_prims = evolution::dg::subcell::fd::project(
+        db::get<typename System::primitive_variables_tag>(box), dg_mesh,
+        subcell_mesh.extents());
+
+    const auto& recons =
+        db::get<grmhd::ValenciaDivClean::fd::Tags::Reconstructor>(box);
+    const auto& boundary_correction =
+        db::get<evolution::Tags::BoundaryCorrection<System>>(box);
+    using derived_boundary_corrections =
+        typename std::decay_t<decltype(boundary_correction)>::creatable_classes;
+    tmpl::for_each<
+        derived_boundary_corrections>([&box, &boundary_correction, &dg_mesh,
+                                       &mortars_to_reconstruct_to,
+                                       &nhbr_package_data, &nhbr_subcell_data,
+                                       &recons, &subcell_mesh, &volume_prims](
+                                          auto derived_correction_v) noexcept {
+      using DerivedCorrection = tmpl::type_from<decltype(derived_correction_v)>;
+      if (typeid(boundary_correction) == typeid(DerivedCorrection)) {
+        using dg_package_data_temporary_tags =
+            typename DerivedCorrection::dg_package_data_temporary_tags;
+        using dg_package_data_argument_tags = tmpl::append<
+            evolved_vars_tags, recons_prim_tags, fluxes_tags,
+            tmpl::remove_duplicates<tmpl::push_back<
+                dg_package_data_temporary_tags, gr::Tags::SpatialMetric<3>,
+                gr::Tags::SqrtDetSpatialMetric<DataVector>,
+                gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>,
+                evolution::dg::Actions::detail::NormalVector<3>>>>;
+
+        const auto& element = db::get<domain::Tags::Element<3>>(box);
+        const auto& eos = get<hydro::Tags::EquationOfStateBase>(box);
+
+        using dg_package_field_tags =
+            typename DerivedCorrection::dg_package_field_tags;
+        Variables<dg_package_data_argument_tags> vars_on_face{0};
+        Variables<dg_package_field_tags> packaged_data{0};
+        for (const auto& mortar_id : mortars_to_reconstruct_to) {
+          const Direction<3>& direction = mortar_id.first;
+
+          Index<3> extents = subcell_mesh.extents();
+          // Switch to face-centered instead of cell-centered points on the FD.
+          // There are num_cell_centered+1 face-centered points.
+          ++extents[direction.dimension()];
+
+          // Computed prims and cons on face via reconstruction
+          const size_t num_face_pts = subcell_mesh.extents()
+                                          .slice_away(direction.dimension())
+                                          .product();
+          vars_on_face.initialize(num_face_pts);
+          // Copy spacetime vars over from volume.
+          using spacetime_vars_to_copy = tmpl::list<
+              gr::Tags::Lapse<DataVector>,
+              gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+              gr::Tags::SpatialMetric<3>,
+              gr::Tags::SqrtDetSpatialMetric<DataVector>,
+              gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>>;
+          tmpl::for_each<spacetime_vars_to_copy>(
+              [&direction, &extents, &vars_on_face,
+               &spacetime_vars_on_faces =
+                   db::get<evolution::dg::subcell::Tags::OnSubcellFaces<
+                       typename System::flux_spacetime_variables_tag, 3>>(box)](
+                  auto tag_v) noexcept {
+                using tag = tmpl::type_from<decltype(tag_v)>;
+                data_on_slice(make_not_null(&get<tag>(vars_on_face)),
+                              get<tag>(gsl::at(spacetime_vars_on_faces,
+                                               direction.dimension())),
+                              extents, direction.dimension(),
+                              direction.side() == Side::Lower
+                                  ? 0
+                                  : extents[direction.dimension()] - 1);
+              });
+
+          call_with_dynamic_type<void, typename grmhd::ValenciaDivClean::fd::
+                                           Reconstructor::creatable_classes>(
+              &recons, [&element, &eos, &mortar_id, &nhbr_subcell_data,
+                        &subcell_mesh, &vars_on_face,
+                        &volume_prims](const auto& reconstructor) noexcept {
+                reconstructor->reconstruct_fd_neighbor(
+                    make_not_null(&vars_on_face), volume_prims, eos, element,
+                    nhbr_subcell_data, subcell_mesh, mortar_id.first);
+              });
+
+          grmhd::ValenciaDivClean::subcell::compute_fluxes(
+              make_not_null(&vars_on_face));
+
+          // Note: since the spacetime isn't dynamical we don't need to
+          // worry about different normal vectors on the different sides
+          // of the element. If the spacetime is dynamical, then the normal
+          // covector needs to be sent, or at least the inverse spatial metric
+          // from the neighbor so that the normal covector can be computed
+          // correctly.
+          tnsr::i<DataVector, 3, Frame::Inertial> normal_covector =
+              get<evolution::dg::Tags::NormalCovector<3>>(
+                  *db::get<evolution::dg::Tags::NormalCovectorAndMagnitude<3>>(
+                       box)
+                       .at(mortar_id.first));
+          for (auto& t : normal_covector) {
+            t *= -1.0;
+          }
+          // Note: Only need to do the projection in 2d and 3d, but GRMHD is
+          // always 3d currently.
+          const auto dg_normal_covector = normal_covector;
+          for (size_t i = 0; i < 3; ++i) {
+            normal_covector.get(i) = evolution::dg::subcell::fd::project(
+                dg_normal_covector.get(i),
+                dg_mesh.slice_away(mortar_id.first.dimension()),
+                subcell_mesh.extents().slice_away(mortar_id.first.dimension()));
+          }
+
+          // Compute the packaged data
+          packaged_data.initialize(num_face_pts);
+          using dg_package_data_projected_tags = tmpl::append<
+              evolved_vars_tags, fluxes_tags, dg_package_data_temporary_tags,
+              typename DerivedCorrection::dg_package_data_primitive_tags>;
+          evolution::dg::Actions::detail::dg_package_data<System>(
+              make_not_null(&packaged_data),
+              dynamic_cast<const DerivedCorrection&>(boundary_correction),
+              vars_on_face, normal_covector, {std::nullopt}, box,
+              typename DerivedCorrection::dg_package_data_volume_tags{},
+              dg_package_data_projected_tags{});
+
+          // Reconstruct the DG solution.
+          // Really we should be solving the boundary correction and
+          // then reconstructing, but away from a shock this doesn't
+          // matter.
+          auto dg_packaged_data = evolution::dg::subcell::fd::reconstruct(
+              packaged_data, dg_mesh.slice_away(mortar_id.first.dimension()),
+              subcell_mesh.extents().slice_away(mortar_id.first.dimension()));
+          nhbr_package_data[mortar_id] = std::vector<double>{
+              dg_packaged_data.data(),
+              dg_packaged_data.data() + dg_packaged_data.size()};
+        }
+      }
+    });
+
+    return nhbr_package_data;
+  }
+};
+}  // namespace grmhd::ValenciaDivClean::subcell

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.hpp
@@ -330,10 +330,9 @@ class BondiMichel : public AnalyticSolution, public MarkAsAnalyticSolution {
   template <typename DataType, typename Tag,
             Requires<not tmpl::list_contains_v<hydro::grmhd_tags<DataType>,
                                                Tag>> = nullptr>
-  tuples::TaggedTuple<Tag> variables(const tnsr::I<DataType, 3>& /*x*/,
-                                     tmpl::list<Tag> /*meta*/,
-                                     IntermediateVars<DataType>& vars) const
-      noexcept {
+  tuples::TaggedTuple<Tag> variables(
+      const tnsr::I<DataType, 3>& /*x*/, tmpl::list<Tag> /*meta*/,
+      const IntermediateVars<DataType>& vars) const noexcept {
     return {std::move(get<Tag>(vars.kerr_schild_soln))};
   }
 

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -15,6 +15,7 @@ set(LIBRARY_SOURCES
   Subcell/Test_FixConservativesAndComputePrims.cpp
   Subcell/Test_GrTagsForHydro.cpp
   Subcell/Test_InitialDataTci.cpp
+  Subcell/Test_NeighborPackagedData.cpp
   Subcell/Test_PrimitiveGhostData.cpp
   Subcell/Test_PrimsAfterRollback.cpp
   Subcell/Test_ResizeAndComputePrimitives.cpp

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
@@ -1,0 +1,306 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/SliceVariables.hpp"
+#include "DataStructures/Tensor/EagerMath/Determinant.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Block.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CreateInitialElement.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/TagsTimeDependent.hpp"
+#include "Evolution/BoundaryCorrectionTags.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
+#include "Evolution/DgSubcell/SliceData.hpp"
+#include "Evolution/DgSubcell/Tags/Coordinates.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/OnSubcellFaces.hpp"
+#include "Evolution/DiscontinuousGalerkin/Actions/NormalCovectorAndMagnitude.hpp"
+#include "Evolution/DiscontinuousGalerkin/MortarTags.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/BoundaryCorrection.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Factory.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Hll.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotisedCentral.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Tag.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/NeighborPackagedData.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+
+namespace grmhd::ValenciaDivClean {
+namespace {
+template <size_t Dim, typename... Maps, typename Solution>
+auto face_centered_gr_tags(
+    const Mesh<Dim>& subcell_mesh, const double time,
+    const domain::CoordinateMap<Frame::Logical, Frame::Inertial, Maps...>& map,
+    const Solution& soln) {
+  std::array<typename System::flux_spacetime_variables_tag::type, Dim>
+      face_centered_gr_vars{};
+
+  for (size_t d = 0; d < Dim; ++d) {
+    const auto basis = make_array<Dim>(subcell_mesh.basis(0));
+    auto quadrature = make_array<Dim>(subcell_mesh.quadrature(0));
+    auto extents = make_array<Dim>(subcell_mesh.extents(0));
+    gsl::at(extents, d) = subcell_mesh.extents(0) + 1;
+    gsl::at(quadrature, d) = Spectral::Quadrature::FaceCentered;
+    const Mesh<Dim> face_centered_mesh{extents, basis, quadrature};
+    const auto face_centered_logical_coords =
+        logical_coordinates(face_centered_mesh);
+    const auto face_centered_inertial_coords =
+        map(face_centered_logical_coords);
+
+    gsl::at(face_centered_gr_vars, d)
+        .initialize(face_centered_mesh.number_of_grid_points());
+    gsl::at(face_centered_gr_vars, d)
+        .assign_subset(soln.variables(
+            face_centered_inertial_coords, time,
+            typename System::flux_spacetime_variables_tag::tags_list{}));
+  }
+  return face_centered_gr_vars;
+}
+
+double test(const size_t num_dg_pts) {
+  using variables_tag = typename System::variables_tag;
+
+  using Affine = domain::CoordinateMaps::Affine;
+  using Affine3D =
+      domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  const Affine affine_map{-1.0, 1.0, 2.0, 3.0};
+  const auto coordinate_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
+          Affine3D{affine_map, affine_map, affine_map});
+  const auto moving_mesh_map =
+      domain::make_coordinate_map<Frame::Grid, Frame::Inertial>(
+          domain::CoordinateMaps::Identity<3>{});
+  const auto element = domain::Initialization::create_initial_element(
+      ElementId<3>{0, {SegmentId{3, 4}, SegmentId{3, 4}, SegmentId{3, 4}}},
+      Block<3>{
+          domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+              Affine3D{affine_map, affine_map, affine_map}),
+          0,
+          {},
+          {}},
+      std::vector<std::array<size_t, 3>>{std::array<size_t, 3>{{3, 3, 3}}});
+
+  const grmhd::Solutions::BondiMichel soln{1.0, 5.0, 0.05, 1.4, 2.0};
+
+  const double time = 0.0;
+  const Mesh<3> dg_mesh{num_dg_pts, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto};
+  const Mesh<3> subcell_mesh = evolution::dg::subcell::fd::mesh(dg_mesh);
+  const auto dg_coords = coordinate_map(logical_coordinates(dg_mesh));
+
+  // Neighbor data for reconstruction.
+  //
+  // 0. neighbors coords (our logical coords +2)
+  // 1. compute prims from solution
+  // 2. compute prims needed for reconstruction
+  // 3. set neighbor data
+  evolution::dg::subcell::Tags::NeighborDataForReconstructionAndRdmpTci<3>::type
+      neighbor_data{};
+  using prims_to_reconstruct_tags =
+      tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
+                 hydro::Tags::Pressure<DataVector>,
+                 hydro::Tags::LorentzFactorTimesSpatialVelocity<DataVector, 3>,
+                 hydro::Tags::MagneticField<DataVector, 3>,
+                 hydro::Tags::DivergenceCleaningField<DataVector>>;
+  for (const Direction<3>& direction : Direction<3>::all_directions()) {
+    auto neighbor_logical_coords = logical_coordinates(subcell_mesh);
+    neighbor_logical_coords.get(direction.dimension()) +=
+        2.0 * direction.sign();
+    auto neighbor_coords = coordinate_map(neighbor_logical_coords);
+    const auto neighbor_prims =
+        soln.variables(neighbor_coords, time,
+                       typename System::primitive_variables_tag::tags_list{});
+    Variables<prims_to_reconstruct_tags> prims_to_reconstruct{
+        subcell_mesh.number_of_grid_points()};
+    get<hydro::Tags::RestMassDensity<DataVector>>(prims_to_reconstruct) =
+        get<hydro::Tags::RestMassDensity<DataVector>>(neighbor_prims);
+    get<hydro::Tags::Pressure<DataVector>>(prims_to_reconstruct) =
+        get<hydro::Tags::Pressure<DataVector>>(neighbor_prims);
+    get<hydro::Tags::LorentzFactorTimesSpatialVelocity<DataVector, 3>>(
+        prims_to_reconstruct) =
+        get<hydro::Tags::SpatialVelocity<DataVector, 3>>(neighbor_prims);
+    for (auto& component :
+         get<hydro::Tags::LorentzFactorTimesSpatialVelocity<DataVector, 3>>(
+             prims_to_reconstruct)) {
+      component *=
+          get(get<hydro::Tags::LorentzFactor<DataVector>>(neighbor_prims));
+    }
+    get<hydro::Tags::MagneticField<DataVector, 3>>(prims_to_reconstruct) =
+        get<hydro::Tags::MagneticField<DataVector, 3>>(neighbor_prims);
+    get<hydro::Tags::DivergenceCleaningField<DataVector>>(
+        prims_to_reconstruct) =
+        get<hydro::Tags::DivergenceCleaningField<DataVector>>(neighbor_prims);
+
+    // Slice data so we can add it to the element's neighbor data
+    DirectionMap<3, bool> directions_to_slice{};
+    directions_to_slice[direction.opposite()] = true;
+    evolution::dg::subcell::NeighborData neighbor_data_in_direction{};
+    neighbor_data_in_direction.data_for_reconstruction =
+        evolution::dg::subcell::slice_data(
+            prims_to_reconstruct, subcell_mesh.extents(),
+            grmhd::ValenciaDivClean::fd::MonotisedCentralPrim{}
+                .ghost_zone_size(),
+            directions_to_slice)
+            .at(direction.opposite());
+    neighbor_data[std::pair{direction,
+                            *element.neighbors().at(direction).begin()}] =
+        neighbor_data_in_direction;
+  }
+
+  Variables<typename System::spacetime_variables_tag::tags_list>
+      dg_spacetime_vars{dg_mesh.number_of_grid_points()};
+  dg_spacetime_vars.assign_subset(soln.variables(
+      dg_coords, time, typename System::spacetime_variables_tag::tags_list{}));
+  Variables<typename System::primitive_variables_tag::tags_list> dg_prim_vars{
+      dg_mesh.number_of_grid_points()};
+  dg_prim_vars.assign_subset(soln.variables(
+      dg_coords, time, typename System::primitive_variables_tag::tags_list{}));
+
+  DirectionMap<3, std::optional<Variables<
+                      tmpl::list<evolution::dg::Tags::MagnitudeOfNormal,
+                                 evolution::dg::Tags::NormalCovector<3>>>>>
+      normal_vectors{};
+  for (const auto& direction : Direction<3>::all_directions()) {
+    using inverse_spatial_metric_tag =
+        typename System::inverse_spatial_metric_tag;
+    const Mesh<2> face_mesh = dg_mesh.slice_away(direction.dimension());
+    const auto face_logical_coords =
+        interface_logical_coordinates(face_mesh, direction);
+    std::unordered_map<Direction<3>, tnsr::i<DataVector, 3, Frame::Inertial>>
+        unnormalized_normal_covectors{};
+    tnsr::i<DataVector, 3, Frame::Inertial> unnormalized_covector{};
+    for (size_t i = 0; i < 3; ++i) {
+      unnormalized_covector.get(i) =
+          coordinate_map.inv_jacobian(face_logical_coords)
+              .get(direction.dimension(), i);
+    }
+    unnormalized_normal_covectors[direction] = unnormalized_covector;
+    Variables<tmpl::list<
+        inverse_spatial_metric_tag,
+        evolution::dg::Actions::detail::NormalVector<3>,
+        evolution::dg::Actions::detail::OneOverNormalVectorMagnitude>>
+        fields_on_face{face_mesh.number_of_grid_points()};
+    fields_on_face.assign_subset(
+        soln.variables(coordinate_map(face_logical_coords), time,
+                       tmpl::list<inverse_spatial_metric_tag>{}));
+    normal_vectors[direction] = std::nullopt;
+    evolution::dg::Actions::detail::
+        unit_normal_vector_and_covector_and_magnitude<System>(
+            make_not_null(&normal_vectors), make_not_null(&fields_on_face),
+            direction, unnormalized_normal_covectors, moving_mesh_map);
+  }
+
+  auto box = db::create<
+      db::AddSimpleTags<
+          domain::Tags::Element<3>, domain::Tags::Mesh<3>,
+          evolution::dg::subcell::Tags::Mesh<3>, fd::Tags::Reconstructor,
+          evolution::Tags::BoundaryCorrection<grmhd::ValenciaDivClean::System>,
+          hydro::Tags::EquationOfState<EquationsOfState::PolytropicFluid<true>>,
+          typename System::spacetime_variables_tag,
+          typename System::primitive_variables_tag, variables_tag,
+          evolution::dg::subcell::Tags::OnSubcellFaces<
+              typename System::flux_spacetime_variables_tag, 3>,
+          evolution::dg::subcell::Tags::NeighborDataForReconstructionAndRdmpTci<
+              3>,
+          Tags::ConstraintDampingParameter, evolution::dg::Tags::MortarData<3>,
+          domain::Tags::MeshVelocity<3>,
+          evolution::dg::Tags::NormalCovectorAndMagnitude<3>>,
+      db::AddComputeTags<
+          evolution::dg::subcell::Tags::LogicalCoordinatesCompute<3>>>(
+      element, dg_mesh, subcell_mesh,
+      std::unique_ptr<grmhd::ValenciaDivClean::fd::Reconstructor>{
+          std::make_unique<
+              grmhd::ValenciaDivClean::fd::MonotisedCentralPrim>()},
+      std::unique_ptr<
+          grmhd::ValenciaDivClean::BoundaryCorrections::BoundaryCorrection>{
+          std::make_unique<
+              grmhd::ValenciaDivClean::BoundaryCorrections::Hll>()},
+      soln.equation_of_state(), dg_spacetime_vars, dg_prim_vars,
+      typename variables_tag::type{dg_mesh.number_of_grid_points()},
+      face_centered_gr_tags(subcell_mesh, time, coordinate_map, soln),
+      neighbor_data, 1.0, evolution::dg::Tags::MortarData<3>::type{},
+      std::optional<tnsr::I<DataVector, 3, Frame::Inertial>>{}, normal_vectors);
+  db::mutate_apply<ConservativeFromPrimitive>(make_not_null(&box));
+
+  std::vector<std::pair<Direction<3>, ElementId<3>>>
+      mortars_to_reconstruct_to{};
+  for (const auto& [direction, neighbors] : element.neighbors()) {
+    mortars_to_reconstruct_to.emplace_back(direction, *neighbors.begin());
+  }
+
+  const auto all_packaged_data =
+      subcell::NeighborPackagedData::apply(box, mortars_to_reconstruct_to);
+
+  // Parse out evolved vars, since those are easiest to check for correctness,
+  // then return absolute difference between analytic and reconstructed values.
+  FixedHashMap<maximum_number_of_neighbors(3),
+               std::pair<Direction<3>, ElementId<3>>,
+               typename variables_tag::type,
+               boost::hash<std::pair<Direction<3>, ElementId<3>>>>
+      evolved_vars_errors{};
+  double max_abs_error = 0.0;
+  for (const auto& [direction_and_id, data] : all_packaged_data) {
+    const auto& direction = direction_and_id.first;
+    using dg_package_field_tags = typename grmhd::ValenciaDivClean::
+        BoundaryCorrections::Hll::dg_package_field_tags;
+    const Mesh<2> face_mesh = dg_mesh.slice_away(direction.dimension());
+    Variables<dg_package_field_tags> packaged_data{
+        face_mesh.number_of_grid_points()};
+    std::copy(data.begin(), data.end(), packaged_data.data());
+
+    auto sliced_vars = data_on_slice(
+        db::get<variables_tag>(box), dg_mesh.extents(), direction.dimension(),
+        direction.side() == Side::Upper
+            ? dg_mesh.extents(direction.dimension()) - 1
+            : 0);
+
+    tmpl::for_each<typename variables_tag::type::tags_list>(
+        [&sliced_vars, &max_abs_error, &packaged_data](auto tag_v) {
+          using tag = tmpl::type_from<decltype(tag_v)>;
+          auto& sliced_tensor = get<tag>(sliced_vars);
+          const auto& packaged_data_tensor = get<tag>(packaged_data);
+          for (size_t tensor_index = 0; tensor_index < sliced_tensor.size();
+               ++tensor_index) {
+            max_abs_error = std::max(
+                max_abs_error, max(abs(sliced_tensor[tensor_index] -
+                                       packaged_data_tensor[tensor_index])));
+          }
+        });
+  }
+  return max_abs_error;
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.ValenciaDivClean.Subcell.NeighborPackagedData",
+    "[Unit][Evolution]") {
+  // This tests sets up a cube [2,3]^3 in a Bondi-Michel spacetime and verifies
+  // that the difference between the reconstructed evolved variables and the
+  // sliced (exact on LGL grid) evolved variables on the interfaces decreases.
+  CHECK(test(4) > test(8));
+  // Check that the error is "reasonably small"
+  CHECK(test(4) < 1.0e-3);
+}
+}  // namespace
+}  // namespace grmhd::ValenciaDivClean


### PR DESCRIPTION
## Proposed changes

- The NeighborPackagedData struct is invoked on elements doing DG and computes the packaged data for the boundary correction that the neighboring subcell element is using. This is the last missing piece before being able to switch GRMHD to DG-subcell.
- Added a missing `const` to the `BondiMichel` solution

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
