### PR TITLE
Add support for clang-13/Ubunt 21.10

### DIFF
--- a/tests/Unit/Helpers/Tests/CMakeLists.txt
+++ b/tests/Unit/Helpers/Tests/CMakeLists.txt
@@ -13,7 +13,15 @@ add_test_library(
   ${LIBRARY}
   "Helpers/Tests"
   "${LIBRARY_SOURCES}"
-  "DataStructures;DataStructuresHelpers"
+  ""
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  DataStructures
+  DataStructuresHelpers
+  GeneralRelativityHelpers
   )
 
 add_subdirectory(PointwiseFunctions)

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
@@ -16,8 +16,21 @@ add_test_library(
   ${LIBRARY}
   "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/"
   "${LIBRARY_SOURCES}"
-  "DataStructures;Domain;GeneralRelativity;GeneralRelativitySolutions;"
-  "GeneralizedHarmonic;Options;Spectral;Utilities"
+  ""
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  DataStructures
+  Domain
+  GeneralRelativity
+  GeneralRelativitySolutions
+  GeneralizedHarmonic
+  Hydro
+  Options
+  Spectral
+  Utilities
   )
 
 add_subdirectory(Python)


### PR DESCRIPTION
## Proposed changes

Fixes some incorrect link dependencies caught in newer versions of clang/ld.lld.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
