### PR TITLE
Enable sleef support

### DIFF
--- a/cmake/FindSleef.cmake
+++ b/cmake/FindSleef.cmake
@@ -1,0 +1,76 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Find Sleef: https://github.com/shibatch/sleef
+# If not in one of the default paths specify -D SLEEF_ROOT=/path/to/Sleef
+# to search there as well.
+
+if(NOT SLEEF_ROOT)
+  # Need to set to empty to avoid warnings with --warn-uninitialized
+  set(SLEEF_ROOT "")
+  set(SLEEF_ROOT $ENV{SLEEF_ROOT})
+endif()
+
+# find the SLEEF include directory
+find_path(SLEEF_INCLUDE_DIR sleef.h
+  PATH_SUFFIXES include
+  HINTS ${SLEEF_ROOT})
+
+find_library(SLEEF_LIBRARIES
+  NAMES sleef
+  PATH_SUFFIXES lib64 lib
+  HINTS ${SLEEF_ROOT})
+
+set(SLEEF_VERSION "")
+
+if (EXISTS "${SLEEF_INCLUDE_DIR}/sleef.h")
+
+  file(READ "${SLEEF_INCLUDE_DIR}/sleef.h" SLEEF_FIND_HEADER_CONTENTS)
+
+  set(SLEEF_MAJOR_PREFIX "#define SLEEF_VERSION_MAJOR ")
+  set(SLEEF_MINOR_PREFIX "#define SLEEF_VERSION_MINOR ")
+  set(SLEEF_PATCH_PREFIX "#define SLEEF_VERSION_PATCHLEVEL ")
+
+  string(REGEX MATCH "${SLEEF_MAJOR_PREFIX}[0-9]+"
+    SLEEF_MAJOR_VERSION "${SLEEF_FIND_HEADER_CONTENTS}")
+  string(REPLACE "${SLEEF_MAJOR_PREFIX}" "" SLEEF_MAJOR_VERSION
+    "${SLEEF_MAJOR_VERSION}")
+
+  string(REGEX MATCH "${SLEEF_MINOR_PREFIX}[0-9]+"
+    SLEEF_MINOR_VERSION "${SLEEF_FIND_HEADER_CONTENTS}")
+  string(REPLACE "${SLEEF_MINOR_PREFIX}" "" SLEEF_MINOR_VERSION
+    "${SLEEF_MINOR_VERSION}")
+
+  string(REGEX MATCH "${SLEEF_PATCH_PREFIX}[0-9]+"
+    SLEEF_SUBMINOR_VERSION "${SLEEF_FIND_HEADER_CONTENTS}")
+  string(REPLACE "${SLEEF_PATCH_PREFIX}" "" SLEEF_SUBMINOR_VERSION
+    "${SLEEF_SUBMINOR_VERSION}")
+
+  set(SLEEF_VERSION
+    "${SLEEF_MAJOR_VERSION}.${SLEEF_MINOR_VERSION}.${SLEEF_SUBMINOR_VERSION}"
+    )
+endif()
+
+set(Sleef_VERSION ${SLEEF_VERSION})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  Sleef
+  FOUND_VAR SLEEF_FOUND
+  REQUIRED_VARS SLEEF_INCLUDE_DIR SLEEF_LIBRARIES
+  VERSION_VAR SLEEF_VERSION)
+mark_as_advanced(SLEEF_INCLUDE_DIR SLEEF_LIBRARIES
+  SLEEF_MAJOR_VERSION SLEEF_MINOR_VERSION SLEEF_PATCH_VERSION
+  SLEEF_VERSION Sleef_VERSION)
+
+add_library(Sleef INTERFACE IMPORTED)
+set_property(TARGET Sleef PROPERTY
+  INTERFACE_INCLUDE_DIRECTORIES ${SLEEF_INCLUDE_DIR})
+set_property(TARGET Sleef
+  APPEND PROPERTY INTERFACE_LINK_LIBRARIES ${SLEEF_LIBRARIES})
+
+add_interface_lib_headers(
+  TARGET Sleef
+  HEADERS
+  sleef.h
+  )

--- a/docs/DevGuide/BuildSystem.md
+++ b/docs/DevGuide/BuildSystem.md
@@ -294,6 +294,12 @@ cmake -D FLAG1=OPT1 ... -D FLAGN=OPTN <SPECTRE_ROOT>
   - This needs to be turned `OFF` in order to use
     [include-what-you-use
     (IWYU)](https://github.com/include-what-you-use/include-what-you-use)
+- USE_SLEEF
+  - Whether to use [Sleef](https://github.com/shibatch/sleef) with Blaze to
+    vectorize addition math functions like `sin`, `cos`, and `exp`.
+    (default is `OFF`)
+  - \note Blaze isn't tested super thoroughly across different architectures so
+    there's unfortunately no guarantee that Blaze+Sleef will work everywhere.
 
 ## CMake targets
 


### PR DESCRIPTION
## Proposed changes

Sleef enables vectorization of special functions like trig, exp, etc.

Unfortunately on my machine Blaze currently doesn't build when Sleef is enabled. I've filed an issue about this with Blaze.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
