### PR TITLE
Fix reference in brigand docs

### DIFF
--- a/docs/DevGuide/Brigand.md
+++ b/docs/DevGuide/Brigand.md
@@ -649,8 +649,8 @@ A pair of types, with easy access to each type in the pair.
 \par
 An unordered collection of distinct types.  Trying to create a `set` with
 duplicate entries is an error (but \ref set_insert "tmpl::insert" ignores
-duplicate entries).  See the section on \ref set_operations "operations on
-sets" for details.
+duplicate entries).  See the section on \ref set_operations
+"operations on sets" for details.
 \snippet Test_TMPLDocumentation.cpp tmpl::set
 
 \par
@@ -1006,7 +1006,7 @@ also work.
 \subsubsection append append<Sequence...>
 
 \par
-Contatenates all of its arguments, keeping the head of the first (or \ref list
+Concatenates all of its arguments, keeping the head of the first (or \ref list
 "tmpl::list" if passed no arguments).
 \snippet Test_TMPLDocumentation.cpp tmpl::append
 


### PR DESCRIPTION
The brigand docs were rendering incorrectly. Apparently doxygen doesn't like when the name of a reference is split up while inside quotes.

Also fix a typo.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
