### PR TITLE
Add temporary tags for repeated expressions in CCZ4 eqs

### DIFF
--- a/src/Evolution/Systems/Ccz4/TempTags.hpp
+++ b/src/Evolution/Systems/Ccz4/TempTags.hpp
@@ -4,11 +4,11 @@
 #pragma once
 
 #include <cstddef>
-#include <string>
 
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/Ccz4/TagsDeclarations.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 
 namespace Ccz4 {
 namespace Tags {
@@ -33,6 +33,200 @@ namespace Tags {
 template <size_t Dim, typename Frame, typename DataType>
 struct GammaHatMinusContractedConformalChristoffel : db::SimpleTag {
   using type = tnsr::I<DataType, Dim, Frame>;
+};
+
+/*!
+ * \brief The CCZ4 temporary expression \f$K - 2 \Theta c\f$
+ *
+ * \details Here, \f$K\f$ is the trace of the extrinsic curvature defined by
+ * `gr::Tags::TraceExtrinsicCurvature`, \f$\Theta\f$ is the projection of the Z4
+ * four-vector along the normal direction, and \f$c\f$ controls whether to
+ * include algebraic source terms proportional to \f$\Theta\f$.
+ */
+template <typename DataType>
+struct KMinus2ThetaC : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+/*!
+ * \brief The CCZ4 temporary expression \f$K - K_0 - 2 \Theta c\f$
+ *
+ * \details Here, \f$K\f$ is the trace of the extrinsic curvature defined by
+ * `gr::Tags::TraceExtrinsicCurvature`, \f$K_0\f$ is the initial time derivative
+ * of the lapse, \f$\Theta\f$ is the projection of the Z4 four-vector along the
+ * normal direction, and \f$c\f$ controls whether to include algebraic source
+ * terms proportional to \f$\Theta\f$.
+ */
+template <typename DataType>
+struct KMinusK0Minus2ThetaC : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+/*!
+ * \brief The CCZ4 temporary expression \f$B_k{}^k\f$
+ *
+ * \details Here, \f$B_k{}^k\f$ is the contraction of the CCZ4 auxiliary
+ * variable defined by `Ccz4::Tags::FieldB`.
+ */
+template <typename DataType>
+struct ContractedFieldB : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+/*!
+ * \brief The CCZ4 temporary expression \f$\tilde{\gamma}_{ki} B_j{}^k\f$
+ *
+ * \details Here, \f$\tilde{\gamma}_{ij}\f$ is the conformal spatial metric
+ * defined by `Ccz4::Tags::ConformalMetric` and \f$B_i{}^j\f$ is the CCZ4
+ * auxiliary variable defined by `Ccz4::Tags::FieldB`.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct ConformalMetricTimesFieldB : db::SimpleTag {
+  using type = tnsr::ij<DataType, Dim, Frame>;
+};
+
+/*!
+ * \brief The CCZ4 temporary expression \f$\alpha (R + 2 \nabla_k Z^k)\f$
+ *
+ * \details Here, \f$\alpha\f$ is the lapse defined by `gr::Tags::Lapse` and
+ * \f$(R + 2 \nabla_k Z^k)\f$ is the Ricci scalar plus twice the divergence of
+ * the spatial Z4 constraint defined by
+ * `Ccz4::Tags::RicciScalarPlusDivergenceZ4Constraint`.
+ */
+template <typename DataType>
+struct LapseTimesRicciScalarPlus2DivergenceZ4Constraint : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+/*!
+ * \brief The CCZ4 temporary expression \f$\tilde{\gamma}_{ij} tr \tilde{A}\f$
+ *
+ * \details Here, \f$\tilde{\gamma}_{ij}\f$ is the conformal spatial metric
+ * defined by `Ccz4::Tags::ConformalMetric` and \f$tr \tilde{A}\f$ is the trace
+ * of the trace-free part of the extrinsic curvature defined by
+ * `Ccz4::Tags::TraceATilde`.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct ConformalMetricTimesTraceATilde : db::SimpleTag {
+  using type = tnsr::ii<DataType, Dim, Frame>;
+};
+
+/*!
+ * \brief The CCZ4 temporary expression \f$\alpha \tilde{A}_{ij}\f$
+ *
+ * \details Here, \f$\alpha\f$ is the lapse defined by `gr::Tags::Lapse` and
+ * \f$\tilde{A}_{ij}\f$ is the trace-free part of the extrinsic curvature
+ * defined by `Ccz4::Tags::ATilde`.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct LapseTimesATilde : db::SimpleTag {
+  using type = tnsr::ii<DataType, Dim, Frame>;
+};
+
+/*!
+ * \brief The CCZ4 temporary expression \f$D_k{}^{nm} \tilde{A}_{nm}\f$
+ *
+ * \details Here, \f$D_k{}^{nm}\f$ is analytically negative one half the spatial
+ * derivative of the inverse conformal spatial metric defined by
+ * `Ccz4::Tags::FieldDUp` and \f$\tilde{A}_{nm}\f$ is the trace-free part of the
+ * extrinsic curvature defined by `Ccz4::Tags::ATilde`.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct FieldDUpTimesATilde : db::SimpleTag {
+  using type = tnsr::i<DataType, Dim, Frame>;
+};
+
+/*!
+ * \brief The CCZ4 temporary expression \f$\alpha \partial_k \tilde{A}_{ij}\f$
+ *
+ * \details Here, \f$\alpha\f$ is the lapse defined by `gr::Tags::Lapse` and
+ * \f$\tilde{A}_{ij}\f$ is the trace-free part of the extrinsic curvature
+ * defined by `Ccz4::Tags::ATilde`, and \f$\partial_k \tilde{A}_{ij}\f$ is its
+ * spatial derivative.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct LapseTimesDerivATilde : db::SimpleTag {
+  using type = tnsr::ijj<DataType, Dim, Frame>;
+};
+
+/*!
+ * \brief The CCZ4 temporary expression
+ * \f$\tilde{\gamma}^{nm} \partial_k \tilde{A}_{nm}\f$
+ *
+ * \details Here, \f$\tilde{\gamma}^{nm}\f$ is the inverse conformal spatial
+ * metric defined by `Ccz4::Tags::InverseConformalMetric`, \f$\tilde{A}_{ij}\f$
+ * is the trace-free part of the extrinsic curvature defined by
+ * `Ccz4::Tags::ATilde`, and \f$\partial_k \tilde{A}_{ij}\f$ is its spatial
+ * derivative.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct InverseConformalMetricTimesDerivATilde : db::SimpleTag {
+  using type = tnsr::i<DataType, Dim, Frame>;
+};
+
+/*!
+ * \brief The CCZ4 temporary expression
+ * \f$\tilde{A}_{ij} - \frac{1}{3} \tilde{\gamma}_{ij} tr \tilde{A}\f$
+ *
+ * \details Here, \f$\tilde{A}_{ij}\f$ is the trace-free part of the extrinsic
+ * curvature defined by `Ccz4::Tags::ATilde`, \f$tr \tilde{A}\f$ is its trace
+ * defined by `Ccz4::Tags::TraceATilde`, and \f$\tilde{\gamma}_{ij}\f$ is the
+ * conformal spatial metric defined by `Ccz4::Tags::ConformalMetric`.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct ATildeMinusOneThirdConformalMetricTimesTraceATilde : db::SimpleTag {
+  using type = tnsr::ii<DataType, Dim, Frame>;
+};
+
+/*!
+ * \brief The CCZ4 temporary expression \f$\alpha A_k\f$
+ *
+ * \details Here, \f$\alpha\f$ is the lapse defined by `gr::Tags::Lapse` and
+ * \f$A_k\f$ is the CCZ4 auxiliary variable defined by `Ccz4::Tags::FieldA`.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct LapseTimesFieldA : db::SimpleTag {
+  using type = tnsr::i<DataType, Dim, Frame>;
+};
+
+/*!
+ * \brief The CCZ4 temporary expression \f$\beta^k \partial_k \hat{\Gamma}^i\f$
+ *
+ * \details Here, \f$\beta^k\f$ is the shift defined by `gr::Tags::Shift`,
+ * \f$\hat{\Gamma}^i\f$ is the CCZ4 evolved variable defined by
+ * `Ccz4::Tags::GammaHat`, and \f$\partial_k \hat{\Gamma}^i\f$ is its spatial
+ * derivative.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct ShiftTimesDerivGammaHat : db::SimpleTag {
+  using type = tnsr::I<DataType, Dim, Frame>;
+};
+
+/*!
+ * \brief The CCZ4 temporary expression \f$\tau^{-1} \tilde{\gamma}_{ij}\f$
+ *
+ * \details Here, \f$\tilde{\gamma}_{ij}\f$ is the conformal spatial metric
+ * defined by `Ccz4::Tags::ConformalMetric` and \f$\tau\f$ is the relaxation
+ * time to enforce the algebraic constraints on the determinant of the conformal
+ * spatial metric and on the trace of the trace-free part of the extrinsic
+ * curvature that is defined by `Ccz4::Tags::ATilde`.
+ */
+template <size_t Dim, typename Frame, typename DataType>
+struct InverseTauTimesConformalMetric : db::SimpleTag {
+  using type = tnsr::ii<DataType, Dim, Frame>;
+};
+
+/*!
+ * \brief The CCZ4 temporary expression \f$\alpha g(\alpha)\f$
+ *
+ * \details Here, \f$\alpha\f$ is the lapse defined by `gr::Tags::Lapse` and
+ * \f$g(\alpha)\f$ is a constant that controls the slicing conditions.
+ * \f$g(\alpha) = 1\f$ leads to harmonic slicing and
+ * \f$g(\alpha) = 2 / \alpha\f$ leads to 1 + log slicing.
+ */
+template <typename DataType>
+struct LapseTimesSlicingCondition : db::SimpleTag {
+  using type = Scalar<DataType>;
 };
 }  // namespace Tags
 }  // namespace Ccz4

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_TempTags.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_TempTags.cpp
@@ -20,6 +20,47 @@ void test_simple_tags() {
       Ccz4::Tags::GammaHatMinusContractedConformalChristoffel<Dim, Frame,
                                                               DataType>>(
       "GammaHatMinusContractedConformalChristoffel");
+  TestHelpers::db::test_simple_tag<Ccz4::Tags::KMinus2ThetaC<DataType>>(
+      "KMinus2ThetaC");
+  TestHelpers::db::test_simple_tag<Ccz4::Tags::KMinusK0Minus2ThetaC<DataType>>(
+      "KMinusK0Minus2ThetaC");
+  TestHelpers::db::test_simple_tag<Ccz4::Tags::ContractedFieldB<DataType>>(
+      "ContractedFieldB");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::ConformalMetricTimesFieldB<Dim, Frame, DataType>>(
+      "ConformalMetricTimesFieldB");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::LapseTimesRicciScalarPlus2DivergenceZ4Constraint<DataType>>(
+      "LapseTimesRicciScalarPlus2DivergenceZ4Constraint");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::ConformalMetricTimesTraceATilde<Dim, Frame, DataType>>(
+      "ConformalMetricTimesTraceATilde");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::LapseTimesATilde<Dim, Frame, DataType>>("LapseTimesATilde");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::FieldDUpTimesATilde<Dim, Frame, DataType>>(
+      "FieldDUpTimesATilde");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::LapseTimesDerivATilde<Dim, Frame, DataType>>(
+      "LapseTimesDerivATilde");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::InverseConformalMetricTimesDerivATilde<Dim, Frame, DataType>>(
+      "InverseConformalMetricTimesDerivATilde");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::ATildeMinusOneThirdConformalMetricTimesTraceATilde<Dim, Frame,
+                                                                     DataType>>(
+      "ATildeMinusOneThirdConformalMetricTimesTraceATilde");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::LapseTimesFieldA<Dim, Frame, DataType>>("LapseTimesFieldA");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::ShiftTimesDerivGammaHat<Dim, Frame, DataType>>(
+      "ShiftTimesDerivGammaHat");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::InverseTauTimesConformalMetric<Dim, Frame, DataType>>(
+      "InverseTauTimesConformalMetric");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::LapseTimesSlicingCondition<DataType>>(
+      "LapseTimesSlicingCondition");
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.TempTags", "[Unit][Evolution]") {


### PR DESCRIPTION
## Proposed changes

This PR adds temporary simple tags for expressions that show up more than once in the CCZ4 evolution equations in [this paper](https://arxiv.org/pdf/1707.09910.pdf) (see ens 12a - 12m).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
