### PR TITLE
Add `file_system::glob`, support importing volume data from multiple files

### DIFF
--- a/src/IO/Importers/Actions/ReadVolumeData.hpp
+++ b/src/IO/Importers/Actions/ReadVolumeData.hpp
@@ -66,7 +66,7 @@ namespace importers::Actions {
 template <typename ImporterOptionsGroup, typename FieldTagsList>
 struct ReadVolumeData {
   using const_global_cache_tags =
-      tmpl::list<Tags::FileName<ImporterOptionsGroup>,
+      tmpl::list<Tags::FileGlob<ImporterOptionsGroup>,
                  Tags::Subgroup<ImporterOptionsGroup>,
                  Tags::ObservationValue<ImporterOptionsGroup>>;
 
@@ -111,7 +111,7 @@ struct ReadVolumeData {
  * - The `ImporterOptionsGroup` parameter specifies the \ref OptionGroupsGroup
  * "options group" in the input file that provides the following run-time
  * options:
- *   - `importers::OptionTags::FileName`
+ *   - `importers::OptionTags::FileGlob`
  *   - `importers::OptionTags::Subgroup`
  *   - `importers::OptionTags::ObservationValue`
  * - The `FieldTagsList` parameter specifies a typelist of tensor tags that
@@ -164,7 +164,7 @@ struct ReadAllVolumeDataAndDistribute {
 
     // Open the volume data file
     h5::H5File<h5::AccessType::ReadOnly> h5file(
-        Parallel::get<Tags::FileName<ImporterOptionsGroup>>(cache));
+        Parallel::get<Tags::FileGlob<ImporterOptionsGroup>>(cache));
     constexpr size_t version_number = 0;
     const auto& volume_file = h5file.get<h5::VolumeData>(
         "/" + Parallel::get<Tags::Subgroup<ImporterOptionsGroup>>(cache),

--- a/src/IO/Importers/Tags.hpp
+++ b/src/IO/Importers/Tags.hpp
@@ -33,7 +33,7 @@ struct Group {
  * \brief The file to read data from.
  */
 template <typename ImporterOptionsGroup>
-struct FileName {
+struct FileGlob {
   static_assert(
       std::is_same_v<typename ImporterOptionsGroup::group, Group>,
       "The importer options should be placed in the 'Importers' option "
@@ -83,12 +83,12 @@ namespace Tags {
  * \brief The file to read data from.
  */
 template <typename ImporterOptionsGroup>
-struct FileName : db::SimpleTag {
+struct FileGlob : db::SimpleTag {
   static std::string name() {
-    return "FileName(" + Options::name<ImporterOptionsGroup>() + ")";
+    return "FileGlob(" + Options::name<ImporterOptionsGroup>() + ")";
   }
   using type = std::string;
-  using option_tags = tmpl::list<OptionTags::FileName<ImporterOptionsGroup>>;
+  using option_tags = tmpl::list<OptionTags::FileGlob<ImporterOptionsGroup>>;
 
   static constexpr bool pass_metavariables = false;
   static type create_from_options(const type& file_name) { return file_name; }

--- a/src/Utilities/FileSystem.cpp
+++ b/src/Utilities/FileSystem.cpp
@@ -11,6 +11,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <dirent.h>
+#include <glob.h>
 #include <libgen.h>
 #include <memory>
 #include <regex>
@@ -262,5 +263,20 @@ void rm(const std::string& path, bool recursive) {
                                     << "' because an unknown error occurred.");
     // LCOV_EXCL_STOP
   }
+}
+
+std::vector<std::string> glob(const std::string& pattern) {
+  glob_t buffer;
+  const int return_value =
+      ::glob(pattern.c_str(), GLOB_TILDE, nullptr, &buffer);
+  if (return_value != 0) {
+    ERROR("Unable to resolve glob '" + pattern + "': " + std::strerror(errno));
+  }
+  std::vector<std::string> file_names(
+      buffer.gl_pathv,
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+      buffer.gl_pathv + buffer.gl_pathc);
+  globfree(&buffer);
+  return file_names;
 }
 }  // namespace file_system

--- a/src/Utilities/FileSystem.hpp
+++ b/src/Utilities/FileSystem.hpp
@@ -137,4 +137,10 @@ std::vector<std::string> ls(const std::string& dir_name = "./");
  * behaves like `rm -r`, otherwise like `rm` but will delete an empty directory
  */
 void rm(const std::string& path, bool recursive);
+
+/*!
+ * \ingroup FileSystemGroup
+ * \brief Get a list of files matching the given glob pattern
+ */
+std::vector<std::string> glob(const std::string& pattern);
 }  // namespace file_system

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -228,7 +228,7 @@ ApparentHorizons:
 # on the same grid as specified by the domain given above
 Importers:
   NumericInitialData:
-    FileName: "/path/to/initial_data.h5"
+    FileGlob: "/path/to/initial_data.h5"
     Subgroup: "element_data"
     ObservationValue: 0.0
 

--- a/tests/Unit/IO/Importers/CMakeLists.txt
+++ b/tests/Unit/IO/Importers/CMakeLists.txt
@@ -12,7 +12,19 @@ add_test_library(
   ${LIBRARY}
   "IO/Importers"
   "${LIBRARY_SOURCES}"
-  "Domain;IO;Importers;Options"
+  ""
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  DataStructures
+  DomainStructure
+  IO
+  Importers
+  Options
+  Spectral
+  Utilities
   )
 
 add_dependencies(

--- a/tests/Unit/IO/Importers/Test_Tags.cpp
+++ b/tests/Unit/IO/Importers/Test_Tags.cpp
@@ -24,8 +24,8 @@ SPECTRE_TEST_CASE("Unit.IO.Importers.Tags", "[Unit][IO]") {
   TestHelpers::db::test_simple_tag<importers::Tags::ElementDataAlreadyRead>(
       "ElementDataAlreadyRead");
   TestHelpers::db::test_simple_tag<
-      importers::Tags::FileName<ExampleVolumeData>>(
-      "FileName(ExampleVolumeData)");
+      importers::Tags::FileGlob<ExampleVolumeData>>(
+      "FileGlob(ExampleVolumeData)");
   TestHelpers::db::test_simple_tag<
       importers::Tags::Subgroup<ExampleVolumeData>>(
       "Subgroup(ExampleVolumeData)");
@@ -34,17 +34,17 @@ SPECTRE_TEST_CASE("Unit.IO.Importers.Tags", "[Unit][IO]") {
       "ObservationValue(ExampleVolumeData)");
 
   Options::Parser<
-      tmpl::list<importers::OptionTags::FileName<ExampleVolumeData>,
+      tmpl::list<importers::OptionTags::FileGlob<ExampleVolumeData>,
                  importers::OptionTags::Subgroup<ExampleVolumeData>,
                  importers::OptionTags::ObservationValue<ExampleVolumeData>>>
       opts("");
   opts.parse(
       "Importers:\n"
       "  ExampleVolumeData:\n"
-      "    FileName: File.name\n"
+      "    FileGlob: File.name\n"
       "    Subgroup: data.group\n"
       "    ObservationValue: 1.");
-  CHECK(opts.get<importers::OptionTags::FileName<ExampleVolumeData>>() ==
+  CHECK(opts.get<importers::OptionTags::FileGlob<ExampleVolumeData>>() ==
         "File.name");
   CHECK(opts.get<importers::OptionTags::Subgroup<ExampleVolumeData>>() ==
         "data.group");

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm.hpp
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm.hpp
@@ -207,17 +207,17 @@ struct WriteTestData {
       const ParallelComponent* const /*meta*/) {
     // The data may be in a shared file, so first clean both, then write both
     clean_test_data<false>(
-        get<importers::Tags::FileName<VolumeDataOptions<Grid::Fine>>>(box));
+        get<importers::Tags::FileGlob<VolumeDataOptions<Grid::Fine>>>(box));
     clean_test_data<false>(
-        get<importers::Tags::FileName<VolumeDataOptions<Grid::Coarse>>>(box));
+        get<importers::Tags::FileGlob<VolumeDataOptions<Grid::Coarse>>>(box));
     write_test_data<Dim>(
-        get<importers::Tags::FileName<VolumeDataOptions<Grid::Fine>>>(box),
+        get<importers::Tags::FileGlob<VolumeDataOptions<Grid::Fine>>>(box),
         get<importers::Tags::Subgroup<VolumeDataOptions<Grid::Fine>>>(box),
         get<importers::Tags::ObservationValue<VolumeDataOptions<Grid::Fine>>>(
             box),
         fine_volume_data<Dim>);
     write_test_data<Dim>(
-        get<importers::Tags::FileName<VolumeDataOptions<Grid::Coarse>>>(box),
+        get<importers::Tags::FileGlob<VolumeDataOptions<Grid::Coarse>>>(box),
         get<importers::Tags::Subgroup<VolumeDataOptions<Grid::Coarse>>>(box),
         get<importers::Tags::ObservationValue<VolumeDataOptions<Grid::Coarse>>>(
             box),
@@ -237,11 +237,11 @@ struct CleanTestData {
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
     clean_test_data<true>(
-        get<importers::Tags::FileName<VolumeDataOptions<Grid::Fine>>>(box));
-    if (get<importers::Tags::FileName<VolumeDataOptions<Grid::Coarse>>>(box) !=
-        get<importers::Tags::FileName<VolumeDataOptions<Grid::Fine>>>(box)) {
+        get<importers::Tags::FileGlob<VolumeDataOptions<Grid::Fine>>>(box));
+    if (get<importers::Tags::FileGlob<VolumeDataOptions<Grid::Coarse>>>(box) !=
+        get<importers::Tags::FileGlob<VolumeDataOptions<Grid::Fine>>>(box)) {
       clean_test_data<true>(
-          get<importers::Tags::FileName<VolumeDataOptions<Grid::Coarse>>>(box));
+          get<importers::Tags::FileGlob<VolumeDataOptions<Grid::Coarse>>>(box));
     }
     return {std::move(box), true};
   }

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm1D.yaml
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm1D.yaml
@@ -3,10 +3,10 @@
 
 Importers:
   FineVolumeData:
-    FileName: "Test_DataImporterAlgorithm1D_fine_data.h5"
+    FileGlob: "Test_DataImporterAlgorithm1D_fine_data.h5"
     Subgroup: "test_data"
     ObservationValue: 3.
   CoarseVolumeData:
-    FileName: "Test_DataImporterAlgorithm1D_coarse_data.h5"
+    FileGlob: "Test_DataImporterAlgorithm1D_coarse_data.h5"
     Subgroup: "test_data"
     ObservationValue: 2.

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm2D.yaml
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm2D.yaml
@@ -4,11 +4,11 @@
 # [importer_options]
 Importers:
   FineVolumeData:
-    FileName: "Test_DataImporterAlgorithm2D_shared.h5"
+    FileGlob: "Test_DataImporterAlgorithm2D_shared.h5"
     Subgroup: "fine_data"
     ObservationValue: 3.
   CoarseVolumeData:
-    FileName: "Test_DataImporterAlgorithm2D_shared.h5"
+    FileGlob: "Test_DataImporterAlgorithm2D_shared.h5"
     Subgroup: "coarse_data"
     ObservationValue: 2.
 # [importer_options]

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm3D.yaml
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm3D.yaml
@@ -3,10 +3,10 @@
 
 Importers:
   FineVolumeData:
-    FileName: "Test_DataImporterAlgorithm3D_shared.h5"
+    FileGlob: "Test_DataImporterAlgorithm3D_shared.h5"
     Subgroup: "fine_data"
     ObservationValue: 3.
   CoarseVolumeData:
-    FileName: "Test_DataImporterAlgorithm3D_shared.h5"
+    FileGlob: "Test_DataImporterAlgorithm3D_shared.h5"
     Subgroup: "coarse_data"
     ObservationValue: 2.

--- a/tests/Unit/Utilities/Test_FileSystem.cpp
+++ b/tests/Unit/Utilities/Test_FileSystem.cpp
@@ -95,6 +95,17 @@ SPECTRE_TEST_CASE("Unit.Utilities.FileSystem", "[Unit][Utilities]") {
     file_system::create_directory("/"s);
     CHECK(file_system::check_if_dir_exists("/"s));
   }
+  {
+    INFO("glob");
+    std::fstream file1("glob1.txt", file1.out);
+    file1.close();
+    std::fstream file2("glob2.txt", file2.out);
+    file2.close();
+    CHECK(file_system::glob("glob*.txt") ==
+          std::vector<std::string>{"glob1.txt", "glob2.txt"});
+    file_system::rm("glob1.txt", false);
+    file_system::rm("glob2.txt", false);
+  }
 }
 
 // [[OutputRegex, Failed to find a file in the given path: '/']]

--- a/tests/Unit/Utilities/Test_FileSystem.cpp
+++ b/tests/Unit/Utilities/Test_FileSystem.cpp
@@ -8,36 +8,93 @@
 
 #include "Utilities/FileSystem.hpp"
 
-SPECTRE_TEST_CASE("Unit.Utilities.FileSystem.get_parent_path",
-                  "[Unit][Utilities]") {
-  // [get_parent_path]
-  CHECK("/test/path/to/dir"s ==
-        file_system::get_parent_path("/test/path/to/dir/dummy.txt"));
-  CHECK("/test/path/to"s == file_system::get_parent_path("/test/path/to/dir/"));
-  CHECK("/"s == file_system::get_parent_path("/"));
-  CHECK("path/to/dir"s ==
-        file_system::get_parent_path("path/to/dir/dummy.txt"));
-  CHECK("/usr"s == file_system::get_parent_path("/usr/lib/"));
-  CHECK("/"s == file_system::get_parent_path("/usr"));
-  CHECK("."s == file_system::get_parent_path("usr"));
-  CHECK("."s == file_system::get_parent_path(".."));
-  CHECK("."s == file_system::get_parent_path(""));
-  // [get_parent_path]
-}
+SPECTRE_TEST_CASE("Unit.Utilities.FileSystem", "[Unit][Utilities]") {
+  {
+    INFO("get_parent_path");
+    // [get_parent_path]
+    CHECK("/test/path/to/dir"s ==
+          file_system::get_parent_path("/test/path/to/dir/dummy.txt"));
+    CHECK("/test/path/to"s ==
+          file_system::get_parent_path("/test/path/to/dir/"));
+    CHECK("/"s == file_system::get_parent_path("/"));
+    CHECK("path/to/dir"s ==
+          file_system::get_parent_path("path/to/dir/dummy.txt"));
+    CHECK("/usr"s == file_system::get_parent_path("/usr/lib/"));
+    CHECK("/"s == file_system::get_parent_path("/usr"));
+    CHECK("."s == file_system::get_parent_path("usr"));
+    CHECK("."s == file_system::get_parent_path(".."));
+    CHECK("."s == file_system::get_parent_path(""));
+    // [get_parent_path]
+  }
+  {
+    INFO("get_file_name");
+    // [get_file_name]
+    CHECK("dummy.txt"s ==
+          file_system::get_file_name("/test/path/to/dir/dummy.txt"));
+    CHECK(".dummy.txt"s ==
+          file_system::get_file_name("/test/path/to/dir/.dummy.txt"));
+    CHECK("dummy.txt"s == file_system::get_file_name("./dummy.txt"));
+    CHECK("dummy.txt"s == file_system::get_file_name("../dummy.txt"));
+    CHECK(".dummy.txt"s == file_system::get_file_name(".dummy.txt"));
+    CHECK("dummy.txt"s == file_system::get_file_name("dummy.txt"));
+    CHECK(".dummy"s == file_system::get_file_name(".dummy"));
+    // [get_file_name]
+  }
+  {
+    INFO("get_absolute_path");
+    CHECK(file_system::cwd() == file_system::get_absolute_path("./"));
+  }
+  {
+    INFO("check_if_exists");
+    CHECK(file_system::check_if_dir_exists("./"));
+    std::fstream file("check_if_exists.txt", file.out);
+    file.close();
+    CHECK(file_system::check_if_file_exists("./check_if_exists.txt"));
+    CHECK(0 == file_system::file_size("./check_if_exists.txt"));
 
-SPECTRE_TEST_CASE("Unit.Utilities.FileSystem.get_file_name",
-                  "[Unit][Utilities]") {
-  // [get_file_name]
-  CHECK("dummy.txt"s ==
-        file_system::get_file_name("/test/path/to/dir/dummy.txt"));
-  CHECK(".dummy.txt"s ==
-        file_system::get_file_name("/test/path/to/dir/.dummy.txt"));
-  CHECK("dummy.txt"s == file_system::get_file_name("./dummy.txt"));
-  CHECK("dummy.txt"s == file_system::get_file_name("../dummy.txt"));
-  CHECK(".dummy.txt"s == file_system::get_file_name(".dummy.txt"));
-  CHECK("dummy.txt"s == file_system::get_file_name("dummy.txt"));
-  CHECK(".dummy"s == file_system::get_file_name(".dummy"));
-  // [get_file_name]
+    file = std::fstream("check_if_exists.txt", file.out);
+    file << "Write something";
+    file.close();
+    CHECK(0 < file_system::file_size("./check_if_exists.txt"));
+
+    file_system::rm("./check_if_exists.txt", false);
+    CHECK_FALSE(file_system::check_if_file_exists("./check_if_exists.txt"));
+  }
+  {
+    INFO("create_and_rm_directory");
+    const std::string dir_one(
+        "./create_and_rm_directory/nested///nested2/nested3///");
+    file_system::create_directory(dir_one);
+    CHECK(file_system::check_if_dir_exists(dir_one));
+    const std::string dir_two(
+        "./create_and_rm_directory/nested/nested2/nested4");
+    file_system::create_directory(dir_two);
+    CHECK(file_system::check_if_dir_exists(dir_two));
+    std::fstream file(
+        "./create_and_rm_directory//nested/nested2/nested4/"
+        "check_if_exists.txt",
+        file.out);
+    file.close();
+    // Check that creating an existing directory does nothing
+    file_system::create_directory(dir_two);
+    CHECK(file_system::check_if_dir_exists(dir_two));
+    CHECK(file_system::check_if_file_exists(dir_two + "/check_if_exists.txt"s));
+    file_system::rm("./create_and_rm_directory"s, true);
+    CHECK_FALSE(file_system::check_if_dir_exists("./create_and_rm_directory"s));
+  }
+  {
+    INFO("create_and_rm_empty_directory");
+    const std::string dir_name("./create_and_rm_empty_directory");
+    file_system::create_directory(dir_name);
+    CHECK(file_system::check_if_dir_exists(dir_name));
+    file_system::rm(dir_name, false);
+    CHECK_FALSE(file_system::check_if_dir_exists(dir_name));
+  }
+  {
+    INFO("create_dir_root");
+    file_system::create_directory("/"s);
+    CHECK(file_system::check_if_dir_exists("/"s));
+  }
 }
 
 // [[OutputRegex, Failed to find a file in the given path: '/']]
@@ -54,11 +111,6 @@ SPECTRE_TEST_CASE("Unit.Utilities.FileSystem.get_file_name_empty_path",
   static_cast<void>(file_system::get_file_name(""));
 }
 
-SPECTRE_TEST_CASE("Unit.Utilities.FileSystem.get_absolute_path",
-                  "[Unit][Utilities]") {
-  CHECK(file_system::cwd() == file_system::get_absolute_path("./"));
-}
-
 // [[OutputRegex, Failed to convert to absolute path because one of the path
 // components does not exist. Relative path is]]
 SPECTRE_TEST_CASE("Unit.Utilities.FileSystem.get_absolute_path_nonexistent",
@@ -66,23 +118,6 @@ SPECTRE_TEST_CASE("Unit.Utilities.FileSystem.get_absolute_path_nonexistent",
   ERROR_TEST();
   static_cast<void>(
       file_system::get_absolute_path("./get_absolute_path_nonexistent/"));
-}
-
-SPECTRE_TEST_CASE("Unit.Utilities.FileSystem.check_if_exists",
-                  "[Unit][Utilities]") {
-  CHECK(file_system::check_if_dir_exists("./"));
-  std::fstream file("check_if_exists.txt", file.out);
-  file.close();
-  CHECK(file_system::check_if_file_exists("./check_if_exists.txt"));
-  CHECK(0 == file_system::file_size("./check_if_exists.txt"));
-
-  file = std::fstream("check_if_exists.txt", file.out);
-  file << "Write something";
-  file.close();
-  CHECK(0 < file_system::file_size("./check_if_exists.txt"));
-
-  file_system::rm("./check_if_exists.txt", false);
-  CHECK_FALSE(file_system::check_if_file_exists("./check_if_exists.txt"));
 }
 
 // [[OutputRegex, Failed to check if path points to a file because the path is
@@ -102,47 +137,11 @@ SPECTRE_TEST_CASE("Unit.Utilities.FileSystem.file_size_error",
   CHECK(file_system::file_size("./file_size_error.txt"));
 }
 
-SPECTRE_TEST_CASE("Unit.Utilities.FileSystem.create_and_rm_directory",
-                  "[Unit][Utilities]") {
-  const std::string dir_one(
-      "./create_and_rm_directory/nested///nested2/nested3///");
-  file_system::create_directory(dir_one);
-  CHECK(file_system::check_if_dir_exists(dir_one));
-  const std::string dir_two("./create_and_rm_directory/nested/nested2/nested4");
-  file_system::create_directory(dir_two);
-  CHECK(file_system::check_if_dir_exists(dir_two));
-  std::fstream file(
-      "./create_and_rm_directory//nested/nested2/nested4/check_if_exists.txt",
-      file.out);
-  file.close();
-  // Check that creating an existing directory does nothing
-  file_system::create_directory(dir_two);
-  CHECK(file_system::check_if_dir_exists(dir_two));
-  CHECK(file_system::check_if_file_exists(dir_two + "/check_if_exists.txt"s));
-  file_system::rm("./create_and_rm_directory"s, true);
-  CHECK_FALSE(file_system::check_if_dir_exists("./create_and_rm_directory"s));
-}
-
-SPECTRE_TEST_CASE("Unit.Utilities.FileSystem.create_and_rm_empty_directory",
-                  "[Unit][Utilities]") {
-  const std::string dir_name("./create_and_rm_empty_directory");
-  file_system::create_directory(dir_name);
-  CHECK(file_system::check_if_dir_exists(dir_name));
-  file_system::rm(dir_name, false);
-  CHECK_FALSE(file_system::check_if_dir_exists(dir_name));
-}
-
 // [[OutputRegex, Cannot create a directory that has no name]]
 SPECTRE_TEST_CASE("Unit.Utilities.FileSystem.create_dir_error_cannot_be_empty",
                   "[Unit][Utilities]") {
   ERROR_TEST();
   file_system::create_directory(""s);
-}
-
-SPECTRE_TEST_CASE("Unit.Utilities.FileSystem.create_dir_root",
-                  "[Unit][Utilities]") {
-  file_system::create_directory("/"s);
-  CHECK(file_system::check_if_dir_exists("/"s));
 }
 
 // [[OutputRegex, Could not delete file './rm_error_not_empty' because the


### PR DESCRIPTION
## Proposed changes

This allows importing volume data from multiple files, e.g., one volume file per node as written by the observers.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
In input files with `Importers`, change the `FileName` option to `FileGlob`.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
