### PR TITLE
Add CCZ4 functions for the gradient of the gradient of the lapse and the divergence of the lapse

### DIFF
--- a/src/Evolution/Systems/Ccz4/CMakeLists.txt
+++ b/src/Evolution/Systems/Ccz4/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   Christoffel.cpp
+  DerivLapse.cpp
   )
 
 spectre_target_headers(
@@ -16,6 +17,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Christoffel.hpp
+  DerivLapse.hpp
   Tags.hpp
   TagsDeclarations.hpp
   )

--- a/src/Evolution/Systems/Ccz4/DerivLapse.cpp
+++ b/src/Evolution/Systems/Ccz4/DerivLapse.cpp
@@ -1,0 +1,80 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Ccz4/DerivLapse.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Ccz4 {
+template <size_t Dim, typename Frame, typename DataType>
+void grad_grad_lapse(
+    const gsl::not_null<tnsr::ij<DataType, Dim, Frame>*> result,
+    const Scalar<DataType>& lapse,
+    const tnsr::Ijj<DataType, Dim, Frame>& christoffel_second_kind,
+    const tnsr::i<DataType, Dim, Frame>& field_a,
+    const tnsr::ij<DataType, Dim, Frame>& d_field_a) noexcept {
+  destructive_resize_components(result, get_size(get(lapse)));
+
+  for (size_t i = 0; i < Dim; ++i) {
+    for (size_t j = 0; j < Dim; ++j) {
+      result->get(i, j) = field_a.get(i) * field_a.get(j) +
+                          0.5 * (d_field_a.get(i, j) + d_field_a.get(j, i));
+      for (size_t k = 0; k < Dim; ++k) {
+        result->get(i, j) -=
+            christoffel_second_kind.get(k, i, j) * field_a.get(k);
+      }
+      result->get(i, j) *= get(lapse);
+    }
+  }
+}
+
+template <size_t Dim, typename Frame, typename DataType>
+tnsr::ij<DataType, Dim, Frame> grad_grad_lapse(
+    const Scalar<DataType>& lapse,
+    const tnsr::Ijj<DataType, Dim, Frame>& christoffel_second_kind,
+    const tnsr::i<DataType, Dim, Frame>& field_a,
+    const tnsr::ij<DataType, Dim, Frame>& d_field_a) noexcept {
+  tnsr::ij<DataType, Dim, Frame> result{};
+  grad_grad_lapse(make_not_null(&result), lapse, christoffel_second_kind,
+                  field_a, d_field_a);
+  return result;
+}
+}  // namespace Ccz4
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                              \
+  template void Ccz4::grad_grad_lapse(                                    \
+      const gsl::not_null<tnsr::ij<DTYPE(data), DIM(data), FRAME(data)>*> \
+          result,                                                         \
+      const Scalar<DTYPE(data)>& lapse,                                   \
+      const tnsr::Ijj<DTYPE(data), DIM(data), FRAME(data)>&               \
+          christoffel_second_kind,                                        \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>& field_a,        \
+      const tnsr::ij<DTYPE(data), DIM(data), FRAME(data)>&                \
+          d_field_a) noexcept;                                            \
+  template tnsr::ij<DTYPE(data), DIM(data), FRAME(data)>                  \
+  Ccz4::grad_grad_lapse(                                                  \
+      const Scalar<DTYPE(data)>& lapse,                                   \
+      const tnsr::Ijj<DTYPE(data), DIM(data), FRAME(data)>&               \
+          christoffel_second_kind,                                        \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>& field_a,        \
+      const tnsr::ij<DTYPE(data), DIM(data), FRAME(data)>&                \
+          d_field_a) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial),
+                        (double, DataVector))
+
+#undef INSTANTIATE
+#undef DTYPE
+#undef FRAME
+#undef DIM

--- a/src/Evolution/Systems/Ccz4/DerivLapse.hpp
+++ b/src/Evolution/Systems/Ccz4/DerivLapse.hpp
@@ -1,0 +1,42 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Ccz4 {
+/// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes the gradient of the gradient of the lapse.
+ *
+ * \details Computes the gradient of the gradient as:
+ * \f{align}
+ *     \nabla_i \nabla_j \alpha &= \alpha A_i A_j -
+ *                 \alpha \Gamma^k{}_{ij} A_k + \alpha \partial_{(i} A_{j)}
+ * \f}
+ * where \f$\alpha\f$, \f$\Gamma^k{}_{ij}\f$, \f$A_i\f$, and
+ * \f$\partial_j A_i\f$ are the lapse, spatial christoffel symbols of the second
+ * kind, the CCZ4 auxiliary variable defined by `Ccz4::Tags::FieldA`, and its
+ * spatial derivative, respectively.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+void grad_grad_lapse(
+    const gsl::not_null<tnsr::ij<DataType, Dim, Frame>*> result,
+    const Scalar<DataType>& lapse,
+    const tnsr::Ijj<DataType, Dim, Frame>& christoffel_second_kind,
+    const tnsr::i<DataType, Dim, Frame>& field_a,
+    const tnsr::ij<DataType, Dim, Frame>& d_field_a) noexcept;
+
+template <size_t Dim, typename Frame, typename DataType>
+tnsr::ij<DataType, Dim, Frame> grad_grad_lapse(
+    const Scalar<DataType>& lapse,
+    const tnsr::Ijj<DataType, Dim, Frame>& christoffel_second_kind,
+    const tnsr::i<DataType, Dim, Frame>& field_a,
+    const tnsr::ij<DataType, Dim, Frame>& d_field_a) noexcept;
+/// @}
+}  // namespace Ccz4

--- a/src/Evolution/Systems/Ccz4/DerivLapse.hpp
+++ b/src/Evolution/Systems/Ccz4/DerivLapse.hpp
@@ -39,4 +39,34 @@ tnsr::ij<DataType, Dim, Frame> grad_grad_lapse(
     const tnsr::i<DataType, Dim, Frame>& field_a,
     const tnsr::ij<DataType, Dim, Frame>& d_field_a) noexcept;
 /// @}
+
+/// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes the divergence of the lapse.
+ *
+ * \details Computes the divergence as:
+ * \f{align}
+ *     \nabla^i \nabla_i \alpha &= \phi^2 \tilde{\gamma}^{ij}
+ *         (\nabla_i \nabla_j \alpha)
+ * \f}
+ * where \f$\phi\f$, \f$\tilde{\gamma}^{ij}\f$, and
+ * \f$\nabla_i \nabla_j \alpha\f$ are the conformal factor, inverse conformal
+ * spatial metric, and the gradient of the gradient of the lapse defined by
+ * `Ccz4::Tags::ConformalFactor`, `Ccz4::Tags::InverseConformalMetric`, and
+ * `Ccz4::Tags::GradGradLapse`, respectively.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+void divergence_lapse(
+    const gsl::not_null<Scalar<DataType>*> result,
+    const Scalar<DataType>& conformal_factor,
+    const tnsr::II<DataType, Dim, Frame>& inverse_conformal_metric,
+    const tnsr::ij<DataType, Dim, Frame>& grad_grad_lapse) noexcept;
+
+template <size_t Dim, typename Frame, typename DataType>
+Scalar<DataType> divergence_lapse(
+    const Scalar<DataType>& conformal_factor,
+    const tnsr::II<DataType, Dim, Frame>& inverse_conformal_metric,
+    const tnsr::ij<DataType, Dim, Frame>& grad_grad_lapse) noexcept;
+/// @}
 }  // namespace Ccz4

--- a/src/Evolution/Systems/Ccz4/Tags.hpp
+++ b/src/Evolution/Systems/Ccz4/Tags.hpp
@@ -152,6 +152,23 @@ template <size_t Dim, typename Frame, typename DataType>
 struct ChristoffelSecondKind : db::SimpleTag {
   using type = tnsr::Ijj<DataType, Dim, Frame>;
 };
+
+/*!
+ * \brief The gradient of the gradient of the lapse
+ *
+ * \details We define:
+ * \f{align}
+ *     \nabla_i \nabla_j \alpha &= \alpha A_i A_j -
+ *                 \alpha \Gamma^k{}_{ij} A_k + \alpha \partial_{(i} A_{j)}
+ * \f}
+ * where \f$\alpha\f$, \f$\Gamma^k{}_{ij}\f$, \f$A_i\f$, and
+ * \f$\partial_j A_i\f$ are the lapse, spatial christoffel symbols of the second
+ * kind, the CCZ4 auxiliary variable defined by `Ccz4::Tags::FieldA`, and its
+ * spatial derivative, respectively.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct GradGradLapse : db::SimpleTag {
+  using type = tnsr::ij<DataType, Dim, Frame>;
 }  // namespace Tags
 
 namespace OptionTags {

--- a/src/Evolution/Systems/Ccz4/Tags.hpp
+++ b/src/Evolution/Systems/Ccz4/Tags.hpp
@@ -169,6 +169,26 @@ struct ChristoffelSecondKind : db::SimpleTag {
 template <size_t Dim, typename Frame, typename DataType>
 struct GradGradLapse : db::SimpleTag {
   using type = tnsr::ij<DataType, Dim, Frame>;
+};
+
+/*!
+ * \brief The divergence of the lapse
+ *
+ * \details We define:
+ * \f{align}
+ *     \nabla^i \nabla_i \alpha &= \phi^2 \tilde{\gamma}^{ij}
+ *         (\nabla_i \nabla_j \alpha)
+ * \f}
+ * where \f$\phi\f$, \f$\tilde{\gamma}^{ij}\f$, and
+ * \f$\nabla_i \nabla_j \alpha\f$ are the conformal factor, inverse conformal
+ * spatial metric, and the gradient of the gradient of the lapse defined by
+ * `Ccz4::Tags::ConformalFactor`, `Ccz4::Tags::InverseConformalMetric`, and
+ * `Ccz4::Tags::GradGradLapse`, respectively.
+ */
+template <typename DataType>
+struct DivergenceLapse : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
 }  // namespace Tags
 
 namespace OptionTags {

--- a/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
@@ -39,6 +39,8 @@ struct ChristoffelSecondKind;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
 struct GradGradLapse;
+template <typename DataType = DataVector>
+struct DivergenceLapse;
 }  // namespace Tags
 
 /// \brief Input option tags for the generalized harmonic evolution system

--- a/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
@@ -36,6 +36,9 @@ struct ConformalChristoffelSecondKind;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
 struct ChristoffelSecondKind;
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
+struct GradGradLapse;
 }  // namespace Tags
 
 /// \brief Input option tags for the generalized harmonic evolution system

--- a/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_Ccz4")
 
 set(LIBRARY_SOURCES
   Test_Christoffel.cpp
+  Test_DerivLapse.cpp
   Test_Tags.cpp
   )
 

--- a/tests/Unit/Evolution/Systems/Ccz4/DerivLapse.py
+++ b/tests/Unit/Evolution/Systems/Ccz4/DerivLapse.py
@@ -9,3 +9,9 @@ def grad_grad_lapse(lapse, christoffel_second_kind, field_a, d_field_a):
             lapse * np.einsum("kij,k", christoffel_second_kind, field_a) +
             0.5 * lapse *
             (np.einsum("ij", d_field_a) + np.einsum("ij->ji", d_field_a)))
+
+
+def divergence_lapse(conformal_factor, inverse_conformal_metric,
+                     grad_grad_lapse):
+    return (conformal_factor * conformal_factor *
+            np.einsum("ij,ij", inverse_conformal_metric, grad_grad_lapse))

--- a/tests/Unit/Evolution/Systems/Ccz4/DerivLapse.py
+++ b/tests/Unit/Evolution/Systems/Ccz4/DerivLapse.py
@@ -1,0 +1,11 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def grad_grad_lapse(lapse, christoffel_second_kind, field_a, d_field_a):
+    return (lapse * np.einsum("i,j", field_a, field_a) -
+            lapse * np.einsum("kij,k", christoffel_second_kind, field_a) +
+            0.5 * lapse *
+            (np.einsum("ij", d_field_a) + np.einsum("ij->ji", d_field_a)))

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_DerivLapse.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_DerivLapse.cpp
@@ -27,6 +27,17 @@ void test_grad_grad_lapse(const DataType& used_for_size) {
           &::Ccz4::grad_grad_lapse<Dim, Frame::Inertial, DataType>),
       "DerivLapse", "grad_grad_lapse", {{{-1., 1.}}}, used_for_size);
 }
+
+template <size_t Dim, typename DataType>
+void test_divergence_lapse(const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(
+      static_cast<Scalar<DataType> (*)(
+          const Scalar<DataType>&,
+          const tnsr::II<DataType, Dim, Frame::Inertial>&,
+          const tnsr::ij<DataType, Dim, Frame::Inertial>&)>(
+          &::Ccz4::divergence_lapse<Dim, Frame::Inertial, DataType>),
+      "DerivLapse", "divergence_lapse", {{{-1., 1.}}}, used_for_size);
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.DerivLapse",
@@ -35,4 +46,5 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.DerivLapse",
 
   GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
   CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_grad_grad_lapse, (1, 2, 3));
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_divergence_lapse, (1, 2, 3));
 }

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_DerivLapse.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_DerivLapse.cpp
@@ -1,0 +1,38 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/Ccz4/DerivLapse.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+template <size_t Dim, typename DataType>
+void test_grad_grad_lapse(const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::ij<DataType, Dim, Frame::Inertial> (*)(
+          const Scalar<DataType>&,
+          const tnsr::Ijj<DataType, Dim, Frame::Inertial>&,
+          const tnsr::i<DataType, Dim, Frame::Inertial>&,
+          const tnsr::ij<DataType, Dim, Frame::Inertial>&)>(
+          &::Ccz4::grad_grad_lapse<Dim, Frame::Inertial, DataType>),
+      "DerivLapse", "grad_grad_lapse", {{{-1., 1.}}}, used_for_size);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.DerivLapse",
+                  "[Evolution][Unit]") {
+  pypp::SetupLocalPythonEnvironment local_python_env("Evolution/Systems/Ccz4/");
+
+  GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_grad_grad_lapse, (1, 2, 3));
+}

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
@@ -41,6 +41,8 @@ void test_simple_tags() {
   TestHelpers::db::test_simple_tag<
       Ccz4::Tags::ChristoffelSecondKind<Dim, Frame, DataType>>(
       "ChristoffelSecondKind");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::GradGradLapse<Dim, Frame, DataType>>("GradGradLapse");
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.Tags", "[Unit][Evolution]") {

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
@@ -43,6 +43,8 @@ void test_simple_tags() {
       "ChristoffelSecondKind");
   TestHelpers::db::test_simple_tag<
       Ccz4::Tags::GradGradLapse<Dim, Frame, DataType>>("GradGradLapse");
+  TestHelpers::db::test_simple_tag<Ccz4::Tags::DivergenceLapse<DataType>>(
+      "DivergenceLapse");
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.Tags", "[Unit][Evolution]") {


### PR DESCRIPTION
## Proposed changes

As part of implementing the first order CCZ4 system, this PR adds functionx for computing:
- the gradient of the gradient of the lapse
- the divergence of the lapse

The motivation for this is to compute eq. (21) and (22) in this [CCZ4 paper](https://arxiv.org/pdf/1707.09910.pdf), whose values will later be necessary for computing the evolved variables.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
