### PR TITLE
Move CurvedScalarWave evolved variables into Tags namespace

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.hpp
@@ -132,17 +132,19 @@ class ConstraintPreservingSphericalRadiation final
 
   void pup(PUP::er& p) override;
 
-  using dg_interior_evolved_variables_tags = tmpl::list<Phi<Dim>, Psi>;
+  using dg_interior_evolved_variables_tags =
+      tmpl::list<Tags::Phi<Dim>, Tags::Psi>;
   using dg_interior_temporary_tags =
       tmpl::list<domain::Tags::Coordinates<Dim, Frame::Inertial>,
                  Tags::ConstraintGamma1, Tags::ConstraintGamma2,
                  gr::Tags::Lapse<DataVector>,
                  gr::Tags::Shift<Dim, Frame::Inertial, DataVector>>;
   using dg_interior_dt_vars_tags =
-      tmpl::list<::Tags::dt<Pi>, ::Tags::dt<Phi<Dim>>, ::Tags::dt<Psi>>;
-  using dg_interior_deriv_vars_tags =
-      tmpl::list<::Tags::deriv<Psi, tmpl::size_t<Dim>, Frame::Inertial>,
-                 ::Tags::deriv<Phi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>>;
+      tmpl::list<::Tags::dt<Tags::Pi>, ::Tags::dt<Tags::Phi<Dim>>,
+                 ::Tags::dt<Tags::Psi>>;
+  using dg_interior_deriv_vars_tags = tmpl::list<
+      ::Tags::deriv<Tags::Psi, tmpl::size_t<Dim>, Frame::Inertial>,
+      ::Tags::deriv<Tags::Phi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>>;
   using dg_gridless_tags = tmpl::list<>;
 
   std::optional<std::string> dg_time_derivative(

--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryCorrections/UpwindPenalty.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryCorrections/UpwindPenalty.cpp
@@ -200,8 +200,10 @@ void UpwindPenalty<Dim>::dg_boundary_terms(
       weighted_char_fields_int{};
   Variables<CurvedScalarWave_detail::char_field_tags<Dim>>
       weighted_char_fields_ext{};
-  Variables<tmpl::list<Psi, Pi, Phi<Dim>>> weighted_evolved_fields_int{};
-  Variables<tmpl::list<Psi, Pi, Phi<Dim>>> weighted_evolved_fields_ext{};
+  Variables<tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<Dim>>>
+      weighted_evolved_fields_int{};
+  Variables<tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<Dim>>>
+      weighted_evolved_fields_ext{};
 
   // Set memory refs
   get(get<Tags::VPsi>(weighted_char_fields_int))
@@ -238,14 +240,14 @@ void UpwindPenalty<Dim>::dg_boundary_terms(
       .set_data_ref(
           make_not_null(&get(get<::Tags::TempScalar<5, DataVector>>(buffer))));
 
-  get(get<Psi>(weighted_evolved_fields_int))
+  get(get<Tags::Psi>(weighted_evolved_fields_int))
       .set_data_ref(
           make_not_null(&get(get<::Tags::TempScalar<6, DataVector>>(buffer))));
-  get(get<Pi>(weighted_evolved_fields_int))
+  get(get<Tags::Pi>(weighted_evolved_fields_int))
       .set_data_ref(
           make_not_null(&get(get<::Tags::TempScalar<7, DataVector>>(buffer))));
   for (size_t i = 0; i < Dim; ++i) {
-    get<Phi<Dim>>(weighted_evolved_fields_int)
+    get<Tags::Phi<Dim>>(weighted_evolved_fields_int)
         .get(i)
         .set_data_ref(make_not_null(
             &get<::Tags::Tempi<2, Dim, Frame::Inertial, DataVector>>(buffer)
@@ -266,14 +268,14 @@ void UpwindPenalty<Dim>::dg_boundary_terms(
       get<Tags::VMinus>(weighted_char_fields_int), interface_unit_normal_int);
 
   // Set memory refs
-  get(get<Psi>(weighted_evolved_fields_ext))
+  get(get<Tags::Psi>(weighted_evolved_fields_ext))
       .set_data_ref(
           make_not_null(&get(get<::Tags::TempScalar<0, DataVector>>(buffer))));
-  get(get<Pi>(weighted_evolved_fields_ext))
+  get(get<Tags::Pi>(weighted_evolved_fields_ext))
       .set_data_ref(
           make_not_null(&get(get<::Tags::TempScalar<1, DataVector>>(buffer))));
   for (size_t i = 0; i < Dim; ++i) {
-    get<Phi<Dim>>(weighted_evolved_fields_ext)
+    get<Tags::Phi<Dim>>(weighted_evolved_fields_ext)
         .get(i)
         .set_data_ref(make_not_null(
             &get<::Tags::Tempi<0, Dim, Frame::Inertial, DataVector>>(buffer)
@@ -287,14 +289,16 @@ void UpwindPenalty<Dim>::dg_boundary_terms(
       get<Tags::VPlus>(weighted_char_fields_ext),
       get<Tags::VMinus>(weighted_char_fields_ext), interface_unit_normal_ext);
 
-  get(*psi_boundary_correction) = get(get<Psi>(weighted_evolved_fields_ext)) -
-                                  get(get<Psi>(weighted_evolved_fields_int));
-  get(*pi_boundary_correction) = get(get<Pi>(weighted_evolved_fields_ext)) -
-                                 get(get<Pi>(weighted_evolved_fields_int));
+  get(*psi_boundary_correction) =
+      get(get<Tags::Psi>(weighted_evolved_fields_ext)) -
+      get(get<Tags::Psi>(weighted_evolved_fields_int));
+  get(*pi_boundary_correction) =
+      get(get<Tags::Pi>(weighted_evolved_fields_ext)) -
+      get(get<Tags::Pi>(weighted_evolved_fields_int));
   for (size_t i = 0; i < Dim; ++i) {
     phi_boundary_correction->get(i) =
-        get<Phi<Dim>>(weighted_evolved_fields_ext).get(i) -
-        get<Phi<Dim>>(weighted_evolved_fields_int).get(i);
+        get<Tags::Phi<Dim>>(weighted_evolved_fields_ext).get(i) -
+        get<Tags::Phi<Dim>>(weighted_evolved_fields_int).get(i);
   }
 }
 

--- a/src/Evolution/Systems/CurvedScalarWave/Characteristics.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Characteristics.cpp
@@ -128,42 +128,44 @@ characteristic_fields(
 
 template <size_t SpatialDim>
 void evolved_fields_from_characteristic_fields(
-    const gsl::not_null<Variables<tmpl::list<Psi, Pi, Phi<SpatialDim>>>*>
+    const gsl::not_null<
+        Variables<tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<SpatialDim>>>*>
         evolved_fields,
     const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& v_psi,
     const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& v_zero,
     const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,
     const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&
         unit_normal_one_form) {
-  if (UNLIKELY(get_size(get(get<Psi>(*evolved_fields))) !=
+  if (UNLIKELY(get_size(get(get<Tags::Psi>(*evolved_fields))) !=
                get_size(get(gamma_2)))) {
     *evolved_fields =
-        Variables<tmpl::list<Psi, Pi, Phi<SpatialDim>>>(get_size(get(gamma_2)));
+        Variables<tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<SpatialDim>>>(
+            get_size(get(gamma_2)));
   }
   // Eq.(36) of Holst+ (2005) for Psi
-  get<Psi>(*evolved_fields) = v_psi;
+  get<Tags::Psi>(*evolved_fields) = v_psi;
 
   // Eq.(37) - (38) of Holst+ (2004) for Pi and Phi
-  get<Pi>(*evolved_fields).get() =
+  get<Tags::Pi>(*evolved_fields).get() =
       0.5 * (get(v_plus) + get(v_minus)) + get(gamma_2) * get(v_psi);
   for (size_t i = 0; i < SpatialDim; ++i) {
-    get<Phi<SpatialDim>>(*evolved_fields).get(i) =
+    get<Tags::Phi<SpatialDim>>(*evolved_fields).get(i) =
         0.5 * (get(v_plus) - get(v_minus)) * unit_normal_one_form.get(i) +
         v_zero.get(i);
   }
 }
 
 template <size_t SpatialDim>
-Variables<tmpl::list<Psi, Pi, Phi<SpatialDim>>>
+Variables<tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<SpatialDim>>>
 evolved_fields_from_characteristic_fields(
     const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& v_psi,
     const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& v_zero,
     const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,
     const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&
         unit_normal_one_form) {
-  auto evolved_fields =
-      make_with_value<Variables<tmpl::list<Psi, Pi, Phi<SpatialDim>>>>(
-          get(gamma_2), std::numeric_limits<double>::signaling_NaN());
+  auto evolved_fields = make_with_value<
+      Variables<tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<SpatialDim>>>>(
+      get(gamma_2), std::numeric_limits<double>::signaling_NaN());
   evolved_fields_from_characteristic_fields(make_not_null(&evolved_fields),
                                             gamma_2, v_psi, v_zero, v_plus,
                                             v_minus, unit_normal_one_form);
@@ -234,17 +236,18 @@ void ComputeLargestCharacteristicSpeed<SpatialDim>::function(
           unit_normal_one_form);                                              \
   template struct CurvedScalarWave::CharacteristicFieldsCompute<DIM(data)>;   \
   template void CurvedScalarWave::evolved_fields_from_characteristic_fields(  \
-      const gsl::not_null<                                                    \
-          Variables<tmpl::list<CurvedScalarWave::Psi, CurvedScalarWave::Pi,   \
-                               CurvedScalarWave::Phi<DIM(data)>>>*>           \
+      const gsl::not_null<Variables<                                          \
+          tmpl::list<CurvedScalarWave::Tags::Psi, CurvedScalarWave::Tags::Pi, \
+                     CurvedScalarWave::Tags::Phi<DIM(data)>>>*>               \
           evolved_fields,                                                     \
       const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& v_psi,     \
       const tnsr::i<DataVector, DIM(data), Frame::Inertial>& v_zero,          \
       const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,    \
       const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                  \
           unit_normal_one_form);                                              \
-  template Variables<tmpl::list<CurvedScalarWave::Psi, CurvedScalarWave::Pi,  \
-                                CurvedScalarWave::Phi<DIM(data)>>>            \
+  template Variables<                                                         \
+      tmpl::list<CurvedScalarWave::Tags::Psi, CurvedScalarWave::Tags::Pi,     \
+                 CurvedScalarWave::Tags::Phi<DIM(data)>>>                     \
   CurvedScalarWave::evolved_fields_from_characteristic_fields(                \
       const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& v_psi,     \
       const tnsr::i<DataVector, DIM(data), Frame::Inertial>& v_zero,          \

--- a/src/Evolution/Systems/CurvedScalarWave/Characteristics.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Characteristics.hpp
@@ -170,7 +170,7 @@ struct CharacteristicFieldsCompute : Tags::CharacteristicFields<SpatialDim>,
   using argument_tags = tmpl::list<
       Tags::ConstraintGamma2,
       gr::Tags::InverseSpatialMetric<SpatialDim, Frame::Inertial, DataVector>,
-      Psi, Pi, Phi<SpatialDim>,
+      Tags::Psi, Tags::Pi, Tags::Phi<SpatialDim>,
       ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<SpatialDim>>>;
 
   static constexpr void function(
@@ -193,7 +193,7 @@ struct CharacteristicFieldsCompute : Tags::CharacteristicFields<SpatialDim>,
  * characteristic ones, see \ref CharacteristicFieldsCompute.
  */
 template <size_t SpatialDim>
-Variables<tmpl::list<Psi, Pi, Phi<SpatialDim>>>
+Variables<tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<SpatialDim>>>
 evolved_fields_from_characteristic_fields(
     const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& v_psi,
     const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& v_zero,
@@ -203,7 +203,8 @@ evolved_fields_from_characteristic_fields(
 
 template <size_t SpatialDim>
 void evolved_fields_from_characteristic_fields(
-    gsl::not_null<Variables<tmpl::list<Psi, Pi, Phi<SpatialDim>>>*>
+    gsl::not_null<
+        Variables<tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<SpatialDim>>>*>
         evolved_fields,
     const Scalar<DataVector>& gamma_2, const Scalar<DataVector>& v_psi,
     const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& v_zero,

--- a/src/Evolution/Systems/CurvedScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Equations.hpp
@@ -52,7 +52,7 @@ template <size_t Dim>
 struct ComputeNormalDotFluxes {
  public:
   using argument_tags =
-      tmpl::list<Pi, Phi<Dim>, Psi, Tags::ConstraintGamma1,
+      tmpl::list<Tags::Pi, Tags::Phi<Dim>, Tags::Psi, Tags::ConstraintGamma1,
                  Tags::ConstraintGamma2, gr::Tags::Lapse<>,
                  gr::Tags::Shift<Dim>, gr::Tags::InverseSpatialMetric<Dim>,
                  ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<

--- a/src/Evolution/Systems/CurvedScalarWave/System.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/System.hpp
@@ -29,9 +29,10 @@ struct System {
 
   using boundary_correction_base = BoundaryCorrections::BoundaryCorrection<Dim>;
 
-  using variables_tag = ::Tags::Variables<tmpl::list<Pi, Phi<Dim>, Psi>>;
+  using variables_tag =
+      ::Tags::Variables<tmpl::list<Tags::Pi, Tags::Phi<Dim>, Tags::Psi>>;
   using flux_variables = tmpl::list<>;
-  using gradient_variables = tmpl::list<Pi, Phi<Dim>, Psi>;
+  using gradient_variables = tmpl::list<Tags::Pi, Tags::Phi<Dim>, Tags::Psi>;
 
   // Relic alias: needs to be removed once all evolution systems
   // convert to using dg::ComputeTimeDerivative

--- a/src/Evolution/Systems/CurvedScalarWave/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Tags.hpp
@@ -19,7 +19,7 @@ template <class>
 class Variables;
 /// \endcond
 
-namespace CurvedScalarWave {
+namespace CurvedScalarWave::Tags {
 struct Psi : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
@@ -33,7 +33,6 @@ struct Phi : db::SimpleTag {
   using type = tnsr::i<DataVector, SpatialDim>;
 };
 
-namespace Tags {
 struct ConstraintGamma1 : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
@@ -104,5 +103,4 @@ template <size_t Dim>
 struct EvolvedFieldsFromCharacteristicFields : db::SimpleTag {
   using type = Variables<tmpl::list<Psi, Pi, Phi<Dim>>>;
 };
-}  // namespace Tags
-}  // namespace CurvedScalarWave
+}  // namespace CurvedScalarWave::Tags

--- a/src/Evolution/Systems/CurvedScalarWave/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/TagsDeclarations.hpp
@@ -7,14 +7,13 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 
-namespace CurvedScalarWave {
+/// \brief Tags for the curved scalar wave system
+namespace CurvedScalarWave::Tags {
 struct Psi;
 struct Pi;
 template <size_t Dim>
 struct Phi;
 
-/// \brief Tags for the curved scalar wave system
-namespace Tags {
 struct ConstraintGamma1;
 struct ConstraintGamma2;
 
@@ -31,5 +30,4 @@ template <size_t Dim>
 struct CharacteristicFields;
 template <size_t Dim>
 struct EvolvedFieldsFromCharacteristicFields;
-}  // namespace Tags
-}  // namespace CurvedScalarWave
+}  // namespace CurvedScalarWave::Tags

--- a/src/Evolution/Systems/CurvedScalarWave/TimeDerivative.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/TimeDerivative.hpp
@@ -59,7 +59,7 @@ struct TimeDerivative {
       Tags::ConstraintGamma1, Tags::ConstraintGamma2>;
 
   using argument_tags = tmpl::list<
-      Pi, Phi<Dim>, gr::Tags::Lapse<DataVector>,
+      Tags::Pi, Tags::Phi<Dim>, gr::Tags::Lapse<DataVector>,
       gr::Tags::Shift<Dim, Frame::Inertial, DataVector>,
       ::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<Dim>,
                     Frame::Inertial>,

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/PureSphericalHarmonic.cpp
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/PureSphericalHarmonic.cpp
@@ -38,12 +38,12 @@ PureSphericalHarmonic::PureSphericalHarmonic(const double radius,
   }
 }
 
-tuples::TaggedTuple<CurvedScalarWave::Pi, CurvedScalarWave::Phi<3>,
-                    CurvedScalarWave::Psi>
+tuples::TaggedTuple<CurvedScalarWave::Tags::Pi, CurvedScalarWave::Tags::Phi<3>,
+                    CurvedScalarWave::Tags::Psi>
 PureSphericalHarmonic::variables(
     const tnsr::I<DataVector, 3>& x, double /*t*/,
-    tmpl::list<CurvedScalarWave::Pi, CurvedScalarWave::Phi<3>,
-               CurvedScalarWave::Psi> /*meta*/) const {
+    tmpl::list<CurvedScalarWave::Tags::Pi, CurvedScalarWave::Tags::Phi<3>,
+               CurvedScalarWave::Tags::Psi> /*meta*/) const {
   Scalar<DataVector> pi{get(magnitude(x)) - radius_};
   get(pi) = exp(-get(pi) * get(pi) / width_sq_);
   const Spectral::Swsh::SpinWeightedSphericalHarmonic spherical_harmonic(
@@ -52,8 +52,9 @@ PureSphericalHarmonic::variables(
   const auto phi = atan2(x[1], x[0]);
   get(pi) *= real(spherical_harmonic.evaluate(theta, phi, sin(theta / 2.),
                                               cos(theta / 2.)));
-  return tuples::TaggedTuple<CurvedScalarWave::Pi, CurvedScalarWave::Phi<3>,
-                             CurvedScalarWave::Psi>{
+  return tuples::TaggedTuple<CurvedScalarWave::Tags::Pi,
+                             CurvedScalarWave::Tags::Phi<3>,
+                             CurvedScalarWave::Tags::Psi>{
       std::move(pi), make_with_value<tnsr::i<DataVector, 3>>(x, 0.),
       make_with_value<Scalar<DataVector>>(x, 0.)};
 }

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/PureSphericalHarmonic.hpp
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/PureSphericalHarmonic.hpp
@@ -75,11 +75,13 @@ class PureSphericalHarmonic : public MarkAsAnalyticData {
                         const Options::Context& context = {});
 
   /// Retrieve the evolution variables at spatial coordinates `x`
-  tuples::TaggedTuple<CurvedScalarWave::Pi, CurvedScalarWave::Phi<3>,
-                      CurvedScalarWave::Psi>
-  variables(const tnsr::I<DataVector, 3>& x, double /*t*/,
-            tmpl::list<CurvedScalarWave::Pi, CurvedScalarWave::Phi<3>,
-                       CurvedScalarWave::Psi> /*meta*/) const;
+  tuples::TaggedTuple<CurvedScalarWave::Tags::Pi,
+                      CurvedScalarWave::Tags::Phi<3>,
+                      CurvedScalarWave::Tags::Psi>
+  variables(
+      const tnsr::I<DataVector, 3>& x, double /*t*/,
+      tmpl::list<CurvedScalarWave::Tags::Pi, CurvedScalarWave::Tags::Phi<3>,
+                 CurvedScalarWave::Tags::Psi> /*meta*/) const;
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/);

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveGr.hpp
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveGr.hpp
@@ -88,8 +88,9 @@ class ScalarWaveGr : public MarkAsAnalyticData {
   // Tags
   template <typename DataType>
   using spacetime_tags = typename BackgroundGrData::template tags<DataType>;
-  using tags = tmpl::append<spacetime_tags<DataVector>,
-                            tmpl::list<Pi, Phi<volume_dim>, Psi>>;
+  using tags =
+      tmpl::append<spacetime_tags<DataVector>,
+                   tmpl::list<Tags::Pi, Tags::Phi<volume_dim>, Tags::Psi>>;
 
   /// Retrieve spacetime variables
   template <
@@ -103,12 +104,13 @@ class ScalarWaveGr : public MarkAsAnalyticData {
   }
 
   /// Retrieve scalar wave variables
-  tuples::TaggedTuple<Pi> variables(const tnsr::I<DataVector, volume_dim>& x,
-                                    tmpl::list<Pi> /*meta*/) const;
-
-  tuples::TaggedTuple<Phi<volume_dim>> variables(
+  tuples::TaggedTuple<Tags::Pi> variables(
       const tnsr::I<DataVector, volume_dim>& x,
-      tmpl::list<Phi<volume_dim>> /*meta*/) const {
+      tmpl::list<Tags::Pi> /*meta*/) const;
+
+  tuples::TaggedTuple<Tags::Phi<volume_dim>> variables(
+      const tnsr::I<DataVector, volume_dim>& x,
+      tmpl::list<Tags::Phi<volume_dim>> /*meta*/) const {
     constexpr double default_initial_time = 0.;
     return {std::move(
         get<ScalarWave::Phi<volume_dim>>(flat_space_scalar_wave_data_.variables(
@@ -116,8 +118,9 @@ class ScalarWaveGr : public MarkAsAnalyticData {
             tmpl::list<ScalarWave::Pi, ScalarWave::Phi<volume_dim>,
                        ScalarWave::Psi>{})))};
   }
-  tuples::TaggedTuple<Psi> variables(const tnsr::I<DataVector, volume_dim>& x,
-                                     tmpl::list<Psi> /*meta*/) const {
+  tuples::TaggedTuple<Tags::Psi> variables(
+      const tnsr::I<DataVector, volume_dim>& x,
+      tmpl::list<Tags::Psi> /*meta*/) const {
     constexpr double default_initial_time = 0.;
     return {
         std::move(get<ScalarWave::Psi>(flat_space_scalar_wave_data_.variables(

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveGr.tpp
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveGr.tpp
@@ -22,10 +22,10 @@ void ScalarWaveGr<ScalarFieldData, BackgroundGrData>::pup(PUP::er& p) {
 }
 
 template <typename ScalarFieldData, typename BackgroundGrData>
-tuples::TaggedTuple<Pi>
+tuples::TaggedTuple<Tags::Pi>
 ScalarWaveGr<ScalarFieldData, BackgroundGrData>::variables(
-    const tnsr::I<DataVector, volume_dim>& x, tmpl::list<Pi> /*meta*/) const
-    {
+    const tnsr::I<DataVector, volume_dim>& x,
+    tmpl::list<Tags::Pi> /*meta*/) const {
   constexpr double default_initial_time = 0.;
   const auto flat_space_scalar_wave_vars =
       flat_space_scalar_wave_data_.variables(
@@ -34,14 +34,14 @@ ScalarWaveGr<ScalarFieldData, BackgroundGrData>::variables(
                      ScalarWave::Psi>{});
   const auto spacetime_variables = background_gr_data_.variables(
       x, default_initial_time, spacetime_tags<DataVector>{});
-  auto result = make_with_value<tuples::TaggedTuple<Pi>>(x, 0.);
+  auto result = make_with_value<tuples::TaggedTuple<Tags::Pi>>(x, 0.);
 
   const auto shift_dot_dpsi = dot_product(
       get<gr::Tags::Shift<volume_dim, Frame::Inertial, DataVector>>(
           spacetime_variables),
       get<ScalarWave::Phi<volume_dim>>(flat_space_scalar_wave_vars));
 
-  get(get<Pi>(result)) =
+  get(get<Tags::Pi>(result)) =
       (get(shift_dot_dpsi) +
        get(get<ScalarWave::Pi>(flat_space_scalar_wave_vars))) /
       get(get<gr::Tags::Lapse<DataVector>>(spacetime_variables));
@@ -52,15 +52,13 @@ ScalarWaveGr<ScalarFieldData, BackgroundGrData>::variables(
 template <typename LocalScalarFieldData, typename LocalBackgroundData>
 bool operator==(
     const ScalarWaveGr<LocalScalarFieldData, LocalBackgroundData>& lhs,
-    const ScalarWaveGr<LocalScalarFieldData, LocalBackgroundData>&
-        rhs) {
+    const ScalarWaveGr<LocalScalarFieldData, LocalBackgroundData>& rhs) {
   return lhs.background_gr_data_ == rhs.background_gr_data_;
 }
 
 template <typename ScalarFieldData, typename BackgroundData>
-bool operator!=(
-    const ScalarWaveGr<ScalarFieldData, BackgroundData>& lhs,
-    const ScalarWaveGr<ScalarFieldData, BackgroundData>& rhs) {
+bool operator!=(const ScalarWaveGr<ScalarFieldData, BackgroundData>& lhs,
+                const ScalarWaveGr<ScalarFieldData, BackgroundData>& rhs) {
   return not(lhs == rhs);
 }
 }  // namespace CurvedScalarWave::AnalyticData

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/BoundaryConditions/Test_ConstraintPreservingSphericalRadiation.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/BoundaryConditions/Test_ConstraintPreservingSphericalRadiation.cpp
@@ -38,12 +38,13 @@ void test() {
       make_not_null(&gen),
       "Evolution.Systems.CurvedScalarWave.BoundaryConditions."
       "ConstraintPreservingSphericalRadiation",
-      tuples::TaggedTuple<
-          helpers::Tags::PythonFunctionForErrorMessage<>,
-          helpers::Tags::PythonFunctionName<::Tags::dt<CurvedScalarWave::Pi>>,
-          helpers::Tags::PythonFunctionName<
-              ::Tags::dt<CurvedScalarWave::Phi<Dim>>>,
-          helpers::Tags::PythonFunctionName<::Tags::dt<CurvedScalarWave::Psi>>>{
+      tuples::TaggedTuple<helpers::Tags::PythonFunctionForErrorMessage<>,
+                          helpers::Tags::PythonFunctionName<
+                              ::Tags::dt<CurvedScalarWave::Tags::Pi>>,
+                          helpers::Tags::PythonFunctionName<
+                              ::Tags::dt<CurvedScalarWave::Tags::Phi<Dim>>>,
+                          helpers::Tags::PythonFunctionName<
+                              ::Tags::dt<CurvedScalarWave::Tags::Psi>>>{
           "error", "dt_pi_constraint_preserving_spherical_radiation",
           "dt_phi_constraint_preserving_spherical_radiation",
           "dt_psi_constraint_preserving_spherical_radiation"},

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_Characteristics.cpp
@@ -126,15 +126,16 @@ void test_evolved_from_characteristic_fields() {
   const DataVector used_for_size(5);
   // Psi
   pypp::check_with_random_values<1>(
-      evolved_field_with_tag<CurvedScalarWave::Psi, SpatialDim>,
+      evolved_field_with_tag<CurvedScalarWave::Tags::Psi, SpatialDim>,
       "Characteristics", "evol_field_psi", {{{-2.0, 2.0}}}, used_for_size);
   // Pi
   pypp::check_with_random_values<1>(
-      evolved_field_with_tag<CurvedScalarWave::Pi, SpatialDim>,
+      evolved_field_with_tag<CurvedScalarWave::Tags::Pi, SpatialDim>,
       "Characteristics", "evol_field_pi", {{{-2.0, 2.0}}}, used_for_size);
   // Phi
   pypp::check_with_random_values<1>(
-      evolved_field_with_tag<CurvedScalarWave::Phi<SpatialDim>, SpatialDim>,
+      evolved_field_with_tag<CurvedScalarWave::Tags::Phi<SpatialDim>,
+                             SpatialDim>,
       "Characteristics", "evol_field_phi", {{{-2.0, 2.0}}}, used_for_size);
 }
 
@@ -190,8 +191,8 @@ void test_characteristics_compute_tags() {
           gr::Tags::Shift<SpatialDim, Frame::Inertial, DataVector>,
           gr::Tags::InverseSpatialMetric<SpatialDim, Frame::Inertial,
                                          DataVector>,
-          CurvedScalarWave::Psi, CurvedScalarWave::Pi,
-          CurvedScalarWave::Phi<SpatialDim>,
+          CurvedScalarWave::Tags::Psi, CurvedScalarWave::Tags::Pi,
+          CurvedScalarWave::Tags::Phi<SpatialDim>,
           ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<SpatialDim>>>,
       db::AddComputeTags<
           CurvedScalarWave::CharacteristicSpeedsCompute<SpatialDim>,

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_Constraints.cpp
@@ -62,10 +62,10 @@ void test_constraint_compute_items(const DataVector& used_for_size) {
   // Insert into databox
   const auto box = db::create<
       db::AddSimpleTags<
-          CurvedScalarWave::Phi<SpatialDim>,
-          ::Tags::deriv<CurvedScalarWave::Phi<SpatialDim>,
+          CurvedScalarWave::Tags::Phi<SpatialDim>,
+          ::Tags::deriv<CurvedScalarWave::Tags::Phi<SpatialDim>,
                         tmpl::size_t<SpatialDim>, Frame::Inertial>,
-          ::Tags::deriv<CurvedScalarWave::Psi, tmpl::size_t<SpatialDim>,
+          ::Tags::deriv<CurvedScalarWave::Tags::Psi, tmpl::size_t<SpatialDim>,
                         Frame::Inertial>>,
       db::AddComputeTags<
           CurvedScalarWave::Tags::OneIndexConstraintCompute<SpatialDim>,

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_Tags.cpp
@@ -8,9 +8,9 @@
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Tags",
                   "[Unit][Evolution]") {
-  TestHelpers::db::test_simple_tag<CurvedScalarWave::Psi>("Psi");
-  TestHelpers::db::test_simple_tag<CurvedScalarWave::Pi>("Pi");
-  TestHelpers::db::test_simple_tag<CurvedScalarWave::Phi<3>>("Phi");
+  TestHelpers::db::test_simple_tag<CurvedScalarWave::Tags::Psi>("Psi");
+  TestHelpers::db::test_simple_tag<CurvedScalarWave::Tags::Pi>("Pi");
+  TestHelpers::db::test_simple_tag<CurvedScalarWave::Tags::Phi<3>>("Phi");
   TestHelpers::db::test_simple_tag<CurvedScalarWave::Tags::ConstraintGamma1>(
       "ConstraintGamma1");
   TestHelpers::db::test_simple_tag<CurvedScalarWave::Tags::ConstraintGamma2>(

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_TimeDerivative.cpp
@@ -86,8 +86,8 @@ Scalar<DataVector> make_trace_extrinsic_curvature(
 }
 
 template <size_t Dim>
-Variables<tmpl::list<CurvedScalarWave::Psi, CurvedScalarWave::Pi,
-                     CurvedScalarWave::Phi<Dim>>>
+Variables<tmpl::list<CurvedScalarWave::Tags::Psi, CurvedScalarWave::Tags::Pi,
+                     CurvedScalarWave::Tags::Phi<Dim>>>
 calculate_du_dt(const DataVector& used_for_size) {
   auto dt_psi = make_with_value<Scalar<DataVector>>(used_for_size, 0.);
   auto dt_pi = make_with_value<Scalar<DataVector>>(used_for_size, 0.);
@@ -116,13 +116,13 @@ calculate_du_dt(const DataVector& used_for_size) {
       make_trace_extrinsic_curvature(used_for_size),
       make_constraint_gamma1(used_for_size),
       make_constraint_gamma2(used_for_size));
-  Variables<tmpl::list<CurvedScalarWave::Psi, CurvedScalarWave::Pi,
-                       CurvedScalarWave::Phi<Dim>>>
+  Variables<tmpl::list<CurvedScalarWave::Tags::Psi, CurvedScalarWave::Tags::Pi,
+                       CurvedScalarWave::Tags::Phi<Dim>>>
       vars(used_for_size.size(), 0.);
 
-  get<CurvedScalarWave::Psi>(vars) = dt_psi;
-  get<CurvedScalarWave::Pi>(vars) = dt_pi;
-  get<CurvedScalarWave::Phi<Dim>>(vars) = dt_phi;
+  get<CurvedScalarWave::Tags::Psi>(vars) = dt_psi;
+  get<CurvedScalarWave::Tags::Pi>(vars) = dt_pi;
+  get<CurvedScalarWave::Tags::Phi<Dim>>(vars) = dt_phi;
   return vars;
 }
 template <size_t Dim>
@@ -131,9 +131,9 @@ void check_du_dt(const DataVector& used_for_size);
 template <>
 void check_du_dt<1>(const DataVector& used_for_size) {
   const auto vars = calculate_du_dt<1>(used_for_size);
-  const auto& dt_psi = get<CurvedScalarWave::Psi>(vars);
-  const auto& dt_pi = get<CurvedScalarWave::Pi>(vars);
-  const auto& dt_phi = get<CurvedScalarWave::Phi<1>>(vars);
+  const auto& dt_psi = get<CurvedScalarWave::Tags::Psi>(vars);
+  const auto& dt_pi = get<CurvedScalarWave::Tags::Pi>(vars);
+  const auto& dt_phi = get<CurvedScalarWave::Tags::Phi<1>>(vars);
   CHECK_ITERABLE_APPROX(dt_psi.get(), (DataVector{used_for_size.size(), 5.3}));
   CHECK_ITERABLE_APPROX(dt_pi.get(), (DataVector{used_for_size.size(), -22.5}));
   CHECK_ITERABLE_APPROX(dt_phi.get(0), (DataVector{used_for_size.size(), 4.}));
@@ -141,9 +141,9 @@ void check_du_dt<1>(const DataVector& used_for_size) {
 template <>
 void check_du_dt<2>(const DataVector& used_for_size) {
   const auto vars = calculate_du_dt<2>(used_for_size);
-  const auto& dt_psi = get<CurvedScalarWave::Psi>(vars);
-  const auto& dt_pi = get<CurvedScalarWave::Pi>(vars);
-  const auto& dt_phi = get<CurvedScalarWave::Phi<2>>(vars);
+  const auto& dt_psi = get<CurvedScalarWave::Tags::Psi>(vars);
+  const auto& dt_pi = get<CurvedScalarWave::Tags::Pi>(vars);
+  const auto& dt_phi = get<CurvedScalarWave::Tags::Phi<2>>(vars);
   CHECK_ITERABLE_APPROX(dt_psi.get(), (DataVector{used_for_size.size(), 68.3}));
   CHECK_ITERABLE_APPROX(dt_pi.get(),
                         (DataVector{used_for_size.size(), -272.15}));
@@ -155,9 +155,9 @@ void check_du_dt<2>(const DataVector& used_for_size) {
 template <>
 void check_du_dt<3>(const DataVector& used_for_size) {
   const auto vars = calculate_du_dt<3>(used_for_size);
-  const auto& dt_psi = get<CurvedScalarWave::Psi>(vars);
-  const auto& dt_pi = get<CurvedScalarWave::Pi>(vars);
-  const auto& dt_phi = get<CurvedScalarWave::Phi<3>>(vars);
+  const auto& dt_psi = get<CurvedScalarWave::Tags::Psi>(vars);
+  const auto& dt_pi = get<CurvedScalarWave::Tags::Pi>(vars);
+  const auto& dt_phi = get<CurvedScalarWave::Tags::Phi<3>>(vars);
   CHECK_ITERABLE_APPROX(dt_psi.get(),
                         (DataVector{used_for_size.size(), 255.8}));
   CHECK_ITERABLE_APPROX(dt_pi.get(),

--- a/tests/Unit/PointwiseFunctions/AnalyticData/CurvedWaveEquation/Test_PureSphericalHarmonic.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/CurvedWaveEquation/Test_PureSphericalHarmonic.cpp
@@ -59,10 +59,10 @@ void test_variables() {
           radius, width, {l, m}};
       const auto sh_res = sh.variables(x, 0., {});
 
-      CHECK_ITERABLE_APPROX(get<CurvedScalarWave::Pi>(sh_res), py_res);
-      CHECK(get<CurvedScalarWave::Phi<3>>(sh_res) ==
+      CHECK_ITERABLE_APPROX(get<CurvedScalarWave::Tags::Pi>(sh_res), py_res);
+      CHECK(get<CurvedScalarWave::Tags::Phi<3>>(sh_res) ==
             make_with_value<tnsr::i<DataVector, 3>>(dv_size, 0.));
-      CHECK(get<CurvedScalarWave::Psi>(sh_res) ==
+      CHECK(get<CurvedScalarWave::Tags::Psi>(sh_res) ==
             make_with_value<Scalar<DataVector>>(dv_size, 0.));
     }
   }

--- a/tests/Unit/PointwiseFunctions/AnalyticData/CurvedWaveEquation/Test_ScalarWaveGr.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/CurvedWaveEquation/Test_ScalarWaveGr.cpp
@@ -59,19 +59,19 @@ void test_no_hole(const CurvedScalarWave::AnalyticData::ScalarWaveGr<
       {DataVector({0., 1., 2., 3.}), DataVector({0., 0., 0., 0.}),
        DataVector({0., 0., 0., 0.})}}};
   auto vars = curved_wave_data.variables(
-      x, tmpl::list<CurvedScalarWave::Pi, CurvedScalarWave::Phi<3>,
-                    CurvedScalarWave::Psi>{});
+      x, tmpl::list<CurvedScalarWave::Tags::Pi, CurvedScalarWave::Tags::Phi<3>,
+                    CurvedScalarWave::Tags::Psi>{});
   auto flat_vars = flat_wave_solution.variables(
       x, 0., tmpl::list<ScalarWave::Pi, ScalarWave::Phi<3>, ScalarWave::Psi>{});
-  CHECK_ITERABLE_APPROX(get(get<CurvedScalarWave::Psi>(vars)),
+  CHECK_ITERABLE_APPROX(get(get<CurvedScalarWave::Tags::Psi>(vars)),
                         get(get<ScalarWave::Psi>(flat_vars)));
-  CHECK_ITERABLE_APPROX(get(get<CurvedScalarWave::Pi>(vars)),
+  CHECK_ITERABLE_APPROX(get(get<CurvedScalarWave::Tags::Pi>(vars)),
                         get(get<ScalarWave::Pi>(flat_vars)));
-  CHECK_ITERABLE_APPROX(get<0>(get<CurvedScalarWave::Phi<3>>(vars)),
+  CHECK_ITERABLE_APPROX(get<0>(get<CurvedScalarWave::Tags::Phi<3>>(vars)),
                         get<0>(get<ScalarWave::Phi<3>>(flat_vars)));
-  CHECK_ITERABLE_APPROX(get<1>(get<CurvedScalarWave::Phi<3>>(vars)),
+  CHECK_ITERABLE_APPROX(get<1>(get<CurvedScalarWave::Tags::Phi<3>>(vars)),
                         get<1>(get<ScalarWave::Phi<3>>(flat_vars)));
-  CHECK_ITERABLE_APPROX(get<2>(get<CurvedScalarWave::Phi<3>>(vars)),
+  CHECK_ITERABLE_APPROX(get<2>(get<CurvedScalarWave::Tags::Phi<3>>(vars)),
                         get<2>(get<ScalarWave::Phi<3>>(flat_vars)));
 }
 
@@ -85,8 +85,8 @@ void test_kerr(
       {DataVector({0., 1., 2., 3.}), DataVector({0., 0., 0., 0.}),
        DataVector({0., 0., 0., 0.})}}};
   auto vars = curved_wave_data.variables(
-      x, tmpl::list<CurvedScalarWave::Pi, CurvedScalarWave::Phi<3>,
-                    CurvedScalarWave::Psi>{});
+      x, tmpl::list<CurvedScalarWave::Tags::Pi, CurvedScalarWave::Tags::Phi<3>,
+                    CurvedScalarWave::Tags::Psi>{});
 
   const auto flat_wave_vars = flat_wave_solution.variables(
       x, 0., ScalarWave::System<3>::variables_tag::tags_list{});
@@ -107,13 +107,15 @@ void test_kerr(
         get(get<gr::Tags::Lapse<DataVector>>(kerr_variables));
   }
 
-  CHECK_ITERABLE_APPROX(get(get<CurvedScalarWave::Psi>(vars)), get(local_psi));
-  CHECK_ITERABLE_APPROX(get(get<CurvedScalarWave::Pi>(vars)), get(local_pi));
-  CHECK_ITERABLE_APPROX(get<0>(get<CurvedScalarWave::Phi<3>>(vars)),
+  CHECK_ITERABLE_APPROX(get(get<CurvedScalarWave::Tags::Psi>(vars)),
+                        get(local_psi));
+  CHECK_ITERABLE_APPROX(get(get<CurvedScalarWave::Tags::Pi>(vars)),
+                        get(local_pi));
+  CHECK_ITERABLE_APPROX(get<0>(get<CurvedScalarWave::Tags::Phi<3>>(vars)),
                         get<0>(local_phi));
-  CHECK_ITERABLE_APPROX(get<1>(get<CurvedScalarWave::Phi<3>>(vars)),
+  CHECK_ITERABLE_APPROX(get<1>(get<CurvedScalarWave::Tags::Phi<3>>(vars)),
                         get<1>(local_phi));
-  CHECK_ITERABLE_APPROX(get<2>(get<CurvedScalarWave::Phi<3>>(vars)),
+  CHECK_ITERABLE_APPROX(get<2>(get<CurvedScalarWave::Tags::Phi<3>>(vars)),
                         get<2>(local_phi));
 }
 


### PR DESCRIPTION
The evolved variables `Psi, Pi, Phi` tags were not in the `Tags` namespace. This PR moves them there.
