### PR TITLE
Fix macOS CI build issue with Boost

### DIFF
--- a/support/DevEnvironments/spack.yaml
+++ b/support/DevEnvironments/spack.yaml
@@ -43,7 +43,7 @@
 spack:
   specs:
   - blaze@3.8
-  - 'boost@1.60:'
+  - 'boost@1.60:+math+program_options'
   - brigand@master
   - 'catch2@2.8:'
   # Charm++:


### PR DESCRIPTION
The recent Spack PR https://github.com/spack/spack/pull/28623
doesn't enable all variants of Boost by default anymore, so
we enable the ones we need.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
