### PR TITLE
Add elliptic HasConverged trigger

### DIFF
--- a/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
+++ b/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
@@ -24,7 +24,7 @@
 #include "Elliptic/Systems/Elasticity/FirstOrderSystem.hpp"
 #include "Elliptic/Systems/Elasticity/Tags.hpp"
 #include "Elliptic/Tags.hpp"
-#include "Elliptic/Triggers/EveryNIterations.hpp"
+#include "Elliptic/Triggers/Factory.hpp"
 #include "IO/Observer/Actions/RegisterEvents.hpp"
 #include "IO/Observer/Helpers.hpp"
 #include "IO/Observer/ObserverComponent.hpp"
@@ -45,7 +45,6 @@
 #include "ParallelAlgorithms/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Completion.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
-#include "ParallelAlgorithms/EventsAndTriggers/LogicalTriggers.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Tags.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Trigger.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/AddComputeTags.hpp"
@@ -205,10 +204,8 @@ struct Metavariables {
                            tmpl::list<Elasticity::Tags::PotentialEnergyDensity<
                                volume_dim>>,
                            LinearSolver::multigrid::Tags::IsFinestGrid>>>>,
-        tmpl::pair<Trigger,
-                   tmpl::push_back<Triggers::logical_triggers,
-                                   elliptic::Triggers::EveryNIterations<
-                                       linear_solver_iteration_id>>>>;
+        tmpl::pair<Trigger, elliptic::Triggers::all_triggers<
+                                typename linear_solver::options_group>>>;
   };
 
   // Collect all reduction tags for observers

--- a/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
@@ -21,7 +21,7 @@
 #include "Elliptic/DiscontinuousGalerkin/SubdomainOperator/SubdomainOperator.hpp"
 #include "Elliptic/Systems/Poisson/FirstOrderSystem.hpp"
 #include "Elliptic/Tags.hpp"
-#include "Elliptic/Triggers/EveryNIterations.hpp"
+#include "Elliptic/Triggers/Factory.hpp"
 #include "IO/Observer/Actions/RegisterEvents.hpp"
 #include "IO/Observer/Helpers.hpp"
 #include "IO/Observer/ObserverComponent.hpp"
@@ -39,7 +39,6 @@
 #include "ParallelAlgorithms/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Completion.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
-#include "ParallelAlgorithms/EventsAndTriggers/LogicalTriggers.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Tags.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Trigger.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
@@ -187,10 +186,8 @@ struct Metavariables {
                            volume_dim, linear_solver_iteration_id,
                            observe_fields, analytic_solution_fields,
                            LinearSolver::multigrid::Tags::IsFinestGrid>>>>,
-        tmpl::pair<Trigger,
-                   tmpl::push_back<Triggers::logical_triggers,
-                                   elliptic::Triggers::EveryNIterations<
-                                       linear_solver_iteration_id>>>>;
+        tmpl::pair<Trigger, elliptic::Triggers::all_triggers<
+                                typename linear_solver::options_group>>>;
   };
 
   // Collect all reduction tags for observers

--- a/src/Elliptic/Executables/Xcts/SolveXcts.hpp
+++ b/src/Elliptic/Executables/Xcts/SolveXcts.hpp
@@ -21,7 +21,7 @@
 #include "Elliptic/SubdomainPreconditioners/RegisterDerived.hpp"
 #include "Elliptic/Systems/Xcts/FirstOrderSystem.hpp"
 #include "Elliptic/Tags.hpp"
-#include "Elliptic/Triggers/EveryNIterations.hpp"
+#include "Elliptic/Triggers/Factory.hpp"
 #include "IO/Observer/Actions/RegisterEvents.hpp"
 #include "IO/Observer/Helpers.hpp"
 #include "IO/Observer/ObserverComponent.hpp"
@@ -39,7 +39,6 @@
 #include "ParallelAlgorithms/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Completion.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
-#include "ParallelAlgorithms/EventsAndTriggers/LogicalTriggers.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Tags.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Trigger.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/AddComputeTags.hpp"
@@ -208,10 +207,8 @@ struct Metavariables {
                            volume_dim, nonlinear_solver_iteration_id,
                            observe_fields, analytic_solution_fields,
                            LinearSolver::multigrid::Tags::IsFinestGrid>>>>,
-        tmpl::pair<Trigger,
-                   tmpl::push_back<Triggers::logical_triggers,
-                                   elliptic::Triggers::EveryNIterations<
-                                       nonlinear_solver_iteration_id>>>>;
+        tmpl::pair<Trigger, elliptic::Triggers::all_triggers<
+                                typename nonlinear_solver::options_group>>>;
   };
 
   // Collect all reduction tags for observers

--- a/src/Elliptic/Triggers/CMakeLists.txt
+++ b/src/Elliptic/Triggers/CMakeLists.txt
@@ -6,4 +6,5 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   EveryNIterations.hpp
+  HasConverged.hpp
   )

--- a/src/Elliptic/Triggers/CMakeLists.txt
+++ b/src/Elliptic/Triggers/CMakeLists.txt
@@ -6,5 +6,6 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   EveryNIterations.hpp
+  Factory.hpp
   HasConverged.hpp
   )

--- a/src/Elliptic/Triggers/EveryNIterations.hpp
+++ b/src/Elliptic/Triggers/EveryNIterations.hpp
@@ -6,16 +6,17 @@
 #include <cstdint>
 #include <pup.h>
 
+#include "NumericalAlgorithms/Convergence/Tags.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Trigger.hpp"
 #include "Utilities/TMPL.hpp"
 
-namespace elliptic {
-namespace Triggers {
+namespace elliptic::Triggers {
 /// \ingroup EventsAndTriggersGroup
-/// Trigger every N iterations after a given offset.
-template <typename IterationId>
+/// Trigger every N iterations of the solver identifid by the `Label`, after a
+/// given offset.
+template <typename Label>
 class EveryNIterations : public Trigger {
  public:
   /// \cond
@@ -42,10 +43,9 @@ class EveryNIterations : public Trigger {
   EveryNIterations(const uint64_t interval, const uint64_t offset) noexcept
       : interval_(interval), offset_(offset) {}
 
-  using argument_tags = tmpl::list<IterationId>;
+  using argument_tags = tmpl::list<Convergence::Tags::IterationId<Label>>;
 
-  bool operator()(const typename IterationId::type& iteration_id) const
-      noexcept {
+  bool operator()(const size_t iteration_id) const noexcept {
     const auto step_number = static_cast<uint64_t>(iteration_id);
     return step_number >= offset_ and (step_number - offset_) % interval_ == 0;
   }
@@ -62,8 +62,7 @@ class EveryNIterations : public Trigger {
 };
 
 /// \cond
-template <typename IterationId>
-PUP::able::PUP_ID EveryNIterations<IterationId>::my_PUP_ID = 0;  // NOLINT
+template <typename Label>
+PUP::able::PUP_ID EveryNIterations<Label>::my_PUP_ID = 0;  // NOLINT
 /// \endcond
-}  // namespace Triggers
-}  // namespace elliptic
+}  // namespace elliptic::Triggers

--- a/src/Elliptic/Triggers/Factory.hpp
+++ b/src/Elliptic/Triggers/Factory.hpp
@@ -1,0 +1,17 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Elliptic/Triggers/EveryNIterations.hpp"
+#include "Elliptic/Triggers/HasConverged.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/LogicalTriggers.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// Triggers for elliptic executables
+namespace elliptic::Triggers {
+template <typename Label>
+using all_triggers =
+    tmpl::push_front<::Triggers::logical_triggers, EveryNIterations<Label>,
+                     HasConverged<Label>>;
+}  // namespace elliptic::Triggers

--- a/src/Elliptic/Triggers/HasConverged.hpp
+++ b/src/Elliptic/Triggers/HasConverged.hpp
@@ -1,0 +1,44 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pup.h>
+
+#include "NumericalAlgorithms/Convergence/HasConverged.hpp"
+#include "NumericalAlgorithms/Convergence/Tags.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Trigger.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace elliptic::Triggers {
+/// \ingroup EventsAndTriggersGroup
+/// Trigger when the solver identified by the `Label` has converged.
+template <typename Label>
+class HasConverged : public Trigger {
+ public:
+  /// \cond
+  HasConverged() = default;
+  explicit HasConverged(CkMigrateMessage* /*unused*/) noexcept {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(HasConverged);  // NOLINT
+  /// \endcond
+
+  using options = tmpl::list<>;
+  static constexpr Options::String help{
+      "Trigger when the solver has converged."};
+
+  using argument_tags = tmpl::list<Convergence::Tags::HasConverged<Label>>;
+
+  bool operator()(
+      const Convergence::HasConverged& has_converged) const noexcept {
+    return static_cast<bool>(has_converged);
+  }
+};
+
+/// \cond
+template <typename Label>
+PUP::able::PUP_ID HasConverged<Label>::my_PUP_ID = 0;  // NOLINT
+/// \endcond
+}  // namespace elliptic::Triggers

--- a/src/ParallelAlgorithms/EventsAndTriggers/LogicalTriggers.hpp
+++ b/src/ParallelAlgorithms/EventsAndTriggers/LogicalTriggers.hpp
@@ -52,7 +52,7 @@ class Not : public Trigger {
   using argument_tags = tmpl::list<Tags::DataBox>;
 
   template <typename DbTags>
-  bool operator()(const db::DataBox<DbTags>& box) noexcept {
+  bool operator()(const db::DataBox<DbTags>& box) const noexcept {
     return not negated_trigger_->is_triggered(box);
   }
 
@@ -85,7 +85,7 @@ class And : public Trigger {
   using argument_tags = tmpl::list<Tags::DataBox>;
 
   template <typename DbTags>
-  bool operator()(const db::DataBox<DbTags>& box) noexcept {
+  bool operator()(const db::DataBox<DbTags>& box) const noexcept {
     for (auto& trigger : combined_triggers_) {
       if (not trigger->is_triggered(box)) {
         return false;
@@ -123,7 +123,7 @@ class Or : public Trigger {
   using argument_tags = tmpl::list<Tags::DataBox>;
 
   template <typename DbTags>
-  bool operator()(const db::DataBox<DbTags>& box) noexcept {
+  bool operator()(const db::DataBox<DbTags>& box) const noexcept {
     for (auto& trigger : combined_triggers_) {
       if (trigger->is_triggered(box)) {
         return true;

--- a/src/ParallelAlgorithms/EventsAndTriggers/Trigger.hpp
+++ b/src/ParallelAlgorithms/EventsAndTriggers/Trigger.hpp
@@ -30,7 +30,7 @@ class Trigger : public PUP::able {
   WRAPPED_PUPable_abstract(Trigger);  // NOLINT
 
   template <typename DbTags>
-  bool is_triggered(const db::DataBox<DbTags>& box) noexcept {
+  bool is_triggered(const db::DataBox<DbTags>& box) const noexcept {
     using factory_classes =
         typename std::decay_t<decltype(db::get<Parallel::Tags::Metavariables>(
             box))>::factory_creation::factory_classes;

--- a/tests/InputFiles/Elasticity/BentBeam.yaml
+++ b/tests/InputFiles/Elasticity/BentBeam.yaml
@@ -67,9 +67,7 @@ LinearSolver:
     SubdomainSolver: ExplicitInverse
 
 EventsAndTriggers:
-  ? EveryNIterations:
-      N: 1
-      Offset: 1
+  ? HasConverged
   : - ObserveErrorNorms:
         SubfileName: ErrorNorms
     - ObserveFields:

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -92,17 +92,12 @@ LinearSolver:
             Solver: ExplicitInverse
 
 EventsAndTriggers:
-  ? EveryNIterations:
-      N: 1
-      Offset: 1
+  ? HasConverged
   : - ObserveErrorNorms:
         SubfileName: ErrorNorms
     - ObserveVolumeIntegrals:
         SubfileName: VolumeIntegrals
-  ? EveryNIterations:
-      N: 1
-      Offset: 0
-  : - ObserveFields:
+    - ObserveFields:
         SubfileName: VolumeData
         VariablesToObserve:
           - Displacement

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -64,9 +64,7 @@ LinearSolver:
     SubdomainSolver: ExplicitInverse
 
 EventsAndTriggers:
-  ? EveryNIterations:
-      N: 1
-      Offset: 3
+  ? HasConverged
   : - ObserveErrorNorms:
         SubfileName: ErrorNorms
     - ObserveFields:

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -60,9 +60,7 @@ LinearSolver:
     SubdomainSolver: ExplicitInverse
 
 EventsAndTriggers:
-  ? EveryNIterations:
-      N: 1
-      Offset: 1
+  ? HasConverged
   : - ObserveErrorNorms:
         SubfileName: ErrorNorms
     - ObserveFields:

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -60,9 +60,7 @@ LinearSolver:
     SubdomainSolver: ExplicitInverse
 
 EventsAndTriggers:
-  ? EveryNIterations:
-      N: 1
-      Offset: 1
+  ? HasConverged
   : - ObserveErrorNorms:
         SubfileName: ErrorNorms
     - ObserveFields:

--- a/tests/InputFiles/Xcts/Schwarzschild.yaml
+++ b/tests/InputFiles/Xcts/Schwarzschild.yaml
@@ -97,9 +97,7 @@ LinearSolver:
     SkipResets: True
 
 EventsAndTriggers:
-  ? EveryNIterations:
-      N: 1
-      Offset: 1
+  ? HasConverged
   : - ObserveErrorNorms:
         SubfileName: ErrorNorms
     - ObserveFields:

--- a/tests/Unit/Elliptic/Triggers/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Triggers/CMakeLists.txt
@@ -5,11 +5,23 @@ set(LIBRARY "Test_EllipticTriggers")
 
 set(LIBRARY_SOURCES
   Test_EveryNIterations.cpp
+  Test_HasConverged.cpp
   )
 
 add_test_library(
   ${LIBRARY}
   "Elliptic/Triggers/"
   "${LIBRARY_SOURCES}"
-  "DataStructures;Elliptic;Parallel;EventsAndTriggers;Utilities"
+  ""
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  Convergence
+  DataStructures
+  Elliptic
+  EventsAndTriggers
+  Parallel
+  Utilities
   )

--- a/tests/Unit/Elliptic/Triggers/Test_HasConverged.cpp
+++ b/tests/Unit/Elliptic/Triggers/Test_HasConverged.cpp
@@ -1,0 +1,57 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Elliptic/Triggers/HasConverged.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/Convergence/Tags.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "Parallel/Tags/Metavariables.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Trigger.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct OptionsGroup {};
+
+struct Metavariables {
+  using component_list = tmpl::list<>;
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<tmpl::pair<
+        Trigger, tmpl::list<elliptic::Triggers::HasConverged<OptionsGroup>>>>;
+  };
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Elliptic.Triggers.HasConverged", "[Unit][Elliptic]") {
+  Parallel::register_classes_with_charm<
+      elliptic::Triggers::HasConverged<OptionsGroup>>();
+
+  const auto created =
+      TestHelpers::test_creation<std::unique_ptr<Trigger>, Metavariables>(
+          "HasConverged");
+  const auto serialized = serialize_and_deserialize(created);
+  const auto& trigger = *serialized;
+
+  auto box = db::create<
+      db::AddSimpleTags<Parallel::Tags::MetavariablesImpl<Metavariables>,
+                        Convergence::Tags::HasConverged<OptionsGroup>>>(
+      Metavariables{}, Convergence::HasConverged{});
+  CHECK_FALSE(trigger.is_triggered(box));
+  db::mutate<Convergence::Tags::HasConverged<OptionsGroup>>(
+      make_not_null(&box), [](const gsl::not_null<Convergence::HasConverged*>
+                                  has_converged) noexcept {
+        *has_converged = Convergence::HasConverged{0, 0};
+      });
+  CHECK(trigger.is_triggered(box));
+}


### PR DESCRIPTION
## Proposed changes

Trigger when the solver has converged. Useful to output norms and volume data only of the solution.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
