### PR TITLE
Add L2IntegralNorm to ObserveNorms

### DIFF
--- a/src/DataStructures/DataBox/ObservationBox.hpp
+++ b/src/DataStructures/DataBox/ObservationBox.hpp
@@ -45,6 +45,9 @@ class ObservationBox<tmpl::list<ComputeTags...>, DataBoxType>
  public:
   /// A list of all the compute item tags
   using compute_item_tags = tmpl::list<ComputeTags...>;
+  /// A list of all tags
+  using tags_list =
+      tmpl::push_back<typename DataBoxType::tags_list, ComputeTags...>;
 
   ObservationBox() = default;
   ObservationBox(const ObservationBox& rhs) = default;
@@ -70,9 +73,6 @@ class ObservationBox<tmpl::list<ComputeTags...>, DataBoxType>
   template <typename ComputeTag, typename... ArgumentTags>
   void evaluate_compute_item(
       tmpl::list<ArgumentTags...> /*meta*/) const;
-
-  using tags_list =
-      tmpl::push_back<typename DataBoxType::tags_list, ComputeTags...>;
 
   const DataBoxType* databox_ = nullptr;
 };

--- a/src/ParallelAlgorithms/Events/ObserveNorms.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveNorms.hpp
@@ -117,41 +117,16 @@ class ObserveNorms<ObservationValueTag, tmpl::list<ObservableTensorTags...>,
     std::string components{};
   };
 
-  template <typename Functional>
-  struct ElementWiseBinary {
-    std::vector<double> operator()(const std::vector<double>& t0,
-                                   const std::vector<double>& t1) const {
-      ASSERT(t0.size() == t1.size(),
-             "Size must be the same but got t0: " << t0.size()
-                                                  << " and t1: " << t1.size());
-      std::vector<double> result(t0.size());
-      for (size_t i = 0; i < t0.size(); ++i) {
-        result[i] = Functional{}(t0[i], t1[i]);
-      }
-      return result;
-    }
-
-    std::vector<double> operator()(const std::vector<double>& t0,
-                                   const double t1) const {
-      // This overload is needed for the L2 norm
-      std::vector<double> result(t0.size());
-      for (size_t i = 0; i < t0.size(); ++i) {
-        result[i] = Functional{}(t0[i], t1);
-      }
-      return result;
-    }
-  };
-
   using ReductionData = tmpl::wrap<
       tmpl::list<Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
                  Parallel::ReductionDatum<size_t, funcl::Plus<>>,
                  Parallel::ReductionDatum<std::vector<double>,
-                                          ElementWiseBinary<funcl::Max<>>>,
+                                          funcl::ElementWise<funcl::Max<>>>,
                  Parallel::ReductionDatum<std::vector<double>,
-                                          ElementWiseBinary<funcl::Min<>>>,
+                                          funcl::ElementWise<funcl::Min<>>>,
                  Parallel::ReductionDatum<
-                     std::vector<double>, ElementWiseBinary<funcl::Plus<>>,
-                     ElementWiseBinary<funcl::Sqrt<funcl::Divides<>>>,
+                     std::vector<double>, funcl::ElementWise<funcl::Plus<>>,
+                     funcl::ElementWise<funcl::Sqrt<funcl::Divides<>>>,
                      std::index_sequence<1>>>,
       Parallel::ReductionData>;
 

--- a/src/ParallelAlgorithms/Events/ObserveNorms.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveNorms.hpp
@@ -420,7 +420,8 @@ operator()(const typename ObservationValueTag::type& observation_value,
       subfile_path_ + section_observation_key.value();
   Parallel::simple_action<observers::Actions::ContributeReductionData>(
       local_observer,
-      observers::ObservationId(observation_value, subfile_path_ + ".dat"),
+      observers::ObservationId(observation_value,
+                               subfile_path_with_suffix + ".dat"),
       observers::ArrayComponentId{
           std::add_pointer_t<ParallelComponent>{nullptr},
           Parallel::ArrayIndex<ArrayIndex>(array_index)},

--- a/src/ParallelAlgorithms/Events/ObserveNorms.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveNorms.hpp
@@ -17,18 +17,23 @@
 #include "DataStructures/DataBox/TagName.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
 #include "IO/Observer/GetSectionObservationKey.hpp"
 #include "IO/Observer/Helpers.hpp"
 #include "IO/Observer/ObservationId.hpp"
 #include "IO/Observer/ObserverComponent.hpp"
 #include "IO/Observer/ReductionActions.hpp"
 #include "IO/Observer/TypeOfObservation.hpp"
+#include "NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/ArrayIndex.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Reduction.hpp"
+#include "ParallelAlgorithms/Events/Tags.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
@@ -58,6 +63,20 @@ namespace Events {
  * L_2(v^k)=\sqrt{\frac{1}{N}\sum_{i=0}^{N} \left[(v^x_i)^2 + (v^y_i)^2
  *          + (v^z_i)^2\right]}
  * \f}
+ *
+ * The L2 integral norm is:
+ *
+ * \begin{equation}
+ * L_{2,\mathrm{int}}(v^k) = \sqrt{\frac{1}{V}\int_\Omega \left[
+ *   (v^x_i)^2 + (v^y_i)^2 + (v^z_i)^2\right] \mathrm{d}V}
+ * \end{equation}
+ *
+ * where $V=\int_\Omega$ is the volume of the entire domain in inertial
+ * coordinates.
+ *
+ * \note The integral norm does not currently work with a
+ * Spectral::Basis::FiniteDifference mesh because ::definite_integral does not
+ * support it.
  *
  * Here is an example of an input file:
  *
@@ -96,7 +115,8 @@ class ObserveNorms<ObservationValueTag, tmpl::list<ObservableTensorTags...>,
     struct NormType {
       using type = std::string;
       static constexpr Options::String help = {
-          "The type of norm to use. Must be one of Max, Min, or L2Norm."};
+          "The type of norm to use. Must be one of Max, Min, L2Norm, or "
+          "L2IntegralNorm."};
     };
     struct Components {
       using type = std::string;
@@ -117,18 +137,29 @@ class ObserveNorms<ObservationValueTag, tmpl::list<ObservableTensorTags...>,
     std::string components{};
   };
 
-  using ReductionData = tmpl::wrap<
-      tmpl::list<Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
-                 Parallel::ReductionDatum<size_t, funcl::Plus<>>,
-                 Parallel::ReductionDatum<std::vector<double>,
-                                          funcl::ElementWise<funcl::Max<>>>,
-                 Parallel::ReductionDatum<std::vector<double>,
-                                          funcl::ElementWise<funcl::Min<>>>,
-                 Parallel::ReductionDatum<
-                     std::vector<double>, funcl::ElementWise<funcl::Plus<>>,
-                     funcl::ElementWise<funcl::Sqrt<funcl::Divides<>>>,
-                     std::index_sequence<1>>>,
-      Parallel::ReductionData>;
+  using ReductionData = Parallel::ReductionData<
+      // Observation value
+      Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
+      // Number of grid points
+      Parallel::ReductionDatum<size_t, funcl::Plus<>>,
+      // Total volume
+      Parallel::ReductionDatum<double, funcl::Plus<>>,
+      // Max
+      Parallel::ReductionDatum<std::vector<double>,
+                               funcl::ElementWise<funcl::Max<>>>,
+      // Min
+      Parallel::ReductionDatum<std::vector<double>,
+                               funcl::ElementWise<funcl::Min<>>>,
+      // L2Norm
+      Parallel::ReductionDatum<
+          std::vector<double>, funcl::ElementWise<funcl::Plus<>>,
+          funcl::ElementWise<funcl::Sqrt<funcl::Divides<>>>,
+          std::index_sequence<1>>,
+      // L2IntegralNorm
+      Parallel::ReductionDatum<
+          std::vector<double>, funcl::ElementWise<funcl::Plus<>>,
+          funcl::ElementWise<funcl::Sqrt<funcl::Divides<>>>,
+          std::index_sequence<2>>>;
 
  public:
   /// The name of the subfile inside the HDF5 file
@@ -154,12 +185,22 @@ class ObserveNorms<ObservationValueTag, tmpl::list<ObservableTensorTags...>,
   static constexpr Options::String help =
       "Observe norms of tensors in the DataBox.\n"
       "\n"
+      "You can choose the norm type for each observation. Note that the\n"
+      "'L2Norm' (root mean square) emphasizes regions of the domain with many\n"
+      "grid points, whereas the 'L2IntegralNorm' emphasizes regions of the\n"
+      "domain with large volume. Choose wisely! When in doubt, try the\n"
+      "'L2Norm' first.\n"
+      "The 'L2IntegralNorm' does not currently work with finite difference\n"
+      "(subcell) meshes.\n"
+      "\n"
       "Writes reduction quantities:\n"
       " * ObservationValueTag (e.g. Time or IterationId)\n"
       " * NumberOfPoints = total number of points in the domain\n"
+      " * Volume = total volume of the domain in inertial coordinates\n"
       " * Max values\n"
       " * Min values\n"
-      " * L2-norm values\n";
+      " * L2-norm values\n"
+      " * L2 integral norm values\n";
 
   ObserveNorms() = default;
 
@@ -175,12 +216,12 @@ class ObserveNorms<ObservationValueTag, tmpl::list<ObservableTensorTags...>,
   using argument_tags = tmpl::list<ObservationValueTag, ::Tags::ObservationBox>;
 
   template <typename ComputeTagsList, typename DataBoxType,
-            typename Metavariables, typename ArrayIndex,
+            typename Metavariables, size_t VolumeDim,
             typename ParallelComponent>
   void operator()(const typename ObservationValueTag::type& observation_value,
                   const ObservationBox<ComputeTagsList, DataBoxType>& box,
                   Parallel::GlobalCache<Metavariables>& cache,
-                  const ArrayIndex& array_index,
+                  const ElementId<VolumeDim>& array_index,
                   const ParallelComponent* const /*meta*/) const;
 
   using observation_registration_tags = tmpl::list<::Tags::DataBox>;
@@ -265,9 +306,12 @@ ObserveNorms<ObservationValueTag, tmpl::list<ObservableTensorTags...>,
                      << tensor << "' is not known. Known tensors are: "
                      << ((db::tag_name<ObservableTensorTags>() + ",") + ...));
   }
-  if (norm_type != "Max" and norm_type != "Min" and norm_type != "L2Norm") {
-    PARSE_ERROR(context, "NormType must be one of Max, Min, or L2Norm, not "
-                             << norm_type);
+  if (norm_type != "Max" and norm_type != "Min" and norm_type != "L2Norm" and
+      norm_type != "L2IntegralNorm") {
+    PARSE_ERROR(
+        context,
+        "NormType must be one of Max, Min, L2Norm, or L2IntegralNorm, not "
+            << norm_type);
   }
   if (components != "Individual" and components != "Sum") {
     PARSE_ERROR(context,
@@ -278,14 +322,14 @@ ObserveNorms<ObservationValueTag, tmpl::list<ObservableTensorTags...>,
 template <typename ObservationValueTag, typename... ObservableTensorTags,
           typename... NonTensorComputeTags, typename ArraySectionIdTag>
 template <typename ComputeTagsList, typename DataBoxType,
-          typename Metavariables, typename ArrayIndex,
+          typename Metavariables, size_t VolumeDim,
           typename ParallelComponent>
 void ObserveNorms<ObservationValueTag, tmpl::list<ObservableTensorTags...>,
                   tmpl::list<NonTensorComputeTags...>, ArraySectionIdTag>::
 operator()(const typename ObservationValueTag::type& observation_value,
            const ObservationBox<ComputeTagsList, DataBoxType>& box,
            Parallel::GlobalCache<Metavariables>& cache,
-           const ArrayIndex& array_index,
+           const ElementId<VolumeDim>& array_index,
            const ParallelComponent* const /*meta*/) const {
   // Skip observation on elements that are not part of a section
   const std::optional<std::string> section_observation_key =
@@ -299,13 +343,25 @@ operator()(const typename ObservationValueTag::type& observation_value,
   std::unordered_map<std::string,
                      std::pair<std::vector<double>, std::vector<std::string>>>
       norm_values_and_names{};
-  size_t number_of_points = 0;
+  const auto& mesh = get<::Events::Tags::ObserverMesh<VolumeDim>>(box);
+  const DataVector det_jacobian =
+      1. / get(get<domain::Tags::DetInvJacobian<Frame::ElementLogical,
+                                                Frame::Inertial>>(box));
+  const size_t number_of_points = mesh.number_of_grid_points();
+  const double local_volume = [&mesh, &det_jacobian]() {
+    if (mesh.basis(0) == Spectral::Basis::FiniteDifference) {
+      return std::numeric_limits<double>::quiet_NaN();
+    } else {
+      return definite_integral(det_jacobian, mesh);
+    }
+  }();
 
   // Loop over ObservableTensorTags and see if it was requested to be observed.
   // This approach allows us to delay evaluating any compute tags until they're
   // actually needed for observing.
   tmpl::for_each<tensor_tags>([this, &box, &norm_values_and_names,
-                               &number_of_points](auto tag_v) {
+                               &number_of_points, &mesh,
+                               &det_jacobian](auto tag_v) {
     using tag = tmpl::type_from<decltype(tag_v)>;
     const std::string tensor_name = db::tag_name<tag>();
     for (size_t i = 0; i < tensor_names_.size(); ++i) {
@@ -321,17 +377,14 @@ operator()(const typename ObservationValueTag::type& observation_value,
 
         auto& [values, names] = norm_values_and_names[tensor_norm_types_[i]];
         const auto [component_names, components] = tensor.get_vector_of_data();
-        if (number_of_points != 0 and
-            components[0].size() != number_of_points) {
-          ERROR("The number of grid points previously was "
-                << number_of_points << " but changed to "
-                << components[0].size()
-                << ". This means you're computing norms of tensors over "
+        if (components[0].size() != number_of_points) {
+          ERROR("The number of grid points of the mesh is "
+                << number_of_points << " but the tensor '" << tensor_name
+                << "' has " << components[0].size()
+                << " points. This means you're computing norms of tensors over "
                    "different grids, which will give the wrong answer for "
-                   "norms that use the grid points. The tensor is: "
-                << tensor_name);
+                   "norms that use the grid points.");
         }
-        number_of_points = components[0].size();
 
         if (tensor_components_[i] == "Individual") {
           for (size_t storage_index = 0; storage_index < component_names.size();
@@ -343,6 +396,14 @@ operator()(const typename ObservationValueTag::type& observation_value,
             } else if (tensor_norm_types_[i] == "L2Norm") {
               values.push_back(
                   alg::accumulate(square(components[storage_index]), 0.0));
+            } else if (tensor_norm_types_[i] == "L2IntegralNorm") {
+              if (mesh.basis(0) == Spectral::Basis::FiniteDifference) {
+                ERROR(
+                    "The 'L2IntegralNorm' is currently not supported on finite "
+                    "difference (subcell) meshes.");
+              }
+              values.push_back(definite_integral(
+                  square(components[storage_index]) * det_jacobian, mesh));
             }
             names.push_back(
                 tensor_norm_types_[i] + "(" +
@@ -366,6 +427,9 @@ operator()(const typename ObservationValueTag::type& observation_value,
               value = std::min(value, min(components[storage_index]));
             } else if (tensor_norm_types_[i] == "L2Norm") {
               value += alg::accumulate(square(components[storage_index]), 0.0);
+            } else if (tensor_norm_types_[i] == "L2IntegralNorm") {
+              value += definite_integral(
+                  square(components[storage_index]) * det_jacobian, mesh);
             }
           }
 
@@ -378,13 +442,16 @@ operator()(const typename ObservationValueTag::type& observation_value,
 
   // Concatenate the legend info together.
   std::vector<std::string> legend{db::tag_name<ObservationValueTag>(),
-                                  "NumberOfPoints"};
+                                  "NumberOfPoints", "Volume"};
   legend.insert(legend.end(), norm_values_and_names["Max"].second.begin(),
                 norm_values_and_names["Max"].second.end());
   legend.insert(legend.end(), norm_values_and_names["Min"].second.begin(),
                 norm_values_and_names["Min"].second.end());
   legend.insert(legend.end(), norm_values_and_names["L2Norm"].second.begin(),
                 norm_values_and_names["L2Norm"].second.end());
+  legend.insert(legend.end(),
+                norm_values_and_names["L2IntegralNorm"].second.begin(),
+                norm_values_and_names["L2IntegralNorm"].second.end());
 
   // Send data to reduction observer
   auto& local_observer =
@@ -399,12 +466,13 @@ operator()(const typename ObservationValueTag::type& observation_value,
                                subfile_path_with_suffix + ".dat"),
       observers::ArrayComponentId{
           std::add_pointer_t<ParallelComponent>{nullptr},
-          Parallel::ArrayIndex<ArrayIndex>(array_index)},
+          Parallel::ArrayIndex<ElementId<VolumeDim>>(array_index)},
       subfile_path_with_suffix, std::move(legend),
       ReductionData{static_cast<double>(observation_value), number_of_points,
-                    std::move(norm_values_and_names["Max"].first),
+                    local_volume, std::move(norm_values_and_names["Max"].first),
                     std::move(norm_values_and_names["Min"].first),
-                    std::move(norm_values_and_names["L2Norm"].first)});
+                    std::move(norm_values_and_names["L2Norm"].first),
+                    std::move(norm_values_and_names["L2IntegralNorm"].first)});
 }
 
 template <typename ObservationValueTag, typename... ObservableTensorTags,

--- a/src/ParallelAlgorithms/Events/ObserveVolumeIntegrals.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveVolumeIntegrals.hpp
@@ -71,7 +71,8 @@ class ObserveVolumeIntegrals<
     tmpl::list<NonTensorComputeTags...>, ArraySectionIdTag> : public Event {
  private:
   using VolumeIntegralDatum =
-      Parallel::ReductionDatum<std::vector<double>, funcl::VectorPlus>;
+      Parallel::ReductionDatum<std::vector<double>,
+                               funcl::ElementWise<funcl::Plus<>>>;
 
   using ReductionData = tmpl::wrap<
       tmpl::list<Parallel::ReductionDatum<double, funcl::AssertEqual<>>,

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
@@ -11,7 +11,7 @@
 #   - Label: constraint violations
 #     Subfile: /Norms.dat
 #     FileGlob: PlaneWaveMinkowski3DReductions.h5
-#     SkipColumns: [0, 1]
+#     SkipColumns: [0, 1, 2]
 #     AbsoluteTolerance: 0.02
 
 AnalyticData:

--- a/tests/InputFiles/Elasticity/BentBeam.yaml
+++ b/tests/InputFiles/Elasticity/BentBeam.yaml
@@ -10,7 +10,7 @@
 #   - Label: Discretization error
 #     Subfile: /ErrorNorms.dat
 #     FileGlob: ElasticBentBeam2DReductions.h5
-#     SkipColumns: [0, 1]
+#     SkipColumns: [0, 1, 2]
 #     AbsoluteTolerance: 1.e-8
 
 Background:

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -11,7 +11,7 @@
 #   - Label: Discretization error
 #     Subfile: /ErrorNorms.dat
 #     FileGlob: ElasticHalfSpaceMirrorReductions.h5
-#     SkipColumns: [0, 1]
+#     SkipColumns: [0, 1, 2]
 #     AbsoluteTolerance: 5.e-4
 
 Background:

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -10,7 +10,7 @@
 #   - Label: Discretization error
 #     Subfile: /ErrorNorms.dat
 #     FileGlob: PoissonProductOfSinusoids1DReductions.h5
-#     SkipColumns: [0, 1]
+#     SkipColumns: [0, 1, 2]
 #     AbsoluteTolerance: 0.004
 
 Background:

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -10,7 +10,7 @@
 #   - Label: Discretization error
 #     Subfile: /ErrorNorms.dat
 #     FileGlob: PoissonProductOfSinusoids2DReductions.h5
-#     SkipColumns: [0, 1]
+#     SkipColumns: [0, 1, 2]
 #     AbsoluteTolerance: 0.007
 
 Background:

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -11,7 +11,7 @@
 #   - Label: Discretization error
 #     Subfile: /ErrorNorms.dat
 #     FileGlob: PoissonProductOfSinusoids3DReductions.h5
-#     SkipColumns: [0, 1]
+#     SkipColumns: [0, 1, 2]
 #     AbsoluteTolerance: 0.004
 
 Background:

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -11,7 +11,7 @@
 #   - Label: Discretization error
 #     Subfile: /ErrorNorms.dat
 #     FileGlob: KerrSchildReductions.h5
-#     SkipColumns: [0, 1]
+#     SkipColumns: [0, 1, 2]
 #     AbsoluteTolerance: 0.08
 
 Background:

--- a/tests/Unit/Helpers/IO/Observers/ObserverHelpers.hpp
+++ b/tests/Unit/Helpers/IO/Observers/ObserverHelpers.hpp
@@ -102,14 +102,17 @@ using reduction_data_from_doubles = Parallel::ReductionData<
 using reduction_data_from_vector = Parallel::ReductionData<
     Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
     Parallel::ReductionDatum<size_t, funcl::Plus<>>,
-    Parallel::ReductionDatum<std::vector<double>, funcl::VectorPlus>>;
+    Parallel::ReductionDatum<std::vector<double>,
+                             funcl::ElementWise<funcl::Plus<>>>>;
 
 // Nothing special about the order. We just want doubles and std::vector's.
 using reduction_data_from_ds_and_vs = Parallel::ReductionData<
     Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
     Parallel::ReductionDatum<size_t, funcl::Plus<>>, l2_error_datum,
-    Parallel::ReductionDatum<std::vector<double>, funcl::VectorPlus>,
-    Parallel::ReductionDatum<std::vector<double>, funcl::VectorPlus>,
+    Parallel::ReductionDatum<std::vector<double>,
+                             funcl::ElementWise<funcl::Plus<>>>,
+    Parallel::ReductionDatum<std::vector<double>,
+                             funcl::ElementWise<funcl::Plus<>>>,
     l2_error_datum>;
 
 template <typename RegistrationActionsList>

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveNorms.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveNorms.cpp
@@ -228,6 +228,8 @@ void test(const std::unique_ptr<ObserveEvent> observe,
 
   const auto& results = MockContributeReductionData::results;
   CHECK(results.observation_id.value() == observation_time);
+  CHECK(results.observation_id.observation_key() ==
+        expected_observation_key_for_reg);
   CHECK(results.subfile_name == expected_subfile_name);
   CHECK(results.reduction_names[0] == "Time");
   CHECK(results.time == observation_time);

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveNorms.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveNorms.cpp
@@ -86,9 +86,11 @@ struct MockContributeReductionData {
     std::vector<std::string> reduction_names;
     double time;
     size_t number_of_grid_points;
+    double volume;
     std::vector<double> max_values;
     std::vector<double> min_values;
     std::vector<double> l2_norm_values;
+    std::vector<double> l2_integral_norm_values;
   };
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static Results results;
@@ -109,9 +111,11 @@ struct MockContributeReductionData {
     results.reduction_names = reduction_names;
     results.time = std::get<0>(reduction_data.data());
     results.number_of_grid_points = std::get<1>(reduction_data.data());
-    results.max_values = std::get<2>(reduction_data.data());
-    results.min_values = std::get<3>(reduction_data.data());
-    results.l2_norm_values = std::get<4>(reduction_data.data());
+    results.volume = std::get<2>(reduction_data.data());
+    results.max_values = std::get<3>(reduction_data.data());
+    results.min_values = std::get<4>(reduction_data.data());
+    results.l2_norm_values = std::get<5>(reduction_data.data());
+    results.l2_integral_norm_values = std::get<6>(reduction_data.data());
   }
 };
 
@@ -124,7 +128,7 @@ struct ElementComponent {
 
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
-  using array_index = int;
+  using array_index = ElementId<Metavariables::volume_dim>;
   using phase_dependent_action_list =
       tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
                                         Metavariables::Phase::Initialization,
@@ -152,8 +156,9 @@ using ObserveNormsEvent = Events::ObserveNorms<
     ::Tags::Time, tmpl::list<Var0, Var1, Var0TimesTwoCompute, Var0TimesThree>,
     tmpl::list<Var0TimesThreeCompute>, ArraySectionIdTag>;
 
-template <typename ArraySectionIdTag>
+template <size_t Dim, typename ArraySectionIdTag>
 struct Metavariables {
+  static constexpr size_t volume_dim = Dim;
   using component_list = tmpl::list<ElementComponent<Metavariables>,
                                     MockObserverComponent<Metavariables>>;
 
@@ -168,14 +173,19 @@ struct Metavariables {
 
 template <typename ArraySectionIdTag, typename ObserveEvent>
 void test(const std::unique_ptr<ObserveEvent> observe,
+          const Spectral::Basis basis, const Spectral::Quadrature quadrature,
           const std::optional<std::string>& section) {
   CAPTURE(pretty_type::short_name<ArraySectionIdTag>());
   CAPTURE(section);
-  using metavariables = Metavariables<ArraySectionIdTag>;
+  using metavariables = Metavariables<3, ArraySectionIdTag>;
   using element_component = ElementComponent<metavariables>;
   using observer_component = MockObserverComponent<metavariables>;
   const typename element_component::array_index array_index(0);
-  const size_t num_points = 5;
+  const Mesh<3> mesh{3, basis, quadrature};
+  const size_t num_points = mesh.number_of_grid_points();
+  // Jacobian of a cube with side length 1, so expected volume is 1.
+  const Scalar<DataVector> det_inv_jacobian(num_points, cube(2.));
+  const double expected_volume = 1.;
   const double observation_time = 2.0;
   Variables<tmpl::list<Var0, Var1>> vars(num_points);
   // Fill the variables with some data.  It doesn't matter much what,
@@ -186,14 +196,16 @@ void test(const std::unique_ptr<ObserveEvent> observe,
 
   ActionTesting::MockRuntimeSystem<metavariables> runner{{}};
   ActionTesting::emplace_component<element_component>(make_not_null(&runner),
-                                                      0);
+                                                      array_index);
   ActionTesting::emplace_group_component<observer_component>(&runner);
 
   const auto box = db::create<db::AddSimpleTags<
-      Parallel::Tags::MetavariablesImpl<metavariables>, ::Tags::Time,
-      Tags::Variables<typename decltype(vars)::tags_list>,
+      Parallel::Tags::MetavariablesImpl<metavariables>,
+      ::Events::Tags::ObserverMesh<3>,
+      domain::Tags::DetInvJacobian<Frame::ElementLogical, Frame::Inertial>,
+      ::Tags::Time, Tags::Variables<typename decltype(vars)::tags_list>,
       observers::Tags::ObservationKey<ArraySectionIdTag>>>(
-      metavariables{}, observation_time, vars, section);
+      metavariables{}, mesh, det_inv_jacobian, observation_time, vars, section);
 
   const auto ids_to_register =
       observers::get_registration_observation_type_and_key(*observe, box);
@@ -235,29 +247,45 @@ void test(const std::unique_ptr<ObserveEvent> observe,
   CHECK(results.time == observation_time);
   CHECK(results.reduction_names[1] == "NumberOfPoints");
   CHECK(results.number_of_grid_points == num_points);
+  CHECK(results.reduction_names[2] == "Volume");
+  if (basis != Spectral::Basis::FiniteDifference) {
+    CHECK(results.volume == approx(expected_volume));
+  }
   // Check max values
-  CHECK(results.reduction_names[2] == "Max(Var0)");
   CHECK(results.reduction_names[3] == "Max(Var0)");
-  CHECK(results.reduction_names[4] == "Max(Var0TimesTwo)");
-  CHECK(results.reduction_names[5] == "Max(Var0TimesThree)");
-  CHECK(results.max_values == std::vector<double>{5.0, 5.0, 10.0, 15.0});
+  CHECK(results.reduction_names[4] == "Max(Var0)");
+  CHECK(results.reduction_names[5] == "Max(Var0TimesTwo)");
+  CHECK(results.reduction_names[6] == "Max(Var0TimesThree)");
+  CHECK(results.max_values == std::vector<double>{27.0, 27.0, 54.0, 81.0});
 
   // Check min values
-  CHECK(results.reduction_names[6] == "Min(Var1_x)");
-  CHECK(results.reduction_names[7] == "Min(Var1_y)");
-  CHECK(results.reduction_names[8] == "Min(Var1_z)");
-  CHECK(results.reduction_names[9] == "Min(Var1)");
-  CHECK(results.min_values == std::vector<double>{6.0, 11.0, 16.0, 6.0});
+  CHECK(results.reduction_names[7] == "Min(Var1_x)");
+  CHECK(results.reduction_names[8] == "Min(Var1_y)");
+  CHECK(results.reduction_names[9] == "Min(Var1_z)");
+  CHECK(results.reduction_names[10] == "Min(Var1)");
+  CHECK(results.min_values == std::vector<double>{28.0, 55.0, 82.0, 28.0});
 
   // Check L2 norms
-  CHECK(results.reduction_names[10] == "L2Norm(Var1)");
-  CHECK(results.reduction_names[11] == "L2Norm(Var1_x)");
-  CHECK(results.reduction_names[12] == "L2Norm(Var1_y)");
-  CHECK(results.reduction_names[13] == "L2Norm(Var1_z)");
-  CHECK(results.l2_norm_values[0] == approx(23.72762103540934575));
-  CHECK(results.l2_norm_values[1] == approx(8.12403840463596083));
-  CHECK(results.l2_norm_values[2] == approx(13.076696830622021));
-  CHECK(results.l2_norm_values[3] == approx(18.055470085267789));
+  CHECK(results.reduction_names[11] == "L2Norm(Var1)");
+  CHECK(results.reduction_names[12] == "L2Norm(Var1_x)");
+  CHECK(results.reduction_names[13] == "L2Norm(Var1_y)");
+  CHECK(results.reduction_names[14] == "L2Norm(Var1_z)");
+  CHECK(results.l2_norm_values[0] == approx(124.5471798155221137));
+  CHECK(results.l2_norm_values[1] == approx(41.73328008516305232));
+  CHECK(results.l2_norm_values[2] == approx(68.44462481938714404));
+  CHECK(results.l2_norm_values[3] == approx(95.3187634554008838));
+
+  // Check L2 integral norms
+  if (basis != Spectral::Basis::FiniteDifference) {
+    CHECK(results.reduction_names[15] == "L2IntegralNorm(Var1)");
+    CHECK(results.reduction_names[16] == "L2IntegralNorm(Var1_x)");
+    CHECK(results.reduction_names[17] == "L2IntegralNorm(Var1_y)");
+    CHECK(results.reduction_names[18] == "L2IntegralNorm(Var1_z)");
+    CHECK(results.l2_integral_norm_values[0] == approx(124.18131904598212145));
+    CHECK(results.l2_integral_norm_values[1] == approx(41.36826480931165406));
+    CHECK(results.l2_integral_norm_values[2] == approx(68.22267462752640199));
+    CHECK(results.l2_integral_norm_values[3] == approx(95.15951520123110186));
+  }
 }
 }  // namespace
 
@@ -271,16 +299,19 @@ SPECTRE_TEST_CASE("Unit.Evolution.ObserveNorms", "[Unit][Evolution]") {
                                   {"Var0TimesTwo", "Max", "Individual"},
                                   {"Var0TimesThree", "Max", "Individual"},
                                   {"Var1", "L2Norm", "Sum"},
+                                  {"Var1", "L2IntegralNorm", "Sum"},
                                   {"Var1", "L2Norm", "Individual"},
+                                  {"Var1", "L2IntegralNorm", "Individual"},
                                   {"Var1", "Min", "Sum"}}}),
-                         "Section0");
+                         Spectral::Basis::Legendre,
+                         Spectral::Quadrature::GaussLobatto, "Section0");
 
   INFO("create/serialize");
-  Parallel::register_factory_classes_with_charm<Metavariables<void>>();
-  const auto factory_event =
-      TestHelpers::test_creation<std::unique_ptr<Event>, Metavariables<void>>(
-          // [input_file_examples]
-          R"(
+  Parallel::register_factory_classes_with_charm<Metavariables<3, void>>();
+  const auto factory_event = TestHelpers::test_creation<std::unique_ptr<Event>,
+                                                        Metavariables<3, void>>(
+      // [input_file_examples]
+      R"(
   ObserveNorms:
     SubfileName: reduction0
     TensorsToObserve:
@@ -303,7 +334,13 @@ SPECTRE_TEST_CASE("Unit.Evolution.ObserveNorms", "[Unit][Evolution]") {
       NormType: L2Norm
       Components: Sum
     - Name: Var1
+      NormType: L2IntegralNorm
+      Components: Sum
+    - Name: Var1
       NormType: L2Norm
+      Components: Individual
+    - Name: Var1
+      NormType: L2IntegralNorm
       Components: Individual
     - Name: Var1
       NormType: Min
@@ -311,5 +348,19 @@ SPECTRE_TEST_CASE("Unit.Evolution.ObserveNorms", "[Unit][Evolution]") {
         )");
   // [input_file_examples]
   auto serialized_event = serialize_and_deserialize(factory_event);
-  test<void>(std::move(serialized_event), std::nullopt);
+  test<void>(std::move(serialized_event), Spectral::Basis::Legendre,
+             Spectral::Quadrature::GaussLobatto, std::nullopt);
+
+  test<void>(std::make_unique<ObserveNormsEvent<void>>(ObserveNormsEvent<void>{
+                 "reduction0",
+                 {{"Var0", "Max", "Individual"},
+                  {"Var1", "Min", "Individual"},
+                  {"Var0", "Max", "Sum"},
+                  {"Var0TimesTwo", "Max", "Individual"},
+                  {"Var0TimesThree", "Max", "Individual"},
+                  {"Var1", "L2Norm", "Sum"},
+                  {"Var1", "L2Norm", "Individual"},
+                  {"Var1", "Min", "Sum"}}}),
+             Spectral::Basis::FiniteDifference,
+             Spectral::Quadrature::CellCentered, std::nullopt);
 }

--- a/tests/Unit/Utilities/Test_Functional.cpp
+++ b/tests/Unit/Utilities/Test_Functional.cpp
@@ -460,9 +460,24 @@ void test_real_functions(const gsl::not_null<Gen*> gen) {
 }
 
 void test_vector_plus() {
-  CHECK_ITERABLE_APPROX(VectorPlus{}(std::vector<double>{0.12, -20.87, 3.2},
-                                     std::vector<double>{-11.04, 7.5, 6.18}),
+  CHECK_ITERABLE_APPROX(funcl::ElementWise<funcl::Abs<>>{}(
+                            std::vector<double>{0.12, -20.87, 3.2}),
+                        (std::vector<double>{0.12, 20.87, 3.2}));
+  CHECK_ITERABLE_APPROX(funcl::ElementWise<funcl::Plus<>>{}(
+                            std::vector<double>{0.12, -20.87, 3.2},
+                            std::vector<double>{-11.04, 7.5, 6.18}),
                         (std::vector<double>{-10.92, -13.37, 9.38}));
+  CHECK_ITERABLE_APPROX(funcl::ElementWise<funcl::Max<>>{}(
+                            std::vector<double>{0.12, -20.87, 3.2},
+                            std::vector<double>{-11.04, 7.5, 6.18}),
+                        (std::vector<double>{0.12, 7.5, 6.18}));
+  CHECK_ITERABLE_APPROX(funcl::ElementWise<funcl::Min<>>{}(
+                            std::vector<double>{0.12, -20.87, 3.2},
+                            std::vector<double>{-11.04, 7.5, 6.18}),
+                        (std::vector<double>{-11.04, -20.87, 3.2}));
+  CHECK_ITERABLE_APPROX(funcl::ElementWise<funcl::Divides<>>{}(
+                            std::vector<double>{0.12, -20.87, 3.2}, 0.5),
+                        (std::vector<double>{0.24, -41.74, 6.4}));
 }
 
 SPECTRE_TEST_CASE("Unit.Utilities.Functional", "[Utilities][Unit]") {
@@ -488,13 +503,14 @@ SPECTRE_TEST_CASE("Unit.Utilities.Functional", "[Utilities][Unit]") {
 }
 
     // clang-format off
-// [[OutputRegex, Vector sizes in `funcl::VectorPlus` operator do not match.]]
+// [[OutputRegex, Sizes must be the same but got]]
 [[noreturn]] SPECTRE_TEST_CASE("Unit.Utilities.Functional.VectorPlus",
                                "[Unit][Utilities]") {
   // clang-format on
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  VectorPlus{}(std::vector<double>{2.0}, std::vector<double>{0.4, -19.90});
+  funcl::ElementWise<funcl::Plus<>>{}(std::vector<double>{2.0},
+                                      std::vector<double>{0.4, -19.90});
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }


### PR DESCRIPTION
## Proposed changes

The L2 RMS norm over grid points can over-emphasize errors at element boundaries where LGL grid-point spacing decreases quadratically. This commits adds the L2 integral norm as an alternative, which weights each grid point with the quadrature weight. Since the integral norm scales with volume, it can over-emphasize large regions of the grid that contain few grid points. Added some of this information to the docs.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
