### PR TITLE
Add block names to domain creators

### DIFF
--- a/src/Domain/Creators/Cylinder.cpp
+++ b/src/Domain/Creators/Cylinder.cpp
@@ -143,16 +143,28 @@ Cylinder::Cylinder(
   for (size_t layer = 0; layer < num_layers; ++layer) {
     std::string layer_prefix =
         num_layers > 1 ? "Layer" + std::to_string(layer) : "";
-    block_names_.push_back(layer_prefix + "InnerCube");
+    const std::string inner_cube_name = layer_prefix + "InnerCube";
+    block_names_.push_back(inner_cube_name);
+    if (num_layers > 1) {
+      block_groups_[layer_prefix].insert(inner_cube_name);
+      block_groups_["InnerCubes"].insert(inner_cube_name);
+    }
     for (size_t shell = 0; shell < num_shells; ++shell) {
       std::string shell_prefix =
           num_shells > 1 ? "Shell" + std::to_string(shell) : "";
       std::string group_name = layer_prefix + shell_prefix + "Wedges";
       for (size_t direction = 0; direction < 4; ++direction) {
-        std::string block_name = layer_prefix + shell_prefix +
-                                 gsl::at(direction_descriptions, direction);
-        block_names_.push_back(block_name);
-        block_groups_[group_name].insert(block_name);
+        const std::string shell_name =
+            layer_prefix + shell_prefix +
+            gsl::at(direction_descriptions, direction);
+        block_names_.push_back(shell_name);
+        block_groups_[group_name].insert(shell_name);
+        if (num_layers > 1) {
+          block_groups_[layer_prefix].insert(shell_name);
+        }
+        if (num_shells > 1) {
+          block_groups_[shell_prefix].insert(shell_name);
+        }
       }
     }
   }

--- a/src/Domain/Creators/Cylinder.cpp
+++ b/src/Domain/Creators/Cylinder.cpp
@@ -140,13 +140,10 @@ Cylinder::Cylinder(
   // Create block names and groups
   static std::array<std::string, 4> direction_descriptions{"East", "North",
                                                            "West", "South"};
-  std::vector<std::string> block_names{};
-  std::unordered_map<std::string, std::unordered_set<std::string>>
-      block_groups{};
   for (size_t layer = 0; layer < num_layers; ++layer) {
     std::string layer_prefix =
         num_layers > 1 ? "Layer" + std::to_string(layer) : "";
-    block_names.push_back(layer_prefix + "InnerCube");
+    block_names_.push_back(layer_prefix + "InnerCube");
     for (size_t shell = 0; shell < num_shells; ++shell) {
       std::string shell_prefix =
           num_shells > 1 ? "Shell" + std::to_string(shell) : "";
@@ -154,15 +151,15 @@ Cylinder::Cylinder(
       for (size_t direction = 0; direction < 4; ++direction) {
         std::string block_name = layer_prefix + shell_prefix +
                                  gsl::at(direction_descriptions, direction);
-        block_names.push_back(block_name);
-        block_groups[group_name].insert(block_name);
+        block_names_.push_back(block_name);
+        block_groups_[group_name].insert(block_name);
       }
     }
   }
 
   // Expand initial refinement and number of grid points over all blocks
-  const ExpandOverBlocks<size_t, 3> expand_over_blocks{block_names,
-                                                       std::move(block_groups)};
+  const ExpandOverBlocks<size_t, 3> expand_over_blocks{block_names_,
+                                                       block_groups_};
   try {
     initial_refinement_ = std::visit(expand_over_blocks, initial_refinement);
   } catch (const std::exception& error) {

--- a/src/Domain/Creators/Cylinder.hpp
+++ b/src/Domain/Creators/Cylinder.hpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstddef>
 #include <unordered_map>
+#include <unordered_set>
 #include <variant>
 #include <vector>
 
@@ -278,6 +279,15 @@ class Cylinder : public DomainCreator<3> {
   std::vector<std::array<size_t, 3>> initial_refinement_levels()
       const noexcept override;
 
+  std::vector<std::string> block_names() const noexcept override {
+    return block_names_;
+  }
+
+  std::unordered_map<std::string, std::unordered_set<std::string>>
+  block_groups() const noexcept override {
+    return block_groups_;
+  }
+
  private:
   double inner_radius_{std::numeric_limits<double>::signaling_NaN()};
   double outer_radius_{std::numeric_limits<double>::signaling_NaN()};
@@ -297,5 +307,8 @@ class Cylinder : public DomainCreator<3> {
       upper_z_boundary_condition_{};
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
       mantle_boundary_condition_{};
+  std::vector<std::string> block_names_{};
+  std::unordered_map<std::string, std::unordered_set<std::string>>
+      block_groups_{};
 };
 }  // namespace domain::creators

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
@@ -174,29 +174,24 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
   }
 
   // Create block names and groups
-  std::vector<std::string> block_names{};
-  std::unordered_map<std::string, std::unordered_set<std::string>>
-      block_groups{};
-
-  auto add_filled_cylinder_name = [&block_names, &block_groups](
+  auto add_filled_cylinder_name = [this](
                                       const std::string& prefix,
                                       const std::string& group_name) noexcept {
     for (const std::string& where :
          {"Center", "East", "North", "West", "South"}) {
       const std::string name =
           std::string(prefix).append("FilledCylinder").append(where);
-      block_names.push_back(name);
-      block_groups[group_name].insert(name);
+      block_names_.push_back(name);
+      block_groups_[group_name].insert(name);
     }
   };
-  auto add_cylinder_name = [&block_names, &block_groups](
-                               const std::string& prefix,
-                               const std::string& group_name) noexcept {
+  auto add_cylinder_name = [this](const std::string& prefix,
+                                  const std::string& group_name) noexcept {
     for (const std::string& where : {"East", "North", "West", "South"}) {
       const std::string name =
           std::string(prefix).append("Cylinder").append(where);
-      block_names.push_back(name);
-      block_groups[group_name].insert(name);
+      block_names_.push_back(name);
+      block_groups_[group_name].insert(name);
     }
   };
 
@@ -241,8 +236,8 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
   add_cylinder_name("CB", "Outer");
 
   // Expand initial refinement over all blocks
-  const ExpandOverBlocks<size_t, 3> expand_over_blocks{block_names,
-                                                       std::move(block_groups)};
+  const ExpandOverBlocks<size_t, 3> expand_over_blocks{block_names_,
+                                                       block_groups_};
   try {
     initial_refinement_ = std::visit(expand_over_blocks, initial_refinement);
   } catch (const std::exception& error) {

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <variant>
 #include <vector>
 
@@ -294,6 +295,15 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
       std::string,
       std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override;
 
+  std::vector<std::string> block_names() const noexcept override {
+    return block_names_;
+  }
+
+  std::unordered_map<std::string, std::unordered_set<std::string>>
+  block_groups() const noexcept override {
+    return block_groups_;
+  }
+
  private:
   // Note that center_A_ and center_B_ are rotated with respect to the
   // input centers (which are in the grid frame), so that we can
@@ -326,5 +336,8 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
       inner_boundary_condition_;
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
       outer_boundary_condition_;
+  std::vector<std::string> block_names_{};
+  std::unordered_map<std::string, std::unordered_set<std::string>>
+      block_groups_{};
 };
 }  // namespace domain::creators

--- a/src/Domain/Creators/DomainCreator.hpp
+++ b/src/Domain/Creators/DomainCreator.hpp
@@ -11,6 +11,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
@@ -40,6 +41,18 @@ class DomainCreator {
   virtual ~DomainCreator() = default;
 
   virtual Domain<VolumeDim> create_domain() const = 0;
+
+  /// A human-readable name for every block, or empty if the domain creator
+  /// doesn't support block names (yet).
+  virtual std::vector<std::string> block_names() const noexcept { return {}; }
+
+  /// Labels to refer to groups of blocks. The groups can overlap, and they
+  /// don't have to cover all blocks in the domain. The groups can be used to
+  /// refer to multiple blocks at once when specifying input-file options.
+  virtual std::unordered_map<std::string, std::unordered_set<std::string>>
+  block_groups() const noexcept {
+    return {};
+  }
 
   /// Obtain the initial grid extents of the Element%s in each block.
   virtual std::vector<std::array<size_t, VolumeDim>> initial_extents() const

--- a/src/Domain/Tags/BlockNamesAndGroups.hpp
+++ b/src/Domain/Tags/BlockNamesAndGroups.hpp
@@ -1,0 +1,52 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/OptionTags.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace domain::Tags {
+
+/// A human-readable name for every block in the domain.
+///
+/// \warning Not all domain creators support block names yet, so the list may be
+/// empty.
+/// \see DomainCreator::block_names
+template <size_t Dim>
+struct BlockNames : db::SimpleTag {
+  using type = std::vector<std::string>;
+
+  static constexpr bool pass_metavariables = false;
+  using option_tags = tmpl::list<domain::OptionTags::DomainCreator<Dim>>;
+  static type create_from_options(
+      const std::unique_ptr<::DomainCreator<Dim>>& domain_creator) noexcept {
+    return domain_creator->block_names();
+  }
+};
+
+/// Labeled groups of blocks
+///
+/// \see DomainCreator::block_groups
+template <size_t Dim>
+struct BlockGroups : db::SimpleTag {
+  using type = std::unordered_map<std::string, std::unordered_set<std::string>>;
+
+  static constexpr bool pass_metavariables = false;
+  using option_tags = tmpl::list<domain::OptionTags::DomainCreator<Dim>>;
+  static type create_from_options(
+      const std::unique_ptr<::DomainCreator<Dim>>& domain_creator) noexcept {
+    return domain_creator->block_groups();
+  }
+};
+
+}  // namespace domain::Tags

--- a/src/Domain/Tags/CMakeLists.txt
+++ b/src/Domain/Tags/CMakeLists.txt
@@ -5,6 +5,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  BlockNamesAndGroups.hpp
   FaceNormal.hpp
   Faces.hpp
   )

--- a/tests/Unit/Domain/Creators/Test_Cylinder.cpp
+++ b/tests/Unit/Domain/Creators/Test_Cylinder.cpp
@@ -307,6 +307,13 @@ void test_cylinder_no_refinement() {
                                      equiangular_map,
                                      {},
                                      {}};
+        CHECK(cylinder.block_names() ==
+              std::vector<std::string>{"InnerCube", "East", "North", "West",
+                                       "South"});
+        CHECK(cylinder.block_groups() ==
+              std::unordered_map<std::string, std::unordered_set<std::string>>{
+                  {"Wedges", {"East", "North", "West", "South"}}});
+
         test_physical_separation(cylinder.create_domain().blocks());
         test_cylinder_construction(
             cylinder, inner_radius, outer_radius, lower_z_bound, upper_z_bound,
@@ -472,6 +479,46 @@ void test_refined_cylinder_boundaries(
       {domain::CoordinateMaps::Distribution::Linear, outer_radial_distribution},
       {domain::CoordinateMaps::Distribution::Linear,
        uppermost_distribution_in_z}};
+  CHECK(refined_cylinder.block_names() ==
+        std::vector<std::string>{
+            "Layer0InnerCube", "Layer0Shell0East", "Layer0Shell0North",
+            "Layer0Shell0West", "Layer0Shell0South", "Layer0Shell1East",
+            "Layer0Shell1North", "Layer0Shell1West", "Layer0Shell1South",
+            "Layer1InnerCube", "Layer1Shell0East", "Layer1Shell0North",
+            "Layer1Shell0West", "Layer1Shell0South", "Layer1Shell1East",
+            "Layer1Shell1North", "Layer1Shell1West", "Layer1Shell1South"});
+  CHECK(refined_cylinder.block_groups() ==
+        std::unordered_map<std::string, std::unordered_set<std::string>>{
+            {"InnerCubes", {"Layer0InnerCube", "Layer1InnerCube"}},
+            {"Layer0",
+             {"Layer0InnerCube", "Layer0Shell0East", "Layer0Shell0North",
+              "Layer0Shell0West", "Layer0Shell0South", "Layer0Shell1East",
+              "Layer0Shell1North", "Layer0Shell1West", "Layer0Shell1South"}},
+            {"Layer1",
+             {"Layer1InnerCube", "Layer1Shell0East", "Layer1Shell0North",
+              "Layer1Shell0West", "Layer1Shell0South", "Layer1Shell1East",
+              "Layer1Shell1North", "Layer1Shell1West", "Layer1Shell1South"}},
+            {"Shell0",
+             {"Layer0Shell0East", "Layer0Shell0North", "Layer0Shell0West",
+              "Layer0Shell0South", "Layer1Shell0East", "Layer1Shell0North",
+              "Layer1Shell0West", "Layer1Shell0South"}},
+            {"Shell1",
+             {"Layer0Shell1East", "Layer0Shell1North", "Layer0Shell1West",
+              "Layer0Shell1South", "Layer1Shell1East", "Layer1Shell1North",
+              "Layer1Shell1West", "Layer1Shell1South"}},
+            {"Layer0Shell0Wedges",
+             {"Layer0Shell0East", "Layer0Shell0North", "Layer0Shell0West",
+              "Layer0Shell0South"}},
+            {"Layer1Shell0Wedges",
+             {"Layer1Shell0East", "Layer1Shell0North", "Layer1Shell0West",
+              "Layer1Shell0South"}},
+            {"Layer0Shell1Wedges",
+             {"Layer0Shell1East", "Layer0Shell1North", "Layer0Shell1West",
+              "Layer0Shell1South"}},
+            {"Layer1Shell1Wedges",
+             {"Layer1Shell1East", "Layer1Shell1North", "Layer1Shell1West",
+              "Layer1Shell1South"}}});
+
   test_physical_separation(refined_cylinder.create_domain().blocks());
 
   const auto domain = refined_cylinder.create_domain();

--- a/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
@@ -226,6 +226,60 @@ void test_connectivity() {
                                        : nullptr,
               with_boundary_conditions ? create_outer_boundary_condition()
                                        : nullptr};
+
+      CHECK(binary_compact_object.block_names() ==
+            std::vector<std::string>{
+                "CAFilledCylinderCenter", "CAFilledCylinderEast",
+                "CAFilledCylinderNorth",  "CAFilledCylinderWest",
+                "CAFilledCylinderSouth",  "CACylinderEast",
+                "CACylinderNorth",        "CACylinderWest",
+                "CACylinderSouth",        "EAFilledCylinderCenter",
+                "EAFilledCylinderEast",   "EAFilledCylinderNorth",
+                "EAFilledCylinderWest",   "EAFilledCylinderSouth",
+                "EACylinderEast",         "EACylinderNorth",
+                "EACylinderWest",         "EACylinderSouth",
+                "EBFilledCylinderCenter", "EBFilledCylinderEast",
+                "EBFilledCylinderNorth",  "EBFilledCylinderWest",
+                "EBFilledCylinderSouth",  "EBCylinderEast",
+                "EBCylinderNorth",        "EBCylinderWest",
+                "EBCylinderSouth",        "MAFilledCylinderCenter",
+                "MAFilledCylinderEast",   "MAFilledCylinderNorth",
+                "MAFilledCylinderWest",   "MAFilledCylinderSouth",
+                "MBFilledCylinderCenter", "MBFilledCylinderEast",
+                "MBFilledCylinderNorth",  "MBFilledCylinderWest",
+                "MBFilledCylinderSouth",  "CBFilledCylinderCenter",
+                "CBFilledCylinderEast",   "CBFilledCylinderNorth",
+                "CBFilledCylinderWest",   "CBFilledCylinderSouth",
+                "CBCylinderEast",         "CBCylinderNorth",
+                "CBCylinderWest",         "CBCylinderSouth"});
+      CHECK(binary_compact_object.block_groups() ==
+            std::unordered_map<std::string, std::unordered_set<std::string>>{
+                {"Outer",
+                 {{"CAFilledCylinderCenter", "CBCylinderEast",
+                   "CAFilledCylinderEast", "CAFilledCylinderNorth",
+                   "CBFilledCylinderNorth", "CACylinderEast",
+                   "CBFilledCylinderEast", "CAFilledCylinderSouth",
+                   "CACylinderNorth", "CAFilledCylinderWest", "CACylinderWest",
+                   "CACylinderSouth", "CBFilledCylinderCenter",
+                   "CBFilledCylinderWest", "CBFilledCylinderSouth",
+                   "CBCylinderNorth", "CBCylinderWest", "CBCylinderSouth"}}},
+                {"InnerA",
+                 {"EAFilledCylinderCenter", "MAFilledCylinderNorth",
+                  "EACylinderSouth", "EAFilledCylinderSouth", "EACylinderNorth",
+                  "EACylinderWest", "MAFilledCylinderCenter",
+                  "EAFilledCylinderNorth", "EAFilledCylinderWest",
+                  "MAFilledCylinderSouth", "EACylinderEast",
+                  "MAFilledCylinderEast", "EAFilledCylinderEast",
+                  "MAFilledCylinderWest"}},
+                {"InnerB",
+                 {"EBFilledCylinderEast", "MBFilledCylinderEast",
+                  "EBFilledCylinderSouth", "EBFilledCylinderNorth",
+                  "EBFilledCylinderWest", "EBCylinderEast",
+                  "MBFilledCylinderWest", "EBCylinderNorth", "EBCylinderSouth",
+                  "EBCylinderWest", "MBFilledCylinderCenter",
+                  "EBFilledCylinderCenter", "MBFilledCylinderNorth",
+                  "MBFilledCylinderSouth"}}});
+
       test_binary_compact_object_construction(
           binary_compact_object, std::numeric_limits<double>::signaling_NaN(),
           {}, {},

--- a/tests/Unit/Domain/Creators/Test_Interval.cpp
+++ b/tests/Unit/Domain/Creators/Test_Interval.cpp
@@ -98,6 +98,12 @@ void test_interval() {
                                       grid_points[0],
                                       std::array<bool, 1>{{false}},
                                       nullptr};
+
+    // This domain creator doesn't support block names and groups yet, so they
+    // should be empty
+    CHECK(interval.block_names().empty());
+    CHECK(interval.block_groups().empty());
+
     test_interval_construction(
         interval, lower_bound, upper_bound, grid_points, refinement_level,
         std::vector<DirectionMap<1, BlockNeighbor<1>>>{{}},

--- a/tests/Unit/Domain/Tags/CMakeLists.txt
+++ b/tests/Unit/Domain/Tags/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_DomainTags")
 
 set(LIBRARY_SOURCES
+  Test_BlockNamesAndGroups.cpp
   Test_Faces.cpp
   )
 

--- a/tests/Unit/Domain/Tags/Test_BlockNamesAndGroups.cpp
+++ b/tests/Unit/Domain/Tags/Test_BlockNamesAndGroups.cpp
@@ -1,0 +1,19 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "Domain/Tags/BlockNamesAndGroups.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+
+namespace domain {
+
+SPECTRE_TEST_CASE("Unit.Domain.Tags.BlockNamesAndGroups", "[Unit][Domain]") {
+  constexpr size_t Dim = 1;
+  TestHelpers::db::test_simple_tag<Tags::BlockNames<Dim>>("BlockNames");
+  TestHelpers::db::test_simple_tag<Tags::BlockGroups<Dim>>("BlockGroups");
+}
+
+}  // namespace domain


### PR DESCRIPTION
## Proposed changes

Domain creators can label the blocks with human-readable names. This will be useful to provide per-block options in the input file, observe reduction quantities per-block, output better error messages, etc.

Only `Cylinder` and `CylindricalBinaryCompactObject` support block names so far.

Closes #3024.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
