### PR TITLE
Optimize elliptic solver (4): Boundary conditions in MinusLaplacian preconditioner

### DIFF
--- a/src/Elliptic/BoundaryConditions/BoundaryCondition.hpp
+++ b/src/Elliptic/BoundaryConditions/BoundaryCondition.hpp
@@ -5,9 +5,11 @@
 
 #include <cstddef>
 #include <pup.h>
+#include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryConditionType.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -105,6 +107,13 @@ class BoundaryCondition : public domain::BoundaryConditions::BoundaryCondition {
   explicit BoundaryCondition(CkMigrateMessage* m) : Base(m) {}
   WRAPPED_PUPable_abstract(BoundaryCondition);  // NOLINT
   /// \endcond
+
+  // The type of boundary condition (Dirichlet or Neumann) for every tensor
+  // component. For example, if the derived class imposes Neumann-type
+  // conditions on a Scalar and Dirichlet-type conditions on a 2D vector, then
+  // it should return `{Dirichlet, Neumann, Neumann}`.
+  virtual std::vector<elliptic::BoundaryConditionType>
+  boundary_condition_types() const = 0;
 };
 
 }  // namespace BoundaryConditions

--- a/src/Elliptic/SubdomainPreconditioners/CMakeLists.txt
+++ b/src/Elliptic/SubdomainPreconditioners/CMakeLists.txt
@@ -30,7 +30,11 @@ target_link_libraries(
   INTERFACE
   Convergence
   DataStructures
+  Domain
+  DomainStructure
+  Elliptic
   EllipticDgSubdomainOperator
+  ErrorHandling
   Logging
   Options
   PoissonBoundaryConditions

--- a/src/Elliptic/SubdomainPreconditioners/MinusLaplacian.hpp
+++ b/src/Elliptic/SubdomainPreconditioners/MinusLaplacian.hpp
@@ -3,9 +3,23 @@
 
 #pragma once
 
+#include <boost/container_hash/hash.hpp>
+#include <boost/functional/hash.hpp>
 #include <cstddef>
+#include <map>
 #include <memory>
+#include <optional>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Tags.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryConditionType.hpp"
 #include "Elliptic/DiscontinuousGalerkin/SubdomainOperator/SubdomainOperator.hpp"
 #include "Elliptic/Systems/Poisson/BoundaryConditions/Robin.hpp"
 #include "Elliptic/Systems/Poisson/FirstOrderSystem.hpp"
@@ -14,9 +28,12 @@
 #include "NumericalAlgorithms/LinearSolver/ExplicitInverse.hpp"
 #include "NumericalAlgorithms/LinearSolver/Gmres.hpp"
 #include "NumericalAlgorithms/LinearSolver/LinearSolver.hpp"
+#include "Options/Auto.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "ParallelAlgorithms/LinearSolver/Schwarz/ElementCenteredSubdomainData.hpp"
+#include "ParallelAlgorithms/LinearSolver/Schwarz/Tags.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -47,16 +64,26 @@ struct MinusLaplacian {
 }  // namespace Registrars
 
 /*!
- * \brief Approximate the subdomain operator with a flat-space Laplacian with
- * Dirichlet boundary conditions for every tensor component separately.
+ * \brief Approximate the subdomain operator with a flat-space Laplacian
+ * for every tensor component separately.
  *
  * This linear solver applies the `Solver` to every tensor component in
- * turn, approximating the subdomain operator with a flat-space Laplacian with
- * Dirichlet boundary conditions. This can be a lot cheaper than solving the
+ * turn, approximating the subdomain operator with a flat-space Laplacian.
+ * This can be a lot cheaper than solving the
  * full subdomain operator and can provide effective preconditioning for an
  * iterative subdomain solver. The approximation is better the closer the
- * original PDEs are to a set of decoupled flat-space Poisson equations with
- * Dirichlet boundary conditions.
+ * original PDEs are to a set of decoupled flat-space Poisson equations.
+ *
+ * \par Boundary conditions
+ * At external boundaries we impose homogeneous Dirichlet or Neumann boundary
+ * conditions on the Poisson sub-problems. For tensor components and element
+ * faces where the original boundary conditions are of Dirichlet-type we choose
+ * homogeneous Dirichlet boundary conditions, and for those where the original
+ * boundary conditions are of Neumann-type we choose homogeneous Neumann
+ * boundary conditions. This means we may end up with more than one distinct
+ * Poisson operator on subdomains with external boundaries, one per unique
+ * combination of element face and boundary-condition type among the tensor
+ * components.
  *
  * \tparam Dim Spatial dimension
  * \tparam OptionsGroup The options group identifying the
@@ -79,17 +106,29 @@ class MinusLaplacian
   using Base = LinearSolver::Serial::LinearSolver<LinearSolverRegistrars>;
   using StoredSolverType = tmpl::conditional_t<std::is_abstract_v<Solver>,
                                                std::unique_ptr<Solver>, Solver>;
+  // Identifies an external block boundary, for boundary conditions
+  using BoundaryId = std::pair<size_t, Direction<Dim>>;
 
  public:
   static constexpr size_t volume_dim = Dim;
   using options_group = OptionsGroup;
   using poisson_system =
       Poisson::FirstOrderSystem<Dim, Poisson::Geometry::FlatCartesian>;
+  using BoundaryConditionsBase =
+      typename poisson_system::boundary_conditions_base;
   using SubdomainOperator = elliptic::dg::subdomain_operator::SubdomainOperator<
       poisson_system, OptionsGroup, tmpl::list<>,
       tmpl::list<Poisson::BoundaryConditions::Robin<Dim>>>;
   using SubdomainData = ::LinearSolver::Schwarz::ElementCenteredSubdomainData<
       Dim, tmpl::list<Poisson::Tags::Field>>;
+  // Associates Dirichlet or Neumann conditions to every external block
+  // boundary. For every configuration of this type we'll need a separate
+  // solver, which may cache the Poisson operator matrix that imposes the
+  // corresponding boundary conditions. This type is used as key in other maps,
+  // so it must be hashable. `std::unordered_map` isn't supported by
+  // `boost::hash`, but `std::map` is.
+  using BoundaryConditionsSignature =
+      std::map<BoundaryId, elliptic::BoundaryConditionType>;
   using solver_type = Solver;
 
   struct SolverOptionTag {
@@ -97,23 +136,36 @@ class MinusLaplacian
     using type = StoredSolverType;
     static constexpr Options::String help =
         "The linear solver used to invert the Laplace operator. The solver is "
-        "shared between the tensor components.";
+        "shared between tensor components with the same type of boundary "
+        "conditions (Dirichlet-type or Neumann-type).";
   };
 
-  using options = tmpl::list<SolverOptionTag>;
+  struct BoundaryConditions {
+    using type = Options::Auto<elliptic::BoundaryConditionType>;
+    static constexpr Options::String help =
+        "The boundary conditions imposed by the Laplace operator. Specify "
+        "'Auto' to choose between homogeneous Dirichlet or Neumann boundary "
+        "conditions automatically, based on the configuration of the the full "
+        "operator.";
+  };
+
+  using options = tmpl::list<SolverOptionTag, BoundaryConditions>;
   static constexpr Options::String help =
-      "Approximate the linear operator with a Laplace operator with Dirichlet "
-      "boundary conditions for every tensor component separately.";
+      "Approximate the linear operator with a Laplace operator "
+      "for every tensor component separately.";
 
   MinusLaplacian() = default;
   MinusLaplacian(MinusLaplacian&& /*rhs*/) = default;
   MinusLaplacian& operator=(MinusLaplacian&& /*rhs*/) = default;
   ~MinusLaplacian() = default;
   MinusLaplacian(const MinusLaplacian& rhs)
-      : Base(rhs), solver_(rhs.clone_solver()) {}
+      : Base(rhs),
+        solver_(rhs.clone_solver()),
+        boundary_condition_type_(rhs.boundary_condition_type_) {}
   MinusLaplacian& operator=(const MinusLaplacian& rhs) {
     Base::operator=(rhs);
     solver_ = rhs.clone_solver();
+    boundary_condition_type_ = rhs.boundary_condition_type_;
     return *this;
   }
 
@@ -123,7 +175,11 @@ class MinusLaplacian
   WRAPPED_PUPable_decl_template(MinusLaplacian);  // NOLINT
   /// \endcond
 
-  MinusLaplacian(StoredSolverType solver) : solver_(std::move(solver)) {}
+  MinusLaplacian(
+      StoredSolverType solver,
+      std::optional<elliptic::BoundaryConditionType> boundary_condition_type)
+      : solver_(std::move(solver)),
+        boundary_condition_type_(boundary_condition_type) {}
 
   const Solver& solver() const {
     if constexpr (std::is_abstract_v<Solver>) {
@@ -133,22 +189,39 @@ class MinusLaplacian
     }
   }
 
+  /// The cached solvers for each unique boundary-condition signature. These are
+  /// only exposed to allow verifying their consistency.
+  const auto& cached_solvers() const { return solvers_; }
+
   /// Solve the equation \f$Ax=b\f$ by approximating \f$A\f$ with a Laplace
-  /// operator with homogeneous Dirichlet boundary conditions for every tensor
-  /// component in \f$x\f$.
+  /// operator for every tensor component in \f$x\f$.
   template <typename LinearOperator, typename VarsType, typename SourceType,
             typename... OperatorArgs>
   Convergence::HasConverged solve(
       gsl::not_null<VarsType*> solution, LinearOperator&& linear_operator,
       const SourceType& source,
-      const std::tuple<OperatorArgs...>& operator_args = std::tuple{}) const;
+      const std::tuple<OperatorArgs...>& operator_args) const;
 
-  void reset() override { mutable_solver().reset(); }
+  void reset() override {
+    mutable_solver().reset();
+    // These buffers depend on the operator being solved, so they are reset when
+    // the operator changes. The other buffers only hold workspace memory so
+    // they don't need to be reset.
+    bc_signatures_ = std::nullopt;
+    solvers_.clear();
+    boundary_conditions_.clear();
+  }
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p) override {
     Base::pup(p);
+    // Serialize object state
     p | solver_;
+    p | boundary_condition_type_;
+    // Serialize caches that are possibly expensive to re-create
+    p | bc_signatures_;
+    p | solvers_;
+    // Other properties are memory buffers that don't need to be serialized.
   }
 
   std::unique_ptr<Base> get_clone() const override {
@@ -156,6 +229,127 @@ class MinusLaplacian
   }
 
  private:
+  // For each tensor component, get the set of boundary conditions that should
+  // be imposed by the Laplacian operator on that component, based on the domain
+  // configuration. These are cached for successive solves of the same operator.
+  // An empty list means the subdomain has no external boundaries.
+  template <typename DbTagsList>
+  const std::vector<BoundaryConditionsSignature>&
+  get_cached_boundary_conditions_signatures(
+      const db::DataBox<DbTagsList>& box) const {
+    if (bc_signatures_.has_value()) {
+      // Use cached value
+      return *bc_signatures_;
+    }
+    bc_signatures_ = std::vector<BoundaryConditionsSignature>{};
+    const auto& blocks = db::get<domain::Tags::Domain<Dim>>(box).blocks();
+    const auto collect_bc_signatures = [&bc_signatures = *bc_signatures_,
+                                        &override_boundary_condition_type =
+                                            boundary_condition_type_,
+                                        &blocks](
+                                           const BoundaryId& boundary_id) {
+      if (not bc_signatures.empty() and
+          bc_signatures[0].find(boundary_id) != bc_signatures[0].end()) {
+        // We have already handled this block boundary in an earlier
+        // iteration of the loop. This can happend when the domain is
+        // h-refined, or when multiple elements in a subdomain face the
+        // block boundary.
+        return;
+      }
+      // Get the type of boundary condition (Dirichlet or Neumann) for
+      // each tensor component from the domain configuration
+      const auto& [block_id, direction] = boundary_id;
+      const auto original_boundary_condition = dynamic_cast<
+          const elliptic::BoundaryConditions::BoundaryCondition<Dim>*>(
+          blocks.at(block_id)
+              .external_boundary_conditions()
+              .at(direction)
+              .get());
+      ASSERT(original_boundary_condition != nullptr,
+             "The boundary condition in block "
+                 << block_id << ", direction " << direction
+                 << " is not of the expected type "
+                    "'elliptic::BoundaryConditions::BoundaryCondition<"
+                 << Dim << ">'.");
+      const std::vector<elliptic::BoundaryConditionType> bc_types =
+          original_boundary_condition->boundary_condition_types();
+      const size_t num_components = bc_types.size();
+      if (bc_signatures.empty()) {
+        bc_signatures.resize(num_components);
+      } else {
+        ASSERT(bc_signatures.size() == num_components,
+               "Unexpected number of boundary-condition types. The "
+               "boundary condition in block "
+                   << block_id << ", direction " << direction << " returned "
+                   << num_components << " items, but another returned "
+                   << bc_signatures.size()
+                   << " (one for each tensor component).");
+      }
+      for (size_t component = 0; component < num_components; ++component) {
+        bc_signatures[component].emplace(
+            boundary_id,
+            override_boundary_condition_type.value_or(bc_types.at(component)));
+      }
+    };
+    // Collect boundary-condition signatures from all elements in the subdomain
+    const auto& element = db::get<domain::Tags::Element<Dim>>(box);
+    for (const auto& direction : element.external_boundaries()) {
+      collect_bc_signatures({element.id().block_id(), direction});
+    }
+    const auto& overlap_elements =
+        db::get<LinearSolver::Schwarz::Tags::Overlaps<
+            domain::Tags::Element<Dim>, Dim, OptionsGroup>>(box);
+    for (const auto& [overlap_id, overlap_element] : overlap_elements) {
+      (void)overlap_id;
+      for (const auto& direction : overlap_element.external_boundaries()) {
+        collect_bc_signatures({overlap_element.id().block_id(), direction});
+      }
+    }
+    return *bc_signatures_;
+  }
+
+  // For a tensor component with the given boundary-condition configuration, get
+  // the solver and the set of boundary conditions that will be passed to the
+  // Poisson subdomain operator. The solver is cached for successive solves of
+  // the same operator. Caching is very important for performance, since the
+  // solver may build up an explicit matrix representation that is expensive to
+  // re-create.
+  std::pair<const Solver&,
+            const std::unordered_map<BoundaryId, const BoundaryConditionsBase&,
+                                     boost::hash<BoundaryId>>&>
+  get_cached_solver_and_boundary_conditions(
+      const std::vector<BoundaryConditionsSignature>& bc_signatures,
+      const size_t component) const {
+    if (bc_signatures.empty()) {
+      // The subdomain has no external boundaries. We use the original solver.
+      return {solver(), boundary_conditions_[{}]};
+    }
+    // Get the cached solver corresponding to this component's
+    // boundary-condition configuration
+    const auto& bc_signature = bc_signatures.at(component);
+    if (solvers_.find(bc_signature) == solvers_.end()) {
+      solvers_.emplace(bc_signature, clone_solver());
+    }
+    const Solver& cached_solver = [this, &bc_signature]() -> const Solver& {
+      if constexpr (std::is_abstract_v<Solver>) {
+        return *solvers_.at(bc_signature);
+      } else {
+        return solvers_.at(bc_signature);
+      }
+    }();
+    // Get the cached set of boundary conditions for this component
+    if (boundary_conditions_.find(bc_signature) == boundary_conditions_.end()) {
+      auto& bc = boundary_conditions_[bc_signature];
+      for (const auto& [boundary_id, bc_type] : bc_signature) {
+        bc.emplace(boundary_id,
+                   bc_type == elliptic::BoundaryConditionType::Dirichlet
+                       ? dirichlet_bc
+                       : neumann_bc);
+      }
+    }
+    return {cached_solver, boundary_conditions_[bc_signature]};
+  }
+
   Solver& mutable_solver() {
     if constexpr (std::is_abstract_v<Solver>) {
       return *solver_;
@@ -172,7 +366,30 @@ class MinusLaplacian
     }
   }
 
+  // The option-constructed solver for the separate Poisson problems. It is
+  // cloned for each unique boundary-condition configuration of the tensor
+  // components.
   StoredSolverType solver_{};
+  std::optional<elliptic::BoundaryConditionType> boundary_condition_type_;
+
+  // These are caches to keep track of the unique boundary-condition
+  // configurations. Each configuration has its own solver, because the solver
+  // may cache the operator to speed up repeated solves.
+  // - The boundary-condition configuration for each tensor component, or an
+  //   empty list if the subdomain has no external boundaries, or `std::nullopt`
+  //   to signal a clean cache.
+  mutable std::optional<std::vector<BoundaryConditionsSignature>>
+      bc_signatures_{};
+  // - A clone of the `solver_` for each unique boundary-condition configuration
+  mutable std::unordered_map<BoundaryConditionsSignature, StoredSolverType,
+                             boost::hash<BoundaryConditionsSignature>>
+      solvers_{};
+  mutable std::unordered_map<
+      BoundaryConditionsSignature,
+      std::unordered_map<BoundaryId, const BoundaryConditionsBase&,
+                         boost::hash<BoundaryId>>,
+      boost::hash<BoundaryConditionsSignature>>
+      boundary_conditions_{};
 
   // These are memory buffers that are kept around for repeated solves. Possible
   // optimization: Free this memory at appropriate times, e.g. when the element
@@ -181,17 +398,15 @@ class MinusLaplacian
   // subdomain solves because it is cached as a matrix (see
   // LinearSolver::Serial::ExplicitInverse), so we don't need the memory anymore
   // at all.
-  mutable SubdomainOperator subdomain_operator_{
-      // Use Dirichlet boundary conditions. Note that the _linearized_ boundary
-      // conditions are applied by the subdomain operator, so the constant is
-      // irrelevant. Possible optimization: Choose a boundary condition for
-      // every external boundary in the input file, so they fit better to the
-      // real boundary conditions. In particular, the correct choice Dirichlet
-      // vs. Neumann b.c. is relevant for the effectiveness of the
-      // preconditioner.
-      std::make_unique<Poisson::BoundaryConditions::Robin<Dim>>(1., 0., 0.)};
+  mutable SubdomainOperator subdomain_operator_{};
   mutable SubdomainData source_{};
   mutable SubdomainData initial_guess_in_solution_out_{};
+
+  // These boundary condition instances can be re-used for all tensor components
+  // Note that the _linearized_ boundary conditions are applied by the subdomain
+  // operator, so the constant (third argument) is irrelevant.
+  const Poisson::BoundaryConditions::Robin<Dim> dirichlet_bc{1., 0., 0.};
+  const Poisson::BoundaryConditions::Robin<Dim> neumann_bc{0., 1., 0.};
 };
 
 namespace detail {
@@ -233,18 +448,31 @@ MinusLaplacian<Dim, OptionsGroup, Solver, LinearSolverRegistrars>::solve(
     const gsl::not_null<VarsType*> initial_guess_in_solution_out,
     LinearOperator&& /*linear_operator*/, const SourceType& source,
     const std::tuple<OperatorArgs...>& operator_args) const {
+  const auto& box = get<0>(operator_args);
+  // Solve each component of the source variables in turn, assuming the operator
+  // is a Laplacian. For each component we select either homogeneous Dirichlet
+  // or Neumann boundary conditions, based on the type of boundary conditions
+  // imposed by the full operator.
+  static constexpr size_t num_components =
+      VarsType::ElementData::number_of_independent_components;
   source_.destructive_resize(source);
   initial_guess_in_solution_out_.destructive_resize(source);
-  // Solve each component of the source variables in turn, assuming the operator
-  // is a Laplacian
-  for (size_t component = 0;
-       component < source.element_data.number_of_independent_components;
-       ++component) {
+  const std::vector<BoundaryConditionsSignature>& bc_signatures =
+      get_cached_boundary_conditions_signatures(box);
+  ASSERT(bc_signatures.empty() or bc_signatures.size() == num_components,
+         "Expected " << num_components
+                     << " boundary-condition signatures (one per tensor "
+                        "component), but got "
+                     << bc_signatures.size() << ".");
+  for (size_t component = 0; component < num_components; ++component) {
     detail::assign_component(make_not_null(&source_), source, 0, component);
     detail::assign_component(make_not_null(&initial_guess_in_solution_out_),
                              *initial_guess_in_solution_out, 0, component);
-    solver().solve(make_not_null(&initial_guess_in_solution_out_),
-                   subdomain_operator_, source_, operator_args);
+    const auto& [solver, boundary_conditions] =
+        get_cached_solver_and_boundary_conditions(bc_signatures, component);
+    solver.solve(make_not_null(&initial_guess_in_solution_out_),
+                 subdomain_operator_, source_,
+                 std::forward_as_tuple(box, boundary_conditions));
     detail::assign_component(initial_guess_in_solution_out,
                              initial_guess_in_solution_out_, component, 0);
   }

--- a/src/Elliptic/Systems/Elasticity/BoundaryConditions/LaserBeam.hpp
+++ b/src/Elliptic/Systems/Elasticity/BoundaryConditions/LaserBeam.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <pup.h>
 #include <string>
+#include <vector>
 
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
@@ -86,6 +87,11 @@ class LaserBeam : public elliptic::BoundaryConditions::BoundaryCondition<3> {
   LaserBeam(double beam_width) : beam_width_(beam_width) {}
 
   double beam_width() const { return beam_width_; }
+
+  std::vector<elliptic::BoundaryConditionType> boundary_condition_types()
+      const override {
+    return {3, elliptic::BoundaryConditionType::Neumann};
+  }
 
   using argument_tags =
       tmpl::list<domain::Tags::Coordinates<3, Frame::Inertial>,

--- a/src/Elliptic/Systems/Elasticity/BoundaryConditions/Zero.hpp
+++ b/src/Elliptic/Systems/Elasticity/BoundaryConditions/Zero.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <pup.h>
 #include <string>
+#include <vector>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
@@ -75,6 +76,11 @@ class Zero : public elliptic::BoundaryConditions::BoundaryCondition<Dim> {
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition> get_clone()
       const override {
     return std::make_unique<Zero>(*this);
+  }
+
+  std::vector<elliptic::BoundaryConditionType> boundary_condition_types()
+      const override {
+    return {Dim, BoundaryConditionType};
   }
 
   using argument_tags = tmpl::list<>;

--- a/src/Elliptic/Systems/Poisson/BoundaryConditions/Robin.hpp
+++ b/src/Elliptic/Systems/Poisson/BoundaryConditions/Robin.hpp
@@ -6,9 +6,11 @@
 #include <cstddef>
 #include <pup.h>
 #include <string>
+#include <vector>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryConditionType.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "Utilities/Gsl.hpp"
@@ -75,6 +77,13 @@ class Robin : public elliptic::BoundaryConditions::BoundaryCondition<Dim> {
   double dirichlet_weight() const { return dirichlet_weight_; }
   double neumann_weight() const { return neumann_weight_; }
   double constant() const { return constant_; }
+
+  std::vector<elliptic::BoundaryConditionType> boundary_condition_types()
+      const override {
+    return {1, neumann_weight_ == 0.
+                   ? elliptic::BoundaryConditionType::Dirichlet
+                   : elliptic::BoundaryConditionType::Neumann};
+  }
 
   using argument_tags = tmpl::list<>;
   using volume_tags = tmpl::list<>;

--- a/src/Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.hpp
+++ b/src/Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.hpp
@@ -6,12 +6,14 @@
 #include <cstddef>
 #include <pup.h>
 #include <string>
+#include <vector>
 
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/Tags.hpp"
 #include "Domain/Tags/FaceNormal.hpp"
 #include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryConditionType.hpp"
 #include "Elliptic/Systems/Xcts/Geometry.hpp"
 #include "Elliptic/Systems/Xcts/Tags.hpp"
 #include "Options/Auto.hpp"
@@ -175,6 +177,20 @@ class ApparentHorizon
   const std::optional<gr::Solutions::KerrSchild>&
   kerr_solution_for_negative_expansion() const {
     return kerr_solution_for_negative_expansion_;
+  }
+
+  std::vector<elliptic::BoundaryConditionType> boundary_condition_types()
+      const override {
+    return {// Conformal factor
+            elliptic::BoundaryConditionType::Neumann,
+            // Lapse times conformal factor
+            this->kerr_solution_for_lapse_.has_value()
+                ? elliptic::BoundaryConditionType::Dirichlet
+                : elliptic::BoundaryConditionType::Neumann,
+            // Shift
+            elliptic::BoundaryConditionType::Dirichlet,
+            elliptic::BoundaryConditionType::Dirichlet,
+            elliptic::BoundaryConditionType::Dirichlet};
   }
 
   using argument_tags = tmpl::flatten<tmpl::list<

--- a/src/Elliptic/Systems/Xcts/BoundaryConditions/Factory.hpp
+++ b/src/Elliptic/Systems/Xcts/BoundaryConditions/Factory.hpp
@@ -9,10 +9,9 @@
 #include "Utilities/TMPL.hpp"
 
 namespace Xcts::BoundaryConditions {
-
 template <typename System>
 using standard_boundary_conditions =
-    tmpl::list<elliptic::BoundaryConditions::AnalyticSolution<System>, Flatness,
+    tmpl::list<elliptic::BoundaryConditions::AnalyticSolution<System>,
+               Flatness<System::enabled_equations>,
                ApparentHorizon<System::conformal_geometry>>;
-
 }

--- a/src/Elliptic/Systems/Xcts/BoundaryConditions/Flatness.hpp
+++ b/src/Elliptic/Systems/Xcts/BoundaryConditions/Flatness.hpp
@@ -10,6 +10,7 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Elliptic/Systems/Xcts/FluxesAndSources.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "Utilities/Gsl.hpp"
@@ -30,7 +31,10 @@ namespace Xcts::BoundaryConditions {
  * is the shift excess (see `Xcts::Tags::ShiftExcess` for details on the split
  * of the shift in background and excess). Note that this choice only truly
  * represents flatness if the conformal background metric is flat.
+ *
+ * \tparam EnabledEquations The subset of XCTS equations that are being solved
  */
+template <Xcts::Equations EnabledEquations>
 class Flatness : public elliptic::BoundaryConditions::BoundaryCondition<3> {
  private:
   using Base = elliptic::BoundaryConditions::BoundaryCondition<3>;
@@ -111,8 +115,12 @@ class Flatness : public elliptic::BoundaryConditions::BoundaryCondition<3> {
           n_dot_longitudinal_shift_excess_correction);
 };
 
-bool operator==(const Flatness& lhs, const Flatness& rhs);
+template <Xcts::Equations EnabledEquations>
+bool operator==(const Flatness<EnabledEquations>& lhs,
+                const Flatness<EnabledEquations>& rhs);
 
-bool operator!=(const Flatness& lhs, const Flatness& rhs);
+template <Xcts::Equations EnabledEquations>
+bool operator!=(const Flatness<EnabledEquations>& lhs,
+                const Flatness<EnabledEquations>& rhs);
 
 }  // namespace Xcts::BoundaryConditions

--- a/src/Elliptic/Systems/Xcts/BoundaryConditions/Flatness.hpp
+++ b/src/Elliptic/Systems/Xcts/BoundaryConditions/Flatness.hpp
@@ -7,9 +7,11 @@
 #include <memory>
 #include <pup.h>
 #include <string>
+#include <vector>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryConditionType.hpp"
 #include "Elliptic/Systems/Xcts/FluxesAndSources.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/CharmPupable.hpp"
@@ -60,6 +62,21 @@ class Flatness : public elliptic::BoundaryConditions::BoundaryCondition<3> {
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition> get_clone()
       const override {
     return std::make_unique<Flatness>(*this);
+  }
+
+  std::vector<elliptic::BoundaryConditionType> boundary_condition_types()
+      const override {
+    return {[]() {
+              if constexpr (EnabledEquations == Xcts::Equations::Hamiltonian) {
+                return 1;
+              } else if constexpr (EnabledEquations ==
+                                   Xcts::Equations::HamiltonianAndLapse) {
+                return 2;
+              } else {
+                return 5;
+              }
+            }(),
+            elliptic::BoundaryConditionType::Dirichlet};
   }
 
   using argument_tags = tmpl::list<>;

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -92,6 +92,7 @@ LinearSolver:
         Preconditioner:
           MinusLaplacian:
             Solver: ExplicitInverse
+            BoundaryConditions: Auto
     ObservePerCoreReductions: False
 
 EventsAndTriggers:

--- a/tests/InputFiles/Xcts/Schwarzschild.yaml
+++ b/tests/InputFiles/Xcts/Schwarzschild.yaml
@@ -94,6 +94,7 @@ LinearSolver:
         Preconditioner:
           MinusLaplacian:
             Solver: ExplicitInverse
+            BoundaryConditions: Auto
     SkipResets: True
     ObservePerCoreReductions: False
 

--- a/tests/Unit/Elliptic/BoundaryConditions/Test_AnalyticSolution.cpp
+++ b/tests/Unit/Elliptic/BoundaryConditions/Test_AnalyticSolution.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
@@ -25,6 +26,7 @@
 #include "Elliptic/BoundaryConditions/AnalyticSolution.hpp"
 #include "Elliptic/BoundaryConditions/ApplyBoundaryCondition.hpp"
 #include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryConditionType.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
@@ -75,6 +77,13 @@ void test_analytic_solution() {
     test_copy_semantics(boundary_condition);
     auto move_boundary_condition = boundary_condition;
     test_move_semantics(std::move(move_boundary_condition), boundary_condition);
+  }
+  {
+    INFO("Properties");
+    CHECK(boundary_condition.boundary_condition_types() ==
+          std::vector<elliptic::BoundaryConditionType>{
+              elliptic::BoundaryConditionType::Dirichlet,
+              elliptic::BoundaryConditionType::Neumann});
   }
   {
     INFO("Test applying the boundary conditions");

--- a/tests/Unit/Elliptic/BoundaryConditions/Test_BoundaryCondition.cpp
+++ b/tests/Unit/Elliptic/BoundaryConditions/Test_BoundaryCondition.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
@@ -70,6 +71,11 @@ class TestBoundaryCondition : public BoundaryCondition<1> {
       tmpl::list<ArgumentTag, VolumeArgumentTag, NonlinearArgumentTag>;
   using volume_tags = tmpl::list<VolumeArgumentTag>;
 
+  std::vector<elliptic::BoundaryConditionType> boundary_condition_types()
+      const override {
+    return {elliptic::BoundaryConditionType::Dirichlet};
+  }
+
   // [example_poisson_fields]
   static void apply(const gsl::not_null<Scalar<DataVector>*> field,
                     const gsl::not_null<Scalar<DataVector>*> n_dot_flux,
@@ -107,6 +113,10 @@ SPECTRE_TEST_CASE("Unit.Elliptic.BoundaryConditions.Base", "[Unit][Elliptic]") {
       BoundaryCondition<1>, TestBoundaryCondition>("TestBoundaryCondition");
   const auto& boundary_condition =
       dynamic_cast<const TestBoundaryCondition&>(*created);
+
+  CHECK(created->boundary_condition_types() ==
+        std::vector<elliptic::BoundaryConditionType>{
+            elliptic::BoundaryConditionType::Dirichlet});
 
   // Test applying boundary conditions
   const auto box = db::create<

--- a/tests/Unit/Elliptic/SubdomainPreconditioners/CMakeLists.txt
+++ b/tests/Unit/Elliptic/SubdomainPreconditioners/CMakeLists.txt
@@ -18,7 +18,9 @@ target_link_libraries(
   ${LIBRARY}
   PRIVATE
   Convergence
+  CoordinateMaps
   DataStructures
+  Domain
   DomainStructure
   EllipticSubdomainPreconditioners
   Options

--- a/tests/Unit/Elliptic/SubdomainPreconditioners/Test_MinusLaplacian.cpp
+++ b/tests/Unit/Elliptic/SubdomainPreconditioners/Test_MinusLaplacian.cpp
@@ -12,7 +12,16 @@
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Block.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CreateInitialElement.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/Structure/BlockNeighbor.hpp"
 #include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/Element.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Elliptic/SubdomainPreconditioners/MinusLaplacian.hpp"
 #include "Elliptic/SubdomainPreconditioners/RegisterDerived.hpp"
@@ -22,6 +31,7 @@
 #include "Options/Options.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "ParallelAlgorithms/LinearSolver/Schwarz/ElementCenteredSubdomainData.hpp"
+#include "ParallelAlgorithms/LinearSolver/Schwarz/OverlapHelpers.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -39,6 +49,35 @@ using PoissonSubdomainData =
         Dim, tmpl::list<Poisson::Tags::Field>>;
 struct OptionsGroup {};
 
+template <size_t Dim>
+struct BoundaryCondition
+    : elliptic::BoundaryConditions::BoundaryCondition<Dim> {
+  explicit BoundaryCondition(
+      std::vector<elliptic::BoundaryConditionType> bc_types)
+      : bc_types_(std::move(bc_types)) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(BoundaryCondition);
+  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition> get_clone()
+      const override {
+    return std::make_unique<BoundaryCondition>(*this);
+  }
+  std::vector<elliptic::BoundaryConditionType> boundary_condition_types()
+      const override {
+    return bc_types_;
+  }
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override {
+    elliptic::BoundaryConditions::BoundaryCondition<Dim>::pup(p);
+    p | bc_types_;
+  }
+
+ private:
+  std::vector<elliptic::BoundaryConditionType> bc_types_;
+};
+
+template <size_t Dim>
+PUP::able::PUP_ID BoundaryCondition<Dim>::my_PUP_ID = 0;  // NOLINT
+
 // We don't actually solve the subdomain operator in this test, because it is
 // implemented and tested elsewhere. Instead, we test the solver is invoked
 // correctly for every tensor component.
@@ -47,13 +86,13 @@ struct TestSolver {
   using options = tmpl::list<>;
   static constexpr Options::String help = "halp";
 
-  template <typename LinearOperator>
+  template <typename LinearOperator, typename... OperatorArgs>
   Convergence::HasConverged solve(
       const gsl::not_null<PoissonSubdomainData<Dim>*>
           initial_guess_in_solution_out,
       const LinearOperator& /*linear_operator*/,
       const PoissonSubdomainData<Dim>& source,
-      const std::tuple<>& /*operator_args*/ = std::tuple{}) const {
+      const std::tuple<OperatorArgs...>& operator_args) const {
     // Check the initial guess for each component is sized correctly and zero
     for (size_t i = 0; i < source.element_data.size(); ++i) {
       CHECK(initial_guess_in_solution_out->element_data.data()[i] == 0.);
@@ -64,15 +103,41 @@ struct TestSolver {
                   .data()[i] == 0.);
       }
     }
+    // Check the boundary conditions
+    const auto& boundary_conditions = get<1>(operator_args);
+    std::map<std::pair<size_t, Direction<Dim>>, elliptic::BoundaryConditionType>
+        local_bc_types{};
+    for (const auto& [boundary_id, bc] : boundary_conditions) {
+      const auto robin_bc =
+          dynamic_cast<const Poisson::BoundaryConditions::Robin<Dim>*>(&bc);
+      REQUIRE(robin_bc != nullptr);
+      CHECK(robin_bc->constant() == 0.);
+      CHECK(((robin_bc->dirichlet_weight() == 1. and
+              robin_bc->neumann_weight() == 0.) or
+             (robin_bc->dirichlet_weight() == 0. and
+              robin_bc->neumann_weight() == 1.)));
+      local_bc_types.emplace(boundary_id,
+                             robin_bc->neumann_weight() == 1.
+                                 ? elliptic::BoundaryConditionType::Neumann
+                                 : elliptic::BoundaryConditionType::Dirichlet);
+    }
+    bc_types.push_back(std::move(local_bc_types));
     // Keep track of the sources so they can be checked
     sources.push_back(source);
     return {0, 0};
   }
-  void reset() { was_reset = true; }
+  void reset() {
+    sources.clear();
+    bc_types.clear();
+    was_reset = true;
+  }
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/) {}
 
   mutable std::vector<PoissonSubdomainData<Dim>> sources{};
+  mutable std::vector<std::map<std::pair<size_t, Direction<Dim>>,
+                               elliptic::BoundaryConditionType>>
+      bc_types{};
   bool was_reset{false};
 };
 
@@ -86,6 +151,133 @@ void check_component(const PoissonSubdomainData<Dim>& poisson_data,
     CHECK(get(get<Poisson::Tags::Field>(poisson_data.overlap_data.at(
               overlap_id))) == get<std::decay_t<Tag>>(data)[component]);
   }
+}
+
+template <size_t Dim>
+auto make_block_map() {
+  return domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+      domain::CoordinateMaps::Identity<Dim>{});
+}
+
+auto make_databox_with_boundary_conditions() {
+  constexpr size_t Dim = 2;
+  // Subdomain geometry:
+  //
+  //             D / D / D
+  //              vvvvv
+  //             +---+-+
+  // N / D / D > |   | |    (Block 0)
+  //             +---+-+
+  // D / N / N > |   |      (Block 1)
+  //             +---+
+  //
+  // - Two blocks, three tensor components (a scalar and a vector). Block 0 has
+  //   an external boundary at the top with Dirichlet conditions for all
+  //   components, and an external boundary to the left with Neumann conditions
+  //   for the scalar and Dirichlet conditions for the vector. Block 1 has an
+  //   external boundary to the left with the reverse.
+  // - The subdomain is centered on the top-left element of the domain.
+  //   Horizontally, it overlaps with another element of Block 0 toward the
+  //   right. Vertically, the element spans the entire Block 0 and the subdomain
+  //   overlaps with an element of Block 1. The domain extends further toward
+  //   the right and the bottom.
+  // - We have two distinct boundary condition signatures: (D, N, D) for the
+  //   the scalar, and (D, D, N) for both vector components, where the three
+  //   entries in the signature refer to the three external boundaries in the
+  //   order (Block 0 top, Block 0 left, Block 1 left).
+
+  // Boundary conditions
+  DirectionMap<Dim,
+               std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>
+      block_0_boundary_conditions{};
+  block_0_boundary_conditions[Direction<Dim>::upper_eta()] =
+      std::make_unique<BoundaryCondition<Dim>>(BoundaryCondition<Dim>{
+          {3, elliptic::BoundaryConditionType::Dirichlet}});
+  block_0_boundary_conditions[Direction<Dim>::lower_xi()] =
+      std::make_unique<BoundaryCondition<Dim>>(
+          BoundaryCondition<Dim>{{elliptic::BoundaryConditionType::Neumann,
+                                  elliptic::BoundaryConditionType::Dirichlet,
+                                  elliptic::BoundaryConditionType::Dirichlet}});
+  DirectionMap<Dim,
+               std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>
+      block_1_boundary_conditions{};
+  block_1_boundary_conditions[Direction<Dim>::lower_xi()] =
+      std::make_unique<BoundaryCondition<Dim>>(
+          BoundaryCondition<Dim>{{elliptic::BoundaryConditionType::Dirichlet,
+                                  elliptic::BoundaryConditionType::Neumann,
+                                  elliptic::BoundaryConditionType::Neumann}});
+  // only needed for completeness, not used in test
+  block_0_boundary_conditions[Direction<Dim>::upper_xi()] =
+      std::make_unique<BoundaryCondition<Dim>>(BoundaryCondition<Dim>{
+          {3, elliptic::BoundaryConditionType::Dirichlet}});
+  block_1_boundary_conditions[Direction<Dim>::upper_xi()] =
+      std::make_unique<BoundaryCondition<Dim>>(BoundaryCondition<Dim>{
+          {3, elliptic::BoundaryConditionType::Dirichlet}});
+  block_1_boundary_conditions[Direction<Dim>::lower_eta()] =
+      std::make_unique<BoundaryCondition<Dim>>(BoundaryCondition<Dim>{
+          {3, elliptic::BoundaryConditionType::Dirichlet}});
+  // Blocks
+  Block<Dim> block_0{make_block_map<Dim>(),
+                     0,
+                     {{Direction<Dim>::lower_eta(), {1, {}}}},
+                     std::move(block_0_boundary_conditions)};
+  Block<Dim> block_1{make_block_map<Dim>(),
+                     1,
+                     {{Direction<Dim>::upper_eta(), {0, {}}}},
+                     std::move(block_1_boundary_conditions)};
+  // Domain
+  std::vector<Block<Dim>> blocks{};
+  blocks.emplace_back(std::move(block_0));
+  blocks.emplace_back(std::move(block_1));
+  Domain<Dim> domain{std::move(blocks)};
+  // Refinement
+  const std::vector<std::array<size_t, Dim>> refinement{{{2, 0}}, {{1, 1}}};
+  // Elements
+  const ElementId<Dim> central_element_id{0, {{{2, 0}, {0, 0}}}};
+  const ElementId<Dim> right_element_id{0, {{{2, 1}, {0, 0}}}};
+  const ElementId<Dim> bottom_element_id{1, {{{1, 0}, {1, 1}}}};
+  Element<Dim> central_element = domain::Initialization::create_initial_element(
+      central_element_id, domain.blocks()[0], refinement);
+  Element<Dim> right_element = domain::Initialization::create_initial_element(
+      right_element_id, domain.blocks()[0], refinement);
+  Element<Dim> bottom_element = domain::Initialization::create_initial_element(
+      bottom_element_id, domain.blocks()[1], refinement);
+  // Subdomain
+  LinearSolver::Schwarz::OverlapMap<Dim, Element<Dim>> overlap_elements{
+      {{Direction<Dim>::upper_xi(), right_element_id},
+       std::move(right_element)},
+      {{Direction<Dim>::lower_eta(), bottom_element_id},
+       std::move(bottom_element)}};
+  return db::create<
+      tmpl::list<domain::Tags::Domain<Dim>, domain::Tags::Element<Dim>,
+                 LinearSolver::Schwarz::Tags::Overlaps<
+                     domain::Tags::Element<Dim>, Dim, OptionsGroup>>>(
+      std::move(domain), std::move(central_element),
+      std::move(overlap_elements));
+}
+
+auto make_databox_without_boundary_conditions() {
+  constexpr size_t Dim = 2;
+  Block<Dim> block{make_block_map<Dim>(), 0, {}};
+  std::vector<Block<Dim>> blocks{};
+  blocks.emplace_back(std::move(block));
+  Domain<Dim> domain{std::move(blocks)};
+  const std::vector<std::array<size_t, Dim>> refinement{{{2, 2}}};
+  const ElementId<Dim> central_element_id{0, {{{2, 1}, {2, 1}}}};
+  const ElementId<Dim> right_element_id{0, {{{2, 2}, {2, 1}}}};
+  Element<Dim> central_element = domain::Initialization::create_initial_element(
+      central_element_id, domain.blocks()[0], refinement);
+  Element<Dim> right_element = domain::Initialization::create_initial_element(
+      right_element_id, domain.blocks()[0], refinement);
+  LinearSolver::Schwarz::OverlapMap<Dim, Element<Dim>> overlap_elements{
+      {{Direction<Dim>::upper_xi(), right_element_id},
+       std::move(right_element)}};
+  return db::create<
+      tmpl::list<domain::Tags::Domain<Dim>, domain::Tags::Element<Dim>,
+                 LinearSolver::Schwarz::Tags::Overlaps<
+                     domain::Tags::Element<Dim>, Dim, OptionsGroup>>>(
+      std::move(domain), std::move(central_element),
+      std::move(overlap_elements));
 }
 }  // namespace
 
@@ -101,16 +293,16 @@ SPECTRE_TEST_CASE("Unit.Elliptic.SubdomainPreconditioners.MinusLaplacian",
     const auto created =
         TestHelpers::test_creation<std::unique_ptr<LinearSolverType>>(
             "MinusLaplacian:\n"
-            "  Solver:\n");
+            "  Solver:\n"
+            "  BoundaryConditions: Auto\n");
     REQUIRE(
         dynamic_cast<const MinusLaplacian<Dim, OptionsGroup, TestSolver<Dim>>*>(
             created.get()) != nullptr);
     const auto serialized = serialize_and_deserialize(created);
-    const auto cloned = serialized->get_clone();
-    const auto& minus_laplacian =
-        dynamic_cast<const MinusLaplacian<Dim, OptionsGroup, TestSolver<Dim>>&>(
+    auto cloned = serialized->get_clone();
+    auto& minus_laplacian =
+        dynamic_cast<MinusLaplacian<Dim, OptionsGroup, TestSolver<Dim>>&>(
             *cloned);
-    const auto& solver = minus_laplacian.solver();
     // The "real" linear operator is unused, because the solve approximates it
     // with a Laplacian
     const NoSuchType linear_operator{};
@@ -127,13 +319,99 @@ SPECTRE_TEST_CASE("Unit.Elliptic.SubdomainPreconditioners.MinusLaplacian",
     // Apply the solver
     auto initial_guess_in_solution_out =
         make_with_value<SubdomainData>(source, 0.);
-    minus_laplacian.solve(make_not_null(&initial_guess_in_solution_out),
-                          linear_operator, source);
-    // Test the solver was applied to every tensor component in turn
-    REQUIRE(solver.sources.size() == 3);
-    check_component(solver.sources[0], source, ScalarFieldTag{}, 0);
-    check_component(solver.sources[1], source, VectorFieldTag<Dim>{}, 0);
-    check_component(solver.sources[2], source, VectorFieldTag<Dim>{}, 1);
+    using BcSignature = typename std::decay_t<
+        decltype(minus_laplacian)>::BoundaryConditionsSignature;
+    {
+      INFO("Subdomain with no external boundaries");
+      minus_laplacian.solve(
+          make_not_null(&initial_guess_in_solution_out), linear_operator,
+          source, std::make_tuple(make_databox_without_boundary_conditions()));
+      // Test the solver was applied to every tensor component in turn
+      const auto& solver = minus_laplacian.solver();
+      REQUIRE(solver.sources.size() == 3);
+      check_component(solver.sources[0], source, ScalarFieldTag{}, 0);
+      check_component(solver.sources[1], source, VectorFieldTag<Dim>{}, 0);
+      check_component(solver.sources[2], source, VectorFieldTag<Dim>{}, 1);
+      CHECK(solver.bc_types[0].empty());
+      CHECK(solver.bc_types[1].empty());
+      CHECK(solver.bc_types[2].empty());
+      CHECK(minus_laplacian.cached_solvers().empty());
+    }
+    minus_laplacian.reset();
+    {
+      INFO("Subdomain with multiple boundary conditions");
+      minus_laplacian.solve(
+          make_not_null(&initial_guess_in_solution_out), linear_operator,
+          source, std::make_tuple(make_databox_with_boundary_conditions()));
+      // Test the solver was applied to every tensor component in turn
+      // - A solver for each unique boundary-condition configuration should have
+      //   been created and cached
+      const auto& cached_solvers = minus_laplacian.cached_solvers();
+      REQUIRE(cached_solvers.size() == 2);
+      // - The solver for (D, N, D) should be used for the scalar
+      const BcSignature signature_dnd{
+          {{0, Direction<Dim>::upper_eta()},
+           elliptic::BoundaryConditionType::Dirichlet},
+          {{0, Direction<Dim>::lower_xi()},
+           elliptic::BoundaryConditionType::Neumann},
+          {{1, Direction<Dim>::lower_xi()},
+           elliptic::BoundaryConditionType::Dirichlet}};
+      REQUIRE(cached_solvers.at(signature_dnd).sources.size() == 1);
+      check_component(cached_solvers.at(signature_dnd).sources[0], source,
+                      ScalarFieldTag{}, 0);
+      CHECK(cached_solvers.at(signature_dnd).bc_types[0] == signature_dnd);
+      // - The solver for (D, D, N) should be used for both vector components
+      const BcSignature signature_ddn{
+          {{0, Direction<Dim>::upper_eta()},
+           elliptic::BoundaryConditionType::Dirichlet},
+          {{0, Direction<Dim>::lower_xi()},
+           elliptic::BoundaryConditionType::Dirichlet},
+          {{1, Direction<Dim>::lower_xi()},
+           elliptic::BoundaryConditionType::Neumann}};
+      REQUIRE(cached_solvers.at(signature_ddn).sources.size() == 2);
+      check_component(cached_solvers.at(signature_ddn).sources[0], source,
+                      VectorFieldTag<Dim>{}, 0);
+      check_component(cached_solvers.at(signature_ddn).sources[1], source,
+                      VectorFieldTag<Dim>{}, 1);
+      CHECK(cached_solvers.at(signature_ddn).bc_types[0] == signature_ddn);
+      CHECK(cached_solvers.at(signature_ddn).bc_types[1] == signature_ddn);
+      // - The factory-constructed solver is not invoked, because it is only
+      //   used as a template for each unique boundary-condition configuration
+      CHECK(minus_laplacian.solver().sources.empty());
+    }
+    {
+      INFO("Explicitly specified boundary condition");
+      const auto minus_laplacian_dirichlet = TestHelpers::test_creation<
+          MinusLaplacian<Dim, OptionsGroup, TestSolver<Dim>>>(
+          "Solver:\n"
+          "BoundaryConditions: Dirichlet\n");
+      minus_laplacian_dirichlet.solve(
+          make_not_null(&initial_guess_in_solution_out), linear_operator,
+          source, std::make_tuple(make_databox_with_boundary_conditions()));
+      // All boundary conditions are Dirichlet, so we should have only a single
+      // cached solver
+      const auto& cached_solvers = minus_laplacian_dirichlet.cached_solvers();
+      REQUIRE(cached_solvers.size() == 1);
+      // The solver for (D, D, D) should be used for all components
+      const BcSignature signature_ddd{
+          {{0, Direction<Dim>::upper_eta()},
+           elliptic::BoundaryConditionType::Dirichlet},
+          {{0, Direction<Dim>::lower_xi()},
+           elliptic::BoundaryConditionType::Dirichlet},
+          {{1, Direction<Dim>::lower_xi()},
+           elliptic::BoundaryConditionType::Dirichlet}};
+      const auto& cached_solver = cached_solvers.at(signature_ddd);
+      REQUIRE(cached_solver.sources.size() == 3);
+      check_component(cached_solver.sources[0], source, ScalarFieldTag{}, 0);
+      check_component(cached_solver.sources[1], source, VectorFieldTag<Dim>{},
+                      0);
+      check_component(cached_solver.sources[2], source, VectorFieldTag<Dim>{},
+                      1);
+      CHECK(cached_solver.bc_types[0] == signature_ddd);
+      CHECK(cached_solver.bc_types[1] == signature_ddd);
+      CHECK(cached_solver.bc_types[2] == signature_ddd);
+      CHECK(minus_laplacian_dirichlet.solver().sources.empty());
+    }
   }
   {
     INFO("Factory-create the solver");
@@ -145,7 +423,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.SubdomainPreconditioners.MinusLaplacian",
     const auto created =
         TestHelpers::test_creation<std::unique_ptr<LinearSolverType>>(
             "MinusLaplacian:\n"
-            "  Solver: ExplicitInverse\n");
+            "  Solver: ExplicitInverse\n"
+            "  BoundaryConditions: Auto");
     const auto serialized = serialize_and_deserialize(created);
     const auto cloned = serialized->get_clone();
     REQUIRE(dynamic_cast<const MinusLaplacian<Dim, OptionsGroup>*>(

--- a/tests/Unit/Elliptic/Systems/Elasticity/BoundaryConditions/Test_Zero.cpp
+++ b/tests/Unit/Elliptic/Systems/Elasticity/BoundaryConditions/Test_Zero.cpp
@@ -6,12 +6,14 @@
 #include <cstddef>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Elliptic/BoundaryConditions/ApplyBoundaryCondition.hpp"
 #include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryConditionType.hpp"
 #include "Elliptic/Systems/Elasticity/BoundaryConditions/Zero.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
@@ -35,14 +37,26 @@ SPECTRE_TEST_CASE("Unit.Elasticity.BoundaryConditions.Zero",
   REQUIRE(dynamic_cast<const Free*>(created_free.get()) != nullptr);
   const auto& fixed = dynamic_cast<const Fixed&>(*created_fixed);
   const auto& free = dynamic_cast<const Free&>(*created_free);
-  test_serialization(fixed);
-  test_serialization(free);
-  test_copy_semantics(fixed);
-  test_copy_semantics(free);
-  auto move_fixed = fixed;
-  auto move_free = free;
-  test_move_semantics(std::move(move_fixed), fixed);
-  test_move_semantics(std::move(move_free), free);
+  {
+    INFO("Semantics");
+    test_serialization(fixed);
+    test_serialization(free);
+    test_copy_semantics(fixed);
+    test_copy_semantics(free);
+    auto move_fixed = fixed;
+    auto move_free = free;
+    test_move_semantics(std::move(move_fixed), fixed);
+    test_move_semantics(std::move(move_free), free);
+  }
+  {
+    INFO("Properties");
+    CHECK(fixed.boundary_condition_types() ==
+          std::vector<elliptic::BoundaryConditionType>{
+              2, elliptic::BoundaryConditionType::Dirichlet});
+    CHECK(free.boundary_condition_types() ==
+          std::vector<elliptic::BoundaryConditionType>{
+              2, elliptic::BoundaryConditionType::Neumann});
+  }
 
   // Test applying the boundary conditions
   const auto box = db::create<db::AddSimpleTags<>>();

--- a/tests/Unit/Elliptic/Systems/Poisson/BoundaryConditions/Test_Robin.cpp
+++ b/tests/Unit/Elliptic/Systems/Poisson/BoundaryConditions/Test_Robin.cpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataVector.hpp"
@@ -13,6 +14,7 @@
 #include "Domain/Structure/Direction.hpp"
 #include "Elliptic/BoundaryConditions/ApplyBoundaryCondition.hpp"
 #include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryConditionType.hpp"
 #include "Elliptic/Systems/Poisson/BoundaryConditions/Robin.hpp"
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
@@ -65,6 +67,13 @@ SPECTRE_TEST_CASE("Unit.Elasticity.BoundaryConditions.Robin",
     CHECK(boundary_condition.dirichlet_weight() == 2.);
     CHECK(boundary_condition.neumann_weight() == 3.);
     CHECK(boundary_condition.constant() == 4.);
+    CHECK(boundary_condition.boundary_condition_types() ==
+          std::vector<elliptic::BoundaryConditionType>{
+              1, elliptic::BoundaryConditionType::Neumann});
+    Robin<2> dirichlet_type_robin{2., 0., 4.};
+    CHECK(dirichlet_type_robin.boundary_condition_types() ==
+          std::vector<elliptic::BoundaryConditionType>{
+              1, elliptic::BoundaryConditionType::Dirichlet});
   }
   {
     INFO("Semantics");

--- a/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/Test_ApparentHorizon.cpp
+++ b/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/Test_ApparentHorizon.cpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataVector.hpp"
@@ -25,6 +26,7 @@
 #include "Domain/Tags/Faces.hpp"
 #include "Elliptic/BoundaryConditions/ApplyBoundaryCondition.hpp"
 #include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryConditionType.hpp"
 #include "Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.hpp"
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
@@ -282,6 +284,15 @@ void test_creation(
       CHECK(*boundary_condition.kerr_solution_for_negative_expansion() ==
             *kerr_solution_for_negative_expansion);
     }
+    CHECK(boundary_condition.boundary_condition_types() ==
+          std::vector<elliptic::BoundaryConditionType>{
+              elliptic::BoundaryConditionType::Neumann,
+              kerr_solution_for_lapse.has_value()
+                  ? elliptic::BoundaryConditionType::Dirichlet
+                  : elliptic::BoundaryConditionType::Neumann,
+              elliptic::BoundaryConditionType::Dirichlet,
+              elliptic::BoundaryConditionType::Dirichlet,
+              elliptic::BoundaryConditionType::Dirichlet});
   }
   {
     INFO("Semantics");

--- a/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/Test_Flatness.cpp
+++ b/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/Test_Flatness.cpp
@@ -15,6 +15,7 @@
 #include "Domain/Tags.hpp"
 #include "Elliptic/BoundaryConditions/ApplyBoundaryCondition.hpp"
 #include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryConditionType.hpp"
 #include "Elliptic/Systems/Xcts/BoundaryConditions/Flatness.hpp"
 #include "Elliptic/Systems/Xcts/FluxesAndSources.hpp"
 #include "Framework/TestCreation.hpp"
@@ -92,6 +93,24 @@ void test_suite() {
     test_copy_semantics(boundary_condition);
     auto move_boundary_condition = boundary_condition;
     test_move_semantics(std::move(move_boundary_condition), boundary_condition);
+  }
+  {
+    INFO("Properties");
+    if constexpr (EnabledEquations == Xcts::Equations::Hamiltonian) {
+      CHECK(boundary_condition.boundary_condition_types() ==
+            std::vector<elliptic::BoundaryConditionType>{
+                1, elliptic::BoundaryConditionType::Dirichlet});
+    } else if constexpr (EnabledEquations ==
+                         Xcts::Equations::HamiltonianAndLapse) {
+      CHECK(boundary_condition.boundary_condition_types() ==
+            std::vector<elliptic::BoundaryConditionType>{
+                2, elliptic::BoundaryConditionType::Dirichlet});
+    } else if constexpr (EnabledEquations ==
+                         Xcts::Equations::HamiltonianLapseAndShift) {
+      CHECK(boundary_condition.boundary_condition_types() ==
+            std::vector<elliptic::BoundaryConditionType>{
+                5, elliptic::BoundaryConditionType::Dirichlet});
+    }
   }
   test_flatness<EnabledEquations, false>(boundary_condition);
   test_flatness<EnabledEquations, true>(boundary_condition);

--- a/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/Test_Flatness.cpp
+++ b/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/Test_Flatness.cpp
@@ -16,6 +16,7 @@
 #include "Elliptic/BoundaryConditions/ApplyBoundaryCondition.hpp"
 #include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
 #include "Elliptic/Systems/Xcts/BoundaryConditions/Flatness.hpp"
+#include "Elliptic/Systems/Xcts/FluxesAndSources.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Utilities/Gsl.hpp"
@@ -24,16 +25,17 @@
 namespace Xcts::BoundaryConditions {
 
 namespace {
-template <size_t EnabledEquations, bool Linearized>
-void test_flatness(const Flatness& boundary_condition) {
+template <Xcts::Equations EnabledEquations, bool Linearized>
+void test_flatness(const Flatness<EnabledEquations>& boundary_condition) {
   const size_t num_points = 3;
   const auto box = db::create<db::AddSimpleTags<>>();
   Scalar<DataVector> conformal_factor{
       num_points, std::numeric_limits<double>::signaling_NaN()};
   Scalar<DataVector> n_dot_conformal_factor_gradient{
       num_points, std::numeric_limits<double>::signaling_NaN()};
-  if constexpr (EnabledEquations == 1) {
-    elliptic::apply_boundary_condition<Linearized, void, tmpl::list<Flatness>>(
+  if constexpr (EnabledEquations == Xcts::Equations::Hamiltonian) {
+    elliptic::apply_boundary_condition<Linearized, void,
+                                       tmpl::list<Flatness<EnabledEquations>>>(
         boundary_condition, box, Direction<3>::lower_xi(),
         make_not_null(&conformal_factor),
         make_not_null(&n_dot_conformal_factor_gradient));
@@ -42,9 +44,9 @@ void test_flatness(const Flatness& boundary_condition) {
         num_points, std::numeric_limits<double>::signaling_NaN()};
     Scalar<DataVector> n_dot_lapse_times_conformal_factor_gradient{
         num_points, std::numeric_limits<double>::signaling_NaN()};
-    if constexpr (EnabledEquations == 2) {
-      elliptic::apply_boundary_condition<Linearized, void,
-                                         tmpl::list<Flatness>>(
+    if constexpr (EnabledEquations == Xcts::Equations::HamiltonianAndLapse) {
+      elliptic::apply_boundary_condition<
+          Linearized, void, tmpl::list<Flatness<EnabledEquations>>>(
           boundary_condition, box, Direction<3>::lower_xi(),
           make_not_null(&conformal_factor),
           make_not_null(&lapse_times_conformal_factor),
@@ -55,8 +57,8 @@ void test_flatness(const Flatness& boundary_condition) {
           num_points, std::numeric_limits<double>::signaling_NaN()};
       tnsr::I<DataVector, 3> n_dot_longitudinal_shift_excess{
           num_points, std::numeric_limits<double>::signaling_NaN()};
-      elliptic::apply_boundary_condition<Linearized, void,
-                                         tmpl::list<Flatness>>(
+      elliptic::apply_boundary_condition<
+          Linearized, void, tmpl::list<Flatness<EnabledEquations>>>(
           boundary_condition, box, Direction<3>::lower_xi(),
           make_not_null(&conformal_factor),
           make_not_null(&lapse_times_conformal_factor),
@@ -73,14 +75,17 @@ void test_flatness(const Flatness& boundary_condition) {
   }
   CHECK(get(conformal_factor) == DataVector(num_points, Linearized ? 0. : 1.));
 }
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Xcts.BoundaryConditions.Flatness", "[Unit][Elliptic]") {
+template <Xcts::Equations EnabledEquations>
+void test_suite() {
   // Test factory-creation
   const auto created = TestHelpers::test_factory_creation<
-      elliptic::BoundaryConditions::BoundaryCondition<3>, Flatness>("Flatness");
-  REQUIRE(dynamic_cast<const Flatness*>(created.get()) != nullptr);
-  const auto& boundary_condition = dynamic_cast<const Flatness&>(*created);
+      elliptic::BoundaryConditions::BoundaryCondition<3>,
+      Flatness<EnabledEquations>>("Flatness");
+  REQUIRE(dynamic_cast<const Flatness<EnabledEquations>*>(created.get()) !=
+          nullptr);
+  const auto& boundary_condition =
+      dynamic_cast<const Flatness<EnabledEquations>&>(*created);
   {
     INFO("Semantics");
     test_serialization(boundary_condition);
@@ -88,12 +93,15 @@ SPECTRE_TEST_CASE("Unit.Xcts.BoundaryConditions.Flatness", "[Unit][Elliptic]") {
     auto move_boundary_condition = boundary_condition;
     test_move_semantics(std::move(move_boundary_condition), boundary_condition);
   }
-  test_flatness<1, false>(boundary_condition);
-  test_flatness<1, true>(boundary_condition);
-  test_flatness<2, false>(boundary_condition);
-  test_flatness<2, true>(boundary_condition);
-  test_flatness<3, false>(boundary_condition);
-  test_flatness<3, true>(boundary_condition);
+  test_flatness<EnabledEquations, false>(boundary_condition);
+  test_flatness<EnabledEquations, true>(boundary_condition);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Xcts.BoundaryConditions.Flatness", "[Unit][Elliptic]") {
+  test_suite<Xcts::Equations::Hamiltonian>();
+  test_suite<Xcts::Equations::HamiltonianAndLapse>();
+  test_suite<Xcts::Equations::HamiltonianLapseAndShift>();
 }
 
 }  // namespace Xcts::BoundaryConditions


### PR DESCRIPTION
## Proposed changes

This is an optimization of the MinusLaplacian subdomain preconditioner. It greatly improves the effectiveness of the preconditioner when Neumann boundary conditions are used for some variables.

This PR implements the strategy described in Section III.E.1 in https://arxiv.org/abs/2111.06767. Results are shown in Fig. 15.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
