### PR TITLE
Support 1/r radial distribution in BBH domain outer shell

### DIFF
--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -25,8 +25,10 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Distribution.hpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/Interval.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/TimeDependent/CubicScale.hpp"
@@ -56,21 +58,21 @@ bool BinaryCompactObject::Object::is_excised() const {
 // Time-independent constructor
 BinaryCompactObject::BinaryCompactObject(
     Object object_A, Object object_B, const double radius_enveloping_cube,
-    const double radius_enveloping_sphere,
+    const double outer_radius_domain,
     const typename InitialRefinement::type& initial_refinement,
     const typename InitialGridPoints::type& initial_number_of_grid_points,
     const bool use_projective_map,
-    const bool use_logarithmic_map_outer_spherical_shell,
+    const std::optional<double>& radius_enveloping_sphere,
+    const CoordinateMaps::Distribution radial_distribution_outer_shell,
     std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
         outer_boundary_condition,
     const Options::Context& context)
     : object_A_(std::move(object_A)),
       object_B_(std::move(object_B)),
       radius_enveloping_cube_(radius_enveloping_cube),
-      radius_enveloping_sphere_(radius_enveloping_sphere),
+      outer_radius_domain_(outer_radius_domain),
       use_projective_map_(use_projective_map),
-      use_logarithmic_map_outer_spherical_shell_(
-          use_logarithmic_map_outer_spherical_shell),
+      radial_distribution_outer_shell_(radial_distribution_outer_shell),
       outer_boundary_condition_(std::move(outer_boundary_condition)) {
   // Determination of parameters for domain construction:
   translation_ = 0.5 * (object_B_.x_coord + object_A_.x_coord);
@@ -232,6 +234,51 @@ BinaryCompactObject::BinaryCompactObject(
   } catch (const std::exception& error) {
     PARSE_ERROR(context, "Invalid 'InitialGridPoints': " << error.what());
   }
+
+  // Compute the inner radius of the outer spherical shell. The computation
+  // makes use of the refinement, so this can't be done earlier.
+  if (radius_enveloping_sphere.has_value()) {
+    radius_enveloping_sphere_ = radius_enveloping_sphere.value();
+    if (radius_enveloping_sphere_ <= radius_enveloping_cube_ or
+        radius_enveloping_sphere_ >= outer_radius_domain_) {
+      PARSE_ERROR(
+          context,
+          "The 'OuterShell.InnerRadius' must be within 'EnvelopingCube.Radius' "
+          "(" << radius_enveloping_cube_
+              << ") and 'OuterShell.OuterRadius' (" << outer_radius_domain_
+              << "), but is: " << radius_enveloping_sphere_
+              << ". Set it to 'Auto' so a reasonable value is chosen "
+                 "automatically.");
+    }
+  } else {
+    // Adjust the outer boundary of the cubed sphere to conform to the spacing
+    // of the spherical shells after refinement, so the cubed sphere is the same
+    // size as the first radial division of the spherical shell (for linear
+    // mapping) or smaller by the same factor as adjacent radial divisions in
+    // the spherical shell (for logarithmic or inverse mapping).
+    const size_t addition_to_outer_layer_radial_refinement_level =
+        initial_refinement_[44][2] - initial_refinement_[34][2];
+    const size_t radial_divisions_in_outer_layers =
+        pow(2, addition_to_outer_layer_radial_refinement_level) + 1;
+    // Use the `Interval` class to divide the interval between
+    // `radius_enveloping_cube_` and `outer_radius_domain_` into
+    // `radial_divisions_in_outer_layers` pieces. Choose
+    // `radius_enveloping_sphere_` as the first of those pieces.
+    radius_enveloping_sphere_ =
+        domain::CoordinateMaps::Interval{// Source interval
+                                         0., 1.,
+                                         // Target interval
+                                         radius_enveloping_cube_,
+                                         outer_radius_domain_,
+                                         // Distribution in target interval
+                                         radial_distribution_outer_shell_,
+                                         // Position of the singularity for log
+                                         // and 1/r maps (in target interval)
+                                         0.}(std::array<double, 1>{
+            {// Inner radius in source interval that is mapped to target
+             // interval
+             1. / static_cast<double>(radial_divisions_in_outer_layers)}})[0];
+  }
 }
 
 // Time-dependent constructor, with additional options for specifying
@@ -249,19 +296,20 @@ BinaryCompactObject::BinaryCompactObject(
     std::array<double, 2> initial_size_map_velocities,
     std::array<double, 2> initial_size_map_accelerations,
     std::array<std::string, 2> size_map_function_of_time_names, Object object_A,
-    Object object_B, double radius_enveloping_cube,
-    double radius_enveloping_sphere,
+    Object object_B, double radius_enveloping_cube, double outer_radius_domain,
     const typename InitialRefinement::type& initial_refinement,
     const typename InitialGridPoints::type& initial_number_of_grid_points,
-    bool use_projective_map, bool use_logarithmic_map_outer_spherical_shell,
+    bool use_projective_map,
+    const std::optional<double>& radius_enveloping_sphere,
+    CoordinateMaps::Distribution radial_distribution_outer_shell,
     std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
         outer_boundary_condition,
     const Options::Context& context)
     : BinaryCompactObject(std::move(object_A), std::move(object_B),
-                          radius_enveloping_cube, radius_enveloping_sphere,
+                          radius_enveloping_cube, outer_radius_domain,
                           initial_refinement, initial_number_of_grid_points,
-                          use_projective_map,
-                          use_logarithmic_map_outer_spherical_shell,
+                          use_projective_map, radius_enveloping_sphere,
+                          radial_distribution_outer_shell,
                           std::move(outer_boundary_condition), context) {
   enable_time_dependence_ = true;
   initial_time_ = initial_time;
@@ -365,45 +413,14 @@ Domain<3> BinaryCompactObject::create_domain() const {
   std::move(maps_frustums.begin(), maps_frustums.end(),
             std::back_inserter(maps));
 
-  // The first shell (Layer 4) goes from sphericity == 0.0 to sphericity
-  // == 1.0. This shell is surrounded by a shell with sphericity == 1.0
-  // throughout (Layer 5) that will have a radial refinement level of
-  // (addition_to_outer_layer_radial_refinement_level_ + initial_refinement_).
-  const double inner_radius_first_outer_shell =
-      sqrt(3.0) * 0.5 * length_outer_cube_;
-
-  // Adjust the outer boundary of the cubed sphere to conform to the
-  // spacing of the spherical shells after refinement, so the cubed sphere is
-  // the same size as the first radial division of the spherical shell
-  // (for linear mapping) or smaller by the same factor as adjacent radial
-  // divisions in the spherical shell (for logarithmic mapping)
-  const size_t addition_to_outer_layer_radial_refinement_level =
-      initial_refinement_[44][2] - initial_refinement_[34][2];
-  const double radial_divisions_in_outer_layers =
-      pow(2, addition_to_outer_layer_radial_refinement_level) + 1;
-  const double outer_radius_first_outer_shell =
-      use_logarithmic_map_outer_spherical_shell_
-          ? inner_radius_first_outer_shell *
-                pow(radius_enveloping_sphere_ / inner_radius_first_outer_shell,
-                    1.0 / static_cast<double>(radial_divisions_in_outer_layers))
-          : inner_radius_first_outer_shell +
-                (radius_enveloping_sphere_ - inner_radius_first_outer_shell) /
-                    static_cast<double>(radial_divisions_in_outer_layers);
-
-  const std::vector<domain::CoordinateMaps::Distribution>
-      outer_spherical_shell_distribution{
-          use_logarithmic_map_outer_spherical_shell_
-              ? domain::CoordinateMaps::Distribution::Logarithmic
-              : domain::CoordinateMaps::Distribution::Linear};
-
   Maps maps_first_outer_shell = sph_wedge_coordinate_maps<Frame::Inertial>(
-      inner_radius_first_outer_shell, outer_radius_first_outer_shell, 0.0, 1.0,
+      radius_enveloping_cube_, radius_enveloping_sphere_, 0.0, 1.0,
       use_equiangular_map_, 0.0, true, 1.0, {},
       {domain::CoordinateMaps::Distribution::Linear}, ShellWedges::All);
   Maps maps_second_outer_shell = sph_wedge_coordinate_maps<Frame::Inertial>(
-      outer_radius_first_outer_shell, radius_enveloping_sphere_, 1.0, 1.0,
+      radius_enveloping_sphere_, outer_radius_domain_, 1.0, 1.0,
       use_equiangular_map_, 0.0, true, 1.0, {},
-      outer_spherical_shell_distribution, ShellWedges::All);
+      {radial_distribution_outer_shell_}, ShellWedges::All);
   if (outer_boundary_condition_ != nullptr) {
     // The outer 10 wedges all have to have the outer boundary condition
     // applied

--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -369,6 +369,7 @@ class BinaryCompactObject : public DomainCreator<3> {
   };
 
   struct UseProjectiveMap {
+    using group = EnvelopingCube;
     using type = bool;
     static constexpr Options::String help = {
         "Use projective scaling on the frustal cloak."};

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -27,6 +27,7 @@ DomainCreator:
       UseLogarithmicMap: false
     EnvelopingCube:
       Radius: 100.0
+      UseProjectiveMap: true
     OuterSphere:
       Radius: 590.0
       UseLogarithmicMap: false
@@ -39,7 +40,6 @@ DomainCreator:
       CubedShell:     [0, 0, 0]
       OuterShell:     [0, 0, 0]
     InitialGridPoints: 3
-    UseProjectiveMap: true
     TimeDependentMaps:
       InitialTime: 0.0
       InitialExpirationDeltaT: Auto

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -28,9 +28,10 @@ DomainCreator:
     EnvelopingCube:
       Radius: 100.0
       UseProjectiveMap: true
-    OuterSphere:
-      Radius: 590.0
-      UseLogarithmicMap: false
+    OuterShell:
+      InnerRadius: Auto
+      OuterRadius: 590.0
+      RadialDistribution: Linear
     InitialRefinement:
       ObjectAShell:   [0, 0, 1]
       ObjectBShell:   [0, 0, 1]

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -30,9 +30,10 @@ DomainCreator:
     EnvelopingCube:
       Radius: 100.0
       UseProjectiveMap: true
-    OuterSphere:
-      Radius: 1493.0
-      UseLogarithmicMap: false
+    OuterShell:
+      InnerRadius: Auto
+      OuterRadius: 1493.0
+      RadialDistribution: Linear
       BoundaryCondition:
         ConstraintPreservingBjorhus:
           Type: ConstraintPreservingPhysical

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -29,6 +29,7 @@ DomainCreator:
       UseLogarithmicMap: false
     EnvelopingCube:
       Radius: 100.0
+      UseProjectiveMap: true
     OuterSphere:
       Radius: 1493.0
       UseLogarithmicMap: false
@@ -44,7 +45,6 @@ DomainCreator:
       CubedShell:     [2, 2, 2]
       OuterShell:     [2, 2, 5]
     InitialGridPoints: 11
-    UseProjectiveMap: true
     TimeDependentMaps:
       InitialTime: 0.0
       InitialExpirationDeltaT: Auto

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -505,6 +505,7 @@ std::string create_option_string(const bool excise_A, const bool excise_B,
          "\n"
          "  EnvelopingCube:\n"
          "    Radius: 22.0\n"
+         "    UseProjectiveMap: true\n"
          "  OuterSphere:\n"
          "    Radius: 25.0\n"
          "    UseLogarithmicMap: false\n" +
@@ -524,8 +525,7 @@ std::string create_option_string(const bool excise_A, const bool excise_B,
          "    OuterShell: [1, 1, " +
          std::to_string(1 + additional_refinement_outer) +
          "]\n"
-         "  InitialGridPoints: 3\n"
-         "  UseProjectiveMap: true\n" +
+         "  InitialGridPoints: 3\n" +
          time_dependence;
 }
 

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -21,6 +21,7 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"  // IWYU pragma: keep
 #include "Domain/Block.hpp"                       // IWYU pragma: keep
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Domain/CoordinateMaps/Distribution.hpp"
 #include "Domain/Creators/BinaryCompactObject.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Domain.hpp"
@@ -47,6 +48,7 @@ using BoundaryCondVector = std::vector<DirectionMap<
     3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>;
 using Object = domain::creators::BinaryCompactObject::Object;
 using Excision = domain::creators::BinaryCompactObject::Excision;
+using Distribution = domain::CoordinateMaps::Distribution;
 
 template <size_t Dim, bool EnableTimeDependentMaps, bool WithBoundaryConditions>
 struct Metavariables {
@@ -167,11 +169,16 @@ void test_connectivity() {
 
   // Enveloping Cube:
   constexpr double radius_enveloping_cube = 25.5;
-  constexpr double radius_enveloping_sphere = 32.4;
+  constexpr bool use_projective_map = true;
+
+  // Enveloping sphere:
+  const std::optional<double> radius_enveloping_sphere = std::nullopt;
+
+  // Outer shell:
+  constexpr double outer_radius = 32.4;
 
   // Misc.:
   constexpr size_t grid_points = 3;
-  constexpr bool use_projective_map = true;
 
   for (const bool with_boundary_conditions : {true, false}) {
     CAPTURE(with_boundary_conditions);
@@ -194,9 +201,10 @@ void test_connectivity() {
         if (not excise_interiorB) {
           refinement["ObjectBInterior"] = std::array<size_t, 3>{{1, 1, 1}};
         }
-        for (const bool use_logarithmic_map_outer_spherical_shell :
-             {true, false}) {
-          CAPTURE(use_logarithmic_map_outer_spherical_shell);
+        for (const auto radial_distribution_outer_shell :
+             {Distribution::Linear, Distribution::Logarithmic,
+              Distribution::Inverse}) {
+          CAPTURE(radial_distribution_outer_shell);
           const domain::creators::BinaryCompactObject binary_compact_object{
               Object{inner_radius_objectA, outer_radius_objectA, xcoord_objectA,
                      excise_interiorA
@@ -215,11 +223,12 @@ void test_connectivity() {
                          : std::nullopt,
                      false},
               radius_enveloping_cube,
-              radius_enveloping_sphere,
+              outer_radius,
               refinement,
               grid_points,
               use_projective_map,
-              use_logarithmic_map_outer_spherical_shell,
+              radius_enveloping_sphere,
+              radial_distribution_outer_shell,
               with_boundary_conditions ? create_outer_boundary_condition()
                                        : nullptr};
 
@@ -318,13 +327,19 @@ void test_connectivity() {
           // The number of radial divisions in layers 4 and 5, excluding those
           // resulting from InitialRefinement > 0.
           const double radial_divisions_in_outer_layers = 9;
-          if (use_logarithmic_map_outer_spherical_shell) {
+          if (radial_distribution_outer_shell == Distribution::Logarithmic) {
             CHECK(layer_5_inner_radius / radius_enveloping_cube ==
-                  approx(pow(radius_enveloping_sphere / radius_enveloping_cube,
+                  approx(pow(outer_radius / radius_enveloping_cube,
                              1.0 / radial_divisions_in_outer_layers)));
+          } else if (radial_distribution_outer_shell == Distribution::Inverse) {
+            CHECK(
+                layer_5_inner_radius / radius_enveloping_cube ==
+                approx(outer_radius /
+                       (outer_radius - (outer_radius - radius_enveloping_cube) /
+                                           radial_divisions_in_outer_layers)));
           } else {
             CHECK(layer_5_inner_radius - radius_enveloping_cube ==
-                  approx((radius_enveloping_sphere - radius_enveloping_cube) /
+                  approx((outer_radius - radius_enveloping_cube) /
                          radial_divisions_in_outer_layers));
           }
           if (with_boundary_conditions) {
@@ -347,9 +362,9 @@ void test_connectivity() {
                                   Excision{create_inner_boundary_condition()})
                             : std::nullopt,
                         false},
-                    radius_enveloping_cube, radius_enveloping_sphere,
-                    refinement, grid_points, use_projective_map,
-                    use_logarithmic_map_outer_spherical_shell,
+                    radius_enveloping_cube, outer_radius, refinement,
+                    grid_points, use_projective_map, radius_enveloping_sphere,
+                    radial_distribution_outer_shell,
                     std::make_unique<PeriodicBc>(),
                     Options::Context{false, {}, 1, 1}),
                 Catch::Matchers::Contains("Cannot have periodic boundary "
@@ -371,9 +386,9 @@ void test_connectivity() {
                                        Excision{std::make_unique<PeriodicBc>()})
                                  : std::nullopt,
                              false},
-                      radius_enveloping_cube, radius_enveloping_sphere,
-                      refinement, grid_points, use_projective_map,
-                      use_logarithmic_map_outer_spherical_shell,
+                      radius_enveloping_cube, outer_radius, refinement,
+                      grid_points, use_projective_map, radius_enveloping_sphere,
+                      radial_distribution_outer_shell,
                       create_outer_boundary_condition(),
                       Options::Context{false, {}, 1, 1}),
                   Catch::Matchers::Contains("Cannot have periodic boundary "
@@ -394,9 +409,9 @@ void test_connectivity() {
                                        create_inner_boundary_condition()})
                                  : std::nullopt,
                              false},
-                      radius_enveloping_cube, radius_enveloping_sphere,
-                      refinement, grid_points, use_projective_map,
-                      use_logarithmic_map_outer_spherical_shell, nullptr,
+                      radius_enveloping_cube, outer_radius, refinement,
+                      grid_points, use_projective_map, radius_enveloping_sphere,
+                      radial_distribution_outer_shell, nullptr,
                       Options::Context{false, {}, 1, 1}),
                   Catch::Matchers::Contains(
                       "Must specify either both inner and outer boundary "
@@ -415,9 +430,9 @@ void test_connectivity() {
                                  ? std::make_optional(Excision{nullptr})
                                  : std::nullopt,
                              false},
-                      radius_enveloping_cube, radius_enveloping_sphere,
-                      refinement, grid_points, use_projective_map,
-                      use_logarithmic_map_outer_spherical_shell,
+                      radius_enveloping_cube, outer_radius, refinement,
+                      grid_points, use_projective_map, radius_enveloping_sphere,
+                      radial_distribution_outer_shell,
                       create_outer_boundary_condition(),
                       Options::Context{false, {}, 1, 1}),
                   Catch::Matchers::Contains(
@@ -506,9 +521,10 @@ std::string create_option_string(const bool excise_A, const bool excise_B,
          "  EnvelopingCube:\n"
          "    Radius: 22.0\n"
          "    UseProjectiveMap: true\n"
-         "  OuterSphere:\n"
-         "    Radius: 25.0\n"
-         "    UseLogarithmicMap: false\n" +
+         "  OuterShell:\n"
+         "    InnerRadius: Auto\n"
+         "    OuterRadius: 25.0\n"
+         "    RadialDistribution: Linear\n" +
          outer_boundary_condition + "  InitialRefinement:\n" +
          (excise_A ? "" : "    ObjectAInterior: [1, 1, 1]\n") +
          (excise_B ? "" : "    ObjectBInterior: [1, 1, 1]\n") +
@@ -672,48 +688,48 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           {0.5, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
           {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, 6_st, true, false, create_outer_boundary_condition(),
-          Options::Context{false, {}, 1, 1}),
+          32.4, 2_st, 6_st, true, std::nullopt, Distribution::Linear,
+          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "The x-coordinate of ObjectA's center is expected to be negative."));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
           {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
           {0.3, 1.0, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, 6_st, true, false, create_outer_boundary_condition(),
-          Options::Context{false, {}, 1, 1}),
+          32.4, 2_st, 6_st, true, std::nullopt, Distribution::Linear,
+          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "The x-coordinate of ObjectB's center is expected to be positive."));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
           {0.5, 1.0, -7.0, {{create_inner_boundary_condition()}}, false},
           {0.3, 1.0, 8.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, 6_st, true, false, create_outer_boundary_condition(),
-          Options::Context{false, {}, 1, 1}),
+          32.4, 2_st, 6_st, true, std::nullopt, Distribution::Linear,
+          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains("The radius for the enveloping cube is too "
                                 "small! The Frustums will be malformed."));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
           {1.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
           {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, 6_st, true, false, create_outer_boundary_condition(),
-          Options::Context{false, {}, 1, 1}),
+          32.4, 2_st, 6_st, true, std::nullopt, Distribution::Linear,
+          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "ObjectA's inner radius must be less than its outer radius."));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
           {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
           {3.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, 6_st, true, false, create_outer_boundary_condition(),
-          Options::Context{false, {}, 1, 1}),
+          32.4, 2_st, 6_st, true, std::nullopt, Distribution::Linear,
+          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "ObjectB's inner radius must be less than its outer radius."));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
           {0.5, 1.0, -1.0, std::nullopt, true},
           {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, 6_st, true, false, create_outer_boundary_condition(),
-          Options::Context{false, {}, 1, 1}),
+          32.4, 2_st, 6_st, true, std::nullopt, Distribution::Linear,
+          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "Using a logarithmically spaced radial grid in the "
           "part of Layer 1 enveloping Object A requires excising the interior "
@@ -722,7 +738,7 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
           {0.3, 1.0, 1.0, std::nullopt, true}, 25.5, 32.4, 2_st, 6_st, true,
-          false, create_outer_boundary_condition(),
+          std::nullopt, Distribution::Linear, create_outer_boundary_condition(),
           Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "Using a logarithmically spaced radial grid in the "
@@ -732,16 +748,25 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
           {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, std::vector<std::array<size_t, 3>>{}, 6_st, true, false,
-          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
+          32.4, std::vector<std::array<size_t, 3>>{}, 6_st, true, std::nullopt,
+          Distribution::Linear, create_outer_boundary_condition(),
+          Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains("Invalid 'InitialRefinement'"));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
           {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
           {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, std::vector<std::array<size_t, 3>>{}, true, false,
-          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
+          32.4, 2_st, std::vector<std::array<size_t, 3>>{}, true, std::nullopt,
+          Distribution::Linear, create_outer_boundary_condition(),
+          Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains("Invalid 'InitialGridPoints'"));
+  CHECK_THROWS_WITH(
+      domain::creators::BinaryCompactObject(
+          {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
+          {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
+          32.4, 2_st, 6_st, true, 35., Distribution::Linear,
+          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::Contains("The 'OuterShell.InnerRadius' must be within"));
   // Note: the boundary condition-related parse errors are checked in the
   // test_connectivity function.
 }


### PR DESCRIPTION
## Proposed changes

A 1/r radial distribution is useful in the wave zone, and necessary to get to very large outer radii.

The radial distribution also affects the computation of the outer shell's inner radius, so I have to deal with that in the same commit. As an alternative to the automatically computed inner radius, the inner radius can now also be specified in the input file directly.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
- When constructing a `BinaryCompactObject` domain from options, move the `UseProjectiveMap` option into the `EnvelopingCube` group. Furthermore, the options for the outer spherical shell have changed to support more radial distributions. If you had these options before:
  ```yaml
  # Old
  EnvelopingCube:
    Radius: 55.
  UseProjectiveMap: True
  OuterSphere:
    Radius: 300.
    UseLogarithmicMap: False
  ```
  adjust them like this:
  ```yaml
  # New
  EnvelopingCube:
    Radius: 55.
    UseProjectiveMap: True
  OuterShell:
    InnerRadius: Auto  # you can specify the first spherical radius explicitly now, or use the default
    OuterRadius: 300.
    RadialDistribution: Linear  # You can also set this to `Logarithmic` or `Inverse`
  ```

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
