### PR TITLE
Add CCZ4 simple tag and function for gradient of the spatial Z4 constraint

### DIFF
--- a/src/Evolution/Systems/Ccz4/CMakeLists.txt
+++ b/src/Evolution/Systems/Ccz4/CMakeLists.txt
@@ -12,6 +12,7 @@ spectre_target_sources(
   Christoffel.cpp
   DerivChristoffel.cpp
   DerivLapse.cpp
+  DerivZ4Constraint.cpp
   Z4Constraint.cpp
   )
 
@@ -23,6 +24,7 @@ spectre_target_headers(
   Christoffel.hpp
   DerivChristoffel.hpp
   DerivLapse.hpp
+  DerivZ4Constraint.hpp
   System.hpp
   Tags.hpp
   TagsDeclarations.hpp

--- a/src/Evolution/Systems/Ccz4/DerivZ4Constraint.cpp
+++ b/src/Evolution/Systems/Ccz4/DerivZ4Constraint.cpp
@@ -1,0 +1,98 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Ccz4/DerivZ4Constraint.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Ccz4 {
+template <size_t Dim, typename Frame, typename DataType>
+void grad_spatial_z4_constraint(
+    const gsl::not_null<tnsr::ij<DataType, Dim, Frame>*> result,
+    const tnsr::i<DataType, Dim, Frame>& spatial_z4_constraint,
+    const tnsr::ii<DataType, Dim, Frame>& conformal_spatial_metric,
+    const tnsr::Ijj<DataType, Dim, Frame>& christoffel_second_kind,
+    const tnsr::ijj<DataType, Dim, Frame>& field_d,
+    const tnsr::I<DataType, Dim, Frame>&
+        gamma_hat_minus_contracted_conformal_christoffel,
+    const tnsr::iJ<DataType, Dim, Frame>&
+        d_gamma_hat_minus_contracted_conformal_christoffel) {
+  destructive_resize_components(result,
+                                get_size(get<0, 0>(conformal_spatial_metric)));
+
+  ::TensorExpressions::evaluate<ti_i, ti_j>(
+      result,
+      field_d(ti_i, ti_j, ti_l) *
+              gamma_hat_minus_contracted_conformal_christoffel(ti_L) +
+          0.5 * conformal_spatial_metric(ti_j, ti_l) *
+              d_gamma_hat_minus_contracted_conformal_christoffel(ti_i, ti_L) -
+          christoffel_second_kind(ti_L, ti_i, ti_j) *
+              spatial_z4_constraint(ti_l));
+}
+
+template <size_t Dim, typename Frame, typename DataType>
+tnsr::ij<DataType, Dim, Frame> grad_spatial_z4_constraint(
+    const tnsr::i<DataType, Dim, Frame>& spatial_z4_constraint,
+    const tnsr::ii<DataType, Dim, Frame>& conformal_spatial_metric,
+    const tnsr::Ijj<DataType, Dim, Frame>& christoffel_second_kind,
+    const tnsr::ijj<DataType, Dim, Frame>& field_d,
+    const tnsr::I<DataType, Dim, Frame>&
+        gamma_hat_minus_contracted_conformal_christoffel,
+    const tnsr::iJ<DataType, Dim, Frame>&
+        d_gamma_hat_minus_contracted_conformal_christoffel) {
+  tnsr::ij<DataType, Dim, Frame> result{};
+  grad_spatial_z4_constraint(
+      make_not_null(&result), spatial_z4_constraint, conformal_spatial_metric,
+      christoffel_second_kind, field_d,
+      gamma_hat_minus_contracted_conformal_christoffel,
+      d_gamma_hat_minus_contracted_conformal_christoffel);
+  return result;
+}
+}  // namespace Ccz4
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                              \
+  template void Ccz4::grad_spatial_z4_constraint(                         \
+      const gsl::not_null<tnsr::ij<DTYPE(data), DIM(data), FRAME(data)>*> \
+          result,                                                         \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>&                 \
+          spatial_z4_constraint,                                          \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&                \
+          conformal_spatial_metric,                                       \
+      const tnsr::Ijj<DTYPE(data), DIM(data), FRAME(data)>&               \
+          christoffel_second_kind,                                        \
+      const tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>& field_d,      \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>&                 \
+          gamma_hat_minus_contracted_conformal_christoffel,               \
+      const tnsr::iJ<DTYPE(data), DIM(data), FRAME(data)>&                \
+          d_gamma_hat_minus_contracted_conformal_christoffel);            \
+  template tnsr::ij<DTYPE(data), DIM(data), FRAME(data)>                  \
+  Ccz4::grad_spatial_z4_constraint(                                       \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>&                 \
+          spatial_z4_constraint,                                          \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&                \
+          conformal_spatial_metric,                                       \
+      const tnsr::Ijj<DTYPE(data), DIM(data), FRAME(data)>&               \
+          christoffel_second_kind,                                        \
+      const tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>& field_d,      \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>&                 \
+          gamma_hat_minus_contracted_conformal_christoffel,               \
+      const tnsr::iJ<DTYPE(data), DIM(data), FRAME(data)>&                \
+          d_gamma_hat_minus_contracted_conformal_christoffel);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial),
+                        (double, DataVector))
+
+#undef INSTANTIATE
+#undef DTYPE
+#undef FRAME
+#undef DIM

--- a/src/Evolution/Systems/Ccz4/DerivZ4Constraint.hpp
+++ b/src/Evolution/Systems/Ccz4/DerivZ4Constraint.hpp
@@ -1,0 +1,61 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Ccz4 {
+/// @{
+/*!
+ * \brief Computes the gradient of the spatial part of the Z4 constraint
+ *
+ * \details Computes the gradient as:
+ *
+ * \f{align}
+ *     \nabla_i Z_j &=
+ *         D_{ijl} \left(\hat{\Gamma}^l - \tilde{\Gamma}^l\right) +
+ *         \frac{1}{2} \tilde{\gamma}_{jl} \left(
+ *             \partial_i \hat{\Gamma}^l - \partial_i \tilde{\Gamma}^l\right) -
+ *         \Gamma^l_{ij} Z_l
+ * \f}
+ *
+ * where \f$Z_i\f$ is the spatial Z4 constraint defined by
+ * `Ccz4::Tags::SpatialZ4Constraint`, \f$\tilde{\gamma}_{ij}\f$ is the conformal
+ * spatial metric defined by `Ccz4::Tags::ConformalMetric`, \f$\Gamma^k_{ij}\f$
+ * is the spatial Christoffel symbols of the second kind defined by
+ * `Ccz4::Tags::ChristoffelSecondKind`, \f$D_{ijk}\f$ is the CCZ4 auxiliary
+ * variable defined by `Ccz4::Tags::FieldD`,
+ * \f$\left(\hat{\Gamma}^i - \tilde{\Gamma}^i\right)\f$ is the CCZ4 temporary
+ * expression defined by
+ * `Ccz4::Tags::GammaHatMinusContractedConformalChristoffel`, and
+ * \f$\left(\partial_i \hat{\Gamma}^j - \partial_i \tilde{\Gamma}^j\right)\f$ is
+ * its spatial derivative.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+void grad_spatial_z4_constraint(
+    const gsl::not_null<tnsr::ij<DataType, Dim, Frame>*> result,
+    const tnsr::i<DataType, Dim, Frame>& spatial_z4_constraint,
+    const tnsr::ii<DataType, Dim, Frame>& conformal_spatial_metric,
+    const tnsr::Ijj<DataType, Dim, Frame>& christoffel_second_kind,
+    const tnsr::ijj<DataType, Dim, Frame>& field_d,
+    const tnsr::I<DataType, Dim, Frame>&
+        gamma_hat_minus_contracted_conformal_christoffel,
+    const tnsr::iJ<DataType, Dim, Frame>&
+        d_gamma_hat_minus_contracted_conformal_christoffel);
+
+template <size_t Dim, typename Frame, typename DataType>
+tnsr::ij<DataType, Dim, Frame> grad_spatial_z4_constraint(
+    const tnsr::i<DataType, Dim, Frame>& spatial_z4_constraint,
+    const tnsr::ii<DataType, Dim, Frame>& conformal_spatial_metric,
+    const tnsr::Ijj<DataType, Dim, Frame>& christoffel_second_kind,
+    const tnsr::ijj<DataType, Dim, Frame>& field_d,
+    const tnsr::I<DataType, Dim, Frame>&
+        gamma_hat_minus_contracted_conformal_christoffel,
+    const tnsr::iJ<DataType, Dim, Frame>&
+        d_gamma_hat_minus_contracted_conformal_christoffel);
+/// @}
+}  // namespace Ccz4

--- a/src/Evolution/Systems/Ccz4/Tags.hpp
+++ b/src/Evolution/Systems/Ccz4/Tags.hpp
@@ -334,6 +334,16 @@ template <size_t Dim, typename Frame, typename DataType>
 struct SpatialZ4ConstraintUp : db::SimpleTag {
   using type = tnsr::I<DataType, Dim, Frame>;
 };
+
+/*!
+ * \brief The gradient of the spatial part of the Z4 constraint
+ *
+ * \details See `Ccz4::grad_spatial_z4_constraint` for details.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct GradSpatialZ4Constraint : db::SimpleTag {
+  using type = tnsr::ij<DataType, Dim, Frame>;
+};
 }  // namespace Tags
 
 namespace OptionTags {

--- a/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
@@ -69,6 +69,9 @@ struct SpatialZ4Constraint;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
 struct SpatialZ4ConstraintUp;
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
+struct GradSpatialZ4Constraint;
 }  // namespace Tags
 
 /// \brief Input option tags for the CCZ4 evolution system

--- a/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_Christoffel.cpp
   Test_DerivChristoffel.cpp
   Test_DerivLapse.cpp
+  Test_DerivZ4Constraint.cpp
   Test_Tags.cpp
   Test_TempTags.cpp
   Test_Z4Constraint.cpp

--- a/tests/Unit/Evolution/Systems/Ccz4/DerivZ4Constraint.py
+++ b/tests/Unit/Evolution/Systems/Ccz4/DerivZ4Constraint.py
@@ -1,0 +1,16 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def grad_spatial_z4_constraint(
+    spatial_z4_constraint, conformal_spatial_metric, christoffel_second_kind,
+    field_d, gamma_hat_minus_contracted_conformal_christoffel,
+    d_gamma_hat_minus_contracted_conformal_christoffel):
+    return (
+        np.einsum("ijl,l", field_d,
+                  gamma_hat_minus_contracted_conformal_christoffel) +
+        0.5 * np.einsum("jl,il", conformal_spatial_metric,
+                        d_gamma_hat_minus_contracted_conformal_christoffel) -
+        np.einsum("lij,l", christoffel_second_kind, spatial_z4_constraint))

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_DerivZ4Constraint.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_DerivZ4Constraint.cpp
@@ -1,0 +1,93 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <climits>
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/Ccz4/DerivZ4Constraint.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace {
+template <size_t Dim, typename DataType>
+void test_compute_grad_spatial_z4_constraint(const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::ij<DataType, Dim, Frame::Inertial> (*)(
+          const tnsr::i<DataType, Dim, Frame::Inertial>&,
+          const tnsr::ii<DataType, Dim, Frame::Inertial>&,
+          const tnsr::Ijj<DataType, Dim, Frame::Inertial>&,
+          const tnsr::ijj<DataType, Dim, Frame::Inertial>&,
+          const tnsr::I<DataType, Dim, Frame::Inertial>&,
+          const tnsr::iJ<DataType, Dim, Frame::Inertial>&)>(
+          &Ccz4::grad_spatial_z4_constraint<Dim, Frame::Inertial, DataType>),
+      "DerivZ4Constraint", "grad_spatial_z4_constraint", {{{-1., 1.}}},
+      used_for_size);
+}
+
+// Test that when \f$\hat{\Gamma}^i == \tilde{\Gamma}^i\f$ and \f$Z_i == 0\f$,
+// the gradient of \f$Z_i\f$ is 0
+template <typename Generator, typename DataType>
+void test_grad_spatial_z4_vanishes(const gsl::not_null<Generator*> generator,
+                                   const DataType& used_for_size) {
+  std::uniform_real_distribution<> distribution(0.1, 1.0);
+
+  // \f$Z_i == 0\f$
+  const auto spatial_z4_constraint =
+      make_with_value<tnsr::i<DataType, 3, Frame::Inertial>>(used_for_size,
+                                                             0.0);
+  const auto conformal_spatial_metric =
+      make_with_random_values<tnsr::ii<DataType, 3, Frame::Inertial>>(
+          generator, distribution, used_for_size);
+  const auto christoffel_second_kind =
+      make_with_random_values<tnsr::Ijj<DataType, 3, Frame::Inertial>>(
+          generator, distribution, used_for_size);
+  const auto field_d =
+      make_with_random_values<tnsr::ijj<DataType, 3, Frame::Inertial>>(
+          generator, distribution, used_for_size);
+  // \f$\hat{\Gamma}^i == \tilde{\Gamma}^i\f$
+  const auto gamma_hat_minus_contracted_conformal_christoffel =
+      make_with_value<tnsr::I<DataType, 3, Frame::Inertial>>(used_for_size,
+                                                             0.0);
+  // \f$\hat{\Gamma}^i == \tilde{\Gamma}^i\f$
+  const auto d_gamma_hat_minus_contracted_conformal_christoffel =
+      make_with_value<tnsr::iJ<DataType, 3, Frame::Inertial>>(used_for_size,
+                                                              0.0);
+
+  using result_tensor_type = tnsr::ij<DataType, 3, Frame::Inertial>;
+  const result_tensor_type expected_grad_z4_constraint =
+      make_with_value<result_tensor_type>(used_for_size, 0.0);
+
+  const result_tensor_type actual_grad_z4_constraint =
+      Ccz4::grad_spatial_z4_constraint(
+          spatial_z4_constraint, conformal_spatial_metric,
+          christoffel_second_kind, field_d,
+          gamma_hat_minus_contracted_conformal_christoffel,
+          d_gamma_hat_minus_contracted_conformal_christoffel);
+
+  CHECK_ITERABLE_APPROX(actual_grad_z4_constraint, expected_grad_z4_constraint);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.DerivZ4Constraint",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env("Evolution/Systems/Ccz4/");
+
+  GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_compute_grad_spatial_z4_constraint,
+                                    (1, 2, 3));
+
+  MAKE_GENERATOR(generator);
+  test_grad_spatial_z4_vanishes(make_not_null(&generator),
+                                std::numeric_limits<double>::signaling_NaN());
+  test_grad_spatial_z4_vanishes(
+      make_not_null(&generator),
+      DataVector(5, std::numeric_limits<double>::signaling_NaN()));
+}

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
@@ -72,6 +72,9 @@ void test_simple_tags() {
   TestHelpers::db::test_simple_tag<
       Ccz4::Tags::SpatialZ4ConstraintUp<Dim, Frame, DataType>>(
       "SpatialZ4ConstraintUp");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::GradSpatialZ4Constraint<Dim, Frame, DataType>>(
+      "GradSpatialZ4Constraint");
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.Tags", "[Unit][Evolution]") {


### PR DESCRIPTION
## Proposed changes

This PR adds a CCZ4 function for computing the gradient of the spatial Z4 constraint.

The motivation for this PR is to implement eq. (26), whose value will be used to implement eq. (27) and eq. (12e) in [this CCZ4 paper](https://arxiv.org/pdf/1707.09910.pdf).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
