### PR TITLE
Fix order of multigrid actions in XCTS executable

### DIFF
--- a/src/Elliptic/Executables/Xcts/SolveXcts.hpp
+++ b/src/Elliptic/Executables/Xcts/SolveXcts.hpp
@@ -267,12 +267,12 @@ struct Metavariables {
       typename nonlinear_solver::template solve<
           build_operator_actions<false>,
           tmpl::list<
-              LinearSolver::multigrid::Actions::SendFieldsToCoarserGrid<
-                  tmpl::list<fields_tag, fluxes_tag>,
-                  typename multigrid::options_group, void>,
               LinearSolver::multigrid::Actions::ReceiveFieldsFromFinerGrid<
                   volume_dim, tmpl::list<fields_tag, fluxes_tag>,
                   typename multigrid::options_group>,
+              LinearSolver::multigrid::Actions::SendFieldsToCoarserGrid<
+                  tmpl::list<fields_tag, fluxes_tag>,
+                  typename multigrid::options_group, void>,
               LinearSolver::Schwarz::Actions::SendOverlapFields<
                   communicated_overlap_tags,
                   typename schwarz_smoother::options_group, false>,


### PR DESCRIPTION
## Proposed changes

This bug wasn't caught on CI because the test input file has no refinement, because the `Shell` domain creator doesn't support anisotropic refinement yet and isotropic refinement is too high-resolution for the test to run fast enough.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
