### PR TITLE
Fix LTS dense output at initial time

### DIFF
--- a/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
@@ -3,6 +3,8 @@
 
 # Executable: EvolveScalarWavePlaneWave2D
 # Check: parse;execute
+# ExpectedOutput:
+#   ScalarWavePlaneWave2DReductions.h5
 
 AnalyticSolution:
   PlaneWave:
@@ -17,7 +19,7 @@ AnalyticSolution:
 PhaseChangeAndTriggers:
 
 Evolution:
-  InitialTime: 0.0
+  InitialTime: &initial_time 0.0
   InitialTimeStep: 0.001
   InitialSlabSize: 0.01
   TimeStepper:
@@ -68,6 +70,12 @@ EventsAndTriggers:
   : - Completion
 
 EventsAndDenseTriggers:
+  # Test LTS dense output at the initial time
+  ? Times:
+      Specified:
+        Values: [*initial_time]
+  : - ObserveErrorNorms:
+        SubfileName: Errors
 
 Observers:
   VolumeFileName: "ScalarWavePlaneWave2DVolume"


### PR DESCRIPTION
There are different requirements for dense output neighbor data right
at the transition from self-start, which the normal receive function
doesn't handle.  Bypass the actual dense output in that case to avoid
the problem.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
