### PR TITLE
Add CI test with oldest supported CMake version, find MPI for HDF5 if necessary

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -327,6 +327,10 @@ jobs:
           - compiler: gcc-8
             build_type: Debug
             PYTHON_EXECUTABLE: /usr/bin/python2
+          # Test compatibility with oldest supported CMake version
+          - compiler: gcc-9
+            build_type: Debug
+            CMAKE_EXECUTABLE: /opt/local/cmake/3.12.4/bin/cmake
           # Test building with static libraries. Do so with clang in release
           # mode because these builds use up little disk space compared to GCC
           # builds or clang Debug builds
@@ -413,6 +417,7 @@ ${{ env.CACHE_KEY_SUFFIX }}"
           BUILD_PYTHON_BINDINGS=${{ matrix.BUILD_PYTHON_BINDINGS }}
           BUILD_SHARED_LIBS=${{ matrix.BUILD_SHARED_LIBS }}
           PYTHON_EXECUTABLE=${{ matrix.PYTHON_EXECUTABLE }}
+          CMAKE_EXECUTABLE=${{ matrix.CMAKE_EXECUTABLE }}
           ASAN=${{ matrix.ASAN }}
           MEMORY_ALLOCATOR=${{ matrix.MEMORY_ALLOCATOR }}
           UBSAN_UNDEFINED=${{ matrix.UBSAN_UNDEFINED }}
@@ -421,7 +426,7 @@ ${{ env.CACHE_KEY_SUFFIX }}"
           COVERAGE=${{ matrix.COVERAGE }}
           TEST_TIMEOUT_FACTOR=${{ matrix.TEST_TIMEOUT_FACTOR }}
 
-          cmake
+          ${CMAKE_EXECUTABLE:-'cmake'}
           -D CMAKE_C_COMPILER=${CC}
           -D CMAKE_CXX_COMPILER=${CXX}
           -D CMAKE_Fortran_COMPILER=${FC}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,8 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.19)
   cmake_policy(SET CMP0110 NEW)
 endif ()
 
+# Define standard installation directories
+include(GNUInstallDirs)
 # Disable `make install` depending on `make all` since we want to control what
 # we install more closely. With this setting, and targets marked as `OPTIONAL`,
 # only targets that were built will be installed.

--- a/cmake/AddSpectreExecutable.cmake
+++ b/cmake/AddSpectreExecutable.cmake
@@ -38,7 +38,8 @@ function(add_spectre_executable TARGET_NAME)
     PRIVATE
     SpectreFlags
     )
-  install(TARGETS ${TARGET_NAME} OPTIONAL)
+  install(TARGETS ${TARGET_NAME} OPTIONAL
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 endfunction()
 
 # A function to add a SpECTRE executable that uses Charm++

--- a/cmake/SetupClangTidy.cmake
+++ b/cmake/SetupClangTidy.cmake
@@ -46,18 +46,10 @@ if (CLANG_TIDY_BIN)
     clang-tidy
     ${MODULES_TO_DEPEND_ON}
     )
-  set_target_properties(
-      clang-tidy
-      PROPERTIES EXCLUDE_FROM_ALL TRUE
-  )
   add_custom_target(
       clang-tidy-all
       COMMAND ${CMAKE_BINARY_DIR}/ClangTidyAll.sh
       \${NUM_THREADS}
-  )
-  set_target_properties(
-      clang-tidy-all
-      PROPERTIES EXCLUDE_FROM_ALL TRUE
   )
   add_dependencies(
     clang-tidy-all
@@ -70,10 +62,6 @@ if (CLANG_TIDY_BIN)
       ${CMAKE_SOURCE_DIR}
       \${HASH}
       \${NUM_THREADS}
-  )
-  set_target_properties(
-      clang-tidy-hash
-      PROPERTIES EXCLUDE_FROM_ALL TRUE
   )
   add_dependencies(
     clang-tidy-hash

--- a/cmake/SetupCppCheck.cmake
+++ b/cmake/SetupCppCheck.cmake
@@ -44,5 +44,4 @@ if(CPPCHECK_EXECUTABLE)
       ${CMAKE_BINARY_DIR}/.cppcheck_run.sh
       WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
   )
-  set_target_properties(cppcheck PROPERTIES EXCLUDE_FROM_ALL TRUE)
 endif()

--- a/cmake/SetupHdf5.cmake
+++ b/cmake/SetupHdf5.cmake
@@ -1,21 +1,42 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-find_package(HDF5 REQUIRED C)
+find_package(HDF5 REQUIRED COMPONENTS C)
 
-message(STATUS "HDF5 libs: " ${HDF5_LIBRARIES})
-message(STATUS "HDF5 incl: " ${HDF5_INCLUDE_DIRS})
+message(STATUS "HDF5 libs: " ${HDF5_C_LIBRARIES})
+message(STATUS "HDF5 incl: " ${HDF5_C_INCLUDE_DIRS})
 message(STATUS "HDF5 vers: " ${HDF5_VERSION})
 
-add_library(Hdf5 INTERFACE IMPORTED)
-set_property(TARGET Hdf5
-  APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${HDF5_INCLUDE_DIRS})
-set_property(TARGET Hdf5
-  APPEND PROPERTY INTERFACE_LINK_LIBRARIES ${HDF5_LIBRARIES})
+if(NOT TARGET hdf5::hdf5)
+  add_library(hdf5::hdf5 INTERFACE IMPORTED)
+  set_target_properties(
+    hdf5::hdf5
+    PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${HDF5_C_INCLUDE_DIRS}"
+    INTERFACE_LINK_LIBRARIES "${HDF5_C_LIBRARIES}"
+    )
+  if(DEFINED HDF5_C_DEFINITIONS)
+    set_target_properties(
+      hdf5::hdf5
+      PROPERTIES
+      INTERFACE_COMPILE_FLAGS "${HDF5_C_DEFINITIONS}"
+      )
+  endif()
+endif()
+
+if(HDF5_IS_PARALLEL)
+  find_package(MPI COMPONENTS C)
+  if(MPI_FOUND)
+    target_link_libraries(hdf5::hdf5 INTERFACE MPI::MPI_C)
+  else()
+    message(WARNING "HDF5 is built with MPI support, but MPI was not found. "
+      "You may encounter build issues with HDF5, such as missing headers.")
+  endif()
+endif()
 
 set_property(
   GLOBAL APPEND PROPERTY SPECTRE_THIRD_PARTY_LIBS
-  Hdf5
+  hdf5::hdf5
   )
 
 file(APPEND

--- a/cmake/SetupIwyu.cmake
+++ b/cmake/SetupIwyu.cmake
@@ -28,10 +28,6 @@ function(add_iwyu_tool_targets IWYU_TOOL)
     iwyu
     ${MODULES_TO_DEPEND_ON}
     )
-  set_target_properties(
-    iwyu
-    PROPERTIES EXCLUDE_FROM_ALL TRUE
-    )
 
   # IWYU for all files modified between two hashes
   add_custom_target(
@@ -47,10 +43,6 @@ function(add_iwyu_tool_targets IWYU_TOOL)
   add_dependencies(
     iwyu-hash
     ${MODULES_TO_DEPEND_ON}
-    )
-  set_target_properties(
-    iwyu-hash
-    PROPERTIES EXCLUDE_FROM_ALL TRUE
     )
 endfunction(add_iwyu_tool_targets IWYU_TOOL)
 

--- a/src/IO/CMakeLists.txt
+++ b/src/IO/CMakeLists.txt
@@ -25,7 +25,7 @@ target_link_libraries(
   DataStructures
   ErrorHandling
   EventsAndTriggers
-  Hdf5
+  hdf5::hdf5
   Options
   Spectral
   Utilities

--- a/src/Informer/CMakeLists.txt
+++ b/src/Informer/CMakeLists.txt
@@ -34,13 +34,15 @@ spectre_target_headers(
 # The Darwin linker is not OK with undefined symbols at link time of the
 # library, so we need to appease it. This is needed so compiling InfoAtLink.cpp
 # can be deferred until we link an executable.
-target_link_options(
-  ${LIBRARY}
-  PUBLIC
-  "$<$<PLATFORM_ID:Darwin>:-Wl,-U,_git_branch>"
-  "$<$<PLATFORM_ID:Darwin>:-Wl,-U,_git_description>"
-  "$<$<PLATFORM_ID:Darwin>:-Wl,-U,_link_date>"
-  )
+if(CMAKE_VERSION GREATER_EQUAL 3.13)
+  target_link_options(
+    ${LIBRARY}
+    PUBLIC
+    "$<$<PLATFORM_ID:Darwin>:-Wl,-U,_git_branch>"
+    "$<$<PLATFORM_ID:Darwin>:-Wl,-U,_git_description>"
+    "$<$<PLATFORM_ID:Darwin>:-Wl,-U,_link_date>"
+    )
+endif()
 
 target_link_libraries(
   ${LIBRARY}

--- a/src/PointwiseFunctions/InitialDataUtilities/Tags/CMakeLists.txt
+++ b/src/PointwiseFunctions/InitialDataUtilities/Tags/CMakeLists.txt
@@ -1,11 +1,6 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-spectre_target_sources(
-  ${LIBRARY}
-  PRIVATE
-  )
-
 spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src


### PR DESCRIPTION
## Proposed changes

Fixes #2830
Fixes #2679
Also fixes an issue with linking HDF5 libraries that were built with MPI support.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
