### PR TITLE
Fix macOS arm64 linker errors

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.cpp
@@ -394,7 +394,9 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector), (true, false))
       tmpl::list<hydro::Tags::LorentzFactor<DTYPE(data)>> /*meta*/,          \
       const FishboneMoncriefDisk::IntermediateVariables<DTYPE(data), true>&  \
           vars,                                                              \
-      const size_t) const;
+      const size_t) const;                                                   \
+  template DTYPE(data) FishboneMoncriefDisk::potential(                      \
+      const DTYPE(data) & r_sqrd, const DTYPE(data) & sin_theta_sqrd) const;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
 

--- a/tests/Unit/Evolution/DgSubcell/Test_NeighborReconstructedFaceSolution.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_NeighborReconstructedFaceSolution.cpp
@@ -22,6 +22,7 @@
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Time/TimeStepId.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/StdHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace {

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
@@ -19,6 +19,7 @@
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CreateInitialElement.hpp"
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/Structure/Element.hpp"

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TimeDerivative.cpp
@@ -16,6 +16,7 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CreateInitialElement.hpp"
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/Structure/Element.hpp"


### PR DESCRIPTION
## Proposed changes

When building spectre on my new MacBook Pro (Apple Silicon), I got some linker errors. The changes in this PR eliminate those linker errors. I'm not sure why no one else has run into this; each of my changes looks to me like something that should have been there anyway.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
