### PR TITLE
Interpolate Ah quantities to 2 frames if desired.

### DIFF
--- a/src/ApparentHorizons/ComputeHorizonVolumeQuantities.hpp
+++ b/src/ApparentHorizons/ComputeHorizonVolumeQuantities.hpp
@@ -8,6 +8,7 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/TMPL.hpp"
 
 /// \cond
 class DataVector;
@@ -75,12 +76,18 @@ struct ComputeHorizonVolumeQuantities {
                  GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>>;
 
   template <typename TargetFrame>
-  using allowed_dest_tags =
+  using allowed_dest_tags_target_frame =
       tmpl::list<gr::Tags::SpatialMetric<3, TargetFrame>,
                  gr::Tags::InverseSpatialMetric<3, TargetFrame>,
                  gr::Tags::ExtrinsicCurvature<3, TargetFrame>,
                  gr::Tags::SpatialChristoffelSecondKind<3, TargetFrame>,
                  gr::Tags::SpatialRicci<3, TargetFrame>>;
+
+  template <typename TargetFrame>
+  using allowed_dest_tags = tmpl::remove_duplicates<
+      tmpl::append<allowed_dest_tags_target_frame<TargetFrame>,
+                   allowed_dest_tags_target_frame<Frame::Inertial>>>;
+
   template <typename TargetFrame>
   using required_dest_tags =
       tmpl::list<gr::Tags::ExtrinsicCurvature<3, TargetFrame>,


### PR DESCRIPTION
Previously, if we found the horizon in the grid frame, we could
run observers only in the grid frame, because the metric quantities
were computed on the horizon only in the grid frame.

Now, if we find the horizon in the grid frame, we can optionally
interpolate (and hence observe) quantities in the inertial frame as well
as in the grid frame.  Technically this means that we are now
allowed to specify quantities in both frames in DestTagList in
ComputeHorizonVolumeQuantities.hpp.

Note that if we don't want quantities in both frames, then those
quantities are not computed (except for any intermediate quantities
that are required to compute the desired output in the desired
frame).  And the computations are still done with minimal
memory allocations.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
