### PR TITLE
Allow ReadSpecPiecewisePolynomial to create QuaternionFunctionsOfTime

### DIFF
--- a/src/Domain/FunctionsOfTime/ReadSpecPiecewisePolynomial.hpp
+++ b/src/Domain/FunctionsOfTime/ReadSpecPiecewisePolynomial.hpp
@@ -34,16 +34,16 @@ class PiecewisePolynomial;
 /// the first component and its derivatives, columns 9-12 give the second
 /// component and its derivatives, etc.
 ///
-/// Currently, only support order 3 piecewise polynomials.
-/// This could be generalized later, but the SpEC functions of time
-/// that we will read in with this action will always be 3rd-order
-/// piecewise polynomials.
+/// Currently, only support order 2 and 3 piecewise polynomials and order 3
+/// quaternion functions of time. This could be generalized later, but the SpEC
+/// functions of time that we will read in with this action will always be
+/// 3rd-order piecewise polynomials.
 ///
-template <size_t MaxDeriv>
+template <template <size_t> class FoTType, size_t MaxDeriv>
 void read_spec_piecewise_polynomial(
-    gsl::not_null<std::unordered_map<
-        std::string, domain::FunctionsOfTime::PiecewisePolynomial<MaxDeriv>>*>
+    gsl::not_null<std::unordered_map<std::string, FoTType<MaxDeriv>>*>
         spec_functions_of_time,
     const std::string& file_name,
-    const std::map<std::string, std::string>& dataset_name_map);
+    const std::map<std::string, std::string>& dataset_name_map,
+    const bool quaternion_rotation = false);
 }  // namespace domain::FunctionsOfTime


### PR DESCRIPTION
## Proposed changes

Previously, `read_spec_piecewise_polynomial` only supported creating `PiecewisePolynomial`s from spec data. Now it can also create `QuaternionFunctionOfTime`s if the domain creator uses one.

#3817 broke reading in spec data for the BBH executable because in its current state, `read_spec_piecewise_polynomial` cannot handle the new `QuaternionFunctionOfTime` in `BinaryCompactObject`.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
