### PR TITLE
Add reconstructor base class for advection subcell

### DIFF
--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -33,6 +33,7 @@
 #include "Evolution/Systems/ScalarAdvection/BoundaryConditions/Factory.hpp"
 #include "Evolution/Systems/ScalarAdvection/BoundaryCorrections/Factory.hpp"
 #include "Evolution/Systems/ScalarAdvection/BoundaryCorrections/RegisterDerived.hpp"
+#include "Evolution/Systems/ScalarAdvection/Subcell/TciOptions.hpp"
 #include "Evolution/Systems/ScalarAdvection/System.hpp"
 #include "Evolution/Systems/ScalarAdvection/VelocityField.hpp"
 #include "IO/Observer/Actions/RegisterEvents.hpp"
@@ -104,6 +105,8 @@ struct EvolutionMetavars {
   static constexpr size_t volume_dim = Dim;
   using system = ScalarAdvection::System<Dim>;
   using temporal_id = Tags::TimeStepId;
+
+  static constexpr bool use_dg_subcell = true;
   static constexpr bool local_time_stepping = false;
 
   using initial_data = InitialData;
@@ -202,9 +205,12 @@ struct EvolutionMetavars {
   using phase_change_tags_and_combines_list =
       PhaseControl::get_phase_change_tags<phase_changes>;
 
-  using const_global_cache_tags =
-      tmpl::list<initial_data_tag, Tags::EventsAndTriggers,
-                 PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes>>;
+  using const_global_cache_tags = tmpl::list<
+      initial_data_tag, Tags::EventsAndTriggers,
+      tmpl::conditional_t<
+          use_dg_subcell,
+          tmpl::list<ScalarAdvection::subcell::Tags::TciOptions>, tmpl::list<>>,
+      PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes>>;
 
   using dg_registration_list =
       tmpl::list<observers::Actions::RegisterEventsWithObservers>;

--- a/src/Evolution/Systems/ScalarAdvection/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarAdvection/CMakeLists.txt
@@ -32,6 +32,7 @@ target_link_libraries(
   PUBLIC
   DataStructures
   DgSubcell
+  FiniteDifference
   INTERFACE
   ErrorHandling
   )

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/CMakeLists.txt
@@ -4,11 +4,16 @@
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  Reconstructor.cpp
+  RegisterDerivedWithCharm.cpp
   )
 
 spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  Factory.hpp
   FiniteDifference.hpp
+  Reconstructor.hpp
+  RegisterDerivedWithCharm.hpp
   )

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/CMakeLists.txt
@@ -16,4 +16,5 @@ spectre_target_headers(
   FiniteDifference.hpp
   Reconstructor.hpp
   RegisterDerivedWithCharm.hpp
+  Tags.hpp
   )

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/Factory.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/Factory.hpp
@@ -1,0 +1,6 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Evolution/Systems/ScalarAdvection/FiniteDifference/Reconstructor.hpp"

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/Reconstructor.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/Reconstructor.cpp
@@ -1,0 +1,28 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarAdvection/FiniteDifference/Reconstructor.hpp"
+
+#include <cstddef>
+#include <pup.h>
+
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace ScalarAdvection::fd {
+template <size_t Dim>
+Reconstructor<Dim>::Reconstructor(CkMigrateMessage* const msg) noexcept
+    : PUP::able(msg) {}
+
+template <size_t Dim>
+void Reconstructor<Dim>::pup(PUP::er& p) {
+  PUP::able::pup(p);
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define INSTANTIATION(r, data) template class Reconstructor<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
+
+#undef INSTANTIATION
+#undef DIM
+}  // namespace ScalarAdvection::fd

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/Reconstructor.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/Reconstructor.hpp
@@ -1,0 +1,40 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ScalarAdvection::fd {
+/*!
+ * \brief The base class from which all reconstruction schemes must inherit
+ */
+template <size_t Dim>
+class Reconstructor : public PUP::able {
+ public:
+  Reconstructor() = default;
+  Reconstructor(const Reconstructor&) = default;
+  Reconstructor& operator=(const Reconstructor&) = default;
+  Reconstructor(Reconstructor&&) = default;
+  Reconstructor& operator=(Reconstructor&&) = default;
+  ~Reconstructor() override = default;
+
+  void pup(PUP::er& p) override;
+
+  /// \cond
+  explicit Reconstructor(CkMigrateMessage* msg) noexcept;
+  WRAPPED_PUPable_abstract(Reconstructor<Dim>);  // NOLINT
+  /// \endcond
+
+  using creatable_classes = tmpl::list<>;
+
+  virtual std::unique_ptr<Reconstructor<Dim>> get_clone() const noexcept = 0;
+
+  virtual size_t ghost_zone_size() const noexcept = 0;
+};
+}  // namespace ScalarAdvection::fd

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/RegisterDerivedWithCharm.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/RegisterDerivedWithCharm.cpp
@@ -1,0 +1,15 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarAdvection/FiniteDifference/RegisterDerivedWithCharm.hpp"
+
+#include "Evolution/Systems/ScalarAdvection/FiniteDifference/Factory.hpp"
+#include "Evolution/Systems/ScalarAdvection/FiniteDifference/Reconstructor.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+
+namespace ScalarAdvection::fd {
+void register_derived_with_charm() noexcept {
+  Parallel::register_derived_classes_with_charm<Reconstructor<1>>();
+  Parallel::register_derived_classes_with_charm<Reconstructor<2>>();
+}
+}  // namespace ScalarAdvection::fd

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/RegisterDerivedWithCharm.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/RegisterDerivedWithCharm.hpp
@@ -1,0 +1,8 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace ScalarAdvection::fd {
+void register_derived_with_charm() noexcept;
+}  // namespace ScalarAdvection::fd

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/Tags.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/Tags.hpp
@@ -1,0 +1,44 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Evolution/DgSubcell/Tags/SubcellSolver.hpp"
+#include "Evolution/Systems/ScalarAdvection/FiniteDifference/Reconstructor.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ScalarAdvection::fd {
+namespace OptionTags {
+/*!
+ * \brief Holds the subcell reconstructor in the input file
+ */
+template <size_t Dim>
+struct Reconstructor {
+  using type = std::unique_ptr<fd::Reconstructor<Dim>>;
+
+  static constexpr Options::String help = {"The reconstruction scheme to use."};
+  using group = evolution::dg::subcell::OptionTags::SubcellSolverGroup;
+};
+}  // namespace OptionTags
+
+namespace Tags {
+/*!
+ * \brief Tag for the reconstructor
+ */
+template <size_t Dim>
+struct Reconstructor : db::SimpleTag {
+  using type = std::unique_ptr<fd::Reconstructor<Dim>>;
+  using option_tags = tmpl::list<OptionTags::Reconstructor<Dim>>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& reconstructor) noexcept {
+    return reconstructor->get_clone();
+  }
+};
+}  // namespace Tags
+}  // namespace ScalarAdvection::fd

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/CMakeLists.txt
@@ -7,6 +7,7 @@ spectre_target_sources(
   InitialDataTci.cpp
   TciOnDgGrid.cpp
   TciOnFdGrid.cpp
+  TciOptions.cpp
   )
 
 spectre_target_headers(
@@ -17,4 +18,5 @@ spectre_target_headers(
   Subcell.hpp
   TciOnDgGrid.hpp
   TciOnFdGrid.hpp
+  TciOptions.hpp
   )

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/TciOptions.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/TciOptions.cpp
@@ -1,0 +1,12 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarAdvection/Subcell/TciOptions.hpp"
+
+#include <pup.h>
+
+#include "Parallel/PupStlCpp17.hpp"
+
+namespace ScalarAdvection::subcell {
+void TciOptions::pup(PUP::er& /*p*/) noexcept {}
+}  // namespace ScalarAdvection::subcell

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/TciOptions.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/TciOptions.hpp
@@ -1,0 +1,51 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <limits>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags/OptionsGroup.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace ScalarAdvection::subcell {
+
+struct TciOptions {
+  using options = tmpl::list<>;
+
+  static constexpr Options::String help = {
+      "Options for the troubled-cell indicator"};
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept;
+};
+
+namespace OptionTags {
+struct TciOptions {
+  using type = subcell::TciOptions;
+  static constexpr Options::String help =
+      "ScalarAdvection-specific options for the TCI";
+  using group = ::dg::OptionTags::DiscontinuousGalerkinGroup;
+};
+}  // namespace OptionTags
+
+namespace Tags {
+struct TciOptions : db::SimpleTag {
+  using type = subcell::TciOptions;
+  using option_tags = tmpl::list<typename OptionTags::TciOptions>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& tci_options) noexcept {
+    return tci_options;
+  }
+};
+}  // namespace Tags
+}  // namespace ScalarAdvection::subcell

--- a/src/NumericalAlgorithms/FiniteDifference/Reconstruct.hpp
+++ b/src/NumericalAlgorithms/FiniteDifference/Reconstruct.hpp
@@ -85,9 +85,11 @@ namespace fd {
  *                              ^ reconstructed_lower_side_of_face_vars
  * \endcode
  *
- * Notice that the `reconstructed_upper_side_of_face_vars` are on the lower side
- * of the cell, while the `reconstructed_lower_side_of_face_vars` are on the
- * upper side of the cell.
+ * Notice that the `reconstructed_upper_side_of_face_vars` are actually on the
+ * lower side of each cells, while the `reconstructed_lower_side_of_face_vars`
+ * are on the upper side of each cells. The `upper` and `lower` here refers to
+ * which side of the interface the quantity is on, not from the perspective of
+ * each cells.
  */
 namespace reconstruction {
 namespace detail {

--- a/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
@@ -37,6 +37,7 @@ SpatialDiscretization:
   DiscontinuousGalerkin:
     Formulation: StrongInertial
     Quadrature: GaussLobatto
+    TciOptions:
 
 AnalyticSolution:
   Krivodonova:

--- a/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
@@ -38,6 +38,8 @@ SpatialDiscretization:
     Formulation: StrongInertial
     Quadrature: GaussLobatto
     TciOptions:
+  SubcellSolver:
+    Reconstructor:
 
 AnalyticSolution:
   Krivodonova:

--- a/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
@@ -36,6 +36,7 @@ SpatialDiscretization:
   DiscontinuousGalerkin:
     Formulation: StrongInertial
     Quadrature: GaussLobatto
+    TciOptions:
 
 AnalyticSolution:
   Kuzmin:

--- a/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
@@ -37,6 +37,8 @@ SpatialDiscretization:
     Formulation: StrongInertial
     Quadrature: GaussLobatto
     TciOptions:
+  SubcellSolver:
+    Reconstructor:
 
 AnalyticSolution:
   Kuzmin:

--- a/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
@@ -38,6 +38,8 @@ SpatialDiscretization:
     Formulation: StrongInertial
     Quadrature: GaussLobatto
     TciOptions:
+  SubcellSolver:
+    Reconstructor:
 
 AnalyticSolution:
   Sinusoid:

--- a/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
@@ -37,6 +37,7 @@ SpatialDiscretization:
   DiscontinuousGalerkin:
     Formulation: StrongInertial
     Quadrature: GaussLobatto
+    TciOptions:
 
 AnalyticSolution:
   Sinusoid:


### PR DESCRIPTION
## Proposed changes

* Add reconstructor base class and associated structures to advection subcell.
* A minor fix on reconstruction namespace documentation.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
