### PR TITLE
Fix unused var error when profiling

### DIFF
--- a/src/Parallel/MaxInlineMethodsReached.hpp
+++ b/src/Parallel/MaxInlineMethodsReached.hpp
@@ -11,8 +11,8 @@ namespace Parallel::detail {
 // Allow 64 inline entry method calls before we fall back to Charm++. This is
 // done to avoid blowing the stack.
 inline bool max_inline_entry_methods_reached() {
-  thread_local size_t approx_stack_depth = 0;
 #ifndef SPECTRE_PROFILING
+  thread_local size_t approx_stack_depth = 0;
   approx_stack_depth++;
   if (approx_stack_depth < 64) {
     return false;


### PR DESCRIPTION
## Proposed changes

Was trying to profile, but kept getting an error about an unused variable.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
