### PR TITLE
Add subcell boundary conditions to Burgers

### DIFF
--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -228,7 +228,7 @@ struct EvolutionMetavars {
 
   struct SubcellOptions {
     static constexpr bool subcell_enabled = use_dg_subcell;
-    static constexpr bool subcell_enabled_at_external_boundary = false;
+    static constexpr bool subcell_enabled_at_external_boundary = true;
 
     // We send `ghost_zone_size` cell-centered grid points for variable
     // reconstruction, of which we need `ghost_zone_size-1` for reconstruction

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/Dirichlet.cpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/Dirichlet.cpp
@@ -39,6 +39,11 @@ std::optional<std::string> Dirichlet::dg_ghost(
   return {};
 }
 
+void Dirichlet::fd_ghost(const gsl::not_null<Scalar<DataVector>*> u,
+                         const Direction<1>& /*direction*/) const {
+  get(*u) = u_value_;
+}
+
 // NOLINTNEXTLINE
 PUP::able::PUP_ID Dirichlet::my_PUP_ID = 0;
 }  // namespace Burgers::BoundaryConditions

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/Dirichlet.hpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/Dirichlet.hpp
@@ -21,6 +21,8 @@
 
 /// \cond
 class DataVector;
+template <size_t Dim>
+class Direction;
 namespace PUP {
 class er;
 }  // namespace PUP
@@ -80,6 +82,13 @@ class Dirichlet final : public BoundaryCondition {
       const std::optional<
           tnsr::I<DataVector, 1, Frame::Inertial>>& /*face_mesh_velocity*/,
       const tnsr::i<DataVector, 1, Frame::Inertial>& /*normal_covector*/) const;
+
+  using fd_interior_evolved_variables_tags = tmpl::list<>;
+  using fd_interior_temporary_tags = tmpl::list<>;
+  using fd_gridless_tags = tmpl::list<>;
+
+  void fd_ghost(gsl::not_null<Scalar<DataVector>*> u,
+                const Direction<1>& /*direction*/) const;
 
  private:
   void dg_ghost_impl(

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/DirichletAnalytic.hpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/DirichletAnalytic.hpp
@@ -8,14 +8,33 @@
 #include <pup.h>
 #include <string>
 #include <type_traits>
+#include <unordered_map>
 
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/Tags.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Tags.hpp"
 #include "Evolution/BoundaryConditions/Type.hpp"
+#include "Evolution/DgSubcell/GhostZoneLogicalCoordinates.hpp"
+#include "Evolution/DgSubcell/SliceData.hpp"
+#include "Evolution/DgSubcell/SliceTensor.hpp"
+#include "Evolution/DgSubcell/Tags/Coordinates.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/Systems/Burgers/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/Burgers/FiniteDifference/Factory.hpp"
+#include "Evolution/Systems/Burgers/FiniteDifference/Reconstructor.hpp"
+#include "Evolution/Systems/Burgers/FiniteDifference/Tags.hpp"
 #include "Evolution/Systems/Burgers/Tags.hpp"
+#include "Evolution/TypeTraits.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticData/Tags.hpp"
@@ -23,13 +42,6 @@
 #include "Time/Tags.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
-
-/// \cond
-namespace domain::Tags {
-template <size_t Dim, typename Frame>
-struct Coordinates;
-}  // namespace domain::Tags
-/// \endcond
 
 namespace Burgers::BoundaryConditions {
 /*!
@@ -92,6 +104,49 @@ class DirichletAnalytic final : public BoundaryCondition {
     }
     flux_impl(flux_u, *u);
     return {};
+  }
+
+  using fd_interior_evolved_variables_tags = tmpl::list<>;
+  using fd_interior_temporary_tags =
+      tmpl::list<evolution::dg::subcell::Tags::Mesh<1>>;
+  using fd_gridless_tags =
+      tmpl::list<::Tags::Time, domain::Tags::FunctionsOfTime,
+                 domain::Tags::ElementMap<1, Frame::Grid>,
+                 domain::CoordinateMaps::Tags::CoordinateMap<1, Frame::Grid,
+                                                             Frame::Inertial>,
+                 fd::Tags::Reconstructor, ::Tags::AnalyticSolutionOrData>;
+
+  template <typename AnalyticSolutionOrData>
+  void fd_ghost(const gsl::not_null<Scalar<DataVector>*> u,
+                const Direction<1>& direction, const Mesh<1> subcell_mesh,
+                const double time,
+                const std::unordered_map<
+                    std::string,
+                    std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+                    functions_of_time,
+                const ElementMap<1, Frame::Grid>& logical_to_grid_map,
+                const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial,
+                                                1>& grid_to_inertial_map,
+                const fd::Reconstructor& reconstructor,
+                const AnalyticSolutionOrData& analytic_solution_or_data) const {
+    const size_t ghost_zone_size{reconstructor.ghost_zone_size()};
+
+    const auto ghost_logical_coords =
+        evolution::dg::subcell::fd::ghost_zone_logical_coordinates(
+            subcell_mesh, ghost_zone_size, direction);
+
+    const auto ghost_inertial_coords = grid_to_inertial_map(
+        logical_to_grid_map(ghost_logical_coords), time, functions_of_time);
+
+    // Compute U according to analytic solution or data
+    if constexpr (std::is_base_of_v<MarkAsAnalyticSolution,
+                                    AnalyticSolutionOrData>) {
+      *u = get<Burgers::Tags::U>(analytic_solution_or_data.variables(
+          ghost_inertial_coords, time, tmpl::list<Burgers::Tags::U>{}));
+    } else {
+      *u = get<Burgers::Tags::U>(analytic_solution_or_data.variables(
+          ghost_inertial_coords, tmpl::list<Burgers::Tags::U>{}));
+    }
   }
 
  private:

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/Outflow.cpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/Outflow.cpp
@@ -5,11 +5,17 @@
 
 #include <cstddef>
 #include <limits>
+#include <optional>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Evolution/DgSubcell/SliceData.hpp"
 #include "Evolution/Systems/Burgers/Fluxes.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/MakeString.hpp"
 
 namespace Burgers::BoundaryConditions {
@@ -42,6 +48,47 @@ std::optional<std::string> Outflow::dg_outflow(
             << "\nn_i: " << outward_directed_normal_covector << "\n"};
   }
   return std::nullopt;
+}
+
+void Outflow::fd_outflow(
+    const gsl::not_null<Scalar<DataVector>*> u, const Direction<1>& direction,
+    const std::optional<tnsr::I<DataVector, 1, Frame::Inertial>>&
+        face_mesh_velocity,
+    const tnsr::i<DataVector, 1, Frame::Inertial>&
+        outward_directed_normal_covector,
+    const Scalar<DataVector>& u_interior, const Mesh<1>& subcell_mesh) {
+  // The outflow condition here simply uses the outermost values on
+  // cell-centered FD grid points to compute face values on the external
+  // boundary. This is equivalent to adopting the piecewise constant FD
+  // reconstruction for FD cells at the external boundaries.
+  //
+  const double u_val_at_boundary = get(
+      u_interior)[direction.side() == Side::Upper ? subcell_mesh.extents(0) - 1
+                                                  : 0];
+
+  double min_char_speed = std::numeric_limits<double>::signaling_NaN();
+  if (face_mesh_velocity.has_value()) {
+    min_char_speed = min(get<0>(outward_directed_normal_covector) *
+                         (u_val_at_boundary - get<0>(*face_mesh_velocity)));
+  } else {
+    min_char_speed =
+        min(get<0>(outward_directed_normal_covector) * u_val_at_boundary);
+  }
+  if (min_char_speed < 0.0) {
+    ERROR("Outflow boundary condition (subcell) violated with speed U ingoing:"
+          << min_char_speed << "\nU: " << u_val_at_boundary
+          << "\nn_i: " << outward_directed_normal_covector << "\n");
+  } else {
+    // Once the outflow condition has been checked, we fill the ghost data with
+    // the boundary values. This does not mirror the data across the boundary
+    // and so is quite low-order.
+    //
+    // The reason that we need this step is to prevent floating point exceptions
+    // being raised while computing the subcell time derivative because of NaN
+    // or uninitialized values in ghost data.
+
+    get(*u) = u_val_at_boundary;
+  }
 }
 
 // NOLINTNEXTLINE

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/Outflow.hpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/Outflow.hpp
@@ -13,12 +13,20 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/BoundaryConditions/Type.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/Systems/Burgers/BoundaryConditions/BoundaryCondition.hpp"
 #include "Evolution/Systems/Burgers/Tags.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
+
+/// \cond
+template <size_t Dim>
+class Direction;
+template <size_t Dim>
+class Mesh;
+/// \endcond
 
 namespace Burgers::BoundaryConditions {
 /*!
@@ -63,5 +71,18 @@ class Outflow final : public BoundaryCondition {
       const tnsr::i<DataVector, 1, Frame::Inertial>&
           outward_directed_normal_covector,
       const Scalar<DataVector>& u);
+
+  using fd_interior_evolved_variables_tags = tmpl::list<Tags::U>;
+  using fd_interior_temporary_tags =
+      tmpl::list<evolution::dg::subcell::Tags::Mesh<1>>;
+  using fd_gridless_tags = tmpl::list<>;
+
+  static void fd_outflow(
+      gsl::not_null<Scalar<DataVector>*> u, const Direction<1>& direction,
+      const std::optional<tnsr::I<DataVector, 1, Frame::Inertial>>&
+          face_mesh_velocity,
+      const tnsr::i<DataVector, 1, Frame::Inertial>&
+          outward_directed_normal_covector,
+      const Scalar<DataVector>& u_interior, const Mesh<1>& subcell_mesh);
 };
 }  // namespace Burgers::BoundaryConditions

--- a/src/Evolution/Systems/Burgers/FiniteDifference/BoundaryConditionGhostData.hpp
+++ b/src/Evolution/Systems/Burgers/FiniteDifference/BoundaryConditionGhostData.hpp
@@ -1,0 +1,214 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Domain/BoundaryConditions/None.hpp"
+#include "Domain/BoundaryConditions/Periodic.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/TagsTimeDependent.hpp"
+#include "Evolution/BoundaryConditions/Type.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/NeighborData.hpp"
+#include "Evolution/DiscontinuousGalerkin/NormalVectorTags.hpp"
+#include "Evolution/Systems/Burgers/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/Burgers/FiniteDifference/Reconstructor.hpp"
+#include "Evolution/Systems/Burgers/System.hpp"
+#include "Evolution/Systems/Burgers/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Parallel/Tags/Metavariables.hpp"
+#include "Utilities/CallWithDynamicType.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Burgers::fd {
+/*!
+ * \brief Computes finite difference ghost data for external boundary
+ * conditions.
+ *
+ * If the element is at the external boundary, computes FD ghost data with a
+ * given boundary condition and stores it into neighbor data with {direction,
+ * ElementId::external_boundary_id()} as the mortar_id key.
+ *
+ * \note Subcell needs to be enabled for boundary elements (see
+ * Burgers::subcell::TimeDerivative). Otherwise this function would be never
+ * called.
+ *
+ */
+struct BoundaryConditionGhostData {
+  template <typename DbTagsList>
+  static void apply(const gsl::not_null<db::DataBox<DbTagsList>*> box,
+                    const Element<1>& element,
+                    const Burgers::fd::Reconstructor& reconstructor);
+
+ private:
+  template <typename FdBoundaryConditionHelper, typename DbTagsList,
+            typename... FdBoundaryConditionArgsTags>
+  // A helper function for calling fd_ghost() of BoundaryCondition subclasses
+  static void apply_subcell_boundary_condition_impl(
+      FdBoundaryConditionHelper& fd_boundary_condition_helper,
+      const gsl::not_null<db::DataBox<DbTagsList>*>& box,
+      tmpl::list<FdBoundaryConditionArgsTags...>) {
+    return fd_boundary_condition_helper(
+        db::get<FdBoundaryConditionArgsTags>(*box)...);
+  }
+};
+
+template <typename DbTagsList>
+void BoundaryConditionGhostData::apply(
+    const gsl::not_null<db::DataBox<DbTagsList>*> box,
+    const Element<1>& element,
+    const Burgers::fd::Reconstructor& reconstructor) {
+  const ::Domain<1>& domain = db::get<domain::Tags::Domain<1>>(*box);
+  const auto& external_boundary_condition =
+      domain.blocks()[element.id().block_id()].external_boundary_conditions();
+
+  // Check if the element is on the external boundary. If not, the caller is
+  // doing something wrong (e.g. trying to compute FD ghost data with boundary
+  // conditions at an element which is not on the external boundary).
+  ASSERT(not element.external_boundaries().empty(),
+         "The element (ID : " << element.id()
+                              << ") is not on external boundaries");
+
+  const Mesh<1> subcell_mesh =
+      db::get<evolution::dg::subcell::Tags::Mesh<1>>(*box);
+
+  const size_t ghost_zone_size{reconstructor.ghost_zone_size()};
+
+  for (const auto& direction : element.external_boundaries()) {
+    ASSERT(external_boundary_condition.at(direction) != nullptr,
+           "Boundary condition is not set (the pointer is null) in block "
+               << element.id().block_id() << ", direction: " << direction
+               << " (Burgers::fd::BoundaryConditionGhostData)");
+
+    const auto& boundary_condition_at_direction =
+        *external_boundary_condition.at(direction);
+
+    const size_t num_face_pts{
+        subcell_mesh.extents().slice_away(direction.dimension()).product()};
+
+    // a Variables object to store the computed FD ghost data
+    Variables<tmpl::list<Burgers::Tags::U>> ghost_data_vars{ghost_zone_size *
+                                                            num_face_pts};
+
+    // We don't need to care about boundary ghost data when using the periodic
+    // condition, so exclude it from the type list
+    using factory_classes =
+        typename std::decay_t<decltype(db::get<Parallel::Tags::Metavariables>(
+            *box))>::factory_creation::factory_classes;
+    using derived_boundary_conditions_for_subcell = tmpl::remove_if<
+        tmpl::at<factory_classes,
+                 typename Burgers::System::boundary_conditions_base>,
+        tmpl::or_<
+            std::is_base_of<domain::BoundaryConditions::MarkAsPeriodic,
+                            tmpl::_1>,
+            std::is_base_of<domain::BoundaryConditions::MarkAsNone, tmpl::_1>>>;
+
+    // Now apply subcell boundary conditions
+    call_with_dynamic_type<void, derived_boundary_conditions_for_subcell>(
+        &boundary_condition_at_direction,
+        [&boundary_condition_at_direction, &box, &direction,
+         &ghost_data_vars](const auto& derived_boundary_condition_v) {
+          using BoundaryCondition =
+              std::decay_t<decltype(*derived_boundary_condition_v)>;
+          if (const auto* boundary_condition =
+                  dynamic_cast<const BoundaryCondition*>(
+                      &boundary_condition_at_direction);
+              boundary_condition != nullptr) {
+            using bcondition_interior_evolved_vars_tags =
+                typename BoundaryCondition::fd_interior_evolved_variables_tags;
+            using bcondition_interior_temporary_tags =
+                typename BoundaryCondition::fd_interior_temporary_tags;
+            using bcondition_gridless_tags =
+                typename BoundaryCondition::fd_gridless_tags;
+
+            using bcondition_interior_tags =
+                tmpl::append<bcondition_interior_evolved_vars_tags,
+                             bcondition_interior_temporary_tags,
+                             bcondition_gridless_tags>;
+
+            if constexpr (BoundaryCondition::bc_type ==
+                          evolution::BoundaryConditions::Type::Ghost) {
+              const auto apply_fd_ghost =
+                  [&boundary_condition, &direction,
+                   &ghost_data_vars](const auto&... boundary_ghost_data_args) {
+                    (*boundary_condition)
+                        .fd_ghost(make_not_null(
+                                      &get<Burgers::Tags::U>(ghost_data_vars)),
+                                  direction, boundary_ghost_data_args...);
+                  };
+              apply_subcell_boundary_condition_impl(apply_fd_ghost, box,
+                                                    bcondition_interior_tags{});
+            } else if constexpr (BoundaryCondition::bc_type ==
+                                 evolution::BoundaryConditions::Type::Outflow) {
+              // Outflow boundary condition only checks if the characteristic
+              // speed is directed out of the element.
+              const auto& volume_mesh_velocity =
+                  db::get<domain::Tags::MeshVelocity<1, Frame::Inertial>>(*box);
+              if (volume_mesh_velocity.has_value()) {
+                ERROR("Subcell currently does not support moving mesh");
+              }
+
+              std::optional<tnsr::I<DataVector, 1>> face_mesh_velocity{};
+
+              const auto& normal_covector_and_magnitude =
+                  db::get<evolution::dg::Tags::NormalCovectorAndMagnitude<1>>(
+                      *box);
+              const auto& outward_directed_normal_covector =
+                  get<evolution::dg::Tags::NormalCovector<1>>(
+                      normal_covector_and_magnitude.at(direction).value());
+              const auto apply_fd_outflow =
+                  [&boundary_condition, &direction, &face_mesh_velocity,
+                   &ghost_data_vars, &outward_directed_normal_covector](
+                      const auto&... boundary_ghost_data_args) {
+                    return (*boundary_condition)
+                        .fd_outflow(make_not_null(&get<Burgers::Tags::U>(
+                                        ghost_data_vars)),
+                                    direction, face_mesh_velocity,
+                                    outward_directed_normal_covector,
+                                    boundary_ghost_data_args...);
+                  };
+              apply_subcell_boundary_condition_impl(apply_fd_outflow, box,
+                                                    bcondition_interior_tags{});
+
+              return;
+            } else {
+              ERROR("Unsupported boundary condition "
+                    << pretty_type::short_name<BoundaryCondition>()
+                    << " when using finite-difference");
+            }
+          }
+        });
+
+    // Put the computed ghost data into neighbor data with {direction,
+    // ElementId::external_boundary_id()} as the mortar_id key
+    std::vector<double> boundary_ghost_data{
+        ghost_data_vars.data(),
+        ghost_data_vars.data() + ghost_data_vars.size()};
+    const std::pair mortar_id{direction, ElementId<1>::external_boundary_id()};
+
+    db::mutate<evolution::dg::subcell::Tags::NeighborDataForReconstruction<1>>(
+        box, [&mortar_id, &boundary_ghost_data](auto neighbor_data) {
+          (*neighbor_data)[mortar_id] = boundary_ghost_data;
+        });
+  }
+}
+}  // namespace Burgers::fd

--- a/src/Evolution/Systems/Burgers/FiniteDifference/CMakeLists.txt
+++ b/src/Evolution/Systems/Burgers/FiniteDifference/CMakeLists.txt
@@ -13,6 +13,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  BoundaryConditionGhostData.hpp
   Factory.hpp
   FiniteDifference.hpp
   MonotonisedCentral.hpp

--- a/tests/Unit/Evolution/Systems/Burgers/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Burgers/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBRARY_SOURCES
   BoundaryConditions/Test_Periodic.cpp
   BoundaryCorrections/Test_Hll.cpp
   BoundaryCorrections/Test_Rusanov.cpp
+  FiniteDifference/Test_BoundaryConditionGhostData.cpp
   FiniteDifference/Test_MonotonisedCentral.cpp
   FiniteDifference/Test_Tag.cpp
   Subcell/Test_ComputeFluxes.cpp

--- a/tests/Unit/Evolution/Systems/Burgers/FiniteDifference/Linear.py
+++ b/tests/Unit/Evolution/Systems/Burgers/FiniteDifference/Linear.py
@@ -1,0 +1,8 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def u(x, t):
+    return x[0] / (t + 0.5)

--- a/tests/Unit/Evolution/Systems/Burgers/FiniteDifference/Test_BoundaryConditionGhostData.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/FiniteDifference/Test_BoundaryConditionGhostData.cpp
@@ -1,0 +1,342 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Block.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/Tags.hpp"
+#include "Domain/CreateInitialElement.hpp"
+#include "Domain/Creators/Interval.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/SegmentId.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/TagsTimeDependent.hpp"
+#include "Evolution/DgSubcell/GhostZoneLogicalCoordinates.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
+#include "Evolution/DgSubcell/SliceData.hpp"
+#include "Evolution/DgSubcell/Tags/Coordinates.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/NeighborData.hpp"
+#include "Evolution/DiscontinuousGalerkin/Actions/NormalCovectorAndMagnitude.hpp"
+#include "Evolution/DiscontinuousGalerkin/NormalVectorTags.hpp"
+#include "Evolution/Systems/Burgers/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/Burgers/BoundaryConditions/Factory.hpp"
+#include "Evolution/Systems/Burgers/FiniteDifference/BoundaryConditionGhostData.hpp"
+#include "Evolution/Systems/Burgers/FiniteDifference/Factory.hpp"
+#include "Evolution/Systems/Burgers/FiniteDifference/Reconstructor.hpp"
+#include "Evolution/Systems/Burgers/FiniteDifference/Tags.hpp"
+#include "Evolution/Systems/Burgers/System.hpp"
+#include "Evolution/Systems/Burgers/Tags.hpp"
+#include "Framework/Pypp.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/Tags/Metavariables.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Burgers/Linear.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "Utilities/CloneUniquePtrs.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+
+enum class TestCases { BcPointerIsNull, AllGoodWithDomain };
+
+// Metavariables to parse the list of derived classes of boundary conditions
+struct EvolutionMetaVars {
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<Burgers::BoundaryConditions::BoundaryCondition,
+                   Burgers::BoundaryConditions::standard_boundary_conditions>>;
+  };
+};
+
+template <typename BoundaryConditionType>
+void test(const BoundaryConditionType& boundary_condition,
+          const TestCases test_this) {
+  const size_t num_dg_pts = 3;
+
+  // Create an 1D interval [-1, 1] and use it for test
+  const std::array<double, 1> lower_x{-1.0};
+  const std::array<double, 1> upper_x{1.0};
+  const std::array<size_t, 1> refinement_level_x{0};
+  const std::array<size_t, 1> number_of_grid_points_in_x{num_dg_pts};
+  const auto interval = domain::creators::Interval(
+      lower_x, upper_x, refinement_level_x, number_of_grid_points_in_x,
+      std::make_unique<BoundaryConditionType>(boundary_condition),
+      std::make_unique<BoundaryConditionType>(boundary_condition), nullptr);
+  auto domain = interval.create_domain();
+  const auto element = domain::Initialization::create_initial_element(
+      ElementId<1>{0, {SegmentId{0, 0}}}, domain.blocks().at(0),
+      std::vector<std::array<size_t, 1>>{{refinement_level_x}});
+
+  // Mesh and coordinates
+  const Mesh<1> dg_mesh{num_dg_pts, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto};
+  const Mesh<1> subcell_mesh = evolution::dg::subcell::fd::mesh(dg_mesh);
+
+  // use MC reconstruction for test
+  using ReconstructorForTest = Burgers::fd::MonotonisedCentral;
+
+  // dummy neighbor data to put into DataBox
+  typename evolution::dg::subcell::Tags::NeighborDataForReconstruction<1>::type
+      neighbor_data{};
+
+  // Below are tags required by DirichletAnalytic boundary condition to compute
+  // inertial coords of ghost FD cells:
+  //  - time
+  //  - functions of time
+  //  - element map
+  //  - coordinate map
+  //  - subcell logical coordinates
+  //  - analytic solution
+
+  const double time{0.0};
+
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time{};
+
+  const ElementMap<1, Frame::Grid> logical_to_grid_map(
+      ElementId<1>{0},
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
+          domain::CoordinateMaps::Identity<1>{}));
+
+  const auto grid_to_inertial_map =
+      domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+          domain::CoordinateMaps::Identity<1>{});
+
+  const auto subcell_logical_coords = logical_coordinates(subcell_mesh);
+
+  using SolutionForTest = Burgers::Solutions::Linear;
+  const SolutionForTest solution{-0.5};
+
+  // Below are tags required by Outflow boundary condition
+  //  - scalar field U on subcell mesh
+  //  - mesh velocity
+  //  - normal vectors
+
+  const double volume_u_val = 1.0;
+  Scalar<DataVector> u_subcell{subcell_mesh.number_of_grid_points(),
+                               volume_u_val};
+
+  std::optional<tnsr::I<DataVector, 1>> volume_mesh_velocity{};
+
+  typename evolution::dg::Tags::NormalCovectorAndMagnitude<1>::type
+      normal_vectors{};
+  for (const auto& direction : Direction<1>::all_directions()) {
+    const auto coordinate_map =
+        domain::make_coordinate_map<Frame::ElementLogical, Frame::Inertial>(
+            domain::CoordinateMaps::Identity<1>{});
+    const auto moving_mesh_map =
+        domain::make_coordinate_map<Frame::Grid, Frame::Inertial>(
+            domain::CoordinateMaps::Identity<1>{});
+
+    const Mesh<0> face_mesh = subcell_mesh.slice_away(direction.dimension());
+    const auto face_logical_coords =
+        interface_logical_coordinates(face_mesh, direction);
+    std::unordered_map<Direction<1>, tnsr::i<DataVector, 1, Frame::Inertial>>
+        unnormalized_normal_covectors{};
+    tnsr::i<DataVector, 1, Frame::Inertial> unnormalized_covector{};
+    unnormalized_covector.get(0) =
+        coordinate_map.inv_jacobian(face_logical_coords)
+            .get(direction.dimension(), 0);
+    unnormalized_normal_covectors[direction] = unnormalized_covector;
+    Variables<tmpl::list<
+        evolution::dg::Actions::detail::NormalVector<1>,
+        evolution::dg::Actions::detail::OneOverNormalVectorMagnitude>>
+        fields_on_face{face_mesh.number_of_grid_points()};
+
+    normal_vectors[direction] = std::nullopt;
+    evolution::dg::Actions::detail::
+        unit_normal_vector_and_covector_and_magnitude<Burgers::System>(
+            make_not_null(&normal_vectors), make_not_null(&fields_on_face),
+            direction, unnormalized_normal_covectors, moving_mesh_map);
+  }
+
+  // create a box
+  auto box = db::create<db::AddSimpleTags<
+      Parallel::Tags::MetavariablesImpl<EvolutionMetaVars>,
+      domain::Tags::Domain<1>, evolution::dg::subcell::Tags::Mesh<1>,
+      evolution::dg::subcell::Tags::Coordinates<1, Frame::ElementLogical>,
+      evolution::dg::subcell::Tags::NeighborDataForReconstruction<1>,
+      Burgers::fd::Tags::Reconstructor, domain::Tags::MeshVelocity<1>,
+      evolution::dg::Tags::NormalCovectorAndMagnitude<1>, Tags::Time,
+      domain::Tags::FunctionsOfTimeInitialize,
+      domain::Tags::ElementMap<1, Frame::Grid>,
+      domain::CoordinateMaps::Tags::CoordinateMap<1, Frame::Grid,
+                                                  Frame::Inertial>,
+      Tags::AnalyticSolution<SolutionForTest>, Burgers::Tags::U>>(
+      EvolutionMetaVars{}, std::move(domain), subcell_mesh,
+      subcell_logical_coords, neighbor_data,
+      std::unique_ptr<Burgers::fd::Reconstructor>{
+          std::make_unique<ReconstructorForTest>()},
+      volume_mesh_velocity, normal_vectors, time,
+      clone_unique_ptrs(functions_of_time),
+      ElementMap<1, Frame::Grid>{
+          ElementId<1>{0},
+          domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
+              domain::CoordinateMaps::Identity<1>{})},
+      domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+          domain::CoordinateMaps::Identity<1>{}),
+      solution, u_subcell);
+
+  if (test_this == TestCases::BcPointerIsNull) {
+#ifdef SPECTRE_DEBUG
+    // replace the domain inside the box with the one without boundary
+    // conditions.
+    db::mutate<domain::Tags::Domain<1>>(
+        make_not_null(&box),
+        [&lower_x, &upper_x, &refinement_level_x, &number_of_grid_points_in_x](
+            const gsl::not_null<Domain<1>*> domain_v) {
+          const auto interval_without_bc = domain::creators::Interval(
+              lower_x, upper_x, refinement_level_x, number_of_grid_points_in_x,
+              nullptr, nullptr, nullptr);
+          *domain_v = interval_without_bc.create_domain();
+        });
+    // See if the ASSERT catches this error correctly.
+    CHECK_THROWS_WITH(
+        ([&box, &element]() {
+          Burgers::fd::BoundaryConditionGhostData::apply(
+              make_not_null(&box), element, ReconstructorForTest{});
+        })(),
+        Catch::Contains("Boundary condition is not set (the pointer is null)"));
+#endif
+
+  } else if (test_this == TestCases::AllGoodWithDomain) {
+    // compute FD ghost data and retrieve the result
+    Burgers::fd::BoundaryConditionGhostData::apply(make_not_null(&box), element,
+                                                   ReconstructorForTest{});
+    const auto direction = Direction<1>::upper_xi();
+    const std::pair mortar_id = {direction,
+                                 ElementId<1>::external_boundary_id()};
+    const std::vector<double>& fd_ghost_data =
+        get<evolution::dg::subcell::Tags::NeighborDataForReconstruction<1>>(box)
+            .at(mortar_id);
+
+    // now check values for each types of boundary conditions
+
+    if (typeid(BoundaryConditionType) ==
+        typeid(Burgers::BoundaryConditions::Dirichlet)) {
+      const std::vector<double> expected_ghost_u(fd_ghost_data.size(), 0.3);
+      CHECK_ITERABLE_APPROX(expected_ghost_u, fd_ghost_data);
+    }
+
+    if (typeid(BoundaryConditionType) ==
+        typeid(Burgers::BoundaryConditions::DirichletAnalytic)) {
+      const size_t ghost_zone_size{ReconstructorForTest{}.ghost_zone_size()};
+
+      const auto ghost_logical_coords =
+          evolution::dg::subcell::fd::ghost_zone_logical_coordinates(
+              subcell_mesh, ghost_zone_size, direction);
+
+      const auto ghost_inertial_coords = (*grid_to_inertial_map)(
+          logical_to_grid_map(ghost_logical_coords), time, functions_of_time);
+
+      const auto solution_py = pypp::call<Scalar<DataVector>>(
+          "Linear", "u", ghost_inertial_coords, time);
+      std::vector<double> expected_ghost_u{
+          get(solution_py).data(),
+          get(solution_py).data() + get(solution_py).size()};
+
+      CHECK_ITERABLE_APPROX(expected_ghost_u, fd_ghost_data);
+    }
+
+    if (typeid(BoundaryConditionType) ==
+        typeid(Burgers::BoundaryConditions::Outflow)) {
+      // U = 1.0 on the subcell mesh, so the outflow condition will not throw
+      // any error. Here we just check if
+      // `Burgers::fd::BoundaryConditionGhostData::apply()` has correctly filled
+      // out `fd_ghost_data` with the outermost value.
+      const std::vector<double> expected_ghost_u(fd_ghost_data.size(),
+                                                 volume_u_val);
+      CHECK_ITERABLE_APPROX(expected_ghost_u, fd_ghost_data);
+
+      // Test when U=-1.0, which will raise ERROR by violating the outflow
+      // condition.
+      db::mutate<Burgers::Tags::U>(
+          make_not_null(&box),
+          [](const gsl::not_null<Scalar<DataVector>*> volume_u) {
+            get(*volume_u) = -1.0;
+          });
+      // See if the code fails correctly.
+      CHECK_THROWS_WITH(
+          ([&box, &element]() {
+            Burgers::fd::BoundaryConditionGhostData::apply(
+                make_not_null(&box), element, ReconstructorForTest{});
+          })(),
+          Catch::Contains("Outflow boundary condition (subcell) violated"));
+
+      // Test when the volume mesh velocity has value, which will raise ERROR.
+      db::mutate<domain::Tags::MeshVelocity<1>>(
+          make_not_null(&box),
+          [&subcell_mesh](
+              const gsl::not_null<std::optional<tnsr::I<DataVector, 1>>*>
+                  mesh_velocity) {
+            tnsr::I<DataVector, 1> volume_mesh_velocity_tnsr(
+                subcell_mesh.number_of_grid_points(), 0.0);
+            *mesh_velocity = volume_mesh_velocity_tnsr;
+          });
+      // See if the code fails correctly.
+      CHECK_THROWS_WITH(
+          ([&box, &element]() {
+            Burgers::fd::BoundaryConditionGhostData::apply(
+                make_not_null(&box), element, ReconstructorForTest{});
+          })(),
+          Catch::Contains("Subcell currently does not support moving mesh"));
+    }
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Burgers.Fd.BCondGhostData",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/Burgers/FiniteDifference"};
+
+  for (const auto test_this :
+       {TestCases::BcPointerIsNull, TestCases::AllGoodWithDomain}) {
+    test(TestHelpers::test_creation<Burgers::BoundaryConditions::Dirichlet>(
+             "U: 0.3\n"),
+         test_this);
+    test(Burgers::BoundaryConditions::DirichletAnalytic{}, test_this);
+    test(Burgers::BoundaryConditions::Outflow{}, test_this);
+  }
+
+  // check that the periodic BC fails
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(([]() {
+                      test(
+                          domain::BoundaryConditions::Periodic<
+                              Burgers::BoundaryConditions::BoundaryCondition>{},
+                          TestCases::AllGoodWithDomain);
+                    })(),
+                    Catch::Contains("not on external boundaries"));
+#endif
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

For Burgers system, enable subcell for the elements at external boundaries by computing FD ghost data.

First three commits are from:
- [x] #3958 
- [x] #3905 


### Upgrade instructions
  
<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
