### PR TITLE
Enable TensorExpressions to internally split up equations

### DIFF
--- a/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
+++ b/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
@@ -265,6 +265,21 @@ struct AddSubType {
 };
 }  // namespace detail
 
+/// \ingroup TensorExpressionsGroup
+/// \brief Defines the tensor expression representing the addition or
+/// subtraction of two tensor expressions
+///
+/// \details
+/// For details on aliases and members defined in this class, as well as general
+/// `TensorExpression` terminology used in its members' documentation, see
+/// documentation for `TensorExpression`.
+///
+/// \tparam T1 the left operand expression
+/// \tparam T2 the right operand expression
+/// \tparam ArgsList1 generic `TensorIndex`s of the left operand
+/// \tparam ArgsList2 generic `TensorIndex`s of the right operand
+/// \tparam Sign the sign of the operation selected, 1 for addition or -1 for
+/// subtraction
 template <typename T1, typename T2, typename ArgsList1, typename ArgsList2,
           int Sign>
 struct AddSub;
@@ -353,8 +368,180 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
   static constexpr size_t num_ops_subtree =
       num_ops_left_child + num_ops_right_child + 1;
 
+  // === Properties for splitting up subexpressions along the primary path ===
+  // These definitions only have meaning if this expression actually ends up
+  // being along the primary path that is taken when evaluating the whole tree.
+  // See documentation for `TensorExpression` for more details.
+  /// If on the primary path, whether or not the expression is an ending point
+  /// of a leg
+  static constexpr bool is_primary_end = T1::is_primary_start;
+  /// If on the primary path, this is the remaining number of arithmetic tensor
+  /// operations that need to be done in the subtree of the child along the
+  /// primary path, given that we will have already computed the whole subtree
+  /// at the next lowest leg's starting point.
+  static constexpr size_t num_ops_to_evaluate_primary_left_child =
+      is_primary_end ? 0 : T1::num_ops_to_evaluate_primary_subtree;
+  /// If on the primary path, this is the remaining number of arithmetic tensor
+  /// operations that need to be done in the right operand's subtree. No
+  /// splitting is currently done, so this is just `num_ops_right_child`.
+  static constexpr size_t num_ops_to_evaluate_primary_right_child =
+      num_ops_right_child;
+  /// If on the primary path, this is the remaining number of arithmetic tensor
+  /// operations that need to be done for this expression's subtree, given that
+  /// we will have already computed the subtree at the next lowest leg's
+  /// starting point
+  static constexpr size_t num_ops_to_evaluate_primary_subtree =
+      num_ops_to_evaluate_primary_left_child +
+      num_ops_to_evaluate_primary_right_child + 1;
+  /// If on the primary path, whether or not the expression is a starting point
+  /// of a leg
+  static constexpr bool is_primary_start =
+      num_ops_to_evaluate_primary_subtree >=
+      detail::max_num_ops_in_sub_expression<type>;
+  /// When evaluating along a primary path, whether each operand's subtrees
+  /// should be evaluated separately. Since `DataVector` expression runtime
+  /// scales poorly with increased number of operations, evaluating the two
+  /// expression subtrees separately like this is beneficial when at least one
+  /// of the subtrees contains a large number of operations.
+  static constexpr bool evaluate_children_separately =
+      is_primary_start and (num_ops_to_evaluate_primary_left_child >=
+                                detail::max_num_ops_in_sub_expression<type> or
+                            num_ops_to_evaluate_primary_right_child >=
+                                detail::max_num_ops_in_sub_expression<type>);
+  /// If on the primary path, whether or not the expression's child along the
+  /// primary path is a subtree that contains a starting point of a leg along
+  /// the primary path
+  static constexpr bool primary_child_subtree_contains_primary_start =
+      T1::primary_subtree_contains_primary_start;
+  /// If on the primary path, whether or not this subtree contains a starting
+  /// point of a leg along the primary path
+  static constexpr bool primary_subtree_contains_primary_start =
+      is_primary_start or primary_child_subtree_contains_primary_start;
+
   AddSub(T1 t1, T2 t2) : t1_(std::move(t1)), t2_(std::move(t2)) {}
   ~AddSub() override = default;
+
+  /// \brief Assert that the LHS tensor of the equation does not also appear in
+  /// this expression's subtree
+  template <typename LhsTensor>
+  SPECTRE_ALWAYS_INLINE void assert_lhs_tensor_not_in_rhs_expression(
+      const gsl::not_null<LhsTensor*> lhs_tensor) const {
+    if constexpr (not std::is_base_of_v<NumberAsExpression, T1>) {
+      t1_.assert_lhs_tensor_not_in_rhs_expression(lhs_tensor);
+    }
+    if constexpr (not std::is_base_of_v<NumberAsExpression, T2>) {
+      t2_.assert_lhs_tensor_not_in_rhs_expression(lhs_tensor);
+    }
+  }
+
+  /// \brief Assert that each instance of the LHS tensor in the RHS tensor
+  /// expression uses the same generic index order that the LHS uses
+  ///
+  /// \tparam LhsTensorIndices the list of generic `TensorIndex`s of the LHS
+  /// result `Tensor` being computed
+  /// \param lhs_tensor the LHS result `Tensor` being computed
+  template <typename LhsTensorIndices, typename LhsTensor>
+  SPECTRE_ALWAYS_INLINE void assert_lhs_tensorindices_same_in_rhs(
+      const gsl::not_null<LhsTensor*> lhs_tensor) const {
+    if constexpr (not std::is_base_of_v<NumberAsExpression, T1>) {
+      t1_.template assert_lhs_tensorindices_same_in_rhs<LhsTensorIndices>(
+          lhs_tensor);
+    }
+    if constexpr (not std::is_base_of_v<NumberAsExpression, T2>) {
+      t2_.template assert_lhs_tensorindices_same_in_rhs<LhsTensorIndices>(
+          lhs_tensor);
+    }
+  }
+
+  /// \brief Return the second operand's multi-index given the first operand's
+  /// multi-index
+  ///
+  /// \param op1_multi_index the multi-index of the left operand
+  /// \return the second operand's multi-index
+  SPECTRE_ALWAYS_INLINE std::array<size_t, num_tensor_indices_op2>
+  get_op2_multi_index(
+      const std::array<size_t, num_tensor_indices>& op1_multi_index) const {
+    if constexpr (ops_have_generic_indices_at_same_positions) {
+      if constexpr (op1_spatial_spacetime_index_positions.size() != 0 or
+                    op2_spatial_spacetime_index_positions.size() != 0) {
+        // Operands have the same generic index order, but at least one of them
+        // has at least one spacetime index where a spatial index has been used,
+        // so we need to compute the 2nd operand's (possibly) shifted
+        // multi-index values
+        constexpr std::array<std::int32_t, num_tensor_indices>
+            spatial_spacetime_index_transformation =
+                detail::spatial_spacetime_index_transformation_from_positions<
+                    num_tensor_indices>(op1_spatial_spacetime_index_positions,
+                                        op2_spatial_spacetime_index_positions);
+        std::array<size_t, num_tensor_indices> op2_multi_index =
+            op1_multi_index;
+        for (size_t i = 0; i < num_tensor_indices; i++) {
+          gsl::at(op2_multi_index, i) = static_cast<size_t>(
+              static_cast<std::int32_t>(gsl::at(op2_multi_index, i)) +
+              gsl::at(spatial_spacetime_index_transformation, i));
+        }
+        return op2_multi_index;
+      } else {
+        // Operands have the same generic index order and neither of them has
+        // a spacetime index where a spatial index has been used, so
+        // both operands have the same multi-index
+        return op1_multi_index;
+      }
+    } else {
+      if constexpr (op1_spatial_spacetime_index_positions.size() != 0 or
+                    op2_spatial_spacetime_index_positions.size() != 0) {
+        // Operands don't have the same generic index order and at least one of
+        // them has at least one spacetime index where a spatial index has been
+        // used, so we need to compute the 2nd operand's (possibly) shifted
+        // multi-index values and reorder them with respect to the 2nd operand's
+        // generic index order
+
+        // The list of positions where generic spatial indices were used for
+        // spacetime indices in the second operand, but rearranged in terms of
+        // the first operand's generic index order.
+        constexpr std::array<size_t,
+                             op2_spatial_spacetime_index_positions.size()>
+            transformed_op2_spatial_spacetime_index_positions = []() {
+              std::array<size_t, op2_spatial_spacetime_index_positions.size()>
+                  transformed_positions{};
+              for (size_t i = 0;
+                   i < op2_spatial_spacetime_index_positions.size(); i++) {
+                gsl::at(transformed_positions, i) =
+                    gsl::at(operand_index_transformation,
+                            gsl::at(op2_spatial_spacetime_index_positions, i));
+              }
+              return transformed_positions;
+            }();
+
+        // According to the transformed positions above, compute the value shift
+        // needed to convert from multi-indices of the first operand to
+        // multi-indices of the 2nd operand (with the generic index order of the
+        // first)
+        constexpr std::array<std::int32_t, num_tensor_indices>
+            spatial_spacetime_index_transformation =
+                detail::spatial_spacetime_index_transformation_from_positions<
+                    num_tensor_indices>(
+                    op1_spatial_spacetime_index_positions,
+                    transformed_op2_spatial_spacetime_index_positions);
+        std::array<size_t, num_tensor_indices> op2_multi_index =
+            op1_multi_index;
+        for (size_t i = 0; i < num_tensor_indices; i++) {
+          gsl::at(op2_multi_index, i) = static_cast<size_t>(
+              static_cast<std::int32_t>(gsl::at(op2_multi_index, i)) +
+              gsl::at(spatial_spacetime_index_transformation, i));
+        }
+        return transform_multi_index(op2_multi_index,
+                                     operand_index_transformation);
+      } else {
+        // Operands don't have the same generic index order, but neither of them
+        // has a spacetime index where a spatial index has been used, so we just
+        // need to reorder the 2nd operand's multi_index according to its
+        // generic index order
+        return transform_multi_index(op1_multi_index,
+                                     operand_index_transformation);
+      }
+    }
+  }
 
   /// \brief Helper function for computing the sum of or difference between
   /// components at given multi-indices from both operands of the expression
@@ -423,88 +610,197 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
   /// tensor
   SPECTRE_ALWAYS_INLINE decltype(auto) get(
       const std::array<size_t, num_tensor_indices>& result_multi_index) const {
-    if constexpr (ops_have_generic_indices_at_same_positions) {
-      if constexpr (op1_spatial_spacetime_index_positions.size() != 0 or
-                    op2_spatial_spacetime_index_positions.size() != 0) {
-        // Operands have the same generic index order, but at least one of them
-        // has at least one spacetime index where a spatial index has been used,
-        // so we need to compute the 2nd operand's (possibly) shifted
-        // multi-index values
-        constexpr std::array<std::int32_t, num_tensor_indices>
-            spatial_spacetime_index_transformation =
-                detail::spatial_spacetime_index_transformation_from_positions<
-                    num_tensor_indices>(op1_spatial_spacetime_index_positions,
-                                        op2_spatial_spacetime_index_positions);
-        std::array<size_t, num_tensor_indices> op2_multi_index =
-            result_multi_index;
-        for (size_t i = 0; i < num_tensor_indices; i++) {
-          gsl::at(op2_multi_index, i) = static_cast<size_t>(
-              static_cast<std::int32_t>(gsl::at(op2_multi_index, i)) +
-              gsl::at(spatial_spacetime_index_transformation, i));
-        }
-        return add_or_subtract(result_multi_index, op2_multi_index);
+    return add_or_subtract(result_multi_index,
+                           get_op2_multi_index(result_multi_index));
+  }
+
+  /// \brief Helper for evaluating the LHS Tensor's result component at this
+  /// subtree by evaluating the two operand's subtrees separately and adding or
+  /// subtracting them
+  ///
+  /// \details
+  /// The left and right operands' subtrees are evaluated successively with
+  /// two separate assignments to the LHS result component. Since `DataVector`
+  /// expression runtime scales poorly with increased number of operations,
+  /// evaluating the two expression subtrees separately like this is beneficial
+  /// when at least one of the subtrees contains a large number of operations.
+  /// Instead of evaluating a larger expression with their combined total number
+  /// of operations, we evaluate two smaller ones.
+  ///
+  /// This function also differs from `add_or_subtract` in that it takes into
+  /// account whether we have already computed part of the result component at a
+  /// lower subtree. In recursively computing this sum/difference, the current
+  /// result component will be substituted in for the most recent (highest)
+  /// subtree below it that has already been evaluated.
+  ///
+  /// \param result_component the LHS tensor component to evaluate
+  /// \param op1_multi_index the multi-index of the component of the first
+  /// operand of the sum or difference to evaluate
+  /// \param op2_multi_index the multi-index of the component of the second
+  /// operand of the sum or difference to evaluate
+  SPECTRE_ALWAYS_INLINE void add_or_subtract_primary_children(
+      type& result_component,
+      const std::array<size_t, num_tensor_indices>& op1_multi_index,
+      const std::array<size_t, num_tensor_indices_op2>& op2_multi_index) const {
+    if constexpr (Sign == 1) {
+      // We're performing addition
+      if constexpr (is_primary_end) {
+        (void)op1_multi_index;
+        // We've already computed the whole child subtree on the primary path,
+        // so just add the result of the other child's subtree to the current
+        // result
+        result_component += t2_.get(op2_multi_index);
       } else {
-        // Operands have the same generic index order and neither of them has
-        // a spacetime index where a spatial index has been used, so
-        // both operands have the same multi-index
-        return add_or_subtract(result_multi_index, result_multi_index);
+        // We haven't yet evaluated the whole subtree of the primary child, so
+        // first assign the result component to be the result of computing the
+        // primary child's subtree
+        result_component = t1_.get_primary(result_component, op1_multi_index);
+        // Now that the primary child's subtree has been computed, add the
+        // result of evaluating the other child's subtree to the current result
+        result_component += t2_.get(op2_multi_index);
       }
     } else {
-      if constexpr (op1_spatial_spacetime_index_positions.size() != 0 or
-                    op2_spatial_spacetime_index_positions.size() != 0) {
-        // Operands don't have the same generic index order and at least one of
-        // them has at least one spacetime index where a spatial index has been
-        // used, so we need to compute the 2nd operand's (possibly) shifted
-        // multi-index values and reorder them with respect to the 2nd operand's
-        // generic index order
-
-        // The list of positions where generic spatial indices were used for
-        // spacetime indices in the second operand, but rearranged in terms of
-        // the first operand's generic index order.
-        constexpr std::array<size_t,
-                             op2_spatial_spacetime_index_positions.size()>
-            transformed_op2_spatial_spacetime_index_positions = []() {
-              std::array<size_t, op2_spatial_spacetime_index_positions.size()>
-                  transformed_positions{};
-              for (size_t i = 0;
-                   i < op2_spatial_spacetime_index_positions.size(); i++) {
-                gsl::at(transformed_positions, i) =
-                    gsl::at(operand_index_transformation,
-                            gsl::at(op2_spatial_spacetime_index_positions, i));
-              }
-              return transformed_positions;
-            }();
-
-        // According to the transformed positions above, compute the value shift
-        // needed to convert from multi-indices of the first operand to
-        // multi-indices of the 2nd operand (with the generic index order of the
-        // first)
-        constexpr std::array<std::int32_t, num_tensor_indices>
-            spatial_spacetime_index_transformation =
-                detail::spatial_spacetime_index_transformation_from_positions<
-                    num_tensor_indices>(
-                    op1_spatial_spacetime_index_positions,
-                    transformed_op2_spatial_spacetime_index_positions);
-        std::array<size_t, num_tensor_indices> op2_multi_index =
-            result_multi_index;
-        for (size_t i = 0; i < num_tensor_indices; i++) {
-          gsl::at(op2_multi_index, i) = static_cast<size_t>(
-              static_cast<std::int32_t>(gsl::at(op2_multi_index, i)) +
-              gsl::at(spatial_spacetime_index_transformation, i));
-        }
-        return add_or_subtract(
-            result_multi_index,
-            transform_multi_index(op2_multi_index,
-                                  operand_index_transformation));
+      // We're performing subtraction
+      if constexpr (is_primary_end) {
+        (void)op1_multi_index;
+        // We've already computed the whole child subtree on the primary path,
+        // so just subtract the result of the other child's subtree from the
+        // current result
+        result_component -= t2_.get(op2_multi_index);
       } else {
-        // Operands don't have the same generic index order, but neither of them
-        // has a spacetime index where a spatial index has been used, so we just
-        // need to reorder the 2nd operand's multi_index according to its
-        // generic index order
-        return add_or_subtract(
-            result_multi_index,
-            transform_multi_index(result_multi_index,
-                                  operand_index_transformation));
+        // We haven't yet evaluated the whole subtree of the primary child, so
+        // first assign the result component to be the result of computing the
+        // primary child's subtree
+        result_component = t1_.get_primary(result_component, op1_multi_index);
+        // Now that the primary child's subtree has been computed, subtract the
+        // result of evaluating the other child's subtree from the current
+        // result
+        result_component -= t2_.get(op2_multi_index);
+      }
+    }
+  }
+
+  /// \brief Evaluate the LHS Tensor's result component at this subtree by
+  /// evaluating the two operand's subtrees separately and adding or subtracting
+  /// them
+  ///
+  /// \details
+  /// See `add_or_subtract_primary_children` for more details
+  ///
+  /// \param result_component the LHS tensor component to evaluate
+  /// \param result_multi_index the multi-index of the component of the result
+  /// tensor to evaluate
+  SPECTRE_ALWAYS_INLINE void evaluate_primary_children(
+      type& result_component,
+      const std::array<size_t, num_tensor_indices>& result_multi_index) const {
+    add_or_subtract_primary_children(result_component, result_multi_index,
+                                     get_op2_multi_index(result_multi_index));
+  }
+
+  /// \brief Helper function for returning the sum of or difference between
+  /// components at given multi-indices from both operands of the expression
+  ///
+  /// \details
+  /// This function differs from `add_or_subtract` in that it takes into account
+  /// whether we have already computed part of the result component at a lower
+  /// subtree. In recursively computing this sum/difference, the current result
+  /// component will be substituted in for the most recent (highest) subtree
+  /// below it that has already been evaluated.
+  ///
+  /// \param result_component the LHS tensor component to evaluate
+  /// \param op1_multi_index the multi-index of the component of the first
+  /// operand
+  /// \param op2_multi_index the multi-index of the component of the second
+  /// operand
+  /// \return the sum of or difference between the two components' values
+  SPECTRE_ALWAYS_INLINE decltype(auto) add_or_subtract_primary(
+      const type& result_component,
+      const std::array<size_t, num_tensor_indices>& op1_multi_index,
+      const std::array<size_t, num_tensor_indices_op2>& op2_multi_index) const {
+    if constexpr (Sign == 1) {
+      // We're performing addition
+      if constexpr (is_primary_end) {
+        (void)op1_multi_index;
+        // We've already computed the whole child subtree on the primary path,
+        // so just add the result of the other child's subtree to the current
+        // result
+        return result_component + t2_.get(op2_multi_index);
+      } else {
+        // We haven't yet evaluated the whole subtree for this expression, so
+        // return the sum of the results of the two operands' subtrees
+        return t1_.get_primary(result_component, op1_multi_index) +
+               t2_.get(op2_multi_index);
+      }
+    } else {
+      // We're performing subtraction
+      if constexpr (is_primary_end) {
+        (void)op1_multi_index;
+        // We've already computed the whole child subtree on the primary path,
+        // so just subtract the result of the other child's subtree from the
+        // current result
+        return result_component - t2_.get(op2_multi_index);
+      } else {
+        // We haven't yet evaluated the whole subtree for this expression, so
+        // return the difference between the results of the two operands'
+        // subtrees
+        return t1_.get_primary(result_component, op1_multi_index) -
+               t2_.get(op2_multi_index);
+      }
+    }
+  }
+
+  /// \brief Return the value of the component at the given multi-index of the
+  /// tensor resulting from addition or subtraction
+  ///
+  /// \details
+  /// This function differs from `get` in that it takes into account whether we
+  /// have already computed part of the result component at a lower subtree.
+  /// In recursively computing this sum/difference, the current result component
+  /// will be substituted in for the most recent (highest) subtree below it that
+  /// has already been evaluated.
+  ///
+  /// \param result_component the LHS tensor component to evaluate
+  /// \param result_multi_index the multi-index of the component of the result
+  /// tensor to retrieve
+  /// \return the value of the component at `result_multi_index` in the result
+  /// tensor
+  SPECTRE_ALWAYS_INLINE decltype(auto) get_primary(
+      const type& result_component,
+      const std::array<size_t, num_tensor_indices>& result_multi_index) const {
+    return add_or_subtract_primary(result_component, result_multi_index,
+                                   get_op2_multi_index(result_multi_index));
+  }
+
+  /// \brief Successively evaluate the LHS Tensor's result component at each
+  /// leg in this expression's subtree
+  ///
+  /// \details
+  /// This function takes into account whether we have already computed part of
+  /// the result component at a lower subtree. In recursively computing this
+  /// sum/difference, the current result component will be substituted in for
+  /// the most recent (highest) subtree below it that has already been
+  /// evaluated.
+  ///
+  /// \param result_component the LHS tensor component to evaluate
+  /// \param result_multi_index the multi-index of the component of the result
+  /// tensor to evaluate
+  SPECTRE_ALWAYS_INLINE void evaluate_primary_subtree(
+      type& result_component,
+      const std::array<size_t, num_tensor_indices>& result_multi_index) const {
+    if constexpr (primary_child_subtree_contains_primary_start) {
+      // The primary child's subtree contains at least one leg, so recurse down
+      // and evaluate that first
+      t1_.evaluate_primary_subtree(result_component, result_multi_index);
+    }
+
+    if constexpr (is_primary_start) {
+      // We want to evaluate the subtree for this expression
+      if constexpr (evaluate_children_separately) {
+        // Evaluate operand's subtrees separately
+        evaluate_primary_children(result_component, result_multi_index);
+      } else {
+        // Evaluate whole subtree as one expression
+        result_component = get_primary(result_component, result_multi_index);
       }
     }
   }

--- a/src/DataStructures/Tensor/Expressions/Contract.hpp
+++ b/src/DataStructures/Tensor/Expressions/Contract.hpp
@@ -20,6 +20,7 @@
 #include "DataStructures/Tensor/Symmetry.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
 #include "Utilities/TMPL.hpp"
 
 /*!
@@ -40,203 +41,722 @@ using indices_contractible = std::bool_constant<
      (I1::index_type == IndexType::Spacetime and I1::dim == I2::dim + 1) or
      (I2::index_type == IndexType::Spacetime and I1::dim + 1 == I2::dim))>;
 
-template <typename T, typename X, typename SymmList, typename IndexList,
-          typename TensorIndexList>
-struct ContractedTypeImpl;
+/// Get the number of index pairs to contract in the operand expression
+template <size_t NumUncontractedIndices>
+constexpr size_t get_num_contracted_index_pairs(
+    const std::array<size_t, NumUncontractedIndices>&
+        uncontracted_tensor_index_values) {
+  size_t count = 0;
+  for (size_t i = 0; i < NumUncontractedIndices; i++) {
+    const size_t current_value = gsl::at(uncontracted_tensor_index_values, i);
+    // Concrete time indices are not contracted
+    if (not detail::is_time_index_value(current_value)) {
+      const size_t opposite_value_to_find =
+          get_tensorindex_value_with_opposite_valence(current_value);
+      for (size_t j = i + 1; j < NumUncontractedIndices; j++) {
+        if (opposite_value_to_find ==
+            gsl::at(uncontracted_tensor_index_values, j)) {
+          // We found both the lower and upper version of a generic index in the
+          // list of generic indices, so we return this pair's positions
+          count++;
+        }
+      }
+    }
+  }
 
-template <typename T, typename X, template <typename...> class SymmList,
-          typename IndexList, typename TensorIndexList, typename... Symm>
-struct ContractedTypeImpl<T, X, SymmList<Symm...>, IndexList, TensorIndexList> {
-  using type = TensorExpression<T, X, Symmetry<Symm::value...>, IndexList,
-                                TensorIndexList>;
-};
+  return count;
+}
 
-template <size_t FirstContractedIndexPos, size_t SecondContractedIndexPos,
-          typename T, typename X, typename Symm, typename IndexList,
-          typename TensorIndexList>
-struct ContractedType {
-  static_assert(FirstContractedIndexPos < SecondContractedIndexPos,
-                "The position of the first provided index to contract must be "
-                "less than the position of the second index to contract.");
-  using contracted_symmetry =
-      tmpl::erase<tmpl::erase<Symm, tmpl::size_t<SecondContractedIndexPos>>,
-                  tmpl::size_t<FirstContractedIndexPos>>;
-  using contracted_index_list = tmpl::erase<
-      tmpl::erase<IndexList, tmpl::size_t<SecondContractedIndexPos>>,
-      tmpl::size_t<FirstContractedIndexPos>>;
-  using contracted_tensorindex_list = tmpl::erase<
-      tmpl::erase<TensorIndexList, tmpl::size_t<SecondContractedIndexPos>>,
-      tmpl::size_t<FirstContractedIndexPos>>;
-  using type = typename ContractedTypeImpl<T, X, contracted_symmetry,
-                                           contracted_index_list,
-                                           contracted_tensorindex_list>::type;
+/// \brief Computes the mapping from the positions of indices in the resultant
+/// contracted tensor to their positions in the operand uncontracted tensor, as
+/// well as the positions of the index pairs in the operand uncontracted tensor
+/// that we wish to contract
+///
+/// \details
+/// Both quantities returned are computed in and returned from the same
+/// function so as to not repeat overlapping necessary work that would be in two
+/// separate functions
+///
+/// \tparam NumContractedIndexPairs the number of pairs of indices that will be
+/// contracted
+/// \tparam NumUncontractedIndices the number of indices in the operand
+/// expression that we wish to contract
+/// \param uncontracted_tensor_index_values the values of the `TensorIndex`s
+/// used to generically represent the uncontracted operand expression
+/// \return the mapping from the positions of indices in the resultant
+/// contracted tensor to their positions in the operand uncontracted tensor, as
+/// well as the positions of the index pairs in the operand uncontracted tensor
+/// that we wish to contract
+template <size_t NumContractedIndexPairs, size_t NumUncontractedIndices>
+constexpr std::pair<
+    std::array<size_t, NumUncontractedIndices - NumContractedIndexPairs * 2>,
+    std::array<std::pair<size_t, size_t>, NumContractedIndexPairs>>
+get_index_transformation_and_contracted_pair_positions(
+    const std::array<size_t, NumUncontractedIndices>&
+        uncontracted_tensor_index_values) {
+  static_assert(NumUncontractedIndices >= 2,
+                "There should be at least 2 indices");
+  // Positions of indices in the result tensor (ones that are not contracted)
+  // mapped to their locations in the uncontracted operand expression
+  std::array<size_t, NumUncontractedIndices - NumContractedIndexPairs * 2>
+      index_transformation{};
+  // Positions of contracted index pairs in the uncontracted operand expression
+  std::array<std::pair<size_t, size_t>, NumContractedIndexPairs>
+      contracted_index_pair_positions{};
+
+  // Marks whether or not we have already paired an index in the uncontracted
+  // operand expression with an index to contract it with
+  std::array<bool, NumUncontractedIndices> index_mapping_set =
+      make_array<NumUncontractedIndices, bool>(false);
+
+  // Index of `contracted_index_pair_positions` that we're currently assigning
+  size_t contracted_map_index_to_assign = 0;
+  // Index of `index_transformation` that we're currently assigning
+  size_t not_contracted_map_index_to_assign =
+      NumUncontractedIndices - NumContractedIndexPairs * 2 - 1;
+  // Iteration is performed backwards here for the reasons below, but note that
+  // no benchmarking has been done to confirm the backwards iteration order
+  // makes a meaningful improvement in runtime vs. iterating forward:
+  //
+  // Here, we iterate backwards to find the "rightmost" contracted indices and
+  // proceed leftwards to find the other contracted index pairs so that the
+  // "rightmost" pairs in the expression to contract appear first in the list of
+  // contracted index pairs (`contracted_index_pair_positions`). Then, when we
+  // later iterate over all of the multi-indices to sum, each time we go to grab
+  // the next multi-index to sum and we need to compute what that next
+  // multi-index is, we can choose to increment the concrete values of the
+  // rightmost index pair.
+  //
+  // This has not been benchmarked to confirm, but the thought with making this
+  // choice to order the contracted pairs from right to left is that this may
+  // help with spatial locality for caching when we are contracting a single
+  // tensor (`TensorAsExpression`) that is non-symmetric. For example, let's say
+  // we are contracting `R(ti::A, ti::B, ti::a, ti::b)` and the current
+  // multi-index we just accessed (one of the components to sum) is
+  // `{0, 0, 0, 0}`, representing \f$R^{00}{}_{00}\f$. To find a next
+  // multi-index to sum, we can simply increase one of the pairs' concrete
+  // values by 1, e.g. the next multi-index to access could be `{0, 1, 0, 1}`
+  // for \f$R^{01}{}_{01}\f$ or `{1, 0, 1, 0}` \f$R^{10}{}_{10}\f$. In this
+  // case, the idea is that choosing to increment the concrete values of the
+  // rightmost pair could provide better spatial locality, as `{0, 1, 0, 1}` is
+  // closer in memory to `{0, 0, 0, 0}` than `{1, 0, 1, 0}` is. It's important
+  // to note that this, of course, depends on the implementation of
+  // `Tensor_detail::Structure` - specifically, the order in which the
+  // components are laid out in memory.
+  //
+  // Note: the loop terminates when underflow causes `i` to wrap back around to
+  // the maximum `size_t` value. If we use the condition `i > 0`, we miss the
+  // final iteration, and if we use `i >= 0`, we never terminate because `i`
+  // is always positive.
+  for (size_t i = NumUncontractedIndices - 1; i < NumUncontractedIndices; i--) {
+    if (not gsl::at(index_mapping_set, i)) {
+      const size_t current_value = gsl::at(uncontracted_tensor_index_values, i);
+      // Concrete time indices are not contracted
+      if (not detail::is_time_index_value(current_value)) {
+        const size_t opposite_value_to_find =
+            get_tensorindex_value_with_opposite_valence(current_value);
+        for (size_t j = i - 1; j < NumUncontractedIndices; j--) {
+          if (opposite_value_to_find ==
+              gsl::at(uncontracted_tensor_index_values, j)) {
+            // We found both the lower and upper version of a generic index in
+            // the list of generic indices, pair them up
+            gsl::at(contracted_index_pair_positions,
+                    contracted_map_index_to_assign)
+                .first = i;
+            gsl::at(contracted_index_pair_positions,
+                    contracted_map_index_to_assign)
+                .second = j;
+            contracted_map_index_to_assign++;
+            // Mark that we've found contraction partners for these two indices
+            gsl::at(index_mapping_set, i) = true;
+            gsl::at(index_mapping_set, j) = true;
+            break;
+          }
+        }
+      }
+      if (not gsl::at(index_mapping_set, i)) {
+        // If we haven't assigned this index to a partner, it is not an index
+        // that is contracted, so record its position mapping from contracted to
+        // uncontracted tensor indices
+        gsl::at(index_transformation, not_contracted_map_index_to_assign) = i;
+        not_contracted_map_index_to_assign--;
+      }
+    }
+  }
+
+  return std::pair{index_transformation, contracted_index_pair_positions};
+}
+
+/// \brief Computes type information for the tensor expression that results from
+/// a contraction, as well as information internally useful for carrying out the
+/// contraction
+///
+/// \tparam UncontractedTensorExpression the operand uncontracted
+/// `TensorExpression` being contracted
+/// \tparam DataType the data type of the `Tensor` components
+/// \tparam UncontractedSymm the ::Symmetry of the operand uncontracted
+/// `TensorExpression`
+/// \tparam UncontractedIndexList the list of
+/// \ref SpacetimeIndex "TensorIndexType"s of the operand uncontracted
+/// `TensorExpression`
+/// \tparam UncontractedTensorIndexList the list of generic `TensorIndex`s used
+/// for the the operand uncontracted `TensorExpression`
+/// \tparam NumContractedIndices the number of indices in the resultant tensor
+/// after contracting
+/// \tparam NumIndexPairsToContract the number of pairs of indices that will be
+/// contracted
+template <typename UncontractedTensorExpression, typename DataType,
+          typename UncontractedSymm, typename UncontractedIndexList,
+          typename UncontractedTensorIndexList, size_t NumContractedIndices,
+          size_t NumIndexPairsToContract,
+          typename ContractedIndexSequence =
+              std::make_index_sequence<NumContractedIndices>,
+          typename IndexPairsToContractSequence =
+              std::make_index_sequence<NumIndexPairsToContract>>
+struct ContractedType;
+
+template <typename UncontractedTensorExpression, typename DataType,
+          template <typename...> class UncontractedSymmList,
+          typename... UncontractedSymm,
+          template <typename...> class UncontractedIndexList,
+          typename... UncontractedIndices,
+          template <typename...> class UncontractedTensorIndexList,
+          typename... UncontractedTensorIndices, size_t NumContractedIndices,
+          size_t NumIndexPairsToContract, size_t... ContractedInts,
+          size_t... IndexPairsToContractInts>
+struct ContractedType<UncontractedTensorExpression, DataType,
+                      UncontractedSymmList<UncontractedSymm...>,
+                      UncontractedIndexList<UncontractedIndices...>,
+                      UncontractedTensorIndexList<UncontractedTensorIndices...>,
+                      NumContractedIndices, NumIndexPairsToContract,
+                      std::index_sequence<ContractedInts...>,
+                      std::index_sequence<IndexPairsToContractInts...>> {
+  static constexpr size_t num_uncontracted_tensor_indices =
+      sizeof...(UncontractedTensorIndices);
+  static constexpr std::array<size_t, num_uncontracted_tensor_indices>
+      uncontracted_tensorindex_values = {{UncontractedTensorIndices::value...}};
+  static constexpr size_t num_indices_to_contract =
+      num_uncontracted_tensor_indices - NumContractedIndices;
+  static constexpr size_t num_contracted_index_pairs =
+      num_indices_to_contract / 2;
+  // First item in pair:
+  // - index transformation: mapping from the positions of indices in the
+  // resultant contracted tensor to their positions in the operand
+  // uncontracted tensor
+  // Second item in pair:
+  // contracted index pair positions: positions of the index pairs in the
+  // operand uncontracted tensor that we wish to contract
+  static constexpr inline std::pair<
+      std::array<size_t, NumContractedIndices>,
+      std::array<std::pair<size_t, size_t>, num_contracted_index_pairs>>
+      index_transformation_and_contracted_pair_positions =
+          get_index_transformation_and_contracted_pair_positions<
+              num_contracted_index_pairs, num_uncontracted_tensor_indices>(
+              uncontracted_tensorindex_values);
+
+  // Make sure it's mathematically legal to perform the requested contraction
+  static_assert(((... and
+                  (indices_contractible<
+                      typename tmpl::at_c<
+                          tmpl::list<UncontractedIndices...>,
+                          index_transformation_and_contracted_pair_positions
+                              .second[IndexPairsToContractInts]
+                              .first>,
+                      typename tmpl::at_c<
+                          tmpl::list<UncontractedIndices...>,
+                          index_transformation_and_contracted_pair_positions
+                              .second[IndexPairsToContractInts]
+                              .second>>::value))),
+                "Cannot contract the requested indices.");
+
+  static constexpr inline std::array<IndexType, num_uncontracted_tensor_indices>
+      uncontracted_index_types = {{UncontractedIndices::index_type...}};
+
+  // First concrete values of contracted indices to sum. This is to handle
+  // cases when we have generic spatial `TensorIndex`s used for spacetime
+  // indices, as the first concrete index value to contract will be 1 (first
+  // spatial index) instead of 0 (the time index). Contracted index pairs will
+  // have different "starting" concrete indices when one index in the pair is a
+  // spatial spacetime index and the other is not.
+  static constexpr inline std::array<std::pair<size_t, size_t>,
+                                     num_contracted_index_pairs>
+      contracted_index_first_values = []() {
+        std::array<std::pair<size_t, size_t>, num_contracted_index_pairs>
+            first_values{};
+        for (size_t i = 0; i < num_contracted_index_pairs; i++) {
+          // Assign the value for first index in a pair to be the smallest value
+          // used in the terms being summed: assign to 1 if we have a spacetime
+          // index where a generic spatial index has been used, otherwise assign
+          // to 0.
+          gsl::at(first_values, i).first = static_cast<size_t>(
+              gsl::at(
+                  uncontracted_index_types,
+                  gsl::at(
+                      index_transformation_and_contracted_pair_positions.second,
+                      i)
+                      .first) == IndexType::Spacetime and
+              gsl::at(
+                  uncontracted_tensorindex_values,
+                  gsl::at(
+                      index_transformation_and_contracted_pair_positions.second,
+                      i)
+                      .first) >= TensorIndex_detail::spatial_sentinel);
+          // Assign the value for second index in a pair to be the smallest
+          // value used in the terms being summed (assigned with same logic
+          // described above for the first index in the pair)
+          gsl::at(first_values, i).second = static_cast<size_t>(
+              gsl::at(
+                  uncontracted_index_types,
+                  gsl::at(
+                      index_transformation_and_contracted_pair_positions.second,
+                      i)
+                      .second) == IndexType::Spacetime and
+              gsl::at(
+                  uncontracted_tensorindex_values,
+                  gsl::at(
+                      index_transformation_and_contracted_pair_positions.second,
+                      i)
+                      .second) >= TensorIndex_detail::spatial_sentinel);
+        }
+        return first_values;
+      }();
+
+  static constexpr inline std::array<size_t, num_uncontracted_tensor_indices>
+      uncontracted_index_dims = {{UncontractedIndices::dim...}};
+
+  // The number of terms to sum for this expression's contraction
+  static constexpr size_t num_terms_summed = []() {
+    size_t num_terms =
+        gsl::at(
+            uncontracted_index_dims,
+            gsl::at(index_transformation_and_contracted_pair_positions.second,
+                    0)
+                .first) -
+        gsl::at(contracted_index_first_values, 0).first;
+    for (size_t i = 1; i < num_contracted_index_pairs; i++) {
+      num_terms *=
+          gsl::at(
+              uncontracted_index_dims,
+              gsl::at(index_transformation_and_contracted_pair_positions.second,
+                      i)
+                  .first) -
+          gsl::at(contracted_index_first_values, i).first;
+    }
+    return num_terms;
+  }();
+  static_assert(num_terms_summed > 0,
+                "There should be a non-zero number of components to sum in the "
+                "contraction.");
+  // The ::Symmetry of the result of the contraction
+  using symmetry =
+      Symmetry<tmpl::at_c<UncontractedSymmList<UncontractedSymm...>,
+                          index_transformation_and_contracted_pair_positions
+                              .first[ContractedInts]>::value...>;
+  // The list of \ref SpacetimeIndex "TensorIndexType"s of the result of the
+  // contraction
+  using index_list =
+      tmpl::list<tmpl::at_c<UncontractedIndexList<UncontractedIndices...>,
+                            index_transformation_and_contracted_pair_positions
+                                .first[ContractedInts]>...>;
+  // The list of generic `TensorIndex`s of the result of the contraction
+  using tensorindex_list = tmpl::list<
+      tmpl::at_c<UncontractedTensorIndexList<UncontractedTensorIndices...>,
+                 index_transformation_and_contracted_pair_positions
+                     .first[ContractedInts]>...>;
+  // The `TensorExpression` type that results from performing the contraction
+  using type = TensorExpression<UncontractedTensorExpression, DataType,
+                                symmetry, index_list, tensorindex_list>;
 };
 }  // namespace detail
 
 /*!
  * \ingroup TensorExpressionsGroup
  */
-template <size_t FirstContractedIndexPos, size_t SecondContractedIndexPos,
-          typename T, typename X, typename Symm, typename IndexList,
-          typename ArgsList>
+template <typename T, typename X, typename Symm, typename IndexList,
+          typename ArgsList, size_t NumContractedIndices>
 struct TensorContract
     : public TensorExpression<
-          TensorContract<FirstContractedIndexPos, SecondContractedIndexPos, T,
-                         X, Symm, IndexList, ArgsList>,
+          TensorContract<T, X, Symm, IndexList, ArgsList, NumContractedIndices>,
           X,
-          typename detail::ContractedType<FirstContractedIndexPos,
-                                          SecondContractedIndexPos, T, X, Symm,
-                                          IndexList, ArgsList>::type::symmetry,
           typename detail::ContractedType<
-              FirstContractedIndexPos, SecondContractedIndexPos, T, X, Symm,
-              IndexList, ArgsList>::type::index_list,
+              T, X, Symm, IndexList, ArgsList, NumContractedIndices,
+              (tmpl::size<Symm>::value - NumContractedIndices) /
+                  2>::type::symmetry,
           typename detail::ContractedType<
-              FirstContractedIndexPos, SecondContractedIndexPos, T, X, Symm,
-              IndexList, ArgsList>::type::args_list> {
-  // First and second \ref SpacetimeIndex "TensorIndexType"s to contract.
-  // "first" and "second" here refer to the position of the indices to contract
-  // in the list of indices, with "first" denoting leftmost
-  //
-  // e.g. `R(ti::A, ti::b, ti::a)` :
-  // - `first_contracted_index` refers to the
-  //   \ref SpacetimeIndex "TensorIndexType" refered to by `ti::A`
-  // - `second_contracted_index` refers to the
-  //   \ref SpacetimeIndex "TensorIndexType" refered to by `ti::a`
-  using first_contracted_index = tmpl::at_c<IndexList, FirstContractedIndexPos>;
-  using second_contracted_index =
-      tmpl::at_c<IndexList, SecondContractedIndexPos>;
-  static_assert(tmpl::size<Symm>::value > 1 and
-                    tmpl::size<IndexList>::value > 1,
-                "Cannot contract indices on a Tensor with rank less than 2");
-  static_assert(detail::indices_contractible<first_contracted_index,
-                                             second_contracted_index>::value,
-                "Cannot contract the requested indices.");
+              T, X, Symm, IndexList, ArgsList, NumContractedIndices,
+              (tmpl::size<Symm>::value - NumContractedIndices) /
+                  2>::type::index_list,
+          typename detail::ContractedType<
+              T, X, Symm, IndexList, ArgsList, NumContractedIndices,
+              (tmpl::size<Symm>::value - NumContractedIndices) /
+                  2>::type::args_list> {
+  /// Stores internally useful information regarding the contraction. See
+  /// `detail::ContractedType` for more details
+  using contracted_type = typename detail::ContractedType<
+      T, X, Symm, IndexList, ArgsList, NumContractedIndices,
+      (tmpl::size<Symm>::value - NumContractedIndices) / 2>;
+  /// The `TensorExpression` type that results from performing the contraction
+  using new_type = typename contracted_type::type;
 
-  using new_type =
-      typename detail::ContractedType<FirstContractedIndexPos,
-                                      SecondContractedIndexPos, T, X, Symm,
-                                      IndexList, ArgsList>::type;
-
+  // === Index properties ===
+  /// The type of the data being stored in the result of the expression
   using type = X;
+  /// The ::Symmetry of the result of the expression
   using symmetry = typename new_type::symmetry;
+  /// The list of \ref SpacetimeIndex "TensorIndexType"s of the result of the
+  /// expression
   using index_list = typename new_type::index_list;
-  static constexpr auto num_tensor_indices = tmpl::size<index_list>::value;
-  static constexpr auto num_uncontracted_tensor_indices =
-      tmpl::size<Symm>::value;
+  /// The list of generic `TensorIndex`s of the result of the expression
   using args_list = typename new_type::args_list;
+  /// The number of tensor indices in the result of the expression
+  static constexpr size_t num_tensor_indices = NumContractedIndices;
+  /// The number of tensor indices in the operand expression being contracted
+  static constexpr size_t num_uncontracted_tensor_indices =
+      tmpl::size<Symm>::value;
+  /// The number of tensor indices in the operand expression that will be
+  /// contracted
+  static constexpr size_t num_indices_to_contract =
+      contracted_type::num_indices_to_contract;
+  static_assert(num_indices_to_contract > 0,
+                "There are no indices to contract that were found.");
+  static_assert(num_indices_to_contract % 2 == 0,
+                "Cannot contract an odd number of indices.");
+  /// The number of tensor index pairs in the operand expression that will be
+  /// contracted
+  static constexpr size_t num_contracted_index_pairs =
+      contracted_type::num_contracted_index_pairs;
+  /// Mapping from the positions of indices in the resultant contracted tensor
+  /// to their positions in the operand uncontracted tensor
+  static constexpr inline std::array<size_t, NumContractedIndices>
+      index_transformation =
+          contracted_type::index_transformation_and_contracted_pair_positions
+              .first;
+  /// Positions of the index pairs in the operand uncontracted tensor that we
+  /// wish to contract
+  static constexpr inline std::array<std::pair<size_t, size_t>,
+                                     num_contracted_index_pairs>
+      contracted_index_pair_positions =
+          contracted_type::index_transformation_and_contracted_pair_positions
+              .second;
+  /// First concrete values of contracted indices to sum. This is to handle
+  /// cases when we have generic spatial `TensorIndex`s used for spacetime
+  /// indices, as the first concrete index value to contract will be 1 (first
+  /// spatial index) instead of 0 (the time index). Contracted index pairs will
+  /// have different "starting" concrete indices when one index in the pair is a
+  /// spatial spacetime index and the other is not.
+  static constexpr inline std::array<std::pair<size_t, size_t>,
+                                     num_contracted_index_pairs>
+      contracted_index_first_values =
+          contracted_type::contracted_index_first_values;
+  /// The dimensions of the indices in the uncontracted operand expression
+  static constexpr inline std::array<size_t, num_uncontracted_tensor_indices>
+      uncontracted_index_dims = contracted_type::uncontracted_index_dims;
+  /// The number of terms to sum for this expression's contraction
+  static constexpr size_t num_terms_summed = contracted_type::num_terms_summed;
 
   explicit TensorContract(
       const TensorExpression<T, X, Symm, IndexList, ArgsList>& t)
       : t_(~t) {}
   ~TensorContract() override = default;
 
-  /// \brief Return a partially-filled multi-index of the uncontracted
-  /// expression where only the values of the indices that are not contracted
-  /// have been filled in
+  /// \brief Return the highest multi-index between the components being summed
+  /// in the contraction
   ///
   /// \details
-  /// Returns the multi-index that results from taking the
-  /// `contracted_multi_index` and inserting the maximum `size_t` value at the
-  /// two positions of the pair of indices to contract.
-  ///
-  /// e.g. `R(ti::A, ti::a, ti::b, ti::c)` represents contracting some
-  /// \f$R^{a}{}_{abc}\f$ to \f$R_{bc}\f$. If `contracted_multi_index` is
-  /// `[5, 4]` (i.e. `b == 5`, `c == 4`), the returned
-  /// `uncontracted_multi_index` is
-  /// `[<max size_t value>, <max size_t value>, 5, 4]`.
+  /// Example:
+  /// We have expression `R(ti::A, ti::b, ti::a)` to represent the contraction
+  /// \f$L_b = R^{a}{}_{ba}\f$. If the `contracted_multi_index` is `{1}`, which
+  /// represents \f$L_1 = R^{a}{}_{1a}\f$, and the dimension of \f$a\f$ is 3,
+  /// then we will need to sum the following terms: \f$R^{0}{}_{10}\f$,
+  /// \f$R^{1}{}_{11}\f$, and \f$R^{2}{}_{12}\f$. Between the terms being
+  /// summed, the multi-index whose values are the largest is
+  /// \f$R^{2}{}_{12}\f$, so this function would return `{2, 1, 2}`.
   ///
   /// \param contracted_multi_index the multi-index of a component of the
   /// contracted expression
-  /// \return the multi-index of the uncontracted expression where only the
-  /// values of the indices that are not contracted have been filled in
+  /// \return the highest multi-index between the components being summed in
+  /// the contraction
   SPECTRE_ALWAYS_INLINE static constexpr std::array<
       size_t, num_uncontracted_tensor_indices>
-  get_uncontracted_multi_index_with_uncontracted_values(
+  get_highest_multi_index_to_sum(
       const std::array<size_t, num_tensor_indices>& contracted_multi_index) {
-    std::array<size_t, num_uncontracted_tensor_indices>
-        uncontracted_multi_index{};
+    // Initialize with placeholders for debugging
+    auto highest_multi_index = make_array<num_uncontracted_tensor_indices>(
+        std::numeric_limits<size_t>::max());
 
-    for (size_t i = 0; i < FirstContractedIndexPos; i++) {
-      gsl::at(uncontracted_multi_index, i) = gsl::at(contracted_multi_index, i);
+    // Fill uncontracted indices
+    for (size_t i = 0; i < num_tensor_indices; i++) {
+      gsl::at(highest_multi_index, gsl::at(index_transformation, i)) =
+          gsl::at(contracted_multi_index, i);
     }
-    uncontracted_multi_index[FirstContractedIndexPos] =
-        std::numeric_limits<size_t>::max();  // placeholder to later be replaced
-    for (size_t i = FirstContractedIndexPos + 1; i < SecondContractedIndexPos;
-         i++) {
-      gsl::at(uncontracted_multi_index, i) =
-          gsl::at(contracted_multi_index, i - 1);
+
+    // Fill contracted indices
+    for (size_t i = 0; i < num_contracted_index_pairs; i++) {
+      const size_t first_index_position_in_pair =
+          gsl::at(contracted_index_pair_positions, i).first;
+      const size_t second_index_position_in_pair =
+          gsl::at(contracted_index_pair_positions, i).second;
+      gsl::at(highest_multi_index, first_index_position_in_pair) =
+          gsl::at(uncontracted_index_dims, first_index_position_in_pair) - 1;
+      gsl::at(highest_multi_index, second_index_position_in_pair) =
+          gsl::at(uncontracted_index_dims, second_index_position_in_pair) - 1;
     }
-    uncontracted_multi_index[SecondContractedIndexPos] =
-        std::numeric_limits<size_t>::max();  // placeholder to later be replaced
-    for (size_t i = SecondContractedIndexPos + 1;
-         i < num_uncontracted_tensor_indices; i++) {
-      gsl::at(uncontracted_multi_index, i) =
-          gsl::at(contracted_multi_index, i - 2);
+
+    return highest_multi_index;
+  }
+
+  /// \brief Return the lowest multi-index between the components being summed
+  /// in the contraction
+  ///
+  /// \details
+  /// Example:
+  /// We have expression `R(ti::A, ti::b, ti::a)` to represent the contraction
+  /// \f$L_b = R^{a}{}_{ba}\f$. If the `contracted_multi_index` is `{1}`, which
+  /// represents \f$L_1 = R^{a}{}_{1a}\f$, and the dimension of \f$a\f$ is 3,
+  /// then we will need to sum the following terms: \f$R^{0}{}_{10}\f$,
+  /// \f$R^{1}{}_{11}\f$, and \f$R^{2}{}_{12}\f$. Between the terms being
+  /// summed, the multi-index whose values are the smallest is
+  /// \f$R^{0}{}_{10}\f$, so this function would return `{0, 1, 0}`.
+  ///
+  /// \param contracted_multi_index the multi-index of a component of the
+  /// contracted expression
+  /// \return the lowest multi-index between the components being summed in
+  /// the contraction
+  SPECTRE_ALWAYS_INLINE static constexpr std::array<
+      size_t, num_uncontracted_tensor_indices>
+  get_lowest_multi_index_to_sum(
+      const std::array<size_t, num_tensor_indices>& contracted_multi_index) {
+    // Initialize with placeholders for debugging
+    auto lowest_multi_index = make_array<num_uncontracted_tensor_indices>(
+        std::numeric_limits<size_t>::max());
+
+    // Fill uncontracted indices
+    for (size_t i = 0; i < num_tensor_indices; i++) {
+      gsl::at(lowest_multi_index, gsl::at(index_transformation, i)) =
+          gsl::at(contracted_multi_index, i);
     }
-    return uncontracted_multi_index;
+
+    // Fill contracted indices
+    for (size_t i = 0; i < num_contracted_index_pairs; i++) {
+      const size_t first_index_position_in_pair =
+          gsl::at(contracted_index_pair_positions, i).first;
+      const size_t second_index_position_in_pair =
+          gsl::at(contracted_index_pair_positions, i).second;
+      gsl::at(lowest_multi_index, first_index_position_in_pair) =
+          gsl::at(contracted_index_first_values, i).first;
+      gsl::at(lowest_multi_index, second_index_position_in_pair) =
+          gsl::at(contracted_index_first_values, i).second;
+    }
+
+    return lowest_multi_index;
+  }
+
+  /// \brief Given the multi-index of one term being summed in the contraction,
+  /// return the next highest multi-index of a component being summed
+  ///
+  /// \details
+  /// What is meant by "next highest" is implementation defined, but generally
+  /// means, of the components being summed, return the multi-index that results
+  /// from lowering one of the contracted index pairs' values by one.
+  ///
+  /// Example:
+  /// We have expression `R(ti::A, ti::b, ti::a)` to represent the contraction
+  /// \f$L_b = R^{a}{}_{ba}\f$. If we are evaluating \f$L_1 = R^{a}{}_{1a}\f$
+  ///  and the dimension of \f$a\f$ is 3, then we will need to sum the following
+  /// terms: \f$R^{0}{}_{10}\f$, \f$R^{1}{}_{11}\f$, and \f$R^{2}{}_{12}\f$.
+  /// If `uncontracted_multi_index` is `{1, 1, 1}`, then the "next highest"
+  /// multi-index is the result of lowering the values of the \f$a\f$ indices by
+  /// 1. The component with that resulting multi-index is \f$R^{0}{}_{10}\f$, so
+  /// this function would return `{0, 1, 0}`.
+  ///
+  /// Note: this function should perform the inverse functionality of
+  /// `get_next_highest_multi_index_to_sum`. If the implementation of this
+  /// function or the other changes what is meant by "next highest" or "next
+  /// lowest," the other function should be updated in accordance.
+  ///
+  /// \param uncontracted_multi_index the multi-index of one of the components
+  /// of the uncontracted operand expression to sum
+  /// \return the next highest multi-index between the components being summed
+  /// in the contraction
+  SPECTRE_ALWAYS_INLINE static std::array<size_t,
+                                          num_uncontracted_tensor_indices>
+  get_next_highest_multi_index_to_sum(
+      const std::array<size_t, num_uncontracted_tensor_indices>&
+          uncontracted_multi_index) {
+    std::array<size_t, num_uncontracted_tensor_indices>
+        next_highest_uncontracted_multi_index = uncontracted_multi_index;
+
+    size_t i = 0;
+    while (i < num_contracted_index_pairs) {
+      // the position of the first index in a pair being contracted
+      const size_t current_index_first_position =
+          gsl::at(contracted_index_pair_positions, i).first;
+      // the position of the second index in a pair being contracted
+      const size_t current_index_second_position =
+          gsl::at(contracted_index_pair_positions, i).second;
+      // of the values being summed over, the lowest concrete value of the first
+      // index in the contracted pair
+      const size_t current_index_first_first_value =
+          gsl::at(contracted_index_first_values, i).first;
+
+      // decrement the current index pair's values
+      gsl::at(next_highest_uncontracted_multi_index,
+              current_index_first_position)--;
+      gsl::at(next_highest_uncontracted_multi_index,
+              current_index_second_position)--;
+
+      // If the index values of the index pair being contracted aren't lower
+      // than the minimum values included in the summation, then we're done
+      // computing this next multi-index
+      if (not(gsl::at(next_highest_uncontracted_multi_index,
+                      current_index_first_position) <
+                  current_index_first_first_value or
+              gsl::at(next_highest_uncontracted_multi_index,
+                      current_index_first_position) >
+                  gsl::at(uncontracted_index_dims,
+                          current_index_first_position))) {
+        break;
+      }
+      // Otherwise, we've wrapped around the lowest value being summed over for
+      // this index, so we need to set it back to the maximum values being
+      // summed and "carry" the decrementing over to the next contracted pair's
+      // values
+      gsl::at(next_highest_uncontracted_multi_index,
+              current_index_first_position) =
+          gsl::at(uncontracted_index_dims, current_index_first_position) - 1;
+      gsl::at(next_highest_uncontracted_multi_index,
+              current_index_second_position) =
+          gsl::at(uncontracted_index_dims, current_index_second_position) - 1;
+
+      i++;
+    }
+
+    return next_highest_uncontracted_multi_index;
+  }
+
+  /// \brief Given the multi-index of one term being summed in the contraction,
+  /// return the next lowest multi-index of a component being summed
+  ///
+  /// \details
+  /// What is meant by "next lowest" is implementation defined, but generally
+  /// means, of the components being summed, return the multi-index that results
+  /// from raising one of the contracted index pairs' values by one.
+  ///
+  /// Example:
+  /// We have expression `R(ti::A, ti::b, ti::a)` to represent the contraction
+  /// \f$L_b = R^{a}{}_{ba}\f$. If we are evaluating \f$L_1 = R^{a}{}_{1a}\f$
+  ///  and the dimension of \f$a\f$ is 3, then we will need to sum the following
+  /// terms: \f$R^{0}{}_{10}\f$, \f$R^{1}{}_{11}\f$, and \f$R^{2}{}_{12}\f$.
+  /// If `uncontracted_multi_index` is `{1, 1, 1}`, then the "next lowest"
+  /// multi-index is the result of raising the values of the \f$a\f$ indices by
+  /// 1. The component with that resulting multi-index is \f$R^{2}{}_{12}\f$, so
+  /// this function would return `{2, 1, 2}`.
+  ///
+  /// Note: this function should perform the inverse functionality of
+  /// `get_next_lowest_multi_index_to_sum`. If the implementation of this
+  /// function or the other changes what is meant by "next highest" or "next
+  /// lowest," the other function should be updated in accordance.
+  ///
+  /// \param uncontracted_multi_index the multi-index of one of the components
+  /// of the uncontracted operand expression to sum
+  /// \return the next lowest multi-index between the components being summed in
+  /// the contraction
+  SPECTRE_ALWAYS_INLINE static std::array<size_t,
+                                          num_uncontracted_tensor_indices>
+  get_next_lowest_multi_index_to_sum(
+      const std::array<size_t, num_uncontracted_tensor_indices>&
+          uncontracted_multi_index) {
+    std::array<size_t, num_uncontracted_tensor_indices>
+        next_lowest_uncontracted_multi_index = uncontracted_multi_index;
+
+    size_t i = 0;
+    while (i < num_contracted_index_pairs) {
+      // the position of the first index in a pair being contracted
+      const size_t current_index_first_position =
+          gsl::at(contracted_index_pair_positions, i).first;
+      // the position of the second index in a pair being contracted
+      const size_t current_index_second_position =
+          gsl::at(contracted_index_pair_positions, i).second;
+
+      // increment the current index pair's values
+      gsl::at(next_lowest_uncontracted_multi_index,
+              current_index_first_position)++;
+      gsl::at(next_lowest_uncontracted_multi_index,
+              current_index_second_position)++;
+
+      // if the previous index value is > dim, then we've wrapped around
+      // and we need to go again
+      // If the index values of the index pair being contracted aren't higher
+      // than the maximum values included in the summation, then we're done
+      // computing this next multi-index
+      if (not(gsl::at(next_lowest_uncontracted_multi_index,
+                      current_index_first_position) >
+              gsl::at(uncontracted_index_dims, current_index_first_position) -
+                  1)) {
+        break;
+      }
+      // Otherwise, we've wrapped around the highest value being summed over for
+      // this index, so we need to set it back to the minimum values being
+      // summed and "carry" the incrementing over to the next contracted pair's
+      // values
+      gsl::at(next_lowest_uncontracted_multi_index,
+              current_index_first_position) =
+          gsl::at(contracted_index_first_values, i).first;
+      gsl::at(next_lowest_uncontracted_multi_index,
+              current_index_second_position) =
+          gsl::at(contracted_index_first_values, i).second;
+
+      i++;
+    }
+
+    return next_lowest_uncontracted_multi_index;
   }
 
   /// \brief Computes the value of a component in the resultant contracted
   /// tensor
   ///
   /// \details
-  /// Returns the value of the component in the resultant contracted tensor
-  /// whose multi-index is that which results from removing the contracted
-  /// indices from `uncontracted_multi_index_to_fill`. For example, if
-  /// `uncontracted_multi_index_to_fill == {0, 1, 0, 3}` and the first and
-  /// third positions are the contracted index positions, this function
-  /// computes the contracted component at multi-index `{1, 3}`.
+  /// The contraction is computed by recursively adding up each component in the
+  /// summation, across all index pairs being contracted in the operand
+  /// expression. This function is called `Iteration = num_terms_summed` times,
+  /// once for each uncontracted tensor component being summed. It should
+  /// externally be called for the first time with `Iteration == 0` and
+  /// `current_multi_index == <highest multi index to sum>` (see
+  /// `get_next_highest_multi_index_to_sum` for details).
   ///
-  /// The distinction between `FirstContractedIndexValue` and
-  /// `SecondContractedIndexValue` is necessary to properly compute the
-  /// contraction of special cases where the "starting" index values to insert
-  /// at the contracted index positions are not equal. One such case:
-  /// `R(ti::J, ti::j)`, where R is a rank 2 tensor whose first index is spatial
-  /// and whose second index is spacetime. The external call to this function
-  /// would require `FirstContractedIndexValue == 0` and
-  /// `SecondContractedIndexValue == 1` to ensure the correct "starting" index
-  /// values are inserted into `uncontracted_multi_index_to_fill` at both index
-  /// positions, respectively.
+  /// In performing the recursive summation, the recursion is
+  /// specifically done "to the left," in that this function returns
+  /// `compute_contraction(next index) + get(this_index)` as opposed to
+  /// `get(this_index) + compute_contraction`. Benchmarking has shown that
+  /// increased breadth in an equation's expression tree can slow down runtime.
+  /// By "recursing left" here, we  minimize breadth in the overall tree for an
+  /// equation, as both `AddSub` addition and `OuterProduct` (other expressions
+  /// with two children) make efforts to make their operands with larger
+  /// subtrees be their left operand.
   ///
-  /// \tparam FirstContractedIndexValue the concrete value inserted for the
-  /// first index to contract
-  /// \tparam SecondContractedIndexValue the concrete value inserted for the
-  /// second index to contract
+  /// \tparam Iteration the nth term to sum, where n is between
+  /// [0, num_terms_summed)
   /// \param t the expression contained within this contraction expression
-  /// \param uncontracted_multi_index_to_fill the multi-index of the
-  /// uncontracted tensor component to fill and sum for contraction
+  /// \param current_multi_index the multi-index of the uncontracted tensor
+  /// component to retrieve
   /// \return the value of a component of the resulant contracted tensor
-  template <size_t FirstContractedIndexValue, size_t SecondContractedIndexValue>
-  static SPECTRE_ALWAYS_INLINE decltype(auto) compute_contraction(
-      const T& t, std::array<size_t, num_uncontracted_tensor_indices>
-                      uncontracted_multi_index_to_fill) {
-    // Fill contracted indices in multi-index with `FirstContractedIndexValue`
-    // and `SecondContractedIndexValue`
-    uncontracted_multi_index_to_fill[FirstContractedIndexPos] =
-        FirstContractedIndexValue;
-    uncontracted_multi_index_to_fill[SecondContractedIndexPos] =
-        SecondContractedIndexValue;
-
-    if constexpr (FirstContractedIndexValue < first_contracted_index::dim - 1) {
+  template <size_t Iteration>
+  SPECTRE_ALWAYS_INLINE static decltype(auto) compute_contraction(
+      const T& t, const std::array<size_t, num_uncontracted_tensor_indices>&
+                      current_multi_index) {
+    if constexpr (Iteration < num_terms_summed - 1) {
       // We have more than one component left to sum
-      return t.get(uncontracted_multi_index_to_fill) +
-             compute_contraction<FirstContractedIndexValue + 1,
-                                 SecondContractedIndexValue + 1>(
-                 t, uncontracted_multi_index_to_fill);
+      return compute_contraction<Iteration + 1>(
+                 t, get_next_highest_multi_index_to_sum(current_multi_index)) +
+             t.get(current_multi_index);
     } else {
       // We only have one final component to sum
-      return t.get(uncontracted_multi_index_to_fill);
+      return t.get(current_multi_index);
     }
   }
 
   /// \brief Return the value of the component of the resultant contracted
   /// tensor at a given multi-index
-  ///
-  /// \details Note that this function is not inlined because it has been
-  /// observed that when `Tensor` components are `DataVector`s, the compile time
-  /// for `TensorExpression` inner products scales poorly as the dimension of
-  /// operands' indices increase and as the number of contracted index pairs
-  /// increases.
   ///
   /// \param contracted_multi_index the multi-index of the resultant contracted
   /// tensor component to retrieve
@@ -244,70 +764,14 @@ struct TensorContract
   /// resultant contracted tensor
   decltype(auto) get(const std::array<size_t, num_tensor_indices>&
                          contracted_multi_index) const {
-    constexpr size_t initial_first_contracted_index_value =
-        first_contracted_index::index_type == IndexType::Spacetime and
-                not tmpl::at_c<ArgsList, FirstContractedIndexPos>::is_spacetime
-            ? 1
-            : 0;
-    constexpr size_t initial_second_contracted_index_value =
-        second_contracted_index::index_type == IndexType::Spacetime and
-                not tmpl::at_c<ArgsList, SecondContractedIndexPos>::is_spacetime
-            ? 1
-            : 0;
-
-    return compute_contraction<initial_first_contracted_index_value,
-                               initial_second_contracted_index_value>(
-        t_, get_uncontracted_multi_index_with_uncontracted_values(
-                contracted_multi_index));
+    return compute_contraction<0>(
+        t_, get_highest_multi_index_to_sum(contracted_multi_index));
   }
 
  private:
+  /// Operand expression being contracted
   T t_;
 };
-
-/*!
- * \ingroup TensorExpressionsGroup
- * \brief Returns the positions of the first indices to contract in an
- * expression
- *
- * \details Given a list of values that represent an expression's generic index
- * encodings, this function looks to see if it can find a pair of values that
- * encode one generic index and the generic index with opposite valence, such as
- * `ti::A` and `ti::a`. This denotes a pair of indices that will need to be
- * contracted. If there exists more than one such pair of indices in the
- * expression, the first pair of values found will be returned.
- *
- * For example, if we have tensor \f$R^{ab}{}_{ab}\f$ represented by the tensor
- * expression, `R(ti::A, ti::B, ti::a, ti::b)`, then this will return the
- * positions of the pair of values encoding `ti::A` and `ti::a`, which would be
- * (0, 2).
- *
- * @param tensorindex_values the TensorIndex values of a tensor expression
- * @return the positions of the first pair of TensorIndex values to contract
- */
-template <size_t NumIndices>
-SPECTRE_ALWAYS_INLINE static constexpr std::pair<size_t, size_t>
-get_first_index_positions_to_contract(
-    const std::array<size_t, NumIndices>& tensorindex_values) {
-  for (size_t i = 0; i < tensorindex_values.size(); ++i) {
-    const size_t current_value = gsl::at(tensorindex_values, i);
-    // Concrete time indices are not contracted
-    if (not detail::is_time_index_value(current_value)) {
-      const size_t opposite_value_to_find =
-          get_tensorindex_value_with_opposite_valence(current_value);
-      for (size_t j = i + 1; j < tensorindex_values.size(); ++j) {
-        if (opposite_value_to_find == gsl::at(tensorindex_values, j)) {
-          // We found both the lower and upper version of a generic index in the
-          // list of generic indices, so we return this pair's positions
-          return std::pair{i, j};
-        }
-      }
-    }
-  }
-  // We couldn't find a single pair of indices that needs to be contracted
-  return std::pair{std::numeric_limits<size_t>::max(),
-                   std::numeric_limits<size_t>::max()};
-}
 
 /*!
  * \ingroup TensorExpressionsGroup
@@ -316,14 +780,7 @@ get_first_index_positions_to_contract(
  *
  * \details If there are no indices to contract, the input TensorExpression is
  * simply returned. Otherwise, a contraction expression is created for
- * contracting one pair of upper and lower indices. If there is more than one
- * pair of indices to contract, subsequent contraction expressions are
- * recursively created, nesting one contraction expression inside another.
- *
- * For example, if we have tensor \f$R^{ab}{}_{ab}\f$ represented by the tensor
- * expression, `R(ti::A, ti::B, ti::a, ti::b)`, then one contraction expression
- * is created to represent contracting \f$R^{ab}{}_ab\f$ to \f$R^b{}_b\f$, and a
- * second to represent contracting \f$R^b{}_b\f$ to the scalar, \f$R\f$.
+ * contracting all pairs of indices that need to be contracted.
  *
  * @param t the TensorExpression to potentially contract
  * @return the input tensor expression or a contraction expression of the input
@@ -333,23 +790,21 @@ template <typename T, typename X, typename Symm, typename IndexList,
 SPECTRE_ALWAYS_INLINE static constexpr auto contract(
     const TensorExpression<T, X, Symm, IndexList, tmpl::list<TensorIndices...>>&
         t) {
-  constexpr std::array<size_t, sizeof...(TensorIndices)> tensorindex_values = {
-      {TensorIndices::value...}};
-  constexpr std::pair first_index_positions_to_contract =
-      get_first_index_positions_to_contract(tensorindex_values);
-  constexpr std::pair no_indices_to_contract_sentinel{
-      std::numeric_limits<size_t>::max(), std::numeric_limits<size_t>::max()};
+  // Number of indices in the tensor expression we're wanting to contract
+  constexpr size_t num_uncontracted_indices = sizeof...(TensorIndices);
+  // The number of index pairs to contract
+  constexpr size_t num_contracted_index_pairs =
+      detail::get_num_contracted_index_pairs<num_uncontracted_indices>(
+          {{TensorIndices::value...}});
 
-  if constexpr (first_index_positions_to_contract ==
-                no_indices_to_contract_sentinel) {
+  if constexpr (num_contracted_index_pairs == 0) {
     // There aren't any indices to contract, so we just return the input
     return ~t;
   } else {
-    // We have a pair of indices to be contract
-    return contract(
-        TensorContract<first_index_positions_to_contract.first,
-                       first_index_positions_to_contract.second, T, X, Symm,
-                       IndexList, tmpl::list<TensorIndices...>>{t});
+    // We have at least one pair of indices to contract
+    return TensorContract<T, X, Symm, IndexList, tmpl::list<TensorIndices...>,
+                          num_uncontracted_indices -
+                              (num_contracted_index_pairs * 2)>{t};
   }
 }
 }  // namespace tenex

--- a/src/DataStructures/Tensor/Expressions/Contract.hpp
+++ b/src/DataStructures/Tensor/Expressions/Contract.hpp
@@ -454,6 +454,19 @@ struct TensorContract
   /// The number of terms to sum for this expression's contraction
   static constexpr size_t num_terms_summed = contracted_type::num_terms_summed;
 
+  // === Arithmetic tensor operations properties ===
+  /// The number of arithmetic tensor operations done in the subtree for the
+  /// left operand
+  static constexpr size_t num_ops_left_child =
+      T::num_ops_subtree * num_terms_summed + num_terms_summed - 1;
+  /// The number of arithmetic tensor operations done in the subtree for the
+  /// right operand. This is 0 because this expression represents a unary
+  /// operation.
+  static constexpr size_t num_ops_right_child = 0;
+  /// The total number of arithmetic tensor operations done in this expression's
+  /// whole subtree
+  static constexpr size_t num_ops_subtree = num_ops_left_child;
+
   explicit TensorContract(
       const TensorExpression<T, X, Symm, IndexList, ArgsList>& t)
       : t_(~t) {}

--- a/src/DataStructures/Tensor/Expressions/Divide.hpp
+++ b/src/DataStructures/Tensor/Expressions/Divide.hpp
@@ -25,6 +25,11 @@ namespace tenex {
 /// expression divided by another tensor expression that evaluates to a rank 0
 /// tensor
 ///
+/// \details
+/// For details on aliases and members defined in this class, as well as general
+/// `TensorExpression` terminology used in its members' documentation, see
+/// documentation for `TensorExpression`.
+///
 /// \tparam T1 the numerator operand expression of the division expression
 /// \tparam T2 the denominator operand expression of the division expression
 /// \tparam Args2 the generic indices of the denominator expression
@@ -80,8 +85,88 @@ struct Divide : public TensorExpression<
   static constexpr size_t num_ops_subtree =
       num_ops_left_child + num_ops_right_child + 1;
 
+  // === Properties for splitting up subexpressions along the primary path ===
+  // These definitions only have meaning if this expression actually ends up
+  // being along the primary path that is taken when evaluating the whole tree.
+  // See documentation for `TensorExpression` for more details.
+  /// If on the primary path, whether or not the expression is an ending point
+  /// of a leg
+  static constexpr bool is_primary_end = T1::is_primary_start;
+  /// If on the primary path, this is the remaining number of arithmetic tensor
+  /// operations that need to be done in the subtree of the child along the
+  /// primary path, given that we will have already computed the whole subtree
+  /// at the next lowest leg's starting point.
+  static constexpr size_t num_ops_to_evaluate_primary_left_child =
+      is_primary_end ? 0 : T1::num_ops_to_evaluate_primary_subtree;
+  /// If on the primary path, this is the remaining number of arithmetic tensor
+  /// operations that need to be done in the right operand's subtree. No
+  /// splitting is currently done, so this is just `num_ops_right_child`.
+  static constexpr size_t num_ops_to_evaluate_primary_right_child =
+      num_ops_right_child;
+  /// If on the primary path, this is the remaining number of arithmetic tensor
+  /// operations that need to be done for this expression's subtree, given that
+  /// we will have already computed the subtree at the next lowest leg's
+  /// starting point
+  static constexpr size_t num_ops_to_evaluate_primary_subtree =
+      num_ops_to_evaluate_primary_left_child +
+      num_ops_to_evaluate_primary_right_child + 1;
+  /// If on the primary path, whether or not the expression is a starting point
+  /// of a leg
+  static constexpr bool is_primary_start =
+      num_ops_to_evaluate_primary_subtree >=
+      detail::max_num_ops_in_sub_expression<type>;
+  /// When evaluating along a primary path, whether each operand's subtrees
+  /// should be evaluated separately. Since `DataVector` expression runtime
+  /// scales poorly with increased number of operations, evaluating the two
+  /// expression subtrees separately like this is beneficial when at least one
+  /// of the subtrees contains a large number of operations.
+  static constexpr bool evaluate_children_separately =
+      is_primary_start and (num_ops_to_evaluate_primary_left_child >=
+                                detail::max_num_ops_in_sub_expression<type> or
+                            num_ops_to_evaluate_primary_right_child >=
+                                detail::max_num_ops_in_sub_expression<type>);
+  /// If on the primary path, whether or not the expression's child along the
+  /// primary path is a subtree that contains a starting point of a leg along
+  /// the primary path
+  static constexpr bool primary_child_subtree_contains_primary_start =
+      T1::primary_subtree_contains_primary_start;
+  /// If on the primary path, whether or not this subtree contains a starting
+  /// point of a leg along the primary path
+  static constexpr bool primary_subtree_contains_primary_start =
+      is_primary_start or primary_child_subtree_contains_primary_start;
+
   Divide(T1 t1, T2 t2) : t1_(std::move(t1)), t2_(std::move(t2)) {}
   ~Divide() override = default;
+
+  /// \brief Assert that the LHS tensor of the equation does not also appear in
+  /// this expression's subtree
+  template <typename LhsTensor>
+  SPECTRE_ALWAYS_INLINE void assert_lhs_tensor_not_in_rhs_expression(
+      const gsl::not_null<LhsTensor*> lhs_tensor) const {
+    if constexpr (not std::is_base_of_v<NumberAsExpression, T1>) {
+      t1_.assert_lhs_tensor_not_in_rhs_expression(lhs_tensor);
+    }
+    if constexpr (not std::is_base_of_v<NumberAsExpression, T2>) {
+      t2_.assert_lhs_tensor_not_in_rhs_expression(lhs_tensor);
+    }
+  }
+
+  /// \brief Assert that each instance of the LHS tensor in the RHS tensor
+  /// expression uses the same generic index order that the LHS uses
+  ///
+  /// \tparam LhsTensorIndices the list of generic `TensorIndex`s of the LHS
+  /// result `Tensor` being computed
+  /// \param lhs_tensor the LHS result `Tensor` being computed
+  template <typename LhsTensorIndices, typename LhsTensor>
+  SPECTRE_ALWAYS_INLINE void assert_lhs_tensorindices_same_in_rhs(
+      const gsl::not_null<LhsTensor*> lhs_tensor) const {
+    if constexpr (not std::is_base_of_v<NumberAsExpression, T1>) {
+      t1_.assert_lhs_tensorindices_same_in_rhs(lhs_tensor);
+    }
+    if constexpr (not std::is_base_of_v<NumberAsExpression, T2>) {
+      t2_.assert_lhs_tensorindices_same_in_rhs(lhs_tensor);
+    }
+  }
 
   /// \brief Return the value of the component of the quotient tensor at a given
   /// multi-index
@@ -93,6 +178,110 @@ struct Divide : public TensorExpression<
   SPECTRE_ALWAYS_INLINE decltype(auto) get(
       const std::array<size_t, num_tensor_indices>& result_multi_index) const {
     return t1_.get(result_multi_index) / t2_.get(op2_multi_index);
+  }
+
+  /// \brief Return the value of the component of the quotient tensor at a given
+  /// multi-index
+  ///
+  /// \details
+  /// This function differs from `get` in that it takes into account whether we
+  /// have already computed part of the result component at a lower subtree.
+  /// In recursively computing this quotient, the current result component will
+  /// be substituted in for the most recent (highest) subtree below it that has
+  /// already been evaluated.
+  ///
+  /// \param result_component the LHS tensor component to evaluate
+  /// \param result_multi_index the multi-index of the component of the quotient
+  //// tensor to retrieve
+  /// \return the value of the component in the quotient tensor at
+  /// `result_multi_index`
+  SPECTRE_ALWAYS_INLINE decltype(auto) get_primary(
+      const type& result_component,
+      const std::array<size_t, num_tensor_indices>& result_multi_index) const {
+    if constexpr (is_primary_end) {
+      (void)result_multi_index;
+      // We've already computed the whole child subtree on the primary path, so
+      // just return the quotient of the current result component and the result
+      // of the other child's subtree
+      return result_component / t2_.get(op2_multi_index);
+    } else {
+      // We haven't yet evaluated the whole subtree for this expression, so
+      // return the quotient of the results of the two operands' subtrees
+      return t1_.get_primary(result_component, result_multi_index) /
+             t2_.get(op2_multi_index);
+    }
+  }
+
+  /// \brief Evaluate the LHS Tensor's result component at this subtree by
+  /// evaluating the two operand's subtrees separately and dividing
+  ///
+  /// \details
+  /// This function takes into account whether we have already computed part of
+  /// the result component at a lower subtree. In recursively computing this
+  /// quotient, the current result component will be substituted in for the most
+  /// recent (highest) subtree below it that has already been evaluated.
+  ///
+  /// The left and right operands' subtrees are evaluated successively with
+  /// two separate assignments to the LHS result component. Since `DataVector`
+  /// expression runtime scales poorly with increased number of operations,
+  /// evaluating the two expression subtrees separately like this is beneficial
+  /// when at least one of the subtrees contains a large number of operations.
+  /// Instead of evaluating a larger expression with their combined total number
+  /// of operations, we evaluate two smaller ones.
+  ///
+  /// \param result_component the LHS tensor component to evaluate
+  /// \param result_multi_index the multi-index of the component of the result
+  /// tensor to evaluate
+  SPECTRE_ALWAYS_INLINE void evaluate_primary_children(
+      type& result_component,
+      const std::array<size_t, num_tensor_indices>& result_multi_index) const {
+    if constexpr (is_primary_end) {
+      (void)result_multi_index;
+      // We've already computed the whole child subtree on the primary path, so
+      // just divide the current result by the result of the other child's
+      // subtree
+      result_component /= t2_.get(op2_multi_index);
+    } else {
+      // We haven't yet evaluated the whole subtree of the primary child, so
+      // first assign the result component to be the result of computing the
+      // primary child's subtree
+      result_component = t1_.get_primary(result_component, result_multi_index);
+      // Now that the primary child's subtree has been computed, divide the
+      // current result by the result of evaluating the other child's subtree
+      result_component /= t2_.get(op2_multi_index);
+    }
+  }
+
+  /// \brief Successively evaluate the LHS Tensor's result component at each
+  /// leg in this expression's subtree
+  ///
+  /// \details
+  /// This function takes into account whether we have already computed part of
+  /// the result component at a lower subtree. In recursively computing this
+  /// quotient, the current result component will be substituted in for the most
+  /// recent (highest) subtree below it that has already been evaluated.
+  ///
+  /// \param result_component the LHS tensor component to evaluate
+  /// \param result_multi_index the multi-index of the component of the result
+  /// tensor to evaluate
+  SPECTRE_ALWAYS_INLINE void evaluate_primary_subtree(
+      type& result_component,
+      const std::array<size_t, num_tensor_indices>& result_multi_index) const {
+    if constexpr (primary_child_subtree_contains_primary_start) {
+      // The primary child's subtree contains at least one leg, so recurse down
+      // and evaluate that first
+      t1_.evaluate_primary_subtree(result_component, result_multi_index);
+    }
+    if constexpr (is_primary_start) {
+      // We want to evaluate the subtree for this expression
+      if constexpr (evaluate_children_separately) {
+        // Evaluate operand's subtrees separately
+        evaluate_primary_children(result_component, result_multi_index);
+      } else {
+        // Evaluate whole subtree as one expression
+        result_component = get_primary(result_component, result_multi_index);
+      }
+    }
   }
 
  private:

--- a/src/DataStructures/Tensor/Expressions/Divide.hpp
+++ b/src/DataStructures/Tensor/Expressions/Divide.hpp
@@ -45,20 +45,40 @@ struct Divide : public TensorExpression<
                 "expression that evaluates to "
                 "a rank 0 tensor.");
 
+  // === Index properties ===
+  /// The type of the data being stored in the result of the expression
   using type =
       std::conditional_t<std::is_same<typename T1::type, DataVector>::value or
                              std::is_same<typename T2::type, DataVector>::value,
                          DataVector, double>;
+  /// The ::Symmetry of the result of the expression
   using symmetry = typename T1::symmetry;
+  /// The list of \ref SpacetimeIndex "TensorIndexType"s of the result of the
+  /// expression
   using index_list = typename T1::index_list;
+  /// The list of generic `TensorIndex`s of the result of the expression
   using args_list = typename T1::args_list;
+  /// The number of tensor indices in the result of the expression
   static constexpr auto num_tensor_indices =
       tmpl::size<typename T1::index_list>::value;
+  /// The number of tensor indices in the left operand expression
   static constexpr auto op2_num_tensor_indices =
       tmpl::size<typename T2::index_list>::value;
-  // the denominator has no indices or all time indices
+  /// The multi-index for the denominator
   static constexpr auto op2_multi_index =
       make_array<op2_num_tensor_indices, size_t>(0);
+
+  // === Arithmetic tensor operations properties ===
+  /// The number of arithmetic tensor operations done in the subtree for the
+  /// left operand
+  static constexpr size_t num_ops_left_child = T1::num_ops_subtree;
+  /// The number of arithmetic tensor operations done in the subtree for the
+  /// right operand
+  static constexpr size_t num_ops_right_child = T2::num_ops_subtree;
+  /// The total number of arithmetic tensor operations done in this expression's
+  /// whole subtree
+  static constexpr size_t num_ops_subtree =
+      num_ops_left_child + num_ops_right_child + 1;
 
   Divide(T1 t1, T2 t2) : t1_(std::move(t1)), t2_(std::move(t2)) {}
   ~Divide() override = default;
@@ -76,7 +96,9 @@ struct Divide : public TensorExpression<
   }
 
  private:
+  /// Left operand (numerator)
   T1 t1_;
+  /// Right operand (denominator)
   T2 t2_;
 };
 }  // namespace tenex

--- a/src/DataStructures/Tensor/Expressions/Negate.hpp
+++ b/src/DataStructures/Tensor/Expressions/Negate.hpp
@@ -25,11 +25,30 @@ template <typename T>
 struct Negate
     : public TensorExpression<Negate<T>, typename T::type, typename T::symmetry,
                               typename T::index_list, typename T::args_list> {
+  // === Index properties ===
+  /// The type of the data being stored in the result of the expression
   using type = typename T::type;
+  /// The ::Symmetry of the result of the expression
   using symmetry = typename T::symmetry;
+  /// The list of \ref SpacetimeIndex "TensorIndexType"s of the result of the
+  /// expression
   using index_list = typename T::index_list;
+  /// The list of generic `TensorIndex`s of the result of the expression
   using args_list = typename T::args_list;
+  /// The number of tensor indices in the result of the expression
   static constexpr auto num_tensor_indices = tmpl::size<index_list>::value;
+
+  // === Arithmetic tensor operations properties ===
+  /// The number of arithmetic tensor operations done in the subtree for the
+  /// left operand
+  static constexpr size_t num_ops_left_child = T::num_ops_subtree;
+  /// The number of arithmetic tensor operations done in the subtree for the
+  /// right operand. This is 0 because this expression represents a unary
+  /// operation.
+  static constexpr size_t num_ops_right_child = 0;
+  /// The total number of arithmetic tensor operations done in this expression's
+  /// whole subtree
+  static constexpr size_t num_ops_subtree = num_ops_left_child + 1;
 
   Negate(T t) : t_(std::move(t)) {}
   ~Negate() override = default;
@@ -47,6 +66,7 @@ struct Negate
   }
 
  private:
+  /// Operand expression
   T t_;
 };
 }  // namespace tenex

--- a/src/DataStructures/Tensor/Expressions/Negate.hpp
+++ b/src/DataStructures/Tensor/Expressions/Negate.hpp
@@ -20,6 +20,11 @@ namespace tenex {
 /// \brief Defines the tensor expression representing the negation of a tensor
 /// expression
 ///
+/// \details
+/// For details on aliases and members defined in this class, as well as general
+/// `TensorExpression` terminology used in its members' documentation, see
+/// documentation for `TensorExpression`.
+///
 /// \tparam T the type of tensor expression being negated
 template <typename T>
 struct Negate
@@ -50,8 +55,73 @@ struct Negate
   /// whole subtree
   static constexpr size_t num_ops_subtree = num_ops_left_child + 1;
 
+  // === Properties for splitting up subexpressions along the primary path ===
+  // These definitions only have meaning if this expression actually ends up
+  // being along the primary path that is taken when evaluating the whole tree.
+  // See documentation for `TensorExpression` for more details.
+  /// If on the primary path, whether or not the expression is an ending point
+  /// of a leg
+  static constexpr bool is_primary_end = T::is_primary_start;
+  /// If on the primary path, this is the remaining number of arithmetic tensor
+  /// operations that need to be done in the subtree of the child along the
+  /// primary path, given that we will have already computed the whole subtree
+  /// at the next lowest leg's starting point.
+  static constexpr size_t num_ops_to_evaluate_primary_left_child =
+      is_primary_end ? 0 : T::num_ops_to_evaluate_primary_subtree;
+  /// If on the primary path, this is the remaining number of arithmetic tensor
+  /// operations that need to be done in the right operand's subtree. No
+  /// splitting is currently done, so this is just `num_ops_right_child`.
+  static constexpr size_t num_ops_to_evaluate_primary_right_child =
+      num_ops_right_child;
+  /// If on the primary path, this is the remaining number of arithmetic tensor
+  /// operations that need to be done for this expression's subtree, given that
+  /// we will have already computed the subtree at the next lowest leg's
+  /// starting point
+  static constexpr size_t num_ops_to_evaluate_primary_subtree =
+      num_ops_to_evaluate_primary_left_child +
+      num_ops_to_evaluate_primary_right_child + 1;
+  /// If on the primary path, whether or not the expression is a starting point
+  /// of a leg
+  static constexpr bool is_primary_start =
+      num_ops_to_evaluate_primary_subtree >=
+      detail::max_num_ops_in_sub_expression<type>;
+  /// If on the primary path, whether or not the expression's child along the
+  /// primary path is a subtree that contains a starting point of a leg along
+  /// the primary path
+  static constexpr bool primary_child_subtree_contains_primary_start =
+      T::primary_subtree_contains_primary_start;
+  /// If on the primary path, whether or not this subtree contains a starting
+  /// point of a leg along the primary path
+  static constexpr bool primary_subtree_contains_primary_start =
+      is_primary_start or primary_child_subtree_contains_primary_start;
+
   Negate(T t) : t_(std::move(t)) {}
   ~Negate() override = default;
+
+  /// \brief Assert that the LHS tensor of the equation does not also appear in
+  /// this expression's subtree
+  template <typename LhsTensor>
+  SPECTRE_ALWAYS_INLINE void assert_lhs_tensor_not_in_rhs_expression(
+      const gsl::not_null<LhsTensor*> lhs_tensor) const {
+    if constexpr (not std::is_base_of_v<NumberAsExpression, T>) {
+      t_.assert_lhs_tensor_not_in_rhs_expression(lhs_tensor);
+    }
+  }
+
+  /// \brief Assert that each instance of the LHS tensor in the RHS tensor
+  /// expression uses the same generic index order that the LHS uses
+  ///
+  /// \tparam LhsTensorIndices the list of generic `TensorIndex`s of the LHS
+  /// result `Tensor` being computed
+  /// \param lhs_tensor the LHS result `Tensor` being computed
+  template <typename LhsTensorIndices, typename LhsTensor>
+  SPECTRE_ALWAYS_INLINE void assert_lhs_tensorindices_same_in_rhs(
+      const gsl::not_null<LhsTensor*> lhs_tensor) const {
+    if constexpr (not std::is_base_of_v<NumberAsExpression, T>) {
+      t_.template assert_lhs_tensorindices_same_in_rhs<LhsTensorIndices>(
+          lhs_tensor);
+    }
+  }
 
   /// \brief Return the value of the component of the negated tensor expression
   /// at a given multi-index
@@ -63,6 +133,62 @@ struct Negate
   SPECTRE_ALWAYS_INLINE decltype(auto) get(
       const std::array<size_t, num_tensor_indices>& multi_index) const {
     return -t_.get(multi_index);
+  }
+
+  /// \brief Return the value of the component of the negated tensor expression
+  /// at a given multi-index
+  ///
+  /// \details
+  /// This function differs from `get` in that it takes into account whether we
+  /// have already computed part of the result component at a lower subtree.
+  /// In recursively computing this negation, the current result component will
+  /// be substituted in for the most recent (highest) subtree below it that has
+  /// already been evaluated.
+  ///
+  /// \param result_component the LHS tensor component to evaluate
+  /// \param multi_index the multi-index of the component to retrieve from the
+  /// negated tensor expression
+  /// \return the value of the component at `multi_index` in the negated tensor
+  /// expression
+  SPECTRE_ALWAYS_INLINE decltype(auto) get_primary(
+      const type& result_component,
+      const std::array<size_t, num_tensor_indices>& multi_index) const {
+    if constexpr (is_primary_end) {
+      (void)multi_index;
+      // We've already computed the whole child subtree on the primary path, so
+      // just return the negation of the current result component
+      return -result_component;
+    } else {
+      // We haven't yet evaluated the whole subtree for this expression, so
+      // return the negation of this expression's subtree
+      return -t_.get_primary(result_component, multi_index);
+    }
+  }
+
+  /// \brief Successively evaluate the LHS Tensor's result component at each
+  /// leg in this expression's subtree
+  ///
+  /// \details
+  /// This function takes into account whether we have already computed part of
+  /// the result component at a lower subtree. In recursively computing this
+  /// negation, the current result component will be substituted in for the most
+  /// recent (highest) subtree below it that has already been evaluated.
+  ///
+  /// \param result_component the LHS tensor component to evaluate
+  /// \param multi_index the multi-index of the component of the result tensor
+  /// to evaluate
+  SPECTRE_ALWAYS_INLINE void evaluate_primary_subtree(
+      type& result_component,
+      const std::array<size_t, num_tensor_indices>& multi_index) const {
+    if constexpr (primary_child_subtree_contains_primary_start) {
+      // The primary child's subtree contains at least one leg, so recurse down
+      // and evaluate that first
+      t_.evaluate_primary_subtree(result_component, multi_index);
+    }
+    if constexpr (is_primary_start) {
+      // We want to evaluate the subtree for this expression
+      result_component = get_primary(result_component, multi_index);
+    }
   }
 
  private:

--- a/src/DataStructures/Tensor/Expressions/NumberAsExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/NumberAsExpression.hpp
@@ -16,21 +16,35 @@ namespace tenex {
 struct NumberAsExpression
     : public TensorExpression<NumberAsExpression, double, tmpl::list<>,
                               tmpl::list<>, tmpl::list<>> {
+  // === Index properties ===
+  /// The type of the data being stored in the result of the expression
   using type = double;
+  /// The list of \ref SpacetimeIndex "TensorIndexType"s of the result of the
+  /// expression
   using symmetry = tmpl::list<>;
+  /// The list of \ref SpacetimeIndex "TensorIndexType"s of the result of the
+  /// expression
   using index_list = tmpl::list<>;
+  /// The list of generic `TensorIndex`s of the result of the expression
   using args_list = tmpl::list<>;
+  /// The number of tensor indices in the result of the expression
   static constexpr auto num_tensor_indices = 0;
+
+  // === Arithmetic tensor operations properties ===
+  /// The number of arithmetic tensor operations done in the subtree for the
+  /// left operand, which is 0 because this is a leaf expression
+  static constexpr size_t num_ops_left_child = 0;
+  /// The number of arithmetic tensor operations done in the subtree for the
+  /// right operand, which is 0 because this is a leaf expression
+  static constexpr size_t num_ops_right_child = 0;
+  /// The total number of arithmetic tensor operations done in this expression's
+  /// whole subtree, which is 0 because this is a leaf expression
+  static constexpr size_t num_ops_subtree = 0;
 
   NumberAsExpression(const double number) : number_(number) {}
   ~NumberAsExpression() override = default;
 
   /// \brief Returns the number represented by the expression
-  ///
-  /// \details
-  /// While a NumberAsExpression does not store a rank 0 Tensor, it does
-  /// represent one. This is why the multi-index argument is always an array of
-  /// size 0.
   ///
   /// \return the number represented by this expression
   SPECTRE_ALWAYS_INLINE double get(
@@ -39,6 +53,7 @@ struct NumberAsExpression
   }
 
  private:
+  /// Number represented by this expression
   double number_;
 };
 }  // namespace tenex

--- a/src/DataStructures/Tensor/Expressions/NumberAsExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/NumberAsExpression.hpp
@@ -13,6 +13,11 @@
 namespace tenex {
 /// \ingroup TensorExpressionsGroup
 /// \brief Defines an expression representing a `double`
+///
+/// \details
+/// For details on aliases and members defined in this class, as well as general
+/// `TensorExpression` terminology used in its members' documentation, see
+/// documentation for `TensorExpression`.
 struct NumberAsExpression
     : public TensorExpression<NumberAsExpression, double, tmpl::list<>,
                               tmpl::list<>, tmpl::list<>> {
@@ -41,8 +46,63 @@ struct NumberAsExpression
   /// whole subtree, which is 0 because this is a leaf expression
   static constexpr size_t num_ops_subtree = 0;
 
+  // === Properties for splitting up subexpressions along the primary path ===
+  // These definitions only have meaning if this expression actually ends up
+  // being along the primary path that is taken when evaluating the whole tree.
+  // See documentation for `TensorExpression` for more details.
+  /// If on the primary path, whether or not the expression is an ending point
+  /// of a leg
+  static constexpr bool is_primary_end = true;
+  /// If on the primary path, this is the remaining number of arithmetic tensor
+  /// operations that need to be done in the subtree of the child along the
+  /// primary path, given that we will have already computed the whole subtree
+  /// at the next lowest leg's starting point. This is just 0 because this
+  /// expression is a leaf.
+  static constexpr size_t num_ops_to_evaluate_primary_left_child = 0;
+  /// If on the primary path, this is the remaining number of arithmetic tensor
+  /// operations that need to be done in the right operand's subtree. This is
+  /// just 0 because this expression is a leaf.
+  static constexpr size_t num_ops_to_evaluate_primary_right_child = 0;
+  /// If on the primary path, this is the remaining number of arithmetic tensor
+  /// operations that need to be done for this expression's subtree, given that
+  /// we will have already computed the subtree at the next lowest leg's
+  /// starting point. This is just 0 because this expression is a leaf.
+  static constexpr size_t num_ops_to_evaluate_primary_subtree = 0;
+  /// \brief If on the primary path, whether or not the expression is a starting
+  /// point of a leg
+  ///
+  /// \details
+  /// Note: it's especially important for `NumberAsExpression` to define this as
+  /// `false` because if we have a case where this kind of an expression is the
+  /// leaf of the first leg being evaluated in the overall tree, we don't want
+  /// to use a `double` to initialize/size one of our LHS tensor's components,
+  /// because things would break if the LHS tensor components are supposed to
+  /// be e.g. a `DataVector` with a specific size.
+  static constexpr bool is_primary_start = false;
+  /// If on the primary path, whether or not the expression's child along the
+  /// primary path is a subtree that contains a starting point of a leg along
+  /// the primary path. This is always falls because this expression is a leaf.
+  static constexpr bool primary_child_subtree_contains_primary_start = false;
+  /// If on the primary path, whether or not this subtree contains a starting
+  /// point of a leg along the primary path
+  static constexpr bool primary_subtree_contains_primary_start =
+      is_primary_start;
+
   NumberAsExpression(const double number) : number_(number) {}
   ~NumberAsExpression() override = default;
+
+  // This expression does not represent a tensor, nor does it have any children,
+  // so we should never need to assert that the LHS `Tensor` is not equal to the
+  // `double` stored by this expression
+  template <typename LhsTensor>
+  void assert_lhs_tensor_not_in_rhs_expression(
+      const gsl::not_null<LhsTensor*>) const = delete;
+  // This expression does not represent a tensor, nor does it have any children,
+  // so we should never need to assert that instances of the LHS Tensor in this
+  // expression's subtree have the same generic index order
+  template <typename LhsTensorIndices, typename LhsTensor>
+  void assert_lhs_tensorindices_same_in_rhs(
+      const gsl::not_null<LhsTensor*> lhs_tensor) const = delete;
 
   /// \brief Returns the number represented by the expression
   ///
@@ -51,6 +111,28 @@ struct NumberAsExpression
       const std::array<size_t, num_tensor_indices>& /*multi_index*/) const {
     return number_;
   }
+
+  /// \brief Returns the number represented by the expression
+  ///
+  /// \return the number represented by this expression
+  template <typename ResultType>
+  SPECTRE_ALWAYS_INLINE double get_primary(
+      const ResultType& /*result_component*/,
+      const std::array<size_t, num_tensor_indices>& /*multi_index*/) const {
+    return number_;
+  }
+
+  // This expression is a leaf but does not store any information related to the
+  // sizing of the tensor components, because it does not represent an actual
+  // expression with tensors. Therefore, this expression should never be used to
+  // initialize a LHS result tensor component. We would run into trouble if e.g.
+  // the tensor components in the equations are `DataVector`s, but then we
+  // initialize a LHS component using the `double` stored in this leaf
+  // expression on the primary path.
+  template <typename ResultType>
+  void evaluate_primary_subtree(
+      ResultType&,
+      const std::array<size_t, num_tensor_indices>&) const = delete;
 
  private:
   /// Number represented by this expression

--- a/src/DataStructures/Tensor/Expressions/Product.hpp
+++ b/src/DataStructures/Tensor/Expressions/Product.hpp
@@ -46,8 +46,13 @@ struct OuterProductType<T1, T2, SymmList1<Symm1...>, SymmList2<Symm2...>> {
 /// \brief Defines the tensor expression representing the outer product of two
 /// tensor expressions
 ///
-/// \tparam T1 the first operand expression of the outer product expression
-/// \tparam T2 the second operand expression of the outer product expression
+/// \details
+/// For details on aliases and members defined in this class, as well as general
+/// `TensorExpression` terminology used in its members' documentation, see
+/// documentation for `TensorExpression`.
+///
+/// \tparam T1 the left operand expression of the outer product expression
+/// \tparam T2 the right operand expression of the outer product expression
 template <typename T1, typename T2,
           typename IndexList1 = typename T1::index_list,
           typename IndexList2 = typename T2::index_list,
@@ -71,7 +76,6 @@ struct OuterProduct<T1, T2, IndexList1<Indices1...>, IndexList2<Indices2...>,
                     std::is_same<T1, NumberAsExpression>::value or
                     std::is_same<T2, NumberAsExpression>::value,
                 "Cannot product Tensors holding different data types.");
-
   // === Index properties ===
   /// The type of the data being stored in the result of the expression
   using type = typename detail::OuterProductType<T1, T2>::type;
@@ -108,8 +112,123 @@ struct OuterProduct<T1, T2, IndexList1<Indices1...>, IndexList2<Indices2...>,
   static constexpr size_t num_ops_subtree =
       num_ops_left_child + num_ops_right_child + 1;
 
+  // === Properties for splitting up subexpressions along the primary path ===
+  // These definitions only have meaning if this expression actually ends up
+  // being along the primary path that is taken when evaluating the whole tree.
+  // See documentation for `TensorExpression` for more details.
+  /// If on the primary path, whether or not the expression is an ending point
+  /// of a leg
+  static constexpr bool is_primary_end = T1::is_primary_start;
+  /// If on the primary path, this is the remaining number of arithmetic tensor
+  /// operations that need to be done in the subtree of the child along the
+  /// primary path, given that we will have already computed the whole subtree
+  /// at the next lowest leg's starting point.
+  static constexpr size_t num_ops_to_evaluate_primary_left_child =
+      is_primary_end ? 0 : T1::num_ops_to_evaluate_primary_subtree;
+  /// If on the primary path, this is the remaining number of arithmetic tensor
+  /// operations that need to be done in the right operand's subtree. No
+  /// splitting is currently done, so this is just `num_ops_right_child`.
+  static constexpr size_t num_ops_to_evaluate_primary_right_child =
+      num_ops_right_child;
+  /// If on the primary path, this is the remaining number of arithmetic tensor
+  /// operations that need to be done for this expression's subtree, given that
+  /// we will have already computed the subtree at the next lowest leg's
+  /// starting point
+  static constexpr size_t num_ops_to_evaluate_primary_subtree =
+      num_ops_to_evaluate_primary_left_child +
+      num_ops_to_evaluate_primary_right_child + 1;
+  /// If on the primary path, whether or not the expression is a starting point
+  /// of a leg
+  static constexpr bool is_primary_start =
+      num_ops_to_evaluate_primary_subtree >=
+      detail::max_num_ops_in_sub_expression<type>;
+  /// When evaluating along a primary path, whether each operand's subtrees
+  /// should be evaluated separately. Since `DataVector` expression runtime
+  /// scales poorly with increased number of operations, evaluating the two
+  /// expression subtrees separately like this is beneficial when at least one
+  /// of the subtrees contains a large number of operations.
+  static constexpr bool evaluate_children_separately =
+      is_primary_start and (num_ops_to_evaluate_primary_left_child >=
+                                detail::max_num_ops_in_sub_expression<type> or
+                            num_ops_to_evaluate_primary_right_child >=
+                                detail::max_num_ops_in_sub_expression<type>);
+  /// If on the primary path, whether or not the expression's child along the
+  /// primary path is a subtree that contains a starting point of a leg along
+  /// the primary path
+  static constexpr bool primary_child_subtree_contains_primary_start =
+      T1::primary_subtree_contains_primary_start;
+  /// If on the primary path, whether or not this subtree contains a starting
+  /// point of a leg along the primary path
+  static constexpr bool primary_subtree_contains_primary_start =
+      is_primary_start or primary_child_subtree_contains_primary_start;
+
   OuterProduct(T1 t1, T2 t2) : t1_(std::move(t1)), t2_(std::move(t2)) {}
   ~OuterProduct() override = default;
+
+  /// \brief Assert that the LHS tensor of the equation does not also appear in
+  /// this expression's subtree
+  template <typename LhsTensor>
+  SPECTRE_ALWAYS_INLINE void assert_lhs_tensor_not_in_rhs_expression(
+      const gsl::not_null<LhsTensor*> lhs_tensor) const {
+    if constexpr (not std::is_base_of_v<NumberAsExpression, T1>) {
+      t1_.assert_lhs_tensor_not_in_rhs_expression(lhs_tensor);
+    }
+    if constexpr (not std::is_base_of_v<NumberAsExpression, T2>) {
+      t2_.assert_lhs_tensor_not_in_rhs_expression(lhs_tensor);
+    }
+  }
+
+  /// \brief Assert that each instance of the LHS tensor in the RHS tensor
+  /// expression uses the same generic index order that the LHS uses
+  ///
+  /// \tparam LhsTensorIndices the list of generic `TensorIndex`s of the LHS
+  /// result `Tensor` being computed
+  /// \param lhs_tensor the LHS result `Tensor` being computed
+  template <typename LhsTensorIndices, typename LhsTensor>
+  SPECTRE_ALWAYS_INLINE void assert_lhs_tensorindices_same_in_rhs(
+      const gsl::not_null<LhsTensor*> lhs_tensor) const {
+    if constexpr (not std::is_base_of_v<NumberAsExpression, T1>) {
+      t1_.template assert_lhs_tensorindices_same_in_rhs<LhsTensorIndices>(
+          lhs_tensor);
+    }
+    if constexpr (not std::is_base_of_v<NumberAsExpression, T2>) {
+      t2_.template assert_lhs_tensorindices_same_in_rhs<LhsTensorIndices>(
+          lhs_tensor);
+    }
+  }
+
+  /// \brief Return the first operand's multi-index given the outer product's
+  /// multi-index
+  ///
+  /// \param result_multi_index the multi-index of the component of the outer
+  /// product tensor
+  /// \return the first operand's multi-index
+  constexpr SPECTRE_ALWAYS_INLINE std::array<size_t, op1_num_tensor_indices>
+  get_op1_multi_index(
+      const std::array<size_t, num_tensor_indices>& result_multi_index) const {
+    std::array<size_t, op1_num_tensor_indices> op1_multi_index{};
+    for (size_t i = 0; i < op1_num_tensor_indices; i++) {
+      gsl::at(op1_multi_index, i) = gsl::at(result_multi_index, i);
+    }
+    return op1_multi_index;
+  }
+
+  /// \brief Return the second operand's multi-index given the outer product's
+  /// multi-index
+  ///
+  /// \param result_multi_index the multi-index of the component of the outer
+  /// product tensor
+  /// \return the second operand's multi-index
+  constexpr SPECTRE_ALWAYS_INLINE std::array<size_t, op2_num_tensor_indices>
+  get_op2_multi_index(
+      const std::array<size_t, num_tensor_indices>& result_multi_index) const {
+    std::array<size_t, op2_num_tensor_indices> op2_multi_index{};
+    for (size_t i = 0; i < op2_num_tensor_indices; i++) {
+      gsl::at(op2_multi_index, i) =
+          gsl::at(result_multi_index, op1_num_tensor_indices + i);
+    }
+    return op2_multi_index;
+  }
 
   /// \brief Return the value of the component of the outer product tensor at a
   /// given multi-index
@@ -132,18 +251,144 @@ struct OuterProduct<T1, T2, IndexList1<Indices1...>, IndexList2<Indices2...>,
   /// product tensor
   SPECTRE_ALWAYS_INLINE decltype(auto) get(
       const std::array<size_t, num_tensor_indices>& result_multi_index) const {
-    std::array<size_t, op1_num_tensor_indices> op1_multi_index{};
-    for (size_t i = 0; i < op1_num_tensor_indices; i++) {
-      gsl::at(op1_multi_index, i) = gsl::at(result_multi_index, i);
+    return t1_.get(get_op1_multi_index(result_multi_index)) *
+           t2_.get(get_op2_multi_index(result_multi_index));
+  }
+
+  /// \brief Return the product of the components at the given multi-indices of
+  /// the left and right operands
+  ///
+  /// \details
+  /// This function differs from `get` in that it takes into account whether we
+  /// have already computed part of the result component at a lower subtree.
+  /// In recursively computing this product, the current result component will
+  /// be substituted in for the most recent (highest) subtree below it that has
+  /// already been evaluated.
+  ///
+  /// \param result_component the LHS tensor component to evaluate
+  /// \param op1_multi_index the multi-index of the component of the first
+  /// operand of the product to retrieve
+  /// \param op2_multi_index the multi-index of the component of the second
+  /// operand of the product to retrieve
+  SPECTRE_ALWAYS_INLINE decltype(auto) get_primary(
+      const type& result_component,
+      const std::array<size_t, op1_num_tensor_indices>& op1_multi_index,
+      const std::array<size_t, op2_num_tensor_indices>& op2_multi_index) const {
+    if constexpr (is_primary_end) {
+      (void)op1_multi_index;
+      // We've already computed the whole child subtree on the primary path, so
+      // just return the product of the current result component and the result
+      // of the other child's subtree
+      return result_component * t2_.get(op2_multi_index);
+    } else {
+      // We haven't yet evaluated the whole subtree for this expression, so
+      // return the product of the results of the two operands' subtrees
+      return t1_.get_primary(result_component, op1_multi_index) *
+             t2_.get(op2_multi_index);
+    }
+  }
+
+  /// \brief Return the value of the component of the outer product tensor at a
+  /// given multi-index
+  ///
+  /// \details
+  /// This function differs from `get` in that it takes into account whether we
+  /// have already computed part of the result component at a lower subtree.
+  /// In recursively computing this product, the current result component will
+  /// be substituted in for the most recent (highest) subtree below it that has
+  /// already been evaluated.
+  ///
+  /// \param result_component the LHS tensor component to evaluate
+  /// \param result_multi_index the multi-index of the component of the outer
+  /// product tensor to retrieve
+  /// \return the value of the component at `result_multi_index` in the outer
+  /// product tensor
+  SPECTRE_ALWAYS_INLINE decltype(auto) get_primary(
+      const type& result_component,
+      const std::array<size_t, num_tensor_indices>& result_multi_index) const {
+    return get_primary(result_component,
+                       get_op1_multi_index(result_multi_index),
+                       get_op2_multi_index(result_multi_index));
+  }
+
+  /// \brief Evaluate the LHS Tensor's result component at this subtree by
+  /// evaluating the two operand's subtrees separately and multiplying
+  ///
+  /// \details
+  /// This function takes into account whether we have already computed part of
+  /// the result component at a lower subtree. In recursively computing this
+  /// product, the current result component will be substituted in for the most
+  /// recent (highest) subtree below it that has already been evaluated.
+  ///
+  /// The left and right operands' subtrees are evaluated successively with
+  /// two separate assignments to the LHS result component. Since `DataVector`
+  /// expression runtime scales poorly with increased number of operations,
+  /// evaluating the two expression subtrees separately like this is beneficial
+  /// when at least one of the subtrees contains a large number of operations.
+  /// Instead of evaluating a larger expression with their combined total number
+  /// of operations, we evaluate two smaller ones.
+  ///
+  /// \param result_component the LHS tensor component to evaluate
+  /// \param op1_multi_index the multi-index of the component of the first
+  /// operand of the product to evaluate
+  /// \param op2_multi_index the multi-index of the component of the second
+  /// operand of the product to evaluate
+  SPECTRE_ALWAYS_INLINE void evaluate_primary_children(
+      type& result_component,
+      const std::array<size_t, op1_num_tensor_indices>& op1_multi_index,
+      const std::array<size_t, op2_num_tensor_indices>& op2_multi_index) const {
+    if constexpr (is_primary_end) {
+      (void)op1_multi_index;
+      // We've already computed the whole child subtree on the primary path, so
+      // just multiply the current result by the result of the other child's
+      // subtree
+      result_component *= t2_.get(op2_multi_index);
+    } else {
+      // We haven't yet evaluated the whole subtree of the primary child, so
+      // first assign the result component to be the result of computing the
+      // primary child's subtree
+      result_component = t1_.get_primary(result_component, op1_multi_index);
+      // Now that the primary child's subtree has been computed, multiply the
+      // current result by the result of evaluating the other child's subtree
+      result_component *= t2_.get(op2_multi_index);
+    }
+  }
+
+  /// \brief Successively evaluate the LHS Tensor's result component at each
+  /// leg in this expression's subtree
+  ///
+  /// \details
+  /// This function takes into account whether we have already computed part of
+  /// the result component at a lower subtree. In recursively computing this
+  /// product, the current result component will be substituted in for the most
+  /// recent (highest) subtree below it that has already been evaluated.
+  ///
+  /// \param result_component the LHS tensor component to evaluate
+  /// \param result_multi_index the multi-index of the component of the outer
+  /// product tensor to evaluate
+  SPECTRE_ALWAYS_INLINE void evaluate_primary_subtree(
+      type& result_component,
+      const std::array<size_t, num_tensor_indices>& result_multi_index) const {
+    const std::array<size_t, op1_num_tensor_indices> op1_multi_index =
+        get_op1_multi_index(result_multi_index);
+    if constexpr (primary_child_subtree_contains_primary_start) {
+      // The primary child's subtree contains at least one leg, so recurse down
+      // and evaluate that first
+      t1_.evaluate_primary_subtree(result_component, op1_multi_index);
     }
 
-    std::array<size_t, op2_num_tensor_indices> op2_multi_index{};
-    for (size_t i = 0; i < op2_num_tensor_indices; i++) {
-      gsl::at(op2_multi_index, i) =
-          gsl::at(result_multi_index, op1_num_tensor_indices + i);
+    if constexpr (is_primary_start) {
+      // We want to evaluate the subtree for this expression
+      if constexpr (evaluate_children_separately) {
+        // Evaluate operand's subtrees separately
+        evaluate_primary_children(result_component, op1_multi_index,
+                                  get_op2_multi_index(result_multi_index));
+      } else {
+        // Evaluate whole subtree as one expression
+        result_component = get_primary(result_component, op1_multi_index,
+                                       get_op2_multi_index(result_multi_index));
+      }
     }
-
-    return t1_.get(op1_multi_index) * t2_.get(op2_multi_index);
   }
 
  private:

--- a/src/DataStructures/Tensor/Expressions/SquareRoot.hpp
+++ b/src/DataStructures/Tensor/Expressions/SquareRoot.hpp
@@ -22,6 +22,10 @@ namespace tenex {
 /// \details The expression can have a non-zero number of indices as long as
 /// all indices are concrete time indices, as this represents a rank 0 tensor.
 ///
+/// For details on aliases and members defined in this class, as well as general
+/// `TensorExpression` terminology used in its members' documentation, see
+/// documentation for `TensorExpression`.
+///
 /// \tparam T the type of the tensor expression of which to take the square
 /// root
 /// \tparam Args the TensorIndexs of the expression
@@ -60,15 +64,80 @@ struct SquareRoot
   /// whole subtree
   static constexpr size_t num_ops_subtree = num_ops_left_child + 1;
 
+  // === Properties for splitting up subexpressions along the primary path ===
+  // These definitions only have meaning if this expression actually ends up
+  // being along the primary path that is taken when evaluating the whole tree.
+  // See documentation for `TensorExpression` for more details.
+  /// If on the primary path, whether or not the expression is an ending point
+  /// of a leg
+  static constexpr bool is_primary_end = T::is_primary_start;
+  /// If on the primary path, this is the remaining number of arithmetic tensor
+  /// operations that need to be done in the subtree of the child along the
+  /// primary path, given that we will have already computed the whole subtree
+  /// at the next lowest leg's starting point.
+  static constexpr size_t num_ops_to_evaluate_primary_left_child =
+      is_primary_end ? 0 : T::num_ops_to_evaluate_primary_subtree;
+  /// If on the primary path, this is the remaining number of arithmetic tensor
+  /// operations that need to be done in the right operand's subtree. No
+  /// splitting is currently done, so this is just `num_ops_right_child`.
+  static constexpr size_t num_ops_to_evaluate_primary_right_child =
+      num_ops_right_child;
+  /// If on the primary path, this is the remaining number of arithmetic tensor
+  /// operations that need to be done for this expression's subtree, given that
+  /// we will have already computed the subtree at the next lowest leg's
+  /// starting point
+  static constexpr size_t num_ops_to_evaluate_primary_subtree =
+      num_ops_to_evaluate_primary_left_child +
+      num_ops_to_evaluate_primary_right_child + 1;
+  /// If on the primary path, whether or not the expression is a starting point
+  /// of a leg
+  static constexpr bool is_primary_start =
+      num_ops_to_evaluate_primary_subtree >=
+      detail::max_num_ops_in_sub_expression<type>;
+  /// If on the primary path, whether or not the expression's child along the
+  /// primary path is a subtree that contains a starting point of a leg along
+  /// the primary path
+  static constexpr bool primary_child_subtree_contains_primary_start =
+      T::primary_subtree_contains_primary_start;
+  /// If on the primary path, whether or not this subtree contains a starting
+  /// point of a leg along the primary path
+  static constexpr bool primary_subtree_contains_primary_start =
+      is_primary_start or primary_child_subtree_contains_primary_start;
+
   SquareRoot(T t) : t_(std::move(t)) {}
   ~SquareRoot() override = default;
+
+  /// \brief Assert that the LHS tensor of the equation does not also appear in
+  /// this expression's subtree
+  template <typename LhsTensor>
+  SPECTRE_ALWAYS_INLINE void assert_lhs_tensor_not_in_rhs_expression(
+      const gsl::not_null<LhsTensor*> lhs_tensor) const {
+    if constexpr (not std::is_base_of_v<NumberAsExpression, T>) {
+      t_.assert_lhs_tensor_not_in_rhs_expression(lhs_tensor);
+    }
+  }
+
+  /// \brief Assert that each instance of the LHS tensor in the RHS tensor
+  /// expression uses the same generic index order that the LHS uses
+  ///
+  /// \tparam LhsTensorIndices the list of generic `TensorIndex`s of the LHS
+  /// result `Tensor` being computed
+  /// \param lhs_tensor the LHS result `Tensor` being computed
+  template <typename LhsTensorIndices, typename LhsTensor>
+  SPECTRE_ALWAYS_INLINE void assert_lhs_tensorindices_same_in_rhs(
+      const gsl::not_null<LhsTensor*> lhs_tensor) const {
+    if constexpr (not std::is_base_of_v<NumberAsExpression, T>) {
+      t_.template assert_lhs_tensorindices_same_in_rhs<LhsTensorIndices>(
+          lhs_tensor);
+    }
+  }
 
   /// \brief Returns the square root of the component of the tensor evaluated
   /// from the contained tensor expression
   ///
   /// \details
   /// SquareRoot only supports tensor expressions that evaluate to a rank 0
-  /// Tensor This is why `multi_index` is always an array of size 0.
+  /// Tensor. This is why `multi_index` is always an array of size 0.
   ///
   /// \param multi_index the multi-index of the component of which to take the
   /// square root
@@ -77,6 +146,66 @@ struct SquareRoot
   SPECTRE_ALWAYS_INLINE decltype(auto) get(
       const std::array<size_t, num_tensor_indices>& multi_index) const {
     return sqrt(t_.get(multi_index));
+  }
+
+  /// \brief Returns the square root of the component of the tensor evaluated
+  /// from the contained tensor expression
+  ///
+  /// \details
+  /// SquareRoot only supports tensor expressions that evaluate to a rank 0
+  /// Tensor. This is why `multi_index` is always an array of size 0.
+  ///
+  /// This function differs from `get` in that it takes into account whether we
+  /// have already computed part of the result component at a lower subtree.
+  /// In recursively computing this square root, the current result component
+  /// will be substituted in for the most recent (highest) subtree below it that
+  /// has already been evaluated.
+  ///
+  /// \param result_component the LHS tensor component to evaluate
+  /// \param multi_index the multi-index of the component of which to take the
+  /// square root
+  /// \return the square root of the component of the tensor evaluated from the
+  /// contained tensor expression
+  SPECTRE_ALWAYS_INLINE decltype(auto) get_primary(
+      const type& result_component,
+      const std::array<size_t, num_tensor_indices>& multi_index) const {
+    if constexpr (is_primary_end) {
+      (void)multi_index;
+      // We've already computed the whole child subtree on the primary path, so
+      // just return the square root of the current result component
+      return sqrt(result_component);
+    } else {
+      // We haven't yet evaluated the whole subtree for this expression, so
+      // return the square root of this expression's subtree
+      return sqrt(t_.get_primary(result_component, multi_index));
+    }
+  }
+
+  /// \brief Successively evaluate the LHS Tensor's result component at each
+  /// leg in this expression's subtree
+  ///
+  /// \details
+  /// This function takes into account whether we have already computed part of
+  /// the result component at a lower subtree. In recursively computing this
+  /// square root, the current result component will be substituted in for the
+  /// most recent (highest) subtree below it that has already been evaluated.
+  ///
+  /// \param result_component the LHS tensor component to evaluate
+  /// \param multi_index the multi-index of the component of the result tensor
+  /// to evaluate
+  SPECTRE_ALWAYS_INLINE void evaluate_primary_subtree(
+      type& result_component,
+      const std::array<size_t, num_tensor_indices>& multi_index) const {
+    if constexpr (primary_child_subtree_contains_primary_start) {
+      // The primary child's subtree contains at least one leg, so recurse down
+      // and evaluate that first
+      t_.evaluate_primary_subtree(result_component, multi_index);
+    }
+
+    if constexpr (is_primary_start) {
+      // We want to evaluate the subtree for this expression
+      result_component = get_primary(result_component, multi_index);
+    }
   }
 
  private:

--- a/src/DataStructures/Tensor/Expressions/SquareRoot.hpp
+++ b/src/DataStructures/Tensor/Expressions/SquareRoot.hpp
@@ -35,11 +35,30 @@ struct SquareRoot
       "Can only take the square root of a tensor expression that evaluates to "
       "a rank 0 tensor.");
 
+  // === Index properties ===
+  /// The type of the data being stored in the result of the expression
   using type = typename T::type;
+  /// The ::Symmetry of the result of the expression
   using symmetry = typename T::symmetry;
+  /// The list of \ref SpacetimeIndex "TensorIndexType"s of the result of the
+  /// expression
   using index_list = typename T::index_list;
+  /// The list of generic `TensorIndex`s of the result of the expression
   using args_list = tmpl::list<Args...>;
+  /// The number of tensor indices in the result of the expression
   static constexpr auto num_tensor_indices = sizeof...(Args);
+
+  // === Arithmetic tensor operations properties ===
+  /// The number of arithmetic tensor operations done in the subtree for the
+  /// left operand
+  static constexpr size_t num_ops_left_child = T::num_ops_subtree;
+  /// The number of arithmetic tensor operations done in the subtree for the
+  /// right operand. This is 0 because this expression represents a unary
+  /// operation.
+  static constexpr size_t num_ops_right_child = 0;
+  /// The total number of arithmetic tensor operations done in this expression's
+  /// whole subtree
+  static constexpr size_t num_ops_subtree = num_ops_left_child + 1;
 
   SquareRoot(T t) : t_(std::move(t)) {}
   ~SquareRoot() override = default;
@@ -49,7 +68,7 @@ struct SquareRoot
   ///
   /// \details
   /// SquareRoot only supports tensor expressions that evaluate to a rank 0
-  /// Tensor. This is why `multi_index` is always an array of size 0.
+  /// Tensor This is why `multi_index` is always an array of size 0.
   ///
   /// \param multi_index the multi-index of the component of which to take the
   /// square root
@@ -61,6 +80,7 @@ struct SquareRoot
   }
 
  private:
+  /// Operand expression
   T t_;
 };
 }  // namespace tenex

--- a/src/DataStructures/Tensor/Expressions/TensorAsExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorAsExpression.hpp
@@ -179,13 +179,32 @@ struct TensorAsExpression<Tensor<X, Symm, IndexList<Indices...>>,
           typename detail::TensorAsExpressionSymm<Symm, IndexList<Indices...>,
                                                   ArgsList<Args...>>::type,
           IndexList<Indices...>, ArgsList<Args...>> {
+  // === Index properties ===
+  /// The type of the data being stored in the result of the expression
   using type = X;
+  /// The list of \ref SpacetimeIndex "TensorIndexType"s of the result of the
+  /// expression
   using symmetry =
       typename detail::TensorAsExpressionSymm<Symm, IndexList<Indices...>,
                                               ArgsList<Args...>>::type;
+  /// The list of \ref SpacetimeIndex "TensorIndexType"s of the result of the
+  /// expression
   using index_list = IndexList<Indices...>;
-  static constexpr auto num_tensor_indices = tmpl::size<index_list>::value;
+  /// The list of generic `TensorIndex`s of the result of the expression
   using args_list = ArgsList<Args...>;
+  /// The number of tensor indices in the result of the expression
+  static constexpr auto num_tensor_indices = tmpl::size<index_list>::value;
+
+  // === Arithmetic tensor operations properties ===
+  /// The number of arithmetic tensor operations done in the subtree for the
+  /// left operand, which is 0 because this is a leaf expression
+  static constexpr size_t num_ops_left_child = 0;
+  /// The number of arithmetic tensor operations done in the subtree for the
+  /// right operand, which is 0 because this is a leaf expression
+  static constexpr size_t num_ops_right_child = 0;
+  /// The total number of arithmetic tensor operations done in this expression's
+  /// whole subtree, which is 0 because this is a leaf expression
+  static constexpr size_t num_ops_subtree = 0;
 
   /// Construct an expression from a Tensor
   explicit TensorAsExpression(const Tensor<X, Symm, IndexList<Indices...>>& t)
@@ -207,6 +226,7 @@ struct TensorAsExpression<Tensor<X, Symm, IndexList<Indices...>>,
   }
 
  private:
+  /// `Tensor` represented by this expression
   const Tensor<X, Symm, IndexList<Indices...>>* t_ = nullptr;
 };
 }  // namespace tenex

--- a/src/DataStructures/Tensor/Expressions/TensorAsExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorAsExpression.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <array>
+#include <cassert>
 #include <cstddef>
 #include <type_traits>
 #include <utility>
@@ -15,6 +16,7 @@
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/Algorithm.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Requires.hpp"
@@ -58,7 +60,7 @@ template <
     size_t NumConcreteTimeIndices,
     Requires<(NumIndices >= 2 and (NumSpatialSpacetimeIndices != 0 or
                                    NumConcreteTimeIndices != 0))> = nullptr>
-constexpr std::array<std::int32_t, NumIndices>
+SPECTRE_ALWAYS_INLINE constexpr std::array<std::int32_t, NumIndices>
 get_transformed_spacetime_symmetry(
     const std::array<std::int32_t, NumIndices>& symmetry,
     const std::array<size_t, NumSpatialSpacetimeIndices>&
@@ -86,7 +88,7 @@ template <size_t NumIndices, size_t NumSpatialSpacetimeIndices,
           size_t NumConcreteTimeIndices,
           Requires<(NumIndices < 2 or (NumSpatialSpacetimeIndices == 0 and
                                        NumConcreteTimeIndices == 0))> = nullptr>
-constexpr std::array<std::int32_t, NumIndices>
+SPECTRE_ALWAYS_INLINE constexpr std::array<std::int32_t, NumIndices>
 get_transformed_spacetime_symmetry(
     const std::array<std::int32_t, NumIndices>& symmetry,
     const std::array<size_t, NumSpatialSpacetimeIndices>&
@@ -162,6 +164,10 @@ struct TensorAsExpressionSymm<SymmList<Symm...>, TensorIndexTypeList,
 /// tensor, this is already over 500 base classes, which the Intel compiler
 /// takes too long to compile.
 ///
+/// For details on aliases and members defined in this class, as well as general
+/// `TensorExpression` terminology used in its members' documentation, see
+/// documentation for `TensorExpression`.
+///
 /// \tparam T the type of Tensor being represented as an expression
 /// \tparam ArgsList the tensor indices, e.g. `_a` and `_b` in `F(_a, _b)`
 template <typename T, typename ArgsList>
@@ -206,10 +212,73 @@ struct TensorAsExpression<Tensor<X, Symm, IndexList<Indices...>>,
   /// whole subtree, which is 0 because this is a leaf expression
   static constexpr size_t num_ops_subtree = 0;
 
+  // === Properties for splitting up subexpressions along the primary path ===
+  // These definitions only have meaning if this expression actually ends up
+  // being along the primary path that is taken when evaluating the whole tree.
+  // See documentation for `TensorExpression` for more details.
+  /// If on the primary path, whether or not the expression is an ending point
+  /// of a leg
+  static constexpr bool is_primary_end = true;
+  /// If on the primary path, this is the remaining number of arithmetic tensor
+  /// operations that need to be done in the subtree of the child along the
+  /// primary path, given that we will have already computed the whole subtree
+  /// at the next lowest leg's starting point. This is just 0 because this
+  /// expression is a leaf.
+  static constexpr size_t num_ops_to_evaluate_primary_left_child = 0;
+  /// If on the primary path, this is the remaining number of arithmetic tensor
+  /// operations that need to be done in the right operand's subtree. This is
+  /// just 0 because this expression is a leaf.
+  static constexpr size_t num_ops_to_evaluate_primary_right_child = 0;
+  /// If on the primary path, this is the remaining number of arithmetic tensor
+  /// operations that need to be done for this expression's subtree, given that
+  /// we will have already computed the subtree at the next lowest leg's
+  /// starting point. This is just 0 because this expression is a leaf.
+  static constexpr size_t num_ops_to_evaluate_primary_subtree = 0;
+  /// If on the primary path, whether or not the expression is a starting point
+  /// of a leg
+  static constexpr bool is_primary_start = false;
+  /// If on the primary path, whether or not the expression's child along the
+  /// primary path is a subtree that contains a starting point of a leg along
+  /// the primary path. This is always falls because this expression is a leaf.
+  static constexpr bool primary_child_subtree_contains_primary_start = false;
+  /// If on the primary path, whether or not this subtree contains a starting
+  /// point of a leg along the primary path
+  static constexpr bool primary_subtree_contains_primary_start =
+      is_primary_start;
+
   /// Construct an expression from a Tensor
   explicit TensorAsExpression(const Tensor<X, Symm, IndexList<Indices...>>& t)
       : t_(&t) {}
   ~TensorAsExpression() override = default;
+
+  /// \brief Assert that the LHS tensor of the equation is not equal to the
+  /// `Tensor` represented by this expression
+  template <typename LhsTensor>
+  SPECTRE_ALWAYS_INLINE void assert_lhs_tensor_not_in_rhs_expression(
+      const gsl::not_null<LhsTensor*> lhs_tensor) const {
+    (void)lhs_tensor;
+    ASSERT(static_cast<const void*>(&(*t_)) != &(*lhs_tensor),
+           "The LHS Tensor cannot also be in the RHS expression in the call to "
+           "tenex::evaluate(). Use tenex::update() instead.");
+  }
+
+  /// \brief If the LHS tensor is the tensor represented by this expression,
+  /// assert that the order of the generic indices are the same
+  ///
+  /// \tparam LhsTensorIndices the list of generic `TensorIndex`s of the LHS
+  /// result `Tensor` being computed
+  /// \param lhs_tensor the LHS result `Tensor` being computed
+  template <typename LhsTensorIndices, typename LhsTensor>
+  SPECTRE_ALWAYS_INLINE void assert_lhs_tensorindices_same_in_rhs(
+      const gsl::not_null<LhsTensor*> lhs_tensor) const {
+    if (static_cast<const void*>(&(*t_)) == &(*lhs_tensor)) {
+      ASSERT(
+          (std::is_same_v<LhsTensorIndices, args_list>),
+          "The LHS Tensor was also found in the RHS tensor expression, but the "
+          "generic index order used for it on the RHS does not match the order "
+          "used for it on the LHS.");
+    }
+  }
 
   /// \brief Returns the value of the contained tensor's multi-index
   ///
@@ -218,6 +287,32 @@ struct TensorAsExpression<Tensor<X, Symm, IndexList<Indices...>>,
   SPECTRE_ALWAYS_INLINE decltype(auto) get(
       const std::array<size_t, num_tensor_indices>& multi_index) const {
     return t_->get(multi_index);
+  }
+
+  /// \brief Returns the value of the contained tensor's multi-index
+  ///
+  /// \param multi_index the multi-index of the tensor component to retrieve
+  /// \return the value of the component at `multi_index` in the tensor
+  SPECTRE_ALWAYS_INLINE decltype(auto) get_primary(
+      const type& /*result_component*/,
+      const std::array<size_t, num_tensor_indices>& multi_index) const {
+    return t_->get(multi_index);
+  }
+
+  /// \brief If this expression is the start of a leg, update the LHS result
+  /// component to be the value of the component at the given multi-index of the
+  /// `Tensor` represented by the expression
+  ///
+  /// \param result_component the LHS tensor component to evaluate
+  /// \param multi_index the multi-index of the component of the `Tensor`
+  /// represented by the expression
+  SPECTRE_ALWAYS_INLINE void evaluate_primary_subtree(
+      type& result_component,
+      const std::array<size_t, num_tensor_indices>& multi_index) const {
+    if constexpr (is_primary_start) {
+      // We want to evaluate the subtree for this expression
+      result_component = get(multi_index);
+    }
   }
 
   /// Retrieve the i'th entry of the Tensor being held

--- a/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <limits>
+
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/TMPL.hpp"
@@ -22,12 +24,245 @@ struct Expression {};
 /// \ingroup TensorExpressionsGroup
 /// \brief The base class all tensor expression implementations derive from
 ///
+/// \details
+/// ## Tensor equation construction
+/// Each derived `TensorExpression` class should be thought of as an expression
+/// tree that represents some operation done on or between tensor expressions.
+/// Arithmetic operators and other mathematical functions of interest
+/// (e.g. `sqrt`) have overloads defined that accept `TensorExpression`s and
+/// return a new `TensorExpression` representing the result tensor of such an
+/// operation. In this way, an equation written with `TensorExpression`s will
+/// generate an expression tree where the internal and leaf nodes are instances
+/// of the derived `TensorExpression` classes. For example, `tenex::AddSub`
+/// defines an internal node for handling the addition and subtraction
+/// operations between tensors expressions, while `tenex::TensorAsExpression`
+/// defines a leaf node that represents a single `Tensor` that appears in the
+/// equation.
+///
+/// ## Tensor equation evaluation
+/// The overall tree for an equation and the order in which we traverse the tree
+/// define the order of operations done to compute the resulting LHS `Tensor`.
+/// The evaluation is done by `tenex::evaluate`, which traverses the whole tree
+/// once for each unique LHS component in order to evaluate the full LHS
+/// `Tensor`. There are two different traversals currently implemented that are
+/// chosen from, depending on the tensor equation being evaluated:
+/// 1. **Evaluate the whole tree as one expression** using in-order traversal.
+/// This is like generating and solving a one-liner of the whole equation.
+/// 2. **Split up the tree into subexpressions** that are each evaluated with
+/// in-order traversal to successively "accumulate" a LHS result component of
+/// the equation. This is like splitting the equation up and solving pieces of
+/// it at a time with multiple lines of assignments/updates (see details below).
+///
+/// ## Equation splitting details
+/// Splitting up the tree and evaluating subexpressions is beneficial when we
+/// believe it to lead to a better runtime than if we were to compute the whole
+/// expression as a one-liner. One important use case is when the `Tensor`s in
+/// the equation hold components whose data type is `DataVector`. From
+/// benchmarking, it was found that the runtime of `DataVector` expressions
+/// scales poorly as we increase the number of operations. For example, for an
+/// inner product with 256 sums of products, instead of adding 256 `DataVector`
+/// products in one line (e.g. `result = A*B + C*D + E*F + ...;`), it's much
+/// faster to, say, set the result to be the sum of the first 8 products, then
+/// `+=` the next 8, and so forth. This is what is meant by "accumulating" the
+/// LHS result tensor, and what the `TensorExpression` splitting emulates. Note
+/// that while 8 is the number used in this example, the exact optimal number of
+/// operations will be hardware-dependent, but probably not something we need to
+/// really worry about fine-tuning. However, a ballpark estimate for a "good"
+/// number of operations may vary greatly depending on the data type of the
+/// components (e.g. `double` vs. `DataVector`), which is something important
+/// to at least coarsely tune.
+///
+/// ### How the tree is split up
+/// Let's define the **primary path** to be the path in the tree going from the
+/// root node to the leftmost leaf. The overall tree contains subtrees
+/// represented by different `TensorExpression`s in the equation. Certain
+/// subtrees are marked as the starting and/or ending points of these "pieces"
+/// of the equation. Let's define a **leg** to be a "segment" along the primary
+/// path delineated by a starting and ending expression subtree. These
+/// delineations are made where we decide there are enough operations in a
+/// subtree that it would be wise to split at that point. What is considered to
+/// be "enough" operations is specialized based on the data type held by the
+/// `Tensor`s in the expression (see `tenex::max_num_ops_in_sub_expression`).
+///
+/// ### How a split tree is traversed and evaluated
+/// We recurse down the primary path, visiting each expression subtree until we
+/// reach the start of the lowest leg, then initialize the LHS result component
+/// we're wanting to compute to be the result of this lowest expression. Then,
+/// we recurse back up to the expression subtree that is starting point of the
+/// leg "above" it and compute that subtree. This time, however, when
+/// recursively evaluating this higher subtree, we substitute in the current LHS
+/// result for that lower subtree that we have already computed. This is
+/// repeated as we "climb up" the primary path to successively accumulate the
+/// result component.
+///
+/// **Note:** The primary path is currently implemented as the path specified
+/// above, but there's no reason it couldn't be reimplemented to be a different
+/// path. The idea with the current implementation is to select a path from root
+/// to leaf that is long so we have more flexibility in splitting, should we
+/// want to. When evaluating, we *could* implement the traversal to take a
+/// different path, but currently, derived `TensorExpression`s that represent
+/// commutative binary operations are instantiated with the larger subtree being
+/// the left child and the smaller subtree being the right child. By
+/// constructing it this way, we elongate the leftmost path, which will allow
+/// for increased splitting.
+///
+/// ## Requirements for derived `TensorExpression` classes
+/// Each derived `TensorExpression` class must define the following aliases and
+/// members:
+/// - `private` variables that store its operands' derived `TensorExpression`s.
+/// We make these non-`const` to allow for move construction.
+/// - Constructor that initializes the above `private` operand members
+/// - alias `type`: The data type of the data being stored in the result of the
+/// expression, e.g. `double`, `DataVector`
+/// - alias `symmetry`: The ::Symmetry of the result of the expression
+/// - alias `index_list`: The list of \ref SpacetimeIndex "TensorIndexType"s of
+/// the result of the expression
+/// - alias `args_list`: The list of generic `TensorIndex`s of the result of the
+/// expression
+/// - variable `static constexpr size_t num_tensor_indices`: The number of
+/// tensor indices in the result of the expression
+/// - variable `static constexpr size_t num_ops_left_child`: The number of
+/// arithmetic tensor operations done in the subtree for the expression's left
+/// operand. If the expression represents a unary operation, their only child is
+/// considered the left child. If the expression is a leaf node, then this value
+/// should be set to 0 since retrieving a value at the leaf involves 0
+/// arithmetic tensor operations.
+/// - variable `static constexpr size_t num_ops_right_child`: The number of
+/// arithmetic tensor operations done in the expression's right operand. If the
+/// expression represents a unary operation or is leaf node, this should be set
+/// to 0 because there is no right child.
+/// - variable `static constexpr size_t num_ops_subtree`: The number of
+/// arithmetic tensor operations done in the subtree represented by the
+/// expression. For `AddSub`, for example, this is
+/// `num_ops_left_child + num_ops_right_child + 1`, the sum of the number of
+/// operations in each operand's subtrees plus one for the operation done for
+/// the expression, itself.
+/// - function `decltype(auto) get(const std::array<size_t, num_tensor_indices>&
+/// result_multi_index) const`: Accepts a multi-index for the result tensor
+/// represented by the expression and returns the computed result of the
+/// expression at that multi-index. This should call the operands' `get`
+/// functions in order to recursively compute the result of the expression.
+/// - function template
+/// `template <typename LhsTensor> void assert_lhs_tensor_not_in_rhs_expression(
+/// const gsl::not_null<LhsTensor*> lhs_tensor) const`: Asserts that the LHS
+/// `Tensor` we're computing does not also appear in the RHS `TensorExpression`.
+/// We define this because if a tree is split up, then the LHS `Tensor` will
+/// generally not be computed correctly because the LHS components will be
+/// updated as we traverse the split tree.
+/// - function template
+/// \code
+/// template <typename LhsTensorIndices, typename LhsTensor>
+/// void assert_lhs_tensorindices_same_in_rhs(
+///     const gsl::not_null<LhsTensor*> lhs_tensor) const;
+/// \endcode
+/// Asserts that any instance of the LHS `Tensor` in the RHS `TensorExpression`
+/// uses the same generic index order that the LHS uses. We define this because
+/// if a tree is not split up, it's safe to use the LHS `Tensor` on the RHS if
+/// the generic index order is the same. In these cases, `tenex::update` should
+/// be used instead of `tenex::evaluate`. See the documentation for
+/// `tenex::update` for more details and `tenex::detail::evaluate_impl` for why
+/// this is safe to do.
+///
+/// Each derived `TensorExpression` class must also define the following
+/// members, which have real meaning for the expression *only* if it ends up
+/// belonging to the primary path of the tree that is traversed:
+/// - variable `static constexpr bool is_primary_start`: If on the primary path,
+/// whether or not the expression is a starting point of a leg. This is true
+/// when there are enough operations to warrant splitting (see
+/// `tenex::max_num_ops_in_sub_expression`).
+/// - variable `static constexpr bool is_primary_end`: If on the primary path,
+/// whether or not the expression is an ending point of a leg. This is true when
+/// the expression's child along the primary path is a starting point of a leg.
+/// - variable `static constexpr size_t num_ops_to_evaluate_primary_left_child`:
+/// If on the primary path, this is the remaining number of arithmetic tensor
+/// operations that need to be done in the subtree of the child along the
+/// primary path, given that we will have already computed the whole subtree at
+/// the next lowest leg's starting point.
+/// - variable
+/// `static constexpr size_t num_ops_to_evaluate_primary_right_child`:
+/// If on the primary path, this is the remaining number of arithmetic tensor
+/// operations that need to be done in the right operand's subtree. Because
+/// the branches off of the primary path currently are not split up in any way,
+/// this currently should simply be equal to `num_ops_right_child`. If logic is
+/// added to split up these branches, logic will need to be added to compute
+/// this remaining number of operations in the right subtree.
+/// - variable `static constexpr size_t num_ops_to_evaluate_primary_subtree`:
+/// If on the primary path, this is the remaining number of arithmetic tensor
+/// operations that need to be done for this expression's subtree, given that we
+/// will have already computed the subtree at the next lowest leg's starting
+/// point. For example, for `tenex::AddSub`, this is just
+/// `num_ops_to_evaluate_primary_left_child +
+/// num_ops_to_evaluate_primary_right_child + 1` (the extra 1 for the `+` or `-`
+/// operation itself).
+/// - variable
+/// `static constexpr bool primary_child_subtree_contains_primary_start`:
+/// If on the primary path, whether or not the expression's child along the
+/// primary path is a subtree that contains a starting point of a leg along the
+/// primary path. In other words, whether or not there is a split on the primary
+/// path lower than this expression. When evaluating a split tree, this is
+/// useful because it tells us we need to keep recursing down to a lower leg and
+/// evaluate that lower subtree first before evaluating the current subtree.
+/// - variable `static constexpr bool primary_subtree_contains_primary_start`:
+/// If on the primary path, whether or not this subtree contains a starting
+/// point of a leg along the primary path. In other words, whether or not there
+/// is a split on the primary path at this expression or beneath it.
+/// - function `decltype(auto) get_primary(const type& result_component,
+/// const std::array<size_t, num_tensor_indices>& result_multi_index) const`:
+/// This is similar to the required `get` function described above, but this
+/// should be used when the tree is split up. The main difference with this
+/// function is that it takes the current result component (that we're
+/// computing) as an argument, and when we hit the starting point of the next
+/// lowest leg on the primary path when recursively evaluating the current leg,
+/// we substitute in the current LHS result for the subtree that we have already
+/// computed. This function should call `get_primary` on the child on the
+/// primary path and `get` on the other child, if one exists.
+/// - function `void evaluate_primary_subtree(type& result_component,
+/// const std::array<size_t, num_tensor_indices>& result_multi_index) const`:
+/// This should first recursively evaluate the legs beneath it on the primary
+/// path, then if the expression itself is the start of a leg, it should
+/// evaluate this leg by calling the expression's own `get_primary` to compute
+/// it and update the result component being accumulated. `tenex::evaluate`
+/// should call this function on the root node for the whole tree if there is
+/// determined to be any splits in the tree.
+///
+/// ## Current advice for improving and extending `TensorExpression`s
+/// - Derived `TensorExpression` classes (or the overloads that produce them)
+/// should include `static_assert`s for ensuring mathematical correctness
+/// wherever reasonable
+/// - Minimize breadth in the tree where possible because benchmarking inner
+/// products has shown that increased tree breadth can cause slower runtimes.
+/// In addition, more breadth means a decreased ability to split up the tree
+/// along the primary path.
+/// - Minimize the number of multi-index transformations that need to be done
+/// when evaluating the tree. For some operations like addition, the associated
+/// multi-indices of the two operands needs to be computed from the multi-index
+/// of the result, which may involve reordering and/or shifting the values of
+/// the result index. It's good to minimize the number of these kinds of
+/// transformations from result to operand multi-index where we can.
+/// - Unless the implementation of Tensor_detail::Structure changes, it's not
+/// advised for the derived `TensorExpression` classes to have anything that
+/// would instantiate the Tensor_detail::Structure of the tensor that would
+/// result from the expression. This is really only a problem when the result of
+/// the expression would be a tensor with many components, because the compile
+/// time of the mapping between storage indices and multi-indices within
+/// Tensor_detail::Structure scales very poorly with the number of components.
+/// It's important to keep in mind that while SpECTRE currently only supports
+/// creating `Tensor`s up to rank 4, there is nothing preventing the represented
+/// result tensor of a expression being higher rank, e.g.
+/// `R(ti_j, ti_b, ti_A) * (S(ti_d, ti_a, ti_B, ti_C) * T(ti_J, ti_k, ti_l))`
+/// contains an intermediate outer product expression
+/// `S(ti_d, ti_a, ti_B, ti_C) * T(ti_J, ti_k, ti_l)` that represents a rank 7
+/// tensor, even though a rank 7 `Tensor` is never instantiated. Having the
+/// outer product expression instantiate the Tensor_detail::Structure of this
+/// intermediate result currently leads to an unreasonable compile time.
+///
 /// \tparam Derived the derived class needed for
 /// [CRTP](https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern)
-/// \tparam DataType the type of the data being stored in the Tensor's
+/// \tparam DataType the type of the data being stored in the `Tensor`s
 /// \tparam Symm the ::Symmetry of the Derived class
-/// \tparam IndexList the list of \ref SpacetimeIndex "TensorIndex"'s
-/// \tparam Args the tensor indices, e.g. `a` and `b` in `F(ti::a, ti::b)`
+/// \tparam IndexList the list of \ref SpacetimeIndex "TensorIndexType"s
+/// \tparam Args typelist of the tensor indices, e.g. types of `ti::a` and
+/// `ti::b` in `F(ti::a, ti::b)`
 /// \cond HIDDEN_SYMBOLS
 template <typename Derived, typename DataType, typename Symm,
           typename IndexList, typename Args = tmpl::list<>,
@@ -43,12 +278,17 @@ struct TensorExpression<Derived, DataType, Symm, tmpl::list<Indices...>,
   static_assert(sizeof...(Args) == 0 or sizeof...(Args) == sizeof...(Indices),
                 "the number of Tensor indices must match the number of "
                 "components specified in an expression.");
+  /// The type of the data being stored in the `Tensor`s
   using type = DataType;
+  /// The ::Symmetry of the `Derived` class
   using symmetry = Symm;
+  /// The list of \ref SpacetimeIndex "TensorIndexType"s
   using index_list = tmpl::list<Indices...>;
-  static constexpr auto num_tensor_indices = tmpl::size<index_list>::value;
-  /// Typelist of the tensor indices, e.g. `_a_t` and `_b_t` in `F(_a, _b)`
+  /// Typelist of the tensor indices, e.g. types of `ti_a` and `ti_b`
+  /// in `F(ti_a, ti_b)`
   using args_list = ArgsList<Args...>;
+  /// The number of tensor indices of the `Derived` class
+  static constexpr auto num_tensor_indices = tmpl::size<index_list>::value;
 
   virtual ~TensorExpression() = 0;
 
@@ -70,3 +310,60 @@ template <typename Derived, typename DataType, typename Symm,
 TensorExpression<Derived, DataType, Symm, tmpl::list<Indices...>,
                  ArgsList<Args...>>::~TensorExpression() = default;
 /// @}
+
+namespace tenex {
+namespace detail {
+/// @{
+/// \brief The maximum number of arithmetic tensor operations allowed in a
+/// `TensorExpression` subtree before having it be a splitting point in the
+/// overall RHS expression, according to the data type held by the `Tensor`s in
+/// the expression
+///
+/// \details
+/// To enable splitting for `TensorExpression`s with a different data type,
+/// define a new variable below like `max_num_ops_in_datavector_sub_expression`
+/// for your data type, then update the control flow in
+/// `max_num_ops_in_sub_expression_helper`.
+///
+/// Before defining a max operations cap for some data type, the change should
+/// first be justified by benchmarking many different tensor expressions before
+/// and after introducing the new cap. The optimal cap will likely be
+/// hardware-dependent, so fine-tuning this would ideally involve benchmarking
+/// on each hardware architecture and then controling the value based on the
+/// hardware.
+///
+/// The current value set for when the data type is `DataVector` was benchmarked
+/// by compiling with clang-10 Release and running on Intel(R) Xeon(R)
+/// CPU E5-2630 v4 @ 2.20GHz.
+static constexpr size_t max_num_ops_in_datavector_sub_expression = 8;
+/// @}
+
+/// \brief Helper struct for getting the maximum number of arithmetic tensor
+/// operations allowed in a `TensorExpression` subtree before having it be a
+/// splitting point in the overall RHS expression, according to the `DataType`
+/// held by the `Tensor`s in the expression
+///
+/// \tparam DataType the type of the data being stored in the `Tensor`s in the
+/// `TensorExpression`
+template <typename DataType>
+struct max_num_ops_in_sub_expression_helper {
+  // Splitting is only enabled for expressions when DataType == DataVector
+  // because benchmarking has shown it to be beneficial. To enable splitting
+  // for other data types, define a new static variable like
+  // `max_num_ops_in_datavector_sub_expression` for the data type of interest,
+  // then update the control flow below
+  static constexpr size_t value = std::is_same_v<DataType, DataVector>
+                                      ? max_num_ops_in_datavector_sub_expression
+                                      // effectively, no splitting
+                                      : std::numeric_limits<size_t>::max();
+};
+
+/// \brief Get maximum number of arithmetic tensor operations allowed in a
+/// `TensorExpression` subtree before having it be a splitting point in the
+/// overall RHS expression, according to the `DataType` held by the `Tensor`s in
+/// the expression
+template <typename DataType>
+inline constexpr size_t max_num_ops_in_sub_expression =
+    max_num_ops_in_sub_expression_helper<DataType>::value;
+}  // namespace detail
+}  // namespace tenex

--- a/src/DataStructures/Tensor/Expressions/TensorIndexTransformation.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorIndexTransformation.hpp
@@ -151,11 +151,12 @@ transform_multi_index(
       make_array<NumIndicesOut, size_t>(0);
   for (size_t i = 0; i < NumIndicesOut; i++) {
     gsl::at(output_multi_index, i) =
-        (gsl::at(tensorindex_transformation, i) ==
+        // Check that the index is not a time index instead of checking that it
+        // is, because we expect it to not be a time index most of the time
+        (gsl::at(tensorindex_transformation, i) !=
          TensorIndexTransformation_detail::time_index_position_placeholder)
-            ? 0
-            : gsl::at(input_multi_index,
-                      gsl::at(tensorindex_transformation, i));
+            ? gsl::at(input_multi_index, gsl::at(tensorindex_transformation, i))
+            : 0;
   }
   return output_multi_index;
 }

--- a/src/Evolution/Systems/Ccz4/TimeDerivative.cpp
+++ b/src/Evolution/Systems/Ccz4/TimeDerivative.cpp
@@ -493,7 +493,7 @@ void TimeDerivative<Dim>::apply(
                    (*spatial_z4_constraint)(ti::j)));
   // now, if s == 1, also add terms with s
   if (static_cast<bool>(evolve_shift)) {
-    ::tenex::evaluate<ti::I>(
+    ::tenex::update<ti::I>(
         dt_gamma_hat,
         (*dt_gamma_hat)(ti::I) +
             // terms with lapse and s
@@ -537,7 +537,7 @@ void TimeDerivative<Dim>::apply(
                2.0 * c * d_theta(ti::k)));
   // now, if s == 1, also add terms with s
   if (static_cast<bool>(evolve_shift)) {
-    ::tenex::evaluate<ti::k>(
+    ::tenex::update<ti::k>(
         dt_field_a, (*dt_field_a)(ti::k) -
                         (*lapse_times_slicing_condition)() *
                             ((*inv_conformal_metric_times_d_a_tilde)(ti::k) -
@@ -584,7 +584,7 @@ void TimeDerivative<Dim>::apply(
                    (*field_d_up_times_a_tilde)(ti::k)));
   // now, if s == 1, also add terms with s
   if (static_cast<bool>(evolve_shift)) {
-    ::tenex::evaluate<ti::k, ti::i, ti::j>(
+    ::tenex::update<ti::k, ti::i, ti::j>(
         dt_field_d, (*dt_field_d)(ti::k, ti::i, ti::j) +
                         0.5 * ((*conformal_metric_times_symmetrized_d_field_b)(
                                    ti::i, ti::k, ti::j) +
@@ -604,7 +604,7 @@ void TimeDerivative<Dim>::apply(
                            field_a(ti::k) * trace_extrinsic_curvature()));
   // now, if s == 1, also add terms with s
   if (static_cast<bool>(evolve_shift)) {
-    ::tenex::evaluate<ti::k>(
+    ::tenex::update<ti::k>(
         dt_field_p,
         (*dt_field_p)(ti::k) +
             one_third *

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_AddSubtract.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_AddSubtract.cpp
@@ -36,6 +36,27 @@ void assign_unique_values_to_tensor(
   }
 }
 
+// Checks that the number of ops in the expressions match what is expected
+void test_tensor_ops_properties() {
+  const Scalar<double> G{};
+  const double H = 0.0;
+  const tnsr::ii<double, 3> R{};
+  const tnsr::ij<double, 3> S{};
+  const tnsr::aa<double, 3> T{};
+
+  const auto scalar_expression = H - G() - H;
+  const auto R_plus_S = R(ti::i, ti::j) + S(ti::i, ti::j);
+  const auto R_minus_T = R(ti::i, ti::j) - T(ti::j, ti::i);
+  const auto large_expression = R(ti::i, ti::j) + S(ti::i, ti::j) -
+                                T(ti::j, ti::i) + S(ti::j, ti::i) +
+                                S(ti::i, ti::j) - R(ti::j, ti::i);
+
+  CHECK(scalar_expression.num_ops_subtree == 2);
+  CHECK(R_plus_S.num_ops_subtree == 1);
+  CHECK(R_minus_T.num_ops_subtree == 1);
+  CHECK(large_expression.num_ops_subtree == 5);
+}
+
 // \brief Test the sum and difference of a `double` and tensor expression is
 // correctly evaluated
 //
@@ -99,6 +120,9 @@ void test_addsub_double(const DataType& used_for_size) {
 
 SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
                   "[DataStructures][Unit]") {
+  test_tensor_ops_properties();
+
+  // Test adding and subtracting `double`s
   test_addsub_double(std::numeric_limits<double>::signaling_NaN());
   test_addsub_double(
       DataVector(5, std::numeric_limits<double>::signaling_NaN()));

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Contract.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Contract.cpp
@@ -34,7 +34,39 @@ void create_tensor(gsl::not_null<Tensor<DataVector, Ts...>*> tensor) {
   }
 }
 
-const size_t contracted_value_placeholder = std::numeric_limits<size_t>::max();
+// Contractions are performed by summing over multi-indices in an order that is
+// implementation defined. What is considered the "next lowest" and
+// "next highest" multi-indices should be opposites of each other. This test
+// checks this, as well as checking that the "lowest" and "highest"
+// multi-indices being summed are correctly determined.
+void test_contraction_summation_consistency() {
+  const tnsr::II<double, 3, Frame::Inertial> R{};
+  const tnsr::iab<double, 3, Frame::Inertial> S{};
+
+  // L is a `TensorContract`, not a `Tensor`
+  const auto L = R(ti::J, ti::I) * S(ti::i, ti::a, ti::j);
+  // multi-index for L_2
+  const std::array<size_t, 1> L_multi_index = {2};
+
+  const std::array<size_t, 5> lowest_multi_index =
+      L.get_lowest_multi_index_to_sum(L_multi_index);
+  const std::array<size_t, 5> expected_lowest_multi_index = {0, 0, 0, 2, 1};
+  CHECK(lowest_multi_index == expected_lowest_multi_index);
+
+  const std::array<size_t, 5> highest_multi_index =
+      L.get_highest_multi_index_to_sum(L_multi_index);
+  const std::array<size_t, 5> expected_highest_multi_index = {2, 2, 2, 2, 3};
+  CHECK(highest_multi_index == expected_highest_multi_index);
+
+  std::array<size_t, 5> current_multi_index = expected_lowest_multi_index;
+  while (current_multi_index != expected_highest_multi_index) {
+    const auto next_lowest_multi_index =
+        L.get_next_lowest_multi_index_to_sum(current_multi_index);
+    CHECK(L.get_next_highest_multi_index_to_sum(next_lowest_multi_index) ==
+          current_multi_index);
+    current_multi_index = next_lowest_multi_index;
+  }
+}
 
 template <typename DataType>
 void test_contractions_rank2(const DataType& used_for_size) {
@@ -47,13 +79,7 @@ void test_contractions_rank2(const DataType& used_for_size) {
       Rul(used_for_size);
   create_tensor(make_not_null(&Rul));
 
-  const auto RIi_expr = Rul(ti::I, ti::i);
-  const std::array<size_t, 2> expected_multi_index{
-      {contracted_value_placeholder, contracted_value_placeholder}};
-  CHECK(RIi_expr.get_uncontracted_multi_index_with_uncontracted_values({{}}) ==
-        expected_multi_index);
-
-  const Tensor<DataType> RIi_contracted = tenex::evaluate(RIi_expr);
+  const Tensor<DataType> RIi_contracted = tenex::evaluate(Rul(ti::I, ti::i));
 
   DataType expected_RIi_sum = make_with_value<DataType>(used_for_size, 0.0);
   for (size_t i = 0; i < 3; i++) {
@@ -68,11 +94,7 @@ void test_contractions_rank2(const DataType& used_for_size) {
       Rlu(used_for_size);
   create_tensor(make_not_null(&Rlu));
 
-  const auto RgG_expr = Rlu(ti::g, ti::G);
-  CHECK(RgG_expr.get_uncontracted_multi_index_with_uncontracted_values({{}}) ==
-        expected_multi_index);
-
-  const Tensor<DataType> RgG_contracted = tenex::evaluate(RgG_expr);
+  const Tensor<DataType> RgG_contracted = tenex::evaluate(Rlu(ti::g, ti::G));
 
   DataType expected_RgG_sum = make_with_value<DataType>(used_for_size, 0.0);
   for (size_t g = 0; g < 4; g++) {
@@ -93,17 +115,11 @@ void test_contractions_rank3(const DataType& used_for_size) {
       Rlul(used_for_size);
   create_tensor(make_not_null(&Rlul));
 
-  const auto RiIj_expr = Rlul(ti::i, ti::I, ti::j);
   const Tensor<DataType, Symmetry<1>,
                index_list<SpatialIndex<4, UpLo::Lo, Frame::Grid>>>
-      RiIj_contracted = tenex::evaluate<ti::j>(RiIj_expr);
+      RiIj_contracted = tenex::evaluate<ti::j>(Rlul(ti::i, ti::I, ti::j));
 
   for (size_t j = 0; j < 4; j++) {
-    const std::array<size_t, 3> expected_multi_index{
-        {contracted_value_placeholder, contracted_value_placeholder, j}};
-    CHECK(RiIj_expr.get_uncontracted_multi_index_with_uncontracted_values(
-              {{j}}) == expected_multi_index);
-
     DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
     for (size_t i = 0; i < 3; i++) {
       expected_sum += Rlul.get(i, i, j);
@@ -119,17 +135,11 @@ void test_contractions_rank3(const DataType& used_for_size) {
       Ruul(used_for_size);
   create_tensor(make_not_null(&Ruul));
 
-  const auto RJLj_expr = Ruul(ti::J, ti::L, ti::j);
   const Tensor<DataType, Symmetry<1>,
                index_list<SpatialIndex<3, UpLo::Up, Frame::Grid>>>
-      RJLj_contracted = tenex::evaluate<ti::L>(RJLj_expr);
+      RJLj_contracted = tenex::evaluate<ti::L>(Ruul(ti::J, ti::L, ti::j));
 
   for (size_t l = 0; l < 3; l++) {
-    const std::array<size_t, 3> expected_multi_index{
-        {contracted_value_placeholder, l, contracted_value_placeholder}};
-    CHECK(RJLj_expr.get_uncontracted_multi_index_with_uncontracted_values(
-              {{l}}) == expected_multi_index);
-
     DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
     for (size_t j = 0; j < 3; j++) {
       expected_sum += Ruul.get(j, l, j);
@@ -145,17 +155,11 @@ void test_contractions_rank3(const DataType& used_for_size) {
       Rulu(used_for_size);
   create_tensor(make_not_null(&Rulu));
 
-  const auto RBfF_expr = Rulu(ti::B, ti::f, ti::F);
   const Tensor<DataType, Symmetry<1>,
                index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>>
-      RBfF_contracted = tenex::evaluate<ti::B>(RBfF_expr);
+      RBfF_contracted = tenex::evaluate<ti::B>(Rulu(ti::B, ti::f, ti::F));
 
   for (size_t b = 0; b < 4; b++) {
-    const std::array<size_t, 3> expected_multi_index{
-        {b, contracted_value_placeholder, contracted_value_placeholder}};
-    CHECK(RBfF_expr.get_uncontracted_multi_index_with_uncontracted_values(
-              {{b}}) == expected_multi_index);
-
     DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
     for (size_t f = 0; f < 4; f++) {
       expected_sum += Rulu.get(b, f, f);
@@ -172,17 +176,11 @@ void test_contractions_rank3(const DataType& used_for_size) {
       Rllu(used_for_size);
   create_tensor(make_not_null(&Rllu));
 
-  const auto RiaI_expr = Rllu(ti::i, ti::a, ti::I);
   const Tensor<DataType, Symmetry<1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      RiaI_contracted = tenex::evaluate<ti::a>(RiaI_expr);
+      RiaI_contracted = tenex::evaluate<ti::a>(Rllu(ti::i, ti::a, ti::I));
 
   for (size_t a = 0; a < 4; a++) {
-    const std::array<size_t, 3> expected_multi_index{
-        {contracted_value_placeholder, a, contracted_value_placeholder}};
-    CHECK(RiaI_expr.get_uncontracted_multi_index_with_uncontracted_values(
-              {{a}}) == expected_multi_index);
-
     DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
     for (size_t i = 0; i < 3; i++) {
       expected_sum += Rllu.get(i, a, i);
@@ -205,19 +203,14 @@ void test_contractions_rank4(const DataType& used_for_size) {
       Rluul(used_for_size);
   create_tensor(make_not_null(&Rluul));
 
-  const auto RiIKj_expr = Rluul(ti::i, ti::I, ti::K, ti::j);
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<4, UpLo::Up, Frame::Inertial>,
                           SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>
-      RiIKj_contracted = tenex::evaluate<ti::K, ti::j>(RiIKj_expr);
+      RiIKj_contracted =
+          tenex::evaluate<ti::K, ti::j>(Rluul(ti::i, ti::I, ti::K, ti::j));
 
   for (size_t k = 0; k < 4; k++) {
     for (size_t j = 0; j < 3; j++) {
-      const std::array<size_t, 4> expected_multi_index{
-          {contracted_value_placeholder, contracted_value_placeholder, k, j}};
-      CHECK(RiIKj_expr.get_uncontracted_multi_index_with_uncontracted_values(
-                {{k, j}}) == expected_multi_index);
-
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
       for (size_t i = 0; i < 3; i++) {
         expected_sum += Rluul.get(i, i, k, j);
@@ -236,19 +229,14 @@ void test_contractions_rank4(const DataType& used_for_size) {
       Ruull(used_for_size);
   create_tensor(make_not_null(&Ruull));
 
-  const auto RABac_expr = Ruull(ti::A, ti::B, ti::a, ti::c);
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                           SpacetimeIndex<4, UpLo::Lo, Frame::Grid>>>
-      RABac_contracted = tenex::evaluate<ti::B, ti::c>(RABac_expr);
+      RABac_contracted =
+          tenex::evaluate<ti::B, ti::c>(Ruull(ti::A, ti::B, ti::a, ti::c));
 
   for (size_t b = 0; b < 4; b++) {
     for (size_t c = 0; c < 5; c++) {
-      const std::array<size_t, 4> expected_multi_index{
-          {contracted_value_placeholder, b, contracted_value_placeholder, c}};
-      CHECK(RABac_expr.get_uncontracted_multi_index_with_uncontracted_values(
-                {{b, c}}) == expected_multi_index);
-
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
       for (size_t a = 0; a < 5; a++) {
         expected_sum += Ruull.get(a, b, a, c);
@@ -267,19 +255,14 @@ void test_contractions_rank4(const DataType& used_for_size) {
       Ruuul(used_for_size);
   create_tensor(make_not_null(&Ruuul));
 
-  const auto RLJIl_expr = Ruuul(ti::L, ti::J, ti::I, ti::l);
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<4, UpLo::Up, Frame::Grid>,
                           SpatialIndex<3, UpLo::Up, Frame::Grid>>>
-      RLJIl_contracted = tenex::evaluate<ti::J, ti::I>(RLJIl_expr);
+      RLJIl_contracted =
+          tenex::evaluate<ti::J, ti::I>(Ruuul(ti::L, ti::J, ti::I, ti::l));
 
   for (size_t j = 0; j < 4; j++) {
     for (size_t i = 0; i < 3; i++) {
-      const std::array<size_t, 4> expected_multi_index{
-          {contracted_value_placeholder, j, i, contracted_value_placeholder}};
-      CHECK(RLJIl_expr.get_uncontracted_multi_index_with_uncontracted_values(
-                {{j, i}}) == expected_multi_index);
-
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
       for (size_t l = 0; l < 3; l++) {
         expected_sum += Ruuul.get(l, j, i, l);
@@ -298,19 +281,14 @@ void test_contractions_rank4(const DataType& used_for_size) {
       Ruulu(used_for_size);
   create_tensor(make_not_null(&Ruulu));
 
-  const auto REDdA_expr = Ruulu(ti::E, ti::D, ti::d, ti::A);
   const Tensor<DataType, Symmetry<1, 1>,
                index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>
-      REDdA_contracted = tenex::evaluate<ti::E, ti::A>(REDdA_expr);
+      REDdA_contracted =
+          tenex::evaluate<ti::E, ti::A>(Ruulu(ti::E, ti::D, ti::d, ti::A));
 
   for (size_t e = 0; e < 4; e++) {
     for (size_t a = 0; a < 4; a++) {
-      const std::array<size_t, 4> expected_multi_index{
-          {e, contracted_value_placeholder, contracted_value_placeholder, a}};
-      CHECK(REDdA_expr.get_uncontracted_multi_index_with_uncontracted_values(
-                {{e, a}}) == expected_multi_index);
-
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
       for (size_t d = 0; d < 4; d++) {
         expected_sum += Ruulu.get(e, d, d, a);
@@ -329,19 +307,14 @@ void test_contractions_rank4(const DataType& used_for_size) {
       Rlull(used_for_size);
   create_tensor(make_not_null(&Rlull));
 
-  const auto RkJij_expr = Rlull(ti::k, ti::J, ti::i, ti::j);
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
                           SpatialIndex<4, UpLo::Lo, Frame::Inertial>>>
-      RkJij_contracted = tenex::evaluate<ti::k, ti::i>(RkJij_expr);
+      RkJij_contracted =
+          tenex::evaluate<ti::k, ti::i>(Rlull(ti::k, ti::J, ti::i, ti::j));
 
   for (size_t k = 0; k < 3; k++) {
     for (size_t i = 0; i < 4; i++) {
-      const std::array<size_t, 4> expected_multi_index{
-          {k, contracted_value_placeholder, i, contracted_value_placeholder}};
-      CHECK(RkJij_expr.get_uncontracted_multi_index_with_uncontracted_values(
-                {{k, i}}) == expected_multi_index);
-
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
       for (size_t j = 0; j < 3; j++) {
         expected_sum += Rlull.get(k, j, i, j);
@@ -360,19 +333,14 @@ void test_contractions_rank4(const DataType& used_for_size) {
       Rullu(used_for_size);
   create_tensor(make_not_null(&Rullu));
 
-  const auto RFcgG_expr = Rullu(ti::F, ti::c, ti::g, ti::G);
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpacetimeIndex<4, UpLo::Up, Frame::Inertial>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>
-      RFcgG_contracted = tenex::evaluate<ti::F, ti::c>(RFcgG_expr);
+      RFcgG_contracted =
+          tenex::evaluate<ti::F, ti::c>(Rullu(ti::F, ti::c, ti::g, ti::G));
 
   for (size_t f = 0; f < 5; f++) {
     for (size_t c = 0; c < 4; c++) {
-      const std::array<size_t, 4> expected_multi_index{
-          {f, c, contracted_value_placeholder, contracted_value_placeholder}};
-      CHECK(RFcgG_expr.get_uncontracted_multi_index_with_uncontracted_values(
-                {{f, c}}) == expected_multi_index);
-
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
       for (size_t g = 0; g < 4; g++) {
         expected_sum += Rullu.get(f, c, g, g);
@@ -391,19 +359,14 @@ void test_contractions_rank4(const DataType& used_for_size) {
       Ruluu(used_for_size);
   create_tensor(make_not_null(&Ruluu));
 
-  const auto RKkIJ_expr = Ruluu(ti::K, ti::k, ti::I, ti::J);
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<2, UpLo::Up, Frame::Grid>,
                           SpatialIndex<3, UpLo::Up, Frame::Grid>>>
-      RKkIJ_contracted_to_JI = tenex::evaluate<ti::J, ti::I>(RKkIJ_expr);
+      RKkIJ_contracted_to_JI =
+          tenex::evaluate<ti::J, ti::I>(Ruluu(ti::K, ti::k, ti::I, ti::J));
 
   for (size_t j = 0; j < 2; j++) {
     for (size_t i = 0; i < 3; i++) {
-      const std::array<size_t, 4> expected_multi_index{
-          {contracted_value_placeholder, contracted_value_placeholder, j, i}};
-      CHECK(RKkIJ_expr.get_uncontracted_multi_index_with_uncontracted_values(
-                {{j, i}}) == expected_multi_index);
-
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
       for (size_t k = 0; k < 3; k++) {
         expected_sum += Ruluu.get(k, k, i, j);
@@ -422,19 +385,14 @@ void test_contractions_rank4(const DataType& used_for_size) {
       Rluuu(used_for_size);
   create_tensor(make_not_null(&Rluuu));
 
-  const auto RbCBE_expr = Rluuu(ti::b, ti::C, ti::B, ti::E);
   const Tensor<DataType, Symmetry<1, 1>,
                index_list<SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
                           SpacetimeIndex<2, UpLo::Up, Frame::Grid>>>
-      RbCBE_contracted_to_EC = tenex::evaluate<ti::E, ti::C>(RbCBE_expr);
+      RbCBE_contracted_to_EC =
+          tenex::evaluate<ti::E, ti::C>(Rluuu(ti::b, ti::C, ti::B, ti::E));
 
   for (size_t e = 0; e < 3; e++) {
     for (size_t c = 0; c < 3; c++) {
-      const std::array<size_t, 4> expected_multi_index{
-          {contracted_value_placeholder, e, contracted_value_placeholder, c}};
-      CHECK(RbCBE_expr.get_uncontracted_multi_index_with_uncontracted_values(
-                {{e, c}}) == expected_multi_index);
-
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
       for (size_t b = 0; b < 3; b++) {
         expected_sum += Rluuu.get(b, c, b, e);
@@ -453,19 +411,14 @@ void test_contractions_rank4(const DataType& used_for_size) {
       Rulll(used_for_size);
   create_tensor(make_not_null(&Rulll));
 
-  const auto RAdba_expr = Rulll(ti::A, ti::d, ti::b, ti::a);
   const Tensor<DataType, Symmetry<1, 1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      RAdba_contracted_to_bd = tenex::evaluate<ti::b, ti::d>(RAdba_expr);
+      RAdba_contracted_to_bd =
+          tenex::evaluate<ti::b, ti::d>(Rulll(ti::A, ti::d, ti::b, ti::a));
 
   for (size_t b = 0; b < 4; b++) {
     for (size_t d = 0; d < 4; d++) {
-      const std::array<size_t, 4> expected_multi_index{
-          {contracted_value_placeholder, b, d, contracted_value_placeholder}};
-      CHECK(RAdba_expr.get_uncontracted_multi_index_with_uncontracted_values(
-                {{b, d}}) == expected_multi_index);
-
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
       for (size_t a = 0; a < 4; a++) {
         expected_sum += Rulll.get(a, d, b, a);
@@ -484,19 +437,14 @@ void test_contractions_rank4(const DataType& used_for_size) {
       Rllul(used_for_size);
   create_tensor(make_not_null(&Rllul));
 
-  const auto RljJi_expr = Rllul(ti::l, ti::j, ti::J, ti::i);
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<4, UpLo::Lo, Frame::Grid>,
                           SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
-      RljJi_contracted_to_il = tenex::evaluate<ti::i, ti::l>(RljJi_expr);
+      RljJi_contracted_to_il =
+          tenex::evaluate<ti::i, ti::l>(Rllul(ti::l, ti::j, ti::J, ti::i));
 
   for (size_t i = 0; i < 4; i++) {
     for (size_t l = 0; l < 3; l++) {
-      const std::array<size_t, 4> expected_multi_index{
-          {i, contracted_value_placeholder, contracted_value_placeholder, l}};
-      CHECK(RljJi_expr.get_uncontracted_multi_index_with_uncontracted_values(
-                {{i, l}}) == expected_multi_index);
-
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
       for (size_t j = 0; j < 3; j++) {
         expected_sum += Rllul.get(l, j, j, i);
@@ -515,19 +463,14 @@ void test_contractions_rank4(const DataType& used_for_size) {
       Rlluu(used_for_size);
   create_tensor(make_not_null(&Rlluu));
 
-  const auto RagDG_expr = Rlluu(ti::a, ti::g, ti::D, ti::G);
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>
-      RagDG_contracted_to_Da = tenex::evaluate<ti::D, ti::a>(RagDG_expr);
+      RagDG_contracted_to_Da =
+          tenex::evaluate<ti::D, ti::a>(Rlluu(ti::a, ti::g, ti::D, ti::G));
 
   for (size_t d = 0; d < 4; d++) {
     for (size_t a = 0; a < 4; a++) {
-      const std::array<size_t, 4> expected_multi_index{
-          {d, contracted_value_placeholder, a, contracted_value_placeholder}};
-      CHECK(RagDG_expr.get_uncontracted_multi_index_with_uncontracted_values(
-                {{d, a}}) == expected_multi_index);
-
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
       for (size_t g = 0; g < 4; g++) {
         expected_sum += Rlluu.get(a, g, d, g);
@@ -546,19 +489,14 @@ void test_contractions_rank4(const DataType& used_for_size) {
       Rlulu(used_for_size);
   create_tensor(make_not_null(&Rlulu));
 
-  const auto RlJiI_expr = Rlulu(ti::l, ti::J, ti::i, ti::I);
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<3, UpLo::Up, Frame::Inertial>,
                           SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>
-      RlJiI_contracted_to_Jl = tenex::evaluate<ti::J, ti::l>(RlJiI_expr);
+      RlJiI_contracted_to_Jl =
+          tenex::evaluate<ti::J, ti::l>(Rlulu(ti::l, ti::J, ti::i, ti::I));
 
   for (size_t j = 0; j < 3; j++) {
     for (size_t l = 0; l < 3; l++) {
-      const std::array<size_t, 4> expected_multi_index{
-          {j, l, contracted_value_placeholder, contracted_value_placeholder}};
-      CHECK(RlJiI_expr.get_uncontracted_multi_index_with_uncontracted_values(
-                {{j, l}}) == expected_multi_index);
-
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
       for (size_t i = 0; i < 3; i++) {
         expected_sum += Rlulu.get(l, j, i, i);
@@ -577,24 +515,8 @@ void test_contractions_rank4(const DataType& used_for_size) {
       Rulul(used_for_size);
   create_tensor(make_not_null(&Rulul));
 
-  const auto RKkLl_expr = Rulul(ti::K, ti::k, ti::L, ti::l);
-  // `RKkLl_expr` is a TensorContract expression that contains another
-  // TensorContract expression. The "inner" expression will contract the L/l
-  // indices, representing contracting the 3rd and 4th indices of the rank 4
-  // tensor `Rulul` to a rank 2 tensor. The "outer" expression will then
-  // contract the K/k indices, representing contracting the rank 2 tensor to
-  // the resulting scalar. This
-  // `get_uncontracted_multi_index_with_uncontracted_values` test checks this
-  // outer contraction of the K/k indices. Because the inner expression is
-  // private, a similar check for it is not done.
-  //
-  // This also applies to similar rank 4 -> rank 0 contraction cases below
-  const std::array<size_t, 2> expected_multi_index{
-      {contracted_value_placeholder, contracted_value_placeholder}};
-  CHECK(RKkLl_expr.get_uncontracted_multi_index_with_uncontracted_values(
-            {{}}) == expected_multi_index);
-
-  const Tensor<DataType> RKkLl_contracted = tenex::evaluate(RKkLl_expr);
+  const Tensor<DataType> RKkLl_contracted =
+      tenex::evaluate(Rulul(ti::K, ti::k, ti::L, ti::l));
 
   DataType expected_RKkLl_sum = make_with_value<DataType>(used_for_size, 0.0);
   for (size_t k = 0; k < 3; k++) {
@@ -606,11 +528,8 @@ void test_contractions_rank4(const DataType& used_for_size) {
 
   // Contract first and third indices and second and fourth indices to rank 0
   // tensor
-  const auto RcaCA_expr = Rlluu(ti::c, ti::a, ti::C, ti::A);
-  CHECK(RcaCA_expr.get_uncontracted_multi_index_with_uncontracted_values(
-            {{}}) == expected_multi_index);
-
-  const Tensor<DataType> RcaCA_contracted = tenex::evaluate(RcaCA_expr);
+  const Tensor<DataType> RcaCA_contracted =
+      tenex::evaluate(Rlluu(ti::c, ti::a, ti::C, ti::A));
 
   DataType expected_RcaCA_sum = make_with_value<DataType>(used_for_size, 0.0);
   for (size_t c = 0; c < 4; c++) {
@@ -622,11 +541,8 @@ void test_contractions_rank4(const DataType& used_for_size) {
 
   // Contract first and fourth indices and second and third indices to rank 0
   // tensor
-  const auto RjIiJ_expr = Rlulu(ti::j, ti::I, ti::i, ti::J);
-  CHECK(RjIiJ_expr.get_uncontracted_multi_index_with_uncontracted_values(
-            {{}}) == expected_multi_index);
-
-  const Tensor<DataType> RjIiJ_contracted = tenex::evaluate(RjIiJ_expr);
+  const Tensor<DataType> RjIiJ_contracted =
+      tenex::evaluate(Rlulu(ti::j, ti::I, ti::i, ti::J));
 
   DataType expected_RjIiJ_sum = make_with_value<DataType>(used_for_size, 0.0);
   for (size_t j = 0; j < 3; j++) {
@@ -902,6 +818,7 @@ void test_contractions(const DataType& used_for_size) {
 
 SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Contract",
                   "[DataStructures][Unit]") {
+  test_contraction_summation_consistency();
   test_contractions(std::numeric_limits<double>::signaling_NaN());
   test_contractions(
       DataVector(5, std::numeric_limits<double>::signaling_NaN()));

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Divide.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Divide.cpp
@@ -16,6 +16,27 @@
 #include "Utilities/MakeWithValue.hpp"
 
 namespace {
+// Checks that the number of ops in the expressions match what is expected
+void test_tensor_ops_properties() {
+  const Scalar<double> G{5.0};
+  const double H = 5.0;
+  const tnsr::ii<double, 3> R{};
+  const tnsr::ij<double, 3> S{};
+
+  const auto H_over_G = H / G();
+  const auto H_over_G_over_H = H / G() / H;
+  const auto R_over_G = R(ti::i, ti::j) / G();
+  const auto S_over_H = S(ti::i, ti::j) / H;
+  const auto R_plus_S_over_G_times_H =
+      (R(ti::i, ti::j) + S(ti::i, ti::j)) / (G() * H);
+
+  CHECK(H_over_G.num_ops_subtree == 1);
+  CHECK(H_over_G_over_H.num_ops_subtree == 2);
+  CHECK(R_over_G.num_ops_subtree == 1);
+  CHECK(S_over_H.num_ops_subtree == 1);
+  CHECK(R_plus_S_over_G_times_H.num_ops_subtree == 3);
+}
+
 // \brief Test the division of a tensor expression over a `double` is correctly
 // evaluated
 //
@@ -282,6 +303,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Divide",
                   "[DataStructures][Unit]") {
   MAKE_GENERATOR(generator);
 
+  test_tensor_ops_properties();
   test_divide(make_not_null(&generator),
               std::numeric_limits<double>::signaling_NaN());
   test_divide(make_not_null(&generator),

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_MixedOperations.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_MixedOperations.cpp
@@ -100,6 +100,141 @@ tnsr::abb<DataType, 3, Frame::Inertial> compute_expected_result3(
   return expected_result;
 }
 
+// Aliases used for test_case4()
+template <typename DataType, size_t Dim>
+using result_tensor_type = tnsr::aa<DataType, Dim>;
+template <typename DataType, size_t Dim>
+using spacetime_deriv_gauge_function_type = tnsr::ab<DataType, Dim>;
+template <typename DataType>
+using pi_two_normals_type = Scalar<DataType>;
+template <typename DataType, size_t Dim>
+using pi_type = tnsr::aa<DataType, Dim>;
+template <typename DataType>
+using gamma0_type = Scalar<DataType>;
+template <typename DataType, size_t Dim>
+using normal_spacetime_one_form_type = tnsr::a<DataType, Dim>;
+template <typename DataType, size_t Dim>
+using gauge_constraint_type = tnsr::a<DataType, Dim>;
+template <typename DataType, size_t Dim>
+using spacetime_metric_type = tnsr::aa<DataType, Dim>;
+template <typename DataType>
+using normal_dot_gauge_constraint_type = Scalar<DataType>;
+template <typename DataType, size_t Dim>
+using christoffel_second_kind_type = tnsr::Abb<DataType, Dim>;
+template <typename DataType, size_t Dim>
+using gauge_function_type = tnsr::a<DataType, Dim>;
+template <typename DataType, size_t Dim>
+using pi_2_up_type = tnsr::aB<DataType, Dim>;
+template <typename DataType, size_t Dim>
+using phi_1_up_type = tnsr::Iaa<DataType, Dim>;
+template <typename DataType, size_t Dim>
+using phi_3_up_type = tnsr::iaB<DataType, Dim>;
+template <typename DataType, size_t Dim>
+using christoffel_first_kind_3_up_type = tnsr::abC<DataType, Dim>;
+template <typename DataType, size_t Dim>
+using pi_one_normal_type = tnsr::a<DataType, Dim>;
+template <typename DataType, size_t Dim>
+using inverse_spatial_metric_type = tnsr::II<DataType, Dim>;
+template <typename DataType, size_t Dim>
+using d_phi_type = tnsr::ijaa<DataType, Dim>;
+template <typename DataType>
+using lapse_type = Scalar<DataType>;
+template <typename DataType>
+using gamma1gamma2_type = Scalar<DataType>;
+template <typename DataType, size_t Dim>
+using shift_dot_three_index_constraint_type = tnsr::aa<DataType, Dim>;
+template <typename DataType, size_t Dim>
+using shift_type = tnsr::I<DataType, Dim>;
+template <typename DataType, size_t Dim>
+using d_pi_type = tnsr::iaa<DataType, Dim>;
+
+// Computes the Generalized Harmonic equation for the time derivative,
+// \f$\partial_t \Pi_{ab} \f$ (eq 36 of \cite Lindblom2005qh). This is taken
+// from the implementation of `GeneralizedHarmonic::TimeDerivative`.
+template <typename DataType, size_t Dim>
+result_tensor_type<DataType, Dim> compute_expected_result4(
+    const spacetime_deriv_gauge_function_type<DataType, Dim>&
+        spacetime_deriv_gauge_function,
+    const pi_two_normals_type<DataType>& pi_two_normals,
+    const pi_type<DataType, Dim>& pi, const gamma0_type<DataType>& gamma0,
+    const normal_spacetime_one_form_type<DataType, Dim>&
+        normal_spacetime_one_form,
+    const gauge_constraint_type<DataType, Dim>& gauge_constraint,
+    const spacetime_metric_type<DataType, Dim>& spacetime_metric,
+    const normal_dot_gauge_constraint_type<DataType>&
+        normal_dot_gauge_constraint,
+    const christoffel_second_kind_type<DataType, Dim>& christoffel_second_kind,
+    const gauge_function_type<DataType, Dim>& gauge_function,
+    const pi_2_up_type<DataType, Dim>& pi_2_up,
+    const phi_1_up_type<DataType, Dim>& phi_1_up,
+    const phi_3_up_type<DataType, Dim>& phi_3_up,
+    const christoffel_first_kind_3_up_type<DataType, Dim>&
+        christoffel_first_kind_3_up,
+    const pi_one_normal_type<DataType, Dim>& pi_one_normal,
+    const inverse_spatial_metric_type<DataType, Dim>& inverse_spatial_metric,
+    const d_phi_type<DataType, Dim>& d_phi, const lapse_type<DataType>& lapse,
+    const gamma1gamma2_type<DataType>& gamma1gamma2,
+    const shift_dot_three_index_constraint_type<DataType, Dim>&
+        shift_dot_three_index_constraint,
+    const shift_type<DataType, Dim>& shift,
+    const d_pi_type<DataType, Dim>& d_pi) {
+  result_tensor_type<DataType, Dim> expected_result{};
+
+  for (size_t mu = 0; mu < Dim + 1; ++mu) {
+    for (size_t nu = mu; nu < Dim + 1; ++nu) {
+      expected_result.get(mu, nu) =
+          -spacetime_deriv_gauge_function.get(mu, nu) -
+          spacetime_deriv_gauge_function.get(nu, mu) -
+          0.5 * get(pi_two_normals) * pi.get(mu, nu) +
+          get(gamma0) *
+              (normal_spacetime_one_form.get(mu) * gauge_constraint.get(nu) +
+               normal_spacetime_one_form.get(nu) * gauge_constraint.get(mu)) -
+          get(gamma0) * spacetime_metric.get(mu, nu) *
+              get(normal_dot_gauge_constraint);
+
+      for (size_t delta = 0; delta < Dim + 1; ++delta) {
+        expected_result.get(mu, nu) +=
+            2 * christoffel_second_kind.get(delta, mu, nu) *
+                gauge_function.get(delta) -
+            2 * pi.get(mu, delta) * pi_2_up.get(nu, delta);
+
+        for (size_t n = 0; n < Dim; ++n) {
+          expected_result.get(mu, nu) +=
+              2 * phi_1_up.get(n, mu, delta) * phi_3_up.get(n, nu, delta);
+        }
+
+        for (size_t alpha = 0; alpha < Dim + 1; ++alpha) {
+          expected_result.get(mu, nu) -=
+              2. * christoffel_first_kind_3_up.get(mu, alpha, delta) *
+              christoffel_first_kind_3_up.get(nu, delta, alpha);
+        }
+      }
+
+      for (size_t m = 0; m < Dim; ++m) {
+        expected_result.get(mu, nu) -=
+            pi_one_normal.get(m + 1) * phi_1_up.get(m, mu, nu);
+
+        for (size_t n = 0; n < Dim; ++n) {
+          expected_result.get(mu, nu) -=
+              inverse_spatial_metric.get(m, n) * d_phi.get(m, n, mu, nu);
+        }
+      }
+
+      expected_result.get(mu, nu) *= get(lapse);
+
+      expected_result.get(mu, nu) +=
+          get(gamma1gamma2) * shift_dot_three_index_constraint.get(mu, nu);
+
+      for (size_t m = 0; m < Dim; ++m) {
+        // DualFrame term
+        expected_result.get(mu, nu) += shift.get(m) * d_pi.get(m, mu, nu);
+      }
+    }
+  }
+
+  return expected_result;
+}
+
 // Includes an expression with addition, subtraction, an inner product, an outer
 // product, a contraction, and a scalar
 template <typename DataType, typename Generator>
@@ -126,12 +261,17 @@ void test_case1(const DataType& used_for_size,
   result_tensor_type expected_result_tensor =
       compute_expected_result1(R, S, G, H, T, used_for_size);
   // \f$L_{a} = R_{ab} S^{b} + G_{a} - H_{ba}{}^{b} T\f$
+  // [use_evaluate_to_return_result]
   result_tensor_type actual_result_tensor_returned = tenex::evaluate<ti::a>(
       R(ti::a, ti::b) * S(ti::B) + G(ti::a) - H(ti::b, ti::a, ti::B) * T());
+  // [use_evaluate_to_return_result]
+
+  // [use_evaluate_with_result_as_arg]
   result_tensor_type actual_result_tensor_filled{};
   tenex::evaluate<ti::a>(
       make_not_null(&actual_result_tensor_filled),
       R(ti::a, ti::b) * S(ti::B) + G(ti::a) - H(ti::b, ti::a, ti::B) * T());
+  // [use_evaluate_with_result_as_arg]
 
   for (size_t a = 0; a < 4; a++) {
     CHECK_ITERABLE_APPROX(actual_result_tensor_returned.get(a),
@@ -198,6 +338,8 @@ void test_case2(const DataType& used_for_size,
            spacetime_metric(ti::t, ti::t)));
 
   CHECK_ITERABLE_APPROX(actual_result_tensor_returned.get(),
+                        expected_result_tensor.get());
+  CHECK_ITERABLE_APPROX(actual_result_tensor_filled.get(),
                         expected_result_tensor.get());
 
   // Test with TempTensor for LHS tensor
@@ -291,12 +433,429 @@ void test_case3(const DataType& used_for_size,
   }
 }
 
+// This test case is the Generalized Harmonic equation for the time derivative,
+// \f$\partial_t \Pi_{ab} \f$ (eq 36 of \cite Lindblom2005qh).
+//
+// This test case is distinct in that it is a large equation and tests calls to
+// `tenex::update`.
+template <typename Generator, typename DataType>
+void test_case4(const gsl::not_null<Generator*> generator,
+                const DataType& used_for_size) {
+  constexpr size_t Dim = 3;
+
+  using result_tensor_type = result_tensor_type<DataType, Dim>;
+  using spacetime_deriv_gauge_function_type =
+      spacetime_deriv_gauge_function_type<DataType, Dim>;
+  using pi_two_normals_type = pi_two_normals_type<DataType>;
+  using pi_type = pi_type<DataType, Dim>;
+  using gamma0_type = gamma0_type<DataType>;
+  using normal_spacetime_one_form_type =
+      normal_spacetime_one_form_type<DataType, Dim>;
+  using gauge_constraint_type = gauge_constraint_type<DataType, Dim>;
+  using spacetime_metric_type = spacetime_metric_type<DataType, Dim>;
+  using normal_dot_gauge_constraint_type =
+      normal_dot_gauge_constraint_type<DataType>;
+  using christoffel_second_kind_type =
+      christoffel_second_kind_type<DataType, Dim>;
+  using gauge_function_type = gauge_function_type<DataType, Dim>;
+  using pi_2_up_type = pi_2_up_type<DataType, Dim>;
+  using phi_1_up_type = phi_1_up_type<DataType, Dim>;
+  using phi_3_up_type = phi_3_up_type<DataType, Dim>;
+  using christoffel_first_kind_3_up_type =
+      christoffel_first_kind_3_up_type<DataType, Dim>;
+  using pi_one_normal_type = pi_one_normal_type<DataType, Dim>;
+  using inverse_spatial_metric_type =
+      inverse_spatial_metric_type<DataType, Dim>;
+  using d_phi_type = d_phi_type<DataType, Dim>;
+  using lapse_type = lapse_type<DataType>;
+  using gamma1gamma2_type = gamma1gamma2_type<DataType>;
+  using shift_dot_three_index_constraint_type =
+      shift_dot_three_index_constraint_type<DataType, Dim>;
+  using shift_type = shift_type<DataType, Dim>;
+  using d_pi_type = d_pi_type<DataType, Dim>;
+
+  std::uniform_real_distribution<> distribution(0.1, 1.0);
+
+  // Not inputs to the eq, but needed to make some variables
+  // that are computed by raising something in order for symmetric
+  // assumptions to hold
+  const auto inverse_spacetime_metric =
+      make_with_random_values<tnsr::AA<DataType, Dim>>(generator, distribution,
+                                                       used_for_size);
+  const auto phi = make_with_random_values<tnsr::iaa<DataType, Dim>>(
+      generator, distribution, used_for_size);
+
+  // RHS: spacetime_deriv_gauge_function
+  const spacetime_deriv_gauge_function_type spacetime_deriv_gauge_function =
+      make_with_random_values<spacetime_deriv_gauge_function_type>(
+          generator, distribution, used_for_size);
+
+  // RHS: pi_two_normals
+  const pi_two_normals_type pi_two_normals =
+      make_with_random_values<pi_two_normals_type>(generator, distribution,
+                                                   used_for_size);
+
+  // RHS: pi
+  const pi_type pi =
+      make_with_random_values<pi_type>(generator, distribution, used_for_size);
+
+  // RHS: gamma0
+  const gamma0_type gamma0 = make_with_random_values<gamma0_type>(
+      generator, distribution, used_for_size);
+
+  // RHS: normal_spacetime_one_form
+  const normal_spacetime_one_form_type normal_spacetime_one_form =
+      make_with_random_values<normal_spacetime_one_form_type>(
+          generator, distribution, used_for_size);
+
+  // RHS: gauge_constraint
+  const gauge_constraint_type gauge_constraint =
+      make_with_random_values<gauge_constraint_type>(generator, distribution,
+                                                     used_for_size);
+
+  // RHS: spacetime_metric
+  const spacetime_metric_type spacetime_metric =
+      make_with_random_values<spacetime_metric_type>(generator, distribution,
+                                                     used_for_size);
+
+  // RHS: normal_dot_gauge_constraint
+  const normal_dot_gauge_constraint_type normal_dot_gauge_constraint =
+      make_with_random_values<normal_dot_gauge_constraint_type>(
+          generator, distribution, used_for_size);
+
+  // RHS: christoffel_second_kind
+  const christoffel_second_kind_type christoffel_second_kind =
+      make_with_random_values<christoffel_second_kind_type>(
+          generator, distribution, used_for_size);
+
+  // RHS: gauge_function
+  const gauge_function_type gauge_function =
+      make_with_random_values<gauge_function_type>(generator, distribution,
+                                                   used_for_size);
+
+  // RHS: pi_2_up
+  pi_2_up_type pi_2_up(used_for_size);
+  for (size_t a = 0; a < Dim + 1; a++) {
+    for (size_t b = 0; b < Dim + 1; b++) {
+      pi_2_up.get(a, b) = 0.0;
+      for (size_t c = 0; c < Dim + 1; c++) {
+        pi_2_up.get(a, b) += inverse_spacetime_metric.get(c, b) * pi.get(a, c);
+      }
+    }
+  }
+
+  // RHS: phi_3_up
+  phi_3_up_type phi_3_up(used_for_size);
+  for (size_t i = 0; i < Dim; i++) {
+    for (size_t a = 0; a < Dim + 1; a++) {
+      for (size_t b = 0; b < Dim + 1; b++) {
+        phi_3_up.get(i, a, b) = 0.0;
+        for (size_t c = 0; c < Dim + 1; c++) {
+          phi_3_up.get(i, a, b) +=
+              inverse_spacetime_metric.get(c, b) * phi.get(i, a, c);
+        }
+      }
+    }
+  }
+
+  // RHS: christoffel_first_kind_3_up
+  const christoffel_first_kind_3_up_type christoffel_first_kind_3_up =
+      make_with_random_values<christoffel_first_kind_3_up_type>(
+          generator, distribution, used_for_size);
+
+  // RHS: pi_one_normal
+  const pi_one_normal_type pi_one_normal =
+      make_with_random_values<pi_one_normal_type>(generator, distribution,
+                                                  used_for_size);
+
+  // RHS: inverse_spatial_metric
+  inverse_spatial_metric_type inverse_spatial_metric(used_for_size);
+  for (size_t i = 0; i < Dim; i++) {
+    for (size_t j = 0; j < Dim; j++) {
+      inverse_spatial_metric.get(i, j) =
+          inverse_spacetime_metric.get(i + 1, j + 1);
+    }
+  }
+
+  // RHS: phi_1_up
+  // Note: arg out of order down here bc needs inverse_spatial_metric
+  phi_1_up_type phi_1_up(used_for_size);
+  for (size_t i = 0; i < Dim; i++) {
+    for (size_t a = 0; a < Dim + 1; a++) {
+      for (size_t b = a; b < Dim + 1; b++) {
+        phi_1_up.get(i, a, b) = 0.0;
+        for (size_t j = 0; j < Dim; j++) {
+          phi_1_up.get(i, a, b) +=
+              inverse_spatial_metric.get(i, j) * phi.get(j, a, b);
+        }
+      }
+    }
+  }
+
+  // RHS: d_phi
+  const d_phi_type d_phi = make_with_random_values<d_phi_type>(
+      generator, distribution, used_for_size);
+
+  // RHS: lapse
+  const lapse_type lapse = make_with_random_values<lapse_type>(
+      generator, distribution, used_for_size);
+
+  // RHS: gamma1gamma2
+  const gamma1gamma2_type gamma1gamma2 =
+      make_with_random_values<gamma1gamma2_type>(generator, distribution,
+                                                 used_for_size);
+
+  // RHS: shift_dot_three_index_constraint
+  const shift_dot_three_index_constraint_type shift_dot_three_index_constraint =
+      make_with_random_values<shift_dot_three_index_constraint_type>(
+          generator, distribution, used_for_size);
+
+  // RHS: shift
+  const shift_type shift = make_with_random_values<shift_type>(
+      generator, distribution, used_for_size);
+
+  // RHS: d_pi
+  const d_pi_type d_pi = make_with_random_values<d_pi_type>(
+      generator, distribution, used_for_size);
+
+  // LHS: dt_pi
+  const result_tensor_type expected_result_tensor = compute_expected_result4(
+      spacetime_deriv_gauge_function, pi_two_normals, pi, gamma0,
+      normal_spacetime_one_form, gauge_constraint, spacetime_metric,
+      normal_dot_gauge_constraint, christoffel_second_kind, gauge_function,
+      pi_2_up, phi_1_up, phi_3_up, christoffel_first_kind_3_up, pi_one_normal,
+      inverse_spatial_metric, d_phi, lapse, gamma1gamma2,
+      shift_dot_three_index_constraint, shift, d_pi);
+
+  // LHS: dt_pi
+  // [use_update]
+  result_tensor_type actual_result_tensor_filled{};
+  tenex::evaluate<ti::a, ti::b>(
+      make_not_null(&actual_result_tensor_filled),
+      -spacetime_deriv_gauge_function(ti::a, ti::b) -
+          spacetime_deriv_gauge_function(ti::b, ti::a) -
+          0.5 * pi_two_normals() * pi(ti::a, ti::b) +
+          gamma0() *
+              (normal_spacetime_one_form(ti::a) * gauge_constraint(ti::b) +
+               normal_spacetime_one_form(ti::b) * gauge_constraint(ti::a)) -
+          gamma0() * spacetime_metric(ti::a, ti::b) *
+              normal_dot_gauge_constraint() +
+          2.0 * christoffel_second_kind(ti::C, ti::a, ti::b) *
+              gauge_function(ti::c) -
+          2.0 * pi(ti::a, ti::c) * pi_2_up(ti::b, ti::C));
+
+  tenex::update<ti::a, ti::b>(
+      make_not_null(&actual_result_tensor_filled),
+      actual_result_tensor_filled(ti::a, ti::b) +
+          2.0 * phi_1_up(ti::I, ti::a, ti::c) * phi_3_up(ti::i, ti::b, ti::C));
+
+  tenex::update<ti::a, ti::b>(
+      make_not_null(&actual_result_tensor_filled),
+      actual_result_tensor_filled(ti::a, ti::b) -
+          2.0 * christoffel_first_kind_3_up(ti::a, ti::d, ti::C) *
+              christoffel_first_kind_3_up(ti::b, ti::c, ti::D));
+
+  tenex::update<ti::a, ti::b>(
+      make_not_null(&actual_result_tensor_filled),
+      actual_result_tensor_filled(ti::a, ti::b) -
+          pi_one_normal(ti::j) * phi_1_up(ti::J, ti::a, ti::b));
+
+  tenex::update<ti::a, ti::b>(make_not_null(&actual_result_tensor_filled),
+                              actual_result_tensor_filled(ti::a, ti::b) -
+                                  inverse_spatial_metric(ti::J, ti::K) *
+                                      d_phi(ti::j, ti::k, ti::a, ti::b));
+
+  tenex::update<ti::a, ti::b>(
+      make_not_null(&actual_result_tensor_filled),
+      actual_result_tensor_filled(ti::a, ti::b) * lapse() +
+          gamma1gamma2() * shift_dot_three_index_constraint(ti::a, ti::b) +
+          shift(ti::J) * d_pi(ti::j, ti::a, ti::b));
+  // [use_update]
+
+  CHECK_ITERABLE_APPROX(actual_result_tensor_filled, expected_result_tensor);
+
+  // Test with TempTensor for LHS tensor
+  if constexpr (not std::is_same_v<DataType, double>) {
+    Variables<tmpl::list<
+        ::Tags::TempTensor<0, result_tensor_type>,
+        ::Tags::TempTensor<1, spacetime_deriv_gauge_function_type>,
+        ::Tags::TempTensor<2, pi_two_normals_type>,
+        ::Tags::TempTensor<3, pi_type>, ::Tags::TempTensor<4, gamma0_type>,
+        ::Tags::TempTensor<5, normal_spacetime_one_form_type>,
+        ::Tags::TempTensor<6, gauge_constraint_type>,
+        ::Tags::TempTensor<7, spacetime_metric_type>,
+        ::Tags::TempTensor<8, normal_dot_gauge_constraint_type>,
+        ::Tags::TempTensor<9, christoffel_second_kind_type>,
+        ::Tags::TempTensor<10, gauge_function_type>,
+        ::Tags::TempTensor<11, pi_2_up_type>,
+        ::Tags::TempTensor<12, phi_1_up_type>,
+        ::Tags::TempTensor<13, phi_3_up_type>,
+        ::Tags::TempTensor<14, christoffel_first_kind_3_up_type>,
+        ::Tags::TempTensor<15, pi_one_normal_type>,
+        ::Tags::TempTensor<16, inverse_spatial_metric_type>,
+        ::Tags::TempTensor<17, d_phi_type>, ::Tags::TempTensor<18, lapse_type>,
+        ::Tags::TempTensor<19, gamma1gamma2_type>,
+        ::Tags::TempTensor<20, shift_dot_three_index_constraint_type>,
+        ::Tags::TempTensor<21, shift_type>, ::Tags::TempTensor<22, d_pi_type>>>
+        vars{used_for_size.size()};
+
+    // RHS: spacetime_deriv_gauge_function
+    spacetime_deriv_gauge_function_type& spacetime_deriv_gauge_function_temp =
+        get<::Tags::TempTensor<1, spacetime_deriv_gauge_function_type>>(vars);
+    spacetime_deriv_gauge_function_temp = spacetime_deriv_gauge_function;
+
+    // RHS: pi_two_normals
+    pi_two_normals_type& pi_two_normals_temp =
+        get<::Tags::TempTensor<2, pi_two_normals_type>>(vars);
+    pi_two_normals_temp = pi_two_normals;
+
+    // RHS: pi
+    pi_type& pi_temp = get<::Tags::TempTensor<3, pi_type>>(vars);
+    pi_temp = pi;
+
+    // RHS: gamma0
+    gamma0_type& gamma0_temp = get<::Tags::TempTensor<4, gamma0_type>>(vars);
+    gamma0_temp = gamma0;
+
+    // RHS: normal_spacetime_one_form
+    normal_spacetime_one_form_type& normal_spacetime_one_form_temp =
+        get<::Tags::TempTensor<5, normal_spacetime_one_form_type>>(vars);
+    normal_spacetime_one_form_temp = normal_spacetime_one_form;
+
+    // RHS: gauge_constraint
+    gauge_constraint_type& gauge_constraint_temp =
+        get<::Tags::TempTensor<6, gauge_constraint_type>>(vars);
+    gauge_constraint_temp = gauge_constraint;
+
+    // RHS: spacetime_metric
+    spacetime_metric_type& spacetime_metric_temp =
+        get<::Tags::TempTensor<7, spacetime_metric_type>>(vars);
+    spacetime_metric_temp = spacetime_metric;
+
+    // RHS: normal_dot_gauge_constraint
+    normal_dot_gauge_constraint_type& normal_dot_gauge_constraint_temp =
+        get<::Tags::TempTensor<8, normal_dot_gauge_constraint_type>>(vars);
+    normal_dot_gauge_constraint_temp = normal_dot_gauge_constraint;
+
+    // RHS: christoffel_second_kind
+    christoffel_second_kind_type& christoffel_second_kind_temp =
+        get<::Tags::TempTensor<9, christoffel_second_kind_type>>(vars);
+    christoffel_second_kind_temp = christoffel_second_kind;
+
+    // RHS: gauge_function
+    gauge_function_type& gauge_function_temp =
+        get<::Tags::TempTensor<10, gauge_function_type>>(vars);
+    gauge_function_temp = gauge_function;
+
+    // RHS: pi_2_up
+    pi_2_up_type& pi_2_up_temp =
+        get<::Tags::TempTensor<11, pi_2_up_type>>(vars);
+    pi_2_up_temp = pi_2_up;
+
+    // RHS: phi_1_up
+    phi_1_up_type& phi_1_up_temp =
+        get<::Tags::TempTensor<12, phi_1_up_type>>(vars);
+    phi_1_up_temp = phi_1_up;
+
+    // RHS: phi_3_up
+    phi_3_up_type& phi_3_up_temp =
+        get<::Tags::TempTensor<13, phi_3_up_type>>(vars);
+    phi_3_up_temp = phi_3_up;
+
+    // RHS: christoffel_first_kind_3_up
+    christoffel_first_kind_3_up_type& christoffel_first_kind_3_up_temp =
+        get<::Tags::TempTensor<14, christoffel_first_kind_3_up_type>>(vars);
+    christoffel_first_kind_3_up_temp = christoffel_first_kind_3_up;
+
+    // RHS: pi_one_normal
+    pi_one_normal_type& pi_one_normal_temp =
+        get<::Tags::TempTensor<15, pi_one_normal_type>>(vars);
+    pi_one_normal_temp = pi_one_normal;
+
+    // RHS: inverse_spatial_metric
+    inverse_spatial_metric_type& inverse_spatial_metric_temp =
+        get<::Tags::TempTensor<16, inverse_spatial_metric_type>>(vars);
+    inverse_spatial_metric_temp = inverse_spatial_metric;
+
+    // RHS: d_phi
+    d_phi_type& d_phi_temp = get<::Tags::TempTensor<17, d_phi_type>>(vars);
+    d_phi_temp = d_phi;
+
+    // RHS: lapse
+    lapse_type& lapse_temp = get<::Tags::TempTensor<18, lapse_type>>(vars);
+    lapse_temp = lapse;
+
+    // RHS: gamma1gamma2
+    gamma1gamma2_type& gamma1gamma2_temp =
+        get<::Tags::TempTensor<19, gamma1gamma2_type>>(vars);
+    gamma1gamma2_temp = gamma1gamma2;
+
+    // RHS: shift_dot_three_index_constraint
+    shift_dot_three_index_constraint_type&
+        shift_dot_three_index_constraint_temp =
+            get<::Tags::TempTensor<20, shift_dot_three_index_constraint_type>>(
+                vars);
+    shift_dot_three_index_constraint_temp = shift_dot_three_index_constraint;
+
+    // RHS: shift
+    shift_type& shift_temp = get<::Tags::TempTensor<21, shift_type>>(vars);
+    shift_temp = shift;
+
+    // RHS: d_pi
+    d_pi_type& d_pi_temp = get<::Tags::TempTensor<22, d_pi_type>>(vars);
+    d_pi_temp = d_pi;
+
+    // LHS: dt_pi
+    result_tensor_type& actual_result_tensor_temp =
+        get<::Tags::TempTensor<0, result_tensor_type>>(vars);
+
+    tenex::evaluate<ti::a, ti::b>(
+        make_not_null(&actual_result_tensor_temp),
+        -spacetime_deriv_gauge_function_temp(ti::a, ti::b) -
+            spacetime_deriv_gauge_function_temp(ti::b, ti::a) -
+            0.5 * pi_two_normals_temp() * pi_temp(ti::a, ti::b) +
+            gamma0_temp() * (normal_spacetime_one_form_temp(ti::a) *
+                                 gauge_constraint_temp(ti::b) +
+                             normal_spacetime_one_form_temp(ti::b) *
+                                 gauge_constraint_temp(ti::a)) -
+            gamma0_temp() * spacetime_metric_temp(ti::a, ti::b) *
+                normal_dot_gauge_constraint_temp() +
+            2.0 * christoffel_second_kind_temp(ti::C, ti::a, ti::b) *
+                gauge_function_temp(ti::c) -
+            2.0 * pi_temp(ti::a, ti::c) * pi_2_up_temp(ti::b, ti::C) +
+            2.0 * phi_3_up_temp(ti::i, ti::a, ti::C) *
+                phi_1_up_temp(ti::I, ti::b, ti::c) -
+            2.0 * christoffel_first_kind_3_up_temp(ti::a, ti::d, ti::C) *
+                christoffel_first_kind_3_up_temp(ti::b, ti::c, ti::D));
+
+    tenex::update<ti::a, ti::b>(
+        make_not_null(&actual_result_tensor_temp),
+        actual_result_tensor_temp(ti::a, ti::b) -
+            pi_one_normal_temp(ti::j) * phi_1_up_temp(ti::J, ti::a, ti::b));
+
+    tenex::update<ti::a, ti::b>(make_not_null(&actual_result_tensor_temp),
+                                actual_result_tensor_temp(ti::a, ti::b) -
+                                    inverse_spatial_metric_temp(ti::J, ti::K) *
+                                        d_phi_temp(ti::j, ti::k, ti::a, ti::b));
+
+    tenex::update<ti::a, ti::b>(
+        make_not_null(&actual_result_tensor_temp),
+        actual_result_tensor_temp(ti::a, ti::b) * lapse_temp() +
+            gamma1gamma2_temp() *
+                shift_dot_three_index_constraint_temp(ti::a, ti::b) +
+            shift_temp(ti::J) * d_pi_temp(ti::j, ti::a, ti::b));
+
+    CHECK_ITERABLE_APPROX(actual_result_tensor_temp, expected_result_tensor);
+  }
+}
+
 template <typename DataType, typename Generator>
 void test_mixed_operations(const DataType& used_for_size,
                            const gsl::not_null<Generator*> generator) {
   test_case1(used_for_size, generator);
   test_case2(used_for_size, generator);
   test_case3(used_for_size, generator);
+  test_case4(generator, used_for_size);
 }
 }  // namespace
 

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Negate.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Negate.cpp
@@ -13,6 +13,26 @@
 #include "Utilities/Gsl.hpp"
 
 namespace {
+// Checks that the number of ops in the expressions match what is expected
+void test_tensor_ops_properties() {
+  const Scalar<double> G{5.0};
+  const double H = 5.0;
+  const tnsr::ii<double, 3> R{};
+  const tnsr::ij<double, 3> S{};
+
+  const auto neg_G = -G();
+  const auto neg_R = -R(ti::i, ti::j);
+  // Below, -H should be `NumberAsExpression(-H)`, so the * should be the only
+  // op for this expression
+  const auto neg_H_times_G = -H * G();
+  const auto neg_S_minus_R_times_G = -(S(ti::j, ti::i) - R(ti::i, ti::j) * G());
+
+  CHECK(neg_G.num_ops_subtree == 1);
+  CHECK(neg_R.num_ops_subtree == 1);
+  CHECK(neg_H_times_G.num_ops_subtree == 1);
+  CHECK(neg_S_minus_R_times_G.num_ops_subtree == 3);
+}
+
 // \brief Test the unary `-` correctly negates a tensor expression
 //
 // \details
@@ -61,6 +81,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Negate",
                   "[DataStructures][Unit]") {
   MAKE_GENERATOR(generator);
 
+  test_tensor_ops_properties();
   test_negate(make_not_null(&generator),
               std::numeric_limits<double>::signaling_NaN());
   test_negate(make_not_null(&generator),

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Product.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Product.cpp
@@ -117,7 +117,8 @@ void test_outer_product_double(const DataType& used_for_size) {
     for (size_t j = 0; j < dim; j++) {
       CHECK(Lij_from_R_Sij.get(i, j) == 5.6 * S.get(i, j));
       CHECK(Lij_from_Sij_R.get(i, j) == S.get(i, j) * -8.1);
-      CHECK(Lij_from_R_Sij_T.get(i, j) == -1.7 * S.get(i, j) * 0.6);
+      CHECK_ITERABLE_APPROX(Lij_from_R_Sij_T.get(i, j),
+                            -1.7 * S.get(i, j) * 0.6);
     }
   }
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Product.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Product.cpp
@@ -37,6 +37,45 @@ void assign_unique_values_to_tensor(
   }
 }
 
+// Checks that the number of ops in the expressions match what is expected
+void test_tensor_ops_properties() {
+  const Scalar<double> G{5.0};
+  const double H = 5.0;
+  const tnsr::II<double, 3> R{};
+  const tnsr::ia<double, 3> S{};
+
+  const auto HG_outer_product = H * G();
+  const auto HGG_outer_product = H * G() * G();
+  const auto RG_outer_product = R(ti::I, ti::J) * G();
+  const auto HSGR_outer_product = H * S(ti::i, ti::j) * G() * R(ti::K, ti::L);
+  // Expected: 3 multiplies + 2 adds = 5 total ops
+  const auto RS_inner_product = R(ti::I, ti::J) * S(ti::j, ti::k);
+  // Expected: 9 multiplies + 8 adds = 17 total ops
+  const auto RS_fully_contract = R(ti::I, ti::J) * S(ti::j, ti::i);
+  // Expected:
+  // If tempIk = R(ti::I, ti::J) * S(ti::j, ti::k) is 5 ops (see above), then
+  // (tempIk) * R(ti::K, ti::L) should be:
+  //      (3 multiplies * (tmpIk ops)) + 3 multiplies + 2 adds = 20 total ops
+  const auto RSR_inner_product =
+      R(ti::I, ti::J) * S(ti::j, ti::k) * R(ti::K, ti::L);
+  // Expected:
+  // If tempij = ((G() * H) * (S(ti::i, ti::j) - S(ti::j, ti::i))), then tempij
+  // should be 2 multiplies + 1 subtract = 3 total ops. Then,
+  // (tempij) * R(ti::I, ti::K) should be:
+  //    (3 multiplies * (tempij ops)) + 3 multiplies + 2 adds = 14 total ops
+  const auto mixed_op_expression =
+      ((G() * H) * (S(ti::i, ti::j) - S(ti::j, ti::i))) * R(ti::I, ti::K);
+
+  CHECK(HG_outer_product.num_ops_subtree == 1);
+  CHECK(HGG_outer_product.num_ops_subtree == 2);
+  CHECK(RG_outer_product.num_ops_subtree == 1);
+  CHECK(HSGR_outer_product.num_ops_subtree == 3);
+  CHECK(RS_inner_product.num_ops_subtree == 5);
+  CHECK(RS_fully_contract.num_ops_subtree == 17);
+  CHECK(RSR_inner_product.num_ops_subtree == 20);
+  CHECK(mixed_op_expression.num_ops_subtree == 14);
+}
+
 // \brief Test the outer product and of a tensor expression and `double` is
 // correctly evaluated
 //
@@ -1301,6 +1340,7 @@ void test_products(const DataType& used_for_size) {
 
 SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Product",
                   "[DataStructures][Unit]") {
+  test_tensor_ops_properties();
   test_products(std::numeric_limits<double>::signaling_NaN());
   test_products(DataVector(5, std::numeric_limits<double>::signaling_NaN()));
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_SquareRoot.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_SquareRoot.cpp
@@ -36,6 +36,21 @@ void assign_unique_values_to_tensor(
   }
 }
 
+// Checks that the number of ops in the expressions match what is expected
+void test_tensor_ops_properties() {
+  const Scalar<double> G{5.0};
+  const double H = 5.0;
+
+  const auto sqrt_G = sqrt(G());
+  const auto sqrt_HGG = sqrt(H * G() * G());
+  // Expected: 2 sqrt + 2 negations + 2 multiplies = 6 total ops
+  const auto sqrt_sqrt_GHG = sqrt(sqrt(-G() * H * -G()));
+
+  CHECK(sqrt_G.num_ops_subtree == 1);
+  CHECK(sqrt_HGG.num_ops_subtree == 3);
+  CHECK(sqrt_sqrt_GHG.num_ops_subtree == 6);
+}
+
 // \brief Test the square root of a rank 0 tensor expression is correctly
 // evaluated
 //
@@ -119,6 +134,7 @@ void test_sqrt(const DataType& used_for_size) {
 
 SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.SquareRoot",
                   "[DataStructures][Unit]") {
+  test_tensor_ops_properties();
   test_sqrt(std::numeric_limits<double>::signaling_NaN());
   test_sqrt(DataVector(5, std::numeric_limits<double>::signaling_NaN()));
 }


### PR DESCRIPTION
## Proposed changes

This PR greatly improves the runtime of `TensorExpression`s, especially those that have many terms and/or tensor operations.

Benchmarking found two sources to be cause of a lot of slowdown:
- breadth in the tree
- large `DataVector` expressions (i.e. massive one-liners generated by equations with many operations)

The changes done in this PR address these two points by:
- reorganizing the expression tree to have more depth and less breadth
- "splitting up" TEs internally by evaluating subtrees when there are a large number of `DataVector` operations

Because the changes in this PR are sweeping (all TEs affected) and there is more cognitive complexity than before, I leaned more on over-documenting. When reviewing, **I recommend first reading the new documentation I've added to `TensorExpression.hpp`**, which defines some new terms I'm defining, as well as how, at a high level, the tree recursion works with the splitting.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
