### PR TITLE
Mass-conservative restriction in elliptic DG

### DIFF
--- a/src/Domain/FaceNormal.cpp
+++ b/src/Domain/FaceNormal.cpp
@@ -14,7 +14,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
-namespace {
 template <size_t VolumeDim, typename TargetFrame>
 void unnormalized_face_normal(
     const gsl::not_null<tnsr::i<DataVector, VolumeDim, TargetFrame>*> result,
@@ -42,7 +41,6 @@ tnsr::i<DataVector, VolumeDim, TargetFrame> unnormalized_face_normal(
                            inv_jacobian_on_interface, direction);
   return result;
 }
-}  // namespace
 
 template <size_t VolumeDim, typename TargetFrame>
 void unnormalized_face_normal(
@@ -165,6 +163,12 @@ tnsr::i<DataVector, VolumeDim, Frame::Inertial> unnormalized_face_normal(
 #define GET_FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 
 #define INSTANTIATION(_, data)                                                \
+  template tnsr::i<DataVector, GET_DIM(data), GET_FRAME(data)>                \
+  unnormalized_face_normal(                                                   \
+      const Mesh<GET_DIM(data) - 1>&,                                         \
+      const InverseJacobian<DataVector, GET_DIM(data), Frame::ElementLogical, \
+                            GET_FRAME(data)>&,                                \
+      const Direction<GET_DIM(data)>&);                                       \
   template void unnormalized_face_normal(                                     \
       const gsl::not_null<                                                    \
           tnsr::i<DataVector, GET_DIM(data), GET_FRAME(data)>*>               \

--- a/src/Domain/FaceNormal.hpp
+++ b/src/Domain/FaceNormal.hpp
@@ -44,11 +44,26 @@ class Mesh;
  * \details
  * Computes the grid-frame normal by taking the logical-frame unit
  * one-form in the given Direction and mapping it to the grid frame
- * with the given map.
+ * with the given map, or the given inverse Jacobian.
  *
  * \example
  * \snippet Test_FaceNormal.cpp face_normal_example
  */
+template <size_t VolumeDim, typename TargetFrame>
+void unnormalized_face_normal(
+    const gsl::not_null<tnsr::i<DataVector, VolumeDim, TargetFrame>*> result,
+    const Mesh<VolumeDim - 1>& interface_mesh,
+    const InverseJacobian<DataVector, VolumeDim, Frame::ElementLogical,
+                          TargetFrame>& inv_jacobian_on_interface,
+    const Direction<VolumeDim>& direction);
+
+template <size_t VolumeDim, typename TargetFrame>
+tnsr::i<DataVector, VolumeDim, TargetFrame> unnormalized_face_normal(
+    const Mesh<VolumeDim - 1>& interface_mesh,
+    const InverseJacobian<DataVector, VolumeDim, Frame::ElementLogical,
+                          TargetFrame>& inv_jacobian_on_interface,
+    const Direction<VolumeDim>& direction);
+
 template <size_t VolumeDim, typename TargetFrame>
 void unnormalized_face_normal(
     gsl::not_null<tnsr::i<DataVector, VolumeDim, TargetFrame>*> result,

--- a/src/Domain/Tags/CMakeLists.txt
+++ b/src/Domain/Tags/CMakeLists.txt
@@ -8,4 +8,5 @@ spectre_target_headers(
   BlockNamesAndGroups.hpp
   FaceNormal.hpp
   Faces.hpp
+  SurfaceJacobian.hpp
   )

--- a/src/Domain/Tags/SurfaceJacobian.hpp
+++ b/src/Domain/Tags/SurfaceJacobian.hpp
@@ -1,0 +1,36 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+
+/// \cond
+class DataVector;
+/// \endcond
+
+namespace domain::Tags {
+
+/*!
+ * \brief The determinant of the induced Jacobian on a surface
+ *
+ * The surface Jacobian determinant on a surface \f$\Sigma\f$ with constant
+ * logical coordinate \f$\xi^i\f$ is:
+ *
+ * \f{equation}
+ * J^\Sigma = J \sqrt{\gamma^{jk} (J^{-1})^i_j (J^{-1})^i_k}
+ * \f}
+ *
+ * where \f$J^i_j = \partial x^i / \xi^j\f$ is the volume Jacobian with
+ * determinant \f$J\f$ and inverse \f$(J^{-1})^i_j = \partial \xi^i / \partial
+ * x^j\f$. Note that the square root in the expression above is the magnitude of
+ * the unnormalized face normal, where \f$\gamma^{jk}\f$ is the inverse spatial
+ * metric.
+ */
+template <typename SourceFrame, typename TargetFrame>
+struct DetSurfaceJacobian : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+}  // namespace domain::Tags

--- a/src/Elliptic/DiscontinuousGalerkin/Actions/ApplyOperator.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Actions/ApplyOperator.hpp
@@ -21,6 +21,7 @@
 #include "Domain/Tags.hpp"
 #include "Domain/Tags/FaceNormal.hpp"
 #include "Domain/Tags/Faces.hpp"
+#include "Domain/Tags/SurfaceJacobian.hpp"
 #include "Elliptic/BoundaryConditions/ApplyBoundaryCondition.hpp"
 #include "Elliptic/DiscontinuousGalerkin/DgOperator.hpp"
 #include "Elliptic/DiscontinuousGalerkin/Initialization.hpp"
@@ -393,8 +394,14 @@ struct ReceiveMortarDataAndApplyOperator<
                                              Frame::Inertial>>(box),
         db::get<domain::Tags::Faces<
             Dim, domain::Tags::UnnormalizedFaceNormalMagnitude<Dim>>>(box),
+        db::get<domain::Tags::Faces<
+            Dim, domain::Tags::DetSurfaceJacobian<Frame::ElementLogical,
+                                                  Frame::Inertial>>>(box),
         db::get<::Tags::Mortars<domain::Tags::Mesh<Dim - 1>, Dim>>(box),
         db::get<::Tags::Mortars<::Tags::MortarSize<Dim - 1>, Dim>>(box),
+        db::get<::Tags::Mortars<domain::Tags::DetSurfaceJacobian<
+                                    Frame::ElementLogical, Frame::Inertial>,
+                                Dim>>(box),
         db::get<elliptic::dg::Tags::PenaltyParameter>(box),
         db::get<elliptic::dg::Tags::Massive>(box), temporal_id,
         std::forward_as_tuple(db::get<SourcesArgsTags>(box)...));

--- a/src/Elliptic/DiscontinuousGalerkin/Initialization.cpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Initialization.cpp
@@ -29,6 +29,7 @@
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
 namespace elliptic::dg {
@@ -74,104 +75,62 @@ void InitializeGeometry<Dim>::operator()(
   *det_inv_jacobian = determinant(*inv_jacobian);
 }
 
+namespace detail {
 template <size_t Dim>
-void InitializeFacesAndMortars<Dim>::operator()(
-    const gsl::not_null<DirectionMap<Dim, Direction<Dim>>*> face_directions,
-    const gsl::not_null<DirectionMap<Dim, tnsr::I<DataVector, Dim>>*>
-        face_inertial_coords,
-    const gsl::not_null<DirectionMap<Dim, tnsr::i<DataVector, Dim>>*>
-        face_normals,
-    const gsl::not_null<DirectionMap<Dim, Scalar<DataVector>>*>
-    /*face_normal_magnitudes*/,
+void deriv_unnormalized_face_normals_impl(
     const gsl::not_null<DirectionMap<Dim, tnsr::ij<DataVector, Dim>>*>
         deriv_unnormalized_face_normals,
-    const gsl::not_null<::dg::MortarMap<Dim, Mesh<Dim - 1>>*> mortar_meshes,
-    const gsl::not_null<::dg::MortarMap<Dim, ::dg::MortarSize<Dim - 1>>*>
-        mortar_sizes,
     const Mesh<Dim>& mesh, const Element<Dim>& element,
-    const ElementMap<Dim, Frame::Inertial>& element_map,
     const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
-                          Frame::Inertial>& inv_jacobian,
-    const std::vector<std::array<size_t, Dim>>& initial_extents)
-    const {
-  const Spectral::Quadrature quadrature = mesh.quadrature(0);
-  // Faces
-  for (const auto& direction : Direction<Dim>::all_directions()) {
-    const auto face_mesh = mesh.slice_away(direction.dimension());
-    (*face_directions)[direction] = direction;
-    // Possible optimization: Not all systems need the coordinates on internal
-    // faces.
-    (*face_inertial_coords)[direction] = element_map.operator()(
-        interface_logical_coordinates(face_mesh, direction));
-    (*face_normals)[direction] =
-        unnormalized_face_normal(face_mesh, element_map, direction);
+                          Frame::Inertial>& inv_jacobian) {
+  if (element.external_boundaries().empty()) {
+    return;
   }
-  // Compute the Jacobian derivative numerically, because our coordinate maps
-  // currently don't provide it analytically.
-  if (not element.external_boundaries().empty()) {
-    ASSERT(mesh.quadrature(0) == Spectral::Quadrature::GaussLobatto,
-           "Slicing the Hessian to the boundary currently supports only "
-           "Gauss-Lobatto grids. Add support to "
-           "'elliptic::dg::InitializeFacesAndMortars'.");
-    using inv_jac_tag =
-        domain::Tags::InverseJacobian<Dim, Frame::ElementLogical,
-                                      Frame::Inertial>;
-    Variables<tmpl::list<inv_jac_tag>> vars_to_differentiate{
-        mesh.number_of_grid_points()};
-    get<inv_jac_tag>(vars_to_differentiate) = inv_jacobian;
-    const auto deriv_vars = partial_derivatives<tmpl::list<inv_jac_tag>>(
-        vars_to_differentiate, mesh, inv_jacobian);
-    const auto& deriv_inv_jac =
-        get<::Tags::deriv<inv_jac_tag, tmpl::size_t<Dim>, Frame::Inertial>>(
-            deriv_vars);
-    for (const auto& direction : element.external_boundaries()) {
-      const auto deriv_inv_jac_on_face =
-          data_on_slice(deriv_inv_jac, mesh.extents(), direction.dimension(),
-                        index_to_slice_at(mesh.extents(), direction));
-      auto& deriv_unnormalized_face_normal =
-          (*deriv_unnormalized_face_normals)[direction];
-      for (size_t i = 0; i < Dim; ++i) {
-        for (size_t j = 0; j < Dim; ++j) {
-          deriv_unnormalized_face_normal.get(i, j) =
-              direction.sign() *
-              deriv_inv_jac_on_face.get(i, direction.dimension(), j);
-        }
+  ASSERT(mesh.quadrature(0) == Spectral::Quadrature::GaussLobatto,
+         "Slicing the Hessian to the boundary currently supports only "
+         "Gauss-Lobatto grids. Add support to "
+         "'elliptic::dg::InitializeFacesAndMortars'.");
+  using inv_jac_tag = domain::Tags::InverseJacobian<Dim, Frame::ElementLogical,
+                                                    Frame::Inertial>;
+  Variables<tmpl::list<inv_jac_tag>> vars_to_differentiate{
+      mesh.number_of_grid_points()};
+  get<inv_jac_tag>(vars_to_differentiate) = inv_jacobian;
+  const auto deriv_vars = partial_derivatives<tmpl::list<inv_jac_tag>>(
+      vars_to_differentiate, mesh, inv_jacobian);
+  const auto& deriv_inv_jac =
+      get<::Tags::deriv<inv_jac_tag, tmpl::size_t<Dim>, Frame::Inertial>>(
+          deriv_vars);
+  for (const auto& direction : element.external_boundaries()) {
+    const auto deriv_inv_jac_on_face =
+        data_on_slice(deriv_inv_jac, mesh.extents(), direction.dimension(),
+                      index_to_slice_at(mesh.extents(), direction));
+    auto& deriv_unnormalized_face_normal =
+        (*deriv_unnormalized_face_normals)[direction];
+    for (size_t i = 0; i < Dim; ++i) {
+      for (size_t j = 0; j < Dim; ++j) {
+        deriv_unnormalized_face_normal.get(i, j) =
+            direction.sign() *
+            deriv_inv_jac_on_face.get(i, direction.dimension(), j);
       }
     }
   }
-  // Mortars
-  const auto& element_id = element.id();
-  for (const auto& [direction, neighbors] : element.neighbors()) {
-    const auto face_mesh = mesh.slice_away(direction.dimension());
-    const auto& orientation = neighbors.orientation();
-    for (const auto& neighbor_id : neighbors) {
-      const ::dg::MortarId<Dim> mortar_id{direction, neighbor_id};
-      mortar_meshes->emplace(
-          mortar_id, ::dg::mortar_mesh(
-                         face_mesh, domain::Initialization::create_initial_mesh(
-                                        initial_extents, neighbor_id,
-                                        quadrature, orientation)
-                                        .slice_away(direction.dimension())));
-      mortar_sizes->emplace(
-          mortar_id, ::dg::mortar_size(element_id, neighbor_id,
-                                       direction.dimension(), orientation));
-    }  // neighbors
-  }    // internal directions
-  for (const auto& direction : element.external_boundaries()) {
-    const auto face_mesh = mesh.slice_away(direction.dimension());
-    const auto mortar_id =
-        std::make_pair(direction, ElementId<Dim>::external_boundary_id());
-    mortar_meshes->emplace(mortar_id, face_mesh);
-    mortar_sizes->emplace(mortar_id,
-                          make_array<Dim - 1>(Spectral::MortarSize::Full));
-  }  // external directions
 }
+}  // namespace detail
 
-template class InitializeGeometry<1>;
-template class InitializeGeometry<2>;
-template class InitializeGeometry<3>;
-template class InitializeFacesAndMortars<1>;
-template class InitializeFacesAndMortars<2>;
-template class InitializeFacesAndMortars<3>;
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                   \
+  template class InitializeGeometry<DIM(data)>;                                \
+  template void detail::deriv_unnormalized_face_normals_impl(                  \
+      gsl::not_null<DirectionMap<DIM(data), tnsr::ij<DataVector, DIM(data)>>*> \
+          deriv_unnormalized_face_normals,                                     \
+      const Mesh<DIM(data)>& mesh, const Element<DIM(data)>& element,          \
+      const InverseJacobian<DataVector, DIM(data), Frame::ElementLogical,      \
+                            Frame::Inertial>& inv_jacobian);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef DIM
+#undef INSTANTIATE
 
 }  // namespace elliptic::dg

--- a/src/Elliptic/DiscontinuousGalerkin/Initialization.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Initialization.hpp
@@ -27,6 +27,7 @@
 #include "Domain/Tags.hpp"
 #include "Domain/Tags/FaceNormal.hpp"
 #include "Domain/Tags/Faces.hpp"
+#include "Domain/Tags/SurfaceJacobian.hpp"
 #include "Elliptic/DiscontinuousGalerkin/Tags.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
@@ -78,6 +79,13 @@ void deriv_unnormalized_face_normals_impl(
     const Mesh<Dim>& mesh, const Element<Dim>& element,
     const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
                           Frame::Inertial>& inv_jacobian);
+
+// Get element-logical coordinates of the mortar collocation points
+template <size_t Dim>
+tnsr::I<DataVector, Dim, Frame::ElementLogical> mortar_logical_coordinates(
+    const Mesh<Dim - 1>& mortar_mesh,
+    const ::dg::MortarSize<Dim - 1>& mortar_size,
+    const Direction<Dim>& direction);
 }  // namespace detail
 
 /// Initialize the geometry on faces and mortars for the elliptic DG operator
@@ -88,6 +96,9 @@ void deriv_unnormalized_face_normals_impl(
 /// which it can be retrieved as additional argument to the call operator. Set
 /// `InvMetricTag` to `void` to normalize face normals with the Euclidean
 /// magnitude.
+///
+/// Mortar Jacobians are added only on nonconforming internal element
+/// boundaries, i.e., when `Spectral::needs_projection()` is true.
 ///
 /// The `::Tags::deriv<domain::Tags::UnnormalizedFaceNormal<Dim>>` is only added
 /// on external boundaries, for use by boundary conditions.
@@ -100,6 +111,8 @@ struct InitializeFacesAndMortars {
                      domain::Tags::Coordinates<Dim, Frame::Inertial>,
                      domain::Tags::FaceNormal<Dim>,
                      domain::Tags::UnnormalizedFaceNormalMagnitude<Dim>,
+                     domain::Tags::DetSurfaceJacobian<Frame::ElementLogical,
+                                                      Frame::Inertial>,
                      // Possible optimization: The derivative of the face normal
                      // could be omitted for some systems, but its memory usage
                      // is probably insignificant since it's only added on
@@ -107,7 +120,10 @@ struct InitializeFacesAndMortars {
                      ::Tags::deriv<domain::Tags::UnnormalizedFaceNormal<Dim>,
                                    tmpl::size_t<Dim>, Frame::Inertial>>>,
       tmpl::list<::Tags::Mortars<domain::Tags::Mesh<Dim - 1>, Dim>,
-                 ::Tags::Mortars<::Tags::MortarSize<Dim - 1>, Dim>>>;
+                 ::Tags::Mortars<::Tags::MortarSize<Dim - 1>, Dim>,
+                 ::Tags::Mortars<domain::Tags::DetSurfaceJacobian<
+                                     Frame::ElementLogical, Frame::Inertial>,
+                                 Dim>>>;
   using argument_tags =
       tmpl::list<domain::Tags::Mesh<Dim>, domain::Tags::Element<Dim>,
                  domain::Tags::ElementMap<Dim>,
@@ -117,16 +133,20 @@ struct InitializeFacesAndMortars {
   void operator()(
       const gsl::not_null<DirectionMap<Dim, Direction<Dim>>*> face_directions,
       const gsl::not_null<DirectionMap<Dim, tnsr::I<DataVector, Dim>>*>
-          face_inertial_coords,
+          faces_inertial_coords,
       const gsl::not_null<DirectionMap<Dim, tnsr::i<DataVector, Dim>>*>
           face_normals,
       const gsl::not_null<DirectionMap<Dim, Scalar<DataVector>>*>
           face_normal_magnitudes,
+      const gsl::not_null<DirectionMap<Dim, Scalar<DataVector>>*>
+          face_jacobians,
       const gsl::not_null<DirectionMap<Dim, tnsr::ij<DataVector, Dim>>*>
           deriv_unnormalized_face_normals,
       const gsl::not_null<::dg::MortarMap<Dim, Mesh<Dim - 1>>*> mortar_meshes,
       const gsl::not_null<::dg::MortarMap<Dim, ::dg::MortarSize<Dim - 1>>*>
           mortar_sizes,
+      const gsl::not_null<::dg::MortarMap<Dim, Scalar<DataVector>>*>
+          mortar_jacobians,
       const Mesh<Dim>& mesh, const Element<Dim>& element,
       const ElementMap<Dim, Frame::Inertial>& element_map,
       const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
@@ -165,6 +185,9 @@ struct InitializeFacesAndMortars {
       for (size_t d = 0; d < Dim; ++d) {
         face_normal.get(d) /= get(face_normal_magnitude);
       }
+      get((*face_jacobians)[direction]) =
+          get(determinant(element_map.jacobian(face_logical_coords))) *
+          get(face_normal_magnitude);
     }
     // Compute the Jacobian derivative numerically, because our coordinate maps
     // currently don't provide it analytically.
@@ -187,6 +210,40 @@ struct InitializeFacesAndMortars {
         mortar_sizes->emplace(
             mortar_id, ::dg::mortar_size(element_id, neighbor_id,
                                          direction.dimension(), orientation));
+        // Mortar Jacobian
+        const auto& mortar_mesh = mortar_meshes->at(mortar_id);
+        const auto& mortar_size = mortar_sizes->at(mortar_id);
+        if (Spectral::needs_projection(face_mesh, mortar_mesh, mortar_size)) {
+          const auto mortar_logical_coords = detail::mortar_logical_coordinates(
+              mortar_mesh, mortar_size, direction);
+          auto& mortar_jacobian = (*mortar_jacobians)[mortar_id];
+          mortar_jacobian =
+              determinant(element_map.jacobian(mortar_logical_coords));
+          // These factors of two account for the mortar size
+          for (const auto& mortar_size_i : mortar_size) {
+            if (mortar_size_i != Spectral::MortarSize::Full) {
+              get(mortar_jacobian) *= 0.5;
+            }
+          }
+          const auto inv_jacobian_on_mortar =
+              element_map.inv_jacobian(mortar_logical_coords);
+          const auto unnormalized_mortar_normal = unnormalized_face_normal(
+              mortar_mesh, inv_jacobian_on_mortar, direction);
+          Scalar<DataVector> mortar_normal_magnitude{};
+          if constexpr (std::is_same_v<InvMetricTag, void>) {
+            magnitude(make_not_null(&mortar_normal_magnitude),
+                      unnormalized_mortar_normal);
+          } else {
+            const auto mortar_inertial_coords =
+                element_map(mortar_logical_coords);
+            const auto inv_metric_on_mortar =
+                get<InvMetricTag>(background.variables(
+                    mortar_inertial_coords, tmpl::list<InvMetricTag>{}));
+            magnitude(make_not_null(&mortar_normal_magnitude),
+                      unnormalized_mortar_normal, inv_metric_on_mortar);
+          }
+          get(mortar_jacobian) *= get(mortar_normal_magnitude);
+        }
       }  // neighbors
     }    // internal directions
     // Mortars (external directions)

--- a/src/Elliptic/DiscontinuousGalerkin/Initialization.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Initialization.hpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cstddef>
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -17,6 +18,8 @@
 #include "Domain/Domain.hpp"
 #include "Domain/ElementMap.hpp"
 #include "Domain/FaceNormal.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Structure/CreateInitialMesh.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/Element.hpp"
@@ -66,16 +69,29 @@ struct InitializeGeometry {
       const Domain<Dim>& domain, const ElementId<Dim>& element_id) const;
 };
 
+namespace detail {
+// Compute derivative of the Jacobian numerically
+template <size_t Dim>
+void deriv_unnormalized_face_normals_impl(
+    gsl::not_null<DirectionMap<Dim, tnsr::ij<DataVector, Dim>>*>
+        deriv_unnormalized_face_normals,
+    const Mesh<Dim>& mesh, const Element<Dim>& element,
+    const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                          Frame::Inertial>& inv_jacobian);
+}  // namespace detail
+
 /// Initialize the geometry on faces and mortars for the elliptic DG operator
 ///
-/// Face normals are not yet normalized, and the face-normal magnitudes are not
-/// yet computed at all. Invoke `elliptic::dg::NormalizeFaceNormals` for this
-/// purpose, possibly preceded by `elliptic::dg::InitializeBackground` if the
-/// system has a background metric.
+/// To normalize face normals this function needs the inverse background metric.
+/// Pass the tag representing the inverse background metric to the
+/// `InvMetricTag` template parameter, and pass the analytic background from
+/// which it can be retrieved as additional argument to the call operator. Set
+/// `InvMetricTag` to `void` to normalize face normals with the Euclidean
+/// magnitude.
 ///
-/// The `::Tags::deriv<domain::Tags::UnnormalizedFaceNormal<Dim>>` is only
-/// added on external boundaries, for use by boundary conditions.
-template <size_t Dim>
+/// The `::Tags::deriv<domain::Tags::UnnormalizedFaceNormal<Dim>>` is only added
+/// on external boundaries, for use by boundary conditions.
+template <size_t Dim, typename InvMetricTag>
 struct InitializeFacesAndMortars {
   using return_tags = tmpl::append<
       domain::make_faces_tags<
@@ -97,24 +113,92 @@ struct InitializeFacesAndMortars {
                  domain::Tags::ElementMap<Dim>,
                  domain::Tags::InverseJacobian<Dim, Frame::ElementLogical,
                                                Frame::Inertial>>;
+  template <typename Background = std::nullptr_t>
   void operator()(
-      gsl::not_null<DirectionMap<Dim, Direction<Dim>>*> face_directions,
-      gsl::not_null<DirectionMap<Dim, tnsr::I<DataVector, Dim>>*>
+      const gsl::not_null<DirectionMap<Dim, Direction<Dim>>*> face_directions,
+      const gsl::not_null<DirectionMap<Dim, tnsr::I<DataVector, Dim>>*>
           face_inertial_coords,
-      gsl::not_null<DirectionMap<Dim, tnsr::i<DataVector, Dim>>*> face_normals,
-      gsl::not_null<DirectionMap<Dim, Scalar<DataVector>>*>
+      const gsl::not_null<DirectionMap<Dim, tnsr::i<DataVector, Dim>>*>
+          face_normals,
+      const gsl::not_null<DirectionMap<Dim, Scalar<DataVector>>*>
           face_normal_magnitudes,
-      gsl::not_null<DirectionMap<Dim, tnsr::ij<DataVector, Dim>>*>
+      const gsl::not_null<DirectionMap<Dim, tnsr::ij<DataVector, Dim>>*>
           deriv_unnormalized_face_normals,
-      gsl::not_null<::dg::MortarMap<Dim, Mesh<Dim - 1>>*> mortar_meshes,
-      gsl::not_null<::dg::MortarMap<Dim, ::dg::MortarSize<Dim - 1>>*>
+      const gsl::not_null<::dg::MortarMap<Dim, Mesh<Dim - 1>>*> mortar_meshes,
+      const gsl::not_null<::dg::MortarMap<Dim, ::dg::MortarSize<Dim - 1>>*>
           mortar_sizes,
       const Mesh<Dim>& mesh, const Element<Dim>& element,
       const ElementMap<Dim, Frame::Inertial>& element_map,
       const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
                             Frame::Inertial>& inv_jacobian,
-      const std::vector<std::array<size_t, Dim>>& initial_extents)
-      const;
+      const std::vector<std::array<size_t, Dim>>& initial_extents,
+      const Background& background = std::nullptr_t{}) const {
+    static_assert(std::is_same_v<InvMetricTag, void> or
+                      not(std::is_same_v<Background, std::nullptr_t>),
+                  "Supply an analytic background from which the 'InvMetricTag' "
+                  "can be retrieved");
+    const Spectral::Quadrature quadrature = mesh.quadrature(0);
+    ASSERT(std::equal(mesh.quadrature().begin() + 1, mesh.quadrature().end(),
+                      mesh.quadrature().begin()),
+           "This function is implemented assuming the quadrature is isotropic");
+    // Faces
+    for (const auto& direction : Direction<Dim>::all_directions()) {
+      const auto face_mesh = mesh.slice_away(direction.dimension());
+      (*face_directions)[direction] = direction;
+      // Possible optimization: Not all systems need the coordinates on internal
+      // faces.
+      const auto face_logical_coords =
+          interface_logical_coordinates(face_mesh, direction);
+      auto& face_inertial_coords = (*faces_inertial_coords)[direction];
+      face_inertial_coords = element_map.operator()(face_logical_coords);
+      auto& face_normal = (*face_normals)[direction];
+      auto& face_normal_magnitude = (*face_normal_magnitudes)[direction];
+      face_normal = unnormalized_face_normal(face_mesh, element_map, direction);
+      if constexpr (std::is_same_v<InvMetricTag, void>) {
+        magnitude(make_not_null(&face_normal_magnitude), face_normal);
+      } else {
+        const auto inv_metric_on_face = get<InvMetricTag>(background.variables(
+            face_inertial_coords, tmpl::list<InvMetricTag>{}));
+        magnitude(make_not_null(&face_normal_magnitude), face_normal,
+                  inv_metric_on_face);
+      }
+      for (size_t d = 0; d < Dim; ++d) {
+        face_normal.get(d) /= get(face_normal_magnitude);
+      }
+    }
+    // Compute the Jacobian derivative numerically, because our coordinate maps
+    // currently don't provide it analytically.
+    detail::deriv_unnormalized_face_normals_impl(
+        deriv_unnormalized_face_normals, mesh, element, inv_jacobian);
+    // Mortars (internal directions)
+    const auto& element_id = element.id();
+    for (const auto& [direction, neighbors] : element.neighbors()) {
+      const auto face_mesh = mesh.slice_away(direction.dimension());
+      const auto& orientation = neighbors.orientation();
+      for (const auto& neighbor_id : neighbors) {
+        const ::dg::MortarId<Dim> mortar_id{direction, neighbor_id};
+        mortar_meshes->emplace(
+            mortar_id,
+            ::dg::mortar_mesh(
+                face_mesh,
+                domain::Initialization::create_initial_mesh(
+                    initial_extents, neighbor_id, quadrature, orientation)
+                    .slice_away(direction.dimension())));
+        mortar_sizes->emplace(
+            mortar_id, ::dg::mortar_size(element_id, neighbor_id,
+                                         direction.dimension(), orientation));
+      }  // neighbors
+    }    // internal directions
+    // Mortars (external directions)
+    for (const auto& direction : element.external_boundaries()) {
+      const auto face_mesh = mesh.slice_away(direction.dimension());
+      const auto mortar_id =
+          std::make_pair(direction, ElementId<Dim>::external_boundary_id());
+      mortar_meshes->emplace(mortar_id, face_mesh);
+      mortar_sizes->emplace(mortar_id,
+                            make_array<Dim - 1>(Spectral::MortarSize::Full));
+    }  // external directions
+  }
 };
 
 /// Initialize background quantities for the elliptic DG operator, possibly
@@ -151,30 +235,6 @@ struct InitializeBackground {
           make_not_null(&(*face_background_fields)[direction]),
           *background_fields, mesh.extents(), direction.dimension(),
           index_to_slice_at(mesh.extents(), direction));
-    }
-  }
-};
-
-/// Normalize face normals, possibly using a background metric. Set
-/// `InvMetricTag` to `void` to normalize face normals with the Euclidean
-/// magnitude.
-template <size_t Dim, typename InvMetricTag>
-struct NormalizeFaceNormal {
-  using return_tags =
-      tmpl::list<domain::Tags::FaceNormal<Dim>,
-                 domain::Tags::UnnormalizedFaceNormalMagnitude<Dim>>;
-  using argument_tags =
-      tmpl::conditional_t<std::is_same_v<InvMetricTag, void>, tmpl::list<>,
-                          tmpl::list<InvMetricTag>>;
-
-  template <typename... InvMetric>
-  void operator()(
-      const gsl::not_null<tnsr::i<DataVector, Dim>*> face_normal,
-      const gsl::not_null<Scalar<DataVector>*> face_normal_magnitude,
-      const InvMetric&... inv_metric) const {
-    magnitude(face_normal_magnitude, *face_normal, inv_metric...);
-    for (size_t d = 0; d < Dim; ++d) {
-      face_normal->get(d) /= get(*face_normal_magnitude);
     }
   }
 };

--- a/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/SubdomainOperator.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/SubdomainOperator.hpp
@@ -21,6 +21,7 @@
 #include "Domain/Tags.hpp"
 #include "Domain/Tags/FaceNormal.hpp"
 #include "Domain/Tags/Faces.hpp"
+#include "Domain/Tags/SurfaceJacobian.hpp"
 #include "Elliptic/BoundaryConditions/ApplyBoundaryCondition.hpp"
 #include "Elliptic/DiscontinuousGalerkin/DgOperator.hpp"
 #include "Elliptic/DiscontinuousGalerkin/SubdomainOperator/Tags.hpp"
@@ -146,8 +147,13 @@ struct SubdomainOperator
       domain::Tags::DetInvJacobian<Frame::ElementLogical, Frame::Inertial>,
       domain::Tags::Faces<Dim,
                           domain::Tags::UnnormalizedFaceNormalMagnitude<Dim>>,
+      domain::Tags::Faces<Dim, domain::Tags::DetSurfaceJacobian<
+                                   Frame::ElementLogical, Frame::Inertial>>,
       ::Tags::Mortars<domain::Tags::Mesh<Dim - 1>, Dim>,
       ::Tags::Mortars<::Tags::MortarSize<Dim - 1>, Dim>,
+      ::Tags::Mortars<domain::Tags::DetSurfaceJacobian<Frame::ElementLogical,
+                                                       Frame::Inertial>,
+                      Dim>,
       elliptic::dg::Tags::PenaltyParameter, elliptic::dg::Tags::Massive>;
   using fluxes_args_tags = typename System::fluxes_computer::argument_tags;
   using sources_args_tags =

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/ApplyMassMatrix.cpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/ApplyMassMatrix.cpp
@@ -23,6 +23,16 @@ void apply_mass_matrix_impl<1>(const gsl::not_null<double*> data,
 }
 
 template <>
+void apply_inverse_mass_matrix_impl<1>(const gsl::not_null<double*> data,
+                                       const Mesh<1>& mesh) {
+  const size_t x_size = mesh.extents(0);
+  const auto& w_x = Spectral::quadrature_weights(mesh);
+  for (size_t i = 0; i < x_size; ++i) {
+    data.get()[i] /= w_x[i];
+  }
+}
+
+template <>
 void apply_mass_matrix_impl<2>(const gsl::not_null<double*> data,
                                const Mesh<2>& mesh) {
   const size_t x_size = mesh.extents(0);
@@ -33,6 +43,21 @@ void apply_mass_matrix_impl<2>(const gsl::not_null<double*> data,
     const size_t offset = j * x_size;
     for (size_t i = 0; i < x_size; ++i) {
       data.get()[offset + i] *= w_x[i] * w_y[j];
+    }
+  }
+}
+
+template <>
+void apply_inverse_mass_matrix_impl<2>(const gsl::not_null<double*> data,
+                                       const Mesh<2>& mesh) {
+  const size_t x_size = mesh.extents(0);
+  const size_t y_size = mesh.extents(1);
+  const auto& w_x = Spectral::quadrature_weights(mesh.slice_through(0));
+  const auto& w_y = Spectral::quadrature_weights(mesh.slice_through(1));
+  for (size_t j = 0; j < y_size; ++j) {
+    const size_t offset = j * x_size;
+    for (size_t i = 0; i < x_size; ++i) {
+      data.get()[offset + i] /= w_x[i] * w_y[j];
     }
   }
 }
@@ -53,6 +78,27 @@ void apply_mass_matrix_impl<3>(const gsl::not_null<double*> data,
       const size_t offset = x_size * j + offset_z;
       for (size_t i = 0; i < x_size; ++i) {
         data.get()[offset + i] *= w_x[i] * w_yz;
+      }
+    }
+  }
+}
+
+template <>
+void apply_inverse_mass_matrix_impl<3>(const gsl::not_null<double*> data,
+                                       const Mesh<3>& mesh) {
+  const size_t x_size = mesh.extents(0);
+  const size_t y_size = mesh.extents(1);
+  const size_t z_size = mesh.extents(2);
+  const auto& w_x = Spectral::quadrature_weights(mesh.slice_through(0));
+  const auto& w_y = Spectral::quadrature_weights(mesh.slice_through(1));
+  const auto& w_z = Spectral::quadrature_weights(mesh.slice_through(2));
+  for (size_t k = 0; k < z_size; ++k) {
+    const size_t offset_z = k * y_size * x_size;
+    for (size_t j = 0; j < y_size; ++j) {
+      const double w_yz = w_y[j] * w_z[k];
+      const size_t offset = x_size * j + offset_z;
+      for (size_t i = 0; i < x_size; ++i) {
+        data.get()[offset + i] /= w_x[i] * w_yz;
       }
     }
   }

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/ApplyMassMatrix.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/ApplyMassMatrix.hpp
@@ -15,6 +15,9 @@ namespace dg {
 namespace detail {
 template <size_t Dim>
 void apply_mass_matrix_impl(gsl::not_null<double*> data, const Mesh<Dim>& mesh);
+template <size_t Dim>
+void apply_inverse_mass_matrix_impl(gsl::not_null<double*> data,
+                                    const Mesh<Dim>& mesh);
 }  // namespace detail
 
 /*!
@@ -69,6 +72,38 @@ void apply_mass_matrix(const gsl::not_null<Variables<TagsList>*> data,
       Variables<TagsList>::number_of_independent_components;
   for (size_t i = 0; i < num_comps; ++i) {
     detail::apply_mass_matrix_impl(data->data() + i * num_points, mesh);
+  }
+}
+/// @}
+
+/*!
+ * \brief Apply the inverse DG mass matrix to the data
+ *
+ * \see dg::apply_mass_matrix
+ */
+/// @{
+template <size_t Dim>
+void apply_inverse_mass_matrix(const gsl::not_null<DataVector*> data,
+                               const Mesh<Dim>& mesh) {
+  ASSERT(data->size() == mesh.number_of_grid_points(),
+         "The DataVector has size " << data->size() << ", but expected size "
+                                    << mesh.number_of_grid_points()
+                                    << " on the given mesh.");
+  detail::apply_inverse_mass_matrix_impl(data->data(), mesh);
+}
+
+template <size_t Dim, typename TagsList>
+void apply_inverse_mass_matrix(const gsl::not_null<Variables<TagsList>*> data,
+                               const Mesh<Dim>& mesh) {
+  const size_t num_points = data->number_of_grid_points();
+  ASSERT(num_points == mesh.number_of_grid_points(),
+         "The Variables data has "
+             << num_points << " grid points, but expected "
+             << mesh.number_of_grid_points() << " on the given mesh.");
+  constexpr size_t num_comps =
+      Variables<TagsList>::number_of_independent_components;
+  for (size_t i = 0; i < num_comps; ++i) {
+    detail::apply_inverse_mass_matrix_impl(data->data() + i * num_points, mesh);
   }
 }
 /// @}

--- a/src/NumericalAlgorithms/Spectral/Projection.cpp
+++ b/src/NumericalAlgorithms/Spectral/Projection.cpp
@@ -70,10 +70,10 @@ const Matrix& projection_matrix_child_to_parent(const Mesh<1>& child_mesh,
     const static auto cache = make_static_cache<
         CacheEnumeration<Quadrature, Quadrature::Gauss,
                          Quadrature::GaussLobatto>,
-        CacheRange<2_st, max_points>,
+        CacheRange<2_st, max_points + 1>,
         CacheEnumeration<Quadrature, Quadrature::Gauss,
                          Quadrature::GaussLobatto>,
-        CacheRange<2_st, max_points>,
+        CacheRange<2_st, max_points + 1>,
         CacheEnumeration<ChildSize, ChildSize::Full, ChildSize::UpperHalf,
                          ChildSize::LowerHalf>>(
         [](const Quadrature child_quadrature, const size_t child_extent,

--- a/tests/Unit/Domain/Tags/CMakeLists.txt
+++ b/tests/Unit/Domain/Tags/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_DomainTags")
 set(LIBRARY_SOURCES
   Test_BlockNamesAndGroups.cpp
   Test_Faces.cpp
+  Test_SurfaceJacobian.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Domain/Tags/Test_SurfaceJacobian.cpp
+++ b/tests/Unit/Domain/Tags/Test_SurfaceJacobian.cpp
@@ -1,0 +1,20 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Tags/SurfaceJacobian.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+
+namespace domain {
+
+SPECTRE_TEST_CASE("Unit.Domain.Tags.SurfaceJacobian", "[Unit][Domain]") {
+  TestHelpers::db::test_simple_tag<
+      Tags::DetSurfaceJacobian<Frame::ElementLogical, Frame::Inertial>>(
+      "DetSurfaceJacobian");
+}
+
+}  // namespace domain

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_ApplyMassMatrix.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_ApplyMassMatrix.cpp
@@ -83,6 +83,8 @@ void test_apply_mass_matrix(
     auto result = scalar_field;
     apply_mass_matrix(make_not_null(&result), mesh);
     CHECK_ITERABLE_APPROX(result, expected_mass_matrix_times_scalar_field);
+    apply_inverse_mass_matrix(make_not_null(&result), mesh);
+    CHECK_ITERABLE_APPROX(result, scalar_field);
   }
   {
     INFO("Test with Variables");
@@ -96,6 +98,9 @@ void test_apply_mass_matrix(
                           expected_mass_matrix_times_scalar_field);
     CHECK_ITERABLE_APPROX(get(get<tag2>(vars)),
                           expected_mass_matrix_times_scalar_field);
+    apply_inverse_mass_matrix(make_not_null(&vars), mesh);
+    CHECK_ITERABLE_APPROX(get(get<tag1>(vars)), scalar_field);
+    CHECK_ITERABLE_APPROX(get(get<tag2>(vars)), scalar_field);
   }
 }
 


### PR DESCRIPTION
## Proposed changes

On nonconforming element boundaries we have to interpolate data to a mortar, apply the numerical flux, and then restrict the data back down to the element face. This operation must be mass-conservative, which basically means we have to restrict the Jacobian-times-the-data. Otherwise, convergence of elliptic solves on nonconforming grids is a lot slower. The code in this PR is used in the results that are about to get published in https://arxiv.org/abs/2108.05826, so it would be very helpful to get this merged quickly so I can point to the correct version of the code in the paper. Adding the "priority" label for that reason.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
