### PR TITLE
Add PhaseSelection metavariables struct for PhaseControl framework

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithoutHorizon.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithoutHorizon.hpp
@@ -33,20 +33,76 @@ struct EvolutionMetavars
           EvolutionMetavars<VolumeDim, InitialData, BoundaryConditions>> {
   using gh_base = GeneralizedHarmonicTemplateBase<
       false, EvolutionMetavars<VolumeDim, InitialData, BoundaryConditions>>;
-  using typename gh_base::const_global_cache_tags;
-  using typename gh_base::observed_reduction_data_tags;
   using typename gh_base::component_list;
-  template <typename ParallelComponent>
-  using registration_list =
-      typename gh_base::template registration_list<ParallelComponent>;
+  using typename gh_base::frame;
+  using typename gh_base::observed_reduction_data_tags;
+  using typename gh_base::Phase;
+
+  using phase_selection = typename gh_base::template PhaseSelection<
+      EvolutionMetavars, typename gh_base::gh_dg_element_array,
+      typename gh_base::dg_registration_list>;
+
+  using const_global_cache_tags = tmpl::list<
+      typename gh_base::analytic_solution_tag, Tags::EventsAndTriggers,
+      GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma0<
+          VolumeDim, Frame::Grid>,
+      GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma1<
+          VolumeDim, Frame::Grid>,
+      GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma2<
+          VolumeDim, Frame::Grid>,
+      PhaseControl::Tags::PhaseChangeAndTriggers<
+          typename phase_selection::phase_changes>>;
 
   static constexpr Options::String help{
       "Evolve the Einstein field equations using the Generalized Harmonic "
       "formulation\n"};
+
+  template <typename... Tags>
+  static Phase determine_next_phase(
+      const gsl::not_null<tuples::TaggedTuple<Tags...>*>
+          phase_change_decision_data,
+      const Phase& current_phase,
+      const Parallel::CProxy_GlobalCache<EvolutionMetavars>&
+          cache_proxy) noexcept {
+    const auto next_phase = PhaseControl::arbitrate_phase_change<
+        typename phase_selection::phase_changes>(
+        phase_change_decision_data, current_phase,
+        *(cache_proxy.ckLocalBranch()));
+    if (next_phase.has_value()) {
+      return next_phase.value();
+    }
+    switch (current_phase) {
+      case Phase::Initialization:
+        return evolution::is_numeric_initial_data_v<InitialData>
+                   ? Phase::RegisterWithElementDataReader
+                   : Phase::InitializeInitialDataDependentQuantities;
+      case Phase::RegisterWithElementDataReader:
+        return Phase::ImportInitialData;
+      case Phase::ImportInitialData:
+        return Phase::InitializeInitialDataDependentQuantities;
+      case Phase::InitializeInitialDataDependentQuantities:
+        return Phase::InitializeTimeStepperHistory;
+      case Phase::InitializeTimeStepperHistory:
+        return Phase::Register;
+      case Phase::Register:
+        return Phase::Evolve;
+      case Phase::Evolve:
+        return Phase::Exit;
+      case Phase::Exit:
+        ERROR(
+            "Should never call determine_next_phase with the current phase "
+            "being 'Exit'");
+      default:
+        ERROR(
+            "Unknown type of phase. Did you static_cast<Phase> an integral "
+            "value?");
+    }
+  }
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{
-    &setup_error_handling, &setup_memory_allocation_failure_reporting,
+    &setup_error_handling,
+    &setup_memory_allocation_failure_reporting,
     &disable_openblas_multithreading,
     &domain::creators::time_dependence::register_derived_with_charm,
     &domain::FunctionsOfTime::register_derived_with_charm,
@@ -55,7 +111,7 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &GeneralizedHarmonic::ConstraintDamping::register_derived_with_charm,
     &Parallel::register_derived_classes_with_charm<TimeStepper>,
     &Parallel::register_derived_classes_with_charm<
-        PhaseChange<metavariables::phase_changes>>,
+        PhaseChange<metavariables::phase_selection::phase_changes>>,
     &Parallel::register_factory_classes_with_charm<metavariables>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -254,32 +254,6 @@ struct EvolutionMetavars {
         << static_cast<int>(phase));
   }
 
-  using phase_changes =
-      tmpl::list<PhaseControl::Registrars::VisitAndReturn<EvolutionMetavars,
-                                                          Phase::LoadBalancing>,
-                 PhaseControl::Registrars::VisitAndReturn<
-                     EvolutionMetavars, Phase::WriteCheckpoint>,
-                 PhaseControl::Registrars::CheckpointAndExitAfterWallclock<
-                     EvolutionMetavars>>;
-
-  using initialize_phase_change_decision_data =
-      PhaseControl::InitializePhaseChangeDecisionData<phase_changes>;
-
-  using phase_change_tags_and_combines_list =
-      PhaseControl::get_phase_change_tags<phase_changes>;
-
-  // A tmpl::list of tags to be added to the GlobalCache by the
-  // metavariables
-  using const_global_cache_tags = tmpl::list<
-      Tags::EventsAndTriggers,
-      GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma0<
-          volume_dim, Frame::Grid>,
-      GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma1<
-          volume_dim, Frame::Grid>,
-      GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma2<
-          volume_dim, Frame::Grid>,
-      PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes>>;
-
   using dg_registration_list =
       tmpl::list<observers::Actions::RegisterEventsWithObservers>;
 
@@ -290,7 +264,8 @@ struct EvolutionMetavars {
       const Phase& current_phase,
       const Parallel::CProxy_GlobalCache<EvolutionMetavars>&
           cache_proxy) noexcept {
-    const auto next_phase = PhaseControl::arbitrate_phase_change<phase_changes>(
+    const auto next_phase = PhaseControl::arbitrate_phase_change<
+        typename phase_selection::phase_changes>(
         phase_change_decision_data, current_phase,
         *(cache_proxy.ckLocalBranch()));
     if (next_phase.has_value()) {
@@ -387,17 +362,56 @@ struct EvolutionMetavars {
                                             Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
               Phase, Phase::Evolve,
-              tmpl::list<
-                  Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
-                  step_actions, Actions::AdvanceTime,
-                  PhaseControl::Actions::ExecutePhaseChange<phase_changes>>>>>>;
+              tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
+                         step_actions, Actions::AdvanceTime,
+                         PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
-  template <typename ParallelComponent>
-  struct registration_list {
-    using type = std::conditional_t<
-        std::is_same_v<ParallelComponent, gh_dg_element_array>,
-        dg_registration_list, tmpl::list<>>;
+  struct phase_selection : tt::ConformsTo<PhaseControl::PhaseSelection> {
+    using phase_changes =
+        tmpl::list<PhaseControl::Registrars::VisitAndReturn<
+                       EvolutionMetavars, Phase::LoadBalancing>,
+                   PhaseControl::Registrars::VisitAndReturn<
+                       EvolutionMetavars, Phase::WriteCheckpoint>,
+                   PhaseControl::Registrars::CheckpointAndExitAfterWallclock<
+                       EvolutionMetavars>>;
+
+    using initialize_phase_change_decision_data =
+        PhaseControl::InitializePhaseChangeDecisionData<phase_changes>;
+    using phase_change_tags_and_combines_list =
+        PhaseControl::get_phase_change_tags<phase_changes>;
+
+    static std::string phase_name(Phase phase) noexcept {
+      if (phase == Phase::LoadBalancing) {
+        return "LoadBalancing";
+      } else if (phase == Phase::WriteCheckpoint) {
+        return "WriteCheckpoint";
+      }
+      ERROR(
+          "Passed phase that should not be used in input file. Integer "
+          "corresponding to phase is: "
+          << static_cast<int>(phase));
+    }
+
+    template <typename ParallelComponent>
+    struct registration_list {
+      using type = std::conditional_t<
+          std::is_same_v<ParallelComponent, gh_dg_element_array>,
+          dg_registration_list, tmpl::list<>>;
+    };
   };
+
+  // A tmpl::list of tags to be added to the GlobalCache by the
+  // metavariables
+  using const_global_cache_tags = tmpl::list<
+      Tags::EventsAndTriggers,
+      GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma0<
+          volume_dim, Frame::Grid>,
+      GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma1<
+          volume_dim, Frame::Grid>,
+      GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma2<
+          volume_dim, Frame::Grid>,
+      PhaseControl::Tags::PhaseChangeAndTriggers<
+          phase_selection::phase_changes>>;
 
   using component_list =
       tmpl::flatten<tmpl::list<observers::Observer<EvolutionMetavars>,
@@ -421,7 +435,7 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &GeneralizedHarmonic::ConstraintDamping::register_derived_with_charm,
     &Parallel::register_derived_classes_with_charm<TimeStepper>,
     &Parallel::register_derived_classes_with_charm<
-        PhaseChange<metavariables::phase_changes>>,
+        PhaseChange<metavariables::phase_selection::phase_changes>>,
     &Parallel::register_factory_classes_with_charm<metavariables>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivClean.hpp
@@ -27,22 +27,84 @@ struct EvolutionMetavars
     : public virtual GhValenciaDivCleanDefaults,
       public GhValenciaDivCleanTemplateBase<
           EvolutionMetavars<InitialData, InterpolationTargetTags...>> {
-  using const_global_cache_tags = typename GhValenciaDivCleanTemplateBase<
-      EvolutionMetavars>::const_global_cache_tags;
   using observed_reduction_data_tags = typename GhValenciaDivCleanTemplateBase<
       EvolutionMetavars>::observed_reduction_data_tags;
   using component_list = typename GhValenciaDivCleanTemplateBase<
       EvolutionMetavars>::component_list;
   using factory_creation = typename GhValenciaDivCleanTemplateBase<
       EvolutionMetavars>::factory_creation;
-  template <typename ParallelComponent>
-  using registration_list = typename GhValenciaDivCleanTemplateBase<
-      EvolutionMetavars>::template registration_list<ParallelComponent>;
+
+  using phase_selection =
+      typename GhValenciaDivCleanTemplateBase<EvolutionMetavars>::
+          template PhaseSelection<
+              EvolutionMetavars,
+              typename GhValenciaDivCleanTemplateBase<
+                  EvolutionMetavars>::dg_element_array_component,
+              typename GhValenciaDivCleanTemplateBase<
+                  EvolutionMetavars>::dg_registration_list>;
+
+  using const_global_cache_tags = tmpl::flatten<tmpl::list<
+      tmpl::conditional_t<evolution::is_numeric_initial_data_v<InitialData>,
+                          tmpl::list<>,
+                          typename GhValenciaDivCleanTemplateBase<
+                              EvolutionMetavars>::initial_data_tag>,
+      grmhd::ValenciaDivClean::Tags::ConstraintDampingParameter,
+      Tags::EventsAndTriggers,
+      GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma0<
+          volume_dim, Frame::Grid>,
+      GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma1<
+          volume_dim, Frame::Grid>,
+      GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma2<
+          volume_dim, Frame::Grid>,
+      PhaseControl::Tags::PhaseChangeAndTriggers<
+          typename phase_selection::phase_changes>>>;
 
   static constexpr Options::String help{
       "Evolve the Valencia formulation of the GRMHD system with divergence "
       "cleaning, coupled to a dynamic spacetime evolved with the Generalized "
       "Harmonic formulation\n"};
+
+  template <typename... Tags>
+  static Phase determine_next_phase(
+      const gsl::not_null<tuples::TaggedTuple<Tags...>*>
+          phase_change_decision_data,
+      const Phase& current_phase,
+      const Parallel::CProxy_GlobalCache<EvolutionMetavars>&
+          cache_proxy) noexcept {
+    const auto next_phase = PhaseControl::arbitrate_phase_change<
+        typename phase_selection::phase_changes>(
+        phase_change_decision_data, current_phase,
+        *(cache_proxy.ckLocalBranch()));
+    if (next_phase.has_value()) {
+      return next_phase.value();
+    }
+    switch (current_phase) {
+      case Phase::Initialization:
+        return evolution::is_numeric_initial_data_v<InitialData>
+                   ? Phase::RegisterWithElementDataReader
+                   : Phase::InitializeInitialDataDependentQuantities;
+      case Phase::RegisterWithElementDataReader:
+        return Phase::ImportInitialData;
+      case Phase::ImportInitialData:
+        return Phase::InitializeInitialDataDependentQuantities;
+      case Phase::InitializeInitialDataDependentQuantities:
+        return Phase::InitializeTimeStepperHistory;
+      case Phase::InitializeTimeStepperHistory:
+        return Phase::Register;
+      case Phase::Register:
+        return Phase::Evolve;
+      case Phase::Evolve:
+        return Phase::Exit;
+      case Phase::Exit:
+        ERROR(
+            "Should never call determine_next_phase with the current phase "
+            "being 'Exit'");
+      default:
+        ERROR(
+            "Unknown type of phase. Did you static_cast<Phase> an integral "
+            "value?");
+    }
+  }
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{
@@ -56,7 +118,7 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &GeneralizedHarmonic::ConstraintDamping::register_derived_with_charm,
     &Parallel::register_derived_classes_with_charm<TimeStepper>,
     &Parallel::register_derived_classes_with_charm<
-        PhaseChange<metavariables::phase_changes>>,
+        PhaseChange<metavariables::phase_selection::phase_changes>>,
     &Parallel::register_factory_classes_with_charm<metavariables>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -95,8 +95,10 @@
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/Algorithms/AlgorithmSingleton.hpp"
 #include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp"
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "Parallel/PhaseControl/PhaseControlTags.hpp"
+#include "Parallel/PhaseControl/PhaseSelection.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/Reduction.hpp"
@@ -219,19 +221,10 @@ struct GhValenciaDivCleanDefaults {
     InitializeTimeStepperHistory,
     Register,
     LoadBalancing,
+    WriteCheckpoint,
     Evolve,
     Exit
   };
-
-  static std::string phase_name(Phase phase) noexcept {
-    if (phase == Phase::LoadBalancing) {
-        return "LoadBalancing";
-      }
-      ERROR(
-          "Passed phase that should not be used in input file. Integer "
-          "corresponding to phase is: "
-          << static_cast<int>(phase));
-  }
 
   using initialize_initial_data_dependent_quantities_actions = tmpl::list<
       GeneralizedHarmonic::gauges::Actions::InitializeDampedHarmonic<
@@ -324,6 +317,42 @@ struct GhValenciaDivCleanTemplateBase<
                                          Triggers::time_triggers>>>;
   };
 
+  template <typename Metavariables, typename DgElementArray,
+            typename DgRegistrationList>
+  struct PhaseSelection : tt::ConformsTo<PhaseControl::PhaseSelection> {
+    using phase_changes =
+        tmpl::list<PhaseControl::Registrars::VisitAndReturn<
+                       Metavariables, Phase::LoadBalancing>,
+                   PhaseControl::Registrars::VisitAndReturn<
+                       Metavariables, Phase::WriteCheckpoint>,
+                   PhaseControl::Registrars::CheckpointAndExitAfterWallclock<
+                       Metavariables>>;
+
+    using initialize_phase_change_decision_data =
+        PhaseControl::InitializePhaseChangeDecisionData<phase_changes>;
+    using phase_change_tags_and_combines_list =
+        PhaseControl::get_phase_change_tags<phase_changes>;
+
+    static std::string phase_name(Phase phase) noexcept {
+      if (phase == Phase::LoadBalancing) {
+        return "LoadBalancing";
+      } else if (phase == Phase::WriteCheckpoint) {
+        return "WriteCheckpoint";
+      }
+      ERROR(
+          "Passed phase that should not be used in input file. Integer "
+          "corresponding to phase is: "
+          << static_cast<int>(phase));
+    }
+
+    template <typename ParallelComponent>
+    struct registration_list {
+      using type =
+          std::conditional_t<std::is_same_v<ParallelComponent, DgElementArray>,
+                             DgRegistrationList, tmpl::list<>>;
+    };
+  };
+
   using interpolation_target_tags = tmpl::list<InterpolationTargetTags...>;
 
   using observed_reduction_data_tags =
@@ -331,70 +360,9 @@ struct GhValenciaDivCleanTemplateBase<
           tmpl::at<typename factory_creation::factory_classes, Event>,
           typename InterpolationTargetTags::post_interpolation_callback...>>;
 
-  using phase_changes = tmpl::list<PhaseControl::Registrars::VisitAndReturn<
-      GhValenciaDivCleanTemplateBase, Phase::LoadBalancing>>;
-  using initialize_phase_change_decision_data =
-      PhaseControl::InitializePhaseChangeDecisionData<phase_changes>;
-  using phase_change_tags_and_combines_list =
-      PhaseControl::get_phase_change_tags<phase_changes>;
-
-  using const_global_cache_tags = tmpl::flatten<tmpl::list<
-      tmpl::conditional_t<evolution::is_numeric_initial_data_v<initial_data>,
-                          tmpl::list<>, initial_data_tag>,
-      grmhd::ValenciaDivClean::Tags::ConstraintDampingParameter,
-      Tags::EventsAndTriggers,
-      GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma0<
-          volume_dim, Frame::Grid>,
-      GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma1<
-          volume_dim, Frame::Grid>,
-      GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma2<
-          volume_dim, Frame::Grid>,
-      PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes>>>;
-
   using dg_registration_list =
       tmpl::list<intrp::Actions::RegisterElementWithInterpolator,
                  observers::Actions::RegisterEventsWithObservers>;
-
-  template <typename... Tags>
-  static Phase determine_next_phase(
-      const gsl::not_null<tuples::TaggedTuple<Tags...>*>
-          phase_change_decision_data,
-      const Phase& current_phase,
-      const Parallel::CProxy_GlobalCache<derived_metavars>&
-          cache_proxy) noexcept {
-    const auto next_phase = PhaseControl::arbitrate_phase_change<phase_changes>(
-        phase_change_decision_data, current_phase,
-        *(cache_proxy.ckLocalBranch()));
-    if (next_phase.has_value()) {
-      return next_phase.value();
-    }
-    switch (current_phase) {
-      case Phase::Initialization:
-        return evolution::is_numeric_initial_data_v<initial_data>
-                   ? Phase::RegisterWithElementDataReader
-                   : Phase::InitializeInitialDataDependentQuantities;
-      case Phase::RegisterWithElementDataReader:
-        return Phase::ImportInitialData;
-      case Phase::ImportInitialData:
-        return Phase::InitializeInitialDataDependentQuantities;
-      case Phase::InitializeInitialDataDependentQuantities:
-        return Phase::InitializeTimeStepperHistory;
-      case Phase::InitializeTimeStepperHistory:
-        return Phase::Register;
-      case Phase::Register:
-        return Phase::Evolve;
-      case Phase::Evolve:
-        return Phase::Exit;
-      case Phase::Exit:
-        ERROR(
-            "Should never call determine_next_phase with the current phase "
-            "being 'Exit'");
-      default:
-        ERROR(
-            "Unknown type of phase. Did you static_cast<Phase> an integral "
-            "value?");
-    }
-  }
 
   using step_actions = tmpl::flatten<tmpl::list<
       evolution::dg::Actions::ComputeTimeDerivative<derived_metavars>,
@@ -472,19 +440,12 @@ struct GhValenciaDivCleanTemplateBase<
                                             Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
               Phase, Phase::Evolve,
-              tmpl::list<
-                  VariableFixing::Actions::FixVariables<
-                      VariableFixing::FixToAtmosphere<volume_dim>>,
-                  Actions::UpdateConservatives, Actions::RunEventsAndTriggers,
-                  Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
-                  PhaseControl::Actions::ExecutePhaseChange<phase_changes>>>>>>;
-
-  template <typename ParallelComponent>
-  struct registration_list {
-    using type = std::conditional_t<
-        std::is_same_v<ParallelComponent, dg_element_array_component>,
-        dg_registration_list, tmpl::list<>>;
-  };
+              tmpl::list<VariableFixing::Actions::FixVariables<
+                             VariableFixing::FixToAtmosphere<volume_dim>>,
+                         Actions::UpdateConservatives,
+                         Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
+                         step_actions, Actions::AdvanceTime,
+                         PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
   using component_list = tmpl::flatten<tmpl::list<
       observers::Observer<derived_metavars>,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -53,6 +53,7 @@
 #include "Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp"
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "Parallel/PhaseControl/PhaseControlTags.hpp"
+#include "Parallel/PhaseControl/PhaseSelection.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
@@ -221,28 +222,6 @@ struct EvolutionMetavars {
     Exit
   };
 
-  static std::string phase_name(Phase phase) noexcept {
-    if (phase == Phase::LoadBalancing) {
-      return "LoadBalancing";
-    }
-    ERROR(
-        "Passed phase that should not be used in input file. Integer "
-        "corresponding to phase is: "
-        << static_cast<int>(phase));
-  }
-
-  using phase_changes =
-      tmpl::list<PhaseControl::Registrars::VisitAndReturn<EvolutionMetavars,
-                                                          Phase::LoadBalancing>,
-                 PhaseControl::Registrars::CheckpointAndExitAfterWallclock<
-                     EvolutionMetavars>>;
-
-  using initialize_phase_change_decision_data =
-      PhaseControl::InitializePhaseChangeDecisionData<phase_changes>;
-
-  using phase_change_tags_and_combines_list =
-      PhaseControl::get_phase_change_tags<phase_changes>;
-
   using dg_registration_list =
       tmpl::list<observers::Actions::RegisterEventsWithObservers>;
 
@@ -291,15 +270,45 @@ struct EvolutionMetavars {
               tmpl::list<Actions::UpdateConservatives,
                          Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
                          step_actions, Actions::AdvanceTime,
-                         PhaseControl::Actions::ExecutePhaseChange<
-                             phase_changes>>>>>;
+                         PhaseControl::Actions::ExecutePhaseChange>>>>;
 
-  template <typename ParallelComponent>
-  struct registration_list {
-    using type =
-        std::conditional_t<std::is_same_v<ParallelComponent, dg_element_array>,
-                           dg_registration_list, tmpl::list<>>;
+  template <typename DgElementArray, typename DgRegistrationList>
+  struct PhaseSelection : tt::ConformsTo<PhaseControl::PhaseSelection> {
+    using phase_changes =
+        tmpl::list<PhaseControl::Registrars::VisitAndReturn<
+                       EvolutionMetavars, Phase::LoadBalancing>,
+                   PhaseControl::Registrars::VisitAndReturn<
+                       EvolutionMetavars, Phase::WriteCheckpoint>,
+                   PhaseControl::Registrars::CheckpointAndExitAfterWallclock<
+                       EvolutionMetavars>>;
+
+    using initialize_phase_change_decision_data =
+        PhaseControl::InitializePhaseChangeDecisionData<phase_changes>;
+    using phase_change_tags_and_combines_list =
+        PhaseControl::get_phase_change_tags<phase_changes>;
+
+    static std::string phase_name(Phase phase) noexcept {
+      if (phase == Phase::LoadBalancing) {
+        return "LoadBalancing";
+      } else if (phase == Phase::WriteCheckpoint) {
+        return "WriteCheckpoint";
+      }
+      ERROR(
+          "Passed phase that should not be used in input file. Integer "
+          "corresponding to phase is: "
+          << static_cast<int>(phase));
+    }
+
+    template <typename ParallelComponent>
+    struct registration_list {
+      using type =
+          std::conditional_t<std::is_same_v<ParallelComponent, DgElementArray>,
+                             DgRegistrationList, tmpl::list<>>;
+    };
   };
+
+  using phase_selection =
+      PhaseSelection<dg_element_array, dg_registration_list>;
 
   using component_list =
       tmpl::list<observers::Observer<EvolutionMetavars>,
@@ -310,7 +319,8 @@ struct EvolutionMetavars {
       initial_data_tag,
       tmpl::conditional_t<has_source_terms, source_term_tag, tmpl::list<>>,
       Tags::EventsAndTriggers,
-      PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes>>;
+      PhaseControl::Tags::PhaseChangeAndTriggers<
+          typename phase_selection::phase_changes>>;
 
   static constexpr Options::String help{
       "Evolve the Newtonian Euler system in conservative form.\n\n"};
@@ -322,10 +332,10 @@ struct EvolutionMetavars {
       const Phase& current_phase,
       const Parallel::CProxy_GlobalCache<EvolutionMetavars>&
           cache_proxy) noexcept {
-    const auto next_phase =
-        PhaseControl::arbitrate_phase_change<phase_changes>(
-            phase_change_decision_data, current_phase,
-            *(cache_proxy.ckLocalBranch()));
+    const auto next_phase = PhaseControl::arbitrate_phase_change<
+        typename phase_selection::phase_changes>(
+        phase_change_decision_data, current_phase,
+        *(cache_proxy.ckLocalBranch()));
     if (next_phase.has_value()) {
       return next_phase.value();
     }
@@ -354,7 +364,8 @@ struct EvolutionMetavars {
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{
-    &setup_error_handling, &setup_memory_allocation_failure_reporting,
+    &setup_error_handling,
+    &setup_memory_allocation_failure_reporting,
     &disable_openblas_multithreading,
     &domain::creators::register_derived_with_charm,
     &domain::creators::time_dependence::register_derived_with_charm,
@@ -362,7 +373,7 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &NewtonianEuler::BoundaryCorrections::register_derived_with_charm,
     &Parallel::register_derived_classes_with_charm<TimeStepper>,
     &Parallel::register_derived_classes_with_charm<
-        PhaseChange<metavariables::phase_changes>>,
+        PhaseChange<metavariables::phase_selection::phase_changes>>,
     &Parallel::register_factory_classes_with_charm<metavariables>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -54,6 +54,7 @@
 #include "Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp"
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "Parallel/PhaseControl/PhaseControlTags.hpp"
+#include "Parallel/PhaseControl/PhaseSelection.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
@@ -207,28 +208,6 @@ struct EvolutionMetavars {
     Exit
   };
 
-  static std::string phase_name(Phase phase) noexcept {
-    if (phase == Phase::LoadBalancing) {
-      return "LoadBalancing";
-    }
-    ERROR(
-        "Passed phase that should not be used in input file. Integer "
-        "corresponding to phase is: "
-        << static_cast<int>(phase));
-  }
-
-  using phase_changes =
-      tmpl::list<PhaseControl::Registrars::VisitAndReturn<EvolutionMetavars,
-                                                          Phase::LoadBalancing>,
-                 PhaseControl::Registrars::CheckpointAndExitAfterWallclock<
-                     EvolutionMetavars>>;
-
-  using initialize_phase_change_decision_data =
-      PhaseControl::InitializePhaseChangeDecisionData<phase_changes>;
-
-  using phase_change_tags_and_combines_list =
-      PhaseControl::get_phase_change_tags<phase_changes>;
-
   using dg_registration_list =
       tmpl::list<observers::Actions::RegisterEventsWithObservers>;
 
@@ -277,15 +256,45 @@ struct EvolutionMetavars {
               Phase, Phase::Evolve,
               tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
                          step_actions, Actions::AdvanceTime,
-                         PhaseControl::Actions::ExecutePhaseChange<
-                             phase_changes>>>>>;
+                         PhaseControl::Actions::ExecutePhaseChange>>>>;
 
-  template <typename ParallelComponent>
-  struct registration_list {
-    using type =
-        std::conditional_t<std::is_same_v<ParallelComponent, dg_element_array>,
-                           dg_registration_list, tmpl::list<>>;
+  template <typename DgElementArray, typename DgRegistrationList>
+  struct PhaseSelection : tt::ConformsTo<PhaseControl::PhaseSelection> {
+    using phase_changes =
+        tmpl::list<PhaseControl::Registrars::VisitAndReturn<
+                       EvolutionMetavars, Phase::LoadBalancing>,
+                   PhaseControl::Registrars::VisitAndReturn<
+                       EvolutionMetavars, Phase::WriteCheckpoint>,
+                   PhaseControl::Registrars::CheckpointAndExitAfterWallclock<
+                       EvolutionMetavars>>;
+
+    using initialize_phase_change_decision_data =
+        PhaseControl::InitializePhaseChangeDecisionData<phase_changes>;
+    using phase_change_tags_and_combines_list =
+        PhaseControl::get_phase_change_tags<phase_changes>;
+
+    static std::string phase_name(Phase phase) noexcept {
+      if (phase == Phase::LoadBalancing) {
+        return "LoadBalancing";
+      } else if (phase == Phase::WriteCheckpoint) {
+        return "WriteCheckpoint";
+      }
+      ERROR(
+          "Passed phase that should not be used in input file. Integer "
+          "corresponding to phase is: "
+          << static_cast<int>(phase));
+    }
+
+    template <typename ParallelComponent>
+    struct registration_list {
+      using type =
+          std::conditional_t<std::is_same_v<ParallelComponent, DgElementArray>,
+                             DgRegistrationList, tmpl::list<>>;
+    };
   };
+
+  using phase_selection =
+      PhaseSelection<dg_element_array, dg_registration_list>;
 
   using component_list =
       tmpl::list<observers::Observer<EvolutionMetavars>,
@@ -294,7 +303,8 @@ struct EvolutionMetavars {
 
   using const_global_cache_tags =
       tmpl::list<initial_data_tag, Tags::EventsAndTriggers,
-                 PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes>>;
+                 PhaseControl::Tags::PhaseChangeAndTriggers<
+                     typename phase_selection::phase_changes>>;
 
   static constexpr Options::String help{
       "Evolve the M1Grey system (without coupling to hydro).\n\n"};
@@ -306,10 +316,10 @@ struct EvolutionMetavars {
       const Phase& current_phase,
       const Parallel::CProxy_GlobalCache<EvolutionMetavars>&
           cache_proxy) noexcept {
-    const auto next_phase =
-        PhaseControl::arbitrate_phase_change<phase_changes>(
-            phase_change_decision_data, current_phase,
-            *(cache_proxy.ckLocalBranch()));
+    const auto next_phase = PhaseControl::arbitrate_phase_change<
+        typename phase_selection::phase_changes>(
+        phase_change_decision_data, current_phase,
+        *(cache_proxy.ckLocalBranch()));
     if (next_phase.has_value()) {
       return next_phase.value();
     }
@@ -338,7 +348,8 @@ struct EvolutionMetavars {
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{
-    &setup_error_handling, &setup_memory_allocation_failure_reporting,
+    &setup_error_handling,
+    &setup_memory_allocation_failure_reporting,
     &disable_openblas_multithreading,
     &domain::creators::register_derived_with_charm,
     &domain::creators::time_dependence::register_derived_with_charm,
@@ -348,7 +359,7 @@ static const std::vector<void (*)()> charm_init_node_funcs{
             metavariables::neutrino_species>>,
     &Parallel::register_derived_classes_with_charm<TimeStepper>,
     &Parallel::register_derived_classes_with_charm<
-        PhaseChange<metavariables::phase_changes>>,
+        PhaseChange<metavariables::phase_selection::phase_changes>>,
     &Parallel::register_factory_classes_with_charm<metavariables>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -56,6 +56,7 @@
 #include "Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp"
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "Parallel/PhaseControl/PhaseControlTags.hpp"
+#include "Parallel/PhaseControl/PhaseSelection.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
@@ -218,28 +219,6 @@ struct EvolutionMetavars {
     Exit
   };
 
-  static std::string phase_name(Phase phase) noexcept {
-    if (phase == Phase::LoadBalancing) {
-      return "LoadBalancing";
-    }
-    ERROR(
-        "Passed phase that should not be used in input file. Integer "
-        "corresponding to phase is: "
-        << static_cast<int>(phase));
-  }
-
-  using phase_changes =
-      tmpl::list<PhaseControl::Registrars::VisitAndReturn<EvolutionMetavars,
-                                                          Phase::LoadBalancing>,
-                 PhaseControl::Registrars::CheckpointAndExitAfterWallclock<
-                     EvolutionMetavars>>;
-
-  using initialize_phase_change_decision_data =
-      PhaseControl::InitializePhaseChangeDecisionData<phase_changes>;
-
-  using phase_change_tags_and_combines_list =
-      PhaseControl::get_phase_change_tags<phase_changes>;
-
   using dg_registration_list =
       tmpl::list<observers::Actions::RegisterEventsWithObservers>;
 
@@ -292,15 +271,45 @@ struct EvolutionMetavars {
                          Actions::UpdateConservatives,
                          Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
                          step_actions, Actions::AdvanceTime,
-                         PhaseControl::Actions::ExecutePhaseChange<
-                             phase_changes>>>>>;
+                         PhaseControl::Actions::ExecutePhaseChange>>>>;
 
-  template <typename ParallelComponent>
-  struct registration_list {
-    using type =
-        std::conditional_t<std::is_same_v<ParallelComponent, dg_element_array>,
-                           dg_registration_list, tmpl::list<>>;
+  template <typename DgElementArray, typename DgRegistrationList>
+  struct PhaseSelection : tt::ConformsTo<PhaseControl::PhaseSelection> {
+    using phase_changes =
+        tmpl::list<PhaseControl::Registrars::VisitAndReturn<
+                       EvolutionMetavars, Phase::LoadBalancing>,
+                   PhaseControl::Registrars::VisitAndReturn<
+                       EvolutionMetavars, Phase::WriteCheckpoint>,
+                   PhaseControl::Registrars::CheckpointAndExitAfterWallclock<
+                       EvolutionMetavars>>;
+
+    using initialize_phase_change_decision_data =
+        PhaseControl::InitializePhaseChangeDecisionData<phase_changes>;
+    using phase_change_tags_and_combines_list =
+        PhaseControl::get_phase_change_tags<phase_changes>;
+
+    static std::string phase_name(Phase phase) noexcept {
+      if (phase == Phase::LoadBalancing) {
+        return "LoadBalancing";
+      } else if (phase == Phase::WriteCheckpoint) {
+        return "WriteCheckpoint";
+      }
+      ERROR(
+          "Passed phase that should not be used in input file. Integer "
+          "corresponding to phase is: "
+          << static_cast<int>(phase));
+    }
+
+    template <typename ParallelComponent>
+    struct registration_list {
+      using type =
+          std::conditional_t<std::is_same_v<ParallelComponent, DgElementArray>,
+                             DgRegistrationList, tmpl::list<>>;
+    };
   };
+
+  using phase_selection =
+      PhaseSelection<dg_element_array, dg_registration_list>;
 
   using component_list =
       tmpl::list<observers::Observer<EvolutionMetavars>,
@@ -309,7 +318,8 @@ struct EvolutionMetavars {
 
   using const_global_cache_tags =
       tmpl::list<initial_data_tag, Tags::EventsAndTriggers,
-                 PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes>>;
+                 PhaseControl::Tags::PhaseChangeAndTriggers<
+                     typename phase_selection::phase_changes>>;
 
   static constexpr Options::String help{
       "Evolve the Valencia formulation of RelativisticEuler system.\n\n"};
@@ -321,10 +331,10 @@ struct EvolutionMetavars {
       const Phase& current_phase,
       const Parallel::CProxy_GlobalCache<EvolutionMetavars>&
           cache_proxy) noexcept {
-    const auto next_phase =
-        PhaseControl::arbitrate_phase_change<phase_changes>(
-            phase_change_decision_data, current_phase,
-            *(cache_proxy.ckLocalBranch()));
+    const auto next_phase = PhaseControl::arbitrate_phase_change<
+        typename phase_selection::phase_changes>(
+        phase_change_decision_data, current_phase,
+        *(cache_proxy.ckLocalBranch()));
     if (next_phase.has_value()) {
       return next_phase.value();
     }
@@ -353,7 +363,8 @@ struct EvolutionMetavars {
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{
-    &setup_error_handling, &setup_memory_allocation_failure_reporting,
+    &setup_error_handling,
+    &setup_memory_allocation_failure_reporting,
     &disable_openblas_multithreading,
     &domain::creators::register_derived_with_charm,
     &domain::creators::time_dependence::register_derived_with_charm,
@@ -362,7 +373,7 @@ static const std::vector<void (*)()> charm_init_node_funcs{
         register_derived_with_charm,
     &Parallel::register_derived_classes_with_charm<TimeStepper>,
     &Parallel::register_derived_classes_with_charm<
-        PhaseChange<metavariables::phase_changes>>,
+        PhaseChange<metavariables::phase_selection::phase_changes>>,
     &Parallel::register_factory_classes_with_charm<metavariables>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -44,8 +44,10 @@
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp"
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "Parallel/PhaseControl/PhaseControlTags.hpp"
+#include "Parallel/PhaseControl/PhaseSelection.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
@@ -177,6 +179,7 @@ struct EvolutionMetavars {
   enum class Phase {
     Initialization,
     LoadBalancing,
+    WriteCheckpoint,
     RegisterWithObserver,
     InitializeTimeStepperHistory,
     Evolve,
@@ -192,19 +195,6 @@ struct EvolutionMetavars {
         "corresponding to phase is: "
         << static_cast<int>(phase));
   }
-
-  using phase_changes = tmpl::list<PhaseControl::Registrars::VisitAndReturn<
-      EvolutionMetavars, Phase::LoadBalancing>>;
-
-  using initialize_phase_change_decision_data =
-      PhaseControl::InitializePhaseChangeDecisionData<phase_changes>;
-
-  using phase_change_tags_and_combines_list =
-      PhaseControl::get_phase_change_tags<phase_changes>;
-
-  using const_global_cache_tags =
-      tmpl::list<initial_data_tag, Tags::EventsAndTriggers,
-                 PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes>>;
 
   using dg_registration_list =
       tmpl::list<observers::Actions::RegisterEventsWithObservers>;
@@ -248,17 +238,52 @@ struct EvolutionMetavars {
 
           Parallel::PhaseActions<
               Phase, Phase::Evolve,
-              tmpl::list<
-                  Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
-                  step_actions, Actions::AdvanceTime,
-                  PhaseControl::Actions::ExecutePhaseChange<phase_changes>>>>>;
+              tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
+                         step_actions, Actions::AdvanceTime,
+                         PhaseControl::Actions::ExecutePhaseChange>>>>;
 
-  template <typename ParallelComponent>
-  struct registration_list {
-    using type =
-        std::conditional_t<std::is_same_v<ParallelComponent, dg_element_array>,
-                           dg_registration_list, tmpl::list<>>;
+  template <typename DgElementArray, typename DgRegistrationList>
+  struct PhaseSelection : tt::ConformsTo<PhaseControl::PhaseSelection> {
+    using phase_changes =
+        tmpl::list<PhaseControl::Registrars::VisitAndReturn<
+                       EvolutionMetavars, Phase::LoadBalancing>,
+                   PhaseControl::Registrars::VisitAndReturn<
+                       EvolutionMetavars, Phase::WriteCheckpoint>,
+                   PhaseControl::Registrars::CheckpointAndExitAfterWallclock<
+                       EvolutionMetavars>>;
+
+    using initialize_phase_change_decision_data =
+        PhaseControl::InitializePhaseChangeDecisionData<phase_changes>;
+    using phase_change_tags_and_combines_list =
+        PhaseControl::get_phase_change_tags<phase_changes>;
+
+    static std::string phase_name(Phase phase) noexcept {
+      if (phase == Phase::LoadBalancing) {
+        return "LoadBalancing";
+      } else if (phase == Phase::WriteCheckpoint) {
+        return "WriteCheckpoint";
+      }
+      ERROR(
+          "Passed phase that should not be used in input file. Integer "
+          "corresponding to phase is: "
+          << static_cast<int>(phase));
+    }
+
+    template <typename ParallelComponent>
+    struct registration_list {
+      using type =
+          std::conditional_t<std::is_same_v<ParallelComponent, DgElementArray>,
+                             DgRegistrationList, tmpl::list<>>;
+    };
   };
+
+  using phase_selection =
+      PhaseSelection<dg_element_array, dg_registration_list>;
+
+  using const_global_cache_tags =
+      tmpl::list<initial_data_tag, Tags::EventsAndTriggers,
+                 PhaseControl::Tags::PhaseChangeAndTriggers<
+                     typename phase_selection::phase_changes>>;
 
   using component_list =
       tmpl::list<observers::Observer<EvolutionMetavars>,
@@ -275,7 +300,8 @@ struct EvolutionMetavars {
       const Phase& current_phase,
       const Parallel::CProxy_GlobalCache<EvolutionMetavars>&
           cache_proxy) noexcept {
-    const auto next_phase = PhaseControl::arbitrate_phase_change<phase_changes>(
+    const auto next_phase = PhaseControl::arbitrate_phase_change<
+        typename phase_selection::phase_changes>(
         phase_change_decision_data, current_phase,
         *(cache_proxy.ckLocalBranch()));
     if (next_phase.has_value()) {
@@ -315,7 +341,7 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &ScalarAdvection::BoundaryCorrections::register_derived_with_charm,
     &Parallel::register_derived_classes_with_charm<TimeStepper>,
     &Parallel::register_derived_classes_with_charm<
-        PhaseChange<metavariables::phase_changes>>,
+        PhaseChange<metavariables::phase_selection::phase_changes>>,
     &Parallel::register_factory_classes_with_charm<metavariables>};
 static const std::vector<void (*)()> charm_init_proc_funcs{
     &enable_floating_point_exceptions};

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -50,6 +50,7 @@
 #include "Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp"
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "Parallel/PhaseControl/PhaseControlTags.hpp"
+#include "Parallel/PhaseControl/PhaseSelection.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/Reduction.hpp"
@@ -208,32 +209,6 @@ struct EvolutionMetavars {
     Exit
   };
 
-  static std::string phase_name(Phase phase) noexcept {
-    if (phase == Phase::LoadBalancing) {
-      return "LoadBalancing";
-    }
-    ERROR(
-        "Passed phase that should not be used in input file. Integer "
-        "corresponding to phase is: "
-        << static_cast<int>(phase));
-  }
-
-  using phase_changes =
-      tmpl::list<PhaseControl::Registrars::VisitAndReturn<EvolutionMetavars,
-                                                          Phase::LoadBalancing>,
-                 PhaseControl::Registrars::CheckpointAndExitAfterWallclock<
-                     EvolutionMetavars>>;
-
-  using initialize_phase_change_decision_data =
-      PhaseControl::InitializePhaseChangeDecisionData<phase_changes>;
-
-  using phase_change_tags_and_combines_list =
-      PhaseControl::get_phase_change_tags<phase_changes>;
-
-  using const_global_cache_tags =
-      tmpl::list<initial_data_tag, Tags::EventsAndTriggers,
-                 PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes>>;
-
   using dg_registration_list =
       tmpl::list<observers::Actions::RegisterEventsWithObservers>;
 
@@ -271,17 +246,52 @@ struct EvolutionMetavars {
 
           Parallel::PhaseActions<
               Phase, Phase::Evolve,
-              tmpl::list<
-                  Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
-                  step_actions, Actions::AdvanceTime,
-                  PhaseControl::Actions::ExecutePhaseChange<phase_changes>>>>>;
+              tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
+                         step_actions, Actions::AdvanceTime,
+                         PhaseControl::Actions::ExecutePhaseChange>>>>;
 
-  template <typename ParallelComponent>
-  struct registration_list {
-    using type =
-        std::conditional_t<std::is_same_v<ParallelComponent, dg_element_array>,
-                           dg_registration_list, tmpl::list<>>;
+  template <typename DgElementArray, typename DgRegistrationList>
+  struct PhaseSelection : tt::ConformsTo<PhaseControl::PhaseSelection> {
+    using phase_changes =
+        tmpl::list<PhaseControl::Registrars::VisitAndReturn<
+                       EvolutionMetavars, Phase::LoadBalancing>,
+                   PhaseControl::Registrars::VisitAndReturn<
+                       EvolutionMetavars, Phase::WriteCheckpoint>,
+                   PhaseControl::Registrars::CheckpointAndExitAfterWallclock<
+                       EvolutionMetavars>>;
+
+    using initialize_phase_change_decision_data =
+        PhaseControl::InitializePhaseChangeDecisionData<phase_changes>;
+    using phase_change_tags_and_combines_list =
+        PhaseControl::get_phase_change_tags<phase_changes>;
+
+    static std::string phase_name(Phase phase) noexcept {
+      if (phase == Phase::LoadBalancing) {
+        return "LoadBalancing";
+      } else if (phase == Phase::WriteCheckpoint) {
+        return "WriteCheckpoint";
+      }
+      ERROR(
+          "Passed phase that should not be used in input file. Integer "
+          "corresponding to phase is: "
+          << static_cast<int>(phase));
+    }
+
+    template <typename ParallelComponent>
+    struct registration_list {
+      using type =
+          std::conditional_t<std::is_same_v<ParallelComponent, DgElementArray>,
+                             DgRegistrationList, tmpl::list<>>;
+    };
   };
+
+  using phase_selection =
+      PhaseSelection<dg_element_array, dg_registration_list>;
+
+  using const_global_cache_tags =
+      tmpl::list<initial_data_tag, Tags::EventsAndTriggers,
+                 PhaseControl::Tags::PhaseChangeAndTriggers<
+                     typename phase_selection::phase_changes>>;
 
   using component_list =
       tmpl::list<observers::Observer<EvolutionMetavars>,
@@ -299,7 +309,8 @@ struct EvolutionMetavars {
       const Phase& current_phase,
       const Parallel::CProxy_GlobalCache<EvolutionMetavars>&
           cache_proxy) noexcept {
-    const auto next_phase = PhaseControl::arbitrate_phase_change<phase_changes>(
+    const auto next_phase = PhaseControl::arbitrate_phase_change<
+        typename phase_selection::phase_changes>(
         phase_change_decision_data, current_phase,
         *(cache_proxy.ckLocalBranch()));
     if (next_phase.has_value()) {
@@ -339,7 +350,7 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &ScalarWave::BoundaryCorrections::register_derived_with_charm,
     &Parallel::register_derived_classes_with_charm<TimeStepper>,
     &Parallel::register_derived_classes_with_charm<
-        PhaseChange<metavariables::phase_changes>>,
+        PhaseChange<metavariables::phase_selection::phase_changes>>,
     &Parallel::register_factory_classes_with_charm<metavariables>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{

--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -62,19 +62,8 @@ class AlgorithmImpl;
 /// \endcond
 
 namespace Algorithm_detail {
-template <typename Metavariables, typename Component, typename = std::void_t<>>
-struct has_registration_list : std::false_type {};
-
-template <typename Metavariables, typename Component>
-struct has_registration_list<
-    Metavariables, Component,
-  std::void_t<
-    typename Metavariables::template registration_list<Component>::type>>
-    : std::true_type {};
-
-template <typename Metavariables, typename Component>
-constexpr bool has_registration_list_v =
-    has_registration_list<Metavariables, Component>::value;
+CREATE_HAS_TYPE_ALIAS(phase_selection)
+CREATE_HAS_TYPE_ALIAS_V(phase_selection)
 }  // namespace Algorithm_detail
 
 /*!
@@ -491,10 +480,9 @@ class AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>
     if (box.which() == *iter and not *already_visited) {
       // The deregistration and registration below does not actually insert
       // anything into the PUP::er stream, so nothing is done on a sizing pup.
-      if constexpr (Algorithm_detail::has_registration_list_v<
-                        metavariables, ParallelComponent>) {
+      if constexpr (Algorithm_detail::has_phase_selection_v<metavariables>) {
         using registration_list =
-            typename metavariables::template registration_list<
+            typename metavariables::phase_selection::template registration_list<
                 ParallelComponent>::type;
         if (p.isPacking()) {
           tmpl::for_each<registration_list>([this, &box](

--- a/src/Parallel/PhaseControl/CMakeLists.txt
+++ b/src/Parallel/PhaseControl/CMakeLists.txt
@@ -13,6 +13,7 @@ spectre_target_headers(
   ExecutePhaseChange.hpp
   PhaseChange.hpp
   PhaseControlTags.hpp
+  PhaseSelection.hpp
   VisitAndReturn.hpp
   )
 

--- a/src/Parallel/PhaseControl/ExecutePhaseChange.hpp
+++ b/src/Parallel/PhaseControl/ExecutePhaseChange.hpp
@@ -37,7 +37,6 @@ namespace Actions {
  *   - `PhaseChange` objects are permitted to perform mutations on the
  *     \ref DataBoxGroup "DataBox" to store persistent state information.
  */
-template <typename PhaseChangeRegistrars>
 struct ExecutePhaseChange {
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
@@ -49,8 +48,8 @@ struct ExecutePhaseChange {
       const ArrayIndex& array_index, const ActionList /*meta*/,
       const ParallelComponent* const /*component*/) noexcept {
     const auto& phase_change_and_triggers =
-        Parallel::get<Tags::PhaseChangeAndTriggers<PhaseChangeRegistrars>>(
-            cache);
+        Parallel::get<Tags::PhaseChangeAndTriggers<
+            typename Metavariables::phase_selection::phase_changes>>(cache);
     bool should_halt = false;
     for (const auto& [trigger, phase_changes] : phase_change_and_triggers) {
       if (trigger->is_triggered(box)) {

--- a/src/Parallel/PhaseControl/PhaseSelection.hpp
+++ b/src/Parallel/PhaseControl/PhaseSelection.hpp
@@ -1,0 +1,108 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <type_traits>
+
+#include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
+#include "Parallel/PhaseControl/PhaseControlTags.hpp"
+#include "Parallel/PhaseControl/VisitAndReturn.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace PhaseControl {
+namespace detail {
+CREATE_HAS_TYPE_ALIAS(type)
+CREATE_HAS_TYPE_ALIAS(combine_method)
+CREATE_HAS_TYPE_ALIAS(main_combine_method)
+}  // namespace detail
+
+/*!
+ * \brief Compile-time information for control-flow of phases.
+ *
+ * \details A class conforming to this protocol is placed in the metavariables
+ * to provide information about the set of phases that can be dynamically chosen
+ * during a simulation, and the runtime information that is used to arbitrate
+ * those decisions. The conforming class must provide the following type
+ * aliases:
+ *
+ * - `phase_changes`: A `tmpl::list` of the set of `PhaseControl` objects used
+ * to change phases.
+ * - `initialize_phase_change_decision_data`: A type with a static member
+ * function with signature:
+ * ```
+ * template <typename... DecisionTags, typename Metavariables>
+ * static void apply(
+ *     const gsl::not_null<tuples::TaggedTuple<DecisionTags...>*>
+ *         phase_change_decision_data,
+ *     const Parallel::GlobalCache<Metavariables>& cache) noexcept;
+ * ```
+ * that initializes each of the tags in `phase_change_tags_and_combines` that
+ * require initial values. This should almost always be an alias to
+ * `PhaseControl::InitializePhaseChangeDecisionData`, but can be customized to
+ * perform additional initialization if necessary.
+ * - `phase_change_tags_and_combines_list`: The set of tags that contain type
+ * aliases `combine_method` and `main_combine_method` for determining how the
+ * reduction is performed. These tags are typically available from the type
+ * alias `phase_change_tags_and_combines` from the individual `PhaseChange`
+ * objects, and can be aggregated from a list of `PhaseChange`s via
+ * `PhaseControl::get_phase_change_tags`.
+ * - `template <typename ParallelComponent> registration_list`: A metafunction
+ * that has the type alias `type` that is the list of registration actions that
+ * are used to de-register and re-register when an element of
+ * `ParallelComponent` is migrated. (Note: each item in these lists must be
+ * actions that also specify `perform_deregistration` and `perform_registration`
+ * static member functions that perform the de-registration and re-registration
+ * when an element is migrated. See
+ * `observers::Actions::RegisterEventsWithObservers` for an example of an action
+ * that conforms to the required interface).
+ *
+ * static member functions:
+ * - `static std::string phase_name(Phase phase) noexcept`: A function that
+ * returns the names of each phase that needs to be optionally specified in the
+ * input file (e.g. phases chosen using `PhaseControl::VisitAndReturn`.
+ *
+ * \note Two important parts of the phase choice architecture must also be
+ * present in the wider metavariables:
+ * - the `enum class Phase` enumerating the set of phases
+ * - the static member function with the signature:
+ * ```
+ * template <typename... Tags>
+ * static Phase determine_next_phase(
+ *     const gsl::not_null<tuples::TaggedTuple<Tags...>*>
+ *         phase_change_decision_data,
+ *     const Phase& current_phase,
+ *     const Parallel::CProxy_GlobalCache<EvolutionMetavars>&
+ *         cache_proxy) noexcept
+ * ```
+ * The function should typically have body similar to (with possible alteration
+ * for the set of sequenced phases in the executable):
+ *
+ * \snippet Test_AlgorithmPhaseControl.cpp determine_next_phase_example
+ */
+struct PhaseSelection {
+  template <typename ConformingType>
+  struct test {
+    using phase_changes = typename ConformingType::phase_changes;
+    using initialize_phase_change_decision_data =
+        typename ConformingType::initialize_phase_change_decision_data;
+    static_assert(
+        std::is_function_v<initialize_phase_change_decision_data::apply>);
+
+    using phase_change_tags_and_combines =
+        typename ConformingType::phase_change_tags_and_combines;
+    static_assert(
+        tmpl::all<
+            phase_change_tags_and_combines,
+            tmpl::bind<tmpl::all, detail::has_type<tmpl::_1>,
+                       detail::has_combine_method<tmpl::_1>,
+                       detail::has_main_combine_method<tmpl::_1>>>::value);
+
+    static_assert(
+        std::is_same_v<std::void_t<typename ConformingType::
+                                       template registration_list<NoSuchType>>,
+                       std::void_t<>>);
+    static_assert(std::is_function_v<ConformingType::phase_name>);
+  };
+};
+}  // namespace PhaseControl

--- a/src/Parallel/PhaseControl/VisitAndReturn.hpp
+++ b/src/Parallel/PhaseControl/VisitAndReturn.hpp
@@ -88,9 +88,9 @@ struct TemporaryPhaseRequested {
  * phase, it will execute.
  *
  * To determine which specialization of this template is requested from the
- * input file, the `Metavariables` must define a `phase_name(Phase)` static
- * member function that returns a string for each phase that will be used in
- * `VisitAndReturn`s.
+ * input file, the `Metavariables::phase_selection` struct must define a
+ * `phase_name(Phase)` static member function that returns a string for each
+ * phase that will be used in `VisitAndReturn`s.
  *
  * \note  If multiple such methods are specified (with different
  * `TargetPhase`s), then the order of phase jumps depends on their order in the
@@ -117,8 +117,8 @@ struct VisitAndReturn : public PhaseChange<PhaseChangeRegistrars> {
   /// \endcond
 
   static std::string name() noexcept {
-    return "VisitAndReturn(" + Metavariables::phase_name(TargetPhase) +
-           ")";
+    return "VisitAndReturn(" +
+           Metavariables::phase_selection::phase_name(TargetPhase) + ")";
   }
   using options = tmpl::list<>;
   static constexpr Options::String help{


### PR DESCRIPTION
## Proposed changes

Adds a metavariables struct that contains the metavariables type aliases and functions that are used by `PhaseControl` infrastructure, and adds some documentation for them in the protocol associated.
Some of the metavariables changes required additional tweaks to the GeneralizedHarmonic and GhValenciaDivClean executables to accommodate the different order of definitions.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
