### PR TITLE
Fix superluminal velocities in Kastaun recovery scheme

### DIFF
--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -38,6 +38,7 @@
 #include "Evolution/DiscontinuousGalerkin/DgElementArray.hpp"
 #include "Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp"
 #include "Evolution/DiscontinuousGalerkin/Initialization/QuadratureTag.hpp"
+#include "Evolution/DiscontinuousGalerkin/Limiters/Krivodonova.hpp"
 #include "Evolution/DiscontinuousGalerkin/Limiters/LimiterActions.hpp"
 #include "Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp"
 #include "Evolution/DiscontinuousGalerkin/Limiters/Tags.hpp"

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.cpp
@@ -158,8 +158,9 @@ std::pair<double, double> FunctionOfMu<ThermodynamicDim>::root_bracket(
     const size_t max_iterations) const {
   // see text between Equations (49) and (50) and after Equation (54)
   double lower_bound = 0.0;
-  double upper_bound =
-      0.0 == h_0_ ? std::numeric_limits<double>::max() : 1.0 / h_0_;
+  // We use `1 / (h_0_ + numeric_limits<double>::min())` to avoid division by
+  // zero in a way that avoids conditionals.
+  double upper_bound = 1.0 / (h_0_ + std::numeric_limits<double>::min());
   if (r_squared_ < square(h_0_)) {
     // need to solve auxiliary function to determine mu_+ which will
     // be the upper bound for the master function bracket

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.cpp
@@ -37,7 +37,10 @@ double compute_r_bar_squared(const double mu, const double x,
 // Equations (33) and (32)
 double compute_v_0_squared(const double r_squared, const double h_0) noexcept {
   const double z_0_squared = r_squared / square(h_0);
-  return z_0_squared / (1.0 + z_0_squared);
+  static constexpr double velocity_squared_upper_bound =
+      1.0 - 4.0 * std::numeric_limits<double>::epsilon();
+  return std::min(z_0_squared / (1.0 + z_0_squared),
+                  velocity_squared_upper_bound);
 }
 
 struct Primitives {


### PR DESCRIPTION
## Proposed changes

- Avoid superluminal velocities
- Avoid a conditional
- Make using the Krivodonova limiter for GRMHD easier by including its header file in the exec

These fixes are necessary to get stable evolutions of the cylindrical blast wave problem with classical limiters.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
