### PR TITLE
Add action to randomize elliptic initial guess

### DIFF
--- a/src/Elliptic/Actions/CMakeLists.txt
+++ b/src/Elliptic/Actions/CMakeLists.txt
@@ -9,4 +9,5 @@ spectre_target_headers(
   InitializeBackgroundFields.hpp
   InitializeFields.hpp
   InitializeFixedSources.hpp
+  RandomizeInitialGuess.hpp
   )

--- a/src/Elliptic/Actions/RandomizeInitialGuess.hpp
+++ b/src/Elliptic/Actions/RandomizeInitialGuess.hpp
@@ -1,0 +1,126 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <optional>
+#include <pup.h>
+#include <pup_stl.h>
+#include <random>
+#include <string>
+#include <tuple>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Options/Auto.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/PupStlCpp17.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Parallel {
+template <typename Metavariables>
+struct GlobalCache;
+}  // namespace Parallel
+namespace tuples {
+template <typename... Tags>
+struct TaggedTuple;
+}  // namespace tuples
+/// \endcond
+
+namespace elliptic::Actions {
+
+/*!
+ * \brief Optionally add random noise to the initial guess.
+ *
+ * Add this action to the action list just after
+ * `elliptic::Actions::InitializeFields` to add random noise to the initial
+ * guess. The random noise can be toggled and is configurable with input-file
+ * options. A random initial guess can be useful to test the convergence of the
+ * elliptic solver.
+ */
+template <typename System>
+struct RandomizeInitialGuess {
+ private:
+  using fields_tag = ::Tags::Variables<typename System::primal_fields>;
+
+ public:
+  // Bundle the options so they can be placed in Options::Auto
+  struct RandomParameters {
+    struct Amplitude {
+      using type = double;
+      static constexpr Options::String help = "Amplitude of the uniform noise.";
+    };
+    struct Seed {
+      using type = Options::Auto<size_t>;
+      static constexpr Options::String help =
+          "Random seed for the noise generator.";
+    };
+    using options = tmpl::list<Amplitude, Seed>;
+    static constexpr Options::String help = "Parameters for the uniform noise.";
+    void pup(PUP::er& p) noexcept {
+      p | amplitude;
+      p | seed;
+    }
+    double amplitude;
+    std::optional<size_t> seed;
+  };
+
+  struct RandomParametersOptionTag {
+    static std::string name() noexcept { return "RandomizeInitialGuess"; }
+    using type = Options::Auto<RandomParameters, Options::AutoLabel::None>;
+    static constexpr Options::String help =
+        "Add uniform random noise to the initial guess.";
+  };
+
+  struct RandomParametersTag : db::SimpleTag {
+    using type = std::optional<RandomParameters>;
+    using option_tags = tmpl::list<RandomParametersOptionTag>;
+    static constexpr bool pass_metavariables = false;
+    static type create_from_options(const type& value) noexcept {
+      return value;
+    }
+  };
+
+  using const_global_cache_tags = tmpl::list<RandomParametersTag>;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            size_t Dim, typename ActionList, typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ElementId<Dim>& element_id, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    // Retrieve the options
+    const std::optional<RandomParameters>& params =
+        db::get<RandomParametersTag>(box);
+    if (not params.has_value()) {
+      return {std::move(box)};
+    }
+    const auto& [amplitude, seed] = params.value();
+    // Seed a random generator. Include the element ID in the seed so the data
+    // is different on each element.
+    std::seed_seq seeds{std::hash<ElementId<Dim>>{}(element_id),
+                        seed.value_or(std::random_device{}())};
+    std::mt19937 generator{seeds};
+    // Set up the random distribution
+    std::uniform_real_distribution<> dist(-amplitude, amplitude);
+    // Add noise to the fields
+    db::mutate<fields_tag>(make_not_null(&box),
+                           [&generator, &dist](const auto fields) noexcept {
+                             for (size_t i = 0; i < fields->size(); ++i) {
+                               fields->data()[i] += dist(generator);
+                             }
+                           });
+    return {std::move(box)};
+  }
+};
+
+}  // namespace elliptic::Actions

--- a/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
@@ -14,6 +14,7 @@
 #include "Elliptic/Actions/InitializeAnalyticSolution.hpp"
 #include "Elliptic/Actions/InitializeFields.hpp"
 #include "Elliptic/Actions/InitializeFixedSources.hpp"
+#include "Elliptic/Actions/RandomizeInitialGuess.hpp"
 #include "Elliptic/DiscontinuousGalerkin/Actions/ApplyOperator.hpp"
 #include "Elliptic/DiscontinuousGalerkin/Actions/InitializeDomain.hpp"
 #include "Elliptic/DiscontinuousGalerkin/DgElementArray.hpp"
@@ -206,6 +207,7 @@ struct Metavariables {
       typename multigrid::initialize_element,
       typename schwarz_smoother::initialize_element,
       elliptic::Actions::InitializeFields<system, initial_guess_tag>,
+      elliptic::Actions::RandomizeInitialGuess<system>,
       elliptic::Actions::InitializeFixedSources<system, analytic_solution_tag>,
       elliptic::Actions::InitializeAnalyticSolution<
           analytic_solution_tag, tmpl::append<typename system::primal_fields,

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -20,6 +20,8 @@ Background:
 InitialGuess:
   Zero:
 
+RandomizeInitialGuess: None
+
 DomainCreator:
   Interval:
     LowerBound: [-1.570796326794896]

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -20,6 +20,8 @@ Background:
 InitialGuess:
   Zero:
 
+RandomizeInitialGuess: None
+
 DomainCreator:
   Rectangle:
     LowerBound: [-1.570796326794896, 0.]

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -21,6 +21,8 @@ Background:
 InitialGuess:
   Zero:
 
+RandomizeInitialGuess: None
+
 DomainCreator:
   Brick:
     LowerBound: [-1.570796326794896, 0., 0.]

--- a/tests/Unit/Elliptic/Actions/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Actions/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_InitializeBackgroundFields.cpp
   Test_InitializeFields.cpp
   Test_InitializeFixedSources.cpp
+  Test_RandomizeInitialGuess.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Elliptic/Actions/Test_RandomizeInitialGuess.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_RandomizeInitialGuess.cpp
@@ -1,0 +1,108 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <optional>
+#include <random>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/SegmentId.hpp"
+#include "Domain/Tags.hpp"
+#include "Elliptic/Actions/RandomizeInitialGuess.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+
+struct ScalarFieldTag : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+struct System {
+  using primal_fields = tmpl::list<ScalarFieldTag>;
+};
+
+template <typename Metavariables>
+struct ElementArray {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementId<1>;
+  using const_global_cache_tags = tmpl::list<>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          tmpl::list<ActionTesting::InitializeDataBox<
+              tmpl::list<::Tags::Variables<tmpl::list<ScalarFieldTag>>>>>>,
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          tmpl::list<elliptic::Actions::RandomizeInitialGuess<
+              typename Metavariables::system>>>>;
+};
+
+struct Metavariables {
+  using system = System;
+  using component_list = tmpl::list<ElementArray<Metavariables>>;
+  using const_global_cache_tags = tmpl::list<>;
+  enum class Phase { Initialization, Testing, Exit };
+};
+
+void test_randomize_initial_guess(
+    std::optional<typename elliptic::Actions::RandomizeInitialGuess<
+        System>::RandomParameters>
+        params) {
+  const DataVector used_for_size{5};
+
+  // Which element we work with does not matter for this test
+  const ElementId<1> element_id{0, {{SegmentId{2, 1}}}};
+  // Generate some random field data
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<double> dist(-1., 1.);
+  const auto fields =
+      make_with_random_values<Variables<tmpl::list<ScalarFieldTag>>>(
+          make_not_null(&generator), make_not_null(&dist), used_for_size);
+
+  using element_array = ElementArray<Metavariables>;
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{{params}};
+  ActionTesting::emplace_component_and_initialize<element_array>(
+      &runner, element_id, {fields});
+  ActionTesting::set_phase(make_not_null(&runner),
+                           Metavariables::Phase::Testing);
+  ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
+  const auto get_tag = [&runner, &element_id ](auto tag_v) -> const auto& {
+    using tag = std::decay_t<decltype(tag_v)>;
+    return ActionTesting::get_databox_tag<element_array, tag>(runner,
+                                                              element_id);
+  };
+
+  const DataVector& fields_randomized = get(get_tag(ScalarFieldTag{}));
+  const DataVector& fields_original = get(get<ScalarFieldTag>(fields));
+  if (params.has_value()) {
+    // Test that the fields have changed, but differ only by the `amplitude`
+    CHECK(fields_randomized != fields_original);
+    for (size_t i = 0; i < fields.size(); ++i) {
+      CHECK(abs(fields_randomized[i] - fields_original[i]) <=
+            params.value().amplitude);
+    }
+  } else {
+    CHECK(fields_randomized == fields_original);
+  }
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Elliptic.Actions.RandomizeInitialGuess",
+                  "[Unit][Elliptic][Actions]") {
+  test_randomize_initial_guess({{1.e-2, std::nullopt}});
+  test_randomize_initial_guess(std::nullopt);
+}


### PR DESCRIPTION
## Proposed changes

Add an action that adds random noise to the initial guess for elliptic solves. The random noise can be toggled and is configurable with input-file options. It is useful to test the convergence of the elliptic solver.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
