### PR TITLE
Expand WhichWedges Options to include Half Wedges

### DIFF
--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -359,18 +359,18 @@ Domain<3> BinaryCompactObject::create_domain() const {
   // ObjectA/B is on the left/right, respectively.
   Maps maps_center_A = sph_wedge_coordinate_maps<Frame::Inertial>(
       object_A_.inner_radius, object_A_.outer_radius, inner_sphericity_A, 1.0,
-      use_equiangular_map_, object_A_.x_coord, false, 1.0, 2, {},
+      use_equiangular_map_, object_A_.x_coord, 1.0, 2, {},
       object_A_radial_distribution);
   Maps maps_cube_A = sph_wedge_coordinate_maps<Frame::Inertial>(
       object_A_.outer_radius, sqrt(3.0) * 0.5 * length_inner_cube_, 1.0, 0.0,
-      use_equiangular_map_, object_A_.x_coord, false);
+      use_equiangular_map_, object_A_.x_coord);
   Maps maps_center_B = sph_wedge_coordinate_maps<Frame::Inertial>(
       object_B_.inner_radius, object_B_.outer_radius, inner_sphericity_B, 1.0,
-      use_equiangular_map_, object_B_.x_coord, false, 1.0, 2, {},
+      use_equiangular_map_, object_B_.x_coord, 1.0, 2, {},
       object_B_radial_distribution);
   Maps maps_cube_B = sph_wedge_coordinate_maps<Frame::Inertial>(
       object_B_.outer_radius, sqrt(3.0) * 0.5 * length_inner_cube_, 1.0, 0.0,
-      use_equiangular_map_, object_B_.x_coord, false);
+      use_equiangular_map_, object_B_.x_coord);
   Maps maps_frustums = frustum_coordinate_maps<Frame::Inertial>(
       length_inner_cube_, length_outer_cube_, use_equiangular_map_,
       {{-translation_, 0.0, 0.0}}, projective_scale_factor_);
@@ -416,12 +416,13 @@ Domain<3> BinaryCompactObject::create_domain() const {
 
   Maps maps_first_outer_shell = sph_wedge_coordinate_maps<Frame::Inertial>(
       radius_enveloping_cube_, radius_enveloping_sphere_, 0.0, 1.0,
-      use_equiangular_map_, 0.0, true, 1.0, 2, {},
-      {domain::CoordinateMaps::Distribution::Linear}, ShellWedges::All);
+      use_equiangular_map_, 0.0, 1.0, 2, {},
+      {domain::CoordinateMaps::Distribution::Linear},
+      ShellWedges::AllAndHalvesYZ);
   Maps maps_second_outer_shell = sph_wedge_coordinate_maps<Frame::Inertial>(
       radius_enveloping_sphere_, outer_radius_domain_, 1.0, 1.0,
-      use_equiangular_map_, 0.0, true, 1.0, 2, {},
-      {radial_distribution_outer_shell_}, ShellWedges::All);
+      use_equiangular_map_, 0.0, 1.0, 2, {}, {radial_distribution_outer_shell_},
+      ShellWedges::AllAndHalvesYZ);
   if (outer_boundary_condition_ != nullptr) {
     // The outer 10 wedges all have to have the outer boundary condition
     // applied

--- a/src/Domain/Creators/Shell.hpp
+++ b/src/Domain/Creators/Shell.hpp
@@ -20,6 +20,8 @@
 namespace domain {
 namespace CoordinateMaps {
 class Affine;
+template <size_t VolumeDim>
+class DiscreteRotation;
 class EquatorialCompression;
 template <size_t VolumeDim>
 class Identity;
@@ -45,6 +47,7 @@ class Shell : public DomainCreator<3> {
  public:
   using maps_list = tmpl::list<domain::CoordinateMap<
       Frame::BlockLogical, Frame::Inertial, CoordinateMaps::Wedge<3>,
+      CoordinateMaps::DiscreteRotation<3>,
       CoordinateMaps::EquatorialCompression,
       CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
                                      CoordinateMaps::Identity<2>>>>;
@@ -194,9 +197,10 @@ class Shell : public DomainCreator<3> {
       "the equator for values greater than 1.0, and towards the poles for\n"
       "positive values less than 1.0. The user may also specify the axis\n"
       "along which this compression is applied. The user may also choose to\n"
-      "use only a "
-      "single wedge (along the -x direction), or four wedges along the x-y "
-      "plane using the `WhichWedges` option. Using the RadialPartitioning "
+      "use only a single wedge (along the -x direction), or four wedges\n"
+      "along a chosen plane, or a whole shell with additional half wedges\n"
+      "along a chosen plane using the `WhichWedges` option. Using the\n"
+      "RadialPartitioning "
       "option, a user may set the locations of boundaries of radial "
       "partitions, each of which will have the grid points and refinement "
       "specified from the previous options. The RadialDistribution option "
@@ -255,6 +259,7 @@ class Shell : public DomainCreator<3> {
   std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
       time_dependence_;
   size_t number_of_layers_{};
+  size_t blocks_per_layer_{};
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
       inner_boundary_condition_;
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -123,12 +123,22 @@ auto corners_for_rectilinear_domains(
     -> std::vector<std::array<size_t, two_to_the(VolumeDim)>>;
 
 /// \ingroup ComputationalDomainGroup
-/// The number of wedges to include in the Shell domain.
+/// Which wedges to include in the Shell domain.
 enum class ShellWedges {
   /// Use the entire shell
   All,
-  /// Use only the four equatorial wedges
-  FourOnEquator,
+  /// Use the entire shell and use half wedges on the XY plane.
+  AllAndHalvesXY,
+  /// Use the entire shell and use half wedges on the XZ plane.
+  AllAndHalvesXZ,
+  /// Use the entire shell and use half wedges on the YZ plane.
+  AllAndHalvesYZ,
+  /// Use only the four equatorial wedges on the XY plane.
+  FourOnEquatorXY,
+  /// Use only the four equatorial wedges on the XY plane.
+  FourOnEquatorXZ,
+  /// Use only the four equatorial wedges on the XY plane.
+  FourOnEquatorYZ,
   /// Use only the single wedge along -x
   OneAlongMinusX
 };
@@ -140,10 +150,10 @@ enum class ShellWedges {
 /// The argument `x_coord_of_shell_center` specifies a translation of the Shell
 /// in the x-direction in the TargetFrame. For example, the BBH DomainCreator
 /// uses this to set the position of each BH.
-/// When the argument `use_half_wedges` is set to `true`, the wedges in the
-/// +z,-z,+y,-y directions are cut in half along their xi-axes. The resulting
-/// ten CoordinateMaps are used for the outermost Blocks of the BBH Domain.
-/// The argument `aspect_ratio` sets the equatorial compression factor,
+/// When the argument `which_wedges` is set to `AllAndHalvesYZ`, the wedges in
+/// the +z,-z,+y,-y directions are cut in half along their xi-axes. The
+/// resulting ten CoordinateMaps are used for the outermost Blocks of the BBH
+/// Domain. The argument `aspect_ratio` sets the equatorial compression factor,
 /// used by the EquatorialCompression maps which get composed with the Wedges.
 /// This is done if `aspect_ratio` is set to something other than the default
 /// value of one. The `radial_partitioning` specifies the radial boundaries of
@@ -154,8 +164,8 @@ template <typename TargetFrame>
 auto sph_wedge_coordinate_maps(
     double inner_radius, double outer_radius, double inner_sphericity,
     double outer_sphericity, bool use_equiangular_map,
-    double x_coord_of_shell_center = 0.0, bool use_half_wedges = false,
-    double aspect_ratio = 1.0, size_t index_polar_axis = 2,
+    double x_coord_of_shell_center = 0.0, double aspect_ratio = 1.0,
+    size_t index_polar_axis = 2,
     const std::vector<double>& radial_partitioning = {},
     const std::vector<domain::CoordinateMaps::Distribution>&
         radial_distribution = {domain::CoordinateMaps::Distribution::Linear},

--- a/tests/Unit/Domain/Creators/Test_Shell.cpp
+++ b/tests/Unit/Domain/Creators/Test_Shell.cpp
@@ -22,6 +22,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/DiscreteRotation.hpp"
 #include "Domain/CoordinateMaps/EquatorialCompression.hpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
@@ -169,7 +170,7 @@ void test_shell_construction(
       {{Direction<3>::upper_zeta()}, {Direction<3>::lower_zeta()}}};
 
   std::vector<std::array<size_t, 3>>::size_type num_pieces = 6;
-  if (UNLIKELY(which_wedges == ShellWedges::FourOnEquator)) {
+  if (UNLIKELY(which_wedges == ShellWedges::FourOnEquatorXY)) {
     num_pieces = 4;
     expected_block_neighbors = {
         {{Direction<3>::upper_xi(), {2, half_turn_about_zeta}},
@@ -250,7 +251,7 @@ void test_shell_construction(
                        {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
                         Direction<3>::upper_eta()}}},
                    use_equiangular_map, Halves::Both, radial_distribution});
-    if (UNLIKELY(which_wedges == ShellWedges::FourOnEquator)) {
+    if (UNLIKELY(which_wedges == ShellWedges::FourOnEquatorXY)) {
       vector_of_maps.erase(vector_of_maps.begin(), vector_of_maps.begin() + 2);
     } else if (UNLIKELY(which_wedges == ShellWedges::OneAlongMinusX)) {
       vector_of_maps.erase(vector_of_maps.begin(), vector_of_maps.begin() + 5);
@@ -345,7 +346,7 @@ void test_shell_construction(
                      Direction<3>::upper_eta()}}},
                 use_equiangular_map, Halves::Both, radial_distribution},
             compression, translation));
-    if (UNLIKELY(which_wedges == ShellWedges::FourOnEquator)) {
+    if (UNLIKELY(which_wedges == ShellWedges::FourOnEquatorXY)) {
       vector_of_maps.erase(vector_of_maps.begin(), vector_of_maps.begin() + 2);
     } else if (UNLIKELY(which_wedges == ShellWedges::OneAlongMinusX)) {
       vector_of_maps.erase(vector_of_maps.begin(), vector_of_maps.begin() + 5);
@@ -878,7 +879,7 @@ void test_shell_factory_wedges_four_on_equator() {
       "    IndexPolarAxis: 2\n"
       "  RadialPartitioning: []\n"
       "  RadialDistribution: [Logarithmic]\n"
-      "  WhichWedges: FourOnEquator\n"
+      "  WhichWedges: FourOnEquatorXY\n"
       "  TimeDependence: None\n");
   const double inner_radius = 1.0;
   const double outer_radius = 3.0;
@@ -887,7 +888,7 @@ void test_shell_factory_wedges_four_on_equator() {
   const double aspect_ratio = 2.0;
   const size_t index_polar_axis = 2;
   const bool use_logarithmic_map = true;
-  const ShellWedges which_wedges = ShellWedges::FourOnEquator;
+  const ShellWedges which_wedges = ShellWedges::FourOnEquatorXY;
   test_shell_construction(
       dynamic_cast<const creators::Shell&>(*shell), inner_radius, outer_radius,
       false, grid_points_r_angular, {4, make_array<3>(refinement_level)},

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -17,6 +17,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/DiscreteRotation.hpp"
 #include "Domain/CoordinateMaps/EquatorialCompression.hpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/Frustum.hpp"
@@ -133,9 +134,9 @@ test_wedge_map_generation(double inner_radius, double outer_radius,
                           double inner_sphericity, double outer_sphericity,
                           bool use_equiangular_map,
                           double x_coord_of_shell_center = 0.0,
-                          bool use_half_wedges = false,
                           double aspect_ratio = 1.0,
-                          size_t index_polar_axis = 2) {
+                          size_t index_polar_axis = 2,
+                          ShellWedges which_wedges = ShellWedges::All) {
   using Wedge3DMap = CoordinateMaps::Wedge<3>;
   using Identity2D = CoordinateMaps::Identity<2>;
   using Affine = CoordinateMaps::Affine;
@@ -146,19 +147,22 @@ test_wedge_map_generation(double inner_radius, double outer_radius,
   const auto compression =
       CoordinateMaps::EquatorialCompression{aspect_ratio, index_polar_axis};
 
-  if (use_half_wedges) {
+  const auto rotation =
+      CoordinateMaps::DiscreteRotation<3>{OrientationMap<3>{}};
+
+  if (which_wedges == ShellWedges::AllAndHalvesYZ) {
     using Halves = Wedge3DMap::WedgeHalves;
     return make_vector(
         make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
                        outer_sphericity, OrientationMap<3>{},
                        use_equiangular_map, Halves::LowerOnly},
-            compression, translation),
+            rotation, compression, translation),
         make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
                        outer_sphericity, OrientationMap<3>{},
                        use_equiangular_map, Halves::UpperOnly},
-            compression, translation),
+            rotation, compression, translation),
         make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
                        outer_sphericity,
@@ -166,7 +170,7 @@ test_wedge_map_generation(double inner_radius, double outer_radius,
                            {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
                             Direction<3>::lower_zeta()}}},
                        use_equiangular_map, Halves::LowerOnly},
-            compression, translation),
+            rotation, compression, translation),
         make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
                        outer_sphericity,
@@ -174,7 +178,7 @@ test_wedge_map_generation(double inner_radius, double outer_radius,
                            {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
                             Direction<3>::lower_zeta()}}},
                        use_equiangular_map, Halves::UpperOnly},
-            compression, translation),
+            rotation, compression, translation),
         make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             Wedge3DMap{
                 inner_radius, outer_radius, inner_sphericity, outer_sphericity,
@@ -182,7 +186,7 @@ test_wedge_map_generation(double inner_radius, double outer_radius,
                     {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
                      Direction<3>::lower_eta()}}},
                 use_equiangular_map, Halves::LowerOnly},
-            compression, translation),
+            rotation, compression, translation),
         make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             Wedge3DMap{
                 inner_radius, outer_radius, inner_sphericity, outer_sphericity,
@@ -190,7 +194,7 @@ test_wedge_map_generation(double inner_radius, double outer_radius,
                     {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
                      Direction<3>::lower_eta()}}},
                 use_equiangular_map, Halves::UpperOnly},
-            compression, translation),
+            rotation, compression, translation),
         make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             Wedge3DMap{
                 inner_radius, outer_radius, inner_sphericity, outer_sphericity,
@@ -198,7 +202,7 @@ test_wedge_map_generation(double inner_radius, double outer_radius,
                     {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
                      Direction<3>::upper_eta()}}},
                 use_equiangular_map, Halves::LowerOnly},
-            compression, translation),
+            rotation, compression, translation),
         make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             Wedge3DMap{
                 inner_radius, outer_radius, inner_sphericity, outer_sphericity,
@@ -206,7 +210,7 @@ test_wedge_map_generation(double inner_radius, double outer_radius,
                     {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
                      Direction<3>::upper_eta()}}},
                 use_equiangular_map, Halves::UpperOnly},
-            compression, translation),
+            rotation, compression, translation),
         make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             Wedge3DMap{
                 inner_radius, outer_radius, inner_sphericity, outer_sphericity,
@@ -214,7 +218,7 @@ test_wedge_map_generation(double inner_radius, double outer_radius,
                     {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
                      Direction<3>::upper_eta()}}},
                 use_equiangular_map},
-            compression, translation),
+            rotation, compression, translation),
         make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             Wedge3DMap{
                 inner_radius, outer_radius, inner_sphericity, outer_sphericity,
@@ -222,7 +226,7 @@ test_wedge_map_generation(double inner_radius, double outer_radius,
                     {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
                      Direction<3>::upper_eta()}}},
                 use_equiangular_map},
-            compression, translation));
+            rotation, compression, translation));
   }
 
   return make_vector(
@@ -276,52 +280,27 @@ test_wedge_map_generation(double inner_radius, double outer_radius,
 void test_wedge_map_generation_against_domain_helpers(
     double inner_radius, double outer_radius, double inner_sphericity,
     double outer_sphericity, bool use_equiangular_map,
-    double x_coord_of_shell_center = 0.0, bool use_half_wedges = false,
-    double aspect_ratio = 1.0, size_t index_polar_axis = 2) {
+    double x_coord_of_shell_center = 0.0, double aspect_ratio = 1.0,
+    size_t index_polar_axis = 2, ShellWedges which_wedges = ShellWedges::All) {
   const auto expected_coord_maps = test_wedge_map_generation(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
-      aspect_ratio, index_polar_axis);
+      use_equiangular_map, x_coord_of_shell_center, aspect_ratio,
+      index_polar_axis, which_wedges);
   const auto maps = sph_wedge_coordinate_maps<Frame::Inertial>(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
-      aspect_ratio, index_polar_axis);
+      use_equiangular_map, x_coord_of_shell_center, aspect_ratio,
+      index_polar_axis, {}, {domain::CoordinateMaps::Distribution::Linear},
+      which_wedges);
   CHECK(maps.size() == expected_coord_maps.size());
   for (size_t i = 0; i < expected_coord_maps.size(); i++) {
     check_if_maps_are_equal(*expected_coord_maps[i], *maps[i]);
   }
 }
 
-// [[OutputRegex, If we are using half wedges we must also be using
-// ShellWedges::All.]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.Domain.DomainHelpers.WedgeCoordinateMaps.Assert1", "[Domain][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  const double inner_radius = 0.5;
-  const double outer_radius = 2.0;
-  const double inner_sphericity = 1.0;
-  const double outer_sphericity = 1.0;
-  const bool use_equiangular_map = true;
-  const double x_coord_of_shell_center = 0.1;
-  const bool use_half_wedges = true;
-  const double aspect_ratio = 1.0;
-  const size_t index_polar_axis = 1;
-  const std::vector<domain::CoordinateMaps::Distribution> radial_distribution{
-      domain::CoordinateMaps::Distribution::Logarithmic};
-  const ShellWedges which_wedges = ShellWedges::FourOnEquator;
-  static_cast<void>(sph_wedge_coordinate_maps<Frame::Inertial>(
-      inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
-      aspect_ratio, index_polar_axis, {}, radial_distribution, which_wedges));
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
 // [[OutputRegex, If we are using more than one layer the inner and outer
 // sphericities must match.]]
 [[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.Domain.DomainHelpers.WedgeCoordinateMaps.Assert2", "[Domain][Unit]") {
+    "Unit.Domain.DomainHelpers.WedgeCoordinateMaps.Assert1", "[Domain][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   const double inner_radius = 0.5;
@@ -330,7 +309,6 @@ void test_wedge_map_generation_against_domain_helpers(
   const double outer_sphericity = 1.0;
   const bool use_equiangular_map = true;
   const double x_coord_of_shell_center = 0.1;
-  const bool use_half_wedges = true;
   const double aspect_ratio = 1.0;
   const double index_polar_axis = 1;
   std::vector<double> radial_partitioning{1., 1.5};
@@ -341,8 +319,8 @@ void test_wedge_map_generation_against_domain_helpers(
   const ShellWedges which_wedges = ShellWedges::All;
   static_cast<void>(sph_wedge_coordinate_maps<Frame::Inertial>(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
-      aspect_ratio, index_polar_axis, radial_partitioning, radial_distribution,
+      use_equiangular_map, x_coord_of_shell_center, aspect_ratio,
+      index_polar_axis, radial_partitioning, radial_distribution,
       which_wedges));
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
@@ -405,10 +383,10 @@ void test_ten_wedge_directions_equiangular() {
   const double inner_sphericity = 0.0;
   const double outer_sphericity = 1.0;
   const bool use_equiangular_map = true;
-  const bool use_half_wedges = true;
+  const ShellWedges which_wedges = ShellWedges::AllAndHalvesYZ;
   test_wedge_map_generation_against_domain_helpers(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, 0.0, use_half_wedges);
+      use_equiangular_map, 0.0, 1.0, 2, which_wedges);
 }
 
 void test_ten_wedge_directions_equidistant() {
@@ -418,10 +396,10 @@ void test_ten_wedge_directions_equidistant() {
   const double inner_sphericity = 0.01;
   const double outer_sphericity = 0.99;
   const bool use_equiangular_map = false;
-  const bool use_half_wedges = true;
+  const ShellWedges which_wedges = ShellWedges::AllAndHalvesYZ;
   test_wedge_map_generation_against_domain_helpers(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, 0.0, use_half_wedges);
+      use_equiangular_map, 0.0, 1.0, 2, which_wedges);
 }
 
 void test_six_wedge_directions_compressed_equiangular() {
@@ -431,13 +409,11 @@ void test_six_wedge_directions_compressed_equiangular() {
   const double inner_sphericity = 0.0;
   const double outer_sphericity = 1.0;
   const bool use_equiangular_map = true;
-  const bool use_half_wedges = false;
   const double aspect_ratio = 6.0;
   const size_t index_polar_axis = 2;
   test_wedge_map_generation_against_domain_helpers(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, 0.0, use_half_wedges, aspect_ratio,
-      index_polar_axis);
+      use_equiangular_map, 0.0, aspect_ratio, index_polar_axis);
 }
 
 void test_six_wedge_directions_compressed_equidistant() {
@@ -447,13 +423,11 @@ void test_six_wedge_directions_compressed_equidistant() {
   const double inner_sphericity = 0.0;
   const double outer_sphericity = 1.0;
   const bool use_equiangular_map = false;
-  const bool use_half_wedges = false;
   const double aspect_ratio = 0.6;
   const size_t index_polar_axis = 1;
   test_wedge_map_generation_against_domain_helpers(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, 0.0, use_half_wedges, aspect_ratio,
-      index_polar_axis);
+      use_equiangular_map, 0.0, aspect_ratio, index_polar_axis);
 }
 
 void test_six_wedge_directions_compressed_translated_equiangular() {
@@ -463,14 +437,13 @@ void test_six_wedge_directions_compressed_translated_equiangular() {
   const double inner_sphericity = 0.0;
   const double outer_sphericity = 1.0;
   const bool use_equiangular_map = true;
-  const bool use_half_wedges = false;
   const double aspect_ratio = 6.0;
   const size_t index_polar_axis = 0;
   const double x_coord_of_shell_center = 2.7;
   test_wedge_map_generation_against_domain_helpers(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
-      aspect_ratio, index_polar_axis);
+      use_equiangular_map, x_coord_of_shell_center, aspect_ratio,
+      index_polar_axis);
 }
 
 void test_six_wedge_directions_compressed_translated_equidistant() {
@@ -480,14 +453,13 @@ void test_six_wedge_directions_compressed_translated_equidistant() {
   const double inner_sphericity = 0.0;
   const double outer_sphericity = 1.0;
   const bool use_equiangular_map = false;
-  const bool use_half_wedges = false;
   const double aspect_ratio = 0.6;
   const size_t index_polar_axis = 2;
   const double x_coord_of_shell_center = 2.7;
   test_wedge_map_generation_against_domain_helpers(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
-      aspect_ratio, index_polar_axis);
+      use_equiangular_map, x_coord_of_shell_center, aspect_ratio,
+      index_polar_axis);
 }
 
 void test_ten_wedge_directions_compressed_translated_equiangular() {
@@ -497,14 +469,14 @@ void test_ten_wedge_directions_compressed_translated_equiangular() {
   const double inner_sphericity = 0.0;
   const double outer_sphericity = 1.0;
   const bool use_equiangular_map = true;
-  const bool use_half_wedges = true;
+  const ShellWedges which_wedges = ShellWedges::AllAndHalvesYZ;
   const double aspect_ratio = 0.6;
   const size_t index_polar_axis = 1;
   const double x_coord_of_shell_center = 2.7;
   test_wedge_map_generation_against_domain_helpers(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
-      aspect_ratio, index_polar_axis);
+      use_equiangular_map, x_coord_of_shell_center, aspect_ratio,
+      index_polar_axis, which_wedges);
 }
 
 void test_ten_wedge_directions_compressed_translated_equidistant() {
@@ -514,14 +486,14 @@ void test_ten_wedge_directions_compressed_translated_equidistant() {
   const double inner_sphericity = 0.01;
   const double outer_sphericity = 0.99;
   const bool use_equiangular_map = false;
-  const bool use_half_wedges = true;
+  const ShellWedges which_wedges = ShellWedges::AllAndHalvesYZ;
   const double aspect_ratio = 0.6;
   const size_t index_polar_axis = 0;
   const double x_coord_of_shell_center = 2.7;
   test_wedge_map_generation_against_domain_helpers(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
-      aspect_ratio, index_polar_axis);
+      use_equiangular_map, x_coord_of_shell_center, aspect_ratio,
+      index_polar_axis, which_wedges);
 }
 
 void test_wedge_map_generation() {
@@ -1749,7 +1721,12 @@ void test_set_cartesian_periodic_boundaries_3() {
 
 void test_which_wedges() {
   CHECK(get_output(ShellWedges::All) == "All");
-  CHECK(get_output(ShellWedges::FourOnEquator) == "FourOnEquator");
+  CHECK(get_output(ShellWedges::FourOnEquatorXY) == "FourOnEquatorXY");
+  CHECK(get_output(ShellWedges::FourOnEquatorXZ) == "FourOnEquatorXZ");
+  CHECK(get_output(ShellWedges::FourOnEquatorYZ) == "FourOnEquatorYZ");
+  CHECK(get_output(ShellWedges::AllAndHalvesXY) == "AllAndHalvesXY");
+  CHECK(get_output(ShellWedges::AllAndHalvesXZ) == "AllAndHalvesXZ");
+  CHECK(get_output(ShellWedges::AllAndHalvesYZ) == "AllAndHalvesYZ");
   CHECK(get_output(ShellWedges::OneAlongMinusX) == "OneAlongMinusX");
 }
 }  // namespace


### PR DESCRIPTION
## Proposed changes

Half Wedges has existed as a CoordinateMap (as a Wedge option) and has been used in the Binary Compact Object Domain, but the Domain Shell, which uses wedges, has not had an option available to use Half Wedges. Now that #3572 has been merged, one can explore using a Shell which uses 8 Half Wedge Blocks instead of 4 full Wedge Blocks along an equator specified by the user, and can use the EquatorialCompression map to expand the Half Wedges such that all ten Blocks in the Domain cover the same area of the sphere.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Any `FourOnEquator` Options used in yaml files for Shell Domains must now be changed to `FourOnEquatorXY`, two additional orientations `FourOnEquatorXZ` and `FourOnEquatorYZ` are also now available.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
This works toward addressing #3545 