### PR TITLE
Add IndexPolarAxis Option to Shell Domain

### DIFF
--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -358,14 +358,14 @@ Domain<3> BinaryCompactObject::create_domain() const {
   // ObjectA/B is on the left/right, respectively.
   Maps maps_center_A = sph_wedge_coordinate_maps<Frame::Inertial>(
       object_A_.inner_radius, object_A_.outer_radius, inner_sphericity_A, 1.0,
-      use_equiangular_map_, object_A_.x_coord, false, 1.0, {},
+      use_equiangular_map_, object_A_.x_coord, false, 1.0, 2, {},
       object_A_radial_distribution);
   Maps maps_cube_A = sph_wedge_coordinate_maps<Frame::Inertial>(
       object_A_.outer_radius, sqrt(3.0) * 0.5 * length_inner_cube_, 1.0, 0.0,
       use_equiangular_map_, object_A_.x_coord, false);
   Maps maps_center_B = sph_wedge_coordinate_maps<Frame::Inertial>(
       object_B_.inner_radius, object_B_.outer_radius, inner_sphericity_B, 1.0,
-      use_equiangular_map_, object_B_.x_coord, false, 1.0, {},
+      use_equiangular_map_, object_B_.x_coord, false, 1.0, 2, {},
       object_B_radial_distribution);
   Maps maps_cube_B = sph_wedge_coordinate_maps<Frame::Inertial>(
       object_B_.outer_radius, sqrt(3.0) * 0.5 * length_inner_cube_, 1.0, 0.0,
@@ -415,11 +415,11 @@ Domain<3> BinaryCompactObject::create_domain() const {
 
   Maps maps_first_outer_shell = sph_wedge_coordinate_maps<Frame::Inertial>(
       radius_enveloping_cube_, radius_enveloping_sphere_, 0.0, 1.0,
-      use_equiangular_map_, 0.0, true, 1.0, {},
+      use_equiangular_map_, 0.0, true, 1.0, 2, {},
       {domain::CoordinateMaps::Distribution::Linear}, ShellWedges::All);
   Maps maps_second_outer_shell = sph_wedge_coordinate_maps<Frame::Inertial>(
       radius_enveloping_sphere_, outer_radius_domain_, 1.0, 1.0,
-      use_equiangular_map_, 0.0, true, 1.0, {},
+      use_equiangular_map_, 0.0, true, 1.0, 2, {},
       {radial_distribution_outer_shell_}, ShellWedges::All);
   if (outer_boundary_condition_ != nullptr) {
     // The outer 10 wedges all have to have the outer boundary condition

--- a/src/Domain/Creators/Python/Shell.cpp
+++ b/src/Domain/Creators/Python/Shell.cpp
@@ -16,11 +16,21 @@ namespace domain::creators::py_bindings {
 
 void bind_shell(py::module& m) {  // NOLINT
   py::class_<Shell, DomainCreator<3>>(m, "Shell")
-      .def(py::init<double, double, size_t, std::array<size_t, 2>, bool,
-                    double>(),
-           py::arg("inner_radius"), py::arg("outer_radius"),
-           py::arg("initial_refinement"),
-           py::arg("initial_number_of_grid_points"),
-           py::arg("use_equiangular_map") = true, py::arg("aspect_ratio") = 1.);
+      .def(
+          py::init([](const double inner_radius, const double outer_radius,
+                      const size_t initial_refinement,
+                      const std::array<size_t, 2> initial_grid_points,
+                      const bool use_equiangular_map, const double aspect_ratio,
+                      const size_t index_polar_axis) {
+            return Shell{
+                inner_radius,        outer_radius,
+                initial_refinement,  initial_grid_points,
+                use_equiangular_map, {{aspect_ratio, index_polar_axis}}};
+          }),
+          py::arg("inner_radius"), py::arg("outer_radius"),
+          py::arg("initial_refinement"),
+          py::arg("initial_number_of_grid_points"),
+          py::arg("use_equiangular_map") = true, py::arg("aspect_ratio") = 1.,
+          py::arg("index_polar_axis") = 2);
 }
 }  // namespace domain::creators::py_bindings

--- a/src/Domain/Creators/Shell.cpp
+++ b/src/Domain/Creators/Shell.cpp
@@ -28,7 +28,9 @@ namespace domain::creators {
 Shell::Shell(
     double inner_radius, double outer_radius, size_t initial_refinement,
     std::array<size_t, 2> initial_number_of_grid_points,
-    bool use_equiangular_map, double aspect_ratio,
+    bool use_equiangular_map,
+    std::optional<domain::creators::Shell::EquatorialCompressionOptions>
+        equatorial_compression,
     std::vector<double> radial_partitioning,
     std::vector<domain::CoordinateMaps::Distribution> radial_distribution,
     ShellWedges which_wedges,
@@ -44,7 +46,6 @@ Shell::Shell(
       initial_refinement_(initial_refinement),
       initial_number_of_grid_points_(initial_number_of_grid_points),
       use_equiangular_map_(use_equiangular_map),
-      aspect_ratio_(aspect_ratio),
       radial_partitioning_(std::move(radial_partitioning)),
       radial_distribution_(std::move(radial_distribution)),
       which_wedges_(which_wedges),
@@ -52,6 +53,13 @@ Shell::Shell(
       inner_boundary_condition_(std::move(inner_boundary_condition)),
       outer_boundary_condition_(std::move(outer_boundary_condition)) {
   number_of_layers_ = radial_partitioning_.size() + 1;
+  if (equatorial_compression.has_value()) {
+    aspect_ratio_ = equatorial_compression.value().aspect_ratio;
+    index_polar_axis_ = equatorial_compression.value().index_polar_axis;
+  } else {
+    aspect_ratio_ = 1.0;
+    index_polar_axis_ = 2;
+  }
   if (time_dependence_ == nullptr) {
     time_dependence_ =
         std::make_unique<domain::creators::time_dependence::None<3>>();
@@ -127,8 +135,8 @@ Domain<3> Shell::create_domain() const {
       CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 3>>>
       coord_maps = sph_wedge_coordinate_maps<Frame::Inertial>(
           inner_radius_, outer_radius_, 1.0, 1.0, use_equiangular_map_, 0.0,
-          false, aspect_ratio_, radial_partitioning_, radial_distribution_,
-          which_wedges_);
+          false, aspect_ratio_, index_polar_axis_, radial_partitioning_,
+          radial_distribution_, which_wedges_);
 
   std::vector<DirectionMap<
       3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -606,6 +606,7 @@ sph_wedge_coordinate_maps(
     const double inner_sphericity, const double outer_sphericity,
     const bool use_equiangular_map, const double x_coord_of_shell_center,
     const bool use_half_wedges, const double aspect_ratio,
+    const size_t index_polar_axis,
     const std::vector<double>& radial_partitioning,
     const std::vector<domain::CoordinateMaps::Distribution>&
         radial_distribution,
@@ -689,8 +690,8 @@ sph_wedge_coordinate_maps(
           Identity2D{});
 
   // Set up compression map:
-  const auto compression =
-      domain::CoordinateMaps::EquatorialCompression{aspect_ratio};
+  const auto compression = domain::CoordinateMaps::EquatorialCompression{
+      aspect_ratio, index_polar_axis};
 
   return domain::make_vector_coordinate_map_base<Frame::BlockLogical,
                                                  TargetFrame, 3>(
@@ -1414,6 +1415,7 @@ sph_wedge_coordinate_maps(
     const double inner_sphericity, const double outer_sphericity,
     const bool use_equiangular_map, const double x_coord_of_shell_center,
     const bool use_wedge_halves, const double aspect_ratio,
+    const size_t index_pole_axis,
     const std::vector<double>& radial_partitioning,
     const std::vector<domain::CoordinateMaps::Distribution>&
         radial_distribution,
@@ -1425,6 +1427,7 @@ sph_wedge_coordinate_maps(
     const double inner_sphericity, const double outer_sphericity,
     const bool use_equiangular_map, const double x_coord_of_shell_center,
     const bool use_wedge_halves, const double aspect_ratio,
+    const size_t index_pole_axis,
     const std::vector<double>& radial_partitioning,
     const std::vector<domain::CoordinateMaps::Distribution>&
         radial_distribution,

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -155,7 +155,7 @@ auto sph_wedge_coordinate_maps(
     double inner_radius, double outer_radius, double inner_sphericity,
     double outer_sphericity, bool use_equiangular_map,
     double x_coord_of_shell_center = 0.0, bool use_half_wedges = false,
-    double aspect_ratio = 1.0,
+    double aspect_ratio = 1.0, size_t index_polar_axis = 2,
     const std::vector<double>& radial_partitioning = {},
     const std::vector<domain::CoordinateMaps::Distribution>&
         radial_distribution = {domain::CoordinateMaps::Distribution::Linear},

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -36,7 +36,7 @@ DomainCreator:
     InitialRefinement: 0
     InitialGridPoints: [5, 5]
     UseEquiangularMap: true
-    AspectRatio: 1.0
+    EquatorialCompression: None
     RadialPartitioning: []
     RadialDistribution: [Logarithmic]
     WhichWedges: All

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -29,7 +29,7 @@ DomainCreator:
     InitialRefinement: 1
     InitialGridPoints: [2, 2]
     UseEquiangularMap: true
-    AspectRatio: 1.0
+    EquatorialCompression: None
     WhichWedges: All
     RadialPartitioning: []
     RadialDistribution: [Logarithmic]

--- a/tests/InputFiles/Xcts/Schwarzschild.yaml
+++ b/tests/InputFiles/Xcts/Schwarzschild.yaml
@@ -28,7 +28,7 @@ DomainCreator:
     InitialRefinement: 0
     InitialGridPoints: [4, 4]
     UseEquiangularMap: True
-    AspectRatio: 1.
+    EquatorialCompression: None
     WhichWedges: All
     RadialPartitioning: []
     RadialDistribution: [Logarithmic]

--- a/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
@@ -327,11 +327,11 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
         1.9, 2.9, 1,
         std::array<size_t, 2>{grid_points_each_dimension,
                               grid_points_each_dimension},
-        false, 1.0, radial_partitioning, radial_distribution, ShellWedges::All,
+        false, domain::creators::Shell::EquatorialCompressionOptions{1.0, 2},
+        radial_partitioning, radial_distribution, ShellWedges::All,
         std::make_unique<
             domain::creators::time_dependence::UniformTranslation<3>>(
-            0.0, expiration_time,
-            std::array<double, 3>({{0.01, 0.02, 0.03}})));
+            0.0, expiration_time, std::array<double, 3>({{0.01, 0.02, 0.03}})));
     tuples::TaggedTuple<
         domain::Tags::Domain<3>,
         typename ::intrp::Tags::ApparentHorizon<typename metavars::AhA, Frame>>

--- a/tests/Unit/ApparentHorizons/Test_StrahlkorperInDifferentFrame.cpp
+++ b/tests/Unit/ApparentHorizons/Test_StrahlkorperInDifferentFrame.cpp
@@ -42,7 +42,8 @@ void test_strahlkorper_in_different_frame() {
       1.9, 2.9, 1,
       std::array<size_t, 2>{grid_points_each_dimension,
                             grid_points_each_dimension},
-      false, 1.0, radial_partitioning, radial_distribution, ShellWedges::All,
+      false, {{1.0, 2}}, radial_partitioning, radial_distribution,
+      ShellWedges::All,
       std::make_unique<
           domain::creators::time_dependence::UniformTranslation<3>>(
           0.0, expiration_time, std::array<double, 3>({{0.01, 0.02, 0.03}})));

--- a/tests/Unit/Domain/Test_BlockAndElementLogicalCoordinates.cpp
+++ b/tests/Unit/Domain/Test_BlockAndElementLogicalCoordinates.cpp
@@ -284,7 +284,8 @@ void fuzzy_test_block_and_element_logical_coordinates_unrefined(
 
 void fuzzy_test_block_and_element_logical_coordinates_shell(
     const size_t n_pts) {
-  const auto shell = domain::creators::Shell(1.5, 2.5, 2, {{1, 1}}, true, 1.0);
+  const auto shell =
+      domain::creators::Shell(1.5, 2.5, 2, {{1, 1}}, true, {{1.0, 2}});
   const auto domain = shell.create_domain();
   fuzzy_test_block_and_element_logical_coordinates_unrefined(domain, n_pts);
   fuzzy_test_block_and_element_logical_coordinates(

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -134,7 +134,8 @@ test_wedge_map_generation(double inner_radius, double outer_radius,
                           bool use_equiangular_map,
                           double x_coord_of_shell_center = 0.0,
                           bool use_half_wedges = false,
-                          double aspect_ratio = 1.0) {
+                          double aspect_ratio = 1.0,
+                          size_t index_polar_axis = 2) {
   using Wedge3DMap = CoordinateMaps::Wedge<3>;
   using Identity2D = CoordinateMaps::Identity<2>;
   using Affine = CoordinateMaps::Affine;
@@ -142,7 +143,8 @@ test_wedge_map_generation(double inner_radius, double outer_radius,
       Affine{-1.0, 1.0, -1.0 + x_coord_of_shell_center,
              1.0 + x_coord_of_shell_center},
       Identity2D{});
-  const auto compression = CoordinateMaps::EquatorialCompression{aspect_ratio};
+  const auto compression =
+      CoordinateMaps::EquatorialCompression{aspect_ratio, index_polar_axis};
 
   if (use_half_wedges) {
     using Halves = Wedge3DMap::WedgeHalves;
@@ -275,15 +277,15 @@ void test_wedge_map_generation_against_domain_helpers(
     double inner_radius, double outer_radius, double inner_sphericity,
     double outer_sphericity, bool use_equiangular_map,
     double x_coord_of_shell_center = 0.0, bool use_half_wedges = false,
-    double aspect_ratio = 1.0) {
+    double aspect_ratio = 1.0, size_t index_polar_axis = 2) {
   const auto expected_coord_maps = test_wedge_map_generation(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
       use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
-      aspect_ratio);
+      aspect_ratio, index_polar_axis);
   const auto maps = sph_wedge_coordinate_maps<Frame::Inertial>(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
       use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
-      aspect_ratio);
+      aspect_ratio, index_polar_axis);
   CHECK(maps.size() == expected_coord_maps.size());
   for (size_t i = 0; i < expected_coord_maps.size(); i++) {
     check_if_maps_are_equal(*expected_coord_maps[i], *maps[i]);
@@ -304,13 +306,14 @@ void test_wedge_map_generation_against_domain_helpers(
   const double x_coord_of_shell_center = 0.1;
   const bool use_half_wedges = true;
   const double aspect_ratio = 1.0;
+  const size_t index_polar_axis = 1;
   const std::vector<domain::CoordinateMaps::Distribution> radial_distribution{
       domain::CoordinateMaps::Distribution::Logarithmic};
   const ShellWedges which_wedges = ShellWedges::FourOnEquator;
   static_cast<void>(sph_wedge_coordinate_maps<Frame::Inertial>(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
       use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
-      aspect_ratio, {}, radial_distribution, which_wedges));
+      aspect_ratio, index_polar_axis, {}, radial_distribution, which_wedges));
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
@@ -329,6 +332,7 @@ void test_wedge_map_generation_against_domain_helpers(
   const double x_coord_of_shell_center = 0.1;
   const bool use_half_wedges = true;
   const double aspect_ratio = 1.0;
+  const double index_polar_axis = 1;
   std::vector<double> radial_partitioning{1., 1.5};
   const std::vector<domain::CoordinateMaps::Distribution> radial_distribution{
       domain::CoordinateMaps::Distribution::Logarithmic,
@@ -338,7 +342,8 @@ void test_wedge_map_generation_against_domain_helpers(
   static_cast<void>(sph_wedge_coordinate_maps<Frame::Inertial>(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
       use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
-      aspect_ratio, radial_partitioning, radial_distribution, which_wedges));
+      aspect_ratio, index_polar_axis, radial_partitioning, radial_distribution,
+      which_wedges));
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
@@ -428,9 +433,11 @@ void test_six_wedge_directions_compressed_equiangular() {
   const bool use_equiangular_map = true;
   const bool use_half_wedges = false;
   const double aspect_ratio = 6.0;
+  const size_t index_polar_axis = 2;
   test_wedge_map_generation_against_domain_helpers(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, 0.0, use_half_wedges, aspect_ratio);
+      use_equiangular_map, 0.0, use_half_wedges, aspect_ratio,
+      index_polar_axis);
 }
 
 void test_six_wedge_directions_compressed_equidistant() {
@@ -442,9 +449,11 @@ void test_six_wedge_directions_compressed_equidistant() {
   const bool use_equiangular_map = false;
   const bool use_half_wedges = false;
   const double aspect_ratio = 0.6;
+  const size_t index_polar_axis = 1;
   test_wedge_map_generation_against_domain_helpers(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, 0.0, use_half_wedges, aspect_ratio);
+      use_equiangular_map, 0.0, use_half_wedges, aspect_ratio,
+      index_polar_axis);
 }
 
 void test_six_wedge_directions_compressed_translated_equiangular() {
@@ -456,11 +465,12 @@ void test_six_wedge_directions_compressed_translated_equiangular() {
   const bool use_equiangular_map = true;
   const bool use_half_wedges = false;
   const double aspect_ratio = 6.0;
+  const size_t index_polar_axis = 0;
   const double x_coord_of_shell_center = 2.7;
   test_wedge_map_generation_against_domain_helpers(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
       use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
-      aspect_ratio);
+      aspect_ratio, index_polar_axis);
 }
 
 void test_six_wedge_directions_compressed_translated_equidistant() {
@@ -472,11 +482,12 @@ void test_six_wedge_directions_compressed_translated_equidistant() {
   const bool use_equiangular_map = false;
   const bool use_half_wedges = false;
   const double aspect_ratio = 0.6;
+  const size_t index_polar_axis = 2;
   const double x_coord_of_shell_center = 2.7;
   test_wedge_map_generation_against_domain_helpers(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
       use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
-      aspect_ratio);
+      aspect_ratio, index_polar_axis);
 }
 
 void test_ten_wedge_directions_compressed_translated_equiangular() {
@@ -488,11 +499,12 @@ void test_ten_wedge_directions_compressed_translated_equiangular() {
   const bool use_equiangular_map = true;
   const bool use_half_wedges = true;
   const double aspect_ratio = 0.6;
+  const size_t index_polar_axis = 1;
   const double x_coord_of_shell_center = 2.7;
   test_wedge_map_generation_against_domain_helpers(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
       use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
-      aspect_ratio);
+      aspect_ratio, index_polar_axis);
 }
 
 void test_ten_wedge_directions_compressed_translated_equidistant() {
@@ -504,11 +516,12 @@ void test_ten_wedge_directions_compressed_translated_equidistant() {
   const bool use_equiangular_map = false;
   const bool use_half_wedges = true;
   const double aspect_ratio = 0.6;
+  const size_t index_polar_axis = 0;
   const double x_coord_of_shell_center = 2.7;
   test_wedge_map_generation_against_domain_helpers(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
       use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
-      aspect_ratio);
+      aspect_ratio, index_polar_axis);
 }
 
 void test_wedge_map_generation() {


### PR DESCRIPTION
## Proposed changes

The existing Shell allows one to change the `aspect_ratio` (which controls the angular distribution of gridpoints, compressing them toward the equator or poles). This PR allows the user to specify which of the x, y, or z axes to treat as the polar axis for the EquatorialCompression map.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
The Shell constructor has been changed such than an additional argument `index_polar_axis` (additional Option `IndexPolarAxis`) must be passed following the argument `aspect_ratio` (Option `AspectRatio`). The default value is set to `2` (the z axis).
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->