### PR TITLE
Remove unused functions from ComputeTimeDerivative

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
@@ -302,25 +302,6 @@ struct ComputeTimeDerivative {
       const ParallelComponent* /*meta*/);  // NOLINT const
 
  private:
-  // The below functions will be removed once we've finished writing the new
-  // method of handling boundaries.
-  template <typename... NormalDotFluxTags, typename... Args>
-  static void apply_flux(
-      gsl::not_null<Variables<tmpl::list<NormalDotFluxTags...>>*> boundary_flux,
-      const Args&... boundary_variables) {
-    Metavariables::system::normal_dot_fluxes::apply(
-        make_not_null(&get<NormalDotFluxTags>(*boundary_flux))...,
-        boundary_variables...);
-  }
-
-  template <typename DbTagsList>
-  static void boundary_terms_nonconservative_products(
-      gsl::not_null<db::DataBox<DbTagsList>*> box);
-
-  template <size_t VolumeDim, typename BoundaryScheme, typename DbTagsList>
-  static void fill_mortar_data_for_internal_boundaries(
-      gsl::not_null<db::DataBox<DbTagsList>*> box);
-
   template <typename ParallelComponent, typename DbTagsList>
   static void send_data_for_fluxes(
       gsl::not_null<Parallel::GlobalCache<Metavariables>*> cache,


### PR DESCRIPTION
## Proposed changes

I missed removing these before. We don't need them anymore with the change in the evolution system.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
