### PR TITLE
Add simple tags related to conformal metric and for CCZ4 auxiliary variables

### DIFF
--- a/src/Elliptic/Systems/Xcts/FirstOrderSystem.hpp
+++ b/src/Elliptic/Systems/Xcts/FirstOrderSystem.hpp
@@ -15,6 +15,7 @@
 #include "Elliptic/Systems/Xcts/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags/Conformal.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace Xcts {
@@ -199,8 +200,8 @@ struct FirstOrderSystem {
   // The variable-independent fields in the equations
   using background_fields = tmpl::flatten<tmpl::list<
       // Quantities for Hamiltonian constraint
-      Tags::Conformal<gr::Tags::EnergyDensity<DataVector>,
-                      ConformalMatterScale>,
+      gr::Tags::Conformal<gr::Tags::EnergyDensity<DataVector>,
+                          ConformalMatterScale>,
       gr::Tags::TraceExtrinsicCurvature<DataVector>,
       tmpl::conditional_t<ConformalGeometry == Geometry::Curved,
                           tmpl::list<Tags::InverseConformalMetric<
@@ -219,8 +220,8 @@ struct FirstOrderSystem {
           EnabledEquations == Equations::HamiltonianAndLapse or
               EnabledEquations ==
                   Equations::HamiltonianLapseAndShift,
-          tmpl::list<Tags::Conformal<gr::Tags::StressTrace<DataVector>,
-                                     ConformalMatterScale>,
+          tmpl::list<gr::Tags::Conformal<gr::Tags::StressTrace<DataVector>,
+                                         ConformalMatterScale>,
                      ::Tags::dt<gr::Tags::TraceExtrinsicCurvature<DataVector>>>,
           tmpl::list<>>,
       tmpl::conditional_t<
@@ -235,7 +236,7 @@ struct FirstOrderSystem {
           EnabledEquations ==
               Equations::HamiltonianLapseAndShift,
           tmpl::list<
-              Tags::Conformal<
+              gr::Tags::Conformal<
                   gr::Tags::MomentumDensity<3, Frame::Inertial, DataVector>,
                   ConformalMatterScale>,
               ::Tags::deriv<gr::Tags::TraceExtrinsicCurvature<DataVector>,

--- a/src/Elliptic/Systems/Xcts/FluxesAndSources.hpp
+++ b/src/Elliptic/Systems/Xcts/FluxesAndSources.hpp
@@ -11,6 +11,7 @@
 #include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags/Conformal.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -174,8 +175,8 @@ template <int ConformalMatterScale>
 struct Sources<Equations::Hamiltonian, Geometry::FlatCartesian,
                ConformalMatterScale> {
   using argument_tags = tmpl::list<
-      Tags::Conformal<gr::Tags::EnergyDensity<DataVector>,
-                      ConformalMatterScale>,
+      gr::Tags::Conformal<gr::Tags::EnergyDensity<DataVector>,
+                          ConformalMatterScale>,
       gr::Tags::TraceExtrinsicCurvature<DataVector>,
       Tags::LongitudinalShiftMinusDtConformalMetricOverLapseSquare<DataVector>>;
   static void apply(
@@ -229,9 +230,10 @@ template <int ConformalMatterScale>
 struct Sources<Equations::HamiltonianAndLapse, Geometry::FlatCartesian,
                ConformalMatterScale> {
   using argument_tags = tmpl::list<
-      Tags::Conformal<gr::Tags::EnergyDensity<DataVector>,
-                      ConformalMatterScale>,
-      Tags::Conformal<gr::Tags::StressTrace<DataVector>, ConformalMatterScale>,
+      gr::Tags::Conformal<gr::Tags::EnergyDensity<DataVector>,
+                          ConformalMatterScale>,
+      gr::Tags::Conformal<gr::Tags::StressTrace<DataVector>,
+                          ConformalMatterScale>,
       gr::Tags::TraceExtrinsicCurvature<DataVector>,
       ::Tags::dt<gr::Tags::TraceExtrinsicCurvature<DataVector>>,
       Tags::LongitudinalShiftMinusDtConformalMetricSquare<DataVector>,
@@ -312,11 +314,13 @@ template <int ConformalMatterScale>
 struct Sources<Equations::HamiltonianLapseAndShift, Geometry::FlatCartesian,
                ConformalMatterScale> {
   using argument_tags = tmpl::list<
-      Tags::Conformal<gr::Tags::EnergyDensity<DataVector>,
-                      ConformalMatterScale>,
-      Tags::Conformal<gr::Tags::StressTrace<DataVector>, ConformalMatterScale>,
-      Tags::Conformal<gr::Tags::MomentumDensity<3, Frame::Inertial, DataVector>,
-                      ConformalMatterScale>,
+      gr::Tags::Conformal<gr::Tags::EnergyDensity<DataVector>,
+                          ConformalMatterScale>,
+      gr::Tags::Conformal<gr::Tags::StressTrace<DataVector>,
+                          ConformalMatterScale>,
+      gr::Tags::Conformal<
+          gr::Tags::MomentumDensity<3, Frame::Inertial, DataVector>,
+          ConformalMatterScale>,
       gr::Tags::TraceExtrinsicCurvature<DataVector>,
       ::Tags::dt<gr::Tags::TraceExtrinsicCurvature<DataVector>>,
       ::Tags::deriv<gr::Tags::TraceExtrinsicCurvature<DataVector>,

--- a/src/Elliptic/Systems/Xcts/Tags.hpp
+++ b/src/Elliptic/Systems/Xcts/Tags.hpp
@@ -8,6 +8,7 @@
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags/Conformal.hpp"
 
 namespace Xcts {
 /// Tags related to the XCTS equations
@@ -23,17 +24,6 @@ struct ConformalFactor : db::SimpleTag {
 };
 
 /*!
- * \brief The quantity `Tag` scaled by the `Xcts::Tags::ConformalFactor` to the
- * given `Power`
- */
-template <typename Tag, int Power>
-struct Conformal : db::PrefixTag, db::SimpleTag {
-  using type = typename Tag::type;
-  using tag = Tag;
-  static constexpr int conformal_factor_power = Power;
-};
-
-/*!
  * \brief The conformally scaled spatial metric
  * \f$\bar{\gamma}_{ij}=\psi^{-4}\gamma_{ij}\f$, where \f$\psi\f$ is the
  * `Xcts::Tags::ConformalFactor` and \f$\gamma_{ij}\f$ is the
@@ -41,7 +31,7 @@ struct Conformal : db::PrefixTag, db::SimpleTag {
  */
 template <typename DataType, size_t Dim, typename Frame>
 using ConformalMetric =
-    Conformal<gr::Tags::SpatialMetric<Dim, Frame, DataType>, -4>;
+    gr::Tags::Conformal<gr::Tags::SpatialMetric<Dim, Frame, DataType>, -4>;
 
 /*!
  * \brief The conformally scaled inverse spatial metric
@@ -51,7 +41,8 @@ using ConformalMetric =
  */
 template <typename DataType, size_t Dim, typename Frame>
 using InverseConformalMetric =
-    Conformal<gr::Tags::InverseSpatialMetric<Dim, Frame, DataType>, 4>;
+    gr::Tags::Conformal<gr::Tags::InverseSpatialMetric<Dim, Frame, DataType>,
+                        4>;
 
 /*!
  * \brief The product of lapse \f$\alpha(x)\f$ and conformal factor

--- a/src/Evolution/Systems/CMakeLists.txt
+++ b/src/Evolution/Systems/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 add_subdirectory(Burgers)
 add_subdirectory(Cce)
+add_subdirectory(Ccz4)
 add_subdirectory(CurvedScalarWave)
 add_subdirectory(GeneralizedHarmonic)
 add_subdirectory(GrMhd)

--- a/src/Evolution/Systems/Ccz4/CMakeLists.txt
+++ b/src/Evolution/Systems/Ccz4/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Tags.hpp
+  TagsDeclarations.hpp
+  )

--- a/src/Evolution/Systems/Ccz4/Tags.hpp
+++ b/src/Evolution/Systems/Ccz4/Tags.hpp
@@ -49,6 +49,68 @@ template <size_t Dim, typename Frame, typename DataType>
 using InverseConformalMetric =
     gr::Tags::Conformal<gr::Tags::InverseSpatialMetric<Dim, Frame, DataType>,
                         -2>;
+
+/*!
+ * \brief The natural log of the lapse
+ */
+template <typename DataType>
+struct LogLapse : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+/*!
+ * \brief Auxiliary variable which is analytically the spatial derivative of the
+ * natural log of the lapse
+ *
+ * \details If \f$ \alpha \f$ is the lapse, then we define
+ * \f$A_i = \partial_i ln(\alpha) = \frac{\partial_i \alpha}{\alpha}\f$.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct FieldA : db::SimpleTag {
+  using type = tnsr::i<DataType, Dim, Frame>;
+};
+
+/*!
+ * \brief Auxiliary variable which is analytically the spatial derivative of the
+ * shift
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct FieldB : db::SimpleTag {
+  using type = tnsr::iJ<DataType, Dim, Frame>;
+};
+
+/*!
+ * \brief Auxiliary variable which is analytically half the spatial derivative
+ * of the conformal spatial metric
+ *
+ * \details If \f$\bar{\gamma}_{ij}\f$ is the conformal spatial metric, then we
+ * define
+ * \f$D_{kij} = \frac{1}{2} \partial_k \bar{\gamma}_{ij}\f$.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct FieldD : db::SimpleTag {
+  using type = tnsr::ijj<DataType, Dim, Frame>;
+};
+
+/*!
+ * \brief The natural log of the conformal factor
+ */
+template <typename DataType>
+struct LogConformalFactor : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+/*!
+ * \brief Auxiliary variable which is analytically the spatial derivative of the
+ * natural log of the conformal factor
+ *
+ * \details If \f$\phi\f$ is the conformal factor, then we define
+ * \f$P_i = \partial_i ln(\phi) = \frac{\partial_i \phi}{\phi}\f$.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct FieldP : db::SimpleTag {
+  using type = tnsr::i<DataType, Dim, Frame>;
+};
 }  // namespace Tags
 
 namespace OptionTags {

--- a/src/Evolution/Systems/Ccz4/Tags.hpp
+++ b/src/Evolution/Systems/Ccz4/Tags.hpp
@@ -1,0 +1,66 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/Ccz4/TagsDeclarations.hpp"
+#include "Evolution/Tags.hpp"
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags/Conformal.hpp"
+
+namespace Ccz4 {
+namespace Tags {
+/*!
+ * \brief The conformal factor that rescales the spatial metric
+ *
+ * \details If \f$\gamma_{ij}\f$ is the spatial metric, then we define
+ * \f$\phi = (det(\gamma_{ij}))^{-1/6}\f$.
+ */
+template <typename DataType>
+struct ConformalFactor : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+/*!
+ * \brief The conformally scaled spatial metric
+ *
+ * \details If \f$\phi\f$ is the conformal factor and \f$\gamma_{ij}\f$ is the
+ * spatial metric, then we define
+ * \f$\bar{\gamma}_{ij} = \phi^2 \gamma_{ij}\f$.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+using ConformalMetric =
+    gr::Tags::Conformal<gr::Tags::SpatialMetric<Dim, Frame, DataType>, 2>;
+
+/*!
+ * \brief The conformally scaled inverse spatial metric
+ *
+ * \details If \f$\phi\f$ is the conformal factor and \f$\gamma^{ij}\f$ is the
+ * inverse spatial metric, then we define
+ * \f$\bar{\gamma}^{ij} = \phi^{-2} \gamma^{ij}\f$.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+using InverseConformalMetric =
+    gr::Tags::Conformal<gr::Tags::InverseSpatialMetric<Dim, Frame, DataType>,
+                        -2>;
+}  // namespace Tags
+
+namespace OptionTags {
+/*!
+ * \ingroup OptionGroupsGroup
+ * Groups option tags related to the Ccz4 evolution system.
+ */
+struct Group {
+  static std::string name() noexcept { return "Ccz4"; }
+  static constexpr Options::String help{
+      "Options for the CCZ4 evolution system"};
+  using group = evolution::OptionTags::SystemGroup;
+};
+}  // namespace OptionTags
+}  // namespace Ccz4

--- a/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
@@ -10,11 +10,26 @@
 class DataVector;
 
 namespace Ccz4 {
-
 /// \brief Tags for the CCZ4 formulation of Einstein equations
 namespace Tags {
 template <typename DataType = DataVector>
 struct ConformalFactor;
+template <typename DataType = DataVector>
+struct LogLapse;
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
+struct FieldA;
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
+struct FieldB;
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
+struct FieldD;
+template <typename DataType = DataVector>
+struct LogConformalFactor;
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
+struct FieldP;
 }  // namespace Tags
 
 /// \brief Input option tags for the generalized harmonic evolution system

--- a/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
@@ -1,0 +1,24 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/IndexType.hpp"
+
+class DataVector;
+
+namespace Ccz4 {
+
+/// \brief Tags for the CCZ4 formulation of Einstein equations
+namespace Tags {
+template <typename DataType = DataVector>
+struct ConformalFactor;
+}  // namespace Tags
+
+/// \brief Input option tags for the generalized harmonic evolution system
+namespace OptionTags {
+struct Group;
+}  // namespace OptionTags
+}  // namespace Ccz4

--- a/src/PointwiseFunctions/AnalyticData/Xcts/Binary.hpp
+++ b/src/PointwiseFunctions/AnalyticData/Xcts/Binary.hpp
@@ -23,6 +23,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/AnalyticSolution.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/Flatness.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags/Conformal.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -55,10 +56,10 @@ using BinaryVariablesCache = cached_temp_buffer_from_typelist<
                       tmpl::size_t<3>, Frame::Inertial>,
         Tags::LongitudinalShiftBackgroundMinusDtConformalMetric<
             DataType, 3, Frame::Inertial>,
-        Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 0>,
-        Tags::Conformal<gr::Tags::StressTrace<DataType>, 0>,
-        Tags::Conformal<gr::Tags::MomentumDensity<3, Frame::Inertial, DataType>,
-                        0>,
+        gr::Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 0>,
+        gr::Tags::Conformal<gr::Tags::StressTrace<DataType>, 0>,
+        gr::Tags::Conformal<
+            gr::Tags::MomentumDensity<3, Frame::Inertial, DataType>, 0>,
         // For initial guesses
         Tags::ConformalFactor<DataType>,
         Tags::LapseTimesConformalFactor<DataType>,
@@ -77,10 +78,10 @@ struct BinaryVariables
                     tmpl::size_t<Dim>, Frame::Inertial>,
       gr::Tags::TraceExtrinsicCurvature<DataType>,
       ::Tags::dt<gr::Tags::TraceExtrinsicCurvature<DataType>>,
-      Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 0>,
-      Tags::Conformal<gr::Tags::StressTrace<DataType>, 0>,
-      Tags::Conformal<gr::Tags::MomentumDensity<Dim, Frame::Inertial, DataType>,
-                      0>,
+      gr::Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 0>,
+      gr::Tags::Conformal<gr::Tags::StressTrace<DataType>, 0>,
+      gr::Tags::Conformal<
+          gr::Tags::MomentumDensity<Dim, Frame::Inertial, DataType>, 0>,
       Tags::ConformalFactor<DataType>,
       Tags::LapseTimesConformalFactor<DataType>,
       Tags::ShiftExcess<DataType, Dim, Frame::Inertial>>;

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/Flatness.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/Flatness.hpp
@@ -15,6 +15,7 @@
 #include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/AnalyticSolution.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags/Conformal.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -93,18 +94,18 @@ class Flatness : public AnalyticSolution<Registrars> {
         ::Tags::div<Tags::LongitudinalShiftBackgroundMinusDtConformalMetric<
             DataVector, 3, Frame::Inertial>>,
         Tags::ShiftDotDerivExtrinsicCurvatureTrace<DataVector>,
-        Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 0>,
-        Tags::Conformal<gr::Tags::StressTrace<DataType>, 0>,
-        Tags::Conformal<gr::Tags::MomentumDensity<3, Frame::Inertial, DataType>,
-                        0>,
-        Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 6>,
-        Tags::Conformal<gr::Tags::StressTrace<DataType>, 6>,
-        Tags::Conformal<gr::Tags::MomentumDensity<3, Frame::Inertial, DataType>,
-                        6>,
-        Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 8>,
-        Tags::Conformal<gr::Tags::StressTrace<DataType>, 8>,
-        Tags::Conformal<gr::Tags::MomentumDensity<3, Frame::Inertial, DataType>,
-                        8>,
+        gr::Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 0>,
+        gr::Tags::Conformal<gr::Tags::StressTrace<DataType>, 0>,
+        gr::Tags::Conformal<
+            gr::Tags::MomentumDensity<3, Frame::Inertial, DataType>, 0>,
+        gr::Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 6>,
+        gr::Tags::Conformal<gr::Tags::StressTrace<DataType>, 6>,
+        gr::Tags::Conformal<
+            gr::Tags::MomentumDensity<3, Frame::Inertial, DataType>, 6>,
+        gr::Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 8>,
+        gr::Tags::Conformal<gr::Tags::StressTrace<DataType>, 8>,
+        gr::Tags::Conformal<
+            gr::Tags::MomentumDensity<3, Frame::Inertial, DataType>, 8>,
         ::Tags::FixedSource<Tags::ConformalFactor<DataType>>,
         ::Tags::FixedSource<Tags::LapseTimesConformalFactor<DataType>>,
         ::Tags::FixedSource<Tags::ShiftExcess<DataType, 3, Frame::Inertial>>>;

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/Kerr.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/Kerr.cpp
@@ -16,6 +16,7 @@
 #include "PointwiseFunctions/Elasticity/Strain.hpp"
 #include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags/Conformal.hpp"
 #include "PointwiseFunctions/Xcts/LongitudinalOperator.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
@@ -220,7 +221,7 @@ template <typename DataType>
 void KerrVariables<DataType>::operator()(
     const gsl::not_null<Scalar<DataType>*> energy_density,
     const gsl::not_null<Cache*> /*cache*/,
-    Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 0> /*meta*/)
+    gr::Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 0> /*meta*/)
     const noexcept {
   std::fill(energy_density->begin(), energy_density->end(), 0.);
 }
@@ -229,7 +230,7 @@ template <typename DataType>
 void KerrVariables<DataType>::operator()(
     const gsl::not_null<Scalar<DataType>*> stress_trace,
     const gsl::not_null<Cache*> /*cache*/,
-    Tags::Conformal<gr::Tags::StressTrace<DataType>, 0> /*meta*/)
+    gr::Tags::Conformal<gr::Tags::StressTrace<DataType>, 0> /*meta*/)
     const noexcept {
   std::fill(stress_trace->begin(), stress_trace->end(), 0.);
 }
@@ -238,8 +239,9 @@ template <typename DataType>
 void KerrVariables<DataType>::operator()(
     const gsl::not_null<tnsr::I<DataType, Dim>*> momentum_density,
     const gsl::not_null<Cache*> /*cache*/,
-    Tags::Conformal<gr::Tags::MomentumDensity<Dim, Frame::Inertial, DataType>,
-                    0> /*meta*/) const noexcept {
+    gr::Tags::Conformal<
+        gr::Tags::MomentumDensity<Dim, Frame::Inertial, DataType>, 0> /*meta*/)
+    const noexcept {
   std::fill(momentum_density->begin(), momentum_density->end(), 0.);
 }
 

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/Kerr.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/Kerr.hpp
@@ -18,6 +18,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/AnalyticSolution.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/CommonVariables.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags/Conformal.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -49,10 +50,10 @@ using KerrVariablesCache = cached_temp_buffer_from_typelist<
             DataType, 3, Frame::Inertial>,
         Tags::ShiftExcess<DataType, 3, Frame::Inertial>,
         Tags::ShiftStrain<DataType, 3, Frame::Inertial>,
-        Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 0>,
-        Tags::Conformal<gr::Tags::StressTrace<DataType>, 0>,
-        Tags::Conformal<gr::Tags::MomentumDensity<3, Frame::Inertial, DataType>,
-                        0>>>;
+        gr::Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 0>,
+        gr::Tags::Conformal<gr::Tags::StressTrace<DataType>, 0>,
+        gr::Tags::Conformal<
+            gr::Tags::MomentumDensity<3, Frame::Inertial, DataType>, 0>>>;
 
 template <typename DataType>
 struct KerrVariables : CommonVariables<DataType, KerrVariablesCache<DataType>> {
@@ -129,16 +130,16 @@ struct KerrVariables : CommonVariables<DataType, KerrVariablesCache<DataType>> {
       const noexcept;
   void operator()(gsl::not_null<Scalar<DataType>*> energy_density,
                   gsl::not_null<Cache*> cache,
-                  Tags::Conformal<gr::Tags::EnergyDensity<DataType>,
-                                  0> /*meta*/) const noexcept;
+                  gr::Tags::Conformal<gr::Tags::EnergyDensity<DataType>,
+                                      0> /*meta*/) const noexcept;
   void operator()(gsl::not_null<Scalar<DataType>*> stress_trace,
                   gsl::not_null<Cache*> cache,
-                  Tags::Conformal<gr::Tags::StressTrace<DataType>, 0> /*meta*/)
-      const noexcept;
-  void operator()(
-      gsl::not_null<tnsr::I<DataType, Dim>*> momentum_density,
-      gsl::not_null<Cache*> cache,
-      Tags::Conformal<gr::Tags::MomentumDensity<Dim, Frame::Inertial, DataType>,
+                  gr::Tags::Conformal<gr::Tags::StressTrace<DataType>,
+                                      0> /*meta*/) const noexcept;
+  void operator()(gsl::not_null<tnsr::I<DataType, Dim>*> momentum_density,
+                  gsl::not_null<Cache*> cache,
+                  gr::Tags::Conformal<
+                      gr::Tags::MomentumDensity<Dim, Frame::Inertial, DataType>,
                       0> /*meta*/) const noexcept;
 };
 

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.cpp
@@ -18,6 +18,7 @@
 #include "Options/ParseOptions.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/CommonVariables.tpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags/Conformal.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
@@ -248,8 +249,8 @@ template <typename DataType>
 void SchwarzschildVariables<DataType>::operator()(
     const gsl::not_null<Scalar<DataType>*> energy_density,
     const gsl::not_null<Cache*> /*cache*/,
-    Tags::Conformal<gr::Tags::EnergyDensity<DataType>,
-                    ConformalMatterScale> /*meta*/) const noexcept {
+    gr::Tags::Conformal<gr::Tags::EnergyDensity<DataType>,
+                        ConformalMatterScale> /*meta*/) const noexcept {
   std::fill(energy_density->begin(), energy_density->end(), 0.);
 }
 
@@ -257,8 +258,8 @@ template <typename DataType>
 void SchwarzschildVariables<DataType>::operator()(
     const gsl::not_null<Scalar<DataType>*> stress_trace,
     const gsl::not_null<Cache*> /*cache*/,
-    Tags::Conformal<gr::Tags::StressTrace<DataType>,
-                    ConformalMatterScale> /*meta*/) const noexcept {
+    gr::Tags::Conformal<gr::Tags::StressTrace<DataType>,
+                        ConformalMatterScale> /*meta*/) const noexcept {
   std::fill(stress_trace->begin(), stress_trace->end(), 0.);
 }
 
@@ -266,8 +267,8 @@ template <typename DataType>
 void SchwarzschildVariables<DataType>::operator()(
     const gsl::not_null<tnsr::I<DataType, 3>*> momentum_density,
     const gsl::not_null<Cache*> /*cache*/,
-    Tags::Conformal<gr::Tags::MomentumDensity<3, Frame::Inertial, DataType>,
-                    ConformalMatterScale> /*meta*/) const noexcept {
+    gr::Tags::Conformal<gr::Tags::MomentumDensity<3, Frame::Inertial, DataType>,
+                        ConformalMatterScale> /*meta*/) const noexcept {
   std::fill(momentum_density->begin(), momentum_density->end(), 0.);
 }
 

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.hpp
@@ -18,6 +18,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/AnalyticSolution.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/CommonVariables.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags/Conformal.hpp"
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -165,10 +166,10 @@ using SchwarzschildVariablesCache = cached_temp_buffer_from_typelist<
             DataType, 3, Frame::Inertial>,
         Tags::ShiftExcess<DataType, 3, Frame::Inertial>,
         Tags::ShiftStrain<DataType, 3, Frame::Inertial>,
-        Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 0>,
-        Tags::Conformal<gr::Tags::StressTrace<DataType>, 0>,
-        Tags::Conformal<gr::Tags::MomentumDensity<3, Frame::Inertial, DataType>,
-                        0>>>;
+        gr::Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 0>,
+        gr::Tags::Conformal<gr::Tags::StressTrace<DataType>, 0>,
+        gr::Tags::Conformal<
+            gr::Tags::MomentumDensity<3, Frame::Inertial, DataType>, 0>>>;
 
 template <typename DataType>
 struct SchwarzschildVariables
@@ -252,17 +253,17 @@ struct SchwarzschildVariables
   void operator()(
       gsl::not_null<Scalar<DataType>*> energy_density,
       gsl::not_null<Cache*> cache,
-      Tags::Conformal<gr::Tags::EnergyDensity<DataType>,
-                      ConformalMatterScale> /*meta*/) const noexcept;
+      gr::Tags::Conformal<gr::Tags::EnergyDensity<DataType>,
+                          ConformalMatterScale> /*meta*/) const noexcept;
   void operator()(
       gsl::not_null<Scalar<DataType>*> stress_trace,
       gsl::not_null<Cache*> cache,
-      Tags::Conformal<gr::Tags::StressTrace<DataType>,
-                      ConformalMatterScale> /*meta*/) const noexcept;
-  void operator()(
-      gsl::not_null<tnsr::I<DataType, 3>*> momentum_density,
-      gsl::not_null<Cache*> cache,
-      Tags::Conformal<gr::Tags::MomentumDensity<3, Frame::Inertial, DataType>,
+      gr::Tags::Conformal<gr::Tags::StressTrace<DataType>,
+                          ConformalMatterScale> /*meta*/) const noexcept;
+  void operator()(gsl::not_null<tnsr::I<DataType, 3>*> momentum_density,
+                  gsl::not_null<Cache*> cache,
+                  gr::Tags::Conformal<
+                      gr::Tags::MomentumDensity<3, Frame::Inertial, DataType>,
                       ConformalMatterScale> /*meta*/) const noexcept;
 };
 

--- a/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -64,3 +64,4 @@ target_link_libraries(
   )
 
 add_subdirectory(GeneralizedHarmonic)
+add_subdirectory(Tags)

--- a/src/PointwiseFunctions/GeneralRelativity/Tags/CMakeLists.txt
+++ b/src/PointwiseFunctions/GeneralRelativity/Tags/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Conformal.hpp
+  )

--- a/src/PointwiseFunctions/GeneralRelativity/Tags/Conformal.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Tags/Conformal.hpp
@@ -1,0 +1,20 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/Tag.hpp"
+
+namespace gr {
+namespace Tags {
+/*!
+ * \brief The quantity `Tag` scaled by a conformal factor to the given `Power`
+ */
+template <typename Tag, int Power>
+struct Conformal : db::PrefixTag, db::SimpleTag {
+  using type = typename Tag::type;
+  using tag = Tag;
+  static constexpr int conformal_factor_power = Power;
+};
+}  // namespace Tags
+}  // namespace gr

--- a/tests/Unit/Elliptic/Systems/Xcts/Test_Tags.cpp
+++ b/tests/Unit/Elliptic/Systems/Xcts/Test_Tags.cpp
@@ -8,6 +8,7 @@
 #include "Elliptic/Systems/Xcts/Tags.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags/Conformal.hpp"
 
 struct DataVector;
 namespace Frame {
@@ -24,7 +25,7 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Systems.Xcts.Tags", "[Unit][Elliptic]") {
   TestHelpers::db::test_simple_tag<
       Tags::ShiftStrain<DataVector, 3, Frame::Inertial>>("ShiftStrain");
   TestHelpers::db::test_prefix_tag<
-      Tags::Conformal<gr::Tags::EnergyDensity<DataVector>, 2>>(
+      gr::Tags::Conformal<gr::Tags::EnergyDensity<DataVector>, 2>>(
       "Conformal(EnergyDensity)");
   TestHelpers::db::test_simple_tag<
       Tags::ConformalMetric<DataVector, 3, Frame::Inertial>>(

--- a/tests/Unit/Evolution/Systems/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 add_subdirectory(Burgers)
 add_subdirectory(Cce)
+add_subdirectory(Ccz4)
 add_subdirectory(CurvedScalarWave)
 add_subdirectory(GeneralizedHarmonic)
 add_subdirectory(GrMhd)

--- a/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_Ccz4")
+
+set(LIBRARY_SOURCES
+  Test_Tags.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "Evolution/Systems/Ccz4/"
+  "${LIBRARY_SOURCES}"
+  "DataBoxTestHelpers;DataStructures"
+  )

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
@@ -1,0 +1,36 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataVector.hpp"
+#include "Evolution/Systems/Ccz4/Tags.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+
+namespace {
+struct ArbitraryFrame;
+}  // namespace
+
+template <size_t Dim, typename Frame, typename DataType>
+void test_simple_tags() {
+  TestHelpers::db::test_simple_tag<Ccz4::Tags::ConformalFactor<DataType>>(
+      "ConformalFactor");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::ConformalMetric<Dim, Frame, DataType>>(
+      "Conformal(SpatialMetric)");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::InverseConformalMetric<Dim, Frame, DataType>>(
+      "Conformal(InverseSpatialMetric)");
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.Tags", "[Unit][Evolution]") {
+  test_simple_tags<1, ArbitraryFrame, double>();
+  test_simple_tags<1, ArbitraryFrame, DataVector>();
+  test_simple_tags<2, ArbitraryFrame, double>();
+  test_simple_tags<2, ArbitraryFrame, DataVector>();
+  test_simple_tags<3, ArbitraryFrame, double>();
+  test_simple_tags<3, ArbitraryFrame, DataVector>();
+}

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
@@ -24,6 +24,17 @@ void test_simple_tags() {
   TestHelpers::db::test_simple_tag<
       Ccz4::Tags::InverseConformalMetric<Dim, Frame, DataType>>(
       "Conformal(InverseSpatialMetric)");
+  TestHelpers::db::test_simple_tag<Ccz4::Tags::LogLapse<DataType>>("LogLapse");
+  TestHelpers::db::test_simple_tag<Ccz4::Tags::FieldA<Dim, Frame, DataType>>(
+      "FieldA");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::FieldB<Dim, Frame, DataType>>("FieldB");
+  TestHelpers::db::test_simple_tag<Ccz4::Tags::FieldD<Dim, Frame, DataType>>(
+      "FieldD");
+  TestHelpers::db::test_simple_tag<Ccz4::Tags::LogConformalFactor<DataType>>(
+      "LogConformalFactor");
+  TestHelpers::db::test_simple_tag<Ccz4::Tags::FieldP<Dim, Frame, DataType>>(
+      "FieldP");
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.Tags", "[Unit][Evolution]") {

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_Schwarzschild.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_Schwarzschild.cpp
@@ -18,6 +18,7 @@
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/PointwiseFunctions/AnalyticSolutions/Xcts/VerifySolution.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags/Conformal.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -53,10 +54,10 @@ using background_tags = tmpl::list<
     Tags::LongitudinalShiftBackgroundMinusDtConformalMetric<DataVector, 3,
                                                             Frame::Inertial>>;
 using matter_source_tags = tmpl::list<
-    Tags::Conformal<gr::Tags::EnergyDensity<DataVector>, 0>,
-    Tags::Conformal<gr::Tags::StressTrace<DataVector>, 0>,
-    Tags::Conformal<gr::Tags::MomentumDensity<3, Frame::Inertial, DataVector>,
-                    0>>;
+    gr::Tags::Conformal<gr::Tags::EnergyDensity<DataVector>, 0>,
+    gr::Tags::Conformal<gr::Tags::StressTrace<DataVector>, 0>,
+    gr::Tags::Conformal<
+        gr::Tags::MomentumDensity<3, Frame::Inertial, DataVector>, 0>>;
 using gr_tags = tmpl::list<gr::Tags::Lapse<DataVector>,
                            gr::Tags::Shift<3, Frame::Inertial, DataVector>>;
 using derived_tags = tmpl::list<

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Tags.cpp
@@ -7,10 +7,15 @@
 
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags/Conformal.hpp"
 
 namespace {
 struct ArbitraryFrame;
 struct ArbitraryType;
+
+struct Tag : db::SimpleTag {
+  using type = int;
+};
 }  // namespace
 
 template <size_t Dim, typename Frame, typename Type>
@@ -83,4 +88,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.Tags",
   test_simple_tags<1, ArbitraryFrame, ArbitraryType>();
   test_simple_tags<2, ArbitraryFrame, ArbitraryType>();
   test_simple_tags<3, ArbitraryFrame, ArbitraryType>();
+
+  TestHelpers::db::test_prefix_tag<gr::Tags::Conformal<Tag, -3>>(
+      "Conformal(Tag)");
 }


### PR DESCRIPTION
## Proposed changes

As part of implementing the first order CCZ4 system, this PR adds simple tags for:
- spatial conformal factor
- conformal spatial metric
- inverse conformal spatial metric
- CCZ4 auxiliary variables `A_i`, `B_k{}^{i}`, `D_{kij}`, and `P_i` and terms in their definitions: the log of the lapse, the derivative of the shift, and the log of the conformal factor

See page 3 of this [CCZ4 paper](https://arxiv.org/pdf/1707.09910.pdf).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
