### PR TITLE
InterpolateWithoutInterpComp: Use compute_vars_to_interpolate.

### DIFF
--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -195,7 +195,6 @@ struct EvolutionMetavars {
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::SpatialMetric<Dim, ::Frame::Inertial, DataVector>,
                    CurvedScalarWave::Tags::Psi>;
-    using compute_items_on_source = tmpl::list<>;
     using compute_items_on_target =
         tmpl::list<CurvedScalarWave::Tags::PsiSquaredCompute,
                    StrahlkorperGr::Tags::AreaElementCompute<::Frame::Inertial>,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -598,7 +598,6 @@ struct CenterOfStar : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
   using compute_target_points =
       intrp::TargetPoints::SpecifiedPoints<CenterOfStar, 3>;
   using compute_items_on_target = tags_to_observe;
-  using compute_items_on_source = tmpl::list<>;
 
   template <typename Metavariables>
   using interpolating_component =
@@ -610,7 +609,6 @@ struct KerrHorizon : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
   using tags_to_observe =
       tmpl::list<StrahlkorperTags::EuclideanSurfaceIntegralVectorCompute<
           hydro::Tags::MassFlux<DataVector, 3>, ::Frame::Inertial>>;
-  using compute_items_on_source = tmpl::list<>;
   using vars_to_interpolate_to_target =
       tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
                  hydro::Tags::SpatialVelocity<DataVector, 3>,

--- a/src/ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp
@@ -70,13 +70,7 @@ constexpr bool if_alias_exists_assert_conforms_to_v =
  * - a type alias `compute_vars_to_interpolate` that conforms to the
  *   intrp::protocols::ComputeVarsToInterpolate protocol. This is a struct that
  *   computes quantities in the volume that are required to compute different
- *   quantities on the surface we are interpolating to. Used only *with* the
- *   Interpolator ParallelComponent.
- *
- * - a type alias `compute_items_on_source` which is a `tmpl::list` of compute
- *   items that uses `Metavariables::interpolator_source_vars` as input and
- *   computes the `Variables` defined by `vars_to_interpolate_to_target`. Used
- *   only *without* the Interpolator ParallelComponent.
+ *   quantities on the surface we are interpolating to.
  *
  * - a type alias `interpolating_component` to the parallel component that will
  *   be interpolating to the interpolation target. Only needed when *not* using

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_SendNextTimeToCce.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_SendNextTimeToCce.cpp
@@ -7,6 +7,7 @@
 #include <utility>
 #include <vector>
 
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Evolution/Systems/Cce/Actions/SendNextTimeToCce.hpp"
 #include "Evolution/Systems/Cce/InterfaceManagers/GhLocalTimeStepping.hpp"
@@ -95,7 +96,9 @@ struct mock_gh_worldtube_boundary {
 };
 
 struct test_metavariables {
+  static constexpr bool use_time_dependent_maps = false;
   static constexpr size_t volume_dim = 3;
+  using const_global_cache_tags = tmpl::list<domain::Tags::Domain<3>>;
   struct InterpolationTargetA
       : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
     using temporal_id = ::Tags::Time;
@@ -105,7 +108,6 @@ struct test_metavariables {
     using post_interpolation_callback =
         intrp::callbacks::ObserveTimeSeriesOnSurface<tmpl::list<>,
                                                      InterpolationTargetA>;
-    using compute_items_on_source = tmpl::list<>;
     using compute_items_on_target = tmpl::list<>;
   };
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
@@ -135,7 +137,7 @@ struct initialize_elements_and_queue_simple_actions {
                   const Domain<3>& domain,
                   const std::vector<ElementId<3>>& element_ids,
                   const InterpPointInfo& interp_point_info, Runner& runner,
-                  const TemporalId& /*temporal_id*/) {
+                  const TemporalId& temporal_id) {
     using elem_component = ElemComponent;
 
     ActionTesting::emplace_component_and_initialize<
@@ -147,8 +149,9 @@ struct initialize_elements_and_queue_simple_actions {
     for (const auto& element_id : element_ids) {
       // 1. Get mesh
       auto mesh =
-          get<1>(InterpolateOnElementTestHelpers::make_volume_data_and_mesh(
-              domain_creator, domain, element_id));
+          get<1>(InterpolateOnElementTestHelpers::make_volume_data_and_mesh<
+                 ElemComponent, false>(domain_creator, runner, domain,
+                                       element_id, temporal_id));
 
       // 2. emplace element.
       ActionTesting::emplace_component_and_initialize<elem_component>(
@@ -217,6 +220,7 @@ void test_send_time_to_cce(const bool substep) {
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.SendNextTimeToCce",
                   "[Unit][Cce]") {
+  domain::creators::register_derived_with_charm();
   test_send_time_to_cce(true);
   test_send_time_to_cce(false);
 }

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
@@ -157,7 +157,6 @@ struct Metavariables {
     using temporal_id = ::Tags::TimeStepId;
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
-    using compute_items_on_source = tmpl::list<>;
     using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
         ::intrp::TargetPoints::LineSegment<InterpolationTargetA, 3>;


### PR DESCRIPTION
Fixes #3788

Previously it created a temporary DataBox and evaluated ComputeItems.
Now uses a mutator function compute_vars_to_interpolate, just like
interpolation with an Interpolator ParallelComponent.

The compute_vars_to_interpolate can do frame transformations if it
chooses, just as for interpolation with an Interpolator
ParallelComponent.

Without an Interpolator ParallelComponent, there is still the
restriction that the interpolation
points must be constant-in-time in some frame.
But that frame can be anything.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
InterpolateWithoutInterpComponent now uses compute_vars_to_interpolate instead of compute_items_on_source.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
