### PR TITLE
Add Frame::Distorted to Domain

### DIFF
--- a/src/Domain/Domain.cpp
+++ b/src/Domain/Domain.cpp
@@ -102,13 +102,21 @@ void Domain<VolumeDim>::inject_time_dependent_map_for_block(
     const size_t block_id,
     std::unique_ptr<
         domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, VolumeDim>>
-        moving_mesh_inertial_map) {
+        moving_mesh_grid_to_inertial_map,
+    std::unique_ptr<
+        domain::CoordinateMapBase<Frame::Grid, Frame::Distorted, VolumeDim>>
+        moving_mesh_grid_to_distorted_map,
+    std::unique_ptr<
+        domain::CoordinateMapBase<Frame::Distorted, Frame::Inertial, VolumeDim>>
+        moving_mesh_distorted_to_inertial_map) {
   ASSERT(block_id < blocks_.size(),
          "The block id " << block_id
                          << " larger than the total number of blocks, "
                          << blocks_.size());
   blocks_[block_id].inject_time_dependent_map(
-      std::move(moving_mesh_inertial_map));
+      std::move(moving_mesh_grid_to_inertial_map),
+      std::move(moving_mesh_grid_to_distorted_map),
+      std::move(moving_mesh_distorted_to_inertial_map));
 }
 
 template <size_t VolumeDim>

--- a/src/Domain/Domain.hpp
+++ b/src/Domain/Domain.hpp
@@ -115,7 +115,13 @@ class Domain {
       size_t block_id,
       std::unique_ptr<
           domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, VolumeDim>>
-          moving_mesh_inertial_map);
+          moving_mesh_grid_to_inertial_map,
+      std::unique_ptr<
+          domain::CoordinateMapBase<Frame::Grid, Frame::Distorted, VolumeDim>>
+          moving_mesh_grid_to_distorted_map = nullptr,
+      std::unique_ptr<domain::CoordinateMapBase<Frame::Distorted,
+                                                Frame::Inertial, VolumeDim>>
+          moving_mesh_distorted_to_inertial_map = nullptr);
 
   const std::vector<Block<VolumeDim>>& blocks() const { return blocks_; }
 


### PR DESCRIPTION
## Proposed changes

The changes to Block in #3625 are carried over to the Domain class, meaning that the maps with `Frame::Distorted` can now be passed to Blocks at the Domain level.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
