### PR TITLE
Configure Blaze: enable BLAS kernels, col-major matrix storage, add comments

### DIFF
--- a/cmake/SetupBlaze.cmake
+++ b/cmake/SetupBlaze.cmake
@@ -19,9 +19,26 @@ set_property(TARGET Blaze PROPERTY
   INTERFACE_INCLUDE_DIRECTORIES ${BLAZE_INCLUDE_DIR})
 set_property(TARGET Blaze PROPERTY
   INTERFACE_LINK_LIBRARIES Lapack)
+target_link_libraries(
+  Blaze
+  INTERFACE
+  Blas
+  GSL::gsl # for BLAS header
+  Lapack
+  )
 
+# Configure Blaze. See documentation:
+# https://bitbucket.org/blaze-lib/blaze/wiki/Configuration%20and%20Installation#!step-2-configuration
 target_compile_definitions(Blaze
   INTERFACE
+  # - Enable external BLAS kernels
+  BLAZE_BLAS_MODE=1
+  # - Use BLAS header from GSL. We could also find and include a <cblas.h> (or
+  #   similarly named) header that may be distributed with the BLAS
+  #   implementation, but it's not guaranteed to be available and may conflict
+  #   with the GSL header. Since we use GSL anyway, it's easier to use their
+  #   BLAS header.
+  BLAZE_BLAS_INCLUDE_FILE=<gsl/gsl_cblas.h>
   # Override SMP configurations
   BLAZE_USE_SHARED_MEMORY_PARALLELIZATION=0
   BLAZE_OPENMP_PARALLEL_MODE=0

--- a/cmake/SetupBlaze.cmake
+++ b/cmake/SetupBlaze.cmake
@@ -27,7 +27,8 @@ target_link_libraries(
   Lapack
   )
 
-# Configure Blaze. See documentation:
+# Configure Blaze. Some of the Blaze configuration options could be optimized
+# for the machine we are running on. See documentation:
 # https://bitbucket.org/blaze-lib/blaze/wiki/Configuration%20and%20Installation#!step-2-configuration
 target_compile_definitions(Blaze
   INTERFACE
@@ -49,6 +50,10 @@ target_compile_definitions(Blaze
   BLAZE_USE_SHARED_MEMORY_PARALLELIZATION=0
   # - Disable MPI parallelization
   BLAZE_MPI_PARALLEL_MODE=0
+  # - Using the default cache size, which may have been configured automatically
+  #   by the Blaze CMake configuration for the machine we are running on. We
+  #   could override it here explicitly to tune performance.
+  # BLAZE_CACHE_SIZE
   BLAZE_USE_PADDING=0
   # Enable non-temporal stores for cache optimization of large data structures
   BLAZE_USE_STREAMING=1

--- a/cmake/SetupBlaze.cmake
+++ b/cmake/SetupBlaze.cmake
@@ -55,10 +55,12 @@ target_compile_definitions(Blaze
   #   could override it here explicitly to tune performance.
   # BLAZE_CACHE_SIZE
   BLAZE_USE_PADDING=0
-  # Enable non-temporal stores for cache optimization of large data structures
+  # - Always enable non-temporal stores for cache optimization of large data
+  #   structures: https://bitbucket.org/blaze-lib/blaze/wiki/Configuration%20Files#!streaming-non-temporal-stores
   BLAZE_USE_STREAMING=1
-  BLAZE_USE_OPTIMIZED_KERNELS=1
-  # Skip initializing default-constructed structures for fundamental types
+  # - We could use SLEEF for vectorized implementations of sin, cos, exp, etc.:
+  # BLAZE_USE_SLEEF
+  # - Skip initializing default-constructed structures for fundamental types
   BLAZE_USE_DEFAULT_INITIALIZATON=0
   )
 

--- a/cmake/SetupBlaze.cmake
+++ b/cmake/SetupBlaze.cmake
@@ -43,15 +43,12 @@ target_compile_definitions(Blaze
   #   functions are implemented for column-major layout. This default reduces
   #   conversions.
   BLAZE_DEFAULT_STORAGE_ORDER=blaze::columnMajor
-  # Override SMP configurations
+  # - Disable SMP parallelization. This disables SMP parallelization for all
+  #   possible backends (OpenMP, C++11 threads, Boost, HPX):
+  #   https://bitbucket.org/blaze-lib/blaze/wiki/Serial%20Execution#!option-3-deactivation-of-parallel-execution
   BLAZE_USE_SHARED_MEMORY_PARALLELIZATION=0
-  BLAZE_OPENMP_PARALLEL_MODE=0
-  BLAZE_CPP_THREADS_PARALLEL_MODE=0
-  BLAZE_BOOST_THREADS_PARALLEL_MODE=0
-  # Disable MPI parallelization
+  # - Disable MPI parallelization
   BLAZE_MPI_PARALLEL_MODE=0
-  # Disable HPX parallelization
-  BLAZE_HPX_PARALLEL_MODE=0
   BLAZE_USE_PADDING=0
   # Enable non-temporal stores for cache optimization of large data structures
   BLAZE_USE_STREAMING=1

--- a/cmake/SetupBlaze.cmake
+++ b/cmake/SetupBlaze.cmake
@@ -39,6 +39,10 @@ target_compile_definitions(Blaze
   #   with the GSL header. Since we use GSL anyway, it's easier to use their
   #   BLAS header.
   BLAZE_BLAS_INCLUDE_FILE=<gsl/gsl_cblas.h>
+  # - Set default matrix storage order to column-major, since many of our
+  #   functions are implemented for column-major layout. This default reduces
+  #   conversions.
+  BLAZE_DEFAULT_STORAGE_ORDER=blaze::columnMajor
   # Override SMP configurations
   BLAZE_USE_SHARED_MEMORY_PARALLELIZATION=0
   BLAZE_OPENMP_PARALLEL_MODE=0

--- a/cmake/SetupGsl.cmake
+++ b/cmake/SetupGsl.cmake
@@ -12,6 +12,13 @@ file(APPEND
   "GSL version: ${GSL_VERSION}\n"
   )
 
+# Link external BLAS library. We don't need the GSL::gslcblas target.
+target_link_libraries(
+  GSL::gsl
+  INTERFACE
+  Blas
+  )
+
 set_property(
   GLOBAL APPEND PROPERTY SPECTRE_THIRD_PARTY_LIBS
   GSL::gsl GSL::gslcblas

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -59,7 +59,9 @@ all of these dependencies.
 * [Charm++](http://charm.cs.illinois.edu/) 6.10.2, or 7.0.0 or later (experimental)
 * [Git](https://git-scm.com/)
 * BLAS (e.g. [OpenBLAS](http://www.openblas.net))
-* [Blaze](https://bitbucket.org/blaze-lib/blaze/overview) v3.8
+* [Blaze](https://bitbucket.org/blaze-lib/blaze/overview) v3.8. It can be
+  beneficial to install Blaze with CMake so some configuration options are
+  determined automatically, such as cache sizes.
 * [Boost](http://www.boost.org/) 1.60.0 or later
 * [Brigand](https://github.com/edouarda/brigand) at commit 1c398e4f1e817ab195e4cd6fbb03c18cb386eea3 (late 2020) or later
 * [Catch](https://github.com/catchorg/Catch2) 2.8.0 or later, but not 3.x as SpECTRE doesn't support v3 yet (If installing from source, it is easiest to use single-header installation)


### PR DESCRIPTION
## Proposed changes

Update the Blaze configuration. In particular, I found odd that external BLAS kernels were not enabled.

- Enable external BLAS kernels
- Set default matrix storage order to column-major
- ~Enable padding (Blaze default). It's recommended by Blaze for performance, and is already supported by most of our functions since Blaze 3.7 had padding always enabled.~ moved to #3825 
- Remove some redundant configuration flags

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
