### PR TITLE
Block implicit DataVector conversion to Variables

### DIFF
--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -49,6 +49,8 @@ template <typename X, typename Symm, typename IndexList>
 class Tensor;
 template <typename TagsList>
 class Variables;
+template <typename T, typename VectorType>
+class VectorImpl;
 namespace Tags {
 template <typename TagsList>
 class Variables;
@@ -267,6 +269,13 @@ class Variables<tmpl::list<Tags...>> {
 
   template <typename VT, bool VF>
   Variables& operator=(const blaze::DenseVector<VT, VF>& expression);
+
+  // Prevent the previous two declarations from implicitly converting
+  // DataVectors and similar to Variables.
+  template <typename T, typename VectorType>
+  Variables(const VectorImpl<T, VectorType>&) = delete;
+  template <typename T, typename VectorType>
+  Variables& operator=(const VectorImpl<T, VectorType>&) = delete;
 
   template <typename... WrappedTags,
             Requires<tmpl2::flat_all<std::is_same_v<

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -704,6 +704,9 @@ template <typename... Tags>
 template <typename VT, bool VF>
 Variables<tmpl::list<Tags...>>::Variables(
     const blaze::DenseVector<VT, VF>& expression) {
+  ASSERT((*expression).size() % number_of_independent_components == 0,
+         "Invalid size " << (*expression).size() << " for a Variables with "
+         << number_of_independent_components << " components.");
   initialize((*expression).size() / number_of_independent_components);
   variable_data_ = expression;
 }
@@ -713,6 +716,9 @@ template <typename... Tags>
 template <typename VT, bool VF>
 Variables<tmpl::list<Tags...>>& Variables<tmpl::list<Tags...>>::operator=(
     const blaze::DenseVector<VT, VF>& expression) {
+  ASSERT((*expression).size() % number_of_independent_components == 0,
+         "Invalid size " << (*expression).size() << " for a Variables with "
+         << number_of_independent_components << " components.");
   initialize((*expression).size() / number_of_independent_components);
   variable_data_ = expression;
   return *this;

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -45,6 +45,10 @@ static_assert(
         Variables<tmpl::list<TestHelpers::Tags::Scalar<DataVector>,
                              TestHelpers::Tags::Vector<DataVector>>>>::value);
 
+static_assert(not std::is_convertible_v<
+              DataVector,
+              Variables<tmpl::list<TestHelpers::Tags::Scalar<DataVector>>>>);
+
 namespace {
 std::string repeat_string_with_commas(const std::string& str,
                                       const size_t repeats) {

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -1042,3 +1042,36 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Variables", "[DataStructures][Unit]") {
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
+
+// [[OutputRegex, Invalid size 4 for a Variables with 3 components]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.DataStructures.Variables.BadSize.constructor",
+    "[DataStructures][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  Variables<tmpl::list<TestHelpers::Tags::Scalar<DataVector>,
+                       TestHelpers::Tags::Scalar2<DataVector>>>
+      source(2, -3.0);
+  // Multiply by one to convert to an expression template.
+  (void)static_cast<
+      Variables<tmpl::list<TestHelpers::Tags::Vector<DataVector>>>>(1.0 *
+                                                                    source);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Invalid size 4 for a Variables with 3 components]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.DataStructures.Variables.BadSize.assignment",
+    "[DataStructures][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  Variables<tmpl::list<TestHelpers::Tags::Scalar<DataVector>,
+                       TestHelpers::Tags::Scalar2<DataVector>>>
+      source(2, -3.0);
+  Variables<tmpl::list<TestHelpers::Tags::Vector<DataVector>>> destination;
+  // Multiply by one to convert to an expression template.
+  destination = 1.0 * source;
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}


### PR DESCRIPTION
This would have caught a bug in some code I'm working on.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
