### PR TITLE
Allow experimental builds with Charm++ 7

### DIFF
--- a/cmake/SetupCharm.cmake
+++ b/cmake/SetupCharm.cmake
@@ -3,9 +3,13 @@
 
 # Apple Silicon (arm64) Macs require charm 7.0.0 to run
 if(APPLE AND "${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "arm64")
-  find_package(Charm 7.0.0 EXACT REQUIRED)
+  find_package(Charm 7.0.0 REQUIRED)
 else()
-  find_package(Charm 6.10.2 EXACT REQUIRED)
+  find_package(Charm 6.10.2 REQUIRED)
+endif()
+if(CHARM_VERSION VERSION_GREATER 6.10.2)
+  message(WARNING "Builds with Charm++ versions greater than 6.10.2 are \
+considered experimental. Please file any issues you encounter.")
 endif()
 
 spectre_include_directories("${CHARM_INCLUDE_DIRS}")

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -30,7 +30,7 @@ all of these dependencies.
 * [GCC](https://gcc.gnu.org/) 7.0 or later,
 [Clang](https://clang.llvm.org/) 8.0 or later, or AppleClang 11.0.0 or later
 * [CMake](https://cmake.org/) 3.12.0 or later
-* [Charm++](http://charm.cs.illinois.edu/) 6.10.2
+* [Charm++](http://charm.cs.illinois.edu/) 6.10.2, or 7.0.0 or later (experimental)
 * [Git](https://git-scm.com/)
 * BLAS (e.g. [OpenBLAS](http://www.openblas.net))
 * [Blaze](https://bitbucket.org/blaze-lib/blaze/overview) v3.8

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -144,9 +144,8 @@ add_algorithm_test(
   REGEX_TO_MATCH
   "Element 0 received reduction: Counted 2 odd elements.")
 
-# macOS builds on Apple Silicon use Charm 7.0.0, which has different
-# output in the following test.
-if(APPLE AND "${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "arm64")
+# Charm 7.0.0 has different output in the following test.
+if(CHARM_VERSION VERSION_GREATER 6.10.2)
   add_algorithm_test_with_balancing("AlgorithmParallelWithBalancing"
     "AlgorithmParallel" "num_objs=14")
 else()


### PR DESCRIPTION
## Proposed changes

Builds with Charm++ 7 seem to work fine so far. This PR simply allows experimental builds with Charm++ 7, no other changes. I had added support for finding Charm++ 7 already in #3079. After a while of testing we can decide if we want to require Charm++ 7, upgrade it in the container, etc.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Builds with Charm++ 7 are now allowed, meaning the SpECTRE build system now accepts Charm++ 7 installations. Builds with Charm++ 7 are still experimental, so please file or fix issues you encounter.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
