### PR TITLE
Load correct libz in ocean_clang.sh

### DIFF
--- a/support/Environments/ocean_clang.sh
+++ b/support/Environments/ocean_clang.sh
@@ -38,6 +38,7 @@ spectre_unload_modules() {
     module unload python/3.9.5
     module unload charm-6.10.2-libs
     module unload doxygen-1.9.1-gcc-7.3.0-nxmwu4a
+    module unload zlib-1.2.11-gcc-7.3.0-h3h2oa4
 }
 
 spectre_load_modules() {
@@ -63,6 +64,7 @@ spectre_load_modules() {
     module load openblas-0.3.4-gcc-7.3.0-tt2coe7
     module load charm-6.10.2-libs
     module load doxygen-1.9.1-gcc-7.3.0-nxmwu4a
+    module load zlib-1.2.11-gcc-7.3.0-h3h2oa4
 }
 
 spectre_run_cmake() {


### PR DESCRIPTION
## Proposed changes

For some reason, ocean_clang.sh did not load the correct libz from spack, even though it did load hdf5 from spack which used it. This caused a cmake warning complaining about conflicts between system and spack versions of libz.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
