### PR TITLE
FindApparentHorizon now stores previous results.

### DIFF
--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -4,7 +4,9 @@
 #pragma once
 
 #include <array>
+#include <deque>
 #include <string>
+#include <utility>
 
 #include "ApparentHorizons/Strahlkorper.hpp"
 #include "ApparentHorizons/StrahlkorperGr.hpp"
@@ -30,13 +32,15 @@ namespace ah::Tags {
 struct FastFlow : db::SimpleTag {
   using type = ::FastFlow;
 };
-/// Tag for holding the previously-found value of a Strahlkorper,
-/// which is saved for extrapolation for future initial guesses
-/// and for recovering the initial guess on failure of the algorithm.
+
+/// Tag for holding the previously-found values of a Strahlkorper,
+/// which are saved for extrapolation for future initial guesses
+/// and for computing the time deriv of a Strahlkorper.
 template <typename Frame>
-struct PreviousStrahlkorper : db::SimpleTag {
-  using type = ::Strahlkorper<Frame>;
+struct PreviousStrahlkorpers : db::SimpleTag {
+  using type = std::deque<std::pair<double, ::Strahlkorper<Frame>>>;
 };
+
 }  // namespace ah::Tags
 
 /// \ingroup SurfacesGroup

--- a/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
@@ -376,13 +376,15 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
   ActionTesting::set_phase(make_not_null(&runner),
                            metavars::Phase::Registration);
 
-  // Find horizon at two temporal_ids.  The horizon find at the second
-  // temporal_id will use the result from the first temporal_id as
-  // an initial guess.  For the time-independent case, the volume data will
-  // not change between horizon finds, so the second horizon find will take
-  // zero iterations.
-  // Having two temporal_ids tests some logic in the interpolator.
-  const std::vector<double> temporal_ids{13.0 / 15.0, 14.0 / 15.0};
+  // Find horizon at three temporal_ids.  The horizon find at the
+  // second temporal_id will use the result from the first temporal_id
+  // as an initial guess.  The horizon find at the third temporal_id
+  // will use an initial guess that was linearly extrapolated from the
+  // first two horizon finds. For the time-independent case, the
+  // volume data will not change between horizon finds, so the second
+  // and third horizon finds will take zero iterations.  Having three
+  // temporal_ids tests some logic in the interpolator.
+  const std::vector<double> temporal_ids{12.0 / 15.0, 13.0 / 15.0, 14.0 / 15.0};
 
   // Create element_ids.
   std::vector<ElementId<3>> element_ids{};
@@ -705,8 +707,8 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
             typename metavars::component_list>(make_not_null(&runner));
   }
 
-  // Make sure function was called twice.
-  CHECK(*test_horizon_called == 2);
+  // Make sure function was called three times.
+  CHECK(*test_horizon_called == 3);
 }
 
 // This tests the entire AH finder including numerical interpolation.


### PR DESCRIPTION
This is used to time-extrapolate the initial guess for the
horizon based on the two previous horizons.

This also will be used (subsequent PR) to provide time derivatives
of the horizon coefficients.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
