### PR TITLE
Add CCZ4 functions for lower and upper spatial Z4 constraint

### DIFF
--- a/src/Evolution/Systems/Ccz4/CMakeLists.txt
+++ b/src/Evolution/Systems/Ccz4/CMakeLists.txt
@@ -12,6 +12,7 @@ spectre_target_sources(
   Christoffel.cpp
   DerivChristoffel.cpp
   DerivLapse.cpp
+  Z4Constraint.cpp
   )
 
 spectre_target_headers(
@@ -25,6 +26,8 @@ spectre_target_headers(
   System.hpp
   Tags.hpp
   TagsDeclarations.hpp
+  TempTags.hpp
+  Z4Constraint.hpp
   )
 
 target_link_libraries(

--- a/src/Evolution/Systems/Ccz4/Tags.hpp
+++ b/src/Evolution/Systems/Ccz4/Tags.hpp
@@ -293,6 +293,37 @@ template <size_t Dim, typename Frame, typename DataType>
 struct DerivContractedConformalChristoffelSecondKind : db::SimpleTag {
   using type = tnsr::iJ<DataType, Dim, Frame>;
 };
+
+/*!
+ * \brief The CCZ4 evolved variable \f$\hat{\Gamma}^i\f$
+ *
+ * \details This must satisfy the identity:
+ *
+ * \f{align}
+ *     \hat{\Gamma}^i &= \tilde{\Gamma}^i + 2 \tilde{\gamma}^{ij} Z_j
+ * \f}
+ *
+ * where \f$\tilde{\gamma}^{ij}\f$ is the inverse conformal spatial metric
+ * defined by `Ccz4::Tags::InverseConformalMetric`, \f$Z_i\f$ is the spatial
+ * part of the Z4 constraint defined by `Ccz4::Tags::SpatialZ4Constraint`, and
+ * \f$\tilde{\Gamma}^i\f$ is the contraction of the conformal spatial
+ * christoffel symbols of the second kind defined by
+ * `Ccz4::Tags::ContractedConformalChristoffelSecondKind`.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct GammaHat : db::SimpleTag {
+  using type = tnsr::I<DataType, Dim, Frame>;
+};
+
+/*!
+ * \brief The spatial part of the Z4 constraint
+ *
+ * \details See `Ccz4::spatial_z4_constraint` for details.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct SpatialZ4Constraint : db::SimpleTag {
+  using type = tnsr::i<DataType, Dim, Frame>;
+};
 }  // namespace Tags
 
 namespace OptionTags {

--- a/src/Evolution/Systems/Ccz4/Tags.hpp
+++ b/src/Evolution/Systems/Ccz4/Tags.hpp
@@ -324,6 +324,16 @@ template <size_t Dim, typename Frame, typename DataType>
 struct SpatialZ4Constraint : db::SimpleTag {
   using type = tnsr::i<DataType, Dim, Frame>;
 };
+
+/*!
+ * \brief The spatial part of the upper Z4 constraint
+ *
+ * \details See `Ccz4::upper_spatial_z4_constraint` for details.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct SpatialZ4ConstraintUp : db::SimpleTag {
+  using type = tnsr::I<DataType, Dim, Frame>;
+};
 }  // namespace Tags
 
 namespace OptionTags {

--- a/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
@@ -60,6 +60,12 @@ struct ContractedConformalChristoffelSecondKind;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
 struct DerivContractedConformalChristoffelSecondKind;
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
+struct GammaHat;
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
+struct SpatialZ4Constraint;
 }  // namespace Tags
 
 /// \brief Input option tags for the CCZ4 evolution system

--- a/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
@@ -66,6 +66,9 @@ struct GammaHat;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
 struct SpatialZ4Constraint;
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
+struct SpatialZ4ConstraintUp;
 }  // namespace Tags
 
 /// \brief Input option tags for the CCZ4 evolution system

--- a/src/Evolution/Systems/Ccz4/TempTags.hpp
+++ b/src/Evolution/Systems/Ccz4/TempTags.hpp
@@ -1,0 +1,38 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/Ccz4/TagsDeclarations.hpp"
+
+namespace Ccz4 {
+namespace Tags {
+/*!
+ * \brief The CCZ4 temporary expression
+ * \f$\hat{\Gamma}^i - \tilde{\Gamma}^i\f$
+ *
+ * \details We define:
+ *
+ * \f{align}
+ *     \hat{\Gamma}^i - \tilde{\Gamma}^i &= 2 \tilde{\gamma}^{ij} Z_j
+ * \f}
+ *
+ * where \f$\hat{\Gamma}^{i}\f$ is the CCZ4 evolved variable defined by
+ * `Ccz4::Tags::GammaHat`, \f$\tilde{\Gamma}^{i}\f$ is the contraction of the
+ * conformal spatial Christoffel symbols of the second kind defined by
+ * `Ccz4::Tags::ContractedConformalChristoffelSecondKind`,
+ * \f$\tilde{\gamma}^{ij}\f$ is the inverse conformal spatial metric defined by
+ * `Ccz4::Tags::InverseConformalMetric`, and \f$Z_i\f$ is the spatial part of
+ * the Z4 constraint defined by `Ccz4::Tags::SpatialZ4Constraint`.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct GammaHatMinusContractedConformalChristoffel : db::SimpleTag {
+  using type = tnsr::I<DataType, Dim, Frame>;
+};
+}  // namespace Tags
+}  // namespace Ccz4

--- a/src/Evolution/Systems/Ccz4/Z4Constraint.cpp
+++ b/src/Evolution/Systems/Ccz4/Z4Constraint.cpp
@@ -36,6 +36,37 @@ tnsr::i<DataType, Dim, Frame> spatial_z4_constraint(
                         gamma_hat_minus_contracted_conformal_christoffel);
   return result;
 }
+
+template <size_t Dim, typename Frame, typename DataType>
+void upper_spatial_z4_constraint(
+    const gsl::not_null<tnsr::I<DataType, Dim, Frame>*> result,
+    const gsl::not_null<Scalar<DataType>*> buffer,
+    const Scalar<DataType>& conformal_factor_squared,
+    const tnsr::I<DataType, Dim, Frame>&
+        gamma_hat_minus_contracted_conformal_christoffel) {
+  destructive_resize_components(result,
+                                get_size(get(conformal_factor_squared)));
+  destructive_resize_components(buffer,
+                                get_size(get(conformal_factor_squared)));
+
+  ::TensorExpressions::evaluate(buffer, 0.5 * conformal_factor_squared());
+  ::TensorExpressions::evaluate<ti_I>(
+      result,
+      (*buffer)() * gamma_hat_minus_contracted_conformal_christoffel(ti_I));
+}
+
+template <size_t Dim, typename Frame, typename DataType>
+tnsr::I<DataType, Dim, Frame> upper_spatial_z4_constraint(
+    const Scalar<DataType>& conformal_factor_squared,
+    const tnsr::I<DataType, Dim, Frame>&
+        gamma_hat_minus_contracted_conformal_christoffel) {
+  tnsr::I<DataType, Dim, Frame> result{};
+  Scalar<DataType> buffer{};
+  upper_spatial_z4_constraint(make_not_null(&result), make_not_null(&buffer),
+                              conformal_factor_squared,
+                              gamma_hat_minus_contracted_conformal_christoffel);
+  return result;
+}
 }  // namespace Ccz4
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
@@ -54,6 +85,18 @@ tnsr::i<DataType, Dim, Frame> spatial_z4_constraint(
   Ccz4::spatial_z4_constraint(                                           \
       const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&               \
           conformal_spatial_metric,                                      \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>&                \
+          gamma_hat_minus_contracted_conformal_christoffel);             \
+  template void Ccz4::upper_spatial_z4_constraint(                       \
+      const gsl::not_null<tnsr::I<DTYPE(data), DIM(data), FRAME(data)>*> \
+          result,                                                        \
+      const gsl::not_null<Scalar<DTYPE(data)>*> buffer,                  \
+      const Scalar<DTYPE(data)>& conformal_factor_squared,               \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>&                \
+          gamma_hat_minus_contracted_conformal_christoffel);             \
+  template tnsr::I<DTYPE(data), DIM(data), FRAME(data)>                  \
+  Ccz4::upper_spatial_z4_constraint(                                     \
+      const Scalar<DTYPE(data)>& conformal_factor_squared,               \
       const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>&                \
           gamma_hat_minus_contracted_conformal_christoffel);
 

--- a/src/Evolution/Systems/Ccz4/Z4Constraint.cpp
+++ b/src/Evolution/Systems/Ccz4/Z4Constraint.cpp
@@ -1,0 +1,66 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Ccz4/Z4Constraint.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Ccz4 {
+template <size_t Dim, typename Frame, typename DataType>
+void spatial_z4_constraint(
+    const gsl::not_null<tnsr::i<DataType, Dim, Frame>*> result,
+    const tnsr::ii<DataType, Dim, Frame>& conformal_spatial_metric,
+    const tnsr::I<DataType, Dim, Frame>&
+        gamma_hat_minus_contracted_conformal_christoffel) {
+  destructive_resize_components(result,
+                                get_size(get<0, 0>(conformal_spatial_metric)));
+
+  ::TensorExpressions::evaluate<ti_i>(
+      result, 0.5 * (conformal_spatial_metric(ti_i, ti_j) *
+                     gamma_hat_minus_contracted_conformal_christoffel(ti_J)));
+}
+
+template <size_t Dim, typename Frame, typename DataType>
+tnsr::i<DataType, Dim, Frame> spatial_z4_constraint(
+    const tnsr::ii<DataType, Dim, Frame>& conformal_spatial_metric,
+    const tnsr::I<DataType, Dim, Frame>&
+        gamma_hat_minus_contracted_conformal_christoffel) {
+  tnsr::i<DataType, Dim, Frame> result{};
+  spatial_z4_constraint(make_not_null(&result), conformal_spatial_metric,
+                        gamma_hat_minus_contracted_conformal_christoffel);
+  return result;
+}
+}  // namespace Ccz4
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                             \
+  template void Ccz4::spatial_z4_constraint(                             \
+      const gsl::not_null<tnsr::i<DTYPE(data), DIM(data), FRAME(data)>*> \
+          result,                                                        \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&               \
+          conformal_spatial_metric,                                      \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>&                \
+          gamma_hat_minus_contracted_conformal_christoffel);             \
+  template tnsr::i<DTYPE(data), DIM(data), FRAME(data)>                  \
+  Ccz4::spatial_z4_constraint(                                           \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&               \
+          conformal_spatial_metric,                                      \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>&                \
+          gamma_hat_minus_contracted_conformal_christoffel);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial),
+                        (double, DataVector))
+
+#undef INSTANTIATE
+#undef DTYPE
+#undef FRAME
+#undef DIM

--- a/src/Evolution/Systems/Ccz4/Z4Constraint.hpp
+++ b/src/Evolution/Systems/Ccz4/Z4Constraint.hpp
@@ -39,4 +39,36 @@ tnsr::i<DataType, Dim, Frame> spatial_z4_constraint(
     const tnsr::I<DataType, Dim, Frame>&
         gamma_hat_minus_contracted_conformal_christoffel);
 /// @}
+
+/// @{
+/*!
+ * \brief Computes the spatial part of the upper Z4 constraint
+ *
+ * \details Computes the constraint as:
+ *
+ * \f{align}
+ *     Z^i &= \frac{1}{2} \phi^2 \left(
+ *         \hat{\Gamma}^i - \tilde{\Gamma}^i\right)
+ * \f}
+ *
+ * where \f$\phi^2 \f$ is the square of the conformal factor defined by
+ * `Ccz4::Tags::ConformalFactorSquared` and
+ * \f$\left(\hat{\Gamma}^i - \tilde{\Gamma}^i\right)\f$ is the CCZ4 temporary
+ * expression defined by
+ * `Ccz4::Tags::GammaHatMinusContractedConformalChristoffel`.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+void upper_spatial_z4_constraint(
+    const gsl::not_null<tnsr::I<DataType, Dim, Frame>*> result,
+    const gsl::not_null<Scalar<DataType>*> buffer,
+    const Scalar<DataType>& conformal_factor_squared,
+    const tnsr::I<DataType, Dim, Frame>&
+        gamma_hat_minus_contracted_conformal_christoffel);
+
+template <size_t Dim, typename Frame, typename DataType>
+tnsr::I<DataType, Dim, Frame> upper_spatial_z4_constraint(
+    const Scalar<DataType>& conformal_factor_squared,
+    const tnsr::I<DataType, Dim, Frame>&
+        gamma_hat_minus_contracted_conformal_christoffel);
+/// @}
 }  // namespace Ccz4

--- a/src/Evolution/Systems/Ccz4/Z4Constraint.hpp
+++ b/src/Evolution/Systems/Ccz4/Z4Constraint.hpp
@@ -1,0 +1,42 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Ccz4 {
+/// @{
+/*!
+ * \brief Computes the spatial part of the Z4 constraint
+ *
+ * \details Computes the constraint as:
+ *
+ * \f{align}
+ *     Z_i &= \frac{1}{2} \tilde{\gamma}_{ij} \left(
+ *         \hat{\Gamma}^j - \tilde{\Gamma}^j\right)
+ * \f}
+ *
+ * where \f$\tilde{\gamma}_{ij}\f$ is the conformal spatial metric defined by
+ * `Ccz4::Tags::ConformalMetric` and
+ * \f$\left(\hat{\Gamma}^i - \tilde{\Gamma}^i\right)\f$ is the CCZ4 temporary
+ * expression defined by
+ * `Ccz4::Tags::GammaHatMinusContractedConformalChristoffel`.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+void spatial_z4_constraint(
+    const gsl::not_null<tnsr::i<DataType, Dim, Frame>*> result,
+    const tnsr::ii<DataType, Dim, Frame>& conformal_spatial_metric,
+    const tnsr::I<DataType, Dim, Frame>&
+        gamma_hat_minus_contracted_conformal_christoffel);
+
+template <size_t Dim, typename Frame, typename DataType>
+tnsr::i<DataType, Dim, Frame> spatial_z4_constraint(
+    const tnsr::ii<DataType, Dim, Frame>& conformal_spatial_metric,
+    const tnsr::I<DataType, Dim, Frame>&
+        gamma_hat_minus_contracted_conformal_christoffel);
+/// @}
+}  // namespace Ccz4

--- a/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
@@ -9,6 +9,8 @@ set(LIBRARY_SOURCES
   Test_DerivChristoffel.cpp
   Test_DerivLapse.cpp
   Test_Tags.cpp
+  Test_TempTags.cpp
+  Test_Z4Constraint.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
@@ -64,6 +64,11 @@ void test_simple_tags() {
       Ccz4::Tags::DerivContractedConformalChristoffelSecondKind<Dim, Frame,
                                                                 DataType>>(
       "DerivContractedConformalChristoffelSecondKind");
+  TestHelpers::db::test_simple_tag<Ccz4::Tags::GammaHat<Dim, Frame, DataType>>(
+      "GammaHat");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::SpatialZ4Constraint<Dim, Frame, DataType>>(
+      "SpatialZ4Constraint");
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.Tags", "[Unit][Evolution]") {

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
@@ -69,6 +69,9 @@ void test_simple_tags() {
   TestHelpers::db::test_simple_tag<
       Ccz4::Tags::SpatialZ4Constraint<Dim, Frame, DataType>>(
       "SpatialZ4Constraint");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::SpatialZ4ConstraintUp<Dim, Frame, DataType>>(
+      "SpatialZ4ConstraintUp");
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.Tags", "[Unit][Evolution]") {

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_TempTags.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_TempTags.cpp
@@ -1,0 +1,32 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataVector.hpp"
+#include "Evolution/Systems/Ccz4/TempTags.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+
+namespace {
+struct ArbitraryFrame;
+}  // namespace
+
+template <size_t Dim, typename Frame, typename DataType>
+void test_simple_tags() {
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::GammaHatMinusContractedConformalChristoffel<Dim, Frame,
+                                                              DataType>>(
+      "GammaHatMinusContractedConformalChristoffel");
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.TempTags", "[Unit][Evolution]") {
+  test_simple_tags<1, ArbitraryFrame, double>();
+  test_simple_tags<1, ArbitraryFrame, DataVector>();
+  test_simple_tags<2, ArbitraryFrame, double>();
+  test_simple_tags<2, ArbitraryFrame, DataVector>();
+  test_simple_tags<3, ArbitraryFrame, double>();
+  test_simple_tags<3, ArbitraryFrame, DataVector>();
+}

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_Z4Constraint.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_Z4Constraint.cpp
@@ -1,0 +1,35 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/Ccz4/Z4Constraint.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+template <size_t Dim, typename DataType>
+void test_compute_spatial_z4_constraint(const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::i<DataType, Dim, Frame::Inertial> (*)(
+          const tnsr::ii<DataType, Dim, Frame::Inertial>&,
+          const tnsr::I<DataType, Dim, Frame::Inertial>&)>(
+          &Ccz4::spatial_z4_constraint<Dim, Frame::Inertial, DataType>),
+      "Z4Constraint", "spatial_z4_constraint", {{{-1., 1.}}}, used_for_size);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.Z4Constraint",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env("Evolution/Systems/Ccz4/");
+
+  GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_compute_spatial_z4_constraint,
+                                    (1, 2, 3));
+}

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_Z4Constraint.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_Z4Constraint.cpp
@@ -23,6 +23,17 @@ void test_compute_spatial_z4_constraint(const DataType& used_for_size) {
           &Ccz4::spatial_z4_constraint<Dim, Frame::Inertial, DataType>),
       "Z4Constraint", "spatial_z4_constraint", {{{-1., 1.}}}, used_for_size);
 }
+
+template <size_t Dim, typename DataType>
+void test_compute_upper_spatial_z4_constraint(const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::I<DataType, Dim, Frame::Inertial> (*)(
+          const Scalar<DataType>&,
+          const tnsr::I<DataType, Dim, Frame::Inertial>&)>(
+          &Ccz4::upper_spatial_z4_constraint<Dim, Frame::Inertial, DataType>),
+      "Z4Constraint", "upper_spatial_z4_constraint", {{{-1., 1.}}},
+      used_for_size);
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.Z4Constraint",
@@ -31,5 +42,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.Z4Constraint",
 
   GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
   CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_compute_spatial_z4_constraint,
+                                    (1, 2, 3));
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_compute_upper_spatial_z4_constraint,
                                     (1, 2, 3));
 }

--- a/tests/Unit/Evolution/Systems/Ccz4/Z4Constraint.py
+++ b/tests/Unit/Evolution/Systems/Ccz4/Z4Constraint.py
@@ -1,0 +1,10 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def spatial_z4_constraint(conformal_spatial_metric,
+                          gamma_hat_minus_contracted_conformal_christoffel):
+    return (0.5 * np.einsum("ij,j", conformal_spatial_metric,
+                            gamma_hat_minus_contracted_conformal_christoffel))

--- a/tests/Unit/Evolution/Systems/Ccz4/Z4Constraint.py
+++ b/tests/Unit/Evolution/Systems/Ccz4/Z4Constraint.py
@@ -8,3 +8,10 @@ def spatial_z4_constraint(conformal_spatial_metric,
                           gamma_hat_minus_contracted_conformal_christoffel):
     return (0.5 * np.einsum("ij,j", conformal_spatial_metric,
                             gamma_hat_minus_contracted_conformal_christoffel))
+
+
+def upper_spatial_z4_constraint(
+    conformal_factor_squared,
+    gamma_hat_minus_contracted_conformal_christoffel):
+    return (0.5 * conformal_factor_squared *
+            gamma_hat_minus_contracted_conformal_christoffel)


### PR DESCRIPTION
## Proposed changes

This PR adds a CCZ4 function for computing the lower and upper spatial Z4 constraint.

The motivation for this PR is to implement eq. (25), whose value will be used to implement eq. (26) and various parts of the evolution equations (12a - 12m) in [this CCZ4 paper](https://arxiv.org/pdf/1707.09910.pdf).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
