### PR TITLE
Optimize elliptic solver (2): Generalize equal_within_roundoff to Variables, skip an unnecessary subdomain-operator application

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.cpp
@@ -165,7 +165,7 @@ void HalfSpaceMirrorVariables<DataType>::operator()(
               },
               lower_boundary, absolute_tolerance, relative_tolerance);
 
-      if (not equal_within_roundoff(r, 0)) {
+      if (not equal_within_roundoff(r, 0.)) {
         const double strain_rz =
             -prefactor *
             integration(

--- a/src/Utilities/EqualWithinRoundoff.hpp
+++ b/src/Utilities/EqualWithinRoundoff.hpp
@@ -5,16 +5,158 @@
 
 #include <algorithm>
 #include <limits>
+#include <type_traits>
 
+#include "Utilities/Algorithm.hpp"
 #include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/ForceInline.hpp"
+#include "Utilities/TypeTraits/IsIterable.hpp"
+#include "Utilities/TypeTraits/IsMaplike.hpp"
 
-/// \ingroup UtilitiesGroup
-/// Checks if two values `a` and `b` are equal within roundoff,
-/// by comparing `abs(a - b) < (max(abs(a), abs(b)) + scale) * eps`.
+namespace EqualWithinRoundoffImpls {
+/*!
+ * \brief Specialize this class to add support for the `equal_within_roundoff`
+ * function.
+ *
+ * Ensure the `Lhs` and `Rhs` are symmetric. A specialization must implement a
+ * static `apply` function with this signature:
+ *
+ * ```cpp
+ * static bool apply(const Lhs& lhs, const Rhs& rhs, const double eps,
+ *                   const double scale);
+ * ```
+ *
+ * It can be helpful to invoke the `equal_within_roundoff` function for floating
+ * points from within your specialization.
+ */
+template <typename Lhs, typename Rhs, typename = std::nullptr_t>
+struct EqualWithinRoundoffImpl;
+}  // namespace EqualWithinRoundoffImpls
+
+/*!
+ * \ingroup UtilitiesGroup
+ * \brief Checks if two values `lhs` and `rhs` are equal within roundoff, by
+ * comparing `abs(lhs - rhs) < (max(abs(lhs), abs(rhs)) + scale) * eps`.
+ *
+ * The two values can be floating-point numbers, or any types for which
+ * `EqualWithinRoundoffImpls::EqualWithinRoundoffImpl` has been specialized. For
+ * example, a default implementation exists for the case where `lhs`, `rhs`, or
+ * both, are iterable, and compares the values point-wise.
+ */
+template <typename Lhs, typename Rhs>
 constexpr SPECTRE_ALWAYS_INLINE bool equal_within_roundoff(
-    const double a, const double b,
+    const Lhs& lhs, const Rhs& rhs,
     const double eps = std::numeric_limits<double>::epsilon() * 100.0,
     const double scale = 1.0) {
-  return ce_fabs(a - b) < (std::max(ce_fabs(a), ce_fabs(b)) + scale) * eps;
+  return EqualWithinRoundoffImpls::EqualWithinRoundoffImpl<Lhs, Rhs>::apply(
+      lhs, rhs, eps, scale);
 }
+
+/// Specializations of `EqualWithinRoundoffImpl` for custom types, to add
+/// support for the `equal_within_roundoff` function.
+namespace EqualWithinRoundoffImpls {
+
+// Compare two floating points
+template <typename Floating>
+struct EqualWithinRoundoffImpl<Floating, Floating,
+                               Requires<std::is_floating_point_v<Floating>>> {
+  static constexpr SPECTRE_ALWAYS_INLINE bool apply(const Floating& lhs,
+                                                    const Floating& rhs,
+                                                    const double eps,
+                                                    const double scale) {
+    return ce_fabs(lhs - rhs) <=
+           (std::max(ce_fabs(lhs), ce_fabs(rhs)) + scale) * eps;
+  }
+};
+
+// Compare a complex number to a floating point, interpreting the latter as a
+// real number
+template <typename Floating>
+struct EqualWithinRoundoffImpl<std::complex<Floating>, Floating,
+                               Requires<std::is_floating_point_v<Floating>>> {
+  static SPECTRE_ALWAYS_INLINE bool apply(const std::complex<Floating>& lhs,
+                                          const Floating& rhs, const double eps,
+                                          const double scale) {
+    return equal_within_roundoff(lhs.real(), rhs, eps, scale) and
+           equal_within_roundoff(lhs.imag(), 0., eps, scale);
+  }
+};
+
+// Compare a floating point to a complex number, interpreting the former as a
+// real number
+template <typename Floating>
+struct EqualWithinRoundoffImpl<Floating, std::complex<Floating>,
+                               Requires<std::is_floating_point_v<Floating>>> {
+  static SPECTRE_ALWAYS_INLINE bool apply(const std::complex<Floating>& lhs,
+                                          const Floating& rhs, const double eps,
+                                          const double scale) {
+    return equal_within_roundoff(rhs, lhs, eps, scale);
+  }
+};
+
+// Compare two complex numbers
+template <typename Floating>
+struct EqualWithinRoundoffImpl<std::complex<Floating>, std::complex<Floating>,
+                               Requires<std::is_floating_point_v<Floating>>> {
+  static SPECTRE_ALWAYS_INLINE bool apply(const std::complex<Floating>& lhs,
+                                          const std::complex<Floating>& rhs,
+                                          const double eps,
+                                          const double scale) {
+    return equal_within_roundoff(lhs.real(), rhs.real(), eps, scale) and
+           equal_within_roundoff(lhs.imag(), rhs.imag(), eps, scale);
+  }
+};
+
+// Compare an iterable to a floating point
+template <typename Lhs, typename Rhs>
+struct EqualWithinRoundoffImpl<
+    Lhs, Rhs,
+    Requires<tt::is_iterable_v<Lhs> and not tt::is_maplike_v<Lhs> and
+             std::is_floating_point_v<Rhs>>> {
+  static SPECTRE_ALWAYS_INLINE bool apply(const Lhs& lhs, const Rhs& rhs,
+                                          const double eps,
+                                          const double scale) {
+    return alg::all_of(lhs, [&rhs, &eps, &scale](const auto& lhs_element) {
+      return equal_within_roundoff(lhs_element, rhs, eps, scale);
+    });
+  }
+};
+
+// Compare a floating point to an iterable
+template <typename Lhs, typename Rhs>
+struct EqualWithinRoundoffImpl<
+    Lhs, Rhs,
+    Requires<tt::is_iterable_v<Rhs> and not tt::is_maplike_v<Rhs> and
+             std::is_floating_point_v<Lhs>>> {
+  static SPECTRE_ALWAYS_INLINE bool apply(const Lhs& lhs, const Rhs& rhs,
+                                          const double eps,
+                                          const double scale) {
+    return equal_within_roundoff(rhs, lhs, eps, scale);
+  }
+};
+
+// Compare two iterables
+template <typename Lhs, typename Rhs>
+struct EqualWithinRoundoffImpl<
+    Lhs, Rhs,
+    Requires<tt::is_iterable_v<Lhs> and not tt::is_maplike_v<Lhs> and
+             tt::is_iterable_v<Rhs> and not tt::is_maplike_v<Rhs>>> {
+  static bool apply(const Lhs& lhs, const Rhs& rhs, const double eps,
+                    const double scale) {
+    auto lhs_it = lhs.begin();
+    auto rhs_it = rhs.begin();
+    while (lhs_it != lhs.end() and rhs_it != rhs.end()) {
+      if (not equal_within_roundoff(*lhs_it, *rhs_it, eps, scale)) {
+        return false;
+      }
+      ++lhs_it;
+      ++rhs_it;
+    }
+    ASSERT(lhs_it == lhs.end() and rhs_it == rhs.end(),
+           "Can't compare lhs and rhs because they have different lengths.");
+    return true;
+  }
+};
+
+}  // namespace EqualWithinRoundoffImpls

--- a/tests/Unit/Helpers/NumericalAlgorithms/LinearSolver/TestHelpers.hpp
+++ b/tests/Unit/Helpers/NumericalAlgorithms/LinearSolver/TestHelpers.hpp
@@ -19,9 +19,11 @@ namespace TestHelpers::LinearSolver {
 
 struct ApplyMatrix {
   DenseMatrix<double> matrix;
+  mutable size_t invocations = 0;
   void operator()(const gsl::not_null<DenseVector<double>*> result,
                   const DenseVector<double>& operand) const {
     *result = matrix * operand;
+    ++invocations;
   }
 };
 

--- a/tests/Unit/Utilities/Test_EqualWithinRoundoff.cpp
+++ b/tests/Unit/Utilities/Test_EqualWithinRoundoff.cpp
@@ -1,7 +1,15 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <vector>
+
 #include "Utilities/EqualWithinRoundoff.hpp"
+
+static_assert(equal_within_roundoff(1.0, 1.0, 0.0),
+              "Failed testing EqualWithinRoundoff");
 
 static_assert(equal_within_roundoff(1.0, 1.0 - 4.0e-16, 1.0e-15),
               "Failed testing EqualWithinRoundoff");
@@ -10,10 +18,30 @@ static_assert(not equal_within_roundoff(1.0, 1.0 - 4.0e-15, 1.0e-15),
 
 static_assert(equal_within_roundoff(1.0e16, 1.0e16 - 1.0e1, 1.0e-15, 1.0e16),
               "Failed testing EqualWithinRoundoff");
-static_assert(not equal_within_roundoff(1.0e16, 1.0e16 - 1.0e1, 1.0e-15, 1.0),
+static_assert(not equal_within_roundoff(1.0e16, 1.0e16 - 2.0e1, 1.0e-15, 1.0),
               "Failed testing EqualWithinRoundoff");
 
 static_assert(not equal_within_roundoff(1.0, 1.0 - 1.0e-8, 1.0e-8, 0.0),
               "Failed testing EqualWithinRoundoff");
 static_assert(equal_within_roundoff(1.0, 1.0 - 1.0e-8, 1.0e-8, 1.0),
               "Failed testing EqualWithinRoundoff");
+
+SPECTRE_TEST_CASE("Unit.Utilities.EqualWithinRoundoff", "[Unit][Utilities]") {
+  CHECK(equal_within_roundoff(
+      std::vector<double>{1.0, 1.0 - 4.0e-16, 1.0 + 5.0e-15}, 1.0));
+  CHECK(equal_within_roundoff(
+      1.0, std::vector<double>{1.0, 1.0 - 4.0e-16, 1.0 + 5.0e-15}));
+  CHECK(equal_within_roundoff(
+      std::array<double, 3>{{1.0, 1.0 - 4.0e-16, 1.0 + 5.0e-15}}, 1.0));
+  CHECK(equal_within_roundoff(
+      1.0, std::array<double, 3>{{1.0, 1.0 - 4.0e-16, 1.0 + 5.0e-15}}));
+  CHECK(equal_within_roundoff(
+      std::vector<double>{1.0, 1.0 - 4.0e-16, 1.0 + 5.0e-15},
+      std::array<double, 3>{{1.0 - 4.0e-16, 1.0 + 5.0e-15, 1.0}}));
+  CHECK(equal_within_roundoff(
+      std::vector<double>{1.0, 1.0 - 4.0e-10, 1.0 + 5.0e-10},
+      std::array<double, 3>{{1.0 - 4.0e-10, 1.0 + 5.0e-10, 1.0}}, 1.e-9));
+  CHECK_FALSE(equal_within_roundoff(
+      std::vector<double>{1.0, 1.0 - 4.0e-10, 1.0 + 5.0e-10},
+      std::array<double, 3>{{1.0 - 4.0e-10, 1.0 + 5.0e-10, 1.0}}, 1.e-11));
+}


### PR DESCRIPTION
## Proposed changes

Applying the subdomain operator is expensive, so skipping it when the data is zero speeds up the solve.

<s>To make `all::all_of` work for data in `Variables` I add support for iterating over the data to `Variables`.</s>
I added support for `equal_within_roundoff` to `Variables`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
