### PR TITLE
Optimize elliptic solver (3): Sparse subdomain data

### DIFF
--- a/src/NumericalAlgorithms/LinearSolver/BuildMatrix.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/BuildMatrix.hpp
@@ -1,0 +1,79 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <tuple>
+
+#include "DataStructures/DenseMatrix.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TypeTraits/CreateIsCallable.hpp"
+
+namespace LinearSolver::Serial {
+
+namespace detail {
+CREATE_IS_CALLABLE(reset)
+CREATE_IS_CALLABLE_V(reset)
+}  // namespace detail
+
+/*!
+ * \brief Construct an explicit matrix representation by "sniffing out" the
+ * linear operator, i.e. feeding it unit vectors.
+ *
+ * We currently store the matrix representation in a `DenseMatrix` because Blaze
+ * doesn't support the inversion of sparse matrices (yet).
+ *
+ * \param matrix Output buffer for the operator matrix. Must be sized correctly
+ * on entry.
+ * \param operand_buffer Memory buffer that can hold operand data for the
+ * `linear_operator`. Must be sized correctly on entry, and must be filled with
+ * zeros.
+ * \param result_buffer Memory buffer that can hold the result of the
+ * `linear_operator` applied to the operand. Must be sized correctly on entry.
+ * \param linear_operator The linear operator of which the matrix representation
+ * should be constructed. See `::LinearSolver::Serial::LinearSolver::solve` for
+ * requirements on the linear operator.
+ * \param operator_args These arguments are passed along to the
+ * `linear_operator` when it is applied to an operand.
+ */
+template <typename LinearOperator, typename OperandType, typename ResultType,
+          typename... OperatorArgs>
+void build_matrix(
+    const gsl::not_null<DenseMatrix<double, blaze::columnMajor>*> matrix,
+    const gsl::not_null<OperandType*> operand_buffer,
+    const gsl::not_null<ResultType*> result_buffer,
+    const LinearOperator& linear_operator,
+    const std::tuple<OperatorArgs...>& operator_args = {}) {
+  size_t i = 0;
+  // Re-using the iterators for all operator invocations
+  auto result_iterator_begin = result_buffer->begin();
+  auto result_iterator_end = result_buffer->end();
+  for (double& unit_vector_data : *operand_buffer) {
+    // Set a 1 at the unit vector location i
+    unit_vector_data = 1.;
+    // Invoke the operator on the unit vector
+    std::apply(
+        linear_operator,
+        std::tuple_cat(std::forward_as_tuple(result_buffer, *operand_buffer),
+                       operator_args));
+    // Set the unit vector back to zero
+    unit_vector_data = 0.;
+    // Reset the iterator by calling its `reset` member function or by
+    // re-creating it
+    if constexpr (detail::is_reset_callable_v<
+                      decltype(result_iterator_begin)>) {
+      result_iterator_begin.reset();
+    } else {
+      result_iterator_begin = result_buffer->begin();
+      result_iterator_end = result_buffer->end();
+    }
+    // Store the result in column i of the matrix
+    std::copy(result_iterator_begin, result_iterator_end,
+              column(*matrix, i).begin());
+    ++i;
+  }
+}
+
+}  // namespace LinearSolver::Serial

--- a/src/NumericalAlgorithms/LinearSolver/CMakeLists.txt
+++ b/src/NumericalAlgorithms/LinearSolver/CMakeLists.txt
@@ -16,6 +16,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  BuildMatrix.hpp
   ExplicitInverse.hpp
   Gmres.hpp
   InnerProduct.hpp

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
@@ -12,6 +12,8 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DenseMatrix.hpp"
+#include "DataStructures/DenseVector.hpp"
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
@@ -45,6 +47,7 @@
 #include "Framework/ActionTesting.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/LinearSolver/BuildMatrix.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
@@ -263,6 +266,55 @@ struct ApplySubdomainOperator {
   }
 };
 
+template <typename SubdomainOperator, typename Fields>
+struct TestSubdomainOperatorMatrix {
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            size_t Dim, typename ActionList, typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTags>&&> apply(
+      db::DataBox<DbTags>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ElementId<Dim>& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    const auto& subdomain_data = db::get<SubdomainDataTag<Dim, Fields>>(box);
+
+    // Build the explicit matrix representation of the subdomain operator
+    // Note: This would be an interesting unit of work to benchmark.
+    const auto& subdomain_operator =
+        db::get<SubdomainOperatorTag<SubdomainOperator>>(box);
+    const size_t operator_size = subdomain_data.size();
+    DenseMatrix<double, blaze::columnMajor> operator_matrix{operator_size,
+                                                            operator_size};
+    auto operand_buffer =
+        make_with_value<std::decay_t<decltype(subdomain_data)>>(subdomain_data,
+                                                                0.);
+    auto result_buffer = make_with_value<
+        typename SubdomainOperatorAppliedToDataTag<Dim, Fields>::type>(
+        subdomain_data, 0.);
+    ::LinearSolver::Serial::build_matrix(
+        make_not_null(&operator_matrix), make_not_null(&operand_buffer),
+        make_not_null(&result_buffer), subdomain_operator,
+        std::forward_as_tuple(box));
+
+    // Check the matrix is equivalent to the operator by applying it to the
+    // data. We need to do the matrix multiplication on a contiguous buffer
+    // because the `ElementCenteredSubdomainData` is not contiguous.
+    DenseVector<double> contiguous_operand(operator_size);
+    std::copy(subdomain_data.begin(), subdomain_data.end(),
+              contiguous_operand.begin());
+    const DenseVector<double> contiguous_result =
+        operator_matrix * contiguous_operand;
+    std::copy(contiguous_result.begin(), contiguous_result.end(),
+              result_buffer.begin());
+    const auto& expected_operator_applied_to_data =
+        db::get<SubdomainOperatorAppliedToDataTag<Dim, Fields>>(box);
+    Approx custom_approx = Approx::custom().epsilon(1.e-12).scale(1.0);
+    CHECK_ITERABLE_CUSTOM_APPROX(
+        result_buffer, expected_operator_applied_to_data, custom_approx);
+    return {std::move(box)};
+  }
+};
+
 template <typename Metavariables, typename System, typename SubdomainOperator,
           typename ExtraInitActions>
 struct ElementArray {
@@ -320,6 +372,8 @@ struct ElementArray {
                      Parallel::Actions::TerminatePhase,
                      ApplySubdomainOperator<SubdomainOperator,
                                             typename fields_tag::tags_list>,
+                     TestSubdomainOperatorMatrix<
+                         SubdomainOperator, typename fields_tag::tags_list>,
                      Parallel::Actions::TerminatePhase>>>;
 };
 
@@ -363,6 +417,11 @@ void test_subdomain_operator(
       SubdomainDataTag<Dim, typename fields_tag::tags_list>;
   using subdomain_operator_applied_to_fields_tag =
       typename element_array::subdomain_operator_applied_to_fields_tag;
+
+  // Select randomly which iteration of the loops below perform expensive tests.
+  MAKE_GENERATOR(gen);
+  std::uniform_int_distribution<size_t> dist_select_overlap(0, max_overlap);
+  const size_t rnd_overlap = dist_select_overlap(gen);
 
   // The test should hold for any number of overlap points
   for (size_t overlap = 0; overlap <= max_overlap; overlap++) {
@@ -417,6 +476,12 @@ void test_subdomain_operator(
                                    ::Actions::SetData<tmpl::list<tag>>>(
           make_not_null(&runner), local_element_id, value);
     };
+
+    // For selection of expensive tests
+    std::uniform_int_distribution<size_t> dist_select_subdomain_center(
+        0, element_ids.size() - 1);
+    const size_t rnd_subdomain_center = dist_select_subdomain_center(gen);
+    size_t subdomain_center_id = 0;
 
     // Take each element as the subdomain-center in turn
     for (const auto& subdomain_center : element_ids) {
@@ -511,6 +576,19 @@ void test_subdomain_operator(
         CHECK_VARIABLES_CUSTOM_APPROX(overlap_result, expected_overlap_result,
                                       custom_approx);
       }
+
+      // Now build the matrix representation of the subdomain operator
+      // explicitly, and apply it to the data to make sure the matrix is
+      // equivalent to the matrix-free operator. This is important to test
+      // because the subdomain operator includes optimizations for when it is
+      // invoked on sparse data, i.e. data that is mostly zero, which is the
+      // case when building it explicitly column-by-column.
+      if (overlap == rnd_overlap and
+          subdomain_center_id == rnd_subdomain_center) {
+        ActionTesting::next_action<element_array>(make_not_null(&runner),
+                                                  subdomain_center);
+      }
+      ++subdomain_center_id;
     }  // loop over subdomain centers
   }    // loop over overlaps
 }

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_LinearSolver")
 
 set(LIBRARY_SOURCES
+  Test_BuildMatrix.cpp
   Test_ExplicitInverse.cpp
   Test_Gmres.cpp
   Test_InnerProduct.cpp

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Test_BuildMatrix.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Test_BuildMatrix.cpp
@@ -1,0 +1,95 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <utility>
+
+#include "DataStructures/ApplyMatrices.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/DenseMatrix.hpp"
+#include "DataStructures/DenseVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/NumericalAlgorithms/LinearSolver/TestHelpers.hpp"
+#include "NumericalAlgorithms/LinearSolver/BuildMatrix.hpp"
+#include "ParallelAlgorithms/LinearSolver/Schwarz/ElementCenteredSubdomainData.hpp"
+#include "ParallelAlgorithms/LinearSolver/Schwarz/OverlapHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace helpers = TestHelpers::LinearSolver;
+
+namespace {
+struct ScalarFieldTag : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+}  // namespace
+
+namespace LinearSolver::Serial {
+
+SPECTRE_TEST_CASE("Unit.LinearSolver.Serial.BuildMatrix",
+                  "[Unit][NumericalAlgorithms][LinearSolver]") {
+  {
+    INFO("Build a simple matrix");
+    const DenseMatrix<double> matrix{{4., 1.}, {3., 1.}};
+    const helpers::ApplyMatrix linear_operator{matrix};
+    DenseMatrix<double> matrix_representation(2, 2);
+    DenseVector<double> operand_buffer(2, 0.);
+    DenseVector<double> result_buffer(2, 0.);
+    build_matrix(make_not_null(&matrix_representation),
+                 make_not_null(&operand_buffer), make_not_null(&result_buffer),
+                 linear_operator);
+    CHECK_MATRIX_APPROX(matrix_representation, matrix);
+    CHECK(linear_operator.invocations == 2);
+  }
+  {
+    INFO("Build matrix from a heterogeneous data structure");
+    using SubdomainData = ::LinearSolver::Schwarz::ElementCenteredSubdomainData<
+        1, tmpl::list<ScalarFieldTag>>;
+
+    const Matrix matrix_element{{4., 1., 1.}, {1., 1., 3.}, {0., 2., 0.}};
+    const Matrix matrix_overlap{{4., 1.}, {3., 1.}};
+    Matrix expected_matrix(5, 5, 0.);
+    blaze::submatrix(expected_matrix, 0, 0, 3, 3) = matrix_element;
+    blaze::submatrix(expected_matrix, 3, 3, 2, 2) = matrix_overlap;
+    const ::LinearSolver::Schwarz::OverlapId<1> overlap_id{
+        Direction<1>::lower_xi(), ElementId<1>{0}};
+    const std::array<std::reference_wrapper<const Matrix>, 1> matrices_element{
+        matrix_element};
+    const std::array<std::reference_wrapper<const Matrix>, 1> matrices_overlap{
+        matrix_overlap};
+    const auto linear_operator = [&matrices_element, &matrices_overlap,
+                                  &overlap_id](
+                                     const gsl::not_null<SubdomainData*> result,
+                                     const SubdomainData& operand) {
+      apply_matrices(make_not_null(&result->element_data), matrices_element,
+                     operand.element_data, Index<1>{3});
+      apply_matrices(make_not_null(&result->overlap_data.at(overlap_id)),
+                     matrices_overlap, operand.overlap_data.at(overlap_id),
+                     Index<1>{2});
+    };
+
+    DenseMatrix<double> matrix_representation(5, 5);
+    SubdomainData operand_buffer{3};
+    get(get<ScalarFieldTag>(operand_buffer.element_data)) = DataVector(3, 0.);
+    operand_buffer.overlap_data.emplace(overlap_id,
+                                        typename SubdomainData::OverlapData{2});
+    get(get<ScalarFieldTag>(operand_buffer.overlap_data.at(overlap_id))) =
+        DataVector(2, 0.);
+    auto result_buffer = make_with_value<SubdomainData>(operand_buffer, 0.);
+
+    build_matrix(make_not_null(&matrix_representation),
+                 make_not_null(&operand_buffer), make_not_null(&result_buffer),
+                 linear_operator);
+    CHECK_MATRIX_APPROX(matrix_representation, expected_matrix);
+  }
+}
+
+}  // namespace LinearSolver::Serial


### PR DESCRIPTION
## Proposed changes

At some point the elliptic solver builds a matrix representation of a Poisson operator by feeding it unit vectors, so most of the data is actually zero (i.e. sparse). This PR makes the DG operator a lot faster when it operates on sparse data.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
