### PR TITLE
Fix missing Boost headers pre v1.67

### DIFF
--- a/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/SubdomainOperator.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/SubdomainOperator.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <boost/container_hash/hash.hpp>
 #include <boost/functional/hash.hpp>
 #include <cstddef>
 #include <optional>

--- a/src/Elliptic/SubdomainPreconditioners/MinusLaplacian.hpp
+++ b/src/Elliptic/SubdomainPreconditioners/MinusLaplacian.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <boost/container_hash/hash.hpp>
 #include <boost/functional/hash.hpp>
 #include <cstddef>
 #include <map>


### PR DESCRIPTION
boost/container_hash/hash.hpp was added in v1.67. The old header
boost/functional/hash.hpp forwards to it, so we can just use that.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
