### PR TITLE
Spectral equation of state

### DIFF
--- a/src/PointwiseFunctions/Hydro/EquationsOfState/CMakeLists.txt
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/CMakeLists.txt
@@ -7,6 +7,7 @@ spectre_target_sources(
   DarkEnergyFluid.cpp
   IdealFluid.cpp
   PolytropicFluid.cpp
+  Spectral.cpp
   )
 
 spectre_target_headers(
@@ -17,6 +18,7 @@ spectre_target_headers(
   EquationOfState.hpp
   IdealFluid.hpp
   PolytropicFluid.hpp
+  Spectral.hpp
   )
 
 add_subdirectory(Python)

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp
@@ -24,6 +24,7 @@ template <bool IsRelativistic>
 class IdealFluid;
 template <bool IsRelativistic>
 class PolytropicFluid;
+class Spectral;
 }  // namespace EquationsOfState
 /// \endcond
 
@@ -32,11 +33,16 @@ namespace EquationsOfState {
 
 namespace detail {
 template <bool IsRelativistic, size_t ThermodynamicDim>
-struct DerivedClasses;
+struct DerivedClasses {};
 
-template <bool IsRelativistic>
-struct DerivedClasses<IsRelativistic, 1> {
-  using type = tmpl::list<PolytropicFluid<IsRelativistic>>;
+template <>
+struct DerivedClasses<true, 1> {
+  using type = tmpl::list<Spectral, PolytropicFluid<true>>;
+};
+
+template <>
+struct DerivedClasses<false, 1> {
+  using type = tmpl::list<PolytropicFluid<false>>;
 };
 
 template <>
@@ -48,6 +54,7 @@ template <>
 struct DerivedClasses<false, 2> {
   using type = tmpl::list<IdealFluid<false>>;
 };
+
 }  // namespace detail
 
 /*!
@@ -404,3 +411,4 @@ class EquationOfState<IsRelativistic, 2>
 #include "PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp"

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Spectral.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Spectral.cpp
@@ -1,0 +1,309 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp"
+
+#include <cmath>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "NumericalAlgorithms/RootFinding/NewtonRaphson.hpp"
+#include "Parallel/Printf.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace {
+std::vector<double> compute_integral_coefficients(
+    const std::vector<double>& gamma_coefficients) {
+  std::vector<double> result = gamma_coefficients;
+  for (size_t i = 0; i < result.size(); ++i) {
+    result[i] /= (1.0 + i);
+  }
+  return result;
+}
+}  // namespace
+
+namespace EquationsOfState {
+Spectral::Spectral(const double reference_density,
+                   const double reference_pressure,
+                   std::vector<double> coefficients, const double upper_density)
+    : reference_density_(reference_density),
+      reference_pressure_(reference_pressure),
+      integral_coefficients_(compute_integral_coefficients(coefficients)),
+      gamma_coefficients_(std::move(coefficients)),
+      x_max_(log(upper_density / reference_density)),
+      gamma_of_x_max_(gamma(x_max_)),
+      integral_of_gamma_of_x_max_(integral_of_gamma(x_max_)) {
+  // Setup table of specific energies
+  // Use 6th order Gauss-Legendre quadrature.
+  // Weights and collocation points can be calculated following
+  // e.g. the gauleg method from Numerical Recipes
+  // (Sec. 4.6.1 in 3rd edition). We only need to consider
+  // collocation points with x>0, as the other points are
+  // just symmetric with respect to the origin.
+  quadrature_weights_ = {0.3607615730481386, 0.4679139345726910,
+                         0.1713244923791704};
+  quadrature_points_ = {0.6612093864662645, 0.2386191860831969,
+                        0.9324695142031521};
+  number_of_quadrature_coefs_ = quadrature_weights_.size();
+  const auto n_points_epsilon = static_cast<size_t>(ceil(2.0 * x_max_) + 1.0);
+  const double delta_x = x_max_ / (n_points_epsilon - 1.0);
+  table_of_specific_energies_.resize(n_points_epsilon);
+  table_of_specific_energies_[0] =
+      reference_pressure_ / reference_density_ / (gamma_coefficients_[0] - 1.0);
+  for (size_t i = 1; i < n_points_epsilon; i++) {
+    table_of_specific_energies_[i] = table_of_specific_energies_[i - 1];
+    // Use Gaussian quadrature to calculate the specific internal
+    // energy at the next point, separated from the old point
+    // by delta_x in log(density)
+    // From the 1st law of thermodynamics,
+    // d(epsilon)/dx = (Pressure)/(reference_density)*exp(-x)
+    const double x0 = (i - 1.) * delta_x;
+    for (size_t q = 0; q < number_of_quadrature_coefs_; q++) {
+      const double xp = x0 + (1.0 + quadrature_points_[q]) * (delta_x / 2.0);
+      const double xm = x0 + (1.0 - quadrature_points_[q]) * (delta_x / 2.0);
+      table_of_specific_energies_[i] +=
+          quadrature_weights_[q] * delta_x / (2.0 * reference_density) *
+          (exp(-xp) * pressure_from_log_density(xp) +
+           exp(-xm) * pressure_from_log_density(xm));
+    }
+  }
+}
+
+EQUATION_OF_STATE_MEMBER_DEFINITIONS(, Spectral, double, 1)
+EQUATION_OF_STATE_MEMBER_DEFINITIONS(, Spectral, DataVector, 1)
+
+Spectral::Spectral(CkMigrateMessage* /*unused*/) {}
+
+void Spectral::pup(PUP::er& p) {
+  EquationOfState<true, 1>::pup(p);
+  p | reference_density_;
+  p | reference_pressure_;
+  p | integral_coefficients_;
+  p | gamma_coefficients_;
+  p | x_max_;
+  p | gamma_of_x_max_;
+  p | integral_of_gamma_of_x_max_;
+  p | number_of_quadrature_coefs_;
+  p | quadrature_weights_;
+  p | quadrature_points_;
+  p | table_of_specific_energies_;
+}
+
+// this evaluates the power series
+// Int_0^x Gamma(xx) dxx = Sum_{n=0}^N \frac{gamma_n}{n+1} xx^{n+1}
+double Spectral::integral_of_gamma(const double x) const {
+  return evaluate_polynomial(integral_coefficients_, x) * x;
+}
+
+template <typename DataType>
+Scalar<DataType> Spectral::pressure_from_density_impl(
+    const Scalar<DataType>& rest_mass_density) const {
+  if constexpr (std::is_same_v<DataType, double>) {
+    return Scalar<double>{pressure_from_density(get(rest_mass_density))};
+  } else if constexpr (std::is_same_v<DataType, DataVector>) {
+    auto result = make_with_value<Scalar<DataVector>>(rest_mass_density, 0.0);
+    for (size_t i = 0; i < get(result).size(); ++i) {
+      get(result)[i] = pressure_from_density(get(rest_mass_density)[i]);
+    }
+    return result;
+  }
+}
+
+template <class DataType>
+Scalar<DataType> Spectral::rest_mass_density_from_enthalpy_impl(
+    const Scalar<DataType>& specific_enthalpy) const {
+  if constexpr (std::is_same_v<DataType, double>) {
+    return Scalar<double>{
+        rest_mass_density_from_enthalpy(get(specific_enthalpy))};
+  } else if constexpr (std::is_same_v<DataType, DataVector>) {
+    auto result = make_with_value<Scalar<DataVector>>(specific_enthalpy, 0.0);
+    for (size_t i = 0; i < get(result).size(); ++i) {
+      get(result)[i] =
+          rest_mass_density_from_enthalpy(get(specific_enthalpy)[i]);
+    }
+    return result;
+  }
+}
+
+template <class DataType>
+Scalar<DataType> Spectral::specific_enthalpy_from_density_impl(
+    const Scalar<DataType>& rest_mass_density) const {
+  if constexpr (std::is_same_v<DataType, double>) {
+    return Scalar<double>{
+        specific_enthalpy_from_density(get(rest_mass_density))};
+  } else if constexpr (std::is_same_v<DataType, DataVector>) {
+    auto result = make_with_value<Scalar<DataVector>>(rest_mass_density, 0.0);
+    for (size_t i = 0; i < get(result).size(); ++i) {
+      get(result)[i] =
+          specific_enthalpy_from_density(get(rest_mass_density)[i]);
+    }
+    return result;
+  }
+}
+
+template <class DataType>
+Scalar<DataType> Spectral::specific_internal_energy_from_density_impl(
+    const Scalar<DataType>& rest_mass_density) const {
+  if constexpr (std::is_same_v<DataType, double>) {
+    return Scalar<double>{
+        specific_internal_energy_from_density(get(rest_mass_density))};
+  } else if constexpr (std::is_same_v<DataType, DataVector>) {
+    auto result = make_with_value<Scalar<DataVector>>(rest_mass_density, 0.0);
+    for (size_t i = 0; i < get(result).size(); ++i) {
+      get(result)[i] =
+          specific_internal_energy_from_density(get(rest_mass_density)[i]);
+    }
+    return result;
+  }
+}
+
+template <class DataType>
+Scalar<DataType> Spectral::chi_from_density_impl(
+    const Scalar<DataType>& rest_mass_density) const {
+  if constexpr (std::is_same_v<DataType, double>) {
+    return Scalar<double>{chi_from_density(get(rest_mass_density))};
+  } else if constexpr (std::is_same_v<DataType, DataVector>) {
+    auto result = make_with_value<Scalar<DataVector>>(rest_mass_density, 0.0);
+    for (size_t i = 0; i < get(result).size(); ++i) {
+      get(result)[i] = chi_from_density(get(rest_mass_density)[i]);
+    }
+    return result;
+  }
+}
+
+template <class DataType>
+Scalar<DataType> Spectral::kappa_times_p_over_rho_squared_from_density_impl(
+    const Scalar<DataType>& rest_mass_density) const {
+  return make_with_value<Scalar<DataType>>(get(rest_mass_density), 0.0);
+}
+
+// this evaluates the power series
+// Gamma(x) = Sum_{n=0}^N gamma_n x^n
+double Spectral::gamma(const double x) const {
+  return evaluate_polynomial(gamma_coefficients_, x);
+}
+
+double Spectral::chi_from_density(const double rest_mass_density) const {
+  const double x = log(rest_mass_density / reference_density_);
+  const double P = pressure_from_log_density(x);
+  const double chi = P / rest_mass_density *
+                     (x <= 0.0 ? integral_coefficients_[0]
+                               : (x < x_max_ ? gamma(x) : gamma(x_max_)));
+  return chi;
+}
+
+double Spectral::specific_internal_energy_from_density(
+    const double rest_mass_density) const {
+  const double x = log(rest_mass_density / reference_density_);
+  if (x <= 0.) {
+    return reference_pressure_ / reference_density_ /
+           (gamma_coefficients_[0] - 1.0) *
+           exp((gamma_coefficients_[0] - 1.0) * x);
+  }
+  const size_t n_points_epsilon = table_of_specific_energies_.size();
+  const double delta_x = x_max_ / (n_points_epsilon - 1.0);
+  double specific_energy = 0.0;
+  if (x >= x_max_) {
+    // Analytic integral at constant gamma_coefficient above x_max_
+    specific_energy = table_of_specific_energies_[n_points_epsilon - 1];
+    specific_energy += pressure_from_log_density(x_max_) / reference_density_ *
+                       exp(-x_max_) *
+                       std::expm1((gamma_of_x_max_ - 1.0) * (x - x_max_)) /
+                       (gamma_of_x_max_ - 1.0);
+    return specific_energy;
+  } else {
+    const auto table_index = static_cast<size_t>(floor(x / delta_x));
+    const double x0 = delta_x * table_index;
+    specific_energy = table_of_specific_energies_[table_index];
+    // Gaussian quadrature integral
+    for (size_t q = 0; q < number_of_quadrature_coefs_; q++) {
+      const double xp = (1.0 + quadrature_points_[q]) * (x - x0) / 2. + x0;
+      const double xm = (1.0 - quadrature_points_[q]) * (x - x0) / 2. + x0;
+      const double Pp = pressure_from_log_density(xp);
+      const double Pm = pressure_from_log_density(xm);
+      specific_energy += quadrature_weights_[q] * (x - x0) / 2. *
+                         (Pp * exp(-xp) + Pm * exp(-xm)) / reference_density_;
+    }
+    return specific_energy;
+  }
+}
+
+double Spectral::specific_enthalpy_from_density(
+    const double rest_mass_density) const {
+  return 1.0 + pressure_from_density(rest_mass_density) / rest_mass_density +
+         specific_internal_energy_from_density(rest_mass_density);
+}
+
+// P = P_0 exp(Int_0^x Gamma(xx) dxx)
+// where
+// Gamma(x) = gamma_0                        for  x < 0
+//            Sum_{n=0}^N gamma_n x^n             0 < x < x_{max}
+//            Sum_{n=0}^N gamma_n x_{max}^n       x > x_{max}
+double Spectral::pressure_from_log_density(const double x) const {
+  const double integral_of_gamma_of_x =
+      x <= 0.0 ? integral_coefficients_[0] * x
+               : (x < x_max_ ? integral_of_gamma(x)
+                             : integral_of_gamma_of_x_max_ +
+                                   gamma_of_x_max_ * (x - x_max_));
+  return reference_pressure_ * exp(integral_of_gamma_of_x);
+}
+
+double Spectral::pressure_from_density(const double rest_mass_density) const {
+  const double x = log(rest_mass_density / reference_density_);
+  return pressure_from_log_density(x);
+}
+
+// Solve for h(rho)=h0, which requires rootfinding for this EoS
+double Spectral::rest_mass_density_from_enthalpy(
+    const double specific_enthalpy) const {
+  const double reference_enthalpy =
+      specific_enthalpy_from_density(reference_density_);
+  const double upper_density = reference_density_ * exp(x_max_);
+  const double enthalpy_of_x_max_ =
+      specific_enthalpy_from_density(upper_density);
+  if (specific_enthalpy <= reference_enthalpy) {
+    double rest_mass_density =
+        (specific_enthalpy - 1.0) * (gamma_coefficients_[0] - 1.0) /
+        gamma_coefficients_[0] *
+        pow(reference_density_, gamma_coefficients_[0]) / reference_pressure_;
+    rest_mass_density =
+        pow(rest_mass_density, 1.0 / (gamma_coefficients_[0] - 1.0));
+    return rest_mass_density;
+  } else if (specific_enthalpy >= enthalpy_of_x_max_) {
+    // Above maximum density, we also have an analytical expression
+    // (h-1-eps_max)*(rho_max/P_max)+1/(Gamma_max-1) = Gamma_max / (Gamma_max-1)
+    // * exp((Gamma_max-1)*(x-x_max)) [Can be derived by combining expressions
+    // for epsilon(x) and P(x) with x = log(rho)]
+    const size_t n_points_epsilon = table_of_specific_energies_.size();
+    const double specific_internal_energy_of_x_max_ =
+        table_of_specific_energies_[n_points_epsilon - 1];
+    const double pressure_of_x_max_ = pressure_from_log_density(x_max_);
+    double x_target =
+        ((specific_enthalpy - 1.0 - specific_internal_energy_of_x_max_) *
+             upper_density / pressure_of_x_max_ +
+         1.0 / (gamma_of_x_max_ - 1.0)) *
+        (gamma_of_x_max_ - 1.0) / gamma_of_x_max_;
+    x_target = log(x_target) / (gamma_of_x_max_ - 1.0) + x_max_;
+    return reference_density_ * exp(x_target);
+  } else {
+    // Root-finding appropriate between reference density and maximum density
+    // We can use x=0 and x=x_max as bounds
+    const auto f_df_lambda = [this, &specific_enthalpy](const double density) {
+      const double f =
+          this->specific_enthalpy_from_density(density) - specific_enthalpy;
+      const double x = log(density / this->reference_density_);
+      const double df = this->pressure_from_log_density(x) /
+                        (density * density) * this->gamma(x);
+      return std::make_pair(f, df);
+    };
+    const size_t digits = 14;
+    const double intial_guess = 0.5 * (reference_density_ + upper_density);
+    const auto root_from_lambda = RootFinder::newton_raphson(
+        f_df_lambda, intial_guess, reference_density_, upper_density, digits);
+    return root_from_lambda;
+  }
+}
+
+PUP::able::PUP_ID EquationsOfState::Spectral::my_PUP_ID = 0;
+
+}  // namespace EquationsOfState

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp
@@ -1,0 +1,164 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <boost/preprocessor/arithmetic/dec.hpp>
+#include <boost/preprocessor/arithmetic/inc.hpp>
+#include <boost/preprocessor/control/expr_iif.hpp>
+#include <boost/preprocessor/list/adt.hpp>
+#include <boost/preprocessor/repetition/for.hpp>
+#include <boost/preprocessor/repetition/repeat.hpp>
+#include <boost/preprocessor/tuple/to_list.hpp>
+#include <limits>
+#include <pup.h>
+#include <vector>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"  // IWYU pragma: keep
+#include "Utilities/Math.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+/// \endcond
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace EquationsOfState {
+/*!
+ * \ingroup EquationsOfStateGroup
+ * \brief A spectral equation of state
+ *
+ * This equation of state is determined as a function of \f$x =
+ * \ln(\rho/\rho_0)\f$ where \f$\rho\f$ is the rest mass density and
+ * \f$\rho_0\f$ is the provided reference density.  The adiabatic
+ * index \f$\Gamma(x)\f$ is defined such that
+ * \f{equation}{
+ * \frac{d \ln p}{dx} = \Gamma(x) = \sum_{n=0}^N
+ * \gamma_n x^n
+ * \f}
+ *
+ * for the set of spectral coefficinets \f$\gamma_n\f$ when
+ * \f$0 < x < x_u = \ln(\rho_u/\rho_0)\f$, where \f$\rho_u\f$ is the provided
+ * upper density.
+ *
+ * For \f$ x < 0 \f$, \f$ \Gamma(x) = \gamma_0 \f$.
+ *
+ * For \f$ x > x_u \f$, \f$ \Gamma(x) = \Gamma(x_u) \f$
+ *
+ *
+ */
+class Spectral : public EquationOfState<true, 1> {
+ public:
+  static constexpr size_t thermodynamic_dim = 1;
+  static constexpr bool is_relativistic = true;
+
+  struct ReferenceDensity {
+    using type = double;
+    static constexpr Options::String help = {"Reference density rho_0"};
+    static double lower_bound() { return 0.0; }
+  };
+
+  struct ReferencePressure {
+    using type = double;
+    static constexpr Options::String help = {"Reference pressure p_0"};
+    static double lower_bound() { return 0.0; }
+  };
+
+  struct Coefficients {
+    using type = std::vector<double>;
+    static constexpr Options::String help = {"Spectral coefficients gamma_i"};
+  };
+
+  struct UpperDensity {
+    using type = double;
+    static constexpr Options::String help = {"Upper density rho_u"};
+    static double lower_bound() { return 0.0; }
+  };
+
+  static constexpr Options::String help = {
+      "A spectral equation of state.  Defining x = log(rho/rho_0), Gamma(x) = "
+      "Sum_i gamma_i x^i, then the pressure is determined from d(log P)/dx = "
+      "Gamma(x) for x > 0.  For x < 0 the EOS is a polytrope with "
+      "Gamma(x)=Gamma(0).  For x > x_u = log(rho_u/rho_0), Gamma(x) = "
+      "Gamma(x_u).\n"
+      "To get smooth equations of state, it is recommended that the second "
+      "and third supplied coefficient should be 0. It is up to the user to "
+      "choose coefficients that are physically reasonable, e.g. that "
+      "satisfy causality."};
+
+  using options = tmpl::list<ReferenceDensity, ReferencePressure, Coefficients,
+                             UpperDensity>;
+
+  Spectral() = default;
+  Spectral(const Spectral&) = default;
+  Spectral& operator=(const Spectral&) = default;
+  Spectral(Spectral&&) = default;
+  Spectral& operator=(Spectral&&) = default;
+  ~Spectral() override = default;
+
+  Spectral(double reference_density, double reference_pressure,
+           std::vector<double> coefficients, double upper_density);
+
+  EQUATION_OF_STATE_FORWARD_DECLARE_MEMBERS(Spectral, 1)
+
+  WRAPPED_PUPable_decl_base_template(  // NOLINT
+      SINGLE_ARG(EquationOfState<true, 1>), Spectral);
+
+  /// The lower bound of the rest mass density that is valid for this EOS
+  double rest_mass_density_lower_bound() const override { return 0.0; }
+
+  /// The upper bound of the rest mass density that is valid for this EOS
+  double rest_mass_density_upper_bound() const override {
+    return std::numeric_limits<double>::max();
+  }
+
+  /// The lower bound of the specific internal energy that is valid for this EOS
+  /// at the given rest mass density \f$\rho\f$
+  double specific_internal_energy_lower_bound(
+      const double /* rest_mass_density */) const override {
+    return 0.0;
+  }
+
+  /// The upper bound of the specific internal energy that is valid for this EOS
+  /// at the given rest mass density \f$\rho\f$
+  double specific_internal_energy_upper_bound(
+      const double /* rest_mass_density */) const override {
+    return std::numeric_limits<double>::max();
+  }
+
+  /// The lower bound of the specific enthalpy that is valid for this EOS
+  double specific_enthalpy_lower_bound() const override { return 1.0; }
+
+ private:
+  EQUATION_OF_STATE_FORWARD_DECLARE_MEMBER_IMPLS(1)
+
+  double gamma(const double x) const;
+  double integral_of_gamma(const double x) const;
+  double chi_from_density(const double density) const;
+  double specific_internal_energy_from_density(const double density) const;
+  double specific_enthalpy_from_density(const double density) const;
+  double pressure_from_density(const double density) const;
+  double pressure_from_log_density(const double x) const;
+  double rest_mass_density_from_enthalpy(const double specific_enthalpy) const;
+
+  double reference_density_ = std::numeric_limits<double>::signaling_NaN();
+  double reference_pressure_ = std::numeric_limits<double>::signaling_NaN();
+  std::vector<double> integral_coefficients_{};
+  std::vector<double> gamma_coefficients_{};
+  double x_max_ = std::numeric_limits<double>::signaling_NaN();
+  double gamma_of_x_max_ = std::numeric_limits<double>::signaling_NaN();
+  double integral_of_gamma_of_x_max_ =
+      std::numeric_limits<double>::signaling_NaN();
+  std::vector<double> table_of_specific_energies_{};
+  // Information for Gaussian quadrature
+  size_t number_of_quadrature_coefs_ =
+      std::numeric_limits<size_t>::signaling_NaN();
+  std::vector<double> quadrature_weights_{};
+  std::vector<double> quadrature_points_{};
+};
+
+}  // namespace EquationsOfState

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_DarkEnergyFluid.cpp
   Test_IdealFluid.cpp
   Test_PolytropicFluid.cpp
+  Test_SpectralEoS.cpp
   )
 
 add_test_library(

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_SpectralEoS.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_SpectralEoS.cpp
@@ -1,0 +1,100 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <limits>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Helpers/PointwiseFunctions/Hydro/EquationsOfState/TestHelpers.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+
+namespace {
+
+void check_exact() {
+  // Test creation
+  namespace EoS = EquationsOfState;
+  const std::vector coefs = {3.0, 0.25, 0.375, 0.5};
+  TestHelpers::test_creation<std::unique_ptr<EoS::EquationOfState<true, 1>>>(
+      {"Spectral:\n"
+       "  ReferenceDensity: 2.0\n"
+       "  ReferencePressure: 4.0  \n"
+       "  Coefficients: [3.0,0.25,0.375,0.5]\n"
+       "  UpperDensity: 15.0\n"});
+
+  EquationsOfState::Spectral eos(2.0, 4.0, {3.0, 0.25, 0.375, 0.5},
+                                 2.0 * exp(2.0));
+  // Test DataVector functions
+  {
+    const Scalar<DataVector> rho{DataVector{
+        2.0 * exp(-1.0), 2.0, 2.0 * exp(1.0), 2.0 * exp(2.0), 2.0 * exp(3.0)}};
+    const Scalar<DataVector> p = eos.pressure_from_density(rho);
+    INFO(rho);
+    INFO(p);
+    const Scalar<DataVector> p_expected{
+        DataVector{4.0 * exp(-3.0), 4.0, 4.0 * exp(3.375), 4.0 * exp(9.5),
+                   4.0 * exp(18.5)}};
+    CHECK(p == p_expected);
+    const auto eps_c = eos.specific_internal_energy_from_density(rho);
+    const Scalar<DataVector> eps_expected{
+        DataVector{exp(-2.0), 1.0, 8.519830698147826, 528.9617452597413,
+                   1347501.570212399}};
+    CHECK_ITERABLE_APPROX(eps_c, eps_expected);
+    const auto h_c = eos.specific_enthalpy_from_density(rho);
+    const auto h_expected =
+        get(eps_expected) + 1.0 + get(p_expected) / get(rho);
+    CHECK_ITERABLE_APPROX(get(h_c), h_expected);
+    const auto chi_c = eos.chi_from_density(rho);
+    const Scalar<DataVector> gamma{DataVector{3.0, 3.0, 4.125, 9.0, 9.0}};
+    const auto chi_expected = get(p_expected) * get(gamma) / get(rho);
+    CHECK_ITERABLE_APPROX(chi_expected, get(chi_c));
+    const Scalar<DataVector> p_c_kappa_c_over_rho_sq_expected{
+        DataVector{0.0, 0.0, 0.0, 0.0, 0.0}};
+    const auto p_c_kappa_c_over_rho_sq =
+        eos.kappa_times_p_over_rho_squared_from_density(rho);
+    CHECK_ITERABLE_APPROX(p_c_kappa_c_over_rho_sq_expected,
+                          p_c_kappa_c_over_rho_sq);
+    const auto rho_from_enthalpy = eos.rest_mass_density_from_enthalpy(h_c);
+    CHECK_ITERABLE_APPROX(rho, rho_from_enthalpy);
+  }
+  // Test double functions
+  {
+    const Scalar<double> rho{2.0 * exp(1.0)};
+    const auto p = eos.pressure_from_density(rho);
+    const double p_expected = 4.0 * exp(3.375);
+    CHECK(get(p) == p_expected);
+    const auto eps = eos.specific_internal_energy_from_density(rho);
+    const double eps_expected = 8.519830698147826;
+    CHECK_ITERABLE_APPROX(get(eps), eps_expected);
+    const auto h = eos.specific_enthalpy_from_density(rho);
+    const double h_expected = eps_expected + 1.0 + p_expected / get(rho);
+    CHECK_ITERABLE_APPROX(get(h), h_expected);
+    const auto chi = eos.chi_from_density(rho);
+    const double chi_expected = p_expected * 4.125 / get(rho);
+    CHECK_ITERABLE_APPROX(chi_expected, get(chi));
+    const auto p_c_kappa_c_over_rho_sq =
+        eos.kappa_times_p_over_rho_squared_from_density(rho);
+    const double p_c_kappa_c_over_rho_sq_expected = 0.0;
+    CHECK_ITERABLE_APPROX(p_c_kappa_c_over_rho_sq_expected,
+                          get(p_c_kappa_c_over_rho_sq));
+    const auto rho_from_enthalpy = eos.rest_mass_density_from_enthalpy(h);
+    CHECK_ITERABLE_APPROX(get(rho), get(rho_from_enthalpy));
+  }
+  // Test bounds
+  CHECK(0.0 == eos.rest_mass_density_lower_bound());
+  CHECK(0.0 == eos.specific_internal_energy_lower_bound(1.0));
+  CHECK(1.0 == eos.specific_enthalpy_lower_bound());
+  const double max_double = std::numeric_limits<double>::max();
+  CHECK(max_double == eos.rest_mass_density_upper_bound());
+  CHECK(max_double == eos.specific_internal_energy_upper_bound(1.0));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.Spectral",
+                  "[Unit][EquationsOfState]") {
+  check_exact();
+}


### PR DESCRIPTION
## Proposed changes

Add the `spectral' family of equations of state, as described in Foucart et al 2019 (10.1103/PhysRevD.100.104048).
This class of EoS is largely inspired from Lindblom 2010 (10.1103/PhysRevD.82.103011).
The aim is to get functions Pressure(density) and InternalEnergy(density) with smooth 1st and 2nd derivatives. 

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
