### PR TITLE
Make doxygen installation correct in buildenv

### DIFF
--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -145,12 +145,12 @@ RUN git clone https://github.com/edouarda/brigand.git \
 RUN wget https://github.com/catchorg/Catch2/releases/download/v2.11.1/catch.hpp -O catch.hpp \
     && mv catch.hpp /usr/local/include
 # - Doxygen
-RUN wget https://www.doxygen.nl/files/doxygen-1.9.2.src.tar.gz \
-    && tar -xzf doxygen-1.9.2.src.tar.gz \
-    && cd doxygen-1.9.2 \
+RUN wget https://www.doxygen.nl/files/doxygen-1.9.1.src.tar.gz \
+    && tar -xzf doxygen-1.9.1.src.tar.gz \
+    && cd doxygen-1.9.1 \
     && mkdir build \
     && cd build \
-    && cmake -G "Unix Makefiles" .. \
+    && cmake -G "Unix Makefiles" -D CMAKE_BUILD_TYPE=Release .. \
     && make $PARALLEL_MAKE_ARG \
     && make install \
     && cd ../.. && rm -rf doxygen*


### PR DESCRIPTION
## Proposed changes

The Dockerfile didn't match what we are actually using in deployment.

I noticed 1.9.2 was very slow on my machine, but I also didn't know to specify
Release as the build type (some projects have that be the default).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
