### PR TITLE
Make timescale tuner serializable and constructible from options. 

### DIFF
--- a/src/ControlSystem/TimescaleTuner.cpp
+++ b/src/ControlSystem/TimescaleTuner.cpp
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <functional>
 #include <ostream>
+#include <pup.h>
 
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
@@ -108,4 +109,30 @@ void TimescaleTuner::update_timescale(
     // maximum(minimum) value.
     timescale_[i] = std::clamp(timescale_[i], min_timescale_, max_timescale_);
   }
+}
+
+void TimescaleTuner::pup(PUP::er&p) {
+    p | timescale_;
+    p | max_timescale_;
+    p | min_timescale_;
+    p | decrease_timescale_threshold_;
+    p | increase_timescale_threshold_;
+    p | increase_factor_;
+    p | decrease_factor_;
+}
+
+bool operator==(const TimescaleTuner& lhs, const TimescaleTuner& rhs) {
+  return (lhs.timescale_ == rhs.timescale_) and
+         (lhs.max_timescale_ == rhs.max_timescale_) and
+         (lhs.min_timescale_ == rhs.min_timescale_) and
+         (lhs.decrease_timescale_threshold_ ==
+          rhs.decrease_timescale_threshold_) and
+         (lhs.increase_timescale_threshold_ ==
+          rhs.increase_timescale_threshold_) and
+         (lhs.increase_factor_ == rhs.increase_factor_) and
+         (lhs.decrease_factor_ == rhs.decrease_factor_);
+}
+
+bool operator!=(const TimescaleTuner& lhs, const TimescaleTuner& rhs){
+  return not(lhs == rhs);
 }

--- a/src/ControlSystem/TimescaleTuner.cpp
+++ b/src/ControlSystem/TimescaleTuner.cpp
@@ -15,20 +15,25 @@
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 
-TimescaleTuner::TimescaleTuner(DataVector initial_timescale,
+TimescaleTuner::TimescaleTuner(const std::vector<double>& initial_timescale,
                                const double max_timescale,
                                const double min_timescale,
                                const double decrease_timescale_threshold,
                                const double increase_timescale_threshold,
                                const double increase_factor,
                                const double decrease_factor) noexcept
-    : timescale_{std::move(initial_timescale)},
-      max_timescale_{max_timescale},
+    : max_timescale_{max_timescale},
       min_timescale_{min_timescale},
       decrease_timescale_threshold_{decrease_timescale_threshold},
       increase_timescale_threshold_{increase_timescale_threshold},
       increase_factor_{increase_factor},
       decrease_factor_{decrease_factor} {
+  DataVector dv(initial_timescale.size());
+  for (size_t i = 0; i < dv.size(); ++i) {
+    dv[i] = initial_timescale[i];
+  }
+  timescale_ = std::move(dv);
+
   for (const auto& t_scale : timescale_) {
     if (t_scale <= 0.0) {
       ERROR("Initial timescale must be > 0");

--- a/src/ControlSystem/TimescaleTuner.hpp
+++ b/src/ControlSystem/TimescaleTuner.hpp
@@ -7,6 +7,12 @@
 
 #include "DataStructures/DataVector.hpp"
 
+/// \cond
+namespace PUP {
+class er;
+}
+/// \endcond
+
 /*!
  * \ingroup ControlSystemGroup
  * \brief Manages control system timescales
@@ -44,6 +50,7 @@ class TimescaleTuner {
                  double increase_timescale_threshold, double increase_factor,
                  double decrease_factor) noexcept;
 
+  TimescaleTuner() = default;
   TimescaleTuner(TimescaleTuner&&) noexcept = default;
   TimescaleTuner& operator=(TimescaleTuner&&) noexcept = default;
   TimescaleTuner(const TimescaleTuner&) = delete;
@@ -60,6 +67,9 @@ class TimescaleTuner {
   /// the control system errors
   void update_timescale(const std::array<DataVector, 2>& q_and_dtq) noexcept;
 
+  void pup(PUP::er& p);
+
+  friend bool operator==(const TimescaleTuner& lhs, const TimescaleTuner& rhs);
  private:
   DataVector timescale_;
   double max_timescale_;
@@ -69,3 +79,5 @@ class TimescaleTuner {
   double increase_factor_;
   double decrease_factor_;
 };
+
+bool operator!=(const TimescaleTuner& lhs, const TimescaleTuner& rhs);

--- a/src/ControlSystem/TimescaleTuner.hpp
+++ b/src/ControlSystem/TimescaleTuner.hpp
@@ -51,7 +51,7 @@ class TimescaleTuner {
   ~TimescaleTuner() = default;
 
   /// returns the current timescale for each component of a FunctionOfTime
-  const DataVector& current_timescale() noexcept { return timescale_; }
+  const DataVector& current_timescale() const noexcept { return timescale_; }
   /// manually sets all timescales to a specified value, unless the value is
   /// outside of the specified minimum and maximum timescale bounds, in which
   /// case it is set to the nearest bounded value

--- a/src/ControlSystem/TimescaleTuner.hpp
+++ b/src/ControlSystem/TimescaleTuner.hpp
@@ -6,6 +6,7 @@
 #include <array>
 
 #include "DataStructures/DataVector.hpp"
+#include "Options/Options.hpp"
 
 /// \cond
 namespace PUP {
@@ -45,8 +46,51 @@ class er;
 
 class TimescaleTuner {
  public:
-  TimescaleTuner(DataVector initial_timescale, double max_timescale,
-                 double min_timescale, double decrease_timescale_threshold,
+  static constexpr Options::String help{
+      "TimescaleTuner: stores and dynamically updates the timescales for each "
+      "component of a particular control system."};
+  struct InitialTimescales {
+    using type = std::vector<double>;
+    static constexpr Options::String help = {
+        "Initial timescales for each function of time"};
+  };
+
+  struct MinTimescale {
+    using type = double;
+    static constexpr Options::String help = {"Minimum timescale"};
+  };
+
+  struct MaxTimescale {
+    using type = double;
+    static constexpr Options::String help = {"Maximum timescale"};
+  };
+
+  struct DecreaseThreshold {
+    using type = double;
+    static constexpr Options::String help = {
+        "Threshold for decrease of timescale"};
+  };
+  struct IncreaseThreshold {
+    using type = double;
+    static constexpr Options::String help = {
+        "Threshold for increase of timescale"};
+  };
+  struct IncreaseFactor {
+    using type = double;
+    static constexpr Options::String help = {"Factor to increase timescale"};
+  };
+  struct DecreaseFactor {
+    using type = double;
+    static constexpr Options::String help = {"Factor to decrease timescale"};
+  };
+
+  using options = tmpl::list<InitialTimescales, MaxTimescale, MinTimescale,
+                             DecreaseThreshold, IncreaseThreshold,
+                             IncreaseFactor, DecreaseFactor>;
+
+  TimescaleTuner(const std::vector<double>& initial_timescale,
+                 double max_timescale, double min_timescale,
+                 double decrease_timescale_threshold,
                  double increase_timescale_threshold, double increase_factor,
                  double decrease_factor) noexcept;
 
@@ -70,6 +114,7 @@ class TimescaleTuner {
   void pup(PUP::er& p);
 
   friend bool operator==(const TimescaleTuner& lhs, const TimescaleTuner& rhs);
+
  private:
   DataVector timescale_;
   double max_timescale_;

--- a/tests/Unit/ControlSystem/Test_TimescaleTuner.cpp
+++ b/tests/Unit/ControlSystem/Test_TimescaleTuner.cpp
@@ -7,6 +7,7 @@
 
 #include "ControlSystem/TimescaleTuner.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/MakeWithValue.hpp"
@@ -281,6 +282,28 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.NoChangeToTimescale",
   run_tests(-1.0);  // test negative Q
 }
 
+SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.CreateFromOptions",
+                  "[ControlSystem][Unit]") {
+  const double decrease_timescale_threshold = 1.0e-2;
+  const double increase_timescale_threshold = 1.0e-4;
+  const double increase_factor = 1.01;
+  const double decrease_factor = 0.99;
+  const double max_timescale = 10.0;
+  const double min_timescale = 1.0e-3;
+
+  const auto tst = TestHelpers::test_creation<TimescaleTuner>(
+      "InitialTimescales: [1.]\n"
+      "MinTimescale: 1e-3\n"
+      "MaxTimescale: 10.\n"
+      "DecreaseThreshold: 1e-2\n"
+      "IncreaseThreshold: 1e-4\n"
+      "IncreaseFactor: 1.01\n"
+      "DecreaseFactor: 0.99\n");
+  CHECK(tst == TimescaleTuner({1.}, max_timescale, min_timescale,
+                              decrease_timescale_threshold,
+                              increase_timescale_threshold, increase_factor,
+                              decrease_factor));
+}
 
 SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.EqualityAndSerialization",
                   "[ControlSystem][Unit]") {
@@ -315,7 +338,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.BadInitTimescale",
   const double max_timescale = 10.0;
   const double min_timescale = 1.0e-3;
 
-  const DataVector init_timescale{0.0};
+  const std::vector<double> init_timescale{0.0};
   TimescaleTuner tst(init_timescale, max_timescale, min_timescale,
                      decrease_timescale_threshold, increase_timescale_threshold,
                      increase_factor, decrease_factor);
@@ -452,7 +475,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.BadDecreaseThreshold",
   const double max_timescale = 10.0;
   const double min_timescale = 1.0e-3;
 
-  const DataVector init_timescale{{1.0, 2.0}};
+  const std::vector<double> init_timescale{{1.0, 2.0}};
   TimescaleTuner tst(init_timescale, max_timescale, min_timescale,
                      decrease_timescale_threshold, increase_timescale_threshold,
                      increase_factor, decrease_factor);

--- a/tests/Unit/ControlSystem/Test_TimescaleTuner.cpp
+++ b/tests/Unit/ControlSystem/Test_TimescaleTuner.cpp
@@ -7,6 +7,7 @@
 
 #include "ControlSystem/TimescaleTuner.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "Framework/TestHelpers.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
@@ -278,6 +279,29 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.NoChangeToTimescale",
   };
   run_tests(1.0);   // test positive Q
   run_tests(-1.0);  // test negative Q
+}
+
+
+SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.EqualityAndSerialization",
+                  "[ControlSystem][Unit]") {
+  const double decrease_timescale_threshold = 1.0e-2;
+  const double increase_timescale_threshold = 1.0e-4;
+  const double increase_factor = 1.01;
+  const double decrease_factor = 0.99;
+  const double max_timescale = 10.0;
+  const double min_timescale = 1.0e-3;
+
+  TimescaleTuner tst1(
+      {0.3}, max_timescale, min_timescale, decrease_timescale_threshold,
+      increase_timescale_threshold, increase_factor, decrease_factor);
+
+  TimescaleTuner tst2(
+      {0.4}, max_timescale, min_timescale, decrease_timescale_threshold,
+      increase_timescale_threshold, increase_factor, decrease_factor);
+
+  CHECK(tst1 == tst1);
+  CHECK(tst1 != tst2);
+  CHECK(serialize_and_deserialize(tst1) == tst1);
 }
 
 // [[OutputRegex, Initial timescale must be > 0]]

--- a/tests/Unit/ControlSystem/Test_TimescaleTuner.cpp
+++ b/tests/Unit/ControlSystem/Test_TimescaleTuner.cpp
@@ -12,8 +12,7 @@
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.IncreaseOrDecrease",
-                  "[ControlSystem][Unit]") {
+void test_increase_or_decrease() {
   const double decrease_timescale_threshold = 1.0e-2;
   const double increase_timescale_threshold = 1.0e-4;
   const double increase_factor = 1.01;
@@ -171,8 +170,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.IncreaseOrDecrease",
   run_tests(-1.0);
 }
 
-SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.NoChangeToTimescale",
-                  "[ControlSystem][Unit]") {
+void test_no_change_to_timescale() {
   const double decrease_timescale_threshold = 1.0e-2;
   const double increase_timescale_threshold = 1.0e-4;
   const double increase_factor = 1.01;
@@ -198,7 +196,6 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.NoChangeToTimescale",
   const double less_than_one = 0.9;
 
   auto run_tests = [&](double sign_of_q) {
-
     // (1) |Q| > decrease_timescale_threshold
     //     |\dot{Q}| <= decrease_timescale_threshold/timescale
     DataVector q{sign_of_q * greater_than_one * decrease_timescale_threshold};
@@ -282,8 +279,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.NoChangeToTimescale",
   run_tests(-1.0);  // test negative Q
 }
 
-SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.CreateFromOptions",
-                  "[ControlSystem][Unit]") {
+void test_create_from_options() {
   const double decrease_timescale_threshold = 1.0e-2;
   const double increase_timescale_threshold = 1.0e-4;
   const double increase_factor = 1.01;
@@ -305,8 +301,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.CreateFromOptions",
                               decrease_factor));
 }
 
-SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.EqualityAndSerialization",
-                  "[ControlSystem][Unit]") {
+void test_equality_and_serialization() {
   const double decrease_timescale_threshold = 1.0e-2;
   const double increase_timescale_threshold = 1.0e-4;
   const double increase_factor = 1.01;
@@ -484,4 +479,12 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.BadDecreaseThreshold",
   tst.update_timescale(qs);
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
+}
+
+SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner",
+                  "[ControlSystem][Unit]") {
+  test_increase_or_decrease();
+  test_no_change_to_timescale();
+  test_create_from_options();
+  test_equality_and_serialization();
 }


### PR DESCRIPTION
## Proposed changes

To construct the timescale tuner from options, I changed the constructor to take a `std::vector<double>` rather than a DataVector. Since this will probably only be constructed from options it seemed like the right thing to do. 

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
