### PR TITLE
Update advection executables to use subcell

### DIFF
--- a/src/Evolution/Executables/ScalarAdvection/CMakeLists.txt
+++ b/src/Evolution/Executables/ScalarAdvection/CMakeLists.txt
@@ -2,11 +2,13 @@
 # See LICENSE.txt for details.
 
 set(LIBS_TO_LINK
+  DgSubcell
   DiscontinuousGalerkin
   DomainCreators
   EventsAndDenseTriggers
   EventsAndTriggers
   Evolution
+  FiniteDifference
   IO
   Informer
   Limiters

--- a/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
@@ -2,20 +2,13 @@
 # See LICENSE.txt for details.
 
 # Executable: EvolveScalarAdvectionKrivodonova1D
-# Check: parse;execute_check_output
+# Check: parse;execute
 # ExpectedOutput:
 #   ScalarAdvectionKrivodonova1DVolume0.h5
-#   ScalarAdvectionKrivodonova1DReductions.h5
-# OutputFileChecks:
-#   - Label: check_analytic_solution
-#     Subfile: /ErrorNorms.dat
-#     FileGlob: ScalarAdvectionKrivodonova1DReductions.h5
-#     SkipColumns: [0,1]
-#     AbsoluteTolerance: 0.2
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.005
+  InitialTimeStep: 0.001
   TimeStepper: RungeKutta3
 
 PhaseChangeAndTriggers:
@@ -24,8 +17,8 @@ DomainCreator:
   Interval:
     LowerBound: [-1.0]
     UpperBound: [1.0]
-    InitialRefinement: [5]
-    InitialGridPoints: [2]
+    InitialRefinement: [2]
+    InitialGridPoints: [5]
     TimeDependence: None
     BoundaryConditions:
       LowerBoundary: Periodic
@@ -37,17 +30,21 @@ SpatialDiscretization:
   DiscontinuousGalerkin:
     Formulation: StrongInertial
     Quadrature: GaussLobatto
+    Subcell:
+      RdmpDelta0: 1.0e-7
+      RdmpEpsilon: 1.0e-3
+      PerssonExponent: 4.0
+      InitialData:
+        RdmpDelta0: 1.0e-7
+        RdmpEpsilon: 1.0e-3
+        PerssonExponent: 4.0
+      AlwaysUseSubcells: false
+  SubcellSolver:
+    Reconstructor:
+      MonotisedCentral
 
 AnalyticSolution:
   Krivodonova:
-
-Limiter:
-  Minmod:
-    Type: LambdaPi1
-    # The optimal value of the TVB constant is problem-dependent.
-    # This test uses 0 to favor robustness over accuracy.
-    TvbConstant: 0.0
-    DisableForDebugging: false
 
 EventsAndTriggers:
   ? Slabs:
@@ -56,20 +53,14 @@ EventsAndTriggers:
   : - Completion
   ? Slabs:
       EvenlySpaced:
-        Interval: 5
-        Offset: 0
-  : - ObserveErrorNorms:
-        SubfileName: ErrorNorms
-  ? Slabs:
-      EvenlySpaced:
         Interval: 10
         Offset: 0
   : - ObserveFields:
         SubfileName: VolumeData
-        VariablesToObserve: [U, VelocityField]
+        VariablesToObserve: [U, TciStatus]
         InterpolateToMesh: None
         CoordinatesFloatingPointType: Double
-        FloatingPointTypes: [Double, Double]
+        FloatingPointTypes: [Double, Float]
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
@@ -2,21 +2,13 @@
 # See LICENSE.txt for details.
 
 # Executable: EvolveScalarAdvectionKuzmin2D
-# Check: parse;execute_check_output
-# Timeout: 10
+# Check: parse;execute
 # ExpectedOutput:
 #   ScalarAdvectionKuzmin2DVolume0.h5
-#   ScalarAdvectionKuzmin2DReductions.h5
-# OutputFileChecks:
-#   - Label: check_analytic_solution
-#     Subfile: /ErrorNorms.dat
-#     FileGlob: ScalarAdvectionKuzmin2DReductions.h5
-#     SkipColumns: [0,1]
-#     AbsoluteTolerance: 0.2
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.01
+  InitialTimeStep: 0.001
   TimeStepper: RungeKutta3
 
 PhaseChangeAndTriggers:
@@ -25,8 +17,8 @@ DomainCreator:
   Rectangle:
     LowerBound: [0.0, 0.0]
     UpperBound: [1.0, 1.0]
-    InitialRefinement: [3, 3]
-    InitialGridPoints: [3, 3]
+    InitialRefinement: [2, 2]
+    InitialGridPoints: [5, 5]
     TimeDependence: None
     BoundaryCondition: Periodic
 
@@ -36,17 +28,21 @@ SpatialDiscretization:
   DiscontinuousGalerkin:
     Formulation: StrongInertial
     Quadrature: GaussLobatto
+    Subcell:
+      RdmpDelta0: 1.0e-7
+      RdmpEpsilon: 1.0e-3
+      PerssonExponent: 4.0
+      InitialData:
+        RdmpDelta0: 1.0e-7
+        RdmpEpsilon: 1.0e-3
+        PerssonExponent: 4.0
+      AlwaysUseSubcells: false
+  SubcellSolver:
+    Reconstructor:
+      MonotisedCentral
 
 AnalyticSolution:
   Kuzmin:
-
-Limiter:
-  Minmod:
-    Type: LambdaPi1
-    # The optimal value of the TVB constant is problem-dependent.
-    # This test uses 0 to favor robustness over accuracy.
-    TvbConstant: 0.0
-    DisableForDebugging: false
 
 EventsAndTriggers:
   ? Slabs:
@@ -55,20 +51,14 @@ EventsAndTriggers:
   : - Completion
   ? Slabs:
       EvenlySpaced:
-        Interval: 5
-        Offset: 0
-  : - ObserveErrorNorms:
-        SubfileName: ErrorNorms
-  ? Slabs:
-      EvenlySpaced:
         Interval: 10
         Offset: 0
   : - ObserveFields:
         SubfileName: VolumeData
-        VariablesToObserve: [U, VelocityField]
+        VariablesToObserve: [U, TciStatus]
         InterpolateToMesh: None
         CoordinatesFloatingPointType: Double
-        FloatingPointTypes: [Double, Double]
+        FloatingPointTypes: [Double, Float]
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
@@ -2,20 +2,13 @@
 # See LICENSE.txt for details.
 
 # Executable: EvolveScalarAdvectionSinusoid1D
-# Check: parse;execute_check_output
+# Check: parse;execute
 # ExpectedOutput:
 #   ScalarAdvectionSinusoid1DVolume0.h5
-#   ScalarAdvectionSinusoid1DReductions.h5
-# OutputFileChecks:
-#   - Label: check_analytic_solution
-#     Subfile: /ErrorNorms.dat
-#     FileGlob: ScalarAdvectionSinusoid1DReductions.h5
-#     SkipColumns: [0,1]
-#     AbsoluteTolerance: 0.02
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.0001
+  InitialTimeStep: 0.001
   TimeStepper: RungeKutta3
 
 PhaseChangeAndTriggers:
@@ -24,8 +17,8 @@ DomainCreator:
   Interval:
     LowerBound: [-1.0]
     UpperBound: [1.0]
-    InitialRefinement: [4]
-    InitialGridPoints: [3]
+    InitialRefinement: [2]
+    InitialGridPoints: [5]
     TimeDependence: None
     BoundaryConditions:
       LowerBoundary: Periodic
@@ -37,17 +30,21 @@ SpatialDiscretization:
   DiscontinuousGalerkin:
     Formulation: StrongInertial
     Quadrature: GaussLobatto
+    Subcell:
+      RdmpDelta0: 1.0e-7
+      RdmpEpsilon: 1.0e-3
+      PerssonExponent: 4.0
+      InitialData:
+        RdmpDelta0: 1.0e-7
+        RdmpEpsilon: 1.0e-3
+        PerssonExponent: 4.0
+      AlwaysUseSubcells: false
+  SubcellSolver:
+    Reconstructor:
+      MonotisedCentral
 
 AnalyticSolution:
   Sinusoid:
-
-Limiter:
-  Minmod:
-    Type: LambdaPi1
-    # The optimal value of the TVB constant is problem-dependent.
-    # This test uses 0 to favor robustness over accuracy.
-    TvbConstant: 0.0
-    DisableForDebugging: false
 
 EventsAndTriggers:
   ? Slabs:
@@ -56,20 +53,14 @@ EventsAndTriggers:
   : - Completion
   ? Slabs:
       EvenlySpaced:
-        Interval: 5
-        Offset: 0
-  : - ObserveErrorNorms:
-        SubfileName: ErrorNorms
-  ? Slabs:
-      EvenlySpaced:
         Interval: 10
         Offset: 0
   : - ObserveFields:
         SubfileName: VolumeData
-        VariablesToObserve: [U, VelocityField]
+        VariablesToObserve: [U, TciStatus]
         InterpolateToMesh: None
         CoordinatesFloatingPointType: Double
-        FloatingPointTypes: [Double, Double]
+        FloatingPointTypes: [Double, Float]
 
 EventsAndDenseTriggers:
 


### PR DESCRIPTION
## Proposed changes

Since subcell currently does not support `ObserveErrorNorms`, corresponding checks were deleted from input files.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

