### PR TITLE
Observe lapse, constraints in GH exec

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -80,6 +80,7 @@
 #include "ParallelAlgorithms/Events/Factory.hpp"
 #include "ParallelAlgorithms/Events/ObserveErrorNorms.hpp"
 #include "ParallelAlgorithms/Events/ObserveFields.hpp"
+#include "ParallelAlgorithms/Events/ObserveNorms.hpp"
 #include "ParallelAlgorithms/Events/ObserveTimeStep.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Completion.hpp"
@@ -208,7 +209,7 @@ struct GeneralizedHarmonicTemplateBase<
 
   using observe_fields = tmpl::append<
       tmpl::push_back<
-          analytic_solution_fields,
+          analytic_solution_fields, gr::Tags::Lapse<DataVector>,
           ::Tags::PointwiseL2Norm<
               GeneralizedHarmonic::Tags::GaugeConstraint<volume_dim, frame>>,
           ::Tags::PointwiseL2Norm<GeneralizedHarmonic::Tags::
@@ -224,12 +225,13 @@ struct GeneralizedHarmonicTemplateBase<
     using factory_classes = tmpl::map<
         tmpl::pair<DenseTrigger, DenseTriggers::standard_dense_triggers>,
         tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
-        tmpl::pair<Event, tmpl::flatten<tmpl::list<
-                              Events::Completion,
-                              dg::Events::field_observations<
-                                  volume_dim, Tags::Time, observe_fields,
-                                  analytic_solution_fields>,
-                              Events::time_events<system>>>>,
+        tmpl::pair<Event,
+                   tmpl::flatten<tmpl::list<
+                       Events::Completion, Events::ObserveNorms<observe_fields>,
+                       dg::Events::field_observations<volume_dim, Tags::Time,
+                                                      observe_fields,
+                                                      analytic_solution_fields>,
+                       Events::time_events<system>>>>,
         tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
                    StepChoosers::standard_step_choosers<system>>,
         tmpl::pair<

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -97,6 +97,25 @@ EventsAndTriggers:
         SubfileName: Errors
   ? Slabs:
       EvenlySpaced:
+        Interval: 2
+        Offset: 0
+  : - ObserveNorms:
+        SubfileName: Norms
+        TensorsToObserve:
+        - Name: Lapse
+          NormType: L2Norm
+          Components: Individual
+        - Name: PointwiseL2Norm(GaugeConstraint)
+          NormType: L2Norm
+          Components: Sum
+        - Name: PointwiseL2Norm(ThreeIndexConstraint)
+          NormType: L2Norm
+          Components: Sum
+        - Name: PointwiseL2Norm(FourIndexConstraint)
+          NormType: L2Norm
+          Components: Sum
+  ? Slabs:
+      EvenlySpaced:
         Interval: 5
         Offset: 0
   : - ObserveFields:


### PR DESCRIPTION
## Proposed changes

This PR makes the following changes necessary for observation in BBH simulations:

1. Currently, field_observations computes only ErrorNorms, which is not appropriate for numeric initial data. This PR updates field_observations to optionally (i.e., if no analytic solution) call ObserveNorms on the fields (e.g., constraints) instead of ObserveErrorNorms on the analytic solution.
2. The GH exec is updated to observe the lapse (useful for visualization) and, if numeric initial data, the constraints (via the changes to ObserveErrorNorms mentioned in item 1 above).

### Upgrade instructions

If you pass `tmpl::list<>` for the analytic solution fields to `field_observations`, norms of the fields (e.g. constraints) will be output, instead of no norms being output.

<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
