### PR TITLE
Add executables to `CurvedScalarWave` system

### DIFF
--- a/src/Evolution/Executables/CMakeLists.txt
+++ b/src/Evolution/Executables/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 add_subdirectory(Burgers)
 add_subdirectory(Cce)
+add_subdirectory(CurvedScalarWave)
 add_subdirectory(GeneralizedHarmonic)
 add_subdirectory(GrMhd)
 add_subdirectory(NewtonianEuler)

--- a/src/Evolution/Executables/CurvedScalarWave/CMakeLists.txt
+++ b/src/Evolution/Executables/CurvedScalarWave/CMakeLists.txt
@@ -1,0 +1,47 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBS_TO_LINK
+  CoordinateMaps
+  CurvedScalarWave
+  CurvedWaveEquationAnalyticData
+  DiscontinuousGalerkin
+  DomainCreators
+  Events
+  EventsAndDenseTriggers
+  EventsAndTriggers
+  Evolution
+  GeneralRelativity
+  IO
+  Informer
+  LinearOperators
+  MathFunctions
+  Time
+  Options
+  Parallel
+  PhaseControl
+  Utilities
+  WaveEquationSolutions
+)
+
+function(add_curved_scalar_wave_executable EXECUTABLE_NAME DIM INITIAL_DATA)
+  add_spectre_parallel_executable(
+    "Evolve${EXECUTABLE_NAME}${DIM}D"
+    EvolveCurvedScalarWave
+    Evolution/Executables/CurvedScalarWave
+    "EvolutionMetavars<${DIM},${INITIAL_DATA}>"
+    "${LIBS_TO_LINK}"
+    )
+endfunction(add_curved_scalar_wave_executable)
+
+function(add_flat_plane_wave_executable DIM)
+  add_curved_scalar_wave_executable(
+    PlaneWaveMinkowski
+    ${DIM}
+    CurvedScalarWave::AnalyticData::ScalarWaveGr<ScalarWave::Solutions::PlaneWave<${DIM}>,gr::Solutions::Minkowski<${DIM}>>
+    )
+endfunction(add_flat_plane_wave_executable)
+
+add_flat_plane_wave_executable(1)
+add_flat_plane_wave_executable(2)
+add_flat_plane_wave_executable(3)

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -1,0 +1,364 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "DataStructures/Tensor/EagerMath/Norms.hpp"
+#include "Domain/Creators/Factory1D.hpp"
+#include "Domain/Creators/Factory2D.hpp"
+#include "Domain/Creators/Factory3D.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Actions/RunEventsAndDenseTriggers.hpp"
+#include "Evolution/ComputeTags.hpp"
+#include "Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp"
+#include "Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp"
+#include "Evolution/DiscontinuousGalerkin/DgElementArray.hpp"
+#include "Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp"
+#include "Evolution/DiscontinuousGalerkin/Initialization/QuadratureTag.hpp"
+#include "Evolution/EventsAndDenseTriggers/DenseTrigger.hpp"
+#include "Evolution/EventsAndDenseTriggers/DenseTriggers/Factory.hpp"
+#include "Evolution/Initialization/DgDomain.hpp"
+#include "Evolution/Initialization/Evolution.hpp"
+#include "Evolution/Initialization/NonconservativeSystem.hpp"
+#include "Evolution/Initialization/SetVariables.hpp"
+#include "Evolution/Systems/CurvedScalarWave/BoundaryConditions/Factory.hpp"
+#include "Evolution/Systems/CurvedScalarWave/BoundaryCorrections/Factory.hpp"
+#include "Evolution/Systems/CurvedScalarWave/BoundaryCorrections/RegisterDerived.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Constraints.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Equations.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Initialize.hpp"
+#include "Evolution/Systems/CurvedScalarWave/System.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "Evolution/TypeTraits.hpp"
+#include "IO/Observer/Actions/RegisterEvents.hpp"
+#include "IO/Observer/Helpers.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/ExponentialFilter.hpp"
+#include "NumericalAlgorithms/LinearOperators/FilterAction.hpp"
+#include "Options/Options.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/Actions/TerminatePhase.hpp"
+#include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp"
+#include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
+#include "Parallel/PhaseControl/PhaseControlTags.hpp"
+#include "Parallel/PhaseControl/VisitAndReturn.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Reduction.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "ParallelAlgorithms/Actions/MutateApply.hpp"
+#include "ParallelAlgorithms/Events/Factory.hpp"
+#include "ParallelAlgorithms/Events/ObserveNorms.hpp"
+#include "ParallelAlgorithms/Events/ObserveVolumeIntegrals.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Completion.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/EventsAndTriggers.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/LogicalTriggers.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Tags.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Trigger.hpp"
+#include "ParallelAlgorithms/Initialization/Actions/AddComputeTags.hpp"
+#include "ParallelAlgorithms/Initialization/Actions/AddSimpleTags.hpp"
+#include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
+#include "PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveGr.hpp"
+#include "PointwiseFunctions/AnalyticData/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ExtrinsicCurvature.hpp"
+#include "PointwiseFunctions/MathFunctions/Factory.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "Time/Actions/AdvanceTime.hpp"
+#include "Time/Actions/ChangeSlabSize.hpp"
+#include "Time/Actions/ChangeStepSize.hpp"
+#include "Time/Actions/RecordTimeStepperData.hpp"
+#include "Time/Actions/SelfStartActions.hpp"
+#include "Time/Actions/UpdateU.hpp"
+#include "Time/StepChoosers/ByBlock.hpp"
+#include "Time/StepChoosers/Factory.hpp"
+#include "Time/StepChoosers/StepChooser.hpp"
+#include "Time/StepControllers/Factory.hpp"
+#include "Time/StepControllers/StepController.hpp"
+#include "Time/Tags.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Time/Triggers/TimeTriggers.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Frame {
+struct Inertial;
+}  // namespace Frame
+namespace Parallel {
+template <typename Metavariables>
+class CProxy_GlobalCache;
+}  // namespace Parallel
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+template <size_t Dim, typename InitialData>
+struct EvolutionMetavars {
+  static constexpr size_t volume_dim = Dim;
+  using initial_data_tag =
+      tmpl::conditional_t<evolution::is_analytic_solution_v<InitialData>,
+                          Tags::AnalyticSolution<InitialData>,
+                          Tags::AnalyticData<InitialData>>;
+  static_assert(
+      evolution::is_analytic_data_v<InitialData> xor
+          evolution::is_analytic_solution_v<InitialData>,
+      "initial_data must be either an analytic_data or an analytic_solution");
+
+  using system = CurvedScalarWave::System<Dim>;
+  using temporal_id = Tags::TimeStepId;
+  static constexpr bool local_time_stepping = true;
+  using time_stepper_tag = Tags::TimeStepper<
+      tmpl::conditional_t<local_time_stepping, LtsTimeStepper, TimeStepper>>;
+
+  using observe_fields = tmpl::flatten<
+      tmpl::list<typename system::variables_tag::tags_list,
+                 CurvedScalarWave::Tags::OneIndexConstraintCompute<volume_dim>,
+                 CurvedScalarWave::Tags::TwoIndexConstraintCompute<volume_dim>,
+                 ::Tags::PointwiseL2NormCompute<
+                     CurvedScalarWave::Tags::OneIndexConstraint<volume_dim>>,
+                 ::Tags::PointwiseL2NormCompute<
+                     CurvedScalarWave::Tags::TwoIndexConstraint<volume_dim>>>>;
+  using deriv_compute = ::Tags::DerivCompute<
+      typename system::variables_tag,
+      domain::Tags::InverseJacobian<volume_dim, Frame::ElementLogical,
+                                    Frame::Inertial>,
+      typename system::gradient_variables>;
+
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<
+            CurvedScalarWave::BoundaryConditions::BoundaryCondition<volume_dim>,
+            CurvedScalarWave::BoundaryConditions::standard_boundary_conditions<
+                volume_dim>>,
+        tmpl::pair<DenseTrigger, DenseTriggers::standard_dense_triggers>,
+        tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
+        tmpl::pair<Event,
+                   tmpl::flatten<tmpl::list<
+                       Events::Completion,
+                       Events::ObserveNorms<::Tags::Time, observe_fields>,
+                       dg::Events::field_observations<
+                           volume_dim, Tags::Time, observe_fields, tmpl::list<>,
+                           tmpl::list<deriv_compute>>,
+                       Events::time_events<system>>>>,
+        tmpl::pair<MathFunction<1, Frame::Inertial>,
+                   MathFunctions::all_math_functions<1, Frame::Inertial>>,
+        tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
+                   tmpl::push_back<StepChoosers::standard_step_choosers<system>,
+                                   StepChoosers::ByBlock<
+                                       StepChooserUse::LtsStep, volume_dim>>>,
+        tmpl::pair<StepChooser<StepChooserUse::Slab>,
+                   tmpl::push_back<StepChoosers::standard_slab_choosers<
+                                       system, local_time_stepping>,
+                                   StepChoosers::ByBlock<StepChooserUse::Slab,
+                                                         volume_dim>>>,
+        tmpl::pair<StepController, StepControllers::standard_step_controllers>,
+        tmpl::pair<TimeSequence<double>,
+                   TimeSequences::all_time_sequences<double>>,
+        tmpl::pair<TimeSequence<std::uint64_t>,
+                   TimeSequences::all_time_sequences<std::uint64_t>>,
+        tmpl::pair<Trigger, tmpl::append<Triggers::logical_triggers,
+                                         Triggers::time_triggers>>>;
+  };
+
+  using observed_reduction_data_tags =
+      observers::collect_reduction_data_tags<tmpl::flatten<tmpl::list<
+          tmpl::at<typename factory_creation::factory_classes, Event>>>>;
+
+  static constexpr bool use_filtering = true;
+
+  using step_actions = tmpl::flatten<tmpl::list<
+      evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
+      tmpl::conditional_t<
+          local_time_stepping,
+          tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<>,
+                     evolution::dg::Actions::ApplyBoundaryCorrections<
+                         EvolutionMetavars>>,
+          tmpl::list<evolution::dg::Actions::ApplyBoundaryCorrections<
+                         EvolutionMetavars>,
+                     Actions::RecordTimeStepperData<>,
+                     evolution::Actions::RunEventsAndDenseTriggers<>,
+                     Actions::UpdateU<>>>,
+      tmpl::conditional_t<
+          use_filtering,
+          dg::Actions::Filter<Filters::Exponential<0>,
+                              tmpl::list<CurvedScalarWave::Tags::Psi,
+                                         CurvedScalarWave::Tags::Pi,
+                                         CurvedScalarWave::Tags::Phi<Dim>>>,
+          tmpl::list<>>>>;
+
+  enum class Phase {
+    Initialization,
+    RegisterWithObserver,
+    InitializeTimeStepperHistory,
+    LoadBalancing,
+    WriteCheckpoint,
+    Evolve,
+    Exit
+  };
+
+  static std::string phase_name(Phase phase) {
+    if (phase == Phase::LoadBalancing) {
+      return "LoadBalancing";
+    }
+    ERROR(
+        "Passed phase that should not be used in input file. Integer "
+        "corresponding to phase is: "
+        << static_cast<int>(phase));
+  }
+
+  using phase_changes =
+      tmpl::list<PhaseControl::Registrars::VisitAndReturn<EvolutionMetavars,
+                                                          Phase::LoadBalancing>,
+                 PhaseControl::Registrars::CheckpointAndExitAfterWallclock<
+                     EvolutionMetavars>>;
+
+  using initialize_phase_change_decision_data =
+      PhaseControl::InitializePhaseChangeDecisionData<phase_changes>;
+
+  using phase_change_tags_and_combines_list =
+      PhaseControl::get_phase_change_tags<phase_changes>;
+
+  using const_global_cache_tags =
+      tmpl::list<initial_data_tag, Tags::EventsAndTriggers,
+                 PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes>>;
+
+  using dg_registration_list =
+      tmpl::list<observers::Actions::RegisterEventsWithObservers>;
+
+  using gr_compute_tags =
+      tmpl::list<gr::Tags::SpatialChristoffelFirstKindCompute<
+                     Dim, Frame::Inertial, DataVector>,
+                 gr::Tags::SpatialChristoffelSecondKindCompute<
+                     Dim, Frame::Inertial, DataVector>,
+                 gr::Tags::TraceSpatialChristoffelSecondKindCompute<
+                     Dim, Frame::Inertial, DataVector>,
+                 GeneralizedHarmonic::Tags::TraceExtrinsicCurvatureCompute<
+                     Dim, Frame::Inertial>>;
+
+  using initialization_actions = tmpl::list<
+      Actions::SetupDataBox,
+      Initialization::Actions::TimeAndTimeStep<EvolutionMetavars>,
+      evolution::dg::Initialization::Domain<volume_dim>,
+      Initialization::Actions::NonconservativeSystem<system>,
+      evolution::Initialization::Actions::SetVariables<
+          domain::Tags::Coordinates<Dim, Frame::ElementLogical>>,
+      Initialization::Actions::TimeStepperHistory<EvolutionMetavars>,
+      Initialization::Actions::AddSimpleTags<
+          CurvedScalarWave::Initialization::InitializeConstraintDampingGammas<
+              volume_dim>,
+          CurvedScalarWave::Initialization::InitializeGrVars<volume_dim>>,
+      Initialization::Actions::AddComputeTags<tmpl::flatten<
+          tmpl::list<StepChoosers::step_chooser_compute_tags<EvolutionMetavars>,
+                     gr_compute_tags>>>,
+      ::evolution::dg::Initialization::Mortars<volume_dim, system>,
+      evolution::Actions::InitializeRunEventsAndDenseTriggers,
+      Initialization::Actions::RemoveOptionsAndTerminatePhase>;
+
+  using dg_element_array = DgElementArray<
+      EvolutionMetavars,
+      tmpl::list<
+          Parallel::PhaseActions<Phase, Phase::Initialization,
+                                 initialization_actions>,
+          Parallel::PhaseActions<
+              Phase, Phase::InitializeTimeStepperHistory,
+              SelfStart::self_start_procedure<step_actions, system>>,
+          Parallel::PhaseActions<Phase, Phase::RegisterWithObserver,
+                                 tmpl::list<dg_registration_list,
+                                            Parallel::Actions::TerminatePhase>>,
+          Parallel::PhaseActions<
+              Phase, Phase::Evolve,
+              tmpl::list<
+                  Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
+                  step_actions, Actions::AdvanceTime,
+                  PhaseControl::Actions::ExecutePhaseChange<phase_changes>>>>>;
+
+  template <typename ParallelComponent>
+  struct registration_list {
+    using type =
+        std::conditional_t<std::is_same_v<ParallelComponent, dg_element_array>,
+                           dg_registration_list, tmpl::list<>>;
+  };
+
+  using component_list =
+      tmpl::list<observers::Observer<EvolutionMetavars>,
+                 observers::ObserverWriter<EvolutionMetavars>,
+                 dg_element_array>;
+
+  static constexpr Options::String help{
+      "Evolve a scalar wave in Dim spatial dimension on a curved background "
+      "spacetime."};
+
+  struct domain {
+    static constexpr bool enable_time_dependent_maps = false;
+  };
+
+  template <typename... Tags>
+  static Phase determine_next_phase(
+      const gsl::not_null<tuples::TaggedTuple<Tags...>*>
+          phase_change_decision_data,
+      const Phase& current_phase,
+      const Parallel::CProxy_GlobalCache<EvolutionMetavars>& cache_proxy) {
+    const auto next_phase = PhaseControl::arbitrate_phase_change<phase_changes>(
+        phase_change_decision_data, current_phase,
+        *(cache_proxy.ckLocalBranch()));
+    if (next_phase.has_value()) {
+      return next_phase.value();
+    }
+    switch (current_phase) {
+      case Phase::Initialization:
+        return Phase::InitializeTimeStepperHistory;
+      case Phase::InitializeTimeStepperHistory:
+        return Phase::RegisterWithObserver;
+      case Phase::RegisterWithObserver:
+        return Phase::Evolve;
+      case Phase::Evolve:
+        return Phase::Exit;
+      case Phase::Exit:
+        ERROR(
+            "Should never call determine_next_phase with the current phase "
+            "being 'Exit'");
+      default:
+        ERROR(
+            "Unknown type of phase. Did you static_cast<Phase> an integral "
+            "value?");
+    }
+  }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) {}
+};
+
+static const std::vector<void (*)()> charm_init_node_funcs{
+    &setup_error_handling,
+    &setup_memory_allocation_failure_reporting,
+    &disable_openblas_multithreading,
+    &domain::creators::register_derived_with_charm,
+    &domain::creators::time_dependence::register_derived_with_charm,
+    &domain::FunctionsOfTime::register_derived_with_charm,
+    &CurvedScalarWave::BoundaryCorrections::register_derived_with_charm,
+    &Parallel::register_derived_classes_with_charm<TimeStepper>,
+    &Parallel::register_derived_classes_with_charm<
+        PhaseChange<metavariables::phase_changes>>,
+    &Parallel::register_factory_classes_with_charm<metavariables>};
+
+static const std::vector<void (*)()> charm_init_proc_funcs{
+    &enable_floating_point_exceptions};

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWaveFwd.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWaveFwd.hpp
@@ -1,0 +1,26 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+/// \cond
+namespace CurvedScalarWave::AnalyticData {
+template <typename ScalarFieldSolution, typename BackgroundGrData>
+class ScalarWaveGr;
+}  // namespace CurvedScalarWave::AnalyticData
+
+namespace gr::Solutions {
+template <size_t Dim>
+class Minkowski;
+}  // namespace gr::Solutions
+
+namespace ScalarWave::Solutions {
+template <size_t Dim>
+class PlaneWave;
+}  // namespace ScalarWave::Solutions
+
+template <size_t Dim, typename InitialData>
+struct EvolutionMetavars;
+/// \endcond

--- a/src/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
+++ b/src/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
@@ -22,6 +22,7 @@ spectre_target_headers(
   Characteristics.hpp
   Constraints.hpp
   Equations.hpp
+  Initialize.hpp
   System.hpp
   Tags.hpp
   TagsDeclarations.hpp

--- a/src/Evolution/Systems/CurvedScalarWave/Initialize.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Initialize.hpp
@@ -1,0 +1,81 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Initialization/InitialData.hpp"
+#include "Evolution/Initialization/Tags.hpp"
+#include "Evolution/Systems/CurvedScalarWave/System.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/AnalyticData/Tags.hpp"
+#include "Time/Time.hpp"
+
+namespace CurvedScalarWave::Initialization {
+/// \ingroup InitializationGroup
+/// \brief Mutator meant to be used with
+/// `Initialization::Actions::AddSimpleTags` to initialize the constraint
+/// damping parameters of the CurvedScalarWave system
+///
+/// DataBox changes:
+/// - Adds:
+///   * `CurvedScalarWave::Tags::ConstraintGamma1`
+///   * `CurvedScalarWave::Tags::ConstraintGamma2`
+/// - Removes: nothing
+/// - Modifies: nothing
+
+template <size_t Dim>
+struct InitializeConstraintDampingGammas {
+  using return_tags =
+      tmpl::list<Tags::ConstraintGamma1, Tags::ConstraintGamma2>;
+  using argument_tags = tmpl::list<domain::Tags::Mesh<Dim>>;
+
+  static void apply(const gsl::not_null<Scalar<DataVector>*> gamma1,
+                    const gsl::not_null<Scalar<DataVector>*> gamma2,
+                    const Mesh<Dim>& mesh) {
+    const size_t number_of_grid_points = mesh.number_of_grid_points();
+    *gamma1 = Scalar<DataVector>{number_of_grid_points, 0.};
+    *gamma2 = Scalar<DataVector>{number_of_grid_points, 1.};
+  }
+};
+
+/// \ingroup InitializationGroup
+/// \brief Mutator meant to be used with
+/// `Initialization::Actions::AddSimpleTags` to initialize items related to the
+/// spacetime background of the CurvedScalarWave system
+///
+/// DataBox changes:
+/// - Adds:
+///   * `CurvedScalarWave::System::spacetime_variables_tag`
+/// - Removes: nothing
+/// - Modifies: nothing
+
+template <size_t Dim>
+struct InitializeGrVars {
+  using gr_vars_tag =
+      typename CurvedScalarWave::System<Dim>::spacetime_variables_tag;
+  using GrVars = typename gr_vars_tag::type;
+  using return_tags = tmpl::list<gr_vars_tag>;
+  using argument_tags =
+      tmpl::list<::Initialization::Tags::InitialTime,
+                 domain::Tags::Coordinates<Dim, Frame::Inertial>,
+                 ::Tags::AnalyticSolutionOrData>;
+
+  template <typename AnalyticSolutionOrData>
+  static void apply(
+      const gsl::not_null<GrVars*> gr_vars, const double initial_time,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords,
+      const AnalyticSolutionOrData& analytic_solution_or_data) {
+    gr_vars->initialize(get<0>(inertial_coords).size());
+    // Set initial data from analytic solution
+    gr_vars->assign_subset(evolution::Initialization::initial_data(
+        analytic_solution_or_data, inertial_coords, initial_time,
+        typename GrVars::tags_list{}));
+  }
+};
+
+}  // namespace CurvedScalarWave::Initialization

--- a/src/Evolution/Systems/CurvedScalarWave/System.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/System.hpp
@@ -5,7 +5,9 @@
 
 #include <cstddef>
 
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/VariablesTag.hpp"
+#include "Evolution/Systems/CurvedScalarWave/BoundaryConditions/BoundaryCondition.hpp"
 #include "Evolution/Systems/CurvedScalarWave/BoundaryCorrections/BoundaryCorrection.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Characteristics.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Equations.hpp"
@@ -27,6 +29,7 @@ struct System {
   static constexpr size_t volume_dim = Dim;
   static constexpr bool is_euclidean = false;
 
+  using boundary_conditions_base = BoundaryConditions::BoundaryCondition<Dim>;
   using boundary_correction_base = BoundaryCorrections::BoundaryCorrection<Dim>;
 
   using variables_tag =
@@ -37,6 +40,23 @@ struct System {
   // Relic alias: needs to be removed once all evolution systems
   // convert to using dg::ComputeTimeDerivative
   using gradients_tags = gradient_variables;
+
+  using spacetime_variables_tag = ::Tags::Variables<tmpl::list<
+      gr::Tags::Lapse<DataVector>, ::Tags::dt<gr::Tags::Lapse<DataVector>>,
+      ::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<Dim>,
+                    Frame::Inertial>,
+      gr::Tags::Shift<volume_dim, Frame::Inertial, DataVector>,
+      ::Tags::dt<gr::Tags::Shift<volume_dim, Frame::Inertial, DataVector>>,
+      ::Tags::deriv<gr::Tags::Shift<Dim, Frame::Inertial, DataVector>,
+                    tmpl::size_t<Dim>, Frame::Inertial>,
+      gr::Tags::SpatialMetric<volume_dim, Frame::Inertial, DataVector>,
+      ::Tags::dt<
+          gr::Tags::SpatialMetric<volume_dim, Frame::Inertial, DataVector>>,
+      ::Tags::deriv<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataVector>,
+                    tmpl::size_t<Dim>, Frame::Inertial>,
+      gr::Tags::SqrtDetSpatialMetric<DataVector>,
+      gr::Tags::ExtrinsicCurvature<volume_dim, Frame::Inertial, DataVector>,
+      gr::Tags::InverseSpatialMetric<volume_dim, Frame::Inertial, DataVector>>>;
 
   using compute_volume_time_derivative_terms = TimeDerivative<Dim>;
   using normal_dot_fluxes = ComputeNormalDotFluxes<Dim>;

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski1D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski1D.yaml
@@ -1,0 +1,71 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Executable: EvolvePlaneWaveMinkowski1D
+# Check: parse;execute
+
+AnalyticData:
+  ScalarWaveGr:
+    Background:
+    ScalarField:
+      WaveVector: [1.0]
+      Center: [0.0]
+      Profile:
+        Sinusoid:
+          Amplitude: 1.0
+          Wavenumber: 1.0
+          Phase: 0.0
+
+
+PhaseChangeAndTriggers:
+
+Evolution:
+  InitialTime: 0.0
+  InitialTimeStep: 0.001
+  InitialSlabSize: 0.01
+  TimeStepper:
+    AdamsBashforthN:
+      Order: 3
+  StepController: BinaryFraction
+  StepChoosers:
+    - Constant: 0.05
+    - Increase:
+        Factor: 2
+    - Cfl:
+        SafetyFactor: 0.2
+
+DomainCreator:
+  Interval:
+    LowerBound: [0.0]
+    UpperBound: [6.283185307179586]
+    InitialRefinement: [1]
+    InitialGridPoints: [5]
+    TimeDependence: None
+    BoundaryConditions:
+      LowerBoundary: Periodic
+      UpperBoundary: Periodic
+
+SpatialDiscretization:
+  BoundaryCorrection:
+    UpwindPenalty:
+  DiscontinuousGalerkin:
+    Formulation: StrongInertial
+    Quadrature: GaussLobatto
+
+Filtering:
+  ExpFilter0:
+    Alpha: 12
+    HalfPower: 32
+    DisableForDebugging: true
+
+EventsAndTriggers:
+  ? Slabs:
+      Specified:
+        Values: [100]
+  : - Completion
+
+EventsAndDenseTriggers:
+
+Observers:
+  VolumeFileName: "PlaneWaveMinkowski3DVolume"
+  ReductionFileName: "PlaneWaveMinkowski3DReductions"

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski2D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski2D.yaml
@@ -1,0 +1,68 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Executable: EvolvePlaneWaveMinkowski2D
+# Check: parse;execute
+
+AnalyticData:
+  ScalarWaveGr:
+    Background:
+    ScalarField:
+      WaveVector: [1.0, 1.0]
+      Center: [0.0, 0.0]
+      Profile:
+        Sinusoid:
+          Amplitude: 1.0
+          Wavenumber: 1.0
+          Phase: 0.0
+
+PhaseChangeAndTriggers:
+
+Evolution:
+  InitialTime: 0.0
+  InitialTimeStep: 0.001
+  InitialSlabSize: 0.01
+  TimeStepper:
+    AdamsBashforthN:
+      Order: 3
+  StepController: BinaryFraction
+  StepChoosers:
+    - Constant: 0.05
+    - Increase:
+        Factor: 2
+    - Cfl:
+        SafetyFactor: 0.2
+
+DomainCreator:
+  Rectangle:
+    LowerBound: [0.0, 0.0]
+    UpperBound: [6.283185307179586, 6.283185307179586]
+    InitialRefinement: [1, 1]
+    InitialGridPoints: [5, 5]
+    TimeDependence: None
+    BoundaryCondition: Periodic
+
+SpatialDiscretization:
+  BoundaryCorrection:
+    UpwindPenalty:
+  DiscontinuousGalerkin:
+    Formulation: StrongInertial
+    Quadrature: GaussLobatto
+
+Filtering:
+  ExpFilter0:
+    Alpha: 12
+    HalfPower: 32
+    DisableForDebugging: true
+
+EventsAndTriggers:
+  ? Slabs:
+      Specified:
+        Values: [100]
+  : - Completion
+
+EventsAndDenseTriggers:
+
+Observers:
+  VolumeFileName: "PlaneWaveMinkowski2DVolume"
+  ReductionFileName: "PlaneWaveMinkowski2DReductions"

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
@@ -1,0 +1,114 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Executable: EvolvePlaneWaveMinkowski3D
+# Check: parse;execute_check_output
+# Timeout: 15
+# ExpectedOutput:
+#   PlaneWaveMinkowski3DVolume0.h5
+#   PlaneWaveMinkowski3DReductions.h5
+# OutputFileChecks:
+#   - Label: constraint violations
+#     Subfile: /Norms.dat
+#     FileGlob: PlaneWaveMinkowski3DReductions.h5
+#     SkipColumns: [0, 1]
+#     AbsoluteTolerance: 0.02
+
+AnalyticData:
+  ScalarWaveGr:
+    Background:
+    ScalarField:
+      WaveVector: [1.0, 1.0, 1.0]
+      Center: [0.0, 0.0, 0.0]
+      Profile:
+        Sinusoid:
+          Amplitude: 1.0
+          Wavenumber: 1.0
+          Phase: 0.0
+
+PhaseChangeAndTriggers:
+
+Evolution:
+  InitialTime: 0.0
+  InitialTimeStep: 0.001
+  InitialSlabSize: 0.01
+  TimeStepper:
+    AdamsBashforthN:
+      Order: 3
+  StepController: BinaryFraction
+  StepChoosers:
+    - Constant: 0.05
+    - Increase:
+        Factor: 2
+    - Cfl:
+        SafetyFactor: 0.2
+
+DomainCreator:
+  Brick:
+    LowerBound: [0.0, 0.0, 0.0]
+    UpperBound: [6.283185307179586, 6.283185307179586, 6.283185307179586]
+    InitialRefinement: [1, 1, 1]
+    InitialGridPoints: [6, 6, 6]
+    TimeDependence: None
+    BoundaryCondition: Periodic
+
+SpatialDiscretization:
+  BoundaryCorrection:
+    UpwindPenalty:
+  DiscontinuousGalerkin:
+    Formulation: StrongInertial
+    Quadrature: GaussLobatto
+
+Filtering:
+  ExpFilter0:
+    Alpha: 12
+    HalfPower: 32
+    DisableForDebugging: true
+
+EventsAndTriggers:
+  ? Slabs:
+      Specified:
+        Values: [30]
+  : - Completion
+  ? Slabs:
+      Specified:
+        Values: [0, 15]
+  : - ObserveFields:
+        SubfileName: VolumePsi0And25
+        VariablesToObserve: ["Psi"]
+        InterpolateToMesh: None
+        CoordinatesFloatingPointType: Double
+        FloatingPointTypes: [Double]
+  ? Slabs:
+      EvenlySpaced:
+        Interval: 10
+        Offset: 0
+  : - ObserveFields:
+        SubfileName: VolumeVarsConstraintsEvery10Slabs
+        VariablesToObserve:
+          - Psi
+          - Pi
+          - Phi
+          - PointwiseL2Norm(OneIndexConstraint)
+        InterpolateToMesh: None
+        CoordinatesFloatingPointType: Double
+        FloatingPointTypes: [Double]
+  ? Slabs:
+      EvenlySpaced:
+        Interval: 10
+        Offset: 0
+  : - ObserveNorms:
+        SubfileName: Norms
+        TensorsToObserve:
+          - Name: PointwiseL2Norm(OneIndexConstraint)
+            NormType: L2Norm
+            Components: Individual
+          - Name: PointwiseL2Norm(TwoIndexConstraint)
+            NormType: L2Norm
+            Components: Individual
+
+EventsAndDenseTriggers:
+
+Observers:
+  VolumeFileName: "PlaneWaveMinkowski3DVolume"
+  ReductionFileName: "PlaneWaveMinkowski3DReductions"

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
@@ -9,6 +9,8 @@ set(LIBRARY_SOURCES
   BoundaryConditions/Test_Outflow.cpp
   Test_Constraints.cpp
   Test_Characteristics.cpp
+  Test_InitializeConstraintDampingGammas.cpp
+  Test_InitializeGrVars.cpp
   Test_Tags.cpp
   Test_TimeDerivative.cpp
   )

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_InitializeConstraintDampingGammas.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_InitializeConstraintDampingGammas.cpp
@@ -1,0 +1,43 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cmath>
+#include <limits>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Initialize.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+
+namespace {
+template <size_t Dim>
+void test_initialize_constraint_damping_gammas() {
+  auto box =
+      db::create<db::AddSimpleTags<CurvedScalarWave::Tags::ConstraintGamma1,
+                                   CurvedScalarWave::Tags::ConstraintGamma2,
+                                   domain::Tags::Mesh<Dim>>>(
+          Scalar<DataVector>{}, Scalar<DataVector>{},
+          Mesh<Dim>{4, Spectral::Basis::Chebyshev,
+                    Spectral::Quadrature::Gauss});
+  db::mutate_apply<
+      CurvedScalarWave::Initialization::InitializeConstraintDampingGammas<Dim>>(
+      make_not_null(&box));
+  CHECK(get<CurvedScalarWave::Tags::ConstraintGamma1>(box) ==
+        Scalar<DataVector>{pow(4, Dim), 0.});
+  CHECK(get<CurvedScalarWave::Tags::ConstraintGamma2>(box) ==
+        Scalar<DataVector>{pow(4, Dim), 1.});
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.CurvedScalarWave.InitializeConstraintGammas",
+    "[Unit][Evolution]") {
+  test_initialize_constraint_damping_gammas<1>();
+  test_initialize_constraint_damping_gammas<2>();
+  test_initialize_constraint_damping_gammas<3>();
+}

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_InitializeGrVars.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_InitializeGrVars.cpp
@@ -1,0 +1,65 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cmath>
+#include <limits>
+#include <random>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Initialize.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+
+template <typename BackgroundSolution>
+void test_initialize_gr_vars(const BackgroundSolution& analytic_solution,
+                             const gsl::not_null<std::mt19937*> generator) {
+  static constexpr size_t Dim = BackgroundSolution::volume_dim;
+  using gr_vars_tag =
+      typename CurvedScalarWave::System<Dim>::spacetime_variables_tag;
+  using GrVars = typename gr_vars_tag::type;
+  const size_t num_points = 42;
+  std::uniform_real_distribution dist{-10., 10.};
+  const auto random_coords = make_with_random_values<tnsr::I<DataVector, Dim>>(
+      generator, make_not_null(&dist), DataVector{num_points});
+  auto box = db::create<
+      db::AddSimpleTags<gr_vars_tag, ::Initialization::Tags::InitialTime,
+                        domain::Tags::Coordinates<Dim, Frame::Inertial>,
+                        ::Tags::AnalyticSolution<BackgroundSolution>>>(
+      GrVars{}, 0., random_coords, analytic_solution);
+  db::mutate_apply<CurvedScalarWave::Initialization::InitializeGrVars<Dim>>(
+      make_not_null(&box));
+  const auto sol = analytic_solution.variables(random_coords, 0.,
+                                               typename GrVars::tags_list{});
+  tmpl::for_each<typename GrVars::tags_list>([&box, &sol](auto tag_v) {
+    using tag = typename decltype(tag_v)::type;
+    CHECK(get<tag>(box) == get<tag>(sol));
+  });
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.InitializeGrVars",
+                  "[Unit][Evolution]") {
+  MAKE_GENERATOR(generator);
+  test_initialize_gr_vars(gr::Solutions::Minkowski<1>(),
+                          make_not_null(&generator));
+  test_initialize_gr_vars(gr::Solutions::Minkowski<2>(),
+                          make_not_null(&generator));
+  test_initialize_gr_vars(gr::Solutions::Minkowski<3>(),
+                          make_not_null(&generator));
+  test_initialize_gr_vars(
+      gr::Solutions::KerrSchild(1., {0.5, 0., 0.1}, {0.2, 0.5, -0.7}),
+      make_not_null(&generator));
+}


### PR DESCRIPTION
## Proposed changes

This adds an executable in 1, 2, and 3 spatial dimensions to the `CurvedScalarWave` system. They are on an Interval/Rectangle/Cube domain with periodic boundary conditions. For the 3D case some observations are made.

I will add shortly in follow-up  PRs:

1. An executable with KerrSchild background that will do observations of scalar wave tails reproducing the results of https://arxiv.org/abs/gr-qc/0305027 
2. Support for time-dependent coordinate maps

This PR replaces #2973 and #1852 which are stale.

- [x] depends on #3728 