### PR TITLE
Add apparent-horizon boundary conditions to XCTS executable

### DIFF
--- a/src/DataStructures/DataBox/SubitemTag.hpp
+++ b/src/DataStructures/DataBox/SubitemTag.hpp
@@ -12,13 +12,13 @@ namespace Tags {
 /// \cond
 // Declaration of a tag for a subitem
 // Unless specialized, it will be the reference tag below,
-template <typename Tag, typename ParentTag>
+template <typename Tag, typename ParentTag, typename = std::nullptr_t>
 struct Subitem;
 /// \endcond
 
 /// \brief a reference tag that refers to a particular Tag that is a subitem of
 /// an item tagged with ParentTag
-template <typename Tag, typename ParentTag>
+template <typename Tag, typename ParentTag, typename>
 struct Subitem : Tag, db::ReferenceTag {
   using base = Tag;
   using parent_tag = ParentTag;

--- a/src/Elliptic/BoundaryConditions/Tags/BoundaryFields.hpp
+++ b/src/Elliptic/BoundaryConditions/Tags/BoundaryFields.hpp
@@ -1,0 +1,83 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/SliceVariables.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/IndexToSliceAt.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/Tags/FaceNormal.hpp"
+#include "Domain/Tags/Faces.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace elliptic::Tags {
+
+/// The `FieldsTag` on external boundaries
+template <size_t Dim, typename FieldsTag>
+struct BoundaryFieldsCompute : db::ComputeTag,
+                               domain::Tags::Faces<Dim, FieldsTag> {
+  using base = domain::Tags::Faces<Dim, FieldsTag>;
+  using return_type = typename base::type;
+  using argument_tags = tmpl::list<FieldsTag, domain::Tags::Mesh<Dim>,
+                                   domain::Tags::Element<Dim>>;
+  static void function(const gsl::not_null<return_type*> vars_on_face,
+                       const typename FieldsTag::type& vars,
+                       const Mesh<Dim>& mesh,
+                       const Element<Dim>& element) noexcept {
+    ASSERT(mesh.quadrature(0) == Spectral::Quadrature::GaussLobatto,
+           "Slicing fields to the boundary currently supports only "
+           "Gauss-Lobatto grids. Add support to "
+           "'elliptic::Tags::BoundaryFieldsCompute'.");
+    for (const auto& direction : element.external_boundaries()) {
+      data_on_slice(make_not_null(&((*vars_on_face)[direction])), vars,
+                    mesh.extents(), direction.dimension(),
+                    index_to_slice_at(mesh.extents(), direction));
+    }
+  }
+};
+
+/// The `::Tags::NormalDotFlux<FieldsTag>` on external boundaries
+template <size_t Dim, typename FieldsTag, typename FluxesTag>
+struct BoundaryFluxesCompute
+    : db::ComputeTag,
+      domain::Tags::Faces<
+          Dim, db::add_tag_prefix<::Tags::NormalDotFlux, FieldsTag>> {
+  using base =
+      domain::Tags::Faces<Dim,
+                          db::add_tag_prefix<::Tags::NormalDotFlux, FieldsTag>>;
+  using return_type = typename base::type;
+  using argument_tags =
+      tmpl::list<FluxesTag,
+                 domain::Tags::Faces<Dim, domain::Tags::FaceNormal<Dim>>,
+                 domain::Tags::Mesh<Dim>, domain::Tags::Element<Dim>>;
+  static void function(
+      const gsl::not_null<return_type*> normal_dot_fluxes,
+      const typename FluxesTag::type& fluxes,
+      const DirectionMap<Dim, tnsr::i<DataVector, Dim>>& face_normals,
+      const Mesh<Dim>& mesh, const Element<Dim>& element) noexcept {
+    ASSERT(mesh.quadrature(0) == Spectral::Quadrature::GaussLobatto,
+           "Slicing fluxes to the boundary currently supports only "
+           "Gauss-Lobatto grids. Add support to "
+           "'elliptic::Tags::BoundaryFluxesCompute'.");
+    for (const auto& direction : element.external_boundaries()) {
+      const auto fluxes_on_face =
+          data_on_slice(fluxes, mesh.extents(), direction.dimension(),
+                        index_to_slice_at(mesh.extents(), direction));
+      normal_dot_flux(make_not_null(&((*normal_dot_fluxes)[direction])),
+                      face_normals.at(direction), fluxes_on_face);
+    }
+  }
+};
+
+}  // namespace elliptic::Tags

--- a/src/Elliptic/Systems/Xcts/FirstOrderSystem.hpp
+++ b/src/Elliptic/Systems/Xcts/FirstOrderSystem.hpp
@@ -9,6 +9,7 @@
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "Elliptic/BoundaryConditions/AnalyticSolution.hpp"
 #include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.hpp"
 #include "Elliptic/Systems/Xcts/BoundaryConditions/Flatness.hpp"
 #include "Elliptic/Systems/Xcts/FluxesAndSources.hpp"
 #include "Elliptic/Systems/Xcts/Geometry.hpp"
@@ -273,7 +274,9 @@ struct FirstOrderSystem {
       elliptic::BoundaryConditions::BoundaryCondition<
           3, tmpl::list<elliptic::BoundaryConditions::Registrars::
                             AnalyticSolution<FirstOrderSystem>,
-                        BoundaryConditions::Registrars::Flatness>>;
+                        BoundaryConditions::Registrars::Flatness,
+                        BoundaryConditions::Registrars::ApparentHorizon<
+                            ConformalGeometry>>>;
 
   // The tag of the operator to compute magnitudes on the manifold, e.g. to
   // normalize vectors on the faces of an element

--- a/tests/Unit/Elliptic/BoundaryConditions/CMakeLists.txt
+++ b/tests/Unit/Elliptic/BoundaryConditions/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_EllipticBoundaryConditions")
 
 set(LIBRARY_SOURCES
+  Tags/Test_BoundaryFields.cpp
   Test_AnalyticSolution.cpp
   Test_BoundaryCondition.cpp
   Test_BoundaryConditionType.cpp

--- a/tests/Unit/Elliptic/BoundaryConditions/Tags/Test_BoundaryFields.cpp
+++ b/tests/Unit/Elliptic/BoundaryConditions/Tags/Test_BoundaryFields.cpp
@@ -1,0 +1,71 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/Tags/FaceNormal.hpp"
+#include "Domain/Tags/Faces.hpp"
+#include "Elliptic/BoundaryConditions/Tags/BoundaryFields.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+
+SPECTRE_TEST_CASE("Unit.Elliptic.BoundaryConditions.BoundaryFields",
+                  "[Unit][Elliptic]") {
+  static constexpr size_t Dim = 2;
+  using vars_tag = ::Tags::Variables<tmpl::list<::Tags::TempScalar<0>>>;
+  using fluxes_tag = ::Tags::Variables<tmpl::list<::Tags::TempI<0, Dim>>>;
+  TestHelpers::db::test_compute_tag<
+      elliptic::Tags::BoundaryFieldsCompute<Dim, vars_tag>>(
+      "Faces(Variables(TempTensor0))");
+  TestHelpers::db::test_compute_tag<
+      elliptic::Tags::BoundaryFluxesCompute<Dim, vars_tag, fluxes_tag>>(
+      "Faces(Variables(NormalDotFlux(TempTensor0)))");
+  {
+    const Mesh<Dim> mesh{3, Spectral::Basis::Legendre,
+                         Spectral::Quadrature::GaussLobatto};
+    const Element<Dim> element{
+        ElementId<Dim>{0},
+        {{Direction<Dim>::upper_xi(), {{{ElementId<Dim>{1}}}, {}}},
+         {Direction<Dim>::lower_eta(), {{{ElementId<Dim>{1}}}, {}}},
+         {Direction<Dim>::upper_eta(), {{{ElementId<Dim>{1}}}, {}}}}};
+    tnsr::i<DataVector, Dim> face_normal{size_t{3}, 0.};
+    get<0>(face_normal) = -1.;
+    DirectionMap<Dim, tnsr::i<DataVector, Dim>> face_normals{
+        {Direction<Dim>::lower_xi(), std::move(face_normal)}};
+    Variables<tmpl::list<::Tags::TempScalar<0>>> vars{size_t{9}, 0.};
+    auto& var = get(get<::Tags::TempScalar<0>>(vars));
+    std::iota(var.begin(), var.end(), 1.);
+    Variables<tmpl::list<::Tags::TempI<0, Dim>>> fluxes{size_t{9}, 0.};
+    for (size_t d = 0; d < Dim; ++d) {
+      auto& flux = get<::Tags::TempI<0, Dim>>(fluxes).get(d);
+      std::iota(flux.begin(), flux.end(), 10. * static_cast<double>(d + 1));
+    }
+    const auto box = db::create<
+        db::AddSimpleTags<
+            vars_tag, fluxes_tag, domain::Tags::Mesh<Dim>,
+            domain::Tags::Element<Dim>,
+            domain::Tags::Faces<Dim, domain::Tags::FaceNormal<Dim>>>,
+        db::AddComputeTags<
+            elliptic::Tags::BoundaryFieldsCompute<Dim, vars_tag>,
+            elliptic::Tags::BoundaryFluxesCompute<Dim, vars_tag, fluxes_tag>>>(
+        std::move(vars), std::move(fluxes), mesh, element,
+        std::move(face_normals));
+    CHECK(get(get<domain::Tags::Faces<Dim, ::Tags::TempScalar<0>>>(box).at(
+              Direction<Dim>::lower_xi())) == DataVector{1., 4., 7.});
+    CHECK(get(get<domain::Tags::Faces<
+                  Dim, ::Tags::NormalDotFlux<::Tags::TempScalar<0>>>>(box)
+                  .at(Direction<Dim>::lower_xi())) ==
+          DataVector{-10., -13., -16.});
+  }
+}


### PR DESCRIPTION
## Proposed changes

Also includes some preparatory commits to slice the non-linear fields and fluxes to external boundaries.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
