### PR TITLE
Fix random roundoff cylindrical map errors

### DIFF
--- a/src/Domain/CoordinateMaps/CylindricalFlatSide.cpp
+++ b/src/Domain/CoordinateMaps/CylindricalFlatSide.cpp
@@ -47,27 +47,27 @@ CylindricalFlatSide::CylindricalFlatSide(
   const double dist_proj = sqrt(square(center_two[0] - proj_center[0]) +
                                 square(center_two[1] - proj_center[1]) +
                                 square(center_two[2] - proj_center[2]));
-  ASSERT(dist_proj < 0.95 * radius_two,
+  ASSERT(dist_proj < 0.85 * radius_two,
          "CylindricalFlatSide: The map has been tested only for the case when "
          "proj_center is contained inside the sphere and not too close to the "
          "surface of the sphere");
   const double dist_xy_annulus = sqrt(square(center_two[0] - center_one[0]) +
                                       square(center_two[1] - center_one[1]));
-  ASSERT(dist_xy_annulus < radius_two,
+  ASSERT(dist_xy_annulus < 0.9 * radius_two,
          "CylindricalFlatSide: The map has been tested only for the case when "
-         "the center of the annulus is contained in the projection of the "
-         "sphere onto the z-axis");
+         "the center of the annulus is contained in a circle that is 90% of "
+         "the size of the projection of the sphere onto the z-axis");
   const double dist_annulus_proj = sqrt(square(center_one[0] - proj_center[0]) +
                                         square(center_one[1] - proj_center[1]) +
                                         square(center_one[2] - proj_center[2]));
-  ASSERT(outer_radius > 0.05 * dist_annulus_proj,
+  ASSERT(outer_radius > 0.1 * dist_annulus_proj,
          "CylindricalFlatSide: The map has been tested only for the case when "
          "the annulus is not too small");
-  ASSERT(inner_radius < 0.95 * outer_radius,
+  ASSERT(inner_radius < 0.9 * outer_radius,
          "CylindricalFlatSide: The map has been tested only for the case when "
          "the annulus is not too thin");
   const double min_inner_radius_fac =
-      std::max(0.05, dist_annulus_proj * 0.01 / outer_radius);
+      std::max(0.1, dist_annulus_proj * 0.03 / outer_radius);
   ASSERT(inner_radius > min_inner_radius_fac * outer_radius,
          "CylindricalFlatSide: The map has been tested only for the case when "
          "the inner radius is not too small");

--- a/src/Domain/CoordinateMaps/CylindricalFlatSide.hpp
+++ b/src/Domain/CoordinateMaps/CylindricalFlatSide.hpp
@@ -69,7 +69,7 @@ namespace domain::CoordinateMaps {
  *   percent of the sphere radius) than the plane containing the
  *   annulus.
  * - The projection point \f$z_\mathrm{P}\f$ is
- *   inside the sphere and more than 5 percent away from the boundary
+ *   inside the sphere and more than 15 percent away from the boundary
  *   of the sphere.
  * - The center of the annulus is contained in the circle that results from
  *   projecting the sphere into the \f$xy\f$ plane.

--- a/src/Domain/CoordinateMaps/CylindricalSide.cpp
+++ b/src/Domain/CoordinateMaps/CylindricalSide.cpp
@@ -54,8 +54,8 @@ CylindricalSide::CylindricalSide(const std::array<double, 3>& center_one,
   //    avoid such cases.
   // b) We do not want to waste effort testing the map for parameters
   //    that we don't expect to be used.  For example, we demand
-  //    here that proj_center and sphere_one are contained within
-  //    sphere_two, but the map should still be valid for some choices
+  //    here that sphere_one is contained within sphere_two, or vice versa,
+  //    but the map should still be valid for some choices
   //    of parameters where sphere_one and sphere_two are disjoint;
   //    allowing those parameter choices would involve much more
   //    complicated logic to determine whether the map produces shapes
@@ -73,38 +73,124 @@ CylindricalSide::CylindricalSide(const std::array<double, 3>& center_one,
   const double dist_proj_one = sqrt(square(center_one[0] - proj_center[0]) +
                                     square(center_one[1] - proj_center[1]) +
                                     square(center_one[2] - proj_center[2]));
-  ASSERT(dist_proj_one < radius_one,
-         "CylindricalSide: The map has been tested only for the case when "
-         "proj_center is contained inside sphere_one");
-
   const double dist_proj_two = sqrt(square(center_two[0] - proj_center[0]) +
                                     square(center_two[1] - proj_center[1]) +
                                     square(center_two[2] - proj_center[2]));
-  ASSERT(dist_proj_two < radius_two,
+
+  ASSERT(dist_proj_one < radius_one,
          "CylindricalSide: The map has been tested only for the case when "
-         "proj_center is contained inside sphere_two. dist_proj_two="
-         << dist_proj_two << ", radius_two=" << radius_two);
+         "proj_center is contained inside sphere_one");
 
   ASSERT(proj_center[2] >= z_lower and proj_center[2] <= z_upper,
          "CylindricalSide: The map has been tested only for the case when "
          "proj_center is contained inside z_lower and z_upper: "
              << z_lower << " " << proj_center[2] << " " << z_upper);
 
-  ASSERT(center_one[2] - z_lower <= 0.92 * radius_one and
-             z_upper - center_one[2] <= 0.92 * radius_one,
-         "CylindricalSide: The map has been tested only when z_lower and "
-         "z_upper are sufficently far from the edge of sphere_one");
+  // We have three different usages for this map, and each usage
+  // is tested for slightly different ranges of parameters.
+  // - sphere_two is contained in sphere_one
+  // - sphere_one is contained in sphere_two, and projection_point is on/near
+  //   the center of one of the z planes.
+  // - sphere_one is contained in sphere_two, and projection_point is away
+  //   from the z planes.
 
-  ASSERT(center_one[2] - z_lower >= 0.01 * radius_one and
-             z_upper - center_one[2] >= 0.01 * radius_one,
-         "CylindricalSide: The map has been tested only when z_lower and "
-         "z_upper are sufficently far from the center of sphere_one");
-
-  if (dist_spheres + radius_two < radius_one) {
+  if (dist_spheres + radius_one < radius_two) {
+    // Sphere_one is contained in sphere_two
+    ASSERT(dist_proj_two < radius_two,
+           "CylindricalSide: The map has been tested only for the case when "
+           "proj_center is contained inside sphere_two. dist_proj_two="
+               << dist_proj_two << ", radius_two=" << radius_two);
+    ASSERT(center_one[2] - z_lower <= 0.9 * radius_one and
+               z_upper - center_one[2] <= 0.9 * radius_one,
+           "CylindricalSide: The map has been tested only when z_lower and "
+           "z_upper are sufficently far from the edge of sphere_one");
+    ASSERT(center_one[2] - z_lower >= 0.02 * radius_one and
+               z_upper - center_one[2] >= 0.02 * radius_one,
+           "CylindricalSide: The map has been tested only when z_lower and "
+           "z_upper are sufficently far from the center of sphere_one");
+    // rho_sphere_one is the radius of the circle formed by the intersection
+    // of sphere_one and a plane at coordinate proj_center[2].
+    const double rho_sphere_one =
+        radius_one *
+        sqrt(1.0 - square((proj_center[2] - center_one[2]) / radius_one));
+    const double rho = sqrt(square(center_one[0] - proj_center[0]) +
+                            square(center_one[1] - proj_center[1]));
+    // Here "projection point away from the z planes" means that
+    // proj_center[2] is between z_min_close and z_max_close.
+    const double z_min_close = z_lower + 1e-15 * (z_upper - z_lower);
+    const double z_max_close = z_upper - 1e-15 * (z_upper - z_lower);
+    if (proj_center[2] <= z_min_close or proj_center[2] >= z_max_close) {
+      // Projection point is near the center of one of the z planes.
+      ASSERT(center_one[0] == center_two[0] and center_one[1] == center_two[1],
+             "When projection point is at a z plane, the two spheres must be "
+             "centered in x and y");
+      ASSERT(center_one[2] - z_lower <= 0.75 * radius_one and
+                 z_upper - center_one[2] <= 0.75 * radius_one,
+             "CylindricalSide: The map has been tested only when z_lower and "
+             "z_upper are sufficently far from the edge of sphere_one");
+      ASSERT(radius_one >= dist_spheres+0.1 and
+                 radius_two <= 4.01 * (radius_one + dist_spheres),
+             "The map has not been tested for either radius_one this small or "
+             "for radius_two this large. radius_one = "
+                 << radius_one << ", radius_two = " << radius_two
+                 << ", dist_spheres = " << dist_spheres);
+      ASSERT(rho <= 1.e-14,
+             "The map has been tested only for the case when the projection "
+             "point is not too close to sphere_one. rho = "
+                 << rho << "\nz_lower = " << z_lower
+                 << "\nz_upper = " << z_upper << "\nradius_one = " << radius_one
+                 << "\nradius_two = " << radius_two << "\nproj_center = ("
+                 << proj_center[0] << "," << proj_center[1] << ","
+                 << proj_center[2] << ")\ncenter_one = (" << center_one[0]
+                 << "," << center_one[1] << "," << center_one[2]
+                 << ")\ncenter_two = (" << center_two[0] << "," << center_two[1]
+                 << "," << center_two[2] << ")\n");
+    } else {
+      // Projection point is not near the center of one of the z planes.
+      ASSERT(
+          proj_center[2] - z_lower >= 0.1 * (z_upper - z_lower) and
+              z_upper - proj_center[2] >= 0.1 * (z_upper - z_lower),
+          "CylindricalSide: The map has been tested only for the case when "
+          "proj_center is sufficiently contained inside z_lower and z_upper: "
+              << z_lower << " " << proj_center[2] << " " << z_upper);
+      ASSERT(radius_one >= 0.3 * dist_spheres and
+                 radius_two <= 2.01 * (radius_one + dist_spheres),
+             "The map has not been tested for either radius_one this small or "
+             "for radius_two this large. radius_one = "
+                 << radius_one << ", radius_two = " << radius_two
+                 << ", dist_spheres = " << dist_spheres);
+      ASSERT(rho <= rho_sphere_one * 0.85,
+             "The map has been tested only for the case when the projection "
+             "point is not too close to sphere_one. rho = "
+                 << rho << ", rho_sphere_one = " << rho_sphere_one
+                 << "\nz_lower = " << z_lower << "\nz_upper = " << z_upper
+                 << "\nradius_one = " << radius_one << "\nradius_two = "
+                 << radius_two << "\nproj_center = (" << proj_center[0] << ","
+                 << proj_center[1] << "," << proj_center[2]
+                 << ")\ncenter_one = (" << center_one[0] << "," << center_one[1]
+                 << "," << center_one[2] << ")\ncenter_two = (" << center_two[0]
+                 << "," << center_two[1] << "," << center_two[2] << ")\n");
+    }
+  } else {
+    // Sphere_two is contained in sphere_one
+    ASSERT(dist_proj_two < 0.9 * radius_two,
+           "CylindricalSide: The map has been tested only for the case when "
+           "proj_center is contained inside sphere_two. dist_proj_two="
+               << dist_proj_two << ", radius_two=" << radius_two);
+    ASSERT(center_one[2] - z_lower <= 0.92 * radius_one and
+               z_upper - center_one[2] <= 0.92 * radius_one,
+           "CylindricalSide: The map has been tested only when z_lower and "
+           "z_upper are sufficently far from the edge of sphere_one");
     ASSERT(center_one[2] - z_lower >= 0.2 * radius_one and
                z_upper - center_one[2] >= 0.2 * radius_one,
            "CylindricalSide: The map has been tested only when z_lower and "
            "z_upper are sufficently far from the center of sphere_one");
+    const double rho = sqrt(square(center_one[0] - center_two[0]) +
+                            square(center_one[1] - center_two[1]));
+    const double rho_max = 0.85 * sqrt(square(radius_one - radius_two) -
+                                      square(center_one[2] - center_two[2]));
+    ASSERT(rho <= rho_max,
+           "sphere_one and sphere_two are too close to each other");
   }
 #endif
 }

--- a/src/Domain/CoordinateMaps/FocallyLiftedMapHelpers.hpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedMapHelpers.hpp
@@ -116,6 +116,14 @@ void scale_factor(const gsl::not_null<tt::remove_cvref_wrap_t<T>*>& result,
  *  `pick_root_greater_than_one` that allow the caller to choose which
  *  root to return.
  *
+ *  Furthermore, to reduce roundoff errors near
+ *  \f$\tilde{\lambda}=1\f$, the default behavior is to solve the
+ *  quadratic equation for \f$\tilde{\lambda}-1\f$ (and then add
+ *  \f$1\f$ to the solution). If instead one wants to solve the
+ *  quadratic equation directly for \f$\tilde{\lambda}\f$ so as to
+ *  obtain slightly different roundoff behavior, then one should
+ *  specify the argument `solve_for_root_minus_one` to be `false`.
+ *
  * `try_scale_factor` is not templated
  *  on type because it is used only by the inverse function, which
  *  works only on doubles.
@@ -125,7 +133,8 @@ std::optional<double> try_scale_factor(
     const std::array<double, 3>& src_point,
     const std::array<double, 3>& proj_center,
     const std::array<double, 3>& sphere_center, double radius,
-    bool pick_larger_root, bool pick_root_greater_than_one) noexcept;
+    bool pick_larger_root, bool pick_root_greater_than_one,
+    bool solve_for_root_minus_one = true) noexcept;
 
 /*!
  * Computes \f$\partial \lambda/\partial x_0^i\f$, where \f$\lambda\f$

--- a/src/Domain/CoordinateMaps/FocallyLiftedSide.cpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedSide.cpp
@@ -232,7 +232,7 @@ std::optional<double> Side::lambda_tilde(
   return FocallyLiftedMapHelpers::try_scale_factor(
       parent_mapped_target_coords, projection_point, center_, radius_,
       source_is_between_focus_and_target,
-      not source_is_between_focus_and_target);
+      not source_is_between_focus_and_target, false);
 }
 
 template <typename T>

--- a/tests/Unit/Domain/CoordinateMaps/Test_CylindricalFlatSide.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CylindricalFlatSide.cpp
@@ -33,10 +33,10 @@ void test_cylindrical_flat_side() {
   // Choose a random center for the annulus, making sure the
   // z-coordinate is outside sphere_two and at least 5 percent below
   // it.  Also make sure that the center of the annulus is not offset
-  // in x-y farther than the radius of sphere_two.
+  // in x-y farther than 90% of the radius of sphere_two.
   const std::array<double, 3> center_one = [&radius_two, &center_two, &unit_dis,
                                             &angle_dis, &gen]() noexcept {
-    const double rho = unit_dis(gen) * radius_two;
+    const double rho = unit_dis(gen) * 0.9 *  radius_two;
     const double phi = angle_dis(gen);
     const double x = center_two[0] + rho * cos(phi);
     const double y = center_two[1] + rho * sin(phi);
@@ -53,7 +53,7 @@ void test_cylindrical_flat_side() {
     const double phi = angle_dis(gen);
     const double cos_theta = interval_dis(gen);
     const double sin_theta = sqrt(1.0 - square(cos_theta));
-    const double r = radius_two * 0.95 * unit_dis(gen);
+    const double r = radius_two * 0.85 * unit_dis(gen);
     return std::array<double, 3>{center_two[0] + r * sin_theta * cos(phi),
                                  center_two[1] + r * sin_theta * sin(phi),
                                  center_two[2] + r * cos_theta};
@@ -66,16 +66,17 @@ void test_cylindrical_flat_side() {
 
   // Pick outer radius of annulus, but not too small.
   // Smallness is decided by making sure angle subtended by annulus with
-  // respect to projection center is greater than 0.05 radians.
-  const double outer_radius = dist_annulus_proj * 0.05 + unit_dis(gen);
+  // respect to projection center is greater than 0.1 radians.
+  const double outer_radius = dist_annulus_proj * 0.1 + unit_dis(gen);
   CAPTURE(outer_radius);
 
   // Pick inner radius of annulus.
   // Don't make the annulus too thin,
   // and don't make the inner radius too small.
   const double min_inner_radius_fac =
-      std::max(0.05, dist_annulus_proj * 0.01 / outer_radius);
-  const double max_inner_radius_fac = 0.95 - min_inner_radius_fac;
+      std::max(0.1, dist_annulus_proj * 0.03 / outer_radius);
+  const double max_inner_radius_fac = 0.9 - min_inner_radius_fac;
+  CHECK(max_inner_radius_fac>0.0);
   const double inner_radius =
       outer_radius *
       (min_inner_radius_fac + max_inner_radius_fac * unit_dis(gen));

--- a/tests/Unit/Domain/CoordinateMaps/Test_CylindricalSide.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CylindricalSide.cpp
@@ -14,7 +14,16 @@
 
 namespace domain {
 namespace {
-void test_cylindrical_side_sphere_two_encloses_sphere_one() {
+// If projection_point_near_z_plane is true, then the projection
+// point is placed near or on one of the z_planes, and near the center
+// of that plane.  Otherwise, the projection point is placed somewhere
+// away from the z_planes.
+//
+// Also, for projection_point_near_z_plane=true, the allowed value of
+// sphere_two is much larger than for projection_point_near_z_plane=false;
+// this reflects our usage of the maps.
+void test_cylindrical_side_sphere_two_encloses_sphere_one(
+    const bool projection_point_near_z_plane) {
   INFO("CylindricalSideSphereTwoEnclosesSphereOne");
   // Set up random number generator
   MAKE_GENERATOR(gen);
@@ -27,8 +36,16 @@ void test_cylindrical_side_sphere_two_encloses_sphere_one() {
   const std::array<double, 3> center_one = {
       interval_dis(gen), interval_dis(gen), interval_dis(gen)};
   CAPTURE(center_one);
-  const std::array<double, 3> center_two = {
-      interval_dis(gen), interval_dis(gen), interval_dis(gen)};
+
+  const auto center_two = [&projection_point_near_z_plane, &center_one,
+                           &interval_dis,
+                           &gen]() noexcept -> std::array<double, 3> {
+    if (projection_point_near_z_plane) {
+      return {center_one[0], center_one[1], interval_dis(gen)};
+    } else {
+      return {interval_dis(gen), interval_dis(gen), interval_dis(gen)};
+    }
+  }();
   CAPTURE(center_two);
   const double dist_between_spheres =
       sqrt(square(center_two[0] - center_one[0]) +
@@ -37,45 +54,84 @@ void test_cylindrical_side_sphere_two_encloses_sphere_one() {
 
   // Pick radius of sphere_one not too small compared to the distance
   // between the centers.
-  const double radius_one = 0.3 * dist_between_spheres + unit_dis(gen);
+  const double radius_one = projection_point_near_z_plane
+                                ? dist_between_spheres + 0.1 + unit_dis(gen)
+                                : 0.3 * dist_between_spheres + unit_dis(gen);
   CAPTURE(radius_one);
 
   // Now construct sphere_two which we make sure encloses sphere_one,
   // but doesn't have too large of a radius.
   const double radius_two =
-      (unit_dis(gen) + 1.0) * (radius_one + dist_between_spheres);
+      projection_point_near_z_plane
+          ? (3.0 * unit_dis(gen) + 1.01) * (radius_one + dist_between_spheres)
+          : (unit_dis(gen) + 1.01) * (radius_one + dist_between_spheres);
   CAPTURE(radius_two);
 
   const std::array<double, 2> z_planes =
-      [&gen, &unit_dis, &center_one, &radius_one ]() noexcept {
-    // Make sure each z_plane intersects sphere_one in two locations;
-    // to do this, ensure that each plane is no closer than 8% of the
-    // radius to the min/max z-extents of sphere_one and no closer than
-    // 1% of the radius to the center.
-    const double z_plane_1 =
-        center_one[2] - (0.01 + 0.91 * unit_dis(gen)) * radius_one;
-    const double z_plane_2 =
-        center_one[2] + (0.01 + 0.91 * unit_dis(gen)) * radius_one;
-    return std::array<double, 2>{z_plane_1, z_plane_2};
-  }
-  ();
+      [&gen, &unit_dis, &center_one, &radius_one,
+       &projection_point_near_z_plane]() noexcept {
+        if (projection_point_near_z_plane) {
+          // Make sure each z_plane intersects sphere_one in two locations;
+          // to do this, ensure that each plane is no closer than 25% of the
+          // radius to the min/max z-extents of sphere_one and no closer than
+          // 2% of the radius to the center.
+          const double z_plane_1 =
+              center_one[2] - (0.02 + 0.73 * unit_dis(gen)) * radius_one;
+          const double z_plane_2 =
+              center_one[2] + (0.02 + 0.73 * unit_dis(gen)) * radius_one;
+          return std::array<double, 2>{z_plane_1, z_plane_2};
+        } else {
+          // Make sure each z_plane intersects sphere_one in two locations;
+          // to do this, ensure that each plane is no closer than 10% of the
+          // radius to the min/max z-extents of sphere_one and no closer than
+          // 2% of the radius to the center.
+          const double z_plane_1 =
+              center_one[2] - (0.02 + 0.88 * unit_dis(gen)) * radius_one;
+          const double z_plane_2 =
+              center_one[2] + (0.02 + 0.88 * unit_dis(gen)) * radius_one;
+          return std::array<double, 2>{z_plane_1, z_plane_2};
+        }
+      }();
   CAPTURE(z_planes);
 
   // Keep proj_center inside sphere_1 and between (or on) the z_planes.
-  const std::array<double, 3> proj_center = [
-    &z_planes, &center_one, &radius_one, &gen, &unit_dis, &angle_dis
-  ]() noexcept {
-    // Need proj_center between or on the z_planes.
-    const double z = z_planes[0] + (z_planes[1] - z_planes[0]) * unit_dis(gen);
-    // choose 0.9 so that proj_center is not on edge of sphere_one.
-    const double rho_max = 0.9 * radius_one *
-                           sqrt(1.0 - square((z - center_one[2]) / radius_one));
-    const double rho = unit_dis(gen) * rho_max;
-    const double phi = angle_dis(gen);
-    return std::array<double, 3>{center_one[0] + rho * cos(phi),
-                                 center_one[1] + rho * sin(phi), z};
-  }
-  ();
+  const std::array<double, 3> proj_center =
+      [&z_planes, &center_one, &radius_one, &gen, &unit_dis, &angle_dis,
+       &projection_point_near_z_plane]() noexcept {
+        // z is z coordinate of projection point.
+        // rho_max_factor is rho_max/rho_sphere_one (see below for
+        // definition of rho_sphere_one).
+        const auto & [z, rho_max_factor] =
+            [&z_planes, &projection_point_near_z_plane, &unit_dis,
+             &gen]() noexcept -> std::array<double, 2> {
+          if (projection_point_near_z_plane) {
+            // Place z exactly at one of the z-planes.
+            // Choose which plane randomly, with probability 1/2.
+            const double z_local =
+                unit_dis(gen) < 0.5 ? z_planes[0] : z_planes[1];
+            // Also, set rho to something very small.
+            return {z_local, 1.e-25};
+          } else {
+            // z is not near one of the z-planes.
+            // Note that z <= z_min but z < z_max.
+            const double z_min =
+                z_planes[0] + 0.1 * (z_planes[1] - z_planes[0]);
+            const double z_max =
+                z_planes[1] - 0.1 * (z_planes[1] - z_planes[0]);
+            const double z_local = z_min + (z_max - z_min) * unit_dis(gen);
+            return {z_local, 0.85};
+          }
+        }();
+        // rho_sphere_one is the radius of the circle formed by the
+        // intersection of sphere_one and a plane at coordinate z.
+        const double rho_sphere_one =
+            radius_one * sqrt(1.0 - square((z - center_one[2]) / radius_one));
+        const double rho_max = rho_sphere_one * rho_max_factor;
+        const double rho = unit_dis(gen) * rho_max;
+        const double phi = angle_dis(gen);
+        return std::array<double, 3>{center_one[0] + rho * cos(phi),
+                                     center_one[1] + rho * sin(phi), z};
+      }();
   CAPTURE(proj_center);
 
   const CoordinateMaps::CylindricalSide map(center_one, center_two, proj_center,
@@ -108,15 +164,14 @@ void test_cylindrical_side_sphere_one_encloses_sphere_two() {
   // Also make sure that each z_plane is not more than 20% away from
   // the center of sphere_one (because we need to fit sphere_two between
   // the planes).
-  const std::array<double, 2> z_planes =
-      [&gen, &unit_dis, &center_one, &radius_one ]() noexcept {
+  const std::array<double, 2> z_planes = [&gen, &unit_dis, &center_one,
+                                          &radius_one]() noexcept {
     const double z_plane_1 =
         center_one[2] - (0.2 + 0.72 * unit_dis(gen)) * radius_one;
     const double z_plane_2 =
         center_one[2] + (0.2 + 0.72 * unit_dis(gen)) * radius_one;
     return std::array<double, 2>{z_plane_1, z_plane_2};
-  }
-  ();
+  }();
   CAPTURE(z_planes);
 
   // Choose sphere_two to be fully contained inside the z_planes,
@@ -135,9 +190,9 @@ void test_cylindrical_side_sphere_one_encloses_sphere_two() {
     const double center_two_z =
         center_two_z_min +
         (center_two_z_max - center_two_z_min) * unit_dis(gen);
-    // Choose 0.95 so that there is some space between sphere_one and
+    // Choose 0.85 so that there is some space between sphere_one and
     // sphere_two.
-    const double rho = 0.95 * unit_dis(gen) *
+    const double rho = 0.85 * unit_dis(gen) *
                        sqrt(square(radius_one - radius_two) -
                             square(center_one[2] - center_two_z));
     const double phi = angle_dis(gen);
@@ -149,8 +204,8 @@ void test_cylindrical_side_sphere_one_encloses_sphere_two() {
   // Keep proj_center inside sphere_two.
   const std::array<double, 3> proj_center = [&center_two, &radius_two, &gen,
                                              &unit_dis, &angle_dis]() noexcept {
-    // choose 0.95 so that proj_center is not on edge of sphere_two.
-    const double r = 0.95 * radius_two * unit_dis(gen);
+    // choose 0.9 so that proj_center is not on edge of sphere_two.
+    const double r = 0.9 * radius_two * unit_dis(gen);
     const double theta = 2.0 * angle_dis(gen);
     const double phi = angle_dis(gen);
     return std::array<double, 3>{center_two[0] + r * sin(theta) * cos(phi),
@@ -168,7 +223,8 @@ void test_cylindrical_side_sphere_one_encloses_sphere_two() {
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.CylindricalSide",
                   "[Domain][Unit]") {
-  test_cylindrical_side_sphere_two_encloses_sphere_one();
+  test_cylindrical_side_sphere_two_encloses_sphere_one(true);
+  test_cylindrical_side_sphere_two_encloses_sphere_one(false);
   test_cylindrical_side_sphere_one_encloses_sphere_two();
   CHECK(not CoordinateMaps::CylindricalSide{}.is_identity());
 }


### PR DESCRIPTION
## Proposed changes
Change allowed bounds in cylinder domains to fix occasional roundoff failures in tests.
Fixes #3380 

See detailed comments in commit messages.

### Upgrade instructions

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
