### PR TITLE
Bulged Frustums in BinaryCompactObject Domain

### DIFF
--- a/src/Domain/CoordinateMaps/Frustum.hpp
+++ b/src/Domain/CoordinateMaps/Frustum.hpp
@@ -160,6 +160,72 @@ namespace CoordinateMaps {
  * This is the value for \f$w_{\delta}\f$ used by this CoordinateMap when
  * `auto_projective_scale_factor` is `true`.
  *
+ * ### Bulged Frustum Coordinate Map and Jacobian
+ * Each of the frustum faces in the frustum map given above are flat, but the
+ * upper +z face of the frustum can be bulged out by setting a non-zero value
+ * for the `sphericity`, where a value of `0.0` corresponds to the usual flat-
+ * face, and a value of `1.0` corresponds to a value of fully spherical. Using
+ * OrientationMaps allows the user to create a set of frustums that fully cover
+ * a spherical surface. The radius of the sphere is determined by the corner of
+ * the frustum that is furthest from the origin.
+ *
+ * The full map is given by:
+ * \f[\vec{x}(\xi,\eta,\zeta) = \begin{bmatrix}
+ * \Sigma^x + \Delta^x_{\xi}\Xi + (\Delta^x_{\zeta} +
+ * \Delta^x_{\xi\zeta}\Xi)\mathrm{Z}\\
+ * \Sigma^y + \Delta^y_{\eta}\mathrm{H} + (\Delta^y_{\zeta} +
+ * \Delta^y_{\eta\zeta}\mathrm{H})\mathrm{Z}\\
+ * \Sigma^z + \Delta^z\mathrm{Z}\\
+ * \end{bmatrix}
+ * + s \frac{1 +
+ * \mathrm{Z}}{2}\left(\frac{R}{|\vec{\sigma}_{\mathrm{+z}}|}-1\right)
+ * \vec{\sigma}_{\mathrm{+z}}
+ * \f]
+ *
+ * where \f$R\f$ is the radius, \f$s\f$ is the `sphericity`, and
+ * \f$\vec{\sigma}_{\mathrm{+z}}\f$ is given by:
+ * \f[
+ * \vec{\sigma}_{\mathrm{+z}} =
+ * \begin{bmatrix}
+ * \Sigma^x + \Delta^x_{\xi}\Xi + \Delta^x_{\zeta} +
+ * \Delta^x_{\xi\zeta}\Xi\\
+ * \Sigma^y + \Delta^y_{\eta}\mathrm{H} + \Delta^y_{\zeta} +
+ * \Delta^y_{\eta\zeta}\mathrm{H}\\
+ * \Sigma^z + \Delta^z\\
+ * \end{bmatrix}.
+ * \f]
+ *
+ * The Jacobian is:
+ * \f[J =
+ * \begin{bmatrix}
+ * (\Delta^x_{\xi} + \Delta^x_{\xi\zeta}\mathrm{Z})\Xi' &
+ * 0 & (\Delta^x_{\zeta}+ \Delta^x_{\xi\zeta}\Xi)\mathrm{Z}' \\
+ * 0 & (\Delta^y_{\eta} + \Delta^y_{\eta\zeta}\mathrm{Z})\mathrm{H}' &
+ * (\Delta^y_{\zeta} + \Delta^y_{\eta\zeta}\mathrm{H})\mathrm{Z}'\\
+ * 0 & 0 & \Delta^z\mathrm{Z}' \\
+ * \end{bmatrix}
+ * +
+ * \frac{s}{2} \left\{ \left(\frac{R}{|\vec{\sigma}_{\mathrm{+z}}|}-1\right)
+ * \vec{\sigma}_{\mathrm{+z}}\hat{\zeta}^{\intercal}\mathrm{Z}'+
+ * (1+\mathrm{Z})\left(\frac{R}{|\vec{\sigma}_{\mathrm{+z}}|}\left(
+ * \mathbb{1}-\frac{\vec{\sigma}_{\mathrm{+z}}
+ * \vec{\sigma}_{\mathrm{+z}}^{\intercal}}
+ * {|\vec{\sigma}_{\mathrm{+z}}|^2}\right)-\mathbb{1}\right)
+ * J_{\sigma}\right\},
+ * \f]
+ *
+ * where \f$\hat{\zeta}\f$ is the row vector \f$[0, 0, 1]\f$, and
+ * \f$J_{\sigma}\f$ is the Jacobian of the upper +z surface, given by:
+ * \f[
+ * J_{\sigma} =
+ * \begin{bmatrix}
+ * (\Delta^x_{\xi} + \Delta^x_{\xi\zeta})\Xi' &
+ * 0 & 0 \\
+ * 0 & (\Delta^y_{\eta} + \Delta^y_{\eta\zeta})\mathrm{H}' &
+ * 0 \\
+ * 0 & 0 & 0 \\
+ * \end{bmatrix}.
+ * \f]
  */
 class Frustum {
  public:
@@ -169,7 +235,8 @@ class Frustum {
           OrientationMap<3> orientation_of_frustum,
           bool with_equiangular_map = false,
           double projective_scale_factor = 1.0,
-          bool auto_projective_scale_factor = false);
+          bool auto_projective_scale_factor = false,
+          double sphericity = 0.0);
   Frustum() = default;
   ~Frustum() = default;
   Frustum(Frustum&&) = default;
@@ -224,6 +291,8 @@ class Frustum {
   double delta_z_zeta_{std::numeric_limits<double>::signaling_NaN()};
   double w_plus_{std::numeric_limits<double>::signaling_NaN()};
   double w_minus_{std::numeric_limits<double>::signaling_NaN()};
+  double sphericity_{std::numeric_limits<double>::signaling_NaN()};
+  double radius_{std::numeric_limits<double>::signaling_NaN()};
 };
 
 bool operator!=(const Frustum& lhs, const Frustum& rhs);

--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -385,6 +385,18 @@ class BinaryCompactObject : public DomainCreator<3> {
         "Use projective scaling on the frustal cloak."};
   };
 
+  struct FrustumSphericity {
+    using group = EnvelopingCube;
+    static std::string name() { return "Sphericity"; }
+    using type = double;
+    static constexpr Options::String help = {
+        "Sphericity of the enveloping cube. The value 0.0 corresponds "
+        "to a cubical envelope of frustums, the value 1.0 corresponds "
+        "to a spherical envelope of frustums."};
+    static double lower_bound() { return 0.; }
+    static double upper_bound() { return 1.; }
+  };
+
   struct RadialDistributionOuterShell {
     using group = OuterShell;
     static std::string name() { return "RadialDistribution"; }
@@ -575,7 +587,8 @@ class BinaryCompactObject : public DomainCreator<3> {
   using time_independent_options = tmpl::append<
       tmpl::list<ObjectA, ObjectB, RadiusEnvelopingCube, OuterRadius,
                  InitialRefinement, InitialGridPoints, UseProjectiveMap,
-                 RadiusEnvelopingSphere, RadialDistributionOuterShell>,
+                 FrustumSphericity, RadiusEnvelopingSphere,
+                 RadialDistributionOuterShell>,
       tmpl::conditional_t<
           domain::BoundaryConditions::has_boundary_conditions_base_v<
               typename Metavariables::system>,
@@ -651,7 +664,7 @@ class BinaryCompactObject : public DomainCreator<3> {
       double outer_radius_domain,
       const typename InitialRefinement::type& initial_refinement,
       const typename InitialGridPoints::type& initial_number_of_grid_points,
-      bool use_projective_map = true,
+      bool use_projective_map = true, double frustum_sphericity = 0.0,
       const std::optional<double>& radius_enveloping_sphere = std::nullopt,
       CoordinateMaps::Distribution radial_distribution_outer_shell =
           CoordinateMaps::Distribution::Linear,
@@ -680,7 +693,7 @@ class BinaryCompactObject : public DomainCreator<3> {
       double outer_radius_domain,
       const typename InitialRefinement::type& initial_refinement,
       const typename InitialGridPoints::type& initial_number_of_grid_points,
-      bool use_projective_map = true,
+      bool use_projective_map = true, double frustum_sphericity = 0.0,
       const std::optional<double>& radius_enveloping_sphere = std::nullopt,
       CoordinateMaps::Distribution radial_distribution_outer_shell =
           CoordinateMaps::Distribution::Linear,
@@ -730,6 +743,7 @@ class BinaryCompactObject : public DomainCreator<3> {
   static constexpr bool use_equiangular_map_ =
       false;  // Doesn't work properly yet
   bool use_projective_map_ = true;
+  double frustum_sphericity_{};
   CoordinateMaps::Distribution radial_distribution_outer_shell_ =
       CoordinateMaps::Distribution::Linear;
   double projective_scale_factor_{};

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -705,7 +705,8 @@ frustum_coordinate_maps(const double length_inner_cube,
                         const double length_outer_cube,
                         const bool use_equiangular_map,
                         const std::array<double, 3>& origin_preimage,
-                        const double projective_scale_factor) {
+                        const double projective_scale_factor,
+                        const double sphericity) {
   ASSERT(length_inner_cube < 0.5 * length_outer_cube,
          "The outer cube is too small! The inner cubes will pierce the surface "
          "of the outer cube.");
@@ -739,7 +740,9 @@ frustum_coordinate_maps(const double length_inner_cube,
         top,
         gsl::at(frustum_orientations, i),
         use_equiangular_map,
-        projective_scale_factor});
+        projective_scale_factor,
+        false,
+        sphericity});
     // frustums on the right
     frustums.push_back(FrustumMap{{{{{-displacement_from_origin[0],
                                       -lower - displacement_from_origin[1]}},
@@ -751,7 +754,9 @@ frustum_coordinate_maps(const double length_inner_cube,
                                   top,
                                   gsl::at(frustum_orientations, i),
                                   use_equiangular_map,
-                                  projective_scale_factor});
+                                  projective_scale_factor,
+                                  false,
+                                  sphericity});
   }
   // end cap frustum on the right
   std::array<double, 3> displacement_from_origin =
@@ -766,7 +771,9 @@ frustum_coordinate_maps(const double length_inner_cube,
                                 top,
                                 frustum_orientations[4],
                                 use_equiangular_map,
-                                projective_scale_factor});
+                                projective_scale_factor,
+                                false,
+                                sphericity});
   // end cap frustum on the left
   displacement_from_origin =
       discrete_rotation(frustum_orientations[5].inverse_map(), origin_preimage);
@@ -780,7 +787,9 @@ frustum_coordinate_maps(const double length_inner_cube,
                                 top,
                                 frustum_orientations[5],
                                 use_equiangular_map,
-                                projective_scale_factor});
+                                projective_scale_factor,
+                                false,
+                                sphericity});
 
   // clang-tidy: trivially copyable
   return domain::make_vector_coordinate_map_base<Frame::BlockLogical,
@@ -1438,14 +1447,16 @@ frustum_coordinate_maps(const double length_inner_cube,
                         const double length_outer_cube,
                         const bool use_equiangular_map,
                         const std::array<double, 3>& origin_preimage,
-                        const double projective_scale_factor);
+                        const double projective_scale_factor,
+                        const double sphericity);
 template std::vector<std::unique_ptr<
     domain::CoordinateMapBase<Frame::BlockLogical, Frame::Grid, 3>>>
 frustum_coordinate_maps(const double length_inner_cube,
                         const double length_outer_cube,
                         const bool use_equiangular_map,
                         const std::array<double, 3>& origin_preimage,
-                        const double projective_scale_factor);
+                        const double projective_scale_factor,
+                        const double sphericity);
 template std::vector<std::unique_ptr<
     domain::CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 3>>>
 cyl_wedge_coordinate_maps(

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -179,7 +179,7 @@ auto frustum_coordinate_maps(
     double length_inner_cube, double length_outer_cube,
     bool use_equiangular_map,
     const std::array<double, 3>& origin_preimage = {{0.0, 0.0, 0.0}},
-    double projective_scale_factor = 1.0)
+    double projective_scale_factor = 1.0, double sphericity = 0.0)
     -> std::vector<std::unique_ptr<
         domain::CoordinateMapBase<Frame::BlockLogical, TargetFrame, 3>>>;
 

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -28,6 +28,7 @@ DomainCreator:
     EnvelopingCube:
       Radius: 100.0
       UseProjectiveMap: true
+      Sphericity: 0.0
     OuterShell:
       InnerRadius: Auto
       OuterRadius: 590.0

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -30,6 +30,7 @@ DomainCreator:
     EnvelopingCube:
       Radius: 100.0
       UseProjectiveMap: true
+      Sphericity: 0.0
     OuterShell:
       InnerRadius: Auto
       OuterRadius: 1493.0

--- a/tests/Unit/Domain/CoordinateMaps/Test_Frustum.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Frustum.cpp
@@ -25,24 +25,26 @@ void test_suite_for_frustum(const bool with_equiangular_map) {
   INFO("Suite for frustum");
   // Set up random number generator
   MAKE_GENERATOR(gen);
-  std::uniform_real_distribution<> lower_bound_dis(-14, -2);
-  std::uniform_real_distribution<> upper_bound_dis(2, 14);
+  std::uniform_real_distribution<> lower_bound_lower_base_dis(-9, -3);
+  std::uniform_real_distribution<> upper_bound_lower_base_dis(3, 9);
+  std::uniform_real_distribution<> lower_bound_upper_base_dis(-14, -9);
+  std::uniform_real_distribution<> upper_bound_upper_base_dis(9, 14);
 
-  const double lower_x_lower_base = lower_bound_dis(gen);
+  const double lower_x_lower_base = lower_bound_lower_base_dis(gen);
   CAPTURE(lower_x_lower_base);
-  const double lower_y_lower_base = lower_bound_dis(gen);
+  const double lower_y_lower_base = lower_bound_lower_base_dis(gen);
   CAPTURE(lower_y_lower_base);
-  const double upper_x_lower_base = upper_bound_dis(gen);
+  const double upper_x_lower_base = upper_bound_lower_base_dis(gen);
   CAPTURE(upper_x_lower_base);
-  const double upper_y_lower_base = upper_bound_dis(gen);
+  const double upper_y_lower_base = upper_bound_lower_base_dis(gen);
   CAPTURE(upper_y_lower_base);
-  const double lower_x_upper_base = lower_bound_dis(gen);
+  const double lower_x_upper_base = lower_bound_upper_base_dis(gen);
   CAPTURE(lower_x_upper_base);
-  const double lower_y_upper_base = lower_bound_dis(gen);
+  const double lower_y_upper_base = lower_bound_upper_base_dis(gen);
   CAPTURE(lower_y_upper_base);
-  const double upper_x_upper_base = upper_bound_dis(gen);
+  const double upper_x_upper_base = upper_bound_upper_base_dis(gen);
   CAPTURE(upper_x_upper_base);
-  const double upper_y_upper_base = upper_bound_dis(gen);
+  const double upper_y_upper_base = upper_bound_upper_base_dis(gen);
   CAPTURE(upper_y_upper_base);
 
   for (OrientationMapIterator<3> map_i{}; map_i; ++map_i) {
@@ -55,7 +57,8 @@ void test_suite_for_frustum(const bool with_equiangular_map) {
          {{lower_x_upper_base, lower_y_upper_base}},
          {{upper_x_upper_base, upper_y_upper_base}}}};
     const CoordinateMaps::Frustum frustum_map(face_vertices, -1.0, 2.0, map_i(),
-                                              with_equiangular_map, 1.01);
+                                              with_equiangular_map, 1.2, false,
+                                              0.5);
     test_suite_for_map_on_unit_cube(frustum_map);
   }
 }
@@ -245,6 +248,60 @@ void test_is_identity() {
       -1.0, 1.0, OrientationMap<3>{}, false, 1.5}
                 .is_identity());
 }
+
+void test_bulged_frustum_jacobian() {
+  INFO("Bulged frustum jacobian");
+  const std::array<std::array<double, 2>, 4> face_vertices{
+      {{{-2.0, -2.0}}, {{2.0, 2.0}}, {{-4.0, -4.0}}, {{4.0, 4.0}}}};
+  const CoordinateMaps::Frustum map(
+      face_vertices, 2.0, 5.0, OrientationMap<3>{}, false, 1.0, false, 1.0);
+
+  const std::array<double, 3> test_point1{{-1.0, 0.25, 0.0}};
+  const std::array<double, 3> test_point2{{1.0, 1.0, -0.5}};
+  const std::array<double, 3> test_point3{{0.7, -0.2, 0.4}};
+  const std::array<double, 3> test_point4{{0.0, 0.0, 0.0}};
+
+  test_jacobian(map, test_point1);
+  test_jacobian(map, test_point2);
+  test_jacobian(map, test_point3);
+  test_jacobian(map, test_point4);
+}
+
+void test_bulged_frustum_inv_jacobian() {
+  INFO("Bulged frustum inverse jacobian");
+  const std::array<std::array<double, 2>, 4> face_vertices{
+      {{{-2.0, -2.0}}, {{2.0, 2.0}}, {{-4.0, -4.0}}, {{4.0, 4.0}}}};
+  const CoordinateMaps::Frustum map(
+      face_vertices, 2.0, 5.0, OrientationMap<3>{}, false, 1.0, false, 1.0);
+
+  const std::array<double, 3> test_point1{{-1.0, 0.25, 0.0}};
+  const std::array<double, 3> test_point2{{1.0, 1.0, -0.5}};
+  const std::array<double, 3> test_point3{{0.7, -0.2, 0.4}};
+  const std::array<double, 3> test_point4{{0.0, 0.0, 0.0}};
+
+  test_inv_jacobian(map, test_point1);
+  test_inv_jacobian(map, test_point2);
+  test_inv_jacobian(map, test_point3);
+  test_inv_jacobian(map, test_point4);
+}
+
+void test_bulged_frustum_inv_map() {
+  INFO("Bulged frustum inverse map");
+  const std::array<std::array<double, 2>, 4> face_vertices{
+      {{{-2.0, -2.0}}, {{2.0, 2.0}}, {{-4.0, -4.0}}, {{4.0, 4.0}}}};
+  const CoordinateMaps::Frustum map(
+      face_vertices, 2.0, 5.0, OrientationMap<3>{}, false, 1.0, false, 1.0);
+
+  const std::array<double, 3> test_point1{{-1.0, 0.25, 0.0}};
+  const std::array<double, 3> test_point2{{1.0, 1.0, -0.5}};
+  const std::array<double, 3> test_point3{{0.7, -0.2, 0.4}};
+  const std::array<double, 3> test_point4{{0.0, 0.0, 0.01}};
+
+  test_inverse_map(map, test_point1);
+  test_inverse_map(map, test_point2);
+  test_inverse_map(map, test_point3);
+  test_inverse_map(map, test_point4);
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum", "[Domain][Unit]") {
@@ -254,6 +311,9 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum", "[Domain][Unit]") {
   test_alignment();
   test_auto_projective_scale_factor();
   test_is_identity();
+  test_bulged_frustum_jacobian();
+  test_bulged_frustum_inv_jacobian();
+  test_bulged_frustum_inv_map();
 }
 
 // [[OutputRegex, A projective scale factor of zero maps all coordinates to
@@ -367,6 +427,30 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum", "[Domain][Unit]") {
 
   auto failed_frustum = CoordinateMaps::Frustum(
       face_vertices, lower_bound, upper_bound, OrientationMap<3>{});
+  static_cast<void>(failed_frustum);
+
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, The sphericity must be set between 0.0, corresponding to a
+// flat surface, and 1.0, corresponding to a spherical surface, inclusive. It is
+// currently set to 1.3.]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum.Assert6",
+                               "[Domain][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  const std::array<std::array<double, 2>, 4> face_vertices{
+      {{{-2.0, -2.0}}, {{2.0, 2.0}}, {{-4.0, -4.0}}, {{4.0, 4.0}}}};
+  const double lower_bound = 2.0;
+  const double upper_bound = 5.0;
+  const double projective_scale_factor = 1.0;
+  const bool with_equiangular_map = false;
+  const double sphericity = 1.3;
+
+  auto failed_frustum = CoordinateMaps::Frustum(
+      face_vertices, lower_bound, upper_bound, OrientationMap<3>{},
+      with_equiangular_map, projective_scale_factor, false, sphericity);
   static_cast<void>(failed_frustum);
 
   ERROR("Failed to trigger ASSERT in an assertion test");

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -169,6 +169,7 @@ void test_connectivity() {
   // Enveloping Cube:
   constexpr double radius_enveloping_cube = 25.5;
   constexpr bool use_projective_map = true;
+  constexpr double sphericity_enveloping_cube = 0.5;
 
   // Enveloping sphere:
   const std::optional<double> radius_enveloping_sphere = std::nullopt;
@@ -226,6 +227,7 @@ void test_connectivity() {
               refinement,
               grid_points,
               use_projective_map,
+              sphericity_enveloping_cube,
               radius_enveloping_sphere,
               radial_distribution_outer_shell,
               with_boundary_conditions ? create_outer_boundary_condition()
@@ -370,8 +372,8 @@ void test_connectivity() {
                             : std::nullopt,
                         false},
                     radius_enveloping_cube, outer_radius, refinement,
-                    grid_points, use_projective_map, radius_enveloping_sphere,
-                    radial_distribution_outer_shell,
+                    grid_points, use_projective_map, sphericity_enveloping_cube,
+                    radius_enveloping_sphere, radial_distribution_outer_shell,
                     std::make_unique<PeriodicBc>(),
                     Options::Context{false, {}, 1, 1}),
                 Catch::Matchers::Contains("Cannot have periodic boundary "
@@ -394,7 +396,8 @@ void test_connectivity() {
                                  : std::nullopt,
                              false},
                       radius_enveloping_cube, outer_radius, refinement,
-                      grid_points, use_projective_map, radius_enveloping_sphere,
+                      grid_points, use_projective_map,
+                      sphericity_enveloping_cube, radius_enveloping_sphere,
                       radial_distribution_outer_shell,
                       create_outer_boundary_condition(),
                       Options::Context{false, {}, 1, 1}),
@@ -417,7 +420,8 @@ void test_connectivity() {
                                  : std::nullopt,
                              false},
                       radius_enveloping_cube, outer_radius, refinement,
-                      grid_points, use_projective_map, radius_enveloping_sphere,
+                      grid_points, use_projective_map,
+                      sphericity_enveloping_cube, radius_enveloping_sphere,
                       radial_distribution_outer_shell, nullptr,
                       Options::Context{false, {}, 1, 1}),
                   Catch::Matchers::Contains(
@@ -438,7 +442,8 @@ void test_connectivity() {
                                  : std::nullopt,
                              false},
                       radius_enveloping_cube, outer_radius, refinement,
-                      grid_points, use_projective_map, radius_enveloping_sphere,
+                      grid_points, use_projective_map,
+                      sphericity_enveloping_cube, radius_enveloping_sphere,
                       radial_distribution_outer_shell,
                       create_outer_boundary_condition(),
                       Options::Context{false, {}, 1, 1}),
@@ -528,6 +533,7 @@ std::string create_option_string(const bool excise_A, const bool excise_B,
          "  EnvelopingCube:\n"
          "    Radius: 22.0\n"
          "    UseProjectiveMap: true\n"
+         "    Sphericity: 1.0\n"
          "  OuterShell:\n"
          "    InnerRadius: Auto\n"
          "    OuterRadius: 25.0\n"
@@ -695,7 +701,7 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           {0.5, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
           {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, 6_st, true, std::nullopt, Distribution::Linear,
+          32.4, 2_st, 6_st, true, 0.0, std::nullopt, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "The x-coordinate of ObjectA's center is expected to be negative."));
@@ -703,7 +709,7 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
           {0.3, 1.0, -1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, 6_st, true, std::nullopt, Distribution::Linear,
+          32.4, 2_st, 6_st, true, 0.0, std::nullopt, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "The x-coordinate of ObjectB's center is expected to be positive."));
@@ -711,7 +717,7 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           {0.5, 1.0, -7.0, {{create_inner_boundary_condition()}}, false},
           {0.3, 1.0, 8.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, 6_st, true, std::nullopt, Distribution::Linear,
+          32.4, 2_st, 6_st, true, 0.0, std::nullopt, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains("The radius for the enveloping cube is too "
                                 "small! The Frustums will be malformed."));
@@ -719,7 +725,7 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           {1.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
           {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, 6_st, true, std::nullopt, Distribution::Linear,
+          32.4, 2_st, 6_st, true, 0.0, std::nullopt, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "ObjectA's inner radius must be less than its outer radius."));
@@ -727,7 +733,7 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
           {3.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, 6_st, true, std::nullopt, Distribution::Linear,
+          32.4, 2_st, 6_st, true, 0.0, std::nullopt, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "ObjectB's inner radius must be less than its outer radius."));
@@ -735,7 +741,7 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           {0.5, 1.0, -1.0, std::nullopt, true},
           {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, 6_st, true, std::nullopt, Distribution::Linear,
+          32.4, 2_st, 6_st, true, 0.0, std::nullopt, Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "Using a logarithmically spaced radial grid in the "
@@ -745,8 +751,8 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
           {0.3, 1.0, 1.0, std::nullopt, true}, 25.5, 32.4, 2_st, 6_st, true,
-          std::nullopt, Distribution::Linear, create_outer_boundary_condition(),
-          Options::Context{false, {}, 1, 1}),
+          0.0, std::nullopt, Distribution::Linear,
+          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "Using a logarithmically spaced radial grid in the "
           "part of Layer 1 enveloping Object B requires excising the interior "
@@ -755,23 +761,23 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
           {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, std::vector<std::array<size_t, 3>>{}, 6_st, true, std::nullopt,
-          Distribution::Linear, create_outer_boundary_condition(),
+          32.4, std::vector<std::array<size_t, 3>>{}, 6_st, true, 0.0,
+          std::nullopt, Distribution::Linear, create_outer_boundary_condition(),
           Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains("Invalid 'InitialRefinement'"));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
           {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
           {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, std::vector<std::array<size_t, 3>>{}, true, std::nullopt,
-          Distribution::Linear, create_outer_boundary_condition(),
+          32.4, 2_st, std::vector<std::array<size_t, 3>>{}, true, 0.0,
+          std::nullopt, Distribution::Linear, create_outer_boundary_condition(),
           Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains("Invalid 'InitialGridPoints'"));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
           {0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
           {0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false}, 25.5,
-          32.4, 2_st, 6_st, true, 35., Distribution::Linear,
+          32.4, 2_st, 6_st, true, 0.0, 35., Distribution::Linear,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains("The 'OuterShell.InnerRadius' must be within"));
   // Note: the boundary condition-related parse errors are checked in the


### PR DESCRIPTION
## Proposed changes

Adds the `sphericity` parameter to Frustum as well as to the BinaryCompactObject Domain.
Addresses some of issue #3545 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

The `EnvelopingCube` in the BinaryCompactObject Domain will now take a `Sphericity` parameter, which can be
set to any value between 0 and 1, inclusive. A value of 0 corresponds to an EnvelopingCube with a flat surface, and
a value of 1 corresponds to an EnvelopingCube with a spherical surface.

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
