### PR TITLE
Remove EquationOfStateType from NewtonianEuler::System

### DIFF
--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -124,8 +124,7 @@ struct EvolutionMetavars {
 
   using source_term_type = typename initial_data::source_term_type;
 
-  using system =
-      NewtonianEuler::System<Dim, equation_of_state_type, initial_data>;
+  using system = NewtonianEuler::System<Dim, initial_data>;
 
   using temporal_id = Tags::TimeStepId;
   static constexpr bool local_time_stepping = false;

--- a/src/Evolution/Executables/NewtonianEuler/VolumeTermsInstantiation.cpp
+++ b/src/Evolution/Executables/NewtonianEuler/VolumeTermsInstantiation.cpp
@@ -15,26 +15,14 @@
 #include "PointwiseFunctions/AnalyticSolutions/NewtonianEuler/SmoothFlow.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
-namespace {
-// The system is currently templated on the equation of state, but it's only
-// used in code that will be removed and that we don't care about. Even the
-// dependence on the thermodynamic dimension can probably be removed. In either
-// case, we don't care about the thermodynamic dimension for the explicit
-// instantiation either.
-struct DummyEquationOfStateType {
-  static constexpr size_t thermodynamic_dim = 1;
-};
-}  // namespace
-
 namespace evolution::dg::Actions::detail {
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define INITIAL_DATA_TYPE(data)                           \
   BOOST_PP_IF(BOOST_PP_TUPLE_ELEM(2, data),               \
               BOOST_PP_TUPLE_ELEM(1, data) < DIM(data) >, \
               BOOST_PP_TUPLE_ELEM(1, data))
-#define SYSTEM(data)                                            \
-  ::NewtonianEuler::System<DIM(data), DummyEquationOfStateType, \
-                           INITIAL_DATA_TYPE(data)>
+#define SYSTEM(data) \
+  ::NewtonianEuler::System<DIM(data), INITIAL_DATA_TYPE(data)>
 
 #define INSTANTIATION(r, data)                                                \
   template void volume_terms<::NewtonianEuler::TimeDerivativeTerms<           \

--- a/src/Evolution/Systems/NewtonianEuler/PrimitiveFromConservative.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/PrimitiveFromConservative.cpp
@@ -18,8 +18,9 @@
 
 namespace NewtonianEuler {
 
-template <size_t Dim, size_t ThermodynamicDim>
-void PrimitiveFromConservative<Dim, ThermodynamicDim>::apply(
+template <size_t Dim>
+template <size_t ThermodynamicDim>
+void PrimitiveFromConservative<Dim>::apply(
     const gsl::not_null<Scalar<DataVector>*> mass_density,
     const gsl::not_null<tnsr::I<DataVector, Dim>*> velocity,
     const gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
@@ -52,14 +53,31 @@ void PrimitiveFromConservative<Dim, ThermodynamicDim>::apply(
 }  // namespace NewtonianEuler
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(_, data) \
+  template struct NewtonianEuler::PrimitiveFromConservative<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+
 #define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define INSTANTIATE(_, data)                                           \
-  template struct NewtonianEuler::PrimitiveFromConservative<DIM(data), \
-                                                            THERMO_DIM(data)>;
+#define INSTANTIATION(_, data)                                               \
+  template void NewtonianEuler::PrimitiveFromConservative<DIM(data)>::apply< \
+      THERMO_DIM(data)>(                                                     \
+      const gsl::not_null<Scalar<DataVector>*> mass_density,                 \
+      const gsl::not_null<tnsr::I<DataVector, DIM(data)>*> velocity,         \
+      const gsl::not_null<Scalar<DataVector>*> specific_internal_energy,     \
+      const gsl::not_null<Scalar<DataVector>*> pressure,                     \
+      const Scalar<DataVector>& mass_density_cons,                           \
+      const tnsr::I<DataVector, DIM(data)>& momentum_density,                \
+      const Scalar<DataVector>& energy_density,                              \
+      const EquationsOfState::EquationOfState<false, THERMO_DIM(data)>&      \
+          equation_of_state) noexcept;
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (1, 2))
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2))
 
-#undef DIM
+#undef INSTANTIATION
 #undef THERMO_DIM
-#undef INSTANTIATE
+#undef DIM

--- a/src/Evolution/Systems/NewtonianEuler/PrimitiveFromConservative.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/PrimitiveFromConservative.hpp
@@ -50,7 +50,7 @@ namespace NewtonianEuler {
  * This routine also returns the mass density as a primitive, and the pressure
  * from a generic equation of state \f$p = p(\rho, \epsilon)\f$.
  */
-template <size_t Dim, size_t ThermodynamicDim>
+template <size_t Dim>
 struct PrimitiveFromConservative {
   using return_tags =
       tmpl::list<Tags::MassDensity<DataVector>, Tags::Velocity<DataVector, Dim>,
@@ -61,6 +61,7 @@ struct PrimitiveFromConservative {
       tmpl::list<Tags::MassDensityCons, Tags::MomentumDensity<Dim>,
                  Tags::EnergyDensity, hydro::Tags::EquationOfStateBase>;
 
+  template <size_t ThermodynamicDim>
   static void apply(
       gsl::not_null<Scalar<DataVector>*> mass_density,
       gsl::not_null<tnsr::I<DataVector, Dim>*> velocity,

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/PrimsAfterRollback.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/PrimsAfterRollback.cpp
@@ -34,7 +34,7 @@ void PrimsAfterRollback<Dim>::apply(
     if (prim_vars->number_of_grid_points() != num_grid_points) {
       prim_vars->initialize(num_grid_points);
     }
-    NewtonianEuler::PrimitiveFromConservative<Dim, ThermodynamicDim>::apply(
+    NewtonianEuler::PrimitiveFromConservative<Dim>::apply(
         make_not_null(&get<MassDensity>(*prim_vars)),
         make_not_null(&get<Velocity>(*prim_vars)),
         make_not_null(&get<SpecificInternalEnergy>(*prim_vars)),

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/ResizeAndComputePrimitives.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/ResizeAndComputePrimitives.cpp
@@ -42,7 +42,7 @@ void ResizeAndComputePrims<Dim>::apply(
 
     // We only need to compute the prims if we switched to the DG grid because
     // otherwise we computed the prims during the FD TCI.
-    NewtonianEuler::PrimitiveFromConservative<Dim, ThermodynamicDim>::apply(
+    NewtonianEuler::PrimitiveFromConservative<Dim>::apply(
         make_not_null(&get<MassDensity>(*prim_vars)),
         make_not_null(&get<Velocity>(*prim_vars)),
         make_not_null(&get<SpecificInternalEnergy>(*prim_vars)),

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnDgGrid.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnDgGrid.cpp
@@ -28,7 +28,7 @@ bool TciOnDgGrid<Dim>::apply(
     const Scalar<DataVector>& energy_density,
     const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
     const Mesh<Dim>& dg_mesh, const double persson_exponent) noexcept {
-  NewtonianEuler::PrimitiveFromConservative<Dim, ThermodynamicDim>::apply(
+  NewtonianEuler::PrimitiveFromConservative<Dim>::apply(
       make_not_null(&get<MassDensity>(*dg_prim_vars)),
       make_not_null(&get<Velocity>(*dg_prim_vars)),
       make_not_null(&get<SpecificInternalEnergy>(*dg_prim_vars)),

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnFdGrid.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnFdGrid.cpp
@@ -33,7 +33,7 @@ bool TciOnFdGrid<Dim>::apply(
     const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
     const Mesh<Dim>& dg_mesh, const double persson_exponent) noexcept {
   constexpr double persson_tci_epsilon = 1.0e-18;
-  NewtonianEuler::PrimitiveFromConservative<Dim, ThermodynamicDim>::apply(
+  NewtonianEuler::PrimitiveFromConservative<Dim>::apply(
       make_not_null(&get<MassDensity>(*subcell_grid_prim_vars)),
       make_not_null(&get<Velocity>(*subcell_grid_prim_vars)),
       make_not_null(&get<SpecificInternalEnergy>(*subcell_grid_prim_vars)),
@@ -42,7 +42,7 @@ bool TciOnFdGrid<Dim>::apply(
       eos);
   Variables<tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>>
       dg_grid_prim_vars{get(dg_energy_density).size()};
-  NewtonianEuler::PrimitiveFromConservative<Dim, ThermodynamicDim>::apply(
+  NewtonianEuler::PrimitiveFromConservative<Dim>::apply(
       make_not_null(&get<MassDensity>(dg_grid_prim_vars)),
       make_not_null(&get<Velocity>(dg_grid_prim_vars)),
       make_not_null(&get<SpecificInternalEnergy>(dg_grid_prim_vars)),

--- a/src/Evolution/Systems/NewtonianEuler/System.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/System.hpp
@@ -22,13 +22,11 @@
 /// \brief Items related to evolving the Newtonian Euler system
 namespace NewtonianEuler {
 
-template <size_t Dim, typename EquationOfStateType, typename InitialDataType>
+template <size_t Dim, typename InitialDataType>
 struct System {
   static constexpr bool is_in_flux_conservative_form = true;
   static constexpr bool has_primitive_and_conservative_vars = true;
   static constexpr size_t volume_dim = Dim;
-  static constexpr size_t thermodynamic_dim =
-      EquationOfStateType::thermodynamic_dim;
 
   using boundary_conditions_base = BoundaryConditions::BoundaryCondition<Dim>;
   using boundary_correction_base = BoundaryCorrections::BoundaryCorrection<Dim>;
@@ -54,8 +52,7 @@ struct System {
   using volume_sources = ComputeSources<InitialDataType>;
 
   using conservative_from_primitive = ConservativeFromPrimitive<Dim>;
-  using primitive_from_conservative =
-      PrimitiveFromConservative<Dim, thermodynamic_dim>;
+  using primitive_from_conservative = PrimitiveFromConservative<Dim>;
 
   using compute_largest_characteristic_speed =
       Tags::ComputeLargestCharacteristicSpeed<Dim>;

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryConditions/Test_DirichletAnalytic.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryConditions/Test_DirichletAnalytic.cpp
@@ -121,8 +121,6 @@ void test() {
       NewtonianEuler::BoundaryConditions::DirichletAnalytic<Dim>,
       NewtonianEuler::BoundaryConditions::BoundaryCondition<Dim>,
       NewtonianEuler::System<Dim,
-                             typename NewtonianEuler::Solutions::SmoothFlow<
-                                 Dim>::equation_of_state_type,
                              NewtonianEuler::Solutions::SmoothFlow<Dim>>,
       tmpl::list<NewtonianEuler::BoundaryCorrections::Rusanov<Dim>>,
       tmpl::list<ConvertSmoothFlow<Dim>>>(
@@ -171,8 +169,6 @@ void test() {
         NewtonianEuler::BoundaryConditions::BoundaryCondition<Dim>,
         NewtonianEuler::System<
             Dim,
-            typename NewtonianEuler::AnalyticData::KhInstability<
-                Dim>::equation_of_state_type,
             NewtonianEuler::AnalyticData::KhInstability<Dim>>,
         tmpl::list<NewtonianEuler::BoundaryCorrections::Rusanov<Dim>>,
         tmpl::list<ConvertKhInstability<Dim>>>(

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Test_Hll.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Test_Hll.cpp
@@ -91,14 +91,14 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts,
       ranges{std::array{1.0e-30, 1.0}, std::array{1.0e-30, 1.0}};
 
   helpers::test_boundary_correction_conservation<
-      NewtonianEuler::System<Dim, EosType, DummyInitialData>>(
+      NewtonianEuler::System<Dim, DummyInitialData>>(
       gen, NewtonianEuler::BoundaryCorrections::Hll<Dim>{},
       Mesh<Dim - 1>{num_pts, Spectral::Basis::Legendre,
                     Spectral::Quadrature::Gauss},
       volume_data, ranges);
 
   helpers::test_boundary_correction_with_python<
-      NewtonianEuler::System<Dim, EosType, DummyInitialData>,
+      NewtonianEuler::System<Dim, DummyInitialData>,
       tmpl::list<ConvertPolytropic, ConvertIdeal>>(
       gen, "Hll",
       {{"dg_package_data_mass_density", "dg_package_data_momentum_density",
@@ -119,7 +119,7 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts,
       NewtonianEuler::BoundaryCorrections::BoundaryCorrection<Dim>>>("Hll:");
 
   helpers::test_boundary_correction_with_python<
-      NewtonianEuler::System<Dim, EosType, DummyInitialData>,
+      NewtonianEuler::System<Dim, DummyInitialData>,
       tmpl::list<ConvertPolytropic, ConvertIdeal>>(
       gen, "Hll",
       {{"dg_package_data_mass_density", "dg_package_data_momentum_density",

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Test_Hllc.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Test_Hllc.cpp
@@ -91,14 +91,14 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts,
       ranges{std::array{1.0e-30, 1.0}, std::array{1.0e-30, 1.0}};
 
   helpers::test_boundary_correction_conservation<
-      NewtonianEuler::System<Dim, EosType, DummyInitialData>>(
+      NewtonianEuler::System<Dim, DummyInitialData>>(
       gen, NewtonianEuler::BoundaryCorrections::Hllc<Dim>{},
       Mesh<Dim - 1>{num_pts, Spectral::Basis::Legendre,
                     Spectral::Quadrature::Gauss},
       volume_data, ranges);
 
   helpers::test_boundary_correction_with_python<
-      NewtonianEuler::System<Dim, EosType, DummyInitialData>,
+      NewtonianEuler::System<Dim, DummyInitialData>,
       tmpl::list<ConvertPolytropic, ConvertIdeal>>(
       gen, "Hllc",
       {{"dg_package_data_mass_density", "dg_package_data_momentum_density",
@@ -121,7 +121,7 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts,
       NewtonianEuler::BoundaryCorrections::BoundaryCorrection<Dim>>>("Hllc:");
 
   helpers::test_boundary_correction_with_python<
-      NewtonianEuler::System<Dim, EosType, DummyInitialData>,
+      NewtonianEuler::System<Dim, DummyInitialData>,
       tmpl::list<ConvertPolytropic, ConvertIdeal>>(
       gen, "Hllc",
       {{"dg_package_data_mass_density", "dg_package_data_momentum_density",

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Test_Rusanov.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Test_Rusanov.cpp
@@ -92,14 +92,14 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts,
              std::array<double, 2>{{1.0e-30, 1.0}}};
 
   helpers::test_boundary_correction_conservation<
-      NewtonianEuler::System<Dim, EosType, DummyInitialData>>(
+      NewtonianEuler::System<Dim, DummyInitialData>>(
       gen, NewtonianEuler::BoundaryCorrections::Rusanov<Dim>{},
       Mesh<Dim - 1>{num_pts, Spectral::Basis::Legendre,
                     Spectral::Quadrature::Gauss},
       volume_data, ranges);
 
   helpers::test_boundary_correction_with_python<
-      NewtonianEuler::System<Dim, EosType, DummyInitialData>,
+      NewtonianEuler::System<Dim, DummyInitialData>,
       tmpl::list<ConvertPolytropic, ConvertIdeal>>(
       gen, "Rusanov",
       {{"dg_package_data_mass_density", "dg_package_data_momentum_density",
@@ -120,7 +120,7 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts,
       "Rusanov:");
 
   helpers::test_boundary_correction_with_python<
-      NewtonianEuler::System<Dim, EosType, DummyInitialData>,
+      NewtonianEuler::System<Dim, DummyInitialData>,
       tmpl::list<ConvertPolytropic, ConvertIdeal>>(
       gen, "Rusanov",
       {{"dg_package_data_mass_density", "dg_package_data_momentum_density",

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_PrimsAfterRollback.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_PrimsAfterRollback.cpp
@@ -78,7 +78,7 @@ void test(const gsl::not_null<std::mt19937*> gen,
         db::get<::Tags::Variables<prim_tags>>(box).number_of_grid_points() ==
         cons_vars.number_of_grid_points());
     expected_prim_vars.initialize(cons_vars.number_of_grid_points());
-    NewtonianEuler::PrimitiveFromConservative<Dim, 1>::apply(
+    NewtonianEuler::PrimitiveFromConservative<Dim>::apply(
         make_not_null(&get<MassDensity>(expected_prim_vars)),
         make_not_null(&get<Velocity>(expected_prim_vars)),
         make_not_null(&get<SpecificInternalEnergy>(expected_prim_vars)),

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_ResizeAndComputePrimitives.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_ResizeAndComputePrimitives.cpp
@@ -83,7 +83,7 @@ void test(const gsl::not_null<std::mt19937*> gen,
           cons_vars.number_of_grid_points());
   if (active_grid == evolution::dg::subcell::ActiveGrid::Dg) {
     prim_vars.initialize(cons_vars.number_of_grid_points());
-    NewtonianEuler::PrimitiveFromConservative<Dim, 1>::apply(
+    NewtonianEuler::PrimitiveFromConservative<Dim>::apply(
         make_not_null(&get<MassDensity>(prim_vars)),
         make_not_null(&get<Velocity>(prim_vars)),
         make_not_null(&get<SpecificInternalEnergy>(prim_vars)),

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Test_PrimitiveFromConservative.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Test_PrimitiveFromConservative.cpp
@@ -29,7 +29,7 @@ struct PrimitiveFromConservativeProxyThermoDim1 {
       const Scalar<DataVector>& mass_density_cons,
       const tnsr::I<DataVector, Dim>& momentum_density,
       const Scalar<DataVector>& energy_density) noexcept {
-    NewtonianEuler::PrimitiveFromConservative<Dim, 1>::apply(
+    NewtonianEuler::PrimitiveFromConservative<Dim>::apply(
         mass_density, velocity, specific_internal_energy, pressure,
         mass_density_cons, momentum_density, energy_density,
         EquationsOfState::PolytropicFluid<false>(1.4, 5.0 / 3.0));
@@ -46,7 +46,7 @@ struct PrimitiveFromConservativeProxyThermoDim2 {
       const Scalar<DataVector>& mass_density_cons,
       const tnsr::I<DataVector, Dim>& momentum_density,
       const Scalar<DataVector>& energy_density) noexcept {
-    NewtonianEuler::PrimitiveFromConservative<Dim, 2>::apply(
+    NewtonianEuler::PrimitiveFromConservative<Dim>::apply(
         mass_density, velocity, specific_internal_energy, pressure,
         mass_density_cons, momentum_density, energy_density,
         EquationsOfState::IdealFluid<false>(5.0 / 3.0));


### PR DESCRIPTION
The template parameter is only used to specify the thermodynamic_dim, but
the thermodynamic_dim can be deduced by PrimitiveFromConservative::apply.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
