### PR TITLE
Modify translation map

### DIFF
--- a/src/Domain/CoordinateMaps/TimeDependent/Translation.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Translation.cpp
@@ -15,16 +15,19 @@
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
+#include "Utilities/StdArrayHelpers.hpp"
 #include "Utilities/StdHelpers.hpp"
 
 namespace domain::CoordinateMaps::TimeDependent {
 
-Translation::Translation(std::string function_of_time_name) noexcept
+template <size_t Dim>
+Translation<Dim>::Translation(std::string function_of_time_name) noexcept
     : f_of_t_name_(std::move(function_of_time_name)) {}
 
+template <size_t Dim>
 template <typename T>
-std::array<tt::remove_cvref_wrap_t<T>, 1> Translation::operator()(
-    const std::array<T, 1>& source_coords, const double time,
+std::array<tt::remove_cvref_wrap_t<T>, Dim> Translation<Dim>::operator()(
+    const std::array<T, Dim>& source_coords, const double time,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) const noexcept {
@@ -33,12 +36,23 @@ std::array<tt::remove_cvref_wrap_t<T>, 1> Translation::operator()(
                                   << "' is not one of the known functions of "
                                      "time. The known functions of time are: "
                                   << keys_of(functions_of_time));
-  return {{source_coords[0] +
-           functions_of_time.at(f_of_t_name_)->func(time)[0][0]}};
+  std::array<tt::remove_cvref_wrap_t<T>, Dim> result{};
+  const DataVector function_of_time =
+      functions_of_time.at(f_of_t_name_)->func(time)[0];
+  ASSERT(function_of_time.size() == Dim,
+         "The dimension of the function of time ("
+             << function_of_time.size()
+             << ") does not match the dimension of the translation map (" << Dim
+             << ").");
+  for (size_t i = 0; i < Dim; i++) {
+    gsl::at(result, i) = gsl::at(source_coords, i) + function_of_time[i];
+  }
+  return result;
 }
 
-std::optional<std::array<double, 1>> Translation::inverse(
-    const std::array<double, 1>& target_coords, const double time,
+template <size_t Dim>
+std::optional<std::array<double, Dim>> Translation<Dim>::inverse(
+    const std::array<double, Dim>& target_coords, const double time,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) const noexcept {
@@ -47,13 +61,24 @@ std::optional<std::array<double, 1>> Translation::inverse(
                                   << "' is not one of the known functions of "
                                      "time. The known functions of time are: "
                                   << keys_of(functions_of_time));
-  return {{{target_coords[0] -
-            functions_of_time.at(f_of_t_name_)->func(time)[0][0]}}};
+  std::array<double, Dim> result{};
+  const DataVector function_of_time =
+      functions_of_time.at(f_of_t_name_)->func(time)[0];
+  ASSERT(function_of_time.size() == Dim,
+         "The dimension of the function of time ("
+             << function_of_time.size()
+             << ") does not match the dimension of the translation map (" << Dim
+             << ").");
+  for (size_t i = 0; i < Dim; i++) {
+    gsl::at(result, i) = gsl::at(target_coords, i) - function_of_time[i];
+  }
+  return result;
 }
 
+template <size_t Dim>
 template <typename T>
-std::array<tt::remove_cvref_wrap_t<T>, 1> Translation::frame_velocity(
-    const std::array<T, 1>& source_coords, const double time,
+std::array<tt::remove_cvref_wrap_t<T>, Dim> Translation<Dim>::frame_velocity(
+    const std::array<T, Dim>& source_coords, const double time,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) const noexcept {
@@ -62,58 +87,94 @@ std::array<tt::remove_cvref_wrap_t<T>, 1> Translation::frame_velocity(
                                   << "' is not one of the known functions of "
                                      "time. The known functions of time are: "
                                   << keys_of(functions_of_time));
-  return {{make_with_value<tt::remove_cvref_wrap_t<T>>(
-      dereference_wrapper(source_coords[0]),
-      functions_of_time.at(f_of_t_name_)->func_and_deriv(time)[1][0])}};
+  std::array<tt::remove_cvref_wrap_t<T>, Dim> result{};
+  const auto function_of_time_and_deriv =
+      functions_of_time.at(f_of_t_name_)->func_and_deriv(time);
+  const DataVector& velocity = function_of_time_and_deriv[1];
+  ASSERT(velocity.size() == Dim,
+         "The dimension of the function of time ("
+             << velocity.size()
+             << ") does not match the dimension of the translation map (" << Dim
+             << ").");
+  for (size_t i = 0; i < Dim; i++) {
+    gsl::at(result, i) = make_with_value<tt::remove_cvref_wrap_t<T>>(
+        dereference_wrapper(gsl::at(source_coords, i)), velocity[i]);
+  }
+  return result;
 }
 
+template <size_t Dim>
 template <typename T>
-tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> Translation::jacobian(
-    const std::array<T, 1>& source_coords) const noexcept {
-  return identity<1>(dereference_wrapper(source_coords[0]));
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame>
+Translation<Dim>::jacobian(
+    const std::array<T, Dim>& source_coords) const noexcept {
+  return identity<Dim>(dereference_wrapper(source_coords[0]));
 }
 
+template <size_t Dim>
 template <typename T>
-tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame>
-Translation::inv_jacobian(const std::array<T, 1>& source_coords) const
-    noexcept {
-  return identity<1>(dereference_wrapper(source_coords[0]));
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame>
+Translation<Dim>::inv_jacobian(
+    const std::array<T, Dim>& source_coords) const noexcept {
+  return identity<Dim>(dereference_wrapper(source_coords[0]));
 }
 
-void Translation::pup(PUP::er& p) noexcept { p | f_of_t_name_; }
+template <size_t Dim>
+void Translation<Dim>::pup(PUP::er& p) noexcept {
+  p | f_of_t_name_;
+}
 
-bool operator==(const Translation& lhs, const Translation& rhs) noexcept {
+template <size_t Dim>
+bool operator==(const Translation<Dim>& lhs,
+                const Translation<Dim>& rhs) noexcept {
   return lhs.f_of_t_name_ == rhs.f_of_t_name_;
 }
 
 // Explicit instantiations
-#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATE(_, data)                                                 \
-  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1>               \
-  Translation::operator()(                                                   \
-      const std::array<DTYPE(data), 1>& source_coords, const double time,    \
-      const std::unordered_map<                                              \
-          std::string,                                                       \
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&         \
-          functions_of_time) const noexcept;                                 \
-  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1>               \
-  Translation::frame_velocity(                                               \
-      const std::array<DTYPE(data), 1>& source_coords, const double time,    \
-      const std::unordered_map<                                              \
-          std::string,                                                       \
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&         \
-          functions_of_time) const noexcept;                                 \
-  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame> \
-  Translation::jacobian(const std::array<DTYPE(data), 1>& source_coords)     \
-      const noexcept;                                                        \
-  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame> \
-  Translation::inv_jacobian(const std::array<DTYPE(data), 1>& source_coords) \
-      const noexcept;
+#define INSTANTIATE(_, data)                              \
+  template class Translation<DIM(data)>;                  \
+  template bool operator==(const Translation<DIM(data)>&, \
+                           const Translation<DIM(data)>&) noexcept;
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
-                                      std::reference_wrapper<const double>,
-                                      std::reference_wrapper<const DataVector>))
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATE
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                                                   \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data)>         \
+  Translation<DIM(data)>::operator()(                                          \
+      const std::array<DTYPE(data), DIM(data)>& source_coords,                 \
+      const double time,                                                       \
+      const std::unordered_map<                                                \
+          std::string,                                                         \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&           \
+          functions_of_time) const noexcept;                                   \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data)>         \
+  Translation<DIM(data)>::frame_velocity(                                      \
+      const std::array<DTYPE(data), DIM(data)>& source_coords,                 \
+      const double time,                                                       \
+      const std::unordered_map<                                                \
+          std::string,                                                         \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&           \
+          functions_of_time) const noexcept;                                   \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data),           \
+                    Frame::NoFrame>                                            \
+  Translation<DIM(data)>::jacobian(                                            \
+      const std::array<DTYPE(data), DIM(data)>& source_coords) const noexcept; \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data),           \
+                    Frame::NoFrame>                                            \
+  Translation<DIM(data)>::inv_jacobian(                                        \
+      const std::array<DTYPE(data), DIM(data)>& source_coords) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3),
+                        (double, DataVector,
+                         std::reference_wrapper<const double>,
+                         std::reference_wrapper<const DataVector>))
+#undef DIM
 #undef DTYPE
 #undef INSTANTIATE
 }  // namespace domain::CoordinateMaps::TimeDependent

--- a/src/Domain/CoordinateMaps/TimeDependent/Translation.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Translation.hpp
@@ -29,21 +29,22 @@ namespace CoordinateMaps {
 namespace TimeDependent {
 /*!
  * \ingroup CoordMapsTimeDependentGroup
- * \brief Translation map defined by \f$x = \xi+T(t)\f$.
+ * \brief Translation map defined by \f$\vec{x} = \vec{\xi}+\vec{T}(t)\f$.
  *
- * The map adds a translation, \f$T(t)\f$, to the coordinates \f$\xi\f$,
- * where \f$T(t)\f$ is a FunctionOfTime.
+ * The map adds a translation, \f$\vec{T}(t)\f$, to the coordinates
+ * \f$\vec{\xi}\f$, where \f$\vec{T}(t)\f$ is a FunctionOfTime.
  */
+template <size_t Dim>
 class Translation {
  public:
-  static constexpr size_t dim = 1;
+  static constexpr size_t dim = Dim;
 
   Translation() = default;
   explicit Translation(std::string function_of_time_name) noexcept;
 
   template <typename T>
-  std::array<tt::remove_cvref_wrap_t<T>, 1> operator()(
-      const std::array<T, 1>& source_coords, double time,
+  std::array<tt::remove_cvref_wrap_t<T>, Dim> operator()(
+      const std::array<T, Dim>& source_coords, double time,
       const std::unordered_map<
           std::string,
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
@@ -53,28 +54,28 @@ class Translation {
   /// might fail if called for a point out of range, and it is unclear
   /// what should happen if the inverse were to succeed for some points in a
   /// DataVector but fail for other points.
-  std::optional<std::array<double, 1>> inverse(
-      const std::array<double, 1>& target_coords, double time,
+  std::optional<std::array<double, Dim>> inverse(
+      const std::array<double, Dim>& target_coords, double time,
       const std::unordered_map<
           std::string,
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           functions_of_time) const noexcept;
 
   template <typename T>
-  std::array<tt::remove_cvref_wrap_t<T>, 1> frame_velocity(
-      const std::array<T, 1>& source_coords, double time,
+  std::array<tt::remove_cvref_wrap_t<T>, Dim> frame_velocity(
+      const std::array<T, Dim>& source_coords, double time,
       const std::unordered_map<
           std::string,
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           functions_of_time) const noexcept;
 
   template <typename T>
-  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> inv_jacobian(
-      const std::array<T, 1>& source_coords) const noexcept;
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame> inv_jacobian(
+      const std::array<T, Dim>& source_coords) const noexcept;
 
   template <typename T>
-  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> jacobian(
-      const std::array<T, 1>& source_coords) const noexcept;
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame> jacobian(
+      const std::array<T, Dim>& source_coords) const noexcept;
 
   // clang-tidy: google-runtime-references
   void pup(PUP::er& p) noexcept;  // NOLINT
@@ -82,14 +83,17 @@ class Translation {
   static bool is_identity() noexcept { return false; }
 
  private:
-  friend bool operator==(const Translation& lhs,
-                         const Translation& rhs) noexcept;
+  template <size_t LocalDim>
+  friend bool operator==(  // NOLINT(readability-redundant-declaration)
+      const Translation<LocalDim>& lhs,
+      const Translation<LocalDim>& rhs) noexcept;
 
   std::string f_of_t_name_{};
 };
 
-inline bool operator!=(const Translation& lhs,
-                       const Translation& rhs) noexcept {
+template <size_t Dim>
+inline bool operator!=(const Translation<Dim>& lhs,
+                       const Translation<Dim>& rhs) noexcept {
   return not(lhs == rhs);
 }
 

--- a/tests/InputFiles/ExportCoordinates/Input1D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input1D.yaml
@@ -19,7 +19,7 @@ DomainCreator:
         InitialTime: 0.0
         InitialExpirationDeltaT: 5.0
         Velocity: [0.5]
-        FunctionOfTimeNames: ["TranslationX"]
+        FunctionOfTimeName: "TranslationX"
 
 SpatialDiscretization:
   DiscontinuousGalerkin:

--- a/tests/InputFiles/ExportCoordinates/Input2D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input2D.yaml
@@ -19,7 +19,7 @@ DomainCreator:
         InitialTime: 0.0
         InitialExpirationDeltaT: 5.0
         Velocity: [0.5, 0.0]
-        FunctionOfTimeNames: ["TranslationX", "TranslationY"]
+        FunctionOfTimeName: "Translation"
 
 SpatialDiscretization:
   DiscontinuousGalerkin:

--- a/tests/InputFiles/ExportCoordinates/Input3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input3D.yaml
@@ -19,7 +19,7 @@ DomainCreator:
         InitialTime: 0.0
         InitialExpirationDeltaT: 5.0
         Velocity: [0.5, 0.0, 0.0]
-        FunctionOfTimeNames: ["TranslationX", "TranslationY", "TranslationZ"]
+        FunctionOfTimeName: "Translation"
 
 SpatialDiscretization:
   DiscontinuousGalerkin:

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
@@ -36,7 +36,7 @@ DomainCreator:
          InitialTime: 0.0
          InitialExpirationDeltaT: Auto
          Velocity: [0.5]
-         FunctionOfTimeNames: ["Translation"]
+         FunctionOfTimeName: "Translation"
     BoundaryConditions:
       LowerBoundary:  DirichletAnalytic
       UpperBoundary:  DirichletAnalytic

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -46,7 +46,7 @@ DomainCreator:
         InitialTime: *InitialTime
         InitialExpirationDeltaT: Auto
         Velocity: [0.5]
-        FunctionOfTimeNames: ["Translation"]
+        FunctionOfTimeName: "Translation"
     BoundaryConditions:
       LowerBoundary: Periodic
       UpperBoundary: Periodic

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_ProductMaps.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_ProductMaps.cpp
@@ -39,7 +39,7 @@ void test_product_of_2_maps_time_dep(
     const double y_target_a, const double y_target_b,
     const std::array<double, 2>& expected_frame_velocity) noexcept {
   using AffineMap = CoordinateMaps::Affine;
-  using TranslationMap = CoordinateMaps::TimeDependent::Translation;
+  using TranslationMap = CoordinateMaps::TimeDependent::Translation<1>;
   static_assert(
       std::is_same_v<Map1, AffineMap> or std::is_same_v<Map1, TranslationMap>,
       "Map1 must be either an affine map or a translation map");
@@ -150,7 +150,7 @@ void test_product_of_2_maps_time_dep() noexcept {
   INFO("Product of two maps with time dependence");
   constexpr size_t deriv_order = 3;
   using affine_map = CoordinateMaps::Affine;
-  using translation_map = CoordinateMaps::TimeDependent::Translation;
+  using translation_map = CoordinateMaps::TimeDependent::Translation<1>;
 
   const std::string f_of_t_name{"translation"};
   const double time = 2.0;
@@ -291,7 +291,7 @@ void test_product_of_3_maps_time_dep(
     const double z_target_b,
     const std::array<double, 3>& expected_frame_velocity) noexcept {
   using AffineMap = CoordinateMaps::Affine;
-  using TranslationMap = CoordinateMaps::TimeDependent::Translation;
+  using TranslationMap = CoordinateMaps::TimeDependent::Translation<1>;
   static_assert(
       std::is_same_v<Map1, AffineMap> or std::is_same_v<Map1, TranslationMap>,
       "Map1 must be either an affine map or a translation map");
@@ -426,7 +426,7 @@ void test_product_of_3_maps() noexcept {
   INFO("Product of 3 maps");
   constexpr size_t deriv_order = 3;
   using affine_map = CoordinateMaps::Affine;
-  using translation_map = CoordinateMaps::TimeDependent::Translation;
+  using translation_map = CoordinateMaps::TimeDependent::Translation<1>;
 
   const std::string f_of_t_name_x{"translation_x"};
   const std::string f_of_t_name_y{"translation_y"};

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_Translation.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_Translation.cpp
@@ -11,19 +11,24 @@
 #include <unordered_map>
 
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Identity.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/Translation.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
 #include "Utilities/TypeTraits.hpp"
 
 namespace domain {
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.TimeDependent.Translation",
-                  "[Domain][Unit]") {
+
+namespace {
+template <size_t Dim>
+void test_translation() {
+  MAKE_GENERATOR(gen);
   // define vars for FunctionOfTime::PiecewisePolynomial f(t) = t**2.
   double t = -1.0;
   const double dt = 0.6;
@@ -31,7 +36,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.TimeDependent.Translation",
   constexpr size_t deriv_order = 3;
 
   const std::array<DataVector, deriv_order + 1> init_func{
-      {{1.0}, {-2.0}, {2.0}, {0.0}}};
+      {{Dim, 1.0}, {Dim, -2.0}, {Dim, 2.0}, {Dim, 0.0}}};
 
   using Polynomial = domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>;
   using FoftPtr = std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>;
@@ -41,42 +46,62 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.TimeDependent.Translation",
 
   const FoftPtr& f_of_t = f_of_t_list.at("translation");
 
-  const CoordinateMaps::TimeDependent::Translation trans_map{"translation"};
+  const CoordinateMaps::TimeDependent::Translation<Dim> trans_map{
+      "translation"};
   // test serialized/deserialized map
   const auto trans_map_deserialized = serialize_and_deserialize(trans_map);
 
-  const std::array<double, 1> point_xi{{3.2}};
+  UniformCustomDistribution<double> dist_double{-5.0, 5.0};
+  std::array<double, Dim> point_xi{};
+  fill_with_random_values(make_not_null(&point_xi), make_not_null(&gen),
+                          make_not_null(&dist_double));
 
   while (t < final_time) {
-    const std::array<double, 1> trans_x{{square(t)}};
-    const std::array<double, 1> frame_vel{{f_of_t->func_and_deriv(t)[1][0]}};
+    std::array<double, Dim> translation{};
+    for (size_t i = 0; i < Dim; i++) {
+      gsl::at(translation, i) = square(t);
+    }
+    std::array<double, Dim> frame_vel{};
+    for (size_t i = 0; i < Dim; i++) {
+      gsl::at(frame_vel, i) = f_of_t->func_and_deriv(t)[1][i];
+    }
 
     CHECK_ITERABLE_APPROX(trans_map(point_xi, t, f_of_t_list),
-                          point_xi + trans_x);
+                          point_xi + translation);
     CHECK_ITERABLE_APPROX(
-        trans_map.inverse(point_xi + trans_x, t, f_of_t_list).value(),
+        trans_map.inverse(point_xi + translation, t, f_of_t_list).value(),
         point_xi);
     CHECK_ITERABLE_APPROX(trans_map.frame_velocity(point_xi, t, f_of_t_list),
                           frame_vel);
 
     CHECK_ITERABLE_APPROX(trans_map_deserialized(point_xi, t, f_of_t_list),
-                          point_xi + trans_x);
+                          point_xi + translation);
     CHECK_ITERABLE_APPROX(
-        trans_map_deserialized.inverse(point_xi + trans_x, t, f_of_t_list)
+        trans_map_deserialized.inverse(point_xi + translation, t, f_of_t_list)
             .value(),
         point_xi);
     CHECK_ITERABLE_APPROX(trans_map_deserialized.frame_velocity(
-                              point_xi + trans_x, t, f_of_t_list),
+                              point_xi + translation, t, f_of_t_list),
                           frame_vel);
 
     t += dt;
   }
 
   // time-independent checks
-  CHECK(trans_map.inv_jacobian(point_xi).get(0, 0) == 1.0);
-  CHECK(trans_map_deserialized.inv_jacobian(point_xi).get(0, 0) == 1.0);
-  CHECK(trans_map.jacobian(point_xi).get(0, 0) == 1.0);
-  CHECK(trans_map_deserialized.jacobian(point_xi).get(0, 0) == 1.0);
+  {
+    const auto identity_matrix = identity<Dim>(point_xi[0]);
+    const auto jacobian = trans_map.jacobian(point_xi);
+    const auto jacobian_deserialized =
+        trans_map_deserialized.jacobian(point_xi);
+    const auto inv_jacobian = trans_map.inv_jacobian(point_xi);
+    const auto inv_jacobian_deserialized =
+        trans_map_deserialized.inv_jacobian(point_xi);
+
+    CHECK_ITERABLE_APPROX(jacobian, identity_matrix);
+    CHECK_ITERABLE_APPROX(jacobian_deserialized, identity_matrix);
+    CHECK_ITERABLE_APPROX(inv_jacobian, identity_matrix);
+    CHECK_ITERABLE_APPROX(inv_jacobian_deserialized, identity_matrix);
+  }
 
   // Check inequivalence operator
   CHECK_FALSE(trans_map != trans_map);
@@ -87,6 +112,14 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.TimeDependent.Translation",
   CHECK_FALSE(trans_map != trans_map_deserialized);
 
   test_coordinate_map_argument_types(trans_map, point_xi, t, f_of_t_list);
-  CHECK(not CoordinateMaps::TimeDependent::Translation{}.is_identity());
+  CHECK(not CoordinateMaps::TimeDependent::Translation<Dim>{}.is_identity());
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.TimeDependent.Translation",
+                  "[Domain][Unit]") {
+  test_translation<1>();
+  test_translation<2>();
+  test_translation<3>();
 }
 }  // namespace domain

--- a/tests/Unit/Domain/Creators/Test_Brick.cpp
+++ b/tests/Unit/Domain/Creators/Test_Brick.cpp
@@ -45,10 +45,7 @@ namespace domain {
 namespace {
 using Affine = CoordinateMaps::Affine;
 using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
-using Translation = CoordinateMaps::TimeDependent::Translation;
-using Translation3D =
-    CoordinateMaps::TimeDependent::ProductOf3Maps<Translation, Translation,
-                                                  Translation>;
+using Translation3D = CoordinateMaps::TimeDependent::Translation<3>;
 
 template <typename... FuncsOfTime>
 void test_brick_construction(
@@ -370,8 +367,7 @@ void test_brick_factory() {
         "      InitialTime: 1.0\n"
         "      InitialExpirationDeltaT: 9.0\n"
         "      Velocity: [2.3, -0.3, 0.5]\n"
-        "      FunctionOfTimeNames: [TranslationX, TranslationY, "
-        "TranslationZ]");
+        "      FunctionOfTimeName: Translation");
     const auto* brick_creator =
         dynamic_cast<const creators::Brick*>(domain_creator.get());
     test_brick_construction(
@@ -387,20 +383,13 @@ void test_brick_factory() {
         std::make_tuple(
             std::pair<std::string,
                       domain::FunctionsOfTime::PiecewisePolynomial<2>>{
-                "TranslationX",
-                {1.0, std::array<DataVector, 3>{{{0.0}, {2.3}, {0.0}}}, 10.0}},
-            std::pair<std::string,
-                      domain::FunctionsOfTime::PiecewisePolynomial<2>>{
-                "TranslationY",
-                {1.0, std::array<DataVector, 3>{{{0.0}, {-0.3}, {0.0}}}, 10.0}},
-            std::pair<std::string,
-                      domain::FunctionsOfTime::PiecewisePolynomial<2>>{
-                "TranslationZ",
-                {1.0, std::array<DataVector, 3>{{{0.0}, {0.5}, {0.0}}}, 10.0}}),
+                "Translation",
+                {1.0,
+                 std::array<DataVector, 3>{
+                     {{3, 0.0}, {2.3, -0.3, 0.5}, {3, 0.0}}},
+                 10.0}}),
         make_vector_coordinate_map_base<Frame::Grid, Frame::Inertial>(
-            Translation3D{Translation{"TranslationX"},
-                          Translation{"TranslationY"},
-                          Translation{"TranslationZ"}}));
+            Translation3D{"Translation"}));
   }
   {
     INFO("Brick factory time dependent");
@@ -418,8 +407,7 @@ void test_brick_factory() {
         "      InitialTime: 1.0\n"
         "      InitialExpirationDeltaT: 9.0\n"
         "      Velocity: [2.3, -0.3, 0.5]\n"
-        "      FunctionOfTimeNames: [TranslationX, TranslationY, "
-        "TranslationZ]\n" +
+        "      FunctionOfTimeName: Translation\n" +
         boundary_conditions);
     const auto* brick_creator =
         dynamic_cast<const creators::Brick*>(domain_creator.get());
@@ -436,20 +424,13 @@ void test_brick_factory() {
         std::make_tuple(
             std::pair<std::string,
                       domain::FunctionsOfTime::PiecewisePolynomial<2>>{
-                "TranslationX",
-                {1.0, std::array<DataVector, 3>{{{0.0}, {2.3}, {0.0}}}, 10.0}},
-            std::pair<std::string,
-                      domain::FunctionsOfTime::PiecewisePolynomial<2>>{
-                "TranslationY",
-                {1.0, std::array<DataVector, 3>{{{0.0}, {-0.3}, {0.0}}}, 10.0}},
-            std::pair<std::string,
-                      domain::FunctionsOfTime::PiecewisePolynomial<2>>{
-                "TranslationZ",
-                {1.0, std::array<DataVector, 3>{{{0.0}, {0.5}, {0.0}}}, 10.0}}),
+                "Translation",
+                {1.0,
+                 std::array<DataVector, 3>{
+                     {{3, 0.0}, {2.3, -0.3, 0.5}, {3, 0.0}}},
+                 10.0}}),
         make_vector_coordinate_map_base<Frame::Grid, Frame::Inertial>(
-            Translation3D{Translation{"TranslationX"},
-                          Translation{"TranslationY"},
-                          Translation{"TranslationZ"}}),
+            Translation3D{"Translation"}),
         create_boundary_conditions());
   }
 }

--- a/tests/Unit/Domain/Creators/Test_Interval.cpp
+++ b/tests/Unit/Domain/Creators/Test_Interval.cpp
@@ -296,7 +296,7 @@ void test_interval_factory() {
         "      InitialTime: 1.0\n"
         "      InitialExpirationDeltaT: 9.0\n"
         "      Velocity: [2.3]\n"
-        "      FunctionOfTimeNames: [TranslationX]");
+        "      FunctionOfTimeName: TranslationX");
     const auto* interval_creator =
         dynamic_cast<const creators::Interval*>(domain_creator.get());
     test_interval_construction(
@@ -308,7 +308,7 @@ void test_interval_factory() {
                 "TranslationX",
                 {1.0, std::array<DataVector, 3>{{{0.0}, {2.3}, {0.0}}}, 10.0}}),
         make_vector_coordinate_map_base<Frame::Grid, Frame::Inertial>(
-            CoordinateMaps::TimeDependent::Translation{"TranslationX"}),
+            CoordinateMaps::TimeDependent::Translation<1>{"TranslationX"}),
         {});
   }
   {
@@ -327,7 +327,7 @@ void test_interval_factory() {
         "      InitialTime: 1.0\n"
         "      InitialExpirationDeltaT: 9.0\n"
         "      Velocity: [2.3]\n"
-        "      FunctionOfTimeNames: [TranslationX]\n"
+        "      FunctionOfTimeName: TranslationX\n"
         "  BoundaryConditions:\n"
         "    LowerBoundary:\n"
         "      TestBoundaryCondition:\n"
@@ -348,7 +348,7 @@ void test_interval_factory() {
                 "TranslationX",
                 {1.0, std::array<DataVector, 3>{{{0.0}, {2.3}, {0.0}}}, 10.0}}),
         make_vector_coordinate_map_base<Frame::Grid, Frame::Inertial>(
-            CoordinateMaps::TimeDependent::Translation{"TranslationX"}),
+            CoordinateMaps::TimeDependent::Translation<1>{"TranslationX"}),
         expected_boundary_conditions);
   }
 }

--- a/tests/Unit/Domain/Creators/Test_Rectangle.cpp
+++ b/tests/Unit/Domain/Creators/Test_Rectangle.cpp
@@ -45,9 +45,7 @@ namespace domain {
 namespace {
 using Affine = CoordinateMaps::Affine;
 using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
-using Translation = CoordinateMaps::TimeDependent::Translation;
-using Translation2D =
-    CoordinateMaps::TimeDependent::ProductOf2Maps<Translation, Translation>;
+using Translation2D = CoordinateMaps::TimeDependent::Translation<2>;
 
 template <typename... FuncsOfTime>
 void test_rectangle_construction(
@@ -294,7 +292,7 @@ void test_rectangle_factory() {
         "      InitialTime: 1.0\n"
         "      InitialExpirationDeltaT: 9.0\n"
         "      Velocity: [2.3, -0.3]\n"
-        "      FunctionOfTimeNames: [TranslationX, TranslationY]");
+        "      FunctionOfTimeName: Translation");
     const auto* rectangle_creator =
         dynamic_cast<const creators::Rectangle*>(domain_creator.get());
     test_rectangle_construction(
@@ -305,16 +303,12 @@ void test_rectangle_factory() {
         std::make_tuple(
             std::pair<std::string,
                       domain::FunctionsOfTime::PiecewisePolynomial<2>>{
-                "TranslationX",
-                {1.0, std::array<DataVector, 3>{{{0.0}, {2.3}, {0.0}}}, 10.0}},
-            std::pair<std::string,
-                      domain::FunctionsOfTime::PiecewisePolynomial<2>>{
-                "TranslationY",
-                {1.0, std::array<DataVector, 3>{{{0.0}, {-0.3}, {0.0}}},
+                "Translation",
+                {1.0,
+                 std::array<DataVector, 3>{{{2, 0.0}, {2.3, -0.3}, {2, 0.0}}},
                  10.0}}),
         make_vector_coordinate_map_base<Frame::Grid, Frame::Inertial>(
-            Translation2D{Translation{"TranslationX"},
-                          Translation{"TranslationY"}}));
+            Translation2D{"Translation"}));
   }
   {
     INFO("Rectangle factory time dependent, with boundary conditions");
@@ -333,7 +327,7 @@ void test_rectangle_factory() {
         "      InitialTime: 1.0\n"
         "      InitialExpirationDeltaT: 9.0\n"
         "      Velocity: [2.3, -0.3]\n"
-        "      FunctionOfTimeNames: [TranslationX, TranslationY]\n"
+        "      FunctionOfTimeName: Translation\n"
         "  BoundaryCondition:\n"
         "    TestBoundaryCondition:\n"
         "      Direction: lower-xi\n"
@@ -349,16 +343,12 @@ void test_rectangle_factory() {
         std::make_tuple(
             std::pair<std::string,
                       domain::FunctionsOfTime::PiecewisePolynomial<2>>{
-                "TranslationX",
-                {1.0, std::array<DataVector, 3>{{{0.0}, {2.3}, {0.0}}}, 10.0}},
-            std::pair<std::string,
-                      domain::FunctionsOfTime::PiecewisePolynomial<2>>{
-                "TranslationY",
-                {1.0, std::array<DataVector, 3>{{{0.0}, {-0.3}, {0.0}}},
+                "Translation",
+                {1.0,
+                 std::array<DataVector, 3>{{{2, 0.0}, {2.3, -0.3}, {2, 0.0}}},
                  10.0}}),
         make_vector_coordinate_map_base<Frame::Grid, Frame::Inertial>(
-            Translation2D{Translation{"TranslationX"},
-                          Translation{"TranslationY"}}),
+            Translation2D{"Translation"}),
         expected_boundary_conditions);
   }
 }  // namespace domain

--- a/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
@@ -334,7 +334,7 @@ void test_rotated_intervals_factory() {
         "      InitialTime: 1.0\n"
         "      InitialExpirationDeltaT: 9.0\n"
         "      Velocity: [2.3]\n"
-        "      FunctionOfTimeNames: [TranslationX]\n");
+        "      FunctionOfTimeName: TranslationX\n");
     const auto* rotated_intervals_creator =
         dynamic_cast<const creators::RotatedIntervals*>(domain_creator.get());
     test_rotated_intervals_construction(
@@ -352,8 +352,8 @@ void test_rotated_intervals_factory() {
                 "TranslationX",
                 {1.0, std::array<DataVector, 3>{{{0.0}, {2.3}, {0.0}}}, 10.0}}),
         make_vector_coordinate_map_base<Frame::Grid, Frame::Inertial>(
-            CoordinateMaps::TimeDependent::Translation{"TranslationX"},
-            CoordinateMaps::TimeDependent::Translation{"TranslationX"}),
+            CoordinateMaps::TimeDependent::Translation<1>{"TranslationX"},
+            CoordinateMaps::TimeDependent::Translation<1>{"TranslationX"}),
         {});
   }
   {
@@ -374,7 +374,7 @@ void test_rotated_intervals_factory() {
         "      InitialTime: 1.0\n"
         "      InitialExpirationDeltaT: 9.0\n"
         "      Velocity: [2.3]\n"
-        "      FunctionOfTimeNames: [TranslationX]\n"
+        "      FunctionOfTimeName: TranslationX\n"
         "  BoundaryConditions:\n"
         "    LowerBoundary:\n"
         "      TestBoundaryCondition:\n"
@@ -399,8 +399,8 @@ void test_rotated_intervals_factory() {
                 "TranslationX",
                 {1.0, std::array<DataVector, 3>{{{0.0}, {2.3}, {0.0}}}, 10.0}}),
         make_vector_coordinate_map_base<Frame::Grid, Frame::Inertial>(
-            CoordinateMaps::TimeDependent::Translation{"TranslationX"},
-            CoordinateMaps::TimeDependent::Translation{"TranslationX"}),
+            CoordinateMaps::TimeDependent::Translation<1>{"TranslationX"},
+            CoordinateMaps::TimeDependent::Translation<1>{"TranslationX"}),
         expected_boundary_conditions);
   }
 }

--- a/tests/Unit/Domain/Creators/Test_Shell.cpp
+++ b/tests/Unit/Domain/Creators/Test_Shell.cpp
@@ -65,10 +65,8 @@
 
 namespace domain {
 namespace {
-using Translation = CoordinateMaps::TimeDependent::Translation;
-using Translation3D =
-    CoordinateMaps::TimeDependent::ProductOf3Maps<Translation, Translation,
-                                                  Translation>;
+using Translation = CoordinateMaps::TimeDependent::Translation<1>;
+using Translation3D = CoordinateMaps::TimeDependent::Translation<3>;
 
 using BoundaryCondVector = std::vector<DirectionMap<
     3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>;
@@ -512,9 +510,7 @@ void test_shell_factory_equiangular_time_dependent() {
         "      InitialTime: 1.0\n"
         "      InitialExpirationDeltaT: 9.0\n"
         "      Velocity: [2.3, -0.3, 1.2]\n"
-        "      FunctionOfTimeNames: [TranslationX,"
-        "                            TranslationY,"
-        "                            TranslationZ]\n" +
+        "      FunctionOfTimeName: Translation\n" +
         (expected_boundary_conditions.empty() ? std::string{}
                                               : boundary_conditions_string()));
     const double inner_radius = 1.0;
@@ -528,35 +524,15 @@ void test_shell_factory_equiangular_time_dependent() {
         std::make_tuple(
             std::pair<std::string,
                       domain::FunctionsOfTime::PiecewisePolynomial<2>>{
-                "TranslationX",
-                {1.0, std::array<DataVector, 3>{{{0.0}, {2.3}, {0.0}}}, 10.0}},
-            std::pair<std::string,
-                      domain::FunctionsOfTime::PiecewisePolynomial<2>>{
-                "TranslationY",
-                {1.0, std::array<DataVector, 3>{{{0.0}, {-0.3}, {0.0}}}, 10.0}},
-            std::pair<std::string,
-                      domain::FunctionsOfTime::PiecewisePolynomial<2>>{
-                "TranslationZ",
-                {1.0, std::array<DataVector, 3>{{{0.0}, {1.2}, {0.0}}}, 10.0}}),
+                "Translation",
+                {1.0,
+                 std::array<DataVector, 3>{
+                     {{3, 0.0}, {2.3, -0.3, 1.2}, {3, 0.0}}},
+                 10.0}}),
         make_vector_coordinate_map_base<Frame::Grid, Frame::Inertial>(
-            Translation3D{Translation{"TranslationX"},
-                          Translation{"TranslationY"},
-                          Translation{"TranslationZ"}},
-            Translation3D{Translation{"TranslationX"},
-                          Translation{"TranslationY"},
-                          Translation{"TranslationZ"}},
-            Translation3D{Translation{"TranslationX"},
-                          Translation{"TranslationY"},
-                          Translation{"TranslationZ"}},
-            Translation3D{Translation{"TranslationX"},
-                          Translation{"TranslationY"},
-                          Translation{"TranslationZ"}},
-            Translation3D{Translation{"TranslationX"},
-                          Translation{"TranslationY"},
-                          Translation{"TranslationZ"}},
-            Translation3D{Translation{"TranslationX"},
-                          Translation{"TranslationY"},
-                          Translation{"TranslationZ"}}),
+            Translation3D{"Translation"}, Translation3D{"Translation"},
+            Translation3D{"Translation"}, Translation3D{"Translation"},
+            Translation3D{"Translation"}, Translation3D{"Translation"}),
         expected_boundary_conditions);
   };
   helper(BoundaryCondVector{}, std::false_type{});

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_Composition.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_Composition.cpp
@@ -22,7 +22,7 @@
 namespace domain::creators::time_dependence {
 
 namespace {
-using Translation = domain::CoordinateMaps::TimeDependent::Translation;
+using Translation = domain::CoordinateMaps::TimeDependent::Translation<1>;
 
 template <typename T0, size_t MeshDim>
 void test_impl(
@@ -111,8 +111,7 @@ void test_impl(
 }
 
 template <typename T>
-void test_composition_1d(const gsl::not_null<T> gen,
-                         const double initial_time,
+void test_composition_1d(const gsl::not_null<T> gen, const double initial_time,
                          const double update_delta_t) noexcept {
   using Composition1d =
       Composition<TimeDependenceCompositionTag<UniformTranslation<1>>,
@@ -120,8 +119,8 @@ void test_composition_1d(const gsl::not_null<T> gen,
 
   const std::array<double, 1> velocity0{{2.4}};
   const std::array<double, 1> velocity1{{-1.4}};
-  const std::array<std::string, 1> f_of_t_names0{{"TranslationInX0"}};
-  const std::array<std::string, 1> f_of_t_names1{{"TranslationInX1"}};
+  const std::string f_of_t_names0 = "TranslationInX0";
+  const std::string f_of_t_names1 = "TranslationInX1";
 
   std::unique_ptr<domain::creators::time_dependence::TimeDependence<1>>
       time_dep0 = std::make_unique<UniformTranslation<1>>(
@@ -132,23 +131,21 @@ void test_composition_1d(const gsl::not_null<T> gen,
 
   const std::unique_ptr<domain::creators::time_dependence::TimeDependence<1>>
       expected_time_dep = std::make_unique<UniformTranslation<1>>(
-          initial_time, update_delta_t, velocity0 + velocity1,
-          std::array<std::string, 1>{{"TranslationX"}});
+          initial_time, update_delta_t, velocity0 + velocity1, "TranslationX");
 
   const std::unique_ptr<domain::creators::time_dependence::TimeDependence<1>>
       time_dep = std::make_unique<Composition1d>(std::move(time_dep0),
                                                  std::move(time_dep1));
 
   test_impl(gen, initial_time, time_dep, expected_time_dep,
-            {f_of_t_names0[0], f_of_t_names1[0]});
+            {f_of_t_names0, f_of_t_names1});
 
   test_impl(gen, initial_time, time_dep->get_clone(), expected_time_dep,
-            {f_of_t_names0[0], f_of_t_names1[0]});
+            {f_of_t_names0, f_of_t_names1});
 }
 
 template <typename T>
-void test_composition_2d(const gsl::not_null<T> gen,
-                         const double initial_time,
+void test_composition_2d(const gsl::not_null<T> gen, const double initial_time,
                          const double update_delta_t) noexcept {
   using Composition2d =
       Composition<TimeDependenceCompositionTag<UniformTranslation<2>>,
@@ -156,10 +153,8 @@ void test_composition_2d(const gsl::not_null<T> gen,
 
   const std::array<double, 2> velocity0{{2.4, -7.3}};
   const std::array<double, 2> velocity1{{-1.4, 3.2}};
-  const std::array<std::string, 2> f_of_t_names0{
-      {"TranslationInX0", "TranslationInY0"}};
-  const std::array<std::string, 2> f_of_t_names1{
-      {"TranslationInX1", "TranslationInY1"}};
+  const std::string f_of_t_names0 = "Translation0";
+  const std::string f_of_t_names1 = "Translation1";
 
   std::unique_ptr<domain::creators::time_dependence::TimeDependence<2>>
       time_dep0 = std::make_unique<UniformTranslation<2>>(
@@ -170,25 +165,21 @@ void test_composition_2d(const gsl::not_null<T> gen,
 
   const std::unique_ptr<domain::creators::time_dependence::TimeDependence<2>>
       expected_time_dep = std::make_unique<UniformTranslation<2>>(
-          initial_time, update_delta_t, velocity0 + velocity1,
-          std::array<std::string, 2>{{"TranslationX", "TranslationY"}});
+          initial_time, update_delta_t, velocity0 + velocity1, "Translation");
 
   const std::unique_ptr<domain::creators::time_dependence::TimeDependence<2>>
       time_dep = std::make_unique<Composition2d>(std::move(time_dep0),
                                                  std::move(time_dep1));
 
-  test_impl(
-      gen, initial_time, time_dep, expected_time_dep,
-      {f_of_t_names0[0], f_of_t_names1[0], f_of_t_names0[1], f_of_t_names1[1]});
+  test_impl(gen, initial_time, time_dep, expected_time_dep,
+            {f_of_t_names0, f_of_t_names1});
 
-  test_impl(
-      gen, initial_time, time_dep->get_clone(), expected_time_dep,
-      {f_of_t_names0[0], f_of_t_names1[0], f_of_t_names0[1], f_of_t_names1[1]});
+  test_impl(gen, initial_time, time_dep->get_clone(), expected_time_dep,
+            {f_of_t_names0, f_of_t_names1});
 }
 
 template <typename T>
-void test_composition_3d(const gsl::not_null<T> gen,
-                         const double initial_time,
+void test_composition_3d(const gsl::not_null<T> gen, const double initial_time,
                          const double update_delta_t) noexcept {
   using Composition3d =
       Composition<TimeDependenceCompositionTag<UniformTranslation<3>>,
@@ -196,10 +187,8 @@ void test_composition_3d(const gsl::not_null<T> gen,
 
   const std::array<double, 3> velocity0{{2.4, -7.3, 5.7}};
   const std::array<double, 3> velocity1{{-1.4, 3.2, -1.9}};
-  const std::array<std::string, 3> f_of_t_names0{
-      {"TranslationInX0", "TranslationInY0", "TranslationInZ0"}};
-  const std::array<std::string, 3> f_of_t_names1{
-      {"TranslationInX1", "TranslationInY1", "TranslationInZ1"}};
+  const std::string f_of_t_names0 = "Translation0";
+  const std::string f_of_t_names1 = "Translation1";
 
   std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
       time_dep0 = std::make_unique<UniformTranslation<3>>(
@@ -210,21 +199,17 @@ void test_composition_3d(const gsl::not_null<T> gen,
 
   const std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
       expected_time_dep = std::make_unique<UniformTranslation<3>>(
-          initial_time, update_delta_t, velocity0 + velocity1,
-          std::array<std::string, 3>{
-              {"TranslationX", "TranslationY", "TranslationZ"}});
+          initial_time, update_delta_t, velocity0 + velocity1, "Translation");
 
   const std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
       time_dep = std::make_unique<Composition3d>(std::move(time_dep0),
                                                  std::move(time_dep1));
 
   test_impl(gen, initial_time, time_dep, expected_time_dep,
-            {f_of_t_names0[0], f_of_t_names1[0], f_of_t_names0[1],
-             f_of_t_names1[1], f_of_t_names0[2], f_of_t_names1[2]});
+            {f_of_t_names0, f_of_t_names1});
 
   test_impl(gen, initial_time, time_dep->get_clone(), expected_time_dep,
-            {f_of_t_names0[0], f_of_t_names1[0], f_of_t_names0[1],
-             f_of_t_names1[1], f_of_t_names0[2], f_of_t_names1[2]});
+            {f_of_t_names0, f_of_t_names1});
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependence.Composition",

--- a/tests/Unit/Domain/Test_Domain.cpp
+++ b/tests/Unit/Domain/Test_Domain.cpp
@@ -43,7 +43,7 @@ namespace {
 namespace helpers = ::TestHelpers::domain::BoundaryConditions;
 
 void test_1d_domains() {
-  using Translation = domain::CoordinateMaps::TimeDependent::Translation;
+  using Translation = domain::CoordinateMaps::TimeDependent::Translation<1>;
   {
     PUPable_reg(SINGLE_ARG(CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                                          CoordinateMaps::Affine>));

--- a/tests/Unit/Evolution/DgSubcell/Events/Test_ObserveFields.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Events/Test_ObserveFields.cpp
@@ -85,22 +85,9 @@ using namespace TestHelpers::dg::Events::ObserveFields;
 template <size_t Dim>
 auto make_map() {
   using domain::make_coordinate_map_base;
-  using domain::CoordinateMaps::TimeDependent::Translation;
-  if constexpr (Dim == 1) {
-    return make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
-        Translation("Translation"));
-  } else if constexpr (Dim == 2) {
-    using domain::CoordinateMaps::TimeDependent::ProductOf2Maps;
-    return make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
-        ProductOf2Maps<Translation, Translation>(Translation("Translation"),
-                                                 Translation("Translation")));
-  } else {
-    using domain::CoordinateMaps::TimeDependent::ProductOf3Maps;
-    return make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
-        ProductOf3Maps<Translation, Translation, Translation>(
-            Translation("Translation"), Translation("Translation"),
-            Translation("Translation")));
-  }
+  using Translation = domain::CoordinateMaps::TimeDependent::Translation<Dim>;
+  return make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+      Translation("Translation"));
 }
 
 template <typename System, bool AlwaysHasAnalyticSolutions>
@@ -129,7 +116,10 @@ void test_observe(
   using solution_variables = typename System::solution_for_test::vars_for_test;
   using Polynomial = domain::FunctionsOfTime::PiecewisePolynomial<3>;
   using FoftPtr = std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>;
-  const std::array<DataVector, 4> init_func{{{1.0}, {-2.0}, {2.0}, {0.0}}};
+  const std::array<DataVector, 4> init_func{{{volume_dim, 1.0},
+                                             {volume_dim, -2.0},
+                                             {volume_dim, 2.0},
+                                             {volume_dim, 0.0}}};
   std::unordered_map<std::string, FoftPtr> functions_of_time{};
   functions_of_time["Translation"] =
       std::make_unique<Polynomial>(0, init_func, 1.0e100);

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_GrTagsForHydro.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_GrTagsForHydro.cpp
@@ -51,7 +51,7 @@ SPECTRE_TEST_CASE(
   using SubcellGrVars = typename subcell_gr_tag::type;
   using FaceGrVars = typename subcell_faces_gr_tag::type::value_type;
 
-  using Translation = domain::CoordinateMaps::TimeDependent::Translation;
+  using Translation = domain::CoordinateMaps::TimeDependent::Translation<1>;
   using Identity2D = domain::CoordinateMaps::Identity<2>;
   using Solution =
       RelativisticEuler::Solutions::TovStar<gr::Solutions::TovSolution>;

--- a/tests/Unit/Evolution/Test_TagsDomain.cpp
+++ b/tests/Unit/Evolution/Test_TagsDomain.cpp
@@ -13,15 +13,12 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/Tags.hpp"
-#include "Domain/CoordinateMaps/TimeDependent/ProductMaps.hpp"
-#include "Domain/CoordinateMaps/TimeDependent/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/TimeDependent/Translation.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
@@ -43,57 +40,17 @@ void test_tags() noexcept {
       "div(MeshVelocity)");
 }
 
-using TranslationMap = domain::CoordinateMaps::TimeDependent::Translation;
-using TranslationMap2d =
-    domain::CoordinateMaps::TimeDependent::ProductOf2Maps<TranslationMap,
-                                                          TranslationMap>;
-using TranslationMap3d = domain::CoordinateMaps::TimeDependent::ProductOf3Maps<
-    TranslationMap, TranslationMap, TranslationMap>;
-
-using AffineMap = domain::CoordinateMaps::Affine;
-using AffineMap2d =
-    domain::CoordinateMaps::ProductOf2Maps<AffineMap, AffineMap>;
-using AffineMap3d =
-    domain::CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
+template <size_t MeshDim>
+using TranslationMap =
+    domain::CoordinateMaps::TimeDependent::Translation<MeshDim>;
 
 template <size_t MeshDim>
-using ConcreteMap = tmpl::conditional_t<
-    MeshDim == 1,
-    domain::CoordinateMap<Frame::Grid, Frame::Inertial, TranslationMap,
-                          AffineMap>,
-    tmpl::conditional_t<MeshDim == 2,
-                        domain::CoordinateMap<Frame::Grid, Frame::Inertial,
-                                              TranslationMap2d, AffineMap2d>,
-                        domain::CoordinateMap<Frame::Grid, Frame::Inertial,
-                                              TranslationMap3d, AffineMap3d>>>;
+using ConcreteMap = domain::CoordinateMap<Frame::Grid, Frame::Inertial,
+                                          TranslationMap<MeshDim>>;
 
 template <size_t MeshDim>
-ConcreteMap<MeshDim> create_coord_map(
-    const std::array<std::string, 3>& f_of_t_names);
-
-template <>
-ConcreteMap<1> create_coord_map<1>(
-    const std::array<std::string, 3>& f_of_t_names) {
-  return ConcreteMap<1>{TranslationMap{f_of_t_names[0]},
-                        AffineMap{-1.0, 1.0, 2.0, 7.2}};
-}
-
-template <>
-ConcreteMap<2> create_coord_map<2>(
-    const std::array<std::string, 3>& f_of_t_names) {
-  return ConcreteMap<2>{
-      {TranslationMap{f_of_t_names[0]}, TranslationMap{f_of_t_names[1]}},
-      {AffineMap{-1.0, 1.0, -2.0, 2.2}, AffineMap{-1.0, 1.0, 2.0, 7.2}}};
-}
-
-template <>
-ConcreteMap<3> create_coord_map<3>(
-    const std::array<std::string, 3>& f_of_t_names) {
-  return ConcreteMap<3>{
-      {TranslationMap{f_of_t_names[0]}, TranslationMap{f_of_t_names[1]},
-       TranslationMap{f_of_t_names[2]}},
-      {AffineMap{-1.0, 1.0, -2.0, 2.2}, AffineMap{-1.0, 1.0, 2.0, 7.2},
-       AffineMap{-1.0, 1.0, 1.0, 3.5}}};
+ConcreteMap<MeshDim> create_coord_map(const std::string& f_of_t_name) {
+  return ConcreteMap<MeshDim>{TranslationMap<MeshDim>{f_of_t_name}};
 }
 
 template <size_t Dim, bool IsTimeDependent>
@@ -114,14 +71,13 @@ void test() noexcept {
       domain::Tags::InertialMeshVelocityCompute<Dim>,
       evolution::domain::Tags::DivMeshVelocityCompute<Dim>>;
 
-  const std::array<double, 3> velocity{{1.2, 0.2, -8.9}};
+  const DataVector velocity{Dim, -4.3};
   const double initial_time = 0.0;
   const double expiration_time = 4.5;
   // In 1d, the helper function create_coord_map will only use the first name,
   // i.e., TranslationX. In 2d, it uses the first two names, TranslationX and
   // TranslationY.
-  const std::array<std::string, 3> functions_of_time_names{
-      {"TranslationX", "TranslationY", "TranslationZ"}};
+  const std::string function_of_time_name = "Translation";
 
   MAKE_GENERATOR(gen);
   UniformCustomDistribution<double> dist(-10.0, 10.0);
@@ -141,27 +97,17 @@ void test() noexcept {
   std::unordered_map<std::string,
                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
       functions_of_time{};
-  functions_of_time[functions_of_time_names[0]] =
+  functions_of_time[function_of_time_name] =
       std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
           initial_time,
-          std::array<DataVector, 3>{{{0.0}, {velocity[0]}, {0.0}}},
-          expiration_time);
-  functions_of_time[functions_of_time_names[1]] =
-      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
-          initial_time,
-          std::array<DataVector, 3>{{{0.0}, {velocity[1]}, {0.0}}},
-          expiration_time);
-  functions_of_time[functions_of_time_names[2]] =
-      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
-          initial_time,
-          std::array<DataVector, 3>{{{0.0}, {velocity[2]}, {0.0}}},
+          std::array<DataVector, 3>{{{Dim, 0.0}, velocity, {Dim, 0.0}}},
           expiration_time);
 
   using MapPtr = std::unique_ptr<
       domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, Dim>>;
   const MapPtr grid_to_inertial_map =
       IsTimeDependent ? MapPtr(std::make_unique<ConcreteMap<Dim>>(
-                            create_coord_map<Dim>(functions_of_time_names)))
+                            create_coord_map<Dim>(function_of_time_name)))
                       : MapPtr(std::make_unique<domain::CoordinateMap<
                                    Frame::Grid, Frame::Inertial,
                                    domain::CoordinateMaps::Identity<Dim>>>());


### PR DESCRIPTION
## Proposed changes
Previously, each component of a translation had to be stored as a separate 1d translation map. If you wanted a 2d or 3d translation map, you'd need to do a product of maps. This simplifies the interface by templating the translation map on the dimension.

This was prompted by control system edits. For translation control, we only want one control system controlling one function of time that represents a translation in 3d. With the old implementation of the translation, we would have needed three separate control systems controlling three separate functions of time. That would not have been ideal.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions
- If you have any Translation maps here are the new versions:
```
Old  ->  New
Translation  ->  Translation<1>
ProductOf2Maps<Translation, Translation>  ->  Translation<2>
ProductOf3Maps<Translation, Translation, Translation>  ->  Translation<3>
```
- The UniformTranslation time dependence for a domain creator now takes as its last argument a `std::string` instead of a `std::array<std::string, Dim>` because we no longer need `Dim` number of functions of time to represent a translation map. We only need 1. Thus, in an input file, just a single string is needed for the name of the function of time, not a list.
- The option for the name of the function of time has been renamed from `FunctionOfTimeNames` to `FunctionOfTimeName`. Thus, with the above change, a typical UniformTranslation time dependence in 1 dimension would look like this in an input file:
```
UniformTranslation:
    InitialTime: 0.0
    InitialExpirationDeltaT: 2.0
    Velocity: [0.5]
    FunctionOfTimeName: "Translation1D"
```
and in 3 dimensions...
```
UniformTranslation:
    InitialTime: 0.0
    InitialExpirationDeltaT: 2.0
    Velocity: [0.5, 0.4, 0.3]
    FunctionOfTimeName: "Translation3D"
```

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
