### PR TITLE
Add dimensionless spin magnitude functions and compute tag

### DIFF
--- a/src/ApparentHorizons/StrahlkorperGr.hpp
+++ b/src/ApparentHorizons/StrahlkorperGr.hpp
@@ -387,7 +387,8 @@ Scalar<DataVector> spin_function(
  * `unit_normal_vector` can
  * be found by raising the index of the one-form returned by
  * `StrahlkorperGr::unit_normal_one_form`.
- * The argument `ylm` is the `YlmSpherepack` of the `Strahlkorper`.
+ * The argument `strahlkorper` is the surface on which the spin magnitude is
+ * computed.
  * The argument `area_element`
  * can be computed via `StrahlkorperGr::area_element`.
  */
@@ -398,7 +399,8 @@ void dimensionful_spin_magnitude(
     const Scalar<DataVector>& spin_function,
     const tnsr::ii<DataVector, 3, Frame>& spatial_metric,
     const StrahlkorperTags::aliases::Jacobian<Frame>& tangents,
-    const YlmSpherepack& ylm, const Scalar<DataVector>& area_element);
+    const Strahlkorper<Frame>& strahlkorper,
+    const Scalar<DataVector>& area_element);
 
 template <typename Frame>
 double dimensionful_spin_magnitude(
@@ -406,7 +408,8 @@ double dimensionful_spin_magnitude(
     const Scalar<DataVector>& spin_function,
     const tnsr::ii<DataVector, 3, Frame>& spatial_metric,
     const StrahlkorperTags::aliases::Jacobian<Frame>& tangents,
-    const YlmSpherepack& ylm, const Scalar<DataVector>& area_element);
+    const Strahlkorper<Frame>& strahlkorper,
+    const Scalar<DataVector>& area_element);
 
 /*!
  * \ingroup SurfacesGroup
@@ -477,4 +480,25 @@ double irreducible_mass(double area);
  */
 double christodoulou_mass(double dimensionful_spin_magnitude,
                           double irreducible_mass);
+
+/// @{
+/*!
+ * \ingroup SurfacesGroup
+ * \brief Dimensionless spin magnitude of a `Strahlkorper`.
+ *
+ * \details
+ * This function computes the dimensionless spin magnitude \f$\chi\f$
+ * from the dimensionful spin magnitude \f$S\f$ and the christodoulou
+ * mass \f$M\f$ of a black hole. Specifically, computes
+ * \f$\chi = \frac{S}{M^2}\f$.
+ */
+
+void dimensionless_spin_magnitude(const gsl::not_null<double*> result,
+                                  const double dimensionful_spin_magnitude,
+                                  const double christodoulou_mass);
+
+double dimensionless_spin_magnitude(const double dimensionful_spin_magnitude,
+                                    const double christodoulou_mass);
+/// @}
+
 }  // namespace StrahlkorperGr

--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -754,8 +754,8 @@ struct DimensionfulSpinMagnitudeCompute : DimensionfulSpinMagnitude,
   static constexpr auto function = static_cast<void (*)(
       const gsl::not_null<double*>, const Scalar<DataVector>&,
       const Scalar<DataVector>&, const tnsr::ii<DataVector, 3, Frame>&,
-      const StrahlkorperTags::aliases::Jacobian<Frame>&, const YlmSpherepack&,
-      const Scalar<DataVector>&)>(
+      const StrahlkorperTags::aliases::Jacobian<Frame>&,
+      const Strahlkorper<Frame>&, const Scalar<DataVector>&)>(
       &StrahlkorperGr::dimensionful_spin_magnitude<Frame>);
   using argument_tags =
       tmpl::list<StrahlkorperTags::RicciScalar, SpinFunction,
@@ -801,8 +801,35 @@ template <typename Frame>
 struct ChristodoulouMassCompute : ChristodoulouMass, db::ComputeTag {
   using base = ChristodoulouMass;
   using return_type = double;
-  static constexpr auto function = &StrahlkorperGr::christodoulou_mass;
+  static void function(const gsl::not_null<double*> result,
+                       const double dimensionful_spin_magnitude,
+                       const double irreducible_mass) {
+    *result = ::StrahlkorperGr::christodoulou_mass(dimensionful_spin_magnitude,
+                                                   irreducible_mass);
+  }
+
   using argument_tags = tmpl::list<DimensionfulSpinMagnitude, IrreducibleMass>;
+};
+
+/// The dimensionless spin magnitude of a `Strahlkorper`.
+template <typename Frame>
+struct DimensionlessSpinMagnitude : db::SimpleTag {
+  using type = double;
+};
+
+/// Computes the dimensionless spin magnitude \f$\chi = \frac{S}{M^2}\f$
+/// from the dimensionful spin magnitude \f$S\f$ and the christodoulou
+/// mass \f$M\f$ of a black hole.
+template <typename Frame>
+struct DimensionlessSpinMagnitudeCompute : DimensionlessSpinMagnitude<Frame>,
+                                           db::ComputeTag {
+  using base = DimensionlessSpinMagnitude<Frame>;
+  using return_type = double;
+  static constexpr auto function = static_cast<void (*)(
+      const gsl::not_null<double*>, const double, const double)>(
+      &StrahlkorperGr::dimensionless_spin_magnitude);
+  using argument_tags =
+      tmpl::list<DimensionfulSpinMagnitude, ChristodoulouMass>;
 };
 
 }  // namespace Tags

--- a/src/ApparentHorizons/TagsDeclarations.hpp
+++ b/src/ApparentHorizons/TagsDeclarations.hpp
@@ -89,6 +89,10 @@ struct DimensionfulSpinMagnitudeCompute;
 struct ChristodoulouMass;
 template <typename Frame>
 struct ChristodoulouMassCompute;
+template <typename Frame>
+struct DimensionlessSpinMagnitude;
+template <typename Frame>
+struct DimensionlessSpinMagnitudeCompute;
 
 }  // namespace Tags
 }  // namespace StrahlkorperGr

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
@@ -67,11 +67,11 @@ struct EvolutionMetavars<3, InitialData, BoundaryConditions>
 
   struct AhA {
     using temporal_id = ::Tags::Time;
-    using tags_to_observe =
-        tmpl::list<StrahlkorperGr::Tags::AreaCompute<frame>,
-                   StrahlkorperGr::Tags::IrreducibleMassCompute<frame>,
-                   StrahlkorperTags::MaxRicciScalarCompute,
-                   StrahlkorperTags::MinRicciScalarCompute>;
+    using tags_to_observe = tmpl::list<
+        StrahlkorperGr::Tags::AreaCompute<frame>,
+        StrahlkorperGr::Tags::IrreducibleMassCompute<frame>,
+        StrahlkorperTags::MaxRicciScalarCompute,
+        StrahlkorperTags::MinRicciScalarCompute>;
     using compute_vars_to_interpolate = ah::ComputeHorizonVolumeQuantities;
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::SpatialMetric<volume_dim, frame, DataVector>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
@@ -71,7 +71,9 @@ struct EvolutionMetavars<3, InitialData, BoundaryConditions>
         StrahlkorperGr::Tags::AreaCompute<frame>,
         StrahlkorperGr::Tags::IrreducibleMassCompute<frame>,
         StrahlkorperTags::MaxRicciScalarCompute,
-        StrahlkorperTags::MinRicciScalarCompute>;
+        StrahlkorperTags::MinRicciScalarCompute,
+        StrahlkorperGr::Tags::ChristodoulouMassCompute<frame>,
+        StrahlkorperGr::Tags::DimensionlessSpinMagnitudeCompute<frame>>;
     using compute_vars_to_interpolate = ah::ComputeHorizonVolumeQuantities;
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::SpatialMetric<volume_dim, frame, DataVector>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -185,16 +185,22 @@ struct EvolutionMetavars {
       gr::Tags::SpatialMetric<volume_dim, ::Frame::Grid, DataVector>,
       gr::Tags::InverseSpatialMetric<volume_dim, ::Frame::Grid>,
       gr::Tags::ExtrinsicCurvature<volume_dim, ::Frame::Grid>,
-      gr::Tags::SpatialChristoffelSecondKind<volume_dim, ::Frame::Grid>>;
+      gr::Tags::SpatialChristoffelSecondKind<volume_dim, ::Frame::Grid>,
+      gr::Tags::SpatialRicci<volume_dim, ::Frame::Grid>>;
   // Observe both horizons in grid frame too.
-  using horizons_tags_to_observe =
-      tmpl::list<StrahlkorperGr::Tags::AreaCompute<::Frame::Grid>,
-                 StrahlkorperGr::Tags::IrreducibleMassCompute<::Frame::Grid>>;
+  using horizons_tags_to_observe = tmpl::list<
+      StrahlkorperGr::Tags::AreaCompute<::Frame::Grid>,
+      StrahlkorperGr::Tags::IrreducibleMassCompute<::Frame::Grid>,
+      StrahlkorperTags::MaxRicciScalarCompute,
+      StrahlkorperTags::MinRicciScalarCompute,
+      StrahlkorperGr::Tags::ChristodoulouMassCompute<::Frame::Grid>,
+      StrahlkorperGr::Tags::DimensionlessSpinMagnitudeCompute<::Frame::Grid>>;
   using horizons_compute_items_on_target = tmpl::append<
       tmpl::list<StrahlkorperGr::Tags::AreaElementCompute<::Frame::Grid>,
                  StrahlkorperTags::ThetaPhiCompute<::Frame::Grid>,
                  StrahlkorperTags::RadiusCompute<::Frame::Grid>,
                  StrahlkorperTags::RhatCompute<::Frame::Grid>,
+                 StrahlkorperTags::TangentsCompute<::Frame::Grid>,
                  StrahlkorperTags::InvJacobianCompute<::Frame::Grid>,
                  StrahlkorperTags::DxRadiusCompute<::Frame::Grid>,
                  StrahlkorperTags::OneOverOneFormMagnitudeCompute<
@@ -204,7 +210,10 @@ struct EvolutionMetavars {
                  StrahlkorperTags::UnitNormalVectorCompute<::Frame::Grid>,
                  StrahlkorperTags::GradUnitNormalOneFormCompute<::Frame::Grid>,
                  StrahlkorperTags::ExtrinsicCurvatureCompute<::Frame::Grid>,
-                 StrahlkorperGr::Tags::SpinFunctionCompute<::Frame::Grid>>,
+                 StrahlkorperGr::Tags::SpinFunctionCompute<::Frame::Grid>,
+                 StrahlkorperTags::RicciScalarCompute<::Frame::Grid>,
+                 StrahlkorperGr::Tags::DimensionfulSpinMagnitudeCompute<
+                     ::Frame::Grid>>,
       horizons_tags_to_observe>;
 
   struct AhA {
@@ -242,10 +251,12 @@ struct EvolutionMetavars {
   };
 
   using interpolation_target_tags = tmpl::list<AhA,AhB>;
-  using interpolator_source_vars =
-      tmpl::list<gr::Tags::SpacetimeMetric<volume_dim, ::Frame::Inertial>,
-                 GeneralizedHarmonic::Tags::Pi<volume_dim, ::Frame::Inertial>,
-                 GeneralizedHarmonic::Tags::Phi<volume_dim, ::Frame::Inertial>>;
+  using interpolator_source_vars = tmpl::list<
+      gr::Tags::SpacetimeMetric<volume_dim, ::Frame::Inertial>,
+      GeneralizedHarmonic::Tags::Pi<volume_dim, ::Frame::Inertial>,
+      GeneralizedHarmonic::Tags::Phi<volume_dim, ::Frame::Inertial>,
+      Tags::deriv<GeneralizedHarmonic::Tags::Phi<volume_dim, Frame::Inertial>,
+                  tmpl::size_t<3>, Frame::Inertial>>;
 
   using observe_fields = tmpl::list<
       gr::Tags::Lapse<DataVector>,

--- a/tests/Unit/ApparentHorizons/Test_Tags.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Tags.cpp
@@ -366,6 +366,27 @@ void test_dimensionful_spin_vector_compute_tag() {
             ricci_scalar, spin_function, strahlkorper));
 }
 
+void test_dimensionless_spin_magnitude_compute_tag() {
+  const double dimensionful_spin_magnitude{5.0};
+  const double christodoulou_mass = 4.444;
+
+  const auto box = db::create<
+      db::AddSimpleTags<StrahlkorperGr::Tags::DimensionfulSpinMagnitude,
+                        StrahlkorperGr::Tags::ChristodoulouMass>,
+      db::AddComputeTags<
+          StrahlkorperGr::Tags::DimensionlessSpinMagnitudeCompute<
+              Frame::Inertial>>>(dimensionful_spin_magnitude,
+                                 christodoulou_mass);
+  // LHS of the == in the CHECK is retrieving the computed dimensionless spin
+  // magnitude from your DimensionlessSpinMagnitudeCompute tag and RHS of ==
+  // should be same logic as DimensionlessSpinMagnitudeCompute::function
+  CHECK(db::get<
+            StrahlkorperGr::Tags::DimensionlessSpinMagnitude<Frame::Inertial>>(
+            box) ==
+        StrahlkorperGr::dimensionless_spin_magnitude(
+            dimensionful_spin_magnitude, christodoulou_mass));
+}
+
 struct SomeType {};
 struct SomeTag : db::SimpleTag {
   using type = SomeType;
@@ -381,6 +402,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
   test_max_ricci_scalar();
   test_min_ricci_scalar();
   test_dimensionful_spin_vector_compute_tag();
+  test_dimensionless_spin_magnitude_compute_tag();
   TestHelpers::db::test_simple_tag<ah::Tags::FastFlow>("FastFlow");
   TestHelpers::db::test_simple_tag<StrahlkorperGr::Tags::Area>("Area");
   TestHelpers::db::test_simple_tag<StrahlkorperGr::Tags::IrreducibleMass>(
@@ -455,6 +477,9 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
   TestHelpers::db::test_simple_tag<
       StrahlkorperGr::Tags::DimensionfulSpinVector<Frame::Inertial>>(
       "DimensionfulSpinVector");
+  TestHelpers::db::test_simple_tag<
+      StrahlkorperGr::Tags::DimensionlessSpinMagnitude<Frame::Inertial>>(
+      "DimensionlessSpinMagnitude");
   TestHelpers::db::test_compute_tag<
       StrahlkorperTags::ThetaPhiCompute<Frame::Inertial>>("ThetaPhi");
   TestHelpers::db::test_compute_tag<
@@ -548,4 +573,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
   TestHelpers::db::test_compute_tag<
       StrahlkorperGr::Tags::DimensionfulSpinVectorCompute<Frame::Inertial>>(
       "DimensionfulSpinVector");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperGr::Tags::DimensionlessSpinMagnitudeCompute<Frame::Inertial>>(
+      "DimensionlessSpinMagnitude");
 }


### PR DESCRIPTION
## Proposed changes

This PR adds the functions and tags used to calculate the dimensionless spin magnitude of a Strahlkorper. Computes the dimensionless spin magnitude from the dimensionful spin magnitude and the Christodoulou mass of a black hole. Adds the DimensionlessSpinMagnitudeCompute tag to EvolveGeneralizedHarmonicWithHorizon.hpp and EvolveGhBinaryBlackHole.hpp.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
