### PR TITLE
Add CCZ4 function for trace-free part of extrinsic curvature, related tags

### DIFF
--- a/src/Evolution/Systems/Ccz4/ATilde.cpp
+++ b/src/Evolution/Systems/Ccz4/ATilde.cpp
@@ -1,0 +1,76 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Ccz4/ATilde.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Ccz4 {
+template <size_t Dim, typename Frame, typename DataType>
+void a_tilde(const gsl::not_null<tnsr::ii<DataType, Dim, Frame>*> result,
+             const gsl::not_null<Scalar<DataType>*> buffer,
+             const Scalar<DataType>& conformal_factor_squared,
+             const tnsr::ii<DataType, Dim, Frame>& spatial_metric,
+             const tnsr::ii<DataType, Dim, Frame>& extrinsic_curvature,
+             const Scalar<DataType>& trace_extrinsic_curvature) {
+  destructive_resize_components(result,
+                                get_size(get(conformal_factor_squared)));
+  destructive_resize_components(buffer,
+                                get_size(get(conformal_factor_squared)));
+
+  ::TensorExpressions::evaluate(buffer, trace_extrinsic_curvature() / 3.0);
+  ::TensorExpressions::evaluate<ti_i, ti_j>(
+      result,
+      conformal_factor_squared() * (extrinsic_curvature(ti_i, ti_j) -
+                                    (*buffer)() * spatial_metric(ti_i, ti_j)));
+}
+
+template <size_t Dim, typename Frame, typename DataType>
+tnsr::ii<DataType, Dim, Frame> a_tilde(
+    const Scalar<DataType>& conformal_factor_squared,
+    const tnsr::ii<DataType, Dim, Frame>& spatial_metric,
+    const tnsr::ii<DataType, Dim, Frame>& extrinsic_curvature,
+    const Scalar<DataType>& trace_extrinsic_curvature) {
+  tnsr::ii<DataType, Dim, Frame> result{};
+  Scalar<DataType> buffer{};
+  a_tilde(make_not_null(&result), make_not_null(&buffer),
+          conformal_factor_squared, spatial_metric, extrinsic_curvature,
+          trace_extrinsic_curvature);
+  return result;
+}
+}  // namespace Ccz4
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                               \
+  template void Ccz4::a_tilde(                                             \
+      const gsl::not_null<tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>*>  \
+          result,                                                          \
+      const gsl::not_null<Scalar<DTYPE(data)>*> buffer,                    \
+      const Scalar<DTYPE(data)>& conformal_factor_squared,                 \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& spatial_metric, \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&                 \
+          extrinsic_curvature,                                             \
+      const Scalar<DTYPE(data)>& trace_extrinsic_curvature);               \
+  template tnsr::ii<DTYPE(data), DIM(data), FRAME(data)> Ccz4::a_tilde(    \
+      const Scalar<DTYPE(data)>& conformal_factor_squared,                 \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& spatial_metric, \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&                 \
+          extrinsic_curvature,                                             \
+      const Scalar<DTYPE(data)>& trace_extrinsic_curvature);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial),
+                        (double, DataVector))
+
+#undef INSTANTIATE
+#undef DTYPE
+#undef FRAME
+#undef DIM

--- a/src/Evolution/Systems/Ccz4/ATilde.hpp
+++ b/src/Evolution/Systems/Ccz4/ATilde.hpp
@@ -1,0 +1,43 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Ccz4 {
+/// @{
+/*!
+ * \brief Computes the trace-free part of the extrinsic curvature
+ *
+ * \details Computes the trace-free part as:
+ *
+ * \f{align}
+ *     \tilde A_{ij} &= \phi^2 \left(K_{ij} - \frac{1}{3} K \gamma_{ij}\right)
+ * \f}
+ *
+ * where \f$\phi^2\f$ is the square of the conformal factor defined by
+ * `Ccz4::Tags::ConformalFactorSquared`, \f$\gamma_{ij}\f$ is the spatial metric
+ * defined by `gr::Tags::SpatialMetric`, \f$K_{ij}\f$ is the extrinsic curvature
+ * defined by `gr::Tags::ExtrinsicCurvature`, and \f$K\f$ is the trace of the
+ * extrinsic curvature defined by `gr::Tags::TraceExtrinsicCurvature`.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+void a_tilde(const gsl::not_null<tnsr::ii<DataType, Dim, Frame>*> result,
+             const gsl::not_null<Scalar<DataType>*> buffer,
+             const Scalar<DataType>& conformal_factor_squared,
+             const tnsr::ii<DataType, Dim, Frame>& spatial_metric,
+             const tnsr::ii<DataType, Dim, Frame>& extrinsic_curvature,
+             const Scalar<DataType>& trace_extrinsic_curvature);
+
+template <size_t Dim, typename Frame, typename DataType>
+tnsr::ii<DataType, Dim, Frame> a_tilde(
+    const Scalar<DataType>& conformal_factor_squared,
+    const tnsr::ii<DataType, Dim, Frame>& spatial_metric,
+    const tnsr::ii<DataType, Dim, Frame>& extrinsic_curvature,
+    const Scalar<DataType>& trace_extrinsic_curvature);
+/// @}
+}  // namespace Ccz4

--- a/src/Evolution/Systems/Ccz4/CMakeLists.txt
+++ b/src/Evolution/Systems/Ccz4/CMakeLists.txt
@@ -8,6 +8,7 @@ add_spectre_library(${LIBRARY})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  ATilde.cpp
   Christoffel.cpp
   DerivChristoffel.cpp
   DerivLapse.cpp
@@ -17,6 +18,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  ATilde.hpp
   Christoffel.hpp
   DerivChristoffel.hpp
   DerivLapse.hpp

--- a/src/Evolution/Systems/Ccz4/CMakeLists.txt
+++ b/src/Evolution/Systems/Ccz4/CMakeLists.txt
@@ -20,6 +20,7 @@ spectre_target_headers(
   Christoffel.hpp
   DerivChristoffel.hpp
   DerivLapse.hpp
+  System.hpp
   Tags.hpp
   TagsDeclarations.hpp
   )

--- a/src/Evolution/Systems/Ccz4/Christoffel.hpp
+++ b/src/Evolution/Systems/Ccz4/Christoffel.hpp
@@ -11,7 +11,6 @@
 namespace Ccz4 {
 /// @{
 /*!
- * \ingroup GeneralRelativityGroup
  * \brief Computes the conformal spatial christoffel symbols of the second kind.
  *
  * \details Computes the christoffel symbols as:
@@ -37,7 +36,6 @@ tnsr::Ijj<DataType, Dim, Frame> conformal_christoffel_second_kind(
 
 /// @{
 /*!
- * \ingroup GeneralRelativityGroup
  * \brief Computes the spatial christoffel symbols of the second kind.
  *
  * \details Computes the christoffel symbols as:

--- a/src/Evolution/Systems/Ccz4/DerivChristoffel.hpp
+++ b/src/Evolution/Systems/Ccz4/DerivChristoffel.hpp
@@ -11,7 +11,6 @@
 namespace Ccz4 {
 /// @{
 /*!
- * \ingroup GeneralRelativityGroup
  * \brief Computes the spatial derivative of the conformal spatial christoffel
  * symbols of the second kind
  *

--- a/src/Evolution/Systems/Ccz4/DerivLapse.hpp
+++ b/src/Evolution/Systems/Ccz4/DerivLapse.hpp
@@ -11,7 +11,6 @@
 namespace Ccz4 {
 /// @{
 /*!
- * \ingroup GeneralRelativityGroup
  * \brief Computes the gradient of the gradient of the lapse.
  *
  * \details Computes the gradient of the gradient as:

--- a/src/Evolution/Systems/Ccz4/System.hpp
+++ b/src/Evolution/Systems/Ccz4/System.hpp
@@ -1,0 +1,10 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+/*!
+ * \ingroup EvolutionSystemsGroup
+ * \brief Items related to evolving the first-order CCZ4 system.
+ */
+namespace Ccz4 {}

--- a/src/Evolution/Systems/Ccz4/Tags.hpp
+++ b/src/Evolution/Systems/Ccz4/Tags.hpp
@@ -72,6 +72,25 @@ struct ATilde : db::SimpleTag {
 };
 
 /*!
+ * \brief The trace of the trace-free part of the extrinsic curvature
+ *
+ * \details We define:
+ *
+ * \f{align}
+ *     tr\tilde{A} &= \tilde{\gamma}^{ij} \tilde{A}_{ij}
+ * \f}
+ *
+ * where \f$\tilde{\gamma}^{ij}\f$ is the inverse conformal spatial metric
+ * defined by `Ccz4::Tags::InverseConformalMetric` and \f$\tilde{A}_{ij}\f$ is
+ * the trace-free part of the extrinsic curvature defined by
+ * `Ccz4::Tags::ATilde`.
+ */
+template <typename DataType>
+struct TraceATilde : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+/*!
  * \brief The natural log of the lapse
  */
 template <typename DataType>

--- a/src/Evolution/Systems/Ccz4/Tags.hpp
+++ b/src/Evolution/Systems/Ccz4/Tags.hpp
@@ -258,7 +258,7 @@ struct DerivContractedConformalChristoffelSecondKind : db::SimpleTag {
 namespace OptionTags {
 /*!
  * \ingroup OptionGroupsGroup
- * Groups option tags related to the Ccz4 evolution system.
+ * Groups option tags related to the CCZ4 evolution system.
  */
 struct Group {
   static std::string name() { return "Ccz4"; }

--- a/src/Evolution/Systems/Ccz4/Tags.hpp
+++ b/src/Evolution/Systems/Ccz4/Tags.hpp
@@ -93,25 +93,6 @@ struct FieldD : db::SimpleTag {
 };
 
 /*!
- * \brief Identity which is analytically negative one half the spatial
- * derivative of the inverse conformal spatial metric
- *
- * \details We define:
- * \f{align}
- *     D_k{}^{ij} &=
- *         \tilde{\gamma}^{in} \tilde{\gamma}^{mj} D_{knm} =
- *         -\frac{1}{2} \partial_k \tilde{\gamma}^{ij}
- * \f}
- * where \f$\tilde{\gamma}^{ij}\f$ and \f$D_{ijk}\f$ are the inverse conformal
- * spatial metric and the CCZ4 auxiliary variable defined by
- * `Ccz4::Tags::FieldD`, respectively.
- */
-template <size_t Dim, typename Frame, typename DataType>
-struct FieldDUp : db::SimpleTag {
-  using type = tnsr::iJJ<DataType, Dim, Frame>;
-};
-
-/*!
  * \brief The natural log of the conformal factor
  */
 template <typename DataType>
@@ -132,6 +113,25 @@ struct FieldP : db::SimpleTag {
 };
 
 /*!
+ * \brief Identity which is analytically negative one half the spatial
+ * derivative of the inverse conformal spatial metric
+ *
+ * \details We define:
+ * \f{align}
+ *     D_k{}^{ij} &=
+ *         \tilde{\gamma}^{in} \tilde{\gamma}^{mj} D_{knm} =
+ *         -\frac{1}{2} \partial_k \tilde{\gamma}^{ij}
+ * \f}
+ * where \f$\tilde{\gamma}^{ij}\f$ and \f$D_{ijk}\f$ are the inverse conformal
+ * spatial metric and the CCZ4 auxiliary variable defined by
+ * `Ccz4::Tags::FieldD`, respectively.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct FieldDUp : db::SimpleTag {
+  using type = tnsr::iJJ<DataType, Dim, Frame>;
+};
+
+/*!
  * \brief The conformal spatial christoffel symbols of the second kind
  *
  * \details We define:
@@ -145,30 +145,6 @@ struct FieldP : db::SimpleTag {
  */
 template <size_t Dim, typename Frame, typename DataType>
 struct ConformalChristoffelSecondKind : db::SimpleTag {
-  using type = tnsr::Ijj<DataType, Dim, Frame>;
-};
-
-/*!
- * \brief The spatial christoffel symbols of the second kind
- *
- * \details We define:
- * \details Computes the christoffel symbols as:
- * \f{align}
- *     \Gamma^k_{ij} &= \tilde{\Gamma}^k_{ij} -
- *         \tilde{\gamma}^{kl} (\tilde{\gamma}_{jl} P_i +
- *                              \tilde{\gamma}_{il} P_j -
- *                              \tilde{\gamma}_{ij} P_l)
- * \f}
- * where \f$\tilde{\gamma}^{ij}\f$, \f$\tilde{\gamma}_{ij}\f$,
- * \f$\tilde{\Gamma}^k_{ij}\f$, and \f$P_i\f$ are the conformal spatial metric,
- * the inverse conformal spatial metric, the conformal spatial christoffel
- * symbols of the second kind, and the CCZ4 auxiliary variable defined by
- * `Ccz4::Tags::ConformalMetric`, `Ccz4::Tags::InverseConformalMetric`,
- * `Ccz4::Tags::ConformalChristoffelSecondKind`, and `Ccz4::Tags::FieldP`,
- * respectively.
- */
-template <size_t Dim, typename Frame, typename DataType>
-struct ChristoffelSecondKind : db::SimpleTag {
   using type = tnsr::Ijj<DataType, Dim, Frame>;
 };
 
@@ -192,6 +168,29 @@ struct ChristoffelSecondKind : db::SimpleTag {
 template <size_t Dim, typename Frame, typename DataType>
 struct DerivConformalChristoffelSecondKind : db::SimpleTag {
   using type = tnsr::iJkk<DataType, Dim, Frame>;
+};
+
+/*!
+ * \brief The spatial christoffel symbols of the second kind
+ *
+ * \details We define:
+ * \f{align}
+ *     \Gamma^k_{ij} &= \tilde{\Gamma}^k_{ij} -
+ *         \tilde{\gamma}^{kl} (\tilde{\gamma}_{jl} P_i +
+ *                              \tilde{\gamma}_{il} P_j -
+ *                              \tilde{\gamma}_{ij} P_l)
+ * \f}
+ * where \f$\tilde{\gamma}^{ij}\f$, \f$\tilde{\gamma}_{ij}\f$,
+ * \f$\tilde{\Gamma}^k_{ij}\f$, and \f$P_i\f$ are the conformal spatial metric,
+ * the inverse conformal spatial metric, the conformal spatial christoffel
+ * symbols of the second kind, and the CCZ4 auxiliary variable defined by
+ * `Ccz4::Tags::ConformalMetric`, `Ccz4::Tags::InverseConformalMetric`,
+ * `Ccz4::Tags::ConformalChristoffelSecondKind`, and `Ccz4::Tags::FieldP`,
+ * respectively.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct ChristoffelSecondKind : db::SimpleTag {
+  using type = tnsr::Ijj<DataType, Dim, Frame>;
 };
 
 /*!

--- a/src/Evolution/Systems/Ccz4/Tags.hpp
+++ b/src/Evolution/Systems/Ccz4/Tags.hpp
@@ -28,6 +28,17 @@ struct ConformalFactor : db::SimpleTag {
 };
 
 /*!
+ * \brief The square of the conformal factor that rescales the spatial metric
+ *
+ * \details If \f$\gamma_{ij}\f$ is the spatial metric, then we define
+ * \f$\phi^2 = (det(\gamma_{ij}))^{-1/3}\f$.
+ */
+template <typename DataType>
+struct ConformalFactorSquared : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+/*!
  * \brief The conformally scaled spatial metric
  *
  * \details If \f$\phi\f$ is the conformal factor and \f$\gamma_{ij}\f$ is the
@@ -49,6 +60,16 @@ template <size_t Dim, typename Frame, typename DataType>
 using InverseConformalMetric =
     gr::Tags::Conformal<gr::Tags::InverseSpatialMetric<Dim, Frame, DataType>,
                         -2>;
+
+/*!
+ * \brief The trace-free part of the extrinsic curvature
+ *
+ * \details See `Ccz4::a_tilde()` for details.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct ATilde : db::SimpleTag {
+  using type = tnsr::ii<DataType, Dim, Frame>;
+};
 
 /*!
  * \brief The natural log of the lapse

--- a/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
@@ -15,6 +15,11 @@ namespace Tags {
 template <typename DataType = DataVector>
 struct ConformalFactor;
 template <typename DataType = DataVector>
+struct ConformalFactorSquared;
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
+struct ATilde;
+template <typename DataType = DataVector>
 struct LogLapse;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>

--- a/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
@@ -25,9 +25,6 @@ struct FieldB;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
 struct FieldD;
-template <size_t Dim, typename Frame = Frame::Inertial,
-          typename DataType = DataVector>
-struct FieldDUp;
 template <typename DataType = DataVector>
 struct LogConformalFactor;
 template <size_t Dim, typename Frame = Frame::Inertial,
@@ -35,13 +32,16 @@ template <size_t Dim, typename Frame = Frame::Inertial,
 struct FieldP;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
+struct FieldDUp;
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
 struct ConformalChristoffelSecondKind;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
-struct ChristoffelSecondKind;
+struct DerivConformalChristoffelSecondKind;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
-struct DerivConformalChristoffelSecondKind;
+struct ChristoffelSecondKind;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
 struct GradGradLapse;

--- a/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
@@ -55,7 +55,7 @@ template <size_t Dim, typename Frame = Frame::Inertial,
 struct DerivContractedConformalChristoffelSecondKind;
 }  // namespace Tags
 
-/// \brief Input option tags for the generalized harmonic evolution system
+/// \brief Input option tags for the CCZ4 evolution system
 namespace OptionTags {
 struct Group;
 }  // namespace OptionTags

--- a/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
@@ -20,6 +20,8 @@ template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
 struct ATilde;
 template <typename DataType = DataVector>
+struct TraceATilde;
+template <typename DataType = DataVector>
 struct LogLapse;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>

--- a/tests/Unit/Evolution/Systems/Ccz4/ATilde.py
+++ b/tests/Unit/Evolution/Systems/Ccz4/ATilde.py
@@ -1,0 +1,10 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def a_tilde(conformal_factor_squared, spatial_metric, extrinsic_curvature,
+            trace_extrinsic_curvature):
+    return conformal_factor_squared * (
+        extrinsic_curvature - trace_extrinsic_curvature * spatial_metric / 3.0)

--- a/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_Ccz4")
 
 set(LIBRARY_SOURCES
+  Test_ATilde.cpp
   Test_Christoffel.cpp
   Test_DerivChristoffel.cpp
   Test_DerivLapse.cpp

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_ATilde.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_ATilde.cpp
@@ -1,0 +1,35 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/Ccz4/ATilde.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+template <size_t Dim, typename DataType>
+void test_compute_a_tilde(const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::ii<DataType, Dim, Frame::Inertial> (*)(
+          const Scalar<DataType>&,
+          const tnsr::ii<DataType, Dim, Frame::Inertial>&,
+          const tnsr::ii<DataType, Dim, Frame::Inertial>&,
+          const Scalar<DataType>&)>(
+          &Ccz4::a_tilde<Dim, Frame::Inertial, DataType>),
+      "ATilde", "a_tilde", {{{-1., 1.}}}, used_for_size);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.ATilde", "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env("Evolution/Systems/Ccz4/");
+
+  GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_compute_a_tilde, (1, 2, 3));
+}

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_Christoffel.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_Christoffel.cpp
@@ -55,7 +55,7 @@ void test_contracted_conformal_christoffel_second_kind(
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.Christoffel",
-                  "[Evolution][Unit]") {
+                  "[Unit][Evolution]") {
   pypp::SetupLocalPythonEnvironment local_python_env("Evolution/Systems/Ccz4/");
 
   GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_DerivChristoffel.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_DerivChristoffel.cpp
@@ -45,8 +45,8 @@ void test_compute_deriv_contracted_conformal_christoffel_second_kind(
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.DerivChristoffel",
-                  "[PointwiseFunctions][Unit]") {
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.DerivChristoffel",
+                  "[Unit][Evolution]") {
   pypp::SetupLocalPythonEnvironment local_python_env("Evolution/Systems/Ccz4/");
 
   GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_DerivLapse.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_DerivLapse.cpp
@@ -41,7 +41,7 @@ void test_divergence_lapse(const DataType& used_for_size) {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.DerivLapse",
-                  "[Evolution][Unit]") {
+                  "[Unit][Evolution]") {
   pypp::SetupLocalPythonEnvironment local_python_env("Evolution/Systems/Ccz4/");
 
   GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
@@ -31,21 +31,21 @@ void test_simple_tags() {
       Ccz4::Tags::FieldB<Dim, Frame, DataType>>("FieldB");
   TestHelpers::db::test_simple_tag<Ccz4::Tags::FieldD<Dim, Frame, DataType>>(
       "FieldD");
-  TestHelpers::db::test_simple_tag<Ccz4::Tags::FieldDUp<Dim, Frame, DataType>>(
-      "FieldDUp");
   TestHelpers::db::test_simple_tag<Ccz4::Tags::LogConformalFactor<DataType>>(
       "LogConformalFactor");
   TestHelpers::db::test_simple_tag<Ccz4::Tags::FieldP<Dim, Frame, DataType>>(
       "FieldP");
+  TestHelpers::db::test_simple_tag<Ccz4::Tags::FieldDUp<Dim, Frame, DataType>>(
+      "FieldDUp");
   TestHelpers::db::test_simple_tag<
       Ccz4::Tags::ConformalChristoffelSecondKind<Dim, Frame, DataType>>(
       "ConformalChristoffelSecondKind");
   TestHelpers::db::test_simple_tag<
-      Ccz4::Tags::ChristoffelSecondKind<Dim, Frame, DataType>>(
-      "ChristoffelSecondKind");
-  TestHelpers::db::test_simple_tag<
       Ccz4::Tags::DerivConformalChristoffelSecondKind<Dim, Frame, DataType>>(
       "DerivConformalChristoffelSecondKind");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::ChristoffelSecondKind<Dim, Frame, DataType>>(
+      "ChristoffelSecondKind");
   TestHelpers::db::test_simple_tag<
       Ccz4::Tags::GradGradLapse<Dim, Frame, DataType>>("GradGradLapse");
   TestHelpers::db::test_simple_tag<Ccz4::Tags::DivergenceLapse<DataType>>(

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
@@ -19,11 +19,15 @@ void test_simple_tags() {
   TestHelpers::db::test_simple_tag<Ccz4::Tags::ConformalFactor<DataType>>(
       "ConformalFactor");
   TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::ConformalFactorSquared<DataType>>("ConformalFactorSquared");
+  TestHelpers::db::test_simple_tag<
       Ccz4::Tags::ConformalMetric<Dim, Frame, DataType>>(
       "Conformal(SpatialMetric)");
   TestHelpers::db::test_simple_tag<
       Ccz4::Tags::InverseConformalMetric<Dim, Frame, DataType>>(
       "Conformal(InverseSpatialMetric)");
+  TestHelpers::db::test_simple_tag<Ccz4::Tags::ATilde<Dim, Frame, DataType>>(
+      "ATilde");
   TestHelpers::db::test_simple_tag<Ccz4::Tags::LogLapse<DataType>>("LogLapse");
   TestHelpers::db::test_simple_tag<Ccz4::Tags::FieldA<Dim, Frame, DataType>>(
       "FieldA");

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
@@ -28,6 +28,8 @@ void test_simple_tags() {
       "Conformal(InverseSpatialMetric)");
   TestHelpers::db::test_simple_tag<Ccz4::Tags::ATilde<Dim, Frame, DataType>>(
       "ATilde");
+  TestHelpers::db::test_simple_tag<Ccz4::Tags::TraceATilde<DataType>>(
+      "TraceATilde");
   TestHelpers::db::test_simple_tag<Ccz4::Tags::LogLapse<DataType>>("LogLapse");
   TestHelpers::db::test_simple_tag<Ccz4::Tags::FieldA<Dim, Frame, DataType>>(
       "FieldA");


### PR DESCRIPTION
## Proposed changes

This PR adds a CCZ4 function for computing the trace-free part of the extrinsic curvature.

The motivation for this PR is to implement eq. (3), whose value will be used to implement eq. (13) and various parts of the evolution equations (12a - 12m) in [this CCZ4 paper](https://arxiv.org/pdf/1707.09910.pdf).

As part of this PR, the first commit just cleans things up, and the second commit is necessary for the documentation to render.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
