### PR TITLE
Add CCZ4 function for the spatial ricci tensor

### DIFF
--- a/src/Evolution/Systems/Ccz4/CMakeLists.txt
+++ b/src/Evolution/Systems/Ccz4/CMakeLists.txt
@@ -13,6 +13,7 @@ spectre_target_sources(
   DerivChristoffel.cpp
   DerivLapse.cpp
   DerivZ4Constraint.cpp
+  Ricci.cpp
   Z4Constraint.cpp
   )
 
@@ -25,6 +26,7 @@ spectre_target_headers(
   DerivChristoffel.hpp
   DerivLapse.hpp
   DerivZ4Constraint.hpp
+  Ricci.hpp
   System.hpp
   Tags.hpp
   TagsDeclarations.hpp

--- a/src/Evolution/Systems/Ccz4/Ricci.cpp
+++ b/src/Evolution/Systems/Ccz4/Ricci.cpp
@@ -1,0 +1,144 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Ccz4/Ricci.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Ccz4 {
+template <size_t Dim, typename Frame, typename DataType>
+void spatial_ricci_tensor(
+    const gsl::not_null<tnsr::ii<DataType, Dim, Frame>*> result,
+    const gsl::not_null<tnsr::ij<DataType, Dim, Frame>*> buffer,
+    const tnsr::Ijj<DataType, Dim, Frame>& christoffel_second_kind,
+    const tnsr::iJkk<DataType, Dim, Frame>& d_conformal_christoffel_second_kind,
+    const tnsr::ii<DataType, Dim, Frame>& conformal_spatial_metric,
+    const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
+    const tnsr::ijj<DataType, Dim, Frame>& field_d,
+    const tnsr::iJJ<DataType, Dim, Frame>& field_d_up,
+    const tnsr::i<DataType, Dim, Frame>& field_p,
+    const tnsr::ij<DataType, Dim, Frame>& d_field_p) {
+  destructive_resize_components(result,
+                                get_size(get<0, 0>(conformal_spatial_metric)));
+  destructive_resize_components(buffer,
+                                get_size(get<0, 0>(conformal_spatial_metric)));
+
+  // Add first terms of \partial_m \Gamma^m_{ij} and
+  // -\partial_j \Gamma^m_{im}
+  ::TensorExpressions::evaluate<ti_i, ti_j>(
+      buffer, d_conformal_christoffel_second_kind(ti_m, ti_M, ti_i, ti_j) -
+                  d_conformal_christoffel_second_kind(ti_j, ti_M, ti_i, ti_m));
+
+  TensorExpressions::evaluate<ti_i, ti_j>(
+      result,
+      (*buffer)(ti_i, ti_j) +
+          // Add terms of \partial_m \Gamma^m_{ij} and
+          // -\partial_j \Gamma^m_{im} that have a coefficient of 2
+          2.0 * ((field_d_up(ti_m, ti_M, ti_L) *
+                  (conformal_spatial_metric(ti_j, ti_l) * field_p(ti_i) +
+                   conformal_spatial_metric(ti_i, ti_l) * field_p(ti_j) -
+                   conformal_spatial_metric(ti_i, ti_j) * field_p(ti_l))) -
+                 inverse_conformal_spatial_metric(ti_M, ti_L) *
+                     (field_d(ti_m, ti_j, ti_l) * field_p(ti_i) +
+                      field_d(ti_m, ti_i, ti_l) * field_p(ti_j) -
+                      field_d(ti_m, ti_i, ti_j) * field_p(ti_l)) -
+                 (field_d_up(ti_j, ti_M, ti_L) *
+                  (conformal_spatial_metric(ti_m, ti_l) * field_p(ti_i) +
+                   conformal_spatial_metric(ti_i, ti_l) * field_p(ti_m) -
+                   conformal_spatial_metric(ti_i, ti_m) * field_p(ti_l))) +
+                 inverse_conformal_spatial_metric(ti_M, ti_L) *
+                     (field_d(ti_j, ti_m, ti_l) * field_p(ti_i) +
+                      field_d(ti_j, ti_i, ti_l) * field_p(ti_m) -
+                      field_d(ti_j, ti_i, ti_m) * field_p(ti_l))) -
+          // Add \partial_{(i} P_{j)} type terms
+          0.5 * (inverse_conformal_spatial_metric(ti_M, ti_L) *
+                 (conformal_spatial_metric(ti_j, ti_l) *
+                      (d_field_p(ti_m, ti_i) + d_field_p(ti_i, ti_m)) +
+                  conformal_spatial_metric(ti_i, ti_l) *
+                      (d_field_p(ti_m, ti_j) + d_field_p(ti_j, ti_m)) -
+                  conformal_spatial_metric(ti_i, ti_j) *
+                      (d_field_p(ti_m, ti_l) + d_field_p(ti_l, ti_m)) -
+                  conformal_spatial_metric(ti_m, ti_l) *
+                      (d_field_p(ti_j, ti_i) + d_field_p(ti_i, ti_j)) -
+                  conformal_spatial_metric(ti_i, ti_l) *
+                      (d_field_p(ti_j, ti_m) + d_field_p(ti_m, ti_j)) +
+                  conformal_spatial_metric(ti_i, ti_m) *
+                      (d_field_p(ti_j, ti_l) + d_field_p(ti_l, ti_j)))) +
+          // Add last two terms for R_{ij}
+          christoffel_second_kind(ti_L, ti_i, ti_j) *
+              christoffel_second_kind(ti_M, ti_l, ti_m) -
+          christoffel_second_kind(ti_L, ti_i, ti_m) *
+              christoffel_second_kind(ti_M, ti_l, ti_j));
+}
+
+template <size_t Dim, typename Frame, typename DataType>
+tnsr::ii<DataType, Dim, Frame> spatial_ricci_tensor(
+    const tnsr::Ijj<DataType, Dim, Frame>& christoffel_second_kind,
+    const tnsr::iJkk<DataType, Dim, Frame>& d_conformal_christoffel_second_kind,
+    const tnsr::ii<DataType, Dim, Frame>& conformal_spatial_metric,
+    const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
+    const tnsr::ijj<DataType, Dim, Frame>& field_d,
+    const tnsr::iJJ<DataType, Dim, Frame>& field_d_up,
+    const tnsr::i<DataType, Dim, Frame>& field_p,
+    const tnsr::ij<DataType, Dim, Frame>& d_field_p) {
+  tnsr::ii<DataType, Dim, Frame> result{};
+  tnsr::ij<DataType, Dim, Frame> buffer{};
+  spatial_ricci_tensor(
+      make_not_null(&result), make_not_null(&buffer), christoffel_second_kind,
+      d_conformal_christoffel_second_kind, conformal_spatial_metric,
+      inverse_conformal_spatial_metric, field_d, field_d_up, field_p,
+      d_field_p);
+  return result;
+}
+}  // namespace Ccz4
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                              \
+  template void Ccz4::spatial_ricci_tensor(                               \
+      const gsl::not_null<tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>*> \
+          result,                                                         \
+      const gsl::not_null<tnsr::ij<DTYPE(data), DIM(data), FRAME(data)>*> \
+          buffer,                                                         \
+      const tnsr::Ijj<DTYPE(data), DIM(data), FRAME(data)>&               \
+          christoffel_second_kind,                                        \
+      const tnsr::iJkk<DTYPE(data), DIM(data), FRAME(data)>&              \
+          d_conformal_christoffel_second_kind,                            \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&                \
+          conformal_spatial_metric,                                       \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                \
+          inverse_conformal_spatial_metric,                               \
+      const tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>& field_d,      \
+      const tnsr::iJJ<DTYPE(data), DIM(data), FRAME(data)>& field_d_up,   \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>& field_p,        \
+      const tnsr::ij<DTYPE(data), DIM(data), FRAME(data)>& d_field_p);    \
+  template tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>                  \
+  Ccz4::spatial_ricci_tensor(                                             \
+      const tnsr::Ijj<DTYPE(data), DIM(data), FRAME(data)>&               \
+          christoffel_second_kind,                                        \
+      const tnsr::iJkk<DTYPE(data), DIM(data), FRAME(data)>&              \
+          d_conformal_christoffel_second_kind,                            \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&                \
+          conformal_spatial_metric,                                       \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                \
+          inverse_conformal_spatial_metric,                               \
+      const tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>& field_d,      \
+      const tnsr::iJJ<DTYPE(data), DIM(data), FRAME(data)>& field_d_up,   \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>& field_p,        \
+      const tnsr::ij<DTYPE(data), DIM(data), FRAME(data)>& d_field_p);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial),
+                        (double, DataVector))
+
+#undef INSTANTIATE
+#undef DTYPE
+#undef FRAME
+#undef DIM

--- a/src/Evolution/Systems/Ccz4/Ricci.hpp
+++ b/src/Evolution/Systems/Ccz4/Ricci.hpp
@@ -1,0 +1,103 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Ccz4 {
+/// @{
+/*!
+ * \brief Computes the spatial Ricci tensor
+ *
+ * \details Computes the spatial Ricci tensor as:
+ *
+ * \f{align}
+ *     R_{ij} &=
+ *       \partial_m \Gamma^m_{ij} - \partial_j \Gamma^m_{im} +
+ *       \Gamma^l_{ij} \Gamma^m_{lm} - \Gamma^l_{im} \Gamma^m_{lj}
+ * \f}
+ *
+ * where
+ *
+ * \f{align}
+ *     \partial_k \Gamma^m_{ij} &=
+ *       \partial_k \tilde{\Gamma}^m_{ij} +
+ *       2 D_k{}^{ml} (\tilde{\gamma}_{jl} P_i + \tilde{\gamma}_{il} P_j -
+ *                     \tilde{\gamma}_{ij} P_l)\nonumber\\
+ *       & - 2 \tilde{\gamma}^{ml} (D_{kjl} P_i + D_{kil} P_j - D_{kij} P_l) -
+ *       \tilde{\gamma}^{ml} (
+ *         \tilde{\gamma}_{jl} \partial_{(k} P_{i)} +
+ *         \tilde{\gamma}_{il} \partial_{(k} P_{j)} -
+ *         \tilde{\gamma}_{ij} \partial_{(k} P_{l)})
+ * \f}
+ *
+ * \f$\Gamma^k_{ij}\f$ is the spatial christoffel symbols of the second kind
+ * defined by `Ccz4::Tags::ChristoffelSecondKind`,
+ * \f$\partial_m \tilde{\Gamma}^k_{ij}\f$ is the spatial derivative of the
+ * conformal spatial christoffel symbols of the second kind defined by
+ * `Ccz4::Tags::DerivConformalChristoffelSecondKind`, \f$\tilde{\gamma}_{ij}\f$
+ * is the conformal spatial metric defined by `Ccz4::Tags::ConformalMetric`,
+ * \f$\tilde{\gamma}^{ij}\f$ is the inverse conformal spatial metric defined by
+ * `Ccz4::Tags::InverseConformalMetric`, \f$D_{ijk}\f$ is the CCZ4 auxiliary
+ * variable defined by `Ccz4::Tags::FieldD`, \f$D_k{}^{ij}\f$ is the CCZ4
+ * identity defined by `Ccz4::Tags::FieldDUp`, \f$P_i\f$ is the CCZ4 auxiliary
+ * variable defined by `Ccz4::Tags::FieldP`, and \f$\partial_j P_{i}\f$ is its
+ * spatial derivative.
+ *
+ * After substituting in the full expressions for \f$\partial_m \Gamma^m_{ij}\f$
+ * and \f$\partial_j \Gamma^m_{im}\f$ and commuting terms with common
+ * coefficients, the full equation becomes and is implemented as:
+ *
+ *  \f{align}{
+ *     R_{ij} &=
+ *       \partial_m \tilde{\Gamma}^m_{ij} -
+ *       \partial_j \tilde{\Gamma}^m_{im}\nonumber\\
+ *       & + 2 D_m{}^{ml} (\tilde{\gamma}_{jl} P_i + \tilde{\gamma}_{il} P_j -
+ *                         \tilde{\gamma}_{ij} P_l) -
+ *       2 \tilde{\gamma}^{ml} (
+ *         D_{mjl} P_i + D_{mil} P_j - D_{mij} P_l)\nonumber\\
+ *       & - 2 D_j{}^{ml} (\tilde{\gamma}_{ml} P_i + \tilde{\gamma}_{il} P_m -
+ *                         \tilde{\gamma}_{im} P_l) +
+ *       2 \tilde{\gamma}^{ml} (
+ *         D_{jml} P_i + D_{jil} P_m - D_{jim} P_l)\nonumber\\
+ *       & - \tilde{\gamma}^{ml} (
+ *         \tilde{\gamma}_{jl} \partial_{(m} P_{i)} +
+ *         \tilde{\gamma}_{il} \partial_{(m} P_{j)} -
+ *         \tilde{\gamma}_{ij} \partial_{(m} P_{l)}) +
+ *       \tilde{\gamma}^{ml} (
+ *         \tilde{\gamma}_{ml} \partial_{(j} P_{i)} +
+ *         \tilde{\gamma}_{il} \partial_{(j} P_{m)} -
+ *         \tilde{\gamma}_{im} \partial_{(j} P_{l)})\nonumber\\
+ *       & + \Gamma^l_{ij} \Gamma^m_{lm} - \Gamma^l_{im} \Gamma^m_{lj}
+ * \f}
+ *
+ */
+template <size_t Dim, typename Frame, typename DataType>
+void spatial_ricci_tensor(
+    const gsl::not_null<tnsr::ii<DataType, Dim, Frame>*> result,
+    const gsl::not_null<tnsr::ij<DataType, Dim, Frame>*> buffer,
+    const tnsr::Ijj<DataType, Dim, Frame>& christoffel_second_kind,
+    const tnsr::iJkk<DataType, Dim, Frame>& d_conformal_christoffel_second_kind,
+    const tnsr::ii<DataType, Dim, Frame>& conformal_spatial_metric,
+    const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
+    const tnsr::ijj<DataType, Dim, Frame>& field_d,
+    const tnsr::iJJ<DataType, Dim, Frame>& field_d_up,
+    const tnsr::i<DataType, Dim, Frame>& field_p,
+    const tnsr::ij<DataType, Dim, Frame>& d_field_p);
+
+template <size_t Dim, typename Frame, typename DataType>
+tnsr::ii<DataType, Dim, Frame> spatial_ricci_tensor(
+    const tnsr::Ijj<DataType, Dim, Frame>& christoffel_second_kind,
+    const tnsr::iJkk<DataType, Dim, Frame>& d_conformal_christoffel_second_kind,
+    const tnsr::ii<DataType, Dim, Frame>& conformal_spatial_metric,
+    const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
+    const tnsr::ijj<DataType, Dim, Frame>& field_d,
+    const tnsr::iJJ<DataType, Dim, Frame>& field_d_up,
+    const tnsr::i<DataType, Dim, Frame>& field_p,
+    const tnsr::ij<DataType, Dim, Frame>& d_field_p);
+/// @}
+}  // namespace Ccz4

--- a/src/Evolution/Systems/Ccz4/Tags.hpp
+++ b/src/Evolution/Systems/Ccz4/Tags.hpp
@@ -234,6 +234,16 @@ struct ChristoffelSecondKind : db::SimpleTag {
 };
 
 /*!
+ * \brief The spatial Ricci tensor
+ *
+ * \details See `Ccz4::spatial_ricci_tensor()` for details.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct Ricci : db::SimpleTag {
+  using type = tnsr::ii<DataType, Dim, Frame>;
+};
+
+/*!
  * \brief The gradient of the gradient of the lapse
  *
  * \details We define:

--- a/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
@@ -51,6 +51,9 @@ template <size_t Dim, typename Frame = Frame::Inertial,
 struct ChristoffelSecondKind;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
+struct Ricci;
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
 struct GradGradLapse;
 template <typename DataType = DataVector>
 struct DivergenceLapse;

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp
@@ -252,8 +252,11 @@ class KerrSchild : public AnalyticSolution<3_st>,
       const tnsr::I<DataType, volume_dim, Frame>& x, double /*t*/,
       tmpl::list<Tags...> /*meta*/) const {
     static_assert(
-        tmpl2::flat_all_v<
-            tmpl::list_contains_v<tags<DataType, Frame>, Tags>...>,
+        tmpl2::flat_all_v<tmpl::list_contains_v<
+            tmpl::push_back<
+                tags<DataType, Frame>,
+                gr::Tags::DerivDetSpatialMetric<3, Frame, DataType>>,
+            Tags>...>,
         "At least one of the requested tags is not supported. The requested "
         "tags are listed as template parameters of the `variables` function.");
     IntermediateVars<DataType, Frame> intermediate(*this, x);

--- a/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   Test_DerivChristoffel.cpp
   Test_DerivLapse.cpp
   Test_DerivZ4Constraint.cpp
+  Test_Ricci.cpp
   Test_Tags.cpp
   Test_TempTags.cpp
   Test_Z4Constraint.cpp
@@ -18,5 +19,6 @@ add_test_library(
   ${LIBRARY}
   "Evolution/Systems/Ccz4/"
   "${LIBRARY_SOURCES}"
-  "Ccz4;DataBoxTestHelpers;DataStructures;Utilities"
+  "Ccz4;DataBoxTestHelpers;DataStructures;Domain;GeneralRelativity"
+  "GeneralRelativitySolutions;LinearOperators;Spectral;Utilities"
   )

--- a/tests/Unit/Evolution/Systems/Ccz4/Ricci.py
+++ b/tests/Unit/Evolution/Systems/Ccz4/Ricci.py
@@ -1,0 +1,45 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def deriv_christoffel_second_kind(d_conformal_christoffel_second_kind,
+                                  conformal_spatial_metric,
+                                  inverse_conformal_spatial_metric, field_d,
+                                  field_d_up, field_p, d_field_p):
+    return (
+        d_conformal_christoffel_second_kind + 2.0 *
+        (np.einsum("kml,ijl->kmij", field_d_up,
+                   (np.einsum("jl,i", conformal_spatial_metric, field_p) +
+                    np.einsum("il,j", conformal_spatial_metric, field_p) -
+                    np.einsum("ij,l", conformal_spatial_metric, field_p))) -
+         np.einsum("ml,ijkl->kmij", inverse_conformal_spatial_metric,
+                   (np.einsum("kjl,i", field_d, field_p) +
+                    np.einsum("kil,j", field_d, field_p) -
+                    np.einsum("kij,l", field_d, field_p)))) -
+        np.einsum("ml,ijkl->kmij", inverse_conformal_spatial_metric,
+                  (np.einsum("jl,ki", conformal_spatial_metric, d_field_p) +
+                   np.einsum("jl,ik", conformal_spatial_metric, d_field_p) +
+                   np.einsum("il,kj", conformal_spatial_metric, d_field_p) +
+                   np.einsum("il,jk", conformal_spatial_metric, d_field_p) -
+                   np.einsum("ij,kl", conformal_spatial_metric, d_field_p) -
+                   np.einsum("ij,lk", conformal_spatial_metric, d_field_p))) /
+        2.0)
+
+
+def spatial_ricci_tensor(christoffel_second_kind,
+                         d_conformal_christoffel_second_kind,
+                         conformal_spatial_metric,
+                         inverse_conformal_spatial_metric, field_d, field_d_up,
+                         field_p, d_field_p):
+    d_christoffel_second_kind = deriv_christoffel_second_kind(
+        d_conformal_christoffel_second_kind, conformal_spatial_metric,
+        inverse_conformal_spatial_metric, field_d, field_d_up, field_p,
+        d_field_p)
+
+    return (
+        np.einsum("mmij", d_christoffel_second_kind) -
+        np.einsum("jmim", d_christoffel_second_kind) + np.einsum(
+            "lij,mlm", christoffel_second_kind, christoffel_second_kind) -
+        np.einsum("lim,mlj", christoffel_second_kind, christoffel_second_kind))

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_Ricci.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_Ricci.cpp
@@ -1,0 +1,219 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <climits>
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Evolution/Systems/Ccz4/Christoffel.hpp"
+#include "Evolution/Systems/Ccz4/DerivChristoffel.hpp"
+#include "Evolution/Systems/Ccz4/Ricci.hpp"
+#include "Evolution/Systems/Ccz4/Tags.hpp"
+#include "Framework/Pypp.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/DerivativeSpatialMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+using Affine = domain::CoordinateMaps::Affine;
+using Affine3D = domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+
+template <typename Solution>
+void test_compute_spatial_ricci_tensor(
+    const Solution& solution, size_t grid_size_each_dimension,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound) {
+  // Setup grid
+  const size_t SpatialDim = 3;
+  Mesh<SpatialDim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto};
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::ElementLogical, Frame::Inertial>(
+          Affine3D{
+              Affine{-1., 1., lower_bound[0], upper_bound[0]},
+              Affine{-1., 1., lower_bound[1], upper_bound[1]},
+              Affine{-1., 1., lower_bound[2], upper_bound[2]},
+          });
+  const size_t num_points_3d = grid_size_each_dimension *
+                               grid_size_each_dimension *
+                               grid_size_each_dimension;
+  // Setup coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  // Arbitrary time for time-independent solution.
+  const double t = std::numeric_limits<double>::signaling_NaN();
+  // Evaluate analytic solution
+  const auto vars =
+      solution.variables(x, t, typename Solution::template tags<DataVector>{});
+  const auto& spatial_metric = get<gr::Tags::SpatialMetric<SpatialDim>>(vars);
+  const auto det_spatial_metric = determinant_and_inverse(spatial_metric).first;
+  const auto& d_spatial_metric =
+      get<Tags::deriv<gr::Tags::SpatialMetric<SpatialDim>,
+                      tmpl::size_t<SpatialDim>, Frame::Inertial>>(vars);
+  const auto d_det_spatial_metric =
+      get<gr::Tags::DerivDetSpatialMetric<SpatialDim>>(solution.variables(
+          x, t, tmpl::list<gr::Tags::DerivDetSpatialMetric<SpatialDim>>{}));
+
+  // Compute arguments for `spatial_ricci_tensor` function to test
+  const auto conformal_factor = pow(get(det_spatial_metric), -1. / 6.);
+
+  tnsr::ii<DataVector, SpatialDim, Frame::Inertial> conformal_spatial_metric{};
+  for (size_t i = 0; i < SpatialDim; i++) {
+    for (size_t j = i; j < SpatialDim; j++) {
+      conformal_spatial_metric.get(i, j) =
+          square(conformal_factor) * spatial_metric.get(i, j);
+    }
+  }
+
+  tnsr::ijj<DataVector, SpatialDim, Frame::Inertial>
+      d_conformal_spatial_metric{};
+  for (size_t k = 0; k < SpatialDim; k++) {
+    for (size_t i = 0; i < SpatialDim; i++) {
+      for (size_t j = i; j < SpatialDim; j++) {
+        d_conformal_spatial_metric.get(k, i, j) =
+            pow<2>(conformal_factor) * d_spatial_metric.get(k, i, j) -
+            pow<8>(conformal_factor) * d_det_spatial_metric.get(k) *
+                spatial_metric.get(i, j) / 3.;
+      }
+    }
+  }
+
+  const auto inverse_conformal_spatial_metric =
+      determinant_and_inverse(conformal_spatial_metric).second;
+
+  tnsr::ijj<DataVector, SpatialDim, Frame::Inertial> field_d{};
+  for (size_t k = 0; k < SpatialDim; k++) {
+    for (size_t i = 0; i < SpatialDim; i++) {
+      for (size_t j = i; j < SpatialDim; j++) {
+        field_d.get(k, i, j) = 0.5 * d_conformal_spatial_metric.get(k, i, j);
+      }
+    }
+  }
+
+  auto field_d_up = gr::deriv_inverse_spatial_metric(
+      inverse_conformal_spatial_metric, field_d);
+  for (size_t k = 0; k < SpatialDim; k++) {
+    for (size_t i = 0; i < SpatialDim; i++) {
+      for (size_t j = i; j < SpatialDim; j++) {
+        field_d_up.get(k, i, j) *= -1.0;
+      }
+    }
+  }
+
+  using field_d_tag =
+      Ccz4::Tags::FieldD<SpatialDim, Frame::Inertial, DataVector>;
+  Variables<tmpl::list<field_d_tag>> field_d_var(num_points_3d);
+  get<field_d_tag>(field_d_var) = field_d;
+  const auto d_field_d_var = partial_derivatives<tmpl::list<field_d_tag>>(
+      field_d_var, mesh, coord_map.inv_jacobian(x_logical));
+  const auto& d_field_d =
+      get<Tags::deriv<field_d_tag, tmpl::size_t<SpatialDim>, Frame::Inertial>>(
+          d_field_d_var);
+
+  const auto d_conformal_christoffel_second_kind =
+      Ccz4::deriv_conformal_christoffel_second_kind(
+          inverse_conformal_spatial_metric, field_d, d_field_d, field_d_up);
+
+  tnsr::i<DataVector, SpatialDim, Frame::Inertial> field_p{};
+  for (size_t i = 0; i < SpatialDim; i++) {
+    field_p.get(i) =
+        -d_det_spatial_metric.get(i) / (6. * get(det_spatial_metric));
+  }
+
+  using field_p_tag =
+      Ccz4::Tags::FieldP<SpatialDim, Frame::Inertial, DataVector>;
+  Variables<tmpl::list<field_p_tag>> field_p_var(num_points_3d);
+  get<field_p_tag>(field_p_var) = field_p;
+  const auto d_field_p_var = partial_derivatives<tmpl::list<field_p_tag>>(
+      field_p_var, mesh, coord_map.inv_jacobian(x_logical));
+  const auto& d_field_p =
+      get<Tags::deriv<field_p_tag, tmpl::size_t<SpatialDim>, Frame::Inertial>>(
+          d_field_p_var);
+
+  const auto conformal_christoffel_second_kind =
+      Ccz4::conformal_christoffel_second_kind(inverse_conformal_spatial_metric,
+                                              field_d);
+
+  const auto christoffel_second_kind = Ccz4::christoffel_second_kind(
+      conformal_spatial_metric, inverse_conformal_spatial_metric, field_p,
+      conformal_christoffel_second_kind);
+
+  using christoffel_second_kind_tag =
+      gr::Tags::SpatialChristoffelSecondKind<SpatialDim, Frame::Inertial,
+                                             DataVector>;
+  Variables<tmpl::list<christoffel_second_kind_tag>>
+      christoffel_second_kind_var(num_points_3d);
+  get<christoffel_second_kind_tag>(christoffel_second_kind_var) =
+      christoffel_second_kind;
+  const auto d_christoffel_second_kind_var =
+      partial_derivatives<tmpl::list<christoffel_second_kind_tag>>(
+          christoffel_second_kind_var, mesh, coord_map.inv_jacobian(x_logical));
+  const auto& d_christoffel_second_kind =
+      get<Tags::deriv<christoffel_second_kind_tag, tmpl::size_t<SpatialDim>,
+                      Frame::Inertial>>(d_christoffel_second_kind_var);
+
+  // Compute expected and actual ricci tensors using above computed arguments
+  const auto expected_py_ricci_tensor{
+      pypp::call<tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(
+          "Ricci", "spatial_ricci_tensor", christoffel_second_kind,
+          d_conformal_christoffel_second_kind, conformal_spatial_metric,
+          inverse_conformal_spatial_metric, field_d, field_d_up, field_p,
+          d_field_p)};
+
+  const auto expected_cpp_ricci_tensor =
+      gr::ricci_tensor(christoffel_second_kind, d_christoffel_second_kind);
+
+  const auto actual_cpp_ricci_tensor = Ccz4::spatial_ricci_tensor(
+      christoffel_second_kind, d_conformal_christoffel_second_kind,
+      conformal_spatial_metric, inverse_conformal_spatial_metric, field_d,
+      field_d_up, field_p, d_field_p);
+
+  CHECK_ITERABLE_APPROX(expected_py_ricci_tensor, actual_cpp_ricci_tensor);
+  // A custom epsilon is used here because the Legendre polynomials don't fit
+  // the derivative of 1 / r well. This was looked at for various box sizes and
+  // number of 1D grid points.
+  Approx approx = Approx::custom().epsilon(1e-12).scale(1.0);
+  CHECK_ITERABLE_CUSTOM_APPROX(expected_cpp_ricci_tensor,
+                               actual_cpp_ricci_tensor, approx);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.Ricci", "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env("Evolution/Systems/Ccz4/");
+
+  const double mass = 2.;
+  const std::array<double, 3> spin{{0.3, 0.5, 0.2}};
+  const std::array<double, 3> center{{0.2, 0.3, 0.4}};
+  const gr::Solutions::KerrSchild solution(mass, spin, center);
+
+  const size_t grid_size = 8;
+  const std::array<double, 3> lower_bound{{0.8, 1.22, 1.30}};
+  const std::array<double, 3> upper_bound{{0.82, 1.24, 1.32}};
+
+  test_compute_spatial_ricci_tensor(solution, grid_size, lower_bound,
+                                    upper_bound);
+}

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
@@ -52,6 +52,8 @@ void test_simple_tags() {
   TestHelpers::db::test_simple_tag<
       Ccz4::Tags::ChristoffelSecondKind<Dim, Frame, DataType>>(
       "ChristoffelSecondKind");
+  TestHelpers::db::test_simple_tag<Ccz4::Tags::Ricci<Dim, Frame, DataType>>(
+      "Ricci");
   TestHelpers::db::test_simple_tag<
       Ccz4::Tags::GradGradLapse<Dim, Frame, DataType>>("GradGradLapse");
   TestHelpers::db::test_simple_tag<Ccz4::Tags::DivergenceLapse<DataType>>(

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_KerrSchild.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_KerrSchild.cpp
@@ -195,22 +195,22 @@ void test_numerical_deriv_det_spatial_metric(const DataVector& used_for_size) {
   const auto x = coord_map(x_logical);
   // Arbitrary time for time-independent solution.
   const double t = std::numeric_limits<double>::signaling_NaN();
-  // Evaluate analytic solution
-  const auto vars = solution.variables(
-      x, t,
-      typename gr::Solutions::KerrSchild::template tags<DataVector,
-                                                        FrameType>{});
 
   // Compute actual analytical derivative of the determinant
-  gr::Solutions::KerrSchild::IntermediateVars<DataVector, FrameType> ks_cache(
-      solution, x);
-  const auto deriv_det_spatial_metric = ks_cache.get_var(
-      gr::Tags::DerivDetSpatialMetric<3, FrameType, DataVector>{});
+  const auto deriv_det_spatial_metric =
+      get<gr::Tags::DerivDetSpatialMetric<SpatialDim, FrameType>>(
+          solution.variables(
+              x, t,
+              tmpl::list<
+                  gr::Tags::DerivDetSpatialMetric<SpatialDim, FrameType>>{}));
 
   // Compute expected numerical derivative of the determinant
   const double null_vector_0 = -1.0;
   gr::Solutions::KerrSchild::IntermediateComputer<DataVector, FrameType>
       ks_computer(solution, x, null_vector_0);
+  gr::Solutions::KerrSchild::IntermediateVars<DataVector, FrameType> ks_cache(
+      solution, x);
+
   auto H = make_with_value<Scalar<DataVector>>(
       used_for_size, std::numeric_limits<double>::signaling_NaN());
   using H_tag = gr::Solutions::KerrSchild::internal_tags::H<DataVector>;


### PR DESCRIPTION
## Proposed changes

This PR adds a CCZ4 function for computing the spatial ricci tensor.

The motivation for this PR is to implement eq. (20), whose value will be used to implement eq. (12e) and (27) in [this CCZ4 paper](https://arxiv.org/pdf/1707.09910.pdf), whose value will later be necessary for computing the evolved variables.

Since eq (20) is the only computation that depends on the spatial derivative of the spatial christoffel symbols (identity defined by eq. (18)) and since it only needs select components from the riemann tensor (eq. 19), the computation of eq. (18) and eq. (19) are not defined generically in separate functions. Instead, this implementation of eq. (20) only computes the components it needs from the eq. (18) LHS and the eq. (19) LHS.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
