### PR TITLE
Compute ADM quantities directly from XCTS variables

### DIFF
--- a/src/Elliptic/Systems/Xcts/FirstOrderSystem.hpp
+++ b/src/Elliptic/Systems/Xcts/FirstOrderSystem.hpp
@@ -201,13 +201,17 @@ struct FirstOrderSystem
       gr::Tags::Conformal<gr::Tags::EnergyDensity<DataVector>,
                           ConformalMatterScale>,
       gr::Tags::TraceExtrinsicCurvature<DataVector>,
-      tmpl::conditional_t<ConformalGeometry == Geometry::Curved,
-                          tmpl::list<Tags::InverseConformalMetric<
-                                         DataVector, 3, Frame::Inertial>,
-                                     Tags::ConformalRicciScalar<DataVector>,
-                                     Tags::ConformalChristoffelContracted<
-                                         DataVector, 3, Frame::Inertial>>,
-                          tmpl::list<>>,
+      tmpl::conditional_t<
+          ConformalGeometry == Geometry::Curved,
+          tmpl::list<
+              Tags::InverseConformalMetric<DataVector, 3, Frame::Inertial>,
+              Tags::ConformalRicciScalar<DataVector>,
+              Tags::ConformalChristoffelContracted<DataVector, 3,
+                                                   Frame::Inertial>,
+              ::Tags::deriv<
+                  Tags::ConformalMetric<DataVector, 3, Frame::Inertial>,
+                  tmpl::size_t<3>, Frame::Inertial>>,
+          tmpl::list<>>,
       tmpl::conditional_t<
           EnabledEquations == Equations::Hamiltonian,
           Tags::LongitudinalShiftMinusDtConformalMetricOverLapseSquare<

--- a/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
@@ -171,23 +171,25 @@ struct MomentumDensity : db::SimpleTag {
   using type = tnsr::I<DataType, Dim, Frame>;
 };
 
-/// The ADM Hamiltonian constraint \f$R + K^2 - K_{ij} K^{ij} - 16 \pi \rho\f$
+/// The ADM Hamiltonian constraint
+/// \f$\frac{1}{2} \left(R + K^2 - K_{ij} K^{ij}\right) - 8 \pi \rho\f$
 /// (see e.g. Eq. (2.132) in \cite BaumgarteShapiro).
 ///
-/// \warning Some authors include a factor of \f$1/2\f$ in the Hamiltonian
-/// constraint, as does SpEC.
+/// \note We include a factor of \f$1/2\f$ in the Hamiltonian constraint for
+/// consistency with SpEC, and so the matter terms in the Hamiltonian and
+/// momentum constraints are both scaled by $8\pi$.
 template <typename DataType>
 struct HamiltonianConstraint : db::SimpleTag {
   using type = Scalar<DataType>;
 };
 
 /// The ADM momentum constraint
-/// \f$\gamma^{jk} (\nabla_j K_{ki} - \nabla_i K_{jk}) - 8 \pi S_i\f$, where
+/// \f$\nabla_j (K^{ij} - \gamma^{ij} K) - 8 \pi S^i\f$, where
 /// \f$\nabla\f$ denotes the covariant derivative associated with the spatial
 /// metric \f$\gamma_{ij}\f$ (see e.g. Eq. (2.133) in \cite BaumgarteShapiro).
 template <size_t Dim, typename Frame, typename DataType>
 struct MomentumConstraint : db::SimpleTag {
-  using type = tnsr::i<DataType, Dim, Frame>;
+  using type = tnsr::I<DataType, Dim, Frame>;
 };
 
 /*!

--- a/src/PointwiseFunctions/Xcts/CMakeLists.txt
+++ b/src/PointwiseFunctions/Xcts/CMakeLists.txt
@@ -32,4 +32,6 @@ target_link_libraries(
   Utilities
   INTERFACE
   Domain
+  PRIVATE
+  ElasticityPointwiseFunctions
   )

--- a/tests/Unit/PointwiseFunctions/Xcts/SpacetimeQuantities.py
+++ b/tests/Unit/PointwiseFunctions/Xcts/SpacetimeQuantities.py
@@ -2,8 +2,7 @@
 # See LICENSE.txt for details.
 
 import numpy as np
-from PointwiseFunctions.GeneralRelativity.ComputeSpacetimeQuantities import (
-    extrinsic_curvature)
+from PointwiseFunctions.Xcts.ExtrinsicCurvature import extrinsic_curvature
 
 
 def spatial_metric(conformal_factor, conformal_metric):


### PR DESCRIPTION
## Proposed changes

- Use the original XCTS variables to compute spatial metric, lapse, shift, and extrinsic curvature. The only really important part here is that we don't take a numerical derivative of the background shift, which may increase linearly with distance (it can have `Omega x r` and `a_dot * r` terms).
- Define both Hamiltonian constraint and momentum constraint such that their matter terms scale with 8 pi, mostly for consistency with SpEC.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
