### PR TITLE
Use quaternion rotation map in BinaryCompactObject domain creator

### DIFF
--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -44,6 +44,7 @@
 #include "Domain/DomainHelpers.hpp"
 #include "Domain/FunctionsOfTime/FixedSpeedCubic.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
 #include "Domain/Structure/BlockNeighbor.hpp"  // IWYU pragma: keep
 #include "Domain/Structure/ExcisionSphere.hpp"
 #include "Utilities/MakeArray.hpp"
@@ -291,7 +292,7 @@ BinaryCompactObject::BinaryCompactObject(
     double initial_expansion, double initial_expansion_velocity,
     double asymptotic_velocity_outer_boundary,
     double decay_timescale_outer_boundary_velocity,
-    double initial_rotation_angle, double initial_angular_velocity,
+    std::array<double, 3> initial_angular_velocity,
     std::array<double, 2> initial_size_map_values,
     std::array<double, 2> initial_size_map_velocities,
     std::array<double, 2> initial_size_map_accelerations, Object object_A,
@@ -318,11 +319,16 @@ BinaryCompactObject::BinaryCompactObject(
   asymptotic_velocity_outer_boundary_ = asymptotic_velocity_outer_boundary;
   decay_timescale_outer_boundary_velocity_ =
       decay_timescale_outer_boundary_velocity;
-  initial_rotation_angle_ = initial_rotation_angle;
-  initial_angular_velocity_ = initial_angular_velocity;
+  // quat = (cos(theta/2), nhat*sin(theta/2)) but we always take theta = 0
+  // initially
+  initial_quaternion_ = DataVector{{1.0, 0.0, 0.0, 0.0}};
   initial_size_map_values_ = initial_size_map_values;
   initial_size_map_velocities_ = initial_size_map_velocities;
   initial_size_map_accelerations_ = initial_size_map_accelerations;
+
+  for (size_t i = 0; i < initial_angular_velocity.size(); i++) {
+    initial_angular_velocity_[i] = gsl::at(initial_angular_velocity, i);
+  }
 }
 
 Domain<3> BinaryCompactObject::create_domain() const {
@@ -537,17 +543,13 @@ Domain<3> BinaryCompactObject::create_domain() const {
     using CubicScaleMapForComposition =
         domain::CoordinateMap<Frame::Grid, Frame::Inertial, CubicScaleMap>;
 
-    using IdentityMap1D = domain::CoordinateMaps::Identity<1>;
-    using RotationMap2D = domain::CoordinateMaps::TimeDependent::Rotation<2>;
-    using RotationMap =
-        domain::CoordinateMaps::TimeDependent::ProductOf2Maps<RotationMap2D,
-                                                              IdentityMap1D>;
+    using RotationMap3D = domain::CoordinateMaps::TimeDependent::Rotation<3>;
     using RotationMapForComposition =
-        domain::CoordinateMap<Frame::Grid, Frame::Inertial, RotationMap>;
+        domain::CoordinateMap<Frame::Grid, Frame::Inertial, RotationMap3D>;
 
     using CubicScaleAndRotationMapForComposition =
         domain::CoordinateMap<Frame::Grid, Frame::Inertial, CubicScaleMap,
-                              RotationMap>;
+                              RotationMap3D>;
 
     using CompressionMap =
         domain::CoordinateMaps::TimeDependent::SphericalCompression<false>;
@@ -556,7 +558,7 @@ Domain<3> BinaryCompactObject::create_domain() const {
 
     using CompressionAndCubicScaleAndRotationMapForComposition =
         domain::CoordinateMap<Frame::Grid, Frame::Inertial, CompressionMap,
-                              CubicScaleMap, RotationMap>;
+                              CubicScaleMap, RotationMap3D>;
 
     std::vector<std::unique_ptr<
         domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, 3>>>
@@ -580,9 +582,8 @@ Domain<3> BinaryCompactObject::create_domain() const {
                     expansion_map_outer_boundary_,
                     expansion_function_of_time_name_,
                     expansion_function_of_time_name_ + "OuterBoundary"s}},
-                RotationMapForComposition{RotationMap{
-                    RotationMap2D{rotation_about_z_axis_function_of_time_name_},
-                    IdentityMap1D{}}}));
+                RotationMapForComposition{
+                    RotationMap3D{rotation_function_of_time_name_}}));
 
     // Initialize the first block of the layer 1 blocks for each object
     // (specifically, initialize block 0 and block 12). If excising interior
@@ -604,10 +605,8 @@ Domain<3> BinaryCompactObject::create_domain() const {
                       expansion_map_outer_boundary_,
                       expansion_function_of_time_name_,
                       expansion_function_of_time_name_ + "OuterBoundary"s}},
-                  RotationMapForComposition{RotationMap{
-                      RotationMap2D{
-                          rotation_about_z_axis_function_of_time_name_},
-                      IdentityMap1D{}}})));
+                  RotationMapForComposition{
+                      RotationMap3D{rotation_function_of_time_name_}})));
     } else {
       block_maps[0] = block_maps[number_of_blocks_ - 1]->get_clone();
     }
@@ -625,10 +624,8 @@ Domain<3> BinaryCompactObject::create_domain() const {
                       expansion_map_outer_boundary_,
                       expansion_function_of_time_name_,
                       expansion_function_of_time_name_ + "OuterBoundary"}},
-                  RotationMapForComposition{RotationMap{
-                      RotationMap2D{
-                          rotation_about_z_axis_function_of_time_name_},
-                      IdentityMap1D{}}})));
+                  RotationMapForComposition{
+                      RotationMap3D{rotation_function_of_time_name_}})));
     } else {
       block_maps[12] = block_maps[number_of_blocks_ - 1]->get_clone();
     }
@@ -673,7 +670,7 @@ BinaryCompactObject::functions_of_time(
   std::unordered_map<std::string, double> expiration_times{
       {expansion_function_of_time_name_,
        std::numeric_limits<double>::infinity()},
-      {rotation_about_z_axis_function_of_time_name_,
+      {rotation_function_of_time_name_,
        std::numeric_limits<double>::infinity()},
       {size_map_function_of_time_names_[0],
        std::numeric_limits<double>::infinity()},
@@ -702,16 +699,17 @@ BinaryCompactObject::functions_of_time(
           1.0, initial_time_, asymptotic_velocity_outer_boundary_,
           decay_timescale_outer_boundary_velocity_);
 
-  // RotationAboutZAxisMap FunctionOfTime for the rotation angle about the z
-  // axis \f$\phi\f$.
-  result[rotation_about_z_axis_function_of_time_name_] =
-      std::make_unique<FunctionsOfTime::PiecewisePolynomial<3>>(
-          initial_time_,
-          std::array<DataVector, 4>{{{initial_rotation_angle_},
-                                     {initial_angular_velocity_},
-                                     {0.0},
-                                     {0.0}}},
-          expiration_times.at(rotation_about_z_axis_function_of_time_name_));
+  // RotationMap FunctionOfTime for the rotation angles about each axis.
+  // The initial rotation angles don't matter as we never actually use the
+  // angles themselves. We only use their derivatives (omega) to determine map
+  // parameters. In theory we could determine each initital angle from the input
+  // axis-angle representation, but we don't need to.
+  result[rotation_function_of_time_name_] =
+      std::make_unique<FunctionsOfTime::QuaternionFunctionOfTime<3>>(
+          initial_time_, std::array<DataVector, 1>{initial_quaternion_},
+          std::array<DataVector, 4>{
+              {{3, 0.0}, initial_angular_velocity_, {3, 0.0}, {3, 0.0}}},
+          expiration_times.at(rotation_function_of_time_name_));
 
   // CompressionMap FunctionOfTime for objects A and B
   for (size_t i = 0; i < size_map_function_of_time_names_.size(); i++) {

--- a/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.cpp
+++ b/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.cpp
@@ -101,7 +101,7 @@ void QuaternionFunctionOfTime<MaxDeriv>::solve_quaternion_ode(
 
   // Dense stepper
   auto dense_stepper = boost::numeric::odeint::make_dense_output(
-      1.0e-15, 1.0e-14,
+      1.0e-12, 1.0e-14,
       boost::numeric::odeint::runge_kutta_dopri5<
           boost::math::quaternion<double>, double,
           boost::math::quaternion<double>, double,

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -50,9 +50,8 @@ DomainCreator:
         InitialExpansionVelocity: 0.01
         AsymptoticVelocityOuterBoundary: -0.1
         DecayTimescaleOuterBoundaryVelocity: 5.0
-      RotationAboutZAxisMap:
-        InitialRotationAngle: 0.0
-        InitialAngularVelocity: 0.0
+      RotationMap:
+        InitialAngularVelocity: [0.0, 0.0, 0.0]
       SizeMap:
         InitialValues: [0.0, 0.0]
         InitialVelocities: [-0.1, -0.1]

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -55,9 +55,8 @@ DomainCreator:
         OuterBoundary: 1493.0
         AsymptoticVelocityOuterBoundary: -1.0e-6
         DecayTimescaleOuterBoundaryVelocity: 50.0
-      RotationAboutZAxisMap:
-        InitialRotationAngle: 0.0
-        InitialAngularVelocity: 0.0
+      RotationMap:
+        InitialAngularVelocity: [0.0, 0.0, 0.0]
       SizeMap:
         InitialValues: [0.0, 0.0]
         InitialVelocities: [0.0, 0.0]

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_RotationMatrixHelpers.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_RotationMatrixHelpers.cpp
@@ -65,94 +65,95 @@ void check_rotation_matrix_helpers_2d(const double init_omega,
   }
 }
 
-SPECTRE_TEST_CASE(
-    "Unit.Domain.CoordinateMaps.TimeDependent.RotationMatrixHelpers",
-    "[Unit][Domain]") {
+void test_rotation_matrix_helpers_2d() {
+  INFO("Dim = 2");
+  const double omega = 2.0;
+  const double check_time = 1.0;
+
+  const std::array<DataVector, 3> init_angle{DataVector{0.0}, DataVector{omega},
+                                             DataVector{0.0}};
+
+  const double theta = omega * check_time;
+  const Matrix expected_rot_matrix_z{{cos(theta), -sin(theta)},
+                                     {sin(theta), cos(theta)}};
+  const Matrix expected_rot_matrix_deriv_z{
+      {-2.0 * sin(theta), -2.0 * cos(theta)},
+      {2.0 * cos(theta), -2.0 * sin(theta)}};
+
+  check_rotation_matrix_helpers_2d(omega, expected_rot_matrix_z,
+                                   expected_rot_matrix_deriv_z, check_time);
+}
+
+void test_rotation_matrix_helpers_3d() {
+  INFO("Dim = 3");
   {
-    INFO("Dim = 2");
+    INFO("Rotation about z")
     const double omega = 2.0;
     const double check_time = 1.0;
 
     const std::array<DataVector, 3> init_angle{
-        DataVector{0.0}, DataVector{omega}, DataVector{0.0}};
+        DataVector{3, 0.0}, DataVector{{0.0, 0.0, omega}}, DataVector{3, 0.0}};
 
     const double theta = omega * check_time;
-    const Matrix expected_rot_matrix_z{{cos(theta), -sin(theta)},
-                                       {sin(theta), cos(theta)}};
+    const Matrix expected_rot_matrix_z{{cos(theta), -sin(theta), 0.0},
+                                       {sin(theta), cos(theta), 0.0},
+                                       {0.0, 0.0, 1.0}};
     const Matrix expected_rot_matrix_deriv_z{
-        {-2.0 * sin(theta), -2.0 * cos(theta)},
-        {2.0 * cos(theta), -2.0 * sin(theta)}};
+        {-2.0 * sin(theta), -2.0 * cos(theta), 0.0},
+        {2.0 * cos(theta), -2.0 * sin(theta), 0.0},
+        {0.0, 0.0, 0.0}};
 
-    check_rotation_matrix_helpers_2d(omega, expected_rot_matrix_z,
+    check_rotation_matrix_helpers_3d(init_angle, expected_rot_matrix_z,
                                      expected_rot_matrix_deriv_z, check_time);
   }
+
   {
-    INFO("Dim = 3");
-    {
-      INFO("Rotation about z")
-      const double omega = 2.0;
-      const double check_time = 1.0;
+    INFO("Rotation about x")
+    const double omega = 2.0;
+    const double check_time = 1.0;
 
-      const std::array<DataVector, 3> init_angle{DataVector{3, 0.0},
-                                                 DataVector{{0.0, 0.0, omega}},
-                                                 DataVector{3, 0.0}};
+    const std::array<DataVector, 3> init_angle{
+        DataVector{3, 0.0}, DataVector{{omega, 0.0, 0.0}}, DataVector{3, 0.0}};
 
-      const double theta = omega * check_time;
-      const Matrix expected_rot_matrix_z{{cos(theta), -sin(theta), 0.0},
-                                         {sin(theta), cos(theta), 0.0},
-                                         {0.0, 0.0, 1.0}};
-      const Matrix expected_rot_matrix_deriv_z{
-          {-2.0 * sin(theta), -2.0 * cos(theta), 0.0},
-          {2.0 * cos(theta), -2.0 * sin(theta), 0.0},
-          {0.0, 0.0, 0.0}};
+    const double theta = omega * check_time;
+    const Matrix expected_rot_matrix_x{{1.0, 0.0, 0.0},
+                                       {0.0, cos(theta), -sin(theta)},
+                                       {0.0, sin(theta), cos(theta)}};
+    const Matrix expected_rot_matrix_deriv_x{
+        {0.0, 0.0, 0.0},
+        {0.0, -2.0 * sin(theta), -2.0 * cos(theta)},
+        {0.0, 2.0 * cos(theta), -2.0 * sin(theta)}};
 
-      check_rotation_matrix_helpers_3d(init_angle, expected_rot_matrix_z,
-                                       expected_rot_matrix_deriv_z, check_time);
-    }
-
-    {
-      INFO("Rotation about x")
-      const double omega = 2.0;
-      const double check_time = 1.0;
-
-      const std::array<DataVector, 3> init_angle{DataVector{3, 0.0},
-                                                 DataVector{{omega, 0.0, 0.0}},
-                                                 DataVector{3, 0.0}};
-
-      const double theta = omega * check_time;
-      const Matrix expected_rot_matrix_x{{1.0, 0.0, 0.0},
-                                         {0.0, cos(theta), -sin(theta)},
-                                         {0.0, sin(theta), cos(theta)}};
-      const Matrix expected_rot_matrix_deriv_x{
-          {0.0, 0.0, 0.0},
-          {0.0, -2.0 * sin(theta), -2.0 * cos(theta)},
-          {0.0, 2.0 * cos(theta), -2.0 * sin(theta)}};
-
-      check_rotation_matrix_helpers_3d(init_angle, expected_rot_matrix_x,
-                                       expected_rot_matrix_deriv_x, check_time);
-    }
-
-    {
-      INFO("Rotation about y")
-      const double omega = 2.0;
-      const double check_time = 1.0;
-
-      const std::array<DataVector, 3> init_angle{DataVector{3, 0.0},
-                                                 DataVector{{0.0, omega, 0.0}},
-                                                 DataVector{3, 0.0}};
-
-      const double theta = omega * check_time;
-      const Matrix expected_rot_matrix_y{{cos(theta), 0.0, sin(theta)},
-                                         {0.0, 1.0, 0.0},
-                                         {-sin(theta), 0.0, cos(theta)}};
-      const Matrix expected_rot_matrix_deriv_y{
-          {-2.0 * sin(theta), 0.0, 2.0 * cos(theta)},
-          {0.0, 0.0, 0.0},
-          {-2.0 * cos(theta), 0.0, -2.0 * sin(theta)}};
-
-      check_rotation_matrix_helpers_3d(init_angle, expected_rot_matrix_y,
-                                       expected_rot_matrix_deriv_y, check_time);
-    }
+    check_rotation_matrix_helpers_3d(init_angle, expected_rot_matrix_x,
+                                     expected_rot_matrix_deriv_x, check_time);
   }
+
+  {
+    INFO("Rotation about y")
+    const double omega = 2.0;
+    const double check_time = 1.0;
+
+    const std::array<DataVector, 3> init_angle{
+        DataVector{3, 0.0}, DataVector{{0.0, omega, 0.0}}, DataVector{3, 0.0}};
+
+    const double theta = omega * check_time;
+    const Matrix expected_rot_matrix_y{{cos(theta), 0.0, sin(theta)},
+                                       {0.0, 1.0, 0.0},
+                                       {-sin(theta), 0.0, cos(theta)}};
+    const Matrix expected_rot_matrix_deriv_y{
+        {-2.0 * sin(theta), 0.0, 2.0 * cos(theta)},
+        {0.0, 0.0, 0.0},
+        {-2.0 * cos(theta), 0.0, -2.0 * sin(theta)}};
+
+    check_rotation_matrix_helpers_3d(init_angle, expected_rot_matrix_y,
+                                     expected_rot_matrix_deriv_y, check_time);
+  }
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.Domain.CoordinateMaps.TimeDependent.RotationMatrixHelpers",
+    "[Unit][Domain]") {
+  test_rotation_matrix_helpers_2d();
+  test_rotation_matrix_helpers_3d();
 }
 }  // namespace

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -27,6 +27,7 @@
 #include "Domain/Domain.hpp"
 #include "Domain/FunctionsOfTime/FixedSpeedCubic.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
 #include "Domain/OptionTags.hpp"
 #include "Domain/Protocols/Metavariables.hpp"
 #include "Domain/Structure/BlockNeighbor.hpp"  // IWYU pragma: keep
@@ -479,9 +480,8 @@ std::string create_option_string(const bool excise_A, const bool excise_B,
                             "      InitialExpansionVelocity: -0.1\n"
                             "      AsymptoticVelocityOuterBoundary: -0.1\n"
                             "      DecayTimescaleOuterBoundaryVelocity: 5.0\n"
-                            "    RotationAboutZAxisMap:\n"
-                            "      InitialRotationAngle: 2.0\n"
-                            "      InitialAngularVelocity: -0.2\n"
+                            "    RotationMap:\n"
+                            "      InitialAngularVelocity: [0.0, 0.0, -0.2]\n"
                             "    SizeMap:\n"
                             "      InitialValues: [0.0, 0.0]\n"
                             "      InitialVelocities: [-0.1, -0.2]\n"
@@ -571,7 +571,7 @@ void test_bbh_time_dependent_factory(const bool with_boundary_conditions,
                                with_boundary_conditions));
     }
   }();
-  const std::array<double, 4> times_to_check{{0.0, 4.4, 7.8}};
+  const std::array<double, 3> times_to_check{{0.0, 0.7, 1.6}};
 
   constexpr double initial_time = 0.0;
   constexpr double expected_time = 1.0;  // matches InitialTime: 1.0 above
@@ -582,7 +582,12 @@ void test_bbh_time_dependent_factory(const bool with_boundary_conditions,
   constexpr double expected_decay_timescale_outer_boundary_velocity =
       5.0;  // matches DecayTimescaleOuterBoundaryVelocity: 5.0 above
   std::array<DataVector, 3> expansion_factor_coefs{{{1.0}, {-0.1}, {0.0}}};
-  std::array<DataVector, 4> rotation_angle_coefs{{{2.0}, {-0.2}, {0.0}, {0.0}}};
+  const DataVector init_angular_vel{{0.0, 0.0, -0.2}};
+  std::array<DataVector, 1> quaternion_coefs{{{1.0, 0.0, 0.0, 0.0}}};
+  // Set initial angle for each axis to 0 because it doesn't matter. We don't
+  // use it or care about it.
+  std::array<DataVector, 4> rotation_angle_coefs{
+      {{3, 0.0}, init_angular_vel, {3, 0.0}, {3, 0.0}}};
   std::array<DataVector, 4> lambda_factor_a0_coefs{
       {{0.0}, {-0.1}, {0.01}, {0.0}}};
   std::array<DataVector, 4> lambda_factor_b0_coefs{
@@ -609,7 +614,8 @@ void test_bbh_time_dependent_factory(const bool with_boundary_conditions,
       std::pair<std::string, domain::FunctionsOfTime::PiecewisePolynomial<3>>,
       std::pair<std::string, domain::FunctionsOfTime::PiecewisePolynomial<2>>,
       std::pair<std::string, domain::FunctionsOfTime::FixedSpeedCubic>,
-      std::pair<std::string, domain::FunctionsOfTime::PiecewisePolynomial<3>>>
+      std::pair<std::string,
+                domain::FunctionsOfTime::QuaternionFunctionOfTime<3>>>
       expected_functions_of_time = std::make_tuple(
           std::pair<std::string,
                     domain::FunctionsOfTime::PiecewisePolynomial<3>>{
@@ -632,9 +638,9 @@ void test_bbh_time_dependent_factory(const bool with_boundary_conditions,
                expected_asymptotic_velocity_outer_boundary,
                expected_decay_timescale_outer_boundary_velocity}},
           std::pair<std::string,
-                    domain::FunctionsOfTime::PiecewisePolynomial<3>>{
+                    domain::FunctionsOfTime::QuaternionFunctionOfTime<3>>{
               rotation_name,
-              {expected_time, rotation_angle_coefs,
+              {expected_time, quaternion_coefs, rotation_angle_coefs,
                initial_expiration_times[rotation_name]}});
   std::unordered_map<std::string,
                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
@@ -649,8 +655,8 @@ void test_bbh_time_dependent_factory(const bool with_boundary_conditions,
           expected_asymptotic_velocity_outer_boundary,
           expected_decay_timescale_outer_boundary_velocity);
   functions_of_time[rotation_name] =
-      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<3>>(
-          initial_time, rotation_angle_coefs,
+      std::make_unique<domain::FunctionsOfTime::QuaternionFunctionOfTime<3>>(
+          initial_time, quaternion_coefs, rotation_angle_coefs,
           initial_expiration_times[rotation_name]);
   functions_of_time[size_a_name] =
       std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<3>>(
@@ -802,7 +808,7 @@ void test_parse_errors() {
 }
 }  // namespace
 
-// [[Timeout, 15]]
+// [[Timeout, 20]]
 SPECTRE_TEST_CASE("Unit.Domain.Creators.BinaryCompactObject.FactoryTests",
                   "[Domain][Unit]") {
   test_connectivity();


### PR DESCRIPTION
Control systems will require us to use the quaternion rotation map.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
When specifying input options for the `BinaryCompactObject` domain creator, replace
```
RotationAboutZAxisMap:
  InitialRotationAngle: 1.0
  InitialAngularVelocity: -0.5
```
with
```
RotationMap:
  InitialAngularVelocity: [0.0, 0.0, -0.5]
```
Note: The initial rotation angle is now always assumed to be zero and cannot be specified by the user.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
