### PR TITLE
Add time to AH finder printed output

### DIFF
--- a/src/ParallelAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp
@@ -21,6 +21,7 @@
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Printf.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/SendPointsToInterpolator.hpp"
+#include "ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
@@ -233,11 +234,12 @@ struct FindApparentHorizon {
       if (verbosity > ::Verbosity::Quiet or
           (verbosity > ::Verbosity::Silent and has_converged)) {
         Parallel::printf(
-            "%s: its=%d: %.1e<R<%.0e, |R|=%.1g, "
+            "%s: t=%.6g: its=%d: %.1e<R<%.0e, |R|=%.1g, "
             "|R_grid|=%.1g, %.4g<r<%.4g\n",
-            pretty_type::short_name<InterpolationTargetTag>(), info.iteration,
-            info.min_residual, info.max_residual, info.residual_ylm,
-            info.residual_mesh, info.r_min, info.r_max);
+            pretty_type::short_name<InterpolationTargetTag>(),
+            InterpolationTarget_detail::get_temporal_id_value(temporal_id),
+            info.iteration, info.min_residual, info.max_residual,
+            info.residual_ylm, info.residual_mesh, info.r_min, info.r_max);
       }
 
       if (status == FastFlow::Status::SuccessfulIteration) {


### PR DESCRIPTION
## Proposed changes

This will help clarify which horizon find happened at which temporal id when output is all jumbled together out of order.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
