### PR TITLE
Use type trait to select between analytic solutions/data for DirchletAnalyticBcs

### DIFF
--- a/src/Evolution/Systems/Burgers/BoundaryConditions/DirichletAnalytic.hpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/DirichletAnalytic.hpp
@@ -16,6 +16,7 @@
 #include "Evolution/BoundaryConditions/Type.hpp"
 #include "Evolution/Systems/Burgers/BoundaryConditions/BoundaryCondition.hpp"
 #include "Evolution/Systems/Burgers/Tags.hpp"
+#include "Evolution/TypeTraits.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticData/Tags.hpp"
@@ -83,8 +84,7 @@ class DirichletAnalytic final : public BoundaryCondition {
       const tnsr::I<DataVector, 1, Frame::Inertial>& coords,
       [[maybe_unused]] const double time,
       const AnalyticSolutionOrData& analytic_solution_or_data) const {
-    if constexpr (std::is_base_of_v<MarkAsAnalyticSolution,
-                                    AnalyticSolutionOrData>) {
+    if constexpr (evolution::is_analytic_solution_v<AnalyticSolutionOrData>) {
       *u = get<Burgers::Tags::U>(analytic_solution_or_data.variables(
           coords, time, tmpl::list<Burgers::Tags::U>{}));
     } else {

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DirichletAnalytic.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DirichletAnalytic.hpp
@@ -17,6 +17,7 @@
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BoundaryCondition.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Evolution/TypeTraits.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticData/Tags.hpp"
@@ -98,8 +99,7 @@ class DirichletAnalytic final : public BoundaryCondition<Dim> {
     *gamma1 = interior_gamma1;
     *gamma2 = interior_gamma2;
     auto boundary_values = [&analytic_solution_or_data, &coords, &time]() {
-      if constexpr (std::is_base_of_v<MarkAsAnalyticSolution,
-                                      AnalyticSolutionOrData>) {
+      if constexpr (evolution::is_analytic_solution_v<AnalyticSolutionOrData>) {
         return analytic_solution_or_data.variables(
             coords, time,
             tmpl::list<

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/DirichletAnalytic.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/DirichletAnalytic.hpp
@@ -18,6 +18,7 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+#include "Evolution/TypeTraits.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticData/Tags.hpp"
@@ -104,8 +105,7 @@ class DirichletAnalytic final : public BoundaryCondition {
       const tnsr::I<DataVector, 3, Frame::Inertial>& coords, const double time,
       const AnalyticSolutionOrData& analytic_solution_or_data) const {
     auto boundary_values = [&analytic_solution_or_data, &coords, &time]() {
-      if constexpr (std::is_base_of_v<MarkAsAnalyticSolution,
-                                      AnalyticSolutionOrData>) {
+      if constexpr (evolution::is_analytic_solution_v<AnalyticSolutionOrData>) {
         return analytic_solution_or_data.variables(
             coords, time,
             tmpl::list<

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/DirichletAnalytic.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/DirichletAnalytic.hpp
@@ -18,6 +18,7 @@
 #include "Evolution/Systems/NewtonianEuler/ConservativeFromPrimitive.hpp"
 #include "Evolution/Systems/NewtonianEuler/Fluxes.hpp"
 #include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "Evolution/TypeTraits.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticData/Tags.hpp"
@@ -97,8 +98,7 @@ class DirichletAnalytic final : public BoundaryCondition<Dim> {
       const double time,
       const AnalyticSolutionOrData& analytic_solution_or_data) const {
     auto boundary_values = [&analytic_solution_or_data, &coords, &time]() {
-      if constexpr (std::is_base_of_v<MarkAsAnalyticSolution,
-                                      AnalyticSolutionOrData>) {
+      if constexpr (evolution::is_analytic_solution_v<AnalyticSolutionOrData>) {
         return analytic_solution_or_data.variables(
             coords, time,
             tmpl::list<Tags::MassDensity<DataVector>,

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/DirichletAnalytic.hpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/DirichletAnalytic.hpp
@@ -19,6 +19,7 @@
 #include "Evolution/Systems/RadiationTransport/M1Grey/Fluxes.hpp"
 #include "Evolution/Systems/RadiationTransport/M1Grey/M1Closure.hpp"
 #include "Evolution/Systems/RadiationTransport/M1Grey/Tags.hpp"
+#include "Evolution/TypeTraits.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticData/Tags.hpp"
@@ -112,8 +113,7 @@ class DirichletAnalytic<tmpl::list<NeutrinoSpecies...>> final
       const tnsr::I<DataVector, 3, Frame::Inertial>& coords, const double time,
       const AnalyticSolutionOrData& analytic_solution_or_data) const {
     auto boundary_values = [&analytic_solution_or_data, &coords, &time]() {
-      if constexpr (std::is_base_of_v<MarkAsAnalyticSolution,
-                                      AnalyticSolutionOrData>) {
+      if constexpr (evolution::is_analytic_solution_v<AnalyticSolutionOrData>) {
         return analytic_solution_or_data.variables(
             coords, time,
             tmpl::list<Tags::TildeE<Frame::Inertial, NeutrinoSpecies>...,

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/DirichletAnalytic.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/DirichletAnalytic.hpp
@@ -18,6 +18,7 @@
 #include "Evolution/Systems/RelativisticEuler/Valencia/ConservativeFromPrimitive.hpp"
 #include "Evolution/Systems/RelativisticEuler/Valencia/Fluxes.hpp"
 #include "Evolution/Systems/RelativisticEuler/Valencia/Tags.hpp"
+#include "Evolution/TypeTraits.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticData/Tags.hpp"
@@ -106,8 +107,7 @@ class DirichletAnalytic final : public BoundaryCondition<Dim> {
       const double time,
       const AnalyticSolutionOrData& analytic_solution_or_data) const {
     auto boundary_values = [&analytic_solution_or_data, &coords, &time]() {
-      if constexpr (std::is_base_of_v<MarkAsAnalyticSolution,
-                                      AnalyticSolutionOrData>) {
+      if constexpr (evolution::is_analytic_solution_v<AnalyticSolutionOrData>) {
         return analytic_solution_or_data.variables(
             coords, time,
             tmpl::list<hydro::Tags::RestMassDensity<DataVector>,

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/DirichletAnalytic.hpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/DirichletAnalytic.hpp
@@ -16,6 +16,7 @@
 #include "Evolution/BoundaryConditions/Type.hpp"
 #include "Evolution/Systems/ScalarWave/BoundaryConditions/BoundaryCondition.hpp"
 #include "Evolution/Systems/ScalarWave/Tags.hpp"
+#include "Evolution/TypeTraits.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticData/Tags.hpp"
@@ -85,8 +86,7 @@ class DirichletAnalytic final : public BoundaryCondition<Dim> {
       const AnalyticSolutionOrData& analytic_solution_or_data) const {
     *gamma2 = interior_gamma2;
     auto boundary_values = [&analytic_solution_or_data, &coords, &time]() {
-      if constexpr (std::is_base_of_v<MarkAsAnalyticSolution,
-                                      AnalyticSolutionOrData>) {
+      if constexpr (evolution::is_analytic_solution_v<AnalyticSolutionOrData>) {
         return analytic_solution_or_data.variables(
             coords, time,
             tmpl::list<ScalarWave::Tags::Psi, ScalarWave::Tags::Pi,


### PR DESCRIPTION
The type trait should be used instead of std::is_base_of as several analytic data privately
inherit from an analytic solution.

## Proposed changes

EvolveValenicaDivCleanMagnetizedTovStar fails to compile on develop.
This PR fixes the problem by correctly choosing between an analytic solution and analytic data.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
