### PR TITLE
Add bool flag for using subcell boundary conditions

### DIFF
--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -186,6 +186,7 @@ struct EvolutionMetavars {
 
   struct SubcellOptions {
     static constexpr bool subcell_enabled = use_dg_subcell;
+    static constexpr bool subcell_enabled_at_external_boundary = false;
 
     // We send `ghost_zone_size` cell-centered grid points for variable
     // reconstruction, of which we need `ghost_zone_size-1` for reconstruction

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -299,6 +299,8 @@ struct EvolutionMetavars {
                          tmpl::size_t<volume_dim>, Frame::Inertial>;
 
     static constexpr bool subcell_enabled = use_dg_subcell;
+    static constexpr bool subcell_enabled_at_external_boundary = false;
+
     // We send `ghost_zone_size` cell-centered grid points for variable
     // reconstruction, of which we need `ghost_zone_size-1` for reconstruction
     // to the internal side of the element face, and `ghost_zone_size` for
@@ -637,7 +639,8 @@ struct KerrHorizon {
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{
-    &setup_error_handling, &setup_memory_allocation_failure_reporting,
+    &setup_error_handling,
+    &setup_memory_allocation_failure_reporting,
     &disable_openblas_multithreading,
     &domain::creators::register_derived_with_charm,
     &domain::creators::time_dependence::register_derived_with_charm,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -315,6 +315,8 @@ struct EvolutionMetavars {
 
   struct SubcellOptions {
     static constexpr bool subcell_enabled = use_dg_subcell;
+    static constexpr bool subcell_enabled_at_external_boundary = false;
+
     // We send `ghost_zone_size` cell-centered grid points for variable
     // reconstruction, of which we need `ghost_zone_size-1` for reconstruction
     // to the internal side of the element face, and `ghost_zone_size` for

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -189,6 +189,7 @@ struct EvolutionMetavars {
 
   struct SubcellOptions {
     static constexpr bool subcell_enabled = use_dg_subcell;
+    static constexpr bool subcell_enabled_at_external_boundary = false;
 
     // We send `ghost_zone_size` cell-centered grid points for variable
     // reconstruction, of which we need `ghost_zone_size-1` for reconstruction

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_Initialize.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_Initialize.cpp
@@ -125,6 +125,10 @@ struct Metavariables {
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/) {}
 
+  struct SubcellOptions {
+    static constexpr bool subcell_enabled_at_external_boundary = false;
+  };
+
   struct DgInitialDataTci {
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     static bool invoked;

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndRollback.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndRollback.cpp
@@ -129,6 +129,10 @@ struct Metavariables {
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static bool tci_invoked;
 
+  struct SubcellOptions {
+    static constexpr bool subcell_enabled_at_external_boundary = false;
+  };
+
   struct TciOnDgGrid {
     using return_tags = tmpl::list<>;
     using argument_tags =


### PR DESCRIPTION
## Proposed changes

Add a bool type compile time constant `subcell_enabled_at_external_boundary` to the `EvolutionMetavars::SubcellOptions` struct. In the future we may want to make this as a runtime option.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
