### PR TITLE
Fix typo in gr::ricci_tensor equation documentation

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/Ricci.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Ricci.hpp
@@ -28,9 +28,8 @@ namespace gr {
  * Christoffel symbol of the second kind and its derivative.
  *
  * \details Computes Ricci tensor \f$R_{ab}\f$ as:
- * \f$ R_{ab} = \frac{1}{2} ( \partial_c \Gamma^{c}_{ab} - \partial_{(b}
- * \Gamma^{c}_{a)c}
- * + \Gamma^{d}_{ab}\Gamma^{c}_{cd} - \Gamma^{d}_{ac} \Gamma^{c}_{bd}  ) \f$
+ * \f$ R_{ab} = \partial_c \Gamma^{c}_{ab} - \partial_{(b} \Gamma^{c}_{a)c}
+ * + \Gamma^{d}_{ab}\Gamma^{c}_{cd} - \Gamma^{d}_{ac} \Gamma^{c}_{bd} \f$
  * where \f$\Gamma^{a}_{bc}\f$ is the Christoffel symbol of the second kind.
  */
 template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>


### PR DESCRIPTION
## Proposed changes

This PR updates the equation documented in `gr::ricci_tensor` to be consistent with the equation implemented in the code. Specifically, it removes the factor of `1 / 2` in the documented equation that does not appear to be present in the implementation.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
