### PR TITLE
Remove initialization_tags in InitializeInterpolationTarget.

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/InitializeInterpolationTarget.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InitializeInterpolationTarget.hpp
@@ -14,6 +14,8 @@
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 #include "Utilities/TypeTraits.hpp"
+#include "Utilities/TypeTraits/CreateGetTypeAliasOrDefault.hpp"
+#include "Utilities/TypeTraits/CreateIsCallable.hpp"
 
 /// \cond
 // IWYU pragma: no_forward_declare db::DataBox
@@ -28,66 +30,16 @@ namespace intrp {
 /// Holds Actions for Interpolator and InterpolationTarget.
 namespace Actions {
 
-// The purpose of the functions and metafunctions in this
-// namespace is to allow InterpolationTarget::compute_target_points
-// to omit an initialize function and a initialization_tags
-// type alias if it doesn't add anything to the DataBox.
+// The purpose of the metafunctions in this namespace is to allow
+// InterpolationTarget::compute_target_points to omit an initialize
+// function and a compute_tags and simple_tags type alias if it
+// doesn't add anything to the DataBox.
 namespace initialize_interpolation_target_detail {
 
-// Sets type to initialization_tags, or
-// to empty list if initialization_tags is not defined.
-template <typename T, typename = std::void_t<>>
-struct initialization_tags {
-  using type = tmpl::list<>;
-};
-
-template <typename T>
-struct initialization_tags<
-    T, std::void_t<typename T::compute_target_points::initialization_tags>> {
-  using type = typename T::compute_target_points::initialization_tags;
-};
-
-// Tests whether T::compute_target_points has a non-empty
-// initialization_tags member.
-template <typename T>
-constexpr bool has_empty_initialization_tags_v =
-    tmpl::size<typename initialization_tags<T>::type>::value == 0;
-
-// Calls initialization function only if initialization_tags is defined
-// and non-empty; otherwise just moves the box.
-template <
-    typename InterpolationTargetTag, typename DbTags, typename Metavariables,
-    Requires<not has_empty_initialization_tags_v<InterpolationTargetTag>> =
-        nullptr>
-void mutate_initial_box(
-    const gsl::not_null<db::DataBox<DbTags>*> box,
-    const Parallel::GlobalCache<Metavariables>& cache) noexcept {
-  InterpolationTargetTag::compute_target_points::initialize(box, cache);
-}
-
-template <
-    typename InterpolationTargetTag, typename DbTags, typename Metavariables,
-    Requires<has_empty_initialization_tags_v<InterpolationTargetTag>> = nullptr>
-void mutate_initial_box(
-    const gsl::not_null<db::DataBox<DbTags>*> /*box*/,
-    const Parallel::GlobalCache<Metavariables>& /*cache*/) noexcept {}
-
-template <typename InterpolationTargetTag, typename = std::void_t<>,
-          bool = not has_empty_initialization_tags_v<InterpolationTargetTag>>
-struct compute_target_points_tags {
-  using simple_tags = tmpl::list<>;
-  using compute_tags = tmpl::list<>;
-};
-
-template <typename InterpolationTargetTag>
-struct compute_target_points_tags<
-    InterpolationTargetTag,
-    std::void_t<typename InterpolationTargetTag::compute_target_points>, true> {
-  using simple_tags =
-      typename InterpolationTargetTag::compute_target_points::simple_tags;
-  using compute_tags =
-      typename InterpolationTargetTag::compute_target_points::compute_tags;
-};
+CREATE_GET_TYPE_ALIAS_OR_DEFAULT(compute_tags)
+CREATE_GET_TYPE_ALIAS_OR_DEFAULT(simple_tags)
+CREATE_IS_CALLABLE(initialize)
+CREATE_IS_CALLABLE_V(initialize)
 
 }  // namespace initialize_interpolation_target_detail
 
@@ -125,18 +77,15 @@ struct InitializeInterpolationTarget {
       Tags::InterpolatedVars<InterpolationTargetTag, TemporalId>,
       ::Tags::Variables<
           typename InterpolationTargetTag::vars_to_interpolate_to_target>>;
-  using return_tag_list =
-      tmpl::append<return_tag_list_initial,
-                   typename initialize_interpolation_target_detail::
-                       initialization_tags<InterpolationTargetTag>::type>;
 
   using simple_tags = tmpl::append<
       return_tag_list_initial,
-      typename initialize_interpolation_target_detail::
-          compute_target_points_tags<InterpolationTargetTag>::simple_tags>;
+      initialize_interpolation_target_detail::get_simple_tags_or_default_t<
+          typename InterpolationTargetTag::compute_target_points,
+          tmpl::list<>>>;
   using compute_tags = tmpl::append<
-      typename initialize_interpolation_target_detail::
-          compute_target_points_tags<InterpolationTargetTag>::compute_tags,
+      initialize_interpolation_target_detail::get_compute_tags_or_default_t<
+          typename InterpolationTargetTag::compute_target_points, tmpl::list<>>,
       typename InterpolationTargetTag::compute_items_on_target>;
 
   template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
@@ -147,8 +96,14 @@ struct InitializeInterpolationTarget {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    initialize_interpolation_target_detail::mutate_initial_box<
-        InterpolationTargetTag>(make_not_null(&box), cache);
+    if constexpr (
+        initialize_interpolation_target_detail::is_initialize_callable_v<
+            typename InterpolationTargetTag::compute_target_points,
+            const gsl::not_null<db::DataBox<DbTagsList>*>,
+            const Parallel::GlobalCache<Metavariables>&>) {
+      InterpolationTargetTag::compute_target_points::initialize(
+          make_not_null(&box), cache);
+    }
     return std::make_tuple(std::move(box));
   }
 };

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
@@ -141,12 +141,6 @@ template <typename InterpolationTargetTag, typename Frame>
 struct ApparentHorizon {
   using const_global_cache_tags =
       tmpl::list<Tags::ApparentHorizon<InterpolationTargetTag, Frame>>;
-  using initialization_tags =
-      tmpl::append<StrahlkorperTags::items_tags<Frame>,
-                   tmpl::list<::ah::Tags::FastFlow,
-                              logging::Tags::Verbosity<InterpolationTargetTag>,
-                              ::ah::Tags::PreviousStrahlkorper<Frame>>,
-                   StrahlkorperTags::compute_items_tags<Frame>>;
   using is_sequential = std::true_type;
   using frame = Frame;
 

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.hpp
@@ -154,9 +154,6 @@ template <typename InterpolationTargetTag, typename Frame>
 struct KerrHorizon {
   using const_global_cache_tags =
       tmpl::list<Tags::KerrHorizon<InterpolationTargetTag>>;
-  using initialization_tags =
-      tmpl::append<StrahlkorperTags::items_tags<Frame>,
-                   StrahlkorperTags::compute_items_tags<Frame>>;
   using is_sequential = std::false_type;
   using frame = Frame;
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
@@ -49,6 +49,10 @@ struct Metavariables {
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
     using compute_items_on_target = tmpl::list<>;
+    // InterpolationTargets must have compute_target_points defined.
+    // But for this test, compute_target_points is not actually used
+    // so we can just define it to be any random type. Choose void.
+    using compute_target_points = void;
   };
 
   using component_list = tmpl::list<

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
@@ -151,6 +151,10 @@ struct Metavariables {
         tmpl::list<gr::Tags::Lapse<DataVector>>;
     using compute_items_on_source = tmpl::list<>;
     using compute_items_on_target = tmpl::list<>;
+    // InterpolationTargets must have compute_target_points defined.
+    // But for this test, compute_target_points is not actually used
+    // so we can just define it to be any random type. Choose void.
+    using compute_target_points = void;
   };
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
@@ -218,6 +218,10 @@ struct MockMetavariables {
     using vars_to_interpolate_to_target = tmpl::list<Tags::Square>;
     using compute_vars_to_interpolate = ComputeSquare;
     using compute_items_on_target = tmpl::list<>;
+    // InterpolationTargets must have compute_target_points defined.
+    // But for this test, compute_target_points is not actually used
+    // so we can just define it to be any random type. Choose void.
+    using compute_target_points = void;
   };
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;


### PR DESCRIPTION
initialization_tags was a relic of an older way of initializing
things in the DataBox, and apparently InitializeInterpolationTarget
was never fully upgraded when those changes were made.

So now:
 - initialization_tags is gone from InitializeInterpolationTarget
   and from the InterpolationTargets that still defined
   their own initialization_tags.
 - The metafunctions at the top of InitializeInterpolationTarget
   have been greatly simplified.
 - Every InterpolationTarget now must define compute_target_points.
   This has always been true for all fully-functional InterpolationTargets,
   but it was not true for some of the InterpolationTargets in the tests
   (in cases where a test cared only about some small subset of the
   functionality of InterpolationTarget).  It simplifies the
   metafunction logic in InitializeInterpolationTarget if one can assume
   that compute_target_points is always defined.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
