### PR TITLE
Runtime retrieval in ObserveFields and simplifications

### DIFF
--- a/src/Evolution/DgSubcell/Events/ObserveFields.hpp
+++ b/src/Evolution/DgSubcell/Events/ObserveFields.hpp
@@ -244,22 +244,6 @@ class ObserveFields<VolumeDim, ObservationValueTag, tmpl::list<Tensors...>,
     }
   }
 
-  // This overload is called when the list of analytic-solution tensors is
-  // empty, i.e. it is clear at compile-time that no analytic solutions are
-  // available
-  template <typename DataBoxType, typename ComputeTagsList,
-            typename Metavariables, typename ParallelComponent>
-  void operator()(const ObservationBox<DataBoxType, ComputeTagsList>& box,
-                  const double observation_value, const Mesh<VolumeDim>& mesh,
-                  const tnsr::I<DataVector, VolumeDim, Frame::Inertial>&
-                      inertial_coordinates,
-                  Parallel::GlobalCache<Metavariables>& cache,
-                  const ElementId<VolumeDim>& array_index,
-                  const ParallelComponent* const component) const {
-    this->operator()(box, observation_value, mesh, inertial_coordinates,
-                     std::nullopt, cache, array_index, component);
-  }
-
   using observation_registration_tags = tmpl::list<>;
   std::pair<observers::TypeOfObservation, observers::ObservationKey>
   get_observation_type_and_key_for_registration() const {


### PR DESCRIPTION
## Proposed changes

Change `ObserveFields` to only grab/evaluate quantities from the ObservationBox when they are actually observed. This should provide some runtime improvements when a lot of observing of something was done (eg lapse) but the 4-index constraint was calculated always just for fun ™️ As a result some other refactoring was possible to simple `ObserveFields` a bit more.

Depends on:
- [x] #3762 
- [x] #3764 

Only new commits are:
- ObserveFields runtime retrieval of data 
- Refactor subcell ObserveFields to reduce arguments
- Remove unused function from subcell ObserveFields

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
