### PR TITLE
Support per-core reductions

### DIFF
--- a/src/IO/Observer/CMakeLists.txt
+++ b/src/IO/Observer/CMakeLists.txt
@@ -6,6 +6,7 @@ spectre_target_sources(
   PRIVATE
   ArrayComponentId.cpp
   ObservationId.cpp
+  ReductionActions.cpp
   TypeOfObservation.cpp
   )
 

--- a/src/IO/Observer/ReductionActions.cpp
+++ b/src/IO/Observer/ReductionActions.cpp
@@ -1,0 +1,24 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "IO/Observer/ReductionActions.hpp"
+
+#include <vector>
+
+#include "Utilities/Gsl.hpp"
+
+namespace observers::ThreadedActions::ReductionActions_detail {
+
+void append_to_reduction_data(
+    const gsl::not_null<std::vector<double>*> all_reduction_data,
+    const double t) noexcept {
+  all_reduction_data->push_back(t);
+}
+
+void append_to_reduction_data(
+    const gsl::not_null<std::vector<double>*> all_reduction_data,
+    const std::vector<double>& t) noexcept {
+  all_reduction_data->insert(all_reduction_data->end(), t.begin(), t.end());
+}
+
+}  // namespace observers::ThreadedActions::ReductionActions_detail

--- a/src/ParallelAlgorithms/Events/ObserveTimeStep.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveTimeStep.hpp
@@ -124,13 +124,19 @@ class ObserveTimeStep : public Event {
         "Whether to print the time to screen."};
   };
 
+  struct ObservePerCore {
+    using type = bool;
+    static constexpr Options::String help = {
+        "Also write the data per-core in a file per-node."};
+  };
+
   /// \cond
   explicit ObserveTimeStep(CkMigrateMessage* /*unused*/) noexcept {}
   using PUP::able::register_constructor;
   WRAPPED_PUPable_decl_template(ObserveTimeStep);  // NOLINT
   /// \endcond
 
-  using options = tmpl::list<SubfileName, PrintTimeToTerminal>;
+  using options = tmpl::list<SubfileName, PrintTimeToTerminal, ObservePerCore>;
   static constexpr Options::String help =
       "Observe the size of the time steps.\n"
       "\n"
@@ -150,7 +156,8 @@ class ObserveTimeStep : public Event {
 
   ObserveTimeStep() = default;
   explicit ObserveTimeStep(const std::string& subfile_name,
-                           const bool output_time) noexcept;
+                           const bool output_time,
+                           const bool observe_per_core) noexcept;
 
   using observed_reduction_data_tags =
       observers::make_reduction_data_tags<tmpl::list<ReductionData>>;
@@ -192,7 +199,7 @@ class ObserveTimeStep : public Event {
         ReductionData{time, number_of_grid_points, slab_size, step_size,
                       step_size, number_of_grid_points / step_size, wall_time,
                       wall_time},
-        std::move(formatter));
+        std::move(formatter), observe_per_core_);
   }
 
   using observation_registration_tags = tmpl::list<>;
@@ -218,17 +225,22 @@ class ObserveTimeStep : public Event {
     Event::pup(p);
     p | subfile_path_;
     p | output_time_;
+    p | observe_per_core_;
   }
 
  private:
   std::string subfile_path_;
   bool output_time_;
+  bool observe_per_core_;
 };
 
 template <typename System>
 ObserveTimeStep<System>::ObserveTimeStep(const std::string& subfile_name,
-                                                const bool output_time) noexcept
-    : subfile_path_("/" + subfile_name), output_time_(output_time) {}
+                                         const bool output_time,
+                                         const bool observe_per_core) noexcept
+    : subfile_path_("/" + subfile_name),
+      output_time_(output_time),
+      observe_per_core_(observe_per_core) {}
 
 /// \cond
 template <typename System>

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/Tags.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/Tags.hpp
@@ -53,6 +53,15 @@ struct SkipSubdomainSolverResets {
       "overall is highly problem-dependent.";
 };
 
+template <typename OptionsGroup>
+struct ObservePerCoreReductions {
+  using type = bool;
+  using group = OptionsGroup;
+  static constexpr Options::String help =
+      "Output statistics per-core in a file per-node, e.g. to assess the load "
+      "(im)balance of subdomain solves.";
+};
+
 }  // namespace OptionTags
 
 /// Tags related to the Schwarz solver
@@ -100,6 +109,16 @@ struct SkipSubdomainSolverResets : db::SimpleTag {
   static constexpr bool pass_metavariables = false;
   using option_tags =
       tmpl::list<OptionTags::SkipSubdomainSolverResets<OptionsGroup>>;
+  static bool create_from_options(const bool value) noexcept { return value; }
+};
+
+/// Enable per-core reduction observations
+template <typename OptionsGroup>
+struct ObservePerCoreReductions : db::SimpleTag {
+  using type = bool;
+  static constexpr bool pass_metavariables = false;
+  using option_tags =
+      tmpl::list<OptionTags::ObservePerCoreReductions<OptionsGroup>>;
   static bool create_from_options(const bool value) noexcept { return value; }
 };
 

--- a/tests/InputFiles/Elasticity/BentBeam.yaml
+++ b/tests/InputFiles/Elasticity/BentBeam.yaml
@@ -65,6 +65,7 @@ LinearSolver:
     MaxOverlap: 2
     Verbosity: Quiet
     SubdomainSolver: ExplicitInverse
+    ObservePerCoreReductions: False
 
 EventsAndTriggers:
   ? HasConverged

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -90,6 +90,7 @@ LinearSolver:
         Preconditioner:
           MinusLaplacian:
             Solver: ExplicitInverse
+    ObservePerCoreReductions: False
 
 EventsAndTriggers:
   ? HasConverged

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -62,6 +62,7 @@ LinearSolver:
     MaxOverlap: 2
     Verbosity: Quiet
     SubdomainSolver: ExplicitInverse
+    ObservePerCoreReductions: False
 
 EventsAndTriggers:
   ? HasConverged

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -58,6 +58,7 @@ LinearSolver:
     MaxOverlap: 2
     Verbosity: Quiet
     SubdomainSolver: ExplicitInverse
+    ObservePerCoreReductions: False
 
 EventsAndTriggers:
   ? HasConverged

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -59,6 +59,7 @@ LinearSolver:
     MaxOverlap: 2
     Verbosity: Quiet
     SubdomainSolver: ExplicitInverse
+    ObservePerCoreReductions: False
 
 EventsAndTriggers:
   ? HasConverged

--- a/tests/InputFiles/Xcts/Schwarzschild.yaml
+++ b/tests/InputFiles/Xcts/Schwarzschild.yaml
@@ -95,6 +95,7 @@ LinearSolver:
           MinusLaplacian:
             Solver: ExplicitInverse
     SkipResets: True
+    ObservePerCoreReductions: False
 
 EventsAndTriggers:
   ? HasConverged

--- a/tests/Unit/IO/CMakeLists.txt
+++ b/tests/Unit/IO/CMakeLists.txt
@@ -28,7 +28,19 @@ add_test_library(
   ${LIBRARY}
   "IO"
   "${LIBRARY_SOURCES}"
-  "Boost::boost;EventsAndTriggers;IO"
+  ""
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  Boost::boost
+  DataStructures
+  DomainStructure
+  EventsAndTriggers
+  IO
+  Parallel
+  Utilities
   )
 
 add_dependencies(

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.yaml
@@ -60,6 +60,7 @@ SchwarzSmoother:
         # Preconditioning with the explicitly-built inverse matrix, so all
         # subdomain solves should converge immediately
         ExplicitInverse
+  ObservePerCoreReductions: False
 
 ConvergenceReason: NumIterations
 


### PR DESCRIPTION
## Proposed changes

The reduction observer now supports writing the intermediate stage of
the reduction over just the core that the element is currently on. This
can be useful e.g. to measure performance metrics to assess
load-balancing such as the number of elements or grid points on
each core. The data will be written in one H5 file per _node_ prefixed
with the reduction file name, and in a `Core{core_id}` subfile. For example,
when running on 2 nodes with 2 cores each you will end up with
`Reductions0.h5` containing `/Core0/{subfile_name}.dat`
and `/Core1/{subfile_name}.dat`, and `Reductions1.h5` containing
`/Core2/{subfile_name}.dat` and `/Core3/{subfile_name}.dat`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
