### PR TITLE
Add ExcisionSpheres to BinaryCompactObject Domain

### DIFF
--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -43,6 +43,7 @@
 #include "Domain/FunctionsOfTime/FixedSpeedCubic.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Domain/Structure/BlockNeighbor.hpp"  // IWYU pragma: keep
+#include "Domain/Structure/ExcisionSphere.hpp"
 #include "Utilities/MakeArray.hpp"
 
 namespace Frame {
@@ -515,7 +516,13 @@ Domain<3> BinaryCompactObject::create_domain() const {
       corners_for_biradially_layered_domains(2, 3, not object_A_.is_excised(),
                                              not object_B_.is_excised()),
       {},
-      std::move(boundary_conditions_all_blocks)};
+      std::move(boundary_conditions_all_blocks),
+      {{"ObjectAExcisionSphere",
+        ExcisionSphere<3>{object_A_.inner_radius,
+                          {{object_A_.x_coord, 0.0, 0.0}}}},
+       {"ObjectBExcisionSphere",
+        ExcisionSphere<3>{object_B_.inner_radius,
+                          {{object_B_.x_coord, 0.0, 0.0}}}}}};
 
   // Inject the hard-coded time-dependence
   if (enable_time_dependence_) {

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -128,7 +128,6 @@ void test_binary_compact_object_construction(
                       binary_compact_object.initial_refinement_levels());
   test_physical_separation(binary_compact_object.create_domain().blocks(), time,
                            functions_of_time);
-
   for (size_t block_id = 0;
        block_id < expected_external_boundary_conditions.size(); ++block_id) {
     CAPTURE(block_id);
@@ -304,6 +303,14 @@ void test_connectivity() {
           }
           CHECK(binary_compact_object.block_names() == expected_block_names);
           CHECK(binary_compact_object.block_groups() == expected_block_groups);
+          CHECK(binary_compact_object.create_domain().excision_spheres() ==
+                std::unordered_map<std::string, ExcisionSphere<3>>{
+                    {"ObjectAExcisionSphere",
+                     ExcisionSphere<3>{inner_radius_objectA,
+                                       {{xcoord_objectA, 0.0, 0.0}}}},
+                    {"ObjectBExcisionSphere",
+                     ExcisionSphere<3>{inner_radius_objectB,
+                                       {{xcoord_objectB, 0.0, 0.0}}}}});
 
           test_binary_compact_object_construction(
               binary_compact_object,


### PR DESCRIPTION
## Proposed changes

Adds ExcisionSpheres to the BinaryCompactObject domain.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

I can look into adding ExcisionSurfaces to the Cylindrical Binary Compact Object Domain next but I might possibly have questions for @markscheel (I haven't looked at the Domain yet, but the way things are going I'll probably be taking a look at it soon!)
