### PR TITLE
Find Scotch library with CMake

### DIFF
--- a/cmake/FindScotch.cmake
+++ b/cmake/FindScotch.cmake
@@ -1,0 +1,68 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Find Scotch: https://www.labri.fr/perso/pelegrin/scotch/
+# If not in one of the default paths specify -D SCOTCH_ROOT=/path/to/Scotch
+# to search there as well.
+
+if(NOT SCOTCH_ROOT)
+  # Need to set to empty to avoid warnings with --warn-uninitialized
+  set(SCOTCH_ROOT "")
+  set(SCOTCH_ROOT $ENV{SCOTCH_ROOT})
+endif()
+
+# Find the Scotch include directory
+find_path(SCOTCH_INCLUDE_DIR scotch.h
+  PATH_SUFFIXES include
+  HINTS ${SCOTCH_ROOT})
+
+find_library(SCOTCH_LIB
+  NAMES scotch
+  PATH_SUFFIXES lib64 lib
+  HINTS ${SCOTCH_ROOT})
+
+find_library(SCOTCH_ERR_LIB
+  NAMES scotcherr
+  PATH_SUFFIXES lib64 lib
+  HINTS ${SCOTCH_ROOT})
+
+set(SCOTCH_LIBRARIES "${SCOTCH_LIB};${SCOTCH_ERR_LIB}")
+
+set(SCOTCH_VERSION "")
+
+file(READ "${SCOTCH_INCLUDE_DIR}/scotch.h" SCOTCH_FIND_HEADER_CONTENTS)
+
+set(SCOTCH_MAJOR_PREFIX "#define SCOTCH_VERSION ")
+set(SCOTCH_MINOR_PREFIX "#define SCOTCH_RELEASE ")
+set(SCOTCH_PATCH_PREFIX "#define SCOTCH_PATCHLEVEL ")
+
+string(REGEX MATCH "${SCOTCH_MAJOR_PREFIX}[0-9]+"
+  SCOTCH_MAJOR_VERSION "${SCOTCH_FIND_HEADER_CONTENTS}")
+string(REPLACE "${SCOTCH_MAJOR_PREFIX}" "" SCOTCH_MAJOR_VERSION
+  "${SCOTCH_MAJOR_VERSION}")
+
+string(REGEX MATCH "${SCOTCH_MINOR_PREFIX}[0-9]+"
+  SCOTCH_MINOR_VERSION "${SCOTCH_FIND_HEADER_CONTENTS}")
+string(REPLACE "${SCOTCH_MINOR_PREFIX}" "" SCOTCH_MINOR_VERSION
+  "${SCOTCH_MINOR_VERSION}")
+
+string(REGEX MATCH "${SCOTCH_PATCH_PREFIX}[0-9]+"
+  SCOTCH_SUBMINOR_VERSION "${SCOTCH_FIND_HEADER_CONTENTS}")
+string(REPLACE "${SCOTCH_PATCH_PREFIX}" "" SCOTCH_SUBMINOR_VERSION
+  "${SCOTCH_SUBMINOR_VERSION}")
+
+set(SCOTCH_VERSION
+  "${SCOTCH_MAJOR_VERSION}.${SCOTCH_MINOR_VERSION}.${SCOTCH_SUBMINOR_VERSION}"
+  )
+
+set(Scotch_VERSION ${SCOTCH_VERSION})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  Scotch
+  FOUND_VAR SCOTCH_FOUND
+  REQUIRED_VARS SCOTCH_INCLUDE_DIR SCOTCH_LIBRARIES
+  VERSION_VAR SCOTCH_VERSION)
+mark_as_advanced(SCOTCH_INCLUDE_DIR SCOTCH_LIBRARIES
+  SCOTCH_MAJOR_VERSION SCOTCH_MINOR_VERSION SCOTCH_PATCH_VERSION
+  SCOTCH_VERSION Scotch_VERSION)

--- a/cmake/SetupCharm.cmake
+++ b/cmake/SetupCharm.cmake
@@ -27,6 +27,37 @@ endif(NOT TARGET Charmxx)
 # Note: The -pthread is necessary with Charm v6.10 to get linking working
 #       with GCC
 if (USE_SCOTCH_LB)
+  find_package(Scotch REQUIRED)
+
+  message(STATUS "Scotch libs: " ${SCOTCH_LIBRARIES})
+  message(STATUS "Scotch incl: " ${SCOTCH_INCLUDE_DIR})
+  message(STATUS "Scotch vers: " ${SCOTCH_VERSION})
+
+  file(APPEND
+    "${CMAKE_BINARY_DIR}/BuildInfo.txt"
+    "Scotch version: ${SCOTCH_VERSION}\n"
+    )
+
+  add_library(Scotch INTERFACE IMPORTED)
+  set_property(TARGET Scotch
+    APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${SCOTCH_INCLUDE_DIRS})
+  set_property(TARGET Scotch
+    APPEND PROPERTY INTERFACE_LINK_LIBRARIES ${SCOTCH_LIBRARIES})
+
+  add_interface_lib_headers(
+    TARGET Scotch
+    HEADERS
+    scotch.h
+    )
+  # We can't actually use the Scotch target until we have a Charm++ CMake
+  # target. We can then override the `-lscotch` and `-lscotcherr` libs specified
+  # in charmc and instead have CMake handle the dependency. Until then we
+  # extract the directory in which we found Scotch and append that to the global
+  # list of directories.
+  list(GET SCOTCH_LIBRARIES 0 SCOTCH_LINK_LIB)
+  get_filename_component(SCOTCH_LINK_LIB "${SCOTCH_LINK_LIB}" DIRECTORY)
+  link_directories(BEFORE "${SCOTCH_LINK_LIB}")
+
   set(SCOTCH_LB_FLAG "-module ScotchLB")
 else()
   set(SCOTCH_LB_FLAG "")


### PR DESCRIPTION
## Proposed changes

Previously I always had to export the (LD_)LIBRARY_PATH for the Scotch
library. Now CMake finds it and we have CMake add the linker search path. We can
only use a CMake target once we have Charm++ set as a CMake target.


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
