### PR TITLE
Evaluate damping parameters in grid frame

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
@@ -119,11 +119,11 @@ struct EvolutionMetavars
           EvolutionMetavars>::analytic_solution_tag,
       Tags::EventsAndTriggers,
       GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma0<
-          volume_dim, frame>,
+          volume_dim, Frame::Grid>,
       GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma1<
-          volume_dim, frame>,
+          volume_dim, Frame::Grid>,
       GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma2<
-          volume_dim, frame>,
+          volume_dim, Frame::Grid>,
       PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes>>;
 
   using observed_reduction_data_tags =

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -265,11 +265,11 @@ struct GeneralizedHarmonicTemplateBase<
   using const_global_cache_tags = tmpl::list<
       analytic_solution_tag, Tags::EventsAndTriggers,
       GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma0<
-          volume_dim, frame>,
+          volume_dim, Frame::Grid>,
       GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma1<
-          volume_dim, frame>,
+          volume_dim, Frame::Grid>,
       GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma2<
-          volume_dim, frame>,
+          volume_dim, Frame::Grid>,
       PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes>>;
 
   using dg_registration_list =

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizon.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizon.hpp
@@ -116,11 +116,11 @@ struct EvolutionMetavars
       grmhd::ValenciaDivClean::Tags::ConstraintDampingParameter,
       Tags::EventsAndTriggers,
       GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma0<
-          volume_dim, domain_frame>,
+          volume_dim, Frame::Grid>,
       GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma1<
-          volume_dim, domain_frame>,
+          volume_dim, Frame::Grid>,
       GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma2<
-          volume_dim, domain_frame>,
+          volume_dim, Frame::Grid>,
       PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes>>>;
 
   using observed_reduction_data_tags =

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -341,11 +341,11 @@ struct GhValenciaDivCleanTemplateBase<
       grmhd::ValenciaDivClean::Tags::ConstraintDampingParameter,
       Tags::EventsAndTriggers,
       GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma0<
-          volume_dim, domain_frame>,
+          volume_dim, Frame::Grid>,
       GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma1<
-          volume_dim, domain_frame>,
+          volume_dim, Frame::Grid>,
       GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma2<
-          volume_dim, domain_frame>,
+          volume_dim, Frame::Grid>,
       PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes>>>;
 
   using dg_registration_list =

--- a/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
@@ -101,17 +101,17 @@ struct InitializeGhAnd3Plus1Variables {
       gr::Tags::SpacetimeNormalVectorCompute<Dim, frame, DataVector>,
       gr::Tags::InverseSpacetimeMetricCompute<Dim, frame, DataVector>,
       GeneralizedHarmonic::Tags::ThreeIndexConstraintCompute<Dim, frame>,
-      ConstraintDamping::Tags::ConstraintGamma0Compute<Dim, frame>,
-      ConstraintDamping::Tags::ConstraintGamma1Compute<Dim, frame>,
-      ConstraintDamping::Tags::ConstraintGamma2Compute<Dim, frame>>;
+      ConstraintDamping::Tags::ConstraintGamma0Compute<Dim, Frame::Grid>,
+      ConstraintDamping::Tags::ConstraintGamma1Compute<Dim, Frame::Grid>,
+      ConstraintDamping::Tags::ConstraintGamma2Compute<Dim, Frame::Grid>>;
 
   using const_global_cache_tags = tmpl::list<
       GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma0<
-          Dim, frame>,
+          Dim, Frame::Grid>,
       GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma1<
-          Dim, frame>,
+          Dim, Frame::Grid>,
       GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma2<
-          Dim, frame>>;
+          Dim, Frame::Grid>>;
 
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,


### PR DESCRIPTION
## Proposed changes

In general, constraint damping parameters for generalized harmonic evolutions should move with the grid, and thus they should be defined in `Frame::Grid` instead of `Frame::Inertial`. This change is required for stable BBH evolutions.

### Upgrade instructions

If you add an executable using the generalized harmonic system, it should add the GH constraint damping parameters in `Frame::Grid`, not `Frame::Inertial`.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
