### PR TITLE
Add Expansion control system

### DIFF
--- a/cmake/SpectreAddTestLibs.cmake
+++ b/cmake/SpectreAddTestLibs.cmake
@@ -54,21 +54,23 @@ function(add_test_library LIBRARY FOLDER LIBRARY_SOURCES LINK_LIBS)
       )
     if(NOT ${FOUND_SPECTRE_TEST_CASE} EQUAL -1)
       # Get the name of the file without path and without extension
-      get_filename_component(
-        SOURCE_NAME
+      string(REGEX REPLACE
+        [^a-zA-Z0-9]
+        _
+        SOURCE_IDENTIFIER
         ${SOURCE_FILE}
-        NAME_WE
         )
       # We specify the macro SPECTRE_TEST_REGISTER_FUNCTION for each
       # source file in the library which is used by the TestingFramework.hpp
       # file to create a function that can be called from the main test
       # executable to get static variables to be initialized in the source
       # file.
+      set(UNIQUE_IDENTIFIER "LIB_${LIBRARY}_FILE_${SOURCE_IDENTIFIER}")
       set_source_files_properties(
         ${SOURCE_FILE}
         PROPERTIES
         COMPILE_FLAGS
-        "-D SPECTRE_TEST_REGISTER_FUNCTION=${LIBRARY}_${SOURCE_NAME}"
+        "-D SPECTRE_TEST_REGISTER_FUNCTION=${UNIQUE_IDENTIFIER}"
         )
       # We use the global "variable" (CMake doesn't really have global
       # variables but global properties are effectively the same)
@@ -83,7 +85,7 @@ function(add_test_library LIBRARY FOLDER LIBRARY_SOURCES LINK_LIBS)
         PROPERTY
         SPECTRE_TESTS_LIB_FUNCTIONS_PROPERTY)
       set(SPECTRE_TESTS_LIB_FUNCTIONS
-        "${SPECTRE_TESTS_LIB_FUNCTIONS};${LIBRARY}_${SOURCE_NAME}")
+        "${SPECTRE_TESTS_LIB_FUNCTIONS};${UNIQUE_IDENTIFIER}")
       set_property(GLOBAL
         PROPERTY
         SPECTRE_TESTS_LIB_FUNCTIONS_PROPERTY

--- a/docs/References.bib
+++ b/docs/References.bib
@@ -1355,6 +1355,21 @@ eprint = {https://doi.org/10.1137/0916035}
   url       = "{http://numerical.recipes}",
 }
 
+@article{Ossokine2013zga,
+  author        = {Ossokine, Serguei and Kidder, Lawrence E. and Pfeiffer,
+                   Harald P.},
+  title         = {Precession-tracking coordinates for simulations of compact-
+                   object-binaries},
+  eprint        = {1304.3067},
+  archivePrefix = {arXiv},
+  primaryClass  = {gr-qc},
+  doi           = {10.1103/PhysRevD.88.084031},
+  journal       = {Phys. Rev. D},
+  volume        = {88},
+  pages         = {084031},
+  year          = {2013}
+}
+
 @article{Ossokine2015yla,
   author        = {Ossokine, Serguei and Foucart, Francois and Pfeiffer, Harald
                    P. and Boyle, Michael and Szil\'agyi, B\'ela},

--- a/src/ApparentHorizons/ComputeHorizonVolumeQuantities.hpp
+++ b/src/ApparentHorizons/ComputeHorizonVolumeQuantities.hpp
@@ -64,12 +64,12 @@ struct ComputeHorizonVolumeQuantities {
       const InverseJacobian<DataVector, 3, Frame::ElementLogical, TargetFrame>&
           inverse_jacobian);
 
-  using allowed_src_tags =
-      tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
-                 GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
-                 GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
-                 Tags::deriv<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
-                             tmpl::size_t<3>, Frame::Inertial>>;
+  using allowed_src_tags = tmpl::list<
+      gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
+      GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
+      GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+      ::Tags::deriv<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+                    tmpl::size_t<3>, Frame::Inertial>>;
   using required_src_tags =
       tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
                  GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,

--- a/src/ControlSystem/CMakeLists.txt
+++ b/src/ControlSystem/CMakeLists.txt
@@ -30,6 +30,7 @@ spectre_target_headers(
   Tags.hpp
   TimescaleTuner.hpp
   Trigger.hpp
+  UpdateControlSystem.hpp
   UpdateFunctionOfTime.hpp
   WriteData.hpp
   )

--- a/src/ControlSystem/CMakeLists.txt
+++ b/src/ControlSystem/CMakeLists.txt
@@ -48,5 +48,7 @@ target_link_libraries(
 
 add_subdirectory(Actions)
 add_subdirectory(ApparentHorizons)
+add_subdirectory(ControlErrors)
 add_subdirectory(Protocols)
+add_subdirectory(Systems)
 add_subdirectory(Tags)

--- a/src/ControlSystem/ControlErrors/CMakeLists.txt
+++ b/src/ControlSystem/ControlErrors/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Expansion.hpp
+  )

--- a/src/ControlSystem/ControlErrors/Expansion.hpp
+++ b/src/ControlSystem/ControlErrors/Expansion.hpp
@@ -1,0 +1,102 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <pup.h>
+
+#include "ApparentHorizons/ObjectLabel.hpp"
+#include "ControlSystem/ApparentHorizons/Measurements.hpp"
+#include "ControlSystem/Protocols/ControlError.hpp"
+#include "ControlSystem/Tags.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace domain::Tags {
+template <size_t Dim>
+struct Domain;
+struct FunctionsOfTime;
+}  // namespace domain::Tags
+/// \endcond
+
+namespace control_system {
+namespace ControlErrors {
+/*!
+ * \brief Control error in the 3D
+ * \link domain::CoordinateMaps::TimeDependent::CubicScale CubicScale \endlink
+ * coordinate map
+ *
+ * \details Computes the error in the map parameter \f$a(t)\f$ using Eq. (40)
+ * from \cite Ossokine2013zga (see \link
+ * domain::CoordinateMaps::TimeDependent::CubicScale CubicScale \endlink for a
+ * definition of \f$a(t)\f$). The equation is
+ *
+ * \f{align}{
+ *   \delta a &= a\left( \frac{\vec{X}\cdot\vec{C}}{||\vec{C}||^2} - 1 \right)
+ * \\ \delta a &= a\left( \frac{X_0}{C_0} - 1 \right) \f}
+ *
+ * where \f$\vec{X} = \vec{x}_B - \vec{x}_A\f$ and \f$\vec{C} = \vec{c}_B -
+ * \vec{c}_A\f$. Here, object B is located on the positive x-axis and object A
+ * is located on the negative x-axis, \f$\vec{X}\f$ is the difference in
+ * positions of the centers of the mapped objects, and
+ * \f$\vec{C}\f$ is the difference of the centers of the excision spheres, all
+ * in the grid frame. It is assumed that the positions of the excision spheres
+ * are exactly along the x-axis, which is why we were able to make the
+ * simplification in the second line above.
+ *
+ * Requirements:
+ * - This control error requires that there be exactly two objects in the
+ *   simulation
+ * - Currently both these objects must be black holes
+ * - Currently this control system can only be used with the \link
+ *   control_system::Systems::Expansion Expansion \endlink control system
+ */
+struct Expansion : tt::ConformsTo<protocols::ControlError> {
+  using options = tmpl::list<>;
+  static constexpr Options::String help{
+      "Computes the control error for expansion control. This should not "
+      "take any options."};
+
+  void pup(PUP::er& /*p*/) {}
+
+  template <typename Metavariables, typename... TupleTags>
+  DataVector operator()(const Parallel::GlobalCache<Metavariables>& cache,
+                        const double time,
+                        const std::string& function_of_time_name,
+                        const tuples::TaggedTuple<TupleTags...>& measurements) {
+    const auto& domain = get<domain::Tags::Domain<3>>(cache);
+    const auto& functions_of_time = get<domain::Tags::FunctionsOfTime>(cache);
+
+    const double current_expansion_factor =
+        functions_of_time.at(function_of_time_name)->func(time)[0][0];
+
+    using horizon_label = ::ah::ObjectLabel;
+    using center_A = control_system::QueueTags::Center<horizon_label::A>;
+    using center_B = control_system::QueueTags::Center<horizon_label::B>;
+
+    const double grid_position_of_A =
+        domain.excision_spheres().at("ObjectAExcisionSphere").center()[0];
+    const double grid_position_of_B =
+        domain.excision_spheres().at("ObjectBExcisionSphere").center()[0];
+    const double current_position_of_A = get<center_A>(measurements)[0];
+    const double current_position_of_B = get<center_B>(measurements)[0];
+
+    // A is to the left of B in grid frame. To get positive differences,
+    // take B - A
+    const double expected_expansion_factor =
+        current_expansion_factor *
+        (current_position_of_B - current_position_of_A) /
+        (grid_position_of_B - grid_position_of_A);
+
+    return {expected_expansion_factor - current_expansion_factor};
+  }
+};
+}  // namespace ControlErrors
+}  // namespace control_system

--- a/src/ControlSystem/NamespaceDocs.hpp
+++ b/src/ControlSystem/NamespaceDocs.hpp
@@ -9,4 +9,29 @@ namespace control_system {
 /// \ingroup ControlSystemGroup
 /// All Actions related to the control system
 namespace Actions {}
+
+/*!
+ * \ingroup ControlSystemGroup
+ * \brief All control errors that will be used in control systems.
+ *
+ * \details A control error is a struct that conforms to the
+ * control_system::protocols::ControlError protocol. Control errors compute the
+ * error between current map parameters and what they are expected to be. See
+ * an example of a control error here:
+ * \snippet Helpers/ControlSystem/Examples.hpp ControlError
+ */
+namespace ControlErrors {}
+
+/*!
+ * \ingroup ControlSystemGroup
+ * \brief All control systems.
+ *
+ * \details A control system is a struct that conforms to the
+ * control_system::protocols::ControlSystem protocol. They are used to control
+ * the time dependent coordinate maps in an evolution. See an example of a
+ * control system here:
+ * \snippet Helpers/ControlSystem/Examples.hpp ControlSystem
+ */
+namespace Systems {}
+
 }  // namespace control_system

--- a/src/ControlSystem/Systems/CMakeLists.txt
+++ b/src/ControlSystem/Systems/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Expansion.hpp
+  )

--- a/src/ControlSystem/Systems/Expansion.hpp
+++ b/src/ControlSystem/Systems/Expansion.hpp
@@ -1,0 +1,110 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <string>
+
+#include "ApparentHorizons/ObjectLabel.hpp"
+#include "ApparentHorizons/Tags.hpp"
+#include "ControlSystem/ApparentHorizons/Measurements.hpp"
+#include "ControlSystem/Component.hpp"
+#include "ControlSystem/ControlErrors/Expansion.hpp"
+#include "ControlSystem/DataVectorHelpers.hpp"
+#include "ControlSystem/Protocols/ControlError.hpp"
+#include "ControlSystem/Protocols/ControlSystem.hpp"
+#include "ControlSystem/Protocols/Measurement.hpp"
+#include "ControlSystem/Tags.hpp"
+#include "ControlSystem/UpdateControlSystem.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/LinkedMessageQueue.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/Actions/UpdateMessageQueue.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Frame {
+struct Grid;
+}  // namespace Frame
+/// \endcond
+
+namespace control_system::Systems {
+/*!
+ * \brief Controls the 3D \link
+ * domain::CoordinateMaps::TimeDependent::CubicScale CubicScale \endlink map
+ *
+ * \details Controls the function \f$a(t)\f$ (a FunctionOfTime) in the
+ * \link domain::CoordinateMaps::TimeDependent::CubicScale
+ * CubicScale \endlink coordinate map, while the function \f$b(t)\f$ is
+ * typically an analytic function (usually a FixedSpeedCubic). See \link
+ * domain::CoordinateMaps::TimeDependent::CubicScale CubicScale \endlink for
+ * definitions of both \f$a(t)\f$ and \f$b(t)\f$.
+ *
+ * Requirements:
+ * - This control system requires that there be exactly two objects in the
+ *   simulation
+ * - Currently both these objects must be black holes
+ * - Currently this control system can only be used with the \link
+ *   control_system::ah::BothHorizons BothHorizons \endlink measurement
+ * - Currently this control system can only be used with the \link
+ *   control_system::ControlErrors::Expansion Expansion \endlink control error
+ */
+template <size_t DerivOrder>
+struct Expansion : tt::ConformsTo<protocols::ControlSystem> {
+  static constexpr size_t deriv_order = DerivOrder;
+
+  static std::string name() {
+    return pretty_type::short_name<Expansion<DerivOrder>>();
+  }
+
+  // Expansion only has one component so just make it "Expansion"
+  static std::string component_name(const size_t /*i*/) { return name(); }
+
+  using measurement = ah::BothHorizons;
+  static_assert(tt::assert_conforms_to<measurement,
+                                       control_system::protocols::Measurement>);
+
+  using control_error = ControlErrors::Expansion;
+  static_assert(tt::assert_conforms_to<
+                control_error, control_system::protocols::ControlError>);
+
+  // tag goes in control component
+  struct MeasurementQueue : db::SimpleTag {
+    using type =
+        LinkedMessageQueue<double,
+                           tmpl::list<QueueTags::Center<::ah::ObjectLabel::A>,
+                                      QueueTags::Center<::ah::ObjectLabel::B>>>;
+  };
+
+  using simple_tags =
+      tmpl::list<MeasurementQueue, Tags::ControlError<Expansion>>;
+
+  struct process_measurement {
+    template <typename Submeasurement>
+    using argument_tags =
+        tmpl::list<StrahlkorperTags::Strahlkorper<Frame::Grid>>;
+
+    template <::ah::ObjectLabel Horizon, typename Metavariables>
+    static void apply(ah::BothHorizons::FindHorizon<Horizon> /*meta*/,
+                      const Strahlkorper<Frame::Grid>& horizon_strahlkorper,
+                      Parallel::GlobalCache<Metavariables>& cache,
+                      const LinkedMessageId<double>& measurement_id) {
+      auto& control_sys_proxy = Parallel::get_parallel_component<
+          ControlComponent<Metavariables, Expansion<DerivOrder>>>(cache);
+
+      const DataVector center =
+          array_to_datavector(horizon_strahlkorper.physical_center());
+
+      Parallel::simple_action<::Actions::UpdateMessageQueue<
+          QueueTags::Center<Horizon>, MeasurementQueue,
+          UpdateControlSystem<Expansion>>>(control_sys_proxy, measurement_id,
+                                           center);
+    }
+  };
+};
+}  // namespace control_system::Systems

--- a/src/ControlSystem/Tags.hpp
+++ b/src/ControlSystem/Tags.hpp
@@ -16,11 +16,32 @@
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
-namespace control_system {
 /// \cond
+namespace ah {
+enum class ObjectLabel;
+}  // namespace ah
+namespace control_system {
 template <typename ControlSystem>
 struct OptionHolder;
+}  // namespace control_system
 /// \endcond
+
+namespace control_system {
+/// \ingroup ControlSystemGroup
+/// All tags that will be used in the LinkedMessageQueue's within control
+/// systems.
+///
+/// These tags will be used to retreive the results of the measurements that
+/// were sent to the control system which have been placed inside a
+/// LinkedMessageQueue.
+namespace QueueTags {
+/// \ingroup ControlSystemGroup
+/// Holds the centers of each horizon from measurements as DataVectors
+template <::ah::ObjectLabel Horizon>
+struct Center {
+  using type = DataVector;
+};
+}  // namespace QueueTags
 
 /// \ingroup ControlSystemGroup
 /// All option tags related to the control system

--- a/src/ControlSystem/Tags.hpp
+++ b/src/ControlSystem/Tags.hpp
@@ -24,6 +24,9 @@ namespace control_system {
 template <typename ControlSystem>
 struct OptionHolder;
 }  // namespace control_system
+namespace OptionTags {
+struct InitialTime;
+}  // namespace OptionTags
 /// \endcond
 
 namespace control_system {
@@ -93,13 +96,6 @@ using inputs =
 namespace Tags {
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ControlSystemGroup
-/// DataBox tag for the name of a control system
-struct ControlSystemName : db::SimpleTag {
-  using type = std::string;
-};
-
-/// \ingroup DataBoxTagsGroup
-/// \ingroup ControlSystemGroup
 /// DataBox tag for writing control system data to disk
 struct WriteDataToDisk : db::SimpleTag {
   using type = bool;
@@ -111,42 +107,61 @@ struct WriteDataToDisk : db::SimpleTag {
 
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ControlSystemGroup
-/// DataBox tag for all options of a single control system.
+/// DataBox tag for the averager
 ///
-/// Only intended to be used during the initialization phase as a way of getting
-/// options from multiple control systems into their corresponding components
-/// DataBox.
+/// To compute the `deriv_order`th derivative of a control error, the max
+/// derivative we need from the averager is the `deriv_order - 1`st derivative.
 template <typename ControlSystem>
-struct ControlSystemInputs : db::SimpleTag {
-  using type = control_system::OptionHolder<ControlSystem>;
+struct Averager : db::SimpleTag {
+  using type = ::Averager<ControlSystem::deriv_order - 1>;
+
   using option_tags =
       tmpl::list<OptionTags::ControlSystemInputs<ControlSystem>>;
-
   static constexpr bool pass_metavariables = false;
-  static type create_from_options(const type& option) { return option; }
-};
-
-/// \ingroup DataBoxTagsGroup
-/// \ingroup ControlSystemGroup
-/// DataBox tag for the averager
-template <size_t DerivOrder>
-struct Averager : db::SimpleTag {
-  using type = ::Averager<DerivOrder>;
+  static type create_from_options(
+      const control_system::OptionHolder<ControlSystem>& option_holder) {
+    return option_holder.averager;
+  }
 };
 
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ControlSystemGroup
 /// DataBox tag for the timescale tuner
+template <typename ControlSystem>
 struct TimescaleTuner : db::SimpleTag {
   using type = ::TimescaleTuner;
+
+  using option_tags =
+      tmpl::list<OptionTags::ControlSystemInputs<ControlSystem>>;
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(
+      const control_system::OptionHolder<ControlSystem>& option_holder) {
+    return option_holder.tuner;
+  }
 };
 
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ControlSystemGroup
 /// DataBox tag for the controller
-template <size_t DerivOrder>
+template <typename ControlSystem>
 struct Controller : db::SimpleTag {
-  using type = ::Controller<DerivOrder>;
+  using type = ::Controller<ControlSystem::deriv_order>;
+
+  using option_tags =
+      tmpl::list<::OptionTags::InitialTime,
+                 OptionTags::ControlSystemInputs<ControlSystem>>;
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(
+      const double initial_time,
+      const control_system::OptionHolder<ControlSystem>& option_holder) {
+    type controller = option_holder.controller;
+    const ::TimescaleTuner tuner = option_holder.tuner;
+
+    controller.set_initial_update_time(initial_time);
+    controller.assign_time_between_updates(min(tuner.current_timescale()));
+
+    return controller;
+  }
 };
 
 /// \ingroup DataBoxTagsGroup
@@ -155,6 +170,14 @@ struct Controller : db::SimpleTag {
 template <typename ControlSystem>
 struct ControlError : db::SimpleTag {
   using type = typename ControlSystem::control_error;
+
+  using option_tags =
+      tmpl::list<OptionTags::ControlSystemInputs<ControlSystem>>;
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(
+      const control_system::OptionHolder<ControlSystem>& option_holder) {
+    return option_holder.control_error;
+  }
 };
 }  // namespace Tags
 
@@ -171,7 +194,7 @@ struct OptionHolder {
   using control_system = ControlSystem;
   static constexpr size_t deriv_order = control_system::deriv_order;
   struct Averager {
-    using type = ::Averager<deriv_order>;
+    using type = ::Averager<deriv_order - 1>;
     static constexpr Options::String help = {
         "Averages the derivatives of the control error and possibly the "
         "control error itself."};
@@ -202,7 +225,7 @@ struct OptionHolder {
       tmpl::list<Averager, Controller, TimescaleTuner, ControlError>;
   static constexpr Options::String help = {"Options for a control system."};
 
-  OptionHolder(::Averager<deriv_order> input_averager,
+  OptionHolder(::Averager<deriv_order - 1> input_averager,
                ::Controller<deriv_order> input_controller,
                ::TimescaleTuner input_tuner,
                typename ControlSystem::control_error input_control_error)
@@ -228,7 +251,7 @@ struct OptionHolder {
 
   // These members are specifically made public for easy access during
   // initialization
-  ::Averager<deriv_order> averager{};
+  ::Averager<deriv_order - 1> averager{};
   ::Controller<deriv_order> controller{};
   ::TimescaleTuner tuner{};
   typename ControlSystem::control_error control_error{};

--- a/src/ControlSystem/Tags/MeasurementTimescales.hpp
+++ b/src/ControlSystem/Tags/MeasurementTimescales.hpp
@@ -36,9 +36,9 @@ namespace control_system {
  * \tau_\mathrm{damp}\f$ where \f$\tau_\mathrm{damp}\f$ is the damping timescale
  * (from the TimescaleTuner) and \f$\alpha_\mathrm{update}\f$ is the update
  * fraction (from the controller). For an Nth order control system, the averager
- * requires at least N measurements in order to perfom its finitite differencing
- * to calculate the derivatives of the control error. This implies that the
- * largest the measurement timescale can be is \f$\tau_\mathrm{m} =
+ * requires at least N measurements in order to perform its finite
+ * differencing to calculate the derivatives of the control error. This implies
+ * that the largest the measurement timescale can be is \f$\tau_\mathrm{m} =
  * \tau_\mathrm{update} / N\f$. To ensure that we have sufficient measurements,
  * we calculate the measurement timescales as \f$\tau_\mathrm{m} =
  * \tau_\mathrm{update} / (N+1)\f$

--- a/src/ControlSystem/UpdateControlSystem.hpp
+++ b/src/ControlSystem/UpdateControlSystem.hpp
@@ -1,0 +1,229 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cmath>
+
+#include "ControlSystem/Averager.hpp"
+#include "ControlSystem/Controller.hpp"
+#include "ControlSystem/Tags.hpp"
+#include "ControlSystem/Tags/MeasurementTimescales.hpp"
+#include "ControlSystem/TimescaleTuner.hpp"
+#include "ControlSystem/UpdateFunctionOfTime.hpp"
+#include "ControlSystem/WriteData.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/LinkedMessageQueue.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Domain/Tags.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace domain::Tags {
+struct FunctionsOfTime;
+}  // namespace domain::Tags
+
+namespace control_system {
+/*!
+ * \brief Functor for updating control systems when they are ready.
+ *
+ * \details The apply operator of this struct is meant to be called by the
+ * UpdateMessageQueue action once an entire measurement has been made.
+ *
+ * Requires a few tags to be in the DataBox of the ControlComponent that this
+ * is running on:
+ * - \link Tags::Averager Averager \endlink
+ * - \link Tags::Controller Controller \endlink
+ * - \link Tags::TimescaleTuner TimescaleTuner \endlink
+ * - \link Tags::ControlError ControlError \endlink
+ * - \link Tags::WriteDataToDisk WriteDataToDisk \endlink
+ *
+ * If these are not in the DataBox, an error will occur.
+ *
+ * The algorithm to determine whether or not to update the functions of time is
+ * as follows:
+ * 1. Determine if we need to update now. This is done by checking if the next
+ *    measurement scheduled to happen will be after the current expiration time
+ *    of the function of time we are controlling. If it is, we need to update
+ *    now, otherwise the functions of time will be expired the next time we
+ *    measure.
+ * 2. Determine if we should store the current measurement. Not all control
+ *    systems are on the same timescale; some are on shorter timescales (like
+ *    characteristic speed control), some are on longer timescales (like
+ *    Rotation). The ones on longer timescales don't need to record measurements
+ *    as often as the ones on shorter timescales. If they did, this could
+ *    introduce unnecessary noise into the measurements. It also causes the
+ *    control errors to be calculated based off only measurements from the end
+ *    of the update interval. This is not what we want. We want measurements
+ *    throughout the udpate interval. If we don't need to store the current
+ *    measurement and we don't need to update now, end here.
+ * 3. Calculate the control error and update the averager (store the current
+ *    measurement).
+ * 4. Determine if we need to update. We only want to update at the very end of
+ *    the update interval, not sooner. If we don't need to update, end here.
+ * 5. Compute control signal using the control error and its derivatives.
+ * 6. Determine the new expiration time.
+ * 7. Update the function of time.
+ * 8. Update the damping timescale using the control error and one derivative.
+ * 9. Determine the new measurement timescale for this function of time using
+ *    the new damping timescale.
+ * 10. Update the measurement timescale.
+ * 11. Write the function of time, control error, their derivatives, and the
+ *     control signal to disk if specified in the input file.
+ */
+template <typename ControlSystem>
+struct UpdateControlSystem {
+  static constexpr size_t deriv_order = ControlSystem::deriv_order;
+
+  template <typename DbTags, typename Metavariables, typename ArrayIndex,
+            typename... TupleTags>
+  static void apply(const gsl::not_null<db::DataBox<DbTags>*> box,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/, const double time,
+                    tuples::TaggedTuple<TupleTags...> data) {
+    if constexpr (db::tag_is_retrievable_v<
+                      control_system::Tags::Averager<ControlSystem>,
+                      db::DataBox<DbTags>> and
+                  db::tag_is_retrievable_v<
+                      control_system::Tags::Controller<ControlSystem>,
+                      db::DataBox<DbTags>> and
+                  db::tag_is_retrievable_v<
+                      control_system::Tags::TimescaleTuner<ControlSystem>,
+                      db::DataBox<DbTags>> and
+                  db::tag_is_retrievable_v<
+                      control_system::Tags::ControlError<ControlSystem>,
+                      db::DataBox<DbTags>> and
+                  db::tag_is_retrievable_v<
+                      ::control_system::Tags::WriteDataToDisk,
+                      db::DataBox<DbTags>>) {
+      // Begin step 1
+      const auto& functions_of_time =
+          Parallel::get<::domain::Tags::FunctionsOfTime>(cache);
+      const auto& measurement_timescales =
+          Parallel::get<Tags::MeasurementTimescales>(cache);
+      const std::string& function_of_time_name = ControlSystem::name();
+      const auto& function_of_time =
+          functions_of_time.at(function_of_time_name);
+
+      const double current_expiration_time = function_of_time->time_bounds()[1];
+      // We need the min over all functions of time because that's when the next
+      // measurement will be
+      double current_min_time_between_measurements{
+          std::numeric_limits<double>::max()};
+      for (const auto& [name, measurement_timescale_fot] :
+           measurement_timescales) {
+        // Avoid compiler warning with gcc-7
+        (void)name;
+        current_min_time_between_measurements =
+            std::min(current_min_time_between_measurements,
+                     min(measurement_timescale_fot->func(time)[0]));
+      }
+
+      // If the next time we are going to measure is after the current
+      // expiration time, we have to update things now
+      const bool need_to_update_now =
+          current_expiration_time <
+          time + current_min_time_between_measurements;
+
+      // Begin step 2
+      // Get the averager, controller, tuner, and control error from the box
+      auto& averager = db::get_mutable_reference<
+          control_system::Tags::Averager<ControlSystem>>(box);
+      auto& controller = db::get_mutable_reference<
+          control_system::Tags::Controller<ControlSystem>>(box);
+      auto& tuner = db::get_mutable_reference<
+          control_system::Tags::TimescaleTuner<ControlSystem>>(box);
+      auto& control_error = db::get_mutable_reference<
+          control_system::Tags::ControlError<ControlSystem>>(box);
+      const DataVector& current_timescale = tuner.current_timescale();
+
+      // Check if we actually need to use the measurement. If a control system
+      // is on a longer timescale, we don't need to store frequent measurements
+      if (not(averager.is_ready(time) or need_to_update_now)) {
+        return;
+      }
+
+      // Begin step 3
+      // Compute control error
+      const DataVector Q =
+          control_error(cache, time, function_of_time_name, data);
+
+      // Update the averager. We do this before we call controller.is_ready()
+      // because we still want the averager to be up to date even if we aren't
+      // updating at this time
+      averager.update(time, Q, current_timescale);
+
+      // Begin step 4
+      // Check if it is time to update
+      if (not(controller.is_ready(time) or need_to_update_now)) {
+        return;
+      }
+
+      // Begin step 5
+      // Get the averaged values of the control error and its derivatives
+      const auto& opt_avg_values = averager(time);
+
+      const double time_offset =
+          averager.last_time_updated() - averager.average_time(time);
+      const double time_offset_0th =
+          averager.using_average_0th_deriv_of_q() ? time_offset : 0.0;
+
+      // Calculate the control signal which will be used to update the highest
+      // derivative of the FunctionOfTime
+      const DataVector control_signal =
+          controller(time, current_timescale, opt_avg_values.value(),
+                     time_offset_0th, time_offset);
+
+      // Begin step 6
+      // Calculate the next expiration time based on the current one
+      const double new_expiration_time =
+          controller.next_expiration_time(current_expiration_time);
+
+      // Begin step 7
+      // Actually update the FunctionOfTime
+      Parallel::mutate<::domain::Tags::FunctionsOfTime, UpdateFunctionOfTime>(
+          cache, function_of_time_name, current_expiration_time, control_signal,
+          new_expiration_time);
+
+      // Begin step 8
+      // Update the damping timescales with the newly calculated control error
+      // and its derivative
+      std::array<DataVector, 2> q_and_dtq{
+          {(*opt_avg_values)[0], {(*opt_avg_values)[0].size(), 0.0}}};
+      if constexpr (deriv_order > 1) {
+        q_and_dtq[1] = (*opt_avg_values)[1];
+      }
+      tuner.update_timescale(q_and_dtq);
+
+      // Begin step 9
+      // Calculate new measurement timescales with updated damping timescales
+      const DataVector new_measurement_timescale =
+          calculate_measurement_timescales(controller, tuner);
+
+      // Begin step 10
+      // Update the measurement timescales
+      Parallel::mutate<Tags::MeasurementTimescales, UpdateFunctionOfTime>(
+          cache, function_of_time_name, current_expiration_time,
+          new_measurement_timescale, new_expiration_time);
+
+      // Now that the measurement timescales have been updated, tell the
+      // averager when to expect the next measurement
+      averager.assign_time_between_measurements(min(new_measurement_timescale));
+
+      // Begin step 11
+      if (db::get<control_system::Tags::WriteDataToDisk>(*box)) {
+        write_components_to_disk<ControlSystem>(
+            time, cache, function_of_time, *opt_avg_values, control_signal);
+      }
+    } else {
+      (void)(box);
+      (void)(cache);
+      (void)(time);
+      (void)(data);
+      ERROR("Wrong DataBox. Expecting a DataBox from a ControlComponent.");
+    }
+  }
+};
+}  // namespace control_system

--- a/tests/Unit/ControlSystem/CMakeLists.txt
+++ b/tests/Unit/ControlSystem/CMakeLists.txt
@@ -19,7 +19,9 @@ set(LIBRARY_SOURCES
   )
 
 add_subdirectory(Actions)
+add_subdirectory(ControlErrors)
 add_subdirectory(Protocols)
+add_subdirectory(Systems)
 add_subdirectory(Tags)
 
 add_test_library(

--- a/tests/Unit/ControlSystem/ControlErrors/CMakeLists.txt
+++ b/tests/Unit/ControlSystem/ControlErrors/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY_SOURCES
+  ${LIBRARY_SOURCES}
+  ControlErrors/Test_Expansion.cpp
+  PARENT_SCOPE)

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
@@ -1,0 +1,128 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+
+#include "ControlSystem/Tags.hpp"
+#include "ControlSystem/Tags/MeasurementTimescales.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Helpers/ControlSystem/SystemHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace control_system {
+namespace {
+void test_expansion_control_error() {
+  constexpr size_t deriv_order = 2;
+  using metavars = TestHelpers::MockMetavars<deriv_order>;
+  using element_component = typename metavars::element_component;
+  MAKE_GENERATOR(gen);
+
+  // Global things
+  domain::FunctionsOfTime::register_derived_with_charm();
+  double initial_time = 0.0;
+  const double initial_separation = 15.0;
+
+  // Set up the system helper.
+  control_system::TestHelpers::SystemHelper<metavars> system_helper{};
+
+  const std::string input_options =
+      "Evolution:\n"
+      "  InitialTime: 0.0\n"
+      "ControlSystems:\n"
+      "  WriteDataToDisk: false\n"
+      "  Expansion:\n"
+      "    Averager:\n"
+      "      AverageTimescaleFraction: 0.25\n"
+      "      Average0thDeriv: true\n"
+      "    Controller:\n"
+      "      UpdateFraction: 0.3\n"
+      "    TimescaleTuner:\n"
+      "      InitialTimescales: [0.5]\n"
+      "      MinTimescale: 0.1\n"
+      "      MaxTimescale: 10.\n"
+      "      DecreaseThreshold: 2.0\n"
+      "      IncreaseThreshold: 0.1\n"
+      "      IncreaseFactor: 1.01\n"
+      "      DecreaseFactor: 0.99\n"
+      "    ControlError:\n";
+
+  // Initialize everything within the system helper
+  system_helper.setup_control_system_test(initial_time, initial_separation,
+                                          input_options);
+
+  // Get references to everything that was set up inside the system helper. The
+  // domain and two functions of time are not const references because they need
+  // to be moved into the runner
+  auto& domain = system_helper.domain();
+  auto& initial_functions_of_time = system_helper.initial_functions_of_time();
+  auto& initial_measurement_timescales =
+      system_helper.initial_measurement_timescales();
+  const std::string& expansion_name = system_helper.expansion_name();
+
+  // Setup runner and element component because it's the easiest way to get the
+  // global cache
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
+  MockRuntimeSystem runner{{std::move(domain)},
+                           {std::move(initial_functions_of_time),
+                            std::move(initial_measurement_timescales)}};
+  ActionTesting::emplace_array_component<element_component>(
+      make_not_null(&runner), ActionTesting::NodeId{0},
+      ActionTesting::LocalCoreId{0}, 0);
+  const auto& cache = ActionTesting::cache<element_component>(runner, 0);
+  const auto& functions_of_time =
+      Parallel::get<domain::Tags::FunctionsOfTime>(cache);
+
+  using QueueTuple = tuples::TaggedTuple<
+      control_system::QueueTags::Center<::ah::ObjectLabel::A>,
+      control_system::QueueTags::Center<::ah::ObjectLabel::B>>;
+
+  // Create fake measurements. For expansion we only care about the x component
+  // because that's all that is used. B is on the positive x-axis, A is on the
+  // negative x-axis
+  std::uniform_real_distribution<double> dist{5.0, 15.0};
+  const double pos_A_x = -dist(gen);
+  const double pos_B_x = dist(gen);
+  QueueTuple fake_measurement_tuple{DataVector{pos_A_x, 0.0, 0.0},
+                                    DataVector{pos_B_x, 0.0, 0.0}};
+
+  using expansion_system = typename metavars::expansion_system;
+  using ControlError = expansion_system::control_error;
+
+  // This is before the first expiration time
+  const double check_time = 0.1;
+  const DataVector control_error =
+      ControlError{}(cache, check_time, expansion_name, fake_measurement_tuple);
+
+  const auto& expansion_f_of_t =
+      dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>&>(
+          *functions_of_time.at(expansion_name));
+  const auto& domain_from_cache = get<domain::Tags::Domain<3>>(cache);
+  // Since we haven't updated, the expansion factor should just be 1.0
+  const double exp_factor = expansion_f_of_t.func(check_time)[0][0];
+  const double pos_diff = pos_B_x - pos_A_x;
+  const double grid_diff = domain_from_cache.excision_spheres()
+                               .at("ObjectBExcisionSphere")
+                               .center()[0] -
+                           domain_from_cache.excision_spheres()
+                               .at("ObjectAExcisionSphere")
+                               .center()[0];
+
+  const DataVector expected_control_error{exp_factor *
+                                          (pos_diff / grid_diff - 1.0)};
+
+  CHECK(control_error == expected_control_error);
+}
+
+SPECTRE_TEST_CASE("Unit.ControlSystem.ControlErrors.Expansion",
+                  "[ControlSystem][Unit]") {
+  test_expansion_control_error();
+}
+}  // namespace
+}  // namespace control_system

--- a/tests/Unit/ControlSystem/Systems/CMakeLists.txt
+++ b/tests/Unit/ControlSystem/Systems/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY_SOURCES
+  ${LIBRARY_SOURCES}
+  Systems/Test_Expansion.cpp
+  PARENT_SCOPE)

--- a/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
@@ -1,0 +1,170 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <string>
+
+#include "ControlSystem/Systems/Expansion.hpp"
+#include "ControlSystem/Tags.hpp"
+#include "ControlSystem/Tags/MeasurementTimescales.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/TimeDependent/CubicScale.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Helpers/ControlSystem/SystemHelpers.hpp"
+#include "Helpers/PointwiseFunctions/PostNewtonian/BinaryTrajectories.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Frame {
+struct Grid;
+struct Inertial;
+}  // namespace Frame
+
+namespace control_system {
+namespace {
+using ExpansionMap = domain::CoordinateMaps::TimeDependent::CubicScale<3>;
+
+using CoordMap =
+    domain::CoordinateMap<Frame::Grid, Frame::Inertial, ExpansionMap>;
+
+template <size_t DerivOrder>
+void test_expansion_control_system() {
+  using metavars = TestHelpers::MockMetavars<DerivOrder>;
+  using expansion_component = typename metavars::expansion_component;
+  using element_component = typename metavars::element_component;
+  using observer_component = typename metavars::observer_component;
+  MAKE_GENERATOR(gen);
+
+  // Global things
+  domain::FunctionsOfTime::register_derived_with_charm();
+  double initial_time = 0.0;
+  const double initial_separation = 15.0;
+  // This final time is chosen so that the damping timescales have adequate time
+  // to reach the maximum damping timescale
+  const double final_time = 500.0;
+
+  // Set up the system helper.
+  control_system::TestHelpers::SystemHelper<metavars> system_helper{};
+
+  const std::string input_options =
+      "Evolution:\n"
+      "  InitialTime: 0.0\n"
+      "ControlSystems:\n"
+      "  WriteDataToDisk: false\n"
+      "  Expansion:\n"
+      "    Averager:\n"
+      "      AverageTimescaleFraction: 0.25\n"
+      "      Average0thDeriv: true\n"
+      "    Controller:\n"
+      "      UpdateFraction: 0.3\n"
+      "    TimescaleTuner:\n"
+      "      InitialTimescales: [0.5]\n"
+      "      MinTimescale: 0.1\n"
+      "      MaxTimescale: 10.\n"
+      "      DecreaseThreshold: 2.0\n"
+      "      IncreaseThreshold: 0.1\n"
+      "      IncreaseFactor: 1.01\n"
+      "      DecreaseFactor: 0.99\n"
+      "    ControlError:\n";
+
+  // Initialize everything within the system helper
+  system_helper.setup_control_system_test(initial_time, initial_separation,
+                                          input_options);
+
+  // Get references to everything that was set up inside the system helper. The
+  // domain and two functions of time are not const references because they need
+  // to be moved into the runner
+  auto& domain = system_helper.domain();
+  auto& initial_functions_of_time = system_helper.initial_functions_of_time();
+  auto& initial_measurement_timescales =
+      system_helper.initial_measurement_timescales();
+  const auto& init_exp_tuple = system_helper.init_exp_tuple();
+
+  // Setup runner and all components
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
+  MockRuntimeSystem runner{{std::move(domain)},
+                           {std::move(initial_functions_of_time),
+                            std::move(initial_measurement_timescales)}};
+  ActionTesting::emplace_singleton_component_and_initialize<
+      expansion_component>(make_not_null(&runner), ActionTesting::NodeId{0},
+                           ActionTesting::LocalCoreId{0}, init_exp_tuple);
+  ActionTesting::emplace_array_component<element_component>(
+      make_not_null(&runner), ActionTesting::NodeId{0},
+      ActionTesting::LocalCoreId{0}, 0);
+  ActionTesting::emplace_nodegroup_component<observer_component>(
+      make_not_null(&runner));
+
+  ActionTesting::set_phase(make_not_null(&runner), metavars::Phase::Testing);
+
+  const BinaryTrajectories binary_trajectories{initial_separation};
+
+  const std::string& expansion_name = system_helper.expansion_name();
+
+  // Create coordinate maps for mapping the PN expansion to the "grid" frame
+  // where the control system does its calculations
+  // The outer boundary is at 1000.0 so that we don't have to worry about it.
+  ExpansionMap expansion_map{1000.0, expansion_name,
+                             expansion_name + "OuterBoundary"s};
+
+  CoordMap coord_map{expansion_map};
+
+  // Get the functions of time from the cache to use in the maps
+  const auto& cache = ActionTesting::cache<element_component>(runner, 0);
+  const auto& functions_of_time =
+      Parallel::get<domain::Tags::FunctionsOfTime>(cache);
+
+  const auto position_function = [&binary_trajectories](const double time) {
+    const double separation = binary_trajectories.separation(time);
+    return std::pair<std::array<double, 3>, std::array<double, 3>>{
+        {-0.5 * separation, 0.0, 0.0}, {0.5 * separation, 0.0, 0.0}};
+  };
+
+  // Run the actual control system test.
+  system_helper.run_control_system_test(runner, final_time, make_not_null(&gen),
+                                        position_function, coord_map);
+
+  // Grab results
+  const std::array<double, 3>& grid_position_of_a =
+      system_helper.grid_position_of_a();
+  const std::array<double, 3>& grid_position_of_b =
+      system_helper.grid_position_of_b();
+
+  // Our expected positions are just the initial positions
+  const std::array<double, 3> expected_grid_position_of_a{
+      {-0.5 * initial_separation, 0.0, 0.0}};
+  const std::array<double, 3> expected_grid_position_of_b{
+      {0.5 * initial_separation, 0.0, 0.0}};
+
+  const auto& expansion_f_of_t =
+      dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<DerivOrder>&>(
+          *functions_of_time.at(expansion_name));
+
+  const double exp_factor = expansion_f_of_t.func(final_time)[0][0];
+
+  // The control system gets more accurate the longer you run for. However, this
+  // is the floor of our accuracy for a changing function of time.
+  Approx custom_approx = Approx::custom().epsilon(5.0e-6).scale(1.0);
+  const double expected_exp_factor =
+      binary_trajectories.separation(final_time) / initial_separation;
+  CHECK(custom_approx(expected_exp_factor) == exp_factor);
+
+  CHECK_ITERABLE_CUSTOM_APPROX(expected_grid_position_of_a, grid_position_of_a,
+                               custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(expected_grid_position_of_b, grid_position_of_b,
+                               custom_approx);
+}
+
+SPECTRE_TEST_CASE("Unit.ControlSystem.Systems.Expansion",
+                  "[ControlSystem][Unit]") {
+  test_expansion_control_system<2>();
+  test_expansion_control_system<3>();
+}
+}  // namespace
+}  // namespace control_system

--- a/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
@@ -180,7 +180,7 @@ void test_functions_of_time_tag() {
   const TimescaleTuner tuner1({timescale}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01,
                               0.99);
   const TimescaleTuner tuner2({0.1}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01, 0.99);
-  const Averager<2> averager(0.25, true);
+  const Averager<1> averager(0.25, true);
   const double update_fraction = 0.3;
   const Controller<2> controller(update_fraction);
   const control_system::TestHelpers::ControlError control_error{};
@@ -227,7 +227,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Tags.FunctionsOfTimeInitialize",
 
         const TimescaleTuner tuner({1.0}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01,
                                    0.99);
-        const Averager<2> averager(0.25, true);
+        const Averager<1> averager(0.25, true);
         const double update_fraction = 0.3;
         const Controller<2> controller(update_fraction);
         const control_system::TestHelpers::ControlError control_error{};
@@ -258,7 +258,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Tags.FunctionsOfTimeInitialize",
 
         const TimescaleTuner tuner({1.0}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01,
                                    0.99);
-        const Averager<2> averager(0.25, true);
+        const Averager<1> averager(0.25, true);
         const double update_fraction = 0.3;
         const Controller<2> controller(update_fraction);
         const control_system::TestHelpers::ControlError control_error{};

--- a/tests/Unit/ControlSystem/Tags/Test_MeasurementTimescales.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_MeasurementTimescales.cpp
@@ -58,13 +58,13 @@ void test_calculate_measurement_timescales() {
   const double update_fraction = 0.25;
   const Controller<DerivOrder> controller(update_fraction);
 
-  const auto measurment_timescales =
+  const auto measurement_timescales =
       control_system::calculate_measurement_timescales(controller, tuner);
 
   const DataVector expected_measurement_timescales =
       DataVector{{timescale}} * update_fraction / double(DerivOrder + 1);
 
-  CHECK(expected_measurement_timescales == measurment_timescales);
+  CHECK(expected_measurement_timescales == measurement_timescales);
 }
 
 template <size_t Index>

--- a/tests/Unit/ControlSystem/Tags/Test_MeasurementTimescales.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_MeasurementTimescales.cpp
@@ -89,7 +89,7 @@ void test_measurement_tag() {
     const TimescaleTuner tuner2({timescale2}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4,
                                 1.01, 0.99);
     const double averaging_fraction = 0.25;
-    const Averager<2> averager(averaging_fraction, true);
+    const Averager<1> averager(averaging_fraction, true);
     const double update_fraction = 0.3;
     const Controller<2> controller(update_fraction);
     const control_system::TestHelpers::ControlError control_error{};
@@ -159,7 +159,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Tags.MeasurementTimescales.Backwards",
   ERROR_TEST();
   const TimescaleTuner tuner1({27.0}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01, 0.99);
   const TimescaleTuner tuner2({0.1}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01, 0.99);
-  const Averager<2> averager(0.25, true);
+  const Averager<1> averager(0.25, true);
   const Controller<2> controller(0.3);
   const control_system::TestHelpers::ControlError control_error{};
 

--- a/tests/Unit/ControlSystem/Test_InitialExpirationTimes.cpp
+++ b/tests/Unit/ControlSystem/Test_InitialExpirationTimes.cpp
@@ -58,7 +58,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.ConstructInitialExpirationTimes",
   const TimescaleTuner tuner1({timescale}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01,
                               0.99);
   const TimescaleTuner tuner2({0.1}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01, 0.99);
-  const Averager<2> averager(0.25, true);
+  const Averager<1> averager(0.25, true);
   const double update_fraction = 0.3;
   const Controller<2> controller(update_fraction);
   const control_system::TestHelpers::ControlError control_error{};

--- a/tests/Unit/ControlSystem/Test_Tags.cpp
+++ b/tests/Unit/ControlSystem/Test_Tags.cpp
@@ -26,31 +26,24 @@
 namespace {
 void test_all_tags() {
   INFO("Test all tags");
-  using name_tag = control_system::Tags::ControlSystemName;
-  TestHelpers::db::test_simple_tag<name_tag>("ControlSystemName");
-  using write_tag = control_system::Tags::WriteDataToDisk;
-  TestHelpers::db::test_simple_tag<write_tag>("WriteDataToDisk");
-  using averager_tag = control_system::Tags::Averager<2>;
-  TestHelpers::db::test_simple_tag<averager_tag>("Averager");
-  using timescaletuner_tag = control_system::Tags::TimescaleTuner;
-  TestHelpers::db::test_simple_tag<timescaletuner_tag>("TimescaleTuner");
-  using controller_tag = control_system::Tags::Controller<2>;
-  TestHelpers::db::test_simple_tag<controller_tag>("Controller");
-  using fot_tag = control_system::Tags::FunctionsOfTimeInitialize;
-  TestHelpers::db::test_simple_tag<fot_tag>("FunctionsOfTime");
-
   using system = control_system::TestHelpers::System<
       2, control_system::TestHelpers::TestStructs_detail::LabelA,
       control_system::TestHelpers::Measurement<
           control_system::TestHelpers::TestStructs_detail::LabelA>>;
 
+  using write_tag = control_system::Tags::WriteDataToDisk;
+  TestHelpers::db::test_simple_tag<write_tag>("WriteDataToDisk");
+  using averager_tag = control_system::Tags::Averager<system>;
+  TestHelpers::db::test_simple_tag<averager_tag>("Averager");
+  using timescaletuner_tag = control_system::Tags::TimescaleTuner<system>;
+  TestHelpers::db::test_simple_tag<timescaletuner_tag>("TimescaleTuner");
+  using controller_tag = control_system::Tags::Controller<system>;
+  TestHelpers::db::test_simple_tag<controller_tag>("Controller");
+  using fot_tag = control_system::Tags::FunctionsOfTimeInitialize;
+  TestHelpers::db::test_simple_tag<fot_tag>("FunctionsOfTime");
+
   using control_error_tag = control_system::Tags::ControlError<system>;
   TestHelpers::db::test_simple_tag<control_error_tag>("ControlError");
-
-  using control_system_inputs_tag =
-      control_system::Tags::ControlSystemInputs<system>;
-  TestHelpers::db::test_simple_tag<control_system_inputs_tag>(
-      "ControlSystemInputs");
 
   using measurement_tag = control_system::Tags::MeasurementTimescales;
   TestHelpers::db::test_simple_tag<measurement_tag>("MeasurementTimescales");
@@ -67,7 +60,7 @@ void test_control_sys_inputs() {
   const TimescaleTuner expected_tuner(
       {1.}, max_timescale, min_timescale, decrease_timescale_threshold,
       increase_timescale_threshold, increase_factor, decrease_factor);
-  const Averager<2> expected_averager(0.25, true);
+  const Averager<1> expected_averager(0.25, true);
   const Controller<2> expected_controller(0.3);
   const std::string expected_name{"LabelA"};
 

--- a/tests/Unit/Helpers/ControlSystem/CMakeLists.txt
+++ b/tests/Unit/Helpers/ControlSystem/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/tests/Unit
   HEADERS
   Examples.hpp
+  SystemHelpers.hpp
   TestStructs.hpp
   )
 
@@ -17,6 +18,7 @@ target_link_libraries(
   ${LIBRARY}
   INTERFACE
   ControlSystem
+  Domain
   DataStructures
   Parallel
   Time

--- a/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
+++ b/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
@@ -1,0 +1,456 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#include "ApparentHorizons/ObjectLabel.hpp"
+#include "ControlSystem/ApparentHorizons/Measurements.hpp"
+#include "ControlSystem/Averager.hpp"
+#include "ControlSystem/Component.hpp"
+#include "ControlSystem/ControlErrors/Expansion.hpp"
+#include "ControlSystem/Controller.hpp"
+#include "ControlSystem/DataVectorHelpers.hpp"
+#include "ControlSystem/Systems/Expansion.hpp"
+#include "ControlSystem/Tags.hpp"
+#include "ControlSystem/Tags/MeasurementTimescales.hpp"
+#include "ControlSystem/TimescaleTuner.hpp"
+#include "ControlSystem/UpdateControlSystem.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/LinkedMessageQueue.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/FunctionsOfTime/FixedSpeedCubic.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Tags.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestingFramework.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "Options/ParseOptions.hpp"
+#include "Parallel/CreateFromOptions.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace OptionTags {
+struct InitialTime;
+}  // namespace OptionTags
+/// \endcond
+
+namespace control_system::TestHelpers {
+template <typename ControlSystem>
+using init_simple_tags =
+    tmpl::list<control_system::Tags::Averager<ControlSystem>,
+               control_system::Tags::TimescaleTuner<ControlSystem>,
+               control_system::Tags::Controller<ControlSystem>,
+               control_system::Tags::ControlError<ControlSystem>,
+               control_system::Tags::WriteDataToDisk,
+               typename ControlSystem::MeasurementQueue>;
+
+template <typename Metavariables, typename ControlSystem>
+struct MockControlComponent {
+  using array_index = int;
+  using component_being_mocked = ControlComponent<Metavariables, ControlSystem>;
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockSingletonChare;
+
+  using system = ControlSystem;
+
+  using simple_tags = init_simple_tags<ControlSystem>;
+
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      typename metavariables::Phase, metavariables::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>>;
+};
+
+template <typename Metavars>
+struct MockElementComponent {
+  using array_index = int;
+  using chare_type = ActionTesting::MockArrayChare;
+
+  using metavariables = Metavars;
+
+  using simple_tags = tmpl::list<>;
+
+  using const_global_cache_tags =
+      tmpl::list<domain::Tags::Domain<Metavars::volume_dim>>;
+
+  using mutable_global_cache_tags =
+      tmpl::list<domain::Tags::FunctionsOfTimeInitialize,
+                 control_system::Tags::MeasurementTimescales>;
+
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<typename metavariables::Phase,
+                                        metavariables::Phase::Initialization,
+                                        tmpl::list<>>>;
+};
+
+template <typename Metavars>
+struct MockObserverWriter {
+  using component_being_mocked = observers::ObserverWriter<Metavars>;
+  using replace_these_simple_actions = tmpl::list<>;
+  using with_these_simple_actions = tmpl::list<>;
+
+  using const_global_cache_tags = tmpl::list<>;
+
+  using initialization_tags = tmpl::list<>;
+
+  using metavariables = Metavars;
+  using chare_type = ActionTesting::MockNodeGroupChare;
+  using array_index = int;
+
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      typename Metavars::Phase, Metavars::Phase::Initialization, tmpl::list<>>>;
+};
+
+template <size_t ExpansionDerivOrder>
+struct MockMetavars {
+  static constexpr size_t volume_dim = 3;
+
+  enum class Phase { Initialization, Testing, Exit };
+
+  using metavars = MockMetavars<ExpansionDerivOrder>;
+
+  using observed_reduction_data_tags = tmpl::list<>;
+
+  static constexpr bool using_expansion = ExpansionDerivOrder != 0;
+
+  // Even if we aren't using certain control systems, we still need valid deriv
+  // orders becuse everything is constructed by default in the SystemHelper. The
+  // bool above just determines if the functions of time are actually created or
+  // not because that's what matters
+  static constexpr size_t exp_deriv_order =
+      using_expansion ? ExpansionDerivOrder : 2;
+
+  using element_component = MockElementComponent<metavars>;
+
+  using expansion_system = control_system::Systems::Expansion<exp_deriv_order>;
+
+  using expansion_component = MockControlComponent<metavars, expansion_system>;
+
+  using observer_component = MockObserverWriter<metavars>;
+
+  using control_components = tmpl::flatten<tmpl::list<
+      tmpl::conditional_t<using_expansion, expansion_component, tmpl::list<>>>>;
+
+  using component_list = tmpl::flatten<
+      tmpl::list<observer_component, element_component, control_components>>;
+};
+
+/*!
+ * \brief Helper struct for testing basic control systems
+ *
+ * To signify which control systems you want, set the corresponding
+ * DerivOrder. To turn control systems off, put 0 for their DerivOrder in the
+ * templates of the metavariables.
+ *
+ * Ideally we'd construct the runner here and just pass that to the test to
+ * simplify as must of the work as possible, but MockRuntimeSystems aren't
+ * copy- or move-able so we have to make the necessary info available. The
+ * simplist way to do this was to have functions that return references to the
+ * member variables.
+ *
+ * \note Rotation and Translation control aren't supported yet. They will be
+ * added in the future.
+ */
+template <typename Metavars>
+struct SystemHelper {
+  static constexpr size_t exp_deriv_order = Metavars::exp_deriv_order;
+
+  static constexpr bool using_expansion = Metavars::using_expansion;
+
+  using expansion_system = typename Metavars::expansion_system;
+
+  using element_component = typename Metavars::element_component;
+  using control_components = typename Metavars::control_components;
+
+  using expansion_init_simple_tags = init_simple_tags<expansion_system>;
+
+  // Members that may be moved out of this struct once they are
+  // constructed
+  auto& domain() { return domain_; }
+  auto& initial_functions_of_time() { return initial_functions_of_time_; }
+  auto& initial_measurement_timescales() {
+    return initial_measurement_timescales_;
+  }
+
+  // Members that won't be moved out of this struct
+  const auto& init_exp_tuple() { return init_exp_tuple_; }
+  const auto& grid_position_of_a() { return grid_position_of_a_; }
+  const auto& grid_position_of_b() { return grid_position_of_b_; }
+  const auto& expansion_name() { return expansion_name_; }
+
+  void setup_control_system_test(const double initial_time,
+                                 const double initial_separation,
+                                 const std::string& option_string) {
+    initial_time_ = initial_time;
+
+    // We don't need a real domain, just one that has the correct excision
+    // sphere centers because the control errors use the `excision_spheres()`
+    // member of a domain to get the centers. The names are chosen to match the
+    // BinaryCompactObject domain, which the control errors were based on and
+    // have these specific names hard-coded into them.
+    domain_ =
+        Domain<3>{{},
+                  {},
+                  {{"ObjectAExcisionSphere",
+                    ExcisionSphere<3>{1.0,
+                                      {{-0.5 * initial_separation, 0.0, 0.0}},
+                                      {{0, Direction<3>::lower_zeta()},
+                                       {1, Direction<3>::lower_zeta()},
+                                       {2, Direction<3>::lower_zeta()},
+                                       {3, Direction<3>::lower_zeta()},
+                                       {4, Direction<3>::lower_zeta()},
+                                       {5, Direction<3>::lower_zeta()}}}},
+                   {"ObjectBExcisionSphere",
+                    ExcisionSphere<3>{1.0,
+                                      {{+0.5 * initial_separation, 0.0, 0.0}},
+                                      {{0, Direction<3>::lower_zeta()},
+                                       {1, Direction<3>::lower_zeta()},
+                                       {2, Direction<3>::lower_zeta()},
+                                       {3, Direction<3>::lower_zeta()},
+                                       {4, Direction<3>::lower_zeta()},
+                                       {5, Direction<3>::lower_zeta()}}}}}};
+
+    // Initial parameters needed. Expiration times would normally be set during
+    // option parsing, and measurement timescales during initialization so we
+    // have to do them manually here instead.
+    if constexpr (using_expansion) {
+      init_exp_tuple_ = parse_options<expansion_system>(option_string);
+      auto& exp_averager =
+          get<control_system::Tags::Averager<expansion_system>>(
+              init_exp_tuple_);
+      const auto& exp_controller =
+          get<control_system::Tags::Controller<expansion_system>>(
+              init_exp_tuple_);
+      const auto& exp_tuner =
+          get<control_system::Tags::TimescaleTuner<expansion_system>>(
+              init_exp_tuple_);
+
+      const std::array<DataVector, 1> expansion_measurement_timescale{
+          {control_system::calculate_measurement_timescales(exp_controller,
+                                                            exp_tuner)}};
+      exp_averager.assign_time_between_measurements(
+          min(expansion_measurement_timescale[0]));
+
+      const double initial_expansion_expiration_time =
+          exp_controller.get_update_fraction() *
+          min(exp_tuner.current_timescale());
+      const double initial_expansion = 1.0;
+      const double expansion_velocity_outer_boundary = 0.0;
+      const double decay_timescale_outer_boundary = 0.05;
+      auto init_func_expansion =
+          make_array<exp_deriv_order + 1, DataVector>(DataVector{1, 0.0});
+      init_func_expansion[0][0] = initial_expansion;
+
+      initial_functions_of_time_[expansion_name_] = std::make_unique<
+          domain::FunctionsOfTime::PiecewisePolynomial<exp_deriv_order>>(
+          initial_time_, init_func_expansion,
+          initial_expansion_expiration_time);
+      initial_functions_of_time_[expansion_name_ + "OuterBoundary"s] =
+          std::make_unique<domain::FunctionsOfTime::FixedSpeedCubic>(
+              initial_expansion, initial_time_,
+              expansion_velocity_outer_boundary,
+              decay_timescale_outer_boundary);
+      initial_measurement_timescales_[expansion_name_] =
+          std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<0>>(
+              initial_time_, expansion_measurement_timescale,
+              initial_expansion_expiration_time);
+    }
+  }
+
+  template <typename Generator, typename F, typename CoordMap>
+  void run_control_system_test(
+      ActionTesting::MockRuntimeSystem<Metavars>& runner,
+      const double final_time, gsl::not_null<Generator*> generator,
+      const F position_function, const CoordMap& coord_map) {
+    // Allocate now because we need these variables outside the loop
+    std::pair<std::array<double, 3>, std::array<double, 3>> positions{};
+    double time = initial_time_;
+    std::optional<double> prev_time{};
+    double dt = 0.0;
+
+    auto& cache = ActionTesting::cache<element_component>(runner, 0);
+    const auto& functions_of_time =
+        Parallel::get<domain::Tags::FunctionsOfTime>(cache);
+    const auto& measurement_timescales =
+        Parallel::get<control_system::Tags::MeasurementTimescales>(cache);
+
+    // Start loop
+    while (time < final_time) {
+      // Setup the measurement Id. This would normally be created in the control
+      // system event.
+      const LinkedMessageId<double> measurement_id{time, prev_time};
+
+      // This whole switching between tensors and arrays is annoying and
+      // clunky, but it's the best that could be done at the moment without
+      // changing BinaryTrajectories to return tensors, which doesn't seem like
+      // a good idea.
+
+      // Get trajectory in "inertial coordinates" as arrays
+      positions = position_function(time);
+
+      // Covert arrays to tensor so we can pass them into the coordinate map
+      const tnsr::I<double, 3, Frame::Inertial> inertial_position_of_a(
+          positions.first);
+      const tnsr::I<double, 3, Frame::Inertial> inertial_position_of_b(
+          positions.second);
+
+      // Convert to "grid coordinates"
+      const auto grid_position_of_a_tnsr =
+          *coord_map.inverse(inertial_position_of_a, time, functions_of_time);
+      const auto grid_position_of_b_tnsr =
+          *coord_map.inverse(inertial_position_of_b, time, functions_of_time);
+
+      // Convert tensors back to arrays so we can pass them to the control
+      // systems
+      for (size_t i = 0; i < 3; i++) {
+        gsl::at(grid_position_of_a_, i) = grid_position_of_a_tnsr.get(i);
+        gsl::at(grid_position_of_b_, i) = grid_position_of_b_tnsr.get(i);
+      }
+
+      // Construct strahlkorpers to pass to control systems. Only the centers
+      // matter.
+      const Strahlkorper<Frame::Grid> horizon_a{2, 2, 1.0, grid_position_of_a_};
+      const Strahlkorper<Frame::Grid> horizon_b{2, 2, 1.0, grid_position_of_b_};
+
+      // Apply measurements
+      tmpl::for_each<control_components>([&runner, &generator, &measurement_id,
+                                          &horizon_a, &cache,
+                                          &horizon_b](auto control_component) {
+        using component = tmpl::type_from<decltype(control_component)>;
+        using system = typename component::system;
+        system::process_measurement::apply(
+            ah::BothHorizons::FindHorizon<::ah::ObjectLabel::A>{}, horizon_a,
+            cache, measurement_id);
+        CHECK(ActionTesting::number_of_queued_simple_actions<component>(
+                  runner, 0) == 1);
+        system::process_measurement::apply(
+            ah::BothHorizons::FindHorizon<::ah::ObjectLabel::B>{}, horizon_b,
+            cache, measurement_id);
+        CHECK(ActionTesting::number_of_queued_simple_actions<component>(
+                  runner, 0) == 2);
+        // We invoke a random measurement because during a normal simulation
+        // we don't know which measurement will reach the control system
+        // first because of charm++ communication
+        ActionTesting::invoke_random_queued_simple_action<control_components>(
+            make_not_null(&runner), generator,
+            ActionTesting::array_indices_with_queued_simple_actions<
+                control_components>(make_not_null(&runner)));
+        ActionTesting::invoke_queued_simple_action<component>(
+            make_not_null(&runner), 0);
+      });
+
+      // At this point, the control systems for each transformation should have
+      // done their thing and updated the functions of time (if they had enough
+      // data).
+
+      // Our dt is set by the smallest measurement timescale. The control system
+      // updates these timescales when it updates the functions of time
+      prev_time = time;
+      dt = std::numeric_limits<double>::max();
+      for (auto& [name, measurement_timescale] : measurement_timescales) {
+        // Avoid compiler warning with gcc-7
+        (void)name;
+        dt = std::min(dt, min(measurement_timescale->func(time)[0]));
+      }
+      time += dt;
+    }
+
+    // Get analytic position in inertial coordinates
+    positions = position_function(final_time);
+
+    // Get position of objects in grid coordinates using the coordinate map that
+    // has had its functions of time updated by the control system
+    const tnsr::I<double, 3, Frame::Inertial> inertial_position_of_a(
+        positions.first);
+    const tnsr::I<double, 3, Frame::Inertial> inertial_position_of_b(
+        positions.second);
+    const auto grid_position_of_a_tnsr = *coord_map.inverse(
+        inertial_position_of_a, final_time, functions_of_time);
+    const auto grid_position_of_b_tnsr = *coord_map.inverse(
+        inertial_position_of_b, final_time, functions_of_time);
+    for (size_t i = 0; i < 3; i++) {
+      gsl::at(grid_position_of_a_, i) = grid_position_of_a_tnsr.get(i);
+      gsl::at(grid_position_of_b_, i) = grid_position_of_b_tnsr.get(i);
+    }
+  }
+
+ private:
+  template <typename Component>
+  using option_tag = control_system::OptionTags::ControlSystemInputs<
+      typename Component::system>;
+  using option_list = tmpl::push_back<
+      tmpl::remove_duplicates<tmpl::transform<
+          control_components, tmpl::bind<option_tag, tmpl::_1>>>,
+      control_system::OptionTags::WriteDataToDisk, ::OptionTags::InitialTime>;
+  template <typename System>
+  using creatable_tags =
+      tmpl::list_difference<init_simple_tags<System>,
+                            tmpl::list<typename System::MeasurementQueue>>;
+
+  template <typename System>
+  tuples::tagged_tuple_from_typelist<init_simple_tags<System>> parse_options(
+      const std::string& option_string) {
+    Options::Parser<option_list> parser{"Peter Parker the option parser."};
+    parser.parse(option_string);
+    const tuples::tagged_tuple_from_typelist<option_list> options =
+        parser.template apply<option_list, Metavars>([](auto... args) {
+          return tuples::tagged_tuple_from_typelist<option_list>(
+              std::move(args)...);
+        });
+
+    tuples::tagged_tuple_from_typelist<creatable_tags<System>> created_tags =
+        Parallel::create_from_options<Metavars>(options,
+                                                creatable_tags<System>{});
+
+    return tuples::tagged_tuple_from_typelist<init_simple_tags<System>>{
+        get<control_system::Tags::Averager<System>>(created_tags),
+        get<control_system::Tags::TimescaleTuner<System>>(created_tags),
+        get<control_system::Tags::Controller<System>>(created_tags),
+        get<control_system::Tags::ControlError<System>>(created_tags),
+        get<control_system::Tags::WriteDataToDisk>(created_tags),
+        // Just need an empty queue. It will get filled in as the control
+        // system is updated
+        LinkedMessageQueue<
+            double, tmpl::list<QueueTags::Center<::ah::ObjectLabel::A>,
+                               QueueTags::Center<::ah::ObjectLabel::B>>>{}};
+  }
+
+  // Members that may be moved out of this struct once they are
+  // constructed
+  Domain<3> domain_;
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      initial_functions_of_time_{};
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      initial_measurement_timescales_{};
+
+  // Members that won't be moved out of this struct
+  tuples::tagged_tuple_from_typelist<expansion_init_simple_tags>
+      init_exp_tuple_;
+  std::array<double, 3> grid_position_of_a_{};
+  std::array<double, 3> grid_position_of_b_{};
+  const std::string expansion_name_{expansion_system::name()};
+  double initial_time_{std::numeric_limits<double>::signaling_NaN()};
+};
+}  // namespace control_system::TestHelpers


### PR DESCRIPTION
## Proposed changes

This add the expansion control system that will control the CubicScale map in the BBH executable.

To do this and make everything simpler, some of the control system tags are now creatable from options and I removed the `ControlSystemName` tag (it can be retrieved by `ControlSystem::name()` anywhere it's needed).

The last 4 commits are the ones that add and test the control system separately. They could be combined into a single commit that does this all at once, but I think it's easier to review this way, and all the commits still compile individually. They just aren't tested in the same commit.

The added struct `UpdateControlSystem` contains all the logic about when to update each control system.

The added struct `SystemHelpers` is a convenient helper struct that will be able to test all the basic (expansion, rotation, translation) control systems individually and collectively. Anything with a `expansion_` prefix in this struct will get an accompanying `translation_` and `rotation_` counterpart once those control systems are added. So if things seem a tad verbose or its not clear why I did something a certain way in this helper, this is why. It is intended to be able to test two additional control systems.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
