### PR TITLE
Move testing Parallel::mutate to ActionTesting

### DIFF
--- a/src/Parallel/GlobalCache.hpp
+++ b/src/Parallel/GlobalCache.hpp
@@ -618,26 +618,6 @@ bool mutable_cache_item_is_ready(GlobalCache<Metavariables>& cache,
 }
 
 /// \ingroup ParallelGroup
-/// \brief Mutates non-const data in the cache, by calling `Function::apply()`
-///
-/// \requires `GlobalCacheTag` is a tag in the `mutable_global_cache_tags`
-/// defined by the Metavariables and in Actions.
-/// \requires `Function` is a struct with a static void `apply()`
-/// function that mutates the object. `Function::apply()` takes as its
-/// first argument a `gsl::not_null` pointer to the object named by
-/// the `GlobalCacheTag`, and takes `args` as
-/// subsequent arguments.
-///
-/// This is the version that takes a GlobalCache<Metavariables>. Used only
-/// for tests.
-template <typename GlobalCacheTag, typename Function, typename Metavariables,
-          typename... Args>
-void mutate(GlobalCache<Metavariables>& cache, Args&&... args) {
-  cache.template mutate<GlobalCacheTag, Function>(
-      std::make_tuple<Args...>(std::forward<Args>(args)...));
-}
-
-/// \ingroup ParallelGroup
 ///
 /// \brief Mutates non-const data in the cache, by calling `Function::apply()`
 ///
@@ -647,8 +627,6 @@ void mutate(GlobalCache<Metavariables>& cache, Args&&... args) {
 /// first argument a `gsl::not_null` pointer to the object named by
 /// the `GlobalCacheTag`, and takes `args` as
 /// subsequent arguments.
-///
-/// This is the version that takes a charm++ proxy to the GlobalCache.
 template <typename GlobalCacheTag, typename Function, typename Metavariables,
           typename... Args>
 void mutate(CProxy_GlobalCache<Metavariables>& cache_proxy, Args&&... args) {

--- a/tests/Unit/ControlSystem/Test_Trigger.cpp
+++ b/tests/Unit/ControlSystem/Test_Trigger.cpp
@@ -127,9 +127,9 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Trigger", "[Domain][Unit]") {
 
   CHECK(not trigger.is_ready(box, cache, 0, component_p));
 
-  Parallel::mutate<control_system::Tags::MeasurementTimescales,
-                   control_system::UpdateFunctionOfTime>(cache, "LabelB"s, 0.5,
-                                                         DataVector{4.0}, 4.0);
+  ActionTesting::mutate<control_system::Tags::MeasurementTimescales,
+                        control_system::UpdateFunctionOfTime>(
+      cache, "LabelB"s, 0.5, DataVector{4.0}, 4.0);
 
   CHECK(trigger.is_ready(box, cache, 0, component_p));
   {

--- a/tests/Unit/ControlSystem/Test_UpdateFunctionOfTime.cpp
+++ b/tests/Unit/ControlSystem/Test_UpdateFunctionOfTime.cpp
@@ -90,8 +90,8 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.UpdateFunctionOfTime",
       ActionTesting::cache<TestSingleton<TestingMetavariables>>(runsys, 0_st);
 
   for (auto& name : {pp_name, quatfot_name}) {
-    Parallel::mutate<domain::Tags::FunctionsOfTime,
-                     control_system::UpdateFunctionOfTime>(
+    ActionTesting::mutate<domain::Tags::FunctionsOfTime,
+                          control_system::UpdateFunctionOfTime>(
         cache, name, update_time, updated_deriv, new_expiration_time);
   }
 
@@ -115,8 +115,8 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.UpdateFunctionOfTime",
   // Update functions of time in global cache with new expiration time
   const double newer_expiration_time = new_expiration_time + 1.0;
   for (auto& name : {pp_name, quatfot_name}) {
-    Parallel::mutate<domain::Tags::FunctionsOfTime,
-                     control_system::ResetFunctionOfTimeExpirationTime>(
+    ActionTesting::mutate<domain::Tags::FunctionsOfTime,
+                          control_system::ResetFunctionOfTimeExpirationTime>(
         cache, name, newer_expiration_time);
   }
 

--- a/tests/Unit/Domain/FunctionsOfTime/Test_FunctionsOfTimeAreReady.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_FunctionsOfTimeAreReady.cpp
@@ -104,7 +104,8 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTimeAreReady", "[Domain][Unit]") {
         cache, 0, component_p, 0.5, std::array{"OtherA"s}));
 
     // Make OtherA ready
-    Parallel::mutate<OtherFunctionsOfTime, UpdateFoT>(cache, "OtherA"s, 123.0);
+    ActionTesting::mutate<OtherFunctionsOfTime, UpdateFoT>(cache, "OtherA"s,
+                                                           123.0);
 
     CHECK(domain::functions_of_time_are_ready<OtherFunctionsOfTime>(
         cache, 0, component_p, 0.5, std::array{"OtherA"s}));
@@ -112,7 +113,8 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTimeAreReady", "[Domain][Unit]") {
         cache, 0, component_p, 0.5, std::array{"OtherA"s, "OtherB"s}));
 
     // Make OtherB ready
-    Parallel::mutate<OtherFunctionsOfTime, UpdateFoT>(cache, "OtherB"s, 456.0);
+    ActionTesting::mutate<OtherFunctionsOfTime, UpdateFoT>(cache, "OtherB"s,
+                                                           456.0);
 
     CHECK(domain::functions_of_time_are_ready<OtherFunctionsOfTime>(
         cache, 0, component_p, 0.5, std::array{"OtherA"s, "OtherB"s}));
@@ -128,14 +130,14 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTimeAreReady", "[Domain][Unit]") {
         make_not_null(&runner), 0));
 
     // Make OtherA ready
-    Parallel::mutate<domain::Tags::FunctionsOfTime, UpdateFoT>(
+    ActionTesting::mutate<domain::Tags::FunctionsOfTime, UpdateFoT>(
         cache, "FunctionA"s, 5.0);
 
     CHECK(not ActionTesting::next_action_if_ready<component>(
         make_not_null(&runner), 0));
 
     // Make OtherB ready
-    Parallel::mutate<domain::Tags::FunctionsOfTime, UpdateFoT>(
+    ActionTesting::mutate<domain::Tags::FunctionsOfTime, UpdateFoT>(
         cache, "FunctionB"s, 10.0);
 
     CHECK(ActionTesting::next_action_if_ready<component>(make_not_null(&runner),

--- a/tests/Unit/Framework/ActionTesting.hpp
+++ b/tests/Unit/Framework/ActionTesting.hpp
@@ -318,6 +318,33 @@ struct get_array_index;
  *
  * \snippet Test_ActionTesting.cpp constructor const global cache tags unknown
  *
+ * ### Mutable global cache tags
+ *
+ * Similarly to const global cache tags, sometimes Actions will want to change
+ * the data of a tag in the `Parallel::GlobalCache`. Consider this tag:
+ *
+ * \snippet Test_ActionTesting.cpp mutable cache tag
+ *
+ * To indicate that this tag in the global cache may be changed, it is added
+ * by, for example, the metavariables:
+ *
+ * \snippet Test_ActionTesting.cpp mutable global cache metavars
+ *
+ * Then, exactly like the const global cache tags, the constructor of
+ * `ActionTesting::MockRuntimeSystem` takes a `tuples::TaggedTuple` of the
+ * mutable global cache tags as its *second* argument. The mutable global cache
+ * tags are empty by default so you need not specify a `tuples::TaggedTuple` if
+ * you don't have any mutable global cache tags. Here is how you would specify
+ * zero const global cache tags and one mutable global cache tag:
+ *
+ * \snippet Test_ActionTesting.cpp mutable global cache runner
+ *
+ * To mutate a tag in the mutable global cache, use the `ActionTesting::mutate`
+ * function. This acts very similarly to the `Parallel::mutate` function, except
+ * that it takes a reference to the global cache instead of a proxy. When
+ * `ActionTesting::mutate` is called, it will queue a simple action on the
+ * component the reference to the cache was created from.
+ *
  * ### Inbox tags introspection
  *
  * The inbox tags can also be retrieved from a component by using the
@@ -331,8 +358,6 @@ struct get_array_index;
  *
  * The non-const version can be used like in the above example to clear or
  * otherwise manipulate the inbox tags.
- *
- * ###
  */
 namespace ActionTesting {}
 

--- a/tests/Unit/Framework/MockRuntimeSystemFreeFunctions.hpp
+++ b/tests/Unit/Framework/MockRuntimeSystemFreeFunctions.hpp
@@ -377,6 +377,23 @@ Parallel::GlobalCache<Metavariables>& cache(
       .cache();
 }
 
+/// \brief Mutates non-const tag GlobalCacheTag in the cache, by calling
+/// `Function::apply()`
+///
+/// \requires `GlobalCacheTag` is a tag in the `mutable_global_cache_tags`
+/// defined by the Metavariables and in Actions.
+/// \requires `Function` is a struct with a static void `apply()`
+/// function that mutates the object. `Function::apply()` takes as its
+/// first argument a `gsl::not_null` pointer to the object named by
+/// the `GlobalCacheTag`, and takes `args` as
+/// subsequent arguments.
+template <typename GlobalCacheTag, typename Function, typename Metavariables,
+          typename... Args>
+void mutate(Parallel::GlobalCache<Metavariables>& cache, Args&&... args) {
+  cache.template mutate<GlobalCacheTag, Function>(
+      std::make_tuple<Args...>(std::forward<Args>(args)...));
+}
+
 /// Returns a vector of all the indices of the Components in the
 /// ComponentList that have queued simple actions, for a particular
 /// array_index.

--- a/tests/Unit/Framework/Tests/Test_ActionTesting.cpp
+++ b/tests/Unit/Framework/Tests/Test_ActionTesting.cpp
@@ -941,9 +941,11 @@ SPECTRE_TEST_CASE("Unit.ActionTesting.NodesAndCores", "[Unit]") {
 }  // namespace TestNodesAndCores
 
 namespace TestMutableGlobalCache {
+// [mutable cache tag]
 struct CacheTag : db::SimpleTag {
   using type = int;
 };
+// [mutable cache tag]
 
 template <int Value>
 struct CacheTagUpdater {
@@ -980,7 +982,9 @@ struct SimpleActionToTest {
 struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
 
+  // [mutable global cache metavars]
   using mutable_global_cache_tags = tmpl::list<CacheTag>;
+  // [mutable global cache metavars]
 
   enum class Phase { Initialization, Testing, Exit };
 };
@@ -989,7 +993,9 @@ SPECTRE_TEST_CASE("Unit.ActionTesting.MutableGlobalCache", "[Unit]") {
   using metavars = Metavariables;
   using component = Component<metavars>;
 
+  // [mutable global cache runner]
   ActionTesting::MockRuntimeSystem<metavars> runner{{}, {0}};
+  // [mutable global cache runner]
   ActionTesting::emplace_array_component<component>(
       &runner, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{0}, 0);
 
@@ -1020,7 +1026,7 @@ SPECTRE_TEST_CASE("Unit.ActionTesting.MutableGlobalCache", "[Unit]") {
   CHECK(ActionTesting::is_simple_action_queue_empty<component>(runner, 0));
 
   // After we mutate the item, then SimpleActionToTest should be queued...
-  Parallel::mutate<CacheTag, CacheTagUpdater<1>>(cache);
+  ActionTesting::mutate<CacheTag, CacheTagUpdater<1>>(cache);
   CHECK(ActionTesting::number_of_queued_simple_actions<component>(runner, 0) ==
         1);
   // ... so invoke it
@@ -1048,7 +1054,7 @@ SPECTRE_TEST_CASE("Unit.ActionTesting.MutableGlobalCache", "[Unit]") {
   CHECK(ActionTesting::is_simple_action_queue_empty<component>(runner, 0));
 
   // After we mutate the item, then SimpleActionToTest should be queued...
-  Parallel::mutate<CacheTag, CacheTagUpdater<3>>(cache);
+  ActionTesting::mutate<CacheTag, CacheTagUpdater<3>>(cache);
   CHECK(ActionTesting::number_of_queued_simple_actions<component>(runner, 0) ==
         1);
   // ... so invoke it

--- a/tests/Unit/Parallel/Test_GlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_GlobalCache.cpp
@@ -17,6 +17,7 @@
 #include <string>
 #include <tuple>
 
+#include "Framework/ActionTesting.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Parallel/Algorithms/AlgorithmArray.hpp"
 #include "Parallel/Algorithms/AlgorithmGroup.hpp"
@@ -421,21 +422,21 @@ void Test_GlobalCache<Metavariables>::run_single_core_test() {
                            Parallel::get<animal_base>(cache).number_of_legs());
 
   // Check that we can modify the non-const items.
-  Parallel::mutate<weight, modify_value<double>>(cache, 150.0);
-  Parallel::mutate<email, modify_value<std::string>>(
+  ActionTesting::mutate<weight, modify_value<double>>(cache, 150.0);
+  ActionTesting::mutate<email, modify_value<std::string>>(
       cache, std::string("nobody@nowhere.com"));
   SPECTRE_PARALLEL_REQUIRE(150 == Parallel::get<weight>(cache));
   SPECTRE_PARALLEL_REQUIRE("nobody@nowhere.com" == Parallel::get<email>(cache));
-  Parallel::mutate<email, modify_value<std::string>>(
+  ActionTesting::mutate<email, modify_value<std::string>>(
       cache, std::string("isaac@newton.com"));
   SPECTRE_PARALLEL_REQUIRE("isaac@newton.com" == Parallel::get<email>(cache));
   // Make the arthropod into a spider.
-  Parallel::mutate<animal, modify_number_of_legs>(cache, 8_st);
+  ActionTesting::mutate<animal, modify_number_of_legs>(cache, 8_st);
   SPECTRE_PARALLEL_REQUIRE(8 == Parallel::get<animal>(cache).number_of_legs());
   SPECTRE_PARALLEL_REQUIRE(8 ==
                            Parallel::get<animal_base>(cache).number_of_legs());
   // Make the arthropod into a Scutigera coleoptrata.
-  Parallel::mutate<animal_base, modify_number_of_legs>(cache, 30_st);
+  ActionTesting::mutate<animal_base, modify_number_of_legs>(cache, 30_st);
   SPECTRE_PARALLEL_REQUIRE(30 == Parallel::get<animal>(cache).number_of_legs());
   SPECTRE_PARALLEL_REQUIRE(30 ==
                            Parallel::get<animal_base>(cache).number_of_legs());

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
@@ -499,8 +499,8 @@ void test_add_temporal_ids_time_dependent() {
   // started when the previous interpolation is finished
   // (and that code is not included in this test).
   auto& cache = ActionTesting::cache<target_component>(runner, 0_st);
-  Parallel::mutate<domain::Tags::FunctionsOfTime,
-                   control_system::ResetFunctionOfTimeExpirationTime>(
+  ActionTesting::mutate<domain::Tags::FunctionsOfTime,
+                        control_system::ResetFunctionOfTimeExpirationTime>(
       cache, f_of_t_name, new_expiration_time);
 
   if (IsSequential::value) {
@@ -557,8 +557,8 @@ void test_add_temporal_ids_time_dependent() {
   // no more simple_actions in the queue.  Now we mutate the
   // FunctionsOfTime while there is still (for the nonsequential case) a
   // VerifyTemporalIdsAndSendPoints queued.
-  Parallel::mutate<domain::Tags::FunctionsOfTime,
-                   control_system::ResetFunctionOfTimeExpirationTime>(
+  ActionTesting::mutate<domain::Tags::FunctionsOfTime,
+                        control_system::ResetFunctionOfTimeExpirationTime>(
       cache, f_of_t_name, new_expiration_time * 2.0);
 
   if (IsSequential::value) {

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
@@ -560,8 +560,8 @@ void test_interpolation_target_receive_vars() {
 
       // Now mutate the FunctionsOfTime.
       auto& cache = ActionTesting::cache<target_component>(runner, 0_st);
-      Parallel::mutate<domain::Tags::FunctionsOfTime,
-                       control_system::ResetFunctionOfTimeExpirationTime>(
+      ActionTesting::mutate<domain::Tags::FunctionsOfTime,
+                            control_system::ResetFunctionOfTimeExpirationTime>(
           cache, f_of_t_name, new_expiration_time);
 
       // The callback should have queued a single simple action,


### PR DESCRIPTION
## Proposed changes

~In addition to adding the function,~ this removes one of the `Parallel::mutate` functions. Previously, there were two `Parallel::mutate` functions: 1) took a reference to the GlobalCache, intended to be used in the testing framework, and 2) took a proxy to the GlobalCache, intended to be used in charm runs. However, during a charm run, there was no protection against accidentally using 1) to mutate the local cache which wouldn't broadcast the mutation to other nodes. ~Now there is only one `Parallel::mutate` function, and using the is_charm_aware function, determines if it should broadcast the mutation (for charm runs) or just mutate the local cache (testing framework).~ The `Parallel::mutate` function that was intended to be used in the testing framework was moved to the free functions of ActionTesting.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
In tests, instead of calling `Parallel::mutate(cache)`, now call `ActionTesting::mutate(cache)`.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
