### PR TITLE
Fix PCH builds with Spack

### DIFF
--- a/tools/WrapPchCompiler.sh
+++ b/tools/WrapPchCompiler.sh
@@ -18,6 +18,6 @@ while [ $# -ne 0 ] ; do
   esac
 done
 
-"${pch_args[@]}" @SPECTRE_PCH_HEADER_PATH@ -o @SPECTRE_PCH_PATH@
+"${pch_args[@]}" -c @SPECTRE_PCH_HEADER_PATH@ -o @SPECTRE_PCH_PATH@
 
 "${compiler_invokation[@]}"


### PR DESCRIPTION
## Proposed changes

I had to add `-c` here so builds with `USE_PCH=ON` compile without error with Spack. @nilsdeppe and @wthrowe does this look right to you? CI builds look fine AFAICT.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
