### PR TITLE
Change PerssonTCI implementation

### DIFF
--- a/src/Evolution/DgSubcell/PerssonTci.cpp
+++ b/src/Evolution/DgSubcell/PerssonTci.cpp
@@ -23,12 +23,14 @@ namespace evolution::dg::subcell::detail {
 template <size_t Dim>
 bool persson_tci_impl(const gsl::not_null<DataVector*> filtered_component,
                       const DataVector& component, const Mesh<Dim>& dg_mesh,
-                      const double alpha, const double zero_cutoff) {
+                      const double alpha) {
   ASSERT(component.size() == dg_mesh.number_of_grid_points(),
          "The tensor components being checked must have the same number of "
          "grid points as the DG mesh. The tensor has "
              << component.size() << " grid points while the DG mesh has "
              << dg_mesh.number_of_grid_points() << " grid points.");
+
+  const double component_norm{l2Norm(component)};
 
   const Matrix identity{};
   for (size_t d = 0; d < Dim; ++d) {
@@ -37,13 +39,45 @@ bool persson_tci_impl(const gsl::not_null<DataVector*> filtered_component,
         dg_mesh.slice_through(d), dg_mesh.extents(d) - 1);
     apply_matrices(filtered_component, matrices, component, dg_mesh.extents());
 
-    // Avoid taking logs of small numbers (or worse, zero)
-    if (l2Norm(*filtered_component) <= zero_cutoff * l2Norm(component)) {
-      continue;
-    }
-
-    if (std::log10(l2Norm(*filtered_component) / l2Norm(component)) >
-        -alpha * std::log10(static_cast<double>(dg_mesh.extents(d) - 1))) {
+    //
+    // Note by Yoonsoo Kim, Oct 2021 :
+    //
+    // The original implementation was
+    //
+    // ```
+    // if (l2Norm(*filtered_component) <= zero_cutoff * l2Norm(component)) {
+    //   continue;
+    // }
+    // if (std::log10(l2Norm(*filtered_component) / l2Norm(component)) >
+    //     -alpha * std::log10(static_cast<double>(dg_mesh.extents(d) - 1))) {
+    //   return true;
+    // }
+    // ```
+    //
+    // This form requires the extra use of `zero_cutoff` to prevent log function
+    // acting on zero or a very small number, and also can be problematic if the
+    // l2Norm of component is computed to be zero (if U < ~10^{-160}). The
+    // evaluation of the TCI criteria is switched into a mathematically
+    // equivalent but less error-prone form using power instead of log.
+    //
+    // Below is the benchmark result for a 3D DG element with 5 grid points per
+    // dimension:
+    // -------------------------------------------------------------------------
+    //                                                 Non-troubled    Troubled
+    //                                                   element        element
+    // -------------------------------------------------------------------------
+    // 1. previous implementation using log10            1262 ns         224 ns
+    // 2. new implementation with pow<double,double>     1091 ns         197 ns
+    // 3. using templated pow<int,int>                   1015 ns         174 ns
+    // -------------------------------------------------------------------------
+    //
+    // Case 3 requires the Persson alpha exponent to be a compile time
+    // (hard-coded) integer, which may be too restrictive. Given that switching
+    // to pow<double,double> already provides a certain amount of speed-up, it
+    // would be sufficient to stick to the case 2 for now.
+    //
+    if (pow(dg_mesh.extents(d) - 1, alpha) * l2Norm(*filtered_component) >
+        component_norm) {
       return true;
     }
   }
@@ -56,7 +90,7 @@ bool persson_tci_impl(const gsl::not_null<DataVector*> filtered_component,
   template bool persson_tci_impl(                                  \
       gsl::not_null<DataVector*> filtered_component,               \
       const DataVector& component, const Mesh<DIM(data)>& dg_mesh, \
-      double alpha, double zero_cutoff);
+      double alpha);
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 

--- a/src/Evolution/DgSubcell/PerssonTci.hpp
+++ b/src/Evolution/DgSubcell/PerssonTci.hpp
@@ -17,7 +17,7 @@ namespace detail {
 template <size_t Dim>
 bool persson_tci_impl(gsl::not_null<DataVector*> filtered_component,
                       const DataVector& component, const Mesh<Dim>& dg_mesh,
-                      double alpha, double zero_cutoff);
+                      double alpha);
 }  // namespace detail
 
 /*!
@@ -65,14 +65,12 @@ bool persson_tci_impl(gsl::not_null<DataVector*> filtered_component,
  */
 template <size_t Dim, typename SymmList, typename IndexList>
 bool persson_tci(const Tensor<DataVector, SymmList, IndexList>& tensor,
-                 const Mesh<Dim>& dg_mesh, const double alpha,
-                 const double zero_cutoff) {
+                 const Mesh<Dim>& dg_mesh, const double alpha) {
   DataVector filtered_component(dg_mesh.number_of_grid_points());
   for (size_t component_index = 0; component_index < tensor.size();
        ++component_index) {
     if (detail::persson_tci_impl(make_not_null(&filtered_component),
-                                 tensor[component_index], dg_mesh, alpha,
-                                 zero_cutoff)) {
+                                 tensor[component_index], dg_mesh, alpha)) {
       return true;
     }
   }

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/InitialDataTci.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/InitialDataTci.cpp
@@ -44,14 +44,14 @@ bool DgInitialDataTci::apply(
                                                    rdmp_delta0, rdmp_epsilon) or
          evolution::dg::subcell::persson_tci(
              get<ValenciaDivClean::Tags::TildeD>(dg_vars), dg_mesh,
-             persson_exponent, 1.0e-18) or
+             persson_exponent) or
          evolution::dg::subcell::persson_tci(
              get<ValenciaDivClean::Tags::TildeTau>(dg_vars), dg_mesh,
-             persson_exponent, 1.0e-18) or
+             persson_exponent) or
          (tci_options.magnetic_field_cutoff.has_value() and
           max(get(tilde_b_magnitude)) >
               tci_options.magnetic_field_cutoff.value() and
           evolution::dg::subcell::persson_tci(tilde_b_magnitude, dg_mesh,
-                                              persson_exponent, 1.0e-18));
+                                              persson_exponent));
 }
 }  // namespace grmhd::ValenciaDivClean::subcell

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.cpp
@@ -39,7 +39,6 @@ bool TciOnDgGrid<RecoveryScheme>::apply(
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const Mesh<3>& dg_mesh, const TciOptions& tci_options,
     const double persson_exponent) {
-  constexpr double persson_tci_epsilon = 1.0e-18;
   const size_t number_of_points = dg_mesh.number_of_grid_points();
   Variables<hydro::grmhd_tags<DataVector>> temp_prims(number_of_points);
 
@@ -134,10 +133,9 @@ bool TciOnDgGrid<RecoveryScheme>::apply(
   }
 
   // Check that tilde_d and tilde_tau satisfy the Persson TCI
-  if (evolution::dg::subcell::persson_tci(tilde_d, dg_mesh, persson_exponent,
-                                          persson_tci_epsilon) or
-      evolution::dg::subcell::persson_tci(tilde_tau, dg_mesh, persson_exponent,
-                                          persson_tci_epsilon)) {
+  if (evolution::dg::subcell::persson_tci(tilde_d, dg_mesh, persson_exponent) or
+      evolution::dg::subcell::persson_tci(tilde_tau, dg_mesh,
+                                          persson_exponent)) {
     return true;
   }
   // Check Cartesian magnitude of magnetic field satisfies the Persson TCI
@@ -147,8 +145,8 @@ bool TciOnDgGrid<RecoveryScheme>::apply(
   if (tci_options.magnetic_field_cutoff.has_value() and
       max(get(tilde_b_magnitude)) >
           tci_options.magnetic_field_cutoff.value() and
-      evolution::dg::subcell::persson_tci(
-          tilde_b_magnitude, dg_mesh, persson_exponent, persson_tci_epsilon)) {
+      evolution::dg::subcell::persson_tci(tilde_b_magnitude, dg_mesh,
+                                          persson_exponent)) {
     return true;
   }
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.cpp
@@ -23,17 +23,14 @@ bool TciOnFdGrid::apply(const Scalar<DataVector>& tilde_d,
       min(get(tilde_d)) <
           tci_options.minimum_rest_mass_density_times_lorentz_factor or
       min(get(tilde_tau)) < tci_options.minimum_tilde_tau or
-      evolution::dg::subcell::persson_tci(tilde_d, dg_mesh, persson_exponent,
-                                          1.0e-18) or
-      evolution::dg::subcell::persson_tci(tilde_tau, dg_mesh, persson_exponent,
-                                          1.0e-18);
+      evolution::dg::subcell::persson_tci(tilde_d, dg_mesh, persson_exponent) or
+      evolution::dg::subcell::persson_tci(tilde_tau, dg_mesh, persson_exponent);
   if (tci_options.magnetic_field_cutoff.has_value() and not cell_is_troubled) {
     const Scalar<DataVector> tilde_b_magnitude = magnitude(tilde_b);
-    cell_is_troubled =
-        (max(get(tilde_b_magnitude)) >
-             tci_options.magnetic_field_cutoff.value() and
-         evolution::dg::subcell::persson_tci(tilde_b_magnitude, dg_mesh,
-                                             persson_exponent, 1.0e-18));
+    cell_is_troubled = (max(get(tilde_b_magnitude)) >
+                            tci_options.magnetic_field_cutoff.value() and
+                        evolution::dg::subcell::persson_tci(
+                            tilde_b_magnitude, dg_mesh, persson_exponent));
   }
   return cell_is_troubled;
 }

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/InitialDataTci.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/InitialDataTci.cpp
@@ -27,10 +27,9 @@ bool DgInitialDataTci<Dim>::apply(
   return evolution::dg::subcell::two_mesh_rdmp_tci(dg_vars, subcell_vars,
                                                    rdmp_delta0, rdmp_epsilon) or
          evolution::dg::subcell::persson_tci(get<MassDensityCons>(dg_vars),
-                                             dg_mesh, persson_exponent,
-                                             1.0e-18) or
+                                             dg_mesh, persson_exponent) or
          evolution::dg::subcell::persson_tci(dg_pressure, dg_mesh,
-                                             persson_exponent, 1.0e-18);
+                                             persson_exponent);
 }
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnDgGrid.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnDgGrid.cpp
@@ -34,14 +34,12 @@ bool TciOnDgGrid<Dim>::apply(
       make_not_null(&get<SpecificInternalEnergy>(*dg_prim_vars)),
       make_not_null(&get<Pressure>(*dg_prim_vars)), mass_density,
       momentum_density, energy_density, eos);
-  constexpr double persson_tci_epsilon = 1.0e-18;
   return min(get(mass_density)) < min_density_allowed or
          min(get(get<Pressure>(*dg_prim_vars))) < min_pressure_allowed or
-         evolution::dg::subcell::persson_tci(
-             mass_density, dg_mesh, persson_exponent, persson_tci_epsilon) or
+         evolution::dg::subcell::persson_tci(mass_density, dg_mesh,
+                                             persson_exponent) or
          evolution::dg::subcell::persson_tci(get<Pressure>(*dg_prim_vars),
-                                             dg_mesh, persson_exponent,
-                                             persson_tci_epsilon);
+                                             dg_mesh, persson_exponent);
 }
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnFdGrid.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnFdGrid.cpp
@@ -32,7 +32,6 @@ bool TciOnFdGrid<Dim>::apply(
     const Scalar<DataVector>& dg_energy_density,
     const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
     const Mesh<Dim>& dg_mesh, const double persson_exponent) {
-  constexpr double persson_tci_epsilon = 1.0e-18;
   NewtonianEuler::PrimitiveFromConservative<Dim>::apply(
       make_not_null(&get<MassDensity>(*subcell_grid_prim_vars)),
       make_not_null(&get<Velocity>(*subcell_grid_prim_vars)),
@@ -55,11 +54,10 @@ bool TciOnFdGrid<Dim>::apply(
          min(min(get(get<Pressure>(*subcell_grid_prim_vars))),
              min(get(get<Pressure>(dg_grid_prim_vars)))) <
              min_pressure_allowed or
-         evolution::dg::subcell::persson_tci(
-             dg_mass_density, dg_mesh, persson_exponent, persson_tci_epsilon) or
+         evolution::dg::subcell::persson_tci(dg_mass_density, dg_mesh,
+                                             persson_exponent) or
          evolution::dg::subcell::persson_tci(get<Pressure>(dg_grid_prim_vars),
-                                             dg_mesh, persson_exponent,
-                                             persson_tci_epsilon);
+                                             dg_mesh, persson_exponent);
 }
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/InitialDataTci.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/InitialDataTci.cpp
@@ -18,10 +18,9 @@ bool DgInitialDataTci<Dim>::apply(
         subcell_vars,
     double rdmp_delta0, double rdmp_epsilon, double persson_exponent,
     const Mesh<Dim>& dg_mesh) {
-  constexpr double persson_tci_epsilon = 1.0e-18;
   return evolution::dg::subcell::persson_tci(
-             get<ScalarAdvection::Tags::U>(dg_vars), dg_mesh, persson_exponent,
-             persson_tci_epsilon) or
+             get<ScalarAdvection::Tags::U>(dg_vars), dg_mesh,
+             persson_exponent) or
          evolution::dg::subcell::two_mesh_rdmp_tci(dg_vars, subcell_vars,
                                                    rdmp_delta0, rdmp_epsilon);
 }

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/TciOnDgGrid.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/TciOnDgGrid.cpp
@@ -13,9 +13,7 @@ template <size_t Dim>
 bool TciOnDgGrid<Dim>::apply(const Scalar<DataVector>& dg_u,
                              const Mesh<Dim>& dg_mesh,
                              const double persson_exponent) {
-  constexpr double persson_tci_epsilon = 1.0e-18;
-  return ::evolution::dg::subcell::persson_tci(dg_u, dg_mesh, persson_exponent,
-                                               persson_tci_epsilon);
+  return ::evolution::dg::subcell::persson_tci(dg_u, dg_mesh, persson_exponent);
 }
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/TciOnFdGrid.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/TciOnFdGrid.cpp
@@ -13,9 +13,7 @@ template <size_t Dim>
 bool TciOnFdGrid<Dim>::apply(const Scalar<DataVector>& dg_u,
                              const Mesh<Dim>& dg_mesh,
                              const double persson_exponent) {
-  constexpr double persson_tci_epsilon = 1.0e-18;
-  return ::evolution::dg::subcell::persson_tci(
-      dg_u, dg_mesh, persson_exponent, persson_tci_epsilon);
+  return ::evolution::dg::subcell::persson_tci(dg_u, dg_mesh, persson_exponent);
 }
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)

--- a/tests/Unit/Evolution/DgSubcell/Test_PerssonTci.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_PerssonTci.cpp
@@ -63,7 +63,6 @@ void test_persson_impl(
   CAPTURE(tensor_component_to_modify);
   CAPTURE(persson_exponent);
   CAPTURE(expected_tci_triggered);
-  const double zero_cutoff = 1.0e-18;
   const Mesh<Dim> dg_mesh{num_pts_1d, Spectral::Basis::Legendre,
                           Spectral::Quadrature::GaussLobatto};
   const auto logical_coords = logical_coordinates(dg_mesh);
@@ -91,7 +90,7 @@ void test_persson_impl(
   }
 
   CHECK(evolution::dg::subcell::persson_tci(get<TagToCheck>(vars), dg_mesh,
-                                            persson_exponent, zero_cutoff) ==
+                                            persson_exponent) ==
         expected_tci_triggered);
 }
 


### PR DESCRIPTION
## Proposed changes

Change to an equivalent form using `pow` instead of `log`. Remove zero cutoffs (`persson_epsilon`) from code, and added a note with brief benchmark results as comments.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.