### PR TITLE
Add `PY_DEV_MODE` CMake flag

### DIFF
--- a/docs/DevGuide/BuildSystem.md
+++ b/docs/DevGuide/BuildSystem.md
@@ -218,6 +218,12 @@ cmake -D FLAG1=OPT1 ... -D FLAGN=OPTN <SPECTRE_ROOT>
     third-party libraries accidentally end up using different allocators, which
     is undefined behavior and will result in complete chaos.
     (default is `JEMALLOC`)
+- PY_DEV_MODE
+  - Enable development mode for the Python package, meaning that Python files
+    are symlinked rather than copied to the build directory. Allows to edit and
+    test Python code much easier, in particular when it uses compiled Python
+    bindings, but doesn't replace CMake placeholders in the Python code such as
+    the project version. (default is `OFF`)
 - SPECTRE_TEST_RUNNER
   - Run test executables through a wrapper.  This might be `charmrun`, for
     example.  (default is to not use one)


### PR DESCRIPTION
## Proposed changes

The flag enables development mode for the Python package, meaning
that Python files are symlinked rather than copied to the build directory.
Allows to edit and test Python code much easier, in particular when it uses
compiled Python bindings, but doesn't replace CMake placeholders
in the Python code such as the project version.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
