### PR TITLE
Clean up CMake code for defining tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,6 @@ include(SetupLibsharp)
 include(SetupYamlCpp)
 
 include(SetupLIBCXXCharm)
-include(SpectreSetupPythonPackage)
 # The precompiled header must be setup after all libraries have been found
 include(SetupPch)
 
@@ -132,10 +131,8 @@ include(SetupSphinx)
 include(CodeCoverageDetection)
 include(SpectreAddLibraries)
 
-set(SPECTRE_TEST_RUNNER "" CACHE STRING
-  "Run test executables through the given wrapper.")
-
-enable_testing(true)
+include(SpectreSetupTesting)
+include(SpectreSetupPythonPackage)
 include(SetupPypp)
 include(SpectreAddTestLibs)
 include(SpectreAddCatchTests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,7 @@ include(SetupPypp)
 include(SpectreAddTestLibs)
 include(SpectreAddCatchTests)
 include(AddInputFileTests)
+include(AddStandaloneTests)
 
 include_directories(${CMAKE_SOURCE_DIR}/external)
 include_directories(${CMAKE_SOURCE_DIR}/src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,9 @@ include(SetupSphinx)
 include(CodeCoverageDetection)
 include(SpectreAddLibraries)
 
+set(SPECTRE_TEST_RUNNER "" CACHE STRING
+  "Run test executables through the given wrapper.")
+
 enable_testing(true)
 include(SetupPypp)
 include(SpectreAddTestLibs)

--- a/cmake/AddInputFileTests.cmake
+++ b/cmake/AddInputFileTests.cmake
@@ -40,7 +40,7 @@ function(add_single_input_file_test INPUT_FILE EXECUTABLE COMMAND_LINE_ARGS
   if ("${CHECK_TYPE}" STREQUAL "parse")
     add_test(
       NAME ${CTEST_NAME}
-      COMMAND ${CMAKE_BINARY_DIR}/bin/${EXECUTABLE}
+      COMMAND ${SPECTRE_TEST_RUNNER} ${CMAKE_BINARY_DIR}/bin/${EXECUTABLE}
       --check-options --input-file ${INPUT_FILE}
       )
   elseif("${CHECK_TYPE}" STREQUAL "execute")
@@ -186,7 +186,7 @@ file(
 #!/bin/sh\n\
 ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/CleanOutput.py -v --force \
 --input-file $2 --output-dir ${CMAKE_BINARY_DIR}
-${CMAKE_BINARY_DIR}/bin/$1 --input-file $2 \${3} && \
+${SPECTRE_TEST_RUNNER} ${CMAKE_BINARY_DIR}/bin/$1 --input-file $2 \${3} && \
 ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/CleanOutput.py -v \
 --input-file $2 --output-dir ${CMAKE_BINARY_DIR}\n"
 )

--- a/cmake/AddInputFileTests.cmake
+++ b/cmake/AddInputFileTests.cmake
@@ -1,9 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-option(SPECTRE_INPUT_FILE_TEST_TIMEOUT_FACTOR
-  "Multiply timeout for input file tests by this factor"
-  1)
+spectre_define_test_timeout_factor_option(INPUT_FILE "input file")
 
 find_package(Python REQUIRED)
 
@@ -71,11 +69,7 @@ function(add_single_input_file_test INPUT_FILE EXECUTABLE COMMAND_LINE_ARGS
     math(EXPR TIMEOUT "3 * ${TIMEOUT}")
   endif()
 
-  # Multiply timeout by the user option
-  # Note: "1" is parsed as "ON" by cmake
-  if (NOT "${SPECTRE_INPUT_FILE_TEST_TIMEOUT_FACTOR}" STREQUAL ON)
-    math(EXPR TIMEOUT "${SPECTRE_INPUT_FILE_TEST_TIMEOUT_FACTOR} * ${TIMEOUT}")
-  endif()
+  spectre_test_timeout(TIMEOUT INPUT_FILE ${TIMEOUT})
 
   set_tests_properties(
     ${CTEST_NAME}

--- a/cmake/AddStandaloneTests.cmake
+++ b/cmake/AddStandaloneTests.cmake
@@ -98,7 +98,7 @@ function(add_standalone_test TEST_NAME)
     COMMAND
     ${SHELL_EXECUTABLE}
     -c
-    "${CMAKE_BINARY_DIR}/bin/${EXECUTABLE_NAME} ${INPUT_FILE_ARGS} 2>&1"
+    "${SPECTRE_TEST_RUNNER} ${CMAKE_BINARY_DIR}/bin/${EXECUTABLE_NAME} ${INPUT_FILE_ARGS} 2>&1"
     )
 
   set_standalone_test_properties("${TEST_NAME}")

--- a/cmake/AddStandaloneTests.cmake
+++ b/cmake/AddStandaloneTests.cmake
@@ -1,0 +1,101 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Helper function to set up a CMake target for a test executable.  It
+# can safely be called multiple times for the same executable.
+function(add_standalone_test_executable EXECUTABLE_NAME)
+  add_dependencies(test-executables ${EXECUTABLE_NAME})
+
+  if (TARGET ${EXECUTABLE_NAME})
+    return()
+  endif()
+
+  add_spectre_executable(
+    ${EXECUTABLE_NAME}
+    ${EXECUTABLE_NAME}.cpp
+    )
+
+  add_dependencies(
+    ${EXECUTABLE_NAME}
+    module_GlobalCache
+    module_Main
+    )
+endfunction()
+
+# For tests that result in a failure it is necessary to redirect
+# output from stderr to stdout. However, it was necessary at least on
+# some systems to do this redirect inside a shell command.
+find_program(SHELL_EXECUTABLE "sh")
+if (NOT SHELL_EXECUTABLE)
+  message(FATAL_ERROR
+    "Could not find 'sh' shell to execute standalone failure tests")
+endif()
+
+# Add a standalone test named TEST_NAME that runs an executable with
+# no arguments.  A test named Foo.Bar.Baz will run the executable
+# Test_Baz by default.
+#
+# A REGEX_TO_MATCH named argument may be passed, in which case the
+# test will pass if the output matches it, otherwise the test will
+# pass if the executable succeeds without any "ERROR" output.
+#
+# An EXECUTABLE named argument can be passed to override the
+# executable name.
+#
+# An INPUT_FILE named argument can be passed to pass an input file to
+# the executable.
+function(add_standalone_test TEST_NAME)
+  cmake_parse_arguments(
+    ARG
+    ""
+    "REGEX_TO_MATCH;EXECUTABLE;INPUT_FILE"
+    ""
+    ${ARGN})
+
+  if(DEFINED ARG_EXECUTABLE)
+    if(NOT ARG_EXECUTABLE MATCHES "^Test_")
+      message(
+        FATAL_ERROR
+        "Test executable name '${ARG_EXECUTABLE}' must begin with 'Test_'")
+    endif()
+    set(EXECUTABLE_NAME "${ARG_EXECUTABLE}")
+  else()
+    # Extract last component of test name as executable name
+    string(REGEX MATCH "[^.]*$" EXECUTABLE_NAME "${TEST_NAME}")
+    set(EXECUTABLE_NAME "Test_${EXECUTABLE_NAME}")
+  endif()
+
+  add_standalone_test_executable("${EXECUTABLE_NAME}")
+  if(DEFINED ARG_INPUT_FILE)
+    set(INPUT_FILE_ARGS
+      "--input-file ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_INPUT_FILE}")
+  else()
+    set(INPUT_FILE_ARGS "")
+  endif()
+  add_test(
+    NAME "${TEST_NAME}"
+    COMMAND
+    ${SHELL_EXECUTABLE}
+    -c
+    "${CMAKE_BINARY_DIR}/bin/${EXECUTABLE_NAME} ${INPUT_FILE_ARGS} 2>&1"
+    )
+
+  if(NOT DEFINED ARG_REGEX_TO_MATCH)
+    set_tests_properties(
+      "${TEST_NAME}"
+      PROPERTIES
+      FAIL_REGULAR_EXPRESSION "ERROR"
+      TIMEOUT 10
+      LABELS "standalone"
+      ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
+  else()
+    set_tests_properties(
+      "${TEST_NAME}"
+      PROPERTIES
+      PASS_REGULAR_EXPRESSION
+      "${ARG_REGEX_TO_MATCH}"
+      TIMEOUT 10
+      LABELS "standalone"
+      ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
+  endif()
+endfunction()

--- a/cmake/AddStandaloneTests.cmake
+++ b/cmake/AddStandaloneTests.cmake
@@ -1,9 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-option(SPECTRE_STANDALONE_TEST_TIMEOUT_FACTOR
-  "Multiply timeout for standalone tests by this factor"
-  1)
+spectre_define_test_timeout_factor_option(STANDALONE "standalone")
 
 # Helper function to set up a CMake target for a test executable.  It
 # can safely be called multiple times for the same executable.
@@ -28,12 +26,7 @@ endfunction()
 
 # Helper function to set standard test properties for standalone tests.
 function(set_standalone_test_properties TEST_NAME)
-  set(TIMEOUT 10)
-  # Multiply timeout by the user option
-  # Note: "1" is parsed as "ON" by cmake
-  if (NOT "${SPECTRE_STANDALONE_TEST_TIMEOUT_FACTOR}" STREQUAL ON)
-    math(EXPR TIMEOUT "${SPECTRE_STANDALONE_TEST_TIMEOUT_FACTOR} * ${TIMEOUT}")
-  endif()
+  spectre_test_timeout(TIMEOUT STANDALONE 10)
 
   set_tests_properties(
     "${TEST_NAME}"

--- a/cmake/ExecuteCheckOutputFilesAndClean.sh
+++ b/cmake/ExecuteCheckOutputFilesAndClean.sh
@@ -7,7 +7,7 @@
                     --input-file $2 --output-dir @CMAKE_BINARY_DIR@/$3
 mkdir @CMAKE_BINARY_DIR@/$3
 cd @CMAKE_BINARY_DIR@/$3
-@CMAKE_BINARY_DIR@/bin/$1 --input-file $2 ${4} &&
+@SPECTRE_TEST_RUNNER@ @CMAKE_BINARY_DIR@/bin/$1 --input-file $2 ${4} &&
     @Python_EXECUTABLE@ @CMAKE_SOURCE_DIR@/tools/CheckOutputFiles.py \
      --input-file $2 --run-directory @CMAKE_BINARY_DIR@/$3 &&
 @Python_EXECUTABLE@ @CMAKE_SOURCE_DIR@/tools/CleanOutput.py -v \

--- a/cmake/SpectreAddCatchTests.cmake
+++ b/cmake/SpectreAddCatchTests.cmake
@@ -213,7 +213,7 @@ function(spectre_parse_file SOURCE_FILE TEST_TARGET)
 
     # Add the test and set its properties
     add_test(NAME ${CTEST_NAME}
-      COMMAND $<TARGET_FILE:${TEST_TARGET}>
+      COMMAND ${SPECTRE_TEST_RUNNER} $<TARGET_FILE:${TEST_TARGET}>
       \"${NAME}\" --durations yes
       --warn NoAssertions
       --name "\"$<CONFIGURATION>.${CTEST_NAME}\"")

--- a/cmake/SpectreAddCatchTests.cmake
+++ b/cmake/SpectreAddCatchTests.cmake
@@ -39,9 +39,7 @@
 
 add_custom_target(unit-tests)
 
-option(SPECTRE_UNIT_TEST_TIMEOUT_FACTOR
-  "Multiply timeout for unit tests by this factor"
-  1)
+spectre_define_test_timeout_factor_option(UNIT "unit")
 
 find_package(Python REQUIRED)
 
@@ -205,11 +203,7 @@ function(spectre_parse_file SOURCE_FILE TEST_TARGET)
       math(EXPR TIMEOUT "3 * ${TIMEOUT}")
     endif()
 
-    # Multiply timeout by the user option
-    # Note: "1" is parsed as "ON" by cmake
-    if (NOT "${SPECTRE_UNIT_TEST_TIMEOUT_FACTOR}" STREQUAL ON)
-      math(EXPR TIMEOUT "${SPECTRE_UNIT_TEST_TIMEOUT_FACTOR} * ${TIMEOUT}")
-    endif()
+    spectre_test_timeout(TIMEOUT UNIT ${TIMEOUT})
 
     # Add the test and set its properties
     add_test(NAME ${CTEST_NAME}

--- a/cmake/SpectreSetupPythonPackage.cmake
+++ b/cmake/SpectreSetupPythonPackage.cmake
@@ -1,9 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-option(SPECTRE_PYTHON_TEST_TIMEOUT_FACTOR
-  "Multiply timeout for Python tests by this factor"
-  1)
+spectre_define_test_timeout_factor_option(PYTHON "Python")
 
 set(SPECTRE_PYTHON_PREFIX "${CMAKE_BINARY_DIR}/bin/python/spectre/")
 get_filename_component(
@@ -368,13 +366,7 @@ function(SPECTRE_ADD_PYTHON_TEST TEST_NAME FILE TAGS
     ${FILE}
     )
 
-  set(TIMEOUT 2)
-
-  # Multiply timeout by the user option
-  # Note: "1" is parsed as "ON" by cmake
-  if (NOT "${SPECTRE_PYTHON_TEST_TIMEOUT_FACTOR}" STREQUAL ON)
-    math(EXPR TIMEOUT "${SPECTRE_PYTHON_TEST_TIMEOUT_FACTOR} * ${TIMEOUT}")
-  endif()
+  spectre_test_timeout(TIMEOUT PYTHON 2)
 
   set(_TEST_ENV_VARS
     "PYTHONPATH=${SPECTRE_PYTHON_PREFIX_PARENT}:\$PYTHONPATH"

--- a/cmake/SpectreSetupTesting.cmake
+++ b/cmake/SpectreSetupTesting.cmake
@@ -1,0 +1,35 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+enable_testing(true)
+
+set(SPECTRE_TEST_RUNNER "" CACHE STRING
+  "Run test executables through the given wrapper.")
+
+option(SPECTRE_TEST_TIMEOUT_FACTOR
+  "Multiply timeout for tests by this factor")
+
+function(spectre_define_test_timeout_factor_option TEST_TYPE HELP_NAME)
+  option(SPECTRE_${TEST_TYPE}_TEST_TIMEOUT_FACTOR
+    "Multiply timeout for ${HELP_NAME} tests by this factor")
+endfunction ()
+
+# Multiply BASE_TIMEOUT by the user specified option for TEST_TYPE
+function(spectre_test_timeout RETURN_VARIABLE TEST_TYPE BASE_TIMEOUT)
+  if (SPECTRE_${TEST_TYPE}_TEST_TIMEOUT_FACTOR)
+    set(FACTOR ${SPECTRE_${TEST_TYPE}_TEST_TIMEOUT_FACTOR})
+  elseif (SPECTRE_TEST_TIMEOUT_FACTOR)
+    set(FACTOR ${SPECTRE_TEST_TIMEOUT_FACTOR})
+  else ()
+    set(FACTOR 1)
+  endif ()
+
+  # Note: "1" is parsed as "ON" by cmake
+  if (NOT "${FACTOR}" STREQUAL ON)
+    math(EXPR RESULT "${FACTOR} * ${BASE_TIMEOUT}")
+  else ()
+    set(RESULT ${BASE_TIMEOUT})
+  endif ()
+
+  set(${RETURN_VARIABLE} ${RESULT} PARENT_SCOPE)
+endfunction ()

--- a/docs/DevGuide/BuildSystem.md
+++ b/docs/DevGuide/BuildSystem.md
@@ -212,8 +212,8 @@ cmake -D FLAG1=OPT1 ... -D FLAGN=OPTN <SPECTRE_ROOT>
     third-party libraries accidentally end up using different allocators, which
     is undefined behavior and will result in complete chaos.
     (default is `JEMALLOC`)
-- SPECTRE_UNIT_TEST_TIMEOUT_FACTOR, SPECTRE_INPUT_FILE_TEST_TIMEOUT_FACTOR and
-  SPECTRE_PYTHON_TEST_TIMEOUT_FACTOR
+- SPECTRE_UNIT_TEST_TIMEOUT_FACTOR, SPECTRE_STANDALONE_TEST_TIMEOUT_FACTOR,
+  SPECTRE_INPUT_FILE_TEST_TIMEOUT_FACTOR and SPECTRE_PYTHON_TEST_TIMEOUT_FACTOR
   - Multiply the timeout for the respective set of tests by this factor (default
     is `1`).
   - This is useful to run tests on slower machines.

--- a/docs/DevGuide/BuildSystem.md
+++ b/docs/DevGuide/BuildSystem.md
@@ -215,8 +215,9 @@ cmake -D FLAG1=OPT1 ... -D FLAGN=OPTN <SPECTRE_ROOT>
 - SPECTRE_TEST_RUNNER
   - Run test executables through a wrapper.  This might be `charmrun`, for
     example.  (default is to not use one)
-- SPECTRE_UNIT_TEST_TIMEOUT_FACTOR, SPECTRE_STANDALONE_TEST_TIMEOUT_FACTOR,
-  SPECTRE_INPUT_FILE_TEST_TIMEOUT_FACTOR and SPECTRE_PYTHON_TEST_TIMEOUT_FACTOR
+- SPECTRE_TEST_TIMEOUT_FACTOR (and specific overrides
+  SPECTRE_X_TEST_TIMEOUT_FACTOR for X one of UNIT, STANDALONE, INPUT_FILE, or
+  PYTHON)
   - Multiply the timeout for the respective set of tests by this factor (default
     is `1`).
   - This is useful to run tests on slower machines.

--- a/docs/DevGuide/BuildSystem.md
+++ b/docs/DevGuide/BuildSystem.md
@@ -212,6 +212,9 @@ cmake -D FLAG1=OPT1 ... -D FLAGN=OPTN <SPECTRE_ROOT>
     third-party libraries accidentally end up using different allocators, which
     is undefined behavior and will result in complete chaos.
     (default is `JEMALLOC`)
+- SPECTRE_TEST_RUNNER
+  - Run test executables through a wrapper.  This might be `charmrun`, for
+    example.  (default is to not use one)
 - SPECTRE_UNIT_TEST_TIMEOUT_FACTOR, SPECTRE_STANDALONE_TEST_TIMEOUT_FACTOR,
   SPECTRE_INPUT_FILE_TEST_TIMEOUT_FACTOR and SPECTRE_PYTHON_TEST_TIMEOUT_FACTOR
   - Multiply the timeout for the respective set of tests by this factor (default

--- a/tests/Unit/IO/Importers/CMakeLists.txt
+++ b/tests/Unit/IO/Importers/CMakeLists.txt
@@ -21,9 +21,10 @@ add_dependencies(
   )
 
 function(add_algorithm_test TEST_NAME DIM)
+  set(TEST_BASE ${TEST_NAME}${DIM}D)
   set(HPP_NAME Test_${TEST_NAME})
   set(EXECUTABLE_NAME ${HPP_NAME}${DIM}D)
-  set(TEST_IDENTIFIER Integration.Importers.${TEST_NAME}${DIM}D)
+  set(TEST_IDENTIFIER Integration.Importers.${TEST_BASE})
 
   add_spectre_parallel_executable(
     ${EXECUTABLE_NAME}
@@ -33,20 +34,9 @@ function(add_algorithm_test TEST_NAME DIM)
     "DataStructures;Domain;ErrorHandling;Informer;IO;Options;Parallel;SystemUtilities"
     )
 
-  add_dependencies(test-executables ${EXECUTABLE_NAME})
-
-  add_test(
-    NAME ${TEST_IDENTIFIER}
-    COMMAND ${CMAKE_BINARY_DIR}/bin/${EXECUTABLE_NAME} --input-file
-    ${CMAKE_CURRENT_SOURCE_DIR}/${EXECUTABLE_NAME}.yaml
-    )
-
-  set_tests_properties(
-    ${TEST_IDENTIFIER}
-    PROPERTIES
-    TIMEOUT 5
-    LABELS "integration"
-    ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
+  add_standalone_test(
+    "${TEST_IDENTIFIER}"
+    INPUT_FILE "Test_${TEST_BASE}.yaml")
 endfunction()
 
 add_algorithm_test("VolumeDataReaderAlgorithm" 1)

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -46,8 +46,8 @@ function(add_algorithm_test_with_balancing TEST_NAME EXECUTABLE_NAME REGEX_TO_MA
     NAME "Unit.Parallel.${TEST_NAME}"
     COMMAND
     ${SHELL_EXECUTABLE}
-    -c "${CMAKE_BINARY_DIR}/bin/Test_${EXECUTABLE_NAME} +p2 +balancer \
-     RotateLB +LBPeriod 4.0e-5 +LBDebug 3 2>&1"
+    -c "${SPECTRE_TEST_RUNNER} ${CMAKE_BINARY_DIR}/bin/Test_${EXECUTABLE_NAME} \
+    +p2 +balancer RotateLB +LBPeriod 4.0e-5 +LBDebug 3 2>&1"
     )
 
   set_standalone_test_properties("Unit.Parallel.${TEST_NAME}")
@@ -86,8 +86,9 @@ function(add_algorithm_test_with_restart_from_checkpoint TEST_NAME)
     ${SHELL_EXECUTABLE}
     -c
     "rm -rf ${CHECKPOINT} \
-    && ${CMAKE_BINARY_DIR}/bin/Test_${TEST_NAME} 2>&1 \
-    && ${CMAKE_BINARY_DIR}/bin/Test_${TEST_NAME} +restart ${CHECKPOINT} 2>&1 \
+    && ${SPECTRE_TEST_RUNNER} ${CMAKE_BINARY_DIR}/bin/Test_${TEST_NAME} 2>&1 \
+    && ${SPECTRE_TEST_RUNNER} ${CMAKE_BINARY_DIR}/bin/Test_${TEST_NAME} \
+       +restart ${CHECKPOINT} 2>&1 \
     && rm -rf ${CHECKPOINT}"
     )
   set_standalone_test_properties("Unit.Parallel.${TEST_NAME}")

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -5,7 +5,11 @@ add_subdirectory(Actions)
 
 add_subdirectory(PhaseControl)
 
-function(add_algorithm_test EXECUTABLE_NAME)
+function(add_algorithm_test_executable EXECUTABLE_NAME)
+  if (TARGET ${EXECUTABLE_NAME})
+    return()
+  endif()
+
   add_spectre_executable(
     ${EXECUTABLE_NAME}
     ${EXECUTABLE_NAME}.cpp
@@ -35,34 +39,6 @@ function(add_algorithm_test EXECUTABLE_NAME)
   add_dependencies(unit-tests ${EXECUTABLE_NAME})
 endfunction()
 
-add_algorithm_test(Test_AlgorithmBadBoxApply)
-add_algorithm_test(Test_AlgorithmCore)
-add_algorithm_test(Test_AlgorithmGlobalCache)
-add_algorithm_test(Test_AlgorithmLocalSyncAction)
-add_algorithm_test(Test_AlgorithmNestedApply1)
-add_algorithm_test(Test_AlgorithmNestedApply2)
-add_algorithm_test(Test_AlgorithmNodelock)
-add_algorithm_test(Test_AlgorithmParallel)
-add_algorithm_test(Test_AlgorithmPhaseControl)
-add_algorithm_test(Test_AlgorithmReduction)
-add_algorithm_test(Test_CheckpointRestart)
-add_algorithm_test(Test_GlobalCache)
-add_algorithm_test(Test_PhaseChangeMain)
-add_algorithm_test(Test_SectionReductions)
-
-# Test GlobalCache
-add_charm_module(Test_GlobalCache)
-
-add_dependencies(
-  module_Test_GlobalCache
-  module_GlobalCache
-  )
-
-add_dependencies(
-  Test_GlobalCache
-  module_Test_GlobalCache
-  )
-
 # Add unit tests. For tests that result in a failure it is necessary to
 # redirect output from stderr to stdout. However, it was necessary at least on
 # some systems to do this redirect inside a shell command.
@@ -73,6 +49,7 @@ if ("${SHELL_EXECUTABLE}" STREQUAL "")
 endif()
 
 function(add_algorithm_test TEST_NAME REGEX_TO_MATCH)
+  add_algorithm_test_executable("Test_${TEST_NAME}")
   add_test(
     NAME Unit.Parallel.${TEST_NAME}
     COMMAND
@@ -102,6 +79,7 @@ function(add_algorithm_test TEST_NAME REGEX_TO_MATCH)
 endfunction()
 
 function(add_algorithm_test_with_input_file TEST_NAME INPUT_FILE_DIR)
+  add_algorithm_test_executable("Test_${TEST_NAME}")
   add_test(
     NAME "\"Unit.Parallel.${TEST_NAME}\""
     COMMAND
@@ -128,6 +106,7 @@ endfunction()
 # due to balancing so much that the test computation doesn't get much of a
 # chance to execute.
 function(add_algorithm_test_with_balancing TEST_NAME EXECUTABLE_NAME REGEX_TO_MATCH)
+  add_algorithm_test_executable("Test_${EXECUTABLE_NAME}")
   add_test(
     NAME "\"Unit.Parallel.${TEST_NAME}\""
     COMMAND
@@ -163,6 +142,7 @@ endfunction()
 # to avoid it getting in the way of future test invocations (which would try
 # to overwrite the prior checkpoint file and error).
 function(add_algorithm_test_with_restart_from_checkpoint TEST_NAME)
+  add_algorithm_test_executable("Test_${TEST_NAME}")
   # Executable writes checkpoint file into the dir where it runs:
   set(CHECKPOINT
     "${CMAKE_BINARY_DIR}/tests/Unit/Parallel/SpectreCheckpoint000000")
@@ -184,6 +164,20 @@ function(add_algorithm_test_with_restart_from_checkpoint TEST_NAME)
     ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
 endfunction()
 
+# Test GlobalCache
+add_algorithm_test("GlobalCache" "")
+add_charm_module(Test_GlobalCache)
+
+add_dependencies(
+  module_Test_GlobalCache
+  module_GlobalCache
+  )
+
+add_dependencies(
+  Test_GlobalCache
+  module_Test_GlobalCache
+  )
+
 add_algorithm_test(
   "AlgorithmBadBoxApply"
   "Cannot call apply function of 'error_size_zero' with DataBox \
@@ -203,7 +197,6 @@ function is not invoked via a proxy, which we do not allow.")
 add_algorithm_test("AlgorithmNodelock" "")
 add_algorithm_test("AlgorithmParallel" "")
 add_algorithm_test("AlgorithmReduction" "")
-add_algorithm_test("GlobalCache" "")
 add_algorithm_test("PhaseChangeMain" "")
 add_algorithm_test("SectionReductions"
   "Element 0 received reduction: Counted 2 odd elements.")

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -43,31 +43,26 @@ function(add_algorithm_test_with_balancing TEST_NAME EXECUTABLE_NAME REGEX_TO_MA
     PRIVATE
     "${ALGORITHM_TEST_LINK_LIBRARIES}")
   add_test(
-    NAME "\"Unit.Parallel.${TEST_NAME}\""
+    NAME "Unit.Parallel.${TEST_NAME}"
     COMMAND
     ${SHELL_EXECUTABLE}
     -c "${CMAKE_BINARY_DIR}/bin/Test_${EXECUTABLE_NAME} +p2 +balancer \
      RotateLB +LBPeriod 4.0e-5 +LBDebug 3 2>&1"
     )
 
+  set_standalone_test_properties("Unit.Parallel.${TEST_NAME}")
   if("${REGEX_TO_MATCH}" STREQUAL "")
     set_tests_properties(
-      "\"Unit.Parallel.${TEST_NAME}\""
+      "Unit.Parallel.${TEST_NAME}"
       PROPERTIES
-      FAIL_REGULAR_EXPRESSION "ERROR"
-      TIMEOUT 10
-      LABELS "standalone"
-      ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
+      FAIL_REGULAR_EXPRESSION "ERROR")
   else()
     set_tests_properties(
-      "\"Unit.Parallel.${TEST_NAME}\""
+      "Unit.Parallel.${TEST_NAME}"
       PROPERTIES
       PASS_REGULAR_EXPRESSION
       "${REGEX_TO_MATCH}"
-      FAIL_REGULAR_EXPRESSION "ERROR"
-      TIMEOUT 10
-      LABELS "standalone"
-      ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
+      FAIL_REGULAR_EXPRESSION "ERROR")
   endif()
 endfunction()
 
@@ -86,7 +81,7 @@ function(add_algorithm_test_with_restart_from_checkpoint TEST_NAME)
   set(CHECKPOINT
     "${CMAKE_BINARY_DIR}/tests/Unit/Parallel/SpectreCheckpoint000000")
   add_test(
-    NAME "\"Unit.Parallel.${TEST_NAME}\""
+    NAME "Unit.Parallel.${TEST_NAME}"
     COMMAND
     ${SHELL_EXECUTABLE}
     -c
@@ -95,12 +90,7 @@ function(add_algorithm_test_with_restart_from_checkpoint TEST_NAME)
     && ${CMAKE_BINARY_DIR}/bin/Test_${TEST_NAME} +restart ${CHECKPOINT} 2>&1 \
     && rm -rf ${CHECKPOINT}"
     )
-  set_tests_properties(
-    "\"Unit.Parallel.${TEST_NAME}\""
-    PROPERTIES
-    TIMEOUT 10
-    LABELS "standalone"
-    ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
+  set_standalone_test_properties("Unit.Parallel.${TEST_NAME}")
 endfunction()
 
 function(add_algorithm_test BASE_NAME)

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -5,96 +5,27 @@ add_subdirectory(Actions)
 
 add_subdirectory(PhaseControl)
 
-function(add_algorithm_test_executable EXECUTABLE_NAME)
-  if (TARGET ${EXECUTABLE_NAME})
-    return()
-  endif()
-
-  add_spectre_executable(
-    ${EXECUTABLE_NAME}
-    ${EXECUTABLE_NAME}.cpp
-    )
-
-  add_dependencies(
-    ${EXECUTABLE_NAME}
-    module_GlobalCache
-    module_Main
-    )
-
-  target_link_libraries(
-    ${EXECUTABLE_NAME}
-    PRIVATE
-    # Link against Boost::program_options for now until we have proper
-    # dependency handling for header-only libs
-    Boost::program_options
-    ErrorHandling
-    Informer
-    Options
-    Parallel
-    PhaseControl
-    SystemUtilities
-    Utilities
-    )
-
-  add_dependencies(unit-tests ${EXECUTABLE_NAME})
-endfunction()
+set(ALGORITHM_TEST_LINK_LIBRARIES
+  # Link against Boost::program_options for now until we have proper
+  # dependency handling for header-only libs
+  Boost::program_options
+  ErrorHandling
+  Informer
+  Options
+  Parallel
+  PhaseControl
+  SystemUtilities
+  Utilities
+  )
 
 # Add unit tests. For tests that result in a failure it is necessary to
 # redirect output from stderr to stdout. However, it was necessary at least on
 # some systems to do this redirect inside a shell command.
 find_program(SHELL_EXECUTABLE "sh")
-if ("${SHELL_EXECUTABLE}" STREQUAL "")
+if (NOT SHELL_EXECUTABLE)
   message(FATAL_ERROR
     "Could not find 'sh' shell to execute failure tests of algorithms")
 endif()
-
-function(add_algorithm_test TEST_NAME REGEX_TO_MATCH)
-  add_algorithm_test_executable("Test_${TEST_NAME}")
-  add_test(
-    NAME Unit.Parallel.${TEST_NAME}
-    COMMAND
-    ${SHELL_EXECUTABLE}
-    -c
-    "${CMAKE_BINARY_DIR}/bin/Test_${TEST_NAME} 2>&1"
-    )
-
-  if("${REGEX_TO_MATCH}" STREQUAL "")
-    set_tests_properties(
-      Unit.Parallel.${TEST_NAME}
-      PROPERTIES
-      FAIL_REGULAR_EXPRESSION "ERROR"
-      TIMEOUT 10
-      LABELS "unit"
-      ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
-  else()
-    set_tests_properties(
-      Unit.Parallel.${TEST_NAME}
-      PROPERTIES
-      PASS_REGULAR_EXPRESSION
-      "${REGEX_TO_MATCH}"
-      TIMEOUT 10
-      LABELS "unit"
-      ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
-  endif()
-endfunction()
-
-function(add_algorithm_test_with_input_file TEST_NAME INPUT_FILE_DIR)
-  add_algorithm_test_executable("Test_${TEST_NAME}")
-  add_test(
-    NAME "\"Unit.Parallel.${TEST_NAME}\""
-    COMMAND
-    ${SHELL_EXECUTABLE}
-    -c
-    "${CMAKE_BINARY_DIR}/bin/Test_${TEST_NAME} --input-file \
-     ${CMAKE_SOURCE_DIR}/tests/${INPUT_FILE_DIR}/Test_${TEST_NAME}.yaml 2>&1"
-    )
-  set_tests_properties(
-    "\"Unit.Parallel.${TEST_NAME}\""
-    PROPERTIES
-    TIMEOUT 10
-    LABELS "unit"
-    ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
-endfunction()
 
 # Note that we have a 'balance' here that happens 2.5e4 of times per second just
 # to be completely certain that the desired number of migrations occur during
@@ -106,7 +37,11 @@ endfunction()
 # due to balancing so much that the test computation doesn't get much of a
 # chance to execute.
 function(add_algorithm_test_with_balancing TEST_NAME EXECUTABLE_NAME REGEX_TO_MATCH)
-  add_algorithm_test_executable("Test_${EXECUTABLE_NAME}")
+  add_standalone_test_executable("Test_${EXECUTABLE_NAME}")
+  target_link_libraries(
+    "Test_${EXECUTABLE_NAME}"
+    PRIVATE
+    "${ALGORITHM_TEST_LINK_LIBRARIES}")
   add_test(
     NAME "\"Unit.Parallel.${TEST_NAME}\""
     COMMAND
@@ -121,7 +56,7 @@ function(add_algorithm_test_with_balancing TEST_NAME EXECUTABLE_NAME REGEX_TO_MA
       PROPERTIES
       FAIL_REGULAR_EXPRESSION "ERROR"
       TIMEOUT 10
-      LABELS "unit"
+      LABELS "standalone"
       ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
   else()
     set_tests_properties(
@@ -131,7 +66,7 @@ function(add_algorithm_test_with_balancing TEST_NAME EXECUTABLE_NAME REGEX_TO_MA
       "${REGEX_TO_MATCH}"
       FAIL_REGULAR_EXPRESSION "ERROR"
       TIMEOUT 10
-      LABELS "unit"
+      LABELS "standalone"
       ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
   endif()
 endfunction()
@@ -142,7 +77,11 @@ endfunction()
 # to avoid it getting in the way of future test invocations (which would try
 # to overwrite the prior checkpoint file and error).
 function(add_algorithm_test_with_restart_from_checkpoint TEST_NAME)
-  add_algorithm_test_executable("Test_${TEST_NAME}")
+  add_standalone_test_executable("Test_${TEST_NAME}")
+  target_link_libraries(
+    "Test_${TEST_NAME}"
+    PRIVATE
+    "${ALGORITHM_TEST_LINK_LIBRARIES}")
   # Executable writes checkpoint file into the dir where it runs:
   set(CHECKPOINT
     "${CMAKE_BINARY_DIR}/tests/Unit/Parallel/SpectreCheckpoint000000")
@@ -160,12 +99,20 @@ function(add_algorithm_test_with_restart_from_checkpoint TEST_NAME)
     "\"Unit.Parallel.${TEST_NAME}\""
     PROPERTIES
     TIMEOUT 10
-    LABELS "unit"
+    LABELS "standalone"
     ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
 endfunction()
 
+function(add_algorithm_test BASE_NAME)
+  add_standalone_test("Unit.Parallel.${BASE_NAME}" ${ARGN})
+  target_link_libraries(
+    "Test_${BASE_NAME}"
+    PRIVATE
+    "${ALGORITHM_TEST_LINK_LIBRARIES}")
+endfunction()
+
 # Test GlobalCache
-add_algorithm_test("GlobalCache" "")
+add_algorithm_test("GlobalCache")
 add_charm_module(Test_GlobalCache)
 
 add_dependencies(
@@ -180,25 +127,30 @@ add_dependencies(
 
 add_algorithm_test(
   "AlgorithmBadBoxApply"
+  REGEX_TO_MATCH
   "Cannot call apply function of 'error_size_zero' with DataBox \
 type 'db::DataBox<brigand::list<")
-add_algorithm_test("AlgorithmCore" "")
-add_algorithm_test("AlgorithmLocalSyncAction" "")
+add_algorithm_test("AlgorithmCore")
+add_algorithm_test("AlgorithmLocalSyncAction")
 add_algorithm_test(
   "AlgorithmNestedApply1"
+  REGEX_TO_MATCH
   "Already performing an Action and cannot execute additional Actions \
 from inside of an Action. This is only possible if the simple_action \
 function is not invoked via a proxy, which we do not allow.")
 add_algorithm_test(
   "AlgorithmNestedApply2"
+  REGEX_TO_MATCH
   "Already performing an Action and cannot execute additional Actions \
 from inside of an Action. This is only possible if the simple_action \
 function is not invoked via a proxy, which we do not allow.")
-add_algorithm_test("AlgorithmNodelock" "")
-add_algorithm_test("AlgorithmParallel" "")
-add_algorithm_test("AlgorithmReduction" "")
-add_algorithm_test("PhaseChangeMain" "")
-add_algorithm_test("SectionReductions"
+add_algorithm_test("AlgorithmNodelock")
+add_algorithm_test("AlgorithmParallel")
+add_algorithm_test("AlgorithmReduction")
+add_algorithm_test("PhaseChangeMain")
+add_algorithm_test(
+  "SectionReductions"
+  REGEX_TO_MATCH
   "Element 0 received reduction: Counted 2 odd elements.")
 
 # macOS builds on Apple Silicon use Charm 7.0.0, which has different
@@ -211,8 +163,12 @@ else()
     "AlgorithmParallel" "Objects migrating: 14")
 endif()
 
-add_algorithm_test_with_input_file("AlgorithmGlobalCache" "Unit/Parallel")
-add_algorithm_test_with_input_file("AlgorithmPhaseControl" "Unit/Parallel")
+add_algorithm_test(
+  "AlgorithmGlobalCache"
+  INPUT_FILE "Test_AlgorithmGlobalCache.yaml")
+add_algorithm_test(
+  "AlgorithmPhaseControl"
+  INPUT_FILE "Test_AlgorithmPhaseControl.yaml")
 
 add_algorithm_test_with_restart_from_checkpoint("CheckpointRestart")
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/CMakeLists.txt
@@ -19,61 +19,24 @@ add_dependencies(
   module_GlobalCache
   )
 
-function(add_linear_solver_algorithm_test TEST_NAME)
-  set(EXECUTABLE_NAME Test_${TEST_NAME})
-  set(TEST_IDENTIFIER Integration.LinearSolver.${TEST_NAME})
+set(INTEGRATION_TEST_LINK_LIBRARIES
+  # Link against Boost::program_options for now until we have proper
+  # dependency handling for header-only libs
+  Boost::program_options
+  DataStructures
+  ErrorHandling
+  IO
+  Informer
+  Parallel
+  ParallelLinearSolver
+  )
 
-  add_spectre_executable(
-    ${EXECUTABLE_NAME}
-    ${EXECUTABLE_NAME}.cpp
-    )
-
-  add_dependencies(
-    ${EXECUTABLE_NAME}
-    module_GlobalCache
-    module_Main
-    )
-
-  target_link_libraries(
-    ${EXECUTABLE_NAME}
-    PUBLIC
-    # Link against Boost::program_options for now until we have proper
-    # dependency handling for header-only libs
-    Boost::program_options
-    DataStructures
-    ErrorHandling
-    IO
-    Informer
-    Parallel
-    ParallelLinearSolver
-    )
-
-  add_dependencies(test-executables ${EXECUTABLE_NAME})
-
-  add_test(
-    NAME ${TEST_IDENTIFIER}
-    COMMAND ${CMAKE_BINARY_DIR}/bin/${EXECUTABLE_NAME} --input-file
-    ${CMAKE_CURRENT_SOURCE_DIR}/${EXECUTABLE_NAME}.yaml
-    )
-
-  set_tests_properties(
-    ${TEST_IDENTIFIER}
-    PROPERTIES
-    TIMEOUT 5
-    LABELS "integration"
-    ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
-endfunction()
-
-function(add_distributed_linear_solver_algorithm_test TEST_NAME)
-  add_linear_solver_algorithm_test(${TEST_NAME})
-  target_link_libraries(
-    Test_${TEST_NAME}
-    PRIVATE
-    Domain
-    DomainBoundaryConditionsHelpers
-    DomainCreators
-    )
-endfunction()
+set(DISTRIBUTED_INTEGRATION_TEST_LINK_LIBRARIES
+  ${INTEGRATION_TEST_LINK_LIBRARIES}
+  Domain
+  DomainBoundaryConditionsHelpers
+  DomainCreators
+  )
 
 add_subdirectory(Actions)
 add_subdirectory(AsynchronousSolvers)

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/CMakeLists.txt
@@ -30,6 +30,17 @@ add_dependencies(
   module_GlobalCache
   )
 
-add_linear_solver_algorithm_test("ConjugateGradientAlgorithm")
-add_distributed_linear_solver_algorithm_test(
-  "DistributedConjugateGradientAlgorithm")
+add_standalone_test(
+  "Integration.LinearSolver.ConjugateGradientAlgorithm"
+  INPUT_FILE "Test_ConjugateGradientAlgorithm.yaml")
+target_link_libraries(
+  "Test_ConjugateGradientAlgorithm"
+  PRIVATE
+  "${INTEGRATION_TEST_LINK_LIBRARIES}")
+add_standalone_test(
+  "Integration.LinearSolver.DistributedConjugateGradientAlgorithm"
+  INPUT_FILE "Test_DistributedConjugateGradientAlgorithm.yaml")
+target_link_libraries(
+  "Test_DistributedConjugateGradientAlgorithm"
+  PRIVATE
+  "${DISTRIBUTED_INTEGRATION_TEST_LINK_LIBRARIES}")

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/CMakeLists.txt
@@ -30,8 +30,31 @@ add_dependencies(
   module_GlobalCache
   )
 
-add_linear_solver_algorithm_test("GmresAlgorithm")
-add_linear_solver_algorithm_test("GmresPreconditionedAlgorithm")
-add_distributed_linear_solver_algorithm_test("DistributedGmresAlgorithm")
-add_distributed_linear_solver_algorithm_test(
-  "DistributedGmresPreconditionedAlgorithm")
+add_standalone_test(
+  "Integration.LinearSolver.GmresAlgorithm"
+  INPUT_FILE "Test_GmresAlgorithm.yaml")
+target_link_libraries(
+  "Test_GmresAlgorithm"
+  PRIVATE
+  "${INTEGRATION_TEST_LINK_LIBRARIES}")
+add_standalone_test(
+  "Integration.LinearSolver.GmresPreconditionedAlgorithm"
+  INPUT_FILE "Test_GmresPreconditionedAlgorithm.yaml")
+target_link_libraries(
+  "Test_GmresPreconditionedAlgorithm"
+  PRIVATE
+  "${INTEGRATION_TEST_LINK_LIBRARIES}")
+add_standalone_test(
+  "Integration.LinearSolver.DistributedGmresAlgorithm"
+  INPUT_FILE "Test_DistributedGmresAlgorithm.yaml")
+target_link_libraries(
+  "Test_DistributedGmresAlgorithm"
+  PRIVATE
+  "${DISTRIBUTED_INTEGRATION_TEST_LINK_LIBRARIES}")
+add_standalone_test(
+  "Integration.LinearSolver.DistributedGmresPreconditionedAlgorithm"
+  INPUT_FILE "Test_DistributedGmresPreconditionedAlgorithm.yaml")
+target_link_libraries(
+  "Test_DistributedGmresPreconditionedAlgorithm"
+  PRIVATE
+  "${DISTRIBUTED_INTEGRATION_TEST_LINK_LIBRARIES}")

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/CMakeLists.txt
@@ -24,32 +24,24 @@ target_link_libraries(
   Utilities
   )
 
-add_distributed_linear_solver_algorithm_test("MultigridAlgorithm")
+add_standalone_test(
+  "Integration.LinearSolver.MultigridAlgorithm"
+  INPUT_FILE "Test_MultigridAlgorithm.yaml")
+add_standalone_test(
+  "Integration.LinearSolver.MultigridAlgorithmMassive"
+  EXECUTABLE "Test_MultigridAlgorithm"
+  INPUT_FILE "Test_MultigridAlgorithmMassive.yaml")
 target_link_libraries(
-  Test_MultigridAlgorithm
+  "Test_MultigridAlgorithm"
   PRIVATE
-  ParallelMultigrid
-  )
+  "${DISTRIBUTED_INTEGRATION_TEST_LINK_LIBRARIES};ParallelMultigrid")
 
-add_test(
-  NAME Integration.LinearSolver.MultigridAlgorithmMassive
-  COMMAND ${CMAKE_BINARY_DIR}/bin/Test_MultigridAlgorithm --input-file
-  ${CMAKE_CURRENT_SOURCE_DIR}/Test_MultigridAlgorithmMassive.yaml
-  )
-set_tests_properties(
-  Integration.LinearSolver.MultigridAlgorithmMassive
-  PROPERTIES
-  TIMEOUT 5
-  LABELS "integration"
-  ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
-
-add_distributed_linear_solver_algorithm_test(
-  "MultigridPreconditionedGmresAlgorithm")
+add_standalone_test(
+  "Integration.LinearSolver.MultigridPreconditionedGmresAlgorithm"
+  INPUT_FILE "Test_MultigridPreconditionedGmresAlgorithm.yaml")
 target_link_libraries(
-  Test_MultigridPreconditionedGmresAlgorithm
+  "Test_MultigridPreconditionedGmresAlgorithm"
   PRIVATE
-  ParallelMultigrid
-  ParallelNonlinearSolver
-  )
+  "${DISTRIBUTED_INTEGRATION_TEST_LINK_LIBRARIES};ParallelMultigrid;ParallelNonlinearSolver")
 
 add_subdirectory(Actions)

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/CMakeLists.txt
@@ -14,5 +14,17 @@ add_test_library(
   "ParallelLinearSolver"
   )
 
-add_linear_solver_algorithm_test("RichardsonAlgorithm")
-add_distributed_linear_solver_algorithm_test("DistributedRichardsonAlgorithm")
+add_standalone_test(
+  "Integration.LinearSolver.RichardsonAlgorithm"
+  INPUT_FILE "Test_RichardsonAlgorithm.yaml")
+target_link_libraries(
+  "Test_RichardsonAlgorithm"
+  PRIVATE
+  "${INTEGRATION_TEST_LINK_LIBRARIES}")
+add_standalone_test(
+  "Integration.LinearSolver.DistributedRichardsonAlgorithm"
+  INPUT_FILE "Test_DistributedRichardsonAlgorithm.yaml")
+target_link_libraries(
+  "Test_DistributedRichardsonAlgorithm"
+  PRIVATE
+  "${DISTRIBUTED_INTEGRATION_TEST_LINK_LIBRARIES}")

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/CMakeLists.txt
@@ -18,13 +18,12 @@ add_test_library(
   "DataStructures;Domain;DomainStructure;LinearSolver;ParallelSchwarz;Spectral"
   )
 
-add_distributed_linear_solver_algorithm_test("SchwarzAlgorithm")
+add_standalone_test(
+  "Integration.LinearSolver.SchwarzAlgorithm"
+  INPUT_FILE "Test_SchwarzAlgorithm.yaml")
 target_link_libraries(
-  Test_SchwarzAlgorithm
+  "Test_SchwarzAlgorithm"
   PRIVATE
-  Domain
-  DomainStructure
-  ParallelSchwarz
-)
+  "${DISTRIBUTED_INTEGRATION_TEST_LINK_LIBRARIES};Domain;DomainStructure;ParallelSchwarz")
 
 add_subdirectory(Actions)

--- a/tests/Unit/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/CMakeLists.txt
@@ -14,52 +14,23 @@ add_test_library(
   "ParallelNonlinearSolver"
   )
 
-# This function is adapted from
-# tests/Unit/ParallelAlgorithms/LinearSolver/CMakeLists.txt
-function(add_nonlinear_solver_algorithm_test TEST_NAME)
-  set(EXECUTABLE_NAME Test_${TEST_NAME})
-  set(TEST_IDENTIFIER Integration.NonlinearSolver.${TEST_NAME})
+set(INTEGRATION_TEST_LINK_LIBRARIES
+  # Link against Boost::program_options for now until we have proper
+  # dependency handling for header-only libs
+  Boost::program_options
+  Convergence
+  DataStructures
+  ErrorHandling
+  Informer
+  IO
+  ParallelLinearSolver
+  ParallelNonlinearSolver
+  )
 
-  add_spectre_executable(
-    ${EXECUTABLE_NAME}
-    ${EXECUTABLE_NAME}.cpp
-    )
-
-  add_dependencies(
-    ${EXECUTABLE_NAME}
-    module_GlobalCache
-    module_Main
-    )
-
-  target_link_libraries(
-    ${EXECUTABLE_NAME}
-    PRIVATE
-    # Link against Boost::program_options for now until we have proper
-    # dependency handling for header-only libs
-    Boost::program_options
-    Convergence
-    DataStructures
-    ErrorHandling
-    Informer
-    IO
-    ParallelLinearSolver
-    ParallelNonlinearSolver
-    )
-
-  add_dependencies(test-executables ${EXECUTABLE_NAME})
-
-  add_test(
-    NAME "\"${TEST_IDENTIFIER}\""
-    COMMAND ${CMAKE_BINARY_DIR}/bin/${EXECUTABLE_NAME} --input-file
-    ${CMAKE_CURRENT_SOURCE_DIR}/${EXECUTABLE_NAME}.yaml
-    )
-
-  set_tests_properties(
-    "\"${TEST_IDENTIFIER}\""
-    PROPERTIES
-    TIMEOUT 5
-    LABELS "integration"
-    ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
-endfunction()
-
-add_nonlinear_solver_algorithm_test("NewtonRaphsonAlgorithm")
+add_standalone_test(
+  "Integration.LinearSolver.NewtonRaphsonAlgorithm"
+  INPUT_FILE "Test_NewtonRaphsonAlgorithm.yaml")
+target_link_libraries(
+  "Test_NewtonRaphsonAlgorithm"
+  PRIVATE
+  "${INTEGRATION_TEST_LINK_LIBRARIES}")

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -644,9 +644,17 @@ cmakelists_hardcoded_libraries() {
     [[ $1 =~ CMakeLists\.txt$ ]] && \
         whitelist "$1" \
                   "tests/Unit/Parallel/CMakeLists.txt$" \
-                  "tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/\
+                  "tests/Unit/ParallelAlgorithms/LinearSolver/\
+ConjugateGradient/CMakeLists.txt$" \
+                  "tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/\
 CMakeLists.txt$" \
                   "tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/\
+CMakeLists.txt$" \
+                  "tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/\
+CMakeLists.txt$" \
+                  "tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/\
+CMakeLists.txt$" \
+                  "tests/Unit/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/\
 CMakeLists.txt$" && \
         staged_grep -E -A1 "(${CHECKED_COMMANDS})\(\$" "$1" | \
             grep -Ev -- "--|${CHECKED_COMMANDS}" | \


### PR DESCRIPTION
Re the charmrun commit: I considered using charmrun unconditionally, but thought it good to test without on systems where we expect to be able to run programs without using it.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
