### PR TITLE
Decouple TOV radial solution, fix bug with multiple instances

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -1235,6 +1235,23 @@ eprint = {https://doi.org/10.1137/0916035}
   year =         "2014"
 }
 
+@article{Moldenhauer2014yaa,
+  author        = {Moldenhauer, Niclas and Markakis, Charalampos M. and
+                   Johnson-McDaniel, Nathan K. and Tichy, Wolfgang and
+                   Br\"ugmann, Bernd},
+  title         = {Initial data for binary neutron stars with adjustable
+                   eccentricity},
+  eprint        = {1408.4136},
+  archiveprefix = {arXiv},
+  primaryclass  = {gr-qc},
+  doi           = {10.1103/PhysRevD.90.084043},
+  journal       = {Phys. Rev. D},
+  volume        = {90},
+  number        = {8},
+  pages         = {084043},
+  year          = {2014}
+}
+
 @article{Muhlberger2014pja,
   author =       "Muhlberger, Curran D. and Nouri, Fatemeh Hossein and Duez,
                   Matthew D. and Foucart, Francois and Kidder, Lawrence E. and

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/CMakeLists.txt
@@ -112,6 +112,6 @@ add_ghmhd_with_horizon_executable(
 
 add_ghmhd_executable(
   TovStar
-  GeneralizedHarmonic::Solutions::WrappedGr<RelativisticEuler::Solutions::TovStar<gr::Solutions::TovSolution>>
+  GeneralizedHarmonic::Solutions::WrappedGr<RelativisticEuler::Solutions::TovStar>
   "${LIBS_TO_LINK}"
   )

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanFwd.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanFwd.hpp
@@ -19,18 +19,10 @@ template <typename GrSolution>
 struct WrappedGr;
 }  // namespace Solutions
 }  // namespace GeneralizedHarmonic
-namespace gr {
-namespace Solutions {
-class TovSolution;
-}  // namespace Solutions
-}  // namespace gr
 
-namespace RelativisticEuler {
-namespace Solutions {
-template <typename RadialSolution>
+namespace RelativisticEuler::Solutions {
 class TovStar;
-}  // namespace Solutions
-}  // namespace RelativisticEuler
+}  // namespace RelativisticEuler::Solutions
 
 namespace grmhd {
 namespace Solutions {
@@ -47,6 +39,6 @@ class OrszagTangVortex;
 }  // namespace grmhd
 
 struct KerrHorizon;
-template <typename InitialData, typename...InterpolationTargetTags>
+template <typename InitialData, typename... InterpolationTargetTags>
 struct EvolutionMetavars;
 /// \endcond

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizonFwd.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizonFwd.hpp
@@ -19,17 +19,10 @@ template <typename GrSolution>
 struct WrappedGr;
 }  // namespace Solutions
 }  // namespace GeneralizedHarmonic
-namespace gr {
-namespace Solutions {
-class TovSolution;
-}  // namespace Solutions
-}  // namespace gr
 
-namespace RelativisticEuler {
-namespace Solutions {
+namespace RelativisticEuler::Solutions {
 class FishboneMoncriefDisk;
-}  // namespace Solutions
-}  // namespace RelativisticEuler
+}  // namespace RelativisticEuler::Solutions
 
 namespace grmhd {
 namespace Solutions {
@@ -42,6 +35,6 @@ class MagnetizedFmDisk;
 }  // namespace grmhd
 
 struct KerrHorizon;
-template <typename InitialData, typename...InterpolationTargetTags>
+template <typename InitialData, typename... InterpolationTargetTags>
 struct EvolutionMetavars;
 /// \endcond

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -47,7 +47,7 @@ add_grmhd_executable(
 
 add_grmhd_executable(
   TovStar
-  RelativisticEuler::Solutions::TovStar<gr::Solutions::TovSolution>,CenterOfStar
+  RelativisticEuler::Solutions::TovStar,CenterOfStar
   "${LIBS_TO_LINK}"
   )
 

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivCleanFwd.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivCleanFwd.hpp
@@ -4,16 +4,9 @@
 #pragma once
 
 /// \cond
-namespace gr {
-namespace Solutions {
-class TovSolution;
-}  // namespace Solutions
-}  // namespace gr
-
 namespace RelativisticEuler {
 namespace Solutions {
 class FishboneMoncriefDisk;
-template <typename RadialSolution>
 class TovStar;
 }  // namespace Solutions
 }  // namespace RelativisticEuler

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Python/Tov.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Python/Tov.cpp
@@ -10,9 +10,7 @@
 
 namespace py = pybind11;
 
-namespace gr {
-namespace Solutions {
-namespace py_bindings {
+namespace gr::Solutions::py_bindings {
 
 void bind_tov(py::module& m) {  // NOLINT
   py::class_<TovSolution>(m, "Tov")
@@ -23,12 +21,11 @@ void bind_tov(py::module& m) {  // NOLINT
            py::arg("absolute_tolerance") = 1.e-14,
            py::arg("relative_tolerance") = 1.e-14)
       .def("outer_radius", &TovSolution::outer_radius)
-      .def("mass_over_radius", py::vectorize(&TovSolution::mass_over_radius))
-      .def("mass", py::vectorize(&TovSolution::mass))
+      .def("total_mass", &TovSolution::total_mass)
+      .def("mass_over_radius",
+           py::vectorize(&TovSolution::mass_over_radius<double>))
       .def("log_specific_enthalpy",
-           py::vectorize(&TovSolution::log_specific_enthalpy));
+           py::vectorize(&TovSolution::log_specific_enthalpy<double>));
 }
 
-}  // namespace py_bindings
-}  // namespace Solutions
-}  // namespace gr
+}  // namespace gr::Solutions::py_bindings

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Python/Tov.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Python/Tov.cpp
@@ -22,6 +22,7 @@ void bind_tov(py::module& m) {  // NOLINT
            py::arg("relative_tolerance") = 1.e-14)
       .def("outer_radius", &TovSolution::outer_radius)
       .def("total_mass", &TovSolution::total_mass)
+      .def("injection_energy", &TovSolution::injection_energy)
       .def("mass_over_radius",
            py::vectorize(&TovSolution::mass_over_radius<double>))
       .def("log_specific_enthalpy",

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Tov.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Tov.cpp
@@ -17,7 +17,8 @@
 #include <vector>
 
 #include "DataStructures/DataVector.hpp"
-#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
@@ -83,85 +84,6 @@ class Observer {
   std::vector<double> mass_over_radius;
   std::vector<double> log_enthalpy;
 };
-
-template <typename DataType>
-RelativisticEuler::Solutions::TovStar<
-    gr::Solutions::TovSolution>::RadialVariables<DataType>
-interior_solution(
-    const EquationsOfState::EquationOfState<true, 1>& equation_of_state,
-    const DataType& radius, const DataType& mass_over_radius,
-    const DataType& log_specific_enthalpy,
-    const double log_lapse_at_outer_radius) {
-  RelativisticEuler::Solutions::TovStar<
-      gr::Solutions::TovSolution>::RadialVariables<DataType>
-      result(radius);
-  result.specific_enthalpy = Scalar<DataType>{exp(log_specific_enthalpy)};
-  result.rest_mass_density = equation_of_state.rest_mass_density_from_enthalpy(
-      result.specific_enthalpy);
-  result.pressure =
-      equation_of_state.pressure_from_density(result.rest_mass_density);
-  result.specific_internal_energy =
-      equation_of_state.specific_internal_energy_from_density(
-          result.rest_mass_density);
-  // From the TOV equation, write radial derivative of the pressure as
-  //   - (rho(1.0+epsilon)+P)*((m/r)+4*pi r^2 P) / (r - 2 * r (m/r))
-  // where rho is the rest-mass density and epsilon the specific internal
-  // energy.
-  for (size_t i = 0; i < get_size(radius); ++i) {
-    if (get_element(radius, i) > 0.0) {
-      get_element(result.dr_pressure, i) =
-          -(get_element(get(result.rest_mass_density), i) *
-                (1.0 + get_element(get(result.specific_internal_energy), i)) +
-            get_element(get(result.pressure), i)) *
-          (get_element(mass_over_radius, i) +
-           4.0 * M_PI * get_element(get(result.pressure), i) *
-               square(get_element(radius, i))) /
-          (get_element(radius, i) *
-           (1.0 - 2.0 * get_element(mass_over_radius, i)));
-    } else {
-      get_element(result.dr_pressure, i) = 0.0;
-    }
-  }
-  result.metric_time_potential =
-      log_lapse_at_outer_radius - log_specific_enthalpy;
-  result.dr_metric_time_potential =
-      (mass_over_radius / radius + 4.0 * M_PI * get(result.pressure) * radius) /
-      (1.0 - 2.0 * mass_over_radius);
-  result.metric_radial_potential = -0.5 * log(1.0 - 2.0 * mass_over_radius);
-  result.dr_metric_radial_potential =
-      (4.0 * M_PI * radius *
-           (get(result.specific_enthalpy) * get(result.rest_mass_density) -
-            get(result.pressure)) -
-       mass_over_radius / radius) /
-      (1.0 - 2.0 * mass_over_radius);
-  result.metric_angular_potential = make_with_value<DataType>(radius, 0.0);
-  result.dr_metric_angular_potential = make_with_value<DataType>(radius, 0.0);
-  return result;
-}
-
-template <typename DataType>
-RelativisticEuler::Solutions::TovStar<
-    gr::Solutions::TovSolution>::RadialVariables<DataType>
-vacuum_solution(const DataType& radius, const double total_mass) {
-  RelativisticEuler::Solutions::TovStar<
-      gr::Solutions::TovSolution>::RadialVariables<DataType>
-      result(radius);
-  result.specific_enthalpy = make_with_value<Scalar<DataType>>(radius, 1.0);
-  result.rest_mass_density = make_with_value<Scalar<DataType>>(radius, 0.0);
-  result.pressure = make_with_value<Scalar<DataType>>(radius, 0.0);
-  result.specific_internal_energy =
-      make_with_value<Scalar<DataType>>(radius, 0.0);
-  result.dr_pressure = make_with_value<DataType>(radius, 0.0);
-  const DataType one_minus_two_m_over_r = 1.0 - 2.0 * total_mass / radius;
-  result.metric_time_potential = 0.5 * log(one_minus_two_m_over_r);
-  result.dr_metric_time_potential =
-      total_mass / square(radius) / one_minus_two_m_over_r;
-  result.metric_radial_potential = -result.metric_time_potential;
-  result.dr_metric_radial_potential = -result.dr_metric_time_potential;
-  result.metric_angular_potential = make_with_value<DataType>(radius, 0.0);
-  result.dr_metric_angular_potential = make_with_value<DataType>(radius, 0.0);
-  return result;
-}
 
 }  // namespace
 
@@ -232,77 +154,6 @@ DataType TovSolution::log_specific_enthalpy(const DataType& r) const {
         "Invalid radius: " << r << " not in [0.0, " << outer_radius_ << "]\n");
     get_element(result, i) = log_enthalpy_interpolant_(get_element(r, i));
   }
-  return result;
-}
-
-template <>
-RelativisticEuler::Solutions::TovStar<TovSolution>::RadialVariables<double>
-TovSolution::radial_variables(
-    const EquationsOfState::EquationOfState<true, 1>& equation_of_state,
-    const tnsr::I<double, 3>& x) const {
-  // add small number to avoid FPEs at origin
-  const double radius = get(magnitude(x)) + 1.e-30 * outer_radius_;
-  if (radius >= outer_radius_) {
-    return vacuum_solution(radius, total_mass_);
-  }
-  const double log_lapse_at_outer_radius =
-      0.5 * log(1.0 - 2.0 * total_mass_ / outer_radius_);
-  return interior_solution(equation_of_state, radius, mass_over_radius(radius),
-                           log_specific_enthalpy(radius),
-                           log_lapse_at_outer_radius_);
-}
-
-template <>
-RelativisticEuler::Solutions::TovStar<TovSolution>::RadialVariables<DataVector>
-TovSolution::radial_variables(
-    const EquationsOfState::EquationOfState<true, 1>& equation_of_state,
-    const tnsr::I<DataVector, 3>& x) const {
-  // add small number to avoid FPEs at origin
-  const DataVector radius = get(magnitude(x)) + 1.e-30 * outer_radius_;
-  if (min(radius) >= outer_radius_) {
-    return vacuum_solution(radius, total_mass_);
-  }
-  const double log_lapse_at_outer_radius =
-      0.5 * log(1.0 - 2.0 * total_mass_ / outer_radius_);
-  if (max(radius) <= outer_radius_) {
-    DataVector mass_over_radius_data(radius.size());
-    DataVector log_of_specific_enthalpy(radius.size());
-    for (size_t i = 0; i < get_size(radius); i++) {
-      const double r = get_element(radius, i);
-      get_element(mass_over_radius_data, i) = mass_over_radius(r);
-      get_element(log_of_specific_enthalpy, i) = log_specific_enthalpy(r);
-    }
-    return interior_solution(equation_of_state, radius, mass_over_radius_data,
-                             log_of_specific_enthalpy,
-                             log_lapse_at_outer_radius);
-  }
-  RelativisticEuler::Solutions::TovStar<TovSolution>::RadialVariables<
-      DataVector>
-      result(radius);
-  for (size_t i = 0; i < radius.size(); i++) {
-    const double r = radius[i];
-    auto radial_vars_at_r =
-        (r <= outer_radius_
-             ? interior_solution(equation_of_state, r, mass_over_radius(r),
-                                 log_specific_enthalpy(r),
-                                 log_lapse_at_outer_radius)
-             : vacuum_solution(r, total_mass_));
-    get(result.rest_mass_density)[i] = get(radial_vars_at_r.rest_mass_density);
-    get(result.pressure)[i] = get(radial_vars_at_r.pressure);
-    get(result.specific_internal_energy)[i] =
-        get(radial_vars_at_r.specific_internal_energy);
-    get(result.specific_enthalpy)[i] = get(radial_vars_at_r.specific_enthalpy);
-    result.dr_pressure[i] = radial_vars_at_r.dr_pressure;
-    result.metric_time_potential[i] = radial_vars_at_r.metric_time_potential;
-    result.dr_metric_time_potential[i] =
-        radial_vars_at_r.dr_metric_time_potential;
-    result.metric_radial_potential[i] =
-        radial_vars_at_r.metric_radial_potential;
-    result.dr_metric_radial_potential[i] =
-        radial_vars_at_r.dr_metric_radial_potential;
-  }
-  result.metric_angular_potential = make_with_value<DataVector>(radius, 0.0);
-  result.dr_metric_angular_potential = make_with_value<DataVector>(radius, 0.0);
   return result;
 }
 

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Tov.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Tov.cpp
@@ -123,6 +123,7 @@ TovSolution::TovSolution(
   outer_radius_ = observer.radius.back();
   const double total_mass_over_radius = observer.mass_over_radius.back();
   total_mass_ = total_mass_over_radius * outer_radius_;
+  injection_energy_ = sqrt(1. - 2. * total_mass_ / outer_radius_);
   mass_over_radius_interpolant_ =
       intrp::BarycentricRational(observer.radius, observer.mass_over_radius, 5);
   // log_enthalpy(radius) is almost linear so an interpolant of order 3
@@ -160,6 +161,7 @@ DataType TovSolution::log_specific_enthalpy(const DataType& r) const {
 void TovSolution::pup(PUP::er& p) {  // NOLINT
   p | outer_radius_;
   p | total_mass_;
+  p | injection_energy_;
   p | mass_over_radius_interpolant_;
   p | log_enthalpy_interpolant_;
 }

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Tov.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Tov.hpp
@@ -61,6 +61,46 @@ class TovSolution {
   /// The total mass \f$m(R)\f$, where \f$R\f$ is the outer radius.
   double total_mass() const { return total_mass_; }
 
+  /*!
+   * \brief The injection energy \f$\mathcal{E}=\alpha(r=R)=\sqrt{1-2M/R}\f$.
+   *
+   * The injection energy of the TOV solution is
+   *
+   * \f{equation}
+   * \mathcal{E} = -h k^a u_a = h \alpha
+   * \text{,}
+   * \f}
+   *
+   * where \f$\boldsymbol{k} = \partial_t\f$ is a Killing vector of the static
+   * solution, \f$h\f$ is the specific enthalpy, \f$u_a\f$ is the fluid
+   * four-velocity, and \f$\alpha\f$ is the lapse (see, e.g., Eqs. (2.19) and
+   * (4.2) in \cite Moldenhauer2014yaa). Since the TOV solution is static, the
+   * injection energy is conserved not only along stream lines but throughout
+   * the star,
+   *
+   * \f{equation}
+   * \nabla_a \mathcal{E} = 0
+   * \text{.}
+   * \f}
+   *
+   * Therefore,
+   *
+   * \f{equation}
+   * \mathcal{E} = \alpha(r=R) = \sqrt{1 - 2M/R}
+   * \f}
+   *
+   * by evaluating the injection energy at the outer radius \f$R\f$, where
+   * \f$h=1\f$ and where we match the lapse to the outer Schwarzschild
+   * solution. The conservation also implies
+   *
+   * \f{equation}
+   * \alpha = \mathcal{E} / h
+   * \f}
+   *
+   * throughout the star.
+   */
+  double injection_energy() const { return injection_energy_; }
+
   /// \brief The mass inside the given radius over the radius
   /// \f$\frac{m(r)}{r}\f$
   ///
@@ -80,6 +120,7 @@ class TovSolution {
  private:
   double outer_radius_{std::numeric_limits<double>::signaling_NaN()};
   double total_mass_{std::numeric_limits<double>::signaling_NaN()};
+  double injection_energy_{std::numeric_limits<double>::signaling_NaN()};
   intrp::BarycentricRational mass_over_radius_interpolant_;
   intrp::BarycentricRational log_enthalpy_interpolant_;
 };

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Tov.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Tov.hpp
@@ -5,9 +5,7 @@
 
 #include <limits>
 
-#include "DataStructures/Tensor/Tensor.hpp"
 #include "NumericalAlgorithms/Interpolation/BarycentricRational.hpp"
-#include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"  // IWYU pragma: keep
 
 /// \cond
@@ -47,8 +45,8 @@ class TovSolution {
       double absolute_tolerance = 1.0e-14, double relative_tolerance = 1.0e-14);
 
   TovSolution() = default;
-  TovSolution(const TovSolution& /*rhs*/) = delete;
-  TovSolution& operator=(const TovSolution& /*rhs*/) = delete;
+  TovSolution(const TovSolution& /*rhs*/) = default;
+  TovSolution& operator=(const TovSolution& /*rhs*/) = default;
   TovSolution(TovSolution&& /*rhs*/) = default;
   TovSolution& operator=(TovSolution&& /*rhs*/) = default;
   ~TovSolution() = default;
@@ -75,19 +73,6 @@ class TovSolution {
   /// \note `r` should be non-negative and not greater than `outer_radius()`
   template <typename DataType>
   DataType log_specific_enthalpy(const DataType& r) const;
-
-  /// \brief The radial variables from which the hydrodynamic quantities and
-  /// spacetime metric can be computed.
-  ///
-  /// For radii greater than the `outer_radius()`, this returns the appropriate
-  /// vacuum spacetime.
-  ///
-  /// \note This solution of the TOV equations is a function of areal radius.
-  template <typename DataType>
-  RelativisticEuler::Solutions::TovStar<TovSolution>::RadialVariables<DataType>
-  radial_variables(
-      const EquationsOfState::EquationOfState<true, 1>& equation_of_state,
-      const tnsr::I<DataType, 3>& x) const;
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p);

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Tov.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Tov.hpp
@@ -58,26 +58,23 @@ class TovSolution {
   /// \note This is the radius at which `log_specific_enthalpy` is equal
   /// to the value of `log_enthalpy_at_outer_radius` that was given when
   /// constructing this TovSolution
-  double outer_radius() const;
+  double outer_radius() const { return outer_radius_; }
+
+  /// The total mass \f$m(R)\f$, where \f$R\f$ is the outer radius.
+  double total_mass() const { return total_mass_; }
 
   /// \brief The mass inside the given radius over the radius
   /// \f$\frac{m(r)}{r}\f$
   ///
   /// \note `r` should be non-negative and not greater than `outer_radius()`.
-  double mass_over_radius(double r) const;
-
-  /// \brief The mass inside the given radius \f$m(r)\f$
-  ///
-  /// \warning When computing \f$\frac{m(r)}{r}\f$, use the `mass_over_radius`
-  /// function instead for greater accuracy.
-  ///
-  /// \note `r` should be non-negative and not greater than `outer_radius()`
-  double mass(double r) const;
+  template <typename DataType>
+  DataType mass_over_radius(const DataType& r) const;
 
   /// \brief The log of the specific enthalpy at the given radius
   ///
   /// \note `r` should be non-negative and not greater than `outer_radius()`
-  double log_specific_enthalpy(double r) const;
+  template <typename DataType>
+  DataType log_specific_enthalpy(const DataType& r) const;
 
   /// \brief The radial variables from which the hydrodynamic quantities and
   /// spacetime metric can be computed.
@@ -98,8 +95,6 @@ class TovSolution {
  private:
   double outer_radius_{std::numeric_limits<double>::signaling_NaN()};
   double total_mass_{std::numeric_limits<double>::signaling_NaN()};
-  double log_lapse_at_outer_radius_{
-      std::numeric_limits<double>::signaling_NaN()};
   intrp::BarycentricRational mass_over_radius_interpolant_;
   intrp::BarycentricRational log_enthalpy_interpolant_;
 };

--- a/src/PointwiseFunctions/AnalyticSolutions/GhRelativisticEuler/InstantiateWrappedGr.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GhRelativisticEuler/InstantiateWrappedGr.cpp
@@ -2,7 +2,6 @@
 // See LICENSE.txt for details.
 
 #include "DataStructures/DataBox/Prefixes.hpp"
-#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Tov.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.tpp"
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp"
@@ -11,10 +10,9 @@
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
-GENERATE_INSTANTIATIONS(
-    WRAPPED_GR_INSTANTIATE,
-    (RelativisticEuler::Solutions::FishboneMoncriefDisk,
-     RelativisticEuler::Solutions::SmoothFlow<1>,
-     RelativisticEuler::Solutions::SmoothFlow<2>,
-     RelativisticEuler::Solutions::SmoothFlow<3>,
-     RelativisticEuler::Solutions::TovStar<gr::Solutions::TovSolution>))
+GENERATE_INSTANTIATIONS(WRAPPED_GR_INSTANTIATE,
+                        (RelativisticEuler::Solutions::FishboneMoncriefDisk,
+                         RelativisticEuler::Solutions::SmoothFlow<1>,
+                         RelativisticEuler::Solutions::SmoothFlow<2>,
+                         RelativisticEuler::Solutions::SmoothFlow<3>,
+                         RelativisticEuler::Solutions::TovStar))

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.cpp
@@ -25,7 +25,8 @@ TovStar::TovStar(const double central_rest_mass_density,
     : central_rest_mass_density_(central_rest_mass_density),
       polytropic_constant_(polytropic_constant),
       polytropic_exponent_(polytropic_exponent),
-      equation_of_state_{polytropic_constant_, polytropic_exponent_} {}
+      equation_of_state_{polytropic_constant_, polytropic_exponent_},
+      radial_solution_(equation_of_state_, central_rest_mass_density_) {}
 
 void TovStar::pup(PUP::er& p) {
   InitialData::pup(p);
@@ -33,12 +34,7 @@ void TovStar::pup(PUP::er& p) {
   p | polytropic_constant_;
   p | polytropic_exponent_;
   p | equation_of_state_;
-}
-
-const gr::Solutions::TovSolution& TovStar::radial_tov_solution() const {
-  static const gr::Solutions::TovSolution solution(
-      equation_of_state_, central_rest_mass_density_, 0.0);
-  return solution;
+  p | radial_solution_;
 }
 
 namespace tov_detail {

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.cpp
@@ -4,34 +4,30 @@
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp"
 
 #include <cstddef>
+#include <pup.h>
 
-#include "DataStructures/DataVector.hpp"                  // IWYU pragma: keep
-#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"  // IWYU pragma: keep
-#include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Tov.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-// IWYU pragma: no_include <complex>
-
 namespace RelativisticEuler::Solutions {
 
-template <typename RadialSolution>
-TovStar<RadialSolution>::TovStar(CkMigrateMessage* msg) : InitialData(msg) {}
+TovStar::TovStar(CkMigrateMessage* msg) : InitialData(msg) {}
 
-template <typename RadialSolution>
-TovStar<RadialSolution>::TovStar(const double central_rest_mass_density,
-                                 const double polytropic_constant,
-                                 const double polytropic_exponent)
+TovStar::TovStar(const double central_rest_mass_density,
+                 const double polytropic_constant,
+                 const double polytropic_exponent)
     : central_rest_mass_density_(central_rest_mass_density),
       polytropic_constant_(polytropic_constant),
       polytropic_exponent_(polytropic_exponent),
       equation_of_state_{polytropic_constant_, polytropic_exponent_} {}
 
-template <typename RadialSolution>
-void TovStar<RadialSolution>::pup(PUP::er& p) {
+void TovStar::pup(PUP::er& p) {
   InitialData::pup(p);
   p | central_rest_mass_density_;
   p | polytropic_constant_;
@@ -39,268 +35,497 @@ void TovStar<RadialSolution>::pup(PUP::er& p) {
   p | equation_of_state_;
 }
 
-template <>
-const gr::Solutions::TovSolution&
-TovStar<gr::Solutions::TovSolution>::radial_tov_solution() const {
+const gr::Solutions::TovSolution& TovStar::radial_tov_solution() const {
   static const gr::Solutions::TovSolution solution(
       equation_of_state_, central_rest_mass_density_, 0.0);
   return solution;
 }
 
-template <typename RadialSolution>
-template <typename DataType>
-tuples::TaggedTuple<hydro::Tags::RestMassDensity<DataType>>
-TovStar<RadialSolution>::variables(
-    const tnsr::I<DataType, 3>& /*x*/,
-    tmpl::list<hydro::Tags::RestMassDensity<DataType>> /*meta*/,
-    const RadialVariables<DataType>& radial_vars) const {
-  return radial_vars.rest_mass_density;
-}
+namespace tov_detail {
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsuggest-attribute=noreturn"
+#endif  // defined(__GNUC__) && !defined(__clang__)
 
-template <typename RadialSolution>
-template <typename DataType>
-tuples::TaggedTuple<hydro::Tags::Pressure<DataType>>
-TovStar<RadialSolution>::variables(
-    const tnsr::I<DataType, 3>& /*x*/,
-    tmpl::list<hydro::Tags::Pressure<DataType>> /*meta*/,
-    const RadialVariables<DataType>& radial_vars) const {
-  return radial_vars.pressure;
-}
-
-template <typename RadialSolution>
-template <typename DataType>
-tuples::TaggedTuple<hydro::Tags::SpecificInternalEnergy<DataType>>
-TovStar<RadialSolution>::variables(
-    const tnsr::I<DataType, 3>& /*x*/,
-    tmpl::list<hydro::Tags::SpecificInternalEnergy<DataType>> /*meta*/,
-    const RadialVariables<DataType>& radial_vars) const {
-  return radial_vars.specific_internal_energy;
-}
-
-template <typename RadialSolution>
-template <typename DataType>
-tuples::TaggedTuple<hydro::Tags::SpecificEnthalpy<DataType>>
-TovStar<RadialSolution>::variables(
-    const tnsr::I<DataType, 3>& /*x*/,
-    tmpl::list<hydro::Tags::SpecificEnthalpy<DataType>> /*meta*/,
-    const RadialVariables<DataType>& radial_vars) const {
-  return radial_vars.specific_enthalpy;
-}
-
-template <typename RadialSolution>
-template <typename DataType>
-tuples::TaggedTuple<hydro::Tags::LorentzFactor<DataType>>
-TovStar<RadialSolution>::variables(
-    const tnsr::I<DataType, 3>& x,
-    tmpl::list<hydro::Tags::LorentzFactor<DataType>> /*meta*/,
-    const RadialVariables<DataType>& /*radial_vars*/) const {
-  return make_with_value<Scalar<DataType>>(x, 1.0);
-}
-
-template <typename RadialSolution>
-template <typename DataType>
-tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DataType, 3>>
-TovStar<RadialSolution>::variables(
-    const tnsr::I<DataType, 3>& x,
-    tmpl::list<hydro::Tags::SpatialVelocity<DataType, 3>> /*meta*/,
-    const RadialVariables<DataType>& /*radial_vars*/) const {
-  return make_with_value<tnsr::I<DataType, 3>>(x, 0.0);
-}
-
-template <typename RadialSolution>
-template <typename DataType>
-tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3>>
-TovStar<RadialSolution>::variables(
-    const tnsr::I<DataType, 3>& x,
-    tmpl::list<hydro::Tags::MagneticField<DataType, 3>> /*meta*/,
-    const RadialVariables<DataType>& /*radial_vars*/) const {
-  return make_with_value<tnsr::I<DataType, 3>>(x, 0.0);
-}
-
-template <typename RadialSolution>
-template <typename DataType>
-tuples::TaggedTuple<hydro::Tags::DivergenceCleaningField<DataType>>
-TovStar<RadialSolution>::variables(
-    const tnsr::I<DataType, 3>& x,
-    tmpl::list<hydro::Tags::DivergenceCleaningField<DataType>> /*meta*/,
-    const RadialVariables<DataType>& /*radial_vars*/) const {
-  return make_with_value<Scalar<DataType>>(x, 0.0);
-}
-
-template <typename RadialSolution>
-template <typename DataType>
-tuples::TaggedTuple<gr::Tags::Lapse<DataType>>
-TovStar<RadialSolution>::variables(
-    const tnsr::I<DataType, 3>& /*x*/,
-    tmpl::list<gr::Tags::Lapse<DataType>> /*meta*/,
-    const RadialVariables<DataType>& radial_vars) const {
-  return Scalar<DataType>{exp(radial_vars.metric_time_potential)};
-}
-
-template <typename RadialSolution>
-template <typename DataType>
-tuples::TaggedTuple<
-    typename TovStar<RadialSolution>::template DerivLapse<DataType>>
-TovStar<RadialSolution>::variables(
-    const tnsr::I<DataType, 3>& x,
-    tmpl::list<typename TovStar<RadialSolution>::template DerivLapse<
-        DataType>> /*meta*/,
-    const RadialVariables<DataType>& radial_vars) const {
-  tnsr::i<DataType, 3, Frame::Inertial> d_lapse{
-      exp(radial_vars.metric_time_potential) *
-      radial_vars.dr_metric_time_potential / radial_vars.radial_coordinate};
-  for (size_t i = 0; i < 3; ++i) {
-    d_lapse.get(i) *= x.get(i);
+template <typename DataType, StarRegion Region>
+void TovVariables<DataType, Region>::operator()(
+    [[maybe_unused]] const gsl::not_null<Scalar<DataType>*> mass_over_radius,
+    const gsl::not_null<Cache*> /*cache*/,
+    Tags::MassOverRadius<DataType> /*meta*/) const {
+  if constexpr (Region == StarRegion::Exterior) {
+    ERROR(
+        "The mass-over-radius quantity should not be needed in the exterior of "
+        "the star.");
+  } else {
+    get(*mass_over_radius) = radial_solution.mass_over_radius(radius);
   }
-  return d_lapse;
 }
 
-template <typename RadialSolution>
-template <typename DataType>
-tuples::TaggedTuple<gr::Tags::Shift<3, Frame::Inertial, DataType>>
-TovStar<RadialSolution>::variables(
-    const tnsr::I<DataType, 3>& x,
-    tmpl::list<gr::Tags::Shift<3, Frame::Inertial, DataType>> /*meta*/,
-    const RadialVariables<DataType>& /*radial_vars*/) const {
-  return make_with_value<tnsr::I<DataType, 3>>(x, 0.0);
+template <typename DataType, StarRegion Region>
+void TovVariables<DataType, Region>::operator()(
+    [[maybe_unused]] const gsl::not_null<Scalar<DataType>*>
+        log_specific_enthalpy,
+    const gsl::not_null<Cache*> /*cache*/,
+    Tags::LogSpecificEnthalpy<DataType> /*meta*/) const {
+  if constexpr (Region == StarRegion::Exterior) {
+    ERROR(
+        "The log-specific-enthalpy quantity should not be needed in the "
+        "exterior of the star (just use the specific enthalpy).");
+  } else {
+    get(*log_specific_enthalpy) = radial_solution.log_specific_enthalpy(radius);
+  }
 }
 
-template <typename RadialSolution>
-template <typename DataType>
-tuples::TaggedTuple<
-    typename TovStar<RadialSolution>::template DerivShift<DataType>>
-TovStar<RadialSolution>::variables(
-    const tnsr::I<DataType, 3>& x,
-    tmpl::list<typename TovStar<RadialSolution>::template DerivShift<
-        DataType>> /*meta*/,
-    const RadialVariables<DataType>& /*radial_vars*/) const {
-  return make_with_value<tnsr::iJ<DataType, 3>>(x, 0.0);
+template <typename DataType, StarRegion Region>
+void TovVariables<DataType, Region>::operator()(
+    const gsl::not_null<Scalar<DataType>*> specific_enthalpy,
+    [[maybe_unused]] const gsl::not_null<Cache*> cache,
+    hydro::Tags::SpecificEnthalpy<DataType> /*meta*/) const {
+  if constexpr (Region == StarRegion::Exterior) {
+    get(*specific_enthalpy) = 1.;
+  } else {
+    const auto& log_specific_enthalpy =
+        get(cache->get_var(*this, Tags::LogSpecificEnthalpy<DataType>{}));
+    get(*specific_enthalpy) = exp(log_specific_enthalpy);
+  }
 }
 
-template <typename RadialSolution>
-template <typename DataType>
-tuples::TaggedTuple<gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>>
-TovStar<RadialSolution>::variables(
-    const tnsr::I<DataType, 3>& x,
-    tmpl::list<gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>> /*meta*/,
-    const RadialVariables<DataType>& radial_vars) const {
-  tnsr::ii<DataType, 3, Frame::Inertial> spatial_metric{
-      (exp(2.0 * radial_vars.metric_radial_potential) -
-       exp(2.0 * radial_vars.metric_angular_potential)) /
-      square(radial_vars.radial_coordinate)};
-  for (size_t i = 0; i < 3; ++i) {
-    for (size_t j = i; j < 3; ++j) {
-      spatial_metric.get(i, j) *= x.get(i) * x.get(j);
+template <typename DataType, StarRegion Region>
+void TovVariables<DataType, Region>::operator()(
+    const gsl::not_null<Scalar<DataType>*> rest_mass_density,
+    [[maybe_unused]] const gsl::not_null<Cache*> cache,
+    hydro::Tags::RestMassDensity<DataType> /*meta*/) const {
+  if constexpr (Region == StarRegion::Exterior) {
+    get(*rest_mass_density) = 0.;
+  } else {
+    const auto& specific_enthalpy =
+        cache->get_var(*this, hydro::Tags::SpecificEnthalpy<DataType>{});
+    *rest_mass_density = eos.rest_mass_density_from_enthalpy(specific_enthalpy);
+  }
+}
+
+template <typename DataType, StarRegion Region>
+void TovVariables<DataType, Region>::operator()(
+    const gsl::not_null<Scalar<DataType>*> pressure,
+    [[maybe_unused]] const gsl::not_null<Cache*> cache,
+    hydro::Tags::Pressure<DataType> /*meta*/) const {
+  if constexpr (Region == StarRegion::Exterior) {
+    get(*pressure) = 0.;
+  } else {
+    const auto& rest_mass_density =
+        cache->get_var(*this, hydro::Tags::RestMassDensity<DataType>{});
+    *pressure = eos.pressure_from_density(rest_mass_density);
+  }
+}
+
+template <typename DataType, StarRegion Region>
+void TovVariables<DataType, Region>::operator()(
+    const gsl::not_null<Scalar<DataType>*> specific_internal_energy,
+    [[maybe_unused]] const gsl::not_null<Cache*> cache,
+    hydro::Tags::SpecificInternalEnergy<DataType> /*meta*/) const {
+  if constexpr (Region == StarRegion::Exterior) {
+    get(*specific_internal_energy) = 0.;
+  } else {
+    const auto& rest_mass_density =
+        cache->get_var(*this, hydro::Tags::RestMassDensity<DataType>{});
+    *specific_internal_energy =
+        eos.specific_internal_energy_from_density(rest_mass_density);
+  }
+}
+
+template <typename DataType, StarRegion Region>
+void TovVariables<DataType, Region>::operator()(
+    const gsl::not_null<Scalar<DataType>*> metric_time_potential,
+    [[maybe_unused]] const gsl::not_null<Cache*> cache,
+    Tags::MetricTimePotential<DataType> /*meta*/) const {
+  // Compute phi in Eq. (1.73) in BaumgarteShapiro, which is the logarithm of
+  // the lapse:
+  //   lapse = e^phi
+  if constexpr (Region == StarRegion::Exterior) {
+    get(*metric_time_potential) =
+        0.5 * log(1. - 2. * radial_solution.total_mass() / radius);
+  } else {
+    const auto& log_specific_enthalpy =
+        get(cache->get_var(*this, Tags::LogSpecificEnthalpy<DataType>{}));
+    const double log_lapse_at_outer_radius =
+        0.5 * log(1. - 2. * radial_solution.total_mass() /
+                           radial_solution.outer_radius());
+    get(*metric_time_potential) =
+        log_lapse_at_outer_radius - log_specific_enthalpy;
+  }
+}
+
+template <typename DataType, StarRegion Region>
+void TovVariables<DataType, Region>::operator()(
+    const gsl::not_null<Scalar<DataType>*> dr_metric_time_potential,
+    [[maybe_unused]] const gsl::not_null<Cache*> cache,
+    Tags::DrMetricTimePotential<DataType> /*meta*/) const {
+  if constexpr (Region == StarRegion::Exterior) {
+    get(*dr_metric_time_potential) =
+        radial_solution.total_mass() / square(radius) /
+        (1. - 2. * radial_solution.total_mass() / radius);
+  } else if constexpr (Region == StarRegion::Center) {
+    get(*dr_metric_time_potential) = 0.;
+  } else {
+    // Compute dphi/dr from the TOV equations, e.g. Eq. (1.79) in
+    // BaumgarteShapiro.
+    const auto& mass_over_radius =
+        get(cache->get_var(*this, Tags::MassOverRadius<DataType>{}));
+    const auto& pressure =
+        get(cache->get_var(*this, hydro::Tags::Pressure<DataType>{}));
+    get(*dr_metric_time_potential) =
+        (mass_over_radius / radius + 4. * M_PI * pressure * radius) /
+        (1. - 2. * mass_over_radius);
+  }
+}
+
+template <typename DataType, StarRegion Region>
+void TovVariables<DataType, Region>::operator()(
+    const gsl::not_null<Scalar<DataType>*> metric_radial_potential,
+    const gsl::not_null<Cache*> cache,
+    Tags::MetricRadialPotential<DataType> /*meta*/) const {
+  // Compute lambda in Eq. (1.73) in BaumgarteShapiro
+  if constexpr (Region == StarRegion::Exterior) {
+    const auto& metric_time_potential =
+        get(cache->get_var(*this, Tags::MetricTimePotential<DataType>{}));
+    get(*metric_radial_potential) = -metric_time_potential;
+  } else {
+    const auto& mass_over_radius =
+        get(cache->get_var(*this, Tags::MassOverRadius<DataType>{}));
+    // Eq. (1.76) in BaumgarteShapiro (equation in book is missing a sqrt)
+    get(*metric_radial_potential) = -0.5 * log(1. - 2. * mass_over_radius);
+  }
+}
+
+template <typename DataType, StarRegion Region>
+void TovVariables<DataType, Region>::operator()(
+    const gsl::not_null<Scalar<DataType>*> dr_metric_radial_potential,
+    [[maybe_unused]] const gsl::not_null<Cache*> cache,
+    Tags::DrMetricRadialPotential<DataType> /*meta*/) const {
+  if constexpr (Region == StarRegion::Exterior) {
+    const auto& dr_metric_time_potential =
+        get(cache->get_var(*this, Tags::DrMetricTimePotential<DataType>{}));
+    get(*dr_metric_radial_potential) = -dr_metric_time_potential;
+  } else if constexpr (Region == StarRegion::Center) {
+    get(*dr_metric_radial_potential) = 0.;
+  } else {
+    const auto& mass_over_radius =
+        get(cache->get_var(*this, Tags::MassOverRadius<DataType>{}));
+    const auto& specific_enthalpy =
+        get(cache->get_var(*this, hydro::Tags::SpecificEnthalpy<DataType>{}));
+    const auto& rest_mass_density =
+        get(cache->get_var(*this, hydro::Tags::RestMassDensity<DataType>{}));
+    const auto& pressure =
+        get(cache->get_var(*this, hydro::Tags::Pressure<DataType>{}));
+    // Compute dm/dr from the TOV equations, e.g. Eq. (1.77) in
+    // BaumgarteShapiro.
+    get(*dr_metric_radial_potential) =
+        (4. * M_PI * radius *
+             (specific_enthalpy * rest_mass_density - pressure) -
+         mass_over_radius / radius) /
+        (1. - 2. * mass_over_radius);
+  }
+}
+
+template <typename DataType, StarRegion Region>
+void TovVariables<DataType, Region>::operator()(
+    const gsl::not_null<Scalar<DataType>*> metric_angular_potential,
+    const gsl::not_null<Cache*> /*cache*/,
+    Tags::MetricAngularPotential<DataType> /*meta*/) const {
+  get(*metric_angular_potential) = 0.;
+}
+
+template <typename DataType, StarRegion Region>
+void TovVariables<DataType, Region>::operator()(
+    const gsl::not_null<Scalar<DataType>*> dr_metric_angular_potential,
+    const gsl::not_null<Cache*> /*cache*/,
+    Tags::DrMetricAngularPotential<DataType> /*meta*/) const {
+  get(*dr_metric_angular_potential) = 0.;
+}
+
+template <typename DataType, StarRegion Region>
+void TovVariables<DataType, Region>::operator()(
+    const gsl::not_null<Scalar<DataType>*> dr_pressure,
+    [[maybe_unused]] const gsl::not_null<Cache*> cache,
+    Tags::DrPressure<DataType> /*meta*/) const {
+  if constexpr (Region == StarRegion::Exterior) {
+    get(*dr_pressure) = 0.;
+  } else {
+    // Compute dP/dr from the TOV equations, e.g. Eq. (1.78) in
+    // BaumgarteShapiro.
+    const auto& dr_metric_time_potential =
+        get(cache->get_var(*this, Tags::DrMetricTimePotential<DataType>{}));
+    const auto& rest_mass_density =
+        get(cache->get_var(*this, hydro::Tags::RestMassDensity<DataType>{}));
+    const auto& specific_enthalpy =
+        get(cache->get_var(*this, hydro::Tags::SpecificEnthalpy<DataType>{}));
+    get(*dr_pressure) =
+        -dr_metric_time_potential * rest_mass_density * specific_enthalpy;
+  }
+}
+
+template <typename DataType, StarRegion Region>
+void TovVariables<DataType, Region>::operator()(
+    const gsl::not_null<Scalar<DataType>*> lorentz_factor,
+    const gsl::not_null<Cache*> /*cache*/,
+    hydro::Tags::LorentzFactor<DataType> /*meta*/) const {
+  get(*lorentz_factor) = 1.;
+}
+
+template <typename DataType, StarRegion Region>
+void TovVariables<DataType, Region>::operator()(
+    const gsl::not_null<tnsr::I<DataType, 3>*> spatial_velocity,
+    const gsl::not_null<Cache*> /*cache*/,
+    hydro::Tags::SpatialVelocity<DataType, 3> /*meta*/) const {
+  get<0>(*spatial_velocity) = 0.;
+  get<1>(*spatial_velocity) = 0.;
+  get<2>(*spatial_velocity) = 0.;
+}
+
+template <typename DataType, StarRegion Region>
+void TovVariables<DataType, Region>::operator()(
+    const gsl::not_null<tnsr::I<DataType, 3>*> magnetic_field,
+    const gsl::not_null<Cache*> /*cache*/,
+    hydro::Tags::MagneticField<DataType, 3> /*meta*/) const {
+  get<0>(*magnetic_field) = 0.;
+  get<1>(*magnetic_field) = 0.;
+  get<2>(*magnetic_field) = 0.;
+}
+
+template <typename DataType, StarRegion Region>
+void TovVariables<DataType, Region>::operator()(
+    const gsl::not_null<Scalar<DataType>*> div_cleaning_field,
+    const gsl::not_null<Cache*> /*cache*/,
+    hydro::Tags::DivergenceCleaningField<DataType> /*meta*/) const {
+  get(*div_cleaning_field) = 0.;
+}
+
+template <typename DataType, StarRegion Region>
+void TovVariables<DataType, Region>::operator()(
+    const gsl::not_null<Scalar<DataType>*> lapse,
+    const gsl::not_null<Cache*> cache,
+    gr::Tags::Lapse<DataType> /*meta*/) const {
+  const auto& metric_time_potential =
+      get(cache->get_var(*this, Tags::MetricTimePotential<DataType>{}));
+  get(*lapse) = exp(metric_time_potential);
+}
+
+template <typename DataType, StarRegion Region>
+void TovVariables<DataType, Region>::operator()(
+    const gsl::not_null<Scalar<DataType>*> dt_lapse,
+    const gsl::not_null<Cache*> /*cache*/,
+    ::Tags::dt<gr::Tags::Lapse<DataType>> /*meta*/) const {
+  get(*dt_lapse) = 0.;
+}
+
+template <typename DataType, StarRegion Region>
+void TovVariables<DataType, Region>::operator()(
+    const gsl::not_null<tnsr::i<DataType, 3>*> deriv_lapse,
+    [[maybe_unused]] const gsl::not_null<Cache*> cache,
+    ::Tags::deriv<gr::Tags::Lapse<DataType>, tmpl::size_t<3>,
+                  Frame::Inertial> /*meta*/) const {
+  if constexpr (Region == StarRegion::Center) {
+    get<0>(*deriv_lapse) = 0.;
+    get<1>(*deriv_lapse) = 0.;
+    get<2>(*deriv_lapse) = 0.;
+  } else {
+    const auto& lapse = get(cache->get_var(*this, gr::Tags::Lapse<DataType>{}));
+    const auto& dr_metric_time_potential =
+        get(cache->get_var(*this, Tags::DrMetricTimePotential<DataType>{}));
+    // lapse = exp(phi), so dlapse/dr = lapse * dphi/dr * x/r
+    get<0>(*deriv_lapse) = lapse * dr_metric_time_potential / radius;
+    get<1>(*deriv_lapse) = get<0>(*deriv_lapse);
+    get<2>(*deriv_lapse) = get<0>(*deriv_lapse);
+    for (size_t i = 0; i < 3; ++i) {
+      deriv_lapse->get(i) *= coords.get(i);
     }
-    spatial_metric.get(i, i) += exp(2.0 * radial_vars.metric_angular_potential);
   }
-  return spatial_metric;
 }
 
-template <typename RadialSolution>
-template <typename DataType>
-tuples::TaggedTuple<
-    typename TovStar<RadialSolution>::template DerivSpatialMetric<DataType>>
-TovStar<RadialSolution>::variables(
-    const tnsr::I<DataType, 3>& x,
-    tmpl::list<typename TovStar<RadialSolution>::template DerivSpatialMetric<
-        DataType>> /*meta*/,
-    const RadialVariables<DataType>& radial_vars) const {
-  tnsr::ijj<DataType, 3, Frame::Inertial> deriv_spatial_metric{
-      2.0 *
-      (exp(2.0 * radial_vars.metric_radial_potential) *
-           (radial_vars.dr_metric_radial_potential -
-            1.0 / radial_vars.radial_coordinate) -
-       exp(2.0 * radial_vars.metric_angular_potential) *
-           (radial_vars.dr_metric_angular_potential -
-            1.0 / radial_vars.radial_coordinate)) /
-      cube(radial_vars.radial_coordinate)};
-  for (size_t k = 0; k < 3; ++k) {
+template <typename DataType, StarRegion Region>
+void TovVariables<DataType, Region>::operator()(
+    const gsl::not_null<tnsr::I<DataType, 3>*> shift,
+    const gsl::not_null<Cache*> /*cache*/,
+    gr::Tags::Shift<3, Frame::Inertial, DataType> /*meta*/) const {
+  get<0>(*shift) = 0.;
+  get<1>(*shift) = 0.;
+  get<2>(*shift) = 0.;
+}
+
+template <typename DataType, StarRegion Region>
+void TovVariables<DataType, Region>::operator()(
+    const gsl::not_null<tnsr::I<DataType, 3>*> dt_shift,
+    const gsl::not_null<Cache*> /*cache*/,
+    ::Tags::dt<gr::Tags::Shift<3, Frame::Inertial, DataType>> /*meta*/) const {
+  get<0>(*dt_shift) = 0.;
+  get<1>(*dt_shift) = 0.;
+  get<2>(*dt_shift) = 0.;
+}
+
+template <typename DataType, StarRegion Region>
+void TovVariables<DataType, Region>::operator()(
+    const gsl::not_null<tnsr::iJ<DataType, 3>*> deriv_shift,
+    const gsl::not_null<Cache*> /*cache*/,
+    ::Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataType>,
+                  tmpl::size_t<3>, Frame::Inertial> /*meta*/) const {
+  *deriv_shift = make_with_value<tnsr::iJ<DataType, 3>>(coords, 0.);
+}
+
+template <typename DataType, StarRegion Region>
+void TovVariables<DataType, Region>::operator()(
+    const gsl::not_null<tnsr::ii<DataType, 3>*> spatial_metric,
+    const gsl::not_null<Cache*> cache,
+    gr::Tags::SpatialMetric<3, Frame::Inertial, DataType> /*meta*/) const {
+  if constexpr (Region == StarRegion::Center) {
+    const auto& metric_angular_potential =
+        get(cache->get_var(*this, Tags::MetricAngularPotential<DataType>{}));
+    get<0, 0>(*spatial_metric) = exp(2. * metric_angular_potential);
+    get<1, 1>(*spatial_metric) = get<0, 0>(*spatial_metric);
+    get<2, 2>(*spatial_metric) = get<0, 0>(*spatial_metric);
+    get<0, 1>(*spatial_metric) = 0.;
+    get<0, 2>(*spatial_metric) = 0.;
+    get<1, 2>(*spatial_metric) = 0.;
+  } else {
+    const auto& metric_radial_potential =
+        get(cache->get_var(*this, Tags::MetricRadialPotential<DataType>{}));
+    const auto& metric_angular_potential =
+        get(cache->get_var(*this, Tags::MetricAngularPotential<DataType>{}));
+    *spatial_metric = tnsr::ii<DataType, 3, Frame::Inertial>{
+        (exp(2. * metric_radial_potential) -
+         exp(2. * metric_angular_potential)) /
+        square(radius)};
     for (size_t i = 0; i < 3; ++i) {
       for (size_t j = i; j < 3; ++j) {
-        deriv_spatial_metric.get(k, i, j) *= x.get(k) * x.get(i) * x.get(j);
-        if (k == i) {
-          deriv_spatial_metric.get(k, i, j) +=
-              (exp(2.0 * radial_vars.metric_radial_potential) -
-               exp(2.0 * radial_vars.metric_angular_potential)) /
-              square(radial_vars.radial_coordinate) * x.get(j);
-        }
-        if (k == j) {
-          deriv_spatial_metric.get(k, i, j) +=
-              (exp(2.0 * radial_vars.metric_radial_potential) -
-               exp(2.0 * radial_vars.metric_angular_potential)) /
-              square(radial_vars.radial_coordinate) * x.get(i);
-        }
-        if (i == j) {
-          deriv_spatial_metric.get(k, i, j) +=
-              2.0 * exp(2.0 * radial_vars.metric_angular_potential) *
-              radial_vars.dr_metric_angular_potential * x.get(k) /
-              radial_vars.radial_coordinate;
+        spatial_metric->get(i, j) *= coords.get(i) * coords.get(j);
+      }
+      spatial_metric->get(i, i) += exp(2. * metric_angular_potential);
+    }
+  }
+}
+
+template <typename DataType, StarRegion Region>
+void TovVariables<DataType, Region>::operator()(
+    const gsl::not_null<tnsr::ii<DataType, 3>*> dt_spatial_metric,
+    const gsl::not_null<Cache*> /*cache*/,
+    ::Tags::dt<gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>> /*meta*/)
+    const {
+  *dt_spatial_metric = make_with_value<tnsr::ii<DataType, 3>>(coords, 0.);
+}
+
+template <typename DataType, StarRegion Region>
+void TovVariables<DataType, Region>::operator()(
+    const gsl::not_null<tnsr::ijj<DataType, 3>*> deriv_spatial_metric,
+    [[maybe_unused]] const gsl::not_null<Cache*> cache,
+    ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>,
+                  tmpl::size_t<3>, Frame::Inertial> /*meta*/) const {
+  if constexpr (Region == StarRegion::Center) {
+    *deriv_spatial_metric = make_with_value<tnsr::ijj<DataType, 3>>(coords, 0.);
+  } else {
+    const auto& metric_radial_potential =
+        get(cache->get_var(*this, Tags::MetricRadialPotential<DataType>{}));
+    const auto& dr_metric_radial_potential =
+        get(cache->get_var(*this, Tags::DrMetricRadialPotential<DataType>{}));
+    const auto& metric_angular_potential =
+        get(cache->get_var(*this, Tags::MetricAngularPotential<DataType>{}));
+    const auto& dr_metric_angular_potential =
+        get(cache->get_var(*this, Tags::DrMetricAngularPotential<DataType>{}));
+    *deriv_spatial_metric = tnsr::ijj<DataType, 3, Frame::Inertial>{
+        2.0 *
+        (exp(2.0 * metric_radial_potential) *
+             (dr_metric_radial_potential - 1.0 / radius) -
+         exp(2.0 * metric_angular_potential) *
+             (dr_metric_angular_potential - 1.0 / radius)) /
+        cube(radius)};
+    for (size_t k = 0; k < 3; ++k) {
+      for (size_t i = 0; i < 3; ++i) {
+        for (size_t j = i; j < 3; ++j) {
+          deriv_spatial_metric->get(k, i, j) *=
+              coords.get(k) * coords.get(i) * coords.get(j);
+          if (k == i) {
+            deriv_spatial_metric->get(k, i, j) +=
+                (exp(2.0 * metric_radial_potential) -
+                 exp(2.0 * metric_angular_potential)) /
+                square(radius) * coords.get(j);
+          }
+          if (k == j) {
+            deriv_spatial_metric->get(k, i, j) +=
+                (exp(2.0 * metric_radial_potential) -
+                 exp(2.0 * metric_angular_potential)) /
+                square(radius) * coords.get(i);
+          }
+          if (i == j) {
+            deriv_spatial_metric->get(k, i, j) +=
+                2.0 * exp(2.0 * metric_angular_potential) *
+                dr_metric_angular_potential * coords.get(k) / radius;
+          }
         }
       }
     }
   }
-  return deriv_spatial_metric;
 }
 
-template <typename RadialSolution>
-template <typename DataType>
-tuples::TaggedTuple<gr::Tags::SqrtDetSpatialMetric<DataType>>
-TovStar<RadialSolution>::variables(
-    const tnsr::I<DataType, 3>& /*x*/,
-    tmpl::list<gr::Tags::SqrtDetSpatialMetric<DataType>> /*meta*/,
-    const RadialVariables<DataType>& radial_vars) const {
-  return Scalar<DataType>{exp(radial_vars.metric_radial_potential +
-                              2.0 * radial_vars.metric_angular_potential)};
+template <typename DataType, StarRegion Region>
+void TovVariables<DataType, Region>::operator()(
+    const gsl::not_null<Scalar<DataType>*> sqrt_det_spatial_metric,
+    const gsl::not_null<Cache*> cache,
+    gr::Tags::SqrtDetSpatialMetric<DataType> /*meta*/) const {
+  const auto& metric_radial_potential =
+      get(cache->get_var(*this, Tags::MetricRadialPotential<DataType>{}));
+  const auto& metric_angular_potential =
+      get(cache->get_var(*this, Tags::MetricAngularPotential<DataType>{}));
+  get(*sqrt_det_spatial_metric) =
+      exp(metric_radial_potential + 2.0 * metric_angular_potential);
 }
 
-template <typename RadialSolution>
-template <typename DataType>
-tuples::TaggedTuple<
-    gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataType>>
-TovStar<RadialSolution>::variables(
-    const tnsr::I<DataType, 3>& x,
-    tmpl::list<
-        gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataType>> /*meta*/,
-    const RadialVariables<DataType>& radial_vars) const {
-  tnsr::II<DataType, 3, Frame::Inertial> g{
-      exp(-2.0 * radial_vars.metric_radial_potential) -
-      exp(-2.0 * radial_vars.metric_angular_potential)};
-  for (size_t d0 = 0; d0 < 3; ++d0) {
-    for (size_t d1 = d0; d1 < 3; ++d1) {
-      g.get(d0, d1) *=
-          x.get(d0) * x.get(d1) / square(radial_vars.radial_coordinate);
+template <typename DataType, StarRegion Region>
+void TovVariables<DataType, Region>::operator()(
+    const gsl::not_null<tnsr::II<DataType, 3>*> inv_spatial_metric,
+    const gsl::not_null<Cache*> cache,
+    gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataType> /*meta*/)
+    const {
+  if constexpr (Region == StarRegion::Center) {
+    const auto& metric_angular_potential =
+        get(cache->get_var(*this, Tags::MetricAngularPotential<DataType>{}));
+    get<0, 0>(*inv_spatial_metric) = exp(-2. * metric_angular_potential);
+    get<1, 1>(*inv_spatial_metric) = get<0, 0>(*inv_spatial_metric);
+    get<2, 2>(*inv_spatial_metric) = get<0, 0>(*inv_spatial_metric);
+    get<0, 1>(*inv_spatial_metric) = 0.;
+    get<0, 2>(*inv_spatial_metric) = 0.;
+    get<1, 2>(*inv_spatial_metric) = 0.;
+  } else {
+    const auto& metric_radial_potential =
+        get(cache->get_var(*this, Tags::MetricRadialPotential<DataType>{}));
+    const auto& metric_angular_potential =
+        get(cache->get_var(*this, Tags::MetricAngularPotential<DataType>{}));
+    *inv_spatial_metric = tnsr::II<DataType, 3, Frame::Inertial>{
+        (exp(-2. * metric_radial_potential) -
+         exp(-2. * metric_angular_potential)) /
+        square(radius)};
+    for (size_t d0 = 0; d0 < 3; ++d0) {
+      for (size_t d1 = d0; d1 < 3; ++d1) {
+        inv_spatial_metric->get(d0, d1) *= coords.get(d0) * coords.get(d1);
+      }
+      inv_spatial_metric->get(d0, d0) += exp(-2.0 * metric_angular_potential);
     }
-    g.get(d0, d0) += exp(-2.0 * radial_vars.metric_angular_potential);
   }
-  return g;
 }
 
-template <typename RadialSolution>
-template <typename DataType>
-tuples::TaggedTuple<gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataType>>
-TovStar<RadialSolution>::variables(
-    const tnsr::I<DataType, 3>& x,
-    tmpl::list<
-        gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataType>> /*meta*/,
-    const RadialVariables<DataType>& /*radial_vars*/) const {
-  return make_with_value<tnsr::ii<DataType, 3>>(x, 0.0);
+template <typename DataType, StarRegion Region>
+void TovVariables<DataType, Region>::operator()(
+    const gsl::not_null<tnsr::ii<DataType, 3>*> extrinsic_curvature,
+    const gsl::not_null<Cache*> /*cache*/,
+    gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataType> /*meta*/) const {
+  *extrinsic_curvature = make_with_value<tnsr::ii<DataType, 3>>(coords, 0.);
 }
 
-template <typename RadialSolution>
-template <typename DataType, typename Tag>
-tuples::TaggedTuple<::Tags::dt<Tag>> TovStar<RadialSolution>::variables(
-    const tnsr::I<DataType, 3>& x, tmpl::list<::Tags::dt<Tag>> /*meta*/,
-    const RadialVariables<DataType>& /*radial_vars*/) const {
-  return make_with_value<typename ::Tags::dt<Tag>::type>(get<0>(x), 0.0);
-}
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif  // defined(__GNUC__) && !defined(__clang__)
+}  // namespace tov_detail
 
-template <typename RadialSolution>
-PUP::able::PUP_ID TovStar<RadialSolution>::my_PUP_ID = 0;
+PUP::able::PUP_ID TovStar::my_PUP_ID = 0;
 
-template <typename LocalRadialSolution>
-bool operator==(const TovStar<LocalRadialSolution>& lhs,
-                const TovStar<LocalRadialSolution>& rhs) {
+bool operator==(const TovStar& lhs, const TovStar& rhs) {
   // there is no comparison operator for the EoS, but should be okay as
   // the `polytropic_exponent`s and `polytropic_constant`s are compared
   return lhs.central_rest_mass_density_ == rhs.central_rest_mass_density_ and
@@ -308,152 +533,21 @@ bool operator==(const TovStar<LocalRadialSolution>& lhs,
          lhs.polytropic_exponent_ == rhs.polytropic_exponent_;
 }
 
-template <typename RadialSolution>
-bool operator!=(const TovStar<RadialSolution>& lhs,
-                const TovStar<RadialSolution>& rhs) {
+bool operator!=(const TovStar& lhs, const TovStar& rhs) {
   return not(lhs == rhs);
 }
 
-#define STYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
-#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
-#define INSTANTIATE_VARS(_, data)                                              \
-  template tuples::TaggedTuple<hydro::Tags::RestMassDensity<DTYPE(data)>>      \
-  TovStar<STYPE(data)>::variables(                                             \
-      const tnsr::I<DTYPE(data), 3>& x,                                        \
-      tmpl::list<hydro::Tags::RestMassDensity<DTYPE(data)>> /*meta*/,          \
-      const RadialVariables<DTYPE(data)>& radial_vars) const;                  \
-  template tuples::TaggedTuple<hydro::Tags::SpecificEnthalpy<DTYPE(data)>>     \
-  TovStar<STYPE(data)>::variables(                                             \
-      const tnsr::I<DTYPE(data), 3>& x,                                        \
-      tmpl::list<hydro::Tags::SpecificEnthalpy<DTYPE(data)>> meta,             \
-      const RadialVariables<DTYPE(data)>& radial_vars) const;                  \
-  template tuples::TaggedTuple<hydro::Tags::Pressure<DTYPE(data)>>             \
-  TovStar<STYPE(data)>::variables(                                             \
-      const tnsr::I<DTYPE(data), 3>& x,                                        \
-      tmpl::list<hydro::Tags::Pressure<DTYPE(data)>> /*meta*/,                 \
-      const RadialVariables<DTYPE(data)>& radial_vars) const;                  \
-  template tuples::TaggedTuple<                                                \
-      hydro::Tags::SpecificInternalEnergy<DTYPE(data)>>                        \
-  TovStar<STYPE(data)>::variables(                                             \
-      const tnsr::I<DTYPE(data), 3>& x,                                        \
-      tmpl::list<hydro::Tags::SpecificInternalEnergy<DTYPE(data)>> /*meta*/,   \
-      const RadialVariables<DTYPE(data)>& radial_vars) const;                  \
-  template tuples::TaggedTuple<hydro::Tags::LorentzFactor<DTYPE(data)>>        \
-  TovStar<STYPE(data)>::variables(                                             \
-      const tnsr::I<DTYPE(data), 3>& x,                                        \
-      tmpl::list<hydro::Tags::LorentzFactor<DTYPE(data)>> /*meta*/,            \
-      const RadialVariables<DTYPE(data)>& radial_vars) const;                  \
-  template tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DTYPE(data), 3>>   \
-  TovStar<STYPE(data)>::variables(                                             \
-      const tnsr::I<DTYPE(data), 3>& x,                                        \
-      tmpl::list<hydro::Tags::SpatialVelocity<DTYPE(data), 3>> /*meta*/,       \
-      const RadialVariables<DTYPE(data)>& radial_vars) const;                  \
-  template tuples::TaggedTuple<hydro::Tags::MagneticField<DTYPE(data), 3>>     \
-  TovStar<STYPE(data)>::variables(                                             \
-      const tnsr::I<DTYPE(data), 3>& x,                                        \
-      tmpl::list<hydro::Tags::MagneticField<DTYPE(data), 3>> /*meta*/,         \
-      const RadialVariables<DTYPE(data)>& radial_vars) const;                  \
-  template tuples::TaggedTuple<                                                \
-      hydro::Tags::DivergenceCleaningField<DTYPE(data)>>                       \
-  TovStar<STYPE(data)>::variables(                                             \
-      const tnsr::I<DTYPE(data), 3>& x,                                        \
-      tmpl::list<hydro::Tags::DivergenceCleaningField<DTYPE(data)>> /*meta*/,  \
-      const RadialVariables<DTYPE(data)>& radial_vars) const;                  \
-  template tuples::TaggedTuple<gr::Tags::Lapse<DTYPE(data)>>                   \
-  TovStar<STYPE(data)>::variables(                                             \
-      const tnsr::I<DTYPE(data), 3>& /*x*/,                                    \
-      tmpl::list<gr::Tags::Lapse<DTYPE(data)>> /*meta*/,                       \
-      const RadialVariables<DTYPE(data)>& radial_vars) const;                  \
-  template tuples::TaggedTuple<                                                \
-      typename TovStar<STYPE(data)>::template DerivLapse<DTYPE(data)>>         \
-  TovStar<STYPE(data)>::variables(                                             \
-      const tnsr::I<DTYPE(data), 3>& x,                                        \
-      tmpl::list<typename TovStar<STYPE(data)>::template DerivLapse<DTYPE(     \
-          data)>> /*meta*/,                                                    \
-      const RadialVariables<DTYPE(data)>& radial_vars) const;                  \
-  template tuples::TaggedTuple<                                                \
-      gr::Tags::Shift<3, Frame::Inertial, DTYPE(data)>>                        \
-  TovStar<STYPE(data)>::variables(                                             \
-      const tnsr::I<DTYPE(data), 3>& /*x*/,                                    \
-      tmpl::list<gr::Tags::Shift<3, Frame::Inertial, DTYPE(data)>> /*meta*/,   \
-      const RadialVariables<DTYPE(data)>& radial_vars) const;                  \
-  template tuples::TaggedTuple<                                                \
-      typename TovStar<STYPE(data)>::template DerivShift<DTYPE(data)>>         \
-  TovStar<STYPE(data)>::variables(                                             \
-      const tnsr::I<DTYPE(data), 3>& x,                                        \
-      tmpl::list<typename TovStar<STYPE(data)>::template DerivShift<DTYPE(     \
-          data)>> /*meta*/,                                                    \
-      const RadialVariables<DTYPE(data)>& radial_vars) const;                  \
-  template tuples::TaggedTuple<                                                \
-      gr::Tags::SpatialMetric<3, Frame::Inertial, DTYPE(data)>>                \
-  TovStar<STYPE(data)>::variables(                                             \
-      const tnsr::I<DTYPE(data), 3>& /*x*/,                                    \
-      tmpl::list<                                                              \
-          gr::Tags::SpatialMetric<3, Frame::Inertial, DTYPE(data)>> /*meta*/,  \
-      const RadialVariables<DTYPE(data)>& radial_vars) const;                  \
-  template tuples::TaggedTuple<                                                \
-      typename TovStar<STYPE(data)>::template DerivSpatialMetric<DTYPE(data)>> \
-  TovStar<STYPE(data)>::variables(                                             \
-      const tnsr::I<DTYPE(data), 3>& x,                                        \
-      tmpl::list<typename TovStar<STYPE(                                       \
-          data)>::template DerivSpatialMetric<DTYPE(data)>> /*meta*/,          \
-      const RadialVariables<DTYPE(data)>& radial_vars) const;                  \
-  template tuples::TaggedTuple<gr::Tags::SqrtDetSpatialMetric<DTYPE(data)>>    \
-  TovStar<STYPE(data)>::variables(                                             \
-      const tnsr::I<DTYPE(data), 3>& /*x*/,                                    \
-      tmpl::list<gr::Tags::SqrtDetSpatialMetric<DTYPE(data)>> /*meta*/,        \
-      const RadialVariables<DTYPE(data)>& radial_vars) const;                  \
-  template tuples::TaggedTuple<                                                \
-      gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DTYPE(data)>>         \
-  TovStar<STYPE(data)>::variables(                                             \
-      const tnsr::I<DTYPE(data), 3>& /*x*/,                                    \
-      tmpl::list<gr::Tags::InverseSpatialMetric<3, Frame::Inertial,            \
-                                                DTYPE(data)>> /*meta*/,        \
-      const RadialVariables<DTYPE(data)>& radial_vars) const;                  \
-  template tuples::TaggedTuple<                                                \
-      gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DTYPE(data)>>           \
-  TovStar<STYPE(data)>::variables(                                             \
-      const tnsr::I<DTYPE(data), 3>& /*x*/,                                    \
-      tmpl::list<gr::Tags::ExtrinsicCurvature<3, Frame::Inertial,              \
-                                              DTYPE(data)>> /*meta*/,          \
-      const RadialVariables<DTYPE(data)>& radial_vars) const;
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define REGION(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define INSTANTIATE(_, data) \
+  template class tov_detail::TovVariables<DTYPE(data), REGION(data)>;
 
-#define INSTANTIATE_DT_VARS(_, data)                                           \
-  template tuples::TaggedTuple<::Tags::dt<gr::Tags::Lapse<DTYPE(data)>>>       \
-  TovStar<STYPE(data)>::variables(                                             \
-      const tnsr::I<DTYPE(data), 3>& x,                                        \
-      tmpl::list<::Tags::dt<gr::Tags::Lapse<DTYPE(data)>>> /*meta*/,           \
-      const RadialVariables<DTYPE(data)>& /*radial_vars*/) const;              \
-  template tuples::TaggedTuple<                                                \
-      ::Tags::dt<gr::Tags::Shift<3, Frame::Inertial, DTYPE(data)>>>            \
-  TovStar<STYPE(data)>::variables(                                             \
-      const tnsr::I<DTYPE(data), 3>& x,                                        \
-      tmpl::list<::Tags::dt<                                                   \
-          gr::Tags::Shift<3, Frame::Inertial, DTYPE(data)>>> /*meta*/,         \
-      const RadialVariables<DTYPE(data)>& /*radial_vars*/) const;              \
-  template tuples::TaggedTuple<                                                \
-      ::Tags::dt<gr::Tags::SpatialMetric<3, Frame::Inertial, DTYPE(data)>>>    \
-  TovStar<STYPE(data)>::variables(                                             \
-      const tnsr::I<DTYPE(data), 3>& x,                                        \
-      tmpl::list<::Tags::dt<                                                   \
-          gr::Tags::SpatialMetric<3, Frame::Inertial, DTYPE(data)>>> /*meta*/, \
-      const RadialVariables<DTYPE(data)>& /*radial_vars*/) const;
-
-#define INSTANTIATE(_, data)                                 \
-  template class TovStar<STYPE(data)>;                       \
-  template bool operator==(const TovStar<STYPE(data)>& lhs,  \
-                           const TovStar<STYPE(data)>& rhs); \
-  template bool operator!=(const TovStar<STYPE(data)>& lhs,  \
-                           const TovStar<STYPE(data)>& rhs);
-
-GENERATE_INSTANTIATIONS(INSTANTIATE_VARS, (gr::Solutions::TovSolution),
-                        (double, DataVector))
-GENERATE_INSTANTIATIONS(INSTANTIATE_DT_VARS, (gr::Solutions::TovSolution),
-                        (double, DataVector))
-GENERATE_INSTANTIATIONS(INSTANTIATE, (gr::Solutions::TovSolution))
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector),
+                        (tov_detail::StarRegion::Center,
+                         tov_detail::StarRegion::Interior,
+                         tov_detail::StarRegion::Exterior))
 
 #undef DTYPE
-#undef STYPE
+#undef REGION
 #undef INSTANTIATE
-#undef INSTANTIATE_VARS
 }  // namespace RelativisticEuler::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.cpp
@@ -144,8 +144,7 @@ void TovVariables<DataType, Region>::operator()(
     const auto& log_specific_enthalpy =
         get(cache->get_var(*this, Tags::LogSpecificEnthalpy<DataType>{}));
     const double log_lapse_at_outer_radius =
-        0.5 * log(1. - 2. * radial_solution.total_mass() /
-                           radial_solution.outer_radius());
+        log(radial_solution.injection_energy());
     get(*metric_time_potential) =
         log_lapse_at_outer_radius - log_specific_enthalpy;
   }

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp
@@ -3,19 +3,24 @@
 
 #pragma once
 
-#include <boost/preprocessor/list/for_each.hpp>
-#include <boost/preprocessor/tuple/to_list.hpp>
+#include <cstddef>
 #include <limits>
 
-#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/CachedTempBuffer.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Tov.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Solutions.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"  // IWYU pragma: keep
-#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -26,12 +31,205 @@ class er;  // IWYU pragma: keep
 }  // namespace PUP
 /// \endcond
 
-// IWYU pragma: no_include <pup.h>
+namespace RelativisticEuler::Solutions {
+namespace tov_detail {
 
-// IWYU pragma: no_include "Utilities/GenerateInstantiations.hpp"
+enum class StarRegion { Center, Interior, Exterior };
 
-namespace RelativisticEuler {
-namespace Solutions {
+namespace Tags {
+template <typename DataType>
+struct MassOverRadius : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+template <typename DataType>
+struct LogSpecificEnthalpy : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+template <typename DataType>
+struct DrPressure : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+template <typename DataType>
+struct MetricTimePotential : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+template <typename DataType>
+struct DrMetricTimePotential : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+template <typename DataType>
+struct MetricRadialPotential : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+template <typename DataType>
+struct DrMetricRadialPotential : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+template <typename DataType>
+struct MetricAngularPotential : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+template <typename DataType>
+struct DrMetricAngularPotential : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+}  // namespace Tags
+
+template <typename DataType>
+using TovVariablesCache = cached_temp_buffer_from_typelist<tmpl::list<
+    Tags::MassOverRadius<DataType>, Tags::LogSpecificEnthalpy<DataType>,
+    hydro::Tags::SpecificEnthalpy<DataType>,
+    hydro::Tags::RestMassDensity<DataType>, hydro::Tags::Pressure<DataType>,
+    Tags::DrPressure<DataType>, hydro::Tags::SpecificInternalEnergy<DataType>,
+    Tags::MetricTimePotential<DataType>, Tags::DrMetricTimePotential<DataType>,
+    Tags::MetricRadialPotential<DataType>,
+    Tags::DrMetricRadialPotential<DataType>,
+    Tags::MetricAngularPotential<DataType>,
+    Tags::DrMetricAngularPotential<DataType>,
+    hydro::Tags::LorentzFactor<DataType>,
+    hydro::Tags::SpatialVelocity<DataType, 3>,
+    hydro::Tags::MagneticField<DataType, 3>,
+    hydro::Tags::DivergenceCleaningField<DataType>, gr::Tags::Lapse<DataType>,
+    ::Tags::dt<gr::Tags::Lapse<DataType>>,
+    ::Tags::deriv<gr::Tags::Lapse<DataType>, tmpl::size_t<3>, Frame::Inertial>,
+    gr::Tags::Shift<3, Frame::Inertial, DataType>,
+    ::Tags::dt<gr::Tags::Shift<3, Frame::Inertial, DataType>>,
+    ::Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataType>,
+                  tmpl::size_t<3>, Frame::Inertial>,
+    gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>,
+    ::Tags::dt<gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>>,
+    ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>,
+                  tmpl::size_t<3>, Frame::Inertial>,
+    gr::Tags::SqrtDetSpatialMetric<DataType>,
+    gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataType>,
+    gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataType>>>;
+
+template <typename DataType, StarRegion Region>
+struct TovVariables {
+  static constexpr size_t Dim = 3;
+  using Cache = TovVariablesCache<DataType>;
+
+  TovVariables(const TovVariables&) = default;
+  TovVariables& operator=(const TovVariables&) = default;
+  TovVariables(TovVariables&&) = default;
+  TovVariables& operator=(TovVariables&&) = default;
+  virtual ~TovVariables() = default;
+
+  TovVariables(const tnsr::I<DataType, 3>& local_coords,
+               const DataType& local_radius,
+               const gr::Solutions::TovSolution& local_radial_solution,
+               const EquationsOfState::PolytropicFluid<true>& local_eos)
+      : coords(local_coords),
+        radius(local_radius),
+        radial_solution(local_radial_solution),
+        eos(local_eos) {}
+
+  const tnsr::I<DataType, 3>& coords;
+  const DataType& radius;
+  const gr::Solutions::TovSolution& radial_solution;
+  const EquationsOfState::PolytropicFluid<true>& eos;
+
+  void operator()(gsl::not_null<Scalar<DataType>*> mass_over_radius,
+                  gsl::not_null<Cache*> cache,
+                  Tags::MassOverRadius<DataType> /*meta*/) const;
+  void operator()(gsl::not_null<Scalar<DataType>*> log_specific_enthalpy,
+                  gsl::not_null<Cache*> cache,
+                  Tags::LogSpecificEnthalpy<DataType> /*meta*/) const;
+  void operator()(gsl::not_null<Scalar<DataType>*> specific_enthalpy,
+                  gsl::not_null<Cache*> cache,
+                  hydro::Tags::SpecificEnthalpy<DataType> /*meta*/) const;
+  void operator()(gsl::not_null<Scalar<DataType>*> rest_mass_density,
+                  gsl::not_null<Cache*> cache,
+                  hydro::Tags::RestMassDensity<DataType> /*meta*/) const;
+  void operator()(gsl::not_null<Scalar<DataType>*> pressure,
+                  gsl::not_null<Cache*> cache,
+                  hydro::Tags::Pressure<DataType> /*meta*/) const;
+  void operator()(gsl::not_null<Scalar<DataType>*> dr_pressure,
+                  gsl::not_null<Cache*> cache,
+                  Tags::DrPressure<DataType> /*meta*/) const;
+  void operator()(gsl::not_null<Scalar<DataType>*> specific_internal_energy,
+                  gsl::not_null<Cache*> cache,
+                  hydro::Tags::SpecificInternalEnergy<DataType> /*meta*/) const;
+  void operator()(gsl::not_null<Scalar<DataType>*> metric_time_potential,
+                  gsl::not_null<Cache*> cache,
+                  Tags::MetricTimePotential<DataType> /*meta*/) const;
+  void operator()(gsl::not_null<Scalar<DataType>*> dr_metric_time_potential,
+                  gsl::not_null<Cache*> cache,
+                  Tags::DrMetricTimePotential<DataType> /*meta*/) const;
+  void operator()(gsl::not_null<Scalar<DataType>*> metric_radial_potential,
+                  gsl::not_null<Cache*> cache,
+                  Tags::MetricRadialPotential<DataType> /*meta*/) const;
+  void operator()(gsl::not_null<Scalar<DataType>*> dr_metric_radial_potential,
+                  gsl::not_null<Cache*> cache,
+                  Tags::DrMetricRadialPotential<DataType> /*meta*/) const;
+  void operator()(gsl::not_null<Scalar<DataType>*> metric_angular_potential,
+                  gsl::not_null<Cache*> cache,
+                  Tags::MetricAngularPotential<DataType> /*meta*/) const;
+  void operator()(gsl::not_null<Scalar<DataType>*> dr_metric_angular_potential,
+                  gsl::not_null<Cache*> cache,
+                  Tags::DrMetricAngularPotential<DataType> /*meta*/) const;
+  void operator()(gsl::not_null<Scalar<DataType>*> lorentz_factor,
+                  gsl::not_null<Cache*> cache,
+                  hydro::Tags::LorentzFactor<DataType> /*meta*/) const;
+  void operator()(gsl::not_null<tnsr::I<DataType, 3>*> spatial_velocity,
+                  gsl::not_null<Cache*> cache,
+                  hydro::Tags::SpatialVelocity<DataType, 3> /*meta*/) const;
+  virtual void operator()(
+      gsl::not_null<tnsr::I<DataType, 3>*> magnetic_field,
+      gsl::not_null<Cache*> cache,
+      hydro::Tags::MagneticField<DataType, 3> /*meta*/) const;
+  void operator()(
+      gsl::not_null<Scalar<DataType>*> div_cleaning_field,
+      gsl::not_null<Cache*> cache,
+      hydro::Tags::DivergenceCleaningField<DataType> /*meta*/) const;
+  void operator()(gsl::not_null<Scalar<DataType>*> lapse,
+                  gsl::not_null<Cache*> cache,
+                  gr::Tags::Lapse<DataType> /*meta*/) const;
+  void operator()(gsl::not_null<Scalar<DataType>*> dt_lapse,
+                  gsl::not_null<Cache*> cache,
+                  ::Tags::dt<gr::Tags::Lapse<DataType>> /*meta*/) const;
+  void operator()(gsl::not_null<tnsr::i<DataType, 3>*> deriv_lapse,
+                  gsl::not_null<Cache*> cache,
+                  ::Tags::deriv<gr::Tags::Lapse<DataType>, tmpl::size_t<3>,
+                                Frame::Inertial> /*meta*/) const;
+  void operator()(gsl::not_null<tnsr::I<DataType, 3>*> shift,
+                  gsl::not_null<Cache*> cache,
+                  gr::Tags::Shift<3, Frame::Inertial, DataType> /*meta*/) const;
+  void operator()(
+      gsl::not_null<tnsr::I<DataType, 3>*> dt_shift,
+      gsl::not_null<Cache*> cache,
+      ::Tags::dt<gr::Tags::Shift<3, Frame::Inertial, DataType>> /*meta*/) const;
+  void operator()(
+      gsl::not_null<tnsr::iJ<DataType, 3>*> deriv_shift,
+      gsl::not_null<Cache*> cache,
+      ::Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataType>,
+                    tmpl::size_t<3>, Frame::Inertial> /*meta*/) const;
+  void operator()(
+      gsl::not_null<tnsr::ii<DataType, 3>*> spatial_metric,
+      gsl::not_null<Cache*> cache,
+      gr::Tags::SpatialMetric<3, Frame::Inertial, DataType> /*meta*/) const;
+  void operator()(gsl::not_null<tnsr::ii<DataType, 3>*> dt_spatial_metric,
+                  gsl::not_null<Cache*> cache,
+                  ::Tags::dt<gr::Tags::SpatialMetric<3, Frame::Inertial,
+                                                     DataType>> /*meta*/) const;
+  void operator()(
+      gsl::not_null<tnsr::ijj<DataType, 3>*> deriv_spatial_metric,
+      gsl::not_null<Cache*> cache,
+      ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>,
+                    tmpl::size_t<3>, Frame::Inertial> /*meta*/) const;
+  void operator()(gsl::not_null<Scalar<DataType>*> sqrt_det_spatial_metric,
+                  gsl::not_null<Cache*> cache,
+                  gr::Tags::SqrtDetSpatialMetric<DataType> /*meta*/) const;
+  void operator()(gsl::not_null<tnsr::ii<DataType, 3>*> extrinsic_curvature,
+                  gsl::not_null<Cache*> cache,
+                  gr::Tags::ExtrinsicCurvature<3, Frame::Inertial,
+                                               DataType> /*meta*/) const;
+  void operator()(gsl::not_null<tnsr::II<DataType, 3>*> inv_spatial_metric,
+                  gsl::not_null<Cache*> cache,
+                  gr::Tags::InverseSpatialMetric<3, Frame::Inertial,
+                                                 DataType> /*meta*/) const;
+};
+}  // namespace tov_detail
 
 /*!
  * \brief A static spherically symmetric star
@@ -40,81 +238,38 @@ namespace Solutions {
  * solving the Tolman-Oppenheimer-Volkoff (TOV) equations.  The equation of
  * state is assumed to be that of a polytropic fluid.
  *
- * \tparam RadialSolution selects not only how the TOV equations are solved, but
- * also the radial coordinate that the solution is given in (e.g. areal or
- * isotropic).  See the documentation of the specific `RadialSolution`s for
- * more details.
+ * If the spherically symmetric metric is written as
+ *
+ * \f[
+ * ds^2 = - e^{2 \Phi_t} dt^2 + e^{2 \Phi_r} dr^2 + e^{2 \Phi_\Omega} r^2
+ * d\Omega^2
+ * \f]
+ *
+ * where \f$r = \delta_{mn} x^m x^n\f$ is the radial coordinate and
+ * \f$\Phi_t\f$, \f$\Phi_r\f$, and \f$\Phi_\Omega\f$ are the metric potentials,
+ * then the lapse, shift, and spatial metric in Cartesian coordinates are
+ *
+ * \f{align*}
+ * \alpha &= e^{\Phi_t} \\
+ * \beta^i &= 0 \\
+ * \gamma_{ij} &= \delta_{ij} e^{2 \Phi_r} + \delta_{im} \delta_{jn}
+ * \frac{x^m x^n}{r^2} \left( e^{2 \Phi_r} - e^{2 \Phi_\Omega} \right)
+ * \f}
+ *
+ * We solve the TOV equations with the method implemented in
+ * `gr::Solutions::TovSolution`. It provides the areal mass-over-radius
+ * \f$m(r)/r\f$ and the log of the specific enthalpy \f$\log{h}\f$. In areal
+ * (Schwarzschild) coordinates the spatial metric potentials are
+ *
+ * \f{align}
+ * e^{\Phi_r} &= \left(1 - \frac{2m}{r}\right)^{-1} \\
+ * e^{\Phi_\Omega} &= 1
+ * \f}
  */
-template <typename RadialSolution>
 class TovStar : public virtual evolution::initial_data::InitialData,
                 public MarkAsAnalyticSolution,
                 public AnalyticSolution<3> {
  public:
-  /*!
-   * \brief The radial variables needed to compute the full `TOVStar` solution
-   *
-   * RadialSolution must provide a method that fills the radial variables
-   * given the equation of state and the Cartesian coordinates \f$x^i\f$
-   *
-   * If the spherically symmetric metric is written as
-   *
-   * \f[
-   * ds^2 = - e^{2 \Phi_t} dt^2 + e^{2 \Phi_r} dr^2 + e^{2 \Phi_\Omega} r^2
-   * d\Omega^2
-   * \f]
-   *
-   * where \f$r = \delta_{mn} x^m x^n\f$ is the `radial_coordinate` and
-   * \f$\Phi_t\f$, \f$\Phi_r\f$, and \f$\Phi_\Omega\f$ are respectvely the
-   * `metric_time_potential`, `metric_radial_potential`, and
-   * `metric_angular_potential`, then the lapse, shift, and spatial metric in
-   * the Cartesian coordinates are
-   *
-   * \f{align*}
-   * \alpha &= e^{\Phi_t} \\
-   * \beta^i &= 0 \\
-   * \gamma_{ij} &= \delta_{ij} e^{2 \Phi_r} + \delta_{im} \delta_{jn}
-   * \frac{x^m x^n}{r^2} \left( e^{2 \Phi_r} - e^{2 \Phi_\Omega} \right)
-   * \f}
-   *
-   */
-  template <typename DataType>
-  struct RadialVariables {
-    explicit RadialVariables(DataType radial_coordinate_in)
-        : radial_coordinate(std::move(radial_coordinate_in)),
-          rest_mass_density(
-              make_with_value<Scalar<DataType>>(radial_coordinate, 0.0)),
-          pressure(make_with_value<Scalar<DataType>>(radial_coordinate, 0.0)),
-          specific_internal_energy(
-              make_with_value<Scalar<DataType>>(radial_coordinate, 0.0)),
-          specific_enthalpy(
-              make_with_value<Scalar<DataType>>(radial_coordinate, 0.0)),
-          dr_pressure(make_with_value<DataType>(radial_coordinate, 0.0)),
-          metric_time_potential(
-              make_with_value<DataType>(radial_coordinate, 0.0)),
-          dr_metric_time_potential(
-              make_with_value<DataType>(radial_coordinate, 0.0)),
-          metric_radial_potential(
-              make_with_value<DataType>(radial_coordinate, 0.0)),
-          dr_metric_radial_potential(
-              make_with_value<DataType>(radial_coordinate, 0.0)),
-          metric_angular_potential(
-              make_with_value<DataType>(radial_coordinate, 0.0)),
-          dr_metric_angular_potential(
-              make_with_value<DataType>(radial_coordinate, 0.0)) {}
-    DataType radial_coordinate{};
-    Scalar<DataType> rest_mass_density{};
-    Scalar<DataType> pressure{};
-    Scalar<DataType> specific_internal_energy{};
-    Scalar<DataType> specific_enthalpy{};
-    DataType dr_pressure{};
-    DataType metric_time_potential{};
-    DataType dr_metric_time_potential{};
-    DataType metric_radial_potential{};
-    DataType dr_metric_radial_potential{};
-    DataType metric_angular_potential{};
-    DataType dr_metric_angular_potential{};
-  };
-
   using equation_of_state_type = EquationsOfState::PolytropicFluid<true>;
 
   /// The central density of the star.
@@ -172,9 +327,7 @@ class TovStar : public virtual evolution::initial_data::InitialData,
   tuples::TaggedTuple<Tags...> variables(const tnsr::I<DataType, 3>& x,
                                          const double /*t*/,
                                          tmpl::list<Tags...> /*meta*/) const {
-    auto radial_vars =
-        radial_tov_solution().radial_variables(equation_of_state_, x);
-    return {get<Tags>(variables(x, tmpl::list<Tags>{}, radial_vars))...};
+    return variables_impl<tov_detail::TovVariables>(x, tmpl::list<Tags...>{});
   }
 
   // clang-tidy: no runtime references
@@ -185,95 +338,122 @@ class TovStar : public virtual evolution::initial_data::InitialData,
   }
 
  protected:
-  const RadialSolution& radial_tov_solution() const;
+  const gr::Solutions::TovSolution& radial_tov_solution() const;
 
-  template <typename DataType>
-  using SpatialVelocity = hydro::Tags::SpatialVelocity<DataType, 3>;
+  template <template <class, tov_detail::StarRegion> class VarsComputer,
+            typename DataType, typename... Tags, typename... VarsComputerArgs>
+  tuples::TaggedTuple<Tags...> variables_impl(
+      const tnsr::I<DataType, 3>& x, tmpl::list<Tags...> /*meta*/,
+      VarsComputerArgs&&... vars_computer_args) const {
+    const auto& radial_solution = radial_tov_solution();
+    const double outer_radius = radial_solution.outer_radius();
+    const double center_radius_cutoff = 1.e-30 * outer_radius;
+    const DataType radius = get(magnitude(x));
+    // Dispatch interior and exterior regions of the star.
+    // - Include the equality in the conditions below for the outer radius so
+    //   the `DataVector` variants are preferred over the pointwise `double`
+    //   variant when possible.
+    // - Order the conditions so the cheaper exterior solution is preferred over
+    //   the interior.
+    // - A `DataVector` variant for the center of the star is not needed because
+    //   it's only a single point.
+    if (min(radius) >= outer_radius) {
+      // All points are outside the star. This could be replaced by a
+      // Schwarzschild solution.
+      using ExteriorVarsComputer =
+          VarsComputer<DataType, tov_detail::StarRegion::Exterior>;
+      typename ExteriorVarsComputer::Cache cache{get_size(radius)};
+      ExteriorVarsComputer computer{
+          x, radius, radial_solution, equation_of_state_,
+          std::forward<VarsComputerArgs>(vars_computer_args)...};
+      return {cache.get_var(computer, Tags{})...};
+    } else if (max(radius) <= outer_radius and
+               min(radius) > center_radius_cutoff) {
+      // All points are in the star interior, but not at the center
+      using InteriorVarsComputer =
+          VarsComputer<DataType, tov_detail::StarRegion::Interior>;
+      typename InteriorVarsComputer::Cache cache{get_size(radius)};
+      InteriorVarsComputer computer{
+          x, radius, radial_solution, equation_of_state_,
+          std::forward<VarsComputerArgs>(vars_computer_args)...};
+      return {cache.get_var(computer, Tags{})...};
+    } else {
+      // Points can be at the center, in the interior, or outside the star, so
+      // check each point individually
+      const size_t num_points = get_size(radius);
+      tuples::TaggedTuple<Tags...> vars{typename Tags::type{num_points}...};
+      const auto get_var = [&vars](const size_t point_index, auto& local_cache,
+                                   const auto& local_computer, auto tag_v) {
+        using tag = std::decay_t<decltype(tag_v)>;
+        if constexpr (std::is_same_v<DataType, DataVector>) {
+          using tags_double = typename VarsComputer<
+              double, tov_detail::StarRegion::Exterior>::Cache::tags_list;
+          using tags_dv = typename VarsComputer<
+              DataVector, tov_detail::StarRegion::Exterior>::Cache::tags_list;
+          using tag_double =
+              tmpl::at<tags_double, tmpl::index_of<tags_dv, tag>>;
+          const auto& tensor =
+              local_cache.get_var(local_computer, tag_double{});
+          for (size_t component = 0; component < tensor.size(); ++component) {
+            get<tag>(vars)[component][point_index] = tensor[component];
+          }
+        } else {
+          get<tag>(vars) = local_cache.get_var(local_computer, tag{});
+        }
+        return '0';
+      };
+      using CenterVarsComputer =
+          VarsComputer<double, tov_detail::StarRegion::Center>;
+      using InteriorVarsComputer =
+          VarsComputer<double, tov_detail::StarRegion::Interior>;
+      using ExteriorVarsComputer =
+          VarsComputer<double, tov_detail::StarRegion::Exterior>;
+      for (size_t i = 0; i < num_points; ++i) {
+        const tnsr::I<double, 3> x_i{
+            {{get_element(get<0>(x), i), get_element(get<1>(x), i),
+              get_element(get<2>(x), i)}}};
+        if (get_element(radius, i) > outer_radius) {
+          typename ExteriorVarsComputer::Cache cache{1};
+          ExteriorVarsComputer computer{
+              x_i, get_element(radius, i), radial_solution, equation_of_state_,
+              std::forward<VarsComputerArgs>(vars_computer_args)...};
+          expand_pack(get_var(i, cache, computer, Tags{})...);
+        } else if (get_element(radius, i) > center_radius_cutoff) {
+          typename InteriorVarsComputer::Cache cache{1};
+          InteriorVarsComputer computer{
+              x_i, get_element(radius, i), radial_solution, equation_of_state_,
+              std::forward<VarsComputerArgs>(vars_computer_args)...};
+          expand_pack(get_var(i, cache, computer, Tags{})...);
+        } else {
+          typename CenterVarsComputer::Cache cache{1};
+          CenterVarsComputer computer{
+              x_i, get_element(radius, i), radial_solution, equation_of_state_,
+              std::forward<VarsComputerArgs>(vars_computer_args)...};
+          expand_pack(get_var(i, cache, computer, Tags{})...);
+        }
+      }
+      return vars;
+    }
+  }
 
-  template <typename DataType>
-  using MagneticField = hydro::Tags::MagneticField<DataType, 3>;
-
-  template <typename DataType>
-  using DerivLapse = ::Tags::deriv<gr::Tags::Lapse<DataType>, tmpl::size_t<3>,
-                                   Frame::Inertial>;
-
-  template <typename DataType>
-  using Shift = gr::Tags::Shift<3, Frame::Inertial, DataType>;
-
-  template <typename DataType>
-  using DerivShift =
-      ::Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataType>,
-                    tmpl::size_t<3>, Frame::Inertial>;
-
-  template <typename DataType>
-  using SpatialMetric = gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>;
-
-  template <typename DataType>
-  using DerivSpatialMetric =
-      ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>,
-                    tmpl::size_t<3>, Frame::Inertial>;
-
-  template <typename DataType>
-  using InverseSpatialMetric =
-      gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataType>;
-
-  template <typename DataType>
-  using ExtrinsicCurvature =
-      gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataType>;
  public:
   template <typename DataType>
-  using tags = tmpl::list<
-      gr::Tags::Lapse<DataType>, ::Tags::dt<gr::Tags::Lapse<DataType>>,
-      DerivLapse<DataType>, gr::Tags::Shift<3, Frame::Inertial, DataType>,
-      ::Tags::dt<gr::Tags::Shift<3, Frame::Inertial, DataType>>,
-      DerivShift<DataType>,
-      gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>,
-      ::Tags::dt<gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>>,
-      DerivSpatialMetric<DataType>, gr::Tags::SqrtDetSpatialMetric<DataType>,
-      gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataType>,
-      gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataType>,
-      hydro::Tags::RestMassDensity<DataType>,
-      hydro::Tags::SpecificInternalEnergy<DataType>,
-      hydro::Tags::Pressure<DataType>,
-      hydro::Tags::SpatialVelocity<DataType, 3>,
-      hydro::Tags::MagneticField<DataType, 3>,
-      hydro::Tags::DivergenceCleaningField<DataType>,
-      hydro::Tags::LorentzFactor<DataType>,
-      hydro::Tags::SpecificEnthalpy<DataType>>;
- protected:
-  template <typename DataType, typename Tag>
-  tuples::TaggedTuple<::Tags::dt<Tag>> variables(
-      const tnsr::I<DataType, 3>& x, tmpl::list<::Tags::dt<Tag>> /*meta*/,
-      const RadialVariables<DataType>& /*radial_vars*/) const;
-
-#define FUNC_DECL(r, data, elem)                                \
-  template <typename DataType>                                  \
-  tuples::TaggedTuple<elem> variables(                          \
-      const tnsr::I<DataType, 3>& x, tmpl::list<elem> /*meta*/, \
-      const RadialVariables<DataType>& radial_vars) const;
-
-#define MY_LIST                                                                \
-  BOOST_PP_TUPLE_TO_LIST(                                                      \
-      17, (hydro::Tags::RestMassDensity<DataType>,                             \
-           hydro::Tags::SpecificInternalEnergy<DataType>,                      \
-           hydro::Tags::Pressure<DataType>, SpatialVelocity<DataType>,         \
-           MagneticField<DataType>,                                            \
-           hydro::Tags::DivergenceCleaningField<DataType>,                     \
-           hydro::Tags::LorentzFactor<DataType>,                               \
-           hydro::Tags::SpecificEnthalpy<DataType>, gr::Tags::Lapse<DataType>, \
-           DerivLapse<DataType>, Shift<DataType>, DerivShift<DataType>,        \
-           SpatialMetric<DataType>, DerivSpatialMetric<DataType>,              \
-           gr::Tags::SqrtDetSpatialMetric<DataType>,                           \
-           InverseSpatialMetric<DataType>, ExtrinsicCurvature<DataType>))
-
-  BOOST_PP_LIST_FOR_EACH(FUNC_DECL, _, MY_LIST)
-#undef MY_LIST
-#undef FUNC_DECL
+  using tags = tmpl::list_difference<
+      typename tov_detail::TovVariablesCache<DataType>::tags_list,
+      tmpl::list<
+          // Remove internal tags, which may not be available in the full domain
+          tov_detail::Tags::MassOverRadius<DataType>,
+          tov_detail::Tags::LogSpecificEnthalpy<DataType>,
+          tov_detail::Tags::DrPressure<DataType>,
+          tov_detail::Tags::MetricTimePotential<DataType>,
+          tov_detail::Tags::DrMetricTimePotential<DataType>,
+          tov_detail::Tags::MetricRadialPotential<DataType>,
+          tov_detail::Tags::DrMetricRadialPotential<DataType>,
+          tov_detail::Tags::MetricAngularPotential<DataType>,
+          tov_detail::Tags::DrMetricAngularPotential<DataType>>>;
 
  private:
-  template <typename LocalRadialSolution>
-  friend bool operator==(const TovStar<LocalRadialSolution>& lhs,
-                         const TovStar<LocalRadialSolution>& rhs);
+  friend bool operator==(const TovStar& lhs, const TovStar& rhs);
 
   double central_rest_mass_density_ =
       std::numeric_limits<double>::signaling_NaN();
@@ -282,9 +462,6 @@ class TovStar : public virtual evolution::initial_data::InitialData,
   EquationsOfState::PolytropicFluid<true> equation_of_state_{};
 };
 
-template <typename RadialSolution>
-bool operator!=(const TovStar<RadialSolution>& lhs,
-                const TovStar<RadialSolution>& rhs);
+bool operator!=(const TovStar& lhs, const TovStar& rhs);
 
-}  // namespace Solutions
-}  // namespace RelativisticEuler
+}  // namespace RelativisticEuler::Solutions

--- a/src/Utilities/ContainerHelpers.hpp
+++ b/src/Utilities/ContainerHelpers.hpp
@@ -146,6 +146,12 @@ SPECTRE_ALWAYS_INLINE decltype(auto) get_size(
       std::is_fundamental_v<std::remove_cv_t<T>>)>::get_size(t, size);
 }
 
+/// Fall-back that allows using `min(x)` where `x` can be a vector or a double
+SPECTRE_ALWAYS_INLINE double min(const double val) { return val; }
+
+/// Fall-back that allows using `max(x)` where `x` can be a vector or a double
+SPECTRE_ALWAYS_INLINE double max(const double val) { return val; }
+
 /*!
  * \ingroup UtilitiesGroup
  * \brief Checks the size of each component of the container, and resizes if

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_GrTagsForHydro.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_GrTagsForHydro.cpp
@@ -32,7 +32,6 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/GrTagsForHydro.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
 #include "Framework/TestHelpers.hpp"
-#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Tov.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "Utilities/CloneUniquePtrs.hpp"
@@ -53,8 +52,7 @@ SPECTRE_TEST_CASE(
 
   using Translation = domain::CoordinateMaps::TimeDependent::Translation<1>;
   using Identity2D = domain::CoordinateMaps::Identity<2>;
-  using Solution =
-      RelativisticEuler::Solutions::TovStar<gr::Solutions::TovSolution>;
+  using Solution = RelativisticEuler::Solutions::TovStar;
   const Mesh<3> subcell_mesh{5, Spectral::Basis::FiniteDifference,
                              Spectral::Quadrature::CellCentered};
   const double time = 0.1;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
@@ -35,7 +35,6 @@
 #include "NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
-#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Tov.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "PointwiseFunctions/MathFunctions/MathFunction.hpp"  // IWYU pragma: keep
@@ -351,8 +350,7 @@ void test_tov() {
         ElementId<3>{0}, cube.stationary_map().get_clone()};
     const auto x = element_map(xi);
 
-    RelativisticEuler::Solutions::TovStar<gr::Solutions::TovSolution> tov_star(
-        central_density, 100.0, 2.0);
+    RelativisticEuler::Solutions::TovStar tov_star(central_density, 100.0, 2.0);
 
     using rho_tag = hydro::Tags::RestMassDensity<DataVector>;
     auto vars = variables_from_tagged_tuple(

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Python/Test_Tov.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Python/Test_Tov.py
@@ -22,6 +22,9 @@ class TestTov(unittest.TestCase):
         expected_mass = 0.0531036941
         self.assertAlmostEqual(tov.total_mass(), expected_mass)
         self.assertAlmostEqual(
+            tov.injection_energy(),
+            np.sqrt(1. - 2. * tov.total_mass() / outer_radius))
+        self.assertAlmostEqual(
             tov.mass_over_radius(outer_radius) * outer_radius, expected_mass)
         self.assertAlmostEqual(tov.log_specific_enthalpy(outer_radius), 0.)
         # Test vectorization of member functions

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Python/Test_Tov.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Python/Test_Tov.py
@@ -20,13 +20,12 @@ class TestTov(unittest.TestCase):
         outer_radius = tov.outer_radius()
         self.assertAlmostEqual(outer_radius, 3.4685521362)
         expected_mass = 0.0531036941
-        self.assertAlmostEqual(tov.mass(outer_radius), expected_mass)
+        self.assertAlmostEqual(tov.total_mass(), expected_mass)
         self.assertAlmostEqual(
             tov.mass_over_radius(outer_radius) * outer_radius, expected_mass)
         self.assertAlmostEqual(tov.log_specific_enthalpy(outer_radius), 0.)
         # Test vectorization of member functions
         radii = np.array([0., outer_radius])
-        npt.assert_allclose(tov.mass(radii), np.array([0., expected_mass]))
         npt.assert_allclose(
             tov.mass_over_radius(radii) * radii, np.array([0., expected_mass]))
         # Testing `log_specific_enthalpy` only at outer radius because we

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_Tov.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_Tov.cpp
@@ -68,6 +68,9 @@ void test_tov(
     CHECK(expected_relativistic_radius == custom_approx(final_radius));
     CHECK(expected_relativistic_mass == custom_approx(final_mass));
   }
+  CHECK(tov_out_full.injection_energy() ==
+        approx(sqrt(1. - 2. * tov_out_full.total_mass() /
+                             tov_out_full.outer_radius())));
 
   // Integrate only to some intermediate value, not the surface. Then compare to
   // interpolated values.

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_Tov.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_Tov.cpp
@@ -50,7 +50,9 @@ void test_tov(
 
   if (newtonian_limit) {
     const double final_radius{tov_out_full.outer_radius()};
-    const double final_mass{tov_out_full.mass(final_radius)};
+    const double final_mass{tov_out_full.total_mass()};
+    CHECK(final_mass ==
+          approx(tov_out_full.mass_over_radius(final_radius) * final_radius));
     CHECK(expected_newtonian_radius() == custom_approx(final_radius));
     CHECK(expected_newtonian_mass(central_mass_density) ==
           custom_approx(final_mass));
@@ -60,7 +62,9 @@ void test_tov(
     constexpr double expected_relativistic_radius = 3.4685521362;
     constexpr double expected_relativistic_mass = 0.0531036941;
     const double final_radius{tov_out_full.outer_radius()};
-    const double final_mass{tov_out_full.mass(final_radius)};
+    const double final_mass{tov_out_full.total_mass()};
+    CHECK(final_mass ==
+          approx(tov_out_full.mass_over_radius(final_radius) * final_radius));
     CHECK(expected_relativistic_radius == custom_approx(final_radius));
     CHECK(expected_relativistic_mass == custom_approx(final_mass));
   }
@@ -70,11 +74,14 @@ void test_tov(
   const gr::Solutions::TovSolution tov_out_intermediate(
       equation_of_state, central_mass_density, final_log_enthalpy);
   const double intermediate_radius{tov_out_intermediate.outer_radius()};
-  const double intermediate_mass{
-      tov_out_intermediate.mass(intermediate_radius)};
+  const double intermediate_mass{tov_out_intermediate.total_mass()};
+  CHECK(intermediate_mass ==
+        approx(tov_out_intermediate.mass_over_radius(intermediate_radius) *
+               intermediate_radius));
   const double intermediate_log_enthalpy{
       tov_out_intermediate.log_specific_enthalpy(intermediate_radius)};
-  const double interpolated_mass{tov_out_full.mass(intermediate_radius)};
+  const double interpolated_mass{
+      tov_out_full.mass_over_radius(intermediate_radius) * intermediate_radius};
   const double interpolated_log_enthalpy{
       tov_out_full.log_specific_enthalpy(intermediate_radius)};
   CHECK(intermediate_mass == custom_approx(interpolated_mass));
@@ -87,12 +94,13 @@ void test_tov(
   const double intermediate_radius_ds{
       deserialized_tov_out_intermediate.outer_radius()};
   const double intermediate_mass_ds{
-      deserialized_tov_out_intermediate.mass(intermediate_radius_ds)};
+      deserialized_tov_out_intermediate.total_mass()};
   const double intermediate_log_enthalpy_ds{
       deserialized_tov_out_intermediate.log_specific_enthalpy(
           intermediate_radius_ds)};
   const double interpolated_mass_ds{
-      deserialized_tov_out_full.mass(intermediate_radius_ds)};
+      deserialized_tov_out_full.mass_over_radius(intermediate_radius_ds) *
+      intermediate_radius_ds};
   const double interpolated_log_enthalpy_ds{
       deserialized_tov_out_full.log_specific_enthalpy(intermediate_radius_ds)};
   CHECK(intermediate_mass_ds == custom_approx(interpolated_mass_ds));
@@ -145,7 +153,7 @@ void test_tov_dp_dr(
     CAPTURE(p);
     CAPTURE(radius);
     if (radius < radial_tov_solution.outer_radius() and radius > 0.0) {
-      const double m = radial_tov_solution.mass(radius);
+      const double m = radial_tov_solution.mass_over_radius(radius) * radius;
       CHECK(approx(dp_dr[i]) == -total_energy_density * m / square(radius) *
                                     (1.0 + p / total_energy_density) *
                                     (1.0 + 4.0 * M_PI * p * cube(radius) / m) /

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GhRelativisticEuler/Test_InstantiateWrappedGr.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GhRelativisticEuler/Test_InstantiateWrappedGr.cpp
@@ -6,7 +6,6 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Helpers/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CheckWrappedGrConsistency.hpp"
-#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Tov.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.hpp"
@@ -59,9 +58,6 @@ SPECTRE_TEST_CASE(
 
   check_wrapped_gr_solution_consistency(
       GeneralizedHarmonic::Solutions::WrappedGr<
-          RelativisticEuler::Solutions::TovStar<gr::Solutions::TovSolution>>{
-          1.e-3, 8.0, 2.0},
-      RelativisticEuler::Solutions::TovStar<gr::Solutions::TovSolution>{
-          1.e-3, 8.0, 2.0},
-      x_3d, t);
+          RelativisticEuler::Solutions::TovStar>{1.e-3, 8.0, 2.0},
+      RelativisticEuler::Solutions::TovStar{1.e-3, 8.0, 2.0}, x_3d, t);
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/CMakeLists.txt
@@ -13,5 +13,19 @@ add_test_library(
   ${LIBRARY}
   "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/"
   "${LIBRARY_SOURCES}"
-  "RelativisticEulerSolutions;Options;Utilities"
+  ""
   )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  DataStructures
+  Domain
+  DomainCreators
+  Hydro
+  RelativisticEulerSolutions
+  Options
+  Spectral
+  Utilities
+  ValenciaDivClean
+)

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_TovStar.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_TovStar.cpp
@@ -47,6 +47,8 @@ void test_move() {
 void test_serialize() {
   TovStar star{1.e-3, 8.0, 2.0};
   test_serialization(star);
+  Approx custom_approx = Approx::custom().epsilon(1.0e-08).scale(1.0);
+  CHECK(star.radial_solution().outer_radius() == custom_approx(3.4685521362));
 }
 
 void verify_solution(const TovStar& solution, const std::array<double, 3>& x) {
@@ -85,6 +87,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.RelEuler.Tov",
           *deserialized_option_solution);
 
   const double radius_of_star = 10.04735006833273303;
+  CHECK(solution.radial_solution().outer_radius() == approx(radius_of_star));
   verify_solution(solution, {{0.0, 0.0, 0.0}});
   verify_solution(solution, {{0.0, 0.0, 0.5 * radius_of_star}});
   verify_solution(solution, {{0.0, radius_of_star, 0.0}});

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_TovStar.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_TovStar.cpp
@@ -20,7 +20,6 @@
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
-#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Tov.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
@@ -28,36 +27,29 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
 
+namespace RelativisticEuler::Solutions {
 namespace {
 
 void test_create_from_options() {
-  const auto star = TestHelpers::test_creation<
-      RelativisticEuler::Solutions::TovStar<gr::Solutions::TovSolution>>(
+  const auto star = TestHelpers::test_creation<TovStar>(
       "CentralDensity: 1.0e-5\n"
       "PolytropicConstant: 0.001\n"
       "PolytropicExponent: 1.4");
-  CHECK(star ==
-        RelativisticEuler::Solutions::TovStar<gr::Solutions::TovSolution>(
-            0.00001, 0.001, 1.4));
+  CHECK(star == TovStar{0.00001, 0.001, 1.4});
 }
 
 void test_move() {
-  RelativisticEuler::Solutions::TovStar<gr::Solutions::TovSolution> star(
-      1.e-4, 4.0, 2.5);
-  RelativisticEuler::Solutions::TovStar<gr::Solutions::TovSolution> star_copy(
-      1.e-4, 4.0, 2.5);
+  TovStar star{1.e-4, 4.0, 2.5};
+  TovStar star_copy{1.e-4, 4.0, 2.5};
   test_move_semantics(std::move(star), star_copy);  //  NOLINT
 }
 
 void test_serialize() {
-  RelativisticEuler::Solutions::TovStar<gr::Solutions::TovSolution> star(
-      1.e-3, 8.0, 2.0);
+  TovStar star{1.e-3, 8.0, 2.0};
   test_serialization(star);
 }
 
-void verify_solution(const RelativisticEuler::Solutions::TovStar<
-                         gr::Solutions::TovSolution>& solution,
-                     const std::array<double, 3>& x) {
+void verify_solution(const TovStar& solution, const std::array<double, 3>& x) {
   const std::array<double, 3> dx{{1.e-4, 1.e-4, 1.e-4}};
   domain::creators::Brick brick(x - dx, x + dx, {{0, 0, 0}}, {{5, 5, 5}},
                                 {{false, false, false}});
@@ -77,20 +69,20 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.RelEuler.Tov",
   test_move();
 
   Parallel::register_classes_with_charm<
-      RelativisticEuler::Solutions::TovStar<gr::Solutions::TovSolution>>();
+      RelativisticEuler::Solutions::TovStar>();
   const std::unique_ptr<evolution::initial_data::InitialData> option_solution =
       TestHelpers::test_option_tag_factory_creation<
           evolution::initial_data::OptionTags::InitialData,
-          RelativisticEuler::Solutions::TovStar<gr::Solutions::TovSolution>>(
+          RelativisticEuler::Solutions::TovStar>(
           "TovStar:\n"
           "  CentralDensity: 1.0e-3\n"
           "  PolytropicConstant: 100.0\n"
           "  PolytropicExponent: 2.0\n");
   const auto deserialized_option_solution =
       serialize_and_deserialize(option_solution);
-  const auto& solution = dynamic_cast<
-      const RelativisticEuler::Solutions::TovStar<gr::Solutions::TovSolution>&>(
-      *deserialized_option_solution);
+  const auto& solution =
+      dynamic_cast<const RelativisticEuler::Solutions::TovStar&>(
+          *deserialized_option_solution);
 
   const double radius_of_star = 10.04735006833273303;
   verify_solution(solution, {{0.0, 0.0, 0.0}});
@@ -106,3 +98,5 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.RelEuler.Tov",
   }
   verify_solution(solution, random_point);
 }
+
+}  // namespace RelativisticEuler::Solutions

--- a/tests/Unit/Utilities/Test_ContainerHelpers.cpp
+++ b/tests/Unit/Utilities/Test_ContainerHelpers.cpp
@@ -119,6 +119,8 @@ SPECTRE_TEST_CASE("Unit.Utilities.ContainerHelpers", "[Unit][Utilities]") {
     CHECK(get_element(array_of_arrays, i, ArrayOfArraysIndexFunctor{}) ==
           static_cast<double>(i));
   }
+  CHECK(min(constant_spectre_vector) == min(2.0));
+  CHECK(max(constant_spectre_vector) == max(2.0));
 
   // Check the destructive resize function applied to tensors
   tnsr::i<DataVector, 3> rank_one{static_cast<size_t>(4)};


### PR DESCRIPTION
## Proposed changes

- Decouple the ODE integration of the TOV equations from the system-specific analytic-solution classes.
- Fix a bug with multiple TOV solutions in one executable. Since the radial solution was stored in a static variable, only a single one was ever instantiated, even if two with different parameters were requested. Now that the classes are decoupled, we can store the radial solution in a member variable, which fixes the bug.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
