### PR TITLE
Add `this_machine` Python function

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -331,6 +331,8 @@ jobs:
           - compiler: gcc-8
             build_type: Debug
             PYTHON_EXECUTABLE: /usr/bin/python2
+            # We make no effort to keep Python bindings compatible with Py2.
+            BUILD_PYTHON_BINDINGS: OFF
           # Test compatibility with oldest supported CMake version
           - compiler: gcc-9
             build_type: Debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,7 @@ spectre_include_directories(${CMAKE_BINARY_DIR}/src/Parallel)
 
 add_subdirectory(external)
 add_subdirectory(src)
+add_subdirectory(support)
 if(BUILD_TESTING)
   add_subdirectory(tests)
 endif()

--- a/cmake/SetupPybind11.cmake
+++ b/cmake/SetupPybind11.cmake
@@ -5,7 +5,7 @@ option(BUILD_PYTHON_BINDINGS "Build the python bindings for SpECTRE" OFF)
 
 if(BUILD_PYTHON_BINDINGS)
   # Make sure to find Python first so it's consistent with pybind11
-  find_package(Python COMPONENTS Interpreter Development)
+  find_package(Python 3.7 REQUIRED COMPONENTS Interpreter Development)
 
   # Try to find the pybind11-config tool to find pybind11's CMake config files
   find_program(PYBIND11_CONFIG_TOOL pybind11-config)

--- a/docs/DevGuide/BuildSystem.md
+++ b/docs/DevGuide/BuildSystem.md
@@ -215,6 +215,11 @@ cmake -D FLAG1=OPT1 ... -D FLAGN=OPTN <SPECTRE_ROOT>
   - Whether to keep the frame pointer. Needed for profiling or other cases
     where you need to be able to figure out what the call stack is.
     (default is `OFF`)
+- MACHINE
+  - Select a machine that we know how to run on, such as a particular
+    supercomputer. A file named MACHINE.yaml must exist in support/Machines and
+    a submit script template named MACHINE.sh must exist in
+    support/SubmitScripts.
 - MEMORY_ALLOCATOR
   - Set which memory allocator to use. If there are unexplained segfaults or
     other memory issues, it would be worth setting `MEMORY_ALLOCATOR=SYSTEM` to

--- a/docs/DevGuide/PythonBindings.md
+++ b/docs/DevGuide/PythonBindings.md
@@ -110,8 +110,7 @@ above).
 
 The `DataVector` bindings serve as an example with code comments on how to write
 bindings for a class. There is also extensive documentation available directly
-from [pybind11](https://pybind11.readthedocs.io/). SpECTRE currently aims to
-support both Python 2.7 and Python 3 and as such all bindings must support both.
+from [pybind11](https://pybind11.readthedocs.io/).
 
 \note Exceptions should be allowed to propagate through the bindings so that
 error handling via exceptions is possible from python rather than having the

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -73,7 +73,9 @@ all of these dependencies.
 * [LIBXSMM](https://github.com/hfp/libxsmm) version 1.16.1 or later
 * [yaml-cpp](https://github.com/jbeder/yaml-cpp) version 0.6.3 is
   recommended. Building with shared library support is also recommended.
-* [Python](https://www.python.org/) 2.7, or 3.5 or later
+* [Python](https://www.python.org/) 2.7, or 3.5 or later. We retain
+  compatibility with Python 2 only for core functionality. Python bindings
+  require Python 3.7.
 * [NumPy](http://www.numpy.org/) 1.10 or later
 * [SciPy](https://www.scipy.org)
 * [matplotlib](https://matplotlib.org/)

--- a/src/PythonBindings/setup.py
+++ b/src/PythonBindings/setup.py
@@ -15,7 +15,6 @@ setup(
     packages=['spectre'],
     install_requires=['h5py', 'numpy', 'scipy'],
     classifiers=[
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",

--- a/support/CMakeLists.txt
+++ b/support/CMakeLists.txt
@@ -1,5 +1,4 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-add_subdirectory(support)
-add_subdirectory(Unit)
+add_subdirectory(Machines)

--- a/support/Environments/minerva_gcc.sh
+++ b/support/Environments/minerva_gcc.sh
@@ -114,5 +114,6 @@ spectre_run_cmake() {
       -D BUILD_SHARED_LIBS=ON \
       -D MEMORY_ALLOCATOR=SYSTEM \
       -D BUILD_PYTHON_BINDINGS=ON \
+      -D MACHINE=Minerva \
       -Wno-dev "$@" $SPECTRE_HOME
 }

--- a/support/Machines/CMakeLists.txt
+++ b/support/Machines/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+option(MACHINE "Select a machine that we know how to run on, such as a \
+particular supercomputer" OFF)
+
+spectre_python_add_module(
+  support
+  PYTHON_FILES
+  Machines.py
+)
+
+if(MACHINE)
+  message(STATUS "Selected machine: ${MACHINE}")
+  configure_file(
+    ${CMAKE_SOURCE_DIR}/support/Machines/${MACHINE}.yaml
+    ${SPECTRE_PYTHON_PREFIX}/support/Machine.yaml
+    )
+  configure_file(
+    ${CMAKE_SOURCE_DIR}/support/SubmitScripts/${MACHINE}.sh
+    ${SPECTRE_PYTHON_PREFIX}/support/Submit.sh
+    )
+endif()

--- a/support/Machines/Machines.py
+++ b/support/Machines/Machines.py
@@ -1,0 +1,79 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+"""Support for host machines, such as supercomputers.
+
+Machines are defined as YAML files in 'support/Machines/'. To add support for a
+new machine, add a YAML file that defines a `Machine:` key with the attributes
+listed in the `Machine` class below.
+
+To select a machine, specify the `MACHINE` option when configuring the CMake
+build.
+"""
+
+from __future__ import annotations
+
+import os
+import yaml
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Machine(yaml.YAMLObject):
+    """A machine we know how to run on, such as a particular supercomputer.
+
+    Attributes:
+      Name: A short name for the machine. Must match the YAML file name.
+      Description: A description of the machine. Give some basic context and
+        any information that may help people get started using the machine.
+        Provide links to wiki pages, signup pages, etc., for additional
+        information.
+      Scheduler: The scheduler used to submit jobs to the queue. Typically
+        'sbatch'.
+      DefaultProcsPerNode: Default number of worker threads spawned per node.
+        It is often advised to leave one core per node or socket free for
+        communication, so this might be the number of cores or hyperthreads
+        per node minus one.
+      DefaultQueue: Default queue that jobs are submitted to. On Slurm systems
+        you can see the available queues with `sinfo`.
+      DefaultTimeLimit: Default wall time limit for submitted jobs. For
+        acceptable formats, see: https://slurm.schedmd.com/sbatch.html#OPT_time
+    """
+    yaml_tag = '!Machine'
+    yaml_loader = yaml.SafeLoader
+    # The YAML machine files can have these attributes:
+    Name: str
+    Description: str
+    Scheduler: str = None
+    DefaultProcsPerNode: int = None
+    DefaultQueue: str = None
+    DefaultTimeLimit: str = None
+
+
+# Parse YAML machine files as Machine objects
+yaml.SafeLoader.add_path_resolver('!Machine', ['Machine'], dict)
+
+
+class UnknownMachineError(Exception):
+    """Indicates we were unsuccessful in identifying the current machine"""
+    pass
+
+
+def this_machine(machinefile_path=os.path.join(os.path.dirname(__file__),
+                                               'Machine.yaml')) -> Machine:
+    """Determine the machine we are running on.
+
+    Raises `UnknownMachineError` if no machine was selected. Specify the
+    `MACHINE` option in the CMake build configuration to select a machine, or
+    pass the `machinefile_path` argument to this function.
+
+    Arguments:
+      machinefile_path: Path to a YAML file that describes the current machine.
+        Defaults to the machine selected in the CMake build configuration.
+    """
+    if not os.path.exists(machinefile_path):
+        raise UnknownMachineError(
+            "No machine was selected. Specify the 'MACHINE' option when "
+            "configuring the build with CMake. If you are running on a new "
+            "machine, please add it to 'support/Machines/'. The machine file "
+            f"was expected at the following path:\n  {machinefile_path}")
+    return yaml.safe_load(open(machinefile_path, 'r'))['Machine']

--- a/support/Machines/Minerva.yaml
+++ b/support/Machines/Minerva.yaml
@@ -1,0 +1,12 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+Machine:
+  Name: Minerva
+  Description: |
+    Supercomputer at the AEI Potsdam.
+    More information: https://minerva.aei.mpg.de
+  Scheduler: 'sbatch'
+  DefaultProcsPerNode: 15
+  DefaultQueue: 'nr'
+  DefaultTimeLimit: '24:00:00'

--- a/tests/Unit/IO/H5/Test_H5.py
+++ b/tests/Unit/IO/H5/Test_H5.py
@@ -7,11 +7,6 @@ import unittest
 import numpy as np
 import os
 import numpy.testing as npt
-# For Py2 compatibility
-try:
-    unittest.TestCase.assertRaisesRegex
-except AttributeError:
-    unittest.TestCase.assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
 
 
 class TestIOH5File(unittest.TestCase):

--- a/tests/Unit/Informer/Test_InfoAtCompile.py
+++ b/tests/Unit/Informer/Test_InfoAtCompile.py
@@ -2,11 +2,8 @@
 # See LICENSE.txt for details.
 
 from spectre import Informer
-try:
-    # Fallback for Py2 that provides `assertRegex`
-    import unittest2 as unittest
-except:
-    import unittest
+
+import unittest
 
 VERSION_PATTERN = r'\d{4}\.\d{2}\.\d{2}(\.\d+)?'
 

--- a/tests/Unit/NumericalAlgorithms/Spectral/Python/Test_Mesh.py
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Python/Test_Mesh.py
@@ -3,12 +3,9 @@
 
 from spectre.Spectral import Mesh1D, Mesh2D, Mesh3D
 from spectre.Spectral import Basis, Quadrature
-try:
-    import cPickle as pickle  # Use cPickle on Python 2.7
-except ImportError:
-    import pickle
 
 import numpy as np
+import pickle
 import unittest
 import random
 
@@ -77,8 +74,7 @@ class TestMesh(unittest.TestCase):
                 ]
 
                 mesh = Mesh(extents, bases, quadratures)
-                # Use pickle protocol 2 for Py2 compatibility
-                mesh = pickle.loads(pickle.dumps(mesh, protocol=2))
+                mesh = pickle.loads(pickle.dumps(mesh))
                 self.check_extents(mesh, extents)
                 self.check_basis(mesh, bases)
                 self.check_quadrature(mesh, quadratures)

--- a/tests/Unit/Visualization/Python/Test_GenerateXdmf.py
+++ b/tests/Unit/Visualization/Python/Test_GenerateXdmf.py
@@ -7,12 +7,6 @@ import spectre.Informer as spectre_informer
 import unittest
 import os
 
-# For Py2 compatibility
-try:
-    unittest.TestCase.assertRaisesRegex
-except AttributeError:
-    unittest.TestCase.assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
-
 
 class TestGenerateXdmf(unittest.TestCase):
     def test_generate_xdmf(self):

--- a/tests/support/CMakeLists.txt
+++ b/tests/support/CMakeLists.txt
@@ -1,5 +1,4 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-add_subdirectory(support)
-add_subdirectory(Unit)
+add_subdirectory(Machines)

--- a/tests/support/Machines/CMakeLists.txt
+++ b/tests/support/Machines/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_add_python_bindings_test(
+  "support.Machines"
+  Test_Machines.py
+  "Machines"
+  None)

--- a/tests/support/Machines/Test_Machines.py
+++ b/tests/support/Machines/Test_Machines.py
@@ -1,0 +1,29 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import os
+import unittest
+import yaml
+from spectre.support.Machines import (Machine, this_machine,
+                                      UnknownMachineError)
+from spectre.Informer import unit_test_build_path
+
+
+class TestMachines(unittest.TestCase):
+    def setUp(self):
+        self.machinefile_path = os.path.join(unit_test_build_path(),
+                                             'TestMachine.yaml')
+        yaml.safe_dump(
+            dict(Machine=dict(Name="TestMachine",
+                              Description="Just for testing")),
+            open(self.machinefile_path, 'w'))
+
+    def test_this_machine(self):
+        with self.assertRaises(UnknownMachineError):
+            this_machine('NonexistentMachinefile.yaml')
+        self.assertEqual(
+            this_machine(self.machinefile_path).Name, "TestMachine")
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Proposed changes

This is a first step toward some lightweight cluster support in Python.

Depends on:

- [x] #3709 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
