### PR TITLE
Move `ScalarWave` evolved variables into `Tags` namespace

### DIFF
--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -213,9 +213,10 @@ struct EvolutionMetavars {
                      Actions::UpdateU<>>>,
       tmpl::conditional_t<
           use_filtering,
-          dg::Actions::Filter<Filters::Exponential<0>,
-                              tmpl::list<ScalarWave::Pi, ScalarWave::Psi,
-                                         ScalarWave::Phi<Dim>>>,
+          dg::Actions::Filter<
+              Filters::Exponential<0>,
+              tmpl::list<ScalarWave::Tags::Pi, ScalarWave::Tags::Psi,
+                         ScalarWave::Tags::Phi<Dim>>>,
           tmpl::list<>>>>;
 
   enum class Phase {

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.hpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.hpp
@@ -213,17 +213,20 @@ class ConstraintPreservingSphericalRadiation final
   void pup(PUP::er& p) override;
 
   using dg_interior_evolved_variables_tags =
-      tmpl::list<ScalarWave::Pi, ScalarWave::Phi<Dim>, ScalarWave::Psi>;
+      tmpl::list<ScalarWave::Tags::Pi, ScalarWave::Tags::Phi<Dim>,
+                 ScalarWave::Tags::Psi>;
   using dg_interior_temporary_tags =
       tmpl::list<domain::Tags::Coordinates<Dim, Frame::Inertial>,
                  Tags::ConstraintGamma2>;
   using dg_interior_dt_vars_tags =
-      tmpl::list<::Tags::dt<ScalarWave::Pi>, ::Tags::dt<ScalarWave::Phi<Dim>>,
-                 ::Tags::dt<ScalarWave::Psi>>;
+      tmpl::list<::Tags::dt<ScalarWave::Tags::Pi>,
+                 ::Tags::dt<ScalarWave::Tags::Phi<Dim>>,
+                 ::Tags::dt<ScalarWave::Tags::Psi>>;
   using dg_interior_deriv_vars_tags = tmpl::list<
-      ::Tags::deriv<ScalarWave::Pi, tmpl::size_t<Dim>, Frame::Inertial>,
-      ::Tags::deriv<ScalarWave::Psi, tmpl::size_t<Dim>, Frame::Inertial>,
-      ::Tags::deriv<ScalarWave::Phi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>>;
+      ::Tags::deriv<ScalarWave::Tags::Pi, tmpl::size_t<Dim>, Frame::Inertial>,
+      ::Tags::deriv<ScalarWave::Tags::Psi, tmpl::size_t<Dim>, Frame::Inertial>,
+      ::Tags::deriv<ScalarWave::Tags::Phi<Dim>, tmpl::size_t<Dim>,
+                    Frame::Inertial>>;
   using dg_gridless_tags = tmpl::list<>;
 
   std::optional<std::string> dg_time_derivative(

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/DirichletAnalytic.hpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/DirichletAnalytic.hpp
@@ -89,19 +89,19 @@ class DirichletAnalytic final : public BoundaryCondition<Dim> {
                                       AnalyticSolutionOrData>) {
         return analytic_solution_or_data.variables(
             coords, time,
-            tmpl::list<ScalarWave::Pi, ScalarWave::Phi<Dim>,
-                       ScalarWave::Psi>{});
+            tmpl::list<ScalarWave::Tags::Pi, ScalarWave::Tags::Phi<Dim>,
+                       ScalarWave::Tags::Psi>{});
 
       } else {
         (void)time;
         return analytic_solution_or_data.variables(
-            coords, tmpl::list<ScalarWave::Pi, ScalarWave::Phi<Dim>,
-                               ScalarWave::Psi>{});
+            coords, tmpl::list<ScalarWave::Tags::Pi, ScalarWave::Tags::Phi<Dim>,
+                               ScalarWave::Tags::Psi>{});
       }
     }();
-    *pi = get<ScalarWave::Pi>(boundary_values);
-    *phi = get<ScalarWave::Phi<Dim>>(boundary_values);
-    *psi = get<ScalarWave::Psi>(boundary_values);
+    *pi = get<ScalarWave::Tags::Pi>(boundary_values);
+    *phi = get<ScalarWave::Tags::Phi<Dim>>(boundary_values);
+    *psi = get<ScalarWave::Tags::Psi>(boundary_values);
     return {};
   }
 };

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/SphericalRadiation.hpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/SphericalRadiation.hpp
@@ -114,7 +114,8 @@ class SphericalRadiation final : public BoundaryCondition<Dim> {
 
   void pup(PUP::er& p) override;
 
-  using dg_interior_evolved_variables_tags = tmpl::list<Phi<Dim>, Psi>;
+  using dg_interior_evolved_variables_tags =
+      tmpl::list<Tags::Phi<Dim>, Tags::Psi>;
   using dg_interior_temporary_tags =
       tmpl::list<domain::Tags::Coordinates<Dim, Frame::Inertial>,
                  Tags::ConstraintGamma2>;

--- a/src/Evolution/Systems/ScalarWave/Characteristics.cpp
+++ b/src/Evolution/Systems/ScalarWave/Characteristics.cpp
@@ -83,7 +83,8 @@ characteristic_fields(
 
 template <size_t Dim>
 void evolved_fields_from_characteristic_fields(
-    const gsl::not_null<Variables<tmpl::list<Psi, Pi, Phi<Dim>>>*>
+    const gsl::not_null<
+        Variables<tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<Dim>>>*>
         evolved_fields,
     const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& v_psi,
     const tnsr::i<DataVector, Dim, Frame::Inertial>& v_zero,
@@ -93,26 +94,26 @@ void evolved_fields_from_characteristic_fields(
     evolved_fields->initialize(get(v_psi).size());
   }
   // Eq.(36) of Holst+ (2004) for Psi
-  get<Psi>(*evolved_fields) = v_psi;
+  get<Tags::Psi>(*evolved_fields) = v_psi;
 
   // Eq.(37) - (38) of Holst+ (2004) for Pi and Phi
-  get<Pi>(*evolved_fields).get() =
+  get<Tags::Pi>(*evolved_fields).get() =
       0.5 * (get(v_plus) + get(v_minus)) + get(gamma_2) * get(v_psi);
   for (size_t i = 0; i < Dim; ++i) {
-    get<Phi<Dim>>(*evolved_fields).get(i) =
+    get<Tags::Phi<Dim>>(*evolved_fields).get(i) =
         0.5 * (get(v_plus) - get(v_minus)) * unit_normal_one_form.get(i) +
         v_zero.get(i);
   }
 }
 
 template <size_t Dim>
-Variables<tmpl::list<Psi, Pi, Phi<Dim>>>
+Variables<tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<Dim>>>
 evolved_fields_from_characteristic_fields(
     const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& v_psi,
     const tnsr::i<DataVector, Dim, Frame::Inertial>& v_zero,
     const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,
     const tnsr::i<DataVector, Dim, Frame::Inertial>& unit_normal_one_form) {
-  Variables<tmpl::list<Psi, Pi, Phi<Dim>>> evolved_fields(
+  Variables<tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<Dim>>> evolved_fields(
       get_size(get(gamma_2)));
   evolved_fields_from_characteristic_fields(make_not_null(&evolved_fields),
                                             gamma_2, v_psi, v_zero, v_plus,
@@ -123,53 +124,54 @@ evolved_fields_from_characteristic_fields(
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATE(_, data)                                                   \
-  template void ScalarWave::characteristic_speeds(                             \
-      const gsl::not_null<std::array<DataVector, 4>*> char_speeds,             \
-      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                   \
-          unit_normal_one_form);                                               \
-  template std::array<DataVector, 4> ScalarWave::characteristic_speeds(        \
-      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                   \
-          unit_normal_one_form);                                               \
-  template struct ScalarWave::Tags::CharacteristicSpeedsCompute<DIM(data)>;    \
-  template void ScalarWave::characteristic_fields(                             \
-      const gsl::not_null<Variables<tmpl::list<                                \
-          ScalarWave::Tags::VPsi, ScalarWave::Tags::VZero<DIM(data)>,          \
-          ScalarWave::Tags::VPlus, ScalarWave::Tags::VMinus>>*>                \
-          char_fields,                                                         \
-      const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& psi,        \
-      const Scalar<DataVector>& pi,                                            \
-      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& phi,              \
-      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                   \
-          unit_normal_one_form);                                               \
-  template Variables<                                                          \
-      tmpl::list<ScalarWave::Tags::VPsi, ScalarWave::Tags::VZero<DIM(data)>,   \
-                 ScalarWave::Tags::VPlus, ScalarWave::Tags::VMinus>>           \
-  ScalarWave::characteristic_fields(                                           \
-      const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& psi,        \
-      const Scalar<DataVector>& pi,                                            \
-      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& phi,              \
-      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                   \
-          unit_normal_one_form);                                               \
-  template struct ScalarWave::Tags::CharacteristicFieldsCompute<DIM(data)>;    \
-  template void ScalarWave::evolved_fields_from_characteristic_fields(         \
-      const gsl::not_null<Variables<tmpl::list<                                \
-          ScalarWave::Psi, ScalarWave::Pi, ScalarWave::Phi<DIM(data)>>>*>      \
-          evolved_fields,                                                      \
-      const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& v_psi,      \
-      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& v_zero,           \
-      const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,     \
-      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                   \
-          unit_normal_one_form);                                               \
-  template Variables<                                                          \
-      tmpl::list<ScalarWave::Psi, ScalarWave::Pi, ScalarWave::Phi<DIM(data)>>> \
-  ScalarWave::evolved_fields_from_characteristic_fields(                       \
-      const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& v_psi,      \
-      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& v_zero,           \
-      const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,     \
-      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                   \
-          unit_normal_one_form);                                               \
-  template struct ScalarWave::Tags::                                           \
+#define INSTANTIATE(_, data)                                                 \
+  template void ScalarWave::characteristic_speeds(                           \
+      const gsl::not_null<std::array<DataVector, 4>*> char_speeds,           \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                 \
+          unit_normal_one_form);                                             \
+  template std::array<DataVector, 4> ScalarWave::characteristic_speeds(      \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                 \
+          unit_normal_one_form);                                             \
+  template struct ScalarWave::Tags::CharacteristicSpeedsCompute<DIM(data)>;  \
+  template void ScalarWave::characteristic_fields(                           \
+      const gsl::not_null<Variables<tmpl::list<                              \
+          ScalarWave::Tags::VPsi, ScalarWave::Tags::VZero<DIM(data)>,        \
+          ScalarWave::Tags::VPlus, ScalarWave::Tags::VMinus>>*>              \
+          char_fields,                                                       \
+      const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& psi,      \
+      const Scalar<DataVector>& pi,                                          \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& phi,            \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                 \
+          unit_normal_one_form);                                             \
+  template Variables<                                                        \
+      tmpl::list<ScalarWave::Tags::VPsi, ScalarWave::Tags::VZero<DIM(data)>, \
+                 ScalarWave::Tags::VPlus, ScalarWave::Tags::VMinus>>         \
+  ScalarWave::characteristic_fields(                                         \
+      const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& psi,      \
+      const Scalar<DataVector>& pi,                                          \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& phi,            \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                 \
+          unit_normal_one_form);                                             \
+  template struct ScalarWave::Tags::CharacteristicFieldsCompute<DIM(data)>;  \
+  template void ScalarWave::evolved_fields_from_characteristic_fields(       \
+      const gsl::not_null<                                                   \
+          Variables<tmpl::list<ScalarWave::Tags::Psi, ScalarWave::Tags::Pi,  \
+                               ScalarWave::Tags::Phi<DIM(data)>>>*>          \
+          evolved_fields,                                                    \
+      const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& v_psi,    \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& v_zero,         \
+      const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,   \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                 \
+          unit_normal_one_form);                                             \
+  template Variables<tmpl::list<ScalarWave::Tags::Psi, ScalarWave::Tags::Pi, \
+                                ScalarWave::Tags::Phi<DIM(data)>>>           \
+  ScalarWave::evolved_fields_from_characteristic_fields(                     \
+      const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& v_psi,    \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& v_zero,         \
+      const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,   \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                 \
+          unit_normal_one_form);                                             \
+  template struct ScalarWave::Tags::                                         \
       EvolvedFieldsFromCharacteristicFieldsCompute<DIM(data)>;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))

--- a/src/Evolution/Systems/ScalarWave/Characteristics.hpp
+++ b/src/Evolution/Systems/ScalarWave/Characteristics.hpp
@@ -174,7 +174,7 @@ struct CharacteristicFieldsCompute : Tags::CharacteristicFields<Dim>,
  * see \ref Tags::CharacteristicFieldsCompute.
  */
 template <size_t Dim>
-Variables<tmpl::list<Psi, Pi, Phi<Dim>>>
+Variables<tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<Dim>>>
 evolved_fields_from_characteristic_fields(
     const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& v_psi,
     const tnsr::i<DataVector, Dim, Frame::Inertial>& v_zero,
@@ -183,7 +183,8 @@ evolved_fields_from_characteristic_fields(
 
 template <size_t Dim>
 void evolved_fields_from_characteristic_fields(
-    gsl::not_null<Variables<tmpl::list<Psi, Pi, Phi<Dim>>>*> evolved_fields,
+    gsl::not_null<Variables<tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<Dim>>>*>
+        evolved_fields,
     const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& v_psi,
     const tnsr::i<DataVector, Dim, Frame::Inertial>& v_zero,
     const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,

--- a/src/Evolution/Systems/ScalarWave/EnergyDensity.hpp
+++ b/src/Evolution/Systems/ScalarWave/EnergyDensity.hpp
@@ -44,7 +44,7 @@ namespace Tags {
 /// \brief Computes the energy density using ScalarWave::energy_density()
 template <size_t SpatialDim>
 struct EnergyDensityCompute : EnergyDensity<SpatialDim>, db::ComputeTag {
-  using argument_tags = tmpl::list<ScalarWave::Pi, ScalarWave::Phi<SpatialDim>>;
+  using argument_tags = tmpl::list<Pi, Phi<SpatialDim>>;
 
   using return_type = Scalar<DataVector>;
 

--- a/src/Evolution/Systems/ScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.hpp
@@ -28,7 +28,7 @@ namespace ScalarWave {
  */
 template <size_t Dim>
 struct ComputeNormalDotFluxes {
-  using argument_tags = tmpl::list<Pi>;
+  using argument_tags = tmpl::list<Tags::Pi>;
   static void apply(gsl::not_null<Scalar<DataVector>*> pi_normal_dot_flux,
                     gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
                         phi_normal_dot_flux,

--- a/src/Evolution/Systems/ScalarWave/System.hpp
+++ b/src/Evolution/Systems/ScalarWave/System.hpp
@@ -45,9 +45,10 @@ struct System {
   static constexpr bool has_primitive_and_conservative_vars = false;
   static constexpr size_t volume_dim = Dim;
 
-  using variables_tag = ::Tags::Variables<tmpl::list<Pi, Phi<Dim>, Psi>>;
+  using variables_tag =
+      ::Tags::Variables<tmpl::list<Tags::Pi, Tags::Phi<Dim>, Tags::Psi>>;
   using flux_variables = tmpl::list<>;
-  using gradient_variables = tmpl::list<Pi, Phi<Dim>, Psi>;
+  using gradient_variables = tmpl::list<Tags::Pi, Tags::Phi<Dim>, Tags::Psi>;
 
   using compute_volume_time_derivative_terms = TimeDerivative<Dim>;
 

--- a/src/Evolution/Systems/ScalarWave/Tags.hpp
+++ b/src/Evolution/Systems/ScalarWave/Tags.hpp
@@ -16,7 +16,7 @@
 
 class DataVector;
 
-namespace ScalarWave {
+namespace ScalarWave::Tags {
 struct Psi : db::SimpleTag {
   using type = Scalar<DataVector>;
   static std::string name() { return "Psi"; }
@@ -33,7 +33,6 @@ struct Phi : db::SimpleTag {
   static std::string name() { return "Phi"; }
 };
 
-namespace Tags {
 struct ConstraintGamma2 : db::SimpleTag {
   using type = Scalar<DataVector>;
   static std::string name() { return "ConstraintGamma2"; }
@@ -108,5 +107,4 @@ template <size_t Dim>
 struct EnergyDensity : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
-}  // namespace Tags
-}  // namespace ScalarWave
+}  // namespace ScalarWave::Tags

--- a/src/Evolution/Systems/ScalarWave/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/ScalarWave/TagsDeclarations.hpp
@@ -5,14 +5,13 @@
 
 #include <cstddef>
 
-namespace ScalarWave {
+/// \brief Tags for the ScalarWave evolution system
+namespace ScalarWave::Tags {
 struct Psi;
 struct Pi;
 template <size_t Dim>
 struct Phi;
 
-/// \brief Tags for the ScalarWave evolution system
-namespace Tags {
 struct ConstraintGamma2;
 
 template <size_t Dim>
@@ -34,5 +33,4 @@ template <size_t Dim>
 struct EvolvedFieldsFromCharacteristicFields;
 template <size_t Dim>
 struct EnergyDensity;
-}  // namespace Tags
-}  // namespace ScalarWave
+}  // namespace ScalarWave::Tags

--- a/src/Evolution/Systems/ScalarWave/TimeDerivative.hpp
+++ b/src/Evolution/Systems/ScalarWave/TimeDerivative.hpp
@@ -25,7 +25,8 @@ namespace ScalarWave {
 template <size_t Dim>
 struct TimeDerivative {
   using temporary_tags = tmpl::list<Tags::ConstraintGamma2>;
-  using argument_tags = tmpl::list<Pi, Phi<Dim>, Tags::ConstraintGamma2>;
+  using argument_tags =
+      tmpl::list<Tags::Pi, Tags::Phi<Dim>, Tags::ConstraintGamma2>;
 
   static void apply(
       // Time derivatives returned by reference. All the tags in the

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveGr.hpp
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveGr.hpp
@@ -112,21 +112,21 @@ class ScalarWaveGr : public MarkAsAnalyticData {
       const tnsr::I<DataVector, volume_dim>& x,
       tmpl::list<Tags::Phi<volume_dim>> /*meta*/) const {
     constexpr double default_initial_time = 0.;
-    return {std::move(
-        get<ScalarWave::Phi<volume_dim>>(flat_space_scalar_wave_data_.variables(
+    return {std::move(get<ScalarWave::Tags::Phi<volume_dim>>(
+        flat_space_scalar_wave_data_.variables(
             x, default_initial_time,
-            tmpl::list<ScalarWave::Pi, ScalarWave::Phi<volume_dim>,
-                       ScalarWave::Psi>{})))};
+            tmpl::list<ScalarWave::Tags::Pi, ScalarWave::Tags::Phi<volume_dim>,
+                       ScalarWave::Tags::Psi>{})))};
   }
   tuples::TaggedTuple<Tags::Psi> variables(
       const tnsr::I<DataVector, volume_dim>& x,
       tmpl::list<Tags::Psi> /*meta*/) const {
     constexpr double default_initial_time = 0.;
-    return {
-        std::move(get<ScalarWave::Psi>(flat_space_scalar_wave_data_.variables(
+    return {std::move(
+        get<ScalarWave::Tags::Psi>(flat_space_scalar_wave_data_.variables(
             x, default_initial_time,
-            tmpl::list<ScalarWave::Pi, ScalarWave::Phi<volume_dim>,
-                       ScalarWave::Psi>{})))};
+            tmpl::list<ScalarWave::Tags::Pi, ScalarWave::Tags::Phi<volume_dim>,
+                       ScalarWave::Tags::Psi>{})))};
   }
 
   // Retrieve one or more tags

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveGr.tpp
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveGr.tpp
@@ -30,8 +30,8 @@ ScalarWaveGr<ScalarFieldData, BackgroundGrData>::variables(
   const auto flat_space_scalar_wave_vars =
       flat_space_scalar_wave_data_.variables(
           x, default_initial_time,
-          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<volume_dim>,
-                     ScalarWave::Psi>{});
+          tmpl::list<ScalarWave::Tags::Pi, ScalarWave::Tags::Phi<volume_dim>,
+                     ScalarWave::Tags::Psi>{});
   const auto spacetime_variables = background_gr_data_.variables(
       x, default_initial_time, spacetime_tags<DataVector>{});
   auto result = make_with_value<tuples::TaggedTuple<Tags::Pi>>(x, 0.);
@@ -39,11 +39,11 @@ ScalarWaveGr<ScalarFieldData, BackgroundGrData>::variables(
   const auto shift_dot_dpsi = dot_product(
       get<gr::Tags::Shift<volume_dim, Frame::Inertial, DataVector>>(
           spacetime_variables),
-      get<ScalarWave::Phi<volume_dim>>(flat_space_scalar_wave_vars));
+      get<ScalarWave::Tags::Phi<volume_dim>>(flat_space_scalar_wave_vars));
 
   get(get<Tags::Pi>(result)) =
       (get(shift_dot_dpsi) +
-       get(get<ScalarWave::Pi>(flat_space_scalar_wave_vars))) /
+       get(get<ScalarWave::Tags::Pi>(flat_space_scalar_wave_vars))) /
       get(get<gr::Tags::Lapse<DataVector>>(spacetime_variables));
 
   return result;

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.cpp
@@ -85,30 +85,27 @@ tnsr::ii<T, Dim> PlaneWave<Dim>::d2psi_dxdx(const tnsr::I<T, Dim>& x,
 }
 
 template <size_t Dim>
-tuples::TaggedTuple<ScalarWave::Pi, ScalarWave::Phi<Dim>, ScalarWave::Psi>
-PlaneWave<Dim>::variables(const tnsr::I<DataVector, Dim>& x, double t,
-                          const tmpl::list<ScalarWave::Pi, ScalarWave::Phi<Dim>,
-                                           ScalarWave::Psi> /*meta*/) const {
-  tuples::TaggedTuple<ScalarWave::Pi, ScalarWave::Phi<Dim>, ScalarWave::Psi>
-      variables{dpsi_dt(x, t), dpsi_dx(x, t), psi(x, t)};
-  get<ScalarWave::Pi>(variables).get() *= -1.0;
+tuples::TaggedTuple<Tags::Pi, Tags::Phi<Dim>, Tags::Psi>
+PlaneWave<Dim>::variables(
+    const tnsr::I<DataVector, Dim>& x, double t,
+    const tmpl::list<Tags::Pi, Tags::Phi<Dim>, Tags::Psi> /*meta*/) const {
+  tuples::TaggedTuple<Tags::Pi, Tags::Phi<Dim>, Tags::Psi> variables{
+      dpsi_dt(x, t), dpsi_dx(x, t), psi(x, t)};
+  get<Tags::Pi>(variables).get() *= -1.0;
   return variables;
 }
 
 template <size_t Dim>
-tuples::TaggedTuple<::Tags::dt<ScalarWave::Pi>,
-                    ::Tags::dt<ScalarWave::Phi<Dim>>,
-                    ::Tags::dt<ScalarWave::Psi>>
+tuples::TaggedTuple<::Tags::dt<Tags::Pi>, ::Tags::dt<Tags::Phi<Dim>>,
+                    ::Tags::dt<Tags::Psi>>
 PlaneWave<Dim>::variables(
     const tnsr::I<DataVector, Dim>& x, double t,
-    const tmpl::list<::Tags::dt<ScalarWave::Pi>,
-                     ::Tags::dt<ScalarWave::Phi<Dim>>,
-                     ::Tags::dt<ScalarWave::Psi>> /*meta*/) const {
-  tuples::TaggedTuple<::Tags::dt<ScalarWave::Pi>,
-                      ::Tags::dt<ScalarWave::Phi<Dim>>,
-                      ::Tags::dt<ScalarWave::Psi>>
+    const tmpl::list<::Tags::dt<Tags::Pi>, ::Tags::dt<Tags::Phi<Dim>>,
+                     ::Tags::dt<Tags::Psi>> /*meta*/) const {
+  tuples::TaggedTuple<::Tags::dt<Tags::Pi>, ::Tags::dt<Tags::Phi<Dim>>,
+                      ::Tags::dt<Tags::Psi>>
       dt_variables{d2psi_dt2(x, t), d2psi_dtdx(x, t), dpsi_dt(x, t)};
-  get<::Tags::dt<ScalarWave::Pi>>(dt_variables).get() *= -1.0;
+  get<::Tags::dt<Tags::Pi>>(dt_variables).get() *= -1.0;
   return dt_variables;
 }
 

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
@@ -20,12 +20,12 @@
 
 /// \cond
 class DataVector;
-namespace ScalarWave {
+namespace ScalarWave::Tags {
 struct Pi;
 struct Psi;
 template <size_t Dim>
 struct Phi;
-}  // namespace ScalarWave
+}  // namespace ScalarWave::Tags
 namespace Tags {
 template <typename Tag>
 struct dt;
@@ -111,23 +111,20 @@ class PlaneWave : public MarkAsAnalyticSolution {
   tnsr::ii<T, Dim> d2psi_dxdx(const tnsr::I<T, Dim>& x, double t) const;
 
   /// Retrieve the evolution variables at time `t` and spatial coordinates `x`
-  tuples::TaggedTuple<ScalarWave::Pi, ScalarWave::Phi<Dim>, ScalarWave::Psi>
-  variables(const tnsr::I<DataVector, Dim>& x, double t,
-            tmpl::list<ScalarWave::Pi, ScalarWave::Phi<Dim>,
-                       ScalarWave::Psi> /*meta*/) const;
+  tuples::TaggedTuple<Tags::Pi, Tags::Phi<Dim>, Tags::Psi> variables(
+      const tnsr::I<DataVector, Dim>& x, double t,
+      tmpl::list<Tags::Pi, Tags::Phi<Dim>, Tags::Psi> /*meta*/) const;
 
   /// Retrieve the time derivative of the evolution variables at time `t` and
   /// spatial coordinates `x`
   ///
   /// \note This function's expected use case is setting the past time
   /// derivative values for Adams-Bashforth-like steppers.
-  tuples::TaggedTuple<::Tags::dt<ScalarWave::Pi>,
-                      ::Tags::dt<ScalarWave::Phi<Dim>>,
-                      ::Tags::dt<ScalarWave::Psi>>
-  variables(
-      const tnsr::I<DataVector, Dim>& x, double t,
-      tmpl::list<::Tags::dt<ScalarWave::Pi>, ::Tags::dt<ScalarWave::Phi<Dim>>,
-                 ::Tags::dt<ScalarWave::Psi>> /*meta*/) const;
+  tuples::TaggedTuple<::Tags::dt<Tags::Pi>, ::Tags::dt<Tags::Phi<Dim>>,
+                      ::Tags::dt<Tags::Psi>>
+  variables(const tnsr::I<DataVector, Dim>& x, double t,
+            tmpl::list<::Tags::dt<Tags::Pi>, ::Tags::dt<Tags::Phi<Dim>>,
+                       ::Tags::dt<Tags::Psi>> /*meta*/) const;
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p);

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.cpp
@@ -25,11 +25,10 @@ RegularSphericalWave::RegularSphericalWave(
     std::unique_ptr<MathFunction<1, Frame::Inertial>> profile)
     : profile_(std::move(profile)) {}
 
-tuples::TaggedTuple<ScalarWave::Pi, ScalarWave::Phi<3>, ScalarWave::Psi>
+tuples::TaggedTuple<Tags::Pi, Tags::Phi<3>, Tags::Psi>
 RegularSphericalWave::variables(
     const tnsr::I<DataVector, 3>& x, double t,
-    const tmpl::list<ScalarWave::Pi, ScalarWave::Phi<3>,
-                     ScalarWave::Psi> /*meta*/) const {
+    const tmpl::list<Tags::Pi, Tags::Phi<3>, Tags::Psi> /*meta*/) const {
   const DataVector r = get(magnitude(x));
   // See class documentation for choice of cutoff
   const double r_cutoff = cbrt(std::numeric_limits<double>::epsilon());
@@ -58,18 +57,18 @@ RegularSphericalWave::variables(
       }
     }
   }
-  tuples::TaggedTuple<ScalarWave::Pi, ScalarWave::Phi<3>, ScalarWave::Psi>
-      variables{std::move(dpsi_dt), std::move(dpsi_dx), std::move(psi)};
-  get<ScalarWave::Pi>(variables).get() *= -1.0;
+  tuples::TaggedTuple<Tags::Pi, Tags::Phi<3>, Tags::Psi> variables{
+      std::move(dpsi_dt), std::move(dpsi_dx), std::move(psi)};
+  get<Tags::Pi>(variables).get() *= -1.0;
   return variables;
 }
 
-tuples::TaggedTuple<::Tags::dt<ScalarWave::Pi>, ::Tags::dt<ScalarWave::Phi<3>>,
-                    ::Tags::dt<ScalarWave::Psi>>
+tuples::TaggedTuple<::Tags::dt<Tags::Pi>, ::Tags::dt<Tags::Phi<3>>,
+                    ::Tags::dt<Tags::Psi>>
 RegularSphericalWave::variables(
     const tnsr::I<DataVector, 3>& x, double t,
-    const tmpl::list<::Tags::dt<ScalarWave::Pi>, ::Tags::dt<ScalarWave::Phi<3>>,
-                     ::Tags::dt<ScalarWave::Psi>> /*meta*/) const {
+    const tmpl::list<::Tags::dt<Tags::Pi>, ::Tags::dt<Tags::Phi<3>>,
+                     ::Tags::dt<Tags::Psi>> /*meta*/) const {
   const DataVector r = get(magnitude(x));
   // See class documentation for choice of cutoff
   const double r_cutoff = cbrt(std::numeric_limits<double>::epsilon());
@@ -98,12 +97,11 @@ RegularSphericalWave::variables(
       }
     }
   }
-  tuples::TaggedTuple<::Tags::dt<ScalarWave::Pi>,
-                      ::Tags::dt<ScalarWave::Phi<3>>,
-                      ::Tags::dt<ScalarWave::Psi>>
+  tuples::TaggedTuple<::Tags::dt<Tags::Pi>, ::Tags::dt<Tags::Phi<3>>,
+                      ::Tags::dt<Tags::Psi>>
       dt_variables{std::move(d2psi_dt2), std::move(d2psi_dtdx),
                    std::move(dpsi_dt)};
-  get<::Tags::dt<ScalarWave::Pi>>(dt_variables).get() *= -1.0;
+  get<::Tags::dt<Tags::Pi>>(dt_variables).get() *= -1.0;
   return dt_variables;
 }
 

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp
@@ -19,12 +19,12 @@
 
 /// \cond
 class DataVector;
-namespace ScalarWave {
+namespace ScalarWave::Tags {
 struct Pi;
 struct Psi;
 template <size_t Dim>
 struct Phi;
-}  // namespace ScalarWave
+}  // namespace ScalarWave::Tags
 namespace Tags {
 template <typename Tag>
 struct dt;
@@ -87,18 +87,15 @@ class RegularSphericalWave : public MarkAsAnalyticSolution {
   RegularSphericalWave& operator=(RegularSphericalWave&&) = default;
   ~RegularSphericalWave() = default;
 
-  tuples::TaggedTuple<ScalarWave::Pi, ScalarWave::Phi<3>, ScalarWave::Psi>
-  variables(const tnsr::I<DataVector, 3>& x, double t,
-            tmpl::list<ScalarWave::Pi, ScalarWave::Phi<3>,
-                       ScalarWave::Psi> /*meta*/) const;
-
-  tuples::TaggedTuple<::Tags::dt<ScalarWave::Pi>,
-                      ::Tags::dt<ScalarWave::Phi<3>>,
-                      ::Tags::dt<ScalarWave::Psi>>
-  variables(
+  tuples::TaggedTuple<Tags::Pi, Tags::Phi<3>, Tags::Psi> variables(
       const tnsr::I<DataVector, 3>& x, double t,
-      tmpl::list<::Tags::dt<ScalarWave::Pi>, ::Tags::dt<ScalarWave::Phi<3>>,
-                 ::Tags::dt<ScalarWave::Psi>> /*meta*/) const;
+      tmpl::list<Tags::Pi, Tags::Phi<3>, Tags::Psi> /*meta*/) const;
+
+  tuples::TaggedTuple<::Tags::dt<Tags::Pi>, ::Tags::dt<Tags::Phi<3>>,
+                      ::Tags::dt<Tags::Psi>>
+  variables(const tnsr::I<DataVector, 3>& x, double t,
+            tmpl::list<::Tags::dt<Tags::Pi>, ::Tags::dt<Tags::Phi<3>>,
+                       ::Tags::dt<Tags::Psi>> /*meta*/) const;
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p);

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/SemidiscretizedDg.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/SemidiscretizedDg.cpp
@@ -93,9 +93,9 @@ std::array<Mode, 4> get_modes(const tnsr::I<DataVector, 1>& x,
 }
 }  // namespace
 
-tuples::TaggedTuple<ScalarWave::Pi> SemidiscretizedDg::variables(
+tuples::TaggedTuple<Tags::Pi> SemidiscretizedDg::variables(
     const tnsr::I<DataVector, 1>& x, double t,
-    tmpl::list<ScalarWave::Pi> /*meta*/) const {
+    tmpl::list<Tags::Pi> /*meta*/) const {
   using namespace std::complex_literals;
 
   const auto modes = get_modes(x, harmonic_);
@@ -110,9 +110,9 @@ tuples::TaggedTuple<ScalarWave::Pi> SemidiscretizedDg::variables(
   return {Scalar<DataVector>(std::move(pi))};
 }
 
-tuples::TaggedTuple<ScalarWave::Phi<1>> SemidiscretizedDg::variables(
+tuples::TaggedTuple<Tags::Phi<1>> SemidiscretizedDg::variables(
     const tnsr::I<DataVector, 1>& x, double t,
-    tmpl::list<ScalarWave::Phi<1>> /*meta*/) const {
+    tmpl::list<Tags::Phi<1>> /*meta*/) const {
   using namespace std::complex_literals;
 
   const auto modes = get_modes(x, harmonic_);
@@ -127,9 +127,9 @@ tuples::TaggedTuple<ScalarWave::Phi<1>> SemidiscretizedDg::variables(
   return {tnsr::i<DataVector, 1>{{{std::move(phi)}}}};
 }
 
-tuples::TaggedTuple<ScalarWave::Psi> SemidiscretizedDg::variables(
+tuples::TaggedTuple<Tags::Psi> SemidiscretizedDg::variables(
     const tnsr::I<DataVector, 1>& x, double t,
-    tmpl::list<ScalarWave::Psi> /*meta*/) const {
+    tmpl::list<Tags::Psi> /*meta*/) const {
   using namespace std::complex_literals;
 
   // There are two more modes that are just constant offsets of Psi,

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/SemidiscretizedDg.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/SemidiscretizedDg.hpp
@@ -37,7 +37,7 @@ namespace Solutions {
  */
 class SemidiscretizedDg : public MarkAsAnalyticSolution {
  public:
-  using tags = tmpl::list<ScalarWave::Pi, ScalarWave::Phi<1>, ScalarWave::Psi>;
+  using tags = tmpl::list<Tags::Pi, Tags::Phi<1>, Tags::Psi>;
 
   struct Harmonic {
     using type = int;
@@ -74,17 +74,17 @@ class SemidiscretizedDg : public MarkAsAnalyticSolution {
   }
 
   /// \cond
-  tuples::TaggedTuple<ScalarWave::Pi> variables(
-      const tnsr::I<DataVector, 1>& x, double t,
-      tmpl::list<ScalarWave::Pi> /*meta*/) const;
+  tuples::TaggedTuple<Tags::Pi> variables(const tnsr::I<DataVector, 1>& x,
+                                          double t,
+                                          tmpl::list<Tags::Pi> /*meta*/) const;
 
-  tuples::TaggedTuple<ScalarWave::Phi<1>> variables(
+  tuples::TaggedTuple<Tags::Phi<1>> variables(
       const tnsr::I<DataVector, 1>& x, double t,
-      tmpl::list<ScalarWave::Phi<1>> /*meta*/) const;
+      tmpl::list<Tags::Phi<1>> /*meta*/) const;
 
-  tuples::TaggedTuple<ScalarWave::Psi> variables(
+  tuples::TaggedTuple<Tags::Psi> variables(
       const tnsr::I<DataVector, 1>& x, double t,
-      tmpl::list<ScalarWave::Psi> /*meta*/) const;
+      tmpl::list<Tags::Psi> /*meta*/) const;
   /// \endcond
 
   // NOLINTNEXTLINE(google-runtime-references)

--- a/tests/Unit/Evolution/Systems/ScalarWave/BoundaryConditions/Test_ConstraintPreservingSphericalRadiation.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/BoundaryConditions/Test_ConstraintPreservingSphericalRadiation.cpp
@@ -37,10 +37,11 @@ void test() {
         make_not_null(&gen), "ConstraintPreservingSphericalRadiation",
         tuples::TaggedTuple<
             helpers::Tags::PythonFunctionForErrorMessage<>,
-            helpers::Tags::PythonFunctionName<::Tags::dt<ScalarWave::Psi>>,
-            helpers::Tags::PythonFunctionName<::Tags::dt<ScalarWave::Pi>>,
             helpers::Tags::PythonFunctionName<
-                ::Tags::dt<ScalarWave::Phi<Dim>>>>{
+                ::Tags::dt<ScalarWave::Tags::Psi>>,
+            helpers::Tags::PythonFunctionName<::Tags::dt<ScalarWave::Tags::Pi>>,
+            helpers::Tags::PythonFunctionName<
+                ::Tags::dt<ScalarWave::Tags::Phi<Dim>>>>{
             "error", "dt_psi", "dt_pi_" + bc_string, "dt_phi"},
         "ConstraintPreservingSphericalRadiation:\n"
         "  Type: " +

--- a/tests/Unit/Evolution/Systems/ScalarWave/BoundaryConditions/Test_DirichletAnalytic.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/BoundaryConditions/Test_DirichletAnalytic.cpp
@@ -80,9 +80,9 @@ void test() {
       make_not_null(&gen), "DirichletAnalytic",
       tuples::TaggedTuple<
           helpers::Tags::PythonFunctionForErrorMessage<>,
-          helpers::Tags::PythonFunctionName<ScalarWave::Psi>,
-          helpers::Tags::PythonFunctionName<ScalarWave::Pi>,
-          helpers::Tags::PythonFunctionName<ScalarWave::Phi<Dim>>,
+          helpers::Tags::PythonFunctionName<ScalarWave::Tags::Psi>,
+          helpers::Tags::PythonFunctionName<ScalarWave::Tags::Pi>,
+          helpers::Tags::PythonFunctionName<ScalarWave::Tags::Phi<Dim>>,
           helpers::Tags::PythonFunctionName<
               ScalarWave::Tags::ConstraintGamma2>>{"error", "psi", "pi", "phi",
                                                    "constraint_gamma2"},

--- a/tests/Unit/Evolution/Systems/ScalarWave/BoundaryConditions/Test_SphericalRadiation.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/BoundaryConditions/Test_SphericalRadiation.cpp
@@ -36,9 +36,9 @@ void test() {
         make_not_null(&gen), "SphericalRadiation",
         tuples::TaggedTuple<
             helpers::Tags::PythonFunctionForErrorMessage<>,
-            helpers::Tags::PythonFunctionName<ScalarWave::Psi>,
-            helpers::Tags::PythonFunctionName<ScalarWave::Pi>,
-            helpers::Tags::PythonFunctionName<ScalarWave::Phi<Dim>>,
+            helpers::Tags::PythonFunctionName<ScalarWave::Tags::Psi>,
+            helpers::Tags::PythonFunctionName<ScalarWave::Tags::Pi>,
+            helpers::Tags::PythonFunctionName<ScalarWave::Tags::Phi<Dim>>,
             helpers::Tags::PythonFunctionName<
                 ScalarWave::Tags::ConstraintGamma2>>{
             "error", "psi", "pi_" + bc_string, "phi", "constraint_gamma2"},

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_Characteristics.cpp
@@ -176,13 +176,14 @@ void test_characteristic_fields_analytic(
   // Evaluate analytic solution
   const auto vars = solution.variables(
       x, t,
-      tmpl::list<ScalarWave::Pi, ScalarWave::Phi<Dim>, ScalarWave::Psi>{});
+      tmpl::list<ScalarWave::Tags::Pi, ScalarWave::Tags::Phi<Dim>,
+                 ScalarWave::Tags::Psi>{});
   // Get ingredients
   const size_t n_pts = mesh.number_of_grid_points();
   const auto gamma_2 = make_with_value<Scalar<DataVector>>(x, 0.1);
-  const auto& psi = get<ScalarWave::Psi>(vars);
-  const auto& phi = get<ScalarWave::Phi<Dim>>(vars);
-  const auto& pi = get<ScalarWave::Pi>(vars);
+  const auto& psi = get<ScalarWave::Tags::Psi>(vars);
+  const auto& phi = get<ScalarWave::Tags::Phi<Dim>>(vars);
+  const auto& pi = get<ScalarWave::Tags::Pi>(vars);
   // Outward 3-normal to the surface on which characteristic fields are needed
   const auto unit_normal_one_form =
       make_with_value<tnsr::i<DataVector, Dim, Frame::Inertial>>(
@@ -231,7 +232,8 @@ typename Tag::type evol_field_with_tag(
     const tnsr::i<DataVector, Dim, Frame::Inertial>& v_zero,
     const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,
     const tnsr::i<DataVector, Dim, Frame::Inertial>& unit_normal_one_form) {
-  Variables<tmpl::list<ScalarWave::Psi, ScalarWave::Pi, ScalarWave::Phi<Dim>>>
+  Variables<tmpl::list<ScalarWave::Tags::Psi, ScalarWave::Tags::Pi,
+                       ScalarWave::Tags::Phi<Dim>>>
       evolved_vars{};
   ScalarWave::Tags::EvolvedFieldsFromCharacteristicFieldsCompute<Dim>::function(
       make_not_null(&evolved_vars), gamma_2, v_psi, v_zero, v_plus, v_minus,
@@ -246,16 +248,16 @@ void test_evolved_from_characteristic_fields() {
       "EvolvedFieldsFromCharacteristicFields");
   const DataVector used_for_size(5);
   // Psi
-  pypp::check_with_random_values<1>(evol_field_with_tag<ScalarWave::Psi, Dim>,
-                                    "Characteristics", "evol_field_psi",
-                                    {{{-100., 100.}}}, used_for_size);
+  pypp::check_with_random_values<1>(
+      evol_field_with_tag<ScalarWave::Tags::Psi, Dim>, "Characteristics",
+      "evol_field_psi", {{{-100., 100.}}}, used_for_size);
   // Pi
-  pypp::check_with_random_values<1>(evol_field_with_tag<ScalarWave::Pi, Dim>,
-                                    "Characteristics", "evol_field_pi",
-                                    {{{-100., 100.}}}, used_for_size);
+  pypp::check_with_random_values<1>(
+      evol_field_with_tag<ScalarWave::Tags::Pi, Dim>, "Characteristics",
+      "evol_field_pi", {{{-100., 100.}}}, used_for_size);
   // Phi
   pypp::check_with_random_values<1>(
-      evol_field_with_tag<ScalarWave::Phi<Dim>, Dim>, "Characteristics",
+      evol_field_with_tag<ScalarWave::Tags::Phi<Dim>, Dim>, "Characteristics",
       "evol_field_phi", {{{-100., 100.}}}, used_for_size);
 }
 
@@ -289,13 +291,14 @@ void test_evolved_from_characteristic_fields_analytic(
   // Evaluate analytic solution
   const auto vars = solution.variables(
       x, t,
-      tmpl::list<ScalarWave::Pi, ScalarWave::Phi<Dim>, ScalarWave::Psi>{});
+      tmpl::list<ScalarWave::Tags::Pi, ScalarWave::Tags::Phi<Dim>,
+                 ScalarWave::Tags::Psi>{});
   // Get ingredients
   const size_t n_pts = mesh.number_of_grid_points();
   const auto gamma_2 = make_with_value<Scalar<DataVector>>(x, 0.1);
-  const auto& psi_expected = get<ScalarWave::Psi>(vars);
-  const auto& phi_expected = get<ScalarWave::Phi<Dim>>(vars);
-  const auto& pi_expected = get<ScalarWave::Pi>(vars);
+  const auto& psi_expected = get<ScalarWave::Tags::Psi>(vars);
+  const auto& phi_expected = get<ScalarWave::Tags::Phi<Dim>>(vars);
+  const auto& pi_expected = get<ScalarWave::Tags::Pi>(vars);
   // Outward 3-normal to the surface on which characteristic fields are needed
   const auto unit_normal_one_form =
       make_with_value<tnsr::i<DataVector, Dim, Frame::Inertial>>(
@@ -321,14 +324,15 @@ void test_evolved_from_characteristic_fields_analytic(
                                   get(gamma_2) * get(psi_expected)};
   // Second, obtain evolved fields using compute tag
   {
-    Variables<tmpl::list<ScalarWave::Psi, ScalarWave::Pi, ScalarWave::Phi<Dim>>>
+    Variables<tmpl::list<ScalarWave::Tags::Psi, ScalarWave::Tags::Pi,
+                         ScalarWave::Tags::Phi<Dim>>>
         fields{};
     ScalarWave::Tags::EvolvedFieldsFromCharacteristicFieldsCompute<
         Dim>::function(make_not_null(&fields), gamma_2, vpsi, vzero, vplus,
                        vminus, unit_normal_one_form);
-    const auto& psi = get<ScalarWave::Psi>(fields);
-    const auto& pi = get<ScalarWave::Pi>(fields);
-    const auto& phi = get<ScalarWave::Phi<Dim>>(fields);
+    const auto& psi = get<ScalarWave::Tags::Psi>(fields);
+    const auto& pi = get<ScalarWave::Tags::Pi>(fields);
+    const auto& phi = get<ScalarWave::Tags::Phi<Dim>>(fields);
 
     CHECK_ITERABLE_APPROX(psi_expected, psi);
     CHECK_ITERABLE_APPROX(pi_expected, pi);
@@ -338,9 +342,9 @@ void test_evolved_from_characteristic_fields_analytic(
   {
     const auto fields = ScalarWave::evolved_fields_from_characteristic_fields(
         gamma_2, vpsi, vzero, vplus, vminus, unit_normal_one_form);
-    const auto& psi = get<ScalarWave::Psi>(fields);
-    const auto& pi = get<ScalarWave::Pi>(fields);
-    const auto& phi = get<ScalarWave::Phi<Dim>>(fields);
+    const auto& psi = get<ScalarWave::Tags::Psi>(fields);
+    const auto& pi = get<ScalarWave::Tags::Pi>(fields);
+    const auto& phi = get<ScalarWave::Tags::Phi<Dim>>(fields);
 
     CHECK_ITERABLE_APPROX(psi_expected, psi);
     CHECK_ITERABLE_APPROX(pi_expected, pi);

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_EnergyDensity.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_EnergyDensity.cpp
@@ -33,7 +33,8 @@ void test_compute_item_in_databox(const DataType& used_for_size) {
           make_not_null(&generator), dist, used_for_size);
 
   const auto box = db::create<
-      db::AddSimpleTags<ScalarWave::Pi, ScalarWave::Phi<SpatialDim>>,
+      db::AddSimpleTags<ScalarWave::Tags::Pi,
+                        ScalarWave::Tags::Phi<SpatialDim>>,
       db::AddComputeTags<ScalarWave::Tags::EnergyDensityCompute<SpatialDim>>>(
       pi, phi);
 

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_TimeDerivative.cpp
@@ -70,11 +70,13 @@ void check_du_dt(const size_t npts, const double time) {
                                const double gamma2, const double constraint) {
     auto box = db::create<db::AddSimpleTags<
         ScalarWave::Tags::ConstraintGamma2, ConstraintGamma2Copy,
-        Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
-        Tags::dt<ScalarWave::Psi>, ScalarWave::Pi, ScalarWave::Phi<Dim>,
-        Tags::deriv<ScalarWave::Pi, tmpl::size_t<Dim>, Frame::Inertial>,
-        Tags::deriv<ScalarWave::Psi, tmpl::size_t<Dim>, Frame::Inertial>,
-        Tags::deriv<ScalarWave::Phi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>>>(
+        Tags::dt<ScalarWave::Tags::Pi>, Tags::dt<ScalarWave::Tags::Phi<Dim>>,
+        Tags::dt<ScalarWave::Tags::Psi>, ScalarWave::Tags::Pi,
+        ScalarWave::Tags::Phi<Dim>,
+        Tags::deriv<ScalarWave::Tags::Pi, tmpl::size_t<Dim>, Frame::Inertial>,
+        Tags::deriv<ScalarWave::Tags::Psi, tmpl::size_t<Dim>, Frame::Inertial>,
+        Tags::deriv<ScalarWave::Tags::Phi<Dim>, tmpl::size_t<Dim>,
+                    Frame::Inertial>>>(
         Scalar<DataVector>(pow<Dim>(npts), gamma2),
         Scalar<DataVector>(pow<Dim>(npts), 0.0),
         Scalar<DataVector>(pow<Dim>(npts), 0.0),
@@ -104,24 +106,27 @@ void check_du_dt(const size_t npts, const double time) {
         }());
 
     db::mutate_apply<
-        tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
-                   Tags::dt<ScalarWave::Psi>, ConstraintGamma2Copy>,
+        tmpl::list<Tags::dt<ScalarWave::Tags::Pi>,
+                   Tags::dt<ScalarWave::Tags::Phi<Dim>>,
+                   Tags::dt<ScalarWave::Tags::Psi>, ConstraintGamma2Copy>,
         tmpl::push_front<
             typename ScalarWave::TimeDerivative<Dim>::argument_tags,
-            Tags::deriv<ScalarWave::Pi, tmpl::size_t<Dim>, Frame::Inertial>,
-            Tags::deriv<ScalarWave::Phi<Dim>, tmpl::size_t<Dim>,
+            Tags::deriv<ScalarWave::Tags::Pi, tmpl::size_t<Dim>,
                         Frame::Inertial>,
-            Tags::deriv<ScalarWave::Psi, tmpl::size_t<Dim>, Frame::Inertial>>>(
-        ScalarWave::TimeDerivative<Dim>{}, make_not_null(&box));
+            Tags::deriv<ScalarWave::Tags::Phi<Dim>, tmpl::size_t<Dim>,
+                        Frame::Inertial>,
+            Tags::deriv<ScalarWave::Tags::Psi, tmpl::size_t<Dim>,
+                        Frame::Inertial>>>(ScalarWave::TimeDerivative<Dim>{},
+                                           make_not_null(&box));
 
     CHECK_ITERABLE_APPROX(
-        db::get<Tags::dt<ScalarWave::Pi>>(box),
+        db::get<Tags::dt<ScalarWave::Tags::Pi>>(box),
         Scalar<DataVector>(-1.0 * solution.d2psi_dt2(x, time).get()));
     CHECK_ITERABLE_APPROX(
-        db::get<Tags::dt<ScalarWave::Phi<Dim>>>(box),
+        db::get<Tags::dt<ScalarWave::Tags::Phi<Dim>>>(box),
         add_scalar_to_tensor_components(solution.d2psi_dtdx(x, time),
                                         -gamma2 * constraint));
-    CHECK_ITERABLE_APPROX(db::get<Tags::dt<ScalarWave::Psi>>(box),
+    CHECK_ITERABLE_APPROX(db::get<Tags::dt<ScalarWave::Tags::Psi>>(box),
                           solution.dpsi_dt(x, time));
   };
 

--- a/tests/Unit/PointwiseFunctions/AnalyticData/CurvedWaveEquation/Test_ScalarWaveGr.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/CurvedWaveEquation/Test_ScalarWaveGr.cpp
@@ -62,17 +62,19 @@ void test_no_hole(const CurvedScalarWave::AnalyticData::ScalarWaveGr<
       x, tmpl::list<CurvedScalarWave::Tags::Pi, CurvedScalarWave::Tags::Phi<3>,
                     CurvedScalarWave::Tags::Psi>{});
   auto flat_vars = flat_wave_solution.variables(
-      x, 0., tmpl::list<ScalarWave::Pi, ScalarWave::Phi<3>, ScalarWave::Psi>{});
+      x, 0.,
+      tmpl::list<ScalarWave::Tags::Pi, ScalarWave::Tags::Phi<3>,
+                 ScalarWave::Tags::Psi>{});
   CHECK_ITERABLE_APPROX(get(get<CurvedScalarWave::Tags::Psi>(vars)),
-                        get(get<ScalarWave::Psi>(flat_vars)));
+                        get(get<ScalarWave::Tags::Psi>(flat_vars)));
   CHECK_ITERABLE_APPROX(get(get<CurvedScalarWave::Tags::Pi>(vars)),
-                        get(get<ScalarWave::Pi>(flat_vars)));
+                        get(get<ScalarWave::Tags::Pi>(flat_vars)));
   CHECK_ITERABLE_APPROX(get<0>(get<CurvedScalarWave::Tags::Phi<3>>(vars)),
-                        get<0>(get<ScalarWave::Phi<3>>(flat_vars)));
+                        get<0>(get<ScalarWave::Tags::Phi<3>>(flat_vars)));
   CHECK_ITERABLE_APPROX(get<1>(get<CurvedScalarWave::Tags::Phi<3>>(vars)),
-                        get<1>(get<ScalarWave::Phi<3>>(flat_vars)));
+                        get<1>(get<ScalarWave::Tags::Phi<3>>(flat_vars)));
   CHECK_ITERABLE_APPROX(get<2>(get<CurvedScalarWave::Tags::Phi<3>>(vars)),
-                        get<2>(get<ScalarWave::Phi<3>>(flat_vars)));
+                        get<2>(get<ScalarWave::Tags::Phi<3>>(flat_vars)));
 }
 
 template <typename ScalarFieldData>
@@ -95,15 +97,15 @@ void test_kerr(
       x, 0., gr::Solutions::KerrSchild::tags<DataVector>{});
 
   // construct the expected vars in-situ
-  const auto& local_psi = get<ScalarWave::Psi>(flat_wave_vars);
-  const auto& local_phi = get<ScalarWave::Phi<3>>(flat_wave_vars);
+  const auto& local_psi = get<ScalarWave::Tags::Psi>(flat_wave_vars);
+  const auto& local_phi = get<ScalarWave::Tags::Phi<3>>(flat_wave_vars);
   auto local_pi = make_with_value<Scalar<DataVector>>(x, 0.);
   {
     const auto shift_dot_dpsi = dot_product(
         get<gr::Tags::Shift<3, Frame::Inertial, DataVector>>(kerr_variables),
-        get<ScalarWave::Phi<3>>(flat_wave_vars));
+        get<ScalarWave::Tags::Phi<3>>(flat_wave_vars));
     get(local_pi) =
-        (get(shift_dot_dpsi) + get(get<ScalarWave::Pi>(flat_wave_vars))) /
+        (get(shift_dot_dpsi) + get(get<ScalarWave::Tags::Pi>(flat_wave_vars))) /
         get(get<gr::Tags::Lapse<DataVector>>(kerr_variables));
   }
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_PlaneWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_PlaneWave.cpp
@@ -102,43 +102,45 @@ void check_solution(
   }
 
   CHECK_ITERABLE_APPROX(
-      get<ScalarWave::Psi>(
-          pw.variables(x, t,
-                       tmpl::list<ScalarWave::Pi, ScalarWave::Phi<DimSolution>,
-                                  ScalarWave::Psi>{})),
+      get<ScalarWave::Tags::Psi>(pw.variables(
+          x, t,
+          tmpl::list<ScalarWave::Tags::Pi, ScalarWave::Tags::Phi<DimSolution>,
+                     ScalarWave::Tags::Psi>{})),
       pw.psi(x, t));
   CHECK_ITERABLE_APPROX(
-      get<ScalarWave::Phi<DimSolution>>(
-          pw.variables(x, t,
-                       tmpl::list<ScalarWave::Pi, ScalarWave::Phi<DimSolution>,
-                                  ScalarWave::Psi>{})),
+      get<ScalarWave::Tags::Phi<DimSolution>>(pw.variables(
+          x, t,
+          tmpl::list<ScalarWave::Tags::Pi, ScalarWave::Tags::Phi<DimSolution>,
+                     ScalarWave::Tags::Psi>{})),
       pw.dpsi_dx(x, t));
   CHECK_ITERABLE_APPROX(
-      get<ScalarWave::Pi>(
-          pw.variables(x, t,
-                       tmpl::list<ScalarWave::Pi, ScalarWave::Phi<DimSolution>,
-                                  ScalarWave::Psi>{})),
+      get<ScalarWave::Tags::Pi>(pw.variables(
+          x, t,
+          tmpl::list<ScalarWave::Tags::Pi, ScalarWave::Tags::Phi<DimSolution>,
+                     ScalarWave::Tags::Psi>{})),
       Scalar<DataVector>(-1.0 * pw.dpsi_dt(x, t).get()));
 
-  CHECK_ITERABLE_APPROX(get<Tags::dt<ScalarWave::Psi>>(pw.variables(
-                            x, t,
-                            tmpl::list<Tags::dt<ScalarWave::Pi>,
-                                       Tags::dt<ScalarWave::Phi<DimSolution>>,
-                                       Tags::dt<ScalarWave::Psi>>{})),
-                        pw.dpsi_dt(x, t));
   CHECK_ITERABLE_APPROX(
-      get<Tags::dt<ScalarWave::Phi<DimSolution>>>(
+      get<Tags::dt<ScalarWave::Tags::Psi>>(
           pw.variables(x, t,
-                       tmpl::list<Tags::dt<ScalarWave::Pi>,
-                                  Tags::dt<ScalarWave::Phi<DimSolution>>,
-                                  Tags::dt<ScalarWave::Psi>>{})),
+                       tmpl::list<Tags::dt<ScalarWave::Tags::Pi>,
+                                  Tags::dt<ScalarWave::Tags::Phi<DimSolution>>,
+                                  Tags::dt<ScalarWave::Tags::Psi>>{})),
+      pw.dpsi_dt(x, t));
+  CHECK_ITERABLE_APPROX(
+      get<Tags::dt<ScalarWave::Tags::Phi<DimSolution>>>(
+          pw.variables(x, t,
+                       tmpl::list<Tags::dt<ScalarWave::Tags::Pi>,
+                                  Tags::dt<ScalarWave::Tags::Phi<DimSolution>>,
+                                  Tags::dt<ScalarWave::Tags::Psi>>{})),
       pw.d2psi_dtdx(x, t));
-  CHECK_ITERABLE_APPROX(get<Tags::dt<ScalarWave::Pi>>(pw.variables(
-                            x, t,
-                            tmpl::list<Tags::dt<ScalarWave::Pi>,
-                                       Tags::dt<ScalarWave::Phi<DimSolution>>,
-                                       Tags::dt<ScalarWave::Psi>>{})),
-                        Scalar<DataVector>(-1.0 * pw.d2psi_dt2(x, t).get()));
+  CHECK_ITERABLE_APPROX(
+      get<Tags::dt<ScalarWave::Tags::Pi>>(
+          pw.variables(x, t,
+                       tmpl::list<Tags::dt<ScalarWave::Tags::Pi>,
+                                  Tags::dt<ScalarWave::Tags::Phi<DimSolution>>,
+                                  Tags::dt<ScalarWave::Tags::Psi>>{})),
+      Scalar<DataVector>(-1.0 * pw.d2psi_dt2(x, t).get()));
 }
 
 void test_1d() {
@@ -176,13 +178,13 @@ void test_1d() {
           "Profile:\n"
           "  PowX:\n"
           "    Power: 3");
-  CHECK(
-      created_solution.variables(
-          x, t,
-          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<1>, ScalarWave::Psi>{}) ==
-      pw.variables(
-          x, t,
-          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<1>, ScalarWave::Psi>{}));
+  CHECK(created_solution.variables(
+            x, t,
+            tmpl::list<ScalarWave::Tags::Pi, ScalarWave::Tags::Phi<1>,
+                       ScalarWave::Tags::Psi>{}) ==
+        pw.variables(x, t,
+                     tmpl::list<ScalarWave::Tags::Pi, ScalarWave::Tags::Phi<1>,
+                                ScalarWave::Tags::Psi>{}));
 }
 
 void test_2d() {
@@ -237,13 +239,13 @@ void test_2d() {
           "Profile:\n"
           "  PowX:\n"
           "    Power: 3");
-  CHECK(
-      created_solution.variables(
-          x, t,
-          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<2>, ScalarWave::Psi>{}) ==
-      pw.variables(
-          x, t,
-          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<2>, ScalarWave::Psi>{}));
+  CHECK(created_solution.variables(
+            x, t,
+            tmpl::list<ScalarWave::Tags::Pi, ScalarWave::Tags::Phi<2>,
+                       ScalarWave::Tags::Psi>{}) ==
+        pw.variables(x, t,
+                     tmpl::list<ScalarWave::Tags::Pi, ScalarWave::Tags::Phi<2>,
+                                ScalarWave::Tags::Psi>{}));
 }
 
 void test_3d() {
@@ -316,13 +318,13 @@ void test_3d() {
           "Profile:\n"
           "  PowX:\n"
           "    Power: 3");
-  CHECK(
-      created_solution.variables(
-          x, t,
-          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<3>, ScalarWave::Psi>{}) ==
-      pw.variables(
-          x, t,
-          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<3>, ScalarWave::Psi>{}));
+  CHECK(created_solution.variables(
+            x, t,
+            tmpl::list<ScalarWave::Tags::Pi, ScalarWave::Tags::Phi<3>,
+                       ScalarWave::Tags::Psi>{}) ==
+        pw.variables(x, t,
+                     tmpl::list<ScalarWave::Tags::Pi, ScalarWave::Tags::Phi<3>,
+                                ScalarWave::Tags::Psi>{}));
 }
 }  // namespace
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_RegularSphericalWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_RegularSphericalWave.cpp
@@ -40,41 +40,44 @@ SPECTRE_TEST_CASE("Unit.AnalyticSolutions.WaveEquation.RegularSphericalWave",
       {DataVector({0., 1., 2., 3.}), DataVector({0., 0., 0., 0.}),
        DataVector({0., 0., 0., 0.})}}};
   auto vars = solution.variables(
-      x, 1., tmpl::list<ScalarWave::Pi, ScalarWave::Phi<3>, ScalarWave::Psi>{});
+      x, 1.,
+      tmpl::list<ScalarWave::Tags::Pi, ScalarWave::Tags::Phi<3>,
+                 ScalarWave::Tags::Psi>{});
   CHECK_ITERABLE_APPROX(
-      get<ScalarWave::Psi>(vars).get(),
+      get<ScalarWave::Tags::Psi>(vars).get(),
       DataVector({{1.471517764685769, 0.9816843611112658, 0.1838780156836778,
                    0.006105175451186487}}));
   CHECK_ITERABLE_APPROX(
-      get<ScalarWave::Pi>(vars).get(),
+      get<ScalarWave::Tags::Pi>(vars).get(),
       DataVector({{1.471517764685769, -0.07326255555493672, -0.3682496705837024,
                    -0.02442115194544483}}));
   CHECK_ITERABLE_APPROX(
-      get<ScalarWave::Phi<3>>(vars).get(0),
+      get<ScalarWave::Tags::Phi<3>>(vars).get(0),
       DataVector({{0., -0.9084218055563291, -0.4594482196010212,
                    -0.02645561024157515}}));
-  CHECK_ITERABLE_APPROX(get<ScalarWave::Phi<3>>(vars).get(1),
+  CHECK_ITERABLE_APPROX(get<ScalarWave::Tags::Phi<3>>(vars).get(1),
                         DataVector({{0., 0., 0., 0.}}));
-  CHECK_ITERABLE_APPROX(get<ScalarWave::Phi<3>>(vars).get(2),
+  CHECK_ITERABLE_APPROX(get<ScalarWave::Tags::Phi<3>>(vars).get(2),
                         DataVector({{0., 0., 0., 0.}}));
-  auto dt_vars = solution.variables(
-      x, 1.,
-      tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<3>>,
-                 Tags::dt<ScalarWave::Psi>>{});
+  auto dt_vars =
+      solution.variables(x, 1.,
+                         tmpl::list<Tags::dt<ScalarWave::Tags::Pi>,
+                                    Tags::dt<ScalarWave::Tags::Phi<3>>,
+                                    Tags::dt<ScalarWave::Tags::Psi>>{});
   CHECK_ITERABLE_APPROX(
-      get<Tags::dt<ScalarWave::Psi>>(dt_vars).get(),
+      get<Tags::dt<ScalarWave::Tags::Psi>>(dt_vars).get(),
       DataVector({{-1.471517764685769, 0.07326255555493672, 0.3682496705837024,
                    0.02442115194544483}}));
   CHECK_ITERABLE_APPROX(
-      get<Tags::dt<ScalarWave::Pi>>(dt_vars).get(),
+      get<Tags::dt<ScalarWave::Tags::Pi>>(dt_vars).get(),
       DataVector({{2.943035529371539, 2.256418944442279, -0.3657814745019688,
                    -0.08547065575381531}}));
-  CHECK_ITERABLE_APPROX(get<Tags::dt<ScalarWave::Phi<3>>>(dt_vars).get(0),
+  CHECK_ITERABLE_APPROX(get<Tags::dt<ScalarWave::Tags::Phi<3>>>(dt_vars).get(0),
                         DataVector({{0., 1.670318500002785, -0.5541022431327671,
                                      -0.09361569118951865}}));
-  CHECK_ITERABLE_APPROX(get<Tags::dt<ScalarWave::Phi<3>>>(dt_vars).get(1),
+  CHECK_ITERABLE_APPROX(get<Tags::dt<ScalarWave::Tags::Phi<3>>>(dt_vars).get(1),
                         DataVector({{0., 0., 0., 0.}}));
-  CHECK_ITERABLE_APPROX(get<Tags::dt<ScalarWave::Phi<3>>>(dt_vars).get(2),
+  CHECK_ITERABLE_APPROX(get<Tags::dt<ScalarWave::Tags::Phi<3>>>(dt_vars).get(2),
                         DataVector({{0., 0., 0., 0.}}));
 
   const auto created_solution =
@@ -85,9 +88,8 @@ SPECTRE_TEST_CASE("Unit.AnalyticSolutions.WaveEquation.RegularSphericalWave",
           "    Amplitude: 1.\n"
           "    Width: 1.\n"
           "    Center: 0.\n");
-  CHECK(
-      created_solution.variables(
-          x, 1.,
-          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<3>, ScalarWave::Psi>{}) ==
-      vars);
+  CHECK(created_solution.variables(
+            x, 1.,
+            tmpl::list<ScalarWave::Tags::Pi, ScalarWave::Tags::Phi<3>,
+                       ScalarWave::Tags::Psi>{}) == vars);
 }


### PR DESCRIPTION
The tags for the evolved variables of the `ScalarWave` system are currently not in the `Tags` namespace so I moved them there. I am planning to do the same for `CurvedScalarWave` very soon.