### PR TITLE
Fix Charm++ include paths on Frontera

### DIFF
--- a/cmake/FindCharm.cmake
+++ b/cmake/FindCharm.cmake
@@ -254,6 +254,9 @@ set(CHARM_INCLUDE_EXTRA ${CHARM_CXX_FLAGS})
 list(FILTER CHARM_INCLUDE_EXTRA INCLUDE REGEX "^-I.+")
 list(FILTER CHARM_CXX_FLAGS EXCLUDE REGEX "^-I.+")
 list(TRANSFORM CHARM_INCLUDE_EXTRA REPLACE "^-I" "")
+# Filter out relative paths to `./proc_management` that are added for some
+# backends (ucx and ofi), since those paths don't seem to exist
+list(FILTER CHARM_INCLUDE_EXTRA EXCLUDE REGEX "^[.]/proc_management")
 list(APPEND CHARM_INCLUDE_DIRS ${CHARM_INCLUDE_EXTRA})
 # - Remove the rpath linker argument, since CMake adds it automatically.
 list(FILTER CHARM_LDXX_FLAGS EXCLUDE REGEX "^-Wl,-rpath,${CHARM_LIBRARIES}/?$")


### PR DESCRIPTION
These relative paths don't seem to exist.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
