### PR TITLE
Add deriv determinant spatial metric computation to KerrSchild

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.cpp
@@ -519,6 +519,21 @@ Scalar<DataType> KerrSchild::IntermediateVars<DataType, Frame>::get_var(
 }
 
 template <typename DataType, typename Frame>
+tnsr::i<DataType, 3, Frame>
+KerrSchild::IntermediateVars<DataType, Frame>::get_var(
+    gr::Tags::DerivDetSpatialMetric<3, Frame, DataType> /*meta*/) {
+  const auto& deriv_H = get_var(internal_tags::deriv_H<DataType, Frame>{});
+
+  auto result =
+      make_with_value<tnsr::i<DataType, 3, Frame>>(get<0>(deriv_H), 0.);
+  for (size_t i = 0; i < 3; ++i) {
+    result.get(i) = 2.0 * square(null_vector_0_) * deriv_H.get(i);
+  }
+
+  return result;
+}
+
+template <typename DataType, typename Frame>
 tnsr::II<DataType, 3, Frame>
 KerrSchild::IntermediateVars<DataType, Frame>::get_var(
     gr::Tags::InverseSpatialMetric<3, Frame, DataType> /*meta*/) {

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp
@@ -78,6 +78,7 @@ namespace Solutions {
  * g_{i j}     &=& \delta_{i j} + 2 H l_i l_j,\\
  * g^{i j}  &=& \delta^{i j} - {2 H l^i l^j \over 1+2H l^t l^t},\\
  * {\rm det} g_{i j}&=& 1+2H l^t l^t,\\
+ * \partial_k ({\rm det} g_{i j})&=& 2 l^t l^t \partial_k H,\\
  * \beta^i       &=& - {2 H l^t l^i \over 1+2H l^t l^t},\\
  * N        &=& \left(1+2 H l^t l^t\right)^{-1/2},\quad\hbox{(lapse)}\\
  * \alpha     &=& \left(1+2 H l^t l^t\right)^{-1},
@@ -492,6 +493,9 @@ class KerrSchild : public AnalyticSolution<3_st>,
         ::Tags::dt<gr::Tags::Shift<3, Frame, DataType>> /*meta*/);
 
     Scalar<DataType> get_var(gr::Tags::SqrtDetSpatialMetric<DataType> /*meta*/);
+
+    tnsr::i<DataType, 3, Frame> get_var(
+        gr::Tags::DerivDetSpatialMetric<3, Frame, DataType> /*meta*/);
 
     tnsr::II<DataType, 3, Frame> get_var(
         gr::Tags::InverseSpatialMetric<3, Frame, DataType> /*meta*/);

--- a/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
@@ -45,6 +45,13 @@ struct SqrtDetSpatialMetric : db::SimpleTag {
   using type = Scalar<DataType>;
 };
 /*!
+ * \brief Derivative of the determinant of the spatial metric.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct DerivDetSpatialMetric : db::SimpleTag {
+  using type = tnsr::i<DataType, Dim, Frame>;
+};
+/*!
  * \brief Spatial derivative of the inverse of the spatial metric.
  */
 template <size_t Dim, typename Frame, typename DataType>

--- a/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
@@ -33,6 +33,9 @@ template <typename DataType = DataVector>
 struct SqrtDetSpatialMetric;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
+struct DerivDetSpatialMetric;
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
 struct DerivInverseSpatialMetric;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
@@ -16,7 +16,8 @@ add_test_library(
   ${LIBRARY}
   "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/"
   "${LIBRARY_SOURCES}"
-  "GeneralRelativitySolutions;GeneralizedHarmonic;GeneralRelativity;Options;Utilities"
+  "DataStructures;Domain;GeneralRelativity;GeneralRelativitySolutions;"
+  "GeneralizedHarmonic;Options;Spectral;Utilities"
   )
 
 add_subdirectory(Python)

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Tags.cpp
@@ -34,6 +34,9 @@ void test_simple_tags() {
   TestHelpers::db::test_simple_tag<gr::Tags::SqrtDetSpatialMetric<Type>>(
       "SqrtDetSpatialMetric");
   TestHelpers::db::test_simple_tag<
+      gr::Tags::DerivDetSpatialMetric<Dim, Frame, Type>>(
+      "DerivDetSpatialMetric");
+  TestHelpers::db::test_simple_tag<
       gr::Tags::DerivInverseSpatialMetric<Dim, Frame, Type>>(
       "DerivInverseSpatialMetric");
   TestHelpers::db::test_simple_tag<gr::Tags::Shift<Dim, Frame, Type>>("Shift");


### PR DESCRIPTION
## Proposed changes

This adds the computation of the spatial derivative of the determinant of the spatial metric to `gr::Solutions::KerrSchild`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
