### PR TITLE
Add filtering to GH Exec

### DIFF
--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
@@ -71,6 +71,12 @@ EvolutionSystem:
         Width: 1.0
         Center: [0.0]
 
+Filtering:
+  ExpFilter0:
+    Alpha: 36.0
+    HalfPower: 64
+    DisableForDebugging: True
+
 SpatialDiscretization:
   DiscontinuousGalerkin:
     Formulation: StrongInertial

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
@@ -63,6 +63,12 @@ EvolutionSystem:
         Width: 1.0
         Center: [0.0, 0.0, 0.0]
 
+Filtering:
+  ExpFilter0:
+    Alpha: 36.0
+    HalfPower: 64
+    DisableForDebugging: True
+
 SpatialDiscretization:
   DiscontinuousGalerkin:
     Formulation: StrongInertial

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -81,6 +81,12 @@ EvolutionSystem:
         Width: 11.313708499
         Center: [0.0, 0.0, 0.0]
 
+Filtering:
+  ExpFilter0:
+    Alpha: 36.0
+    HalfPower: 64
+    DisableForDebugging: False
+
 SpatialDiscretization:
   BoundaryCorrection:
     UpwindPenalty:


### PR DESCRIPTION
## Proposed changes

Add filtering to the GH executables. Note that filtering can be disabled in evolutions through input file options. This change is to support BBH evolutions.

### Upgrade instructions

Input files for the generalized harmonic executables must provide options specifying what filtering to use (or to disable the filtering entirely).

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
