### PR TITLE
Fix CSW / SW docs for evolved variable tags

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Tags.hpp
@@ -20,14 +20,39 @@ class Variables;
 /// \endcond
 
 namespace CurvedScalarWave::Tags {
+
+/*!
+ * \brief The scalar field.
+ */
 struct Psi : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 
+/*!
+ * \brief The conjugate momentum of the scalar field.
+ *
+ * \details Its definition comes from requiring it to be the future-directed
+ * time derivative of the scalar field \f$\Psi\f$ in curved spacetime, see
+ * \cite Scheel2003vs , Eq. 2.16:
+ *
+ * \f{align}
+ * \Pi :=& -n^a \partial_a \Psi \\
+ *     =&  \frac{1}{\alpha}\left(\beta^k \partial_k \Psi -
+ * {\partial_t\Psi}\right),\\ \f}
+ *
+ * where \f$n^a\f$ is the unit normal to spatial slices of the spacetime
+ * foliation, \f$\alpha\f$ is the lapse and \f$\beta^i\f$ is the shift vector.
+ */
 struct Pi : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 
+/*!
+ * \brief Auxiliary variable which is analytically the spatial derivative of the
+ * scalar field.
+ * \details If \f$\Psi\f$ is the scalar field then we define
+ * \f$\Phi_{i} = \partial_i \Psi\f$
+ */
 template <size_t SpatialDim>
 struct Phi : db::SimpleTag {
   using type = tnsr::i<DataVector, SpatialDim>;

--- a/src/Evolution/Systems/ScalarWave/Tags.hpp
+++ b/src/Evolution/Systems/ScalarWave/Tags.hpp
@@ -26,19 +26,10 @@ struct Psi : db::SimpleTag {
 };
 
 /*!
- * \brief The conjugate momentum of the scalar field.
- *
- * \details Its definition comes from requiring it to be the future-directed
- * time derivative of the scalar field \f$\Psi\f$ in curved spacetime, see
- * \cite Scheel2003vs , Eq. 2.16:
- *
- * \f{align}
- * \Pi :=& -n^a \partial_a \Psi \\
- *     =&  \frac{1}{\alpha}\left(\beta^k \Phi_k - {\partial_t\Psi}\right),\\
- * \f}
- *
- * where \f$n^a\f$ is the unit normal to spatial slices of the spacetime
- * foliation, \f$\alpha\f$ is the lapse and \f$\beta^i\f$ is the shift vector.
+ * \brief Auxiliary variable which is analytically the time derivative of the
+ * scalar field.
+ * \details If \f$\Psi\f$ is the scalar field then we define
+ * \f$\Pi = \partial_t \Psi\f$
  */
 struct Pi : db::SimpleTag {
   using type = Scalar<DataVector>;


### PR DESCRIPTION
This documentation of the evolved variables meant for the `CurvedScalarWave` system was erroneously added to the `ScalarWave` system in #3737 .

This PR moves the documentation to the `CurvedScalarWave` system and adds the appropriate documentation to the `ScalarWave` system.