### PR TITLE
Print number of DataBox items on startup

### DIFF
--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -700,11 +700,15 @@ class AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>
     using type = typename T::databox_types;
   };
 
-  using databox_types = tmpl::flatten<
-      tmpl::transform<databox_phase_types, get_databox_types<tmpl::_1>>>;
+  // Make the DataBox types public so `Main` can print some info about it
+ public:
+  using databox_types = tmpl::remove_duplicates<tmpl::flatten<
+      tmpl::transform<databox_phase_types, get_databox_types<tmpl::_1>>>>;
+
+ private:
   // Create a boost::variant that can hold any of the DataBox's
-  using variant_boxes = tmpl::remove_duplicates<
-      tmpl::push_front<databox_types, db::DataBox<tmpl::list<>>>>;
+  using variant_boxes =
+      tmpl::push_front<databox_types, db::DataBox<tmpl::list<>>>;
   make_boost_variant_over<variant_boxes> box_;
   tuples::tagged_tuple_from_typelist<inbox_tags_list> inboxes_{};
   array_index array_index_;


### PR DESCRIPTION
## Proposed changes

I found this useful to understand the size of the DataBox and the effect of things like #3248 . Let me know if you think this would be useful to merge. I enabled it only for Debug builds for now. It prints this (for `SolvePoisson1D`):

```
Parallel components:
  DgElementArray (Array) has 3 DataBox variants with [27, 108, 104] items.
  ResidualMonitor (Singleton) has 2 DataBox variants with [20, 22] items.
  Observer (Group) has 2 DataBox variants with [20, 32] items.
  ObserverWriter (Nodegroup) has 2 DataBox variants with [20, 37] items.
```

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
