### PR TITLE
Added the Constraint Energy to be Observable

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -193,11 +193,16 @@ struct GeneralizedHarmonicTemplateBase<
       tmpl::push_back<
           analytic_solution_fields, gr::Tags::Lapse<DataVector>,
           GeneralizedHarmonic::Tags::GaugeConstraintCompute<volume_dim, frame>,
+          GeneralizedHarmonic::Tags::TwoIndexConstraintCompute<volume_dim,
+                                                                 frame>,
           GeneralizedHarmonic::Tags::ThreeIndexConstraintCompute<volume_dim,
                                                                  frame>,
           // following tags added to observe constraints
           ::Tags::PointwiseL2NormCompute<
               GeneralizedHarmonic::Tags::GaugeConstraint<volume_dim, frame>>,
+          ::Tags::PointwiseL2NormCompute<
+              GeneralizedHarmonic::Tags::TwoIndexConstraint<volume_dim,
+                                                              frame>>,
           ::Tags::PointwiseL2NormCompute<
               GeneralizedHarmonic::Tags::ThreeIndexConstraint<volume_dim,
                                                               frame>>>,
@@ -206,8 +211,12 @@ struct GeneralizedHarmonicTemplateBase<
           volume_dim == 3,
           tmpl::list<
               GeneralizedHarmonic::Tags::FourIndexConstraintCompute<3, frame>,
+              GeneralizedHarmonic::Tags::FConstraintCompute<3, frame>,
               ::Tags::PointwiseL2NormCompute<
-                  GeneralizedHarmonic::Tags::FourIndexConstraint<3, frame>>>,
+              GeneralizedHarmonic::Tags::FConstraint<3, frame>>,
+              ::Tags::PointwiseL2NormCompute<
+                  GeneralizedHarmonic::Tags::FourIndexConstraint<3, frame>>,
+              GeneralizedHarmonic::Tags::ConstraintEnergyCompute<3, frame>>,
           tmpl::list<>>>;
 
   struct factory_creation


### PR DESCRIPTION
## Proposed changes

Added the Constraint Energy to outputs we can observe which also meant
that we needed to compute and be able to output the F Constraint and TwoIndexConstraint. 

### Upgrade instructions

Will have to rebuild any solution that requires builds from GeneralizedHarmonic.
Also once it's rebuilt, when observing these outputs, the legend in the reductions file will be 
different from what it was before so make sure you're observing what you think you are.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.



