### PR TITLE
Add CCZ4 function for ricci scalar plus divergence Z4 constraint

### DIFF
--- a/src/Evolution/Systems/Ccz4/CMakeLists.txt
+++ b/src/Evolution/Systems/Ccz4/CMakeLists.txt
@@ -14,6 +14,7 @@ spectre_target_sources(
   DerivLapse.cpp
   DerivZ4Constraint.cpp
   Ricci.cpp
+  RicciScalarPlusDivergenceZ4Constraint.cpp
   Z4Constraint.cpp
   )
 
@@ -27,6 +28,7 @@ spectre_target_headers(
   DerivLapse.hpp
   DerivZ4Constraint.hpp
   Ricci.hpp
+  RicciScalarPlusDivergenceZ4Constraint.hpp
   System.hpp
   Tags.hpp
   TagsDeclarations.hpp

--- a/src/Evolution/Systems/Ccz4/RicciScalarPlusDivergenceZ4Constraint.cpp
+++ b/src/Evolution/Systems/Ccz4/RicciScalarPlusDivergenceZ4Constraint.cpp
@@ -1,0 +1,78 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Ccz4/RicciScalarPlusDivergenceZ4Constraint.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Ccz4 {
+template <size_t Dim, typename Frame, typename DataType>
+void ricci_scalar_plus_divergence_z4_constraint(
+    const gsl::not_null<Scalar<DataType>*> result,
+    const Scalar<DataType>& conformal_factor_squared,
+    const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
+    const tnsr::ii<DataType, Dim, Frame>& spatial_ricci_tensor,
+    const tnsr::ij<DataType, Dim, Frame>& grad_spatial_z4_constraint) {
+  destructive_resize_components(result,
+                                get_size(get(conformal_factor_squared)));
+
+  ::TensorExpressions::evaluate(
+      result, conformal_factor_squared() *
+                  inverse_conformal_spatial_metric(ti_I, ti_J) *
+                  (spatial_ricci_tensor(ti_i, ti_j) +
+                   grad_spatial_z4_constraint(ti_i, ti_j) +
+                   grad_spatial_z4_constraint(ti_j, ti_i)));
+}
+
+template <size_t Dim, typename Frame, typename DataType>
+Scalar<DataType> ricci_scalar_plus_divergence_z4_constraint(
+    const Scalar<DataType>& conformal_factor_squared,
+    const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
+    const tnsr::ii<DataType, Dim, Frame>& spatial_ricci_tensor,
+    const tnsr::ij<DataType, Dim, Frame>& grad_spatial_z4_constraint) {
+  Scalar<DataType> result{};
+  ricci_scalar_plus_divergence_z4_constraint(
+      make_not_null(&result), conformal_factor_squared,
+      inverse_conformal_spatial_metric, spatial_ricci_tensor,
+      grad_spatial_z4_constraint);
+  return result;
+}
+}  // namespace Ccz4
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                      \
+  template void Ccz4::ricci_scalar_plus_divergence_z4_constraint( \
+      const gsl::not_null<Scalar<DTYPE(data)>*> result,           \
+      const Scalar<DTYPE(data)>& conformal_factor_squared,        \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&        \
+          inverse_conformal_spatial_metric,                       \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&        \
+          spatial_ricci_tensor,                                   \
+      const tnsr::ij<DTYPE(data), DIM(data), FRAME(data)>&        \
+          grad_spatial_z4_constraint);                            \
+  template Scalar<DTYPE(data)>                                    \
+  Ccz4::ricci_scalar_plus_divergence_z4_constraint(               \
+      const Scalar<DTYPE(data)>& conformal_factor_squared,        \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&        \
+          inverse_conformal_spatial_metric,                       \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&        \
+          spatial_ricci_tensor,                                   \
+      const tnsr::ij<DTYPE(data), DIM(data), FRAME(data)>&        \
+          grad_spatial_z4_constraint);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial),
+                        (double, DataVector))
+
+#undef INSTANTIATE
+#undef DTYPE
+#undef FRAME
+#undef DIM

--- a/src/Evolution/Systems/Ccz4/RicciScalarPlusDivergenceZ4Constraint.hpp
+++ b/src/Evolution/Systems/Ccz4/RicciScalarPlusDivergenceZ4Constraint.hpp
@@ -1,0 +1,47 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Ccz4 {
+/// @{
+/*!
+ * \brief Computes the sum of the Ricci scalar and twice the divergence of the
+ * upper spatial Z4 constraint
+ *
+ * \details Computes the expression as:
+ *
+ * \f{align}
+ *     R + 2 \nabla_k Z^k &=
+ *         \phi^2 \tilde{\gamma}^{ij} (R_{ij} + \nabla_i Z_j + \nabla_j Z_i)
+ * \f}
+ *
+ * where \f$R\f$ is the spatial Ricci scalar, \f$Z^i\f$ is the upper spatial Z4
+ * constraint defined by `Ccz4::Tags::Z4ConstraintUp`, \f$phi^2\f$ is the square
+ * of the conformal factor defined by `Ccz4::Tags::ConformalFactorSquared`,
+ * \f$\tilde{\gamma}^{ij}\f$ is the inverse conformal spatial metric defined by
+ * `Ccz4::Tags::InverseConformalMetric`, \f$R_{ij}\f$ is the spatial Ricci
+ * tensor defined by `Ccz4::Tags::Ricci`, and \f$\nabla_j Z_i\f$ is the gradient
+ * of the spatial Z4 constraint defined by `Ccz4::Tags::GradZ4Constraint`.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+void ricci_scalar_plus_divergence_z4_constraint(
+    const gsl::not_null<Scalar<DataType>*> result,
+    const Scalar<DataType>& conformal_factor_squared,
+    const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
+    const tnsr::ii<DataType, Dim, Frame>& spatial_ricci_tensor,
+    const tnsr::ij<DataType, Dim, Frame>& grad_spatial_z4_constraint);
+
+template <size_t Dim, typename Frame, typename DataType>
+Scalar<DataType> ricci_scalar_plus_divergence_z4_constraint(
+    const Scalar<DataType>& conformal_factor_squared,
+    const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
+    const tnsr::ii<DataType, Dim, Frame>& spatial_ricci_tensor,
+    const tnsr::ij<DataType, Dim, Frame>& grad_spatial_z4_constraint);
+/// @}
+}  // namespace Ccz4

--- a/src/Evolution/Systems/Ccz4/Tags.hpp
+++ b/src/Evolution/Systems/Ccz4/Tags.hpp
@@ -354,6 +354,17 @@ template <size_t Dim, typename Frame, typename DataType>
 struct GradSpatialZ4Constraint : db::SimpleTag {
   using type = tnsr::ij<DataType, Dim, Frame>;
 };
+
+/*!
+ * \brief The sum of the Ricci scalar and twice the divergence of the upper
+ * spatial Z4 constraint
+ *
+ * \details See `Ccz4::ricci_scalar_plus_divergence_z4_constraint` for details.
+ */
+template <typename DataType>
+struct RicciScalarPlusDivergenceZ4Constraint : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
 }  // namespace Tags
 
 namespace OptionTags {

--- a/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
@@ -75,6 +75,8 @@ struct SpatialZ4ConstraintUp;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
 struct GradSpatialZ4Constraint;
+template <typename DataType = DataVector>
+struct RicciScalarPlusDivergenceZ4Constraint;
 }  // namespace Tags
 
 /// \brief Input option tags for the CCZ4 evolution system

--- a/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBRARY_SOURCES
   Test_DerivLapse.cpp
   Test_DerivZ4Constraint.cpp
   Test_Ricci.cpp
+  Test_RicciScalarPlusDivergenceZ4Constraint.cpp
   Test_Tags.cpp
   Test_TempTags.cpp
   Test_Z4Constraint.cpp

--- a/tests/Unit/Evolution/Systems/Ccz4/RicciScalarPlusDivergenceZ4Constraint.py
+++ b/tests/Unit/Evolution/Systems/Ccz4/RicciScalarPlusDivergenceZ4Constraint.py
@@ -1,0 +1,13 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def ricci_scalar_plus_divergence_z4_constraint(
+    conformal_factor_squared, inverse_conformal_spatial_metric,
+    spatial_ricci_tensor, grad_spatial_z4_constraint):
+    return conformal_factor_squared * np.einsum(
+        "ij,ij", inverse_conformal_spatial_metric,
+        spatial_ricci_tensor + grad_spatial_z4_constraint +
+        np.einsum("ji", grad_spatial_z4_constraint))

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_RicciScalarPlusDivergenceZ4Constraint.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_RicciScalarPlusDivergenceZ4Constraint.cpp
@@ -1,0 +1,176 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <string>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Evolution/Systems/Ccz4/RicciScalarPlusDivergenceZ4Constraint.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/Pypp.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+using Affine = domain::CoordinateMaps::Affine;
+using Affine3D = domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+
+template <size_t Dim, typename DataType>
+void test_compute_ricci_scalar_plus_divergence_z4_constraint(
+    const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(
+      static_cast<Scalar<DataType> (*)(
+          const Scalar<DataType>&,
+          const tnsr::II<DataType, Dim, Frame::Inertial>&,
+          const tnsr::ii<DataType, Dim, Frame::Inertial>&,
+          const tnsr::ij<DataType, Dim, Frame::Inertial>&)>(
+          &Ccz4::ricci_scalar_plus_divergence_z4_constraint<
+              Dim, Frame::Inertial, DataType>),
+      "RicciScalarPlusDivergenceZ4Constraint",
+      "ricci_scalar_plus_divergence_z4_constraint", {{{-1., 1.}}},
+      used_for_size);
+}
+
+// Test that when \f$\nabla_i Z_j == 0\f$, \f$R + 2 \nabla_k Z^k == R\f$. Uses
+// KerrSchild for reference Ricci tensor solution.
+template <typename Solution>
+void test_divergence_spatial_z4_constraint_vanishes(
+    const Solution& solution, size_t grid_size_each_dimension,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound) {
+  // Setup grid
+  const size_t SpatialDim = 3;
+  Mesh<SpatialDim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto};
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::ElementLogical, Frame::Inertial>(
+          Affine3D{
+              Affine{-1., 1., lower_bound[0], upper_bound[0]},
+              Affine{-1., 1., lower_bound[1], upper_bound[1]},
+              Affine{-1., 1., lower_bound[2], upper_bound[2]},
+          });
+  const size_t num_points_3d = grid_size_each_dimension *
+                               grid_size_each_dimension *
+                               grid_size_each_dimension;
+  // Setup coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  // Arbitrary time for time-independent solution.
+  const double t = std::numeric_limits<double>::signaling_NaN();
+  // Evaluate analytic solution
+  const auto vars =
+      solution.variables(x, t, typename Solution::template tags<DataVector>{});
+  const auto& spatial_metric = get<gr::Tags::SpatialMetric<SpatialDim>>(vars);
+  const auto det_and_inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric);
+  const auto det_spatial_metric = det_and_inverse_spatial_metric.first;
+  const auto inverse_spatial_metric = det_and_inverse_spatial_metric.second;
+  const auto& d_spatial_metric =
+      get<Tags::deriv<gr::Tags::SpatialMetric<SpatialDim>,
+                      tmpl::size_t<SpatialDim>, Frame::Inertial>>(vars);
+
+  // Compute arguments for KerrSchild Ricci scalar and
+  // `Ccz4::ricci_scalar_plus_divergence_z4_constraint`
+  const DataVector used_for_size =
+      DataVector(num_points_3d, std::numeric_limits<double>::signaling_NaN());
+  Scalar<DataVector> conformal_factor_squared{};
+  get(conformal_factor_squared) = pow(get(det_spatial_metric), -1. / 3.);
+
+  tnsr::II<DataVector, SpatialDim, Frame::Inertial>
+      inverse_conformal_spatial_metric{};
+  for (size_t i = 0; i < SpatialDim; i++) {
+    for (size_t j = i; j < SpatialDim; j++) {
+      inverse_conformal_spatial_metric.get(i, j) =
+          inverse_spatial_metric.get(i, j) / get(conformal_factor_squared);
+    }
+  }
+
+  const auto christoffel_second_kind =
+      gr::christoffel_second_kind(d_spatial_metric, inverse_spatial_metric);
+
+  using christoffel_second_kind_tag =
+      gr::Tags::SpatialChristoffelSecondKind<SpatialDim, Frame::Inertial,
+                                             DataVector>;
+  Variables<tmpl::list<christoffel_second_kind_tag>>
+      christoffel_second_kind_var(num_points_3d);
+  get<christoffel_second_kind_tag>(christoffel_second_kind_var) =
+      christoffel_second_kind;
+  const auto d_christoffel_second_kind_var =
+      partial_derivatives<tmpl::list<christoffel_second_kind_tag>>(
+          christoffel_second_kind_var, mesh, coord_map.inv_jacobian(x_logical));
+  const auto& d_christoffel_second_kind =
+      get<Tags::deriv<christoffel_second_kind_tag, tmpl::size_t<SpatialDim>,
+                      Frame::Inertial>>(d_christoffel_second_kind_var);
+
+  const auto spatial_ricci_tensor =
+      gr::ricci_tensor(christoffel_second_kind, d_christoffel_second_kind);
+
+  auto expected_ricci_scalar =
+      make_with_value<Scalar<DataVector>>(used_for_size, 0.0);
+  for (size_t i = 0; i < SpatialDim; i++) {
+    for (size_t j = 0; j < SpatialDim; j++) {
+      get(expected_ricci_scalar) +=
+          inverse_spatial_metric.get(i, j) * spatial_ricci_tensor.get(i, j);
+    }
+  }
+
+  // Let \f$\nabla_i Z_j = 0\f$
+  const auto grad_spatial_z4_constraint =
+      make_with_value<tnsr::ij<DataVector, SpatialDim, Frame::Inertial>>(
+          used_for_size, 0.0);
+
+  const auto actual_result = Ccz4::ricci_scalar_plus_divergence_z4_constraint(
+      conformal_factor_squared, inverse_conformal_spatial_metric,
+      spatial_ricci_tensor, grad_spatial_z4_constraint);
+
+  // Check that the result is the Ricci scalar
+  CHECK_ITERABLE_APPROX(actual_result, expected_ricci_scalar);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.Ccz4.RicciScalarPlusDivergenceZ4Constraint",
+    "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env("Evolution/Systems/Ccz4/");
+
+  GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(
+      test_compute_ricci_scalar_plus_divergence_z4_constraint, (1, 2, 3));
+
+  const double mass = 2.;
+  const std::array<double, 3> spin{{0.3, 0.5, 0.2}};
+  const std::array<double, 3> center{{0.2, 0.3, 0.4}};
+  const gr::Solutions::KerrSchild solution(mass, spin, center);
+
+  const size_t grid_size = 8;
+  const std::array<double, 3> lower_bound{{0.8, 1.22, 1.30}};
+  const std::array<double, 3> upper_bound{{0.82, 1.24, 1.32}};
+
+  test_divergence_spatial_z4_constraint_vanishes(solution, grid_size,
+                                                 lower_bound, upper_bound);
+}

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_Tags.cpp
@@ -77,6 +77,9 @@ void test_simple_tags() {
   TestHelpers::db::test_simple_tag<
       Ccz4::Tags::GradSpatialZ4Constraint<Dim, Frame, DataType>>(
       "GradSpatialZ4Constraint");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::RicciScalarPlusDivergenceZ4Constraint<DataType>>(
+      "RicciScalarPlusDivergenceZ4Constraint");
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.Tags", "[Unit][Evolution]") {


### PR DESCRIPTION
## Proposed changes

This PR adds a CCZ4 function for computing the value of the Ricci scalar plus twice the divergence of the upper spatial Z4 constraint.

The motivation for this PR is to implement eq. (27), whose value will be used to implement the evolution equations eq. 12e, 12f, and 12g in [this CCZ4 paper](https://arxiv.org/pdf/1707.09910.pdf).


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
