### PR TITLE
Add ObservationBox

### DIFF
--- a/src/DataStructures/DataBox/CMakeLists.txt
+++ b/src/DataStructures/DataBox/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_headers(
   DataBoxTag.hpp
   DataOnSlice.hpp
   Item.hpp
+  ObservationBox.hpp
   PrefixHelpers.hpp
   Prefixes.hpp
   SubitemTag.hpp

--- a/src/DataStructures/DataBox/ObservationBox.hpp
+++ b/src/DataStructures/DataBox/ObservationBox.hpp
@@ -1,0 +1,121 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Item.hpp"
+#include "Utilities/ErrorHandling/StaticAssert.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+template <typename ComputeTagsList, typename DataBoxType>
+class ObservationBox;
+/// \endcond
+
+/*!
+ * \ingroup DataStructuresGroup
+ * \brief Used for adding compute items to a `DataBox` without copying or moving
+ * any data from the original `DataBox`
+ *
+ * The intended use-case for this class is during IO/observing where additional
+ * compute tags are needed only for observation. The memory used by those
+ * compute tags does not need to be persistent and so we'd like a light-weight
+ * class to handle the on-demand computation.
+ */
+template <typename DataBoxType, typename... ComputeTags>
+class ObservationBox<tmpl::list<ComputeTags...>, DataBoxType>
+    : private db::detail::Item<ComputeTags>... {
+ public:
+  /// A list of all the compute item tags
+  using compute_item_tags = tmpl::list<ComputeTags...>;
+
+  ObservationBox() = default;
+  ObservationBox(const ObservationBox& rhs) = default;
+  ObservationBox& operator=(const ObservationBox& rhs) = default;
+  ObservationBox(ObservationBox&& rhs) = default;
+  ObservationBox& operator=(ObservationBox&& rhs) = default;
+  ~ObservationBox() = default;
+
+  /// Create an `ObservationBox` that can also retrieve things out of the
+  /// `databox` passed in.
+  ObservationBox(const DataBoxType& databox);
+
+  /// Retrieve the tag `Tag`, should be called by the free function db::get
+  template <typename Tag>
+  const auto& get() const;
+
+ private:
+  template <typename Tag>
+  const auto& get_item() const {
+    return static_cast<const db::detail::Item<Tag>&>(*this);
+  }
+
+  template <typename ComputeTag, typename... ArgumentTags>
+  void evaluate_compute_item(
+      tmpl::list<ArgumentTags...> /*meta*/) const;
+
+  using tags_list =
+      tmpl::push_back<typename DataBoxType::tags_list, ComputeTags...>;
+
+  const DataBoxType* databox_ = nullptr;
+};
+
+/*!
+ * \ingroup DataStructuresGroup
+ * \brief Retrieve a `Tag` from the `ObservationBox`.
+ */
+template <typename Tag, typename DataBoxType, typename... ComputeTags>
+const auto& get(
+    const ObservationBox<tmpl::list<ComputeTags...>, DataBoxType>& box) {
+  return box.template get<Tag>();
+}
+
+template <typename DataBoxType, typename... ComputeTags>
+ObservationBox<tmpl::list<ComputeTags...>, DataBoxType>::ObservationBox(
+    const DataBoxType& databox)
+    : databox_(&databox) {
+  DEBUG_STATIC_ASSERT(
+      (db::is_immutable_item_tag_v<ComputeTags> and ...),
+      "All tags passed to ObservationBox must be compute tags.");
+}
+
+template <typename DataBoxType, typename... ComputeTags>
+template <typename Tag>
+const auto& ObservationBox<tmpl::list<ComputeTags...>, DataBoxType>::get()
+    const {
+  DEBUG_STATIC_ASSERT(not db::detail::has_no_matching_tag_v<tags_list, Tag>,
+                      "Found no tags in the ObservationBox that match the tag "
+                      "being retrieved.");
+  DEBUG_STATIC_ASSERT(
+      db::detail::has_unique_matching_tag_v<tags_list, Tag>,
+      "Found more than one tag in the ObservationBox that matches the tag "
+      "being retrieved. This happens because more than one tag with the same "
+      "base (class) tag was added to the ObservationBox.");
+
+  if constexpr (db::tag_is_retrievable_v<Tag, DataBoxType>) {
+    return db::get<Tag>(*databox_);
+  } else {
+    using item_tag = db::detail::first_matching_tag<compute_item_tags, Tag>;
+    if (not get_item<item_tag>().evaluated()) {
+      evaluate_compute_item<item_tag>(typename item_tag::argument_tags{});
+    }
+    if constexpr (tt::is_a_v<std::unique_ptr, typename item_tag::type>) {
+      return *(get_item<item_tag>().get());
+    } else {
+      return get_item<item_tag>().get();
+    }
+  }
+}
+
+template <typename DataBoxType, typename... ComputeTags>
+template <typename ComputeTag, typename... ArgumentTags>
+void ObservationBox<tmpl::list<ComputeTags...>, DataBoxType>::
+    evaluate_compute_item(tmpl::list<ArgumentTags...> /*meta*/) const {
+  get_item<ComputeTag>().evaluate(get<ArgumentTags>()...);
+}
+
+template <typename ComputeTagsList, typename DataBoxType>
+auto make_observation_box(const DataBoxType& databox) {
+  return ObservationBox<ComputeTagsList, DataBoxType>{databox};
+}

--- a/src/DataStructures/DataBox/ObservationBox.hpp
+++ b/src/DataStructures/DataBox/ObservationBox.hpp
@@ -143,3 +143,29 @@ template <typename ComputeTagsList, typename DataBoxType>
 auto make_observation_box(const DataBoxType& databox) {
   return ObservationBox<ComputeTagsList, DataBoxType>{databox};
 }
+
+namespace observation_box_detail {
+template <typename DataBoxType, typename ComputeTagsList, typename... Args,
+          typename F, typename... ArgumentTags>
+auto apply(F&& f, tmpl::list<ArgumentTags...> /*meta*/,
+           const ObservationBox<ComputeTagsList, DataBoxType>& observation_box,
+           Args&&... args) {
+  return std::forward<F>(f)(get<ArgumentTags>(observation_box)...,
+                            std::forward<Args>(args)...);
+}
+}  // namespace observation_box_detail
+
+/*!
+ * \ingroup DataStructuresGroup
+ * \brief Apply the function object `f` using its nested `argument_tags` list of
+ * tags.
+ */
+template <typename DataBoxType, typename ComputeTagsList, typename... Args,
+          typename F>
+auto apply(F&& f,
+           const ObservationBox<ComputeTagsList, DataBoxType>& observation_box,
+           Args&&... args) {
+  return observation_box_detail::apply(
+      std::forward<F>(f), typename std::decay_t<F>::argument_tags{},
+      observation_box, std::forward<Args>(args)...);
+}

--- a/src/IO/Observer/GetSectionObservationKey.hpp
+++ b/src/IO/Observer/GetSectionObservationKey.hpp
@@ -17,13 +17,14 @@ namespace observers {
 /// parallel algorithms. The return value can be used to construct a subfile
 /// path for observations, and to skip observations on elements that are not
 /// part of a section (`std::nullopt`).
-template <typename SectionIdTag, typename DbTagsList>
+template <typename SectionIdTag, typename Box>
 std::optional<std::string> get_section_observation_key(
-    [[maybe_unused]] const db::DataBox<DbTagsList>& box) {
+    [[maybe_unused]] const Box& box) {
   if constexpr (std::is_same_v<SectionIdTag, void>) {
     return "";
   } else {
-    return db::get<observers::Tags::ObservationKey<SectionIdTag>>(box);
+    using db::get;
+    return get<observers::Tags::ObservationKey<SectionIdTag>>(box);
   }
 }
 

--- a/tests/Unit/DataStructures/DataBox/CMakeLists.txt
+++ b/tests/Unit/DataStructures/DataBox/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_DataBox.cpp
   Test_DataBoxDocumentation.cpp
   Test_DataBoxPrefixes.cpp
+  Test_ObservationBox.cpp
   Test_PrefixHelpers.cpp
   Test_TagName.cpp
   Test_TagTraits.cpp

--- a/tests/Unit/DataStructures/DataBox/Test_ObservationBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_ObservationBox.cpp
@@ -6,7 +6,12 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/ObservationBox.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace {
 void multiply_by_two(const gsl::not_null<double*> result, const double value) {
@@ -57,6 +62,29 @@ struct Tag3Compute : Tag3, db::ComputeTag {
 
 size_t Tag3Compute::times_called = 0;
 
+struct ScalarVar : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+struct VectorVar : db::SimpleTag {
+  using type = tnsr::I<DataVector, 3, Frame::Inertial>;
+};
+
+struct VarsCompute : db::ComputeTag,
+                     ::Tags::Variables<tmpl::list<ScalarVar, VectorVar>> {
+  using base = ::Tags::Variables<tmpl::list<ScalarVar, VectorVar>>;
+  using return_type = typename base::type;
+  using argument_tags = tmpl::list<>;
+  static void function(
+      const gsl::not_null<::Variables<tmpl::list<ScalarVar, VectorVar>>*>
+          result) {
+    result->initialize(5, 1.0);
+    for (size_t i = 0; i < 3; ++i) {
+      get<VectorVar>(*result).get(i) += static_cast<double>(i) + 1.0;
+    }
+  }
+};
+
 // Test that we can return values from the apply functions and that we can
 // retrieve both the nested DataBox and the ObservationBox via the argument
 // tags.
@@ -83,9 +111,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.ObservationBox",
                   "[Unit][DataStructures]") {
   const auto db_box =
       db::create<db::AddSimpleTags<Tag0>, db::AddComputeTags<Tag1Compute>>(2.0);
-  const auto obs_box =
-      make_observation_box<db::AddComputeTags<Tag2Compute, Tag3Compute>>(
-          db_box);
+  const auto obs_box = make_observation_box<
+      db::AddComputeTags<Tag2Compute, Tag3Compute, VarsCompute>>(db_box);
   CHECK(Tag3Compute::times_called == 0);
   CHECK(get<Tag0>(obs_box) == 2.0);
   CHECK(get<Tag1>(obs_box) == 4.0);
@@ -100,6 +127,10 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.ObservationBox",
 
   CHECK(apply(SubtractNumberAndReturn{}, obs_box, 5.0) ==
         (get<Tag3>(obs_box) - 5.0));
+  CHECK(get(get<ScalarVar>(obs_box)) == DataVector(5, 1.0));
+  CHECK(get<0>(get<VectorVar>(obs_box)) == DataVector(5, 2.0));
+  CHECK(get<1>(get<VectorVar>(obs_box)) == DataVector(5, 3.0));
+  CHECK(get<2>(get<VectorVar>(obs_box)) == DataVector(5, 4.0));
 }
 
 }  // namespace

--- a/tests/Unit/DataStructures/DataBox/Test_ObservationBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_ObservationBox.cpp
@@ -1,0 +1,78 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+void multiply_by_two(const gsl::not_null<double*> result, const double value) {
+  *result = 2.0 * value;
+}
+
+struct Tag0 : db::SimpleTag {
+  using type = double;
+};
+
+struct Tag1 : db::SimpleTag {
+  using type = double;
+};
+
+struct Tag1Compute : Tag1, db::ComputeTag {
+  using base = Tag1;
+  using return_type = double;
+  static constexpr auto function = multiply_by_two;
+  using argument_tags = tmpl::list<Tag0>;
+};
+
+struct Tag2 : db::SimpleTag {
+  using type = double;
+};
+
+struct Tag2Compute : Tag2, db::ComputeTag {
+  using base = Tag2;
+  using return_type = double;
+  static constexpr auto function = multiply_by_two;
+  using argument_tags = tmpl::list<Tag1>;
+};
+
+struct Tag3 : db::SimpleTag {
+  using type = double;
+};
+
+struct Tag3Compute : Tag3, db::ComputeTag {
+  using base = Tag3;
+  using return_type = double;
+  static auto function(const gsl::not_null<double*> result, const double value0,
+                       const double value1, const double value2) {
+    ++times_called;
+    *result = value0 + value1 + value2;
+  }
+  using argument_tags = tmpl::list<Tag0, Tag1, Tag2>;
+  static size_t times_called;
+};
+
+size_t Tag3Compute::times_called = 0;
+
+SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.ObservationBox",
+                  "[Unit][DataStructures]") {
+  const auto db_box =
+      db::create<db::AddSimpleTags<Tag0>, db::AddComputeTags<Tag1Compute>>(2.0);
+  const auto obs_box =
+      make_observation_box<db::AddComputeTags<Tag2Compute, Tag3Compute>>(
+          db_box);
+  CHECK(Tag3Compute::times_called == 0);
+  CHECK(get<Tag0>(obs_box) == 2.0);
+  CHECK(get<Tag1>(obs_box) == 4.0);
+  CHECK(get<Tag2>(obs_box) == (2.0 * 2.0 * 2.0));
+  CHECK(get<Tag3>(obs_box) == (2.0 + 2.0 * 2.0 + 2.0 * 2.0 * 2.0));
+  CHECK(Tag3Compute::times_called == 1);
+  // Call a second time to make sure the compute tag didn't get evaluated again.
+  CHECK(get<Tag3>(obs_box) == (2.0 + 2.0 * 2.0 + 2.0 * 2.0 * 2.0));
+  CHECK(Tag3Compute::times_called == 1);
+}
+
+}  // namespace

--- a/tests/Unit/DataStructures/DataBox/Test_ObservationBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_ObservationBox.cpp
@@ -73,6 +73,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.ObservationBox",
   // Call a second time to make sure the compute tag didn't get evaluated again.
   CHECK(get<Tag3>(obs_box) == (2.0 + 2.0 * 2.0 + 2.0 * 2.0 * 2.0));
   CHECK(Tag3Compute::times_called == 1);
+  CHECK(&db_box == &get<::Tags::DataBox>(obs_box));
+  CHECK(&obs_box == &get<::Tags::ObservationBox>(obs_box));
 }
 
 }  // namespace


### PR DESCRIPTION
## Proposed changes

Adds data structure `ObservationBox` that will be used by events and allows adding compute tags to the `DataBox` with very little compile time overhead. The `ObservationBox` goes out of scope after events are run and so reduces memory overhead. For GH, this will be close to a 50% reduction in memory usage since there are 250 tensor components currently stored only for observing.

In future PRs I will convert the `ObserveFields` and `ObserveNorms` events to use this data structure, followed by switching over the scalar wave and GH executables to reduce memory usage.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
