### PR TITLE
Add GR function for spatial derivative of inverse spatial metric

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   Christoffel.cpp
+  DerivativeSpatialMetric.cpp
   DerivativesOfSpacetimeMetric.cpp
   ExtrinsicCurvature.cpp
   IndexManipulation.cpp
@@ -34,6 +35,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Christoffel.hpp
+  DerivativeSpatialMetric.hpp
   DerivativesOfSpacetimeMetric.hpp
   DetAndInverseSpatialMetric.hpp
   ExtrinsicCurvature.hpp

--- a/src/PointwiseFunctions/GeneralRelativity/DerivativeSpatialMetric.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/DerivativeSpatialMetric.cpp
@@ -1,0 +1,79 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <cstddef>
+
+#include "PointwiseFunctions/GeneralRelativity/DerivativeSpatialMetric.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace gr {
+template <size_t Dim, typename Frame, typename DataType>
+void deriv_inverse_spatial_metric(
+    const gsl::not_null<tnsr::iJJ<DataType, Dim, Frame>*> result,
+    const tnsr::II<DataType, Dim, Frame>& inverse_spatial_metric,
+    const tnsr::ijj<DataType, Dim, Frame>& d_spatial_metric) noexcept {
+  destructive_resize_components(result,
+                                get_size(get<0, 0>(inverse_spatial_metric)));
+  for (auto& component : *result) {
+    component = 0.0;
+  }
+
+  for (size_t i = 0; i < Dim; ++i) {
+    for (size_t j = i; j < Dim; ++j) {
+      for (size_t k = 0; k < Dim; ++k) {
+        for (size_t m = 0; m < Dim; ++m) {
+          for (size_t n = 0; n < Dim; ++n) {
+            (*result).get(k, i, j) -= inverse_spatial_metric.get(i, n) *
+                                      inverse_spatial_metric.get(m, j) *
+                                      d_spatial_metric.get(k, n, m);
+          }
+        }
+      }
+    }
+  }
+}
+
+template <size_t Dim, typename Frame, typename DataType>
+tnsr::iJJ<DataType, Dim, Frame> deriv_inverse_spatial_metric(
+    const tnsr::II<DataType, Dim, Frame>& inverse_spatial_metric,
+    const tnsr::ijj<DataType, Dim, Frame>& d_spatial_metric) noexcept {
+  tnsr::iJJ<DataType, Dim, Frame> result{};
+  deriv_inverse_spatial_metric(make_not_null(&result), inverse_spatial_metric,
+                               d_spatial_metric);
+  return result;
+}
+}  // namespace gr
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                               \
+  template void gr::deriv_inverse_spatial_metric(                          \
+      const gsl::not_null<tnsr::iJJ<DTYPE(data), DIM(data), FRAME(data)>*> \
+          result,                                                          \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                 \
+          inverse_spatial_metric,                                          \
+      const tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>&                \
+          d_spatial_metric) noexcept;                                      \
+  template tnsr::iJJ<DTYPE(data), DIM(data), FRAME(data)>                  \
+  gr::deriv_inverse_spatial_metric(                                        \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                 \
+          inverse_spatial_metric,                                          \
+      const tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>&                \
+          d_spatial_metric) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial),
+                        (double, DataVector))
+
+#undef INSTANTIATE
+#undef DTYPE
+#undef FRAME
+#undef DIM

--- a/src/PointwiseFunctions/GeneralRelativity/DerivativeSpatialMetric.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/DerivativeSpatialMetric.hpp
@@ -1,0 +1,38 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace gr {
+/// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes the spatial derivative of the inverse spatial metric from the
+ * inverse spatial metric and the spatial derivative of the spatial metric.
+ *
+ * \details Computes the derivative as:
+ * \f{align}
+ *     \partial_k \gamma^{ij} &= -\gamma^{in} \gamma^{mj}
+ *                 \partial_k \gamma_{nm}
+ * \f}
+ * where \f$\gamma^{ij}\f$ and \f$\partial_k \gamma_{ij}\f$ are the inverse
+ * spatial metric and spatial derivative of the spatial metric, respectively.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+void deriv_inverse_spatial_metric(
+    const gsl::not_null<tnsr::iJJ<DataType, Dim, Frame>*> result,
+    const tnsr::II<DataType, Dim, Frame>& inverse_spatial_metric,
+    const tnsr::ijj<DataType, Dim, Frame>& d_spatial_metric) noexcept;
+
+template <size_t Dim, typename Frame, typename DataType>
+tnsr::iJJ<DataType, Dim, Frame> deriv_inverse_spatial_metric(
+    const tnsr::II<DataType, Dim, Frame>& inverse_spatial_metric,
+    const tnsr::ijj<DataType, Dim, Frame>& d_spatial_metric) noexcept;
+/// @}
+}  // namespace gr

--- a/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
@@ -44,6 +44,13 @@ template <typename DataType>
 struct SqrtDetSpatialMetric : db::SimpleTag {
   using type = Scalar<DataType>;
 };
+/*!
+ * \brief Spatial derivative of the inverse of the spatial metric.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct DerivInverseSpatialMetric : db::SimpleTag {
+  using type = tnsr::iJJ<DataType, Dim, Frame>;
+};
 template <size_t Dim, typename Frame, typename DataType>
 struct Shift : db::SimpleTag {
   using type = tnsr::I<DataType, Dim, Frame>;

--- a/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
@@ -33,6 +33,9 @@ template <typename DataType = DataVector>
 struct SqrtDetSpatialMetric;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
+struct DerivInverseSpatialMetric;
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
 struct Shift;
 template <typename DataType = DataVector>
 struct Lapse;

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.py
@@ -97,3 +97,8 @@ def extrinsic_curvature(lapse, shift, deriv_shift, spatial_metric,
         - dt_spatial_metric
     ext_curve *= 0.5 / lapse
     return ext_curve
+
+
+def deriv_inverse_spatial_metric(inverse_spatial_metric, d_spatial_metric):
+    return -np.einsum("in,mj,knm->kij", inverse_spatial_metric,
+                      inverse_spatial_metric, d_spatial_metric)

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -20,6 +20,7 @@
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "PointwiseFunctions/GeneralRelativity/DerivativeSpatialMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/DerivativesOfSpacetimeMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/DetAndInverseSpatialMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/ExtrinsicCurvature.hpp"
@@ -179,6 +180,16 @@ void test_compute_spatial_metric_lapse_shift(const T& used_for_size) {
   CHECK_ITERABLE_APPROX(lapse, lapse_test);
 }
 
+template <size_t Dim, typename DataType>
+void test_compute_deriv_inverse_spatial_metric(const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::iJJ<DataType, Dim, Frame::Inertial> (*)(
+          const tnsr::II<DataType, Dim, Frame::Inertial>&,
+          const tnsr::ijj<DataType, Dim, Frame::Inertial>&) noexcept>(
+          &gr::deriv_inverse_spatial_metric<Dim, Frame::Inertial, DataType>),
+      "ComputeSpacetimeQuantities", "deriv_inverse_spatial_metric",
+      {{{-10., 10.}}}, used_for_size);
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
@@ -201,6 +212,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
   CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_compute_spatial_metric_lapse_shift,
                                     (1, 2, 3));
   CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_compute_extrinsic_curvature,
+                                    (1, 2, 3));
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_compute_deriv_inverse_spatial_metric,
                                     (1, 2, 3));
 
   // Check that compute items work correctly in the DataBox

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Tags.cpp
@@ -33,6 +33,9 @@ void test_simple_tags() {
       "DetSpatialMetric");
   TestHelpers::db::test_simple_tag<gr::Tags::SqrtDetSpatialMetric<Type>>(
       "SqrtDetSpatialMetric");
+  TestHelpers::db::test_simple_tag<
+      gr::Tags::DerivInverseSpatialMetric<Dim, Frame, Type>>(
+      "DerivInverseSpatialMetric");
   TestHelpers::db::test_simple_tag<gr::Tags::Shift<Dim, Frame, Type>>("Shift");
   TestHelpers::db::test_simple_tag<gr::Tags::Lapse<Type>>("Lapse");
   TestHelpers::db::test_simple_tag<


### PR DESCRIPTION
## Proposed changes

As part of implementing the first order CCZ4 system, this PR adds a function for computing the spatial derivative of the inverse spatial metric.

The motivation for this is to eventually compute quantities such as eq. (14) in this [CCZ4 paper](https://arxiv.org/pdf/1707.09910.pdf), whose future implementation with the conformal inverse metric will be able to use the generic form being implemented in this PR.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
