### PR TITLE
Omit BBH domain cube-to-sphere transition

### DIFF
--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -341,6 +341,16 @@ Domain<3> BinaryCompactObject::create_domain() const {
       3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>;
 
   std::vector<BcMap> boundary_conditions_all_blocks{};
+  // Add an empty map to the boundary conditions for blocks that have no
+  // external boundaries
+  const auto add_no_boundary_conditions =
+      [this, &boundary_conditions_all_blocks](const Maps& local_maps) {
+        if (outer_boundary_condition_ != nullptr) {
+          for (size_t i = 0; i < local_maps.size(); ++i) {
+            boundary_conditions_all_blocks.emplace_back(BcMap{});
+          }
+        }
+      };
 
   const std::vector<domain::CoordinateMaps::Distribution>
       object_A_radial_distribution{
@@ -355,6 +365,11 @@ Domain<3> BinaryCompactObject::create_domain() const {
               : domain::CoordinateMaps::Distribution::Linear};
 
   Maps maps{};
+
+  // --- Blocks enclosing each object (24 blocks) ---
+  //
+  // Each object is surrounded by 6 inner wedges that make a sphere, and another
+  // 6 outer wedges that transition to a cube.
 
   // ObjectA/B is on the left/right, respectively.
   const Translation translation_A{
@@ -394,11 +409,6 @@ Domain<3> BinaryCompactObject::create_domain() const {
                                     sqrt(3.0) * 0.5 * length_inner_cube_, 1.0,
                                     0.0, use_equiangular_map_),
           translation_B);
-  Maps maps_frustums = domain::make_vector_coordinate_map_base<
-      Frame::BlockLogical, Frame::Inertial, 3>(
-      frustum_coordinate_maps(length_inner_cube_, length_outer_cube_,
-                              use_equiangular_map_, {{-translation_, 0.0, 0.0}},
-                              projective_scale_factor_, frustum_sphericity_));
 
   if (outer_boundary_condition_ != nullptr) {
     for (size_t i = 0; i < maps_center_A.size(); ++i) {
@@ -412,11 +422,7 @@ Domain<3> BinaryCompactObject::create_domain() const {
   }
   std::move(maps_center_A.begin(), maps_center_A.end(),
             std::back_inserter(maps));
-  if (outer_boundary_condition_ != nullptr) {
-    for (size_t i = 0; i < maps_cube_A.size(); ++i) {
-      boundary_conditions_all_blocks.emplace_back(BcMap{});
-    }
-  }
+  add_no_boundary_conditions(maps_cube_A);
   std::move(maps_cube_A.begin(), maps_cube_A.end(), std::back_inserter(maps));
   if (outer_boundary_condition_ != nullptr) {
     for (size_t i = 0; i < maps_center_B.size(); ++i) {
@@ -430,20 +436,39 @@ Domain<3> BinaryCompactObject::create_domain() const {
   }
   std::move(maps_center_B.begin(), maps_center_B.end(),
             std::back_inserter(maps));
-  if (outer_boundary_condition_ != nullptr) {
-    for (size_t i = 0; i < maps_cube_B.size() + maps_frustums.size(); ++i) {
-      boundary_conditions_all_blocks.emplace_back(BcMap{});
-    }
-  }
+  add_no_boundary_conditions(maps_cube_B);
   std::move(maps_cube_B.begin(), maps_cube_B.end(), std::back_inserter(maps));
+
+  // --- Frustums enclosing both objects (10 blocks) ---
+  //
+  // The two abutting cubes are enclosed by a layer of frustums that form a cube
+  // (if frustum_sphericity_ is 0) or a sphere (if frustum_sphericity_ is 1)
+  // surrounding both objects. While the two objects can be offset from the
+  // origin to account for their center of mass, the enclosing frustums are
+  // centered at the origin.
+  Maps maps_frustums = domain::make_vector_coordinate_map_base<
+      Frame::BlockLogical, Frame::Inertial, 3>(
+      frustum_coordinate_maps(length_inner_cube_, length_outer_cube_,
+                              use_equiangular_map_, {{-translation_, 0.0, 0.0}},
+                              projective_scale_factor_, frustum_sphericity_));
+  add_no_boundary_conditions(maps_frustums);
   std::move(maps_frustums.begin(), maps_frustums.end(),
             std::back_inserter(maps));
 
+  // --- Transition from frustums to sphere (10 blocks) ---
+  //
+  // Another layer of wedges transitions from the surrounding frustums to a
+  // surrounding sphere.
   Maps maps_first_outer_shell = domain::make_vector_coordinate_map_base<
       Frame::BlockLogical, Frame::Inertial, 3>(sph_wedge_coordinate_maps(
       radius_enveloping_cube_, radius_enveloping_sphere_, frustum_sphericity_,
       1.0, use_equiangular_map_, true, {},
       {domain::CoordinateMaps::Distribution::Linear}));
+  add_no_boundary_conditions(maps_first_outer_shell);
+  std::move(maps_first_outer_shell.begin(), maps_first_outer_shell.end(),
+            std::back_inserter(maps));
+
+  // --- Outer spherical shell (10 blocks) ---
   Maps maps_second_outer_shell = domain::make_vector_coordinate_map_base<
       Frame::BlockLogical, Frame::Inertial, 3>(sph_wedge_coordinate_maps(
       radius_enveloping_sphere_, outer_radius_domain_, 1.0, 1.0,
@@ -451,23 +476,20 @@ Domain<3> BinaryCompactObject::create_domain() const {
   if (outer_boundary_condition_ != nullptr) {
     // The outer 10 wedges all have to have the outer boundary condition
     // applied
-    for (size_t i = 0; i < maps_first_outer_shell.size() +
-                               maps_second_outer_shell.size() - 10;
-         ++i) {
-      boundary_conditions_all_blocks.emplace_back(BcMap{});
-    }
-    for (size_t i = 0; i < 10; ++i) {
+    for (size_t i = 0; i < maps_second_outer_shell.size(); ++i) {
       BcMap bcs{};
       bcs[Direction<3>::upper_zeta()] = outer_boundary_condition_->get_clone();
       boundary_conditions_all_blocks.push_back(std::move(bcs));
     }
   }
-  std::move(maps_first_outer_shell.begin(), maps_first_outer_shell.end(),
-            std::back_inserter(maps));
   std::move(maps_second_outer_shell.begin(), maps_second_outer_shell.end(),
             std::back_inserter(maps));
 
-  // Set up the maps for the central cubes, if any exist.
+  // --- (Optional) object centers (0 to 2 blocks) ---
+  //
+  // Each object can optionally be filled with a cube-shaped block, in which
+  // case the enclosing wedges configured above transition from the cube to a
+  // sphere.
   if (not object_A_.is_excised()) {
     if (outer_boundary_condition_ != nullptr) {
       boundary_conditions_all_blocks.emplace_back(BcMap{});

--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -106,10 +106,13 @@ namespace creators {
  * - 2: The blocks that surround each object with a cube. Around each compact
  *      object, this layer transitions from a sphere to a cube.
  * - 3: The blocks that surround each cube with a half-cube. At this layer, the
- *      two compact objects are enclosed in a single cube-shaped grid.
+ *      two compact objects are enclosed in a single cube-shaped grid. This
+ *      layer can have a spherical outer shape by setting the "frustum
+ *      sphericity" to one.
  * - 4: The 10 blocks that form the first outer shell. This layer transitions
  *      back to spherical. The gridpoints are distributed linearly with respect
- *      to radius.
+ *      to radius. This layer can be omitted if the "frustum sphericity" is one,
+ *      so layer 3 is already spherical.
  * - 5: The 10 blocks that form a second outer shell. This layer is
  *      spherical, so a logarithmic map can optionally be used in this layer.
  *      This allows the domain to extend to large radial distances from the
@@ -336,7 +339,9 @@ class BinaryCompactObject : public DomainCreator<3> {
     static constexpr Options::String help = {
         "Inner radius of the outer spherical shell. Set to 'Auto' to compute a "
         "reasonable value automatically based on the "
-        "'OuterShell.RadialDistribution'."};
+        "'OuterShell.RadialDistribution', or to omit the layer of blocks "
+        "altogether when EnvelopingCube.Sphericity is 1 and hence the "
+        "cube-to-sphere transition is not needed."};
   };
 
   struct InitialRefinement {
@@ -376,6 +381,9 @@ class BinaryCompactObject : public DomainCreator<3> {
         "to a spherical envelope of frustums."};
     static double lower_bound() { return 0.; }
     static double upper_bound() { return 1.; }
+    // Suggest spherical frustums to encourage upgrading, but keep supporting
+    // cubical frustums until spherical frustums are sufficiently battle-tested
+    static double suggested_value() { return 1.; }
   };
 
   struct RadialDistributionOuterShell {
@@ -663,6 +671,7 @@ class BinaryCompactObject : public DomainCreator<3> {
  private:
   Object object_A_{};
   Object object_B_{};
+  bool need_cube_to_sphere_transition_{};
   double radius_enveloping_cube_{};
   double radius_enveloping_sphere_{};
   double outer_radius_domain_{};

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -83,8 +83,12 @@ create_outer_boundary_condition() {
       Direction<3>::upper_zeta(), 50);
 }
 
-auto create_boundary_conditions(const bool excise_A, const bool excise_B) {
-  size_t total_blocks = 54;
+auto create_boundary_conditions(const bool excise_A, const bool excise_B,
+                                const bool need_cube_to_sphere_transition) {
+  size_t total_blocks = 44;
+  if (need_cube_to_sphere_transition) {
+    total_blocks += 10;
+  }
   if (not excise_A) {
     total_blocks++;
   }
@@ -106,7 +110,10 @@ auto create_boundary_conditions(const bool excise_A, const bool excise_B) {
           create_inner_boundary_condition();
     }
   }
-  const size_t block_offset = 44;
+  size_t block_offset = 34;
+  if (need_cube_to_sphere_transition) {
+    block_offset += 10;
+  }
   for (size_t block_id = block_offset; block_id < block_offset + 10;
        ++block_id) {
     boundary_conditions_all_blocks[block_id][Direction<3>::upper_zeta()] =
@@ -341,9 +348,10 @@ void test_connectivity() {
           test_binary_compact_object_construction(
               binary_compact_object,
               std::numeric_limits<double>::signaling_NaN(), {}, {},
-              with_boundary_conditions ? create_boundary_conditions(
-                                             excise_interiorA, excise_interiorB)
-                                       : BoundaryCondVector{});
+              with_boundary_conditions
+                  ? create_boundary_conditions(excise_interiorA,
+                                               excise_interiorB, true)
+                  : BoundaryCondVector{});
 
           // Also check whether the radius of the inner boundary of Layer 5 is
           // chosen correctly.
@@ -568,7 +576,6 @@ std::string create_option_string(const bool excise_A, const bool excise_B,
          "    ObjectACube: [1, 1, 1]\n"
          "    ObjectBCube: [1, 1, 1]\n"
          "    EnvelopingCube: [1, 1, 1]\n"
-         "    CubedShell: [1, 1, 1]\n"
          "    OuterShell: [1, 1, " +
          std::to_string(1 + additional_refinement_outer) +
          "]\n"
@@ -692,7 +699,7 @@ void test_bbh_time_dependent_factory(const bool with_boundary_conditions,
         dynamic_cast<const domain::creators::BinaryCompactObject&>(
             *binary_compact_object),
         time, functions_of_time, expected_functions_of_time,
-        with_boundary_conditions ? create_boundary_conditions(true, true)
+        with_boundary_conditions ? create_boundary_conditions(true, true, false)
                                  : BoundaryCondVector{},
         with_control_systems ? initial_expiration_times : ExpirationTimeMap{});
   }


### PR DESCRIPTION
## Proposed changes

The cube-to-sphere transition is not needed when the layer of frustums is already spherical, as added by https://github.com/sxs-collaboration/spectre/pull/3598. This commit omits the 10 blocks that do the cube-to-sphere transition when the frustums are already spherical.

The old behavior is still supported by just setting the frustum sphericity to 0. We can remove it at a later time, once we are satisfied the bulged frustums work sufficiently well.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
If you use the `BinaryCompactObject` domain, try setting `EnvelopingCube.Sphericity = 1` and `OuterShell.InnerRadius = Auto`. This configuration transitions from the two inner objects to the outer spherical shell in a single layer of blocks, which can greatly improve the effectiveness of grid points in the domain.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
