### PR TITLE
Use linear interpolation for subcell

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/IrregularInterpolant.cpp
+++ b/src/NumericalAlgorithms/Interpolation/IrregularInterpolant.cpp
@@ -3,15 +3,44 @@
 
 #include "IrregularInterpolant.hpp"
 
+#include <algorithm>
 #include <array>
+#include <iterator>
+#include <vector>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 // IWYU pragma: no_forward_declare Tensor
 
 namespace {
+
+// Just linear for now, can be extended to higher order...
+// Future optimization: it might be more efficient to use Blaze's sparse
+// matrices since the interpolation matrix is mostly zeros
+std::vector<double> fd_stencil(const DataVector& xi_source,
+                               const double xi_target) noexcept {
+  ASSERT(std::is_sorted(std::begin(xi_source), std::end(xi_source)),
+         "xi_source = " << xi_source);
+  auto xi_u =
+      std::upper_bound(std::begin(xi_source), std::end(xi_source), xi_target);
+  if (std::end(xi_source) == xi_u) {
+    std::advance(xi_u, -1);
+  }
+  if (std::begin(xi_source) == xi_u) {
+    std::advance(xi_u, 1);
+  }
+  const auto xi_l = std::prev(xi_u);
+  auto index = std::distance(std::begin(xi_source), xi_l);
+  std::vector<double> result(xi_source.size(), 0.0);
+  const auto result_l = std::next(std::begin(result), index);
+  const auto result_u = std::next(result_l, 1);
+  *result_l = (*xi_u - xi_target) / (*xi_u - *xi_l);
+  *result_u = (xi_target - *xi_l) / (*xi_u - *xi_l);
+  return result;
+}
 
 template <size_t Dim>
 Matrix interpolation_matrix(
@@ -22,8 +51,24 @@ template <>
 Matrix interpolation_matrix(
     const Mesh<1>& mesh,
     const tnsr::I<DataVector, 1, Frame::Logical>& points) noexcept {
-  // For 1d interpolation matrix, simply return the legendre-gauss-lobatto
-  // matrix.
+  if (mesh.basis()[0] == Spectral::Basis::FiniteDifference) {
+    auto source_xi = logical_coordinates(mesh);
+    const auto number_of_source_points = mesh.number_of_grid_points();
+    const DataVector xi_source(get<0>(source_xi).data(),
+                               number_of_source_points);
+    const auto number_of_target_points = get<0>(points).size();
+    Matrix result(number_of_target_points, mesh.number_of_grid_points());
+    for (size_t p = 0; p < number_of_target_points; ++p) {
+      const double xi_target = get<0>(points)[p];
+      const auto stencil = fd_stencil(xi_source, xi_target);
+      for (size_t i = 0; i < number_of_source_points; ++i) {
+        result(p, i) = stencil[i];
+      }
+    }
+    return result;
+  }
+
+  // Not FD, so use spectral interpolation
   return Spectral::interpolation_matrix(mesh, get<0>(points));
 }
 
@@ -31,16 +76,47 @@ template <>
 Matrix interpolation_matrix(
     const Mesh<2>& mesh,
     const tnsr::I<DataVector, 2, Frame::Logical>& points) noexcept {
+  const auto number_of_target_points = get<0>(points).size();
+  Matrix result(number_of_target_points, mesh.number_of_grid_points());
+
+  if (mesh.basis()[0] == Spectral::Basis::FiniteDifference) {
+    ASSERT(mesh.basis()[1] == Spectral::Basis::FiniteDifference,
+           "Mixed FD and DG bases are not supported. Mesh = " << mesh);
+    auto source_xi = logical_coordinates(mesh);
+    DataVector xi_source{get<0>(source_xi).data(), mesh.extents(0)};
+    DataVector eta_source;
+    if (mesh.extents(1) == mesh.extents(0)) {
+      eta_source.set_data_ref(&xi_source);
+    } else {
+      eta_source.destructive_resize(mesh.extents(1));
+      for (size_t j = 0; j < mesh.extents(1); ++j) {
+        eta_source[j] = get<1>(source_xi)[j * mesh.extents(0)];
+      }
+    }
+    for (size_t p = 0; p < number_of_target_points; ++p) {
+      const double xi_target = get<0>(points)[p];
+      const double eta_target = get<1>(points)[p];
+      const auto xi_stencil = fd_stencil(xi_source, xi_target);
+      const auto eta_stencil = fd_stencil(eta_source, eta_target);
+      for (size_t j = 0, s = 0; j < mesh.extents(1); ++j) {
+        for (size_t i = 0; i < mesh.extents(0); ++i) {
+          result(p, s) = xi_stencil[i] * eta_stencil[j];
+          ++s;
+        }
+      }
+    }
+    return result;
+  }
+
+  // Not FD, so use spectral interpolation
   const std::array<Matrix, 2> matrices{
       {Spectral::interpolation_matrix(mesh.slice_through(0), get<0>(points)),
        Spectral::interpolation_matrix(mesh.slice_through(1), get<1>(points))}};
 
-  const auto number_of_points = get<0>(points).size();
-  Matrix result(number_of_points, mesh.number_of_grid_points());
   // First dimension of DataVector varies fastest.
   for (size_t j = 0, s = 0; j < mesh.extents(1); ++j) {
     for (size_t i = 0; i < mesh.extents(0); ++i) {
-      for (size_t p = 0; p < number_of_points; ++p) {
+      for (size_t p = 0; p < number_of_target_points; ++p) {
         result(p, s) = matrices[0](p, i) * matrices[1](p, j);
       }
       ++s;
@@ -53,18 +129,66 @@ template <>
 Matrix interpolation_matrix(
     const Mesh<3>& mesh,
     const tnsr::I<DataVector, 3, Frame::Logical>& points) noexcept {
+  const auto number_of_target_points = get<0>(points).size();
+  Matrix result(number_of_target_points, mesh.number_of_grid_points());
+
+  if (mesh.basis()[0] == Spectral::Basis::FiniteDifference) {
+    ASSERT(mesh.basis()[1] == Spectral::Basis::FiniteDifference and
+               mesh.basis()[2] == Spectral::Basis::FiniteDifference,
+           "Mixed FD and DG bases are not supported. Mesh = " << mesh);
+    auto source_xi = logical_coordinates(mesh);
+    DataVector xi_source{get<0>(source_xi).data(), mesh.extents(0)};
+    DataVector eta_source;
+    if (mesh.extents(1) == mesh.extents(0)) {
+      eta_source.set_data_ref(&xi_source);
+    } else {
+      eta_source.destructive_resize(mesh.extents(1));
+      for (size_t j = 0; j < mesh.extents(1); ++j) {
+        eta_source[j] = get<1>(source_xi)[j * mesh.extents(0)];
+      }
+    }
+    DataVector zeta_source;
+    if (mesh.extents(2) == mesh.extents(0)) {
+      zeta_source.set_data_ref(&xi_source);
+    } else if (mesh.extents(2) == mesh.extents(1)) {
+      zeta_source.set_data_ref(&eta_source);
+    } else {
+      zeta_source.destructive_resize(mesh.extents(2));
+      for (size_t k = 0; k < mesh.extents(2); ++k) {
+        zeta_source[k] =
+            get<2>(source_xi)[k * mesh.extents(0) * mesh.extents(1)];
+      }
+    }
+    for (size_t p = 0; p < number_of_target_points; ++p) {
+      const double xi_target = get<0>(points)[p];
+      const double eta_target = get<1>(points)[p];
+      const double zeta_target = get<2>(points)[p];
+      const auto xi_stencil = fd_stencil(xi_source, xi_target);
+      const auto eta_stencil = fd_stencil(eta_source, eta_target);
+      const auto zeta_stencil = fd_stencil(zeta_source, zeta_target);
+      for (size_t k = 0, s = 0; k < mesh.extents(2); ++k) {
+        for (size_t j = 0; j < mesh.extents(1); ++j) {
+          for (size_t i = 0; i < mesh.extents(0); ++i) {
+            result(p, s) = xi_stencil[i] * eta_stencil[j] * zeta_stencil[k];
+            ++s;
+          }
+        }
+      }
+    }
+    return result;
+  }
+
+  // Not FD, so use spectral interpolation
   const std::array<Matrix, 3> matrices{
       {Spectral::interpolation_matrix(mesh.slice_through(0), get<0>(points)),
        Spectral::interpolation_matrix(mesh.slice_through(1), get<1>(points)),
        Spectral::interpolation_matrix(mesh.slice_through(2), get<2>(points))}};
 
-  const auto number_of_points = get<0>(points).size();
-  Matrix result(number_of_points, mesh.number_of_grid_points());
   // First dimension of DataVector varies fastest.
   for (size_t k = 0, s = 0; k < mesh.extents(2); ++k) {
     for (size_t j = 0; j < mesh.extents(1); ++j) {
       for (size_t i = 0; i < mesh.extents(0); ++i) {
-        for (size_t p = 0; p < number_of_points; ++p) {
+        for (size_t p = 0; p < number_of_target_points; ++p) {
           result(p, s) =
               matrices[0](p, i) * matrices[1](p, j) * matrices[2](p, k);
         }

--- a/src/NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp
+++ b/src/NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp
@@ -25,7 +25,12 @@ class er;
 namespace intrp {
 
 /// \ingroup NumericalAlgorithmsGroup
-/// Interpolates a `Variables` onto an arbitrary set of points.
+/// \brief Interpolates a `Variables` onto an arbitrary set of points.
+///
+/// \details If the `source_mesh` uses Spectral::Basis::FiniteDifference,
+/// linear interpolation is done in each dimension; otherwise it uses the
+/// barycentric interpolation provided by Spectral::interpolation_matrix in each
+/// dimension.
 template <size_t Dim>
 class Irregular {
  public:

--- a/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -46,10 +46,19 @@ target_link_libraries(
   ${LIBRARY}
   PRIVATE
   Boost::boost
+  CoordinateMaps
+  DataStructures
+  Domain
+  DomainCreators
+  DomainStructure
+  GeneralRelativitySolutions
   Interpolation
   IO
   Logging
   MathFunctions
+  RelativisticEulerSolutions
+  Spectral
+  Utilities
   )
 
 add_dependencies(

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
@@ -16,23 +16,36 @@
 #include "DataStructures/IndexIterator.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"  // IWYU pragma: keep
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/Block.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/Creators/Brick.hpp"
+#include "Domain/Creators/Interval.hpp"
+#include "Domain/Creators/Rectangle.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/ElementMap.hpp"
 #include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Structure/ElementId.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Tov.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "PointwiseFunctions/MathFunctions/MathFunction.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/MathFunctions/PowX.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/MathFunctions/TensorProduct.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
 // IWYU pragma: no_forward_declare MathFunction
 // IWYU pragma: no_forward_declare PowX
 // IWYU pragma: no_forward_declare Tensor
@@ -173,9 +186,8 @@ void test_interpolate_to_points(const Mesh<Dim>& mesh) noexcept {
     MathFunctions::TensorProduct<Dim> f(1.0, std::move(functions));
 
     // Fill source and expected destination Variables with analytic solution.
-    tmpl::for_each<tags>([
-      &f, &src_x, &target_x_inertial, &src_vars, &expected_dest_vars
-    ](auto tag) noexcept {
+    tmpl::for_each<tags>([&f, &src_x, &target_x_inertial, &src_vars,
+                          &expected_dest_vars](auto tag) noexcept {
       using Tag = tmpl::type_from<decltype(tag)>;
       get<Tag>(src_vars) = Tag::fill_values(f, src_x);
       get<Tag>(expected_dest_vars) = Tag::fill_values(f, target_x_inertial);
@@ -186,7 +198,7 @@ void test_interpolate_to_points(const Mesh<Dim>& mesh) noexcept {
     const Variables<tags> dest_vars =
         irregular_interpolant.interpolate(src_vars);
 
-    tmpl::for_each<tags>([&dest_vars, &expected_dest_vars ](auto tag) noexcept {
+    tmpl::for_each<tags>([&dest_vars, &expected_dest_vars](auto tag) noexcept {
       using Tag = tmpl::type_from<decltype(tag)>;
       CHECK_ITERABLE_APPROX(get<Tag>(dest_vars), get<Tag>(expected_dest_vars));
     });
@@ -230,6 +242,144 @@ void test_irregular_interpolant_mixed_quadrature() {
   }
 }
 
+template <size_t Dim>
+Domain<Dim> create_domain(double length,
+                          const std::array<size_t, Dim>& extents) noexcept;
+
+template <>
+Domain<3> create_domain<3>(const double length,
+                           const std::array<size_t, 3>& extents) noexcept {
+  const domain::creators::Brick creator{{{0.0, 0.0, 0.0}},
+                                        {{length, length, length}},
+                                        {{0, 0, 0}},
+                                        extents,
+                                        {{false, false, false}}};
+  return creator.create_domain();
+}
+
+template <>
+Domain<2> create_domain<2>(const double length,
+                           const std::array<size_t, 2>& extents) noexcept {
+  const domain::creators::Rectangle creator{
+      {{0.0, 0.0}}, {{length, length}}, {{0, 0}}, extents, {{false, false}}};
+  return creator.create_domain();
+}
+
+template <>
+Domain<1> create_domain<1>(const double length,
+                           const std::array<size_t, 1>& extents) noexcept {
+  const domain::creators::Interval creator{{{0.0}}, {{length}}, {{0}},
+                                           extents, {{false}},  nullptr};
+  return creator.create_domain();
+}
+
+template <size_t Dim>
+tnsr::I<DataVector, Dim, Frame::Logical> create_target_points(
+    size_t n_random_target_points) {
+  tnsr::I<DataVector, Dim, Frame::Logical> xi_target{n_random_target_points + 2,
+                                                     -1.0};
+  for (size_t d = 0; d < Dim; ++d) {
+    xi_target.get(d)[1] = 1.0;
+  }
+  return xi_target;
+}
+
+namespace Tags {
+struct Scalar : ::db::SimpleTag {
+  using type = ::Scalar<DataVector>;
+};
+}  // namespace Tags
+
+using var_tags = tmpl::list<Tags::Scalar>;
+
+template <size_t Dim>
+Variables<var_tags> polynomial(
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& x, const size_t degree) {
+  tnsr::I<DataVector, Dim, Frame::Inertial> v = x;
+  for (size_t d = 0; d < Dim; ++d) {
+    for (size_t n = degree; n > 1; --n) {
+      v.get(d) *= (x.get(d) + 1.0);
+    }
+  }
+  Variables<var_tags> result{get<0>(x).size()};
+  get(get<Tags::Scalar>(result)) = get<0>(v);
+  for (size_t d = 1; d < Dim; ++d) {
+    get(get<Tags::Scalar>(result)) *= v.get(d);
+  }
+  return result;
+}
+
+template <size_t Dim, size_t MaxDegree>
+void test_polynomial_interpolant(
+    const std::array<size_t, Dim>& extents) noexcept {
+  const size_t n_random_target_points = 10;
+
+  const auto domain = create_domain<Dim>(20.0 / 3.0, extents);
+  const auto& block = domain.blocks()[0];
+  const ElementMap<Dim, Frame::Inertial> element_map{
+      ElementId<Dim>{0}, block.stationary_map().get_clone()};
+  Mesh<Dim> mesh(extents, Spectral::Basis::FiniteDifference,
+                 Spectral::Quadrature::CellCentered);
+
+  const auto source_xi = logical_coordinates(mesh);
+  const auto source_x = element_map(source_xi);
+  const auto target_xi = create_target_points<Dim>(n_random_target_points);
+  const auto target_x = element_map(target_xi);
+  intrp::Irregular irregular_interp{mesh, target_xi};
+
+  for (size_t degree = 0; degree <= MaxDegree; ++degree) {
+    const auto source_vars = polynomial<Dim>(source_x, degree);
+    const auto target_vars = irregular_interp.interpolate(source_vars);
+    const auto expected_vars = polynomial<Dim>(target_x, degree);
+    CHECK_VARIABLES_APPROX(target_vars, expected_vars);
+  }
+}
+
+void test_tov() noexcept {
+  const std::array<size_t, 3> isotropic_extents{{11, 11, 11}};
+  constexpr size_t n_resolutions = 4;
+  auto errors =
+      make_array<n_resolutions>(std::numeric_limits<double>::signaling_NaN());
+  const double central_density = 1.28e-3;
+  for (size_t i = 0; i < n_resolutions; ++i) {
+    const Domain<3> domain = create_domain<3>(
+        6.6666666666666666666 / two_to_the(i), isotropic_extents);
+    const Block<3>& cube = domain.blocks()[0];
+    Mesh<3> mesh(isotropic_extents, Spectral::Basis::FiniteDifference,
+                 Spectral::Quadrature::CellCentered);
+    const auto xi = logical_coordinates(mesh);
+    const ElementMap<3, Frame::Inertial> element_map{
+        ElementId<3>{0}, cube.stationary_map().get_clone()};
+    const auto x = element_map(xi);
+
+    RelativisticEuler::Solutions::TovStar<gr::Solutions::TovSolution> tov_star(
+        central_density, 100.0, 2.0);
+
+    using rho_tag = hydro::Tags::RestMassDensity<DataVector>;
+    auto vars = variables_from_tagged_tuple(
+        tov_star.variables(x, 0.0, tmpl::list<rho_tag>{}));
+
+    const tnsr::I<DataVector, 3, Frame::Logical> xi_target{1_st, -1.0};
+
+    intrp::Irregular irregular_interp{mesh, xi_target};
+
+    const auto target_vars = irregular_interp.interpolate(vars);
+    gsl::at(errors, i) =
+        fabs(central_density - get(get<rho_tag>(target_vars))[0]);
+  }
+
+  std::reverse(std::begin(errors), std::end(errors));
+  auto ratio_of_errors =
+      make_array<n_resolutions>(std::numeric_limits<double>::signaling_NaN());
+  std::adjacent_difference(std::begin(errors), std::end(errors),
+                           std::begin(ratio_of_errors), std::divides<>{});
+
+  Approx custom_approx = Approx::custom().epsilon(1.e-2).scale(1.);
+  for (size_t i = 1; i < n_resolutions; ++i) {
+    CHECK(4.0 == custom_approx(gsl::at(ratio_of_errors, i)));
+  }
+}
+
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Numerical.Interpolation.IrregularInterpolant",
@@ -239,4 +389,13 @@ SPECTRE_TEST_CASE("Unit.Numerical.Interpolation.IrregularInterpolant",
   test_irregular_interpolant<Spectral::Basis::Legendre,
                              Spectral::Quadrature::Gauss>();
   test_irregular_interpolant_mixed_quadrature();
+  test_polynomial_interpolant<1, 1>({{11}});
+  test_polynomial_interpolant<2, 1>({{11, 11}});
+  test_polynomial_interpolant<2, 1>({{11, 9}});
+  test_polynomial_interpolant<3, 1>({{11, 11, 11}});
+  test_polynomial_interpolant<3, 1>({{11, 9, 11}});
+  test_polynomial_interpolant<3, 1>({{11, 11, 9}});
+  test_polynomial_interpolant<3, 1>({{11, 9, 9}});
+  test_polynomial_interpolant<3, 1>({{11, 9, 13}});
+  test_tov();
 }


### PR DESCRIPTION

## Proposed changes

Instead of using barycetric interpolation as is done for DG, check if the basis is
FiniteDifference and if so use linear interpolation in each dimension.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
