### PR TITLE
Add virtual functions to FunctionOfTime base

### DIFF
--- a/src/Domain/FunctionsOfTime/FunctionOfTime.hpp
+++ b/src/Domain/FunctionsOfTime/FunctionOfTime.hpp
@@ -10,6 +10,7 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "Parallel/CharmPupable.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 
 namespace domain {
 /// \ingroup ComputationalDomainGroup
@@ -54,6 +55,21 @@ class FunctionOfTime : public PUP::able {
   /// `time_bounds` tells you the bounds including the allowed extrapolation
   /// interval.
   virtual std::array<double, 2> time_bounds() const noexcept = 0;
+
+  /// Updates the maximum derivative of the FunctionOfTime at a given time while
+  /// also resetting the expiration. By default, a FunctionOfTime cannot be
+  /// updated.
+  virtual void update(double /*time_of_update*/,
+                      DataVector /*updated_max_deriv*/,
+                      double /*next_expiration_time*/) noexcept {
+    ERROR("Cannot update this FunctionOfTime.");
+  }
+
+  /// Resets the expiration time to a new value. By default, the expiration time
+  /// of a FunctionOfTime cannot be reset.
+  virtual void reset_expiration_time(double /*next_expiration_time*/) noexcept {
+    ERROR("Cannot reset expiration time of this FunctionOfTime.");
+  }
 
   /// The DataVector can be of any size
   virtual std::array<DataVector, 1> func(double t) const noexcept = 0;

--- a/src/Domain/FunctionsOfTime/PiecewisePolynomial.hpp
+++ b/src/Domain/FunctionsOfTime/PiecewisePolynomial.hpp
@@ -66,12 +66,12 @@ class PiecewisePolynomial : public FunctionOfTime {
   /// `updated_max_deriv` is a vector of the `MaxDeriv`ths for each component.
   /// `next_expiration_time` is the next expiration time.
   void update(double time_of_update, DataVector updated_max_deriv,
-              double next_expiration_time) noexcept;
+              double next_expiration_time) noexcept override;
 
   /// Used by `FunctionOfTimeUpdater` to reset the expiration time
   /// when it decides not to do an update, but instead decides to
   /// keep the current values valid for longer.
-  void reset_expiration_time(double next_expiration_time) noexcept;
+  void reset_expiration_time(double next_expiration_time) noexcept override;
 
   /// Returns the domain of validity of the function,
   /// including the extrapolation region.

--- a/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp
+++ b/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp
@@ -79,7 +79,8 @@ class QuaternionFunctionOfTime : public FunctionOfTime {
   // clang-tidy: cppcoreguidelines-owning-memory,-warnings-as-errors
   WRAPPED_PUPable_decl_template(QuaternionFunctionOfTime<MaxDeriv>);  // NOLINT
 
-  void reset_expiration_time(const double next_expiration_time) noexcept {
+  void reset_expiration_time(
+      const double next_expiration_time) noexcept override {
     omega_f_of_t_.reset_expiration_time(next_expiration_time);
   }
 
@@ -94,7 +95,7 @@ class QuaternionFunctionOfTime : public FunctionOfTime {
   /// `updated_max_deriv` is a datavector of the `MaxDeriv`s for each component.
   /// `next_expiration_time` is the next expiration time.
   void update(double time_of_update, DataVector updated_max_deriv,
-              double next_expiration_time) noexcept;
+              double next_expiration_time) noexcept override;
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p) override;

--- a/tests/Unit/ControlSystem/Test_Controller.cpp
+++ b/tests/Unit/ControlSystem/Test_Controller.cpp
@@ -45,9 +45,6 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Controller", "[ControlSystem][Unit]") {
                {freq * std::cos(freq * t)},
                {-square(freq) * std::sin(freq * t)}}},
           t + dt);
-  auto& f_of_t_derived =
-      dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>&>(
-          *f_of_t);
 
   Controller<deriv_order> control_signal;
   const double t_offset = 0.0;
@@ -73,7 +70,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Controller", "[ControlSystem][Unit]") {
                                         t_offset, t_offset);
 
     t += dt;
-    f_of_t_derived.update(t, {U}, t + dt);
+    f_of_t->update(t, {U}, t + dt);
 
     // update the timescale
     tst.update_timescale({{q_and_derivs[0], q_and_derivs[1]}});
@@ -116,9 +113,6 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Controller.TimeOffsets",
                {freq * std::cos(freq * t)},
                {-square(freq) * std::sin(freq * t)}}},
           t + dt);
-  auto& f_of_t_derived =
-      dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>&>(
-          *f_of_t);
 
   Controller<deriv_order> control_signal;
 
@@ -157,7 +151,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Controller.TimeOffsets",
         control_signal(tst.current_timescale(), avg_qs, t_offset, t_offset);
 
     t += dt;
-    f_of_t_derived.update(t, {U}, t + dt);
+    f_of_t->update(t, {U}, t + dt);
 
     // update the timescale
     tst.update_timescale({{avg_qs[0], avg_qs[1]}});
@@ -200,9 +194,6 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Controller.TimeOffsets_DontAverageQ",
                {freq * std::cos(freq * t)},
                {-square(freq) * std::sin(freq * t)}}},
           t + dt);
-  auto& f_of_t_derived =
-      dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>&>(
-          *f_of_t);
 
   Controller<deriv_order> control_signal;
 
@@ -243,7 +234,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Controller.TimeOffsets_DontAverageQ",
         control_signal(tst.current_timescale(), avg_qs, q_t_offset, t_offset);
 
     t += dt;
-    f_of_t_derived.update(t, {U}, t + dt);
+    f_of_t->update(t, {U}, t + dt);
 
     // update the timescale
     tst.update_timescale({{avg_qs[0], avg_qs[1]}});

--- a/tests/Unit/Domain/FunctionsOfTime/Test_FixedSpeedCubic.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_FixedSpeedCubic.cpp
@@ -141,3 +141,38 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.FixedSpeedCubic",
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
+
+// [[OutputRegex, Cannot update this FunctionOfTime.]]
+SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.FixedSpeedCubic.BadUpdate",
+                  "[Domain][Unit]") {
+  ERROR_TEST();
+  const double initial_function_value = 1.0;
+  const double initial_time = 0.0;
+  const double velocity = -0.1;
+  const double decay_timescale = 0.0;
+  const std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> f_of_t =
+      std::make_unique<domain::FunctionsOfTime::FixedSpeedCubic>(
+          initial_function_value, initial_time, velocity, decay_timescale);
+
+  const double update_time = 1.0;
+  const DataVector updated_deriv{};
+  const double next_expr_time = 2.0;
+  f_of_t->update(update_time, updated_deriv, next_expr_time);
+}
+
+// [[OutputRegex, Cannot reset expiration time of this FunctionOfTime.]]
+SPECTRE_TEST_CASE(
+    "Unit.Domain.FunctionsOfTime.FixedSpeedCubic.BadResetExprTime",
+    "[Domain][Unit]") {
+  ERROR_TEST();
+  const double initial_function_value = 1.0;
+  const double initial_time = 0.0;
+  const double velocity = -0.1;
+  const double decay_timescale = 0.0;
+  const std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> f_of_t =
+      std::make_unique<domain::FunctionsOfTime::FixedSpeedCubic>(
+          initial_function_value, initial_time, velocity, decay_timescale);
+
+  const double next_expr_time = 2.0;
+  f_of_t->reset_expiration_time(next_expr_time);
+}

--- a/tests/Unit/Domain/FunctionsOfTime/Test_FunctionsOfTimeAreReady.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_FunctionsOfTimeAreReady.cpp
@@ -34,9 +34,7 @@ struct OtherFunctionsOfTime : db::SimpleTag {
 struct UpdateFoT {
   static void apply(const gsl::not_null<FunctionMap*> functions,
                     const std::string& name, const double expiration) noexcept {
-    dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<2>&>(
-        *functions->at(name))
-        .reset_expiration_time(expiration);
+    (*functions).at(name)->reset_expiration_time(expiration);
   }
 };
 

--- a/tests/Unit/Domain/FunctionsOfTime/Test_SettleToConstant.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_SettleToConstant.cpp
@@ -130,3 +130,38 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.SettleToConstant",
                          decay_time});
   }
 }
+
+// [[OutputRegex, Cannot update this FunctionOfTime.]]
+SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.SettleToConstant.BadUpdate",
+                  "[Domain][Unit]") {
+  ERROR_TEST();
+  const std::array<DataVector, 3> initial_function_value{
+      {DataVector{1, 0.0}, DataVector{1, 0.0}, DataVector{1, 0.0}}};
+  const double match_time = 10.0;
+  const double decay_time = 1.0;
+  const std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> f_of_t =
+      std::make_unique<domain::FunctionsOfTime::SettleToConstant>(
+          initial_function_value, match_time, decay_time);
+
+  const double update_time = 1.0;
+  const DataVector updated_deriv{};
+  const double next_expr_time = 2.0;
+  f_of_t->update(update_time, updated_deriv, next_expr_time);
+}
+
+// [[OutputRegex, Cannot reset expiration time of this FunctionOfTime.]]
+SPECTRE_TEST_CASE(
+    "Unit.Domain.FunctionsOfTime.SettleToConstant.BadResetExprTime",
+    "[Domain][Unit]") {
+  ERROR_TEST();
+  const std::array<DataVector, 3> initial_function_value{
+      {DataVector{1, 0.0}, DataVector{1, 0.0}, DataVector{1, 0.0}}};
+  const double match_time = 10.0;
+  const double decay_time = 1.0;
+  const std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> f_of_t =
+      std::make_unique<domain::FunctionsOfTime::SettleToConstant>(
+          initial_function_value, match_time, decay_time);
+
+  const double next_expr_time = 2.0;
+  f_of_t->reset_expiration_time(next_expr_time);
+}

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
@@ -309,11 +309,7 @@ struct MyFunctionOfTimeUpdater {
   static void apply(gsl::not_null<typename domain::Tags::FunctionsOfTime::type*>
                         functions_of_time) {
     for (auto& name_and_function_of_time : *functions_of_time) {
-      auto* function_of_time =
-          dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<2>*>(
-              name_and_function_of_time.second.get());
-      REQUIRE(function_of_time != nullptr);
-      function_of_time->reset_expiration_time(0.5 * Multiplier);
+      name_and_function_of_time.second->reset_expiration_time(0.5 * Multiplier);
     }
   }
 };

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
@@ -295,11 +295,7 @@ struct MyFunctionOfTimeUpdater {
       const gsl::not_null<typename domain::Tags::FunctionsOfTime::type*>
           functions_of_time) noexcept {
     for (auto& name_and_function_of_time : *functions_of_time) {
-      auto* function_of_time =
-          dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<2>*>(
-              name_and_function_of_time.second.get());
-      REQUIRE(function_of_time != nullptr);
-      function_of_time->reset_expiration_time(14.5 / 16.0);
+      name_and_function_of_time.second->reset_expiration_time(14.5 / 16.0);
     }
   }
 };


### PR DESCRIPTION
To avoid having to cast whenever we need to update or reset the expiration time of a FunctionOfTime, this adds `update` and
`reset_expiration_time` as virtual functions of the FunctionOfTime base class. The default of these virtual functions is to ERROR because by defualt FunctionsOfTime shouldn't be able to update.

As discussed in #3478 

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
