### PR TITLE
Add ObserveAtPoint event

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/IrregularInterpolant.cpp
+++ b/src/NumericalAlgorithms/Interpolation/IrregularInterpolant.cpp
@@ -217,6 +217,31 @@ void Irregular<Dim>::pup(PUP::er& p) {
 }
 
 template <size_t Dim>
+void Irregular<Dim>::interpolate(const gsl::not_null<DataVector*> result,
+                                 const DataVector& input) const {
+  const size_t m = interpolation_matrix_.rows();
+  const size_t k = interpolation_matrix_.columns();
+  ASSERT(k == input.size(),
+         "Number of points in 'input', "
+             << input.size()
+             << ",\n disagrees with the size of the source_mesh, " << k
+             << ", that was passed into the constructor");
+  if (result->size() != m) {
+    *result = DataVector{m};
+  }
+  dgemm_('n', 'n', m, 1, k, 1.0, interpolation_matrix_.data(),
+         interpolation_matrix_.spacing(), input.data(), k, 0.0, result->data(),
+         m);
+}
+
+template <size_t Dim>
+DataVector Irregular<Dim>::interpolate(const DataVector& input) const {
+  DataVector result{input.size()};
+  interpolate(make_not_null(&result), input);
+  return result;
+}
+
+template <size_t Dim>
 bool operator!=(const Irregular<Dim>& lhs, const Irregular<Dim>& rhs) {
   return not(lhs == rhs);
 }

--- a/src/NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp
+++ b/src/NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp
@@ -56,6 +56,18 @@ class Irregular {
   Variables<TagsList> interpolate(const Variables<TagsList>& vars) const;
   /// @}
 
+  /// @{
+  /// \brief Interpolate a DataVector onto the target points.
+  ///
+  /// \note When interpolating multiple tensors, the Variables interface is more
+  /// efficient. However, this DataVector interface is useful for applications
+  /// where only some components of a Tensor or Variables need to be
+  /// interpolated.
+  void interpolate(gsl::not_null<DataVector*> result,
+                   const DataVector& input) const;
+  DataVector interpolate(const DataVector& input) const;
+  /// @}
+
  private:
   friend bool operator==(const Irregular& lhs, const Irregular& rhs) {
     return lhs.interpolation_matrix_ == rhs.interpolation_matrix_;
@@ -101,4 +113,3 @@ template <size_t Dim>
 bool operator!=(const Irregular<Dim>& lhs, const Irregular<Dim>& rhs);
 
 }  // namespace intrp
-

--- a/src/ParallelAlgorithms/Events/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Events/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_headers(
   HEADERS
   Factory.hpp
   MonitorMemory.hpp
+  ObserveAtPoint.hpp
   ObserveFields.hpp
   ObserveNorms.hpp
   ObserveTimeStep.hpp

--- a/src/ParallelAlgorithms/Events/Factory.hpp
+++ b/src/ParallelAlgorithms/Events/Factory.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <type_traits>
 
+#include "ParallelAlgorithms/Events/ObserveAtPoint.hpp"
 #include "ParallelAlgorithms/Events/ObserveFields.hpp"
 #include "ParallelAlgorithms/Events/ObserveNorms.hpp"
 #include "ParallelAlgorithms/Events/ObserveTimeStep.hpp"
@@ -18,6 +19,8 @@ template <size_t VolumeDim, typename TimeTag, typename Fields,
 using field_observations = tmpl::flatten<
     tmpl::list<ObserveFields<VolumeDim, TimeTag, Fields,
                              NonTensorComputeTagsList, ArraySectionIdTag>,
+               ObserveAtPoint<VolumeDim, TimeTag, Fields,
+                              NonTensorComputeTagsList, ArraySectionIdTag>,
                ::Events::ObserveNorms<TimeTag, Fields, NonTensorComputeTagsList,
                                       ArraySectionIdTag>>>;
 }  // namespace dg::Events

--- a/src/ParallelAlgorithms/Events/ObserveAtPoint.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveAtPoint.hpp
@@ -1,0 +1,439 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <limits>
+#include <optional>
+#include <pup.h>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
+#include "DataStructures/DataBox/TagName.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/IdPair.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/ElementLogicalCoordinates.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Domain/Structure/BlockId.hpp"
+#include "IO/Observer/GetSectionObservationKey.hpp"
+#include "IO/Observer/Helpers.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/ReductionActions.hpp"
+#include "IO/Observer/TypeOfObservation.hpp"
+#include "NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/ArrayIndex.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Reduction.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/Numeric.hpp"
+#include "Utilities/OptionalHelpers.hpp"
+#include "Utilities/StdHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace dg::Events {
+/// \cond
+template <size_t Dim, typename ObservationValueTag,
+          typename ObservableTensorTagsList,
+          typename NonTensorComputeTagsList = tmpl::list<>,
+          typename ArraySectionIdTag = void>
+class ObserveAtPoint;
+/// \endcond
+
+/*!
+ * \brief Interpolate tensors to a user-specified point and write the values to
+ * disk
+ *
+ * The interpolated values are an easy way to compare simulation data on
+ * different grids, or from different codes. The `ObservableTensorTags` are the
+ * set of tensors in the DataBox that are available for observation. The user
+ * can select a subset of these tensors, and the coordinates of the point to
+ * interpolate to.
+ *
+ * To observe data at multiple points the user can specify multiple instances of
+ * this event in the input file. This way, each instance of this event only
+ * depends on data from the single element that the point is on, or the few
+ * elements that share the point if it is on the interface of elements with
+ * Gauss-Lobatto grids.
+ *
+ * When the domain is time dependent, the `domain::Tags::FunctionsOfTime` must
+ * be up to date when this event is invoked.
+ *
+ * \par Array sections
+ * This event supports sections (see `Parallel::Section`). Set the
+ * `ArraySectionIdTag` template parameter to split up observations into subsets
+ * of elements. The `observers::Tags::ObservationKey<ArraySectionIdTag>` must be
+ * available in the DataBox. It identifies the section and is used as a suffix
+ * for the path in the output file.
+ */
+template <size_t Dim, typename ObservationValueTag,
+          typename... ObservableTensorTags, typename NonTensorComputeTagsList,
+          typename ArraySectionIdTag>
+class ObserveAtPoint<Dim, ObservationValueTag,
+                     tmpl::list<ObservableTensorTags...>,
+                     NonTensorComputeTagsList, ArraySectionIdTag>
+    : public Event {
+ private:
+  using ReductionData = Parallel::ReductionData<
+      // Observation value (e.g. time or iteration ID)
+      Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
+      // Number of contributing elements. This is usually one, but can be larger
+      // than one for Gauss-Lobatto grids when the user-specified point is on
+      // an element boundary.
+      Parallel::ReductionDatum<size_t, funcl::Plus<>>,
+      // Interpolated value at the user-specified point for all selected tensor
+      // components. We take the mean over all contributing elements.
+      Parallel::ReductionDatum<
+          std::vector<double>, funcl::ElementWise<funcl::Plus<>>,
+          funcl::ElementWise<funcl::Divides<>>, std::index_sequence<1>>>;
+
+ public:
+  struct SubfileName {
+    using type = std::string;
+    static constexpr Options::String help = {
+        "The name of the subfile inside the HDF5 file without an extension and "
+        "without a preceding '/'."};
+  };
+  struct TensorsToObserve {
+    using type = std::vector<std::string>;
+    static constexpr Options::String help = {
+        "List the names of tensors to interpolate to the specified point."};
+  };
+  struct Coordinates {
+    using type = std::array<double, Dim>;
+    static constexpr Options::String help = {
+        "The coordinates of the point to interpolate to."};
+  };
+
+  /// \cond
+  explicit ObserveAtPoint(CkMigrateMessage* msg) : Event(msg) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(ObserveAtPoint);  // NOLINT
+  /// \endcond
+
+  using options = tmpl::list<SubfileName, Coordinates, TensorsToObserve>;
+  static constexpr Options::String help =
+      "Observe tensors interpolated to the specified point.\n";
+
+  ObserveAtPoint() = default;
+  ObserveAtPoint(const std::string& subfile_name,
+                 std::array<double, Dim> coords,
+                 std::vector<std::string> tensor_names,
+                 const Options::Context& context = {})
+      : subfile_path_("/" + subfile_name),
+        coords_(std::move(coords)),
+        tensor_names_(std::move(tensor_names)) {
+    for (const auto& name : tensor_names_) {
+      if (((name != db::tag_name<ObservableTensorTags>()) and ...)) {
+        PARSE_ERROR(context, "No tensor with name '"
+                                 << name << "' available to observe.");
+      }
+    }
+  }
+
+  using observed_reduction_data_tags =
+      observers::make_reduction_data_tags<tmpl::list<ReductionData>>;
+
+  using compute_tags_for_observation_box =
+      tmpl::push_back<NonTensorComputeTagsList, ObservableTensorTags...>;
+
+  using argument_tags = tmpl::list<ObservationValueTag, ::Tags::ObservationBox>;
+
+  template <typename DataBoxType, typename ComputeTagsList,
+            typename Metavariables, typename ParallelComponent>
+  void operator()(const typename ObservationValueTag::type& observation_value,
+                  const ObservationBox<DataBoxType, ComputeTagsList>& box,
+                  Parallel::GlobalCache<Metavariables>& cache,
+                  const ElementId<Dim>& element_id,
+                  const ParallelComponent* const /*meta*/) const;
+
+  using observation_registration_tags = tmpl::list<::Tags::DataBox>;
+
+  template <typename DbTagsList>
+  std::optional<
+      std::pair<observers::TypeOfObservation, observers::ObservationKey>>
+  get_observation_type_and_key_for_registration(
+      const db::DataBox<DbTagsList>& box) const {
+    const std::optional<std::string> section_observation_key =
+        observers::get_section_observation_key<ArraySectionIdTag>(box);
+    if (not section_observation_key.has_value()) {
+      return std::nullopt;
+    }
+    // If the domain is static we can get away with registering only the
+    // element(s) that contain the specified point at the time of registration
+    if (not domain_is_time_dependent(db::get<domain::Tags::Domain<Dim>>(box))) {
+      // This registration function is sometimes instantiated with an empty
+      // DataBox
+      if constexpr (db::tag_is_retrievable_v<domain::Tags::Element<Dim>,
+                                             db::DataBox<DbTagsList>>) {
+        const auto element_logical_coords = get_element_logical_coords(box);
+        if (not element_logical_coords.has_value()) {
+          return std::nullopt;
+        }
+      } else {
+        ERROR(
+            "Invoking registration with a DataBox that is missing "
+            "'domain::Tags::Element'. Make sure the registration is invoked "
+            "after initialization.");
+      }
+    }
+    return {{observers::TypeOfObservation::Reduction,
+             observers::ObservationKey(
+                 subfile_path_ + section_observation_key.value() + ".dat")}};
+  }
+
+  using is_ready_argument_tags = tmpl::list<>;
+
+  template <typename Metavariables, typename ArrayIndex, typename Component>
+  bool is_ready(Parallel::GlobalCache<Metavariables>& /*cache*/,
+                const ArrayIndex& /*array_index*/,
+                const Component* const /*meta*/) const {
+    return true;
+  }
+
+  bool needs_evolved_variables() const override { return true; }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override;
+
+ private:
+  static bool domain_is_time_dependent(const Domain<Dim>& domain) {
+    return alg::any_of(domain.blocks(), [](const auto& block) {
+      return block.is_time_dependent();
+    });
+  }
+
+  template <typename DataBoxType>
+  std::optional<tnsr::I<DataVector, Dim, Frame::ElementLogical>>
+  get_element_logical_coords(const DataBoxType& box) const {
+    const auto& element_id = get<domain::Tags::Element<Dim>>(box).id();
+    // The coordinates of the single point, as a tensor and stored in a
+    // DataVector to comply with the interface used below
+    tnsr::I<DataVector, Dim> coords_as_tensor{size_t{1}};
+    for (size_t i = 0; i < Dim; ++i) {
+      coords_as_tensor.get(i) = gsl::at(coords_, i);
+    }
+    // Note: If the point is on a block boundary, only the block with the lowest
+    // block ID is returned here currently.
+    const auto block_logical_coords = [*this, &coords_as_tensor, &box]() {
+      const auto& domain = get<domain::Tags::Domain<Dim>>(box);
+      if (domain_is_time_dependent(domain)) {
+        if constexpr (db::tag_is_retrievable_v<domain::Tags::FunctionsOfTime,
+                                               DataBoxType>) {
+          return ::block_logical_coordinates(
+              domain, coords_as_tensor, get<::Tags::Time>(box),
+              get<domain::Tags::FunctionsOfTime>(box));
+        } else {
+          ERROR(
+              "The domain is time-dependent, but no functions of time are "
+              "available. If you intend to use a time-dependent domain, please "
+              "add 'domain::Tags::FunctionsOfTime' to the GlobalCache.");
+        }
+      } else {
+        return ::block_logical_coordinates(domain, coords_as_tensor);
+      }
+    }();
+    // The subscript [0] refers to the single point we are looking at here
+    if (not block_logical_coords[0].has_value()) {
+      throw std::runtime_error{"The point " + get_output(coords_) +
+                               " in an 'ObserveAtPoint' event is outside the "
+                               "computational domain."};
+    }
+    const auto element_logical_coords =
+        ::element_logical_coordinates({element_id}, block_logical_coords);
+    const auto found_element_id = element_logical_coords.find(element_id);
+    if (found_element_id == element_logical_coords.end()) {
+      return std::nullopt;
+    } else {
+      return found_element_id->second.element_logical_coords;
+    }
+  }
+
+  std::string subfile_path_;
+  std::array<double, Dim> coords_{};
+  std::vector<std::string> tensor_names_{};
+};
+
+/// \cond
+template <size_t Dim, typename ObservationValueTag,
+          typename... ObservableTensorTags, typename NonTensorComputeTagsList,
+          typename ArraySectionIdTag>
+template <typename DataBoxType, typename ComputeTagsList,
+          typename Metavariables, typename ParallelComponent>
+void ObserveAtPoint<Dim, ObservationValueTag,
+                    tmpl::list<ObservableTensorTags...>,
+                    NonTensorComputeTagsList, ArraySectionIdTag>::
+operator()(const typename ObservationValueTag::type& observation_value,
+           const ObservationBox<DataBoxType, ComputeTagsList>& box,
+           Parallel::GlobalCache<Metavariables>& cache,
+           const ElementId<Dim>& element_id,
+           const ParallelComponent* const /*meta*/) const {
+  // Skip observation on elements that are not part of a section
+  const std::optional<std::string> section_observation_key =
+      observers::get_section_observation_key<ArraySectionIdTag>(box);
+  if (not section_observation_key.has_value()) {
+    return;
+  }
+  using tensor_tags = tmpl::list<ObservableTensorTags...>;
+  auto& local_observer =
+      *Parallel::get_parallel_component<observers::Observer<Metavariables>>(
+           cache)
+           .ckLocalBranch();
+  const std::string subfile_path_with_suffix =
+      subfile_path_ + section_observation_key.value();
+
+  // Construct the legend
+  std::vector<std::string> legend{db::tag_name<ObservationValueTag>(),
+                                  "NumContributingElements"};
+  tmpl::for_each<tensor_tags>([this, &legend](auto tag_v) {
+    using tag = tmpl::type_from<decltype(tag_v)>;
+    const std::string tensor_name = db::tag_name<tag>();
+    for (size_t tensor_index = 0; tensor_index < tensor_names_.size();
+         ++tensor_index) {
+      if (tensor_name != tensor_names_[tensor_index]) {
+        continue;
+      }
+      using TensorType = std::decay_t<decltype(value(typename tag::type{}))>;
+      for (size_t component = 0; component < TensorType::size(); ++component) {
+        legend.push_back(tensor_name + TensorType::component_suffix(component));
+      }
+    }
+  });
+
+  // Check if the point is in the domain
+  const bool is_time_dep =
+      domain_is_time_dependent(get<domain::Tags::Domain<Dim>>(box));
+  std::optional<tnsr::I<DataVector, Dim, Frame::ElementLogical>>
+      element_logical_coords{};
+  try {
+    element_logical_coords = get_element_logical_coords(box);
+  } catch (std::runtime_error& /*err*/) {
+    if (is_time_dep) {
+      // When the domain is time-dependent it's ok if the point is currently
+      // outside the domain. We contribute NaN to the reduction so it's clear
+      // that we didn't observe anything.
+      Parallel::simple_action<observers::Actions::ContributeReductionData>(
+          local_observer,
+          observers::ObservationId(observation_value,
+                                   subfile_path_with_suffix + ".dat"),
+          observers::ArrayComponentId{
+              std::add_pointer_t<ParallelComponent>{nullptr},
+              Parallel::ArrayIndex<ElementId<Dim>>(element_id)},
+          subfile_path_with_suffix, std::move(legend),
+          ReductionData{
+              static_cast<double>(observation_value), size_t{1},
+              std::vector<double>(legend.size() - 2,
+                                  std::numeric_limits<double>::quiet_NaN())});
+      return;
+    } else {
+      // When the domain is static it's an error if the point is outside
+      throw;
+    }
+  }
+
+  // Check if the point is in this element
+  if (not element_logical_coords.has_value()) {
+    // The point is in the domain, but outside this element
+    if (is_time_dep) {
+      // Contribute nothing to the reduction
+      Parallel::simple_action<observers::Actions::ContributeReductionData>(
+          local_observer,
+          observers::ObservationId(observation_value,
+                                   subfile_path_with_suffix + ".dat"),
+          observers::ArrayComponentId{
+              std::add_pointer_t<ParallelComponent>{nullptr},
+              Parallel::ArrayIndex<ElementId<Dim>>(element_id)},
+          subfile_path_with_suffix, std::move(legend),
+          ReductionData{static_cast<double>(observation_value), size_t{0},
+                        std::vector<double>(legend.size() - 2, 0.)});
+      return;
+    } else {
+      // We haven't even registered the element, so we can return right here
+      // without contributing to the reduction.
+      return;
+    }
+  }
+
+  // Construct the interpolant to the user-specified point
+  const intrp::Irregular<Dim> interpolant{get<domain::Tags::Mesh<Dim>>(box),
+                                          *element_logical_coords};
+
+  // Each component of the user-specified tensors, interpolated to the point
+  std::vector<double> interpolated_data{};
+
+  // Loop over ObservableTensorTags and see if it was requested to be observed
+  // before retrieving it from the box. This approach allows us to delay
+  // evaluating any compute tags until they're actually needed for observing.
+  tmpl::for_each<tensor_tags>(
+      [this, &box, &interpolant, &interpolated_data](auto tag_v) {
+        using tag = tmpl::type_from<decltype(tag_v)>;
+        const std::string tensor_name = db::tag_name<tag>();
+        for (size_t tensor_index = 0; tensor_index < tensor_names_.size();
+             ++tensor_index) {
+          if (tensor_name != tensor_names_[tensor_index]) {
+            continue;
+          }
+          if (UNLIKELY(not has_value(get<tag>(box)))) {
+            ERROR("Cannot observe '"
+                  << tensor_name
+                  << "' because it is a std::optional and wasn't able to be "
+                     "computed. This can happen when you try to observe errors "
+                     "without an analytic solution.");
+          }
+          const auto& tensor = value(get<tag>(box));
+          for (size_t component = 0; component < tensor.size(); ++component) {
+            // The subscript [0] refers to the single point in the DataVector
+            interpolated_data.push_back(
+                interpolant.interpolate(tensor[component])[0]);
+          }
+        }
+      });
+
+  // Send data to reduction observer
+  Parallel::simple_action<observers::Actions::ContributeReductionData>(
+      local_observer,
+      observers::ObservationId(observation_value,
+                               subfile_path_with_suffix + ".dat"),
+      observers::ArrayComponentId{
+          std::add_pointer_t<ParallelComponent>{nullptr},
+          Parallel::ArrayIndex<ElementId<Dim>>(element_id)},
+      subfile_path_with_suffix, std::move(legend),
+      ReductionData{static_cast<double>(observation_value), size_t{1},
+                    std::move(interpolated_data)});
+}
+
+template <size_t Dim, typename ObservationValueTag,
+          typename... ObservableTensorTags, typename NonTensorComputeTagsList,
+          typename ArraySectionIdTag>
+void ObserveAtPoint<
+    Dim, ObservationValueTag, tmpl::list<ObservableTensorTags...>,
+    NonTensorComputeTagsList, ArraySectionIdTag>::pup(PUP::er& p) {
+  Event::pup(p);
+  p | subfile_path_;
+  p | coords_;
+  p | tensor_names_;
+}
+
+template <size_t Dim, typename ObservationValueTag,
+          typename... ObservableTensorTags, typename NonTensorComputeTagsList,
+          typename ArraySectionIdTag>
+PUP::able::PUP_ID ObserveAtPoint<
+    Dim, ObservationValueTag, tmpl::list<ObservableTensorTags...>,
+    NonTensorComputeTagsList, ArraySectionIdTag>::my_PUP_ID = 0;  // NOLINT
+/// \endcond
+}  // namespace dg::Events

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -12,6 +12,11 @@
 #     FileGlob: PoissonProductOfSinusoids1DReductions.h5
 #     SkipColumns: [0, 1, 2]
 #     AbsoluteTolerance: 0.004
+#   - Label: Interpolation
+#     Subfile: /Origin.dat
+#     FileGlob: PoissonProductOfSinusoids1DReductions.h5
+#     SkipColumns: [0, 1]
+#     AbsoluteTolerance: 0.005
 
 ResourceInfo:
   AvoidGlobalProc0: false
@@ -79,6 +84,11 @@ EventsAndTriggers:
             - Name: Error(Field)
               NormType: L2Norm
               Components: Sum
+      - ObserveAtPoint:
+          SubfileName: Origin
+          TensorsToObserve:
+            - Field
+          Coordinates: [0.]
       - ObserveFields:
           SubfileName: VolumeData
           VariablesToObserve: [Field]

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
@@ -201,6 +201,11 @@ void test_interpolate_to_points(const Mesh<Dim>& mesh) {
       using Tag = tmpl::type_from<decltype(tag)>;
       CHECK_ITERABLE_APPROX(get<Tag>(dest_vars), get<Tag>(expected_dest_vars));
     });
+
+    const DataVector result_dv = irregular_interpolant.interpolate(
+        get<0>(get<TestTags::Vector<Dim>>(src_vars)));
+    CHECK_ITERABLE_APPROX(
+        result_dv, get<0>(get<TestTags::Vector<Dim>>(expected_dest_vars)));
   }
 }
 

--- a/tests/Unit/ParallelAlgorithms/Events/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Events/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_ParallelAlgorithmsEvents")
 
 set(LIBRARY_SOURCES
+  Test_ObserveAtPoint.cpp
   Test_ObserveFields.cpp
   Test_ObserveNorms.cpp
   Test_ObserveTimeStep.cpp

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveAtPoint.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveAtPoint.cpp
@@ -1,0 +1,423 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataBox/TagName.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CreateInitialElement.hpp"
+#include "Domain/Creators/Brick.hpp"
+#include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/Creators/Interval.hpp"
+#include "Domain/Creators/Rectangle.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/Tags.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "IO/Observer/Actions/RegisterEvents.hpp"
+#include "IO/Observer/ArrayComponentId.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Reduction.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "Parallel/Tags/Metavariables.hpp"
+#include "ParallelAlgorithms/Events/ObserveAtPoint.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Numeric.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/StdHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Parallel {
+template <typename Metavariables>
+class GlobalCache;
+}  // namespace Parallel
+namespace observers::Actions {
+struct ContributeReductionData;
+}  // namespace observers::Actions
+
+namespace {
+
+struct TestSectionIdTag {};
+
+struct MockContributeReductionData {
+  struct Results {
+    observers::ObservationId observation_id;
+    std::string subfile_name;
+    std::vector<std::string> reduction_names{};
+    double time;
+    size_t num_contributing_elements;
+    std::vector<double> interpolated_data{};
+  };
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+  static Results results;
+
+  template <typename ParallelComponent, typename... DbTags,
+            typename Metavariables, typename ArrayIndex, typename... Ts>
+  static void apply(db::DataBox<tmpl::list<DbTags...>>& /*box*/,
+                    Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const observers::ObservationId& observation_id,
+                    observers::ArrayComponentId /*sender_array_id*/,
+                    const std::string& subfile_name,
+                    const std::vector<std::string>& reduction_names,
+                    Parallel::ReductionData<Ts...>&& reduction_data) {
+    results.observation_id = observation_id;
+    results.subfile_name = subfile_name;
+    results.reduction_names = reduction_names;
+    results.time = std::get<0>(reduction_data.data());
+    results.num_contributing_elements = std::get<1>(reduction_data.data());
+    results.interpolated_data = std::get<2>(reduction_data.data());
+  }
+};
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+MockContributeReductionData::Results MockContributeReductionData::results{};
+
+template <typename Metavariables>
+struct ElementComponent {
+  using component_being_mocked = void;
+
+  using metavariables = Metavariables;
+  using array_index = int;
+  using chare_type = ActionTesting::MockArrayChare;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::Initialization,
+                                        tmpl::list<>>>;
+};
+
+template <typename Metavariables>
+struct MockObserverComponent {
+  using component_being_mocked = observers::Observer<Metavariables>;
+  using replace_these_simple_actions =
+      tmpl::list<observers::Actions::ContributeReductionData>;
+  using with_these_simple_actions = tmpl::list<MockContributeReductionData>;
+
+  using metavariables = Metavariables;
+  using array_index = int;
+  using chare_type = ActionTesting::MockGroupChare;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::Initialization,
+                                        tmpl::list<>>>;
+};
+
+struct ScalarVar : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+struct ScalarVarTimesTwo : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct VectorVar : db::SimpleTag {
+  using type = tnsr::I<DataVector, Dim>;
+};
+
+struct ScalarVarTimesTwoCompute
+    : db::ComputeTag,
+      ::Tags::Variables<tmpl::list<ScalarVarTimesTwo>> {
+  using base = ::Tags::Variables<tmpl::list<ScalarVarTimesTwo>>;
+  using return_type = typename base::type;
+  using argument_tags = tmpl::list<ScalarVar>;
+  static void function(const gsl::not_null<type*> result,
+                       const Scalar<DataVector>& scalar_var) {
+    result->initialize(get(scalar_var).size());
+    get(get<ScalarVarTimesTwo>(*result)) = 2.0 * get(scalar_var);
+  }
+};
+
+template <size_t Dim>
+using variables_for_test =
+    tmpl::list<ScalarVar, VectorVar<Dim>, ScalarVarTimesTwo>;
+
+template <size_t Dim, typename ArraySectionIdTag>
+struct Metavariables {
+  using component_list = tmpl::list<ElementComponent<Metavariables>,
+                                    MockObserverComponent<Metavariables>>;
+  using const_global_cache_tags = tmpl::list<>;  //  unused
+
+  using ObserveEvent =
+      dg::Events::ObserveAtPoint<Dim, ::Tags::Time, variables_for_test<Dim>,
+                                 tmpl::list<ScalarVarTimesTwoCompute>,
+                                 ArraySectionIdTag>;
+
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes =
+        tmpl::map<tmpl::pair<Event, tmpl::list<ObserveEvent>>>;
+  };
+  enum class Phase { Initialization, Testing, Exit };
+};
+
+template <size_t Dim>
+std::unique_ptr<DomainCreator<Dim>> make_domain_creator() {
+  if constexpr (Dim == 1) {
+    // 1D case has h-refinement
+    return std::make_unique<domain::creators::Interval>(
+        domain::creators::Interval({{-0.5}}, {{1.5}}, {{1}}, {{4}}, {{false}},
+                                   nullptr));
+  } else if constexpr (Dim == 2) {
+    // 2D case has time dependence so at t=0 the point (0.25, 0.25) is inside
+    // the domain and at t=2 the point is outside
+    return std::make_unique<domain::creators::Rectangle>(
+        domain::creators::Rectangle(
+            {{-0.5, -0.5}}, {{0.5, 0.5}}, {{0, 0}}, {{4, 4}}, {{false, false}},
+            std::make_unique<
+                domain::creators::time_dependence::UniformTranslation<2, 0>>(
+                0., std::array<double, 2>{{1., 0.}})));
+  } else {
+    return std::make_unique<domain::creators::Brick>(domain::creators::Brick(
+        {{-0.5, -0.5, -0.5}}, {{0.5, 0.5, 0.5}}, {{0, 0, 0}}, {{4, 4, 4}},
+        {{false, false, false}}));
+  }
+}
+
+template <size_t Dim>
+ElementId<Dim> make_element_id() {
+  if constexpr (Dim == 1) {
+    // 1D case has h-refinement
+    return {0, {{{1, 0}}}};
+  } else {
+    return ElementId<Dim>{0};
+  }
+}
+
+template <size_t Dim, typename ArraySectionIdTag, typename ObserveEvent>
+void test_observe(const ObserveEvent& observe_event, const double time,
+                  const bool point_is_in_element,
+                  const std::optional<std::string>& section) {
+  CAPTURE(Dim);
+  CAPTURE(time);
+  CAPTURE(point_is_in_element);
+  CAPTURE(section.has_value());
+  constexpr bool domain_is_time_dependent = (Dim == 2);
+  CAPTURE(domain_is_time_dependent);
+  using metavariables = Metavariables<Dim, ArraySectionIdTag>;
+  using element_component = ElementComponent<metavariables>;
+  using observer_component = MockObserverComponent<metavariables>;
+
+  const typename element_component::array_index array_index(0);
+  const ElementId<Dim> element_id = make_element_id<Dim>();
+
+  // ObserveAtPoint requires the domain in the DataBox
+  const auto creator = make_domain_creator<Dim>();
+  auto domain = creator->create_domain();
+  // Only needed for element ID
+  auto element = domain::Initialization::create_initial_element(
+      element_id, domain.blocks()[0], creator->initial_refinement_levels());
+  const Mesh<Dim> mesh{creator->initial_extents()[0], Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto};
+  auto fot = creator->functions_of_time();
+
+  // Any data held by tensors to interpolate should be fine
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<double> dist{-10.0, 10.0};
+  const size_t num_points = mesh.number_of_grid_points();
+  Variables<variables_for_test<Dim>> vars(num_points);
+  fill_with_random_values(make_not_null(&vars), make_not_null(&gen),
+                          make_not_null(&dist));
+
+  // Compute expected data for checks
+  size_t num_tensor_components = 0;
+  tnsr::I<DataVector, Dim, Frame::ElementLogical> target_coords{num_points};
+  for (size_t d = 0; d < Dim; ++d) {
+    target_coords.get(d) = 0.5;
+  }
+  const intrp::Irregular<Dim> interpolant{mesh, target_coords};
+  std::vector<double> expected_interpolated_data{};
+  std::vector<std::string> expected_reduction_names = {
+      db::tag_name<::Tags::Time>(), "NumContributingElements"};
+  tmpl::for_each<typename std::decay_t<decltype(vars)>::tags_list>(
+      [&num_tensor_components, &vars, &expected_interpolated_data,
+       &expected_reduction_names, &interpolant](auto tag) {
+        using tensor_tag = tmpl::type_from<decltype(tag)>;
+        const auto& tensor = get<tensor_tag>(vars);
+        for (size_t i = 0; i < tensor.size(); ++i) {
+          expected_reduction_names.push_back(db::tag_name<tensor_tag>() +
+                                             tensor.component_suffix(i));
+          expected_interpolated_data.push_back(
+              interpolant.interpolate(tensor[i])[0]);
+          ++num_tensor_components;
+        }
+      });
+
+  const auto box = db::create<db::AddSimpleTags<
+      Parallel::Tags::MetavariablesImpl<metavariables>, ::Tags::Time,
+      domain::Tags::Mesh<Dim>, domain::Tags::Domain<Dim>,
+      domain::Tags::Element<Dim>, domain::Tags::FunctionsOfTimeInitialize,
+      Tags::Variables<variables_for_test<Dim>>,
+      observers::Tags::ObservationKey<ArraySectionIdTag>>>(
+      metavariables{}, time, mesh, std::move(domain), std::move(element),
+      std::move(fot), std::move(vars), section);
+
+  ActionTesting::MockRuntimeSystem<metavariables> runner{{}};
+  ActionTesting::emplace_component<element_component>(make_not_null(&runner),
+                                                      0);
+  ActionTesting::emplace_group_component<observer_component>(&runner);
+
+  const auto ids_to_register =
+      observers::get_registration_observation_type_and_key(observe_event, box);
+  const std::string expected_subfile_name{
+      "/interpolated_data" +
+      (std::is_same_v<ArraySectionIdTag, void> ? ""
+                                               : section.value_or("Unused"))};
+  const observers::ObservationKey expected_observation_key_for_reg(
+      expected_subfile_name + ".dat");
+  if ((std::is_same_v<ArraySectionIdTag, void> or section.has_value()) and
+      (domain_is_time_dependent or point_is_in_element)) {
+    CHECK(ids_to_register->first == observers::TypeOfObservation::Reduction);
+    CHECK(ids_to_register->second == expected_observation_key_for_reg);
+  } else {
+    CHECK_FALSE(ids_to_register.has_value());
+  }
+
+  observe_event.run(
+      make_observation_box<db::AddComputeTags<>>(box),
+      ActionTesting::cache<element_component>(runner, array_index), element_id,
+      std::add_pointer_t<element_component>{});
+
+  if (not ids_to_register.has_value()) {
+    CHECK(runner.template is_simple_action_queue_empty<observer_component>(0));
+    return;
+  }
+
+  // Process the data
+  runner.template invoke_queued_simple_action<observer_component>(0);
+  CHECK(runner.template is_simple_action_queue_empty<observer_component>(0));
+
+  const auto& results = MockContributeReductionData::results;
+  CHECK(results.observation_id.value() == time);
+  CHECK(results.observation_id.observation_key() ==
+        expected_observation_key_for_reg);
+  CHECK(results.subfile_name == expected_subfile_name);
+  CHECK(results.reduction_names == expected_reduction_names);
+  CHECK(results.time == time);
+  CHECK(results.num_contributing_elements == 1);
+  CHECK(results.interpolated_data.size() == num_tensor_components);
+  if (point_is_in_element) {
+    CHECK_ITERABLE_APPROX(results.interpolated_data,
+                          expected_interpolated_data);
+  } else {
+    for (size_t i = 0; i < num_tensor_components; ++i) {
+      CHECK(std::isnan(results.interpolated_data[i]));
+    }
+  }
+
+  CHECK(observe_event.needs_evolved_variables());
+}
+}  // namespace
+
+template <size_t Dim, typename ArraySectionIdTag = void>
+void test_observe_system(
+    const std::optional<std::string>& section = std::nullopt) {
+  using metavariables = Metavariables<Dim, ArraySectionIdTag>;
+  using ObserveAtPoint = typename metavariables::ObserveEvent;
+  {
+    INFO("Testing observation");
+    // Point inside domain
+    const ObserveAtPoint observe_at_point{
+        "interpolated_data",
+        make_array<Dim>(0.25),
+        {"ScalarVar", "VectorVar", "ScalarVarTimesTwo"}};
+    test_observe<Dim, ArraySectionIdTag>(observe_at_point, 0., true, section);
+    if constexpr (Dim == 2) {
+      // Time-dependent test in 2D. Point is outside the domain at t=2.
+      test_observe<Dim, ArraySectionIdTag>(observe_at_point, 2., false,
+                                           section);
+    }
+    // Point outside domain
+    const ObserveAtPoint observe_at_point_outside_domain{
+        "interpolated_data",
+        make_array<Dim>(2.),
+        {"ScalarVar", "VectorVar", "ScalarVarTimesTwo"}};
+    if constexpr (Dim == 2) {
+      test_observe<Dim, ArraySectionIdTag>(observe_at_point_outside_domain, 2.,
+                                           false, section);
+    } else if (std::is_same_v<ArraySectionIdTag, void> or section.has_value()) {
+      CHECK_THROWS_WITH(
+          (test_observe<Dim, ArraySectionIdTag>(observe_at_point_outside_domain,
+                                                0., false, section)),
+          Catch::Matchers::Contains("outside the computational domain"));
+    } else {
+      test_observe<Dim, ArraySectionIdTag>(observe_at_point_outside_domain, 0.,
+                                           false, section);
+    }
+    // Point inside domain but outside element
+    if constexpr (Dim == 1) {
+      const ObserveAtPoint observe_at_point_outside_element{
+          "interpolated_data",
+          make_array<Dim>(1.),
+          {"ScalarVar", "VectorVar", "ScalarVarTimesTwo"}};
+      test_observe<Dim, ArraySectionIdTag>(observe_at_point_outside_element, 0.,
+                                           false, section);
+    }
+  }
+  {
+    INFO("Testing create/serialize");
+    Parallel::register_factory_classes_with_charm<metavariables>();
+    const auto factory_event = TestHelpers::test_creation<
+        std::unique_ptr<Event>, metavariables>(
+        "ObserveAtPoint:\n"
+        "  SubfileName: interpolated_data\n"
+        "  Coordinates: " +
+            []() -> std::string {
+          if constexpr (Dim == 1) {
+            return "[0.25]";
+          } else if constexpr (Dim == 2) {
+            return "[0.25, 0.25]";
+          } else if constexpr (Dim == 3) {
+            return "[0.25, 0.25, 0.25]";
+          }
+        }() + "\n"
+              "  TensorsToObserve: [ScalarVar, VectorVar, ScalarVarTimesTwo]");
+    auto serialized_event_ptr = serialize_and_deserialize(factory_event);
+    REQUIRE(dynamic_cast<const ObserveAtPoint*>(serialized_event_ptr.get()) !=
+            nullptr);
+    const auto& serialized_event =
+        dynamic_cast<const ObserveAtPoint&>(*serialized_event_ptr);
+    test_observe<Dim, ArraySectionIdTag>(serialized_event, 0., true, section);
+    CHECK_THROWS_WITH(
+        ObserveAtPoint("subfile", make_array<Dim>(0.),
+                       {"ScalarVar", "Nonexistent"},
+                       Options::Context{false, {}, 1, 1}),
+        Catch::Matchers::Contains(
+            "No tensor with name 'Nonexistent' available to observe."));
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.Events.ObserveAtPoint", "[Unit]") {
+  test_observe_system<1, void>();
+  test_observe_system<1, void>("Section0");
+  test_observe_system<1, TestSectionIdTag>(std::nullopt);
+  test_observe_system<1, TestSectionIdTag>("Section0");
+  test_observe_system<2>();
+  test_observe_system<3>();
+}

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveVolumeIntegrals.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveVolumeIntegrals.cpp
@@ -245,7 +245,7 @@ void test_observe(const std::unique_ptr<ObserveEvent> observe,
       [&num_tensor_components, &vars, &expected_volume_integrals,
        &expected_reduction_names, &det_jacobian, &mesh](auto tag) {
         using tensor_tag = tmpl::type_from<decltype(tag)>;
-        const auto tensor = get<tensor_tag>(vars);
+        const auto& tensor = get<tensor_tag>(vars);
         for (size_t i = 0; i < tensor.size(); ++i) {
           expected_reduction_names.push_back("VolumeIntegral(" +
                                              db::tag_name<tensor_tag>() +


### PR DESCRIPTION
## Proposed changes

Interpolate tensors to a user-specified point. This is an easy way to
compare simulation data on different grids, or from different codes
(e.g. compare to SpEC).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
