### PR TITLE
Make GRMHD, Burgers, SW solutions factory createable, add test_option_tag_factory_creation

### DIFF
--- a/src/PointwiseFunctions/AnalyticData/Burgers/Sinusoid.cpp
+++ b/src/PointwiseFunctions/AnalyticData/Burgers/Sinusoid.cpp
@@ -20,12 +20,16 @@ Scalar<T> Sinusoid::u(const tnsr::I<T, 1>& x) const {
   return Scalar<T>{sin(get<0>(x))};
 }
 
+Sinusoid::Sinusoid(CkMigrateMessage* msg) : InitialData(msg) {}
+
 tuples::TaggedTuple<Tags::U> Sinusoid::variables(
     const tnsr::I<DataVector, 1>& x, tmpl::list<Tags::U> /*meta*/) const {
   return {u(x)};
 }
 
-void Sinusoid::pup(PUP::er& /*p*/) {}
+void Sinusoid::pup(PUP::er& p) { InitialData::pup(p); }
+
+PUP::able::PUP_ID Sinusoid::my_PUP_ID = 0;
 
 bool operator==(const Sinusoid& /*lhs*/, const Sinusoid& /*rhs*/) {
   return true;

--- a/src/PointwiseFunctions/AnalyticData/Burgers/Sinusoid.hpp
+++ b/src/PointwiseFunctions/AnalyticData/Burgers/Sinusoid.hpp
@@ -7,7 +7,9 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/Burgers/Tags.hpp"  // IWYU pragma: keep
 #include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -19,8 +21,7 @@ class er;
 }  // namespace PUP
 /// \endcond
 
-namespace Burgers {
-namespace AnalyticData {
+namespace Burgers::AnalyticData {
 /*!
  * \brief Analytic data (with an "exact" solution known) that is periodic over
  * the interval \f$[0,2\pi]\f$.
@@ -87,7 +88,8 @@ namespace AnalyticData {
        return np.asarray(results)
  * \endcode
  */
-class Sinusoid : public MarkAsAnalyticData {
+class Sinusoid : public evolution::initial_data::InitialData,
+                 public MarkAsAnalyticData {
  public:
   using options = tmpl::list<>;
   static constexpr Options::String help{
@@ -102,6 +104,12 @@ class Sinusoid : public MarkAsAnalyticData {
   Sinusoid& operator=(Sinusoid&&) = default;
   ~Sinusoid() = default;
 
+  /// \cond
+  explicit Sinusoid(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Sinusoid);
+  /// \endcond
+
   template <typename T>
   Scalar<T> u(const tnsr::I<T, 1>& x) const;
 
@@ -115,5 +123,4 @@ class Sinusoid : public MarkAsAnalyticData {
 bool operator==(const Sinusoid& /*lhs*/, const Sinusoid& /*rhs*/);
 
 bool operator!=(const Sinusoid& lhs, const Sinusoid& rhs);
-}  // namespace AnalyticData
-}  // namespace Burgers
+}  // namespace Burgers::AnalyticData

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/BlastWave.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/BlastWave.cpp
@@ -79,7 +79,10 @@ BlastWave::BlastWave(const double inner_radius, const double outer_radius,
   }
 }
 
+BlastWave::BlastWave(CkMigrateMessage* msg) : InitialData(msg) {}
+
 void BlastWave::pup(PUP::er& p) {
+  InitialData::pup(p);
   p | inner_radius_;
   p | outer_radius_;
   p | inner_density_;
@@ -168,6 +171,8 @@ BlastWave::variables(
       get<hydro::Tags::SpecificInternalEnergy<DataType>>(variables(
           x, tmpl::list<hydro::Tags::SpecificInternalEnergy<DataType>>{})));
 }
+
+PUP::able::PUP_ID BlastWave::my_PUP_ID = 0;
 
 bool operator==(const BlastWave& lhs, const BlastWave& rhs) {
   return lhs.inner_radius_ == rhs.inner_radius_ and

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/BlastWave.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/BlastWave.hpp
@@ -138,8 +138,8 @@ class BlastWave : public evolution::initial_data::InitialData,
       "Cylindrical or spherical blast wave analytic initial data."};
 
   BlastWave() = default;
-  BlastWave(const BlastWave& /*rhs*/) = delete;
-  BlastWave& operator=(const BlastWave& /*rhs*/) = delete;
+  BlastWave(const BlastWave& /*rhs*/) = default;
+  BlastWave& operator=(const BlastWave& /*rhs*/) = default;
   BlastWave(BlastWave&& /*rhs*/) = default;
   BlastWave& operator=(BlastWave&& /*rhs*/) = default;
   ~BlastWave() = default;

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/BlastWave.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/BlastWave.hpp
@@ -8,11 +8,13 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
 #include "PointwiseFunctions/AnalyticData/GrMhd/AnalyticData.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -57,7 +59,9 @@ namespace grmhd::AnalyticData {
  * \cite CerdaDuran2007 \cite CerdaDuran2008 \cite Cipolletta2019. The magnetic
  * field is chosen to be in the z-direction instead of the x-direction.
  */
-class BlastWave : public MarkAsAnalyticData, public AnalyticDataBase {
+class BlastWave : public evolution::initial_data::InitialData,
+                  public MarkAsAnalyticData,
+                  public AnalyticDataBase {
  public:
   using equation_of_state_type = EquationsOfState::IdealFluid<true>;
 
@@ -145,7 +149,11 @@ class BlastWave : public MarkAsAnalyticData, public AnalyticDataBase {
             const std::array<double, 3>& magnetic_field, double adiabatic_index,
             Geometry geometry, const Options::Context& context = {});
 
-  explicit BlastWave(CkMigrateMessage* /*unused*/) {}
+  /// \cond
+  explicit BlastWave(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(BlastWave);
+  /// \endcond
 
   /// @{
   /// Retrieve the GRMHD variables at a given position.

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.cpp
@@ -36,7 +36,11 @@ BondiHoyleAccretion::BondiHoyleAccretion(const double bh_mass,
           bh_mass, {{0.0, 0.0, bh_dimless_spin}}, {{0.0, 0.0, 0.0}}},
       kerr_schild_coords_{bh_mass, bh_dimless_spin} {}
 
+BondiHoyleAccretion::BondiHoyleAccretion(CkMigrateMessage* msg)
+    : InitialData(msg) {}
+
 void BondiHoyleAccretion::pup(PUP::er& p) {
+  InitialData::pup(p);
   p | bh_mass_;
   p | bh_spin_a_;
   p | rest_mass_density_;
@@ -183,6 +187,8 @@ BondiHoyleAccretion::variables(
       get<hydro::Tags::RestMassDensity<DataType>>(
           variables(x, tmpl::list<hydro::Tags::RestMassDensity<DataType>>{})));
 }
+
+PUP::able::PUP_ID BondiHoyleAccretion::my_PUP_ID = 0;
 
 bool operator==(const BondiHoyleAccretion& lhs,
                 const BondiHoyleAccretion& rhs) {

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.hpp
@@ -140,8 +140,8 @@ class BondiHoyleAccretion : public evolution::initial_data::InitialData,
       "Axially symmetric accretion on to a Kerr black hole."};
 
   BondiHoyleAccretion() = default;
-  BondiHoyleAccretion(const BondiHoyleAccretion& /*rhs*/) = delete;
-  BondiHoyleAccretion& operator=(const BondiHoyleAccretion& /*rhs*/) = delete;
+  BondiHoyleAccretion(const BondiHoyleAccretion& /*rhs*/) = default;
+  BondiHoyleAccretion& operator=(const BondiHoyleAccretion& /*rhs*/) = default;
   BondiHoyleAccretion(BondiHoyleAccretion&& /*rhs*/) = default;
   BondiHoyleAccretion& operator=(BondiHoyleAccretion&& /*rhs*/) = default;
   ~BondiHoyleAccretion() = default;

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.hpp
@@ -7,12 +7,14 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
 #include "PointwiseFunctions/AnalyticData/GrMhd/AnalyticData.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "PointwiseFunctions/GeneralRelativity/KerrSchildCoords.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -25,8 +27,7 @@ class er;  // IWYU pragma: keep
 }  // namespace PUP
 /// \endcond
 
-namespace grmhd {
-namespace AnalyticData {
+namespace grmhd::AnalyticData {
 
 /*!
  * \brief Analytic initial data for axially symmetric Bondi-Hoyle accretion.
@@ -77,7 +78,9 @@ namespace AnalyticData {
  * where \f$\gamma = \text{det}(\gamma_{ij})\f$. Wald's solution reproduces a
  * uniform magnetic field far from the black hole.
  */
-class BondiHoyleAccretion : public MarkAsAnalyticData, public AnalyticDataBase {
+class BondiHoyleAccretion : public evolution::initial_data::InitialData,
+                            public MarkAsAnalyticData,
+                            public AnalyticDataBase {
  public:
   using equation_of_state_type = EquationsOfState::PolytropicFluid<true>;
 
@@ -147,6 +150,12 @@ class BondiHoyleAccretion : public MarkAsAnalyticData, public AnalyticDataBase {
                       double rest_mass_density, double flow_speed,
                       double magnetic_field_strength,
                       double polytropic_constant, double polytropic_exponent);
+
+  /// \cond
+  explicit BondiHoyleAccretion(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(BondiHoyleAccretion);
+  /// \endcond
 
   /// @{
   /// Retrieve hydro variable at `x`
@@ -251,5 +260,4 @@ class BondiHoyleAccretion : public MarkAsAnalyticData, public AnalyticDataBase {
 
 bool operator!=(const BondiHoyleAccretion& lhs, const BondiHoyleAccretion& rhs);
 
-}  // namespace AnalyticData
-}  // namespace grmhd
+}  // namespace grmhd::AnalyticData

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/KhInstability.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/KhInstability.cpp
@@ -55,7 +55,10 @@ KhInstability::KhInstability(
              << strip_thickness << ".");
 }
 
+KhInstability::KhInstability(CkMigrateMessage* msg) : InitialData(msg) {}
+
 void KhInstability::pup(PUP::er& p) {
+  InitialData::pup(p);
   p | adiabatic_index_;
   p | strip_bimedian_height_;
   p | strip_half_thickness_;
@@ -178,6 +181,8 @@ KhInstability::variables(
       get<hydro::Tags::SpecificInternalEnergy<DataType>>(variables(
           x, tmpl::list<hydro::Tags::SpecificInternalEnergy<DataType>>{})));
 }
+
+PUP::able::PUP_ID KhInstability::my_PUP_ID = 0;
 
 bool operator==(const KhInstability& lhs, const KhInstability& rhs) {
   // No comparison for equation_of_state_. Comparing adiabatic_index_ should

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/KhInstability.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/KhInstability.hpp
@@ -8,12 +8,14 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
 #include "PointwiseFunctions/AnalyticData/GrMhd/AnalyticData.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
 #include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -74,7 +76,9 @@ namespace grmhd::AnalyticData {
  *
  * A uniform magnetic field can be added.
  */
-class KhInstability : public MarkAsAnalyticData, public AnalyticDataBase {
+class KhInstability : public evolution::initial_data::InitialData,
+                      public MarkAsAnalyticData,
+                      public AnalyticDataBase {
  public:
   using equation_of_state_type = EquationsOfState::IdealFluid<true>;
 
@@ -180,7 +184,11 @@ class KhInstability : public MarkAsAnalyticData, public AnalyticDataBase {
                 double perturbation_amplitude, double perturbation_width,
                 const std::array<double, 3>& magnetic_field);
 
-  explicit KhInstability(CkMigrateMessage* /*unused*/) {}
+  /// \cond
+  explicit KhInstability(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(KhInstability);
+  /// \endcond
 
   /// @{
   /// Retrieve the GRMHD variables at a given position.

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.cpp
@@ -51,7 +51,11 @@ MagneticFieldLoop::MagneticFieldLoop(
   }
 }
 
+MagneticFieldLoop::MagneticFieldLoop(CkMigrateMessage* msg)
+    : InitialData(msg) {}
+
 void MagneticFieldLoop::pup(PUP::er& p) {
+  InitialData::pup(p);
   p | pressure_;
   p | rest_mass_density_;
   p | adiabatic_index_;
@@ -163,6 +167,8 @@ MagneticFieldLoop::variables(
       get<hydro::Tags::SpecificInternalEnergy<DataType>>(variables(
           x, tmpl::list<hydro::Tags::SpecificInternalEnergy<DataType>>{})));
 }
+
+PUP::able::PUP_ID MagneticFieldLoop::my_PUP_ID = 0;
 
 bool operator==(const MagneticFieldLoop& lhs, const MagneticFieldLoop& rhs) {
   // there is no comparison operator for the EoS, but should be okay as

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.hpp
@@ -126,8 +126,8 @@ class MagneticFieldLoop : public evolution::initial_data::InitialData,
       "Periodic advection of a magnetic field loop in Minkowski."};
 
   MagneticFieldLoop() = default;
-  MagneticFieldLoop(const MagneticFieldLoop& /*rhs*/) = delete;
-  MagneticFieldLoop& operator=(const MagneticFieldLoop& /*rhs*/) = delete;
+  MagneticFieldLoop(const MagneticFieldLoop& /*rhs*/) = default;
+  MagneticFieldLoop& operator=(const MagneticFieldLoop& /*rhs*/) = default;
   MagneticFieldLoop(MagneticFieldLoop&& /*rhs*/) = default;
   MagneticFieldLoop& operator=(MagneticFieldLoop&& /*rhs*/) = default;
   ~MagneticFieldLoop() = default;

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.hpp
@@ -8,11 +8,13 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
 #include "PointwiseFunctions/AnalyticData/GrMhd/AnalyticData.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -24,8 +26,7 @@ class er;  // IWYU pragma: keep
 }  // namespace PUP
 /// \endcond
 
-namespace grmhd {
-namespace AnalyticData {
+namespace grmhd::AnalyticData {
 
 /*!
  * \brief Analytic initial data for an advecting magnetic field loop.
@@ -56,7 +57,9 @@ namespace AnalyticData {
  * -  AdiabaticIndex: 1.66666666666666667
  *
  */
-class MagneticFieldLoop : public MarkAsAnalyticData, public AnalyticDataBase {
+class MagneticFieldLoop : public evolution::initial_data::InitialData,
+                          public MarkAsAnalyticData,
+                          public AnalyticDataBase {
  public:
   using equation_of_state_type = EquationsOfState::IdealFluid<true>;
 
@@ -135,7 +138,11 @@ class MagneticFieldLoop : public MarkAsAnalyticData, public AnalyticDataBase {
                     double magnetic_field_magnitude, double inner_radius,
                     double outer_radius, const Options::Context& context = {});
 
-  explicit MagneticFieldLoop(CkMigrateMessage* /*unused*/) {}
+  /// \cond
+  explicit MagneticFieldLoop(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(MagneticFieldLoop);
+  /// \endcond
 
   /// @{
   /// Retrieve the GRMHD variables at a given position.
@@ -230,5 +237,4 @@ class MagneticFieldLoop : public MarkAsAnalyticData, public AnalyticDataBase {
                          const MagneticFieldLoop& rhs);
 };
 
-}  // namespace AnalyticData
-}  // namespace grmhd
+}  // namespace grmhd::AnalyticData

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticRotor.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticRotor.cpp
@@ -58,7 +58,10 @@ MagneticRotor::MagneticRotor(
   }
 }
 
+MagneticRotor::MagneticRotor(CkMigrateMessage* msg) : InitialData(msg) {}
+
 void MagneticRotor::pup(PUP::er& p) {
+  InitialData::pup(p);
   p | rotor_radius_;
   p | rotor_density_;
   p | background_density_;
@@ -154,6 +157,8 @@ MagneticRotor::variables(
       get<hydro::Tags::SpecificInternalEnergy<DataType>>(variables(
           x, tmpl::list<hydro::Tags::SpecificInternalEnergy<DataType>>{})));
 }
+
+PUP::able::PUP_ID MagneticRotor::my_PUP_ID = 0;
 
 bool operator==(const MagneticRotor& lhs, const MagneticRotor& rhs) {
   // there is no comparison operator for the EoS, but should be okay as

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticRotor.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticRotor.hpp
@@ -124,8 +124,8 @@ class MagneticRotor : public evolution::initial_data::InitialData,
       "Magnetic rotor analytic initial data."};
 
   MagneticRotor() = default;
-  MagneticRotor(const MagneticRotor& /*rhs*/) = delete;
-  MagneticRotor& operator=(const MagneticRotor& /*rhs*/) = delete;
+  MagneticRotor(const MagneticRotor& /*rhs*/) = default;
+  MagneticRotor& operator=(const MagneticRotor& /*rhs*/) = default;
   MagneticRotor(MagneticRotor&& /*rhs*/) = default;
   MagneticRotor& operator=(MagneticRotor&& /*rhs*/) = default;
   ~MagneticRotor() = default;

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticRotor.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticRotor.hpp
@@ -8,11 +8,13 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
-#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
 #include "PointwiseFunctions/AnalyticData/GrMhd/AnalyticData.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -24,8 +26,7 @@ class er;  // IWYU pragma: keep
 }  // namespace PUP
 /// \endcond
 
-namespace grmhd {
-namespace AnalyticData {
+namespace grmhd::AnalyticData {
 
 /*!
  * \brief Analytic initial data for a magnetic rotor.
@@ -64,7 +65,9 @@ namespace AnalyticData {
  *
  * The magnetic field in the disk should rotate by about 90 degrees by t = 0.4.
  */
-class MagneticRotor : public MarkAsAnalyticData, public AnalyticDataBase {
+class MagneticRotor : public evolution::initial_data::InitialData,
+                      public MarkAsAnalyticData,
+                      public AnalyticDataBase {
  public:
   using equation_of_state_type = EquationsOfState::IdealFluid<true>;
 
@@ -133,7 +136,11 @@ class MagneticRotor : public MarkAsAnalyticData, public AnalyticDataBase {
                 const std::array<double, 3>& magnetic_field,
                 double adiabatic_index, const Options::Context& context = {});
 
-  explicit MagneticRotor(CkMigrateMessage* /*unused*/) {}
+  /// \cond
+  explicit MagneticRotor(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(MagneticRotor);
+  /// \endcond
 
   /// @{
   /// Retrieve the GRMHD variables at a given position.
@@ -224,5 +231,4 @@ class MagneticRotor : public MarkAsAnalyticData, public AnalyticDataBase {
   friend bool operator!=(const MagneticRotor& lhs, const MagneticRotor& rhs);
 };
 
-}  // namespace AnalyticData
-}  // namespace grmhd
+}  // namespace grmhd::AnalyticData

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.cpp
@@ -115,6 +115,9 @@ MagnetizedFmDisk::MagnetizedFmDisk(
            inverse_plasma_beta_ / b_squared_max);
 }
 
+MagnetizedFmDisk::MagnetizedFmDisk(CkMigrateMessage* msg)
+    : FishboneMoncriefDisk(msg) {}
+
 void MagnetizedFmDisk::pup(PUP::er& p) {
   RelativisticEuler::Solutions::FishboneMoncriefDisk::pup(p);
   p | threshold_density_;
@@ -226,6 +229,8 @@ MagnetizedFmDisk::variables(
   }
   return result;
 }
+
+PUP::able::PUP_ID MagnetizedFmDisk::my_PUP_ID = 0;
 
 bool operator==(const MagnetizedFmDisk& lhs, const MagnetizedFmDisk& rhs) {
   using fm_disk = MagnetizedFmDisk::fm_disk;

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.hpp
@@ -128,8 +128,8 @@ class MagnetizedFmDisk
       "Magnetized Fishbone-Moncrief disk."};
 
   MagnetizedFmDisk() = default;
-  MagnetizedFmDisk(const MagnetizedFmDisk& /*rhs*/) = delete;
-  MagnetizedFmDisk& operator=(const MagnetizedFmDisk& /*rhs*/) = delete;
+  MagnetizedFmDisk(const MagnetizedFmDisk& /*rhs*/) = default;
+  MagnetizedFmDisk& operator=(const MagnetizedFmDisk& /*rhs*/) = default;
   MagnetizedFmDisk(MagnetizedFmDisk&& /*rhs*/) = default;
   MagnetizedFmDisk& operator=(MagnetizedFmDisk&& /*rhs*/) = default;
   ~MagnetizedFmDisk() = default;

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.hpp
@@ -8,12 +8,14 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
 #include "PointwiseFunctions/AnalyticData/GrMhd/AnalyticData.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp"
 #include "PointwiseFunctions/GeneralRelativity/KerrSchildCoords.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -25,8 +27,7 @@ class er;  // IWYU pragma: keep
 }  // namespace PUP
 /// \endcond
 
-namespace grmhd {
-namespace AnalyticData {
+namespace grmhd::AnalyticData {
 
 /*!
  * \brief Magnetized fluid disk orbiting a Kerr black hole.
@@ -71,7 +72,8 @@ namespace AnalyticData {
  * the spatial velocity, and \f$W\f$ the Lorentz factor.
  */
 class MagnetizedFmDisk
-    : public MarkAsAnalyticData,
+    : public virtual evolution::initial_data::InitialData,
+      public MarkAsAnalyticData,
       private RelativisticEuler::Solutions::FishboneMoncriefDisk {
  private:
   using fm_disk = RelativisticEuler::Solutions::FishboneMoncriefDisk;
@@ -138,6 +140,12 @@ class MagnetizedFmDisk
       double polytropic_exponent, double threshold_density,
       double inverse_plasma_beta,
       size_t normalization_grid_res = BFieldNormGridRes::suggested_value());
+
+  /// \cond
+  explicit MagnetizedFmDisk(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(MagnetizedFmDisk);
+  /// \endcond
 
   // Overload the variables function from the base class.
   using fm_disk::equation_of_state;
@@ -218,5 +226,4 @@ class MagnetizedFmDisk
 
 bool operator!=(const MagnetizedFmDisk& lhs, const MagnetizedFmDisk& rhs);
 
-}  // namespace AnalyticData
-}  // namespace grmhd
+}  // namespace grmhd::AnalyticData

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.cpp
@@ -37,6 +37,8 @@ MagnetizedTovStar::MagnetizedTovStar(const double central_rest_mass_density,
                            Scalar<double>{central_rest_mass_density}))),
       vector_potential_amplitude_(vector_potential_amplitude) {}
 
+MagnetizedTovStar::MagnetizedTovStar(CkMigrateMessage* msg) : tov_star(msg) {}
+
 void MagnetizedTovStar::pup(PUP::er& p) {
   tov_star::pup(p);
   p | pressure_exponent_;
@@ -99,6 +101,8 @@ MagnetizedTovStar::variables(
   }
   return magnetic_field;
 }
+
+PUP::able::PUP_ID MagnetizedTovStar::my_PUP_ID = 0;
 
 bool operator==(const MagnetizedTovStar& lhs, const MagnetizedTovStar& rhs) {
   return static_cast<const typename MagnetizedTovStar::tov_star&>(lhs) ==

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.hpp
@@ -8,12 +8,14 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
 #include "PointwiseFunctions/AnalyticData/GrMhd/AnalyticData.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Tov.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
 #include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -146,7 +148,8 @@ namespace grmhd::AnalyticData {
  * Note that the magnetic field strength goes as \f$A_b\f$ so any desired value
  * can be achieved by a linear scaling.
  */
-class MagnetizedTovStar : public MarkAsAnalyticData,
+class MagnetizedTovStar : public virtual evolution::initial_data::InitialData,
+                          public MarkAsAnalyticData,
                           private RelativisticEuler::Solutions::TovStar<
                               gr::Solutions::TovSolution> {
  private:
@@ -200,6 +203,12 @@ class MagnetizedTovStar : public MarkAsAnalyticData,
                     double polytropic_constant, double polytropic_exponent,
                     size_t pressure_exponent, double cutoff_pressure_fraction,
                     double vector_potential_amplitude);
+
+  /// \cond
+  explicit MagnetizedTovStar(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(MagnetizedTovStar);
+  /// \endcond
 
   // Overload the variables function from the base class.
   using tov_star::equation_of_state;

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.hpp
@@ -193,8 +193,8 @@ class MagnetizedTovStar : public virtual evolution::initial_data::InitialData,
   using tags = typename tov_star::template tags<DataType>;
 
   MagnetizedTovStar() = default;
-  MagnetizedTovStar(const MagnetizedTovStar& /*rhs*/) = delete;
-  MagnetizedTovStar& operator=(const MagnetizedTovStar& /*rhs*/) = delete;
+  MagnetizedTovStar(const MagnetizedTovStar& /*rhs*/) = default;
+  MagnetizedTovStar& operator=(const MagnetizedTovStar& /*rhs*/) = default;
   MagnetizedTovStar(MagnetizedTovStar&& /*rhs*/) = default;
   MagnetizedTovStar& operator=(MagnetizedTovStar&& /*rhs*/) = default;
   ~MagnetizedTovStar() = default;

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/OrszagTangVortex.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/OrszagTangVortex.cpp
@@ -18,6 +18,13 @@ namespace grmhd::AnalyticData {
 
 OrszagTangVortex::OrszagTangVortex() = default;
 
+OrszagTangVortex::OrszagTangVortex(CkMigrateMessage* msg) : InitialData(msg) {}
+
+void OrszagTangVortex::pup(PUP::er& p) {
+  InitialData::pup(p);
+  p | equation_of_state_;
+}
+
 template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::RestMassDensity<DataType>>
 OrszagTangVortex::variables(
@@ -98,7 +105,7 @@ OrszagTangVortex::variables(
       get<density_tag>(data), get<energy_tag>(data));
 }
 
-void OrszagTangVortex::pup(PUP::er& p) { p | equation_of_state_; }
+PUP::able::PUP_ID OrszagTangVortex::my_PUP_ID = 0;
 
 bool operator==(const OrszagTangVortex& /*lhs*/,
                 const OrszagTangVortex& /*rhs*/) {

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/OrszagTangVortex.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/OrszagTangVortex.hpp
@@ -69,8 +69,8 @@ class OrszagTangVortex : public evolution::initial_data::InitialData,
       "The relativistic Orszag-Tang vortex"};
 
   OrszagTangVortex();
-  OrszagTangVortex(const OrszagTangVortex& /*rhs*/) = delete;
-  OrszagTangVortex& operator=(const OrszagTangVortex& /*rhs*/) = delete;
+  OrszagTangVortex(const OrszagTangVortex& /*rhs*/) = default;
+  OrszagTangVortex& operator=(const OrszagTangVortex& /*rhs*/) = default;
   OrszagTangVortex(OrszagTangVortex&& /*rhs*/) = default;
   OrszagTangVortex& operator=(OrszagTangVortex&& /*rhs*/) = default;
   ~OrszagTangVortex() = default;

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/OrszagTangVortex.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/OrszagTangVortex.hpp
@@ -5,10 +5,12 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -21,8 +23,7 @@ class er;
 }  // namespace PUP
 /// \endcond
 
-namespace grmhd {
-namespace AnalyticData {
+namespace grmhd::AnalyticData {
 
 /*!
  * \brief Analytic initial data for the relativistic Orszag-Tang vortex.
@@ -57,7 +58,8 @@ namespace AnalyticData {
  * problem as presented here.
  * \endparblock
  */
-class OrszagTangVortex : public MarkAsAnalyticData {
+class OrszagTangVortex : public evolution::initial_data::InitialData,
+                         public MarkAsAnalyticData {
  public:
   using equation_of_state_type = EquationsOfState::IdealFluid<true>;
 
@@ -67,6 +69,17 @@ class OrszagTangVortex : public MarkAsAnalyticData {
       "The relativistic Orszag-Tang vortex"};
 
   OrszagTangVortex();
+  OrszagTangVortex(const OrszagTangVortex& /*rhs*/) = delete;
+  OrszagTangVortex& operator=(const OrszagTangVortex& /*rhs*/) = delete;
+  OrszagTangVortex(OrszagTangVortex&& /*rhs*/) = default;
+  OrszagTangVortex& operator=(OrszagTangVortex&& /*rhs*/) = default;
+  ~OrszagTangVortex() = default;
+
+  /// \cond
+  explicit OrszagTangVortex(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(OrszagTangVortex);
+  /// \endcond
 
   /// @{
   /// Retrieve hydro variable at `x`
@@ -148,5 +161,4 @@ bool operator==(const OrszagTangVortex& lhs, const OrszagTangVortex& rhs);
 
 bool operator!=(const OrszagTangVortex& lhs, const OrszagTangVortex& rhs);
 
-}  // namespace AnalyticData
-}  // namespace grmhd
+}  // namespace grmhd::AnalyticData

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/RiemannProblem.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/RiemannProblem.cpp
@@ -39,9 +39,10 @@ RiemannProblem::RiemannProblem(
       lapse_(lapse),
       shift_(shift) {}
 
-RiemannProblem::RiemannProblem(CkMigrateMessage* /*unused*/) {}
+RiemannProblem::RiemannProblem(CkMigrateMessage* msg) : InitialData(msg) {}
 
 void RiemannProblem::pup(PUP::er& p) {
+  InitialData::pup(p);
   p | equation_of_state_;
   p | background_spacetime_;
   p | adiabatic_index_;
@@ -189,6 +190,8 @@ RiemannProblem::variables(
   get<0>(shift) = shift_;
   return {std::move(shift)};
 }
+
+PUP::able::PUP_ID RiemannProblem::my_PUP_ID = 0;
 
 bool operator==(const RiemannProblem& lhs, const RiemannProblem& rhs) {
   return lhs.adiabatic_index_ == rhs.adiabatic_index_ and

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/RiemannProblem.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/RiemannProblem.hpp
@@ -201,8 +201,8 @@ class RiemannProblem : public evolution::initial_data::InitialData,
       "x=0."};
 
   RiemannProblem() = default;
-  RiemannProblem(const RiemannProblem& /*rhs*/) = delete;
-  RiemannProblem& operator=(const RiemannProblem& /*rhs*/) = delete;
+  RiemannProblem(const RiemannProblem& /*rhs*/) = default;
+  RiemannProblem& operator=(const RiemannProblem& /*rhs*/) = default;
   RiemannProblem(RiemannProblem&& /*rhs*/) = default;
   RiemannProblem& operator=(RiemannProblem&& /*rhs*/) = default;
   ~RiemannProblem() = default;

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/RiemannProblem.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/RiemannProblem.hpp
@@ -9,10 +9,12 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -116,7 +118,8 @@ namespace grmhd::AnalyticData {
  *  - ShiftX: 0.0
  *  - Final time: 0.55
  */
-class RiemannProblem : public MarkAsAnalyticData {
+class RiemannProblem : public evolution::initial_data::InitialData,
+                       public MarkAsAnalyticData {
  public:
   using equation_of_state_type = EquationsOfState::IdealFluid<true>;
 
@@ -213,7 +216,11 @@ class RiemannProblem : public MarkAsAnalyticData {
                  const std::array<double, 3>& right_magnetic_field,
                  double lapse, double shift);
 
-  explicit RiemannProblem(CkMigrateMessage* /*unused*/);
+  /// \cond
+  explicit RiemannProblem(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(RiemannProblem);
+  /// \endcond
 
   /// @{
   /// Retrieve the GRMHD variables at a given position.

--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/Bump.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/Bump.cpp
@@ -13,11 +13,12 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-namespace Burgers {
-namespace Solutions {
+namespace Burgers::Solutions {
 
 Bump::Bump(const double half_width, const double height, const double center)
     : half_width_(half_width), height_(height), center_(center) {}
+
+Bump::Bump(CkMigrateMessage* msg) : InitialData(msg) {}
 
 template <typename T>
 Scalar<T> Bump::u(const tnsr::I<T, 1>& x, double t) const {
@@ -64,13 +65,14 @@ tuples::TaggedTuple<::Tags::dt<Tags::U>> Bump::variables(
 }
 
 void Bump::pup(PUP::er& p) {
+  InitialData::pup(p);
   p | half_width_;
   p | height_;
   p | center_;
 }
 
-}  // namespace Solutions
-}  // namespace Burgers
+PUP::able::PUP_ID Bump::my_PUP_ID = 0;
+}  // namespace Burgers::Solutions
 
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/Bump.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/Bump.hpp
@@ -60,8 +60,8 @@ class Bump : public evolution::initial_data::InitialData,
   static constexpr Options::String help{"A bump solution"};
 
   Bump() = default;
-  Bump(const Bump&) = delete;
-  Bump& operator=(const Bump&) = delete;
+  Bump(const Bump&) = default;
+  Bump& operator=(const Bump&) = default;
   Bump(Bump&&) = default;
   Bump& operator=(Bump&&) = default;
   ~Bump() = default;

--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/Bump.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/Bump.hpp
@@ -9,7 +9,9 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/Burgers/Tags.hpp"  // IWYU pragma: keep
 #include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -21,8 +23,7 @@ class er;
 }  // namespace PUP
 /// \endcond
 
-namespace Burgers {
-namespace Solutions {
+namespace Burgers::Solutions {
 /*!
  * \brief A solution resembling a bump.
  *
@@ -35,7 +36,8 @@ namespace Solutions {
  * from infinity and reaches one of the zeros at \f$t = \frac{w}{2
  * h}\f$.
  */
-class Bump : public MarkAsAnalyticSolution {
+class Bump : public evolution::initial_data::InitialData,
+             public MarkAsAnalyticSolution {
  public:
   struct HalfWidth {
     using type = double;
@@ -66,6 +68,12 @@ class Bump : public MarkAsAnalyticSolution {
 
   Bump(double half_width, double height, double center = 0.);
 
+  /// \cond
+  explicit Bump(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Bump);
+  /// \endcond
+
   template <typename T>
   Scalar<T> u(const tnsr::I<T, 1>& x, double t) const;
 
@@ -88,5 +96,4 @@ class Bump : public MarkAsAnalyticSolution {
   double height_ = std::numeric_limits<double>::signaling_NaN();
   double center_ = std::numeric_limits<double>::signaling_NaN();
 };
-}  // namespace Solutions
-}  // namespace Burgers
+}  // namespace Burgers::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/Linear.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/Linear.cpp
@@ -12,10 +12,11 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-namespace Burgers {
-namespace Solutions {
+namespace Burgers::Solutions {
 
 Linear::Linear(const double shock_time) : shock_time_(shock_time) {}
+
+Linear::Linear(CkMigrateMessage* msg) : InitialData(msg) {}
 
 template <typename T>
 Scalar<T> Linear::u(const tnsr::I<T, 1>& x, double t) const {
@@ -43,10 +44,13 @@ tuples::TaggedTuple<::Tags::dt<Tags::U>> Linear::variables(
   return {du_dt(x, t)};
 }
 
-void Linear::pup(PUP::er& p) { p | shock_time_; }
+void Linear::pup(PUP::er& p) {
+  InitialData::pup(p);
+  p | shock_time_;
+}
 
-}  // namespace Solutions
-}  // namespace Burgers
+PUP::able::PUP_ID Linear::my_PUP_ID = 0;
+}  // namespace Burgers::Solutions
 
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/Linear.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/Linear.hpp
@@ -9,7 +9,9 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/Burgers/Tags.hpp"  // IWYU pragma: keep
 #include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -21,12 +23,12 @@ class er;
 }  // namespace PUP
 /// \endcond
 
-namespace Burgers {
-namespace Solutions {
+namespace Burgers::Solutions {
 /// A solution that is linear in space at all times.
 ///
 /// \f$u(x, t) = x / (t - t_0)\f$ where \f$t_0\f$ is the shock time.
-class Linear : public MarkAsAnalyticSolution {
+class Linear : public evolution::initial_data::InitialData,
+               public MarkAsAnalyticSolution {
  public:
   struct ShockTime {
     using type = double;
@@ -44,6 +46,12 @@ class Linear : public MarkAsAnalyticSolution {
   ~Linear() = default;
 
   explicit Linear(double shock_time);
+
+  /// \cond
+  explicit Linear(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Linear);
+  /// \endcond
 
   template <typename T>
   Scalar<T> u(const tnsr::I<T, 1>& x, double t) const;
@@ -65,5 +73,4 @@ class Linear : public MarkAsAnalyticSolution {
  private:
   double shock_time_ = std::numeric_limits<double>::signaling_NaN();
 };
-}  // namespace Solutions
-}  // namespace Burgers
+}  // namespace Burgers::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/Linear.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/Linear.hpp
@@ -39,8 +39,8 @@ class Linear : public evolution::initial_data::InitialData,
   static constexpr Options::String help{"A spatially linear solution"};
 
   Linear() = default;
-  Linear(const Linear&) = delete;
-  Linear& operator=(const Linear&) = delete;
+  Linear(const Linear&) = default;
+  Linear& operator=(const Linear&) = default;
   Linear(Linear&&) = default;
   Linear& operator=(Linear&&) = default;
   ~Linear() = default;

--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/Step.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/Step.cpp
@@ -13,8 +13,7 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-namespace Burgers {
-namespace Solutions {
+namespace Burgers::Solutions {
 
 Step::Step(const double left_value, const double right_value,
            const double initial_shock_position, const Options::Context& context)
@@ -25,6 +24,8 @@ Step::Step(const double left_value, const double right_value,
     PARSE_ERROR(context, "Shock solution expects left_value > right_value");
   }
 }
+
+Step::Step(CkMigrateMessage* msg) : InitialData(msg) {}
 
 template <typename T>
 Scalar<T> Step::u(const tnsr::I<T, 1>& x, const double t) const {
@@ -53,13 +54,14 @@ tuples::TaggedTuple<::Tags::dt<Tags::U>> Step::variables(
 }
 
 void Step::pup(PUP::er& p) {
+  InitialData::pup(p);
   p | left_value_;
   p | right_value_;
   p | initial_shock_position_;
 }
 
-}  // namespace Solutions
-}  // namespace Burgers
+PUP::able::PUP_ID Step::my_PUP_ID = 0;
+}  // namespace Burgers::Solutions
 
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/Step.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/Step.hpp
@@ -9,7 +9,9 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/Burgers/Tags.hpp"  // IWYU pragma: keep
 #include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -21,8 +23,7 @@ class er;
 }  // namespace PUP
 /// \endcond
 
-namespace Burgers {
-namespace Solutions {
+namespace Burgers::Solutions {
 /// \brief A propagating shock between two constant states
 ///
 /// The shock propagates left-to-right, with profile
@@ -36,7 +37,8 @@ namespace Solutions {
 /// (This is inherited from the Heaviside implementation `step_function`.)
 /// Additionally, the time derivative \f$\partial_t u0\f$ is zero, rather than
 /// the correct delta function.
-class Step : public MarkAsAnalyticSolution {
+class Step : public evolution::initial_data::InitialData,
+             public MarkAsAnalyticSolution {
  public:
   struct LeftValue {
     using type = double;
@@ -66,6 +68,12 @@ class Step : public MarkAsAnalyticSolution {
   Step& operator=(Step&&) = default;
   ~Step() = default;
 
+  /// \cond
+  explicit Step(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Step);
+  /// \endcond
+
   template <typename T>
   Scalar<T> u(const tnsr::I<T, 1>& x, double t) const;
 
@@ -88,5 +96,4 @@ class Step : public MarkAsAnalyticSolution {
   double right_value_ = std::numeric_limits<double>::signaling_NaN();
   double initial_shock_position_ = std::numeric_limits<double>::signaling_NaN();
 };
-}  // namespace Solutions
-}  // namespace Burgers
+}  // namespace Burgers::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.cpp
@@ -72,7 +72,10 @@ AlfvenWave::AlfvenWave(const double wavenumber, const double pressure,
   fluid_speed_ = -auxiliary_speed_b1 * one_over_speed_denominator;
 }
 
+AlfvenWave::AlfvenWave(CkMigrateMessage* msg) : InitialData(msg) {}
+
 void AlfvenWave::pup(PUP::er& p) {
+  InitialData::pup(p);
   p | wavenumber_;
   p | pressure_;
   p | rest_mass_density_;
@@ -187,6 +190,8 @@ AlfvenWave::variables(
   get(specific_internal_energy) += 1.0;
   return {std::move(specific_internal_energy)};
 }
+
+PUP::able::PUP_ID AlfvenWave::my_PUP_ID = 0;
 
 bool operator==(const AlfvenWave& lhs, const AlfvenWave& rhs) {
   // there is no comparison operator for the EoS, but should be okay as

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.hpp
@@ -9,11 +9,13 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GrMhd/Solutions.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
 #include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -25,8 +27,7 @@ class er;  // IWYU pragma: keep
 }  // namespace PUP
 /// \endcond
 
-namespace grmhd {
-namespace Solutions {
+namespace grmhd::Solutions {
 
 /*!
  * \brief Circularly polarized Alfv&eacute;n wave solution in Minkowski
@@ -87,7 +88,9 @@ namespace Solutions {
  *
  * \f[b^2 = B_0^2 + B_1^2 - B_0^2 v_f^2\f]
  */
-class AlfvenWave : public AnalyticSolution, public MarkAsAnalyticSolution {
+class AlfvenWave : public evolution::initial_data::InitialData,
+                   public AnalyticSolution,
+                   public MarkAsAnalyticSolution {
  public:
   using equation_of_state_type = EquationsOfState::IdealFluid<true>;
 
@@ -155,6 +158,12 @@ class AlfvenWave : public AnalyticSolution, public MarkAsAnalyticSolution {
              double adiabatic_index,
              const std::array<double, 3>& background_magnetic_field,
              const std::array<double, 3>& wave_magnetic_field);
+
+  /// \cond
+  explicit AlfvenWave(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(AlfvenWave);
+  /// \endcond
 
   /// @{
   /// Retrieve hydro variable at `(x, t)`
@@ -258,5 +267,4 @@ class AlfvenWave : public AnalyticSolution, public MarkAsAnalyticSolution {
 
 bool operator!=(const AlfvenWave& lhs, const AlfvenWave& rhs);
 
-}  // namespace Solutions
-}  // namespace grmhd
+}  // namespace grmhd::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.hpp
@@ -148,8 +148,8 @@ class AlfvenWave : public evolution::initial_data::InitialData,
       "Circularly polarized Alfven wave in Minkowski spacetime."};
 
   AlfvenWave() = default;
-  AlfvenWave(const AlfvenWave& /*rhs*/) = delete;
-  AlfvenWave& operator=(const AlfvenWave& /*rhs*/) = delete;
+  AlfvenWave(const AlfvenWave& /*rhs*/) = default;
+  AlfvenWave& operator=(const AlfvenWave& /*rhs*/) = default;
   AlfvenWave(AlfvenWave&& /*rhs*/) = default;
   AlfvenWave& operator=(AlfvenWave&& /*rhs*/) = default;
   ~AlfvenWave() = default;

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.cpp
@@ -75,7 +75,10 @@ BondiMichel::BondiMichel(const double mass, const double sonic_radius,
                            1.0 / gamma_minus_one);
 }
 
+BondiMichel::BondiMichel(CkMigrateMessage* msg) : InitialData(msg) {}
+
 void BondiMichel::pup(PUP::er& p) {
+  InitialData::pup(p);
   p | mass_;
   p | sonic_radius_;
   p | sonic_density_;
@@ -293,6 +296,8 @@ BondiMichel::variables(
   result.get(2) = mag_field_strength_factor * x.get(2);
   return result;
 }
+
+PUP::able::PUP_ID BondiMichel::my_PUP_ID = 0;
 
 bool operator==(const BondiMichel& lhs, const BondiMichel& rhs) {
   // there is no comparison operator for the EoS, but should be okay as

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.hpp
@@ -8,17 +8,18 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GrMhd/Solutions.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
-namespace grmhd {
-namespace Solutions {
+namespace grmhd::Solutions {
 
 /*!
  * \brief Bondi-Michel accretion \cite Michel1972 with superposed magnetic field
@@ -162,7 +163,9 @@ namespace Solutions {
  *
  * The magnetic field \f$b^2\f$ is the same as the \f$\gamma\ne5/3\f$.
  */
-class BondiMichel : public AnalyticSolution, public MarkAsAnalyticSolution {
+class BondiMichel : public evolution::initial_data::InitialData,
+                    public AnalyticSolution,
+                    public MarkAsAnalyticSolution {
  protected:
   template <typename DataType>
   struct IntermediateVars;
@@ -225,6 +228,12 @@ class BondiMichel : public AnalyticSolution, public MarkAsAnalyticSolution {
 
   BondiMichel(double mass, double sonic_radius, double sonic_density,
               double polytropic_exponent, double mag_field_strength);
+
+  /// \cond
+  explicit BondiMichel(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(BondiMichel);
+  /// \endcond
 
   /// Retrieve a collection of  hydro variables at `(x, t)`
   template <typename DataType, typename... Tags>
@@ -381,5 +390,4 @@ class BondiMichel : public AnalyticSolution, public MarkAsAnalyticSolution {
 
 bool operator!=(const BondiMichel& lhs, const BondiMichel& rhs);
 
-}  // namespace Solutions
-}  // namespace grmhd
+}  // namespace grmhd::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.hpp
@@ -220,8 +220,8 @@ class BondiMichel : public evolution::initial_data::InitialData,
       "where the fluid speed overtakes the sound speed."};
 
   BondiMichel() = default;
-  BondiMichel(const BondiMichel& /*rhs*/) = delete;
-  BondiMichel& operator=(const BondiMichel& /*rhs*/) = delete;
+  BondiMichel(const BondiMichel& /*rhs*/) = default;
+  BondiMichel& operator=(const BondiMichel& /*rhs*/) = default;
   BondiMichel(BondiMichel&& /*rhs*/) = default;
   BondiMichel& operator=(BondiMichel&& /*rhs*/) = default;
   ~BondiMichel() = default;

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.cpp
@@ -64,7 +64,10 @@ KomissarovShock::KomissarovShock(
       right_magnetic_field_(right_magnetic_field),
       shock_speed_(shock_speed) {}
 
+KomissarovShock::KomissarovShock(CkMigrateMessage* msg) : InitialData(msg) {}
+
 void KomissarovShock::pup(PUP::er& p) {
+  InitialData::pup(p);
   p | adiabatic_index_;
   p | left_rest_mass_density_;
   p | right_rest_mass_density_;
@@ -157,6 +160,8 @@ KomissarovShock::variables(
       get<hydro::Tags::SpecificInternalEnergy<DataType>>(variables(
           x, t, tmpl::list<hydro::Tags::SpecificInternalEnergy<DataType>>{})));
 }
+
+PUP::able::PUP_ID KomissarovShock::my_PUP_ID = 0;
 
 bool operator==(const KomissarovShock& lhs, const KomissarovShock& rhs) {
   return lhs.adiabatic_index_ == rhs.adiabatic_index_ and

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.hpp
@@ -9,11 +9,13 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GrMhd/Solutions.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -25,8 +27,7 @@ class er;  // IWYU pragma: keep
 }  // namespace PUP
 /// \endcond
 
-namespace grmhd {
-namespace Solutions {
+namespace grmhd::Solutions {
 
 /*!
  * \brief A one-dimensional shock solution for an ideal fluid in Minkowski
@@ -42,7 +43,9 @@ namespace Solutions {
  * be represented by a single element with periodic boundary conditions in the
  * \f$y\f$ and \f$z\f$ directions.
  */
-class KomissarovShock : public AnalyticSolution, public MarkAsAnalyticSolution {
+class KomissarovShock : public evolution::initial_data::InitialData,
+                        public AnalyticSolution,
+                        public MarkAsAnalyticSolution {
  public:
   using equation_of_state_type = EquationsOfState::IdealFluid<true>;
 
@@ -131,7 +134,11 @@ class KomissarovShock : public AnalyticSolution, public MarkAsAnalyticSolution {
                   const std::array<double, 3>& right_magnetic_field,
                   double shock_speed);
 
-  explicit KomissarovShock(CkMigrateMessage* /*unused*/) {}
+  /// \cond
+  explicit KomissarovShock(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(KomissarovShock);
+  /// \endcond
 
   /// @{
   /// Retrieve the GRMHD variables at a given position.
@@ -238,5 +245,4 @@ class KomissarovShock : public AnalyticSolution, public MarkAsAnalyticSolution {
                          const KomissarovShock& rhs);
 };
 
-}  // namespace Solutions
-}  // namespace grmhd
+}  // namespace grmhd::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.hpp
@@ -119,8 +119,8 @@ class KomissarovShock : public evolution::initial_data::InitialData,
       "x=0."};
 
   KomissarovShock() = default;
-  KomissarovShock(const KomissarovShock& /*rhs*/) = delete;
-  KomissarovShock& operator=(const KomissarovShock& /*rhs*/) = delete;
+  KomissarovShock(const KomissarovShock& /*rhs*/) = default;
+  KomissarovShock& operator=(const KomissarovShock& /*rhs*/) = default;
   KomissarovShock(KomissarovShock&& /*rhs*/) = default;
   KomissarovShock& operator=(KomissarovShock&& /*rhs*/) = default;
   ~KomissarovShock() = default;

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.cpp
@@ -21,6 +21,9 @@ SmoothFlow::SmoothFlow(const std::array<double, 3>& mean_velocity,
                                                   pressure, adiabatic_index,
                                                   perturbation_size) {}
 
+SmoothFlow::SmoothFlow(CkMigrateMessage* msg)
+    : RelativisticEuler::Solutions::SmoothFlow<3>(msg) {}
+
 void SmoothFlow::pup(PUP::er& p) {
   RelativisticEuler::Solutions::SmoothFlow<3>::pup(p);
 }
@@ -40,6 +43,8 @@ SmoothFlow::variables(
     tmpl::list<hydro::Tags::DivergenceCleaningField<DataType>> /*meta*/) const {
   return {make_with_value<Scalar<DataType>>(x, 0.0)};
 }
+
+PUP::able::PUP_ID SmoothFlow::my_PUP_ID = 0;
 
 bool operator==(const SmoothFlow& lhs, const SmoothFlow& rhs) {
   using smooth_flow = RelativisticEuler::Solutions::SmoothFlow<3>;

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.hpp
@@ -8,6 +8,7 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GrMhd/Solutions.hpp"
@@ -16,8 +17,7 @@
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
-namespace grmhd {
-namespace Solutions {
+namespace grmhd::Solutions {
 
 /*!
  * \brief Periodic GrMhd solution in Minkowski spacetime.
@@ -58,6 +58,12 @@ class SmoothFlow : virtual public MarkAsAnalyticSolution,
              const std::array<double, 3>& wavevector, double pressure,
              double adiabatic_index, double perturbation_size);
 
+  /// \cond
+  explicit SmoothFlow(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(SmoothFlow);
+  /// \endcond
+
   using smooth_flow::equation_of_state;
   using smooth_flow::equation_of_state_type;
 
@@ -97,5 +103,4 @@ class SmoothFlow : virtual public MarkAsAnalyticSolution,
 };
 
 bool operator!=(const SmoothFlow& lhs, const SmoothFlow& rhs);
-}  // namespace Solutions
-}  // namespace grmhd
+}  // namespace grmhd::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.hpp
@@ -48,8 +48,8 @@ class SmoothFlow : virtual public MarkAsAnalyticSolution,
       "Periodic smooth flow in Minkowski spacetime with zero magnetic field."};
 
   SmoothFlow() = default;
-  SmoothFlow(const SmoothFlow& /*rhs*/) = delete;
-  SmoothFlow& operator=(const SmoothFlow& /*rhs*/) = delete;
+  SmoothFlow(const SmoothFlow& /*rhs*/) = default;
+  SmoothFlow& operator=(const SmoothFlow& /*rhs*/) = default;
   SmoothFlow(SmoothFlow&& /*rhs*/) = default;
   SmoothFlow& operator=(SmoothFlow&& /*rhs*/) = default;
   ~SmoothFlow() = default;

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.cpp
@@ -27,6 +27,9 @@
 
 namespace RelativisticEuler::Solutions {
 
+FishboneMoncriefDisk::FishboneMoncriefDisk(CkMigrateMessage* msg)
+    : InitialData(msg) {}
+
 FishboneMoncriefDisk::FishboneMoncriefDisk(const double bh_mass,
                                            const double bh_dimless_spin,
                                            const double inner_edge_radius,
@@ -56,6 +59,7 @@ FishboneMoncriefDisk::FishboneMoncriefDisk(const double bh_mass,
 }
 
 void FishboneMoncriefDisk::pup(PUP::er& p) {
+  InitialData::pup(p);
   p | bh_mass_;
   p | bh_spin_a_;
   p | inner_edge_radius_;
@@ -310,6 +314,8 @@ void FishboneMoncriefDisk::variables_impl(
     }
   }
 }
+
+PUP::able::PUP_ID FishboneMoncriefDisk::my_PUP_ID = 0;
 
 bool operator==(const FishboneMoncriefDisk& lhs,
                 const FishboneMoncriefDisk& rhs) {

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp
@@ -8,11 +8,13 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Solutions.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
@@ -148,8 +150,10 @@ namespace Solutions {
  * \f$l_* = u_\phi u^t\f$ in order to
  * distinguish this quantity from their own definition \f$l = - u_\phi/u_t\f$.
  */
-class FishboneMoncriefDisk : public MarkAsAnalyticSolution,
-                             public AnalyticSolution<3> {
+class FishboneMoncriefDisk
+    : public virtual evolution::initial_data::InitialData,
+      public MarkAsAnalyticSolution,
+      public AnalyticSolution<3> {
  protected:
   template <typename DataType, bool NeedSpacetime>
   struct IntermediateVariables;
@@ -214,6 +218,12 @@ class FishboneMoncriefDisk : public MarkAsAnalyticSolution,
   FishboneMoncriefDisk(double bh_mass, double bh_dimless_spin,
                        double inner_edge_radius, double max_pressure_radius,
                        double polytropic_constant, double polytropic_exponent);
+
+  /// \cond
+  explicit FishboneMoncriefDisk(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(FishboneMoncriefDisk);
+  /// \endcond
 
   // Eventually, if we implement a gr::Solutions::BoyerLindquist
   // black hole, the following two functions aren't needed, and the algebra

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp
@@ -209,8 +209,9 @@ class FishboneMoncriefDisk
       "Fluid disk orbiting a Kerr black hole."};
 
   FishboneMoncriefDisk() = default;
-  FishboneMoncriefDisk(const FishboneMoncriefDisk& /*rhs*/) = delete;
-  FishboneMoncriefDisk& operator=(const FishboneMoncriefDisk& /*rhs*/) = delete;
+  FishboneMoncriefDisk(const FishboneMoncriefDisk& /*rhs*/) = default;
+  FishboneMoncriefDisk& operator=(const FishboneMoncriefDisk& /*rhs*/) =
+      default;
   FishboneMoncriefDisk(FishboneMoncriefDisk&& /*rhs*/) = default;
   FishboneMoncriefDisk& operator=(FishboneMoncriefDisk&& /*rhs*/) = default;
   ~FishboneMoncriefDisk() = default;

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.cpp
@@ -28,7 +28,8 @@ SmoothFlow<Dim>::SmoothFlow(const std::array<double, Dim>& mean_velocity,
                   perturbation_size} {}
 
 template <size_t Dim>
-SmoothFlow<Dim>::SmoothFlow(CkMigrateMessage* msg) : smooth_flow(msg) {}
+SmoothFlow<Dim>::SmoothFlow(CkMigrateMessage* msg)
+    : InitialData(msg), smooth_flow(msg) {}
 
 template <size_t Dim>
 template <typename DataType>
@@ -50,9 +51,13 @@ SmoothFlow<Dim>::variables(
 
 template <size_t Dim>
 void SmoothFlow<Dim>::pup(PUP::er& p) {
+  InitialData::pup(p);
   hydro::Solutions::SmoothFlow<Dim, true>::pup(p);
   p | background_spacetime_;
 }
+
+template <size_t Dim>
+PUP::able::PUP_ID SmoothFlow<Dim>::my_PUP_ID = 0;
 
 template <size_t Dim>
 bool operator==(const SmoothFlow<Dim>& lhs, const SmoothFlow<Dim>& rhs) {

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.hpp
@@ -67,8 +67,8 @@ class SmoothFlow : public evolution::initial_data::InitialData,
       "Smooth flow in Minkowski spacetime."};
 
   SmoothFlow() = default;
-  SmoothFlow(const SmoothFlow& /*rhs*/) = delete;
-  SmoothFlow& operator=(const SmoothFlow& /*rhs*/) = delete;
+  SmoothFlow(const SmoothFlow& /*rhs*/) = default;
+  SmoothFlow& operator=(const SmoothFlow& /*rhs*/) = default;
   SmoothFlow(SmoothFlow&& /*rhs*/) = default;
   SmoothFlow& operator=(SmoothFlow&& /*rhs*/) = default;
   ~SmoothFlow() = default;

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.hpp
@@ -9,12 +9,14 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Hydro/SmoothFlow.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Solutions.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
 #include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -52,7 +54,8 @@ namespace RelativisticEuler::Solutions {
  * where the pressure is held constant.
  */
 template <size_t Dim>
-class SmoothFlow : virtual public MarkAsAnalyticSolution,
+class SmoothFlow : public evolution::initial_data::InitialData,
+                   virtual public MarkAsAnalyticSolution,
                    public AnalyticSolution<Dim>,
                    private hydro::Solutions::SmoothFlow<Dim, true> {
   using smooth_flow = hydro::Solutions::SmoothFlow<Dim, true>;
@@ -74,7 +77,11 @@ class SmoothFlow : virtual public MarkAsAnalyticSolution,
              const std::array<double, Dim>& wavevector, double pressure,
              double adiabatic_index, double perturbation_size);
 
+  /// \cond
   explicit SmoothFlow(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(SmoothFlow);
+  /// \endcond
 
   using smooth_flow::equation_of_state;
   using typename smooth_flow::equation_of_state_type;

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.cpp
@@ -19,6 +19,9 @@
 namespace RelativisticEuler::Solutions {
 
 template <typename RadialSolution>
+TovStar<RadialSolution>::TovStar(CkMigrateMessage* msg) : InitialData(msg) {}
+
+template <typename RadialSolution>
 TovStar<RadialSolution>::TovStar(const double central_rest_mass_density,
                                  const double polytropic_constant,
                                  const double polytropic_exponent)
@@ -29,6 +32,7 @@ TovStar<RadialSolution>::TovStar(const double central_rest_mass_density,
 
 template <typename RadialSolution>
 void TovStar<RadialSolution>::pup(PUP::er& p) {
+  InitialData::pup(p);
   p | central_rest_mass_density_;
   p | polytropic_constant_;
   p | polytropic_exponent_;
@@ -290,6 +294,9 @@ tuples::TaggedTuple<::Tags::dt<Tag>> TovStar<RadialSolution>::variables(
     const RadialVariables<DataType>& /*radial_vars*/) const {
   return make_with_value<typename ::Tags::dt<Tag>::type>(get<0>(x), 0.0);
 }
+
+template <typename RadialSolution>
+PUP::able::PUP_ID TovStar<RadialSolution>::my_PUP_ID = 0;
 
 template <typename LocalRadialSolution>
 bool operator==(const TovStar<LocalRadialSolution>& lhs,

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp
@@ -9,11 +9,13 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Solutions.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -44,7 +46,9 @@ namespace Solutions {
  * more details.
  */
 template <typename RadialSolution>
-class TovStar : public MarkAsAnalyticSolution, public AnalyticSolution<3> {
+class TovStar : public virtual evolution::initial_data::InitialData,
+                public MarkAsAnalyticSolution,
+                public AnalyticSolution<3> {
  public:
   /*!
    * \brief The radial variables needed to compute the full `TOVStar` solution
@@ -156,6 +160,12 @@ class TovStar : public MarkAsAnalyticSolution, public AnalyticSolution<3> {
 
   TovStar(double central_rest_mass_density, double polytropic_constant,
           double polytropic_exponent);
+
+  /// \cond
+  explicit TovStar(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(TovStar);
+  /// \endcond
 
   /// Retrieve a collection of variables at `(x, t)`
   template <typename DataType, typename... Tags>

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp
@@ -152,8 +152,8 @@ class TovStar : public virtual evolution::initial_data::InitialData,
       "density and polytropic fluid."};
 
   TovStar() = default;
-  TovStar(const TovStar& /*rhs*/) = delete;
-  TovStar& operator=(const TovStar& /*rhs*/) = delete;
+  TovStar(const TovStar& /*rhs*/) = default;
+  TovStar& operator=(const TovStar& /*rhs*/) = default;
   TovStar(TovStar&& /*rhs*/) = default;
   TovStar& operator=(TovStar&& /*rhs*/) = default;
   ~TovStar() = default;

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.cpp
@@ -26,6 +26,9 @@ PlaneWave<Dim>::PlaneWave(
       omega_(magnitude(wave_vector_)) {}
 
 template <size_t Dim>
+PlaneWave<Dim>::PlaneWave(CkMigrateMessage* msg) : InitialData(msg) {}
+
+template <size_t Dim>
 template <typename T>
 Scalar<T> PlaneWave<Dim>::psi(const tnsr::I<T, Dim>& x, const double t) const {
   return Scalar<T>(profile_->operator()(u(x, t)));
@@ -111,6 +114,7 @@ PlaneWave<Dim>::variables(
 
 template <size_t Dim>
 void PlaneWave<Dim>::pup(PUP::er& p) {
+  InitialData::pup(p);
   p | wave_vector_;
   p | center_;
   p | profile_;
@@ -127,6 +131,8 @@ T PlaneWave<Dim>::u(const tnsr::I<T, Dim>& x, const double t) const {
   return result;
 }
 
+template <size_t Dim>
+PUP::able::PUP_ID PlaneWave<Dim>::my_PUP_ID = 0;
 }  // namespace ScalarWave::Solutions
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
@@ -12,7 +12,9 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/TMPL.hpp"
@@ -38,8 +40,7 @@ class er;
 }  // namespace PUP
 /// \endcond
 
-namespace ScalarWave {
-namespace Solutions {
+namespace ScalarWave::Solutions {
 /*!
  * \brief A plane wave solution to the Euclidean wave equation
  *
@@ -52,7 +53,8 @@ namespace Solutions {
  * \tparam Dim the spatial dimension of the solution
  */
 template <size_t Dim>
-class PlaneWave : public MarkAsAnalyticSolution {
+class PlaneWave : public evolution::initial_data::InitialData,
+                  public MarkAsAnalyticSolution {
  public:
   static constexpr size_t volume_dim = Dim;
   struct WaveVector {
@@ -88,6 +90,12 @@ class PlaneWave : public MarkAsAnalyticSolution {
   PlaneWave(PlaneWave&&) = default;
   PlaneWave& operator=(PlaneWave&&) = default;
   ~PlaneWave() = default;
+
+  /// \cond
+  explicit PlaneWave(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(PlaneWave);
+  /// \endcond
 
   /// The value of the scalar field
   template <typename T>
@@ -141,5 +149,4 @@ class PlaneWave : public MarkAsAnalyticSolution {
   std::unique_ptr<MathFunction<1, Frame::Inertial>> profile_;
   double omega_{};
 };
-}  // namespace Solutions
-}  // namespace ScalarWave
+}  // namespace ScalarWave::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.cpp
@@ -25,6 +25,9 @@ RegularSphericalWave::RegularSphericalWave(
     std::unique_ptr<MathFunction<1, Frame::Inertial>> profile)
     : profile_(std::move(profile)) {}
 
+RegularSphericalWave::RegularSphericalWave(CkMigrateMessage* msg)
+    : InitialData(msg) {}
+
 tuples::TaggedTuple<Tags::Psi, Tags::Pi, Tags::Phi<3>>
 RegularSphericalWave::variables(
     const tnsr::I<DataVector, 3>& x, double t,
@@ -105,6 +108,10 @@ RegularSphericalWave::variables(
   return dt_variables;
 }
 
-void RegularSphericalWave::pup(PUP::er& p) { p | profile_; }
+void RegularSphericalWave::pup(PUP::er& p) {
+  InitialData::pup(p);
+  p | profile_;
+}
 
+PUP::able::PUP_ID RegularSphericalWave::my_PUP_ID = 0;
 }  // namespace ScalarWave::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp
@@ -11,7 +11,9 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"  // IWYU pragma: keep
 #include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -36,8 +38,7 @@ class er;
 }  // namespace PUP
 /// \endcond
 
-namespace ScalarWave {
-namespace Solutions {
+namespace ScalarWave::Solutions {
 /*!
  * \brief A 3D spherical wave solution to the Euclidean wave equation that is
  * regular at the origin
@@ -63,7 +64,8 @@ namespace Solutions {
  * because of the scale invariance of the wave equation. The profile could be a
  * Gausssian centered at 0 with width 1, for instance.
  */
-class RegularSphericalWave : public MarkAsAnalyticSolution {
+class RegularSphericalWave : public evolution::initial_data::InitialData,
+                             public MarkAsAnalyticSolution {
  public:
   static constexpr size_t volume_dim = 3;
   struct Profile {
@@ -91,6 +93,12 @@ class RegularSphericalWave : public MarkAsAnalyticSolution {
   RegularSphericalWave& operator=(RegularSphericalWave&&) = default;
   ~RegularSphericalWave() = default;
 
+  /// \cond
+  explicit RegularSphericalWave(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(RegularSphericalWave);
+  /// \endcond
+
   tuples::TaggedTuple<Tags::Psi, Tags::Pi, Tags::Phi<3>> variables(
       const tnsr::I<DataVector, 3>& x, double t,
       tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<3>> /*meta*/) const;
@@ -107,5 +115,4 @@ class RegularSphericalWave : public MarkAsAnalyticSolution {
  private:
   std::unique_ptr<MathFunction<1, Frame::Inertial>> profile_;
 };
-}  // namespace Solutions
-}  // namespace ScalarWave
+}  // namespace ScalarWave::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/SemidiscretizedDg.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/SemidiscretizedDg.cpp
@@ -23,6 +23,9 @@ SemidiscretizedDg::SemidiscretizedDg(const int harmonic,
                                      const std::array<double, 4>& amplitudes)
     : harmonic_(harmonic), amplitudes_(amplitudes) {}
 
+SemidiscretizedDg::SemidiscretizedDg(CkMigrateMessage* msg)
+    : InitialData(msg) {}
+
 namespace {
 struct Mode {
   std::complex<double> frequency;
@@ -152,7 +155,10 @@ tuples::TaggedTuple<Tags::Psi> SemidiscretizedDg::variables(
 }
 
 void SemidiscretizedDg::pup(PUP::er& p) {
+  InitialData::pup(p);
   p | harmonic_;
   p | amplitudes_;
 }
+
+PUP::able::PUP_ID SemidiscretizedDg::my_PUP_ID = 0;
 }  // namespace ScalarWave::Solutions

--- a/src/PointwiseFunctions/GeneralRelativity/KerrSchildCoords.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/KerrSchildCoords.hpp
@@ -151,8 +151,8 @@ namespace gr {
 class KerrSchildCoords {
  public:
   KerrSchildCoords() = default;
-  KerrSchildCoords(const KerrSchildCoords& /*rhs*/) = delete;
-  KerrSchildCoords& operator=(const KerrSchildCoords& /*rhs*/) = delete;
+  KerrSchildCoords(const KerrSchildCoords& /*rhs*/) = default;
+  KerrSchildCoords& operator=(const KerrSchildCoords& /*rhs*/) = default;
   KerrSchildCoords(KerrSchildCoords&& /*rhs*/) = default;
   KerrSchildCoords& operator=(KerrSchildCoords&& /*rhs*/) = default;
   ~KerrSchildCoords() = default;

--- a/tests/Unit/Framework/Tests/Test_TestCreation.cpp
+++ b/tests/Unit/Framework/Tests/Test_TestCreation.cpp
@@ -232,6 +232,15 @@ void test_test_creation() {
             .value == 24);
 }
 
+// [test_option_tag_factory_creation_tag]
+namespace OptionTags {
+struct BaseClass {
+  static constexpr Options::String help = "Halp";
+  using type = std::unique_ptr<::BaseClass>;
+};
+}  // namespace OptionTags
+// [test_option_tag_factory_creation_tag]
+
 void test_test_factory_creation() {
   // [test_factory_creation]
   CHECK(TestHelpers::test_factory_creation<BaseClass, DerivedClass>(
@@ -239,6 +248,14 @@ void test_test_factory_creation() {
             "  SizeT: 5")
             ->get_value() == 5);
   // [test_factory_creation]
+
+  // [test_option_tag_factory_creation]
+  CHECK(TestHelpers::test_option_tag_factory_creation<OptionTags::BaseClass,
+                                                      DerivedClass>(
+            "DerivedClass:\n"
+            "  SizeT: 5")
+            ->get_value() == 5);
+  // [test_option_tag_factory_creation]
 }
 
 void test_test_enum_creation() {

--- a/tests/Unit/PointwiseFunctions/AnalyticData/Burgers/Test_Sinusoid.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/Burgers/Test_Sinusoid.cpp
@@ -43,9 +43,9 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticData.Burgers.Sinusoid",
           Burgers::AnalyticData::Sinusoid>("Sinusoid:\n");
   const auto deserialized_option_solution =
       serialize_and_deserialize(option_solution);
-  const auto& periodic = dynamic_cast<const Burgers::AnalyticData::Sinusoid&>(
+  const auto& sinusoid = dynamic_cast<const Burgers::AnalyticData::Sinusoid&>(
       *deserialized_option_solution);
-  CHECK(periodic == Burgers::AnalyticData::Sinusoid{});
+  CHECK(sinusoid == Burgers::AnalyticData::Sinusoid{});
   test_move_semantics(Burgers::AnalyticData::Sinusoid{},
                       Burgers::AnalyticData::Sinusoid{});
 

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_KhInstability.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_KhInstability.cpp
@@ -3,12 +3,17 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <memory>
+
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/AnalyticData/GrMhd/KhInstability.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/Tags/InitialData.hpp"
 
 namespace {
 struct KhInstabilityProxy : public ::grmhd::AnalyticData::KhInstability {
@@ -50,18 +55,29 @@ void test(const DataType& used_for_size) {
       strip_velocity, background_density, background_velocity, pressure,
       perturbation_amplitude, perturbation_width, magnetic_field);
 
-  const auto kh_instability = TestHelpers::test_creation<KhInstabilityProxy>(
-      "  AdiabaticIndex: 1.43\n"
-      "  StripBimedianHeight: 0.5\n"
-      "  StripThickness: 0.4\n"
-      "  StripDensity: 2.1\n"
-      "  StripVelocity: 0.3\n"
-      "  BackgroundDensity: 2.0\n"
-      "  BackgroundVelocity: -0.2\n"
-      "  Pressure: 1.1\n"
-      "  PerturbAmplitude: 0.1\n"
-      "  PerturbWidth: 0.01\n"
-      "  MagneticField: [1.0e-3, 0.0, 0.0]\n");
+  Parallel::register_classes_with_charm<grmhd::AnalyticData::KhInstability>();
+  const std::unique_ptr<evolution::initial_data::InitialData> option_solution =
+      TestHelpers::test_option_tag_factory_creation<
+          evolution::initial_data::OptionTags::InitialData,
+          grmhd::AnalyticData::KhInstability>(
+          "KhInstability:\n"
+          "  AdiabaticIndex: 1.43\n"
+          "  StripBimedianHeight: 0.5\n"
+          "  StripThickness: 0.4\n"
+          "  StripDensity: 2.1\n"
+          "  StripVelocity: 0.3\n"
+          "  BackgroundDensity: 2.0\n"
+          "  BackgroundVelocity: -0.2\n"
+          "  Pressure: 1.1\n"
+          "  PerturbAmplitude: 0.1\n"
+          "  PerturbWidth: 0.01\n"
+          "  MagneticField: [1.0e-3, 0.0, 0.0]\n");
+  const auto deserialized_option_solution =
+      serialize_and_deserialize(option_solution);
+  const auto& kh_instability =
+      dynamic_cast<const grmhd::AnalyticData::KhInstability&>(
+          *deserialized_option_solution);
+
   CHECK(kh_instability == grmhd::AnalyticData::KhInstability(
                               adiabatic_index, strip_bimedian_height,
                               strip_thickness, strip_density, strip_velocity,
@@ -73,12 +89,16 @@ void test(const DataType& used_for_size) {
       adiabatic_index, strip_bimedian_height, strip_thickness, strip_density,
       strip_velocity, background_density, background_velocity, pressure,
       perturbation_amplitude, perturbation_width, magnetic_field);
-  test_move_semantics(std::move(kh_inst_to_move), kh_instability);  //  NOLINT
+  KhInstabilityProxy kh_inst(
+      adiabatic_index, strip_bimedian_height, strip_thickness, strip_density,
+      strip_velocity, background_density, background_velocity, pressure,
+      perturbation_amplitude, perturbation_width, magnetic_field);
+  test_move_semantics(std::move(kh_inst_to_move), kh_inst);  //  NOLINT
 
   // run post-serialized state through checks with random numbers
   pypp::check_with_random_values<1>(
       &KhInstabilityProxy::template primitive_variables<DataType>,
-      serialize_and_deserialize(kh_instability), "KhInstability",
+      serialize_and_deserialize(kh_inst), "KhInstability",
       {"rest_mass_density", "velocity", "specific_internal_energy", "pressure",
        "lorentz_factor", "specific_enthalpy", "magnetic_field",
        "divergence_cleaning_field"},

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/Test_Bump.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/Test_Bump.cpp
@@ -3,7 +3,8 @@
 
 #include "Framework/TestingFramework.hpp"
 
-#include <vector>  // IWYU pragma: keep
+#include <memory>
+#include <vector>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -11,7 +12,10 @@
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/PointwiseFunctions/AnalyticSolutions/Burgers/CheckBurgersSolution.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Burgers/Bump.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/Tags/InitialData.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -36,11 +40,20 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Burgers.Bump",
           tnsr::I<DataVector, 1>{{{positions}}}, 0.)),
       height * (1. - square((positions - center) / half_width)));
 
-  const auto created_solution =
-      TestHelpers::test_creation<Burgers::Solutions::Bump>(
-          "HalfWidth: 5.\n"
-          "Height: 3.\n"
-          "Center: -8.\n");
+  Parallel::register_classes_with_charm<Burgers::Solutions::Bump>();
+  const std::unique_ptr<evolution::initial_data::InitialData> option_solution =
+      TestHelpers::test_option_tag_factory_creation<
+          evolution::initial_data::OptionTags::InitialData,
+          Burgers::Solutions::Bump>(
+          "Bump:\n"
+          "  HalfWidth: 5.\n"
+          "  Height: 3.\n"
+          "  Center: -8.\n");
+  const auto deserialized_option_solution =
+      serialize_and_deserialize(option_solution);
+  const auto& created_solution = dynamic_cast<const Burgers::Solutions::Bump&>(
+      *deserialized_option_solution);
+
   const auto x = tnsr::I<DataVector, 1>{{{positions}}};
   const double t = 0.0;
   CHECK(created_solution.variables(x, t, tmpl::list<Burgers::Tags::U>{}) ==

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/Test_Linear.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/Test_Linear.cpp
@@ -3,7 +3,8 @@
 
 #include "Framework/TestingFramework.hpp"
 
-#include <vector>  // IWYU pragma: keep
+#include <memory>
+#include <vector>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -11,7 +12,10 @@
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/PointwiseFunctions/AnalyticSolutions/Burgers/CheckBurgersSolution.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Burgers/Linear.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/Tags/InitialData.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -32,8 +36,19 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Burgers.Linear",
                             tnsr::I<DataVector, 1>{{{positions}}}, 0.)),
                         positions / -shock_time);
 
-  const auto created_solution =
-      TestHelpers::test_creation<Burgers::Solutions::Linear>("ShockTime: 1.5");
+  Parallel::register_classes_with_charm<Burgers::Solutions::Linear>();
+  const std::unique_ptr<evolution::initial_data::InitialData> option_solution =
+      TestHelpers::test_option_tag_factory_creation<
+          evolution::initial_data::OptionTags::InitialData,
+          Burgers::Solutions::Linear>(
+          "Linear:\n"
+          "  ShockTime: 1.5\n");
+  const auto deserialized_option_solution =
+      serialize_and_deserialize(option_solution);
+  const auto& created_solution =
+      dynamic_cast<const Burgers::Solutions::Linear&>(
+          *deserialized_option_solution);
+
   const auto x = tnsr::I<DataVector, 1>{{{positions}}};
   const double t = 0.0;
   CHECK(created_solution.variables(x, t, tmpl::list<Burgers::Tags::U>{}) ==

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/Test_Step.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/Test_Step.cpp
@@ -3,7 +3,8 @@
 
 #include "Framework/TestingFramework.hpp"
 
-#include <vector>  // IWYU pragma: keep
+#include <memory>
+#include <vector>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -11,7 +12,10 @@
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/PointwiseFunctions/AnalyticSolutions/Burgers/CheckBurgersSolution.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Burgers/Step.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/Tags/InitialData.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -46,11 +50,20 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Burgers.Step",
   // solution breaks the tests of check_burgers_solution
   check_burgers_solution(solution, positions, {0., 0.7, 1.2, 10.0});
 
-  const auto created_solution =
-      TestHelpers::test_creation<Burgers::Solutions::Step>(
-          "LeftValue: 2.3\n"
-          "RightValue: 1.2\n"
-          "InitialPosition: -0.5");
+  Parallel::register_classes_with_charm<Burgers::Solutions::Step>();
+  const std::unique_ptr<evolution::initial_data::InitialData> option_solution =
+      TestHelpers::test_option_tag_factory_creation<
+          evolution::initial_data::OptionTags::InitialData,
+          Burgers::Solutions::Step>(
+          "Step:\n"
+          "  LeftValue: 2.3\n"
+          "  RightValue: 1.2\n"
+          "  InitialPosition: -0.5\n");
+  const auto deserialized_option_solution =
+      serialize_and_deserialize(option_solution);
+  const auto& created_solution = dynamic_cast<const Burgers::Solutions::Step&>(
+      *deserialized_option_solution);
+
   const auto x = tnsr::I<DataVector, 1>{{{positions}}};
   const double t = 0.0;
   CHECK(created_solution.variables(x, t, tmpl::list<Burgers::Tags::U>{}) ==

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_BondiMichel.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_BondiMichel.cpp
@@ -20,8 +20,11 @@
 #include "Helpers/PointwiseFunctions/AnalyticSolutions/GrMhd/VerifyGrMhdSolution.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/Tags/InitialData.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -121,7 +124,22 @@ void test_variables(const DataType& used_for_size) {
 }
 
 void test_solution() {
-  grmhd::Solutions::BondiMichel solution(1.1, 50.0, 1.3, 1.5, 0.24);
+  Parallel::register_classes_with_charm<grmhd::Solutions::BondiMichel>();
+  const std::unique_ptr<evolution::initial_data::InitialData> option_solution =
+      TestHelpers::test_option_tag_factory_creation<
+          evolution::initial_data::OptionTags::InitialData,
+          grmhd::Solutions::BondiMichel>(
+          "BondiMichel:\n"
+          "  Mass: 1.1\n"
+          "  SonicRadius: 50.0\n"
+          "  SonicDensity: 1.3\n"
+          "  PolytropicExponent: 1.5\n"
+          "  MagFieldStrength: 0.24\n");
+  const auto deserialized_option_solution =
+      serialize_and_deserialize(option_solution);
+  const auto& solution = dynamic_cast<const grmhd::Solutions::BondiMichel&>(
+      *deserialized_option_solution);
+
   const std::array<double, 3> x{{4.0, 4.0, 4.0}};
   const std::array<double, 3> dx{{1.e-3, 1.e-3, 1.e-3}};
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_SmoothFlow.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_SmoothFlow.cpp
@@ -21,9 +21,12 @@
 #include "Helpers/PointwiseFunctions/AnalyticSolutions/GrMhd/VerifyGrMhdSolution.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/Tags/InitialData.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
 #include "Utilities/TMPL.hpp"
@@ -154,8 +157,22 @@ void test_variables(const DataType& used_for_size) {
 }
 
 void test_solution() {
-  grmhd::Solutions::SmoothFlow solution(
-      {{0.1, -0.2, 0.3}}, {{-0.13, -0.54, 0.04}}, 1.23, 1.4, 0.75);
+  Parallel::register_classes_with_charm<grmhd::Solutions::SmoothFlow>();
+  const std::unique_ptr<evolution::initial_data::InitialData> option_solution =
+      TestHelpers::test_option_tag_factory_creation<
+          evolution::initial_data::OptionTags::InitialData,
+          grmhd::Solutions::SmoothFlow>(
+          "SmoothFlow:\n"
+          "  MeanVelocity: [0.1, -0.2, 0.3]\n"
+          "  WaveVector: [-0.13, -0.54, 0.04]\n"
+          "  Pressure: 1.23\n"
+          "  AdiabaticIndex: 1.4\n"
+          "  PerturbationSize: 0.75\n");
+  const auto deserialized_option_solution =
+      serialize_and_deserialize(option_solution);
+  const auto& solution = dynamic_cast<const grmhd::Solutions::SmoothFlow&>(
+      *deserialized_option_solution);
+
   const std::array<double, 3> x{{4.0, 4.0, 4.0}};
   const std::array<double, 3> dx{{1.e-3, 1.e-3, 1.e-3}};
 


### PR DESCRIPTION
## Proposed changes

- Add a test helper `test_option_tag_factory_creation` to more easily test that a option tag and a derived class are factory createable
- Make analytic data and analytic solutions for GRMHD, Burgers and scalar wave factory createable. Ultimately we will have these read in from an input file, but that requires modifying observers and initialization code.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
