### PR TITLE
Added Ability to Observe Constraint Energy to BBH

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -273,12 +273,17 @@ struct EvolutionMetavars {
   using observe_fields = tmpl::append<
       tmpl::list<gr::Tags::Lapse<DataVector>,
                  GeneralizedHarmonic::Tags::GaugeConstraintCompute<
+                                       volume_dim, ::Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::TwoIndexConstraintCompute<
                      volume_dim, ::Frame::Inertial>,
                  GeneralizedHarmonic::Tags::ThreeIndexConstraintCompute<
                      volume_dim, ::Frame::Inertial>,
                  // following tags added to observe constraints
                  ::Tags::PointwiseL2NormCompute<
                      GeneralizedHarmonic::Tags::GaugeConstraint<
+                         volume_dim, ::Frame::Inertial>>,
+                 ::Tags::PointwiseL2NormCompute<
+                     GeneralizedHarmonic::Tags::TwoIndexConstraint<
                          volume_dim, ::Frame::Inertial>>,
                  ::Tags::PointwiseL2NormCompute<
                      GeneralizedHarmonic::Tags::ThreeIndexConstraint<
@@ -288,11 +293,19 @@ struct EvolutionMetavars {
       // The 4-index constraint is only implemented in 3d
       tmpl::conditional_t<
           volume_dim == 3,
-          tmpl::list<GeneralizedHarmonic::Tags::FourIndexConstraintCompute<
+          tmpl::list<
+              GeneralizedHarmonic::Tags::FourIndexConstraintCompute<
                          3, ::Frame::Inertial>,
-                     ::Tags::PointwiseL2NormCompute<
-                         GeneralizedHarmonic::Tags::FourIndexConstraint<
-                             3, ::Frame::Inertial>>>,
+              GeneralizedHarmonic::Tags::FConstraintCompute<
+                         3, ::Frame::Inertial>,
+              ::Tags::PointwiseL2NormCompute<
+                  GeneralizedHarmonic::Tags::FConstraint<
+                         3, ::Frame::Inertial>>,
+              ::Tags::PointwiseL2NormCompute<
+                  GeneralizedHarmonic::Tags::FourIndexConstraint<
+                         3, ::Frame::Inertial>>,
+              GeneralizedHarmonic::Tags::ConstraintEnergyCompute<
+                         3, ::Frame::Inertial>>,
           tmpl::list<>>>;
   using non_tensor_compute_tags =
       tmpl::list<::Events::Tags::ObserverMeshCompute<volume_dim>>;


### PR DESCRIPTION
## Proposed changes

Same thing as PR #3855 except now adding it to BBH executable.

### Upgrade instructions

Any projects using EvolveGhBinaryBlackHoles will have to rebuild if they want to
observe the Constraint Energy.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
