### PR TITLE
Add function to write control system data to disk

### DIFF
--- a/src/ControlSystem/Actions/Initialization.hpp
+++ b/src/ControlSystem/Actions/Initialization.hpp
@@ -33,6 +33,7 @@ namespace Actions {
  *   - `control_system::Tags::Controller<2>`
  *   - `control_system::Tags::TimescaleTuner`
  *   - `control_system::Tags::ControlSystemName`
+ *   - `control_system::Tags::WriteDataToDisk`
  * - Removes: Nothing
  * - Modifies:
  *   - `control_system::Tags::Controller<2>`
@@ -46,7 +47,11 @@ struct Initialize {
   static constexpr size_t deriv_order = ControlSystem::deriv_order;
 
   using initialization_tags =
-      tmpl::list<control_system::Tags::ControlSystemInputs<ControlSystem>>;
+      tmpl::list<control_system::Tags::ControlSystemInputs<ControlSystem>,
+                 control_system::Tags::WriteDataToDisk>;
+
+  using initialization_tags_to_keep =
+      tmpl::list<control_system::Tags::WriteDataToDisk>;
 
   using tags_to_be_initialized =
       tmpl::list<control_system::Tags::Averager<deriv_order>,

--- a/src/ControlSystem/CMakeLists.txt
+++ b/src/ControlSystem/CMakeLists.txt
@@ -31,6 +31,7 @@ spectre_target_headers(
   TimescaleTuner.hpp
   Trigger.hpp
   UpdateFunctionOfTime.hpp
+  WriteData.hpp
   )
 
 target_link_libraries(
@@ -41,6 +42,7 @@ target_link_libraries(
   Domain
   ErrorHandling
   FunctionsOfTime
+  IO
   )
 
 add_subdirectory(Actions)

--- a/src/ControlSystem/Protocols/ControlSystem.hpp
+++ b/src/ControlSystem/Protocols/ControlSystem.hpp
@@ -22,6 +22,12 @@ namespace control_system::protocols {
 ///   corresponds to the name of the FunctionOfTime controlled by this
 ///   system.
 ///
+/// - a static function `component_name` returning a `std::string`.  This
+///   gives a name associated to each component of the FunctionOfTime that is
+///   being controlled. E.g. a FunctionOfTime controlling translation will have
+///   three components with names "X", "Y", and "Z". This is useful when writing
+///   data to disk.
+///
 /// - a type alias `measurement` to a struct implementing the
 ///   Measurement protocol.
 ///
@@ -67,6 +73,10 @@ struct ControlSystem {
   template <typename ConformingType>
   struct test {
     static_assert(std::is_same_v<std::decay_t<decltype(ConformingType::name())>,
+                                 std::string>);
+
+    static_assert(std::is_same_v<decltype(ConformingType::component_name(
+                                     std::declval<const size_t>())),
                                  std::string>);
 
     using measurement = typename ConformingType::measurement;

--- a/src/ControlSystem/Tags.hpp
+++ b/src/ControlSystem/Tags.hpp
@@ -46,6 +46,16 @@ struct ControlSystemInputs {
   static std::string name() { return ControlSystem::name(); }
   using group = ControlSystemGroup;
 };
+
+/// \ingroup OptionTagsGroup
+/// \ingroup ControlSystemGroup
+/// Option tag on whether to write data to disk.
+struct WriteDataToDisk {
+  using type = bool;
+  static constexpr Options::String help = {
+      "Whether control system data should be saved during an evolution."};
+  using group = ControlSystemGroup;
+};
 }  // namespace OptionTags
 
 /// \ingroup ControlSystemGroup
@@ -65,6 +75,17 @@ namespace Tags {
 /// DataBox tag for the name of a control system
 struct ControlSystemName : db::SimpleTag {
   using type = std::string;
+};
+
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ControlSystemGroup
+/// DataBox tag for writing control system data to disk
+struct WriteDataToDisk : db::SimpleTag {
+  using type = bool;
+  using option_tags = tmpl::list<OptionTags::WriteDataToDisk>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& option) { return option; }
 };
 
 /// \ingroup DataBoxTagsGroup

--- a/src/ControlSystem/WriteData.hpp
+++ b/src/ControlSystem/WriteData.hpp
@@ -1,0 +1,189 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "ControlSystem/Component.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
+#include "IO/Observer/Helpers.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ReductionActions.hpp"
+#include "IO/Observer/TypeOfObservation.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Info.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Reduction.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/MakeString.hpp"
+
+namespace control_system {
+/*!
+ * Helper struct that contains common things all control systems will need if
+ * they want to write their data to disk.
+ *
+ * To have a control system write data, this `WriterHelper` struct must be
+ * put in the `tmpl::list` of `observed_reduction_data_tags` in the
+ * metavariables.
+ */
+struct WriterHelper {
+  // Use funcl::AssertEqual for all because we aren't actually "reducing"
+  // anything. These are just one time measurements.
+  using ReductionData = Parallel::ReductionData<
+      // Time
+      Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
+      // Lambda, dtLambda, d2tLambda
+      Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
+      Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
+      Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
+      // ControlError, dtControlError, ControlSignal
+      Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
+      Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
+      Parallel::ReductionDatum<double, funcl::AssertEqual<>>>;
+
+  using observed_reduction_data_tags =
+      observers::make_reduction_data_tags<tmpl::list<ReductionData>>;
+
+  /// All controlled components of functions of time have the same legend
+  const static inline std::vector<std::string> legend{
+      "Time",         "Lambda",         "dtLambda",     "d2tLambda",
+      "ControlError", "dtControlError", "ControlSignal"};
+};
+
+/// Used in
+/// `observers::Actions::RegisterSingletonWithObserverWriter<RegisterHelper>`
+/// as the `RegisterHelper`
+template <typename ControlSystem>
+struct Registration {
+  template <typename ParallelComponent, typename DbTagsList,
+            typename ArrayIndex>
+  static std::pair<observers::TypeOfObservation, observers::ObservationKey>
+  register_info(const db::DataBox<DbTagsList>& /*box*/,
+                const ArrayIndex& /*array_index*/) {
+    return {observers::TypeOfObservation::Reduction,
+            observers::ObservationKey{ControlSystem::name()}};
+  }
+};
+
+/*!
+ * \ingroup ControlSystemGroup
+ * \brief Writes all components of a function of time to disk at a specific time
+ * from a control system after it updates the functions of time.
+ *
+ * \details The columns of data written are:
+ * - %Time
+ * - Lambda
+ * - dtLambda
+ * - d2tLambda
+ * - ControlError
+ * - dtControlError
+ * - ControlSignal
+ *
+ * where "Lambda" is the function of time value.
+ *
+ * Data will be stored in the reduction file. All subfiles for the control
+ * system within the H5 file will be under the group "/ControlSystems".
+ * Within this group, there will be one group for each control system. The name
+ * of each group will be the result of the `name()` function from each control
+ * system. An example would look like
+ *
+ * - /ControlSystems/SystemA
+ * - /ControlSystems/SystemB
+ * - /ControlSystems/SystemC
+ *
+ * Then, within each system group, there will be one subfile for each component
+ * of the function of time that is being controlled. The name of this subfile is
+ * the name of the component. The name of each component will be the result of
+ * the `component_name(i)` function from the control system, where `i` is the
+ * index of the component. For example, if "SystemA" has 3 components with names
+ * "X", "Y", and "Z", then the subfiles would look like
+ *
+ * - /ControlSystems/SystemA/X.dat
+ * - /ControlSystems/SystemA/Y.dat
+ * - /ControlSystems/SystemA/Z.dat
+ *
+ * \note In order to use this function, you must
+ * 1. Put the
+ * `observers::Actions::RegisterSingletonWithObserverWriter<RegisterHelper>`
+ * action in the registration phase of the `ControlComponent` where
+ * `RegisterHelper` is the `control_system::Registration<ControlSystem>` struct
+ * 2. Add `control_system::WriterHelper` to the `tmpl::list` of
+ * `observed_reduction_data_tags` in the metavariables.
+ */
+template <typename ControlSystem, typename Metavariables>
+void write_components_to_disk(
+    const double time, Parallel::GlobalCache<Metavariables>& cache,
+    const std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>&
+        function_of_time,
+    const std::array<DataVector, ControlSystem::deriv_order>& q_and_derivs,
+    const DataVector& control_signal) {
+  auto& observer_writer_proxy = Parallel::get_parallel_component<
+      observers::ObserverWriter<Metavariables>>(cache);
+  auto& control_component_proxy = Parallel::get_parallel_component<
+      ControlComponent<Metavariables, ControlSystem>>(cache);
+
+  constexpr size_t deriv_order = ControlSystem::deriv_order;
+  std::array<DataVector, 3> function_at_current_time{};
+  const auto* const quat_func_of_time = dynamic_cast<
+      const domain::FunctionsOfTime::QuaternionFunctionOfTime<deriv_order>*>(
+      function_of_time.get());
+  if (quat_func_of_time == nullptr) {
+    // Just call the usual `func_and_2_derivs` member.
+    function_at_current_time = function_of_time->func_and_2_derivs(time);
+  } else {
+    // If we are working with a QuaternionFunctionOfTime, we aren't actually
+    // controlling a quaternion. We are controlling a small change in angle
+    // associated with the angular velocity in each direction. Because of this,
+    // we want to write the component data of the thing we are actually
+    // controlling. This is accessed by the `angle_func_and_2_derivs` member of
+    // a QuaternionFunctionOfTime. Since `angle_func_and_2_derivs` is not a
+    // virtual function of the FunctionOfTime base class, we need to down cast
+    // the original function to a QuaternionFunctionOfTime.
+    function_at_current_time = quat_func_of_time->angle_func_and_2_derivs(time);
+  }
+
+  // Each control system is its own group under the overarching `ControlSystems`
+  // group. There is a different subfile for each component, so loop over them.
+  // Eg. translation files will look like
+  //
+  // ControlSystems/Translation/X.dat
+  // ControlSystems/Translation/Y.dat
+  // ControlSystems/Translation/Z.dat
+  const size_t num_components = function_at_current_time[0].size();
+  for (size_t i = 0; i < num_components; ++i) {
+    const std::string component_name = ControlSystem::component_name(i);
+    // Currently all reduction data is written to the reduction file so preface
+    // everything with ControlSystems/
+    const std::string subfile_name{"/ControlSystems/" + ControlSystem::name() +
+                                   "/" + component_name};
+    const auto observation_id =
+        observers::ObservationId(time, ControlSystem::name());
+    const auto& legend = WriterHelper::legend;
+
+    Parallel::threaded_action<observers::ThreadedActions::WriteReductionData>(
+        // Node 0 is always the writer
+        observer_writer_proxy[0], observation_id,
+        static_cast<size_t>(
+            Parallel::my_node(*control_component_proxy.ckLocal())),
+        subfile_name, legend,
+        WriterHelper::ReductionData{
+            // clang-format off
+            time,
+            function_at_current_time[0][i],
+            function_at_current_time[1][i],
+            function_at_current_time[2][i],
+            q_and_derivs[0][i],
+            q_and_derivs[1][i],
+            control_signal[i]}
+        // clang-format on
+    );
+  }
+}
+}  // namespace control_system

--- a/tests/Unit/ControlSystem/Actions/Test_Initialization.cpp
+++ b/tests/Unit/ControlSystem/Actions/Test_Initialization.cpp
@@ -49,6 +49,7 @@ struct MockControlComponent {
                  control_system::Tags::Averager<2>,
                  control_system::Tags::TimescaleTuner,
                  control_system::Tags::ControlSystemName,
+                 control_system::Tags::WriteDataToDisk,
                  control_system::Tags::Controller<2>>;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
@@ -77,11 +78,16 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Initialization",
   Controller<2> controller_empty{};
   std::string controlsys_name{"LabelA"};
   std::string controlsys_name_empty{};
+  bool write_data = false;
 
   tuples::tagged_tuple_from_typelist<tags> init_tuple{
       control_system::OptionHolder<mock_control_sys>{averager, controller,
                                                      tuner},
-      averager_empty, tuner_empty, controlsys_name_empty, controller_empty};
+      averager_empty,
+      tuner_empty,
+      controlsys_name_empty,
+      write_data,
+      controller_empty};
 
   MockRuntimeSystem runner{{}};
   ActionTesting::emplace_singleton_component_and_initialize<component>(
@@ -108,6 +114,10 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Initialization",
       ActionTesting::get_databox_tag<component,
                                      control_system::Tags::ControlSystemName>(
           runner, 0);
+  const auto& box_write_data =
+      ActionTesting::get_databox_tag<component,
+                                     control_system::Tags::WriteDataToDisk>(
+          runner, 0);
 
   // Check that things haven't been initialized
   CHECK(box_averager != averager);
@@ -124,4 +134,5 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Initialization",
   CHECK(box_tuner == tuner);
   CHECK(box_controlsys_name == controlsys_name);
   CHECK(box_controller == controller);
+  CHECK_FALSE(box_write_data);
 }

--- a/tests/Unit/ControlSystem/Actions/Test_Initialization.cpp
+++ b/tests/Unit/ControlSystem/Actions/Test_Initialization.cpp
@@ -13,6 +13,7 @@
 #include "ControlSystem/TimescaleTuner.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "Helpers/ControlSystem/TestStructs.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
@@ -25,6 +26,7 @@ template <typename Label, typename Measurement>
 struct MockControlSystem
     : tt::ConformsTo<control_system::protocols::ControlSystem> {
   static std::string name() { return pretty_type::short_name<Label>(); }
+  static std::string component_name(const size_t i) { return get_output(i); }
   using measurement = Measurement;
   static constexpr size_t deriv_order = 2;
   using simple_tags = tmpl::list<>;

--- a/tests/Unit/ControlSystem/Actions/Test_Initialization.cpp
+++ b/tests/Unit/ControlSystem/Actions/Test_Initialization.cpp
@@ -112,7 +112,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Initialization",
   CHECK(box_tuner != tuner);
   CHECK(box_controlsys_name != controlsys_name);
   // We don't check the controller now because one of its members is
-  // inititalized with signaling_NaN() so comparing now would throw an FPE.
+  // initialized with signaling_NaN() so comparing now would throw an FPE.
 
   // Now initialize everything
   runner.next_action<component>(0);

--- a/tests/Unit/ControlSystem/Actions/Test_InitializeMeasurements.cpp
+++ b/tests/Unit/ControlSystem/Actions/Test_InitializeMeasurements.cpp
@@ -35,6 +35,7 @@
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
 #include "Time/Tags.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
@@ -85,6 +86,7 @@ struct SystemB;
 
 struct SystemA : tt::ConformsTo<control_system::protocols::ControlSystem> {
   static std::string name() { return "A"; }
+  static std::string component_name(const size_t i) { return get_output(i); }
   using simple_tags = tmpl::list<>;
   using measurement = Measurement<tmpl::list<SystemA, SystemB>>;
   struct process_measurement {
@@ -95,6 +97,7 @@ struct SystemA : tt::ConformsTo<control_system::protocols::ControlSystem> {
 
 struct SystemB : tt::ConformsTo<control_system::protocols::ControlSystem> {
   static std::string name() { return "B"; }
+  static std::string component_name(const size_t /*i*/) { return ""; }
   using simple_tags = tmpl::list<>;
   using measurement = Measurement<tmpl::list<SystemA, SystemB>>;
   struct process_measurement {
@@ -105,6 +108,7 @@ struct SystemB : tt::ConformsTo<control_system::protocols::ControlSystem> {
 
 struct SystemC : tt::ConformsTo<control_system::protocols::ControlSystem> {
   static std::string name() { return "C"; }
+  static std::string component_name(const size_t /*i*/) { return ""; }
   using simple_tags = tmpl::list<>;
   using measurement = Measurement<tmpl::list<SystemC>>;
   struct process_measurement {

--- a/tests/Unit/ControlSystem/CMakeLists.txt
+++ b/tests/Unit/ControlSystem/CMakeLists.txt
@@ -15,6 +15,7 @@ set(LIBRARY_SOURCES
   Test_TimescaleTuner.cpp
   Test_Trigger.cpp
   Test_UpdateFunctionOfTime.cpp
+  Test_WriteData.cpp
   )
 
 add_subdirectory(Actions)

--- a/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
@@ -39,6 +39,7 @@ struct FakeControlSystem
     : tt::ConformsTo<control_system::protocols::ControlSystem> {
   static constexpr size_t deriv_order = 2;
   static std::string name() { return "Controlled"s + get_output(Index); }
+  static std::string component_name(const size_t i) { return get_output(i); }
   using measurement = control_system::TestHelpers::Measurement<
       control_system::TestHelpers::TestStructs_detail::LabelA>;
   using simple_tags = tmpl::list<>;

--- a/tests/Unit/ControlSystem/Tags/Test_MeasurementTimescales.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_MeasurementTimescales.cpp
@@ -28,6 +28,7 @@ struct FakeControlSystem
     : tt::ConformsTo<control_system::protocols::ControlSystem> {
   static constexpr size_t deriv_order = 2;
   static std::string name() { return "Controlled"s + get_output(Index); }
+  static std::string component_name(const size_t i) { return get_output(i); }
   using measurement = control_system::TestHelpers::Measurement<
       control_system::TestHelpers::TestStructs_detail::LabelA>;
   using simple_tags = tmpl::list<>;

--- a/tests/Unit/ControlSystem/Test_InitialExpirationTimes.cpp
+++ b/tests/Unit/ControlSystem/Test_InitialExpirationTimes.cpp
@@ -21,6 +21,7 @@ struct FakeControlSystem
     : tt::ConformsTo<control_system::protocols::ControlSystem> {
   static constexpr size_t deriv_order = 2;
   static std::string name() { return "Controlled"s + get_output(Index); }
+  static std::string component_name(const size_t i) { return get_output(i); }
   using measurement = control_system::TestHelpers::Measurement<
       control_system::TestHelpers::TestStructs_detail::LabelA>;
   using simple_tags = tmpl::list<>;

--- a/tests/Unit/ControlSystem/Test_Tags.cpp
+++ b/tests/Unit/ControlSystem/Test_Tags.cpp
@@ -28,6 +28,8 @@ void test_all_tags() {
   INFO("Test all tags");
   using name_tag = control_system::Tags::ControlSystemName;
   TestHelpers::db::test_simple_tag<name_tag>("ControlSystemName");
+  using write_tag = control_system::Tags::WriteDataToDisk;
+  TestHelpers::db::test_simple_tag<write_tag>("WriteDataToDisk");
   using averager_tag = control_system::Tags::Averager<2>;
   TestHelpers::db::test_simple_tag<averager_tag>("Averager");
   using timescaletuner_tag = control_system::Tags::TimescaleTuner;
@@ -89,6 +91,11 @@ void test_control_sys_inputs() {
   CHECK(expected_tuner == input_holder.tuner);
   CHECK(expected_name ==
         std::decay_t<decltype(input_holder)>::control_system::name());
+
+  const auto write_data =
+      TestHelpers::test_option_tag<control_system::OptionTags::WriteDataToDisk>(
+          "true");
+  CHECK(write_data);
 }
 }  // namespace
 

--- a/tests/Unit/ControlSystem/Test_WriteData.cpp
+++ b/tests/Unit/ControlSystem/Test_WriteData.cpp
@@ -1,0 +1,335 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <random>
+#include <string>
+
+#include "ControlSystem/Component.hpp"
+#include "ControlSystem/Protocols/ControlSystem.hpp"
+#include "ControlSystem/Tags.hpp"
+#include "ControlSystem/WriteData.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/ControlSystem/TestStructs.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/Dat.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/Observer/Actions/RegisterSingleton.hpp"
+#include "IO/Observer/Helpers.hpp"
+#include "IO/Observer/Initialize.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/Tags.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace control_system {
+namespace {
+struct LabelA {};
+
+constexpr size_t total_components = 3;
+
+struct FakeControlSystem
+    : tt::ConformsTo<control_system::protocols::ControlSystem> {
+  static constexpr size_t deriv_order = 2;
+  static std::string name() {
+    return pretty_type::short_name<FakeControlSystem>();
+  }
+  static std::string component_name(const size_t i) {
+    return i == 0 ? "Foo" : (i == 1 ? "Bar" : "Baz");
+  }
+  using measurement = control_system::TestHelpers::Measurement<LabelA>;
+  using simple_tags = tmpl::list<>;
+  struct process_measurement {
+    using argument_tags = tmpl::list<>;
+  };
+};
+
+struct FakeQuatControlSystem
+    : tt::ConformsTo<control_system::protocols::ControlSystem> {
+  static constexpr size_t deriv_order = 3;
+  static std::string name() {
+    return pretty_type::short_name<FakeQuatControlSystem>();
+  }
+  static std::string component_name(const size_t i) { return get_output(i); }
+  using measurement = control_system::TestHelpers::Measurement<LabelA>;
+  using simple_tags = tmpl::list<>;
+  struct process_measurement {
+    using argument_tags = tmpl::list<>;
+  };
+};
+
+template <typename Metavariables>
+struct MockObserverWriter {
+  using component_being_mocked = observers::ObserverWriter<Metavariables>;
+  using replace_these_simple_actions = tmpl::list<>;
+  using with_these_simple_actions = tmpl::list<>;
+
+  using const_global_cache_tags =
+      tmpl::list<observers::Tags::ReductionFileName>;
+
+  using initialize_action_list =
+      tmpl::list<::Actions::SetupDataBox,
+                 observers::Actions::InitializeWriter<Metavariables>>;
+  using initialization_tags =
+      Parallel::get_initialization_tags<initialize_action_list>;
+
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockNodeGroupChare;
+  using array_index = int;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::Initialization,
+                             initialize_action_list>,
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::WriteData, tmpl::list<>>>;
+};
+
+template <typename Metavariables, typename ControlSystem>
+struct MockControlComponent {
+  using component_being_mocked = ControlComponent<Metavariables, ControlSystem>;
+  using replace_these_simple_actions = tmpl::list<>;
+  using with_these_simple_actions = tmpl::list<>;
+  using array_index = int;
+
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockSingletonChare;
+
+  using register_action =
+      tmpl::list<observers::Actions::RegisterSingletonWithObserverWriter<
+          control_system::Registration<ControlSystem>>>;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::Register, register_action>>;
+};
+
+struct TestMetavars {
+  using observed_reduction_data_tags =
+      observers::collect_reduction_data_tags<tmpl::list<WriterHelper>>;
+
+  enum class Phase { Initialization, Register, WriteData, Exit };
+
+  using component_list =
+      tmpl::list<MockObserverWriter<TestMetavars>,
+                 MockControlComponent<TestMetavars, FakeControlSystem>,
+                 MockControlComponent<TestMetavars, FakeQuatControlSystem>>;
+};
+
+using FoTPtr = std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>;
+
+template <typename ControlSystem>
+void check_written_data(
+    const h5::H5File<h5::AccessType::ReadOnly>& read_file,
+    const std::vector<double>& times, FoTPtr& fot,
+    const std::vector<std::array<DataVector, ControlSystem::deriv_order>>&
+        q_and_derivs,
+    const std::vector<DataVector>& control_signal) {
+  std::array<DataVector, 3> func_and_2_derivs{};
+  for (size_t component_num = 0; component_num < total_components;
+       component_num++) {
+    // per file checks
+    const auto& dataset = read_file.get<h5::Dat>(
+        "/ControlSystems/" + ControlSystem::name() + "/" +
+        ControlSystem::component_name(component_num));
+    const Matrix data = dataset.get_data();
+    const std::vector<std::string>& legend = dataset.get_legend();
+    // Check legend is correct
+    for (size_t i = 0; i < legend.size(); i++) {
+      CHECK(legend[i] == WriterHelper::legend[i]);
+    }
+    CHECK(data.rows() == times.size());
+
+    // per time per file checks
+    for (size_t time_num = 0; time_num < times.size(); time_num++) {
+      const double time = times[time_num];
+      const auto* const quat_func_of_time =
+          dynamic_cast<const domain::FunctionsOfTime::QuaternionFunctionOfTime<
+              ControlSystem::deriv_order>*>(fot.get());
+      if (quat_func_of_time == nullptr) {
+        func_and_2_derivs = fot->func_and_2_derivs(time);
+      } else {
+        func_and_2_derivs = quat_func_of_time->angle_func_and_2_derivs(time);
+      }
+
+      // check time is correct
+      size_t offset = 0;
+      CHECK(data(time_num, offset) == time);
+      ++offset;
+
+      // check values for lambda are correct
+      for (size_t deriv_num = 0; deriv_num < 3; deriv_num++) {
+        CHECK(data(time_num, offset) ==
+              func_and_2_derivs[deriv_num][component_num]);
+        ++offset;
+      }
+
+      // check control error and derivs are correct
+      for (size_t deriv_num = 0; deriv_num < 2; deriv_num++) {
+        CHECK(data(time_num, offset) ==
+              q_and_derivs[time_num][deriv_num][component_num]);
+        ++offset;
+      }
+
+      // check control signal
+      CHECK(data(time_num, offset) == control_signal[time_num][component_num]);
+    }
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.ControlSystem.WriteData", "[Unit][ControlSystem]") {
+  domain::FunctionsOfTime::register_derived_with_charm();
+  constexpr size_t deriv_order = FakeControlSystem::deriv_order;
+  constexpr size_t quat_deriv_order = FakeQuatControlSystem::deriv_order;
+  using observer = MockObserverWriter<TestMetavars>;
+  using control_comp = MockControlComponent<TestMetavars, FakeControlSystem>;
+  using quat_control_comp =
+      MockControlComponent<TestMetavars, FakeQuatControlSystem>;
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<double> dist{-1.0, 1.0};
+  const std::string filename = "WriteDataTest_Output";
+
+  // clean up just in case
+  if (file_system::check_if_file_exists(filename + ".h5")) {
+    file_system::rm(filename + ".h5", true);
+  }
+
+  // set up runner and stuff
+  ActionTesting::MockRuntimeSystem<TestMetavars> runner{{filename}};
+  runner.set_phase(TestMetavars::Phase::Initialization);
+  ActionTesting::emplace_nodegroup_component<observer>(make_not_null(&runner));
+  ActionTesting::emplace_singleton_component<control_comp>(
+      make_not_null(&runner), ActionTesting::NodeId{0},
+      ActionTesting::LocalCoreId{0});
+  ActionTesting::emplace_singleton_component<quat_control_comp>(
+      make_not_null(&runner), ActionTesting::NodeId{0},
+      ActionTesting::LocalCoreId{0});
+  auto& cache = ActionTesting::cache<observer>(runner, 0);
+
+  // the initialization actions
+  for (size_t i = 0; i < 2; ++i) {
+    ActionTesting::next_action<observer>(make_not_null(&runner), 0);
+  }
+  // Register singletons with observer writer
+  runner.set_phase(TestMetavars::Phase::Register);
+  ActionTesting::next_action<control_comp>(make_not_null(&runner), 0);
+  CHECK(ActionTesting::number_of_queued_simple_actions<observer>(runner, 0) ==
+        1);
+  ActionTesting::invoke_queued_simple_action<observer>(make_not_null(&runner),
+                                                       0);
+  ActionTesting::next_action<quat_control_comp>(make_not_null(&runner), 0);
+  CHECK(ActionTesting::number_of_queued_simple_actions<observer>(runner, 0) ==
+        1);
+  ActionTesting::invoke_queued_simple_action<observer>(make_not_null(&runner),
+                                                       0);
+
+  runner.set_phase(TestMetavars::Phase::WriteData);
+
+  // set up data to write
+  FoTPtr normal_fot = std::make_unique<
+      domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>>(
+      0.0,
+      std::array<DataVector, deriv_order + 1>{
+          {make_with_random_values<DataVector>(
+               make_not_null(&gen), dist, DataVector{total_components, 0.0}),
+           make_with_random_values<DataVector>(
+               make_not_null(&gen), dist, DataVector{total_components, 0.0}),
+           make_with_random_values<DataVector>(
+               make_not_null(&gen), dist, DataVector{total_components, 0.0})}},
+      5.0);
+
+  FoTPtr quat_fot = std::make_unique<
+      domain::FunctionsOfTime::QuaternionFunctionOfTime<quat_deriv_order>>(
+      0.0, std::array<DataVector, 1>{{{1.0, 0.0, 0.0, 0.0}}},
+      std::array<DataVector, quat_deriv_order + 1>{
+          {make_with_random_values<DataVector>(
+               make_not_null(&gen), dist, DataVector{total_components, 0.0}),
+           make_with_random_values<DataVector>(
+               make_not_null(&gen), dist, DataVector{total_components, 0.0}),
+           make_with_random_values<DataVector>(
+               make_not_null(&gen), dist, DataVector{total_components, 0.0}),
+           make_with_random_values<DataVector>(
+               make_not_null(&gen), dist, DataVector{total_components, 0.0})}},
+      5.0);
+
+  const std::vector<double> times{0.0, 0.1, 0.2, 0.3, 0.4, 0.5};
+  std::vector<std::array<DataVector, deriv_order>> normal_q_and_derivs{
+      times.size()};
+  std::vector<std::array<DataVector, quat_deriv_order>> quat_q_and_derivs{
+      times.size()};
+  std::vector<DataVector> normal_control_signals{times.size()};
+  std::vector<DataVector> quat_control_signals{times.size()};
+
+  // write some data
+  for (size_t i = 0; i < times.size(); i++) {
+    const double time = times[i];
+    for (size_t j = 0; j < deriv_order; j++) {
+      gsl::at(normal_q_and_derivs[i], j) = make_with_random_values<DataVector>(
+          make_not_null(&gen), dist, DataVector{total_components, 0.0});
+    }
+    for (size_t j = 0; j < quat_deriv_order; j++) {
+      gsl::at(quat_q_and_derivs[i], j) = make_with_random_values<DataVector>(
+          make_not_null(&gen), dist, DataVector{total_components, 0.0});
+    }
+    normal_control_signals[i] = make_with_random_values<DataVector>(
+        make_not_null(&gen), dist, DataVector{total_components, 0.0});
+    quat_control_signals[i] = make_with_random_values<DataVector>(
+        make_not_null(&gen), dist, DataVector{total_components, 0.0});
+
+    write_components_to_disk<FakeControlSystem>(time, cache, normal_fot,
+                                                normal_q_and_derivs[i],
+                                                normal_control_signals[i]);
+    write_components_to_disk<FakeQuatControlSystem>(
+        time, cache, quat_fot, quat_q_and_derivs[i], quat_control_signals[i]);
+
+    // 3 for each control system
+    size_t num_threaded_actions =
+        ActionTesting::number_of_queued_threaded_actions<observer>(runner, 0);
+    CHECK(num_threaded_actions == total_components * 2);
+    for (size_t j = 0; j < total_components * 2; j++) {
+      ActionTesting::invoke_queued_threaded_action<observer>(
+          make_not_null(&runner), 0);
+    }
+
+    num_threaded_actions =
+        ActionTesting::number_of_queued_threaded_actions<observer>(runner, 0);
+    CHECK(not num_threaded_actions);
+  }
+
+  // scoped to close file
+  {
+    h5::H5File<h5::AccessType::ReadOnly> read_file{filename + ".h5"};
+    check_written_data<FakeControlSystem>(read_file, times, normal_fot,
+                                          normal_q_and_derivs,
+                                          normal_control_signals);
+    check_written_data<FakeQuatControlSystem>(
+        read_file, times, quat_fot, quat_q_and_derivs, quat_control_signals);
+  }
+
+  // clean up now that we are done
+  if (file_system::check_if_file_exists(filename + ".h5")) {
+    file_system::rm(filename + ".h5", true);
+  }
+}
+}  // namespace
+}  // namespace control_system

--- a/tests/Unit/Helpers/ControlSystem/Examples.hpp
+++ b/tests/Unit/Helpers/ControlSystem/Examples.hpp
@@ -94,6 +94,9 @@ struct ExampleMeasurement
 struct ExampleControlSystem
     : tt::ConformsTo<control_system::protocols::ControlSystem> {
   static std::string name() { return "ExampleControlSystem"; }
+  static std::string component_name(const size_t i) {
+    return i == 0 ? "X" : (i == 1 ? "Y" : "Z");
+  }
   using measurement = ExampleMeasurement;
 
   using simple_tags = tmpl::list<>;

--- a/tests/Unit/Helpers/ControlSystem/TestStructs.hpp
+++ b/tests/Unit/Helpers/ControlSystem/TestStructs.hpp
@@ -8,6 +8,7 @@
 
 #include "ControlSystem/Protocols/ControlSystem.hpp"
 #include "ControlSystem/Protocols/Measurement.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
@@ -28,6 +29,7 @@ static_assert(tt::assert_conforms_to<Measurement<TestStructs_detail::LabelA>,
 template <size_t DerivOrder, typename Label, typename Measurement>
 struct System : tt::ConformsTo<control_system::protocols::ControlSystem> {
   static std::string name() { return pretty_type::short_name<Label>(); }
+  static std::string component_name(const size_t i) { return get_output(i); }
   using measurement = Measurement;
   using simple_tags = tmpl::list<>;
   static constexpr size_t deriv_order = DerivOrder;


### PR DESCRIPTION
## Proposed changes

Also add a couple other things:
- function `component_name(size_t)` to the control system protocol. This is used to name the subfiles.
- databox tag to represent whether control systems should write their data to disk (during evolutions this will almost always be true, but for testing it will be nice to not write data)

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
