### PR TITLE
Fix failing exact comparison in Test_Divergence.cpp

### DIFF
--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
@@ -151,7 +151,8 @@ void test_divergence_impl(
   // Test divergence of a single tensor
   const auto div_vector =
       divergence(get<Flux1<Dim, Frame>>(fluxes), mesh, inv_jacobian);
-  CHECK(get<Tags::div<Flux1<Dim, Frame>>>(div_fluxes) == div_vector);
+  CHECK_ITERABLE_APPROX((get<Tags::div<Flux1<Dim, Frame>>>(div_fluxes)),
+                        div_vector);
 }
 
 void test_divergence() {
@@ -255,7 +256,8 @@ void test_divergence_compute_item_impl(
 
   const auto& div_flux1 =
       db::get<Tags::DivVectorCompute<Flux1<Dim, Frame>, inv_jac_tag>>(box);
-  CHECK(get<Tags::div<Flux1<Dim, Frame>>>(div_fluxes) == div_flux1);
+  CHECK_ITERABLE_APPROX((get<Tags::div<Flux1<Dim, Frame>>>(div_fluxes)),
+                        div_flux1);
 }
 
 void test_divergence_compute() {


### PR DESCRIPTION
## Proposed changes

The test occasionally failed CI at numerical roundoff. Switched to `CHECK_ITERABLE_APPROX`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
