### PR TITLE
Add action to randomize inital evolved fields

### DIFF
--- a/src/Elliptic/Actions/CMakeLists.txt
+++ b/src/Elliptic/Actions/CMakeLists.txt
@@ -9,5 +9,4 @@ spectre_target_headers(
   InitializeBackgroundFields.hpp
   InitializeFields.hpp
   InitializeFixedSources.hpp
-  RandomizeInitialGuess.hpp
   )

--- a/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
@@ -14,7 +14,6 @@
 #include "Elliptic/Actions/InitializeAnalyticSolution.hpp"
 #include "Elliptic/Actions/InitializeFields.hpp"
 #include "Elliptic/Actions/InitializeFixedSources.hpp"
-#include "Elliptic/Actions/RandomizeInitialGuess.hpp"
 #include "Elliptic/DiscontinuousGalerkin/Actions/ApplyOperator.hpp"
 #include "Elliptic/DiscontinuousGalerkin/Actions/InitializeDomain.hpp"
 #include "Elliptic/DiscontinuousGalerkin/DgElementArray.hpp"
@@ -36,6 +35,7 @@
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/Reduction.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "ParallelAlgorithms/Actions/RandomizeVariables.hpp"
 #include "ParallelAlgorithms/Events/Factory.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Completion.hpp"
@@ -201,6 +201,9 @@ struct Metavariables {
   // Specify all global synchronization points.
   enum class Phase { Initialization, RegisterWithObserver, Solve, Exit };
 
+  // For labeling the yaml option for RandomizeVariables
+  struct RandomizeInitialGuess {};
+
   using initialization_actions = tmpl::list<
       Actions::SetupDataBox,
       elliptic::dg::Actions::InitializeDomain<volume_dim>,
@@ -208,7 +211,9 @@ struct Metavariables {
       typename multigrid::initialize_element,
       typename schwarz_smoother::initialize_element,
       elliptic::Actions::InitializeFields<system, initial_guess_tag>,
-      elliptic::Actions::RandomizeInitialGuess<system>,
+      Actions::RandomizeVariables<
+          ::Tags::Variables<typename system::primal_fields>,
+          RandomizeInitialGuess>,
       elliptic::Actions::InitializeFixedSources<system, analytic_solution_tag>,
       elliptic::Actions::InitializeAnalyticSolution<
           analytic_solution_tag, tmpl::append<typename system::primal_fields,

--- a/src/ParallelAlgorithms/Actions/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Actions/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   MutateApply.hpp
+  RandomizeVariables.hpp
   SetData.hpp
   UpdateMessageQueue.hpp
   )

--- a/tests/Unit/Elliptic/Actions/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Actions/CMakeLists.txt
@@ -8,7 +8,6 @@ set(LIBRARY_SOURCES
   Test_InitializeBackgroundFields.cpp
   Test_InitializeFields.cpp
   Test_InitializeFixedSources.cpp
-  Test_RandomizeInitialGuess.cpp
   )
 
 add_test_library(

--- a/tests/Unit/ParallelAlgorithms/Actions/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Actions/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_ParallelAlgorithmsActions")
 set(LIBRARY_SOURCES
   Test_MutateApply.cpp
   Test_SetData.cpp
+  Test_RandomizeVariables.cpp
   Test_UpdateMessageQueue.cpp
   )
 


### PR DESCRIPTION
## Proposed changes

Add code similar to `RandomizeInitialGuess` from the elliptic solver that adds random noise to the initial data in an evolution. This is useful for testing accuracy and stability.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
