### PR TITLE
Generate BibTeX entry at releases

### DIFF
--- a/.github/scripts/Release.py
+++ b/.github/scripts/Release.py
@@ -57,7 +57,6 @@ def raise_for_status(response):
 @uplink.response_handler(raise_for_status)
 class Zenodo(uplink.Consumer):
     """Abstraction of the [Zenodo API](https://developers.zenodo.org)"""
-
     @uplink.returns.json
     @uplink.get('deposit/depositions/{id}')
     def get_deposition(self, id: uplink.Path):
@@ -536,7 +535,8 @@ if __name__ == "__main__":
     parent_parser.add_argument(
         '--zenodo-sandbox',
         action='store_true',
-        help=("Use the Zenodo sandbox instead of the public version of Zenodo"))
+        help=(
+            "Use the Zenodo sandbox instead of the public version of Zenodo"))
     parent_parser.add_argument(
         '--github-token',
         required=False,

--- a/.github/scripts/requirements-release.txt
+++ b/.github/scripts/requirements-release.txt
@@ -4,6 +4,7 @@
 # Required Python packages for the release workflow
 
 GitPython~=3.1.11
+pybtex~=0.24.0
 PyGithub~=1.53
 PyYAML~=5.3.1
 tqdm~=4.55.1

--- a/Metadata.yaml
+++ b/Metadata.yaml
@@ -5,7 +5,7 @@ Name: SpECTRE
 
 License: MIT
 
-Homepage: https://spectre-code.org/
+Homepage: https://spectre-code.org
 
 GitHub: sxs-collaboration/spectre
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,25 @@ is:
 
 You can cite this BibTeX entry in your publication:
 
-- [Find BibTeX entry for this version on Zenodo](https://zenodo.org/record/5815438/export/hx)
+<!-- The BibTeX entry below is updated automatically at releases -->
+<!-- BIBTEX ENTRY -->
+@software{spectrecode,
+    author = "Deppe, Nils and Throwe, William and Kidder, Lawrence E. and
+Fischer, Nils L. and H\'ebert, Fran\c cois and Moxon, Jordan and Armaza,
+Crist\'obal and Bonilla, Gabriel S. and Kumar, Prayush and Lovelace, Geoffrey
+and O'Shea, Eamonn and Pfeiffer, Harald P. and Scheel, Mark A. and Teukolsky,
+Saul A. and others",
+    title = "\texttt{SpECTRE v2022.01.03}",
+    version = "2022.01.03",
+    publisher = "Zenodo",
+    doi = "10.5281/zenodo.5815438",
+    url = "https://spectre-code.org",
+    howpublished = "\href{https://doi.org/10.5281/zenodo.5815438}{10.5281/zenodo.5815438}",
+    license = "MIT",
+    year = "2022",
+    month = "1"
+}
+<!-- BIBTEX ENTRY -->
 
 To aid reproducibility of your scientific results with SpECTRE, we recommend you
 keep track of the version(s) you used and report this information in your

--- a/citation.bib
+++ b/citation.bib
@@ -1,0 +1,16 @@
+@software{spectrecode,
+    author = "Deppe, Nils and Throwe, William and Kidder, Lawrence E. and
+Fischer, Nils L. and H\'ebert, Fran\c cois and Moxon, Jordan and Armaza,
+Crist\'obal and Bonilla, Gabriel S. and Kumar, Prayush and Lovelace, Geoffrey
+and O'Shea, Eamonn and Pfeiffer, Harald P. and Scheel, Mark A. and Teukolsky,
+Saul A. and others",
+    title = "\texttt{SpECTRE v2022.01.03}",
+    version = "2022.01.03",
+    publisher = "Zenodo",
+    doi = "10.5281/zenodo.5815438",
+    url = "https://spectre-code.org",
+    howpublished = "\href{https://doi.org/10.5281/zenodo.5815438}{10.5281/zenodo.5815438}",
+    license = "MIT",
+    year = "2022",
+    month = "1"
+}

--- a/cmake/SetupFormaline.cmake
+++ b/cmake/SetupFormaline.cmake
@@ -14,6 +14,7 @@ set(SPECTRE_FORMALINE_LOCATIONS
   .style.yapf
   .travis
   .travis.yml
+  citation.bib
   CITATION.cff
   cmake
   CMakeLists.txt

--- a/cmake/SetupFormaline.cmake
+++ b/cmake/SetupFormaline.cmake
@@ -6,9 +6,28 @@
 # directory that are tracked by Git. I.e.
 #   git ls-tree --full-tree --name-only HEAD
 set(SPECTRE_FORMALINE_LOCATIONS
-  "CITATION.cff;.clang-format;.clang-tidy;cmake;CMakeLists.txt;.codecov.yaml;"
-  "containers;docs;external;.github;.gitignore;LICENSE.txt;Metadata.yaml;"
-  "README.md;src;.style.yapf;support;tests;tools;.travis;.travis.yml")
+  .clang-format
+  .clang-tidy
+  .codecov.yaml
+  .github
+  .gitignore
+  .style.yapf
+  .travis
+  .travis.yml
+  CITATION.cff
+  cmake
+  CMakeLists.txt
+  containers
+  docs
+  external
+  LICENSE.txt
+  Metadata.yaml
+  README.md
+  src
+  support
+  tests
+  tools
+  )
 
 find_package(Git)
 

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -123,7 +123,8 @@ EXCLUDE_SYMBOLS        = charm_init_*                                 \
 
 EXAMPLE_PATH           = @PROJECT_SOURCE_DIR@/tests/ \
                          @PROJECT_SOURCE_DIR@/src/Executables/Examples/ \
-                         @PROJECT_SOURCE_DIR@/support/DevEnvironments/spack.yaml
+                         @PROJECT_SOURCE_DIR@/support/DevEnvironments/spack.yaml \
+                         @PROJECT_SOURCE_DIR@/citation.bib
 
 EXAMPLE_PATTERNS       =
 

--- a/docs/Main.md
+++ b/docs/Main.md
@@ -86,7 +86,7 @@ is:
 
 You can cite this BibTeX entry in your publication:
 
-- [Find BibTeX entry for this version on Zenodo](https://zenodo.org/record/\spectrezenodoid/export/hx)
+\include citation.bib
 
 To aid reproducibility of your scientific results with SpECTRE, we recommend you
 keep track of the version(s) you used and report this information in your

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -344,6 +344,7 @@ license() {
               '.style.yapf' \
               '.svg' \
               'LICENSE' \
+              'citation.bib' \
               'cmake/CodeCoverage.cmake$' \
               'cmake/CodeCoverageDetection.cmake$' \
               'cmake/FindCatch.cmake$' \


### PR DESCRIPTION
## Proposed changes

Zenodo's BibTeX entry isn't very good. Instead, generate an entry when
creating a release and store it in the repo. This also means that people
can easily copy it from the README or download the file.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
