### PR TITLE
Use ObservationBox in events

### DIFF
--- a/src/ControlSystem/Event.hpp
+++ b/src/ControlSystem/Event.hpp
@@ -78,6 +78,8 @@ class Event : public ::Event {
   static constexpr bool factory_creatable = false;
   Event() = default;
 
+  using compute_tags_for_observation_box = tmpl::list<>;
+
   using argument_tags = tmpl::list<::Tags::DataBox>;
 
   template <typename DbTags, typename Metavariables, typename ArrayIndex,

--- a/src/Evolution/DgSubcell/Events/ObserveFields.hpp
+++ b/src/Evolution/DgSubcell/Events/ObserveFields.hpp
@@ -156,6 +156,8 @@ class ObserveFields<VolumeDim, ObservationValueTag, tmpl::list<Tensors...>,
   using coordinates_tag =
       ::domain::Tags::Coordinates<VolumeDim, Frame::Inertial>;
 
+  using compute_tags_for_observation_box = tmpl::list<>;
+
   using argument_tags =
       tmpl::list<ObservationValueTag, ::domain::Tags::Mesh<VolumeDim>,
                  subcell::Tags::Mesh<VolumeDim>, subcell::Tags::ActiveGrid,

--- a/src/ParallelAlgorithms/Events/ObserveErrorNorms.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveErrorNorms.hpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataBox/TagName.hpp"
 #include "Domain/Tags.hpp"
@@ -125,13 +126,15 @@ class ObserveErrorNorms<ObservationValueTag, tmpl::list<Tensors...>,
   using observed_reduction_data_tags =
       observers::make_reduction_data_tags<tmpl::list<ReductionData>>;
 
-  using argument_tags = tmpl::list<::Tags::DataBox, ObservationValueTag,
+  using compute_tags_for_observation_box = tmpl::list<>;
+
+  using argument_tags = tmpl::list<::Tags::ObservationBox, ObservationValueTag,
                                    Tensors..., ::Tags::AnalyticSolutionsBase>;
 
-  template <typename DbTagsList, typename OptionalAnalyticSolutions,
-            typename Metavariables, typename ArrayIndex,
-            typename ParallelComponent>
-  void operator()(const db::DataBox<DbTagsList>& box,
+  template <typename DataBoxType, typename ComputeTagsList,
+            typename OptionalAnalyticSolutions, typename Metavariables,
+            typename ArrayIndex, typename ParallelComponent>
+  void operator()(const ObservationBox<DataBoxType, ComputeTagsList>& box,
                   const typename ObservationValueTag::type& observation_value,
                   const typename Tensors::type&... tensors,
                   const OptionalAnalyticSolutions& optional_analytic_solutions,

--- a/src/ParallelAlgorithms/Events/ObserveFields.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveFields.hpp
@@ -14,7 +14,7 @@
 #include <utility>
 #include <vector>
 
-#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataBox/TagName.hpp"
 #include "DataStructures/DataVector.hpp"
@@ -187,15 +187,17 @@ class ObserveFields<VolumeDim, ObservationValueTag, tmpl::list<Tensors...>,
                 std::optional<Mesh<VolumeDim>> interpolation_mesh = {},
                 const Options::Context& context = {});
 
+  using compute_tags_for_observation_box = tmpl::list<>;
+
   using argument_tags =
-      tmpl::list<::Tags::DataBox, ObservationValueTag,
+      tmpl::list<::Tags::ObservationBox, ObservationValueTag,
                  domain::Tags::Mesh<VolumeDim>, coordinates_tag,
                  AnalyticSolutionTensors..., NonSolutionTensors...>;
 
-  template <typename DbTagsList, typename Metavariables,
-            typename ParallelComponent>
+  template <typename DataBoxType, typename ComputeTagsList,
+            typename Metavariables, typename ParallelComponent>
   void operator()(
-      const db::DataBox<DbTagsList>& box,
+      const ObservationBox<DataBoxType, ComputeTagsList>& box,
       const typename ObservationValueTag::type& observation_value,
       const Mesh<VolumeDim>& mesh,
       const tnsr::I<DataVector, VolumeDim, Frame::Inertial>&
@@ -215,7 +217,7 @@ class ObserveFields<VolumeDim, ObservationValueTag, tmpl::list<Tensors...>,
     // Get analytic solutions
     auto&& optional_analytic_solutions = [&box]() -> decltype(auto) {
       if constexpr (sizeof...(AnalyticSolutionTensors) > 0) {
-        return db::get<::Tags::AnalyticSolutionsBase>(box);
+        return get<::Tags::AnalyticSolutionsBase>(box);
       } else {
         (void)box;
         return std::nullopt;

--- a/src/ParallelAlgorithms/Events/ObserveTimeStep.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveTimeStep.hpp
@@ -160,6 +160,8 @@ class ObserveTimeStep : public Event {
   using observed_reduction_data_tags =
       observers::make_reduction_data_tags<tmpl::list<ReductionData>>;
 
+  using compute_tags_for_observation_box = tmpl::list<>;
+
   // We obtain the grid size from the variables, rather than the mesh,
   // so that this observer is not DG-specific.
   using argument_tags =

--- a/src/ParallelAlgorithms/Events/ObserveVolumeIntegrals.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveVolumeIntegrals.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "Domain/Tags.hpp"
@@ -110,14 +111,19 @@ class ObserveVolumeIntegrals<VolumeDim, ObservationValueTag,
   using observed_reduction_data_tags =
       observers::make_reduction_data_tags<tmpl::list<ReductionData>>;
 
+
+  using compute_tags_for_observation_box = tmpl::list<>;
+
   using argument_tags = tmpl::list<
-      ::Tags::DataBox, ObservationValueTag, domain::Tags::Mesh<VolumeDim>,
+      ::Tags::ObservationBox, ObservationValueTag,
+      domain::Tags::Mesh<VolumeDim>,
       domain::Tags::DetInvJacobian<Frame::ElementLogical, Frame::Inertial>,
       Tensors...>;
 
-  template <typename DbTagsList, typename Metavariables, typename ArrayIndex,
+  template <typename DataBoxType, typename ComputeTagsList,
+            typename Metavariables, typename ArrayIndex,
             typename ParallelComponent>
-  void operator()(const db::DataBox<DbTagsList>& box,
+  void operator()(const ObservationBox<DataBoxType, ComputeTagsList>& box,
                   const typename ObservationValueTag::type& observation_value,
                   const Mesh<VolumeDim>& mesh,
                   const Scalar<DataVector>& det_inv_jacobian,

--- a/src/ParallelAlgorithms/EventsAndTriggers/Completion.hpp
+++ b/src/ParallelAlgorithms/EventsAndTriggers/Completion.hpp
@@ -20,6 +20,7 @@ class Completion : public Event {
   WRAPPED_PUPable_decl_template(Completion);  // NOLINT
   /// \endcond
 
+  using compute_tags_for_observation_box = tmpl::list<>;
   using options = tmpl::list<>;
   static constexpr Options::String help = {
       "Sets the termination flag for the code to exit."};

--- a/src/ParallelAlgorithms/EventsAndTriggers/Event.hpp
+++ b/src/ParallelAlgorithms/EventsAndTriggers/Event.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Tags/Metavariables.hpp"
@@ -16,6 +16,14 @@ namespace Events {}
 /// \ingroup EventsAndTriggersGroup
 /// Base class for something that can happen during a simulation (such
 /// as an observation).
+///
+/// Derived events must have a `compute_tags_for_observation_box` that is a
+/// `tmpl::list` of simple or compute tags. Simple tags are assumed to already
+/// be in the `DataBox`. Evolved variables, for example, would be listed as
+/// simple tags. The compute tags are used to compute additional quantities that
+/// may be observed. For example, in the scalar wave system the 1- and 2-index
+/// constraints would be added as compute tags, as well as anything they depend
+/// on that's not already in the `DataBox`.
 class Event : public PUP::able {
  protected:
   /// \cond
@@ -32,18 +40,18 @@ class Event : public PUP::able {
 
   WRAPPED_PUPable_abstract(Event);  // NOLINT
 
-  template <typename DbTags, typename Metavariables, typename ArrayIndex,
+  template <typename ComputeTagsList, typename DataBoxType,
+            typename Metavariables, typename ArrayIndex,
             typename ComponentPointer>
-  void run(const db::DataBox<DbTags>& box,
+  void run(const ObservationBox<ComputeTagsList, DataBoxType>& box,
            Parallel::GlobalCache<Metavariables>& cache,
            const ArrayIndex& array_index,
            const ComponentPointer /*meta*/) const {
     using factory_classes =
-        typename std::decay_t<decltype(db::get<Parallel::Tags::Metavariables>(
-            box))>::factory_creation::factory_classes;
+        typename std::decay_t<Metavariables>::factory_creation::factory_classes;
     call_with_dynamic_type<void, tmpl::at<factory_classes, Event>>(
         this, [&box, &cache, &array_index](auto* const event) {
-          db::apply(*event, box, cache, array_index, ComponentPointer{});
+          apply(*event, box, cache, array_index, ComponentPointer{});
         });
   }
 

--- a/src/ParallelAlgorithms/Interpolation/Events/Interpolate.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Events/Interpolate.hpp
@@ -68,6 +68,8 @@ class Interpolate<VolumeDim, InterpolationTargetTag, tmpl::list<Tensors...>>
 
   Interpolate() = default;
 
+  using compute_tags_for_observation_box = tmpl::list<>;
+
   using argument_tags = tmpl::list<typename InterpolationTargetTag::temporal_id,
                                    domain::Tags::Mesh<VolumeDim>, Tensors...>;
 

--- a/src/ParallelAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp
@@ -76,6 +76,8 @@ class InterpolateWithoutInterpComponent<VolumeDim, InterpolationTargetTag,
 
   InterpolateWithoutInterpComponent() = default;
 
+  using compute_tags_for_observation_box = tmpl::list<>;
+
   using argument_tags = tmpl::conditional_t<
       detail::get_use_dg_subcell_or_default_v<Metavariables, false>,
       tmpl::list<typename InterpolationTargetTag::temporal_id,

--- a/src/Time/Actions/ChangeSlabSize.hpp
+++ b/src/Time/Actions/ChangeSlabSize.hpp
@@ -260,6 +260,8 @@ class ChangeSlabSize : public Event {
                  const uint64_t delay_change)
       : step_choosers_(std::move(step_choosers)), delay_change_(delay_change) {}
 
+  using compute_tags_for_observation_box = tmpl::list<>;
+
   using argument_tags = tmpl::list<Tags::TimeStepId, Tags::DataBox>;
 
   template <typename DbTags, typename Metavariables, typename ArrayIndex,

--- a/tests/Unit/ControlSystem/Test_Measurement.cpp
+++ b/tests/Unit/ControlSystem/Test_Measurement.cpp
@@ -9,6 +9,7 @@
 #include "ControlSystem/Component.hpp"
 #include "ControlSystem/Event.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
 #include "Evolution/EventsAndDenseTriggers/EventsAndDenseTriggers.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "Helpers/ControlSystem/Examples.hpp"
@@ -99,7 +100,8 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Measurement", "[ControlSystem][Unit]") {
 
   const MeasureEvent event{};
   CHECK(event.needs_evolved_variables());
-  event.run(box, cache, 0, element_component_p);
+  event.run(make_observation_box<db::AddComputeTags<>>(box), cache, 0,
+            element_component_p);
 
   ActionTesting::invoke_queued_simple_action<control_system_component>(
       make_not_null(&runner), 0);

--- a/tests/Unit/Evolution/Actions/Test_RunEventsAndDenseTriggers.cpp
+++ b/tests/Unit/Evolution/Actions/Test_RunEventsAndDenseTriggers.cpp
@@ -139,6 +139,8 @@ struct TestEvent : public Event {
   explicit TestEvent(const bool needs_evolved_variables)
       : needs_evolved_variables_(needs_evolved_variables) {}
 
+  using compute_tags_for_observation_box = tmpl::list<>;
+
   using argument_tags = tmpl::list<Tags::Time, Var, PrimVar>;
 
   template <typename Metavariables, typename ArrayIndex, typename Component>

--- a/tests/Unit/Evolution/DgSubcell/Events/Test_ObserveFields.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Events/Test_ObserveFields.cpp
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
@@ -193,7 +194,7 @@ void test_observe(
 
   // Reset to empty
   MockContributeVolumeData::results = MockContributeVolumeData::Results{};
-  observe->run(box,
+  observe->run(make_observation_box<db::AddComputeTags<>>(box),
                ActionTesting::cache<element_component>(runner, array_index),
                array_index, std::add_pointer_t<element_component>{});
 

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveErrorNorms.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveErrorNorms.cpp
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
@@ -305,7 +306,7 @@ void test_observe(const std::unique_ptr<ObserveEvent> observe,
     CHECK_FALSE(ids_to_register.has_value());
   }
 
-  observe->run(box,
+  observe->run(make_observation_box<db::AddComputeTags<>>(box),
                ActionTesting::cache<element_component>(runner, array_index),
                array_index, std::add_pointer_t<element_component>{});
 

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
@@ -143,7 +144,7 @@ void test_observe(
       }(),
       section);
 
-  observe->run(box,
+  observe->run(make_observation_box<db::AddComputeTags<>>(box),
                ActionTesting::cache<element_component>(runner, array_index),
                array_index, std::add_pointer_t<element_component>{});
 

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveNorms.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveNorms.cpp
@@ -177,7 +177,7 @@ void test(const std::unique_ptr<ObserveEvent> observe,
       box, ActionTesting::cache<element_component>(runner, array_index),
       array_index, std::add_pointer_t<element_component>{}));
 
-  observe->run(box,
+  observe->run(make_observation_box<db::AddComputeTags<>>(box),
                ActionTesting::cache<element_component>(runner, array_index),
                array_index, std::add_pointer_t<element_component>{});
 

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStep.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStep.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -225,10 +226,11 @@ void test_observe(const Observer& observer, const bool backwards_in_time,
         ActionTesting::cache<element_component>(runner, index),
         static_cast<element_component::array_index>(index),
         std::add_pointer_t<element_component>{}));
-    observer.run(element_boxes[index],
-                 ActionTesting::cache<element_component>(runner, index),
-                 static_cast<element_component::array_index>(index),
-                 std::add_pointer_t<element_component>{});
+    observer.run(
+        make_observation_box<db::AddComputeTags<>>(element_boxes[index]),
+        ActionTesting::cache<element_component>(runner, index),
+        static_cast<element_component::array_index>(index),
+        std::add_pointer_t<element_component>{});
   }
 
   // Process the data

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveVolumeIntegrals.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveVolumeIntegrals.cpp
@@ -254,7 +254,7 @@ void test_observe(const std::unique_ptr<ObserveEvent> observe,
                                                       0);
   ActionTesting::emplace_group_component<observer_component>(&runner);
 
-  observe->run(box,
+  observe->run(make_observation_box<db::AddComputeTags<>>(box),
                ActionTesting::cache<element_component>(runner, array_index),
                array_index, std::add_pointer_t<element_component>{});
 

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolateEvent.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolateEvent.cpp
@@ -11,6 +11,7 @@
 #include <type_traits>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Domain/Structure/ElementId.hpp"
@@ -30,6 +31,7 @@
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
 #include "Time/TimeStepId.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -235,8 +237,11 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.InterpolateEvent",
       box, ActionTesting::cache<elem_component>(runner, array_index),
       array_index, std::add_pointer_t<elem_component>{}));
   CHECK(event.needs_evolved_variables());
-  event.run(box, ActionTesting::cache<elem_component>(runner, array_index),
-            array_index, std::add_pointer_t<elem_component>{});
+  event.run(
+      make_observation_box<
+          typename metavars::event::compute_tags_for_observation_box>(box),
+      ActionTesting::cache<elem_component>(runner, array_index), array_index,
+      std::add_pointer_t<elem_component>{});
 
   // Invoke all actions
   runner.invoke_queued_simple_action<interp_component>(0);

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolateWithoutInterpComponent.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolateWithoutInterpComponent.cpp
@@ -7,6 +7,7 @@
 #include <type_traits>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Domain.hpp"
@@ -80,9 +81,11 @@ struct initialize_elements_and_queue_simple_actions {
 
       // 3. Run the event.  This will invoke simple actions on
       // InterpolationTarget.
-      event.run(box,
-                ActionTesting::cache<elem_component>(runner, element_id),
-                element_id, std::add_pointer_t<elem_component>{});
+      event.run(
+          make_observation_box<
+              typename metavars::event::compute_tags_for_observation_box>(box),
+          ActionTesting::cache<elem_component>(runner, element_id), element_id,
+          std::add_pointer_t<elem_component>{});
     }
   }
 };


### PR DESCRIPTION
## Proposed changes

Only the commit `Use ObservationBox in Events` is new. Uses the `ObservationBox` in events, switching over the `EventsAndTriggers` classes as well as individual events.

Depends on:
- [x] #3556

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
