### PR TITLE
Load initial data from XCTS solver in GH execs

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
@@ -14,6 +14,7 @@
 #include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
 #include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
 #include "Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Actions/NumericInitialData.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/RegisterDerived.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/RegisterDerivedWithCharm.hpp"
 #include "Options/FactoryHelpers.hpp"
@@ -169,13 +170,12 @@ struct EvolutionMetavars<3, InitialData, BoundaryConditions>
                           Parallel::Actions::TerminatePhase>>,
                   Parallel::PhaseActions<
                       Phase, Phase::ImportInitialData,
-                      tmpl::list<importers::Actions::ReadVolumeData<
-                                     evolution::OptionTags::NumericInitialData,
-                                     typename system::variables_tag::tags_list>,
-                                 importers::Actions::ReceiveVolumeData<
-                                     evolution::OptionTags::NumericInitialData,
-                                     typename system::variables_tag::tags_list>,
-                                 Parallel::Actions::TerminatePhase>>>,
+                      tmpl::list<
+                          GeneralizedHarmonic::Actions::ReadNumericInitialData<
+                              evolution::OptionTags::NumericInitialData>,
+                          GeneralizedHarmonic::Actions::SetNumericInitialData<
+                              evolution::OptionTags::NumericInitialData>,
+                          Parallel::Actions::TerminatePhase>>>,
               tmpl::list<>>,
           Parallel::PhaseActions<
               Phase, Phase::InitializeInitialDataDependentQuantities,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -33,6 +33,7 @@
 #include "Evolution/Initialization/Evolution.hpp"
 #include "Evolution/Initialization/NonconservativeSystem.hpp"
 #include "Evolution/NumericInitialData.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Actions/NumericInitialData.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DirichletMinkowski.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Factory.hpp"
@@ -46,8 +47,6 @@
 #include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "Evolution/TypeTraits.hpp"
-#include "IO/Importers/Actions/ReadVolumeData.hpp"
-#include "IO/Importers/Actions/ReceiveVolumeData.hpp"
 #include "IO/Importers/Actions/RegisterWithElementDataReader.hpp"
 #include "IO/Importers/ElementDataReader.hpp"
 #include "IO/Observer/Actions/ObserverRegistration.hpp"
@@ -487,12 +486,10 @@ struct EvolutionMetavars {
                          Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
               Phase, Phase::ImportInitialData,
-              tmpl::list<importers::Actions::ReadVolumeData<
-                             evolution::OptionTags::NumericInitialData,
-                             typename system::variables_tag::tags_list>,
-                         importers::Actions::ReceiveVolumeData<
-                             evolution::OptionTags::NumericInitialData,
-                             typename system::variables_tag::tags_list>,
+              tmpl::list<GeneralizedHarmonic::Actions::ReadNumericInitialData<
+                             evolution::OptionTags::NumericInitialData>,
+                         GeneralizedHarmonic::Actions::SetNumericInitialData<
+                             evolution::OptionTags::NumericInitialData>,
                          Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
               Phase, Phase::InitializeInitialDataDependentQuantities,

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -31,6 +31,7 @@
 #include "Evolution/Initialization/NonconservativeSystem.hpp"
 #include "Evolution/Initialization/SetVariables.hpp"
 #include "Evolution/NumericInitialData.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Actions/NumericInitialData.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Factory.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/Factory.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Equations.hpp"
@@ -39,8 +40,6 @@
 #include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "Evolution/TypeTraits.hpp"
-#include "IO/Importers/Actions/ReadVolumeData.hpp"
-#include "IO/Importers/Actions/ReceiveVolumeData.hpp"
 #include "IO/Importers/Actions/RegisterWithElementDataReader.hpp"
 #include "IO/Importers/ElementDataReader.hpp"
 #include "IO/Observer/Actions/ObserverRegistration.hpp"
@@ -398,13 +397,12 @@ struct GeneralizedHarmonicTemplateBase<
                           Parallel::Actions::TerminatePhase>>,
                   Parallel::PhaseActions<
                       Phase, Phase::ImportInitialData,
-                      tmpl::list<importers::Actions::ReadVolumeData<
-                                     evolution::OptionTags::NumericInitialData,
-                                     typename system::variables_tag::tags_list>,
-                                 importers::Actions::ReceiveVolumeData<
-                                     evolution::OptionTags::NumericInitialData,
-                                     typename system::variables_tag::tags_list>,
-                                 Parallel::Actions::TerminatePhase>>>,
+                      tmpl::list<
+                          GeneralizedHarmonic::Actions::ReadNumericInitialData<
+                              evolution::OptionTags::NumericInitialData>,
+                          GeneralizedHarmonic::Actions::SetNumericInitialData<
+                              evolution::OptionTags::NumericInitialData>,
+                          Parallel::Actions::TerminatePhase>>>,
               tmpl::list<>>,
           Parallel::PhaseActions<
               Phase, Phase::InitializeInitialDataDependentQuantities,

--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -62,7 +62,10 @@ namespace Actions {
 ///
 /// Since we have not started the evolution yet, we initialize the state
 /// _before_ the initial time. So `Tags::TimeStepId` is undefined at this point,
-/// and `Tags::Next<Tags::TimeStepId>` is the initial time.
+/// and `Tags::Next<Tags::TimeStepId>` is the initial time. `::Tags::Time` is
+/// set to the initial time so it is available to dependent compute items, e.g.,
+/// Jacobians of time-dependent domains that are needed to take numerical
+/// derivatives of initial data.
 ///
 /// DataBox changes:
 /// - Adds:
@@ -157,8 +160,8 @@ struct TimeAndTimeStep {
     Initialization::mutate_assign<tmpl::list<
         ::Tags::TimeStepId, ::Tags::Next<::Tags::TimeStepId>, ::Tags::Time,
         ::Tags::TimeStep, ::Tags::Next<::Tags::TimeStep>>>(
-        make_not_null(&box), TimeStepId{}, time_id,
-        std::numeric_limits<double>::signaling_NaN(), initial_dt, initial_dt);
+        make_not_null(&box), TimeStepId{}, time_id, initial_time.value(),
+        initial_dt, initial_dt);
     return std::make_tuple(std::move(box));
   }
 

--- a/src/Evolution/Systems/GeneralizedHarmonic/Actions/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Actions/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  NumericInitialData.hpp
+  )

--- a/src/Evolution/Systems/GeneralizedHarmonic/Actions/NumericInitialData.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Actions/NumericInitialData.hpp
@@ -1,0 +1,303 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <limits>
+#include <tuple>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "IO/Importers/Actions/ReadVolumeData.hpp"
+#include "IO/Importers/ElementDataReader.hpp"
+#include "IO/Importers/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Phi.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Pi.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TimeDerivativeOfSpatialMetric.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace GeneralizedHarmonic {
+
+namespace detail {
+namespace OptionTags {
+template <typename Tag>
+struct VarName {
+  using tag = Tag;
+  static std::string name() { return db::tag_name<Tag>(); }
+  using type = std::string;
+  static constexpr Options::String help =
+      "Name of the variable in the volume data file";
+};
+}  // namespace OptionTags
+
+// These are the sets of variables that we support loading from volume data
+// files:
+// - ADM variables
+using adm_vars =
+    tmpl::list<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+               gr::Tags::Lapse<DataVector>,
+               gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+               gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>>;
+struct Adm : tuples::tagged_tuple_from_typelist<
+                 db::wrap_tags_in<OptionTags::VarName, adm_vars>> {
+  using Base = tuples::tagged_tuple_from_typelist<
+      db::wrap_tags_in<OptionTags::VarName, adm_vars>>;
+  static constexpr Options::String help =
+      "ADM variables: 'Lapse', 'Shift', 'SpatialMetric' and "
+      "'ExtrinsicCurvature'. The initial GH variables will be computed from "
+      "these numeric fields, as well as their numeric spatial derivatives on "
+      "the computational grid.";
+  using options = db::wrap_tags_in<OptionTags::VarName, adm_vars>;
+  using Base::TaggedTuple;
+};
+// - Generalized harmonic variables
+using gh_vars =
+    tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial, DataVector>,
+               Tags::Pi<3, Frame::Inertial>, Tags::Phi<3, Frame::Inertial>>;
+struct GeneralizedHarmonic
+    : tuples::tagged_tuple_from_typelist<
+          db::wrap_tags_in<OptionTags::VarName, gh_vars>> {
+  using Base = tuples::tagged_tuple_from_typelist<
+      db::wrap_tags_in<OptionTags::VarName, gh_vars>>;
+  static constexpr Options::String help =
+      "GH variables: 'SpacetimeMetric', 'Pi' and 'Phi'. These variables are "
+      "used to set the initial data directly.";
+  using options = db::wrap_tags_in<OptionTags::VarName, gh_vars>;
+  using Base::TaggedTuple;
+};
+
+// Collect all variables that we support loading from volume data files.
+// Remember to `tmpl::remove_duplicates` when adding overlapping sets of vars.
+using all_numeric_vars = tmpl::append<adm_vars, gh_vars>;
+
+namespace OptionTags {
+template <typename ImporterOptionsGroup>
+struct NumericInitialDataVariables {
+  static std::string name() { return "Variables"; }
+  // The user can supply any of these choices of variables in the input file
+  using type = std::variant<Adm, GeneralizedHarmonic>;
+  static constexpr Options::String help =
+      "Set of initial data variables from which the generalized harmonic "
+      "system variables are computed.";
+  using group = ImporterOptionsGroup;
+};
+}  // namespace OptionTags
+
+namespace Tags {
+template <typename ImporterOptionsGroup>
+struct NumericInitialDataVariables : db::SimpleTag {
+  using type = typename OptionTags::NumericInitialDataVariables<
+      ImporterOptionsGroup>::type;
+  using option_tags =
+      tmpl::list<OptionTags::NumericInitialDataVariables<ImporterOptionsGroup>>;
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& value) { return value; }
+};
+}  // namespace Tags
+}  // namespace detail
+
+namespace Actions {
+
+/*!
+ * \brief Dispatch loading numeric initial data from files.
+ *
+ * Place this action before GeneralizedHarmonic::Actions::SetNumericInitialData
+ * in the action list. See importers::Actions::ReadAllVolumeDataAndDistribute
+ * for details, which is invoked by this action.
+ *
+ * \tparam ImporterOptionsGroup Option group in which options are placed.
+ */
+template <typename ImporterOptionsGroup>
+struct ReadNumericInitialData {
+  using const_global_cache_tags = tmpl::list<
+      importers::Tags::FileGlob<ImporterOptionsGroup>,
+      importers::Tags::Subgroup<ImporterOptionsGroup>,
+      importers::Tags::ObservationValue<ImporterOptionsGroup>,
+      detail::Tags::NumericInitialDataVariables<ImporterOptionsGroup>>;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    // Select the subset of the available variables that we want to read from
+    // the volume data file
+    const auto& selected_initial_data_vars =
+        get<detail::Tags::NumericInitialDataVariables<ImporterOptionsGroup>>(
+            box);
+    tuples::tagged_tuple_from_typelist<
+        db::wrap_tags_in<importers::Tags::Selected, detail::all_numeric_vars>>
+        selected_fields{};
+    std::visit(
+        [&selected_fields](const auto& vars) {
+          // This lambda is invoked with the set of vars selected in the input
+          // file, which map to the tensor names that should be read from the H5
+          // file
+          using selected_vars = std::decay_t<decltype(vars)>;
+          // Get the mapped tensor name from the input file and select it in the
+          // set of all possible vars.
+          tmpl::for_each<typename selected_vars::tags_list>(
+              [&selected_fields, &vars](const auto tag_v) {
+                using tag = typename std::decay_t<decltype(tag_v)>::type::tag;
+                get<importers::Tags::Selected<tag>>(selected_fields) =
+                    get<detail::OptionTags::VarName<tag>>(vars);
+              });
+        },
+        selected_initial_data_vars);
+    // Dispatch loading the variables from the volume data file
+    // - Not using `ckLocalBranch` here to make sure the simple action
+    //   invocation is asynchronous.
+    auto& reader_component = Parallel::get_parallel_component<
+        importers::ElementDataReader<Metavariables>>(cache);
+    Parallel::simple_action<importers::Actions::ReadAllVolumeDataAndDistribute<
+        ImporterOptionsGroup, detail::all_numeric_vars, ParallelComponent>>(
+        reader_component, std::move(selected_fields));
+    return {std::move(box)};
+  }
+};
+
+/*!
+ * \brief Receive numeric initial data loaded by
+ * GeneralizedHarmonic::Actions::ReadNumericInitialData.
+ *
+ * Place this action in the action list after
+ * GeneralizedHarmonic::Actions::ReadNumericInitialData to wait until the data
+ * for this element has arrived, and then transform the data to GH variables and
+ * store it in the DataBox to be used as initial data.
+ *
+ * This action modifies the following tags in the DataBox:
+ * - gr::Tags::SpacetimeMetric<3, Frame::Inertial, DataVector>
+ * - GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>
+ * - GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>
+ *
+ * \tparam ImporterOptionsGroup Option group in which options are placed.
+ */
+template <typename ImporterOptionsGroup>
+struct SetNumericInitialData {
+  static constexpr size_t Dim = 3;
+  using inbox_tags =
+      tmpl::list<importers::Tags::VolumeData<ImporterOptionsGroup,
+                                             detail::all_numeric_vars>>;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ActionList, typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&, Parallel::AlgorithmExecution>
+  apply(db::DataBox<DbTagsList>& box,
+        tuples::TaggedTuple<InboxTags...>& inboxes,
+        const Parallel::GlobalCache<Metavariables>& /*cache*/,
+        const ElementId<Dim>& /*element_id*/, const ActionList /*meta*/,
+        const ParallelComponent* const /*meta*/) {
+    auto& inbox = tuples::get<importers::Tags::VolumeData<
+        ImporterOptionsGroup, detail::all_numeric_vars>>(inboxes);
+    // Using 0 for the temporal ID since we only read the volume data once, so
+    // there's no need to keep track of the temporal ID.
+    if (inbox.find(0_st) == inbox.end()) {
+      return {std::move(box), Parallel::AlgorithmExecution::Retry};
+    }
+    auto numeric_initial_data = std::move(inbox.extract(0_st).mapped());
+
+    const auto& selected_initial_data_vars =
+        get<detail::Tags::NumericInitialDataVariables<ImporterOptionsGroup>>(
+            box);
+    if (std::holds_alternative<detail::GeneralizedHarmonic>(
+            selected_initial_data_vars)) {
+      // We have loaded the GH system variables from the file, so just move the
+      // data into the DataBox directly. No conversion needed.
+      db::mutate<gr::Tags::SpacetimeMetric<3, Frame::Inertial, DataVector>,
+                 Tags::Pi<3, Frame::Inertial>, Tags::Phi<3, Frame::Inertial>>(
+          make_not_null(&box),
+          [&numeric_initial_data](
+              const gsl::not_null<tnsr::aa<DataVector, 3>*> spacetime_metric,
+              const gsl::not_null<tnsr::aa<DataVector, 3>*> pi,
+              const gsl::not_null<tnsr::iaa<DataVector, 3>*> phi) {
+            *spacetime_metric = std::move(
+                get<gr::Tags::SpacetimeMetric<3, Frame::Inertial, DataVector>>(
+                    numeric_initial_data));
+            *pi = std::move(
+                get<Tags::Pi<3, Frame::Inertial>>(numeric_initial_data));
+            *phi = std::move(
+                get<Tags::Phi<3, Frame::Inertial>>(numeric_initial_data));
+          });
+    } else if (std::holds_alternative<detail::Adm>(
+                   selected_initial_data_vars)) {
+      // We have loaded ADM variables from the file. Convert to GH variables.
+      const auto& spatial_metric =
+          get<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>(
+              numeric_initial_data);
+      const auto& lapse =
+          get<gr::Tags::Lapse<DataVector>>(numeric_initial_data);
+      const auto& shift = get<gr::Tags::Shift<3, Frame::Inertial, DataVector>>(
+          numeric_initial_data);
+      const auto& extrinsic_curvature =
+          get<gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>>(
+              numeric_initial_data);
+
+      // Take numerical derivatives
+      const auto& mesh = db::get<domain::Tags::Mesh<Dim>>(box);
+      const auto& inv_jacobian =
+          db::get<domain::Tags::InverseJacobian<Dim, Frame::ElementLogical,
+                                                Frame::Inertial>>(box);
+      const auto deriv_spatial_metric =
+          partial_derivative(spatial_metric, mesh, inv_jacobian);
+      const auto deriv_lapse = partial_derivative(lapse, mesh, inv_jacobian);
+      const auto deriv_shift = partial_derivative(
+          get<gr::Tags::Shift<3, Frame::Inertial, DataVector>>(
+              numeric_initial_data),
+          mesh, inv_jacobian);
+
+      // Compute GH variables
+      db::mutate<gr::Tags::SpacetimeMetric<3, Frame::Inertial, DataVector>,
+                 Tags::Pi<3, Frame::Inertial>, Tags::Phi<3, Frame::Inertial>>(
+          make_not_null(&box),
+          [&spatial_metric, &deriv_spatial_metric, &lapse, &deriv_lapse, &shift,
+           &deriv_shift, &extrinsic_curvature](
+              const gsl::not_null<tnsr::aa<DataVector, 3>*> spacetime_metric,
+              const gsl::not_null<tnsr::aa<DataVector, 3>*> pi,
+              const gsl::not_null<tnsr::iaa<DataVector, 3>*> phi) {
+            // Choose dt_lapse = 0 and dt_shift = 0 (for now)
+            const auto dt_lapse =
+                make_with_value<Scalar<DataVector>>(lapse, 0.);
+            const auto dt_shift =
+                make_with_value<tnsr::I<DataVector, 3>>(shift, 0.);
+            const auto dt_spatial_metric =
+                gr::time_derivative_of_spatial_metric(
+                    lapse, shift, deriv_shift, spatial_metric,
+                    deriv_spatial_metric, extrinsic_curvature);
+            gr::spacetime_metric(spacetime_metric, lapse, shift,
+                                 spatial_metric);
+            GeneralizedHarmonic::phi(phi, lapse, deriv_lapse, shift,
+                                     deriv_shift, spatial_metric,
+                                     deriv_spatial_metric);
+            GeneralizedHarmonic::pi(pi, lapse, dt_lapse, shift, dt_shift,
+                                    spatial_metric, dt_spatial_metric, *phi);
+          });
+    } else {
+      ERROR(
+          "These initial data variables are not implemented yet. Please add "
+          "an implementation to "
+          "GeneralizedHarmonic::Actions::SetNumericInitialData.");
+    }
+    return {std::move(box), Parallel::AlgorithmExecution::Continue};
+  }
+};
+
+}  // namespace Actions
+}  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
@@ -39,6 +39,8 @@ target_link_libraries(
   ErrorHandling
   GeneralRelativity
   GeneralRelativitySolutions
+  IO
+  LinearOperators
   Options
   Spectral
   Utilities
@@ -47,6 +49,7 @@ target_link_libraries(
   Parallel
   )
 
+add_subdirectory(Actions)
 add_subdirectory(BoundaryConditions)
 add_subdirectory(BoundaryCorrections)
 add_subdirectory(ConstraintDamping)

--- a/src/IO/Importers/Actions/RegisterWithElementDataReader.hpp
+++ b/src/IO/Importers/Actions/RegisterWithElementDataReader.hpp
@@ -10,6 +10,7 @@
 #include "Domain/Structure/ElementId.hpp"
 #include "IO/Importers/Tags.hpp"
 #include "IO/Observer/ArrayComponentId.hpp"
+#include "Parallel/ArrayIndex.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Utilities/Gsl.hpp"

--- a/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -25,6 +25,7 @@ spectre_target_sources(
   SpacetimeNormalVector.cpp
   SpatialMetric.cpp
   TimeDerivativeOfSpacetimeMetric.cpp
+  TimeDerivativeOfSpatialMetric.cpp
   Transform.cpp
   WeylElectric.cpp
   WeylMagnetic.cpp
@@ -55,6 +56,7 @@ spectre_target_headers(
   Tags.hpp
   TagsDeclarations.hpp
   TimeDerivativeOfSpacetimeMetric.hpp
+  TimeDerivativeOfSpatialMetric.hpp
   Transform.hpp
   WeylElectric.hpp
   WeylMagnetic.hpp

--- a/src/PointwiseFunctions/GeneralRelativity/TimeDerivativeOfSpatialMetric.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/TimeDerivativeOfSpatialMetric.cpp
@@ -1,0 +1,90 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/GeneralRelativity/TimeDerivativeOfSpatialMetric.hpp"
+
+#include <cmath>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace gr {
+template <size_t SpatialDim, typename Frame, typename DataType>
+void time_derivative_of_spatial_metric(
+    const gsl::not_null<tnsr::ii<DataType, SpatialDim, Frame>*>
+        dt_spatial_metric,
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::iJ<DataType, SpatialDim, Frame>& deriv_shift,
+    const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
+    const tnsr::ijj<DataType, SpatialDim, Frame>& deriv_spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& extrinsic_curvature) {
+  destructive_resize_components(dt_spatial_metric, get_size(get(lapse)));
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = 0; j <= i; ++j) {
+      dt_spatial_metric->get(i, j) =
+          -2. * get(lapse) * extrinsic_curvature.get(i, j);
+      for (size_t k = 0; k < SpatialDim; ++k) {
+        dt_spatial_metric->get(i, j) +=
+            shift.get(k) * deriv_spatial_metric.get(k, i, j) +
+            spatial_metric.get(k, i) * deriv_shift.get(j, k) +
+            spatial_metric.get(k, j) * deriv_shift.get(i, k);
+      }
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::ii<DataType, SpatialDim, Frame> time_derivative_of_spatial_metric(
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::iJ<DataType, SpatialDim, Frame>& deriv_shift,
+    const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
+    const tnsr::ijj<DataType, SpatialDim, Frame>& deriv_spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& extrinsic_curvature) {
+  tnsr::ii<DataType, SpatialDim, Frame> dt_spatial_metric{get_size(get(lapse))};
+  time_derivative_of_spatial_metric(make_not_null(&dt_spatial_metric), lapse,
+                                    shift, deriv_shift, spatial_metric,
+                                    deriv_spatial_metric, extrinsic_curvature);
+  return dt_spatial_metric;
+}
+}  // namespace gr
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                               \
+  template tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>                   \
+  gr::time_derivative_of_spatial_metric(                                   \
+      const Scalar<DTYPE(data)>& lapse,                                    \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,           \
+      const tnsr::iJ<DTYPE(data), DIM(data), FRAME(data)>& deriv_shift,    \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& spatial_metric, \
+      const tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>&                \
+          deriv_spatial_metric,                                            \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&                 \
+          extrinsic_curvature);                                            \
+  template void gr::time_derivative_of_spatial_metric(                     \
+      const gsl::not_null<tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>*>  \
+          dt_spatial_metric,                                               \
+      const Scalar<DTYPE(data)>& lapse,                                    \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,           \
+      const tnsr::iJ<DTYPE(data), DIM(data), FRAME(data)>& deriv_shift,    \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& spatial_metric, \
+      const tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>&                \
+          deriv_spatial_metric,                                            \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&                 \
+          extrinsic_curvature);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
+                        (Frame::Grid, Frame::Inertial))
+
+#undef DIM
+#undef DTYPE
+#undef FRAME
+#undef INSTANTIATE

--- a/src/PointwiseFunctions/GeneralRelativity/TimeDerivativeOfSpatialMetric.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/TimeDerivativeOfSpatialMetric.hpp
@@ -1,0 +1,50 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace gr {
+/// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes the time derivative of the spatial metric from extrinsic
+ * curvature, lapse, shift, and their time derivatives.
+ *
+ * \details Computes the derivative as (see e.g. \cite BaumgarteShapiro, Eq.
+ * (2.134)):
+ *
+ * \f{equation}
+ * \partial_t \gamma_{ij} = -2 \alpha K_{ij} + 2 \nabla_{(i} \beta_{j)}
+ *   = -2 \alpha K_{ij} + \beta^k \partial_k \gamma_{ij}
+ *     + \gamma_{ik} \partial_j \beta^k + \gamma_{jk} \partial_i \beta^k
+ * \f}
+ *
+ * where \f$\alpha\f$ is the lapse, \f$\beta^i\f$ is the shift,
+ * \f$\gamma_{ij}\f$ is the spatial metric and \f$K_{ij}\f$ is the extrinsic
+ * curvature.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+void time_derivative_of_spatial_metric(
+    gsl::not_null<tnsr::ii<DataType, SpatialDim, Frame>*> dt_spatial_metric,
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::iJ<DataType, SpatialDim, Frame>& deriv_shift,
+    const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
+    const tnsr::ijj<DataType, SpatialDim, Frame>& deriv_spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& extrinsic_curvature);
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::ii<DataType, SpatialDim, Frame> time_derivative_of_spatial_metric(
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::iJ<DataType, SpatialDim, Frame>& deriv_shift,
+    const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
+    const tnsr::ijj<DataType, SpatialDim, Frame>& deriv_spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& extrinsic_curvature);
+/// @}
+}  // namespace gr

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -226,11 +226,25 @@ ApparentHorizons:
 
 # initial_data.h5 should contain numerical initial data
 # on the same grid as specified by the domain given above
+# - One way to produce initial data is with the `SolveXcts` executable. See the
+#   example in `docs/Examples/BbhInitialData`.
+# - You can also produce initial data with SpEC, interpolate it (using SpEC) to
+#   the domain given above (using the `ExportCoordinates` executable to get the
+#   coordinates of all grid points in the domain), and then load it here by
+#   selecting either the GH variables (`SpacetimeMetric`, `Pi`, `Phi`) or the
+#   ADM variables (`Lapse`, `Shift`, `SpatialMetric`, `ExtrinsicCurvature`).
 Importers:
   NumericInitialData:
     FileGlob: "/path/to/initial_data.h5"
-    Subgroup: "element_data"
+    Subgroup: "VolumeData"
     ObservationValue: Last
+    Variables:
+      Lapse: Lapse
+      # Load a shift that is not corotating. See `docs/Examples/BbhInitialData`
+      # for details.
+      Shift: ShiftExcess
+      SpatialMetric: SpatialMetric
+      ExtrinsicCurvature: ExtrinsicCurvature
 
 # control.h5 should contain data for FunctionsOfTime that can be
 # read by ReadSpecPiecewisePolynomial.

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Actions/Test_NumericInitialData.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Actions/Test_NumericInitialData.cpp
@@ -1,0 +1,282 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <limits>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <variant>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Wedge.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Actions/NumericInitialData.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Framework/TestCreation.hpp"
+#include "IO/Importers/Actions/ReadVolumeData.hpp"
+#include "IO/Importers/ElementDataReader.hpp"
+#include "IO/Importers/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.tpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace GeneralizedHarmonic {
+namespace {
+
+struct TestOptionGroup {
+  using group = importers::OptionTags::Group;
+  static constexpr Options::String help = "halp";
+};
+
+using gh_system_vars = GeneralizedHarmonic::System<3>::variables_tag::tags_list;
+
+template <typename Metavariables>
+struct MockElementArray {
+  using component_being_mocked = void;  // Not needed
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementId<3>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          tmpl::list<ActionTesting::InitializeDataBox<tmpl::append<
+              gh_system_vars,
+              tmpl::list<domain::Tags::Mesh<3>,
+                         domain::Tags::InverseJacobian<3, Frame::ElementLogical,
+                                                       Frame::Inertial>>>>>>,
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          tmpl::list<GeneralizedHarmonic::Actions::ReadNumericInitialData<
+                         TestOptionGroup>,
+                     GeneralizedHarmonic::Actions::SetNumericInitialData<
+                         TestOptionGroup>>>>;
+};
+
+struct MockReadVolumeData {
+  template <typename ParallelComponent, typename DataBox,
+            typename Metavariables, typename ArrayIndex>
+  static void apply(
+      DataBox& /*box*/, Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/,
+      tuples::tagged_tuple_from_typelist<
+          db::wrap_tags_in<importers::Tags::Selected, detail::all_numeric_vars>>
+          selected_fields) {
+    const auto selected_vars =
+        get<detail::Tags::NumericInitialDataVariables<TestOptionGroup>>(cache);
+    if (std::holds_alternative<detail::GeneralizedHarmonic>(selected_vars)) {
+      CHECK(get<importers::Tags::Selected<
+                gr::Tags::SpacetimeMetric<3, Frame::Inertial, DataVector>>>(
+                selected_fields) == "CustomSpacetimeMetric");
+      CHECK(get<importers::Tags::Selected<Tags::Pi<3, Frame::Inertial>>>(
+                selected_fields) == "CustomPi");
+      CHECK(get<importers::Tags::Selected<Tags::Phi<3, Frame::Inertial>>>(
+                selected_fields) == "CustomPhi");
+      CHECK_FALSE(get<importers::Tags::Selected<
+                      gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>>(
+          selected_fields));
+      CHECK_FALSE(get<importers::Tags::Selected<gr::Tags::Lapse<DataVector>>>(
+          selected_fields));
+      CHECK_FALSE(get<importers::Tags::Selected<
+                      gr::Tags::Shift<3, Frame::Inertial, DataVector>>>(
+          selected_fields));
+      CHECK_FALSE(
+          get<importers::Tags::Selected<
+              gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>>>(
+              selected_fields));
+    } else if (std::holds_alternative<detail::Adm>(selected_vars)) {
+      CHECK(get<importers::Tags::Selected<
+                gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>>(
+                selected_fields) == "CustomSpatialMetric");
+      CHECK(get<importers::Tags::Selected<gr::Tags::Lapse<DataVector>>>(
+                selected_fields) == "CustomLapse");
+      CHECK(get<importers::Tags::Selected<
+                gr::Tags::Shift<3, Frame::Inertial, DataVector>>>(
+                selected_fields) == "CustomShift");
+      CHECK(get<importers::Tags::Selected<
+                gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>>>(
+                selected_fields) == "CustomExtrinsicCurvature");
+      CHECK_FALSE(
+          get<importers::Tags::Selected<
+              gr::Tags::SpacetimeMetric<3, Frame::Inertial, DataVector>>>(
+              selected_fields));
+      CHECK_FALSE(get<importers::Tags::Selected<Tags::Pi<3, Frame::Inertial>>>(
+          selected_fields));
+      CHECK_FALSE(get<importers::Tags::Selected<Tags::Phi<3, Frame::Inertial>>>(
+          selected_fields));
+    } else {
+      REQUIRE(false);
+    }
+  }
+};
+
+template <typename Metavariables>
+struct MockVolumeDataReader {
+  using component_being_mocked = importers::ElementDataReader<Metavariables>;
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockNodeGroupChare;
+  using array_index = size_t;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::Initialization,
+                                        tmpl::list<>>>;
+  using replace_these_simple_actions =
+      tmpl::list<importers::Actions::ReadAllVolumeDataAndDistribute<
+          TestOptionGroup, detail::all_numeric_vars,
+          MockElementArray<Metavariables>>>;
+  using with_these_simple_actions = tmpl::list<MockReadVolumeData>;
+};
+
+struct Metavariables {
+  using component_list = tmpl::list<MockElementArray<Metavariables>,
+                                    MockVolumeDataReader<Metavariables>>;
+  enum class Phase { Initialization, Testing };
+};
+
+}  // namespace
+
+void test_numeric_initial_data(
+    const typename detail::Tags::NumericInitialDataVariables<
+        TestOptionGroup>::type& selected_vars,
+    const std::string& option_string) {
+  CHECK(TestHelpers::test_option_tag<
+            detail::OptionTags::NumericInitialDataVariables<TestOptionGroup>>(
+            option_string) == selected_vars);
+
+  using reader_component = MockVolumeDataReader<Metavariables>;
+  using element_array = MockElementArray<Metavariables>;
+
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{tuples::TaggedTuple<
+      importers::Tags::FileGlob<TestOptionGroup>,
+      importers::Tags::Subgroup<TestOptionGroup>,
+      importers::Tags::ObservationValue<TestOptionGroup>,
+      detail::Tags::NumericInitialDataVariables<TestOptionGroup>>{
+      "TestInitialData.h5", "VolumeData", 0., selected_vars}};
+
+  // Setup mock data file reader
+  ActionTesting::emplace_nodegroup_component<reader_component>(
+      make_not_null(&runner));
+
+  // Setup element
+  const ElementId<3> element_id{0, {{{1, 0}, {1, 0}, {1, 0}}}};
+  const Mesh<3> mesh{8, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto};
+  const auto map =
+      domain::make_coordinate_map<Frame::ElementLogical, Frame::Inertial>(
+          domain::CoordinateMaps::Wedge<3>{2., 4., 1., 1., {}, true});
+  const auto logical_coords = logical_coordinates(mesh);
+  const auto coords = map(logical_coords);
+  const auto inv_jacobian = map.inv_jacobian(logical_coords);
+  ActionTesting::emplace_component_and_initialize<element_array>(
+      make_not_null(&runner), element_id,
+      {tnsr::aa<DataVector, 3>{}, tnsr::aa<DataVector, 3>{},
+       tnsr::iaa<DataVector, 3>{}, mesh, inv_jacobian});
+
+  const auto get_element_tag = [&runner,
+                                &element_id](auto tag_v) -> decltype(auto) {
+    using tag = std::decay_t<decltype(tag_v)>;
+    return ActionTesting::get_databox_tag<element_array, tag>(runner,
+                                                              element_id);
+  };
+
+  ActionTesting::set_phase(make_not_null(&runner),
+                           Metavariables::Phase::Testing);
+
+  // ReadNumericInitialData
+  ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
+  REQUIRE_FALSE(ActionTesting::next_action_if_ready<element_array>(
+      make_not_null(&runner), element_id));
+
+  // MockReadVolumeData
+  ActionTesting::invoke_queued_simple_action<reader_component>(
+      make_not_null(&runner), 0);
+
+  // Insert KerrSchild data into the inbox
+  auto& inbox = ActionTesting::get_inbox_tag<
+      element_array,
+      importers::Tags::VolumeData<TestOptionGroup, detail::all_numeric_vars>,
+      Metavariables>(make_not_null(&runner), element_id)[0];
+  GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::KerrSchild> kerr{
+      1., {{0., 0., 0.}}, {{0., 0., 0.}}};
+  const auto kerr_gh_vars = kerr.variables(coords, 0., gh_system_vars{});
+  if (std::holds_alternative<detail::GeneralizedHarmonic>(selected_vars)) {
+    get<gr::Tags::SpacetimeMetric<3, Frame::Inertial, DataVector>>(inbox) =
+        get<gr::Tags::SpacetimeMetric<3, Frame::Inertial, DataVector>>(
+            kerr_gh_vars);
+    get<Tags::Pi<3, Frame::Inertial>>(inbox) =
+        get<Tags::Pi<3, Frame::Inertial>>(kerr_gh_vars);
+    get<Tags::Phi<3, Frame::Inertial>>(inbox) =
+        get<Tags::Phi<3, Frame::Inertial>>(kerr_gh_vars);
+  } else if (std::holds_alternative<detail::Adm>(selected_vars)) {
+    const auto kerr_adm_vars = kerr.variables(
+        coords, 0.,
+        tmpl::list<
+            gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+            gr::Tags::Lapse<DataVector>,
+            gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+            gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>>{});
+    get<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>(inbox) =
+        get<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>(
+            kerr_adm_vars);
+    get<gr::Tags::Lapse<DataVector>>(inbox) =
+        get<gr::Tags::Lapse<DataVector>>(kerr_adm_vars);
+    get<gr::Tags::Shift<3, Frame::Inertial, DataVector>>(inbox) =
+        get<gr::Tags::Shift<3, Frame::Inertial, DataVector>>(kerr_adm_vars);
+    get<gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>>(inbox) =
+        get<gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>>(
+            kerr_adm_vars);
+  } else {
+    REQUIRE(false);
+  }
+
+  // SetNumericInitialData
+  ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
+
+  // Check result. These variables are not particularly precise because we are
+  // taking numerical derivatives on a fairly coarse wedge-shaped grid.
+  Approx custom_approx = Approx::custom().epsilon(1.e-3).scale(1.0);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get_element_tag(
+          gr::Tags::SpacetimeMetric<3, Frame::Inertial, DataVector>{}),
+      (get<gr::Tags::SpacetimeMetric<3, Frame::Inertial, DataVector>>(
+          kerr_gh_vars)),
+      custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get_element_tag(Tags::Pi<3, Frame::Inertial>{}),
+      (get<Tags::Pi<3, Frame::Inertial>>(kerr_gh_vars)), custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get_element_tag(Tags::Phi<3, Frame::Inertial>{}),
+      (get<Tags::Phi<3, Frame::Inertial>>(kerr_gh_vars)), custom_approx);
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Gh.NumericInitialData",
+                  "[Unit][Evolution]") {
+  test_numeric_initial_data(
+      detail::GeneralizedHarmonic{"CustomSpacetimeMetric", "CustomPi",
+                                  "CustomPhi"},
+      "SpacetimeMetric: CustomSpacetimeMetric\n"
+      "Pi: CustomPi\n"
+      "Phi: CustomPhi");
+  test_numeric_initial_data(
+      detail::Adm{"CustomSpatialMetric", "CustomLapse", "CustomShift",
+                  "CustomExtrinsicCurvature"},
+      "SpatialMetric: CustomSpatialMetric\n"
+      "Lapse: CustomLapse\n"
+      "Shift: CustomShift\n"
+      "ExtrinsicCurvature: CustomExtrinsicCurvature");
+}
+
+}  // namespace GeneralizedHarmonic

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
@@ -7,6 +7,7 @@ add_subdirectory(ConstraintDamping)
 set(LIBRARY "Test_GeneralizedHarmonic")
 
 set(LIBRARY_SOURCES
+  Actions/Test_NumericInitialData.cpp
   BoundaryConditions/Test_Bjorhus.cpp
   BoundaryConditions/Test_BjorhusImpl.cpp
   BoundaryConditions/Test_DirichletAnalytic.cpp
@@ -26,5 +27,21 @@ add_test_library(
   ${LIBRARY}
   "Evolution/Systems/GeneralizedHarmonic/"
   "${LIBRARY_SOURCES}"
-  "GeneralRelativityHelpers;GeneralizedHarmonic;Test_GeneralRelativity"
+  ""
   )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  CoordinateMaps
+  DataBoxTestHelpers
+  DataStructures
+  DataStructuresHelpers
+  Domain
+  GeneralizedHarmonic
+  GeneralRelativity
+  GeneralRelativityHelpers
+  Importers
+  Spectral
+  Utilities
+)

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -23,5 +23,23 @@ add_test_library(
   ${LIBRARY}
   "PointwiseFunctions/GeneralRelativity/"
   "${LIBRARY_SOURCES}"
-  "GeneralRelativityHelpers"
+  ""
   )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  CoordinateMaps
+  DataBoxTestHelpers
+  DataStructures
+  DataStructuresHelpers
+  Domain
+  DomainStructure
+  GeneralizedHarmonic
+  GeneralRelativity
+  GeneralRelativityHelpers
+  GeneralRelativitySolutions
+  LinearOperators
+  Spectral
+  Utilities
+)

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.py
@@ -50,6 +50,14 @@ def dt_spacetime_metric(lapse, dt_lapse, shift, dt_shift, spatial_metric,
     return dt_psi
 
 
+def dt_spatial_metric(lapse, shift, deriv_shift, spatial_metric,
+                      deriv_spatial_metric, extrinsic_curvature):
+    return (-2. * lapse * extrinsic_curvature +
+            np.einsum("k,kij", shift, deriv_spatial_metric) +
+            np.einsum("ik,jk", spatial_metric, deriv_shift) +
+            np.einsum("jk,ik", spatial_metric, deriv_shift))
+
+
 def spatial_deriv_spacetime_metric(lapse, deriv_lapse, shift, deriv_shift,
                                    spatial_metric, deriv_spatial_metric):
     dim = shift.size

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -33,6 +33,7 @@
 #include "PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/TimeDerivativeOfSpacetimeMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TimeDerivativeOfSpatialMetric.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
@@ -80,6 +81,22 @@ void test_compute_time_derivative_of_spacetime_metric(
           &gr::time_derivative_of_spacetime_metric<Dim, Frame::Inertial,
                                                    DataType>),
       "ComputeSpacetimeQuantities", "dt_spacetime_metric", {{{-10., 10.}}},
+      used_for_size);
+}
+template <size_t Dim, typename DataType>
+void test_compute_time_derivative_of_spatial_metric(
+    const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::ii<DataType, Dim, Frame::Inertial> (*)(
+          const Scalar<DataType>&,
+          const tnsr::I<DataType, Dim, Frame::Inertial>&,
+          const tnsr::iJ<DataType, Dim, Frame::Inertial>&,
+          const tnsr::ii<DataType, Dim, Frame::Inertial>&,
+          const tnsr::ijj<DataType, Dim, Frame::Inertial>&,
+          const tnsr::ii<DataType, Dim, Frame::Inertial>&)>(
+          &gr::time_derivative_of_spatial_metric<Dim, Frame::Inertial,
+                                                 DataType>),
+      "ComputeSpacetimeQuantities", "dt_spatial_metric", {{{-10., 10.}}},
       used_for_size);
 }
 template <size_t Dim, typename DataType>
@@ -205,6 +222,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
       test_compute_derivatives_of_spacetime_metric, (1, 2, 3));
   CHECK_FOR_DOUBLES_AND_DATAVECTORS(
       test_compute_time_derivative_of_spacetime_metric, (1, 2, 3));
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(
+      test_compute_time_derivative_of_spatial_metric, (1, 2, 3));
   CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_compute_spacetime_normal_vector,
                                     (1, 2, 3));
   CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_compute_spacetime_normal_one_form,


### PR DESCRIPTION
## Proposed changes

This PR connects the XCTS elliptic solver with the GH execs:

- Output lapse, shift, spatial metric and extrinsic curvature from the XCTS solver.
- Load these variables in the GH execs and transform to GH variables.

I tested this with a Kerr solution. It should also work with BBH initial data, but I haven't done much testing yet. Here are some example input files: https://github.com/nilsvu/spectre/commit/78c936be17f4eb59f3d039cefb2687967c2a1072

Current limitations:

- No interpolation. Run the initial data solver on the same grid as the evolution.
- (fixed in #3824) ~Use the last iteration number of the initial data solver as the `ObservationValue` in the GH input file. This should get smoothed out of course.~
- dt_lapse and dt_shift are both chosen to be zero in the "inertial" frame at the moment. Which options do we want to support here?

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
