### PR TITLE
Spack CI test: disable debug symbols

### DIFF
--- a/.github/workflows/Spack.yaml
+++ b/.github/workflows/Spack.yaml
@@ -32,12 +32,16 @@ jobs:
     runs-on: ${{ matrix.host }}
     env:
       # This is the configuration ("spec") that we'll install with Spack
+      # - Build a subset of executables, and Python bindings
+      # - Disable debug symbols to fit in the memory of the GitHub Actions VM
       # - Select the 'multicore' backend for Charm++, since we're running on a
       #   single node.
       # - Select HDF5 without MPI to avoid compiling MPI.
       SPECTRE_SPEC: >-  # Line breaks are spaces, no trailing newline
         spectre@${{ matrix.version }}
+          executables=SolvePoisson1D
           +python
+          ~debug_symbols
           %${{ matrix.compiler }}
           ^charmpp backend=multicore
           ^hdf5~mpi


### PR DESCRIPTION
## Proposed changes

The Spack package supports disabling debug symbols now, so building executables fits into the memory of the GitHub Actions VMs.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
