### PR TITLE
Add tensor slicing for subcell

### DIFF
--- a/src/Evolution/DgSubcell/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/CMakeLists.txt
@@ -24,6 +24,7 @@ spectre_target_headers(
   RdmpTciData.hpp
   Reconstruction.hpp
   SliceData.hpp
+  SliceTensor.hpp
   SubcellOptions.hpp
   TciStatus.hpp
   TwoMeshRdmpTci.hpp

--- a/src/Evolution/DgSubcell/SliceData.cpp
+++ b/src/Evolution/DgSubcell/SliceData.cpp
@@ -11,6 +11,7 @@
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/Side.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
 
@@ -86,8 +87,17 @@ DirectionMap<Dim, std::vector<double>> slice_data_impl(
   const size_t number_of_components = volume_subcell_vars.size() / num_pts;
   std::array<size_t, Dim> result_grid_points{};
   for (size_t d = 0; d < Dim; ++d) {
-    gsl::at(result_grid_points, d) =
+    const size_t num_sliced_pts =
         number_of_ghost_points * subcell_extents.slice_away(d).product();
+
+    ASSERT(num_sliced_pts <= num_pts,
+           "Number of ghost points (" << number_of_ghost_points
+                                      << ") is larger than the subcell mesh "
+                                         "extent to the slicing direction ("
+                                      << subcell_extents.indices().at(d)
+                                      << ") ");
+
+    gsl::at(result_grid_points, d) = num_sliced_pts;
   }
   DirectionMap<Dim, std::vector<double>> result{};
   for (const auto& [dir, should_slice] : directions_to_slice) {

--- a/src/Evolution/DgSubcell/SliceTensor.hpp
+++ b/src/Evolution/DgSubcell/SliceTensor.hpp
@@ -1,0 +1,80 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Evolution/DgSubcell/SliceData.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace evolution::dg::subcell {
+// template specialization for handling scalar (rank 0)
+template <size_t Dim, typename VectorType>
+void slice_tensor_for_subcell(
+    const gsl::not_null<Tensor<VectorType, Symmetry<>, index_list<>>*>
+        sliced_scalar,
+    const Tensor<VectorType, Symmetry<>, index_list<>>& volume_scalar,
+    const Index<Dim>& subcell_extents, size_t number_of_ghost_points,
+    const Direction<Dim>& direction) {
+  DirectionMap<Dim, bool> directions_to_slice{};
+  directions_to_slice[direction] = true;
+
+  auto& scalar_dv = get(volume_scalar);
+  auto sliced_data = evolution::dg::subcell::detail::slice_data_impl(
+      gsl::make_span(scalar_dv.data(), scalar_dv.size()), subcell_extents,
+      number_of_ghost_points, directions_to_slice)[direction];
+
+  std::copy(sliced_data.begin(), sliced_data.end(), get(*sliced_scalar).data());
+}
+
+/// @{
+/*!
+ * \brief Slice a single volume tensor for a given direction and slicing depth
+ * (number of ghost points).
+ *
+ * Note that the last argument has the type `Direction<Dim>`, not a DirectionMap
+ * (cf. `evolution::dg::subcell::slice_data`)
+ *
+ */
+template <size_t Dim, typename VectorType, typename... Structure>
+void slice_tensor_for_subcell(
+    const gsl::not_null<Tensor<VectorType, Structure...>*> sliced_tensor,
+    const Tensor<VectorType, Structure...>& volume_tensor,
+    const Index<Dim>& subcell_extents, size_t number_of_ghost_points,
+    const Direction<Dim>& direction) {
+  DirectionMap<Dim, bool> directions_to_slice{};
+  directions_to_slice[direction] = true;
+
+  for (size_t i = 0; i < volume_tensor.size(); i++) {
+    auto& ti = volume_tensor.get(i);
+
+    auto sliced_data = evolution::dg::subcell::detail::slice_data_impl(
+        gsl::make_span(ti.data(), ti.size()), subcell_extents,
+        number_of_ghost_points, directions_to_slice)[direction];
+
+    std::copy(sliced_data.begin(), sliced_data.end(),
+              (*sliced_tensor).get(i).data());
+  }
+}
+
+template <size_t Dim, typename VectorType, typename... Structure>
+Tensor<VectorType, Structure...> slice_tensor_for_subcell(
+    const Tensor<VectorType, Structure...>& volume_tensor,
+    const Index<Dim>& subcell_extents, size_t number_of_ghost_points,
+    const Direction<Dim>& direction) {
+  Tensor<VectorType, Structure...> sliced_tensor(
+      subcell_extents.slice_away(direction.dimension()).product() *
+      number_of_ghost_points);
+  slice_tensor_for_subcell(make_not_null(&sliced_tensor), volume_tensor,
+                           subcell_extents, number_of_ghost_points, direction);
+  return sliced_tensor;
+}
+/// @}
+}  // namespace evolution::dg::subcell

--- a/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
+++ b/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
@@ -25,6 +25,7 @@ set(LIBRARY_SOURCES
   Test_RdmpTciData.cpp
   Test_Reconstruction.cpp
   Test_SliceData.cpp
+  Test_SliceTensor.cpp
   Test_SubcellOptions.cpp
   Test_Tags.cpp
   Test_TciStatus.cpp

--- a/tests/Unit/Evolution/DgSubcell/Test_SliceTensor.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_SliceTensor.cpp
@@ -1,0 +1,92 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <numeric>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/SliceIterator.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Evolution/DgSubcell/SliceTensor.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+// types of Tensor to test
+namespace Tags {
+struct Scalar : db::SimpleTag {
+  using type = ::Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct TensorI : db::SimpleTag {
+  using type = ::tnsr::I<DataVector, Dim>;
+};
+}  // namespace Tags
+
+template <size_t Dim>
+void test() {
+  for (size_t num_mesh_pts_1d = 3; num_mesh_pts_1d < 5; ++num_mesh_pts_1d) {
+    // ghost zone size iterates up to the maximum possible value (mesh extent of
+    // each dimension)
+    for (size_t num_ghost_pts = 1; num_ghost_pts <= num_mesh_pts_1d;
+         ++num_ghost_pts) {
+      const Index<Dim> volume_extents{num_mesh_pts_1d};
+
+      // Create volume tensors and assign values
+      Variables<tmpl::list<Tags::Scalar, Tags::TensorI<Dim>>> volume_vars{
+          volume_extents.product()};
+      std::iota(volume_vars.data(), volume_vars.data() + volume_vars.size(),
+                0.0);
+
+      auto& volume_scalar = get<Tags::Scalar>(volume_vars);
+      auto& volume_tensor = get<Tags::TensorI<Dim>>(volume_vars);
+
+      for (const auto& direction : Direction<Dim>::all_directions()) {
+        // slice data
+        auto sliced_scalar = evolution::dg::subcell::slice_tensor_for_subcell(
+            volume_scalar, volume_extents, num_ghost_pts, direction);
+        auto sliced_tensor = evolution::dg::subcell::slice_tensor_for_subcell(
+            volume_tensor, volume_extents, num_ghost_pts, direction);
+
+        Index<Dim> sliced_extents = volume_extents;
+        sliced_extents[direction.dimension()] = num_ghost_pts;
+
+        for (size_t i_ghost = 0; i_ghost < num_ghost_pts; ++i_ghost) {
+          const size_t fixed_index =
+              direction.side() == Side::Lower
+                  ? i_ghost
+                  : volume_extents[direction.dimension()] + i_ghost -
+                        num_ghost_pts;
+
+          // check the result
+          for (SliceIterator volume_it(volume_extents, direction.dimension(),
+                                       fixed_index),
+               slice_it(sliced_extents, direction.dimension(), i_ghost);
+               volume_it; ++volume_it, ++slice_it) {
+            CHECK(*(get(volume_scalar).data() + volume_it.volume_offset()) ==
+                  get(sliced_scalar)[slice_it.volume_offset()]);
+
+            for (size_t i_tnsr = 0; i_tnsr < volume_tensor.size(); ++i_tnsr) {
+              CHECK(*(volume_tensor.get(i_tnsr).data() +
+                      volume_it.volume_offset()) ==
+                    sliced_tensor.get(i_tnsr)[slice_it.volume_offset()]);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Subcell.SliceTensor", "[Evolution][Unit]") {
+  test<1>();
+  test<2>();
+  test<3>();
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

* Add an `ASSERT` test on the number of grid points to the existing data slicing function.
* Add slicing functions for a single tensor.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
