### PR TITLE
Enforce tags for Variables are derived from db::SimpleTag

### DIFF
--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -23,6 +23,7 @@
 #include "DataStructures/DataBox/Subitems.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataBox/TagName.hpp"
+#include "DataStructures/DataBox/TagTraits.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -94,6 +95,7 @@ class Variables<tmpl::list<Tags...>> {
   static_assert(sizeof...(Tags) > 0,
                 "You must provide at least one tag to the Variables "
                 "for type inference");
+  static_assert((db::is_simple_tag_v<Tags> and ...));
   static_assert(tmpl2::flat_all_v<tt::is_a_v<Tensor, typename Tags::type>...>);
 
  private:

--- a/src/Elliptic/DiscontinuousGalerkin/DgOperator.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/DgOperator.hpp
@@ -9,6 +9,7 @@
 #include <unordered_map>
 #include <utility>
 
+#include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/SliceVariables.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -157,7 +158,7 @@ struct PerpendicularNumPoints {
 
 /// A measure of element size perpendicular to an element face. Used to compute
 /// the penalty (see `elliptic::dg::penalty`).
-struct ElementSize {
+struct ElementSize : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 
@@ -166,7 +167,7 @@ struct ElementSize {
 /// \f$n_i\f$ is the face normal. This quantity is projected to mortars to
 /// compute the jump term of the numerical flux.
 template <typename Tag>
-struct NormalDotFluxForJump : db::PrefixTag {
+struct NormalDotFluxForJump : db::PrefixTag, db::SimpleTag {
   using type = typename Tag::type;
   using tag = Tag;
 };

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Sources.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Sources.cpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 
+#include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -49,13 +50,13 @@ void densitized_stress(
   }
 }
 
-struct MagneticFieldOneForm {
+struct MagneticFieldOneForm : db::SimpleTag {
   using type = tnsr::i<DataVector, 3, Frame::Inertial>;
 };
-struct TildeSUp {
+struct TildeSUp : db::SimpleTag {
   using type = tnsr::I<DataVector, 3, Frame::Inertial>;
 };
-struct DensitizedStress {
+struct DensitizedStress : db::SimpleTag {
   using type = tnsr::II<DataVector, 3, Frame::Inertial>;
 };
 struct OneOverLorentzFactorSquared : db::SimpleTag {

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/M1Closure.cpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/M1Closure.cpp
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <utility>
 
+#include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -23,10 +24,10 @@
 // IWYU pragma: no_forward_declare Tensor
 
 namespace {
-struct MomentumUp {
+struct MomentumUp : db::SimpleTag {
   using type = tnsr::I<DataVector, 3, Frame::Inertial>;
 };
-struct MomentumSquared {
+struct MomentumSquared : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/M1HydroCoupling.cpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/M1HydroCoupling.cpp
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <utility>
 
+#include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -22,11 +23,11 @@
 // IWYU pragma: no_forward_declare Tensor
 
 namespace {
-struct densitized_eta_minus_kappaJ {
+struct densitized_eta_minus_kappaJ : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 
-struct kappaT_lapse {
+struct kappaT_lapse : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 }  // namespace

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/Sources.cpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/Sources.cpp
@@ -11,7 +11,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
-#include "PointwiseFunctions/GeneralRelativity/Tags.hpp" // IWYU pragma: keep
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_forward_declare Tensor
 
@@ -21,10 +21,7 @@ struct AlphaTildeP : db::SimpleTag {
 };
 }  //  namespace
 
-namespace RadiationTransport {
-namespace M1Grey {
-
-namespace detail {
+namespace RadiationTransport::M1Grey::detail {
 void compute_sources_impl(
     const gsl::not_null<Scalar<DataVector>*> source_tilde_e,
     const gsl::not_null<tnsr::i<DataVector, 3>*> source_tilde_s,
@@ -84,6 +81,4 @@ void compute_sources_impl(
   }
 }
 
-}  // namespace detail
-}  // namespace M1Grey
-}  // namespace RadiationTransport
+}  // namespace RadiationTransport::M1Grey::detail

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/Sources.cpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/Sources.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstddef>
 
+#include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
@@ -15,7 +16,7 @@
 // IWYU pragma: no_forward_declare Tensor
 
 namespace {
-struct AlphaTildeP {
+struct AlphaTildeP : db::SimpleTag {
   using type = tnsr::II<DataVector, 3>;
 };
 }  //  namespace

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/Sources.hpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/Sources.hpp
@@ -20,8 +20,7 @@ class DataVector;
 // IWYU pragma: no_forward_declare Tensor
 // IWYU pragma: no_forward_declare Tags::deriv
 
-namespace RadiationTransport {
-namespace M1Grey {
+namespace RadiationTransport::M1Grey {
 
 // Implementation of the curvature source terms
 // for the M1 system, for an individual species.
@@ -117,5 +116,4 @@ struct ComputeSources {
   }
 };
 
-}  // namespace M1Grey
-}  // namespace RadiationTransport
+}  // namespace RadiationTransport::M1Grey

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstddef>
 
+#include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
@@ -17,7 +18,7 @@
 
 namespace {
 template <size_t Dim, typename DerivativeFrame>
-struct VectorTag {
+struct VectorTag : db::SimpleTag {
   using type = tnsr::I<DataVector, Dim, DerivativeFrame>;
 };
 }  // namespace

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.hpp
@@ -8,6 +8,7 @@
 
 #include "DataStructures/CachedTempBuffer.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Elliptic/Systems/Elasticity/Tags.hpp"
 #include "Options/Options.hpp"
@@ -25,7 +26,7 @@ namespace Elasticity::Solutions {
 namespace detail {
 template <typename DataType>
 struct HalfSpaceMirrorVariables {
-  struct DisplacementR {
+  struct DisplacementR : db::SimpleTag {
     using type = Scalar<DataType>;
   };
   using Cache =

--- a/src/PointwiseFunctions/Xcts/SpacetimeQuantities.cpp
+++ b/src/PointwiseFunctions/Xcts/SpacetimeQuantities.cpp
@@ -4,6 +4,7 @@
 #include "PointwiseFunctions/Xcts/SpacetimeQuantities.hpp"
 
 #include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Elliptic/Systems/Xcts/Tags.hpp"
@@ -21,7 +22,7 @@ namespace Xcts {
 
 namespace detail {
 template <typename T>
-struct TempTag {
+struct TempTag : db::SimpleTag {
   using type = T;
 };
 template <typename U, typename T, size_t Dim, typename DerivativeFrame>

--- a/tests/Unit/DataStructures/Test_ApplyMatrices.cpp
+++ b/tests/Unit/DataStructures/Test_ApplyMatrices.cpp
@@ -13,6 +13,7 @@
 
 #include "DataStructures/ApplyMatrices.hpp"
 #include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Index.hpp"
 #include "DataStructures/IndexIterator.hpp"
@@ -43,19 +44,19 @@ using ScalarType = Scalar<T>;
 template <typename T>
 using VectorType = tnsr::I<T, 2>;
 
-struct ScalarTag {
+struct ScalarTag : db::SimpleTag {
   using type = ScalarType<DataVector>;
 };
 
-struct TensorTag {
+struct TensorTag : db::SimpleTag {
   using type = VectorType<DataVector>;
 };
 
-struct ComplexScalarTag {
+struct ComplexScalarTag : db::SimpleTag {
   using type = ScalarType<ComplexDataVector>;
 };
 
-struct ComplexTensorTag {
+struct ComplexTensorTag : db::SimpleTag {
   using type = VectorType<ComplexDataVector>;
 };
 

--- a/tests/Unit/DataStructures/Test_Transpose.cpp
+++ b/tests/Unit/DataStructures/Test_Transpose.cpp
@@ -59,7 +59,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Transpose", "[DataStructures][Unit]") {
   const size_t n_pts = chunk_size * number_of_chunks;
   DataVector data(n_pts);
   for (size_t i = 0; i < data.size(); ++i) {
-    data[i] = i * i;
+    data[i] = static_cast<double>(i * i);
   }
   DataVector transposed_data(n_pts, 0.);
   transposed_data = transpose(data, chunk_size, number_of_chunks);

--- a/tests/Unit/DataStructures/Test_Transpose.cpp
+++ b/tests/Unit/DataStructures/Test_Transpose.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cstddef>
 
+#include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Transpose.hpp"
@@ -19,11 +20,11 @@ class Variables;
 namespace {
 
 template <size_t Dim>
-struct Var1 {
+struct Var1 : db::SimpleTag {
   using type = tnsr::i<DataVector, Dim, Frame::Grid>;
 };
 
-struct Var2 {
+struct Var2 : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 

--- a/tests/Unit/Domain/Structure/Test_OrientationMapHelpers.cpp
+++ b/tests/Unit/Domain/Structure/Test_OrientationMapHelpers.cpp
@@ -10,6 +10,7 @@
 #include <pup.h>
 #include <type_traits>
 
+#include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Index.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -37,12 +38,12 @@ using Affine = domain::CoordinateMaps::Affine;
 using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
 using Affine3D = domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
 
-struct ScalarTensor {
+struct ScalarTensor : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 
 template <size_t SpatialDim>
-struct Coords {
+struct Coords : db::SimpleTag {
   using type = tnsr::I<DataVector, SpatialDim, Frame::Inertial>;
 };
 

--- a/tests/Unit/Elliptic/SubdomainPreconditioners/Test_MinusLaplacian.cpp
+++ b/tests/Unit/Elliptic/SubdomainPreconditioners/Test_MinusLaplacian.cpp
@@ -9,6 +9,7 @@
 #include <type_traits>
 #include <vector>
 
+#include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Structure/Direction.hpp"
@@ -25,11 +26,11 @@
 #include "Utilities/TMPL.hpp"
 
 namespace {
-struct ScalarFieldTag {
+struct ScalarFieldTag : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 template <size_t Dim>
-struct VectorFieldTag {
+struct VectorFieldTag : db::SimpleTag {
   using type = tnsr::I<DataVector, Dim>;
 };
 template <size_t Dim>

--- a/tests/Unit/Evolution/DgSubcell/Test_Projection.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Projection.cpp
@@ -22,7 +22,7 @@
 namespace {
 namespace Tags {
 template <typename Tag>
-struct Prefix : db::PrefixTag {
+struct Prefix : db::PrefixTag, db::SimpleTag {
   using tag = Tag;
   using type = typename Tag::type;
 };

--- a/tests/Unit/Evolution/DgSubcell/Test_Reconstruction.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Reconstruction.cpp
@@ -39,7 +39,7 @@
 namespace {
 namespace Tags {
 template <typename Tag>
-struct Prefix : db::PrefixTag {
+struct Prefix : db::PrefixTag, db::SimpleTag {
   using tag = Tag;
   using type = typename Tag::type;
 };

--- a/tests/Unit/Helpers/Tests/Test_MakeWithRandomValues.cpp
+++ b/tests/Unit/Helpers/Tests/Test_MakeWithRandomValues.cpp
@@ -9,6 +9,7 @@
 #include <unordered_set>
 #include <utility>
 
+#include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
@@ -23,11 +24,11 @@
 
 namespace {
 template <size_t Dim>
-struct Var1 {
+struct Var1 : db::SimpleTag {
   using type = tnsr::i<DataVector, Dim, Frame::Grid>;
 };
 
-struct Var2 {
+struct Var2 : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_SimpleBoundaryData.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_SimpleBoundaryData.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstddef>
 
+#include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
@@ -19,7 +20,7 @@
 
 namespace {
 
-struct SomeField {
+struct SomeField : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Test_ExplicitInverse.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Test_ExplicitInverse.cpp
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include "DataStructures/ApplyMatrices.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/DenseMatrix.hpp"
 #include "DataStructures/DenseVector.hpp"
@@ -25,7 +26,7 @@
 namespace helpers = TestHelpers::LinearSolver;
 
 namespace {
-struct ScalarFieldTag {
+struct ScalarFieldTag : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 }  // namespace

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Test_Gmres.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Test_Gmres.cpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 
+#include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/DenseMatrix.hpp"
 #include "DataStructures/DenseVector.hpp"
@@ -28,7 +29,7 @@ struct ScalarField : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 template <typename Tag>
-struct SomePrefix : db::PrefixTag {
+struct SomePrefix : db::PrefixTag, db::SimpleTag {
   using type = tmpl::type_from<Tag>;
   using tag = Tag;
 };

--- a/tests/Unit/Utilities/Test_MakeWithValue.cpp
+++ b/tests/Unit/Utilities/Test_MakeWithValue.cpp
@@ -7,6 +7,7 @@
 #include <complex>
 #include <cstddef>
 
+#include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
@@ -20,11 +21,11 @@
 
 namespace {
 template <size_t Dim>
-struct Var1 {
+struct Var1 : db::SimpleTag {
   using type = tnsr::i<DataVector, Dim, Frame::Grid>;
 };
 
-struct Var2 {
+struct Var2 : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 


### PR DESCRIPTION
## Proposed changes

The documentation already listed this as a requirement, but it was not enforced.
The primary motivation is to prevent someone from using a compute tag and expecting it to behave as a compute item in a DataBox.

### Upgrade instructions

<!--
-->
<!-- UPGRADE INSTRUCTIONS -->
Any tag used in the list of tags on which a Variables is templated must derive from `db::SimpleTag`

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
