### PR TITLE
Add simple post-Newtonian compact binary trajectories

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -225,6 +225,20 @@ URL = {https://doi.org/10.1137/0916035},
 eprint = {https://doi.org/10.1137/0916035}
 }
 
+@article{Blanchet:2013haa,
+  archiveprefix = {arXiv},
+  author        = {Blanchet, Luc},
+  doi           = {10.12942/lrr-2014-2},
+  eprint        = {1310.1528},
+  journal       = {Living Rev. Rel.},
+  pages         = {2},
+  primaryclass  = {gr-qc},
+  title         = {Gravitational Radiation from Post-Newtonian Sources and
+                   Inspiralling Compact Binaries},
+  volume        = {17},
+  year          = {2014}
+}
+
 @article{Borges20083191,
   title =   {An improved weighted essentially non-oscillatory scheme for
              hyperbolic conservation laws},

--- a/tests/Unit/Helpers/PointwiseFunctions/PostNewtonian/BinaryTrajectories.cpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/PostNewtonian/BinaryTrajectories.cpp
@@ -1,0 +1,30 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Helpers/PointwiseFunctions/PostNewtonian/BinaryTrajectories.hpp"
+
+#include <array>
+#include <cmath>
+#include <utility>
+
+#include "Utilities/ConstantExpressions.hpp"
+
+BinaryTrajectories::BinaryTrajectories(double initial_separation)
+    : initial_separation_fourth_power_{square(square(initial_separation))} {}
+
+double BinaryTrajectories::separation(const double time) const {
+  return pow(initial_separation_fourth_power_ - 12.8 * time, 0.25);
+}
+
+double BinaryTrajectories::orbital_frequency(const double time) const {
+  return pow(separation(time), -1.5);
+}
+
+std::pair<std::array<double, 3>, std::array<double, 3>>
+BinaryTrajectories::positions(const double time) const {
+  const double sep = separation(time);
+  const double omega = orbital_frequency(time);
+  const double x1 = 0.5 * sep * cos(omega * time);
+  const double y1 = 0.5 * sep * sin(omega * time);
+  return {{x1, y1, 0.0}, {-x1, -y1, 0.0}};
+}

--- a/tests/Unit/Helpers/PointwiseFunctions/PostNewtonian/BinaryTrajectories.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/PostNewtonian/BinaryTrajectories.hpp
@@ -1,0 +1,50 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <utility>
+
+/*!
+ * \brief Class to compute post-Newtonian trajectories
+ *
+ * \details Computes the leading post-Newtonian trajectories \f$x_1^i(t)\f$
+ * and \f$x_2^i(t)\f$ for an equal-mass binary with a total mass of 1.
+ * Currently, this class implements the leading-order terms of the integral of
+ * Eq. (226) and the square root of Eq. (228) of \cite Blanchet:2013haa :
+ * \f{align}{
+ *   r(t) &= \left(r_0^4 - \frac{64}{5}t\right)^{1/4}, \\
+ *   \Omega(t) &= r^{-3/2}(t).
+ * \f}
+ * In terms of these functions, the positions of objects 1 and 2 are
+ * \f{align}{
+ *   x_1(t) &= \frac{r(t)}{2}\cos\left[\Omega(t) t\right], \\
+ *   y_1(t) &= \frac{r(t)}{2}\sin\left[\Omega(t) t\right], \\
+ *   x_2(t) &= -\frac{r(t)}{2}\cos\left[\Omega(t) t\right], \\
+ *   y_2(t) &= -\frac{r(t)}{2}\sin\left[\Omega(t) t\right], \\
+ *   z_1(t) &= z_2(t) = 0.
+ * \f} These trajectories are useful for, e.g., testing a horizon-tracking
+ * control system.
+ *
+ * \note The trajectories could be generalized to higher post-Newtonian order if
+ * needed.
+ */
+class BinaryTrajectories {
+ public:
+  BinaryTrajectories(double initial_separation);
+  BinaryTrajectories() = default;
+  BinaryTrajectories(BinaryTrajectories&&) = default;
+  BinaryTrajectories& operator=(BinaryTrajectories&&) = default;
+  BinaryTrajectories(const BinaryTrajectories&) = default;
+  BinaryTrajectories& operator=(const BinaryTrajectories&) = default;
+  ~BinaryTrajectories() = default;
+
+  double separation(double time) const;
+  double orbital_frequency(double time) const;
+  std::pair<std::array<double, 3>, std::array<double, 3>> positions(
+      double time) const;
+
+ private:
+  double initial_separation_fourth_power_;
+};

--- a/tests/Unit/Helpers/PointwiseFunctions/PostNewtonian/CMakeLists.txt
+++ b/tests/Unit/Helpers/PointwiseFunctions/PostNewtonian/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "PostNewtonianHelpers")
+
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  BinaryTrajectories.cpp
+  )
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  BinaryTrajectories.hpp
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  Utilities
+  PUBLIC
+  DataStructures
+  )

--- a/tests/Unit/Helpers/Tests/CMakeLists.txt
+++ b/tests/Unit/Helpers/Tests/CMakeLists.txt
@@ -15,3 +15,5 @@ add_test_library(
   "${LIBRARY_SOURCES}"
   "DataStructures;DataStructuresHelpers"
   )
+
+add_subdirectory(PointwiseFunctions)

--- a/tests/Unit/Helpers/Tests/PointwiseFunctions/CMakeLists.txt
+++ b/tests/Unit/Helpers/Tests/PointwiseFunctions/CMakeLists.txt
@@ -1,7 +1,4 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-add_subdirectory(AnalyticSolutions)
-add_subdirectory(GeneralRelativity)
-add_subdirectory(Hydro)
 add_subdirectory(PostNewtonian)

--- a/tests/Unit/Helpers/Tests/PointwiseFunctions/PostNewtonian/BinaryTrajectories.py
+++ b/tests/Unit/Helpers/Tests/PointwiseFunctions/PostNewtonian/BinaryTrajectories.py
@@ -1,0 +1,34 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+initial_separation = 15.366
+
+
+def separation(time, init_sep):
+    return (init_sep**4 - 12.8 * time)**0.25
+
+
+def orbital_frequency(time, init_sep):
+    return separation(time, init_sep)**-1.5
+
+
+def positions1(time):
+    init_sep = initial_separation
+    return [
+        0.5 * separation(time, init_sep) *
+        np.cos(orbital_frequency(time, init_sep) * time),
+        0.5 * separation(time, init_sep) *
+        np.sin(orbital_frequency(time, init_sep) * time), 0.0
+    ]
+
+
+def positions2(time):
+    init_sep = initial_separation
+    return [
+        -0.5 * separation(time, init_sep) *
+        np.cos(orbital_frequency(time, init_sep) * time),
+        -0.5 * separation(time, init_sep) *
+        np.sin(orbital_frequency(time, init_sep) * time), 0.0
+    ]

--- a/tests/Unit/Helpers/Tests/PointwiseFunctions/PostNewtonian/CMakeLists.txt
+++ b/tests/Unit/Helpers/Tests/PointwiseFunctions/PostNewtonian/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_PostNewtonianHelpers")
+
+set(LIBRARY_SOURCES
+  Test_BinaryTrajectories.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "Helpers/Tests/PointwiseFunctions/PostNewtonian/"
+  "${LIBRARY_SOURCES}"
+  "PostNewtonianHelpers"
+  )

--- a/tests/Unit/Helpers/Tests/PointwiseFunctions/PostNewtonian/Test_BinaryTrajectories.cpp
+++ b/tests/Unit/Helpers/Tests/PointwiseFunctions/PostNewtonian/Test_BinaryTrajectories.cpp
@@ -1,0 +1,50 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <random>
+#include <tuple>
+#include <utility>
+
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Helpers/PointwiseFunctions/PostNewtonian/BinaryTrajectories.hpp"
+
+namespace {
+constexpr double initial_separation{
+    15.366};  // must match value in BinaryTrajectories.py
+std::array<double, 3> positions1(const double time) {
+  const BinaryTrajectories expected{initial_separation};
+  return expected.positions(time).first;
+}
+
+std::array<double, 3> positions2(const double time) {
+  const BinaryTrajectories expected{initial_separation};
+  return expected.positions(time).second;
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Test.TestHelpers.PostNewtonian.BinaryTrajectories",
+                  "[PointwiseFunctions][Unit]") {
+  pypp::SetupLocalPythonEnvironment local_python_env(
+      "Helpers/Tests/PointwiseFunctions/PostNewtonian/");
+  const BinaryTrajectories expected{initial_separation};
+
+  pypp::check_with_random_values<1>(
+      &BinaryTrajectories::separation, BinaryTrajectories{initial_separation},
+      "BinaryTrajectories", {"separation"}, {{{-100.0, 100.0}}},
+      std::make_tuple(initial_separation), initial_separation);
+  pypp::check_with_random_values<1>(
+      &BinaryTrajectories::orbital_frequency,
+      BinaryTrajectories{initial_separation}, "BinaryTrajectories",
+      {"orbital_frequency"}, {{{-100.0, 100.0}}},
+      std::make_tuple(initial_separation), initial_separation);
+  pypp::check_with_random_values<1>(&positions1, "BinaryTrajectories",
+                                    "positions1", {{{-100.0, 100.0}}},
+                                    initial_separation);
+  pypp::check_with_random_values<1>(&positions2, "BinaryTrajectories",
+                                    "positions2", {{{-100.0, 100.0}}},
+                                    initial_separation);
+}


### PR DESCRIPTION
## Proposed changes

This PR adds a simple function that returns a std::pair of (x,y,z) points corresponding to the trajectories of two equal-mass particles in a Newtonian circular orbit + a leading-order post-Newtonian inspiral. This is useful e.g. for testing horizon-tracking control systems. It could be upgraded to higher post-Newtonian order later on, if needed.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
