### PR TITLE
Fix doc-coverage with Doxygen 1.9.1

### DIFF
--- a/cmake/SetupDoxygen.cmake
+++ b/cmake/SetupDoxygen.cmake
@@ -140,6 +140,8 @@ ${DOCS_POST_PROCESS_COMMAND} && exit \${generate_docs_exit}\n"
       --remove ${CMAKE_BINARY_DIR}/docs/tmp/doc_coverage.info
       '${CMAKE_SOURCE_DIR}/src/Executables/*'
       '${CMAKE_SOURCE_DIR}/tests/*'
+      '${CMAKE_SOURCE_DIR}/citelist'
+      '${CMAKE_SOURCE_DIR}/[generated]'
       --output ${CMAKE_BINARY_DIR}/docs/tmp/doc_coverage.info
 
       COMMAND


### PR DESCRIPTION
## Proposed changes

Upgrading Doxygen broke the `doc-coverage` target and thus docs deployment to gh-pages. This fixes it.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
