### PR TITLE
Add (non-char-speed) BBH control measurement

### DIFF
--- a/src/ApparentHorizons/CMakeLists.txt
+++ b/src/ApparentHorizons/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   ChangeCenterOfStrahlkorper.cpp
   FastFlow.cpp
+  ObjectLabel.cpp
   Strahlkorper.cpp
   StrahlkorperFunctions.cpp
   StrahlkorperGr.cpp
@@ -26,6 +27,7 @@ spectre_target_headers(
   ComputeHorizonVolumeQuantities.tpp
   ComputeItems.hpp
   FastFlow.hpp
+  ObjectLabel.hpp
   Strahlkorper.hpp
   StrahlkorperFunctions.hpp
   StrahlkorperGr.hpp

--- a/src/ApparentHorizons/ObjectLabel.cpp
+++ b/src/ApparentHorizons/ObjectLabel.cpp
@@ -1,0 +1,18 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ApparentHorizons/ObjectLabel.hpp"
+
+#include <ostream>
+
+#include "Utilities/Literals.hpp"
+
+namespace ah {
+std::string name(const ObjectLabel x) {
+  return x == ObjectLabel::A ? "A"s : "B"s;
+}
+
+std::ostream& operator<<(std::ostream& s, const ObjectLabel x) {
+  return s << name(x);
+}
+}  // namespace ah

--- a/src/ApparentHorizons/ObjectLabel.hpp
+++ b/src/ApparentHorizons/ObjectLabel.hpp
@@ -1,0 +1,16 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <iosfwd>
+#include <string>
+
+namespace ah {
+/// Labels for the objects in a binary system.
+enum class ObjectLabel { A, B };
+
+std::string name(const ObjectLabel x);
+
+std::ostream& operator<<(std::ostream& s, const ObjectLabel x);
+}  // namespace ah

--- a/src/ControlSystem/ApparentHorizons/CMakeLists.txt
+++ b/src/ControlSystem/ApparentHorizons/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY ControlSystemApparentHorizons)
+
+add_spectre_library(${LIBRARY} INTERFACE)
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Measurements.hpp
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE
+  ApparentHorizons
+  ControlSystem
+  DataStructures
+  GeneralRelativity
+  GeneralizedHarmonic
+  ParallelInterpolation
+  Utilities
+  )

--- a/src/ControlSystem/ApparentHorizons/Measurements.hpp
+++ b/src/ControlSystem/ApparentHorizons/Measurements.hpp
@@ -1,0 +1,121 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+#include "ApparentHorizons/ComputeHorizonVolumeQuantities.hpp"
+#include "ApparentHorizons/ObjectLabel.hpp"
+#include "ApparentHorizons/Tags.hpp"
+#include "ControlSystem/Protocols/Measurement.hpp"
+#include "ControlSystem/Protocols/Submeasurement.hpp"
+#include "ControlSystem/RunCallbacks.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/LinkedMessageQueue.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "ParallelAlgorithms/Interpolation/Callbacks/ErrorOnFailedApparentHorizon.hpp"
+#include "ParallelAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp"
+#include "ParallelAlgorithms/Interpolation/Interpolate.hpp"
+#include "ParallelAlgorithms/Interpolation/Targets/ApparentHorizon.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+template <size_t VolumeDim>
+class ElementId;
+template <size_t Dim>
+class Mesh;
+namespace Parallel {
+template <typename Metavariables>
+class GlobalCache;
+}  // namespace Parallel
+namespace domain::Tags {
+template <size_t Dim>
+struct Mesh;
+}  // namespace domain::Tags
+/// \endcond
+
+namespace control_system::ah {
+struct BothHorizons : tt::ConformsTo<protocols::Measurement> {
+  template <::ah::ObjectLabel Horizon>
+  struct FindHorizon : tt::ConformsTo<protocols::Submeasurement> {
+   private:
+    template <typename ControlSystems>
+    struct InterpolationTarget {
+      static std::string name() {
+        return "ControlSystem::BothHorizons::Ah" + ::ah::name(Horizon);
+      }
+
+      struct temporal_id : db::SimpleTag {
+        using type = LinkedMessageId<double>;
+      };
+
+      using vars_to_interpolate_to_target =
+          tmpl::list<gr::Tags::SpatialMetric<3, ::Frame::Grid, DataVector>,
+                     gr::Tags::InverseSpatialMetric<3, ::Frame::Grid>,
+                     gr::Tags::ExtrinsicCurvature<3, ::Frame::Grid>,
+                     gr::Tags::SpatialChristoffelSecondKind<3, ::Frame::Grid>>;
+      using compute_vars_to_interpolate = ::ah::ComputeHorizonVolumeQuantities;
+      using compute_items_on_target = tmpl::list<
+          StrahlkorperTags::ThetaPhiCompute<::Frame::Grid>,
+          StrahlkorperTags::RadiusCompute<::Frame::Grid>,
+          StrahlkorperTags::RhatCompute<::Frame::Grid>,
+          StrahlkorperTags::InvJacobianCompute<::Frame::Grid>,
+          StrahlkorperTags::DxRadiusCompute<::Frame::Grid>,
+          StrahlkorperTags::OneOverOneFormMagnitudeCompute<3, ::Frame::Grid,
+                                                           DataVector>,
+          StrahlkorperTags::NormalOneFormCompute<::Frame::Grid>,
+          StrahlkorperTags::UnitNormalOneFormCompute<::Frame::Grid>,
+          StrahlkorperTags::UnitNormalVectorCompute<::Frame::Grid>,
+          StrahlkorperTags::GradUnitNormalOneFormCompute<::Frame::Grid>,
+          StrahlkorperTags::ExtrinsicCurvatureCompute<::Frame::Grid>>;
+      using compute_target_points =
+          intrp::TargetPoints::ApparentHorizon<InterpolationTarget,
+                                               ::Frame::Grid>;
+      using post_interpolation_callback =
+          intrp::callbacks::FindApparentHorizon<InterpolationTarget,
+                                                ::Frame::Grid>;
+      using horizon_find_failure_callback =
+          intrp::callbacks::ErrorOnFailedApparentHorizon;
+      using post_horizon_find_callback =
+          control_system::RunCallbacks<FindHorizon, ControlSystems>;
+    };
+
+    using source_tensors =
+        tmpl::list<gr::Tags::SpacetimeMetric<3, ::Frame::Inertial>,
+                   GeneralizedHarmonic::Tags::Pi<3, ::Frame::Inertial>,
+                   GeneralizedHarmonic::Tags::Phi<3, ::Frame::Inertial>>;
+
+   public:
+    template <typename ControlSystems>
+    using interpolation_target_tag = InterpolationTarget<ControlSystems>;
+
+    using argument_tags =
+        tmpl::push_front<source_tensors, domain::Tags::Mesh<3>>;
+
+    template <typename Metavariables, typename ParallelComponent,
+              typename ControlSystems>
+    static void apply(
+        const Mesh<3>& mesh,
+        const tnsr::aa<DataVector, 3, ::Frame::Inertial>& spacetime_metric,
+        const tnsr::aa<DataVector, 3, ::Frame::Inertial>& pi,
+        const tnsr::iaa<DataVector, 3, ::Frame::Inertial>& phi,
+        const LinkedMessageId<double>& measurement_id,
+        Parallel::GlobalCache<Metavariables>& cache,
+        const ElementId<3>& array_index,
+        const ParallelComponent* const /*meta*/, ControlSystems /*meta*/) {
+      intrp::interpolate<interpolation_target_tag<ControlSystems>,
+                         source_tensors>(
+          measurement_id, mesh, cache, array_index, spacetime_metric, pi, phi);
+    }
+  };
+
+  using submeasurements = tmpl::list<FindHorizon<::ah::ObjectLabel::A>,
+                                     FindHorizon<::ah::ObjectLabel::B>>;
+};
+}  // namespace control_system::ah

--- a/src/ControlSystem/CMakeLists.txt
+++ b/src/ControlSystem/CMakeLists.txt
@@ -44,5 +44,6 @@ target_link_libraries(
   )
 
 add_subdirectory(Actions)
+add_subdirectory(ApparentHorizons)
 add_subdirectory(Protocols)
 add_subdirectory(Tags)

--- a/src/Domain/FunctionsOfTime/FunctionsOfTimeAreReady.hpp
+++ b/src/Domain/FunctionsOfTime/FunctionsOfTimeAreReady.hpp
@@ -58,6 +58,7 @@ bool functions_of_time_are_ready(
                      std::string,
                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
                          functions_of_time) {
+        using ::operator<<;
         ASSERT(alg::all_of(
                    functions_to_check,
                    [&functions_of_time](const std::string& function_to_check) {

--- a/src/ParallelAlgorithms/Interpolation/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Interpolation/CMakeLists.txt
@@ -15,6 +15,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  Interpolate.hpp
   InterpolatedVars.hpp
   InterpolationTarget.hpp
   InterpolationTargetDetail.hpp

--- a/src/ParallelAlgorithms/Interpolation/Interpolate.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Interpolate.hpp
@@ -1,0 +1,67 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <tuple>
+#include <type_traits>
+#include <vector>
+
+#include "DataStructures/Variables.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "ParallelAlgorithms/Interpolation/Actions/AddTemporalIdsToInterpolationTarget.hpp"
+#include "ParallelAlgorithms/Interpolation/Actions/InterpolatorReceiveVolumeData.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+template <size_t VolumeDim>
+class ElementId;
+namespace intrp {
+template <typename Metavariables, typename Tag>
+struct InterpolationTarget;
+template <typename Metavariables>
+struct Interpolator;
+}  // namespace intrp
+/// \endcond
+
+namespace intrp {
+template <typename InterpolationTargetTag, typename Tensors, size_t VolumeDim,
+          typename Metavariables, typename... TensorTypes>
+void interpolate(
+    const typename InterpolationTargetTag::temporal_id::type& temporal_id,
+    const Mesh<VolumeDim>& mesh, Parallel::GlobalCache<Metavariables>& cache,
+    const ElementId<VolumeDim>& array_index, const TensorTypes&... tensors) {
+  static_assert(
+      std::is_same_v<
+          tmpl::transform<Tensors, tmpl::bind<tmpl::type_from, tmpl::_1>>,
+          tmpl::list<TensorTypes...>>,
+      "Tensors passed do not match structures of Tensors list of tags.");
+  Variables<Tensors> interp_vars(mesh.number_of_grid_points());
+  const std::tuple<const TensorTypes&...> tensors_tuple{tensors...};
+  tmpl::for_each<tmpl::make_sequence<tmpl::size_t<0>, sizeof...(TensorTypes)>>(
+      [&interp_vars, &tensors_tuple](auto index_v) {
+        constexpr size_t index = tmpl::type_from<decltype(index_v)>::value;
+        get<tmpl::at_c<Tensors, index>>(interp_vars) =
+            get<index>(tensors_tuple);
+      });
+
+  // Send volume data to the Interpolator, to trigger interpolation.
+  auto& interpolator =
+      *::Parallel::get_parallel_component<Interpolator<Metavariables>>(cache)
+           .ckLocalBranch();
+  Parallel::simple_action<Actions::InterpolatorReceiveVolumeData<
+      typename InterpolationTargetTag::temporal_id>>(
+      interpolator, temporal_id, array_index, mesh, interp_vars);
+
+  // Tell the interpolation target that it should interpolate.
+  auto& target = Parallel::get_parallel_component<
+      InterpolationTarget<Metavariables, InterpolationTargetTag>>(cache);
+  Parallel::simple_action<
+      Actions::AddTemporalIdsToInterpolationTarget<InterpolationTargetTag>>(
+      target, std::vector<typename InterpolationTargetTag::temporal_id::type>{
+                  temporal_id});
+}
+}  // namespace intrp

--- a/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.cpp
+++ b/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.cpp
@@ -3,14 +3,21 @@
 
 #include "ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp"
 
+#include "DataStructures/LinkedMessageQueue.hpp"
 #include "Time/TimeStepId.hpp"
 
 namespace intrp::InterpolationTarget_detail {
 double get_temporal_id_value(const double time) { return time; }
+double get_temporal_id_value(const LinkedMessageId<double>& id) {
+  return id.id;
+}
 double get_temporal_id_value(const TimeStepId& time_id) {
   return time_id.substep_time().value();
 }
 double evaluate_temporal_id_for_expiration(const double time) { return time; }
+double evaluate_temporal_id_for_expiration(const LinkedMessageId<double>& id) {
+  return id.id;
+}
 double evaluate_temporal_id_for_expiration(const TimeStepId& time_id) {
   return time_id.step_time().value();
 }

--- a/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
+++ b/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
@@ -55,6 +55,8 @@ template <typename TemporalId>
 struct TemporalIds;
 }  // namespace Tags
 }  // namespace intrp
+template <typename Id>
+struct LinkedMessageId;
 template <typename TagsList>
 struct Variables;
 /// \endcond
@@ -63,8 +65,10 @@ namespace intrp {
 
 namespace InterpolationTarget_detail {
 double get_temporal_id_value(double time);
+double get_temporal_id_value(const LinkedMessageId<double>& id);
 double get_temporal_id_value(const TimeStepId& time_id);
 double evaluate_temporal_id_for_expiration(double time);
+double evaluate_temporal_id_for_expiration(const LinkedMessageId<double>& id);
 double evaluate_temporal_id_for_expiration(const TimeStepId& time_id);
 
 // apply_callback accomplishes the overload for the

--- a/tests/Unit/ApparentHorizons/CMakeLists.txt
+++ b/tests/Unit/ApparentHorizons/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   Test_ComputeHorizonVolumeQuantities.cpp
   Test_ComputeItems.cpp
   Test_FastFlow.cpp
+  Test_ObjectLabel.cpp
   Test_Strahlkorper.cpp
   Test_StrahlkorperFunctions.cpp
   Test_StrahlkorperGr.cpp

--- a/tests/Unit/ApparentHorizons/Test_ObjectLabel.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ObjectLabel.cpp
@@ -1,0 +1,15 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "ApparentHorizons/ObjectLabel.hpp"
+#include "Utilities/GetOutput.hpp"
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizons.ObjectLabel",
+                  "[ApparentHorizons][Unit]") {
+  CHECK(name(ah::ObjectLabel::A) == "A");
+  CHECK(get_output(ah::ObjectLabel::A) == "A");
+  CHECK(name(ah::ObjectLabel::B) == "B");
+  CHECK(get_output(ah::ObjectLabel::B) == "B");
+}

--- a/tests/Unit/ParallelAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/CMakeLists.txt
@@ -9,7 +9,7 @@ set(LIBRARY_SOURCES
   Test_ElementReceiveInterpPoints.cpp
   Test_InitializeInterpolationTarget.cpp
   Test_InitializeInterpolator.cpp
-  Test_InterpolateEvent.cpp
+  Test_Interpolate.cpp
   Test_InterpolateWithoutInterpComponent.cpp
   Test_InterpolationTargetApparentHorizon.cpp
   Test_InterpolationTargetKerrHorizon.cpp


### PR DESCRIPTION
This includes a cherry-pick of an old version of #3566.  This is mostly to pick up the input file changes there.

As with #3566, I can't test this directly because I lack the required initial data.  @geoffrey4444, can you try this?  The BBH executable should print out the AH centers (in the grid frame) every time step.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
