### PR TITLE
Drop Py2 support for pybindings

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -337,6 +337,8 @@ jobs:
           - compiler: gcc-11
             build_type: Debug
             PYTHON_EXECUTABLE: /usr/bin/python2
+            # We make no effort to keep Python bindings compatible with Py2.
+            BUILD_PYTHON_BINDINGS: OFF
           # Add a test without PCH to the build matrix, which only builds core
           # libraries. Building all the tests without the PCH takes very long
           # and the most we would catch is a missing include of something that's

--- a/cmake/SetupPybind11.cmake
+++ b/cmake/SetupPybind11.cmake
@@ -5,7 +5,7 @@ option(BUILD_PYTHON_BINDINGS "Build the python bindings for SpECTRE" OFF)
 
 if(BUILD_PYTHON_BINDINGS)
   # Make sure to find Python first so it's consistent with pybind11
-  find_package(Python COMPONENTS Interpreter Development)
+  find_package(Python 3.7 REQUIRED COMPONENTS Interpreter Development)
 
   # Try to find the pybind11-config tool to find pybind11's CMake config files
   find_program(PYBIND11_CONFIG_TOOL pybind11-config)

--- a/docs/DevGuide/PythonBindings.md
+++ b/docs/DevGuide/PythonBindings.md
@@ -110,8 +110,7 @@ above).
 
 The `DataVector` bindings serve as an example with code comments on how to write
 bindings for a class. There is also extensive documentation available directly
-from [pybind11](https://pybind11.readthedocs.io/). SpECTRE currently aims to
-support both Python 2.7 and Python 3 and as such all bindings must support both.
+from [pybind11](https://pybind11.readthedocs.io/).
 
 \note Exceptions should be allowed to propagate through the bindings so that
 error handling via exceptions is possible from python rather than having the

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -77,7 +77,8 @@ all of these dependencies.
 * [LIBXSMM](https://github.com/hfp/libxsmm) version 1.16.1 or later
 * [yaml-cpp](https://github.com/jbeder/yaml-cpp) version 0.6.3 or later.
   Building with shared library support is also recommended.
-* [Python](https://www.python.org/) 2.7, or 3.5 or later
+* [Python](https://www.python.org/) 2.7, or 3.5 or later. Python bindings
+  require Python 3.7.
 * [NumPy](http://www.numpy.org/) 1.10 or later
 * [SciPy](https://www.scipy.org)
 * [matplotlib](https://matplotlib.org/)

--- a/tests/Unit/IO/H5/Test_H5.py
+++ b/tests/Unit/IO/H5/Test_H5.py
@@ -7,11 +7,6 @@ import unittest
 import numpy as np
 import os
 import numpy.testing as npt
-# For Py2 compatibility
-try:
-    unittest.TestCase.assertRaisesRegex
-except AttributeError:
-    unittest.TestCase.assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
 
 
 class TestIOH5File(unittest.TestCase):

--- a/tests/Unit/Informer/Test_InfoAtCompile.py
+++ b/tests/Unit/Informer/Test_InfoAtCompile.py
@@ -2,11 +2,8 @@
 # See LICENSE.txt for details.
 
 from spectre import Informer
-try:
-    # Fallback for Py2 that provides `assertRegex`
-    import unittest2 as unittest
-except:
-    import unittest
+
+import unittest
 
 VERSION_PATTERN = r'\d{4}\.\d{2}\.\d{2}(\.\d+)?'
 

--- a/tests/Unit/NumericalAlgorithms/Spectral/Python/Test_Mesh.py
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Python/Test_Mesh.py
@@ -3,12 +3,9 @@
 
 from spectre.Spectral import Mesh1D, Mesh2D, Mesh3D
 from spectre.Spectral import Basis, Quadrature
-try:
-    import cPickle as pickle  # Use cPickle on Python 2.7
-except ImportError:
-    import pickle
 
 import numpy as np
+import pickle
 import unittest
 import random
 
@@ -77,8 +74,7 @@ class TestMesh(unittest.TestCase):
                 ]
 
                 mesh = Mesh(extents, bases, quadratures)
-                # Use pickle protocol 2 for Py2 compatibility
-                mesh = pickle.loads(pickle.dumps(mesh, protocol=2))
+                mesh = pickle.loads(pickle.dumps(mesh))
                 self.check_extents(mesh, extents)
                 self.check_basis(mesh, bases)
                 self.check_quadrature(mesh, quadratures)

--- a/tests/Unit/Visualization/Python/Test_GenerateXdmf.py
+++ b/tests/Unit/Visualization/Python/Test_GenerateXdmf.py
@@ -7,12 +7,6 @@ import spectre.Informer as spectre_informer
 import unittest
 import os
 
-# For Py2 compatibility
-try:
-    unittest.TestCase.assertRaisesRegex
-except AttributeError:
-    unittest.TestCase.assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
-
 
 class TestGenerateXdmf(unittest.TestCase):
     def test_generate_xdmf(self):


### PR DESCRIPTION
## Proposed changes

The code still builds and runs with Py2, including unit tests. Only require Py3 when pybindings are enabled (`BUILD_PYTHON_BINDINGS=ON`). It doesn't seem worth the effort to keep supporting Py2 for the pybindings, and would hold back further development of the supporting Python code in the repo.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Python bindings (builds with `BUILD_PYTHON_BINDINGS=ON`) require Python 3.7 or newer now.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
