### PR TITLE
Disable IWYU by default

### DIFF
--- a/cmake/SetupIwyu.cmake
+++ b/cmake/SetupIwyu.cmake
@@ -1,6 +1,8 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+option(USE_IWYU "Enable include-what-you-use tools" OFF)
+
 function(add_iwyu_tool_targets IWYU_TOOL)
   # Run IWYU in parallel using half the available cores. On single
   # core machines using only 1 core
@@ -52,7 +54,9 @@ function(add_iwyu_tool_targets IWYU_TOOL)
     )
 endfunction(add_iwyu_tool_targets IWYU_TOOL)
 
-if(NOT ${USE_PCH})
+if(NOT ${USE_IWYU})
+  message(STATUS "Disabled include-what-you-use.")
+elseif(NOT ${USE_PCH})
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(IWYU_REQUIRED_VERSION 0.9)
     find_program(IWYU_BINARY include-what-you-use)
@@ -87,8 +91,8 @@ if(NOT ${USE_PCH})
       "iwyu: Cannot use include-what-you-use without clang compiler. "
       "Compile with clang to use iwyu.")
   endif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-else(NOT ${USE_PCH})
+else()
   message(STATUS
     "iwyu: Cannot use include-what-you-use with precompiled header. "
     "Pass USE_PCH=OFF to CMake to disable the precompiled header.")
-endif(NOT ${USE_PCH})
+endif()

--- a/docs/DevGuide/BuildSystem.md
+++ b/docs/DevGuide/BuildSystem.md
@@ -268,6 +268,9 @@ cmake -D FLAG1=OPT1 ... -D FLAGN=OPTN <SPECTRE_ROOT>
     the same checks are performed during CI and there is a good reason why the
     checks exist in the first place.
     (default is `ON`)
+- USE_IWYU
+  - Enable [include-what-you-use (IWYU)](https://github.com/include-what-you-use/include-what-you-use)
+    tools. (default is `OFF`)
 - USE_LD
   - Override the automatically chosen linker. The options are `ld`, `gold`, and
     `lld`.


### PR DESCRIPTION
## Proposed changes

I got a cmake config error for a `USE_PCH=OFF` build, which tries to
enable IWYU automatically. Since we haven't used IWYU actively in a
while, this PR disables it by default.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
To enable IWYU, set `-D USE_IWYU=ON` in your CMake config.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
