### PR TITLE
Add error in SetupLocalPythonEnvironment env if path doesn't exist

### DIFF
--- a/tests/Unit/Framework/SetupLocalPythonEnvironment.cpp
+++ b/tests/Unit/Framework/SetupLocalPythonEnvironment.cpp
@@ -19,6 +19,7 @@
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "Informer/InfoFromBuild.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/FileSystem.hpp"
 
 namespace pypp {
 SetupLocalPythonEnvironment::SetupLocalPythonEnvironment(
@@ -47,6 +48,14 @@ SetupLocalPythonEnvironment::SetupLocalPythonEnvironment(
       pypp::from_py_object<std::vector<std::string>>(pyob_old_paths);
   std::string new_path =
       unit_test_src_path()+cur_dir_relative_to_unit_test_path;
+  if (not file_system::check_if_dir_exists(new_path)) {
+    ERROR_NO_TRACE("Trying to add path '"
+                   << new_path
+                   << "' to the python environment during setup "
+                      "but this directory does not exist. Maybe "
+                      "you have a typo in your path?");
+  }
+
   for (const auto &p : old_paths) {
     new_path += ":";
     new_path += p;


### PR DESCRIPTION
## Proposed changes

Previously the error message was that the python module being called by pypp didn't exist, which was technically true but not helpful in tracking down the error.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
