### PR TITLE
Add `CurvedScalarWave` executable that observes a scalar field in Kerr-Schild background

### DIFF
--- a/src/Evolution/Executables/CurvedScalarWave/CMakeLists.txt
+++ b/src/Evolution/Executables/CurvedScalarWave/CMakeLists.txt
@@ -24,6 +24,11 @@ set(LIBS_TO_LINK
   WaveEquationSolutions
 )
 
+set(INTERPOLATION_LIBS_TO_LINK
+  ApparentHorizons
+  ParallelInterpolation
+)
+
 function(add_curved_scalar_wave_executable EXECUTABLE_NAME DIM INITIAL_DATA)
   add_spectre_parallel_executable(
     "Evolve${EXECUTABLE_NAME}${DIM}D"
@@ -33,6 +38,16 @@ function(add_curved_scalar_wave_executable EXECUTABLE_NAME DIM INITIAL_DATA)
     "${LIBS_TO_LINK}"
     )
 endfunction(add_curved_scalar_wave_executable)
+
+function(add_interpolating_curved_scalar_wave_executable EXECUTABLE_NAME DIM INITIAL_DATA)
+  add_spectre_parallel_executable(
+    "Evolve${EXECUTABLE_NAME}${DIM}D"
+    EvolveCurvedScalarWave
+    Evolution/Executables/CurvedScalarWave
+    "EvolutionMetavars<${DIM},${INITIAL_DATA}>"
+    "${LIBS_TO_LINK};${INTERPOLATION_LIBS_TO_LINK}"
+    )
+endfunction(add_interpolating_curved_scalar_wave_executable)
 
 function(add_flat_plane_wave_executable DIM)
   add_curved_scalar_wave_executable(
@@ -44,4 +59,15 @@ endfunction(add_flat_plane_wave_executable)
 
 add_flat_plane_wave_executable(1)
 add_flat_plane_wave_executable(2)
-add_flat_plane_wave_executable(3)
+
+add_interpolating_curved_scalar_wave_executable(
+  PlaneWaveMinkowski
+  3
+  CurvedScalarWave::AnalyticData::ScalarWaveGr<ScalarWave::Solutions::PlaneWave<3>,gr::Solutions::Minkowski<3>>
+  )
+
+add_interpolating_curved_scalar_wave_executable(
+  ScalarWaveKerrSchild
+  3
+  CurvedScalarWave::AnalyticData::ScalarWaveGr<CurvedScalarWave::AnalyticData::PureSphericalHarmonic,gr::Solutions::KerrSchild>
+  )

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWaveFwd.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWaveFwd.hpp
@@ -14,12 +14,17 @@ class ScalarWaveGr;
 namespace gr::Solutions {
 template <size_t Dim>
 class Minkowski;
+class KerrSchild;
 }  // namespace gr::Solutions
 
 namespace ScalarWave::Solutions {
 template <size_t Dim>
 class PlaneWave;
 }  // namespace ScalarWave::Solutions
+
+namespace CurvedScalarWave::AnalyticData {
+class PureSphericalHarmonic;
+}
 
 template <size_t Dim, typename InitialData>
 struct EvolutionMetavars;

--- a/src/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
+++ b/src/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
@@ -23,6 +23,7 @@ spectre_target_headers(
   Constraints.hpp
   Equations.hpp
   Initialize.hpp
+  PsiSquared.hpp
   System.hpp
   Tags.hpp
   TagsDeclarations.hpp

--- a/src/Evolution/Systems/CurvedScalarWave/PsiSquared.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/PsiSquared.hpp
@@ -1,0 +1,35 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/CurvedScalarWave/TagsDeclarations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace CurvedScalarWave::Tags {
+/*!
+ * \brief The square of the scalar field \f$\Psi\f$.
+ */
+struct PsiSquared : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+/*!
+ * \brief Compute tag that calculates the square of the scalar field \f$\Psi\f$.
+ */
+struct PsiSquaredCompute : PsiSquared, db::ComputeTag {
+  using base = PsiSquared;
+  using return_type = Scalar<DataVector>;
+  using argument_tags = tmpl::list<CurvedScalarWave::Tags::Psi>;
+  static void function(const gsl::not_null<Scalar<DataVector>*> psi_squared,
+                       const Scalar<DataVector>& psi) {
+    get(*psi_squared) = get(psi) * get(psi);
+  }
+};
+}  // namespace CurvedScalarWave::Tags

--- a/src/ParallelAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp
@@ -7,6 +7,7 @@
 #include <pup.h>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/ElementLogicalCoordinates.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"

--- a/src/ParallelAlgorithms/Interpolation/Targets/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Interpolation/Targets/CMakeLists.txt
@@ -8,6 +8,7 @@ spectre_target_sources(
   KerrHorizon.cpp
   LineSegment.cpp
   SpecifiedPoints.cpp
+  Sphere.cpp
   WedgeSectionTorus.cpp
 )
 
@@ -19,5 +20,6 @@ spectre_target_headers(
   KerrHorizon.hpp
   LineSegment.hpp
   SpecifiedPoints.hpp
+  Sphere.hpp
   WedgeSectionTorus.hpp
 )

--- a/src/ParallelAlgorithms/Interpolation/Targets/Sphere.cpp
+++ b/src/ParallelAlgorithms/Interpolation/Targets/Sphere.cpp
@@ -1,0 +1,32 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ParallelAlgorithms/Interpolation/Targets/Sphere.hpp"
+
+#include <array>
+#include <cstddef>
+#include <pup.h>
+
+#include "Options/Options.hpp"
+
+namespace intrp::OptionHolders {
+Sphere::Sphere(const size_t l_max_in, const std::array<double, 3> center_in,
+               const double radius_in)
+    : l_max(l_max_in), center(center_in), radius(radius_in) {}
+
+void Sphere::pup(PUP::er& p) {
+  p | l_max;
+  p | center;
+  p | radius;
+}
+
+bool operator==(const Sphere& lhs, const Sphere& rhs) {
+  return lhs.l_max == rhs.l_max and lhs.center == rhs.center and
+         lhs.radius == rhs.radius;
+}
+
+bool operator!=(const Sphere& lhs, const Sphere& rhs) {
+  return not(lhs == rhs);
+}
+
+}  // namespace intrp::OptionHolders

--- a/src/ParallelAlgorithms/Interpolation/Targets/Sphere.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Targets/Sphere.hpp
@@ -1,0 +1,146 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+
+#include "ApparentHorizons/Strahlkorper.hpp"
+#include "ApparentHorizons/Tags.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
+#include "ParallelAlgorithms/Interpolation/Tags.hpp"
+
+/// \cond
+class DataVector;
+namespace PUP {
+class er;
+}  // namespace PUP
+namespace db {
+template <typename TagsList>
+class DataBox;
+}  // namespace db
+namespace intrp {
+namespace Tags {
+template <typename TemporalId>
+struct TemporalIds;
+}  // namespace Tags
+}  // namespace intrp
+/// \endcond
+
+namespace intrp {
+
+namespace OptionHolders {
+/// A spherical surface.
+///
+/// \details The parameter `Lmax` controls the number of collocation points on
+/// the spherical surface equal to `(l_max + 1) * (2 * l_max + 1)`
+struct Sphere {
+  struct Lmax {
+    using type = size_t;
+    static constexpr Options::String help = {
+        "The number of collocation points on the sphere will be equal to "
+        "`(l_max + 1) * (2 * l_max + 1)`"};
+  };
+  struct Center {
+    using type = std::array<double, 3>;
+    static constexpr Options::String help = {"Center of the sphere"};
+  };
+  struct Radius {
+    using type = double;
+    static constexpr Options::String help = {"Radius of the sphere"};
+    static constexpr double lower_bound() { return 0.; }
+  };
+  using options = tmpl::list<Lmax, Center, Radius>;
+  static constexpr Options::String help = {"A spherical surface."};
+  Sphere(const size_t l_max_in, const std::array<double, 3> center_in,
+         const double radius_in);
+
+  Sphere() = default;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p);
+
+  size_t l_max{0};
+  std::array<double, 3> center{std::numeric_limits<double>::signaling_NaN()};
+  double radius{std::numeric_limits<double>::signaling_NaN()};
+};
+
+bool operator==(const Sphere& lhs, const Sphere& rhs);
+bool operator!=(const Sphere& lhs, const Sphere& rhs);
+
+}  // namespace OptionHolders
+
+namespace OptionTags {
+template <typename InterpolationTargetTag>
+struct Sphere {
+  using type = OptionHolders::Sphere;
+  static constexpr Options::String help{
+      "Options for interpolation onto a sphere."};
+  static std::string name() { return Options::name<InterpolationTargetTag>(); }
+  using group = InterpolationTargets;
+};
+}  // namespace OptionTags
+
+namespace Tags {
+template <typename InterpolationTargetTag>
+struct Sphere : db::SimpleTag {
+  using type = OptionHolders::Sphere;
+  using option_tags = tmpl::list<OptionTags::Sphere<InterpolationTargetTag>>;
+
+  static constexpr bool pass_metavariables = false;
+  static OptionHolders::Sphere create_from_options(
+      const OptionHolders::Sphere& option) {
+    return option;
+  }
+};
+}  // namespace Tags
+
+namespace TargetPoints {
+/// \brief Computes points on a spherical surface.
+///
+/// For requirements on InterpolationTargetTag, see InterpolationTarget
+template <typename InterpolationTargetTag, typename Frame>
+struct Sphere {
+  using const_global_cache_tags =
+      tmpl::list<Tags::Sphere<InterpolationTargetTag>>;
+  using is_sequential = std::false_type;
+  using frame = Frame;
+
+  using simple_tags = typename StrahlkorperTags::items_tags<Frame>;
+  using compute_tags = typename StrahlkorperTags::compute_items_tags<Frame>;
+
+  template <typename DbTags, typename Metavariables>
+  static void initialize(const gsl::not_null<db::DataBox<DbTags>*> box,
+                         const Parallel::GlobalCache<Metavariables>& cache) {
+    const auto& sphere =
+        Parallel::get<Tags::Sphere<InterpolationTargetTag>>(cache);
+    const size_t l_max = sphere.l_max;
+    // Make a spherical strahlkorper
+    ::Strahlkorper<Frame> strahlkorper(
+        l_max, l_max, DataVector{(l_max + 1) * (2 * l_max + 1), sphere.radius},
+        sphere.center);
+    Initialization::mutate_assign<simple_tags>(box, std::move(strahlkorper));
+  }
+
+  template <typename Metavariables, typename DbTags, typename TemporalId>
+  static tnsr::I<DataVector, 3, Frame> points(
+      const db::DataBox<DbTags>& box,
+      const tmpl::type_<Metavariables>& /*meta*/,
+      const TemporalId& /*temporal_id*/) {
+    return db::get<StrahlkorperTags::CartesianCoords<Frame>>(box);
+  }
+  template <typename Metavariables, typename DbTags>
+  static tnsr::I<DataVector, 3, Frame> points(
+      const db::DataBox<DbTags>& box,
+      const tmpl::type_<Metavariables>& /*meta*/) {
+    return db::get<StrahlkorperTags::CartesianCoords<Frame>>(box);
+  }
+};
+
+}  // namespace TargetPoints
+}  // namespace intrp

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
@@ -109,6 +109,12 @@ EventsAndTriggers:
 
 EventsAndDenseTriggers:
 
+InterpolationTargets:
+  SphericalSurface:
+    Lmax: 10
+    Center: [0., 0., 0.]
+    Radius: 1.
+
 Observers:
   VolumeFileName: "PlaneWaveMinkowski3DVolume"
   ReductionFileName: "PlaneWaveMinkowski3DReductions"

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIBRARY_SOURCES
   Test_Characteristics.cpp
   Test_InitializeConstraintDampingGammas.cpp
   Test_InitializeGrVars.cpp
+  Test_PsiSquared.cpp
   Test_Tags.cpp
   Test_TimeDerivative.cpp
   )

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_PsiSquared.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_PsiSquared.cpp
@@ -1,0 +1,15 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Evolution/Systems/CurvedScalarWave/PsiSquared.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.PsiSquared",
+                  "[Unit][Evolution]") {
+  TestHelpers::db::test_simple_tag<CurvedScalarWave::Tags::PsiSquared>(
+      "PsiSquared");
+  TestHelpers::db::test_compute_tag<CurvedScalarWave::Tags::PsiSquaredCompute>(
+      "PsiSquared");
+}

--- a/tests/Unit/ParallelAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/CMakeLists.txt
@@ -17,6 +17,7 @@ set(LIBRARY_SOURCES
   Test_InterpolationTargetReceiveVars.cpp
   Test_InterpolationTargetVarsFromElement.cpp
   Test_InterpolationTargetSpecifiedPoints.cpp
+  Test_InterpolationTargetSphere.cpp
   Test_InterpolationTargetWedgeSectionTorus.cpp
   Test_InterpolatorReceivePoints.cpp
   Test_InterpolatorReceiveVolumeData.cpp

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetSphere.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetSphere.cpp
@@ -1,0 +1,115 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/Creators/Shell.hpp"
+#include "Domain/Domain.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp"
+#include "ParallelAlgorithms/Interpolation/Targets/Sphere.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Spherepack.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct MockMetavariables {
+  struct InterpolationTargetA {
+    using temporal_id = ::Tags::TimeStepId;
+    using vars_to_interpolate_to_target =
+        tmpl::list<gr::Tags::Lapse<DataVector>>;
+    using compute_items_on_target = tmpl::list<>;
+    using compute_target_points =
+        ::intrp::TargetPoints::Sphere<InterpolationTargetA, ::Frame::Inertial>;
+  };
+  static constexpr size_t volume_dim = 3;
+  using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
+  using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
+
+  using component_list =
+      tmpl::list<InterpTargetTestHelpers::mock_interpolation_target<
+                     MockMetavariables, InterpolationTargetA>,
+                 InterpTargetTestHelpers::mock_interpolator<MockMetavariables>>;
+  enum class Phase { Initialization, Testing, Exit };
+};
+}  // namespace
+
+void test_interpolation_target_sphere() {
+  const size_t l_max = 18;
+  const double radius = 3.6;
+  const std::array<double, 3> center = {{0.05, 0.06, 0.07}};
+
+  // Options for Sphere
+  intrp::OptionHolders::Sphere sphere_opts(l_max, center, radius);
+
+  // Test creation of options
+  const auto created_opts =
+      TestHelpers::test_creation<intrp::OptionHolders::Sphere>(
+          "Center: [0.05, 0.06, 0.07]\n"
+          "Radius: 3.6\n"
+          "Lmax: 18");
+  CHECK(created_opts == sphere_opts);
+
+  const auto domain_creator =
+      domain::creators::Shell(0.9, 4.9, 1, {{5, 5}}, false);
+
+  TestHelpers::db::test_simple_tag<
+      intrp::Tags::Sphere<MockMetavariables::InterpolationTargetA>>("Sphere");
+
+  const auto expected_block_coord_holders = [&domain_creator, &radius,
+                                             &center]() {
+    // How many points are supposed to be in a Strahlkorper,
+    // reproduced here by hand for the test.
+    const size_t n_theta = l_max + 1;
+    const size_t n_phi = 2 * l_max + 1;
+
+    // The theta points of a Strahlkorper are Gauss-Legendre points.
+    const std::vector<double> theta_points = []() {
+      std::vector<double> thetas(n_theta);
+      std::vector<double> work(n_theta + 1);
+      std::vector<double> unused_weights(n_theta);
+      int err = 0;
+      gaqd_(static_cast<int>(n_theta), thetas.data(), unused_weights.data(),
+            work.data(), static_cast<int>(n_theta + 1), &err);
+      return thetas;
+    }();
+
+    const double two_pi_over_n_phi = 2.0 * M_PI / n_phi;
+    tnsr::I<DataVector, 3, Frame::Inertial> points(n_theta * n_phi);
+    size_t s = 0;
+    for (size_t i_phi = 0; i_phi < n_phi; ++i_phi) {
+      const double phi = two_pi_over_n_phi * i_phi;
+      for (size_t i_theta = 0; i_theta < n_theta; ++i_theta) {
+        const double theta = theta_points[i_theta];
+        points.get(0)[s] = radius * sin(theta) * cos(phi) + center[0];
+        points.get(1)[s] = radius * sin(theta) * sin(phi) + center[1],
+        points.get(2)[s] = radius * cos(theta) + center[2];
+        ++s;
+      }
+    }
+    return block_logical_coordinates(domain_creator.create_domain(), points);
+  }();
+  InterpTargetTestHelpers::test_interpolation_target<
+      MockMetavariables,
+      intrp::Tags::Sphere<MockMetavariables::InterpolationTargetA>>(
+      domain_creator, sphere_opts, expected_block_coord_holders);
+}
+
+SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.Sphere",
+                  "[Unit]") {
+  domain::creators::register_derived_with_charm();
+  test_interpolation_target_sphere();
+}


### PR DESCRIPTION
This adds an executable that observes the tails of a scalar wave on a Kerr-Schild background similar to the simulations of https://arxiv.org/abs/gr-qc/0305027.

It adds an observation of a surface integral of Psi^2 over a  spherical shell to the executable.
