### PR TITLE
Update tensor variable names in GeneralRelativity

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/DerivativesOfSpacetimeMetric.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/DerivativesOfSpacetimeMetric.hpp
@@ -29,15 +29,15 @@ namespace gr {
  *
  * \details Computes the derivatives as:
  * \f{align}
- *     \partial_\mu \psi_{tt} &= - 2 N \partial_\mu N
- *                 + 2 g_{mn} N^m \partial_\mu N^n
- *                 + N^m N^n \partial_\mu g_{mn} \\
- *     \partial_\mu \psi_{ti} &= g_{mi} \partial_\mu N^m
- *                 + N^m \partial_\mu g_{mi} \\
- *     \partial_\mu \psi_{ij} &= \partial_\mu g_{ij}
+ *     \partial_\mu g_{tt} &= - 2 \alpha \partial_\mu \alpha
+ *                 + 2 \gamma_{mn} \beta^m \partial_\mu \beta^n
+ *                 + \beta^m \beta^n \partial_\mu \gamma_{mn} \\
+ *     \partial_\mu g_{ti} &= \gamma_{mi} \partial_\mu \beta^m
+ *                 + \beta^m \partial_\mu \gamma_{mi} \\
+ *     \partial_\mu g_{ij} &= \partial_\mu \gamma_{ij}
  * \f}
- * where \f$ N, N^i, g \f$ are the lapse, shift, and spatial metric
- * respectively.
+ * where \f$ \alpha, \beta^i, \gamma_{ij} \f$ are the lapse, shift, and spatial
+ * metric respectively.
  */
 template <size_t SpatialDim, typename Frame, typename DataType>
 void derivatives_of_spacetime_metric(

--- a/src/PointwiseFunctions/GeneralRelativity/DetAndInverseSpatialMetric.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/DetAndInverseSpatialMetric.hpp
@@ -26,8 +26,8 @@ namespace gr {
 
 namespace Tags {
 /*!
- * \brief Compute item for spatial metric determinant \f$g\f$
- * and inverse \f$g^{ij}\f$ in terms of the spatial metric \f$g_{ij}\f$.
+ * \brief Compute item for spatial metric determinant \f$\gamma\f$ and inverse
+ * \f$\gamma^{ij}\f$ in terms of the spatial metric \f$\gamma_{ij}\f$.
  *
  * \details Can be retrieved using `gr::Tags::DetSpatialMetric` and
  * `gr::Tags::InverseSpatialMetric`.
@@ -53,7 +53,7 @@ struct DetAndInverseSpatialMetricCompute
 
 /*!
  * \brief Compute item to get the square root of the determinant of the spatial
- * metric \f$\sqrt{g}\f$ via `gr::Tags::DetAndInverseSpatialMetric`.
+ * metric \f$\sqrt{\gamma}\f$ via `gr::Tags::DetAndInverseSpatialMetric`.
  *
  * \details Can be retrieved using `gr::Tags::SqrtDetSpatialMetric`.
  */

--- a/src/PointwiseFunctions/GeneralRelativity/ExtrinsicCurvature.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ExtrinsicCurvature.hpp
@@ -28,15 +28,17 @@ namespace gr {
  * \ingroup GeneralRelativityGroup
  * \brief  Computes extrinsic curvature from metric and derivatives.
  * \details Uses the ADM evolution equation for the spatial metric,
- * \f[ K_{ij} = \frac{1}{2N} \left ( -\partial_0 g_{ij}
- * + N^k \partial_k g_{ij} + g_{ki} \partial_j N^k
- * + g_{kj} \partial_i N^k \right ) \f]
- * where \f$K_{ij}\f$ is the extrinsic curvature, \f$N\f$ is the lapse,
- * \f$N^i\f$ is the shift, and \f$g_{ij}\f$ is the spatial metric. In terms
- * of the Lie derivative of the spatial metric with respect to a unit timelike
- * vector \f$t^a\f$ normal to the spatial slice, this corresponds to the sign
- * convention
- * \f[ K_{ab} = - \frac{1}{2} \mathcal{L}_{\mathbf{t}} g_{ab} \f]
+ * \f[ K_{ij} = \frac{1}{2 \alpha} \left ( -\partial_0 \gamma_{ij}
+ * + \beta^k \partial_k \gamma_{ij} + \gamma_{ki} \partial_j \beta^k
+ * + \gamma_{kj} \partial_i \beta^k \right ) \f]
+ * where \f$K_{ij}\f$ is the extrinsic curvature, \f$\alpha\f$ is the lapse,
+ * \f$\beta^i\f$ is the shift, and \f$\gamma_{ij}\f$ is the spatial metric. In
+ * terms of the Lie derivative of the spatial metric with respect to a unit
+ * timelike vector \f$n^a\f$ normal to the spatial slice, this corresponds to
+ * the sign convention
+ * \f[ K_{ab} = - \frac{1}{2} \mathcal{L}_{\mathbf{n}} \gamma_{ab} \f]
+ * where \f$\gamma_{ab}\f$ is the spatial metric. See Eq. (2.53) in
+ * \cite BaumgarteShapiro.
  */
 template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::ii<DataType, SpatialDim, Frame> extrinsic_curvature(

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Christoffel.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Christoffel.hpp
@@ -18,8 +18,8 @@ namespace GeneralizedHarmonic {
  *
  * \details
  * If \f$ \Phi_{kab} \f$ is the generalized harmonic spatial derivative
- * variable \f$ \Phi_{kab} = \partial_k \psi_{ab}\f$ and \f$\gamma^{ij}\f$
- * is the inverse spatial metric, the Christoffel symbols are
+ * variable \f$ \Phi_{kab} = \partial_k g_{ab}\f$ and \f$\gamma^{ij}\f$ is the
+ * inverse spatial metric, the Christoffel symbols are
  * \f[
  *   \Gamma^m_{ij} = \frac{1}{2}\gamma^{mk}(\Phi_{ijk}+\Phi_{jik}-\Phi_{kij}).
  * \f]

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/DerivSpatialMetric.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/DerivSpatialMetric.hpp
@@ -41,7 +41,7 @@ namespace GeneralizedHarmonic {
  * harmonic spatial derivative variable, then the derivatives of the
  * spatial metric are
  * \f[
- *      \partial_k g_{ij} = \Phi_{kij}
+ *      \partial_k \gamma_{ij} = \Phi_{kij}
  * \f]
  *
  * This quantity is needed for computing spatial Christoffel symbols.

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ExtrinsicCurvature.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ExtrinsicCurvature.hpp
@@ -39,10 +39,10 @@ namespace GeneralizedHarmonic {
  *
  * \details If \f$ \Pi_{ab} \f$ and \f$ \Phi_{iab} \f$ are the generalized
  * harmonic conjugate momentum and spatial derivative variables, and if
- * \f$t^a\f$ is the spacetime normal vector, then the extrinsic curvature
+ * \f$n^a\f$ is the spacetime normal vector, then the extrinsic curvature
  * is computed as
  * \f{align}
- *     K_{ij} &= \frac{1}{2} \Pi_{ij} + \Phi_{(ij)a} t^a
+ *     K_{ij} &= \frac{1}{2} \Pi_{ij} + \Phi_{(ij)a} n^a
  * \f}
  */
 template <size_t SpatialDim, typename Frame, typename DataType>

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/GaugeSource.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/GaugeSource.hpp
@@ -35,13 +35,15 @@ namespace GeneralizedHarmonic {
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief  Computes generalized harmonic gauge source function.
- * \details If \f$N, N^i, g_{ij}, \Gamma_{ijk}, K\f$ are the lapse, shift,
- * spatial metric, spatial Christoffel symbols, and trace of the extrinsic
- * curvature, then we compute
+ * \details If \f$\alpha, \beta^i, \gamma_{ij}, \Gamma_{ijk}, K\f$ are the
+ * lapse, shift, spatial metric, spatial Christoffel symbols, and trace of the
+ * extrinsic curvature, then we compute
  * \f{align}
- * H_l &= N^{-2} g_{il}(\partial_t N^i - N^k \partial_k N^i)
- * + N^{-1} \partial_l N - g^{km}\Gamma_{lkm} \\
- * H_0 &= -N^{-1} \partial_t N + N^{-1} N^k\partial_k N + N^k H_k - N K
+ * H_l &=
+ * \alpha^{-2} \gamma_{il}(\partial_t \beta^i - \beta^k \partial_k \beta^i)
+ * + \alpha^{-1} \partial_l \alpha - \gamma^{km}\Gamma_{lkm} \\
+ * H_0 &= -\alpha^{-1} \partial_t \alpha + \alpha^{-1} \beta^k\partial_k \alpha
+ * + \beta^k H_k - \alpha K
  * \f}
  * See Eqs. 8 and 9 of \cite Lindblom2005qh
  */

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Phi.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Phi.hpp
@@ -36,16 +36,16 @@ namespace GeneralizedHarmonic {
  * \brief Computes the auxiliary variable \f$\Phi_{iab}\f$ used by the
  * generalized harmonic formulation of Einstein's equations.
  *
- * \details If \f$ N, N^i\f$ and \f$ g_{ij} \f$ are the lapse, shift and spatial
- * metric respectively, then \f$\Phi_{iab} \f$ is computed as
+ * \details If \f$ \alpha, \beta^i\f$ and \f$ \gamma_{ij} \f$ are the lapse,
+ * shift and spatial metric respectively, then \f$\Phi_{iab} \f$ is computed as
  *
  * \f{align}
- *     \Phi_{ktt} &= - 2 N \partial_k N
- *                 + 2 g_{mn} N^m \partial_k N^n
- *                 + N^m N^n \partial_k g_{mn} \\
- *     \Phi_{kti} &= g_{mi} \partial_k N^m
- *                 + N^m \partial_k g_{mi} \\
- *     \Phi_{kij} &= \partial_k g_{ij}
+ *     \Phi_{ktt} &= - 2 \alpha \partial_k \alpha
+ *                 + 2 \gamma_{mn} \beta^m \partial_k \beta^n
+ *                 + \beta^m \beta^n \partial_k \gamma_{mn} \\
+ *     \Phi_{kti} &= \gamma_{mi} \partial_k \beta^m
+ *                 + \beta^m \partial_k \gamma_{mi} \\
+ *     \Phi_{kij} &= \partial_k \gamma_{ij}
  * \f}
  */
 template <size_t SpatialDim, typename Frame, typename DataType>

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Pi.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Pi.hpp
@@ -34,21 +34,21 @@ namespace GeneralizedHarmonic {
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes the conjugate momentum \f$\Pi_{ab}\f$ of the spacetime metric
- * \f$ \psi_{ab} \f$.
+ * \f$ g_{ab} \f$.
  *
- * \details If \f$ N, N^i\f$ are the lapse and shift
- * respectively, and \f$ \Phi_{iab} = \partial_i \psi_{ab} \f$ then
- * \f$\Pi_{\mu\nu} = -\frac{1}{N} ( \partial_t \psi_{\mu\nu}  -
- *      N^m \Phi_{m\mu\nu}) \f$ where \f$ \partial_t \psi_{ab} \f$ is computed
+ * \details If \f$ \alpha, \beta^i\f$ are the lapse and shift respectively, and
+ * \f$ \Phi_{iab} = \partial_i g_{ab} \f$ then
+ * \f$\Pi_{\mu\nu} = -\frac{1}{\alpha} ( \partial_t g_{\mu\nu}  -
+ *      \beta^m \Phi_{m\mu\nu}) \f$ where \f$ \partial_t g_{ab} \f$ is computed
  * as
  *
  * \f{align}
- *     \partial_t \psi_{tt} &= - 2 N \partial_t N
- *                 + 2 g_{mn} N^m \partial_t N^n
- *                 + N^m N^n \partial_t g_{mn} \\
- *     \partial_t \psi_{ti} &= g_{mi} \partial_t N^m
- *                 + N^m \partial_t g_{mi} \\
- *     \partial_t \psi_{ij} &= \partial_t g_{ij}
+ *     \partial_t g_{tt} &= - 2 \alpha \partial_t \alpha
+ *                 + 2 \gamma_{mn} \beta^m \partial_t \beta^n
+ *                 + \beta^m \beta^n \partial_t \gamma_{mn} \\
+ *     \partial_t g_{ti} &= \gamma_{mi} \partial_t \beta^m
+ *                 + \beta^m \partial_t \gamma_{mi} \\
+ *     \partial_t g_{ij} &= \partial_t \gamma_{ij}
  * \f}
  */
 template <size_t SpatialDim, typename Frame, typename DataType>
@@ -73,7 +73,7 @@ tnsr::aa<DataType, SpatialDim, Frame> pi(
 namespace Tags {
 /*!
  * \brief Compute item the conjugate momentum \f$\Pi_{ab}\f$ of the spacetime
- * metric \f$ \psi_{ab} \f$.
+ * metric \f$ g_{ab} \f$.
  *
  * \details See `pi()`. Can be retrieved using `GeneralizedHarmonic::Tags::Pi`.
  */

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Ricci.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Ricci.hpp
@@ -28,47 +28,47 @@ namespace GeneralizedHarmonic {
  *
  * \details Lets write the Christoffel symbols of the first kind as
  * \f{align}
- * \Gamma_{kij} = \frac{1}{2}(\partial_i g_{jk} +
- *                             \partial_j g_{ik} -
- *                             \partial_k g_{ij})
+ * \Gamma_{kij} = \frac{1}{2}(\partial_i \gamma_{jk} +
+ *                             \partial_j \gamma_{ik} -
+ *                             \partial_k \gamma_{ij})
  *              = (\Phi_{(ij)k} - \frac{1}{2}\Phi_{kij})
  * \f}
- * substituting \f$\partial_k g_{ij}\rightarrow{}\Phi_{kij}\f$ by
+ * substituting \f$\partial_k \gamma_{ij}\rightarrow{}\Phi_{kij}\f$ by
  * subtracting out the three-index constraint
- * \f$C_{kij}=\partial_{k}g_{ij}-\Phi_{kij}\f$ from every term. We also
- * define contractions \f$d_k=\frac{1}{2}g^{ij}\Phi_{kij}\f$ and
- * \f$b_k=\frac{1}{2}g^{ij}\Phi_{ijk}\f$. This allows us to rewrite the
+ * \f$C_{kij}=\partial_{k}\gamma_{ij}-\Phi_{kij}\f$ from every term. We also
+ * define contractions \f$d_k=\frac{1}{2}\gamma^{ij}\Phi_{kij}\f$ and
+ * \f$b_k=\frac{1}{2}\gamma^{ij}\Phi_{ijk}\f$. This allows us to rewrite the
  * spatial Ricci tensor as:
  * \f{align}
  * R_{i j} =& \partial_k \Gamma^{k}_{ij} - \partial_i \Gamma^{k}_{kj}
  *            + \Gamma^{k}_{kl}\Gamma^{l}_{ij}
  *            - \Gamma^{l}_{ki}\Gamma^{k}_{lj},\\
  *
- *         =& g^{kl}\left(\partial_{k}\Phi_{(ij)l} -
+ *         =& \gamma^{kl}\left(\partial_{k}\Phi_{(ij)l} -
  *                        \frac{1}{2}\partial_{k}\Phi_{lij}\right)
  *            - b^{l} (\Phi_{(ij)l} - \frac{1}{2}\Phi_{lij})\nonumber\\
- *          & - g^{kl}\left(\partial_{i}\Phi_{(kj)l}
+ *          & - \gamma^{kl}\left(\partial_{i}\Phi_{(kj)l}
  *                          - \frac{1}{2}\partial_{i}\Phi_{lkj}\right)
  *            - \Phi_{i}{}^{kl}\left(\Phi_{(kj)l}
  *                                   - \frac{1}{2}\Phi_{lkj}
  *                                   \right)\nonumber\\
- *          & + g^{km}\left(\Phi_{(kl)m} - \frac{1}{2}\Phi_{mkl}\right)
- *              g^{ln}\left(\Phi_{(ij)n} - \frac{1}{2}\Phi_{nij}\right)
+ *          & + \gamma^{km}\left(\Phi_{(kl)m} - \frac{1}{2}\Phi_{mkl}\right)
+ *              \gamma^{ln}\left(\Phi_{(ij)n} - \frac{1}{2}\Phi_{nij}\right)
  *              \nonumber\\
  *
- *          & - g^{km}\left(\Phi_{(il)m} - \frac{1}{2}\Phi_{mil}\right)
- *              g^{ln}\left(\Phi_{(jk)n} - \frac{1}{2}\Phi_{njk}\right).
+ *          & - \gamma^{km}\left(\Phi_{(il)m} - \frac{1}{2}\Phi_{mil}\right)
+ *              \gamma^{ln}\left(\Phi_{(jk)n} - \frac{1}{2}\Phi_{njk}\right).
  * \f}
  * Gathering all terms with second derivatives:
  * \f{align}
- * R_{i j} =& \frac{1}{2} g^{k l} \left(\partial_k\Phi_{ijl}
+ * R_{i j} =& \frac{1}{2} \gamma^{k l} \left(\partial_k\Phi_{ijl}
  *                                      + \partial_k\Phi_{jil}
  *                                      - \partial_k\Phi_{lij}
  *                                      + \partial_i\Phi_{lkj}
  *                                      - \partial_i\Phi_{kjl}
  *                                      - \partial_i\Phi_{jkl}\right)
  *          + \mathcal{O}(\Phi), \nonumber\\
- *         =& \frac{1}{2} g^{kl} \left(\partial_{(j}\Phi_{lki)}
+ *         =& \frac{1}{2} \gamma^{kl} \left(\partial_{(j}\Phi_{lki)}
  *                                     - \partial_{(j}\Phi_{i)kl}
  *                                     + \partial_k \Phi_{(ij)l}
  *                                     - \partial_l \Phi_{kij} \right)
@@ -97,8 +97,8 @@ namespace GeneralizedHarmonic {
  *         + \mathcal{O}(\partial\Phi).
  * \f}
  * Gathering everything together, we compute the spatial Ricci tensor as:
- * \f{eqnarray}\label{eq:rij}
- * R_{i j} &=& \frac{1}{2} g^{kl} \left(\partial_{(j|}\Phi_{lk|i)}
+ * \f{eqnarray}
+ * R_{i j} &=& \frac{1}{2} \gamma^{kl} \left(\partial_{(j|}\Phi_{lk|i)}
  *                                     - \partial_{(j}\Phi_{i)kl}
  *                                     + \partial_k \Phi_{(ij)l}
  *                                     - \partial_l \Phi_{kij}\right)\nonumber\\
@@ -107,6 +107,7 @@ namespace GeneralizedHarmonic {
  *          + \frac{1}{4} \Phi_{ik}{}^l \Phi_{jl}{}^k
  *          + \frac{1}{2} \left(\Phi^k{}_{il} \Phi_{kj}{}^l
  *                              - \Phi^k{}_{li} \Phi^l{}_{kj}\right).
+ * \label{eq:rij}
  * \f}
  * This follows from equations (2.13) - (2.20) of \cite Kidder2001tz .
  *

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpacetimeDerivOfDetSpatialMetric.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpacetimeDerivOfDetSpatialMetric.hpp
@@ -38,7 +38,8 @@ namespace GeneralizedHarmonic {
  *        using the generalized harmonic variables, spatial metric, and its
  *        time derivative.
  *
- * \details Using the relation \f$ \partial_a g = g g^{jk} \partial_a g_{jk} \f$
+ * \details Using the relation
+ * \f$ \partial_a \gamma = \gamma \gamma^{jk} \partial_a \gamma_{jk} \f$
  */
 template <size_t SpatialDim, typename Frame, typename DataType>
 void spacetime_deriv_of_det_spatial_metric(

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpacetimeDerivOfNormOfShift.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpacetimeDerivOfNormOfShift.hpp
@@ -38,8 +38,9 @@ namespace GeneralizedHarmonic {
  *
  * \details The same is computed as:
  * \f{align*}
- * \partial_a (N^i N_i) = (N_i \partial_0 N^i + N^i \partial_0 N_i,
- *                               N_i \partial_j N^i + N^i \partial_j N_i)
+ * \partial_a (\beta^i \beta_i) =
+ *     (\beta_i \partial_0 \beta^i + \beta^i \partial_0 \beta_i,
+ *      \beta_i \partial_j \beta^i + \beta^i \partial_j \beta_i)
  * \f}
  */
 template <size_t SpatialDim, typename Frame, typename DataType>

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfLapse.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfLapse.hpp
@@ -34,26 +34,31 @@ namespace GeneralizedHarmonic {
 /// @{
 /*!
  * \ingroup GeneralRelativityGroup
- * \brief Computes spatial derivatives of lapse (N) from the generalized
- *        harmonic variables and spacetime unit normal 1-form.
+ * \brief Computes spatial derivatives of lapse (\f$\alpha\f$) from the
+ *        generalized harmonic variables and spacetime unit normal 1-form.
  *
  * \details If the generalized harmonic conjugate momentum and spatial
- * derivative variables are \f$\Pi_{ab} = -t^c \partial_c \psi_{ab} \f$ and
- * \f$\Phi_{iab} = \partial_i \psi_{ab} \f$, the spatial derivatives of N
- * can be obtained from:
+ * derivative variables are \f$\Pi_{ab} = -n^c \partial_c g_{ab} \f$ and
+ * \f$\Phi_{iab} = \partial_i g_{ab} \f$, the spatial derivatives of
+ * \f$\alpha\f$ can be obtained from:
+ *
  * \f{align*}
- *  t^a t^b \Phi_{iab} = -\frac{1}{2N} [\partial_i (-N^2 + N_jN^j)-
- *                               2 N^j \partial_i N_j
- *                               + N^j N^k \partial_i g_{jk}]
- *                     = -\frac{2}{N} \partial_i N,
+ *      n^a n^b \Phi_{iab} =
+ *          -\frac{1}{2\alpha} [\partial_i (-\alpha^2 + \beta_j\beta^j)-
+ *                              2 \beta^j \partial_i \beta_j
+ *                              + \beta^j \beta^k \partial_i \gamma_{jk}]
+ *                         = -\frac{2}{\alpha} \partial_i \alpha,
  * \f}
+ *
  * since
+ *
  * \f[
- * \partial_i (N_jN^j) = 2N^j \partial_i N_j - N^j N^k \partial_i g_{jk}.
+ * \partial_i (\beta_j\beta^j) =
+ *     2\beta^j \partial_i \beta_j - \beta^j \beta^k \partial_i \gamma_{jk}.
  * \f]
  *
  * \f[
- * \Longrightarrow \partial_i N = -(N/2) t^a \Phi_{iab} t^b
+ *     \Longrightarrow \partial_i \alpha = -(\alpha/2) n^a \Phi_{iab} n^b
  * \f]
  */
 template <size_t SpatialDim, typename Frame, typename DataType>

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfShift.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfShift.hpp
@@ -37,22 +37,24 @@ namespace GeneralizedHarmonic {
  * \brief Computes spatial derivatives of the shift vector from
  *        the generalized harmonic and geometric variables
  *
- * \details Spatial derivatives of the shift vector \f$N^i\f$ can be derived
+ * \details Spatial derivatives of the shift vector \f$\beta^i\f$ can be derived
  * from the following steps:
  * \f{align*}
- * \partial_i N^j
- *  =& g^{jl} g_{kl} \partial_i N^k \\
- *  =& g^{jl} (N^k \partial_i g_{lk}
- *             + g_{kl}\partial_i N^k - N^k \partial_i g_{kl}) \\
- *  =& g^{jl} (\partial_i N_l - N^k \partial_i g_{lk}) (\because g^{j0} = 0) \\
- *  =& g^{ja} (\partial_i \psi_{a0} - N^k \partial _i \psi_{ak}) \\
- *  =& N g^{ja} t^b \partial_i \psi_{ab} \\
- *  =& (g^{ja} - t^j t^a) N t^b \Phi_{iab} - 2 t^j \partial_i N \\
- *  =& \psi^{ja} N t^b \Phi_{iab} - 2 t^j \partial_i N \\
- *  =& N (\psi^{ja} + t^j t^a) t^b \Phi_{iab}.
+ * \partial_i \beta^j
+ *  =& \gamma^{jl} \gamma_{kl} \partial_i \beta^k \\
+ *  =& \gamma^{jl} (\beta^k \partial_i \gamma_{lk}
+ *         + \gamma_{kl}\partial_i \beta^k - \beta^k \partial_i \gamma_{kl}) \\
+ *  =& \gamma^{jl} (\partial_i \beta_l - \beta^k \partial_i \gamma_{lk})
+ *         (\because \gamma^{j0} = 0) \\
+ *  =& \gamma^{ja} (\partial_i g_{a0} - \beta^k \partial _i g_{ak}) \\
+ *  =& \alpha \gamma^{ja} n^b \partial_i g_{ab} \\
+ *  =& (\gamma^{ja} - n^j n^a) \alpha n^b \Phi_{iab}
+ *         - 2 n^j \partial_i \alpha \\
+ *  =& g^{ja} \alpha n^b \Phi_{iab} - 2 n^j \partial_i \alpha \\
+ *  =& \alpha (g^{ja} + n^j n^a) n^b \Phi_{iab}.
  * \f}
  * where we used the equation from spatial_deriv_of_lapse() for
- * \f$\partial_i N\f$.
+ * \f$\partial_i \alpha\f$.
  */
 template <size_t SpatialDim, typename Frame, typename DataType>
 void spatial_deriv_of_shift(

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfLapse.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfLapse.hpp
@@ -34,32 +34,43 @@ namespace GeneralizedHarmonic {
 /// @{
 /*!
  * \ingroup GeneralRelativityGroup
- * \brief Computes time derivative of lapse (N) from the generalized
+ * \brief Computes time derivative of lapse (\f$\alpha\f$) from the generalized
  *        harmonic variables, lapse, shift and the spacetime unit normal 1-form.
  *
  * \details Let the generalized harmonic conjugate momentum and spatial
- * derivative variables be \f$\Pi_{ab} = -t^c \partial_c \psi_{ab} \f$ and
- * \f$\Phi_{iab} = \partial_i \psi_{ab} \f$, and the operator
- * \f$D := \partial_0 - N^k \partial_k \f$. The time derivative of N is then:
+ * derivative variables be \f$\Pi_{ab} = -n^c \partial_c g_{ab} \f$ and
+ * \f$\Phi_{iab} = \partial_i g_{ab} \f$, and the operator
+ * \f$D := \partial_0 - \beta^k \partial_k \f$. The time derivative of
+ * \f$\alpha\f$ is then:
+ *
  * \f{align*}
- *  \frac{1}{2} N^2 t^a t^b \Pi_{ab} - \frac{1}{2} N N^i t^a t^b \Phi_{iab}
- *  =& \frac{1}{2} N^2 t^a t^b t^c \partial_c \psi_{ab}
- *       - \frac{1}{2} N N^i (-(2/N) \partial_i N) \\
- *  =& \frac{1}{2} N^2 [-(1/N^3) D[g_{jk} N^j N^k - N^2] \\
- *           &- (N^j N^k / N^3)D[g_{jk}] \\
- *           &+ 2 (N^j / N^3) D[g_{jk} N^k] + (2 / N^2)(N^i \partial_i N)] \\
- *  =& \frac{1}{2N} [-D[g_{jk}N^jN^k - N^2] - N^jN^k D[g_{jk}]
- *            + 2N N^k\partial_k N + 2N^j D[g_{jk}N^k]] \\
- *  =& D[N] + N^k\partial_k N \\
- *  =& \partial_0 N
+ *  \frac{1}{2} \alpha^2 n^a n^b \Pi_{ab}
+ *       - \frac{1}{2} \alpha \beta^i n^a n^b \Phi_{iab}
+ *  =& \frac{1}{2} \alpha^2 n^a n^b n^c \partial_c g_{ab}
+ *       - \frac{1}{2} \alpha \beta^i (-(2/\alpha) \partial_i \alpha) \\
+ *  =& \frac{1}{2} \alpha^2 [ \\
+ *       &-(1/\alpha^3) D[\gamma_{jk} \beta^j \beta^k - \alpha^2] \\
+ *       &- (\beta^j \beta^k / \alpha^3)D[\gamma_{jk}] \\
+ *       &+ 2 (\beta^j / \alpha^3) D[\gamma_{jk} \beta^k] \\
+ *       &+ (2 / \alpha^2)(\beta^i \partial_i \alpha)]] \\
+ *  =& \frac{1}{2\alpha} [-D[\gamma_{jk}\beta^j\beta^k - \alpha^2]
+ *       - \beta^j\beta^k D[\gamma_{jk}] + 2\alpha \beta^k\partial_k \alpha
+ *       + 2\beta^j D[\gamma_{jk}\beta^k]] \\
+ *  =& D[\alpha] + \beta^k\partial_k \alpha \\
+ *  =& \partial_0 \alpha
  * \f}
- * where the simplification done for \f$\partial_i N\f$ is used to substitute
- * for the second term (\f$\frac{1}{2} N N^i t^a t^b \Phi_{iab}\f$).
+ *
+ * where the simplification done for \f$\partial_i \alpha\f$ is used to
+ * substitute for the second term (\f$\frac{1}{2} \alpha \beta^i n^a n^b
+ * \Phi_{iab}\f$).
  *
  * Thus,
+ *
  * \f[
- *  \partial_0 N = (N/2)(N t^a t^b \Pi_{ab} - N^i t^a t^b \Phi_{iab})
+ *  \partial_0 \alpha =
+ *      (\alpha/2)(\alpha n^a n^b \Pi_{ab} - \beta^i n^a n^b \Phi_{iab})
  * \f]
+ *
  */
 template <size_t SpatialDim, typename Frame, typename DataType>
 void time_deriv_of_lapse(
@@ -80,8 +91,9 @@ Scalar<DataType> time_deriv_of_lapse(
 
 namespace Tags {
 /*!
- * \brief Compute item to get time derivative of lapse (N) from the generalized
- *        harmonic variables, lapse, shift and the spacetime unit normal 1-form.
+ * \brief Compute item to get time derivative of lapse (\f$\alpha\f$) from the
+ *        generalized harmonic variables, lapse, shift and the spacetime unit
+ *        normal 1-form.
  *
  * \details See `time_deriv_of_lapse()`. Can be retrieved using
  * `gr::Tags::Lapse` wrapped in `Tags::dt`.

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfLowerShift.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfLowerShift.hpp
@@ -37,9 +37,10 @@ namespace GeneralizedHarmonic {
  * \brief Computes time derivative of index lowered shift from generalized
  *        harmonic variables, spatial metric and its time derivative.
  *
- * \details The time derivative of \f$ N_i \f$ is given by:
+ * \details The time derivative of \f$ \beta_i \f$ is given by:
  * \f{align*}
- *  \partial_0 N_i = g_{ij} \partial_0 N^j + N^j \partial_0 g_{ij}
+ *  \partial_0 \beta_i =
+ *      \gamma_{ij} \partial_0 \beta^j + \beta^j \partial_0 \gamma_{ij}
  * \f}
  * where the first term is obtained from `time_deriv_of_shift()`, and the latter
  * is a user input.

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfShift.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfShift.hpp
@@ -37,16 +37,18 @@ namespace GeneralizedHarmonic {
  * \brief Computes time derivative of the shift vector from
  *        the generalized harmonic and geometric variables
  *
- * \details The time derivative of \f$ N^i \f$ can be derived from the following
- * steps:
+ * \details The time derivative of \f$ \beta^i \f$ can be derived from the
+ * following steps:
  * \f{align*}
- * \partial_0 N^i
- *  =& g^{ik} \partial_0 (g_{kj} N^j) - N^j g^{ik} \partial_0 g_{kj} \\
- *  =& N g^{ik} t^b \partial_0 \psi_{kb} \\
- *  =& N g^{ik} t^b (\partial_0 - N^j\partial_j) \psi_{kb}
- *                  + N g^{ik} t^b N^j\partial_j \psi_{kb} \\
- *  =& -N^2 t^b\Pi_{kb} g^{ik} + N N^j t^b\Phi_{jkb} g^{ik} \\
- *  =& -N g^{ik} t^b (N \Pi_{kb} - N^j \Phi_{jkb}) \\
+ * \partial_0 \beta^i
+ *  =& \gamma^{ik} \partial_0 (\gamma_{kj} \beta^j)
+ *         - \beta^j \gamma^{ik} \partial_0 \gamma_{kj} \\
+ *  =& \alpha \gamma^{ik} n^b \partial_0 g_{kb} \\
+ *  =& \alpha \gamma^{ik} n^b (\partial_0 - \beta^j\partial_j) g_{kb}
+ *                  + \alpha \gamma^{ik} n^b \beta^j\partial_j g_{kb} \\
+ *  =& -\alpha^2 n^b\Pi_{kb} \gamma^{ik}
+ *         + \alpha \beta^j n^b\Phi_{jkb} \gamma^{ik} \\
+ *  =& -\alpha \gamma^{ik} n^b (\alpha \Pi_{kb} - \beta^j \Phi_{jkb}) \\
  * \f}
  */
 template <size_t SpatialDim, typename Frame, typename DataType>

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfSpatialMetric.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfSpatialMetric.hpp
@@ -37,17 +37,17 @@ namespace GeneralizedHarmonic {
  * \brief Computes time derivative of the spatial metric.
  *
  * \details Let the generalized harmonic conjugate momentum and spatial
- * derivative variables be \f$\Pi_{ab} = -t^c \partial_c \psi_{ab} \f$ and
- * \f$\Phi_{iab} = \partial_i \psi_{ab} \f$. As \f$ t_i \equiv 0 \f$. The time
+ * derivative variables be \f$\Pi_{ab} = -n^c \partial_c g_{ab} \f$ and
+ * \f$\Phi_{iab} = \partial_i g_{ab} \f$. As \f$ n_i \equiv 0 \f$. The time
  * derivative of the spatial metric is given by the time derivative of the
  * spatial sector of the spacetime metric, i.e.
- * \f$ \partial_0 g_{ij} = \partial_0 \psi_{ij} \f$.
+ * \f$ \partial_0 \gamma_{ij} = \partial_0 g_{ij} \f$.
  *
- * To compute the latter, we use the evolution equation for \f$ \psi_{ij} \f$,
+ * To compute the latter, we use the evolution equation for \f$ g_{ij} \f$,
  * c.f. eq.(35) of \cite Lindblom2005qh (with \f$\gamma_1 = -1\f$):
  *
  * \f[
- * \partial_0 \psi_{ab} = - N \Pi_{ab} + N^k \Phi_{kab}
+ * \partial_0 g_{ab} = - \alpha \Pi_{ab} + \beta^k \Phi_{kab}
  * \f]
  */
 template <size_t SpatialDim, typename Frame, typename DataType>

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivativeOfSpacetimeMetric.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivativeOfSpacetimeMetric.hpp
@@ -41,7 +41,7 @@ namespace GeneralizedHarmonic {
  * \details Computes the derivative as:
  *
  * \f{align}{
- * \partial_t \psi_{a b} = \beta^i \Phi_{i a b} - \alpha \Pi_{a b}.
+ * \partial_t g_{a b} = \beta^i \Phi_{i a b} - \alpha \Pi_{a b}.
  * \f}
  */
 template <size_t SpatialDim, typename Frame, typename DataType>

--- a/src/PointwiseFunctions/GeneralRelativity/InverseSpacetimeMetric.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/InverseSpacetimeMetric.hpp
@@ -29,14 +29,14 @@ namespace gr {
  * \brief Compute inverse spacetime metric from inverse spatial metric, lapse
  * and shift
  *
- * \details The inverse spacetime metric \f$ \psi^{ab} \f$ is calculated as
+ * \details The inverse spacetime metric \f$ g^{ab} \f$ is calculated as
  * \f{align}
- *    \psi^{tt} &= -  1/N^2 \\
- *    \psi^{ti} &= N^i / N^2 \\
- *    \psi^{ij} &= g^{ij} - N^i N^j / N^2
+ *    g^{tt} &= -  1/\alpha^2 \\
+ *    g^{ti} &= \beta^i / \alpha^2 \\
+ *    g^{ij} &= \gamma^{ij} - \beta^i \beta^j / \alpha^2
  * \f}
- * where \f$ N, N^i\f$ and \f$ g^{ij}\f$ are the lapse, shift and inverse
- * spatial metric respectively
+ * where \f$ \alpha, \beta^i\f$ and \f$ \gamma^{ij}\f$ are the lapse, shift and
+ * inverse spatial metric respectively
  */
 template <size_t SpatialDim, typename Frame, typename DataType>
 void inverse_spacetime_metric(
@@ -55,9 +55,9 @@ tnsr::AA<DataType, SpatialDim, Frame> inverse_spacetime_metric(
 
 namespace Tags {
 /*!
- * \brief Compute item for inverse spacetime metric \f$\psi^{ab}\f$
- * in terms of the lapse \f$N\f$, shift \f$N^i\f$, and inverse
- * spatial metric \f$g^{ij}\f$.
+ * \brief Compute item for inverse spacetime metric \f$g^{ab}\f$ in terms of the
+ * lapse \f$\alpha\f$, shift \f$\beta^i\f$, and inverse spatial metric
+ * \f$\gamma^{ij}\f$.
  *
  * \details Can be retrieved using `gr::Tags::InverseSpacetimeMetric`.
  */

--- a/src/PointwiseFunctions/GeneralRelativity/Lapse.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Lapse.hpp
@@ -30,9 +30,9 @@ namespace gr {
  *
  * \details Computes
  * \f{align}
- *    N &= \sqrt{N^i \psi_{it}-\psi_{tt}}
+ *    \alpha &= \sqrt{\beta^i g_{it}-g_{tt}}
  * \f}
- * where \f$ N \f$, \f$ N^i\f$, and \f$\psi_{ab}\f$ are the lapse, shift,
+ * where \f$ \alpha \f$, \f$ \beta^i\f$, and \f$g_{ab}\f$ are the lapse, shift,
  * and spacetime metric.
  * This can be derived, e.g., from Eqs. 2.121--2.122 of Baumgarte & Shapiro.
  */
@@ -49,8 +49,8 @@ void lapse(gsl::not_null<Scalar<DataType>*> lapse,
 
 namespace Tags {
 /*!
- * \brief Compute item for lapse \f$N\f$ from the spacetime metric
- * \f$\psi_{ab}\f$ and the shift \f$N^i\f$.
+ * \brief Compute item for lapse \f$\alpha\f$ from the spacetime metric
+ * \f$g_{ab}\f$ and the shift \f$\beta^i\f$.
  *
  * \details Can be retrieved using `gr::Tags::Lapse`.
  */

--- a/src/PointwiseFunctions/GeneralRelativity/ProjectionOperators.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ProjectionOperators.hpp
@@ -22,8 +22,8 @@ namespace gr {
  * \ingroup GeneralRelativityGroup
  * \brief Compute projection operator onto an interface
  *
- * \details Returns the operator \f$P^{ij} = g^{ij} - n^i n^j\f$,
- * where \f$g^{ij}\f$ is the inverse spatial metric, and
+ * \details Returns the operator \f$P^{ij} = \gamma^{ij} - n^i n^j\f$,
+ * where \f$\gamma^{ij}\f$ is the inverse spatial metric, and
  * \f$n^i\f$ is the normal vector to the interface in question.
  *
  */
@@ -44,8 +44,8 @@ void transverse_projection_operator(
  * \ingroup GeneralRelativityGroup
  * \brief Compute projection operator onto an interface
  *
- * \details Returns the operator \f$P_{ij} = g_{ij} - n_i n_j\f$,
- * where \f$ g_{ij}\f$ is the spatial metric, and \f$ n_i\f$ is
+ * \details Returns the operator \f$P_{ij} = \gamma_{ij} - n_i n_j\f$,
+ * where \f$ \gamma_{ij}\f$ is the spatial metric, and \f$ n_i\f$ is
  * the normal one-form to the interface in question.
  */
 template <size_t VolumeDim, typename Frame, typename DataType>
@@ -86,15 +86,15 @@ void transverse_projection_operator(
  * \ingroup GeneralRelativityGroup
  * \brief Compute spacetime projection operator onto an interface
  *
- * \details Consider an \f$n-1\f$-dimensional surface \f$S\f$ in an
- * \f$n\f$-dimensional spatial hypersurface \f$\Sigma\f$. Let \f$s_a\f$
+ * \details Consider a \f$d-1\f$-dimensional surface \f$S\f$ in a
+ * \f$d\f$-dimensional spatial hypersurface \f$\Sigma\f$. Let \f$s_a\f$
  * be the unit spacelike one-form orthogonal to \f$S\f$ in \f$\Sigma\f$,
  * and \f$n_a\f$ be the timelike unit vector orthogonal to \f$\Sigma\f$.
  * This function returns the projection operator onto \f$S\f$ for
- * \f$n+1\f$ dimensional quantities:
+ * \f$d+1\f$ dimensional quantities:
  *
  * \f{align*}
- * P_{ab} = \psi_{ab} + n_a n_b - s_a s_b.
+ * P_{ab} = g_{ab} + n_a n_b - s_a s_b = \gamma_{ab} - s_a s_b.
  * \f}
  */
 template <size_t VolumeDim, typename Frame, typename DataType>
@@ -116,15 +116,15 @@ void transverse_projection_operator(
  * \ingroup GeneralRelativityGroup
  * \brief Compute spacetime projection operator onto an interface
  *
- * \details Consider an \f$n-1\f$-dimensional surface \f$S\f$ in an
- * \f$n\f$-dimensional spatial hypersurface \f$\Sigma\f$. Let \f$s^a\f$
+ * \details Consider a \f$d-1\f$-dimensional surface \f$S\f$ in a
+ * \f$d\f$-dimensional spatial hypersurface \f$\Sigma\f$. Let \f$s^a\f$
  * be the unit spacelike vector orthogonal to \f$S\f$ in \f$\Sigma\f$,
  * and \f$n^a\f$ be the timelike unit vector orthogonal to \f$\Sigma\f$.
  * This function returns the projection operator onto \f$S\f$ for
- * \f$n+1\f$ dimensional quantities:
+ * \f$d+1\f$ dimensional quantities:
  *
  * \f{align*}
- * P^{ab} = \psi^{ab} + n^a n^b - s^a s^b.
+ * P^{ab} = g^{ab} + n^a n^b - s^a s^b = \gamma_{ab} - s_a s_b.
  * \f}
  */
 template <size_t VolumeDim, typename Frame, typename DataType>
@@ -146,12 +146,12 @@ void transverse_projection_operator(
  * \ingroup GeneralRelativityGroup
  * \brief Compute spacetime projection operator onto an interface
  *
- * \details Consider an \f$n-1\f$-dimensional surface \f$S\f$ in an
- * \f$n\f$-dimensional spatial hypersurface \f$\Sigma\f$. Let \f$s^a\f$
+ * \details Consider a \f$d-1\f$-dimensional surface \f$S\f$ in a
+ * \f$d\f$-dimensional spatial hypersurface \f$\Sigma\f$. Let \f$s^a\f$
  * \f$(s_a)\f$ be the unit spacelike vector (one-form) orthogonal
  * to \f$S\f$ in \f$\Sigma\f$, and \f$n^a\f$ \f$(n_a)\f$ be the timelike
  * unit vector (one-form) orthogonal to \f$\Sigma\f$. This function
- * returns the projection operator onto \f$S\f$ for \f$n+1\f$ dimensional
+ * returns the projection operator onto \f$S\f$ for \f$d+1\f$ dimensional
  * quantities:
  *
  * \f{align*}

--- a/src/PointwiseFunctions/GeneralRelativity/Shift.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Shift.hpp
@@ -30,10 +30,10 @@ namespace gr {
  *
  * \details Computes
  * \f{align}
- *    N^i &= g^{ij} \psi_{jt}
+ *    \beta^i &= \gamma^{ij} g_{jt}
  * \f}
- * where \f$ N^i\f$, \f$ g^{ij}\f$, and \f$\psi_{ab}\f$ are the shift, inverse
- * spatial metric, and spacetime metric.
+ * where \f$ \beta^i\f$, \f$ \gamma^{ij}\f$, and \f$g_{ab}\f$ are the shift,
+ * inverse spatial metric, and spacetime metric.
  * This can be derived, e.g., from Eqs. 2.121--2.122 of Baumgarte & Shapiro.
  */
 template <size_t SpatialDim, typename Frame, typename DataType>
@@ -49,8 +49,8 @@ void shift(gsl::not_null<tnsr::I<DataType, SpatialDim, Frame>*> shift,
 
 namespace Tags {
 /*!
- * \brief Compute item for shift \f$N^i\f$ from the spacetime metric
- * \f$\psi_{ab}\f$ and the inverse spatial metric \f$g^{ij}\f$.
+ * \brief Compute item for shift \f$\beta^i\f$ from the spacetime metric
+ * \f$g_{ab}\f$ and the inverse spatial metric \f$\gamma^{ij}\f$.
  *
  * \details Can be retrieved using `gr::Tags::Shift`.
  */

--- a/src/PointwiseFunctions/GeneralRelativity/SpacetimeMetric.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/SpacetimeMetric.hpp
@@ -24,14 +24,14 @@ namespace gr {
  * \ingroup GeneralRelativityGroup
  * \brief Computes the spacetime metric from the spatial metric, lapse, and
  * shift.
- * \details The spacetime metric \f$ \psi_{ab} \f$ is calculated as
+ * \details The spacetime metric \f$ g_{ab} \f$ is calculated as
  * \f{align}{
- *   \psi_{tt} &= - N^2 + N^m N^n g_{mn} \\
- *   \psi_{ti} &= g_{mi} N^m  \\
- *   \psi_{ij} &= g_{ij}
+ *   g_{tt} &= - \alpha^2 + \beta^m \beta^n \gamma_{mn} \\
+ *   g_{ti} &= \gamma_{mi} \beta^m  \\
+ *   g_{ij} &= \gamma_{ij}
  * \f}
- * where \f$ N, N^i\f$ and \f$ g_{ij}\f$ are the lapse, shift and spatial metric
- * respectively
+ * where \f$ \alpha, \beta^i\f$ and \f$ \gamma_{ij}\f$ are the lapse, shift and
+ * spatial metric respectively
  */
 template <size_t Dim, typename Frame, typename DataType>
 void spacetime_metric(
@@ -48,8 +48,8 @@ tnsr::aa<DataType, SpatialDim, Frame> spacetime_metric(
 
 namespace Tags {
 /*!
- * \brief Compute item for spacetime metric \f$\psi_{ab}\f$ from the
- * lapse \f$N\f$, shift \f$N^i\f$, and spatial metric \f$g_{ij}\f$.
+ * \brief Compute item for spacetime metric \f$g_{ab}\f$ from the lapse
+ * \f$\alpha\f$, shift \f$\beta^i\f$, and spatial metric \f$\gamma_{ij}\f$.
  *
  * \details Can be retrieved using `gr::Tags::SpacetimeMetric`.
  */

--- a/src/PointwiseFunctions/GeneralRelativity/SpacetimeNormalOneForm.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/SpacetimeNormalOneForm.hpp
@@ -27,9 +27,13 @@ namespace gr {
 /*!
  * \brief Computes spacetime normal one-form from lapse.
  *
- * \details If \f$N\f$ is the lapse, then
- * \f{align} n_t &= - N \\
- * n_i &= 0 \f}
+ * \details If \f$\alpha\f$ is the lapse, then
+ *
+ * \f{align}
+ *     n_t &= - \alpha \\
+ *     n_i &= 0
+ * \f}
+ *
  * is computed.
  */
 template <size_t SpatialDim, typename Frame, typename DataType>
@@ -45,7 +49,7 @@ tnsr::a<DataType, SpatialDim, Frame> spacetime_normal_one_form(
 namespace Tags {
 /*!
  * \brief Compute item for spacetime normal oneform \f$n_a\f$ from
- * the lapse \f$N\f$.
+ * the lapse \f$\alpha\f$.
  *
  * \details Can be retrieved using `gr::Tags::SpacetimeNormalOneForm`.
  */

--- a/src/PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.hpp
@@ -27,9 +27,12 @@ namespace gr {
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief  Computes spacetime normal vector from lapse and shift.
- * \details If \f$N, N^i\f$ are the lapse and shift respectively, then
- * \f{align} n^t &= 1/N \\
- * n^i &= -\frac{N^i}{N} \f}
+ *
+ * \details If \f$\alpha, \beta^i\f$ are the lapse and shift respectively, then
+ *
+ * \f{align} n^t &= 1/\alpha \\
+ * n^i &= -\frac{\beta^i}{\alpha} \f}
+ *
  * is computed.
  */
 template <size_t SpatialDim, typename Frame, typename DataType>
@@ -48,7 +51,7 @@ void spacetime_normal_vector(
 namespace Tags {
 /*!
  * \brief Compute item for spacetime normal vector \f$n^a\f$ from
- * the lapse \f$N\f$ and the shift \f$N^i\f$.
+ * the lapse \f$\alpha\f$ and the shift \f$\beta^i\f$.
  *
  * \details Can be retrieved using `gr::Tags::SpacetimeNormalVector`.
  */

--- a/src/PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp
@@ -41,8 +41,8 @@ void spatial_metric(
 
 namespace Tags {
 /*!
- * \brief Compute item for spatial metric \f$g_{ij}\f$ from the
- * spacetime metric \f$\psi_{ab}\f$.
+ * \brief Compute item for spatial metric \f$\gamma_{ij}\f$ from the
+ * spacetime metric \f$g_{ab}\f$.
  *
  * \details Can be retrieved using `gr::Tags::SpatialMetric`.
  */

--- a/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
@@ -70,7 +70,7 @@ struct Lapse : db::SimpleTag {
  * \brief Spacetime derivatives of the spacetime metric
  *
  * \details Spacetime derivatives of the spacetime metric
- * \f$\partial_a \psi_{bc}\f$ assembled from the spatial and temporal
+ * \f$\partial_a g_{bc}\f$ assembled from the spatial and temporal
  * derivatives of evolved 3+1 variables.
  */
 template <size_t Dim, typename Frame, typename DataType>
@@ -107,8 +107,8 @@ struct TraceSpacetimeChristoffelFirstKind : db::SimpleTag {
 };
 /*!
  * \brief Trace of the spatial Christoffel symbols of the first kind
- * \f$\Gamma_{i} = \Gamma_{ijk}g^{jk}\f$, where \f$\Gamma_{ijk}\f$ are
- * Christoffel symbols of the first kind and \f$g^{jk}\f$ is the
+ * \f$\Gamma_{i} = \Gamma_{ijk}\gamma^{jk}\f$, where \f$\Gamma_{ijk}\f$ are
+ * Christoffel symbols of the first kind and \f$\gamma^{jk}\f$ is the
  * inverse spatial metric.
  */
 template <size_t Dim, typename Frame, typename DataType>

--- a/src/PointwiseFunctions/GeneralRelativity/WeylElectric.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/WeylElectric.hpp
@@ -54,7 +54,7 @@ void weyl_electric(
  *
  * \details Computes the scalar \f$E_{ij} E^{ij}\f$ from the electric part
  * of the Weyl tensor \f$E_{ij}\f$ and the inverse spatial metric
- * \f$g^{ij}\f$, i.e. \f$E_{ij} = \gamma^{ik}\gamma^{jl}E_{ij}E_{kl}\f$.
+ * \f$\gamma^{ij}\f$, i.e. \f$E_{ij} = \gamma^{ik}\gamma^{jl}E_{ij}E_{kl}\f$.
  *
  * \note The electric part of the Weyl tensor in vacuum is available via
  * gr::weyl_electric(). The electric part of the Weyl tensor needs additional


### PR DESCRIPTION
This updates the names of tensor variables in equations documented in the `GeneralRelativity` folder. Specifically:
- spatial metric: `g_{ij}` -> `\gamma_{ij}`
- spacetime metric: `\psi_{ab}` -> `g_{ab}`
- lapse: `N` -> `\alpha`
- shift: `N^i` -> `\beta^i`
- spacetime normal vector: `t^a` -> `n^a`

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
