### PR TITLE
Derive advection solutions from the new ID base class

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/CMakeLists.txt
@@ -17,6 +17,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  Factory.hpp
   Krivodonova.hpp
   Kuzmin.hpp
   Sinusoid.hpp

--- a/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Factory.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Factory.hpp
@@ -1,0 +1,26 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Krivodonova.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Kuzmin.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Sinusoid.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ScalarAdvection::Solutions {
+/*!
+ * \brief Typelist of all analytic solutions of advection system
+ */
+template <size_t Dim>
+using all_analytic_solutions = tmpl::flatten<tmpl::list<
+    tmpl::conditional_t<Dim == 1,
+                        tmpl::list<ScalarAdvection::Solutions::Sinusoid,
+                                   ScalarAdvection::Solutions::Krivodonova>,
+                        tmpl::list<>>,
+    tmpl::conditional_t<Dim == 2,
+                        tmpl::list<ScalarAdvection::Solutions::Kuzmin>,
+                        tmpl::list<>>>>;
+}  // namespace ScalarAdvection::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Krivodonova.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Krivodonova.cpp
@@ -78,7 +78,11 @@ tuples::TaggedTuple<ScalarAdvection::Tags::U> Krivodonova::variables(
   return u_variable;
 }
 
-void Krivodonova::pup(PUP::er& /*p*/) {}
+void Krivodonova::pup(PUP::er& p) { InitialData::pup(p); }
+
+Krivodonova::Krivodonova(CkMigrateMessage* msg) : InitialData(msg) {}
+
+PUP::able::PUP_ID Krivodonova::my_PUP_ID = 0;
 
 bool operator==(const Krivodonova& /*lhs*/, const Krivodonova& /*rhs*/) {
   return true;

--- a/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Krivodonova.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Krivodonova.hpp
@@ -3,10 +3,13 @@
 
 #pragma once
 
+#include <pup.h>
+
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/ScalarAdvection/Tags.hpp"
 #include "Options/Options.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -54,7 +57,8 @@ namespace Solutions {
  * condition. The initial profile is simply advected (translated) to +x
  * direction, going over cycles in the domain every 2.0 time unit.
  */
-class Krivodonova : public MarkAsAnalyticSolution {
+class Krivodonova : public evolution::initial_data::InitialData,
+                    public MarkAsAnalyticSolution {
  public:
   using options = tmpl::list<>;
   static constexpr Options::String help{
@@ -75,6 +79,12 @@ class Krivodonova : public MarkAsAnalyticSolution {
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p);
+
+  /// \cond
+  explicit Krivodonova(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Krivodonova);
+  /// \endcond
 };
 
 bool operator==(const Krivodonova& /*lhs*/, const Krivodonova& /*rhs*/);

--- a/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Kuzmin.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Kuzmin.cpp
@@ -75,7 +75,11 @@ tuples::TaggedTuple<ScalarAdvection::Tags::U> Kuzmin::variables(
   return u_variable;
 }
 
-void Kuzmin::pup(PUP::er& /*p*/) {}
+void Kuzmin::pup(PUP::er& p) { InitialData::pup(p); }
+
+Kuzmin::Kuzmin(CkMigrateMessage* msg) : InitialData(msg) {}
+
+PUP::able::PUP_ID Kuzmin::my_PUP_ID = 0;
 
 bool operator==(const Kuzmin& /*lhs*/, const Kuzmin& /*rhs*/) { return true; }
 

--- a/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Kuzmin.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Kuzmin.hpp
@@ -3,10 +3,13 @@
 
 #pragma once
 
+#include <pup.h>
+
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/ScalarAdvection/Tags.hpp"
 #include "Options/Options.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -51,7 +54,8 @@ namespace Solutions {
  * rotation about \f$(x,y)=(0.5,0.5)\f$ with angular velocity being 1.0. We use
  * the periodic boundary condition for evolving this problem.
  */
-class Kuzmin : public MarkAsAnalyticSolution {
+class Kuzmin : public evolution::initial_data::InitialData,
+               public MarkAsAnalyticSolution {
  public:
   using options = tmpl::list<>;
   static constexpr Options::String help{
@@ -71,6 +75,12 @@ class Kuzmin : public MarkAsAnalyticSolution {
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p);
+
+  /// \cond
+  explicit Kuzmin(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Kuzmin);
+  /// \endcond
 };
 
 bool operator==(const Kuzmin& /*lhs*/, const Kuzmin& /*rhs*/);

--- a/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Sinusoid.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Sinusoid.cpp
@@ -22,7 +22,11 @@ tuples::TaggedTuple<ScalarAdvection::Tags::U> Sinusoid::variables(
   return u;
 }
 
-void Sinusoid::pup(PUP::er& /*p*/) {}
+void Sinusoid::pup(PUP::er& p) { InitialData::pup(p); }
+
+Sinusoid::Sinusoid(CkMigrateMessage* msg) : InitialData(msg) {}
+
+PUP::able::PUP_ID Sinusoid::my_PUP_ID = 0;
 
 bool operator==(const Sinusoid& /*lhs*/, const Sinusoid& /*rhs*/) {
   return true;

--- a/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Sinusoid.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Sinusoid.hpp
@@ -3,11 +3,14 @@
 
 #pragma once
 
+#include <pup.h>
+
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/ScalarAdvection/Tags.hpp"
 #include "Options/Options.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -30,7 +33,8 @@ namespace Solutions {
  * \f}
  *
  */
-class Sinusoid : public MarkAsAnalyticSolution {
+class Sinusoid : public evolution::initial_data::InitialData,
+                 public MarkAsAnalyticSolution {
  public:
   using options = tmpl::list<>;
   static constexpr Options::String help{
@@ -51,6 +55,12 @@ class Sinusoid : public MarkAsAnalyticSolution {
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p);
+
+  /// \cond
+  explicit Sinusoid(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Sinusoid);
+  /// \endcond
 };
 
 bool operator==(const Sinusoid& /*lhs*/, const Sinusoid& /*rhs*/);


### PR DESCRIPTION
## Proposed changes

Only the last commit is the net change.

Derive analytic solutions of the ScalarAdvection system from the new initial data base class. All available solutions are listed in `PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Factory.hpp` with a type alias named `all_analytic_solutions` templated with dimension. Rather than listing all the types of analytic data or solution and their header files, it will be sufficient to include corresponding Factory.hpp and add its type aliases to factory classes in `EvolutionMetavars`.

Dependent on 
- [x] #3599 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
