### PR TITLE
Add Flattener to GRMHD

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_sources(
   Characteristics.cpp
   ConservativeFromPrimitive.cpp
   FixConservatives.cpp
+  Flattener.cpp
   Fluxes.cpp
   KastaunEtAl.cpp
   NewmanHamlin.cpp
@@ -29,6 +30,7 @@ spectre_target_headers(
   Characteristics.hpp
   ConservativeFromPrimitive.hpp
   FixConservatives.hpp
+  Flattener.hpp
   Fluxes.hpp
   KastaunEtAl.hpp
   NewmanHamlin.hpp

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Flattener.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Flattener.cpp
@@ -1,0 +1,301 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Flattener.hpp"
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.hpp"
+#include "NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+
+namespace grmhd::ValenciaDivClean {
+template <typename RecoverySchemesList>
+Flattener<RecoverySchemesList>::Flattener(
+    const bool require_positive_mean_tilde_d,
+    const bool require_physical_mean_tilde_tau, const bool recover_primitives)
+    : require_positive_mean_tilde_d_(require_positive_mean_tilde_d),
+      require_physical_mean_tilde_tau_(require_physical_mean_tilde_tau),
+      recover_primitives_(recover_primitives) {}
+
+template <typename RecoverySchemesList>
+void Flattener<RecoverySchemesList>::pup(PUP::er& p) {
+  p | require_positive_mean_tilde_d_;
+  p | require_physical_mean_tilde_tau_;
+  p | recover_primitives_;
+}
+
+template <typename RecoverySchemesList>
+template <size_t ThermodynamicDim>
+void Flattener<RecoverySchemesList>::operator()(
+    const gsl::not_null<Scalar<DataVector>*> tilde_d,
+    const gsl::not_null<Scalar<DataVector>*> tilde_tau,
+    const gsl::not_null<tnsr::i<DataVector, 3>*> tilde_s,
+    const gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*> primitives,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
+    const Scalar<DataVector>& tilde_phi,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+    const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
+    const Mesh<3>& mesh,
+    const Scalar<DataVector>& det_logical_to_inertial_inv_jacobian,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos)
+    const {
+  // Create a temporary variable for each field's cell average.
+  // These temporaries live on the stack and should have minimal cost.
+  double mean_tilde_d = std::numeric_limits<double>::signaling_NaN();
+  double mean_tilde_tau = std::numeric_limits<double>::signaling_NaN();
+  auto mean_tilde_s =
+      make_array<3>(std::numeric_limits<double>::signaling_NaN());
+  const Scalar<DataVector> det_logical_to_inertial_jacobian{
+      DataVector{get(det_logical_to_inertial_inv_jacobian)}};
+  bool already_computed_means = false;
+
+  const auto compute_means =
+      [&already_computed_means, &mean_tilde_d, &mean_tilde_tau, &mean_tilde_s,
+       &tilde_d, &tilde_tau, &tilde_s, &mesh, &det_logical_to_inertial_jacobian,
+       require_positive_mean_tilde_d =
+           require_positive_mean_tilde_d_]() {
+        if (already_computed_means) {
+          return;
+        }
+        already_computed_means = true;
+        // Compute the means w.r.t. the inertial coords
+        // (Note that several other parts of the limiter code take means w.r.t.
+        // the logical coords, and therefore might not be conservative on curved
+        // grids)
+        const double volume_of_cell =
+            definite_integral(get(det_logical_to_inertial_jacobian), mesh);
+        const auto inertial_coord_mean =
+            [&mesh, &det_logical_to_inertial_jacobian,
+             &volume_of_cell](const DataVector& u) {
+              // Note that the term `det_jac * u` below results in an
+              // allocation. If this function needs to be optimized, a buffer
+              // for the product could be allocated outside the lambda, and
+              // updated in the lambda.
+              return definite_integral(
+                         get(det_logical_to_inertial_jacobian) * u, mesh) /
+                     volume_of_cell;
+            };
+        mean_tilde_d = inertial_coord_mean(get(*tilde_d));
+        mean_tilde_tau = inertial_coord_mean(get(*tilde_tau));
+        for (size_t i = 0; i < 3; ++i) {
+          gsl::at(mean_tilde_s, i) = inertial_coord_mean(tilde_s->get(i));
+        }
+
+        if (require_positive_mean_tilde_d and mean_tilde_d < 0.) {
+          ERROR("We require TildeD to have positive mean, but got "
+                << *tilde_d << " with mean value " << mean_tilde_d);
+        }
+      };
+
+  // If min(tilde_d) is negative, then flatten.
+  if (const double min_tilde_d = min(get(*tilde_d)); min_tilde_d < 0.) {
+    compute_means();
+
+    // Note: the current algorithm flattens all fields by the same factor,
+    // though in principle a different factor could be applied to each field.
+    //
+    // Experiments with cylindrical blast wave simulations showed that applying
+    // the same factor to all fields here dramatically improves results for the
+    // cylindrical blast wave. Of course, this might differ depending on the
+    // test problem.
+    constexpr double safety = 0.95;
+    const double factor = safety * mean_tilde_d / (mean_tilde_d - min_tilde_d);
+
+    get(*tilde_d) = mean_tilde_d + factor * (get(*tilde_d) - mean_tilde_d);
+    get(*tilde_tau) =
+        mean_tilde_tau + factor * (get(*tilde_tau) - mean_tilde_tau);
+    for (size_t i = 0; i < 3; ++i) {
+      tilde_s->get(i) = gsl::at(mean_tilde_s, i) +
+                        factor * (tilde_s->get(i) - gsl::at(mean_tilde_s, i));
+    }
+  }
+
+  const Scalar<DataVector> tilde_b_squared =
+      dot_product(tilde_b, tilde_b, spatial_metric);
+
+  if (require_physical_mean_tilde_tau_) {
+    compute_means();
+    if (UNLIKELY(max((0.5 / mean_tilde_tau) * get(tilde_b_squared) /
+                     get(sqrt_det_spatial_metric)) > 1.0)) {
+      ERROR(
+          "Unable to rescale TildeTau to the required range in a "
+          "conservative manner:\n"
+          "mean_tilde_tau: "
+          << mean_tilde_tau << "\ntilde_b_squared: " << tilde_b_squared
+          << "\nsqrt_det_spatial_metric: " << sqrt_det_spatial_metric);
+    }
+  }
+
+  // Check TildeTau with the condition from Foucart's thesis
+  //
+  // Increase tilde_tau if necessary. We do this by _decreasing_ the amount of
+  // oscillation around the mean.
+  compute_means();
+  const size_t num_pts = get(*tilde_tau).size();
+  double tilde_tau_scale_factor = 1.;
+  for (size_t i = 0; i < num_pts; ++i) {
+    if (0.5 * get(tilde_b_squared)[i] / get(sqrt_det_spatial_metric)[i] /
+            get(*tilde_tau)[i] >
+        1.) {
+      tilde_tau_scale_factor =
+          std::min(tilde_tau_scale_factor,
+                   std::abs((0.5 * get(tilde_b_squared)[i] /
+                                 get(sqrt_det_spatial_metric)[i] -
+                             mean_tilde_tau) /
+                            (get(*tilde_tau)[i] - mean_tilde_tau)));
+    }
+  }
+  if (tilde_tau_scale_factor < 1.) {
+    constexpr double safety = 0.99;
+    get(*tilde_tau) = mean_tilde_tau + (safety * tilde_tau_scale_factor) *
+                                           (get(*tilde_tau) - mean_tilde_tau);
+  }
+
+  // Check if we can recover the primitive variables. If not, then we need to
+  // flatten.
+  const size_t number_of_points = mesh.number_of_grid_points();
+  Variables<hydro::grmhd_tags<DataVector>> temp_prims(number_of_points);
+  get<hydro::Tags::Pressure<DataVector>>(temp_prims) =
+      get<hydro::Tags::Pressure<DataVector>>(*primitives);
+  if (not grmhd::ValenciaDivClean::
+          PrimitiveFromConservative<RecoverySchemesList, false>::apply(
+              make_not_null(
+                  &get<hydro::Tags::RestMassDensity<DataVector>>(temp_prims)),
+              make_not_null(
+                  &get<hydro::Tags::SpecificInternalEnergy<DataVector>>(
+                      temp_prims)),
+              make_not_null(&get<hydro::Tags::SpatialVelocity<DataVector, 3>>(
+                  temp_prims)),
+              make_not_null(
+                  &get<hydro::Tags::MagneticField<DataVector, 3>>(temp_prims)),
+              make_not_null(
+                  &get<hydro::Tags::DivergenceCleaningField<DataVector>>(
+                      temp_prims)),
+              make_not_null(
+                  &get<hydro::Tags::LorentzFactor<DataVector>>(temp_prims)),
+              make_not_null(
+                  &get<hydro::Tags::Pressure<DataVector>>(temp_prims)),
+              make_not_null(
+                  &get<hydro::Tags::SpecificEnthalpy<DataVector>>(temp_prims)),
+              *tilde_d, *tilde_tau, *tilde_s, tilde_b, tilde_phi,
+              spatial_metric, inv_spatial_metric, sqrt_det_spatial_metric,
+              eos)) {
+    compute_means();
+
+    get(*tilde_d) = mean_tilde_d;
+    get(*tilde_tau) = mean_tilde_tau;
+    for (size_t i = 0; i < 3; ++i) {
+      tilde_s->get(i) = gsl::at(mean_tilde_s, i);
+    }
+
+    if (recover_primitives_) {
+      grmhd::ValenciaDivClean::
+          PrimitiveFromConservative<RecoverySchemesList, true>::apply(
+              make_not_null(
+                  &get<hydro::Tags::RestMassDensity<DataVector>>(temp_prims)),
+              make_not_null(
+                  &get<hydro::Tags::SpecificInternalEnergy<DataVector>>(
+                      temp_prims)),
+              make_not_null(&get<hydro::Tags::SpatialVelocity<DataVector, 3>>(
+                  temp_prims)),
+              make_not_null(
+                  &get<hydro::Tags::MagneticField<DataVector, 3>>(temp_prims)),
+              make_not_null(
+                  &get<hydro::Tags::DivergenceCleaningField<DataVector>>(
+                      temp_prims)),
+              make_not_null(
+                  &get<hydro::Tags::LorentzFactor<DataVector>>(temp_prims)),
+              make_not_null(
+                  &get<hydro::Tags::Pressure<DataVector>>(temp_prims)),
+              make_not_null(
+                  &get<hydro::Tags::SpecificEnthalpy<DataVector>>(temp_prims)),
+              *tilde_d, *tilde_tau, *tilde_s, tilde_b, tilde_phi,
+              spatial_metric, inv_spatial_metric, sqrt_det_spatial_metric, eos);
+    }
+  }
+  if (recover_primitives_) {
+    using std::swap;
+    swap(*primitives, temp_prims);
+  }
+}
+
+template <typename RecoverySchemesList>
+bool operator==(const Flattener<RecoverySchemesList>& lhs,
+                const Flattener<RecoverySchemesList>& rhs) {
+  return lhs.require_positive_mean_tilde_d_ ==
+             rhs.require_positive_mean_tilde_d_ and
+         lhs.require_physical_mean_tilde_tau_ ==
+             rhs.require_physical_mean_tilde_tau_ and
+         lhs.recover_primitives_ == rhs.recover_primitives_;
+}
+
+template <typename RecoverySchemesList>
+bool operator!=(const Flattener<RecoverySchemesList>& lhs,
+                const Flattener<RecoverySchemesList>& rhs) {
+  return not(lhs == rhs);
+}
+
+using NewmanHamlinThenPalenzuelaEtAl =
+    tmpl::list<PrimitiveRecoverySchemes::NewmanHamlin,
+               PrimitiveRecoverySchemes::PalenzuelaEtAl>;
+using KastaunThenNewmanThenPalenzuela =
+    tmpl::list<PrimitiveRecoverySchemes::KastaunEtAl,
+               PrimitiveRecoverySchemes::NewmanHamlin,
+               PrimitiveRecoverySchemes::PalenzuelaEtAl>;
+
+#define ORDERED_RECOVERY_LIST                            \
+  (tmpl::list<PrimitiveRecoverySchemes::KastaunEtAl>,    \
+   tmpl::list<PrimitiveRecoverySchemes::NewmanHamlin>,   \
+   tmpl::list<PrimitiveRecoverySchemes::PalenzuelaEtAl>, \
+   NewmanHamlinThenPalenzuelaEtAl, KastaunThenNewmanThenPalenzuela)
+
+#define RECOVERY(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define INSTANTIATION(r, data)                                    \
+  template class Flattener<RECOVERY(data)>;                       \
+  template bool operator==(const Flattener<RECOVERY(data)>& lhs,  \
+                           const Flattener<RECOVERY(data)>& rhs); \
+  template bool operator!=(const Flattener<RECOVERY(data)>& lhs,  \
+                           const Flattener<RECOVERY(data)>& rhs);
+GENERATE_INSTANTIATIONS(INSTANTIATION, ORDERED_RECOVERY_LIST)
+#undef INSTANTIATION
+
+#define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define INSTANTIATION(r, data)                                              \
+  template void Flattener<RECOVERY(data)>::operator()<THERMO_DIM(data)>(    \
+      gsl::not_null<Scalar<DataVector>*> tilde_d,                           \
+      gsl::not_null<Scalar<DataVector>*> tilde_tau,                         \
+      gsl::not_null<tnsr::i<DataVector, 3>*> tilde_s,                       \
+      gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*> primitives,  \
+      const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,               \
+      const Scalar<DataVector>& tilde_phi,                                  \
+      const Scalar<DataVector>& sqrt_det_spatial_metric,                    \
+      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,       \
+      const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,   \
+      const Mesh<3>& mesh,                                                  \
+      const Scalar<DataVector>& det_logical_to_inertial_inv_jacobian,       \
+      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos) \
+      const;
+GENERATE_INSTANTIATIONS(INSTANTIATION, ORDERED_RECOVERY_LIST, (1, 2))
+#undef INSTANTIATION
+#undef THERMO_DIM
+#undef RECOVERY
+#undef ORDERED_RECOVERY_LIST
+}  // namespace grmhd::ValenciaDivClean

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Flattener.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Flattener.hpp
@@ -1,0 +1,149 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <limits>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace EquationsOfState {
+template <bool IsRelativistic, size_t ThermodynamicDim>
+class EquationOfState;
+}  // namespace EquationsOfState
+namespace PUP {
+class er;
+}  // namespace PUP
+template <size_t Dim>
+class Mesh;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+template <typename TagsList>
+class Variables;
+/// \endcond
+
+namespace grmhd::ValenciaDivClean {
+/*!
+ * \brief Reduces oscillations inside an element in an attempt to guarantee a
+ * physical solution of the conserved variables for which the primitive
+ * variables can be recovered.
+ *
+ * The algorithm uses the conditions of FixConservatives on \f$\tilde{D}\f$ and
+ * \f$\tilde{\tau}\f$ to reduce oscillations inside an element. Oscillations are
+ * reduced by rescaling the conserved variables about the mean to bring them
+ * into the required range. When rescaling \f$\tilde{D}\f$ because it is
+ * negative, it is important to also rescale \f$\tilde{\tau}\f$ and
+ * \f$\tilde{S}_i\f$ by the same amount. At least, this is what is observed in
+ * the cylindrical blast wave test problem.
+ *
+ * This currently doesn't use the check on \f$\tilde{S}^2\f$, but instead checks
+ * that the primitive variables can be recovered. If the primitives cannot be
+ * recovered then we flatten to the mean values in the element.
+ */
+template <typename RecoverySchemesList>
+class Flattener {
+ public:
+  /// \brief Require that the mean of TildeD is positive, otherwise terminate
+  /// the simulation.
+  struct RequirePositiveMeanTildeD {
+    using type = bool;
+    static constexpr Options::String help = {
+        "Require that the mean of TildeD is positive, otherwise terminate the "
+        "simulation."};
+  };
+
+  /// \brief Require that the mean of TildeTau is physical, otherwise terminate
+  /// the simulation.
+  struct RequirePhysicalMeanTildeTau {
+    using type = bool;
+    static constexpr Options::String help = {
+        "Require that the mean of TildeTau is physical, otherwise terminate "
+        "the simulation."};
+  };
+
+  /// \brief If true, then the primitive variables are updated at the end of the
+  /// function.
+  ///
+  /// This is useful when not using any pointwise conserved variable fixing,
+  /// treating the case that the means do not satisfy the bounds as an error.
+  struct RecoverPrimitives {
+    using type = bool;
+    static constexpr Options::String help = {
+        "If true, then the primitive variables are updated at the end of the "
+        "function."};
+  };
+
+  using options = tmpl::list<RequirePositiveMeanTildeD,
+                             RequirePhysicalMeanTildeTau, RecoverPrimitives>;
+  static constexpr Options::String help = {
+      "Reduces oscillations (flattens) the conserved variables according to "
+      "the variable fixing procedure described in Foucart's thesis.\n"};
+
+  Flattener(bool require_positive_mean_tilde_d,
+            bool require_physical_mean_tilde_tau, bool recover_primitives);
+
+  Flattener() = default;
+  Flattener(const Flattener& /*rhs*/) = default;
+  Flattener& operator=(const Flattener& /*rhs*/) = default;
+  Flattener(Flattener&& /*rhs*/) = default;
+  Flattener& operator=(Flattener&& /*rhs*/) = default;
+  ~Flattener() = default;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p);
+
+  using return_tags =
+      tmpl::list<Tags::TildeD, Tags::TildeTau, Tags::TildeS<Frame::Inertial>,
+                 ::Tags::Variables<hydro::grmhd_tags<DataVector>>>;
+  using argument_tags = tmpl::list<
+      Tags::TildeB<>, Tags::TildePhi,
+      gr::Tags::SqrtDetSpatialMetric<DataVector>,
+      gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+      gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>,
+      domain::Tags::Mesh<3>,
+      domain::Tags::DetInvJacobian<Frame::ElementLogical, Frame::Inertial>,
+      hydro::Tags::EquationOfStateBase>;
+
+  template <size_t ThermodynamicDim>
+  void operator()(
+      gsl::not_null<Scalar<DataVector>*> tilde_d,
+      gsl::not_null<Scalar<DataVector>*> tilde_tau,
+      gsl::not_null<tnsr::i<DataVector, 3>*> tilde_s,
+      gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*> primitives,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
+      const Scalar<DataVector>& tilde_phi,
+      const Scalar<DataVector>& sqrt_det_spatial_metric,
+      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+      const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
+      const Mesh<3>& mesh,
+      const Scalar<DataVector>& det_logical_to_inertial_inv_jacobian,
+      const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos)
+      const;
+
+ private:
+  template <typename LocalRecoverySchemesList>
+  // NOLINTNEXTLINE(readability-redundant-declaration)
+  friend bool operator==(const Flattener<LocalRecoverySchemesList>& lhs,
+                         const Flattener<LocalRecoverySchemesList>& rhs);
+
+  bool require_positive_mean_tilde_d_ = false;
+  bool require_physical_mean_tilde_tau_ = false;
+  bool recover_primitives_ = false;
+};
+
+template <typename RecoverySchemesList>
+bool operator!=(const Flattener<RecoverySchemesList>& lhs,
+                const Flattener<RecoverySchemesList>& rhs);
+}  // namespace grmhd::ValenciaDivClean

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -27,6 +27,7 @@ set(LIBRARY_SOURCES
   Test_Characteristics.cpp
   Test_ConservativeFromPrimitive.cpp
   Test_FixConservatives.cpp
+  Test_Flattener.cpp
   Test_Fluxes.cpp
   Test_PrimitiveFromConservative.cpp
   Test_SetVariablesNeededFixingToFalse.cpp

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_Flattener.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_Flattener.cpp
@@ -1,0 +1,257 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Flattener.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes {
+class KastaunEtAl;
+}  // namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes
+
+SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.Flattener", "[Unit][GrMhd]") {
+  const Mesh<3> mesh(2, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto);
+  const size_t num_points = mesh.number_of_grid_points();
+
+  EquationsOfState::IdealFluid<true> ideal_fluid(4.0 / 3.0);
+  const Scalar<DataVector> tilde_phi(num_points, 0.);
+  tnsr::I<DataVector, 3> tilde_b;
+  get<0>(tilde_b) = DataVector(num_points, 0.02);
+  get<1>(tilde_b) = DataVector(num_points, 0.02);
+  get<2>(tilde_b) = DataVector{{0.2, 0.3, 0.1, 0.1, 0.1, 0.01, 0.4, 0.5}};
+
+  const Scalar<DataVector> sqrt_det_spatial_metric(DataVector{
+      {sqrt(1.1), sqrt(1.1), sqrt(1.1), 1., 1., sqrt(2.184), 1., 1.}});
+  tnsr::ii<DataVector, 3, Frame::Inertial> spatial_metric(num_points, 0.);
+  tnsr::II<DataVector, 3, Frame::Inertial> inverse_spatial_metric(num_points,
+                                                                  0.);
+  for (size_t i = 0; i < 3; ++i) {
+    spatial_metric.get(i, i) = cbrt(get(sqrt_det_spatial_metric));
+    inverse_spatial_metric.get(i, i) = 1. / spatial_metric.get(i, i);
+  }
+
+  const Scalar<DataVector> det_logical_to_inertial_jacobian(
+      DataVector{{0.2, 0.1, 0.3, 0.2, 0.5, 0.6, 0.4, 0.5}});
+
+  const double volume_of_cell =
+      definite_integral(get(det_logical_to_inertial_jacobian), mesh);
+
+  const auto flattener = serialize_and_deserialize(
+      grmhd::ValenciaDivClean::Flattener<tmpl::list<
+          grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl>>{
+          true, false, true});
+  CHECK(flattener ==
+        grmhd::ValenciaDivClean::Flattener<tmpl::list<
+            grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl>>{
+            true, false, true});
+  CHECK(flattener !=
+        grmhd::ValenciaDivClean::Flattener<tmpl::list<
+            grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl>>{
+            false, false, true});
+  CHECK(flattener !=
+        grmhd::ValenciaDivClean::Flattener<tmpl::list<
+            grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl>>{
+            true, true, true});
+  CHECK(flattener !=
+        grmhd::ValenciaDivClean::Flattener<tmpl::list<
+            grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl>>{
+            true, false, false});
+
+  {
+    INFO("Case: NoOp");
+    Scalar<DataVector> tilde_d(
+        DataVector{{1.4, 1.3, 1.2, 1.6, 1.8, 1.7, 1.3, 1.4}});
+    Scalar<DataVector> tilde_tau(
+        DataVector{{3.1, 3.3, 4.3, 3.5, 2.9, 2.8, 2.6, 2.7}});
+    tnsr::i<DataVector, 3> tilde_s;
+    get<0>(tilde_s) = DataVector(num_points, 0.);
+    get<1>(tilde_s) = DataVector(num_points, 0.);
+    get<2>(tilde_s) =
+        DataVector{{-0.3, -0.2, -0.4, -0.3, -0.8, -0.2, -0.3, -0.1}};
+
+    const auto expected_tilde_d = tilde_d;
+    const auto expected_tilde_tau = tilde_tau;
+    const auto expected_tilde_s = tilde_s;
+
+    Variables<hydro::grmhd_tags<DataVector>> prims(num_points, 0.);
+
+    flattener(make_not_null(&tilde_d), make_not_null(&tilde_tau),
+              make_not_null(&tilde_s), make_not_null(&prims), tilde_b,
+              tilde_phi, sqrt_det_spatial_metric, spatial_metric,
+              inverse_spatial_metric, mesh, det_logical_to_inertial_jacobian,
+              ideal_fluid);
+
+    CHECK_ITERABLE_APPROX(tilde_d, expected_tilde_d);
+    CHECK_ITERABLE_APPROX(tilde_tau, expected_tilde_tau);
+    CHECK_ITERABLE_APPROX(tilde_s, expected_tilde_s);
+  }
+
+  {
+    INFO("Case: ScaledSolution because of negative TildeD");
+    constexpr double safety = 0.95;
+    Scalar<DataVector> tilde_d(
+        DataVector{{1.4, 1.3, 1.2, 1.6, -1.6, 1.7, 1.3, 1.4}});
+    Scalar<DataVector> tilde_tau(
+        DataVector{{2.1, 2.3, 4.3, 3.5, 2.9, 1.8, 2.6, 2.9}});
+    tnsr::i<DataVector, 3> tilde_s;
+    get<0>(tilde_s) = DataVector(num_points, 0.);
+    get<1>(tilde_s) = DataVector(num_points, 0.);
+    get<2>(tilde_s) =
+        DataVector{{-0.3, -0.2, -0.4, -0.3, -0.8, -0.2, -0.3, -0.1}};
+    const double expected_mean_tilde_d =
+        definite_integral(get(det_logical_to_inertial_jacobian) * get(tilde_d),
+                          mesh) /
+        volume_of_cell;
+    const double expected_mean_tilde_tau =
+        definite_integral(
+            get(det_logical_to_inertial_jacobian) * get(tilde_tau), mesh) /
+        volume_of_cell;
+    std::array<double, 3> expected_mean_tilde_s{};
+    for (size_t i = 0; i < 3; ++i) {
+      gsl::at(expected_mean_tilde_s, i) =
+          definite_integral(
+              get(det_logical_to_inertial_jacobian) * tilde_s.get(i), mesh) /
+          volume_of_cell;
+    }
+
+    const double rescale_factor =
+        safety * expected_mean_tilde_d /
+        (expected_mean_tilde_d -
+         (get(tilde_d)[4] * get(sqrt_det_spatial_metric)[4]));
+    const Scalar<DataVector> expected_tilde_d(
+        DataVector(expected_mean_tilde_d +
+                   rescale_factor * (get(tilde_d) - expected_mean_tilde_d)));
+    const Scalar<DataVector> expected_tilde_tau(DataVector(
+        expected_mean_tilde_tau +
+        rescale_factor * (get(tilde_tau) - expected_mean_tilde_tau)));
+    auto expected_tilde_s = tilde_s;
+    for (size_t i = 0; i < 3; ++i) {
+      expected_tilde_s.get(i) =
+          gsl::at(expected_mean_tilde_s, i) +
+          rescale_factor * (tilde_s.get(i) - gsl::at(expected_mean_tilde_s, i));
+    }
+
+    Variables<hydro::grmhd_tags<DataVector>> prims(num_points, 0.);
+
+    flattener(make_not_null(&tilde_d), make_not_null(&tilde_tau),
+              make_not_null(&tilde_s), make_not_null(&prims), tilde_b,
+              tilde_phi, sqrt_det_spatial_metric, spatial_metric,
+              inverse_spatial_metric, mesh, det_logical_to_inertial_jacobian,
+              ideal_fluid);
+
+    // check 1) action, 2) positive tilde_d, 3) all fields changed
+    CHECK(min(get(tilde_d)) > 0.);
+    CHECK(definite_integral(
+              get(det_logical_to_inertial_jacobian) * get(tilde_d), mesh) /
+              volume_of_cell ==
+          expected_mean_tilde_d);
+    CHECK(definite_integral(
+              get(det_logical_to_inertial_jacobian) * get(tilde_tau), mesh) /
+              volume_of_cell ==
+          expected_mean_tilde_tau);
+    for (size_t i = 0; i < 3; ++i) {
+      CAPTURE(i);
+      CHECK(gsl::at(expected_mean_tilde_s, i) ==
+            definite_integral(
+                get(det_logical_to_inertial_jacobian) * tilde_s.get(i), mesh) /
+                volume_of_cell);
+    }
+
+    CHECK_ITERABLE_APPROX(tilde_d, expected_tilde_d);
+    CHECK_ITERABLE_APPROX(tilde_tau, expected_tilde_tau);
+    CHECK_ITERABLE_APPROX(tilde_s, expected_tilde_s);
+  }
+
+  {
+    INFO("Case: SetSolutionToMean because of too-small TildeTau");
+    Scalar<DataVector> tilde_d(
+        DataVector{{1.4, 1.3, 1.2, 1.6, 1.8, 1.7, 1.3, 1.4}});
+    Scalar<DataVector> tilde_tau(
+        DataVector{{3.1, 3.3, 4.3, 3.5, 2.9, 2.8, 2.6, 9.e-3}});
+    tnsr::i<DataVector, 3> tilde_s;
+    get<0>(tilde_s) = DataVector(num_points, 0.);
+    get<1>(tilde_s) = DataVector(num_points, 0.);
+    get<2>(tilde_s) =
+        DataVector{{-0.3, -0.2, -0.4, -0.3, -0.8, -0.2, -0.3, -0.1}};
+
+    Variables<hydro::grmhd_tags<DataVector>> prims(num_points, 0.);
+
+    const double expected_mean_tilde_d =
+        definite_integral(get(det_logical_to_inertial_jacobian) * get(tilde_d),
+                          mesh) /
+        volume_of_cell;
+    const double expected_mean_tilde_tau =
+        definite_integral(
+            get(det_logical_to_inertial_jacobian) * get(tilde_tau), mesh) /
+        volume_of_cell;
+    std::array<double, 3> expected_mean_tilde_s{};
+    for (size_t i = 0; i < 3; ++i) {
+      gsl::at(expected_mean_tilde_s, i) =
+          definite_integral(
+              get(det_logical_to_inertial_jacobian) * tilde_s.get(i), mesh) /
+          volume_of_cell;
+    }
+
+    constexpr double safety = 0.99;
+    const double scale_factor =
+        safety *
+        (0.5 *
+             get(dot_product(tilde_b, tilde_b,
+                             spatial_metric))[num_points - 1] /
+             get(sqrt_det_spatial_metric)[num_points - 1] -
+         expected_mean_tilde_tau) /
+        (get(tilde_tau)[num_points - 1] - expected_mean_tilde_tau);
+
+    const Scalar<DataVector> expected_tilde_tau{
+        DataVector{expected_mean_tilde_tau +
+                   scale_factor * (get(tilde_tau) - expected_mean_tilde_tau)}};
+    const Scalar<DataVector> expected_tilde_d = tilde_d;
+    const tnsr::i<DataVector, 3, Frame::Inertial> expected_tilde_s = tilde_s;
+
+    flattener(make_not_null(&tilde_d), make_not_null(&tilde_tau),
+              make_not_null(&tilde_s), make_not_null(&prims), tilde_b,
+              tilde_phi, sqrt_det_spatial_metric, spatial_metric,
+              inverse_spatial_metric, mesh, det_logical_to_inertial_jacobian,
+              ideal_fluid);
+
+    CHECK(definite_integral(
+              get(det_logical_to_inertial_jacobian) * get(tilde_d), mesh) /
+              volume_of_cell ==
+          expected_mean_tilde_d);
+    CHECK(definite_integral(
+              get(det_logical_to_inertial_jacobian) * get(tilde_tau), mesh) /
+              volume_of_cell ==
+          approx(expected_mean_tilde_tau));
+    for (size_t i = 0; i < 3; ++i) {
+      CAPTURE(i);
+      CHECK(gsl::at(expected_mean_tilde_s, i) ==
+            definite_integral(
+                get(det_logical_to_inertial_jacobian) * tilde_s.get(i), mesh) /
+                volume_of_cell);
+    }
+
+    CHECK_ITERABLE_APPROX(tilde_d, expected_tilde_d);
+    CHECK_ITERABLE_APPROX(tilde_tau, expected_tilde_tau);
+    CHECK_ITERABLE_APPROX(tilde_s, expected_tilde_s);
+
+    // Check that the scaling made the max be less than one:
+    CHECK(1. > max(0.5 * get(dot_product(tilde_b, tilde_b, spatial_metric)) /
+                   get(sqrt_det_spatial_metric) / get(tilde_tau)));
+  }
+}


### PR DESCRIPTION
## Proposed changes

The flattener reduces the amount of oscillations in an element in an attempt to
guarantee that the primitive variables can be recovered.

This is from #3419 

Note: I didn't change the executable in this PR yet. If that's desirable (I'd say probably) then I can add a commit that uses the flattener instead of the pointwise fixer.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
