### PR TITLE
Change ASSERT and ERROR to throw an exception instead of aborting

### DIFF
--- a/docs/DevGuide/WritingTests.md
+++ b/docs/DevGuide/WritingTests.md
@@ -245,9 +245,6 @@ testing `ASSERT`s you must mark the `SPECTRE_TEST_CASE` as
 the test, and also have the test call `ERROR("Failed to trigger ASSERT
 in an assertion test");` at the end of the test body.  The test body
 should be enclosed between `#%ifdef SPECTRE_DEBUG` and an `#%endif`
-For example,
-
-\snippet Test_AssertAndError.cpp assertion_test_example
 
 If the `#%ifdef SPECTRE_DEBUG` block is omitted then compilers will
 correctly flag the code as being unreachable which results in
@@ -256,9 +253,17 @@ warnings.
 You can also test `ERROR`s inside your code. These tests need to have
 the `OutputRegex`, and also call `ERROR_TEST();` at the
 beginning. They do not need the `#%ifdef SPECTRE_DEBUG` block, they
-can just call have the code that triggers an `ERROR`. For example,
+can just call have the code that triggers an `ERROR`.
 
-\snippet Test_AssertAndError.cpp error_test_example
+We are currently transforming these failure cases to use the
+`CHECK_THROWS_WITH` macro. This macro takes two arguments: the first
+is either an expression or a lambda that is expected to trigger an
+exception (which now are thrown by `ASSERT` and `ERROR` (Note: You may
+need to add `()` wrapping the lambda in order for it to compile.); the
+second is a Catch Matcher (see
+[Catch2](https://github.com/catchorg/Catch2 for complete
+documentaion), usually a `Catch::Contains()` macro that matches
+a substring of the error message of the thrown exception.
 
 Note that a `OutputRegex` can also be specified in a test that is
 supposed to succeed with output that matches the regular expression.

--- a/docs/GroupDefs.hpp
+++ b/docs/GroupDefs.hpp
@@ -754,9 +754,6 @@
  * </tr>
  * </table>
  *
- * \example
- * \snippet Test_H5.cpp willfail_example_for_dev_doc
- *
  * ### Debugging Tests in GDB or LLDB
  *
  * Several tests fail intentionally at the executable level to test error

--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -190,7 +190,7 @@ BinaryCompactObject::BinaryCompactObject(
   };
   const auto add_outer_region = [this](const std::string& region_name) {
     for (const std::string& wedge_direction : wedge_directions) {
-      for (const std::string& leftright : {"Left", "Right"}) {
+      for (const std::string& leftright : {"Left"s, "Right"s}) {
         if ((wedge_direction == "UpperX" and leftright == "Left") or
             (wedge_direction == "LowerX" and leftright == "Right")) {
           // The outer regions are divided in half perpendicular to the

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
@@ -175,7 +175,7 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
   auto add_filled_cylinder_name = [this](const std::string& prefix,
                                          const std::string& group_name) {
     for (const std::string& where :
-         {"Center", "East", "North", "West", "South"}) {
+         {"Center"s, "East"s, "North"s, "West"s, "South"s}) {
       const std::string name =
           std::string(prefix).append("FilledCylinder").append(where);
       block_names_.push_back(name);
@@ -184,7 +184,7 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
   };
   auto add_cylinder_name = [this](const std::string& prefix,
                                   const std::string& group_name) {
-    for (const std::string& where : {"East", "North", "West", "South"}) {
+    for (const std::string& where : {"East"s, "North"s, "West"s, "South"s}) {
       const std::string name =
           std::string(prefix).append("Cylinder").append(where);
       block_names_.push_back(name);

--- a/src/Parallel/InitializationFunctions.cpp
+++ b/src/Parallel/InitializationFunctions.cpp
@@ -3,9 +3,12 @@
 
 #include "Parallel/InitializationFunctions.hpp"
 
+#include <charm++.h>
 #include <exception>
+#include <sstream>
 
 #include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/System/Abort.hpp"
 
 void setup_error_handling() {
   std::set_terminate([]() {
@@ -14,15 +17,21 @@ void setup_error_handling() {
       try {
         std::rethrow_exception(exception);
       } catch (std::exception& ex) {
-        ERROR("Terminated due to an uncaught exception: " << ex.what());
+        std::ostringstream os;
+        os << "Terminated due to an uncaught exception:\n " << ex.what();
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+        CkError("%s\n", os.str().c_str());
       } catch (...) {
-        ERROR("Terminated due to unknown exception\n");
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+        CkError("Terminated due to unknown exception\n");
       }
     } else {
-      ERROR(
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+      CkError(
           "Terminate was called for an unknown reason (not an uncaught "
           "exception), calling Charm++'s abort function to properly "
           "terminate execution.");
     }
+    sys::abort("");
   });
 }

--- a/src/Parallel/Main.hpp
+++ b/src/Parallel/Main.hpp
@@ -423,12 +423,15 @@ Main<Metavariables>::Main(CkArgMsg* msg) {
                      pretty_type::short_name<parallel_component>(),
                      pretty_type::short_name<chare_type>(),
                      tmpl::size<databox_types>::value);
-    tmpl::for_each<databox_types>([](auto databox_type_v) {
+    tmpl::for_each<databox_types>([&parallel_component_v](auto databox_type_v) {
+      // gcc11 and clang12 don't agree on where parallel_component_v is used...
+      (void)(parallel_component_v);
       using databox_type = tmpl::type_from<decltype(databox_type_v)>;
       Parallel::printf("%u",
                        tmpl::size<typename databox_type::tags_list>::value);
-      if constexpr (not std::is_same_v<databox_type,
-                                       tmpl::back<databox_types>>) {
+      // gcc11.1.1 couldn't handle inlining the following type alias
+      using last_databox_type = tmpl::back<databox_types>;
+      if constexpr (not std::is_same_v<databox_type, last_databox_type>) {
         Parallel::printf(", ");
       }
     });

--- a/src/Utilities/ErrorHandling/AbortWithErrorMessage.cpp
+++ b/src/Utilities/ErrorHandling/AbortWithErrorMessage.cpp
@@ -15,7 +15,7 @@
 #include <sstream>
 
 #include "Utilities/ErrorHandling/Breakpoint.hpp"
-#include "Utilities/System/Abort.hpp"
+#include "Utilities/ErrorHandling/Exceptions.hpp"
 #include "Utilities/System/ParallelInfo.hpp"
 
 namespace {
@@ -85,13 +85,8 @@ template <bool ShowTrace>
      << message << "\n"
      << "############ ERROR ############\n"
      << "\n";
-  // We use CkError instead of abort to print the error message because in the
-  // case of an executable not using Charm++'s main function the call to abort
-  // will segfault before anything is printed.
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
-  CkError("%s", os.str().c_str());
   breakpoint();
-  sys::abort("");
+  throw SpectreError(os.str());
 }
 }  // namespace
 
@@ -110,13 +105,8 @@ void abort_with_error_message(const char* expression, const char* file,
      << message << "\n"
      << "############ ASSERT FAILED ############\n"
      << "\n";
-  // We use CkError instead of abort to print the error message because in the
-  // case of an executable not using Charm++'s main function the call to abort
-  // will segfault before anything is printed.
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
-  CkError("%s", os.str().c_str());
   breakpoint();
-  sys::abort("");
+  throw SpectreAssert(os.str());
 }
 
 

--- a/src/Utilities/ErrorHandling/Exceptions.hpp
+++ b/src/Utilities/ErrorHandling/Exceptions.hpp
@@ -6,6 +6,20 @@
 #include <stdexcept>
 
 /// \ingroup ErrorHandlingGroup
+/// Exception indicating an ASSERT failed
+class SpectreAssert : public std::runtime_error {
+ public:
+  explicit SpectreAssert(const std::string& message) : runtime_error(message) {}
+};
+
+/// \ingroup ErrorHandlingGroup
+/// Exception indicating an ERROR was triggered
+class SpectreError : public std::runtime_error {
+ public:
+  explicit SpectreError(const std::string& message) : runtime_error(message) {}
+};
+
+/// \ingroup ErrorHandlingGroup
 /// Exception indicating convergence failure
 class convergence_error : public std::runtime_error {
  public:

--- a/src/Utilities/TaggedTuple.hpp
+++ b/src/Utilities/TaggedTuple.hpp
@@ -673,6 +673,7 @@ ReturnedTaggedTuple reorder(TaggedTuple<Tags...> input) {
 }
 
 /// Stream operator for TaggedTuple
+using ::operator<<;
 template <class... Tags>
 std::ostream& operator<<(std::ostream& os, const TaggedTuple<Tags...>& t) {
   os << "(";

--- a/tests/Unit/ApparentHorizons/CMakeLists.txt
+++ b/tests/Unit/ApparentHorizons/CMakeLists.txt
@@ -27,8 +27,10 @@ target_link_libraries(
   ApparentHorizons
   ApparentHorizonsHelpers
   GeneralRelativitySolutions
+  LinearOperators
   Logging
   Options
+  ParallelInterpolation
   RootFinding
   SphericalHarmonics
   SphericalHarmonicsHelpers

--- a/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
@@ -757,36 +757,21 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ApparentHorizonFinder",
   test_apparent_horizon<tmpl::list<TestKerrHorizon<Frame::Grid>>,
                         std::true_type, Frame::Grid>(
       &test_kerr_horizon_called, 3, 7, 1.1, {{0.12, 0.23, 0.45}});
-}
-
-// [[OutputRegex, Cannot interpolate onto surface]]
-// [[Timeout, 5]]
-SPECTRE_TEST_CASE(
-    "Unit.NumericalAlgorithms.Interpolator.ApparentHorizonFinder.Error",
-    "[Unit]") {
-  ERROR_TEST();
-  domain::creators::register_derived_with_charm();
-  domain::creators::time_dependence::register_derived_with_charm();
-  domain::FunctionsOfTime::register_derived_with_charm();
 
   test_schwarzschild_horizon_called = 0;
-  test_apparent_horizon<tmpl::list<TestSchwarzschildHorizon<Frame::Inertial>>,
-                        std::true_type, Frame::Inertial, true>(
-      &test_schwarzschild_horizon_called, 3, 4, 1.0, {{0.0, 0.0, 0.0}});
-}
-
-// [[OutputRegex, Cannot interpolate onto surface]]
-// [[Timeout, 5]]
-SPECTRE_TEST_CASE("Unit.Interpolator.ApparentHorizonFinder.NotConvergedError",
-                  "[Unit]") {
-  ERROR_TEST();
-  domain::creators::register_derived_with_charm();
-  domain::creators::time_dependence::register_derived_with_charm();
-  domain::FunctionsOfTime::register_derived_with_charm();
+  CHECK_THROWS_WITH(
+      (test_apparent_horizon<
+          tmpl::list<TestSchwarzschildHorizon<Frame::Inertial>>, std::true_type,
+          Frame::Inertial, true>(&test_schwarzschild_horizon_called, 3, 4, 1.0,
+                                 {{0.0, 0.0, 0.0}})),
+      Catch::Contains("Cannot interpolate onto surface"));
 
   test_schwarzschild_horizon_called = 0;
-  test_apparent_horizon<tmpl::list<TestSchwarzschildHorizon<Frame::Inertial>>,
-                        std::true_type, Frame::Inertial, true>(
-      &test_schwarzschild_horizon_called, 3, 4, 1.0, {{0.0, 0.0, 0.0}}, 1);
+  CHECK_THROWS_WITH(
+      (test_apparent_horizon<
+          tmpl::list<TestSchwarzschildHorizon<Frame::Inertial>>, std::true_type,
+          Frame::Inertial, true>(&test_schwarzschild_horizon_called, 3, 4, 1.0,
+                                 {{0.0, 0.0, 0.0}}, 1)),
+      Catch::Contains("Cannot interpolate onto surface"));
 }
 }  // namespace

--- a/tests/Unit/ControlSystem/CMakeLists.txt
+++ b/tests/Unit/ControlSystem/CMakeLists.txt
@@ -26,5 +26,14 @@ add_test_library(
   ${LIBRARY}
   "ControlSystem"
   "${LIBRARY_SOURCES}"
-  "Boost::boost;ControlSystem;Domain;FunctionsOfTime"
+  ""
   )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  ControlSystem
+  EventsAndDenseTriggers
+  FunctionsOfTime
+  Utilities
+)

--- a/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
@@ -217,61 +217,66 @@ void test_functions_of_time_tag() {
 SPECTRE_TEST_CASE("Unit.ControlSystem.Tags.FunctionsOfTimeInitialize",
                   "[ControlSystem][Unit]") {
   test_functions_of_time_tag();
-}
 
-// [[OutputRegex, is not controlling a function of time. Check that the
-// DomainCreator you have chosen uses all of the control systems in the
-// executable. The existing functions of time are]]
-SPECTRE_TEST_CASE(
-    "Unit.ControlSystem.Tags.FunctionsOfTimeInitialize.ExtraControlSystem",
-    "[ControlSystem][Unit]") {
-  ERROR_TEST();
   using fot_tag = control_system::Tags::FunctionsOfTimeInitialize;
   using Creator = tmpl::front<fot_tag::option_tags<Metavariables>>::type;
 
-  const Creator creator = std::make_unique<TestCreator>(true);
+  CHECK_THROWS_WITH(
+      []() {
+        const Creator creator = std::make_unique<TestCreator>(true);
 
-  const TimescaleTuner tuner({1.0}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01, 0.99);
-  const Averager<2> averager(0.25, true);
-  const double update_fraction = 0.3;
-  const Controller<2> controller(update_fraction);
-  const control_system::TestHelpers::ControlError control_error{};
+        const TimescaleTuner tuner({1.0}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01,
+                                   0.99);
+        const Averager<2> averager(0.25, true);
+        const double update_fraction = 0.3;
+        const Controller<2> controller(update_fraction);
+        const control_system::TestHelpers::ControlError control_error{};
 
-  OptionHolder<1> option_holder1(averager, controller, tuner, control_error);
-  OptionHolder<2> option_holder2(averager, controller, tuner, control_error);
-  OptionHolder<3> option_holder3(averager, controller, tuner, control_error);
-  OptionHolder<4> option_holder4(averager, controller, tuner, control_error);
+        OptionHolder<1> option_holder1(averager, controller, tuner,
+                                       control_error);
+        OptionHolder<2> option_holder2(averager, controller, tuner,
+                                       control_error);
+        OptionHolder<3> option_holder3(averager, controller, tuner,
+                                       control_error);
+        OptionHolder<4> option_holder4(averager, controller, tuner,
+                                       control_error);
 
-  const double initial_time_step = 1.0;
-  fot_tag::type functions_of_time = fot_tag::create_from_options<Metavariables>(
-      creator, initial_time, initial_time_step, option_holder1, option_holder2,
-      option_holder3, option_holder4);
-}
+        const double initial_time_step = 1.0;
+        fot_tag::type functions_of_time =
+            fot_tag::create_from_options<Metavariables>(
+                creator, initial_time, initial_time_step, option_holder1,
+                option_holder2, option_holder3, option_holder4);
+      }(),
+      Catch::Contains(
+          "is not controlling a function of time. Check that the DomainCreator "
+          "you have chosen uses all of the control systems in the executable. "
+          "The existing functions of time are"));
 
-// [[OutputRegex, It is possible that the DomainCreator you are using isn't
-// compatible with the control systems]]
-SPECTRE_TEST_CASE(
-    "Unit.ControlSystem.Tags.FunctionsOfTimeInitialize.ImproperExprTime",
-    "[ControlSystem][Unit]") {
-  ERROR_TEST();
-  using fot_tag = control_system::Tags::FunctionsOfTimeInitialize;
-  using Creator = tmpl::front<fot_tag::option_tags<Metavariables>>::type;
+  CHECK_THROWS_WITH(
+      []() {
+        const Creator creator = std::make_unique<BadCreator>();
 
-  const Creator creator = std::make_unique<BadCreator>();
+        const TimescaleTuner tuner({1.0}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01,
+                                   0.99);
+        const Averager<2> averager(0.25, true);
+        const double update_fraction = 0.3;
+        const Controller<2> controller(update_fraction);
+        const control_system::TestHelpers::ControlError control_error{};
 
-  const TimescaleTuner tuner({1.0}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01, 0.99);
-  const Averager<2> averager(0.25, true);
-  const double update_fraction = 0.3;
-  const Controller<2> controller(update_fraction);
-  const control_system::TestHelpers::ControlError control_error{};
+        OptionHolder<1> option_holder1(averager, controller, tuner,
+                                       control_error);
+        OptionHolder<2> option_holder2(averager, controller, tuner,
+                                       control_error);
+        OptionHolder<3> option_holder3(averager, controller, tuner,
+                                       control_error);
 
-  OptionHolder<1> option_holder1(averager, controller, tuner, control_error);
-  OptionHolder<2> option_holder2(averager, controller, tuner, control_error);
-  OptionHolder<3> option_holder3(averager, controller, tuner, control_error);
-
-  const double initial_time_step = 1.0;
-  fot_tag::type functions_of_time = fot_tag::create_from_options<Metavariables>(
-      creator, initial_time, initial_time_step, option_holder1, option_holder2,
-      option_holder3);
+        const double initial_time_step = 1.0;
+        fot_tag::type functions_of_time =
+            fot_tag::create_from_options<Metavariables>(
+                creator, initial_time, initial_time_step, option_holder1,
+                option_holder2, option_holder3);
+      }(),
+      Catch::Contains("It is possible that the DomainCreator you are using "
+                      "isn't compatible with the control systems"));
 }
 }  // namespace

--- a/tests/Unit/ControlSystem/Test_TimescaleTuner.cpp
+++ b/tests/Unit/ControlSystem/Test_TimescaleTuner.cpp
@@ -322,166 +322,161 @@ void test_equality_and_serialization() {
   CHECK(tst1 != tst2);
   CHECK(serialize_and_deserialize(tst1) == tst1);
 }
-}  // namespace
 
-// [[OutputRegex, Initial timescale must be > 0]]
-SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.BadInitTimescale",
-                  "[ControlSystem][Unit]") {
-  ERROR_TEST();
-  const double decrease_timescale_threshold = 1.0e-2;
-  const double increase_timescale_threshold = 1.0e-4;
-  const double increase_factor = 1.01;
-  const double decrease_factor = 0.99;
-  const double max_timescale = 10.0;
-  const double min_timescale = 1.0e-3;
+void test_errors() {
+  CHECK_THROWS_WITH(([]() {
+                      const double decrease_timescale_threshold = 1.0e-2;
+                      const double increase_timescale_threshold = 1.0e-4;
+                      const double increase_factor = 1.01;
+                      const double decrease_factor = 0.99;
+                      const double max_timescale = 10.0;
+                      const double min_timescale = 1.0e-3;
 
-  const std::vector<double> init_timescale{0.0};
-  TimescaleTuner tst(init_timescale, max_timescale, min_timescale,
-                     decrease_timescale_threshold, increase_timescale_threshold,
-                     increase_factor, decrease_factor);
-}
+                      const std::vector<double> init_timescale{0.0};
+                      TimescaleTuner tst(init_timescale, max_timescale,
+                                         min_timescale,
+                                         decrease_timescale_threshold,
+                                         increase_timescale_threshold,
+                                         increase_factor, decrease_factor);
+                    }()),
+                    Catch::Contains("Initial timescale must be > 0"));
 
-// [[OutputRegex, must satisfy 0 < decrease_factor <= 1]]
-SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.BadDecFactor0",
-                  "[ControlSystem][Unit]") {
-  ERROR_TEST();
-  const double decrease_timescale_threshold = 1.0e-2;
-  const double increase_timescale_threshold = 1.0e-4;
-  const double max_timescale = 10.0;
-  const double min_timescale = 1.0e-3;
+  CHECK_THROWS_WITH(([]() {
+                      const double decrease_timescale_threshold = 1.0e-2;
+                      const double increase_timescale_threshold = 1.0e-4;
+                      const double max_timescale = 10.0;
+                      const double min_timescale = 1.0e-3;
 
-  const double increase_factor = 1.1;
-  const double decrease_factor = -0.99;
+                      const double increase_factor = 1.1;
+                      const double decrease_factor = -0.99;
 
-  TimescaleTuner tst({1.0}, max_timescale, min_timescale,
-                     decrease_timescale_threshold, increase_timescale_threshold,
-                     increase_factor, decrease_factor);
-}
+                      TimescaleTuner tst({1.0}, max_timescale, min_timescale,
+                                         decrease_timescale_threshold,
+                                         increase_timescale_threshold,
+                                         increase_factor, decrease_factor);
+                    }()),
+                    Catch::Contains("must satisfy 0 < decrease_factor <= 1"));
 
-// [[OutputRegex, must satisfy 0 < decrease_factor <= 1]]
-SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.BadDecFactor1",
-                  "[ControlSystem][Unit]") {
-  ERROR_TEST();
-  const double decrease_timescale_threshold = 1.0e-2;
-  const double increase_timescale_threshold = 1.0e-4;
-  const double max_timescale = 10.0;
-  const double min_timescale = 1.0e-3;
+  CHECK_THROWS_WITH(([]() {
+                      const double decrease_timescale_threshold = 1.0e-2;
+                      const double increase_timescale_threshold = 1.0e-4;
+                      const double max_timescale = 10.0;
+                      const double min_timescale = 1.0e-3;
 
-  const double increase_factor = 1.1;
-  const double decrease_factor = 1.01;
+                      const double increase_factor = 1.1;
+                      const double decrease_factor = 1.01;
 
-  TimescaleTuner tst({1.0}, max_timescale, min_timescale,
-                     decrease_timescale_threshold, increase_timescale_threshold,
-                     increase_factor, decrease_factor);
-}
+                      TimescaleTuner tst({1.0}, max_timescale, min_timescale,
+                                         decrease_timescale_threshold,
+                                         increase_timescale_threshold,
+                                         increase_factor, decrease_factor);
+                    }()),
+                    Catch::Contains("must satisfy 0 < decrease_factor <= 1"));
 
-// [[OutputRegex, must be >= 1]]
-SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.BadIncFactor",
-                  "[ControlSystem][Unit]") {
-  ERROR_TEST();
-  const double decrease_timescale_threshold = 1.0e-2;
-  const double increase_timescale_threshold = 1.0e-4;
-  const double max_timescale = 10.0;
-  const double min_timescale = 1.0e-3;
+  CHECK_THROWS_WITH(([]() {
+                      const double decrease_timescale_threshold = 1.0e-2;
+                      const double increase_timescale_threshold = 1.0e-4;
+                      const double max_timescale = 10.0;
+                      const double min_timescale = 1.0e-3;
 
-  const double increase_factor = 0.99;
-  const double decrease_factor = 0.8;
+                      const double increase_factor = 0.99;
+                      const double decrease_factor = 0.8;
 
-  TimescaleTuner tst({1.0}, max_timescale, min_timescale,
-                     decrease_timescale_threshold, increase_timescale_threshold,
-                     increase_factor, decrease_factor);
-}
+                      TimescaleTuner tst({1.0}, max_timescale, min_timescale,
+                                         decrease_timescale_threshold,
+                                         increase_timescale_threshold,
+                                         increase_factor, decrease_factor);
+                    }()),
+                    Catch::Contains("must be >= 1"));
 
-// [[OutputRegex, must be > 0]]
-SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.BadMinTimescale",
-                  "[ControlSystem][Unit]") {
-  ERROR_TEST();
-  const double decrease_timescale_threshold = 1.0e-2;
-  const double increase_timescale_threshold = 1.0e-4;
-  const double increase_factor = 1.01;
-  const double decrease_factor = 0.99;
+  CHECK_THROWS_WITH(([]() {
+                      const double decrease_timescale_threshold = 1.0e-2;
+                      const double increase_timescale_threshold = 1.0e-4;
+                      const double increase_factor = 1.01;
+                      const double decrease_factor = 0.99;
 
-  const double max_timescale = 10.0;
-  const double min_timescale = 0.0;
+                      const double max_timescale = 10.0;
+                      const double min_timescale = 0.0;
 
-  TimescaleTuner tst({1.0}, max_timescale, min_timescale,
-                     decrease_timescale_threshold, increase_timescale_threshold,
-                     increase_factor, decrease_factor);
-}
+                      TimescaleTuner tst({1.0}, max_timescale, min_timescale,
+                                         decrease_timescale_threshold,
+                                         increase_timescale_threshold,
+                                         increase_factor, decrease_factor);
+                    }()),
+                    Catch::Contains("must be > 0"));
 
-// [[OutputRegex, must be > than the specified minimum timescale]]
-SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.BadMaxTimescale",
-                  "[ControlSystem][Unit]") {
-  ERROR_TEST();
-  const double decrease_timescale_threshold = 1.0e-2;
-  const double increase_timescale_threshold = 1.0e-4;
-  const double increase_factor = 1.01;
-  const double decrease_factor = 0.99;
+  CHECK_THROWS_WITH(
+      ([]() {
+        const double decrease_timescale_threshold = 1.0e-2;
+        const double increase_timescale_threshold = 1.0e-4;
+        const double increase_factor = 1.01;
+        const double decrease_factor = 0.99;
 
-  const double max_timescale = 1.0e-4;
-  const double min_timescale = 1.0e-3;
+        const double max_timescale = 1.0e-4;
+        const double min_timescale = 1.0e-3;
 
-  TimescaleTuner tst({1.0}, max_timescale, min_timescale,
-                     decrease_timescale_threshold, increase_timescale_threshold,
-                     increase_factor, decrease_factor);
-}
+        TimescaleTuner tst(
+            {1.0}, max_timescale, min_timescale, decrease_timescale_threshold,
+            increase_timescale_threshold, increase_factor, decrease_factor);
+      }()),
+      Catch::Contains("must be > than the specified minimum timescale"));
 
-// [[OutputRegex, The specified increase-timescale threshold]]
-SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.BadIncreaseThreshold",
-                  "[ControlSystem][Unit]") {
-  ERROR_TEST();
-  const double increase_factor = 1.01;
-  const double decrease_factor = 0.99;
-  const double max_timescale = 10.0;
-  const double min_timescale = 1.0e-3;
+  CHECK_THROWS_WITH(
+      ([]() {
+        const double increase_factor = 1.01;
+        const double decrease_factor = 0.99;
+        const double max_timescale = 10.0;
+        const double min_timescale = 1.0e-3;
 
-  const double decrease_timescale_threshold = 1.0e-2;
-  const double increase_timescale_threshold = 0.0;
+        const double decrease_timescale_threshold = 1.0e-2;
+        const double increase_timescale_threshold = 0.0;
 
-  TimescaleTuner tst({1.0}, max_timescale, min_timescale,
-                     decrease_timescale_threshold, increase_timescale_threshold,
-                     increase_factor, decrease_factor);
-}
+        TimescaleTuner tst(
+            {1.0}, max_timescale, min_timescale, decrease_timescale_threshold,
+            increase_timescale_threshold, increase_factor, decrease_factor);
+      }()),
+      Catch::Contains("The specified increase-timescale threshold"));
 
-// [[OutputRegex, must be > than the specified increase-timescale threshold]]
-SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.BadDecreaseThreshold",
-                  "[ControlSystem][Unit]") {
-  ERROR_TEST();
-  const double increase_factor = 1.01;
-  const double decrease_factor = 0.99;
-  const double max_timescale = 10.0;
-  const double min_timescale = 1.0e-3;
+  CHECK_THROWS_WITH(
+      ([]() {
+        const double increase_factor = 1.01;
+        const double decrease_factor = 0.99;
+        const double max_timescale = 10.0;
+        const double min_timescale = 1.0e-3;
 
-  const double decrease_timescale_threshold = 1.0e-4;
-  const double increase_timescale_threshold = 1.0e-3;
+        const double decrease_timescale_threshold = 1.0e-4;
+        const double increase_timescale_threshold = 1.0e-3;
 
-  TimescaleTuner tst({1.0}, max_timescale, min_timescale,
-                     decrease_timescale_threshold, increase_timescale_threshold,
-                     increase_factor, decrease_factor);
-}
+        TimescaleTuner tst(
+            {1.0}, max_timescale, min_timescale, decrease_timescale_threshold,
+            increase_timescale_threshold, increase_factor, decrease_factor);
+      }()),
+      Catch::Contains(
+          "must be > than the specified increase-timescale threshold"));
 
-// [[OutputRegex, One or both of the number of components in q_and_dtq]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.SizeMismatch",
-                               "[ControlSystem][Unit]") {
-  ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  const double decrease_timescale_threshold = 1.0e-2;
-  const double increase_timescale_threshold = 1.0e-4;
-  const double increase_factor = 1.01;
-  const double decrease_factor = 0.99;
-  const double max_timescale = 10.0;
-  const double min_timescale = 1.0e-3;
+  CHECK_THROWS_WITH(
+      ([]() {
+        const double decrease_timescale_threshold = 1.0e-2;
+        const double increase_timescale_threshold = 1.0e-4;
+        const double increase_factor = 1.01;
+        const double decrease_factor = 0.99;
+        const double max_timescale = 10.0;
+        const double min_timescale = 1.0e-3;
 
-  const std::vector<double> init_timescale{{1.0, 2.0}};
-  TimescaleTuner tst(init_timescale, max_timescale, min_timescale,
-                     decrease_timescale_threshold, increase_timescale_threshold,
-                     increase_factor, decrease_factor);
+        const std::vector<double> init_timescale{{1.0, 2.0}};
+        TimescaleTuner tst(init_timescale, max_timescale, min_timescale,
+                           decrease_timescale_threshold,
+                           increase_timescale_threshold, increase_factor,
+                           decrease_factor);
 
-  const std::array<DataVector, 2> qs{{{2.0}, {3.0}}};
-  tst.update_timescale(qs);
-  ERROR("Failed to trigger ASSERT in an assertion test");
+        const std::array<DataVector, 2> qs{{{2.0}, {3.0}}};
+        tst.update_timescale(qs);
+      }()),
+      Catch::Contains("One or both of the number of components in q_and_dtq"));
 #endif
 }
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner",
                   "[ControlSystem][Unit]") {
@@ -489,4 +484,5 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner",
   test_no_change_to_timescale();
   test_create_from_options();
   test_equality_and_serialization();
+  test_errors();
 }

--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -483,15 +483,8 @@ void test_get_databox() {
   db::apply<tmpl::list<Tags::DataBox>>(check_result_no_args, original_box);
   // [databox_self_tag_example]
 }
-}  // namespace
 
-// [[OutputRegex, Unable to retrieve a \(compute\) item 'DataBox' from the
-// DataBox from within a call to mutate. You must pass these either through the
-// capture list of the lambda or the constructor of a class, this restriction
-// exists to avoid complexity.]]
-SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.get_databox_error",
-                  "[Unit][DataStructures]") {
-  ERROR_TEST();
+void trigger_get_databox_error() {
   auto original_box = db::create<
       db::AddSimpleTags<test_databox_tags::Tag0, test_databox_tags::Tag1,
                         test_databox_tags::Tag2>,
@@ -507,7 +500,16 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.get_databox_error",
       });
 }
 
-namespace {
+void test_get_databox_error() {
+  CHECK_THROWS_WITH(
+      trigger_get_databox_error(),
+      Catch::Contains(
+          "Unable to retrieve a (compute) item 'DataBox' from the DataBox from "
+          "within a call to mutate. You must pass these either through the "
+          "capture list of the lambda or the constructor of a class, this "
+          "restriction exists to avoid complexity."));
+}
+
 void test_mutate() {
   INFO("test mutate");
   auto original_box = db::create<
@@ -566,15 +568,8 @@ void test_mutate() {
       });
   CHECK(db::get<test_databox_tags::Pointer>(original_box) == 5);
 }
-}  // namespace
 
-// [[OutputRegex, Unable to retrieve a \(compute\) item 'Tag4' from the
-// DataBox from within a call to mutate. You must pass these either through the
-// capture list of the lambda or the constructor of a class, this restriction
-// exists to avoid complexity]]
-SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.mutate_locked_get",
-                  "[Unit][DataStructures]") {
-  ERROR_TEST();
+void trigger_mutate_locked_get() {
   auto original_box = db::create<
       db::AddSimpleTags<test_databox_tags::Tag0, test_databox_tags::Tag1,
                         test_databox_tags::Tag2>,
@@ -591,12 +586,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.mutate_locked_get",
       });
 }
 
-// [[OutputRegex, Unable to mutate a DataBox that is already being mutated. This
-// error occurs when mutating a DataBox from inside the invokable passed to the
-// mutate function]]
-SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.mutate_locked_mutate",
-                  "[Unit][DataStructures]") {
-  ERROR_TEST();
+void trigger_mutate_locked_mutate() {
   auto original_box = db::create<
       db::AddSimpleTags<test_databox_tags::Tag0, test_databox_tags::Tag1,
                         test_databox_tags::Tag2>,
@@ -614,7 +604,21 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.mutate_locked_mutate",
       });
 }
 
-namespace {
+void test_mutate_locked() {
+  CHECK_THROWS_WITH(
+      trigger_mutate_locked_get(),
+      Catch::Contains(
+          "Unable to retrieve a (compute) item 'Tag4' from the DataBox from "
+          "within a call to mutate. You must pass these either through the "
+          "capture list of the lambda or the constructor of a class, this "
+          "restriction exists to avoid complexity"));
+  CHECK_THROWS_WITH(
+      trigger_mutate_locked_mutate(),
+      Catch::Contains("Unable to mutate a DataBox that is already being "
+                      "mutated. This error occurs when mutating a DataBox from "
+                      "inside the invokable passed to the mutate function"));
+}
+
 struct NonCopyableFunctor {
   NonCopyableFunctor() = default;
   NonCopyableFunctor(const NonCopyableFunctor&) = delete;
@@ -2845,7 +2849,9 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox", "[Unit][DataStructures]") {
   test_databox();
   test_create_argument_types();
   test_get_databox();
+  test_get_databox_error();
   test_mutate();
+  test_mutate_locked();
   test_apply();
   test_variables();
   test_variables2();

--- a/tests/Unit/DataStructures/Tensor/Test_Tensor.cpp
+++ b/tests/Unit/DataStructures/Tensor/Test_Tensor.cpp
@@ -486,19 +486,25 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.BadDim2",
   os << tensor_6.component_name(std::array<size_t, 1>{{4}});
 }
 
-// [[OutputRegex, Dimension mismatch: Tensor has dim = 4, but you specified 8
-// different labels in abcdefgh]]
-SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.StreamBad",
-                  "[DataStructures][Unit]") {
-  ERROR_TEST();
+namespace {
+void trigger_bad_stream() {
   Tensor<double, Symmetry<1, 2, 2>,
          index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                     SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                     SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
       tensor_5{};
-  CHECK(tensor_5.component_name(
-            tensor_5.get_tensor_index(size_t{0}),  // 0 can be a pointer
-            make_array<3>(std::string("abcdefgh"))) == "aaa");
+  auto bla = tensor_5.component_name(
+      tensor_5.get_tensor_index(size_t{0}),  // 0 can be a pointer
+      make_array<3>(std::string("abcdefgh")));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.StreamBad",
+                  "[DataStructures][Unit]") {
+  CHECK_THROWS_WITH(
+      trigger_bad_stream(),
+      Catch::Contains("Dimension mismatch: Tensor has dim = 4, but you "
+                      "specified 8 different labels in abcdefgh"));
 }
 
 SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.RankAndSize",

--- a/tests/Unit/Domain/CoordinateMaps/Test_Frustum.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Frustum.cpp
@@ -314,146 +314,115 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum", "[Domain][Unit]") {
   test_bulged_frustum_jacobian();
   test_bulged_frustum_inv_jacobian();
   test_bulged_frustum_inv_map();
-}
 
-// [[OutputRegex, A projective scale factor of zero maps all coordinates to
-// zero! Set projective_scale_factor to unity to turn off projective scaling.]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum.Assert0",
-                               "[Domain][Unit]") {
-  ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  const std::array<std::array<double, 2>, 4> face_vertices{
-      {{{-2.0, -2.0}}, {{2.0, 2.0}}, {{-4.0, -4.0}}, {{4.0, 4.0}}}};
-  const double lower_bound = 2.0;
-  const double upper_bound = 5.0;
-  const double projective_scale_factor = 0.0;
-  const bool with_equiangular_map = false;
+  CHECK_THROWS_WITH(
+      ([]() {
+        const std::array<std::array<double, 2>, 4> face_vertices{
+            {{{-2.0, -2.0}}, {{2.0, 2.0}}, {{-4.0, -4.0}}, {{4.0, 4.0}}}};
+        const double lower_bound = 2.0;
+        const double upper_bound = 5.0;
+        const double projective_scale_factor = 0.0;
+        const bool with_equiangular_map = false;
 
-  auto failed_frustum = CoordinateMaps::Frustum(
-      face_vertices, lower_bound, upper_bound, OrientationMap<3>{},
-      with_equiangular_map, projective_scale_factor);
-  static_cast<void>(failed_frustum);
+        auto failed_frustum = CoordinateMaps::Frustum(
+            face_vertices, lower_bound, upper_bound, OrientationMap<3>{},
+            with_equiangular_map, projective_scale_factor);
+        static_cast<void>(failed_frustum);
+      }()),
+      Catch::Contains(
+          "A projective scale factor of zero maps all coordinates to zero! Set "
+          "projective_scale_factor to unity to turn off projective scaling."));
 
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
+  CHECK_THROWS_WITH(
+      ([]() {
+        const std::array<std::array<double, 2>, 4> face_vertices{
+            {{{-2.0, -2.0}}, {{-3.0, 2.0}}, {{-4.0, -4.0}}, {{4.0, 4.0}}}};
+        const double lower_bound = 2.0;
+        const double upper_bound = 5.0;
 
-// [[OutputRegex, The lower bound for a coordinate must be numerically less
-// than the upper bound for that coordinate.]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum.Assert1",
-                               "[Domain][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  const std::array<std::array<double, 2>, 4> face_vertices{
-      {{{-2.0, -2.0}}, {{-3.0, 2.0}}, {{-4.0, -4.0}}, {{4.0, 4.0}}}};
-  const double lower_bound = 2.0;
-  const double upper_bound = 5.0;
+        auto failed_frustum = CoordinateMaps::Frustum(
+            face_vertices, lower_bound, upper_bound, OrientationMap<3>{});
+        static_cast<void>(failed_frustum);
+      }()),
+      Catch::Contains("The lower bound for a coordinate must be numerically "
+                      "less than the upper bound for that coordinate."));
 
-  auto failed_frustum = CoordinateMaps::Frustum(
-      face_vertices, lower_bound, upper_bound, OrientationMap<3>{});
-  static_cast<void>(failed_frustum);
+  CHECK_THROWS_WITH(
+      ([]() {
+        const std::array<std::array<double, 2>, 4> face_vertices{
+            {{{-2.0, -2.0}}, {{2.0, -3.0}}, {{-4.0, -4.0}}, {{4.0, 4.0}}}};
+        const double lower_bound = 2.0;
+        const double upper_bound = 5.0;
 
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
+        auto failed_frustum = CoordinateMaps::Frustum(
+            face_vertices, lower_bound, upper_bound, OrientationMap<3>{});
+        static_cast<void>(failed_frustum);
+      }()),
+      Catch::Contains("The lower bound for a coordinate must be numerically "
+                      "less than the upper bound for that coordinate."));
 
-// [[OutputRegex, The lower bound for a coordinate must be numerically less
-// than the upper bound for that coordinate.]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum.Assert2",
-                               "[Domain][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  const std::array<std::array<double, 2>, 4> face_vertices{
-      {{{-2.0, -2.0}}, {{2.0, -3.0}}, {{-4.0, -4.0}}, {{4.0, 4.0}}}};
-  const double lower_bound = 2.0;
-  const double upper_bound = 5.0;
+  CHECK_THROWS_WITH(
+      ([]() {
+        const std::array<std::array<double, 2>, 4> face_vertices{
+            {{{-2.0, -2.0}}, {{2.0, 2.0}}, {{-4.0, -4.0}}, {{-5.0, 4.0}}}};
+        const double lower_bound = 2.0;
+        const double upper_bound = 5.0;
 
-  auto failed_frustum = CoordinateMaps::Frustum(
-      face_vertices, lower_bound, upper_bound, OrientationMap<3>{});
-  static_cast<void>(failed_frustum);
+        auto failed_frustum = CoordinateMaps::Frustum(
+            face_vertices, lower_bound, upper_bound, OrientationMap<3>{});
+        static_cast<void>(failed_frustum);
+      }()),
+      Catch::Contains("The lower bound for a coordinate must be numerically "
+                      "less than the upper bound for that coordinate."));
 
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
+  CHECK_THROWS_WITH(
+      ([]() {
+        const std::array<std::array<double, 2>, 4> face_vertices{
+            {{{-2.0, -2.0}}, {{2.0, 2.0}}, {{-4.0, -4.0}}, {{4.0, -5.0}}}};
+        const double lower_bound = 2.0;
+        const double upper_bound = 5.0;
 
-// [[OutputRegex, The lower bound for a coordinate must be numerically less
-// than the upper bound for that coordinate.]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum.Assert3",
-                               "[Domain][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  const std::array<std::array<double, 2>, 4> face_vertices{
-      {{{-2.0, -2.0}}, {{2.0, 2.0}}, {{-4.0, -4.0}}, {{-5.0, 4.0}}}};
-  const double lower_bound = 2.0;
-  const double upper_bound = 5.0;
+        auto failed_frustum = CoordinateMaps::Frustum(
+            face_vertices, lower_bound, upper_bound, OrientationMap<3>{});
+        static_cast<void>(failed_frustum);
+      }()),
+      Catch::Contains("The lower bound for a coordinate must be numerically "
+                      "less than the upper bound for that coordinate."));
 
-  auto failed_frustum = CoordinateMaps::Frustum(
-      face_vertices, lower_bound, upper_bound, OrientationMap<3>{});
-  static_cast<void>(failed_frustum);
+  CHECK_THROWS_WITH(
+      ([]() {
+        const std::array<std::array<double, 2>, 4> face_vertices{
+            {{{-2.0, -2.0}}, {{2.0, 2.0}}, {{-4.0, -4.0}}, {{4.0, 4.0}}}};
+        const double lower_bound = 2.0;
+        const double upper_bound = -2.0;
 
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
+        auto failed_frustum = CoordinateMaps::Frustum(
+            face_vertices, lower_bound, upper_bound, OrientationMap<3>{});
+        static_cast<void>(failed_frustum);
+      }()),
+      Catch::Contains("The lower bound for a coordinate must be numerically "
+                      "less than the upper bound for that coordinate."));
 
-// [[OutputRegex, The lower bound for a coordinate must be numerically less
-// than the upper bound for that coordinate.]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum.Assert4",
-                               "[Domain][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  const std::array<std::array<double, 2>, 4> face_vertices{
-      {{{-2.0, -2.0}}, {{2.0, 2.0}}, {{-4.0, -4.0}}, {{4.0, -5.0}}}};
-  const double lower_bound = 2.0;
-  const double upper_bound = 5.0;
+  CHECK_THROWS_WITH(
+      ([]() {
+        const std::array<std::array<double, 2>, 4> face_vertices{
+            {{{-2.0, -2.0}}, {{2.0, 2.0}}, {{-4.0, -4.0}}, {{4.0, 4.0}}}};
+        const double lower_bound = 2.0;
+        const double upper_bound = 5.0;
+        const double projective_scale_factor = 1.0;
+        const bool with_equiangular_map = false;
+        const double sphericity = 1.3;
 
-  auto failed_frustum = CoordinateMaps::Frustum(
-      face_vertices, lower_bound, upper_bound, OrientationMap<3>{});
-  static_cast<void>(failed_frustum);
-
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// [[OutputRegex, The lower bound for a coordinate must be numerically less
-// than the upper bound for that coordinate.]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum.Assert5",
-                               "[Domain][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  const std::array<std::array<double, 2>, 4> face_vertices{
-      {{{-2.0, -2.0}}, {{2.0, 2.0}}, {{-4.0, -4.0}}, {{4.0, 4.0}}}};
-  const double lower_bound = 2.0;
-  const double upper_bound = -2.0;
-
-  auto failed_frustum = CoordinateMaps::Frustum(
-      face_vertices, lower_bound, upper_bound, OrientationMap<3>{});
-  static_cast<void>(failed_frustum);
-
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// [[OutputRegex, The sphericity must be set between 0.0, corresponding to a
-// flat surface, and 1.0, corresponding to a spherical surface, inclusive. It is
-// currently set to 1.3.]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum.Assert6",
-                               "[Domain][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  const std::array<std::array<double, 2>, 4> face_vertices{
-      {{{-2.0, -2.0}}, {{2.0, 2.0}}, {{-4.0, -4.0}}, {{4.0, 4.0}}}};
-  const double lower_bound = 2.0;
-  const double upper_bound = 5.0;
-  const double projective_scale_factor = 1.0;
-  const bool with_equiangular_map = false;
-  const double sphericity = 1.3;
-
-  auto failed_frustum = CoordinateMaps::Frustum(
-      face_vertices, lower_bound, upper_bound, OrientationMap<3>{},
-      with_equiangular_map, projective_scale_factor, false, sphericity);
-  static_cast<void>(failed_frustum);
-
-  ERROR("Failed to trigger ASSERT in an assertion test");
+        auto failed_frustum = CoordinateMaps::Frustum(
+            face_vertices, lower_bound, upper_bound, OrientationMap<3>{},
+            with_equiangular_map, projective_scale_factor, false, sphericity);
+        static_cast<void>(failed_frustum);
+      }()),
+      Catch::Contains(
+          "The sphericity must be set between 0.0, corresponding to a flat "
+          "surface, and 1.0, corresponding to a spherical surface, inclusive. "
+          "It is currently set to 1.3."));
 #endif
 }
 }  // namespace domain

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge2D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge2D.cpp
@@ -209,62 +209,29 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge2D.Map", "[Domain][Unit]") {
   test_wedge2d_all_orientations(true);   // Equiangular
   test_equality();
   CHECK(not Wedge2D{}.is_identity());
-}
 
-// [[OutputRegex, The radius of the inner surface must be greater than zero.]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge2D.RadiusInner",
-                               "[Domain][Unit]") {
-  ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  auto failed_wedge2d = Wedge2D(-0.2, 4.0, 0.0, 1.0, OrientationMap<2>{}, true);
-  static_cast<void>(failed_wedge2d);
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// [[OutputRegex, Sphericity of the inner surface must be between 0 and 1]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.Domain.CoordinateMaps.Wedge2D.CircularityInner", "[Domain][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  auto failed_wedge2d = Wedge2D(0.2, 4.0, -0.2, 1.0, OrientationMap<2>{}, true);
-  static_cast<void>(failed_wedge2d);
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// [[OutputRegex, Sphericity of the outer surface must be between 0 and 1]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.Domain.CoordinateMaps.Wedge2D.CircularityOuter", "[Domain][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  auto failed_wedge2d = Wedge2D(0.2, 4.0, 0.0, -0.2, OrientationMap<2>{}, true);
-  static_cast<void>(failed_wedge2d);
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// [[OutputRegex, The radius of the outer surface must be greater than the
-// radius of the inner surface.]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge2D.RadiusOuter",
-                               "[Domain][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  auto failed_wedge2d = Wedge2D(4.2, 4.0, 0.0, 1.0, OrientationMap<2>{}, true);
-  static_cast<void>(failed_wedge2d);
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// [[OutputRegex, The arguments passed into the constructor for Wedge result
-// in an object where the outer surface is pierced by the inner surface.]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.Domain.CoordinateMaps.Wedge2D.PiercedSurface", "[Domain][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  auto failed_wedge2d = Wedge2D(3.0, 4.0, 1.0, 0.0, OrientationMap<2>{}, true);
-  static_cast<void>(failed_wedge2d);
-  ERROR("Failed to trigger ASSERT in an assertion test");
+  CHECK_THROWS_WITH(
+      Wedge2D(-0.2, 4.0, 0.0, 1.0, OrientationMap<2>{}, true),
+      Catch::Contains(
+          "The radius of the inner surface must be greater than zero."));
+  CHECK_THROWS_WITH(
+      Wedge2D(0.2, 4.0, -0.2, 1.0, OrientationMap<2>{}, true),
+      Catch::Contains(
+          "Sphericity of the inner surface must be between 0 and 1"));
+  CHECK_THROWS_WITH(
+      Wedge2D(0.2, 4.0, 0.0, -0.2, OrientationMap<2>{}, true),
+      Catch::Contains(
+          "Sphericity of the outer surface must be between 0 and 1"));
+  CHECK_THROWS_WITH(
+      Wedge2D(4.2, 4.0, 0.0, 1.0, OrientationMap<2>{}, true),
+      Catch::Contains("The radius of the outer surface must be greater than "
+                      "the radius of the inner surface."));
+  CHECK_THROWS_WITH(
+      Wedge2D(3.0, 4.0, 1.0, 0.0, OrientationMap<2>{}, true),
+      Catch::Contains(
+          "The arguments passed into the constructor for Wedge result in an "
+          "object where the outer surface is pierced by the inner surface."));
 #endif
 }
 }  // namespace domain

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
@@ -338,76 +338,35 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.Map", "[Domain][Unit]") {
   test_wedge3d_alignment();
   test_wedge3d_random_radii();
   CHECK(not Wedge3D{}.is_identity());
-}
 
-// [[OutputRegex, The radius of the inner surface must be greater than zero.]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.RadiusInner",
-                               "[Domain][Unit]") {
-  ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  auto failed_wedge3d = Wedge3D(-0.2, 4.0, 0.0, 1.0, OrientationMap<3>{}, true);
-  static_cast<void>(failed_wedge3d);
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// [[OutputRegex, Sphericity of the inner surface must be between 0 and 1]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.SphericityInner",
-                               "[Domain][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  auto failed_wedge3d = Wedge3D(0.2, 4.0, -0.2, 1.0, OrientationMap<3>{}, true);
-  static_cast<void>(failed_wedge3d);
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// [[OutputRegex, Sphericity of the outer surface must be between 0 and 1]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.SphericityOuter",
-                               "[Domain][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  auto failed_wedge3d = Wedge3D(0.2, 4.0, 0.0, -0.2, OrientationMap<3>{}, true);
-  static_cast<void>(failed_wedge3d);
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// [[OutputRegex, The radius of the outer surface must be greater than the
-// radius of the inner surface.]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.RadiusOuter",
-                               "[Domain][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  auto failed_wedge3d = Wedge3D(4.2, 4.0, 0.0, 1.0, OrientationMap<3>{}, true);
-  static_cast<void>(failed_wedge3d);
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// [[OutputRegex, The arguments passed into the constructor for Wedge result
-// in an object where the outer surface is pierced by the inner surface.]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.PiercedSurface",
-                               "[Domain][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  auto failed_wedge3d = Wedge3D(3.0, 4.0, 1.0, 0.0, OrientationMap<3>{}, true);
-  static_cast<void>(failed_wedge3d);
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// [[OutputRegex, Only the 'Linear' radial distribution is supported for
-// non-spherical wedges.]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.LogarithmicMap",
-                               "[Domain][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  auto failed_wedge3d = Wedge3D(
-      0.2, 4.0, 0.8, 0.9, OrientationMap<3>{}, true, Wedge3D::WedgeHalves::Both,
-      domain::CoordinateMaps::Distribution::Logarithmic);
-  static_cast<void>(failed_wedge3d);
-  ERROR("Failed to trigger ASSERT in an assertion test");
+  CHECK_THROWS_WITH(
+      Wedge3D(-0.2, 4.0, 0.0, 1.0, OrientationMap<3>{}, true),
+      Catch::Contains(
+          "The radius of the inner surface must be greater than zero."));
+  CHECK_THROWS_WITH(
+      Wedge3D(0.2, 4.0, -0.2, 1.0, OrientationMap<3>{}, true),
+      Catch::Contains(
+          "Sphericity of the inner surface must be between 0 and 1"));
+  CHECK_THROWS_WITH(
+      Wedge3D(0.2, 4.0, 0.0, -0.2, OrientationMap<3>{}, true),
+      Catch::Contains(
+          "Sphericity of the outer surface must be between 0 and 1"));
+  CHECK_THROWS_WITH(
+      Wedge3D(4.2, 4.0, 0.0, 1.0, OrientationMap<3>{}, true),
+      Catch::Contains(
+          "The radius of the outer surface must be greater than the "
+          "radius of the inner surface."));
+  CHECK_THROWS_WITH(
+      Wedge3D(3.0, 4.0, 1.0, 0.0, OrientationMap<3>{}, true),
+      Catch::Contains(
+          "The arguments passed into the constructor for Wedge result in an "
+          "object where the outer surface is pierced by the inner surface."));
+  CHECK_THROWS_WITH(Wedge3D(0.2, 4.0, 0.8, 0.9, OrientationMap<3>{}, true,
+                            Wedge3D::WedgeHalves::Both,
+                            domain::CoordinateMaps::Distribution::Logarithmic),
+                    Catch::Contains("Only the 'Linear' radial distribution is "
+                                    "supported for non-spherical wedges."));
 #endif
 }
 }  // namespace domain

--- a/tests/Unit/Domain/FunctionsOfTime/Test_PiecewisePolynomial.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_PiecewisePolynomial.cpp
@@ -240,120 +240,120 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.PiecewisePolynomial",
     f_of_t.update(2.0, {3.0, 4.0}, 2.1);
     CHECK(f_of_t.func(2.0)[0] == DataVector{1.0, 2.0});
   }
-}
 
-// [[OutputRegex, t must be increasing from call to call. Attempted to update at
-// time 1, which precedes the previous update time of 2.]]
-SPECTRE_TEST_CASE(
-    "Unit.Domain.FunctionsOfTime.PiecewisePolynomial.BadUpdateTime",
-    "[Domain][Unit]") {
-  ERROR_TEST();
-  // two component system (x**3 and x**2)
-  constexpr size_t deriv_order = 3;
-  const std::array<DataVector, deriv_order + 1> init_func{
-      {{0.0, 0.0}, {0.0, 0.0}, {0.0, 2.0}, {6.0, 0.0}}};
-  FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(0.0, init_func, 0.1);
-  f_of_t.update(2.0, {6.0, 0.0}, 2.1);
-  f_of_t.update(1.0, {6.0, 0.0}, 2.1);
-}
+  CHECK_THROWS_WITH(
+      ([]() {
+        // two component system (x**3 and x**2)
+        constexpr size_t deriv_order = 3;
+        const std::array<DataVector, deriv_order + 1> init_func{
+            {{0.0, 0.0}, {0.0, 0.0}, {0.0, 2.0}, {6.0, 0.0}}};
+        FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(0.0, init_func,
+                                                                 0.1);
+        f_of_t.update(2.0, {6.0, 0.0}, 2.1);
+        f_of_t.update(1.0, {6.0, 0.0}, 2.1);
+      }()),
+      Catch::Contains(
+          "t must be increasing from call to call. Attempted to update "
+          "at time 1, which precedes the previous update time of 2."));
 
-// [[OutputRegex, expiration_time must be nondecreasing from call to call.
-// Attempted to change expiration time to 1\.1, which precedes the
-// previous expiration time of 2\.1.]]
-SPECTRE_TEST_CASE(
-    "Unit.Domain.FunctionsOfTime.PiecewisePolynomial.BadExpiryTime",
-    "[Domain][Unit]") {
-  ERROR_TEST();
-  // two component system (x**3 and x**2)
-  constexpr size_t deriv_order = 3;
-  const std::array<DataVector, deriv_order + 1> init_func{
-      {{0.0, 0.0}, {0.0, 0.0}, {0.0, 2.0}, {6.0, 0.0}}};
-  FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(0.0, init_func, 0.1);
-  f_of_t.update(1.0, {6.0, 0.0}, 2.1);
-  f_of_t.update(2.0, {6.0, 0.0}, 1.1);
-}
+  CHECK_THROWS_WITH(
+      ([]() {
+        // two component system (x**3 and x**2)
+        constexpr size_t deriv_order = 3;
+        const std::array<DataVector, deriv_order + 1> init_func{
+            {{0.0, 0.0}, {0.0, 0.0}, {0.0, 2.0}, {6.0, 0.0}}};
+        FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(0.0, init_func,
+                                                                 0.1);
+        f_of_t.update(1.0, {6.0, 0.0}, 2.1);
+        f_of_t.update(2.0, {6.0, 0.0}, 1.1);
+      }()),
+      Catch::Contains(
+          "expiration_time must be nondecreasing from call to call. "
+          "Attempted to change expiration time to 1.1, which precedes "
+          "the previous expiration time of 2.1."));
 
-// [[OutputRegex, Attempt to update PiecewisePolynomial at a time 1
-// that is earlier than the previous expiration time of 2.]]
-SPECTRE_TEST_CASE(
-    "Unit.Domain.FunctionsOfTime.PiecewisePolynomial.BadUpdateGtExpiry",
-    "[Domain][Unit]") {
-  ERROR_TEST();
-  // two component system (x**3 and x**2)
-  constexpr size_t deriv_order = 3;
-  const std::array<DataVector, deriv_order + 1> init_func{
-      {{0.0, 0.0}, {0.0, 0.0}, {0.0, 2.0}, {6.0, 0.0}}};
-  FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(0.0, init_func, 2.0);
-  f_of_t.update(1.0, {6.0, 0.0}, 2.1);
-}
+  CHECK_THROWS_WITH(
+      ([]() {
+        // two component system (x**3 and x**2)
+        constexpr size_t deriv_order = 3;
+        const std::array<DataVector, deriv_order + 1> init_func{
+            {{0.0, 0.0}, {0.0, 0.0}, {0.0, 2.0}, {6.0, 0.0}}};
+        FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(0.0, init_func,
+                                                                 2.0);
+        f_of_t.update(1.0, {6.0, 0.0}, 2.1);
+      }()),
+      Catch::Contains(
+          "Attempt to update PiecewisePolynomial at a time 1 that is "
+          "earlier than the previous expiration time of 2."));
 
-// [[OutputRegex, Attempt to set the expiration time of PiecewisePolynomial
-// to a value 2\.2 that is earlier than the current time 2\.5.]]
-SPECTRE_TEST_CASE(
-    "Unit.Domain.FunctionsOfTime.PiecewisePolynomial.BadUpdateLtExpiry",
-    "[Domain][Unit]") {
-  ERROR_TEST();
-  // two component system (x**3 and x**2)
-  constexpr size_t deriv_order = 3;
-  const std::array<DataVector, deriv_order + 1> init_func{
-      {{0.0, 0.0}, {0.0, 0.0}, {0.0, 2.0}, {6.0, 0.0}}};
-  FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(0.0, init_func, 2.0);
-  f_of_t.update(2.5, {6.0, 0.0}, 2.2);
-}
+  CHECK_THROWS_WITH(
+      ([]() {
+        // two component system (x**3 and x**2)
+        constexpr size_t deriv_order = 3;
+        const std::array<DataVector, deriv_order + 1> init_func{
+            {{0.0, 0.0}, {0.0, 0.0}, {0.0, 2.0}, {6.0, 0.0}}};
+        FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(0.0, init_func,
+                                                                 2.0);
+        f_of_t.update(2.5, {6.0, 0.0}, 2.2);
+      }()),
+      Catch::Contains(
+          "Attempt to set the expiration time of PiecewisePolynomial to "
+          "a value 2.2 that is earlier than the current time 2.5."));
 
-// [[OutputRegex, Attempted to change expiration time to
-// 1\.5, which precedes the previous expiration time of 2.]]
-SPECTRE_TEST_CASE(
-    "Unit.Domain.FunctionsOfTime.PiecewisePolynomial.BadResetExpiry",
-    "[Domain][Unit]") {
-  ERROR_TEST();
-  // two component system (x**3 and x**2)
-  constexpr size_t deriv_order = 3;
-  const std::array<DataVector, deriv_order + 1> init_func{
-      {{0.0, 0.0}, {0.0, 0.0}, {0.0, 2.0}, {6.0, 0.0}}};
-  FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(0.0, init_func, 2.0);
-  f_of_t.reset_expiration_time(1.5);
-}
+  CHECK_THROWS_WITH(
+      ([]() {
+        // two component system (x**3 and x**2)
+        constexpr size_t deriv_order = 3;
+        const std::array<DataVector, deriv_order + 1> init_func{
+            {{0.0, 0.0}, {0.0, 0.0}, {0.0, 2.0}, {6.0, 0.0}}};
+        FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(0.0, init_func,
+                                                                 2.0);
+        f_of_t.reset_expiration_time(1.5);
+        f_of_t.update(2.5, {6.0, 0.0}, 2.2);
+      }()),
+      Catch::Contains(
+          "Attempted to change expiration time to 1.5, which precedes "
+          "the previous expiration time of 2."));
 
-// [[OutputRegex, the number of components trying to be updated \(3\) does not
-// match the number of components \(2\) in the PiecewisePolynomial.]]
-SPECTRE_TEST_CASE(
-    "Unit.Domain.FunctionsOfTime.PiecewisePolynomial.BadUpdateSize",
-    "[Domain][Unit]") {
-  ERROR_TEST();
-  // two component system (x**3 and x**2)
-  constexpr size_t deriv_order = 3;
-  const std::array<DataVector, deriv_order + 1> init_func{
-      {{0.0, 0.0}, {0.0, 0.0}, {0.0, 2.0}, {6.0, 0.0}}};
-  FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(0.0, init_func, 0.1);
-  f_of_t.update(1.0, {6.0, 0.0, 0.0}, 1.1);
-}
+  CHECK_THROWS_WITH(
+      ([]() {
+        // two component system (x**3 and x**2)
+        constexpr size_t deriv_order = 3;
+        const std::array<DataVector, deriv_order + 1> init_func{
+            {{0.0, 0.0}, {0.0, 0.0}, {0.0, 2.0}, {6.0, 0.0}}};
+        FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(0.0, init_func,
+                                                                 0.1);
+        f_of_t.update(1.0, {6.0, 0.0, 0.0}, 1.1);
+      }()),
+      Catch::Contains(
+          "the number of components trying to be updated (3) does not match "
+          "the number of components (2) in the PiecewisePolynomial."));
 
-// [[OutputRegex, requested time 0.5 precedes earliest time 1 of times.]]
-SPECTRE_TEST_CASE(
-    "Unit.Domain.FunctionsOfTime.PiecewisePolynomial.TimeOutOfRange",
-    "[Domain][Unit]") {
-  ERROR_TEST();
-  // two component system (x**3 and x**2)
-  constexpr size_t deriv_order = 3;
-  const std::array<DataVector, deriv_order + 1> init_func{
-      {{1.0, 1.0}, {3.0, 2.0}, {6.0, 2.0}, {6.0, 0.0}}};
-  FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(1.0, init_func, 2.0);
-  f_of_t.update(2.0, {6.0, 0.0}, 2.1);
-  f_of_t.func(0.5);
-}
+  CHECK_THROWS_WITH(
+      ([]() {
+        // two component system (x**3 and x**2)
+        constexpr size_t deriv_order = 3;
+        const std::array<DataVector, deriv_order + 1> init_func{
+            {{1.0, 1.0}, {3.0, 2.0}, {6.0, 2.0}, {6.0, 0.0}}};
+        FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(1.0, init_func,
+                                                                 2.0);
+        f_of_t.update(2.0, {6.0, 0.0}, 2.1);
+        f_of_t.func(0.5);
+      }()),
+      Catch::Contains("requested time 0.5 precedes earliest time 1 of times."));
 
-// [[OutputRegex, Attempt to evaluate PiecewisePolynomial at a time 2\.2
-// that is after the expiration time 2\.]]
-SPECTRE_TEST_CASE(
-    "Unit.Domain.FunctionsOfTime.PiecewisePolynomial.TimeAfterExpiry",
-    "[Domain][Unit]") {
-  ERROR_TEST();
-  // two component system (x**3 and x**2)
-  constexpr size_t deriv_order = 3;
-  const std::array<DataVector, deriv_order + 1> init_func{
-      {{1.0, 1.0}, {3.0, 2.0}, {6.0, 2.0}, {6.0, 0.0}}};
-  FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(1.0, init_func, 2.0);
-  f_of_t.func(2.2);
+  CHECK_THROWS_WITH(
+      ([]() {
+        // two component system (x**3 and x**2)
+        constexpr size_t deriv_order = 3;
+        const std::array<DataVector, deriv_order + 1> init_func{
+            {{1.0, 1.0}, {3.0, 2.0}, {6.0, 2.0}, {6.0, 0.0}}};
+        FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(1.0, init_func,
+                                                                 2.0);
+        f_of_t.func(2.2);
+      }()),
+      Catch::Contains(
+          "Attempt to evaluate PiecewisePolynomial at a time 2.2 that "
+          "is after the expiration time 2."));
 }
 }  // namespace domain

--- a/tests/Unit/Domain/FunctionsOfTime/Test_ReadSpecPiecewisePolynomial.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_ReadSpecPiecewisePolynomial.cpp
@@ -123,11 +123,14 @@ void test_options() {
           .get<domain::FunctionsOfTime::OptionTags::FunctionOfTimeNameMap>() ==
       expected_set_names);
 }
+
+void test_errors();
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.ReadSpecPiecewisePolynomial",
                   "[Unit][Evolution][Actions]") {
   test_options();
+  test_errors();
 
   // Create a temporary file with test data to read in
   // First, check if the file exists, and delete it if so
@@ -383,147 +386,155 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.ReadSpecPiecewisePolynomial",
   file_system::rm(test_filename, true);
 }
 
-// [[OutputRegex, Non-monotonic time found]]
-SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.ReadSpecPolyNonmonotonic",
-                  "[Unit][Evolution][Actions]") {
-  ERROR_TEST();
+namespace {
+void test_errors() {
+  CHECK_THROWS_WITH(
+      ([]() {
+        // Create a temporary file with test data to read in
+        // First, check if the file exists, and delete it if so
+        const std::string test_filename{
+            "TestSpecFuncOfTimeDataNonmonotonic.h5"};
+        const std::map<std::string, std::string> test_name_map{
+            {{"RotationAngle", "RotationAngle"}}};
+        constexpr uint32_t version_number = 4;
+        if (file_system::check_if_file_exists(test_filename)) {
+          file_system::rm(test_filename, true);
+        }
 
-  // Create a temporary file with test data to read in
-  // First, check if the file exists, and delete it if so
-  const std::string test_filename{"TestSpecFuncOfTimeDataNonmonotonic.h5"};
-  const std::map<std::string, std::string> test_name_map{
-      {{"RotationAngle", "RotationAngle"}}};
-  constexpr uint32_t version_number = 4;
-  if (file_system::check_if_file_exists(test_filename)) {
-    file_system::rm(test_filename, true);
-  }
+        h5::H5File<h5::AccessType::ReadWrite> test_file(test_filename);
 
-  h5::H5File<h5::AccessType::ReadWrite> test_file(test_filename);
+        constexpr size_t number_of_times = 3;
+        const std::array<double, number_of_times> expected_times{
+            {0.0, 0.1, 0.2}};
+        const std::string expected_name{"RotationAngle"};
 
-  constexpr size_t number_of_times = 3;
-  const std::array<double, number_of_times> expected_times{{0.0, 0.1, 0.2}};
-  const std::string expected_name{"RotationAngle"};
+        const std::array<DataVector, 4> initial_rotation{
+            {{{2.0}}, {{-0.1}}, {{-0.02}}, {{-0.003}}}};
+        const std::array<DataVector, number_of_times - 1>
+            next_rotation_fourth_deriv{{{{-0.5}}, {{-0.75}}}};
+        domain::FunctionsOfTime::PiecewisePolynomial<3> rotation(
+            expected_times[0], initial_rotation, expected_times[0]);
+        rotation.update(expected_times[1], {{next_rotation_fourth_deriv[0]}},
+                        expected_times[1]);
+        rotation.update(expected_times[2], {{next_rotation_fourth_deriv[1]}},
+                        expected_times[2]);
+        const std::array<std::array<DataVector, 3>, number_of_times - 1>&
+            rotation_func_and_2_derivs_next{
+                {rotation.func_and_2_derivs(expected_times[1]),
+                 rotation.func_and_2_derivs(expected_times[2])}};
 
-  const std::array<DataVector, 4> initial_rotation{
-      {{{2.0}}, {{-0.1}}, {{-0.02}}, {{-0.003}}}};
-  const std::array<DataVector, number_of_times - 1> next_rotation_fourth_deriv{
-      {{{-0.5}}, {{-0.75}}}};
-  domain::FunctionsOfTime::PiecewisePolynomial<3> rotation(
-      expected_times[0], initial_rotation, expected_times[0]);
-  rotation.update(expected_times[1], {{next_rotation_fourth_deriv[0]}},
-                  expected_times[1]);
-  rotation.update(expected_times[2], {{next_rotation_fourth_deriv[1]}},
-                  expected_times[2]);
-  const std::array<std::array<DataVector, 3>, number_of_times - 1>&
-      rotation_func_and_2_derivs_next{
-          {rotation.func_and_2_derivs(expected_times[1]),
-           rotation.func_and_2_derivs(expected_times[2])}};
+        const std::vector<std::vector<double>> test_rotation{
+            {expected_times[0], expected_times[0], 1.0, 3.0, 1.0,
+             initial_rotation[0][0], initial_rotation[1][0],
+             initial_rotation[2][0], initial_rotation[3][0]},
+            {expected_times[2], expected_times[2], 1.0, 3.0, 1.0,
+             rotation_func_and_2_derivs_next[0][0][0],
+             rotation_func_and_2_derivs_next[0][1][0],
+             rotation_func_and_2_derivs_next[0][2][0],
+             next_rotation_fourth_deriv[0][0]},
+            {expected_times[1], expected_times[1], 1.0, 3.0, 1.0,
+             rotation_func_and_2_derivs_next[1][0][0],
+             rotation_func_and_2_derivs_next[1][1][0],
+             rotation_func_and_2_derivs_next[1][2][0],
+             next_rotation_fourth_deriv[1][0]}};
+        const std::vector<std::string> rotation_legend{
+            "Time", "TLastUpdate", "Nc",    "DerivOrder", "Version",
+            "Phi",  "dPhi",        "d2Phi", "d3Phi"};
+        auto& rotation_file = test_file.insert<h5::Dat>(
+            "/" + expected_name, rotation_legend, version_number);
+        rotation_file.append(test_rotation);
 
-  const std::vector<std::vector<double>> test_rotation{
-      {expected_times[0], expected_times[0], 1.0, 3.0, 1.0,
-       initial_rotation[0][0], initial_rotation[1][0], initial_rotation[2][0],
-       initial_rotation[3][0]},
-      {expected_times[2], expected_times[2], 1.0, 3.0, 1.0,
-       rotation_func_and_2_derivs_next[0][0][0],
-       rotation_func_and_2_derivs_next[0][1][0],
-       rotation_func_and_2_derivs_next[0][2][0],
-       next_rotation_fourth_deriv[0][0]},
-      {expected_times[1], expected_times[1], 1.0, 3.0, 1.0,
-       rotation_func_and_2_derivs_next[1][0][0],
-       rotation_func_and_2_derivs_next[1][1][0],
-       rotation_func_and_2_derivs_next[1][2][0],
-       next_rotation_fourth_deriv[1][0]}};
-  const std::vector<std::string> rotation_legend{
-      "Time", "TLastUpdate", "Nc",    "DerivOrder", "Version",
-      "Phi",  "dPhi",        "d2Phi", "d3Phi"};
-  auto& rotation_file = test_file.insert<h5::Dat>(
-      "/" + expected_name, rotation_legend, version_number);
-  rotation_file.append(test_rotation);
+        std::unordered_map<std::string,
+                           domain::FunctionsOfTime::PiecewisePolynomial<3>>
+            spec_functions_of_time{};
+        // Attempt to read in the file: will trigger error that file contains
+        // a non-monotonic time step
+        domain::FunctionsOfTime::read_spec_piecewise_polynomial(
+            make_not_null(&spec_functions_of_time), test_filename,
+            test_name_map);
+      }()),
+      Catch::Contains("Non-monotonic time found"));
 
-  std::unordered_map<std::string,
-                     domain::FunctionsOfTime::PiecewisePolynomial<3>>
-      spec_functions_of_time{};
-  // Attempt to read in the file: will trigger error that file contains
-  // a non-monotonic time step
-  domain::FunctionsOfTime::read_spec_piecewise_polynomial(
-      make_not_null(&spec_functions_of_time), test_filename, test_name_map);
+  CHECK_THROWS_WITH(
+      ([]() {
+        // Each row in the SpEC data read by
+        // read_spec_piecewise_polynomial() should have the same values in
+        // column 2 (number of components), column 3 (max deriv order), or
+        // column 4 (version). This test checks that an appropriate ERROR()
+        // triggers if one of these (randomly chosen) is not satisfied.
+
+        // Create a temporary file with test data to read in
+        // First, check if the file exists, and delete it if so
+        const std::string test_filename{"TestSpecFuncOfTimeDataCols234.h5"};
+        const std::map<std::string, std::string> test_name_map{
+            {{"RotationAngle", "RotationAngle"}}};
+        constexpr uint32_t version_number = 4;
+        if (file_system::check_if_file_exists(test_filename)) {
+          file_system::rm(test_filename, true);
+        }
+
+        h5::H5File<h5::AccessType::ReadWrite> test_file(test_filename);
+
+        constexpr size_t number_of_times = 3;
+        const std::array<double, number_of_times> expected_times{
+            {0.0, 0.1, 0.2}};
+        const std::string expected_name{"RotationAngle"};
+
+        const std::array<DataVector, 4> initial_rotation{
+            {{{2.0}}, {{-0.1}}, {{-0.02}}, {{-0.003}}}};
+        const std::array<DataVector, number_of_times - 1>
+            next_rotation_third_deriv{{{{-0.5}}, {{-0.75}}}};
+        domain::FunctionsOfTime::PiecewisePolynomial<3> rotation(
+            expected_times[0], initial_rotation, expected_times[0]);
+        rotation.update(expected_times[1], {{next_rotation_third_deriv[0]}},
+                        expected_times[1]);
+        rotation.update(expected_times[2], {{next_rotation_third_deriv[1]}},
+                        expected_times[2]);
+        const std::array<std::array<DataVector, 3>, number_of_times - 1>&
+            rotation_func_and_2_derivs_next{
+                {rotation.func_and_2_derivs(expected_times[1]),
+                 rotation.func_and_2_derivs(expected_times[2])}};
+
+        // Select which of columns 2, 3, 4 to make unequal.
+        const std::array<double, 3> columns_234{{1.0, 3.0, 1.0}};
+        std::array<double, 3> columns_234_row1{columns_234};
+        MAKE_GENERATOR(gen);
+        std::uniform_int_distribution<> dist(0, 2);
+        gsl::at(columns_234_row1, dist(gen)) += 1.0;
+
+        const std::vector<std::vector<double>> test_rotation{
+            {expected_times[0], expected_times[0], columns_234[0],
+             columns_234[1], columns_234[2], initial_rotation[0][0],
+             initial_rotation[1][0], initial_rotation[2][0],
+             initial_rotation[3][0]},
+            {expected_times[1], expected_times[1], columns_234_row1[0],
+             columns_234_row1[1], columns_234_row1[2],
+             rotation_func_and_2_derivs_next[0][0][0],
+             rotation_func_and_2_derivs_next[0][1][0],
+             rotation_func_and_2_derivs_next[0][2][0],
+             next_rotation_third_deriv[0][0]},
+            {expected_times[2], expected_times[2], columns_234[0],
+             columns_234[1], columns_234[2],
+             rotation_func_and_2_derivs_next[1][0][0],
+             rotation_func_and_2_derivs_next[1][1][0],
+             rotation_func_and_2_derivs_next[1][2][0],
+             next_rotation_third_deriv[1][0]}};
+        const std::vector<std::string> rotation_legend{
+            "Time", "TLastUpdate", "Nc",    "DerivOrder", "Version",
+            "Phi",  "dPhi",        "d2Phi", "d3Phi"};
+        auto& rotation_file = test_file.insert<h5::Dat>(
+            "/" + expected_name, rotation_legend, version_number);
+        rotation_file.append(test_rotation);
+
+        std::unordered_map<std::string,
+                           domain::FunctionsOfTime::PiecewisePolynomial<3>>
+            spec_functions_of_time{};
+        // Attempt to read in the file: will trigger error that column 2, 3, or
+        // 4 should be constant, but one isn't
+        domain::FunctionsOfTime::read_spec_piecewise_polynomial(
+            make_not_null(&spec_functions_of_time), test_filename,
+            test_name_map);
+      }()),
+      Catch::Contains("Values in column 2"));
 }
-
-// [[OutputRegex, Values in column 2]]
-SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.ReadSpecPolyCols234Const",
-                  "[Unit][Evolution][Actions]") {
-  ERROR_TEST();
-  // Each row in the SpEC data read by
-  // read_spec_piecewise_polynomial() should have the same values in
-  // column 2 (number of components), column 3 (max deriv order), or column 4
-  // (version). This test checks that an appropriate ERROR() triggers if one of
-  // these (randomly chosen) is not satisfied.
-
-  // Create a temporary file with test data to read in
-  // First, check if the file exists, and delete it if so
-  const std::string test_filename{"TestSpecFuncOfTimeDataCols234.h5"};
-  const std::map<std::string, std::string> test_name_map{
-      {{"RotationAngle", "RotationAngle"}}};
-  constexpr uint32_t version_number = 4;
-  if (file_system::check_if_file_exists(test_filename)) {
-    file_system::rm(test_filename, true);
-  }
-
-  h5::H5File<h5::AccessType::ReadWrite> test_file(test_filename);
-
-  constexpr size_t number_of_times = 3;
-  const std::array<double, number_of_times> expected_times{{0.0, 0.1, 0.2}};
-  const std::string expected_name{"RotationAngle"};
-
-  const std::array<DataVector, 4> initial_rotation{
-      {{{2.0}}, {{-0.1}}, {{-0.02}}, {{-0.003}}}};
-  const std::array<DataVector, number_of_times - 1> next_rotation_third_deriv{
-      {{{-0.5}}, {{-0.75}}}};
-  domain::FunctionsOfTime::PiecewisePolynomial<3> rotation(
-      expected_times[0], initial_rotation, expected_times[0]);
-  rotation.update(expected_times[1], {{next_rotation_third_deriv[0]}},
-                  expected_times[1]);
-  rotation.update(expected_times[2], {{next_rotation_third_deriv[1]}},
-                  expected_times[2]);
-  const std::array<std::array<DataVector, 3>, number_of_times - 1>&
-      rotation_func_and_2_derivs_next{
-          {rotation.func_and_2_derivs(expected_times[1]),
-           rotation.func_and_2_derivs(expected_times[2])}};
-
-  // Select which of columns 2, 3, 4 to make unequal.
-  const std::array<double, 3> columns_234{{1.0, 3.0, 1.0}};
-  std::array<double, 3> columns_234_row1{columns_234};
-  MAKE_GENERATOR(gen);
-  std::uniform_int_distribution<> dist(0, 2);
-  gsl::at(columns_234_row1, dist(gen)) += 1.0;
-
-  const std::vector<std::vector<double>> test_rotation{
-      {expected_times[0], expected_times[0], columns_234[0], columns_234[1],
-       columns_234[2], initial_rotation[0][0], initial_rotation[1][0],
-       initial_rotation[2][0], initial_rotation[3][0]},
-      {expected_times[1], expected_times[1], columns_234_row1[0],
-       columns_234_row1[1], columns_234_row1[2],
-       rotation_func_and_2_derivs_next[0][0][0],
-       rotation_func_and_2_derivs_next[0][1][0],
-       rotation_func_and_2_derivs_next[0][2][0],
-       next_rotation_third_deriv[0][0]},
-      {expected_times[2], expected_times[2], columns_234[0], columns_234[1],
-       columns_234[2], rotation_func_and_2_derivs_next[1][0][0],
-       rotation_func_and_2_derivs_next[1][1][0],
-       rotation_func_and_2_derivs_next[1][2][0],
-       next_rotation_third_deriv[1][0]}};
-  const std::vector<std::string> rotation_legend{
-      "Time", "TLastUpdate", "Nc",    "DerivOrder", "Version",
-      "Phi",  "dPhi",        "d2Phi", "d3Phi"};
-  auto& rotation_file = test_file.insert<h5::Dat>(
-      "/" + expected_name, rotation_legend, version_number);
-  rotation_file.append(test_rotation);
-
-  std::unordered_map<std::string,
-                     domain::FunctionsOfTime::PiecewisePolynomial<3>>
-      spec_functions_of_time{};
-  // Attempt to read in the file: will trigger error that column 2, 3, or 4
-  // should be constant, but one isn't
-  domain::FunctionsOfTime::read_spec_piecewise_polynomial(
-      make_not_null(&spec_functions_of_time), test_filename, test_name_map);
-}
+}  // namespace

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -235,52 +235,50 @@ void test_wedge_map_generation_against_domain_helpers(
   CHECK(maps == expected_coord_maps);
 }
 
-// [[OutputRegex, If we are using half wedges we must also be using
-// ShellWedges::All.]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.Domain.DomainHelpers.WedgeCoordinateMaps.Assert1", "[Domain][Unit]") {
-  ASSERTION_TEST();
+void test_wedge_errors() {
 #ifdef SPECTRE_DEBUG
-  const double inner_radius = 0.5;
-  const double outer_radius = 2.0;
-  const double inner_sphericity = 1.0;
-  const double outer_sphericity = 1.0;
-  const bool use_equiangular_map = true;
-  const bool use_half_wedges = true;
-  const std::vector<domain::CoordinateMaps::Distribution> radial_distribution{
-      domain::CoordinateMaps::Distribution::Logarithmic};
-  const ShellWedges which_wedges = ShellWedges::FourOnEquator;
-  static_cast<void>(sph_wedge_coordinate_maps(
-      inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, use_half_wedges, {}, radial_distribution,
-      which_wedges));
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
+  CHECK_THROWS_WITH(
+      ([]() {
+        const double inner_radius = 0.5;
+        const double outer_radius = 2.0;
+        const double inner_sphericity = 1.0;
+        const double outer_sphericity = 1.0;
+        const bool use_equiangular_map = true;
+        const bool use_half_wedges = true;
+        const std::vector<domain::CoordinateMaps::Distribution>
+            radial_distribution{
+                domain::CoordinateMaps::Distribution::Logarithmic};
+        const ShellWedges which_wedges = ShellWedges::FourOnEquator;
+        static_cast<void>(sph_wedge_coordinate_maps(
+            inner_radius, outer_radius, inner_sphericity, outer_sphericity,
+            use_equiangular_map, use_half_wedges, {}, radial_distribution,
+            which_wedges));
+      }()),
+      Catch::Contains("If we are using half wedges we must also be using "
+                      "ShellWedges::All."));
 
-// [[OutputRegex, If we are using more than one layer the inner and outer
-// sphericities must match.]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.Domain.DomainHelpers.WedgeCoordinateMaps.Assert2", "[Domain][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  const double inner_radius = 0.5;
-  const double outer_radius = 2.0;
-  const double inner_sphericity = 0.9;
-  const double outer_sphericity = 1.0;
-  const bool use_equiangular_map = true;
-  const bool use_half_wedges = true;
-  std::vector<double> radial_partitioning{1., 1.5};
-  const std::vector<domain::CoordinateMaps::Distribution> radial_distribution{
-      domain::CoordinateMaps::Distribution::Logarithmic,
-      domain::CoordinateMaps::Distribution::Logarithmic,
-      domain::CoordinateMaps::Distribution::Logarithmic};
-  const ShellWedges which_wedges = ShellWedges::All;
-  static_cast<void>(sph_wedge_coordinate_maps(
-      inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, use_half_wedges, radial_partitioning,
-      radial_distribution, which_wedges));
-  ERROR("Failed to trigger ASSERT in an assertion test");
+  CHECK_THROWS_WITH(
+      ([]() {
+        const double inner_radius = 0.5;
+        const double outer_radius = 2.0;
+        const double inner_sphericity = 0.9;
+        const double outer_sphericity = 1.0;
+        const bool use_equiangular_map = true;
+        const bool use_half_wedges = true;
+        std::vector<double> radial_partitioning{1., 1.5};
+        const std::vector<domain::CoordinateMaps::Distribution>
+            radial_distribution{
+                domain::CoordinateMaps::Distribution::Logarithmic,
+                domain::CoordinateMaps::Distribution::Logarithmic,
+                domain::CoordinateMaps::Distribution::Logarithmic};
+        const ShellWedges which_wedges = ShellWedges::All;
+        static_cast<void>(sph_wedge_coordinate_maps(
+            inner_radius, outer_radius, inner_sphericity, outer_sphericity,
+            use_equiangular_map, use_half_wedges, radial_partitioning,
+            radial_distribution, which_wedges));
+      }()),
+      Catch::Contains("If we are using more than one layer the inner and outer "
+                      "sphericities must match."));
 #endif
 }
 
@@ -535,39 +533,33 @@ void test_all_frustum_directions() {
   }
 }
 
-// [[OutputRegex, The outer cube is too small! The inner cubes will pierce the
-// surface of the outer cube.]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.Domain.DomainHelpers.FrustumCoordinateMaps.Assert1",
-    "[Domain][Unit]") {
-  ASSERTION_TEST();
+void test_frustrum_errors() {
 #ifdef SPECTRE_DEBUG
-  const double length_inner_cube = 0.9;
-  const double length_outer_cube = 1.5;
-  const bool use_equiangular_map = true;
-  const std::array<double, 3> origin_preimage = {{0.0, 0.0, 0.0}};
-  static_cast<void>(
-      frustum_coordinate_maps(length_inner_cube, length_outer_cube,
-                              use_equiangular_map, origin_preimage));
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
+  CHECK_THROWS_WITH(
+      ([]() {
+        const double length_inner_cube = 0.9;
+        const double length_outer_cube = 1.5;
+        const bool use_equiangular_map = true;
+        const std::array<double, 3> origin_preimage = {{0.0, 0.0, 0.0}};
+        static_cast<void>(
+            frustum_coordinate_maps(length_inner_cube, length_outer_cube,
+                                    use_equiangular_map, origin_preimage));
+      }()),
+      Catch::Contains("The outer cube is too small! The inner cubes will "
+                      "pierce the surface of the outer cube."));
 
-// [[OutputRegex, The current choice for `origin_preimage` results in the inner
-// cubes piercing the surface of the outer cube.]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.Domain.DomainHelpers.FrustumCoordinateMaps.Assert2",
-    "[Domain][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  const double length_inner_cube = 1;
-  const double length_outer_cube = 3;
-  const bool use_equiangular_map = true;
-  const std::array<double, 3> origin_preimage = {{0.6, 0.0, 0.0}};
-  static_cast<void>(
-      frustum_coordinate_maps(length_inner_cube, length_outer_cube,
-                              use_equiangular_map, origin_preimage));
-  ERROR("Failed to trigger ASSERT in an assertion test");
+  CHECK_THROWS_WITH(
+      ([]() {
+        const double length_inner_cube = 1.0;
+        const double length_outer_cube = 3.0;
+        const bool use_equiangular_map = true;
+        const std::array<double, 3> origin_preimage = {{0.6, 0.0, 0.0}};
+        static_cast<void>(
+            frustum_coordinate_maps(length_inner_cube, length_outer_cube,
+                                    use_equiangular_map, origin_preimage));
+      }()),
+      Catch::Contains("The current choice for `origin_preimage` results in the "
+                      "inner cubes piercing the surface of the outer cube."));
 #endif
 }
 
@@ -1552,7 +1544,9 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers", "[Domain][Unit]") {
   test_periodic_same_block();
   test_periodic_different_blocks();
   test_wedge_map_generation();
+  test_wedge_errors();
   test_all_frustum_directions();
+  test_frustrum_errors();
   test_shell_graph();
   test_sphere_graph();
   test_bbh_corners();

--- a/tests/Unit/ErrorHandling/Test_AbortWithErrorMessage.cpp
+++ b/tests/Unit/ErrorHandling/Test_AbortWithErrorMessage.cpp
@@ -5,21 +5,33 @@
 
 #include "Utilities/ErrorHandling/AbortWithErrorMessage.hpp"
 
-// [[OutputRegex, 'a == b' violated!]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.ErrorHandling.AbortWithErrorMessage.Assert",
-    "[Unit][ErrorHandling]") {
-  ERROR_TEST();
-  abort_with_error_message("a == b", __FILE__, __LINE__,
-                           static_cast<const char*>(__PRETTY_FUNCTION__),
-                           "Test Error");
-}
-
-// [[OutputRegex, ############ ERROR]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.ErrorHandling.AbortWithErrorMessage.Error",
-                               "[Unit][ErrorHandling]") {
-  ERROR_TEST();
-  abort_with_error_message(__FILE__, __LINE__,
-                           static_cast<const char*>(__PRETTY_FUNCTION__),
-                           "Test Error");
+SPECTRE_TEST_CASE("Unit.ErrorHandling.AbortWithErrorMessage",
+                  "[Unit][ErrorHandling]") {
+  CHECK_THROWS_WITH(
+      abort_with_error_message("a == b", __FILE__, __LINE__,
+                               static_cast<const char*>(__PRETTY_FUNCTION__),
+                               "Test Abort"),
+      Catch::Contains("ASSERT FAILED") && Catch::Contains("a == b") &&
+          Catch::Contains("Test Abort") &&
+          Catch::Contains("Test_AbortWithErrorMessage") &&
+          Catch::Contains("Shortened stack trace is"));
+  CHECK_THROWS_WITH(
+      abort_with_error_message(__FILE__, __LINE__,
+                               static_cast<const char*>(__PRETTY_FUNCTION__),
+                               "Test Error"),
+      Catch::Contains("ERROR") && Catch::Contains("Test Error") &&
+          Catch::Contains("Test_AbortWithErrorMessage") &&
+          Catch::Contains("Shortened stack trace is"));
+  CHECK_THROWS_WITH(
+      abort_with_error_message_no_trace(
+          __FILE__, __LINE__, static_cast<const char*>(__PRETTY_FUNCTION__),
+          "Test no trace"),
+      Catch::Contains("ERROR") && Catch::Contains("Test no trace") &&
+          Catch::Contains("Test_AbortWithErrorMessage") &&
+          not Catch::Contains("Shortened stack trace is"));
+  CHECK_THROWS_AS(
+      abort_with_error_message_no_trace(
+          __FILE__, __LINE__, static_cast<const char*>(__PRETTY_FUNCTION__),
+          "Test no trace"),
+      std::runtime_error);
 }

--- a/tests/Unit/ErrorHandling/Test_AssertAndError.cpp
+++ b/tests/Unit/ErrorHandling/Test_AssertAndError.cpp
@@ -6,23 +6,19 @@
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 
-// [assertion_test_example]
-// [[OutputRegex, Testing assert]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.ErrorHandling.Assert",
-                               "[Unit][ErrorHandling]") {
-  ASSERTION_TEST();
+namespace {
 #ifdef SPECTRE_DEBUG
-  ASSERT(false, "Testing assert");
-  ERROR("Failed to trigger ASSERT in an assertion test");
+[[noreturn]] void trigger_assert() { ASSERT(false, "Testing assert"); }
 #endif
-}
-// [assertion_test_example]
 
-// [error_test_example]
-// [[OutputRegex, Testing error]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.ErrorHandling.Error",
-                               "[Unit][ErrorHandling]") {
-  ERROR_TEST();
-  ERROR("Testing error");
+[[noreturn]] void trigger_error() { ERROR("Testing error"); }
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ErrorHandling.AssertAndError",
+                  "[Unit][ErrorHandling]") {
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(trigger_assert(), Catch::Contains("Testing assert") &&
+                                          Catch::Contains("false"));
+#endif
+  CHECK_THROWS_WITH(trigger_error(), Catch::Contains("Testing error"));
 }
-// [error_test_example]

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_Bjorhus.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_Bjorhus.cpp
@@ -33,7 +33,7 @@ void test() {
   CAPTURE(Dim);
   MAKE_GENERATOR(gen);
   for (const std::string& bc_string :
-       {"ConstraintPreserving", "ConstraintPreservingPhysical"}) {
+       {"ConstraintPreserving"s, "ConstraintPreservingPhysical"s}) {
     CAPTURE(bc_string);
 
     helpers::test_boundary_condition_with_python<

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
@@ -38,10 +38,16 @@ target_link_libraries(
   DataStructures
   DataStructuresHelpers
   Domain
-  GeneralizedHarmonic
+  DomainStructure
+  FunctionsOfTime
   GeneralRelativity
   GeneralRelativityHelpers
+  GeneralRelativitySolutions
+  GeneralizedHarmonic
   Importers
+  LinearOperators
+  MathFunctions
+  Options
   Spectral
   Utilities
 )

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -51,6 +51,7 @@ target_link_libraries(
   DomainHelpers
   Framework
   GeneralRelativityHelpers
+  GrMhdAnalyticData
   HydroHelpers
   ValenciaDivClean
   )

--- a/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/CMakeLists.txt
@@ -21,7 +21,16 @@ add_test_library(
   "Evolution/Systems/RadiationTransport/M1Grey/"
   "${LIBRARY_SOURCES}"
   "M1Grey"
-  "Boost::boost"
+  ""
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  DataStructures
+  M1Grey
+  M1GreySolutions
+  Spectral
   )
 
 add_dependencies(

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/CMakeLists.txt
@@ -21,5 +21,27 @@ add_test_library(
   ${LIBRARY}
   "Evolution/Systems/RelativisticEuler/Valencia/"
   "${LIBRARY_SOURCES}"
-  "Test_Domain;Test_GeneralRelativity;Test_Hydro;Valencia"
+  ""
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  CoordinateMaps
+  DataStructures
+  DataStructuresHelpers
+  Domain
+  DomainHelpers
+  DomainStructure
+  FunctionsOfTime
+  GeneralRelativity
+  GeneralRelativityHelpers
+  Hydro
+  HydroHelpers
+  MathFunctions
+  LinearOperators
+  Options
+  RelativisticEulerSolutions
+  Spectral
+  Valencia
   )

--- a/tests/Unit/Evolution/Systems/ScalarWave/BoundaryConditions/Test_ConstraintPreservingSphericalRadiation.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/BoundaryConditions/Test_ConstraintPreservingSphericalRadiation.cpp
@@ -26,7 +26,8 @@ void test() {
   CAPTURE(Dim);
   MAKE_GENERATOR(gen);
   for (const std::string& bc_string :
-       {"Sommerfeld", "FirstOrderBaylissTurkel", "SecondOrderBaylissTurkel"}) {
+       {"Sommerfeld"s, "FirstOrderBaylissTurkel"s,
+        "SecondOrderBaylissTurkel"s}) {
     CAPTURE(bc_string);
     helpers::test_boundary_condition_with_python<
         ScalarWave::BoundaryConditions::ConstraintPreservingSphericalRadiation<

--- a/tests/Unit/Evolution/Systems/ScalarWave/BoundaryConditions/Test_SphericalRadiation.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/BoundaryConditions/Test_SphericalRadiation.cpp
@@ -26,7 +26,7 @@ template <size_t Dim>
 void test() {
   CAPTURE(Dim);
   MAKE_GENERATOR(gen);
-  for (const std::string& bc_string : {"Sommerfeld", "BaylissTurkel"}) {
+  for (const std::string& bc_string : {"Sommerfeld"s, "BaylissTurkel"s}) {
     CAPTURE(bc_string);
     helpers::test_boundary_condition_with_python<
         ScalarWave::BoundaryConditions::SphericalRadiation<Dim>,

--- a/tests/Unit/Framework/TestingFramework.hpp
+++ b/tests/Unit/Framework/TestingFramework.hpp
@@ -305,9 +305,6 @@ struct check_matrix_approx {
  * we must install a signal handler after Catch does, which means inside the
  * SPECTRE_TEST_CASE itself. The ERROR_TEST() macro should be the first line in
  * the SPECTRE_TEST_CASE.
- *
- * \example
- * \snippet Test_AssertAndError.cpp error_test_example
  */
 #define ERROR_TEST()                                      \
   do {                                                    \

--- a/tests/Unit/IO/H5/Test_VolumeData.cpp
+++ b/tests/Unit/IO/H5/Test_VolumeData.cpp
@@ -290,106 +290,92 @@ void test() {
 SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData", "[Unit][IO][H5]") {
   test<DataVector>();
   test<std::vector<float>>();
-}
 
-// [[OutputRegex, The expected format of the tensor component names is
-// 'GROUP_NAME/COMPONENT_NAME' but could not find a '/' in]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData.ComponentFormat0",
-                               "[Unit][IO][H5]") {
-  ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  const std::string h5_file_name("Unit.IO.H5.VolumeData.ComponentFormat.h5");
-  const uint32_t version_number = 4;
-  if (file_system::check_if_file_exists(h5_file_name)) {
-    file_system::rm(h5_file_name, true);
-  }
-  h5::H5File<h5::AccessType::ReadWrite> my_file(h5_file_name);
-  auto& volume_file =
-      my_file.insert<h5::VolumeData>("/element_data", version_number);
-  volume_file.write_volume_data(100, 10.0,
-                                {{{2},
-                                  {TensorComponent{"S", DataVector{1.0, 2.0}}},
-                                  {Spectral::Basis::Legendre},
-                                  {Spectral::Quadrature::Gauss}}});
-  ERROR("Failed to trigger ASSERT in an assertion test");
+  CHECK_THROWS_WITH(
+      []() {
+        const std::string h5_file_name(
+            "Unit.IO.H5.VolumeData.ComponentFormat.h5");
+        const uint32_t version_number = 4;
+        if (file_system::check_if_file_exists(h5_file_name)) {
+          file_system::rm(h5_file_name, true);
+        }
+        h5::H5File<h5::AccessType::ReadWrite> my_file(h5_file_name);
+        auto& volume_file =
+            my_file.insert<h5::VolumeData>("/element_data", version_number);
+        volume_file.write_volume_data(
+            100, 10.0,
+            {{{2},
+              {TensorComponent{"S", DataVector{1.0, 2.0}}},
+              {Spectral::Basis::Legendre},
+              {Spectral::Quadrature::Gauss}}});
+      }(),
+      Catch::Contains(
+          "The expected format of the tensor component names is "
+          "'GROUP_NAME/COMPONENT_NAME' but could not find a '/' in"));
+  CHECK_THROWS_WITH(
+      []() {
+        const std::string h5_file_name(
+            "Unit.IO.H5.VolumeData.ComponentFormat1.h5");
+        const uint32_t version_number = 4;
+        if (file_system::check_if_file_exists(h5_file_name)) {
+          file_system::rm(h5_file_name, true);
+        }
+        h5::H5File<h5::AccessType::ReadWrite> my_file(h5_file_name);
+        auto& volume_file =
+            my_file.insert<h5::VolumeData>("/element_data", version_number);
+        volume_file.write_volume_data(
+            100, 10.0,
+            {{{2},
+              {TensorComponent{"A/S", DataVector{1.0, 2.0}},
+               TensorComponent{"S", DataVector{1.0, 2.0}}},
+              {Spectral::Basis::Legendre},
+              {Spectral::Quadrature::Gauss}}});
+      }(),
+      Catch::Contains(
+          "The expected format of the tensor component names is "
+          "'GROUP_NAME/COMPONENT_NAME' but could not find a '/' in"));
+  CHECK_THROWS_WITH(
+      []() {
+        const std::string h5_file_name("Unit.IO.H5.VolumeData.WriteTwice.h5");
+        const uint32_t version_number = 4;
+        if (file_system::check_if_file_exists(h5_file_name)) {
+          file_system::rm(h5_file_name, true);
+        }
+        h5::H5File<h5::AccessType::ReadWrite> my_file(h5_file_name);
+        auto& volume_file =
+            my_file.insert<h5::VolumeData>("/element_data", version_number);
+        volume_file.write_volume_data(
+            100, 10.0,
+            {{{2},
+              {TensorComponent{"A/S", DataVector{1.0, 2.0}},
+               TensorComponent{"A/S", DataVector{1.0, 2.0}}},
+              {Spectral::Basis::Legendre},
+              {Spectral::Quadrature::Gauss}}});
+      }(),
+      Catch::Contains(
+          "Trying to write tensor component 'S' which already exists in HDF5 "
+          "file in group 'element_data.vol/ObservationId100'"));
 #endif
-  // clang-format off
-}
 
-// [[OutputRegex, The expected format of the tensor component names is
-// 'GROUP_NAME/COMPONENT_NAME' but could not find a '/' in]]
-[[noreturn]]
-SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData.ComponentFormat1",
-                               "[Unit][IO][H5]") {
-  // clang-format on
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  const std::string h5_file_name("Unit.IO.H5.VolumeData.ComponentFormat1.h5");
-  const uint32_t version_number = 4;
-  if (file_system::check_if_file_exists(h5_file_name)) {
-    file_system::rm(h5_file_name, true);
-  }
-  h5::H5File<h5::AccessType::ReadWrite> my_file(h5_file_name);
-  auto& volume_file =
-      my_file.insert<h5::VolumeData>("/element_data", version_number);
-  volume_file.write_volume_data(100, 10.0,
-                                {{{2},
-                                  {TensorComponent{"A/S", DataVector{1.0, 2.0}},
-                                   TensorComponent{"S", DataVector{1.0, 2.0}}},
-                                  {Spectral::Basis::Legendre},
-                                  {Spectral::Quadrature::Gauss}}});
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-  // clang-format off
-}
-
-
-// [[OutputRegex, Trying to write tensor component 'S' which already exists
-// in HDF5 file in group 'element_data.vol/ObservationId100']]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData.WriteTwice",
-                               "[Unit][IO][H5]") {
-  // clang-format on
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  const std::string h5_file_name("Unit.IO.H5.VolumeData.WriteTwice.h5");
-  const uint32_t version_number = 4;
-  if (file_system::check_if_file_exists(h5_file_name)) {
-    file_system::rm(h5_file_name, true);
-  }
-  h5::H5File<h5::AccessType::ReadWrite> my_file(h5_file_name);
-  auto& volume_file =
-      my_file.insert<h5::VolumeData>("/element_data", version_number);
-  volume_file.write_volume_data(
-      100, 10.0,
-      {{{2},
-        {TensorComponent{"A/S", DataVector{1.0, 2.0}},
-         TensorComponent{"A/S", DataVector{1.0, 2.0}}},
-        {Spectral::Basis::Legendre},
-        {Spectral::Quadrature::Gauss}}});
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-  // clang-format off
-}
-
-// [[OutputRegex, No observation with value]]
-SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData.FindNoObservationId",
-                  "[Unit][IO][H5]") {
-  // clang-format on
-  ERROR_TEST();
-  const std::string h5_file_name(
-      "Unit.IO.H5.VolumeData.FindNoObservationId.h5");
-  const uint32_t version_number = 4;
-  if (file_system::check_if_file_exists(h5_file_name)) {
-    file_system::rm(h5_file_name, true);
-  }
-  h5::H5File<h5::AccessType::ReadWrite> h5_file(h5_file_name);
-  auto& volume_file =
-      h5_file.insert<h5::VolumeData>("/element_data", version_number);
-  volume_file.write_volume_data(
-      100, 10.0,
-      {{{2},
-        {TensorComponent{"A/S", DataVector{1.0, 2.0}}},
-        {Spectral::Basis::Legendre},
-        {Spectral::Quadrature::Gauss}}});
-  volume_file.find_observation_id(11.0);
+  CHECK_THROWS_WITH(
+      []() {
+        const std::string h5_file_name(
+            "Unit.IO.H5.VolumeData.FindNoObservationId.h5");
+        const uint32_t version_number = 4;
+        if (file_system::check_if_file_exists(h5_file_name)) {
+          file_system::rm(h5_file_name, true);
+        }
+        h5::H5File<h5::AccessType::ReadWrite> h5_file(h5_file_name);
+        auto& volume_file =
+            h5_file.insert<h5::VolumeData>("/element_data", version_number);
+        volume_file.write_volume_data(
+            100, 10.0,
+            {{{2},
+              {TensorComponent{"A/S", DataVector{1.0, 2.0}}},
+              {Spectral::Basis::Legendre},
+              {Spectral::Quadrature::Gauss}}});
+        volume_file.find_observation_id(11.0);
+      }(),
+      Catch::Contains("No observation with value"));
 }

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(
   PRIVATE
   CoordinateMaps
   DataStructures
+  DgSubcell
   Domain
   FiniteDifference
   ErrorHandling

--- a/tests/Unit/Options/Test_CustomTypeConstruction.cpp
+++ b/tests/Unit/Options/Test_CustomTypeConstruction.cpp
@@ -133,24 +133,30 @@ SPECTRE_TEST_CASE("Unit.Options.CustomType", "[Unit][Options]") {
   }
 }
 
-// [[OutputRegex, In string:.*At line 2 column 3:.Option 'NotOption' is not a
-// valid option.]]
 SPECTRE_TEST_CASE("Unit.Options.CustomType.error", "[Unit][Options]") {
-  ERROR_TEST();
-  Options::Parser<tmpl::list<Cfo>> opts("");
-  opts.parse("Cfo:\n"
-             "  NotOption: foo");
-  opts.get<Cfo>();
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<Cfo>> opts("");
+        opts.parse(
+            "Cfo:\n"
+            "  NotOption: foo");
+        opts.get<Cfo>();
+      }(),
+      Catch::Contains(
+          "At line 2 column 3:\nOption 'NotOption' is not a valid option."));
 }
 
-// [[OutputRegex, In string:.*At line 2 column 3:.Option must start with an 'f'
-// but is]]
 SPECTRE_TEST_CASE("Unit.Options.CustomType.custom_error", "[Unit][Options]") {
-  ERROR_TEST();
-  Options::Parser<tmpl::list<Cfo>> opts("");
-  opts.parse("Cfo:\n"
-             "  CfoOption: zoo");
-  opts.get<Cfo>();
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<Cfo>> opts("");
+        opts.parse(
+            "Cfo:\n"
+            "  CfoOption: zoo");
+        opts.get<Cfo>();
+      }(),
+      Catch::Contains(
+          "At line 2 column 3:\nOption must start with an 'f' but is"));
 }
 
 // [enum_creation_example]
@@ -240,12 +246,16 @@ SPECTRE_TEST_CASE("Unit.Options.CustomType.specialized_void",
          CreateFromOptionsExoticAnimal::MexicanWalkingFish);
 }
 
-// [[OutputRegex, In string:.*While parsing option CfoAnimal:.*At line 1
-// column 12:.CreateFromOptionsAnimal must be 'Cat' or 'Dog']]
 SPECTRE_TEST_CASE("Unit.Options.CustomType.specialized.error",
                   "[Unit][Options]") {
-  ERROR_TEST();
-  Options::Parser<tmpl::list<CfoAnimal>> opts("");
-  opts.parse("CfoAnimal: Mouse");
-  opts.get<CfoAnimal>();
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<CfoAnimal>> opts("");
+        opts.parse("CfoAnimal: Mouse");
+        opts.get<CfoAnimal>();
+      }(),
+      Catch::Contains(
+          "While parsing option CfoAnimal:\nWhile creating a "
+          "CreateFromOptionsAnimal:\nAt line 1 "
+          "column 12:\nCreateFromOptionsAnimal must be 'Cat' or 'Dog'"));
 }

--- a/tests/Unit/Options/Test_Factory.cpp
+++ b/tests/Unit/Options/Test_Factory.cpp
@@ -366,49 +366,72 @@ SPECTRE_TEST_CASE("Unit.Options.Factory", "[Unit][Options]") {
   test_factory_not_creatable();
 }
 
-// [[OutputRegex, In string:.*At line 1 column 1:.Expected a class to
-// create:.Known Ids:.*Test1]]
-SPECTRE_TEST_CASE("Unit.Options.Factory.missing", "[Unit][Options]") {
-  ERROR_TEST();
+namespace {
+void trigger_missing() {
   Options::Parser<tmpl::list<OptionType>> opts("");
   opts.parse("OptionType:");
   opts.get<OptionType, Metavars<true>>();
 }
 
-// [[OutputRegex, In string:.*At line 2 column 3:.Expected a single class to
-// create, got 2]]
-SPECTRE_TEST_CASE("Unit.Options.Factory.multiple", "[Unit][Options]") {
-  ERROR_TEST();
+void trigger_multiple() {
   Options::Parser<tmpl::list<OptionType>> opts("");
-  opts.parse("OptionType:\n"
-             "  Test1:\n"
-             "  Test2:");
+  opts.parse(
+      "OptionType:\n"
+      "  Test1:\n"
+      "  Test2:");
   opts.get<OptionType, Metavars<true>>();
 }
 
-// [[OutputRegex, In string:.*At line 1 column 13:.Expected a class or a class
-// with options]]
-SPECTRE_TEST_CASE("Unit.Options.Factory.vector", "[Unit][Options]") {
-  ERROR_TEST();
+void trigger_vector() {
   Options::Parser<tmpl::list<OptionType>> opts("");
   opts.parse("OptionType: []");
   opts.get<OptionType, Metavars<true>>();
 }
 
-// [[OutputRegex, In string:.*At line 1 column 13:.Unknown Id 'Potato']]
-SPECTRE_TEST_CASE("Unit.Options.Factory.unknown", "[Unit][Options]") {
-  ERROR_TEST();
+void trigger_unknown() {
   Options::Parser<tmpl::list<OptionType>> opts("");
   opts.parse("OptionType: Potato");
   opts.get<OptionType, Metavars<true>>();
 }
 
-// [[OutputRegex, In string:.*At line 2 column 1:.You did not specify the
-// option \(Arg\)]]
-SPECTRE_TEST_CASE("Unit.Options.Factory.missing_arg", "[Unit][Options]") {
-  ERROR_TEST();
+void trigger_missing_arg() {
   Options::Parser<tmpl::list<OptionType>> opts("");
-  opts.parse("OptionType:\n"
-             "  TestWithArg:");
+  opts.parse(
+      "OptionType:\n"
+      "  TestWithArg:");
   opts.get<OptionType, Metavars<true>>();
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Options.Factory.missing", "[Unit][Options]") {
+  CHECK_THROWS_WITH(trigger_missing(),
+                    Catch::Contains("At line 1 column 1:\nExpected a class to "
+                                    "create:\nKnown Ids:\n  Test1"));
+}
+
+SPECTRE_TEST_CASE("Unit.Options.Factory.multiple", "[Unit][Options]") {
+  CHECK_THROWS_WITH(
+      trigger_multiple(),
+      Catch::Contains(
+          "At line 2 column 3:\nExpected a single class to create, got 2"));
+}
+
+SPECTRE_TEST_CASE("Unit.Options.Factory.vector", "[Unit][Options]") {
+  CHECK_THROWS_WITH(
+      trigger_vector(),
+      Catch::Contains(
+          "At line 1 column 13:\nExpected a class or a class with options"));
+}
+
+SPECTRE_TEST_CASE("Unit.Options.Factory.unknown", "[Unit][Options]") {
+  CHECK_THROWS_WITH(
+      trigger_unknown(),
+      Catch::Contains("At line 1 column 13:\nUnknown Id 'Potato'"));
+}
+
+SPECTRE_TEST_CASE("Unit.Options.Factory.missing_arg", "[Unit][Options]") {
+  CHECK_THROWS_WITH(
+      trigger_missing_arg(),
+      Catch::Contains(
+          "At line 2 column 1:\nYou did not specify the option (Arg)"));
 }

--- a/tests/Unit/Options/Test_Options.cpp
+++ b/tests/Unit/Options/Test_Options.cpp
@@ -30,12 +30,14 @@ void test_options_empty_success() {
   CHECK(true);
 }
 
-// [[OutputRegex, In string:.*At line 1 column 1:.Option 'Option' is not a valid
-// option.]]
 SPECTRE_TEST_CASE("Unit.Options.Empty.extra", "[Unit][Options]") {
-  ERROR_TEST();
-  Options::Parser<tmpl::list<>> opts("");
-  opts.parse("Option:");
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<>> opts("");
+        opts.parse("Option:");
+      }(),
+      Catch::Contains(
+          "At line 1 column 1:\nOption 'Option' is not a valid option."));
 }
 
 // [[OutputRegex, In string:.*'4' does not look like options]]
@@ -45,14 +47,16 @@ SPECTRE_TEST_CASE("Unit.Options.Empty.not_map", "[Unit][Options]") {
   opts.parse("4");
 }
 
-// [[OutputRegex, In string:.*At line 1 column 30:.Unable to correctly parse
-// the input file because of a syntax error]]
 SPECTRE_TEST_CASE("Unit.Options.syntax_error", "[Unit][Options]") {
-  ERROR_TEST();
-  Options::Parser<tmpl::list<>> opts("");
-  opts.parse(
-      "DomainCreator: CreateInterval:\n"
-      "  IsPeriodicIn: [false]");
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<>> opts("");
+        opts.parse(
+            "DomainCreator: CreateInterval:\n"
+            "  IsPeriodicIn: [false]");
+      }(),
+      Catch::Contains("At line 1 column 30:\nUnable to correctly parse the "
+                      "input file because of a syntax error"));
 }
 
 struct Simple {
@@ -103,24 +107,27 @@ Options:
 )");
 }
 
-// [[OutputRegex, In string:.*At line 2 column 1:.Option 'Simple' specified
-// twice.]]
 SPECTRE_TEST_CASE("Unit.Options.Simple.duplicate", "[Unit][Options]") {
-  ERROR_TEST();
-  Options::Parser<tmpl::list<Simple>> opts("");
-  opts.parse(
-      "Simple: -4\n"
-      "Simple: -3");
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<Simple>> opts("");
+        opts.parse(
+            "Simple: -4\n"
+            "Simple: -3");
+      }(),
+      Catch::Contains("At line 2 column 1:\nOption 'Simple' specified twice."));
 }
 
-// [[OutputRegex, In string:.*At line 2 column 1:.Option 'SomeName' specified
-// twice.]]
 SPECTRE_TEST_CASE("Unit.Options.NamedSimple.duplicate", "[Unit][Options]") {
-  ERROR_TEST();
-  Options::Parser<tmpl::list<NamedSimple>> opts("");
-  opts.parse(
-      "SomeName: -4\n"
-      "SomeName: -3");
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<NamedSimple>> opts("");
+        opts.parse(
+            "SomeName: -4\n"
+            "SomeName: -3");
+      }(),
+      Catch::Contains(
+          "At line 2 column 1:\nOption 'SomeName' specified twice."));
 }
 
 // [[OutputRegex, In string:.*You did not specify the option \(Simple\)]]
@@ -145,40 +152,48 @@ SPECTRE_TEST_CASE("Unit.Options.multiple_missing", "[Unit][Options]") {
   opts.parse("");
 }
 
-// [[OutputRegex, In string:.*While parsing option Simple:.At line 1 column
-// 1:.Failed to convert value to type int:]]
 SPECTRE_TEST_CASE("Unit.Options.Simple.missing_arg", "[Unit][Options]") {
-  ERROR_TEST();
-  Options::Parser<tmpl::list<Simple>> opts("");
-  opts.parse("Simple:");
-  opts.get<Simple>();
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<Simple>> opts("");
+        opts.parse("Simple:");
+        opts.get<Simple>();
+      }(),
+      Catch::Contains("While parsing option Simple:\nAt line 1 column "
+                      "1:\nFailed to convert value to type int:"));
 }
 
-// [[OutputRegex, In string:.*While parsing option SomeName:.At line 1 column
-// 1:.Failed to convert value to type int:]]
 SPECTRE_TEST_CASE("Unit.Options.NamedSimple.missing_arg", "[Unit][Options]") {
-  ERROR_TEST();
-  Options::Parser<tmpl::list<NamedSimple>> opts("");
-  opts.parse("SomeName:");
-  opts.get<NamedSimple>();
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<NamedSimple>> opts("");
+        opts.parse("SomeName:");
+        opts.get<NamedSimple>();
+      }(),
+      Catch::Contains("While parsing option SomeName:\nAt line 1 column "
+                      "1:\nFailed to convert value to type int:"));
 }
 
-// [[OutputRegex, In string:.*While parsing option Simple:.At line 1 column
-// 9:.Failed to convert value to type int: 2.3]]
 SPECTRE_TEST_CASE("Unit.Options.Simple.invalid", "[Unit][Options]") {
-  ERROR_TEST();
-  Options::Parser<tmpl::list<Simple>> opts("");
-  opts.parse("Simple: 2.3");
-  opts.get<Simple>();
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<Simple>> opts("");
+        opts.parse("Simple: 2.3");
+        opts.get<Simple>();
+      }(),
+      Catch::Contains("While parsing option Simple:\nAt line 1 column "
+                      "9:\nFailed to convert value to type int: 2.3"));
 }
 
-// [[OutputRegex, In string:.*While parsing option SomeName:.At line 1 column
-// 11:.Failed to convert value to type int: 2.3]]
 SPECTRE_TEST_CASE("Unit.Options.NamedSimple.invalid", "[Unit][Options]") {
-  ERROR_TEST();
-  Options::Parser<tmpl::list<NamedSimple>> opts("");
-  opts.parse("SomeName: 2.3");
-  opts.get<NamedSimple>();
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<NamedSimple>> opts("");
+        opts.parse("SomeName: 2.3");
+        opts.get<NamedSimple>();
+      }(),
+      Catch::Contains("While parsing option SomeName:\nAt line 1 column "
+                      "11:\nFailed to convert value to type int: 2.3"));
 }
 
 namespace {
@@ -271,14 +286,16 @@ SPECTRE_TEST_CASE("Unit.Options.Grouped.missing_outer_group",
   opts.get<InnerGroupedTag>();
 }
 
-// [[OutputRegex, In string:.*In group OuterGroup:.You did not specify the
-// option \(InnerGroup\)]]
 SPECTRE_TEST_CASE("Unit.Options.Grouped.missing_inner_group",
                   "[Unit][Options]") {
-  ERROR_TEST();
-  Options::Parser<tmpl::list<InnerGroupedTag>> opts("");
-  opts.parse("OuterGroup:");
-  opts.get<InnerGroupedTag>();
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<InnerGroupedTag>> opts("");
+        opts.parse("OuterGroup:");
+        opts.get<InnerGroupedTag>();
+      }(),
+      Catch::Contains(
+          "In group OuterGroup:\nYou did not specify the option (InnerGroup)"));
 }
 
 // [options_example_scalar_struct]
@@ -307,13 +324,15 @@ void test_options_suggested_not_followed() {
   // [options_example_scalar_parse]
 }
 
-// [[OutputRegex, In string:.*While parsing option Bounded:.At line 1 column
-// 10:.Value 1 is below the lower bound of 2]]
 SPECTRE_TEST_CASE("Unit.Options.Bounded.below", "[Unit][Options]") {
-  ERROR_TEST();
-  Options::Parser<tmpl::list<Bounded>> opts("");
-  opts.parse("Bounded: 1");
-  opts.get<Bounded>();
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<Bounded>> opts("");
+        opts.parse("Bounded: 1");
+        opts.get<Bounded>();
+      }(),
+      Catch::Contains("While parsing option Bounded:\nAt line 1 column "
+                      "10:\nValue 1 is below the lower bound of 2"));
 }
 
 void test_options_bounded_lower_bound() {
@@ -328,13 +347,15 @@ void test_options_bounded_upper_bound() {
   CHECK(opts.get<Bounded>() == 10);
 }
 
-// [[OutputRegex, In string:.*While parsing option Bounded:.At line 1 column
-// 10:.Value 11 is above the upper bound of 10]]
 SPECTRE_TEST_CASE("Unit.Options.Bounded.above", "[Unit][Options]") {
-  ERROR_TEST();
-  Options::Parser<tmpl::list<Bounded>> opts("");
-  opts.parse("Bounded: 11");
-  opts.get<Bounded>();
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<Bounded>> opts("");
+        opts.parse("Bounded: 11");
+        opts.get<Bounded>();
+      }(),
+      Catch::Contains("While parsing option Bounded:\nAt line 1 column "
+                      "10:\nValue 11 is above the upper bound of 10"));
 }
 
 // [[OutputRegex, Bounded, line 1:.  Specified: 5.  Suggested: 3]]
@@ -359,22 +380,26 @@ struct NamedBadSuggestion {
   static type lower_bound() { return 4; }
 };
 
-// [[OutputRegex, Checking SUGGESTED value for BadSuggestion:.Value 3 is below
-// the lower bound of 4]]
 SPECTRE_TEST_CASE("Unit.Options.BadSuggestion", "[Unit][Options]") {
-  ERROR_TEST();
-  Options::Parser<tmpl::list<BadSuggestion>> opts("");
-  opts.parse("BadSuggestion: 5");
-  opts.get<BadSuggestion>();
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<BadSuggestion>> opts("");
+        opts.parse("BadSuggestion: 5");
+        opts.get<BadSuggestion>();
+      }(),
+      Catch::Contains("Checking SUGGESTED value for BadSuggestion:\nValue 3 is "
+                      "below the lower bound of 4"));
 }
 
-// [[OutputRegex, Checking SUGGESTED value for SomeName:.Value 3 is below the
-// lower bound of 4]]
 SPECTRE_TEST_CASE("Unit.Options.NamedBadSuggestion", "[Unit][Options]") {
-  ERROR_TEST();
-  Options::Parser<tmpl::list<NamedBadSuggestion>> opts("");
-  opts.parse("SomeName: 5");
-  opts.get<NamedBadSuggestion>();
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<NamedBadSuggestion>> opts("");
+        opts.parse("SomeName: 5");
+        opts.get<NamedBadSuggestion>();
+      }(),
+      Catch::Contains("Checking SUGGESTED value for SomeName:\nValue 3 is "
+                      "below the lower bound of 4"));
 }
 
 // [options_example_vector_struct]
@@ -390,13 +415,16 @@ struct VectorOption {
 };
 // [options_example_vector_struct]
 
-// [[OutputRegex, In string:.*While parsing option Vector:.At line 1 column
-// 9:.Value must have at least 2 entries, but 1 were given.]]
 SPECTRE_TEST_CASE("Unit.Options.Vector.too_short", "[Unit][Options]") {
-  ERROR_TEST();
-  Options::Parser<tmpl::list<VectorOption>> opts("");
-  opts.parse("Vector: [2]");
-  opts.get<VectorOption>();
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<VectorOption>> opts("");
+        opts.parse("Vector: [2]");
+        opts.get<VectorOption>();
+      }(),
+      Catch::Contains(
+          "While parsing option Vector:\nAt line 1 column 9:\nValue must have "
+          "at least 2 entries, but 1 were given."));
 }
 
 void test_options_vector_lower_bound() {
@@ -411,22 +439,28 @@ void test_options_vector_upper_bound() {
   CHECK(opts.get<VectorOption>() == (std::vector<int>{2, 3, 3, 3, 5}));
 }
 
-// [[OutputRegex, In string:.*While parsing option Vector:.At line 1 column
-// 9:.Value must have at most 5 entries, but 6 were given.]]
 SPECTRE_TEST_CASE("Unit.Options.Vector.too_long", "[Unit][Options]") {
-  ERROR_TEST();
-  Options::Parser<tmpl::list<VectorOption>> opts("");
-  opts.parse("Vector: [2, 3, 3, 3, 5, 6]");
-  opts.get<VectorOption>();
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<VectorOption>> opts("");
+        opts.parse("Vector: [2, 3, 3, 3, 5, 6]");
+        opts.get<VectorOption>();
+      }(),
+      Catch::Contains(
+          "While parsing option Vector:\nAt line 1 column 9:\nValue must have "
+          "at most 5 entries, but 6 were given."));
 }
 
-// [[OutputRegex, In string:.*While parsing option Vector:.At line 1 column
-// 1:.Value must have at least 2 entries, but 0 were given.]]
 SPECTRE_TEST_CASE("Unit.Options.Vector.empty_too_short", "[Unit][Options]") {
-  ERROR_TEST();
-  Options::Parser<tmpl::list<VectorOption>> opts("");
-  opts.parse("Vector:");
-  opts.get<VectorOption>();
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<VectorOption>> opts("");
+        opts.parse("Vector:");
+        opts.get<VectorOption>();
+      }(),
+      Catch::Contains(
+          "While parsing option Vector:\nAt line 1 column 1:\nValue must have "
+          "at least 2 entries, but 0 were given."));
 }
 
 struct Array {
@@ -434,13 +468,15 @@ struct Array {
   static constexpr Options::String help = {"halp"};
 };
 
-// [[OutputRegex, In string:.*While parsing option Array:.At line 1 column
-// 8:.Failed to convert value to type \[int x3\]:]]
 SPECTRE_TEST_CASE("Unit.Options.Array.too_short", "[Unit][Options]") {
-  ERROR_TEST();
-  Options::Parser<tmpl::list<Array>> opts("");
-  opts.parse("Array: [1, 2]");
-  opts.get<Array>();
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<Array>> opts("");
+        opts.parse("Array: [1, 2]");
+        opts.get<Array>();
+      }(),
+      Catch::Contains("While parsing option Array:\nAt line 1 column "
+                      "8:\nFailed to convert value to type [int x3]: [1, 2]"));
 }
 
 void test_options_array_success() {
@@ -449,37 +485,44 @@ void test_options_array_success() {
   CHECK(opts.get<Array>() == (std::array<int, 3>{{1, 2, 3}}));
 }
 
-// [[OutputRegex, In string:.*While parsing option Array:.At line 1 column
-// 8:.Failed to convert value to type \[int x3\]: .1, 2, 3, 4.]]
 SPECTRE_TEST_CASE("Unit.Options.Array.too_long", "[Unit][Options]") {
-  ERROR_TEST();
-  Options::Parser<tmpl::list<Array>> opts("");
-  opts.parse("Array: [1, 2, 3, 4]");
-  opts.get<Array>();
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<Array>> opts("");
+        opts.parse("Array: [1, 2, 3, 4]");
+        opts.get<Array>();
+      }(),
+      Catch::Contains(
+          "While parsing option Array:\nAt line 1 column 8:\nFailed to convert "
+          "value to type [int x3]: [1, 2, 3, 4]"));
 }
 
-// [[OutputRegex, In string:.*While parsing option Array:.At line 2 column
-// 3:.Failed to convert value to type \[int x3\]:.  - 1.  - 2.  -
-// 3.  - 4]]
 SPECTRE_TEST_CASE("Unit.Options.Array.too_long.formatting", "[Unit][Options]") {
-  ERROR_TEST();
-  Options::Parser<tmpl::list<Array>> opts("");
-  opts.parse(
-      "Array:\n"
-      "  - 1\n"
-      "  - 2\n"
-      "  - 3\n"
-      "  - 4");
-  opts.get<Array>();
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<Array>> opts("");
+        opts.parse(
+            "Array:\n"
+            "  - 1\n"
+            "  - 2\n"
+            "  - 3\n"
+            "  - 4");
+        opts.get<Array>();
+      }(),
+      Catch::Contains(
+          "While parsing option Array:\nAt line 2 column 3:\nFailed to convert "
+          "value to type [int x3]:\n  - 1\n  - 2\n  - 3\n  - 4"));
 }
 
-// [[OutputRegex, In string:.*While parsing option Array:.At line 1 column
-// 1:.Failed to convert value to type \[int x3\]:]]
 SPECTRE_TEST_CASE("Unit.Options.Array.missing", "[Unit][Options]") {
-  ERROR_TEST();
-  Options::Parser<tmpl::list<Array>> opts("");
-  opts.parse("Array:");
-  opts.get<Array>();
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<Array>> opts("");
+        opts.parse("Array:");
+        opts.get<Array>();
+      }(),
+      Catch::Contains("While parsing option Array:\nAt line 1 column "
+                      "1:\nFailed to convert value to type [int x3]:"));
 }
 
 struct ZeroArray {
@@ -519,24 +562,28 @@ void test_options_map_empty() {
   CHECK(opts.get<Map>().empty());
 }
 
-// [[OutputRegex, In string:.*While parsing option Map:.At line 1 column
-// 6:.Failed to convert value to type {string: int}: string]]
 SPECTRE_TEST_CASE("Unit.Options.Map.invalid", "[Unit][Options]") {
-  ERROR_TEST();
-  Options::Parser<tmpl::list<Map>> opts("");
-  opts.parse("Map: string");
-  opts.get<Map>();
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<Map>> opts("");
+        opts.parse("Map: string");
+        opts.get<Map>();
+      }(),
+      Catch::Contains("While parsing option Map:\nAt line 1 column 6:\nFailed "
+                      "to convert value to type {string: int}: string"));
 }
 
-// [[OutputRegex, In string:.*While parsing option Map:.At line 2 column
-// 6:.Failed to convert value to type {string: int}: A: string]]
 SPECTRE_TEST_CASE("Unit.Options.Map.invalid_entry", "[Unit][Options]") {
-  ERROR_TEST();
-  Options::Parser<tmpl::list<Map>> opts("");
-  opts.parse(
-      "Map:\n"
-      "  A: string");
-  opts.get<Map>();
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<Map>> opts("");
+        opts.parse(
+            "Map:\n"
+            "  A: string");
+        opts.get<Map>();
+      }(),
+      Catch::Contains("While parsing option Map:\nAt line 2 column 6:\nFailed "
+                      "to convert value to type {string: int}: A: string"));
 }
 
 struct UnorderedMap {
@@ -588,14 +635,16 @@ void test_options_variant() {
   }
 }
 
-// [[OutputRegex, While creating a variant:.At line 1 column 13:.Failed to
-// convert value to type int or string]]
 SPECTRE_TEST_CASE("Unit.Options.Format.variant.Error", "[Unit][Options]") {
-  ERROR_TEST();
   using tag = VariantTag<int, std::string>;
-  Options::Parser<tmpl::list<tag>> opts("");
-  opts.parse("VariantTag: []");
-  opts.get<tag>();
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<tag>> opts("");
+        opts.parse("VariantTag: []");
+        opts.get<tag>();
+      }(),
+      Catch::Contains("While creating a variant:\nAt line 1 column 13:\nFailed "
+                      "to convert value to type int or string"));
 }
 
 template <typename T>
@@ -708,6 +757,8 @@ struct
   using type = int;
   static constexpr Options::String help = {"halp"};
 };
+using short_alias_for_too_long =
+    ToooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooLong;
 struct NamedTooLong {
   using type = int;
   static std::string name() {
@@ -725,29 +776,22 @@ struct NamedNoHelp {
   static std::string name() { return "NoHelp"; }
   static constexpr Options::String help = {""};
 };
-#endif  // SPECTRE_DEBUG
-
-// [[OutputRegex, The option name
-// ToooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooLong is
-// too long for nice formatting]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Options.TooLong", "[Unit][Options]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  Options::Parser<tmpl::list<
-      ToooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooLong>>
-      opts("");
-  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
-}
 
-// [[OutputRegex, The option name
-// ToooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooLong is
-// too long for nice formatting]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Options.NamedTooLong", "[Unit][Options]") {
-  ASSERTION_TEST();
+void test_options_too_long() {
 #ifdef SPECTRE_DEBUG
-  Options::Parser<tmpl::list<NamedTooLong>> opts("");
-  ERROR("Failed to trigger ASSERT in an assertion test");
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<short_alias_for_too_long>> opts("");
+      }(),
+      Catch::Contains("The option name "
+                      "Tooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+                      "ooooooooooooooLong is too long for nice formatting"));
+  CHECK_THROWS_WITH(
+      []() { Options::Parser<tmpl::list<NamedTooLong>> opts(""); }(),
+      Catch::Contains("The option name "
+                      "Tooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+                      "ooooooooooooooLong is too long for nice formatting"));
 #endif
 }
 
@@ -909,12 +953,17 @@ SPECTRE_TEST_CASE("Unit.Options.Format.UnorderedMap.Error", "[Unit][Options]") {
   opts.get<FormatUnorderedMap>();
 }
 
-// [[OutputRegex, At line 3 column 1:.Unable to correctly parse the
+// At line 3 column 1:.Unable to correctly parse the
 // input file because of a syntax error]]
 SPECTRE_TEST_CASE("Unit.Options.bad_colon", "[Unit][Options]") {
-  ERROR_TEST();
-  Options::Parser<tmpl::list<>> opts("");
-  opts.parse("\n\n:");
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<>> opts("");
+        opts.parse("\n\n:");
+      }(),
+      Catch::Contains("At line 3 column 1:\nUnable to correctly parse the "
+                      "input file because of "
+                      "a syntax error"));
 }
 
 struct ExplicitObject {
@@ -1248,47 +1297,54 @@ void test_options_overlay() {
   CHECK(parser.get<InnerGroupedTag>() == 5);
 }
 
-// [[OutputRegex, In string:.*At line 1 column 1:.Option 'NotSimple' is not a
-// valid option.]]
 SPECTRE_TEST_CASE("Unit.Options.overlay.invalid", "[Unit][Options]") {
-  ERROR_TEST();
-  Options::Parser<tmpl::list<Simple>> parser("");
-  parser.parse("Simple: 1");
-  parser.overlay<tmpl::list<Simple>>("NotSimple: 2");
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<Simple>> parser("");
+        parser.parse("Simple: 1");
+        parser.overlay<tmpl::list<Simple>>("NotSimple: 2");
+      }(),
+      Catch::Contains(
+          "At line 1 column 1:\nOption 'NotSimple' is not a valid option."));
 }
 
-// [[OutputRegex, In string:.*At line 1 column 1:.Option 'Simple' is not
-// overlayable.]]
 SPECTRE_TEST_CASE("Unit.Options.overlay.not_overlayable", "[Unit][Options]") {
-  ERROR_TEST();
-  Options::Parser<tmpl::list<Simple>> parser("");
-  parser.parse("Simple: 1");
-  parser.overlay<tmpl::list<>>("Simple: 2");
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<Simple>> parser("");
+        parser.parse("Simple: 1");
+        parser.overlay<tmpl::list<>>("Simple: 2");
+      }(),
+      Catch::Contains(
+          "At line 1 column 1:\nOption 'Simple' is not overlayable."));
 }
 
-// [[OutputRegex, In string:.*At line 2 column 1:.Option 'Simple' specified
-// twice.]]
 SPECTRE_TEST_CASE("Unit.Options.overlay.duplicate", "[Unit][Options]") {
-  ERROR_TEST();
-  Options::Parser<tmpl::list<Simple>> parser("");
-  parser.parse("Simple: 1");
-  parser.overlay<tmpl::list<Simple>>(
-      "Simple: 2\n"
-      "Simple: 2");
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<Simple>> parser("");
+        parser.parse("Simple: 1");
+        parser.overlay<tmpl::list<Simple>>(
+            "Simple: 2\n"
+            "Simple: 2");
+      }(),
+      Catch::Contains("At line 2 column 1:\nOption 'Simple' specified twice."));
 }
 
-// [[OutputRegex, In string:.In group OuterGroup:.At line 3 column 3:.Option
-// 'OuterGroupedTag' specified twice.]]
 SPECTRE_TEST_CASE("Unit.Options.overlay.subgroup_context", "[Unit][Options]") {
-  ERROR_TEST();
-  Options::Parser<tmpl::list<OuterGroupedTag>> parser("");
-  parser.parse(
-      "OuterGroup:\n"
-      "  OuterGroupedTag: 1");
-  parser.overlay<tmpl::list<OuterGroupedTag>>(
-      "OuterGroup:\n"
-      "  OuterGroupedTag: 2\n"
-      "  OuterGroupedTag: 2");
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<OuterGroupedTag>> parser("");
+        parser.parse(
+            "OuterGroup:\n"
+            "  OuterGroupedTag: 1");
+        parser.overlay<tmpl::list<OuterGroupedTag>>(
+            "OuterGroup:\n"
+            "  OuterGroupedTag: 2\n"
+            "  OuterGroupedTag: 2");
+      }(),
+      Catch::Contains("In group OuterGroup:\nAt line 3 column 3:\nOption "
+                      "'OuterGroupedTag' specified twice."));
 }
 
 void test_options_serialization() {
@@ -1411,6 +1467,7 @@ SPECTRE_TEST_CASE("Unit.Options", "[Unit][Options]") {
   test_options_unordered_map_success();
   test_options_variant();
   test_options_complex_containers();
+  test_options_too_long();
   test_options_apply();
   test_options_option_context_default_stream();
   test_options_format();

--- a/tests/Unit/ParallelAlgorithms/Actions/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Actions/CMakeLists.txt
@@ -14,7 +14,14 @@ add_test_library(
   ${LIBRARY}
   "ParallelAlgorithms/Actions/"
   "${LIBRARY_SOURCES}"
-  "DataStructures"
+  ""
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  DataStructures
+  DomainStructure
   )
 
 add_dependencies(

--- a/tests/Unit/ParallelAlgorithms/Initialization/Test_MergeIntoDataBox.cpp
+++ b/tests/Unit/ParallelAlgorithms/Initialization/Test_MergeIntoDataBox.cpp
@@ -130,14 +130,12 @@ void test_failure_value() {
 SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.Initialization.AddToDataBox",
                   "[Unit][ParallelAlgorithms]") {
   TestAddToBox_detail::test();
-}
 
-// [[OutputRegex, While adding the simple tag Int that is already in the DataBox
-// we found that the value being set by the action
-// TestAddToBox_detail::FakeAction is not the same as what is already in the
-// DataBox. The value in the DataBox is: 2 while the value being added is 3]]
-SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.Initialization.AddToDataBox.Error",
-                  "[Unit][ParallelAlgorithms]") {
-  ERROR_TEST();
-  TestAddToBox_detail::test_failure_value();
+  CHECK_THROWS_WITH(
+      TestAddToBox_detail::test_failure_value(),
+      Catch::Contains("While adding the simple tag Int that is already in the "
+                      "DataBox we found that the value being set by the action "
+                      "TestAddToBox_detail::FakeAction is not the same as what "
+                      "is already in the DataBox. The value in the DataBox is: "
+                      "2 while the value being added is 3"));
 }

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/CMakeLists.txt
@@ -11,5 +11,14 @@ add_test_library(
   ${LIBRARY}
   "ParallelAlgorithms/LinearSolver/AsynchronousSolvers"
   "${LIBRARY_SOURCES}"
-  "Convergence;DataStructures;IO;ParallelLinearSolver"
+  ""
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  Convergence
+  DataStructures
+  IO
+  ParallelLinearSolver
   )

--- a/tests/Unit/PointwiseFunctions/AnalyticData/CurvedWaveEquation/Test_ScalarWaveGr.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/CurvedWaveEquation/Test_ScalarWaveGr.cpp
@@ -595,19 +595,8 @@ void test_curved_scalarwave_minkowski() {
   test_no_hole(curved_wave_data, wave_solution);
 }
 
-SPECTRE_TEST_CASE("Unit.AnalyticData.CurvedWaveEquation.ScalarWaveGr",
-                  "[PointwiseFunctions][Unit]") {
-  test_scalarwave_bh();
-  test_scalarwave_minkowski();
-  test_curved_scalarwave_minkowski();
-}
-
-// Check restrictions on input options below
-
-// [[OutputRegex, Mass must be non-negative]]
-SPECTRE_TEST_CASE("Unit.AnalyticData.CurvedWaveEquation.ScalarWaveGrMass",
-                  "[PointwiseFunctions][Unit]") {
-  ERROR_TEST();
+namespace {
+void trigger_negative_mass() {
   CurvedScalarWave::AnalyticData::ScalarWaveGr<
       ScalarWave::Solutions::RegularSphericalWave, gr::Solutions::KerrSchild>
       solution(
@@ -618,11 +607,7 @@ SPECTRE_TEST_CASE("Unit.AnalyticData.CurvedWaveEquation.ScalarWaveGrMass",
                   1., 1., 0.)));
 }
 
-// [[OutputRegex, In string:.*At line 3 column 11:.Value -0.5 is below the
-// lower bound of 0]]
-SPECTRE_TEST_CASE("Unit.AnalyticData.CurvedWaveEquation.ScalarWaveGrOptM",
-                  "[PointwiseFunctions][Unit]") {
-  ERROR_TEST();
+void trigger_bound_error() {
   TestHelpers::test_creation<CurvedScalarWave::AnalyticData::ScalarWaveGr<
                                  ScalarWave::Solutions::RegularSphericalWave,
                                  gr::Solutions::KerrSchild>,
@@ -639,10 +624,7 @@ SPECTRE_TEST_CASE("Unit.AnalyticData.CurvedWaveEquation.ScalarWaveGrOptM",
       "      Center: 0.3");
 }
 
-// [[OutputRegex, Spin magnitude must be < 1]]
-SPECTRE_TEST_CASE("Unit.AnalyticData.CurvedWaveEquation.ScalarWaveGrSpin",
-                  "[PointwiseFunctions][Unit]") {
-  ERROR_TEST();
+void trigger_spin_error() {
   CurvedScalarWave::AnalyticData::ScalarWaveGr<
       ScalarWave::Solutions::RegularSphericalWave, gr::Solutions::KerrSchild>
       solution(
@@ -650,4 +632,20 @@ SPECTRE_TEST_CASE("Unit.AnalyticData.CurvedWaveEquation.ScalarWaveGrSpin",
           ScalarWave::Solutions::RegularSphericalWave(
               std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(
                   1., 1., 0.)));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.AnalyticData.CurvedWaveEquation.ScalarWaveGr",
+                  "[PointwiseFunctions][Unit]") {
+  test_scalarwave_bh();
+  test_scalarwave_minkowski();
+  test_curved_scalarwave_minkowski();
+
+  CHECK_THROWS_WITH(trigger_negative_mass(),
+                    Catch::Contains("Mass must be non-negative"));
+  CHECK_THROWS_WITH(
+      trigger_bound_error(),
+      Catch::Contains("Value -0.5 is below the lower bound of 0"));
+  CHECK_THROWS_WITH(trigger_spin_error(),
+                    Catch::Contains("Spin magnitude must be < 1"));
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_BondiHoyleAccretion.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_BondiHoyleAccretion.cpp
@@ -140,100 +140,65 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticData.GrMhd.BondiHoyle",
 
   test_variables(std::numeric_limits<double>::signaling_NaN());
   test_variables(DataVector(5));
-}
 
-// [[OutputRegex, In string:.*At line 2 column 11:.Value -1.345 is below the
-// lower bound of 0]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticData.GrMhd.BondiHoyleBHMassOpt",
-    "[PointwiseFunctions][Unit]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<grmhd::AnalyticData::BondiHoyleAccretion>(
-      "BhMass: -1.345\n"
-      "BhDimlessSpin: 0.3\n"
-      "RestMassDensity: 1.32\n"
-      "FlowSpeed: 4.3\n"
-      "MagFieldStrength: 0.52\n"
-      "PolytropicConstant: 0.12\n"
-      "PolytropicExponent: 1.5");
-}
-
-// [[OutputRegex, In string:.*At line 3 column 18:.Value -1.23 is below the
-// lower bound of -1]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticData.GrMhd.BondiHoyleBHSpinLowerOpt",
-    "[PointwiseFunctions][Unit]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<grmhd::AnalyticData::BondiHoyleAccretion>(
-      "BhMass: 4.4231\n"
-      "BhDimlessSpin: -1.23\n"
-      "RestMassDensity: 0.31\n"
-      "FlowSpeed: 0.11\n"
-      "MagFieldStrength: 2.4\n"
-      "PolytropicConstant: 300.0\n"
-      "PolytropicExponent: 1.4");
-}
-
-// [[OutputRegex, In string:.*At line 3 column 18:.Value 3.99 is above the
-// upper bound of 1]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticData.GrMhd.BondiHoyleBHSpinUpperOpt",
-    "[PointwiseFunctions][Unit]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<grmhd::AnalyticData::BondiHoyleAccretion>(
-      "BhMass: 0.654\n"
-      "BhDimlessSpin: 3.99\n"
-      "RestMassDensity: 5.234\n"
-      "FlowSpeed: 0.543\n"
-      "MagFieldStrength: -0.352\n"
-      "PolytropicConstant: 80.123\n"
-      "PolytropicExponent: 1.66");
-}
-
-// [[OutputRegex, In string:.*At line 4 column 20:.Value -4.21 is below the
-// lower bound of 0]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticData.GrMhd.BondiHoyleDensityOpt",
-    "[PointwiseFunctions][Unit]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<grmhd::AnalyticData::BondiHoyleAccretion>(
-      "BhMass: 12.34\n"
-      "BhDimlessSpin: 0.99\n"
-      "RestMassDensity: -4.21\n"
-      "FlowSpeed: 1.3\n"
-      "MagFieldStrength: 0.21\n"
-      "PolytropicConstant: 54.16\n"
-      "PolytropicExponent: 1.598");
-}
-
-// [[OutputRegex, In string:.*At line 7 column 23:.Value -1.52 is below the
-// lower bound of 0]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticData.GrMhd.BondiHoylePolytConstOpt",
-    "[PointwiseFunctions][Unit]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<grmhd::AnalyticData::BondiHoyleAccretion>(
-      "BhMass: 0.765\n"
-      "BhDimlessSpin: -0.324\n"
-      "RestMassDensity: 156.2\n"
-      "FlowSpeed: 0.653\n"
-      "MagFieldStrength: 1.454\n"
-      "PolytropicConstant: -1.52\n"
-      "PolytropicExponent: 2.0");
-}
-
-// [[OutputRegex, In string:.*At line 8 column 23:.Value 0.123 is below the
-// lower bound of 1]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticData.GrMhd.BondiHoylePolytExpOpt",
-    "[PointwiseFunctions][Unit]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<grmhd::AnalyticData::BondiHoyleAccretion>(
-      "BhMass: 4.21\n"
-      "BhDimlessSpin: -0.11\n"
-      "RestMassDensity: 0.43\n"
-      "FlowSpeed: 0.435\n"
-      "MagFieldStrength: 3.44\n"
-      "PolytropicConstant: 0.653\n"
-      "PolytropicExponent: 0.123");
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<grmhd::AnalyticData::BondiHoyleAccretion>(
+          "BhMass: -1.345\n"
+          "BhDimlessSpin: 0.3\n"
+          "RestMassDensity: 1.32\n"
+          "FlowSpeed: 4.3\n"
+          "MagFieldStrength: 0.52\n"
+          "PolytropicConstant: 0.12\n"
+          "PolytropicExponent: 1.5"),
+      Catch::Contains("Value -1.345 is below the lower bound of 0"));
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<grmhd::AnalyticData::BondiHoyleAccretion>(
+          "BhMass: 4.4231\n"
+          "BhDimlessSpin: -1.23\n"
+          "RestMassDensity: 0.31\n"
+          "FlowSpeed: 0.11\n"
+          "MagFieldStrength: 2.4\n"
+          "PolytropicConstant: 300.0\n"
+          "PolytropicExponent: 1.4"),
+      Catch::Contains("Value -1.23 is below the lower bound of -1"));
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<grmhd::AnalyticData::BondiHoyleAccretion>(
+          "BhMass: 0.654\n"
+          "BhDimlessSpin: 3.99\n"
+          "RestMassDensity: 5.234\n"
+          "FlowSpeed: 0.543\n"
+          "MagFieldStrength: -0.352\n"
+          "PolytropicConstant: 80.123\n"
+          "PolytropicExponent: 1.66"),
+      Catch::Contains("Value 3.99 is above the upper bound of 1"));
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<grmhd::AnalyticData::BondiHoyleAccretion>(
+          "BhMass: 12.34\n"
+          "BhDimlessSpin: 0.99\n"
+          "RestMassDensity: -4.21\n"
+          "FlowSpeed: 1.3\n"
+          "MagFieldStrength: 0.21\n"
+          "PolytropicConstant: 54.16\n"
+          "PolytropicExponent: 1.598"),
+      Catch::Contains("Value -4.21 is below the lower bound of 0"));
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<grmhd::AnalyticData::BondiHoyleAccretion>(
+          "BhMass: 0.765\n"
+          "BhDimlessSpin: -0.324\n"
+          "RestMassDensity: 156.2\n"
+          "FlowSpeed: 0.653\n"
+          "MagFieldStrength: 1.454\n"
+          "PolytropicConstant: -1.52\n"
+          "PolytropicExponent: 2.0"),
+      Catch::Contains("Value -1.52 is below the lower bound of 0"));
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<grmhd::AnalyticData::BondiHoyleAccretion>(
+          "BhMass: 4.21\n"
+          "BhDimlessSpin: -0.11\n"
+          "RestMassDensity: 0.43\n"
+          "FlowSpeed: 0.435\n"
+          "MagFieldStrength: 3.44\n"
+          "PolytropicConstant: 0.653\n"
+          "PolytropicExponent: 0.123"),
+      Catch::Contains("Value 0.123 is below the lower bound of 1"));
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagnetizedFmDisk.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagnetizedFmDisk.cpp
@@ -200,144 +200,86 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticData.GrMhd.MagFmDisk",
 
   test_variables(std::numeric_limits<double>::signaling_NaN());
   test_variables(DataVector(5));
-}
 
-// [[OutputRegex, The threshold density must be in the range \(0, 1\)]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticData.GrMhd.MagFmDiskThreshLower",
-    "[Unit][PointwiseFunctions]") {
-  ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  grmhd::AnalyticData::MagnetizedFmDisk disk(0.7, 0.61, 5.4, 9.182, 11.123,
-                                             1.44, -0.2, 0.023, 4);
-  ERROR("Failed to trigger ASSERT in an assertion test");
+  CHECK_THROWS_WITH(
+      []() {
+        grmhd::AnalyticData::MagnetizedFmDisk disk(
+            0.7, 0.61, 5.4, 9.182, 11.123, 1.44, -0.2, 0.023, 4);
+      }(),
+      Catch::Contains("The threshold density must be in the range (0, 1)"));
+  CHECK_THROWS_WITH(
+      []() {
+        grmhd::AnalyticData::MagnetizedFmDisk disk(
+            0.7, 0.61, 5.4, 9.182, 11.123, 1.44, 1.45, 0.023, 4);
+      }(),
+      Catch::Contains("The threshold density must be in the range (0, 1)"));
+  CHECK_THROWS_WITH(
+      []() {
+        grmhd::AnalyticData::MagnetizedFmDisk disk(
+            0.7, 0.61, 5.4, 9.182, 11.123, 1.44, 0.2, -0.153, 4);
+      }(),
+      Catch::Contains("The inverse plasma beta must be non-negative."));
+  CHECK_THROWS_WITH(
+      []() {
+        grmhd::AnalyticData::MagnetizedFmDisk disk(0.7, 0.61, 5.4, 9.182,
+                                                   11.123, 1.44, 0.2, 0.153, 2);
+      }(),
+      Catch::Contains("The grid resolution used in the magnetic field "
+                      "normalization must be at least 4 points."));
+  CHECK_THROWS_WITH(
+      []() {
+        grmhd::AnalyticData::MagnetizedFmDisk disk(0.7, 0.61, 5.4, 9.182,
+                                                   11.123, 1.44, 0.2, 0.023, 5);
+      }(),
+      Catch::Contains("Max b squared is zero."));
 #endif
-}
-
-// clang-format off
-// [[OutputRegex, The threshold density must be in the range \(0, 1\)]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticData.GrMhd.MagFmDiskThreshUpper",
-    "[Unit][PointwiseFunctions]") {
-  // clang-format on
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  grmhd::AnalyticData::MagnetizedFmDisk disk(0.7, 0.61, 5.4, 9.182, 11.123,
-                                             1.44, 1.45, 0.023, 4);
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// [[OutputRegex, The inverse plasma beta must be non-negative.]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticData.GrMhd.MagFmDiskInvBeta",
-    "[Unit][PointwiseFunctions]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  grmhd::AnalyticData::MagnetizedFmDisk disk(0.7, 0.61, 5.4, 9.182, 11.123,
-                                             1.44, 0.2, -0.153, 4);
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// clang-format off
-// [[OutputRegex, The grid resolution used in the magnetic field
-// normalization must be at least 4 points.]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticData.GrMhd.MagFmDiskGridRes",
-    "[Unit][PointwiseFunctions]") {
-  // clang-format on
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  grmhd::AnalyticData::MagnetizedFmDisk disk(0.7, 0.61, 5.4, 9.182, 11.123,
-                                             1.44, 0.2, 0.153, 2);
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// Some random member variables might give rise to vanishing magnetic fields.
-// clang-format off
-// [[OutputRegex, Max b squared is zero.]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticData.GrMhd.MagFmDiskGridUnphysical",
-    "[Unit][PointwiseFunctions]") {
-  // clang-format on
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  grmhd::AnalyticData::MagnetizedFmDisk disk(0.7, 0.61, 5.4, 9.182, 11.123,
-                                             1.44, 0.2, 0.023, 5);
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// [[OutputRegex, In string:.*At line 8 column 21:.Value -0.01 is below the
-// lower bound of 0]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticData.GrMhd.MagFmDiskThreshLowerOpt",
-    "[PointwiseFunctions][Unit]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<grmhd::AnalyticData::MagnetizedFmDisk>(
-      "BhMass: 13.45\n"
-      "BhDimlessSpin: 0.45\n"
-      "InnerEdgeRadius: 6.1\n"
-      "MaxPressureRadius: 7.6\n"
-      "PolytropicConstant: 2.42\n"
-      "PolytropicExponent: 1.33\n"
-      "ThresholdDensity: -0.01\n"
-      "InversePlasmaBeta: 0.016\n"
-      "BFieldNormGridRes: 4");
-}
-
-// [[OutputRegex, In string:.*At line 8 column 21:.Value 4.1 is above the
-// upper bound of 1]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticData.GrMhd.MagFmDiskThreshUpperOpt",
-    "[PointwiseFunctions][Unit]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<grmhd::AnalyticData::MagnetizedFmDisk>(
-      "BhMass: 1.5\n"
-      "BhDimlessSpin: 0.94\n"
-      "InnerEdgeRadius: 6.4\n"
-      "MaxPressureRadius: 8.2\n"
-      "PolytropicConstant: 41.1\n"
-      "PolytropicExponent: 1.8\n"
-      "ThresholdDensity: 4.1\n"
-      "InversePlasmaBeta: 0.03\n"
-      "BFieldNormGridRes: 4");
-}
-
-// [[OutputRegex, In string:.*At line 9 column 22:.Value -0.03 is below the
-// lower bound of 0]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticData.GrMhd.MagFmDiskInvBetaOpt",
-    "[PointwiseFunctions][Unit]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<grmhd::AnalyticData::MagnetizedFmDisk>(
-      "BhMass: 1.4\n"
-      "BhDimlessSpin: 0.91\n"
-      "InnerEdgeRadius: 6.5\n"
-      "MaxPressureRadius: 7.8\n"
-      "PolytropicConstant: 13.5\n"
-      "PolytropicExponent: 1.54\n"
-      "ThresholdDensity: 0.22\n"
-      "InversePlasmaBeta: -0.03\n"
-      "BFieldNormGridRes: 4");
-}
-
-// [[OutputRegex, In string:.*At line 10 column 22:.Value 2 is below the
-// lower bound of 4]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticData.GrMhd.MagFmDiskGridResOpt",
-    "[PointwiseFunctions][Unit]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<grmhd::AnalyticData::MagnetizedFmDisk>(
-      "BhMass: 1.4\n"
-      "BhDimlessSpin: 0.91\n"
-      "InnerEdgeRadius: 6.5\n"
-      "MaxPressureRadius: 7.8\n"
-      "PolytropicConstant: 13.5\n"
-      "PolytropicExponent: 1.54\n"
-      "ThresholdDensity: 0.22\n"
-      "InversePlasmaBeta: 0.03\n"
-      "BFieldNormGridRes: 2");
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<grmhd::AnalyticData::MagnetizedFmDisk>(
+          "BhMass: 13.45\n"
+          "BhDimlessSpin: 0.45\n"
+          "InnerEdgeRadius: 6.1\n"
+          "MaxPressureRadius: 7.6\n"
+          "PolytropicConstant: 2.42\n"
+          "PolytropicExponent: 1.33\n"
+          "ThresholdDensity: -0.01\n"
+          "InversePlasmaBeta: 0.016\n"
+          "BFieldNormGridRes: 4"),
+      Catch::Contains("Value -0.01 is below the lower bound of 0"));
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<grmhd::AnalyticData::MagnetizedFmDisk>(
+          "BhMass: 1.5\n"
+          "BhDimlessSpin: 0.94\n"
+          "InnerEdgeRadius: 6.4\n"
+          "MaxPressureRadius: 8.2\n"
+          "PolytropicConstant: 41.1\n"
+          "PolytropicExponent: 1.8\n"
+          "ThresholdDensity: 4.1\n"
+          "InversePlasmaBeta: 0.03\n"
+          "BFieldNormGridRes: 4"),
+      Catch::Contains("Value 4.1 is above the upper bound of 1"));
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<grmhd::AnalyticData::MagnetizedFmDisk>(
+          "BhMass: 1.4\n"
+          "BhDimlessSpin: 0.91\n"
+          "InnerEdgeRadius: 6.5\n"
+          "MaxPressureRadius: 7.8\n"
+          "PolytropicConstant: 13.5\n"
+          "PolytropicExponent: 1.54\n"
+          "ThresholdDensity: 0.22\n"
+          "InversePlasmaBeta: -0.03\n"
+          "BFieldNormGridRes: 4"),
+      Catch::Contains("Value -0.03 is below the lower bound of 0"));
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<grmhd::AnalyticData::MagnetizedFmDisk>(
+          "BhMass: 1.4\n"
+          "BhDimlessSpin: 0.91\n"
+          "InnerEdgeRadius: 6.5\n"
+          "MaxPressureRadius: 7.8\n"
+          "PolytropicConstant: 13.5\n"
+          "PolytropicExponent: 1.54\n"
+          "ThresholdDensity: 0.22\n"
+          "InversePlasmaBeta: 0.03\n"
+          "BFieldNormGridRes: 2"),
+      Catch::Contains("Value 2 is below the lower bound of 4"));
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticData/NewtonianEuler/Test_KhInstability.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/NewtonianEuler/Test_KhInstability.cpp
@@ -105,194 +105,143 @@ SPECTRE_TEST_CASE(
 
   GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
   CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_analytic_data, (2, 3));
-}
 
-// [[OutputRegex, In string:.*At line 5 column 17:.Value -2.1 is below the
-// lower bound of 0]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticData.NewtEuler.KhInstability.RhoOut2d",
-    "[Unit][PointwiseFunctions]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<NewtonianEuler::AnalyticData::KhInstability<2>>(
-      "AdiabaticIndex: 1.43\n"
-      "StripBimedianHeight: 0.5\n"
-      "StripThickness: 0.4\n"
-      "StripDensity: -2.1\n"
-      "StripVelocity: 0.3\n"
-      "BackgroundDensity: 2.0\n"
-      "BackgroundVelocity: -0.2\n"
-      "Pressure: 1.1\n"
-      "PerturbAmplitude: 0.1\n"
-      "PerturbWidth: 0.01");
-}
-
-// [[OutputRegex, In string:.*At line 5 column 17:.Value -2.1 is below the
-// lower bound of 0]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticData.NewtEuler.KhInstability.RhoOut3d",
-    "[Unit][PointwiseFunctions]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<NewtonianEuler::AnalyticData::KhInstability<3>>(
-      "AdiabaticIndex: 1.43\n"
-      "StripBimedianHeight: 0.5\n"
-      "StripThickness: 0.4\n"
-      "StripDensity: -2.1\n"
-      "StripVelocity: 0.3\n"
-      "BackgroundDensity: 2.0\n"
-      "BackgroundVelocity: -0.2\n"
-      "Pressure: 1.1\n"
-      "PerturbAmplitude: 0.1\n"
-      "PerturbWidth: 0.01");
-}
-
-// [[OutputRegex, In string:.*At line 7 column 22:.Value -2 is below the
-// lower bound of 0]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticData.NewtEuler.KhInstability.RhoIn2d",
-    "[Unit][PointwiseFunctions]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<NewtonianEuler::AnalyticData::KhInstability<2>>(
-      "AdiabaticIndex: 1.43\n"
-      "StripBimedianHeight: 0.5\n"
-      "StripThickness: 0.4\n"
-      "StripDensity: 2.1\n"
-      "StripVelocity: 0.3\n"
-      "BackgroundDensity: -2.0\n"
-      "BackgroundVelocity: -0.2\n"
-      "Pressure: 1.1\n"
-      "PerturbAmplitude: 0.1\n"
-      "PerturbWidth: 0.01");
-}
-
-// [[OutputRegex, In string:.*At line 7 column 22:.Value -2 is below the
-// lower bound of 0]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticData.NewtEuler.KhInstability.RhoIn3d",
-    "[Unit][PointwiseFunctions]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<NewtonianEuler::AnalyticData::KhInstability<3>>(
-      "AdiabaticIndex: 1.43\n"
-      "StripBimedianHeight: 0.5\n"
-      "StripThickness: 0.4\n"
-      "StripDensity: 2.1\n"
-      "StripVelocity: 0.3\n"
-      "BackgroundDensity: -2.0\n"
-      "BackgroundVelocity: -0.2\n"
-      "Pressure: 1.1\n"
-      "PerturbAmplitude: 0.1\n"
-      "PerturbWidth: 0.01");
-}
-
-// [[OutputRegex, In string:.*At line 9 column 13:.Value -1.1 is below the
-// lower bound of 0]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticData.NewtEuler.KhInstability.Pressure2d",
-    "[Unit][PointwiseFunctions]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<NewtonianEuler::AnalyticData::KhInstability<2>>(
-      "AdiabaticIndex: 1.43\n"
-      "StripBimedianHeight: 0.5\n"
-      "StripThickness: 0.4\n"
-      "StripDensity: 2.1\n"
-      "StripVelocity: 0.3\n"
-      "BackgroundDensity: 2.0\n"
-      "BackgroundVelocity: -0.2\n"
-      "Pressure: -1.1\n"
-      "PerturbAmplitude: 0.1\n"
-      "PerturbWidth: 0.01");
-}
-
-// [[OutputRegex, In string:.*At line 9 column 13:.Value -1.1 is below the
-// lower bound of 0]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticData.NewtEuler.KhInstability.Pressure3d",
-    "[Unit][PointwiseFunctions]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<NewtonianEuler::AnalyticData::KhInstability<3>>(
-      "AdiabaticIndex: 1.43\n"
-      "StripBimedianHeight: 0.5\n"
-      "StripThickness: 0.4\n"
-      "StripDensity: 2.1\n"
-      "StripVelocity: 0.3\n"
-      "BackgroundDensity: 2.0\n"
-      "BackgroundVelocity: -0.2\n"
-      "Pressure: -1.1\n"
-      "PerturbAmplitude: 0.1\n"
-      "PerturbWidth: 0.01");
-}
-
-// [[OutputRegex, In string:.*At line 11 column 17:.Value -0.01 is below the
-// lower bound of 0]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticData.NewtEuler.KhInstability.PertWidth2d",
-    "[Unit][PointwiseFunctions]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<NewtonianEuler::AnalyticData::KhInstability<2>>(
-      "AdiabaticIndex: 1.43\n"
-      "StripBimedianHeight: 0.5\n"
-      "StripThickness: 0.4\n"
-      "StripDensity: 2.1\n"
-      "StripVelocity: 0.3\n"
-      "BackgroundDensity: 2.0\n"
-      "BackgroundVelocity: -0.2\n"
-      "Pressure: 1.1\n"
-      "PerturbAmplitude: 0.1\n"
-      "PerturbWidth: -0.01");
-}
-
-// [[OutputRegex, In string:.*At line 11 column 17:.Value -0.01 is below the
-// lower bound of 0]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticData.NewtEuler.KhInstability.PertWidth3d",
-    "[Unit][PointwiseFunctions]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<NewtonianEuler::AnalyticData::KhInstability<3>>(
-      "AdiabaticIndex: 1.43\n"
-      "StripBimedianHeight: 0.5\n"
-      "StripThickness: 0.4\n"
-      "StripDensity: 2.1\n"
-      "StripVelocity: 0.3\n"
-      "BackgroundDensity: 2.0\n"
-      "BackgroundVelocity: -0.2\n"
-      "Pressure: 1.1\n"
-      "PerturbAmplitude: 0.1\n"
-      "PerturbWidth: -0.01");
-}
-
-// [[OutputRegex, In string:.*At line 4 column 19:.Value -0.4 is below the
-// lower bound of 0]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticData.NewtEuler.KhInstability.StripThick2d",
-    "[Unit][PointwiseFunctions]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<NewtonianEuler::AnalyticData::KhInstability<2>>(
-      "AdiabaticIndex: 1.43\n"
-      "StripBimedianHeight: 0.5\n"
-      "StripThickness: -0.4\n"
-      "StripDensity: 2.1\n"
-      "StripVelocity: 0.3\n"
-      "BackgroundDensity: 2.0\n"
-      "BackgroundVelocity: -0.2\n"
-      "Pressure: 1.1\n"
-      "PerturbAmplitude: 0.1\n"
-      "PerturbWidth: 0.01");
-}
-
-// [[OutputRegex, In string:.*At line 4 column 19:.Value -0.4 is below the
-// lower bound of 0]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticData.NewtEuler.KhInstability.StripThick3d",
-    "[Unit][PointwiseFunctions]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<NewtonianEuler::AnalyticData::KhInstability<3>>(
-      "AdiabaticIndex: 1.43\n"
-      "StripBimedianHeight: 0.5\n"
-      "StripThickness: -0.4\n"
-      "StripDensity: 2.1\n"
-      "StripVelocity: 0.3\n"
-      "BackgroundDensity: 2.0\n"
-      "BackgroundVelocity: -0.2\n"
-      "Pressure: 1.1\n"
-      "PerturbAmplitude: 0.1\n"
-      "PerturbWidth: 0.01");
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<
+          NewtonianEuler::AnalyticData::KhInstability<2>>(
+          "AdiabaticIndex: 1.43\n"
+          "StripBimedianHeight: 0.5\n"
+          "StripThickness: 0.4\n"
+          "StripDensity: -2.1\n"
+          "StripVelocity: 0.3\n"
+          "BackgroundDensity: 2.0\n"
+          "BackgroundVelocity: -0.2\n"
+          "Pressure: 1.1\n"
+          "PerturbAmplitude: 0.1\n"
+          "PerturbWidth: 0.01"),
+      Catch::Contains("Value -2.1 is below the lower bound of 0"));
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<
+          NewtonianEuler::AnalyticData::KhInstability<3>>(
+          "AdiabaticIndex: 1.43\n"
+          "StripBimedianHeight: 0.5\n"
+          "StripThickness: 0.4\n"
+          "StripDensity: -2.1\n"
+          "StripVelocity: 0.3\n"
+          "BackgroundDensity: 2.0\n"
+          "BackgroundVelocity: -0.2\n"
+          "Pressure: 1.1\n"
+          "PerturbAmplitude: 0.1\n"
+          "PerturbWidth: 0.01"),
+      Catch::Contains("Value -2.1 is below the lower bound of 0"));
+  CHECK_THROWS_WITH(TestHelpers::test_creation<
+                        NewtonianEuler::AnalyticData::KhInstability<2>>(
+                        "AdiabaticIndex: 1.43\n"
+                        "StripBimedianHeight: 0.5\n"
+                        "StripThickness: 0.4\n"
+                        "StripDensity: 2.1\n"
+                        "StripVelocity: 0.3\n"
+                        "BackgroundDensity: -2.0\n"
+                        "BackgroundVelocity: -0.2\n"
+                        "Pressure: 1.1\n"
+                        "PerturbAmplitude: 0.1\n"
+                        "PerturbWidth: 0.01"),
+                    Catch::Contains("Value -2 is below the lower bound of 0"));
+  CHECK_THROWS_WITH(TestHelpers::test_creation<
+                        NewtonianEuler::AnalyticData::KhInstability<3>>(
+                        "AdiabaticIndex: 1.43\n"
+                        "StripBimedianHeight: 0.5\n"
+                        "StripThickness: 0.4\n"
+                        "StripDensity: 2.1\n"
+                        "StripVelocity: 0.3\n"
+                        "BackgroundDensity: -2.0\n"
+                        "BackgroundVelocity: -0.2\n"
+                        "Pressure: 1.1\n"
+                        "PerturbAmplitude: 0.1\n"
+                        "PerturbWidth: 0.01"),
+                    Catch::Contains("Value -2 is below the lower bound of 0"));
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<
+          NewtonianEuler::AnalyticData::KhInstability<2>>(
+          "AdiabaticIndex: 1.43\n"
+          "StripBimedianHeight: 0.5\n"
+          "StripThickness: 0.4\n"
+          "StripDensity: 2.1\n"
+          "StripVelocity: 0.3\n"
+          "BackgroundDensity: 2.0\n"
+          "BackgroundVelocity: -0.2\n"
+          "Pressure: -1.1\n"
+          "PerturbAmplitude: 0.1\n"
+          "PerturbWidth: 0.01"),
+      Catch::Contains("Value -1.1 is below the lower bound of 0"));
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<
+          NewtonianEuler::AnalyticData::KhInstability<3>>(
+          "AdiabaticIndex: 1.43\n"
+          "StripBimedianHeight: 0.5\n"
+          "StripThickness: 0.4\n"
+          "StripDensity: 2.1\n"
+          "StripVelocity: 0.3\n"
+          "BackgroundDensity: 2.0\n"
+          "BackgroundVelocity: -0.2\n"
+          "Pressure: -1.1\n"
+          "PerturbAmplitude: 0.1\n"
+          "PerturbWidth: 0.01"),
+      Catch::Contains("Value -1.1 is below the lower bound of 0"));
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<
+          NewtonianEuler::AnalyticData::KhInstability<2>>(
+          "AdiabaticIndex: 1.43\n"
+          "StripBimedianHeight: 0.5\n"
+          "StripThickness: 0.4\n"
+          "StripDensity: 2.1\n"
+          "StripVelocity: 0.3\n"
+          "BackgroundDensity: 2.0\n"
+          "BackgroundVelocity: -0.2\n"
+          "Pressure: 1.1\n"
+          "PerturbAmplitude: 0.1\n"
+          "PerturbWidth: -0.01"),
+      Catch::Contains("Value -0.01 is below the lower bound of 0"));
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<
+          NewtonianEuler::AnalyticData::KhInstability<3>>(
+          "AdiabaticIndex: 1.43\n"
+          "StripBimedianHeight: 0.5\n"
+          "StripThickness: 0.4\n"
+          "StripDensity: 2.1\n"
+          "StripVelocity: 0.3\n"
+          "BackgroundDensity: 2.0\n"
+          "BackgroundVelocity: -0.2\n"
+          "Pressure: 1.1\n"
+          "PerturbAmplitude: 0.1\n"
+          "PerturbWidth: -0.01"),
+      Catch::Contains("Value -0.01 is below the lower bound of 0"));
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<
+          NewtonianEuler::AnalyticData::KhInstability<2>>(
+          "AdiabaticIndex: 1.43\n"
+          "StripBimedianHeight: 0.5\n"
+          "StripThickness: -0.4\n"
+          "StripDensity: 2.1\n"
+          "StripVelocity: 0.3\n"
+          "BackgroundDensity: 2.0\n"
+          "BackgroundVelocity: -0.2\n"
+          "Pressure: 1.1\n"
+          "PerturbAmplitude: 0.1\n"
+          "PerturbWidth: 0.01"),
+      Catch::Contains("Value -0.4 is below the lower bound of 0"));
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<
+          NewtonianEuler::AnalyticData::KhInstability<3>>(
+          "AdiabaticIndex: 1.43\n"
+          "StripBimedianHeight: 0.5\n"
+          "StripThickness: -0.4\n"
+          "StripDensity: 2.1\n"
+          "StripVelocity: 0.3\n"
+          "BackgroundDensity: 2.0\n"
+          "BackgroundVelocity: -0.2\n"
+          "Pressure: 1.1\n"
+          "PerturbAmplitude: 0.1\n"
+          "PerturbWidth: 0.01"),
+      Catch::Contains("Value -0.4 is below the lower bound of 0"));
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_GaugeWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_GaugeWave.cpp
@@ -270,40 +270,21 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Gr.GaugeWave",
   test_copy_and_move();
   test_serialize();
   test_construct_from_options();
-}
 
-// [[OutputRegex, Amplitude must be less than one]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticSolutions.Gr.GaugeWaveAmplitude",
-    "[PointwiseFunctions][Unit]") {
-  ERROR_TEST();
-  const gr::Solutions::GaugeWave<3> solution(-1.25, 1.0);
-}
-
-// [[OutputRegex, Wavelength must be non-negative]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticSolutions.Gr.GaugeWaveWavelength",
-    "[PointwiseFunctions][Unit]") {
-  ERROR_TEST();
-  const gr::Solutions::GaugeWave<3> solution(0.0, -0.25);
-}
-
-// [[OutputRegex, In string:.*At line 2 column 14:.Value -1.25 is below the
-// lower bound of -1]]
-SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Gr.GaugeWaveOptA",
-                  "[PointwiseFunctions][Unit]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<gr::Solutions::GaugeWave<3>>(
-      "Amplitude: -1.25\n"
-      "Wavelength: 1.0");
-}
-
-// [[OutputRegex, In string:.*At line 3 column 15:.Value -0.25 is below the
-// lower bound of 0]]
-SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Gr.GaugeWaveOptW",
-                  "[PointwiseFunctions][Unit]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<gr::Solutions::GaugeWave<3>>(
-      "Amplitude: 1.0\n"
-      "Wavelength: -0.25\n");
+  CHECK_THROWS_WITH(
+      []() { const gr::Solutions::GaugeWave<3> solution(-1.25, 1.0); }(),
+      Catch::Contains("Amplitude must be less than one"));
+  CHECK_THROWS_WITH(
+      []() { const gr::Solutions::GaugeWave<3> solution(0.0, -0.25); }(),
+      Catch::Contains("Wavelength must be non-negative"));
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<gr::Solutions::GaugeWave<3>>(
+          "Amplitude: -1.25\n"
+          "Wavelength: 1.0"),
+      Catch::Contains("Value -1.25 is below the lower bound of -1"));
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<gr::Solutions::GaugeWave<3>>(
+          "Amplitude: 1.0\n"
+          "Wavelength: -0.25\n"),
+      Catch::Contains("Value -0.25 is below the lower bound of 0"));
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_HarmonicSchwarzschild.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_HarmonicSchwarzschild.cpp
@@ -632,23 +632,15 @@ SPECTRE_TEST_CASE(
   test_harmonic_conditions_satisfied<Frame::Inertial>(0.0);
   test_harmonic_conditions_satisfied<Frame::Grid>(DataVector(5));
   test_harmonic_conditions_satisfied<Frame::Grid>(0.0);
-}
 
-// [[OutputRegex, Mass must be non-negative]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticSolutions.Gr.HarmonicSchwarzschildMass",
-    "[PointwiseFunctions][Unit]") {
-  ERROR_TEST();
-  gr::Solutions::HarmonicSchwarzschild solution(-1.0, {{0.0, 0.0, 0.0}});
-}
-
-// [[OutputRegex, In string:.*At line 2 column 9:.Value -0.5 is below the lower
-// bound of 0]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticSolutions.Gr.HarmonicSchwarzschildOptM",
-    "[PointwiseFunctions][Unit]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<gr::Solutions::HarmonicSchwarzschild>(
-      "Mass: -0.5\n"
-      "Center: [1.0,3.0,2.0]");
+  CHECK_THROWS_WITH(
+      []() {
+        gr::Solutions::HarmonicSchwarzschild solution(-1.0, {{0.0, 0.0, 0.0}});
+      }(),
+      Catch::Contains("Mass must be non-negative"));
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<gr::Solutions::HarmonicSchwarzschild>(
+          "Mass: -0.5\n"
+          "Center: [1.0,3.0,2.0]"),
+      Catch::Contains("Value -0.5 is below the lower bound of 0"));
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_KerrSchild.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_KerrSchild.cpp
@@ -323,40 +323,28 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Gr.KerrSchild",
   test_tag_retrieval<Frame::Grid>(DataVector(5));
   test_tag_retrieval<Frame::Grid>(0.0);
   test_einstein_solution<Frame::Grid>();
-}
 
-// [[OutputRegex, Spin magnitude must be < 1]]
-SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Gr.KerrSchildSpin",
-                  "[PointwiseFunctions][Unit]") {
-  ERROR_TEST();
-  gr::Solutions::KerrSchild solution(1.0, {{1.0, 1.0, 1.0}}, {{0.0, 0.0, 0.0}});
-}
-
-// [[OutputRegex, Mass must be non-negative]]
-SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Gr.KerrSchildMass",
-                  "[PointwiseFunctions][Unit]") {
-  ERROR_TEST();
-  gr::Solutions::KerrSchild solution(-1.0, {{0.0, 0.0, 0.0}},
-                                     {{0.0, 0.0, 0.0}});
-}
-
-// [[OutputRegex, In string:.*At line 2 column 9:.Value -0.5 is below the lower
-// bound of 0]]
-SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Gr.KerrSchildOptM",
-                  "[PointwiseFunctions][Unit]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<gr::Solutions::KerrSchild>(
-      "Mass: -0.5\n"
-      "Spin: [0.1,0.2,0.3]\n"
-      "Center: [1.0,3.0,2.0]");
-}
-
-// [[OutputRegex, In string:.*At line 2 column 3:.Spin magnitude must be < 1]]
-SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Gr.KerrSchildOptS",
-                  "[PointwiseFunctions][Unit]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<gr::Solutions::KerrSchild>(
-      "Mass: 0.5\n"
-      "Spin: [1.1,0.9,0.3]\n"
-      "Center: [1.0,3.0,2.0]");
+  CHECK_THROWS_WITH(
+      []() {
+        gr::Solutions::KerrSchild solution(1.0, {{1.0, 1.0, 1.0}},
+                                           {{0.0, 0.0, 0.0}});
+      }(),
+      Catch::Contains("Spin magnitude must be < 1"));
+  CHECK_THROWS_WITH(
+      []() {
+        gr::Solutions::KerrSchild solution(-1.0, {{0.0, 0.0, 0.0}},
+                                           {{0.0, 0.0, 0.0}});
+      }(),
+      Catch::Contains("Mass must be non-negative"));
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<gr::Solutions::KerrSchild>(
+          "Mass: -0.5\n"
+          "Spin: [0.1,0.2,0.3]\n"
+          "Center: [1.0,3.0,2.0]"),
+      Catch::Contains("Value -0.5 is below the lower bound of 0"));
+  CHECK_THROWS_WITH(TestHelpers::test_creation<gr::Solutions::KerrSchild>(
+                        "Mass: 0.5\n"
+                        "Spin: [1.1,0.9,0.3]\n"
+                        "Center: [1.0,3.0,2.0]"),
+                    Catch::Contains("Spin magnitude must be < 1"));
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_IsentropicVortex.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_IsentropicVortex.cpp
@@ -111,11 +111,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.NewtEuler.Vortex",
   test_solution<3>(DataVector(5), center_3d, "[-0.53, -0.1, 1.4]",
                    mean_velocity_3d, "[-0.04, 0.14, 0.3]",
                    perturbation_amplitude, "0.5");
-}
 
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticSolutions.NewtEuler.Vortex.Pert",
-    "[Unit][PointwiseFunctions]") {
   static_assert(
       std::is_same_v<
           NewtonianEuler::Solutions::IsentropicVortex<3>::source_term_type,
@@ -136,72 +132,43 @@ SPECTRE_TEST_CASE(
   CHECK(vortex.perturbation_profile(random_z_dv) == sin(random_z_dv));
   CHECK(vortex.deriv_of_perturbation_profile(random_z) == cos(random_z));
   CHECK(vortex.deriv_of_perturbation_profile(random_z_dv) == cos(random_z_dv));
-}
 
-// [[OutputRegex, A nonzero perturbation amplitude only makes sense in 3
-// dimensions.]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticSolutions.NewtEuler.VortexPertAmpIn2d",
-    "[Unit][PointwiseFunctions]") {
-  ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  NewtonianEuler::Solutions::IsentropicVortex<2> test_vortex(
-      1.3, {{3.21, -1.4}}, {{0.12, -0.53}}, 1.7, 1.e-12);
-  ERROR("Failed to trigger ASSERT in an assertion test");
+  CHECK_THROWS_WITH(
+      []() {
+        NewtonianEuler::Solutions::IsentropicVortex<2> test_vortex(
+            1.3, {{3.21, -1.4}}, {{0.12, -0.53}}, 1.7, 1.e-12);
+      }(),
+      Catch::Contains("A nonzero perturbation amplitude only "
+                      "makes sense in 3 dimensions."));
+  CHECK_THROWS_WITH(
+      []() {
+        NewtonianEuler::Solutions::IsentropicVortex<2> test_vortex(
+            1.3, {{3.21, -1.4}}, {{0.12, -0.53}}, -1.7);
+      }(),
+      Catch::Contains("The strength must be non-negative."));
+  CHECK_THROWS_WITH(
+      []() {
+        NewtonianEuler::Solutions::IsentropicVortex<3> test_vortex(
+            1.65, {{-0.12, 1.542, 3.12}}, {{-0.04, -0.32, 0.003}}, -0.5, 4.2);
+      }(),
+      Catch::Contains("The strength must be non-negative."));
 #endif
-}
-
-    // clang-format off
-// [[OutputRegex, The strength must be non-negative.]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticSolutions.NewtEuler.VortexStrength2d",
-    "[Unit][PointwiseFunctions]") {
-  // clang-format on
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  NewtonianEuler::Solutions::IsentropicVortex<2> test_vortex(
-      1.3, {{3.21, -1.4}}, {{0.12, -0.53}}, -1.7);
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-    // clang-format off
-// [[OutputRegex, The strength must be non-negative.]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticSolutions.NewtEuler.VortexStrength3d",
-    "[Unit][PointwiseFunctions]") {
-  // clang-format on
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  NewtonianEuler::Solutions::IsentropicVortex<3> test_vortex(
-      1.65, {{-0.12, 1.542, 3.12}}, {{-0.04, -0.32, 0.003}}, -0.5, 4.2);
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// [[OutputRegex, In string:.*At line 5 column 13:.Value -0.2 is below the lower
-// bound of 0]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticSolutions.NewtEuler.VortexStrengthOpt2d",
-    "[PointwiseFunctions][Unit]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<NewtonianEuler::Solutions::IsentropicVortex<2>>(
-      "AdiabaticIndex: 1.4\n"
-      "Center: [-3.9, 1.1]\n"
-      "MeanVelocity: [0.1, -0.032]\n"
-      "Strength: -0.2");
-}
-
-// [[OutputRegex, In string:.*At line 5 column 13:.Value -0.3 is below the lower
-// bound of 0]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticSolutions.NewtEuler.VortexStrengthOpt3d",
-    "[PointwiseFunctions][Unit]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<NewtonianEuler::Solutions::IsentropicVortex<3>>(
-      "AdiabaticIndex: 1.12\n"
-      "Center: [0.3, -0.12, 4.2]\n"
-      "MeanVelocity: [-0.03, -0.1, 0.09]\n"
-      "Strength: -0.3\n"
-      "PerturbAmplitude: 0.42");
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<
+          NewtonianEuler::Solutions::IsentropicVortex<2>>(
+          "AdiabaticIndex: 1.4\n"
+          "Center: [-3.9, 1.1]\n"
+          "MeanVelocity: [0.1, -0.032]\n"
+          "Strength: -0.2"),
+      Catch::Contains("Value -0.2 is below the lower bound of 0"));
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<
+          NewtonianEuler::Solutions::IsentropicVortex<3>>(
+          "AdiabaticIndex: 1.12\n"
+          "Center: [0.3, -0.12, 4.2]\n"
+          "MeanVelocity: [-0.03, -0.1, 0.09]\n"
+          "Strength: -0.3\n"
+          "PerturbAmplitude: 0.42"),
+      Catch::Contains("Value -0.3 is below the lower bound of 0"));
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_FishboneMoncriefDisk.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_FishboneMoncriefDisk.cpp
@@ -230,84 +230,55 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.RelEuler.FMDisk",
   test_sin_theta_squared(DataVector(5));
 
   test_solution();
-}
 
-// [[OutputRegex, In string:.*At line 2 column 11:.Value -1.5 is below the lower
-// bound of 0]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticSolutions.RelEuler.FMDiskBHMassOpt",
-    "[PointwiseFunctions][Unit]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<
-      RelativisticEuler::Solutions::FishboneMoncriefDisk>(
-      "BhMass: -1.5\n"
-      "BhDimlessSpin: 0.3\n"
-      "InnerEdgeRadius: 4.3\n"
-      "MaxPressureRadius: 6.7\n"
-      "PolytropicConstant: 0.12\n"
-      "PolytropicExponent: 1.5");
-}
-
-// [[OutputRegex, In string:.*At line 3 column 18:.Value -0.24 is below the
-// lower bound of 0]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticSolutions.RelEuler.FMDiskBHSpinLowerOpt",
-    "[PointwiseFunctions][Unit]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<
-      RelativisticEuler::Solutions::FishboneMoncriefDisk>(
-      "BhMass: 1.5\n"
-      "BhDimlessSpin: -0.24\n"
-      "InnerEdgeRadius: 5.76\n"
-      "MaxPressureRadius: 13.2\n"
-      "PolytropicConstant: 0.002\n"
-      "PolytropicExponent: 1.34");
-}
-
-// [[OutputRegex, In string:.*At line 3 column 18:.Value 1.24 is above the
-// upper bound of 1.]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticSolutions.RelEuler.FMDiskBHSpinUpperOpt",
-    "[PointwiseFunctions][Unit]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<
-      RelativisticEuler::Solutions::FishboneMoncriefDisk>(
-      "BhMass: 1.5\n"
-      "BhDimlessSpin: 1.24\n"
-      "InnerEdgeRadius: 5.76\n"
-      "MaxPressureRadius: 13.2\n"
-      "PolytropicConstant: 0.002\n"
-      "PolytropicExponent: 1.34");
-}
-
-// [[OutputRegex, In string:.*At line 6 column 23:.Value -0.12 is below the
-// lower bound of 0]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticSolutions.RelEuler.FMDiskPolytConstOpt",
-    "[PointwiseFunctions][Unit]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<
-      RelativisticEuler::Solutions::FishboneMoncriefDisk>(
-      "BhMass: 1.5\n"
-      "BhDimlessSpin: 0.3\n"
-      "InnerEdgeRadius: 4.3\n"
-      "MaxPressureRadius: 6.7\n"
-      "PolytropicConstant: -0.12\n"
-      "PolytropicExponent: 1.5");
-}
-
-// [[OutputRegex, In string:.*At line 7 column 23:.Value 0.25 is below the
-// lower bound of 1]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticSolutions.RelEuler.FMDiskPolytExpOpt",
-    "[PointwiseFunctions][Unit]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<
-      RelativisticEuler::Solutions::FishboneMoncriefDisk>(
-      "BhMass: 1.5\n"
-      "BhDimlessSpin: 0.3\n"
-      "InnerEdgeRadius: 4.3\n"
-      "MaxPressureRadius: 6.7\n"
-      "PolytropicConstant: 0.123\n"
-      "PolytropicExponent: 0.25");
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<
+          RelativisticEuler::Solutions::FishboneMoncriefDisk>(
+          "BhMass: -1.5\n"
+          "BhDimlessSpin: 0.3\n"
+          "InnerEdgeRadius: 4.3\n"
+          "MaxPressureRadius: 6.7\n"
+          "PolytropicConstant: 0.12\n"
+          "PolytropicExponent: 1.5"),
+      Catch::Contains("Value -1.5 is below the lower bound of 0"));
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<
+          RelativisticEuler::Solutions::FishboneMoncriefDisk>(
+          "BhMass: 1.5\n"
+          "BhDimlessSpin: -0.24\n"
+          "InnerEdgeRadius: 5.76\n"
+          "MaxPressureRadius: 13.2\n"
+          "PolytropicConstant: 0.002\n"
+          "PolytropicExponent: 1.34"),
+      Catch::Contains("Value -0.24 is below the lower bound of 0"));
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<
+          RelativisticEuler::Solutions::FishboneMoncriefDisk>(
+          "BhMass: 1.5\n"
+          "BhDimlessSpin: 1.24\n"
+          "InnerEdgeRadius: 5.76\n"
+          "MaxPressureRadius: 13.2\n"
+          "PolytropicConstant: 0.002\n"
+          "PolytropicExponent: 1.34"),
+      Catch::Contains("Value 1.24 is above the upper bound of 1"));
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<
+          RelativisticEuler::Solutions::FishboneMoncriefDisk>(
+          "BhMass: 1.5\n"
+          "BhDimlessSpin: 0.3\n"
+          "InnerEdgeRadius: 4.3\n"
+          "MaxPressureRadius: 6.7\n"
+          "PolytropicConstant: -0.12\n"
+          "PolytropicExponent: 1.5"),
+      Catch::Contains("Value -0.12 is below the lower bound of 0"));
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<
+          RelativisticEuler::Solutions::FishboneMoncriefDisk>(
+          "BhMass: 1.5\n"
+          "BhDimlessSpin: 0.3\n"
+          "InnerEdgeRadius: 4.3\n"
+          "MaxPressureRadius: 6.7\n"
+          "PolytropicConstant: 0.123\n"
+          "PolytropicExponent: 0.25"),
+      Catch::Contains("Value 0.25 is below the lower bound of 1"));
 }

--- a/tests/Unit/Time/CMakeLists.txt
+++ b/tests/Unit/Time/CMakeLists.txt
@@ -27,7 +27,17 @@ add_test_library(
   ${LIBRARY}
   "Time"
   "${LIBRARY_SOURCES}"
-  "Boost::boost;EventsAndTriggers;Time;TimeStepperHelpers"
+  ""
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  CoordinateMaps
+  Domain
+  DomainStructure
+  Time
+  TimeStepperHelpers
   )
 
 add_dependencies(

--- a/tests/Unit/Utilities/Test_Blas.cpp
+++ b/tests/Unit/Utilities/Test_Blas.cpp
@@ -5,59 +5,29 @@
 
 #include "Utilities/Test_Blas.hpp"
 
-#include "Utilities/ErrorHandling/Error.hpp"
-
-// [[OutputRegex, TRANSA must be upper or lower case N, T, or C. See the BLAS
-// documentation for help.]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Utilities.Blas.dgemm_error_transa_false",
-                               "[Unit][Utilities]") {
-  ASSERTION_TEST();
+SPECTRE_TEST_CASE("Unit.Utilities.Blas", "[Unit][Utilities]") {
 #ifdef SPECTRE_DEBUG
-  test_blas_asserts_for_bad_char::dgemm_error_transa_false();
-  ERROR("Assertion test failed incorrectly");
+  CHECK_THROWS_WITH(
+      test_blas_asserts_for_bad_char::dgemm_error_transa_false(),
+      Catch::Contains("TRANSA must be upper or lower case N, T, or C. See the "
+                      "BLAS documentation for help."));
+  CHECK_THROWS_WITH(
+      test_blas_asserts_for_bad_char::dgemm_error_transb_false(),
+      Catch::Contains("TRANSB must be upper or lower case N, T, or C. See the "
+                      "BLAS documentation for help."));
+  CHECK_THROWS_WITH(
+      test_blas_asserts_for_bad_char::dgemm_error_transa_true(),
+      Catch::Contains("TRANSA must be upper or lower case N, T, or C. See the "
+                      "BLAS documentation for help."));
+  CHECK_THROWS_WITH(
+      test_blas_asserts_for_bad_char::dgemm_error_transb_true(),
+      Catch::Contains("TRANSB must be upper or lower case N, T, or C. See the "
+                      "BLAS documentation for help."));
+  CHECK_THROWS_WITH(
+      test_blas_asserts_for_bad_char::dgemv_error_trans(),
+      Catch::Contains("TRANS must be upper or lower case N, T, or C. See the "
+                      "BLAS documentation for help."));
 #endif
-}
-
-// [[OutputRegex, TRANSB must be upper or lower case N, T, or C. See the BLAS
-// documentation for help.]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Utilities.Blas.dgemm_error_transb_false",
-                               "[Unit][Utilities]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  test_blas_asserts_for_bad_char::dgemm_error_transb_false();
-  ERROR("Assertion test failed incorrectly");
-#endif
-}
-
-// [[OutputRegex, TRANSA must be upper or lower case N, T, or C. See the BLAS
-// documentation for help.]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Utilities.Blas.dgemm_error_transa_true",
-                               "[Unit][Utilities]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  test_blas_asserts_for_bad_char::dgemm_error_transa_true();
-  ERROR("Assertion test failed incorrectly");
-#endif
-}
-
-// [[OutputRegex, TRANSB must be upper or lower case N, T, or C. See the BLAS
-// documentation for help.]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Utilities.Blas.dgemm_error_transb_true",
-                               "[Unit][Utilities]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  test_blas_asserts_for_bad_char::dgemm_error_transb_true();
-  ERROR("Assertion test failed incorrectly");
-#endif
-}
-
-// [[OutputRegex, TRANS must be upper or lower case N, T, or C. See the BLAS
-// documentation for help.]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Utilities.Blas.dgemv_error_trans",
-                               "[Unit][Utilities]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  test_blas_asserts_for_bad_char::dgemv_error_trans();
-  ERROR("Assertion test failed incorrectly");
-#endif
+  // so test does not fail in release mode
+  CHECK(true);
 }


### PR DESCRIPTION
## Proposed changes

- Change ASSERT and ERROR to throw an exception instead of aborting.
- Enclose entry methods of AlgorithmImpl in try-catch blocks that call a function initiate_shutdown when catching an exception.  For now, initiate_shutdown just aborts.  The plan is to have it do more sophisticated things in the future.
- Convert some ASSERTION(ERROR)_TESTs to use the Catch macro CHECK_THROWS_WITH.  This allows the separate test cases to be merged together, reducing the number of tests.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

If you have an ASSERTION_TEST or ERROR_TEST as a separate SPECTRE_TEST_CASE, they should be combined with the standard SPECTRE_TEST_CASE by calling CHECK_THROWS_WITH (see the Catch documentation for usage)

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

We should remove as many of the remaining ASSERTION/ERROR_TESTs as we can in follow-up PRs; I would appreciate splitting these up.
