### PR TITLE
Add continuous extension RK time steppers

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -722,6 +722,22 @@ eprint = {https://doi.org/10.1137/0916035}
       SLACcitation   = "%%CITATION = ASTRO-PH/0501557;%%"
 }
 
+@article{Gassner20114232,
+  title =        {Explicit one-step time discretizations for discontinuous
+                  Galerkin and finite volume schemes based on local predictors},
+  journal =      {Journal of Computational Physics},
+  volume =       {230},
+  number =       {11},
+  pages =        {4232-4247},
+  year =         {2011},
+  note =         {Special issue High Order Methods for CFD Problems},
+  issn =         {0021-9991},
+  doi =          {https://doi.org/10.1016/j.jcp.2010.10.024},
+  url =  {https://www.sciencedirect.com/science/article/pii/S0021999110005802},
+  author =       {Gregor Gassner and Michael Dumbser and Florian Hindenlang and
+                  Claus-Dieter Munz}
+}
+
 @article{Giacomazzo2006,
   author =       {{Giacomazzo}, Bruno and {Rezzolla}, Luciano},
   title =        "{The exact solution of the Riemann problem in relativistic
@@ -1338,6 +1354,19 @@ eprint = {https://doi.org/10.1137/0916035}
   archivePrefix  = "arXiv",
   primaryClass   = "gr-qc",
   SLACcitation   = "%%CITATION = ARXIV:1708.07325;%%"
+}
+
+@article{Owren1992,
+  author =       {Owren, Brynjulf and Zennaro, Marino},
+  title =        {Derivation of Efficient, Continuous, Explicit Runge–Kutta
+                  Methods},
+  journal =      {SIAM Journal on Scientific and Statistical Computing},
+  volume =       {13},
+  number =       {6},
+  pages =        {1488-1501},
+  year =         {1992},
+  doi =          {10.1137/0913084},
+  URL =          {https://epubs.siam.org/doi/10.1137/0913084}
 }
 
 @article{Penner2011,

--- a/src/Time/TimeSteppers/CMakeLists.txt
+++ b/src/Time/TimeSteppers/CMakeLists.txt
@@ -7,6 +7,7 @@ spectre_target_sources(
   AdamsBashforthN.cpp
   Cerk2.cpp
   Cerk3.cpp
+  Cerk4.cpp
   DormandPrince5.cpp
   RungeKutta3.cpp
   RungeKutta4.cpp
@@ -19,6 +20,7 @@ spectre_target_headers(
   AdamsBashforthN.hpp
   Cerk2.hpp
   Cerk3.hpp
+  Cerk4.hpp
   DormandPrince5.hpp
   RungeKutta3.hpp
   RungeKutta4.hpp

--- a/src/Time/TimeSteppers/CMakeLists.txt
+++ b/src/Time/TimeSteppers/CMakeLists.txt
@@ -8,6 +8,7 @@ spectre_target_sources(
   Cerk2.cpp
   Cerk3.cpp
   Cerk4.cpp
+  Cerk5.cpp
   DormandPrince5.cpp
   RungeKutta3.cpp
   RungeKutta4.cpp
@@ -21,6 +22,7 @@ spectre_target_headers(
   Cerk2.hpp
   Cerk3.hpp
   Cerk4.hpp
+  Cerk5.hpp
   DormandPrince5.hpp
   RungeKutta3.hpp
   RungeKutta4.hpp

--- a/src/Time/TimeSteppers/CMakeLists.txt
+++ b/src/Time/TimeSteppers/CMakeLists.txt
@@ -5,6 +5,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   AdamsBashforthN.cpp
+  Cerk2.cpp
   DormandPrince5.cpp
   RungeKutta3.cpp
   RungeKutta4.cpp
@@ -15,6 +16,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   AdamsBashforthN.hpp
+  Cerk2.hpp
   DormandPrince5.hpp
   RungeKutta3.hpp
   RungeKutta4.hpp

--- a/src/Time/TimeSteppers/CMakeLists.txt
+++ b/src/Time/TimeSteppers/CMakeLists.txt
@@ -6,6 +6,7 @@ spectre_target_sources(
   PRIVATE
   AdamsBashforthN.cpp
   Cerk2.cpp
+  Cerk3.cpp
   DormandPrince5.cpp
   RungeKutta3.cpp
   RungeKutta4.cpp
@@ -17,6 +18,7 @@ spectre_target_headers(
   HEADERS
   AdamsBashforthN.hpp
   Cerk2.hpp
+  Cerk3.hpp
   DormandPrince5.hpp
   RungeKutta3.hpp
   RungeKutta4.hpp

--- a/src/Time/TimeSteppers/Cerk2.cpp
+++ b/src/Time/TimeSteppers/Cerk2.cpp
@@ -1,0 +1,80 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Time/TimeSteppers/Cerk2.hpp"
+
+#include <cmath>
+#include <limits>
+
+#include "Time/TimeStepId.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace TimeSteppers {
+
+size_t Cerk2::order() const { return 2; }
+
+size_t Cerk2::error_estimate_order() const { return 1; }
+
+uint64_t Cerk2::number_of_substeps() const { return 2; }
+
+uint64_t Cerk2::number_of_substeps_for_error() const { return 2; }
+
+size_t Cerk2::number_of_past_steps() const { return 0; }
+
+// The stability polynomial is
+//
+//   p(z) = \sum_{n=0}^{stages-1} alpha_n z^n / n!,
+//
+// alpha_n=1.0 for n=1...(order-1). It is the same as for forward Euler.
+double Cerk2::stable_step() const { return 1.0; }
+
+TimeStepId Cerk2::next_time_id(const TimeStepId& current_id,
+                               const TimeDelta& time_step) const {
+  const auto& step = current_id.substep();
+  const auto& t0 = current_id.step_time();
+  const auto& t = current_id.substep_time();
+  if (step < number_of_substeps()) {
+    if (step == 0) {
+      ASSERT(t == t0, "In Cerk2 substep 0, the substep time ("
+                          << t << ") should equal t0 (" << t0 << ")");
+    } else {
+      ASSERT(t == t0 + gsl::at(c_, step - 1) * time_step,
+             "In Cerk2 substep "
+                 << step << ", the substep time (" << t
+                 << ") should equal t0+c[" << step - 1 << "]*dt ("
+                 << t0 + gsl::at(c_, step - 1) * time_step << ")");
+    }
+    if (step < number_of_substeps() - 1) {
+      return {current_id.time_runs_forward(), current_id.slab_number(), t0,
+              step + 1, t0 + gsl::at(c_, step) * time_step};
+    } else {
+      return {current_id.time_runs_forward(), current_id.slab_number(),
+              t0 + time_step};
+    }
+  } else {
+    ERROR("In Cerk2 substep should be one of 0,1, not "
+          << current_id.substep());
+  }
+}
+
+TimeStepId Cerk2::next_time_id_for_error(const TimeStepId& current_id,
+                                         const TimeDelta& time_step) const {
+  return next_time_id(current_id, time_step);
+}
+
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr double Cerk2::a2_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 2> Cerk2::a3_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 3> Cerk2::b1_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 3> Cerk2::b2_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 2> Cerk2::e_;
+const std::array<Time::rational_t, 1> Cerk2::c_ = {{{1, 1}}};
+}  // namespace TimeSteppers
+
+PUP::able::PUP_ID TimeSteppers::Cerk2::my_PUP_ID =  // NOLINT
+    0;

--- a/src/Time/TimeSteppers/Cerk2.hpp
+++ b/src/Time/TimeSteppers/Cerk2.hpp
@@ -1,0 +1,226 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <ostream>
+#include <pup.h>
+
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Math.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+struct TimeStepId;
+namespace TimeSteppers {
+template <typename Vars, typename DerivVars>
+class History;
+}  // namespace TimeSteppers
+/// \endcond
+
+namespace TimeSteppers {
+/*!
+ * \ingroup TimeSteppersGroup
+ * \brief A second order continuous-extension RK method that provides 2nd-order
+ * dense output.
+ *
+ * \f{eqnarray}{
+ * \frac{du}{dt} & = & \mathcal{L}(t,u).
+ * \f}
+ * Given a solution \f$u(t^n)=u^n\f$, this stepper computes
+ * \f$u(t^{n+1})=u^{n+1}\f$ using the following equations:
+ *
+ * \f{align}{
+ * k^{(i)} & = \mathcal{L}(t^n + c_i \Delta t,
+ *                         u^n + \Delta t \sum_{j=1}^{i-1} a_{ij} k^{(j)}),
+ *                              \mbox{ } 1 \leq i \leq s,\\
+ * u^{n+1}(t^n + \theta \Delta t) & = u^n + \Delta t \sum_{i=1}^{s} b_i(\theta)
+ * k^{(i)}. \f}
+ *
+ * Here the coefficients \f$a_{ij}\f$, \f$b_i\f$, and \f$c_i\f$ are given
+ * in \cite Gassner20114232. Note that \f$c_1 = 0\f$, \f$s\f$ is the number
+ * of stages, and \f$\theta\f$ is the fraction of the step.
+ *
+ * The CFL factor/stable step size is 1.0.
+ */
+class Cerk2 : public TimeStepper::Inherit {
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help = {
+      "A 2nd order accurate continuous extension Runge-Kutta method.."};
+
+  Cerk2() = default;
+  Cerk2(const Cerk2&) = default;
+  Cerk2& operator=(const Cerk2&) = default;
+  Cerk2(Cerk2&&) = default;
+  Cerk2& operator=(Cerk2&&) = default;
+  ~Cerk2() override = default;
+
+  template <typename Vars, typename DerivVars>
+  void update_u(gsl::not_null<Vars*> u,
+                gsl::not_null<History<Vars, DerivVars>*> history,
+                const TimeDelta& time_step) const;
+
+  template <typename Vars, typename ErrVars, typename DerivVars>
+  bool update_u(gsl::not_null<Vars*> u, gsl::not_null<ErrVars*> u_error,
+                gsl::not_null<History<Vars, DerivVars>*> history,
+                const TimeDelta& time_step) const;
+
+  template <typename Vars, typename DerivVars>
+  bool dense_update_u(gsl::not_null<Vars*> u,
+                      const History<Vars, DerivVars>& history,
+                      double time) const;
+
+  size_t order() const override;
+
+  size_t error_estimate_order() const override;
+
+  uint64_t number_of_substeps() const override;
+
+  uint64_t number_of_substeps_for_error() const override;
+
+  size_t number_of_past_steps() const override;
+
+  double stable_step() const override;
+
+  TimeStepId next_time_id(const TimeStepId& current_id,
+                          const TimeDelta& time_step) const override;
+
+  TimeStepId next_time_id_for_error(const TimeStepId& current_id,
+                                    const TimeDelta& time_step) const override;
+
+  template <typename Vars, typename DerivVars>
+  bool can_change_step_size(
+      const TimeStepId& time_id,
+      const TimeSteppers::History<Vars, DerivVars>& /*history*/) const {
+    return time_id.substep() == 0;
+  }
+
+  WRAPPED_PUPable_decl_template(Cerk2);  // NOLINT
+
+  explicit Cerk2(CkMigrateMessage* /*unused*/) {}
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override { TimeStepper::Inherit::pup(p); }
+
+ private:
+  static constexpr double a2_ = 1.0;
+  static constexpr std::array<double, 2> a3_{{0.5, 0.5}};
+
+  // For the dense output coefficients the index indicates
+  // `(degree of theta)`.
+  static constexpr std::array<double, 3> b1_{{-a3_[0], 1.0, -0.5}};
+  static constexpr std::array<double, 3> b2_{{-a3_[1], 0.0, 0.5}};
+
+  // constants for discrete error estimate
+  static constexpr std::array<double, 2> e_{{1.0, 0.0}};
+  static const std::array<Time::rational_t, 1> c_;
+};
+
+inline bool constexpr operator==(const Cerk2& /*lhs*/, const Cerk2& /*rhs*/) {
+  return true;
+}
+
+inline bool constexpr operator!=(const Cerk2& /*lhs*/, const Cerk2& /*rhs*/) {
+  return false;
+}
+
+template <typename Vars, typename DerivVars>
+void Cerk2::update_u(const gsl::not_null<Vars*> u,
+                     const gsl::not_null<History<Vars, DerivVars>*> history,
+                     const TimeDelta& time_step) const {
+  ASSERT(history->integration_order() == 2,
+         "Fixed-order stepper cannot run at order "
+             << history->integration_order());
+  const size_t substep = (history->end() - 1).time_step_id().substep();
+
+  // Clean up old history
+  if (substep == 0) {
+    history->mark_unneeded(history->end() - 1);
+  }
+
+  const auto& u0 = history->most_recent_value();
+  const double dt = time_step.value();
+
+  switch (substep) {
+    case 0: {
+      *u = u0 + (a2_ * dt) * history->begin().derivative();
+      break;
+    }
+    case 1: {
+      *u = u0 + ((a3_[0] - a2_) * dt) * history->begin().derivative() +
+           (a3_[1] * dt) * (history->begin() + 1).derivative();
+      break;
+    }
+    default:
+      ERROR("Bad substep value in Cerk2: " << substep);
+  }
+}
+
+template <typename Vars, typename ErrVars, typename DerivVars>
+bool Cerk2::update_u(const gsl::not_null<Vars*> u,
+                     const gsl::not_null<ErrVars*> u_error,
+                     const gsl::not_null<History<Vars, DerivVars>*> history,
+                     const TimeDelta& time_step) const {
+  ASSERT(history->integration_order() == 2,
+         "Fixed-order stepper cannot run at order "
+             << history->integration_order());
+  update_u(u, history, time_step);
+  const size_t current_substep = (history->end() - 1).time_step_id().substep();
+  if (current_substep == 1) {
+    const double dt = time_step.value();
+    *u_error = ((e_[0] - a3_[0]) * dt) * history->begin().derivative() -
+               a3_[1] * dt * (history->begin() + 1).derivative();
+    return true;
+  }
+  return false;
+}
+
+template <typename Vars, typename DerivVars>
+bool Cerk2::dense_update_u(const gsl::not_null<Vars*> u,
+                           const History<Vars, DerivVars>& history,
+                           const double time) const {
+  if ((history.end() - 1).time_step_id().substep() != 0) {
+    return false;
+  }
+  const double t0 = history[0].value();
+  const double t_end = history[history.size() - 1].value();
+  if (time == t_end) {
+    // Special case necessary for dense output at the initial time,
+    // before taking a step.
+    *u = history.most_recent_value();
+    return true;
+  }
+  const evolution_less<double> before{t_end > t0};
+  if (history.size() == 1 or before(t_end, time)) {
+    return false;
+  }
+  const double dt = t_end - t0;
+  const double output_fraction = (time - t0) / dt;
+  ASSERT(output_fraction >= 0.0, "Attempting dense output at time "
+                                     << time << ", but already progressed past "
+                                     << t0);
+  ASSERT(output_fraction <= 1.0, "Requested time ("
+                                     << time << ") not within step [" << t0
+                                     << ", " << t0 + dt << "]");
+
+  const auto& u_n_plus_1 = history.most_recent_value();
+
+  // We need the following: k1, k2
+  const auto& k1 = history.begin().derivative();
+  const auto& k2 = (history.begin() + 1).derivative();
+
+  *u = u_n_plus_1 + (dt * evaluate_polynomial(b1_, output_fraction)) * k1 +
+       (dt * evaluate_polynomial(b2_, output_fraction)) * k2;
+  return true;
+}
+}  // namespace TimeSteppers

--- a/src/Time/TimeSteppers/Cerk3.cpp
+++ b/src/Time/TimeSteppers/Cerk3.cpp
@@ -1,0 +1,84 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Time/TimeSteppers/Cerk3.hpp"
+
+#include <cmath>
+#include <limits>
+
+#include "Time/TimeStepId.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace TimeSteppers {
+
+size_t Cerk3::order() const { return 3; }
+
+size_t Cerk3::error_estimate_order() const { return 2; }
+
+uint64_t Cerk3::number_of_substeps() const { return 3; }
+
+uint64_t Cerk3::number_of_substeps_for_error() const { return 3; }
+
+size_t Cerk3::number_of_past_steps() const { return 0; }
+
+// The stability polynomial is
+//
+//   p(z) = \sum_{n=0}^{stages-1} alpha_n z^n / n!,
+//
+// alpha_n=1.0 for n=1...(order-1).
+double Cerk3::stable_step() const { return 1.2563726633091645; }
+
+TimeStepId Cerk3::next_time_id(const TimeStepId& current_id,
+                               const TimeDelta& time_step) const {
+  const auto& step = current_id.substep();
+  const auto& t0 = current_id.step_time();
+  const auto& t = current_id.substep_time();
+  if (step < number_of_substeps()) {
+    if (step == 0) {
+      ASSERT(t == t0, "In Cerk3 substep 0, the substep time ("
+                          << t << ") should equal t0 (" << t0 << ")");
+    } else {
+      ASSERT(t == t0 + gsl::at(c_, step - 1) * time_step,
+             "In Cerk3 substep "
+                 << step << ", the substep time (" << t
+                 << ") should equal t0+c[" << step - 1 << "]*dt ("
+                 << t0 + gsl::at(c_, step - 1) * time_step << ")");
+    }
+    if (step < number_of_substeps() - 1) {
+      return {current_id.time_runs_forward(), current_id.slab_number(), t0,
+              step + 1, t0 + gsl::at(c_, step) * time_step};
+    } else {
+      return {current_id.time_runs_forward(), current_id.slab_number(),
+              t0 + time_step};
+    }
+  } else {
+    ERROR("In Cerk3 substep should be one of 0,1,2,3, not "
+          << current_id.substep());
+  }
+}
+
+TimeStepId Cerk3::next_time_id_for_error(const TimeStepId& current_id,
+                                         const TimeDelta& time_step) const {
+  return next_time_id(current_id, time_step);
+}
+
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr double Cerk3::a2_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 2> Cerk3::a3_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 3> Cerk3::a4_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 4> Cerk3::b1_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 4> Cerk3::b3_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 4> Cerk3::b4_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 4> Cerk3::e_;
+const std::array<Time::rational_t, 2> Cerk3::c_ = {{{12, 23}, {4, 5}}};
+}  // namespace TimeSteppers
+
+PUP::able::PUP_ID TimeSteppers::Cerk3::my_PUP_ID =  // NOLINT
+    0;

--- a/src/Time/TimeSteppers/Cerk3.hpp
+++ b/src/Time/TimeSteppers/Cerk3.hpp
@@ -1,0 +1,246 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <ostream>
+#include <pup.h>
+
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Math.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+struct TimeStepId;
+namespace TimeSteppers {
+template <typename Vars, typename DerivVars>
+class History;
+}  // namespace TimeSteppers
+/// \endcond
+
+namespace TimeSteppers {
+/*!
+ * \ingroup TimeSteppersGroup
+ * \brief A third order continuous-extension RK method that provides 3rd-order
+ * dense output.
+ *
+ * \f{eqnarray}{
+ * \frac{du}{dt} & = & \mathcal{L}(t,u).
+ * \f}
+ * Given a solution \f$u(t^n)=u^n\f$, this stepper computes
+ * \f$u(t^{n+1})=u^{n+1}\f$ using the following equations:
+ *
+ * \f{align}{
+ * k^{(i)} & = \mathcal{L}(t^n + c_i \Delta t,
+ *                         u^n + \Delta t \sum_{j=1}^{i-1} a_{ij} k^{(j)}),
+ *                              \mbox{ } 1 \leq i \leq s,\\
+ * u^{n+1}(t^n + \theta \Delta t) & = u^n + \Delta t \sum_{i=1}^{s} b_i(\theta)
+ * k^{(i)}. \f}
+ *
+ * Here the coefficients \f$a_{ij}\f$, \f$b_i\f$, and \f$c_i\f$ are given
+ * in \cite Owren1992 and \cite Gassner20114232. Note that \f$c_1 = 0\f$,
+ * \f$s\f$ is the number of stages, and \f$\theta\f$ is the fraction of the
+ * step. This is an FSAL stepper.
+ *
+ * The CFL factor/stable step size is 1.2563726633091645.
+ */
+class Cerk3 : public TimeStepper::Inherit {
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help = {
+      "A 3rd-order continuous extension Runge-Kutta method."};
+
+  Cerk3() = default;
+  Cerk3(const Cerk3&) = default;
+  Cerk3& operator=(const Cerk3&) = default;
+  Cerk3(Cerk3&&) = default;
+  Cerk3& operator=(Cerk3&&) = default;
+  ~Cerk3() override = default;
+
+  template <typename Vars, typename DerivVars>
+  void update_u(gsl::not_null<Vars*> u,
+                gsl::not_null<History<Vars, DerivVars>*> history,
+                const TimeDelta& time_step) const;
+
+  template <typename Vars, typename ErrVars, typename DerivVars>
+  bool update_u(gsl::not_null<Vars*> u, gsl::not_null<ErrVars*> u_error,
+                gsl::not_null<History<Vars, DerivVars>*> history,
+                const TimeDelta& time_step) const;
+
+  template <typename Vars, typename DerivVars>
+  bool dense_update_u(gsl::not_null<Vars*> u,
+                      const History<Vars, DerivVars>& history,
+                      double time) const;
+
+  size_t order() const override;
+
+  size_t error_estimate_order() const override;
+
+  uint64_t number_of_substeps() const override;
+
+  uint64_t number_of_substeps_for_error() const override;
+
+  size_t number_of_past_steps() const override;
+
+  double stable_step() const override;
+
+  TimeStepId next_time_id(const TimeStepId& current_id,
+                          const TimeDelta& time_step) const override;
+
+  TimeStepId next_time_id_for_error(const TimeStepId& current_id,
+                                    const TimeDelta& time_step) const override;
+
+  template <typename Vars, typename DerivVars>
+  bool can_change_step_size(
+      const TimeStepId& time_id,
+      const TimeSteppers::History<Vars, DerivVars>& /*history*/) const {
+    return time_id.substep() == 0;
+  }
+
+  WRAPPED_PUPable_decl_template(Cerk3);  // NOLINT
+
+  explicit Cerk3(CkMigrateMessage* /*unused*/) {}
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override { TimeStepper::Inherit::pup(p); }
+
+ private:
+  static constexpr double a2_ = 12.0 / 23.0;
+  static constexpr std::array<double, 2> a3_{{-68.0 / 375.0, 368.0 / 375.0}};
+  static constexpr std::array<double, 3> a4_{
+      {31.0 / 144.0, 529.0 / 1152.0, 125.0 / 384.0}};
+
+  // For the dense output coefficients the index indicates
+  // `(degree of theta)`.
+  static constexpr std::array<double, 4> b1_{
+      {-a4_[0], 1.0, -65.0 / 48.0, 41.0 / 72.0}};
+  static constexpr std::array<double, 4> b2_{
+      {-a4_[1], 0.0, 529.0 / 384.0, -529.0 / 576.0}};
+  static constexpr std::array<double, 4> b3_{
+      {-a4_[2], 0.0, 125.0 / 128.0, -125.0 / 192.0}};
+  static constexpr std::array<double, 4> b4_{{0.0, 0.0, -1.0, 1.0}};
+
+  // constants for discrete error estimate
+  static constexpr std::array<double, 4> e_{
+      {1.0 / 24.0, 23.0 / 24.0, 0.0, 0.0}};
+  static const std::array<Time::rational_t, 2> c_;
+};
+
+inline bool constexpr operator==(const Cerk3& /*lhs*/, const Cerk3& /*rhs*/) {
+  return true;
+}
+
+inline bool constexpr operator!=(const Cerk3& /*lhs*/, const Cerk3& /*rhs*/) {
+  return false;
+}
+
+template <typename Vars, typename DerivVars>
+void Cerk3::update_u(const gsl::not_null<Vars*> u,
+                     const gsl::not_null<History<Vars, DerivVars>*> history,
+                     const TimeDelta& time_step) const {
+  ASSERT(history->integration_order() == 3,
+         "Fixed-order stepper cannot run at order "
+             << history->integration_order());
+  const size_t substep = (history->end() - 1).time_step_id().substep();
+
+  // Clean up old history
+  if (substep == 0) {
+    history->mark_unneeded(history->end() - 1);
+  }
+
+  const auto& u0 = history->most_recent_value();
+  const double dt = time_step.value();
+
+  switch (substep) {
+    case 0: {
+      *u = u0 + (a2_ * dt) * history->begin().derivative();
+      break;
+    }
+    case 1: {
+      *u = u0 + ((a3_[0] - a2_) * dt) * history->begin().derivative() +
+           (a3_[1] * dt) * (history->begin() + 1).derivative();
+      break;
+    }
+    case 2: {
+      *u = u0 + ((a4_[0] - a3_[0]) * dt) * history->begin().derivative() +
+           ((a4_[1] - a3_[1]) * dt) * (history->begin() + 1).derivative() +
+           (a4_[2] * dt) * (history->begin() + 2).derivative();
+      break;
+    }
+    default:
+      ERROR("Bad substep value in Cerk3: " << substep);
+  }
+}
+
+template <typename Vars, typename ErrVars, typename DerivVars>
+bool Cerk3::update_u(const gsl::not_null<Vars*> u,
+                     const gsl::not_null<ErrVars*> u_error,
+                     const gsl::not_null<History<Vars, DerivVars>*> history,
+                     const TimeDelta& time_step) const {
+  ASSERT(history->integration_order() == 3,
+         "Fixed-order stepper cannot run at order "
+             << history->integration_order());
+  update_u(u, history, time_step);
+  const size_t current_substep = (history->end() - 1).time_step_id().substep();
+  if (current_substep == 2) {
+    const double dt = time_step.value();
+    *u_error = ((e_[0] - a4_[0]) * dt) * history->begin().derivative() +
+               ((e_[1] - a4_[1]) * dt) * (history->begin() + 1).derivative() -
+               a4_[2] * dt * (history->begin() + 2).derivative();
+    return true;
+  }
+  return false;
+}
+
+template <typename Vars, typename DerivVars>
+bool Cerk3::dense_update_u(const gsl::not_null<Vars*> u,
+                           const History<Vars, DerivVars>& history,
+                           const double time) const {
+  if ((history.end() - 1).time_step_id().substep() != 0) {
+    return false;
+  }
+  const double t0 = history[0].value();
+  const double t_end = history[history.size() - 1].value();
+  if (time == t_end) {
+    // Special case necessary for dense output at the initial time,
+    // before taking a step.
+    *u = history.most_recent_value();
+    return true;
+  }
+  const evolution_less<double> before{t_end > t0};
+  if (history.size() == 1 or before(t_end, time)) {
+    return false;
+  }
+  const double dt = t_end - t0;
+  const double output_fraction = (time - t0) / dt;
+  ASSERT(output_fraction >= 0.0, "Attempting dense output at time "
+                                     << time << ", but already progressed past "
+                                     << t0);
+  ASSERT(output_fraction <= 1.0, "Requested time ("
+                                     << time << ") not within step [" << t0
+                                     << ", " << t0 + dt << "]");
+
+  const auto& u_n_plus_1 = history.most_recent_value();
+
+  // We need the following: k1, k2, k3, k4
+  const auto& k1 = history.begin().derivative();
+  const auto& k2 = (history.begin() + 1).derivative();
+  const auto& k3 = (history.begin() + 2).derivative();
+  const auto& k4 = (history.begin() + 3).derivative();
+
+  *u = u_n_plus_1 + (dt * evaluate_polynomial(b1_, output_fraction)) * k1 +
+       (dt * evaluate_polynomial(b2_, output_fraction)) * k2 +
+       (dt * evaluate_polynomial(b3_, output_fraction)) * k3 +
+       (dt * evaluate_polynomial(b4_, output_fraction)) * k4;
+  return true;
+}
+}  // namespace TimeSteppers

--- a/src/Time/TimeSteppers/Cerk4.cpp
+++ b/src/Time/TimeSteppers/Cerk4.cpp
@@ -1,0 +1,99 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Time/TimeSteppers/Cerk4.hpp"
+
+#include <cmath>
+#include <limits>
+
+#include "Time/TimeStepId.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace TimeSteppers {
+Cerk4::Cerk4(CkMigrateMessage* /*msg*/) {}
+
+size_t Cerk4::order() const { return 4; }
+
+size_t Cerk4::error_estimate_order() const { return 3; }
+
+uint64_t Cerk4::number_of_substeps() const { return 5; }
+
+uint64_t Cerk4::number_of_substeps_for_error() const { return 5; }
+
+size_t Cerk4::number_of_past_steps() const { return 0; }
+
+// The stability polynomial is
+//
+//   p(z) = \sum_{n=0}^{stages-1} alpha_n z^n / n!,
+//
+// alpha_n=1.0 for n=1...(order-1). For the fourth order method:
+//  alpha_5 = 5 (1 - 2 c_3) c_4
+// The stability limit as compared to a forward Euler method is given by finding
+// the root for |p(-2 z)|-1=0. For forward Euler this is 1.0.
+double Cerk4::stable_step() const { return 1.4367588951002057; }
+
+TimeStepId Cerk4::next_time_id(const TimeStepId& current_id,
+                               const TimeDelta& time_step) const {
+  const auto& step = current_id.substep();
+  const auto& t0 = current_id.step_time();
+  const auto& t = current_id.substep_time();
+  if (step < number_of_substeps()) {
+    if (step == 0) {
+      ASSERT(t == t0, "In Cerk4 substep 0, the substep time ("
+                          << t << ") should equal t0 (" << t0 << ")");
+    } else {
+      ASSERT(t == t0 + gsl::at(c_, step - 1) * time_step,
+             "In Cerk4 substep "
+                 << step << ", the substep time (" << t
+                 << ") should equal t0+c[" << step - 1 << "]*dt ("
+                 << t0 + gsl::at(c_, step - 1) * time_step << ")");
+    }
+    if (step < number_of_substeps() - 1) {
+      return {current_id.time_runs_forward(), current_id.slab_number(), t0,
+              step + 1, t0 + gsl::at(c_, step) * time_step};
+    } else {
+      return {current_id.time_runs_forward(), current_id.slab_number(),
+              t0 + time_step};
+    }
+  } else {
+    ERROR("In Cerk4 substep should be one of 0,1,2,3,4,5, not "
+          << current_id.substep());
+  }
+}
+
+TimeStepId Cerk4::next_time_id_for_error(const TimeStepId& current_id,
+                                         const TimeDelta& time_step) const {
+  return next_time_id(current_id, time_step);
+}
+
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr double Cerk4::a2_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 2> Cerk4::a3_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 3> Cerk4::a4_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 4> Cerk4::a5_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 5> Cerk4::a6_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 5> Cerk4::b1_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr double Cerk4::b2_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 5> Cerk4::b3_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 5> Cerk4::b4_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 5> Cerk4::b5_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 5> Cerk4::b6_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 6> Cerk4::e_;
+const std::array<Time::rational_t, 4> Cerk4::c_ = {
+    {{1, 6}, {11, 37}, {11, 17}, {13, 15}}};
+}  // namespace TimeSteppers
+
+PUP::able::PUP_ID TimeSteppers::Cerk4::my_PUP_ID =  // NOLINT
+    0;

--- a/src/Time/TimeSteppers/Cerk4.hpp
+++ b/src/Time/TimeSteppers/Cerk4.hpp
@@ -1,0 +1,282 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <ostream>
+#include <pup.h>
+
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Math.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+struct TimeStepId;
+namespace TimeSteppers {
+template <typename Vars, typename DerivVars>
+class History;
+}  // namespace TimeSteppers
+/// \endcond
+
+namespace TimeSteppers {
+/*!
+ * \ingroup TimeSteppersGroup
+ * \brief A fourth order continuous-extension RK method that provides 4th-order
+ * dense output.
+ *
+ * \f{eqnarray}{
+ * \frac{du}{dt} & = & \mathcal{L}(t,u).
+ * \f}
+ * Given a solution \f$u(t^n)=u^n\f$, this stepper computes
+ * \f$u(t^{n+1})=u^{n+1}\f$ using the following equations:
+ *
+ * \f{align}{
+ * k^{(i)} & = \mathcal{L}(t^n + c_i \Delta t,
+ *                         u^n + \Delta t \sum_{j=1}^{i-1} a_{ij} k^{(j)}),
+ *                              \mbox{ } 1 \leq i \leq s,\\
+ * u^{n+1}(t^n + \theta \Delta t) & = u^n + \Delta t \sum_{i=1}^{s} b_i(\theta)
+ * k^{(i)}. \f}
+ *
+ * Here the coefficients \f$a_{ij}\f$, \f$b_i\f$, and \f$c_i\f$ are given
+ * in \cite Owren1992 and \cite Gassner20114232. Note that \f$c_1 = 0\f$,
+ * \f$s\f$ is the number of stages, and \f$\theta\f$ is the fraction of the
+ * step. This is an FSAL stepper.
+ *
+ * The CFL factor/stable step size is 1.4367588951002057.
+ */
+class Cerk4 : public TimeStepper::Inherit {
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help = {
+      "A 4th-order continuous extension Runge-Kutta time stepper."};
+
+  Cerk4() = default;
+  Cerk4(const Cerk4&) = default;
+  Cerk4& operator=(const Cerk4&) = default;
+  Cerk4(Cerk4&&) = default;
+  Cerk4& operator=(Cerk4&&) = default;
+  ~Cerk4() override = default;
+
+  template <typename Vars, typename DerivVars>
+  void update_u(gsl::not_null<Vars*> u,
+                gsl::not_null<History<Vars, DerivVars>*> history,
+                const TimeDelta& time_step) const;
+
+  template <typename Vars, typename ErrVars, typename DerivVars>
+  bool update_u(gsl::not_null<Vars*> u, gsl::not_null<ErrVars*> u_error,
+                gsl::not_null<History<Vars, DerivVars>*> history,
+                const TimeDelta& time_step) const;
+
+  template <typename Vars, typename DerivVars>
+  bool dense_update_u(gsl::not_null<Vars*> u,
+                      const History<Vars, DerivVars>& history,
+                      double time) const;
+
+  size_t order() const override;
+
+  size_t error_estimate_order() const override;
+
+  uint64_t number_of_substeps() const override;
+
+  uint64_t number_of_substeps_for_error() const override;
+
+  size_t number_of_past_steps() const override;
+
+  double stable_step() const override;
+
+  TimeStepId next_time_id(const TimeStepId& current_id,
+                          const TimeDelta& time_step) const override;
+
+  TimeStepId next_time_id_for_error(const TimeStepId& current_id,
+                                    const TimeDelta& time_step) const override;
+
+  template <typename Vars, typename DerivVars>
+  bool can_change_step_size(
+      const TimeStepId& time_id,
+      const TimeSteppers::History<Vars, DerivVars>& /*history*/) const {
+    return time_id.substep() == 0;
+  }
+
+  WRAPPED_PUPable_decl_template(Cerk4);  // NOLINT
+
+  explicit Cerk4(CkMigrateMessage* /*msg*/);
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override { TimeStepper::Inherit::pup(p); }
+
+ private:
+  static constexpr double a2_ = 1.0 / 6.0;
+  static constexpr std::array<double, 2> a3_{{44.0 / 1369.0, 363.0 / 1369.0}};
+  static constexpr std::array<double, 3> a4_{
+      {3388.0 / 4913.0, -8349.0 / 4913.0, 8140.0 / 4913.0}};
+  static constexpr std::array<double, 4> a5_{
+      {-36764.0 / 408375.0, 767.0 / 1125.0, -32708.0 / 136125.0,
+       210392.0 / 408375.0}};
+  static constexpr std::array<double, 5> a6_{
+      {1697.0 / 18876.0, 0.0, 50653.0 / 116160.0, 299693.0 / 1626240.0,
+       3375.0 / 11648.0}};
+
+  // For the dense output coefficients the index indicates
+  // `(degree of theta) - 1`.
+  static constexpr std::array<double, 5> b1_{{-a6_[0], 1.0, -104217.0 / 37466.0,
+                                              1806901.0 / 618189.0,
+                                              -866577.0 / 824252.0}};
+  // b2 = {-a8_[1], 0.0, ...}
+  static constexpr double b2_ = -a6_[1];
+  static constexpr std::array<double, 5> b3_{{-a6_[2], 0.0, 861101.0 / 230560.0,
+                                              -2178079.0 / 380424.0,
+                                              12308679.0 / 5072320.0}};
+  static constexpr std::array<double, 5> b4_{{-a6_[3], 0.0, -63869.0 / 293440.0,
+                                              6244423.0 / 5325936.0,
+                                              -7816583.0 / 10144640.0}};
+  static constexpr std::array<double, 5> b5_{
+      {-a6_[4], 0.0, -1522125.0 / 762944.0, 982125.0 / 190736.0,
+       -624375.0 / 217984.0}};
+  static constexpr std::array<double, 5> b6_{
+      {0.0, 0.0, 165.0 / 131.0, -461.0 / 131.0, 296.0 / 131.0}};
+
+  // constants for discrete error estimate
+  static constexpr std::array<double, 6> e_{
+      {101.0 / 363.0, 0.0, -1369.0 / 14520.0, 11849.0 / 14520.0, 0.0, 0.0}};
+  static const std::array<Time::rational_t, 4> c_;
+};
+
+inline bool constexpr operator==(const Cerk4& /*lhs*/, const Cerk4& /*rhs*/) {
+  return true;
+}
+
+inline bool constexpr operator!=(const Cerk4& /*lhs*/, const Cerk4& /*rhs*/) {
+  return false;
+}
+
+template <typename Vars, typename DerivVars>
+void Cerk4::update_u(const gsl::not_null<Vars*> u,
+                     const gsl::not_null<History<Vars, DerivVars>*> history,
+                     const TimeDelta& time_step) const {
+  ASSERT(history->integration_order() == 4,
+         "Fixed-order stepper cannot run at order "
+             << history->integration_order());
+  const size_t substep = (history->end() - 1).time_step_id().substep();
+
+  // Clean up old history
+  if (substep == 0) {
+    history->mark_unneeded(history->end() - 1);
+  }
+
+  const auto& u0 = history->most_recent_value();
+  const double dt = time_step.value();
+
+  switch (substep) {
+    case 0: {
+      *u = u0 + (a2_ * dt) * history->begin().derivative();
+      break;
+    }
+    case 1: {
+      *u = u0 + ((a3_[0] - a2_) * dt) * history->begin().derivative() +
+           (a3_[1] * dt) * (history->begin() + 1).derivative();
+      break;
+    }
+    case 2: {
+      *u = u0 + ((a4_[0] - a3_[0]) * dt) * history->begin().derivative() +
+           ((a4_[1] - a3_[1]) * dt) * (history->begin() + 1).derivative() +
+           (a4_[2] * dt) * (history->begin() + 2).derivative();
+      break;
+    }
+    case 3: {
+      *u = u0 + ((a5_[0] - a4_[0]) * dt) * history->begin().derivative() +
+           ((a5_[1] - a4_[1]) * dt) * (history->begin() + 1).derivative() +
+           ((a5_[2] - a4_[2]) * dt) * (history->begin() + 2).derivative() +
+           (a5_[3] * dt) * (history->begin() + 3).derivative();
+      break;
+    }
+    case 4: {
+      *u = u0 + ((a6_[0] - a5_[0]) * dt) * history->begin().derivative() +
+           ((a6_[1] - a5_[1]) * dt) * (history->begin() + 1).derivative() +
+           ((a6_[2] - a5_[2]) * dt) * (history->begin() + 2).derivative() +
+           ((a6_[3] - a5_[3]) * dt) * (history->begin() + 3).derivative() +
+           (a6_[4] * dt) * (history->begin() + 4).derivative();
+      break;
+    }
+    default:
+      ERROR("Bad substep value in CERK4: " << substep);
+  }
+}
+
+template <typename Vars, typename ErrVars, typename DerivVars>
+bool Cerk4::update_u(const gsl::not_null<Vars*> u,
+                     const gsl::not_null<ErrVars*> u_error,
+                     const gsl::not_null<History<Vars, DerivVars>*> history,
+                     const TimeDelta& time_step) const {
+  ASSERT(history->integration_order() == 4,
+         "Fixed-order stepper cannot run at order "
+             << history->integration_order());
+  update_u(u, history, time_step);
+  const size_t current_substep = (history->end() - 1).time_step_id().substep();
+  if (current_substep == 4) {
+    const double dt = time_step.value();
+    *u_error = ((e_[0] - a6_[0]) * dt) * history->begin().derivative() +
+               ((e_[1] - a6_[1]) * dt) * (history->begin() + 1).derivative() +
+               ((e_[2] - a6_[2]) * dt) * (history->begin() + 2).derivative() +
+               ((e_[3] - a6_[3]) * dt) * (history->begin() + 3).derivative() -
+               (a6_[4] * dt) * (history->begin() + 4).derivative();
+    return true;
+  }
+  return false;
+}
+
+template <typename Vars, typename DerivVars>
+bool Cerk4::dense_update_u(const gsl::not_null<Vars*> u,
+                           const History<Vars, DerivVars>& history,
+                           const double time) const {
+  if ((history.end() - 1).time_step_id().substep() != 0) {
+    return false;
+  }
+  const double t0 = history[0].value();
+  const double t_end = history[history.size() - 1].value();
+  if (time == t_end) {
+    // Special case necessary for dense output at the initial time,
+    // before taking a step.
+    *u = history.most_recent_value();
+    return true;
+  }
+  const evolution_less<double> before{t_end > t0};
+  if (history.size() == 1 or before(t_end, time)) {
+    return false;
+  }
+  const double dt = t_end - t0;
+  const double output_fraction = (time - t0) / dt;
+  ASSERT(output_fraction >= 0.0, "Attempting dense output at time "
+                                     << time << ", but already progressed past "
+                                     << t0);
+  ASSERT(output_fraction <= 1.0, "Requested time ("
+                                     << time << ") not within step [" << t0
+                                     << ", " << t0 + dt << "]");
+
+  const auto& u_n_plus_1 = history.most_recent_value();
+
+  // We need the following: k1, k2, k3, k4, k5, k6
+  const auto& k1 = history.begin().derivative();
+  const auto& k2 = (history.begin() + 1).derivative();
+  const auto& k3 = (history.begin() + 2).derivative();
+  const auto& k4 = (history.begin() + 3).derivative();
+  const auto& k5 = (history.begin() + 4).derivative();
+  const auto& k6 = (history.begin() + 5).derivative();
+
+  *u = u_n_plus_1 + (dt * evaluate_polynomial(b1_, output_fraction)) * k1 +
+       (dt * b2_) * k2 +  //
+       (dt * evaluate_polynomial(b3_, output_fraction)) * k3 +
+       (dt * evaluate_polynomial(b4_, output_fraction)) * k4 +
+       (dt * evaluate_polynomial(b5_, output_fraction)) * k5 +
+       (dt * evaluate_polynomial(b6_, output_fraction)) * k6;
+  return true;
+}
+}  // namespace TimeSteppers

--- a/src/Time/TimeSteppers/Cerk5.cpp
+++ b/src/Time/TimeSteppers/Cerk5.cpp
@@ -1,0 +1,110 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Time/TimeSteppers/Cerk5.hpp"
+
+#include <cmath>
+#include <limits>
+
+#include "Time/TimeStepId.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace TimeSteppers {
+Cerk5::Cerk5(CkMigrateMessage* /*msg*/) {}
+
+size_t Cerk5::order() const { return 5; }
+
+size_t Cerk5::error_estimate_order() const { return 4; }
+
+uint64_t Cerk5::number_of_substeps() const { return 7; }
+
+uint64_t Cerk5::number_of_substeps_for_error() const { return 7; }
+
+size_t Cerk5::number_of_past_steps() const { return 0; }
+
+// The stability polynomial is
+//
+//   p(z) = \sum_{n=0}^{stages-1} alpha_n z^n / n!,
+//
+// alpha_n=1.0 for n=1...(order-1). For the fifth order method:
+//  alpha_6 = 6 (-5 c3**2 + 2 c3) - 2 c6 beta
+//  alpha_7 = 14 c3 c6 beta
+// where
+//   beta = 20 c3**2 - 15 c3 + 3
+// The stability limit as compared to a forward Euler method is given by finding
+// the root for |p(-2 z)|-1=0. For forward Euler this is 1.0.
+double Cerk5::stable_step() const { return 1.5961737362090775; }
+
+TimeStepId Cerk5::next_time_id(const TimeStepId& current_id,
+                               const TimeDelta& time_step) const {
+  const auto& step = current_id.substep();
+  const auto& t0 = current_id.step_time();
+  const auto& t = current_id.substep_time();
+  if (step < number_of_substeps()) {
+    if (step == 0) {
+      ASSERT(t == t0, "In CERK5 substep 0, the substep time ("
+                          << t << ") should equal t0 (" << t0 << ")");
+    } else {
+      ASSERT(t == t0 + gsl::at(c_, step - 1) * time_step,
+             "In CERK5 substep "
+                 << step << ", the substep time (" << t
+                 << ") should equal t0+c[" << step - 1 << "]*dt ("
+                 << t0 + gsl::at(c_, step - 1) * time_step << ")");
+    }
+    if (step < number_of_substeps() - 1) {
+      return {current_id.time_runs_forward(), current_id.slab_number(), t0,
+              step + 1, t0 + gsl::at(c_, step) * time_step};
+    } else {
+      return {current_id.time_runs_forward(), current_id.slab_number(),
+              t0 + time_step};
+    }
+  } else {
+    ERROR("In CERK5 substep should be one of 0,1,2,3,4,5,6,7, not "
+          << current_id.substep());
+  }
+}
+
+TimeStepId Cerk5::next_time_id_for_error(const TimeStepId& current_id,
+                                         const TimeDelta& time_step) const {
+  return next_time_id(current_id, time_step);
+}
+
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr double Cerk5::a2_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 2> Cerk5::a3_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 3> Cerk5::a4_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 4> Cerk5::a5_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 5> Cerk5::a6_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 6> Cerk5::a7_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 7> Cerk5::a8_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 6> Cerk5::b1_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr double Cerk5::b2_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 6> Cerk5::b3_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 6> Cerk5::b4_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 6> Cerk5::b5_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 6> Cerk5::b6_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 6> Cerk5::b7_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 6> Cerk5::b8_;
+// NOLINTNEXTLINE(readability-redundant-declaration)
+constexpr std::array<double, 8> Cerk5::e_;
+const std::array<Time::rational_t, 6> Cerk5::c_ = {
+    {{1, 6}, {1, 4}, {1, 2}, {1, 2}, {9, 14}, {7, 8}}};
+}  // namespace TimeSteppers
+
+PUP::able::PUP_ID TimeSteppers::Cerk5::my_PUP_ID =  // NOLINT
+    0;

--- a/src/Time/TimeSteppers/Cerk5.hpp
+++ b/src/Time/TimeSteppers/Cerk5.hpp
@@ -1,0 +1,318 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <ostream>
+#include <pup.h>
+
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Math.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+struct TimeStepId;
+namespace TimeSteppers {
+template <typename Vars, typename DerivVars>
+class History;
+}  // namespace TimeSteppers
+/// \endcond
+
+namespace TimeSteppers {
+/*!
+ * \ingroup TimeSteppersGroup
+ * \brief A fifth order continuous-extension RK method that provides 5th-order
+ * dense output.
+ *
+ * \f{eqnarray}{
+ * \frac{du}{dt} & = & \mathcal{L}(t,u).
+ * \f}
+ * Given a solution \f$u(t^n)=u^n\f$, this stepper computes
+ * \f$u(t^{n+1})=u^{n+1}\f$ using the following equations:
+ *
+ * \f{align}{
+ * k^{(i)} & = \mathcal{L}(t^n + c_i \Delta t,
+ *                         u^n + \Delta t \sum_{j=1}^{i-1} a_{ij} k^{(j)}),
+ *                              \mbox{ } 1 \leq i \leq s,\\
+ * u^{n+1}(t^n + \theta \Delta t) & = u^n + \Delta t \sum_{i=1}^{s} b_i(\theta)
+ * k^{(i)}. \f}
+ *
+ * Here the coefficients \f$a_{ij}\f$, \f$b_i\f$, and \f$c_i\f$ are given
+ * in \cite Owren1992 and \cite Gassner20114232. Note that \f$c_1 = 0\f$,
+ * \f$s\f$ is the number of stages, and \f$\theta\f$ is the fraction of the
+ * step. This is an FSAL stepper.
+ *
+ * The CFL factor/stable step size is 1.5961737362090775.
+ */
+class Cerk5 : public TimeStepper::Inherit {
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help = {
+      "A 5th-order continuous extension Runge-Kutta time stepper."};
+
+  Cerk5() = default;
+  Cerk5(const Cerk5&) = default;
+  Cerk5& operator=(const Cerk5&) = default;
+  Cerk5(Cerk5&&) = default;
+  Cerk5& operator=(Cerk5&&) = default;
+  ~Cerk5() override = default;
+
+  template <typename Vars, typename DerivVars>
+  void update_u(gsl::not_null<Vars*> u,
+                gsl::not_null<History<Vars, DerivVars>*> history,
+                const TimeDelta& time_step) const;
+
+  template <typename Vars, typename ErrVars, typename DerivVars>
+  bool update_u(gsl::not_null<Vars*> u, gsl::not_null<ErrVars*> u_error,
+                gsl::not_null<History<Vars, DerivVars>*> history,
+                const TimeDelta& time_step) const;
+
+  template <typename Vars, typename DerivVars>
+  bool dense_update_u(gsl::not_null<Vars*> u,
+                      const History<Vars, DerivVars>& history,
+                      double time) const;
+
+  size_t order() const override;
+
+  size_t error_estimate_order() const override;
+
+  uint64_t number_of_substeps() const override;
+
+  uint64_t number_of_substeps_for_error() const override;
+
+  size_t number_of_past_steps() const override;
+
+  double stable_step() const override;
+
+  TimeStepId next_time_id(const TimeStepId& current_id,
+                          const TimeDelta& time_step) const override;
+
+  TimeStepId next_time_id_for_error(const TimeStepId& current_id,
+                                    const TimeDelta& time_step) const override;
+
+  template <typename Vars, typename DerivVars>
+  bool can_change_step_size(
+      const TimeStepId& time_id,
+      const TimeSteppers::History<Vars, DerivVars>& /*history*/) const {
+    return time_id.substep() == 0;
+  }
+
+  WRAPPED_PUPable_decl_template(Cerk5);  // NOLINT
+
+  explicit Cerk5(CkMigrateMessage* /*msg*/);
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override { TimeStepper::Inherit::pup(p); }
+
+ private:
+  static constexpr double a2_ = 1.0 / 6.0;
+  static constexpr std::array<double, 2> a3_{{1.0 / 16.0, 3.0 / 16.0}};
+  static constexpr std::array<double, 3> a4_{{0.25, -0.75, 1.0}};
+  static constexpr std::array<double, 4> a5_{{-0.75, 15.0 / 4.0, -3.0, 0.5}};
+  static constexpr std::array<double, 5> a6_{{369.0 / 1372.0, -243.0 / 343.0,
+                                              297.0 / 343.0, 1485.0 / 9604.0,
+                                              297.0 / 4802.0}};
+  static constexpr std::array<double, 6> a7_{
+      {-133.0 / 4512.0, 1113.0 / 6016.0, 7945.0 / 16544.0, -12845.0 / 24064.0,
+       -315.0 / 24064.0, 156065.0 / 198528.0}};
+  // a8 gives the final value and allows us to evaluate k_8 which we need for
+  // dense output
+  static constexpr std::array<double, 7> a8_{
+      {83.0 / 945.0, 0.0, 248.0 / 825.0, 41.0 / 180.0, 1.0 / 36.0,
+       2401.0 / 38610.0, 6016.0 / 20475.0}};
+
+  // For the dense output coefficients the index indicates
+  // `(degree of theta) - 1`.
+  static constexpr std::array<double, 6> b1_{{-a8_[0], 1.0, -3292.0 / 819.0,
+                                              17893.0 / 2457.0, -4969.0 / 819.0,
+                                              596.0 / 315.0}};
+  // b2 = {-a8_[1], 0.0, ...}
+  static constexpr double b2_ = -a8_[1];
+  static constexpr std::array<double, 6> b3_{{-a8_[2], 0.0, 5112.0 / 715.0,
+                                              -43568.0 / 2145.0, 1344.0 / 65.0,
+                                              -1984.0 / 275.0}};
+  static constexpr std::array<double, 6> b4_{{-a8_[3], 0.0, -123.0 / 52.0,
+                                              3161.0 / 234.0, -1465.0 / 78.0,
+                                              118.0 / 15.0}};
+  static constexpr std::array<double, 6> b5_{
+      {-a8_[4], 0.0, -63.0 / 52.0, 1061.0 / 234.0, -413.0 / 78.0, 2.0}};
+  static constexpr std::array<double, 6> b6_{
+      {-a8_[5], 0.0, -40817.0 / 33462.0, 60025.0 / 50193.0, 2401.0 / 1521.0,
+       -9604.0 / 6435.0}};
+  static constexpr std::array<double, 6> b7_{
+      {-a8_[6], 0.0, 18048.0 / 5915.0, -637696.0 / 53235.0, 96256.0 / 5915.0,
+       -48128.0 / 6825.0}};
+  static constexpr std::array<double, 6> b8_{
+      {0.0, 0.0, -18.0 / 13.0, 75.0 / 13.0, -109.0 / 13.0, 4.0}};
+
+  // constants for discrete error estimate
+  static constexpr std::array<double, 8> e_{{-1.0 / 9.0, 0.0, 40.0 / 33.0,
+                                             -7.0 / 4.0, -1.0 / 12.0,
+                                             343.0 / 198.0, 0.0, 0.0}};
+  static const std::array<Time::rational_t, 6> c_;
+};
+
+inline bool constexpr operator==(const Cerk5& /*lhs*/, const Cerk5& /*rhs*/) {
+  return true;
+}
+
+inline bool constexpr operator!=(const Cerk5& /*lhs*/, const Cerk5& /*rhs*/) {
+  return false;
+}
+
+template <typename Vars, typename DerivVars>
+void Cerk5::update_u(const gsl::not_null<Vars*> u,
+                     const gsl::not_null<History<Vars, DerivVars>*> history,
+                     const TimeDelta& time_step) const {
+  ASSERT(history->integration_order() == 5,
+         "Fixed-order stepper cannot run at order "
+             << history->integration_order());
+  const size_t substep = (history->end() - 1).time_step_id().substep();
+
+  // Clean up old history
+  if (substep == 0) {
+    history->mark_unneeded(history->end() - 1);
+  }
+
+  const auto& u0 = history->most_recent_value();
+  const double dt = time_step.value();
+
+  switch (substep) {
+    case 0: {
+      *u = u0 + (a2_ * dt) * history->begin().derivative();
+      break;
+    }
+    case 1: {
+      *u = u0 + ((a3_[0] - a2_) * dt) * history->begin().derivative() +
+           (a3_[1] * dt) * (history->begin() + 1).derivative();
+      break;
+    }
+    case 2: {
+      *u = u0 + ((a4_[0] - a3_[0]) * dt) * history->begin().derivative() +
+           ((a4_[1] - a3_[1]) * dt) * (history->begin() + 1).derivative() +
+           (a4_[2] * dt) * (history->begin() + 2).derivative();
+      break;
+    }
+    case 3: {
+      *u = u0 + ((a5_[0] - a4_[0]) * dt) * history->begin().derivative() +
+           ((a5_[1] - a4_[1]) * dt) * (history->begin() + 1).derivative() +
+           ((a5_[2] - a4_[2]) * dt) * (history->begin() + 2).derivative() +
+           (a5_[3] * dt) * (history->begin() + 3).derivative();
+      break;
+    }
+    case 4: {
+      *u = u0 + ((a6_[0] - a5_[0]) * dt) * history->begin().derivative() +
+           ((a6_[1] - a5_[1]) * dt) * (history->begin() + 1).derivative() +
+           ((a6_[2] - a5_[2]) * dt) * (history->begin() + 2).derivative() +
+           ((a6_[3] - a5_[3]) * dt) * (history->begin() + 3).derivative() +
+           (a6_[4] * dt) * (history->begin() + 4).derivative();
+      break;
+    }
+    case 5: {
+      *u = u0 + ((a7_[0] - a6_[0]) * dt) * history->begin().derivative() +
+           ((a7_[1] - a6_[1]) * dt) * (history->begin() + 1).derivative() +
+           ((a7_[2] - a6_[2]) * dt) * (history->begin() + 2).derivative() +
+           ((a7_[3] - a6_[3]) * dt) * (history->begin() + 3).derivative() +
+           ((a7_[4] - a6_[4]) * dt) * (history->begin() + 4).derivative() +
+           (a7_[5] * dt) * (history->begin() + 5).derivative();
+      break;
+    }
+    case 6: {
+      *u = u0 + ((a8_[0] - a7_[0]) * dt) * history->begin().derivative() +
+           ((a8_[1] - a7_[1]) * dt) * (history->begin() + 1).derivative() +
+           ((a8_[2] - a7_[2]) * dt) * (history->begin() + 2).derivative() +
+           ((a8_[3] - a7_[3]) * dt) * (history->begin() + 3).derivative() +
+           ((a8_[4] - a7_[4]) * dt) * (history->begin() + 4).derivative() +
+           ((a8_[5] - a7_[5]) * dt) * (history->begin() + 5).derivative() +
+           (a8_[6] * dt) * (history->begin() + 6).derivative();
+      break;
+    }
+    default:
+      ERROR("Bad substep value in CERK5: " << substep);
+  }
+}
+
+template <typename Vars, typename ErrVars, typename DerivVars>
+bool Cerk5::update_u(const gsl::not_null<Vars*> u,
+                     const gsl::not_null<ErrVars*> u_error,
+                     const gsl::not_null<History<Vars, DerivVars>*> history,
+                     const TimeDelta& time_step) const {
+  ASSERT(history->integration_order() == 5,
+         "Fixed-order stepper cannot run at order "
+             << history->integration_order());
+  update_u(u, history, time_step);
+  const size_t current_substep = (history->end() - 1).time_step_id().substep();
+  if (current_substep == 6) {
+    const double dt = time_step.value();
+    *u_error = ((e_[0] - a8_[0]) * dt) * history->begin().derivative() +
+               ((e_[1] - a8_[1]) * dt) * (history->begin() + 1).derivative() +
+               ((e_[2] - a8_[2]) * dt) * (history->begin() + 2).derivative() +
+               ((e_[3] - a8_[3]) * dt) * (history->begin() + 3).derivative() +
+               ((e_[4] - a8_[4]) * dt) * (history->begin() + 4).derivative() +
+               ((e_[5] - a8_[5]) * dt) * (history->begin() + 5).derivative() -
+               a8_[6] * dt * (history->begin() + 6).derivative();
+    return true;
+  }
+  return false;
+}
+
+template <typename Vars, typename DerivVars>
+bool Cerk5::dense_update_u(const gsl::not_null<Vars*> u,
+                           const History<Vars, DerivVars>& history,
+                           const double time) const {
+  if ((history.end() - 1).time_step_id().substep() != 0) {
+    return false;
+  }
+  const double t0 = history[0].value();
+  const double t_end = history[history.size() - 1].value();
+  if (time == t_end) {
+    // Special case necessary for dense output at the initial time,
+    // before taking a step.
+    *u = history.most_recent_value();
+    return true;
+  }
+  const evolution_less<double> before{t_end > t0};
+  if (history.size() == 1 or before(t_end, time)) {
+    return false;
+  }
+  const double dt = t_end - t0;
+  const double output_fraction = (time - t0) / dt;
+  ASSERT(output_fraction >= 0.0, "Attempting dense output at time "
+                                     << time << ", but already progressed past "
+                                     << t0);
+  ASSERT(output_fraction <= 1.0, "Requested time ("
+                                     << time << ") not within step [" << t0
+                                     << ", " << t0 + dt << "]");
+
+  const auto& u_n_plus_1 = history.most_recent_value();
+
+  // We need the following: k1, k2, k3, k4, k5, k6, k7, k8
+  const auto& k1 = history.begin().derivative();
+  const auto& k2 = (history.begin() + 1).derivative();
+  const auto& k3 = (history.begin() + 2).derivative();
+  const auto& k4 = (history.begin() + 3).derivative();
+  const auto& k5 = (history.begin() + 4).derivative();
+  const auto& k6 = (history.begin() + 5).derivative();
+  const auto& k7 = (history.begin() + 6).derivative();
+  const auto& k8 = (history.begin() + 7).derivative();
+
+  *u = u_n_plus_1 + (dt * evaluate_polynomial(b1_, output_fraction)) * k1 +
+       (dt * b2_) * k2 +  //
+       (dt * evaluate_polynomial(b3_, output_fraction)) * k3 +
+       (dt * evaluate_polynomial(b4_, output_fraction)) * k4 +
+       (dt * evaluate_polynomial(b5_, output_fraction)) * k5 +
+       (dt * evaluate_polynomial(b6_, output_fraction)) * k6 +
+       (dt * evaluate_polynomial(b7_, output_fraction)) * k7 +
+       (dt * evaluate_polynomial(b8_, output_fraction)) * k8;
+  return true;
+}
+}  // namespace TimeSteppers

--- a/src/Time/TimeSteppers/TimeStepper.hpp
+++ b/src/Time/TimeSteppers/TimeStepper.hpp
@@ -32,6 +32,7 @@ namespace TimeSteppers {
 class AdamsBashforthN;  // IWYU pragma: keep
 class Cerk2;
 class Cerk3;
+class Cerk4;
 class DormandPrince5;
 class RungeKutta3;  // IWYU pragma: keep
 class RungeKutta4;
@@ -53,8 +54,9 @@ class TimeStepper : public PUP::able {
           TimeStepper_detail::FakeVirtualInherit_update_u<TimeStepper>>>;
   using creatable_classes =
       tmpl::list<TimeSteppers::AdamsBashforthN, TimeSteppers::Cerk2,
-                 TimeSteppers::Cerk3, TimeSteppers::DormandPrince5,
-                 TimeSteppers::RungeKutta3, TimeSteppers::RungeKutta4>;
+                 TimeSteppers::Cerk3, TimeSteppers::Cerk4,
+                 TimeSteppers::DormandPrince5, TimeSteppers::RungeKutta3,
+                 TimeSteppers::RungeKutta4>;
 
   WRAPPED_PUPable_abstract(TimeStepper);  // NOLINT
 
@@ -246,6 +248,7 @@ class LtsTimeStepper : public TimeStepper::Inherit {
 #include "Time/TimeSteppers/AdamsBashforthN.hpp"  // IWYU pragma: keep
 #include "Time/TimeSteppers/Cerk2.hpp"
 #include "Time/TimeSteppers/Cerk3.hpp"
+#include "Time/TimeSteppers/Cerk4.hpp"
 #include "Time/TimeSteppers/DormandPrince5.hpp"
 #include "Time/TimeSteppers/RungeKutta3.hpp"  // IWYU pragma: keep
 #include "Time/TimeSteppers/RungeKutta4.hpp"  // IWYU pragma: keep

--- a/src/Time/TimeSteppers/TimeStepper.hpp
+++ b/src/Time/TimeSteppers/TimeStepper.hpp
@@ -31,6 +31,7 @@ class History;
 namespace TimeSteppers {
 class AdamsBashforthN;  // IWYU pragma: keep
 class Cerk2;
+class Cerk3;
 class DormandPrince5;
 class RungeKutta3;  // IWYU pragma: keep
 class RungeKutta4;
@@ -52,8 +53,8 @@ class TimeStepper : public PUP::able {
           TimeStepper_detail::FakeVirtualInherit_update_u<TimeStepper>>>;
   using creatable_classes =
       tmpl::list<TimeSteppers::AdamsBashforthN, TimeSteppers::Cerk2,
-                 TimeSteppers::DormandPrince5, TimeSteppers::RungeKutta3,
-                 TimeSteppers::RungeKutta4>;
+                 TimeSteppers::Cerk3, TimeSteppers::DormandPrince5,
+                 TimeSteppers::RungeKutta3, TimeSteppers::RungeKutta4>;
 
   WRAPPED_PUPable_abstract(TimeStepper);  // NOLINT
 
@@ -244,6 +245,7 @@ class LtsTimeStepper : public TimeStepper::Inherit {
 
 #include "Time/TimeSteppers/AdamsBashforthN.hpp"  // IWYU pragma: keep
 #include "Time/TimeSteppers/Cerk2.hpp"
+#include "Time/TimeSteppers/Cerk3.hpp"
 #include "Time/TimeSteppers/DormandPrince5.hpp"
 #include "Time/TimeSteppers/RungeKutta3.hpp"  // IWYU pragma: keep
 #include "Time/TimeSteppers/RungeKutta4.hpp"  // IWYU pragma: keep

--- a/src/Time/TimeSteppers/TimeStepper.hpp
+++ b/src/Time/TimeSteppers/TimeStepper.hpp
@@ -30,6 +30,7 @@ class History;
 /// Holds classes that take time steps.
 namespace TimeSteppers {
 class AdamsBashforthN;  // IWYU pragma: keep
+class Cerk2;
 class DormandPrince5;
 class RungeKutta3;  // IWYU pragma: keep
 class RungeKutta4;
@@ -50,8 +51,9 @@ class TimeStepper : public PUP::able {
       TimeStepper_detail::FakeVirtualInherit_dense_update_u<
           TimeStepper_detail::FakeVirtualInherit_update_u<TimeStepper>>>;
   using creatable_classes =
-      tmpl::list<TimeSteppers::AdamsBashforthN, TimeSteppers::DormandPrince5,
-                 TimeSteppers::RungeKutta3, TimeSteppers::RungeKutta4>;
+      tmpl::list<TimeSteppers::AdamsBashforthN, TimeSteppers::Cerk2,
+                 TimeSteppers::DormandPrince5, TimeSteppers::RungeKutta3,
+                 TimeSteppers::RungeKutta4>;
 
   WRAPPED_PUPable_abstract(TimeStepper);  // NOLINT
 
@@ -241,6 +243,7 @@ class LtsTimeStepper : public TimeStepper::Inherit {
 
 
 #include "Time/TimeSteppers/AdamsBashforthN.hpp"  // IWYU pragma: keep
+#include "Time/TimeSteppers/Cerk2.hpp"
 #include "Time/TimeSteppers/DormandPrince5.hpp"
 #include "Time/TimeSteppers/RungeKutta3.hpp"  // IWYU pragma: keep
 #include "Time/TimeSteppers/RungeKutta4.hpp"  // IWYU pragma: keep

--- a/src/Time/TimeSteppers/TimeStepper.hpp
+++ b/src/Time/TimeSteppers/TimeStepper.hpp
@@ -33,6 +33,7 @@ class AdamsBashforthN;  // IWYU pragma: keep
 class Cerk2;
 class Cerk3;
 class Cerk4;
+class Cerk5;
 class DormandPrince5;
 class RungeKutta3;  // IWYU pragma: keep
 class RungeKutta4;
@@ -54,7 +55,7 @@ class TimeStepper : public PUP::able {
           TimeStepper_detail::FakeVirtualInherit_update_u<TimeStepper>>>;
   using creatable_classes =
       tmpl::list<TimeSteppers::AdamsBashforthN, TimeSteppers::Cerk2,
-                 TimeSteppers::Cerk3, TimeSteppers::Cerk4,
+                 TimeSteppers::Cerk3, TimeSteppers::Cerk4, TimeSteppers::Cerk5,
                  TimeSteppers::DormandPrince5, TimeSteppers::RungeKutta3,
                  TimeSteppers::RungeKutta4>;
 
@@ -249,6 +250,7 @@ class LtsTimeStepper : public TimeStepper::Inherit {
 #include "Time/TimeSteppers/Cerk2.hpp"
 #include "Time/TimeSteppers/Cerk3.hpp"
 #include "Time/TimeSteppers/Cerk4.hpp"
+#include "Time/TimeSteppers/Cerk5.hpp"
 #include "Time/TimeSteppers/DormandPrince5.hpp"
 #include "Time/TimeSteppers/RungeKutta3.hpp"  // IWYU pragma: keep
 #include "Time/TimeSteppers/RungeKutta4.hpp"  // IWYU pragma: keep

--- a/tests/Unit/Time/TimeSteppers/CMakeLists.txt
+++ b/tests/Unit/Time/TimeSteppers/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY_SOURCES
   ${LIBRARY_SOURCES}
   TimeSteppers/Test_AdamsBashforthN.cpp
+  TimeSteppers/Test_Cerk2.cpp
   TimeSteppers/Test_DormandPrince5.cpp
   TimeSteppers/Test_RungeKutta3.cpp
   TimeSteppers/Test_RungeKutta4.cpp

--- a/tests/Unit/Time/TimeSteppers/CMakeLists.txt
+++ b/tests/Unit/Time/TimeSteppers/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY_SOURCES
   TimeSteppers/Test_AdamsBashforthN.cpp
   TimeSteppers/Test_Cerk2.cpp
   TimeSteppers/Test_Cerk3.cpp
+  TimeSteppers/Test_Cerk4.cpp
   TimeSteppers/Test_DormandPrince5.cpp
   TimeSteppers/Test_RungeKutta3.cpp
   TimeSteppers/Test_RungeKutta4.cpp

--- a/tests/Unit/Time/TimeSteppers/CMakeLists.txt
+++ b/tests/Unit/Time/TimeSteppers/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY_SOURCES
   ${LIBRARY_SOURCES}
   TimeSteppers/Test_AdamsBashforthN.cpp
   TimeSteppers/Test_Cerk2.cpp
+  TimeSteppers/Test_Cerk3.cpp
   TimeSteppers/Test_DormandPrince5.cpp
   TimeSteppers/Test_RungeKutta3.cpp
   TimeSteppers/Test_RungeKutta4.cpp

--- a/tests/Unit/Time/TimeSteppers/CMakeLists.txt
+++ b/tests/Unit/Time/TimeSteppers/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   TimeSteppers/Test_Cerk2.cpp
   TimeSteppers/Test_Cerk3.cpp
   TimeSteppers/Test_Cerk4.cpp
+  TimeSteppers/Test_Cerk5.cpp
   TimeSteppers/Test_DormandPrince5.cpp
   TimeSteppers/Test_RungeKutta3.cpp
   TimeSteppers/Test_RungeKutta4.cpp

--- a/tests/Unit/Time/TimeSteppers/Test_Cerk2.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_Cerk2.cpp
@@ -1,0 +1,33 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Time/TimeSteppers/TimeStepperTestUtils.hpp"
+#include "Time/TimeSteppers/Cerk2.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+
+SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.Cerk2", "[Unit][Time]") {
+  const TimeSteppers::Cerk2 stepper{};
+  TimeStepperTestUtils::check_substep_properties(stepper);
+  TimeStepperTestUtils::integrate_test(stepper, 2, 0, 1.0, 1.0e-6);
+  TimeStepperTestUtils::integrate_test(stepper, 2, 0, -1.0, 1.0e-6);
+  TimeStepperTestUtils::integrate_test_explicit_time_dependence(stepper, 2, 0,
+                                                                -1.0, 1.0e-6);
+  TimeStepperTestUtils::integrate_error_test(stepper, 2, 0, 1.0, 1.0e-6, 600,
+                                             1.0e-4);
+  TimeStepperTestUtils::integrate_error_test(stepper, 2, 0, -1.0, 1.0e-6, 600,
+                                             1.0e-4);
+  TimeStepperTestUtils::integrate_variable_test(stepper, 2, 0, 1.0e-6);
+  TimeStepperTestUtils::stability_test(stepper);
+  TimeStepperTestUtils::check_convergence_order(stepper);
+  TimeStepperTestUtils::check_dense_output(stepper, 2_st);
+
+  TestHelpers::test_creation<std::unique_ptr<TimeStepper>>("Cerk2");
+  test_serialization(stepper);
+  test_serialization_via_base<TimeStepper, TimeSteppers::Cerk2>();
+  // test operator !=
+  CHECK_FALSE(stepper != stepper);
+}

--- a/tests/Unit/Time/TimeSteppers/Test_Cerk3.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_Cerk3.cpp
@@ -1,0 +1,33 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Time/TimeSteppers/TimeStepperTestUtils.hpp"
+#include "Time/TimeSteppers/Cerk3.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+
+SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.Cerk3", "[Unit][Time]") {
+  const TimeSteppers::Cerk3 stepper{};
+  TimeStepperTestUtils::check_substep_properties(stepper);
+  TimeStepperTestUtils::integrate_test(stepper, 3, 0, 1.0, 1.0e-9);
+  TimeStepperTestUtils::integrate_test(stepper, 3, 0, -1.0, 1.0e-9);
+  TimeStepperTestUtils::integrate_test_explicit_time_dependence(stepper, 3, 0,
+                                                                -1.0, 1.0e-9);
+  TimeStepperTestUtils::integrate_error_test(stepper, 3, 0, 1.0, 1.0e-6, 100,
+                                             1.0e-3);
+  TimeStepperTestUtils::integrate_error_test(stepper, 3, 0, -1.0, 1.0e-6, 100,
+                                             1.0e-3);
+  TimeStepperTestUtils::integrate_variable_test(stepper, 3, 0, 1.0e-9);
+  TimeStepperTestUtils::stability_test(stepper);
+  TimeStepperTestUtils::check_convergence_order(stepper);
+  TimeStepperTestUtils::check_dense_output(stepper, 3_st);
+
+  TestHelpers::test_creation<std::unique_ptr<TimeStepper>>("Cerk3");
+  test_serialization(stepper);
+  test_serialization_via_base<TimeStepper, TimeSteppers::Cerk3>();
+  // test operator !=
+  CHECK_FALSE(stepper != stepper);
+}

--- a/tests/Unit/Time/TimeSteppers/Test_Cerk4.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_Cerk4.cpp
@@ -1,0 +1,33 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Time/TimeSteppers/TimeStepperTestUtils.hpp"
+#include "Time/TimeSteppers/Cerk4.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+
+SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.Cerk4", "[Unit][Time]") {
+  const TimeSteppers::Cerk4 stepper{};
+  TimeStepperTestUtils::check_substep_properties(stepper);
+  TimeStepperTestUtils::integrate_test(stepper, 4, 0, 1.0, 1.0e-9);
+  TimeStepperTestUtils::integrate_test(stepper, 4, 0, -1.0, 1.0e-9);
+  TimeStepperTestUtils::integrate_test_explicit_time_dependence(stepper, 4, 0,
+                                                                -1.0, 1.0e-9);
+  TimeStepperTestUtils::integrate_error_test(stepper, 4, 0, 1.0, 1.0e-8, 20,
+                                             1.0e-3);
+  TimeStepperTestUtils::integrate_error_test(stepper, 4, 0, -1.0, 1.0e-8, 20,
+                                             1.0e-3);
+  TimeStepperTestUtils::integrate_variable_test(stepper, 4, 0, 1.0e-9);
+  TimeStepperTestUtils::stability_test(stepper);
+  TimeStepperTestUtils::check_convergence_order(stepper);
+  TimeStepperTestUtils::check_dense_output(stepper, 4_st);
+
+  TestHelpers::test_creation<std::unique_ptr<TimeStepper>>("Cerk4");
+  test_serialization(stepper);
+  test_serialization_via_base<TimeStepper, TimeSteppers::Cerk4>();
+  // test operator !=
+  CHECK_FALSE(stepper != stepper);
+}

--- a/tests/Unit/Time/TimeSteppers/Test_Cerk5.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_Cerk5.cpp
@@ -1,0 +1,33 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Time/TimeSteppers/TimeStepperTestUtils.hpp"
+#include "Time/TimeSteppers/Cerk5.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+
+SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.Cerk5", "[Unit][Time]") {
+  const TimeSteppers::Cerk5 stepper{};
+  TimeStepperTestUtils::check_substep_properties(stepper);
+  TimeStepperTestUtils::integrate_test(stepper, 5, 0, 1.0, 1.0e-9);
+  TimeStepperTestUtils::integrate_test(stepper, 5, 0, -1.0, 1.0e-9);
+  TimeStepperTestUtils::integrate_test_explicit_time_dependence(stepper, 5, 0,
+                                                                -1.0, 1.0e-9);
+  TimeStepperTestUtils::integrate_error_test(stepper, 5, 0, 1.0, 1.0e-8, 10,
+                                             1.0e-2);
+  TimeStepperTestUtils::integrate_error_test(stepper, 5, 0, -1.0, 1.0e-8, 10,
+                                             1.0e-2);
+  TimeStepperTestUtils::integrate_variable_test(stepper, 5, 0, 1.0e-9);
+  TimeStepperTestUtils::stability_test(stepper);
+  TimeStepperTestUtils::check_convergence_order(stepper);
+  TimeStepperTestUtils::check_dense_output(stepper, 5_st);
+
+  TestHelpers::test_creation<std::unique_ptr<TimeStepper>>("Cerk5");
+  test_serialization(stepper);
+  test_serialization_via_base<TimeStepper, TimeSteppers::Cerk5>();
+  // test operator !=
+  CHECK_FALSE(stepper != stepper);
+}


### PR DESCRIPTION
## Proposed changes

These are used in ADER schemes to provide a high-order initial guess to the locally implicit in time problem being solved.

I've had these partly done on a branch for a couple years now and figured I might as well add the missing features and submit a PR.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
