### PR TITLE
Switch GRMHD executable to support DG-subcell

### DIFF
--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -113,6 +113,7 @@
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
 #include "ParallelAlgorithms/Events/Factory.hpp"
+#include "ParallelAlgorithms/Events/ObserveNorms.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp"  // IWYU pragma: keep
 #include "ParallelAlgorithms/EventsAndTriggers/Completion.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
@@ -234,6 +235,8 @@ struct EvolutionMetavars {
             Event,
             tmpl::flatten<tmpl::list<
                 Events::Completion,
+                Events::ObserveNorms<
+                    tmpl::list<hydro::Tags::RestMassDensity<DataVector>>>,
                 tmpl::conditional_t<
                     UseDgSubcell,
                     evolution::dg::subcell::Events::ObserveFields<

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -182,6 +182,7 @@ struct EvolutionMetavars {
       tmpl::conditional_t<local_time_stepping, LtsTimeStepper, TimeStepper>>;
 
   using ordered_list_of_primitive_recovery_schemes = tmpl::list<
+      grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl,
       grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin,
       grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::PalenzuelaEtAl>;
 

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -262,6 +262,8 @@ struct EvolutionMetavars {
   static std::string phase_name(Phase phase) noexcept {
     if (phase == Phase::LoadBalancing) {
       return "LoadBalancing";
+    } else if (phase == Phase::WriteCheckpoint) {
+      return "WriteCheckpoint";
     }
     ERROR(
         "Passed phase that should not be used in input file. Integer "
@@ -272,6 +274,8 @@ struct EvolutionMetavars {
   using phase_changes =
       tmpl::list<PhaseControl::Registrars::VisitAndReturn<EvolutionMetavars,
                                                           Phase::LoadBalancing>,
+                 PhaseControl::Registrars::VisitAndReturn<
+                     EvolutionMetavars, Phase::WriteCheckpoint>,
                  PhaseControl::Registrars::CheckpointAndExitAfterWallclock<
                      EvolutionMetavars>>;
 

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -33,6 +33,24 @@ SpatialDiscretization:
   DiscontinuousGalerkin:
     Formulation: StrongInertial
     Quadrature: GaussLobatto
+    Subcell:
+      RdmpDelta0: 1.0e-7
+      RdmpEpsilon: 1.0e-3
+      PerssonExponent: 4.0
+      InitialData:
+        RdmpDelta0: 1.0e-7
+        RdmpEpsilon: 1.0e-3
+        PerssonExponent: 4.0
+      AlwaysUseSubcells: false
+    TciOptions:
+      MinimumValueOfD: 1.0e-20
+      MinimumValueOfTildeTau: 1.0e-50
+      MagneticFieldCutoff: DoNotCheckMagneticField
+      AtmosphereDensity: 1.01e-15
+      SafetyFactorForB: 1.0e-12
+  SubcellSolver:
+    Reconstructor:
+      MonotisedCentralPrim:
 
 AnalyticData:
   BlastWave:
@@ -48,15 +66,7 @@ AnalyticData:
 
 EvolutionSystem:
   ValenciaDivClean:
-    DampingParameter: 0.0
-
-Limiter:
-  Minmod:
-    Type: Muscl
-    # The optimal value of the TVB constant is problem-dependent.
-    # This test uses 0 to favor robustness over accuracy.
-    TvbConstant: 0.0
-    DisableForDebugging: false
+    DampingParameter: 1.0
 
 VariableFixing:
   FixConservatives:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -45,6 +45,24 @@ SpatialDiscretization:
   DiscontinuousGalerkin:
     Formulation: StrongInertial
     Quadrature: GaussLobatto
+    Subcell:
+      RdmpDelta0: 1.0e-7
+      RdmpEpsilon: 1.0e-3
+      PerssonExponent: 4.0
+      InitialData:
+        RdmpDelta0: 1.0e-7
+        RdmpEpsilon: 1.0e-3
+        PerssonExponent: 4.0
+      AlwaysUseSubcells: false
+    TciOptions:
+      MinimumValueOfD: 1.0e-20
+      MinimumValueOfTildeTau: 1.0e-50
+      MagneticFieldCutoff: DoNotCheckMagneticField
+      AtmosphereDensity: 1.01e-15
+      SafetyFactorForB: 1.0e-12
+  SubcellSolver:
+    Reconstructor:
+      MonotisedCentralPrim:
 
 AnalyticSolution:
   FishboneMoncriefDisk:
@@ -57,15 +75,7 @@ AnalyticSolution:
 
 EvolutionSystem:
   ValenciaDivClean:
-    DampingParameter: 0.0
-
-Limiter:
-  Minmod:
-    Type: LambdaPiN
-    # The optimal value of the TVB constant is problem-dependent.
-    # This test uses 0 to favor robustness over accuracy.
-    TvbConstant: 0.0
-    DisableForDebugging: false
+    DampingParameter: 1.0
 
 VariableFixing:
   FixConservatives:


### PR DESCRIPTION
## Proposed changes

Switches the GRMHD executable to being able to use DG subcell.
- There's a `bool` that can be used to switch back to the "classic" limiters
- I've removed dense triggers but only because I haven't tested it. They should work fine, though.
- This is the last code needed to do magnetized TOV star evolutions with the develop branch.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
