### PR TITLE
Fix PiecewisePolynomial results at update times

### DIFF
--- a/src/Domain/FunctionsOfTime/FunctionOfTime.hpp
+++ b/src/Domain/FunctionsOfTime/FunctionOfTime.hpp
@@ -32,6 +32,11 @@ namespace FunctionsOfTime {
 ///
 /// The domain of validity of the function is given by the `time_bounds` member
 /// function.
+///
+/// The function and all of its derivatives are left-continuous, that
+/// is, when evaluated at a time when the function was updated, they
+/// return the values just before the update, ignoring the updated
+/// value.
 class FunctionOfTime : public PUP::able {
  public:
   FunctionOfTime() = default;

--- a/src/Domain/FunctionsOfTime/FunctionOfTimeHelpers.cpp
+++ b/src/Domain/FunctionsOfTime/FunctionOfTimeHelpers.cpp
@@ -68,10 +68,10 @@ const StoredInfo<MaxDerivPlusOne, StoreCoefs>& stored_info_from_upper_bound(
          "Vector of StoredInfos you are trying to access is empty. Was it "
          "constructed properly?");
 
-  const auto upper_bound_stored_info = std::upper_bound(
+  const auto upper_bound_stored_info = std::lower_bound(
       all_stored_infos.begin(), all_stored_infos.end(), t,
-      [](double t0, const StoredInfo<MaxDerivPlusOne, StoreCoefs>& d) {
-        return d.time > t0;
+      [](const StoredInfo<MaxDerivPlusOne, StoreCoefs>& d, double t0) {
+        return d.time < t0;
       });
 
   if (upper_bound_stored_info == all_stored_infos.begin()) {

--- a/src/Domain/FunctionsOfTime/FunctionOfTimeHelpers.hpp
+++ b/src/Domain/FunctionsOfTime/FunctionOfTimeHelpers.hpp
@@ -60,7 +60,7 @@ void reset_expiration_time(const gsl::not_null<double*> prev_expiration_time,
                            const double next_expiration_time) noexcept;
 
 /// Returns a StoredInfo corresponding to the closest element in the range of
-/// `StoredInfo.time`s that is less than or equal to `t`. The function throws an
+/// `StoredInfo.time`s that is less than `t`. The function throws an
 /// error if `t` is less than all `StoredInfo.time`s (unless `t` is just less
 /// than the earliest `StoredInfo.time` by roundoff, in which case it returns
 /// the earliest StoredInfo.)

--- a/src/Domain/FunctionsOfTime/PiecewisePolynomial.cpp
+++ b/src/Domain/FunctionsOfTime/PiecewisePolynomial.cpp
@@ -160,15 +160,15 @@ bool operator!=(const PiecewisePolynomial<MaxDeriv>& lhs,
 #define DIMRETURNED(data) BOOST_PP_TUPLE_ELEM(1, data)
 
 #define INSTANTIATE(_, data)                                       \
+  template class PiecewisePolynomial<DIM(data)>;                   \
   template bool operator==                                         \
       <DIM(data)>(const PiecewisePolynomial<DIM(data)>&,           \
                   const PiecewisePolynomial<DIM(data)>&) noexcept; \
-  template class PiecewisePolynomial<DIM(data)>;                   \
   template bool operator!=                                         \
       <DIM(data)>(const PiecewisePolynomial<DIM(data)>&,           \
                   const PiecewisePolynomial<DIM(data)>&) noexcept;
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3, 4))
+GENERATE_INSTANTIATIONS(INSTANTIATE, (0, 1, 2, 3, 4))
 
 #undef INSTANTIATE
 
@@ -177,6 +177,8 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3, 4))
   PiecewisePolynomial<DIM(data)>::func_and_derivs<DIMRETURNED(data)>( \
       const double) const noexcept;
 
+GENERATE_INSTANTIATIONS(INSTANTIATE, (0), (0))
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1), (0, 1))
 GENERATE_INSTANTIATIONS(INSTANTIATE, (2), (0, 1, 2))
 GENERATE_INSTANTIATIONS(INSTANTIATE, (3), (0, 1, 2, 3))
 GENERATE_INSTANTIATIONS(INSTANTIATE, (4), (0, 1, 2, 3, 4))

--- a/src/Domain/FunctionsOfTime/PiecewisePolynomial.hpp
+++ b/src/Domain/FunctionsOfTime/PiecewisePolynomial.hpp
@@ -41,16 +41,21 @@ class PiecewisePolynomial : public FunctionOfTime {
   // clang-tidy: cppcoreguidelines-owning-memory,-warnings-as-errors
   WRAPPED_PUPable_decl_template(PiecewisePolynomial<MaxDeriv>);  // NOLINT
 
-  /// Returns the function at an arbitrary time `t`.
+  /// Returns the function at an arbitrary time `t`.  If `MaxDeriv` is
+  /// 0 and `update` has been called for time `t`, the updated value
+  /// is ignored.
   std::array<DataVector, 1> func(double t) const noexcept override {
     return func_and_derivs<0>(t);
   }
   /// Returns the function and its first derivative at an arbitrary time `t`.
+  /// If `MaxDeriv` is 1 and `update` has been called for time `t`, the updated
+  /// value is ignored.
   std::array<DataVector, 2> func_and_deriv(double t) const noexcept override {
     return func_and_derivs<1>(t);
   }
   /// Returns the function and the first two derivatives at an arbitrary time
-  /// `t`.
+  /// `t`.  If `MaxDeriv` is 2 and `update` has been called for time `t`, the
+  /// updated value is ignored.
   std::array<DataVector, 3> func_and_2_derivs(
       double t) const noexcept override {
     return func_and_derivs<2>(t);

--- a/tests/Unit/Domain/FunctionsOfTime/Test_FunctionOfTimeHelpers.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_FunctionOfTimeHelpers.cpp
@@ -75,7 +75,7 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.FunctionOfTimeHelpers",
     const auto& upper_bound_stored_info2 =
         FunctionOfTimeHelpers::stored_info_from_upper_bound(4.0,
                                                             all_stored_info);
-    CHECK(upper_bound_stored_info2 == gsl::at(all_stored_info, 4));
+    CHECK(upper_bound_stored_info2 == gsl::at(all_stored_info, 3));
 
     const auto& upper_bound_stored_info3 =
         FunctionOfTimeHelpers::stored_info_from_upper_bound(-1.e-15,

--- a/tests/Unit/Domain/FunctionsOfTime/Test_PiecewisePolynomial.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_PiecewisePolynomial.cpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cstddef>
+#include <limits>
 #include <memory>
 
 #include "DataStructures/DataVector.hpp"
@@ -68,6 +69,7 @@ void test_non_const_deriv(
     f_of_t_derived->update(t, {3.0 + t}, t + dt);
     CHECK(*f_of_t_derived != f_of_t_derived_copy);
   }
+  t *= 1.0 + std::numeric_limits<double>::epsilon();
   const auto lambdas0 = f_of_t->func_and_2_derivs(t);
   CHECK(approx(lambdas0[0][0]) == 33.948);
   CHECK(approx(lambdas0[1][0]) == 19.56);
@@ -223,6 +225,14 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.PiecewisePolynomial",
 
     test_within_roundoff<deriv_order>(f_of_t);
     test_within_roundoff<deriv_order>(f_of_t2);
+  }
+  {
+    INFO("Test evaluation at update time.");
+    FunctionsOfTime::PiecewisePolynomial<0> f_of_t(1.0, {{{1.0, 2.0}}}, 2.0);
+
+    CHECK(f_of_t.func(2.0)[0] == DataVector{1.0, 2.0});
+    f_of_t.update(2.0, {3.0, 4.0}, 2.1);
+    CHECK(f_of_t.func(2.0)[0] == DataVector{1.0, 2.0});
   }
 }
 


### PR DESCRIPTION
It is allowed to update at the last valid time for evaluating the
function.  An evaluation at this time must not reflect the effects of
the update because it could have been previously evaluated before the
update was performed.

Also instantiate more cases to make testing easier and for potential
later use.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
