### PR TITLE
Add block names to BinaryCompactObject domain, support per-block refinement

### DIFF
--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -4,7 +4,9 @@
 #include "Domain/Creators/BinaryCompactObject.hpp"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
+#include <cstddef>
 #include <iterator>
 #include <limits>
 #include <memory>
@@ -12,7 +14,10 @@
 #include <pup.h>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
+#include <variant>
+#include <vector>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/Block.hpp"  // IWYU pragma: keep
@@ -30,6 +35,7 @@
 #include "Domain/CoordinateMaps/TimeDependent/Rotation.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/SphericalCompression.hpp"
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
+#include "Domain/Creators/ExpandOverBlocks.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"
 #include "Domain/FunctionsOfTime/FixedSpeedCubic.hpp"
@@ -50,10 +56,11 @@ bool BinaryCompactObject::Object::is_excised() const noexcept {
 // Time-independent constructor
 BinaryCompactObject::BinaryCompactObject(
     Object object_A, Object object_B, const double radius_enveloping_cube,
-    const double radius_enveloping_sphere, const size_t initial_refinement,
-    const size_t initial_grid_points_per_dim, const bool use_projective_map,
+    const double radius_enveloping_sphere,
+    const typename InitialRefinement::type& initial_refinement,
+    const typename InitialGridPoints::type& initial_number_of_grid_points,
+    const bool use_projective_map,
     const bool use_logarithmic_map_outer_spherical_shell,
-    const size_t addition_to_outer_layer_radial_refinement_level,
     std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
         outer_boundary_condition,
     const Options::Context& context)
@@ -61,13 +68,9 @@ BinaryCompactObject::BinaryCompactObject(
       object_B_(std::move(object_B)),
       radius_enveloping_cube_(radius_enveloping_cube),
       radius_enveloping_sphere_(radius_enveloping_sphere),
-      initial_refinement_(initial_refinement),
-      initial_grid_points_per_dim_(initial_grid_points_per_dim),
       use_projective_map_(use_projective_map),
       use_logarithmic_map_outer_spherical_shell_(
           use_logarithmic_map_outer_spherical_shell),
-      addition_to_outer_layer_radial_refinement_level_(
-          addition_to_outer_layer_radial_refinement_level),
       outer_boundary_condition_(std::move(outer_boundary_condition)) {
   // Determination of parameters for domain construction:
   translation_ = 0.5 * (object_B_.x_coord + object_A_.x_coord);
@@ -156,6 +159,81 @@ BinaryCompactObject::BinaryCompactObject(
         context,
         "Cannot have periodic boundary conditions with a binary domain");
   }
+
+  // Create block names and groups
+  static std::array<std::string, 6> wedge_directions{
+      "UpperZ", "LowerZ", "UpperY", "LowerY", "UpperX", "LowerX"};
+  const auto add_object_region = [this](
+                                     const std::string& object_name,
+                                     const std::string& region_name) noexcept {
+    for (const std::string& wedge_direction : wedge_directions) {
+      const std::string block_name =
+          // NOLINTNEXTLINE(performance-inefficient-string-concatenation)
+          object_name + region_name + wedge_direction;
+      block_names_.push_back(block_name);
+      block_groups_[object_name + region_name].insert(block_name);
+    }
+  };
+  const auto add_object_interior =
+      [this](const std::string& object_name) noexcept {
+        const std::string block_name = object_name + "Interior";
+        block_names_.push_back(block_name);
+      };
+  const auto add_outer_region =
+      [this](const std::string& region_name) noexcept {
+        for (const std::string& wedge_direction : wedge_directions) {
+          for (const std::string& leftright : {"Left", "Right"}) {
+            if ((wedge_direction == "UpperX" and leftright == "Left") or
+                (wedge_direction == "LowerX" and leftright == "Right")) {
+              // The outer regions are divided in half perpendicular to the
+              // x-axis at x=0. Therefore, the left side only has a block in
+              // negative x-direction, and the right side only has one in
+              // positive x-direction.
+              continue;
+            }
+            // NOLINTNEXTLINE(performance-inefficient-string-concatenation)
+            const std::string block_name =
+                region_name + wedge_direction +
+                (wedge_direction == "UpperX" or wedge_direction == "LowerX"
+                     ? ""
+                     : leftright);
+            block_names_.push_back(block_name);
+            block_groups_[region_name].insert(block_name);
+          }
+        }
+      };
+  add_object_region("ObjectA", "Shell");  // 6 blocks
+  add_object_region("ObjectA", "Cube");   // 6 blocks
+  add_object_region("ObjectB", "Shell");  // 6 blocks
+  add_object_region("ObjectB", "Cube");   // 6 blocks
+  add_outer_region("EnvelopingCube");     // 10 blocks
+  add_outer_region("CubedShell");         // 10 blocks
+  add_outer_region("OuterShell");         // 10 blocks
+  if (not object_A_.is_excised()) {
+    add_object_interior("ObjectA");  // 1 block
+  }
+  if (not object_B_.is_excised()) {
+    add_object_interior("ObjectB");  // 1 block
+  }
+  ASSERT(block_names_.size() == number_of_blocks_,
+         "Number of block names (" << block_names_.size()
+                                   << ") doesn't match number of blocks ("
+                                   << number_of_blocks_ << ").");
+
+  // Expand initial refinement and number of grid points over all blocks
+  const ExpandOverBlocks<size_t, 3> expand_over_blocks{block_names_,
+                                                       block_groups_};
+  try {
+    initial_refinement_ = std::visit(expand_over_blocks, initial_refinement);
+  } catch (const std::exception& error) {
+    PARSE_ERROR(context, "Invalid 'InitialRefinement': " << error.what());
+  }
+  try {
+    initial_number_of_grid_points_ =
+        std::visit(expand_over_blocks, initial_number_of_grid_points);
+  } catch (const std::exception& error) {
+    PARSE_ERROR(context, "Invalid 'InitialGridPoints': " << error.what());
+  }
 }
 
 // Time-dependent constructor, with additional options for specifying
@@ -174,19 +252,18 @@ BinaryCompactObject::BinaryCompactObject(
     std::array<double, 2> initial_size_map_accelerations,
     std::array<std::string, 2> size_map_function_of_time_names, Object object_A,
     Object object_B, double radius_enveloping_cube,
-    double radius_enveloping_sphere, size_t initial_refinement,
-    size_t initial_grid_points_per_dim, bool use_projective_map,
-    bool use_logarithmic_map_outer_spherical_shell,
-    size_t addition_to_outer_layer_radial_refinement_level,
+    double radius_enveloping_sphere,
+    const typename InitialRefinement::type& initial_refinement,
+    const typename InitialGridPoints::type& initial_number_of_grid_points,
+    bool use_projective_map, bool use_logarithmic_map_outer_spherical_shell,
     std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
         outer_boundary_condition,
     const Options::Context& context)
     : BinaryCompactObject(std::move(object_A), std::move(object_B),
                           radius_enveloping_cube, radius_enveloping_sphere,
-                          initial_refinement, initial_grid_points_per_dim,
+                          initial_refinement, initial_number_of_grid_points,
                           use_projective_map,
                           use_logarithmic_map_outer_spherical_shell,
-                          addition_to_outer_layer_radial_refinement_level,
                           std::move(outer_boundary_condition), context) {
   enable_time_dependence_ = true;
   initial_time_ = initial_time;
@@ -302,8 +379,10 @@ Domain<3> BinaryCompactObject::create_domain() const noexcept {
   // the same size as the first radial division of the spherical shell
   // (for linear mapping) or smaller by the same factor as adjacent radial
   // divisions in the spherical shell (for logarithmic mapping)
+  const size_t addition_to_outer_layer_radial_refinement_level =
+      initial_refinement_[44][2] - initial_refinement_[34][2];
   const double radial_divisions_in_outer_layers =
-      pow(2, addition_to_outer_layer_radial_refinement_level_) + 1;
+      pow(2, addition_to_outer_layer_radial_refinement_level) + 1;
   const double outer_radius_first_outer_shell =
       use_logarithmic_map_outer_spherical_shell_
           ? inner_radius_first_outer_shell *
@@ -550,57 +629,6 @@ Domain<3> BinaryCompactObject::create_domain() const noexcept {
   }
 
   return domain;
-}
-
-std::vector<std::array<size_t, 3>> BinaryCompactObject::initial_extents()
-    const noexcept {
-  return {number_of_blocks_, make_array<3>(initial_grid_points_per_dim_)};
-}
-
-std::vector<std::array<size_t, 3>>
-BinaryCompactObject::initial_refinement_levels() const noexcept {
-  std::vector<std::array<size_t, 3>> initial_levels{
-      number_of_blocks_, make_array<3>(initial_refinement_)};
-  // Increase the radial refinement level of the blocks corresponding to the
-  // part of Layer 1 enveloping object A (block 0 through block 5, inclusive)
-  if (object_A_.addition_to_radial_refinement_level > 0) {
-    for (size_t block = 0; block < 6; ++block) {
-      // Refine in the radial direction, which is direction 2
-      // (i.e. the zeta direction)
-      gsl::at(initial_levels[block], 2) +=
-          object_A_.addition_to_radial_refinement_level;
-    }
-  }
-
-  // Increase the radial refinement level of the blocks corresponding to the
-  // part of Layer 1 enveloping object B (block 12 through block 17, inclusive).
-  if (object_B_.addition_to_radial_refinement_level > 0) {
-    for (size_t block = 12; block < 18; ++block) {
-      // Refine in the radial direction, which is direction 2
-      // (i.e. the zeta direction)
-      gsl::at(initial_levels[block], 2) +=
-          object_B_.addition_to_radial_refinement_level;
-    }
-  }
-
-  // Increase the radial refinement of the blocks corresponding to the outer
-  // spherical shell (with sphericity == 1 throughout) to achieve the desired
-  // number of radial refinements. The outer layer consists of 10 blocks,
-  // created via sph_wedge_coordinate_maps() with use_half_wedges == true.
-  // Because this outer layer of blocks is added last to the CoordinateMaps in
-  // create_domain(), the 10 blocks to refine are the last 10 blocks in the
-  // domain--unless one or both of the interiors are not excised. (For each
-  // interior not excised, there is one extra block appended to the list of
-  // CoordinateMaps.)
-  if (addition_to_outer_layer_radial_refinement_level_ > 0) {
-    for (size_t block = 44; block < 54; ++block) {
-      // Refine in the radial direction, which is direction 2
-      // (i.e. the zeta direction)
-      gsl::at(initial_levels[block], 2) +=
-          addition_to_outer_layer_radial_refinement_level_;
-    }
-  }
-  return initial_levels;
 }
 
 std::unordered_map<std::string,

--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -703,9 +703,6 @@ class BinaryCompactObject : public DomainCreator<3> {
       std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override;
 
  private:
-  void check_for_parse_errors(const Options::Context& context) const;
-  void initialize_calculated_member_variables() noexcept;
-
   Object object_A_{};
   Object object_B_{};
   double radius_enveloping_cube_{};

--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -11,6 +11,8 @@
 #include <string>
 #include <type_traits>
 #include <unordered_map>
+#include <unordered_set>
+#include <variant>
 #include <vector>
 
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
@@ -261,13 +263,6 @@ class BinaryCompactObject : public DomainCreator<3> {
           "Use a logarithmically spaced radial grid in the part of Layer 1 "
           "enveloping the object (requires the interior is excised)"};
     };
-    struct AdditionToRadialRefinementLevel {
-      using type = size_t;
-      static constexpr Options::String help = {
-          "Addition to radial refinement level in the part of Layer 1 "
-          "enveloping the object, beyond the refinement level set by "
-          "InitialRefinement."};
-    };
     template <typename Metavariables>
     using options = tmpl::list<
         InnerRadius, OuterRadius, XCoord,
@@ -275,12 +270,11 @@ class BinaryCompactObject : public DomainCreator<3> {
             domain::BoundaryConditions::has_boundary_conditions_base_v<
                 typename Metavariables::system>,
             Interior, ExciseInterior>,
-        UseLogarithmicMap, AdditionToRadialRefinementLevel>;
+        UseLogarithmicMap>;
     Object() = default;
     Object(double local_inner_radius, double local_outer_radius,
            double local_x_coord, std::optional<Excision> interior,
-           bool local_use_logarithmic_map,
-           size_t local_addition_to_radial_refinement_level) noexcept
+           bool local_use_logarithmic_map) noexcept
         : inner_radius(local_inner_radius),
           outer_radius(local_outer_radius),
           x_coord(local_x_coord),
@@ -288,13 +282,10 @@ class BinaryCompactObject : public DomainCreator<3> {
               interior.has_value()
                   ? std::make_optional(std::move(interior->boundary_condition))
                   : std::nullopt),
-          use_logarithmic_map(local_use_logarithmic_map),
-          addition_to_radial_refinement_level(
-              local_addition_to_radial_refinement_level) {}
+          use_logarithmic_map(local_use_logarithmic_map) {}
     Object(double local_inner_radius, double local_outer_radius,
            double local_x_coord, bool local_excise_interior,
-           bool local_use_logarithmic_map,
-           size_t local_addition_to_radial_refinement_level) noexcept
+           bool local_use_logarithmic_map) noexcept
         : inner_radius(local_inner_radius),
           outer_radius(local_outer_radius),
           x_coord(local_x_coord),
@@ -303,9 +294,7 @@ class BinaryCompactObject : public DomainCreator<3> {
                   ? std::optional<std::unique_ptr<
                         domain::BoundaryConditions::BoundaryCondition>>{nullptr}
                   : std::nullopt),
-          use_logarithmic_map(local_use_logarithmic_map),
-          addition_to_radial_refinement_level(
-              local_addition_to_radial_refinement_level) {}
+          use_logarithmic_map(local_use_logarithmic_map) {}
 
     /// Whether or not the object should be excised from the domain, leaving a
     /// spherical hole. When this is true, `inner_boundary_condition` is
@@ -320,7 +309,6 @@ class BinaryCompactObject : public DomainCreator<3> {
         std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>
         inner_boundary_condition;
     bool use_logarithmic_map;
-    size_t addition_to_radial_refinement_level;
   };
 
   struct ObjectA {
@@ -363,15 +351,23 @@ class BinaryCompactObject : public DomainCreator<3> {
   };
 
   struct InitialRefinement {
-    using type = size_t;
+    using type =
+        std::variant<size_t, std::array<size_t, 3>,
+                     std::vector<std::array<size_t, 3>>,
+                     std::unordered_map<std::string, std::array<size_t, 3>>>;
     static constexpr Options::String help = {
-        "Initial refinement level. Applied to each dimension."};
+        "Initial refinement level in each block of the domain. See main help "
+        "text for details."};
   };
 
   struct InitialGridPoints {
-    using type = size_t;
+    using type =
+        std::variant<size_t, std::array<size_t, 3>,
+                     std::vector<std::array<size_t, 3>>,
+                     std::unordered_map<std::string, std::array<size_t, 3>>>;
     static constexpr Options::String help = {
-        "Initial number of grid points in each dim per element."};
+        "Initial number of grid points in the elements of each block of the "
+        "domain. See main help text for details."};
   };
 
   struct UseProjectiveMap {
@@ -387,18 +383,6 @@ class BinaryCompactObject : public DomainCreator<3> {
     static constexpr Options::String help = {
         "Use a logarithmically spaced radial grid in Layer 5, the outer "
         "spherical shell that covers the wave zone."};
-  };
-
-  struct AdditionToOuterLayerRadialRefinementLevel {
-    using group = OuterSphere;
-    static std::string name() noexcept {
-      return "AdditionToRadialRefinementLevel";
-    }
-    using type = size_t;
-    static constexpr Options::String help = {
-        "Addition to radial refinement level in Layer 5 (the outer spherical "
-        "shell that covers that wave zone), beyond the refinement "
-        "level set by InitialRefinement."};
   };
 
   template <typename BoundaryConditionsBase>
@@ -582,8 +566,7 @@ class BinaryCompactObject : public DomainCreator<3> {
   using time_independent_options = tmpl::append<
       tmpl::list<ObjectA, ObjectB, RadiusEnvelopingCube, RadiusOuterSphere,
                  InitialRefinement, InitialGridPoints, UseProjectiveMap,
-                 UseLogarithmicMapOuterSphericalShell,
-                 AdditionToOuterLayerRadialRefinementLevel>,
+                 UseLogarithmicMapOuterSphericalShell>,
       tmpl::conditional_t<
           domain::BoundaryConditions::has_boundary_conditions_base_v<
               typename Metavariables::system>,
@@ -612,30 +595,36 @@ class BinaryCompactObject : public DomainCreator<3> {
   static constexpr Options::String help{
       "The BinaryCompactObject domain is a general domain for two compact "
       "objects. The user must provide the inner and outer radii of the "
-      "spherical shells surrounding each of the two compact objects A and "
-      "B. The radial refinement levels for these shells are (InitialRefinement "
-      "+ Object{A,B}.AdditionToRadialRefinementLevel).\n\n"
-      "The user must also provide the radius of the sphere that "
-      "circumscribes the cube containing both compact objects, and the "
-      "radius of the outer boundary. The options Object{A,B}.Interior (or "
+      "spherical shells surrounding each of the two compact objects A and B "
+      "(\"ObjectAShell\" and \"ObjectBShell\"). Each object is enveloped in "
+      "a cube (\"ObjectACube\" and \"ObjectBCube\")."
+      "The user must also provide the radius of the sphere that circumscribes "
+      "the cube containing both compact objects (\"EnvelopingCube\"). "
+      "A radial layer transitions from the enveloping cube to a sphere "
+      "(\"CubedShell\"). A final radial layer transitions to the outer "
+      "boundary (\"OuterShell\"). The options Object{A,B}.Interior (or "
       "Object{A,B}.ExciseInterior if we're not working with boundary "
-      "conditions) determine whether the layer-zero blocks are present "
-      "inside each compact object. If set to a boundary condition or 'false', "
-      "the domain will not contain layer zero for that object. The user "
+      "conditions) determine whether blocks are present inside each compact "
+      "object (\"ObjectAInterior\" and \"ObjectBInterior\"). If set to a "
+      "boundary condition or 'false', the region will be excised. The user "
       "specifies Object{A,B}.XCoord, the x-coordinates of the locations of the "
       "centers of each compact object. In these coordinates, the location for "
       "the axis of rotation is x=0. ObjectA is located on the left and ObjectB "
       "is located on the right. Please make sure that your choices of "
       "x-coordinate locations are such that the resulting center of mass "
-      "is located at zero.\n\n"
-      "Two radial layers join the enveloping cube to the spherical outer "
-      "boundary. The first of these layers transitions from sphericity == 0.0 "
-      "on the inner boundary to sphericity == 1.0 on the outer boundary. The "
-      "second has sphericity == 1 (so either linear or logarithmic mapping can "
-      "be used in the radial direction), extends to the spherical outer "
-      "boundary of the domain, and has a radial refinement level of "
-      "(InitialRefinement + OuterSphere.AdditionToRadialRefinementLevel)."
-      "Note that the domain optionally includes time-dependent maps; enabling "
+      "is located at zero.\n"
+      "\n"
+      "Both the InitialRefinement and the InitialGridPoints can be one of "
+      "the following:\n"
+      "  - A single number: Uniform refinement in all blocks and "
+      "dimensions\n"
+      "  - Three numbers: Refinement in [polar, azimuthal, radial] direction "
+      "in all blocks\n"
+      "  - A map from block names or groups to three numbers: Per-block "
+      "refinement in [polar, azimuthal, radial] direction\n"
+      "  - A list, with [polar, azimuthal, radial] refinement for each block\n"
+      "\n"
+      "The domain optionally includes time-dependent maps. Enabling "
       "the time-dependent maps requires adding a "
       "struct named domain to the Metavariables, with this "
       "struct conforming to domain::protocols::Metavariables. To enable the "
@@ -650,10 +639,11 @@ class BinaryCompactObject : public DomainCreator<3> {
   // Metavariables::domain::enable_time_dependent_maps)
   BinaryCompactObject(
       Object object_A, Object object_B, double radius_enveloping_cube,
-      double radius_enveloping_sphere, size_t initial_refinement,
-      size_t initial_grid_points_per_dim, bool use_projective_map = true,
+      double radius_enveloping_sphere,
+      const typename InitialRefinement::type& initial_refinement,
+      const typename InitialGridPoints::type& initial_number_of_grid_points,
+      bool use_projective_map = true,
       bool use_logarithmic_map_outer_spherical_shell = false,
-      size_t addition_to_outer_layer_radial_refinement_level = 0,
       std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
           outer_boundary_condition = nullptr,
       const Options::Context& context = {});
@@ -676,10 +666,11 @@ class BinaryCompactObject : public DomainCreator<3> {
       std::array<double, 2> initial_size_map_accelerations,
       std::array<std::string, 2> size_map_function_of_time_names,
       Object object_A, Object object_B, double radius_enveloping_cube,
-      double radius_enveloping_sphere, size_t initial_refinement,
-      size_t initial_grid_points_per_dim, bool use_projective_map = true,
+      double radius_enveloping_sphere,
+      const typename InitialRefinement::type& initial_refinement,
+      const typename InitialGridPoints::type& initial_number_of_grid_points,
+      bool use_projective_map = true,
       bool use_logarithmic_map_outer_spherical_shell = false,
-      size_t addition_to_outer_layer_radial_refinement_level = 0,
       std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
           outer_boundary_condition = nullptr,
       const Options::Context& context = {});
@@ -693,10 +684,23 @@ class BinaryCompactObject : public DomainCreator<3> {
 
   Domain<3> create_domain() const noexcept override;
 
-  std::vector<std::array<size_t, 3>> initial_extents() const noexcept override;
+  std::vector<std::array<size_t, 3>> initial_extents() const noexcept override {
+    return initial_number_of_grid_points_;
+  }
 
-  std::vector<std::array<size_t, 3>> initial_refinement_levels() const
-      noexcept override;
+  std::vector<std::array<size_t, 3>> initial_refinement_levels()
+      const noexcept override {
+    return initial_refinement_;
+  }
+
+  std::vector<std::string> block_names() const noexcept override {
+    return block_names_;
+  }
+
+  std::unordered_map<std::string, std::unordered_set<std::string>>
+  block_groups() const noexcept override {
+    return block_groups_;
+  }
 
   auto functions_of_time() const noexcept -> std::unordered_map<
       std::string,
@@ -707,13 +711,12 @@ class BinaryCompactObject : public DomainCreator<3> {
   Object object_B_{};
   double radius_enveloping_cube_{};
   double radius_enveloping_sphere_{};
-  size_t initial_refinement_{};
-  size_t initial_grid_points_per_dim_{};
+  std::vector<std::array<size_t, 3>> initial_refinement_{};
+  std::vector<std::array<size_t, 3>> initial_number_of_grid_points_{};
   static constexpr bool use_equiangular_map_ =
       false;  // Doesn't work properly yet
   bool use_projective_map_ = true;
   bool use_logarithmic_map_outer_spherical_shell_ = false;
-  size_t addition_to_outer_layer_radial_refinement_level_{};
   double projective_scale_factor_{};
   double translation_{};
   double length_inner_cube_{};
@@ -721,6 +724,9 @@ class BinaryCompactObject : public DomainCreator<3> {
   size_t number_of_blocks_{};
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
       outer_boundary_condition_;
+  std::vector<std::string> block_names_{};
+  std::unordered_map<std::string, std::unordered_set<std::string>>
+      block_groups_{};
 
   // Variables for FunctionsOfTime options
   bool enable_time_dependence_{false};

--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -726,21 +726,33 @@ class BinaryCompactObject : public DomainCreator<3> {
       outer_boundary_condition_;
 
   // Variables for FunctionsOfTime options
-  bool enable_time_dependence_;
-  double initial_time_;
-  std::optional<double> initial_expiration_delta_t_;
-  double expansion_map_outer_boundary_;
-  double initial_expansion_;
-  double initial_expansion_velocity_;
+  bool enable_time_dependence_{false};
+  double initial_time_{std::numeric_limits<double>::signaling_NaN()};
+  std::optional<double> initial_expiration_delta_t_{
+      std::numeric_limits<double>::signaling_NaN()};
+  double expansion_map_outer_boundary_{
+      std::numeric_limits<double>::signaling_NaN()};
+  double initial_expansion_{std::numeric_limits<double>::signaling_NaN()};
+  double initial_expansion_velocity_{
+      std::numeric_limits<double>::signaling_NaN()};
   std::string expansion_function_of_time_name_;
-  double asymptotic_velocity_outer_boundary_;
-  double decay_timescale_outer_boundary_velocity_;
-  double initial_rotation_angle_;
-  double initial_angular_velocity_;
+  double asymptotic_velocity_outer_boundary_{
+      std::numeric_limits<double>::signaling_NaN()};
+  double decay_timescale_outer_boundary_velocity_{
+      std::numeric_limits<double>::signaling_NaN()};
+  double initial_rotation_angle_{std::numeric_limits<double>::signaling_NaN()};
+  double initial_angular_velocity_{
+      std::numeric_limits<double>::signaling_NaN()};
   std::string rotation_about_z_axis_function_of_time_name_;
-  std::array<double, 2> initial_size_map_values_;
-  std::array<double, 2> initial_size_map_velocities_;
-  std::array<double, 2> initial_size_map_accelerations_;
+  std::array<double, 2> initial_size_map_values_{
+      std::numeric_limits<double>::signaling_NaN(),
+      std::numeric_limits<double>::signaling_NaN()};
+  std::array<double, 2> initial_size_map_velocities_{
+      std::numeric_limits<double>::signaling_NaN(),
+      std::numeric_limits<double>::signaling_NaN()};
+  std::array<double, 2> initial_size_map_accelerations_{
+      std::numeric_limits<double>::signaling_NaN(),
+      std::numeric_limits<double>::signaling_NaN()};
   std::array<std::string, 2> size_map_function_of_time_names_;
 };
 }  // namespace creators

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -19,21 +19,25 @@ DomainCreator:
       XCoord: -10.0
       ExciseInterior: true
       UseLogarithmicMap: false
-      AdditionToRadialRefinementLevel: 1
     ObjectB:
       InnerRadius: 0.4409
       OuterRadius: 6.0
       XCoord: 10.0
       ExciseInterior: true
       UseLogarithmicMap: false
-      AdditionToRadialRefinementLevel: 1
     EnvelopingCube:
       Radius: 100.0
     OuterSphere:
       Radius: 590.0
       UseLogarithmicMap: false
-      AdditionToRadialRefinementLevel: 0
-    InitialRefinement: 0
+    InitialRefinement:
+      ObjectAShell:   [0, 0, 1]
+      ObjectBShell:   [0, 0, 1]
+      ObjectACube:    [0, 0, 0]
+      ObjectBCube:    [0, 0, 0]
+      EnvelopingCube: [0, 0, 0]
+      CubedShell:     [0, 0, 0]
+      OuterShell:     [0, 0, 0]
     InitialGridPoints: 3
     UseProjectiveMap: true
     TimeDependentMaps:

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -19,7 +19,6 @@ DomainCreator:
         ExciseWithBoundaryCondition:
           Outflow:
       UseLogarithmicMap: false
-      AdditionToRadialRefinementLevel: 1
     ObjectB:
       InnerRadius: 0.7925
       OuterRadius: 6.683
@@ -28,17 +27,22 @@ DomainCreator:
         ExciseWithBoundaryCondition:
           Outflow:
       UseLogarithmicMap: false
-      AdditionToRadialRefinementLevel: 1
     EnvelopingCube:
       Radius: 100.0
     OuterSphere:
       Radius: 1493.0
       UseLogarithmicMap: false
-      AdditionToRadialRefinementLevel: 3
       BoundaryCondition:
         ConstraintPreservingBjorhus:
           Type: ConstraintPreservingPhysical
-    InitialRefinement: 2
+    InitialRefinement:
+      ObjectAShell:   [2, 2, 3]
+      ObjectACube:    [2, 2, 2]
+      ObjectBShell:   [2, 2, 3]
+      ObjectBCube:    [2, 2, 2]
+      EnvelopingCube: [2, 2, 2]
+      CubedShell:     [2, 2, 2]
+      OuterShell:     [2, 2, 5]
     InitialGridPoints: 11
     UseProjectiveMap: true
     TimeDependentMaps:


### PR DESCRIPTION
## Proposed changes

Support block names and groups in the `BinaryCompactObject` domain creator, and add per-block support to `InitialRefinement` and `InitialGridPoints`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
When constructing a `BinaryCompactObject` domain creator from options, delete the `AdditionToRadialRefinementLevel` options. They have been replaced by per-block support for the `InitialRefinement` and `InitialGridPoints` options.

- If you used no additional radial refinement before, you can just delete the options:

    ```yaml
    # New - uniform refinement
    DomainCreator:
      BinaryCompactObject:
        # ... (delete AdditionToRadialRefinementLevel options)
        InitialRefinement: 1
    ```

- If you had this additional radial refinement configuration before:

    ```yaml
    # Old - additional radial refinement
    DomainCreator:
      BinaryCompactObject:
        ObjectA:
          # ...
          AdditionToRadialRefinementLevel: 1
        # ...
        OuterSphere:
          # ...
          AdditionToRadialRefinementLevel: 2
        InitialRefinement: 1
    ```

    you can reproduce it now with these options:

    ```yaml
    # New - additional radial refinement
    DomainCreator:
      BinaryCompactObject:
        # ...
        InitialRefinement:
          ObjectAShell:   [1, 1, 2]
          ObjectBShell:   [1, 1, 1]
          ObjectACube:    [1, 1, 1]
          ObjectBCube:    [1, 1, 1]
          EnvelopingCube: [1, 1, 1]
          CubedShell:     [1, 1, 1]
          OuterShell:     [1, 1, 3]
    ```

Refer to the help string of the `BinaryCompactObject` domain creator for details.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
