### PR TITLE
Add Ricci Scalar compute tags to EvolveGeneralizedHarmonic.hpp

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
@@ -69,18 +69,22 @@ struct EvolutionMetavars<3, InitialData, BoundaryConditions>
     using temporal_id = ::Tags::Time;
     using tags_to_observe =
         tmpl::list<StrahlkorperGr::Tags::AreaCompute<frame>,
-                   StrahlkorperGr::Tags::IrreducibleMassCompute<frame>>;
+                   StrahlkorperGr::Tags::IrreducibleMassCompute<frame>,
+                   StrahlkorperTags::MaxRicciScalarCompute,
+                   StrahlkorperTags::MinRicciScalarCompute>;
     using compute_vars_to_interpolate = ah::ComputeHorizonVolumeQuantities;
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::SpatialMetric<volume_dim, frame, DataVector>,
                    gr::Tags::InverseSpatialMetric<volume_dim, frame>,
                    gr::Tags::ExtrinsicCurvature<volume_dim, frame>,
-                   gr::Tags::SpatialChristoffelSecondKind<volume_dim, frame>>;
+                   gr::Tags::SpatialChristoffelSecondKind<volume_dim, frame>,
+                   gr::Tags::SpatialRicci<volume_dim, frame>>;
     using compute_items_on_target = tmpl::append<
         tmpl::list<StrahlkorperGr::Tags::AreaElementCompute<frame>,
                    StrahlkorperTags::ThetaPhiCompute<frame>,
                    StrahlkorperTags::RadiusCompute<frame>,
                    StrahlkorperTags::RhatCompute<frame>,
+                   StrahlkorperTags::TangentsCompute<frame>,
                    StrahlkorperTags::InvJacobianCompute<frame>,
                    StrahlkorperTags::DxRadiusCompute<frame>,
                    StrahlkorperTags::OneOverOneFormMagnitudeCompute<
@@ -90,7 +94,8 @@ struct EvolutionMetavars<3, InitialData, BoundaryConditions>
                    StrahlkorperTags::UnitNormalVectorCompute<frame>,
                    StrahlkorperTags::GradUnitNormalOneFormCompute<frame>,
                    StrahlkorperTags::ExtrinsicCurvatureCompute<frame>,
-                   StrahlkorperGr::Tags::SpinFunctionCompute<frame>>,
+                   StrahlkorperGr::Tags::SpinFunctionCompute<frame>,
+                   StrahlkorperTags::RicciScalarCompute<frame>>,
         tags_to_observe>;
     using compute_target_points =
         intrp::TargetPoints::ApparentHorizon<AhA, ::Frame::Inertial>;
@@ -103,10 +108,12 @@ struct EvolutionMetavars<3, InitialData, BoundaryConditions>
   };
 
   using interpolation_target_tags = tmpl::list<AhA>;
-  using interpolator_source_vars =
-      tmpl::list<gr::Tags::SpacetimeMetric<volume_dim, frame>,
-                 GeneralizedHarmonic::Tags::Pi<volume_dim, frame>,
-                 GeneralizedHarmonic::Tags::Phi<volume_dim, frame>>;
+  using interpolator_source_vars = tmpl::list<
+      gr::Tags::SpacetimeMetric<volume_dim, Frame::Inertial>,
+      GeneralizedHarmonic::Tags::Pi<volume_dim, Frame::Inertial>,
+      GeneralizedHarmonic::Tags::Phi<volume_dim, Frame::Inertial>,
+      Tags::deriv<GeneralizedHarmonic::Tags::Phi<volume_dim, Frame::Inertial>,
+                  tmpl::size_t<3>, Frame::Inertial>>;
 
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {


### PR DESCRIPTION
## Proposed changes

Adding the Ricci scalar compute tags to `EvolveGeneralizedHarmonic.hpp` that computes the Min and Max Ricci scalar of a Strahlkorper. This PR also adds arguments tags that are dependent on calculating the Ricci scalar quantities. 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
