### PR TITLE
Add domain::Tags::JacobianCompute to docs

### DIFF
--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -209,6 +209,7 @@ struct Jacobian : db::SimpleTag {
   using type = ::Jacobian<DataVector, Dim, SourceFrame, TargetFrame>;
 };
 
+/// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup
 /// Computes the Jacobian of the map from the `InverseJacobian<Dim, SourceFrame,
 /// TargetFrame>` tag.


### PR DESCRIPTION
Was going through the tags in the DataBox Tags doxygen group and noticed one was missing.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
