### PR TITLE
Make order of `CurvedScalarWave` evolved variables tags consistent

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.cpp
@@ -38,20 +38,21 @@ ConstraintPreservingSphericalRadiation<
 template <size_t Dim>
 std::optional<std::string>
 ConstraintPreservingSphericalRadiation<Dim>::dg_time_derivative(
+    const gsl::not_null<Scalar<DataVector>*> dt_psi_correction,
     const gsl::not_null<Scalar<DataVector>*> dt_pi_correction,
     const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
         dt_phi_correction,
-    const gsl::not_null<Scalar<DataVector>*> dt_psi_correction,
     const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
         face_mesh_velocity,
     const tnsr::i<DataVector, Dim>& normal_covector,
     const tnsr::I<DataVector, Dim>& normal_vector,
-    const tnsr::i<DataVector, Dim>& phi, const Scalar<DataVector>& psi,
+    const Scalar<DataVector>& psi, const tnsr::i<DataVector, Dim>& phi,
     const tnsr::I<DataVector, Dim, Frame::Inertial>& coords,
     const Scalar<DataVector>& gamma1, const Scalar<DataVector>& gamma2,
     const Scalar<DataVector>& lapse, const tnsr::I<DataVector, Dim>& shift,
-    const Scalar<DataVector>& dt_pi, const tnsr::i<DataVector, Dim>& dt_phi,
-    const Scalar<DataVector>& dt_psi, const tnsr::i<DataVector, Dim>& d_psi,
+    const Scalar<DataVector>& dt_psi, const Scalar<DataVector>& dt_pi,
+    const tnsr::i<DataVector, Dim>& dt_phi,
+    const tnsr::i<DataVector, Dim>& d_psi,
     const tnsr::ij<DataVector, Dim>& d_phi) const {
   Variables<tmpl::list<::Tags::Tempa<0, 3>, ::Tags::TempScalar<1>,
                        ::Tags::TempScalar<2>>>

--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.hpp
@@ -133,34 +133,35 @@ class ConstraintPreservingSphericalRadiation final
   void pup(PUP::er& p) override;
 
   using dg_interior_evolved_variables_tags =
-      tmpl::list<Tags::Phi<Dim>, Tags::Psi>;
+      tmpl::list<Tags::Psi, Tags::Phi<Dim>>;
   using dg_interior_temporary_tags =
       tmpl::list<domain::Tags::Coordinates<Dim, Frame::Inertial>,
                  Tags::ConstraintGamma1, Tags::ConstraintGamma2,
                  gr::Tags::Lapse<DataVector>,
                  gr::Tags::Shift<Dim, Frame::Inertial, DataVector>>;
   using dg_interior_dt_vars_tags =
-      tmpl::list<::Tags::dt<Tags::Pi>, ::Tags::dt<Tags::Phi<Dim>>,
-                 ::Tags::dt<Tags::Psi>>;
+      tmpl::list<::Tags::dt<Tags::Psi>, ::Tags::dt<Tags::Pi>,
+                 ::Tags::dt<Tags::Phi<Dim>>>;
   using dg_interior_deriv_vars_tags = tmpl::list<
       ::Tags::deriv<Tags::Psi, tmpl::size_t<Dim>, Frame::Inertial>,
       ::Tags::deriv<Tags::Phi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>>;
   using dg_gridless_tags = tmpl::list<>;
 
   std::optional<std::string> dg_time_derivative(
+      gsl::not_null<Scalar<DataVector>*> dt_psi_correction,
       gsl::not_null<Scalar<DataVector>*> dt_pi_correction,
       gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
           dt_phi_correction,
-      gsl::not_null<Scalar<DataVector>*> dt_psi_correction,
       const std::optional<tnsr::I<DataVector, Dim>>& face_mesh_velocity,
       const tnsr::i<DataVector, Dim>& normal_covector,
       const tnsr::I<DataVector, Dim>& normal_vector,
-      const tnsr::i<DataVector, Dim>& phi, const Scalar<DataVector>& psi,
+      const Scalar<DataVector>& psi, const tnsr::i<DataVector, Dim>& phi,
       const tnsr::I<DataVector, Dim, Frame::Inertial>& coords,
       const Scalar<DataVector>& gamma1, const Scalar<DataVector>& gamma2,
       const Scalar<DataVector>& lapse, const tnsr::I<DataVector, Dim>& shift,
-      const Scalar<DataVector>& dt_pi, const tnsr::i<DataVector, Dim>& dt_phi,
-      const Scalar<DataVector>& dt_psi, const tnsr::i<DataVector, Dim>& d_psi,
+      const Scalar<DataVector>& dt_psi, const Scalar<DataVector>& dt_pi,
+      const tnsr::i<DataVector, Dim>& dt_phi,
+      const tnsr::i<DataVector, Dim>& d_psi,
       const tnsr::ij<DataVector, Dim>& d_phi) const;
 };
 }  // namespace CurvedScalarWave::BoundaryConditions

--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryCorrections/UpwindPenalty.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryCorrections/UpwindPenalty.cpp
@@ -112,9 +112,8 @@ double UpwindPenalty<Dim>::dg_package_data(
     const gsl::not_null<tnsr::a<DataVector, 3, Frame::Inertial>*>
         packaged_char_speeds,
 
-    const Scalar<DataVector>& pi,
+    const Scalar<DataVector>& psi, const Scalar<DataVector>& pi,
     const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
-    const Scalar<DataVector>& psi,
 
     const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, Dim, Frame::Inertial>& shift,
@@ -166,10 +165,10 @@ double UpwindPenalty<Dim>::dg_package_data(
 
 template <size_t Dim>
 void UpwindPenalty<Dim>::dg_boundary_terms(
+    const gsl::not_null<Scalar<DataVector>*> psi_boundary_correction,
     const gsl::not_null<Scalar<DataVector>*> pi_boundary_correction,
     const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
         phi_boundary_correction,
-    const gsl::not_null<Scalar<DataVector>*> psi_boundary_correction,
 
     const Scalar<DataVector>& v_psi_int,
     const tnsr::i<DataVector, Dim, Frame::Inertial>& v_zero_int,

--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryCorrections/UpwindPenalty.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryCorrections/UpwindPenalty.hpp
@@ -134,9 +134,8 @@ class UpwindPenalty final : public BoundaryCorrection<Dim> {
       gsl::not_null<tnsr::a<DataVector, 3, Frame::Inertial>*>
           packaged_char_speeds,
 
-      const Scalar<DataVector>& pi,
+      const Scalar<DataVector>& psi, const Scalar<DataVector>& pi,
       const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
-      const Scalar<DataVector>& psi,
 
       const Scalar<DataVector>& lapse,
       const tnsr::I<DataVector, Dim, Frame::Inertial>& shift,
@@ -152,10 +151,10 @@ class UpwindPenalty final : public BoundaryCorrection<Dim> {
       const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity) const;
 
   void dg_boundary_terms(
+      gsl::not_null<Scalar<DataVector>*> psi_boundary_correction,
       gsl::not_null<Scalar<DataVector>*> pi_boundary_correction,
       gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
           phi_boundary_correction,
-      gsl::not_null<Scalar<DataVector>*> psi_boundary_correction,
 
       const Scalar<DataVector>& v_psi_int,
       const tnsr::i<DataVector, Dim, Frame::Inertial>& v_zero_int,

--- a/src/Evolution/Systems/CurvedScalarWave/Equations.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Equations.cpp
@@ -20,11 +20,11 @@ class Tensor;
 namespace CurvedScalarWave {
 template <size_t Dim>
 void ComputeNormalDotFluxes<Dim>::apply(
+    const gsl::not_null<Scalar<DataVector>*> psi_normal_dot_flux,
     const gsl::not_null<Scalar<DataVector>*> pi_normal_dot_flux,
     const gsl::not_null<tnsr::i<DataVector, Dim>*> phi_normal_dot_flux,
-    const gsl::not_null<Scalar<DataVector>*> psi_normal_dot_flux,
-    const Scalar<DataVector>& pi, const tnsr::i<DataVector, Dim>& phi,
-    const Scalar<DataVector>& psi, const Scalar<DataVector>& gamma1,
+    const Scalar<DataVector>& psi, const Scalar<DataVector>& pi,
+    const tnsr::i<DataVector, Dim>& phi, const Scalar<DataVector>& gamma1,
     const Scalar<DataVector>& gamma2, const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, Dim>& shift,
     const tnsr::II<DataVector, Dim>& inverse_spatial_metric,

--- a/src/Evolution/Systems/CurvedScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Equations.hpp
@@ -52,18 +52,18 @@ template <size_t Dim>
 struct ComputeNormalDotFluxes {
  public:
   using argument_tags =
-      tmpl::list<Tags::Pi, Tags::Phi<Dim>, Tags::Psi, Tags::ConstraintGamma1,
+      tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<Dim>, Tags::ConstraintGamma1,
                  Tags::ConstraintGamma2, gr::Tags::Lapse<>,
                  gr::Tags::Shift<Dim>, gr::Tags::InverseSpatialMetric<Dim>,
                  ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<
                      Dim, Frame::Inertial>>>;
 
   static void apply(
+      gsl::not_null<Scalar<DataVector>*> psi_normal_dot_flux,
       gsl::not_null<Scalar<DataVector>*> pi_normal_dot_flux,
       gsl::not_null<tnsr::i<DataVector, Dim>*> phi_normal_dot_flux,
-      gsl::not_null<Scalar<DataVector>*> psi_normal_dot_flux,
-      const Scalar<DataVector>& pi, const tnsr::i<DataVector, Dim>& phi,
-      const Scalar<DataVector>& psi, const Scalar<DataVector>& gamma1,
+      const Scalar<DataVector>& psi, const Scalar<DataVector>& pi,
+      const tnsr::i<DataVector, Dim>& phi, const Scalar<DataVector>& gamma1,
       const Scalar<DataVector>& gamma2, const Scalar<DataVector>& lapse,
       const tnsr::I<DataVector, Dim>& shift,
       const tnsr::II<DataVector, Dim>& inverse_spatial_metric,

--- a/src/Evolution/Systems/CurvedScalarWave/System.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/System.hpp
@@ -30,9 +30,9 @@ struct System {
   using boundary_correction_base = BoundaryCorrections::BoundaryCorrection<Dim>;
 
   using variables_tag =
-      ::Tags::Variables<tmpl::list<Tags::Pi, Tags::Phi<Dim>, Tags::Psi>>;
+      ::Tags::Variables<tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<Dim>>>;
   using flux_variables = tmpl::list<>;
-  using gradient_variables = tmpl::list<Tags::Pi, Tags::Phi<Dim>, Tags::Psi>;
+  using gradient_variables = tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<Dim>>;
 
   // Relic alias: needs to be removed once all evolution systems
   // convert to using dg::ComputeTimeDerivative

--- a/src/Evolution/Systems/CurvedScalarWave/TimeDerivative.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/TimeDerivative.cpp
@@ -17,9 +17,9 @@
 namespace CurvedScalarWave {
 template <size_t Dim>
 void TimeDerivative<Dim>::apply(
+    const gsl::not_null<Scalar<DataVector>*> dt_psi,
     const gsl::not_null<Scalar<DataVector>*> dt_pi,
     const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> dt_phi,
-    const gsl::not_null<Scalar<DataVector>*> dt_psi,
 
     const gsl::not_null<Scalar<DataVector>*> result_lapse,
     const gsl::not_null<tnsr::I<DataVector, Dim>*> result_shift,
@@ -28,9 +28,8 @@ void TimeDerivative<Dim>::apply(
     const gsl::not_null<Scalar<DataVector>*> result_gamma1,
     const gsl::not_null<Scalar<DataVector>*> result_gamma2,
 
-    const tnsr::i<DataVector, Dim>& d_pi,
-    const tnsr::ij<DataVector, Dim>& d_phi,
-    const tnsr::i<DataVector, Dim>& d_psi, const Scalar<DataVector>& pi,
+    const tnsr::i<DataVector, Dim>& d_psi, const tnsr::i<DataVector, Dim>& d_pi,
+    const tnsr::ij<DataVector, Dim>& d_phi, const Scalar<DataVector>& pi,
     const tnsr::i<DataVector, Dim>& phi, const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, Dim>& shift,
     const tnsr::i<DataVector, Dim>& deriv_lapse,

--- a/src/Evolution/Systems/CurvedScalarWave/TimeDerivative.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/TimeDerivative.hpp
@@ -72,9 +72,9 @@ struct TimeDerivative {
       Tags::ConstraintGamma2>;
 
   static void apply(
+      gsl::not_null<Scalar<DataVector>*> dt_psi,
       gsl::not_null<Scalar<DataVector>*> dt_pi,
       gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> dt_phi,
-      gsl::not_null<Scalar<DataVector>*> dt_psi,
 
       gsl::not_null<Scalar<DataVector>*> result_lapse,
       gsl::not_null<tnsr::I<DataVector, Dim>*> result_shift,
@@ -82,9 +82,9 @@ struct TimeDerivative {
       gsl::not_null<Scalar<DataVector>*> result_gamma1,
       gsl::not_null<Scalar<DataVector>*> result_gamma2,
 
+      const tnsr::i<DataVector, Dim>& d_psi,
       const tnsr::i<DataVector, Dim>& d_pi,
-      const tnsr::ij<DataVector, Dim>& d_phi,
-      const tnsr::i<DataVector, Dim>& d_psi, const Scalar<DataVector>& pi,
+      const tnsr::ij<DataVector, Dim>& d_phi, const Scalar<DataVector>& pi,
       const tnsr::i<DataVector, Dim>& phi, const Scalar<DataVector>& lapse,
       const tnsr::I<DataVector, Dim>& shift,
       const tnsr::i<DataVector, Dim>& deriv_lapse,

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveGr.hpp
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveGr.hpp
@@ -90,7 +90,7 @@ class ScalarWaveGr : public MarkAsAnalyticData {
   using spacetime_tags = typename BackgroundGrData::template tags<DataType>;
   using tags =
       tmpl::append<spacetime_tags<DataVector>,
-                   tmpl::list<Tags::Pi, Tags::Phi<volume_dim>, Tags::Psi>>;
+                   tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<volume_dim>>>;
 
   /// Retrieve spacetime variables
   template <

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.py
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.py
@@ -6,15 +6,15 @@ from Evolution.Systems.CurvedScalarWave.Characteristics import (
     char_speed_vpsi, char_speed_vzero, char_speed_vplus, char_speed_vminus)
 
 
-def error(face_mesh_velocity, normal_covector, normal_vector, phi, psi,
-          inertial_coords, gamma1, gamma2, lapse, shift, dt_pi, dt_phi, dt_psi,
+def error(face_mesh_velocity, normal_covector, normal_vector, psi, phi,
+          inertial_coords, gamma1, gamma2, lapse, shift, dt_psi, dt_pi, dt_phi,
           d_psi, d_phi):
     return None
 
 
 def dt_psi_constraint_preserving_spherical_radiation(
-    face_mesh_velocity, normal_covector, normal_vector, phi, psi,
-    inertial_coords, gamma1, gamma2, lapse, shift, dt_pi, dt_phi, dt_psi,
+    face_mesh_velocity, normal_covector, normal_vector, psi, phi,
+    inertial_coords, gamma1, gamma2, lapse, shift, dt_psi, dt_pi, dt_phi,
     d_psi, d_phi):
     char_speed_psi = char_speed_vpsi(gamma1, lapse, shift, normal_covector)
 
@@ -25,8 +25,8 @@ def dt_psi_constraint_preserving_spherical_radiation(
 
 
 def dt_phi_constraint_preserving_spherical_radiation(
-    face_mesh_velocity, normal_covector, normal_vector, phi, psi,
-    inertial_coords, gamma1, gamma2, lapse, shift, dt_pi, dt_phi, dt_psi,
+    face_mesh_velocity, normal_covector, normal_vector, psi, phi,
+    inertial_coords, gamma1, gamma2, lapse, shift, dt_psi, dt_pi, dt_phi,
     d_psi, d_phi):
     char_speed_zero = char_speed_vzero(gamma1, lapse, shift, normal_covector)
     if face_mesh_velocity is not None:
@@ -36,12 +36,12 @@ def dt_phi_constraint_preserving_spherical_radiation(
 
 
 def dt_pi_constraint_preserving_spherical_radiation(
-    face_mesh_velocity, normal_covector, normal_vector, phi, psi,
-    inertial_coords, gamma1, gamma2, lapse, shift, dt_pi, dt_phi, dt_psi,
+    face_mesh_velocity, normal_covector, normal_vector, psi, phi,
+    inertial_coords, gamma1, gamma2, lapse, shift, dt_psi, dt_pi, dt_phi,
     d_psi, d_phi):
     dt_psi_correction = dt_psi_constraint_preserving_spherical_radiation(
-        face_mesh_velocity, normal_covector, normal_vector, phi, psi,
-        inertial_coords, gamma1, gamma2, lapse, shift, dt_pi, dt_phi, dt_psi,
+        face_mesh_velocity, normal_covector, normal_vector, psi, phi,
+        inertial_coords, gamma1, gamma2, lapse, shift, dt_psi, dt_pi, dt_phi,
         d_psi, d_phi)
     inv_radius = 1. / np.linalg.norm(inertial_coords)
     bc_dt_pi = (2. * inv_radius**2 * psi + 4. * inv_radius * dt_psi +

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/BoundaryConditions/Test_ConstraintPreservingSphericalRadiation.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/BoundaryConditions/Test_ConstraintPreservingSphericalRadiation.cpp
@@ -40,14 +40,14 @@ void test() {
       "ConstraintPreservingSphericalRadiation",
       tuples::TaggedTuple<helpers::Tags::PythonFunctionForErrorMessage<>,
                           helpers::Tags::PythonFunctionName<
+                              ::Tags::dt<CurvedScalarWave::Tags::Psi>>,
+                          helpers::Tags::PythonFunctionName<
                               ::Tags::dt<CurvedScalarWave::Tags::Pi>>,
                           helpers::Tags::PythonFunctionName<
-                              ::Tags::dt<CurvedScalarWave::Tags::Phi<Dim>>>,
-                          helpers::Tags::PythonFunctionName<
-                              ::Tags::dt<CurvedScalarWave::Tags::Psi>>>{
-          "error", "dt_pi_constraint_preserving_spherical_radiation",
-          "dt_phi_constraint_preserving_spherical_radiation",
-          "dt_psi_constraint_preserving_spherical_radiation"},
+                              ::Tags::dt<CurvedScalarWave::Tags::Phi<Dim>>>>{
+          "error", "dt_psi_constraint_preserving_spherical_radiation",
+          "dt_pi_constraint_preserving_spherical_radiation",
+          "dt_phi_constraint_preserving_spherical_radiation"},
       "ConstraintPreservingSphericalRadiation:\n",
       Index<Dim - 1>{Dim == 1 ? 1 : 5}, db::DataBox<tmpl::list<>>{},
       tuples::TaggedTuple<>{});

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/BoundaryCorrections/Test_UpwindPenalty.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/BoundaryCorrections/Test_UpwindPenalty.cpp
@@ -37,8 +37,8 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts) {
         "dg_package_data_v_plus", "dg_package_data_v_minus",
         "dg_package_data_gamma2", "dg_package_data_interface_unit_normal",
         "dg_package_data_char_speeds"}},
-      {{"dg_boundary_terms_pi", "dg_boundary_terms_phi",
-        "dg_boundary_terms_psi"}},
+      {{"dg_boundary_terms_psi", "dg_boundary_terms_pi",
+        "dg_boundary_terms_phi"}},
       CurvedScalarWave::BoundaryCorrections::UpwindPenalty<Dim>{},
       Mesh<Dim - 1>{num_pts, Spectral::Basis::Legendre,
                     Spectral::Quadrature::Gauss},
@@ -56,8 +56,8 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts) {
         "dg_package_data_v_plus", "dg_package_data_v_minus",
         "dg_package_data_gamma2", "dg_package_data_interface_unit_normal",
         "dg_package_data_char_speeds"}},
-      {{"dg_boundary_terms_pi", "dg_boundary_terms_phi",
-        "dg_boundary_terms_psi"}},
+      {{"dg_boundary_terms_psi", "dg_boundary_terms_pi",
+        "dg_boundary_terms_phi"}},
       dynamic_cast<
           const CurvedScalarWave::BoundaryCorrections::UpwindPenalty<Dim>&>(
           *upwind_penalty),
@@ -95,9 +95,9 @@ void test_flat_spacetime(const gsl::not_null<std::mt19937*> gen) {
   auto csw_normal_ext = tnsr::i<DataVector, Dim>(num_pts);
   auto csw_char_speeds_int = tnsr::a<DataVector, 3>(num_pts);
   auto csw_char_speeds_ext = tnsr::a<DataVector, 3>(num_pts);
+  auto csw_psi_bcorr = Scalar<DataVector>(num_pts);
   auto csw_pi_bcorr = Scalar<DataVector>(num_pts);
   auto csw_phi_bcorr = tnsr::i<DataVector, Dim>(num_pts);
-  auto csw_psi_bcorr = Scalar<DataVector>(num_pts);
 
   // variables for SW
   auto sw_char_speed_v_psi_int = Scalar<DataVector>(num_pts);
@@ -116,19 +116,19 @@ void test_flat_spacetime(const gsl::not_null<std::mt19937*> gen) {
   auto sw_char_speed_gamma2_v_psi_ext = Scalar<DataVector>(num_pts);
   auto sw_char_speeds_int = tnsr::i<DataVector, 3>(num_pts);
   auto sw_char_speeds_ext = tnsr::i<DataVector, 3>(num_pts);
+  auto sw_psi_bcorr = Scalar<DataVector>(num_pts);
   auto sw_pi_bcorr = Scalar<DataVector>(num_pts);
   auto sw_phi_bcorr = tnsr::i<DataVector, Dim>(num_pts);
-  auto sw_psi_bcorr = Scalar<DataVector>(num_pts);
 
   // For CSW & SW
+  // create psi
+  const auto psi = make_with_random_values<Scalar<DataVector>>(
+      gen, make_not_null(&uniform_m11_dist), x);
   // create pi
   const auto pi = make_with_random_values<Scalar<DataVector>>(
       gen, make_not_null(&uniform_m11_dist), x);
   // create phi
   const auto phi = make_with_random_values<tnsr::i<DataVector, Dim>>(
-      gen, make_not_null(&uniform_m11_dist), x);
-  // create psi
-  const auto psi = make_with_random_values<Scalar<DataVector>>(
       gen, make_not_null(&uniform_m11_dist), x);
   // create gamma2
   const Scalar<DataVector> gamma2(num_pts, 0.);
@@ -192,19 +192,19 @@ void test_flat_spacetime(const gsl::not_null<std::mt19937*> gen) {
       make_not_null(&csw_v_psi_int), make_not_null(&csw_v_zero_int),
       make_not_null(&csw_v_plus_int), make_not_null(&csw_v_minus_int),
       make_not_null(&csw_gamma2_int), make_not_null(&csw_normal_int),
-      make_not_null(&csw_char_speeds_int), pi, phi, psi, lapse, shift,
+      make_not_null(&csw_char_speeds_int), psi, pi, phi, lapse, shift,
       inverse_spatial_metric, gamma1, gamma2, normal_int, normal_vector_int,
       mesh_velocity, normal_dot_mesh_velociy_int);
   csw_flux_computer.dg_package_data(
       make_not_null(&csw_v_psi_ext), make_not_null(&csw_v_zero_ext),
       make_not_null(&csw_v_plus_ext), make_not_null(&csw_v_minus_ext),
       make_not_null(&csw_gamma2_ext), make_not_null(&csw_normal_ext),
-      make_not_null(&csw_char_speeds_ext), pi, phi, psi, lapse, shift,
+      make_not_null(&csw_char_speeds_ext), psi, pi, phi, lapse, shift,
       inverse_spatial_metric, gamma1, gamma2, normal_ext, normal_vector_ext,
       mesh_velocity, normal_dot_mesh_velociy_ext);
   csw_flux_computer.dg_boundary_terms(
-      make_not_null(&csw_pi_bcorr), make_not_null(&csw_phi_bcorr),
-      make_not_null(&csw_psi_bcorr), csw_v_psi_int, csw_v_zero_int,
+      make_not_null(&csw_psi_bcorr), make_not_null(&csw_pi_bcorr),
+      make_not_null(&csw_phi_bcorr), csw_v_psi_int, csw_v_zero_int,
       csw_v_plus_int, csw_v_minus_int, csw_gamma2_int, csw_normal_int,
       csw_char_speeds_int, csw_v_psi_ext, csw_v_zero_ext, csw_v_plus_ext,
       csw_v_minus_ext, csw_gamma2_ext, csw_normal_ext, csw_char_speeds_ext,
@@ -243,9 +243,9 @@ void test_flat_spacetime(const gsl::not_null<std::mt19937*> gen) {
       sw_char_speed_gamma2_v_psi_ext, sw_char_speeds_ext,
       dg::Formulation::StrongInertial);
 
+  CHECK_ITERABLE_APPROX(sw_psi_bcorr, csw_psi_bcorr);
   CHECK_ITERABLE_APPROX(sw_pi_bcorr, csw_pi_bcorr);
   CHECK_ITERABLE_APPROX(sw_phi_bcorr, csw_phi_bcorr);
-  CHECK_ITERABLE_APPROX(sw_psi_bcorr, csw_psi_bcorr);
 }
 }  // namespace
 

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/BoundaryCorrections/UpwindPenalty.py
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/BoundaryCorrections/UpwindPenalty.py
@@ -9,7 +9,7 @@ from Evolution.Systems.CurvedScalarWave.Characteristics import (
     evol_field_psi, evol_field_pi, evol_field_phi)
 
 
-def dg_package_data_v_psi(pi, phi, psi, lapse, shift, inverse_spatial_metric,
+def dg_package_data_v_psi(psi, pi, phi, lapse, shift, inverse_spatial_metric,
                           constraint_gamma1, constraint_gamma2,
                           interface_unit_normal, interface_unit_normal_vector,
                           mesh_velocity, normal_dot_mesh_velocity):
@@ -17,7 +17,7 @@ def dg_package_data_v_psi(pi, phi, psi, lapse, shift, inverse_spatial_metric,
                            phi, interface_unit_normal)
 
 
-def dg_package_data_v_zero(pi, phi, psi, lapse, shift, inverse_spatial_metric,
+def dg_package_data_v_zero(psi, pi, phi, lapse, shift, inverse_spatial_metric,
                            constraint_gamma1, constraint_gamma2,
                            interface_unit_normal, interface_unit_normal_vector,
                            mesh_velocity, normal_dot_mesh_velocity):
@@ -25,7 +25,7 @@ def dg_package_data_v_zero(pi, phi, psi, lapse, shift, inverse_spatial_metric,
                             phi, interface_unit_normal)
 
 
-def dg_package_data_v_plus(pi, phi, psi, lapse, shift, inverse_spatial_metric,
+def dg_package_data_v_plus(psi, pi, phi, lapse, shift, inverse_spatial_metric,
                            constraint_gamma1, constraint_gamma2,
                            interface_unit_normal, interface_unit_normal_vector,
                            mesh_velocity, normal_dot_mesh_velocity):
@@ -33,7 +33,7 @@ def dg_package_data_v_plus(pi, phi, psi, lapse, shift, inverse_spatial_metric,
                             phi, interface_unit_normal)
 
 
-def dg_package_data_v_minus(pi, phi, psi, lapse, shift, inverse_spatial_metric,
+def dg_package_data_v_minus(psi, pi, phi, lapse, shift, inverse_spatial_metric,
                             constraint_gamma1, constraint_gamma2,
                             interface_unit_normal,
                             interface_unit_normal_vector, mesh_velocity,
@@ -42,7 +42,7 @@ def dg_package_data_v_minus(pi, phi, psi, lapse, shift, inverse_spatial_metric,
                              pi, phi, interface_unit_normal)
 
 
-def dg_package_data_gamma2(pi, phi, psi, lapse, shift, inverse_spatial_metric,
+def dg_package_data_gamma2(psi, pi, phi, lapse, shift, inverse_spatial_metric,
                            constraint_gamma1, constraint_gamma2,
                            interface_unit_normal, interface_unit_normal_vector,
                            mesh_velocity, normal_dot_mesh_velocity):
@@ -50,13 +50,13 @@ def dg_package_data_gamma2(pi, phi, psi, lapse, shift, inverse_spatial_metric,
 
 
 def dg_package_data_interface_unit_normal(
-    pi, phi, psi, lapse, shift, inverse_spatial_metric, constraint_gamma1,
+    psi, pi, phi, lapse, shift, inverse_spatial_metric, constraint_gamma1,
     constraint_gamma2, interface_unit_normal, interface_unit_normal_vector,
     mesh_velocity, normal_dot_mesh_velocity):
     return interface_unit_normal
 
 
-def dg_package_data_char_speeds(pi, phi, psi, lapse, shift,
+def dg_package_data_char_speeds(psi, pi, phi, lapse, shift,
                                 inverse_spatial_metric, constraint_gamma1,
                                 constraint_gamma2, interface_unit_normal,
                                 interface_unit_normal_vector, mesh_velocity,

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_Constraints.cpp
@@ -63,14 +63,14 @@ void test_constraint_compute_items(const DataVector& used_for_size) {
   const auto box = db::create<
       db::AddSimpleTags<
           CurvedScalarWave::Tags::Phi<SpatialDim>,
-          ::Tags::deriv<CurvedScalarWave::Tags::Phi<SpatialDim>,
-                        tmpl::size_t<SpatialDim>, Frame::Inertial>,
           ::Tags::deriv<CurvedScalarWave::Tags::Psi, tmpl::size_t<SpatialDim>,
-                        Frame::Inertial>>,
+                        Frame::Inertial>,
+          ::Tags::deriv<CurvedScalarWave::Tags::Phi<SpatialDim>,
+                        tmpl::size_t<SpatialDim>, Frame::Inertial>>,
       db::AddComputeTags<
           CurvedScalarWave::Tags::OneIndexConstraintCompute<SpatialDim>,
           CurvedScalarWave::Tags::TwoIndexConstraintCompute<SpatialDim>>>(
-      phi, d_phi, d_psi);
+      phi, d_psi, d_phi);
 
   // Check compute tag against locally computed quantities
   CHECK(db::get<CurvedScalarWave::Tags::OneIndexConstraint<SpatialDim>>(box) ==

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_TimeDerivative.cpp
@@ -102,11 +102,11 @@ calculate_du_dt(const DataVector& used_for_size) {
   auto r_gamma1 = make_with_value<Scalar<DataVector>>(used_for_size, 0.);
   auto r_gamma2 = make_with_value<Scalar<DataVector>>(used_for_size, 0.);
   CurvedScalarWave::TimeDerivative<Dim>::apply(
-      make_not_null(&dt_pi), make_not_null(&dt_phi), make_not_null(&dt_psi),
+      make_not_null(&dt_psi), make_not_null(&dt_pi), make_not_null(&dt_phi),
       make_not_null(&r_lapse), make_not_null(&r_shift),
       make_not_null(&r_inv_spatial_metric), make_not_null(&r_gamma1),
-      make_not_null(&r_gamma2), make_d_pi<Dim>(used_for_size),
-      make_d_phi<Dim>(used_for_size), make_d_psi<Dim>(used_for_size),
+      make_not_null(&r_gamma2), make_d_psi<Dim>(used_for_size),
+      make_d_pi<Dim>(used_for_size), make_d_phi<Dim>(used_for_size),
       make_pi(used_for_size), make_phi<Dim>(used_for_size),
       make_lapse(used_for_size), make_shift<Dim>(used_for_size),
       make_deriv_lapse<Dim>(used_for_size),


### PR DESCRIPTION
The order evolved variables `Psi, Pi, Phi` of the `CurvedScalarWave` system is inconsistent across the codebase which could lead to errors. This PR makes the order consistent.

- [x] depends on #3727 