### PR TITLE
StrahlkorperInDifferentFrame now works for center not at origin.

### DIFF
--- a/src/ApparentHorizons/StrahlkorperInDifferentFrame.cpp
+++ b/src/ApparentHorizons/StrahlkorperInDifferentFrame.cpp
@@ -121,6 +121,8 @@ void strahlkorper_in_different_frame(
     return center;
   }();
 
+  const auto center_src = src_strahlkorper.center();
+
   // Find the coordinate radius of the destination surface at each of
   // the angular collocation points of the destination surface. To do
   // so, for each index 's' (corresponding to an angular collocation
@@ -130,7 +132,8 @@ void strahlkorper_in_different_frame(
   // because it might fail if r_dest is out of range of the map. Below
   // there is another version of the function that returns a double.
   const auto radius_function_for_bracketing =
-      [&r_hat, &center_dest, &src_strahlkorper, &domain, &functions_of_time,
+      [&r_hat, &center_src, &center_dest, &src_strahlkorper, &domain,
+       &functions_of_time,
        &time](const double r_dest, const size_t s) -> std::optional<double> {
     // Get destination Cartesian coordinates of the point.
     const tnsr::I<double, 3, DestFrame> x_dest{
@@ -168,14 +171,16 @@ void strahlkorper_in_different_frame(
             get<2>(x_logical.value()) <= 1.0 and
             get<2>(x_logical.value()) >= -1.0) {
           // Find (r_src,theta_src,phi_src) in source coordinates.
-          const double r_src = std::hypot(get<0>(x_src.value()),
-                                          get<1>(x_src.value()),
-                                          get<2>(x_src.value()));
+          const double r_src =
+              std::hypot(get<0>(x_src.value()) - center_src[0],
+                         get<1>(x_src.value()) - center_src[1],
+                         get<2>(x_src.value()) - center_src[2]);
           const double theta_src =
-              atan2(std::hypot(get<0>(x_src.value()), get<1>(x_src.value())),
-                    get<2>(x_src.value()));
-          const double phi_src =
-              atan2(get<1>(x_src.value()), get<0>(x_src.value()));
+              atan2(std::hypot(get<0>(x_src.value()) - center_src[0],
+                               get<1>(x_src.value()) - center_src[1]),
+                    get<2>(x_src.value()) - center_src[2]);
+          const double phi_src = atan2(get<1>(x_src.value()) - center_src[1],
+                                       get<0>(x_src.value()) - center_src[0]);
 
           // Evaluate the radius of the surface at (theta_src,phi_src).
           const double r_surf_src = src_strahlkorper.radius(theta_src, phi_src);

--- a/tests/Unit/ApparentHorizons/Test_StrahlkorperInDifferentFrame.cpp
+++ b/tests/Unit/ApparentHorizons/Test_StrahlkorperInDifferentFrame.cpp
@@ -26,9 +26,12 @@ void test_strahlkorper_in_different_frame() {
 
   // Set up a Strahlkorper corresponding to a Schwarzschild hole of
   // mass 1, in the grid frame.
+  // Center the Strahlkorper at (0.03,0.02,0.01) so that we test a
+  // nonzero center.
+  const std::array<double, 3> strahlkorper_grid_center = {0.03, 0.02, 0.01};
   const size_t l_max = 8;
   const Strahlkorper<Frame::Grid> strahlkorper_grid(l_max, 2.0,
-                                                   {{0.0, 0.0, 0.0}});
+                                                    strahlkorper_grid_center);
 
   // Create a Domain.
   // We choose a spherical shell domain extending from radius 1.9M to
@@ -58,7 +61,9 @@ void test_strahlkorper_in_different_frame() {
 
   // Now compare.
   const Strahlkorper<Frame::Inertial> strahlkorper_expected(
-      l_max, 2.0, {{0.005, 0.01, 0.015}});
+      l_max, 2.0,
+      {{strahlkorper_grid_center[0] + 0.005, strahlkorper_grid_center[1] + 0.01,
+        strahlkorper_grid_center[2] + 0.015}});
   CHECK_ITERABLE_APPROX(strahlkorper_expected.physical_center(),
                         strahlkorper_inertial.physical_center());
   CHECK_ITERABLE_APPROX(strahlkorper_expected.coefficients(),


### PR DESCRIPTION
The test was changed too; previously only center=origin was tested.
Now the previous version fails the test.

This fixes a problem @geoffrey4444 found with running the executable with changes in #3566

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
