### PR TITLE
Enable running a gauge wave on a moving mesh

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
@@ -7,18 +7,18 @@ function(add_generalized_harmonic_executable_with_horizon
     "EvolveGh${INITIAL_DATA_NAME}"
     EvolveGeneralizedHarmonicWithHorizon
     Evolution/Executables/GeneralizedHarmonic
-    "EvolutionMetavars<${INITIAL_DATA}, ${BOUNDARY_CONDITIONS}>"
+    "EvolutionMetavars<3, ${INITIAL_DATA}, ${BOUNDARY_CONDITIONS}>"
     "${LIBS_TO_LINK}"
     )
 endfunction(add_generalized_harmonic_executable_with_horizon)
 
 function(add_generalized_harmonic_executable_without_horizon
-    INITIAL_DATA_NAME INITIAL_DATA BOUNDARY_CONDITIONS LIBS_TO_LINK)
+    INITIAL_DATA_NAME DIM INITIAL_DATA BOUNDARY_CONDITIONS LIBS_TO_LINK)
   add_spectre_parallel_executable(
-    "EvolveGh${INITIAL_DATA_NAME}"
+    "EvolveGh${INITIAL_DATA_NAME}${DIM}D"
     EvolveGeneralizedHarmonicWithoutHorizon
     Evolution/Executables/GeneralizedHarmonic
-    "EvolutionMetavars<${INITIAL_DATA}, ${BOUNDARY_CONDITIONS}>"
+    "EvolutionMetavars<${DIM}, ${INITIAL_DATA}, ${BOUNDARY_CONDITIONS}>"
     "${LIBS_TO_LINK}"
     )
 endfunction(add_generalized_harmonic_executable_without_horizon)
@@ -63,15 +63,24 @@ add_generalized_harmonic_executable_with_horizon(
 
 add_generalized_harmonic_executable_without_horizon(
   GaugeWave
-  GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::GaugeWave<3>>
-  GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::GaugeWave<3>>
+  1
+  GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::GaugeWave<1>>
+  GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::GaugeWave<1>>
   "${LIBS_TO_LINK};GeneralRelativitySolutions"
 )
 
 add_generalized_harmonic_executable_without_horizon(
-  GaugeWaveNumericInitialData
-  evolution::NumericInitialData
-  GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::GaugeWave<3>>
-  "${LIBS_TO_LINK};GeneralRelativitySolutions;Importers"
+  GaugeWave
+  2
+  GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::GaugeWave<2>>
+  GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::GaugeWave<2>>
+  "${LIBS_TO_LINK};GeneralRelativitySolutions"
 )
 
+add_generalized_harmonic_executable_without_horizon(
+  GaugeWave
+  3
+  GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::GaugeWave<3>>
+  GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::GaugeWave<3>>
+  "${LIBS_TO_LINK};GeneralRelativitySolutions"
+)

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
@@ -50,10 +50,17 @@
 // Second template parameter specifies the analytic solution used when imposing
 // dirichlet boundary conditions or against which to compute error norms.
 template <typename InitialData, typename BoundaryConditions>
-struct EvolutionMetavars
-    : public virtual GeneralizedHarmonicDefaults,
-      public GeneralizedHarmonicTemplateBase<
-          EvolutionMetavars<InitialData, BoundaryConditions>> {
+struct EvolutionMetavars<3, InitialData, BoundaryConditions>
+    : public GeneralizedHarmonicTemplateBase<
+          EvolutionMetavars<3, InitialData, BoundaryConditions>> {
+  using gh_base = GeneralizedHarmonicTemplateBase<
+      EvolutionMetavars<3, InitialData, BoundaryConditions>>;
+  using typename gh_base::frame;
+  using typename gh_base::initialize_initial_data_dependent_quantities_actions;
+  using typename gh_base::Phase;
+  using typename gh_base::system;
+  static constexpr size_t volume_dim = 3;
+
   static constexpr Options::String help{
       "Evolve the Einstein field equations using the Generalized Harmonic "
       "formulation,\n"

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
@@ -52,9 +52,9 @@
 template <typename InitialData, typename BoundaryConditions>
 struct EvolutionMetavars<3, InitialData, BoundaryConditions>
     : public GeneralizedHarmonicTemplateBase<
-          EvolutionMetavars<3, InitialData, BoundaryConditions>> {
+          true, EvolutionMetavars<3, InitialData, BoundaryConditions>> {
   using gh_base = GeneralizedHarmonicTemplateBase<
-      EvolutionMetavars<3, InitialData, BoundaryConditions>>;
+      true, EvolutionMetavars<3, InitialData, BoundaryConditions>>;
   using typename gh_base::frame;
   using typename gh_base::initialize_initial_data_dependent_quantities_actions;
   using typename gh_base::Phase;
@@ -112,19 +112,15 @@ struct EvolutionMetavars<3, InitialData, BoundaryConditions>
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes = Options::add_factory_classes<
-        typename GeneralizedHarmonicTemplateBase<
-            EvolutionMetavars>::factory_creation::factory_classes,
+        typename gh_base::factory_creation::factory_classes,
         tmpl::pair<Event, tmpl::list<intrp::Events::Interpolate<
                               3, AhA, interpolator_source_vars>>>>;
   };
 
-  using phase_changes = typename GeneralizedHarmonicTemplateBase<
-      EvolutionMetavars>::phase_changes;
+  using typename gh_base::phase_changes;
 
   using const_global_cache_tags = tmpl::list<
-      typename GeneralizedHarmonicTemplateBase<
-          EvolutionMetavars>::analytic_solution_tag,
-      Tags::EventsAndTriggers,
+      typename gh_base::analytic_solution_tag, Tags::EventsAndTriggers,
       GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma0<
           volume_dim, frame>,
       GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma1<
@@ -139,15 +135,12 @@ struct EvolutionMetavars<3, InitialData, BoundaryConditions>
           typename AhA::post_horizon_find_callback>>;
 
   using dg_registration_list =
-      tmpl::push_back<typename GeneralizedHarmonicTemplateBase<
-                          EvolutionMetavars>::dg_registration_list,
+      tmpl::push_back<typename gh_base::dg_registration_list,
                       intrp::Actions::RegisterElementWithInterpolator>;
 
-  using initialization_actions = typename GeneralizedHarmonicTemplateBase<
-      EvolutionMetavars>::initialization_actions;
+  using typename gh_base::initialization_actions;
 
-  using step_actions =
-      typename GeneralizedHarmonicTemplateBase<EvolutionMetavars>::step_actions;
+  using typename gh_base::step_actions;
 
   // the dg element array needs to be re-declared to capture the new type
   // aliases for the action lists.

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizonFwd.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizonFwd.hpp
@@ -23,6 +23,6 @@ namespace evolution {
 struct NumericInitialData;
 }  // namespace evolution
 
-template <typename InitialData, typename BoundaryConditions>
+template <size_t VolumeDim, typename InitialData, typename BoundaryConditions>
 struct EvolutionMetavars;
 /// \endcond

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithoutHorizon.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithoutHorizon.hpp
@@ -23,27 +23,22 @@
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 
-// First template parameter specifies the source of the initial data, which
+// Second template parameter specifies the source of the initial data, which
 // could be an analytic solution, analytic data, or imported numerical data.
-// Second template parameter specifies the analytic solution used when imposing
+// Third template parameter specifies the analytic solution used when imposing
 // dirichlet boundary conditions or against which to compute error norms.
-template <typename InitialData, typename BoundaryConditions>
+template <size_t VolumeDim, typename InitialData, typename BoundaryConditions>
 struct EvolutionMetavars
-    : public virtual GeneralizedHarmonicDefaults,
-      public GeneralizedHarmonicTemplateBase<
-          EvolutionMetavars<InitialData, BoundaryConditions>> {
-  using const_global_cache_tags =
-      typename GeneralizedHarmonicTemplateBase<EvolutionMetavars<
-          InitialData, BoundaryConditions>>::const_global_cache_tags;
-  using observed_reduction_data_tags =
-      typename GeneralizedHarmonicTemplateBase<EvolutionMetavars<
-          InitialData, BoundaryConditions>>::observed_reduction_data_tags;
-  using component_list = typename GeneralizedHarmonicTemplateBase<
-      EvolutionMetavars<InitialData, BoundaryConditions>>::component_list;
+    : public GeneralizedHarmonicTemplateBase<
+          EvolutionMetavars<VolumeDim, InitialData, BoundaryConditions>> {
+  using gh_base = GeneralizedHarmonicTemplateBase<
+      EvolutionMetavars<VolumeDim, InitialData, BoundaryConditions>>;
+  using typename gh_base::const_global_cache_tags;
+  using typename gh_base::observed_reduction_data_tags;
+  using typename gh_base::component_list;
   template <typename ParallelComponent>
-  using registration_list = typename GeneralizedHarmonicTemplateBase<
-      EvolutionMetavars<InitialData, BoundaryConditions>>::
-      template registration_list<ParallelComponent>;
+  using registration_list =
+      typename gh_base::template registration_list<ParallelComponent>;
 
   static constexpr Options::String help{
       "Evolve the Einstein field equations using the Generalized Harmonic "

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithoutHorizon.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithoutHorizon.hpp
@@ -30,9 +30,10 @@
 template <size_t VolumeDim, typename InitialData, typename BoundaryConditions>
 struct EvolutionMetavars
     : public GeneralizedHarmonicTemplateBase<
+          false,
           EvolutionMetavars<VolumeDim, InitialData, BoundaryConditions>> {
   using gh_base = GeneralizedHarmonicTemplateBase<
-      EvolutionMetavars<VolumeDim, InitialData, BoundaryConditions>>;
+      false, EvolutionMetavars<VolumeDim, InitialData, BoundaryConditions>>;
   using typename gh_base::const_global_cache_tags;
   using typename gh_base::observed_reduction_data_tags;
   using typename gh_base::component_list;

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithoutHorizonFwd.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithoutHorizonFwd.hpp
@@ -24,6 +24,6 @@ namespace evolution {
 struct NumericInitialData;
 }  // namespace evolution
 
-template <typename InitialData, typename BoundaryConditions>
+template <size_t VolumeDim, typename InitialData, typename BoundaryConditions>
 struct EvolutionMetavars;
 /// \endcond

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -140,22 +140,24 @@ class CProxy_GlobalCache;
 }  // namespace Parallel
 /// \endcond
 
-template <typename EvolutionMetavarsDerived>
+template <bool UseDampedHarmonicRollon, typename EvolutionMetavarsDerived>
 struct GeneralizedHarmonicTemplateBase;
 
-template <template <size_t, typename, typename> class EvolutionMetavarsDerived,
+template <bool UseDampedHarmonicRollon,
+          template <size_t, typename, typename> class EvolutionMetavarsDerived,
           size_t VolumeDim, typename InitialData, typename BoundaryConditions>
 struct GeneralizedHarmonicTemplateBase<
+    UseDampedHarmonicRollon,
     EvolutionMetavarsDerived<VolumeDim, InitialData, BoundaryConditions>> {
   using derived_metavars =
       EvolutionMetavarsDerived<VolumeDim, InitialData, BoundaryConditions>;
   static constexpr size_t volume_dim = VolumeDim;
+  static constexpr bool use_damped_harmonic_rollon = UseDampedHarmonicRollon;
   using initial_data = InitialData;
   using frame = Frame::Inertial;
   using system = GeneralizedHarmonic::System<volume_dim>;
   static constexpr dg::Formulation dg_formulation =
       dg::Formulation::StrongInertial;
-  static constexpr bool use_damped_harmonic_rollon = true;
   using temporal_id = Tags::TimeStepId;
   static constexpr bool local_time_stepping = false;
   // Set override_functions_of_time to true to override the

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -10,6 +10,8 @@
 #include "ApparentHorizons/Tags.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
+#include "Domain/Creators/Factory1D.hpp"
+#include "Domain/Creators/Factory2D.hpp"
 #include "Domain/Creators/Factory3D.hpp"
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
@@ -138,8 +140,17 @@ class CProxy_GlobalCache;
 }  // namespace Parallel
 /// \endcond
 
-struct GeneralizedHarmonicDefaults {
-  static constexpr size_t volume_dim = 3;
+template <typename EvolutionMetavarsDerived>
+struct GeneralizedHarmonicTemplateBase;
+
+template <template <size_t, typename, typename> class EvolutionMetavarsDerived,
+          size_t VolumeDim, typename InitialData, typename BoundaryConditions>
+struct GeneralizedHarmonicTemplateBase<
+    EvolutionMetavarsDerived<VolumeDim, InitialData, BoundaryConditions>> {
+  using derived_metavars =
+      EvolutionMetavarsDerived<VolumeDim, InitialData, BoundaryConditions>;
+  static constexpr size_t volume_dim = VolumeDim;
+  using initial_data = InitialData;
   using frame = Frame::Inertial;
   using system = GeneralizedHarmonic::System<volume_dim>;
   static constexpr dg::Formulation dg_formulation =
@@ -159,29 +170,6 @@ struct GeneralizedHarmonicDefaults {
       std::conditional_t<local_time_stepping, LtsTimeStepper, TimeStepper>>;
   using analytic_solution_fields = typename system::variables_tag::tags_list;
 
-  enum class Phase {
-    Initialization,
-    RegisterWithElementDataReader,
-    ImportInitialData,
-    InitializeInitialDataDependentQuantities,
-    InitializeTimeStepperHistory,
-    Register,
-    LoadBalancing,
-    WriteCheckpoint,
-    Evolve,
-    Exit
-  };
-
-  static std::string phase_name(Phase phase) noexcept {
-    if (phase == Phase::LoadBalancing) {
-        return "LoadBalancing";
-      }
-      ERROR(
-          "Passed phase that should not be used in input file. Integer "
-          "corresponding to phase is: "
-          << static_cast<int>(phase));
-  }
-
   using initialize_initial_data_dependent_quantities_actions = tmpl::list<
       GeneralizedHarmonic::gauges::Actions::InitializeDampedHarmonic<
           volume_dim, use_damped_harmonic_rollon>,
@@ -190,20 +178,6 @@ struct GeneralizedHarmonicDefaults {
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/) noexcept {}
-};
-
-template <typename EvolutionMetavarsDerived>
-struct GeneralizedHarmonicTemplateBase;
-
-template <template <typename, typename> class EvolutionMetavarsDerived,
-          typename InitialData, typename BoundaryConditions>
-struct GeneralizedHarmonicTemplateBase<
-    EvolutionMetavarsDerived<InitialData, BoundaryConditions>>
-    : public virtual GeneralizedHarmonicDefaults {
-  using derived_metavars =
-      EvolutionMetavarsDerived<InitialData, BoundaryConditions>;
-
-  using initial_data = InitialData;
   using analytic_solution_tag = Tags::AnalyticSolution<BoundaryConditions>;
 
   using observe_fields = tmpl::append<
@@ -247,6 +221,29 @@ struct GeneralizedHarmonicTemplateBase<
   using observed_reduction_data_tags =
       observers::collect_reduction_data_tags<tmpl::push_back<
           tmpl::at<typename factory_creation::factory_classes, Event>>>;
+
+  enum class Phase {
+    Initialization,
+    RegisterWithElementDataReader,
+    ImportInitialData,
+    InitializeInitialDataDependentQuantities,
+    InitializeTimeStepperHistory,
+    Register,
+    LoadBalancing,
+    WriteCheckpoint,
+    Evolve,
+    Exit
+  };
+
+  static std::string phase_name(Phase phase) noexcept {
+    if (phase == Phase::LoadBalancing) {
+        return "LoadBalancing";
+      }
+      ERROR(
+          "Passed phase that should not be used in input file. Integer "
+          "corresponding to phase is: "
+          << static_cast<int>(phase));
+  }
 
   using phase_changes =
       tmpl::list<PhaseControl::Registrars::VisitAndReturn<

--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -96,9 +96,9 @@ struct TimeAndTimeStep {
           Metavariables::local_time_stepping,
           tmpl::list<::Tags::IsUsingTimeSteppingErrorControl<>,
                      ::Tags::TimeStepper<LtsTimeStepper>, ::Tags::StepChoosers,
-                     ::Tags::StepController>,
+                     ::Tags::StepController, Tags::InitialTime>,
           tmpl::list<::Tags::NeverUsingTimeSteppingErrorControl,
-                     ::Tags::TimeStepper<TimeStepper>>>>>;
+                     ::Tags::TimeStepper<TimeStepper>, Tags::InitialTime>>>>;
 
   using simple_tags =
       tmpl::push_back<StepChoosers::step_chooser_simple_tags<Metavariables>,

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
@@ -1,16 +1,16 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-# Executable: EvolveGhGaugeWave
+# Executable: EvolveGhGaugeWave1D
 # Check: parse;execute
 # Timeout: 8
 # ExpectedOutput:
-#   GhGaugeWaveVolume0.h5
-#   GhGaugeWaveReductions.h5
+#   GhGaugeWave1DVolume0.h5
+#   GhGaugeWave1DReductions.h5
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.0002
+  InitialTimeStep: 0.002
   TimeStepper:
     AdamsBashforthN:
       Order: 3
@@ -25,13 +25,15 @@ PhaseChangeAndTriggers:
           WallclockHours: None
 
 DomainCreator:
-  Brick:
-    LowerBound: [0.0, 0.0, 0.0]
-    UpperBound: [1.0, 1.0, 1.0]
-    InitialRefinement: [1, 1, 1]
-    InitialGridPoints: [5, 5, 5]
+  Interval:
+    LowerBound: [0.0]
+    UpperBound: [1.0]
+    InitialRefinement: [1]
+    InitialGridPoints: [7]
     TimeDependence: None
-    BoundaryCondition: Periodic
+    BoundaryConditions:
+      LowerBoundary:  Periodic
+      UpperBoundary:  Periodic
 
 AnalyticSolution:
   GaugeWave:
@@ -51,19 +53,19 @@ EvolutionSystem:
         Constant: 1.0
         Amplitude: 0.0
         Width: 1.0
-        Center: [0.0, 0.0, 0.0]
+        Center: [0.0]
     DampingFunctionGamma1:
       GaussianPlusConstant:
         Constant: -1.0
         Amplitude: 0.0
         Width: 1.0
-        Center: [0.0, 0.0, 0.0]
+        Center: [0.0]
     DampingFunctionGamma2:
       GaussianPlusConstant:
         Constant: 1.0
         Amplitude: 0.0
         Width: 1.0
-        Center: [0.0, 0.0, 0.0]
+        Center: [0.0]
 
 SpatialDiscretization:
   DiscontinuousGalerkin:
@@ -91,17 +93,16 @@ EventsAndTriggers:
           - Phi
           - PointwiseL2Norm(GaugeConstraint)
           - PointwiseL2Norm(ThreeIndexConstraint)
-          - PointwiseL2Norm(FourIndexConstraint)
         InterpolateToMesh: None
         CoordinatesFloatingPointType: Double
         FloatingPointTypes: [Double]
   ? Slabs:
       Specified:
-        Values: [2]
+        Values: [5]
   : - Completion
 
 EventsAndDenseTriggers:
 
 Observers:
-  VolumeFileName: "GhGaugeWaveVolume"
-  ReductionFileName: "GhGaugeWaveReductions"
+  VolumeFileName: "GhGaugeWave1DVolume"
+  ReductionFileName: "GhGaugeWave1DReductions"

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
@@ -25,28 +25,32 @@ PhaseChangeAndTriggers:
           WallclockHours: None
 
 DomainCreator:
-  Interval:
+  RotatedIntervals:
     LowerBound: [0.0]
-    UpperBound: [1.0]
+    Midpoint: [3.0]
+    UpperBound: [6.283185307179586]
     InitialRefinement: [1]
-    InitialGridPoints: [7]
-    TimeDependence: None
+    InitialGridPoints: [[7,7]]
+    TimeDependence:
+      UniformTranslation:
+         InitialTime: 0.0
+         InitialExpirationDeltaT: Auto
+         Velocity: [0.5]
+         FunctionOfTimeNames: ["Translation"]
     BoundaryConditions:
-      LowerBoundary:  Periodic
-      UpperBoundary:  Periodic
+      LowerBoundary:  DirichletAnalytic
+      UpperBoundary:  DirichletAnalytic
 
 AnalyticSolution:
   GaugeWave:
-    Amplitude: 0.1
-    Wavelength: 1.0
+    Amplitude: 0.5
+    Wavelength: 6.283185307179586
 
 EvolutionSystem:
   GeneralizedHarmonic:
     DhGaugeParameters:
-      RollOnStartTime: 100000.0
-      RollOnTimeWindow: 100.0
       SpatialDecayWidth: 50.0
-      Amplitudes: [1.0, 1.0, 1.0]
+      Amplitudes: [0.0, 0.0, 0.0]
       Exponents: [4, 4, 4]
     DampingFunctionGamma0:
       GaussianPlusConstant:
@@ -70,7 +74,7 @@ EvolutionSystem:
 SpatialDiscretization:
   DiscontinuousGalerkin:
     Formulation: StrongInertial
-    Quadrature: GaussLobatto
+    Quadrature: Gauss
   BoundaryCorrection:
     UpwindPenalty:
 

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
@@ -41,8 +41,6 @@ AnalyticSolution:
 EvolutionSystem:
   GeneralizedHarmonic:
     DhGaugeParameters:
-      RollOnStartTime: 100000.0
-      RollOnTimeWindow: 100.0
       SpatialDecayWidth: 50.0
       Amplitudes: [1.0, 1.0, 1.0]
       Exponents: [4, 4, 4]

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
@@ -1,0 +1,107 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Executable: EvolveGhGaugeWave3D
+# Check: parse;execute
+# Timeout: 8
+# ExpectedOutput:
+#   GhGaugeWave3DVolume0.h5
+#   GhGaugeWave3DReductions.h5
+
+Evolution:
+  InitialTime: 0.0
+  InitialTimeStep: 0.0002
+  TimeStepper:
+    AdamsBashforthN:
+      Order: 3
+
+PhaseChangeAndTriggers:
+  - - Slabs:
+       EvenlySpaced:
+         # Current implementation checks wallclock at these global syncs
+         Interval: 100
+         Offset: 0
+    - - CheckpointAndExitAfterWallclock:
+          WallclockHours: None
+
+DomainCreator:
+  Brick:
+    LowerBound: [0.0, 0.0, 0.0]
+    UpperBound: [1.0, 1.0, 1.0]
+    InitialRefinement: [1, 1, 1]
+    InitialGridPoints: [5, 5, 5]
+    TimeDependence: None
+    BoundaryCondition: Periodic
+
+AnalyticSolution:
+  GaugeWave:
+    Amplitude: 0.1
+    Wavelength: 1.0
+
+EvolutionSystem:
+  GeneralizedHarmonic:
+    DhGaugeParameters:
+      RollOnStartTime: 100000.0
+      RollOnTimeWindow: 100.0
+      SpatialDecayWidth: 50.0
+      Amplitudes: [1.0, 1.0, 1.0]
+      Exponents: [4, 4, 4]
+    DampingFunctionGamma0:
+      GaussianPlusConstant:
+        Constant: 1.0
+        Amplitude: 0.0
+        Width: 1.0
+        Center: [0.0, 0.0, 0.0]
+    DampingFunctionGamma1:
+      GaussianPlusConstant:
+        Constant: -1.0
+        Amplitude: 0.0
+        Width: 1.0
+        Center: [0.0, 0.0, 0.0]
+    DampingFunctionGamma2:
+      GaussianPlusConstant:
+        Constant: 1.0
+        Amplitude: 0.0
+        Width: 1.0
+        Center: [0.0, 0.0, 0.0]
+
+SpatialDiscretization:
+  DiscontinuousGalerkin:
+    Formulation: StrongInertial
+    Quadrature: GaussLobatto
+  BoundaryCorrection:
+    UpwindPenalty:
+
+EventsAndTriggers:
+  ? Slabs:
+      EvenlySpaced:
+        Interval: 2
+        Offset: 0
+  : - ObserveErrorNorms:
+        SubfileName: Errors
+  ? Slabs:
+      EvenlySpaced:
+        Interval: 5
+        Offset: 0
+  : - ObserveFields:
+        SubfileName: VolumeData
+        VariablesToObserve:
+          - SpacetimeMetric
+          - Pi
+          - Phi
+          - PointwiseL2Norm(GaugeConstraint)
+          - PointwiseL2Norm(ThreeIndexConstraint)
+          - PointwiseL2Norm(FourIndexConstraint)
+        InterpolateToMesh: None
+        CoordinatesFloatingPointType: Double
+        FloatingPointTypes: [Double]
+  ? Slabs:
+      Specified:
+        Values: [2]
+  : - Completion
+
+EventsAndDenseTriggers:
+
+Observers:
+  VolumeFileName: "GhGaugeWave3DVolume"
+  ReductionFileName: "GhGaugeWave3DReductions"


### PR DESCRIPTION
## Proposed changes

- Enable 1D and 2D executables for generalized harmonic 
- Enable moving mesh for GH evolutions without a horizon

### Upgrade instructions

Structs that set up GH executables take extra template arguments for the volume dimension and whether or not the damped harmonic gauge is rolled on.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

To see the 1D gauge wave in action:
- From your spectre build directory copy/link `bin/EvolveGhGaugeWave1D` and `bin/Render1D` into a directory in which you will do the run
- Copy `tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml` into your run directory
-  edit `GaugeWave1D.yaml`, changing the observation Intervals from 2 and 5 to 20 and 50, and the Completion Value from 5 to 5000.
- run  `./EvolveGhGaugeWave1D --input-file GaugeWave.yaml`
- run `./Render1D --file-prefix GhGaugeWave1DVolume --subfile VolumeData --var SpacetimeMetric_xx`
