### PR TITLE
Add ControlError protocol and tag

### DIFF
--- a/src/ControlSystem/Actions/Initialization.hpp
+++ b/src/ControlSystem/Actions/Initialization.hpp
@@ -29,14 +29,15 @@ namespace Actions {
  * - Uses:
  *   - `control_system::Tags::ControlSystemInputs<ControlSystem>`
  * - Adds:
- *   - `control_system::Tags::Averager<2>`
- *   - `control_system::Tags::Controller<2>`
+ *   - `control_system::Tags::Averager<deriv_order>`
+ *   - `control_system::Tags::Controller<deriv_order>`
  *   - `control_system::Tags::TimescaleTuner`
+ *   - `control_system::Tags::ControlError`
  *   - `control_system::Tags::ControlSystemName`
  *   - `control_system::Tags::WriteDataToDisk`
  * - Removes: Nothing
  * - Modifies:
- *   - `control_system::Tags::Controller<2>`
+ *   - `control_system::Tags::Controller<deriv_order>`
  *
  * \note This action relies on the `SetupDataBox` aggregated initialization
  * mechanism, so `Actions::SetupDataBox` must be present in the `Initialization`
@@ -57,6 +58,7 @@ struct Initialize {
       tmpl::list<control_system::Tags::Averager<deriv_order>,
                  control_system::Tags::Controller<deriv_order>,
                  control_system::Tags::TimescaleTuner,
+                 control_system::Tags::ControlError<ControlSystem>,
                  control_system::Tags::ControlSystemName>;
 
   using simple_tags =
@@ -77,7 +79,8 @@ struct Initialize {
         db::get<control_system::Tags::ControlSystemInputs<ControlSystem>>(box);
     ::Initialization::mutate_assign<tags_to_be_initialized>(
         make_not_null(&box), option_holder.averager, option_holder.controller,
-        option_holder.tuner, ControlSystem::name());
+        option_holder.tuner, option_holder.control_error,
+        ControlSystem::name());
 
     // Set the initial time between updates using the initial timescale
     const auto& tuner = db::get<control_system::Tags::TimescaleTuner>(box);

--- a/src/ControlSystem/Protocols/CMakeLists.txt
+++ b/src/ControlSystem/Protocols/CMakeLists.txt
@@ -5,6 +5,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  ControlError.hpp
   ControlSystem.hpp
   Measurement.hpp
   NamespaceDocs.hpp

--- a/src/ControlSystem/Protocols/ControlError.hpp
+++ b/src/ControlSystem/Protocols/ControlError.hpp
@@ -1,0 +1,42 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <string>
+#include <type_traits>
+
+#include "DataStructures/DataVector.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace control_system::protocols {
+/// \brief Definition of a control error
+///
+/// A control error is used within a control system to compute how far off the
+/// the value you are controlling is from its expected value.
+///
+/// A conforming type must specify:
+///
+/// - a call operator that returns a DataVector with a signature the same as in
+///   the example shown here:
+///   \snippet Helpers/ControlSystem/Examples.hpp ControlError
+struct ControlError {
+  template <typename ConformingType>
+  struct test {
+    struct DummyMetavariables;
+    struct DummyTupleTags;
+
+    static_assert(
+        std::is_same_v<
+            DataVector,
+            decltype(ConformingType{}(
+                std::declval<
+                    const Parallel::GlobalCache<DummyMetavariables>&>(),
+                std::declval<const double>(),
+                std::declval<const std::string&>(),
+                std::declval<const tuples::TaggedTuple<DummyTupleTags>&>()))>);
+  };
+};
+}  // namespace control_system::protocols

--- a/src/ControlSystem/Protocols/ControlSystem.hpp
+++ b/src/ControlSystem/Protocols/ControlSystem.hpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <type_traits>
 
+#include "ControlSystem/Protocols/ControlError.hpp"
 #include "ControlSystem/Protocols/Measurement.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
@@ -34,6 +35,9 @@ namespace control_system::protocols {
 /// - a type alias `simple_tags` to a `tmpl::list` of simple tags needed for the
 ///   control system. These tags will be added to the DataBox of the
 ///   ControlComponent. The list may be empty.
+///
+/// - a type alias `control_error` to a struct that conforms to the ControlError
+///   protocol
 ///
 /// - a static constexpr size_t `deriv_order` which is the order of the highest
 ///   derivative of a FunctionOfTime that you wish to control. Typically, this
@@ -90,6 +94,9 @@ struct ControlSystem {
     };
 
     using simple_tags = typename ConformingType::simple_tags;
+
+    using control_error = typename ConformingType::control_error;
+    static_assert(tt::assert_conforms_to<control_error, ControlError>);
 
     static constexpr size_t deriv_order = ConformingType::deriv_order;
 

--- a/src/ControlSystem/Tags.hpp
+++ b/src/ControlSystem/Tags.hpp
@@ -127,6 +127,14 @@ template <size_t DerivOrder>
 struct Controller : db::SimpleTag {
   using type = ::Controller<DerivOrder>;
 };
+
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ControlSystemGroup
+/// DataBox tag for the control error
+template <typename ControlSystem>
+struct ControlError : db::SimpleTag {
+  using type = typename ControlSystem::control_error;
+};
 }  // namespace Tags
 
 /// \ingroup ControlSystemGroup
@@ -162,15 +170,25 @@ struct OptionHolder {
         "which other timescales are based of off."};
   };
 
-  using options = tmpl::list<Averager, Controller, TimescaleTuner>;
+  struct ControlError {
+    using type = typename ControlSystem::control_error;
+    static constexpr Options::String help = {
+        "Computes the control error for the control system based on quantities "
+        "in the simulation."};
+  };
+
+  using options =
+      tmpl::list<Averager, Controller, TimescaleTuner, ControlError>;
   static constexpr Options::String help = {"Options for a control system."};
 
   OptionHolder(::Averager<deriv_order> input_averager,
                ::Controller<deriv_order> input_controller,
-               ::TimescaleTuner input_tuner)
+               ::TimescaleTuner input_tuner,
+               typename ControlSystem::control_error input_control_error)
       : averager(std::move(input_averager)),
         controller(std::move(input_controller)),
-        tuner(std::move(input_tuner)) {}
+        tuner(std::move(input_tuner)),
+        control_error(std::move(input_control_error)) {}
 
   OptionHolder() = default;
   OptionHolder(const OptionHolder& /*rhs*/) = default;
@@ -184,6 +202,7 @@ struct OptionHolder {
     p | averager;
     p | controller;
     p | tuner;
+    p | control_error;
   };
 
   // These members are specifically made public for easy access during
@@ -191,5 +210,6 @@ struct OptionHolder {
   ::Averager<deriv_order> averager{};
   ::Controller<deriv_order> controller{};
   ::TimescaleTuner tuner{};
+  typename ControlSystem::control_error control_error{};
 };
 }  // namespace control_system

--- a/tests/Unit/ControlSystem/Actions/Test_Initialization.cpp
+++ b/tests/Unit/ControlSystem/Actions/Test_Initialization.cpp
@@ -28,6 +28,7 @@ struct MockControlSystem
   static std::string name() { return pretty_type::short_name<Label>(); }
   static std::string component_name(const size_t i) { return get_output(i); }
   using measurement = Measurement;
+  using control_error = control_system::TestHelpers::ControlError;
   static constexpr size_t deriv_order = 2;
   using simple_tags = tmpl::list<>;
 };

--- a/tests/Unit/ControlSystem/Actions/Test_Initialization.cpp
+++ b/tests/Unit/ControlSystem/Actions/Test_Initialization.cpp
@@ -51,6 +51,7 @@ struct MockControlComponent {
                  control_system::Tags::TimescaleTuner,
                  control_system::Tags::ControlSystemName,
                  control_system::Tags::WriteDataToDisk,
+                 control_system::Tags::ControlError<mock_control_sys>,
                  control_system::Tags::Controller<2>>;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
@@ -80,14 +81,16 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Initialization",
   std::string controlsys_name{"LabelA"};
   std::string controlsys_name_empty{};
   bool write_data = false;
+  const control_system::TestHelpers::ControlError control_error{};
 
   tuples::tagged_tuple_from_typelist<tags> init_tuple{
       control_system::OptionHolder<mock_control_sys>{averager, controller,
-                                                     tuner},
+                                                     tuner, control_error},
       averager_empty,
       tuner_empty,
       controlsys_name_empty,
       write_data,
+      control_error,
       controller_empty};
 
   MockRuntimeSystem runner{{}};
@@ -119,6 +122,9 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Initialization",
       ActionTesting::get_databox_tag<component,
                                      control_system::Tags::WriteDataToDisk>(
           runner, 0);
+  // We don't check the control error because the example one is empty and
+  // doesn't have a comparison operator. Once a control error is added that
+  // contains member data (and thus, options), then it can be tested
 
   // Check that things haven't been initialized
   CHECK(box_averager != averager);

--- a/tests/Unit/ControlSystem/Actions/Test_InitializeMeasurements.cpp
+++ b/tests/Unit/ControlSystem/Actions/Test_InitializeMeasurements.cpp
@@ -29,6 +29,7 @@
 #include "Framework/MockDistributedObject.hpp"
 #include "Framework/MockRuntimeSystem.hpp"
 #include "Framework/MockRuntimeSystemFreeFunctions.hpp"
+#include "Helpers/ControlSystem/TestStructs.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
@@ -89,6 +90,7 @@ struct SystemA : tt::ConformsTo<control_system::protocols::ControlSystem> {
   static std::string component_name(const size_t i) { return get_output(i); }
   using simple_tags = tmpl::list<>;
   using measurement = Measurement<tmpl::list<SystemA, SystemB>>;
+  using control_error = control_system::TestHelpers::ControlError;
   struct process_measurement {
     template <typename Submeasurement>
     using argument_tags = tmpl::list<>;
@@ -100,6 +102,7 @@ struct SystemB : tt::ConformsTo<control_system::protocols::ControlSystem> {
   static std::string component_name(const size_t /*i*/) { return ""; }
   using simple_tags = tmpl::list<>;
   using measurement = Measurement<tmpl::list<SystemA, SystemB>>;
+  using control_error = control_system::TestHelpers::ControlError;
   struct process_measurement {
     template <typename Submeasurement>
     using argument_tags = tmpl::list<>;
@@ -111,6 +114,7 @@ struct SystemC : tt::ConformsTo<control_system::protocols::ControlSystem> {
   static std::string component_name(const size_t /*i*/) { return ""; }
   using simple_tags = tmpl::list<>;
   using measurement = Measurement<tmpl::list<SystemC>>;
+  using control_error = control_system::TestHelpers::ControlError;
   struct process_measurement {
     template <typename Submeasurement>
     using argument_tags = tmpl::list<>;

--- a/tests/Unit/ControlSystem/Protocols/Test_Protocols.cpp
+++ b/tests/Unit/ControlSystem/Protocols/Test_Protocols.cpp
@@ -16,3 +16,6 @@ static_assert(
 static_assert(
     tt::assert_conforms_to<control_system::TestHelpers::ExampleControlSystem,
                            control_system::protocols::ControlSystem>);
+static_assert(
+    tt::assert_conforms_to<control_system::TestHelpers::ExampleControlError,
+                           control_system::protocols::ControlError>);

--- a/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
@@ -183,10 +183,11 @@ void test_functions_of_time_tag() {
   const Averager<2> averager(0.25, true);
   const double update_fraction = 0.3;
   const Controller<2> controller(update_fraction);
+  const control_system::TestHelpers::ControlError control_error{};
 
-  OptionHolder<1> option_holder1(averager, controller, tuner1);
-  OptionHolder<2> option_holder2(averager, controller, tuner1);
-  OptionHolder<3> option_holder3(averager, controller, tuner2);
+  OptionHolder<1> option_holder1(averager, controller, tuner1, control_error);
+  OptionHolder<2> option_holder2(averager, controller, tuner1, control_error);
+  OptionHolder<3> option_holder3(averager, controller, tuner2, control_error);
 
   const double initial_time_step = 1.0;
   fot_tag::type functions_of_time = fot_tag::create_from_options<Metavariables>(
@@ -234,11 +235,12 @@ SPECTRE_TEST_CASE(
   const Averager<2> averager(0.25, true);
   const double update_fraction = 0.3;
   const Controller<2> controller(update_fraction);
+  const control_system::TestHelpers::ControlError control_error{};
 
-  OptionHolder<1> option_holder1(averager, controller, tuner);
-  OptionHolder<2> option_holder2(averager, controller, tuner);
-  OptionHolder<3> option_holder3(averager, controller, tuner);
-  OptionHolder<4> option_holder4(averager, controller, tuner);
+  OptionHolder<1> option_holder1(averager, controller, tuner, control_error);
+  OptionHolder<2> option_holder2(averager, controller, tuner, control_error);
+  OptionHolder<3> option_holder3(averager, controller, tuner, control_error);
+  OptionHolder<4> option_holder4(averager, controller, tuner, control_error);
 
   const double initial_time_step = 1.0;
   fot_tag::type functions_of_time = fot_tag::create_from_options<Metavariables>(
@@ -261,10 +263,11 @@ SPECTRE_TEST_CASE(
   const Averager<2> averager(0.25, true);
   const double update_fraction = 0.3;
   const Controller<2> controller(update_fraction);
+  const control_system::TestHelpers::ControlError control_error{};
 
-  OptionHolder<1> option_holder1(averager, controller, tuner);
-  OptionHolder<2> option_holder2(averager, controller, tuner);
-  OptionHolder<3> option_holder3(averager, controller, tuner);
+  OptionHolder<1> option_holder1(averager, controller, tuner, control_error);
+  OptionHolder<2> option_holder2(averager, controller, tuner, control_error);
+  OptionHolder<3> option_holder3(averager, controller, tuner, control_error);
 
   const double initial_time_step = 1.0;
   fot_tag::type functions_of_time = fot_tag::create_from_options<Metavariables>(

--- a/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
@@ -43,6 +43,7 @@ struct FakeControlSystem
   using measurement = control_system::TestHelpers::Measurement<
       control_system::TestHelpers::TestStructs_detail::LabelA>;
   using simple_tags = tmpl::list<>;
+  using control_error = control_system::TestHelpers::ControlError;
   struct process_measurement {
     using argument_tags = tmpl::list<>;
   };

--- a/tests/Unit/ControlSystem/Tags/Test_MeasurementTimescales.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_MeasurementTimescales.cpp
@@ -32,6 +32,7 @@ struct FakeControlSystem
   using measurement = control_system::TestHelpers::Measurement<
       control_system::TestHelpers::TestStructs_detail::LabelA>;
   using simple_tags = tmpl::list<>;
+  using control_error = control_system::TestHelpers::ControlError;
   struct process_measurement {
     using argument_tags = tmpl::list<>;
   };

--- a/tests/Unit/ControlSystem/Tags/Test_MeasurementTimescales.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_MeasurementTimescales.cpp
@@ -92,10 +92,11 @@ void test_measurement_tag() {
     const Averager<2> averager(averaging_fraction, true);
     const double update_fraction = 0.3;
     const Controller<2> controller(update_fraction);
+    const control_system::TestHelpers::ControlError control_error{};
 
-    OptionHolder<1> option_holder1(averager, controller, tuner1);
-    OptionHolder<2> option_holder2(averager, controller, tuner1);
-    OptionHolder<3> option_holder3(averager, controller, tuner2);
+    OptionHolder<1> option_holder1(averager, controller, tuner1, control_error);
+    OptionHolder<2> option_holder2(averager, controller, tuner1, control_error);
+    OptionHolder<3> option_holder3(averager, controller, tuner2, control_error);
 
     const measurement_tag::type timescales =
         measurement_tag::create_from_options<Metavariables>(
@@ -160,10 +161,11 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Tags.MeasurementTimescales.Backwards",
   const TimescaleTuner tuner2({0.1}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01, 0.99);
   const Averager<2> averager(0.25, true);
   const Controller<2> controller(0.3);
+  const control_system::TestHelpers::ControlError control_error{};
 
-  OptionHolder<1> option_holder1(averager, controller, tuner1);
-  OptionHolder<2> option_holder2(averager, controller, tuner1);
-  OptionHolder<3> option_holder3(averager, controller, tuner2);
+  OptionHolder<1> option_holder1(averager, controller, tuner1, control_error);
+  OptionHolder<2> option_holder2(averager, controller, tuner1, control_error);
+  OptionHolder<3> option_holder3(averager, controller, tuner2, control_error);
 
   using measurement_tag = control_system::Tags::MeasurementTimescales;
   measurement_tag::create_from_options<Metavariables>(

--- a/tests/Unit/ControlSystem/Test_InitialExpirationTimes.cpp
+++ b/tests/Unit/ControlSystem/Test_InitialExpirationTimes.cpp
@@ -61,10 +61,11 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.ConstructInitialExpirationTimes",
   const Averager<2> averager(0.25, true);
   const double update_fraction = 0.3;
   const Controller<2> controller(update_fraction);
+  const control_system::TestHelpers::ControlError control_error{};
 
-  OptionHolder<1> option_holder1(averager, controller, tuner1);
-  OptionHolder<2> option_holder2(averager, controller, tuner1);
-  OptionHolder<3> option_holder3(averager, controller, tuner2);
+  OptionHolder<1> option_holder1(averager, controller, tuner1, control_error);
+  OptionHolder<2> option_holder2(averager, controller, tuner1, control_error);
+  OptionHolder<3> option_holder3(averager, controller, tuner2, control_error);
 
   {
     INFO("No control systems");

--- a/tests/Unit/ControlSystem/Test_InitialExpirationTimes.cpp
+++ b/tests/Unit/ControlSystem/Test_InitialExpirationTimes.cpp
@@ -25,6 +25,7 @@ struct FakeControlSystem
   using measurement = control_system::TestHelpers::Measurement<
       control_system::TestHelpers::TestStructs_detail::LabelA>;
   using simple_tags = tmpl::list<>;
+  using control_error = control_system::TestHelpers::ControlError;
   struct process_measurement {
     using argument_tags = tmpl::list<>;
   };

--- a/tests/Unit/ControlSystem/Test_Tags.cpp
+++ b/tests/Unit/ControlSystem/Test_Tags.cpp
@@ -43,6 +43,10 @@ void test_all_tags() {
       2, control_system::TestHelpers::TestStructs_detail::LabelA,
       control_system::TestHelpers::Measurement<
           control_system::TestHelpers::TestStructs_detail::LabelA>>;
+
+  using control_error_tag = control_system::Tags::ControlError<system>;
+  TestHelpers::db::test_simple_tag<control_error_tag>("ControlError");
+
   using control_system_inputs_tag =
       control_system::Tags::ControlSystemInputs<system>;
   TestHelpers::db::test_simple_tag<control_system_inputs_tag>(
@@ -85,7 +89,8 @@ void test_control_sys_inputs() {
       "  DecreaseThreshold: 1e-2\n"
       "  IncreaseThreshold: 1e-4\n"
       "  IncreaseFactor: 1.01\n"
-      "  DecreaseFactor: 0.99\n");
+      "  DecreaseFactor: 0.99\n"
+      "ControlError:\n");
   CHECK(expected_averager == input_holder.averager);
   CHECK(expected_controller == input_holder.controller);
   CHECK(expected_tuner == input_holder.tuner);
@@ -96,6 +101,9 @@ void test_control_sys_inputs() {
       TestHelpers::test_option_tag<control_system::OptionTags::WriteDataToDisk>(
           "true");
   CHECK(write_data);
+  // We don't check the control error because the example one is empty and
+  // doesn't have a comparison operator. Once a control error is added that
+  // contains member data (and thus, options), then it can be tested
 }
 }  // namespace
 

--- a/tests/Unit/Helpers/ControlSystem/Examples.hpp
+++ b/tests/Unit/Helpers/ControlSystem/Examples.hpp
@@ -128,6 +128,8 @@ struct ExampleControlSystem
 
   static constexpr size_t deriv_order = 2;
 
+  using control_error = ExampleControlError;
+
   // This is not part of the required interface, but is used by this
   // control system to store the measurement data.  Most control
   // systems will do something like this.

--- a/tests/Unit/Helpers/ControlSystem/Examples.hpp
+++ b/tests/Unit/Helpers/ControlSystem/Examples.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstddef>
+#include <pup.h>
 
 #include "ControlSystem/Component.hpp"
 #include "ControlSystem/Protocols/ControlSystem.hpp"
@@ -13,6 +14,7 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/LinkedMessageQueue.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
 #include "ParallelAlgorithms/Actions/UpdateMessageQueue.hpp"
@@ -89,6 +91,29 @@ struct ExampleMeasurement
   using submeasurements = tmpl::list<ExampleSubmeasurement>;
 };
 /// [Measurement]
+
+/// [ControlError]
+struct ExampleControlError
+    : tt::ConformsTo<control_system::protocols::ControlError> {
+  void pup(PUP::er& /*p*/) {}
+
+  template <typename Metavariables, typename... QueueTags>
+  DataVector operator()(const Parallel::GlobalCache<Metavariables>& cache,
+                        const double time,
+                        const std::string& function_of_time_name,
+                        const tuples::TaggedTuple<QueueTags...>& measurements) {
+    const auto& functions_of_time =
+        Parallel::get<domain::Tags::FunctionsOfTime>(cache);
+    const double current_map_value =
+        functions_of_time.at(function_of_time_name)->func(time)[0][0];
+    const double measured_value = 0.0;
+    // Would do something like get<QueueTag>(measurements) here
+    (void)measurements;
+
+    return {current_map_value - measured_value};
+  }
+};
+/// [ControlError]
 
 /// [ControlSystem]
 struct ExampleControlSystem

--- a/tests/Unit/Helpers/ControlSystem/TestStructs.hpp
+++ b/tests/Unit/Helpers/ControlSystem/TestStructs.hpp
@@ -53,6 +53,7 @@ struct System : tt::ConformsTo<control_system::protocols::ControlSystem> {
   static std::string component_name(const size_t i) { return get_output(i); }
   using measurement = Measurement;
   using simple_tags = tmpl::list<>;
+  using control_error = ControlError;
   static constexpr size_t deriv_order = DerivOrder;
 };
 

--- a/tests/Unit/Helpers/ControlSystem/TestStructs.hpp
+++ b/tests/Unit/Helpers/ControlSystem/TestStructs.hpp
@@ -4,14 +4,20 @@
 #pragma once
 
 #include <cstddef>
+#include <pup.h>
 #include <string>
 
+#include "ControlSystem/Protocols/ControlError.hpp"
 #include "ControlSystem/Protocols/ControlSystem.hpp"
 #include "ControlSystem/Protocols/Measurement.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/GlobalCache.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
 
 namespace control_system::TestHelpers {
 namespace TestStructs_detail {
@@ -21,6 +27,21 @@ struct LabelA {};
 template <typename Label>
 struct Measurement : tt::ConformsTo<control_system::protocols::Measurement> {
   using submeasurements = tmpl::list<>;
+};
+
+struct ControlError : tt::ConformsTo<control_system::protocols::ControlError> {
+  void pup(PUP::er& /*p*/) {}
+
+  using options = tmpl::list<>;
+  static constexpr Options::String help{"Example control error."};
+
+  template <typename Metavariables, typename... QueueTags>
+  DataVector operator()(
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const double /*time*/, const std::string& /*function_of_time_name*/,
+      const tuples::TaggedTuple<QueueTags...>& /*measurements*/) {
+    return DataVector{};
+  }
 };
 
 static_assert(tt::assert_conforms_to<Measurement<TestStructs_detail::LabelA>,


### PR DESCRIPTION
## Proposed changes

- Adds a protocol for control errors.
- Adds the control error to the ControlSystem protocol (because all control systems have to have a control error of some kind)
- Adds a DataBox tag for the control error and also adds the control error to the option holder (certain control errors may need to have runtime options).

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
