### PR TITLE
Make subcell projection be dim-by-dim operation

### DIFF
--- a/src/Evolution/DgSubcell/Matrices.hpp
+++ b/src/Evolution/DgSubcell/Matrices.hpp
@@ -16,12 +16,10 @@ class Mesh;
 namespace evolution::dg::subcell::fd {
 /*!
  * \ingroup DgSubcellGroup
- * \brief Computes the projection matrix in `Dim` dimensions going from a DG
+ * \brief Computes the projection matrix in 1 dimension going from a DG
  * mesh to a conservative finite difference subcell mesh.
  */
-template <size_t Dim>
-const Matrix& projection_matrix(const Mesh<Dim>& dg_mesh,
-                                const Index<Dim>& subcell_extents);
+const Matrix& projection_matrix(const Mesh<1>& dg_mesh, size_t subcell_extents);
 
 /*!
  * \ingroup DgSubcellGroup


### PR DESCRIPTION
## Proposed changes

This speeds up subcell evolutions of GRMHD smooth flow by ~3x.

I'm going to add the option to do dim-by-dim reconstruction and to only run the TCI for going back to DG every `N` steps, but that'll be in a separate PR. I'm hoping to bring the overhead of DG-subcell down to < 5% when the solution is smooth with some more refactoring and changing order-of-operations in the code. That'll be a bit bigger of a refactor but I think will be mostly transparent from the user perspective. At that point we will need to profile the code again and make sure all of our time is spent in the RHS 🤞 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
