### PR TITLE
Add TensorIndex m and instructions on how to add new TensorIndexs

### DIFF
--- a/src/DataStructures/Tensor/Expressions/TensorIndex.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorIndex.hpp
@@ -125,7 +125,7 @@ get_tensorindex_value_with_opposite_valence(const size_t i) noexcept {
  * - Uppercase: contravariant/upper index
  * - Lowercase: covariant/lower index
  * - A/a - H/h: generic spacetime index
- * - I/i - L/l: generic spatial index
+ * - I/i - M/m: generic spatial index
  * - T/t: concrete time index (defined as a spacetime `TensorIndex`)
  *
  * \snippet Test_AddSubtract.cpp use_tensor_index
@@ -194,6 +194,12 @@ static constexpr TensorIndex<
 static constexpr TensorIndex<
     TensorExpressions::TensorIndex_detail::upper_spatial_sentinel + 3>
     ti_L{};
+static constexpr TensorIndex<
+    TensorExpressions::TensorIndex_detail::spatial_sentinel + 4>
+    ti_m{};
+static constexpr TensorIndex<
+    TensorExpressions::TensorIndex_detail::upper_spatial_sentinel + 4>
+    ti_M{};
 /// @}
 
 namespace tt {

--- a/src/DataStructures/Tensor/Expressions/TensorIndex.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorIndex.hpp
@@ -129,6 +129,30 @@ get_tensorindex_value_with_opposite_valence(const size_t i) noexcept {
  * - T/t: concrete time index (defined as a spacetime `TensorIndex`)
  *
  * \snippet Test_AddSubtract.cpp use_tensor_index
+ *
+ * If you want to support a new generic index, definitions for the upper and
+ * lower versions of the index must be added as unique `TensorIndex` types, e.g.
+ * \code
+ * static constexpr TensorIndex<UNIQUE_INTEGER_IN_PROPER_RANGE_LOWER> ti_x{};
+ * static constexpr TensorIndex<UNIQUE_INTEGER_IN_PROPER_RANGE_UPPER> ti_X{};
+ * \endcode
+ * where `UNIQUE_INTEGER_IN_PROPER_RANGE_LOWER` and
+ * `UNIQUE_INTEGER_IN_PROPER_RANGE_UPPER` are unique, but related integers that
+ * fall in the integer ranges that properly encode the index's properties
+ * according to the `_sentinel` values defined at the top of
+ * `src/DataStructures/Tensor/Expressions/TensorIndex.hpp`. This enables the new
+ * index to be distinguishable from others and for the upper and lower versions
+ * to be recognized as related by opposite valence. See comments there on these
+ * integer ranges to properly encode the new index (both upper and lower
+ * definitions) that you wish to add. In short, you should simply be able to
+ * continue the pattern used for the existing `TensorIndex` types that are
+ * already defined. For example, if `ti_M`/`ti_m` is the highest-valued generic
+ * spatial index currently defined and you want to add `ti_N`/`ti_n` as a new
+ * generic spatial index, you can simply define `ti_N` and `ti_n`'s unique
+ * integer values to be `INTEGER_VALUE_FOR_M + 1` and `INTEGER_VALUE_FOR_m + 1`,
+ * respectively. For adding a new generic spacetime index, you should be able to
+ * do the same thing with respect to the upper and lower versions of the
+ * highest-valued currently defined generic spacetime `TensorIndex`.
  */
 static constexpr TensorIndex<0> ti_a{};
 static constexpr TensorIndex<


### PR DESCRIPTION
## Proposed changes

This PR adds
- m (`ti_m` and `ti_M`) as new generic `TensorIndex`s that can be used to write tensor equations with `TensorExpression`s
- documentation with instructions on how to add new `TensorIndex`s when needed

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
