### PR TITLE
Add and observe XCTS constraint norms

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -205,7 +205,8 @@ struct GeneralizedHarmonicTemplateBase<
         tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
         tmpl::pair<Event,
                    tmpl::flatten<tmpl::list<
-                       Events::Completion, Events::ObserveNorms<observe_fields>,
+                       Events::Completion,
+                       Events::ObserveNorms<::Tags::Time, observe_fields>,
                        dg::Events::field_observations<volume_dim, Tags::Time,
                                                       observe_fields,
                                                       analytic_solution_fields>,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -236,6 +236,7 @@ struct EvolutionMetavars {
             tmpl::flatten<tmpl::list<
                 Events::Completion,
                 Events::ObserveNorms<
+                    ::Tags::Time,
                     tmpl::list<hydro::Tags::RestMassDensity<DataVector>>>,
                 tmpl::conditional_t<
                     use_dg_subcell,

--- a/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
@@ -157,6 +157,25 @@ struct MomentumDensity : db::SimpleTag {
   using type = tnsr::I<DataType, Dim, Frame>;
 };
 
+/// The ADM Hamiltonian constraint \f$R + K^2 - K_{ij} K^{ij} - 16 \pi \rho\f$
+/// (see e.g. Eq. (2.132) in \cite BaumgarteShapiro).
+///
+/// \warning Some authors include a factor of \f$1/2\f$ in the Hamiltonian
+/// constraint, as does SpEC.
+template <typename DataType>
+struct HamiltonianConstraint : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+/// The ADM momentum constraint
+/// \f$\gamma^{jk} (\nabla_j K_{ki} - \nabla_i K_{jk}) - 8 \pi S_i\f$, where
+/// \f$\nabla\f$ denotes the covariant derivative associated with the spatial
+/// metric \f$\gamma_{ij}\f$ (see e.g. Eq. (2.133) in \cite BaumgarteShapiro).
+template <size_t Dim, typename Frame, typename DataType>
+struct MomentumConstraint : db::SimpleTag {
+  using type = tnsr::i<DataType, Dim, Frame>;
+};
+
 /*!
  * \brief Computes the electric part of the Weyl tensor in vacuum
  * as: \f$ E_{ij} = R_{ij} + KK_{ij} - K^m_{i}K_{mj}\f$ where \f$R_{ij}\f$ is

--- a/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
@@ -83,5 +83,10 @@ template <typename DataType = DataVector>
 struct StressTrace;
 template <size_t Dim, typename Frame, typename DataType>
 struct MomentumDensity;
+template <typename DataType = DataVector>
+struct HamiltonianConstraint;
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
+struct MomentumConstraint;
 }  // namespace Tags
 }  // namespace gr

--- a/src/PointwiseFunctions/Xcts/CMakeLists.txt
+++ b/src/PointwiseFunctions/Xcts/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   LongitudinalOperator.cpp
+  SpacetimeQuantities.cpp
   )
 
 spectre_target_headers(
@@ -16,11 +17,17 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   LongitudinalOperator.hpp
+  SpacetimeQuantities.hpp
   )
 
 target_link_libraries(
   ${LIBRARY}
   PUBLIC
   DataStructures
+  GeneralRelativity
+  LinearOperators
+  Spectral
   Utilities
+  INTERFACE
+  Domain
   )

--- a/src/PointwiseFunctions/Xcts/LongitudinalOperator.cpp
+++ b/src/PointwiseFunctions/Xcts/LongitudinalOperator.cpp
@@ -1,7 +1,7 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-#include "PointwiseFunctions/Elasticity/PotentialEnergy.hpp"
+#include "PointwiseFunctions/Xcts/LongitudinalOperator.hpp"
 
 #include <algorithm>
 #include <cstddef>

--- a/src/PointwiseFunctions/Xcts/SpacetimeQuantities.cpp
+++ b/src/PointwiseFunctions/Xcts/SpacetimeQuantities.cpp
@@ -1,0 +1,263 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/Xcts/SpacetimeQuantities.hpp"
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Elliptic/Systems/Xcts/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ExtrinsicCurvature.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Xcts {
+
+namespace detail {
+template <typename T>
+struct TempTag {
+  using type = T;
+};
+template <typename U, typename T, size_t Dim, typename DerivativeFrame>
+auto deriv_tensor(
+    const gsl::not_null<U*> deriv, const T& tensor, const Mesh<Dim>& mesh,
+    const InverseJacobian<DataVector, Dim, Frame::Logical, DerivativeFrame>&
+        inv_jacobian) noexcept {
+  Variables<tmpl::list<TempTag<T>>> vars{tensor.begin()->size()};
+  get<TempTag<T>>(vars) = tensor;
+  const auto deriv_vars =
+      partial_derivatives<tmpl::list<TempTag<T>>>(vars, mesh, inv_jacobian);
+  *deriv = get<::Tags::deriv<TempTag<T>, tmpl::size_t<Dim>, DerivativeFrame>>(
+      deriv_vars);
+}
+}  // namespace detail
+
+void SpacetimeQuantitiesComputer::operator()(
+    const gsl::not_null<tnsr::ii<DataVector, 3>*> spatial_metric,
+    const gsl::not_null<Cache*> /*cache*/,
+    gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector> /*meta*/)
+    const noexcept {
+  *spatial_metric = conformal_metric;
+  for (auto& spatial_metric_component : *spatial_metric) {
+    spatial_metric_component *= pow<4>(get(conformal_factor));
+  }
+}
+
+void SpacetimeQuantitiesComputer::operator()(
+    const gsl::not_null<tnsr::II<DataVector, 3>*> inv_spatial_metric,
+    const gsl::not_null<Cache*> /*cache*/,
+    gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector> /*meta*/)
+    const noexcept {
+  *inv_spatial_metric = inv_conformal_metric;
+  for (auto& inv_spatial_metric_component : *inv_spatial_metric) {
+    inv_spatial_metric_component /= pow<4>(get(conformal_factor));
+  }
+}
+
+void SpacetimeQuantitiesComputer::operator()(
+    const gsl::not_null<tnsr::ijj<DataVector, 3>*> deriv_spatial_metric,
+    const gsl::not_null<Cache*> cache,
+    ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+                  tmpl::size_t<3>, Frame::Inertial> /*meta*/) const noexcept {
+  const auto& spatial_metric =
+      cache->get_var(gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>{});
+  detail::deriv_tensor(deriv_spatial_metric, spatial_metric, mesh,
+                       inv_jacobian);
+}
+
+void SpacetimeQuantitiesComputer::operator()(
+    const gsl::not_null<tnsr::Ijj<DataVector, 3>*> christoffel_second_kind,
+    const gsl::not_null<Cache*> cache,
+    gr::Tags::SpatialChristoffelSecondKind<
+        3, Frame::Inertial, DataVector> /*meta*/) const noexcept {
+  const auto& deriv_spatial_metric = cache->get_var(
+      ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+                    tmpl::size_t<3>, Frame::Inertial>{});
+  const auto& inv_spatial_metric = cache->get_var(
+      gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>{});
+  gr::christoffel_second_kind(christoffel_second_kind, deriv_spatial_metric,
+                              inv_spatial_metric);
+}
+
+void SpacetimeQuantitiesComputer::operator()(
+    const gsl::not_null<tnsr::iJkk<DataVector, 3>*>
+        deriv_christoffel_second_kind,
+    const gsl::not_null<Cache*> cache,
+    ::Tags::deriv<
+        gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial, DataVector>,
+        tmpl::size_t<3>, Frame::Inertial> /*meta*/) const noexcept {
+  const auto& christoffel_second_kind = cache->get_var(
+      gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial, DataVector>{});
+  detail::deriv_tensor(deriv_christoffel_second_kind, christoffel_second_kind,
+                       mesh, inv_jacobian);
+}
+
+void SpacetimeQuantitiesComputer::operator()(
+    const gsl::not_null<tnsr::ii<DataVector, 3>*> ricci_tensor,
+    const gsl::not_null<Cache*> cache,
+    gr::Tags::SpatialRicci<3, Frame::Inertial, DataVector> /*meta*/)
+    const noexcept {
+  const auto& christoffel_second_kind = cache->get_var(
+      gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial, DataVector>{});
+  const auto& deriv_christoffel_second_kind = cache->get_var(
+      ::Tags::deriv<gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial,
+                                                           DataVector>,
+                    tmpl::size_t<3>, Frame::Inertial>{});
+  gr::ricci_tensor(ricci_tensor, christoffel_second_kind,
+                   deriv_christoffel_second_kind);
+}
+
+void SpacetimeQuantitiesComputer::operator()(
+    const gsl::not_null<Scalar<DataVector>*> lapse,
+    const gsl::not_null<Cache*> /*cache*/,
+    gr::Tags::Lapse<DataVector> /*meta*/) const noexcept {
+  get(*lapse) = get(lapse_times_conformal_factor) / get(conformal_factor);
+}
+
+void SpacetimeQuantitiesComputer::operator()(
+    const gsl::not_null<tnsr::I<DataVector, 3>*> shift,
+    const gsl::not_null<Cache*> /*cache*/,
+    gr::Tags::Shift<3, Frame::Inertial, DataVector> /*meta*/) const noexcept {
+  for (size_t i = 0; i < 3; ++i) {
+    shift->get(i) = shift_excess.get(i) + shift_background.get(i);
+  }
+}
+
+void SpacetimeQuantitiesComputer::operator()(
+    const gsl::not_null<tnsr::iJ<DataVector, 3>*> deriv_shift,
+    const gsl::not_null<Cache*> cache,
+    ::Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+                  tmpl::size_t<3>, Frame::Inertial> /*meta*/) const noexcept {
+  const auto& shift =
+      cache->get_var(gr::Tags::Shift<3, Frame::Inertial, DataVector>{});
+  detail::deriv_tensor(deriv_shift, shift, mesh, inv_jacobian);
+}
+
+void SpacetimeQuantitiesComputer::operator()(
+    const gsl::not_null<tnsr::ii<DataVector, 3>*> dt_spatial_metric,
+    const gsl::not_null<Cache*> /*cache*/,
+    ::Tags::dt<gr::Tags::SpatialMetric<3, Frame::Inertial,
+                                       DataVector>> /*meta*/) const noexcept {
+  for (auto& dt_spatial_metric_component : *dt_spatial_metric) {
+    dt_spatial_metric_component = 0.;
+  }
+}
+
+void SpacetimeQuantitiesComputer::operator()(
+    const gsl::not_null<tnsr::ii<DataVector, 3>*> extrinsic_curvature,
+    const gsl::not_null<Cache*> cache,
+    gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector> /*meta*/)
+    const noexcept {
+  const auto& lapse = cache->get_var(gr::Tags::Lapse<DataVector>{});
+  const auto& shift =
+      cache->get_var(gr::Tags::Shift<3, Frame::Inertial, DataVector>{});
+  const auto& deriv_shift = cache->get_var(
+      ::Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+                    tmpl::size_t<3>, Frame::Inertial>{});
+  const auto& spatial_metric =
+      cache->get_var(gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>{});
+  const auto& dt_spatial_metric = cache->get_var(
+      ::Tags::dt<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>{});
+  const auto& deriv_spatial_metric = cache->get_var(
+      ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+                    tmpl::size_t<3>, Frame::Inertial>{});
+  gr::extrinsic_curvature(extrinsic_curvature, lapse, shift, deriv_shift,
+                          spatial_metric, dt_spatial_metric,
+                          deriv_spatial_metric);
+}
+
+void SpacetimeQuantitiesComputer::operator()(
+    const gsl::not_null<Scalar<DataVector>*> extrinsic_curvature_square,
+    const gsl::not_null<Cache*> cache,
+    detail::ExtrinsicCurvatureSquare<DataVector> /*meta*/) const noexcept {
+  const auto& extrinsic_curvature = cache->get_var(
+      gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>{});
+  const auto& inv_spatial_metric = cache->get_var(
+      gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>{});
+  get(*extrinsic_curvature_square) = 0.;
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      for (size_t k = 0; k < 3; ++k) {
+        for (size_t l = 0; l < 3; ++l) {
+          get(*extrinsic_curvature_square) +=
+              inv_spatial_metric.get(i, k) * inv_spatial_metric.get(j, l) *
+              extrinsic_curvature.get(i, j) * extrinsic_curvature.get(k, l);
+        }
+      }
+    }
+  }
+}
+
+void SpacetimeQuantitiesComputer::operator()(
+    const gsl::not_null<tnsr::ijj<DataVector, 3>*> deriv_extrinsic_curvature,
+    const gsl::not_null<Cache*> cache,
+    ::Tags::deriv<gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>,
+                  tmpl::size_t<3>, Frame::Inertial> /*meta*/) const noexcept {
+  const auto& extrinsic_curvature = cache->get_var(
+      gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>{});
+  const auto& christoffel = cache->get_var(
+      gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial, DataVector>{});
+  detail::deriv_tensor(deriv_extrinsic_curvature, extrinsic_curvature, mesh,
+                       inv_jacobian);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      for (size_t k = 0; k <= j; ++k) {
+        for (size_t l = 0; l < 3; ++l) {
+          deriv_extrinsic_curvature->get(i, j, k) -=
+              christoffel.get(l, i, j) * extrinsic_curvature.get(l, k);
+          deriv_extrinsic_curvature->get(i, j, k) -=
+              christoffel.get(l, i, k) * extrinsic_curvature.get(j, l);
+        }
+      }
+    }
+  }
+}
+
+void SpacetimeQuantitiesComputer::operator()(
+    const gsl::not_null<Scalar<DataVector>*> hamiltonian_constraint,
+    const gsl::not_null<Cache*> cache,
+    gr::Tags::HamiltonianConstraint<DataVector> /*meta*/) const noexcept {
+  const auto& ricci_tensor =
+      cache->get_var(gr::Tags::SpatialRicci<3, Frame::Inertial, DataVector>{});
+  const auto& extrinsic_curvature = cache->get_var(
+      gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>{});
+  const auto& inv_spatial_metric = cache->get_var(
+      gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>{});
+  const auto& extrinsic_curvature_square =
+      cache->get_var(detail::ExtrinsicCurvatureSquare<DataVector>{});
+  get(*hamiltonian_constraint) =
+      get(trace(ricci_tensor, inv_spatial_metric)) +
+             square(get(trace(extrinsic_curvature, inv_spatial_metric))) -
+             get(extrinsic_curvature_square);
+}
+
+void SpacetimeQuantitiesComputer::operator()(
+    const gsl::not_null<tnsr::i<DataVector, 3>*> momentum_constraint,
+    const gsl::not_null<Cache*> cache,
+    gr::Tags::MomentumConstraint<3, Frame::Inertial, DataVector> /*meta*/)
+    const noexcept {
+  const auto& deriv_extrinsic_curvature = cache->get_var(
+      ::Tags::deriv<
+          gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>,
+          tmpl::size_t<3>, Frame::Inertial>{});
+  const auto& inv_spatial_metric = cache->get_var(
+      gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>{});
+  for (size_t i = 0; i < 3; ++i) {
+    momentum_constraint->get(i) = 0.;
+    for (size_t j = 0; j < 3; ++j) {
+      for (size_t k = 0; k < 3; ++k) {
+        momentum_constraint->get(i) += inv_spatial_metric.get(j, k) *
+                                       (deriv_extrinsic_curvature.get(j, k, i) -
+                                        deriv_extrinsic_curvature.get(i, j, k));
+      }
+    }
+  }
+}
+
+}  // namespace Xcts

--- a/src/PointwiseFunctions/Xcts/SpacetimeQuantities.hpp
+++ b/src/PointwiseFunctions/Xcts/SpacetimeQuantities.hpp
@@ -1,0 +1,174 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/CachedTempBuffer.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/Tags.hpp"
+#include "Elliptic/Systems/Xcts/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Xcts {
+/// \cond
+struct SpacetimeQuantitiesComputer;
+/// \endcond
+
+namespace detail {
+template <typename DataType>
+struct ExtrinsicCurvatureSquare : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+}  // namespace detail
+
+/// General-relativistic 3+1 quantities computed from XCTS variables.
+using SpacetimeQuantities = CachedTempBuffer<
+    SpacetimeQuantitiesComputer,
+    gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+    gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>,
+    ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+                  tmpl::size_t<3>, Frame::Inertial>,
+    gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial, DataVector>,
+    ::Tags::deriv<
+        gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial, DataVector>,
+        tmpl::size_t<3>, Frame::Inertial>,
+    gr::Tags::SpatialRicci<3, Frame::Inertial, DataVector>,
+    gr::Tags::Lapse<DataVector>,
+    gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+    ::Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+                  tmpl::size_t<3>, Frame::Inertial>,
+    ::Tags::dt<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>,
+    gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>,
+    detail::ExtrinsicCurvatureSquare<DataVector>,
+    ::Tags::deriv<gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>,
+                  tmpl::size_t<3>, Frame::Inertial>,
+    gr::Tags::HamiltonianConstraint<DataVector>,
+    gr::Tags::MomentumConstraint<3, Frame::Inertial, DataVector>>;
+
+/// `CachedTempBuffer` computer class for 3+1 quantities from XCTS variables.
+/// See `Xcts::SpacetimeQuantities`.
+struct SpacetimeQuantitiesComputer {
+  using Cache = SpacetimeQuantities;
+
+  void operator()(gsl::not_null<tnsr::ii<DataVector, 3>*> spatial_metric,
+                  gsl::not_null<Cache*> cache,
+                  gr::Tags::SpatialMetric<3, Frame::Inertial,
+                                          DataVector> /*meta*/) const noexcept;
+  void operator()(
+      gsl::not_null<tnsr::II<DataVector, 3>*> inv_spatial_metric,
+      gsl::not_null<Cache*> cache,
+      gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector> /*meta*/)
+      const noexcept;
+  void operator()(
+      gsl::not_null<tnsr::ijj<DataVector, 3>*> deriv_spatial_metric,
+      gsl::not_null<Cache*> cache,
+      ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+                    tmpl::size_t<3>, Frame::Inertial> /*meta*/) const noexcept;
+  void operator()(
+      gsl::not_null<tnsr::Ijj<DataVector, 3>*> christoffel_second_kind,
+      gsl::not_null<Cache*> cache,
+      gr::Tags::SpatialChristoffelSecondKind<
+          3, Frame::Inertial, DataVector> /*meta*/) const noexcept;
+  void operator()(
+      gsl::not_null<tnsr::iJkk<DataVector, 3>*> deriv_christoffel_second_kind,
+      gsl::not_null<Cache*> cache,
+      ::Tags::deriv<gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial,
+                                                           DataVector>,
+                    tmpl::size_t<3>, Frame::Inertial> /*meta*/) const noexcept;
+  void operator()(gsl::not_null<tnsr::ii<DataVector, 3>*> ricci_tensor,
+                  gsl::not_null<Cache*> cache,
+                  gr::Tags::SpatialRicci<3, Frame::Inertial,
+                                         DataVector> /*meta*/) const noexcept;
+  void operator()(gsl::not_null<Scalar<DataVector>*> lapse,
+                  gsl::not_null<Cache*> cache,
+                  gr::Tags::Lapse<DataVector> /*meta*/) const noexcept;
+  void operator()(
+      gsl::not_null<tnsr::I<DataVector, 3>*> shift, gsl::not_null<Cache*> cache,
+      gr::Tags::Shift<3, Frame::Inertial, DataVector> /*meta*/) const noexcept;
+  void operator()(
+      gsl::not_null<tnsr::iJ<DataVector, 3>*> deriv_shift,
+      gsl::not_null<Cache*> cache,
+      ::Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+                    tmpl::size_t<3>, Frame::Inertial> /*meta*/) const noexcept;
+  void operator()(gsl::not_null<tnsr::ii<DataVector, 3>*> dt_spatial_metric,
+                  gsl::not_null<Cache*> cache,
+                  ::Tags::dt<gr::Tags::SpatialMetric<
+                      3, Frame::Inertial, DataVector>> /*meta*/) const noexcept;
+  void operator()(
+      gsl::not_null<tnsr::ii<DataVector, 3>*> extrinsic_curvature,
+      gsl::not_null<Cache*> cache,
+      gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector> /*meta*/)
+      const noexcept;
+  void operator()(
+      gsl::not_null<Scalar<DataVector>*> extrinsic_curvature_square,
+      gsl::not_null<Cache*> cache,
+      detail::ExtrinsicCurvatureSquare<DataVector> /*meta*/) const noexcept;
+  void operator()(
+      gsl::not_null<tnsr::ijj<DataVector, 3>*> deriv_extrinsic_curvature,
+      gsl::not_null<Cache*> cache,
+      ::Tags::deriv<
+          gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>,
+          tmpl::size_t<3>, Frame::Inertial> /*meta*/) const noexcept;
+  void operator()(
+      gsl::not_null<Scalar<DataVector>*> hamiltonian_constraint,
+      gsl::not_null<Cache*> cache,
+      gr::Tags::HamiltonianConstraint<DataVector> /*meta*/) const noexcept;
+  void operator()(
+      gsl::not_null<tnsr::i<DataVector, 3>*> momentum_constraint,
+      gsl::not_null<Cache*> cache,
+      gr::Tags::MomentumConstraint<3, Frame::Inertial, DataVector> /*meta*/)
+      const noexcept;
+
+  const Scalar<DataVector>& conformal_factor;
+  const Scalar<DataVector>& lapse_times_conformal_factor;
+  const tnsr::I<DataVector, 3>& shift_excess;
+  const tnsr::ii<DataVector, 3>& conformal_metric;
+  const tnsr::II<DataVector, 3>& inv_conformal_metric;
+  const tnsr::I<DataVector, 3>& shift_background;
+  const Mesh<3>& mesh;
+  const InverseJacobian<DataVector, 3, Frame::Logical, Frame::Inertial>&
+      inv_jacobian;
+};
+
+namespace Tags {
+/// Compute tag for the 3+1 quantities `Tags` from XCTS variables. The `Tags`
+/// can be any subset of the tags supported by `Xcts::SpacetimeQuantities`.
+template <typename Tags>
+struct SpacetimeQuantitiesCompute : ::Tags::Variables<Tags>, db::ComputeTag {
+  using base = ::Tags::Variables<Tags>;
+  using argument_tags = tmpl::list<
+      domain::Tags::Mesh<3>, ConformalFactor<DataVector>,
+      LapseTimesConformalFactor<DataVector>,
+      ShiftExcess<DataVector, 3, Frame::Inertial>,
+      ConformalMetric<DataVector, 3, Frame::Inertial>,
+      InverseConformalMetric<DataVector, 3, Frame::Inertial>,
+      ShiftBackground<DataVector, 3, Frame::Inertial>, domain::Tags::Mesh<3>,
+      domain::Tags::InverseJacobian<3, Frame::Logical, Frame::Inertial>>;
+  template <typename... Args>
+  static void function(const gsl::not_null<typename base::type*> result,
+                       const Mesh<3>& mesh, const Args&... args) noexcept {
+    const size_t num_points = mesh.number_of_grid_points();
+    if (result->number_of_grid_points() != num_points) {
+      result->initialize(num_points);
+    }
+    SpacetimeQuantities spacetime_quantities{num_points, {args...}};
+    tmpl::for_each<Tags>(
+        [&spacetime_quantities, &result](const auto tag_v) noexcept {
+          using tag = tmpl::type_from<std::decay_t<decltype(tag_v)>>;
+          get<tag>(*result) = spacetime_quantities.get_var(tag{});
+        });
+  }
+};
+}  // namespace Tags
+
+}  // namespace Xcts

--- a/tests/InputFiles/Xcts/Schwarzschild.yaml
+++ b/tests/InputFiles/Xcts/Schwarzschild.yaml
@@ -101,12 +101,23 @@ EventsAndTriggers:
   ? HasConverged
   : - ObserveErrorNorms:
         SubfileName: ErrorNorms
+    - ObserveNorms:
+        SubfileName: Norms
+        TensorsToObserve:
+          - Name: HamiltonianConstraint
+            NormType: L2Norm
+            Components: Individual
+          - Name: MomentumConstraint
+            NormType: L2Norm
+            Components: Individual
     - ObserveFields:
         SubfileName: VolumeData
         VariablesToObserve:
           - ConformalFactor
           - LapseTimesConformalFactor
           - ShiftExcess
+          - HamiltonianConstraint
+          - MomentumConstraint
         InterpolateToMesh: None
         CoordinatesFloatingPointType: Double
         FloatingPointTypes: [Double]

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Tags.cpp
@@ -74,6 +74,10 @@ void test_simple_tags() {
   TestHelpers::db::test_simple_tag<gr::Tags::MomentumDensity<Dim, Frame, Type>>(
       "MomentumDensity");
   TestHelpers::db::test_simple_tag<gr::Tags::StressTrace<Type>>("StressTrace");
+  TestHelpers::db::test_simple_tag<gr::Tags::HamiltonianConstraint<Type>>(
+      "HamiltonianConstraint");
+  TestHelpers::db::test_simple_tag<
+      gr::Tags::MomentumConstraint<Dim, Frame, Type>>("MomentumConstraint");
   TestHelpers::db::test_simple_tag<gr::Tags::WeylElectric<Dim, Frame, Type>>(
       "WeylElectric");
 }

--- a/tests/Unit/PointwiseFunctions/Xcts/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Xcts/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY Test_XctsPointwiseFunctions)
 
 set(LIBRARY_SOURCES
   Test_LongitudinalOperator.cpp
+  Test_SpacetimeQuantities.cpp
   )
 
 add_test_library(
@@ -18,5 +19,7 @@ target_link_libraries(
   ${LIBRARY}
   PRIVATE
   DataStructures
+  Spectral
+  Utilities
   XctsPointwiseFunctions
   )

--- a/tests/Unit/PointwiseFunctions/Xcts/SpacetimeQuantities.py
+++ b/tests/Unit/PointwiseFunctions/Xcts/SpacetimeQuantities.py
@@ -1,0 +1,40 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+from PointwiseFunctions.GeneralRelativity.ComputeSpacetimeQuantities import (
+    extrinsic_curvature)
+
+
+def spatial_metric(conformal_factor, conformal_metric):
+    return conformal_factor**4 * conformal_metric
+
+
+def inv_spatial_metric(conformal_factor, inv_conformal_metric):
+    return conformal_factor**(-4) * inv_conformal_metric
+
+
+def lapse(conformal_factor, lapse_times_conformal_factor):
+    return lapse_times_conformal_factor / conformal_factor
+
+
+def shift(shift_excess, shift_background):
+    return shift_excess + shift_background
+
+
+def hamiltonian_constraint(spatial_ricci_tensor, extrinsic_curvature,
+                           local_inv_spatial_metric):
+    return (
+        np.einsum('ij,ij', local_inv_spatial_metric, spatial_ricci_tensor) +
+        np.einsum('ij,ij', local_inv_spatial_metric, extrinsic_curvature)**2 -
+        np.einsum('ij,kl,ik,jl', local_inv_spatial_metric,
+                  local_inv_spatial_metric, extrinsic_curvature,
+                  extrinsic_curvature))
+
+
+def momentum_constraint(cov_deriv_extrinsic_curvature,
+                        local_inv_spatial_metric):
+    return (np.einsum('jk,jki', local_inv_spatial_metric,
+                      cov_deriv_extrinsic_curvature) -
+            np.einsum('jk,ijk', local_inv_spatial_metric,
+                      cov_deriv_extrinsic_curvature))

--- a/tests/Unit/PointwiseFunctions/Xcts/Test_SpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/Xcts/Test_SpacetimeQuantities.cpp
@@ -1,0 +1,109 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <random>
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/Xcts/SpacetimeQuantities.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace Xcts {
+
+namespace {
+template <typename Computed, typename... Args>
+void check_with_python(const Computed& computed,
+                       const std::string& function_name, const Args&... args) {
+  CAPTURE(function_name);
+  const auto expected = pypp::call<Computed>(
+      "PointwiseFunctions.Xcts.SpacetimeQuantities", function_name, args...);
+  Approx custom_approx = Approx::custom().epsilon(1.e-10).scale(1.);
+  CHECK_ITERABLE_CUSTOM_APPROX(computed, expected, custom_approx);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Xcts.SpacetimeQuantities",
+                  "[Unit][PointwiseFunctions]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{""};
+  // Set up a mesh for numerical derivatives
+  const Mesh<3> mesh{8, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto};
+  const size_t num_points = mesh.number_of_grid_points();
+  auto inv_jacobian = make_with_value<
+      InverseJacobian<DataVector, 3, Frame::Logical, Frame::Inertial>>(
+      num_points, 0.);
+  get<0, 0>(inv_jacobian) = 1.;
+  get<1, 1>(inv_jacobian) = 1.;
+  get<2, 2>(inv_jacobian) = 1.;
+  // Generate random input vars
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<double> dist_factor{0.5, 2.};
+  std::uniform_real_distribution<double> dist_isotropic{-1., 1.};
+  const auto conformal_factor = make_with_random_values<Scalar<DataVector>>(
+      make_not_null(&gen), make_not_null(&dist_factor), num_points);
+  const auto lapse_times_conformal_factor =
+      make_with_random_values<Scalar<DataVector>>(
+          make_not_null(&gen), make_not_null(&dist_factor), num_points);
+  const auto shift_excess = make_with_random_values<tnsr::I<DataVector, 3>>(
+      make_not_null(&gen), make_not_null(&dist_isotropic), num_points);
+  const auto conformal_metric =
+      make_with_random_values<tnsr::ii<DataVector, 3>>(
+          make_not_null(&gen), make_not_null(&dist_isotropic), num_points);
+  const auto inv_conformal_metric =
+      make_with_random_values<tnsr::II<DataVector, 3>>(
+          make_not_null(&gen), make_not_null(&dist_isotropic), num_points);
+  const auto shift_background = make_with_random_values<tnsr::I<DataVector, 3>>(
+      make_not_null(&gen), make_not_null(&dist_isotropic), num_points);
+  // Check output vars
+  const auto box = db::create<
+      tmpl::remove_duplicates<typename Tags::SpacetimeQuantitiesCompute<
+          typename SpacetimeQuantities::tags_list>::argument_tags>,
+      db::AddComputeTags<Tags::SpacetimeQuantitiesCompute<
+          typename SpacetimeQuantities::tags_list>>>(
+      mesh, conformal_factor, lapse_times_conformal_factor, shift_excess,
+      conformal_metric, inv_conformal_metric, shift_background,
+      std::move(inv_jacobian));
+  const auto& vars =
+      get<::Tags::Variables<typename SpacetimeQuantities::tags_list>>(box);
+  check_with_python(get<gr::Tags::SpatialMetric<3>>(vars), "spatial_metric",
+                    conformal_factor, conformal_metric);
+  check_with_python(get<gr::Tags::InverseSpatialMetric<3>>(vars),
+                    "inv_spatial_metric", conformal_factor,
+                    inv_conformal_metric);
+  check_with_python(get<gr::Tags::Lapse<DataVector>>(vars), "lapse",
+                    conformal_factor, lapse_times_conformal_factor);
+  check_with_python(get<gr::Tags::Shift<3>>(vars), "shift", shift_excess,
+                    shift_background);
+  check_with_python(
+      get<gr::Tags::ExtrinsicCurvature<3>>(vars), "extrinsic_curvature",
+      get<gr::Tags::Lapse<DataVector>>(vars), get<gr::Tags::Shift<3>>(vars),
+      get<::Tags::deriv<gr::Tags::Shift<3>, tmpl::size_t<3>, Frame::Inertial>>(
+          vars),
+      get<gr::Tags::SpatialMetric<3>>(vars),
+      get<::Tags::dt<gr::Tags::SpatialMetric<3>>>(vars),
+      get<::Tags::deriv<gr::Tags::SpatialMetric<3>, tmpl::size_t<3>,
+                        Frame::Inertial>>(vars));
+  check_with_python(get<gr::Tags::HamiltonianConstraint<DataVector>>(vars),
+                    "hamiltonian_constraint",
+                    get<gr::Tags::SpatialRicci<3>>(vars),
+                    get<gr::Tags::ExtrinsicCurvature<3>>(vars),
+                    get<gr::Tags::InverseSpatialMetric<3>>(vars));
+  check_with_python(get<gr::Tags::MomentumConstraint<3>>(vars),
+                    "momentum_constraint",
+                    get<::Tags::deriv<gr::Tags::ExtrinsicCurvature<3>,
+                                      tmpl::size_t<3>, Frame::Inertial>>(vars),
+                    get<gr::Tags::InverseSpatialMetric<3>>(vars));
+}
+
+}  // namespace Xcts

--- a/tests/Unit/PointwiseFunctions/Xcts/__init__.py
+++ b/tests/Unit/PointwiseFunctions/Xcts/__init__.py
@@ -1,0 +1,2 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.


### PR DESCRIPTION
## Proposed changes

- Give `ObserveNorms` the same treatment to work with the elliptic code as the other observation actions.
- Add the ADM Hamiltonian and momentum constraints, and compute them from XCTS variables.
- Observe them in the XCTS executable.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
`ObserveNorms` now takes the observation value tag as first template parameter. Pass `::Tags::Time` to get the same behavior as before.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
