### PR TITLE
Add basic support for `make install`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,11 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.19)
   cmake_policy(SET CMP0110 NEW)
 endif ()
 
+# Disable `make install` depending on `make all` since we want to control what
+# we install more closely. With this setting, and targets marked as `OPTIONAL`,
+# only targets that were built will be installed.
+set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY ON)
+
 set(CMAKE_VERBOSE_MAKEFILE OFF)
 
 include(SpectreGetGitHash)

--- a/cmake/AddSpectreExecutable.cmake
+++ b/cmake/AddSpectreExecutable.cmake
@@ -38,6 +38,7 @@ function(add_spectre_executable TARGET_NAME)
     PRIVATE
     SpectreFlags
     )
+  install(TARGETS ${TARGET_NAME} OPTIONAL)
 endfunction()
 
 # A function to add a SpECTRE executable that uses Charm++

--- a/cmake/SpectreSetupPythonPackage.cmake
+++ b/cmake/SpectreSetupPythonPackage.cmake
@@ -1,6 +1,11 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+set(SPECTRE_PYTHON_INSTALL_LIBDIR
+  "lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages"
+  CACHE STRING "Location where the Python package is installed. Defaults to \
+CMAKE_INSTALL_PREFIX/lib/pythonX.Y/site-packages/.")
+
 spectre_define_test_timeout_factor_option(PYTHON "Python")
 
 set(SPECTRE_PYTHON_PREFIX "${CMAKE_BINARY_DIR}/bin/python/spectre/")
@@ -41,6 +46,12 @@ file(WRITE
 configure_file(
   "${CMAKE_BINARY_DIR}/tmp/LoadPython.sh"
   "${CMAKE_BINARY_DIR}/bin/LoadPython.sh")
+
+# Install the SpECTRE Python package to the user-specified location.
+install(
+  DIRECTORY ${SPECTRE_PYTHON_PREFIX}
+  DESTINATION ${SPECTRE_PYTHON_INSTALL_LIBDIR}
+  )
 
 add_custom_target(all-pybindings)
 

--- a/docs/DevGuide/BuildSystem.md
+++ b/docs/DevGuide/BuildSystem.md
@@ -293,6 +293,18 @@ cmake -D FLAG1=OPT1 ... -D FLAGN=OPTN <SPECTRE_ROOT>
     [include-what-you-use
     (IWYU)](https://github.com/include-what-you-use/include-what-you-use)
 
+## CMake targets
+
+In addition to individual simulation executables, the following targets are
+available to build with `make` or `ninja`:
+
+- all-pybindings
+  - Build Python bindings. See \ref spectre_using_python for details.
+- install
+  - Install targets that have been built to the `CMAKE_INSTALL_PREFIX`. Doesn't
+    try to build anything else. Only supports static libraries so far, i.e.
+    builds with `BUILD_SHARED_LIBS=OFF`.
+
 ## Checking Dependencies
 
 Getting dependencies of libraries correct is quite difficult. SpECTRE offers the

--- a/docs/DevGuide/BuildSystem.md
+++ b/docs/DevGuide/BuildSystem.md
@@ -192,6 +192,14 @@ cmake -D FLAG1=OPT1 ... -D FLAGN=OPTN <SPECTRE_ROOT>
   - Sets the directory where the library and executables are placed.
     By default libraries end up in `<BUILD_DIR>/lib` and executables
     in `<BUILD_DIR>/bin`.
+- CMAKE_INSTALL_PREFIX
+  - Location where the `install` target copies executables, libraries, etc. Make
+    sure to set this variable before you `install`, or a default location such
+    as `/usr/local` is used.
+- SPECTRE_PYTHON_INSTALL_LIBDIR
+  - Location where the `install` target copies the SpECTRE Python package.
+    Defaults to `CMAKE_INSTALL_PREFIX/lib/pythonX.Y/site-packages/`, which is a
+    location where Python packages are often expected.
 - DEBUG_SYMBOLS
   - Whether or not to use debug symbols (default is `ON`)
   - Disabling debug symbols will reduce compile time and total size of the build


### PR DESCRIPTION
## Proposed changes

This is a step toward installing SpECTRE with Spack (which is useful to install a specific release, e.g. one that is listed in a paper, along with its dependencies). The `install` target installs only those executables that have been built, and doesn't try to build anything else.

This doesn't support shared libs yet. CMake has some ways to figure out runtime dependencies automatically, but I haven't tried it yet.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
