### PR TITLE
Fix an issue with encoded accents in bib entry

### DIFF
--- a/.github/scripts/Release.py
+++ b/.github/scripts/Release.py
@@ -438,6 +438,9 @@ def prepare(metadata: dict, version_name: str, metadata_file: str,
         'bibtex',
         # LaTeX-encode special characters, instead of writing unicode symbols
         encoding='ASCII')
+    # Fix an issue with encoded accents (a space in the author list is
+    # recognized as delimiter between names)
+    bib_file_content = bib_file_content.replace(r'\c c', r'\c{c}')
     # Wrap long lines in BibTeX output
     bib_file_content = "\n".join([
         textwrap.fill(line, width=80) for line in bib_file_content.split('\n')

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can cite this BibTeX entry in your publication:
 ```bib
 @software{spectrecode,
     author = "Deppe, Nils and Throwe, William and Kidder, Lawrence E. and
-Fischer, Nils L. and H\'ebert, Fran\c cois and Moxon, Jordan and Armaza,
+Fischer, Nils L. and H\'ebert, Fran\c{c}ois and Moxon, Jordan and Armaza,
 Crist\'obal and Bonilla, Gabriel S. and Kumar, Prayush and Lovelace, Geoffrey
 and O'Shea, Eamonn and Pfeiffer, Harald P. and Scheel, Mark A. and Teukolsky,
 Saul A. and others",

--- a/citation.bib
+++ b/citation.bib
@@ -1,6 +1,6 @@
 @software{spectrecode,
     author = "Deppe, Nils and Throwe, William and Kidder, Lawrence E. and
-Fischer, Nils L. and H\'ebert, Fran\c cois and Moxon, Jordan and Armaza,
+Fischer, Nils L. and H\'ebert, Fran\c{c}ois and Moxon, Jordan and Armaza,
 Crist\'obal and Bonilla, Gabriel S. and Kumar, Prayush and Lovelace, Geoffrey
 and O'Shea, Eamonn and Pfeiffer, Harald P. and Scheel, Mark A. and Teukolsky,
 Saul A. and others",


### PR DESCRIPTION
## Proposed changes

A space in the author list is recognized as delimiter between names, so `François` was rendered as `F.~c.`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
