### PR TITLE
Add CCZ4 functions for contracted conformal spatial christoffel 2nd kind and its derivative

### DIFF
--- a/src/Evolution/Systems/Ccz4/Christoffel.cpp
+++ b/src/Evolution/Systems/Ccz4/Christoffel.cpp
@@ -66,6 +66,30 @@ tnsr::Ijj<DataType, Dim, Frame> christoffel_second_kind(
                           conformal_christoffel_second_kind);
   return result;
 }
+
+template <size_t Dim, typename Frame, typename DataType>
+void contracted_conformal_christoffel_second_kind(
+    const gsl::not_null<tnsr::I<DataType, Dim, Frame>*> result,
+    const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
+    const tnsr::Ijj<DataType, Dim, Frame>& conformal_christoffel_second_kind) {
+  destructive_resize_components(
+      result, get_size(get<0, 0>(inverse_conformal_spatial_metric)));
+
+  ::TensorExpressions::evaluate<ti_I>(
+      result, inverse_conformal_spatial_metric(ti_J, ti_L) *
+                  conformal_christoffel_second_kind(ti_I, ti_j, ti_l));
+}
+
+template <size_t Dim, typename Frame, typename DataType>
+tnsr::I<DataType, Dim, Frame> contracted_conformal_christoffel_second_kind(
+    const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
+    const tnsr::Ijj<DataType, Dim, Frame>& conformal_christoffel_second_kind) {
+  tnsr::I<DataType, Dim, Frame> result{};
+  contracted_conformal_christoffel_second_kind(
+      make_not_null(&result), inverse_conformal_spatial_metric,
+      conformal_christoffel_second_kind);
+  return result;
+}
 }  // namespace Ccz4
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
@@ -101,6 +125,19 @@ tnsr::Ijj<DataType, Dim, Frame> christoffel_second_kind(
       const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                 \
           inverse_conformal_spatial_metric,                                \
       const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>& field_p,         \
+      const tnsr::Ijj<DTYPE(data), DIM(data), FRAME(data)>&                \
+          conformal_christoffel_second_kind);                              \
+  template void Ccz4::contracted_conformal_christoffel_second_kind(        \
+      const gsl::not_null<tnsr::I<DTYPE(data), DIM(data), FRAME(data)>*>   \
+          result,                                                          \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                 \
+          inverse_conformal_spatial_metric,                                \
+      const tnsr::Ijj<DTYPE(data), DIM(data), FRAME(data)>&                \
+          conformal_christoffel_second_kind);                              \
+  template tnsr::I<DTYPE(data), DIM(data), FRAME(data)>                    \
+  Ccz4::contracted_conformal_christoffel_second_kind(                      \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                 \
+          inverse_conformal_spatial_metric,                                \
       const tnsr::Ijj<DTYPE(data), DIM(data), FRAME(data)>&                \
           conformal_christoffel_second_kind);
 

--- a/src/Evolution/Systems/Ccz4/Christoffel.hpp
+++ b/src/Evolution/Systems/Ccz4/Christoffel.hpp
@@ -70,4 +70,32 @@ tnsr::Ijj<DataType, Dim, Frame> christoffel_second_kind(
     const tnsr::i<DataType, Dim, Frame>& field_p,
     const tnsr::Ijj<DataType, Dim, Frame>& conformal_christoffel_second_kind);
 /// @}
+
+/// @{
+/*!
+ * \brief Computes the contraction of the conformal spatial Christoffel symbols
+ * of the second kind.
+ *
+ * \details Computes the contraction as:
+ *
+ * \f{align}
+ *     \tilde{\Gamma}^i &= \tilde{\gamma}^{jl} \tilde{\Gamma}^i_{jl}
+ * \f}
+ *
+ * where \f$\tilde{\gamma}^{ij}\f$ is the inverse conformal spatial metric
+ * defined by `Ccz4::Tags::InverseConformalMetric` and
+ * \f$\tilde{\Gamma}^k_{ij}\f$ is the conformal spatial Christoffel symbols of
+ * the second kind defined by `Ccz4::Tags::ConformalChristoffelSecondKind`.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+void contracted_conformal_christoffel_second_kind(
+    const gsl::not_null<tnsr::I<DataType, Dim, Frame>*> result,
+    const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
+    const tnsr::Ijj<DataType, Dim, Frame>& conformal_christoffel_second_kind);
+
+template <size_t Dim, typename Frame, typename DataType>
+tnsr::I<DataType, Dim, Frame> contracted_conformal_christoffel_second_kind(
+    const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
+    const tnsr::Ijj<DataType, Dim, Frame>& conformal_christoffel_second_kind);
+/// @}
 }  // namespace Ccz4

--- a/src/Evolution/Systems/Ccz4/DerivChristoffel.cpp
+++ b/src/Evolution/Systems/Ccz4/DerivChristoffel.cpp
@@ -62,6 +62,40 @@ tnsr::iJkk<DataType, Dim, Frame> deriv_conformal_christoffel_second_kind(
                                           field_d, d_field_d, field_d_up);
   return result;
 }
+
+template <size_t Dim, typename Frame, typename DataType>
+void deriv_contracted_conformal_christoffel_second_kind(
+    const gsl::not_null<tnsr::iJ<DataType, Dim, Frame>*> result,
+    const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
+    const tnsr::iJJ<DataType, Dim, Frame>& field_d_up,
+    const tnsr::Ijj<DataType, Dim, Frame>& conformal_christoffel_second_kind,
+    const tnsr::iJkk<DataType, Dim, Frame>&
+        d_conformal_christoffel_second_kind) {
+  destructive_resize_components(
+      result, get_size(get<0, 0>(inverse_conformal_spatial_metric)));
+
+  ::TensorExpressions::evaluate<ti_k, ti_I>(
+      result,
+      -2.0 * field_d_up(ti_k, ti_J, ti_L) *
+              conformal_christoffel_second_kind(ti_I, ti_j, ti_l) +
+          inverse_conformal_spatial_metric(ti_J, ti_L) *
+              d_conformal_christoffel_second_kind(ti_k, ti_I, ti_j, ti_l));
+}
+
+template <size_t Dim, typename Frame, typename DataType>
+tnsr::iJ<DataType, Dim, Frame>
+deriv_contracted_conformal_christoffel_second_kind(
+    const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
+    const tnsr::iJJ<DataType, Dim, Frame>& field_d_up,
+    const tnsr::Ijj<DataType, Dim, Frame>& conformal_christoffel_second_kind,
+    const tnsr::iJkk<DataType, Dim, Frame>&
+        d_conformal_christoffel_second_kind) {
+  tnsr::iJ<DataType, Dim, Frame> result{};
+  deriv_contracted_conformal_christoffel_second_kind(
+      make_not_null(&result), inverse_conformal_spatial_metric, field_d_up,
+      conformal_christoffel_second_kind, d_conformal_christoffel_second_kind);
+  return result;
+}
 }  // namespace Ccz4
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
@@ -83,7 +117,26 @@ tnsr::iJkk<DataType, Dim, Frame> deriv_conformal_christoffel_second_kind(
           inverse_conformal_spatial_metric,                                 \
       const tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>& field_d,        \
       const tnsr::ijkk<DTYPE(data), DIM(data), FRAME(data)>& d_field_d,     \
-      const tnsr::iJJ<DTYPE(data), DIM(data), FRAME(data)>& field_d_up);
+      const tnsr::iJJ<DTYPE(data), DIM(data), FRAME(data)>& field_d_up);    \
+  template void Ccz4::deriv_contracted_conformal_christoffel_second_kind(   \
+      const gsl::not_null<tnsr::iJ<DTYPE(data), DIM(data), FRAME(data)>*>   \
+          result,                                                           \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                  \
+          inverse_conformal_spatial_metric,                                 \
+      const tnsr::iJJ<DTYPE(data), DIM(data), FRAME(data)>& field_d_up,     \
+      const tnsr::Ijj<DTYPE(data), DIM(data), FRAME(data)>&                 \
+          conformal_christoffel_second_kind,                                \
+      const tnsr::iJkk<DTYPE(data), DIM(data), FRAME(data)>&                \
+          d_conformal_christoffel_second_kind);                             \
+  template tnsr::iJ<DTYPE(data), DIM(data), FRAME(data)>                    \
+  Ccz4::deriv_contracted_conformal_christoffel_second_kind(                 \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                  \
+          inverse_conformal_spatial_metric,                                 \
+      const tnsr::iJJ<DTYPE(data), DIM(data), FRAME(data)>& field_d_up,     \
+      const tnsr::Ijj<DTYPE(data), DIM(data), FRAME(data)>&                 \
+          conformal_christoffel_second_kind,                                \
+      const tnsr::iJkk<DTYPE(data), DIM(data), FRAME(data)>&                \
+          d_conformal_christoffel_second_kind);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial),
                         (double, DataVector))

--- a/src/Evolution/Systems/Ccz4/DerivChristoffel.hpp
+++ b/src/Evolution/Systems/Ccz4/DerivChristoffel.hpp
@@ -43,4 +43,43 @@ tnsr::iJkk<DataType, Dim, Frame> deriv_conformal_christoffel_second_kind(
     const tnsr::ijkk<DataType, Dim, Frame>& d_field_d,
     const tnsr::iJJ<DataType, Dim, Frame>& field_d_up);
 /// @}
+
+/// @{
+/*!
+ * \brief Computes the spatial derivative of the contraction of the conformal
+ * spatial Christoffel symbols of the second kind
+ *
+ * \details Computes the derivative as:
+ *
+ * \f{align}
+ *     \partial_k \tilde{\Gamma}^i &= -2 D_k{}^{jl} \tilde{\Gamma}^i_{jl} +
+ *       \tilde{\gamma}^{jl} \partial_k \tilde{\Gamma}^i_{jl}
+ * \f}
+ *
+ * where \f$\tilde{\gamma}^{ij}\f$ is the inverse conformal spatial metric
+ * defined by `Ccz4::Tags::InverseConformalMetric`, \f$D_k{}^{ij}\f$ is the CCZ4
+ * identity defined by `Ccz4::Tags::FieldDUp`, \f$\tilde{\Gamma}^k_{ij}\f$ is
+ * the conformal spatial Christoffel symbols of the second kind defined by
+ * `Ccz4::Tags::ConformalChristoffelSecondKind`, and
+ * \f$\partial_k \tilde{\Gamma}^k_{ij}\f$ is its spatial derivative defined by
+ * `Ccz4::Tags::DerivConformalChristoffelSecondKind`.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+void deriv_contracted_conformal_christoffel_second_kind(
+    const gsl::not_null<tnsr::iJ<DataType, Dim, Frame>*> result,
+    const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
+    const tnsr::iJJ<DataType, Dim, Frame>& field_d_up,
+    const tnsr::Ijj<DataType, Dim, Frame>& conformal_christoffel_second_kind,
+    const tnsr::iJkk<DataType, Dim, Frame>&
+        d_conformal_christoffel_second_kind);
+
+template <size_t Dim, typename Frame, typename DataType>
+tnsr::iJ<DataType, Dim, Frame>
+deriv_contracted_conformal_christoffel_second_kind(
+    const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
+    const tnsr::iJJ<DataType, Dim, Frame>& field_d_up,
+    const tnsr::Ijj<DataType, Dim, Frame>& conformal_christoffel_second_kind,
+    const tnsr::iJkk<DataType, Dim, Frame>&
+        d_conformal_christoffel_second_kind);
+/// @}
 }  // namespace Ccz4

--- a/src/Evolution/Systems/Ccz4/Tags.hpp
+++ b/src/Evolution/Systems/Ccz4/Tags.hpp
@@ -230,6 +230,18 @@ template <typename DataType>
 struct DivergenceLapse : db::SimpleTag {
   using type = Scalar<DataType>;
 };
+
+/*!
+ * \brief The contraction of the conformal spatial Christoffel symbols of the
+ * second kind
+ *
+ * \details See `Ccz4::contracted_conformal_christoffel_second_kind()` for
+ * details.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct ContractedConformalChristoffelSecondKind : db::SimpleTag {
+  using type = tnsr::I<DataType, Dim, Frame>;
+};
 }  // namespace Tags
 
 namespace OptionTags {

--- a/src/Evolution/Systems/Ccz4/Tags.hpp
+++ b/src/Evolution/Systems/Ccz4/Tags.hpp
@@ -242,6 +242,18 @@ template <size_t Dim, typename Frame, typename DataType>
 struct ContractedConformalChristoffelSecondKind : db::SimpleTag {
   using type = tnsr::I<DataType, Dim, Frame>;
 };
+
+/*!
+ * \brief The spatial derivative of the contraction of the conformal spatial
+ * Christoffel symbols of the second kind
+ *
+ * \details See `Ccz4::deriv_contracted_conformal_christoffel_second_kind()` for
+ * details.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct DerivContractedConformalChristoffelSecondKind : db::SimpleTag {
+  using type = tnsr::iJ<DataType, Dim, Frame>;
+};
 }  // namespace Tags
 
 namespace OptionTags {

--- a/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
@@ -50,6 +50,9 @@ struct DivergenceLapse;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
 struct ContractedConformalChristoffelSecondKind;
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
+struct DerivContractedConformalChristoffelSecondKind;
 }  // namespace Tags
 
 /// \brief Input option tags for the generalized harmonic evolution system

--- a/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
@@ -47,6 +47,9 @@ template <size_t Dim, typename Frame = Frame::Inertial,
 struct GradGradLapse;
 template <typename DataType = DataVector>
 struct DivergenceLapse;
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
+struct ContractedConformalChristoffelSecondKind;
 }  // namespace Tags
 
 /// \brief Input option tags for the generalized harmonic evolution system

--- a/tests/Unit/Evolution/Systems/Ccz4/Christoffel.py
+++ b/tests/Unit/Evolution/Systems/Ccz4/Christoffel.py
@@ -20,3 +20,9 @@ def christoffel_second_kind(conformal_spatial_metric,
                    (np.einsum("jl,i", conformal_spatial_metric, field_p) +
                     np.einsum("il,j", conformal_spatial_metric, field_p) -
                     np.einsum("ij,l", conformal_spatial_metric, field_p)))))
+
+
+def contracted_conformal_christoffel_second_kind(
+    inverse_conformal_spatial_metric, conformal_christoffel_second_kind):
+    return np.einsum("jl,ijl", inverse_conformal_spatial_metric,
+                     conformal_christoffel_second_kind)

--- a/tests/Unit/Evolution/Systems/Ccz4/DerivChristoffel.py
+++ b/tests/Unit/Evolution/Systems/Ccz4/DerivChristoffel.py
@@ -16,3 +16,12 @@ def deriv_conformal_christoffel_second_kind(inverse_conformal_spatial_metric,
              np.einsum("kjil", d_field_d) + np.einsum("jkil", d_field_d) -
              np.einsum("klij", d_field_d) - np.einsum("lkij", d_field_d))) /
         2.0)
+
+
+def deriv_contracted_conformal_christoffel_second_kind(
+    inverse_conformal_spatial_metric, field_d_up,
+    conformal_christoffel_second_kind, d_conformal_christoffel_second_kind):
+    return (-2.0 * np.einsum("kjl,ijl->ki", field_d_up,
+                             conformal_christoffel_second_kind) +
+            np.einsum("jl,kijl->ki", inverse_conformal_spatial_metric,
+                      d_conformal_christoffel_second_kind))

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_Christoffel.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_Christoffel.cpp
@@ -39,6 +39,19 @@ void test_christoffel_second_kind(const DataType& used_for_size) {
           &::Ccz4::christoffel_second_kind<Dim, Frame::Inertial, DataType>),
       "Christoffel", "christoffel_second_kind", {{{-1., 1.}}}, used_for_size);
 }
+
+template <size_t Dim, typename DataType>
+void test_contracted_conformal_christoffel_second_kind(
+    const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::I<DataType, Dim, Frame::Inertial> (*)(
+          const tnsr::II<DataType, Dim, Frame::Inertial>&,
+          const tnsr::Ijj<DataType, Dim, Frame::Inertial>&)>(
+          &::Ccz4::contracted_conformal_christoffel_second_kind<
+              Dim, Frame::Inertial, DataType>),
+      "Christoffel", "contracted_conformal_christoffel_second_kind",
+      {{{-1., 1.}}}, used_for_size);
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.Christoffel",
@@ -49,4 +62,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.Christoffel",
   CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_conformal_christoffel_second_kind,
                                     (1, 2, 3));
   CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_christoffel_second_kind, (1, 2, 3));
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(
+      test_contracted_conformal_christoffel_second_kind, (1, 2, 3));
 }

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_DerivChristoffel.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_DerivChristoffel.cpp
@@ -28,6 +28,21 @@ void test_compute_deriv_conformal_christoffel_second_kind(
       "DerivChristoffel", "deriv_conformal_christoffel_second_kind",
       {{{-1., 1.}}}, used_for_size);
 }
+
+template <size_t Dim, typename DataType>
+void test_compute_deriv_contracted_conformal_christoffel_second_kind(
+    const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::iJ<DataType, Dim, Frame::Inertial> (*)(
+          const tnsr::II<DataType, Dim, Frame::Inertial>&,
+          const tnsr::iJJ<DataType, Dim, Frame::Inertial>&,
+          const tnsr::Ijj<DataType, Dim, Frame::Inertial>&,
+          const tnsr::iJkk<DataType, Dim, Frame::Inertial>&)>(
+          &Ccz4::deriv_contracted_conformal_christoffel_second_kind<
+              Dim, Frame::Inertial, DataType>),
+      "DerivChristoffel", "deriv_contracted_conformal_christoffel_second_kind",
+      {{{-1., 1.}}}, used_for_size);
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.DerivChristoffel",
@@ -37,4 +52,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.DerivChristoffel",
   GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
   CHECK_FOR_DOUBLES_AND_DATAVECTORS(
       test_compute_deriv_conformal_christoffel_second_kind, (1, 2, 3));
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(
+      test_compute_deriv_contracted_conformal_christoffel_second_kind,
+      (1, 2, 3));
 }

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
@@ -50,6 +50,10 @@ void test_simple_tags() {
       Ccz4::Tags::GradGradLapse<Dim, Frame, DataType>>("GradGradLapse");
   TestHelpers::db::test_simple_tag<Ccz4::Tags::DivergenceLapse<DataType>>(
       "DivergenceLapse");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::ContractedConformalChristoffelSecondKind<Dim, Frame,
+                                                           DataType>>(
+      "ContractedConformalChristoffelSecondKind");
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.Tags", "[Unit][Evolution]") {

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
@@ -54,6 +54,10 @@ void test_simple_tags() {
       Ccz4::Tags::ContractedConformalChristoffelSecondKind<Dim, Frame,
                                                            DataType>>(
       "ContractedConformalChristoffelSecondKind");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::DerivContractedConformalChristoffelSecondKind<Dim, Frame,
+                                                                DataType>>(
+      "DerivContractedConformalChristoffelSecondKind");
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.Tags", "[Unit][Evolution]") {


### PR DESCRIPTION
## Proposed changes

As part of implementing the first order CCZ4 system, this PR adds functions for computing the contraction of the conformal spatial christoffel symbols of the second kind and its spatial derivative.

The motivation for this is to compute eq. (23) and (24) in this [CCZ4 paper](https://arxiv.org/pdf/1707.09910.pdf), whose values will later be necessary for computing eq. (25) and (26).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
