### PR TITLE
Compress docs upload on CI

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -253,11 +253,15 @@ jobs:
         run: |
           make doc-coverage
       # Upload as an artifact to make available to PRs
+      - name: Prepare for upload
+        working-directory: /work/build
+        run: |
+          zip -qr docs-html.zip docs/html
       - name: Upload documentation
         uses: actions/upload-artifact@v2
         with:
           name: docs-html
-          path: /work/build/docs/html
+          path: /work/build/docs-html.zip
       # Deploy to gh-pages on pushes to develop
       - name: Deploy to gh-pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/develop'


### PR DESCRIPTION
## Proposed changes

GitHub's upload-artifact action doesn't automatically compress the
upload, so it takes ~5 min to upload the ~10k files in the docs,
and sometimes hits rate limits. With compression the upload
takes only a few seconds.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
