### PR TITLE
Add void dimensionful_spin_magnitude free function to StrahlkorperGr.cpp

### DIFF
--- a/src/ApparentHorizons/StrahlkorperGr.cpp
+++ b/src/ApparentHorizons/StrahlkorperGr.cpp
@@ -731,8 +731,8 @@ Scalar<DataVector> spin_function(
 }
 
 template <typename Frame>
-double dimensionful_spin_magnitude(
-    const Scalar<DataVector>& ricci_scalar,
+void dimensionful_spin_magnitude(
+    const gsl::not_null<double*> result, const Scalar<DataVector>& ricci_scalar,
     const Scalar<DataVector>& spin_function,
     const tnsr::ii<DataVector, 3, Frame>& spatial_metric,
     const StrahlkorperTags::aliases::Jacobian<Frame>& tangents,
@@ -768,7 +768,22 @@ double dimensionful_spin_magnitude(
   const auto potentials =
       get_normalized_spin_potentials(smallest_eigenvectors, ylm, area_element);
 
-  return get_spin_magnitude(potentials, spin_function, area_element, ylm);
+  *result = get_spin_magnitude(potentials, spin_function, area_element, ylm);
+}
+
+template <typename Frame>
+double dimensionful_spin_magnitude(
+    const Scalar<DataVector>& ricci_scalar,
+
+    const Scalar<DataVector>& spin_function,
+    const tnsr::ii<DataVector, 3, Frame>& spatial_metric,
+    const StrahlkorperTags::aliases::Jacobian<Frame>& tangents,
+    const YlmSpherepack& ylm, const Scalar<DataVector>& area_element) {
+  double result{};
+  dimensionful_spin_magnitude(make_not_null(&result), ricci_scalar,
+                              spin_function, spatial_metric, tangents, ylm,
+                              area_element);
+  return result;
 }
 
 template <typename Frame>
@@ -966,6 +981,13 @@ double christodoulou_mass(const double dimensionful_spin_magnitude,
       const tnsr::I<DataVector, 3, FRAME(data)>& unit_normal_vector,        \
       const Scalar<DataVector>& area_element,                               \
       const tnsr::ii<DataVector, 3, FRAME(data)>& extrinsic_curvature);     \
+  template void StrahlkorperGr::dimensionful_spin_magnitude<FRAME(data)>(   \
+      const gsl::not_null<double*> result,                                  \
+      const Scalar<DataVector>& ricci_scalar,                               \
+      const Scalar<DataVector>& spin_function,                              \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& spatial_metric,           \
+      const StrahlkorperTags::aliases::Jacobian<FRAME(data)>& tangents,     \
+      const YlmSpherepack& ylm, const Scalar<DataVector>& area_element);    \
   template double StrahlkorperGr::dimensionful_spin_magnitude<FRAME(data)>( \
       const Scalar<DataVector>& ricci_scalar,                               \
       const Scalar<DataVector>& spin_function,                              \

--- a/src/ApparentHorizons/StrahlkorperGr.hpp
+++ b/src/ApparentHorizons/StrahlkorperGr.hpp
@@ -391,6 +391,15 @@ Scalar<DataVector> spin_function(
  * The argument `area_element`
  * can be computed via `StrahlkorperGr::area_element`.
  */
+
+template <typename Frame>
+void dimensionful_spin_magnitude(
+    gsl::not_null<double*> result, const Scalar<DataVector>& ricci_scalar,
+    const Scalar<DataVector>& spin_function,
+    const tnsr::ii<DataVector, 3, Frame>& spatial_metric,
+    const StrahlkorperTags::aliases::Jacobian<Frame>& tangents,
+    const YlmSpherepack& ylm, const Scalar<DataVector>& area_element);
+
 template <typename Frame>
 double dimensionful_spin_magnitude(
     const Scalar<DataVector>& ricci_scalar,

--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -751,8 +751,12 @@ struct DimensionfulSpinMagnitudeCompute : DimensionfulSpinMagnitude,
                                           db::ComputeTag {
   using base = DimensionfulSpinMagnitude;
   using return_type = double;
-  static constexpr auto function =
-      &StrahlkorperGr::dimensionful_spin_magnitude<Frame>;
+  static constexpr auto function = static_cast<void (*)(
+      const gsl::not_null<double*>, const Scalar<DataVector>&,
+      const Scalar<DataVector>&, const tnsr::ii<DataVector, 3, Frame>&,
+      const StrahlkorperTags::aliases::Jacobian<Frame>&, const YlmSpherepack&,
+      const Scalar<DataVector>&)>(
+      &StrahlkorperGr::dimensionful_spin_magnitude<Frame>);
   using argument_tags =
       tmpl::list<StrahlkorperTags::RicciScalar, SpinFunction,
                  gr::Tags::SpatialMetric<3, Frame>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
@@ -80,22 +80,24 @@ struct EvolutionMetavars<3, InitialData, BoundaryConditions>
                    gr::Tags::SpatialChristoffelSecondKind<volume_dim, frame>,
                    gr::Tags::SpatialRicci<volume_dim, frame>>;
     using compute_items_on_target = tmpl::append<
-        tmpl::list<StrahlkorperGr::Tags::AreaElementCompute<frame>,
-                   StrahlkorperTags::ThetaPhiCompute<frame>,
-                   StrahlkorperTags::RadiusCompute<frame>,
-                   StrahlkorperTags::RhatCompute<frame>,
-                   StrahlkorperTags::TangentsCompute<frame>,
-                   StrahlkorperTags::InvJacobianCompute<frame>,
-                   StrahlkorperTags::DxRadiusCompute<frame>,
-                   StrahlkorperTags::OneOverOneFormMagnitudeCompute<
-                       volume_dim, frame, DataVector>,
-                   StrahlkorperTags::NormalOneFormCompute<frame>,
-                   StrahlkorperTags::UnitNormalOneFormCompute<frame>,
-                   StrahlkorperTags::UnitNormalVectorCompute<frame>,
-                   StrahlkorperTags::GradUnitNormalOneFormCompute<frame>,
-                   StrahlkorperTags::ExtrinsicCurvatureCompute<frame>,
-                   StrahlkorperGr::Tags::SpinFunctionCompute<frame>,
-                   StrahlkorperTags::RicciScalarCompute<frame>>,
+        tmpl::list<
+            StrahlkorperGr::Tags::AreaElementCompute<frame>,
+            StrahlkorperTags::ThetaPhiCompute<frame>,
+            StrahlkorperTags::RadiusCompute<frame>,
+            StrahlkorperTags::RhatCompute<frame>,
+            StrahlkorperTags::TangentsCompute<frame>,
+            StrahlkorperTags::InvJacobianCompute<frame>,
+            StrahlkorperTags::DxRadiusCompute<frame>,
+            StrahlkorperTags::OneOverOneFormMagnitudeCompute<volume_dim, frame,
+                                                             DataVector>,
+            StrahlkorperTags::NormalOneFormCompute<frame>,
+            StrahlkorperTags::UnitNormalOneFormCompute<frame>,
+            StrahlkorperTags::UnitNormalVectorCompute<frame>,
+            StrahlkorperTags::GradUnitNormalOneFormCompute<frame>,
+            StrahlkorperTags::ExtrinsicCurvatureCompute<frame>,
+            StrahlkorperGr::Tags::SpinFunctionCompute<frame>,
+            StrahlkorperTags::RicciScalarCompute<frame>,
+            StrahlkorperGr::Tags::DimensionfulSpinMagnitudeCompute<frame>>,
         tags_to_observe>;
     using compute_target_points =
         intrp::TargetPoints::ApparentHorizon<AhA, ::Frame::Inertial>;

--- a/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
+++ b/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
@@ -694,8 +694,15 @@ void test_dimensionful_spin_magnitude(
   const double spin_magnitude = StrahlkorperGr::dimensionful_spin_magnitude(
       ricci_scalar, spin_function, spatial_metric, tangents, ylm, area_element);
 
+  double spin_magnitude_void = std::numeric_limits<double>::signaling_NaN();
+  StrahlkorperGr::dimensionful_spin_magnitude(
+      make_not_null(&spin_magnitude_void), ricci_scalar, spin_function,
+      spatial_metric, tangents, ylm, area_element);
+
   Approx custom_approx = Approx::custom().epsilon(tolerance).scale(1.0);
   CHECK_ITERABLE_CUSTOM_APPROX(spin_magnitude, expected, custom_approx);
+
+  CHECK_ITERABLE_CUSTOM_APPROX(spin_magnitude_void, expected, custom_approx);
 }
 
 template <typename Solution, typename Fr>


### PR DESCRIPTION
## Proposed changes

Adds the void `dimensionful_spin_magnitude` free function to `StrahlkorperGr.cpp`. Fixup the DimensionfulSpinMagnitude tag to take a `static constexpr auto function = static_cast<void` function in `Tags.hpp`. Adds a test for `dimensionful_spin_magnitude` in `Test_StrahlkorperGr.cpp`Add the DimensionfulSpinMagnitude to the `EvolveGeneralizedHarmonicWithHorizon.hpp`. 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
