### PR TITLE
Add ExcisionSphere to Domain/Structure and test

### DIFF
--- a/src/Domain/Structure/CMakeLists.txt
+++ b/src/Domain/Structure/CMakeLists.txt
@@ -14,6 +14,7 @@ spectre_target_sources(
   Direction.cpp
   Element.cpp
   ElementId.cpp
+  ExcisionSphere.cpp
   Hypercube.cpp
   InitialElementIds.cpp
   Neighbors.cpp
@@ -35,6 +36,7 @@ spectre_target_headers(
   DirectionMap.hpp
   Element.hpp
   ElementId.hpp
+  ExcisionSphere.hpp
   Hypercube.hpp
   IndexToSliceAt.hpp
   InitialElementIds.hpp

--- a/src/Domain/Structure/ExcisionSphere.cpp
+++ b/src/Domain/Structure/ExcisionSphere.cpp
@@ -1,0 +1,63 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Structure/ExcisionSphere.hpp"
+
+#include <ostream>
+#include <pup.h>  // IWYU pragma: keep
+#include <pup_stl.h>
+
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
+
+template <size_t VolumeDim>
+ExcisionSphere<VolumeDim>::ExcisionSphere(
+    const double radius, const std::array<double, VolumeDim> center) noexcept
+    : radius_(radius), center_(center) {
+  ASSERT(radius_ > 0.0,
+         "The ExcisionSphere must have a radius greater than zero.");
+}
+
+template <size_t VolumeDim>
+void ExcisionSphere<VolumeDim>::pup(PUP::er& p) noexcept {
+  p | radius_;
+  p | center_;
+}
+
+template <size_t VolumeDim>
+bool operator==(const ExcisionSphere<VolumeDim>& lhs,
+                const ExcisionSphere<VolumeDim>& rhs) noexcept {
+  return lhs.radius() == rhs.radius() and lhs.center() == rhs.center();
+}
+
+template <size_t VolumeDim>
+bool operator!=(const ExcisionSphere<VolumeDim>& lhs,
+                const ExcisionSphere<VolumeDim>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+template <size_t VolumeDim>
+std::ostream& operator<<(std::ostream& os,
+                         const ExcisionSphere<VolumeDim>& sphere) noexcept {
+  os << "ExcisionSphere:\n";
+  os << "  Radius: " << sphere.radius() << "\n";
+  os << "  Center: " << sphere.center() << "\n";
+  return os;
+}
+
+#define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data)                                             \
+  template class ExcisionSphere<GET_DIM(data)>;                            \
+  template bool operator==(const ExcisionSphere<GET_DIM(data)>&,           \
+                           const ExcisionSphere<GET_DIM(data)>&) noexcept; \
+  template bool operator!=(const ExcisionSphere<GET_DIM(data)>&,           \
+                           const ExcisionSphere<GET_DIM(data)>&) noexcept; \
+  template std::ostream& operator<<(                                       \
+      std::ostream&, const ExcisionSphere<GET_DIM(data)>&) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef GET_DIM
+#undef INSTANTIATION

--- a/src/Domain/Structure/ExcisionSphere.hpp
+++ b/src/Domain/Structure/ExcisionSphere.hpp
@@ -1,0 +1,77 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines class ExcisionSphere.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <iosfwd>
+#include <limits>
+
+#include "Utilities/MakeArray.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+/// \ingroup ComputationalDomainGroup
+/// The excision sphere information of a computational domain.
+/// The excision sphere is assumed to be a coordinate sphere in the
+/// grid frame.
+///
+/// \tparam VolumeDim the volume dimension.
+template <size_t VolumeDim>
+class ExcisionSphere {
+ public:
+  /// Constructor
+  ///
+  /// \param radius the radius of the excision sphere in the
+  /// computational domain.
+  /// \param center the coordinate center of the excision sphere
+  /// in the computational domain.
+  ExcisionSphere(double radius, std::array<double, VolumeDim> center) noexcept;
+
+  /// Default constructor needed for Charm++ serialization.
+  ExcisionSphere() noexcept = default;
+  ~ExcisionSphere() noexcept = default;
+  ExcisionSphere(const ExcisionSphere<VolumeDim>& /*rhs*/) noexcept = default;
+  ExcisionSphere(ExcisionSphere<VolumeDim>&& /*rhs*/) noexcept = default;
+  ExcisionSphere<VolumeDim>& operator=(
+      const ExcisionSphere<VolumeDim>& /*rhs*/) noexcept = default;
+  ExcisionSphere<VolumeDim>& operator=(
+      ExcisionSphere<VolumeDim>&& /*rhs*/) noexcept = default;
+
+  /// The radius of the ExcisionSphere.
+  double radius() const noexcept { return radius_; }
+
+  /// The coodinate center of the ExcisionSphere.
+  const std::array<double, VolumeDim>& center() const noexcept {
+    return center_;
+  }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) noexcept;
+
+ private:
+  double radius_{std::numeric_limits<double>::signaling_NaN()};
+  std::array<double, VolumeDim> center_{
+      make_array<VolumeDim>(std::numeric_limits<double>::signaling_NaN())};
+};
+
+template <size_t VolumeDim>
+std::ostream& operator<<(
+    std::ostream& os,
+    const ExcisionSphere<VolumeDim>& excision_sphere) noexcept;
+
+template <size_t VolumeDim>
+bool operator==(const ExcisionSphere<VolumeDim>& lhs,
+                const ExcisionSphere<VolumeDim>& rhs) noexcept;
+
+template <size_t VolumeDim>
+bool operator!=(const ExcisionSphere<VolumeDim>& lhs,
+                const ExcisionSphere<VolumeDim>& rhs) noexcept;

--- a/tests/Unit/Domain/Structure/CMakeLists.txt
+++ b/tests/Unit/Domain/Structure/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIBRARY_SOURCES
   Test_Direction.cpp
   Test_Element.cpp
   Test_ElementId.cpp
+  Test_ExcisionSphere.cpp
   Test_Hypercube.cpp
   Test_IndexToSliceAt.cpp
   Test_InitialElementIds.cpp

--- a/tests/Unit/Domain/Structure/Test_ExcisionSphere.cpp
+++ b/tests/Unit/Domain/Structure/Test_ExcisionSphere.cpp
@@ -1,0 +1,77 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <functional>
+
+#include "Domain/Structure/ExcisionSphere.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
+
+namespace {
+template <size_t VolumeDim>
+void check_excision_sphere_work(const double radius,
+                                const std::array<double, VolumeDim> center) {
+  const ExcisionSphere<VolumeDim> excision_sphere(radius, center);
+
+  CHECK(excision_sphere.radius() == radius);
+  CHECK(excision_sphere.center() == center);
+  CHECK(excision_sphere == excision_sphere);
+  CHECK_FALSE(excision_sphere != excision_sphere);
+
+  const double diff_radius = 0.001;
+  const ExcisionSphere<VolumeDim> excision_sphere_diff_radius(diff_radius,
+                                                              center);
+  CHECK(excision_sphere != excision_sphere_diff_radius);
+  CHECK_FALSE(excision_sphere == excision_sphere_diff_radius);
+
+  CHECK(get_output(excision_sphere) ==
+        "ExcisionSphere:\n"
+        "  Radius: " +
+            get_output(excision_sphere.radius()) +
+            "\n"
+            "  Center: " +
+            get_output(excision_sphere.center()) + "\n");
+
+  test_serialization(excision_sphere);
+}
+
+void check_excision_sphere_1d() {
+  const double radius = 1.2;
+  const std::array<double, 1> center = {{5.4}};
+  check_excision_sphere_work<1>(radius, center);
+}
+
+void check_excision_sphere_2d() {
+  const double radius = 4.2;
+  const std::array<double, 2> center = {{5.4, -2.3}};
+  check_excision_sphere_work<2>(radius, center);
+}
+
+void check_excision_sphere_3d() {
+  const double radius = 5.2;
+  const std::array<double, 3> center = {{5.4, -2.3, 9.0}};
+  check_excision_sphere_work<3>(radius, center);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.Structure.ExcisionSphere", "[Domain][Unit]") {
+  check_excision_sphere_1d();
+  check_excision_sphere_2d();
+  check_excision_sphere_3d();
+}
+
+// [[OutputRegex, The ExcisionSphere must have a radius greater than zero.]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Structure.ExcisionSphereAssert",
+                               "[Domain][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  auto failed_excision_sphere = ExcisionSphere<3>(-2.0, {{3.4, 1.2, -0.9}});
+  static_cast<void>(failed_excision_sphere);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}


### PR DESCRIPTION
## Proposed changes
Adds the class ExcisionSphere to Domain/Structure, which holds the computational domain's excision sphere
information, including the center and radius, as well as an ID for when more than one excision surface is present.

Please see Further Comments for more information.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

This is the first in a series of PRs that will place the computational domain's excision
sphere information into the Domain where it can be used to the control system. This PR
adds the ExcisionSphere class, and domains with excision spheres (Shell, BinaryCompactObject) will hold maps of strings to ExcisionSpheres. These will be added in future PRs.
