### PR TITLE
Add option to apply Persson TCI to GRMHD TildeB

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.cpp
@@ -8,6 +8,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tags/TempTensor.hpp"
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Evolution/DgSubcell/PerssonTci.hpp"
@@ -137,6 +138,17 @@ bool TciOnDgGrid<RecoveryScheme>::apply(
                                           persson_tci_epsilon) or
       evolution::dg::subcell::persson_tci(tilde_tau, dg_mesh, persson_exponent,
                                           persson_tci_epsilon)) {
+    return true;
+  }
+  // Check Cartesian magnitude of magnetic field satisfies the Persson TCI
+  const Scalar<DataVector> tilde_b_magnitude =
+      tci_options.magnetic_field_cutoff.has_value() ? magnitude(tilde_b)
+                                                    : Scalar<DataVector>{};
+  if (tci_options.magnetic_field_cutoff.has_value() and
+      max(get(tilde_b_magnitude)) >
+          tci_options.magnetic_field_cutoff.value() and
+      evolution::dg::subcell::persson_tci(
+          tilde_b_magnitude, dg_mesh, persson_exponent, persson_tci_epsilon)) {
     return true;
   }
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.cpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/DgSubcell/PerssonTci.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
@@ -13,16 +14,27 @@
 namespace grmhd::ValenciaDivClean::subcell {
 bool TciOnFdGrid::apply(const Scalar<DataVector>& tilde_d,
                         const Scalar<DataVector>& tilde_tau,
+                        const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
                         const bool vars_needed_fixing, const Mesh<3>& dg_mesh,
                         const TciOptions& tci_options,
                         const double persson_exponent) noexcept {
-  return vars_needed_fixing or
-         min(get(tilde_d)) <
-             tci_options.minimum_rest_mass_density_times_lorentz_factor or
-         min(get(tilde_tau)) < tci_options.minimum_tilde_tau or
-         evolution::dg::subcell::persson_tci(tilde_d, dg_mesh, persson_exponent,
-                                             1.0e-18) or
-         evolution::dg::subcell::persson_tci(tilde_tau, dg_mesh,
-                                             persson_exponent, 1.0e-18);
+  bool cell_is_troubled =
+      vars_needed_fixing or
+      min(get(tilde_d)) <
+          tci_options.minimum_rest_mass_density_times_lorentz_factor or
+      min(get(tilde_tau)) < tci_options.minimum_tilde_tau or
+      evolution::dg::subcell::persson_tci(tilde_d, dg_mesh, persson_exponent,
+                                          1.0e-18) or
+      evolution::dg::subcell::persson_tci(tilde_tau, dg_mesh, persson_exponent,
+                                          1.0e-18);
+  if (tci_options.magnetic_field_cutoff.has_value() and not cell_is_troubled) {
+    const Scalar<DataVector> tilde_b_magnitude = magnitude(tilde_b);
+    cell_is_troubled =
+        (max(get(tilde_b_magnitude)) >
+             tci_options.magnetic_field_cutoff.value() and
+         evolution::dg::subcell::persson_tci(tilde_b_magnitude, dg_mesh,
+                                             persson_exponent, 1.0e-18));
+  }
+  return cell_is_troubled;
 }
 }  // namespace grmhd::ValenciaDivClean::subcell

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.hpp
@@ -43,10 +43,13 @@ struct TciOnFdGrid {
                      grmhd::ValenciaDivClean::Tags::TildeD>,
                  evolution::dg::subcell::Tags::Inactive<
                      grmhd::ValenciaDivClean::Tags::TildeTau>,
+                 evolution::dg::subcell::Tags::Inactive<
+                     grmhd::ValenciaDivClean::Tags::TildeB<>>,
                  grmhd::ValenciaDivClean::Tags::VariablesNeededFixing,
                  domain::Tags::Mesh<3>, Tags::TciOptions>;
   static bool apply(const Scalar<DataVector>& tilde_d,
                     const Scalar<DataVector>& tilde_tau,
+                    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
                     bool vars_needed_fixing, const Mesh<3>& dg_mesh,
                     const TciOptions& tci_options,
                     double persson_exponent) noexcept;

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOptions.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOptions.cpp
@@ -5,11 +5,14 @@
 
 #include <pup.h>
 
+#include "Parallel/PupStlCpp17.hpp"
+
 namespace grmhd::ValenciaDivClean::subcell {
 void TciOptions::pup(PUP::er& p) noexcept {
   p | minimum_rest_mass_density_times_lorentz_factor;
   p | minimum_tilde_tau;
   p | atmosphere_density;
   p | safety_factor_for_magnetic_field;
+  p | magnetic_field_cutoff;
 }
 }  // namespace grmhd::ValenciaDivClean::subcell

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnDgGrid.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnDgGrid.cpp
@@ -36,6 +36,7 @@ enum class TestThis {
   PrimRecoveryFailed,
   PerssonTildeD,
   PerssonTildeTau,
+  PerssonTildeB,
   NegativeTildeDSubcell,
   NegativeTildeTauSubcell,
   NegativeTildeTau
@@ -86,7 +87,9 @@ void test(const TestThis test_this) {
                                                    1.0};
 
   const grmhd::ValenciaDivClean::subcell::TciOptions tci_options{
-      1.0e-20, 1.0e-40, 1.1e-12, 1.0e-12};
+      1.0e-20, 1.0e-40, 1.1e-12, 1.0e-12,
+      test_this == TestThis::PerssonTildeB ? std::optional<double>{1.0e-2}
+                                           : std::nullopt};
 
   auto box = db::create<db::AddSimpleTags<
       evolution::dg::subcell::Tags::Inactive<
@@ -167,6 +170,13 @@ void test(const TestThis test_this) {
         make_not_null(&box), [point_to_change](const auto tilde_d_ptr) {
           get(*tilde_d_ptr)[point_to_change] *= 2.0;
         });
+  } else if (test_this == TestThis::PerssonTildeB) {
+    db::mutate<grmhd::ValenciaDivClean::Tags::TildeB<>>(
+        make_not_null(&box), [point_to_change](const auto tilde_b_ptr) {
+          for (size_t i = 0; i < 3; ++i) {
+            tilde_b_ptr->get(i)[point_to_change] = 6.0;
+          }
+        });
   } else if (test_this == TestThis::NegativeTildeDSubcell) {
     db::mutate<evolution::dg::subcell::Tags::Inactive<
         grmhd::ValenciaDivClean::Tags::TildeD>>(
@@ -211,8 +221,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ValenciaDivClean.Subcell.TciOnDgGrid",
        {TestThis::AllGood, TestThis::SmallTildeD, TestThis::InAtmosphere,
         TestThis::TildeB2TooBig, TestThis::PrimRecoveryFailed,
         TestThis::PerssonTildeD, TestThis::PerssonTildeTau,
-        TestThis::NegativeTildeDSubcell, TestThis::NegativeTildeTauSubcell,
-        TestThis::NegativeTildeTau}) {
+        TestThis::PerssonTildeB, TestThis::NegativeTildeDSubcell,
+        TestThis::NegativeTildeTauSubcell, TestThis::NegativeTildeTau}) {
     test(test_this);
   }
 }

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOptions.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOptions.cpp
@@ -14,10 +14,12 @@ SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.Subcell.TciOptions",
       "MinimumValueOfD: 1.0e-18\n"
       "MinimumValueOfTildeTau: 1.0e-38\n"
       "AtmosphereDensity: 1.1e-12\n"
-      "SafetyFactorForB: 1.0e-12\n");
+      "SafetyFactorForB: 1.0e-12\n"
+      "MagneticFieldCutoff: 0.01\n");
   const auto tci_options = serialize_and_deserialize(tci_options_from_opts);
   CHECK(tci_options.minimum_rest_mass_density_times_lorentz_factor == 1.0e-18);
   CHECK(tci_options.minimum_tilde_tau == 1.0e-38);
   CHECK(tci_options.atmosphere_density == 1.1e-12);
   CHECK(tci_options.safety_factor_for_magnetic_field == 1.0e-12);
+  CHECK(tci_options.magnetic_field_cutoff.value() == 0.01);
 }


### PR DESCRIPTION
## Proposed changes

So far this has only been necessary for cases where the magnetic field has a
discontinuity but the fluid variables are smooth. Specifically, the magnetic
loop advection problem. Magnetized TOV stars seem to do okay without this, but a
careful comparison on whether the Persson TCI should be applied to TildeB in
the magnetized neutron star case should be done.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
