### PR TITLE
Make observing from singletons easier

### DIFF
--- a/docs/DevGuide/Observers.md
+++ b/docs/DevGuide/Observers.md
@@ -58,16 +58,15 @@ the input file using the option
 through the reductions.
 
 The actions used for registering reductions are
-`observers::Actions::RegisterEventsWithObservers`,
-`observers::Actions::RegisterSingletonWithObserverWriter`, and
+`observers::Actions::RegisterEventsWithObservers` and
 `observers::Actions::RegisterWithObservers`. There is a separate `Registration`
 phase at the beginning of all simulations where everything must register with
 the observers. The action `observers::Actions::ContributeReductionData` is used
 to send data to the `observers::Observer` component in the case where there is a
 reduction done across an array or subset of an array. If a singleton parallel
-component needs to write data directly to disk it should use the
-`observers::ThreadedActions::WriteReductionData` action called on the zeroth
-element of the `observers::ObserverWriter` component.
+component or a specific chare needs to write data directly to disk it should use
+the `observers::ThreadedActions::WriteReductionDataRow` action called on the
+zeroth element of the `observers::ObserverWriter` component.
 
 ### Volume Data
 

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ConjugateGradient.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ConjugateGradient.hpp
@@ -5,11 +5,9 @@
 
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
-#include "IO/Observer/Helpers.hpp"
 #include "ParallelAlgorithms/LinearSolver/ConjugateGradient/ElementActions.hpp"
 #include "ParallelAlgorithms/LinearSolver/ConjugateGradient/InitializeElement.hpp"
 #include "ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp"
-#include "ParallelAlgorithms/LinearSolver/Observe.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// Items related to the conjugate gradient linear solver
@@ -84,9 +82,6 @@ struct ConjugateGradient {
   using initialize_element = detail::InitializeElement<FieldsTag, OptionsGroup>;
 
   using register_element = tmpl::list<>;
-
-  using observed_reduction_data_tags = observers::make_reduction_data_tags<
-      tmpl::list<observe_detail::reduction_data>>;
 
   template <typename ApplyOperatorActions, typename Label = OptionsGroup>
   using solve = tmpl::list<

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp
@@ -11,7 +11,6 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "IO/Logging/Tags.hpp"
-#include "IO/Observer/Actions/RegisterSingleton.hpp"
 #include "NumericalAlgorithms/Convergence/Tags.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Algorithms/AlgorithmSingleton.hpp"
@@ -19,7 +18,6 @@
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
-#include "ParallelAlgorithms/LinearSolver/Observe.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -47,16 +45,10 @@ struct ResidualMonitor {
   // on this component as the result of reductions from the actions in
   // `ElementActions.hpp`. See `LinearSolver::cg::ConjugateGradient` for
   // details.
-  using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<::Actions::SetupDataBox,
-                     InitializeResidualMonitor<FieldsTag, OptionsGroup>>>,
-      Parallel::PhaseActions<
-          typename Metavariables::Phase,
-          Metavariables::Phase::RegisterWithObserver,
-          tmpl::list<observers::Actions::RegisterSingletonWithObserverWriter<
-              LinearSolver::observe_detail::Registration<OptionsGroup>>>>>;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      tmpl::list<::Actions::SetupDataBox,
+                 InitializeResidualMonitor<FieldsTag, OptionsGroup>>>>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp
@@ -5,11 +5,9 @@
 
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
-#include "IO/Observer/Helpers.hpp"
 #include "ParallelAlgorithms/LinearSolver/Gmres/ElementActions.hpp"
 #include "ParallelAlgorithms/LinearSolver/Gmres/InitializeElement.hpp"
 #include "ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp"
-#include "ParallelAlgorithms/LinearSolver/Observe.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -127,9 +125,6 @@ struct Gmres {
       detail::InitializeElement<FieldsTag, OptionsGroup, Preconditioned>;
 
   using register_element = tmpl::list<>;
-
-  using observed_reduction_data_tags = observers::make_reduction_data_tags<
-      tmpl::list<observe_detail::reduction_data>>;
 
   template <typename ApplyOperatorActions, typename Label = OptionsGroup>
   using solve = tmpl::list<

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp
@@ -10,7 +10,6 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "IO/Logging/Tags.hpp"
-#include "IO/Observer/Actions/RegisterSingleton.hpp"
 #include "NumericalAlgorithms/Convergence/Tags.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Algorithms/AlgorithmSingleton.hpp"
@@ -18,7 +17,6 @@
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
-#include "ParallelAlgorithms/LinearSolver/Observe.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -45,16 +43,10 @@ struct ResidualMonitor {
   // The actions in `ResidualMonitorActions.hpp` are invoked as simple actions
   // on this component as the result of reductions from the actions in
   // `ElementActions.hpp`. See `LinearSolver::gmres::Gmres` for details.
-  using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<::Actions::SetupDataBox,
-                     InitializeResidualMonitor<FieldsTag, OptionsGroup>>>,
-      Parallel::PhaseActions<
-          typename Metavariables::Phase,
-          Metavariables::Phase::RegisterWithObserver,
-          tmpl::list<observers::Actions::RegisterSingletonWithObserverWriter<
-              LinearSolver::observe_detail::Registration<OptionsGroup>>>>>;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      tmpl::list<::Actions::SetupDataBox,
+                 InitializeResidualMonitor<FieldsTag, OptionsGroup>>>>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 

--- a/src/ParallelAlgorithms/LinearSolver/Observe.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Observe.hpp
@@ -5,41 +5,19 @@
 
 #include <cstddef>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
-#include "IO/Observer/ObservationId.hpp"
 #include "IO/Observer/ObserverComponent.hpp"
 #include "IO/Observer/ReductionActions.hpp"
-#include "IO/Observer/TypeOfObservation.hpp"
 #include "Parallel/GlobalCache.hpp"
-#include "Parallel/Info.hpp"
 #include "Parallel/Invoke.hpp"
-#include "Parallel/Reduction.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
 #include "Utilities/Functional.hpp"
-#include "Utilities/PrettyType.hpp"
 
 namespace LinearSolver {
 namespace observe_detail {
-
-using reduction_data = Parallel::ReductionData<
-    // Iteration
-    Parallel::ReductionDatum<size_t, funcl::AssertEqual<>>,
-    // Residual
-    Parallel::ReductionDatum<double, funcl::AssertEqual<>>>;
-
-template <typename OptionsGroup>
-struct Registration {
-  template <typename ParallelComponent, typename DbTagsList,
-            typename ArrayIndex>
-  static std::pair<observers::TypeOfObservation, observers::ObservationKey>
-  register_info(const db::DataBox<DbTagsList>& /*box*/,
-                const ArrayIndex& /*array_index*/) {
-    return {observers::TypeOfObservation::Reduction,
-            observers::ObservationKey{pretty_type::get_name<OptionsGroup>()}};
-  }
-};
 
 /*!
  * \brief Contributes data from the residual monitor to the reduction observer
@@ -49,22 +27,18 @@ template <typename OptionsGroup, typename ParallelComponent,
 void contribute_to_reduction_observer(
     const size_t iteration_id, const double residual_magnitude,
     Parallel::GlobalCache<Metavariables>& cache) {
-  const auto observation_id = observers::ObservationId(
-      iteration_id, pretty_type::get_name<OptionsGroup>());
   auto& reduction_writer = Parallel::get_parallel_component<
       observers::ObserverWriter<Metavariables>>(cache);
-  auto& my_proxy = Parallel::get_parallel_component<ParallelComponent>(cache);
-  Parallel::threaded_action<observers::ThreadedActions::WriteReductionData>(
+  Parallel::threaded_action<observers::ThreadedActions::WriteReductionDataRow>(
       // Node 0 is always the writer, so directly call the component on that
       // node
-      reduction_writer[0], observation_id,
-      static_cast<size_t>(Parallel::my_node(*my_proxy.ckLocal())),
+      reduction_writer[0],
       // When multiple linear solves are performed, e.g. for the nonlinear
       // solver, we'll need to write into separate subgroups, e.g.:
       // `/linear_residuals/<nonlinear_iteration_id>`
       std::string{"/" + Options::name<OptionsGroup>() + "Residuals"},
       std::vector<std::string>{"Iteration", "Residual"},
-      reduction_data{iteration_id, residual_magnitude});
+      std::make_tuple(iteration_id, residual_magnitude));
 }
 
 }  // namespace observe_detail

--- a/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/NewtonRaphson.hpp
+++ b/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/NewtonRaphson.hpp
@@ -5,10 +5,8 @@
 
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
-#include "IO/Observer/Helpers.hpp"
 #include "ParallelAlgorithms/NonlinearSolver/NewtonRaphson/ElementActions.hpp"
 #include "ParallelAlgorithms/NonlinearSolver/NewtonRaphson/ResidualMonitor.hpp"
-#include "ParallelAlgorithms/NonlinearSolver/Observe.hpp"
 #include "ParallelAlgorithms/NonlinearSolver/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -100,9 +98,6 @@ struct NewtonRaphson {
       detail::InitializeElement<FieldsTag, OptionsGroup, SourceTag>;
 
   using register_element = tmpl::list<>;
-
-  using observed_reduction_data_tags = observers::make_reduction_data_tags<
-      tmpl::list<NonlinearSolver::observe_detail::reduction_data>>;
 
   template <typename ApplyNonlinearOperator, typename SolveLinearization,
             typename ObserveActions = tmpl::list<>,

--- a/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/ResidualMonitor.hpp
+++ b/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/ResidualMonitor.hpp
@@ -8,14 +8,12 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "IO/Logging/Tags.hpp"
-#include "IO/Observer/Actions/RegisterSingleton.hpp"
 #include "NumericalAlgorithms/Convergence/Tags.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Algorithms/AlgorithmSingleton.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
-#include "ParallelAlgorithms/NonlinearSolver/Observe.hpp"
 #include "ParallelAlgorithms/NonlinearSolver/Tags.hpp"
 
 /// \cond
@@ -40,16 +38,10 @@ struct ResidualMonitor {
                  NonlinearSolver::Tags::SufficientDecrease<OptionsGroup>,
                  NonlinearSolver::Tags::MaxGlobalizationSteps<OptionsGroup>>;
   using metavariables = Metavariables;
-  using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<::Actions::SetupDataBox,
-                     InitializeResidualMonitor<FieldsTag, OptionsGroup>>>,
-      Parallel::PhaseActions<
-          typename Metavariables::Phase,
-          Metavariables::Phase::RegisterWithObserver,
-          tmpl::list<observers::Actions::RegisterSingletonWithObserverWriter<
-              NonlinearSolver::observe_detail::Registration<OptionsGroup>>>>>;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      tmpl::list<::Actions::SetupDataBox,
+                 InitializeResidualMonitor<FieldsTag, OptionsGroup>>>>;
 
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;

--- a/src/ParallelAlgorithms/NonlinearSolver/Observe.hpp
+++ b/src/ParallelAlgorithms/NonlinearSolver/Observe.hpp
@@ -5,43 +5,19 @@
 
 #include <cstddef>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
-#include "IO/Observer/ObservationId.hpp"
 #include "IO/Observer/ObserverComponent.hpp"
 #include "IO/Observer/ReductionActions.hpp"
-#include "IO/Observer/TypeOfObservation.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Reduction.hpp"
 #include "Utilities/Functional.hpp"
-#include "Utilities/PrettyType.hpp"
 #include "Utilities/System/ParallelInfo.hpp"
 
 namespace NonlinearSolver::observe_detail {
-
-using reduction_data = Parallel::ReductionData<
-    // Iteration
-    Parallel::ReductionDatum<size_t, funcl::AssertEqual<>>,
-    // Globalization step
-    Parallel::ReductionDatum<size_t, funcl::AssertEqual<>>,
-    // Residual
-    Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
-    // Step length
-    Parallel::ReductionDatum<double, funcl::AssertEqual<>>>;
-
-template <typename OptionsGroup>
-struct Registration {
-  template <typename ParallelComponent, typename DbTagsList,
-            typename ArrayIndex>
-  static std::pair<observers::TypeOfObservation, observers::ObservationKey>
-  register_info(const db::DataBox<DbTagsList>& /*box*/,
-                const ArrayIndex& /*array_index*/) {
-    return {observers::TypeOfObservation::Reduction,
-            observers::ObservationKey{pretty_type::get_name<OptionsGroup>()}};
-  }
-};
 
 /*!
  * \brief Contributes data from the residual monitor to the reduction observer
@@ -52,21 +28,17 @@ void contribute_to_reduction_observer(
     const size_t iteration_id, const size_t globalization_iteration_id,
     const double residual_magnitude, const double step_length,
     Parallel::GlobalCache<Metavariables>& cache) {
-  const auto observation_id = observers::ObservationId(
-      iteration_id, pretty_type::get_name<OptionsGroup>());
   auto& reduction_writer = Parallel::get_parallel_component<
       observers::ObserverWriter<Metavariables>>(cache);
-  auto& my_proxy = Parallel::get_parallel_component<ParallelComponent>(cache);
-  Parallel::threaded_action<observers::ThreadedActions::WriteReductionData>(
+  Parallel::threaded_action<observers::ThreadedActions::WriteReductionDataRow>(
       // Node 0 is always the writer, so directly call the component on that
       // node
-      reduction_writer[0], observation_id,
-      static_cast<size_t>(Parallel::my_node(*my_proxy.ckLocal())),
+      reduction_writer[0],
       std::string{"/" + Options::name<OptionsGroup>() + "Residuals"},
       std::vector<std::string>{"Iteration", "GlobalizationStep", "Residual",
                                "StepLength"},
-      reduction_data{iteration_id, globalization_iteration_id,
-                     residual_magnitude, step_length});
+      std::make_tuple(iteration_id, globalization_iteration_id,
+                      residual_magnitude, step_length));
 }
 
 }  // namespace NonlinearSolver::observe_detail

--- a/tests/Unit/IO/Observers/Test_ReductionObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_ReductionObserver.cpp
@@ -267,6 +267,16 @@ void test_reduction_observer(const bool observe_per_core) {
             observe_per_core);
     REQUIRE(file_system::check_if_file_exists(output_file_prefix + "1.h5") ==
             observe_per_core);
+
+    // Invoke the WriteReductionDataRow action to write a single row of
+    // data
+    std::vector<double> single_row_of_data(legend.size() - 2);
+    std::iota(single_row_of_data.begin(), single_row_of_data.end(), 2.);
+    runner.threaded_action<obs_writer,
+                           observers::ThreadedActions::WriteReductionDataRow>(
+        0, "/element_data", legend,
+        std::make_tuple(0., 1., single_row_of_data));
+
     // Check that the H5 file was written correctly.
     {
       const auto file = h5::H5File<h5::AccessType::ReadOnly>(h5_file_name);
@@ -331,6 +341,11 @@ void test_reduction_observer(const bool observe_per_core) {
           CHECK(std::get<4>(expected)[i] == approx(written_data(0, i + 5)));
         }
         CHECK(std::get<5>(expected) == approx(written_data(0, 7)));
+      }
+
+      // Check row of data written by WriteReductionDataRow
+      for (size_t i = 0; i < legend.size(); ++i) {
+        CHECK(written_data(1, i) == i);
       }
     }
     // Check the per-core H5 files were written correctly. Only check the

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ResidualMonitorActions.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ResidualMonitorActions.cpp
@@ -157,9 +157,6 @@ SPECTRE_TEST_CASE(
                         TestLinearSolver>{})
                     .at(0));
     // Test observer writer state
-    CHECK(
-        get_observer_writer_tag(helpers::CheckObservationIdTag{}) ==
-        observers::ObservationId{0, "(anonymous namespace)::TestLinearSolver"});
     CHECK(get_observer_writer_tag(helpers::CheckSubfileNameTag{}) ==
           "/TestLinearSolverResiduals");
     CHECK(get_observer_writer_tag(helpers::CheckReductionNamesTag{}) ==
@@ -228,9 +225,6 @@ SPECTRE_TEST_CASE(
     const auto& has_converged = get<1>(element_inbox);
     CHECK_FALSE(has_converged);
     // Test observer writer state
-    CHECK(
-        get_observer_writer_tag(helpers::CheckObservationIdTag{}) ==
-        observers::ObservationId{1, "(anonymous namespace)::TestLinearSolver"});
     CHECK(get_observer_writer_tag(helpers::CheckSubfileNameTag{}) ==
           "/TestLinearSolverResiduals");
     CHECK(get_observer_writer_tag(helpers::CheckReductionNamesTag{}) ==

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_ResidualMonitorActions.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_ResidualMonitorActions.cpp
@@ -164,9 +164,6 @@ SPECTRE_TEST_CASE(
     const auto& has_converged = get<1>(element_inbox);
     CHECK_FALSE(has_converged);
     // Test observer writer state
-    CHECK(
-        get_observer_writer_tag(helpers::CheckObservationIdTag{}) ==
-        observers::ObservationId{0, "(anonymous namespace)::TestLinearSolver"});
     CHECK(get_observer_writer_tag(helpers::CheckSubfileNameTag{}) ==
           "/TestLinearSolverResiduals");
     CHECK(get_observer_writer_tag(helpers::CheckReductionNamesTag{}) ==
@@ -261,9 +258,6 @@ SPECTRE_TEST_CASE(
     CHECK_FALSE(has_converged);
     CHECK(get<0>(element_inbox) == approx(2.));
     // Test observer writer state
-    CHECK(
-        get_observer_writer_tag(helpers::CheckObservationIdTag{}) ==
-        observers::ObservationId{1, "(anonymous namespace)::TestLinearSolver"});
     CHECK(get_observer_writer_tag(helpers::CheckSubfileNameTag{}) ==
           "/TestLinearSolverResiduals");
     CHECK(get_observer_writer_tag(helpers::CheckReductionNamesTag{}) ==


### PR DESCRIPTION
## Proposed changes

Adds an action that writes a row of data to the reductions file. It doesn't need any of the registration and reduction infrastructure, which can be tedious to set up. This makes it easier to observe from singletons or from a specific chare.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
