### PR TITLE
Add dim-by-dim subcell reconstruction

### DIFF
--- a/src/Evolution/DgSubcell/Actions/TciAndSwitchToDg.hpp
+++ b/src/Evolution/DgSubcell/Actions/TciAndSwitchToDg.hpp
@@ -21,6 +21,7 @@
 #include "Evolution/DgSubcell/RdmpTci.hpp"
 #include "Evolution/DgSubcell/RdmpTciData.hpp"
 #include "Evolution/DgSubcell/Reconstruction.hpp"
+#include "Evolution/DgSubcell/ReconstructionMethod.hpp"
 #include "Evolution/DgSubcell/SubcellOptions.hpp"
 #include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
 #include "Evolution/DgSubcell/Tags/DataForRdmpTci.hpp"
@@ -178,7 +179,8 @@ struct TciAndSwitchToDg {
           // Note: strictly speaking, to be conservative this should reconstruct
           // uJ instead of u.
           fd::reconstruct(inactive_vars_ptr, active_vars, dg_mesh,
-                          subcell_mesh.extents());
+                          subcell_mesh.extents(),
+                          fd::ReconstructionMethod::AllDimsAtOnce);
         },
         db::get<variables_tag>(box));
 
@@ -253,13 +255,16 @@ struct TciAndSwitchToDg {
                 dg_history{active_history_ptr->integration_order()};
             const auto end_it = active_history_ptr->end();
             for (auto it = active_history_ptr->begin(); it != end_it; ++it) {
-              dg_history.insert(it.time_step_id(),
-                                fd::reconstruct(it.derivative(), dg_mesh,
-                                                subcell_mesh.extents()));
+              dg_history.insert(
+                  it.time_step_id(),
+                  fd::reconstruct(it.derivative(), dg_mesh,
+                                  subcell_mesh.extents(),
+                                  fd::ReconstructionMethod::AllDimsAtOnce));
             }
             dg_history.most_recent_value() =
                 fd::reconstruct(active_history_ptr->most_recent_value(),
-                                dg_mesh, subcell_mesh.extents()),
+                                dg_mesh, subcell_mesh.extents(),
+                                fd::ReconstructionMethod::AllDimsAtOnce),
             *active_history_ptr = std::move(dg_history);
             *active_grid_ptr = ActiveGrid::Dg;
 

--- a/src/Evolution/DgSubcell/Actions/TciAndSwitchToDg.hpp
+++ b/src/Evolution/DgSubcell/Actions/TciAndSwitchToDg.hpp
@@ -174,13 +174,13 @@ struct TciAndSwitchToDg {
 
     db::mutate<Tags::Inactive<variables_tag>>(
         make_not_null(&box),
-        [&dg_mesh, &subcell_mesh](const auto inactive_vars_ptr,
-                                  const auto& active_vars) {
+        [&dg_mesh, &subcell_mesh, &subcell_options](
+            const auto inactive_vars_ptr, const auto& active_vars) {
           // Note: strictly speaking, to be conservative this should reconstruct
           // uJ instead of u.
           fd::reconstruct(inactive_vars_ptr, active_vars, dg_mesh,
                           subcell_mesh.extents(),
-                          fd::ReconstructionMethod::AllDimsAtOnce);
+                          subcell_options.reconstruction_method());
         },
         db::get<variables_tag>(box));
 
@@ -235,7 +235,7 @@ struct TciAndSwitchToDg {
                  subcell::Tags::NeighborDataForReconstruction<Dim>,
                  evolution::dg::subcell::Tags::TciGridHistory>(
           make_not_null(&box),
-          [&dg_mesh, &subcell_mesh](
+          [&dg_mesh, &subcell_mesh, &subcell_options](
               const auto active_vars_ptr, const auto inactive_vars_ptr,
               const auto active_history_ptr,
               const gsl::not_null<ActiveGrid*> active_grid_ptr,
@@ -259,12 +259,12 @@ struct TciAndSwitchToDg {
                   it.time_step_id(),
                   fd::reconstruct(it.derivative(), dg_mesh,
                                   subcell_mesh.extents(),
-                                  fd::ReconstructionMethod::AllDimsAtOnce));
+                                  subcell_options.reconstruction_method()));
             }
             dg_history.most_recent_value() =
                 fd::reconstruct(active_history_ptr->most_recent_value(),
                                 dg_mesh, subcell_mesh.extents(),
-                                fd::ReconstructionMethod::AllDimsAtOnce),
+                                subcell_options.reconstruction_method()),
             *active_history_ptr = std::move(dg_history);
             *active_grid_ptr = ActiveGrid::Dg;
 

--- a/src/Evolution/DgSubcell/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/CMakeLists.txt
@@ -23,6 +23,7 @@ spectre_target_headers(
   RdmpTci.hpp
   RdmpTciData.hpp
   Reconstruction.hpp
+  ReconstructionMethod.hpp
   SliceData.hpp
   SliceTensor.hpp
   SubcellOptions.hpp
@@ -41,6 +42,7 @@ spectre_target_sources(
   Projection.cpp
   RdmpTciData.cpp
   Reconstruction.cpp
+  ReconstructionMethod.cpp
   SliceData.cpp
   SubcellOptions.cpp
   TciStatus.cpp

--- a/src/Evolution/DgSubcell/Reconstruction.cpp
+++ b/src/Evolution/DgSubcell/Reconstruction.cpp
@@ -3,8 +3,11 @@
 
 #include "Evolution/DgSubcell/Reconstruction.hpp"
 
+#include <array>
 #include <cstddef>
+#include <functional>
 
+#include "DataStructures/ApplyMatrices.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Matrix.hpp"
 #include "Evolution/DgSubcell/Matrices.hpp"
@@ -14,6 +17,7 @@
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
 
 namespace evolution::dg::subcell::fd {
 namespace detail {
@@ -21,21 +25,45 @@ template <size_t Dim>
 void reconstruct_impl(
     gsl::span<double> dg_u,
     const gsl::span<const double> subcell_u_times_projected_det_jac,
-    const Mesh<Dim>& dg_mesh, const Index<Dim>& subcell_extents) {
+    const Mesh<Dim>& dg_mesh, const Index<Dim>& subcell_extents,
+    const ReconstructionMethod reconstruction_method) {
   const size_t number_of_components =
       dg_u.size() / dg_mesh.number_of_grid_points();
-  const Matrix& recons_matrix = reconstruction_matrix(dg_mesh, subcell_extents);
-  dgemm_<true>('N', 'N', recons_matrix.rows(), number_of_components,
-               recons_matrix.columns(), 1.0, recons_matrix.data(),
-               recons_matrix.rows(), subcell_u_times_projected_det_jac.data(),
-               recons_matrix.columns(), 0.0, dg_u.data(), recons_matrix.rows());
+  if (reconstruction_method == ReconstructionMethod::AllDimsAtOnce) {
+    const Matrix& recons_matrix =
+        reconstruction_matrix(dg_mesh, subcell_extents);
+    dgemm_<true>('N', 'N', recons_matrix.rows(), number_of_components,
+                 recons_matrix.columns(), 1.0, recons_matrix.data(),
+                 recons_matrix.rows(), subcell_u_times_projected_det_jac.data(),
+                 recons_matrix.columns(), 0.0, dg_u.data(),
+                 recons_matrix.rows());
+  } else {
+    ASSERT(reconstruction_method == ReconstructionMethod::DimByDim,
+           "reconstruction_method must be either DimByDim or AllDimsAtOnce");
+    // We multiply the last dim first because projection is done with the last
+    // dim last. We do this because it ensures the R(P)==I up to machine
+    // precision.
+    const Matrix empty{};
+    auto recons_matrices = make_array<Dim>(std::cref(empty));
+    for (size_t d = 0; d < Dim; d++) {
+      gsl::at(recons_matrices, d) = std::cref(reconstruction_matrix(
+          dg_mesh.slice_through(d), Index<1>{subcell_extents[d]}));
+    }
+    DataVector result{dg_u.data(), dg_u.size()};
+    const DataVector u{
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+        const_cast<double*>(subcell_u_times_projected_det_jac.data()),
+        subcell_u_times_projected_det_jac.size()};
+    apply_matrices(make_not_null(&result), recons_matrices, u, subcell_extents);
+  }
 }
 }  // namespace detail
 
 template <size_t Dim>
 void reconstruct(const gsl::not_null<DataVector*> dg_u,
                  const DataVector& subcell_u_times_projected_det_jac,
-                 const Mesh<Dim>& dg_mesh, const Index<Dim>& subcell_extents) {
+                 const Mesh<Dim>& dg_mesh, const Index<Dim>& subcell_extents,
+                 const ReconstructionMethod reconstruction_method) {
   ASSERT(subcell_u_times_projected_det_jac.size() == subcell_extents.product(),
          "Incorrect subcell size of u: "
              << subcell_u_times_projected_det_jac.size() << " but should be "
@@ -45,30 +73,33 @@ void reconstruct(const gsl::not_null<DataVector*> dg_u,
       gsl::span<double>{dg_u->data(), dg_u->size()},
       gsl::span<const double>{subcell_u_times_projected_det_jac.data(),
                               subcell_u_times_projected_det_jac.size()},
-      dg_mesh, subcell_extents);
+      dg_mesh, subcell_extents, reconstruction_method);
 }
 
 template <size_t Dim>
 DataVector reconstruct(const DataVector& subcell_u_times_projected_det_jac,
                        const Mesh<Dim>& dg_mesh,
-                       const Index<Dim>& subcell_extents) {
+                       const Index<Dim>& subcell_extents,
+                       const ReconstructionMethod reconstruction_method) {
   DataVector dg_u{dg_mesh.number_of_grid_points()};
   reconstruct(&dg_u, subcell_u_times_projected_det_jac, dg_mesh,
-              subcell_extents);
+              subcell_extents, reconstruction_method);
   return dg_u;
 }
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATION(r, data)                                                \
-  template DataVector reconstruct(const DataVector&, const Mesh<DIM(data)>&,  \
-                                  const Index<DIM(data)>&);                   \
-  template void reconstruct(gsl::not_null<DataVector*>, const DataVector&,    \
-                            const Mesh<DIM(data)>&, const Index<DIM(data)>&); \
-  template void detail::reconstruct_impl(                                     \
-      gsl::span<double> dg_u, const gsl::span<const double>,                  \
-      const Mesh<DIM(data)>& dg_mesh,                                         \
-      const Index<DIM(data)>& subcell_extents);
+#define INSTANTIATION(r, data)                                                 \
+  template DataVector reconstruct(const DataVector&, const Mesh<DIM(data)>&,   \
+                                  const Index<DIM(data)>&,                     \
+                                  ReconstructionMethod);                       \
+  template void reconstruct(gsl::not_null<DataVector*>, const DataVector&,     \
+                            const Mesh<DIM(data)>&, const Index<DIM(data)>&,   \
+                            ReconstructionMethod);                             \
+  template void detail::reconstruct_impl(                                      \
+      gsl::span<double> dg_u, const gsl::span<const double>,                   \
+      const Mesh<DIM(data)>& dg_mesh, const Index<DIM(data)>& subcell_extents, \
+      ReconstructionMethod);
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 

--- a/src/Evolution/DgSubcell/ReconstructionMethod.cpp
+++ b/src/Evolution/DgSubcell/ReconstructionMethod.cpp
@@ -1,0 +1,42 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/DgSubcell/ReconstructionMethod.hpp"
+
+#include <ostream>
+#include <string>
+
+#include "Options/Options.hpp"
+#include "Options/ParseOptions.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GetOutput.hpp"
+
+namespace evolution::dg::subcell::fd {
+std::ostream& operator<<(std::ostream& os, ReconstructionMethod recons_method) {
+  switch (recons_method) {
+    case ReconstructionMethod::DimByDim:
+      return os << "DimByDim";
+    case ReconstructionMethod::AllDimsAtOnce:
+      return os << "AllDimsAtOnce";
+    default:
+      ERROR("Unknown reconstruction method, must be DimByDim or AllDimsAtOnce");
+  }
+}
+}  // namespace evolution::dg::subcell::fd
+
+template <>
+evolution::dg::subcell::fd::ReconstructionMethod
+Options::create_from_yaml<evolution::dg::subcell::fd::ReconstructionMethod>::
+    create<void>(const Options::Option& options) {
+  const auto recons_method = options.parse_as<std::string>();
+  if (recons_method == get_output(type::DimByDim)) {
+    return type::DimByDim;
+  } else if (recons_method == get_output(type::AllDimsAtOnce)) {
+    return type::AllDimsAtOnce;
+  } else {
+    PARSE_ERROR(options.context(),
+                "ReconstructionMethod must be '"
+                    << get_output(type::DimByDim) << "', or '"
+                    << get_output(type::AllDimsAtOnce) << "'");
+  }
+}

--- a/src/Evolution/DgSubcell/ReconstructionMethod.hpp
+++ b/src/Evolution/DgSubcell/ReconstructionMethod.hpp
@@ -1,0 +1,39 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <iosfwd>
+
+#include "Options/Options.hpp"
+
+namespace evolution::dg::subcell::fd {
+/*!
+ * \brief The reconstruction method to use
+ */
+enum class ReconstructionMethod {
+  /// Dimension-by-dimension reconstruction assuming a tensor-product basis
+  DimByDim,
+  /// Reconstruct all dimensions at once.
+  AllDimsAtOnce
+};
+
+std::ostream& operator<<(std::ostream& os, ReconstructionMethod recons_method);
+}  // namespace evolution::dg::subcell::fd
+
+/// \cond
+template <>
+struct Options::create_from_yaml<
+    evolution::dg::subcell::fd::ReconstructionMethod> {
+  using type = evolution::dg::subcell::fd::ReconstructionMethod;
+  template <typename Metavariables>
+  static type create(const Options::Option& options) {
+    return create<void>(options);
+  }
+};
+
+template <>
+evolution::dg::subcell::fd::ReconstructionMethod
+Options::create_from_yaml<evolution::dg::subcell::fd::ReconstructionMethod>::
+    create<void>(const Options::Option& options);
+/// \endcond

--- a/src/Evolution/DgSubcell/SubcellOptions.cpp
+++ b/src/Evolution/DgSubcell/SubcellOptions.cpp
@@ -4,6 +4,7 @@
 #include "Evolution/DgSubcell/SubcellOptions.hpp"
 
 #include <pup.h>
+#include <pup_stl.h>
 
 namespace evolution::dg::subcell {
 SubcellOptions::SubcellOptions(double initial_data_rdmp_delta0,
@@ -11,14 +12,16 @@ SubcellOptions::SubcellOptions(double initial_data_rdmp_delta0,
                                double rdmp_delta0, double rdmp_epsilon,
                                double initial_data_persson_exponent,
                                double persson_exponent,
-                               bool always_use_subcells)
+                               bool always_use_subcells,
+                               fd::ReconstructionMethod recons_method)
     : initial_data_rdmp_delta0_(initial_data_rdmp_delta0),
       initial_data_rdmp_epsilon_(initial_data_rdmp_epsilon),
       rdmp_delta0_(rdmp_delta0),
       rdmp_epsilon_(rdmp_epsilon),
       initial_data_persson_exponent_(initial_data_persson_exponent),
       persson_exponent_(persson_exponent),
-      always_use_subcells_(always_use_subcells) {}
+      always_use_subcells_(always_use_subcells),
+      reconstruction_method_(recons_method) {}
 
 void SubcellOptions::pup(PUP::er& p) {
   p | initial_data_rdmp_delta0_;
@@ -28,6 +31,7 @@ void SubcellOptions::pup(PUP::er& p) {
   p | initial_data_persson_exponent_;
   p | persson_exponent_;
   p | always_use_subcells_;
+  p | reconstruction_method_;
 }
 
 bool operator==(const SubcellOptions& lhs, const SubcellOptions& rhs) {
@@ -38,7 +42,8 @@ bool operator==(const SubcellOptions& lhs, const SubcellOptions& rhs) {
          lhs.initial_data_persson_exponent() ==
              rhs.initial_data_persson_exponent() and
          lhs.persson_exponent() == rhs.persson_exponent() and
-         lhs.always_use_subcells() == rhs.always_use_subcells();
+         lhs.always_use_subcells() == rhs.always_use_subcells() and
+         lhs.reconstruction_method() == rhs.reconstruction_method();
 }
 
 bool operator!=(const SubcellOptions& lhs, const SubcellOptions& rhs) {

--- a/src/Evolution/DgSubcell/SubcellOptions.hpp
+++ b/src/Evolution/DgSubcell/SubcellOptions.hpp
@@ -6,6 +6,7 @@
 #include <limits>
 #include <string>
 
+#include "Evolution/DgSubcell/ReconstructionMethod.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -93,11 +94,19 @@ class SubcellOptions {
         "instead of DG."};
     using type = bool;
   };
+  /// Method to use for reconstructing the DG solution from the subcell
+  /// solution.
+  struct SubcellToDgReconstructionMethod {
+    static constexpr Options::String help{
+        "Method to use for reconstructing the DG solution from the subcell "
+        "solution."};
+    using type = fd::ReconstructionMethod;
+  };
 
   using options =
       tmpl::list<InitialDataRdmpDelta0, InitialDataRdmpEpsilon, RdmpDelta0,
                  RdmpEpsilon, InitialDataPerssonExponent, PerssonExponent,
-                 AlwaysUseSubcells>;
+                 AlwaysUseSubcells, SubcellToDgReconstructionMethod>;
 
   static constexpr Options::String help{
       "System-agnostic options for the DG-subcell method."};
@@ -106,7 +115,8 @@ class SubcellOptions {
   SubcellOptions(double initial_data_rdmp_delta0,
                  double initial_data_rdmp_epsilon, double rdmp_delta0,
                  double rdmp_epsilon, double initial_data_persson_exponent,
-                 double persson_exponent, bool always_use_subcells);
+                 double persson_exponent, bool always_use_subcells,
+                 fd::ReconstructionMethod recons_method);
 
   void pup(PUP::er& p);
 
@@ -128,6 +138,10 @@ class SubcellOptions {
 
   bool always_use_subcells() const { return always_use_subcells_; }
 
+  fd::ReconstructionMethod reconstruction_method() const {
+    return reconstruction_method_;
+  }
+
  private:
   double initial_data_rdmp_delta0_ =
       std::numeric_limits<double>::signaling_NaN();
@@ -139,6 +153,8 @@ class SubcellOptions {
       std::numeric_limits<double>::signaling_NaN();
   double persson_exponent_ = std::numeric_limits<double>::signaling_NaN();
   bool always_use_subcells_ = false;
+  fd::ReconstructionMethod reconstruction_method_ =
+      fd::ReconstructionMethod::AllDimsAtOnce;
 };
 
 bool operator==(const SubcellOptions& lhs, const SubcellOptions& rhs);

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/ResizeAndComputePrimitives.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/ResizeAndComputePrimitives.cpp
@@ -53,7 +53,8 @@ void ResizeAndComputePrims<OrderedListOfRecoverySchemes>::apply(
     evolution::dg::subcell::fd::reconstruct(
         make_not_null(&get(get<hydro::Tags::Pressure<DataVector>>(*prim_vars))),
         get(fd_pressure), dg_mesh, subcell_mesh.extents(),
-        evolution::dg::subcell::fd ::ReconstructionMethod::AllDimsAtOnce);
+        // Always do dim-by-dim reconstruction because it's fast
+        evolution::dg::subcell::fd ::ReconstructionMethod::DimByDim);
 
     // Compute the spatial metric, inverse spatial metric, and sqrt{det{spatial
     // metric}} on the DG grid since we need these for the prim recovery.

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/ResizeAndComputePrimitives.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/ResizeAndComputePrimitives.cpp
@@ -10,6 +10,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Evolution/DgSubcell/Reconstruction.hpp"
+#include "Evolution/DgSubcell/ReconstructionMethod.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.hpp"
@@ -51,7 +52,8 @@ void ResizeAndComputePrims<OrderedListOfRecoverySchemes>::apply(
     prim_vars->initialize(num_grid_points);
     evolution::dg::subcell::fd::reconstruct(
         make_not_null(&get(get<hydro::Tags::Pressure<DataVector>>(*prim_vars))),
-        get(fd_pressure), dg_mesh, subcell_mesh.extents());
+        get(fd_pressure), dg_mesh, subcell_mesh.extents(),
+        evolution::dg::subcell::fd ::ReconstructionMethod::AllDimsAtOnce);
 
     // Compute the spatial metric, inverse spatial metric, and sqrt{det{spatial
     // metric}} on the DG grid since we need these for the prim recovery.

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/NeighborPackagedData.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/NeighborPackagedData.hpp
@@ -29,9 +29,11 @@
 #include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/DgSubcell/Reconstruction.hpp"
 #include "Evolution/DgSubcell/ReconstructionMethod.hpp"
+#include "Evolution/DgSubcell/SubcellOptions.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/NeighborData.hpp"
 #include "Evolution/DgSubcell/Tags/OnSubcellFaces.hpp"
+#include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
 #include "Evolution/DiscontinuousGalerkin/Actions/NormalCovectorAndMagnitude.hpp"
 #include "Evolution/DiscontinuousGalerkin/Actions/PackageDataImpl.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/BoundaryCorrection.hpp"
@@ -97,6 +99,8 @@ struct NeighborPackagedData {
     const Mesh<3>& subcell_mesh =
         db::get<evolution::dg::subcell::Tags::Mesh<3>>(box);
     const Mesh<3>& dg_mesh = db::get<domain::Tags::Mesh<3>>(box);
+    const auto& subcell_options =
+        db::get<evolution::dg::subcell::Tags::SubcellOptions>(box);
 
     const auto volume_prims = evolution::dg::subcell::fd::project(
         db::get<typename System::primitive_variables_tag>(box), dg_mesh,
@@ -112,7 +116,8 @@ struct NeighborPackagedData {
         derived_boundary_corrections>([&box, &boundary_correction, &dg_mesh,
                                        &mortars_to_reconstruct_to,
                                        &nhbr_package_data, &nhbr_subcell_data,
-                                       &recons, &subcell_mesh, &volume_prims](
+                                       &recons, &subcell_mesh, &subcell_options,
+                                       &volume_prims](
                                           auto derived_correction_v) {
       using DerivedCorrection = tmpl::type_from<decltype(derived_correction_v)>;
       if (typeid(boundary_correction) == typeid(DerivedCorrection)) {
@@ -225,7 +230,7 @@ struct NeighborPackagedData {
           auto dg_packaged_data = evolution::dg::subcell::fd::reconstruct(
               packaged_data, dg_mesh.slice_away(mortar_id.first.dimension()),
               subcell_mesh.extents().slice_away(mortar_id.first.dimension()),
-              evolution::dg::subcell::fd::ReconstructionMethod::AllDimsAtOnce);
+              subcell_options.reconstruction_method());
           nhbr_package_data[mortar_id] = std::vector<double>{
               dg_packaged_data.data(),
               dg_packaged_data.data() + dg_packaged_data.size()};

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/NeighborPackagedData.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/NeighborPackagedData.hpp
@@ -28,6 +28,7 @@
 #include "Evolution/BoundaryCorrectionTags.hpp"
 #include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/DgSubcell/Reconstruction.hpp"
+#include "Evolution/DgSubcell/ReconstructionMethod.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/NeighborData.hpp"
 #include "Evolution/DgSubcell/Tags/OnSubcellFaces.hpp"
@@ -223,7 +224,8 @@ struct NeighborPackagedData {
           // matter.
           auto dg_packaged_data = evolution::dg::subcell::fd::reconstruct(
               packaged_data, dg_mesh.slice_away(mortar_id.first.dimension()),
-              subcell_mesh.extents().slice_away(mortar_id.first.dimension()));
+              subcell_mesh.extents().slice_away(mortar_id.first.dimension()),
+              evolution::dg::subcell::fd::ReconstructionMethod::AllDimsAtOnce);
           nhbr_package_data[mortar_id] = std::vector<double>{
               dg_packaged_data.data(),
               dg_packaged_data.data() + dg_packaged_data.size()};

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ResizeAndComputePrimitives.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ResizeAndComputePrimitives.cpp
@@ -10,6 +10,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Evolution/DgSubcell/Reconstruction.hpp"
+#include "Evolution/DgSubcell/ReconstructionMethod.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.hpp"
@@ -52,7 +53,8 @@ void ResizeAndComputePrims<OrderedListOfRecoverySchemes>::apply(
     prim_vars->initialize(num_grid_points);
     evolution::dg::subcell::fd::reconstruct(
         make_not_null(&get(get<hydro::Tags::Pressure<DataVector>>(*prim_vars))),
-        get(fd_pressure), dg_mesh, subcell_mesh.extents());
+        get(fd_pressure), dg_mesh, subcell_mesh.extents(),
+        evolution::dg::subcell::fd ::ReconstructionMethod::AllDimsAtOnce);
 
     // We only need to compute the prims if we switched to the DG grid because
     // otherwise we computed the prims during the FD TCI.

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ResizeAndComputePrimitives.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ResizeAndComputePrimitives.cpp
@@ -54,7 +54,8 @@ void ResizeAndComputePrims<OrderedListOfRecoverySchemes>::apply(
     evolution::dg::subcell::fd::reconstruct(
         make_not_null(&get(get<hydro::Tags::Pressure<DataVector>>(*prim_vars))),
         get(fd_pressure), dg_mesh, subcell_mesh.extents(),
-        evolution::dg::subcell::fd ::ReconstructionMethod::AllDimsAtOnce);
+        // Always do dim-by-dim reconstruction because it's fast
+        evolution::dg::subcell::fd ::ReconstructionMethod::DimByDim);
 
     // We only need to compute the prims if we switched to the DG grid because
     // otherwise we computed the prims during the FD TCI.

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/NeighborPackagedData.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/NeighborPackagedData.hpp
@@ -28,6 +28,7 @@
 #include "Evolution/BoundaryCorrectionTags.hpp"
 #include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/DgSubcell/Reconstruction.hpp"
+#include "Evolution/DgSubcell/ReconstructionMethod.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/NeighborData.hpp"
 #include "Evolution/DiscontinuousGalerkin/Actions/NormalCovectorAndMagnitude.hpp"
@@ -200,7 +201,9 @@ struct NeighborPackagedData {
             // matter.
             auto dg_packaged_data = evolution::dg::subcell::fd::reconstruct(
                 packaged_data, dg_mesh.slice_away(mortar_id.first.dimension()),
-                subcell_mesh.extents().slice_away(mortar_id.first.dimension()));
+                subcell_mesh.extents().slice_away(mortar_id.first.dimension()),
+                evolution::dg::subcell::fd::ReconstructionMethod::
+                    AllDimsAtOnce);
             neighbor_package_data[mortar_id] = std::vector<double>{
                 dg_packaged_data.data(),
                 dg_packaged_data.data() + dg_packaged_data.size()};

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/NeighborPackagedData.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/NeighborPackagedData.hpp
@@ -25,6 +25,7 @@
 #include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/DgSubcell/Reconstruction.hpp"
+#include "Evolution/DgSubcell/ReconstructionMethod.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/NeighborData.hpp"
 #include "Evolution/DgSubcell/Tags/OnSubcellFaces.hpp"
@@ -204,7 +205,9 @@ struct NeighborPackagedData {
                     packaged_data,
                     dg_mesh.slice_away(mortar_id.first.dimension()),
                     subcell_mesh.extents().slice_away(
-                        mortar_id.first.dimension()));
+                        mortar_id.first.dimension()),
+                    evolution::dg::subcell::fd::ReconstructionMethod::
+                        AllDimsAtOnce);
             neighbor_package_data[mortar_id] = std::vector<double>{
                 dg_packaged_data.data(),
                 dg_packaged_data.data() + dg_packaged_data.size()};

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/NeighborPackagedData.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/NeighborPackagedData.hpp
@@ -26,9 +26,11 @@
 #include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/DgSubcell/Reconstruction.hpp"
 #include "Evolution/DgSubcell/ReconstructionMethod.hpp"
+#include "Evolution/DgSubcell/SubcellOptions.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/NeighborData.hpp"
 #include "Evolution/DgSubcell/Tags/OnSubcellFaces.hpp"
+#include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
 #include "Evolution/DiscontinuousGalerkin/Actions/PackageDataImpl.hpp"
 #include "Evolution/DiscontinuousGalerkin/NormalVectorTags.hpp"
 #include "Evolution/Systems/ScalarAdvection/BoundaryCorrections/BoundaryCorrection.hpp"
@@ -89,6 +91,8 @@ struct NeighborPackagedData {
     const Mesh<Dim>& dg_mesh = db::get<domain::Tags::Mesh<Dim>>(box);
     const Mesh<Dim>& subcell_mesh =
         db::get<evolution::dg::subcell::Tags::Mesh<Dim>>(box);
+    const auto& subcell_options =
+        db::get<evolution::dg::subcell::Tags::SubcellOptions>(box);
     const auto volume_vars_subcell = evolution::dg::subcell::fd::project(
         db::get<typename System<Dim>::variables_tag>(box), dg_mesh,
         subcell_mesh.extents());
@@ -206,8 +210,7 @@ struct NeighborPackagedData {
                     dg_mesh.slice_away(mortar_id.first.dimension()),
                     subcell_mesh.extents().slice_away(
                         mortar_id.first.dimension()),
-                    evolution::dg::subcell::fd::ReconstructionMethod::
-                        AllDimsAtOnce);
+                    subcell_options.reconstruction_method());
             neighbor_package_data[mortar_id] = std::vector<double>{
                 dg_packaged_data.data(),
                 dg_packaged_data.data() + dg_packaged_data.size()};

--- a/tests/InputFiles/Burgers/Step.yaml
+++ b/tests/InputFiles/Burgers/Step.yaml
@@ -52,6 +52,7 @@ SpatialDiscretization:
         RdmpEpsilon: 1.0e-3
         PerssonExponent: 4.0
       AlwaysUseSubcells: false
+      SubcellToDgReconstructionMethod: DimByDim
   SubcellSolver:
     Reconstructor: MonotisedCentral
 

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -42,6 +42,7 @@ SpatialDiscretization:
         RdmpEpsilon: 1.0e-3
         PerssonExponent: 4.0
       AlwaysUseSubcells: false
+      SubcellToDgReconstructionMethod: DimByDim
     TciOptions:
       MinimumValueOfD: 1.0e-20
       MinimumValueOfTildeTau: 1.0e-50

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -54,6 +54,7 @@ SpatialDiscretization:
         RdmpEpsilon: 1.0e-3
         PerssonExponent: 4.0
       AlwaysUseSubcells: false
+      SubcellToDgReconstructionMethod: DimByDim
     TciOptions:
       MinimumValueOfD: 1.0e-20
       MinimumValueOfTildeTau: 1.0e-50

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
@@ -38,6 +38,7 @@ SpatialDiscretization:
       RdmpEpsilon: 1.0e-3
       PerssonExponent: 4.0
       AlwaysUseSubcells: false
+      SubcellToDgReconstructionMethod: DimByDim
   SubcellSolver:
     Reconstructor:
       MonotisedCentralPrim:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
@@ -36,6 +36,7 @@ SpatialDiscretization:
       RdmpEpsilon: 1.0e-3
       PerssonExponent: 4.0
       AlwaysUseSubcells: false
+      SubcellToDgReconstructionMethod: DimByDim
   SubcellSolver:
     Reconstructor:
       MonotisedCentralPrim:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
@@ -36,6 +36,7 @@ SpatialDiscretization:
       RdmpEpsilon: 1.0e-3
       PerssonExponent: 4.0
       AlwaysUseSubcells: false
+      SubcellToDgReconstructionMethod: DimByDim
   SubcellSolver:
     Reconstructor:
       MonotisedCentralPrim:

--- a/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
@@ -39,6 +39,7 @@ SpatialDiscretization:
         RdmpEpsilon: 1.0e-3
         PerssonExponent: 4.0
       AlwaysUseSubcells: false
+      SubcellToDgReconstructionMethod: DimByDim
   SubcellSolver:
     Reconstructor:
       MonotisedCentral

--- a/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
@@ -37,6 +37,7 @@ SpatialDiscretization:
         RdmpEpsilon: 1.0e-3
         PerssonExponent: 4.0
       AlwaysUseSubcells: false
+      SubcellToDgReconstructionMethod: DimByDim
   SubcellSolver:
     Reconstructor:
       MonotisedCentral

--- a/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
@@ -39,6 +39,7 @@ SpatialDiscretization:
         RdmpEpsilon: 1.0e-3
         PerssonExponent: 4.0
       AlwaysUseSubcells: false
+      SubcellToDgReconstructionMethod: DimByDim
   SubcellSolver:
     Reconstructor:
       MonotisedCentral

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_Initialize.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_Initialize.cpp
@@ -27,6 +27,7 @@
 #include "Evolution/DgSubcell/ActiveGrid.hpp"
 #include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/Projection.hpp"
+#include "Evolution/DgSubcell/ReconstructionMethod.hpp"
 #include "Evolution/DgSubcell/SubcellOptions.hpp"
 #include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
 #include "Evolution/DgSubcell/Tags/Coordinates.hpp"
@@ -174,8 +175,9 @@ void test(const bool always_use_subcell, const bool interior_element) {
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
   MockRuntimeSystem runner{
       {SystemAnalyticSolution{},
-       evolution::dg::subcell::SubcellOptions{1.0e-3, 1.0e-4, 2.0e-3, 2.0e-4,
-                                              4.0, 4.1, always_use_subcell}}};
+       evolution::dg::subcell::SubcellOptions{
+           1.0e-3, 1.0e-4, 2.0e-3, 2.0e-4, 4.0, 4.1, always_use_subcell,
+           evolution::dg::subcell::fd::ReconstructionMethod::DimByDim}}};
   Metavariables<Dim, TciFails>::DgInitialDataTci::invoked = false;
 
   const Mesh<Dim> dg_mesh{5, Spectral::Basis::Legendre,

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndRollback.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndRollback.cpp
@@ -29,7 +29,7 @@
 #include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/DgSubcell/RdmpTciData.hpp"
-#include "Evolution/DgSubcell/Reconstruction.hpp"
+#include "Evolution/DgSubcell/ReconstructionMethod.hpp"
 #include "Evolution/DgSubcell/SubcellOptions.hpp"
 #include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
 #include "Evolution/DgSubcell/Tags/DataForRdmpTci.hpp"
@@ -199,7 +199,8 @@ void test_impl(const bool rdmp_fails, const bool tci_fails,
   using comp = component<Dim, metavars>;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
   MockRuntimeSystem runner{{evolution::dg::subcell::SubcellOptions{
-      1.0e-3, 1.0e-4, 2.0e-3, 2.0e-4, 5.0, 4.0, always_use_subcell}}};
+      1.0e-3, 1.0e-4, 2.0e-3, 2.0e-4, 5.0, 4.0, always_use_subcell,
+      evolution::dg::subcell::fd::ReconstructionMethod::DimByDim}}};
 
   const TimeStepId time_step_id{true, self_starting ? -1 : 1,
                                 Time{Slab{1.0, 2.0}, {0, 10}}};

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndSwitchToDg.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndSwitchToDg.cpp
@@ -114,19 +114,22 @@ struct Metavariables {
     using argument_tags =
         tmpl::list<evolution::dg::subcell::Tags::Inactive<
                        Tags::Variables<tmpl::list<Var1>>>,
-                   Tags::Variables<tmpl::list<Var1>>, domain::Tags::Mesh<Dim>>;
+                   Tags::Variables<tmpl::list<Var1>>, domain::Tags::Mesh<Dim>,
+                   evolution::dg::subcell::Tags::SubcellOptions>;
 
     static bool apply(
         const Variables<
             tmpl::list<evolution::dg::subcell::Tags::Inactive<Var1>>>& dg_vars,
         const Variables<tmpl::list<Var1>>& subcell_vars,
-        const Mesh<Dim>& dg_mesh, const double persson_exponent) {
+        const Mesh<Dim>& dg_mesh,
+        const evolution::dg::subcell::SubcellOptions& subcell_options,
+        const double persson_exponent) {
       Variables<tmpl::list<evolution::dg::subcell::Tags::Inactive<Var1>>>
           reconstructed_dg_vars{dg_vars.number_of_grid_points()};
       evolution::dg::subcell::fd::reconstruct(
           make_not_null(&reconstructed_dg_vars), subcell_vars, dg_mesh,
           evolution::dg::subcell::fd::mesh(dg_mesh).extents(),
-          evolution::dg::subcell::fd::ReconstructionMethod::AllDimsAtOnce);
+          subcell_options.reconstruction_method());
       CHECK(reconstructed_dg_vars == dg_vars);
       CHECK(approx(persson_exponent) == 5.0);  // Should be subcell_opts + 1
       tci_invoked = true;
@@ -155,9 +158,11 @@ std::unique_ptr<TimeStepper> make_time_stepper(
 }
 
 template <size_t Dim>
-void test_impl(const bool multistep_time_stepper, const bool rdmp_fails,
-               const bool tci_fails, const bool always_use_subcell,
-               const bool self_starting, const bool in_substep) {
+void test_impl(
+    const bool multistep_time_stepper, const bool rdmp_fails,
+    const bool tci_fails, const bool always_use_subcell,
+    const bool self_starting, const bool in_substep,
+    const evolution::dg::subcell::fd::ReconstructionMethod recons_method) {
   CAPTURE(Dim);
   CAPTURE(multistep_time_stepper);
   CAPTURE(rdmp_fails);
@@ -165,6 +170,7 @@ void test_impl(const bool multistep_time_stepper, const bool rdmp_fails,
   CAPTURE(always_use_subcell);
   CAPTURE(self_starting);
   CAPTURE(in_substep);
+  CAPTURE(recons_method);
   if (in_substep and multistep_time_stepper) {
     ERROR("Can't both be taking a substep and using a multistep time stepper");
   }
@@ -177,7 +183,8 @@ void test_impl(const bool multistep_time_stepper, const bool rdmp_fails,
   using comp = component<Dim, metavars>;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
   MockRuntimeSystem runner{{evolution::dg::subcell::SubcellOptions{
-      1.0e-3, 1.0e-4, 2.0e-3, 2.0e-4, 4.0, 4.0, always_use_subcell}}};
+      1.0e-3, 1.0e-4, 2.0e-3, 2.0e-4, 4.0, 4.0, always_use_subcell,
+      recons_method}}};
 
   TimeStepId time_step_id{true, self_starting ? -1 : 1,
                           Time{Slab{1.0, 2.0}, {0, 10}}};
@@ -293,8 +300,7 @@ void test_impl(const bool multistep_time_stepper, const bool rdmp_fails,
     auto reconstructed_dg_vars = inactive_evolved_vars;
     evolution::dg::subcell::fd::reconstruct(
         make_not_null(&reconstructed_dg_vars), evolved_vars, dg_mesh,
-        subcell_mesh.extents(),
-        evolution::dg::subcell::fd::ReconstructionMethod::AllDimsAtOnce);
+        subcell_mesh.extents(), recons_method);
     if (active_grid_from_box == evolution::dg::subcell::ActiveGrid::Subcell) {
       CHECK(reconstructed_dg_vars == inactive_vars_from_box);
     } else {
@@ -306,20 +312,17 @@ void test_impl(const bool multistep_time_stepper, const bool rdmp_fails,
   }
 
   if (active_grid_from_box == evolution::dg::subcell::ActiveGrid::Dg) {
-    CHECK(
-        evolution::dg::subcell::fd::reconstruct(
-            time_stepper_history.most_recent_value(), dg_mesh,
-            subcell_mesh.extents(),
-            evolution::dg::subcell::fd::ReconstructionMethod::AllDimsAtOnce) ==
-        time_stepper_history_from_box.most_recent_value());
+    CHECK(evolution::dg::subcell::fd::reconstruct(
+              time_stepper_history.most_recent_value(), dg_mesh,
+              subcell_mesh.extents(), recons_method) ==
+          time_stepper_history_from_box.most_recent_value());
     for (auto expected_it = time_stepper_history.cbegin(),
               box_it = time_stepper_history_from_box.cbegin();
          expected_it != time_stepper_history.end(); ++expected_it, ++box_it) {
       CHECK(expected_it.time_step_id() == box_it.time_step_id());
       CHECK(evolution::dg::subcell::fd::reconstruct(
                 expected_it.derivative(), dg_mesh, subcell_mesh.extents(),
-                evolution::dg::subcell::fd::ReconstructionMethod::
-                    AllDimsAtOnce) == box_it.derivative());
+                recons_method) == box_it.derivative());
     }
     CHECK(tci_grid_history_from_box.empty());
   } else {
@@ -357,11 +360,18 @@ void test() {
       for (const bool tci_fails : {false, true}) {
         for (const bool always_use_subcell : {false, true}) {
           for (const bool self_starting : {false, true}) {
-            test_impl<Dim>(use_multistep_time_stepper, rdmp_fails, tci_fails,
-                           always_use_subcell, self_starting, false);
-            if (not use_multistep_time_stepper) {
+            for (const auto recons_method :
+                 {evolution::dg::subcell::fd::ReconstructionMethod::
+                      AllDimsAtOnce,
+                  evolution::dg::subcell::fd::ReconstructionMethod::DimByDim}) {
               test_impl<Dim>(use_multistep_time_stepper, rdmp_fails, tci_fails,
-                             always_use_subcell, self_starting, true);
+                             always_use_subcell, self_starting, false,
+                             recons_method);
+              if (not use_multistep_time_stepper) {
+                test_impl<Dim>(use_multistep_time_stepper, rdmp_fails,
+                               tci_fails, always_use_subcell, self_starting,
+                               true, recons_method);
+              }
             }
           }
         }

--- a/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
+++ b/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
@@ -24,6 +24,7 @@ set(LIBRARY_SOURCES
   Test_RdmpTci.cpp
   Test_RdmpTciData.cpp
   Test_Reconstruction.cpp
+  Test_ReconstructionMethod.cpp
   Test_SliceData.cpp
   Test_SliceTensor.cpp
   Test_SubcellOptions.cpp

--- a/tests/Unit/Evolution/DgSubcell/Test_ReconstructionMethod.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_ReconstructionMethod.cpp
@@ -1,0 +1,31 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "Evolution/DgSubcell/ReconstructionMethod.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+template <evolution::dg::subcell::fd::ReconstructionMethod ReconsMethod>
+void test_construct_from_options() {
+  const auto created = TestHelpers::test_creation<
+      evolution::dg::subcell::fd::ReconstructionMethod>(
+      get_output(ReconsMethod));
+  CHECK(created == ReconsMethod);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Fd.ReconstructionMethod",
+                  "[Evolution][Unit]") {
+  using evolution::dg::subcell::fd::ReconstructionMethod;
+  CHECK(get_output(ReconstructionMethod::DimByDim) == "DimByDim");
+  CHECK(get_output(ReconstructionMethod::AllDimsAtOnce) == "AllDimsAtOnce");
+
+  test_construct_from_options<ReconstructionMethod::DimByDim>();
+  test_construct_from_options<ReconstructionMethod::AllDimsAtOnce>();
+}

--- a/tests/Unit/Evolution/DgSubcell/Test_SubcellOptions.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_SubcellOptions.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include "Evolution/DgSubcell/ReconstructionMethod.hpp"
 #include "Evolution/DgSubcell/SubcellOptions.hpp"
 #include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
 #include "Framework/TestCreation.hpp"
@@ -18,30 +19,51 @@ void test_impl(const std::vector<double>& expected_values,
                const size_t incorrect_value_index) {
   std::vector<double> values = expected_values;
   values[incorrect_value_index] += 0.1;
+  const fd::ReconstructionMethod recons_method =
+      fd::ReconstructionMethod::AllDimsAtOnce;
 
   CHECK(SubcellOptions(expected_values[0], expected_values[1],
                        expected_values[2], expected_values[3],
-                       expected_values[4], expected_values[5], false) !=
+                       expected_values[4], expected_values[5], false,
+                       recons_method) !=
         SubcellOptions(values[0], values[1], values[2], values[3], values[4],
-                       values[5], false));
+                       values[5], false, recons_method));
   CHECK_FALSE(SubcellOptions(expected_values[0], expected_values[1],
                              expected_values[2], expected_values[3],
-                             expected_values[4], expected_values[5], false) ==
+                             expected_values[4], expected_values[5], false,
+                             recons_method) ==
               SubcellOptions(values[0], values[1], values[2], values[3],
-                             values[4], values[5], false));
+                             values[4], values[5], false, recons_method));
 
-  CHECK(SubcellOptions(expected_values[0], expected_values[1],
-                       expected_values[2], expected_values[3],
-                       expected_values[4], expected_values[5], false) !=
-        SubcellOptions(expected_values[0], expected_values[1],
-                       expected_values[2], expected_values[3],
-                       expected_values[4], expected_values[5], true));
-  CHECK_FALSE(SubcellOptions(expected_values[0], expected_values[1],
-                             expected_values[2], expected_values[3],
-                             expected_values[4], expected_values[5], false) ==
-              SubcellOptions(expected_values[0], expected_values[1],
-                             expected_values[2], expected_values[3],
-                             expected_values[4], expected_values[5], true));
+  CHECK(
+      SubcellOptions(expected_values[0], expected_values[1], expected_values[2],
+                     expected_values[3], expected_values[4], expected_values[5],
+                     false, recons_method) !=
+      SubcellOptions(expected_values[0], expected_values[1], expected_values[2],
+                     expected_values[3], expected_values[4], expected_values[5],
+                     true, recons_method));
+  CHECK_FALSE(
+      SubcellOptions(expected_values[0], expected_values[1], expected_values[2],
+                     expected_values[3], expected_values[4], expected_values[5],
+                     false, recons_method) ==
+      SubcellOptions(expected_values[0], expected_values[1], expected_values[2],
+                     expected_values[3], expected_values[4], expected_values[5],
+                     true, recons_method));
+
+  CHECK(
+      SubcellOptions(expected_values[0], expected_values[1], expected_values[2],
+                     expected_values[3], expected_values[4], expected_values[5],
+                     false, recons_method) !=
+      SubcellOptions(expected_values[0], expected_values[1], expected_values[2],
+                     expected_values[3], expected_values[4], expected_values[5],
+                     false, fd::ReconstructionMethod::DimByDim));
+  CHECK_FALSE(
+      SubcellOptions(expected_values[0], expected_values[1], expected_values[2],
+                     expected_values[3], expected_values[4], expected_values[5],
+                     false, recons_method) ==
+      SubcellOptions(expected_values[0], expected_values[1], expected_values[2],
+                     expected_values[3], expected_values[4], expected_values[5],
+                     false, fd::ReconstructionMethod::DimByDim));
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.Subcell.SubcellOptions",
@@ -54,21 +76,22 @@ SPECTRE_TEST_CASE("Unit.Evolution.Subcell.SubcellOptions",
 
   const SubcellOptions options(expected_values[0], expected_values[1],
                                expected_values[2], expected_values[3],
-                               expected_values[4], expected_values[5], true);
+                               expected_values[4], expected_values[5], true,
+                               fd::ReconstructionMethod::DimByDim);
   const SubcellOptions deserialized_options =
       serialize_and_deserialize(options);
   CHECK(options == deserialized_options);
 
-  CHECK(options ==
-        TestHelpers::test_option_tag<OptionTags::SubcellOptions>(
-            "InitialData:\n"
-            "  RdmpDelta0: 1.0e-3\n"
-            "  RdmpEpsilon: 1.0e-4\n"
-            "  PerssonExponent: 5.0\n"
-            "RdmpDelta0: 2.0e-3\n"
-            "RdmpEpsilon: 2.0e-4\n"
-            "PerssonExponent: 4.0\n"
-            "AlwaysUseSubcells: true\n"));
+  CHECK(options == TestHelpers::test_option_tag<OptionTags::SubcellOptions>(
+                       "InitialData:\n"
+                       "  RdmpDelta0: 1.0e-3\n"
+                       "  RdmpEpsilon: 1.0e-4\n"
+                       "  PerssonExponent: 5.0\n"
+                       "RdmpDelta0: 2.0e-3\n"
+                       "RdmpEpsilon: 2.0e-4\n"
+                       "PerssonExponent: 4.0\n"
+                       "AlwaysUseSubcells: true\n"
+                       "SubcellToDgReconstructionMethod: DimByDim\n"));
 }
 }  // namespace
 }  // namespace evolution::dg::subcell

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_PrimsAfterRollback.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_PrimsAfterRollback.cpp
@@ -18,6 +18,7 @@
 #include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/DgSubcell/Reconstruction.hpp"
+#include "Evolution/DgSubcell/ReconstructionMethod.hpp"
 #include "Evolution/DgSubcell/Tags/DidRollback.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/PrimsAfterRollback.hpp"
@@ -116,8 +117,9 @@ void test(const gsl::not_null<std::mt19937*> gen,
             subcell_prims),
         sqrt_det_spatial_metric, spatial_metric,
         get<hydro::Tags::DivergenceCleaningField<DataVector>>(subcell_prims));
-    dg_prims = evolution::dg::subcell::fd::reconstruct(subcell_prims, dg_mesh,
-                                                       subcell_mesh.extents());
+    dg_prims = evolution::dg::subcell::fd::reconstruct(
+        subcell_prims, dg_mesh, subcell_mesh.extents(),
+        evolution::dg::subcell::fd::ReconstructionMethod::AllDimsAtOnce);
   }
 
   // The DG prims are used as an initial guess so we need to provide them

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_ResizeAndComputePrimitives.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_ResizeAndComputePrimitives.cpp
@@ -18,6 +18,7 @@
 #include "Evolution/DgSubcell/ActiveGrid.hpp"
 #include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/Reconstruction.hpp"
+#include "Evolution/DgSubcell/ReconstructionMethod.hpp"
 #include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/ResizeAndComputePrimitives.hpp"
@@ -127,7 +128,8 @@ void test(const gsl::not_null<std::mt19937*> gen,
   };
   if (active_grid == evolution::dg::subcell::ActiveGrid::Dg) {
     const auto dg_prims = evolution::dg::subcell::fd::reconstruct(
-        prim_vars, dg_mesh, subcell_mesh.extents());
+        prim_vars, dg_mesh, subcell_mesh.extents(),
+        evolution::dg::subcell::fd ::ReconstructionMethod::AllDimsAtOnce);
     compute_cons(dg_prims);
   } else {
     compute_cons(prim_vars);

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
@@ -28,10 +28,12 @@
 #include "Evolution/BoundaryCorrectionTags.hpp"
 #include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/SliceData.hpp"
+#include "Evolution/DgSubcell/SubcellOptions.hpp"
 #include "Evolution/DgSubcell/Tags/Coordinates.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/NeighborData.hpp"
 #include "Evolution/DgSubcell/Tags/OnSubcellFaces.hpp"
+#include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
 #include "Evolution/DiscontinuousGalerkin/Actions/NormalCovectorAndMagnitude.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarTags.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/BoundaryCorrection.hpp"
@@ -227,7 +229,8 @@ double test(const size_t num_dg_pts) {
           evolution::dg::subcell::Tags::NeighborDataForReconstruction<3>,
           Tags::ConstraintDampingParameter, evolution::dg::Tags::MortarData<3>,
           domain::Tags::MeshVelocity<3>,
-          evolution::dg::Tags::NormalCovectorAndMagnitude<3>>,
+          evolution::dg::Tags::NormalCovectorAndMagnitude<3>,
+          evolution::dg::subcell::Tags::SubcellOptions>,
       db::AddComputeTags<
           evolution::dg::subcell::Tags::LogicalCoordinatesCompute<3>>>(
       element, dg_mesh, subcell_mesh,
@@ -242,7 +245,10 @@ double test(const size_t num_dg_pts) {
       typename variables_tag::type{dg_mesh.number_of_grid_points()},
       face_centered_gr_tags(subcell_mesh, time, coordinate_map, soln),
       neighbor_data, 1.0, evolution::dg::Tags::MortarData<3>::type{},
-      std::optional<tnsr::I<DataVector, 3, Frame::Inertial>>{}, normal_vectors);
+      std::optional<tnsr::I<DataVector, 3, Frame::Inertial>>{}, normal_vectors,
+      evolution::dg::subcell::SubcellOptions{
+          1.0e-3, 1.0e-4, 1.0e-3, 1.0e-4, 4.0, 4.0, false,
+          evolution::dg::subcell::fd::ReconstructionMethod::DimByDim});
   db::mutate_apply<ConservativeFromPrimitive>(make_not_null(&box));
 
   std::vector<std::pair<Direction<3>, ElementId<3>>>

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_PrimsAfterRollback.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_PrimsAfterRollback.cpp
@@ -18,6 +18,7 @@
 #include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/DgSubcell/Reconstruction.hpp"
+#include "Evolution/DgSubcell/ReconstructionMethod.hpp"
 #include "Evolution/DgSubcell/Tags/DidRollback.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.hpp"
@@ -112,8 +113,9 @@ void test(const gsl::not_null<std::mt19937*> gen,
             subcell_prims),
         sqrt_det_spatial_metric, spatial_metric,
         get<hydro::Tags::DivergenceCleaningField<DataVector>>(subcell_prims));
-    dg_prims = evolution::dg::subcell::fd::reconstruct(subcell_prims, dg_mesh,
-                                                       subcell_mesh.extents());
+    dg_prims = evolution::dg::subcell::fd::reconstruct(
+        subcell_prims, dg_mesh, subcell_mesh.extents(),
+        evolution::dg::subcell::fd::ReconstructionMethod::AllDimsAtOnce);
   }
 
   // The DG prims are used as an initial guess so we need to provide them

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_ResizeAndComputePrimitives.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_ResizeAndComputePrimitives.cpp
@@ -19,6 +19,7 @@
 #include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/DgSubcell/Reconstruction.hpp"
+#include "Evolution/DgSubcell/ReconstructionMethod.hpp"
 #include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.hpp"
@@ -121,7 +122,8 @@ void test(const gsl::not_null<std::mt19937*> gen,
   };
   if (active_grid == evolution::dg::subcell::ActiveGrid::Dg) {
     const auto dg_prims = evolution::dg::subcell::fd::reconstruct(
-        prim_vars, dg_mesh, subcell_mesh.extents());
+        prim_vars, dg_mesh, subcell_mesh.extents(),
+        evolution::dg::subcell::fd ::ReconstructionMethod::AllDimsAtOnce);
     compute_cons(dg_prims);
   } else {
     compute_cons(prim_vars);

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_NeighborPackagedData.cpp
@@ -34,9 +34,11 @@
 #include "Evolution/BoundaryCorrectionTags.hpp"
 #include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/SliceData.hpp"
+#include "Evolution/DgSubcell/SubcellOptions.hpp"
 #include "Evolution/DgSubcell/Tags/Coordinates.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/NeighborData.hpp"
+#include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
 #include "Evolution/DiscontinuousGalerkin/Actions/NormalCovectorAndMagnitude.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarTags.hpp"
 #include "Evolution/Systems/NewtonianEuler/BoundaryCorrections/BoundaryCorrection.hpp"
@@ -238,7 +240,8 @@ double test(const size_t num_dg_pts) {
           typename system::primitive_variables_tag, variables_tag,
           evolution::dg::subcell::Tags::NeighborDataForReconstruction<Dim>,
           evolution::dg::Tags::MortarData<Dim>, domain::Tags::MeshVelocity<Dim>,
-          evolution::dg::Tags::NormalCovectorAndMagnitude<Dim>>,
+          evolution::dg::Tags::NormalCovectorAndMagnitude<Dim>,
+          evolution::dg::subcell::Tags::SubcellOptions>,
       db::AddComputeTags<
           evolution::dg::subcell::Tags::LogicalCoordinatesCompute<Dim>>>(
       MetaVars<Dim>{}, element, dg_mesh, subcell_mesh,
@@ -251,7 +254,10 @@ double test(const size_t num_dg_pts) {
       typename variables_tag::type{dg_mesh.number_of_grid_points()},
       neighbor_data, typename evolution::dg::Tags::MortarData<Dim>::type{},
       std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>{},
-      normal_vectors);
+      normal_vectors,
+      evolution::dg::subcell::SubcellOptions{
+          1.0e-3, 1.0e-4, 1.0e-3, 1.0e-4, 4.0, 4.0, false,
+          evolution::dg::subcell::fd::ReconstructionMethod::DimByDim});
 
   db::mutate_apply<NewtonianEuler::ConservativeFromPrimitive<Dim>>(
       make_not_null(&box));

--- a/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_NeighborPackagedData.cpp
@@ -33,11 +33,13 @@
 #include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/DgSubcell/Reconstruction.hpp"
 #include "Evolution/DgSubcell/ReconstructionMethod.hpp"
+#include "Evolution/DgSubcell/SubcellOptions.hpp"
 #include "Evolution/DgSubcell/Tags/Coordinates.hpp"
 #include "Evolution/DgSubcell/Tags/Inactive.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/NeighborData.hpp"
 #include "Evolution/DgSubcell/Tags/OnSubcellFaces.hpp"
+#include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
 #include "Evolution/DiscontinuousGalerkin/Actions/NormalCovectorAndMagnitude.hpp"
 #include "Evolution/DiscontinuousGalerkin/NormalVectorTags.hpp"
 #include "Evolution/Initialization/Tags.hpp"
@@ -180,7 +182,8 @@ void test_neighbor_packaged_data(const size_t num_dg_pts_per_dimension,
       evolution::dg::subcell::Tags::Coordinates<Dim, Frame::ElementLogical>,
       subcell_velocity_field, subcell_faces_velocity_field,
       domain::Tags::MeshVelocity<Dim>,
-      evolution::dg::Tags::NormalCovectorAndMagnitude<Dim>>>(
+      evolution::dg::Tags::NormalCovectorAndMagnitude<Dim>,
+      evolution::dg::subcell::Tags::SubcellOptions>>(
       element, dg_mesh, subcell_mesh, volume_vars_dg, neighbor_data,
       std::unique_ptr<fd::Reconstructor<Dim>>{
           std::make_unique<ReconstructionForTest>()},
@@ -197,7 +200,10 @@ void test_neighbor_packaged_data(const size_t num_dg_pts_per_dimension,
       std::array<typename subcell_faces_velocity_field::type::value_type,
                  Dim>{},
       std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>{},
-      normal_vectors);
+      normal_vectors,
+      evolution::dg::subcell::SubcellOptions{
+          1.0e-3, 1.0e-4, 1.0e-3, 1.0e-4, 4.0, 4.0, false,
+          evolution::dg::subcell::fd::ReconstructionMethod::DimByDim});
 
   // Compute face-centered velocity field and add it to the box. This action
   // needs to be called in prior since NeighborPackagedData::apply() internally

--- a/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_NeighborPackagedData.cpp
@@ -32,6 +32,7 @@
 #include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/DgSubcell/Reconstruction.hpp"
+#include "Evolution/DgSubcell/ReconstructionMethod.hpp"
 #include "Evolution/DgSubcell/Tags/Coordinates.hpp"
 #include "Evolution/DgSubcell/Tags/Inactive.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
@@ -302,7 +303,8 @@ void test_neighbor_packaged_data(const size_t num_dg_pts_per_dimension,
           evolution::dg::subcell::fd::reconstruct(
               expected_fd_packaged_data_on_mortar,
               dg_mesh.slice_away(mortar_id.first.dimension()),
-              subcell_mesh.extents().slice_away(mortar_id.first.dimension()));
+              subcell_mesh.extents().slice_away(mortar_id.first.dimension()),
+              evolution::dg::subcell::fd::ReconstructionMethod::AllDimsAtOnce);
 
       std::vector<double> vector_to_check{
           expected_dg_packaged_data.data(),


### PR DESCRIPTION
## Proposed changes

Dim-by-dim reconstruction is faster than all dims at once, but I think sacrifices strict conservation (I'd need to think about it more). However, it does have the added feature that constant flow is preserved along axes, which isn't the case in all dims at once reconstruction.

**Note**: The projection commit is in another PR waiting on review.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
