### PR TITLE
Add CCZ4 function for derivivative conformal spatial christoffel second kind

### DIFF
--- a/src/Evolution/Systems/Ccz4/CMakeLists.txt
+++ b/src/Evolution/Systems/Ccz4/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   Christoffel.cpp
+  DerivChristoffel.cpp
   DerivLapse.cpp
   )
 
@@ -17,6 +18,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Christoffel.hpp
+  DerivChristoffel.hpp
   DerivLapse.hpp
   Tags.hpp
   TagsDeclarations.hpp

--- a/src/Evolution/Systems/Ccz4/DerivChristoffel.cpp
+++ b/src/Evolution/Systems/Ccz4/DerivChristoffel.cpp
@@ -1,0 +1,96 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Ccz4/DerivChristoffel.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Ccz4 {
+template <size_t Dim, typename Frame, typename DataType>
+void deriv_conformal_christoffel_second_kind(
+    const gsl::not_null<tnsr::iJkk<DataType, Dim, Frame>*> result,
+    const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
+    const tnsr::ijj<DataType, Dim, Frame>& field_d,
+    const tnsr::ijkk<DataType, Dim, Frame>& d_field_d,
+    const tnsr::iJJ<DataType, Dim, Frame>& field_d_up) noexcept {
+  destructive_resize_components(
+      result, get_size(get<0, 0>(inverse_conformal_spatial_metric)));
+
+  for (size_t i = 0; i < Dim; ++i) {
+    for (size_t j = i; j < Dim; ++j) {
+      for (size_t k = 0; k < Dim; ++k) {
+        for (size_t m = 0; m < Dim; ++m) {
+          (*result).get(k, m, i, j) =
+              -2.0 * field_d_up.get(k, m, 0) *
+                  (field_d.get(i, j, 0) + field_d.get(j, i, 0) -
+                   field_d.get(0, i, j)) +
+              0.5 * inverse_conformal_spatial_metric.get(m, 0) *
+                  (d_field_d.get(k, i, j, 0) + d_field_d.get(i, k, j, 0) +
+                   d_field_d.get(k, j, i, 0) + d_field_d.get(j, k, i, 0) -
+                   d_field_d.get(k, 0, i, j) - d_field_d.get(0, k, i, j));
+          for (size_t l = 1; l < Dim; ++l) {
+            (*result).get(k, m, i, j) +=
+                -2.0 * field_d_up.get(k, m, l) *
+                    (field_d.get(i, j, l) + field_d.get(j, i, l) -
+                     field_d.get(l, i, j)) +
+                0.5 * inverse_conformal_spatial_metric.get(m, l) *
+                    (d_field_d.get(k, i, j, l) + d_field_d.get(i, k, j, l) +
+                     d_field_d.get(k, j, i, l) + d_field_d.get(j, k, i, l) -
+                     d_field_d.get(k, l, i, j) - d_field_d.get(l, k, i, j));
+          }
+        }
+      }
+    }
+  }
+}
+
+template <size_t Dim, typename Frame, typename DataType>
+tnsr::iJkk<DataType, Dim, Frame> deriv_conformal_christoffel_second_kind(
+    const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
+    const tnsr::ijj<DataType, Dim, Frame>& field_d,
+    const tnsr::ijkk<DataType, Dim, Frame>& d_field_d,
+    const tnsr::iJJ<DataType, Dim, Frame>& field_d_up) noexcept {
+  tnsr::iJkk<DataType, Dim, Frame> result{};
+  deriv_conformal_christoffel_second_kind(make_not_null(&result),
+                                          inverse_conformal_spatial_metric,
+                                          field_d, d_field_d, field_d_up);
+  return result;
+}
+}  // namespace Ccz4
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                                \
+  template void Ccz4::deriv_conformal_christoffel_second_kind(              \
+      const gsl::not_null<tnsr::iJkk<DTYPE(data), DIM(data), FRAME(data)>*> \
+          result,                                                           \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                  \
+          inverse_conformal_spatial_metric,                                 \
+      const tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>& field_d,        \
+      const tnsr::ijkk<DTYPE(data), DIM(data), FRAME(data)>& d_field_d,     \
+      const tnsr::iJJ<DTYPE(data), DIM(data), FRAME(data)>&                 \
+          field_d_up) noexcept;                                             \
+  template tnsr::iJkk<DTYPE(data), DIM(data), FRAME(data)>                  \
+  Ccz4::deriv_conformal_christoffel_second_kind(                            \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                  \
+          inverse_conformal_spatial_metric,                                 \
+      const tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>& field_d,        \
+      const tnsr::ijkk<DTYPE(data), DIM(data), FRAME(data)>& d_field_d,     \
+      const tnsr::iJJ<DTYPE(data), DIM(data), FRAME(data)>&                 \
+          field_d_up) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial),
+                        (double, DataVector))
+
+#undef INSTANTIATE
+#undef DTYPE
+#undef FRAME
+#undef DIM

--- a/src/Evolution/Systems/Ccz4/DerivChristoffel.hpp
+++ b/src/Evolution/Systems/Ccz4/DerivChristoffel.hpp
@@ -1,0 +1,46 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Ccz4 {
+/// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes the spatial derivative of the conformal spatial christoffel
+ * symbols of the second kind
+ *
+ * \details Computes the derivative as:
+ * \f{align}
+ *     \partial_k \tilde{\Gamma}^m{}_{ij} &=
+ *       -2 D_k{}^{ml} (D_{ijl} + D_{jil} - D_{lij}) +
+ *       \tilde{\gamma}^{ml}(\partial_{(k} D_{i)jl} + \partial_{(k} D_{j)il} -
+ *       \partial_{(k} D_{l)ij})
+ * \f}
+ * where \f$\tilde{\gamma}^{ij}\f$, \f$D_{ijk}\f$, \f$\partial_l D_{ijk}\f$, and
+ * \f$D_k{}^{ij}\f$ are the inverse conformal spatial metric defined by
+ * `Ccz4::Tags::InverseConformalMetric`, the CCZ4 auxiliary variable defined by
+ * `Ccz4::Tags::FieldD`, its spatial derivative, and the CCZ4 identity defined
+ * by `Ccz4::Tags::FieldDUp`.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+void deriv_conformal_christoffel_second_kind(
+    const gsl::not_null<tnsr::iJkk<DataType, Dim, Frame>*> result,
+    const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
+    const tnsr::ijj<DataType, Dim, Frame>& field_d,
+    const tnsr::ijkk<DataType, Dim, Frame>& d_field_d,
+    const tnsr::iJJ<DataType, Dim, Frame>& field_d_up) noexcept;
+
+template <size_t Dim, typename Frame, typename DataType>
+tnsr::iJkk<DataType, Dim, Frame> deriv_conformal_christoffel_second_kind(
+    const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
+    const tnsr::ijj<DataType, Dim, Frame>& field_d,
+    const tnsr::ijkk<DataType, Dim, Frame>& d_field_d,
+    const tnsr::iJJ<DataType, Dim, Frame>& field_d_up) noexcept;
+/// @}
+}  // namespace Ccz4

--- a/src/Evolution/Systems/Ccz4/Tags.hpp
+++ b/src/Evolution/Systems/Ccz4/Tags.hpp
@@ -93,6 +93,25 @@ struct FieldD : db::SimpleTag {
 };
 
 /*!
+ * \brief Identity which is analytically negative one half the spatial
+ * derivative of the inverse conformal spatial metric
+ *
+ * \details We define:
+ * \f{align}
+ *     D_k{}^{ij} &=
+ *         \tilde{\gamma}^{in} \tilde{\gamma}^{mj} D_{knm} =
+ *         -\frac{1}{2} \partial_k \tilde{\gamma}^{ij}
+ * \f}
+ * where \f$\tilde{\gamma}^{ij}\f$ and \f$D_{ijk}\f$ are the inverse conformal
+ * spatial metric and the CCZ4 auxiliary variable defined by
+ * `Ccz4::Tags::FieldD`, respectively.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct FieldDUp : db::SimpleTag {
+  using type = tnsr::iJJ<DataType, Dim, Frame>;
+};
+
+/*!
  * \brief The natural log of the conformal factor
  */
 template <typename DataType>
@@ -151,6 +170,28 @@ struct ConformalChristoffelSecondKind : db::SimpleTag {
 template <size_t Dim, typename Frame, typename DataType>
 struct ChristoffelSecondKind : db::SimpleTag {
   using type = tnsr::Ijj<DataType, Dim, Frame>;
+};
+
+/*!
+ * \brief The spatial derivative of the conformal spatial christoffel symbols
+ * of the second kind
+ *
+ * \details We define:
+ * \f{align}
+ *     \partial_k \tilde{\Gamma}^m{}_{ij} &=
+ *       -2 D_k{}^{ml} (D_{ijl} + D_{jil} - D_{lij}) +
+ *       \tilde{\gamma}^{ml}(\partial_{(k} D_{i)jl} + \partial_{(k} D_{j)il} -
+ *       \partial_{(k} D_{l)ij})
+ * \f}
+ * where \f$\tilde{\gamma}^{ij}\f$, \f$D_{ijk}\f$, \f$\partial_l D_{ijk}\f$, and
+ * \f$D_k{}^{ij}\f$ are the inverse conformal spatial metric defined by
+ * `Ccz4::Tags::InverseConformalMetric`, the CCZ4 auxiliary variable defined by
+ * `Ccz4::Tags::FieldD`, its spatial derivative, and the CCZ4 identity defined
+ * by `Ccz4::Tags::FieldDUp`.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct DerivConformalChristoffelSecondKind : db::SimpleTag {
+  using type = tnsr::iJkk<DataType, Dim, Frame>;
 };
 
 /*!

--- a/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
@@ -25,6 +25,9 @@ struct FieldB;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
 struct FieldD;
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
+struct FieldDUp;
 template <typename DataType = DataVector>
 struct LogConformalFactor;
 template <size_t Dim, typename Frame = Frame::Inertial,
@@ -36,6 +39,9 @@ struct ConformalChristoffelSecondKind;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
 struct ChristoffelSecondKind;
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
+struct DerivConformalChristoffelSecondKind;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
 struct GradGradLapse;

--- a/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_Ccz4")
 
 set(LIBRARY_SOURCES
   Test_Christoffel.cpp
+  Test_DerivChristoffel.cpp
   Test_DerivLapse.cpp
   Test_Tags.cpp
   )

--- a/tests/Unit/Evolution/Systems/Ccz4/DerivChristoffel.py
+++ b/tests/Unit/Evolution/Systems/Ccz4/DerivChristoffel.py
@@ -1,0 +1,18 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def deriv_conformal_christoffel_second_kind(inverse_conformal_spatial_metric,
+                                            field_d, d_field_d, field_d_up):
+    return (
+        -2.0 * np.einsum("kml,ijl->kmij", field_d_up,
+                         (np.einsum("ijl", field_d) + np.einsum(
+                             "jil", field_d) - np.einsum("lij", field_d))) +
+        np.einsum(
+            "ml,ijkl->kmij", inverse_conformal_spatial_metric,
+            (np.einsum("kijl", d_field_d) + np.einsum("ikjl", d_field_d) +
+             np.einsum("kjil", d_field_d) + np.einsum("jkil", d_field_d) -
+             np.einsum("klij", d_field_d) - np.einsum("lkij", d_field_d))) /
+        2.0)

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_DerivChristoffel.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_DerivChristoffel.cpp
@@ -1,0 +1,40 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/Ccz4/DerivChristoffel.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+template <size_t Dim, typename DataType>
+void test_compute_deriv_conformal_christoffel_second_kind(
+    const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::iJkk<DataType, Dim, Frame::Inertial> (*)(
+          const tnsr::II<DataType, Dim, Frame::Inertial>&,
+          const tnsr::ijj<DataType, Dim, Frame::Inertial>&,
+          const tnsr::ijkk<DataType, Dim, Frame::Inertial>&,
+          const tnsr::iJJ<DataType, Dim, Frame::Inertial>&) noexcept>(
+          &Ccz4::deriv_conformal_christoffel_second_kind<Dim, Frame::Inertial,
+                                                         DataType>),
+      "DerivChristoffel", "deriv_conformal_christoffel_second_kind",
+      {{{-1., 1.}}}, used_for_size);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.DerivChristoffel",
+                  "[PointwiseFunctions][Unit]") {
+  pypp::SetupLocalPythonEnvironment local_python_env("Evolution/Systems/Ccz4/");
+
+  GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(
+      test_compute_deriv_conformal_christoffel_second_kind, (1, 2, 3));
+}

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
@@ -31,6 +31,8 @@ void test_simple_tags() {
       Ccz4::Tags::FieldB<Dim, Frame, DataType>>("FieldB");
   TestHelpers::db::test_simple_tag<Ccz4::Tags::FieldD<Dim, Frame, DataType>>(
       "FieldD");
+  TestHelpers::db::test_simple_tag<Ccz4::Tags::FieldDUp<Dim, Frame, DataType>>(
+      "FieldDUp");
   TestHelpers::db::test_simple_tag<Ccz4::Tags::LogConformalFactor<DataType>>(
       "LogConformalFactor");
   TestHelpers::db::test_simple_tag<Ccz4::Tags::FieldP<Dim, Frame, DataType>>(
@@ -41,6 +43,9 @@ void test_simple_tags() {
   TestHelpers::db::test_simple_tag<
       Ccz4::Tags::ChristoffelSecondKind<Dim, Frame, DataType>>(
       "ChristoffelSecondKind");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::DerivConformalChristoffelSecondKind<Dim, Frame, DataType>>(
+      "DerivConformalChristoffelSecondKind");
   TestHelpers::db::test_simple_tag<
       Ccz4::Tags::GradGradLapse<Dim, Frame, DataType>>("GradGradLapse");
   TestHelpers::db::test_simple_tag<Ccz4::Tags::DivergenceLapse<DataType>>(


### PR DESCRIPTION
## Proposed changes

As part of implementing the first order CCZ4 system, this PR adds a function for computing the spatial derivative of the conformal spatial christoffel symbols of the second kind.

The motivation for this is to compute eq. (16) in this [CCZ4 paper](https://arxiv.org/pdf/1707.09910.pdf), whose value will later be necessary for computing the evolved variables.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
