### PR TITLE
Pass more things to dense triggers' is_ready

### DIFF
--- a/src/Evolution/EventsAndDenseTriggers/DenseTriggers/Filter.hpp
+++ b/src/Evolution/EventsAndDenseTriggers/DenseTriggers/Filter.hpp
@@ -14,6 +14,10 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
+namespace Parallel {
+template <typename Metavariables>
+class GlobalCache;
+}  // namespace Parallel
 namespace Tags {
 struct DataBox;
 }  // namespace Tags
@@ -70,9 +74,12 @@ class Filter : public DenseTrigger {
 
   using is_ready_argument_tags = tmpl::list<Tags::DataBox>;
 
-  template <typename DbTags>
-  bool is_ready(const db::DataBox<DbTags>& box) const noexcept {
-    return trigger_->is_ready(box);
+  template <typename Metavariables, typename ArrayIndex, typename Component,
+            typename DbTags>
+  bool is_ready(Parallel::GlobalCache<Metavariables>& cache,
+                const ArrayIndex& array_index, const Component* const component,
+                const db::DataBox<DbTags>& box) const noexcept {
+    return trigger_->is_ready(box, cache, array_index, component);
   }
 
   // NOLINTNEXTLINE(google-runtime-references)

--- a/src/Evolution/EventsAndDenseTriggers/DenseTriggers/Or.hpp
+++ b/src/Evolution/EventsAndDenseTriggers/DenseTriggers/Or.hpp
@@ -18,6 +18,10 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
+namespace Parallel {
+template <typename Metavariables>
+class GlobalCache;
+}  // namespace Parallel
 namespace Tags {
 struct DataBox;
 struct TimeStepId;
@@ -68,12 +72,16 @@ class Or : public DenseTrigger {
 
   using is_ready_argument_tags = tmpl::list<Tags::DataBox>;
 
-  template <typename DbTags>
-  bool is_ready(const db::DataBox<DbTags>& box) const noexcept {
+  template <typename Metavariables, typename ArrayIndex, typename Component,
+            typename DbTags>
+  bool is_ready(Parallel::GlobalCache<Metavariables>& cache,
+                const ArrayIndex& array_index, const Component* const component,
+                const db::DataBox<DbTags>& box) const noexcept {
     return alg::all_of(
         triggers_,
-        [&box](const std::unique_ptr<DenseTrigger>& trigger) noexcept {
-          return trigger->is_ready(box);
+        [&array_index, &box, &cache, &component](
+            const std::unique_ptr<DenseTrigger>& trigger) noexcept {
+          return trigger->is_ready(box, cache, array_index, component);
         });
   }
 

--- a/src/Evolution/EventsAndDenseTriggers/DenseTriggers/Times.cpp
+++ b/src/Evolution/EventsAndDenseTriggers/DenseTriggers/Times.cpp
@@ -30,8 +30,6 @@ DenseTrigger::Result Times::is_triggered(const TimeStepId& time_step_id,
   return {time == trigger_times[1], next_time};
 }
 
-bool Times::is_ready() noexcept { return true; }
-
 void Times::pup(PUP::er& p) noexcept {
   DenseTrigger::pup(p);
   p | times_;

--- a/src/Evolution/EventsAndDenseTriggers/DenseTriggers/Times.hpp
+++ b/src/Evolution/EventsAndDenseTriggers/DenseTriggers/Times.hpp
@@ -15,6 +15,10 @@
 
 /// \cond
 class TimeStepId;
+namespace Parallel {
+template <typename Metavariables>
+class GlobalCache;
+}  // namespace Parallel
 namespace Tags {
 struct Time;
 struct TimeStepId;
@@ -45,7 +49,12 @@ class Times : public DenseTrigger {
 
   using is_ready_argument_tags = tmpl::list<>;
 
-  static bool is_ready() noexcept;
+  template <typename Metavariables, typename ArrayIndex, typename Component>
+  static bool is_ready(Parallel::GlobalCache<Metavariables>& /*cache*/,
+                       const ArrayIndex& /*array_index*/,
+                       const Component* const /*meta*/) noexcept {
+    return true;
+  }
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p) noexcept override;

--- a/src/Evolution/EventsAndDenseTriggers/EventsAndDenseTriggers.hpp
+++ b/src/Evolution/EventsAndDenseTriggers/EventsAndDenseTriggers.hpp
@@ -165,7 +165,8 @@ EventsAndDenseTriggers::TriggeringState EventsAndDenseTriggers::is_ready(
       db::get<::Tags::TimeStepId>(box).time_runs_forward()};
 
   while (current_trigger() != events_and_triggers_.end()) {
-    if (not current_trigger()->trigger->is_ready(box)) {
+    if (not current_trigger()->trigger->is_ready(box, cache, array_index,
+                                                 component)) {
       return TriggeringState::NotReady;
     }
 

--- a/tests/Unit/Evolution/Actions/Test_RunEventsAndDenseTriggers.cpp
+++ b/tests/Unit/Evolution/Actions/Test_RunEventsAndDenseTriggers.cpp
@@ -83,10 +83,10 @@ class TestTrigger : public DenseTrigger {
   // we have to handle that call and set up for triggering at the
   // interesting time.
   TestTrigger(const double init_time, const double trigger_time,
-              const bool is_ready, const bool is_triggered) noexcept
+              const bool is_ready_arg, const bool is_triggered) noexcept
       : init_time_(init_time),
         trigger_time_(trigger_time),
-        is_ready_(is_ready),
+        is_ready_(is_ready_arg),
         is_triggered_(is_triggered) {}
 
   using is_triggered_argument_tags = tmpl::list<Tags::Time>;
@@ -100,7 +100,11 @@ class TestTrigger : public DenseTrigger {
   }
 
   using is_ready_argument_tags = tmpl::list<Tags::Time>;
-  bool is_ready(const double time) const noexcept {
+  template <typename Metavariables, typename ArrayIndex, typename Component>
+  bool is_ready(Parallel::GlobalCache<Metavariables>& /*cache*/,
+                const ArrayIndex& /*array_index*/,
+                const Component* const /*meta*/,
+                const double time) const noexcept {
     if (time == init_time_) {
       return true;
     }

--- a/tests/Unit/Evolution/EventsAndDenseTriggers/DenseTriggers/Test_Times.cpp
+++ b/tests/Unit/Evolution/EventsAndDenseTriggers/DenseTriggers/Test_Times.cpp
@@ -14,6 +14,7 @@
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/GlobalCache.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
@@ -25,6 +26,7 @@
 
 namespace {
 struct Metavariables {
+  using component_list = tmpl::list<>;
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes =
@@ -62,8 +64,11 @@ void check_one_direction(const std::vector<double>& trigger_times,
                         Tags::TimeStepId, Tags::Time>>(
       Metavariables{}, TimeStepId(time_runs_forward, 100, slab.start()),
       current_time);
+  Parallel::GlobalCache<Metavariables> cache{};
+  const int array_index = 0;
+  const void* component = nullptr;
 
-  CHECK(trigger->is_ready(box));
+  CHECK(trigger->is_ready(box, cache, array_index, component));
   const auto is_triggered = trigger->is_triggered(box);
   CHECK(is_triggered.is_triggered == expected_is_triggered);
   CHECK(is_triggered.next_check == expected_next_check);

--- a/tests/Unit/Helpers/Evolution/EventsAndDenseTriggers/DenseTriggers/TestTrigger.hpp
+++ b/tests/Unit/Helpers/Evolution/EventsAndDenseTriggers/DenseTriggers/TestTrigger.hpp
@@ -14,6 +14,13 @@
 #include "Parallel/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
 
+/// \cond
+namespace Parallel {
+template <typename Metavariables>
+class GlobalCache;
+}  // namespace Parallel
+/// \endcond
+
 namespace TestHelpers::DenseTriggers {
 class TestTrigger : public DenseTrigger {
  public:
@@ -43,9 +50,9 @@ class TestTrigger : public DenseTrigger {
   using options = tmpl::list<IsReady, IsTriggered, NextCheck>;
   constexpr static Options::String help = "help";
 
-  TestTrigger(const bool is_ready, const bool is_triggered,
+  TestTrigger(const bool is_ready_arg, const bool is_triggered,
               const double next_check) noexcept
-      : is_ready_(is_ready),
+      : is_ready_(is_ready_arg),
         is_triggered_(is_triggered),
         next_check_(next_check) {}
 
@@ -56,7 +63,12 @@ class TestTrigger : public DenseTrigger {
   }
 
   using is_ready_argument_tags = tmpl::list<>;
-  bool is_ready() const noexcept { return is_ready_; }
+  template <typename Metavariables, typename ArrayIndex, typename Component>
+  bool is_ready(Parallel::GlobalCache<Metavariables>& /*cache*/,
+                const ArrayIndex& /*array_index*/,
+                const Component* const /*meta*/) const noexcept {
+    return is_ready_;
+  }
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p) noexcept override {
@@ -104,14 +116,20 @@ class BoxTrigger : public DenseTrigger {
 
   using is_triggered_argument_tags =
       tmpl::list<IsReady, IsTriggered, NextCheck>;
-  Result is_triggered(const bool is_ready, const bool is_triggered,
+  Result is_triggered(const bool is_ready_arg, const bool is_triggered,
                       const double next_check) const noexcept {
-    CHECK(is_ready);
+    CHECK(is_ready_arg);
     return {is_triggered, next_check};
   }
 
   using is_ready_argument_tags = tmpl::list<IsReady>;
-  bool is_ready(const bool is_ready) const noexcept { return is_ready; }
+  template <typename Metavariables, typename ArrayIndex, typename Component>
+  bool is_ready(Parallel::GlobalCache<Metavariables>& /*cache*/,
+                const ArrayIndex& /*array_index*/,
+                const Component* const /*meta*/,
+                const bool is_ready_arg) const noexcept {
+    return is_ready_arg;
+  }
 };
 
 /// \cond


### PR DESCRIPTION
These functions are primarily intended to check FunctionOfTime
validity, which requires access to the cache and chare identifiers.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
