### PR TITLE
StrahlkorperGr now uses geometric objects to compute spin magnitude

### DIFF
--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -753,7 +753,11 @@ struct DimensionfulSpinMagnitudeCompute : DimensionfulSpinMagnitude,
       tmpl::list<StrahlkorperTags::RicciScalar, SpinFunction,
                  gr::Tags::SpatialMetric<3, Frame>,
                  StrahlkorperTags::Tangents<Frame>,
-                 StrahlkorperTags::Strahlkorper<Frame>, AreaElement<Frame>>;
+                 StrahlkorperTags::Strahlkorper<Frame>, AreaElement<Frame>,
+                 StrahlkorperTags::Radius<Frame>, StrahlkorperTags::Rhat<Frame>,
+                 StrahlkorperTags::Jacobian<Frame>,
+                 StrahlkorperTags::InvHessian<Frame>,
+                 StrahlkorperTags::CartesianCoords<Frame>>;
 };
 
 /// The dimensionful spin angular momentum vector.

--- a/src/ApparentHorizons/TagsTypeAliases.hpp
+++ b/src/ApparentHorizons/TagsTypeAliases.hpp
@@ -36,6 +36,13 @@ using InvHessian =
                       SpatialIndex<3, UpLo::Lo, Frame>,
                       SpatialIndex<3, UpLo::Lo, Frame>>>;
 template <typename Frame>
+using Hessian =
+    Tensor<DataVector, tmpl::integral_list<std::int32_t, 3, 2, 1>,
+           index_list<SpatialIndex<3, UpLo::Up, Frame>,
+                      SpatialIndex<2, UpLo::Lo, ::Frame::Spherical<Frame>>,
+                      SpatialIndex<2, UpLo::Lo, ::Frame::Spherical<Frame>>>>;
+
+template <typename Frame>
 using SecondDeriv = tnsr::ii<DataVector, 3, Frame>;
 }  // namespace aliases
 }  // namespace StrahlkorperTags

--- a/src/DataStructures/Tags/TempTensor.hpp
+++ b/src/DataStructures/Tags/TempTensor.hpp
@@ -124,5 +124,33 @@ using TempabC = TempTensor<N, tnsr::abC<DataType, SpatialDim, Fr>>;
 template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
           typename DataType = DataVector>
 using Tempijaa = TempTensor<N, tnsr::ijaa<DataType, SpatialDim, Fr>>;
+
+// Temporary tensor types used in the file `ApparentHorizons/StrahlkorperGr.cpp`
+template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
+          typename DataType = DataVector>
+using Temp_hessian =
+    TempTensor<N, Tensor<DataType, tmpl::integral_list<std::int32_t, 3, 2, 1>,
+                         index_list<SpatialIndex<SpatialDim, UpLo::Up, Fr>,
+                                    SpatialIndex<SpatialDim - 1, UpLo::Lo,
+                                                 ::Frame::Spherical<Fr>>,
+                                    SpatialIndex<SpatialDim - 1, UpLo::Lo,
+                                                 ::Frame::Spherical<Fr>>>>>;
+
+template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
+          typename DataType = DataVector>
+using Temp_surface_dual_basis =
+    TempTensor<N, Tensor<DataType, tmpl::integral_list<std::int32_t, 1, 2>,
+                         index_list<SpatialIndex<SpatialDim - 1, UpLo::Lo, Fr>,
+                                    SpatialIndex<SpatialDim, UpLo::Lo, Fr>>>>;
+
+template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
+          typename DataType = DataVector>
+using Temp_grad_spatial_metric =
+    TempTensor<N,
+               Tensor<DataType, tmpl::integral_list<std::int32_t, 1, 1, 2>,
+                      index_list<SpatialIndex<SpatialDim, UpLo::Lo, Fr>,
+                                 SpatialIndex<SpatialDim, UpLo::Lo, Fr>,
+                                 SpatialIndex<SpatialDim - 1, UpLo::Lo, Fr>>>>;
+
 /// @}
 }  // namespace Tags

--- a/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
+++ b/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
@@ -691,8 +691,12 @@ void test_dimensionful_spin_magnitude(
       horizon_radius_with_spin_on_z_axis, ylm_with_spin_on_z_axis, ylm, mass,
       dimensionless_spin);
 
+  const auto& inv_hessian =
+      db::get<StrahlkorperTags::InvHessian<Frame::Inertial>>(box);
+
   const double spin_magnitude = StrahlkorperGr::dimensionful_spin_magnitude(
-      ricci_scalar, spin_function, spatial_metric, tangents, ylm, area_element);
+      ricci_scalar, spin_function, spatial_metric, tangents, ylm, area_element,
+      radius, r_hat, jacobian, inv_hessian, cart_coords);
 
   Approx custom_approx = Approx::custom().epsilon(tolerance).scale(1.0);
   CHECK_ITERABLE_CUSTOM_APPROX(spin_magnitude, expected, custom_approx);


### PR DESCRIPTION
## Proposed changes
A port of Rob's spec PR(https://github.com/sxs-collaboration/spec/pull/1832) to spectre.

Functions in StrahlkorperGr used factors of angles in computing the spin. This PR uses geometric versions of those functions therefore eliminating the need of using factors of angles.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
