### PR TITLE
Construct measurement timescales using control sys info

### DIFF
--- a/src/ControlSystem/Actions/InitializeMeasurements.hpp
+++ b/src/ControlSystem/Actions/InitializeMeasurements.hpp
@@ -9,7 +9,7 @@
 
 #include "ControlSystem/Event.hpp"
 #include "ControlSystem/Metafunctions.hpp"
-#include "ControlSystem/Tags.hpp"
+#include "ControlSystem/Tags/MeasurementTimescales.hpp"
 #include "ControlSystem/Trigger.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "Evolution/EventsAndDenseTriggers/DenseTrigger.hpp"

--- a/src/ControlSystem/Averager.hpp
+++ b/src/ControlSystem/Averager.hpp
@@ -116,6 +116,8 @@ class Averager {
   /// Returns a bool corresponding to whether `average_0th_deriv_of_q`
   /// is `true`/`false`.
   bool using_average_0th_deriv_of_q() const { return average_0th_deriv_of_q_; };
+  /// Returns the averaging timescale fraction
+  double avg_timescale_frac() const { return avg_tscale_frac_; }
 
   void pup(PUP::er& p);
 

--- a/src/ControlSystem/CMakeLists.txt
+++ b/src/ControlSystem/CMakeLists.txt
@@ -21,6 +21,7 @@ spectre_target_headers(
   Component.hpp
   Controller.hpp
   Event.hpp
+  InitialExpirationTimes.hpp
   Metafunctions.hpp
   NamespaceDocs.hpp
   RunCallbacks.hpp

--- a/src/ControlSystem/InitialExpirationTimes.hpp
+++ b/src/ControlSystem/InitialExpirationTimes.hpp
@@ -1,0 +1,56 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+
+#include "DataStructures/DataVector.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace control_system {
+/*!
+ * \ingroup ControlSystemGroup
+ * \brief Construct the initial expiration times for functions of time that are
+ * controlled by a control system
+ *
+ * The expiration times are constructed using inputs from control system
+ * OptionHolders as an unordered map from the name of the function of time being
+ * controlled to the expiration time. The expiration time is computed as
+ * \f$\tau_\mathrm{exp} = \alpha_\mathrm{update} \tau_\mathrm{damp}\f$ where
+ * \f$\alpha_\mathrm{update}\f$ is the update fraction supplied as input to the
+ * Controller and \f$\tau_\mathrm{damp}\f$ is/are the damping timescales
+ * supplied from the TimescaleTuner (\f$\tau_\mathrm{damp}\f$ is a DataVector
+ * with as many components as the corresponding function of time, thus
+ * \f$\tau_\mathrm{exp}\f$ will also be a DataVector of the same length).
+ *
+ */
+template <typename... OptionHolders>
+std::unordered_map<std::string, double> initial_expiration_times(
+    const double initial_time, const double initial_time_step,
+    const OptionHolders&... option_holders) {
+  std::unordered_map<std::string, double> initial_expiration_times{};
+
+  [[maybe_unused]] const auto gather_initial_expiration_times =
+      [&initial_time, &initial_time_step,
+       &initial_expiration_times](const auto& option_holder) {
+        const auto& controller = option_holder.controller;
+        const std::string& name =
+            std::decay_t<decltype(option_holder)>::control_system::name();
+        const auto& tuner = option_holder.tuner;
+
+        const double update_fraction = controller.get_update_fraction();
+        const double curr_timescale = min(tuner.current_timescale());
+        const double initial_expiration_time = update_fraction * curr_timescale;
+        initial_expiration_times[name] =
+            initial_time + std::max(initial_time_step, initial_expiration_time);
+      };
+
+  EXPAND_PACK_LEFT_TO_RIGHT(gather_initial_expiration_times(option_holders));
+
+  return initial_expiration_times;
+}
+}  // namespace control_system

--- a/src/ControlSystem/Tags.hpp
+++ b/src/ControlSystem/Tags.hpp
@@ -3,11 +3,8 @@
 
 #pragma once
 
-#include <array>
-#include <limits>
-#include <memory>
+#include <cstddef>
 #include <string>
-#include <unordered_map>
 #include <utility>
 
 #include "ControlSystem/Averager.hpp"
@@ -15,15 +12,7 @@
 #include "ControlSystem/Protocols/ControlSystem.hpp"
 #include "ControlSystem/TimescaleTuner.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
-#include "DataStructures/DataVector.hpp"
-#include "Domain/Creators/DomainCreator.hpp"
-#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
-#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
-#include "Domain/OptionTags.hpp"
 #include "Options/Options.hpp"
-#include "Time/Tags.hpp"
-#include "Utilities/ErrorHandling/Error.hpp"
-#include "Utilities/MakeWithValue.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -116,65 +105,6 @@ struct TimescaleTuner : db::SimpleTag {
 template <size_t DerivOrder>
 struct Controller : db::SimpleTag {
   using type = ::Controller<DerivOrder>;
-};
-
-/// \ingroup DataBoxTagsGroup
-/// \ingroup ControlSystemGroup
-/// \brief The measurement timescales associated with
-/// domain::Tags::FunctionsOfTime.
-///
-/// Each function of time associated with a control system has a corresponding
-/// set of timescales here, represented as `PiecewisePolynomial<0>` with the
-/// same components as the function itself.
-struct MeasurementTimescales : db::SimpleTag {
-  using type = std::unordered_map<
-      std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>;
-
-  static constexpr bool pass_metavariables = true;
-
-  template <typename Metavariables>
-  using option_tags =
-      tmpl::list<domain::OptionTags::DomainCreator<Metavariables::volume_dim>,
-                 ::OptionTags::InitialTimeStep>;
-
-  template <typename Metavariables>
-  static type create_from_options(
-      const std::unique_ptr<::DomainCreator<Metavariables::volume_dim>>&
-          domain_creator,
-      const double initial_time_step) {
-    std::unordered_map<std::string,
-                       std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
-        timescales;
-    for (const auto& function_of_time : domain_creator->functions_of_time()) {
-      if (function_of_time.second->time_bounds()[1] ==
-          std::numeric_limits<double>::infinity()) {
-        // This function of time is not controlled by a control
-        // system.  It is an analytic function or similar.
-        continue;
-      }
-      const double function_initial_time =
-          function_of_time.second->time_bounds()[0];
-      const DataVector used_for_size =
-          function_of_time.second->func(function_initial_time)[0];
-
-      // This check is intentionally inside the loop over the
-      // functions of time so that it will not trigger for domains
-      // without control systems.
-      if (initial_time_step <= 0.0) {
-        ERROR(
-            "Control systems can only be used in forward-in-time evolutions.");
-      }
-
-      auto initial_timescale =
-          make_with_value<DataVector>(used_for_size, initial_time_step);
-      timescales.emplace(
-          function_of_time.first,
-          std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<0>>(
-              function_initial_time, std::array{std::move(initial_timescale)},
-              std::numeric_limits<double>::infinity()));
-    }
-    return timescales;
-  }
 };
 }  // namespace Tags
 

--- a/src/ControlSystem/Tags/CMakeLists.txt
+++ b/src/ControlSystem/Tags/CMakeLists.txt
@@ -6,4 +6,5 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   FunctionsOfTimeInitialize.hpp
+  MeasurementTimescales.hpp
   )

--- a/src/ControlSystem/Tags/MeasurementTimescales.hpp
+++ b/src/ControlSystem/Tags/MeasurementTimescales.hpp
@@ -1,0 +1,81 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <limits>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/OptionTags.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace control_system::Tags {
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ControlSystemGroup
+/// \brief The measurement timescales associated with
+/// domain::Tags::FunctionsOfTime.
+///
+/// Each function of time associated with a control system has a corresponding
+/// set of timescales here, represented as `PiecewisePolynomial<0>` with the
+/// same components as the function itself.
+struct MeasurementTimescales : db::SimpleTag {
+  using type = std::unordered_map<
+      std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>;
+
+  static constexpr bool pass_metavariables = true;
+
+  template <typename Metavariables>
+  using option_tags =
+      tmpl::list<domain::OptionTags::DomainCreator<Metavariables::volume_dim>,
+                 ::OptionTags::InitialTimeStep>;
+
+  template <typename Metavariables>
+  static type create_from_options(
+      const std::unique_ptr<::DomainCreator<Metavariables::volume_dim>>&
+          domain_creator,
+      const double initial_time_step) {
+    std::unordered_map<std::string,
+                       std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+        timescales;
+    for (const auto& function_of_time : domain_creator->functions_of_time()) {
+      if (function_of_time.second->time_bounds()[1] ==
+          std::numeric_limits<double>::infinity()) {
+        // This function of time is not controlled by a control
+        // system.  It is an analytic function or similar.
+        continue;
+      }
+      const double function_initial_time =
+          function_of_time.second->time_bounds()[0];
+      const DataVector used_for_size =
+          function_of_time.second->func(function_initial_time)[0];
+
+      // This check is intentionally inside the loop over the
+      // functions of time so that it will not trigger for domains
+      // without control systems.
+      if (initial_time_step <= 0.0) {
+        ERROR(
+            "Control systems can only be used in forward-in-time evolutions.");
+      }
+
+      auto initial_timescale =
+          make_with_value<DataVector>(used_for_size, initial_time_step);
+      timescales.emplace(
+          function_of_time.first,
+          std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<0>>(
+              function_initial_time, std::array{std::move(initial_timescale)},
+              std::numeric_limits<double>::infinity()));
+    }
+    return timescales;
+  }
+};
+}  // namespace control_system::Tags

--- a/src/ControlSystem/Tags/MeasurementTimescales.hpp
+++ b/src/ControlSystem/Tags/MeasurementTimescales.hpp
@@ -4,20 +4,25 @@
 #pragma once
 
 #include <array>
-#include <limits>
 #include <memory>
 #include <string>
 #include <unordered_map>
 
+#include "ControlSystem/InitialExpirationTimes.hpp"
+#include "ControlSystem/Tags.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
-#include "Domain/OptionTags.hpp"
 #include "Time/Tags.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
-#include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits/IsA.hpp"
+
+/// \cond
+template <class Metavariables, typename ControlSystem>
+struct ControlComponent;
+/// \endcond
 
 namespace control_system::Tags {
 /// \ingroup DataBoxTagsGroup
@@ -35,46 +40,62 @@ struct MeasurementTimescales : db::SimpleTag {
   static constexpr bool pass_metavariables = true;
 
   template <typename Metavariables>
-  using option_tags =
-      tmpl::list<domain::OptionTags::DomainCreator<Metavariables::volume_dim>,
-                 ::OptionTags::InitialTimeStep>;
+  using option_tags = tmpl::flatten<
+      tmpl::list<::OptionTags::InitialTime, ::OptionTags::InitialTimeStep,
+                 control_system::inputs<tmpl::transform<
+                     tmpl::filter<typename Metavariables::component_list,
+                                  tt::is_a_lambda<ControlComponent, tmpl::_1>>,
+                     tmpl::bind<tmpl::back, tmpl::_1>>>>>;
 
-  template <typename Metavariables>
-  static type create_from_options(
-      const std::unique_ptr<::DomainCreator<Metavariables::volume_dim>>&
-          domain_creator,
-      const double initial_time_step) {
+  template <typename Metavariables, typename... OptionHolders>
+  static type create_from_options(const double initial_time,
+                                  const double initial_time_step,
+                                  const OptionHolders&... option_holders) {
     std::unordered_map<std::string,
                        std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
-        timescales;
-    for (const auto& function_of_time : domain_creator->functions_of_time()) {
-      if (function_of_time.second->time_bounds()[1] ==
-          std::numeric_limits<double>::infinity()) {
-        // This function of time is not controlled by a control
-        // system.  It is an analytic function or similar.
-        continue;
-      }
-      const double function_initial_time =
-          function_of_time.second->time_bounds()[0];
-      const DataVector used_for_size =
-          function_of_time.second->func(function_initial_time)[0];
+        timescales{};
+    const auto initial_expiration_times =
+        control_system::initial_expiration_times(
+            initial_time, initial_time_step, option_holders...);
 
-      // This check is intentionally inside the loop over the
-      // functions of time so that it will not trigger for domains
-      // without control systems.
-      if (initial_time_step <= 0.0) {
-        ERROR(
-            "Control systems can only be used in forward-in-time evolutions.");
-      }
+    [[maybe_unused]] const auto calculate_measurement_timescales =
+        [&timescales, &initial_time, &initial_time_step,
+         &initial_expiration_times](const auto& option_holder) {
+          // This check is intentionally inside the lambda so that it will not
+          // trigger for domains without control systems.
+          if (initial_time_step <= 0.0) {
+            ERROR(
+                "Control systems can only be used in forward-in-time "
+                "evolutions.");
+          }
 
-      auto initial_timescale =
-          make_with_value<DataVector>(used_for_size, initial_time_step);
-      timescales.emplace(
-          function_of_time.first,
-          std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<0>>(
-              function_initial_time, std::array{std::move(initial_timescale)},
-              std::numeric_limits<double>::infinity()));
-    }
+          const auto& controller = option_holder.controller;
+          const std::string& name =
+              std::decay_t<decltype(option_holder)>::control_system::name();
+          const auto& tuner = option_holder.tuner;
+          const auto& averager = option_holder.averager;
+
+          const double update_fraction = controller.get_update_fraction();
+          const double averaging_fraction = averager.avg_timescale_frac();
+          const DataVector& curr_timescale = tuner.current_timescale();
+
+          DataVector measurement_timescales =
+              averaging_fraction * update_fraction * curr_timescale;
+          // At a minimum, we can only measure once a time step with GTS.
+          for (size_t i = 0; i < measurement_timescales.size(); i++) {
+            measurement_timescales[i] =
+                std::max(initial_time_step, measurement_timescales[i]);
+          }
+
+          timescales.emplace(
+              name,
+              std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<0>>(
+                  initial_time, std::array{std::move(measurement_timescales)},
+                  initial_expiration_times.at(name)));
+        };
+
+    EXPAND_PACK_LEFT_TO_RIGHT(calculate_measurement_timescales(option_holders));
+
     return timescales;
   }
 };

--- a/tests/Unit/ControlSystem/CMakeLists.txt
+++ b/tests/Unit/ControlSystem/CMakeLists.txt
@@ -18,6 +18,7 @@ set(LIBRARY_SOURCES
 
 add_subdirectory(Actions)
 add_subdirectory(Protocols)
+add_subdirectory(Tags)
 
 add_test_library(
   ${LIBRARY}

--- a/tests/Unit/ControlSystem/CMakeLists.txt
+++ b/tests/Unit/ControlSystem/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_Averager.cpp
   Test_Controller.cpp
   Test_EventTriggerMetafunctions.cpp
+  Test_InitialExpirationTimes.cpp
   Test_Measurement.cpp
   Test_Metafunctions.cpp
   Test_Tags.cpp

--- a/tests/Unit/ControlSystem/Tags/CMakeLists.txt
+++ b/tests/Unit/ControlSystem/Tags/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY_SOURCES
+  ${LIBRARY_SOURCES}
+  Tags/Test_FunctionsOfTimeInitialize.cpp
+  PARENT_SCOPE)

--- a/tests/Unit/ControlSystem/Tags/CMakeLists.txt
+++ b/tests/Unit/ControlSystem/Tags/CMakeLists.txt
@@ -4,4 +4,5 @@
 set(LIBRARY_SOURCES
   ${LIBRARY_SOURCES}
   Tags/Test_FunctionsOfTimeInitialize.cpp
+  Tags/Test_MeasurementTimescales.cpp
   PARENT_SCOPE)

--- a/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
@@ -1,0 +1,167 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "ControlSystem/Averager.hpp"
+#include "ControlSystem/Component.hpp"
+#include "ControlSystem/Controller.hpp"
+#include "ControlSystem/Protocols/ControlSystem.hpp"
+#include "ControlSystem/Tags.hpp"
+#include "ControlSystem/Tags/FunctionsOfTimeInitialize.hpp"
+#include "ControlSystem/TimescaleTuner.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/OptionTags.hpp"
+#include "Helpers/ControlSystem/TestStructs.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+const double initial_time = 2.0;
+
+template <size_t Index>
+struct FakeControlSystem
+    : tt::ConformsTo<control_system::protocols::ControlSystem> {
+  static constexpr size_t deriv_order = 2;
+  static std::string name() { return "Controlled"s + get_output(Index); }
+  using measurement = control_system::TestHelpers::Measurement<
+      control_system::TestHelpers::TestStructs_detail::LabelA>;
+  using simple_tags = tmpl::list<>;
+  struct process_measurement {
+    using argument_tags = tmpl::list<>;
+  };
+};
+
+struct Metavariables {
+  static constexpr size_t volume_dim = 1;
+
+  using control_systems = tmpl::list<FakeControlSystem<1>, FakeControlSystem<2>,
+                                     FakeControlSystem<3>>;
+  using component_list = control_components<Metavariables, control_systems>;
+};
+
+struct MetavariablesNoControlSystems {
+  using component_list = tmpl::list<>;
+};
+
+class TestCreator : public DomainCreator<1> {
+ public:
+  explicit TestCreator(const bool add_controlled)
+      : add_controlled_(add_controlled) {}
+  Domain<1> create_domain() const override { ERROR(""); }
+  std::vector<std::array<size_t, 1>> initial_extents() const override {
+    ERROR("");
+  }
+  std::vector<std::array<size_t, 1>> initial_refinement_levels()
+      const override {
+    ERROR("");
+  }
+  auto functions_of_time() const -> std::unordered_map<
+      std::string,
+      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override {
+    const std::array<DataVector, 3> initial_values{{{-1.0}, {-2.0}, {-3.0}}};
+
+    std::unordered_map<std::string,
+                       std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+        result{};
+    if (add_controlled_) {
+      result.insert(
+          {"Controlled1",
+           std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+               initial_time, initial_values, initial_time + 7.0)});
+      result.insert(
+          {"Controlled2",
+           std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+               initial_time, initial_values, initial_time + 10.0)});
+      result.insert(
+          {"Controlled3",
+           std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+               initial_time, initial_values, initial_time + 0.5)});
+    }
+    result.insert(
+        {"Uncontrolled",
+         std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+             initial_time, initial_values,
+             std::numeric_limits<double>::infinity())});
+    return result;
+  }
+
+ private:
+  bool add_controlled_{};
+};
+
+template <size_t Index>
+using OptionHolder = control_system::OptionHolder<FakeControlSystem<Index>>;
+
+template <typename ControlSys>
+using ControlSysInputs =
+    control_system::OptionTags::ControlSystemInputs<ControlSys>;
+
+void test_functions_of_time_tag() {
+  INFO("Test FunctionsOfTimeInitialize tag");
+  using fot_tag = control_system::Tags::FunctionsOfTimeInitialize;
+  using Creator = tmpl::front<fot_tag::option_tags<Metavariables>>::type;
+
+  const Creator creator = std::make_unique<TestCreator>(true);
+
+  // Initial expiration times are set to be update_fraction *
+  // min(current_timescale) where update_fraction is the argument to the
+  // Controller. This value for the timescale was chosen to give an expiration
+  // time between the two expiration times used above in the TestCreator
+  const double timescale = 27.0;
+  const TimescaleTuner tuner1({timescale}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01,
+                              0.99);
+  const TimescaleTuner tuner2({0.1}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01, 0.99);
+  const Averager<2> averager(0.25, true);
+  const double update_fraction = 0.3;
+  const Controller<2> controller(update_fraction);
+
+  OptionHolder<1> option_holder1(averager, controller, tuner1);
+  OptionHolder<2> option_holder2(averager, controller, tuner1);
+  OptionHolder<3> option_holder3(averager, controller, tuner2);
+
+  const double initial_time_step = 1.0;
+  fot_tag::type functions_of_time = fot_tag::create_from_options<Metavariables>(
+      creator, initial_time, initial_time_step, option_holder1, option_holder2,
+      option_holder3);
+
+  CHECK(functions_of_time.at("Controlled1")->time_bounds()[1] ==
+        initial_time + update_fraction * timescale);
+  CHECK(functions_of_time.at("Controlled2")->time_bounds()[1] ==
+        initial_time + 10.0);
+  CHECK(functions_of_time.at("Controlled3")->time_bounds()[1] ==
+        initial_time + initial_time_step);
+  CHECK(functions_of_time.at("Uncontrolled")->time_bounds()[1] ==
+        std::numeric_limits<double>::infinity());
+
+  static_assert(
+      std::is_same_v<
+          fot_tag::option_tags<Metavariables>,
+          tmpl::list<
+              domain::OptionTags::DomainCreator<Metavariables::volume_dim>,
+              ::OptionTags::InitialTime, ::OptionTags::InitialTimeStep,
+              ControlSysInputs<FakeControlSystem<1>>,
+              ControlSysInputs<FakeControlSystem<2>>,
+              ControlSysInputs<FakeControlSystem<3>>>>);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ControlSystem.Tags.FunctionsOfTimeInitialize",
+                  "[ControlSystem][Unit]") {
+  test_functions_of_time_tag();
+}

--- a/tests/Unit/ControlSystem/Tags/Test_MeasurementTimescales.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_MeasurementTimescales.cpp
@@ -1,0 +1,128 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <string>
+
+#include "ControlSystem/Tags/MeasurementTimescales.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/OptionTags.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+const double initial_time = 2.0;
+
+struct Metavariables {
+  static constexpr size_t volume_dim = 1;
+};
+
+class TestCreator : public DomainCreator<1> {
+ public:
+  explicit TestCreator(const bool add_controlled)
+      : add_controlled_(add_controlled) {}
+  Domain<1> create_domain() const override { ERROR(""); }
+  std::vector<std::array<size_t, 1>> initial_extents() const override {
+    ERROR("");
+  }
+  std::vector<std::array<size_t, 1>> initial_refinement_levels()
+      const override {
+    ERROR("");
+  }
+  auto functions_of_time() const -> std::unordered_map<
+      std::string,
+      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override {
+    const std::array<DataVector, 3> initial_values{{{-1.0}, {-2.0}, {-3.0}}};
+
+    std::unordered_map<std::string,
+                       std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+        result{};
+    if (add_controlled_) {
+      result.insert(
+          {"Controlled1",
+           std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+               initial_time, initial_values, initial_time + 7.0)});
+      result.insert(
+          {"Controlled2",
+           std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+               initial_time, initial_values, initial_time + 10.0)});
+      result.insert(
+          {"Controlled3",
+           std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+               initial_time, initial_values, initial_time + 0.5)});
+    }
+    result.insert(
+        {"Uncontrolled",
+         std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+             initial_time, initial_values,
+             std::numeric_limits<double>::infinity())});
+    return result;
+  }
+
+ private:
+  bool add_controlled_{};
+};
+
+void test_measurement_tag() {
+  INFO("Test measurement tag");
+  using measurement_tag = control_system::Tags::MeasurementTimescales;
+  static_assert(
+      tmpl::size<measurement_tag::option_tags<Metavariables>>::value == 2);
+  using Creator =
+      tmpl::front<measurement_tag::option_tags<Metavariables>>::type;
+  const double time_step = 0.2;
+  {
+    const Creator creator = std::make_unique<TestCreator>(true);
+
+    const measurement_tag::type timescales =
+        measurement_tag::create_from_options<Metavariables>(creator, time_step);
+    CHECK(timescales.size() == 3);
+    // The lack of expiration is a placeholder until the control systems
+    // have been implemented sufficiently to manage their timescales.
+    CHECK(timescales.at("Controlled1")->time_bounds() ==
+          std::array{initial_time, std::numeric_limits<double>::infinity()});
+    CHECK(timescales.at("Controlled1")->func(2.0)[0] == DataVector{time_step});
+    CHECK(timescales.at("Controlled1")->func(3.0)[0] == DataVector{time_step});
+    CHECK(timescales.at("Controlled2")->time_bounds() ==
+          std::array{initial_time, std::numeric_limits<double>::infinity()});
+    CHECK(timescales.at("Controlled2")->func(2.0)[0] == DataVector{time_step});
+    CHECK(timescales.at("Controlled2")->func(3.0)[0] == DataVector{time_step});
+    CHECK(timescales.at("Controlled3")->time_bounds() ==
+          std::array{initial_time, std::numeric_limits<double>::infinity()});
+    CHECK(timescales.at("Controlled3")->func(2.5)[0] == DataVector{time_step});
+  }
+  {
+    const Creator creator = std::make_unique<TestCreator>(false);
+
+    // Verify that negative time steps are accepted with no control
+    // systems.
+    const measurement_tag::type timescales =
+        measurement_tag::create_from_options<Metavariables>(creator,
+                                                            -time_step);
+    CHECK(timescales.empty());
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ControlSystem.Tags.MeasurementTimescales",
+                  "[ControlSystem][Unit]") {
+  test_measurement_tag();
+}
+
+// [[OutputRegex, Control systems can only be used in forward-in-time
+// evolutions.]]
+SPECTRE_TEST_CASE("Unit.ControlSystem.Tags.MeasurementTimescales.Backwards",
+                  "[ControlSystem][Unit]") {
+  ERROR_TEST();
+  using measurement_tag = control_system::Tags::MeasurementTimescales;
+  const std::unique_ptr<DomainCreator<1>> creator =
+      std::make_unique<TestCreator>(true);
+  measurement_tag::create_from_options<Metavariables>(creator, -1.0);
+}

--- a/tests/Unit/ControlSystem/Tags/Test_MeasurementTimescales.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_MeasurementTimescales.cpp
@@ -7,105 +7,117 @@
 #include <cstddef>
 #include <string>
 
+#include "ControlSystem/Averager.hpp"
+#include "ControlSystem/Component.hpp"
+#include "ControlSystem/Controller.hpp"
+#include "ControlSystem/Protocols/ControlSystem.hpp"
+#include "ControlSystem/Tags.hpp"
 #include "ControlSystem/Tags/MeasurementTimescales.hpp"
+#include "ControlSystem/TimescaleTuner.hpp"
 #include "DataStructures/DataVector.hpp"
-#include "Domain/Creators/DomainCreator.hpp"
-#include "Domain/Domain.hpp"
-#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
-#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
-#include "Domain/OptionTags.hpp"
-#include "Utilities/ErrorHandling/Error.hpp"
+#include "Helpers/ControlSystem/TestStructs.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace {
 const double initial_time = 2.0;
 
+template <size_t Index>
+struct FakeControlSystem
+    : tt::ConformsTo<control_system::protocols::ControlSystem> {
+  static constexpr size_t deriv_order = 2;
+  static std::string name() { return "Controlled"s + get_output(Index); }
+  using measurement = control_system::TestHelpers::Measurement<
+      control_system::TestHelpers::TestStructs_detail::LabelA>;
+  using simple_tags = tmpl::list<>;
+  struct process_measurement {
+    using argument_tags = tmpl::list<>;
+  };
+};
+
 struct Metavariables {
-  static constexpr size_t volume_dim = 1;
+  using control_systems = tmpl::list<FakeControlSystem<1>, FakeControlSystem<2>,
+                                     FakeControlSystem<3>>;
+  using component_list = control_components<Metavariables, control_systems>;
 };
 
-class TestCreator : public DomainCreator<1> {
- public:
-  explicit TestCreator(const bool add_controlled)
-      : add_controlled_(add_controlled) {}
-  Domain<1> create_domain() const override { ERROR(""); }
-  std::vector<std::array<size_t, 1>> initial_extents() const override {
-    ERROR("");
-  }
-  std::vector<std::array<size_t, 1>> initial_refinement_levels()
-      const override {
-    ERROR("");
-  }
-  auto functions_of_time() const -> std::unordered_map<
-      std::string,
-      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override {
-    const std::array<DataVector, 3> initial_values{{{-1.0}, {-2.0}, {-3.0}}};
-
-    std::unordered_map<std::string,
-                       std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
-        result{};
-    if (add_controlled_) {
-      result.insert(
-          {"Controlled1",
-           std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
-               initial_time, initial_values, initial_time + 7.0)});
-      result.insert(
-          {"Controlled2",
-           std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
-               initial_time, initial_values, initial_time + 10.0)});
-      result.insert(
-          {"Controlled3",
-           std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
-               initial_time, initial_values, initial_time + 0.5)});
-    }
-    result.insert(
-        {"Uncontrolled",
-         std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
-             initial_time, initial_values,
-             std::numeric_limits<double>::infinity())});
-    return result;
-  }
-
- private:
-  bool add_controlled_{};
+struct MetavariablesNoControlSystems {
+  using component_list = tmpl::list<>;
 };
+
+template <size_t Index>
+using OptionHolder = control_system::OptionHolder<FakeControlSystem<Index>>;
 
 void test_measurement_tag() {
   INFO("Test measurement tag");
   using measurement_tag = control_system::Tags::MeasurementTimescales;
   static_assert(
-      tmpl::size<measurement_tag::option_tags<Metavariables>>::value == 2);
-  using Creator =
-      tmpl::front<measurement_tag::option_tags<Metavariables>>::type;
+      tmpl::size<
+          measurement_tag::option_tags<MetavariablesNoControlSystems>>::value ==
+      2);
+  static_assert(
+      tmpl::size<measurement_tag::option_tags<Metavariables>>::value == 5);
+
   const double time_step = 0.2;
   {
-    const Creator creator = std::make_unique<TestCreator>(true);
+    const double timescale1 = 27.0;
+    const TimescaleTuner tuner1({timescale1}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4,
+                                1.01, 0.99);
+    const double timescale2 = 0.5;
+    const TimescaleTuner tuner2({timescale2}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4,
+                                1.01, 0.99);
+    const double averaging_fraction = 0.25;
+    const Averager<2> averager(averaging_fraction, true);
+    const double update_fraction = 0.3;
+    const Controller<2> controller(update_fraction);
+
+    OptionHolder<1> option_holder1(averager, controller, tuner1);
+    OptionHolder<2> option_holder2(averager, controller, tuner1);
+    OptionHolder<3> option_holder3(averager, controller, tuner2);
 
     const measurement_tag::type timescales =
-        measurement_tag::create_from_options<Metavariables>(creator, time_step);
+        measurement_tag::create_from_options<Metavariables>(
+            initial_time, time_step, option_holder1, option_holder2,
+            option_holder3);
     CHECK(timescales.size() == 3);
     // The lack of expiration is a placeholder until the control systems
     // have been implemented sufficiently to manage their timescales.
+    const double expr_time1 = initial_time + update_fraction * timescale1;
+    const double expr_time2 = initial_time + time_step;
+    const double measure_time1 =
+        averaging_fraction * (expr_time1 - initial_time);
+    const double measure_time2 = time_step;
     CHECK(timescales.at("Controlled1")->time_bounds() ==
-          std::array{initial_time, std::numeric_limits<double>::infinity()});
-    CHECK(timescales.at("Controlled1")->func(2.0)[0] == DataVector{time_step});
-    CHECK(timescales.at("Controlled1")->func(3.0)[0] == DataVector{time_step});
+          std::array{initial_time, expr_time1});
+    CHECK(timescales.at("Controlled1")->func(2.0)[0] ==
+          DataVector{measure_time1});
+    CHECK(timescales.at("Controlled1")->func(3.0)[0] ==
+          DataVector{measure_time1});
     CHECK(timescales.at("Controlled2")->time_bounds() ==
-          std::array{initial_time, std::numeric_limits<double>::infinity()});
-    CHECK(timescales.at("Controlled2")->func(2.0)[0] == DataVector{time_step});
-    CHECK(timescales.at("Controlled2")->func(3.0)[0] == DataVector{time_step});
+          std::array{initial_time, expr_time1});
+    CHECK(timescales.at("Controlled2")->func(2.0)[0] ==
+          DataVector{measure_time1});
+    CHECK(timescales.at("Controlled2")->func(3.0)[0] ==
+          DataVector{measure_time1});
     CHECK(timescales.at("Controlled3")->time_bounds() ==
-          std::array{initial_time, std::numeric_limits<double>::infinity()});
-    CHECK(timescales.at("Controlled3")->func(2.5)[0] == DataVector{time_step});
+          std::array{initial_time, expr_time2});
+    CHECK(timescales.at("Controlled3")->func(2.1)[0] ==
+          DataVector{measure_time2});
   }
   {
-    const Creator creator = std::make_unique<TestCreator>(false);
-
+    // Verify that no control systems means no measurement timescales
+    const measurement_tag::type timescales =
+        measurement_tag::create_from_options<MetavariablesNoControlSystems>(
+            initial_time, time_step);
+    CHECK(timescales.empty());
+  }
+  {
     // Verify that negative time steps are accepted with no control
     // systems.
     const measurement_tag::type timescales =
-        measurement_tag::create_from_options<Metavariables>(creator,
-                                                            -time_step);
+        measurement_tag::create_from_options<MetavariablesNoControlSystems>(
+            initial_time, -time_step);
     CHECK(timescales.empty());
   }
 }
@@ -121,8 +133,16 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Tags.MeasurementTimescales",
 SPECTRE_TEST_CASE("Unit.ControlSystem.Tags.MeasurementTimescales.Backwards",
                   "[ControlSystem][Unit]") {
   ERROR_TEST();
+  const TimescaleTuner tuner1({27.0}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01, 0.99);
+  const TimescaleTuner tuner2({0.1}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01, 0.99);
+  const Averager<2> averager(0.25, true);
+  const Controller<2> controller(0.3);
+
+  OptionHolder<1> option_holder1(averager, controller, tuner1);
+  OptionHolder<2> option_holder2(averager, controller, tuner1);
+  OptionHolder<3> option_holder3(averager, controller, tuner2);
+
   using measurement_tag = control_system::Tags::MeasurementTimescales;
-  const std::unique_ptr<DomainCreator<1>> creator =
-      std::make_unique<TestCreator>(true);
-  measurement_tag::create_from_options<Metavariables>(creator, -1.0);
+  measurement_tag::create_from_options<Metavariables>(
+      initial_time, -1.0, option_holder1, option_holder2, option_holder3);
 }

--- a/tests/Unit/ControlSystem/Test_Averager.cpp
+++ b/tests/Unit/ControlSystem/Test_Averager.cpp
@@ -290,6 +290,9 @@ void test_equality_and_serialization() {
   CHECK(averager1 != averager3);
   CHECK_FALSE(averager1 == averager3);
 
+  CHECK(averager1.avg_timescale_frac() == 1.0);
+  CHECK(averager3.avg_timescale_frac() == 0.5);
+
   averager2.update(0.1, {0.2}, {0.3});
   CHECK_FALSE(averager1 == averager2);
 

--- a/tests/Unit/ControlSystem/Test_InitialExpirationTimes.cpp
+++ b/tests/Unit/ControlSystem/Test_InitialExpirationTimes.cpp
@@ -1,0 +1,111 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+#include <unordered_map>
+
+#include "ControlSystem/InitialExpirationTimes.hpp"
+#include "ControlSystem/Protocols/ControlSystem.hpp"
+#include "ControlSystem/Tags.hpp"
+#include "Helpers/ControlSystem/TestStructs.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/StdHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+template <size_t Index>
+struct FakeControlSystem
+    : tt::ConformsTo<control_system::protocols::ControlSystem> {
+  static constexpr size_t deriv_order = 2;
+  static std::string name() { return "Controlled"s + get_output(Index); }
+  using measurement = control_system::TestHelpers::Measurement<
+      control_system::TestHelpers::TestStructs_detail::LabelA>;
+  using simple_tags = tmpl::list<>;
+  struct process_measurement {
+    using argument_tags = tmpl::list<>;
+  };
+};
+
+template <size_t Index>
+using OptionHolder = control_system::OptionHolder<FakeControlSystem<Index>>;
+
+void check_expiration_times(
+    const std::unordered_map<std::string, double>& initial_expiration_times,
+    const std::unordered_map<std::string, double>&
+        expected_initial_expiration_times) {
+  CHECK(expected_initial_expiration_times.size() ==
+        initial_expiration_times.size());
+  for (auto& [expected_name, expected_expiration_time] :
+       expected_initial_expiration_times) {
+    CHECK(initial_expiration_times.count(expected_name) == 1);
+    CHECK(initial_expiration_times.at(expected_name) ==
+          expected_expiration_time);
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ControlSystem.ConstructInitialExpirationTimes",
+                  "[ControlSystem][Unit]") {
+  const double initial_time = 1.3;
+  const double initial_time_step = 0.1;
+
+  const double timescale = 2.0;
+  const TimescaleTuner tuner1({timescale}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01,
+                              0.99);
+  const TimescaleTuner tuner2({0.1}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01, 0.99);
+  const Averager<2> averager(0.25, true);
+  const double update_fraction = 0.3;
+  const Controller<2> controller(update_fraction);
+
+  OptionHolder<1> option_holder1(averager, controller, tuner1);
+  OptionHolder<2> option_holder2(averager, controller, tuner1);
+  OptionHolder<3> option_holder3(averager, controller, tuner2);
+
+  {
+    INFO("No control systems");
+    const auto initial_expiration_times =
+        control_system::initial_expiration_times(initial_time,
+                                                 initial_time_step);
+
+    const std::unordered_map<std::string, double>
+        expected_initial_expiration_times{};
+
+    check_expiration_times(expected_initial_expiration_times,
+                           initial_expiration_times);
+  }
+  {
+    INFO("One control system");
+    const auto initial_expiration_times =
+        control_system::initial_expiration_times(
+            initial_time, initial_time_step, option_holder1);
+
+    const std::unordered_map<std::string, double>
+        expected_initial_expiration_times{
+            {FakeControlSystem<1>::name(),
+             initial_time + update_fraction * timescale}};
+
+    check_expiration_times(expected_initial_expiration_times,
+                           initial_expiration_times);
+  }
+  {
+    INFO("Three control system");
+    const auto initial_expiration_times =
+        control_system::initial_expiration_times(
+            initial_time, initial_time_step, option_holder1, option_holder2,
+            option_holder3);
+
+    const std::unordered_map<std::string, double>
+        expected_initial_expiration_times{
+            {FakeControlSystem<1>::name(),
+             initial_time + update_fraction * timescale},
+            {FakeControlSystem<2>::name(),
+             initial_time + update_fraction * timescale},
+            {FakeControlSystem<3>::name(), initial_time + initial_time_step}};
+
+    check_expiration_times(expected_initial_expiration_times,
+                           initial_expiration_times);
+  }
+}

--- a/tests/Unit/ControlSystem/Test_Tags.cpp
+++ b/tests/Unit/ControlSystem/Test_Tags.cpp
@@ -15,97 +15,15 @@
 #include "ControlSystem/Averager.hpp"
 #include "ControlSystem/Component.hpp"
 #include "ControlSystem/Controller.hpp"
-#include "ControlSystem/Protocols/ControlSystem.hpp"
 #include "ControlSystem/Tags.hpp"
 #include "ControlSystem/Tags/FunctionsOfTimeInitialize.hpp"
+#include "ControlSystem/Tags/MeasurementTimescales.hpp"
 #include "ControlSystem/TimescaleTuner.hpp"
-#include "DataStructures/DataVector.hpp"
-#include "Domain/Creators/DomainCreator.hpp"
-#include "Domain/Domain.hpp"
-#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
-#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
-#include "Domain/OptionTags.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Helpers/ControlSystem/TestStructs.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
-#include "Time/Tags.hpp"
-#include "Utilities/ErrorHandling/Error.hpp"
-#include "Utilities/GetOutput.hpp"
-#include "Utilities/Literals.hpp"
-#include "Utilities/ProtocolHelpers.hpp"
-#include "Utilities/TMPL.hpp"
-#include "Utilities/TaggedTuple.hpp"
 
 namespace {
-const double initial_time = 2.0;
-
-template <size_t Index>
-struct FakeControlSystem
-    : tt::ConformsTo<control_system::protocols::ControlSystem> {
-  static constexpr size_t deriv_order = 2;
-  static std::string name() { return "Controlled"s + get_output(Index); }
-  using measurement = control_system::TestHelpers::Measurement<
-      control_system::TestHelpers::TestStructs_detail::LabelA>;
-  using simple_tags = tmpl::list<>;
-  struct process_measurement {
-    using argument_tags = tmpl::list<>;
-  };
-};
-
-struct Metavariables {
-  static constexpr size_t volume_dim = 1;
-
-  using control_systems = tmpl::list<FakeControlSystem<1>, FakeControlSystem<2>,
-                                     FakeControlSystem<3>>;
-  using component_list = control_components<Metavariables, control_systems>;
-};
-
-class TestCreator : public DomainCreator<1> {
- public:
-  explicit TestCreator(const bool add_controlled)
-      : add_controlled_(add_controlled) {}
-  Domain<1> create_domain() const override { ERROR(""); }
-  std::vector<std::array<size_t, 1>> initial_extents() const override {
-    ERROR("");
-  }
-  std::vector<std::array<size_t, 1>> initial_refinement_levels()
-      const override {
-    ERROR("");
-  }
-  auto functions_of_time() const -> std::unordered_map<
-      std::string,
-      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override {
-    const std::array<DataVector, 3> initial_values{{{-1.0}, {-2.0}, {-3.0}}};
-
-    std::unordered_map<std::string,
-                       std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
-        result{};
-    if (add_controlled_) {
-      result.insert(
-          {"Controlled1",
-           std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
-               initial_time, initial_values, initial_time + 7.0)});
-      result.insert(
-          {"Controlled2",
-           std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
-               initial_time, initial_values, initial_time + 10.0)});
-      result.insert(
-          {"Controlled3",
-           std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
-               initial_time, initial_values, initial_time + 0.5)});
-    }
-    result.insert(
-        {"Uncontrolled",
-         std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
-             initial_time, initial_values,
-             std::numeric_limits<double>::infinity())});
-    return result;
-  }
-
- private:
-  bool add_controlled_{};
-};
-
 void test_all_tags() {
   INFO("Test all tags");
   using name_tag = control_system::Tags::ControlSystemName;
@@ -172,61 +90,9 @@ void test_control_sys_inputs() {
   CHECK(expected_name ==
         std::decay_t<decltype(input_holder)>::control_system::name());
 }
-
-void test_measurement_tag() {
-  INFO("Test measurement tag");
-  using measurement_tag = control_system::Tags::MeasurementTimescales;
-  static_assert(
-      tmpl::size<measurement_tag::option_tags<Metavariables>>::value == 2);
-  using Creator =
-      tmpl::front<measurement_tag::option_tags<Metavariables>>::type;
-  const double time_step = 0.2;
-  {
-    const Creator creator = std::make_unique<TestCreator>(true);
-
-    const measurement_tag::type timescales =
-        measurement_tag::create_from_options<Metavariables>(creator, time_step);
-    CHECK(timescales.size() == 3);
-    // The lack of expiration is a placeholder until the control systems
-    // have been implemented sufficiently to manage their timescales.
-    CHECK(timescales.at("Controlled1")->time_bounds() ==
-          std::array{initial_time, std::numeric_limits<double>::infinity()});
-    CHECK(timescales.at("Controlled1")->func(2.0)[0] == DataVector{time_step});
-    CHECK(timescales.at("Controlled1")->func(3.0)[0] == DataVector{time_step});
-    CHECK(timescales.at("Controlled2")->time_bounds() ==
-          std::array{initial_time, std::numeric_limits<double>::infinity()});
-    CHECK(timescales.at("Controlled2")->func(2.0)[0] == DataVector{time_step});
-    CHECK(timescales.at("Controlled2")->func(3.0)[0] == DataVector{time_step});
-    CHECK(timescales.at("Controlled3")->time_bounds() ==
-          std::array{initial_time, std::numeric_limits<double>::infinity()});
-    CHECK(timescales.at("Controlled3")->func(2.5)[0] == DataVector{time_step});
-  }
-  {
-    const Creator creator = std::make_unique<TestCreator>(false);
-
-    // Verify that negative time steps are accepted with no control
-    // systems.
-    const measurement_tag::type timescales =
-        measurement_tag::create_from_options<Metavariables>(creator,
-                                                            -time_step);
-    CHECK(timescales.empty());
-  }
-}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.ControlSystem.Tags", "[ControlSystem][Unit]") {
   test_all_tags();
   test_control_sys_inputs();
-  test_measurement_tag();
-}
-
-// [[OutputRegex, Control systems can only be used in forward-in-time
-// evolutions.]]
-SPECTRE_TEST_CASE("Unit.ControlSystem.Tags.Backwards",
-                  "[ControlSystem][Unit]") {
-  ERROR_TEST();
-  using measurement_tag = control_system::Tags::MeasurementTimescales;
-  const std::unique_ptr<DomainCreator<1>> creator =
-      std::make_unique<TestCreator>(true);
-  measurement_tag::create_from_options<Metavariables>(creator, -1.0);
 }

--- a/tests/Unit/ControlSystem/Test_Trigger.cpp
+++ b/tests/Unit/ControlSystem/Test_Trigger.cpp
@@ -7,7 +7,7 @@
 #include <memory>
 #include <utility>
 
-#include "ControlSystem/Tags.hpp"
+#include "ControlSystem/Tags/MeasurementTimescales.hpp"
 #include "ControlSystem/Trigger.hpp"
 #include "ControlSystem/UpdateFunctionOfTime.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"


### PR DESCRIPTION
## Proposed changes

Use control system info to construct the measurement timescales.

First commit factors out some of the work of constructing the initial expiration times to its own function. The measurement timescales will need the exact same code.
Second commit moves the `control_system::Tags::MeasurementTimescales` tag to its own file. (`ControlSystem/Tags.hpp` was a bit crowded and `control_system::Tags::FunctionsOfTimeInitialize` has its own file as well)

This also factors out a bit of work from #3612 to keep it as small as possible.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
