### PR TITLE
Add TensorIndex n for TensorExpressions

### DIFF
--- a/src/DataStructures/Tensor/Expressions/TensorIndex.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorIndex.hpp
@@ -224,6 +224,12 @@ static constexpr TensorIndex<
 static constexpr TensorIndex<
     TensorExpressions::TensorIndex_detail::upper_spatial_sentinel + 4>
     ti_M{};
+static constexpr TensorIndex<
+    TensorExpressions::TensorIndex_detail::spatial_sentinel + 5>
+    ti_n{};
+static constexpr TensorIndex<
+    TensorExpressions::TensorIndex_detail::upper_spatial_sentinel + 5>
+    ti_N{};
 /// @}
 
 namespace tt {


### PR DESCRIPTION
## Proposed changes

This PR adds `TensorIndex`s `ti_N` and `ti_n` to support using the letter n as a generic spatial index in `TensorExpression` equations.

The motivation for this PR is the use of n as a tensor index in eq 14 in [this CCZ4 paper](https://arxiv.org/pdf/1707.09910.pdf), whose system is currently being implemented in SpECTRE.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
