### PR TITLE
Add a single variables slicing for subcell

### DIFF
--- a/src/Evolution/DgSubcell/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/CMakeLists.txt
@@ -26,6 +26,7 @@ spectre_target_headers(
   ReconstructionMethod.hpp
   SliceData.hpp
   SliceTensor.hpp
+  SliceVariable.hpp
   SubcellOptions.hpp
   TciStatus.hpp
   TwoMeshRdmpTci.hpp

--- a/src/Evolution/DgSubcell/SliceVariable.hpp
+++ b/src/Evolution/DgSubcell/SliceVariable.hpp
@@ -1,0 +1,64 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <vector>
+
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Evolution/DgSubcell/SliceData.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace evolution::dg::subcell {
+/// @{
+/*!
+ * \brief Slice a Variables object on subcell mesh for a given direction and
+ * slicing depth (number of ghost points).
+ */
+template <size_t Dim, typename TagList>
+void slice_variable(
+    const gsl::not_null<Variables<TagList>*>& sliced_subcell_vars,
+    const Variables<TagList>& volume_subcell_vars,
+    const Index<Dim>& subcell_extents, const size_t ghost_zone_size,
+    const Direction<Dim>& direction) {
+  // check the size of sliced_subcell_vars (output)
+  const size_t num_sliced_pts =
+      subcell_extents.slice_away(direction.dimension()).product() *
+      ghost_zone_size;
+  if (sliced_subcell_vars->size() != num_sliced_pts) {
+    sliced_subcell_vars->initialize(num_sliced_pts);
+  }
+
+  // Slice volume variables. Note that the return type of the
+  // `slice_data_impl()` function is std::vector<double>.
+  DirectionMap<Dim, bool> directions_to_slice{};
+  directions_to_slice[direction] = true;
+
+  const std::vector<double> sliced_data{detail::slice_data_impl(
+      gsl::make_span(volume_subcell_vars.data(), volume_subcell_vars.size()),
+      subcell_extents, ghost_zone_size, directions_to_slice)[direction]};
+
+  // copy the returned std::vector<double> data into sliced variables
+  std::copy(sliced_data.begin(), sliced_data.end(),
+            sliced_subcell_vars->data());
+}
+
+template <size_t Dim, typename TagList>
+Variables<TagList> slice_variable(const Variables<TagList>& volume_subcell_vars,
+                                  const Index<Dim>& subcell_extents,
+                                  const size_t ghost_zone_size,
+                                  const Direction<Dim>& direction) {
+  Variables<TagList> sliced_subcell_vars{
+      subcell_extents.slice_away(direction.dimension()).product() *
+      ghost_zone_size};
+  slice_variable(make_not_null(&sliced_subcell_vars), volume_subcell_vars,
+                 subcell_extents, ghost_zone_size, direction);
+  return sliced_subcell_vars;
+}
+/// @}
+}  // namespace evolution::dg::subcell

--- a/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
+++ b/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
@@ -26,6 +26,7 @@ set(LIBRARY_SOURCES
   Test_ReconstructionMethod.cpp
   Test_SliceData.cpp
   Test_SliceTensor.cpp
+  Test_SliceVariable.cpp
   Test_SubcellOptions.cpp
   Test_Tags.cpp
   Test_TciStatus.cpp

--- a/tests/Unit/Evolution/DgSubcell/Test_SliceVariable.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_SliceVariable.cpp
@@ -1,0 +1,99 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <numeric>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/SliceIterator.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Evolution/DgSubcell/SliceVariable.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+// types of Tensor to test
+namespace Tags {
+struct Scalar : db::SimpleTag {
+  using type = ::Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct TensorI : db::SimpleTag {
+  using type = ::tnsr::I<DataVector, Dim>;
+};
+}  // namespace Tags
+
+template <size_t Dim>
+void test_slice(
+    const Variables<tmpl::list<Tags::Scalar, Tags::TensorI<Dim>>>& volume_vars,
+    const Index<Dim>& volume_extents, size_t num_ghost_pts,
+    const Direction<Dim>& direction) {
+  // retrieve a sliced Variables object
+  auto sliced_vars = evolution::dg::subcell::slice_variable(
+      volume_vars, volume_extents, num_ghost_pts, direction);
+
+  Index<Dim> sliced_extents = volume_extents;
+  sliced_extents[direction.dimension()] = num_ghost_pts;
+
+  // for each ghost slices,
+  for (size_t i_ghost = 0; i_ghost < num_ghost_pts; ++i_ghost) {
+    // for each of Variables components ( Scalar x 1 + TensorI x Dim )
+    for (size_t component_index = 0;
+         component_index < volume_vars.number_of_independent_components;
+         ++component_index) {
+      const size_t fixed_index =
+          direction.side() == Side::Lower
+              ? i_ghost
+              : volume_extents[direction.dimension()] + i_ghost - num_ghost_pts;
+
+      const size_t volume_offset = component_index * volume_extents.product();
+      const size_t slice_offset = component_index * sliced_extents.product();
+
+      // check the result
+      for (SliceIterator
+               volume_it(volume_extents, direction.dimension(), fixed_index),
+           slice_it(sliced_extents, direction.dimension(), i_ghost);
+           volume_it; ++volume_it, ++slice_it) {
+        CHECK(
+            *(volume_vars.data() + volume_offset + volume_it.volume_offset()) ==
+            *(sliced_vars.data() + slice_offset + slice_it.volume_offset()));
+      }
+    }
+  }
+}
+
+template <size_t Dim>
+void test() {
+  for (size_t num_mesh_pts_1d = 3; num_mesh_pts_1d < 5; ++num_mesh_pts_1d) {
+    // ghost zone size iterates up to the maximum possible value (mesh extent of
+    // each dimension)
+    for (size_t num_ghost_pts = 1; num_ghost_pts <= num_mesh_pts_1d;
+         ++num_ghost_pts) {
+      const Index<Dim> volume_extents{num_mesh_pts_1d};
+
+      // Create volume tensors and assign values
+      Variables<tmpl::list<Tags::Scalar, Tags::TensorI<Dim>>> volume_vars{
+          volume_extents.product()};
+      std::iota(volume_vars.data(), volume_vars.data() + volume_vars.size(),
+                0.0);
+
+      for (const auto& direction : Direction<Dim>::all_directions()) {
+        // check slicing for each direction
+        test_slice(volume_vars, volume_extents, num_ghost_pts, direction);
+      }
+    }
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Subcell.SliceVariable", "[Evolution][Unit]") {
+  test<1>();
+  test<2>();
+  test<3>();
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments


I'm not sure `std::copy`ing from `std::vector<double>` into the returned variables object is the best option for implementing this feature. There might be more efficient way, so welcome any suggestions.