### PR TITLE
Support scalar division and unary minus for TensorExpressions

### DIFF
--- a/src/DataStructures/Tensor/Expressions/CMakeLists.txt
+++ b/src/DataStructures/Tensor/Expressions/CMakeLists.txt
@@ -7,6 +7,7 @@ spectre_target_headers(
   HEADERS
   AddSubtract.hpp
   Contract.hpp
+  Divide.hpp
   Evaluate.hpp
   IndexPropertyCheck.hpp
   LhsTensorSymmAndIndices.hpp

--- a/src/DataStructures/Tensor/Expressions/CMakeLists.txt
+++ b/src/DataStructures/Tensor/Expressions/CMakeLists.txt
@@ -11,8 +11,9 @@ spectre_target_headers(
   Evaluate.hpp
   IndexPropertyCheck.hpp
   LhsTensorSymmAndIndices.hpp
-  Product.hpp
+  Negate.hpp
   NumberAsExpression.hpp
+  Product.hpp
   SpatialSpacetimeIndex.hpp
   SquareRoot.hpp
   TensorAsExpression.hpp

--- a/src/DataStructures/Tensor/Expressions/Divide.hpp
+++ b/src/DataStructures/Tensor/Expressions/Divide.hpp
@@ -1,0 +1,140 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines ET for tensor division by scalars
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+#include "DataStructures/Tensor/Expressions/NumberAsExpression.hpp"
+#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "DataStructures/Tensor/Expressions/TimeIndex.hpp"
+#include "Utilities/ForceInline.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace TensorExpressions {
+/// \ingroup TensorExpressionsGroup
+/// \brief Defines the tensor expression representing the quotient of one tensor
+/// expression divided by another tensor expression that evaluates to a rank 0
+/// tensor
+///
+/// \tparam T1 the numerator operand expression of the division expression
+/// \tparam T2 the denominator operand expression of the division expression
+/// \tparam Args2 the generic indices of the denominator expression
+template <typename T1, typename T2, typename... Args2>
+struct Divide : public TensorExpression<
+                    Divide<T1, T2, Args2...>,
+                    typename std::conditional_t<
+                        std::is_same<typename T1::type, DataVector>::value or
+                            std::is_same<typename T2::type, DataVector>::value,
+                        DataVector, double>,
+                    typename T1::symmetry, typename T1::index_list,
+                    typename T1::args_list> {
+  static_assert(std::is_same<typename T1::type, typename T2::type>::value or
+                    std::is_same<T1, NumberAsExpression>::value,
+                "Cannot divide TensorExpressions holding different data types");
+  static_assert((... and tt::is_time_index<Args2>::value),
+                "Can only divide a tensor expression by a double or a tensor "
+                "expression that evaluates to "
+                "a rank 0 tensor.");
+
+  using type =
+      std::conditional_t<std::is_same<typename T1::type, DataVector>::value or
+                             std::is_same<typename T2::type, DataVector>::value,
+                         DataVector, double>;
+  using symmetry = typename T1::symmetry;
+  using index_list = typename T1::index_list;
+  using args_list = typename T1::args_list;
+  static constexpr auto num_tensor_indices =
+      tmpl::size<typename T1::index_list>::value;
+  static constexpr auto op2_num_tensor_indices =
+      tmpl::size<typename T2::index_list>::value;
+  // the denominator has no indices or all time indices
+  static constexpr auto op2_multi_index =
+      make_array<op2_num_tensor_indices, size_t>(0);
+
+  Divide(T1 t1, T2 t2) : t1_(std::move(t1)), t2_(std::move(t2)) {}
+  ~Divide() override = default;
+
+  /// \brief Return the value of the component of the quotient tensor at a given
+  /// multi-index
+  ///
+  /// \param result_multi_index the multi-index of the component of the quotient
+  //// tensor to retrieve
+  /// \return the value of the component in the quotient tensor at
+  /// `result_multi_index`
+  SPECTRE_ALWAYS_INLINE decltype(auto) get(
+      const std::array<size_t, num_tensor_indices>& result_multi_index) const {
+    return t1_.get(result_multi_index) / t2_.get(op2_multi_index);
+  }
+
+ private:
+  T1 t1_;
+  T2 t2_;
+};
+}  // namespace TensorExpressions
+
+/// \ingroup TensorExpressionsGroup
+/// \brief Returns the tensor expression representing the quotient of one tensor
+/// expression over another tensor expression that evaluates to a rank 0 tensor
+///
+/// \details
+/// `t2` must be an expression that, when evaluated, would be a rank 0 tensor.
+/// For example, if `R` and `S` are Tensors, here is a non-exhaustive list of
+/// some of the acceptable forms that `t2` could take:
+/// - `R()`
+/// - `R(ti_A, ti_a)`
+/// - `(R(ti_A, ti_B) * S(ti_a, ti_b))`
+/// - `R(ti_t, ti_t) + 1.0`
+///
+/// \param t1 the tensor expression numerator
+/// \param t2 the rank 0 tensor expression denominator
+template <typename T1, typename T2, typename... Args2>
+SPECTRE_ALWAYS_INLINE auto operator/(
+    const TensorExpression<T1, typename T1::type, typename T1::symmetry,
+                           typename T1::index_list, typename T1::args_list>& t1,
+    const TensorExpression<T2, typename T2::type, typename T2::symmetry,
+                           typename T2::index_list, tmpl::list<Args2...>>& t2) {
+  return TensorExpressions::Divide<T1, T2, Args2...>(~t1, ~t2);
+}
+
+/// \ingroup TensorExpressionsGroup
+/// \brief Returns the tensor expression representing the quotient of a tensor
+/// expression over a `double`
+///
+/// \note The implementation instead uses the operation, `t * (1.0 / number)`
+///
+/// \param t the tensor expression operand of the quotient
+/// \param number the `double` operand of the quotient
+/// \return the tensor expression representing the quotient of a tensor
+/// expression and a `double`
+template <typename T>
+SPECTRE_ALWAYS_INLINE auto operator/(
+    const TensorExpression<T, typename T::type, typename T::symmetry,
+                           typename T::index_list, typename T::args_list>& t,
+    const double number) {
+  return t * TensorExpressions::NumberAsExpression(1.0 / number);
+}
+
+/// \ingroup TensorExpressionsGroup
+/// \brief Returns the tensor expression representing the quotient of a `double`
+/// over a tensor expression that evaluates to a rank 0 tensor
+///
+/// \param number the `double` numerator of the quotient
+/// \param t the tensor expression denominator of the quotient
+/// \return the tensor expression representing the quotient of a `double` over a
+/// tensor expression that evaluates to a rank 0 tensor
+template <typename T>
+SPECTRE_ALWAYS_INLINE auto operator/(
+    const double number,
+    const TensorExpression<T, typename T::type, typename T::symmetry,
+                           typename T::index_list, typename T::args_list>& t) {
+  return TensorExpressions::NumberAsExpression(number) / t;
+}

--- a/src/DataStructures/Tensor/Expressions/Negate.hpp
+++ b/src/DataStructures/Tensor/Expressions/Negate.hpp
@@ -1,0 +1,65 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines the tensor expression representing negation
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "Utilities/ForceInline.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace TensorExpressions {
+/// \ingroup TensorExpressionsGroup
+/// \brief Defines the tensor expression representing the negation of a tensor
+/// expression
+///
+/// \tparam T the type of tensor expression being negated
+template <typename T>
+struct Negate
+    : public TensorExpression<Negate<T>, typename T::type, typename T::symmetry,
+                              typename T::index_list, typename T::args_list> {
+  using type = typename T::type;
+  using symmetry = typename T::symmetry;
+  using index_list = typename T::index_list;
+  using args_list = typename T::args_list;
+  static constexpr auto num_tensor_indices = tmpl::size<index_list>::value;
+
+  Negate(T t) : t_(std::move(t)) {}
+  ~Negate() override = default;
+
+  /// \brief Return the value of the component of the negated tensor expression
+  /// at a given multi-index
+  ///
+  /// \param multi_index the multi-index of the component to retrieve from the
+  /// negated tensor expression
+  /// \return the value of the component at `multi_index` in the negated tensor
+  /// expression
+  SPECTRE_ALWAYS_INLINE decltype(auto) get(
+      const std::array<size_t, num_tensor_indices>& multi_index) const {
+    return -t_.get(multi_index);
+  }
+
+ private:
+  T t_;
+};
+}  // namespace TensorExpressions
+
+/// \ingroup TensorExpressionsGroup
+/// \brief Returns the tensor expression representing the negation of a tensor
+/// expression
+///
+/// \param t the tensor expression
+/// \return the tensor expression representing the negation of `t`
+template <typename T>
+SPECTRE_ALWAYS_INLINE auto operator-(
+    const TensorExpression<T, typename T::type, typename T::symmetry,
+                           typename T::index_list, typename T::args_list>& t) {
+  return TensorExpressions::Negate<T>(~t);
+}

--- a/src/DataStructures/Tensor/Expressions/Product.hpp
+++ b/src/DataStructures/Tensor/Expressions/Product.hpp
@@ -124,7 +124,6 @@ struct OuterProduct<T1, T2, IndexList1<Indices1...>, IndexList2<Indices2...>,
   T1 t1_;
   T2 t2_;
 };
-
 }  // namespace TensorExpressions
 
 /// \ingroup TensorExpressionsGroup
@@ -191,27 +190,3 @@ SPECTRE_ALWAYS_INLINE auto operator*(
   return TensorExpressions::NumberAsExpression(number) * t;
 }
 /// @}
-
-/// \ingroup TensorExpressionsGroup
-/// \brief Returns the tensor expression representing the quotient of a tensor
-/// expression and a `double`
-///
-/// \note The implementation instead uses the operation, `t * (1.0 / number)`
-///
-/// \tparam T the derived TensorExpression type of the tensor expression operand
-/// of the quotient
-/// \tparam X the type of data stored in the tensor expression operand of the
-/// quotient
-/// \tparam ArgsList the TensorIndexs of the tensor expression operand of the
-/// quotient
-/// \param t the tensor expression operand of the quotient
-/// \param number the `double` operand of the quotient
-/// \return the tensor expression representing the quotient of a tensor
-/// expression and a `double`
-template <typename T, typename X, typename ArgsList>
-SPECTRE_ALWAYS_INLINE auto operator/(
-    const TensorExpression<T, X, typename T::symmetry, typename T::index_list,
-                           ArgsList>& t,
-    const double number) {
-  return t * TensorExpressions::NumberAsExpression(1.0 / number);
-}

--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -21,6 +21,7 @@
 #include "DataStructures/Tensor/Expressions/Evaluate.hpp"
 #include "DataStructures/Tensor/Expressions/IndexPropertyCheck.hpp"
 #include "DataStructures/Tensor/Expressions/LhsTensorSymmAndIndices.hpp"
+#include "DataStructures/Tensor/Expressions/Negate.hpp"
 #include "DataStructures/Tensor/Expressions/NumberAsExpression.hpp"
 #include "DataStructures/Tensor/Expressions/Product.hpp"
 #include "DataStructures/Tensor/Expressions/SpatialSpacetimeIndex.hpp"

--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -17,6 +17,7 @@
 #include "DataStructures/SpinWeighted.hpp"
 #include "DataStructures/Tensor/Expressions/AddSubtract.hpp"
 #include "DataStructures/Tensor/Expressions/Contract.hpp"
+#include "DataStructures/Tensor/Expressions/Divide.hpp"
 #include "DataStructures/Tensor/Expressions/Evaluate.hpp"
 #include "DataStructures/Tensor/Expressions/IndexPropertyCheck.hpp"
 #include "DataStructures/Tensor/Expressions/LhsTensorSymmAndIndices.hpp"

--- a/tests/Unit/DataStructures/Tensor/Expressions/CMakeLists.txt
+++ b/tests/Unit/DataStructures/Tensor/Expressions/CMakeLists.txt
@@ -14,6 +14,7 @@ set(LIBRARY_SOURCES
   Test_EvaluateSpatialSpacetimeIndex.cpp
   Test_EvaluateTimeIndex.cpp
   Test_MixedOperations.cpp
+  Test_Negate.cpp
   Test_Product.cpp
   Test_ProductHighRankIntermediate.cpp
   Test_SpatialSpacetimeIndex.cpp

--- a/tests/Unit/DataStructures/Tensor/Expressions/CMakeLists.txt
+++ b/tests/Unit/DataStructures/Tensor/Expressions/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_AddSubSymmetry.cpp
   Test_AddSubtract.cpp
   Test_Contract.cpp
+  Test_Divide.cpp
   Test_Evaluate.cpp
   Test_EvaluateRank3.cpp
   Test_EvaluateRank4.cpp

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Divide.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Divide.cpp
@@ -1,0 +1,292 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <climits>
+#include <cmath>
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace {
+// \brief Test the division of a tensor expression over a `double` is correctly
+// evaluated
+//
+// \details
+// The cases tested are:
+// - \f$L_{ij} = S_{ij} / R\f$
+// - \f$L_{ij} = (R * S_{ij} / T) / G\f$
+//
+// where \f$R\f$, \f$T\f$, and \f$G\f$ are `double`s and \f$S\f$ and \f$L\f$ are
+// Tensors with data type `double` or DataVector.
+//
+// \tparam DataType the type of data being stored in the numerator
+template <typename Generator, typename DataType>
+void test_divide_double_denominator(const gsl::not_null<Generator*> generator,
+                                    const DataType& used_for_size) {
+  std::uniform_real_distribution<> distribution(-2.0, 2.0);
+  constexpr size_t dim = 3;
+
+  const auto S = make_with_random_values<tnsr::ii<DataType, dim>>(
+      generator, distribution, used_for_size);
+
+  // \f$L_{ij} = S_{ij} / R\f$
+  // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
+  // return type of `evaluate`
+  const tnsr::ii<DataType, dim> Lij_from_Sij_over_R =
+      TensorExpressions::evaluate<ti_i, ti_j>(S(ti_i, ti_j) / 4.3);
+  // \f$L_{ij} = (R * S_{ij} / T / G)\f$
+  const tnsr::ii<DataType, dim> Lij_from_R_Sij_over_T =
+      TensorExpressions::evaluate<ti_i, ti_j>((-5.2 * S(ti_i, ti_j) / 1.6) /
+                                              2.1);
+
+  for (size_t i = 0; i < dim; i++) {
+    for (size_t j = 0; j < dim; j++) {
+      CHECK_ITERABLE_APPROX(Lij_from_Sij_over_R.get(i, j), S.get(i, j) / 4.3);
+      CHECK_ITERABLE_APPROX(Lij_from_R_Sij_over_T.get(i, j),
+                            -5.2 * S.get(i, j) / 1.6 / 2.1);
+    }
+  }
+}
+
+// \brief Test the division of a `double` over a tensor expression is correctly
+// evaluated
+//
+// \details
+// The cases tested are:
+// - \f$L = R / S\f$
+// - \f$L = R / \sqrt{T^j{}_j}\f$
+//
+// where \f$R\f$ is a `double` and \f$S\f$, \f$T\f$, and \f$L\f$ are tensors
+// with data type `double` or DataVector.
+//
+// \tparam DataType the type of data being stored in the numerator
+template <typename Generator, typename DataType>
+void test_divide_double_numerator(const gsl::not_null<Generator*> generator,
+                                  const DataType& used_for_size) {
+  std::uniform_real_distribution<> distribution(0.1, 2.0);
+  constexpr size_t dim = 3;
+
+  const auto S = make_with_random_values<Scalar<DataType>>(
+      generator, distribution, used_for_size);
+  const auto T = make_with_random_values<tnsr::Ij<DataType, dim>>(
+      generator, distribution, used_for_size);
+
+  // \f$L = R / S\f$
+  // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
+  // return type of `evaluate`
+  const Scalar<DataType> result1 = TensorExpressions::evaluate(2.1 / S());
+  CHECK(get(result1) == 2.1 / get(S));
+
+  // \f$L = R / \sqrt{T^j{}_j}\f$
+  const Scalar<DataType> result2 =
+      TensorExpressions::evaluate(-5.7 / sqrt(T(ti_J, ti_j)));
+
+  DataType trace_T = make_with_value<DataType>(used_for_size, 0.0);
+  for (size_t j = 0; j < dim; j++) {
+    trace_T += T.get(j, j);
+  }
+  CHECK_ITERABLE_APPROX(get(result2), -5.7 / sqrt(trace_T));
+}
+
+// \brief Test the division of a tensor expression over a rank 0 tensor
+// expression is correctly evaluated
+//
+// \details
+// The cases tested are:
+// - \f$L_{i}{}^{j} = S^{i}{}_{j} / R\f$
+// - \f$L^{k}{}_{i} = (R T_{i}{}^{k}) / (T_{j}{}^{l} S^{j}{}_{l})\f$
+// - \f$L_{i}{}^{k} = T_{i}{}^{k} / R^2 / R\f$
+//
+// where \f$R\f$, \f$S\f$, \f$T\f$, and \f$L\f$ are Tensors with data type
+// `double` or DataVector.
+//
+// \tparam DataType the type of data being stored in the operands and result
+template <typename Generator, typename DataType>
+void test_divide_rank0_denominator(const gsl::not_null<Generator*> generator,
+                                   const DataType& used_for_size) {
+  std::uniform_real_distribution<> distribution(0.1, 2.0);
+  constexpr size_t dim = 3;
+
+  const auto R = make_with_random_values<Scalar<DataType>>(
+      generator, distribution, used_for_size);
+  const auto S = make_with_random_values<tnsr::Ij<DataType, dim>>(
+      generator, distribution, used_for_size);
+  const auto T = make_with_random_values<tnsr::iJ<DataType, dim>>(
+      generator, distribution, used_for_size);
+
+  // \f$L_{i}{}^{j} = S^{i}{}_{j} / R\f$
+  // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
+  // return type of `evaluate`
+  const tnsr::iJ<DataType, dim> result1 =
+      TensorExpressions::evaluate<ti_j, ti_I>(S(ti_I, ti_j) / R());
+
+  for (size_t i = 0; i < dim; i++) {
+    for (size_t j = 0; j < dim; j++) {
+      CHECK(result1.get(j, i) == S.get(i, j) / get(R));
+    }
+  }
+
+  // \f$L^{k}{}_{i} = (R T_{i}{}^{k}) / (T_{j}{}^{l} S^{j}{}_{l})\f$
+  const tnsr::Ij<DataType, dim> result2 =
+      TensorExpressions::evaluate<ti_K, ti_i>(
+          (R() * T(ti_i, ti_K)) / ((T(ti_j, ti_L) * S(ti_J, ti_l))));
+
+  DataType result2_expected_denominator =
+      make_with_value<DataType>(used_for_size, 0.0);
+  for (size_t j = 0; j < dim; j++) {
+    for (size_t l = 0; l < dim; l++) {
+      result2_expected_denominator += T.get(j, l) * S.get(j, l);
+    }
+  }
+
+  for (size_t i = 0; i < dim; i++) {
+    for (size_t k = 0; k < dim; k++) {
+      CHECK_ITERABLE_APPROX(
+          result2.get(k, i),
+          get(R) * T.get(i, k) / result2_expected_denominator);
+    }
+  }
+
+  // \f$L_{i}{}^{k} = T_{i}{}^{k} / R^2 / R\f$
+  const tnsr::iJ<DataType, dim> result3 =
+      TensorExpressions::evaluate<ti_i, ti_K>(T(ti_i, ti_K) / square(R()) /
+                                              R());
+
+  DataType result3_expected_denominator = get(R) * get(R) * get(R);
+  for (size_t i = 0; i < dim; i++) {
+    for (size_t k = 0; k < dim; k++) {
+      CHECK_ITERABLE_APPROX(result3.get(i, k),
+                            T.get(i, k) / result3_expected_denominator);
+    }
+  }
+}
+
+// \brief Test the division of a tensor expression over a rank 0 tensor
+// expression is correctly evaluated when generic indices are used for some
+// spacetime indices
+//
+// \details
+// The cases tested are:
+// - \f$L_{ai} = (T_{a}{}^{i} - S^{i}{}_{a}) / R\f$
+// - \f$L = (R / (T_{j}{}^{l} S^{j}{}_{l}) / 2\f$
+//
+// where \f$R\f$, \f$S\f$, \f$T\f$, and \f$L\f$ are Tensors with data type
+// `double` or DataVector.
+//
+// \tparam DataType the type of data being stored in the operands and result
+template <typename Generator, typename DataType>
+void test_divide_spatial_spacetime_index(
+    const gsl::not_null<Generator*> generator, const DataType& used_for_size) {
+  std::uniform_real_distribution<> distribution(0.1, 2.0);
+  constexpr size_t dim = 3;
+  using aI = Tensor<DataType, Symmetry<2, 1>,
+                    index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
+                               SpatialIndex<dim, UpLo::Up, Frame::Inertial>>>;
+
+  const auto R = make_with_random_values<Scalar<DataType>>(
+      generator, distribution, used_for_size);
+  const auto S = make_with_random_values<tnsr::Ab<DataType, dim>>(
+      generator, distribution, used_for_size);
+  const auto T =
+      make_with_random_values<aI>(generator, distribution, used_for_size);
+
+  // \f$L_{ai} = (T_{a}{}^{i} - S^{i}{}_{a}) / R\f$
+  // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
+  // return type of `evaluate`
+  const aI result1 = TensorExpressions::evaluate<ti_a, ti_I>(
+      (T(ti_a, ti_I) - S(ti_I, ti_a)) / R());
+
+  for (size_t a = 0; a < dim + 1; a++) {
+    for (size_t i = 0; i < dim; i++) {
+      CHECK_ITERABLE_APPROX(result1.get(a, i),
+                            (T.get(a, i) - S.get(i + 1, a)) / get(R));
+    }
+  }
+
+  // \f$L = (R / (T_{j}{}^{l} S^{j}{}_{l}) / 2\f$
+  const Scalar<DataType> result2 =
+      TensorExpressions::evaluate(R() / (T(ti_j, ti_L) * S(ti_J, ti_l)) / 2.0);
+
+  DataType result2_expected_denominator =
+      make_with_value<DataType>(used_for_size, 0.0);
+  for (size_t j = 0; j < dim; j++) {
+    for (size_t l = 0; l < dim; l++) {
+      result2_expected_denominator += T.get(j + 1, l) * S.get(j + 1, l + 1);
+    }
+  }
+
+  CHECK_ITERABLE_APPROX(get(result2),
+                        0.5 * get(R) / result2_expected_denominator);
+}
+
+// \brief Test the division of a tensor expression over a rank 0 tensor
+// expression is correctly evaluated when time indices are used for some
+// spacetime indices
+//
+// \details
+// The cases tested are:
+// - \f$L^{a} = S^{a}{}_{t} / \sqrt{R}\f$
+// - \f$L = R / (T_{tt} / S^{t}{}_{t} \f$
+//
+// where \f$R\f$, \f$S\f$, \f$T\f$, and \f$L\f$ are Tensors with data type
+// `double` or DataVector.
+//
+// \tparam DataType the type of data being stored in the operands and result
+template <typename Generator, typename DataType>
+void test_divide_time_index(const gsl::not_null<Generator*> generator,
+                            const DataType& used_for_size) {
+  std::uniform_real_distribution<> distribution(0.1, 2.0);
+  constexpr size_t dim = 3;
+
+  const auto R = make_with_random_values<Scalar<DataType>>(
+      generator, distribution, used_for_size);
+  const auto S = make_with_random_values<tnsr::Ab<DataType, dim>>(
+      generator, distribution, used_for_size);
+  const auto T = make_with_random_values<tnsr::ab<DataType, dim>>(
+      generator, distribution, used_for_size);
+
+  // \f$L^{a} = S^{a}{}_{t} / \sqrt{R}\f$
+  // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
+  // return type of `evaluate`
+  const tnsr::A<DataType, dim> result1 =
+      TensorExpressions::evaluate<ti_A>((S(ti_A, ti_t)) / sqrt(R()));
+
+  for (size_t a = 0; a < dim + 1; a++) {
+    CHECK_ITERABLE_APPROX(result1.get(a), (S.get(a, 0)) / sqrt(get(R)));
+  }
+
+  // \f$L = R / (T_{tt} / S^{t}{}_{t} \f$
+  const Scalar<DataType> result2 =
+      TensorExpressions::evaluate(R() / T(ti_t, ti_t) / S(ti_T, ti_t));
+
+  CHECK_ITERABLE_APPROX(get(result2), get(R) / T.get(0, 0) / S.get(0, 0));
+}
+
+template <typename Generator, typename DataType>
+void test_divide(const gsl::not_null<Generator*> generator,
+                 const DataType& used_for_size) {
+  test_divide_double_denominator(generator, used_for_size);
+  test_divide_double_numerator(generator, used_for_size);
+  test_divide_rank0_denominator(generator, used_for_size);
+  test_divide_spatial_spacetime_index(generator, used_for_size);
+  test_divide_time_index(generator, used_for_size);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Divide",
+                  "[DataStructures][Unit]") {
+  MAKE_GENERATOR(generator);
+
+  test_divide(make_not_null(&generator),
+              std::numeric_limits<double>::signaling_NaN());
+  test_divide(make_not_null(&generator),
+              DataVector(5, std::numeric_limits<double>::signaling_NaN()));
+}

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Negate.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Negate.cpp
@@ -1,0 +1,70 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <climits>
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+// \brief Test the unary `-` correctly negates a tensor expression
+//
+// \details
+// The cases tested are:
+// - \f$L_{ji}{}^{k} = -R^{k}_{ji}\f$
+// - \f$L^{i}{}_{kj} = -(R^{i}_{kj} + S^{i}_{kj})\f$
+//
+// \tparam DataType the type of data being stored in the tensors
+template <typename Generator, typename DataType>
+void test_negate(const gsl::not_null<Generator*> generator,
+                 const DataType& used_for_size) {
+  std::uniform_real_distribution<> distribution(-2.0, 2.0);
+  constexpr size_t dim = 3;
+
+  const auto R =
+      make_with_random_values<tnsr::Ijj<DataType, dim, Frame::Inertial>>(
+          generator, make_not_null(&distribution), used_for_size);
+  const auto S =
+      make_with_random_values<tnsr::Ijj<DataType, dim, Frame::Inertial>>(
+          generator, make_not_null(&distribution), used_for_size);
+
+  // \f$L_{ji}{}^{k} = -R^{k}_{ji}\f$
+  // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
+  // return type of `evaluate`
+  const Tensor<DataType, Symmetry<2, 2, 1>,
+               index_list<SpatialIndex<dim, UpLo::Lo, Frame::Inertial>,
+                          SpatialIndex<dim, UpLo::Lo, Frame::Inertial>,
+                          SpatialIndex<dim, UpLo::Up, Frame::Inertial>>>
+      result1 =
+          TensorExpressions::evaluate<ti_j, ti_i, ti_K>(-R(ti_K, ti_j, ti_i));
+  // \f$L^{i}{}_{kj} = -(R^{i}_{kj} + S^{i}_{kj})\f$
+  const tnsr::Ijj<DataType, dim> result2 =
+      TensorExpressions::evaluate<ti_I, ti_k, ti_j>(
+          -(R(ti_I, ti_k, ti_j) + S(ti_I, ti_k, ti_j)));
+
+  for (size_t i = 0; i < dim; i++) {
+    for (size_t j = 0; j < dim; j++) {
+      for (size_t k = 0; k < dim; k++) {
+        CHECK(result1.get(j, i, k) == -R.get(k, j, i));
+        CHECK(result2.get(i, k, j) == -R.get(i, k, j) - S.get(i, k, j));
+      }
+    }
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Negate",
+                  "[DataStructures][Unit]") {
+  MAKE_GENERATOR(generator);
+
+  test_negate(make_not_null(&generator),
+              std::numeric_limits<double>::signaling_NaN());
+  test_negate(make_not_null(&generator),
+              DataVector(5, std::numeric_limits<double>::signaling_NaN()));
+}

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Product.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Product.cpp
@@ -37,18 +37,14 @@ void assign_unique_values_to_tensor(
   }
 }
 
-// \brief Test the outer product and quotient of a tensor and `double` is
+// \brief Test the outer product and of a tensor expression and `double` is
 // correctly evaluated
 //
 // \details
-// The outer product cases tested are:
+// The cases tested are:
 // - \f$L_{ij} = R * S_{ij}\f$
 // - \f$L_{ij} = S_{ij} * R\f$
 // - \f$L_{ij} = R * S_{ij} * T\f$
-//
-// The division cases tested are:
-// - \f$L_{ij} = S_{ij} / R\f$
-// - \f$L_{ij} = R * S_{ij} / T\f$
 //
 // where \f$R\f$ and \f$T\f$ are `double`s and \f$S\f$ and \f$L\f$ are Tensors
 // with data type `double` or DataVector.
@@ -56,7 +52,7 @@ void assign_unique_values_to_tensor(
 // \tparam DataType the type of data being stored in the tensor operand of the
 // products
 template <typename DataType>
-void test_outer_product_quotient_double(const DataType& used_for_size) {
+void test_outer_product_double(const DataType& used_for_size) {
   constexpr size_t dim = 3;
   using tensor_type =
       Tensor<DataType, Symmetry<1, 1>,
@@ -78,21 +74,11 @@ void test_outer_product_quotient_double(const DataType& used_for_size) {
   const tensor_type Lij_from_R_Sij_T =
       TensorExpressions::evaluate<ti_i, ti_j>(-1.7 * S(ti_i, ti_j) * 0.6);
 
-  // \f$L_{ij} = S_{ij} / R\f$
-  const tensor_type Lij_from_Sij_over_R =
-      TensorExpressions::evaluate<ti_i, ti_j>(S(ti_i, ti_j) / 4.3);
-  // \f$L_{ij} = R * S_{ij} / T\f$
-  const tensor_type Lij_from_R_Sij_over_T =
-      TensorExpressions::evaluate<ti_i, ti_j>(-5.2 * S(ti_i, ti_j) / 1.6);
-
   for (size_t i = 0; i < dim; i++) {
     for (size_t j = 0; j < dim; j++) {
       CHECK(Lij_from_R_Sij.get(i, j) == 5.6 * S.get(i, j));
       CHECK(Lij_from_Sij_R.get(i, j) == S.get(i, j) * -8.1);
       CHECK(Lij_from_R_Sij_T.get(i, j) == -1.7 * S.get(i, j) * 0.6);
-
-      CHECK(Lij_from_Sij_over_R.get(i, j) == S.get(i, j) / 4.3);
-      CHECK(Lij_from_R_Sij_over_T.get(i, j) == -5.2 * S.get(i, j) / 1.6);
     }
   }
 }
@@ -1339,7 +1325,7 @@ void test_time_index(const DataType& used_for_size) {
 template <typename DataType>
 void test_products(const DataType& used_for_size) {
   // Test evaluation of outer products
-  test_outer_product_quotient_double(used_for_size);
+  test_outer_product_double(used_for_size);
   test_outer_product_rank_0_operand(used_for_size);
   test_outer_product_rank_1_operand(used_for_size);
   test_outer_product_rank_2x2_operands(used_for_size);


### PR DESCRIPTION
## Proposed changes

This PR adds support for the following operations for `TensorExpression`s:
- unary `-`, e.g. `-R(ti_a, ti_b)`
- division by tensor expressions that evaluate to a rank 0 tensor, e.g.:
    - `(...) / R()`
    - `(...) / sqrt(R(ti_a) * S(ti_A))`
    - `(...) / (R(ti_t, ti_t))`

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
