### PR TITLE
TimeDependence now recognizes distorted frame.

### DIFF
--- a/src/Domain/Creators/Brick.cpp
+++ b/src/Domain/Creators/Brick.cpp
@@ -127,7 +127,9 @@ Domain<3> Brick::create_domain() const {
 
   if (not time_dependence_->is_none()) {
     domain.inject_time_dependent_map_for_block(
-        0, std::move(time_dependence_->block_maps(1)[0]));
+        0, std::move(time_dependence_->block_maps_grid_to_inertial(1)[0]),
+        std::move(time_dependence_->block_maps_grid_to_distorted(1)[0]),
+        std::move(time_dependence_->block_maps_distorted_to_inertial(1)[0]));
   }
   return domain;
 }

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
@@ -663,8 +663,8 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
   if (not time_dependence_->is_none()) {
     for (size_t block = 0; block < number_of_blocks_; ++block) {
       domain.inject_time_dependent_map_for_block(
-          block,
-          std::move(time_dependence_->block_maps(number_of_blocks_)[block]));
+          block, std::move(time_dependence_->block_maps_grid_to_inertial(
+                     number_of_blocks_)[block]));
     }
   }
   return domain;

--- a/src/Domain/Creators/Interval.cpp
+++ b/src/Domain/Creators/Interval.cpp
@@ -125,7 +125,9 @@ Domain<1> Interval::create_domain() const {
       std::move(boundary_conditions_all_blocks)};
   if (not time_dependence_->is_none()) {
     domain.inject_time_dependent_map_for_block(
-        0, std::move(time_dependence_->block_maps(1)[0]));
+        0, std::move(time_dependence_->block_maps_grid_to_inertial(1)[0]),
+        std::move(time_dependence_->block_maps_grid_to_distorted(1)[0]),
+        std::move(time_dependence_->block_maps_distorted_to_inertial(1)[0]));
   }
   return domain;
 }

--- a/src/Domain/Creators/Rectangle.cpp
+++ b/src/Domain/Creators/Rectangle.cpp
@@ -123,7 +123,9 @@ Domain<2> Rectangle::create_domain() const {
 
   if (not time_dependence_->is_none()) {
     domain.inject_time_dependent_map_for_block(
-        0, std::move(time_dependence_->block_maps(1)[0]));
+        0, std::move(time_dependence_->block_maps_grid_to_inertial(1)[0]),
+        std::move(time_dependence_->block_maps_grid_to_distorted(1)[0]),
+        std::move(time_dependence_->block_maps_distorted_to_inertial(1)[0]));
   }
   return domain;
 }

--- a/src/Domain/Creators/RotatedIntervals.cpp
+++ b/src/Domain/Creators/RotatedIntervals.cpp
@@ -128,10 +128,17 @@ Domain<1> RotatedIntervals::create_domain() const {
       is_periodic_in_);
   if (not time_dependence_->is_none()) {
     const size_t number_of_blocks = domain.blocks().size();
-    auto block_maps = time_dependence_->block_maps(number_of_blocks);
+    auto block_maps_grid_to_inertial =
+        time_dependence_->block_maps_grid_to_inertial(number_of_blocks);
+    auto block_maps_grid_to_distorted =
+        time_dependence_->block_maps_grid_to_distorted(number_of_blocks);
+    auto block_maps_distorted_to_inertial =
+        time_dependence_->block_maps_distorted_to_inertial(number_of_blocks);
     for (size_t block_id = 0; block_id < number_of_blocks; ++block_id) {
       domain.inject_time_dependent_map_for_block(
-          block_id, std::move(block_maps[block_id]));
+          block_id, std::move(block_maps_grid_to_inertial[block_id]),
+          std::move(block_maps_grid_to_distorted[block_id]),
+          std::move(block_maps_distorted_to_inertial[block_id]));
     }
   }
   return domain;

--- a/src/Domain/Creators/Shell.cpp
+++ b/src/Domain/Creators/Shell.cpp
@@ -174,10 +174,17 @@ Domain<3> Shell::create_domain() const {
 
   if (not time_dependence_->is_none()) {
     const size_t number_of_blocks = domain.blocks().size();
-    auto block_maps = time_dependence_->block_maps(number_of_blocks);
+    auto block_maps_grid_to_inertial =
+        time_dependence_->block_maps_grid_to_inertial(number_of_blocks);
+    auto block_maps_grid_to_distorted =
+        time_dependence_->block_maps_grid_to_distorted(number_of_blocks);
+    auto block_maps_distorted_to_inertial =
+        time_dependence_->block_maps_distorted_to_inertial(number_of_blocks);
     for (size_t block_id = 0; block_id < number_of_blocks; ++block_id) {
       domain.inject_time_dependent_map_for_block(
-          block_id, std::move(block_maps[block_id]));
+          block_id, std::move(block_maps_grid_to_inertial[block_id]),
+          std::move(block_maps_grid_to_distorted[block_id]),
+          std::move(block_maps_distorted_to_inertial[block_id]));
     }
   }
   return domain;

--- a/src/Domain/Creators/TimeDependence/CubicScale.cpp
+++ b/src/Domain/Creators/TimeDependence/CubicScale.cpp
@@ -57,7 +57,8 @@ std::unique_ptr<TimeDependence<MeshDim>> CubicScale<MeshDim>::get_clone()
 template <size_t MeshDim>
 std::vector<std::unique_ptr<
     domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, MeshDim>>>
-CubicScale<MeshDim>::block_maps(const size_t number_of_blocks) const {
+CubicScale<MeshDim>::block_maps_grid_to_inertial(
+    const size_t number_of_blocks) const {
   ASSERT(number_of_blocks > 0, "Must have at least one block to create.");
   std::vector<std::unique_ptr<
       domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, MeshDim>>>

--- a/src/Domain/Creators/TimeDependence/CubicScale.hpp
+++ b/src/Domain/Creators/TimeDependence/CubicScale.hpp
@@ -21,24 +21,23 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
-namespace domain {
-namespace FunctionsOfTime {
+namespace domain::FunctionsOfTime {
 class FunctionOfTime;
-}  // namespace FunctionsOfTime
+}  // namespace domain::FunctionsOfTime
 
+namespace domain {
 template <typename SourceFrame, typename TargetFrame, typename... Maps>
 class CoordinateMap;
 }  // namespace domain
 
 namespace Frame {
+struct Distorted;
 struct Grid;
 struct Inertial;
 }  // namespace Frame
 /// \endcond
 
-namespace domain {
-namespace creators {
-namespace time_dependence {
+namespace domain::creators::time_dependence {
 /// \brief A linear or cubic radial scaling time dependence.
 ///
 /// Adds the `domain::CoordinateMaps::TimeDependent::CubicScale` map. A linear
@@ -119,9 +118,25 @@ class CubicScale final : public TimeDependence<MeshDim> {
 
   auto get_clone() const -> std::unique_ptr<TimeDependence<MeshDim>> override;
 
-  auto block_maps(size_t number_of_blocks) const
+  auto block_maps_grid_to_inertial(size_t number_of_blocks) const
       -> std::vector<std::unique_ptr<domain::CoordinateMapBase<
           Frame::Grid, Frame::Inertial, MeshDim>>> override;
+
+  auto block_maps_grid_to_distorted(size_t number_of_blocks) const
+      -> std::vector<std::unique_ptr<domain::CoordinateMapBase<
+          Frame::Grid, Frame::Distorted, MeshDim>>> override {
+    using ptr_type =
+        domain::CoordinateMapBase<Frame::Grid, Frame::Distorted, MeshDim>;
+    return std::vector<std::unique_ptr<ptr_type>>(number_of_blocks);
+  }
+
+  auto block_maps_distorted_to_inertial(size_t number_of_blocks) const
+      -> std::vector<std::unique_ptr<domain::CoordinateMapBase<
+          Frame::Distorted, Frame::Inertial, MeshDim>>> override {
+    using ptr_type =
+        domain::CoordinateMapBase<Frame::Distorted, Frame::Inertial, MeshDim>;
+    return std::vector<std::unique_ptr<ptr_type>>(number_of_blocks);
+  }
 
   auto functions_of_time(const std::unordered_map<std::string, double>&
                              initial_expiration_times = {}) const
@@ -155,6 +170,4 @@ bool operator==(const CubicScale<Dim>& lhs, const CubicScale<Dim>& rhs);
 
 template <size_t Dim>
 bool operator!=(const CubicScale<Dim>& lhs, const CubicScale<Dim>& rhs);
-}  // namespace time_dependence
-}  // namespace creators
-}  // namespace domain
+}  // namespace domain::creators::time_dependence

--- a/src/Domain/Creators/TimeDependence/GenerateCoordinateMap.hpp
+++ b/src/Domain/Creators/TimeDependence/GenerateCoordinateMap.hpp
@@ -10,28 +10,18 @@ namespace domain {
 template <typename SourceFrame, typename TargetFrame, typename... Maps>
 class CoordinateMap;
 }  // namespace domain
-namespace Frame {
-struct Grid;
-struct Inertial;
-}  // namespace Frame
 /// \endcond
 
-namespace domain {
-namespace creators {
-namespace time_dependence {
-namespace detail {
-template <typename MapsList>
+namespace domain::creators::time_dependence::detail {
+template <typename SourceFrame, typename TargetFrame, typename MapsList>
 struct generate_coordinate_map;
 
-template <typename... Maps>
-struct generate_coordinate_map<tmpl::list<Maps...>> {
-  using type = domain::CoordinateMap<Frame::Grid, Frame::Inertial, Maps...>;
+template <typename SourceFrame, typename TargetFrame, typename... Maps>
+struct generate_coordinate_map<SourceFrame, TargetFrame, tmpl::list<Maps...>> {
+  using type = domain::CoordinateMap<SourceFrame, TargetFrame, Maps...>;
 };
 
-template <typename MapsList>
+template <typename SourceFrame, typename TargetFrame, typename MapsList>
 using generate_coordinate_map_t =
-    typename generate_coordinate_map<MapsList>::type;
-}  // namespace detail
-}  // namespace time_dependence
-}  // namespace creators
-}  // namespace domain
+    typename generate_coordinate_map<SourceFrame, TargetFrame, MapsList>::type;
+}  // namespace domain::creators::time_dependence::detail

--- a/src/Domain/Creators/TimeDependence/None.cpp
+++ b/src/Domain/Creators/TimeDependence/None.cpp
@@ -22,11 +22,34 @@ std::unique_ptr<TimeDependence<MeshDim>> None<MeshDim>::get_clone() const {
 template <size_t MeshDim>
 [[noreturn]] std::vector<std::unique_ptr<
     domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, MeshDim>>>
-None<MeshDim>::block_maps(const size_t /*number_of_blocks*/) const {
+None<MeshDim>::block_maps_grid_to_inertial(
+    const size_t /*number_of_blocks*/) const {
   ERROR(
-      "The 'block_maps' function of the 'None' TimeDependence should never be "
-      "called because 'None' is only used as a place holder class to mark that "
-      "the mesh is time-independent.");
+      "The 'block_maps_grid_to_inertial' function of the 'None' TimeDependence "
+      "should never be called because 'None' is only used as a place holder "
+      "class to mark that the mesh is time-independent.");
+}
+
+template <size_t MeshDim>
+[[noreturn]] std::vector<std::unique_ptr<
+    domain::CoordinateMapBase<Frame::Grid, Frame::Distorted, MeshDim>>>
+None<MeshDim>::block_maps_grid_to_distorted(
+    const size_t /*number_of_blocks*/) const {
+  ERROR(
+      "The 'block_maps_grid_to_distorted' function of the 'None' "
+      "TimeDependence should never be called because 'None' is only used as a "
+      "place holder class to mark that the mesh is time-independent.");
+}
+
+template <size_t MeshDim>
+[[noreturn]] std::vector<std::unique_ptr<
+    domain::CoordinateMapBase<Frame::Distorted, Frame::Inertial, MeshDim>>>
+None<MeshDim>::block_maps_distorted_to_inertial(
+    const size_t /*number_of_blocks*/) const {
+  ERROR(
+      "The 'block_maps_distorted_to_inertial' function of the 'None' "
+      "TimeDependence should never be called because 'None' is only used as a "
+      "place holder class to mark that the mesh is time-independent.");
 }
 
 template <size_t MeshDim>

--- a/src/Domain/Creators/TimeDependence/None.hpp
+++ b/src/Domain/Creators/TimeDependence/None.hpp
@@ -15,21 +15,18 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
-namespace domain {
-namespace FunctionsOfTime {
+namespace domain::FunctionsOfTime {
 class FunctionOfTime;
-}  // namespace FunctionsOfTime
-}  // namespace domain
+}  // namespace domain::FunctionsOfTime
 
 namespace Frame {
+struct Distorted;
 struct Grid;
 struct Inertial;
 }  // namespace Frame
 /// \endcond
 
-namespace domain {
-namespace creators {
-namespace time_dependence {
+namespace domain::creators::time_dependence {
 /// \brief Make the mesh time independent so that it isn't moving.
 ///
 /// \warning Calling the `block_maps` and `functions_of_time` functions causes
@@ -54,9 +51,17 @@ class None final : public TimeDependence<MeshDim> {
 
   auto get_clone() const -> std::unique_ptr<TimeDependence<MeshDim>> override;
 
-  [[noreturn]] auto block_maps(size_t number_of_blocks) const
+  [[noreturn]] auto block_maps_grid_to_inertial(size_t number_of_blocks) const
       -> std::vector<std::unique_ptr<domain::CoordinateMapBase<
           Frame::Grid, Frame::Inertial, MeshDim>>> override;
+
+  [[noreturn]] auto block_maps_grid_to_distorted(size_t number_of_blocks) const
+      -> std::vector<std::unique_ptr<domain::CoordinateMapBase<
+          Frame::Grid, Frame::Distorted, MeshDim>>> override;
+
+  [[noreturn]] auto block_maps_distorted_to_inertial(size_t number_of_blocks)
+      const -> std::vector<std::unique_ptr<domain::CoordinateMapBase<
+          Frame::Distorted, Frame::Inertial, MeshDim>>> override;
 
   [[noreturn]] auto functions_of_time(
       const std::unordered_map<std::string, double>& initial_expiration_times =
@@ -71,6 +76,4 @@ bool operator==(const None<Dim>& lhs, const None<Dim>& rhs);
 
 template <size_t Dim>
 bool operator!=(const None<Dim>& lhs, const None<Dim>& rhs);
-}  // namespace time_dependence
-}  // namespace creators
-}  // namespace domain
+}  // namespace domain::creators::time_dependence

--- a/src/Domain/Creators/TimeDependence/SphericalCompression.cpp
+++ b/src/Domain/Creators/TimeDependence/SphericalCompression.cpp
@@ -57,7 +57,8 @@ std::unique_ptr<TimeDependence<3>> SphericalCompression::get_clone() const {
 
 std::vector<
     std::unique_ptr<domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, 3>>>
-SphericalCompression::block_maps(const size_t number_of_blocks) const {
+SphericalCompression::block_maps_grid_to_inertial(
+    const size_t number_of_blocks) const {
   ASSERT(number_of_blocks > 0,
          "Must have at least one block on which to create a map.");
   std::vector<std::unique_ptr<

--- a/src/Domain/Creators/TimeDependence/TimeDependence.hpp
+++ b/src/Domain/Creators/TimeDependence/TimeDependence.hpp
@@ -20,6 +20,7 @@ class FunctionOfTime;
 }  // namespace FunctionsOfTime
 }  // namespace domain
 namespace Frame {
+struct Distorted;
 struct Grid;
 struct Inertial;
 }  // namespace Frame
@@ -84,9 +85,23 @@ struct TimeDependence {
 
   /// Returns the coordinate maps from the `Frame::Grid` to the
   /// `Frame::Inertial` frame for each block.
-  virtual auto
-  block_maps(size_t number_of_blocks) const -> std::vector<std::unique_ptr<
-      domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, MeshDim>>> = 0;
+  virtual auto block_maps_grid_to_inertial(size_t number_of_blocks) const
+      -> std::vector<std::unique_ptr<domain::CoordinateMapBase<
+          Frame::Grid, Frame::Inertial, MeshDim>>> = 0;
+
+  /// Returns the coordinate maps from the `Frame::Grid` to the
+  /// `Frame::Distorted` frame for each block.
+  /// Returns vector of nullptr if there is no distorted frame.
+  virtual auto block_maps_grid_to_distorted(size_t number_of_blocks) const
+      -> std::vector<std::unique_ptr<domain::CoordinateMapBase<
+          Frame::Grid, Frame::Distorted, MeshDim>>> = 0;
+
+  /// Returns the coordinate maps from the `Frame::Distorted` to the
+  /// `Frame::Inertial` frame for each block.
+  /// Returns vector of nullptr if is no distorted frame.
+  virtual auto block_maps_distorted_to_inertial(size_t number_of_blocks) const
+      -> std::vector<std::unique_ptr<domain::CoordinateMapBase<
+          Frame::Distorted, Frame::Inertial, MeshDim>>> = 0;
 
   /// Returns the functions of time for the domain.
   virtual auto functions_of_time(const std::unordered_map<std::string, double>&

--- a/src/Domain/Creators/TimeDependence/UniformRotationAboutZAxis.cpp
+++ b/src/Domain/Creators/TimeDependence/UniformRotationAboutZAxis.cpp
@@ -44,7 +44,7 @@ UniformRotationAboutZAxis<MeshDim>::get_clone() const {
 template <size_t MeshDim>
 std::vector<std::unique_ptr<
     domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, MeshDim>>>
-UniformRotationAboutZAxis<MeshDim>::block_maps(
+UniformRotationAboutZAxis<MeshDim>::block_maps_grid_to_inertial(
     const size_t number_of_blocks) const {
   ASSERT(number_of_blocks > 0, "Must have at least one block to create.");
   std::vector<std::unique_ptr<

--- a/src/Domain/Creators/TimeDependence/UniformTranslation.cpp
+++ b/src/Domain/Creators/TimeDependence/UniformTranslation.cpp
@@ -41,7 +41,7 @@ UniformTranslation<MeshDim, Index>::get_clone() const {
 template <size_t MeshDim, size_t Index>
 std::vector<std::unique_ptr<
     domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, MeshDim>>>
-UniformTranslation<MeshDim, Index>::block_maps(
+UniformTranslation<MeshDim, Index>::block_maps_grid_to_inertial(
     const size_t number_of_blocks) const {
   ASSERT(number_of_blocks > 0, "Must have at least one block to create.");
   std::vector<std::unique_ptr<

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_CubicScale.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_CubicScale.cpp
@@ -79,13 +79,20 @@ void test_impl(
   const auto expected_block_map =
       create_coord_map<MeshDim>(outer_boundary, f_of_t_names);
 
-  const auto block_maps = time_dep_unique_ptr->block_maps(num_blocks);
+  const auto block_maps =
+      time_dep_unique_ptr->block_maps_grid_to_inertial(num_blocks);
   for (const auto& block_map_unique_ptr : block_maps) {
     const auto* const block_map =
         dynamic_cast<const CoordMap<MeshDim>*>(block_map_unique_ptr.get());
     REQUIRE(block_map != nullptr);
     CHECK(*block_map == expected_block_map);
   }
+
+  // Check that maps involving distorted frame are empty.
+  CHECK(time_dep_unique_ptr->block_maps_grid_to_distorted(1)[0].get() ==
+        nullptr);
+  CHECK(time_dep_unique_ptr->block_maps_distorted_to_inertial(1)[0].get() ==
+        nullptr);
 
   // Test functions of time without expiration times
   {

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_None.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_None.cpp
@@ -47,10 +47,24 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependence.None",
 }
 
 template <size_t MeshDim>
-void test_error_block_maps() {
+void test_error_block_maps_grid_to_inertial() {
   const std::unique_ptr<TimeDependence<MeshDim>> time_dep =
       std::make_unique<None<MeshDim>>();
-  (void)time_dep->block_maps(5);
+  (void)time_dep->block_maps_grid_to_inertial(5);
+}
+
+template <size_t MeshDim>
+void test_error_block_maps_grid_to_distorted() {
+  const std::unique_ptr<TimeDependence<MeshDim>> time_dep =
+      std::make_unique<None<MeshDim>>();
+  (void)time_dep->block_maps_grid_to_distorted(5);
+}
+
+template <size_t MeshDim>
+void test_error_block_maps_distorted_to_inertial() {
+  const std::unique_ptr<TimeDependence<MeshDim>> time_dep =
+      std::make_unique<None<MeshDim>>();
+  (void)time_dep->block_maps_distorted_to_inertial(5);
 }
 
 template <size_t MeshDim>
@@ -60,9 +74,9 @@ void test_error_functions_of_time() {
   (void)time_dep->functions_of_time();
 }
 
-// [[OutputRegex, The 'block_maps' function of the 'None']]
+// [[OutputRegex, The 'block_maps_grid_to_inertial' function of the 'None']]
 [[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.Domain.Creators.TimeDependence.None.ErrorBlockMaps",
+    "Unit.Domain.Creators.TimeDependence.None.ErrorBlockMaps0",
     "[Domain][Unit]") {
   ERROR_TEST();
 
@@ -71,11 +85,51 @@ void test_error_functions_of_time() {
   const size_t mesh_dim = dist_size_t(gen);
 
   if (mesh_dim == 1) {
-    test_error_block_maps<1>();
+    test_error_block_maps_grid_to_inertial<1>();
   } else if (mesh_dim == 2) {
-    test_error_block_maps<2>();
+    test_error_block_maps_grid_to_inertial<2>();
   } else if (mesh_dim == 3) {
-    test_error_block_maps<3>();
+    test_error_block_maps_grid_to_inertial<3>();
+  }
+  ERROR("Bad MeshDim in test: " << mesh_dim);
+}
+
+// [[OutputRegex, The 'block_maps_grid_to_distorted' function of the 'None']]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Domain.Creators.TimeDependence.None.ErrorBlockMaps1",
+    "[Domain][Unit]") {
+  ERROR_TEST();
+
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<size_t> dist_size_t{1, 3};
+  const size_t mesh_dim = dist_size_t(gen);
+
+  if (mesh_dim == 1) {
+    test_error_block_maps_grid_to_distorted<1>();
+  } else if (mesh_dim == 2) {
+    test_error_block_maps_grid_to_distorted<2>();
+  } else if (mesh_dim == 3) {
+    test_error_block_maps_grid_to_distorted<3>();
+  }
+  ERROR("Bad MeshDim in test: " << mesh_dim);
+}
+
+// [[OutputRegex, The 'block_maps_distorted_to_inertial' function of the ]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Domain.Creators.TimeDependence.None.ErrorBlockMaps2",
+    "[Domain][Unit]") {
+  ERROR_TEST();
+
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<size_t> dist_size_t{1, 3};
+  const size_t mesh_dim = dist_size_t(gen);
+
+  if (mesh_dim == 1) {
+    test_error_block_maps_distorted_to_inertial<1>();
+  } else if (mesh_dim == 2) {
+    test_error_block_maps_distorted_to_inertial<2>();
+  } else if (mesh_dim == 3) {
+    test_error_block_maps_distorted_to_inertial<3>();
   }
   ERROR("Bad MeshDim in test: " << mesh_dim);
 }

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_SphericalCompression.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_SphericalCompression.cpp
@@ -70,13 +70,20 @@ void test(const std::unique_ptr<TimeDependence<3>>& time_dep_unique_ptr,
   const auto expected_block_map =
       create_coord_map(f_of_t_name, min_radius, max_radius, center);
 
-  const auto block_maps = time_dep_unique_ptr->block_maps(num_blocks);
+  const auto block_maps =
+      time_dep_unique_ptr->block_maps_grid_to_inertial(num_blocks);
   for (const auto& block_map_unique_ptr : block_maps) {
     const auto* const block_map =
         dynamic_cast<const ConcreteMap*>(block_map_unique_ptr.get());
     REQUIRE(block_map != nullptr);
     CHECK(*block_map == expected_block_map);
   }
+
+  // Check that maps involving distorted frame are empty.
+  CHECK(time_dep_unique_ptr->block_maps_grid_to_distorted(1)[0].get() ==
+        nullptr);
+  CHECK(time_dep_unique_ptr->block_maps_distorted_to_inertial(1)[0].get() ==
+        nullptr);
 
   // Test functions of time without expiration times
   {

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_UniformRotationAboutZAxis.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_UniformRotationAboutZAxis.cpp
@@ -79,13 +79,20 @@ void test(const std::unique_ptr<TimeDependence<MeshDim>>& time_dep_unique_ptr,
 
   const auto expected_block_map = create_coord_map<MeshDim>(f_of_t_name);
 
-  const auto block_maps = time_dep_unique_ptr->block_maps(num_blocks);
+  const auto block_maps =
+      time_dep_unique_ptr->block_maps_grid_to_inertial(num_blocks);
   for (const auto& block_map_unique_ptr : block_maps) {
     const auto* const block_map =
         dynamic_cast<const ConcreteMap<MeshDim>*>(block_map_unique_ptr.get());
     REQUIRE(block_map != nullptr);
     CHECK(*block_map == expected_block_map);
   }
+
+  // Check that maps involving distorted frame are empty.
+  CHECK(time_dep_unique_ptr->block_maps_grid_to_distorted(1)[0].get() ==
+        nullptr);
+  CHECK(time_dep_unique_ptr->block_maps_distorted_to_inertial(1)[0].get() ==
+        nullptr);
 
   // Test functions of time without expiration times
   {

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_UniformTranslation.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_UniformTranslation.cpp
@@ -64,13 +64,20 @@ void test(const std::unique_ptr<TimeDependence<MeshDim>>& time_dep_unique_ptr,
 
   const auto expected_block_map = create_coord_map<MeshDim>(f_of_t_name);
 
-  const auto block_maps = time_dep_unique_ptr->block_maps(num_blocks);
+  const auto block_maps =
+      time_dep_unique_ptr->block_maps_grid_to_inertial(num_blocks);
   for (const auto& block_map_unique_ptr : block_maps) {
     const auto* const block_map =
         dynamic_cast<const ConcreteMap<MeshDim>*>(block_map_unique_ptr.get());
     REQUIRE(block_map != nullptr);
     CHECK(*block_map == expected_block_map);
   }
+
+  // Check that maps involving distorted frame are empty.
+  CHECK(time_dep_unique_ptr->block_maps_grid_to_distorted(1)[0].get() ==
+        nullptr);
+  CHECK(time_dep_unique_ptr->block_maps_distorted_to_inertial(1)[0].get() ==
+        nullptr);
 
   // Test functions of time without expiration times
   {


### PR DESCRIPTION
## Proposed changes

TimeDependence now has 3 maps: GridToInertial, GridToDistorted, and DistortedToInertial.
The distorted-frame maps are optional (if the map doesn't exist then the TimeDependence member functions return a std::unique_ptr set to nullptr).  Only one TimeDependence (ScalingAndZRotation) has distorted-frame maps.

The DomainCreators that use a TimeDependence now can use distorted-frame maps.

### Upgrade instructions

<!-- UPGRADE INSTRUCTIONS -->
Instead of a `block_maps` member function, each TimeDependence now has 3 functions: `block_maps_grid_to_inertial` (which is the former `block_maps`), `block_maps_grid_to_distorted`, and `block_maps_distorted_to_inertial`.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
