### PR TITLE
Add is_nan function that doesn't raise FPEs

### DIFF
--- a/src/Domain/CoordinateMaps/CoordinateMapHelpers.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMapHelpers.hpp
@@ -46,7 +46,8 @@ void apply_map(
     /*is_time_dependent*/) {
   ASSERT(not functions_of_time.empty(),
          "A function of time must be present if the maps are time-dependent.");
-  ASSERT(not is_nan(t), "The time must not be NaN for time-dependent maps.");
+  ASSERT(not isnan_safe(t),
+         "The time must not be NaN for time-dependent maps.");
   *t_map_point = the_map(*t_map_point, t, functions_of_time);
 }
 
@@ -82,7 +83,8 @@ auto apply_map(
   // to the coordinate map.
   ASSERT(not functions_of_time.empty(),
          "A function of time must be present if the maps are time-dependent.");
-  ASSERT(not is_nan(t), "The time must not be NaN for time-dependent maps.");
+  ASSERT(not isnan_safe(t),
+         "The time must not be NaN for time-dependent maps.");
   return the_map(source_points, t, functions_of_time);
 }
 /// @}
@@ -118,7 +120,8 @@ auto apply_inverse_map(
     /*is_time_dependent*/) {
   ASSERT(not functions_of_time.empty(),
          "A function of time must be present if the maps are time-dependent.");
-  ASSERT(not is_nan(t), "The time must not be NaN for time-dependent maps.");
+  ASSERT(not isnan_safe(t),
+         "The time must not be NaN for time-dependent maps.");
   return the_map.inverse(target_points, t, functions_of_time);
 }
 /// @}
@@ -148,7 +151,8 @@ auto apply_frame_velocity(
     /*is_time_dependent*/) {
   ASSERT(not functions_of_time.empty(),
          "A function of time must be present if the maps are time-dependent.");
-  ASSERT(not is_nan(t), "The time must not be NaN for time-dependent maps.");
+  ASSERT(not isnan_safe(t),
+         "The time must not be NaN for time-dependent maps.");
   return the_map.frame_velocity(source_points, t, functions_of_time);
 }
 /// @}
@@ -179,7 +183,8 @@ auto apply_jacobian(
     /*is_time_dependent*/) {
   ASSERT(not functions_of_time.empty(),
          "A function of time must be present if the maps are time-dependent.");
-  ASSERT(not is_nan(t), "The time must not be NaN for time-dependent maps.");
+  ASSERT(not isnan_safe(t),
+         "The time must not be NaN for time-dependent maps.");
   if (LIKELY(not the_map.is_identity())) {
     return the_map.jacobian(source_points, t, functions_of_time);
   }
@@ -213,7 +218,8 @@ auto apply_inverse_jacobian(
     /*is_time_dependent*/) {
   ASSERT(not functions_of_time.empty(),
          "A function of time must be present if the maps are time-dependent.");
-  ASSERT(not is_nan(t), "The time must not be NaN for time-dependent maps.");
+  ASSERT(not isnan_safe(t),
+         "The time must not be NaN for time-dependent maps.");
   if (LIKELY(not the_map.is_identity())) {
     return the_map.inv_jacobian(source_points, t, functions_of_time);
   }

--- a/src/Domain/CoordinateMaps/CoordinateMapHelpers.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMapHelpers.hpp
@@ -13,8 +13,8 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Utilities/DereferenceWrapper.hpp"
-#include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/IsNan.hpp"
 #include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
 
 namespace domain {
@@ -46,14 +46,7 @@ void apply_map(
     /*is_time_dependent*/) {
   ASSERT(not functions_of_time.empty(),
          "A function of time must be present if the maps are time-dependent.");
-  ASSERT(
-      [t]() {
-        disable_floating_point_exceptions();
-        const bool isnan = std::isnan(t);
-        enable_floating_point_exceptions();
-        return not isnan;
-      }(),
-      "The time must not be NaN for time-dependent maps.");
+  ASSERT(not is_nan(t), "The time must not be NaN for time-dependent maps.");
   *t_map_point = the_map(*t_map_point, t, functions_of_time);
 }
 
@@ -89,14 +82,7 @@ auto apply_map(
   // to the coordinate map.
   ASSERT(not functions_of_time.empty(),
          "A function of time must be present if the maps are time-dependent.");
-  ASSERT(
-      [t]() {
-        disable_floating_point_exceptions();
-        const bool isnan = std::isnan(t);
-        enable_floating_point_exceptions();
-        return not isnan;
-      }(),
-      "The time must not be NaN for time-dependent maps.");
+  ASSERT(not is_nan(t), "The time must not be NaN for time-dependent maps.");
   return the_map(source_points, t, functions_of_time);
 }
 /// @}
@@ -132,14 +118,7 @@ auto apply_inverse_map(
     /*is_time_dependent*/) {
   ASSERT(not functions_of_time.empty(),
          "A function of time must be present if the maps are time-dependent.");
-  ASSERT(
-      [t]() {
-        disable_floating_point_exceptions();
-        const bool isnan = std::isnan(t);
-        enable_floating_point_exceptions();
-        return not isnan;
-      }(),
-      "The time must not be NaN for time-dependent maps.");
+  ASSERT(not is_nan(t), "The time must not be NaN for time-dependent maps.");
   return the_map.inverse(target_points, t, functions_of_time);
 }
 /// @}
@@ -169,14 +148,7 @@ auto apply_frame_velocity(
     /*is_time_dependent*/) {
   ASSERT(not functions_of_time.empty(),
          "A function of time must be present if the maps are time-dependent.");
-  ASSERT(
-      [t]() {
-        disable_floating_point_exceptions();
-        const bool isnan = std::isnan(t);
-        enable_floating_point_exceptions();
-        return not isnan;
-      }(),
-      "The time must not be NaN for time-dependent maps.");
+  ASSERT(not is_nan(t), "The time must not be NaN for time-dependent maps.");
   return the_map.frame_velocity(source_points, t, functions_of_time);
 }
 /// @}
@@ -207,14 +179,7 @@ auto apply_jacobian(
     /*is_time_dependent*/) {
   ASSERT(not functions_of_time.empty(),
          "A function of time must be present if the maps are time-dependent.");
-  ASSERT(
-      [t]() {
-        disable_floating_point_exceptions();
-        const bool isnan = std::isnan(t);
-        enable_floating_point_exceptions();
-        return not isnan;
-      }(),
-      "The time must not be NaN for time-dependent maps.");
+  ASSERT(not is_nan(t), "The time must not be NaN for time-dependent maps.");
   if (LIKELY(not the_map.is_identity())) {
     return the_map.jacobian(source_points, t, functions_of_time);
   }
@@ -248,14 +213,7 @@ auto apply_inverse_jacobian(
     /*is_time_dependent*/) {
   ASSERT(not functions_of_time.empty(),
          "A function of time must be present if the maps are time-dependent.");
-  ASSERT(
-      [t]() {
-        disable_floating_point_exceptions();
-        const bool isnan = std::isnan(t);
-        enable_floating_point_exceptions();
-        return not isnan;
-      }(),
-      "The time must not be NaN for time-dependent maps.");
+  ASSERT(not is_nan(t), "The time must not be NaN for time-dependent maps.");
   if (LIKELY(not the_map.is_identity())) {
     return the_map.inv_jacobian(source_points, t, functions_of_time);
   }

--- a/src/ParallelAlgorithms/Interpolation/Targets/ApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Targets/ApparentHorizon.hpp
@@ -173,8 +173,7 @@ struct ApparentHorizon : tt::ConformsTo<intrp::protocols::ComputeTargetPoints> {
     // is initialized to (time=NaN, strahlkorper=options.initial_guess).
     // The NaN is a sentinel value which indicates that the
     // PreviousStrahlkorper has not been computed but is instead the
-    // supplied initial guess.  Note that the NaN must be quiet_NaN,
-    // so we can test for it later without generating an FPE.
+    // supplied initial guess.
     //
     // Note that if frame is not inertial,
     // StrahlkorperTags::Strahlkorper<::Frame::Inertial> is already
@@ -183,7 +182,8 @@ struct ApparentHorizon : tt::ConformsTo<intrp::protocols::ComputeTargetPoints> {
     Initialization::mutate_assign<common_tags>(
         box, options.initial_guess, options.fast_flow, options.verbosity,
         std::deque<std::pair<double, ::Strahlkorper<Frame>>>{std::make_pair(
-            std::numeric_limits<double>::quiet_NaN(), options.initial_guess)});
+            std::numeric_limits<double>::signaling_NaN(),
+            options.initial_guess)});
   }
 
   template <typename Metavariables, typename DbTags, typename TemporalId>

--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_sources(
   Blas.cpp
   FileSystem.cpp
   Formaline.cpp
+  IsNan.cpp
   MemoryHelpers.cpp
   OptimizerHacks.cpp
   PrettyType.cpp
@@ -40,6 +41,7 @@ spectre_target_headers(
   GenerateInstantiations.hpp
   GetOutput.hpp
   Gsl.hpp
+  IsNan.hpp
   Literals.hpp
   MakeArray.hpp
   MakeSignalingNan.hpp

--- a/src/Utilities/IsNan.cpp
+++ b/src/Utilities/IsNan.cpp
@@ -7,10 +7,10 @@
 
 #include "ErrorHandling/FloatingPointExceptions.hpp"
 
-bool is_nan(const double arg) {
+bool isnan_safe(const double arg) {
   disable_floating_point_exceptions();
 #if defined(__clang__) && __clang__ < 10
-  // Old versions of clang still throw FPEs here, so prevent then from
+  // Old versions of clang still throw FPEs here, so prevent them from
   // reordering statements.
   asm("");
 #endif  /* defined(__clang__) && __clang__ < 10 */
@@ -22,10 +22,10 @@ bool is_nan(const double arg) {
   return result;
 }
 
-bool is_nan(const float arg) {
+bool isnan_safe(const float arg) {
   disable_floating_point_exceptions();
 #if defined(__clang__) && __clang__ < 10
-  // Old versions of clang still throw FPEs here, so prevent then from
+  // Old versions of clang still throw FPEs here, so prevent them from
   // reordering statements.
   asm("");
 #endif  /* defined(__clang__) && __clang__ < 10 */

--- a/src/Utilities/IsNan.cpp
+++ b/src/Utilities/IsNan.cpp
@@ -1,0 +1,38 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Utilities/IsNan.hpp"
+
+#include <cmath>
+
+#include "ErrorHandling/FloatingPointExceptions.hpp"
+
+bool is_nan(const double arg) {
+  disable_floating_point_exceptions();
+#if defined(__clang__) && __clang__ < 10
+  // Old versions of clang still throw FPEs here, so prevent then from
+  // reordering statements.
+  asm("");
+#endif  /* defined(__clang__) && __clang__ < 10 */
+  const bool result = std::isnan(arg);
+#if defined(__clang__) && __clang__ < 10
+  asm("");
+#endif  /* defined(__clang__) && __clang__ < 10 */
+  enable_floating_point_exceptions();
+  return result;
+}
+
+bool is_nan(const float arg) {
+  disable_floating_point_exceptions();
+#if defined(__clang__) && __clang__ < 10
+  // Old versions of clang still throw FPEs here, so prevent then from
+  // reordering statements.
+  asm("");
+#endif  /* defined(__clang__) && __clang__ < 10 */
+  const bool result = std::isnan(arg);
+#if defined(__clang__) && __clang__ < 10
+  asm("");
+#endif  /* defined(__clang__) && __clang__ < 10 */
+  enable_floating_point_exceptions();
+  return result;
+}

--- a/src/Utilities/IsNan.cpp
+++ b/src/Utilities/IsNan.cpp
@@ -8,31 +8,31 @@
 #include "ErrorHandling/FloatingPointExceptions.hpp"
 
 bool isnan_safe(const double arg) {
-  disable_floating_point_exceptions();
+  //disable_floating_point_exceptions();
 #if defined(__clang__) && __clang__ < 10
   // Old versions of clang still throw FPEs here, so prevent them from
   // reordering statements.
-  asm("");
+  //asm("");
 #endif  /* defined(__clang__) && __clang__ < 10 */
   const bool result = std::isnan(arg);
 #if defined(__clang__) && __clang__ < 10
-  asm("");
+  //asm("");
 #endif  /* defined(__clang__) && __clang__ < 10 */
-  enable_floating_point_exceptions();
+  //enable_floating_point_exceptions();
   return result;
 }
 
 bool isnan_safe(const float arg) {
-  disable_floating_point_exceptions();
+  //disable_floating_point_exceptions();
 #if defined(__clang__) && __clang__ < 10
   // Old versions of clang still throw FPEs here, so prevent them from
   // reordering statements.
-  asm("");
+  //asm("");
 #endif  /* defined(__clang__) && __clang__ < 10 */
   const bool result = std::isnan(arg);
 #if defined(__clang__) && __clang__ < 10
-  asm("");
+  //asm("");
 #endif  /* defined(__clang__) && __clang__ < 10 */
-  enable_floating_point_exceptions();
+  //enable_floating_point_exceptions();
   return result;
 }

--- a/src/Utilities/IsNan.hpp
+++ b/src/Utilities/IsNan.hpp
@@ -1,0 +1,12 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+/// \ingroup UtilitiesGroup
+/// Check whether the argument is a NaN.  This performs the same test
+/// as std::isnan, but never raises a floating point exception.
+/// @{
+bool is_nan(double arg);
+bool is_nan(float arg);
+/// @}

--- a/src/Utilities/IsNan.hpp
+++ b/src/Utilities/IsNan.hpp
@@ -7,6 +7,6 @@
 /// Check whether the argument is a NaN.  This performs the same test
 /// as std::isnan, but never raises a floating point exception.
 /// @{
-bool is_nan(double arg);
-bool is_nan(float arg);
+bool isnan_safe(double arg);
+bool isnan_safe(float arg);
 /// @}

--- a/tests/Unit/Utilities/CMakeLists.txt
+++ b/tests/Unit/Utilities/CMakeLists.txt
@@ -20,6 +20,7 @@ set(LIBRARY_SOURCES
   Test_Functional.cpp
   Test_GetOutput.cpp
   Test_Gsl.cpp
+  Test_IsNan.cpp
   Test_MakeArray.cpp
   Test_MakeSignalingNan.cpp
   Test_MakeString.cpp

--- a/tests/Unit/Utilities/Test_IsNan.cpp
+++ b/tests/Unit/Utilities/Test_IsNan.cpp
@@ -1,0 +1,15 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <limits>
+
+#include "Utilities/IsNan.hpp"
+
+SPECTRE_TEST_CASE("Unit.Utilities.IsNan", "[Unit][Utilities]") {
+  CHECK_FALSE(is_nan(0.));
+  CHECK_FALSE(is_nan(0.f));
+  CHECK(is_nan(std::numeric_limits<double>::signaling_NaN()));
+  CHECK(is_nan(std::numeric_limits<float>::signaling_NaN()));
+}

--- a/tests/Unit/Utilities/Test_IsNan.cpp
+++ b/tests/Unit/Utilities/Test_IsNan.cpp
@@ -8,8 +8,10 @@
 #include "Utilities/IsNan.hpp"
 
 SPECTRE_TEST_CASE("Unit.Utilities.IsNan", "[Unit][Utilities]") {
-  CHECK_FALSE(is_nan(0.));
-  CHECK_FALSE(is_nan(0.f));
-  CHECK(is_nan(std::numeric_limits<double>::signaling_NaN()));
-  CHECK(is_nan(std::numeric_limits<float>::signaling_NaN()));
+  CHECK_FALSE(isnan_safe(0.));
+  CHECK_FALSE(isnan_safe(0.f));
+  CHECK(isnan_safe(std::numeric_limits<double>::signaling_NaN()));
+  CHECK(isnan_safe(std::numeric_limits<float>::signaling_NaN()));
+  CHECK(isnan_safe(std::numeric_limits<double>::quiet_NaN()));
+  CHECK(isnan_safe(std::numeric_limits<float>::quiet_NaN()));
 }

--- a/tests/Unit/Utilities/Test_MakeSignalingNan.cpp
+++ b/tests/Unit/Utilities/Test_MakeSignalingNan.cpp
@@ -3,20 +3,17 @@
 
 #include "Framework/TestingFramework.hpp"
 
-#include <cmath>
 #include <complex>
 
-#include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/IsNan.hpp"
 #include "Utilities/MakeSignalingNan.hpp"
 
 SPECTRE_TEST_CASE("Unit.Utilities.MakeSignalingNaN", "[Unit][Utilities]") {
-  disable_floating_point_exceptions();
   const auto double_snan = make_signaling_NaN<double>();
-  CHECK(std::isnan(double_snan));
+  CHECK(is_nan(double_snan));
   const auto float_snan = make_signaling_NaN<float>();
-  CHECK(std::isnan(float_snan));
+  CHECK(is_nan(float_snan));
   const auto complex_snan = make_signaling_NaN<std::complex<double>>();
-  CHECK(std::isnan(complex_snan.real()));
-  CHECK(std::isnan(complex_snan.imag()));
-  enable_floating_point_exceptions();
+  CHECK(is_nan(complex_snan.real()));
+  CHECK(is_nan(complex_snan.imag()));
 }

--- a/tests/Unit/Utilities/Test_MakeSignalingNan.cpp
+++ b/tests/Unit/Utilities/Test_MakeSignalingNan.cpp
@@ -10,10 +10,10 @@
 
 SPECTRE_TEST_CASE("Unit.Utilities.MakeSignalingNaN", "[Unit][Utilities]") {
   const auto double_snan = make_signaling_NaN<double>();
-  CHECK(is_nan(double_snan));
+  CHECK(isnan_safe(double_snan));
   const auto float_snan = make_signaling_NaN<float>();
-  CHECK(is_nan(float_snan));
+  CHECK(isnan_safe(float_snan));
   const auto complex_snan = make_signaling_NaN<std::complex<double>>();
-  CHECK(is_nan(complex_snan.real()));
-  CHECK(is_nan(complex_snan.imag()));
+  CHECK(isnan_safe(complex_snan.real()));
+  CHECK(isnan_safe(complex_snan.imag()));
 }


### PR DESCRIPTION
std::isnan can throw an FPE.  I don't think it's supposed to do that,
but we have to live with the behavior whether it is correct or not.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
