### PR TITLE
Update ocean doxygen to 1.9.1

### DIFF
--- a/support/Environments/ocean_clang.sh
+++ b/support/Environments/ocean_clang.sh
@@ -37,6 +37,7 @@ spectre_unload_modules() {
     module unload openblas-0.3.4-gcc-7.3.0-tt2coe7
     module unload python/3.9.5
     module unload charm-6.10.2-libs
+    module unload doxygen-1.9.1-gcc-7.3.0-nxmwu4a
 }
 
 spectre_load_modules() {
@@ -61,6 +62,7 @@ spectre_load_modules() {
     module load hdf5-1.12.0-gcc-7.3.0-mknp6xv
     module load openblas-0.3.4-gcc-7.3.0-tt2coe7
     module load charm-6.10.2-libs
+    module load doxygen-1.9.1-gcc-7.3.0-nxmwu4a
 }
 
 spectre_run_cmake() {


### PR DESCRIPTION
## Proposed changes

Update ocean oxygen to 1.9.1, so that users can render documentation after #3412. I verified that I can build the docs in #3412 successfully on ocean with this commit's version of `ocean_clang.sh`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
