### PR TITLE
Add excision_sphere to Domain, changes to Shell

### DIFF
--- a/src/Domain/Creators/Shell.cpp
+++ b/src/Domain/Creators/Shell.cpp
@@ -16,6 +16,7 @@
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"
 #include "Domain/Structure/BlockNeighbor.hpp"  // IWYU pragma: keep
+#include "Domain/Structure/ExcisionSphere.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
 
@@ -159,7 +160,9 @@ Domain<3> Shell::create_domain() const {
       corners_for_radially_layered_domains(
           number_of_layers_, false, {{1, 2, 3, 4, 5, 6, 7, 8}}, which_wedges_),
       {},
-      std::move(boundary_conditions_all_blocks)};
+      std::move(boundary_conditions_all_blocks),
+      {{"CentralExcisionSphere",
+        ExcisionSphere<3>{inner_radius_, {{0.0, 0.0, 0.0}}}}}};
 
   if (not time_dependence_->is_none()) {
     const size_t number_of_blocks = domain.blocks().size();

--- a/src/Domain/Domain.cpp
+++ b/src/Domain/Domain.cpp
@@ -31,7 +31,10 @@ Domain<VolumeDim>::Domain(
     std::vector<DirectionMap<
         VolumeDim,
         std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
-        boundary_conditions) {
+        boundary_conditions,
+    std::unordered_map<std::string, ExcisionSphere<VolumeDim>>
+        excision_spheres)
+    : excision_spheres_(std::move(excision_spheres)) {
   ASSERT(
       boundary_conditions.size() == maps.size() or boundary_conditions.empty(),
       "There must be either one set of boundary conditions per block or none "
@@ -63,7 +66,10 @@ Domain<VolumeDim>::Domain(
     std::vector<DirectionMap<
         VolumeDim,
         std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
-        boundary_conditions) {
+        boundary_conditions,
+    std::unordered_map<std::string, ExcisionSphere<VolumeDim>>
+        excision_spheres)
+    : excision_spheres_(std::move(excision_spheres)) {
   ASSERT(
       maps.size() == corners_of_all_blocks.size(),
       "Must pass same number of maps as block corner sets, but maps.size() == "
@@ -106,8 +112,10 @@ void Domain<VolumeDim>::inject_time_dependent_map_for_block(
 }
 
 template <size_t VolumeDim>
-bool operator==(const Domain<VolumeDim>& lhs, const Domain<VolumeDim>& rhs) {
-  return lhs.blocks() == rhs.blocks();
+bool operator==(const Domain<VolumeDim>& lhs,
+                const Domain<VolumeDim>& rhs) {
+  return lhs.blocks() == rhs.blocks() and
+         lhs.excision_spheres() == rhs.excision_spheres();
 }
 
 template <size_t VolumeDim>
@@ -122,12 +130,14 @@ std::ostream& operator<<(std::ostream& os, const Domain<VolumeDim>& d) {
   for (const auto& block : blocks) {
     os << block << '\n';
   }
+  os << "Excision spheres:\n" << d.excision_spheres() << '\n';
   return os;
 }
 
 template <size_t VolumeDim>
 void Domain<VolumeDim>::pup(PUP::er& p) {
   p | blocks_;
+  p | excision_spheres_;
 }
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)

--- a/src/Domain/Domain.hpp
+++ b/src/Domain/Domain.hpp
@@ -10,12 +10,15 @@
 #include <cstddef>
 #include <iosfwd>
 #include <memory>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "Domain/Block.hpp"  // IWYU pragma: keep
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Domain/DomainHelpers.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/ExcisionSphere.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 
 namespace Frame {
@@ -64,7 +67,9 @@ class Domain {
       std::vector<DirectionMap<
           VolumeDim,
           std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
-          boundary_conditions = {});
+          boundary_conditions = {},
+      std::unordered_map<std::string, ExcisionSphere<VolumeDim>>
+          excision_spheres = {});
 
   /*!
    * Create a Domain using a corner numbering scheme to encode the Orientations,
@@ -95,7 +100,9 @@ class Domain {
          std::vector<DirectionMap<
              VolumeDim,
              std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
-             boundary_conditions = {});
+             boundary_conditions = {},
+         std::unordered_map<std::string, ExcisionSphere<VolumeDim>>
+             excision_spheres = {});
 
   Domain() = default;
   ~Domain() = default;
@@ -112,11 +119,18 @@ class Domain {
 
   const std::vector<Block<VolumeDim>>& blocks() const { return blocks_; }
 
+  const std::unordered_map<std::string, ExcisionSphere<VolumeDim>>&
+  excision_spheres() const {
+    return excision_spheres_;
+  }
+
   // clang-tidy: google-runtime-references
   void pup(PUP::er& p);  // NOLINT
 
  private:
   std::vector<Block<VolumeDim>> blocks_{};
+  std::unordered_map<std::string, ExcisionSphere<VolumeDim>>
+      excision_spheres_{};
 };
 
 template <size_t VolumeDim>

--- a/tests/Unit/Domain/Creators/Test_Shell.cpp
+++ b/tests/Unit/Domain/Creators/Test_Shell.cpp
@@ -254,15 +254,16 @@ void test_shell_construction(
     } else if (UNLIKELY(which_wedges == ShellWedges::OneAlongMinusX)) {
       vector_of_maps.erase(vector_of_maps.begin(), vector_of_maps.begin() + 5);
     }
-    test_domain_construction(
-        domain, expected_block_neighbors, expected_external_boundaries,
-        vector_of_maps,
-        expected_grid_to_inertial_maps.empty() ?
-        std::numeric_limits<double>::signaling_NaN() : 10.0,
-        shell.functions_of_time(), expected_grid_to_inertial_maps,
-        expected_boundary_conditions);
+    test_domain_construction(domain, expected_block_neighbors,
+                             expected_external_boundaries, vector_of_maps,
+                             expected_grid_to_inertial_maps.empty()
+                                 ? std::numeric_limits<double>::signaling_NaN()
+                                 : 10.0,
+                             shell.functions_of_time(),
+                             expected_grid_to_inertial_maps,
+                             expected_boundary_conditions);
 
-    if constexpr(sizeof...(FuncsOfTime) == 0) {
+    if constexpr (sizeof...(FuncsOfTime) == 0) {
       // We turn off the domain_no_corners test for time-dependent
       // maps because Domain doesn't have a constructor that takes
       // maps from BlockLogical to Grid.
@@ -382,6 +383,10 @@ void test_shell_construction(
       test_serialization(domain_no_corners);
     }
   }
+  CHECK(domain.excision_spheres() ==
+        std::unordered_map<std::string, ExcisionSphere<3>>{
+            {"CentralExcisionSphere",
+             ExcisionSphere<3>{inner_radius, {{0.0, 0.0, 0.0}}}}});
 
   test_initial_domain(domain, shell.initial_refinement_levels());
   TestHelpers::domain::creators::test_functions_of_time(

--- a/tests/Unit/Domain/Test_Domain.cpp
+++ b/tests/Unit/Domain/Test_Domain.cpp
@@ -201,12 +201,16 @@ void test_1d_domains() {
     CHECK(get_output(domain_from_corners) ==
           "Domain with 2 blocks:\n" +
               get_output(domain_from_corners.blocks()[0]) + "\n" +
-              get_output(domain_from_corners.blocks()[1]) + "\n");
+              get_output(domain_from_corners.blocks()[1]) + "\n" +
+          "Excision spheres:\n" +
+              get_output(domain_from_corners.excision_spheres()) + "\n");
 
     CHECK(get_output(domain_no_corners) ==
           "Domain with 2 blocks:\n" +
               get_output(domain_from_corners.blocks()[0]) + "\n" +
-              get_output(domain_from_corners.blocks()[1]) + "\n");
+              get_output(domain_from_corners.blocks()[1]) + "\n" +
+          "Excision spheres:\n" +
+              get_output(domain_from_corners.excision_spheres()) + "\n");
   }
 
   {


### PR DESCRIPTION
## Proposed changes

This is the second in a series of PRs, the first being #3541 
This PR adds the member variable `excision_sphere_` to the `Domain` class, as well as adds an accessor function for it.
This PR also changes the Shell DomainCreator such that when `create_domain()` is called, the `Domain` is created with a `std::unordered_map<std::string, ExcisionSphere<3>> excision_spheres` with one `ExcisionSphere`.

This PR is dependent on #3541.

### Upgrade instructions

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

The next PR in the series will modify the BinaryCompactObject Domain in a similar fashion to Shell. Implementation suggestions in this PR will be carried over to the next.