### PR TITLE
Add TOV solution in isotropic coords

### DIFF
--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.cpp
@@ -23,14 +23,14 @@
 #include "Utilities/MakeWithValue.hpp"
 
 namespace grmhd::AnalyticData {
-MagnetizedTovStar::MagnetizedTovStar(const double central_rest_mass_density,
-                                     const double polytropic_constant,
-                                     const double polytropic_exponent,
-                                     const size_t pressure_exponent,
-                                     const double cutoff_pressure_fraction,
-                                     const double vector_potential_amplitude)
+MagnetizedTovStar::MagnetizedTovStar(
+    const double central_rest_mass_density, const double polytropic_constant,
+    const double polytropic_exponent,
+    const gr::Solutions::TovCoordinates coordinate_system,
+    const size_t pressure_exponent, const double cutoff_pressure_fraction,
+    const double vector_potential_amplitude)
     : tov_star(central_rest_mass_density, polytropic_constant,
-               polytropic_exponent),
+               polytropic_exponent, coordinate_system),
       pressure_exponent_(pressure_exponent),
       cutoff_pressure_(cutoff_pressure_fraction *
                        get(equation_of_state().pressure_from_density(

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.hpp
@@ -222,8 +222,7 @@ class MagnetizedTovStar : public virtual evolution::initial_data::InitialData,
       tmpl::push_back<tov_star::options, PressureExponent,
                       CutoffPressureFraction, VectorPotentialAmplitude>;
 
-  static constexpr Options::String help = {
-      "Magnetized TOV star in areal coordinates."};
+  static constexpr Options::String help = {"Magnetized TOV star."};
 
   static constexpr size_t volume_dim = 3_st;
 
@@ -239,6 +238,7 @@ class MagnetizedTovStar : public virtual evolution::initial_data::InitialData,
 
   MagnetizedTovStar(double central_rest_mass_density,
                     double polytropic_constant, double polytropic_exponent,
+                    gr::Solutions::TovCoordinates coordinate_system,
                     size_t pressure_exponent, double cutoff_pressure_fraction,
                     double vector_potential_amplitude);
 

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Python/Tov.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Python/Tov.cpp
@@ -13,10 +13,14 @@ namespace py = pybind11;
 namespace gr::Solutions::py_bindings {
 
 void bind_tov(py::module& m) {  // NOLINT
+  py::enum_<TovCoordinates>(m, "TovCoordinates")
+      .value("Schwarzschild", TovCoordinates::Schwarzschild)
+      .value("Isotropic", TovCoordinates::Isotropic);
   py::class_<TovSolution>(m, "Tov")
       .def(py::init<const EquationsOfState::EquationOfState<true, 1>&, double,
-                    double, double, double>(),
+                    TovCoordinates, double, double, double>(),
            py::arg("equation_of_state"), py::arg("central_mass_density"),
+           py::arg("coordinate_system") = TovCoordinates::Schwarzschild,
            py::arg("log_enthalpy_at_outer_radius") = 0.,
            py::arg("absolute_tolerance") = 1.e-14,
            py::arg("relative_tolerance") = 1.e-14)
@@ -26,7 +30,9 @@ void bind_tov(py::module& m) {  // NOLINT
       .def("mass_over_radius",
            py::vectorize(&TovSolution::mass_over_radius<double>))
       .def("log_specific_enthalpy",
-           py::vectorize(&TovSolution::log_specific_enthalpy<double>));
+           py::vectorize(&TovSolution::log_specific_enthalpy<double>))
+      .def("conformal_factor",
+           py::vectorize(&TovSolution::conformal_factor<double>));
 }
 
 }  // namespace gr::Solutions::py_bindings

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Tov.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Tov.cpp
@@ -14,6 +14,8 @@
 #include <functional>
 #include <ostream>
 #include <pup.h>
+#include <string>
+#include <type_traits>
 #include <vector>
 
 #include "DataStructures/DataVector.hpp"
@@ -22,26 +24,55 @@
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-// IWYU pragma: no_include <boost/numeric/odeint/integrate/integrate_adaptive.hpp>
-// IWYU pragma: no_include <boost/numeric/odeint/stepper/controlled_runge_kutta.hpp>
-// IWYU pragma: no_include <boost/numeric/odeint/stepper/dense_output_runge_kutta.hpp>
-// IWYU pragma: no_include <boost/numeric/odeint/stepper/generation/make_dense_output.hpp>
-// IWYU pragma: no_include <boost/numeric/odeint/stepper/runge_kutta_dopri5.hpp>
-// IWYU pragma: no_include <complex>
+namespace gr::Solutions {
+std::ostream& operator<<(std::ostream& os, const TovCoordinates coords) {
+  switch (coords) {
+    case TovCoordinates::Schwarzschild:
+      return os << "Schwarzschild";
+    case TovCoordinates::Isotropic:
+      return os << "Isotropic";
+    default:
+      ERROR("Unknown TovCoordinates");
+  }
+}
+}  // namespace gr::Solutions
 
-// IWYU pragma: no_forward_declare boost::numeric::odeint::controlled_runge_kutta
-// IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
-// IWYU pragma: no_forward_declare Tensor
+template <>
+gr::Solutions::TovCoordinates
+Options::create_from_yaml<gr::Solutions::TovCoordinates>::create<void>(
+    const Options::Option& options) {
+  const auto type_read = options.parse_as<std::string>();
+  if ("Schwarzschild" == type_read) {
+    return gr::Solutions::TovCoordinates::Schwarzschild;
+  } else if ("Isotropic" == type_read) {
+    return gr::Solutions::TovCoordinates::Isotropic;
+  }
+  PARSE_ERROR(options.context(),
+              "Failed to convert '"
+                  << type_read
+                  << "' to gr::Solutions::TovCoordinates. Must be "
+                     "'Schwarzschild' or 'Isotropic'.");
+}
 
+namespace gr::Solutions {
 namespace {
 
+// In Schwarzschild coords we integrate u=r^2 and v=m/r (2 vars), and in
+// isotropic coords we also integrate w=ln(psi) (3 vars).
+template <TovCoordinates CoordSystem>
+using TovVars =
+    std::conditional_t<CoordSystem == TovCoordinates::Schwarzschild,
+                       std::array<double, 2>, std::array<double, 3>>;
+
+template <TovCoordinates CoordSystem>
 void lindblom_rhs(
-    const gsl::not_null<std::array<double, 2>*> dvars,
-    const std::array<double, 2>& vars, const double log_enthalpy,
+    const gsl::not_null<TovVars<CoordSystem>*> dvars,
+    const TovVars<CoordSystem>& vars, const double log_enthalpy,
     const EquationsOfState::EquationOfState<true, 1>& equation_of_state) {
   const double& radius_squared = vars[0];
   const double& mass_over_radius = vars[1];
@@ -61,75 +92,139 @@ void lindblom_rhs(
     d_radius_squared = -3.0 / (2.0 * M_PI * (energy_density + 3.0 * pressure));
     d_mass_over_radius =
         -2.0 * energy_density / (energy_density + 3.0 * pressure);
+    if constexpr (CoordSystem == TovCoordinates::Isotropic) {
+      double& d_log_conformal_factor = (*dvars)[2];
+      d_log_conformal_factor = -0.25 * d_mass_over_radius;
+    }
   } else {
-    const double common_factor =
-        (1.0 - 2.0 * mass_over_radius) /
-        (4.0 * M_PI * radius_squared * pressure + mass_over_radius);
+    const double one_minus_two_m_over_r = 1.0 - 2.0 * mass_over_radius;
+    const double denominator =
+        4.0 * M_PI * radius_squared * pressure + mass_over_radius;
+    const double common_factor = one_minus_two_m_over_r / denominator;
     d_radius_squared = -2.0 * radius_squared * common_factor;
     d_mass_over_radius =
         -(4.0 * M_PI * radius_squared * energy_density - mass_over_radius) *
         common_factor;
+    if constexpr (CoordSystem == TovCoordinates::Isotropic) {
+      double& d_log_conformal_factor = (*dvars)[2];
+      d_log_conformal_factor = sqrt(one_minus_two_m_over_r) /
+                               (1.0 + sqrt(one_minus_two_m_over_r)) *
+                               mass_over_radius / denominator;
+    }
   }
 }
 
-class Observer {
+template <TovCoordinates CoordSystem>
+class IntegralObserver {
  public:
-  void operator()(const std::array<double, 2>& vars,
+  void operator()(const TovVars<CoordSystem>& vars,
                   const double current_log_enthalpy) {
     radius.push_back(std::sqrt(vars[0]));
     mass_over_radius.push_back(vars[1]);
+    if constexpr (CoordSystem == TovCoordinates::Isotropic) {
+      conformal_factor.push_back(exp(vars[2]));
+    }
     log_enthalpy.push_back(current_log_enthalpy);
   }
   std::vector<double> radius;
   std::vector<double> mass_over_radius;
+  std::vector<double> conformal_factor;
   std::vector<double> log_enthalpy;
 };
 
 }  // namespace
 
-namespace gr::Solutions {
-
-TovSolution::TovSolution(
+template <TovCoordinates CoordSystem>
+void TovSolution::integrate(
     const EquationsOfState::EquationOfState<true, 1>& equation_of_state,
     const double central_mass_density,
     const double log_enthalpy_at_outer_radius, const double absolute_tolerance,
     const double relative_tolerance) {
-  std::array<double, 2> u_and_v = {{0.0, 0.0}};
-  std::array<double, 2> dudh_and_dvdh{};
+  using Vars = TovVars<CoordSystem>;
+  Vars vars{};
+  // Initial integration variables at the center of the star
+  vars[0] = 0.;  // u = r^2 = 0
+  vars[1] = 0.;  // v = m / r = 0
+  if constexpr (CoordSystem == TovCoordinates::Isotropic) {
+    vars[2] = 0.;  // w = ln(psi) = 0 (rescaled later)
+  }
+  Vars dvars{};
   const double central_log_enthalpy =
       std::log(get(equation_of_state.specific_enthalpy_from_density(
           Scalar<double>{central_mass_density})));
-  lindblom_rhs(&dudh_and_dvdh, u_and_v, central_log_enthalpy,
-               equation_of_state);
-  const double initial_step = -std::min(std::abs(1.0 / dudh_and_dvdh[0]),
-                                        std::abs(1.0 / dudh_and_dvdh[1]));
-  using StateDopri5 =
-      boost::numeric::odeint::runge_kutta_dopri5<std::array<double, 2>>;
+  lindblom_rhs<CoordSystem>(make_not_null(&dvars), vars, central_log_enthalpy,
+                            equation_of_state);
+  double initial_step =
+      -std::min(std::abs(1.0 / dvars[0]), std::abs(1.0 / dvars[1]));
+  if constexpr (CoordSystem == TovCoordinates::Isotropic) {
+    initial_step = -std::min(std::abs(initial_step), std::abs(1.0 / dvars[2]));
+  }
+  using StateDopri5 = boost::numeric::odeint::runge_kutta_dopri5<Vars>;
   boost::numeric::odeint::dense_output_runge_kutta<
       boost::numeric::odeint::controlled_runge_kutta<StateDopri5>>
       dopri5 = make_dense_output(absolute_tolerance, relative_tolerance,
                                  StateDopri5{});
-  Observer observer{};
+  IntegralObserver<CoordSystem> observer{};
   boost::numeric::odeint::integrate_adaptive(
       dopri5,
-      [&equation_of_state](const std::array<double, 2>& lindblom_u_and_v,
-                           std::array<double, 2>& lindblom_dudh_and_dvdh,
-                           const double lindblom_enthalpy) {
-        return lindblom_rhs(&lindblom_dudh_and_dvdh, lindblom_u_and_v,
-                            lindblom_enthalpy, equation_of_state);
+      [&equation_of_state](const Vars& local_vars, Vars& local_dvars,
+                           const double local_enthalpy) {
+        return lindblom_rhs<CoordSystem>(&local_dvars, local_vars,
+                                         local_enthalpy, equation_of_state);
       },
-      u_and_v, central_log_enthalpy, log_enthalpy_at_outer_radius, initial_step,
+      vars, central_log_enthalpy, log_enthalpy_at_outer_radius, initial_step,
       std::ref(observer));
   outer_radius_ = observer.radius.back();
   const double total_mass_over_radius = observer.mass_over_radius.back();
   total_mass_ = total_mass_over_radius * outer_radius_;
   injection_energy_ = sqrt(1. - 2. * total_mass_ / outer_radius_);
+
+  if constexpr (CoordSystem == TovCoordinates::Isotropic) {
+    // Transform outer radius to isotropic
+    const double outer_areal_radius = outer_radius_;
+    outer_radius_ = 0.5 * (outer_areal_radius - total_mass_ +
+                           sqrt(square(outer_areal_radius) -
+                                2. * total_mass_ * outer_areal_radius));
+
+    // Match conformal factor to exterior solution
+    const double outer_conformal_factor =
+        1.0 + 0.5 * total_mass_ / outer_radius_;
+    const double matching_constant =
+        outer_conformal_factor / observer.conformal_factor.back();
+    const size_t num_points = observer.radius.size();
+    for (size_t i = 0; i < num_points; ++i) {
+      observer.conformal_factor[i] *= matching_constant;
+      // Transform observed radius to isotropic, so we use the isotropic radius
+      // for all interpolations below
+      observer.radius[i] /= square(observer.conformal_factor[i]);
+    }
+    conformal_factor_interpolant_ = intrp::BarycentricRational(
+        observer.radius, observer.conformal_factor, 5);
+  }
+
   mass_over_radius_interpolant_ =
       intrp::BarycentricRational(observer.radius, observer.mass_over_radius, 5);
   // log_enthalpy(radius) is almost linear so an interpolant of order 3
   // maximizes precision
   log_enthalpy_interpolant_ =
       intrp::BarycentricRational(observer.radius, observer.log_enthalpy, 3);
+}
+
+TovSolution::TovSolution(
+    const EquationsOfState::EquationOfState<true, 1>& equation_of_state,
+    const double central_mass_density, const TovCoordinates coordinate_system,
+    const double log_enthalpy_at_outer_radius, const double absolute_tolerance,
+    const double relative_tolerance)
+    : coordinate_system_(coordinate_system) {
+  if (coordinate_system_ == TovCoordinates::Schwarzschild) {
+    integrate<TovCoordinates::Schwarzschild>(
+        equation_of_state, central_mass_density, log_enthalpy_at_outer_radius,
+        absolute_tolerance, relative_tolerance);
+  } else {
+    integrate<TovCoordinates::Isotropic>(
+        equation_of_state, central_mass_density, log_enthalpy_at_outer_radius,
+        absolute_tolerance, relative_tolerance);
+  }
 }
 
 template <typename DataType>
@@ -158,12 +253,29 @@ DataType TovSolution::log_specific_enthalpy(const DataType& r) const {
   return result;
 }
 
+template <typename DataType>
+DataType TovSolution::conformal_factor(const DataType& r) const {
+  ASSERT(coordinate_system_ == TovCoordinates::Isotropic,
+         "The conformal factor is computed only for isotropic coordinates.");
+  // Possible optimization: Support DataVector in intrp::BarycentricRational
+  auto result = make_with_value<DataType>(r, 0.);
+  for (size_t i = 0; i < get_size(r); ++i) {
+    ASSERT(
+        get_element(r, i) >= 0.0 and get_element(r, i) <= outer_radius_,
+        "Invalid radius: " << r << " not in [0.0, " << outer_radius_ << "]\n");
+    get_element(result, i) = conformal_factor_interpolant_(get_element(r, i));
+  }
+  return result;
+}
+
 void TovSolution::pup(PUP::er& p) {  // NOLINT
+  p | coordinate_system_;
   p | outer_radius_;
   p | total_mass_;
   p | injection_energy_;
   p | mass_over_radius_interpolant_;
   p | log_enthalpy_interpolant_;
+  p | conformal_factor_interpolant_;
 }
 
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
@@ -172,7 +284,9 @@ void TovSolution::pup(PUP::er& p) {  // NOLINT
   template DTYPE(data) TovSolution::mass_over_radius(const DTYPE(data) & r) \
       const;                                                                \
   template DTYPE(data)                                                      \
-      TovSolution::log_specific_enthalpy(const DTYPE(data) & r) const;
+      TovSolution::log_specific_enthalpy(const DTYPE(data) & r) const;      \
+  template DTYPE(data) TovSolution::conformal_factor(const DTYPE(data) & r) \
+      const;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
 

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Tov.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Tov.hpp
@@ -4,9 +4,12 @@
 #pragma once
 
 #include <limits>
+#include <ostream>
 
 #include "NumericalAlgorithms/Interpolation/BarycentricRational.hpp"
-#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"  // IWYU pragma: keep
+#include "Options/Options.hpp"
+#include "Options/ParseOptions.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 
 /// \cond
 namespace PUP {
@@ -14,34 +17,121 @@ class er;
 }  // namespace PUP
 /// \endcond
 
-// IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
-// IWYU pragma: no_forward_declare Tensor
+namespace gr::Solutions {
 
-namespace gr {
-namespace Solutions {
+/// Radial coordinate of a TOV solution.
+enum class TovCoordinates {
+  /// Areal radial coordinate, in which the exterior TOV solution coincides with
+  /// the Schwarzschild metric in standard Schwarzschild coordinates.
+  Schwarzschild,
+  /// Isotropic radial coordinate, in which the spatial metric is conformally
+  /// flat.
+  Isotropic
+};
+
+std::ostream& operator<<(std::ostream& os, TovCoordinates coords);
+
+}  // namespace gr::Solutions
+
+template <>
+struct Options::create_from_yaml<gr::Solutions::TovCoordinates> {
+  template <typename Metavariables>
+  static gr::Solutions::TovCoordinates create(const Options::Option& options) {
+    return create<void>(options);
+  }
+};
+
+template <>
+gr::Solutions::TovCoordinates
+Options::create_from_yaml<gr::Solutions::TovCoordinates>::create<void>(
+    const Options::Option& options);
+
+namespace gr::Solutions {
 
 /*!
  * \brief TOV solver based on Lindblom's method
  *
  * Uses Lindblom's method of integrating the TOV equations from
- * \cite Lindblom1998dp
+ * \cite Lindblom1998dp .
  *
- * Instead of integrating \f$m(r)\f$ and \f$p(r)\f$
- * (\f$r\f$=radius, \f$m\f$=mass, \f$p\f$=pressure)
- * Lindblom introduces the variables \f$u\f$ and \f$v\f$, with \f$u=r^{2}\f$ and
- * \f$v=m/r\f$.
- * The integration is then done with the log of the specific enthalpy
- * (\f$\mathrm{log}(h)\f$) as the independent variable.
+ * Instead of integrating the interior mass \f$m(r)\f$ and pressure \f$p(r)\f$,
+ * Lindblom introduces the variables \f$u=r^2\f$ and \f$v=m/r\f$. Then, the TOV
+ * equations are integrated with the log of the specific enthalpy as the
+ * independent variable, \f$\ln(h)\f$, from the center of the star where
+ * \f$h(r=0) = h_c\f$ to its surface \f$h(r=R) = 1\f$. The ODEs being solved are
+ * Eq. (A2) and (A3) in \cite Lindblom1998dp :
  *
- * Lindblom's paper simply labels the independent variable as \f$h\f$.
- * The \f$h\f$ in Lindblom's paper is NOT the specific enthalpy.
- * Rather, Lindblom's \f$h\f$ is in fact \f$\mathrm{log}(h)\f$.
+ * \f{align}
+ * \frac{\mathrm{d}u}{\mathrm{d}\ln{h}} &= \frac{-2u (1 - 2v)}{4\pi u p + v} \\
+ * \frac{\mathrm{d}v}{\mathrm{d}\ln{h}} &=
+ *   -(1 - 2v) \frac{4\pi u \rho - v}{4\pi u p + v}
+ * \f}
+ *
+ * Note that Lindblom's paper labels the independent variable as \f$h\f$.
+ * However the \f$h\f$ in Lindblom's paper is **not** the specific enthalpy but
+ * its logarithm, \f$\ln(h)\f$.
+ *
+ * The ODEs are solved numerically when this class is constructed, and the
+ * quantities \f$m(r)/r\f$ and \f$\ln(h)\f$ are interpolated and exposed as
+ * member functions. With these quantities the metric can be constructed as:
+ *
+ * \f{equation}
+ * \mathrm{d}s^2 = -\alpha^2 \mathrm{d}t^2 + (1 - 2m/r)^{-1} \mathrm{d}r^2
+ *   + r^2 \mathrm{d}\Omega^2
+ * \f}
+ *
+ * where the lapse is
+ *
+ * \f{equation}
+ * \alpha(r < R) = \mathcal{E} / h = \alpha(r=R) / h
+ * \text{,}
+ * \f}
+ *
+ * with the conserved `injection_energy()` \f$\mathcal{E}\f$, such that the
+ * lapse matches the exterior Schwarzschild solution:
+ *
+ * \f{equation}
+ * \alpha(r \geq R) = \sqrt{1 - \frac{2M}{r}}
+ * \f}
+ *
+ * \par Isotropic radial coordinate
+ * This class also supports transforming to an isotropic radial coordinate. When
+ * you pass `gr::Solutions::TovCoordinates::Isotropic` to the constructor, an
+ * additional ODE is integrated alongside the TOV equations to determine the
+ * conformal factor
+ *
+ * \f{equation}
+ * \psi^2 = \frac{r}{\bar{r}}
+ * \f}
+ *
+ * where \f$r\f$ is the areal (Schwarzschild) radius and \f$\bar{r}\f$ is the
+ * isotropic radius. The additional ODE is:
+ *
+ * \f{equation}
+ * \frac{\mathrm{d}\ln(\psi)}{\mathrm{d}\ln{h}} =
+ *   \frac{\sqrt{1 - 2v}}{1 + \sqrt{1 - 2v}} \frac{v}{4\pi u p + v}
+ * \f}
+ *
+ * In isotropic coordinates, the spatial metric is conformally flat:
+ *
+ * \f{equation}
+ * \mathrm{d}s^2 = -\alpha^2 \mathrm{d}t^2 + \psi^4 (\mathrm{d}\bar{r}^2 +
+ *   \bar{r}^2 \mathrm{d}\Omega^2)
+ * \f}
+ *
+ * When isotropic coordinates are selected, radii returned by member functions
+ * or taken as arguments are isotropic. An exception is `mass_over_radius()`,
+ * which always returns the quantity \f$m / r\f$ because that is the quantity
+ * stored internally and hence most numerically precise. See
+ * `mass_over_radius()` for details.
  */
 class TovSolution {
  public:
   TovSolution(
       const EquationsOfState::EquationOfState<true, 1>& equation_of_state,
-      double central_mass_density, double log_enthalpy_at_outer_radius = 0.0,
+      double central_mass_density,
+      const TovCoordinates coordinate_system = TovCoordinates::Schwarzschild,
+      double log_enthalpy_at_outer_radius = 0.0,
       double absolute_tolerance = 1.0e-14, double relative_tolerance = 1.0e-14);
 
   TovSolution() = default;
@@ -51,7 +141,15 @@ class TovSolution {
   TovSolution& operator=(TovSolution&& /*rhs*/) = default;
   ~TovSolution() = default;
 
+  /// The type of radial coordinate.
+  ///
+  /// \see gr::Solutions::TovCoordinates
+  TovCoordinates coordinate_system() const { return coordinate_system_; }
+
   /// \brief The outer radius of the solution.
+  ///
+  /// This is the outer radius in the specified `coordinate_system()`, i.e.,
+  /// areal or isotropic.
   ///
   /// \note This is the radius at which `log_specific_enthalpy` is equal
   /// to the value of `log_enthalpy_at_outer_radius` that was given when
@@ -89,8 +187,8 @@ class TovSolution {
    * \mathcal{E} = \alpha(r=R) = \sqrt{1 - 2M/R}
    * \f}
    *
-   * by evaluating the injection energy at the outer radius \f$R\f$, where
-   * \f$h=1\f$ and where we match the lapse to the outer Schwarzschild
+   * by evaluating the injection energy at the outer (areal) radius \f$R\f$,
+   * where \f$h=1\f$ and where we match the lapse to the outer Schwarzschild
    * solution. The conservation also implies
    *
    * \f{equation}
@@ -101,8 +199,18 @@ class TovSolution {
    */
   double injection_energy() const { return injection_energy_; }
 
-  /// \brief The mass inside the given radius over the radius
+  /// \brief The mass inside the given radius over the areal radius,
   /// \f$\frac{m(r)}{r}\f$
+  ///
+  /// The argument to this function is the radius in the `coordinate_system()`,
+  /// i.e., areal (Schwarzschild) or isotropic radius. The denominator \f$r\f$
+  /// in the return value is always the areal (Schwarzschild) radius. You can
+  /// use the conformal factor \f$\psi=\sqrt{r / \bar{r}}\f$ returned by the
+  /// `conformal_factor()` function to obtain the mass over the isotropic
+  /// radius, or the mass alone. The reason for this choice is that we represent
+  /// the solution internally as the mass over the areal radius, so this is the
+  /// most numerically precise quantity from which other quantities can be
+  /// derived.
   ///
   /// \note `r` should be non-negative and not greater than `outer_radius()`.
   template <typename DataType>
@@ -114,16 +222,34 @@ class TovSolution {
   template <typename DataType>
   DataType log_specific_enthalpy(const DataType& r) const;
 
+  /// \brief The conformal factor \f$\psi=\sqrt{r / \bar{r}}\f$.
+  ///
+  /// The conformal factor is computed only when the `coordinate_system()` is
+  /// `gr::Solution::TovCoordinates::Isotropic`. Otherwise, it is an error to
+  /// call this function.
+  ///
+  /// \note `r` should be non-negative and not greater than `outer_radius()`
+  template <typename DataType>
+  DataType conformal_factor(const DataType& r) const;
+
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p);
 
  private:
+  template <TovCoordinates CoordSystem>
+  void integrate(
+      const EquationsOfState::EquationOfState<true, 1>& equation_of_state,
+      const double central_mass_density,
+      const double log_enthalpy_at_outer_radius,
+      const double absolute_tolerance, const double relative_tolerance);
+
+  TovCoordinates coordinate_system_{};
   double outer_radius_{std::numeric_limits<double>::signaling_NaN()};
   double total_mass_{std::numeric_limits<double>::signaling_NaN()};
   double injection_energy_{std::numeric_limits<double>::signaling_NaN()};
   intrp::BarycentricRational mass_over_radius_interpolant_;
   intrp::BarycentricRational log_enthalpy_interpolant_;
+  intrp::BarycentricRational conformal_factor_interpolant_;
 };
 
-}  // namespace Solutions
-}  // namespace gr
+}  // namespace gr::Solutions

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -41,6 +41,7 @@ AnalyticSolution:
     CentralDensity: 1.28e-3
     PolytropicConstant: 100.0
     PolytropicExponent: 2.0
+    Coordinates: Schwarzschild
 
 VariableFixing:
   FixConservatives:

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_TovStar.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_TovStar.cpp
@@ -30,26 +30,7 @@
 namespace RelativisticEuler::Solutions {
 namespace {
 
-void test_create_from_options() {
-  const auto star = TestHelpers::test_creation<TovStar>(
-      "CentralDensity: 1.0e-5\n"
-      "PolytropicConstant: 0.001\n"
-      "PolytropicExponent: 1.4");
-  CHECK(star == TovStar{0.00001, 0.001, 1.4});
-}
-
-void test_move() {
-  TovStar star{1.e-4, 4.0, 2.5};
-  TovStar star_copy{1.e-4, 4.0, 2.5};
-  test_move_semantics(std::move(star), star_copy);  //  NOLINT
-}
-
-void test_serialize() {
-  TovStar star{1.e-3, 8.0, 2.0};
-  test_serialization(star);
-  Approx custom_approx = Approx::custom().epsilon(1.0e-08).scale(1.0);
-  CHECK(star.radial_solution().outer_radius() == custom_approx(3.4685521362));
-}
+using TovCoordinates = gr::Solutions::TovCoordinates;
 
 void verify_solution(const TovStar& solution, const std::array<double, 3>& x) {
   const std::array<double, 3> dx{{1.e-4, 1.e-4, 1.e-4}};
@@ -62,14 +43,7 @@ void verify_solution(const TovStar& solution, const std::array<double, 3>& x) {
                         1.e-4);
 }
 
-}  // namespace
-
-SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.RelEuler.Tov",
-                  "[Unit][PointwiseFunctions]") {
-  test_create_from_options();
-  test_serialize();
-  test_move();
-
+void test_tov_star(const TovCoordinates coord_system) {
   Parallel::register_classes_with_charm<
       RelativisticEuler::Solutions::TovStar>();
   const std::unique_ptr<evolution::initial_data::InitialData> option_solution =
@@ -79,15 +53,35 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.RelEuler.Tov",
           "TovStar:\n"
           "  CentralDensity: 1.0e-3\n"
           "  PolytropicConstant: 100.0\n"
-          "  PolytropicExponent: 2.0\n");
+          "  PolytropicExponent: 2.0\n"
+          "  Coordinates: " +
+          get_output(coord_system));
   const auto deserialized_option_solution =
       serialize_and_deserialize(option_solution);
   const auto& solution =
       dynamic_cast<const RelativisticEuler::Solutions::TovStar&>(
           *deserialized_option_solution);
+  {
+    INFO("Semantics");
+    CHECK(solution == TovStar{1.0e-3, 100.0, 2.0, coord_system});
+    test_copy_semantics(solution);
+    TovStar star_copy = solution;
+    test_move_semantics(std::move(star_copy), solution);
+    test_serialization(solution);
+  }
+  if (coord_system == TovCoordinates::Schwarzschild) {
+    INFO("Properties");
+    Approx custom_approx = Approx::custom().epsilon(1.0e-08).scale(1.0);
+    CHECK(solution.radial_solution().outer_radius() ==
+          custom_approx(10.0473500683));
+    // Check a second solution
+    TovStar second_solution{1.0e-3, 8.0, 2.0};
+    CHECK(second_solution.radial_solution().outer_radius() ==
+          custom_approx(3.4685521362));
+  }
 
-  const double radius_of_star = 10.04735006833273303;
-  CHECK(solution.radial_solution().outer_radius() == approx(radius_of_star));
+  // Check the solution numerically solves the GRMHD equations
+  const double radius_of_star = solution.radial_solution().outer_radius();
   verify_solution(solution, {{0.0, 0.0, 0.0}});
   verify_solution(solution, {{0.0, 0.0, 0.5 * radius_of_star}});
   verify_solution(solution, {{0.0, radius_of_star, 0.0}});
@@ -102,4 +96,11 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.RelEuler.Tov",
   verify_solution(solution, random_point);
 }
 
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.RelEuler.Tov",
+                  "[Unit][PointwiseFunctions]") {
+  test_tov_star(TovCoordinates::Schwarzschild);
+  test_tov_star(TovCoordinates::Isotropic);
+}
+
+}  // namespace
 }  // namespace RelativisticEuler::Solutions


### PR DESCRIPTION
## Proposed changes

Add the TOV solution in isotropic coordinates, which requires an additional ODE integration.

This PR depends on the following to be merged first (I opened it already to provide context):

- [x] #3686
- [x] #3703 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
