### PR TITLE
Add CCZ4 functions for christoffel 2nd kind and conformal christoffel 2nd kind

### DIFF
--- a/src/Evolution/Systems/Ccz4/CMakeLists.txt
+++ b/src/Evolution/Systems/Ccz4/CMakeLists.txt
@@ -1,10 +1,31 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+set(LIBRARY Ccz4)
+
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  Christoffel.cpp
+  )
+
 spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  Christoffel.hpp
   Tags.hpp
   TagsDeclarations.hpp
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  DataStructures
+  GeneralRelativity
+  Options
+  Utilities
+  INTERFACE
   )

--- a/src/Evolution/Systems/Ccz4/Christoffel.cpp
+++ b/src/Evolution/Systems/Ccz4/Christoffel.cpp
@@ -1,0 +1,63 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Ccz4/Christoffel.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Ccz4 {
+template <size_t Dim, typename Frame, typename DataType>
+void conformal_christoffel_second_kind(
+    const gsl::not_null<tnsr::Ijj<DataType, Dim, Frame>*> result,
+    const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
+    const tnsr::ijj<DataType, Dim, Frame>& field_d) noexcept {
+  destructive_resize_components(
+      result, get_size(get<0, 0>(inverse_conformal_spatial_metric)));
+
+  ::TensorExpressions::evaluate<ti_K, ti_i, ti_j>(
+      result, inverse_conformal_spatial_metric(ti_K, ti_L) *
+                  (field_d(ti_i, ti_j, ti_l) + field_d(ti_j, ti_i, ti_l) -
+                   field_d(ti_l, ti_i, ti_j)));
+}
+
+template <size_t Dim, typename Frame, typename DataType>
+tnsr::Ijj<DataType, Dim, Frame> conformal_christoffel_second_kind(
+    const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
+    const tnsr::ijj<DataType, Dim, Frame>& field_d) noexcept {
+  tnsr::Ijj<DataType, Dim, Frame> result{};
+  conformal_christoffel_second_kind(make_not_null(&result),
+                                    inverse_conformal_spatial_metric, field_d);
+  return result;
+}
+}  // namespace Ccz4
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                                   \
+  template void Ccz4::conformal_christoffel_second_kind(                       \
+      const gsl::not_null<tnsr::Ijj<DTYPE(data), DIM(data), FRAME(data)>*>     \
+          result,                                                              \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                     \
+          inverse_conformal_spatial_metric,                                    \
+      const tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>& field_d) noexcept; \
+  template tnsr::Ijj<DTYPE(data), DIM(data), FRAME(data)>                      \
+  Ccz4::conformal_christoffel_second_kind(                                     \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                     \
+          inverse_conformal_spatial_metric,                                    \
+      const tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>& field_d) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial),
+                        (double, DataVector))
+
+#undef INSTANTIATE
+#undef DTYPE
+#undef FRAME
+#undef DIM

--- a/src/Evolution/Systems/Ccz4/Christoffel.cpp
+++ b/src/Evolution/Systems/Ccz4/Christoffel.cpp
@@ -35,6 +35,39 @@ tnsr::Ijj<DataType, Dim, Frame> conformal_christoffel_second_kind(
                                     inverse_conformal_spatial_metric, field_d);
   return result;
 }
+
+template <size_t Dim, typename Frame, typename DataType>
+void christoffel_second_kind(
+    const gsl::not_null<tnsr::Ijj<DataType, Dim, Frame>*> result,
+    const tnsr::ii<DataType, Dim, Frame>& conformal_spatial_metric,
+    const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
+    const tnsr::i<DataType, Dim, Frame>& field_p,
+    const tnsr::Ijj<DataType, Dim, Frame>&
+        conformal_christoffel_second_kind) noexcept {
+  destructive_resize_components(result,
+                                get_size(get<0, 0>(conformal_spatial_metric)));
+
+  ::TensorExpressions::evaluate<ti_K, ti_i, ti_j>(
+      result, conformal_christoffel_second_kind(ti_K, ti_i, ti_j) -
+                  inverse_conformal_spatial_metric(ti_K, ti_L) *
+                      (conformal_spatial_metric(ti_j, ti_l) * field_p(ti_i) +
+                       conformal_spatial_metric(ti_i, ti_l) * field_p(ti_j) -
+                       conformal_spatial_metric(ti_i, ti_j) * field_p(ti_l)));
+}
+
+template <size_t Dim, typename Frame, typename DataType>
+tnsr::Ijj<DataType, Dim, Frame> christoffel_second_kind(
+    const tnsr::ii<DataType, Dim, Frame>& conformal_spatial_metric,
+    const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
+    const tnsr::i<DataType, Dim, Frame>& field_p,
+    const tnsr::Ijj<DataType, Dim, Frame>&
+        conformal_christoffel_second_kind) noexcept {
+  tnsr::Ijj<DataType, Dim, Frame> result{};
+  christoffel_second_kind(make_not_null(&result), conformal_spatial_metric,
+                          inverse_conformal_spatial_metric, field_p,
+                          conformal_christoffel_second_kind);
+  return result;
+}
 }  // namespace Ccz4
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
@@ -52,7 +85,26 @@ tnsr::Ijj<DataType, Dim, Frame> conformal_christoffel_second_kind(
   Ccz4::conformal_christoffel_second_kind(                                     \
       const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                     \
           inverse_conformal_spatial_metric,                                    \
-      const tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>& field_d) noexcept;
+      const tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>& field_d) noexcept; \
+  template void Ccz4::christoffel_second_kind(                                 \
+      const gsl::not_null<tnsr::Ijj<DTYPE(data), DIM(data), FRAME(data)>*>     \
+          result,                                                              \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&                     \
+          conformal_spatial_metric,                                            \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                     \
+          inverse_conformal_spatial_metric,                                    \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>& field_p,             \
+      const tnsr::Ijj<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          conformal_christoffel_second_kind) noexcept;                         \
+  template tnsr::Ijj<DTYPE(data), DIM(data), FRAME(data)>                      \
+  Ccz4::christoffel_second_kind(                                               \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&                     \
+          conformal_spatial_metric,                                            \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                     \
+          inverse_conformal_spatial_metric,                                    \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>& field_p,             \
+      const tnsr::Ijj<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          conformal_christoffel_second_kind) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial),
                         (double, DataVector))

--- a/src/Evolution/Systems/Ccz4/Christoffel.hpp
+++ b/src/Evolution/Systems/Ccz4/Christoffel.hpp
@@ -34,4 +34,42 @@ tnsr::Ijj<DataType, Dim, Frame> conformal_christoffel_second_kind(
     const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
     const tnsr::ijj<DataType, Dim, Frame>& field_d) noexcept;
 /// @}
+
+/// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes the spatial christoffel symbols of the second kind.
+ *
+ * \details Computes the christoffel symbols as:
+ * \f{align}
+ *     \Gamma^k_{ij} &= \tilde{\Gamma}^k_{ij} -
+ *         \tilde{\gamma}^{kl} (\tilde{\gamma}_{jl} P_i +
+ *                              \tilde{\gamma}_{il} P_j -
+ *                              \tilde{\gamma}_{ij} P_l)
+ * \f}
+ * where \f$\tilde{\gamma}^{ij}\f$, \f$\tilde{\gamma}_{ij}\f$,
+ * \f$\tilde{\Gamma}^k_{ij}\f$, and \f$P_i\f$ are the conformal spatial metric,
+ * the inverse conformal spatial metric, the conformal spatial christoffel
+ * symbols of the second kind, and the CCZ4 auxiliary variable defined by
+ * `Ccz4::Tags::ConformalMetric`, `Ccz4::Tags::InverseConformalMetric`,
+ * `Ccz4::Tags::ConformalChristoffelSecondKind`, and `Ccz4::Tags::FieldP`,
+ * respectively.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+void christoffel_second_kind(
+    const gsl::not_null<tnsr::Ijj<DataType, Dim, Frame>*> result,
+    const tnsr::ii<DataType, Dim, Frame>& conformal_spatial_metric,
+    const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
+    const tnsr::i<DataType, Dim, Frame>& field_p,
+    const tnsr::Ijj<DataType, Dim, Frame>&
+        conformal_christoffel_second_kind) noexcept;
+
+template <size_t Dim, typename Frame, typename DataType>
+tnsr::Ijj<DataType, Dim, Frame> christoffel_second_kind(
+    const tnsr::ii<DataType, Dim, Frame>& conformal_spatial_metric,
+    const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
+    const tnsr::i<DataType, Dim, Frame>& field_p,
+    const tnsr::Ijj<DataType, Dim, Frame>&
+        conformal_christoffel_second_kind) noexcept;
+/// @}
 }  // namespace Ccz4

--- a/src/Evolution/Systems/Ccz4/Christoffel.hpp
+++ b/src/Evolution/Systems/Ccz4/Christoffel.hpp
@@ -1,0 +1,37 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Ccz4 {
+/// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes the conformal spatial christoffel symbols of the second kind.
+ *
+ * \details Computes the christoffel symbols as:
+ * \f{align}
+ *     \tilde{\Gamma}^k_{ij} &=
+ *         \tilde{\gamma}^{kl} (D_{ijl} + D_{jil} - D_{lij})
+ * \f}
+ * where \f$\tilde{\gamma}^{ij}\f$ and \f$D_{ijk}\f$ are the inverse conformal
+ * spatial metric and the CCZ4 auxiliary variable defined by
+ * `Ccz4::Tags::InverseConformalMetric` and `Ccz4::Tags::FieldD`, respectively.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+void conformal_christoffel_second_kind(
+    const gsl::not_null<tnsr::Ijj<DataType, Dim, Frame>*> result,
+    const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
+    const tnsr::ijj<DataType, Dim, Frame>& field_d) noexcept;
+
+template <size_t Dim, typename Frame, typename DataType>
+tnsr::Ijj<DataType, Dim, Frame> conformal_christoffel_second_kind(
+    const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
+    const tnsr::ijj<DataType, Dim, Frame>& field_d) noexcept;
+/// @}
+}  // namespace Ccz4

--- a/src/Evolution/Systems/Ccz4/Tags.hpp
+++ b/src/Evolution/Systems/Ccz4/Tags.hpp
@@ -128,6 +128,30 @@ template <size_t Dim, typename Frame, typename DataType>
 struct ConformalChristoffelSecondKind : db::SimpleTag {
   using type = tnsr::Ijj<DataType, Dim, Frame>;
 };
+
+/*!
+ * \brief The spatial christoffel symbols of the second kind
+ *
+ * \details We define:
+ * \details Computes the christoffel symbols as:
+ * \f{align}
+ *     \Gamma^k_{ij} &= \tilde{\Gamma}^k_{ij} -
+ *         \tilde{\gamma}^{kl} (\tilde{\gamma}_{jl} P_i +
+ *                              \tilde{\gamma}_{il} P_j -
+ *                              \tilde{\gamma}_{ij} P_l)
+ * \f}
+ * where \f$\tilde{\gamma}^{ij}\f$, \f$\tilde{\gamma}_{ij}\f$,
+ * \f$\tilde{\Gamma}^k_{ij}\f$, and \f$P_i\f$ are the conformal spatial metric,
+ * the inverse conformal spatial metric, the conformal spatial christoffel
+ * symbols of the second kind, and the CCZ4 auxiliary variable defined by
+ * `Ccz4::Tags::ConformalMetric`, `Ccz4::Tags::InverseConformalMetric`,
+ * `Ccz4::Tags::ConformalChristoffelSecondKind`, and `Ccz4::Tags::FieldP`,
+ * respectively.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct ChristoffelSecondKind : db::SimpleTag {
+  using type = tnsr::Ijj<DataType, Dim, Frame>;
+};
 }  // namespace Tags
 
 namespace OptionTags {

--- a/src/Evolution/Systems/Ccz4/Tags.hpp
+++ b/src/Evolution/Systems/Ccz4/Tags.hpp
@@ -111,6 +111,23 @@ template <size_t Dim, typename Frame, typename DataType>
 struct FieldP : db::SimpleTag {
   using type = tnsr::i<DataType, Dim, Frame>;
 };
+
+/*!
+ * \brief The conformal spatial christoffel symbols of the second kind
+ *
+ * \details We define:
+ * \f{align}
+ *     \tilde{\Gamma}^k_{ij} &=
+ *         \tilde{\gamma}^{kl} (D_{ijl} + D_{jil} - D_{lij})
+ * \f}
+ * where \f$\tilde{\gamma}^{ij}\f$ and \f$D_{ijk}\f$ are the inverse conformal
+ * spatial metric and the CCZ4 auxiliary variable defined by
+ * `Ccz4::Tags::InverseConformalMetric` and `Ccz4::Tags::FieldD`, respectively.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct ConformalChristoffelSecondKind : db::SimpleTag {
+  using type = tnsr::Ijj<DataType, Dim, Frame>;
+};
 }  // namespace Tags
 
 namespace OptionTags {

--- a/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
@@ -33,6 +33,9 @@ struct FieldP;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
 struct ConformalChristoffelSecondKind;
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
+struct ChristoffelSecondKind;
 }  // namespace Tags
 
 /// \brief Input option tags for the generalized harmonic evolution system

--- a/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
@@ -30,6 +30,9 @@ struct LogConformalFactor;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
 struct FieldP;
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
+struct ConformalChristoffelSecondKind;
 }  // namespace Tags
 
 /// \brief Input option tags for the generalized harmonic evolution system

--- a/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_Ccz4")
 
 set(LIBRARY_SOURCES
+  Test_Christoffel.cpp
   Test_Tags.cpp
   )
 
@@ -11,5 +12,5 @@ add_test_library(
   ${LIBRARY}
   "Evolution/Systems/Ccz4/"
   "${LIBRARY_SOURCES}"
-  "DataBoxTestHelpers;DataStructures"
+  "Ccz4;DataBoxTestHelpers;DataStructures;Utilities"
   )

--- a/tests/Unit/Evolution/Systems/Ccz4/Christoffel.py
+++ b/tests/Unit/Evolution/Systems/Ccz4/Christoffel.py
@@ -9,3 +9,14 @@ def conformal_christoffel_second_kind(inverse_conformal_spatial_metric,
     return np.einsum("kl,ijl->kij", inverse_conformal_spatial_metric,
                      (np.einsum("ijl", field_d) + np.einsum("jil", field_d) -
                       np.einsum("lij", field_d)))
+
+
+def christoffel_second_kind(conformal_spatial_metric,
+                            inverse_conformal_spatial_metric, field_p,
+                            conformal_christoffel_second_kind):
+    return (
+        np.einsum("kij->kij", conformal_christoffel_second_kind) -
+        (np.einsum("kl,ijl->kij", inverse_conformal_spatial_metric,
+                   (np.einsum("jl,i", conformal_spatial_metric, field_p) +
+                    np.einsum("il,j", conformal_spatial_metric, field_p) -
+                    np.einsum("ij,l", conformal_spatial_metric, field_p)))))

--- a/tests/Unit/Evolution/Systems/Ccz4/Christoffel.py
+++ b/tests/Unit/Evolution/Systems/Ccz4/Christoffel.py
@@ -1,0 +1,11 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def conformal_christoffel_second_kind(inverse_conformal_spatial_metric,
+                                      field_d):
+    return np.einsum("kl,ijl->kij", inverse_conformal_spatial_metric,
+                     (np.einsum("ijl", field_d) + np.einsum("jil", field_d) -
+                      np.einsum("lij", field_d)))

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_Christoffel.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_Christoffel.cpp
@@ -27,6 +27,18 @@ void test_conformal_christoffel_second_kind(const DataType& used_for_size) {
       "Christoffel", "conformal_christoffel_second_kind", {{{-1., 1.}}},
       used_for_size);
 }
+
+template <size_t Dim, typename DataType>
+void test_christoffel_second_kind(const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::Ijj<DataType, Dim, Frame::Inertial> (*)(
+          const tnsr::ii<DataType, Dim, Frame::Inertial>&,
+          const tnsr::II<DataType, Dim, Frame::Inertial>&,
+          const tnsr::i<DataType, Dim, Frame::Inertial>&,
+          const tnsr::Ijj<DataType, Dim, Frame::Inertial>&)>(
+          &::Ccz4::christoffel_second_kind<Dim, Frame::Inertial, DataType>),
+      "Christoffel", "christoffel_second_kind", {{{-1., 1.}}}, used_for_size);
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.Christoffel",
@@ -36,4 +48,5 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.Christoffel",
   GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
   CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_conformal_christoffel_second_kind,
                                     (1, 2, 3));
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_christoffel_second_kind, (1, 2, 3));
 }

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_Christoffel.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_Christoffel.cpp
@@ -1,0 +1,39 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/Ccz4/Christoffel.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+template <size_t Dim, typename DataType>
+void test_conformal_christoffel_second_kind(const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::Ijj<DataType, Dim, Frame::Inertial> (*)(
+          const tnsr::II<DataType, Dim, Frame::Inertial>&,
+          const tnsr::ijj<DataType, Dim, Frame::Inertial>&)>(
+          &::Ccz4::conformal_christoffel_second_kind<Dim, Frame::Inertial,
+                                                     DataType>),
+      "Christoffel", "conformal_christoffel_second_kind", {{{-1., 1.}}},
+      used_for_size);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.Christoffel",
+                  "[Evolution][Unit]") {
+  pypp::SetupLocalPythonEnvironment local_python_env("Evolution/Systems/Ccz4/");
+
+  GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_conformal_christoffel_second_kind,
+                                    (1, 2, 3));
+}

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
@@ -35,6 +35,9 @@ void test_simple_tags() {
       "LogConformalFactor");
   TestHelpers::db::test_simple_tag<Ccz4::Tags::FieldP<Dim, Frame, DataType>>(
       "FieldP");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::ConformalChristoffelSecondKind<Dim, Frame, DataType>>(
+      "ConformalChristoffelSecondKind");
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.Tags", "[Unit][Evolution]") {

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
@@ -38,6 +38,9 @@ void test_simple_tags() {
   TestHelpers::db::test_simple_tag<
       Ccz4::Tags::ConformalChristoffelSecondKind<Dim, Frame, DataType>>(
       "ConformalChristoffelSecondKind");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::ChristoffelSecondKind<Dim, Frame, DataType>>(
+      "ChristoffelSecondKind");
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.Tags", "[Unit][Evolution]") {


### PR DESCRIPTION
## Proposed changes

As part of implementing the first order CCZ4 system, this PR adds a function for computing:
- the conformal spatial christoffel symbols of the second kind
- the spatial christoffel symbols of the second kind

The motivation for this is to compute equations (15) and (17) in this [CCZ4 paper](https://arxiv.org/pdf/1707.09910.pdf), whose values will be used in the future implementation of computing evolution quantities.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
