### PR TITLE
Pass cache, array_index, component to events registration, minor fixes

### DIFF
--- a/src/DataStructures/DataBox/ObservationBox.hpp
+++ b/src/DataStructures/DataBox/ObservationBox.hpp
@@ -45,6 +45,9 @@ class ObservationBox<tmpl::list<ComputeTags...>, DataBoxType>
  public:
   /// A list of all the compute item tags
   using compute_item_tags = tmpl::list<ComputeTags...>;
+  /// A list of all tags
+  using tags_list =
+      tmpl::push_back<typename DataBoxType::tags_list, ComputeTags...>;
 
   ObservationBox() = default;
   ObservationBox(const ObservationBox& rhs) = default;
@@ -70,9 +73,6 @@ class ObservationBox<tmpl::list<ComputeTags...>, DataBoxType>
   template <typename ComputeTag, typename... ArgumentTags>
   void evaluate_compute_item(
       tmpl::list<ArgumentTags...> /*meta*/) const;
-
-  using tags_list =
-      tmpl::push_back<typename DataBoxType::tags_list, ComputeTags...>;
 
   const DataBoxType* databox_ = nullptr;
 };

--- a/src/Evolution/DgSubcell/Events/ObserveFields.hpp
+++ b/src/Evolution/DgSubcell/Events/ObserveFields.hpp
@@ -266,8 +266,13 @@ class ObserveFields<VolumeDim, ObservationValueTag, tmpl::list<Tensors...>,
   }
 
   using observation_registration_tags = tmpl::list<>;
+
+  template <typename Metavariables, typename ParallelComponent>
   std::pair<observers::TypeOfObservation, observers::ObservationKey>
-  get_observation_type_and_key_for_registration() const {
+  get_observation_type_and_key_for_registration(
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ElementId<VolumeDim>& /*array_index*/,
+      const ParallelComponent* const /*meta*/) const {
     return {observers::TypeOfObservation::Volume,
             observers::ObservationKey(subfile_path_ + ".vol")};
   }

--- a/src/ParallelAlgorithms/Events/ObserveErrorNorms.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveErrorNorms.hpp
@@ -210,11 +210,15 @@ class ObserveErrorNorms<ObservationValueTag, tmpl::list<Tensors...>,
 
   using observation_registration_tags = tmpl::list<::Tags::DataBox>;
 
-  template <typename DbTagsList>
+  template <typename DbTagsList, typename Metavariables, typename ArrayIndex,
+            typename ParallelComponent>
   std::optional<
       std::pair<observers::TypeOfObservation, observers::ObservationKey>>
   get_observation_type_and_key_for_registration(
-      const db::DataBox<DbTagsList>& box) const {
+      const db::DataBox<DbTagsList>& box,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/,
+      const ParallelComponent* const /*meta*/) const {
     const std::optional<std::string> section_observation_key =
         observers::get_section_observation_key<ArraySectionIdTag>(box);
     if (not section_observation_key.has_value()) {

--- a/src/ParallelAlgorithms/Events/ObserveFields.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveFields.hpp
@@ -369,11 +369,15 @@ class ObserveFields<VolumeDim, ObservationValueTag, tmpl::list<Tensors...>,
 
   using observation_registration_tags = tmpl::list<::Tags::DataBox>;
 
-  template <typename DbTagsList>
+  template <typename DbTagsList, typename Metavariables,
+            typename ParallelComponent>
   std::optional<
       std::pair<observers::TypeOfObservation, observers::ObservationKey>>
   get_observation_type_and_key_for_registration(
-      const db::DataBox<DbTagsList>& box) const {
+      const db::DataBox<DbTagsList>& box,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ElementId<VolumeDim>& /*array_index*/,
+      const ParallelComponent* const /*meta*/) const {
     const std::optional<std::string> section_observation_key =
         observers::get_section_observation_key<ArraySectionIdTag>(box);
     if (not section_observation_key.has_value()) {

--- a/src/ParallelAlgorithms/Events/ObserveNorms.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveNorms.hpp
@@ -413,7 +413,8 @@ operator()(const typename ObservationValueTag::type& observation_value,
       subfile_path_ + section_observation_key.value();
   Parallel::simple_action<observers::Actions::ContributeReductionData>(
       local_observer,
-      observers::ObservationId(observation_value, subfile_path_ + ".dat"),
+      observers::ObservationId(observation_value,
+                               subfile_path_with_suffix + ".dat"),
       observers::ArrayComponentId{
           std::add_pointer_t<ParallelComponent>{nullptr},
           Parallel::ArrayIndex<ArrayIndex>(array_index)},

--- a/src/ParallelAlgorithms/Events/ObserveNorms.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveNorms.hpp
@@ -212,11 +212,15 @@ class ObserveNorms<ObservationValueTag, tmpl::list<ObservableTensorTags...>,
 
   using observation_registration_tags = tmpl::list<::Tags::DataBox>;
 
-  template <typename DbTagsList>
+  template <typename DbTagsList, typename Metavariables, typename ArrayIndex,
+            typename ParallelComponent>
   std::optional<
       std::pair<observers::TypeOfObservation, observers::ObservationKey>>
   get_observation_type_and_key_for_registration(
-      const db::DataBox<DbTagsList>& box) const {
+      const db::DataBox<DbTagsList>& box,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/,
+      const ParallelComponent* const /*meta*/) const {
     const std::optional<std::string> section_observation_key =
         observers::get_section_observation_key<ArraySectionIdTag>(box);
     if (not section_observation_key.has_value()) {

--- a/src/ParallelAlgorithms/Events/ObserveTimeStep.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveTimeStep.hpp
@@ -203,8 +203,14 @@ class ObserveTimeStep : public Event {
   }
 
   using observation_registration_tags = tmpl::list<>;
+
+  template <typename Metavariables, typename ArrayIndex,
+            typename ParallelComponent>
   std::pair<observers::TypeOfObservation, observers::ObservationKey>
-  get_observation_type_and_key_for_registration() const {
+  get_observation_type_and_key_for_registration(
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/,
+      const ParallelComponent* const /*meta*/) const {
     return {observers::TypeOfObservation::Reduction,
             observers::ObservationKey(subfile_path_ + ".dat")};
   }

--- a/src/ParallelAlgorithms/Events/ObserveVolumeIntegrals.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveVolumeIntegrals.hpp
@@ -185,11 +185,15 @@ class ObserveVolumeIntegrals<
 
   using observation_registration_tags = tmpl::list<::Tags::DataBox>;
 
-  template <typename DbTagsList>
+  template <typename DbTagsList, typename Metavariables, typename ArrayIndex,
+            typename ParallelComponent>
   std::optional<
       std::pair<observers::TypeOfObservation, observers::ObservationKey>>
   get_observation_type_and_key_for_registration(
-      const db::DataBox<DbTagsList>& box) const {
+      const db::DataBox<DbTagsList>& box,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/,
+      const ParallelComponent* const /*meta*/) const {
     const std::optional<std::string> section_observation_key =
         observers::get_section_observation_key<ArraySectionIdTag>(box);
     if (not section_observation_key.has_value()) {

--- a/tests/Unit/IO/Observers/Test_RegisterEvents.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterEvents.cpp
@@ -57,8 +57,14 @@ class SomeEvent : public Event {
 #pragma GCC diagnostic pop
 
   using observation_registration_tags = tmpl::list<>;
+
+  template <typename Metavariables, typename ArrayIndex,
+            typename ParallelComponent>
   std::pair<observers::TypeOfObservation, observers::ObservationKey>
-  get_observation_type_and_key_for_registration() const {
+  get_observation_type_and_key_for_registration(
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/,
+      const ParallelComponent* const /*meta*/) const {
     return {observers::TypeOfObservation::Reduction,
             observers::ObservationKey(subfile_path_ + ".dat")};
   }

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveErrorNorms.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveErrorNorms.cpp
@@ -323,6 +323,8 @@ void test_observe(const std::unique_ptr<ObserveEvent> observe,
 
   const auto& results = MockContributeReductionData::results;
   CHECK(results.observation_id.value() == observation_time);
+  CHECK(results.observation_id.observation_key() ==
+        expected_observation_key_for_reg);
   CHECK(results.subfile_name == expected_subfile_name);
   CHECK(results.reduction_names[0] == "ObservationTimeTag");
   CHECK(results.time == observation_time);

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveErrorNorms.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveErrorNorms.cpp
@@ -292,7 +292,10 @@ void test_observe(const std::unique_ptr<ObserveEvent> observe,
       section);
 
   const auto ids_to_register =
-      observers::get_registration_observation_type_and_key(*observe, box);
+      observers::get_registration_observation_type_and_key(
+          *observe, box,
+          ActionTesting::cache<element_component>(runner, array_index),
+          array_index, std::add_pointer_t<element_component>{});
   const std::string expected_subfile_name{
       "/reduction0" +
       (std::is_same_v<ArraySectionIdTag, void> ? ""

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
@@ -29,6 +29,7 @@
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/ParallelAlgorithms/Events/ObserveFields.hpp"
+#include "IO/Observer/Actions/RegisterEvents.hpp"
 #include "IO/Observer/ArrayComponentId.hpp"
 #include "IO/Observer/ObservationId.hpp"
 #include "IO/Observer/ObserverComponent.hpp"
@@ -144,6 +145,21 @@ void test_observe(
       }(),
       section);
 
+  const auto ids_to_register =
+      observers::get_registration_observation_type_and_key(*observe, box);
+  const std::string expected_subfile_name{
+      "/element_data" +
+      (std::is_same_v<ArraySectionIdTag, void> ? ""
+                                               : section.value_or("Unused"))};
+  const observers::ObservationKey expected_observation_key_for_reg(
+      expected_subfile_name + ".vol");
+  if (std::is_same_v<ArraySectionIdTag, void> or section.has_value()) {
+    CHECK(ids_to_register->first == observers::TypeOfObservation::Volume);
+    CHECK(ids_to_register->second == expected_observation_key_for_reg);
+  } else {
+    CHECK_FALSE(ids_to_register.has_value());
+  }
+
   observe->run(
       make_observation_box<tmpl::filter<
           typename System::ObserveEvent::compute_tags_for_observation_box,
@@ -156,17 +172,14 @@ void test_observe(
     return;
   }
 
-  const std::string expected_subfile_name{
-      "/element_data" +
-      (std::is_same_v<ArraySectionIdTag, void> ? ""
-                                               : section.value_or("Unused"))};
-
   // Process the data
   runner.template invoke_queued_simple_action<observer_component>(0);
   CHECK(runner.template is_simple_action_queue_empty<observer_component>(0));
 
   const auto& results = MockContributeVolumeData::results;
   CHECK(results.observation_id.value() == observation_time);
+  CHECK(results.observation_id.observation_key() ==
+        expected_observation_key_for_reg);
   CHECK(results.subfile_name == expected_subfile_name);
   CHECK(results.array_component_id ==
         observers::ArrayComponentId(

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
@@ -146,7 +146,10 @@ void test_observe(
       section);
 
   const auto ids_to_register =
-      observers::get_registration_observation_type_and_key(*observe, box);
+      observers::get_registration_observation_type_and_key(
+          *observe, box,
+          ActionTesting::cache<element_component>(runner, array_index),
+          array_index, std::add_pointer_t<element_component>{});
   const std::string expected_subfile_name{
       "/element_data" +
       (std::is_same_v<ArraySectionIdTag, void> ? ""

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveNorms.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveNorms.cpp
@@ -226,6 +226,8 @@ void test(const std::unique_ptr<ObserveEvent> observe,
 
   const auto& results = MockContributeReductionData::results;
   CHECK(results.observation_id.value() == observation_time);
+  CHECK(results.observation_id.observation_key() ==
+        expected_observation_key_for_reg);
   CHECK(results.subfile_name == expected_subfile_name);
   CHECK(results.reduction_names[0] == "Time");
   CHECK(results.time == observation_time);

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveNorms.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveNorms.cpp
@@ -194,7 +194,10 @@ void test(const std::unique_ptr<ObserveEvent> observe,
       metavariables{}, observation_time, vars, section);
 
   const auto ids_to_register =
-      observers::get_registration_observation_type_and_key(*observe, box);
+      observers::get_registration_observation_type_and_key(
+          *observe, box,
+          ActionTesting::cache<element_component>(runner, array_index),
+          array_index, std::add_pointer_t<element_component>{});
   const std::string expected_subfile_name{
       "/reduction0" +
       (std::is_same_v<ArraySectionIdTag, void> ? ""

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStep.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStep.cpp
@@ -198,17 +198,21 @@ void test_observe(const Observer& observer, const bool backwards_in_time,
             Metavariables{}, observation_time, slab.duration() * slab_fraction,
             System::variables_tag::type(num_points));
 
+        element_boxes.push_back(std::move(box));
+
+        const size_t index = element_boxes.size() - 1;
+        ActionTesting::emplace_component<element_component>(&runner, index);
+
         const auto ids_to_register =
-            observers::get_registration_observation_type_and_key(observer, box);
+            observers::get_registration_observation_type_and_key(
+                observer, element_boxes.back(),
+                ActionTesting::cache<element_component>(runner, index),
+                static_cast<element_component::array_index>(index),
+                std::add_pointer_t<element_component>{});
         CHECK(ids_to_register->first ==
               observers::TypeOfObservation::Reduction);
         CHECK(ids_to_register->second ==
               observers::ObservationKey("/time_step_subfile.dat"));
-
-        element_boxes.push_back(std::move(box));
-
-        ActionTesting::emplace_component<element_component>(
-            &runner, element_boxes.size() - 1);
       };
 
   create_element(5, {1, 20});

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveVolumeIntegrals.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveVolumeIntegrals.cpp
@@ -275,7 +275,10 @@ void test_observe(const std::unique_ptr<ObserveEvent> observe,
   ActionTesting::emplace_group_component<observer_component>(&runner);
 
   const auto ids_to_register =
-      observers::get_registration_observation_type_and_key(*observe, box);
+      observers::get_registration_observation_type_and_key(
+          *observe, box,
+          ActionTesting::cache<element_component>(runner, array_index),
+          array_index, std::add_pointer_t<element_component>{});
   const std::string expected_subfile_name{
       "/volume_integrals" +
       (std::is_same_v<ArraySectionIdTag, void> ? ""


### PR DESCRIPTION
## Proposed changes

Make the events registration function consistent with the call operator and the is_ready function, giving it access to the same information. Also fix a few minor things in events.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
