### PR TITLE
Fix Ylmspherepack segfault

### DIFF
--- a/src/NumericalAlgorithms/SphericalHarmonics/YlmSpherepack.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/YlmSpherepack.hpp
@@ -83,7 +83,8 @@ class YlmSpherepack {
   /// points.
   template <typename T>
   struct InterpolationInfo {
-    InterpolationInfo(size_t m_max, const std::vector<double>& pmm,
+    InterpolationInfo(size_t l_max, size_t m_max,
+                      const std::vector<double>& pmm,
                       const std::array<T, 2>& target_points);
     T cos_theta;
     // cos(m*phi)
@@ -93,9 +94,13 @@ class YlmSpherepack {
     // pbar_factor[m] = Pbar(m,m)*sin(theta)^m
     DynamicBuffer<T> pbar_factor;
 
-    size_t size() const { return num_points_; };
+    size_t size() const { return num_points_; }
+    size_t m_max() const { return m_max_; }
+    size_t l_max() const { return l_max_; }
 
    private:
+    size_t l_max_;
+    size_t m_max_;
     size_t num_points_;
   };
 
@@ -432,6 +437,7 @@ class YlmSpherepack {
                                 size_t physical_stride = 1,
                                 size_t physical_offset = 0,
                                 bool loop_over_offset = false) const;
+  void calculate_interpolation_data() const;
   void fill_scalar_work_arrays() const;
   void fill_vector_work_arrays() const;
   size_t l_max_, m_max_, n_theta_, n_phi_;


### PR DESCRIPTION
## Proposed changes
Fixes a bug where creating an `InterpolationInfo` with one `YlmSpherepack` instance and using it with another instance causes a segfault as some storage vectors are only initialized once `set_up_interpolation_info` is called for the first time. 

Further improvements might include removing the `mutable` keyword from `YlmSpherepack_detail::Storage storage_`  since calculations depend on the content. Depending on the cost and frequency of use,  these `storage_` calculations could perhaps just be done at initialization to avoid the complexity of initializing them the first time a certain method is  called. 
