### PR TITLE
Remove template from UpdateFunctionOfTime functions

### DIFF
--- a/src/ControlSystem/UpdateFunctionOfTime.hpp
+++ b/src/ControlSystem/UpdateFunctionOfTime.hpp
@@ -16,7 +16,6 @@ namespace control_system {
 /// \ingroup ControlSystemGroup
 /// Updates a FunctionOfTime in the global cache. Intended to be used in
 /// Parallel::mutate.
-template <size_t DerivOrder>
 struct UpdateFunctionOfTime {
   static void apply(
       const gsl::not_null<std::unordered_map<
@@ -35,7 +34,6 @@ struct UpdateFunctionOfTime {
 /// \ingroup ControlSystemGroup
 /// Resets the expiration time of a FunctionOfTime in the global cache. Intended
 /// to be used in Parallel::mutate.
-template <size_t DerivOrder>
 struct ResetFunctionOfTimeExpirationTime {
   static void apply(
       const gsl::not_null<std::unordered_map<

--- a/tests/Unit/ControlSystem/Test_UpdateFunctionOfTime.cpp
+++ b/tests/Unit/ControlSystem/Test_UpdateFunctionOfTime.cpp
@@ -90,7 +90,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.UpdateFunctionOfTime",
 
   for (auto& name : {pp_name, quatfot_name}) {
     Parallel::mutate<domain::Tags::FunctionsOfTime,
-                     control_system::UpdateFunctionOfTime<deriv_order>>(
+                     control_system::UpdateFunctionOfTime>(
         cache, name, update_time, updated_deriv, new_expiration_time);
   }
 
@@ -114,9 +114,8 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.UpdateFunctionOfTime",
   // Update functions of time in global cache with new expiration time
   const double newer_expiration_time = new_expiration_time + 1.0;
   for (auto& name : {pp_name, quatfot_name}) {
-    Parallel::mutate<
-        domain::Tags::FunctionsOfTime,
-        control_system::ResetFunctionOfTimeExpirationTime<deriv_order>>(
+    Parallel::mutate<domain::Tags::FunctionsOfTime,
+                     control_system::ResetFunctionOfTimeExpirationTime>(
         cache, name, newer_expiration_time);
   }
 


### PR DESCRIPTION
Forgot to do this when I added the virtual `update` and `reset_expiration_time` functions to the FunctionOfTime base class.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
