### PR TITLE
Fix docs of KerrHorizonConforming map, disambiguate spin, add test

### DIFF
--- a/src/Domain/CoordinateMaps/KerrHorizonConforming.cpp
+++ b/src/Domain/CoordinateMaps/KerrHorizonConforming.cpp
@@ -20,7 +20,7 @@ namespace domain::CoordinateMaps {
 
 KerrHorizonConforming::KerrHorizonConforming(
     const double mass, const std::array<double, 3> dimensionless_spin)
-    : spin_(mass * dimensionless_spin),
+    : spin_parameter_(mass * dimensionless_spin),
       spin_mag_sq_(square(mass) * dot(dimensionless_spin, dimensionless_spin)) {
   ASSERT(magnitude(dimensionless_spin) < 1.,
          "Dimensionless spin magnitude must be < 1. Given dimensionless spin: "
@@ -47,7 +47,7 @@ std::optional<std::array<double, 3>> KerrHorizonConforming::inverse(
     const std::array<double, 3>& target_coords) const {
   const auto coords_mag_sq = dot(target_coords, target_coords);
   const auto coords_sq_min_spin_sq = coords_mag_sq - spin_mag_sq_;
-  const auto coords_dot_spin = dot(target_coords, spin_);
+  const auto coords_dot_spin = dot(target_coords, spin_parameter_);
   const auto fac = (coords_sq_min_spin_sq +
                     sqrt(coords_sq_min_spin_sq * coords_sq_min_spin_sq +
                          4. * square(coords_dot_spin))) /
@@ -83,14 +83,14 @@ KerrHorizonConforming::jacobian(const std::array<T, 3>& source_coords) const {
 
   stretch_factor_square(make_not_null(&fac), source_coords);
   source_coords_sq = dot(source_coords, source_coords);
-  coords_dot_spin = dot(source_coords, spin_);
+  coords_dot_spin = dot(source_coords, spin_parameter_);
   subexpr_1 = 4. * source_coords_sq * (1. - fac);
   subexpr_2 = 2. * fac * coords_dot_spin;
 
   for (size_t i = 0; i < 3; ++i) {
     gsl::at(dfac_dx, i) = subexpr_1 * gsl::at(source_coords, i) +
                           2. * spin_mag_sq_ * gsl::at(source_coords, i) -
-                          subexpr_2 * gsl::at(spin_, i);
+                          subexpr_2 * gsl::at(spin_parameter_, i);
   }
   dfac_dx = dfac_dx / (square(source_coords_sq) + square(coords_dot_spin));
 
@@ -135,15 +135,16 @@ KerrHorizonConforming::inv_jacobian(
 
   mapped_mag_sq = dot(mapped, mapped);
   mapped_mag = sqrt(mapped_mag_sq);
-  mapped_dot_spin = dot(mapped, spin_);
+  mapped_dot_spin = dot(mapped, spin_parameter_);
   mapped_sq_min_spin_sq = mapped_mag_sq - spin_mag_sq_;
   r = sqrt(0.5 * (mapped_sq_min_spin_sq + sqrt(square(mapped_sq_min_spin_sq) +
                                                4 * square(mapped_dot_spin))));
   fac = 1. / (2. * cube(r) - mapped_sq_min_spin_sq * r);
 
   for (size_t i = 0; i < 3; ++i) {
-    gsl::at(dr_dx, i) =
-        (square(r) * mapped.at(i) + mapped_dot_spin * gsl::at(spin_, i)) * fac;
+    gsl::at(dr_dx, i) = (square(r) * mapped.at(i) +
+                         mapped_dot_spin * gsl::at(spin_parameter_, i)) *
+                        fac;
   }
 
   // normalized from this point
@@ -166,19 +167,19 @@ void KerrHorizonConforming::stretch_factor_square(
     const std::array<T, 3>& source_coords) const {
   auto& source_coords_sq = *result;
   source_coords_sq = dot(source_coords, source_coords);
-  *result =
-      source_coords_sq * (source_coords_sq + spin_mag_sq_) /
-      (source_coords_sq * source_coords_sq + square(dot(source_coords, spin_)));
+  *result = source_coords_sq * (source_coords_sq + spin_mag_sq_) /
+            (source_coords_sq * source_coords_sq +
+             square(dot(source_coords, spin_parameter_)));
 }
 
 void KerrHorizonConforming::pup(PUP::er& p) {
-  p | spin_;
+  p | spin_parameter_;
   p | spin_mag_sq_;
 }
 
 bool operator==(const KerrHorizonConforming& lhs,
                 const KerrHorizonConforming& rhs) {
-  return lhs.spin_ == rhs.spin_;
+  return lhs.spin_parameter_ == rhs.spin_parameter_;
 }
 
 bool operator!=(const KerrHorizonConforming& lhs,

--- a/src/Domain/CoordinateMaps/KerrHorizonConforming.cpp
+++ b/src/Domain/CoordinateMaps/KerrHorizonConforming.cpp
@@ -10,6 +10,7 @@
 #include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
@@ -17,8 +18,16 @@
 
 namespace domain::CoordinateMaps {
 
-KerrHorizonConforming::KerrHorizonConforming(std::array<double, 3> spin)
-    : spin_(spin), spin_mag_sq_(dot(spin, spin)) {}
+KerrHorizonConforming::KerrHorizonConforming(
+    const double mass, const std::array<double, 3> dimensionless_spin)
+    : spin_(mass * dimensionless_spin),
+      spin_mag_sq_(square(mass) * dot(dimensionless_spin, dimensionless_spin)) {
+  ASSERT(magnitude(dimensionless_spin) < 1.,
+         "Dimensionless spin magnitude must be < 1. Given dimensionless spin: "
+             << dimensionless_spin << " with magnitude "
+             << magnitude(dimensionless_spin));
+  ASSERT(mass > 0., "Mass must be positive. Given mass: " << mass);
+}
 
 template <typename T>
 std::array<tt::remove_cvref_wrap_t<T>, 3> KerrHorizonConforming::operator()(

--- a/src/Domain/CoordinateMaps/KerrHorizonConforming.hpp
+++ b/src/Domain/CoordinateMaps/KerrHorizonConforming.hpp
@@ -15,7 +15,7 @@ namespace domain::CoordinateMaps {
 
 /*!
  * \brief Distorts cartesian coordinates \f$x^i\f$ such that a coordinate sphere
- * \f$\delta_{ij}x^ix^j=C\f$ is mapped to an ellipsoid of constant
+ * \f$\delta_{ij}x^ix^j=C^2\f$ is mapped to an ellipsoid of constant
  * Kerr-Schild radius \f$r=C\f$.
  *
  * The Kerr-Schild radius \f$r\f$ is defined as the largest positive
@@ -68,10 +68,21 @@ class KerrHorizonConforming {
   KerrHorizonConforming() = default;
   static constexpr size_t dim = 3;
   /*!
-   * constructs a Kerr horizon conforming map.
-   * \param spin : the dimensionless spin
+   * \brief Constructs a Kerr horizon conforming map.
+   *
+   * \param mass The Kerr mass parameter $M$
+   * \param dimensionless_spin The dimensionless spin $\vec{\chi} = \vec{a} / M
+   * = \vec{S} / M^2$, where $M$ is the Kerr mass parameter, $\vec{S}$ is the
+   * angular momentum or quasilocal spin, and $\vec{a}$ is the Kerr spin
+   * parameter.
+   *
+   * \note The horizon depends only on the dimensionful spin parameter $\vec{a}
+   * = M \vec{\chi}$. This constructor takes $M$ and $\vec{\chi}$ separately for
+   * consistency with other code such as gr::Solutions::KerrSchild, and hence to
+   * avoid bugs where the wrong spin quantity is used accidentally.
    */
-  explicit KerrHorizonConforming(std::array<double, 3> spin);
+  explicit KerrHorizonConforming(const double mass,
+                                 std::array<double, 3> dimensionless_spin);
 
   template <typename T>
   std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(

--- a/src/Domain/CoordinateMaps/KerrHorizonConforming.hpp
+++ b/src/Domain/CoordinateMaps/KerrHorizonConforming.hpp
@@ -100,7 +100,7 @@ class KerrHorizonConforming {
       const std::array<T, 3>& source_coords) const;
 
   bool is_identity() const {
-    return spin_ == std::array<double, 3>{0., 0., 0.};
+    return spin_parameter_ == std::array<double, 3>{0., 0., 0.};
   }
 
   friend bool operator==(const KerrHorizonConforming& lhs,
@@ -114,7 +114,7 @@ class KerrHorizonConforming {
       const gsl::not_null<tt::remove_cvref_wrap_t<T>*> result,
       const std::array<T, 3>& source_coords) const;
 
-  std::array<double, 3> spin_;
+  std::array<double, 3> spin_parameter_;
   double spin_mag_sq_;
 };
 bool operator!=(const KerrHorizonConforming& lhs,

--- a/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
@@ -33,7 +33,23 @@ add_test_library(
   ${LIBRARY}
   "Domain/CoordinateMaps"
   "${LIBRARY_SOURCES}"
-  "CoordinateMaps;FunctionsOfTime"
+  ""
   )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  CoordinateMaps
+  DataStructures
+  DataStructuresHelpers
+  Domain
+  DomainStructure
+  ErrorHandling
+  FunctionsOfTime
+  GeneralRelativitySolutions
+  RootFinding
+  Spectral
+  Utilities
+)
 
 add_subdirectory(TimeDependent)

--- a/tests/Unit/Domain/CoordinateMaps/Test_KerrHorizonConforming.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_KerrHorizonConforming.cpp
@@ -9,19 +9,30 @@
 #include <random>
 
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/KerrHorizonConforming.hpp"
+#include "Domain/CoordinateMaps/Wedge.hpp"
+#include "Domain/LogicalCoordinates.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
 
 namespace {
 
 void test_map_helpers(const gsl::not_null<std::mt19937*> generator) {
+  std::uniform_real_distribution mass_dist{0.5, 2.};
+  const double mass = mass_dist(*generator);
   std::uniform_real_distribution spin_dist{-1. / sqrt(3), 1. / sqrt(3)};
   const auto spin =
       make_with_random_values<std::array<double, 3>>(generator, spin_dist, 3);
-  const domain::CoordinateMaps::KerrHorizonConforming map(spin);
+  const domain::CoordinateMaps::KerrHorizonConforming map(mass, spin);
   std::uniform_real_distribution point_dist{-10., 10.};
   const auto random_point =
       make_with_random_values<std::array<double, 3>>(generator, point_dist, 3);
@@ -33,16 +44,20 @@ void test_map_helpers(const gsl::not_null<std::mt19937*> generator) {
 }
 
 void test_no_spin(const gsl::not_null<std::mt19937*> generator) {
+  std::uniform_real_distribution mass_dist{0.5, 2.};
+  const double mass = mass_dist(*generator);
   const std::array<double, 3> spin{0., 0., 0.};
   std::uniform_real_distribution dist{-10., 10.};
   const auto coords =
       make_with_random_values<std::array<double, 3>>(generator, dist, 3);
-  const auto map = domain::CoordinateMaps::KerrHorizonConforming(spin);
+  const auto map = domain::CoordinateMaps::KerrHorizonConforming(mass, spin);
   const auto res = map(coords);
   CHECK_ITERABLE_APPROX(coords, res);
 }
 
 void test_random_spin(const gsl::not_null<std::mt19937*> generator) {
+  std::uniform_real_distribution mass_dist{0.5, 2.};
+  const double mass = mass_dist(*generator);
   std::uniform_real_distribution spin_dist{-1. / sqrt(3), 1. / sqrt(3)};
   const auto spin =
       make_with_random_values<std::array<double, 3>>(generator, spin_dist, 3);
@@ -53,21 +68,63 @@ void test_random_spin(const gsl::not_null<std::mt19937*> generator) {
       generator, point_dist, number_of_points);
   coords = coords / magnitude(coords);
 
-  const auto map = domain::CoordinateMaps::KerrHorizonConforming(spin);
+  const auto map = domain::CoordinateMaps::KerrHorizonConforming(mass, spin);
   const auto mapped_coords = map(coords);
 
   const DataVector coords_sq_min_spin_sq =
-      dot(mapped_coords, mapped_coords) - dot(spin, spin);
+      dot(mapped_coords, mapped_coords) - square(mass) * dot(spin, spin);
 
   // explicit expression for Kerr-Schild radius r
   DataVector r = coords_sq_min_spin_sq +
                  sqrt(coords_sq_min_spin_sq * coords_sq_min_spin_sq +
-                      4 * dot(mapped_coords, spin) * dot(mapped_coords, spin));
+                      4 * square(mass * dot(mapped_coords, spin)));
   r = sqrt(r / 2.);
 
   for (const auto& val : r) {
     CHECK(val == approx(1.));
   }
+}
+
+void test_with_kerr_horizon(const double mass,
+                            const std::array<double, 3>& dimensionless_spin) {
+  CAPTURE(mass);
+  CAPTURE(dimensionless_spin);
+
+  // This is r_+
+  const double horizon_kerrschild_radius =
+      mass * (1. + sqrt(1. - dot(dimensionless_spin, dimensionless_spin)));
+  CAPTURE(horizon_kerrschild_radius);
+
+  // Set up a wedge with a Kerr-horizon-conforming inner surface.
+  // The inner radius of r_+ will be mapped to an ellipsoid with constant
+  // Boyer-Lindquist radius r_+.
+  const domain::CoordinateMaps::Wedge<3> wedge_map{
+      horizon_kerrschild_radius,
+      2. * horizon_kerrschild_radius,
+      1.,
+      1.,
+      {},
+      false};
+  const domain::CoordinateMaps::KerrHorizonConforming horizon_map{
+      mass, dimensionless_spin};
+  const auto coord_map =
+      domain::make_coordinate_map_base<Frame::ElementLogical, Frame::Inertial>(
+          wedge_map, horizon_map);
+
+  // Get some coordinates on the inner face
+  const Mesh<2> face_mesh{12, Spectral::Basis::Legendre,
+                          Spectral::Quadrature::GaussLobatto};
+  const auto logical_coords =
+      interface_logical_coordinates(face_mesh, Direction<3>::lower_zeta());
+  const tnsr::I<DataVector, 3> x = (*coord_map)(logical_coords);
+
+  // Check the coordinates on the inner face are on a Kerr horizon
+  const std::array<DataVector, 2> theta_phi{
+      {atan2(sqrt(square(get<0>(x)) + square(get<1>(x))), get<2>(x)),
+       atan2(get<1>(x), get<0>(x))}};
+  const DataVector expected_horizon_radii = get(
+      gr::Solutions::kerr_horizon_radius(theta_phi, mass, dimensionless_spin));
+  CHECK_ITERABLE_APPROX(get(magnitude(x)), expected_horizon_radii);
 }
 
 }  // namespace
@@ -78,4 +135,5 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.KerrHorizonConforming",
   test_map_helpers(make_not_null(&generator));
   test_no_spin(make_not_null(&generator));
   test_random_spin(make_not_null(&generator));
+  test_with_kerr_horizon(0.45, {{0., 0.2, 0.8}});
 }

--- a/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(
   Domain
   DomainStructure
   Elliptic
+  GeneralRelativitySolutions
   Utilities
   XctsBoundaryConditions
   XctsSolutions

--- a/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/Test_ApparentHorizon.cpp
+++ b/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/Test_ApparentHorizon.cpp
@@ -35,6 +35,7 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.hpp"
 #include "Utilities/TMPL.hpp"
@@ -380,7 +381,7 @@ void test_with_random_values() {
 void test_consistency_with_kerr(const bool compute_expansion) {
   INFO("Consistency with Kerr solution");
   CAPTURE(compute_expansion);
-  const double mass = 1.;
+  const double mass = 0.45;
   const std::array<double, 3> center{{0., 0., 0.}};
   const std::array<double, 3> dimensionless_spin{{0., 0., 0.8}};
   const double horizon_kerrschild_radius =
@@ -433,6 +434,15 @@ void test_consistency_with_kerr(const bool compute_expansion) {
   const size_t slice_index = index_to_slice_at(mesh.extents(), direction);
   const auto x = data_on_slice(inertial_coords, mesh.extents(),
                                direction.dimension(), slice_index);
+
+  // Make sure the face is indeed horizon conforming
+  const std::array<DataVector, 2> theta_phi{
+      {atan2(sqrt(square(get<0>(x)) + square(get<1>(x))), get<2>(x)),
+       atan2(get<1>(x), get<0>(x))}};
+  const DataVector expected_horizon_radii = get(
+      gr::Solutions::kerr_horizon_radius(theta_phi, mass, dimensionless_spin));
+  CHECK_ITERABLE_APPROX(get(magnitude(x)), expected_horizon_radii);
+
   // Get background fields from the solution
   const auto background_fields = solution.variables(
       x,

--- a/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/Test_ApparentHorizon.cpp
+++ b/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/Test_ApparentHorizon.cpp
@@ -411,7 +411,7 @@ void test_consistency_with_kerr(const bool compute_expansion) {
       {},
       false};
   const domain::CoordinateMaps::KerrHorizonConforming horizon_map{
-      dimensionless_spin};
+      mass, dimensionless_spin};
   const auto coord_map =
       domain::make_coordinate_map_base<Frame::ElementLogical, Frame::Inertial>(
           wedge_map, horizon_map);


### PR DESCRIPTION
## Proposed changes

The expected spin parameter is not dimensionless. Add test to make sure the mapped surface is indeed a Kerr horizon for non-unit mass.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
