### PR TITLE
Remove a redundant operator in Grmhd ResizeAndComputePrims

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ResizeAndComputePrimitives.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ResizeAndComputePrimitives.cpp
@@ -44,10 +44,7 @@ void ResizeAndComputePrims<OrderedListOfRecoverySchemes>::apply(
                << subcell_mesh.number_of_grid_points() << ") but got "
                << prim_vars->number_of_grid_points() << ". The DG grid has "
                << dg_mesh.number_of_grid_points() << " grid points");
-    const size_t num_grid_points =
-        (active_grid == evolution::dg::subcell::ActiveGrid::Dg ? dg_mesh
-                                                               : subcell_mesh)
-            .number_of_grid_points();
+    const size_t num_grid_points = dg_mesh.number_of_grid_points();
     // Reconstruct a copy of the pressure from the FD grid to the DG grid to
     // provide a high-order initial guess.
     const Scalar<DataVector> fd_pressure =


### PR DESCRIPTION


## Proposed changes

This is the one I pointed out at #3637 for the Gh+Grmhd code. This PR is for the same chage for Grmhd.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
