### PR TITLE
Support factory-created solution in AH boundary conditions, prepare for SHK initial data

### DIFF
--- a/src/Elliptic/Systems/Xcts/BoundaryConditions/CMakeLists.txt
+++ b/src/Elliptic/Systems/Xcts/BoundaryConditions/CMakeLists.txt
@@ -28,7 +28,7 @@ target_link_libraries(
   Domain
   Elliptic
   ErrorHandling
-  GeneralRelativitySolutions
+  XctsSolutions
   Options
   Parallel
   Utilities

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.cpp
@@ -266,7 +266,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3),
                         (tnsr::a, tnsr::A, tnsr::i, tnsr::I, tnsr::ab, tnsr::Ab,
                          tnsr::aB, tnsr::AB, tnsr::ij, tnsr::iJ, tnsr::Ij,
                          tnsr::IJ, tnsr::iA, tnsr::ia, tnsr::aa, tnsr::AA,
-                         tnsr::ii, tnsr::II))
+                         tnsr::ii, tnsr::II, tnsr::Ijj))
 
 #undef INSTANTIATION
 #undef GET_TENSOR

--- a/src/Parallel/PupStlCpp17.hpp
+++ b/src/Parallel/PupStlCpp17.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cassert>
 #include <optional>
 #include <pup_stl.h>
 #include <utility>

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.hpp
@@ -139,6 +139,10 @@ class BentBeam : public elliptic::analytic_data::AnalyticSolution {
   BentBeam(BentBeam&&) = default;
   BentBeam& operator=(BentBeam&&) = default;
   ~BentBeam() override = default;
+  std::unique_ptr<elliptic::analytic_data::AnalyticSolution> get_clone()
+      const override {
+    return std::make_unique<BentBeam>(*this);
+  }
 
   /// \cond
   explicit BentBeam(CkMigrateMessage* m)

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.hpp
@@ -170,6 +170,10 @@ class HalfSpaceMirror : public elliptic::analytic_data::AnalyticSolution {
   HalfSpaceMirror(HalfSpaceMirror&&) = default;
   HalfSpaceMirror& operator=(HalfSpaceMirror&&) = default;
   ~HalfSpaceMirror() override = default;
+  std::unique_ptr<elliptic::analytic_data::AnalyticSolution> get_clone()
+      const override {
+    return std::make_unique<HalfSpaceMirror>(*this);
+  }
 
   /// \cond
   explicit HalfSpaceMirror(CkMigrateMessage* m)

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/Zero.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/Zero.hpp
@@ -35,6 +35,10 @@ class Zero : public elliptic::analytic_data::AnalyticSolution {
   Zero(Zero&&) = default;
   Zero& operator=(Zero&&) = default;
   ~Zero() override = default;
+  std::unique_ptr<elliptic::analytic_data::AnalyticSolution> get_clone()
+      const override {
+    return std::make_unique<Zero>(*this);
+  }
 
   /// \cond
   explicit Zero(CkMigrateMessage* m)

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/Lorentzian.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/Lorentzian.hpp
@@ -76,6 +76,10 @@ class Lorentzian : public elliptic::analytic_data::AnalyticSolution {
   Lorentzian(Lorentzian&&) = default;
   Lorentzian& operator=(Lorentzian&&) = default;
   ~Lorentzian() override = default;
+  std::unique_ptr<elliptic::analytic_data::AnalyticSolution> get_clone()
+      const override {
+    return std::make_unique<Lorentzian>(*this);
+  }
 
   /// \cond
   explicit Lorentzian(CkMigrateMessage* m)

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.hpp
@@ -83,6 +83,10 @@ class Moustache : public elliptic::analytic_data::AnalyticSolution {
   Moustache(Moustache&&) = default;
   Moustache& operator=(Moustache&&) = default;
   ~Moustache() override = default;
+  std::unique_ptr<elliptic::analytic_data::AnalyticSolution> get_clone()
+      const override {
+    return std::make_unique<Moustache>(*this);
+  }
 
   /// \cond
   explicit Moustache(CkMigrateMessage* m)

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/ProductOfSinusoids.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/ProductOfSinusoids.hpp
@@ -75,6 +75,10 @@ class ProductOfSinusoids : public elliptic::analytic_data::AnalyticSolution {
   ProductOfSinusoids(ProductOfSinusoids&&) = default;
   ProductOfSinusoids& operator=(ProductOfSinusoids&&) = default;
   ~ProductOfSinusoids() override = default;
+  std::unique_ptr<elliptic::analytic_data::AnalyticSolution> get_clone()
+      const override {
+    return std::make_unique<ProductOfSinusoids>(*this);
+  }
 
   /// \cond
   explicit ProductOfSinusoids(CkMigrateMessage* m)

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/Zero.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/Zero.hpp
@@ -34,6 +34,10 @@ class Zero : public elliptic::analytic_data::AnalyticSolution {
   Zero(Zero&&) = default;
   Zero& operator=(Zero&&) = default;
   ~Zero() override = default;
+  std::unique_ptr<elliptic::analytic_data::AnalyticSolution> get_clone()
+      const override {
+    return std::make_unique<Zero>(*this);
+  }
 
   /// \cond
   explicit Zero(CkMigrateMessage* m)

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/CMakeLists.txt
@@ -35,6 +35,7 @@ target_link_libraries(
   ErrorHandling
   GeneralRelativity
   GeneralRelativitySolutions
+  InitialDataUtilities
   Options
   Parallel
   Utilities

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/CommonVariables.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/CommonVariables.hpp
@@ -21,8 +21,13 @@ using common_tags = tmpl::push_back<
     // Solved variables
     Tags::ConformalFactor<DataType>, Tags::LapseTimesConformalFactor<DataType>,
     Tags::ShiftExcess<DataType, 3, Frame::Inertial>,
-    // GR lapse and shift
+    // ADM variables
     gr::Tags::Lapse<DataType>, gr::Tags::Shift<3, Frame::Inertial, DataType>,
+    gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>,
+    gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataType>,
+    ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>,
+                  tmpl::size_t<3>, Frame::Inertial>,
+    gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataType>,
     // Derivatives of solved variables
     ::Tags::deriv<Tags::ConformalFactor<DataType>, tmpl::size_t<3>,
                   Frame::Inertial>,
@@ -63,6 +68,20 @@ struct CommonVariables : AnalyticData::CommonVariables<DataType, Cache> {
                           gsl::not_null<Cache*> cache,
                           gr::Tags::Lapse<DataType> /*meta*/) const = 0;
   virtual void operator()(
+      gsl::not_null<tnsr::ii<DataType, Dim>*> spatial_metric,
+      gsl::not_null<Cache*> cache,
+      gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType> /*meta*/) const;
+  virtual void operator()(
+      gsl::not_null<tnsr::II<DataType, Dim>*> inv_spatial_metric,
+      gsl::not_null<Cache*> cache,
+      gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataType> /*meta*/)
+      const;
+  virtual void operator()(
+      gsl::not_null<tnsr::ijj<DataType, Dim>*> deriv_spatial_metric,
+      gsl::not_null<Cache*> cache,
+      ::Tags::deriv<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>,
+                    tmpl::size_t<Dim>, Frame::Inertial> /*meta*/) const;
+  virtual void operator()(
       gsl::not_null<tnsr::i<DataType, Dim>*> deriv_conformal_factor,
       gsl::not_null<Cache*> cache,
       ::Tags::deriv<Tags::ConformalFactor<DataType>, tmpl::size_t<Dim>,
@@ -94,6 +113,11 @@ struct CommonVariables : AnalyticData::CommonVariables<DataType, Cache> {
   virtual void operator()(
       gsl::not_null<tnsr::I<DataType, Dim>*> shift, gsl::not_null<Cache*> cache,
       gr::Tags::Shift<Dim, Frame::Inertial, DataType> /*meta*/) const;
+  virtual void operator()(
+      gsl::not_null<tnsr::ii<DataType, Dim>*> extrinsic_curvature,
+      gsl::not_null<Cache*> cache,
+      gr::Tags::ExtrinsicCurvature<Dim, Frame::Inertial, DataType> /*meta*/)
+      const = 0;
   virtual void operator()(
       gsl::not_null<Scalar<DataType>*>
           longitudinal_shift_minus_dt_conformal_metric_square,

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/ConstantDensityStar.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/ConstantDensityStar.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <limits>
+#include <memory>
 #include <pup.h>
 
 #include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
@@ -115,6 +116,10 @@ class ConstantDensityStar : public elliptic::analytic_data::AnalyticSolution {
   ConstantDensityStar(ConstantDensityStar&&) = default;
   ConstantDensityStar& operator=(ConstantDensityStar&&) = default;
   ~ConstantDensityStar() = default;
+  std::unique_ptr<elliptic::analytic_data::AnalyticSolution> get_clone()
+      const override {
+    return std::make_unique<ConstantDensityStar>(*this);
+  }
 
   /// \cond
   explicit ConstantDensityStar(CkMigrateMessage* m)

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/Flatness.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/Flatness.hpp
@@ -61,6 +61,8 @@ class Flatness : public elliptic::analytic_data::AnalyticSolution {
     using supported_tags_zero = tmpl::list<
         ::Tags::deriv<Tags::ConformalMetric<DataType, 3, Frame::Inertial>,
                       tmpl::size_t<3>, Frame::Inertial>,
+        ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>,
+                      tmpl::size_t<3>, Frame::Inertial>,
         Tags::ConformalChristoffelFirstKind<DataType, 3, Frame::Inertial>,
         Tags::ConformalChristoffelSecondKind<DataType, 3, Frame::Inertial>,
         Tags::ConformalChristoffelContracted<DataType, 3, Frame::Inertial>,
@@ -76,6 +78,7 @@ class Flatness : public elliptic::analytic_data::AnalyticSolution {
         Tags::ShiftBackground<DataType, 3, Frame::Inertial>,
         Tags::ShiftExcess<DataType, 3, Frame::Inertial>,
         Tags::ShiftStrain<DataType, 3, Frame::Inertial>,
+        gr::Tags::Shift<3, Frame::Inertial, DataType>,
         ::Tags::Flux<Tags::ConformalFactor<DataType>, tmpl::size_t<3>,
                      Frame::Inertial>,
         ::Tags::Flux<Tags::LapseTimesConformalFactor<DataType>, tmpl::size_t<3>,
@@ -89,6 +92,7 @@ class Flatness : public elliptic::analytic_data::AnalyticSolution {
         ::Tags::div<Tags::LongitudinalShiftBackgroundMinusDtConformalMetric<
             DataVector, 3, Frame::Inertial>>,
         Tags::ShiftDotDerivExtrinsicCurvatureTrace<DataVector>,
+        gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>,
         gr::Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 0>,
         gr::Tags::Conformal<gr::Tags::StressTrace<DataType>, 0>,
         gr::Tags::Conformal<
@@ -106,10 +110,13 @@ class Flatness : public elliptic::analytic_data::AnalyticSolution {
         ::Tags::FixedSource<Tags::ShiftExcess<DataType, 3, Frame::Inertial>>>;
     using supported_tags_one =
         tmpl::list<Tags::ConformalFactor<DataType>,
-                   Tags::LapseTimesConformalFactor<DataType>>;
-    using supported_tags_metric =
-        tmpl::list<Tags::ConformalMetric<DataType, 3, Frame::Inertial>,
-                   Tags::InverseConformalMetric<DataType, 3, Frame::Inertial>>;
+                   Tags::LapseTimesConformalFactor<DataType>,
+                   gr::Tags::Lapse<DataType>>;
+    using supported_tags_metric = tmpl::list<
+        Tags::ConformalMetric<DataType, 3, Frame::Inertial>,
+        Tags::InverseConformalMetric<DataType, 3, Frame::Inertial>,
+        gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>,
+        gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataType>>;
     using supported_tags = tmpl::append<supported_tags_zero, supported_tags_one,
                                         supported_tags_metric>;
     static_assert(

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/Flatness.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/Flatness.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <limits>
+#include <memory>
 #include <ostream>
 
 #include "DataStructures/DataBox/Prefixes.hpp"
@@ -41,6 +42,10 @@ class Flatness : public elliptic::analytic_data::AnalyticSolution {
   Flatness(Flatness&&) = default;
   Flatness& operator=(Flatness&&) = default;
   ~Flatness() = default;
+  std::unique_ptr<elliptic::analytic_data::AnalyticSolution> get_clone()
+      const override {
+    return std::make_unique<Flatness>(*this);
+  }
 
   /// \cond
   explicit Flatness(CkMigrateMessage* m)

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.hpp
@@ -347,6 +347,11 @@ struct SchwarzschildVariables
       gsl::not_null<Cache*> cache,
       Xcts::Tags::ShiftStrain<DataType, 3, Frame::Inertial> /*meta*/)
       const override;
+  void operator()(
+      gsl::not_null<tnsr::ii<DataType, 3>*> extrinsic_curvature,
+      gsl::not_null<Cache*> cache,
+      gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataType> /*meta*/)
+      const override;
   void operator()(gsl::not_null<Scalar<DataType>*> energy_density,
                   gsl::not_null<Cache*> cache,
                   gr::Tags::Conformal<gr::Tags::EnergyDensity<DataType>,

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <limits>
+#include <memory>
 #include <ostream>
 
 #include "DataStructures/CachedTempBuffer.hpp"
@@ -388,6 +389,10 @@ class Schwarzschild : public elliptic::analytic_data::AnalyticSolution,
       : elliptic::analytic_data::AnalyticSolution(m) {}
   using PUP::able::register_constructor;
   WRAPPED_PUPable_decl_template(Schwarzschild);
+  std::unique_ptr<elliptic::analytic_data::AnalyticSolution> get_clone()
+      const override {
+    return std::make_unique<Schwarzschild>(*this);
+  }
   /// \endcond
 
   template <typename DataType, typename... RequestedTags>

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.cpp
@@ -28,6 +28,37 @@ namespace detail {
 
 template <typename DataType>
 void WrappedGrVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::ii<DataType, Dim>*> spatial_metric,
+    const gsl::not_null<Cache*> /*cache*/,
+    gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType> /*meta*/) const {
+  *spatial_metric =
+      get<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>>(gr_solution);
+}
+
+template <typename DataType>
+void WrappedGrVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::II<DataType, Dim>*> inv_spatial_metric,
+    const gsl::not_null<Cache*> /*cache*/,
+    gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataType> /*meta*/)
+    const {
+  *inv_spatial_metric =
+      get<gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataType>>(
+          gr_solution);
+}
+
+template <typename DataType>
+void WrappedGrVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::ijj<DataType, Dim>*> deriv_spatial_metric,
+    const gsl::not_null<Cache*> /*cache*/,
+    ::Tags::deriv<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>,
+                  tmpl::size_t<Dim>, Frame::Inertial> /*meta*/) const {
+  *deriv_spatial_metric =
+      get<::Tags::deriv<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>,
+                        tmpl::size_t<Dim>, Frame::Inertial>>(gr_solution);
+}
+
+template <typename DataType>
+void WrappedGrVariables<DataType>::operator()(
     const gsl::not_null<tnsr::ii<DataType, Dim>*> conformal_metric,
     const gsl::not_null<Cache*> cache,
     Xcts::Tags::ConformalMetric<DataType, Dim, Frame::Inertial> /*meta*/)
@@ -223,6 +254,16 @@ void WrappedGrVariables<DataType>::operator()(
   Elasticity::strain(shift_strain, deriv_shift, conformal_metric,
                      deriv_conformal_metric, conformal_christoffel_first_kind,
                      shift);
+}
+
+template <typename DataType>
+void WrappedGrVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::ii<DataType, 3>*> extrinsic_curvature,
+    const gsl::not_null<Cache*> /*cache*/,
+    gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataType> /*meta*/) const {
+  *extrinsic_curvature =
+      get<gr::Tags::ExtrinsicCurvature<Dim, Frame::Inertial, DataType>>(
+          gr_solution);
 }
 
 template <typename DataType>

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.hpp
@@ -89,6 +89,21 @@ struct WrappedGrVariables
       ::Tags::deriv<Xcts::Tags::ConformalMetric<DataType, Dim, Frame::Inertial>,
                     tmpl::size_t<Dim>, Frame::Inertial> /*meta*/)
       const override;
+  void operator()(gsl::not_null<tnsr::ii<DataType, Dim>*> spatial_metric,
+                  gsl::not_null<Cache*> cache,
+                  gr::Tags::SpatialMetric<Dim, Frame::Inertial,
+                                          DataType> /*meta*/) const override;
+  void operator()(
+      gsl::not_null<tnsr::II<DataType, Dim>*> inv_spatial_metric,
+      gsl::not_null<Cache*> cache,
+      gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataType> /*meta*/)
+      const override;
+  void operator()(
+      gsl::not_null<tnsr::ijj<DataType, Dim>*> deriv_spatial_metric,
+      gsl::not_null<Cache*> cache,
+      ::Tags::deriv<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>,
+                    tmpl::size_t<Dim>, Frame::Inertial> /*meta*/)
+      const override;
   void operator()(
       gsl::not_null<Scalar<DataType>*> trace_extrinsic_curvature,
       gsl::not_null<Cache*> cache,
@@ -139,6 +154,11 @@ struct WrappedGrVariables
       gsl::not_null<tnsr::ii<DataType, Dim>*> shift_strain,
       gsl::not_null<Cache*> cache,
       Xcts::Tags::ShiftStrain<DataType, Dim, Frame::Inertial> /*meta*/)
+      const override;
+  void operator()(
+      gsl::not_null<tnsr::ii<DataType, 3>*> extrinsic_curvature,
+      gsl::not_null<Cache*> cache,
+      gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataType> /*meta*/)
       const override;
   void operator()(
       gsl::not_null<Scalar<DataType>*> energy_density,

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.hpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <limits>
+#include <memory>
 #include <pup.h>
 
 #include "DataStructures/CachedTempBuffer.hpp"
@@ -202,6 +203,10 @@ class WrappedGr : public elliptic::analytic_data::AnalyticSolution,
   using GrSolution::GrSolution;
   using PUP::able::register_constructor;
   WRAPPED_PUPable_decl_template(WrappedGr<GrSolution>);
+  std::unique_ptr<elliptic::analytic_data::AnalyticSolution> get_clone()
+      const override {
+    return std::make_unique<WrappedGr<GrSolution>>(*this);
+  }
 
   template <typename DataType, typename... RequestedTags>
   tuples::TaggedTuple<RequestedTags...> variables(

--- a/src/PointwiseFunctions/InitialDataUtilities/AnalyticSolution.hpp
+++ b/src/PointwiseFunctions/InitialDataUtilities/AnalyticSolution.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <memory>
 #include <pup.h>
 
 #include "Parallel/CharmPupable.hpp"
@@ -34,5 +35,7 @@ class AnalyticSolution : public elliptic::analytic_data::InitialGuess,
   explicit AnalyticSolution(CkMigrateMessage* msg) : PUP::able(msg) {}
   WRAPPED_PUPable_abstract(AnalyticSolution);
   /// \endcond
+
+  virtual std::unique_ptr<AnalyticSolution> get_clone() const = 0;
 };
 }  // namespace elliptic::analytic_data

--- a/src/PointwiseFunctions/Xcts/CMakeLists.txt
+++ b/src/PointwiseFunctions/Xcts/CMakeLists.txt
@@ -8,6 +8,7 @@ add_spectre_library(${LIBRARY})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  ExtrinsicCurvature.cpp
   LongitudinalOperator.cpp
   SpacetimeQuantities.cpp
   )
@@ -16,6 +17,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  ExtrinsicCurvature.hpp
   LongitudinalOperator.hpp
   SpacetimeQuantities.hpp
   )

--- a/src/PointwiseFunctions/Xcts/ExtrinsicCurvature.cpp
+++ b/src/PointwiseFunctions/Xcts/ExtrinsicCurvature.cpp
@@ -1,0 +1,61 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/Xcts/ExtrinsicCurvature.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Xcts {
+
+template <typename DataType>
+void extrinsic_curvature(
+    const gsl::not_null<tnsr::ii<DataType, 3>*> result,
+    const Scalar<DataType>& conformal_factor, const Scalar<DataType>& lapse,
+    const tnsr::ii<DataType, 3>& conformal_metric,
+    const tnsr::II<DataType, 3>& longitudinal_shift_minus_dt_conformal_metric,
+    const Scalar<DataType>& trace_extrinsic_curvature) {
+  TensorExpressions::evaluate<ti_i, ti_j>(
+      result,
+      pow<4>(conformal_factor()) *
+          (conformal_metric(ti_i, ti_k) * conformal_metric(ti_j, ti_l) *
+               longitudinal_shift_minus_dt_conformal_metric(ti_K, ti_L) /
+               (2. * lapse()) +
+           conformal_metric(ti_i, ti_j) * trace_extrinsic_curvature() / 3.));
+}
+
+template <typename DataType>
+tnsr::ii<DataType, 3> extrinsic_curvature(
+    const Scalar<DataType>& conformal_factor, const Scalar<DataType>& lapse,
+    const tnsr::ii<DataType, 3>& conformal_metric,
+    const tnsr::II<DataType, 3>& longitudinal_shift_minus_dt_conformal_metric,
+    const Scalar<DataType>& trace_extrinsic_curvature) {
+  tnsr::ii<DataType, 3> result{get_size(get(conformal_factor))};
+  extrinsic_curvature(
+      make_not_null(&result), conformal_factor, lapse, conformal_metric,
+      longitudinal_shift_minus_dt_conformal_metric, trace_extrinsic_curvature);
+  return result;
+}
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                             \
+  template tnsr::ii<DTYPE(data), 3> extrinsic_curvature( \
+      const Scalar<DTYPE(data)>& conformal_factor,       \
+      const Scalar<DTYPE(data)>& lapse,                  \
+      const tnsr::ii<DTYPE(data), 3>& conformal_metric,  \
+      const tnsr::II<DTYPE(data), 3>&                    \
+          longitudinal_shift_minus_dt_conformal_metric,  \
+      const Scalar<DTYPE(data)>& trace_extrinsic_curvature);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
+
+#undef DTYPE
+#undef INSTANTIATE
+
+}  // namespace Xcts

--- a/src/PointwiseFunctions/Xcts/ExtrinsicCurvature.hpp
+++ b/src/PointwiseFunctions/Xcts/ExtrinsicCurvature.hpp
@@ -1,0 +1,56 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Xcts {
+
+/// @{
+/*!
+ * \brief Extrinsic curvature computed from the conformal decomposition used in
+ * the XCTS system.
+ *
+ * The extrinsic curvature decomposition is (see Eq. 3.113 in
+ * \cite BaumgarteShapiro):
+ *
+ * \begin{equation}
+ *   K_{ij} = A_{ij} + \frac{1}{3}\gamma_{ij}K
+ *     = \frac{\psi^4}{2\lapse}\left((\bar{L}\beta)_{ij} - \bar{u}_{ij}\right)
+ *       + \frac{\psi^4}{3} \bar{\gamma}_{ij} K
+ * \end{equation}
+ *
+ * \param result output buffer for the extrinsic curvature
+ * \param conformal_factor the conformal factor $\psi$
+ * \param lapse the lapse $\alpha$
+ * \param conformal_metric the conformal metric $\bar{\gamma}_{ij}$
+ * \param longitudinal_shift_minus_dt_conformal_metric the term
+ * $(\bar{L}\beta)^{ij} - \bar{u}^{ij}$. Note that $(\bar{L}\beta)^{ij}$ is the
+ * _conformal_ longitudinal shift, and $(\bar{L}\beta)^{ij}=\psi^4(L\beta)^{ij}$
+ * (Eq. 3.98 in \cite BaumgarteShapiro). See also Xcts::longitudinal_operator.
+ * \param trace_extrinsic_curvature the trace of the extrinsic curvature,
+ * $K=\gamma^{ij}K_{ij}$. Note that it is a conformal invariant, $K=\bar{K}$ (by
+ * choice).
+ */
+template <typename DataType>
+void extrinsic_curvature(
+    const gsl::not_null<tnsr::ii<DataType, 3>*> result,
+    const Scalar<DataType>& conformal_factor, const Scalar<DataType>& lapse,
+    const tnsr::ii<DataType, 3>& conformal_metric,
+    const tnsr::II<DataType, 3>& longitudinal_shift_minus_dt_conformal_metric,
+    const Scalar<DataType>& trace_extrinsic_curvature);
+
+/// Return-by-value overload
+template <typename DataType>
+tnsr::ii<DataType, 3> extrinsic_curvature(
+    const Scalar<DataType>& conformal_factor, const Scalar<DataType>& lapse,
+    const tnsr::ii<DataType, 3>& conformal_metric,
+    const tnsr::II<DataType, 3>& longitudinal_shift_minus_dt_conformal_metric,
+    const Scalar<DataType>& trace_extrinsic_curvature);
+/// @}
+
+}  // namespace Xcts

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -8,13 +8,13 @@
 Background: &background
   Binary:
     XCoords: [&x_left -8., &x_right 8.]
-    ObjectA:
-      KerrSchild: &kerr_left
+    ObjectA: &kerr_left
+      KerrSchild:
         Mass: 0.4229
         Spin: [0., 0., 0.]
         Center: [0., 0., 0.]
-    ObjectB:
-      KerrSchild: &kerr_right
+    ObjectB: &kerr_right
+      KerrSchild:
         Mass: 0.4229
         Spin: [0., 0., 0.]
         Center: [0., 0., 0.]

--- a/tests/Unit/Elliptic/Actions/Test_InitializeAnalyticSolution.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeAnalyticSolution.cpp
@@ -52,6 +52,10 @@ struct AnalyticSolution : elliptic::analytic_data::AnalyticSolution {
   explicit AnalyticSolution(CkMigrateMessage* m)
       : elliptic::analytic_data::AnalyticSolution(m) {}
   WRAPPED_PUPable_decl_template(AnalyticSolution);
+  std::unique_ptr<elliptic::analytic_data::AnalyticSolution> get_clone()
+      const override {
+    return std::make_unique<AnalyticSolution>(*this);
+  }
 
   static tuples::TaggedTuple<ScalarFieldTag> variables(
       const tnsr::I<DataVector, 1>& x, tmpl::list<ScalarFieldTag> /*meta*/) {

--- a/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/Xcts/VerifySolution.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/Xcts/VerifySolution.hpp
@@ -13,11 +13,153 @@
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/TestingFramework.hpp"
 #include "Helpers/PointwiseFunctions/AnalyticSolutions/FirstOrderEllipticSolutionsTestHelpers.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
 
 namespace TestHelpers::Xcts::Solutions {
 
 namespace detail {
+
+// Verify the Hamiltonian and momentum constraints are satisfied. This is only a
+// consistency check of the solution, not a test of the system.
+template <typename Solution>
+void verify_adm_constraints(const Solution& solution,
+                            const std::array<double, 3>& center,
+                            const double inner_radius,
+                            const double outer_radius, const double tolerance) {
+  INFO("ADM constraints");
+  Approx custom_approx = Approx::custom().epsilon(tolerance).scale(1.0);
+
+  // Set up a grid for evaluating the solution and taking numerical derivatives
+  const Mesh<3> mesh{12, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto};
+  const size_t num_points = mesh.number_of_grid_points();
+  using AffineMap = domain::CoordinateMaps::Affine;
+  using AffineMap3D =
+      domain::CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
+  const domain::CoordinateMap<Frame::ElementLogical, Frame::Inertial,
+                              AffineMap3D>
+      coord_map{
+          {{-1., 1., center[0] + inner_radius, center[0] + outer_radius},
+           {-1., 1., center[1] + inner_radius, center[1] + outer_radius},
+           {-1., 1., center[2] + inner_radius, center[2] + outer_radius}}};
+  const auto logical_coords = logical_coordinates(mesh);
+  const auto x = coord_map(logical_coords);
+  const auto inv_jacobian = coord_map.inv_jacobian(logical_coords);
+
+  // Retrieve analytic variables
+  using analytic_tags = tmpl::list<
+      ::Xcts::Tags::ConformalFactor<DataVector>,
+      ::Xcts::Tags::ConformalMetric<DataVector, 3, Frame::Inertial>,
+      gr::Tags::Lapse<DataVector>,
+      gr::Tags::TraceExtrinsicCurvature<DataVector>,
+      gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>,
+      gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+      gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>,
+      ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+                    tmpl::size_t<3>, Frame::Inertial>,
+      ::Xcts::Tags::LongitudinalShiftExcess<DataVector, 3, Frame::Inertial>,
+      ::Xcts::Tags::LongitudinalShiftBackgroundMinusDtConformalMetric<
+          DataVector, 3, Frame::Inertial>,
+      gr::Tags::Conformal<gr::Tags::EnergyDensity<DataVector>, 0>,
+      gr::Tags::Conformal<
+          gr::Tags::MomentumDensity<3, Frame::Inertial, DataVector>, 0>>;
+  const auto analytic_vars = solution.variables(x, analytic_tags{});
+  const auto& conformal_factor =
+      get<::Xcts::Tags::ConformalFactor<DataVector>>(analytic_vars);
+  const auto& conformal_metric =
+      get<::Xcts::Tags::ConformalMetric<DataVector, 3, Frame::Inertial>>(
+          analytic_vars);
+  const auto& lapse = get<gr::Tags::Lapse<DataVector>>(analytic_vars);
+  const auto& extrinsic_curvature =
+      get<gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>>(
+          analytic_vars);
+  const auto& trace_extrinsic_curvature =
+      get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(analytic_vars);
+  const auto& spatial_metric =
+      get<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>(
+          analytic_vars);
+  const auto& inv_spatial_metric =
+      get<gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>>(
+          analytic_vars);
+  const auto& deriv_spatial_metric =
+      get<::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+                        tmpl::size_t<3>, Frame::Inertial>>(analytic_vars);
+  const auto& longitudinal_shift_excess = get<
+      ::Xcts::Tags::LongitudinalShiftExcess<DataVector, 3, Frame::Inertial>>(
+      analytic_vars);
+  const auto& longitudinal_shift_background_minus_dt_conformal_metric =
+      get<::Xcts::Tags::LongitudinalShiftBackgroundMinusDtConformalMetric<
+          DataVector, 3, Frame::Inertial>>(analytic_vars);
+  const auto& energy_density =
+      get<gr::Tags::Conformal<gr::Tags::EnergyDensity<DataVector>, 0>>(
+          analytic_vars);
+  const auto& momentum_density = get<gr::Tags::Conformal<
+      gr::Tags::MomentumDensity<3, Frame::Inertial, DataVector>, 0>>(
+      analytic_vars);
+
+  // Compute Christoffels and Ricci
+  const auto spatial_christoffel =
+      gr::christoffel_second_kind(deriv_spatial_metric, inv_spatial_metric);
+  const auto deriv_spatial_christoffel =
+      partial_derivative(spatial_christoffel, mesh, inv_jacobian);
+  const auto spatial_ricci =
+      gr::ricci_tensor(spatial_christoffel, deriv_spatial_christoffel);
+  const auto ricci_scalar = trace(spatial_ricci, inv_spatial_metric);
+
+  // Check extrinsic curvature trace
+  CHECK_ITERABLE_APPROX(trace(extrinsic_curvature, inv_spatial_metric),
+                        trace_extrinsic_curvature);
+
+  // Check extrinsic curvature decomposition
+  //   K_ij = \psi^-2 \bar{A}_ij + 1/3 \gamma_ij K
+  // with
+  //   \bar{A}^ij = \psi^6 / (2 \alpha) * (\bar{L}\beta^ij - \bar{u}^ij)
+  tnsr::ii<DataVector, 3> composed_extcurv{};
+  TensorExpressions::evaluate<ti_i, ti_j>(
+      make_not_null(&composed_extcurv),
+      pow<4>(conformal_factor()) / (2. * lapse()) *
+              (longitudinal_shift_excess(ti_K, ti_L) +
+               longitudinal_shift_background_minus_dt_conformal_metric(ti_K,
+                                                                       ti_L)) *
+              conformal_metric(ti_i, ti_k) * conformal_metric(ti_l, ti_j) +
+          spatial_metric(ti_i, ti_j) * trace_extrinsic_curvature() / 3.);
+  CHECK_ITERABLE_APPROX(composed_extcurv, extrinsic_curvature);
+
+  // Check Hamiltonian constraint R + K^2 + K_ij K^ij = 16 \pi \rho
+  const Scalar<DataVector> hamiltonian_constraint = TensorExpressions::evaluate(
+      ricci_scalar() + square(trace_extrinsic_curvature()) -
+      extrinsic_curvature(ti_i, ti_j) * extrinsic_curvature(ti_k, ti_l) *
+          inv_spatial_metric(ti_I, ti_K) * inv_spatial_metric(ti_J, ti_L) -
+      16. * M_PI * energy_density());
+  CHECK_ITERABLE_CUSTOM_APPROX(get(hamiltonian_constraint),
+                               DataVector(num_points, 0.), custom_approx);
+
+  // Check momentum constraint \nabla_j (K^ij - K \gamma^ij) = 8 \pi S^i
+  tnsr::II<DataVector, 3> extcurv_min_trace{};
+  TensorExpressions::evaluate<ti_I, ti_J>(
+      make_not_null(&extcurv_min_trace),
+      extrinsic_curvature(ti_k, ti_l) * inv_spatial_metric(ti_I, ti_K) *
+              inv_spatial_metric(ti_J, ti_L) -
+          trace_extrinsic_curvature() * inv_spatial_metric(ti_I, ti_J));
+  const tnsr::iJJ<DataVector, 3> deriv_extcurv_min_trace =
+      partial_derivative(extcurv_min_trace, mesh, inv_jacobian);
+  const tnsr::I<DataVector, 3> momentum_constraint =
+      TensorExpressions::evaluate<ti_I>(
+          deriv_extcurv_min_trace(ti_j, ti_I, ti_J) +
+          spatial_christoffel(ti_I, ti_k, ti_j) *
+              extcurv_min_trace(ti_K, ti_J) +
+          spatial_christoffel(ti_J, ti_k, ti_j) *
+              extcurv_min_trace(ti_I, ti_K) -
+          8. * M_PI * momentum_density(ti_I));
+  CHECK_ITERABLE_CUSTOM_APPROX(momentum_constraint,
+                               (tnsr::I<DataVector, 3>(num_points, 0.)),
+                               custom_approx);
+}
+
 template <::Xcts::Equations EnabledEquations,
           ::Xcts::Geometry ConformalGeometry, int ConformalMatterScale,
           typename Solution>
@@ -64,6 +206,8 @@ void verify_solution(const Solution& solution,
                      const std::array<double, 3>& center,
                      const double inner_radius, const double outer_radius,
                      const double tolerance) {
+  detail::verify_adm_constraints(solution, center, inner_radius, outer_radius,
+                                 tolerance);
   if constexpr (ConformalGeometry == ::Xcts::Geometry::FlatCartesian) {
     INVOKE_TEST_FUNCTION(
         detail::verify_solution_impl,

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_Schwarzschild.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_Schwarzschild.cpp
@@ -148,7 +148,7 @@ void test_solution(const double mass,
 
 }  // namespace
 
-// [[Timeout, 8]]
+// [[Timeout, 15]]
 SPECTRE_TEST_CASE(
     "Unit.PointwiseFunctions.AnalyticSolutions.Xcts.Schwarzschild",
     "[PointwiseFunctions][Unit]") {

--- a/tests/Unit/PointwiseFunctions/Xcts/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Xcts/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY Test_XctsPointwiseFunctions)
 
 set(LIBRARY_SOURCES
+  Test_ExtrinsicCurvature.cpp
   Test_LongitudinalOperator.cpp
   Test_SpacetimeQuantities.cpp
   )

--- a/tests/Unit/PointwiseFunctions/Xcts/ExtrinsicCurvature.py
+++ b/tests/Unit/PointwiseFunctions/Xcts/ExtrinsicCurvature.py
@@ -1,0 +1,15 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def extrinsic_curvature(conformal_factor, lapse, conformal_metric,
+                        longitudinal_shift_minus_dt_conformal_metric,
+                        trace_extrinsic_curvature):
+    longitudinal_shift_minus_dt_conformal_metric_lower = np.einsum(
+        'ij,ik,jl', longitudinal_shift_minus_dt_conformal_metric,
+        conformal_metric, conformal_metric)
+    return conformal_factor**4 * (
+        longitudinal_shift_minus_dt_conformal_metric_lower / 2. / lapse +
+        conformal_metric * trace_extrinsic_curvature / 3.)

--- a/tests/Unit/PointwiseFunctions/Xcts/Test_ExtrinsicCurvature.cpp
+++ b/tests/Unit/PointwiseFunctions/Xcts/Test_ExtrinsicCurvature.cpp
@@ -1,0 +1,27 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "PointwiseFunctions/Xcts/ExtrinsicCurvature.hpp"
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Xcts.ExtrinsicCurvature",
+                  "[Unit][PointwiseFunctions]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{"PointwiseFunctions/Xcts"};
+  const DataVector used_for_size{5};
+  pypp::check_with_random_values<1>(
+      static_cast<void (*)(
+          gsl::not_null<tnsr::ii<DataVector, 3>*>, const Scalar<DataVector>&,
+          const Scalar<DataVector>&, const tnsr::ii<DataVector, 3>&,
+          const tnsr::II<DataVector, 3>&, const Scalar<DataVector>&)>(
+          &Xcts::extrinsic_curvature<DataVector>),
+      "ExtrinsicCurvature", {"extrinsic_curvature"}, {{{-1., 1.}}},
+      used_for_size);
+}


### PR DESCRIPTION
## Proposed changes

Use analytic solution base class in `Xcts::BoundaryConditions::ApparentHorizon`. The `Xcts::AnalyticData::Binary` already supports factory creation. Therefore, this change should enable SKS, SHK, and also mixed superposed KerrSchild/Harmonic coordinates (which I think haven't been tried in SpEC yet?), once a Kerr solution in those coords is implemented.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
