### PR TITLE
Add LinkedMessageQueue

### DIFF
--- a/src/DataStructures/CMakeLists.txt
+++ b/src/DataStructures/CMakeLists.txt
@@ -40,6 +40,7 @@ spectre_target_headers(
   Index.hpp
   IndexIterator.hpp
   LeviCivitaIterator.hpp
+  LinkedMessageQueue.hpp
   Matrix.hpp
   ModalVector.hpp
   SliceIterator.hpp

--- a/src/DataStructures/LinkedMessageQueue.hpp
+++ b/src/DataStructures/LinkedMessageQueue.hpp
@@ -1,0 +1,176 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <optional>
+#include <ostream>
+#include <pup.h>
+#include <unordered_map>
+#include <utility>
+
+#include "Parallel/PupStlCpp17.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \ingroup DataStructuresGroup
+/// An identifier for an element in a sequence
+///
+/// The struct contains an ID and the ID for the previous element of
+/// the sequence, if any.  This allows the sequence to be
+/// reconstructed even when elements are received out-of-order.
+///
+/// \see LinkedMessageQueue
+template <typename Id>
+struct LinkedMessageId {
+  Id id;
+  std::optional<Id> previous;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) noexcept {
+    p | id;
+    p | previous;
+  }
+};
+
+template <typename Id>
+bool operator==(const LinkedMessageId<Id>& a,
+                const LinkedMessageId<Id>& b) noexcept {
+  return a.id == b.id and a.previous == b.previous;
+}
+
+template <typename Id>
+bool operator!=(const LinkedMessageId<Id>& a,
+                const LinkedMessageId<Id>& b) noexcept {
+  return not(a == b);
+}
+
+template <typename Id>
+std::ostream& operator<<(std::ostream& s,
+                         const LinkedMessageId<Id>& id) noexcept {
+  return s << id.id << " (" << id.previous << ")";
+}
+
+template <typename Id>
+struct std::hash<LinkedMessageId<Id>> {
+  size_t operator()(const LinkedMessageId<Id>& id) const noexcept {
+    // For normal use, any particular .id should only appear with one
+    // .previous, and vice versa, so hashing only one is fine.
+    return std::hash<Id>{}(id.id);
+  }
+};
+
+/// \cond
+template <typename Id, typename QueueTags>
+class LinkedMessageQueue;
+/// \endcond
+
+/// \ingroup DataStructuresGroup
+/// A collection of queues of asynchronously received data
+///
+/// This class is designed to collect asynchronously received
+/// messages, possibly from multiple sources, until sufficient data
+/// has been received for processing.  Each tag in \p QueueTags
+/// defines a queue of messages of type `Tag::type`.
+template <typename Id, typename... QueueTags>
+class LinkedMessageQueue<Id, tmpl::list<QueueTags...>> {
+  static_assert(sizeof...(QueueTags) > 0,
+                "Must have at least one message source.");
+
+ public:
+  using IdType = Id;
+
+  /// Insert data into a given queue at a given ID.  All queues must
+  /// receive data with the same collection of \p id_and_previous, but
+  /// are not required to receive them in the same order.
+  template <typename Tag>
+  void insert(const LinkedMessageId<Id>& id_and_previous,
+              typename Tag::type message) noexcept;
+
+  /// The next ID in the received sequence, if all queues have
+  /// received messages at that ID.
+  std::optional<Id> next_ready_id() const noexcept;
+
+  /// All the messages received at the time indicated by
+  /// `next_ready_id()`.  It is an error to call this function if
+  /// `next_ready_id()` would return an empty optional.  This function
+  /// removes the stored messages from the queues, advancing the
+  /// internal sequence ID.
+  tuples::TaggedTuple<QueueTags...> extract() noexcept;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) noexcept {
+    p | previous_id_;
+    p | messages_;
+  }
+
+ private:
+  template <typename Tag>
+  struct Optional {
+    using type = std::optional<typename Tag::type>;
+  };
+
+  using OptionalTuple = tuples::TaggedTuple<Optional<QueueTags>...>;
+
+  std::optional<Id> previous_id_{};
+  std::unordered_map<std::optional<Id>, std::pair<Id, OptionalTuple>>
+      messages_{};
+};
+
+template <typename Id, typename... QueueTags>
+template <typename Tag>
+void LinkedMessageQueue<Id, tmpl::list<QueueTags...>>::insert(
+    const LinkedMessageId<Id>& id_and_previous,
+    typename Tag::type message) noexcept {
+  static_assert((... or std::is_same_v<Tag, QueueTags>), "Unrecognized tag.");
+  const auto entry =
+      messages_
+          .insert({id_and_previous.previous,
+                   std::pair{id_and_previous.id, OptionalTuple{}}})
+          .first;
+  auto& [id, tuple] = entry->second;
+  ASSERT(id_and_previous.id == id,
+         "Received messages with different ids (" << id << " and "
+         << id_and_previous.id << ") but the same previous id ("
+         << id_and_previous.previous << ").");
+  ASSERT(not tuples::get<Optional<Tag>>(tuple).has_value(),
+         "Received duplicate messages at id " << id << " and previous id "
+         << id_and_previous.previous << ".");
+  tuples::get<Optional<Tag>>(tuple) = std::move(message);
+}
+
+template <typename Id, typename... QueueTags>
+std::optional<Id> LinkedMessageQueue<
+    Id, tmpl::list<QueueTags...>>::next_ready_id() const noexcept {
+  const auto current_entry = messages_.find(previous_id_);
+  if (current_entry == messages_.end()) {
+    return {};
+  }
+  const auto& current_value = current_entry->second;
+  const auto& [current_id, current_messages] = current_value;
+  if ((... and
+       tuples::get<Optional<QueueTags>>(current_messages).has_value())) {
+    return current_id;
+  } else {
+    return {};
+  }
+}
+
+template <typename Id, typename... QueueTags>
+tuples::TaggedTuple<QueueTags...>
+LinkedMessageQueue<Id, tmpl::list<QueueTags...>>::extract() noexcept {
+  ASSERT(next_ready_id().has_value(),
+         "Cannot extract before all messages have been received.");
+  const auto current_entry = messages_.find(previous_id_);
+  auto& current_value = current_entry->second;
+  auto& [current_id, current_messages] = current_value;
+  tuples::TaggedTuple<QueueTags...> result{};
+  (void)(..., (tuples::get<QueueTags>(result) = std::move(
+                   *tuples::get<Optional<QueueTags>>(current_messages))));
+  previous_id_ = current_id;
+  messages_.erase(current_entry);
+  return result;
+}

--- a/src/ParallelAlgorithms/Actions/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Actions/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_headers(
   HEADERS
   MutateApply.hpp
   SetData.hpp
+  UpdateMessageQueue.hpp
   )
 
 target_link_libraries(

--- a/src/ParallelAlgorithms/Actions/UpdateMessageQueue.hpp
+++ b/src/ParallelAlgorithms/Actions/UpdateMessageQueue.hpp
@@ -1,0 +1,61 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/LinkedMessageQueue.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+namespace Parallel {
+template <typename Metavariables>
+struct GlobalCache;
+}  // namespace Parallel
+/// \endcond
+
+namespace Actions {
+/// \ingroup ActionsGroup
+/// \brief Add data to a LinkedMessageQueue
+///
+/// Add the passed `id_and_previous` and `message` to the queue
+/// `QueueTag` in the `LinkedMessageQueue` stored in the DataBox tag
+/// `LinkedMessageQueueTag`.  Then, for each ID for which the message
+/// queue has all required messages, call `Processor::apply`.  The
+/// signature for an `apply` function for a message queue containing
+/// `Queue1` and `Queue2` with ID type `int` is:
+///
+/// \snippet Test_UpdateMessageQueue.cpp Processor::apply
+template <typename QueueTag, typename LinkedMessageQueueTag, typename Processor>
+struct UpdateMessageQueue {
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
+  static void apply(
+      db::DataBox<DbTags>& box, Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& array_index,
+      const LinkedMessageId<typename LinkedMessageQueueTag::type::IdType>&
+          id_and_previous,
+      typename QueueTag::type message) noexcept {
+    if constexpr (db::tag_is_retrievable_v<LinkedMessageQueueTag,
+                                           db::DataBox<DbTags>>) {
+      auto& queue =
+          db::get_mutable_reference<LinkedMessageQueueTag>(make_not_null(&box));
+      queue.template insert<QueueTag>(id_and_previous, std::move(message));
+      while (auto id = queue.next_ready_id()) {
+        Processor::apply(make_not_null(&box), cache, array_index, *id,
+                         queue.extract());
+      }
+    } else {
+      (void)box;
+      (void)cache;
+      (void)array_index;
+      (void)id_and_previous;
+      (void)message;
+      ERROR("LinkedMessageQueueTag not found in DataBox");  // LCOV_EXCL_LINE
+    }
+  }
+};
+}  // namespace Actions

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -27,6 +27,7 @@ set(LIBRARY_SOURCES
   Test_Index.cpp
   Test_IndexIterator.cpp
   Test_LeviCivitaIterator.cpp
+  Test_LinkedMessageQueue.cpp
   Test_ModalVector.cpp
   Test_ModalVectorInhomogeneousOperations.cpp
   Test_MoreComplexDiagonalModalOperatorMath.cpp

--- a/tests/Unit/DataStructures/Test_LinkedMessageQueue.cpp
+++ b/tests/Unit/DataStructures/Test_LinkedMessageQueue.cpp
@@ -1,0 +1,128 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <memory>
+#include <optional>
+#include <utility>
+
+#include "DataStructures/LinkedMessageQueue.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+struct Label1;
+struct Label2;
+
+// Can't use "Queue" because Charm defines a type with that name.
+template <typename Label>
+struct MyQueue {
+  // Non-copyable
+  using type = std::unique_ptr<double>;
+};
+
+void test_id() noexcept {
+  const LinkedMessageId<int> id_one_nothing{1, {}};
+  const LinkedMessageId<int> id_one_two{1, 2};
+  const LinkedMessageId<int> id_two_nothing{2, {}};
+  CHECK(id_one_nothing == id_one_nothing);
+  CHECK_FALSE(id_one_nothing != id_one_nothing);
+  CHECK_FALSE(id_one_nothing == id_one_two);
+  CHECK(id_one_nothing != id_one_two);
+  CHECK_FALSE(id_one_nothing == id_two_nothing);
+  CHECK(id_one_nothing != id_two_nothing);
+  CHECK(get_output(id_one_two) == "1 (2)");
+}
+
+void test_queue() noexcept {
+  LinkedMessageQueue<int, tmpl::list<MyQueue<Label1>, MyQueue<Label2>>> queue{};
+  CHECK(not queue.next_ready_id().has_value());
+
+  queue.insert<MyQueue<Label1>>({1, {}}, std::make_unique<double>(1.1));
+  CHECK(not queue.next_ready_id().has_value());
+  queue.insert<MyQueue<Label2>>({1, {}}, std::make_unique<double>(-1.1));
+
+  CHECK(queue.next_ready_id() == std::optional{1});
+  {
+    const auto out = queue.extract();
+    CHECK(*tuples::get<MyQueue<Label1>>(out) == 1.1);
+    CHECK(*tuples::get<MyQueue<Label2>>(out) == -1.1);
+  }
+
+  queue.insert<MyQueue<Label2>>({3, {1}}, std::make_unique<double>(-3.3));
+  CHECK(not queue.next_ready_id().has_value());
+  queue.insert<MyQueue<Label2>>({2, {3}}, std::make_unique<double>(-2.2));
+  CHECK(not queue.next_ready_id().has_value());
+  queue.insert<MyQueue<Label1>>({2, {3}}, std::make_unique<double>(2.2));
+
+  const auto finish_checks = [](decltype(queue) test_queue) noexcept {
+    CHECK(not test_queue.next_ready_id().has_value());
+    test_queue.insert<MyQueue<Label1>>({3, {1}}, std::make_unique<double>(3.3));
+
+    CHECK(test_queue.next_ready_id() == std::optional{3});
+    {
+      const auto out = test_queue.extract();
+      CHECK(*tuples::get<MyQueue<Label1>>(out) == 3.3);
+      CHECK(*tuples::get<MyQueue<Label2>>(out) == -3.3);
+    }
+
+    CHECK(test_queue.next_ready_id() == std::optional{2});
+    {
+      const auto out = test_queue.extract();
+      CHECK(*tuples::get<MyQueue<Label1>>(out) == 2.2);
+      CHECK(*tuples::get<MyQueue<Label2>>(out) == -2.2);
+    }
+  };
+  finish_checks(serialize_and_deserialize(queue));
+  finish_checks(std::move(queue));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DataStructures.LinkedMessageQueue",
+                  "[Unit][DataStructures]") {
+  test_id();
+  test_queue();
+}
+
+// [[OutputRegex, Received duplicate messages at id 1 and previous id --\.]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.DataStructures.LinkedMessageQueue.Duplicate",
+    "[Unit][DataStructures]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  LinkedMessageQueue<int, tmpl::list<MyQueue<Label1>, MyQueue<Label2>>> queue{};
+  queue.insert<MyQueue<Label1>>({1, {}}, std::make_unique<double>(1.1));
+  queue.insert<MyQueue<Label1>>({1, {}}, std::make_unique<double>(1.1));
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif /* SPECTRE_DEBUG */
+}
+
+// [[OutputRegex, Received messages with different ids \(1 and 2\) but the same
+// previous id \(--\)\.]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.DataStructures.LinkedMessageQueue.Inconsistent",
+    "[Unit][DataStructures]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  LinkedMessageQueue<int, tmpl::list<MyQueue<Label1>, MyQueue<Label2>>> queue{};
+  queue.insert<MyQueue<Label1>>({1, {}}, std::make_unique<double>(1.1));
+  queue.insert<MyQueue<Label2>>({2, {}}, std::make_unique<double>(1.1));
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif /* SPECTRE_DEBUG */
+}
+
+// [[OutputRegex, Cannot extract before all messages have been received\.]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.DataStructures.LinkedMessageQueue.NotReady",
+    "[Unit][DataStructures]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  LinkedMessageQueue<int, tmpl::list<MyQueue<Label1>, MyQueue<Label2>>> queue{};
+  queue.insert<MyQueue<Label1>>({1, {}}, std::make_unique<double>(1.1));
+  queue.extract();
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif /* SPECTRE_DEBUG */
+}

--- a/tests/Unit/ParallelAlgorithms/Actions/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Actions/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_ParallelAlgorithmsActions")
 set(LIBRARY_SOURCES
   Test_MutateApply.cpp
   Test_SetData.cpp
+  Test_UpdateMessageQueue.cpp
   )
 
 add_test_library(

--- a/tests/Unit/ParallelAlgorithms/Actions/Test_UpdateMessageQueue.cpp
+++ b/tests/Unit/ParallelAlgorithms/Actions/Test_UpdateMessageQueue.cpp
@@ -1,0 +1,127 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/LinkedMessageQueue.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "ParallelAlgorithms/Actions/UpdateMessageQueue.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace Parallel {
+template <typename Metavaiables>
+class GlobalCache;
+}  // namespace Parallel
+
+namespace {
+struct Queue1 {
+  using type = double;
+};
+
+struct Queue2 {
+  using type = double;
+};
+
+struct LinkedMessageQueueTag : db::SimpleTag {
+  using type = LinkedMessageQueue<int, tmpl::list<Queue1, Queue2>>;
+};
+
+struct ProcessorCalls : db::SimpleTag {
+  using type = std::vector<std::pair<int, tuples::TaggedTuple<Queue1, Queue2>>>;
+};
+
+struct Processor {
+// [Processor::apply]
+  template <typename DbTags, typename Metavariables, typename ArrayIndex>
+  static void apply(const gsl::not_null<db::DataBox<DbTags>*> box,
+                    Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/, const int id,
+                    tuples::TaggedTuple<Queue1, Queue2> data) noexcept {
+// [Processor::apply]
+    db::mutate<ProcessorCalls>(
+        box, [&id, &data](
+                 const gsl::not_null<ProcessorCalls::type*> calls) noexcept {
+          calls->emplace_back(id, std::move(data));
+        });
+  }
+};
+
+template <typename Metavariables>
+struct Component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using initialization_tags = tmpl::list<LinkedMessageQueueTag, ProcessorCalls>;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::Initialization,
+                                        tmpl::list<>>>;
+};
+
+struct Metavariables {
+  using component_list = tmpl::list<Component<Metavariables>>;
+  enum class Phase { Initialization, Testing, Exit };
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Actions.UpdateMessageQueue", "[Unit][Actions]") {
+  using component = Component<Metavariables>;
+
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{{}};
+  ActionTesting::emplace_component<component>(
+      &runner, 0, LinkedMessageQueueTag::type{}, ProcessorCalls::type{});
+
+  ActionTesting::set_phase(make_not_null(&runner),
+                           Metavariables::Phase::Testing);
+
+  const auto processed_by_call =
+      [&runner](auto queue_v, const LinkedMessageId<int>& id,
+                auto data) noexcept -> decltype(auto) {
+    ActionTesting::simple_action<
+        component, Actions::UpdateMessageQueue<
+                       decltype(queue_v), LinkedMessageQueueTag, Processor>>(
+        make_not_null(&runner), 0, id, std::move(data));
+    return db::mutate<ProcessorCalls>(
+        make_not_null(&ActionTesting::get_databox<component, tmpl::list<>>(
+            make_not_null(&runner), 0)),
+        [](const gsl::not_null<ProcessorCalls::type*> calls) noexcept {
+          auto ret = std::move(*calls);
+          calls->clear();
+          return ret;
+        });
+  };
+
+  CHECK(processed_by_call(Queue1{}, {0, {}}, 1.23).empty());
+  {
+    const auto processed = processed_by_call(Queue2{}, {0, {}}, 2.34);
+    CHECK(processed.size() == 1);
+
+    CHECK(processed[0].first == 0);
+    CHECK(get<Queue1>(processed[0].second) == 1.23);
+    CHECK(get<Queue2>(processed[0].second) == 2.34);
+  }
+  CHECK(processed_by_call(Queue1{}, {2, 1}, 2.2).empty());
+  CHECK(processed_by_call(Queue2{}, {1, 0}, 1.1).empty());
+  CHECK(processed_by_call(Queue2{}, {2, 1}, 2.2).empty());
+  {
+    const auto processed = processed_by_call(Queue1{}, {1, 0}, 1.1);
+    CHECK(processed.size() == 2);
+
+    CHECK(processed[0].first == 1);
+    CHECK(get<Queue1>(processed[0].second) == 1.1);
+    CHECK(get<Queue2>(processed[0].second) == 1.1);
+
+    CHECK(processed[1].first == 2);
+    CHECK(get<Queue1>(processed[1].second) == 2.2);
+    CHECK(get<Queue2>(processed[1].second) == 2.2);
+  }
+}


### PR DESCRIPTION
This is roughly a generalization of some of the stuff @moxcodes wrote in #3422 to handle cases where more than one data source is needed (for example, two horizon finds).  I have not investigated how difficult it would be to use this class in that PR.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
