### PR TITLE
Strahlkorper diff

### DIFF
--- a/src/ApparentHorizons/CMakeLists.txt
+++ b/src/ApparentHorizons/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_sources(
   ChangeCenterOfStrahlkorper.cpp
   FastFlow.cpp
   Strahlkorper.cpp
+  StrahlkorperFunctions.cpp
   StrahlkorperGr.cpp
   StrahlkorperInDifferentFrame.cpp
   Tags.cpp
@@ -26,6 +27,7 @@ spectre_target_headers(
   ComputeItems.hpp
   FastFlow.hpp
   Strahlkorper.hpp
+  StrahlkorperFunctions.hpp
   StrahlkorperGr.hpp
   StrahlkorperInDifferentFrame.hpp
   Tags.hpp

--- a/src/ApparentHorizons/StrahlkorperFunctions.cpp
+++ b/src/ApparentHorizons/StrahlkorperFunctions.cpp
@@ -1,0 +1,43 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ApparentHorizons/StrahlkorperFunctions.hpp"
+
+#include "ApparentHorizons/Strahlkorper.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace StrahlkorperFunctions {
+template <typename Fr>
+Scalar<DataVector> radius(const Strahlkorper<Fr>& strahlkorper) {
+  Scalar<DataVector> result{
+      DataVector{strahlkorper.ylm_spherepack().physical_size()}};
+  radius(make_not_null(&result), strahlkorper);
+  return result;
+}
+
+template <typename Fr>
+void radius(const gsl::not_null<Scalar<DataVector>*> result,
+            const Strahlkorper<Fr>& strahlkorper) {
+  get(*result) =
+      strahlkorper.ylm_spherepack().spec_to_phys(strahlkorper.coefficients());
+}
+}  // namespace StrahlkorperFunctions
+
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                 \
+  template Scalar<DataVector> StrahlkorperFunctions::radius( \
+      const Strahlkorper<FRAME(data)>& strahlkorper);        \
+  template void StrahlkorperFunctions::radius(               \
+      const gsl::not_null<Scalar<DataVector>*> result,       \
+      const Strahlkorper<FRAME(data)>& strahlkorper);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE,
+                        (Frame::Distorted, Frame::Grid, Frame::Inertial))
+
+#undef INSTANTIATE
+#undef FRAME

--- a/src/ApparentHorizons/StrahlkorperFunctions.hpp
+++ b/src/ApparentHorizons/StrahlkorperFunctions.hpp
@@ -1,0 +1,42 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+/// \cond
+class DataVector;
+
+template <typename Fr>
+class Strahlkorper;
+
+template <typename X, typename Symm, typename IndexList>
+class Tensor;
+
+namespace gsl {
+template <typename>
+struct not_null;
+}  // namespace gsl
+/// \endcond
+
+/// \ingroup SurfacesGroup
+/// Contains functions that depend on a Strahlkorper but not on a metric.
+namespace StrahlkorperFunctions {
+/// @{
+/*!
+ * The physical radius at each collocation point, obtained by
+ * transforming the coefficients to physical space.
+ */
+template <typename Fr>
+Scalar<DataVector> radius(const Strahlkorper<Fr>& strahlkorper);
+
+/*!
+ * The physical radius at each collocation point, obtained by
+ * transforming the coefficients to physical space.
+ */
+template <typename Fr>
+void radius(const gsl::not_null<Scalar<DataVector>*> result,
+            const Strahlkorper<Fr>& strahlkorper);
+/// @}
+}  // namespace StrahlkorperFunctions

--- a/src/ApparentHorizons/StrahlkorperGr.hpp
+++ b/src/ApparentHorizons/StrahlkorperGr.hpp
@@ -501,4 +501,19 @@ double dimensionless_spin_magnitude(const double dimensionful_spin_magnitude,
                                     const double christodoulou_mass);
 /// @}
 
+
+/*!
+ * \ingroup SurfacesGroup
+ * \brief Radial distance between two `Strahlkorper`s.
+ *
+ * \details Computes the pointwise radial distance \f$r_a-r_b\f$ between two
+ * Strahlkorpers `strahlkorper_a` and `strahlkorper_b` that have the same
+ * center, first (if the Strahlkorpers' resolutions are unequal) prolonging the
+ * lower-resolution Strahlkorper to the same resolution as the higher-resolution
+ * Strahlkorper.
+ */
+template <typename Frame>
+void radial_distance(gsl::not_null<Scalar<DataVector>*> radial_distance,
+                     const Strahlkorper<Frame>& strahlkorper_a,
+                     const Strahlkorper<Frame>& strahlkorper_b);
 }  // namespace StrahlkorperGr

--- a/src/ApparentHorizons/Tags.cpp
+++ b/src/ApparentHorizons/Tags.cpp
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <cstddef>
 
+#include "ApparentHorizons/StrahlkorperFunctions.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/ConstantExpressions.hpp"
@@ -146,8 +147,7 @@ void RadiusCompute<Frame>::function(
     const ::Strahlkorper<Frame>& strahlkorper) {
   get(*radius).destructive_resize(
       strahlkorper.ylm_spherepack().physical_size());
-  get(*radius) =
-      strahlkorper.ylm_spherepack().spec_to_phys(strahlkorper.coefficients());
+  StrahlkorperFunctions::radius(radius, strahlkorper);
 }
 
 template <typename Frame>

--- a/tests/Unit/ApparentHorizons/CMakeLists.txt
+++ b/tests/Unit/ApparentHorizons/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBRARY_SOURCES
   Test_ComputeItems.cpp
   Test_FastFlow.cpp
   Test_Strahlkorper.cpp
+  Test_StrahlkorperFunctions.cpp
   Test_StrahlkorperGr.cpp
   Test_StrahlkorperInDifferentFrame.cpp
   Test_Tags.cpp

--- a/tests/Unit/ApparentHorizons/Test_Strahlkorper.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Strahlkorper.cpp
@@ -13,6 +13,8 @@
 #include "ApparentHorizons/Strahlkorper.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "Framework/TestHelpers.hpp"
+#include "Helpers/ApparentHorizons/StrahlkorperTestHelpers.hpp"
+#include "Helpers/NumericalAlgorithms/SphericalHarmonics/YlmTestFunctions.hpp"
 #include "NumericalAlgorithms/RootFinding/QuadraticEquation.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/YlmSpherepack.hpp"
@@ -26,7 +28,6 @@ struct Inertial;
 }  // namespace Frame
 
 namespace {
-
 void test_invert_spec_phys_transform() {
   const double avg_radius = 1.0;
   const double delta_radius = 0.1;

--- a/tests/Unit/ApparentHorizons/Test_StrahlkorperFunctions.cpp
+++ b/tests/Unit/ApparentHorizons/Test_StrahlkorperFunctions.cpp
@@ -1,0 +1,46 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "ApparentHorizons/StrahlkorperFunctions.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Helpers/ApparentHorizons/StrahlkorperTestHelpers.hpp"
+#include "Helpers/NumericalAlgorithms/SphericalHarmonics/YlmTestFunctions.hpp"
+
+namespace Frame {
+struct Inertial;
+}  // namespace Frame
+
+namespace {
+void test_radius() {
+  const double y11_amplitude = 1.0;
+  const double radius = 2.0;
+  const std::array<double, 3> center = {{0.1, 0.2, 0.3}};
+  const auto strahlkorper =
+      create_strahlkorper_y11(y11_amplitude, radius, center);
+
+  // Now construct a Y00 + Im(Y11) surface by hand.
+  const auto& theta_points = strahlkorper.ylm_spherepack().theta_points();
+  const auto& phi_points = strahlkorper.ylm_spherepack().phi_points();
+  const auto n_pts = theta_points.size() * phi_points.size();
+  YlmTestFunctions::Y11 y_11;
+  DataVector expected_radius{n_pts};
+  y_11.func(&expected_radius, 1, 0, theta_points, phi_points);
+  for (size_t s = 0; s < n_pts; ++s) {
+    expected_radius[s] *= y11_amplitude;
+    expected_radius[s] += radius;
+  }
+
+  const DataVector strahlkorper_radius{
+      get(StrahlkorperFunctions::radius(strahlkorper))};
+  CHECK_ITERABLE_APPROX(strahlkorper_radius, expected_radius);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperFunctions",
+                  "[ApparentHorizons][Unit]") {
+  test_radius();
+}

--- a/tests/Unit/ApparentHorizons/Test_Tags.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Tags.cpp
@@ -18,6 +18,7 @@
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Framework/TestHelpers.hpp"
+#include "Helpers/ApparentHorizons/StrahlkorperTestHelpers.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Helpers/NumericalAlgorithms/SphericalHarmonics/YlmTestFunctions.hpp"
@@ -28,25 +29,6 @@
 #include "Utilities/TMPL.hpp"
 
 namespace {
-
-// Create a strahlkorper with a Im(Y11) dependence, with
-// a given average radius and a given center.
-auto create_strahlkorper_y11(const double y11_amplitude, const double radius,
-                             const std::array<double, 3>& center) {
-  static const size_t l_max = 4;
-  static const size_t m_max = 4;
-
-  Strahlkorper<Frame::Inertial> strahlkorper_sphere(l_max, m_max, radius,
-                                                    center);
-
-  auto coefs = strahlkorper_sphere.coefficients();
-  SpherepackIterator it(l_max, m_max);
-  // Conversion between SPHEREPACK b_lm and real valued harmonic coefficients:
-  // b_lm = (-1)^{m+1} sqrt(1/2pi) d_lm
-  coefs[it.set(1, -1)()] = y11_amplitude * sqrt(0.5 / M_PI);
-  return Strahlkorper<Frame::Inertial>(coefs, strahlkorper_sphere);
-}
-
 void test_average_radius() {
   // Create spherical Strahlkorper
   const std::array<double, 3> center = {{0.1, 0.2, 0.3}};

--- a/tests/Unit/Helpers/ApparentHorizons/CMakeLists.txt
+++ b/tests/Unit/Helpers/ApparentHorizons/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "ApparentHorizonsHelpers")
 
 set(LIBRARY_SOURCES
   StrahlkorperGrTestHelpers.cpp
+  StrahlkorperTestHelpers.cpp
   )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/tests/Unit/Helpers/ApparentHorizons/StrahlkorperTestHelpers.cpp
+++ b/tests/Unit/Helpers/ApparentHorizons/StrahlkorperTestHelpers.cpp
@@ -1,0 +1,28 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "StrahlkorperGrTestHelpers.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+
+#include "ApparentHorizons/Strahlkorper.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
+
+Strahlkorper<Frame::Inertial> create_strahlkorper_y11(
+    const double y11_amplitude, const double radius,
+    const std::array<double, 3>& center) {
+  static const size_t l_max = 4;
+  static const size_t m_max = 4;
+
+  Strahlkorper<Frame::Inertial> strahlkorper_sphere(l_max, m_max, radius,
+                                                    center);
+
+  auto coefs = strahlkorper_sphere.coefficients();
+  SpherepackIterator it(l_max, m_max);
+  // Conversion between SPHEREPACK b_lm and real valued harmonic coefficients:
+  // b_lm = (-1)^{m+1} sqrt(1/2pi) d_lm
+  coefs[it.set(1, -1)()] = y11_amplitude * sqrt(0.5 / M_PI);
+  return Strahlkorper<Frame::Inertial>(coefs, strahlkorper_sphere);
+}

--- a/tests/Unit/Helpers/ApparentHorizons/StrahlkorperTestHelpers.hpp
+++ b/tests/Unit/Helpers/ApparentHorizons/StrahlkorperTestHelpers.hpp
@@ -1,0 +1,20 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+
+#include "ApparentHorizons/Strahlkorper.hpp"
+
+/// \cond
+namespace Frame {
+struct Inertial;
+}  // namespace Frame
+/// \endcond
+
+// Create a strahlkorper with a Im(Y11) dependence, with
+// a given average radius and a given center.
+Strahlkorper<Frame::Inertial> create_strahlkorper_y11(
+    const double y11_amplitude, const double radius,
+    const std::array<double, 3>& center);


### PR DESCRIPTION
## Proposed changes

This PR does two things: 1) add a function to `Strahlkorper` that returns the radius at each collocation point, and 2) adds a function that returns a `Scalar<DataVector>` containing the radial distance between the Strahlkorpers, assuming they have the same center, which is an operation that is necessary for size/characteristic speed control.


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
