### PR TITLE
Remove duplicate `inverse_spatial_metric` tag

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/BoundaryConditionsImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/BoundaryConditionsImpl.hpp
@@ -401,12 +401,12 @@ void apply_boundary_condition_on_face(
 
   // Now we populate the fields on the exterior side of the face using the
   // boundary condition.
-  using tags_on_exterior_face =
+  using tags_on_exterior_face = tmpl::remove_duplicates<
       tmpl::append<variables_tags, fluxes_tags, correction_temp_tags,
                    correction_prim_tags, inverse_spatial_metric_list,
                    tmpl::list<detail::OneOverNormalVectorMagnitude,
                               detail::NormalVector<Dim>,
-                              evolution::dg::Tags::NormalCovector<Dim>>>;
+                              evolution::dg::Tags::NormalCovector<Dim>>>>;
   Variables<tags_on_exterior_face> exterior_face_fields{
       number_of_points_on_face};
 


### PR DESCRIPTION
## Proposed changes

When trying to implement ghost boundary conditions for a system with `has_inv_spatial_metric` that also has a boundary correction with `inverse_spatial_metric` specified in the `dg_package_data_temporary_tags` it will currently cause a compilation error as the `InverseSpatialMetric` tag is now present twice in `tags_on_exterior_face` and we try to allocate a variables with this tags_list. This fixes it by removing the duplicate tag.