### PR TITLE
Remove uses of TimeStepId in interpolation

### DIFF
--- a/src/ParallelAlgorithms/Interpolation/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Interpolation/CMakeLists.txt
@@ -45,7 +45,6 @@ target_link_libraries(
   Options
   Parallel
   Spectral
-  Time
   Utilities
   INTERFACE
   Cce

--- a/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.cpp
+++ b/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.cpp
@@ -3,15 +3,7 @@
 
 #include "ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp"
 
-#include "Time/TimeStepId.hpp"
-
 namespace intrp::InterpolationTarget_detail {
 double get_temporal_id_value(const double time) { return time; }
-double get_temporal_id_value(const TimeStepId& time_id) {
-  return time_id.substep_time().value();
-}
 double evaluate_temporal_id_for_expiration(const double time) { return time; }
-double evaluate_temporal_id_for_expiration(const TimeStepId& time_id) {
-  return time_id.step_time().value();
-}
 }  // namespace intrp::InterpolationTarget_detail

--- a/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
+++ b/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
@@ -63,9 +63,7 @@ namespace intrp {
 
 namespace InterpolationTarget_detail {
 double get_temporal_id_value(double time);
-double get_temporal_id_value(const TimeStepId& time_id);
 double evaluate_temporal_id_for_expiration(double time);
-double evaluate_temporal_id_for_expiration(const TimeStepId& time_id);
 
 // apply_callback accomplishes the overload for the
 // two signatures of callback functions.

--- a/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolateOnElementTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolateOnElementTestHelpers.hpp
@@ -26,10 +26,7 @@
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InterpolationTargetVarsFromElement.hpp"
-#include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
-#include "Time/Time.hpp"
-#include "Time/TimeStepId.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -185,8 +182,7 @@ void test_interpolate_on_element(
   const auto domain_creator =
       domain::creators::Shell(0.9, 2.9, 2, {{7, 7}}, false);
   const auto domain = domain_creator.create_domain();
-  Slab slab(0.0, 1.0);
-  TimeStepId temporal_id(true, 0, Time(slab, Rational(11, 15)));
+  double temporal_id = 11.0 / 15.0;
 
   // Create Element_ids.
   std::vector<ElementId<3>> element_ids{};
@@ -232,24 +228,11 @@ void test_interpolate_on_element(
 
   static_assert(
       std::is_same_v<typename metavars::InterpolationTargetA::temporal_id::type,
-                     double> or
-          std::is_same_v<
-              typename metavars::InterpolationTargetA::temporal_id::type,
-              TimeStepId>,
+                     double>,
       "Unsupported temporal_id type");
-  if constexpr (std::is_same_v<
-                    typename metavars::InterpolationTargetA::temporal_id::type,
-                    double>) {
-    initialize_elements_and_queue_simple_actions(
-        domain_creator, domain, element_ids, interp_point_info, runner,
-        temporal_id.substep_time().value());
-  } else if constexpr (std::is_same_v<typename metavars::InterpolationTargetA::
-                                          temporal_id::type,
-                                      TimeStepId>) {
-    initialize_elements_and_queue_simple_actions(domain_creator, domain,
-                                                 element_ids, interp_point_info,
-                                                 runner, temporal_id);
-  }
+  initialize_elements_and_queue_simple_actions(
+      domain_creator, domain, element_ids, interp_point_info, runner,
+      temporal_id);
 
   // Only some of the actions/events just invoked on elements (those elements
   // which contain target points) will queue a simple action on the

--- a/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
@@ -21,9 +21,6 @@
 #include "ParallelAlgorithms/Interpolation/Actions/SendPointsToInterpolator.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolatedVars.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp"
-#include "Time/Slab.hpp"
-#include "Time/Time.hpp"
-#include "Time/TimeStepId.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/Requires.hpp"
@@ -176,26 +173,15 @@ void test_interpolation_target(
   }
   ActionTesting::set_phase(make_not_null(&runner), metavars::Phase::Testing);
 
-  Slab slab(0.0, 1.0);
-  TimeStepId temporal_id(true, 0, Time(slab, 0));
+  double temporal_id = 0.0;
   static_assert(
       std::is_same_v<typename metavars::InterpolationTargetA::temporal_id::type,
-                     double> or
-          std::is_same_v<
-              typename metavars::InterpolationTargetA::temporal_id::type,
-              TimeStepId>,
+                     double>,
       "Unsupported temporal_id type");
-  if constexpr (std::is_same_v<temporal_id_type, double>) {
-    ActionTesting::simple_action<target_component,
-                                 intrp::Actions::SendPointsToInterpolator<
-                                     typename metavars::InterpolationTargetA>>(
-        make_not_null(&runner), 0, temporal_id.substep_time().value());
-  } else if constexpr (std::is_same_v<temporal_id_type, TimeStepId>) {
-    ActionTesting::simple_action<target_component,
-                                 intrp::Actions::SendPointsToInterpolator<
-                                     typename metavars::InterpolationTargetA>>(
-        make_not_null(&runner), 0, temporal_id);
-  }
+  ActionTesting::simple_action<target_component,
+                               intrp::Actions::SendPointsToInterpolator<
+                                   typename metavars::InterpolationTargetA>>(
+      make_not_null(&runner), 0, temporal_id);
 
   // This should not have changed.
   CHECK(ActionTesting::get_databox_tag<
@@ -242,7 +228,7 @@ void test_interpolation_target(
   }
 
   // Call again at a different temporal_id
-  TimeStepId new_temporal_id(true, 0, Time(slab, 1));
+  double new_temporal_id = 1.0;
   ActionTesting::simple_action<target_component,
                                intrp::Actions::SendPointsToInterpolator<
                                    typename metavars::InterpolationTargetA>>(

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ElementReceiveInterpPoints.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ElementReceiveInterpPoints.cpp
@@ -76,7 +76,7 @@ struct mock_interpolation_target {
 
 struct MockMetavariables {
   struct InterpolationTargetA {
-    using temporal_id = ::Tags::TimeStepId;
+    using temporal_id = ::Tags::Time;
     using vars_to_interpolate_to_target = tmpl::list<Tags::TestSolution>;
     using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
@@ -85,7 +85,7 @@ struct MockMetavariables {
     using interpolating_component = mock_element<Metavariables>;
   };
   struct InterpolationTargetB {
-    using temporal_id = ::Tags::TimeStepId;
+    using temporal_id = ::Tags::Time;
     using vars_to_interpolate_to_target = tmpl::list<Tags::TestSolution>;
     using compute_items_on_target = tmpl::list<>;
     using compute_target_points =

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
@@ -45,7 +45,7 @@ struct mock_interpolation_target {
 
 struct Metavariables {
   struct InterpolationTargetA {
-    using temporal_id = ::Tags::TimeStepId;
+    using temporal_id = ::Tags::Time;
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
     using compute_items_on_target = tmpl::list<>;

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InitializeInterpolator.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InitializeInterpolator.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <unordered_map>
 
+#include "DataStructures/DataBox/Tag.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
@@ -25,6 +26,10 @@ class DataVector;
 
 namespace {
 
+struct OtherId : db::SimpleTag {
+  using type = double;
+};
+
 template <typename Metavariables>
 struct mock_interpolator {
   using metavariables = Metavariables;
@@ -36,14 +41,14 @@ struct mock_interpolator {
                  intrp::Actions::InitializeInterpolator<
                      tmpl::list<intrp::Tags::VolumeVarsInfo<Metavariables,
                                                             ::Tags::Time>,
-                                intrp::Tags::VolumeVarsInfo<
-                                    Metavariables, ::Tags::TimeStepId>>,
+                                intrp::Tags::VolumeVarsInfo<Metavariables,
+                                                            OtherId>>,
                      intrp::Tags::InterpolatedVarsHolders<Metavariables>>>>>;
 };
 
 struct Metavariables {
   struct InterpolatorTargetA {
-    using temporal_id = ::Tags::TimeStepId;
+    using temporal_id = OtherId;
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
   };
@@ -78,8 +83,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.Initialize",
             .empty());
   CHECK(ActionTesting::get_databox_tag<
             component,
-            ::intrp::Tags::VolumeVarsInfo<metavars, ::Tags::TimeStepId>>(runner,
-                                                                         0)
+            ::intrp::Tags::VolumeVarsInfo<metavars, OtherId>>(runner, 0)
             .empty());
 
   const auto& holders = ActionTesting::get_databox_tag<

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolateWithoutInterpComponent.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolateWithoutInterpComponent.cpp
@@ -20,7 +20,6 @@
 #include "ParallelAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp"
 #include "ParallelAlgorithms/Interpolation/Tags.hpp"
 #include "Time/Tags.hpp"
-#include "Time/TimeStepId.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -90,7 +89,7 @@ struct initialize_elements_and_queue_simple_actions {
 template <bool HaveComputeItemsOnSource>
 struct MockMetavariables {
   struct InterpolationTargetA {
-    using temporal_id = ::Tags::TimeStepId;
+    using temporal_id = ::Tags::Time;
     using vars_to_interpolate_to_target = tmpl::list<tmpl::conditional_t<
         HaveComputeItemsOnSource,
         InterpolateOnElementTestHelpers::Tags::MultiplyByTwo,

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetApparentHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetApparentHorizon.cpp
@@ -32,7 +32,7 @@
 namespace {
 struct MockMetavariables {
   struct InterpolationTargetA {
-    using temporal_id = ::Tags::TimeStepId;
+    using temporal_id = ::Tags::Time;
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
     using compute_items_on_target = tmpl::list<>;

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
@@ -29,7 +29,7 @@
 namespace {
 struct MockMetavariables {
   struct InterpolationTargetA {
-    using temporal_id = ::Tags::TimeStepId;
+    using temporal_id = ::Tags::Time;
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
     using compute_items_on_target = tmpl::list<>;

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
@@ -25,7 +25,7 @@
 namespace {
 struct MockMetavariables {
   struct InterpolationTargetA {
-    using temporal_id = ::Tags::TimeStepId;
+    using temporal_id = ::Tags::Time;
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
     using compute_items_on_target = tmpl::list<>;

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetSpecifiedPoints.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetSpecifiedPoints.cpp
@@ -28,7 +28,7 @@ namespace {
 template <size_t Dim>
 struct MockMetavariables {
   struct InterpolationTargetA {
-    using temporal_id = ::Tags::TimeStepId;
+    using temporal_id = ::Tags::Time;
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
     using compute_items_on_target = tmpl::list<>;

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetVarsFromElement.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetVarsFromElement.cpp
@@ -18,9 +18,7 @@
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InitializeInterpolationTarget.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InterpolationTargetVarsFromElement.hpp"
-#include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
-#include "Time/Time.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/Rational.hpp"
 
@@ -79,9 +77,8 @@ struct MockPostInterpolationCallback {
       const typename Metavariables::InterpolationTargetA::temporal_id::type&
           temporal_id) {
     // This callback simply checks that the points are as expected.
-    Slab slab(0.0, 1.0);
-    const TimeStepId first_temporal_id(true, 0, Time(slab, Rational(13, 15)));
-    const TimeStepId second_temporal_id(true, 0, Time(slab, Rational(14, 15)));
+    const double first_temporal_id = 13.0 / 15.0;
+    const double second_temporal_id = 14.0 / 15.0;
     if (temporal_id == first_temporal_id) {
       const Scalar<DataVector> expected{
           DataVector{{0.0, 1.0, 4.0, 9.0, 16.0, 25.0, 36.0, 49.0, 64.0, 81.0}}};
@@ -117,7 +114,7 @@ struct mock_interpolation_target {
 
 struct MockMetavariables {
   struct InterpolationTargetA {
-    using temporal_id = ::Tags::TimeStepId;
+    using temporal_id = ::Tags::Time;
     using vars_to_interpolate_to_target = tmpl::list<Tags::TestSolution>;
     using compute_items_on_target = tmpl::list<Tags::SquareCompute>;
     using compute_target_points = MockComputeTargetPoints;
@@ -142,9 +139,8 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.TargetVarsFromElement",
       mock_interpolation_target<metavars,
                                 typename metavars::InterpolationTargetA>;
 
-  Slab slab(0.0, 1.0);
-  const TimeStepId first_temporal_id(true, 0, Time(slab, Rational(13, 15)));
-  const TimeStepId second_temporal_id(true, 0, Time(slab, Rational(14, 15)));
+  const double first_temporal_id = 13.0 / 15.0;
+  const double second_temporal_id = 14.0 / 15.0;
   const auto domain_creator =
       domain::creators::Shell(0.9, 4.9, 1, {{5, 5}}, false);
 

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
@@ -27,7 +27,7 @@
 namespace {
 struct MockMetavariables {
   struct InterpolationTargetA {
-    using temporal_id = ::Tags::TimeStepId;
+    using temporal_id = ::Tags::Time;
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
     using compute_items_on_target = tmpl::list<>;

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
@@ -30,10 +30,7 @@
 #include "ParallelAlgorithms/Interpolation/Actions/TryToInterpolate.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolatedVars.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
-#include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
-#include "Time/Time.hpp"
-#include "Time/TimeStepId.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Rational.hpp"
 #include "Utilities/Requires.hpp"
@@ -137,7 +134,7 @@ struct mock_interpolator {
           tmpl::list<::Actions::SetupDataBox,
                      ::intrp::Actions::InitializeInterpolator<
                          intrp::Tags::VolumeVarsInfo<Metavariables,
-                                                     ::Tags::TimeStepId>,
+                                                     ::Tags::Time>,
                          intrp::Tags::InterpolatedVarsHolders<Metavariables>>>>,
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Testing, tmpl::list<>>>;
@@ -146,7 +143,7 @@ struct mock_interpolator {
 
 struct Metavariables {
   struct InterpolationTargetA {
-    using temporal_id = ::Tags::TimeStepId;
+    using temporal_id = ::Tags::Time;
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
     using compute_items_on_source = tmpl::list<>;
@@ -206,8 +203,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ReceivePoints",
     }
     return block_logical_coordinates(domain, points);
   }();
-  Slab slab(0.0, 1.0);
-  TimeStepId temporal_id(true, 0, Time(slab, Rational(11, 15)));
+  double temporal_id = 11.0 / 15.0;
 
   runner.simple_action<
       mock_interpolator<metavars>,

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
@@ -44,10 +44,7 @@
 #include "ParallelAlgorithms/Interpolation/Actions/TryToInterpolate.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolatedVars.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
-#include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
-#include "Time/Time.hpp"
-#include "Time/TimeStepId.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
@@ -152,8 +149,7 @@ struct MockInterpolationTargetReceiveVars {
     // indeed called.  Put some unusual temporal_id into Tags::TemporalIds.
     // This is not the usual usage of Tags::TemporalIds; this is done just
     // for the test.
-    Slab slab(0.0, 1.0);
-    TimeStepId strange_temporal_id(true, 0, Time(slab, Rational(111, 135)));
+    double strange_temporal_id = 111.0 / 135.0;
     db::mutate<intrp::Tags::TemporalIds<TemporalId>>(
         make_not_null(&box),
         [&strange_temporal_id](
@@ -198,7 +194,7 @@ struct mock_interpolator {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
   using simple_tags = typename intrp::Actions::InitializeInterpolator<
-      intrp::Tags::VolumeVarsInfo<Metavariables, ::Tags::TimeStepId>,
+      intrp::Tags::VolumeVarsInfo<Metavariables, ::Tags::Time>,
       intrp::Tags::InterpolatedVarsHolders<Metavariables>>::simple_tags;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
@@ -213,7 +209,7 @@ struct mock_interpolator {
 
 struct MockMetavariables {
   struct InterpolationTargetA {
-    using temporal_id = ::Tags::TimeStepId;
+    using temporal_id = ::Tags::Time;
     using vars_to_interpolate_to_target = tmpl::list<Tags::Square>;
     using compute_vars_to_interpolate = ComputeSquare;
     using compute_items_on_target = tmpl::list<>;
@@ -246,8 +242,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ReceiveVolumeData",
   const auto domain_creator =
       domain::creators::Shell(0.9, 4.9, 1, {{7, 7}}, false);
   const auto domain = domain_creator.create_domain();
-  Slab slab(0.0, 1.0);
-  TimeStepId temporal_id(true, 0, Time(slab, Rational(11, 15)));
+  double temporal_id = 11.0 / 15.0;
   auto vars_holders = [&domain, &temporal_id]() {
     const size_t n_pts = 15;
     tnsr::I<DataVector, 3, Frame::Inertial> points(n_pts);
@@ -349,8 +344,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ReceiveVolumeData",
   CHECK(ActionTesting::get_databox_tag<
             target_component, intrp::Tags::TemporalIds<temporal_id_type>>(
             runner, 0)
-            .front() ==
-        TimeStepId(true, 0, Time(Slab(0.0, 1.0), Rational(111, 135))));
+            .front() == 111.0 / 135.0);
 
   // No more queued simple actions.
   CHECK(runner.is_simple_action_queue_empty<target_component>(0));

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorRegisterElement.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorRegisterElement.cpp
@@ -36,13 +36,13 @@ struct mock_interpolator {
           tmpl::list<Actions::SetupDataBox,
                      ::intrp::Actions::InitializeInterpolator<
                          intrp::Tags::VolumeVarsInfo<Metavariables,
-                                                     ::Tags::TimeStepId>,
+                                                     ::Tags::Time>,
                          intrp::Tags::InterpolatedVarsHolders<Metavariables>>>>,
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Registration, tmpl::list<>>>;
   using initial_databox = db::compute_databox_type<
       typename ::intrp::Actions::InitializeInterpolator<
-          intrp::Tags::VolumeVarsInfo<Metavariables, ::Tags::TimeStepId>,
+          intrp::Tags::VolumeVarsInfo<Metavariables, ::Tags::Time>,
           intrp::Tags::InterpolatedVarsHolders<Metavariables>>::
           return_tag_list>;
   using component_being_mocked = intrp::Interpolator<Metavariables>;
@@ -65,7 +65,7 @@ struct mock_element {
 
 struct MockMetavariables {
   struct InterpolatorTargetA {
-    using temporal_id = ::Tags::TimeStepId;
+    using temporal_id = ::Tags::Time;
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
     using compute_items_on_target = tmpl::list<>;


### PR DESCRIPTION
TimeStepId is not a global identifier, so it cannot be used as an ID
for the interpolator component.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
