### PR TITLE
Make `ScalarWaveGr` accept `CurvedScalarWave` initial data directly

### DIFF
--- a/src/Evolution/Systems/ScalarWave/Tags.hpp
+++ b/src/Evolution/Systems/ScalarWave/Tags.hpp
@@ -17,16 +17,40 @@
 class DataVector;
 
 namespace ScalarWave::Tags {
+/*!
+ * \brief The scalar field.
+ */
 struct Psi : db::SimpleTag {
   using type = Scalar<DataVector>;
   static std::string name() { return "Psi"; }
 };
 
+/*!
+ * \brief The conjugate momentum of the scalar field.
+ *
+ * \details Its definition comes from requiring it to be the future-directed
+ * time derivative of the scalar field \f$\Psi\f$ in curved spacetime, see
+ * \cite Scheel2003vs , Eq. 2.16:
+ *
+ * \f{align}
+ * \Pi :=& -n^a \partial_a \Psi \\
+ *     =&  \frac{1}{\alpha}\left(\beta^k \Phi_k - {\partial_t\Psi}\right),\\
+ * \f}
+ *
+ * where \f$n^a\f$ is the unit normal to spatial slices of the spacetime
+ * foliation, \f$\alpha\f$ is the lapse and \f$\beta^i\f$ is the shift vector.
+ */
 struct Pi : db::SimpleTag {
   using type = Scalar<DataVector>;
   static std::string name() { return "Pi"; }
 };
 
+/*!
+ * \brief Auxiliary variable which is analytically the spatial derivative of the
+ * scalar field.
+ * \details If \f$\Psi\f$ is the scalar field then we define
+ * \f$\Phi_{i} = \partial_i \Psi\f$
+ */
 template <size_t Dim>
 struct Phi : db::SimpleTag {
   using type = tnsr::i<DataVector, Dim, Frame::Inertial>;

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/PureSphericalHarmonic.cpp
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/PureSphericalHarmonic.cpp
@@ -38,12 +38,10 @@ PureSphericalHarmonic::PureSphericalHarmonic(const double radius,
   }
 }
 
-tuples::TaggedTuple<CurvedScalarWave::Tags::Pi, CurvedScalarWave::Tags::Phi<3>,
-                    CurvedScalarWave::Tags::Psi>
-PureSphericalHarmonic::variables(
-    const tnsr::I<DataVector, 3>& x, double /*t*/,
-    tmpl::list<CurvedScalarWave::Tags::Pi, CurvedScalarWave::Tags::Phi<3>,
-               CurvedScalarWave::Tags::Psi> /*meta*/) const {
+tuples::TaggedTuple<CurvedScalarWave::Tags::Psi, CurvedScalarWave::Tags::Pi,
+                    CurvedScalarWave::Tags::Phi<3>>
+PureSphericalHarmonic::variables(const tnsr::I<DataVector, 3>& x, double /*t*/,
+                                 tags /*meta*/) const {
   Scalar<DataVector> pi{get(magnitude(x)) - radius_};
   get(pi) = exp(-get(pi) * get(pi) / width_sq_);
   const Spectral::Swsh::SpinWeightedSphericalHarmonic spherical_harmonic(
@@ -52,11 +50,11 @@ PureSphericalHarmonic::variables(
   const auto phi = atan2(x[1], x[0]);
   get(pi) *= real(spherical_harmonic.evaluate(theta, phi, sin(theta / 2.),
                                               cos(theta / 2.)));
-  return tuples::TaggedTuple<CurvedScalarWave::Tags::Pi,
-                             CurvedScalarWave::Tags::Phi<3>,
-                             CurvedScalarWave::Tags::Psi>{
-      std::move(pi), make_with_value<tnsr::i<DataVector, 3>>(x, 0.),
-      make_with_value<Scalar<DataVector>>(x, 0.)};
+  return tuples::TaggedTuple<CurvedScalarWave::Tags::Psi,
+                             CurvedScalarWave::Tags::Pi,
+                             CurvedScalarWave::Tags::Phi<3>>{
+      make_with_value<Scalar<DataVector>>(x, 0.), std::move(pi),
+      make_with_value<tnsr::i<DataVector, 3>>(x, 0.)};
 }
 
 void PureSphericalHarmonic::pup(PUP::er& p) {

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/PureSphericalHarmonic.hpp
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/PureSphericalHarmonic.hpp
@@ -74,14 +74,15 @@ class PureSphericalHarmonic : public MarkAsAnalyticData {
                         std::pair<size_t, int> mode,
                         const Options::Context& context = {});
 
+  static constexpr size_t volume_dim = 3;
+  using tags =
+      tmpl::list<CurvedScalarWave::Tags::Psi, CurvedScalarWave::Tags::Pi,
+                 CurvedScalarWave::Tags::Phi<3>>;
+
   /// Retrieve the evolution variables at spatial coordinates `x`
-  tuples::TaggedTuple<CurvedScalarWave::Tags::Pi,
-                      CurvedScalarWave::Tags::Phi<3>,
-                      CurvedScalarWave::Tags::Psi>
-  variables(
-      const tnsr::I<DataVector, 3>& x, double /*t*/,
-      tmpl::list<CurvedScalarWave::Tags::Pi, CurvedScalarWave::Tags::Phi<3>,
-                 CurvedScalarWave::Tags::Psi> /*meta*/) const;
+  tuples::TaggedTuple<CurvedScalarWave::Tags::Psi, CurvedScalarWave::Tags::Pi,
+                      CurvedScalarWave::Tags::Phi<3>>
+  variables(const tnsr::I<DataVector, 3>& x, double /*t*/, tags /*meta*/) const;
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/);

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveGr.cpp
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveGr.cpp
@@ -20,7 +20,7 @@ namespace CurvedScalarWave::AnalyticData {
 
 template <typename ScalarFieldData, typename BackgroundGrData>
 void ScalarWaveGr<ScalarFieldData, BackgroundGrData>::pup(PUP::er& p) {
-  p | flat_space_scalar_wave_data_;
+  p | scalar_wave_data_;
   p | background_gr_data_;
 }
 
@@ -30,23 +30,22 @@ ScalarWaveGr<ScalarFieldData, BackgroundGrData>::variables(
     const tnsr::I<DataVector, volume_dim>& x,
     tmpl::list<Tags::Pi> /*meta*/) const {
   constexpr double default_initial_time = 0.;
-  const auto flat_space_scalar_wave_vars =
-      flat_space_scalar_wave_data_.variables(
-          x, default_initial_time,
-          tmpl::list<ScalarWave::Tags::Psi, ScalarWave::Tags::Pi,
-                     ScalarWave::Tags::Phi<volume_dim>>{});
+  const auto scalar_wave_vars = scalar_wave_data_.variables(
+      x, default_initial_time, evolved_field_vars_tags{});
+  if constexpr (is_curved) {
+    return std::move(get<InitialDataPi>(scalar_wave_vars));
+  }
   const auto spacetime_variables = background_gr_data_.variables(
       x, default_initial_time, spacetime_tags<DataVector>{});
   auto result = make_with_value<tuples::TaggedTuple<Tags::Pi>>(x, 0.);
 
-  const auto shift_dot_dpsi = dot_product(
-      get<gr::Tags::Shift<volume_dim, Frame::Inertial, DataVector>>(
-          spacetime_variables),
-      get<ScalarWave::Tags::Phi<volume_dim>>(flat_space_scalar_wave_vars));
+  const auto shift_dot_dpsi =
+      dot_product(get<gr::Tags::Shift<volume_dim, Frame::Inertial, DataVector>>(
+                      spacetime_variables),
+                  get<InitialDataPhi>(scalar_wave_vars));
 
   get(get<Tags::Pi>(result)) =
-      (get(shift_dot_dpsi) +
-       get(get<ScalarWave::Tags::Pi>(flat_space_scalar_wave_vars))) /
+      (get(shift_dot_dpsi) + get(get<InitialDataPi>(scalar_wave_vars))) /
       get(get<gr::Tags::Lapse<DataVector>>(spacetime_variables));
 
   return result;
@@ -85,7 +84,8 @@ GENERATE_INSTANTIATIONS(INSTANTIATE,
                         (gr::Solutions::Minkowski<3>,
                          gr::Solutions::KerrSchild),
                         (ScalarWave::Solutions::PlaneWave<3>,
-                         ScalarWave::Solutions::RegularSphericalWave))
+                         ScalarWave::Solutions::RegularSphericalWave,
+                         CurvedScalarWave::AnalyticData::PureSphericalHarmonic))
 
 #undef BG
 #undef SOL

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
@@ -76,6 +76,9 @@ class PlaneWave : public MarkAsAnalyticSolution {
 
   static constexpr Options::String help = {
       "A plane wave solution of the Euclidean wave equation"};
+  using tags =
+      tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<3>, ::Tags::dt<Tags::Psi>,
+                 ::Tags::dt<Tags::Pi>, ::Tags::dt<Tags::Phi<Dim>>>;
 
   PlaneWave() = default;
   PlaneWave(std::array<double, Dim> wave_vector, std::array<double, Dim> center,

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp
@@ -78,6 +78,10 @@ class RegularSphericalWave : public MarkAsAnalyticSolution {
       "A spherical wave solution of the Euclidean wave equation that is "
       "regular at the origin"};
 
+  using tags =
+      tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<3>, ::Tags::dt<Tags::Psi>,
+                 ::Tags::dt<Tags::Pi>, ::Tags::dt<Tags::Phi<3>>>;
+
   RegularSphericalWave() = default;
   explicit RegularSphericalWave(
       std::unique_ptr<MathFunction<1, Frame::Inertial>> profile);

--- a/tests/Unit/PointwiseFunctions/AnalyticData/CurvedWaveEquation/Test_ScalarWaveGr.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/CurvedWaveEquation/Test_ScalarWaveGr.cpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <memory>
+#include <tuple>
 #include <utility>
 
 #include "DataStructures/DataVector.hpp"
@@ -15,6 +16,7 @@
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/PointwiseFunctions/AnalyticData/TestHelpers.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
+#include "PointwiseFunctions/AnalyticData/CurvedWaveEquation/PureSphericalHarmonic.hpp"
 #include "PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveGr.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
@@ -54,27 +56,33 @@ void test_tag_retrieval(const CurvedScalarWave::AnalyticData::ScalarWaveGr<
 template <typename ScalarFieldData, typename BackgroundData>
 void test_no_hole(const CurvedScalarWave::AnalyticData::ScalarWaveGr<
                       ScalarFieldData, BackgroundData>& curved_wave_data,
-                  const ScalarFieldData& flat_wave_solution) {
+                  const ScalarFieldData& wave_solution) {
+  using ScalarWaveGrType =
+      typename CurvedScalarWave::AnalyticData::ScalarWaveGr<ScalarFieldData,
+                                                            BackgroundData>;
   const tnsr::I<DataVector, 3> x{std::array<DataVector, 3>{
       {DataVector({0., 1., 2., 3.}), DataVector({0., 0., 0., 0.}),
        DataVector({0., 0., 0., 0.})}}};
   auto vars = curved_wave_data.variables(
       x, tmpl::list<CurvedScalarWave::Tags::Psi, CurvedScalarWave::Tags::Pi,
                     CurvedScalarWave::Tags::Phi<3>>{});
-  auto flat_vars = flat_wave_solution.variables(
-      x, 0.,
-      tmpl::list<ScalarWave::Tags::Psi, ScalarWave::Tags::Pi,
-                 ScalarWave::Tags::Phi<3>>{});
-  CHECK_ITERABLE_APPROX(get(get<CurvedScalarWave::Tags::Psi>(vars)),
-                        get(get<ScalarWave::Tags::Psi>(flat_vars)));
-  CHECK_ITERABLE_APPROX(get(get<CurvedScalarWave::Tags::Pi>(vars)),
-                        get(get<ScalarWave::Tags::Pi>(flat_vars)));
-  CHECK_ITERABLE_APPROX(get<0>(get<CurvedScalarWave::Tags::Phi<3>>(vars)),
-                        get<0>(get<ScalarWave::Tags::Phi<3>>(flat_vars)));
-  CHECK_ITERABLE_APPROX(get<1>(get<CurvedScalarWave::Tags::Phi<3>>(vars)),
-                        get<1>(get<ScalarWave::Tags::Phi<3>>(flat_vars)));
-  CHECK_ITERABLE_APPROX(get<2>(get<CurvedScalarWave::Tags::Phi<3>>(vars)),
-                        get<2>(get<ScalarWave::Tags::Phi<3>>(flat_vars)));
+  auto wave_vars = wave_solution.variables(
+      x, 0., typename ScalarWaveGrType::evolved_field_vars_tags{});
+  CHECK_ITERABLE_APPROX(
+      get(get<CurvedScalarWave::Tags::Psi>(vars)),
+      get(get<typename ScalarWaveGrType::InitialDataPsi>(wave_vars)));
+  CHECK_ITERABLE_APPROX(
+      get(get<CurvedScalarWave::Tags::Pi>(vars)),
+      get(get<typename ScalarWaveGrType::InitialDataPi>(wave_vars)));
+  CHECK_ITERABLE_APPROX(
+      get<0>(get<CurvedScalarWave::Tags::Phi<3>>(vars)),
+      get<0>(get<typename ScalarWaveGrType::InitialDataPhi>(wave_vars)));
+  CHECK_ITERABLE_APPROX(
+      get<1>(get<CurvedScalarWave::Tags::Phi<3>>(vars)),
+      get<1>(get<typename ScalarWaveGrType::InitialDataPhi>(wave_vars)));
+  CHECK_ITERABLE_APPROX(
+      get<2>(get<CurvedScalarWave::Tags::Phi<3>>(vars)),
+      get<2>(get<typename ScalarWaveGrType::InitialDataPhi>(wave_vars)));
 }
 
 template <typename ScalarFieldData>
@@ -82,7 +90,11 @@ void test_kerr(
     const CurvedScalarWave::AnalyticData::ScalarWaveGr<
         ScalarFieldData, gr::Solutions::KerrSchild>& curved_wave_data,
     const gr::Solutions::KerrSchild& bh_solution,
-    const ScalarFieldData& flat_wave_solution) {
+    const ScalarFieldData& wave_solution) {
+  using ScalarWaveGrType =
+      CurvedScalarWave::AnalyticData::ScalarWaveGr<ScalarFieldData,
+                                                   gr::Solutions::KerrSchild>;
+
   const tnsr::I<DataVector, 3> x{std::array<DataVector, 3>{
       {DataVector({0., 1., 2., 3.}), DataVector({0., 0., 0., 0.}),
        DataVector({0., 0., 0., 0.})}}};
@@ -90,22 +102,25 @@ void test_kerr(
       x, tmpl::list<CurvedScalarWave::Tags::Psi, CurvedScalarWave::Tags::Pi,
                     CurvedScalarWave::Tags::Phi<3>>{});
 
-  const auto flat_wave_vars = flat_wave_solution.variables(
-      x, 0., ScalarWave::System<3>::variables_tag::tags_list{});
+  const auto wave_vars = wave_solution.variables(
+      x, 0., typename ScalarWaveGrType::evolved_field_vars_tags{});
 
   const auto kerr_variables = bh_solution.variables(
       x, 0., gr::Solutions::KerrSchild::tags<DataVector>{});
 
   // construct the expected vars in-situ
-  const auto& local_psi = get<ScalarWave::Tags::Psi>(flat_wave_vars);
-  const auto& local_phi = get<ScalarWave::Tags::Phi<3>>(flat_wave_vars);
-  auto local_pi = make_with_value<Scalar<DataVector>>(x, 0.);
-  {
+  const auto& local_psi =
+      get<typename ScalarWaveGrType::InitialDataPsi>(wave_vars);
+  const auto& local_phi =
+      get<typename ScalarWaveGrType::InitialDataPhi>(wave_vars);
+  auto local_pi = get<typename ScalarWaveGrType::InitialDataPi>(wave_vars);
+  if constexpr (not ScalarWaveGrType::is_curved) {
     const auto shift_dot_dpsi = dot_product(
         get<gr::Tags::Shift<3, Frame::Inertial, DataVector>>(kerr_variables),
-        get<ScalarWave::Tags::Phi<3>>(flat_wave_vars));
+        get<typename ScalarWaveGrType::InitialDataPhi>(wave_vars));
     get(local_pi) =
-        (get(shift_dot_dpsi) + get(get<ScalarWave::Tags::Pi>(flat_wave_vars))) /
+        (get(shift_dot_dpsi) +
+         get(get<typename ScalarWaveGrType::InitialDataPi>(wave_vars))) /
         get(get<gr::Tags::Lapse<DataVector>>(kerr_variables));
   }
 
@@ -227,6 +242,36 @@ void test_construct_from_options() {
 
     test_kerr(curved_wave_data_constructed_from_opts, bh_solution,
               flat_wave_solution);
+  }
+  {  // test with wave profile = PureSphericalHarmonic
+    const auto curved_wave_data_constructed_from_opts =
+        TestHelpers::test_creation<
+            CurvedScalarWave::AnalyticData::ScalarWaveGr<
+                CurvedScalarWave::AnalyticData::PureSphericalHarmonic,
+                gr::Solutions::KerrSchild>,
+            Metavariables>(
+            "Background:\n"
+            "  Mass: 0.7\n"
+            "  Spin: [0.1, -0.2, 0.3]\n"
+            "  Center: [0.7,0.6,-2.]\n"
+            "ScalarField:\n"
+            "  Radius: 10.\n"
+            "  Width: 1.\n"
+            "  Mode: [4, -3]");
+
+    // construct internals of data constructed from options
+    const gr::Solutions::KerrSchild bh_solution(0.7, {{0.1, -0.2, 0.3}},
+                                                {{0.7, 0.6, -2.}});
+    const CurvedScalarWave::AnalyticData::PureSphericalHarmonic wave_solution{
+        10., 1., {4, -3}};
+
+    CHECK(curved_wave_data_constructed_from_opts ==
+          CurvedScalarWave::AnalyticData::ScalarWaveGr<
+              CurvedScalarWave::AnalyticData::PureSphericalHarmonic,
+              gr::Solutions::KerrSchild>(bh_solution, wave_solution));
+
+    test_kerr(curved_wave_data_constructed_from_opts, bh_solution,
+              wave_solution);
   }
   {  // test flat spacetime with wave profile = plane in 3D
     const auto curved_wave_data_constructed_from_opts =
@@ -366,6 +411,24 @@ void test_serialize(const double mass, const std::array<double, 3>& spin,
 
     test_kerr(snd_curved_wave_data, bh_solution, flat_wave_solution);
   }
+  {  // test with wave profile = PureSphericalHarmonic
+    CurvedScalarWave::AnalyticData::ScalarWaveGr<
+        CurvedScalarWave::AnalyticData::PureSphericalHarmonic,
+        gr::Solutions::KerrSchild>
+        curved_wave_data(gr::Solutions::KerrSchild(mass, spin, center),
+                         CurvedScalarWave::AnalyticData::PureSphericalHarmonic(
+                             10., 2., {4, 2}));
+    const auto snd_curved_wave_data =
+        serialize_and_deserialize(curved_wave_data);
+    CHECK(curved_wave_data == snd_curved_wave_data);
+
+    // test internals of deserialized data
+    const gr::Solutions::KerrSchild bh_solution(mass, spin, center);
+    const CurvedScalarWave::AnalyticData::PureSphericalHarmonic
+        curved_wave_solution{10., 2., {4, 2}};
+
+    test_kerr(snd_curved_wave_data, bh_solution, curved_wave_solution);
+  }
 }
 
 void test_move(const double mass, const std::array<double, 3>& spin,
@@ -406,6 +469,23 @@ void test_move(const double mass, const std::array<double, 3>& spin,
                 {{1.0, 1.0, 1.0}}, {{0.0, 0.0, 0.0}},
                 std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(
                     11., 1.4, 0.3)));
+    test_move_semantics(std::move(curved_wave_data), copy_of_curved_wave_data);
+  }
+  {  // test with wave profile = PureSphericalHarmonic
+    CurvedScalarWave::AnalyticData::ScalarWaveGr<
+        CurvedScalarWave::AnalyticData::PureSphericalHarmonic,
+        gr::Solutions::KerrSchild>
+        curved_wave_data(gr::Solutions::KerrSchild(mass, spin, center),
+                         CurvedScalarWave::AnalyticData::PureSphericalHarmonic(
+                             10., 2., {4, 2}));
+    // since it can't actually be copied
+    CurvedScalarWave::AnalyticData::ScalarWaveGr<
+        CurvedScalarWave::AnalyticData::PureSphericalHarmonic,
+        gr::Solutions::KerrSchild>
+        copy_of_curved_wave_data(
+            gr::Solutions::KerrSchild(mass, spin, center),
+            CurvedScalarWave::AnalyticData::PureSphericalHarmonic(10., 2.,
+                                                                  {4, 2}));
     test_move_semantics(std::move(curved_wave_data), copy_of_curved_wave_data);
   }
 }
@@ -498,10 +578,28 @@ void test_scalarwave_minkowski() {
   test_no_hole(curved_wave_data, flat_wave_solution);
 }
 
+void test_curved_scalarwave_minkowski() {
+  // test with wave profile = PureSphericalHarmonic in flat space
+  using flat_background_tag = gr::Solutions::Minkowski<3>;
+  using sw_tag = CurvedScalarWave::AnalyticData::PureSphericalHarmonic;
+  const double radius = 10.;
+  const double width = 2.;
+  const std::pair<size_t, int> mode{4, -3};
+  const CurvedScalarWave::AnalyticData::ScalarWaveGr<sw_tag,
+                                                     flat_background_tag>
+      curved_wave_data{flat_background_tag{}, sw_tag(radius, width, mode)};
+
+  const sw_tag wave_solution{radius, width, mode};
+
+  test_tag_retrieval(curved_wave_data);
+  test_no_hole(curved_wave_data, wave_solution);
+}
+
 SPECTRE_TEST_CASE("Unit.AnalyticData.CurvedWaveEquation.ScalarWaveGr",
                   "[PointwiseFunctions][Unit]") {
   test_scalarwave_bh();
   test_scalarwave_minkowski();
+  test_curved_scalarwave_minkowski();
 }
 
 // Check restrictions on input options below


### PR DESCRIPTION
## Proposed changes

Currently the `ScalarWaveGr` class accepts only `ScalarWave` solutions and adjusts `Pi` to the background with spacetime quantities. There is no way to directly set `Pi` for the `CurvedScalarWave` initial data.

This PR adjusts `ScalarWaveGr` to recognize whether the wave solution//data comes from a `ScalarWave` solution where `Pi` needs to be adjusted with the background spacetime or directly from a `CurvedScalarWave` solution where `Pi` just needs to be forwarded.

- [x] depends on #3736

