### PR TITLE
Make EquatorialCompression generic in polar axis.

### DIFF
--- a/src/Domain/CoordinateMaps/EquatorialCompression.hpp
+++ b/src/Domain/CoordinateMaps/EquatorialCompression.hpp
@@ -26,12 +26,15 @@ namespace CoordinateMaps {
  * \brief Redistributes gridpoints on the sphere.
  * \image html EquatorialCompression.png "A sphere with an `aspect_ratio` of 3."
  *
- * \details A mapping from the sphere to itself which depends on a single
- * parameter, the `aspect_ratio` \f$\alpha\f$, which is the ratio of the
- * horizontal length to the vertical height for a given point. This parameter
- * name was chosen because points with \f$\tan \theta = 1\f$ get mapped to
- * points with \f$\tan \theta' = \alpha\f$. In general, gridpoints located
- * at an angle \f$\theta\f$ from the pole are mapped to a new angle
+ * \details A mapping from the sphere to itself which redistributes points
+ * towards (or away from) a user-specifed axis, indicated by `index_pole_axis_`.
+ * Once the axis is selected, the map is determined by a single parameter,
+ * the `aspect_ratio` \f$\alpha\f$, which is the ratio of the distance
+ * perpendicular to the polar axis to the distance along the polar axis for
+ * a given point. This parameter name was chosen because points with
+ * \f$\tan \theta = 1\f$ get mapped to points with \f$\tan \theta' = \alpha\f$.
+ * In general, gridpoints located at an angle \f$\theta\f$ from the pole are
+ * mapped to a new angle
  * \f$\theta'\f$ satisfying \f$\tan \theta' = \alpha \tan \theta\f$.
  *
  * For an `aspect_ratio` greater than one, the gridpoints are mapped towards
@@ -39,7 +42,8 @@ namespace CoordinateMaps {
  * `aspect_ratio` less than one, the gridpoints are mapped towards the poles.
  * Note that the aspect ratio must be positive.
  *
- * We define the auxiliary variables \f$ r := \sqrt{x^2 + y^2 +z^2}\f$
+ * Suppose the polar axis were the z-axis, given by `index_pole_axis_ == 2`.
+ * We can then define the auxiliary variables \f$ r := \sqrt{x^2 + y^2 +z^2}\f$
  * and \f$ \rho := \sqrt{x^2 + y^2 + \alpha^{-2} z^2}\f$.
  *
  * The map corresponding to this transformation in cartesian coordinates
@@ -50,13 +54,15 @@ namespace CoordinateMaps {
  * x\\
  * y\\
  * \alpha^{-1} z\\
- * \end{bmatrix}\f]
+ * \end{bmatrix}.\f]
  *
+ * The mappings for polar axes along the x and y axes are similarly obtained.
  */
 class EquatorialCompression {
  public:
   static constexpr size_t dim = 3;
-  explicit EquatorialCompression(double aspect_ratio);
+  explicit EquatorialCompression(double aspect_ratio,
+                                 size_t index_pole_axis = 2);
   EquatorialCompression() = default;
   ~EquatorialCompression() = default;
   EquatorialCompression(EquatorialCompression&&) = default;
@@ -102,6 +108,7 @@ class EquatorialCompression {
   double aspect_ratio_{std::numeric_limits<double>::signaling_NaN()};
   double inverse_aspect_ratio_{std::numeric_limits<double>::signaling_NaN()};
   bool is_identity_{false};
+  size_t index_pole_axis_{};
 };
 bool operator!=(const EquatorialCompression& lhs,
                 const EquatorialCompression& rhs);

--- a/tests/Unit/Domain/CoordinateMaps/Test_EquatorialCompression.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_EquatorialCompression.cpp
@@ -15,6 +15,7 @@
 #include "Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Literals.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
 
 namespace domain {
@@ -46,36 +47,47 @@ void test_radius() {
   const double aspect_ratio = aspect_ratio_dis(gen);
   CAPTURE(aspect_ratio);
   const std::array<double, 3> input_point{{x, y, z}};
-  const CoordinateMaps::EquatorialCompression angular_compression_map(
-      aspect_ratio);
-  const auto result_point = angular_compression_map(input_point);
-  const auto& result_x = result_point[0];
-  const auto& result_y = result_point[1];
-  const auto& result_z = result_point[2];
 
-  // The EquatorialCompression map should preserve radial lengths.
-  CHECK(magnitude(result_point) == approx(magnitude(input_point)));
+  for (const auto& index_polar_axis : {0_st, 1_st, 2_st}) {
+    const CoordinateMaps::EquatorialCompression angular_compression_map(
+        aspect_ratio, index_polar_axis);
+    const auto result_point = angular_compression_map(input_point);
 
-  // It is easy to mix up \alpha with one over \alpha,
-  // so this comment serves as a reminder to future readers
-  // as to which direction the \alpha should go in the
-  // CHECK statement.
-  //
-  // The aspect ratio is the ratio of the horizontal length
-  // to the vertical height. The parameter name `aspect_ratio` is
-  // used because points with tan \theta = 1 get mapped to points
-  // with tan \theta = \alpha, the value passed to `aspect_ratio`.
-  //
-  // The angular compression map is:
-  //  tan \theta' = \alpha tan\theta.
-  // Then, if the argument provided to the EquatorialCompression
-  // map is, for example, 4, points on the undistorted sphere
-  // that have an angle tan \theta = sqrt(x^2 + y^2)/z are
-  // mapped to points that have an angle
-  //  tan \theta' = 4*sqrt(x^2+y^2)/z
-  //              = sqrt(x'^2 + y'^2)/z'.
-  CHECK(aspect_ratio * sqrt(pow<2>(x) + pow<2>(y)) / z ==
-        approx(sqrt(pow<2>(result_x) + pow<2>(result_y)) / result_z));
+    // The EquatorialCompression map should preserve radial lengths.
+    CHECK(magnitude(result_point) == approx(magnitude(input_point)));
+
+    // It is easy to mix up \alpha with one over \alpha,
+    // so this comment serves as a reminder to future readers
+    // as to which direction the \alpha should go in the
+    // CHECK statement.
+    //
+    // The aspect ratio is the ratio of the distance perpendicular to
+    // the polar axis to the distance along the polar axis for a given point.
+    // The parameter name `aspect_ratio` is used because points with
+    // tan \theta = 1, which have an aspect ratio of one, get mapped to points
+    // with tan \theta = \alpha, which have an aspect ratio of `aspect_ratio`.
+    //
+    // The angular compression map is:
+    //  tan \theta' = \alpha tan\theta.
+    // Then, if the argument provided to the EquatorialCompression
+    // map is, for example, 4, points on the undistorted sphere
+    // that have an angle tan \theta = sqrt(x^2 + y^2)/z are
+    // mapped to points that have an angle
+    //  tan \theta' = 4*sqrt(x^2+y^2)/z
+    //              = sqrt(x'^2 + y'^2)/z'.
+
+    const auto& planar_distance =
+        sqrt(square(gsl::at(input_point, (index_polar_axis + 1) % 3)) +
+             square(gsl::at(input_point, (index_polar_axis + 2) % 3)));
+    const auto& result_planar_distance =
+        sqrt(square(gsl::at(result_point, (index_polar_axis + 1) % 3)) +
+             square(gsl::at(result_point, (index_polar_axis + 2) % 3)));
+
+    CHECK(aspect_ratio * planar_distance /
+              gsl::at(input_point, index_polar_axis) ==
+          approx(result_planar_distance /
+                 gsl::at(result_point, index_polar_axis)));
+  }
 }
 
 void test_is_identity() {


### PR DESCRIPTION
## Proposed changes

The existing EquatorialCompression coordinate map compresses angles toward/away from the z axis.
The existing HalfWedges are aligned along the y-z plane - their axes of symmetry are different.

This PR addresses this incompatibility between HalfWedges and EquatorialCompression by allowing
the user to select which axes to treat as the polar axis.

This PR addresses some of issue #3545.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

