### PR TITLE
Add FD computeflux to advection subcell and fix initial TCI args order

### DIFF
--- a/src/Evolution/Systems/ScalarAdvection/Subcell/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/CMakeLists.txt
@@ -14,6 +14,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  ComputeFluxes.hpp
   GhostData.hpp
   InitialDataTci.hpp
   Subcell.hpp

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/ComputeFluxes.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/ComputeFluxes.hpp
@@ -1,0 +1,37 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/ScalarAdvection/Fluxes.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ScalarAdvection::subcell {
+namespace detail {
+/*!
+ * \brief Helper function that calls `ScalarAdvection::Fluxes::apply` by
+ * retrieving the return and argument tags from the Variables object `vars`.
+ */
+template <size_t Dim, typename TagsList, typename... ReturnTags,
+          typename... ArgumentTags>
+void compute_fluxes_impl(const gsl::not_null<Variables<TagsList>*> vars,
+                         tmpl::list<ReturnTags...> /*meta*/,
+                         tmpl::list<ArgumentTags...> /*meta*/) {
+  Fluxes<Dim>::apply(make_not_null(&get<ReturnTags>(*vars))...,
+                     get<ArgumentTags>(*vars)...);
+}
+}  // namespace detail
+
+/*!
+ * \brief Compute fluxes for subcell variables.
+ */
+template <size_t Dim, typename TagsList>
+void compute_fluxes(const gsl::not_null<Variables<TagsList>*> vars) {
+  detail::compute_fluxes_impl<Dim>(vars, typename Fluxes<Dim>::return_tags{},
+                                   typename Fluxes<Dim>::argument_tags{});
+}
+}  // namespace ScalarAdvection::subcell

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/InitialDataTci.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/InitialDataTci.cpp
@@ -16,8 +16,8 @@ bool DgInitialDataTci<Dim>::apply(
     const Variables<tmpl::list<ScalarAdvection::Tags::U>>& dg_vars,
     const Variables<tmpl::list<Inactive<ScalarAdvection::Tags::U>>>&
         subcell_vars,
-    const Mesh<Dim>& dg_mesh, const double persson_exponent,
-    const double rdmp_delta0, const double rdmp_epsilon) {
+    double rdmp_delta0, double rdmp_epsilon, double persson_exponent,
+    const Mesh<Dim>& dg_mesh) {
   constexpr double persson_tci_epsilon = 1.0e-18;
   return evolution::dg::subcell::persson_tci(
              get<ScalarAdvection::Tags::U>(dg_vars), dg_mesh, persson_exponent,

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/InitialDataTci.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/InitialDataTci.hpp
@@ -38,7 +38,7 @@ struct DgInitialDataTci {
       const Variables<tmpl::list<ScalarAdvection::Tags::U>>& dg_vars,
       const Variables<tmpl::list<Inactive<ScalarAdvection::Tags::U>>>&
           subcell_vars,
-      const Mesh<Dim>& dg_mesh, double persson_exponent, double rdmp_delta0,
-      double rdmp_epsilon);
+      double rdmp_delta0, double rdmp_epsilon, double persson_exponent,
+      const Mesh<Dim>& dg_mesh);
 };
 }  // namespace ScalarAdvection::subcell

--- a/tests/Unit/Evolution/Systems/ScalarAdvection/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarAdvection/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   BoundaryConditions/Test_Periodic.cpp
   BoundaryCorrections/Test_Rusanov.cpp
   FiniteDifference/Test_Tag.cpp
+  Subcell/Test_ComputeFluxes.cpp
   Subcell/Test_GhostData.cpp
   Subcell/Test_InitialDataTci.cpp
   Subcell/Test_TciOnDgGrid.cpp

--- a/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_ComputeFluxes.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_ComputeFluxes.cpp
@@ -1,0 +1,62 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <random>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/ScalarAdvection/Fluxes.hpp"
+#include "Evolution/Systems/ScalarAdvection/Subcell/ComputeFluxes.hpp"
+#include "Evolution/Systems/ScalarAdvection/Tags.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ScalarAdvection {
+namespace {
+template <size_t Dim>
+void test(const gsl::not_null<std::mt19937*> gen,
+          const gsl::not_null<std::uniform_real_distribution<>*> dist) {
+  using argument_tags = typename Fluxes<Dim>::argument_tags;
+  using return_tags = typename Fluxes<Dim>::return_tags;
+
+  // generate random vars
+  const size_t num_pts = 5;
+  auto random_vars = make_with_random_values<
+      Variables<tmpl::append<return_tags, argument_tags>>>(gen, dist, num_pts);
+
+  // store computed fluxes into return_tags portion of `random_vars`
+  subcell::compute_fluxes<Dim>(make_not_null(&random_vars));
+
+  // compute expected fluxes
+  Variables<return_tags> expected_flux{num_pts};
+  Fluxes<Dim>::apply(
+      make_not_null(
+          &get<::Tags::Flux<Tags::U, tmpl::size_t<Dim>, Frame::Inertial>>(
+              expected_flux)),
+      get<Tags::U>(random_vars), get<Tags::VelocityField<Dim>>(random_vars));
+
+  // check result
+  CHECK_ITERABLE_APPROX(
+      (get<::Tags::Flux<Tags::U, tmpl::size_t<Dim>, Frame::Inertial>>(
+          random_vars)),
+      (get<::Tags::Flux<Tags::U, tmpl::size_t<Dim>, Frame::Inertial>>(
+          expected_flux)));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.ScalarAdvection.Subcell.ComputeFluxes",
+    "[Unit][Evolution]") {
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> dist(-1.0, 1.0);
+
+  test<1>(make_not_null(&gen), make_not_null(&dist));
+  test<2>(make_not_null(&gen), make_not_null(&dist));
+}
+}  // namespace ScalarAdvection

--- a/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_InitialDataTci.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_InitialDataTci.cpp
@@ -46,8 +46,8 @@ void test() {
     // set dg_vars == subcell_vars
     const InactiveVars subcell_vars{number_of_subcell_grid_points, 1.0};
     CHECK_FALSE(ScalarAdvection::subcell::DgInitialDataTci<Dim>::apply(
-        dg_vars, subcell_vars, dg_mesh, persson_exponent, rdmp_delta0,
-        rdmp_epsilon));
+        dg_vars, subcell_vars, rdmp_delta0, rdmp_epsilon, persson_exponent,
+        dg_mesh));
   }
 
   {
@@ -55,8 +55,8 @@ void test() {
     // set subcell_vars to be smooth but quite different from dg_vars
     const InactiveVars subcell_vars{number_of_subcell_grid_points, 2.0};
     CHECK(ScalarAdvection::subcell::DgInitialDataTci<Dim>::apply(
-        dg_vars, subcell_vars, dg_mesh, persson_exponent, rdmp_delta0,
-        rdmp_epsilon));
+        dg_vars, subcell_vars, rdmp_delta0, rdmp_epsilon, persson_exponent,
+        dg_mesh));
   }
 
   {
@@ -68,8 +68,8 @@ void test() {
     // set rdmp_delta0 to be very large to ensure that it's the Persson TCI
     // which triggers alarm here
     CHECK(ScalarAdvection::subcell::DgInitialDataTci<Dim>::apply(
-        dg_vars, subcell_vars, dg_mesh, persson_exponent, 1.0e100,
-        rdmp_epsilon));
+        dg_vars, subcell_vars, rdmp_delta0, rdmp_epsilon, persson_exponent,
+        dg_mesh));
   }
 }
 }  // namespace


### PR DESCRIPTION
## Proposed changes

- Add `compute_fluxes` for subcell variables in ScalarAdvection system.
- Fix the order of arguments of initial data TCI (to conform with `Evolution/DgSubcell/Actions/Initialize.hpp`)

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
