### PR TITLE
ComputeHorizonVolumeQuantities documentation.

### DIFF
--- a/src/ApparentHorizons/ComputeHorizonVolumeQuantities.hpp
+++ b/src/ApparentHorizons/ComputeHorizonVolumeQuantities.hpp
@@ -37,8 +37,18 @@ namespace ah {
 /// volume; only those computations that require data in the volume
 /// (e.g. volume numerical derivatives) should be done here.
 ///
-/// For the dual-frame case, takes the Jacobians and does numerical
-/// derivatives in order to avoid Hessians.
+/// For the dual-frame case, numerical derivatives of Jacobians are
+/// taken in order to avoid Hessians.
+///
+/// SrcTagList is usually `interpolator_source_vars` in the
+/// Metavariables, and the allowed and required tags in SrcTagList are
+/// given by the type aliases `allowed_src_tags` and `required_src_tags`
+/// below.
+///
+/// DestTagList is usually `vars_to_interpolate_to_target` in the
+/// `InterpolationTarget` that uses `ComputeHorizonVolumeQuantities`.
+/// The allowed and required tags in DestTagList are given by
+/// the type aliases `allowed_dest_tags` and `required_dest_tags` below.
 struct ComputeHorizonVolumeQuantities {
   /// Single-frame case
   template <typename SrcTagList, typename DestTagList>
@@ -63,6 +73,18 @@ struct ComputeHorizonVolumeQuantities {
       tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
                  GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
                  GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>>;
+
+  template <typename TargetFrame>
+  using allowed_dest_tags =
+      tmpl::list<gr::Tags::SpatialMetric<3, TargetFrame>,
+                 gr::Tags::InverseSpatialMetric<3, TargetFrame>,
+                 gr::Tags::ExtrinsicCurvature<3, TargetFrame>,
+                 gr::Tags::SpatialChristoffelSecondKind<3, TargetFrame>,
+                 gr::Tags::SpatialRicci<3, TargetFrame>>;
+  template <typename TargetFrame>
+  using required_dest_tags =
+      tmpl::list<gr::Tags::ExtrinsicCurvature<3, TargetFrame>,
+                 gr::Tags::SpatialChristoffelSecondKind<3, TargetFrame>>;
 };
 
 }  // namespace ah

--- a/src/ApparentHorizons/ComputeHorizonVolumeQuantities.tpp
+++ b/src/ApparentHorizons/ComputeHorizonVolumeQuantities.tpp
@@ -64,21 +64,14 @@ void ComputeHorizonVolumeQuantities::apply(
                      tmpl::list<>>,
       "A required src tag is missing");
 
-  using allowed_dest_tags =
-      tmpl::list<gr::Tags::SpatialMetric<3, Frame::Inertial>,
-                 gr::Tags::InverseSpatialMetric<3, Frame::Inertial>,
-                 gr::Tags::ExtrinsicCurvature<3, Frame::Inertial>,
-                 gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial>,
-                 gr::Tags::SpatialRicci<3, Frame::Inertial>>;
   static_assert(
-      std::is_same_v<tmpl::list_difference<DestTagList, allowed_dest_tags>,
+      std::is_same_v<tmpl::list_difference<DestTagList,
+                                           allowed_dest_tags<Frame::Inertial>>,
                      tmpl::list<>>,
       "Found a dest tag that is not allowed");
-  using required_dest_tags =
-      tmpl::list<gr::Tags::ExtrinsicCurvature<3, Frame::Inertial>,
-                 gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial>>;
   static_assert(
-      std::is_same_v<tmpl::list_difference<required_dest_tags, DestTagList>,
+      std::is_same_v<tmpl::list_difference<required_dest_tags<Frame::Inertial>,
+                                           DestTagList>,
                      tmpl::list<>>,
       "A required dest tag is missing");
 
@@ -179,22 +172,15 @@ void ComputeHorizonVolumeQuantities::apply(
                      tmpl::list<>>,
       "A required src tag is missing");
 
-  using allowed_dest_tags =
-      tmpl::list<gr::Tags::SpatialMetric<3, TargetFrame>,
-                 gr::Tags::InverseSpatialMetric<3, TargetFrame>,
-                 gr::Tags::ExtrinsicCurvature<3, TargetFrame>,
-                 gr::Tags::SpatialChristoffelSecondKind<3, TargetFrame>,
-                 gr::Tags::SpatialRicci<3, TargetFrame>>;
   static_assert(
-      std::is_same_v<tmpl::list_difference<DestTagList, allowed_dest_tags>,
-                     tmpl::list<>>,
+      std::is_same_v<
+          tmpl::list_difference<DestTagList, allowed_dest_tags<TargetFrame>>,
+          tmpl::list<>>,
       "Found a dest tag that is not allowed");
-  using required_dest_tags =
-      tmpl::list<gr::Tags::ExtrinsicCurvature<3, TargetFrame>,
-                 gr::Tags::SpatialChristoffelSecondKind<3, TargetFrame>>;
   static_assert(
-      std::is_same_v<tmpl::list_difference<required_dest_tags, DestTagList>,
-                     tmpl::list<>>,
+      std::is_same_v<
+          tmpl::list_difference<required_dest_tags<TargetFrame>, DestTagList>,
+          tmpl::list<>>,
       "A required dest tag is missing");
 
   const auto& psi =


### PR DESCRIPTION
In ComputeHorizonVolumeQuantities, move some type aliases to the hpp file where they are more
easily visible, and add documentation of these type aliases and of what SrcTagList and DestTagList are.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
