### PR TITLE
Use obs box in ScalarWave, switch ObserveVolumeIntegrals to obs box

### DIFF
--- a/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
+++ b/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
@@ -204,6 +204,7 @@ struct Metavariables {
                     volume_dim, linear_solver_iteration_id,
                     tmpl::list<
                         Elasticity::Tags::PotentialEnergyDensity<volume_dim>>,
+                    tmpl::list<>,
                     LinearSolver::multigrid::Tags::IsFinestGrid>>>>,
         tmpl::pair<Trigger, elliptic::Triggers::all_triggers<
                                 typename linear_solver::options_group>>>;

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -134,17 +134,17 @@ struct EvolutionMetavars {
     using factory_classes = tmpl::map<
         tmpl::pair<DenseTrigger, DenseTriggers::standard_dense_triggers>,
         tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
-        tmpl::pair<
-            Event,
-            tmpl::flatten<tmpl::list<
-                Events::Completion,
-                dg::Events::field_observations<
-                    volume_dim, Tags::Time, observe_fields,
-                    analytic_solution_fields, tmpl::list<>>,
-                dg::Events::ObserveVolumeIntegrals<
-                    volume_dim, Tags::Time,
-                    tmpl::list<ScalarWave::Tags::EnergyDensity<volume_dim>>>,
-                Events::time_events<system>>>>,
+        tmpl::pair<Event,
+                   tmpl::flatten<tmpl::list<
+                       Events::Completion,
+                       dg::Events::field_observations<
+                           volume_dim, Tags::Time, observe_fields,
+                           analytic_solution_fields, tmpl::list<>>,
+                       dg::Events::ObserveVolumeIntegrals<
+                           volume_dim, Tags::Time,
+                           tmpl::list<ScalarWave::Tags::EnergyDensityCompute<
+                               volume_dim>>>,
+                       Events::time_events<system>>>>,
         tmpl::pair<MathFunction<1, Frame::Inertial>,
                    MathFunctions::all_math_functions<1, Frame::Inertial>>,
         tmpl::pair<
@@ -248,9 +248,8 @@ struct EvolutionMetavars {
                  ScalarWave::Actions::InitializeConstraints<volume_dim>,
                  Initialization::Actions::AddComputeTags<tmpl::push_back<
                      StepChoosers::step_chooser_compute_tags<EvolutionMetavars>,
-                     evolution::Tags::AnalyticCompute<Dim, initial_data_tag,
-                                                      analytic_solution_fields>,
-                     ScalarWave::Tags::EnergyDensityCompute<volume_dim>>>,
+                     evolution::Tags::AnalyticCompute<
+                         Dim, initial_data_tag, analytic_solution_fields>>>,
                  ::evolution::dg::Initialization::Mortars<volume_dim, system>,
                  evolution::Actions::InitializeRunEventsAndDenseTriggers,
                  Initialization::Actions::RemoveOptionsAndTerminatePhase>;

--- a/src/Evolution/Systems/ScalarWave/Initialize.hpp
+++ b/src/Evolution/Systems/ScalarWave/Initialize.hpp
@@ -26,10 +26,6 @@ namespace Actions {
 /// DataBox changes:
 /// - Adds:
 ///   * `ScalarWave::Tags::ConstraintGamma2`
-///   * `ScalarWave::Tags::OneIndexConstraint<Dim>`
-///   * `ScalarWave::Tags::TwoIndexConstraint<Dim>`
-///   * `::Tags::PointwiseL2Norm<ScalarWave::Tags::OneIndexConstraint<Dim>>`
-///   * `::Tags::PointwiseL2Norm<ScalarWave::Tags::TwoIndexConstraint<Dim>>`
 /// - Removes: nothing
 /// - Modifies: nothing
 ///
@@ -40,16 +36,7 @@ template <size_t Dim>
 struct InitializeConstraints {
   using simple_tags = tmpl::list<ScalarWave::Tags::ConstraintGamma2>;
 
-  using compute_tags = tmpl::list<
-      ::Tags::DerivCompute<typename System<Dim>::variables_tag,
-                           domain::Tags::InverseJacobian<
-                               Dim, Frame::ElementLogical, Frame::Inertial>,
-                           typename System<Dim>::gradient_variables>,
-      ScalarWave::Tags::OneIndexConstraintCompute<Dim>,
-      ScalarWave::Tags::TwoIndexConstraintCompute<Dim>,
-      ::Tags::PointwiseL2NormCompute<ScalarWave::Tags::OneIndexConstraint<Dim>>,
-      ::Tags::PointwiseL2NormCompute<
-          ScalarWave::Tags::TwoIndexConstraint<Dim>>>;
+  using compute_tags = tmpl::list<>;
 
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,

--- a/src/ParallelAlgorithms/Events/ObserveVolumeIntegrals.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveVolumeIntegrals.hpp
@@ -40,11 +40,13 @@ struct Inertial;
 }  // namespace Frame
 /// \endcond
 
-namespace dg {
-namespace Events {
+namespace dg::Events {
+/// \cond
 template <size_t VolumeDim, typename ObservationValueTag, typename Tensors,
+          typename NonTensorComputeTagsList = tmpl::list<>,
           typename ArraySectionIdTag = void>
 class ObserveVolumeIntegrals;
+/// \endcond
 
 /*!
  * \ingroup DiscontinuousGalerkinGroup
@@ -63,10 +65,10 @@ class ObserveVolumeIntegrals;
  * for the path in the output file.
  */
 template <size_t VolumeDim, typename ObservationValueTag, typename... Tensors,
-          typename ArraySectionIdTag>
-class ObserveVolumeIntegrals<VolumeDim, ObservationValueTag,
-                             tmpl::list<Tensors...>, ArraySectionIdTag>
-    : public Event {
+          typename... NonTensorComputeTags, typename ArraySectionIdTag>
+class ObserveVolumeIntegrals<
+    VolumeDim, ObservationValueTag, tmpl::list<Tensors...>,
+    tmpl::list<NonTensorComputeTags...>, ArraySectionIdTag> : public Event {
  private:
   using VolumeIntegralDatum =
       Parallel::ReductionDatum<std::vector<double>, funcl::VectorPlus>;
@@ -111,8 +113,8 @@ class ObserveVolumeIntegrals<VolumeDim, ObservationValueTag,
   using observed_reduction_data_tags =
       observers::make_reduction_data_tags<tmpl::list<ReductionData>>;
 
-
-  using compute_tags_for_observation_box = tmpl::list<>;
+  using compute_tags_for_observation_box =
+      tmpl::list<Tensors..., NonTensorComputeTags...>;
 
   using argument_tags = tmpl::list<
       ::Tags::ObservationBox, ObservationValueTag,
@@ -220,19 +222,19 @@ class ObserveVolumeIntegrals<VolumeDim, ObservationValueTag,
 };
 
 template <size_t VolumeDim, typename ObservationValueTag, typename... Tensors,
-          typename ArraySectionIdTag>
-ObserveVolumeIntegrals<
-    VolumeDim, ObservationValueTag, tmpl::list<Tensors...>,
-    ArraySectionIdTag>::ObserveVolumeIntegrals(const std::string& subfile_name)
+          typename... NonTensorComputeTags, typename ArraySectionIdTag>
+ObserveVolumeIntegrals<VolumeDim, ObservationValueTag, tmpl::list<Tensors...>,
+                       tmpl::list<NonTensorComputeTags...>, ArraySectionIdTag>::
+    ObserveVolumeIntegrals(const std::string& subfile_name)
     : subfile_path_("/" + subfile_name) {}
 
 /// \cond
 template <size_t VolumeDim, typename ObservationValueTag, typename... Tensors,
-          typename ArraySectionIdTag>
+          typename... NonTensorComputeTags, typename ArraySectionIdTag>
 PUP::able::PUP_ID ObserveVolumeIntegrals<VolumeDim, ObservationValueTag,
                                          tmpl::list<Tensors...>,
+                                         tmpl::list<NonTensorComputeTags...>,
                                          ArraySectionIdTag>::my_PUP_ID =
     0;  // NOLINT
 /// \endcond
-}  // namespace Events
-}  // namespace dg
+}  // namespace dg::Events


### PR DESCRIPTION
## Proposed changes

- Add ObservationBox compute tag support to `ObserveVolumeIntegrals`
- Switch the scalar wave executable to using the observation box instead of storing constraints, L2 norms, etc. in the DataBox.

Depends on:
- [x] #3558 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
