### PR TITLE
Add DirichletMinkowski GH BC

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -32,6 +32,7 @@
 #include "Evolution/Initialization/NonconservativeSystem.hpp"
 #include "Evolution/NumericInitialData.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DirichletMinkowski.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Factory.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Outflow.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/Factory.hpp"
@@ -202,6 +203,8 @@ struct EvolutionMetavars {
                        volume_dim>,
                    tmpl::list<GeneralizedHarmonic::BoundaryConditions::
                                   ConstraintPreservingBjorhus<volume_dim>,
+                              GeneralizedHarmonic::BoundaryConditions::
+                                  DirichletMinkowski<volume_dim>,
                               GeneralizedHarmonic::BoundaryConditions::Outflow<
                                   volume_dim>>>,
         tmpl::pair<StepChooser<StepChooserUse::LtsStep>,

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/CMakeLists.txt
@@ -8,6 +8,7 @@ spectre_target_sources(
   BjorhusImpl.cpp
   BoundaryCondition.cpp
   DirichletAnalytic.cpp
+  DirichletMinkowski.cpp
   Outflow.cpp
   )
 
@@ -19,6 +20,7 @@ spectre_target_headers(
   BjorhusImpl.hpp
   BoundaryCondition.hpp
   DirichletAnalytic.hpp
+  DirichletMinkowski.hpp
   Factory.hpp
   Outflow.hpp
   )

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DirichletMinkowski.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DirichletMinkowski.cpp
@@ -1,0 +1,91 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DirichletMinkowski.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <pup.h>
+
+#include "PointwiseFunctions/GeneralRelativity/Lapse.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Shift.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace GeneralizedHarmonic::BoundaryConditions {
+template <size_t Dim>
+DirichletMinkowski<Dim>::DirichletMinkowski(CkMigrateMessage* const msg)
+    : BoundaryCondition<Dim>(msg) {}
+
+template <size_t Dim>
+std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+DirichletMinkowski<Dim>::get_clone() const {
+  return std::make_unique<DirichletMinkowski>(*this);
+}
+
+template <size_t Dim>
+void DirichletMinkowski<Dim>::pup(PUP::er& p) {
+  BoundaryCondition<Dim>::pup(p);
+}
+
+template <size_t Dim>
+std::optional<std::string> DirichletMinkowski<Dim>::dg_ghost(
+    const gsl::not_null<tnsr::aa<DataVector, Dim, Frame::Inertial>*>
+        spacetime_metric,
+    const gsl::not_null<tnsr::aa<DataVector, Dim, Frame::Inertial>*> pi,
+    const gsl::not_null<tnsr::iaa<DataVector, Dim, Frame::Inertial>*> phi,
+    const gsl::not_null<Scalar<DataVector>*> gamma1,
+    const gsl::not_null<Scalar<DataVector>*> gamma2,
+    const gsl::not_null<Scalar<DataVector>*> lapse,
+    const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> shift,
+    const gsl::not_null<tnsr::II<DataVector, Dim, Frame::Inertial>*>
+        inv_spatial_metric,
+    const std::optional<
+        tnsr::I<DataVector, Dim, Frame::Inertial>>& /*face_mesh_velocity*/,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& /*normal_covector*/,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& /*normal_vector*/,
+    const Scalar<DataVector>& interior_gamma1,
+    const Scalar<DataVector>& interior_gamma2) const {
+  *gamma1 = interior_gamma1;
+  *gamma2 = interior_gamma2;
+
+  // Hard-code Minkowski values to avoid passing coords or time as arguments
+  *spacetime_metric =
+      make_with_value<tnsr::aa<DataVector, Dim, Frame::Inertial>>(
+          interior_gamma1, 0.0);
+  get<0, 0>(*spacetime_metric) = -1.0;
+  for (size_t i = 1; i < Dim + 1; ++i) {
+    (*spacetime_metric).get(i, i) = 1.0;
+  }
+  *pi = make_with_value<tnsr::aa<DataVector, Dim, Frame::Inertial>>(
+      interior_gamma1, 0.0);
+  *phi = make_with_value<tnsr::iaa<DataVector, Dim, Frame::Inertial>>(
+      interior_gamma1, 0.0);
+
+  *lapse = make_with_value<Scalar<DataVector>>(interior_gamma1, 1.0);
+  *shift = make_with_value<tnsr::I<DataVector, Dim, Frame::Inertial>>(
+      interior_gamma1, 0.0);
+  *inv_spatial_metric =
+      make_with_value<tnsr::II<DataVector, Dim, Frame::Inertial>>(
+          interior_gamma1, 0.0);
+  for (size_t i = 0; i < Dim; ++i) {
+    (*inv_spatial_metric).get(i, i) = 1.0;
+  }
+
+  return {};
+}
+
+template <size_t Dim>
+// NOLINTNEXTLINE
+PUP::able::PUP_ID DirichletMinkowski<Dim>::my_PUP_ID = 0;
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data) template class DirichletMinkowski<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+#undef DIM
+}  // namespace GeneralizedHarmonic::BoundaryConditions

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DirichletMinkowski.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DirichletMinkowski.hpp
@@ -1,0 +1,93 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <pup.h>
+#include <string>
+#include <type_traits>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/BoundaryConditions/Type.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace domain::Tags {
+template <size_t Dim, typename Frame>
+struct Coordinates;
+}  // namespace domain::Tags
+/// \endcond
+
+namespace GeneralizedHarmonic::BoundaryConditions {
+/*!
+ * \brief Sets Dirichlet boundary conditions to a Minkowski spacetime.
+ */
+template <size_t Dim>
+class DirichletMinkowski final : public BoundaryCondition<Dim> {
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help{
+      "DirichletMinkowski boundary conditions setting the value of the "
+      "spacetime metric and its derivatives Phi and Pi to Minkowski (i.e., "
+      "flat spacetime)."};
+
+  DirichletMinkowski() = default;
+  DirichletMinkowski(DirichletMinkowski&&) = default;
+  DirichletMinkowski& operator=(DirichletMinkowski&&) = default;
+  DirichletMinkowski(const DirichletMinkowski&) = default;
+  DirichletMinkowski& operator=(const DirichletMinkowski&) = default;
+  ~DirichletMinkowski() override = default;
+
+  explicit DirichletMinkowski(CkMigrateMessage* msg);
+
+  WRAPPED_PUPable_decl_base_template(
+      domain::BoundaryConditions::BoundaryCondition, DirichletMinkowski);
+
+  auto get_clone() const -> std::unique_ptr<
+      domain::BoundaryConditions::BoundaryCondition> override;
+
+  static constexpr evolution::BoundaryConditions::Type bc_type =
+      evolution::BoundaryConditions::Type::Ghost;
+
+  void pup(PUP::er& p) override;
+
+  using dg_interior_evolved_variables_tags = tmpl::list<>;
+  using dg_interior_temporary_tags = tmpl::list<
+      ::GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1,
+      ::GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma2>;
+  using dg_gridless_tags = tmpl::list<>;
+
+  std::optional<std::string> dg_ghost(
+      const gsl::not_null<tnsr::aa<DataVector, Dim, Frame::Inertial>*>
+          spacetime_metric,
+      const gsl::not_null<tnsr::aa<DataVector, Dim, Frame::Inertial>*> pi,
+      const gsl::not_null<tnsr::iaa<DataVector, Dim, Frame::Inertial>*> phi,
+      const gsl::not_null<Scalar<DataVector>*> gamma1,
+      const gsl::not_null<Scalar<DataVector>*> gamma2,
+      const gsl::not_null<Scalar<DataVector>*> lapse,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> shift,
+      const gsl::not_null<tnsr::II<DataVector, Dim, Frame::Inertial>*>
+          inv_spatial_metric,
+      const std::optional<
+          tnsr::I<DataVector, Dim, Frame::Inertial>>& /*face_mesh_velocity*/,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& /*normal_covector*/,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& /*normal_vector*/,
+      const Scalar<DataVector>& interior_gamma1,
+      const Scalar<DataVector>& interior_gamma2) const;
+};
+}  // namespace GeneralizedHarmonic::BoundaryConditions

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Factory.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Factory.hpp
@@ -9,6 +9,7 @@
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BoundaryCondition.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DirichletAnalytic.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DirichletMinkowski.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Outflow.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -17,6 +18,6 @@ namespace GeneralizedHarmonic::BoundaryConditions {
 template <size_t Dim>
 using standard_boundary_conditions =
     tmpl::list<ConstraintPreservingBjorhus<Dim>, DirichletAnalytic<Dim>,
-               Outflow<Dim>,
+               DirichletMinkowski<Dim>, Outflow<Dim>,
                domain::BoundaryConditions::Periodic<BoundaryCondition<Dim>>>;
 }  // namespace GeneralizedHarmonic::BoundaryConditions

--- a/src/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
@@ -38,6 +38,7 @@ target_link_libraries(
   DomainBoundaryConditions
   ErrorHandling
   GeneralRelativity
+  GeneralRelativitySolutions
   Options
   Spectral
   Utilities

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DirichletMinkowski.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DirichletMinkowski.py
@@ -1,0 +1,56 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+import PointwiseFunctions.GeneralRelativity.ComputeSpacetimeQuantities as gr
+
+
+def error(face_mesh_velocity, outward_directed_normal_covector,
+          outward_directed_normal_vector, interior_gamma1, interior_gamma2):
+    return None
+
+
+def lapse(face_mesh_velocity, outward_directed_normal_covector,
+          outward_directed_normal_vector, interior_gamma1, interior_gamma2):
+    return 1.0
+
+
+def shift(face_mesh_velocity, outward_directed_normal_covector,
+          outward_directed_normal_vector, interior_gamma1, interior_gamma2):
+    return np.zeros_like(outward_directed_normal_covector)
+
+
+def spacetime_metric(face_mesh_velocity, outward_directed_normal_covector,
+                     outward_directed_normal_vector, interior_gamma1,
+                     interior_gamma2):
+    return gr.spacetime_metric(
+        -1.0, np.zeros_like(outward_directed_normal_covector),
+        np.diag(np.ones(len(outward_directed_normal_covector))))
+
+
+def phi(face_mesh_velocity, outward_directed_normal_covector,
+        outward_directed_normal_vector, interior_gamma1, interior_gamma2):
+    return np.zeros((len(outward_directed_normal_covector),
+                     len(outward_directed_normal_covector) + 1,
+                     len(outward_directed_normal_covector) + 1))
+
+
+def pi(face_mesh_velocity, outward_directed_normal_covector,
+       outward_directed_normal_vector, interior_gamma1, interior_gamma2):
+    return np.zeros((len(outward_directed_normal_covector) + 1,
+                     len(outward_directed_normal_covector) + 1))
+
+
+def constraint_gamma1(face_mesh_velocity, outward_directed_normal_covector,
+                      outward_directed_normal_vector, interior_gamma1,
+                      interior_gamma2):
+    assert interior_gamma1 >= 0.0
+    return interior_gamma1
+
+
+def constraint_gamma2(face_mesh_velocity, outward_directed_normal_covector,
+                      outward_directed_normal_vector, interior_gamma1,
+                      interior_gamma2):
+    assert interior_gamma2 >= 0.0
+    return interior_gamma2

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_DirichletMinkowski.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_DirichletMinkowski.cpp
@@ -1,0 +1,108 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Index.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DirichletMinkowski.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Factory.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/UpwindPenalty.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/Range.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/MathFunctions/Gaussian.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace helpers = TestHelpers::evolution::dg;
+
+namespace {
+template <size_t Dim>
+struct ConvertMinkowski {
+  using unpacked_container = int;
+  using packed_container =
+      GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::Minkowski<Dim>>;
+  using packed_type = double;
+
+  static packed_container create_container() { return {}; }
+
+  static inline unpacked_container unpack(const packed_container& /*packed*/,
+                                          const size_t /*grid_point_index*/) {
+    // No way of getting the args from the boundary condition.
+    return Dim;
+  }
+
+  static inline void pack(const gsl::not_null<packed_container*> packed,
+                          const unpacked_container /*unpacked*/,
+                          const size_t /*grid_point_index*/) {
+    *packed = create_container();
+  }
+
+  static inline size_t get_size(const packed_container& /*packed*/) {
+    return 1;
+  }
+};
+
+template <size_t Dim>
+void test() {
+  CAPTURE(Dim);
+  MAKE_GENERATOR(gen);
+  const auto box_analytic_soln = db::create<db::AddSimpleTags<
+      Tags::Time,
+      Tags::AnalyticSolution<GeneralizedHarmonic::Solutions::WrappedGr<
+          gr::Solutions::Minkowski<Dim>>>>>(
+      0.5, ConvertMinkowski<Dim>::create_container());
+
+  helpers::test_boundary_condition_with_python<
+      GeneralizedHarmonic::BoundaryConditions::DirichletMinkowski<Dim>,
+      GeneralizedHarmonic::BoundaryConditions::BoundaryCondition<Dim>,
+      GeneralizedHarmonic::System<Dim>,
+      tmpl::list<GeneralizedHarmonic::BoundaryCorrections::UpwindPenalty<Dim>>,
+      tmpl::list<ConvertMinkowski<Dim>>>(
+      make_not_null(&gen),
+      "Evolution.Systems.GeneralizedHarmonic.BoundaryConditions."
+      "DirichletMinkowski",
+      tuples::TaggedTuple<
+          helpers::Tags::PythonFunctionForErrorMessage<>,
+          helpers::Tags::PythonFunctionName<gr::Tags::SpacetimeMetric<Dim>>,
+          helpers::Tags::PythonFunctionName<GeneralizedHarmonic::Tags::Pi<Dim>>,
+          helpers::Tags::PythonFunctionName<
+              GeneralizedHarmonic::Tags::Phi<Dim>>,
+          helpers::Tags::PythonFunctionName<
+              GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1>,
+          helpers::Tags::PythonFunctionName<
+              GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma2>,
+          helpers::Tags::PythonFunctionName<gr::Tags::Lapse<DataVector>>,
+          helpers::Tags::PythonFunctionName<
+              gr::Tags::Shift<Dim, Frame::Inertial, DataVector>>>{
+          "error", "spacetime_metric", "pi", "phi", "constraint_gamma1",
+          "constraint_gamma2", "lapse", "shift"},
+      "DirichletMinkowski:\n", Index<Dim - 1>{Dim == 1 ? 1 : 5},
+      box_analytic_soln,
+      tuples::TaggedTuple<
+          helpers::Tags::Range<
+              GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1>,
+          helpers::Tags::Range<
+              GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma2>>{
+          std::array{0.0, 1.0}, std::array{0.0, 1.0}});
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.GeneralizedHarmonic.BoundaryConditions.DirichletMinkowski",
+    "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{""};
+  test<1>();
+  test<2>();
+  test<3>();
+}

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBRARY_SOURCES
   BoundaryConditions/Test_Bjorhus.cpp
   BoundaryConditions/Test_BjorhusImpl.cpp
   BoundaryConditions/Test_DirichletAnalytic.cpp
+  BoundaryConditions/Test_DirichletMinkowski.cpp
   BoundaryConditions/Test_Outflow.cpp
   BoundaryConditions/Test_Periodic.cpp
   BoundaryCorrections/Test_UpwindPenalty.cpp

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.py
@@ -1,0 +1,57 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def minkowski_lapse(x, t):
+    return 1.0
+
+
+def minkowski_dt_lapse(x, t):
+    return 0.0
+
+
+def minkowski_d_lapse(x, t):
+    return 0.0
+
+
+def minkowski_shift(x, t):
+    return np.zeros_like(x)
+
+
+def minkowski_dt_shift(x, t):
+    return np.zeros_like(x)
+
+
+def minkowski_d_shift(x, t):
+    return np.zeros((len(x), len(x)))
+
+
+def minkowski_spatial_metric(x, t):
+    spatial_metric = np.diag(np.ones_like(x))
+    return spatial_metric
+
+
+def minkowski_dt_spatial_metric(x, t):
+    dt_spatial_metric = np.zeros((len(x), len(x)))
+    return dt_spatial_metric
+
+
+def minkowski_d_spatial_metric(x, t):
+    d_spatial_metric = np.zeros((len(x), len(x), len(x)))
+    return d_spatial_metric
+
+
+def minkowski_sqrt_det_spatial_metric(x, t):
+    return 1.0
+
+
+def minkowski_extrinsic_curvature(x, t):
+    extrinsic_curvature = np.zeros((len(x), len(x)))
+    return extrinsic_curvature
+
+
+def minkowski_inverse_spatial_metric(x, t):
+    inverse_spatial_metric = np.diag(np.ones_like(x))
+    return inverse_spatial_metric


### PR DESCRIPTION
## Proposed changes

Add a GH Dirichlet boundary condition that sets the spacetime metric, phi, and pi to Minkowski. This allows you to impose flat space on the outer boundary without supplying an analytic solution, which is necessary for testing Dirichlet boundary conditions in binary-black-hole simulations, which do not have an analytic solution.

Ultimately, we will want to use bjorhus, constraint-preserving boundary conditions in these simulations, but until simulations using the Bjorhus BCs are working, having a flat-space Dirichlet condition as an alternative is helpful for comparing with the Bjorhus conditions.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
