### PR TITLE
MutableCache callbacks now work in ActionTesting.

### DIFF
--- a/tests/Unit/Framework/ActionTesting.hpp
+++ b/tests/Unit/Framework/ActionTesting.hpp
@@ -483,6 +483,16 @@ class MockDistributedObjectProxy {
                : nullptr;
   }
 
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {
+    ERROR(
+        "Should not try to serialize the MockDistributedObjectProxy. "
+        "If you encountered this error you are using the mocking framework "
+        "in a way that it was not intended to be used. It may be possible "
+        "to extend it to more use cases but it is recommended you file an "
+        "issue to discuss before modifying the mocking framework.");
+  }
+
  private:
   // mock_node_ and mock_local_core_ are the (mocked) node and core
   // that this MockDistributedObjectProxy lives on.  This is different
@@ -621,8 +631,8 @@ class MockCollectionOfDistributedObjectsProxy {
                   });
   }
 
-  // clang-tidy: no non-const references
-  void pup(PUP::er& /*p*/) noexcept {  // NOLINT
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {
     ERROR(
         "Should not try to serialize the CollectionOfMockDistributedObjects. "
         "If you encountered this error you are using the mocking framework "


### PR DESCRIPTION
## Proposed changes

Fixes #3454

Previously, callbacks worked when called on a collection of elements (i.e. a full chare) but not on a single element (i.e. a component of a chare).

Three things needed to be changed:
1. MockDistributedObjectProxy now has a pup function (the pup function errors and should not be used, but needs to be there to compile).  There already was a pup function in MockCollectionOfDistributedObjectsProxy, which is why callbacks worked on a collection of elements.
2. MockCollectionOfDistributedObjectsProxy::operator[] now returns a reference to a stored MockDistributedObjectProxy (previously it created a temporary MockDistributedObjectProxy and returned that temporary by value).  So now the mock proxies have the same interface as the non-mocked proxies (i.e. you can do `auto& proxy = mock_collection_of_distributed_objects_proxy[i];`).
3. Add a test, which is an expanded version of the test @wthrowe posted in #3454.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

