### PR TITLE
Sort `list_observation_ids()`, support importing first or last observation ID from a volume file

### DIFF
--- a/src/IO/H5/VolumeData.cpp
+++ b/src/IO/H5/VolumeData.cpp
@@ -273,8 +273,13 @@ std::vector<size_t> VolumeData::list_observation_ids() const {
   const auto helper = [](const std::string& s) {
     return std::stoul(s.substr(std::string("ObservationId").size()));
   };
-  return {boost::make_transform_iterator(names.begin(), helper),
-          boost::make_transform_iterator(names.end(), helper)};
+  std::vector<size_t> obs_ids{
+      boost::make_transform_iterator(names.begin(), helper),
+      boost::make_transform_iterator(names.end(), helper)};
+  alg::sort(obs_ids, [this](const size_t lhs, const size_t rhs) {
+    return this->get_observation_value(lhs) < this->get_observation_value(rhs);
+  });
+  return obs_ids;
 }
 
 double VolumeData::get_observation_value(const size_t observation_id) const {

--- a/src/IO/H5/VolumeData.hpp
+++ b/src/IO/H5/VolumeData.hpp
@@ -101,6 +101,9 @@ class VolumeData : public h5::Object {
                          const std::vector<ElementVolumeData>& elements);
 
   /// List all the integral observation ids in the subfile
+  ///
+  /// The list of observation IDs is sorted by their observation value, as
+  /// returned by get_observation_value(size_t).
   std::vector<size_t> list_observation_ids() const;
 
   /// Get the observation value at the the integral observation id in the

--- a/src/IO/Importers/CMakeLists.txt
+++ b/src/IO/Importers/CMakeLists.txt
@@ -3,25 +3,33 @@
 
 set(LIBRARY Importers)
 
-add_spectre_library(${LIBRARY} INTERFACE)
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  ObservationSelector.cpp
+  )
 
 spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ElementDataReader.hpp
+  ObservationSelector.hpp
   Tags.hpp
   )
 
 target_link_libraries(
   ${LIBRARY}
+  PUBLIC
+  ErrorHandling
+  Options
   INTERFACE
   DataStructures
   DomainStructure
-  ErrorHandling
   IO
   Initialization
-  Options
   Parallel
   Utilities
   )

--- a/src/IO/Importers/ObservationSelector.cpp
+++ b/src/IO/Importers/ObservationSelector.cpp
@@ -1,0 +1,41 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "IO/Importers/ObservationSelector.hpp"
+
+#include <ostream>
+#include <string>
+
+#include "Options/ParseOptions.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+
+namespace importers {
+std::ostream& operator<<(std::ostream& os, const ObservationSelector value) {
+  switch (value) {
+    case ObservationSelector::First:
+      return os << "First";
+    case ObservationSelector::Last:
+      return os << "Last";
+      // LCOV_EXCL_START
+    default:
+      ERROR("Unknown importers::ObservationSelector");
+      // LCOV_EXCL_STOP
+  }
+}
+}  // namespace importers
+
+template <>
+importers::ObservationSelector
+Options::create_from_yaml<importers::ObservationSelector>::create<void>(
+    const Options::Option& options) {
+  const auto value = options.parse_as<std::string>();
+  if (value == "First") {
+    return importers::ObservationSelector::First;
+  } else if (value == "Last") {
+    return importers::ObservationSelector::Last;
+  }
+  PARSE_ERROR(options.context(), "Failed to convert '"
+                                     << value
+                                     << "' to importers::ObservationSelector. "
+                                        "Must be one of First, Last.");
+}

--- a/src/IO/Importers/ObservationSelector.hpp
+++ b/src/IO/Importers/ObservationSelector.hpp
@@ -1,0 +1,31 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <ostream>
+
+#include "Options/ParseOptions.hpp"
+
+namespace importers {
+
+/// Represents the first or last observation in a volume data file, to allow
+/// specifying it in an input file without knowledge of the specific observation
+/// values.
+enum class ObservationSelector { First, Last };
+
+std::ostream& operator<<(std::ostream& os, const ObservationSelector value);
+
+}  // namespace importers
+
+template <>
+struct Options::create_from_yaml<importers::ObservationSelector> {
+  template <typename Metavariables>
+  static importers::ObservationSelector create(const Options::Option& options) {
+    return create<void>(options);
+  }
+};
+template <>
+importers::ObservationSelector
+Options::create_from_yaml<importers::ObservationSelector>::create<void>(
+    const Options::Option& options);

--- a/src/IO/Importers/Tags.hpp
+++ b/src/IO/Importers/Tags.hpp
@@ -7,8 +7,10 @@
 #include <map>
 #include <string>
 #include <unordered_set>
+#include <variant>
 
 #include "DataStructures/DataBox/Tag.hpp"
+#include "IO/Importers/ObservationSelector.hpp"
 #include "IO/Observer/ArrayComponentId.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/InboxInserters.hpp"
@@ -69,7 +71,7 @@ struct ObservationValue {
       std::is_same_v<typename ImporterOptionsGroup::group, Group>,
       "The importer options should be placed in the 'Importers' option "
       "group. Add a type alias `using group = importers::OptionTags::Group`.");
-  using type = double;
+  using type = std::variant<double, ObservationSelector>;
   static constexpr Options::String help =
       "The observation value at which to read data";
   using group = ImporterOptionsGroup;
@@ -120,7 +122,7 @@ struct ObservationValue : db::SimpleTag {
     return "ObservationValue(" + Options::name<ImporterOptionsGroup>() +
            ")";
   }
-  using type = double;
+  using type = std::variant<double, ObservationSelector>;
   using option_tags =
       tmpl::list<OptionTags::ObservationValue<ImporterOptionsGroup>>;
 

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -230,7 +230,7 @@ Importers:
   NumericInitialData:
     FileGlob: "/path/to/initial_data.h5"
     Subgroup: "element_data"
-    ObservationValue: 0.0
+    ObservationValue: Last
 
 # control.h5 should contain data for FunctionsOfTime that can be
 # read by ReadSpecPiecewisePolynomial.

--- a/tests/Unit/IO/H5/Test_VolumeData.cpp
+++ b/tests/Unit/IO/H5/Test_VolumeData.cpp
@@ -129,9 +129,8 @@ void test() {
   const auto& volume_file =
       my_file.get<h5::VolumeData>("/element_data", version_number);
   const auto read_observation_ids = volume_file.list_observation_ids();
-  CHECK(alg::all_of(read_observation_ids, [&observation_ids](const size_t id) {
-    return alg::found(observation_ids, id);
-  }));
+  // The observation IDs should be sorted by their observation value
+  CHECK(read_observation_ids == std::vector<size_t>{size_t(-1), 8435087234});
   {
     INFO("Test find_observation_id");
     std::vector<size_t> found_observation_ids(observation_values.size());

--- a/tests/Unit/IO/Importers/CMakeLists.txt
+++ b/tests/Unit/IO/Importers/CMakeLists.txt
@@ -43,7 +43,22 @@ function(add_algorithm_test TEST_NAME DIM)
     ${HPP_NAME}
     IO/Importers
     Metavariables<${DIM}>
-    "DataStructures;Domain;ErrorHandling;Informer;IO;Options;Parallel;SystemUtilities"
+    ""
+    )
+
+  target_link_libraries(
+    ${EXECUTABLE_NAME}
+    PRIVATE
+    DataStructures
+    DomainStructure
+    ErrorHandling
+    Importers
+    Informer
+    IO
+    Options
+    Parallel
+    SystemUtilities
+    Utilities
     )
 
   add_standalone_test(

--- a/tests/Unit/IO/Importers/Test_Tags.cpp
+++ b/tests/Unit/IO/Importers/Test_Tags.cpp
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "DataStructures/DataBox/TagName.hpp"
+#include "Framework/TestCreation.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "IO/Importers/Tags.hpp"
 #include "Options/Options.hpp"
@@ -49,6 +50,17 @@ SPECTRE_TEST_CASE("Unit.IO.Importers.Tags", "[Unit][IO]") {
   CHECK(opts.get<importers::OptionTags::Subgroup<ExampleVolumeData>>() ==
         "data.group");
   CHECK(
-      opts.get<importers::OptionTags::ObservationValue<ExampleVolumeData>>() ==
+      std::get<double>(
+          opts.get<
+              importers::OptionTags::ObservationValue<ExampleVolumeData>>()) ==
       1.);
+
+  CHECK(std::get<importers::ObservationSelector>(
+            TestHelpers::test_option_tag<
+                importers::OptionTags::ObservationValue<ExampleVolumeData>>(
+                "First")) == importers::ObservationSelector::First);
+  CHECK(std::get<importers::ObservationSelector>(
+            TestHelpers::test_option_tag<
+                importers::OptionTags::ObservationValue<ExampleVolumeData>>(
+                "Last")) == importers::ObservationSelector::Last);
 }

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderActions.cpp
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderActions.cpp
@@ -94,12 +94,13 @@ struct Metavariables {
 
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.IO.Importers.VolumeDataReaderActions", "[Unit][IO]") {
+void test_actions(const std::variant<double, importers::ObservationSelector>&
+                      observation_selection) {
   using reader_component = MockVolumeDataReader<Metavariables>;
   using element_array = MockElementArray<Metavariables>;
 
   ActionTesting::MockRuntimeSystem<Metavariables> runner{
-      {"TestVolumeData*.h5", "element_data", 0.}};
+      {"TestVolumeData*.h5", "element_data", observation_selection}};
 
   // Setup mock data file reader
   ActionTesting::emplace_nodegroup_component<reader_component>(
@@ -235,4 +236,10 @@ SPECTRE_TEST_CASE("Unit.IO.Importers.VolumeDataReaderActions", "[Unit][IO]") {
       file_system::rm(h5_file_name, true);
     }
   }
+}
+
+SPECTRE_TEST_CASE("Unit.IO.Importers.VolumeDataReaderActions", "[Unit][IO]") {
+  test_actions(0.);
+  test_actions(importers::ObservationSelector::First);
+  test_actions(importers::ObservationSelector::Last);
 }

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm.hpp
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm.hpp
@@ -213,14 +213,14 @@ struct WriteTestData {
     write_test_data<Dim>(
         get<importers::Tags::FileGlob<VolumeDataOptions<Grid::Fine>>>(box),
         get<importers::Tags::Subgroup<VolumeDataOptions<Grid::Fine>>>(box),
-        get<importers::Tags::ObservationValue<VolumeDataOptions<Grid::Fine>>>(
-            box),
+        std::get<double>(get<importers::Tags::ObservationValue<
+                             VolumeDataOptions<Grid::Fine>>>(box)),
         fine_volume_data<Dim>);
     write_test_data<Dim>(
         get<importers::Tags::FileGlob<VolumeDataOptions<Grid::Coarse>>>(box),
         get<importers::Tags::Subgroup<VolumeDataOptions<Grid::Coarse>>>(box),
-        get<importers::Tags::ObservationValue<VolumeDataOptions<Grid::Coarse>>>(
-            box),
+        std::get<double>(get<importers::Tags::ObservationValue<
+                             VolumeDataOptions<Grid::Coarse>>>(box)),
         coarse_volume_data<Dim>);
     return {std::move(box), true};
   }


### PR DESCRIPTION
## Proposed changes

Now you can specify `ObservationValue: Last` to load initial data, so the observation value doesn't have to be known.

Also:

- Sort `VolumeData::list_observation_ids()`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
