### PR TITLE
Add more parameters and functions to BinaryTrajectories

### DIFF
--- a/tests/Unit/Helpers/PointwiseFunctions/PostNewtonian/BinaryTrajectories.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/PostNewtonian/BinaryTrajectories.hpp
@@ -19,20 +19,29 @@
  * \f}
  * In terms of these functions, the positions of objects 1 and 2 are
  * \f{align}{
- *   x_1(t) &= \frac{r(t)}{2}\cos\left[\Omega(t) t\right], \\
- *   y_1(t) &= \frac{r(t)}{2}\sin\left[\Omega(t) t\right], \\
- *   x_2(t) &= -\frac{r(t)}{2}\cos\left[\Omega(t) t\right], \\
- *   y_2(t) &= -\frac{r(t)}{2}\sin\left[\Omega(t) t\right], \\
- *   z_1(t) &= z_2(t) = 0.
+ *   x_1(t) &= \frac{r(t)}{2}\cos\left[\Omega(t) t\right] + v_x t, \\
+ *   y_1(t) &= \frac{r(t)}{2}\sin\left[\Omega(t) t\right], + v_y t\\
+ *   x_2(t) &= -\frac{r(t)}{2}\cos\left[\Omega(t) t\right], + v_x t\\
+ *   y_2(t) &= -\frac{r(t)}{2}\sin\left[\Omega(t) t\right], + v_y t\\
+ *   z_1(t) &= z_2(t) = v_z t.
  * \f} These trajectories are useful for, e.g., testing a horizon-tracking
  * control system.
  *
+ * \parblock
  * \note The trajectories could be generalized to higher post-Newtonian order if
  * needed.
+ * \endparblock
+ * \parblock
+ * \note If the `newtonian` argument is true, then this will just give Kepler's
+ * third law
+ * \endparblock
  */
 class BinaryTrajectories {
  public:
-  BinaryTrajectories(double initial_separation);
+  BinaryTrajectories(double initial_separation,
+                     const std::array<double, 3>& velocity =
+                         std::array<double, 3>{{0.0, 0.0, 0.0}},
+                     bool newtonian = false);
   BinaryTrajectories() = default;
   BinaryTrajectories(BinaryTrajectories&&) = default;
   BinaryTrajectories& operator=(BinaryTrajectories&&) = default;
@@ -40,11 +49,36 @@ class BinaryTrajectories {
   BinaryTrajectories& operator=(const BinaryTrajectories&) = default;
   ~BinaryTrajectories() = default;
 
+  /// Gives separation as function of time
   double separation(double time) const;
+  /// Gives orbital frequency \f$f\f$ as a function of time calculated from
+  /// Kepler's third law \f$f^2\propto\frac{1}{a^3}\f$ where \f$a\f$ is
+  /// calculated from `separation`.
   double orbital_frequency(double time) const;
+  /// Gives the angular velocity of the objects as a function of time.
+  /// Calculated by \f$\omega(t)=\frac{d\theta(t)}{dt}\f$ where
+  /// \f$\theta(t)=f(t)t\f$.
+  ///
+  /// \note For the newtonian case, `orbital_frequency` and `angular_velocity`
+  /// give the same result because the orbital frequency is independent of time.
+  double angular_velocity(const double time) const;
+  /// Gives the positions of the two objects as a function of time.
   std::pair<std::array<double, 3>, std::array<double, 3>> positions(
       double time) const;
+  /// Same as `positions`, except the separation remains constant (equal to the
+  /// initial separation).
+  ///
+  /// \note This is useful for testing the rotation control system by itself,
+  /// because we want the frequency to vary, but the separation to remain the
+  /// same. This way, we don't have to worry about expansion effects.
+  std::pair<std::array<double, 3>, std::array<double, 3>>
+  positions_no_expansion(double time) const;
 
  private:
+  std::pair<std::array<double, 3>, std::array<double, 3>> position_impl(
+      double time, double separation) const;
+
   double initial_separation_fourth_power_;
+  std::array<double, 3> velocity_;
+  bool newtonian_;
 };

--- a/tests/Unit/Helpers/Tests/PointwiseFunctions/PostNewtonian/BinaryTrajectories.py
+++ b/tests/Unit/Helpers/Tests/PointwiseFunctions/PostNewtonian/BinaryTrajectories.py
@@ -4,31 +4,42 @@
 import numpy as np
 
 initial_separation = 15.366
+initial_velocity = np.array([0.1, -0.2, 0.3])
 
 
-def separation(time, init_sep):
-    return (init_sep**4 - 12.8 * time)**0.25
+def separation(time, init_sep, newtonian):
+    correction = 0.0 if newtonian else 12.8 * time
+    return (init_sep**4 - correction)**0.25
 
 
-def orbital_frequency(time, init_sep):
-    return separation(time, init_sep)**-1.5
+def orbital_frequency(time, init_sep, newtonian):
+    return separation(time, init_sep, newtonian)**-1.5
 
 
-def positions1(time):
-    init_sep = initial_separation
+def angular_velocity(time, init_sep, newtonian):
+    correction = 0.0 if newtonian else 4.8 * (init_sep**4 -
+                                              12.8 * time)**-1.375
+    return orbital_frequency(time, init_sep, newtonian) + correction * time
+
+
+def position_helper(time, init_sep, newtonian, sign, no_expansion):
+    sep = separation(time, init_sep, True) if no_expansion else separation(
+        time, init_sep, newtonian)
+    freq = orbital_frequency(time, init_sep, newtonian)
     return [
-        0.5 * separation(time, init_sep) *
-        np.cos(orbital_frequency(time, init_sep) * time),
-        0.5 * separation(time, init_sep) *
-        np.sin(orbital_frequency(time, init_sep) * time), 0.0
+        sign * 0.5 * sep * np.cos(freq * time) + initial_velocity[0] * time,
+        sign * 0.5 * sep * np.sin(freq * time) + initial_velocity[1] * time,
+        initial_velocity[2] * time
     ]
 
 
-def positions2(time):
-    init_sep = initial_separation
-    return [
-        -0.5 * separation(time, init_sep) *
-        np.cos(orbital_frequency(time, init_sep) * time),
-        -0.5 * separation(time, init_sep) *
-        np.sin(orbital_frequency(time, init_sep) * time), 0.0
-    ]
+def positions1(time, newtonian, no_expansion):
+    newt = True if newtonian > 0.0 else False
+    no_exp = True if no_expansion > 0.0 else False
+    return position_helper(time, initial_separation, newt, -1.0, no_exp)
+
+
+def positions2(time, newtonian, no_expansion):
+    newt = True if newtonian > 0.0 else False
+    no_exp = True if no_expansion > 0.0 else False
+    return position_helper(time, initial_separation, newt, +1.0, no_exp)

--- a/tests/Unit/Helpers/Tests/PointwiseFunctions/PostNewtonian/Test_BinaryTrajectories.cpp
+++ b/tests/Unit/Helpers/Tests/PointwiseFunctions/PostNewtonian/Test_BinaryTrajectories.cpp
@@ -13,16 +13,35 @@
 #include "Helpers/PointwiseFunctions/PostNewtonian/BinaryTrajectories.hpp"
 
 namespace {
-constexpr double initial_separation{
-    15.366};  // must match value in BinaryTrajectories.py
-std::array<double, 3> positions1(const double time) {
-  const BinaryTrajectories expected{initial_separation};
-  return expected.positions(time).first;
+// must match value in BinaryTrajectories.py
+constexpr double initial_separation{15.366};
+const std::array<double, 3> initial_velocity{0.1, -0.2, 0.3};
+
+// Since we can't pass bools to these functions, pass more doubles.
+// - newtonian: If it's positive, newtonian is true. If it's negative, newtonian
+//   is false.
+// - no_expansion: If it's positive, call the `positions_no_expansion` function.
+//   If it's negative, just call the `positions` function.
+std::array<double, 3> positions1(const double time, const double newtonian,
+                                 const double no_expansion) {
+  const bool newt = newtonian > 0.0 ? true : false;
+  BinaryTrajectories expected{initial_separation, initial_velocity, newt};
+  if (no_expansion > 0.0) {
+    return expected.positions_no_expansion(time).first;
+  } else {
+    return expected.positions(time).first;
+  }
 }
 
-std::array<double, 3> positions2(const double time) {
-  const BinaryTrajectories expected{initial_separation};
-  return expected.positions(time).second;
+std::array<double, 3> positions2(const double time, const double newtonian,
+                                 const double no_expansion) {
+  const bool newt = newtonian > 0.0 ? true : false;
+  BinaryTrajectories expected{initial_separation, initial_velocity, newt};
+  if (no_expansion > 0.0) {
+    return expected.positions_no_expansion(time).second;
+  } else {
+    return expected.positions(time).second;
+  }
 }
 }  // namespace
 
@@ -30,21 +49,33 @@ SPECTRE_TEST_CASE("Test.TestHelpers.PostNewtonian.BinaryTrajectories",
                   "[PointwiseFunctions][Unit]") {
   pypp::SetupLocalPythonEnvironment local_python_env(
       "Helpers/Tests/PointwiseFunctions/PostNewtonian/");
-  const BinaryTrajectories expected{initial_separation};
 
-  pypp::check_with_random_values<1>(
-      &BinaryTrajectories::separation, BinaryTrajectories{initial_separation},
-      "BinaryTrajectories", {"separation"}, {{{-100.0, 100.0}}},
-      std::make_tuple(initial_separation), initial_separation);
-  pypp::check_with_random_values<1>(
-      &BinaryTrajectories::orbital_frequency,
-      BinaryTrajectories{initial_separation}, "BinaryTrajectories",
-      {"orbital_frequency"}, {{{-100.0, 100.0}}},
-      std::make_tuple(initial_separation), initial_separation);
-  pypp::check_with_random_values<1>(&positions1, "BinaryTrajectories",
-                                    "positions1", {{{-100.0, 100.0}}},
-                                    initial_separation);
-  pypp::check_with_random_values<1>(&positions2, "BinaryTrajectories",
-                                    "positions2", {{{-100.0, 100.0}}},
-                                    initial_separation);
+  for (const bool newtonian : {true, false}) {
+    const BinaryTrajectories expected{initial_separation, initial_velocity,
+                                      newtonian};
+    pypp::check_with_random_values<1>(
+        &BinaryTrajectories::separation,
+        BinaryTrajectories{initial_separation, initial_velocity, newtonian},
+        "BinaryTrajectories", {"separation"}, {{{-100.0, 100.0}}},
+        std::make_tuple(initial_separation, newtonian), initial_separation);
+    pypp::check_with_random_values<1>(
+        &BinaryTrajectories::orbital_frequency,
+        BinaryTrajectories{initial_separation, initial_velocity, newtonian},
+        "BinaryTrajectories", {"orbital_frequency"}, {{{-100.0, 100.0}}},
+        std::make_tuple(initial_separation, newtonian), initial_separation);
+    pypp::check_with_random_values<1>(
+        &BinaryTrajectories::angular_velocity,
+        BinaryTrajectories{initial_separation, initial_velocity, newtonian},
+        "BinaryTrajectories", {"angular_velocity"}, {{{-100.0, 100.0}}},
+        std::make_tuple(initial_separation, newtonian), initial_separation);
+  }
+  // Run these a few times so we get a good mix
+  for (size_t i = 0; i < 8; i++) {
+    pypp::check_with_random_values<1>(&positions1, "BinaryTrajectories",
+                                      "positions1", {{{-100.0, 100.0}}},
+                                      initial_separation);
+    pypp::check_with_random_values<1>(&positions2, "BinaryTrajectories",
+                                      "positions2", {{{-100.0, 100.0}}},
+                                      initial_separation);
+  }
 }


### PR DESCRIPTION
These things will be helpful for testing control systems:
- `velocity` parameter. The CoM of the binary will move with this
  constant velocity. Default is zero velocity.
- `newtonian` bool to indicate using Newtonian trajectories instead
  of PN trajectories (Default is false, i.e. PN trajectory)
- `angulary_velocity` function. Returns the angular velocity.
- `positions_no_expansion` function. Regardless of Newtonian or PN,
  the orbit is circular, but the frequency of the orbit follows
  either Newtonain or PN, whetever was specified. (Note: these
  positions are not physical, just useful for testing control
  systems)

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
