### PR TITLE
Add ObserverMesh and ObserverCoordinates tags

### DIFF
--- a/src/Evolution/DgSubcell/Tags/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/Tags/CMakeLists.txt
@@ -15,6 +15,7 @@ spectre_target_headers(
   Jacobians.hpp
   Mesh.hpp
   NeighborData.hpp
+  ObserverCoordinates.hpp
   OnSubcellFaces.hpp
   OnSubcells.hpp
   SubcellOptions.hpp

--- a/src/Evolution/DgSubcell/Tags/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/Tags/CMakeLists.txt
@@ -16,6 +16,7 @@ spectre_target_headers(
   Mesh.hpp
   NeighborData.hpp
   ObserverCoordinates.hpp
+  ObserverMesh.hpp
   OnSubcellFaces.hpp
   OnSubcells.hpp
   SubcellOptions.hpp
@@ -23,4 +24,10 @@ spectre_target_headers(
   Tags.hpp
   TciGridHistory.hpp
   TciStatus.hpp
+  )
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  ObserverMesh.cpp
   )

--- a/src/Evolution/DgSubcell/Tags/Jacobians.hpp
+++ b/src/Evolution/DgSubcell/Tags/Jacobians.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstddef>
+#include <optional>
 #include <string>
 
 #include "DataStructures/DataBox/Tag.hpp"

--- a/src/Evolution/DgSubcell/Tags/ObserverCoordinates.hpp
+++ b/src/Evolution/DgSubcell/Tags/ObserverCoordinates.hpp
@@ -1,0 +1,56 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Tags/Coordinates.hpp"
+#include "ParallelAlgorithms/Events/Tags.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace evolution::dg::subcell::Tags {
+/*!
+ * \brief "Computes" the active coordinates by setting the `DataVector`s to
+ * point into the coordinates of either the DG or subcell grid.
+ */
+template <size_t Dim, typename Fr>
+struct ObserverCoordinatesCompute
+    : db::ComputeTag,
+      ::Events::Tags::ObserverCoordinates<Dim, Fr> {
+  using base = ::Events::Tags::ObserverCoordinates<Dim, Fr>;
+  using return_type = typename base::type;
+  using argument_tags = tmpl::list<ActiveGrid, Coordinates<Dim, Fr>,
+                                   ::domain::Tags::Coordinates<Dim, Fr>>;
+  static void function(const gsl::not_null<return_type*> active_coords,
+                       const subcell::ActiveGrid active_grid,
+                       const tnsr::I<DataVector, Dim, Fr>& subcell_coords,
+                       const tnsr::I<DataVector, Dim, Fr>& dg_coords) {
+    const auto set_to_refs =
+        [&active_coords](const tnsr::I<DataVector, Dim, Fr>& coords) {
+          for (size_t i = 0; i < Dim; ++i) {
+            active_coords->get(i).set_data_ref(
+                make_not_null(&const_cast<DataVector&>(coords.get(i))));
+          }
+        };
+    if (active_grid == subcell::ActiveGrid::Dg) {
+      set_to_refs(dg_coords);
+    } else {
+      ASSERT(active_grid == subcell::ActiveGrid::Subcell,
+             "ActiveGrid should be subcell if it isn't DG. Maybe an extra enum "
+             "entry was added?");
+      set_to_refs(subcell_coords);
+    }
+  }
+};
+}  // namespace evolution::dg::subcell::Tags

--- a/src/Evolution/DgSubcell/Tags/ObserverMesh.cpp
+++ b/src/Evolution/DgSubcell/Tags/ObserverMesh.cpp
@@ -1,0 +1,38 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/DgSubcell/Tags/ObserverMesh.hpp"
+
+#include <cstddef>
+
+#include "Evolution/DgSubcell/ActiveGrid.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace evolution::dg::subcell::Tags {
+template <size_t Dim>
+void ObserverMeshCompute<Dim>::function(
+    const gsl::not_null<return_type*> active_mesh, const ::Mesh<Dim>& dg_mesh,
+    const ::Mesh<Dim>& subcell_mesh, const subcell::ActiveGrid active_grid) {
+  if (active_grid == subcell::ActiveGrid::Dg) {
+    *active_mesh = dg_mesh;
+  } else {
+    ASSERT(active_grid == subcell::ActiveGrid::Subcell,
+           "The active grid must be either DG or subcell");
+    *active_mesh = subcell_mesh;
+  }
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data) template class ObserverMeshCompute<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef GET_DIM
+#undef INSTANTIATION
+
+}  // namespace evolution::dg::subcell::Tags

--- a/src/Evolution/DgSubcell/Tags/ObserverMesh.hpp
+++ b/src/Evolution/DgSubcell/Tags/ObserverMesh.hpp
@@ -1,0 +1,37 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "ParallelAlgorithms/Events/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+template <size_t Dim>
+class Mesh;
+/// \endcond
+
+namespace evolution::dg::subcell::Tags {
+/// \brief Computes the active mesh, which is the DG mesh if `ActiveGrid` is
+/// `Dg` and the subcell mesh if `ActiveGrid` is `Subcell`.
+template <size_t Dim>
+struct ObserverMeshCompute : ::Events::Tags::ObserverMesh<Dim>, db::ComputeTag {
+  using base = ::Events::Tags::ObserverMesh<Dim>;
+  using return_type = typename base::type;
+  using argument_tags =
+      tmpl::list<::domain::Tags::Mesh<Dim>, subcell::Tags::Mesh<Dim>,
+                 subcell::Tags::ActiveGrid>;
+  static void function(gsl::not_null<return_type*> active_mesh,
+                       const ::Mesh<Dim>& dg_mesh,
+                       const ::Mesh<Dim>& subcell_mesh,
+                       const subcell::ActiveGrid active_grid);
+};
+}  // namespace evolution::dg::subcell::Tags

--- a/src/ParallelAlgorithms/Events/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Events/CMakeLists.txt
@@ -15,6 +15,7 @@ spectre_target_headers(
   ObserveNorms.hpp
   ObserveTimeStep.hpp
   ObserveVolumeIntegrals.hpp
+  Tags.hpp
   )
 
 target_link_libraries(
@@ -28,6 +29,7 @@ target_link_libraries(
   Interpolation
   LinearOperators
   Options
+  Spectral
   Time
   Utilities
   )

--- a/src/ParallelAlgorithms/Events/Tags.hpp
+++ b/src/ParallelAlgorithms/Events/Tags.hpp
@@ -1,0 +1,36 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Events::Tags {
+/// \brief The mesh for the observation computational grid. For hybrid methods
+/// like DG-FD the observer mesh changes throughout the evolution.
+template <size_t Dim>
+struct ObserverMesh : db::SimpleTag {
+  using type = ::Mesh<Dim>;
+};
+
+/// \brief Sets the `ObserverMesh` to `domain::Tags::Mesh`
+///
+/// This is what you would use for a single numerical method simulation. Hybrid
+/// methods will supply their own tags.
+template <size_t Dim>
+struct ObserverMeshCompute : ObserverMesh<Dim>, db::ComputeTag {
+  using base = ObserverMesh<Dim>;
+  using return_type = typename base::type;
+  using argument_tags = tmpl::list<::domain::Tags::Mesh<Dim>>;
+  static void function(const gsl::not_null<return_type*> observer_mesh,
+                       const ::Mesh<Dim>& mesh) {
+    *observer_mesh = mesh;
+  }
+};
+}  // namespace Events::Tags

--- a/src/ParallelAlgorithms/Events/Tags.hpp
+++ b/src/ParallelAlgorithms/Events/Tags.hpp
@@ -4,10 +4,14 @@
 #pragma once
 
 #include <cstddef>
+#include <string>
 
 #include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Tags.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -31,6 +35,38 @@ struct ObserverMeshCompute : ObserverMesh<Dim>, db::ComputeTag {
   static void function(const gsl::not_null<return_type*> observer_mesh,
                        const ::Mesh<Dim>& mesh) {
     *observer_mesh = mesh;
+  }
+};
+
+/*!
+ * \brief The coordinates used for observation.
+ *
+ * In methods like DG-FD the mesh and coordinates change throughout the
+ * simulation, so we need to always grab the right ones.
+ */
+template <size_t Dim, typename Fr>
+struct ObserverCoordinates : db::SimpleTag {
+  static std::string name() { return get_output(Fr{}) + "Coordinates"; }
+  using type = tnsr::I<DataVector, Dim, Fr>;
+};
+
+/// \brief Sets the `ObserverCoordinates` to `domain::Tags::Coordinates`
+///
+/// This is what you would use for a single numerical method simulation. Hybrid
+/// methods will supply their own tags.
+template <size_t Dim, typename Fr>
+struct ObserverCoordinatesCompute : ObserverCoordinates<Dim, Fr>,
+                                    db::ComputeTag {
+  using base = ObserverCoordinates<Dim, Fr>;
+  using return_type = typename base::type;
+  using argument_tags = tmpl::list<::domain::Tags::Coordinates<Dim, Fr>>;
+  static void function(const gsl::not_null<return_type*> observer_coords,
+                       const return_type& coords) {
+    for (size_t i = 0; i < Dim; ++i) {
+      observer_coords->get(i).set_data_ref(
+          // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+          make_not_null(&const_cast<DataVector&>(coords.get(i))));
+    }
   }
 };
 }  // namespace Events::Tags

--- a/tests/Unit/ParallelAlgorithms/Events/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Events/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   Test_ObserveNorms.cpp
   Test_ObserveTimeStep.cpp
   Test_ObserveVolumeIntegrals.cpp
+  Test_Tags.cpp
   )
 
 add_test_library(

--- a/tests/Unit/ParallelAlgorithms/Events/Test_Tags.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_Tags.cpp
@@ -6,24 +6,49 @@
 #include <cstddef>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Tags.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "ParallelAlgorithms/Events/Tags.hpp"
+#include "Utilities/Literals.hpp"
 
 namespace {
 template <size_t Dim>
 void test(const Mesh<Dim>& mesh) {
-  const auto box =
-      db::create<db::AddSimpleTags<domain::Tags::Mesh<Dim>>,
-                 db::AddComputeTags<Events::Tags::ObserverMeshCompute<Dim>>>(
-          mesh);
+  const tnsr::I<DataVector, Dim, Frame::Grid> grid_coords{5_st, 7.2};
+  const tnsr::I<DataVector, Dim, Frame::Inertial> inertial_coords{5_st, 7.2};
+  const auto box = db::create<
+      db::AddSimpleTags<domain::Tags::Mesh<Dim>,
+                        domain::Tags::Coordinates<Dim, Frame::Grid>,
+                        domain::Tags::Coordinates<Dim, Frame::Inertial>>,
+      db::AddComputeTags<
+          Events::Tags::ObserverMeshCompute<Dim>,
+          Events::Tags::ObserverCoordinatesCompute<Dim, Frame::Grid>,
+          Events::Tags::ObserverCoordinatesCompute<Dim, Frame::Inertial>>>(
+      mesh, grid_coords, inertial_coords);
   CHECK(db::get<Events::Tags::ObserverMesh<Dim>>(box) == mesh);
+  CHECK(db::get<Events::Tags::ObserverCoordinates<Dim, Frame::Grid>>(box) ==
+        grid_coords);
+  CHECK(db::get<Events::Tags::ObserverCoordinates<Dim, Frame::Inertial>>(box) ==
+        inertial_coords);
   TestHelpers::db::test_simple_tag<Events::Tags::ObserverMesh<Dim>>(
       "ObserverMesh");
   TestHelpers::db::test_compute_tag<Events::Tags::ObserverMeshCompute<Dim>>(
       "ObserverMesh");
+  TestHelpers::db::test_simple_tag<
+      Events::Tags::ObserverCoordinates<Dim, Frame::Grid>>("GridCoordinates");
+  TestHelpers::db::test_compute_tag<
+      Events::Tags::ObserverCoordinatesCompute<Dim, Frame::Grid>>(
+      "GridCoordinates");
+  TestHelpers::db::test_simple_tag<
+      Events::Tags::ObserverCoordinates<Dim, Frame::Inertial>>(
+      "InertialCoordinates");
+  TestHelpers::db::test_compute_tag<
+      Events::Tags::ObserverCoordinatesCompute<Dim, Frame::Inertial>>(
+      "InertialCoordinates");
 }
 }  // namespace
 

--- a/tests/Unit/ParallelAlgorithms/Events/Test_Tags.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_Tags.cpp
@@ -1,0 +1,37 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/Tags.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "ParallelAlgorithms/Events/Tags.hpp"
+
+namespace {
+template <size_t Dim>
+void test(const Mesh<Dim>& mesh) {
+  const auto box =
+      db::create<db::AddSimpleTags<domain::Tags::Mesh<Dim>>,
+                 db::AddComputeTags<Events::Tags::ObserverMeshCompute<Dim>>>(
+          mesh);
+  CHECK(db::get<Events::Tags::ObserverMesh<Dim>>(box) == mesh);
+  TestHelpers::db::test_simple_tag<Events::Tags::ObserverMesh<Dim>>(
+      "ObserverMesh");
+  TestHelpers::db::test_compute_tag<Events::Tags::ObserverMeshCompute<Dim>>(
+      "ObserverMesh");
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.Events.Tags", "[Unit]") {
+  test(Mesh<1>{3, Spectral::Basis::Legendre,
+               Spectral::Quadrature::GaussLobatto});
+  test(Mesh<2>{3, Spectral::Basis::Legendre,
+               Spectral::Quadrature::GaussLobatto});
+  test(Mesh<3>{3, Spectral::Basis::Legendre,
+               Spectral::Quadrature::GaussLobatto});
+}


### PR DESCRIPTION
## Proposed changes

This loosely depends on #3762 . However, I'm pretty sure I can remove the commits from the other PR without any issues. The followup PRs will depend on both.

Only new commits are:
- Add subcell::Tags::ActiveCoordinates
- Add ActiveMesh tag to domain
- Add ActiveMeshCompute for DG-subcell
- Add missing include to DgSubcell/Tags/Jacobians.hpp

Adds some compute tags that are light-weight wrappers that are set to whatever the active mesh/coordinates are. For DG-only evolutions this is just the identity operation (but with pointers not memory copies), while for DG-subcell the actual active grid is checked and data set (pointed to) accordingly.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
