### PR TITLE
Use Direction/ElementId comparison operator

### DIFF
--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementCenteredSubdomainData.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementCenteredSubdomainData.hpp
@@ -37,31 +37,7 @@ void ordered_overlap_ids(
                  [](const auto& overlap_id_and_value) {
                    return overlap_id_and_value.first;
                  });
-  std::sort(overlap_ids->begin(), overlap_ids->end(),
-            [](const OverlapId<Dim>& lhs, const OverlapId<Dim>& rhs) {
-              if (lhs.first.axis() != rhs.first.axis()) {
-                return lhs.first.axis() < rhs.first.axis();
-              }
-              if (lhs.first.side() != rhs.first.side()) {
-                return lhs.first.side() < rhs.first.side();
-              }
-              if (lhs.second.block_id() != rhs.second.block_id()) {
-                return lhs.second.block_id() < rhs.second.block_id();
-              }
-              for (size_t d = 0; d < Dim; ++d) {
-                const auto lhs_segment_id = lhs.second.segment_id(d);
-                const auto rhs_segment_id = rhs.second.segment_id(d);
-                if (lhs_segment_id.refinement_level() !=
-                    rhs_segment_id.refinement_level()) {
-                  return lhs_segment_id.refinement_level() <
-                         rhs_segment_id.refinement_level();
-                }
-                if (lhs_segment_id.index() != rhs_segment_id.index()) {
-                  return lhs_segment_id.index() < rhs_segment_id.index();
-                }
-              }
-              return false;
-            });
+  std::sort(overlap_ids->begin(), overlap_ids->end());
 }
 }  // namespace detail
 


### PR DESCRIPTION
This code can now just be deleted because Direction
and ElementId have comparison operators now.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
