### PR TITLE
Split up bulky tensor expression test into two test files

### DIFF
--- a/tests/Unit/DataStructures/Tensor/Expressions/CMakeLists.txt
+++ b/tests/Unit/DataStructures/Tensor/Expressions/CMakeLists.txt
@@ -9,7 +9,8 @@ set(LIBRARY_SOURCES
   Test_Contract.cpp
   Test_Divide.cpp
   Test_Evaluate.cpp
-  Test_EvaluateRank3.cpp
+  Test_EvaluateRank3NonSymmetric.cpp
+  Test_EvaluateRank3Symmetric.cpp
   Test_EvaluateRank4.cpp
   Test_EvaluateSpatialSpacetimeIndex.cpp
   Test_EvaluateTimeIndex.cpp

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3NonSymmetric.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3NonSymmetric.cpp
@@ -1,0 +1,27 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+// Rank 3 test cases for TensorExpressions::evaluate are split into this file
+// and Test_EvaluateRank3Symmetric.cpp in order to reduce compile time memory
+// usage per cpp file.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Expressions/TensorIndex.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank3.hpp"
+
+SPECTRE_TEST_CASE(
+    "Unit.DataStructures.Tensor.Expression.EvaluateRank3NonSymmetric",
+    "[DataStructures][Unit]") {
+  // Rank 3: double; nonsymmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_3_no_symmetry<
+      double, SpacetimeIndex, SpatialIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo,
+      UpLo::Up, ti_D, ti_j, ti_B>();
+
+  // Rank 3: DataVector; nonsymmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_3_no_symmetry<
+      DataVector, SpacetimeIndex, SpatialIndex, SpacetimeIndex, UpLo::Up,
+      UpLo::Lo, UpLo::Up, ti_D, ti_j, ti_B>();
+}

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3Symmetric.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3Symmetric.cpp
@@ -1,6 +1,10 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+// Rank 3 test cases for TensorExpressions::evaluate are split into this file
+// and Test_EvaluateRank3NonSymmetric.cpp in order to reduce compile time memory
+// usage per cpp file.
+
 #include "Framework/TestingFramework.hpp"
 
 #include "DataStructures/DataVector.hpp"
@@ -8,13 +12,9 @@
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank3.hpp"
 
-SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateRank3",
-                  "[DataStructures][Unit]") {
-  // Rank 3: double; nonsymmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_3_no_symmetry<
-      double, SpacetimeIndex, SpatialIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo,
-      UpLo::Up, ti_D, ti_j, ti_B>();
-
+SPECTRE_TEST_CASE(
+    "Unit.DataStructures.Tensor.Expression.EvaluateRank3Symmetric",
+    "[DataStructures][Unit]") {
   // Rank 3: double; first and second indices symmetric
   TestHelpers::TensorExpressions::test_evaluate_rank_3_ab_symmetry<
       double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti_b, ti_a,
@@ -33,11 +33,6 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateRank3",
   // Rank 3: double; symmetric
   TestHelpers::TensorExpressions::test_evaluate_rank_3_abc_symmetry<
       double, SpacetimeIndex, UpLo::Lo, ti_f, ti_d, ti_a>();
-
-  // Rank 3: DataVector; nonsymmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_3_no_symmetry<
-      DataVector, SpacetimeIndex, SpatialIndex, SpacetimeIndex, UpLo::Up,
-      UpLo::Lo, UpLo::Up, ti_D, ti_j, ti_B>();
 
   // Rank 3: DataVector; first and second indices symmetric
   TestHelpers::TensorExpressions::test_evaluate_rank_3_ab_symmetry<


### PR DESCRIPTION
## Proposed changes

Fixes https://github.com/sxs-collaboration/spectre/issues/3614

This PR splits a bulky `TensorExpressions` test into two separate cpp files to reduce the amount of memory consumed per cpp file. This is meant to address CI builds that have been killed (see [here](https://github.com/sxs-collaboration/spectre/issues/3614)) when building the `Test_Expressions` target.

Here are the comparisons for compiling these test cases with gcc-10 debug before and after splitting the original file into two new files:

**Compiling `Test_EvaluateRank3` before**
- peak RAM usage: ~4.6 GB
- time: ~2 min 25 sec

**Compiling `Test_EvaluateRank3Symmetric.cpp` and `Test_EvaluateRank3NonSymmetric.cpp` together after this PR**
- peak RAM usage: ~2.6 GB
- time: ~1 min 3 sec

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
