### PR TITLE
Remove unneeded interp dependencies.

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -33,29 +33,17 @@ spectre_target_headers(
   SpanInterpolator.hpp
   )
 
-add_dependencies(
-  ${LIBRARY}
-  module_GlobalCache
-  )
-
 target_link_libraries(
   ${LIBRARY}
   PUBLIC
-  ApparentHorizons
   Blas
   Boost::boost
   DataStructures
-  DgSubcell
   Domain
-  DomainStructure
   ErrorHandling
-  EventsAndTriggers
   GSL::gsl
-  Logging
   Options
   Spectral
-  INTERFACE
-  SystemUtilities
   )
 
 add_subdirectory(Python)

--- a/src/ParallelAlgorithms/Interpolation/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Interpolation/CMakeLists.txt
@@ -34,8 +34,6 @@ target_link_libraries(
   ${LIBRARY}
   PUBLIC
   ApparentHorizons
-  Blas
-  Boost::boost
   DataStructures
   DgSubcell
   Domain
@@ -47,8 +45,6 @@ target_link_libraries(
   Logging
   Options
   Spectral
-  INTERFACE
-  SystemUtilities
   )
 
 add_subdirectory(Actions)


### PR DESCRIPTION
Dependences removed both in NumericalAlgorithms/Interpolation
and in ParallelAlgorithms/Interpolation.
These dependencies are no longer needed now that
the parallel interpolation framework has been moved (and some apparently
were not needed even before the framework was moved)

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
