### PR TITLE
XCTS solver: generalize Kerr to WrappedGr solution

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/CMakeLists.txt
@@ -10,8 +10,8 @@ spectre_target_sources(
   PRIVATE
   ConstantDensityStar.cpp
   Flatness.cpp
-  Kerr.cpp
   Schwarzschild.cpp
+  WrappedGr.cpp
   )
 
 spectre_target_headers(
@@ -23,8 +23,8 @@ spectre_target_headers(
   ConstantDensityStar.hpp
   Factory.hpp
   Flatness.hpp
-  Kerr.hpp
   Schwarzschild.hpp
+  WrappedGr.hpp
   )
 
 target_link_libraries(

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/Factory.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/Factory.hpp
@@ -3,11 +3,13 @@
 
 #pragma once
 
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/Flatness.hpp"
-#include "PointwiseFunctions/AnalyticSolutions/Xcts/Kerr.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace Xcts::Solutions {
-using all_analytic_solutions = tmpl::list<Flatness, Kerr, Schwarzschild>;
+using all_analytic_solutions =
+    tmpl::list<Flatness, WrappedGr<gr::Solutions::KerrSchild>, Schwarzschild>;
 }  // namespace Xcts::Solutions

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -9,12 +9,12 @@ Background: &background
   Binary:
     XCoords: [&x_left -8., &x_right 8.]
     ObjectA:
-      Kerr: &kerr_left
+      KerrSchild: &kerr_left
         Mass: 0.4229
         Spin: [0., 0., 0.]
         Center: [0., 0., 0.]
     ObjectB:
-      Kerr: &kerr_right
+      KerrSchild: &kerr_right
         Mass: 0.4229
         Spin: [0., 0., 0.]
         Center: [0., 0., 0.]

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -15,7 +15,7 @@
 #     AbsoluteTolerance: 0.08
 
 Background:
-  Kerr:
+  KerrSchild:
     Mass: 1.
     Spin: [0., 0., 0.]
     Center: [0., 0., 0.]

--- a/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/Test_ApparentHorizon.cpp
+++ b/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/Test_ApparentHorizon.cpp
@@ -35,7 +35,8 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
-#include "PointwiseFunctions/AnalyticSolutions/Xcts/Kerr.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace Xcts::BoundaryConditions {
@@ -389,7 +390,8 @@ void test_consistency_with_kerr(const bool compute_expansion) {
   std::array<double, 3> rotation =
       -0.5 * dimensionless_spin / horizon_kerrschild_radius;
   CAPTURE(rotation);
-  const Solutions::Kerr solution{mass, dimensionless_spin, {{0., 0., 0.}}};
+  const Solutions::WrappedGr<gr::Solutions::KerrSchild> solution{
+      mass, dimensionless_spin, {{0., 0., 0.}}};
   const ApparentHorizon<Xcts::Geometry::Curved> kerr_horizon{
       center, rotation, solution,
       // Check with and without the negative-expansion condition. Either the

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_Kerr.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_Kerr.cpp
@@ -11,12 +11,15 @@
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/PointwiseFunctions/AnalyticSolutions/Xcts/VerifySolution.hpp"
-#include "PointwiseFunctions/AnalyticSolutions/Xcts/Kerr.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/AnalyticSolution.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace Xcts::Solutions {
 namespace {
+
+using Kerr = WrappedGr<gr::Solutions::KerrSchild>;
 
 void test_solution(const double mass, const std::array<double, 3> spin,
                    const std::array<double, 3>& center,
@@ -53,7 +56,7 @@ void test_solution(const double mass, const std::array<double, 3> spin,
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Xcts.Kerr",
                   "[PointwiseFunctions][Unit]") {
   test_solution(0.43, {{0.1, 0.2, 0.3}}, {{1., 2., 3.}},
-                "Kerr:\n"
+                "KerrSchild:\n"
                 "  Mass: 0.43\n"
                 "  Spin: [0.1, 0.2, 0.3]\n"
                 "  Center: [1., 2., 3.]");


### PR DESCRIPTION
## Proposed changes

This will allow solving BBH initial data in harmonic coordinates, by wrapping #3829.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
