### PR TITLE
Support ObservationBox compute tags in ObserveFields and ObserveNorms

### DIFF
--- a/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
+++ b/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
@@ -192,18 +192,19 @@ struct Metavariables {
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes = tmpl::map<
         tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
-        tmpl::pair<Event,
-                   tmpl::flatten<tmpl::list<
-                       Events::Completion,
-                       dg::Events::field_observations<
-                           volume_dim, linear_solver_iteration_id,
-                           observe_fields, analytic_solution_fields,
-                           LinearSolver::multigrid::Tags::IsFinestGrid>,
-                       dg::Events::ObserveVolumeIntegrals<
-                           volume_dim, linear_solver_iteration_id,
-                           tmpl::list<Elasticity::Tags::PotentialEnergyDensity<
-                               volume_dim>>,
-                           LinearSolver::multigrid::Tags::IsFinestGrid>>>>,
+        tmpl::pair<
+            Event,
+            tmpl::flatten<tmpl::list<
+                Events::Completion,
+                dg::Events::field_observations<
+                    volume_dim, linear_solver_iteration_id, observe_fields,
+                    analytic_solution_fields, tmpl::list<>,
+                    LinearSolver::multigrid::Tags::IsFinestGrid>,
+                dg::Events::ObserveVolumeIntegrals<
+                    volume_dim, linear_solver_iteration_id,
+                    tmpl::list<
+                        Elasticity::Tags::PotentialEnergyDensity<volume_dim>>,
+                    LinearSolver::multigrid::Tags::IsFinestGrid>>>>,
         tmpl::pair<Trigger, elliptic::Triggers::all_triggers<
                                 typename linear_solver::options_group>>>;
   };

--- a/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
@@ -180,13 +180,14 @@ struct Metavariables {
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes = tmpl::map<
         tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
-        tmpl::pair<Event,
-                   tmpl::flatten<tmpl::list<
-                       Events::Completion,
-                       dg::Events::field_observations<
-                           volume_dim, linear_solver_iteration_id,
-                           observe_fields, analytic_solution_fields,
-                           LinearSolver::multigrid::Tags::IsFinestGrid>>>>,
+        tmpl::pair<
+            Event,
+            tmpl::flatten<tmpl::list<
+                Events::Completion,
+                dg::Events::field_observations<
+                    volume_dim, linear_solver_iteration_id, observe_fields,
+                    analytic_solution_fields, tmpl::list<>,
+                    LinearSolver::multigrid::Tags::IsFinestGrid>>>>,
         tmpl::pair<Trigger, elliptic::Triggers::all_triggers<
                                 typename linear_solver::options_group>>>;
   };

--- a/src/Elliptic/Executables/Xcts/SolveXcts.hpp
+++ b/src/Elliptic/Executables/Xcts/SolveXcts.hpp
@@ -224,6 +224,7 @@ struct Metavariables {
                     LinearSolver::multigrid::Tags::IsFinestGrid>,
                 Events::ObserveNorms<
                     nonlinear_solver_iteration_id, constraint_fields,
+                    tmpl::list<>,
                     LinearSolver::multigrid::Tags::IsFinestGrid>>>>,
         tmpl::pair<Trigger, elliptic::Triggers::all_triggers<
                                 typename nonlinear_solver::options_group>>>;

--- a/src/Elliptic/Executables/Xcts/SolveXcts.hpp
+++ b/src/Elliptic/Executables/Xcts/SolveXcts.hpp
@@ -214,16 +214,17 @@ struct Metavariables {
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes = tmpl::map<
         tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
-        tmpl::pair<Event,
-                   tmpl::flatten<tmpl::list<
-                       Events::Completion,
-                       dg::Events::field_observations<
-                           volume_dim, nonlinear_solver_iteration_id,
-                           observe_fields, analytic_solution_fields,
-                           LinearSolver::multigrid::Tags::IsFinestGrid>,
-                       Events::ObserveNorms<
-                           nonlinear_solver_iteration_id, constraint_fields,
-                           LinearSolver::multigrid::Tags::IsFinestGrid>>>>,
+        tmpl::pair<
+            Event,
+            tmpl::flatten<tmpl::list<
+                Events::Completion,
+                dg::Events::field_observations<
+                    volume_dim, nonlinear_solver_iteration_id, observe_fields,
+                    analytic_solution_fields, tmpl::list<>,
+                    LinearSolver::multigrid::Tags::IsFinestGrid>,
+                Events::ObserveNorms<
+                    nonlinear_solver_iteration_id, constraint_fields,
+                    LinearSolver::multigrid::Tags::IsFinestGrid>>>>,
         tmpl::pair<Trigger, elliptic::Triggers::all_triggers<
                                 typename nonlinear_solver::options_group>>>;
   };

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -137,7 +137,7 @@ struct EvolutionMetavars {
                               Events::Completion,
                               dg::Events::field_observations<
                                   volume_dim, Tags::Time, observe_fields,
-                                  analytic_solution_fields>,
+                                  analytic_solution_fields, tmpl::list<>>,
                               Events::time_events<system>>>>,
         tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
                    StepChoosers::standard_step_choosers<system>>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -269,7 +269,8 @@ struct EvolutionMetavars {
                 Events::Completion,
                 Events::ObserveNorms<::Tags::Time, observe_fields>,
                 dg::Events::field_observations<volume_dim, Tags::Time,
-                                               observe_fields, tmpl::list<>>,
+                                               observe_fields, tmpl::list<>,
+                                               tmpl::list<>>,
                 Events::time_events<system>>>>,
         tmpl::pair<GeneralizedHarmonic::BoundaryConditions::BoundaryCondition<
                        volume_dim>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -201,9 +201,9 @@ struct GeneralizedHarmonicTemplateBase<
                    tmpl::flatten<tmpl::list<
                        Events::Completion,
                        Events::ObserveNorms<::Tags::Time, observe_fields>,
-                       dg::Events::field_observations<volume_dim, Tags::Time,
-                                                      observe_fields,
-                                                      analytic_solution_fields>,
+                       dg::Events::field_observations<
+                           volume_dim, Tags::Time, observe_fields,
+                           analytic_solution_fields, tmpl::list<>>,
                        Events::time_events<system>>>>,
         tmpl::pair<GeneralizedHarmonic::BoundaryConditions::BoundaryCondition<
                        volume_dim>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -197,14 +197,14 @@ struct GeneralizedHarmonicTemplateBase<
     using factory_classes = tmpl::map<
         tmpl::pair<DenseTrigger, DenseTriggers::standard_dense_triggers>,
         tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
-        tmpl::pair<Event,
-                   tmpl::flatten<tmpl::list<
-                       Events::Completion,
-                       Events::ObserveNorms<::Tags::Time, observe_fields>,
-                       dg::Events::field_observations<
-                           volume_dim, Tags::Time, observe_fields,
-                           analytic_solution_fields, tmpl::list<>>,
-                       Events::time_events<system>>>>,
+        tmpl::pair<Event, tmpl::flatten<tmpl::list<
+                              Events::Completion,
+                              Events::ObserveNorms<::Tags::Time, observe_fields,
+                                                   tmpl::list<>>,
+                              dg::Events::field_observations<
+                                  volume_dim, Tags::Time, observe_fields,
+                                  analytic_solution_fields, tmpl::list<>>,
+                              Events::time_events<system>>>>,
         tmpl::pair<GeneralizedHarmonic::BoundaryConditions::BoundaryCondition<
                        volume_dim>,
                    GeneralizedHarmonic::BoundaryConditions::

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -301,7 +301,8 @@ struct GhValenciaDivCleanTemplateBase<
                     volume_dim, Tags::Time, observe_fields,
                     tmpl::conditional_t<
                         evolution::is_analytic_solution_v<initial_data>,
-                        analytic_solution_fields, tmpl::list<>>>,
+                        analytic_solution_fields, tmpl::list<>>,
+                    tmpl::list<>>,
                 Events::time_events<system>,
                 intrp::Events::Interpolate<3, InterpolationTargetTags,
                                            interpolator_source_vars>...>>>,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -256,7 +256,8 @@ struct EvolutionMetavars {
                                          tags_list>,
                         tmpl::conditional_t<
                             evolution::is_analytic_solution_v<initial_data>,
-                            analytic_variables_tags, tmpl::list<>>>>,
+                            analytic_variables_tags, tmpl::list<>>,
+                        tmpl::list<>>>,
                 Events::time_events<system>,
                 intrp::Events::InterpolateWithoutInterpComponent<
                     3, InterpolationTargetTags, EvolutionMetavars,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -236,7 +236,8 @@ struct EvolutionMetavars {
                 Events::Completion,
                 Events::ObserveNorms<
                     ::Tags::Time,
-                    tmpl::list<hydro::Tags::RestMassDensity<DataVector>>>,
+                    tmpl::list<hydro::Tags::RestMassDensity<DataVector>>,
+                    tmpl::list<>>,
                 tmpl::conditional_t<
                     use_dg_subcell,
                     evolution::dg::subcell::Events::ObserveFields<

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -165,7 +165,8 @@ struct EvolutionMetavars {
                     tmpl::conditional_t<
                         evolution::is_analytic_solution_v<initial_data>,
                         typename system::primitive_variables_tag::tags_list,
-                        tmpl::list<>>>,
+                        tmpl::list<>>,
+                    tmpl::list<>>,
                 Events::time_events<system>>>>,
         tmpl::pair<
             NewtonianEuler::BoundaryConditions::BoundaryCondition<volume_dim>,

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -151,7 +151,8 @@ struct EvolutionMetavars {
                         typename system::primitive_variables_tag::tags_list>,
                     tmpl::conditional_t<
                         evolution::is_analytic_solution_v<initial_data>,
-                        analytic_variables_tags, tmpl::list<>>>,
+                        analytic_variables_tags, tmpl::list<>>,
+                    tmpl::list<>>,
                 Events::time_events<system>>>>,
         tmpl::pair<
             RadiationTransport::M1Grey::BoundaryConditions::BoundaryCondition<

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -161,7 +161,8 @@ struct EvolutionMetavars {
                         typename system::primitive_variables_tag::tags_list>,
                     tmpl::conditional_t<
                         evolution::is_analytic_solution_v<initial_data>,
-                        analytic_variables_tags, tmpl::list<>>>,
+                        analytic_variables_tags, tmpl::list<>>,
+                    tmpl::list<>>,
                 Events::time_events<system>>>>,
         tmpl::pair<RelativisticEuler::Valencia::BoundaryConditions::
                        BoundaryCondition<volume_dim>,

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -165,10 +165,10 @@ struct EvolutionMetavars {
                         volume_dim, Tags::Time,
                         tmpl::push_back<observe_fields, evolution::dg::subcell::
                                                             Tags::TciStatus>,
-                        analytic_solution_fields>,
-                    dg::Events::field_observations<volume_dim, Tags::Time,
-                                                   observe_fields,
-                                                   analytic_solution_fields>>,
+                        analytic_solution_fields, tmpl::list<>>,
+                    dg::Events::field_observations<
+                        volume_dim, Tags::Time, observe_fields,
+                        analytic_solution_fields, tmpl::list<>>>,
                 Events::time_events<system>>>>,
         tmpl::pair<ScalarAdvection::BoundaryConditions::BoundaryCondition<Dim>,
                    ScalarAdvection::BoundaryConditions::

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -138,9 +138,9 @@ struct EvolutionMetavars {
             Event,
             tmpl::flatten<tmpl::list<
                 Events::Completion,
-                dg::Events::field_observations<volume_dim, Tags::Time,
-                                               observe_fields,
-                                               analytic_solution_fields>,
+                dg::Events::field_observations<
+                    volume_dim, Tags::Time, observe_fields,
+                    analytic_solution_fields, tmpl::list<>>,
                 dg::Events::ObserveVolumeIntegrals<
                     volume_dim, Tags::Time,
                     tmpl::list<ScalarWave::Tags::EnergyDensity<volume_dim>>>,

--- a/src/ParallelAlgorithms/Events/Factory.hpp
+++ b/src/ParallelAlgorithms/Events/Factory.hpp
@@ -14,10 +14,11 @@
 
 namespace dg::Events {
 template <size_t VolumeDim, typename TimeTag, typename Fields,
-          typename SolutionFields, typename ArraySectionIdTag = void>
+          typename SolutionFields, typename NonTensorComputeTagsList,
+          typename ArraySectionIdTag = void>
 using field_observations = tmpl::flatten<tmpl::list<
-    ObserveFields<VolumeDim, TimeTag, Fields, SolutionFields,
-                  ArraySectionIdTag>,
+    ObserveFields<VolumeDim, TimeTag, Fields, NonTensorComputeTagsList,
+                  SolutionFields, ArraySectionIdTag>,
     tmpl::conditional_t<
         std::is_same_v<SolutionFields, tmpl::list<>>, tmpl::list<>,
         ObserveErrorNorms<TimeTag, SolutionFields, ArraySectionIdTag>>>>;

--- a/src/ParallelAlgorithms/Events/ObserveFields.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveFields.hpp
@@ -62,6 +62,7 @@ namespace dg {
 namespace Events {
 /// \cond
 template <size_t VolumeDim, typename ObservationValueTag, typename Tensors,
+          typename NonTensorComputeTagsList = tmpl::list<>,
           typename AnalyticSolutionTensors = tmpl::list<>,
           typename ArraySectionIdTag = void,
           typename NonSolutionTensors =
@@ -83,6 +84,9 @@ class ObserveFields;
  * The user may specify an `interpolation_mesh` to which the
  * data is interpolated.
  *
+ * \note The `NonTensorComputeTags` are intended to be used for `Variables`
+ * compute tags like `Tags::DerivCompute`
+ *
  * \par Array sections
  * This event supports sections (see `Parallel::Section`). Set the
  * `ArraySectionIdTag` template parameter to split up observations into subsets
@@ -91,9 +95,10 @@ class ObserveFields;
  * for the path in the output file.
  */
 template <size_t VolumeDim, typename ObservationValueTag, typename... Tensors,
-          typename... AnalyticSolutionTensors, typename ArraySectionIdTag,
-          typename... NonSolutionTensors>
+          typename... NonTensorComputeTags, typename... AnalyticSolutionTensors,
+          typename ArraySectionIdTag, typename... NonSolutionTensors>
 class ObserveFields<VolumeDim, ObservationValueTag, tmpl::list<Tensors...>,
+                    tmpl::list<NonTensorComputeTags...>,
                     tmpl::list<AnalyticSolutionTensors...>, ArraySectionIdTag,
                     tmpl::list<NonSolutionTensors...>> : public Event {
  private:
@@ -187,7 +192,8 @@ class ObserveFields<VolumeDim, ObservationValueTag, tmpl::list<Tensors...>,
                 std::optional<Mesh<VolumeDim>> interpolation_mesh = {},
                 const Options::Context& context = {});
 
-  using compute_tags_for_observation_box = tmpl::list<>;
+  using compute_tags_for_observation_box =
+      tmpl::list<Tensors..., NonTensorComputeTags...>;
 
   using argument_tags =
       tmpl::list<::Tags::ObservationBox, ObservationValueTag,
@@ -404,9 +410,10 @@ class ObserveFields<VolumeDim, ObservationValueTag, tmpl::list<Tensors...>,
 };
 
 template <size_t VolumeDim, typename ObservationValueTag, typename... Tensors,
-          typename... AnalyticSolutionTensors, typename ArraySectionIdTag,
-          typename... NonSolutionTensors>
+          typename... NonTensorComputeTags, typename... AnalyticSolutionTensors,
+          typename ArraySectionIdTag, typename... NonSolutionTensors>
 ObserveFields<VolumeDim, ObservationValueTag, tmpl::list<Tensors...>,
+              tmpl::list<NonTensorComputeTags...>,
               tmpl::list<AnalyticSolutionTensors...>, ArraySectionIdTag,
               tmpl::list<NonSolutionTensors...>>::
     ObserveFields(const std::string& subfile_name,
@@ -463,10 +470,11 @@ ObserveFields<VolumeDim, ObservationValueTag, tmpl::list<Tensors...>,
 
 /// \cond
 template <size_t VolumeDim, typename ObservationValueTag, typename... Tensors,
-          typename... AnalyticSolutionTensors, typename ArraySectionIdTag,
-          typename... NonSolutionTensors>
+          typename... NonTensorComputeTags, typename... AnalyticSolutionTensors,
+          typename ArraySectionIdTag, typename... NonSolutionTensors>
 PUP::able::PUP_ID
     ObserveFields<VolumeDim, ObservationValueTag, tmpl::list<Tensors...>,
+                  tmpl::list<NonTensorComputeTags...>,
                   tmpl::list<AnalyticSolutionTensors...>, ArraySectionIdTag,
                   tmpl::list<NonSolutionTensors...>>::my_PUP_ID = 0;  // NOLINT
 /// \endcond

--- a/tests/Unit/Evolution/DgSubcell/Events/Test_ObserveFields.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Events/Test_ObserveFields.cpp
@@ -162,7 +162,7 @@ void test_observe(
   // roundoff error.
   // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   std::iota(vars.data(), vars.data() + vars.size(), 1.0);
-  const Variables<db::wrap_tags_in<Tags::Analytic, solution_variables>>
+  const Variables<db::wrap_tags_in<::Tags::Analytic, solution_variables>>
       solutions{variables_from_tagged_tuple(analytic_solution.variables(
           active_inertial_coords, observation_time, solution_variables{}))};
   const Variables<solution_variables> errors =
@@ -171,7 +171,7 @@ void test_observe(
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
   MockRuntimeSystem runner(
       tuples::TaggedTuple<
-          Tags::AnalyticSolution<typename System::solution_for_test>>{
+          ::Tags::AnalyticSolution<typename System::solution_for_test>>{
           std::move(analytic_solution)});
   ActionTesting::emplace_component<element_component>(make_not_null(&runner),
                                                       element_id);
@@ -183,7 +183,7 @@ void test_observe(
                         evolution::dg::subcell::Tags::Mesh<volume_dim>,
                         evolution::dg::subcell::Tags::ActiveGrid,
                         dg_coordinates_tag, subcell_coordinates_tag,
-                        Tags::Variables<typename decltype(vars)::tags_list>,
+                        ::Tags::Variables<typename decltype(vars)::tags_list>,
                         ::domain::CoordinateMaps::Tags::CoordinateMap<
                             volume_dim, Frame::Grid, Frame::Inertial>,
                         ::domain::Tags::FunctionsOfTimeInitialize>>(
@@ -194,9 +194,12 @@ void test_observe(
 
   // Reset to empty
   MockContributeVolumeData::results = MockContributeVolumeData::Results{};
-  observe->run(make_observation_box<db::AddComputeTags<>>(box),
-               ActionTesting::cache<element_component>(runner, array_index),
-               array_index, std::add_pointer_t<element_component>{});
+  observe->run(
+      make_observation_box<tmpl::filter<
+          typename System::ObserveEvent::compute_tags_for_observation_box,
+          db::is_compute_tag<tmpl::_1>>>(box),
+      ActionTesting::cache<element_component>(runner, array_index), array_index,
+      std::add_pointer_t<element_component>{});
 
   // Process the data
   runner.template invoke_queued_simple_action<observer_component>(0);
@@ -255,7 +258,19 @@ void test_observe(
   System::check_data([&check_component, &vars](const std::string& name,
                                                auto tag,
                                                const auto... indices) {
-    check_component(name, get<decltype(tag)>(vars).get(indices...));
+    if constexpr (std::is_same_v<decltype(tag),
+                                 TestHelpers::dg::Events::ObserveFields::Tags::
+                                     ScalarVarTimesTwo>) {
+      check_component(
+          name, DataVector{2.0 * get<typename System::ScalarVar>(vars).get()});
+    } else if constexpr (std::is_same_v<decltype(tag),
+                                        TestHelpers::dg::Events::ObserveFields::
+                                            Tags::ScalarVarTimesThree>) {
+      check_component(
+          name, DataVector{3.0 * get<typename System::ScalarVar>(vars).get()});
+    } else {
+      check_component(name, get<decltype(tag)>(vars).get(indices...));
+    }
   });
   if (AlwaysHasAnalyticSolutions) {
     System::solution_for_test::check_data(


### PR DESCRIPTION
## Proposed changes

Allows specifying compute tags to be used during EventsAndTriggers/Observations in ObserveFields/Norms that are then deallocated to avoid memory overhead. I've tested this with scalar wave and can remove the derivatives of the evolved fields, the constraints, and pointwise normals of the constraints from the DataBox.

Only following commits are new:
- Add any compute tag via ObserveFields event
- Add any compute tag via ObserveFields event

Depends on:
- [x] #3556 
- [x] #3557 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
