### PR TITLE
Add reconstructor base class to advection subcell

### DIFF
--- a/src/Evolution/Systems/ScalarAdvection/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarAdvection/CMakeLists.txt
@@ -32,6 +32,7 @@ target_link_libraries(
   PUBLIC
   DataStructures
   DgSubcell
+  FiniteDifference
   INTERFACE
   ErrorHandling
   )

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/CMakeLists.txt
@@ -4,11 +4,16 @@
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  Reconstructor.cpp
+  RegisterDerivedWithCharm.cpp
   )
 
 spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  Factory.hpp
   FiniteDifference.hpp
+  Reconstructor.hpp
+  RegisterDerivedWithCharm.hpp
   )

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/CMakeLists.txt
@@ -16,4 +16,5 @@ spectre_target_headers(
   FiniteDifference.hpp
   Reconstructor.hpp
   RegisterDerivedWithCharm.hpp
+  Tags.hpp
   )

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/Factory.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/Factory.hpp
@@ -1,0 +1,6 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Evolution/Systems/ScalarAdvection/FiniteDifference/Reconstructor.hpp"

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/Reconstructor.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/Reconstructor.cpp
@@ -1,0 +1,28 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarAdvection/FiniteDifference/Reconstructor.hpp"
+
+#include <cstddef>
+#include <pup.h>
+
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace ScalarAdvection::fd {
+template <size_t Dim>
+Reconstructor<Dim>::Reconstructor(CkMigrateMessage* const msg) noexcept
+    : PUP::able(msg) {}
+
+template <size_t Dim>
+void Reconstructor<Dim>::pup(PUP::er& p) {
+  PUP::able::pup(p);
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define INSTANTIATION(r, data) template class Reconstructor<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
+
+#undef INSTANTIATION
+#undef DIM
+}  // namespace ScalarAdvection::fd

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/Reconstructor.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/Reconstructor.hpp
@@ -1,0 +1,40 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ScalarAdvection::fd {
+/*!
+ * \brief The base class from which all reconstruction schemes must inherit
+ */
+template <size_t Dim>
+class Reconstructor : public PUP::able {
+ public:
+  Reconstructor() = default;
+  Reconstructor(const Reconstructor&) = default;
+  Reconstructor& operator=(const Reconstructor&) = default;
+  Reconstructor(Reconstructor&&) = default;
+  Reconstructor& operator=(Reconstructor&&) = default;
+  ~Reconstructor() override = default;
+
+  void pup(PUP::er& p) override;
+
+  /// \cond
+  explicit Reconstructor(CkMigrateMessage* msg) noexcept;
+  WRAPPED_PUPable_abstract(Reconstructor<Dim>);  // NOLINT
+  /// \endcond
+
+  using creatable_classes = tmpl::list<>;
+
+  virtual std::unique_ptr<Reconstructor<Dim>> get_clone() const noexcept = 0;
+
+  virtual size_t ghost_zone_size() const noexcept = 0;
+};
+}  // namespace ScalarAdvection::fd

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/RegisterDerivedWithCharm.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/RegisterDerivedWithCharm.cpp
@@ -1,0 +1,15 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarAdvection/FiniteDifference/RegisterDerivedWithCharm.hpp"
+
+#include "Evolution/Systems/ScalarAdvection/FiniteDifference/Factory.hpp"
+#include "Evolution/Systems/ScalarAdvection/FiniteDifference/Reconstructor.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+
+namespace ScalarAdvection::fd {
+void register_derived_with_charm() noexcept {
+  Parallel::register_derived_classes_with_charm<Reconstructor<1>>();
+  Parallel::register_derived_classes_with_charm<Reconstructor<2>>();
+}
+}  // namespace ScalarAdvection::fd

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/RegisterDerivedWithCharm.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/RegisterDerivedWithCharm.hpp
@@ -1,0 +1,8 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace ScalarAdvection::fd {
+void register_derived_with_charm() noexcept;
+}  // namespace ScalarAdvection::fd

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/Tags.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/Tags.hpp
@@ -1,0 +1,44 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Evolution/DgSubcell/Tags/SubcellSolver.hpp"
+#include "Evolution/Systems/ScalarAdvection/FiniteDifference/Reconstructor.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ScalarAdvection::fd {
+namespace OptionTags {
+/*!
+ * \brief Holds the subcell reconstructor in the input file
+ */
+template <size_t Dim>
+struct Reconstructor {
+  using type = std::unique_ptr<fd::Reconstructor<Dim>>;
+
+  static constexpr Options::String help = {"The reconstruction scheme to use."};
+  using group = evolution::dg::subcell::OptionTags::SubcellSolverGroup;
+};
+}  // namespace OptionTags
+
+namespace Tags {
+/*!
+ * \brief Tag for the reconstructor
+ */
+template <size_t Dim>
+struct Reconstructor : db::SimpleTag {
+  using type = std::unique_ptr<fd::Reconstructor<Dim>>;
+  using option_tags = tmpl::list<OptionTags::Reconstructor<Dim>>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& reconstructor) noexcept {
+    return reconstructor->get_clone();
+  }
+};
+}  // namespace Tags
+}  // namespace ScalarAdvection::fd

--- a/src/NumericalAlgorithms/FiniteDifference/Reconstruct.hpp
+++ b/src/NumericalAlgorithms/FiniteDifference/Reconstruct.hpp
@@ -85,9 +85,11 @@ namespace fd {
  *                              ^ reconstructed_lower_side_of_face_vars
  * \endcode
  *
- * Notice that the `reconstructed_upper_side_of_face_vars` are on the lower side
- * of the cell, while the `reconstructed_lower_side_of_face_vars` are on the
- * upper side of the cell.
+ * Notice that the `reconstructed_upper_side_of_face_vars` are actually on the
+ * lower side of the cells, while the `reconstructed_lower_side_of_face_vars`
+ * are on the upper side of the cells. The `upper` and `lower` here refers to
+ * which side of the interface the quantity is on, not from the perspective of
+ * each cells.
  */
 namespace reconstruction {
 namespace detail {

--- a/tests/Unit/Evolution/Systems/ScalarAdvection/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarAdvection/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY Test_ScalarAdvection)
 set(LIBRARY_SOURCES
   BoundaryConditions/Test_Periodic.cpp
   BoundaryCorrections/Test_Rusanov.cpp
+  FiniteDifference/Test_Tag.cpp
   Subcell/Test_InitialDataTci.cpp
   Subcell/Test_TciOnDgGrid.cpp
   Subcell/Test_TciOnFdGrid.cpp

--- a/tests/Unit/Evolution/Systems/ScalarAdvection/FiniteDifference/Test_Tag.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarAdvection/FiniteDifference/Test_Tag.cpp
@@ -1,0 +1,23 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "Evolution/Systems/ScalarAdvection/FiniteDifference/Tags.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+
+namespace {
+template <size_t Dim>
+void test() {
+  TestHelpers::db::test_simple_tag<
+      ScalarAdvection::fd::Tags::Reconstructor<Dim>>("Reconstructor");
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarAdvection.Fd.Tag",
+                  "[Unit][Evolution]") {
+  test<1>();
+  test<2>();
+}


### PR DESCRIPTION
## Proposed changes

* A minor fix on reconstruction namespace documentation
* Add reconstructor base class, its required structures, and option tag to advection subcell.


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
