### PR TITLE
Switch to Intel MPI 2017.1 on Wheeler

### DIFF
--- a/support/Environments/wheeler_clang.sh
+++ b/support/Environments/wheeler_clang.sh
@@ -19,13 +19,13 @@ spectre_unload_modules() {
     module unload openblas/0.2.18
     module unload papi/5.5.1
     module unload yaml-cpp/master
-    module unload openmpi/2.0.0
+    module unload impi/2017.1
     module unload cmake/3.18.2
     module unload ninja/1.10.0
     module unload doxygen/1.8.13
     module unload git/2.8.4
     module unload llvm/10.0.0
-    module unload charm/6.10.2-mpi-smp
+    module unload charm/6.10.2-intelmpi-smp
     module unload python/anaconda3-2019.10
     module unload pybind11/2.6.1
 }
@@ -42,13 +42,13 @@ spectre_load_modules() {
     module load openblas/0.2.18
     module load papi/5.5.1
     module load yaml-cpp/master
-    module load openmpi/2.0.0
+    module load impi/2017.1
     module load cmake/3.18.2
     module load ninja/1.10.0
     module load doxygen/1.8.13
     module load git/2.8.4
     module load llvm/10.0.0
-    module load charm/6.10.2-mpi-smp
+    module load charm/6.10.2-intelmpi-smp
     module load python/anaconda3-2019.10
     module load pybind11/2.6.1
 }

--- a/support/Environments/wheeler_gcc.sh
+++ b/support/Environments/wheeler_gcc.sh
@@ -19,13 +19,13 @@ spectre_unload_modules() {
     module unload openblas/0.2.18
     module unload papi/5.5.1
     module unload yaml-cpp/master
-    module unload openmpi/2.0.0
+    module unload impi/2017.1
     module unload cmake/3.18.2
     module unload ninja/1.10.0
     module unload doxygen/1.8.13
     module unload git/2.8.4
     module unload lcov/1.13
-    module unload charm/6.10.2-mpi-smp
+    module unload charm/6.10.2-intelmpi-smp
     module unload python/anaconda3-2019.10
     module unload pybind11/2.6.1
 }
@@ -42,13 +42,13 @@ spectre_load_modules() {
     module load openblas/0.2.18
     module load papi/5.5.1
     module load yaml-cpp/master
-    module load openmpi/2.0.0
+    module load impi/2017.1
     module load cmake/3.18.2
     module load ninja/1.10.0
     module load doxygen/1.8.13
     module load git/2.8.4
     module load lcov/1.13
-    module load charm/6.10.2-mpi-smp
+    module load charm/6.10.2-intelmpi-smp
     module load python/anaconda3-2019.10
     module load pybind11/2.6.1
 }


### PR DESCRIPTION
This resolves performance issues, and also the "corrupted message"-type errors
we were seeing.

Note: UCX is broken, and so OpenMPI 4 and newer is also broken. The verbs layer
is about a factor of 3 slower than Intel MPI.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
