### PR TITLE
Convert elliptic boundary conditions to use factory map

### DIFF
--- a/src/Elliptic/BoundaryConditions/AnalyticSolution.hpp
+++ b/src/Elliptic/BoundaryConditions/AnalyticSolution.hpp
@@ -30,27 +30,9 @@
 namespace elliptic::BoundaryConditions {
 
 /// \cond
-template <typename System, size_t Dim, typename FieldTags, typename FluxTags,
-          typename Registrars>
-struct AnalyticSolution;
-
-namespace Registrars {
 template <typename System, size_t Dim = System::volume_dim,
           typename FieldTags = typename System::primal_fields,
           typename FluxTags = typename System::primal_fluxes>
-struct AnalyticSolution {
-  template <typename Registrars>
-  using f = BoundaryConditions::AnalyticSolution<System, Dim, FieldTags,
-                                                 FluxTags, Registrars>;
-};
-}  // namespace Registrars
-
-template <typename System, size_t Dim = System::volume_dim,
-          typename FieldTags = typename System::primal_fields,
-          typename FluxTags = typename System::primal_fluxes,
-          typename Registrars =
-              tmpl::list<BoundaryConditions::Registrars::AnalyticSolution<
-                  System, Dim, FieldTags, FluxTags>>>
 struct AnalyticSolution;
 /// \endcond
 
@@ -69,12 +51,12 @@ struct AnalyticSolution;
  * add the analytic solutions to the DataBox.
  */
 template <typename System, size_t Dim, typename... FieldTags,
-          typename... FluxTags, typename Registrars>
+          typename... FluxTags>
 class AnalyticSolution<System, Dim, tmpl::list<FieldTags...>,
-                       tmpl::list<FluxTags...>, Registrars>
-    : public BoundaryCondition<Dim, Registrars> {
+                       tmpl::list<FluxTags...>>
+    : public BoundaryCondition<Dim> {
  private:
-  using Base = BoundaryCondition<Dim, Registrars>;
+  using Base = BoundaryCondition<Dim>;
 
  public:
   using options =
@@ -229,19 +211,19 @@ class AnalyticSolution<System, Dim, tmpl::list<FieldTags...>,
 };
 
 template <typename System, size_t Dim, typename... FieldTags,
-          typename... FluxTags, typename Registrars>
+          typename... FluxTags>
 void AnalyticSolution<System, Dim, tmpl::list<FieldTags...>,
-                      tmpl::list<FluxTags...>, Registrars>::pup(PUP::er& p) {
+                      tmpl::list<FluxTags...>>::pup(PUP::er& p) {
   Base::pup(p);
   p | boundary_condition_types_;
 }
 
 /// \cond
 template <typename System, size_t Dim, typename... FieldTags,
-          typename... FluxTags, typename Registrars>
+          typename... FluxTags>
 PUP::able::PUP_ID AnalyticSolution<System, Dim, tmpl::list<FieldTags...>,
-                                   tmpl::list<FluxTags...>,
-                                   Registrars>::my_PUP_ID = 0;  // NOLINT
+                                   tmpl::list<FluxTags...>>::my_PUP_ID =
+    0;  // NOLINT
 /// \endcond
 
 }  // namespace elliptic::BoundaryConditions

--- a/src/Elliptic/BoundaryConditions/BoundaryCondition.hpp
+++ b/src/Elliptic/BoundaryConditions/BoundaryCondition.hpp
@@ -9,7 +9,6 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Parallel/CharmPupable.hpp"
-#include "Utilities/Registration.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace elliptic {
@@ -87,14 +86,13 @@ namespace BoundaryConditions {
  * linearly on the field data, since these are the fields the linearization is
  * performed for.
  */
-template <size_t Dim, typename Registrars>
+template <size_t Dim>
 class BoundaryCondition : public domain::BoundaryConditions::BoundaryCondition {
  private:
   using Base = domain::BoundaryConditions::BoundaryCondition;
 
  public:
   static constexpr size_t volume_dim = Dim;
-  using registrars = Registrars;
 
   BoundaryCondition() = default;
   BoundaryCondition(const BoundaryCondition&) = default;
@@ -107,8 +105,6 @@ class BoundaryCondition : public domain::BoundaryConditions::BoundaryCondition {
   explicit BoundaryCondition(CkMigrateMessage* m) : Base(m) {}
   WRAPPED_PUPable_abstract(BoundaryCondition);  // NOLINT
   /// \endcond
-
-  using creatable_classes = Registration::registrants<registrars>;
 };
 
 }  // namespace BoundaryConditions

--- a/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/SubdomainOperator.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/SubdomainOperator.hpp
@@ -106,14 +106,19 @@ struct make_neighbor_mortars_tag_impl {
  * Poisson system is used for preconditioning that doesn't have boundary
  * conditions set up in the domain. In these cases, the boundary conditions used
  * for the subdomain operator can be overridden with the
- * `override_boundary_conditions` argument in the constructor. Note that the
- * subdomain operator always applies the _linearized_ boundary conditions.
+ * `override_boundary_conditions` argument in the constructor. If the overriding
+ * boundary conditions are different from those listed in
+ * `Metavariables::factory_creation`, you can supply the list of
+ * boundary-condition classes to the `BoundaryConditionClasses` template
+ * parameter. Note that the subdomain operator always applies the _linearized_
+ * boundary conditions.
  *
  * \warning The subdomain operator hasn't been tested with periodic boundary
  * conditions so far.
  */
 template <typename System, typename OptionsGroup,
-          typename ArgsTagsFromCenter = tmpl::list<>>
+          typename ArgsTagsFromCenter = tmpl::list<>,
+          typename BoundaryConditionClasses = tmpl::list<>>
 struct SubdomainOperator
     : LinearSolver::Schwarz::SubdomainOperator<System::volume_dim> {
  private:
@@ -303,8 +308,9 @@ struct SubdomainOperator
           }();
           elliptic::apply_boundary_condition<
               linearized,
-              tmpl::conditional_t<is_overlap_v, make_overlap_tag, void>>(
-              boundary_condition, box, map_keys, fields_and_fluxes...);
+              tmpl::conditional_t<is_overlap_v, make_overlap_tag, void>,
+              BoundaryConditionClasses>(boundary_condition, box, map_keys,
+                                        fields_and_fluxes...);
         };
 
     // Check if the subdomain data is sparse, i.e. if some elements have zero

--- a/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
+++ b/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
@@ -14,6 +14,7 @@
 #include "Elliptic/Actions/InitializeAnalyticSolution.hpp"
 #include "Elliptic/Actions/InitializeFields.hpp"
 #include "Elliptic/Actions/InitializeFixedSources.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
 #include "Elliptic/DiscontinuousGalerkin/Actions/ApplyOperator.hpp"
 #include "Elliptic/DiscontinuousGalerkin/Actions/InitializeDomain.hpp"
 #include "Elliptic/DiscontinuousGalerkin/DgElementArray.hpp"
@@ -21,6 +22,7 @@
 #include "Elliptic/DiscontinuousGalerkin/SubdomainOperator/SubdomainOperator.hpp"
 #include "Elliptic/SubdomainPreconditioners/MinusLaplacian.hpp"
 #include "Elliptic/SubdomainPreconditioners/RegisterDerived.hpp"
+#include "Elliptic/Systems/Elasticity/BoundaryConditions/Factory.hpp"
 #include "Elliptic/Systems/Elasticity/FirstOrderSystem.hpp"
 #include "Elliptic/Systems/Elasticity/Tags.hpp"
 #include "Elliptic/Tags.hpp"
@@ -192,6 +194,9 @@ struct Metavariables {
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes = tmpl::map<
         tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
+        tmpl::pair<elliptic::BoundaryConditions::BoundaryCondition<volume_dim>,
+                   Elasticity::BoundaryConditions::standard_boundary_conditions<
+                       system>>,
         tmpl::pair<
             Event,
             tmpl::flatten<tmpl::list<
@@ -329,8 +334,6 @@ static const std::vector<void (*)()> charm_init_node_funcs{
         metavariables::background_tag::type::element_type>,
     &Parallel::register_derived_classes_with_charm<
         metavariables::initial_guess_tag::type::element_type>,
-    &Parallel::register_derived_classes_with_charm<
-        metavariables::system::boundary_conditions_base>,
     &Parallel::register_derived_classes_with_charm<
         metavariables::schwarz_smoother::subdomain_solver>,
     &elliptic::subdomain_preconditioners::register_derived_with_charm,

--- a/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
@@ -14,11 +14,13 @@
 #include "Elliptic/Actions/InitializeAnalyticSolution.hpp"
 #include "Elliptic/Actions/InitializeFields.hpp"
 #include "Elliptic/Actions/InitializeFixedSources.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
 #include "Elliptic/DiscontinuousGalerkin/Actions/ApplyOperator.hpp"
 #include "Elliptic/DiscontinuousGalerkin/Actions/InitializeDomain.hpp"
 #include "Elliptic/DiscontinuousGalerkin/DgElementArray.hpp"
 #include "Elliptic/DiscontinuousGalerkin/SubdomainOperator/InitializeSubdomain.hpp"
 #include "Elliptic/DiscontinuousGalerkin/SubdomainOperator/SubdomainOperator.hpp"
+#include "Elliptic/Systems/Poisson/BoundaryConditions/Factory.hpp"
 #include "Elliptic/Systems/Poisson/FirstOrderSystem.hpp"
 #include "Elliptic/Tags.hpp"
 #include "Elliptic/Triggers/Factory.hpp"
@@ -181,6 +183,9 @@ struct Metavariables {
     using factory_classes = tmpl::map<
         tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
         tmpl::pair<
+            elliptic::BoundaryConditions::BoundaryCondition<volume_dim>,
+            Poisson::BoundaryConditions::standard_boundary_conditions<system>>,
+        tmpl::pair<
             Event,
             tmpl::flatten<tmpl::list<
                 Events::Completion,
@@ -310,8 +315,6 @@ static const std::vector<void (*)()> charm_init_node_funcs{
         metavariables::analytic_solution_tag::type::element_type>,
     &Parallel::register_derived_classes_with_charm<
         metavariables::initial_guess_tag::type::element_type>,
-    &Parallel::register_derived_classes_with_charm<
-        metavariables::system::boundary_conditions_base>,
     &Parallel::register_derived_classes_with_charm<
         metavariables::schwarz_smoother::subdomain_solver>,
     &Parallel::register_factory_classes_with_charm<metavariables>};

--- a/src/Elliptic/Executables/Xcts/SolveXcts.hpp
+++ b/src/Elliptic/Executables/Xcts/SolveXcts.hpp
@@ -12,6 +12,7 @@
 #include "Elliptic/Actions/InitializeAnalyticSolution.hpp"
 #include "Elliptic/Actions/InitializeFields.hpp"
 #include "Elliptic/Actions/InitializeFixedSources.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
 #include "Elliptic/BoundaryConditions/Tags/BoundaryFields.hpp"
 #include "Elliptic/DiscontinuousGalerkin/Actions/ApplyOperator.hpp"
 #include "Elliptic/DiscontinuousGalerkin/Actions/InitializeDomain.hpp"
@@ -20,6 +21,7 @@
 #include "Elliptic/DiscontinuousGalerkin/SubdomainOperator/SubdomainOperator.hpp"
 #include "Elliptic/SubdomainPreconditioners/MinusLaplacian.hpp"
 #include "Elliptic/SubdomainPreconditioners/RegisterDerived.hpp"
+#include "Elliptic/Systems/Xcts/BoundaryConditions/Factory.hpp"
 #include "Elliptic/Systems/Xcts/FirstOrderSystem.hpp"
 #include "Elliptic/Tags.hpp"
 #include "Elliptic/Triggers/Factory.hpp"
@@ -215,6 +217,9 @@ struct Metavariables {
     using factory_classes = tmpl::map<
         tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
         tmpl::pair<
+            elliptic::BoundaryConditions::BoundaryCondition<volume_dim>,
+            Xcts::BoundaryConditions::standard_boundary_conditions<system>>,
+        tmpl::pair<
             Event,
             tmpl::flatten<tmpl::list<
                 Events::Completion,
@@ -373,8 +378,6 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &Parallel::register_derived_classes_with_charm<
         Xcts::Solutions::AnalyticSolution<
             typename metavariables::analytic_solution_registrars>>,
-    &Parallel::register_derived_classes_with_charm<
-        metavariables::system::boundary_conditions_base>,
     &Parallel::register_derived_classes_with_charm<
         metavariables::schwarz_smoother::subdomain_solver>,
     &elliptic::subdomain_preconditioners::register_derived_with_charm,

--- a/src/Elliptic/SubdomainPreconditioners/MinusLaplacian.hpp
+++ b/src/Elliptic/SubdomainPreconditioners/MinusLaplacian.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include "Elliptic/DiscontinuousGalerkin/SubdomainOperator/SubdomainOperator.hpp"
+#include "Elliptic/Systems/Poisson/BoundaryConditions/Robin.hpp"
 #include "Elliptic/Systems/Poisson/FirstOrderSystem.hpp"
 #include "Elliptic/Systems/Poisson/Tags.hpp"
 #include "NumericalAlgorithms/Convergence/HasConverged.hpp"
@@ -84,9 +85,9 @@ class MinusLaplacian
   using options_group = OptionsGroup;
   using poisson_system =
       Poisson::FirstOrderSystem<Dim, Poisson::Geometry::FlatCartesian>;
-  using SubdomainOperator =
-      elliptic::dg::subdomain_operator::SubdomainOperator<poisson_system,
-                                                          OptionsGroup>;
+  using SubdomainOperator = elliptic::dg::subdomain_operator::SubdomainOperator<
+      poisson_system, OptionsGroup, tmpl::list<>,
+      tmpl::list<Poisson::BoundaryConditions::Robin<Dim>>>;
   using SubdomainData = ::LinearSolver::Schwarz::ElementCenteredSubdomainData<
       Dim, tmpl::list<Poisson::Tags::Field>>;
   using solver_type = Solver;
@@ -188,9 +189,7 @@ class MinusLaplacian
       // real boundary conditions. In particular, the correct choice Dirichlet
       // vs. Neumann b.c. is relevant for the effectiveness of the
       // preconditioner.
-      std::make_unique<Poisson::BoundaryConditions::Robin<
-          Dim, typename poisson_system::boundary_conditions_base::registrars>>(
-          1., 0., 0.)};
+      std::make_unique<Poisson::BoundaryConditions::Robin<Dim>>(1., 0., 0.)};
   mutable SubdomainData source_{};
   mutable SubdomainData initial_guess_in_solution_out_{};
 };

--- a/src/Elliptic/Systems/Elasticity/BoundaryConditions/CMakeLists.txt
+++ b/src/Elliptic/Systems/Elasticity/BoundaryConditions/CMakeLists.txt
@@ -16,6 +16,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  Factory.hpp
   LaserBeam.hpp
   Zero.hpp
   )

--- a/src/Elliptic/Systems/Elasticity/BoundaryConditions/Factory.hpp
+++ b/src/Elliptic/Systems/Elasticity/BoundaryConditions/Factory.hpp
@@ -1,0 +1,25 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "Elliptic/BoundaryConditions/AnalyticSolution.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryConditionType.hpp"
+#include "Elliptic/Systems/Elasticity/BoundaryConditions/LaserBeam.hpp"
+#include "Elliptic/Systems/Elasticity/BoundaryConditions/Zero.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Elasticity::BoundaryConditions {
+
+template <typename System>
+using standard_boundary_conditions = tmpl::append<
+    tmpl::list<
+        elliptic::BoundaryConditions::AnalyticSolution<System>,
+        Zero<System::volume_dim, elliptic::BoundaryConditionType::Dirichlet>,
+        Zero<System::volume_dim, elliptic::BoundaryConditionType::Neumann>>,
+    tmpl::conditional_t<System::volume_dim == 3, tmpl::list<LaserBeam>,
+                        tmpl::list<>>>;
+
+}

--- a/src/Elliptic/Systems/Elasticity/BoundaryConditions/LaserBeam.cpp
+++ b/src/Elliptic/Systems/Elasticity/BoundaryConditions/LaserBeam.cpp
@@ -10,9 +10,9 @@
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
 
-namespace Elasticity::BoundaryConditions::detail {
+namespace Elasticity::BoundaryConditions {
 
-void LaserBeamImpl::apply(
+void LaserBeam::apply(
     const gsl::not_null<tnsr::I<DataVector, 3>*> /*displacement*/,
     const gsl::not_null<tnsr::I<DataVector, 3>*> n_dot_minus_stress,
     const tnsr::I<DataVector, 3>& x,
@@ -29,7 +29,7 @@ void LaserBeamImpl::apply(
   get<2>(*n_dot_minus_stress) = -beam_profile * get<2>(face_normal);
 }
 
-void LaserBeamImpl::apply_linearized(
+void LaserBeam::apply_linearized(
     const gsl::not_null<tnsr::I<DataVector, 3>*> /*displacement*/,
     const gsl::not_null<tnsr::I<DataVector, 3>*> n_dot_minus_stress) {
   get<0>(*n_dot_minus_stress) = 0.;
@@ -37,12 +37,14 @@ void LaserBeamImpl::apply_linearized(
   get<2>(*n_dot_minus_stress) = 0.;
 }
 
-bool operator==(const LaserBeamImpl& lhs, const LaserBeamImpl& rhs) {
+bool operator==(const LaserBeam& lhs, const LaserBeam& rhs) {
   return lhs.beam_width() == rhs.beam_width();
 }
 
-bool operator!=(const LaserBeamImpl& lhs, const LaserBeamImpl& rhs) {
+bool operator!=(const LaserBeam& lhs, const LaserBeam& rhs) {
   return not(lhs == rhs);
 }
 
-}  // namespace Elasticity::BoundaryConditions::detail
+PUP::able::PUP_ID LaserBeam::my_PUP_ID = 0;  // NOLINT
+
+}  // namespace Elasticity::BoundaryConditions

--- a/src/Elliptic/Systems/Elasticity/BoundaryConditions/Zero.cpp
+++ b/src/Elliptic/Systems/Elasticity/BoundaryConditions/Zero.cpp
@@ -13,10 +13,10 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
-namespace Elasticity::BoundaryConditions::detail {
+namespace Elasticity::BoundaryConditions {
 
 template <size_t Dim, elliptic::BoundaryConditionType BoundaryConditionType>
-std::string ZeroImpl<Dim, BoundaryConditionType>::name() {
+std::string Zero<Dim, BoundaryConditionType>::name() {
   if constexpr (BoundaryConditionType ==
                 elliptic::BoundaryConditionType::Dirichlet) {
     return "Fixed";
@@ -26,7 +26,7 @@ std::string ZeroImpl<Dim, BoundaryConditionType>::name() {
 }
 
 template <size_t Dim, elliptic::BoundaryConditionType BoundaryConditionType>
-void ZeroImpl<Dim, BoundaryConditionType>::apply(
+void Zero<Dim, BoundaryConditionType>::apply(
     const gsl::not_null<tnsr::I<DataVector, Dim>*> displacement,
     const gsl::not_null<tnsr::I<DataVector, Dim>*> n_dot_minus_stress) {
   if constexpr (BoundaryConditionType ==
@@ -44,33 +44,16 @@ void ZeroImpl<Dim, BoundaryConditionType>::apply(
 }
 
 template <size_t Dim, elliptic::BoundaryConditionType BoundaryConditionType>
-void ZeroImpl<Dim, BoundaryConditionType>::apply_linearized(
+void Zero<Dim, BoundaryConditionType>::apply_linearized(
     const gsl::not_null<tnsr::I<DataVector, Dim>*> displacement,
     const gsl::not_null<tnsr::I<DataVector, Dim>*> n_dot_minus_stress) {
   apply(displacement, n_dot_minus_stress);
 }
 
-template <size_t Dim, elliptic::BoundaryConditionType BoundaryConditionType>
-bool operator==(const ZeroImpl<Dim, BoundaryConditionType>& /*lhs*/,
-                const ZeroImpl<Dim, BoundaryConditionType>& /*rhs*/) {
-  return true;
-}
-
-template <size_t Dim, elliptic::BoundaryConditionType BoundaryConditionType>
-bool operator!=(const ZeroImpl<Dim, BoundaryConditionType>& lhs,
-                const ZeroImpl<Dim, BoundaryConditionType>& rhs) {
-  return not(lhs == rhs);
-}
-
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define BCTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define INSTANTIATE(_, data)                                              \
-  template class ZeroImpl<DIM(data), BCTYPE(data)>;                       \
-  template bool operator==(const ZeroImpl<DIM(data), BCTYPE(data)>& lhs,  \
-                           const ZeroImpl<DIM(data), BCTYPE(data)>& rhs); \
-  template bool operator!=(const ZeroImpl<DIM(data), BCTYPE(data)>& lhs,  \
-                           const ZeroImpl<DIM(data), BCTYPE(data)>& rhs);
+#define INSTANTIATE(_, data) template class Zero<DIM(data), BCTYPE(data)>;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3),
                         (elliptic::BoundaryConditionType::Dirichlet,
@@ -80,4 +63,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3),
 #undef BCTYPE
 #undef INSTANTIATE
 
-}  // namespace Elasticity::BoundaryConditions::detail
+}  // namespace Elasticity::BoundaryConditions

--- a/src/Elliptic/Systems/Elasticity/FirstOrderSystem.hpp
+++ b/src/Elliptic/Systems/Elasticity/FirstOrderSystem.hpp
@@ -7,12 +7,8 @@
 
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
-#include "Elliptic/BoundaryConditions/AnalyticSolution.hpp"
 #include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
-#include "Elliptic/BoundaryConditions/BoundaryConditionType.hpp"
 #include "Elliptic/Protocols/FirstOrderSystem.hpp"
-#include "Elliptic/Systems/Elasticity/BoundaryConditions/LaserBeam.hpp"
-#include "Elliptic/Systems/Elasticity/BoundaryConditions/Zero.hpp"
 #include "Elliptic/Systems/Elasticity/Equations.hpp"
 #include "Elliptic/Systems/Elasticity/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
@@ -75,18 +71,6 @@ struct FirstOrderSystem
   using sources_computer = Sources<Dim>;
 
   using boundary_conditions_base =
-      elliptic::BoundaryConditions::BoundaryCondition<
-          Dim,
-          tmpl::append<
-              tmpl::list<elliptic::BoundaryConditions::Registrars::
-                             AnalyticSolution<FirstOrderSystem>,
-                         BoundaryConditions::Registrars::Zero<
-                             Dim, elliptic::BoundaryConditionType::Dirichlet>,
-                         BoundaryConditions::Registrars::Zero<
-                             Dim, elliptic::BoundaryConditionType::Neumann>>,
-              tmpl::conditional_t<
-                  Dim == 3,
-                  tmpl::list<BoundaryConditions::Registrars::LaserBeam>,
-                  tmpl::list<>>>>;
+      elliptic::BoundaryConditions::BoundaryCondition<Dim>;
 };
 }  // namespace Elasticity

--- a/src/Elliptic/Systems/Poisson/BoundaryConditions/CMakeLists.txt
+++ b/src/Elliptic/Systems/Poisson/BoundaryConditions/CMakeLists.txt
@@ -15,6 +15,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  Factory.hpp
   Robin.hpp
   )
 

--- a/src/Elliptic/Systems/Poisson/BoundaryConditions/Factory.hpp
+++ b/src/Elliptic/Systems/Poisson/BoundaryConditions/Factory.hpp
@@ -1,0 +1,17 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Elliptic/BoundaryConditions/AnalyticSolution.hpp"
+#include "Elliptic/Systems/Poisson/BoundaryConditions/Robin.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Poisson::BoundaryConditions {
+
+template <typename System>
+using standard_boundary_conditions =
+    tmpl::list<elliptic::BoundaryConditions::AnalyticSolution<System>,
+               Robin<System::volume_dim>>;
+
+}

--- a/src/Elliptic/Systems/Poisson/BoundaryConditions/Robin.hpp
+++ b/src/Elliptic/Systems/Poisson/BoundaryConditions/Robin.hpp
@@ -19,9 +19,16 @@ class DataVector;
 /// \endcond
 
 namespace Poisson::BoundaryConditions {
-namespace detail {
 
-struct RobinImpl {
+/// Impose Robin boundary conditions \f$a u + b n_i \nabla^i u = c\f$. The
+/// boundary condition is imposed as Neumann-type (i.e. on \f$n_i \nabla^i u\f$)
+/// if \f$|b| > 0\f$ and as Dirichlet-type (i.e. on \f$u\f$) if \f$b = 0\f$.
+template <size_t Dim>
+class Robin : public elliptic::BoundaryConditions::BoundaryCondition<Dim> {
+ private:
+  using Base = elliptic::BoundaryConditions::BoundaryCondition<Dim>;
+
+ public:
   static constexpr Options::String help =
       "Robin boundary conditions a * u + b * n_i grad(u)^i = c. The boundary "
       "condition is imposed as Neumann-type (i.e. on n_i grad(u)^i) if abs(b) "
@@ -44,19 +51,30 @@ struct RobinImpl {
 
   using options = tmpl::list<DirichletWeight, NeumannWeight, Constant>;
 
-  RobinImpl() = default;
-  RobinImpl(const RobinImpl&) = default;
-  RobinImpl& operator=(const RobinImpl&) = default;
-  RobinImpl(RobinImpl&&) = default;
-  RobinImpl& operator=(RobinImpl&&) = default;
-  ~RobinImpl() = default;
+  Robin() = default;
+  Robin(const Robin&) = default;
+  Robin& operator=(const Robin&) = default;
+  Robin(Robin&&) = default;
+  Robin& operator=(Robin&&) = default;
+  ~Robin() = default;
 
-  RobinImpl(double dirichlet_weight, double neumann_weight, double constant,
-            const Options::Context& context = {});
+  /// \cond
+  explicit Robin(CkMigrateMessage* m) : Base(m) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Robin);
+  /// \endcond
 
-  double dirichlet_weight() const;
-  double neumann_weight() const;
-  double constant() const;
+  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition> get_clone()
+      const override {
+    return std::make_unique<Robin>(*this);
+  }
+
+  Robin(double dirichlet_weight, double neumann_weight, double constant,
+        const Options::Context& context = {});
+
+  double dirichlet_weight() const { return dirichlet_weight_; }
+  double neumann_weight() const { return neumann_weight_; }
+  double constant() const { return constant_; }
 
   using argument_tags = tmpl::list<>;
   using volume_tags = tmpl::list<>;
@@ -71,7 +89,7 @@ struct RobinImpl {
       gsl::not_null<Scalar<DataVector>*> field_correction,
       gsl::not_null<Scalar<DataVector>*> n_dot_field_gradient_correction) const;
 
-  void pup(PUP::er& p);
+  void pup(PUP::er& p) override;
 
  private:
   double dirichlet_weight_ = std::numeric_limits<double>::signaling_NaN();
@@ -79,66 +97,10 @@ struct RobinImpl {
   double constant_ = std::numeric_limits<double>::signaling_NaN();
 };
 
-bool operator==(const RobinImpl& lhs, const RobinImpl& rhs);
-bool operator!=(const RobinImpl& lhs, const RobinImpl& rhs);
-
-}  // namespace detail
-
-// The following implements the registration and factory-creation mechanism
-
-/// \cond
-template <size_t Dim, typename Registrars>
-struct Robin;
-
-namespace Registrars {
 template <size_t Dim>
-struct Robin {
-  template <typename Registrars>
-  using f = BoundaryConditions::Robin<Dim, Registrars>;
-};
-}  // namespace Registrars
-/// \endcond
+bool operator==(const Robin<Dim>& lhs, const Robin<Dim>& rhs);
 
-/// Impose Robin boundary conditions \f$a u + b n_i \nabla^i u = c\f$. The
-/// boundary condition is imposed as Neumann-type (i.e. on \f$n_i \nabla^i u\f$)
-/// if \f$|b| > 0\f$ and as Dirichlet-type (i.e. on \f$u\f$) if \f$b = 0\f$.
-template <size_t Dim, typename Registrars = tmpl::list<Registrars::Robin<Dim>>>
-class Robin
-    : public elliptic::BoundaryConditions::BoundaryCondition<Dim, Registrars>,
-      public detail::RobinImpl {
- private:
-  using Base = elliptic::BoundaryConditions::BoundaryCondition<Dim, Registrars>;
-
- public:
-  Robin() = default;
-  Robin(const Robin&) = default;
-  Robin& operator=(const Robin&) = default;
-  Robin(Robin&&) = default;
-  Robin& operator=(Robin&&) = default;
-  ~Robin() = default;
-  using RobinImpl::RobinImpl;
-
-  /// \cond
-  explicit Robin(CkMigrateMessage* m) : Base(m) {}
-  using PUP::able::register_constructor;
-  WRAPPED_PUPable_decl_template(Robin);
-  /// \endcond
-
-  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition> get_clone()
-      const override {
-    return std::make_unique<Robin>(*this);
-  }
-
-  void pup(PUP::er& p) override {
-    Base::pup(p);
-    RobinImpl::pup(p);
-  }
-};
-
-/// \cond
-template <size_t Dim, typename Registrars>
-PUP::able::PUP_ID Robin<Dim,
-                        Registrars>::my_PUP_ID = 0;  // NOLINT
-/// \endcond
+template <size_t Dim>
+bool operator!=(const Robin<Dim>& lhs, const Robin<Dim>& rhs);
 
 }  // namespace Poisson::BoundaryConditions

--- a/src/Elliptic/Systems/Poisson/FirstOrderSystem.hpp
+++ b/src/Elliptic/Systems/Poisson/FirstOrderSystem.hpp
@@ -10,10 +10,8 @@
 
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
-#include "Elliptic/BoundaryConditions/AnalyticSolution.hpp"
 #include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
 #include "Elliptic/Protocols/FirstOrderSystem.hpp"
-#include "Elliptic/Systems/Poisson/BoundaryConditions/Robin.hpp"
 #include "Elliptic/Systems/Poisson/Equations.hpp"
 #include "Elliptic/Systems/Poisson/Geometry.hpp"
 #include "Elliptic/Systems/Poisson/Tags.hpp"
@@ -97,9 +95,6 @@ struct FirstOrderSystem
   using sources_computer = Sources<Dim, BackgroundGeometry>;
 
   using boundary_conditions_base =
-      elliptic::BoundaryConditions::BoundaryCondition<
-          Dim, tmpl::list<elliptic::BoundaryConditions::Registrars::
-                              AnalyticSolution<FirstOrderSystem>,
-                          Poisson::BoundaryConditions::Registrars::Robin<Dim>>>;
+      elliptic::BoundaryConditions::BoundaryCondition<Dim>;
 };
 }  // namespace Poisson

--- a/src/Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.cpp
+++ b/src/Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.cpp
@@ -24,10 +24,10 @@
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
 
-namespace Xcts::BoundaryConditions::detail {
+namespace Xcts::BoundaryConditions {
 
 template <Xcts::Geometry ConformalGeometry>
-ApparentHorizonImpl<ConformalGeometry>::ApparentHorizonImpl(
+ApparentHorizon<ConformalGeometry>::ApparentHorizon(
     std::array<double, 3> center, std::array<double, 3> rotation,
     std::optional<gr::Solutions::KerrSchild> kerr_solution_for_lapse,
     std::optional<gr::Solutions::KerrSchild>
@@ -267,7 +267,7 @@ void apparent_horizon_impl(
       get<::Tags::TempScalar<3>>(buffer);
   Scalar<DataVector>& beta_orthogonal = get<::Tags::TempScalar<1>>(buffer);
   if (kerr_solution_for_negative_expansion.has_value()) {
-    detail::negative_expansion_quantities(
+    negative_expansion_quantities(
         make_not_null(&expansion_of_solution), make_not_null(&beta_orthogonal),
         *kerr_solution_for_negative_expansion, x, face_normal,
         face_normal_magnitude, deriv_unnormalized_face_normal);
@@ -391,11 +391,11 @@ void linearized_apparent_horizon_impl(
     get<0>(x) -= center[0];
     get<1>(x) -= center[1];
     get<2>(x) -= center[2];
-    detail::negative_expansion_quantities(
-        make_not_null(&expansion_of_solution),
-        make_not_null(&beta_orthogonal_correction),
-        *kerr_solution_for_negative_expansion, x, face_normal,
-        face_normal_magnitude, deriv_unnormalized_face_normal);
+    negative_expansion_quantities(make_not_null(&expansion_of_solution),
+                                  make_not_null(&beta_orthogonal_correction),
+                                  *kerr_solution_for_negative_expansion, x,
+                                  face_normal, face_normal_magnitude,
+                                  deriv_unnormalized_face_normal);
   }
 
   tnsr::I<DataVector, 3>& face_normal_raised = get<::Tags::TempI<0, 3>>(buffer);
@@ -494,7 +494,7 @@ void linearized_apparent_horizon_impl(
 }
 
 template <Xcts::Geometry ConformalGeometry>
-void ApparentHorizonImpl<ConformalGeometry>::apply(
+void ApparentHorizon<ConformalGeometry>::apply(
     const gsl::not_null<Scalar<DataVector>*> conformal_factor,
     const gsl::not_null<Scalar<DataVector>*> lapse_times_conformal_factor,
     const gsl::not_null<tnsr::I<DataVector, 3>*> shift_excess,
@@ -522,7 +522,7 @@ void ApparentHorizonImpl<ConformalGeometry>::apply(
 }
 
 template <Xcts::Geometry ConformalGeometry>
-void ApparentHorizonImpl<ConformalGeometry>::apply(
+void ApparentHorizon<ConformalGeometry>::apply(
     const gsl::not_null<Scalar<DataVector>*> conformal_factor,
     const gsl::not_null<Scalar<DataVector>*> lapse_times_conformal_factor,
     const gsl::not_null<tnsr::I<DataVector, 3>*> shift_excess,
@@ -553,7 +553,7 @@ void ApparentHorizonImpl<ConformalGeometry>::apply(
 }
 
 template <Xcts::Geometry ConformalGeometry>
-void ApparentHorizonImpl<ConformalGeometry>::apply_linearized(
+void ApparentHorizon<ConformalGeometry>::apply_linearized(
     const gsl::not_null<Scalar<DataVector>*> conformal_factor_correction,
     const gsl::not_null<Scalar<DataVector>*>
         lapse_times_conformal_factor_correction,
@@ -586,7 +586,7 @@ void ApparentHorizonImpl<ConformalGeometry>::apply_linearized(
 }
 
 template <Xcts::Geometry ConformalGeometry>
-void ApparentHorizonImpl<ConformalGeometry>::apply_linearized(
+void ApparentHorizon<ConformalGeometry>::apply_linearized(
     const gsl::not_null<Scalar<DataVector>*> conformal_factor_correction,
     const gsl::not_null<Scalar<DataVector>*>
         lapse_times_conformal_factor_correction,
@@ -622,7 +622,7 @@ void ApparentHorizonImpl<ConformalGeometry>::apply_linearized(
 }
 
 template <Xcts::Geometry ConformalGeometry>
-void ApparentHorizonImpl<ConformalGeometry>::pup(PUP::er& p) {
+void ApparentHorizon<ConformalGeometry>::pup(PUP::er& p) {
   p | center_;
   p | rotation_;
   p | kerr_solution_for_lapse_;
@@ -630,8 +630,8 @@ void ApparentHorizonImpl<ConformalGeometry>::pup(PUP::er& p) {
 }
 
 template <Xcts::Geometry ConformalGeometry>
-bool operator==(const ApparentHorizonImpl<ConformalGeometry>& lhs,
-                const ApparentHorizonImpl<ConformalGeometry>& rhs) {
+bool operator==(const ApparentHorizon<ConformalGeometry>& lhs,
+                const ApparentHorizon<ConformalGeometry>& rhs) {
   return lhs.center() == rhs.center() and lhs.rotation() == rhs.rotation() and
          lhs.kerr_solution_for_lapse() == rhs.kerr_solution_for_lapse() and
          lhs.kerr_solution_for_negative_expansion() ==
@@ -639,24 +639,25 @@ bool operator==(const ApparentHorizonImpl<ConformalGeometry>& lhs,
 }
 
 template <Xcts::Geometry ConformalGeometry>
-bool operator!=(const ApparentHorizonImpl<ConformalGeometry>& lhs,
-                const ApparentHorizonImpl<ConformalGeometry>& rhs) {
+bool operator!=(const ApparentHorizon<ConformalGeometry>& lhs,
+                const ApparentHorizon<ConformalGeometry>& rhs) {
   return not(lhs == rhs);
 }
 
-template class ApparentHorizonImpl<Xcts::Geometry::FlatCartesian>;
-template class ApparentHorizonImpl<Xcts::Geometry::Curved>;
-template bool operator==(
-    const ApparentHorizonImpl<Xcts::Geometry::FlatCartesian>& lhs,
-    const ApparentHorizonImpl<Xcts::Geometry::FlatCartesian>& rhs);
-template bool operator!=(
-    const ApparentHorizonImpl<Xcts::Geometry::FlatCartesian>& lhs,
-    const ApparentHorizonImpl<Xcts::Geometry::FlatCartesian>& rhs);
-template bool operator==(
-    const ApparentHorizonImpl<Xcts::Geometry::Curved>& lhs,
-    const ApparentHorizonImpl<Xcts::Geometry::Curved>& rhs);
-template bool operator!=(
-    const ApparentHorizonImpl<Xcts::Geometry::Curved>& lhs,
-    const ApparentHorizonImpl<Xcts::Geometry::Curved>& rhs);
+template <Xcts::Geometry ConformalGeometry>
+PUP::able::PUP_ID ApparentHorizon<ConformalGeometry>::my_PUP_ID = 0;  // NOLINT
 
-}  // namespace Xcts::BoundaryConditions::detail
+template class ApparentHorizon<Xcts::Geometry::FlatCartesian>;
+template class ApparentHorizon<Xcts::Geometry::Curved>;
+template bool operator==(
+    const ApparentHorizon<Xcts::Geometry::FlatCartesian>& lhs,
+    const ApparentHorizon<Xcts::Geometry::FlatCartesian>& rhs);
+template bool operator!=(
+    const ApparentHorizon<Xcts::Geometry::FlatCartesian>& lhs,
+    const ApparentHorizon<Xcts::Geometry::FlatCartesian>& rhs);
+template bool operator==(const ApparentHorizon<Xcts::Geometry::Curved>& lhs,
+                         const ApparentHorizon<Xcts::Geometry::Curved>& rhs);
+template bool operator!=(const ApparentHorizon<Xcts::Geometry::Curved>& lhs,
+                         const ApparentHorizon<Xcts::Geometry::Curved>& rhs);
+
+}  // namespace Xcts::BoundaryConditions

--- a/src/Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.hpp
+++ b/src/Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.hpp
@@ -28,10 +28,78 @@ class DataVector;
 /// \endcond
 
 namespace Xcts::BoundaryConditions {
-namespace detail {
 
+/*!
+ * \brief Impose the surface is a quasi-equilibrium apparent horizon.
+ *
+ * These boundary conditions on the conformal factor \f$\psi\f$, the lapse
+ * \f$\alpha\f$ and the shift \f$\beta^i\f$ impose the surface is an apparent
+ * horizon, i.e. that the expansion on the surface vanishes: \f$\Theta=0\f$.
+ * Specifically, we impose:
+ *
+ * \f{align}
+ * \label{eq:ah_psi}
+ * \bar{s}^k\bar{D}_k\psi &= -\frac{\psi^3}{8\alpha}\bar{s}_i\bar{s}_j\left(
+ * (\bar{L}\beta)^{ij} - \bar{u}^{ij}\right)
+ * - \frac{\psi}{4}\bar{m}^{ij}\bar{\nabla}_i\bar{s}_j + \frac{1}{6}K\psi^3
+ * \\
+ * \label{eq:ah_beta}
+ * \beta_\mathrm{excess}^i &= \frac{\alpha}{\psi^2}\bar{s}^i
+ * + \epsilon_{ijk}\Omega^j x^k
+ * \f}
+ *
+ * following section 7.2 of \cite Pfeiffer2005zm, section 12.3.2 of
+ * \cite BaumgarteShapiro or section II.B.1 of \cite Varma2018sqd. In these
+ * equations \f$\bar{s}_i\f$ is the conformal surface normal to the apparent
+ * horizon, \f$\bar{m}^{ij}=\bar{\gamma}^{ij}-\bar{s}^i\bar{s}^j\f$ is the
+ * induced conformal surface metric (denoted \f$\tilde{h}^{ij}\f$ in
+ * \cite Pfeiffer2005zm and \cite Varma2018sqd) and \f$\bar{D}\f$ is the
+ * covariant derivative w.r.t. to the conformal metric \f$\bar{\gamma}_{ij}\f$.
+ * Note that e.g. in \cite Varma2018sqd Eq. (16) appears the surface-normal
+ * \f$s^i\f$, not the _conformal_ surface normal \f$\bar{s}^i = \psi^2 s^i\f$.
+ * To incur a spin on the apparent horizon we can freely choose the rotational
+ * parameters \f$\boldsymbol{\Omega}\f$. Note that for a Kerr solution with
+ * dimensionless spin \f$\boldsymbol{\chi}\f$ the rotational parameters at the
+ * outer horizon are \f$\boldsymbol{\Omega} =
+ * -\frac{\boldsymbol{\chi}}{2r_+}\f$, where \f$r_+ / M = 1 + \sqrt{1 -
+ * \chi^2}\f$ (see e.g. Eq. (8) in \cite Ossokine2015yla). \f$\epsilon_{ijk}\f$
+ * is the flat-space Levi-Civita symbol.
+ *
+ * Note that the quasi-equilibrium conditions don't restrict the boundary
+ * condition for the lapse. The choice for the lapse boundary condition is made
+ * by the `Lapse` input-file options. Currently implemented choices are:
+ * - A zero von-Neumann boundary condition:
+ *   \f$\bar{s}^k\bar{D}_k(\alpha\psi) = 0\f$
+ * - A Dirichlet boundary condition imposing the lapse of a Kerr-Schild analytic
+ *   solution.
+ *
+ * \par Negative-expansion boundary conditions:
+ * This class also supports negative-expansion boundary conditions following
+ * section II.B.2 of \cite Varma2018sqd by taking a Kerr solution as additional
+ * parameter and computing its expansion at the excision surface. Choosing an
+ * excision surface _within_ the apparent horizon of the Kerr solution will
+ * result in a negative expansion that is added to the boundary condition for
+ * the conformal factor. Therefore, the excision surface will lie within an
+ * apparent horizon. Specifically, we add the quantity
+ * \f$\frac{\psi^3}{4}\Theta_\mathrm{Kerr}\f$ to (\f$\ref{eq:ah_psi}\f$), where
+ * \f$\Theta_\mathrm{Kerr}\f$ is the expansion of the specified Kerr solution at
+ * the excision surface, and we add the quantity \f$\epsilon = s_i
+ * \beta_\mathrm{Kerr}^i - \alpha_\mathrm{Kerr}\f$ to the orthogonal part
+ * \f$s_i\beta_\mathrm{excess}^i\f$ of (\f$\ref{eq:ah_beta}\f$).
+ *
+ * \note When negative-expansion boundary conditions are selected, the Kerr
+ * solution gets evaluated at every boundary-condition application. This may
+ * turn out to incur a significant computational cost, in which case a future
+ * optimization might be to pre-compute the negative-expansion quantities at
+ * initialization time and store them in the DataBox.
+ */
 template <Xcts::Geometry ConformalGeometry>
-struct ApparentHorizonImpl {
+class ApparentHorizon
+    : public elliptic::BoundaryConditions::BoundaryCondition<3> {
+ private:
+  using Base = elliptic::BoundaryConditions::BoundaryCondition<3>;
+
+ public:
   static constexpr Options::String help =
       "Impose the boundary is a quasi-equilibrium apparent horizon.";
 
@@ -73,14 +141,25 @@ struct ApparentHorizonImpl {
 
   using options = tmpl::list<Center, Rotation, Lapse, NegativeExpansion>;
 
-  ApparentHorizonImpl() = default;
-  ApparentHorizonImpl(const ApparentHorizonImpl&) = default;
-  ApparentHorizonImpl& operator=(const ApparentHorizonImpl&) = default;
-  ApparentHorizonImpl(ApparentHorizonImpl&&) = default;
-  ApparentHorizonImpl& operator=(ApparentHorizonImpl&&) = default;
-  ~ApparentHorizonImpl() = default;
+  ApparentHorizon() = default;
+  ApparentHorizon(const ApparentHorizon&) = default;
+  ApparentHorizon& operator=(const ApparentHorizon&) = default;
+  ApparentHorizon(ApparentHorizon&&) = default;
+  ApparentHorizon& operator=(ApparentHorizon&&) = default;
+  ~ApparentHorizon() = default;
 
-  ApparentHorizonImpl(
+  /// \cond
+  explicit ApparentHorizon(CkMigrateMessage* m) : Base(m) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(ApparentHorizon);
+  /// \endcond
+
+  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition> get_clone()
+      const override {
+    return std::make_unique<ApparentHorizon>(*this);
+  }
+
+  ApparentHorizon(
       std::array<double, 3> center, std::array<double, 3> rotation,
       std::optional<gr::Solutions::KerrSchild> kerr_solution_for_lapse,
       std::optional<gr::Solutions::KerrSchild>
@@ -217,7 +296,7 @@ struct ApparentHorizonImpl {
       const tnsr::Ijj<DataVector, 3>& conformal_christoffel_second_kind) const;
 
   // NOLINTNEXTLINE(google-runtime-references)
-  void pup(PUP::er& p);
+  void pup(PUP::er& p) override;
 
  private:
   std::array<double, 3> center_ =
@@ -230,134 +309,11 @@ struct ApparentHorizonImpl {
 };
 
 template <Xcts::Geometry ConformalGeometry>
-bool operator==(const ApparentHorizonImpl<ConformalGeometry>& lhs,
-                const ApparentHorizonImpl<ConformalGeometry>& rhs);
+bool operator==(const ApparentHorizon<ConformalGeometry>& lhs,
+                const ApparentHorizon<ConformalGeometry>& rhs);
 
 template <Xcts::Geometry ConformalGeometry>
-bool operator!=(const ApparentHorizonImpl<ConformalGeometry>& lhs,
-                const ApparentHorizonImpl<ConformalGeometry>& rhs);
-
-}  // namespace detail
-
-// The following implements the registration and factory-creation mechanism
-
-/// \cond
-template <Xcts::Geometry ConformalGeometry, typename Registrars>
-struct ApparentHorizon;
-
-namespace Registrars {
-template <Xcts::Geometry ConformalGeometry>
-struct ApparentHorizon {
-  template <typename Registrars>
-  using f = BoundaryConditions::ApparentHorizon<ConformalGeometry, Registrars>;
-};
-}  // namespace Registrars
-/// \endcond
-
-/*!
- * \brief Impose the surface is a quasi-equilibrium apparent horizon.
- *
- * These boundary conditions on the conformal factor \f$\psi\f$, the lapse
- * \f$\alpha\f$ and the shift \f$\beta^i\f$ impose the surface is an apparent
- * horizon, i.e. that the expansion on the surface vanishes: \f$\Theta=0\f$.
- * Specifically, we impose:
- *
- * \f{align}
- * \label{eq:ah_psi}
- * \bar{s}^k\bar{D}_k\psi &= -\frac{\psi^3}{8\alpha}\bar{s}_i\bar{s}_j\left(
- * (\bar{L}\beta)^{ij} - \bar{u}^{ij}\right)
- * - \frac{\psi}{4}\bar{m}^{ij}\bar{\nabla}_i\bar{s}_j + \frac{1}{6}K\psi^3
- * \\
- * \label{eq:ah_beta}
- * \beta_\mathrm{excess}^i &= \frac{\alpha}{\psi^2}\bar{s}^i
- * + \epsilon_{ijk}\Omega^j x^k
- * \f}
- *
- * following section 7.2 of \cite Pfeiffer2005zm, section 12.3.2 of
- * \cite BaumgarteShapiro or section II.B.1 of \cite Varma2018sqd. In these
- * equations \f$\bar{s}_i\f$ is the conformal surface normal to the apparent
- * horizon, \f$\bar{m}^{ij}=\bar{\gamma}^{ij}-\bar{s}^i\bar{s}^j\f$ is the
- * induced conformal surface metric (denoted \f$\tilde{h}^{ij}\f$ in
- * \cite Pfeiffer2005zm and \cite Varma2018sqd) and \f$\bar{D}\f$ is the
- * covariant derivative w.r.t. to the conformal metric \f$\bar{\gamma}_{ij}\f$.
- * Note that e.g. in \cite Varma2018sqd Eq. (16) appears the surface-normal
- * \f$s^i\f$, not the _conformal_ surface normal \f$\bar{s}^i = \psi^2 s^i\f$.
- * To incur a spin on the apparent horizon we can freely choose the rotational
- * parameters \f$\boldsymbol{\Omega}\f$. Note that for a Kerr solution with
- * dimensionless spin \f$\boldsymbol{\chi}\f$ the rotational parameters at the
- * outer horizon are \f$\boldsymbol{\Omega} =
- * -\frac{\boldsymbol{\chi}}{2r_+}\f$, where \f$r_+ / M = 1 + \sqrt{1 -
- * \chi^2}\f$ (see e.g. Eq. (8) in \cite Ossokine2015yla). \f$\epsilon_{ijk}\f$
- * is the flat-space Levi-Civita symbol.
- *
- * Note that the quasi-equilibrium conditions don't restrict the boundary
- * condition for the lapse. The choice for the lapse boundary condition is made
- * by the `Lapse` input-file options. Currently implemented choices are:
- * - A zero von-Neumann boundary condition:
- *   \f$\bar{s}^k\bar{D}_k(\alpha\psi) = 0\f$
- * - A Dirichlet boundary condition imposing the lapse of a Kerr-Schild analytic
- *   solution.
- *
- * \par Negative-expansion boundary conditions:
- * This class also supports negative-expansion boundary conditions following
- * section II.B.2 of \cite Varma2018sqd by taking a Kerr solution as additional
- * parameter and computing its expansion at the excision surface. Choosing an
- * excision surface _within_ the apparent horizon of the Kerr solution will
- * result in a negative expansion that is added to the boundary condition for
- * the conformal factor. Therefore, the excision surface will lie within an
- * apparent horizon. Specifically, we add the quantity
- * \f$\frac{\psi^3}{4}\Theta_\mathrm{Kerr}\f$ to (\f$\ref{eq:ah_psi}\f$), where
- * \f$\Theta_\mathrm{Kerr}\f$ is the expansion of the specified Kerr solution at
- * the excision surface, and we add the quantity \f$\epsilon = s_i
- * \beta_\mathrm{Kerr}^i - \alpha_\mathrm{Kerr}\f$ to the orthogonal part
- * \f$s_i\beta_\mathrm{excess}^i\f$ of (\f$\ref{eq:ah_beta}\f$).
- *
- * \note When negative-expansion boundary conditions are selected, the Kerr
- * solution gets evaluated at every boundary-condition application. This may
- * turn out to incur a significant computational cost, in which case a future
- * optimization might be to pre-compute the negative-expansion quantities at
- * initialization time and store them in the DataBox.
- */
-template <Xcts::Geometry ConformalGeometry,
-          typename Registrars =
-              tmpl::list<Registrars::ApparentHorizon<ConformalGeometry>>>
-class ApparentHorizon
-    : public elliptic::BoundaryConditions::BoundaryCondition<3, Registrars>,
-      public detail::ApparentHorizonImpl<ConformalGeometry> {
- private:
-  using Base = elliptic::BoundaryConditions::BoundaryCondition<3, Registrars>;
-
- public:
-  ApparentHorizon() = default;
-  ApparentHorizon(const ApparentHorizon&) = default;
-  ApparentHorizon& operator=(const ApparentHorizon&) = default;
-  ApparentHorizon(ApparentHorizon&&) = default;
-  ApparentHorizon& operator=(ApparentHorizon&&) = default;
-  ~ApparentHorizon() = default;
-
-  using detail::ApparentHorizonImpl<ConformalGeometry>::ApparentHorizonImpl;
-
-  /// \cond
-  explicit ApparentHorizon(CkMigrateMessage* m) : Base(m) {}
-  using PUP::able::register_constructor;
-  WRAPPED_PUPable_decl_template(ApparentHorizon);
-  /// \endcond
-
-  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition> get_clone()
-      const override {
-    return std::make_unique<ApparentHorizon>(*this);
-  }
-
-  void pup(PUP::er& p) override {
-    Base::pup(p);
-    detail::ApparentHorizonImpl<ConformalGeometry>::pup(p);
-  }
-};
-
-/// \cond
-template <Xcts::Geometry ConformalGeometry, typename Registrars>
-PUP::able::PUP_ID ApparentHorizon<ConformalGeometry, Registrars>::my_PUP_ID =
-    0;  // NOLINT
-/// \endcond
+bool operator!=(const ApparentHorizon<ConformalGeometry>& lhs,
+                const ApparentHorizon<ConformalGeometry>& rhs);
 
 }  // namespace Xcts::BoundaryConditions

--- a/src/Elliptic/Systems/Xcts/BoundaryConditions/CMakeLists.txt
+++ b/src/Elliptic/Systems/Xcts/BoundaryConditions/CMakeLists.txt
@@ -17,6 +17,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ApparentHorizon.hpp
+  Factory.hpp
   Flatness.hpp
   )
 

--- a/src/Elliptic/Systems/Xcts/BoundaryConditions/Factory.hpp
+++ b/src/Elliptic/Systems/Xcts/BoundaryConditions/Factory.hpp
@@ -1,0 +1,18 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Elliptic/BoundaryConditions/AnalyticSolution.hpp"
+#include "Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.hpp"
+#include "Elliptic/Systems/Xcts/BoundaryConditions/Flatness.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Xcts::BoundaryConditions {
+
+template <typename System>
+using standard_boundary_conditions =
+    tmpl::list<elliptic::BoundaryConditions::AnalyticSolution<System>, Flatness,
+               ApparentHorizon<System::conformal_geometry>>;
+
+}

--- a/src/Elliptic/Systems/Xcts/BoundaryConditions/Flatness.cpp
+++ b/src/Elliptic/Systems/Xcts/BoundaryConditions/Flatness.cpp
@@ -10,16 +10,15 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/Gsl.hpp"
 
-namespace Xcts::BoundaryConditions::detail {
+namespace Xcts::BoundaryConditions {
 
-void FlatnessImpl::apply(
-    const gsl::not_null<Scalar<DataVector>*> conformal_factor,
-    const gsl::not_null<Scalar<DataVector>*>
-    /*n_dot_conformal_factor_gradient*/) {
+void Flatness::apply(const gsl::not_null<Scalar<DataVector>*> conformal_factor,
+                     const gsl::not_null<Scalar<DataVector>*>
+                     /*n_dot_conformal_factor_gradient*/) {
   get(*conformal_factor) = 1.;
 }
 
-void FlatnessImpl::apply(
+void Flatness::apply(
     const gsl::not_null<Scalar<DataVector>*> conformal_factor,
     const gsl::not_null<Scalar<DataVector>*> lapse_times_conformal_factor,
     const gsl::not_null<Scalar<DataVector>*>
@@ -30,7 +29,7 @@ void FlatnessImpl::apply(
   get(*lapse_times_conformal_factor) = 1.;
 }
 
-void FlatnessImpl::apply(
+void Flatness::apply(
     const gsl::not_null<Scalar<DataVector>*> conformal_factor,
     const gsl::not_null<Scalar<DataVector>*> lapse_times_conformal_factor,
     const gsl::not_null<tnsr::I<DataVector, 3>*> shift_excess,
@@ -45,14 +44,14 @@ void FlatnessImpl::apply(
   std::fill(shift_excess->begin(), shift_excess->end(), 0.);
 }
 
-void FlatnessImpl::apply_linearized(
+void Flatness::apply_linearized(
     const gsl::not_null<Scalar<DataVector>*> conformal_factor_correction,
     const gsl::not_null<Scalar<DataVector>*>
     /*n_dot_conformal_factor_gradient_correction*/) {
   get(*conformal_factor_correction) = 0.;
 }
 
-void FlatnessImpl::apply_linearized(
+void Flatness::apply_linearized(
     const gsl::not_null<Scalar<DataVector>*> conformal_factor_correction,
     const gsl::not_null<Scalar<DataVector>*>
         lapse_times_conformal_factor_correction,
@@ -64,7 +63,7 @@ void FlatnessImpl::apply_linearized(
   get(*lapse_times_conformal_factor_correction) = 0.;
 }
 
-void FlatnessImpl::apply_linearized(
+void Flatness::apply_linearized(
     const gsl::not_null<Scalar<DataVector>*> conformal_factor_correction,
     const gsl::not_null<Scalar<DataVector>*>
         lapse_times_conformal_factor_correction,
@@ -81,12 +80,14 @@ void FlatnessImpl::apply_linearized(
             0.);
 }
 
-bool operator==(const FlatnessImpl& /*lhs*/, const FlatnessImpl& /*rhs*/) {
+bool operator==(const Flatness& /*lhs*/, const Flatness& /*rhs*/) {
   return true;
 }
 
-bool operator!=(const FlatnessImpl& lhs, const FlatnessImpl& rhs) {
+bool operator!=(const Flatness& lhs, const Flatness& rhs) {
   return not(lhs == rhs);
 }
 
-}  // namespace Xcts::BoundaryConditions::detail
+PUP::able::PUP_ID Flatness::my_PUP_ID = 0;  // NOLINT
+
+}  // namespace Xcts::BoundaryConditions

--- a/src/Elliptic/Systems/Xcts/BoundaryConditions/Flatness.hpp
+++ b/src/Elliptic/Systems/Xcts/BoundaryConditions/Flatness.hpp
@@ -20,12 +20,43 @@ class DataVector;
 /// \endcond
 
 namespace Xcts::BoundaryConditions {
-namespace detail {
 
-struct FlatnessImpl {
+/*!
+ * \brief Impose flat spacetime at this boundary
+ *
+ * Impose \f$\psi=1\f$, \f$\alpha\psi=1\f$, \f$\beta_\mathrm{excess}^i=0\f$ on
+ * this boundary, where \f$\psi\f$ is the conformal factor, \f$\alpha\f$ is the
+ * lapse and \f$\beta_\mathrm{excess}^i=\beta^i-\beta_\mathrm{background}^i\f$
+ * is the shift excess (see `Xcts::Tags::ShiftExcess` for details on the split
+ * of the shift in background and excess). Note that this choice only truly
+ * represents flatness if the conformal background metric is flat.
+ */
+class Flatness : public elliptic::BoundaryConditions::BoundaryCondition<3> {
+ private:
+  using Base = elliptic::BoundaryConditions::BoundaryCondition<3>;
+
+ public:
   using options = tmpl::list<>;
   static constexpr Options::String help =
       "Impose flat spacetime at this boundary.";
+
+  Flatness() = default;
+  Flatness(const Flatness&) = default;
+  Flatness& operator=(const Flatness&) = default;
+  Flatness(Flatness&&) = default;
+  Flatness& operator=(Flatness&&) = default;
+  ~Flatness() = default;
+
+  /// \cond
+  explicit Flatness(CkMigrateMessage* m) : Base(m) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Flatness);
+  /// \endcond
+
+  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition> get_clone()
+      const override {
+    return std::make_unique<Flatness>(*this);
+  }
 
   using argument_tags = tmpl::list<>;
   using volume_tags = tmpl::list<>;
@@ -80,66 +111,8 @@ struct FlatnessImpl {
           n_dot_longitudinal_shift_excess_correction);
 };
 
-bool operator==(const FlatnessImpl& lhs, const FlatnessImpl& rhs);
+bool operator==(const Flatness& lhs, const Flatness& rhs);
 
-bool operator!=(const FlatnessImpl& lhs, const FlatnessImpl& rhs);
-
-}  // namespace detail
-
-// The following implements the registration and factory-creation mechanism
-
-/// \cond
-template <typename Registrars>
-struct Flatness;
-
-namespace Registrars {
-struct Flatness {
-  template <typename Registrars>
-  using f = BoundaryConditions::Flatness<Registrars>;
-};
-}  // namespace Registrars
-/// \endcond
-
-/*!
- * \brief Impose flat spacetime at this boundary
- *
- * Impose \f$\psi=1\f$, \f$\alpha\psi=1\f$, \f$\beta_\mathrm{excess}^i=0\f$ on
- * this boundary, where \f$\psi\f$ is the conformal factor, \f$\alpha\f$ is the
- * lapse and \f$\beta_\mathrm{excess}^i=\beta^i-\beta_\mathrm{background}^i\f$
- * is the shift excess (see `Xcts::Tags::ShiftExcess` for details on the split
- * of the shift in background and excess). Note that this choice only truly
- * represents flatness if the conformal background metric is flat.
- */
-template <typename Registrars = tmpl::list<Registrars::Flatness>>
-class Flatness
-    : public elliptic::BoundaryConditions::BoundaryCondition<3, Registrars>,
-      public detail::FlatnessImpl {
- private:
-  using Base = elliptic::BoundaryConditions::BoundaryCondition<3, Registrars>;
-
- public:
-  Flatness() = default;
-  Flatness(const Flatness&) = default;
-  Flatness& operator=(const Flatness&) = default;
-  Flatness(Flatness&&) = default;
-  Flatness& operator=(Flatness&&) = default;
-  ~Flatness() = default;
-
-  /// \cond
-  explicit Flatness(CkMigrateMessage* m) : Base(m) {}
-  using PUP::able::register_constructor;
-  WRAPPED_PUPable_decl_template(Flatness);
-  /// \endcond
-
-  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition> get_clone()
-      const override {
-    return std::make_unique<Flatness>(*this);
-  }
-};
-
-/// \cond
-template <typename Registrars>
-PUP::able::PUP_ID Flatness<Registrars>::my_PUP_ID = 0;  // NOLINT
-/// \endcond
+bool operator!=(const Flatness& lhs, const Flatness& rhs);
 
 }  // namespace Xcts::BoundaryConditions

--- a/src/Elliptic/Systems/Xcts/FirstOrderSystem.hpp
+++ b/src/Elliptic/Systems/Xcts/FirstOrderSystem.hpp
@@ -7,11 +7,8 @@
 
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
-#include "Elliptic/BoundaryConditions/AnalyticSolution.hpp"
 #include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
 #include "Elliptic/Protocols/FirstOrderSystem.hpp"
-#include "Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.hpp"
-#include "Elliptic/Systems/Xcts/BoundaryConditions/Flatness.hpp"
 #include "Elliptic/Systems/Xcts/FluxesAndSources.hpp"
 #include "Elliptic/Systems/Xcts/Geometry.hpp"
 #include "Elliptic/Systems/Xcts/Tags.hpp"
@@ -139,6 +136,11 @@ template <Equations EnabledEquations, Geometry ConformalGeometry,
           int ConformalMatterScale>
 struct FirstOrderSystem
     : tt::ConformsTo<elliptic::protocols::FirstOrderSystem> {
+ public:
+  static constexpr Equations enabled_equations = EnabledEquations;
+  static constexpr Geometry conformal_geometry = ConformalGeometry;
+  static constexpr int conformal_matter_scale = ConformalMatterScale;
+
  private:
   using conformal_factor = Tags::ConformalFactor<DataVector>;
   using conformal_factor_gradient =
@@ -267,12 +269,7 @@ struct FirstOrderSystem
                         ConformalMatterScale>;
 
   using boundary_conditions_base =
-      elliptic::BoundaryConditions::BoundaryCondition<
-          3, tmpl::list<elliptic::BoundaryConditions::Registrars::
-                            AnalyticSolution<FirstOrderSystem>,
-                        BoundaryConditions::Registrars::Flatness,
-                        BoundaryConditions::Registrars::ApparentHorizon<
-                            ConformalGeometry>>>;
+      elliptic::BoundaryConditions::BoundaryCondition<3>;
 };
 
 }  // namespace Xcts

--- a/tests/Unit/Elliptic/Systems/Elasticity/BoundaryConditions/Test_Zero.cpp
+++ b/tests/Unit/Elliptic/Systems/Elasticity/BoundaryConditions/Test_Zero.cpp
@@ -23,21 +23,14 @@ namespace Elasticity::BoundaryConditions {
 SPECTRE_TEST_CASE("Unit.Elasticity.BoundaryConditions.Zero",
                   "[Unit][Elliptic]") {
   // Test factory-creation
-  using registrar_fixed =
-      Registrars::Zero<2, elliptic::BoundaryConditionType::Dirichlet>;
-  using registrar_free =
-      Registrars::Zero<2, elliptic::BoundaryConditionType::Neumann>;
-  const auto created_fixed = TestHelpers::test_creation<
-      std::unique_ptr<elliptic::BoundaryConditions::BoundaryCondition<
-          2, tmpl::list<registrar_fixed>>>>("Fixed");
-  const auto created_free = TestHelpers::test_creation<
-      std::unique_ptr<elliptic::BoundaryConditions::BoundaryCondition<
-          2, tmpl::list<registrar_free>>>>("Free");
+  using Fixed = Zero<2, elliptic::BoundaryConditionType::Dirichlet>;
+  using Free = Zero<2, elliptic::BoundaryConditionType::Neumann>;
+  const auto created_fixed = TestHelpers::test_factory_creation<
+      elliptic::BoundaryConditions::BoundaryCondition<2>, Fixed>("Fixed");
+  const auto created_free = TestHelpers::test_factory_creation<
+      elliptic::BoundaryConditions::BoundaryCondition<2>, Free>("Free");
 
   // Test semantics
-  using Fixed =
-      typename registrar_fixed::template f<tmpl::list<registrar_fixed>>;
-  using Free = typename registrar_free::template f<tmpl::list<registrar_free>>;
   REQUIRE(dynamic_cast<const Fixed*>(created_fixed.get()) != nullptr);
   REQUIRE(dynamic_cast<const Free*>(created_free.get()) != nullptr);
   const auto& fixed = dynamic_cast<const Fixed&>(*created_fixed);
@@ -59,7 +52,7 @@ SPECTRE_TEST_CASE("Unit.Elasticity.BoundaryConditions.Zero",
                                         std::numeric_limits<double>::max()};
     tnsr::I<DataVector, 2> n_dot_minus_stress{
         3_st, std::numeric_limits<double>::max()};
-    elliptic::apply_boundary_condition<false>(
+    elliptic::apply_boundary_condition<false, void, tmpl::list<Fixed>>(
         fixed, box, Direction<2>::lower_xi(), make_not_null(&displacement),
         make_not_null(&n_dot_minus_stress));
     CHECK_ITERABLE_APPROX(get<0>(displacement), SINGLE_ARG(DataVector{3, 0.}));
@@ -71,7 +64,7 @@ SPECTRE_TEST_CASE("Unit.Elasticity.BoundaryConditions.Zero",
                                         std::numeric_limits<double>::max()};
     tnsr::I<DataVector, 2> n_dot_minus_stress{
         3_st, std::numeric_limits<double>::max()};
-    elliptic::apply_boundary_condition<true>(
+    elliptic::apply_boundary_condition<true, void, tmpl::list<Fixed>>(
         fixed, box, Direction<2>::lower_xi(), make_not_null(&displacement),
         make_not_null(&n_dot_minus_stress));
     CHECK_ITERABLE_APPROX(get<0>(displacement), SINGLE_ARG(DataVector{3, 0.}));
@@ -83,7 +76,7 @@ SPECTRE_TEST_CASE("Unit.Elasticity.BoundaryConditions.Zero",
                                         std::numeric_limits<double>::max()};
     tnsr::I<DataVector, 2> n_dot_minus_stress{
         3_st, std::numeric_limits<double>::max()};
-    elliptic::apply_boundary_condition<false>(
+    elliptic::apply_boundary_condition<false, void, tmpl::list<Free>>(
         free, box, Direction<2>::lower_xi(), make_not_null(&displacement),
         make_not_null(&n_dot_minus_stress));
     CHECK_ITERABLE_APPROX(get<0>(n_dot_minus_stress),
@@ -97,7 +90,7 @@ SPECTRE_TEST_CASE("Unit.Elasticity.BoundaryConditions.Zero",
                                         std::numeric_limits<double>::max()};
     tnsr::I<DataVector, 2> n_dot_minus_stress{
         3_st, std::numeric_limits<double>::max()};
-    elliptic::apply_boundary_condition<true>(
+    elliptic::apply_boundary_condition<true, void, tmpl::list<Free>>(
         free, box, Direction<2>::lower_xi(), make_not_null(&displacement),
         make_not_null(&n_dot_minus_stress));
     CHECK_ITERABLE_APPROX(get<0>(n_dot_minus_stress),

--- a/tests/Unit/Elliptic/Systems/Poisson/BoundaryConditions/Test_Robin.cpp
+++ b/tests/Unit/Elliptic/Systems/Poisson/BoundaryConditions/Test_Robin.cpp
@@ -32,7 +32,7 @@ void apply_dirichlet_boundary_condition(
   const auto box = db::create<db::AddSimpleTags<>>();
   auto n_dot_field_gradient = make_with_value<Scalar<DataVector>>(
       *field, std::numeric_limits<double>::signaling_NaN());
-  elliptic::apply_boundary_condition<Linearized>(
+  elliptic::apply_boundary_condition<Linearized, void, tmpl::list<Robin<1>>>(
       boundary_condition, box, Direction<1>::lower_xi(), field,
       make_not_null(&n_dot_field_gradient));
 }
@@ -43,7 +43,7 @@ void apply_neumann_boundary_condition(
     const double neumann_weight, const double constant) {
   const Robin<1> boundary_condition{dirichlet_weight, neumann_weight, constant};
   const auto box = db::create<db::AddSimpleTags<>>();
-  elliptic::apply_boundary_condition<Linearized>(
+  elliptic::apply_boundary_condition<Linearized, void, tmpl::list<Robin<1>>>(
       boundary_condition, box, Direction<1>::lower_xi(), make_not_null(&field),
       n_dot_field_gradient);
 }
@@ -52,9 +52,8 @@ void apply_neumann_boundary_condition(
 SPECTRE_TEST_CASE("Unit.Elasticity.BoundaryConditions.Robin",
                   "[Unit][Elliptic]") {
   // Test factory-creation
-  const auto created = TestHelpers::test_creation<
-      std::unique_ptr<elliptic::BoundaryConditions::BoundaryCondition<
-          1, tmpl::list<Registrars::Robin<1>>>>>(
+  const auto created = TestHelpers::test_factory_creation<
+      elliptic::BoundaryConditions::BoundaryCondition<1>, Robin<1>>(
       "Robin:\n"
       "  DirichletWeight: 2.\n"
       "  NeumannWeight: 3.\n"

--- a/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/Test_ApparentHorizon.cpp
+++ b/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/Test_ApparentHorizon.cpp
@@ -122,7 +122,8 @@ void apply_boundary_condition_impl(
           typename ApparentHorizon<ConformalGeometry>::volume_tags>>>(
       DirectionMap<3, std::decay_t<decltype(args)>>{
           {direction, std::move(args)}}...);
-  elliptic::apply_boundary_condition<Linearized>(
+  elliptic::apply_boundary_condition<
+      Linearized, void, tmpl::list<ApparentHorizon<ConformalGeometry>>>(
       boundary_condition, box, direction, make_not_null(&conformal_factor),
       make_not_null(&lapse_times_conformal_factor), shift_excess,
       n_dot_conformal_factor_gradient,
@@ -255,10 +256,9 @@ void test_creation(
         kerr_solution_for_negative_expansion,
     const std::string& option_string) {
   INFO("Test factory-creation");
-  const auto created = TestHelpers::test_creation<
-      std::unique_ptr<elliptic::BoundaryConditions::BoundaryCondition<
-          3, tmpl::list<Registrars::ApparentHorizon<Xcts::Geometry::Curved>>>>>(
-      option_string);
+  const auto created = TestHelpers::test_factory_creation<
+      elliptic::BoundaryConditions::BoundaryCondition<3>,
+      ApparentHorizon<Xcts::Geometry::Curved>>(option_string);
   REQUIRE(dynamic_cast<const ApparentHorizon<Xcts::Geometry::Curved>*>(
               created.get()) != nullptr);
   const auto& boundary_condition =

--- a/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/Test_Flatness.cpp
+++ b/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/Test_Flatness.cpp
@@ -25,7 +25,7 @@ namespace Xcts::BoundaryConditions {
 
 namespace {
 template <size_t EnabledEquations, bool Linearized>
-void test_flatness(const Flatness<>& boundary_condition) {
+void test_flatness(const Flatness& boundary_condition) {
   const size_t num_points = 3;
   const auto box = db::create<db::AddSimpleTags<>>();
   Scalar<DataVector> conformal_factor{
@@ -33,7 +33,7 @@ void test_flatness(const Flatness<>& boundary_condition) {
   Scalar<DataVector> n_dot_conformal_factor_gradient{
       num_points, std::numeric_limits<double>::signaling_NaN()};
   if constexpr (EnabledEquations == 1) {
-    elliptic::apply_boundary_condition<Linearized>(
+    elliptic::apply_boundary_condition<Linearized, void, tmpl::list<Flatness>>(
         boundary_condition, box, Direction<3>::lower_xi(),
         make_not_null(&conformal_factor),
         make_not_null(&n_dot_conformal_factor_gradient));
@@ -43,7 +43,8 @@ void test_flatness(const Flatness<>& boundary_condition) {
     Scalar<DataVector> n_dot_lapse_times_conformal_factor_gradient{
         num_points, std::numeric_limits<double>::signaling_NaN()};
     if constexpr (EnabledEquations == 2) {
-      elliptic::apply_boundary_condition<Linearized>(
+      elliptic::apply_boundary_condition<Linearized, void,
+                                         tmpl::list<Flatness>>(
           boundary_condition, box, Direction<3>::lower_xi(),
           make_not_null(&conformal_factor),
           make_not_null(&lapse_times_conformal_factor),
@@ -54,7 +55,8 @@ void test_flatness(const Flatness<>& boundary_condition) {
           num_points, std::numeric_limits<double>::signaling_NaN()};
       tnsr::I<DataVector, 3> n_dot_longitudinal_shift_excess{
           num_points, std::numeric_limits<double>::signaling_NaN()};
-      elliptic::apply_boundary_condition<Linearized>(
+      elliptic::apply_boundary_condition<Linearized, void,
+                                         tmpl::list<Flatness>>(
           boundary_condition, box, Direction<3>::lower_xi(),
           make_not_null(&conformal_factor),
           make_not_null(&lapse_times_conformal_factor),
@@ -75,11 +77,10 @@ void test_flatness(const Flatness<>& boundary_condition) {
 
 SPECTRE_TEST_CASE("Unit.Xcts.BoundaryConditions.Flatness", "[Unit][Elliptic]") {
   // Test factory-creation
-  const auto created = TestHelpers::test_creation<
-      std::unique_ptr<elliptic::BoundaryConditions::BoundaryCondition<
-          3, tmpl::list<Registrars::Flatness>>>>("Flatness");
-  REQUIRE(dynamic_cast<const Flatness<>*>(created.get()) != nullptr);
-  const auto& boundary_condition = dynamic_cast<const Flatness<>&>(*created);
+  const auto created = TestHelpers::test_factory_creation<
+      elliptic::BoundaryConditions::BoundaryCondition<3>, Flatness>("Flatness");
+  REQUIRE(dynamic_cast<const Flatness*>(created.get()) != nullptr);
+  const auto& boundary_condition = dynamic_cast<const Flatness&>(*created);
   {
     INFO("Semantics");
     test_serialization(boundary_condition);


### PR DESCRIPTION
## Proposed changes

List the available boundary conditions in `Metavariables::factory_creation` and remove all the registration code from the individual classes.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
