### PR TITLE
XCTS binary: superpose matter without Gaussian falloff

### DIFF
--- a/tests/Unit/PointwiseFunctions/AnalyticData/Xcts/Binary.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/Xcts/Binary.py
@@ -40,3 +40,15 @@ def conformal_factor_bbh_isotropic(x):
     r2 = np.sqrt((x[0] - centers[1])**2 + x[1]**2 + x[2]**2)
     return 1. + 0.5 * (np.exp(-r1**2 / falloff_widths[0]**2) * masses[0] / r1 +
                        np.exp(-r2**2 / falloff_widths[1]**2) * masses[1] / r2)
+
+
+def energy_density_bbh_isotropic(x):
+    return 0.
+
+
+def stress_trace_bbh_isotropic(x):
+    return 0.
+
+
+def momentum_density_bbh_isotropic(x):
+    return np.zeros(3)

--- a/tests/Unit/PointwiseFunctions/AnalyticData/Xcts/Test_Binary.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/Xcts/Test_Binary.cpp
@@ -35,7 +35,11 @@ using test_tags = tmpl::list<
     Tags::ShiftBackground<DataVector, 3, Frame::Inertial>,
     Tags::LongitudinalShiftBackgroundMinusDtConformalMetric<DataVector, 3,
                                                             Frame::Inertial>,
-    Tags::ConformalFactor<DataVector>>;
+    Tags::ConformalFactor<DataVector>,
+    gr::Tags::Conformal<gr::Tags::EnergyDensity<DataVector>, 0>,
+    gr::Tags::Conformal<gr::Tags::StressTrace<DataVector>, 0>,
+    gr::Tags::Conformal<
+        gr::Tags::MomentumDensity<3, Frame::Inertial, DataVector>, 0>>;
 
 template <typename IsolatedObjectBase, typename IsolatedObjectClasses>
 struct BinaryProxy {
@@ -103,7 +107,10 @@ void test_data(const std::array<double, 2>& x_coords,
          "deriv_conformal_metric_" + py_functions_suffix,
          "extrinsic_curvature_trace_" + py_functions_suffix, "shift_background",
          "longitudinal_shift_background_" + py_functions_suffix,
-         "conformal_factor_" + py_functions_suffix},
+         "conformal_factor_" + py_functions_suffix,
+         "energy_density_" + py_functions_suffix,
+         "stress_trace_" + py_functions_suffix,
+         "momentum_density_" + py_functions_suffix},
         {{{x_coords[0] * 2, x_coords[1] * 2}}}, std::make_tuple(),
         DataVector(5));
   }


### PR DESCRIPTION
## Proposed changes

Matter sources are superposed without the Gaussian falloffs. They are of limited use anyway, because in a binary setting they don't take the gravitational influence of the other body into account. Therefore, the matter sources should typically be solved-for alongside the gravity sector to impose conditions such as hydrostatic equilibrium. For scenarios where we just want to superpose the isolated matter solutions and compute the resulting gravity, the matter sources are simply added.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
