### PR TITLE
Remove inlining of TensorContract::get

### DIFF
--- a/src/DataStructures/Tensor/Expressions/Contract.hpp
+++ b/src/DataStructures/Tensor/Expressions/Contract.hpp
@@ -232,13 +232,18 @@ struct TensorContract
   /// \brief Return the value of the component of the resultant contracted
   /// tensor at a given multi-index
   ///
+  /// \details Note that this function is not inlined because it has been
+  /// observed that when `Tensor` components are `DataVector`s, the compile time
+  /// for `TensorExpression` inner products scales poorly as the dimension of
+  /// operands' indices increase and as the number of contracted index pairs
+  /// increases.
+  ///
   /// \param contracted_multi_index the multi-index of the resultant contracted
   /// tensor component to retrieve
   /// \return the value of the component at `contracted_multi_index` in the
   /// resultant contracted tensor
-  SPECTRE_ALWAYS_INLINE decltype(auto) get(
-      const std::array<size_t, num_tensor_indices>& contracted_multi_index)
-      const {
+  decltype(auto) get(const std::array<size_t, num_tensor_indices>&
+                         contracted_multi_index) const {
     constexpr size_t initial_first_contracted_index_value =
         first_contracted_index::index_type == IndexType::Spacetime and
                 not tmpl::at_c<ArgsList, FirstContractedIndexPos>::is_spacetime


### PR DESCRIPTION
## Proposed changes

This PR simply removes the inlining of `TensorContract::get`.

The motivation for this is that it has been observed that when `DataType == DataVector`, the compile time for `TensorExpression` inner products scales poorly as the dimension of operands' indices increase and as the number of contracted index pairs increases. See **Further comments** for details.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

(1) **(When `DataType == DataVector`) Compile time scales poorly as we increase the number of index pairs being contracted in an inner product:**
See [results](https://docs.google.com/spreadsheets/d/1aRVNsAcLtQD4HFBtGLRVVn6pg9SJ_zWcIcfWqidTcyg/edit?usp=sharing).

[**Specific problematic inner product test case**](https://github.com/macedo22/spectre/commit/e1d8e3fdd2da13a94a13415f6dbb25e86e189464)**:**
```
// R and S indices have 3 spatial dim + 1 time dim
const Scalar<DataVector> L = TensorExpressions::evaluate(
      R(ti_A, ti_B, ti_C, ti_D) * S(ti_d, ti_c, ti_b, ti_a));
```
**Compile time**
Current: ~5m 12s
After removing inlining of `TensorContract::get`: ~45s (~85% improvement)

(2) **(When `DataType == DataVector`) Compile time seems to scale poorly as we increase the number of arithmetic operations in `TensorExpression` operands:**
I observed another [problematic test case (CCZ4 spatial ricci tensor equation)](https://github.com/macedo22/spectre/commit/1ade48f23c90b72d8162016b0d311b5553c6fd36) whose compile time was greatly improved by removing inlining of `TensorContract::get`. This equation does not contain multiple nested contractions like the problematic test case in (1), but it does involve inner products with  `TensorExpression` operands that have multiple operations, e.g. [this part](https://github.com/macedo22/spectre/blob/1ade48f23c90b72d8162016b0d311b5553c6fd36/tests/Unit/DataStructures/Test_DataVector.cpp#L84).

**Compile time**
Current: ~40s
After removing inlining of `TensorContract::get`: ~10s (~75% improvement)

Note that I did not test the compile times after varying the number of operations in an `TensorExpression` operand or after varying the ordering of the terms (e.g. having contractions be the leftmost part of the expression), I'm simply saying that more operations in the inner product operand *seems* to be the reason that the current compile time of this expression is so bad.

(3) **(When `DataType == DataVector`) Compile time seems to scale poorly as we increase the dimension of operands:**
No specific branch or rigorous test to link, but I observed:
```
// Contract over only the 3 spatial dim
// Compile time: ~16s
const Scalar<DataVector> L = TensorExpressions::evaluate(
      R(ti_I, ti_J, ti_K, ti_K) * S(ti_l, ti_k, ti_j, ti_i));

// Contract over 3 spatial dim + 1 time dim <-- test case from (1)
// Compile time: ~5m 12s
const Scalar<DataVector> L = TensorExpressions::evaluate(
      R(ti_A, ti_B, ti_C, ti_D) * S(ti_d, ti_c, ti_b, ti_a));
```
This is just to be complete in substantiating that increased dimension in the inner products leads to bad compile time scaling. I haven't tested what the compile time of the spatial one is after removing the inlining of `TensorContract::get`, but I assume it would be slightly better.
