### PR TITLE
Install SpECTRE with Spack

### DIFF
--- a/.github/workflows/Spack.yaml
+++ b/.github/workflows/Spack.yaml
@@ -1,0 +1,76 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Regularly scheduled installation test with the Spack package manager
+name: Spack
+
+on:
+  schedule:
+    - cron: '0 0 * * 1' # every Monday morning
+  workflow_dispatch:
+
+concurrency:
+  group: spack
+  cancel-in-progress: true
+
+jobs:
+  spack_install:
+    name: Install
+    strategy:
+      matrix:
+        host: [ubuntu-latest, macos-latest]
+        compiler: [gcc, clang, apple-clang]
+        exclude:
+          - host: ubuntu-latest
+            compiler: apple-clang
+        version:
+          # A non-exhaustive set of versions to test, e.g., versions listed in
+          # published papers.
+          - 'develop'
+          - '2021.12.15'
+      fail-fast: false
+    runs-on: ${{ matrix.host }}
+    env:
+      # This is the configuration ("spec") that we'll install with Spack
+      # - Select the 'multicore' backend for Charm++, since we're running on a
+      #   single node.
+      # - Select HDF5 without MPI to avoid compiling MPI.
+      SPECTRE_SPEC: >-  # Line breaks are spaces, no trailing newline
+        spectre@${{ matrix.version }}
+          +python
+          %${{ matrix.compiler }}
+          ^charmpp backend=multicore
+          ^hdf5~mpi
+      SPACK_COLOR: always
+    steps:
+      - name: Install compiler
+        if: matrix.host == 'macos-latest' && matrix.compiler == 'clang'
+        run: |
+          brew install llvm
+          echo "$(brew --prefix llvm)/bin" >> $GITHUB_PATH
+      - name: Install Spack
+        run: |
+          git clone -c feature.manyFiles=true --depth=1 \
+            https://github.com/spack/spack.git
+          echo $PWD/spack/bin >> $GITHUB_PATH
+      - name: Configure Spack
+        run: |
+          spack debug report
+          spack compiler find
+          spack compiler info ${{ matrix.compiler }}
+          spack external find
+      - name: Configure mixed toolchain
+        if: matrix.host == 'ubuntu-latest' && matrix.compiler == 'clang'
+        # Clang doesn't bundle a fortran compiler, so we specify one
+        run: |
+          export FC=$(which gfortran)
+          export COMPILERS_CONFIG="$HOME/.spack/*/compilers.yaml"
+          sed -i "s|f77: null$|f77: $FC|" $COMPILERS_CONFIG
+          sed -i "s|fc: null$|fc: $FC|" $COMPILERS_CONFIG
+          cat $COMPILERS_CONFIG
+      - name: Print packages to install
+        run: |
+          spack spec -I ${SPECTRE_SPEC}
+      - name: Install SpECTRE
+        run: |
+          spack install --show-log-on-error ${SPECTRE_SPEC}

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -10,6 +10,32 @@ For instructions on installing SpECTRE on clusters please refer to the
 \subpage versioning_and_releases page for information on specific versions to
 install.
 
+### Install a specific version with Spack
+
+You can install SpECTRE with the [Spack](https://github.com/spack/spack) package
+manager:
+
+```sh
+git clone https://github.com/spack/spack
+source ./spack/share/spack/setup-env.sh
+spack compiler find
+spack external find
+spack install spectre executables=ExportCoordinates3D \
+  ^charmpp backend=multicore
+```
+
+You probably want to customize your installation, e.g., to select a particular
+version of SpECTRE, the executables you want to install, additional options such
+as Python bindings, or the Charm++ backend. You can display all possible options
+with:
+
+```sh
+spack info spectre  # or charmpp, etc.
+```
+
+Refer to the [Spack documentation](https://spack.readthedocs.io/en/latest/) for
+more information.
+
 ### Quick-start guide for code development with Docker and Visual Studio Code
 
 If you're new to writing code for SpECTRE and would like to jump right into a


### PR DESCRIPTION
## Proposed changes

SpECTRE is now available to install with the [Spack](https://github.com/spack/spack) package manager, as of https://github.com/spack/spack/pull/28399. I think this is mostly useful to install a particular version of the code, e.g. one referenced in a paper, along with the corresponding dependencies. This PR adds brief installation instructions to our docs, and a CI test that regularly checks that the Spack installation still works.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
