### PR TITLE
Add subcell boundary condition to NewtonianEuler

### DIFF
--- a/src/Evolution/DgSubcell/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/CMakeLists.txt
@@ -26,6 +26,7 @@ spectre_target_headers(
   ReconstructionMethod.hpp
   SliceData.hpp
   SliceTensor.hpp
+  SliceVariable.hpp
   SubcellOptions.hpp
   TciStatus.hpp
   TwoMeshRdmpTci.hpp

--- a/src/Evolution/DgSubcell/SliceVariable.hpp
+++ b/src/Evolution/DgSubcell/SliceVariable.hpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <vector>
 
 #include "DataStructures/Index.hpp"
 #include "DataStructures/Variables.hpp"
@@ -18,13 +19,9 @@ namespace evolution::dg::subcell {
 /*!
  * \brief Slice a Variables object on subcell mesh for a given direction and
  * slicing depth (number of ghost points).
- *
- * This is essentially a wrapper of
- * `evolution::dg::subcell::detail::slice_data_impl` function, but note that the
- * last argument has the type `Direction<Dim>`, not a DirectionMap.
  */
 template <size_t Dim, typename TagList>
-void slice_variable_for_subcell(
+void slice_variable(
     const gsl::not_null<Variables<TagList>*>& sliced_subcell_vars,
     const Variables<TagList>& volume_subcell_vars,
     const Index<Dim>& subcell_extents, const size_t ghost_zone_size,
@@ -34,15 +31,15 @@ void slice_variable_for_subcell(
       subcell_extents.slice_away(direction.dimension()).product() *
       ghost_zone_size;
   if (sliced_subcell_vars->size() != num_sliced_pts) {
-    *sliced_subcell_vars = Variables<TagList>(num_sliced_pts);
+    sliced_subcell_vars->initialize(num_sliced_pts);
   }
 
-  // Slice volume variables. Note that the return type of slicing function is
-  // std::vector<double>.
+  // Slice volume variables. Note that the return type of the
+  // `slice_data_impl()` function is std::vector<double>.
   DirectionMap<Dim, bool> directions_to_slice{};
   directions_to_slice[direction] = true;
 
-  std::vector<double> sliced_data{detail::slice_data_impl(
+  const std::vector<double> sliced_data{detail::slice_data_impl(
       gsl::make_span(volume_subcell_vars.data(), volume_subcell_vars.size()),
       subcell_extents, ghost_zone_size, directions_to_slice)[direction]};
 
@@ -56,13 +53,11 @@ Variables<TagList> slice_variable(const Variables<TagList>& volume_subcell_vars,
                                   const Index<Dim>& subcell_extents,
                                   const size_t ghost_zone_size,
                                   const Direction<Dim>& direction) {
-  Variables<TagList> sliced_subcell_vars{};
-  sliced_subcell_vars.initialize(
+  Variables<TagList> sliced_subcell_vars{
       subcell_extents.slice_away(direction.dimension()).product() *
-      ghost_zone_size);
-  slice_variable_for_subcell(make_not_null(&sliced_subcell_vars),
-                             volume_subcell_vars, subcell_extents,
-                             ghost_zone_size, direction);
+      ghost_zone_size};
+  slice_variable(make_not_null(&sliced_subcell_vars), volume_subcell_vars,
+                 subcell_extents, ghost_zone_size, direction);
   return sliced_subcell_vars;
 }
 /// @}

--- a/src/Evolution/DgSubcell/SliceVariable.hpp
+++ b/src/Evolution/DgSubcell/SliceVariable.hpp
@@ -1,0 +1,69 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Evolution/DgSubcell/SliceData.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace evolution::dg::subcell {
+/// @{
+/*!
+ * \brief Slice a Variables object on subcell mesh for a given direction and
+ * slicing depth (number of ghost points).
+ *
+ * This is essentially a wrapper of
+ * `evolution::dg::subcell::detail::slice_data_impl` function, but note that the
+ * last argument has the type `Direction<Dim>`, not a DirectionMap.
+ */
+template <size_t Dim, typename TagList>
+void slice_variable_for_subcell(
+    const gsl::not_null<Variables<TagList>*>& sliced_subcell_vars,
+    const Variables<TagList>& volume_subcell_vars,
+    const Index<Dim>& subcell_extents, const size_t ghost_zone_size,
+    const Direction<Dim>& direction) {
+  // check the size of sliced_subcell_vars (output)
+  const size_t num_sliced_pts =
+      subcell_extents.slice_away(direction.dimension()).product() *
+      ghost_zone_size;
+  if (sliced_subcell_vars->size() != num_sliced_pts) {
+    *sliced_subcell_vars = Variables<TagList>(num_sliced_pts);
+  }
+
+  // Slice volume variables. Note that the return type of slicing function is
+  // std::vector<double>.
+  DirectionMap<Dim, bool> directions_to_slice{};
+  directions_to_slice[direction] = true;
+
+  std::vector<double> sliced_data{detail::slice_data_impl(
+      gsl::make_span(volume_subcell_vars.data(), volume_subcell_vars.size()),
+      subcell_extents, ghost_zone_size, directions_to_slice)[direction]};
+
+  // copy the returned std::vector<double> data into sliced variables
+  std::copy(sliced_data.begin(), sliced_data.end(),
+            sliced_subcell_vars->data());
+}
+
+template <size_t Dim, typename TagList>
+Variables<TagList> slice_variable(const Variables<TagList>& volume_subcell_vars,
+                                  const Index<Dim>& subcell_extents,
+                                  const size_t ghost_zone_size,
+                                  const Direction<Dim>& direction) {
+  Variables<TagList> sliced_subcell_vars{};
+  sliced_subcell_vars.initialize(
+      subcell_extents.slice_away(direction.dimension()).product() *
+      ghost_zone_size);
+  slice_variable_for_subcell(make_not_null(&sliced_subcell_vars),
+                             volume_subcell_vars, subcell_extents,
+                             ghost_zone_size, direction);
+  return sliced_subcell_vars;
+}
+/// @}
+}  // namespace evolution::dg::subcell

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -319,7 +319,7 @@ struct EvolutionMetavars {
 
   struct SubcellOptions {
     static constexpr bool subcell_enabled = use_dg_subcell;
-    static constexpr bool subcell_enabled_at_external_boundary = false;
+    static constexpr bool subcell_enabled_at_external_boundary = true;
 
     // We send `ghost_zone_size` cell-centered grid points for variable
     // reconstruction, of which we need `ghost_zone_size-1` for reconstruction

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/CMakeLists.txt
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/CMakeLists.txt
@@ -6,6 +6,7 @@ spectre_target_sources(
   PRIVATE
   BoundaryCondition.cpp
   DirichletAnalytic.cpp
+  Outflow.cpp
   Reflection.cpp
   )
 
@@ -16,5 +17,6 @@ spectre_target_headers(
   BoundaryCondition.hpp
   DirichletAnalytic.hpp
   Factory.hpp
+  Outflow.hpp
   Reflection.hpp
   )

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/Factory.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/Factory.hpp
@@ -8,6 +8,7 @@
 #include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Evolution/Systems/NewtonianEuler/BoundaryConditions/BoundaryCondition.hpp"
 #include "Evolution/Systems/NewtonianEuler/BoundaryConditions/DirichletAnalytic.hpp"
+#include "Evolution/Systems/NewtonianEuler/BoundaryConditions/Outflow.hpp"
 #include "Evolution/Systems/NewtonianEuler/BoundaryConditions/Reflection.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -16,5 +17,5 @@ namespace NewtonianEuler::BoundaryConditions {
 template <size_t Dim>
 using standard_boundary_conditions =
     tmpl::list<domain::BoundaryConditions::Periodic<BoundaryCondition<Dim>>,
-               DirichletAnalytic<Dim>, Reflection<Dim>>;
+               DirichletAnalytic<Dim>, Outflow<Dim>, Reflection<Dim>>;
 }  // namespace NewtonianEuler::BoundaryConditions

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/Outflow.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/Outflow.cpp
@@ -10,13 +10,19 @@
 #include <string>
 
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/SliceVariables.hpp"
 #include "DataStructures/Tags/TempTensor.hpp"
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Evolution/DgSubcell/SliceTensor.hpp"
+#include "Evolution/Systems/NewtonianEuler/FiniteDifference/Reconstructor.hpp"
 #include "Evolution/Systems/NewtonianEuler/SoundSpeedSquared.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeString.hpp"
@@ -90,6 +96,119 @@ std::optional<std::string> Outflow<Dim>::dg_outflow(
   }
 
   return std::nullopt;
+}
+
+template <size_t Dim>
+template <size_t ThermodynamicDim>
+void Outflow<Dim>::fd_outflow(
+    const gsl::not_null<Scalar<DataVector>*> mass_density,
+    const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> velocity,
+    const gsl::not_null<Scalar<DataVector>*> pressure,
+    const Direction<Dim>& direction,
+
+    const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+        face_mesh_velocity,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>&
+        outward_directed_normal_covector,
+
+    const Mesh<Dim>& subcell_mesh,
+    const Scalar<DataVector>& interior_mass_density,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& interior_velocity,
+    const Scalar<DataVector>& interior_pressure,
+    const Scalar<DataVector>& interior_specific_internal_energy,
+
+    const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
+        equation_of_state,
+    const fd::Reconstructor<Dim>& reconstructor) {
+  double min_char_speed = std::numeric_limits<double>::signaling_NaN();
+
+  const size_t ghost_zone_size{reconstructor.ghost_zone_size()};
+  const size_t dim_direction{direction.dimension()};
+
+  const auto subcell_extents{subcell_mesh.extents()};
+  const size_t num_face_pts{
+      subcell_extents.slice_away(dim_direction).product()};
+
+  // The outflow condition here simply uses the outermost values on
+  // cell-centered FD grid points to compute face values on the external
+  // boundary. This is equivalent to adopting the piecewise constant FD
+  // reconstruction for FD cells at the external boundaries.
+  //
+  // In the future we may want to use more accurate methods (for instance,
+  // one-sided characteristic reconstruction using WENO) for imposing
+  // higher-order outflow boundary condition.
+  //
+  auto get_boundary_val = [&direction, &subcell_extents](auto volume_tensor) {
+    return evolution::dg::subcell::slice_tensor_for_subcell(
+        volume_tensor, subcell_extents, 1, direction);
+  };
+  auto boundary_mass_density = get_boundary_val(interior_mass_density);
+  auto boundary_velocity = get_boundary_val(interior_velocity);
+  auto boundary_specific_internal_energy =
+      get_boundary_val(interior_specific_internal_energy);
+
+  // compute sound speed on the boundary interface
+  auto boundary_sound_speed =
+      sound_speed_squared(boundary_mass_density,
+                          boundary_specific_internal_energy, equation_of_state);
+  get(boundary_sound_speed) = sqrt(get(boundary_sound_speed));
+
+  Variables<tmpl::list<::Tags::TempScalar<0>, ::Tags::TempScalar<1>>> buffer{};
+  buffer.initialize(num_face_pts);
+
+  auto& normal_dot_velocity = get<::Tags::TempScalar<0>>(buffer);
+  dot_product(make_not_null(&normal_dot_velocity),
+              outward_directed_normal_covector, boundary_velocity);
+
+  // Compute the largest ingoing char speed
+  if (face_mesh_velocity.has_value()) {
+    auto& normal_dot_mesh_velocity = get<::Tags::TempScalar<1>>(buffer);
+    dot_product(make_not_null(&normal_dot_mesh_velocity),
+                outward_directed_normal_covector, face_mesh_velocity.value());
+
+    min_char_speed = min(get(normal_dot_velocity) - get(boundary_sound_speed) -
+                         get(normal_dot_mesh_velocity));
+  } else {
+    min_char_speed = min(get(normal_dot_velocity) - get(boundary_sound_speed));
+  }
+
+  // Check the outflow condition
+  if (min_char_speed < 0.0) {
+    ERROR(
+        "Subcell outflow boundary condition violated with the characteristic "
+        "speed : "
+        << min_char_speed << "\n");
+  } else {
+    // Once the outflow condition has been checked, we fill each slices of the
+    // ghost data with the boundary values. The reason that we need this step is
+    // to prevent floating point exceptions being raised during computing
+    // subcell time derivative due to NaN or uninitialized values in ghost data.
+
+    using MassDensity = Tags::MassDensity<DataVector>;
+    using Velocity = Tags::Velocity<DataVector, Dim>;
+    using Pressure = Tags::Pressure<DataVector>;
+
+    Variables<tmpl::list<MassDensity, Velocity, Pressure>> boundary_vars{};
+    boundary_vars.initialize(num_face_pts);
+    get<MassDensity>(boundary_vars) = boundary_mass_density;
+    get<Velocity>(boundary_vars) = boundary_velocity;
+    get<Pressure>(boundary_vars) = get_boundary_val(interior_pressure);
+
+    Index<Dim> ghost_data_extents = subcell_extents;
+    ghost_data_extents[dim_direction] = ghost_zone_size;
+
+    Variables<tmpl::list<MassDensity, Velocity, Pressure>> ghost_vars{};
+    ghost_vars.initialize(num_face_pts * ghost_zone_size, 0.0);
+
+    for (size_t i_ghost = 0; i_ghost < ghost_zone_size; ++i_ghost) {
+      add_slice_to_data(make_not_null(&ghost_vars), boundary_vars,
+                        ghost_data_extents, dim_direction, i_ghost);
+    }
+
+    *mass_density = get<MassDensity>(ghost_vars);
+    *velocity = get<Velocity>(ghost_vars);
+    *pressure = get<Pressure>(ghost_vars);
+  }
 }  // namespace NewtonianEuler::BoundaryConditions
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
@@ -113,7 +232,26 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
       const tnsr::I<DataVector, DIM(data), Frame::Inertial>& velocity,      \
       const Scalar<DataVector>& specific_internal_energy,                   \
       const EquationsOfState::EquationOfState<false, THERMODIM(data)>&      \
-          equation_of_state);
+          equation_of_state);                                               \
+  template void Outflow<DIM(data)>::fd_outflow<THERMODIM(data)>(            \
+      const gsl::not_null<Scalar<DataVector>*> mass_density,                \
+      const gsl::not_null<tnsr::I<DataVector, DIM(data), Frame::Inertial>*> \
+          velocity,                                                         \
+      const gsl::not_null<Scalar<DataVector>*> pressure,                    \
+      const Direction<DIM(data)>& direction,                                \
+      const std::optional<tnsr::I<DataVector, DIM(data), Frame::Inertial>>& \
+          face_mesh_velocity,                                               \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                \
+          outward_directed_normal_covector,                                 \
+      const Mesh<DIM(data)>& subcell_mesh,                                  \
+      const Scalar<DataVector>& interior_mass_density,                      \
+      const tnsr::I<DataVector, DIM(data), Frame::Inertial>&                \
+          interior_velocity,                                                \
+      const Scalar<DataVector>& interior_pressure,                          \
+      const Scalar<DataVector>& interior_specific_internal_energy,          \
+      const EquationsOfState::EquationOfState<false, THERMODIM(data)>&      \
+          equation_of_state,                                                \
+      const fd::Reconstructor<DIM(data)>& reconstructor);
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2))
 

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/Outflow.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/Outflow.cpp
@@ -1,0 +1,125 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/NewtonianEuler/BoundaryConditions/Outflow.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <pup.h>
+#include <string>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/NewtonianEuler/SoundSpeedSquared.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace NewtonianEuler::BoundaryConditions {
+template <size_t Dim>
+Outflow<Dim>::Outflow(CkMigrateMessage* const msg)
+    : BoundaryCondition<Dim>(msg) {}
+
+template <size_t Dim>
+std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+Outflow<Dim>::get_clone() const {
+  return std::make_unique<Outflow>(*this);
+}
+
+template <size_t Dim>
+void Outflow<Dim>::pup(PUP::er& p) {
+  BoundaryCondition<Dim>::pup(p);
+}
+
+template <size_t Dim>
+// NOLINTNEXTLINE
+PUP::able::PUP_ID Outflow<Dim>::my_PUP_ID = 0;
+
+template <size_t Dim>
+template <size_t ThermodynamicDim>
+std::optional<std::string> Outflow<Dim>::dg_outflow(
+    const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+        face_mesh_velocity,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>&
+        outward_directed_normal_covector,
+
+    const Scalar<DataVector>& mass_density,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& velocity,
+    const Scalar<DataVector>& specific_internal_energy,
+    const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
+        equation_of_state) {
+  double min_char_speed = std::numeric_limits<double>::signaling_NaN();
+
+  // Temp buffer for sound speed, normal dot velocity, and (optional) normal
+  // dot mesh velocity
+  Variables<tmpl::list<::Tags::TempScalar<0>, ::Tags::TempScalar<1>,
+                       ::Tags::TempScalar<2>>>
+      buffer{get(mass_density).size()};
+
+  auto& sound_speed = get<::Tags::TempScalar<0>>(buffer);
+  sound_speed_squared(make_not_null(&sound_speed), mass_density,
+                      specific_internal_energy, equation_of_state);
+  get(sound_speed) = sqrt(get(sound_speed));
+
+  auto& normal_dot_velocity = get<::Tags::TempScalar<1>>(buffer);
+  dot_product(make_not_null(&normal_dot_velocity),
+              outward_directed_normal_covector, velocity);
+
+  if (face_mesh_velocity.has_value()) {
+    auto& normal_dot_mesh_velocity = get<::Tags::TempScalar<2>>(buffer);
+    dot_product(make_not_null(&normal_dot_mesh_velocity),
+                outward_directed_normal_covector, face_mesh_velocity.value());
+
+    min_char_speed = min(get(normal_dot_velocity) - get(sound_speed) -
+                         get(normal_dot_mesh_velocity));
+  } else {
+    min_char_speed = min(get(normal_dot_velocity) - get(sound_speed));
+  }
+
+  if (min_char_speed < 0.0) {
+    return {MakeString{} << "Outflow boundary condition violated with the "
+                            "characteristic speed : "
+                         << min_char_speed << "\n"};
+  }
+
+  return std::nullopt;
+}  // namespace NewtonianEuler::BoundaryConditions
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(_, data) template class Outflow<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+
+#define THERMODIM(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATION(_, data)                                              \
+  template std::optional<std::string>                                       \
+  Outflow<DIM(data)>::dg_outflow<THERMODIM(data)>(                          \
+      const std::optional<tnsr::I<DataVector, DIM(data), Frame::Inertial>>& \
+          face_mesh_velocity,                                               \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                \
+          outward_directed_normal_covector,                                 \
+      const Scalar<DataVector>& mass_density,                               \
+      const tnsr::I<DataVector, DIM(data), Frame::Inertial>& velocity,      \
+      const Scalar<DataVector>& specific_internal_energy,                   \
+      const EquationsOfState::EquationOfState<false, THERMODIM(data)>&      \
+          equation_of_state);
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2))
+
+#undef INSTANTIATION
+
+#undef THERMODIM
+
+#undef DIM
+}  // namespace NewtonianEuler::BoundaryConditions

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/Outflow.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/Outflow.hpp
@@ -1,0 +1,88 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <pup.h>
+#include <string>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/BoundaryConditions/Type.hpp"
+#include "Evolution/Systems/NewtonianEuler/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace EquationsOfState {
+template <bool IsRelativistic, size_t ThermodynamicDim>
+class EquationOfState;
+}  // namespace EquationsOfState
+namespace gsl {
+template <class T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace NewtonianEuler::BoundaryConditions {
+/*!
+ * \brief A boundary condition that only verifies that all characteristic speeds
+ * are directed out of the domain; no boundary data is altered by this boundary
+ * condition.
+ */
+template <size_t Dim>
+class Outflow final : public BoundaryCondition<Dim> {
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help{
+      "Outflow boundary condition that only verifies the characteristic speeds "
+      "are all directed out of the domain."};
+
+  Outflow() = default;
+  Outflow(Outflow&&) = default;
+  Outflow& operator=(Outflow&&) = default;
+  Outflow(const Outflow&) = default;
+  Outflow& operator=(const Outflow&) = default;
+  ~Outflow() override = default;
+
+  explicit Outflow(CkMigrateMessage* msg);
+
+  WRAPPED_PUPable_decl_base_template(
+      domain::BoundaryConditions::BoundaryCondition, Outflow);
+
+  auto get_clone() const -> std::unique_ptr<
+      domain::BoundaryConditions::BoundaryCondition> override;
+
+  static constexpr evolution::BoundaryConditions::Type bc_type =
+      evolution::BoundaryConditions::Type::Outflow;
+
+  void pup(PUP::er& p) override;
+
+  using dg_interior_evolved_variables_tags = tmpl::list<>;
+  using dg_interior_temporary_tags = tmpl::list<>;
+  using dg_interior_primitive_variables_tags = tmpl::list<
+      NewtonianEuler::Tags::MassDensity<DataVector>,
+      NewtonianEuler::Tags::Velocity<DataVector, Dim, Frame::Inertial>,
+      NewtonianEuler::Tags::SpecificInternalEnergy<DataVector>>;
+  using dg_gridless_tags = tmpl::list<hydro::Tags::EquationOfStateBase>;
+
+  template <size_t ThermodynamicDim>
+  static std::optional<std::string> dg_outflow(
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+          face_mesh_velocity,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>&
+          outward_directed_normal_covector,
+
+      const Scalar<DataVector>& mass_density,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& velocity,
+      const Scalar<DataVector>& specific_internal_energy,
+      const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
+          equation_of_state);
+};
+}  // namespace NewtonianEuler::BoundaryConditions

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/Reflection.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/Reflection.cpp
@@ -9,12 +9,10 @@
 #include <pup.h>
 #include <string>
 
-#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tags/TempTensor.hpp"
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
-#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Evolution/Systems/NewtonianEuler/ConservativeFromPrimitive.hpp"
 #include "Evolution/Systems/NewtonianEuler/Fluxes.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
@@ -59,12 +57,12 @@ std::optional<std::string> Reflection<Dim>::dg_ghost(
     const tnsr::i<DataVector, Dim, Frame::Inertial>&
         outward_directed_normal_covector,
 
-    const Scalar<DataVector>& interior_mass_desity,
+    const Scalar<DataVector>& interior_mass_density,
     const tnsr::I<DataVector, Dim, Frame::Inertial>& interior_velocity,
     const Scalar<DataVector>& interior_specific_internal_energy,
     const Scalar<DataVector>& interior_pressure) const {
   Variables<tmpl::list<::Tags::TempScalar<0>, ::Tags::TempScalar<1>>> buffer{
-      get(interior_mass_desity).size()};
+      get(interior_mass_density).size()};
   auto& normal_dot_velocity = get<::Tags::TempScalar<0>>(buffer);
   dot_product(make_not_null(&normal_dot_velocity),
               outward_directed_normal_covector, interior_velocity);
@@ -86,7 +84,7 @@ std::optional<std::string> Reflection<Dim>::dg_ghost(
   *specific_internal_energy = interior_specific_internal_energy;
 
   ConservativeFromPrimitive<Dim>::apply(
-      mass_density, momentum_density, energy_density, interior_mass_desity,
+      mass_density, momentum_density, energy_density, interior_mass_density,
       *velocity, interior_specific_internal_energy);
   ComputeFluxes<Dim>::apply(flux_mass_density, flux_momentum_density,
                             flux_energy_density, *momentum_density,

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/Reflection.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/Reflection.hpp
@@ -3,27 +3,49 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <memory>
 #include <optional>
 #include <pup.h>
-#include <string>
+#include <type_traits>
+#include <unordered_map>
 
-#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/Tags.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/OrientationMap.hpp"
+#include "Domain/Structure/OrientationMapHelpers.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/TagsTimeDependent.hpp"
 #include "Evolution/BoundaryConditions/Type.hpp"
+#include "Evolution/DgSubcell/SliceVariable.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/DiscontinuousGalerkin/Actions/NormalCovectorAndMagnitude.hpp"
+#include "Evolution/DiscontinuousGalerkin/NormalVectorTags.hpp"
 #include "Evolution/Systems/NewtonianEuler/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/NewtonianEuler/FiniteDifference/Reconstructor.hpp"
+#include "Evolution/Systems/NewtonianEuler/FiniteDifference/Tag.hpp"
 #include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Options/Options.hpp"
+#include "Parallel/Tags/Metavariables.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
-
-/// \cond
-class DataVector;
-namespace gsl {
-template <class T>
-class not_null;
-}  // namespace gsl
-/// \endcond
 
 namespace NewtonianEuler::BoundaryConditions {
 /*!
@@ -110,10 +132,186 @@ class Reflection final : public BoundaryCondition<Dim> {
       const tnsr::i<DataVector, Dim, Frame::Inertial>&
           outward_directed_normal_covector,
 
-      const Scalar<DataVector>& interior_mass_desity,
+      const Scalar<DataVector>& interior_mass_density,
       const tnsr::I<DataVector, Dim, Frame::Inertial>& interior_velocity,
       const Scalar<DataVector>& interior_specific_internal_energy,
       const Scalar<DataVector>& interior_pressure) const;
+
+  using fd_interior_evolved_variables_tags = tmpl::list<>;
+  using fd_interior_temporary_tags =
+      tmpl::list<evolution::dg::subcell::Tags::Mesh<Dim>,
+                 domain::Tags::MeshVelocity<Dim, Frame::Inertial>>;
+  using fd_interior_primitive_variables_tags =
+      tmpl::list<Tags::MassDensity<DataVector>, Tags::Velocity<DataVector, Dim>,
+                 Tags::Pressure<DataVector>>;
+  using fd_gridless_tags =
+      tmpl::list<fd::Tags::Reconstructor<Dim>, ::Tags::Time,
+                 domain::Tags::FunctionsOfTime,
+                 domain::Tags::ElementMap<Dim, Frame::Grid>,
+                 domain::CoordinateMaps::Tags::CoordinateMap<Dim, Frame::Grid,
+                                                             Frame::Inertial>,
+                 Parallel::Tags::Metavariables>;
+
+  template <typename Metavariables>
+  void fd_ghost(
+      const gsl::not_null<Scalar<DataVector>*> mass_density,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> velocity,
+      const gsl::not_null<Scalar<DataVector>*> pressure,
+      const Direction<Dim>& direction,
+      // interior temporary tags
+      const Mesh<Dim> subcell_mesh,
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>
+          volume_mesh_velocity,
+      // interior primitive variables tags
+      const Scalar<DataVector>& interior_mass_density,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& interior_velocity,
+      const Scalar<DataVector>& interior_pressure,
+      // gridless tags
+      const fd::Reconstructor<Dim>& reconstructor, const double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time,
+      const ElementMap<Dim, Frame::Grid>& logical_to_grid_map,
+      const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, Dim>&
+          grid_to_inertial_map,
+      const Metavariables& /*meta*/) const {
+    const size_t ghost_zone_size{reconstructor.ghost_zone_size()};
+
+    const auto subcell_extents = subcell_mesh.extents();
+
+    Variables<fd_interior_primitive_variables_tags> volume_prim_vars{};
+    volume_prim_vars.initialize(subcell_extents.product());
+
+    using MassDensity = Tags::MassDensity<DataVector>;
+    using Velocity = Tags::Velocity<DataVector, Dim>;
+    using Pressure = Tags::Pressure<DataVector>;
+    get<MassDensity>(volume_prim_vars) = interior_mass_density;
+    get<Velocity>(volume_prim_vars) = interior_velocity;
+    get<Pressure>(volume_prim_vars) = interior_pressure;
+
+    Variables<fd_interior_primitive_variables_tags> sliced_prim_vars{};
+    const size_t num_sliced_pts{
+        subcell_extents.slice_away(direction.dimension()).product() *
+        ghost_zone_size};
+    sliced_prim_vars.initialize(num_sliced_pts);
+
+    // Slice volume primitive variables upto the depth `ghost_zone_size`
+    evolution::dg::subcell::slice_variable(make_not_null(&sliced_prim_vars),
+                                           volume_prim_vars, subcell_extents,
+                                           ghost_zone_size, direction);
+
+    // Construct an ourward-pointing normal vector field on the sliced subcell
+    // mesh, which is needed for computing normal components of velocity at each
+    // grid points.
+    //
+    // Note) It is assumed here that the outward normal vector field on ghost
+    // points is aligned with internal grid lines and same as the outward normal
+    // vector field at internal grid points. We will need a different strategy
+    // when using unstructured meshes in the future.
+    //
+    Index<Dim> sliced_extents = subcell_extents;
+    sliced_extents[direction.dimension()] = ghost_zone_size;
+    const Mesh<Dim> sliced_mesh{sliced_extents.indices(),
+                                Spectral::Basis::FiniteDifference,
+                                Spectral::Quadrature::CellCentered};
+
+    DirectionMap<Dim, std::optional<Variables<tmpl::list<
+                          evolution::dg::Tags::MagnitudeOfNormal,
+                          evolution::dg::Tags::NormalCovector<Dim>>>>>
+        normal_covectors_and_magnitudes{};
+    {
+      auto sliced_logical_coords = logical_coordinates(sliced_mesh);
+      std::unordered_map<Direction<Dim>,
+                         tnsr::i<DataVector, Dim, Frame::Inertial>>
+          unnormalized_normal_covectors{};
+      tnsr::i<DataVector, Dim, Frame::Inertial> unnormalized_covector{};
+      for (size_t i = 0; i < Dim; ++i) {
+        unnormalized_covector.get(i) =
+            grid_to_inertial_map
+                .inv_jacobian(logical_to_grid_map(sliced_logical_coords), time,
+                              functions_of_time)
+                .get(direction.dimension(), i);
+      }
+      unnormalized_normal_covectors[direction] = unnormalized_covector;
+      Variables<tmpl::list<
+          evolution::dg::Actions::detail::NormalVector<Dim>,
+          evolution::dg::Actions::detail::OneOverNormalVectorMagnitude>>
+          fields_on_face{sliced_mesh.number_of_grid_points()};
+      normal_covectors_and_magnitudes[direction] = std::nullopt;
+      using system = typename std::decay_t<Metavariables>::system;
+      evolution::dg::Actions::detail::
+          unit_normal_vector_and_covector_and_magnitude<system>(
+              make_not_null(&normal_covectors_and_magnitudes),
+              make_not_null(&fields_on_face), direction,
+              unnormalized_normal_covectors, grid_to_inertial_map);
+    }
+    auto& outward_normal_on_sliced_mesh =
+        get<evolution::dg::Tags::NormalCovector<Dim>>(
+            normal_covectors_and_magnitudes[direction].value());
+
+    Variables<tmpl::list<::Tags::TempScalar<0>, ::Tags::TempScalar<1>>>
+        buffer{};
+    buffer.initialize(num_sliced_pts);
+
+    // Reverse the normal component of velocity.
+    auto& normal_dot_velocity = get<::Tags::TempScalar<0>>(buffer);
+    auto& sliced_interior_velocity = get<Velocity>(sliced_prim_vars);
+    dot_product(make_not_null(&normal_dot_velocity),
+                outward_normal_on_sliced_mesh, sliced_interior_velocity);
+    for (size_t i = 0; i < Dim; i++) {
+      sliced_interior_velocity.get(i) -=
+          2.0 * get(normal_dot_velocity) * outward_normal_on_sliced_mesh.get(i);
+    }
+
+    if (volume_mesh_velocity.has_value()) {
+      auto& normal_dot_mesh_velocity = get<::Tags::TempScalar<1>>(buffer);
+      dot_product(make_not_null(&normal_dot_mesh_velocity),
+                  outward_normal_on_sliced_mesh, volume_mesh_velocity.value());
+      for (size_t i = 0; i < Dim; i++) {
+        // See the class documentation above for plus(+) sign here
+        sliced_interior_velocity.get(i) += 2.0 * get(normal_dot_mesh_velocity) *
+                                           outward_normal_on_sliced_mesh.get(i);
+      }
+    }
+
+    // Now using OrientationMap, we reverse the data ordering of
+    // sliced_prim_vars, which completes the 'mirroring' operation to get the
+    // desired FD ghost data.
+    std::array<Direction<Dim>, Dim> default_orientation;
+    std::array<Direction<Dim>, Dim> reflected_orientation;
+
+    if constexpr (Dim == 1) {
+      default_orientation = {{Direction<1>::upper_xi()}};
+      reflected_orientation = {{Direction<1>::lower_xi()}};
+    } else if constexpr (Dim == 2) {
+      default_orientation = {
+          {Direction<2>::upper_xi(), Direction<2>::upper_eta()}};
+      reflected_orientation = default_orientation;
+
+      const size_t dim_to_reflect = direction.dimension();
+      reflected_orientation[dim_to_reflect] =
+          default_orientation[dim_to_reflect].opposite();
+    } else if constexpr (Dim == 3) {
+      default_orientation = {{Direction<3>::upper_xi(),
+                              Direction<3>::upper_eta(),
+                              Direction<3>::upper_zeta()}};
+      reflected_orientation = default_orientation;
+
+      const size_t dim_to_reflect = direction.dimension();
+      reflected_orientation[dim_to_reflect] =
+          default_orientation[dim_to_reflect].opposite();
+    }
+
+    OrientationMap<Dim> orientation_map(default_orientation,
+                                        reflected_orientation);
+    auto reflected_vars =
+        orient_variables(sliced_prim_vars, sliced_extents, orientation_map);
+
+    *mass_density = get<MassDensity>(reflected_vars);
+    *velocity = get<Velocity>(reflected_vars);
+    *pressure = get<Pressure>(reflected_vars);
+  }
 };
 
 }  // namespace NewtonianEuler::BoundaryConditions

--- a/src/Evolution/Systems/NewtonianEuler/FiniteDifference/BoundaryGhostData.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/FiniteDifference/BoundaryGhostData.hpp
@@ -1,0 +1,229 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Domain/BoundaryConditions/None.hpp"
+#include "Domain/BoundaryConditions/Periodic.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/TagsTimeDependent.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/NeighborData.hpp"
+#include "Evolution/DiscontinuousGalerkin/ProjectToBoundary.hpp"
+#include "Evolution/Systems/NewtonianEuler/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/NewtonianEuler/BoundaryConditions/Factory.hpp"
+#include "Evolution/Systems/NewtonianEuler/FiniteDifference/Reconstructor.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/CallWithDynamicType.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace NewtonianEuler::fd {
+/*!
+ * \brief Computes finite difference ghost data for external boundary
+ * conditions.
+ *
+ */
+struct BoundaryGhostData {
+  template <typename FdBoundaryConditionHelper, typename DbTagsList,
+            typename... FdBoundaryConditionArgsTags>
+  // A helper function for calling fd_ghost() of BoundaryCondition subclasses
+  static void apply_subcell_boundary_condition_impl(
+      FdBoundaryConditionHelper& fd_boundary_condition_helper,
+      const gsl::not_null<db::DataBox<DbTagsList>*>& box,
+      tmpl::list<FdBoundaryConditionArgsTags...>) {
+    return fd_boundary_condition_helper(
+        db::get<FdBoundaryConditionArgsTags>(*box)...);
+  }
+
+  template <typename DbTagsList, size_t Dim>
+  static void apply(const gsl::not_null<db::DataBox<DbTagsList>*> box,
+                    const Element<Dim>& element,
+                    const Reconstructor<Dim>& reconstructor);
+};
+
+template <typename DbTagsList, size_t Dim>
+void BoundaryGhostData::apply(const gsl::not_null<db::DataBox<DbTagsList>*> box,
+                              const Element<Dim>& element,
+                              const Reconstructor<Dim>& reconstructor) {
+  const ::Domain<Dim>& domain = db::get<domain::Tags::Domain<Dim>>(*box);
+  const auto& external_boundary_condition =
+      domain.blocks()[element.id().block_id()].external_boundary_conditions();
+
+  const Mesh<Dim> subcell_mesh =
+      db::get<evolution::dg::subcell::Tags::Mesh<Dim>>(*box);
+
+  const size_t ghost_zone_size{reconstructor.ghost_zone_size()};
+
+  // Tags for reconstruction
+  using prims_to_reconstruct =
+      tmpl::list<NewtonianEuler::Tags::MassDensity<DataVector>,
+                 NewtonianEuler::Tags::Velocity<DataVector, Dim>,
+                 NewtonianEuler::Tags::Pressure<DataVector>>;
+
+  for (const auto& direction : Direction<Dim>::all_directions()) {
+    if (not(element.neighbors().contains(direction))) {
+      // If a direction is not in elements.neighbors(), then the element must
+      // be at the external boundary
+      ASSERT(element.external_boundaries().count(direction),
+             "Element contains a direction which is neither neighbor nor "
+             "external boundary");
+      // Also check if the pointer is not null. This will catch an error that
+      // the pointer has a correct type but not pointing anything
+      ASSERT(external_boundary_condition.at(direction) != nullptr, "");
+      const auto& boundary_condition =
+          *external_boundary_condition.at(direction);
+
+      const size_t num_face_pts{
+          subcell_mesh.extents().slice_away(direction.dimension()).product()};
+
+      // a Variables object to store the computed FD ghost data
+      Variables<prims_to_reconstruct> ghost_data_vars{ghost_zone_size *
+                                                      num_face_pts};
+
+      // We don't need to care about boundary ghost data when using the periodic
+      // condition, so exclude it from the type list
+      using factory_classes =
+          typename std::decay_t<decltype(db::get<Parallel::Tags::Metavariables>(
+              *box))>::factory_creation::factory_classes;
+      using derived_boundary_conditions_for_subcell = tmpl::remove_if<
+          tmpl::at<factory_classes,
+                   typename NewtonianEuler::BoundaryConditions::
+                       BoundaryCondition<Dim>>,
+          tmpl::or_<std::is_base_of<domain::BoundaryConditions::MarkAsPeriodic,
+                                    tmpl::_1>,
+                    std::is_base_of<domain::BoundaryConditions::MarkAsNone,
+                                    tmpl::_1>>>;
+
+      // Now apply subcell boundary conditions
+      call_with_dynamic_type<void, derived_boundary_conditions_for_subcell>(
+          &boundary_condition, [&boundary_condition, &box, &direction,
+                                &ghost_data_vars, &num_face_pts, &subcell_mesh](
+                                   const auto& derived_boundary_condition_v) {
+            using BoundaryCondition =
+                std::decay_t<decltype(*derived_boundary_condition_v)>;
+            if (dynamic_cast<const BoundaryCondition*>(&boundary_condition) !=
+                nullptr) {
+              using bcondition_interior_evolved_vars_tags =
+                  typename BoundaryCondition::
+                      fd_interior_evolved_variables_tags;
+              using bcondition_interior_temporary_tags =
+                  typename BoundaryCondition::fd_interior_temporary_tags;
+              using bcondition_interior_primitive_vars_tags =
+                  typename BoundaryCondition::
+                      fd_interior_primitive_variables_tags;
+              using bcondition_gridless_tags =
+                  typename BoundaryCondition::fd_gridless_tags;
+
+              using bcondition_interior_tags =
+                  tmpl::append<bcondition_interior_evolved_vars_tags,
+                               bcondition_interior_temporary_tags,
+                               bcondition_interior_primitive_vars_tags,
+                               bcondition_gridless_tags>;
+
+              if constexpr (BoundaryCondition::bc_type ==
+                            evolution::BoundaryConditions::Type::Ghost) {
+                auto apply_fd_ghost =
+                    [&boundary_condition, &direction, &ghost_data_vars](
+                        const auto&... boundary_ghost_data_args) {
+                      dynamic_cast<const BoundaryCondition&>(boundary_condition)
+                          .fd_ghost(
+                              make_not_null(
+                                  &get<NewtonianEuler::Tags::MassDensity<
+                                      DataVector>>(ghost_data_vars)),
+                              make_not_null(
+                                  &get<NewtonianEuler::Tags::Velocity<
+                                      DataVector, Dim>>(ghost_data_vars)),
+                              make_not_null(&get<NewtonianEuler::Tags::Pressure<
+                                                DataVector>>(ghost_data_vars)),
+                              direction, boundary_ghost_data_args...);
+                    };
+                apply_subcell_boundary_condition_impl(
+                    apply_fd_ghost, box, bcondition_interior_tags{});
+              } else if constexpr (BoundaryCondition::bc_type ==
+                                   evolution::BoundaryConditions::Type::
+                                       Outflow) {
+                // Outflow boundary condition checks if the characteristic speed
+                // is directed out of the element.
+                const auto& volume_mesh_velocity =
+                    db::get<domain::Tags::MeshVelocity<Dim, Frame::Inertial>>(
+                        *box);
+                std::optional<tnsr::I<DataVector, Dim>> face_mesh_velocity{};
+
+                if (volume_mesh_velocity.has_value()) {
+                  face_mesh_velocity = tnsr::I<DataVector, Dim>{num_face_pts};
+                  evolution::dg::project_tensor_to_boundary(
+                      make_not_null(&*face_mesh_velocity),
+                      *volume_mesh_velocity, subcell_mesh, direction);
+                }
+
+                const auto& normal_covector_and_magnitude = db::get<
+                    evolution::dg::Tags::NormalCovectorAndMagnitude<Dim>>(*box);
+                auto outward_directed_normal_covector =
+                    get<evolution::dg::Tags::NormalCovector<Dim>>(
+                        normal_covector_and_magnitude.at(direction).value());
+
+                const auto apply_fd_outflow =
+                    [&boundary_condition, &direction, &face_mesh_velocity,
+                     &ghost_data_vars, &outward_directed_normal_covector](
+                        const auto&... boundary_ghost_data_args) {
+                      return dynamic_cast<const BoundaryCondition&>(
+                                 boundary_condition)
+                          .fd_outflow(
+                              make_not_null(
+                                  &get<NewtonianEuler::Tags::MassDensity<
+                                      DataVector>>(ghost_data_vars)),
+                              make_not_null(
+                                  &get<NewtonianEuler::Tags::Velocity<
+                                      DataVector, Dim>>(ghost_data_vars)),
+                              make_not_null(&get<NewtonianEuler::Tags::Pressure<
+                                                DataVector>>(ghost_data_vars)),
+                              direction, face_mesh_velocity,
+                              outward_directed_normal_covector,
+                              boundary_ghost_data_args...);
+                    };
+                apply_subcell_boundary_condition_impl(
+                    apply_fd_outflow, box, bcondition_interior_tags{});
+              } else {
+                ERROR("Unsupported boundary condition "
+                      << pretty_type::short_name<BoundaryCondition>()
+                      << " when using finite-difference");
+              }
+            }
+          });
+
+      // Put the computed ghost data into neighbor data with {direction,
+      // ElementId::external_boundary_id()} as the mortar_id key
+      std::vector<double> boundary_ghost_data{
+          ghost_data_vars.data(),
+          ghost_data_vars.data() + ghost_data_vars.size()};
+      const std::pair mortar_id{direction,
+                                ElementId<Dim>::external_boundary_id()};
+
+      db::mutate<
+          evolution::dg::subcell::Tags::NeighborDataForReconstruction<Dim>>(
+          box, [&mortar_id, &boundary_ghost_data](auto neighbor_data) {
+            (*neighbor_data)[mortar_id] = boundary_ghost_data;
+          });
+    }
+  }
+}
+
+}  // namespace NewtonianEuler::fd

--- a/src/Evolution/Systems/NewtonianEuler/FiniteDifference/CMakeLists.txt
+++ b/src/Evolution/Systems/NewtonianEuler/FiniteDifference/CMakeLists.txt
@@ -15,6 +15,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   AoWeno.hpp
+  BoundaryGhostData.hpp
   Factory.hpp
   FiniteDifference.hpp
   MonotisedCentral.hpp

--- a/src/Evolution/Systems/NewtonianEuler/FiniteDifference/ReconstructWork.tpp
+++ b/src/Evolution/Systems/NewtonianEuler/FiniteDifference/ReconstructWork.tpp
@@ -89,20 +89,30 @@ void reconstruct_prims_work(
         }
 
         DirectionMap<Dim, gsl::span<const double>> ghost_cell_vars{};
+
         for (const auto& direction : Direction<Dim>::all_directions()) {
-          const auto& neighbors_in_direction =
-              element.neighbors().at(direction);
-          ASSERT(neighbors_in_direction.size() == 1,
-                 "Currently only support one neighbor in each direction, but "
-                 "got "
-                     << neighbors_in_direction.size() << " in direction "
-                     << direction);
-          ghost_cell_vars[direction] = gsl::make_span(
-              &neighbor_data.at(std::pair{
-                  direction,
-                  *neighbors_in_direction
-                       .begin()})[vars_in_neighbor_count * neighbor_num_pts],
-              number_of_components * neighbor_num_pts);
+          if (element.neighbors().contains(direction)) {
+            const auto& neighbors_in_direction =
+                element.neighbors().at(direction);
+            ASSERT(neighbors_in_direction.size() == 1,
+                   "Currently only support one neighbor in each direction, but "
+                   "got "
+                       << neighbors_in_direction.size() << " in direction "
+                       << direction);
+            ghost_cell_vars[direction] = gsl::make_span(
+                &neighbor_data.at(std::pair{
+                    direction,
+                    *neighbors_in_direction
+                         .begin()})[vars_in_neighbor_count * neighbor_num_pts],
+                number_of_components * neighbor_num_pts);
+          } else {
+            // retrieve boundary ghost data from neighbor_data
+            ghost_cell_vars[direction] = gsl::make_span(
+                &neighbor_data.at(std::pair{
+                    direction, ElementId<Dim>::external_boundary_id()})
+                     [vars_in_neighbor_count * neighbor_num_pts],
+                number_of_components * neighbor_num_pts);
+          }
         }
 
         reconstruct(make_not_null(&upper_face_vars),

--- a/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
+++ b/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
@@ -26,6 +26,7 @@ set(LIBRARY_SOURCES
   Test_ReconstructionMethod.cpp
   Test_SliceData.cpp
   Test_SliceTensor.cpp
+  Test_SliceVariable.cpp
   Test_SubcellOptions.cpp
   Test_Tags.cpp
   Test_TciStatus.cpp

--- a/tests/Unit/Evolution/DgSubcell/Test_SliceVariable.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_SliceVariable.cpp
@@ -1,0 +1,99 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <numeric>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/SliceIterator.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Evolution/DgSubcell/SliceVariable.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+// types of Tensor to test
+namespace Tags {
+struct Scalar : db::SimpleTag {
+  using type = ::Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct TensorI : db::SimpleTag {
+  using type = ::tnsr::I<DataVector, Dim>;
+};
+}  // namespace Tags
+
+template <size_t Dim>
+void test_slice(
+    const Variables<tmpl::list<Tags::Scalar, Tags::TensorI<Dim>>>& volume_vars,
+    const Index<Dim>& volume_extents, size_t num_ghost_pts,
+    const Direction<Dim>& direction) {
+  // retrieve a sliced Variables object
+  auto sliced_vars = evolution::dg::subcell::slice_variable(
+      volume_vars, volume_extents, num_ghost_pts, direction);
+
+  Index<Dim> sliced_extents = volume_extents;
+  sliced_extents[direction.dimension()] = num_ghost_pts;
+
+  // for each ghost slices,
+  for (size_t i_ghost = 0; i_ghost < num_ghost_pts; ++i_ghost) {
+    // for each of Variables components ( Scalar x 1 + TensorI x Dim )
+    for (size_t component_index = 0;
+         component_index < volume_vars.number_of_independent_components;
+         ++component_index) {
+      const size_t fixed_index =
+          direction.side() == Side::Lower
+              ? i_ghost
+              : volume_extents[direction.dimension()] + i_ghost - num_ghost_pts;
+
+      const size_t volume_offset = component_index * volume_extents.product();
+      const size_t slice_offset = component_index * sliced_extents.product();
+
+      // check the result
+      for (SliceIterator
+               volume_it(volume_extents, direction.dimension(), fixed_index),
+           slice_it(sliced_extents, direction.dimension(), i_ghost);
+           volume_it; ++volume_it, ++slice_it) {
+        CHECK(
+            *(volume_vars.data() + volume_offset + volume_it.volume_offset()) ==
+            *(sliced_vars.data() + slice_offset + slice_it.volume_offset()));
+      }
+    }
+  }
+}
+
+template <size_t Dim>
+void test() {
+  for (size_t num_mesh_pts_1d = 3; num_mesh_pts_1d < 5; ++num_mesh_pts_1d) {
+    // ghost zone size iterates up to the maximum possible value (mesh extent of
+    // each dimension)
+    for (size_t num_ghost_pts = 1; num_ghost_pts <= num_mesh_pts_1d;
+         ++num_ghost_pts) {
+      const Index<Dim> volume_extents{num_mesh_pts_1d};
+
+      // Create volume tensors and assign values
+      Variables<tmpl::list<Tags::Scalar, Tags::TensorI<Dim>>> volume_vars{
+          volume_extents.product()};
+      std::iota(volume_vars.data(), volume_vars.data() + volume_vars.size(),
+                0.0);
+
+      for (const auto& direction : Direction<Dim>::all_directions()) {
+        // check slicing for each direction
+        test_slice(volume_vars, volume_extents, num_ghost_pts, direction);
+      }
+    }
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Subcell.SliceVariable", "[Evolution][Unit]") {
+  test<1>();
+  test<2>();
+  test<3>();
+}
+}  // namespace

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryConditions/Outflow.py
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryConditions/Outflow.py
@@ -1,0 +1,36 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def error(face_mesh_velocity, normal_covector, int_mass_density, int_velocity,
+          int_specific_internal_energy, use_polytropic_eos):
+
+    if use_polytropic_eos:
+        polytropic_constant = 1.4
+        polytropic_exponent = 5.0 / 3.0
+        sound_speed = np.sqrt(polytropic_constant * polytropic_exponent *
+                              pow(int_mass_density, polytropic_exponent - 1.0))
+    else:
+        adiabatic_index = 1.3
+        chi = int_specific_internal_energy * (adiabatic_index - 1.0)
+        kappa_times_p_over_rho_squared = ((adiabatic_index - 1.0)**2 *
+                                          int_specific_internal_energy)
+        sound_speed = np.sqrt(chi + kappa_times_p_over_rho_squared)
+
+    normal_dot_velocity = np.einsum("i,i", int_velocity, normal_covector)
+
+    if face_mesh_velocity is None:
+        min_char_speed = normal_dot_velocity - sound_speed
+    else:
+        normal_dot_mesh_velocity = np.einsum("i,i", face_mesh_velocity,
+                                             normal_covector)
+
+        min_char_speed = normal_dot_velocity \
+            - normal_dot_mesh_velocity - sound_speed
+
+    if min_char_speed < 0.0:
+        return "Outflow boundary condition violated"
+
+    return None

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryConditions/Test_Outflow.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryConditions/Test_Outflow.cpp
@@ -1,0 +1,121 @@
+// Distributed under the MIT License
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Evolution/Systems/NewtonianEuler/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/NewtonianEuler/BoundaryConditions/Outflow.hpp"
+#include "Evolution/Systems/NewtonianEuler/BoundaryCorrections/Rusanov.hpp"
+#include "Evolution/Systems/NewtonianEuler/System.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/Range.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace helpers = TestHelpers::evolution::dg;
+
+namespace {
+
+struct ConvertPolytropic {
+  using unpacked_container = bool;
+  using packed_container = EquationsOfState::PolytropicFluid<false>;
+  using packed_type = bool;
+
+  static inline unpacked_container unpack(const packed_container& /*packed*/,
+                                          const size_t /*grid_point_index*/) {
+    return true;
+  }
+
+  [[noreturn]] static inline void pack(
+      const gsl::not_null<packed_container*> /*packed*/,
+      const unpacked_container& /*unpacked*/,
+      const size_t /*grid_point_index*/) {
+    ERROR("Should not be converting an EOS from an unpacked to a packed type");
+  }
+
+  static inline size_t get_size(const packed_container& /*packed*/) {
+    return 1;
+  }
+};
+
+struct ConvertIdeal {
+  using unpacked_container = bool;
+  using packed_container = EquationsOfState::IdealFluid<false>;
+  using packed_type = bool;
+
+  static inline unpacked_container unpack(const packed_container& /*packed*/,
+                                          const size_t /*grid_point_index*/) {
+    return false;
+  }
+
+  [[noreturn]] static inline void pack(
+      const gsl::not_null<packed_container*> /*packed*/,
+      const unpacked_container& /*unpacked*/,
+      const size_t /*grid_point_index*/) {
+    ERROR("Should not be converting an EOS from an unpacked to a packed type");
+  }
+
+  static inline size_t get_size(const packed_container& /*packed*/) {
+    return 1;
+  }
+};
+
+struct DummyInitialData {
+  using argument_tags = tmpl::list<>;
+  struct source_term_type {
+    using sourced_variables = tmpl::list<>;
+    using argument_tags = tmpl::list<>;
+  };
+};
+
+template <size_t Dim, typename EosType>
+void test(EosType& eos) {
+  MAKE_GENERATOR(gen);
+
+  auto box =
+      db::create<db::AddSimpleTags<hydro::Tags::EquationOfState<EosType>>>(eos);
+
+  const tuples::TaggedTuple<
+      helpers::Tags::Range<NewtonianEuler::Tags::MassDensity<DataVector>>,
+      helpers::Tags::Range<
+          NewtonianEuler::Tags::SpecificInternalEnergy<DataVector>>>
+      ranges{std::array{1.0e-30, 1.0}, std::array{1.0e-30, 1.0}};
+
+  helpers::test_boundary_condition_with_python<
+      NewtonianEuler::BoundaryConditions::Outflow<Dim>,
+      NewtonianEuler::BoundaryConditions::BoundaryCondition<Dim>,
+      NewtonianEuler::System<Dim, DummyInitialData>,
+      tmpl::list<NewtonianEuler::BoundaryCorrections::Rusanov<Dim>>,
+      tmpl::list<ConvertPolytropic, ConvertIdeal>>(
+      make_not_null(&gen),
+      "Evolution.Systems.NewtonianEuler.BoundaryConditions.Outflow",
+      tuples::TaggedTuple<helpers::Tags::PythonFunctionForErrorMessage<>>{
+          "error"},
+      "Outflow:\n", Index<Dim - 1>{Dim == 1 ? 1 : 5}, box, ranges);
+}  // namespace
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.NewtonianEuler.BoundaryConditions.Outflow",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{""};
+
+  EquationsOfState::PolytropicFluid<false> eos_polytrope{1.4, 5.0 / 3.0};
+  test<1>(eos_polytrope);
+  test<2>(eos_polytrope);
+  test<3>(eos_polytrope);
+
+  EquationsOfState::IdealFluid<false> eos_ideal{1.3};
+  test<1>(eos_ideal);
+  test<2>(eos_ideal);
+  test<3>(eos_ideal);
+}

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_NewtonianEuler")
 
 set(LIBRARY_SOURCES
   BoundaryConditions/Test_DirichletAnalytic.cpp
+  BoundaryConditions/Test_Outflow.cpp
   BoundaryConditions/Test_Periodic.cpp
   BoundaryConditions/Test_Reflection.cpp
   BoundaryCorrections/Test_Hll.cpp

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBRARY_SOURCES
   BoundaryCorrections/Test_Hllc.cpp
   BoundaryCorrections/Test_Rusanov.cpp
   FiniteDifference/Test_AoWeno.cpp
+  FiniteDifference/Test_BoundaryGhostData.cpp
   FiniteDifference/Test_MonotisedCentral.cpp
   FiniteDifference/Test_Tag.cpp
   Subcell/Test_ComputeFluxes.cpp

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/FiniteDifference/Test_BoundaryGhostData.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/FiniteDifference/Test_BoundaryGhostData.cpp
@@ -1,0 +1,421 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/Slice.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/Tags.hpp"
+#include "Domain/CreateInitialElement.hpp"
+#include "Domain/Creators/Brick.hpp"
+#include "Domain/Creators/Interval.hpp"
+#include "Domain/Creators/Rectangle.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/SegmentId.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/TagsTimeDependent.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
+#include "Evolution/DgSubcell/SliceTensor.hpp"
+#include "Evolution/DgSubcell/Tags/Coordinates.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/NeighborData.hpp"
+#include "Evolution/DiscontinuousGalerkin/Actions/NormalCovectorAndMagnitude.hpp"
+#include "Evolution/DiscontinuousGalerkin/NormalVectorTags.hpp"
+#include "Evolution/Systems/NewtonianEuler/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/NewtonianEuler/BoundaryConditions/Factory.hpp"
+#include "Evolution/Systems/NewtonianEuler/FiniteDifference/BoundaryGhostData.hpp"
+#include "Evolution/Systems/NewtonianEuler/FiniteDifference/Factory.hpp"
+#include "Evolution/Systems/NewtonianEuler/FiniteDifference/Reconstructor.hpp"
+#include "Evolution/Systems/NewtonianEuler/FiniteDifference/Tag.hpp"
+#include "Evolution/Systems/NewtonianEuler/System.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/Tags/Metavariables.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/NewtonianEuler/SmoothFlow.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/CloneUniquePtrs.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace NewtonianEuler {
+namespace {
+
+// use smoothflow solution for test
+template <size_t Dim>
+Solutions::SmoothFlow<Dim> make_solution() {
+  const double pressure{1.0};
+  const double adiabatic_index{1.4};
+  const double perturbation_size{0.3};
+  std::array<double, Dim> mean_velocity;
+  std::array<double, Dim> wave_vector;
+
+  if constexpr (Dim == 1) {
+    mean_velocity = {1.0};
+    wave_vector = {1.0};
+  } else if constexpr (Dim == 2) {
+    mean_velocity = {1.0, 1.0};
+    wave_vector = {1.0, 1.0};
+  } else if constexpr (Dim == 3) {
+    mean_velocity = {1.0, 1.0, 1.0};
+    wave_vector = {1.0, 1.0, 1.0};
+  }
+  return Solutions::SmoothFlow<Dim>{mean_velocity, wave_vector, pressure,
+                                    adiabatic_index, perturbation_size};
+}
+
+template <size_t Dim, typename InitialData>
+struct EvolutionMetaVars {
+  using system = System<Dim, InitialData>;
+
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<BoundaryConditions::BoundaryCondition<Dim>,
+                   BoundaryConditions::standard_boundary_conditions<Dim>>>;
+  };
+};
+
+template <size_t Dim, typename BoundaryConditionType>
+void test(const BoundaryConditionType boundary_condition) {
+  const size_t num_dg_pts = 5;
+
+  // Create domain and element
+  // Let's use [0, 1]^D for test.
+  Domain<Dim> domain{};
+  std::array<size_t, Dim> refinement_levels{};
+
+  if constexpr (Dim == 1) {
+    std::array<double, Dim> lower_bounds{0.0};
+    std::array<double, Dim> upper_bounds{1.0};
+    std::array<size_t, Dim> number_of_grid_points{num_dg_pts};
+    refinement_levels = {0};
+
+    const auto interval = domain::creators::Interval(
+        lower_bounds, upper_bounds, refinement_levels, number_of_grid_points,
+        std::make_unique<BoundaryConditionType>(boundary_condition),
+        std::make_unique<BoundaryConditionType>(boundary_condition), nullptr);
+    domain = interval.create_domain();
+  } else if constexpr (Dim == 2) {
+    std::array<double, Dim> lower_bounds{0.0, 0.0};
+    std::array<double, Dim> upper_bounds{1.0, 1.0};
+    std::array<size_t, Dim> number_of_grid_points{num_dg_pts, num_dg_pts};
+    refinement_levels = {0, 0};
+
+    const auto rectangle = domain::creators::Rectangle(
+        lower_bounds, upper_bounds, refinement_levels, number_of_grid_points,
+        std::make_unique<BoundaryConditionType>(boundary_condition), nullptr);
+    domain = rectangle.create_domain();
+  } else if constexpr (Dim == 3) {
+    std::array<double, Dim> lower_bounds{0.0, 0.0, 0.0};
+    std::array<double, Dim> upper_bounds{1.0, 1.0, 1.0};
+    std::array<size_t, Dim> number_of_grid_points{num_dg_pts, num_dg_pts,
+                                                  num_dg_pts};
+    refinement_levels = {0, 0, 0};
+
+    const auto brick = domain::creators::Brick(
+        lower_bounds, upper_bounds, refinement_levels, number_of_grid_points,
+        std::make_unique<BoundaryConditionType>(boundary_condition), nullptr);
+    domain = brick.create_domain();
+  }
+
+  const auto element = domain::Initialization::create_initial_element(
+      ElementId<Dim>{0, {SegmentId{0, 0}}}, domain.blocks().at(0),
+      std::vector<std::array<size_t, Dim>>{{refinement_levels}});
+
+  // Mesh and coordinates
+  const Mesh<Dim> dg_mesh{num_dg_pts, Spectral::Basis::Legendre,
+                          Spectral::Quadrature::GaussLobatto};
+  const Mesh<Dim> subcell_mesh = evolution::dg::subcell::fd::mesh(dg_mesh);
+
+  // use MC reconstruction for test
+  using ReconstructorForTest = fd::MonotisedCentralPrim<Dim>;
+
+  // dummy neighbor data to put into DataBox
+  typename evolution::dg::subcell::Tags::NeighborDataForReconstruction<
+      Dim>::type neighbor_data{};
+
+  // Below are tags required by DirichletAnalytic boundary condition.
+  //  - time
+  //  - functions of time
+  //  - element map
+  //  - coordinate map
+  //  - subcell logical coordinates
+  //  - analytic solution
+
+  const double time{0.3};
+
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time{};
+
+  const ElementMap<Dim, Frame::Grid> logical_to_grid_map(
+      ElementId<Dim>{0},
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
+          domain::CoordinateMaps::Identity<Dim>{}));
+
+  const auto grid_to_inertial_map =
+      domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+          domain::CoordinateMaps::Identity<Dim>{});
+
+  const auto subcell_logical_coords = logical_coordinates(subcell_mesh);
+
+  using SolutionForTest = Solutions::SmoothFlow<Dim>;
+  auto solution = make_solution<Dim>();
+
+  // Below are tags required by Outflow boundary condition
+  //  - primitive variables on subcell mesh
+  //  - equation of state (for computing sound speed)
+  //  - volume mesh velocity
+  //  - normal vector on face
+  using MassDensity = Tags::MassDensity<DataVector>;
+  using Velocity = Tags::Velocity<DataVector, Dim>;
+  using Pressure = Tags::Pressure<DataVector>;
+  using SpecificInternalEnergy = Tags::SpecificInternalEnergy<DataVector>;
+
+  const auto subcell_inertial_coords = (*grid_to_inertial_map)(
+      logical_to_grid_map(subcell_logical_coords), time, functions_of_time);
+
+  auto volume_prims = [&solution, &subcell_inertial_coords, &time]() {
+    return solution.variables(
+        subcell_inertial_coords, time,
+        tmpl::list<MassDensity, Velocity, Pressure, SpecificInternalEnergy>{});
+  }();
+  auto& mass_density = get<MassDensity>(volume_prims);
+  auto& velocity = get<Velocity>(volume_prims);
+  auto& pressure = get<Pressure>(volume_prims);
+  auto& specific_internal_energy = get<SpecificInternalEnergy>(volume_prims);
+
+  using EosType = EquationsOfState::PolytropicFluid<false>;
+  EosType eos_polytrope(0.1, 4.0 / 3.0);
+
+  std::optional<tnsr::I<DataVector, Dim>> volume_mesh_velocity{};
+
+  typename evolution::dg::Tags::NormalCovectorAndMagnitude<Dim>::type
+      normal_vectors{};
+  for (const auto& direction : Direction<Dim>::all_directions()) {
+    const auto coordinate_map =
+        domain::make_coordinate_map<Frame::ElementLogical, Frame::Inertial>(
+            domain::CoordinateMaps::Identity<Dim>{});
+    const auto moving_mesh_map =
+        domain::make_coordinate_map<Frame::Grid, Frame::Inertial>(
+            domain::CoordinateMaps::Identity<Dim>{});
+
+    // Note that we used `subcell_mesh` here, since we need normal vector field
+    // on the `subcell face mesh` to apply outflow condition.
+    const Mesh<Dim - 1> face_mesh =
+        subcell_mesh.slice_away(direction.dimension());
+    const auto face_logical_coords =
+        interface_logical_coordinates(face_mesh, direction);
+    std::unordered_map<Direction<Dim>,
+                       tnsr::i<DataVector, Dim, Frame::Inertial>>
+        unnormalized_normal_covectors{};
+    tnsr::i<DataVector, Dim, Frame::Inertial> unnormalized_covector{};
+    for (size_t i = 0; i < Dim; ++i) {
+      unnormalized_covector.get(i) =
+          coordinate_map.inv_jacobian(face_logical_coords)
+              .get(direction.dimension(), i);
+    }
+    unnormalized_normal_covectors[direction] = unnormalized_covector;
+    Variables<tmpl::list<
+        evolution::dg::Actions::detail::NormalVector<Dim>,
+        evolution::dg::Actions::detail::OneOverNormalVectorMagnitude>>
+        fields_on_face{face_mesh.number_of_grid_points()};
+
+    normal_vectors[direction] = std::nullopt;
+    evolution::dg::Actions::detail::
+        unit_normal_vector_and_covector_and_magnitude<
+            System<Dim, Solutions::SmoothFlow<Dim>>>(
+            make_not_null(&normal_vectors), make_not_null(&fields_on_face),
+            direction, unnormalized_normal_covectors, moving_mesh_map);
+  }
+
+  // create a box
+  auto box = db::create<db::AddSimpleTags<
+      Parallel::Tags::MetavariablesImpl<
+          EvolutionMetaVars<Dim, SolutionForTest>>,
+      domain::Tags::Domain<Dim>, evolution::dg::subcell::Tags::Mesh<Dim>,
+      evolution::dg::subcell::Tags::Coordinates<Dim, Frame::ElementLogical>,
+      evolution::dg::subcell::Tags::NeighborDataForReconstruction<Dim>,
+      fd::Tags::Reconstructor<Dim>, domain::Tags::MeshVelocity<Dim>,
+      evolution::dg::Tags::NormalCovectorAndMagnitude<Dim>, ::Tags::Time,
+      domain::Tags::FunctionsOfTimeInitialize,
+      domain::Tags::ElementMap<Dim, Frame::Grid>,
+      domain::CoordinateMaps::Tags::CoordinateMap<Dim, Frame::Grid,
+                                                  Frame::Inertial>,
+      hydro::Tags::EquationOfState<EosType>,
+      ::Tags::AnalyticSolution<SolutionForTest>, MassDensity, Velocity,
+      Pressure, SpecificInternalEnergy>>(
+      EvolutionMetaVars<Dim, SolutionForTest>{}, std::move(domain),
+      subcell_mesh, subcell_logical_coords, neighbor_data,
+      std::unique_ptr<fd::Reconstructor<Dim>>{
+          std::make_unique<ReconstructorForTest>()},
+      volume_mesh_velocity, normal_vectors, time,
+      clone_unique_ptrs(functions_of_time),
+      ElementMap<Dim, Frame::Grid>{
+          ElementId<Dim>{0},
+          domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
+              domain::CoordinateMaps::Identity<Dim>{})},
+      domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+          domain::CoordinateMaps::Identity<Dim>{}),
+      eos_polytrope, solution, mass_density, velocity, pressure,
+      specific_internal_energy);
+
+  // compute FD ghost data and retrieve the result
+  fd::BoundaryGhostData::apply(make_not_null(&box), element,
+                               ReconstructorForTest{});
+
+  const auto direction = Direction<Dim>::upper_xi();
+  const size_t dim_direction = direction.dimension();
+
+  const std::pair mortar_id = {direction,
+                               ElementId<Dim>::external_boundary_id()};
+  const std::vector<double>& fd_ghost_data =
+      get<evolution::dg::subcell::Tags::NeighborDataForReconstruction<Dim>>(box)
+          .at(mortar_id);
+
+  const size_t ghost_zone_size = ReconstructorForTest{}.ghost_zone_size();
+  const size_t num_face_pts =
+      subcell_mesh.slice_away(0).number_of_grid_points();
+  const size_t num_ghost_pts = num_face_pts * ghost_zone_size;
+
+  // copy the returned std::vector<double> data into a Variables to do checks a
+  // bit easier
+  Variables<tmpl::list<MassDensity, Velocity, Pressure>> fd_ghost_vars{
+      num_ghost_pts};
+  std::copy(fd_ghost_data.begin(), fd_ghost_data.end(), fd_ghost_vars.data());
+
+  // Now we compare results
+  Index<Dim> ghost_data_extents = subcell_mesh.extents();
+  ghost_data_extents[dim_direction] = ghost_zone_size;
+
+  if (typeid(BoundaryConditionType) ==
+      typeid(BoundaryConditions::DirichletAnalytic<Dim>)) {
+    // Slice subcell logical coordinates and shift it to get inertial
+    // coordinates of ghost points
+    auto sliced_logical_coords =
+        evolution::dg::subcell::slice_tensor_for_subcell(
+            subcell_logical_coords, subcell_mesh.extents(), ghost_zone_size,
+            direction);
+    const double delta_x{get<0>(subcell_logical_coords)[1] -
+                         get<0>(subcell_logical_coords)[0]};
+    sliced_logical_coords.get(dim_direction) =
+        sliced_logical_coords.get(dim_direction) +
+        direction.sign() * delta_x * ghost_zone_size;
+    const auto shifted_inertial_coords = (*grid_to_inertial_map)(
+        logical_to_grid_map(sliced_logical_coords), time, functions_of_time);
+
+    // Compute analytic solution
+    auto expected_ghost_prims = [&shifted_inertial_coords, &solution, &time]() {
+      return solution.variables(shifted_inertial_coords, time,
+                                tmpl::list<MassDensity, Velocity, Pressure>{});
+    }();
+
+    // Check results
+    tmpl::for_each<tmpl::list<MassDensity, Velocity, Pressure>>(
+        [&expected_ghost_prims, &fd_ghost_vars](auto tag_v) {
+          using tag = tmpl::type_from<decltype(tag_v)>;
+          CHECK_ITERABLE_APPROX(get<tag>(expected_ghost_prims),
+                                get<tag>(fd_ghost_vars));
+        });
+  }
+  if (typeid(BoundaryConditionType) ==
+      typeid(BoundaryConditions::Reflection<Dim>)) {
+    // Invert the normal component of velocity.
+    velocity.get(dim_direction) =
+        velocity.get(dim_direction) - direction.sign() * 2.0;
+
+    tmpl::for_each<tmpl::list<MassDensity, Velocity, Pressure>>(
+        [&dim_direction, &fd_ghost_vars, &ghost_data_extents, &ghost_zone_size,
+         &subcell_mesh, &volume_prims](auto tag_v) {
+          using tag = tmpl::type_from<decltype(tag_v)>;
+
+          for (size_t i_ghost = 0; i_ghost < ghost_zone_size; ++i_ghost) {
+            // i-th slice of ghost data
+            auto i_th_slice_ghost =
+                data_on_slice(get<tag>(fd_ghost_vars), ghost_data_extents,
+                              dim_direction, i_ghost);
+
+            // (n-i)-th slice of volume data where n is the extent of subcell
+            // mesh along the `direction`. This is the i-th slice when counted
+            // from the external boundary.
+            auto n_minus_i_th_slice_volume = data_on_slice(
+                get<tag>(volume_prims), subcell_mesh.extents(), dim_direction,
+                subcell_mesh.extents(dim_direction) - i_ghost - 1);
+
+            // Check results
+            CHECK(i_th_slice_ghost == n_minus_i_th_slice_volume);
+          }
+        });
+  }
+  if (typeid(BoundaryConditionType) ==
+      typeid(BoundaryConditions::Outflow<Dim>)) {
+    tmpl::for_each<tmpl::list<MassDensity, Velocity, Pressure>>(
+        [&dim_direction, &fd_ghost_vars, &ghost_data_extents, &ghost_zone_size,
+         &subcell_mesh, &volume_prims](auto tag_v) {
+          using tag = tmpl::type_from<decltype(tag_v)>;
+
+          for (size_t i_ghost = 0; i_ghost < ghost_zone_size; ++i_ghost) {
+            // i-th slice of ghost data
+            auto i_th_slice_ghost =
+                data_on_slice(get<tag>(fd_ghost_vars), ghost_data_extents,
+                              dim_direction, i_ghost);
+
+            // n-th slice of volume data where n is the extent of subcell
+            // mesh along the `direction`. This is the data on the outermost FD
+            // cell.
+            auto n_th_slice_volume = data_on_slice(
+                get<tag>(volume_prims), subcell_mesh.extents(), dim_direction,
+                subcell_mesh.extents(dim_direction) - 1);
+
+            // Check results
+            CHECK(i_th_slice_ghost == n_th_slice_volume);
+          }
+        });
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.NewtonianEuler.Fd.BoundaryGhostData",
+                  "[Unit][Evolution]") {
+  test<1>(BoundaryConditions::DirichletAnalytic<1>{});
+  test<2>(BoundaryConditions::DirichletAnalytic<2>{});
+  test<3>(BoundaryConditions::DirichletAnalytic<3>{});
+
+  test<1>(BoundaryConditions::Reflection<1>{});
+  test<2>(BoundaryConditions::Reflection<2>{});
+  test<3>(BoundaryConditions::Reflection<3>{});
+
+  test<1>(BoundaryConditions::Outflow<1>{});
+  test<2>(BoundaryConditions::Outflow<2>{});
+  test<3>(BoundaryConditions::Outflow<3>{});
+}
+}  // namespace
+}  // namespace NewtonianEuler


### PR DESCRIPTION
## Proposed changes

Enable using subcell on external boundary elements for NE system.

First two commits are from following dependent PRs:
- [ ] #3814 
- [ ] #3826 

Works in this PR mainly follows that of #3746 ; I will update this one corresponding to the proposed changes from the code review of #3746. 


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

