### PR TITLE
Print Charm++ startup time

### DIFF
--- a/src/Informer/Informer.cpp
+++ b/src/Informer/Informer.cpp
@@ -15,9 +15,10 @@ void Informer::print_startup_info(CkArgMsg* msg) {
   Parallel::printf(
       "\n"
       "Executing '%s' using %d processors.\n"
+      "Charm++ startup time in seconds: %f\n"
       "Date and time at startup: %s\n",
       msg->argv[0], sys::number_of_procs(),  // NOLINT
-      current_date_and_time());
+      sys::wall_time(), current_date_and_time());
 
   Parallel::printf("%s\n", info_from_build());
 }


### PR DESCRIPTION
## Proposed changes

Charm++ can take a few seconds to launch the executable on multiple threads. This offset in wall time is relevant when discussing parallel efficiency.

For example, here's a screenshot from HPCToolkit of an executable running for 13s on 12 threads (+1 communication thread). The first 4.5s are Charm++ startup time where no worker threads have been launched yet:

<img width="953" alt="Bildschirmfoto 2021-09-18 um 13 06 13" src="https://user-images.githubusercontent.com/746230/133886816-fc2fbaf7-f4dc-4ac3-b3d2-893528304d2c.png">

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
