### PR TITLE
Minor retroactive fixes for subcell codes

### DIFF
--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -202,7 +202,7 @@ struct EvolutionMetavars {
     }
 
     using DgComputeSubcellNeighborPackagedData =
-        ScalarAdvection::subcell::NeighborPackagedData<volume_dim>;
+        ScalarAdvection::subcell::NeighborPackagedData;
 
     using GhostDataToSlice =
         ScalarAdvection::subcell::GhostDataToSlice<volume_dim>;

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/GhostData.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/GhostData.cpp
@@ -6,9 +6,7 @@
 #include <cstddef>
 
 #include "DataStructures/Variables.hpp"
-#include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/Projection.hpp"
-#include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/Systems/ScalarAdvection/Tags.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Utilities/GenerateInstantiations.hpp"

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/GhostData.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/GhostData.hpp
@@ -28,7 +28,7 @@ namespace ScalarAdvection::subcell {
  * This mutator is passed to
  * `evolution::dg::subcell::Actions::SendDataForReconstruction`.
  *
- * \note Called only by FD-solving elements.
+ * \note Only called on elements using FD.
  */
 class GhostDataOnSubcells {
  public:

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/NeighborPackagedData.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/NeighborPackagedData.hpp
@@ -5,7 +5,6 @@
 
 #include <boost/functional/hash.hpp>
 #include <cstddef>
-#include <limits>
 #include <optional>
 #include <type_traits>
 #include <utility>
@@ -129,21 +128,13 @@ struct NeighborPackagedData {
           const Direction<Dim>& direction = mortar_id.first;
           Index<Dim> extents = subcell_mesh.extents();
 
-          size_t num_face_pts{std::numeric_limits<size_t>::signaling_NaN()};
-
-          if constexpr (Dim == 1) {
-            // Note : 1D mortar has only one face point
-            num_face_pts = 1;
-            vars_on_face.initialize(num_face_pts);
-          } else {
-            // Switch to face-centered instead of cell-centered points on the
-            // FD. There are num_cell_centered+1 face-centered points.
-            ++extents[direction.dimension()];
-            num_face_pts = subcell_mesh.extents()
-                               .slice_away(direction.dimension())
-                               .product();
-            vars_on_face.initialize(num_face_pts);
-          }
+          // Switch to face-centered instead of cell-centered points on the
+          // FD. There are num_cell_centered+1 face-centered points.
+          ++extents[direction.dimension()];
+          const size_t num_face_pts = subcell_mesh.extents()
+                                          .slice_away(direction.dimension())
+                                          .product();
+          vars_on_face.initialize(num_face_pts);
 
           using velocity_field = ScalarAdvection::Tags::VelocityField<Dim>;
           const auto& velocity_on_face =

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/NeighborPackagedData.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/NeighborPackagedData.hpp
@@ -58,9 +58,9 @@ namespace ScalarAdvection::subcell {
  * and can be explained by that we only need strict conservation at shocks, and
  * if one element is doing DG, then we aren't at a shock.
  */
-template <size_t Dim>
+
 struct NeighborPackagedData {
-  template <typename DbTagsList>
+  template <size_t Dim, typename DbTagsList>
   static FixedHashMap<maximum_number_of_neighbors(Dim),
                       std::pair<Direction<Dim>, ElementId<Dim>>,
                       std::vector<double>,

--- a/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_NeighborPackagedData.cpp
@@ -211,7 +211,7 @@ void test_neighbor_packaged_data(const size_t num_dg_pts_per_dimension,
     mortars_to_reconstruct_to.emplace_back(direction, *neighbors.begin());
   }
   const auto packaged_data =
-      subcell::NeighborPackagedData<Dim>::apply(box, mortars_to_reconstruct_to);
+      subcell::NeighborPackagedData::apply(box, mortars_to_reconstruct_to);
 
   // Now for each directions, check that the packaged_data agrees with expected
   // values


### PR DESCRIPTION
## Proposed changes

Some retroactive changes on subcell codes motivated from recent reviews on PRs.

* ScalarAdvection : 
  * minor fixes on GhostData
  * make the `NeighborPackagedData` struct untemplated and move template parameter `Dim` to the function inside it
  * remove unnecessary `if` branch for computing the number of face points.
* NewtonianEuler : match variable naming in subcell TimeDerivative (see #3676)

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
