### PR TITLE
Separate CachedTempBuffer from computer

### DIFF
--- a/src/PointwiseFunctions/AnalyticData/Xcts/Binary.cpp
+++ b/src/PointwiseFunctions/AnalyticData/Xcts/Binary.cpp
@@ -80,19 +80,22 @@ void BinaryVariables<DataType>::operator()(
     const gsl::not_null<Cache*> cache,
     Tags::LongitudinalShiftBackgroundMinusDtConformalMetric<
         DataType, Dim, Frame::Inertial> /*meta*/) const {
-  const auto& shift_background =
-      cache->get_var(Tags::ShiftBackground<DataType, Dim, Frame::Inertial>{});
+  const auto& shift_background = cache->get_var(
+      *this, Tags::ShiftBackground<DataType, Dim, Frame::Inertial>{});
   const auto& deriv_shift_background = cache->get_var(
+      *this,
       ::Tags::deriv<Tags::ShiftBackground<DataType, Dim, Frame::Inertial>,
                     tmpl::size_t<Dim>, Frame::Inertial>{});
-  const auto& conformal_metric =
-      cache->get_var(Tags::ConformalMetric<DataType, Dim, Frame::Inertial>{});
+  const auto& conformal_metric = cache->get_var(
+      *this, Tags::ConformalMetric<DataType, Dim, Frame::Inertial>{});
   const auto& inv_conformal_metric = cache->get_var(
-      Tags::InverseConformalMetric<DataType, Dim, Frame::Inertial>{});
+      *this, Tags::InverseConformalMetric<DataType, Dim, Frame::Inertial>{});
   const auto& deriv_conformal_metric = cache->get_var(
+      *this,
       ::Tags::deriv<Tags::ConformalMetric<DataType, Dim, Frame::Inertial>,
                     tmpl::size_t<Dim>, Frame::Inertial>{});
   const auto& conformal_christoffel_first_kind = cache->get_var(
+      *this,
       Tags::ConformalChristoffelFirstKind<DataType, Dim, Frame::Inertial>{});
   auto shift_background_strain =
       make_with_value<tnsr::ii<DataType, Dim>>(x, 0.);

--- a/src/PointwiseFunctions/AnalyticData/Xcts/Binary.hpp
+++ b/src/PointwiseFunctions/AnalyticData/Xcts/Binary.hpp
@@ -39,11 +39,7 @@ namespace Xcts::AnalyticData {
 namespace detail {
 
 template <typename DataType>
-struct BinaryVariables;
-
-template <typename DataType>
 using BinaryVariablesCache = cached_temp_buffer_from_typelist<
-    BinaryVariables<DataType>,
     tmpl::push_front<
         common_tags<DataType>,
         ::Tags::deriv<Tags::ShiftBackground<DataType, 3, Frame::Inertial>,
@@ -419,13 +415,18 @@ class Binary : public ::AnalyticData<3, Registrars> {
               ->variables(gsl::at(x_isolated, i), requested_superposed_tags{});
     }
     auto flat_vars = flatness_.variables(x, requested_superposed_tags{});
-    typename VarsComputer::Cache cache{
-        get_size(*x.begin()),
-        VarsComputer{std::move(mesh), std::move(inv_jacobian), x,
-                     angular_velocity_, expansion_, falloff_widths_,
-                     std::move(x_isolated), std::move(windows),
-                     std::move(flat_vars), std::move(isolated_vars)}};
-    return {cache.get_var(RequestedTags{})...};
+    typename VarsComputer::Cache cache{get_size(*x.begin())};
+    const VarsComputer computer{std::move(mesh),
+                                std::move(inv_jacobian),
+                                x,
+                                angular_velocity_,
+                                expansion_,
+                                falloff_widths_,
+                                std::move(x_isolated),
+                                std::move(windows),
+                                std::move(flat_vars),
+                                std::move(isolated_vars)};
+    return {cache.get_var(computer, RequestedTags{})...};
   }
 };
 

--- a/src/PointwiseFunctions/AnalyticData/Xcts/CommonVariables.tpp
+++ b/src/PointwiseFunctions/AnalyticData/Xcts/CommonVariables.tpp
@@ -37,8 +37,8 @@ void CommonVariables<DataType, Cache>::operator()(
     const gsl::not_null<Cache*> cache,
     Tags::InverseConformalMetric<DataType, Dim, Frame::Inertial> /*meta*/)
     const {
-  const auto& conformal_metric =
-      cache->get_var(Tags::ConformalMetric<DataType, Dim, Frame::Inertial>{});
+  const auto& conformal_metric = cache->get_var(
+      *this, Tags::ConformalMetric<DataType, Dim, Frame::Inertial>{});
   Scalar<DataType> unused_det{get_size(*conformal_metric.begin())};
   determinant_and_inverse(make_not_null(&unused_det), inv_conformal_metric,
                           conformal_metric);
@@ -49,11 +49,11 @@ void CommonVariables<DataType, Cache>::operator()(
     const gsl::not_null<tnsr::ijj<DataType, Dim>*>
         conformal_christoffel_first_kind,
     const gsl::not_null<Cache*> cache,
-    Tags::ConformalChristoffelFirstKind<
-        DataType, Dim, Frame::Inertial> /*meta*/) const {
+    Tags::ConformalChristoffelFirstKind<DataType, Dim,
+                                        Frame::Inertial> /*meta*/) const {
   const auto& deriv_conformal_metric = cache->get_var(
-      ::Tags::deriv<Tags::ConformalMetric<DataType, 3, Frame::Inertial>,
-                    tmpl::size_t<3>, Frame::Inertial>{});
+      *this, ::Tags::deriv<Tags::ConformalMetric<DataType, 3, Frame::Inertial>,
+                           tmpl::size_t<3>, Frame::Inertial>{});
   gr::christoffel_first_kind(conformal_christoffel_first_kind,
                              deriv_conformal_metric);
 }
@@ -63,12 +63,13 @@ void CommonVariables<DataType, Cache>::operator()(
     const gsl::not_null<tnsr::Ijj<DataType, Dim>*>
         conformal_christoffel_second_kind,
     const gsl::not_null<Cache*> cache,
-    Tags::ConformalChristoffelSecondKind<
-        DataType, Dim, Frame::Inertial> /*meta*/) const {
+    Tags::ConformalChristoffelSecondKind<DataType, Dim,
+                                         Frame::Inertial> /*meta*/) const {
   const auto& conformal_christoffel_first_kind = cache->get_var(
+      *this,
       Tags::ConformalChristoffelFirstKind<DataType, Dim, Frame::Inertial>{});
   const auto& inv_conformal_metric = cache->get_var(
-      Tags::InverseConformalMetric<DataType, 3, Frame::Inertial>{});
+      *this, Tags::InverseConformalMetric<DataType, 3, Frame::Inertial>{});
   raise_or_lower_first_index(conformal_christoffel_second_kind,
                              conformal_christoffel_first_kind,
                              inv_conformal_metric);
@@ -79,9 +80,10 @@ void CommonVariables<DataType, Cache>::operator()(
     const gsl::not_null<tnsr::i<DataType, Dim>*>
         conformal_christoffel_contracted,
     const gsl::not_null<Cache*> cache,
-    Tags::ConformalChristoffelContracted<
-        DataType, Dim, Frame::Inertial> /*meta*/) const {
+    Tags::ConformalChristoffelContracted<DataType, Dim,
+                                         Frame::Inertial> /*meta*/) const {
   const auto& conformal_christoffel_second_kind = cache->get_var(
+      *this,
       Tags::ConformalChristoffelSecondKind<DataType, Dim, Frame::Inertial>{});
   for (size_t i = 0; i < Dim; ++i) {
     conformal_christoffel_contracted->get(i) =
@@ -98,8 +100,7 @@ void CommonVariables<DataType, Cache>::operator()(
     const gsl::not_null<Scalar<DataType>*>
         fixed_source_for_hamiltonian_constraint,
     const gsl::not_null<Cache*> /*cache*/,
-    ::Tags::FixedSource<Tags::ConformalFactor<DataType>> /*meta*/)
-    const {
+    ::Tags::FixedSource<Tags::ConformalFactor<DataType>> /*meta*/) const {
   std::fill(fixed_source_for_hamiltonian_constraint->begin(),
             fixed_source_for_hamiltonian_constraint->end(), 0.);
 }
@@ -119,8 +120,7 @@ void CommonVariables<DataType, Cache>::operator()(
     const gsl::not_null<tnsr::I<DataType, 3>*> fixed_source_momentum_constraint,
     const gsl::not_null<Cache*> /*cache*/,
     ::Tags::FixedSource<
-        Tags::ShiftExcess<DataType, 3, Frame::Inertial>> /*meta*/)
-    const {
+        Tags::ShiftExcess<DataType, 3, Frame::Inertial>> /*meta*/) const {
   std::fill(fixed_source_momentum_constraint->begin(),
             fixed_source_momentum_constraint->end(), 0.);
 }
@@ -148,7 +148,7 @@ void CommonVariables<DataType, Cache>::operator()(
     using tag =
         Tags::ConformalChristoffelSecondKind<DataType, Dim, Frame::Inertial>;
     Variables<tmpl::list<tag>> vars{mesh->get().number_of_grid_points()};
-    get<tag>(vars) = cache->get_var(tag{});
+    get<tag>(vars) = cache->get_var(*this, tag{});
     const auto derivs = partial_derivatives<tmpl::list<tag>>(
         vars, mesh->get(), inv_jacobian->get());
     *deriv_conformal_christoffel_second_kind =
@@ -169,11 +169,12 @@ template <typename DataType, typename Cache>
 void CommonVariables<DataType, Cache>::operator()(
     const gsl::not_null<tnsr::ii<DataType, Dim>*> conformal_ricci_tensor,
     const gsl::not_null<Cache*> cache,
-    Tags::ConformalRicciTensor<DataType, Dim, Frame::Inertial> /*meta*/)
-    const {
+    Tags::ConformalRicciTensor<DataType, Dim, Frame::Inertial> /*meta*/) const {
   const auto& conformal_christoffel_second_kind = cache->get_var(
+      *this,
       Tags::ConformalChristoffelSecondKind<DataType, Dim, Frame::Inertial>{});
   const auto& deriv_conformal_christoffel_second_kind = cache->get_var(
+      *this,
       ::Tags::deriv<
           Tags::ConformalChristoffelSecondKind<DataType, Dim, Frame::Inertial>,
           tmpl::size_t<Dim>, Frame::Inertial>{});
@@ -187,9 +188,9 @@ void CommonVariables<DataType, Cache>::operator()(
     const gsl::not_null<Cache*> cache,
     Tags::ConformalRicciScalar<DataType> /*meta*/) const {
   const auto& conformal_ricci_tensor = cache->get_var(
-      Tags::ConformalRicciTensor<DataType, Dim, Frame::Inertial>{});
+      *this, Tags::ConformalRicciTensor<DataType, Dim, Frame::Inertial>{});
   const auto& inv_conformal_metric = cache->get_var(
-      Tags::InverseConformalMetric<DataType, Dim, Frame::Inertial>{});
+      *this, Tags::InverseConformalMetric<DataType, Dim, Frame::Inertial>{});
   trace(conformal_ricci_scalar, conformal_ricci_tensor, inv_conformal_metric);
 }
 
@@ -214,7 +215,7 @@ void CommonVariables<DataType, Cache>::operator()(
     // optimization here.
     using tag = gr::Tags::TraceExtrinsicCurvature<DataType>;
     Variables<tmpl::list<tag>> vars{mesh->get().number_of_grid_points()};
-    get<tag>(vars) = cache->get_var(tag{});
+    get<tag>(vars) = cache->get_var(*this, tag{});
     const auto derivs = partial_derivatives<tmpl::list<tag>>(
         vars, mesh->get(), inv_jacobian->get());
     *deriv_extrinsic_curvature_trace =
@@ -245,7 +246,7 @@ void CommonVariables<DataType, Cache>::operator()(
     using tag = Tags::LongitudinalShiftBackgroundMinusDtConformalMetric<
         DataType, Dim, Frame::Inertial>;
     Variables<tmpl::list<tag>> vars{mesh->get().number_of_grid_points()};
-    get<tag>(vars) = cache->get_var(tag{});
+    get<tag>(vars) = cache->get_var(*this, tag{});
     const auto derivs = divergence(vars, mesh->get(), inv_jacobian->get());
     *div_longitudinal_shift_background = get<::Tags::div<tag>>(derivs);
   } else {

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.hpp
@@ -24,10 +24,10 @@ namespace Elasticity::Solutions {
 namespace detail {
 template <typename DataType>
 struct BentBeamVariables {
-  using Cache = CachedTempBuffer<BentBeamVariables, Tags::Displacement<2>,
-                                 Tags::Strain<2>, Tags::MinusStress<2>,
-                                 Tags::PotentialEnergyDensity<2>,
-                                 ::Tags::FixedSource<Tags::Displacement<2>>>;
+  using Cache =
+      CachedTempBuffer<Tags::Displacement<2>, Tags::Strain<2>,
+                       Tags::MinusStress<2>, Tags::PotentialEnergyDensity<2>,
+                       ::Tags::FixedSource<Tags::Displacement<2>>>;
 
   const tnsr::I<DataType, 2>& x;
   const double length;
@@ -183,10 +183,10 @@ class BentBeam : public AnalyticSolution<2, Registrars> {
       const tnsr::I<DataType, 2>& x,
       tmpl::list<RequestedTags...> /*meta*/) const {
     using VarsComputer = detail::BentBeamVariables<DataType>;
-    typename VarsComputer::Cache cache{
-        get_size(*x.begin()), VarsComputer{x, length_, height_, bending_moment_,
-                                           constitutive_relation_}};
-    return {cache.get_var(RequestedTags{})...};
+    typename VarsComputer::Cache cache{get_size(*x.begin())};
+    const VarsComputer computer{x, length_, height_, bending_moment_,
+                                constitutive_relation_};
+    return {cache.get_var(computer, RequestedTags{})...};
   }
 
   // clang-tidy: no pass by reference

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.cpp
@@ -79,7 +79,7 @@ void HalfSpaceMirrorVariables<DataType>::operator()(
   const double shear_modulus = constitutive_relation.shear_modulus();
   const double lame_parameter = constitutive_relation.lame_parameter();
   const auto radius = sqrt(square(get<0>(x)) + square(get<1>(x)));
-  const auto& displacement_r = get(cache->get_var(DisplacementR{}));
+  const auto& displacement_r = get(cache->get_var(*this, DisplacementR{}));
 
   const integration::GslQuadAdaptive<
       integration::GslIntegralType::UpperBoundaryInfinite>
@@ -128,7 +128,7 @@ void HalfSpaceMirrorVariables<DataType>::operator()(
   const double shear_modulus = constitutive_relation.shear_modulus();
   const double lame_parameter = constitutive_relation.lame_parameter();
   const auto radius = sqrt(square(get<0>(x)) + square(get<1>(x)));
-  const auto& displacement_r = get(cache->get_var(DisplacementR{}));
+  const auto& displacement_r = get(cache->get_var(*this, DisplacementR{}));
 
   const integration::GslQuadAdaptive<
       integration::GslIntegralType::UpperBoundaryInfinite>
@@ -208,7 +208,7 @@ template <typename DataType>
 void HalfSpaceMirrorVariables<DataType>::operator()(
     const gsl::not_null<tnsr::II<DataType, 3>*> minus_stress,
     const gsl::not_null<Cache*> cache, Tags::MinusStress<3> /*meta*/) const {
-  const auto& strain = cache->get_var(Tags::Strain<3>{});
+  const auto& strain = cache->get_var(*this, Tags::Strain<3>{});
   constitutive_relation.stress(minus_stress, strain, x);
   for (auto& component : *minus_stress) {
     component *= -1.;
@@ -220,7 +220,7 @@ void HalfSpaceMirrorVariables<DataType>::operator()(
     const gsl::not_null<Scalar<DataType>*> potential_energy_density,
     const gsl::not_null<Cache*> cache,
     Tags::PotentialEnergyDensity<3> /*meta*/) const {
-  const auto& strain = cache->get_var(Tags::Strain<3>{});
+  const auto& strain = cache->get_var(*this, Tags::Strain<3>{});
   Elasticity::potential_energy_density(potential_energy_density, strain, x,
                                        constitutive_relation);
 }

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.hpp
@@ -30,8 +30,7 @@ struct HalfSpaceMirrorVariables {
     using type = Scalar<DataType>;
   };
   using Cache =
-      CachedTempBuffer<HalfSpaceMirrorVariables, DisplacementR,
-                       Tags::Displacement<3>, Tags::Strain<3>,
+      CachedTempBuffer<DisplacementR, Tags::Displacement<3>, Tags::Strain<3>,
                        Tags::MinusStress<3>, Tags::PotentialEnergyDensity<3>,
                        ::Tags::FixedSource<Tags::Displacement<3>>>;
 
@@ -222,12 +221,14 @@ class HalfSpaceMirror : public AnalyticSolution<3, Registrars> {
       }
     }
     using VarsComputer = detail::HalfSpaceMirrorVariables<DataType>;
-    typename VarsComputer::Cache cache{
-        get_size(*x.begin()),
-        VarsComputer{x, beam_width_, constitutive_relation_,
-                     integration_intervals_, absolute_tolerance_,
-                     relative_tolerance_}};
-    return {cache.get_var(RequestedTags{})...};
+    typename VarsComputer::Cache cache{get_size(*x.begin())};
+    const VarsComputer computer{x,
+                                beam_width_,
+                                constitutive_relation_,
+                                integration_intervals_,
+                                absolute_tolerance_,
+                                relative_tolerance_};
+    return {cache.get_var(computer, RequestedTags{})...};
   }
 
   // clang-tidy: no pass by reference

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.cpp
@@ -51,9 +51,8 @@ void KerrSchild::pup(PUP::er& p) {
 
 template <typename DataType, typename Frame>
 KerrSchild::IntermediateComputer<DataType, Frame>::IntermediateComputer(
-    const KerrSchild& solution, const tnsr::I<DataType, 3, Frame>& x,
-    const double null_vector_0)
-    : solution_(solution), x_(x), null_vector_0_(null_vector_0) {}
+    const KerrSchild& solution, const tnsr::I<DataType, 3, Frame>& x)
+    : solution_(solution), x_(x) {}
 
 template <typename DataType, typename Frame>
 void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
@@ -72,7 +71,7 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<CachedBuffer*> cache,
     internal_tags::a_dot_x<DataType> /*meta*/) const {
   const auto& x_minus_center =
-      cache->get_var(internal_tags::x_minus_center<DataType, Frame>{});
+      cache->get_var(*this, internal_tags::x_minus_center<DataType, Frame>{});
 
   const auto spin_a = solution_.dimensionless_spin() * solution_.mass();
   get(*a_dot_x) = spin_a[0] * get<0>(x_minus_center) +
@@ -85,7 +84,8 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<Scalar<DataType>*> a_dot_x_squared,
     const gsl::not_null<CachedBuffer*> cache,
     internal_tags::a_dot_x_squared<DataType> /*meta*/) const {
-  const auto& a_dot_x = get(cache->get_var(internal_tags::a_dot_x<DataType>{}));
+  const auto& a_dot_x =
+      get(cache->get_var(*this, internal_tags::a_dot_x<DataType>{}));
 
   get(*a_dot_x_squared) = square(a_dot_x);
 }
@@ -96,7 +96,7 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<CachedBuffer*> cache,
     internal_tags::half_xsq_minus_asq<DataType> /*meta*/) const {
   const auto& x_minus_center =
-      cache->get_var(internal_tags::x_minus_center<DataType, Frame>{});
+      cache->get_var(*this, internal_tags::x_minus_center<DataType, Frame>{});
 
   const auto spin_a = solution_.dimensionless_spin() * solution_.mass();
   const auto a_squared =
@@ -113,9 +113,9 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<CachedBuffer*> cache,
     internal_tags::r_squared<DataType> /*meta*/) const {
   const auto& half_xsq_minus_asq =
-      get(cache->get_var(internal_tags::half_xsq_minus_asq<DataType>{}));
+      get(cache->get_var(*this, internal_tags::half_xsq_minus_asq<DataType>{}));
   const auto& a_dot_x_squared =
-      get(cache->get_var(internal_tags::a_dot_x_squared<DataType>{}));
+      get(cache->get_var(*this, internal_tags::a_dot_x_squared<DataType>{}));
 
   get(*r_squared) =
       half_xsq_minus_asq + sqrt(square(half_xsq_minus_asq) + a_dot_x_squared);
@@ -127,7 +127,7 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<CachedBuffer*> cache,
     internal_tags::r<DataType> /*meta*/) const {
   const auto& r_squared =
-      get(cache->get_var(internal_tags::r_squared<DataType>{}));
+      get(cache->get_var(*this, internal_tags::r_squared<DataType>{}));
 
   get(*r) = sqrt(r_squared);
 }
@@ -137,9 +137,10 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<Scalar<DataType>*> a_dot_x_over_rsquared,
     const gsl::not_null<CachedBuffer*> cache,
     internal_tags::a_dot_x_over_rsquared<DataType> /*meta*/) const {
-  const auto& a_dot_x = get(cache->get_var(internal_tags::a_dot_x<DataType>{}));
+  const auto& a_dot_x =
+      get(cache->get_var(*this, internal_tags::a_dot_x<DataType>{}));
   const auto& r_squared =
-      get(cache->get_var(internal_tags::r_squared<DataType>{}));
+      get(cache->get_var(*this, internal_tags::r_squared<DataType>{}));
 
   get(*a_dot_x_over_rsquared) = a_dot_x / r_squared;
 }
@@ -150,9 +151,9 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<CachedBuffer*> cache,
     internal_tags::deriv_log_r_denom<DataType> /*meta*/) const {
   const auto& r_squared =
-      get(cache->get_var(internal_tags::r_squared<DataType>{}));
+      get(cache->get_var(*this, internal_tags::r_squared<DataType>{}));
   const auto& half_xsq_minus_asq =
-      get(cache->get_var(internal_tags::half_xsq_minus_asq<DataType>{}));
+      get(cache->get_var(*this, internal_tags::half_xsq_minus_asq<DataType>{}));
 
   get(*deriv_log_r_denom) = 0.5 / (r_squared - half_xsq_minus_asq);
 }
@@ -163,11 +164,11 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<CachedBuffer*> cache,
     internal_tags::deriv_log_r<DataType, Frame> /*meta*/) const {
   const auto& x_minus_center =
-      cache->get_var(internal_tags::x_minus_center<DataType, Frame>{});
-  const auto& a_dot_x_over_rsquared =
-      get(cache->get_var(internal_tags::a_dot_x_over_rsquared<DataType>{}));
+      cache->get_var(*this, internal_tags::x_minus_center<DataType, Frame>{});
+  const auto& a_dot_x_over_rsquared = get(
+      cache->get_var(*this, internal_tags::a_dot_x_over_rsquared<DataType>{}));
   const auto& deriv_log_r_denom =
-      get(cache->get_var(internal_tags::deriv_log_r_denom<DataType>{}));
+      get(cache->get_var(*this, internal_tags::deriv_log_r_denom<DataType>{}));
 
   const auto spin_a = solution_.dimensionless_spin() * solution_.mass();
   for (size_t i = 0; i < 3; ++i) {
@@ -183,9 +184,9 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<CachedBuffer*> cache,
     internal_tags::H_denom<DataType> /*meta*/) const {
   const auto& r_squared =
-      get(cache->get_var(internal_tags::r_squared<DataType>{}));
+      get(cache->get_var(*this, internal_tags::r_squared<DataType>{}));
   const auto& a_dot_x_squared =
-      get(cache->get_var(internal_tags::a_dot_x_squared<DataType>{}));
+      get(cache->get_var(*this, internal_tags::a_dot_x_squared<DataType>{}));
 
   get(*H_denom) = 1.0 / (square(r_squared) + a_dot_x_squared);
 }
@@ -195,10 +196,11 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<Scalar<DataType>*> H,
     const gsl::not_null<CachedBuffer*> cache,
     internal_tags::H<DataType> /*meta*/) const {
-  const auto& r = get(cache->get_var(internal_tags::r<DataType>{}));
+  const auto& r = get(cache->get_var(*this, internal_tags::r<DataType>{}));
   const auto& r_squared =
-      get(cache->get_var(internal_tags::r_squared<DataType>{}));
-  const auto& H_denom = get(cache->get_var(internal_tags::H_denom<DataType>{}));
+      get(cache->get_var(*this, internal_tags::r_squared<DataType>{}));
+  const auto& H_denom =
+      get(cache->get_var(*this, internal_tags::H_denom<DataType>{}));
 
   get(*H) = solution_.mass() * r * r_squared * H_denom;
 }
@@ -208,10 +210,11 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<Scalar<DataType>*> deriv_H_temp1,
     const gsl::not_null<CachedBuffer*> cache,
     internal_tags::deriv_H_temp1<DataType> /*meta*/) const {
-  const auto& H = get(cache->get_var(internal_tags::H<DataType>{}));
+  const auto& H = get(cache->get_var(*this, internal_tags::H<DataType>{}));
   const auto& r_squared =
-      get(cache->get_var(internal_tags::r_squared<DataType>{}));
-  const auto& H_denom = get(cache->get_var(internal_tags::H_denom<DataType>{}));
+      get(cache->get_var(*this, internal_tags::r_squared<DataType>{}));
+  const auto& H_denom =
+      get(cache->get_var(*this, internal_tags::H_denom<DataType>{}));
 
   get(*deriv_H_temp1) = H * (3.0 - 4.0 * square(r_squared) * H_denom);
 }
@@ -221,9 +224,11 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<Scalar<DataType>*> deriv_H_temp2,
     const gsl::not_null<CachedBuffer*> cache,
     internal_tags::deriv_H_temp2<DataType> /*meta*/) const {
-  const auto& H = get(cache->get_var(internal_tags::H<DataType>{}));
-  const auto& H_denom = get(cache->get_var(internal_tags::H_denom<DataType>{}));
-  const auto& a_dot_x = get(cache->get_var(internal_tags::a_dot_x<DataType>{}));
+  const auto& H = get(cache->get_var(*this, internal_tags::H<DataType>{}));
+  const auto& H_denom =
+      get(cache->get_var(*this, internal_tags::H_denom<DataType>{}));
+  const auto& a_dot_x =
+      get(cache->get_var(*this, internal_tags::a_dot_x<DataType>{}));
 
   get(*deriv_H_temp2) = H * (2.0 * H_denom * a_dot_x);
 }
@@ -234,11 +239,11 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<CachedBuffer*> cache,
     internal_tags::deriv_H<DataType, Frame> /*meta*/) const {
   const auto& deriv_log_r =
-      cache->get_var(internal_tags::deriv_log_r<DataType, Frame>{});
+      cache->get_var(*this, internal_tags::deriv_log_r<DataType, Frame>{});
   const auto& deriv_H_temp1 =
-      get(cache->get_var(internal_tags::deriv_H_temp1<DataType>{}));
+      get(cache->get_var(*this, internal_tags::deriv_H_temp1<DataType>{}));
   const auto& deriv_H_temp2 =
-      get(cache->get_var(internal_tags::deriv_H_temp2<DataType>{}));
+      get(cache->get_var(*this, internal_tags::deriv_H_temp2<DataType>{}));
 
   const auto spin_a = solution_.dimensionless_spin() * solution_.mass();
   for (size_t i = 0; i < 3; ++i) {
@@ -253,7 +258,7 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<CachedBuffer*> cache,
     internal_tags::denom<DataType> /*meta*/) const {
   const auto& r_squared =
-      get(cache->get_var(internal_tags::r_squared<DataType>{}));
+      get(cache->get_var(*this, internal_tags::r_squared<DataType>{}));
 
   const auto spin_a = solution_.dimensionless_spin() * solution_.mass();
   const auto a_squared =
@@ -267,8 +272,9 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<Scalar<DataType>*> a_dot_x_over_r,
     const gsl::not_null<CachedBuffer*> cache,
     internal_tags::a_dot_x_over_r<DataType> /*meta*/) const {
-  const auto& a_dot_x = get(cache->get_var(internal_tags::a_dot_x<DataType>{}));
-  const auto& r = get(cache->get_var(internal_tags::r<DataType>{}));
+  const auto& a_dot_x =
+      get(cache->get_var(*this, internal_tags::a_dot_x<DataType>{}));
+  const auto& r = get(cache->get_var(*this, internal_tags::r<DataType>{}));
 
   get(*a_dot_x_over_r) = a_dot_x / r;
 }
@@ -279,11 +285,12 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<CachedBuffer*> cache,
     internal_tags::null_form<DataType, Frame> /*meta*/) const {
   const auto& a_dot_x_over_r =
-      get(cache->get_var(internal_tags::a_dot_x_over_r<DataType>{}));
-  const auto& r = get(cache->get_var(internal_tags::r<DataType>{}));
+      get(cache->get_var(*this, internal_tags::a_dot_x_over_r<DataType>{}));
+  const auto& r = get(cache->get_var(*this, internal_tags::r<DataType>{}));
   const auto& x_minus_center =
-      cache->get_var(internal_tags::x_minus_center<DataType, Frame>{});
-  const auto& denom = get(cache->get_var(internal_tags::denom<DataType>{}));
+      cache->get_var(*this, internal_tags::x_minus_center<DataType, Frame>{});
+  const auto& denom =
+      get(cache->get_var(*this, internal_tags::denom<DataType>{}));
 
   const auto spin_a = solution_.dimensionless_spin() * solution_.mass();
   for (size_t i = 0; i < 3; ++i) {
@@ -304,16 +311,17 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<CachedBuffer*> cache,
     internal_tags::deriv_null_form<DataType, Frame> /*meta*/) const {
   const auto spin_a = solution_.dimensionless_spin() * solution_.mass();
-  const auto& denom = get(cache->get_var(internal_tags::denom<DataType>{}));
-  const auto& r = get(cache->get_var(internal_tags::r<DataType>{}));
+  const auto& denom =
+      get(cache->get_var(*this, internal_tags::denom<DataType>{}));
+  const auto& r = get(cache->get_var(*this, internal_tags::r<DataType>{}));
   const auto& x_minus_center =
-      cache->get_var(internal_tags::x_minus_center<DataType, Frame>{});
+      cache->get_var(*this, internal_tags::x_minus_center<DataType, Frame>{});
   const auto& null_form =
-      cache->get_var(internal_tags::null_form<DataType, Frame>{});
-  const auto& a_dot_x_over_rsquared =
-      get(cache->get_var(internal_tags::a_dot_x_over_rsquared<DataType>{}));
+      cache->get_var(*this, internal_tags::null_form<DataType, Frame>{});
+  const auto& a_dot_x_over_rsquared = get(
+      cache->get_var(*this, internal_tags::a_dot_x_over_rsquared<DataType>{}));
   const auto& deriv_log_r =
-      cache->get_var(internal_tags::deriv_log_r<DataType, Frame>{});
+      cache->get_var(*this, internal_tags::deriv_log_r<DataType, Frame>{});
 
   for (size_t i = 0; i < 3; i++) {
     for (size_t j = 0; j < 3; j++) {
@@ -343,7 +351,7 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<Scalar<DataType>*> lapse_squared,
     const gsl::not_null<CachedBuffer*> cache,
     internal_tags::lapse_squared<DataType> /*meta*/) const {
-  const auto& H = get(cache->get_var(internal_tags::H<DataType>{}));
+  const auto& H = get(cache->get_var(*this, internal_tags::H<DataType>{}));
   get(*lapse_squared) = 1.0 / (1.0 + 2.0 * square(null_vector_0_) * H);
 }
 
@@ -353,7 +361,7 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<CachedBuffer*> cache,
     gr::Tags::Lapse<DataType> /*meta*/) const {
   const auto& lapse_squared =
-      get(cache->get_var(internal_tags::lapse_squared<DataType>{}));
+      get(cache->get_var(*this, internal_tags::lapse_squared<DataType>{}));
   get(*lapse) = sqrt(lapse_squared);
 }
 
@@ -362,9 +370,9 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<Scalar<DataType>*> deriv_lapse_multiplier,
     const gsl::not_null<CachedBuffer*> cache,
     internal_tags::deriv_lapse_multiplier<DataType> /*meta*/) const {
-  const auto& lapse = get(cache->get_var(gr::Tags::Lapse<DataType>{}));
+  const auto& lapse = get(cache->get_var(*this, gr::Tags::Lapse<DataType>{}));
   const auto& lapse_squared =
-      get(cache->get_var(internal_tags::lapse_squared<DataType>{}));
+      get(cache->get_var(*this, internal_tags::lapse_squared<DataType>{}));
   get(*deriv_lapse_multiplier) =
       -square(null_vector_0_) * lapse * lapse_squared;
 }
@@ -374,9 +382,9 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<Scalar<DataType>*> shift_multiplier,
     const gsl::not_null<CachedBuffer*> cache,
     internal_tags::shift_multiplier<DataType> /*meta*/) const {
-  const auto& H = get(cache->get_var(internal_tags::H<DataType>{}));
+  const auto& H = get(cache->get_var(*this, internal_tags::H<DataType>{}));
   const auto& lapse_squared =
-      get(cache->get_var(internal_tags::lapse_squared<DataType>{}));
+      get(cache->get_var(*this, internal_tags::lapse_squared<DataType>{}));
 
   get(*shift_multiplier) = -2.0 * null_vector_0_ * H * lapse_squared;
 }
@@ -387,9 +395,9 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<CachedBuffer*> cache,
     gr::Tags::Shift<3, Frame, DataType> /*meta*/) const {
   const auto& null_form =
-      cache->get_var(internal_tags::null_form<DataType, Frame>{});
+      cache->get_var(*this, internal_tags::null_form<DataType, Frame>{});
   const auto& shift_multiplier =
-      get(cache->get_var(internal_tags::shift_multiplier<DataType>{}));
+      get(cache->get_var(*this, internal_tags::shift_multiplier<DataType>{}));
 
   for (size_t i = 0; i < 3; ++i) {
     shift->get(i) = shift_multiplier * null_form.get(i);
@@ -401,15 +409,15 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<tnsr::iJ<DataType, 3, Frame>*> deriv_shift,
     const gsl::not_null<CachedBuffer*> cache,
     DerivShift<DataType, Frame> /*meta*/) const {
-  const auto& H = get(cache->get_var(internal_tags::H<DataType>{}));
+  const auto& H = get(cache->get_var(*this, internal_tags::H<DataType>{}));
   const auto& null_form =
-      cache->get_var(internal_tags::null_form<DataType, Frame>{});
+      cache->get_var(*this, internal_tags::null_form<DataType, Frame>{});
   const auto& lapse_squared =
-      get(cache->get_var(internal_tags::lapse_squared<DataType>{}));
+      get(cache->get_var(*this, internal_tags::lapse_squared<DataType>{}));
   const auto& deriv_H =
-      cache->get_var(internal_tags::deriv_H<DataType, Frame>{});
+      cache->get_var(*this, internal_tags::deriv_H<DataType, Frame>{});
   const auto& deriv_null_form =
-      cache->get_var(internal_tags::deriv_null_form<DataType, Frame>{});
+      cache->get_var(*this, internal_tags::deriv_null_form<DataType, Frame>{});
 
   for (size_t m = 0; m < 3; ++m) {
     for (size_t i = 0; i < 3; ++i) {
@@ -428,9 +436,9 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<tnsr::ii<DataType, 3, Frame>*> spatial_metric,
     const gsl::not_null<CachedBuffer*> cache,
     gr::Tags::SpatialMetric<3, Frame, DataType> /*meta*/) const {
-  const auto& H = get(cache->get_var(internal_tags::H<DataType>{}));
+  const auto& H = get(cache->get_var(*this, internal_tags::H<DataType>{}));
   const auto& null_form =
-      cache->get_var(internal_tags::null_form<DataType, Frame>{});
+      cache->get_var(*this, internal_tags::null_form<DataType, Frame>{});
 
   std::fill(spatial_metric->begin(), spatial_metric->end(), 0.);
   for (size_t i = 0; i < 3; ++i) {
@@ -448,12 +456,12 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
     const gsl::not_null<CachedBuffer*> cache,
     DerivSpatialMetric<DataType, Frame> /*meta*/) const {
   const auto& null_form =
-      cache->get_var(internal_tags::null_form<DataType, Frame>{});
+      cache->get_var(*this, internal_tags::null_form<DataType, Frame>{});
   const auto& deriv_H =
-      cache->get_var(internal_tags::deriv_H<DataType, Frame>{});
-  const auto& H = get(cache->get_var(internal_tags::H<DataType>{}));
+      cache->get_var(*this, internal_tags::deriv_H<DataType, Frame>{});
+  const auto& H = get(cache->get_var(*this, internal_tags::H<DataType>{}));
   const auto& deriv_null_form =
-      cache->get_var(internal_tags::deriv_null_form<DataType, Frame>{});
+      cache->get_var(*this, internal_tags::deriv_null_form<DataType, Frame>{});
 
   for (size_t i = 0; i < 3; ++i) {
     for (size_t j = i; j < 3; ++j) {  // Symmetry
@@ -477,19 +485,15 @@ void KerrSchild::IntermediateComputer<DataType, Frame>::operator()(
 }
 
 template <typename DataType, typename Frame>
-KerrSchild::IntermediateVars<DataType, Frame>::IntermediateVars(
-    const KerrSchild& solution, const tnsr::I<DataType, 3, Frame>& x)
-    : CachedBuffer(get_size(::get<0>(x)), IntermediateComputer<DataType, Frame>(
-                                              solution, x, null_vector_0_)) {}
-
-template <typename DataType, typename Frame>
 tnsr::i<DataType, 3, Frame>
 KerrSchild::IntermediateVars<DataType, Frame>::get_var(
+    const IntermediateComputer<DataType, Frame>& computer,
     DerivLapse<DataType, Frame> /*meta*/) {
   tnsr::i<DataType, 3, Frame> result{};
-  const auto& deriv_H = get_var(internal_tags::deriv_H<DataType, Frame>{});
+  const auto& deriv_H =
+      get_var(computer, internal_tags::deriv_H<DataType, Frame>{});
   const auto& deriv_lapse_multiplier =
-      get(get_var(internal_tags::deriv_lapse_multiplier<DataType>{}));
+      get(get_var(computer, internal_tags::deriv_lapse_multiplier<DataType>{}));
 
   for (size_t i = 0; i < 3; ++i) {
     result.get(i) = deriv_lapse_multiplier * deriv_H.get(i);
@@ -499,30 +503,36 @@ KerrSchild::IntermediateVars<DataType, Frame>::get_var(
 
 template <typename DataType, typename Frame>
 Scalar<DataType> KerrSchild::IntermediateVars<DataType, Frame>::get_var(
+    const IntermediateComputer<DataType, Frame>& computer,
     ::Tags::dt<gr::Tags::Lapse<DataType>> /*meta*/) {
-  const auto& H = get(get_var(internal_tags::H<DataType>{}));
+  const auto& H = get(get_var(computer, internal_tags::H<DataType>{}));
   return make_with_value<Scalar<DataType>>(H, 0.);
 }
 
 template <typename DataType, typename Frame>
 tnsr::I<DataType, 3, Frame>
 KerrSchild::IntermediateVars<DataType, Frame>::get_var(
+    const IntermediateComputer<DataType, Frame>& computer,
     ::Tags::dt<gr::Tags::Shift<3, Frame, DataType>> /*meta*/) {
-  const auto& H = get(get_var(internal_tags::H<DataType>()));
+  const auto& H = get(get_var(computer, internal_tags::H<DataType>()));
   return make_with_value<tnsr::I<DataType, 3, Frame>>(H, 0.);
 }
 
 template <typename DataType, typename Frame>
 Scalar<DataType> KerrSchild::IntermediateVars<DataType, Frame>::get_var(
+    const IntermediateComputer<DataType, Frame>& computer,
     gr::Tags::SqrtDetSpatialMetric<DataType> /*meta*/) {
-  return Scalar<DataType>(1.0 / get(get_var(gr::Tags::Lapse<DataType>{})));
+  return Scalar<DataType>(1.0 /
+                          get(get_var(computer, gr::Tags::Lapse<DataType>{})));
 }
 
 template <typename DataType, typename Frame>
 tnsr::i<DataType, 3, Frame>
 KerrSchild::IntermediateVars<DataType, Frame>::get_var(
+    const IntermediateComputer<DataType, Frame>& computer,
     gr::Tags::DerivDetSpatialMetric<3, Frame, DataType> /*meta*/) {
-  const auto& deriv_H = get_var(internal_tags::deriv_H<DataType, Frame>{});
+  const auto& deriv_H =
+      get_var(computer, internal_tags::deriv_H<DataType, Frame>{});
 
   auto result =
       make_with_value<tnsr::i<DataType, 3, Frame>>(get<0>(deriv_H), 0.);
@@ -536,11 +546,13 @@ KerrSchild::IntermediateVars<DataType, Frame>::get_var(
 template <typename DataType, typename Frame>
 tnsr::II<DataType, 3, Frame>
 KerrSchild::IntermediateVars<DataType, Frame>::get_var(
+    const IntermediateComputer<DataType, Frame>& computer,
     gr::Tags::InverseSpatialMetric<3, Frame, DataType> /*meta*/) {
-  const auto& H = get(get_var(internal_tags::H<DataType>{}));
+  const auto& H = get(get_var(computer, internal_tags::H<DataType>{}));
   const auto& lapse_squared =
-      get(get_var(internal_tags::lapse_squared<DataType>{}));
-  const auto& null_form = get_var(internal_tags::null_form<DataType, Frame>{});
+      get(get_var(computer, internal_tags::lapse_squared<DataType>{}));
+  const auto& null_form =
+      get_var(computer, internal_tags::null_form<DataType, Frame>{});
 
   auto result = make_with_value<tnsr::II<DataType, 3, Frame>>(H, 0.);
   for (size_t i = 0; i < 3; ++i) {
@@ -557,15 +569,16 @@ KerrSchild::IntermediateVars<DataType, Frame>::get_var(
 template <typename DataType, typename Frame>
 tnsr::ii<DataType, 3, Frame>
 KerrSchild::IntermediateVars<DataType, Frame>::get_var(
+    const IntermediateComputer<DataType, Frame>& computer,
     gr::Tags::ExtrinsicCurvature<3, Frame, DataType> /*meta*/) {
   return gr::extrinsic_curvature(
-      get_var(gr::Tags::Lapse<DataType>{}),
-      get_var(gr::Tags::Shift<3, Frame, DataType>{}),
-      get_var(DerivShift<DataType, Frame>{}),
-      get_var(gr::Tags::SpatialMetric<3, Frame, DataType>{}),
-      get_var(
-          ::Tags::dt<gr::Tags::SpatialMetric<3, Frame, DataType>>{}),
-      get_var(DerivSpatialMetric<DataType, Frame>{}));
+      get_var(computer, gr::Tags::Lapse<DataType>{}),
+      get_var(computer, gr::Tags::Shift<3, Frame, DataType>{}),
+      get_var(computer, DerivShift<DataType, Frame>{}),
+      get_var(computer, gr::Tags::SpatialMetric<3, Frame, DataType>{}),
+      get_var(computer,
+              ::Tags::dt<gr::Tags::SpatialMetric<3, Frame, DataType>>{}),
+      get_var(computer, DerivSpatialMetric<DataType, Frame>{}));
 }
 
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/Lorentzian.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/Lorentzian.cpp
@@ -43,7 +43,7 @@ void LorentzianVariables<DataType, Dim>::operator()(
     ::Tags::Flux<Tags::Field, tmpl::size_t<Dim>, Frame::Inertial> /*meta*/)
     const {
   const auto& field_gradient = cache->get_var(
-      ::Tags::deriv<Tags::Field, tmpl::size_t<Dim>, Frame::Inertial>{});
+      *this, ::Tags::deriv<Tags::Field, tmpl::size_t<Dim>, Frame::Inertial>{});
   for (size_t d = 0; d < Dim; ++d) {
     flux_for_field->get(d) = field_gradient.get(d);
   }

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/Lorentzian.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/Lorentzian.hpp
@@ -24,7 +24,7 @@ namespace detail {
 template <typename DataType, size_t Dim>
 struct LorentzianVariables {
   using Cache = CachedTempBuffer<
-      LorentzianVariables, Tags::Field,
+      Tags::Field,
       ::Tags::deriv<Tags::Field, tmpl::size_t<Dim>, Frame::Inertial>,
       ::Tags::Flux<Tags::Field, tmpl::size_t<Dim>, Frame::Inertial>,
       ::Tags::FixedSource<Tags::Field>>;
@@ -105,8 +105,9 @@ class Lorentzian : public AnalyticSolution<Dim, Registrars> {
       const tnsr::I<DataType, Dim>& x,
       tmpl::list<RequestedTags...> /*meta*/) const {
     using VarsComputer = detail::LorentzianVariables<DataType, Dim>;
-    typename VarsComputer::Cache cache{get_size(*x.begin()), VarsComputer{x}};
-    return {cache.get_var(RequestedTags{})...};
+    typename VarsComputer::Cache cache{get_size(*x.begin())};
+    const VarsComputer computer{x};
+    return {cache.get_var(computer, RequestedTags{})...};
   }
 
   // NOLINTNEXTLINE(google-runtime-references)

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.cpp
@@ -66,7 +66,7 @@ void MoustacheVariables<DataType, Dim>::operator()(
     ::Tags::Flux<Tags::Field, tmpl::size_t<Dim>, Frame::Inertial> /*meta*/)
     const {
   const auto& field_gradient = cache->get_var(
-      ::Tags::deriv<Tags::Field, tmpl::size_t<Dim>, Frame::Inertial>{});
+      *this, ::Tags::deriv<Tags::Field, tmpl::size_t<Dim>, Frame::Inertial>{});
   for (size_t d = 0; d < Dim; ++d) {
     flux_for_field->get(d) = field_gradient.get(d);
   }

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.hpp
@@ -24,7 +24,7 @@ namespace detail {
 template <typename DataType, size_t Dim>
 struct MoustacheVariables {
   using Cache = CachedTempBuffer<
-      MoustacheVariables, Tags::Field,
+      Tags::Field,
       ::Tags::deriv<Tags::Field, tmpl::size_t<Dim>, Frame::Inertial>,
       ::Tags::Flux<Tags::Field, tmpl::size_t<Dim>, Frame::Inertial>,
       ::Tags::FixedSource<Tags::Field>>;
@@ -112,8 +112,9 @@ class Moustache : public AnalyticSolution<Dim, Registrars> {
       const tnsr::I<DataType, Dim>& x,
       tmpl::list<RequestedTags...> /*meta*/) const {
     using VarsComputer = detail::MoustacheVariables<DataType, Dim>;
-    typename VarsComputer::Cache cache{get_size(*x.begin()), VarsComputer{x}};
-    return {cache.get_var(RequestedTags{})...};
+    typename VarsComputer::Cache cache{get_size(*x.begin())};
+    const VarsComputer computer{x};
+    return {cache.get_var(computer, RequestedTags{})...};
   }
 
   // NOLINTNEXTLINE(google-runtime-references)

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/ProductOfSinusoids.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/ProductOfSinusoids.cpp
@@ -52,7 +52,7 @@ void ProductOfSinusoidsVariables<DataType, Dim>::operator()(
     ::Tags::Flux<Tags::Field, tmpl::size_t<Dim>, Frame::Inertial> /*meta*/)
     const {
   const auto& field_gradient = cache->get_var(
-      ::Tags::deriv<Tags::Field, tmpl::size_t<Dim>, Frame::Inertial>{});
+      *this, ::Tags::deriv<Tags::Field, tmpl::size_t<Dim>, Frame::Inertial>{});
   for (size_t d = 0; d < Dim; ++d) {
     flux_for_field->get(d) = field_gradient.get(d);
   }
@@ -63,7 +63,7 @@ void ProductOfSinusoidsVariables<DataType, Dim>::operator()(
     const gsl::not_null<Scalar<DataType>*> fixed_source_for_field,
     const gsl::not_null<Cache*> cache,
     ::Tags::FixedSource<Tags::Field> /*meta*/) const {
-  const auto& field = cache->get_var(Tags::Field{});
+  const auto& field = cache->get_var(*this, Tags::Field{});
   get(*fixed_source_for_field) = get(field) * square(magnitude(wave_numbers));
 }
 

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/ProductOfSinusoids.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/ProductOfSinusoids.hpp
@@ -26,7 +26,7 @@ namespace detail {
 template <typename DataType, size_t Dim>
 struct ProductOfSinusoidsVariables {
   using Cache = CachedTempBuffer<
-      ProductOfSinusoidsVariables, Tags::Field,
+      Tags::Field,
       ::Tags::deriv<Tags::Field, tmpl::size_t<Dim>, Frame::Inertial>,
       ::Tags::Flux<Tags::Field, tmpl::size_t<Dim>, Frame::Inertial>,
       ::Tags::FixedSource<Tags::Field>>;
@@ -108,9 +108,9 @@ class ProductOfSinusoids : public AnalyticSolution<Dim, Registrars> {
       const tnsr::I<DataType, Dim>& x,
       tmpl::list<RequestedTags...> /*meta*/) const {
     using VarsComputer = detail::ProductOfSinusoidsVariables<DataType, Dim>;
-    typename VarsComputer::Cache cache{get_size(*x.begin()),
-                                       VarsComputer{x, wave_numbers_}};
-    return {cache.get_var(RequestedTags{})...};
+    typename VarsComputer::Cache cache{get_size(*x.begin())};
+    const VarsComputer computer{x, wave_numbers_};
+    return {cache.get_var(computer, RequestedTags{})...};
   }
 
   // NOLINTNEXTLINE(google-runtime-references)

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/CommonVariables.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/CommonVariables.hpp
@@ -18,12 +18,24 @@ namespace Xcts::Solutions {
 template <typename DataType>
 using common_tags = tmpl::push_back<
     AnalyticData::common_tags<DataType>,
+    // Solved variables
+    Tags::ConformalFactor<DataType>, Tags::LapseTimesConformalFactor<DataType>,
+    Tags::ShiftExcess<DataType, 3, Frame::Inertial>,
+    // GR lapse and shift
+    gr::Tags::Lapse<DataType>, gr::Tags::Shift<3, Frame::Inertial, DataType>,
+    // Derivatives of solved variables
+    ::Tags::deriv<Tags::ConformalFactor<DataType>, tmpl::size_t<3>,
+                  Frame::Inertial>,
+    ::Tags::deriv<Tags::LapseTimesConformalFactor<DataType>, tmpl::size_t<3>,
+                  Frame::Inertial>,
+    Tags::ShiftStrain<DataType, 3, Frame::Inertial>,
+    // Fluxes
     ::Tags::Flux<Tags::ConformalFactor<DataType>, tmpl::size_t<3>,
                  Frame::Inertial>,
     ::Tags::Flux<Tags::LapseTimesConformalFactor<DataType>, tmpl::size_t<3>,
                  Frame::Inertial>,
     Tags::LongitudinalShiftExcess<DataType, 3, Frame::Inertial>,
-    gr::Tags::Shift<3, Frame::Inertial, DataType>,
+    // Background quantities for subsets of the XCTS equations
     Tags::LongitudinalShiftMinusDtConformalMetricSquare<DataType>,
     Tags::LongitudinalShiftMinusDtConformalMetricOverLapseSquare<DataType>,
     Tags::ShiftDotDerivExtrinsicCurvatureTrace<DataType>>;
@@ -32,38 +44,69 @@ using common_tags = tmpl::push_back<
 template <typename DataType, typename Cache>
 struct CommonVariables : AnalyticData::CommonVariables<DataType, Cache> {
   static constexpr size_t Dim = 3;
-  using AnalyticData::CommonVariables<DataType, Cache>::operator();
-  void operator()(
+  using Base = AnalyticData::CommonVariables<DataType, Cache>;
+  using Base::Base;
+  using Base::operator();
+
+  virtual void operator()(gsl::not_null<Scalar<DataType>*> conformal_factor,
+                          gsl::not_null<Cache*> cache,
+                          Tags::ConformalFactor<DataType> /*meta*/) const = 0;
+  virtual void operator()(
+      gsl::not_null<Scalar<DataType>*> lapse_times_conformal_factor,
+      gsl::not_null<Cache*> cache,
+      Tags::LapseTimesConformalFactor<DataType> /*meta*/) const = 0;
+  virtual void operator()(
+      gsl::not_null<tnsr::I<DataType, Dim>*> shift_excess,
+      gsl::not_null<Cache*> cache,
+      Tags::ShiftExcess<DataType, Dim, Frame::Inertial> /*meta*/) const = 0;
+  virtual void operator()(gsl::not_null<Scalar<DataType>*> lapse,
+                          gsl::not_null<Cache*> cache,
+                          gr::Tags::Lapse<DataType> /*meta*/) const = 0;
+  virtual void operator()(
+      gsl::not_null<tnsr::i<DataType, Dim>*> deriv_conformal_factor,
+      gsl::not_null<Cache*> cache,
+      ::Tags::deriv<Tags::ConformalFactor<DataType>, tmpl::size_t<Dim>,
+                    Frame::Inertial> /*meta*/) const = 0;
+  virtual void operator()(
+      gsl::not_null<tnsr::i<DataType, Dim>*> deriv_lapse_times_conformal_factor,
+      gsl::not_null<Cache*> cache,
+      ::Tags::deriv<Tags::LapseTimesConformalFactor<DataType>,
+                    tmpl::size_t<Dim>, Frame::Inertial> /*meta*/) const = 0;
+  virtual void operator()(
+      gsl::not_null<tnsr::ii<DataType, Dim>*> shift_strain,
+      gsl::not_null<Cache*> cache,
+      Tags::ShiftStrain<DataType, Dim, Frame::Inertial> /*meta*/) const = 0;
+  virtual void operator()(
       gsl::not_null<tnsr::I<DataType, Dim>*> conformal_factor_flux,
       gsl::not_null<Cache*> cache,
       ::Tags::Flux<Tags::ConformalFactor<DataType>, tmpl::size_t<Dim>,
                    Frame::Inertial> /*meta*/) const;
-  void operator()(
+  virtual void operator()(
       gsl::not_null<tnsr::I<DataType, Dim>*> lapse_times_conformal_factor_flux,
       gsl::not_null<Cache*> cache,
       ::Tags::Flux<Tags::LapseTimesConformalFactor<DataType>, tmpl::size_t<Dim>,
                    Frame::Inertial> /*meta*/) const;
-  void operator()(
+  virtual void operator()(
       gsl::not_null<tnsr::II<DataType, Dim>*> longitudinal_shift_excess,
       gsl::not_null<Cache*> cache,
       Tags::LongitudinalShiftExcess<DataType, Dim, Frame::Inertial> /*meta*/)
       const;
-  void operator()(
+  virtual void operator()(
       gsl::not_null<tnsr::I<DataType, Dim>*> shift, gsl::not_null<Cache*> cache,
       gr::Tags::Shift<Dim, Frame::Inertial, DataType> /*meta*/) const;
-  void operator()(
+  virtual void operator()(
       gsl::not_null<Scalar<DataType>*>
           longitudinal_shift_minus_dt_conformal_metric_square,
       gsl::not_null<Cache*> cache,
       Tags::LongitudinalShiftMinusDtConformalMetricSquare<DataType> /*meta*/)
       const;
-  void operator()(
+  virtual void operator()(
       gsl::not_null<Scalar<DataType>*>
           longitudinal_shift_minus_dt_conformal_metric_over_lapse_square,
       gsl::not_null<Cache*> cache,
       Tags::LongitudinalShiftMinusDtConformalMetricOverLapseSquare<
           DataType> /*meta*/) const;
-  void operator()(
+  virtual void operator()(
       gsl::not_null<Scalar<DataType>*>
           shift_dot_deriv_extrinsic_curvature_trace,
       gsl::not_null<Cache*> cache,

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/CommonVariables.tpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/CommonVariables.tpp
@@ -26,11 +26,11 @@ void CommonVariables<DataType, Cache>::operator()(
     const gsl::not_null<Cache*> cache,
     ::Tags::Flux<Tags::ConformalFactor<DataType>, tmpl::size_t<Dim>,
                  Frame::Inertial> /*meta*/) const {
-  const auto& conformal_factor_gradient =
-      cache->get_var(::Tags::deriv<Tags::ConformalFactor<DataType>,
-                                   tmpl::size_t<Dim>, Frame::Inertial>{});
+  const auto& conformal_factor_gradient = cache->get_var(
+      *this, ::Tags::deriv<Tags::ConformalFactor<DataType>, tmpl::size_t<Dim>,
+                           Frame::Inertial>{});
   const auto& inv_conformal_metric = cache->get_var(
-      Tags::InverseConformalMetric<DataType, Dim, Frame::Inertial>{});
+      *this, Tags::InverseConformalMetric<DataType, Dim, Frame::Inertial>{});
   raise_or_lower_index(conformal_factor_flux, conformal_factor_gradient,
                        inv_conformal_metric);
 }
@@ -42,11 +42,11 @@ void CommonVariables<DataType, Cache>::operator()(
     const gsl::not_null<Cache*> cache,
     ::Tags::Flux<Tags::LapseTimesConformalFactor<DataType>, tmpl::size_t<Dim>,
                  Frame::Inertial> /*meta*/) const {
-  const auto& lapse_times_conformal_factor_gradient =
-      cache->get_var(::Tags::deriv<Tags::LapseTimesConformalFactor<DataType>,
-                                   tmpl::size_t<Dim>, Frame::Inertial>{});
+  const auto& lapse_times_conformal_factor_gradient = cache->get_var(
+      *this, ::Tags::deriv<Tags::LapseTimesConformalFactor<DataType>,
+                           tmpl::size_t<Dim>, Frame::Inertial>{});
   const auto& inv_conformal_metric = cache->get_var(
-      Tags::InverseConformalMetric<DataType, Dim, Frame::Inertial>{});
+      *this, Tags::InverseConformalMetric<DataType, Dim, Frame::Inertial>{});
   raise_or_lower_index(lapse_times_conformal_factor_flux,
                        lapse_times_conformal_factor_gradient,
                        inv_conformal_metric);
@@ -58,10 +58,10 @@ void CommonVariables<DataType, Cache>::operator()(
     const gsl::not_null<Cache*> cache,
     Tags::LongitudinalShiftExcess<DataType, Dim, Frame::Inertial> /*meta*/)
     const {
-  const auto& shift_strain =
-      cache->get_var(Tags::ShiftStrain<DataType, Dim, Frame::Inertial>{});
+  const auto& shift_strain = cache->get_var(
+      *this, Tags::ShiftStrain<DataType, Dim, Frame::Inertial>{});
   const auto& inv_conformal_metric = cache->get_var(
-      Tags::InverseConformalMetric<DataType, Dim, Frame::Inertial>{});
+      *this, Tags::InverseConformalMetric<DataType, Dim, Frame::Inertial>{});
   Xcts::longitudinal_operator(longitudinal_shift_excess, shift_strain,
                               inv_conformal_metric);
 }
@@ -71,9 +71,10 @@ void CommonVariables<DataType, Cache>::operator()(
     const gsl::not_null<tnsr::I<DataType, Dim>*> shift,
     const gsl::not_null<Cache*> cache,
     gr::Tags::Shift<Dim, Frame::Inertial, DataType> /*meta*/) const {
-  *shift = cache->get_var(Tags::ShiftExcess<DataType, Dim, Frame::Inertial>{});
-  const auto& shift_background =
-      cache->get_var(Tags::ShiftBackground<DataType, Dim, Frame::Inertial>{});
+  *shift = cache->get_var(*this,
+                          Tags::ShiftExcess<DataType, Dim, Frame::Inertial>{});
+  const auto& shift_background = cache->get_var(
+      *this, Tags::ShiftBackground<DataType, Dim, Frame::Inertial>{});
   for (size_t d = 0; d < Dim; ++d) {
     shift->get(d) += shift_background.get(d);
   }
@@ -86,13 +87,13 @@ void CommonVariables<DataType, Cache>::operator()(
     const gsl::not_null<Cache*> cache,
     Tags::LongitudinalShiftMinusDtConformalMetricSquare<DataType> /*meta*/)
     const {
-  const auto& longitudinal_shift_background =
-      cache->get_var(Tags::LongitudinalShiftBackgroundMinusDtConformalMetric<
-                     DataType, Dim, Frame::Inertial>{});
+  const auto& longitudinal_shift_background = cache->get_var(
+      *this, Tags::LongitudinalShiftBackgroundMinusDtConformalMetric<
+                 DataType, Dim, Frame::Inertial>{});
   const auto& longitudinal_shift_excess = cache->get_var(
-      Tags::LongitudinalShiftExcess<DataType, Dim, Frame::Inertial>{});
-  const auto& conformal_metric =
-      cache->get_var(Tags::ConformalMetric<DataType, Dim, Frame::Inertial>{});
+      *this, Tags::LongitudinalShiftExcess<DataType, Dim, Frame::Inertial>{});
+  const auto& conformal_metric = cache->get_var(
+      *this, Tags::ConformalMetric<DataType, Dim, Frame::Inertial>{});
   get(*longitudinal_shift_minus_dt_conformal_metric_square) = 0.;
   for (size_t i = 0; i < 3; ++i) {
     for (size_t j = 0; j < 3; ++j) {
@@ -119,8 +120,9 @@ void CommonVariables<DataType, Cache>::operator()(
         DataType> /*meta*/) const {
   *longitudinal_shift_minus_dt_conformal_metric_over_lapse_square =
       cache->get_var(
+          *this,
           Tags::LongitudinalShiftMinusDtConformalMetricSquare<DataType>{});
-  const auto& lapse = cache->get_var(gr::Tags::Lapse<DataType>{});
+  const auto& lapse = cache->get_var(*this, gr::Tags::Lapse<DataType>{});
   get(*longitudinal_shift_minus_dt_conformal_metric_over_lapse_square) /=
       square(get(lapse));
 }
@@ -130,13 +132,12 @@ void CommonVariables<DataType, Cache>::operator()(
     const gsl::not_null<Scalar<DataType>*>
         shift_dot_deriv_extrinsic_curvature_trace,
     const gsl::not_null<Cache*> cache,
-    Tags::ShiftDotDerivExtrinsicCurvatureTrace<DataType> /*meta*/)
-    const {
+    Tags::ShiftDotDerivExtrinsicCurvatureTrace<DataType> /*meta*/) const {
   const auto& shift =
-      cache->get_var(gr::Tags::Shift<Dim, Frame::Inertial, DataType>{});
-  const auto& deriv_extrinsic_curvature_trace =
-      cache->get_var(::Tags::deriv<gr::Tags::TraceExtrinsicCurvature<DataType>,
-                                   tmpl::size_t<Dim>, Frame::Inertial>{});
+      cache->get_var(*this, gr::Tags::Shift<Dim, Frame::Inertial, DataType>{});
+  const auto& deriv_extrinsic_curvature_trace = cache->get_var(
+      *this, ::Tags::deriv<gr::Tags::TraceExtrinsicCurvature<DataType>,
+                           tmpl::size_t<Dim>, Frame::Inertial>{});
   dot_product(shift_dot_deriv_extrinsic_curvature_trace, shift,
               deriv_extrinsic_curvature_trace);
 }

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/Kerr.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/Kerr.cpp
@@ -29,8 +29,9 @@ void KerrVariables<DataType>::operator()(
     const gsl::not_null<Cache*> cache,
     Tags::ConformalMetric<DataType, Dim, Frame::Inertial> /*meta*/) const {
   const auto& conformal_factor =
-      cache->get_var(Xcts::Tags::ConformalFactor<DataType>{});
-  *conformal_metric = kerr_schild.get_var(
+      cache->get_var(*this, Xcts::Tags::ConformalFactor<DataType>{});
+  *conformal_metric = kerr_schild_cache.get_var(
+      kerr_schild_computer,
       gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>{});
   for (size_t i = 0; i < Dim; ++i) {
     for (size_t j = 0; j <= i; ++j) {
@@ -46,8 +47,9 @@ void KerrVariables<DataType>::operator()(
     Tags::InverseConformalMetric<DataType, Dim, Frame::Inertial> /*meta*/)
     const {
   const auto& conformal_factor =
-      cache->get_var(Xcts::Tags::ConformalFactor<DataType>{});
-  *inv_conformal_metric = kerr_schild.get_var(
+      cache->get_var(*this, Xcts::Tags::ConformalFactor<DataType>{});
+  *inv_conformal_metric = kerr_schild_cache.get_var(
+      kerr_schild_computer,
       gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataType>{});
   for (size_t i = 0; i < Dim; ++i) {
     for (size_t j = 0; j <= i; ++j) {
@@ -63,13 +65,14 @@ void KerrVariables<DataType>::operator()(
     ::Tags::deriv<Tags::ConformalMetric<DataType, Dim, Frame::Inertial>,
                   tmpl::size_t<Dim>, Frame::Inertial> /*meta*/) const {
   const auto& conformal_factor =
-      cache->get_var(Xcts::Tags::ConformalFactor<DataType>{});
-  const auto& deriv_conformal_factor =
-      cache->get_var(::Tags::deriv<Xcts::Tags::ConformalFactor<DataType>,
-                                   tmpl::size_t<Dim>, Frame::Inertial>{});
+      cache->get_var(*this, Xcts::Tags::ConformalFactor<DataType>{});
+  const auto& deriv_conformal_factor = cache->get_var(
+      *this, ::Tags::deriv<Xcts::Tags::ConformalFactor<DataType>,
+                           tmpl::size_t<Dim>, Frame::Inertial>{});
   const auto& conformal_metric = cache->get_var(
-      Xcts::Tags::ConformalMetric<DataType, Dim, Frame::Inertial>{});
-  *deriv_conformal_metric = kerr_schild.get_var(
+      *this, Xcts::Tags::ConformalMetric<DataType, Dim, Frame::Inertial>{});
+  *deriv_conformal_metric = kerr_schild_cache.get_var(
+      kerr_schild_computer,
       ::Tags::deriv<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>,
                     tmpl::size_t<Dim>, Frame::Inertial>{});
   for (size_t i = 0; i < Dim; ++i) {
@@ -89,9 +92,11 @@ void KerrVariables<DataType>::operator()(
     const gsl::not_null<Scalar<DataType>*> trace_extrinsic_curvature,
     const gsl::not_null<Cache*> /*cache*/,
     gr::Tags::TraceExtrinsicCurvature<DataType> /*meta*/) const {
-  const auto& extrinsic_curvature = kerr_schild.get_var(
+  const auto& extrinsic_curvature = kerr_schild_cache.get_var(
+      kerr_schild_computer,
       gr::Tags::ExtrinsicCurvature<Dim, Frame::Inertial, DataType>{});
-  const auto& inv_spatial_metric = kerr_schild.get_var(
+  const auto& inv_spatial_metric = kerr_schild_cache.get_var(
+      kerr_schild_computer,
       gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataType>{});
   trace(trace_extrinsic_curvature, extrinsic_curvature, inv_spatial_metric);
 }
@@ -127,7 +132,8 @@ void KerrVariables<DataType>::operator()(
     const gsl::not_null<Scalar<DataType>*> lapse,
     const gsl::not_null<Cache*> /*cache*/,
     gr::Tags::Lapse<DataType> /*meta*/) const {
-  *lapse = kerr_schild.get_var(gr::Tags::Lapse<DataType>{});
+  *lapse = kerr_schild_cache.get_var(kerr_schild_computer,
+                                     gr::Tags::Lapse<DataType>{});
 }
 
 template <typename DataType>
@@ -135,9 +141,10 @@ void KerrVariables<DataType>::operator()(
     const gsl::not_null<Scalar<DataType>*> lapse_times_conformal_factor,
     const gsl::not_null<Cache*> cache,
     Tags::LapseTimesConformalFactor<DataType> /*meta*/) const {
-  *lapse_times_conformal_factor = cache->get_var(gr::Tags::Lapse<DataType>{});
+  *lapse_times_conformal_factor =
+      cache->get_var(*this, gr::Tags::Lapse<DataType>{});
   const auto& conformal_factor =
-      cache->get_var(Xcts::Tags::ConformalFactor<DataType>{});
+      cache->get_var(*this, Xcts::Tags::ConformalFactor<DataType>{});
   get(*lapse_times_conformal_factor) *= get(conformal_factor);
 }
 
@@ -149,14 +156,16 @@ void KerrVariables<DataType>::operator()(
     ::Tags::deriv<Tags::LapseTimesConformalFactor<DataType>, tmpl::size_t<Dim>,
                   Frame::Inertial> /*meta*/) const {
   const auto& conformal_factor =
-      cache->get_var(Xcts::Tags::ConformalFactor<DataType>{});
-  const auto& deriv_conformal_factor =
-      cache->get_var(::Tags::deriv<Xcts::Tags::ConformalFactor<DataType>,
-                                   tmpl::size_t<Dim>, Frame::Inertial>{});
-  *lapse_times_conformal_factor_gradient =
-      kerr_schild.get_var(::Tags::deriv<gr::Tags::Lapse<DataType>,
-                                        tmpl::size_t<Dim>, Frame::Inertial>{});
-  const auto& lapse = kerr_schild.get_var(gr::Tags::Lapse<DataType>{});
+      cache->get_var(*this, Xcts::Tags::ConformalFactor<DataType>{});
+  const auto& deriv_conformal_factor = cache->get_var(
+      *this, ::Tags::deriv<Xcts::Tags::ConformalFactor<DataType>,
+                           tmpl::size_t<Dim>, Frame::Inertial>{});
+  *lapse_times_conformal_factor_gradient = kerr_schild_cache.get_var(
+      kerr_schild_computer,
+      ::Tags::deriv<gr::Tags::Lapse<DataType>, tmpl::size_t<Dim>,
+                    Frame::Inertial>{});
+  const auto& lapse = kerr_schild_cache.get_var(kerr_schild_computer,
+                                                gr::Tags::Lapse<DataType>{});
   for (size_t i = 0; i < Dim; ++i) {
     lapse_times_conformal_factor_gradient->get(i) *= get(conformal_factor);
     lapse_times_conformal_factor_gradient->get(i) +=
@@ -188,8 +197,8 @@ void KerrVariables<DataType>::operator()(
     const gsl::not_null<tnsr::I<DataType, Dim>*> shift_excess,
     const gsl::not_null<Cache*> /*cache*/,
     Tags::ShiftExcess<DataType, Dim, Frame::Inertial> /*meta*/) const {
-  *shift_excess =
-      kerr_schild.get_var(gr::Tags::Shift<Dim, Frame::Inertial, DataType>{});
+  *shift_excess = kerr_schild_cache.get_var(
+      kerr_schild_computer, gr::Tags::Shift<Dim, Frame::Inertial, DataType>{});
 }
 
 template <typename DataType>
@@ -197,17 +206,20 @@ void KerrVariables<DataType>::operator()(
     const gsl::not_null<tnsr::ii<DataType, Dim>*> shift_strain,
     const gsl::not_null<Cache*> cache,
     Tags::ShiftStrain<DataType, Dim, Frame::Inertial> /*meta*/) const {
-  const auto& shift =
-      kerr_schild.get_var(gr::Tags::Shift<Dim, Frame::Inertial, DataType>{});
-  const auto& deriv_shift = kerr_schild.get_var(
+  const auto& shift = kerr_schild_cache.get_var(
+      kerr_schild_computer, gr::Tags::Shift<Dim, Frame::Inertial, DataType>{});
+  const auto& deriv_shift = kerr_schild_cache.get_var(
+      kerr_schild_computer,
       ::Tags::deriv<gr::Tags::Shift<Dim, Frame::Inertial, DataType>,
                     tmpl::size_t<Dim>, Frame::Inertial>{});
   const auto& conformal_metric = cache->get_var(
-      Xcts::Tags::ConformalMetric<DataType, Dim, Frame::Inertial>{});
+      *this, Xcts::Tags::ConformalMetric<DataType, Dim, Frame::Inertial>{});
   const auto& deriv_conformal_metric = cache->get_var(
+      *this,
       ::Tags::deriv<Xcts::Tags::ConformalMetric<DataType, Dim, Frame::Inertial>,
                     tmpl::size_t<Dim>, Frame::Inertial>{});
   const auto& conformal_christoffel_first_kind = cache->get_var(
+      *this,
       Tags::ConformalChristoffelFirstKind<DataType, Dim, Frame::Inertial>{});
   Elasticity::strain(shift_strain, deriv_shift, conformal_metric,
                      deriv_conformal_metric, conformal_christoffel_first_kind,

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/Kerr.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/Kerr.hpp
@@ -34,22 +34,6 @@ using KerrVariablesCache = cached_temp_buffer_from_typelist<
     KerrVariables<DataType>,
     tmpl::push_back<
         common_tags<DataType>,
-        Tags::ConformalMetric<DataType, 3, Frame::Inertial>,
-        ::Tags::deriv<Tags::ConformalMetric<DataType, 3, Frame::Inertial>,
-                      tmpl::size_t<3>, Frame::Inertial>,
-        gr::Tags::TraceExtrinsicCurvature<DataType>,
-        ::Tags::dt<gr::Tags::TraceExtrinsicCurvature<DataType>>,
-        Tags::ConformalFactor<DataType>,
-        ::Tags::deriv<Tags::ConformalFactor<DataType>, tmpl::size_t<3>,
-                      Frame::Inertial>,
-        gr::Tags::Lapse<DataType>, Tags::LapseTimesConformalFactor<DataType>,
-        ::Tags::deriv<Tags::LapseTimesConformalFactor<DataType>,
-                      tmpl::size_t<3>, Frame::Inertial>,
-        Tags::ShiftBackground<DataType, 3, Frame::Inertial>,
-        Tags::LongitudinalShiftBackgroundMinusDtConformalMetric<
-            DataType, 3, Frame::Inertial>,
-        Tags::ShiftExcess<DataType, 3, Frame::Inertial>,
-        Tags::ShiftStrain<DataType, 3, Frame::Inertial>,
         gr::Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 0>,
         gr::Tags::Conformal<gr::Tags::StressTrace<DataType>, 0>,
         gr::Tags::Conformal<
@@ -59,7 +43,19 @@ template <typename DataType>
 struct KerrVariables : CommonVariables<DataType, KerrVariablesCache<DataType>> {
   static constexpr size_t Dim = 3;
   using Cache = KerrVariablesCache<DataType>;
-  using CommonVariables<DataType, KerrVariablesCache<DataType>>::operator();
+  using Base = CommonVariables<DataType, KerrVariablesCache<DataType>>;
+  using Base::operator();
+
+  KerrVariables(
+      std::optional<std::reference_wrapper<const Mesh<Dim>>> local_mesh,
+      std::optional<std::reference_wrapper<const InverseJacobian<
+          DataType, Dim, Frame::ElementLogical, Frame::Inertial>>>
+          local_inv_jacobian,
+      const tnsr::I<DataType, 3>& local_x,
+      gr::Solutions::KerrSchild::IntermediateVars<DataType> local_kerr_schild)
+      : Base(std::move(local_mesh), std::move(local_inv_jacobian)),
+        x(local_x),
+        kerr_schild(std::move(local_kerr_schild)) {}
 
   const tnsr::I<DataType, Dim>& x;
   mutable gr::Solutions::KerrSchild::IntermediateVars<DataType> kerr_schild;
@@ -67,60 +63,67 @@ struct KerrVariables : CommonVariables<DataType, KerrVariablesCache<DataType>> {
   void operator()(
       gsl::not_null<tnsr::ii<DataType, Dim>*> conformal_metric,
       gsl::not_null<Cache*> cache,
-      Tags::ConformalMetric<DataType, Dim, Frame::Inertial> /*meta*/) const;
-  void operator()(gsl::not_null<tnsr::II<DataType, Dim>*> inv_conformal_metric,
-                  gsl::not_null<Cache*> cache,
-                  Tags::InverseConformalMetric<DataType, Dim,
-                                               Frame::Inertial> /*meta*/) const;
+      Tags::ConformalMetric<DataType, Dim, Frame::Inertial> /*meta*/)
+      const override;
+  void operator()(
+      gsl::not_null<tnsr::II<DataType, Dim>*> inv_conformal_metric,
+      gsl::not_null<Cache*> cache,
+      Tags::InverseConformalMetric<DataType, Dim, Frame::Inertial> /*meta*/)
+      const override;
   void operator()(
       gsl::not_null<tnsr::ijj<DataType, Dim>*> deriv_conformal_metric,
       gsl::not_null<Cache*> cache,
       ::Tags::deriv<Tags::ConformalMetric<DataType, Dim, Frame::Inertial>,
-                    tmpl::size_t<Dim>, Frame::Inertial> /*meta*/) const;
-  void operator()(gsl::not_null<Scalar<DataType>*> trace_extrinsic_curvature,
-                  gsl::not_null<Cache*> cache,
-                  gr::Tags::TraceExtrinsicCurvature<DataType> /*meta*/) const;
+                    tmpl::size_t<Dim>, Frame::Inertial> /*meta*/)
+      const override;
+  void operator()(
+      gsl::not_null<Scalar<DataType>*> trace_extrinsic_curvature,
+      gsl::not_null<Cache*> cache,
+      gr::Tags::TraceExtrinsicCurvature<DataType> /*meta*/) const override;
   void operator()(
       gsl::not_null<Scalar<DataType>*> dt_trace_extrinsic_curvature,
       gsl::not_null<Cache*> cache,
-      ::Tags::dt<gr::Tags::TraceExtrinsicCurvature<DataType>> /*meta*/) const;
+      ::Tags::dt<gr::Tags::TraceExtrinsicCurvature<DataType>> /*meta*/)
+      const override;
   void operator()(gsl::not_null<Scalar<DataType>*> conformal_factor,
                   gsl::not_null<Cache*> cache,
-                  Tags::ConformalFactor<DataType> /*meta*/) const;
+                  Tags::ConformalFactor<DataType> /*meta*/) const override;
   void operator()(
       gsl::not_null<tnsr::i<DataType, Dim>*> conformal_factor_gradient,
       gsl::not_null<Cache*> cache,
       ::Tags::deriv<Xcts::Tags::ConformalFactor<DataType>, tmpl::size_t<Dim>,
-                    Frame::Inertial> /*meta*/) const;
+                    Frame::Inertial> /*meta*/) const override;
   void operator()(gsl::not_null<Scalar<DataType>*> lapse,
                   gsl::not_null<Cache*> cache,
-                  gr::Tags::Lapse<DataType> /*meta*/) const;
-  void operator()(gsl::not_null<Scalar<DataType>*> lapse_times_conformal_factor,
-                  gsl::not_null<Cache*> cache,
-                  Tags::LapseTimesConformalFactor<DataType> /*meta*/) const;
+                  gr::Tags::Lapse<DataType> /*meta*/) const override;
   void operator()(
-      gsl::not_null<tnsr::i<DataType, Dim>*>
-          lapse_times_conformal_factor_gradient,
+      gsl::not_null<Scalar<DataType>*> lapse_times_conformal_factor,
       gsl::not_null<Cache*> cache,
-      ::Tags::deriv<Tags::LapseTimesConformalFactor<DataType>,
-                    tmpl::size_t<Dim>, Frame::Inertial> /*meta*/) const;
+      Tags::LapseTimesConformalFactor<DataType> /*meta*/) const override;
+  void operator()(gsl::not_null<tnsr::i<DataType, Dim>*>
+                      lapse_times_conformal_factor_gradient,
+                  gsl::not_null<Cache*> cache,
+                  ::Tags::deriv<Tags::LapseTimesConformalFactor<DataType>,
+                                tmpl::size_t<Dim>, Frame::Inertial> /*meta*/)
+      const override;
   void operator()(
       gsl::not_null<tnsr::I<DataType, Dim>*> shift_background,
       gsl::not_null<Cache*> cache,
-      Tags::ShiftBackground<DataType, Dim, Frame::Inertial> /*meta*/) const;
+      Tags::ShiftBackground<DataType, Dim, Frame::Inertial> /*meta*/)
+      const override;
   void operator()(gsl::not_null<tnsr::II<DataType, Dim, Frame::Inertial>*>
                       longitudinal_shift_background_minus_dt_conformal_metric,
                   gsl::not_null<Cache*> cache,
                   Tags::LongitudinalShiftBackgroundMinusDtConformalMetric<
-                      DataType, Dim, Frame::Inertial> /*meta*/) const;
-  void operator()(
-      gsl::not_null<tnsr::I<DataType, Dim>*> shift_excess,
-      gsl::not_null<Cache*> cache,
-      Tags::ShiftExcess<DataType, Dim, Frame::Inertial> /*meta*/) const;
-  void operator()(
-      gsl::not_null<tnsr::ii<DataType, Dim>*> shift_strain,
-      gsl::not_null<Cache*> cache,
-      Tags::ShiftStrain<DataType, Dim, Frame::Inertial> /*meta*/) const;
+                      DataType, Dim, Frame::Inertial> /*meta*/) const override;
+  void operator()(gsl::not_null<tnsr::I<DataType, Dim>*> shift_excess,
+                  gsl::not_null<Cache*> cache,
+                  Tags::ShiftExcess<DataType, Dim, Frame::Inertial> /*meta*/)
+      const override;
+  void operator()(gsl::not_null<tnsr::ii<DataType, Dim>*> shift_strain,
+                  gsl::not_null<Cache*> cache,
+                  Tags::ShiftStrain<DataType, Dim, Frame::Inertial> /*meta*/)
+      const override;
   void operator()(
       gsl::not_null<Scalar<DataType>*> energy_density,
       gsl::not_null<Cache*> cache,
@@ -191,8 +194,7 @@ class Kerr : public AnalyticSolution<Registrars>,
     typename VarsComputer::Cache cache{
         get_size(*x.begin()),
         VarsComputer{
-            {{std::nullopt, std::nullopt}},
-            x,
+            std::nullopt, std::nullopt, x,
             gr::Solutions::KerrSchild::IntermediateVars<DataType>{*this, x}}};
     return {cache.get_var(RequestedTags{})...};
   }
@@ -207,8 +209,7 @@ class Kerr : public AnalyticSolution<Registrars>,
     typename VarsComputer::Cache cache{
         get_size(*x.begin()),
         VarsComputer{
-            {{mesh, inv_jacobian}},
-            x,
+            mesh, inv_jacobian, x,
             gr::Solutions::KerrSchild::IntermediateVars<DataType>{*this, x}}};
     return {cache.get_var(RequestedTags{})...};
   }

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.cpp
@@ -182,9 +182,9 @@ void SchwarzschildVariables<DataType>::operator()(
     const gsl::not_null<Scalar<DataType>*> lapse,
     const gsl::not_null<Cache*> cache,
     gr::Tags::Lapse<DataType> /*meta*/) const {
-  *lapse = cache->get_var(Tags::LapseTimesConformalFactor<DataType>{});
+  *lapse = cache->get_var(*this, Tags::LapseTimesConformalFactor<DataType>{});
   const auto& conformal_factor =
-      cache->get_var(Tags::ConformalFactor<DataType>{});
+      cache->get_var(*this, Tags::ConformalFactor<DataType>{});
   get(*lapse) /= get(conformal_factor);
 }
 
@@ -196,8 +196,8 @@ void SchwarzschildVariables<DataType>::operator()(
     ::Tags::deriv<Tags::LapseTimesConformalFactor<DataType>, tmpl::size_t<3>,
                   Frame::Inertial> /*meta*/) const {
   *lapse_times_conformal_factor_gradient =
-      cache->get_var(::Tags::deriv<Tags::ConformalFactor<DataType>,
-                                   tmpl::size_t<3>, Frame::Inertial>{});
+      cache->get_var(*this, ::Tags::deriv<Tags::ConformalFactor<DataType>,
+                                          tmpl::size_t<3>, Frame::Inertial>{});
   get<0>(*lapse_times_conformal_factor_gradient) *= -1.;
   get<1>(*lapse_times_conformal_factor_gradient) *= -1.;
   get<2>(*lapse_times_conformal_factor_gradient) *= -1.;

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.hpp
@@ -147,22 +147,6 @@ using SchwarzschildVariablesCache = cached_temp_buffer_from_typelist<
     SchwarzschildVariables<DataType>,
     tmpl::push_front<
         common_tags<DataType>,
-        Tags::ConformalMetric<DataType, 3, Frame::Inertial>,
-        ::Tags::deriv<Tags::ConformalMetric<DataType, 3, Frame::Inertial>,
-                      tmpl::size_t<3>, Frame::Inertial>,
-        gr::Tags::TraceExtrinsicCurvature<DataType>,
-        ::Tags::dt<gr::Tags::TraceExtrinsicCurvature<DataType>>,
-        Tags::ConformalFactor<DataType>,
-        ::Tags::deriv<Tags::ConformalFactor<DataType>, tmpl::size_t<3>,
-                      Frame::Inertial>,
-        gr::Tags::Lapse<DataType>, Tags::LapseTimesConformalFactor<DataType>,
-        ::Tags::deriv<Tags::LapseTimesConformalFactor<DataType>,
-                      tmpl::size_t<3>, Frame::Inertial>,
-        Tags::ShiftBackground<DataType, 3, Frame::Inertial>,
-        Tags::LongitudinalShiftBackgroundMinusDtConformalMetric<
-            DataType, 3, Frame::Inertial>,
-        Tags::ShiftExcess<DataType, 3, Frame::Inertial>,
-        Tags::ShiftStrain<DataType, 3, Frame::Inertial>,
         gr::Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 0>,
         gr::Tags::Conformal<gr::Tags::StressTrace<DataType>, 0>,
         gr::Tags::Conformal<
@@ -174,75 +158,91 @@ struct SchwarzschildVariables
   static constexpr size_t Dim = 3;
   static constexpr int ConformalMatterScale = 0;
   using Cache = SchwarzschildVariablesCache<DataType>;
-  using CommonVariables<DataType,
-                        SchwarzschildVariablesCache<DataType>>::operator();
+  using Base = CommonVariables<DataType, SchwarzschildVariablesCache<DataType>>;
+  using Base::operator();
+
+  SchwarzschildVariables(
+      std::optional<std::reference_wrapper<const Mesh<Dim>>> local_mesh,
+      std::optional<std::reference_wrapper<const InverseJacobian<
+          DataType, Dim, Frame::ElementLogical, Frame::Inertial>>>
+          local_inv_jacobian,
+      const tnsr::I<DataType, 3>& local_x, const double local_mass,
+      const SchwarzschildCoordinates local_coordinate_system)
+      : Base(std::move(local_mesh), std::move(local_inv_jacobian)),
+        x(local_x),
+        mass(local_mass),
+        coordinate_system(local_coordinate_system) {}
 
   const tnsr::I<DataType, 3>& x;
   double mass;
   SchwarzschildCoordinates coordinate_system;
 
-  void operator()(
-      gsl::not_null<tnsr::ii<DataType, 3>*> conformal_metric,
-      gsl::not_null<Cache*> cache,
-      Tags::ConformalMetric<DataType, 3, Frame::Inertial> /*meta*/) const;
-  void operator()(gsl::not_null<tnsr::II<DataType, 3>*> inv_conformal_metric,
+  void operator()(gsl::not_null<tnsr::ii<DataType, 3>*> conformal_metric,
                   gsl::not_null<Cache*> cache,
-                  Tags::InverseConformalMetric<DataType, 3,
-                                               Frame::Inertial> /*meta*/) const;
+                  Tags::ConformalMetric<DataType, 3, Frame::Inertial> /*meta*/)
+      const override;
+  void operator()(
+      gsl::not_null<tnsr::II<DataType, 3>*> inv_conformal_metric,
+      gsl::not_null<Cache*> cache,
+      Tags::InverseConformalMetric<DataType, 3, Frame::Inertial> /*meta*/)
+      const override;
   void operator()(
       gsl::not_null<tnsr::ijj<DataType, 3>*> deriv_conformal_metric,
       gsl::not_null<Cache*> cache,
       ::Tags::deriv<Tags::ConformalMetric<DataType, 3, Frame::Inertial>,
-                    tmpl::size_t<3>, Frame::Inertial> /*meta*/) const;
-  void operator()(gsl::not_null<Scalar<DataType>*> trace_extrinsic_curvature,
-                  gsl::not_null<Cache*> cache,
-                  gr::Tags::TraceExtrinsicCurvature<DataType> /*meta*/) const;
+                    tmpl::size_t<3>, Frame::Inertial> /*meta*/) const override;
+  void operator()(
+      gsl::not_null<Scalar<DataType>*> trace_extrinsic_curvature,
+      gsl::not_null<Cache*> cache,
+      gr::Tags::TraceExtrinsicCurvature<DataType> /*meta*/) const override;
   void operator()(
       gsl::not_null<tnsr::i<DataType, 3>*> trace_extrinsic_curvature_gradient,
       gsl::not_null<Cache*> cache,
       ::Tags::deriv<gr::Tags::TraceExtrinsicCurvature<DataType>,
-                    tmpl::size_t<3>, Frame::Inertial> /*meta*/) const;
+                    tmpl::size_t<3>, Frame::Inertial> /*meta*/) const override;
   void operator()(
       gsl::not_null<Scalar<DataType>*> dt_trace_extrinsic_curvature,
       gsl::not_null<Cache*> cache,
-      ::Tags::dt<gr::Tags::TraceExtrinsicCurvature<DataType>> /*meta*/) const;
+      ::Tags::dt<gr::Tags::TraceExtrinsicCurvature<DataType>> /*meta*/)
+      const override;
   void operator()(gsl::not_null<Scalar<DataType>*> conformal_factor,
                   gsl::not_null<Cache*> cache,
-                  Tags::ConformalFactor<DataType> /*meta*/) const;
+                  Tags::ConformalFactor<DataType> /*meta*/) const override;
   void operator()(
       gsl::not_null<tnsr::i<DataType, 3>*> conformal_factor_gradient,
       gsl::not_null<Cache*> cache,
       ::Tags::deriv<Xcts::Tags::ConformalFactor<DataType>, tmpl::size_t<3>,
-                    Frame::Inertial> /*meta*/) const;
+                    Frame::Inertial> /*meta*/) const override;
   void operator()(gsl::not_null<Scalar<DataType>*> lapse,
                   gsl::not_null<Cache*> cache,
-                  gr::Tags::Lapse<DataType> /*meta*/) const;
-  void operator()(gsl::not_null<Scalar<DataType>*> lapse_times_conformal_factor,
-                  gsl::not_null<Cache*> cache,
-                  Tags::LapseTimesConformalFactor<DataType> /*meta*/) const;
+                  gr::Tags::Lapse<DataType> /*meta*/) const override;
+  void operator()(
+      gsl::not_null<Scalar<DataType>*> lapse_times_conformal_factor,
+      gsl::not_null<Cache*> cache,
+      Tags::LapseTimesConformalFactor<DataType> /*meta*/) const override;
   void operator()(
       gsl::not_null<tnsr::i<DataType, 3>*>
           lapse_times_conformal_factor_gradient,
       gsl::not_null<Cache*> cache,
       ::Tags::deriv<Tags::LapseTimesConformalFactor<DataType>, tmpl::size_t<3>,
-                    Frame::Inertial> /*meta*/) const;
-  void operator()(
-      gsl::not_null<tnsr::I<DataType, 3>*> shift_background,
-      gsl::not_null<Cache*> cache,
-      Tags::ShiftBackground<DataType, 3, Frame::Inertial> /*meta*/) const;
+                    Frame::Inertial> /*meta*/) const override;
+  void operator()(gsl::not_null<tnsr::I<DataType, 3>*> shift_background,
+                  gsl::not_null<Cache*> cache,
+                  Tags::ShiftBackground<DataType, 3, Frame::Inertial> /*meta*/)
+      const override;
   void operator()(gsl::not_null<tnsr::II<DataType, 3, Frame::Inertial>*>
                       longitudinal_shift_background_minus_dt_conformal_metric,
                   gsl::not_null<Cache*> cache,
                   Tags::LongitudinalShiftBackgroundMinusDtConformalMetric<
-                      DataType, 3, Frame::Inertial> /*meta*/) const;
+                      DataType, 3, Frame::Inertial> /*meta*/) const override;
   void operator()(
       gsl::not_null<tnsr::I<DataType, 3>*> shift_excess,
       gsl::not_null<Cache*> cache,
-      Tags::ShiftExcess<DataType, 3, Frame::Inertial> /*meta*/) const;
+      Tags::ShiftExcess<DataType, 3, Frame::Inertial> /*meta*/) const override;
   void operator()(
       gsl::not_null<tnsr::ii<DataType, 3>*> shift_strain,
       gsl::not_null<Cache*> cache,
-      Tags::ShiftStrain<DataType, 3, Frame::Inertial> /*meta*/) const;
+      Tags::ShiftStrain<DataType, 3, Frame::Inertial> /*meta*/) const override;
   void operator()(gsl::not_null<Scalar<DataType>*> energy_density,
                   gsl::not_null<Cache*> cache,
                   gr::Tags::Conformal<gr::Tags::EnergyDensity<DataType>,
@@ -312,8 +312,7 @@ class Schwarzschild : public AnalyticSolution<Registrars>,
     using VarsComputer = detail::SchwarzschildVariables<DataType>;
     typename VarsComputer::Cache cache{
         get_size(*x.begin()),
-        VarsComputer{
-            {{std::nullopt, std::nullopt}}, x, mass_, coordinate_system_}};
+        VarsComputer{std::nullopt, std::nullopt, x, mass_, coordinate_system_}};
     return {cache.get_var(RequestedTags{})...};
   }
 
@@ -326,7 +325,7 @@ class Schwarzschild : public AnalyticSolution<Registrars>,
     using VarsComputer = detail::SchwarzschildVariables<DataVector>;
     typename VarsComputer::Cache cache{
         get_size(*x.begin()),
-        VarsComputer{{{mesh, inv_jacobian}}, x, mass_, coordinate_system_}};
+        VarsComputer{mesh, inv_jacobian, x, mass_, coordinate_system_}};
     return {cache.get_var(RequestedTags{})...};
   }
 

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.hpp
@@ -140,11 +140,7 @@ bool operator==(const SchwarzschildImpl& lhs, const SchwarzschildImpl& rhs);
 bool operator!=(const SchwarzschildImpl& lhs, const SchwarzschildImpl& rhs);
 
 template <typename DataType>
-struct SchwarzschildVariables;
-
-template <typename DataType>
 using SchwarzschildVariablesCache = cached_temp_buffer_from_typelist<
-    SchwarzschildVariables<DataType>,
     tmpl::push_front<
         common_tags<DataType>,
         gr::Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 0>,
@@ -310,10 +306,10 @@ class Schwarzschild : public AnalyticSolution<Registrars>,
       const tnsr::I<DataType, 3, Frame::Inertial>& x,
       tmpl::list<RequestedTags...> /*meta*/) const {
     using VarsComputer = detail::SchwarzschildVariables<DataType>;
-    typename VarsComputer::Cache cache{
-        get_size(*x.begin()),
-        VarsComputer{std::nullopt, std::nullopt, x, mass_, coordinate_system_}};
-    return {cache.get_var(RequestedTags{})...};
+    typename VarsComputer::Cache cache{get_size(*x.begin())};
+    const VarsComputer computer{std::nullopt, std::nullopt, x, mass_,
+                                coordinate_system_};
+    return {cache.get_var(computer, RequestedTags{})...};
   }
 
   template <typename... RequestedTags>
@@ -323,10 +319,10 @@ class Schwarzschild : public AnalyticSolution<Registrars>,
                             Frame::Inertial>& inv_jacobian,
       tmpl::list<RequestedTags...> /*meta*/) const {
     using VarsComputer = detail::SchwarzschildVariables<DataVector>;
-    typename VarsComputer::Cache cache{
-        get_size(*x.begin()),
-        VarsComputer{mesh, inv_jacobian, x, mass_, coordinate_system_}};
-    return {cache.get_var(RequestedTags{})...};
+    typename VarsComputer::Cache cache{get_size(*x.begin())};
+    const VarsComputer computer{mesh, inv_jacobian, x, mass_,
+                                coordinate_system_};
+    return {cache.get_var(computer, RequestedTags{})...};
   }
 
   void pup(PUP::er& p) override {

--- a/src/PointwiseFunctions/Xcts/SpacetimeQuantities.cpp
+++ b/src/PointwiseFunctions/Xcts/SpacetimeQuantities.cpp
@@ -65,8 +65,8 @@ void SpacetimeQuantitiesComputer::operator()(
     const gsl::not_null<Cache*> cache,
     ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
                   tmpl::size_t<3>, Frame::Inertial> /*meta*/) const {
-  const auto& spatial_metric =
-      cache->get_var(gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>{});
+  const auto& spatial_metric = cache->get_var(
+      *this, gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>{});
   detail::deriv_tensor(deriv_spatial_metric, spatial_metric, mesh,
                        inv_jacobian);
 }
@@ -77,10 +77,11 @@ void SpacetimeQuantitiesComputer::operator()(
     gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial,
                                            DataVector> /*meta*/) const {
   const auto& deriv_spatial_metric = cache->get_var(
+      *this,
       ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
                     tmpl::size_t<3>, Frame::Inertial>{});
   const auto& inv_spatial_metric = cache->get_var(
-      gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>{});
+      *this, gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>{});
   gr::christoffel_second_kind(christoffel_second_kind, deriv_spatial_metric,
                               inv_spatial_metric);
 }
@@ -93,6 +94,7 @@ void SpacetimeQuantitiesComputer::operator()(
         gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial, DataVector>,
         tmpl::size_t<3>, Frame::Inertial> /*meta*/) const {
   const auto& christoffel_second_kind = cache->get_var(
+      *this,
       gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial, DataVector>{});
   detail::deriv_tensor(deriv_christoffel_second_kind, christoffel_second_kind,
                        mesh, inv_jacobian);
@@ -103,8 +105,10 @@ void SpacetimeQuantitiesComputer::operator()(
     const gsl::not_null<Cache*> cache,
     gr::Tags::SpatialRicci<3, Frame::Inertial, DataVector> /*meta*/) const {
   const auto& christoffel_second_kind = cache->get_var(
+      *this,
       gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial, DataVector>{});
   const auto& deriv_christoffel_second_kind = cache->get_var(
+      *this,
       ::Tags::deriv<gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial,
                                                            DataVector>,
                     tmpl::size_t<3>, Frame::Inertial>{});
@@ -134,7 +138,7 @@ void SpacetimeQuantitiesComputer::operator()(
     ::Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataVector>,
                   tmpl::size_t<3>, Frame::Inertial> /*meta*/) const {
   const auto& shift =
-      cache->get_var(gr::Tags::Shift<3, Frame::Inertial, DataVector>{});
+      cache->get_var(*this, gr::Tags::Shift<3, Frame::Inertial, DataVector>{});
   detail::deriv_tensor(deriv_shift, shift, mesh, inv_jacobian);
 }
 
@@ -153,17 +157,19 @@ void SpacetimeQuantitiesComputer::operator()(
     const gsl::not_null<Cache*> cache,
     gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector> /*meta*/)
     const {
-  const auto& lapse = cache->get_var(gr::Tags::Lapse<DataVector>{});
+  const auto& lapse = cache->get_var(*this, gr::Tags::Lapse<DataVector>{});
   const auto& shift =
-      cache->get_var(gr::Tags::Shift<3, Frame::Inertial, DataVector>{});
+      cache->get_var(*this, gr::Tags::Shift<3, Frame::Inertial, DataVector>{});
   const auto& deriv_shift = cache->get_var(
-      ::Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataVector>,
-                    tmpl::size_t<3>, Frame::Inertial>{});
-  const auto& spatial_metric =
-      cache->get_var(gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>{});
+      *this, ::Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+                           tmpl::size_t<3>, Frame::Inertial>{});
+  const auto& spatial_metric = cache->get_var(
+      *this, gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>{});
   const auto& dt_spatial_metric = cache->get_var(
+      *this,
       ::Tags::dt<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>{});
   const auto& deriv_spatial_metric = cache->get_var(
+      *this,
       ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
                     tmpl::size_t<3>, Frame::Inertial>{});
   gr::extrinsic_curvature(extrinsic_curvature, lapse, shift, deriv_shift,
@@ -176,9 +182,9 @@ void SpacetimeQuantitiesComputer::operator()(
     const gsl::not_null<Cache*> cache,
     detail::ExtrinsicCurvatureSquare<DataVector> /*meta*/) const {
   const auto& extrinsic_curvature = cache->get_var(
-      gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>{});
+      *this, gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>{});
   const auto& inv_spatial_metric = cache->get_var(
-      gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>{});
+      *this, gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>{});
   get(*extrinsic_curvature_square) = 0.;
   for (size_t i = 0; i < 3; ++i) {
     for (size_t j = 0; j < 3; ++j) {
@@ -199,8 +205,9 @@ void SpacetimeQuantitiesComputer::operator()(
     ::Tags::deriv<gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>,
                   tmpl::size_t<3>, Frame::Inertial> /*meta*/) const {
   const auto& extrinsic_curvature = cache->get_var(
-      gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>{});
+      *this, gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>{});
   const auto& christoffel = cache->get_var(
+      *this,
       gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial, DataVector>{});
   detail::deriv_tensor(deriv_extrinsic_curvature, extrinsic_curvature, mesh,
                        inv_jacobian);
@@ -222,14 +229,14 @@ void SpacetimeQuantitiesComputer::operator()(
     const gsl::not_null<Scalar<DataVector>*> hamiltonian_constraint,
     const gsl::not_null<Cache*> cache,
     gr::Tags::HamiltonianConstraint<DataVector> /*meta*/) const {
-  const auto& ricci_tensor =
-      cache->get_var(gr::Tags::SpatialRicci<3, Frame::Inertial, DataVector>{});
+  const auto& ricci_tensor = cache->get_var(
+      *this, gr::Tags::SpatialRicci<3, Frame::Inertial, DataVector>{});
   const auto& extrinsic_curvature = cache->get_var(
-      gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>{});
+      *this, gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>{});
   const auto& inv_spatial_metric = cache->get_var(
-      gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>{});
+      *this, gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>{});
   const auto& extrinsic_curvature_square =
-      cache->get_var(detail::ExtrinsicCurvatureSquare<DataVector>{});
+      cache->get_var(*this, detail::ExtrinsicCurvatureSquare<DataVector>{});
   get(*hamiltonian_constraint) =
       get(trace(ricci_tensor, inv_spatial_metric)) +
              square(get(trace(extrinsic_curvature, inv_spatial_metric))) -
@@ -242,11 +249,11 @@ void SpacetimeQuantitiesComputer::operator()(
     gr::Tags::MomentumConstraint<3, Frame::Inertial, DataVector> /*meta*/)
     const {
   const auto& deriv_extrinsic_curvature = cache->get_var(
-      ::Tags::deriv<
-          gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>,
-          tmpl::size_t<3>, Frame::Inertial>{});
+      *this, ::Tags::deriv<
+                 gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>,
+                 tmpl::size_t<3>, Frame::Inertial>{});
   const auto& inv_spatial_metric = cache->get_var(
-      gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>{});
+      *this, gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>{});
   for (size_t i = 0; i < 3; ++i) {
     momentum_constraint->get(i) = 0.;
     for (size_t j = 0; j < 3; ++j) {

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_KerrSchild.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_KerrSchild.cpp
@@ -207,9 +207,9 @@ void test_numerical_deriv_det_spatial_metric(const DataVector& used_for_size) {
   // Compute expected numerical derivative of the determinant
   const double null_vector_0 = -1.0;
   gr::Solutions::KerrSchild::IntermediateComputer<DataVector, FrameType>
-      ks_computer(solution, x, null_vector_0);
+      ks_computer(solution, x);
   gr::Solutions::KerrSchild::IntermediateVars<DataVector, FrameType> ks_cache(
-      solution, x);
+      num_points_3d);
 
   auto H = make_with_value<Scalar<DataVector>>(
       used_for_size, std::numeric_limits<double>::signaling_NaN());


### PR DESCRIPTION
## Proposed changes

This makes it easier to work with subclasses of the cached-buffer computer, which is needed for #3685. Please see that PR for context.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
