### PR TITLE
Compute numerical deriv diagnostic in ExportCoords

### DIFF
--- a/src/Executables/ExportCoordinates/CMakeLists.txt
+++ b/src/Executables/ExportCoordinates/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBS_TO_LINK
   Evolution
   Informer
   IO
+  LinearOperators
   Options
   Parallel
   Time

--- a/tests/InputFiles/ExportCoordinates/Input1D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input1D.yaml
@@ -31,7 +31,7 @@ EventsAndTriggers:
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.01
+  InitialTimeStep: 0.1
   TimeStepper:
     AdamsBashforthN:
       Order: 1

--- a/tests/InputFiles/ExportCoordinates/Input2D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input2D.yaml
@@ -31,7 +31,7 @@ EventsAndTriggers:
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.01
+  InitialTimeStep: 0.1
   TimeStepper:
     AdamsBashforthN:
       Order: 1

--- a/tests/InputFiles/ExportCoordinates/Input3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input3D.yaml
@@ -25,7 +25,7 @@ SpatialDiscretization:
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.01
+  InitialTimeStep: 0.1
   TimeStepper:
     AdamsBashforthN:
       Order: 1

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -63,7 +63,7 @@ SpatialDiscretization:
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.01
+  InitialTimeStep: 0.5
   TimeStepper:
     AdamsBashforthN:
       Order: 1
@@ -71,7 +71,7 @@ Evolution:
 EventsAndTriggers:
   ? TimeCompares:
       Comparison: GreaterThanOrEqualTo
-      Value: 0.08
+      Value: 1.0
   : - Completion
 
 Observers:


### PR DESCRIPTION
## Proposed changes

Outputs \partial_i x^j in ExportCoordinates as a diagnostic of grid resolution

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
