### PR TITLE
Allow monopole and dipole in shape map

### DIFF
--- a/src/Domain/CoordinateMaps/TimeDependent/Shape.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Shape.cpp
@@ -166,7 +166,7 @@ tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> Shape::jacobian(
   // cartesian gradient.
   SpherepackIterator extended_iter(l_max_ + 1, m_max_ + 1);
   SpherepackIterator iter(l_max_, m_max_);
-  for (size_t l = 2; l <= l_max_; ++l) {
+  for (size_t l = 0; l <= l_max_; ++l) {
     const int m_max = std::min(l, m_max_);
     for (int m = -m_max; m <= m_max; ++m) {
       iter.set(l, m);
@@ -300,18 +300,6 @@ void Shape::check_coefficients([[maybe_unused]] const DataVector& coefs) const {
          "Spectral coefficients are expected to be in YlmSpherepack format "
          "with size 2 * (l_max + 1) * (m_max + 1) = "
              << ylm_.spectral_size() << ", but have size " << coefs.size());
-
-  SpherepackIterator iter(l_max_, m_max_);
-  const std::vector<std::pair<size_t, int>> mono_and_dipole{
-      {0, 0}, {1, 0}, {1, -1}, {1, 1}};
-  for (const auto& [l, m] : mono_and_dipole) {
-    iter.set(l, m);
-    ASSERT(
-        coefs[iter()] == 0.,
-        "The shape map expects the values of the mono- and dipole (l = 0, 1) "
-        "to be zero, but the coefficients for l = "
-            << l << ", m = " << m << " have value " << coefs[iter()]);
-  }
 #endif  // SPECTRE_DEBUG
 }
 

--- a/src/Domain/CoordinateMaps/TimeDependent/Shape.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Shape.hpp
@@ -41,11 +41,8 @@ namespace domain::CoordinateMaps::TimeDependent {
  * applying a spherical harmonic expansion with time-dependent coefficients
  * \f$\lambda_{lm}(t)\f$. An additional domain-dependent transition function
  * \f$f(r, \theta, \phi)\f$ ensures that the distortion falls off correctly to
- * zero at the boundary of the domain. The monopole and dipole coefficients \f$
- * \lambda_{00}, \lambda_{10}, \lambda_{11}\f$ are expected to be zero since
- * these degrees of freedoms are controlled by the `SphericalCompression` and
- * `Translation` map, respectively. The shape map maps the unmapped coordinates
- * \f$\xi^i\f$ to coordinates \f$x^i\f$:
+ * zero at the boundary of the domain. The shape map maps the unmapped
+ * coordinates \f$\xi^i\f$ to coordinates \f$x^i\f$:
  *
  * \f{equation}{
  * x^i = \xi^i - (\xi^i - x_c^i) f(r, \theta, \phi) \sum_{lm}

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_Shape.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_Shape.cpp
@@ -166,10 +166,6 @@ std::vector<std::vector<std::complex<double>>> generate_random_coefs(
     coefs.emplace_back(tmp);
   }
 
-  // set monopole and dipole to zero
-  coefs.at(0).at(0) = 0.;
-  coefs.at(1).at(0) = 0.;
-  coefs.at(1).at(1) = 0.;
   return coefs;
 }
 


### PR DESCRIPTION
## Proposed changes

These were asserted to be zero before, but the map works just as well if these modes are nonzero. This allows to use the shape map to reshape a coordinate sphere to a Kerr horizon without using an additional SphericalCompression map
just for the monopole. If the zero-ness of the monopole and dipole are diagnostics for the control system, then they should be checked by the control system instead of imposing this artificial constraint.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
