### PR TITLE
Add radial velocity to initial data solves

### DIFF
--- a/src/PointwiseFunctions/AnalyticData/Xcts/Binary.cpp
+++ b/src/PointwiseFunctions/AnalyticData/Xcts/Binary.cpp
@@ -53,9 +53,11 @@ void BinaryVariables<DataType>::operator()(
     const gsl::not_null<tnsr::I<DataType, Dim>*> shift_background,
     const gsl::not_null<Cache*> /*cache*/,
     Tags::ShiftBackground<DataType, Dim, Frame::Inertial> /*meta*/) const {
-  get<0>(*shift_background) = -angular_velocity * get<1>(x);
-  get<1>(*shift_background) = angular_velocity * get<0>(x);
-  get<2>(*shift_background) = 0.;
+  get<0>(*shift_background) =
+      -angular_velocity * get<1>(x) + expansion * get<0>(x);
+  get<1>(*shift_background) =
+      angular_velocity * get<0>(x) + expansion * get<1>(x);
+  get<2>(*shift_background) = expansion * get<2>(x);
 }
 
 template <typename DataType>
@@ -67,6 +69,9 @@ void BinaryVariables<DataType>::operator()(
   std::fill(deriv_shift_background->begin(), deriv_shift_background->end(), 0.);
   get<1, 0>(*deriv_shift_background) = -angular_velocity;
   get<0, 1>(*deriv_shift_background) = angular_velocity;
+  get<0, 0>(*deriv_shift_background) = expansion;
+  get<1, 1>(*deriv_shift_background) = expansion;
+  get<2, 2>(*deriv_shift_background) = expansion;
 }
 
 template <typename DataType>

--- a/tests/Unit/PointwiseFunctions/AnalyticData/Xcts/Binary.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/Xcts/Binary.py
@@ -6,6 +6,7 @@ import numpy as np
 centers = [-5., 6.]
 masses = [1.1, 0.43]
 angular_velocity = 0.02
+radial_velocity = 0.01
 falloff_widths = [7., 8.]
 
 
@@ -26,7 +27,8 @@ def extrinsic_curvature_trace_bbh_isotropic(x):
 
 
 def shift_background(x):
-    return np.array([-angular_velocity * x[1], angular_velocity * x[0], 0.])
+    return (np.array([-angular_velocity * x[1], angular_velocity * x[0], 0.]) +
+            radial_velocity * x)
 
 
 def longitudinal_shift_background_bbh_isotropic(x):

--- a/tests/Unit/PointwiseFunctions/AnalyticData/Xcts/Test_Binary.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/Xcts/Test_Binary.cpp
@@ -48,7 +48,7 @@ struct BinaryProxy {
 
 template <typename IsolatedObjectRegistrars>
 void test_data(const std::array<double, 2>& x_coords,
-               const double angular_velocity,
+               const double angular_velocity, const double expansion,
                const std::optional<std::array<double, 2>>& falloff_widths,
                const std::array<double, 2>& masses,
                const std::string& py_functions_suffix,
@@ -68,6 +68,7 @@ void test_data(const std::array<double, 2>& x_coords,
     INFO("Properties");
     CHECK(binary.x_coords() == x_coords);
     CHECK(binary.angular_velocity() == angular_velocity);
+    CHECK(binary.expansion() == expansion);
     CHECK(binary.falloff_widths() == falloff_widths);
     const auto& superposed_objects = binary.superposed_objects();
     CHECK(dynamic_cast<const Xcts::Solutions::Schwarzschild<>&>(
@@ -100,7 +101,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticData.Xcts.Binary",
   pypp::SetupLocalPythonEnvironment local_python_env{
       "PointwiseFunctions/AnalyticData/Xcts"};
   test_data<tmpl::list<Xcts::Solutions::Registrars::Schwarzschild>>(
-      {{-5., 6.}}, 0.02, {{7., 8.}}, {{1.1, 0.43}}, "bbh_isotropic",
+      {{-5., 6.}}, 0.02, 0.01, {{7., 8.}}, {{1.1, 0.43}}, "bbh_isotropic",
       "Binary:\n"
       "  XCoords: [-5., 6.]\n"
       "  ObjectA:\n"
@@ -112,6 +113,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticData.Xcts.Binary",
       "      Mass: 0.43\n"
       "      Coordinates: Isotropic\n"
       "  AngularVelocity: 0.02\n"
+      "  Expansion: 0.01\n"
       "  FalloffWidths: [7., 8.]");
 }
 


### PR DESCRIPTION
## Proposed changes

The radial velocity helps control eccentricity. It's the adot0 parameter in SpEC.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
