### PR TITLE
Make Ccz4::divergence_lapse take square of conformal factor as arg

### DIFF
--- a/src/Evolution/Systems/Ccz4/DerivLapse.cpp
+++ b/src/Evolution/Systems/Ccz4/DerivLapse.cpp
@@ -50,10 +50,11 @@ tnsr::ij<DataType, Dim, Frame> grad_grad_lapse(
 template <size_t Dim, typename Frame, typename DataType>
 void divergence_lapse(
     const gsl::not_null<Scalar<DataType>*> result,
-    const Scalar<DataType>& conformal_factor,
+    const Scalar<DataType>& conformal_factor_squared,
     const tnsr::II<DataType, Dim, Frame>& inverse_conformal_metric,
     const tnsr::ij<DataType, Dim, Frame>& grad_grad_lapse) {
-  destructive_resize_components(result, get_size(get(conformal_factor)));
+  destructive_resize_components(result,
+                                get_size(get(conformal_factor_squared)));
 
   get(*result) = 0.0;
   for (size_t i = 0; i < Dim; ++i) {
@@ -62,16 +63,16 @@ void divergence_lapse(
           inverse_conformal_metric.get(i, j) * grad_grad_lapse.get(i, j);
     }
   }
-  get(*result) *= square(get(conformal_factor));
+  get(*result) *= get(conformal_factor_squared);
 }
 
 template <size_t Dim, typename Frame, typename DataType>
 Scalar<DataType> divergence_lapse(
-    const Scalar<DataType>& conformal_factor,
+    const Scalar<DataType>& conformal_factor_squared,
     const tnsr::II<DataType, Dim, Frame>& inverse_conformal_metric,
     const tnsr::ij<DataType, Dim, Frame>& grad_grad_lapse) {
   Scalar<DataType> result{};
-  divergence_lapse(make_not_null(&result), conformal_factor,
+  divergence_lapse(make_not_null(&result), conformal_factor_squared,
                    inverse_conformal_metric, grad_grad_lapse);
   return result;
 }
@@ -99,12 +100,12 @@ Scalar<DataType> divergence_lapse(
       const tnsr::ij<DTYPE(data), DIM(data), FRAME(data)>& d_field_a);       \
   template void Ccz4::divergence_lapse(                                      \
       const gsl::not_null<Scalar<DTYPE(data)>*> result,                      \
-      const Scalar<DTYPE(data)>& conformal_factor,                           \
+      const Scalar<DTYPE(data)>& conformal_factor_squared,                   \
       const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                   \
           inverse_conformal_metric,                                          \
       const tnsr::ij<DTYPE(data), DIM(data), FRAME(data)>& grad_grad_lapse); \
   template Scalar<DTYPE(data)> Ccz4::divergence_lapse(                       \
-      const Scalar<DTYPE(data)>& conformal_factor,                           \
+      const Scalar<DTYPE(data)>& conformal_factor_squared,                   \
       const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                   \
           inverse_conformal_metric,                                          \
       const tnsr::ij<DTYPE(data), DIM(data), FRAME(data)>& grad_grad_lapse);

--- a/src/Evolution/Systems/Ccz4/DerivLapse.hpp
+++ b/src/Evolution/Systems/Ccz4/DerivLapse.hpp
@@ -58,13 +58,13 @@ tnsr::ij<DataType, Dim, Frame> grad_grad_lapse(
 template <size_t Dim, typename Frame, typename DataType>
 void divergence_lapse(
     const gsl::not_null<Scalar<DataType>*> result,
-    const Scalar<DataType>& conformal_factor,
+    const Scalar<DataType>& conformal_factor_squared,
     const tnsr::II<DataType, Dim, Frame>& inverse_conformal_metric,
     const tnsr::ij<DataType, Dim, Frame>& grad_grad_lapse);
 
 template <size_t Dim, typename Frame, typename DataType>
 Scalar<DataType> divergence_lapse(
-    const Scalar<DataType>& conformal_factor,
+    const Scalar<DataType>& conformal_factor_squared,
     const tnsr::II<DataType, Dim, Frame>& inverse_conformal_metric,
     const tnsr::ij<DataType, Dim, Frame>& grad_grad_lapse);
 /// @}

--- a/tests/Unit/Evolution/Systems/Ccz4/DerivLapse.py
+++ b/tests/Unit/Evolution/Systems/Ccz4/DerivLapse.py
@@ -11,7 +11,7 @@ def grad_grad_lapse(lapse, christoffel_second_kind, field_a, d_field_a):
             (np.einsum("ij", d_field_a) + np.einsum("ij->ji", d_field_a)))
 
 
-def divergence_lapse(conformal_factor, inverse_conformal_metric,
+def divergence_lapse(conformal_factor_squared, inverse_conformal_metric,
                      grad_grad_lapse):
-    return (conformal_factor * conformal_factor *
+    return (conformal_factor_squared *
             np.einsum("ij,ij", inverse_conformal_metric, grad_grad_lapse))


### PR DESCRIPTION
## Proposed changes

This PR updates `Ccz4::divergence_lapse` to take the square of the conformal factor as an argument instead of the conformal factor.

The motivation for this PR is relevant to the implementation of the first order CCZ4 system described in [this paper](https://arxiv.org/pdf/1707.09910.pdf), where `\phi^2` repeatedly appears in eq 12 - 27, but `\phi` does not. i.e. In the future implementation of `Ccz4::TimeDerivative` (which computes eq. 12 - 27 and where calling `Ccz4::divergence_lapse` computes eq. 22), I expect that we will only need `\phi^2` and will not need `\phi`.
 
### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
