### PR TITLE
Allow creation of FunctionsOfTime with control system info

### DIFF
--- a/src/ControlSystem/Actions/Initialization.hpp
+++ b/src/ControlSystem/Actions/Initialization.hpp
@@ -32,9 +32,9 @@ namespace Actions {
  *   - `control_system::Tags::Averager<2>`
  *   - `control_system::Tags::Controller<2>`
  *   - `control_system::Tags::TimescaleTuner`
+ *   - `control_system::Tags::ControlSystemName`
  * - Removes: Nothing
  * - Modifies:
- *   - `control_system::Tags::ControlSystemName`
  *   - `control_system::Tags::Controller<2>`
  *
  * \note This action relies on the `SetupDataBox` aggregated initialization
@@ -51,7 +51,8 @@ struct Initialize {
   using tags_to_be_initialized =
       tmpl::list<control_system::Tags::Averager<deriv_order>,
                  control_system::Tags::Controller<deriv_order>,
-                 control_system::Tags::TimescaleTuner>;
+                 control_system::Tags::TimescaleTuner,
+                 control_system::Tags::ControlSystemName>;
 
   using simple_tags =
       tmpl::append<tags_to_be_initialized, typename ControlSystem::simple_tags>;
@@ -71,7 +72,7 @@ struct Initialize {
         db::get<control_system::Tags::ControlSystemInputs<ControlSystem>>(box);
     ::Initialization::mutate_assign<tags_to_be_initialized>(
         make_not_null(&box), option_holder.averager, option_holder.controller,
-        option_holder.tuner);
+        option_holder.tuner, ControlSystem::name());
 
     // Set the initial time between updates using the initial timescale
     const auto& tuner = db::get<control_system::Tags::TimescaleTuner>(box);
@@ -83,10 +84,6 @@ struct Initialize {
           controller->assign_time_between_updates(current_min_timescale);
         });
 
-    db::mutate<control_system::Tags::ControlSystemName>(
-        make_not_null(&box), [](const gsl::not_null<std::string*> tag0) {
-          *tag0 = ControlSystem::name();
-        });
     return std::forward_as_tuple(std::move(box));
   }
 };

--- a/src/ControlSystem/CMakeLists.txt
+++ b/src/ControlSystem/CMakeLists.txt
@@ -42,3 +42,4 @@ target_link_libraries(
 
 add_subdirectory(Actions)
 add_subdirectory(Protocols)
+add_subdirectory(Tags)

--- a/src/ControlSystem/Controller.hpp
+++ b/src/ControlSystem/Controller.hpp
@@ -74,6 +74,8 @@ class Controller {
     time_between_updates_ = update_fraction_ * current_min_timescale;
   }
 
+  double get_update_fraction() const { return update_fraction_; }
+
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p) {
     p | update_fraction_;

--- a/src/ControlSystem/Tags/CMakeLists.txt
+++ b/src/ControlSystem/Tags/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  FunctionsOfTimeInitialize.hpp
+  )

--- a/src/ControlSystem/Tags/FunctionsOfTimeInitialize.hpp
+++ b/src/ControlSystem/Tags/FunctionsOfTimeInitialize.hpp
@@ -1,0 +1,86 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+
+#include "ControlSystem/Tags.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Domain/OptionTags.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits/IsA.hpp"
+
+/// \cond
+template <class Metavariables, typename ControlSystem>
+struct ControlComponent;
+/// \endcond
+
+namespace control_system::Tags {
+/// \ingroup ControlSystemGroup
+/// The FunctionsOfTime initialized from a DomainCreator, initial time
+/// step, and control system OptionHolders.
+struct FunctionsOfTimeInitialize : domain::Tags::FunctionsOfTime,
+                                   db::SimpleTag {
+  using type = std::unordered_map<
+      std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>;
+
+  static constexpr bool pass_metavariables = true;
+
+  static std::string name() { return "FunctionsOfTime"; }
+
+  template <typename Metavariables>
+  using option_tags = tmpl::flatten<
+      tmpl::list<domain::OptionTags::DomainCreator<Metavariables::volume_dim>,
+                 ::OptionTags::InitialTime, ::OptionTags::InitialTimeStep,
+                 control_system::inputs<tmpl::transform<
+                     tmpl::filter<typename Metavariables::component_list,
+                                  tt::is_a_lambda<ControlComponent, tmpl::_1>>,
+                     tmpl::bind<tmpl::back, tmpl::_1>>>>>;
+
+  template <typename Metavariables, typename... OptionHolders>
+  static type create_from_options(
+      const std::unique_ptr<::DomainCreator<Metavariables::volume_dim>>&
+          domain_creator,
+      const double initial_time, const double initial_time_step,
+      const OptionHolders&... option_holders) {
+    std::unordered_map<std::string, double> initial_expiration_times{};
+    [[maybe_unused]] const auto gather_initial_expiration_times =
+        [&initial_expiration_times, &initial_time,
+         &initial_time_step](const auto& option_holder) {
+          const auto& controller = option_holder.controller;
+          const std::string& name =
+              std::decay_t<decltype(option_holder)>::control_system::name();
+          const auto& tuner = option_holder.tuner;
+
+          const double update_fraction = controller.get_update_fraction();
+          const double curr_timescale = min(tuner.current_timescale());
+          const double initial_expiration_time =
+              update_fraction * curr_timescale;
+          initial_expiration_times[name] =
+              initial_time +
+              std::max(initial_time_step, initial_expiration_time);
+        };
+    EXPAND_PACK_LEFT_TO_RIGHT(gather_initial_expiration_times(option_holders));
+    // Until the domain creator infrastructure is modified to take control
+    // system information into account when constructing the functions of time,
+    // update them retroactively. This is not how this will normally be done,
+    // there just needs to be a place holder until the domain creators have been
+    // changed.
+    auto functions_of_time = domain_creator->functions_of_time();
+    for (auto& [name, expr_time] : initial_expiration_times) {
+      const double curr_expr_time =
+          functions_of_time.at(name)->time_bounds()[1];
+      functions_of_time.at(name)->reset_expiration_time(
+          std::max(curr_expr_time, expr_time));
+    }
+    return functions_of_time;
+  }
+};
+}  // namespace control_system::Tags

--- a/tests/Unit/ControlSystem/Actions/Test_Initialization.cpp
+++ b/tests/Unit/ControlSystem/Actions/Test_Initialization.cpp
@@ -27,7 +27,7 @@ struct MockControlSystem
   static std::string name() { return pretty_type::short_name<Label>(); }
   using measurement = Measurement;
   static constexpr size_t deriv_order = 2;
-  using simple_tags = tmpl::list<control_system::Tags::ControlSystemName>;
+  using simple_tags = tmpl::list<>;
 };
 
 using mock_control_sys =
@@ -77,7 +77,8 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Initialization",
   std::string controlsys_name_empty{};
 
   tuples::tagged_tuple_from_typelist<tags> init_tuple{
-      control_system::OptionHolder<2>{averager, controller, tuner},
+      control_system::OptionHolder<mock_control_sys>{averager, controller,
+                                                     tuner},
       averager_empty, tuner_empty, controlsys_name_empty, controller_empty};
 
   MockRuntimeSystem runner{{}};

--- a/tests/Unit/ControlSystem/Test_Controller.cpp
+++ b/tests/Unit/ControlSystem/Test_Controller.cpp
@@ -258,6 +258,7 @@ void test_equality_and_serialization() {
   controller1.assign_time_between_updates(2.0);
 
   CHECK(controller1 == controller3);
+  CHECK(controller1.get_update_fraction() == 0.5);
 
   Controller<2> controller1_serialized = serialize_and_deserialize(controller1);
 

--- a/tests/Unit/ControlSystem/Test_Tags.cpp
+++ b/tests/Unit/ControlSystem/Test_Tags.cpp
@@ -110,6 +110,7 @@ void test_control_sys_inputs() {
       increase_timescale_threshold, increase_factor, decrease_factor);
   const Averager<2> expected_averager(0.25, true);
   const Controller<2> expected_controller(0.3);
+  const std::string expected_name{"LabelA"};
 
   using system = control_system::TestHelpers::System<
       2, control_system::TestHelpers::TestStructs_detail::LabelA,
@@ -133,6 +134,8 @@ void test_control_sys_inputs() {
   CHECK(expected_averager == input_holder.averager);
   CHECK(expected_controller == input_holder.controller);
   CHECK(expected_tuner == input_holder.tuner);
+  CHECK(expected_name ==
+        std::decay_t<decltype(input_holder)>::control_system::name());
 }
 
 void test_measurement_tag() {

--- a/tests/Unit/ControlSystem/Test_Tags.cpp
+++ b/tests/Unit/ControlSystem/Test_Tags.cpp
@@ -8,14 +8,19 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 #include <vector>
 
 #include "ControlSystem/Averager.hpp"
+#include "ControlSystem/Component.hpp"
 #include "ControlSystem/Controller.hpp"
+#include "ControlSystem/Protocols/ControlSystem.hpp"
 #include "ControlSystem/Tags.hpp"
+#include "ControlSystem/Tags/FunctionsOfTimeInitialize.hpp"
 #include "ControlSystem/TimescaleTuner.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
@@ -23,16 +28,36 @@
 #include "Framework/TestCreation.hpp"
 #include "Helpers/ControlSystem/TestStructs.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Time/Tags.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "Utilities/Literals.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
 namespace {
 const double initial_time = 2.0;
 
+template <size_t Index>
+struct FakeControlSystem
+    : tt::ConformsTo<control_system::protocols::ControlSystem> {
+  static constexpr size_t deriv_order = 2;
+  static std::string name() { return "Controlled"s + get_output(Index); }
+  using measurement = control_system::TestHelpers::Measurement<
+      control_system::TestHelpers::TestStructs_detail::LabelA>;
+  using simple_tags = tmpl::list<>;
+  struct process_measurement {
+    using argument_tags = tmpl::list<>;
+  };
+};
+
 struct Metavariables {
   static constexpr size_t volume_dim = 1;
+
+  using control_systems = tmpl::list<FakeControlSystem<1>, FakeControlSystem<2>,
+                                     FakeControlSystem<3>>;
+  using component_list = control_components<Metavariables, control_systems>;
 };
 
 class TestCreator : public DomainCreator<1> {
@@ -57,9 +82,17 @@ class TestCreator : public DomainCreator<1> {
         result{};
     if (add_controlled_) {
       result.insert(
-          {"Controlled",
+          {"Controlled1",
            std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
-               initial_time, initial_values, 7.0)});
+               initial_time, initial_values, initial_time + 7.0)});
+      result.insert(
+          {"Controlled2",
+           std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+               initial_time, initial_values, initial_time + 10.0)});
+      result.insert(
+          {"Controlled3",
+           std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+               initial_time, initial_values, initial_time + 0.5)});
     }
     result.insert(
         {"Uncontrolled",
@@ -83,6 +116,8 @@ void test_all_tags() {
   TestHelpers::db::test_simple_tag<timescaletuner_tag>("TimescaleTuner");
   using controller_tag = control_system::Tags::Controller<2>;
   TestHelpers::db::test_simple_tag<controller_tag>("Controller");
+  using fot_tag = control_system::Tags::FunctionsOfTimeInitialize;
+  TestHelpers::db::test_simple_tag<fot_tag>("FunctionsOfTime");
 
   using system = control_system::TestHelpers::System<
       2, control_system::TestHelpers::TestStructs_detail::LabelA,
@@ -138,6 +173,70 @@ void test_control_sys_inputs() {
         std::decay_t<decltype(input_holder)>::control_system::name());
 }
 
+template <size_t Index>
+using OptionHolder = control_system::OptionHolder<FakeControlSystem<Index>>;
+
+template <typename ControlSys>
+using ControlSysInputs =
+    control_system::OptionTags::ControlSystemInputs<ControlSys>;
+
+void test_functions_of_time_tag() {
+  INFO("Test FunctionsOfTimeInitialize tag");
+  using fot_tag = control_system::Tags::FunctionsOfTimeInitialize;
+  using Creator = tmpl::front<fot_tag::option_tags<Metavariables>>::type;
+
+  const Creator creator = std::make_unique<TestCreator>(true);
+
+  const double decrease_timescale_threshold = 1.0e-2;
+  const double increase_timescale_threshold = 1.0e-4;
+  const double increase_factor = 1.01;
+  const double decrease_factor = 0.99;
+  const double max_timescale = 10.0;
+  const double min_timescale = 1.0e-3;
+  // Initial expiration times are set to be update_fraction *
+  // min(current_timescale) where update_fraction is the argument to the
+  // Controller. This value for the timescale was chosen to give an expiration
+  // time between the two expiration times used above in the TestCreator
+  const double timescale = 27.0;
+  const TimescaleTuner tuner1(
+      {timescale}, max_timescale, min_timescale, decrease_timescale_threshold,
+      increase_timescale_threshold, increase_factor, decrease_factor);
+  const TimescaleTuner tuner2(
+      {0.1}, max_timescale, min_timescale, decrease_timescale_threshold,
+      increase_timescale_threshold, increase_factor, decrease_factor);
+  const Averager<2> averager(0.25, true);
+  const double update_fraction = 0.3;
+  const Controller<2> controller(update_fraction);
+
+  OptionHolder<1> option_holder1(averager, controller, tuner1);
+  OptionHolder<2> option_holder2(averager, controller, tuner1);
+  OptionHolder<3> option_holder3(averager, controller, tuner2);
+
+  const double initial_time_step = 1.0;
+  fot_tag::type functions_of_time = fot_tag::create_from_options<Metavariables>(
+      creator, initial_time, initial_time_step, option_holder1, option_holder2,
+      option_holder3);
+
+  CHECK(functions_of_time.at("Controlled1")->time_bounds()[1] ==
+        initial_time + update_fraction * timescale);
+  CHECK(functions_of_time.at("Controlled2")->time_bounds()[1] ==
+        initial_time + 10.0);
+  CHECK(functions_of_time.at("Controlled3")->time_bounds()[1] ==
+        initial_time + initial_time_step);
+  CHECK(functions_of_time.at("Uncontrolled")->time_bounds()[1] ==
+        std::numeric_limits<double>::infinity());
+
+  static_assert(
+      std::is_same_v<
+          fot_tag::option_tags<Metavariables>,
+          tmpl::list<
+              domain::OptionTags::DomainCreator<Metavariables::volume_dim>,
+              ::OptionTags::InitialTime, ::OptionTags::InitialTimeStep,
+              ControlSysInputs<FakeControlSystem<1>>,
+              ControlSysInputs<FakeControlSystem<2>>,
+              ControlSysInputs<FakeControlSystem<3>>>>);
+}
+
 void test_measurement_tag() {
   INFO("Test measurement tag");
   using measurement_tag = control_system::Tags::MeasurementTimescales;
@@ -151,13 +250,20 @@ void test_measurement_tag() {
 
     const measurement_tag::type timescales =
         measurement_tag::create_from_options<Metavariables>(creator, time_step);
-    CHECK(timescales.size() == 1);
+    CHECK(timescales.size() == 3);
     // The lack of expiration is a placeholder until the control systems
     // have been implemented sufficiently to manage their timescales.
-    CHECK(timescales.at("Controlled")->time_bounds() ==
+    CHECK(timescales.at("Controlled1")->time_bounds() ==
           std::array{initial_time, std::numeric_limits<double>::infinity()});
-    CHECK(timescales.at("Controlled")->func(2.0)[0] == DataVector{time_step});
-    CHECK(timescales.at("Controlled")->func(3.0)[0] == DataVector{time_step});
+    CHECK(timescales.at("Controlled1")->func(2.0)[0] == DataVector{time_step});
+    CHECK(timescales.at("Controlled1")->func(3.0)[0] == DataVector{time_step});
+    CHECK(timescales.at("Controlled2")->time_bounds() ==
+          std::array{initial_time, std::numeric_limits<double>::infinity()});
+    CHECK(timescales.at("Controlled2")->func(2.0)[0] == DataVector{time_step});
+    CHECK(timescales.at("Controlled2")->func(3.0)[0] == DataVector{time_step});
+    CHECK(timescales.at("Controlled3")->time_bounds() ==
+          std::array{initial_time, std::numeric_limits<double>::infinity()});
+    CHECK(timescales.at("Controlled3")->func(2.5)[0] == DataVector{time_step});
   }
   {
     const Creator creator = std::make_unique<TestCreator>(false);
@@ -176,6 +282,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Tags", "[ControlSystem][Unit]") {
   test_all_tags();
   test_control_sys_inputs();
   test_measurement_tag();
+  test_functions_of_time_tag();
 }
 
 // [[OutputRegex, Control systems can only be used in forward-in-time


### PR DESCRIPTION
## Proposed changes

Adds a second simple tag derived off the `domain::Tags::FunctionsOfTime` base tag. This new tag uses control system information (specifically control system OptionHolders) to construct the functions of time so it is placed in the control system library.

There are additional commits that 1) add a function to the Controller and 2) change the template of the control system OptionHolder to allow these changes.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
