### PR TITLE
Increase AH finder test timeouts

### DIFF
--- a/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
@@ -716,7 +716,7 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
 // Already the resolution used for the tests is very low
 // (lmax=3, num_pts_per_dim=3 to 7) and the error
 // tolerance Approx::custom().epsilon() is pretty large (1e-2 and 1e-3).
-// [[TimeOut, 10]]
+// [[TimeOut, 20]]
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ApparentHorizonFinder",
                   "[Unit]") {
   domain::creators::register_derived_with_charm();
@@ -753,6 +753,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ApparentHorizonFinder",
 }
 
 // [[OutputRegex, Cannot interpolate onto surface]]
+// [[Timeout, 5]]
 SPECTRE_TEST_CASE(
     "Unit.NumericalAlgorithms.Interpolator.ApparentHorizonFinder.Error",
     "[Unit]") {
@@ -768,6 +769,7 @@ SPECTRE_TEST_CASE(
 }
 
 // [[OutputRegex, Cannot interpolate onto surface]]
+// [[Timeout, 5]]
 SPECTRE_TEST_CASE("Unit.Interpolator.ApparentHorizonFinder.NotConvergedError",
                   "[Unit]") {
   ERROR_TEST();


### PR DESCRIPTION
## Proposed changes

These tests have timed out recently quite a bit.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
