### PR TITLE
Clarify `center()` function of strahlkorper as `expansion_center()`

### DIFF
--- a/src/ApparentHorizons/ChangeCenterOfStrahlkorper.cpp
+++ b/src/ApparentHorizons/ChangeCenterOfStrahlkorper.cpp
@@ -36,7 +36,7 @@ void change_expansion_center(
     const std::array<double, 3>& new_center,
     const tnsr::i<DataVector, 3, Frame>& r_hat) {
   // Get new_center minus old_center.
-  const auto& old_center = strahlkorper->center();
+  const auto& old_center = strahlkorper->expansion_center();
   const std::array<double, 3> center_difference{
       {new_center[0] - old_center[0], new_center[1] - old_center[1],
        new_center[2] - old_center[2]}};
@@ -126,11 +126,11 @@ void change_expansion_center_of_strahlkorper_to_physical(
   const size_t maxiter = 14;
   for (size_t iter = 0; iter < maxiter; ++iter) {
     const auto phys_center = strahlkorper->physical_center();
-    const auto center = strahlkorper->center();
+    const auto exp_center = strahlkorper->expansion_center();
     const auto average_radius = strahlkorper->average_radius();
-    const double relative_error = sqrt(square(center[0] - phys_center[0]) +
-                                       square(center[1] - phys_center[1]) +
-                                       square(center[2] - phys_center[2])) /
+    const double relative_error = sqrt(square(exp_center[0] - phys_center[0]) +
+                                       square(exp_center[1] - phys_center[1]) +
+                                       square(exp_center[2] - phys_center[2])) /
                                   average_radius;
     if (relative_error <= 2.0 * std::numeric_limits<double>::epsilon()) {
       return;

--- a/src/ApparentHorizons/ChangeCenterOfStrahlkorper.hpp
+++ b/src/ApparentHorizons/ChangeCenterOfStrahlkorper.hpp
@@ -17,7 +17,7 @@ class not_null;
 /// Changes the expansion center of a Strahlkorper, where the
 /// expansion center is defined as the point about which the spectral
 /// basis of the Strahlkorper is expanded, which is the quantity
-/// returned by `Strahlkorper::center()`.
+/// returned by `Strahlkorper::expansion_center()`.
 template <typename Frame>
 void change_expansion_center_of_strahlkorper(
     gsl::not_null<Strahlkorper<Frame>*> strahlkorper,

--- a/src/ApparentHorizons/Strahlkorper.hpp
+++ b/src/ApparentHorizons/Strahlkorper.hpp
@@ -125,7 +125,7 @@ class Strahlkorper {
   /// The center is given in the frame in which the Strahlkorper is defined.
   /// This center must be somewhere inside the Strahlkorper, but in principle
   /// it can be anywhere.  See `physical_center()` for a different measure.
-  SPECTRE_ALWAYS_INLINE const std::array<double, 3>& center() const {
+  SPECTRE_ALWAYS_INLINE const std::array<double, 3>& expansion_center() const {
     return center_;
   }
 
@@ -179,7 +179,7 @@ template <typename Frame>
 bool operator==(const Strahlkorper<Frame>& lhs,
                 const Strahlkorper<Frame>& rhs) {
   return lhs.l_max() == rhs.l_max() and lhs.m_max() == rhs.m_max() and
-         lhs.center() == rhs.center() and
+         lhs.expansion_center() == rhs.expansion_center() and
          lhs.coefficients() == rhs.coefficients();
 }
 

--- a/src/ApparentHorizons/StrahlkorperInDifferentFrame.cpp
+++ b/src/ApparentHorizons/StrahlkorperInDifferentFrame.cpp
@@ -121,7 +121,7 @@ void strahlkorper_in_different_frame(
     return center;
   }();
 
-  const auto center_src = src_strahlkorper.center();
+  const auto center_src = src_strahlkorper.expansion_center();
 
   // Find the coordinate radius of the destination surface at each of
   // the angular collocation points of the destination surface. To do

--- a/src/ApparentHorizons/Tags.cpp
+++ b/src/ApparentHorizons/Tags.cpp
@@ -164,8 +164,8 @@ void CartesianCoordsCompute<Frame>::function(
     const aliases::OneForm<Frame>& r_hat) {
   destructive_resize_components(coords, get(radius).size());
   for (size_t d = 0; d < 3; ++d) {
-    coords->get(d) =
-        gsl::at(strahlkorper.center(), d) + r_hat.get(d) * get(radius);
+    coords->get(d) = gsl::at(strahlkorper.expansion_center(), d) +
+                     r_hat.get(d) * get(radius);
   }
 }
 

--- a/tests/Unit/ApparentHorizons/Test_ChangeCenterOfStrahlkorper.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ChangeCenterOfStrahlkorper.cpp
@@ -51,7 +51,8 @@ void test_change_center_of_strahlkorper() {
 
   // Center should have changed
   for (size_t i = 0; i < 3; ++i) {
-    CHECK(gsl::at(new_center, i) == gsl::at(strahlkorper.center(), i));
+    CHECK(gsl::at(new_center, i) ==
+          gsl::at(strahlkorper.expansion_center(), i));
   }
 
   // Physical center should not change (to lowest order only, since physical
@@ -64,13 +65,13 @@ void test_change_center_of_strahlkorper() {
   }
 
   // Now transform back
-  change_expansion_center_of_strahlkorper(make_not_null(&strahlkorper),
-                                          original_strahlkorper.center());
+  change_expansion_center_of_strahlkorper(
+      make_not_null(&strahlkorper), original_strahlkorper.expansion_center());
 
   // The original center and radii should have been restored.
   for (size_t i = 0; i < 3; ++i) {
-    CHECK(gsl::at(original_strahlkorper.center(), i) ==
-          gsl::at(strahlkorper.center(), i));
+    CHECK(gsl::at(original_strahlkorper.expansion_center(), i) ==
+          gsl::at(strahlkorper.expansion_center(), i));
   }
   // Radii are not the same to machine precision, but only to the
   // specified l_max.  If l_max is changed at the top of this file, then the
@@ -90,7 +91,7 @@ void test_change_center_of_strahlkorper_to_physical() {
       make_not_null(&strahlkorper));
 
   const auto new_physical_center = strahlkorper.physical_center();
-  const auto new_center = strahlkorper.center();
+  const auto new_center = strahlkorper.expansion_center();
   for (size_t i = 0; i < 3; ++i) {
     CHECK(approx(gsl::at(new_physical_center, i)) == gsl::at(new_center, i));
   }


### PR DESCRIPTION
## Proposed changes

The `center()` of a strahlkorper is ambiguous. Does it mean the physical approximation of the center of the surface or the center about which the surface is expanded? ~This PR standardizes the names of these functions to `physical_center()` and `expansion_center()`, respectively, and removes all `center()` functions.~ This PR changes `center()` to `expansion_center()` in `Strahlkorper`.

~In some cases (like KerrSchild) the expansion center and physical center are the same. In these scenarios, `center()` is renamed to `expansion_center()`.~

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
`Strahlkorper` now has its `center()` function renamed to `expansion_center()`
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
