### PR TITLE
Consolidate mutation of global cache into single function

### DIFF
--- a/docs/DevGuide/Parallelization.md
+++ b/docs/DevGuide/Parallelization.md
@@ -687,7 +687,7 @@ compute items are considered.
 To modify a mutable item, pass `Parallel::mutate` two template
 parameters: the tag to mutate, and a struct with an `apply` function
 that does the mutating. `Parallel::mutate` takes two arguments:
-a proxy to the GlobalCache, and a tuple that is passed into the
+a reference to the local GlobalCache, and a tuple that is passed into the
 mutator function.  For the following example,
 
 \snippet Test_AlgorithmGlobalCache.cpp mutate_global_cache_item

--- a/src/Parallel/GlobalCache.hpp
+++ b/src/Parallel/GlobalCache.hpp
@@ -121,7 +121,7 @@ class MutableGlobalCache : public CBase_MutableGlobalCache<Metavariables> {
   auto get() const
       -> const GlobalCache_detail::type_for_get<GlobalCacheTag, Metavariables>&;
 
-  // Entry method to mutate the object indentified by `GlobalCacheTag`.
+  // Entry method to mutate the object identified by `GlobalCacheTag`.
   // Internally calls Function::apply(), where
   // Function is a struct, and Function::apply is a user-defined
   // static function that mutates the object.  Function::apply() takes

--- a/src/Parallel/GlobalCache.hpp
+++ b/src/Parallel/GlobalCache.hpp
@@ -618,6 +618,26 @@ bool mutable_cache_item_is_ready(GlobalCache<Metavariables>& cache,
 }
 
 /// \ingroup ParallelGroup
+/// \brief Mutates non-const data in the cache, by calling `Function::apply()`
+///
+/// \requires `GlobalCacheTag` is a tag in the `mutable_global_cache_tags`
+/// defined by the Metavariables and in Actions.
+/// \requires `Function` is a struct with a static void `apply()`
+/// function that mutates the object. `Function::apply()` takes as its
+/// first argument a `gsl::not_null` pointer to the object named by
+/// the `GlobalCacheTag`, and takes `args` as
+/// subsequent arguments.
+///
+/// This is the version that takes a GlobalCache<Metavariables>. Used only
+/// for tests.
+template <typename GlobalCacheTag, typename Function, typename Metavariables,
+          typename... Args>
+void mutate(GlobalCache<Metavariables>& cache, Args&&... args) {
+  cache.template mutate<GlobalCacheTag, Function>(
+      std::make_tuple<Args...>(std::forward<Args>(args)...));
+}
+
+/// \ingroup ParallelGroup
 ///
 /// \brief Mutates non-const data in the cache, by calling `Function::apply()`
 ///
@@ -627,6 +647,8 @@ bool mutable_cache_item_is_ready(GlobalCache<Metavariables>& cache,
 /// first argument a `gsl::not_null` pointer to the object named by
 /// the `GlobalCacheTag`, and takes `args` as
 /// subsequent arguments.
+///
+/// This is the version that takes a charm++ proxy to the GlobalCache.
 template <typename GlobalCacheTag, typename Function, typename Metavariables,
           typename... Args>
 void mutate(CProxy_GlobalCache<Metavariables>& cache_proxy, Args&&... args) {

--- a/tests/Unit/ControlSystem/Test_Trigger.cpp
+++ b/tests/Unit/ControlSystem/Test_Trigger.cpp
@@ -127,9 +127,9 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Trigger", "[Domain][Unit]") {
 
   CHECK(not trigger.is_ready(box, cache, 0, component_p));
 
-  ActionTesting::mutate<control_system::Tags::MeasurementTimescales,
-                        control_system::UpdateFunctionOfTime>(
-      cache, "LabelB"s, 0.5, DataVector{4.0}, 4.0);
+  Parallel::mutate<control_system::Tags::MeasurementTimescales,
+                   control_system::UpdateFunctionOfTime>(cache, "LabelB"s, 0.5,
+                                                         DataVector{4.0}, 4.0);
 
   CHECK(trigger.is_ready(box, cache, 0, component_p));
   {

--- a/tests/Unit/ControlSystem/Test_UpdateFunctionOfTime.cpp
+++ b/tests/Unit/ControlSystem/Test_UpdateFunctionOfTime.cpp
@@ -90,8 +90,8 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.UpdateFunctionOfTime",
       ActionTesting::cache<TestSingleton<TestingMetavariables>>(runsys, 0_st);
 
   for (auto& name : {pp_name, quatfot_name}) {
-    ActionTesting::mutate<domain::Tags::FunctionsOfTime,
-                          control_system::UpdateFunctionOfTime>(
+    Parallel::mutate<domain::Tags::FunctionsOfTime,
+                     control_system::UpdateFunctionOfTime>(
         cache, name, update_time, updated_deriv, new_expiration_time);
   }
 
@@ -115,8 +115,8 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.UpdateFunctionOfTime",
   // Update functions of time in global cache with new expiration time
   const double newer_expiration_time = new_expiration_time + 1.0;
   for (auto& name : {pp_name, quatfot_name}) {
-    ActionTesting::mutate<domain::Tags::FunctionsOfTime,
-                          control_system::ResetFunctionOfTimeExpirationTime>(
+    Parallel::mutate<domain::Tags::FunctionsOfTime,
+                     control_system::ResetFunctionOfTimeExpirationTime>(
         cache, name, newer_expiration_time);
   }
 

--- a/tests/Unit/Domain/FunctionsOfTime/Test_FunctionsOfTimeAreReady.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_FunctionsOfTimeAreReady.cpp
@@ -104,8 +104,7 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTimeAreReady", "[Domain][Unit]") {
         cache, 0, component_p, 0.5, std::array{"OtherA"s}));
 
     // Make OtherA ready
-    ActionTesting::mutate<OtherFunctionsOfTime, UpdateFoT>(cache, "OtherA"s,
-                                                           123.0);
+    Parallel::mutate<OtherFunctionsOfTime, UpdateFoT>(cache, "OtherA"s, 123.0);
 
     CHECK(domain::functions_of_time_are_ready<OtherFunctionsOfTime>(
         cache, 0, component_p, 0.5, std::array{"OtherA"s}));
@@ -113,8 +112,7 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTimeAreReady", "[Domain][Unit]") {
         cache, 0, component_p, 0.5, std::array{"OtherA"s, "OtherB"s}));
 
     // Make OtherB ready
-    ActionTesting::mutate<OtherFunctionsOfTime, UpdateFoT>(cache, "OtherB"s,
-                                                           456.0);
+    Parallel::mutate<OtherFunctionsOfTime, UpdateFoT>(cache, "OtherB"s, 456.0);
 
     CHECK(domain::functions_of_time_are_ready<OtherFunctionsOfTime>(
         cache, 0, component_p, 0.5, std::array{"OtherA"s, "OtherB"s}));
@@ -130,14 +128,14 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTimeAreReady", "[Domain][Unit]") {
         make_not_null(&runner), 0));
 
     // Make OtherA ready
-    ActionTesting::mutate<domain::Tags::FunctionsOfTime, UpdateFoT>(
+    Parallel::mutate<domain::Tags::FunctionsOfTime, UpdateFoT>(
         cache, "FunctionA"s, 5.0);
 
     CHECK(not ActionTesting::next_action_if_ready<component>(
         make_not_null(&runner), 0));
 
     // Make OtherB ready
-    ActionTesting::mutate<domain::Tags::FunctionsOfTime, UpdateFoT>(
+    Parallel::mutate<domain::Tags::FunctionsOfTime, UpdateFoT>(
         cache, "FunctionB"s, 10.0);
 
     CHECK(ActionTesting::next_action_if_ready<component>(make_not_null(&runner),

--- a/tests/Unit/Framework/ActionTesting.hpp
+++ b/tests/Unit/Framework/ActionTesting.hpp
@@ -318,6 +318,30 @@ struct get_array_index;
  *
  * \snippet Test_ActionTesting.cpp constructor const global cache tags unknown
  *
+ * ### Mutable global cache tags
+ *
+ * Similarly to const global cache tags, sometimes Actions will want to change
+ * the data of a tag in the `Parallel::GlobalCache`. Consider this tag:
+ *
+ * \snippet Test_ActionTesting.cpp mutable cache tag
+ *
+ * To indicate that this tag in the global cache may be changed, it is added
+ * by, for example, the metavariables:
+ *
+ * \snippet Test_ActionTesting.cpp mutable global cache metavars
+ *
+ * Then, exactly like the const global cache tags, the constructor of
+ * `ActionTesting::MockRuntimeSystem` takes a `tuples::TaggedTuple` of the
+ * mutable global cache tags as its *second* argument. The mutable global cache
+ * tags are empty by default so you need not specify a `tuples::TaggedTuple` if
+ * you don't have any mutable global cache tags. Here is how you would specify
+ * zero const global cache tags and one mutable global cache tag:
+ *
+ * \snippet Test_ActionTesting.cpp mutable global cache runner
+ *
+ * To mutate a tag in the mutable global cache, use the `Parallel::mutate`
+ * function just like you would in a charm-aware situation.
+ *
  * ### Inbox tags introspection
  *
  * The inbox tags can also be retrieved from a component by using the
@@ -331,8 +355,6 @@ struct get_array_index;
  *
  * The non-const version can be used like in the above example to clear or
  * otherwise manipulate the inbox tags.
- *
- * ###
  */
 namespace ActionTesting {}
 

--- a/tests/Unit/Framework/ActionTesting.hpp
+++ b/tests/Unit/Framework/ActionTesting.hpp
@@ -318,33 +318,6 @@ struct get_array_index;
  *
  * \snippet Test_ActionTesting.cpp constructor const global cache tags unknown
  *
- * ### Mutable global cache tags
- *
- * Similarly to const global cache tags, sometimes Actions will want to change
- * the data of a tag in the `Parallel::GlobalCache`. Consider this tag:
- *
- * \snippet Test_ActionTesting.cpp mutable cache tag
- *
- * To indicate that this tag in the global cache may be changed, it is added
- * by, for example, the metavariables:
- *
- * \snippet Test_ActionTesting.cpp mutable global cache metavars
- *
- * Then, exactly like the const global cache tags, the constructor of
- * `ActionTesting::MockRuntimeSystem` takes a `tuples::TaggedTuple` of the
- * mutable global cache tags as its *second* argument. The mutable global cache
- * tags are empty by default so you need not specify a `tuples::TaggedTuple` if
- * you don't have any mutable global cache tags. Here is how you would specify
- * zero const global cache tags and one mutable global cache tag:
- *
- * \snippet Test_ActionTesting.cpp mutable global cache runner
- *
- * To mutate a tag in the mutable global cache, use the `ActionTesting::mutate`
- * function. This acts very similarly to the `Parallel::mutate` function, except
- * that it takes a reference to the global cache instead of a proxy. When
- * `ActionTesting::mutate` is called, it will queue a simple action on the
- * component the reference to the cache was created from.
- *
  * ### Inbox tags introspection
  *
  * The inbox tags can also be retrieved from a component by using the
@@ -358,6 +331,8 @@ struct get_array_index;
  *
  * The non-const version can be used like in the above example to clear or
  * otherwise manipulate the inbox tags.
+ *
+ * ###
  */
 namespace ActionTesting {}
 

--- a/tests/Unit/Framework/MockRuntimeSystemFreeFunctions.hpp
+++ b/tests/Unit/Framework/MockRuntimeSystemFreeFunctions.hpp
@@ -377,23 +377,6 @@ Parallel::GlobalCache<Metavariables>& cache(
       .cache();
 }
 
-/// \brief Mutates non-const tag GlobalCacheTag in the cache, by calling
-/// `Function::apply()`
-///
-/// \requires `GlobalCacheTag` is a tag in the `mutable_global_cache_tags`
-/// defined by the Metavariables and in Actions.
-/// \requires `Function` is a struct with a static void `apply()`
-/// function that mutates the object. `Function::apply()` takes as its
-/// first argument a `gsl::not_null` pointer to the object named by
-/// the `GlobalCacheTag`, and takes `args` as
-/// subsequent arguments.
-template <typename GlobalCacheTag, typename Function, typename Metavariables,
-          typename... Args>
-void mutate(Parallel::GlobalCache<Metavariables>& cache, Args&&... args) {
-  cache.template mutate<GlobalCacheTag, Function>(
-      std::make_tuple<Args...>(std::forward<Args>(args)...));
-}
-
 /// Returns a vector of all the indices of the Components in the
 /// ComponentList that have queued simple actions, for a particular
 /// array_index.

--- a/tests/Unit/Framework/Tests/Test_ActionTesting.cpp
+++ b/tests/Unit/Framework/Tests/Test_ActionTesting.cpp
@@ -941,11 +941,9 @@ SPECTRE_TEST_CASE("Unit.ActionTesting.NodesAndCores", "[Unit]") {
 }  // namespace TestNodesAndCores
 
 namespace TestMutableGlobalCache {
-// [mutable cache tag]
 struct CacheTag : db::SimpleTag {
   using type = int;
 };
-// [mutable cache tag]
 
 template <int Value>
 struct CacheTagUpdater {
@@ -982,9 +980,7 @@ struct SimpleActionToTest {
 struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
 
-  // [mutable global cache metavars]
   using mutable_global_cache_tags = tmpl::list<CacheTag>;
-  // [mutable global cache metavars]
 
   enum class Phase { Initialization, Testing, Exit };
 };
@@ -993,9 +989,7 @@ SPECTRE_TEST_CASE("Unit.ActionTesting.MutableGlobalCache", "[Unit]") {
   using metavars = Metavariables;
   using component = Component<metavars>;
 
-  // [mutable global cache runner]
   ActionTesting::MockRuntimeSystem<metavars> runner{{}, {0}};
-  // [mutable global cache runner]
   ActionTesting::emplace_array_component<component>(
       &runner, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{0}, 0);
 
@@ -1026,7 +1020,7 @@ SPECTRE_TEST_CASE("Unit.ActionTesting.MutableGlobalCache", "[Unit]") {
   CHECK(ActionTesting::is_simple_action_queue_empty<component>(runner, 0));
 
   // After we mutate the item, then SimpleActionToTest should be queued...
-  ActionTesting::mutate<CacheTag, CacheTagUpdater<1>>(cache);
+  Parallel::mutate<CacheTag, CacheTagUpdater<1>>(cache);
   CHECK(ActionTesting::number_of_queued_simple_actions<component>(runner, 0) ==
         1);
   // ... so invoke it
@@ -1054,7 +1048,7 @@ SPECTRE_TEST_CASE("Unit.ActionTesting.MutableGlobalCache", "[Unit]") {
   CHECK(ActionTesting::is_simple_action_queue_empty<component>(runner, 0));
 
   // After we mutate the item, then SimpleActionToTest should be queued...
-  ActionTesting::mutate<CacheTag, CacheTagUpdater<3>>(cache);
+  Parallel::mutate<CacheTag, CacheTagUpdater<3>>(cache);
   CHECK(ActionTesting::number_of_queued_simple_actions<component>(runner, 0) ==
         1);
   // ... so invoke it

--- a/tests/Unit/Framework/Tests/Test_ActionTesting.cpp
+++ b/tests/Unit/Framework/Tests/Test_ActionTesting.cpp
@@ -941,9 +941,11 @@ SPECTRE_TEST_CASE("Unit.ActionTesting.NodesAndCores", "[Unit]") {
 }  // namespace TestNodesAndCores
 
 namespace TestMutableGlobalCache {
+// [mutable cache tag]
 struct CacheTag : db::SimpleTag {
   using type = int;
 };
+// [mutable cache tag]
 
 template <int Value>
 struct CacheTagUpdater {
@@ -980,7 +982,9 @@ struct SimpleActionToTest {
 struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
 
+  // [mutable global cache metavars]
   using mutable_global_cache_tags = tmpl::list<CacheTag>;
+  // [mutable global cache metavars]
 
   enum class Phase { Initialization, Testing, Exit };
 };
@@ -989,7 +993,9 @@ SPECTRE_TEST_CASE("Unit.ActionTesting.MutableGlobalCache", "[Unit]") {
   using metavars = Metavariables;
   using component = Component<metavars>;
 
+  // [mutable global cache runner]
   ActionTesting::MockRuntimeSystem<metavars> runner{{}, {0}};
+  // [mutable global cache runner]
   ActionTesting::emplace_array_component<component>(
       &runner, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{0}, 0);
 

--- a/tests/Unit/Parallel/Test_AlgorithmGlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmGlobalCache.cpp
@@ -95,8 +95,7 @@ struct add_new_stored_double {
                     const ArrayIndex& /*array_index*/) {
     // [mutate_global_cache_item]
     Parallel::mutate<Tags::VectorOfDoubles,
-                     MutationFunctions::add_stored_double>(cache.thisProxy,
-                                                           42.0);
+                     MutationFunctions::add_stored_double>(cache, 42.0);
     // [mutate_global_cache_item]
   }
 };

--- a/tests/Unit/Parallel/Test_GlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_GlobalCache.cpp
@@ -275,7 +275,7 @@ void TestArrayChare<Metavariables>::run_test_one() {
                                     .number_of_sides());
 
   // Mutate the weight to 150.
-  Parallel::mutate<weight, modify_value<double>>(global_cache_proxy_, 150.0);
+  Parallel::mutate<weight, modify_value<double>>(local_cache, 150.0);
   run_test_two();
 }
 
@@ -299,9 +299,9 @@ void TestArrayChare<Metavariables>::run_test_two() {
 
     // Now the weight is 150, so mutate the email.
     Parallel::mutate<email, modify_value<std::string>>(
-        global_cache_proxy_, std::string("albert@einstein.de"));
+        local_cache, std::string("albert@einstein.de"));
     // ... and make the arthropod into a lobster.
-    Parallel::mutate<animal, modify_number_of_legs>(global_cache_proxy_, 10_st);
+    Parallel::mutate<animal, modify_number_of_legs>(local_cache, 10_st);
     run_test_three();
   }
 }
@@ -326,7 +326,7 @@ void TestArrayChare<Metavariables>::run_test_three() {
                              Parallel::get<email>(local_cache));
 
     // Now make the arthropod into a spider.
-    Parallel::mutate<animal, modify_number_of_legs>(global_cache_proxy_, 8_st);
+    Parallel::mutate<animal, modify_number_of_legs>(local_cache, 8_st);
     run_test_four();
   }
 }
@@ -351,8 +351,7 @@ void TestArrayChare<Metavariables>::run_test_four() {
         8 == Parallel::get<animal>(local_cache).number_of_legs());
 
     // Make the arthropod into a Scutigera coleoptrata.
-    Parallel::mutate<animal_base, modify_number_of_legs>(global_cache_proxy_,
-                                                         30_st);
+    Parallel::mutate<animal_base, modify_number_of_legs>(local_cache, 30_st);
 
     run_test_five();
   }

--- a/tests/Unit/Parallel/Test_GlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_GlobalCache.cpp
@@ -17,7 +17,6 @@
 #include <string>
 #include <tuple>
 
-#include "Framework/ActionTesting.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Parallel/Algorithms/AlgorithmArray.hpp"
 #include "Parallel/Algorithms/AlgorithmGroup.hpp"
@@ -422,21 +421,21 @@ void Test_GlobalCache<Metavariables>::run_single_core_test() {
                            Parallel::get<animal_base>(cache).number_of_legs());
 
   // Check that we can modify the non-const items.
-  ActionTesting::mutate<weight, modify_value<double>>(cache, 150.0);
-  ActionTesting::mutate<email, modify_value<std::string>>(
+  Parallel::mutate<weight, modify_value<double>>(cache, 150.0);
+  Parallel::mutate<email, modify_value<std::string>>(
       cache, std::string("nobody@nowhere.com"));
   SPECTRE_PARALLEL_REQUIRE(150 == Parallel::get<weight>(cache));
   SPECTRE_PARALLEL_REQUIRE("nobody@nowhere.com" == Parallel::get<email>(cache));
-  ActionTesting::mutate<email, modify_value<std::string>>(
+  Parallel::mutate<email, modify_value<std::string>>(
       cache, std::string("isaac@newton.com"));
   SPECTRE_PARALLEL_REQUIRE("isaac@newton.com" == Parallel::get<email>(cache));
   // Make the arthropod into a spider.
-  ActionTesting::mutate<animal, modify_number_of_legs>(cache, 8_st);
+  Parallel::mutate<animal, modify_number_of_legs>(cache, 8_st);
   SPECTRE_PARALLEL_REQUIRE(8 == Parallel::get<animal>(cache).number_of_legs());
   SPECTRE_PARALLEL_REQUIRE(8 ==
                            Parallel::get<animal_base>(cache).number_of_legs());
   // Make the arthropod into a Scutigera coleoptrata.
-  ActionTesting::mutate<animal_base, modify_number_of_legs>(cache, 30_st);
+  Parallel::mutate<animal_base, modify_number_of_legs>(cache, 30_st);
   SPECTRE_PARALLEL_REQUIRE(30 == Parallel::get<animal>(cache).number_of_legs());
   SPECTRE_PARALLEL_REQUIRE(30 ==
                            Parallel::get<animal_base>(cache).number_of_legs());

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
@@ -499,8 +499,8 @@ void test_add_temporal_ids_time_dependent() {
   // started when the previous interpolation is finished
   // (and that code is not included in this test).
   auto& cache = ActionTesting::cache<target_component>(runner, 0_st);
-  ActionTesting::mutate<domain::Tags::FunctionsOfTime,
-                        control_system::ResetFunctionOfTimeExpirationTime>(
+  Parallel::mutate<domain::Tags::FunctionsOfTime,
+                   control_system::ResetFunctionOfTimeExpirationTime>(
       cache, f_of_t_name, new_expiration_time);
 
   if (IsSequential::value) {
@@ -557,8 +557,8 @@ void test_add_temporal_ids_time_dependent() {
   // no more simple_actions in the queue.  Now we mutate the
   // FunctionsOfTime while there is still (for the nonsequential case) a
   // VerifyTemporalIdsAndSendPoints queued.
-  ActionTesting::mutate<domain::Tags::FunctionsOfTime,
-                        control_system::ResetFunctionOfTimeExpirationTime>(
+  Parallel::mutate<domain::Tags::FunctionsOfTime,
+                   control_system::ResetFunctionOfTimeExpirationTime>(
       cache, f_of_t_name, new_expiration_time * 2.0);
 
   if (IsSequential::value) {

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
@@ -560,8 +560,8 @@ void test_interpolation_target_receive_vars() {
 
       // Now mutate the FunctionsOfTime.
       auto& cache = ActionTesting::cache<target_component>(runner, 0_st);
-      ActionTesting::mutate<domain::Tags::FunctionsOfTime,
-                            control_system::ResetFunctionOfTimeExpirationTime>(
+      Parallel::mutate<domain::Tags::FunctionsOfTime,
+                       control_system::ResetFunctionOfTimeExpirationTime>(
           cache, f_of_t_name, new_expiration_time);
 
       // The callback should have queued a single simple action,


### PR DESCRIPTION
## Proposed changes

Previously, our testing framework could not handle calls to `Parallel::mutate` that happen in source code. We didn't actually
have any because all calls to `Parallel::mutate` were in the tests, so everything was ok. The control system will be the first place we have a mutate call in source code. This is how this issue came up.

In order to avoid having multiple mutate functions for the action testing framework and for charm-aware executables, use only a single `Parallel::mutate` function that takes a reference to the local cache. Then, if `Parallel::mutate` is called in an executable, it will call mutate on the proxy, but if it is called in a test, it will just mutate the local cache.

The easiest way to do this was to revert #3740 first.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
To mutate a mutable global cache tag `Tag`, use `Parallel::mutate<Tag, Functor>(cache, args...)` where `cache` is a reference to the local GlobalCache. This works in both the testing framework and charm-aware situations.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
