### PR TITLE
Add previous trigger time to dense triggers

### DIFF
--- a/src/Evolution/Actions/RunEventsAndDenseTriggers.hpp
+++ b/src/Evolution/Actions/RunEventsAndDenseTriggers.hpp
@@ -12,6 +12,7 @@
 #include "Evolution/EventsAndDenseTriggers/EventsAndDenseTriggers.hpp"
 #include "Evolution/EventsAndDenseTriggers/Tags.hpp"
 #include "Parallel/AlgorithmMetafunctions.hpp"
+#include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "Time/EvolutionOrdering.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
@@ -199,6 +200,7 @@ struct InitializeRunEventsAndDenseTriggers {
   using initialization_tags =
       tmpl::list<evolution::Tags::EventsAndDenseTriggers>;
   using initialization_tags_to_keep = initialization_tags;
+  using simple_tags = tmpl::list<Tags::PreviousTriggerTime>;
 
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
@@ -209,6 +211,8 @@ struct InitializeRunEventsAndDenseTriggers {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*component*/) noexcept {
+    Initialization::mutate_assign<simple_tags>(make_not_null(&box),
+                                               std::nullopt);
     return std::forward_as_tuple(std::move(box));
   }
 };

--- a/tests/Unit/Evolution/Actions/Test_RunEventsAndDenseTriggers.cpp
+++ b/tests/Unit/Evolution/Actions/Test_RunEventsAndDenseTriggers.cpp
@@ -252,7 +252,8 @@ struct Component {
   // only accesses it when it should.
   using primitives_tag = Tags::Variables<tmpl::list<PrimVar>>;
   using initialization_tags = tmpl::append<
-      tmpl::list<Tags::TimeStepId, Tags::TimeStep, Tags::Time, variables_tag,
+      tmpl::list<Tags::TimeStepId, Tags::TimeStep, Tags::Time,
+                 evolution::Tags::PreviousTriggerTime, variables_tag,
                  primitives_tag, Tags::HistoryEvolvedVariables<variables_tag>,
                  evolution::Tags::EventsAndDenseTriggers>,
       tmpl::conditional_t<
@@ -382,8 +383,8 @@ void test(const bool time_runs_forward) noexcept {
 
         ActionTesting::emplace_array_component<component>(
             runner, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{0}, 0,
-            time_step_id, exact_step_size, start_time, initial_vars,
-            unset_primitives, std::move(history),
+            time_step_id, exact_step_size, start_time, std::optional<double>{},
+            initial_vars, unset_primitives, std::move(history),
             evolution::EventsAndDenseTriggers(
                 std::move(events_and_dense_triggers)));
         ActionTesting::set_phase(runner, metavars::Phase::Testing);
@@ -593,8 +594,8 @@ void test_lts(const bool time_runs_forward) noexcept {
 
         ActionTesting::emplace_array_component<component>(
             runner, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{0}, 0,
-            time_step_id, exact_step_size, start_time, initial_vars,
-            unset_primitives, std::move(history),
+            time_step_id, exact_step_size, start_time, std::optional<double>{},
+            initial_vars, unset_primitives, std::move(history),
             evolution::EventsAndDenseTriggers(
                 std::move(events_and_dense_triggers)),
             mesh,

--- a/tests/Unit/Evolution/EventsAndDenseTriggers/DenseTriggers/Test_Filter.cpp
+++ b/tests/Unit/Evolution/EventsAndDenseTriggers/DenseTriggers/Test_Filter.cpp
@@ -94,9 +94,9 @@ void check(const bool expected_is_ready,
                   << "    TestTrigger:\n"
                   << "      Result: " << non_dense_is_triggered;
   CAPTURE(creation_string.str());
-  const auto box = db::create<
-      db::AddSimpleTags<Parallel::Tags::MetavariablesImpl<Metavariables>>>(
-      Metavariables{});
+  const auto box = db::create<db::AddSimpleTags<
+      Parallel::Tags::MetavariablesImpl<Metavariables>, ::Tags::Time>>(
+      Metavariables{}, 0.0);
   Parallel::GlobalCache<Metavariables> cache{};
   const int array_index = 0;
   const void* component = nullptr;

--- a/tests/Unit/Evolution/EventsAndDenseTriggers/DenseTriggers/Test_Or.cpp
+++ b/tests/Unit/Evolution/EventsAndDenseTriggers/DenseTriggers/Test_Or.cpp
@@ -43,10 +43,11 @@ void check(const bool time_runs_forward, const bool expected_is_ready,
            const bool expected_is_triggered, const double expected_next_check,
            const std::string& creation_string) noexcept {
   CAPTURE(creation_string);
-  const auto box = db::create<db::AddSimpleTags<
-      Parallel::Tags::MetavariablesImpl<Metavariables>, Tags::TimeStepId>>(
-      Metavariables{},
-      TimeStepId(time_runs_forward, 0, Slab(0.0, 1.0).start()));
+  const auto box = db::create<
+      db::AddSimpleTags<Parallel::Tags::MetavariablesImpl<Metavariables>,
+                        Tags::TimeStepId, Tags::Time>>(
+      Metavariables{}, TimeStepId(time_runs_forward, 0, Slab(0.0, 1.0).start()),
+      0.0);
   Parallel::GlobalCache<Metavariables> cache{};
   const int array_index = 0;
   const void* component = nullptr;

--- a/tests/Unit/Helpers/Evolution/EventsAndDenseTriggers/DenseTriggers/TestTrigger.hpp
+++ b/tests/Unit/Helpers/Evolution/EventsAndDenseTriggers/DenseTriggers/TestTrigger.hpp
@@ -130,6 +130,7 @@ class BoxTrigger : public DenseTrigger {
                 const bool is_ready_arg) const noexcept {
     return is_ready_arg;
   }
+  void pup(PUP::er& p) noexcept { DenseTrigger::pup(p); }
 };
 
 /// \cond


### PR DESCRIPTION
## Proposed changes

Make available the previous time a trigger has fired, and store in the `DataBox` when each event is called, so that events may make use of the previous time without altering the events interface

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

This is required for the CCE-GH executable to enforce strict ordering of GH data as discussed in #3422 