### PR TITLE
Add spherical harmonic initial data for CurvedScalarWave

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -1376,6 +1376,21 @@ eprint = {https://doi.org/10.1137/0916035}
   volume   = "453",
 }
 
+@article{Scheel2003vs,
+    author = "Scheel, Mark A. and Erickcek, Adrienne L. and Burko, Lior M. and
+              Kidder, Lawrence E. and Pfeiffer, Harald P.
+              and Teukolsky, Saul A.",
+    title = "{3-D simulations of linearized scalar fields in Kerr space-time}",
+    eprint = "gr-qc/0305027",
+    archivePrefix = "arXiv",
+    doi = "10.1103/PhysRevD.69.104006",
+    journal = "Phys. Rev. D",
+    volume = "69",
+    pages = "104006",
+    year = "2004",
+    url = {https://journals.aps.org/prd/abstract/10.1103/PhysRevD.69.104006}
+}
+
 @book{Shapiro1983,
   author = "Shapiro, Stuart L. and Teukolsky, Saul A.",
   title  = "Black holes, white dwarfs, and neutron stars:

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   PlaneWave3DKerrSchild.cpp
   PlaneWaveMinkowski.cpp
+  PureSphericalHarmonic.cpp
   RegularSphericalWave3DKerrSchild.cpp
   )
 
@@ -18,6 +19,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   AnalyticData.hpp
+  PureSphericalHarmonic.hpp
   ScalarWaveGr.hpp
   ScalarWaveGr.tpp
   )
@@ -33,6 +35,7 @@ target_link_libraries(
   DataStructures
   GeneralRelativity
   GeneralRelativitySolutions
+  Spectral
   Utilities
   WaveEquationSolutions
   )

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/PureSphericalHarmonic.cpp
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/PureSphericalHarmonic.cpp
@@ -1,0 +1,76 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticData/CurvedWaveEquation/PureSphericalHarmonic.hpp"
+
+#include <complex>
+#include <cstddef>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/SwshInterpolation.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace CurvedScalarWave::AnalyticData {
+
+PureSphericalHarmonic::PureSphericalHarmonic(const double radius,
+                                             const double width,
+                                             std::pair<size_t, int> mode,
+                                             const Options::Context& context)
+    : radius_(radius), width_sq_(width * width), mode_{std::move(mode)} {
+  if (abs(mode_.second) > static_cast<int>(mode_.first)) {
+    PARSE_ERROR(
+        context,
+        "The absolute value of the m_mode must be less than or equal to the "
+        "l-mode but the m-mode is "
+            << mode_.second << " and the l-mode is " << mode_.first);
+  }
+  if (radius_ <= 0.) {
+    PARSE_ERROR(context,
+                "The radius must be greater than 0 but is " << radius_);
+  }
+  if (width <= 0.) {
+    PARSE_ERROR(context, "The width must be greater than 0 but is " << width);
+  }
+}
+
+tuples::TaggedTuple<CurvedScalarWave::Pi, CurvedScalarWave::Phi<3>,
+                    CurvedScalarWave::Psi>
+PureSphericalHarmonic::variables(
+    const tnsr::I<DataVector, 3>& x, double /*t*/,
+    tmpl::list<CurvedScalarWave::Pi, CurvedScalarWave::Phi<3>,
+               CurvedScalarWave::Psi> /*meta*/) const noexcept {
+  Scalar<DataVector> pi{get(magnitude(x)) - radius_};
+  get(pi) = exp(-get(pi) * get(pi) / width_sq_);
+  const Spectral::Swsh::SpinWeightedSphericalHarmonic spherical_harmonic(
+      0, mode_.first, mode_.second);
+  const auto theta = atan2(hypot(x[0], x[1]), x[2]);
+  const auto phi = atan2(x[1], x[0]);
+  get(pi) *= real(spherical_harmonic.evaluate(theta, phi, sin(theta / 2.),
+                                              cos(theta / 2.)));
+  return tuples::TaggedTuple<CurvedScalarWave::Pi, CurvedScalarWave::Phi<3>,
+                             CurvedScalarWave::Psi>{
+      std::move(pi), make_with_value<tnsr::i<DataVector, 3>>(x, 0.),
+      make_with_value<Scalar<DataVector>>(x, 0.)};
+}
+
+void PureSphericalHarmonic::pup(PUP::er& p) noexcept {
+  p | radius_;
+  p | width_sq_;
+  p | mode_;
+}
+
+bool operator==(const PureSphericalHarmonic& lhs,
+                const PureSphericalHarmonic& rhs) noexcept {
+  return lhs.radius_ == rhs.radius_ and lhs.width_sq_ == rhs.width_sq_ and
+         lhs.mode_ == rhs.mode_;
+}
+bool operator!=(const PureSphericalHarmonic& lhs,
+                const PureSphericalHarmonic& rhs) noexcept {
+  return not(lhs == rhs);
+}
+}  // namespace CurvedScalarWave::AnalyticData

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/PureSphericalHarmonic.hpp
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/PureSphericalHarmonic.hpp
@@ -1,0 +1,100 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <limits>
+#include <pup.h>
+#include <utility>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace CurvedScalarWave::AnalyticData {
+
+/*!
+ * \brief Analytic initial data for a pure spherical harmonic in three
+ * dimensions.
+ *
+ * \details The initial data is taken from \cite Scheel2003vs , Eqs. 4.1--4.3,
+ * and sets the evolved variables of the scalar wave as follows:
+ *
+ * \f{align}
+ * \Psi &= 0 \\
+ * \Phi_i &= 0 \\
+ * \Pi &= \Pi_0(r, \theta, \phi) =  e^{- (r - r_0)^2 / w^2} Y_{lm}(\theta,
+ * \phi), \f}
+ *
+ * where \f$r_0\f$ is the radius of the profile and \f$w\f$ is its width. This
+ * describes a pure spherical harmonic mode \f$Y_{lm}(\theta, \phi)\f$ truncated
+ * by a circular Gaussian window function.
+ *
+ * When evolved, the scalar field \f$\Phi\f$ will briefly build up around the
+ * radius \f$r_0\f$ and then disperse. This can be used to study the ringdown
+ * behavior and late-time tails in different background spacetimes.
+ */
+
+class PureSphericalHarmonic : public MarkAsAnalyticData {
+ public:
+  struct Radius {
+    using type = double;
+    static constexpr Options::String help = {
+        "The radius of the spherical harmonic profile"};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+
+  struct Width {
+    using type = double;
+    static constexpr Options::String help = {
+        "The width of the spherical harmonic profile."};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+
+  struct Mode {
+    using type = std::pair<size_t, int>;
+    static constexpr Options::String help = {
+        "The l-mode and m-mode of the spherical harmonic Ylm"};
+  };
+
+  using options = tmpl::list<Radius, Width, Mode>;
+
+  static constexpr Options::String help = {
+      "Initial data for a pure spherical harmonic mode truncated by a circular "
+      "Gaussian window funtion. The expression is taken from Scheel(2003), "
+      "equations 4.1-4.3."};
+
+  PureSphericalHarmonic() = default;
+
+  PureSphericalHarmonic(double radius, double width,
+                        std::pair<size_t, int> mode,
+                        const Options::Context& context = {});
+
+  /// Retrieve the evolution variables at spatial coordinates `x`
+  tuples::TaggedTuple<CurvedScalarWave::Pi, CurvedScalarWave::Phi<3>,
+                      CurvedScalarWave::Psi>
+  variables(const tnsr::I<DataVector, 3>& x, double /*t*/,
+            tmpl::list<CurvedScalarWave::Pi, CurvedScalarWave::Phi<3>,
+                       CurvedScalarWave::Psi> /*meta*/) const noexcept;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept;
+
+ private:
+  double radius_{std::numeric_limits<double>::signaling_NaN()};
+  double width_sq_{std::numeric_limits<double>::signaling_NaN()};
+  std::pair<size_t, int> mode_{std::numeric_limits<size_t>::signaling_NaN(),
+                               std::numeric_limits<int>::signaling_NaN()};
+
+  friend bool operator==(const PureSphericalHarmonic& lhs,
+                         const PureSphericalHarmonic& rhs) noexcept;
+
+  friend bool operator!=(const PureSphericalHarmonic& lhs,
+                         const PureSphericalHarmonic& rhs) noexcept;
+};
+
+}  // namespace CurvedScalarWave::AnalyticData

--- a/tests/Unit/PointwiseFunctions/AnalyticData/CurvedWaveEquation/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/CurvedWaveEquation/CMakeLists.txt
@@ -5,6 +5,7 @@
 set(LIBRARY "Test_CurvedWaveEquationAnalyticData")
 
 set(LIBRARY_SOURCES
+  Test_PureSphericalHarmonic.cpp
   Test_ScalarWaveGr.cpp
   )
 

--- a/tests/Unit/PointwiseFunctions/AnalyticData/CurvedWaveEquation/PureSphericalHarmonic.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/CurvedWaveEquation/PureSphericalHarmonic.py
@@ -1,0 +1,14 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+from scipy.special import sph_harm
+
+
+def pi(x, radius, width, l, m):
+    radial = np.exp(-(np.linalg.norm(x) - radius)**2 / width**2)
+    # note opposite theta, phi convention for Spectre and scipy
+    phi = np.arctan2(np.sqrt(x[0]**2 + x[1]**2), x[2])
+    theta = np.arctan2(x[1], x[0])
+    angular = sph_harm(m, l, theta, phi)
+    return radial * np.real(angular)

--- a/tests/Unit/PointwiseFunctions/AnalyticData/CurvedWaveEquation/Test_PureSphericalHarmonic.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/CurvedWaveEquation/Test_PureSphericalHarmonic.cpp
@@ -1,0 +1,101 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Framework/Pypp.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "PointwiseFunctions/AnalyticData/CurvedWaveEquation/PureSphericalHarmonic.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+void test_create_from_options() {
+  INFO("Testing option creation");
+  const auto option_parsed = TestHelpers::test_creation<
+      CurvedScalarWave::AnalyticData::PureSphericalHarmonic>(
+      "Radius: 0.8 \n"
+      "Width: 2. \n"
+      "Mode: [10, 8]");
+  const CurvedScalarWave::AnalyticData::PureSphericalHarmonic constructed{
+      0.8, 2., {10, 8}};
+  CHECK(option_parsed == constructed);
+  CHECK_FALSE(option_parsed != constructed);
+
+  INFO("Testing serialization");
+  test_serialization(constructed);
+}
+
+// `check_with_random_values` does not allow us to forward the l and m arguments
+// of type size_t / int to python, so we generate the random numbers and call
+// the python function manually here
+void test_variables() {
+  INFO("Testing random values against python function");
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<double> x_dist{1., 10.};
+  std::uniform_real_distribution<double> radius_dist{1., 10.};
+  std::uniform_real_distribution<double> width_dist{2., 20.};
+  // size of the DataVector we are testing with
+  const size_t dv_size = 10;
+  for (size_t l = 0; l < 8; l++) {
+    for (int m = -l; m <= static_cast<int>(l); ++m) {
+      const auto x = make_with_random_values<tnsr::I<DataVector, 3>>(
+          make_not_null(&gen), make_not_null(&x_dist), DataVector(dv_size));
+      const double radius = radius_dist(gen);
+      const double width = width_dist(gen);
+      const auto py_res = pypp::call<Scalar<DataVector>>(
+          "PureSphericalHarmonic", "pi", x, radius, width, l, m);
+
+      const CurvedScalarWave::AnalyticData::PureSphericalHarmonic sh{
+          radius, width, {l, m}};
+      const auto sh_res = sh.variables(x, 0., {});
+
+      CHECK_ITERABLE_APPROX(get<CurvedScalarWave::Pi>(sh_res), py_res);
+      CHECK(get<CurvedScalarWave::Phi<3>>(sh_res) ==
+            make_with_value<tnsr::i<DataVector, 3>>(dv_size, 0.));
+      CHECK(get<CurvedScalarWave::Psi>(sh_res) ==
+            make_with_value<Scalar<DataVector>>(dv_size, 0.));
+    }
+  }
+}
+
+void test_errors() {
+  INFO("Testing configuration errors");
+  CHECK_THROWS_WITH(CurvedScalarWave::AnalyticData::PureSphericalHarmonic(
+                        -0.1, 1., {1, 1}, Options::Context{false, {}, 1, 1}),
+                    Catch::Matchers::Contains(
+                        "The radius must be greater than 0 but is -0.1"));
+
+  CHECK_THROWS_WITH(CurvedScalarWave::AnalyticData::PureSphericalHarmonic(
+                        1., -0.1, {1, 1}, Options::Context{false, {}, 1, 1}),
+                    Catch::Matchers::Contains(
+                        "The width must be greater than 0 but is -0.1"));
+
+  CHECK_THROWS_WITH(
+      CurvedScalarWave::AnalyticData::PureSphericalHarmonic(
+          1., 1., {7, 8}, Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::Contains(
+          "The absolute value of the m_mode must be less than or equal to the "
+          "l-mode but the m-mode is 8 and the l-mode is 7"));
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticData.CurvedWaveEquation.SphericalHarmonic",
+    "[Unit][PointwiseFunctions]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/AnalyticData/CurvedWaveEquation"};
+  test_create_from_options();
+  test_variables();
+  test_errors();
+}

--- a/tests/Unit/PointwiseFunctions/AnalyticData/CurvedWaveEquation/__init__.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/CurvedWaveEquation/__init__.py
@@ -1,0 +1,2 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.


### PR DESCRIPTION
## Proposed changes

Adds the initial data from Scheel(2003), equation 4.1-4.3 for CurvedScalarWave. 

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
