### PR TITLE
Add serialization, option creation to Blaze vector and matrix types

### DIFF
--- a/src/DataStructures/CMakeLists.txt
+++ b/src/DataStructures/CMakeLists.txt
@@ -28,11 +28,15 @@ spectre_target_headers(
   ComplexDataVector.hpp
   ComplexDiagonalModalOperator.hpp
   ComplexModalVector.hpp
+  CompressedMatrix.hpp
+  CompressedVector.hpp
   DataVector.hpp
   DenseMatrix.hpp
   DenseVector.hpp
   DiagonalModalOperator.hpp
   DynamicBuffer.hpp
+  DynamicMatrix.hpp
+  DynamicVector.hpp
   FixedHashMap.hpp
   FloatingPointType.hpp
   GeneralIndexIterator.hpp
@@ -47,6 +51,8 @@ spectre_target_headers(
   SliceTensorToVariables.hpp
   SliceVariables.hpp
   SpinWeighted.hpp
+  StaticMatrix.hpp
+  StaticVector.hpp
   StripeIterator.hpp
   Tags.hpp
   TempBuffer.hpp

--- a/src/DataStructures/CompressedMatrix.hpp
+++ b/src/DataStructures/CompressedMatrix.hpp
@@ -1,0 +1,97 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// `blaze::CompressedMatrix` is a general-purpose sparse matrix type. This file
+/// implements interoperability of `blaze::CompressedMatrix` with our data
+/// structures.
+
+#pragma once
+
+#include <blaze/math/CompressedMatrix.h>
+#include <cstddef>
+#include <pup.h>
+#include <vector>
+
+#include "Options/ParseOptions.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace PUP {
+/// @{
+/// Serialization of blaze::CompressedMatrix
+template <typename Type, bool SO, typename Tag>
+void pup(er& p, blaze::CompressedMatrix<Type, SO, Tag>& t) {
+  size_t rows = t.rows();
+  size_t columns = t.columns();
+  p | rows;
+  p | columns;
+  const size_t first_dimension = (SO == blaze::rowMajor) ? rows : columns;
+  size_t num_non_zeros = t.nonZeros();
+  p | num_non_zeros;
+  // blaze::CompressedMatrix has no `.data()` access, so we use the low-level
+  // `append` mechanism for serialization instead of `PUParray`. Maybe there's
+  // an even faster way using PUPbytes.
+  size_t index;
+  if (p.isUnpacking()) {
+    t.resize(rows, columns);
+    t.reserve(num_non_zeros);
+    Type value;
+    for (size_t i = 0; i < first_dimension; ++i) {
+      p | num_non_zeros;
+      for (size_t j = 0; j < num_non_zeros; ++j) {
+        p | index;
+        p | value;
+        if constexpr (SO == blaze::rowMajor) {
+          t.append(i, index, value);
+        } else {
+          t.append(index, i, value);
+        }
+      }
+      t.finalize(i);
+    }
+  } else {
+    for (size_t i = 0; i < first_dimension; ++i) {
+      num_non_zeros = t.nonZeros(i);
+      p | num_non_zeros;
+      for (auto it = t.begin(i); it != t.end(i); ++it) {
+        index = it->index();
+        p | index;
+        p | it->value();
+      }
+    }
+  }
+}
+template <typename Type, bool SO, typename Tag>
+void operator|(er& p, blaze::CompressedMatrix<Type, SO, Tag>& t) {
+  pup(p, t);
+}
+/// @}
+}  // namespace PUP
+
+template <typename Type, bool SO, typename Tag>
+struct Options::create_from_yaml<blaze::CompressedMatrix<Type, SO, Tag>> {
+  template <typename Metavariables>
+  static blaze::CompressedMatrix<Type, SO, Tag> create(
+      const Options::Option& options) {
+    const auto data = options.parse_as<std::vector<std::vector<Type>>>();
+    const size_t num_rows = data.size();
+    size_t num_cols = 0;
+    if (num_rows > 0) {
+      num_cols = data[0].size();
+    }
+    blaze::CompressedMatrix<Type, SO, Tag> result(num_rows, num_cols);
+    for (size_t i = 0; i < num_rows; i++) {
+      const auto& row = gsl::at(data, i);
+      if (row.size() != num_cols) {
+        PARSE_ERROR(options.context(),
+                    "All matrix rows must have the same size.");
+      }
+      for (size_t j = 0; j < num_cols; j++) {
+        if (gsl::at(row, j) != 0.) {
+          result(i, j) = gsl::at(row, j);
+        }
+      }
+    }
+    return result;
+  }
+};

--- a/src/DataStructures/CompressedVector.hpp
+++ b/src/DataStructures/CompressedVector.hpp
@@ -1,0 +1,75 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// `blaze::CompressedVector` is a general-purpose sparse vector type. This file
+/// implements interoperability of `blaze::CompressedVector` with our data
+/// structures.
+
+#pragma once
+
+#include <blaze/math/CompressedVector.h>
+#include <cstddef>
+#include <pup.h>
+#include <vector>
+
+#include "Options/ParseOptions.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace PUP {
+/// @{
+/// Serialization of blaze::CompressedVector
+template <typename T, bool TF, typename Tag>
+void pup(er& p, blaze::CompressedVector<T, TF, Tag>& t) {
+  size_t size = t.size();
+  p | size;
+  size_t num_non_zeros = t.nonZeros();
+  p | num_non_zeros;
+  // blaze::CompressedVector has no `.data()` access, so we use the low-level
+  // `append` mechanism for serialization instead of `PUParray`. Maybe there's
+  // an even faster way using PUPbytes.
+  size_t index;
+  if (p.isUnpacking()) {
+    t.resize(size);
+    t.reserve(num_non_zeros);
+    T value;
+    for (size_t i = 0; i < num_non_zeros; ++i) {
+      p | index;
+      p | value;
+      t.append(index, value);
+    }
+  } else {
+    for (auto it = t.begin(); it != t.end(); ++it) {
+      index = it->index();
+      p | index;
+      p | it->value();
+    }
+  }
+}
+template <typename T, bool TF, typename Tag>
+void operator|(er& p, blaze::CompressedVector<T, TF, Tag>& t) {
+  pup(p, t);
+}
+/// @}
+}  // namespace PUP
+
+template <typename T, bool TF, typename Tag>
+struct Options::create_from_yaml<blaze::CompressedVector<T, TF, Tag>> {
+  template <typename Metavariables>
+  static blaze::CompressedVector<T, TF, Tag> create(
+      const Options::Option& options) {
+    const auto data = options.parse_as<std::vector<T>>();
+    blaze::CompressedVector<T, TF, Tag> result(data.size());
+    // Insert only non-zero elements. Can't use iterators and `std::copy`
+    // because for sparse types the iterators only run over non-zero elements.
+    // There's probably a faster way to do this construction using the low-level
+    // `append` function, but it's probably not worth the effort for small
+    // matrices created in input files.
+    for (size_t i = 0; i < data.size(); ++i) {
+      if (gsl::at(data, i) != 0.) {
+        result[i] = gsl::at(data, i);
+      }
+    }
+    return result;
+  }
+};

--- a/src/DataStructures/DynamicMatrix.hpp
+++ b/src/DataStructures/DynamicMatrix.hpp
@@ -1,0 +1,71 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// `blaze::DynamicMatrix` is a general-purpose dynamically sized matrix type.
+/// This file implements interoperability of `blaze::DynamicMatrix` with our
+/// data structures.
+
+#pragma once
+
+#include <blaze/math/DynamicMatrix.h>
+#include <cstddef>
+#include <pup.h>
+#include <type_traits>
+#include <vector>
+
+#include "Options/ParseOptions.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace PUP {
+/// @{
+/// Serialization of blaze::DynamicMatrix
+template <typename Type, bool SO, typename Alloc, typename Tag>
+void pup(er& p, blaze::DynamicMatrix<Type, SO, Alloc, Tag>& t) {
+  size_t rows = t.rows();
+  size_t columns = t.columns();
+  p | rows;
+  p | columns;
+  if (p.isUnpacking()) {
+    t.resize(rows, columns);
+  }
+  const size_t spacing = t.spacing();
+  const size_t data_size = spacing * (SO == blaze::rowMajor ? rows : columns);
+  if (std::is_fundamental_v<Type>) {
+    PUParray(p, t.data(), data_size);
+  } else {
+    for (size_t i = 0; i < data_size; ++i) {
+      p | t.data()[i];
+    }
+  }
+}
+template <typename Type, bool SO, typename Alloc, typename Tag>
+void operator|(er& p, blaze::DynamicMatrix<Type, SO, Alloc, Tag>& t) {
+  pup(p, t);
+}
+/// @}
+}  // namespace PUP
+
+template <typename Type, bool SO, typename Alloc, typename Tag>
+struct Options::create_from_yaml<blaze::DynamicMatrix<Type, SO, Alloc, Tag>> {
+  template <typename Metavariables>
+  static blaze::DynamicMatrix<Type, SO, Alloc, Tag> create(
+      const Options::Option& options) {
+    const auto data = options.parse_as<std::vector<std::vector<Type>>>();
+    const size_t num_rows = data.size();
+    size_t num_cols = 0;
+    if (num_rows > 0) {
+      num_cols = data[0].size();
+    }
+    blaze::DynamicMatrix<Type, SO, Alloc, Tag> result(num_rows, num_cols);
+    for (size_t i = 0; i < num_rows; i++) {
+      const auto& row = gsl::at(data, i);
+      if (row.size() != num_cols) {
+        PARSE_ERROR(options.context(),
+                    "All matrix rows must have the same size.");
+      }
+      std::copy(row.begin(), row.end(), blaze::row(result, i).begin());
+    }
+    return result;
+  }
+};

--- a/src/DataStructures/DynamicVector.hpp
+++ b/src/DataStructures/DynamicVector.hpp
@@ -1,0 +1,72 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// `blaze::DynamicVector` is a general-purpose dynamically sized vector type.
+/// This file implements interoperability of `blaze::DynamicVector` with our
+/// data structures.
+
+#pragma once
+
+#include <blaze/math/DynamicVector.h>
+#include <pup.h>
+#include <type_traits>
+#include <vector>
+
+#include "Options/ParseOptions.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace PUP {
+/// @{
+/// Serialization of blaze::DynamicVector
+template <typename T, bool TF, typename Tag>
+void pup(er& p, blaze::DynamicVector<T, TF, Tag>& t) {
+  size_t size = t.size();
+  p | size;
+  if (p.isUnpacking()) {
+    t.resize(size);
+  }
+  if (std::is_fundamental_v<T>) {
+    PUParray(p, t.data(), size);
+  } else {
+    for (T& element : t) {
+      p | element;
+    }
+  }
+}
+template <typename T, bool TF, typename Tag>
+void operator|(er& p, blaze::DynamicVector<T, TF, Tag>& t) {
+  pup(p, t);
+}
+/// @}
+}  // namespace PUP
+
+namespace MakeWithValueImpls {
+template <typename T, bool TF, typename Tag>
+struct NumberOfPoints<blaze::DynamicVector<T, TF, Tag>> {
+  static SPECTRE_ALWAYS_INLINE size_t
+  apply(const blaze::DynamicVector<T, TF, Tag>& input) {
+    return input.size();
+  }
+};
+
+template <typename T, bool TF, typename Tag>
+struct MakeWithSize<blaze::DynamicVector<T, TF, Tag>> {
+  static SPECTRE_ALWAYS_INLINE blaze::DynamicVector<T, TF, Tag> apply(
+      const size_t size, const T& value) {
+    return blaze::DynamicVector<T, TF, Tag>(size, value);
+  }
+};
+}  // namespace MakeWithValueImpls
+
+template <typename T, bool TF, typename Tag>
+struct Options::create_from_yaml<blaze::DynamicVector<T, TF, Tag>> {
+  template <typename Metavariables>
+  static blaze::DynamicVector<T, TF, Tag> create(
+      const Options::Option& options) {
+    const auto data = options.parse_as<std::vector<T>>();
+    blaze::DynamicVector<T, TF, Tag> result(data.size());
+    std::copy(std::begin(data), std::end(data), result.begin());
+    return result;
+  }
+};

--- a/src/DataStructures/StaticMatrix.hpp
+++ b/src/DataStructures/StaticMatrix.hpp
@@ -1,0 +1,52 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// `blaze::StaticMatrix` is a general-purpose fixed size matrix type. This file
+/// implements interoperability of `blaze::StaticMatrix` with our data
+/// structures.
+
+#pragma once
+
+#include <array>
+#include <blaze/math/StaticMatrix.h>
+#include <cstddef>
+#include <pup.h>
+#include <type_traits>
+
+#include "Options/ParseOptions.hpp"
+
+namespace PUP {
+/// @{
+/// Serialization of blaze::StaticMatrix
+template <typename Type, size_t M, size_t N, bool SO, blaze::AlignmentFlag AF,
+          blaze::PaddingFlag PF, typename Tag>
+void pup(er& p, blaze::StaticMatrix<Type, M, N, SO, AF, PF, Tag>& t) {
+  const size_t spacing = t.spacing();
+  const size_t data_size = spacing * (SO == blaze::rowMajor ? M : N);
+  if (std::is_fundamental_v<Type>) {
+    PUParray(p, t.data(), data_size);
+  } else {
+    for (size_t i = 0; i < data_size; ++i) {
+      p | t.data()[i];
+    }
+  }
+}
+template <typename Type, size_t M, size_t N, bool SO, blaze::AlignmentFlag AF,
+          blaze::PaddingFlag PF, typename Tag>
+void operator|(er& p, blaze::StaticMatrix<Type, M, N, SO, AF, PF, Tag>& t) {
+  pup(p, t);
+}
+/// @}
+}  // namespace PUP
+
+template <typename Type, size_t M, size_t N, bool SO, blaze::AlignmentFlag AF,
+          blaze::PaddingFlag PF, typename Tag>
+struct Options::create_from_yaml<
+    blaze::StaticMatrix<Type, M, N, SO, AF, PF, Tag>> {
+  template <typename Metavariables>
+  static blaze::StaticMatrix<Type, M, N, SO, AF, PF, Tag> create(
+      const Options::Option& options) {
+    return {options.parse_as<std::array<std::array<Type, N>, M>>()};
+  }
+};

--- a/src/DataStructures/StaticVector.hpp
+++ b/src/DataStructures/StaticVector.hpp
@@ -1,0 +1,72 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// `blaze::StaticVector` is a general-purpose fixed size vector type. This file
+/// implements interoperability of `blaze::StaticVector` with our data
+/// structures.
+
+#pragma once
+
+#include <array>
+#include <blaze/math/StaticVector.h>
+#include <pup.h>
+#include <type_traits>
+
+#include "Options/ParseOptions.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace PUP {
+/// @{
+/// Serialization of blaze::StaticVector
+template <typename T, size_t N, bool TF, blaze::AlignmentFlag AF,
+          blaze::PaddingFlag PF, typename Tag>
+void pup(er& p, blaze::StaticVector<T, N, TF, AF, PF, Tag>& t) {
+  if (std::is_fundamental_v<T>) {
+    PUParray(p, t.data(), N);
+  } else {
+    for (T& element : t) {
+      p | element;
+    }
+  }
+}
+template <typename T, size_t N, bool TF, blaze::AlignmentFlag AF,
+          blaze::PaddingFlag PF, typename Tag>
+void operator|(er& p, blaze::StaticVector<T, N, TF, AF, PF, Tag>& t) {
+  pup(p, t);
+}
+/// @}
+}  // namespace PUP
+
+namespace MakeWithValueImpls {
+template <typename T, size_t N, bool TF, blaze::AlignmentFlag AF,
+          blaze::PaddingFlag PF, typename Tag>
+struct NumberOfPoints<blaze::StaticVector<T, N, TF, AF, PF, Tag>> {
+  static constexpr size_t apply(
+      const blaze::StaticVector<T, N, TF, AF, PF, Tag>& /*input*/) {
+    return N;
+  }
+};
+
+template <typename T, size_t N, bool TF, blaze::AlignmentFlag AF,
+          blaze::PaddingFlag PF, typename Tag>
+struct MakeWithSize<blaze::StaticVector<T, N, TF, AF, PF, Tag>> {
+  static SPECTRE_ALWAYS_INLINE blaze::StaticVector<T, N, TF, AF, PF, Tag> apply(
+      const size_t size, const T& value) {
+    ASSERT(size == N, "Size mismatch for StaticVector: Expected "
+                          << N << ", got " << size << ".");
+    return blaze::StaticVector<T, N, TF, AF, PF, Tag>(value);
+  }
+};
+}  // namespace MakeWithValueImpls
+
+template <typename T, size_t N, bool TF, blaze::AlignmentFlag AF,
+          blaze::PaddingFlag PF, typename Tag>
+struct Options::create_from_yaml<blaze::StaticVector<T, N, TF, AF, PF, Tag>> {
+  template <typename Metavariables>
+  static blaze::StaticVector<T, N, TF, AF, PF, Tag> create(
+      const Options::Option& options) {
+    return {options.parse_as<std::array<T, N>>()};
+  }
+};

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_DataStructures")
 
 set(LIBRARY_SOURCES
   Test_ApplyMatrices.cpp
+  Test_BlazeInteroperability.cpp
   Test_CachedTempBuffer.cpp
   Test_ComplexDataVector.cpp
   Test_ComplexDataVectorAsserts.cpp

--- a/tests/Unit/DataStructures/Test_BlazeInteroperability.cpp
+++ b/tests/Unit/DataStructures/Test_BlazeInteroperability.cpp
@@ -1,0 +1,120 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/CompressedMatrix.hpp"
+#include "DataStructures/CompressedVector.hpp"
+#include "DataStructures/DynamicMatrix.hpp"
+#include "DataStructures/DynamicVector.hpp"
+#include "DataStructures/StaticMatrix.hpp"
+#include "DataStructures/StaticVector.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+SPECTRE_TEST_CASE("Unit.DataStructures.BlazeInteroperability",
+                  "[DataStructures][Unit]") {
+  {
+    INFO("StaticVector");
+    test_serialization(blaze::StaticVector<double, 4>{0., 1., 0., 2.});
+    CHECK(make_with_value<blaze::StaticVector<double, 3>>(
+              blaze::DynamicVector<double>(3), 1.) ==
+          blaze::StaticVector<double, 3>(1.));
+    CHECK(TestHelpers::test_creation<blaze::StaticVector<double, 4>>(
+              "[0., 1., 0., 2.]") ==
+          blaze::StaticVector<double, 4>{0., 1., 0., 2.});
+  }
+  {
+    INFO("DynamicVector");
+    test_serialization(blaze::DynamicVector<double>{0., 1., 0., 2.});
+    CHECK(make_with_value<blaze::DynamicVector<double>>(
+              blaze::DynamicVector<double>(3), 1.) ==
+          blaze::DynamicVector<double>(3, 1.));
+    CHECK(TestHelpers::test_creation<blaze::DynamicVector<double>>(
+              "[0., 1., 0., 2.]") ==
+          blaze::DynamicVector<double>{0., 1., 0., 2.});
+  }
+  {
+    INFO("CompressedVector");
+    test_serialization(blaze::CompressedVector<double>{0., 1., 0., 2.});
+    CHECK(serialize_and_deserialize(
+              blaze::CompressedVector<double>{0., 1., 0., 2.})
+              .nonZeros() == 2);
+    CHECK(TestHelpers::test_creation<blaze::CompressedVector<double>>(
+              "[0., 1., 0., 2.]") ==
+          blaze::CompressedVector<double>{0., 1., 0., 2.});
+    CHECK(TestHelpers::test_creation<blaze::CompressedVector<double>>(
+              "[0., 1., 0., 2.]")
+              .nonZeros() == 2);
+  }
+  {
+    INFO("StaticMatrix");
+    test_serialization(blaze::StaticMatrix<double, 2, 3, blaze::columnMajor>{
+        {0., 1., 2.}, {3., 0., 4.}});
+    test_serialization(blaze::StaticMatrix<double, 2, 3, blaze::rowMajor>{
+        {0., 1., 2.}, {3., 0., 4.}});
+    CHECK(TestHelpers::test_creation<
+              blaze::StaticMatrix<double, 2, 3, blaze::columnMajor>>(
+              "[[0., 1., 2.], [3., 0., 4.]]") ==
+          blaze::StaticMatrix<double, 2, 3, blaze::columnMajor>{{0., 1., 2.},
+                                                                {3., 0., 4.}});
+    CHECK(TestHelpers::test_creation<
+              blaze::StaticMatrix<double, 2, 3, blaze::rowMajor>>(
+              "[[0., 1., 2.], [3., 0., 4.]]") ==
+          blaze::StaticMatrix<double, 2, 3, blaze::rowMajor>{{0., 1., 2.},
+                                                             {3., 0., 4.}});
+  }
+  {
+    INFO("DynamicMatrix");
+    test_serialization(blaze::DynamicMatrix<double, blaze::columnMajor>{
+        {0., 1., 2.}, {3., 0., 4.}});
+    test_serialization(blaze::DynamicMatrix<double, blaze::rowMajor>{
+        {0., 1., 2.}, {3., 0., 4.}});
+    CHECK(TestHelpers::test_creation<
+              blaze::DynamicMatrix<double, blaze::columnMajor>>(
+              "[[0., 1., 2.], [3., 0., 4.]]") ==
+          blaze::DynamicMatrix<double, blaze::columnMajor>{{0., 1., 2.},
+                                                           {3., 0., 4.}});
+    CHECK(TestHelpers::test_creation<
+              blaze::DynamicMatrix<double, blaze::rowMajor>>(
+              "[[0., 1., 2.], [3., 0., 4.]]") ==
+          blaze::DynamicMatrix<double, blaze::rowMajor>{{0., 1., 2.},
+                                                        {3., 0., 4.}});
+  }
+  {
+    INFO("CompressedMatrix");
+    test_serialization(blaze::CompressedMatrix<double, blaze::columnMajor>{
+        {0., 1., 2.}, {3., 0., 4.}});
+    CHECK(serialize_and_deserialize(
+              blaze::CompressedMatrix<double, blaze::columnMajor>{{0., 1., 2.},
+                                                                  {3., 0., 4.}})
+              .nonZeros() == 4);
+    test_serialization(blaze::CompressedMatrix<double, blaze::rowMajor>{
+        {0., 1., 2.}, {3., 0., 4.}});
+    CHECK(serialize_and_deserialize(
+              blaze::CompressedMatrix<double, blaze::rowMajor>{{0., 1., 2.},
+                                                               {3., 0., 4.}})
+              .nonZeros() == 4);
+    CHECK(TestHelpers::test_creation<
+              blaze::CompressedMatrix<double, blaze::columnMajor>>(
+              "[[0., 1., 2.], [3., 0., 4.]]") ==
+          blaze::CompressedMatrix<double, blaze::columnMajor>{{0., 1., 2.},
+                                                              {3., 0., 4.}});
+    CHECK(TestHelpers::test_creation<
+              blaze::CompressedMatrix<double, blaze::columnMajor>>(
+              "[[0., 1., 2.], [3., 0., 4.]]")
+              .nonZeros() == 4);
+    CHECK(TestHelpers::test_creation<
+              blaze::CompressedMatrix<double, blaze::rowMajor>>(
+              "[[0., 1., 2.], [3., 0., 4.]]") ==
+          blaze::CompressedMatrix<double, blaze::rowMajor>{{0., 1., 2.},
+                                                           {3., 0., 4.}});
+    CHECK(TestHelpers::test_creation<
+              blaze::CompressedMatrix<double, blaze::rowMajor>>(
+              "[[0., 1., 2.], [3., 0., 4.]]")
+              .nonZeros() == 4);
+  }
+}


### PR DESCRIPTION
## Proposed changes

Add interoperability with Blaze. This will allow working with Blaze vector and matrix types more directly. For example, I will need to use sparse linear operations a lot in optimizations of the elliptic solver, which reduce runtime of an elliptic solve by ~30%. Specifically, I need to store (and hence serialize/deserialize) incomplete LU decompositions of linear operators on each element. I currently use [Eigen3](https://eigen.tuxfamily.org) for this on my branch, but I'm considering to port the functionality to Blaze.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
