### PR TITLE
Don't erase Wedge map type in DomainHelpers, make Shape map copyable

### DIFF
--- a/src/Domain/CoordinateMaps/TimeDependent/Shape.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Shape.cpp
@@ -49,6 +49,20 @@ Shape::Shape(
                              << l_max << ", m_max = " << m_max);
 }
 
+Shape& Shape::operator=(const Shape& rhs) {
+  if (*this != rhs) {
+    f_of_t_name_ = rhs.f_of_t_name_;
+    center_ = rhs.center_;
+    l_max_ = rhs.l_max_;
+    m_max_ = rhs.m_max_;
+    ylm_ = rhs.ylm_;
+    transition_func_ = rhs.transition_func_->get_clone();
+  }
+  return *this;
+}
+
+Shape::Shape(const Shape& rhs) { *this = rhs; }
+
 template <typename T>
 std::array<tt::remove_cvref_wrap_t<T>, 3> Shape::operator()(
     const std::array<T, 3>& source_coords, const double time,
@@ -318,7 +332,11 @@ void Shape::check_coefficients([[maybe_unused]] const DataVector& coefs) const {
 bool operator==(const Shape& lhs, const Shape& rhs) {
   return lhs.f_of_t_name_ == rhs.f_of_t_name_ and lhs.center_ == rhs.center_ and
          lhs.l_max_ == rhs.l_max_ and lhs.m_max_ == rhs.m_max_ and
-         *lhs.transition_func_ == *rhs.transition_func_;
+         (lhs.transition_func_ == nullptr) ==
+             (rhs.transition_func_ == nullptr) and
+         ((lhs.transition_func_ == nullptr and
+           rhs.transition_func_ == nullptr) or
+          *lhs.transition_func_ == *rhs.transition_func_);
 }
 
 bool operator!=(const Shape& lhs, const Shape& rhs) { return not(lhs == rhs); }

--- a/src/Domain/CoordinateMaps/TimeDependent/Shape.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Shape.hpp
@@ -97,6 +97,11 @@ class Shape {
       std::string function_of_time_name);
 
   Shape() = default;
+  ~Shape() = default;
+  Shape(Shape&&) = default;
+  Shape& operator=(Shape&&) = default;
+  Shape(const Shape& rhs);
+  Shape& operator=(const Shape& rhs);
 
   template <typename T>
   std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/ShapeMapTransitionFunction.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/ShapeMapTransitionFunction.hpp
@@ -110,6 +110,9 @@ class ShapeMapTransitionFunction : public PUP::able {
       const std::array<double, 3>& source_coords) const = 0;
   virtual std::array<DataVector, 3> gradient(
       const std::array<DataVector, 3>& source_coords) const = 0;
+
+  virtual std::unique_ptr<ShapeMapTransitionFunction> get_clone() const = 0;
+
   /// @}
   virtual bool operator==(const ShapeMapTransitionFunction& other) const = 0;
   virtual bool operator!=(const ShapeMapTransitionFunction& other) const = 0;

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.hpp
@@ -45,6 +45,10 @@ class SphereTransition final : public ShapeMapTransitionFunction {
   explicit SphereTransition(CkMigrateMessage* const msg);
   void pup(PUP::er& p) override;
 
+  std::unique_ptr<ShapeMapTransitionFunction> get_clone() const override {
+    return std::make_unique<SphereTransition>(*this);
+  }
+
   bool operator==(const ShapeMapTransitionFunction& other) const override;
   bool operator!=(const ShapeMapTransitionFunction& other) const override;
 

--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -27,6 +27,7 @@
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/Distribution.hpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
+#include "Domain/CoordinateMaps/Frustum.hpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/Interval.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
@@ -387,10 +388,11 @@ Domain<3> BinaryCompactObject::create_domain() const {
                                     sqrt(3.0) * 0.5 * length_inner_cube_, 1.0,
                                     0.0, use_equiangular_map_),
           translation_B);
-  Maps maps_frustums = frustum_coordinate_maps<Frame::Inertial>(
-      length_inner_cube_, length_outer_cube_, use_equiangular_map_,
-      {{-translation_, 0.0, 0.0}}, projective_scale_factor_,
-      frustum_sphericity_);
+  Maps maps_frustums = domain::make_vector_coordinate_map_base<
+      Frame::BlockLogical, Frame::Inertial, 3>(
+      frustum_coordinate_maps(length_inner_cube_, length_outer_cube_,
+                              use_equiangular_map_, {{-translation_, 0.0, 0.0}},
+                              projective_scale_factor_, frustum_sphericity_));
 
   if (outer_boundary_condition_ != nullptr) {
     for (size_t i = 0; i < maps_center_A.size(); ++i) {

--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -150,58 +150,44 @@ namespace creators {
  * map about the z axis.
  */
 class BinaryCompactObject : public DomainCreator<3> {
+ private:
+  using Affine = CoordinateMaps::Affine;
+  using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  using Identity2D = CoordinateMaps::Identity<2>;
+  using Translation = CoordinateMaps::ProductOf2Maps<Affine, Identity2D>;
+  using Equiangular = CoordinateMaps::Equiangular;
+  using Equiangular3D =
+      CoordinateMaps::ProductOf3Maps<Equiangular, Equiangular, Equiangular>;
+  using RotationZ = domain::CoordinateMaps::TimeDependent::ProductOf2Maps<
+      domain::CoordinateMaps::TimeDependent::Rotation<2>,
+      domain::CoordinateMaps::Identity<1>>;
+
  public:
   using maps_list = tmpl::list<
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial, Affine3D>,
       domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
-                            CoordinateMaps::ProductOf3Maps<
-                                CoordinateMaps::Affine, CoordinateMaps::Affine,
-                                CoordinateMaps::Affine>>,
-      domain::CoordinateMap<
-          Frame::BlockLogical, Frame::Inertial,
-          CoordinateMaps::ProductOf3Maps<CoordinateMaps::Equiangular,
-                                         CoordinateMaps::Equiangular,
-                                         CoordinateMaps::Equiangular>>,
-      domain::CoordinateMap<
-          Frame::BlockLogical, Frame::Inertial,
-          CoordinateMaps::ProductOf3Maps<CoordinateMaps::Affine,
-                                         CoordinateMaps::Affine,
-                                         CoordinateMaps::Affine>,
-          CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
-                                         CoordinateMaps::Identity<2>>>,
+                            Equiangular3D>,
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial, Affine3D,
+                            Translation>,
       domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
-                            CoordinateMaps::DiscreteRotation<3>,
-                            CoordinateMaps::ProductOf3Maps<
-                                CoordinateMaps::Affine, CoordinateMaps::Affine,
-                                CoordinateMaps::Affine>>,
-      domain::CoordinateMap<
-          Frame::BlockLogical, Frame::Inertial,
-          CoordinateMaps::ProductOf3Maps<CoordinateMaps::Equiangular,
-                                         CoordinateMaps::Equiangular,
-                                         CoordinateMaps::Equiangular>>,
-      domain::CoordinateMap<
-          Frame::BlockLogical, Frame::Inertial,
-          CoordinateMaps::ProductOf3Maps<CoordinateMaps::Equiangular,
-                                         CoordinateMaps::Equiangular,
-                                         CoordinateMaps::Equiangular>,
-          CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
-                                         CoordinateMaps::Identity<2>>>,
+                            CoordinateMaps::DiscreteRotation<3>, Affine3D>,
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
+                            Equiangular3D>,
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial, Equiangular3D,
+                            Translation>,
       domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                             CoordinateMaps::Frustum>,
       domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                             CoordinateMaps::Wedge<3>>,
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
+                            CoordinateMaps::Wedge<3>, Translation>,
       domain::CoordinateMap<
           Frame::Grid, Frame::Inertial,
-          domain::CoordinateMaps::TimeDependent::CubicScale<3>,
-          domain::CoordinateMaps::TimeDependent::ProductOf2Maps<
-              domain::CoordinateMaps::TimeDependent::Rotation<2>,
-              domain::CoordinateMaps::Identity<1>>>,
+          domain::CoordinateMaps::TimeDependent::CubicScale<3>, RotationZ>,
       domain::CoordinateMap<
           Frame::Grid, Frame::Inertial,
           domain::CoordinateMaps::TimeDependent::SphericalCompression<false>,
-          domain::CoordinateMaps::TimeDependent::CubicScale<3>,
-          domain::CoordinateMaps::TimeDependent::ProductOf2Maps<
-              domain::CoordinateMaps::TimeDependent::Rotation<2>,
-              domain::CoordinateMaps::Identity<1>>>>;
+          domain::CoordinateMaps::TimeDependent::CubicScale<3>, RotationZ>>;
 
   /// Options for an excision region in the domain
   struct Excision {

--- a/src/Domain/Creators/FrustalCloak.cpp
+++ b/src/Domain/Creators/FrustalCloak.cpp
@@ -11,6 +11,9 @@
 #include "Domain/Block.hpp"                   // IWYU pragma: keep
 #include "Domain/BoundaryConditions/None.hpp"
 #include "Domain/BoundaryConditions/Periodic.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Frustum.hpp"
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"
@@ -67,9 +70,11 @@ FrustalCloak::FrustalCloak(
 Domain<3> FrustalCloak::create_domain() const {
   std::vector<std::unique_ptr<
       CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 3>>>
-      coord_maps = frustum_coordinate_maps<Frame::Inertial>(
-          length_inner_cube_, length_outer_cube_, use_equiangular_map_,
-          origin_preimage_, projection_factor_);
+      coord_maps = domain::make_vector_coordinate_map_base<Frame::BlockLogical,
+                                                           Frame::Inertial, 3>(
+          frustum_coordinate_maps(length_inner_cube_, length_outer_cube_,
+                                  use_equiangular_map_, origin_preimage_,
+                                  projection_factor_));
   std::vector<DirectionMap<
       3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
       boundary_conditions_all_blocks{};

--- a/src/Domain/Creators/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/Creators/RegisterDerivedWithCharm.cpp
@@ -23,6 +23,8 @@
 #include "Domain/CoordinateMaps/TimeDependent/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/TimeDependent/Rotation.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/Shape.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/RegisterDerivedWithCharm.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/SphericalCompression.hpp"
 #include "Domain/CoordinateMaps/Wedge.hpp"
 #include "Domain/Creators/Factory.hpp"
@@ -64,5 +66,8 @@ void register_derived_with_charm() {
       tmpl::remove_duplicates<tmpl::append<all_maps, maps_to_grid>>;
 
   Parallel::register_classes_with_charm(maps_to_register{});
+
+  domain::CoordinateMaps::ShapeMapTransitionFunctions::
+      register_derived_with_charm();
 }
 }  // namespace domain::creators

--- a/src/Domain/Creators/Shell.cpp
+++ b/src/Domain/Creators/Shell.cpp
@@ -10,6 +10,10 @@
 #include "Domain/Block.hpp"  // IWYU pragma: keep
 #include "Domain/BoundaryConditions/None.hpp"
 #include "Domain/BoundaryConditions/Periodic.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/EquatorialCompression.hpp"
+#include "Domain/CoordinateMaps/Wedge.hpp"
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Creators/TimeDependence/None.hpp"
 #include "Domain/Creators/TimeDependence/TimeDependence.hpp"
@@ -132,12 +136,15 @@ Shell::Shell(
 }
 
 Domain<3> Shell::create_domain() const {
-  std::vector<std::unique_ptr<
-      CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 3>>>
-      coord_maps = sph_wedge_coordinate_maps<Frame::Inertial>(
-          inner_radius_, outer_radius_, 1.0, 1.0, use_equiangular_map_, 0.0,
-          false, aspect_ratio_, index_polar_axis_, radial_partitioning_,
-          radial_distribution_, which_wedges_);
+  const domain::CoordinateMaps::EquatorialCompression compression{
+      aspect_ratio_, index_polar_axis_};
+
+  auto coord_maps = domain::make_vector_coordinate_map_base<Frame::BlockLogical,
+                                                            Frame::Inertial, 3>(
+      sph_wedge_coordinate_maps(
+          inner_radius_, outer_radius_, 1.0, 1.0, use_equiangular_map_, false,
+          radial_partitioning_, radial_distribution_, which_wedges_),
+      compression);
 
   std::vector<DirectionMap<
       3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>

--- a/src/Domain/Creators/Shell.hpp
+++ b/src/Domain/Creators/Shell.hpp
@@ -19,12 +19,7 @@
 /// \cond
 namespace domain {
 namespace CoordinateMaps {
-class Affine;
 class EquatorialCompression;
-template <size_t VolumeDim>
-class Identity;
-template <typename Map1, typename Map2>
-class ProductOf2Maps;
 template <size_t Dim>
 class Wedge;
 }  // namespace CoordinateMaps
@@ -43,11 +38,10 @@ namespace domain::creators {
  */
 class Shell : public DomainCreator<3> {
  public:
-  using maps_list = tmpl::list<domain::CoordinateMap<
-      Frame::BlockLogical, Frame::Inertial, CoordinateMaps::Wedge<3>,
-      CoordinateMaps::EquatorialCompression,
-      CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
-                                     CoordinateMaps::Identity<2>>>>;
+  using maps_list =
+      tmpl::list<domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
+                                       CoordinateMaps::Wedge<3>,
+                                       CoordinateMaps::EquatorialCompression>>;
 
   /// Options for the EquatorialCompression map
   struct EquatorialCompressionOptions {

--- a/src/Domain/Creators/Sphere.cpp
+++ b/src/Domain/Creators/Sphere.cpp
@@ -15,6 +15,7 @@
 #include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/CoordinateMaps/Wedge.hpp"
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"
@@ -60,18 +61,13 @@ Sphere::Sphere(typename InnerRadius::type inner_radius,
 }
 
 Domain<3> Sphere::create_domain() const {
-  using Affine = CoordinateMaps::Affine;
-  using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
-  using Equiangular = CoordinateMaps::Equiangular;
-  using Equiangular3D =
-      CoordinateMaps::ProductOf3Maps<Equiangular, Equiangular, Equiangular>;
   std::vector<std::array<size_t, 8>> corners =
       corners_for_radially_layered_domains(1, true);
 
-  std::vector<std::unique_ptr<
-      CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 3>>>
-      coord_maps = sph_wedge_coordinate_maps<Frame::Inertial>(
-          inner_radius_, outer_radius_, 0.0, 1.0, use_equiangular_map_);
+  auto coord_maps = domain::make_vector_coordinate_map_base<Frame::BlockLogical,
+                                                            Frame::Inertial, 3>(
+      sph_wedge_coordinate_maps(inner_radius_, outer_radius_, 0.0, 1.0,
+                                use_equiangular_map_));
   if (use_equiangular_map_) {
     coord_maps.emplace_back(
         make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(

--- a/src/Domain/Creators/Sphere.hpp
+++ b/src/Domain/Creators/Sphere.hpp
@@ -25,12 +25,7 @@
 namespace domain {
 namespace CoordinateMaps {
 class Affine;
-class EquatorialCompression;
 class Equiangular;
-template <size_t VolumeDim>
-class Identity;
-template <typename Map1, typename Map2>
-class ProductOf2Maps;
 template <typename Map1, typename Map2, typename Map3>
 class ProductOf3Maps;
 template <size_t Dim>
@@ -48,22 +43,20 @@ namespace creators {
 /// and a central cube. For an image showing how the wedges are aligned in
 /// this Domain, see the documentation for Shell.
 class Sphere : public DomainCreator<3> {
+ private:
+  using Affine = CoordinateMaps::Affine;
+  using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  using Equiangular = CoordinateMaps::Equiangular;
+  using Equiangular3D =
+      CoordinateMaps::ProductOf3Maps<Equiangular, Equiangular, Equiangular>;
+
  public:
   using maps_list = tmpl::list<
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial, Affine3D>,
       domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
-                            CoordinateMaps::ProductOf3Maps<
-                                CoordinateMaps::Affine, CoordinateMaps::Affine,
-                                CoordinateMaps::Affine>>,
-      domain::CoordinateMap<
-          Frame::BlockLogical, Frame::Inertial,
-          CoordinateMaps::ProductOf3Maps<CoordinateMaps::Equiangular,
-                                         CoordinateMaps::Equiangular,
-                                         CoordinateMaps::Equiangular>>,
-      domain::CoordinateMap<
-          Frame::BlockLogical, Frame::Inertial, CoordinateMaps::Wedge<3>,
-          CoordinateMaps::EquatorialCompression,
-          CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
-                                         CoordinateMaps::Identity<2>>>>;
+                            Equiangular3D>,
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
+                            CoordinateMaps::Wedge<3>>>;
 
   struct InnerRadius {
     using type = double;

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -598,15 +598,10 @@ size_t which_wedge_index(const ShellWedges& which_wedges) {
 }
 }  // namespace
 
-template <typename TargetFrame>
-std::vector<std::unique_ptr<
-    domain::CoordinateMapBase<Frame::BlockLogical, TargetFrame, 3>>>
-sph_wedge_coordinate_maps(
+std::vector<domain::CoordinateMaps::Wedge<3>> sph_wedge_coordinate_maps(
     const double inner_radius, const double outer_radius,
     const double inner_sphericity, const double outer_sphericity,
-    const bool use_equiangular_map, const double x_coord_of_shell_center,
-    const bool use_half_wedges, const double aspect_ratio,
-    const size_t index_polar_axis,
+    const bool use_equiangular_map, const bool use_half_wedges,
     const std::vector<double>& radial_partitioning,
     const std::vector<domain::CoordinateMaps::Distribution>&
         radial_distribution,
@@ -679,23 +674,7 @@ sph_wedge_coordinate_maps(
       temp_inner_radius = radial_partitioning.at(layer_i);
     }
   }
-
-  // Set up translation map:
-  using Identity2D = domain::CoordinateMaps::Identity<2>;
-  using Affine = domain::CoordinateMaps::Affine;
-  const auto translation =
-      domain::CoordinateMaps::ProductOf2Maps<Affine, Identity2D>(
-          Affine{-1.0, 1.0, -1.0 + x_coord_of_shell_center,
-                 1.0 + x_coord_of_shell_center},
-          Identity2D{});
-
-  // Set up compression map:
-  const auto compression = domain::CoordinateMaps::EquatorialCompression{
-      aspect_ratio, index_polar_axis};
-
-  return domain::make_vector_coordinate_map_base<Frame::BlockLogical,
-                                                 TargetFrame, 3>(
-      std::move(wedges_for_all_layers), compression, translation);
+  return wedges_for_all_layers;
 }
 
 template <typename TargetFrame>
@@ -1417,30 +1396,6 @@ ShellWedges Options::create_from_yaml<ShellWedges>::create<void>(
               "WhichWedges must be 'All', 'FourOnEquator' or 'OneAlongMinusX'");
 }
 
-template std::vector<std::unique_ptr<
-    domain::CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 3>>>
-sph_wedge_coordinate_maps(
-    const double inner_radius, const double outer_radius,
-    const double inner_sphericity, const double outer_sphericity,
-    const bool use_equiangular_map, const double x_coord_of_shell_center,
-    const bool use_wedge_halves, const double aspect_ratio,
-    const size_t index_pole_axis,
-    const std::vector<double>& radial_partitioning,
-    const std::vector<domain::CoordinateMaps::Distribution>&
-        radial_distribution,
-    const ShellWedges which_wedges);
-template std::vector<std::unique_ptr<
-    domain::CoordinateMapBase<Frame::BlockLogical, Frame::Grid, 3>>>
-sph_wedge_coordinate_maps(
-    const double inner_radius, const double outer_radius,
-    const double inner_sphericity, const double outer_sphericity,
-    const bool use_equiangular_map, const double x_coord_of_shell_center,
-    const bool use_wedge_halves, const double aspect_ratio,
-    const size_t index_pole_axis,
-    const std::vector<double>& radial_partitioning,
-    const std::vector<domain::CoordinateMaps::Distribution>&
-        radial_distribution,
-    const ShellWedges which_wedges);
 template std::vector<std::unique_ptr<
     domain::CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 3>>>
 frustum_coordinate_maps(const double length_inner_cube,

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -677,15 +677,11 @@ std::vector<domain::CoordinateMaps::Wedge<3>> sph_wedge_coordinate_maps(
   return wedges_for_all_layers;
 }
 
-template <typename TargetFrame>
-std::vector<std::unique_ptr<
-    domain::CoordinateMapBase<Frame::BlockLogical, TargetFrame, 3>>>
-frustum_coordinate_maps(const double length_inner_cube,
-                        const double length_outer_cube,
-                        const bool use_equiangular_map,
-                        const std::array<double, 3>& origin_preimage,
-                        const double projective_scale_factor,
-                        const double sphericity) {
+std::vector<domain::CoordinateMaps::Frustum> frustum_coordinate_maps(
+    const double length_inner_cube, const double length_outer_cube,
+    const bool use_equiangular_map,
+    const std::array<double, 3>& origin_preimage,
+    const double projective_scale_factor, const double sphericity) {
   ASSERT(length_inner_cube < 0.5 * length_outer_cube,
          "The outer cube is too small! The inner cubes will pierce the surface "
          "of the outer cube.");
@@ -769,12 +765,7 @@ frustum_coordinate_maps(const double length_inner_cube,
                                 projective_scale_factor,
                                 false,
                                 sphericity});
-
-  // clang-tidy: trivially copyable
-  return domain::make_vector_coordinate_map_base<Frame::BlockLogical,
-                                                 TargetFrame,
-                                                 3>(
-      std::move(frustums));  // NOLINT
+  return frustums;
 }
 
 namespace {
@@ -1396,22 +1387,6 @@ ShellWedges Options::create_from_yaml<ShellWedges>::create<void>(
               "WhichWedges must be 'All', 'FourOnEquator' or 'OneAlongMinusX'");
 }
 
-template std::vector<std::unique_ptr<
-    domain::CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 3>>>
-frustum_coordinate_maps(const double length_inner_cube,
-                        const double length_outer_cube,
-                        const bool use_equiangular_map,
-                        const std::array<double, 3>& origin_preimage,
-                        const double projective_scale_factor,
-                        const double sphericity);
-template std::vector<std::unique_ptr<
-    domain::CoordinateMapBase<Frame::BlockLogical, Frame::Grid, 3>>>
-frustum_coordinate_maps(const double length_inner_cube,
-                        const double length_outer_cube,
-                        const bool use_equiangular_map,
-                        const std::array<double, 3>& origin_preimage,
-                        const double projective_scale_factor,
-                        const double sphericity);
 template std::vector<std::unique_ptr<
     domain::CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 3>>>
 cyl_wedge_coordinate_maps(

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -49,6 +49,7 @@ class ProductOf3Maps;
 class Interval;
 template <size_t Dim>
 class Wedge;
+class Frustum;
 }  // namespace domain::CoordinateMaps
 /// \endcond
 
@@ -170,14 +171,11 @@ std::vector<domain::CoordinateMaps::Wedge<3>> sph_wedge_coordinate_maps(
 /// that moves the center of the two joined inner cubes away from the origin
 /// and to `-origin_preimage`. `projective_scale_factor` acts to change the
 /// gridpoint distribution in the radial direction. \see Frustum for details.
-template <typename TargetFrame>
-auto frustum_coordinate_maps(
+std::vector<domain::CoordinateMaps::Frustum> frustum_coordinate_maps(
     double length_inner_cube, double length_outer_cube,
     bool use_equiangular_map,
     const std::array<double, 3>& origin_preimage = {{0.0, 0.0, 0.0}},
-    double projective_scale_factor = 1.0, double sphericity = 0.0)
-    -> std::vector<std::unique_ptr<
-        domain::CoordinateMapBase<Frame::BlockLogical, TargetFrame, 3>>>;
+    double projective_scale_factor = 1.0, double sphericity = 0.0);
 
 /// \ingroup ComputationalDomainGroup
 /// \brief The corners for a domain with radial layers.

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -150,18 +150,14 @@ enum class ShellWedges {
 /// sub-shells between `inner_radius` and `outer_radius`. Set the
 /// `radial_distribution` to select the radial distribution of grid points in
 /// the spherical shells.
-template <typename TargetFrame>
-auto sph_wedge_coordinate_maps(
+std::vector<domain::CoordinateMaps::Wedge<3>> sph_wedge_coordinate_maps(
     double inner_radius, double outer_radius, double inner_sphericity,
     double outer_sphericity, bool use_equiangular_map,
-    double x_coord_of_shell_center = 0.0, bool use_half_wedges = false,
-    double aspect_ratio = 1.0, size_t index_polar_axis = 2,
+    bool use_half_wedges = false,
     const std::vector<double>& radial_partitioning = {},
     const std::vector<domain::CoordinateMaps::Distribution>&
         radial_distribution = {domain::CoordinateMaps::Distribution::Linear},
-    ShellWedges which_wedges = ShellWedges::All)
-    -> std::vector<std::unique_ptr<
-        domain::CoordinateMapBase<Frame::BlockLogical, TargetFrame, 3>>>;
+    ShellWedges which_wedges = ShellWedges::All);
 
 /// \ingroup ComputationalDomainGroup
 /// These are the ten Frustums used in the DomainCreators for binary compact

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_Shape.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_Shape.cpp
@@ -264,6 +264,7 @@ void test_map_helpers(const TransitionFunction& transition_func, size_t l_max,
   // Check map against a suite of functions in
   // tests/Unit/Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp
   test_serialization(map);
+  test_copy_semantics(map);
   CHECK_FALSE(map != map);
   test_coordinate_map_argument_types(map, random_point, time,
                                      functions_of_time);

--- a/tests/Unit/Domain/Creators/Test_Shell.cpp
+++ b/tests/Unit/Domain/Creators/Test_Shell.cpp
@@ -294,12 +294,6 @@ void test_shell_construction(
   } else {
     const auto compression =
         CoordinateMaps::EquatorialCompression{aspect_ratio, index_polar_axis};
-    // Set up translation map:
-    using Identity2D = domain::CoordinateMaps::Identity<2>;
-    using Affine = domain::CoordinateMaps::Affine;
-    const auto translation =
-        domain::CoordinateMaps::ProductOf2Maps<Affine, Identity2D>(
-            Affine{-1.0, 1.0, -1.0, 1.0}, Identity2D{});
     using TargetFrame = tmpl::conditional_t<sizeof...(FuncsOfTime) == 0,
                                             Frame::Inertial, Frame::Grid>;
     auto vector_of_maps = make_vector(
@@ -307,14 +301,14 @@ void test_shell_construction(
             Wedge3DMap{inner_radius, outer_radius, 1.0, 1.0,
                        OrientationMap<3>{}, use_equiangular_map, Halves::Both,
                        radial_distribution},
-            compression, translation),
+            compression),
         make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
             Wedge3DMap{inner_radius, outer_radius, 1.0, 1.0,
                        OrientationMap<3>{std::array<Direction<3>, 3>{
                            {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
                             Direction<3>::lower_zeta()}}},
                        use_equiangular_map, Halves::Both, radial_distribution},
-            compression, translation),
+            compression),
         make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
             Wedge3DMap{
                 inner_radius, outer_radius, 1.0, 1.0,
@@ -322,7 +316,7 @@ void test_shell_construction(
                     {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
                      Direction<3>::lower_eta()}}},
                 use_equiangular_map, Halves::Both, radial_distribution},
-            compression, translation),
+            compression),
         make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
             Wedge3DMap{
                 inner_radius, outer_radius, 1.0, 1.0,
@@ -330,7 +324,7 @@ void test_shell_construction(
                     {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
                      Direction<3>::upper_eta()}}},
                 use_equiangular_map, Halves::Both, radial_distribution},
-            compression, translation),
+            compression),
         make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
             Wedge3DMap{
                 inner_radius, outer_radius, 1.0, 1.0,
@@ -338,7 +332,7 @@ void test_shell_construction(
                     {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
                      Direction<3>::upper_eta()}}},
                 use_equiangular_map, Halves::Both, radial_distribution},
-            compression, translation),
+            compression),
         make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
             Wedge3DMap{
                 inner_radius, outer_radius, 1.0, 1.0,
@@ -346,7 +340,7 @@ void test_shell_construction(
                     {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
                      Direction<3>::upper_eta()}}},
                 use_equiangular_map, Halves::Both, radial_distribution},
-            compression, translation));
+            compression));
     if (UNLIKELY(which_wedges == ShellWedges::FourOnEquator)) {
       vector_of_maps.erase(vector_of_maps.begin(), vector_of_maps.begin() + 2);
     } else if (UNLIKELY(which_wedges == ShellWedges::OneAlongMinusX)) {

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -411,135 +411,127 @@ void test_all_frustum_directions() {
 
   const double projective_scale_factor = 0.3;
   for (const bool use_equiangular_map : {true, false}) {
-    const auto expected_coord_maps =
-        make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
-            FrustumMap{{{{{-2.0 * lower - displacement1[0],
-                           -lower - displacement1[1]}},
-                         {{-displacement1[0], lower - displacement1[1]}},
-                         {{-top, -top}},
-                         {{0.0, top}}}},
-                       lower - displacement1[2],
-                       top,
-                       OrientationMap<3>{},
-                       use_equiangular_map,
-                       projective_scale_factor},
-            FrustumMap{
-                {{{{-displacement2[0], -lower - displacement2[1]}},
-                  {{2.0 * lower - displacement2[0], lower - displacement2[1]}},
-                  {{0.0, -top}},
-                  {{top, top}}}},
-                lower - displacement2[2],
-                top,
-                OrientationMap<3>{},
-                use_equiangular_map,
-                projective_scale_factor},
-            FrustumMap{{{{{-2.0 * lower - displacement3[0],
-                           -lower - displacement3[1]}},
-                         {{-displacement3[0], lower - displacement3[1]}},
-                         {{-top, -top}},
-                         {{0.0, top}}}},
-                       lower - displacement3[2],
-                       top,
-                       OrientationMap<3>{std::array<Direction<3>, 3>{
-                           {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
-                            Direction<3>::lower_zeta()}}},
-                       use_equiangular_map,
-                       projective_scale_factor},
-            FrustumMap{
-                {{{{-displacement4[0], -lower - displacement4[1]}},
-                  {{2.0 * lower - displacement4[0], lower - displacement4[1]}},
-                  {{0.0, -top}},
-                  {{top, top}}}},
-                lower - displacement4[2],
-                top,
-                OrientationMap<3>{std::array<Direction<3>, 3>{
-                    {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
-                     Direction<3>::lower_zeta()}}},
-                use_equiangular_map,
-                projective_scale_factor},
-            FrustumMap{
-                {{{{-2.0 * lower - displacement5[0],
-                    -lower - displacement5[1]}},
-                  {{-displacement5[0], lower - displacement5[1]}},
-                  {{-top, -top}},
-                  {{0.0, top}}}},
-                lower - displacement5[2],
-                top,
-                OrientationMap<3>{std::array<Direction<3>, 3>{
-                    {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
-                     Direction<3>::lower_eta()}}},
-                use_equiangular_map,
-                projective_scale_factor},
-            FrustumMap{
-                {{{{-displacement6[0], -lower - displacement6[1]}},
-                  {{2.0 * lower - displacement6[0], lower - displacement6[1]}},
-                  {{0.0, -top}},
-                  {{top, top}}}},
-                lower - displacement6[2],
-                top,
-                OrientationMap<3>{std::array<Direction<3>, 3>{
-                    {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
-                     Direction<3>::lower_eta()}}},
-                use_equiangular_map,
-                projective_scale_factor},
-            FrustumMap{
-                {{{{-2.0 * lower - displacement7[0],
-                    -lower - displacement7[1]}},
-                  {{-displacement7[0], lower - displacement7[1]}},
-                  {{-top, -top}},
-                  {{0.0, top}}}},
-                lower - displacement7[2],
-                top,
-                OrientationMap<3>{std::array<Direction<3>, 3>{
-                    {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
-                     Direction<3>::upper_eta()}}},
-                use_equiangular_map,
-                projective_scale_factor},
-            FrustumMap{
-                {{{{-displacement8[0], -lower - displacement8[1]}},
-                  {{2.0 * lower - displacement8[0], lower - displacement8[1]}},
-                  {{0.0, -top}},
-                  {{top, top}}}},
-                lower - displacement8[2],
-                top,
-                OrientationMap<3>{std::array<Direction<3>, 3>{
-                    {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
-                     Direction<3>::upper_eta()}}},
-                use_equiangular_map,
-                projective_scale_factor},
-            // Frustum on right half in the +x direction
-            FrustumMap{
-                {{{{-lower - displacement9[0], -lower - displacement9[1]}},
-                  {{lower - displacement9[0], lower - displacement9[1]}},
-                  {{-top, -top}},
-                  {{top, top}}}},
-                2.0 * lower - displacement9[2],
-                top,
-                OrientationMap<3>{std::array<Direction<3>, 3>{
-                    {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
-                     Direction<3>::upper_eta()}}},
-                use_equiangular_map,
-                projective_scale_factor},
-            // Frustum on left half in the -x direction
-            FrustumMap{
-                {{{{-lower - displacement10[0], -lower - displacement10[1]}},
-                  {{lower - displacement10[0], lower - displacement10[1]}},
-                  {{-top, -top}},
-                  {{top, top}}}},
-                2.0 * lower - displacement10[2],
-                top,
-                OrientationMap<3>{std::array<Direction<3>, 3>{
-                    {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
-                     Direction<3>::upper_eta()}}},
-                use_equiangular_map,
-                projective_scale_factor});
+    const auto expected_coord_maps = make_vector(
+        FrustumMap{
+            {{{{-2.0 * lower - displacement1[0], -lower - displacement1[1]}},
+              {{-displacement1[0], lower - displacement1[1]}},
+              {{-top, -top}},
+              {{0.0, top}}}},
+            lower - displacement1[2],
+            top,
+            OrientationMap<3>{},
+            use_equiangular_map,
+            projective_scale_factor},
+        FrustumMap{
+            {{{{-displacement2[0], -lower - displacement2[1]}},
+              {{2.0 * lower - displacement2[0], lower - displacement2[1]}},
+              {{0.0, -top}},
+              {{top, top}}}},
+            lower - displacement2[2],
+            top,
+            OrientationMap<3>{},
+            use_equiangular_map,
+            projective_scale_factor},
+        FrustumMap{
+            {{{{-2.0 * lower - displacement3[0], -lower - displacement3[1]}},
+              {{-displacement3[0], lower - displacement3[1]}},
+              {{-top, -top}},
+              {{0.0, top}}}},
+            lower - displacement3[2],
+            top,
+            OrientationMap<3>{std::array<Direction<3>, 3>{
+                {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
+                 Direction<3>::lower_zeta()}}},
+            use_equiangular_map,
+            projective_scale_factor},
+        FrustumMap{
+            {{{{-displacement4[0], -lower - displacement4[1]}},
+              {{2.0 * lower - displacement4[0], lower - displacement4[1]}},
+              {{0.0, -top}},
+              {{top, top}}}},
+            lower - displacement4[2],
+            top,
+            OrientationMap<3>{std::array<Direction<3>, 3>{
+                {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
+                 Direction<3>::lower_zeta()}}},
+            use_equiangular_map,
+            projective_scale_factor},
+        FrustumMap{
+            {{{{-2.0 * lower - displacement5[0], -lower - displacement5[1]}},
+              {{-displacement5[0], lower - displacement5[1]}},
+              {{-top, -top}},
+              {{0.0, top}}}},
+            lower - displacement5[2],
+            top,
+            OrientationMap<3>{std::array<Direction<3>, 3>{
+                {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
+                 Direction<3>::lower_eta()}}},
+            use_equiangular_map,
+            projective_scale_factor},
+        FrustumMap{
+            {{{{-displacement6[0], -lower - displacement6[1]}},
+              {{2.0 * lower - displacement6[0], lower - displacement6[1]}},
+              {{0.0, -top}},
+              {{top, top}}}},
+            lower - displacement6[2],
+            top,
+            OrientationMap<3>{std::array<Direction<3>, 3>{
+                {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
+                 Direction<3>::lower_eta()}}},
+            use_equiangular_map,
+            projective_scale_factor},
+        FrustumMap{
+            {{{{-2.0 * lower - displacement7[0], -lower - displacement7[1]}},
+              {{-displacement7[0], lower - displacement7[1]}},
+              {{-top, -top}},
+              {{0.0, top}}}},
+            lower - displacement7[2],
+            top,
+            OrientationMap<3>{std::array<Direction<3>, 3>{
+                {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
+                 Direction<3>::upper_eta()}}},
+            use_equiangular_map,
+            projective_scale_factor},
+        FrustumMap{
+            {{{{-displacement8[0], -lower - displacement8[1]}},
+              {{2.0 * lower - displacement8[0], lower - displacement8[1]}},
+              {{0.0, -top}},
+              {{top, top}}}},
+            lower - displacement8[2],
+            top,
+            OrientationMap<3>{std::array<Direction<3>, 3>{
+                {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
+                 Direction<3>::upper_eta()}}},
+            use_equiangular_map,
+            projective_scale_factor},
+        // Frustum on right half in the +x direction
+        FrustumMap{{{{{-lower - displacement9[0], -lower - displacement9[1]}},
+                     {{lower - displacement9[0], lower - displacement9[1]}},
+                     {{-top, -top}},
+                     {{top, top}}}},
+                   2.0 * lower - displacement9[2],
+                   top,
+                   OrientationMap<3>{std::array<Direction<3>, 3>{
+                       {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
+                        Direction<3>::upper_eta()}}},
+                   use_equiangular_map,
+                   projective_scale_factor},
+        // Frustum on left half in the -x direction
+        FrustumMap{{{{{-lower - displacement10[0], -lower - displacement10[1]}},
+                     {{lower - displacement10[0], lower - displacement10[1]}},
+                     {{-top, -top}},
+                     {{top, top}}}},
+                   2.0 * lower - displacement10[2],
+                   top,
+                   OrientationMap<3>{std::array<Direction<3>, 3>{
+                       {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
+                        Direction<3>::upper_eta()}}},
+                   use_equiangular_map,
+                   projective_scale_factor});
 
-    const auto maps = frustum_coordinate_maps<Frame::Inertial>(
+    const auto maps = frustum_coordinate_maps(
         2.0 * lower, 2.0 * top, use_equiangular_map, origin_preimage, 0.3);
-    for (size_t i = 0; i < maps.size(); i++) {
-      INFO(i);
-      CHECK(*expected_coord_maps[i] == *maps[i]);
-    }
+    CHECK(maps == expected_coord_maps);
   }
 }
 
@@ -554,9 +546,9 @@ void test_all_frustum_directions() {
   const double length_outer_cube = 1.5;
   const bool use_equiangular_map = true;
   const std::array<double, 3> origin_preimage = {{0.0, 0.0, 0.0}};
-  static_cast<void>(frustum_coordinate_maps<Frame::Inertial>(
-      length_inner_cube, length_outer_cube, use_equiangular_map,
-      origin_preimage));
+  static_cast<void>(
+      frustum_coordinate_maps(length_inner_cube, length_outer_cube,
+                              use_equiangular_map, origin_preimage));
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
@@ -572,9 +564,9 @@ void test_all_frustum_directions() {
   const double length_outer_cube = 3;
   const bool use_equiangular_map = true;
   const std::array<double, 3> origin_preimage = {{0.6, 0.0, 0.0}};
-  static_cast<void>(frustum_coordinate_maps<Frame::Inertial>(
-      length_inner_cube, length_outer_cube, use_equiangular_map,
-      origin_preimage));
+  static_cast<void>(
+      frustum_coordinate_maps(length_inner_cube, length_outer_cube,
+                              use_equiangular_map, origin_preimage));
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -127,169 +127,112 @@ void test_periodic_different_blocks() {
   CHECK(neighbors_of_all_blocks == expected_block_neighbors);
 }
 
-std::vector<
-    std::unique_ptr<CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 3>>>
-test_wedge_map_generation(double inner_radius, double outer_radius,
-                          double inner_sphericity, double outer_sphericity,
-                          bool use_equiangular_map,
-                          double x_coord_of_shell_center = 0.0,
-                          bool use_half_wedges = false,
-                          double aspect_ratio = 1.0,
-                          size_t index_polar_axis = 2) {
+std::vector<CoordinateMaps::Wedge<3>> test_wedge_map_generation(
+    double inner_radius, double outer_radius, double inner_sphericity,
+    double outer_sphericity, bool use_equiangular_map,
+    bool use_half_wedges = false) {
   using Wedge3DMap = CoordinateMaps::Wedge<3>;
-  using Identity2D = CoordinateMaps::Identity<2>;
-  using Affine = CoordinateMaps::Affine;
-  const auto translation = CoordinateMaps::ProductOf2Maps<Affine, Identity2D>(
-      Affine{-1.0, 1.0, -1.0 + x_coord_of_shell_center,
-             1.0 + x_coord_of_shell_center},
-      Identity2D{});
-  const auto compression =
-      CoordinateMaps::EquatorialCompression{aspect_ratio, index_polar_axis};
 
   if (use_half_wedges) {
     using Halves = Wedge3DMap::WedgeHalves;
     return make_vector(
-        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
-            Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
-                       outer_sphericity, OrientationMap<3>{},
-                       use_equiangular_map, Halves::LowerOnly},
-            compression, translation),
-        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
-            Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
-                       outer_sphericity, OrientationMap<3>{},
-                       use_equiangular_map, Halves::UpperOnly},
-            compression, translation),
-        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
-            Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
-                       outer_sphericity,
-                       OrientationMap<3>{std::array<Direction<3>, 3>{
-                           {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
-                            Direction<3>::lower_zeta()}}},
-                       use_equiangular_map, Halves::LowerOnly},
-            compression, translation),
-        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
-            Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
-                       outer_sphericity,
-                       OrientationMap<3>{std::array<Direction<3>, 3>{
-                           {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
-                            Direction<3>::lower_zeta()}}},
-                       use_equiangular_map, Halves::UpperOnly},
-            compression, translation),
-        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
-            Wedge3DMap{
-                inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-                OrientationMap<3>{std::array<Direction<3>, 3>{
-                    {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
-                     Direction<3>::lower_eta()}}},
-                use_equiangular_map, Halves::LowerOnly},
-            compression, translation),
-        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
-            Wedge3DMap{
-                inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-                OrientationMap<3>{std::array<Direction<3>, 3>{
-                    {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
-                     Direction<3>::lower_eta()}}},
-                use_equiangular_map, Halves::UpperOnly},
-            compression, translation),
-        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
-            Wedge3DMap{
-                inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-                OrientationMap<3>{std::array<Direction<3>, 3>{
-                    {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
-                     Direction<3>::upper_eta()}}},
-                use_equiangular_map, Halves::LowerOnly},
-            compression, translation),
-        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
-            Wedge3DMap{
-                inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-                OrientationMap<3>{std::array<Direction<3>, 3>{
-                    {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
-                     Direction<3>::upper_eta()}}},
-                use_equiangular_map, Halves::UpperOnly},
-            compression, translation),
-        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
-            Wedge3DMap{
-                inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-                OrientationMap<3>{std::array<Direction<3>, 3>{
-                    {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
-                     Direction<3>::upper_eta()}}},
-                use_equiangular_map},
-            compression, translation),
-        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
-            Wedge3DMap{
-                inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-                OrientationMap<3>{std::array<Direction<3>, 3>{
-                    {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
-                     Direction<3>::upper_eta()}}},
-                use_equiangular_map},
-            compression, translation));
+        Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
+                   outer_sphericity, OrientationMap<3>{}, use_equiangular_map,
+                   Halves::LowerOnly},
+        Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
+                   outer_sphericity, OrientationMap<3>{}, use_equiangular_map,
+                   Halves::UpperOnly},
+        Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
+                   outer_sphericity,
+                   OrientationMap<3>{std::array<Direction<3>, 3>{
+                       {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
+                        Direction<3>::lower_zeta()}}},
+                   use_equiangular_map, Halves::LowerOnly},
+        Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
+                   outer_sphericity,
+                   OrientationMap<3>{std::array<Direction<3>, 3>{
+                       {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
+                        Direction<3>::lower_zeta()}}},
+                   use_equiangular_map, Halves::UpperOnly},
+        Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
+                   outer_sphericity,
+                   OrientationMap<3>{std::array<Direction<3>, 3>{
+                       {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
+                        Direction<3>::lower_eta()}}},
+                   use_equiangular_map, Halves::LowerOnly},
+        Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
+                   outer_sphericity,
+                   OrientationMap<3>{std::array<Direction<3>, 3>{
+                       {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
+                        Direction<3>::lower_eta()}}},
+                   use_equiangular_map, Halves::UpperOnly},
+        Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
+                   outer_sphericity,
+                   OrientationMap<3>{std::array<Direction<3>, 3>{
+                       {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
+                        Direction<3>::upper_eta()}}},
+                   use_equiangular_map, Halves::LowerOnly},
+        Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
+                   outer_sphericity,
+                   OrientationMap<3>{std::array<Direction<3>, 3>{
+                       {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
+                        Direction<3>::upper_eta()}}},
+                   use_equiangular_map, Halves::UpperOnly},
+        Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
+                   outer_sphericity,
+                   OrientationMap<3>{std::array<Direction<3>, 3>{
+                       {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
+                        Direction<3>::upper_eta()}}},
+                   use_equiangular_map},
+        Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
+                   outer_sphericity,
+                   OrientationMap<3>{std::array<Direction<3>, 3>{
+                       {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
+                        Direction<3>::upper_eta()}}},
+                   use_equiangular_map});
   }
 
   return make_vector(
-      make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
-          Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
-                     outer_sphericity, OrientationMap<3>{},
-                     use_equiangular_map},
-          compression, translation),
-      make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
-          Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
-                     outer_sphericity,
-                     OrientationMap<3>{std::array<Direction<3>, 3>{
-                         {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
-                          Direction<3>::lower_zeta()}}},
-                     use_equiangular_map},
-          compression, translation),
-      make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
-          Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
-                     outer_sphericity,
-                     OrientationMap<3>{std::array<Direction<3>, 3>{
-                         {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
-                          Direction<3>::lower_eta()}}},
-                     use_equiangular_map},
-          compression, translation),
-      make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
-          Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
-                     outer_sphericity,
-                     OrientationMap<3>{std::array<Direction<3>, 3>{
-                         {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
-                          Direction<3>::upper_eta()}}},
-                     use_equiangular_map},
-          compression, translation),
-      make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
-          Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
-                     outer_sphericity,
-                     OrientationMap<3>{std::array<Direction<3>, 3>{
-                         {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
-                          Direction<3>::upper_eta()}}},
-                     use_equiangular_map},
-          compression, translation),
-      make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
-          Wedge3DMap{inner_radius, outer_radius, inner_sphericity,
-                     outer_sphericity,
-                     OrientationMap<3>{std::array<Direction<3>, 3>{
-                         {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
-                          Direction<3>::upper_eta()}}},
-                     use_equiangular_map},
-          compression, translation));
+      Wedge3DMap{inner_radius, outer_radius, inner_sphericity, outer_sphericity,
+                 OrientationMap<3>{}, use_equiangular_map},
+      Wedge3DMap{inner_radius, outer_radius, inner_sphericity, outer_sphericity,
+                 OrientationMap<3>{std::array<Direction<3>, 3>{
+                     {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
+                      Direction<3>::lower_zeta()}}},
+                 use_equiangular_map},
+      Wedge3DMap{inner_radius, outer_radius, inner_sphericity, outer_sphericity,
+                 OrientationMap<3>{std::array<Direction<3>, 3>{
+                     {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
+                      Direction<3>::lower_eta()}}},
+                 use_equiangular_map},
+      Wedge3DMap{inner_radius, outer_radius, inner_sphericity, outer_sphericity,
+                 OrientationMap<3>{std::array<Direction<3>, 3>{
+                     {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
+                      Direction<3>::upper_eta()}}},
+                 use_equiangular_map},
+      Wedge3DMap{inner_radius, outer_radius, inner_sphericity, outer_sphericity,
+                 OrientationMap<3>{std::array<Direction<3>, 3>{
+                     {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
+                      Direction<3>::upper_eta()}}},
+                 use_equiangular_map},
+      Wedge3DMap{inner_radius, outer_radius, inner_sphericity, outer_sphericity,
+                 OrientationMap<3>{std::array<Direction<3>, 3>{
+                     {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
+                      Direction<3>::upper_eta()}}},
+                 use_equiangular_map});
 }
 
 void test_wedge_map_generation_against_domain_helpers(
     double inner_radius, double outer_radius, double inner_sphericity,
     double outer_sphericity, bool use_equiangular_map,
-    double x_coord_of_shell_center = 0.0, bool use_half_wedges = false,
-    double aspect_ratio = 1.0, size_t index_polar_axis = 2) {
+    bool use_half_wedges = false) {
   const auto expected_coord_maps = test_wedge_map_generation(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
-      aspect_ratio, index_polar_axis);
-  const auto maps = sph_wedge_coordinate_maps<Frame::Inertial>(
+      use_equiangular_map, use_half_wedges);
+  const auto maps = sph_wedge_coordinate_maps(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
-      aspect_ratio, index_polar_axis);
-  CHECK(maps.size() == expected_coord_maps.size());
-  for (size_t i = 0; i < expected_coord_maps.size(); i++) {
-    check_if_maps_are_equal(*expected_coord_maps[i], *maps[i]);
-  }
+      use_equiangular_map, use_half_wedges);
+  CHECK(maps == expected_coord_maps);
 }
 
 // [[OutputRegex, If we are using half wedges we must also be using
@@ -303,17 +246,14 @@ void test_wedge_map_generation_against_domain_helpers(
   const double inner_sphericity = 1.0;
   const double outer_sphericity = 1.0;
   const bool use_equiangular_map = true;
-  const double x_coord_of_shell_center = 0.1;
   const bool use_half_wedges = true;
-  const double aspect_ratio = 1.0;
-  const size_t index_polar_axis = 1;
   const std::vector<domain::CoordinateMaps::Distribution> radial_distribution{
       domain::CoordinateMaps::Distribution::Logarithmic};
   const ShellWedges which_wedges = ShellWedges::FourOnEquator;
-  static_cast<void>(sph_wedge_coordinate_maps<Frame::Inertial>(
+  static_cast<void>(sph_wedge_coordinate_maps(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
-      aspect_ratio, index_polar_axis, {}, radial_distribution, which_wedges));
+      use_equiangular_map, use_half_wedges, {}, radial_distribution,
+      which_wedges));
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
@@ -329,26 +269,22 @@ void test_wedge_map_generation_against_domain_helpers(
   const double inner_sphericity = 0.9;
   const double outer_sphericity = 1.0;
   const bool use_equiangular_map = true;
-  const double x_coord_of_shell_center = 0.1;
   const bool use_half_wedges = true;
-  const double aspect_ratio = 1.0;
-  const double index_polar_axis = 1;
   std::vector<double> radial_partitioning{1., 1.5};
   const std::vector<domain::CoordinateMaps::Distribution> radial_distribution{
       domain::CoordinateMaps::Distribution::Logarithmic,
       domain::CoordinateMaps::Distribution::Logarithmic,
       domain::CoordinateMaps::Distribution::Logarithmic};
   const ShellWedges which_wedges = ShellWedges::All;
-  static_cast<void>(sph_wedge_coordinate_maps<Frame::Inertial>(
+  static_cast<void>(sph_wedge_coordinate_maps(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
-      aspect_ratio, index_polar_axis, radial_partitioning, radial_distribution,
-      which_wedges));
+      use_equiangular_map, use_half_wedges, radial_partitioning,
+      radial_distribution, which_wedges));
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
-void test_default_six_wedge_directions_equiangular() {
+void test_six_wedge_directions_equiangular() {
   INFO("Default six wedge directions equiangular");
   const double inner_radius = 1.2;
   const double outer_radius = 2.7;
@@ -360,8 +296,8 @@ void test_default_six_wedge_directions_equiangular() {
       use_equiangular_map);
 }
 
-void test_default_six_wedge_directions_equidistant() {
-  INFO("Defaul six wedge directions equidistant");
+void test_six_wedge_directions_equidistant() {
+  INFO("Default six wedge directions equidistant");
   const double inner_radius = 0.8;
   const double outer_radius = 7.1;
   const double inner_sphericity = 0.2;
@@ -370,32 +306,6 @@ void test_default_six_wedge_directions_equidistant() {
   test_wedge_map_generation_against_domain_helpers(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
       use_equiangular_map);
-}
-
-void test_translated_six_wedge_directions_equiangular() {
-  INFO("Translated six wedge directions equiangular");
-  const double inner_radius = 1.2;
-  const double outer_radius = 3.1;
-  const double inner_sphericity = 0.3;
-  const double outer_sphericity = 0.6;
-  const bool use_equiangular_map = true;
-  const double x_coord_of_shell_center = 0.6;
-  test_wedge_map_generation_against_domain_helpers(
-      inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, x_coord_of_shell_center);
-}
-
-void test_translated_six_wedge_directions_equidistant() {
-  INFO("Translated six wedge directions equidistant");
-  const double inner_radius = 12.2;
-  const double outer_radius = 31.1;
-  const double inner_sphericity = 0.9;
-  const double outer_sphericity = 0.1;
-  const bool use_equiangular_map = false;
-  const double x_coord_of_shell_center = -2.7;
-  test_wedge_map_generation_against_domain_helpers(
-      inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, x_coord_of_shell_center);
 }
 
 void test_ten_wedge_directions_equiangular() {
@@ -408,7 +318,7 @@ void test_ten_wedge_directions_equiangular() {
   const bool use_half_wedges = true;
   test_wedge_map_generation_against_domain_helpers(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, 0.0, use_half_wedges);
+      use_equiangular_map, use_half_wedges);
 }
 
 void test_ten_wedge_directions_equidistant() {
@@ -421,122 +331,14 @@ void test_ten_wedge_directions_equidistant() {
   const bool use_half_wedges = true;
   test_wedge_map_generation_against_domain_helpers(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, 0.0, use_half_wedges);
-}
-
-void test_six_wedge_directions_compressed_equiangular() {
-  INFO("Six wedge directions compressed equiangular");
-  const double inner_radius = 7.2;
-  const double outer_radius = 12.2;
-  const double inner_sphericity = 0.0;
-  const double outer_sphericity = 1.0;
-  const bool use_equiangular_map = true;
-  const bool use_half_wedges = false;
-  const double aspect_ratio = 6.0;
-  const size_t index_polar_axis = 2;
-  test_wedge_map_generation_against_domain_helpers(
-      inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, 0.0, use_half_wedges, aspect_ratio,
-      index_polar_axis);
-}
-
-void test_six_wedge_directions_compressed_equidistant() {
-  INFO("Six wedge directions compressed equidistant");
-  const double inner_radius = 9.6;
-  const double outer_radius = 29.2;
-  const double inner_sphericity = 0.0;
-  const double outer_sphericity = 1.0;
-  const bool use_equiangular_map = false;
-  const bool use_half_wedges = false;
-  const double aspect_ratio = 0.6;
-  const size_t index_polar_axis = 1;
-  test_wedge_map_generation_against_domain_helpers(
-      inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, 0.0, use_half_wedges, aspect_ratio,
-      index_polar_axis);
-}
-
-void test_six_wedge_directions_compressed_translated_equiangular() {
-  INFO("Six wedge directions compressed translated equiangular");
-  const double inner_radius = 7.2;
-  const double outer_radius = 12.2;
-  const double inner_sphericity = 0.0;
-  const double outer_sphericity = 1.0;
-  const bool use_equiangular_map = true;
-  const bool use_half_wedges = false;
-  const double aspect_ratio = 6.0;
-  const size_t index_polar_axis = 0;
-  const double x_coord_of_shell_center = 2.7;
-  test_wedge_map_generation_against_domain_helpers(
-      inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
-      aspect_ratio, index_polar_axis);
-}
-
-void test_six_wedge_directions_compressed_translated_equidistant() {
-  INFO("Six wedge directions compressed translated equidistant");
-  const double inner_radius = 9.6;
-  const double outer_radius = 29.2;
-  const double inner_sphericity = 0.0;
-  const double outer_sphericity = 1.0;
-  const bool use_equiangular_map = false;
-  const bool use_half_wedges = false;
-  const double aspect_ratio = 0.6;
-  const size_t index_polar_axis = 2;
-  const double x_coord_of_shell_center = 2.7;
-  test_wedge_map_generation_against_domain_helpers(
-      inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
-      aspect_ratio, index_polar_axis);
-}
-
-void test_ten_wedge_directions_compressed_translated_equiangular() {
-  INFO("Ten wedge directions compressed translated equiangular");
-  const double inner_radius = 0.2;
-  const double outer_radius = 2.2;
-  const double inner_sphericity = 0.0;
-  const double outer_sphericity = 1.0;
-  const bool use_equiangular_map = true;
-  const bool use_half_wedges = true;
-  const double aspect_ratio = 0.6;
-  const size_t index_polar_axis = 1;
-  const double x_coord_of_shell_center = 2.7;
-  test_wedge_map_generation_against_domain_helpers(
-      inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
-      aspect_ratio, index_polar_axis);
-}
-
-void test_ten_wedge_directions_compressed_translated_equidistant() {
-  INFO("Ten wedge directions compressed translated equidistant");
-  const double inner_radius = 0.2;
-  const double outer_radius = 29.2;
-  const double inner_sphericity = 0.01;
-  const double outer_sphericity = 0.99;
-  const bool use_equiangular_map = false;
-  const bool use_half_wedges = true;
-  const double aspect_ratio = 0.6;
-  const size_t index_polar_axis = 0;
-  const double x_coord_of_shell_center = 2.7;
-  test_wedge_map_generation_against_domain_helpers(
-      inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
-      aspect_ratio, index_polar_axis);
+      use_equiangular_map, use_half_wedges);
 }
 
 void test_wedge_map_generation() {
-  test_default_six_wedge_directions_equiangular();
-  test_default_six_wedge_directions_equidistant();
-  test_translated_six_wedge_directions_equiangular();
-  test_translated_six_wedge_directions_equidistant();
+  test_six_wedge_directions_equiangular();
+  test_six_wedge_directions_equidistant();
   test_ten_wedge_directions_equiangular();
   test_ten_wedge_directions_equidistant();
-  test_six_wedge_directions_compressed_equiangular();
-  test_six_wedge_directions_compressed_equidistant();
-  test_six_wedge_directions_compressed_translated_equiangular();
-  test_six_wedge_directions_compressed_translated_equidistant();
-  test_ten_wedge_directions_compressed_translated_equiangular();
-  test_ten_wedge_directions_compressed_translated_equidistant();
 }
 
 void test_all_frustum_directions() {


### PR DESCRIPTION
## Proposed changes

Preparation to use the `Shape` map in domain creators.

The type erasure done in `sph_wedge_coordinate_maps` meant that it was hard to compose different maps based on input file options. I think it's a lot cleaner to return a `std::vector<Wedge>` and have the domain creators add things like a translation map. It not only gets rid of a lot of code and (I think unnecessary) tests, but also makes the composition of maps in the domain creator easier to understand IMO.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
