### PR TITLE
Add abutting directions to excision spheres

### DIFF
--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -514,18 +514,44 @@ Domain<3> BinaryCompactObject::create_domain() const {
               translation_B));
     }
   }
+
+  // Excision spheres
+  // - Block 0 through 5 enclose object A, and 12 through 17 enclose object B.
+  // - The 3D wedge map is oriented such that the lower-zeta logical direction
+  //   points radially inward.
+  std::unordered_map<std::string, ExcisionSphere<3>> excision_spheres{};
+  if (object_A_.is_excised()) {
+    excision_spheres.emplace(
+        "ObjectAExcisionSphere",
+        ExcisionSphere<3>{object_A_.inner_radius,
+                          {{object_A_.x_coord, 0.0, 0.0}},
+                          {{0, Direction<3>::lower_zeta()},
+                           {1, Direction<3>::lower_zeta()},
+                           {2, Direction<3>::lower_zeta()},
+                           {3, Direction<3>::lower_zeta()},
+                           {4, Direction<3>::lower_zeta()},
+                           {5, Direction<3>::lower_zeta()}}});
+  }
+  if (object_B_.is_excised()) {
+    excision_spheres.emplace(
+        "ObjectBExcisionSphere",
+        ExcisionSphere<3>{object_B_.inner_radius,
+                          {{object_B_.x_coord, 0.0, 0.0}},
+                          {{12, Direction<3>::lower_zeta()},
+                           {13, Direction<3>::lower_zeta()},
+                           {14, Direction<3>::lower_zeta()},
+                           {15, Direction<3>::lower_zeta()},
+                           {16, Direction<3>::lower_zeta()},
+                           {17, Direction<3>::lower_zeta()}}});
+  }
+
   Domain<3> domain{
       std::move(maps),
       corners_for_biradially_layered_domains(2, 3, not object_A_.is_excised(),
                                              not object_B_.is_excised()),
       {},
       std::move(boundary_conditions_all_blocks),
-      {{"ObjectAExcisionSphere",
-        ExcisionSphere<3>{object_A_.inner_radius,
-                          {{object_A_.x_coord, 0.0, 0.0}}}},
-       {"ObjectBExcisionSphere",
-        ExcisionSphere<3>{object_B_.inner_radius,
-                          {{object_B_.x_coord, 0.0, 0.0}}}}}};
+      std::move(excision_spheres)};
 
   // Inject the hard-coded time-dependence
   if (enable_time_dependence_) {

--- a/src/Domain/Creators/Shell.cpp
+++ b/src/Domain/Creators/Shell.cpp
@@ -170,14 +170,29 @@ Domain<3> Shell::create_domain() const {
     }
   }
 
+  // Excision spheres
+  // - The first 6 blocks enclose the excised sphere, see
+  //   sph_wedge_coordinate_maps
+  // - The 3D wedge map is oriented such that the lower-zeta logical direction
+  //   points radially inward.
+  std::unordered_map<std::string, ExcisionSphere<3>> excision_spheres{
+      {"CentralExcisionSphere",
+       ExcisionSphere<3>{inner_radius_,
+                         {{0.0, 0.0, 0.0}},
+                         {{0, Direction<3>::lower_zeta()},
+                          {1, Direction<3>::lower_zeta()},
+                          {2, Direction<3>::lower_zeta()},
+                          {3, Direction<3>::lower_zeta()},
+                          {4, Direction<3>::lower_zeta()},
+                          {5, Direction<3>::lower_zeta()}}}}};
+
   Domain<3> domain{
       std::move(coord_maps),
       corners_for_radially_layered_domains(
           number_of_layers_, false, {{1, 2, 3, 4, 5, 6, 7, 8}}, which_wedges_),
       {},
       std::move(boundary_conditions_all_blocks),
-      {{"CentralExcisionSphere",
-        ExcisionSphere<3>{inner_radius_, {{0.0, 0.0, 0.0}}}}}};
+      std::move(excision_spheres)};
 
   if (not time_dependence_->is_none()) {
     const size_t number_of_blocks = domain.blocks().size();

--- a/src/Domain/Structure/ExcisionSphere.cpp
+++ b/src/Domain/Structure/ExcisionSphere.cpp
@@ -3,18 +3,24 @@
 
 #include "Domain/Structure/ExcisionSphere.hpp"
 
+#include <cstddef>
 #include <ostream>
 #include <pup.h>  // IWYU pragma: keep
 #include <pup_stl.h>
+#include <unordered_map>
 
+#include "Domain/Structure/Direction.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
 
 template <size_t VolumeDim>
 ExcisionSphere<VolumeDim>::ExcisionSphere(
-    const double radius, const std::array<double, VolumeDim> center)
-    : radius_(radius), center_(center) {
+    const double radius, const std::array<double, VolumeDim> center,
+    std::unordered_map<size_t, Direction<VolumeDim>> abutting_directions)
+    : radius_(radius),
+      center_(center),
+      abutting_directions_(std::move(abutting_directions)) {
   ASSERT(radius_ > 0.0,
          "The ExcisionSphere must have a radius greater than zero.");
 }
@@ -23,12 +29,14 @@ template <size_t VolumeDim>
 void ExcisionSphere<VolumeDim>::pup(PUP::er& p) {
   p | radius_;
   p | center_;
+  p | abutting_directions_;
 }
 
 template <size_t VolumeDim>
 bool operator==(const ExcisionSphere<VolumeDim>& lhs,
                 const ExcisionSphere<VolumeDim>& rhs) {
-  return lhs.radius() == rhs.radius() and lhs.center() == rhs.center();
+  return lhs.radius() == rhs.radius() and lhs.center() == rhs.center() and
+         lhs.abutting_directions() == rhs.abutting_directions();
 }
 
 template <size_t VolumeDim>
@@ -43,6 +51,7 @@ std::ostream& operator<<(std::ostream& os,
   os << "ExcisionSphere:\n";
   os << "  Radius: " << sphere.radius() << "\n";
   os << "  Center: " << sphere.center() << "\n";
+  os << "  Abutting directions: " << sphere.abutting_directions() << "\n";
   return os;
 }
 

--- a/src/Domain/Structure/ExcisionSphere.hpp
+++ b/src/Domain/Structure/ExcisionSphere.hpp
@@ -10,7 +10,9 @@
 #include <cstddef>
 #include <iosfwd>
 #include <limits>
+#include <unordered_map>
 
+#include "Domain/Structure/Direction.hpp"
 #include "Utilities/MakeArray.hpp"
 
 /// \cond
@@ -34,7 +36,11 @@ class ExcisionSphere {
   /// computational domain.
   /// \param center the coordinate center of the excision sphere
   /// in the computational domain.
-  ExcisionSphere(double radius, std::array<double, VolumeDim> center);
+  /// \param abutting_directions the set of blocks that touch the excision
+  /// sphere, along with the direction in which they touch it.
+  ExcisionSphere(
+      double radius, std::array<double, VolumeDim> center,
+      std::unordered_map<size_t, Direction<VolumeDim>> abutting_directions);
 
   /// Default constructor needed for Charm++ serialization.
   ExcisionSphere() = default;
@@ -52,6 +58,13 @@ class ExcisionSphere {
   /// The coodinate center of the ExcisionSphere.
   const std::array<double, VolumeDim>& center() const { return center_; }
 
+  /// The set of blocks that touch the excision sphere, along with the direction
+  /// in which they touch it
+  const std::unordered_map<size_t, Direction<VolumeDim>>& abutting_directions()
+      const {
+    return abutting_directions_;
+  }
+
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p);
 
@@ -59,6 +72,7 @@ class ExcisionSphere {
   double radius_{std::numeric_limits<double>::signaling_NaN()};
   std::array<double, VolumeDim> center_{
       make_array<VolumeDim>(std::numeric_limits<double>::signaling_NaN())};
+  std::unordered_map<size_t, Direction<VolumeDim>> abutting_directions_{};
 };
 
 template <size_t VolumeDim>

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -308,14 +308,34 @@ void test_connectivity() {
           }
           CHECK(binary_compact_object.block_names() == expected_block_names);
           CHECK(binary_compact_object.block_groups() == expected_block_groups);
+          std::unordered_map<std::string, ExcisionSphere<3>>
+              expected_excision_spheres{};
+          if (excise_interiorA) {
+            expected_excision_spheres.emplace(
+                "ObjectAExcisionSphere",
+                ExcisionSphere<3>{inner_radius_objectA,
+                                  {{xcoord_objectA, 0.0, 0.0}},
+                                  {{0, Direction<3>::lower_zeta()},
+                                   {1, Direction<3>::lower_zeta()},
+                                   {2, Direction<3>::lower_zeta()},
+                                   {3, Direction<3>::lower_zeta()},
+                                   {4, Direction<3>::lower_zeta()},
+                                   {5, Direction<3>::lower_zeta()}}});
+          }
+          if (excise_interiorB) {
+            expected_excision_spheres.emplace(
+                "ObjectBExcisionSphere",
+                ExcisionSphere<3>{inner_radius_objectB,
+                                  {{xcoord_objectB, 0.0, 0.0}},
+                                  {{12, Direction<3>::lower_zeta()},
+                                   {13, Direction<3>::lower_zeta()},
+                                   {14, Direction<3>::lower_zeta()},
+                                   {15, Direction<3>::lower_zeta()},
+                                   {16, Direction<3>::lower_zeta()},
+                                   {17, Direction<3>::lower_zeta()}}});
+          }
           CHECK(binary_compact_object.create_domain().excision_spheres() ==
-                std::unordered_map<std::string, ExcisionSphere<3>>{
-                    {"ObjectAExcisionSphere",
-                     ExcisionSphere<3>{inner_radius_objectA,
-                                       {{xcoord_objectA, 0.0, 0.0}}}},
-                    {"ObjectBExcisionSphere",
-                     ExcisionSphere<3>{inner_radius_objectB,
-                                       {{xcoord_objectB, 0.0, 0.0}}}}});
+                expected_excision_spheres);
 
           test_binary_compact_object_construction(
               binary_compact_object,

--- a/tests/Unit/Domain/Creators/Test_Shell.cpp
+++ b/tests/Unit/Domain/Creators/Test_Shell.cpp
@@ -383,7 +383,14 @@ void test_shell_construction(
   CHECK(domain.excision_spheres() ==
         std::unordered_map<std::string, ExcisionSphere<3>>{
             {"CentralExcisionSphere",
-             ExcisionSphere<3>{inner_radius, {{0.0, 0.0, 0.0}}}}});
+             ExcisionSphere<3>{inner_radius,
+                               {{0.0, 0.0, 0.0}},
+                               {{0, Direction<3>::lower_zeta()},
+                                {1, Direction<3>::lower_zeta()},
+                                {2, Direction<3>::lower_zeta()},
+                                {3, Direction<3>::lower_zeta()},
+                                {4, Direction<3>::lower_zeta()},
+                                {5, Direction<3>::lower_zeta()}}}}});
 
   test_initial_domain(domain, shell.initial_refinement_levels());
   TestHelpers::domain::creators::test_functions_of_time(

--- a/tests/Unit/Domain/Structure/Test_ExcisionSphere.cpp
+++ b/tests/Unit/Domain/Structure/Test_ExcisionSphere.cpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <functional>
 
+#include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/ExcisionSphere.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Utilities/GetOutput.hpp"
@@ -13,18 +14,22 @@
 
 namespace {
 template <size_t VolumeDim>
-void check_excision_sphere_work(const double radius,
-                                const std::array<double, VolumeDim> center) {
-  const ExcisionSphere<VolumeDim> excision_sphere(radius, center);
+void check_excision_sphere_work(
+    const double radius, const std::array<double, VolumeDim> center,
+    const std::unordered_map<size_t, Direction<VolumeDim>>&
+        abutting_directions) {
+  const ExcisionSphere<VolumeDim> excision_sphere(radius, center,
+                                                  abutting_directions);
 
   CHECK(excision_sphere.radius() == radius);
   CHECK(excision_sphere.center() == center);
+  CHECK(excision_sphere.abutting_directions() == abutting_directions);
   CHECK(excision_sphere == excision_sphere);
   CHECK_FALSE(excision_sphere != excision_sphere);
 
   const double diff_radius = 0.001;
-  const ExcisionSphere<VolumeDim> excision_sphere_diff_radius(diff_radius,
-                                                              center);
+  const ExcisionSphere<VolumeDim> excision_sphere_diff_radius(
+      diff_radius, center, abutting_directions);
   CHECK(excision_sphere != excision_sphere_diff_radius);
   CHECK_FALSE(excision_sphere == excision_sphere_diff_radius);
 
@@ -34,7 +39,10 @@ void check_excision_sphere_work(const double radius,
             get_output(excision_sphere.radius()) +
             "\n"
             "  Center: " +
-            get_output(excision_sphere.center()) + "\n");
+            get_output(excision_sphere.center()) +
+            "\n"
+            "  Abutting directions: " +
+            get_output(excision_sphere.abutting_directions()) + "\n");
 
   test_serialization(excision_sphere);
 }
@@ -42,19 +50,25 @@ void check_excision_sphere_work(const double radius,
 void check_excision_sphere_1d() {
   const double radius = 1.2;
   const std::array<double, 1> center = {{5.4}};
-  check_excision_sphere_work<1>(radius, center);
+  check_excision_sphere_work<1>(
+      radius, center,
+      {{0, Direction<1>::lower_xi()}, {2, Direction<1>::upper_xi()}});
 }
 
 void check_excision_sphere_2d() {
   const double radius = 4.2;
   const std::array<double, 2> center = {{5.4, -2.3}};
-  check_excision_sphere_work<2>(radius, center);
+  check_excision_sphere_work<2>(
+      radius, center,
+      {{0, Direction<2>::lower_eta()}, {2, Direction<2>::upper_xi()}});
 }
 
 void check_excision_sphere_3d() {
   const double radius = 5.2;
   const std::array<double, 3> center = {{5.4, -2.3, 9.0}};
-  check_excision_sphere_work<3>(radius, center);
+  check_excision_sphere_work<3>(
+      radius, center,
+      {{0, Direction<3>::lower_xi()}, {2, Direction<3>::upper_zeta()}});
 }
 
 }  // namespace
@@ -70,7 +84,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.ExcisionSphere", "[Domain][Unit]") {
                                "[Domain][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  auto failed_excision_sphere = ExcisionSphere<3>(-2.0, {{3.4, 1.2, -0.9}});
+  auto failed_excision_sphere = ExcisionSphere<3>(-2.0, {{3.4, 1.2, -0.9}}, {});
   static_cast<void>(failed_excision_sphere);
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif


### PR DESCRIPTION
## Proposed changes

This is the information needed to figure out which elements face the excision boundary. Used for interpolations from element faces to a Strahlkorper representing the excision.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
