### PR TITLE
Interpolate to center of star on subcell

### DIFF
--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -46,7 +46,7 @@ add_grmhd_executable(
 
 add_grmhd_executable(
   TovStar
-  RelativisticEuler::Solutions::TovStar<gr::Solutions::TovSolution>
+  RelativisticEuler::Solutions::TovStar<gr::Solutions::TovSolution>,CenterOfStar
   "${LIBS_TO_LINK}"
   )
 

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivCleanFwd.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivCleanFwd.hpp
@@ -37,6 +37,7 @@ class RiemannProblem;
 }  // namespace AnalyticData
 }  // namespace grmhd
 
+struct CenterOfStar;
 struct KerrHorizon;
 template <typename InitialData, typename...InterpolationTargetTags>
 struct EvolutionMetavars;

--- a/src/NumericalAlgorithms/Interpolation/Actions/InterpolationTargetSendPoints.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Actions/InterpolationTargetSendPoints.hpp
@@ -46,7 +46,8 @@ struct InterpolationTargetSendTimeIndepPointsToElements {
     auto coords = InterpolationTarget_detail::block_logical_coords<
         InterpolationTargetTag>(box, tmpl::type_<Metavariables>{});
     auto& receiver_proxy = Parallel::get_parallel_component<
-        typename InterpolationTargetTag::interpolating_component>(cache);
+        typename InterpolationTargetTag::template interpolating_component<
+            Metavariables>>(cache);
     Parallel::simple_action<ElementReceiveInterpPoints<InterpolationTargetTag>>(
         receiver_proxy, std::move(coords));
     return std::forward_as_tuple(std::move(box));

--- a/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -74,6 +74,7 @@ target_link_libraries(
   Blas
   Boost::boost
   DataStructures
+  DgSubcell
   Domain
   DomainStructure
   ErrorHandling

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTarget.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTarget.hpp
@@ -117,7 +117,7 @@ namespace intrp {
 ///   Domain will be filled with this value. If this variable is not defined,
 ///   then the `apply` function must check for invalid points,
 ///   and should typically exit with an error message if it finds any.
-/// - interpolating_component (used only if not `is_sequential`):
+/// - interpolating_component:
 ///      A type alias for the component that will be interpolating to the
 ///      interpolation target.
 ///

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetSpecifiedPoints.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetSpecifiedPoints.hpp
@@ -50,7 +50,7 @@ struct SpecifiedPoints {
       std::vector<std::array<double, VolumeDim>> points_in) noexcept;
 
   SpecifiedPoints() = default;
-  SpecifiedPoints(const SpecifiedPoints& /*rhs*/) = delete;
+  SpecifiedPoints(const SpecifiedPoints& /*rhs*/) = default;
   SpecifiedPoints& operator=(const SpecifiedPoints& /*rhs*/) = default;
   SpecifiedPoints(SpecifiedPoints&& /*rhs*/) noexcept = default;
   SpecifiedPoints& operator=(SpecifiedPoints&& /*rhs*/) noexcept = default;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ElementReceiveInterpPoints.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ElementReceiveInterpPoints.cpp
@@ -81,7 +81,8 @@ struct MockMetavariables {
     using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
         ::intrp::TargetPoints::LineSegment<InterpolationTargetA, 3>;
-    using interpolating_component = mock_element<MockMetavariables>;
+    template <typename Metavariables>
+    using interpolating_component = mock_element<Metavariables>;
   };
   struct InterpolationTargetB {
     using temporal_id = ::Tags::TimeStepId;
@@ -89,7 +90,8 @@ struct MockMetavariables {
     using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
         ::intrp::TargetPoints::LineSegment<InterpolationTargetB, 3>;
-    using interpolating_component = mock_element<MockMetavariables>;
+    template <typename Metavariables>
+    using interpolating_component = mock_element<Metavariables>;
   };
   static constexpr size_t volume_dim = 3;
   using interpolation_target_tags = tmpl::list<InterpolationTargetA,

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
@@ -193,48 +193,32 @@ void test_interpolate_to_points(const Mesh<Dim>& mesh) noexcept {
   }
 }
 
-}  // namespace
-
-SPECTRE_TEST_CASE("Unit.Numerical.Interpolation.IrregularInterpolant",
-                  "[Unit][NumericalAlgorithms]") {
+template <Spectral::Basis Basis, Spectral::Quadrature Quadrature>
+void test_irregular_interpolant() {
   const size_t start_points = 4;
   const size_t end_points = 6;
   for (size_t n0 = start_points; n0 < end_points; ++n0) {
-    test_interpolate_to_points<1>(Mesh<1>{n0, Spectral::Basis::Legendre,
-                                          Spectral::Quadrature::GaussLobatto});
+    test_interpolate_to_points<1>(Mesh<1>{n0, Basis, Quadrature});
     for (size_t n1 = start_points; n1 < end_points; ++n1) {
-      test_interpolate_to_points<2>(
-          Mesh<2>{{{n0, n1}},
-                  Spectral::Basis::Legendre,
-                  Spectral::Quadrature::GaussLobatto});
+      test_interpolate_to_points<2>(Mesh<2>{{{n0, n1}}, Basis, Quadrature});
       for (size_t n2 = start_points; n2 < end_points; ++n2) {
         test_interpolate_to_points<3>(
-            Mesh<3>{{{n0, n1, n2}},
-                    Spectral::Basis::Legendre,
-                    Spectral::Quadrature::GaussLobatto});
+            Mesh<3>{{{n0, n1, n2}}, Basis, Quadrature});
       }
     }
   }
 }
 
-SPECTRE_TEST_CASE("Unit.Numerical.Interpolation.IrregularInterpolant.Meshes",
-                  "[Unit][NumericalAlgorithms]") {
+void test_irregular_interpolant_mixed_quadrature() {
   const size_t start_points = 4;
   const size_t end_points = 6;
   for (size_t n0 = start_points; n0 < end_points; ++n0) {
-    test_interpolate_to_points<1>(
-        Mesh<1>{n0, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss});
     for (size_t n1 = start_points; n1 < end_points; ++n1) {
-      test_interpolate_to_points<2>(Mesh<2>{
-          {{n0, n1}}, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss});
       test_interpolate_to_points<2>(Mesh<2>{
           {{n0, n1}},
           {{Spectral::Basis::Legendre, Spectral::Basis::Legendre}},
           {{Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss}}});
       for (size_t n2 = start_points; n2 < end_points; ++n2) {
-        test_interpolate_to_points<3>(Mesh<3>{{{n0, n1, n2}},
-                                              Spectral::Basis::Legendre,
-                                              Spectral::Quadrature::Gauss});
         test_interpolate_to_points<3>(Mesh<3>{
             {{n0, n1, n2}},
             {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
@@ -244,4 +228,15 @@ SPECTRE_TEST_CASE("Unit.Numerical.Interpolation.IrregularInterpolant.Meshes",
       }
     }
   }
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Numerical.Interpolation.IrregularInterpolant",
+                  "[Unit][NumericalAlgorithms]") {
+  test_irregular_interpolant<Spectral::Basis::Legendre,
+                             Spectral::Quadrature::GaussLobatto>();
+  test_irregular_interpolant<Spectral::Basis::Legendre,
+                             Spectral::Quadrature::Gauss>();
+  test_irregular_interpolant_mixed_quadrature();
 }


### PR DESCRIPTION
## Proposed changes

Add an interpolation target for the center of a star in the GRMHD executable and enable it for subcell.

### Upgrade instructions


<!-- UPGRADE INSTRUCTIONS -->
The  interpolation target tags need `interpolating_component` to be templated on the metavariables
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
