### PR TITLE
Add Frame::Distorted to Block

### DIFF
--- a/src/Domain/Block.hpp
+++ b/src/Domain/Block.hpp
@@ -87,15 +87,45 @@ class Block {
   const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, VolumeDim>&
   moving_mesh_grid_to_inertial_map() const;
 
+  /// \brief The map going from the last time independent frame to the
+  /// distorted frame. Only used when the coordinate map is
+  /// time-dependent. See \ref domain_concepts to see how the distorted
+  /// frame is defined.
+  ///
+  /// \see is_time_dependent() moving_mesh_distorted_to_grid_map()
+  const domain::CoordinateMapBase<Frame::Grid, Frame::Distorted, VolumeDim>&
+  moving_mesh_grid_to_distorted_map() const;
+
+  /// \brief The map going from the distorted frame to the frame in
+  /// which the equations are solved. Only used when the coordinate map is
+  /// time-dependent. See \ref domain_concepts to see how the distorted
+  /// frame is defined.
+  ///
+  /// \see is_time_dependent() moving_mesh_grid_to_distorted_map()
+  const domain::CoordinateMapBase<Frame::Distorted, Frame::Inertial, VolumeDim>&
+  moving_mesh_distorted_to_inertial_map() const;
+
   /// \brief Returns `true` if the block has time-dependent maps.
   bool is_time_dependent() const { return stationary_map_ == nullptr; }
+
+  /// \brief Returns `true` if the block has a distorted frame.
+  bool has_distorted_frame() const {
+    return moving_mesh_grid_to_distorted_map_ != nullptr and
+           moving_mesh_distorted_to_inertial_map_ != nullptr;
+  }
 
   /// \brief Given a Block that has a time-independent map, injects the
   /// time-dependent map into the Block.
   void inject_time_dependent_map(
       std::unique_ptr<
           domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, VolumeDim>>
-          moving_mesh_inertial_map);
+          moving_mesh_grid_to_inertial_map,
+      std::unique_ptr<
+          domain::CoordinateMapBase<Frame::Grid, Frame::Distorted, VolumeDim>>
+          moving_mesh_grid_to_distorted_map = nullptr,
+      std::unique_ptr<domain::CoordinateMapBase<Frame::Distorted,
+                                                Frame::Inertial, VolumeDim>>
+          moving_mesh_distorted_to_inertial_map = nullptr);
 
   /// A unique identifier for the Block that is in the range
   /// [0, number_of_blocks -1] where number_of_blocks is the number
@@ -134,10 +164,16 @@ class Block {
       stationary_map_{nullptr};
   std::unique_ptr<
       domain::CoordinateMapBase<Frame::BlockLogical, Frame::Grid, VolumeDim>>
-      moving_mesh_grid_map_{nullptr};
+      moving_mesh_logical_to_grid_map_{nullptr};
   std::unique_ptr<
       domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, VolumeDim>>
-      moving_mesh_inertial_map_{nullptr};
+      moving_mesh_grid_to_inertial_map_{nullptr};
+  std::unique_ptr<
+      domain::CoordinateMapBase<Frame::Grid, Frame::Distorted, VolumeDim>>
+      moving_mesh_grid_to_distorted_map_{nullptr};
+  std::unique_ptr<
+      domain::CoordinateMapBase<Frame::Distorted, Frame::Inertial, VolumeDim>>
+      moving_mesh_distorted_to_inertial_map_{nullptr};
 
   size_t id_{0};
   DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbors_;

--- a/tests/Unit/Domain/Test_Block.cpp
+++ b/tests/Unit/Domain/Test_Block.cpp
@@ -106,6 +106,18 @@ auto make_translation_map() {
       Translation<VolumeDim>{"Translation"});
 }
 
+template <size_t VolumeDim>
+auto make_translation_grid_to_distorted_map() {
+  return domain::make_coordinate_map<Frame::Grid, Frame::Distorted>(
+      Translation<VolumeDim>{"TranslationGridToDistorted"});
+}
+
+template <size_t VolumeDim>
+auto make_translation_distorted_to_inertial_map() {
+  return domain::make_coordinate_map<Frame::Distorted, Frame::Inertial>(
+      Translation<VolumeDim>{"TranslationDistortedToInertial"});
+}
+
 template <size_t Dim>
 void test_block_time_dependent() {
   using TranslationDimD =
@@ -183,6 +195,141 @@ void test_block_time_dependent() {
   block_copy.inject_time_dependent_map(translation_map.get_clone());
   test_move_semantics(std::move(original_block), block_copy);
 }
+
+template <size_t Dim>
+void test_block_time_dependent_distorted() {
+  using TranslationDimD =
+      domain::CoordinateMap<Frame::Grid, Frame::Inertial, Translation<Dim>>;
+  using TranslationGridDistortedDimD =
+      domain::CoordinateMap<Frame::Grid, Frame::Distorted, Translation<Dim>>;
+  using TranslationDistortedInertialDimD =
+      domain::CoordinateMap<Frame::Distorted, Frame::Inertial,
+                            Translation<Dim>>;
+
+  using logical_to_grid_coordinate_map =
+      CoordinateMap<Frame::BlockLogical, Frame::Inertial,
+                    CoordinateMaps::Identity<Dim>>;
+
+  using grid_to_inertial_coordinate_map = TranslationDimD;
+  using grid_to_distorted_coordinate_map = TranslationGridDistortedDimD;
+  using distorted_to_inertial_coordinate_map = TranslationDistortedInertialDimD;
+
+  PUPable_reg(SINGLE_ARG(CoordinateMap<Frame::BlockLogical, Frame::Grid,
+                                       CoordinateMaps::Identity<Dim>>));
+  PUPable_reg(grid_to_inertial_coordinate_map);
+
+  PUPable_reg(logical_to_grid_coordinate_map);
+  PUPable_reg(SINGLE_ARG(CoordinateMap<Frame::BlockLogical, Frame::Grid,
+                                       CoordinateMaps::Identity<Dim>>));
+  PUPable_reg(grid_to_distorted_coordinate_map);
+  PUPable_reg(distorted_to_inertial_coordinate_map);
+
+  const logical_to_grid_coordinate_map identity_map{
+      CoordinateMaps::Identity<Dim>{}};
+  const grid_to_inertial_coordinate_map translation_map =
+      make_translation_map<Dim>();
+  const grid_to_distorted_coordinate_map translation_grid_to_distorted_map =
+      make_translation_grid_to_distorted_map<Dim>();
+  const distorted_to_inertial_coordinate_map
+      translation_distorted_to_inertial_map =
+          make_translation_distorted_to_inertial_map<Dim>();
+  Block<Dim> original_block(identity_map.get_clone(), 7, {},
+                            create_external_bcs<Dim>());
+  CHECK_FALSE(original_block.is_time_dependent());
+  original_block.inject_time_dependent_map(
+      translation_map.get_clone(),
+      translation_grid_to_distorted_map.get_clone(),
+      translation_distorted_to_inertial_map.get_clone());
+  CHECK(original_block.is_time_dependent());
+
+  const auto check_block = [](const Block<Dim>& block) {
+    const double time = 2.0;
+
+    std::unordered_map<std::string,
+                       std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+        functions_of_time{};
+
+    std::unordered_map<std::string,
+                       std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+        functions_of_time_grid_to_distorted{};
+
+    std::unordered_map<std::string,
+                       std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+        functions_of_time_distorted_to_inertial{};
+
+    functions_of_time["Translation"] =
+        std::make_unique<FunctionsOfTime::PiecewisePolynomial<2>>(
+            0.0,
+            std::array<DataVector, 3>{{{Dim, 0.0}, {Dim, 3.0}, {Dim, 0.0}}},
+            5.0);
+
+    functions_of_time_grid_to_distorted["TranslationGridToDistorted"] =
+        std::make_unique<FunctionsOfTime::PiecewisePolynomial<2>>(
+            0.0,
+            std::array<DataVector, 3>{{{Dim, 0.0}, {Dim, 1.0}, {Dim, 0.0}}},
+            5.0);
+
+    functions_of_time_distorted_to_inertial["TranslationDistortedToInertial"] =
+        std::make_unique<FunctionsOfTime::PiecewisePolynomial<2>>(
+            0.0,
+            std::array<DataVector, 3>{{{Dim, 0.0}, {Dim, 2.0}, {Dim, 0.0}}},
+            5.0);
+
+    // Test external boundaries:
+    CHECK((block.external_boundaries().size()) == 2 * Dim);
+
+    // Test neighbors:
+    CHECK((block.neighbors().size()) == 0);
+
+    // Test id:
+    CHECK((block.id()) == 7);
+
+    // Test that the block's coordinate_map is Identity:
+    const auto& grid_to_inertial_map = block.moving_mesh_grid_to_inertial_map();
+    const auto& grid_to_distorted_map =
+        block.moving_mesh_grid_to_distorted_map();
+    const auto& distorted_to_inertial_map =
+        block.moving_mesh_distorted_to_inertial_map();
+    const auto& logical_to_grid_map = block.moving_mesh_logical_to_grid_map();
+    const tnsr::I<double, Dim, Frame::BlockLogical> xi(1.0);
+    const tnsr::I<double, Dim, Frame::Inertial> x(1.0 + 3.0 * time);
+
+    const auto& result_grid = logical_to_grid_map(xi);
+    const auto& result_distorted = grid_to_distorted_map(
+        result_grid, time, functions_of_time_grid_to_distorted);
+    const auto& result_inertial = distorted_to_inertial_map(
+        result_distorted, time, functions_of_time_distorted_to_inertial);
+    CHECK(result_inertial == x);
+
+    CHECK(logical_to_grid_map
+              .inverse(grid_to_inertial_map.inverse(x, time, functions_of_time)
+                           .value())
+              .value() == xi);
+
+    for (const auto& direction : Direction<Dim>::all_directions()) {
+      CAPTURE(direction);
+      REQUIRE(block.external_boundary_conditions().at(direction) != nullptr);
+      CHECK(dynamic_cast<const helpers::TestBoundaryCondition<Dim>&>(
+                *block.external_boundary_conditions().at(direction))
+                .direction() == direction);
+    }
+  };
+
+  check_block(original_block);
+  check_block(serialize_and_deserialize(original_block));
+
+  // Test PUP
+  test_serialization(original_block);
+
+  // Test move semantics:
+  Block<Dim> block_copy(identity_map.get_clone(), 7, {},
+                        create_external_bcs<Dim>());
+  block_copy.inject_time_dependent_map(
+      translation_map.get_clone(),
+      translation_grid_to_distorted_map.get_clone(),
+      translation_distorted_to_inertial_map.get_clone());
+  test_move_semantics(std::move(original_block), block_copy);
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.Block", "[Domain][Unit]") {
@@ -195,6 +342,10 @@ SPECTRE_TEST_CASE("Unit.Domain.Block", "[Domain][Unit]") {
   test_block_time_dependent<1>();
   test_block_time_dependent<2>();
   test_block_time_dependent<3>();
+
+  test_block_time_dependent_distorted<1>();
+  test_block_time_dependent_distorted<2>();
+  test_block_time_dependent_distorted<3>();
 
   // Create DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>
 


### PR DESCRIPTION
## Proposed changes

Adds functions to inject maps from Frame::Grid to Frame::Distorted and Frame::Distorted to Frame::Inertial into the Block.
A future PR will add this functionality to Domain as well.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
