### PR TITLE
Add ghost data routines to advection subcell

### DIFF
--- a/src/Evolution/Systems/ScalarAdvection/Subcell/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/CMakeLists.txt
@@ -4,6 +4,7 @@
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  GhostData.cpp
   InitialDataTci.cpp
   TciOnDgGrid.cpp
   TciOnFdGrid.cpp
@@ -13,6 +14,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  GhostData.hpp
   InitialDataTci.hpp
   Subcell.hpp
   TciOnDgGrid.hpp

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/GhostData.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/GhostData.cpp
@@ -1,0 +1,36 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarAdvection/Subcell/GhostData.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/Variables.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/Projection.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/Systems/ScalarAdvection/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ScalarAdvection::subcell {
+Variables<tmpl::list<ScalarAdvection::Tags::U>> GhostDataOnSubcells::apply(
+    const Variables<tmpl::list<ScalarAdvection::Tags::U>>& vars) noexcept {
+  return vars;
+}
+
+template <size_t Dim>
+Variables<tmpl::list<ScalarAdvection::Tags::U>> GhostDataToSlice<Dim>::apply(
+    const Variables<tmpl::list<ScalarAdvection::Tags::U>>& vars,
+    const Mesh<Dim>& dg_mesh, const Mesh<Dim>& subcell_mesh) noexcept {
+  return evolution::dg::subcell::fd::project(vars, dg_mesh,
+                                             subcell_mesh.extents());
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define INSTANTIATION(r, data) template class GhostDataToSlice<DIM(data)>;
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
+#undef INSTANTIATION
+#undef DIM
+}  // namespace ScalarAdvection::subcell

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/GhostData.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/GhostData.hpp
@@ -1,0 +1,63 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/Systems/ScalarAdvection/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+template <size_t Dim>
+class Mesh;
+template <typename T>
+class Variables;
+namespace Tags {
+template <typename TagsList>
+struct Variables;
+}  // namespace Tags
+/// \endcond
+
+namespace ScalarAdvection::subcell {
+/*!
+ * \brief Returns \f$U\f$ on the subcells so it can be used for reconstruction.
+ *
+ * This mutator is passed to
+ * `evolution::dg::subcell::Actions::SendDataForReconstruction`.
+ *
+ * \note Called only by FD-solving elements.
+ */
+class GhostDataOnSubcells {
+ public:
+  using return_tags = tmpl::list<>;
+  using argument_tags =
+      tmpl::list<::Tags::Variables<tmpl::list<ScalarAdvection::Tags::U>>>;
+
+  static Variables<tmpl::list<ScalarAdvection::Tags::U>> apply(
+      const Variables<tmpl::list<ScalarAdvection::Tags::U>>& vars) noexcept;
+};
+
+/*!
+ * \brief Projects \f$U\f$ from DG grid to subcell grid to send out ghost cell
+ * data to neighbors for reconstruction.
+ *
+ * This mutator is passed what `Metavars::SubcellOptions::GhostDataToSlice` must
+ * be set to.
+ */
+template <size_t Dim>
+class GhostDataToSlice {
+ public:
+  using return_tags = tmpl::list<>;
+  using argument_tags =
+      tmpl::list<::Tags::Variables<tmpl::list<ScalarAdvection::Tags::U>>,
+                 domain::Tags::Mesh<Dim>,
+                 evolution::dg::subcell::Tags::Mesh<Dim>>;
+
+  static Variables<tmpl::list<ScalarAdvection::Tags::U>> apply(
+      const Variables<tmpl::list<ScalarAdvection::Tags::U>>& vars,
+      const Mesh<Dim>& dg_mesh, const Mesh<Dim>& subcell_mesh) noexcept;
+};
+}  // namespace ScalarAdvection::subcell

--- a/tests/Unit/Evolution/Systems/ScalarAdvection/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarAdvection/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   BoundaryConditions/Test_Periodic.cpp
   BoundaryCorrections/Test_Rusanov.cpp
   FiniteDifference/Test_Tag.cpp
+  Subcell/Test_GhostData.cpp
   Subcell/Test_InitialDataTci.cpp
   Subcell/Test_TciOnDgGrid.cpp
   Subcell/Test_TciOnFdGrid.cpp

--- a/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_GhostData.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_GhostData.cpp
@@ -1,0 +1,74 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <random>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
+#include "Evolution/DgSubcell/Projection.hpp"
+#include "Evolution/Systems/ScalarAdvection/Subcell/GhostData.hpp"
+#include "Evolution/Systems/ScalarAdvection/Tags.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+
+const size_t num_of_pts_dg_grid = 4;
+
+template <size_t Dim>
+void test(const gsl::not_null<std::mt19937*> gen,
+          const gsl::not_null<std::uniform_real_distribution<>*> dist) {
+  // make random U on DG and subcell mesh
+  const Mesh<Dim> dg_mesh{num_of_pts_dg_grid, Spectral::Basis::Legendre,
+                          Spectral::Quadrature::GaussLobatto};
+  const Mesh<Dim> subcell_mesh = evolution::dg::subcell::fd::mesh(dg_mesh);
+  const auto random_vars_dg =
+      make_with_random_values<Variables<tmpl::list<ScalarAdvection::Tags::U>>>(
+          gen, dist, dg_mesh.number_of_grid_points());
+  const auto random_vars_subcell =
+      make_with_random_values<Variables<tmpl::list<ScalarAdvection::Tags::U>>>(
+          gen, dist, subcell_mesh.number_of_grid_points());
+
+  // add the random U on the subcell mesh to a databox, apply
+  // GhostDataOnSubcells and compare with the returned vector
+  auto box_subcell = db::create<db::AddSimpleTags<
+      ::Tags::Variables<tmpl::list<ScalarAdvection::Tags::U>>>>(
+      random_vars_subcell);
+  const auto retrieved_vars_subcell =
+      db::mutate_apply<ScalarAdvection::subcell::GhostDataOnSubcells>(
+          make_not_null(&box_subcell));
+  CHECK_ITERABLE_APPROX(get<ScalarAdvection::Tags::U>(random_vars_subcell),
+                        get<ScalarAdvection::Tags::U>(retrieved_vars_subcell));
+
+  // add the random U on the DG mesh to a databox, apply GhostDataToSlice and
+  // compare with a projected vector
+  auto box_projection = db::create<db::AddSimpleTags<
+      ::Tags::Variables<tmpl::list<ScalarAdvection::Tags::U>>,
+      domain::Tags::Mesh<Dim>, evolution::dg::subcell::Tags::Mesh<Dim>>>(
+      random_vars_dg, dg_mesh, subcell_mesh);
+  const auto retrieved_vars_slice =
+      db::mutate_apply<ScalarAdvection::subcell::GhostDataToSlice<Dim>>(
+          make_not_null(&box_projection));
+  CHECK_ITERABLE_APPROX(
+      get<ScalarAdvection::Tags::U>(evolution::dg::subcell::fd::project(
+          random_vars_dg, dg_mesh, subcell_mesh.extents())),
+      get<ScalarAdvection::Tags::U>(retrieved_vars_slice));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarAdvection.Subcell.GhostData",
+                  "[Unit][Evolution]") {
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> dist(-1.0, 1.0);
+
+  test<1>(make_not_null(&gen), make_not_null(&dist));
+  test<2>(make_not_null(&gen), make_not_null(&dist));
+}


### PR DESCRIPTION
## Proposed changes

Classes for sending out ghost data for FD reconstruction.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

