### PR TITLE
add enthalpy-parametrized equation of state

### DIFF
--- a/src/PointwiseFunctions/Hydro/EquationsOfState/CMakeLists.txt
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/CMakeLists.txt
@@ -5,6 +5,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   DarkEnergyFluid.cpp
+  Enthalpy.cpp
   IdealFluid.cpp
   PolytropicFluid.cpp
   Spectral.cpp
@@ -20,6 +21,7 @@ spectre_target_headers(
   IdealFluid.hpp
   PolytropicFluid.hpp
   Spectral.hpp
+  Enthalpy.hpp
   )
 
 add_subdirectory(Python)

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.cpp
@@ -1,0 +1,468 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.hpp"
+
+#include <cmath>
+#include <numeric>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "NumericalAlgorithms/RootFinding/NewtonRaphson.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace EquationsOfState {
+template <typename LowDensityEoS>
+Enthalpy<LowDensityEoS>::Coefficients::Coefficients(
+    std::vector<double> in_polynomial_coefficients,
+    std::vector<double> in_sin_coefficients,
+    std::vector<double> in_cos_coefficients, double in_trig_scale,
+    double in_reference_density, double in_exponential_constant)
+    : polynomial_coefficients(std::move(in_polynomial_coefficients)),
+      sin_coefficients(std::move(in_sin_coefficients)),
+      cos_coefficients(std::move(in_cos_coefficients)),
+      trig_scale(in_trig_scale),
+      reference_density(in_reference_density) {
+  if (not std::isnan(in_exponential_constant)) {
+    // There is no code that currently calls this so it
+    // is not accessible at the moment
+    ERROR(
+        "This code is untested, it may be useful in the "
+        "future for directly constructing Coefficient objects.");
+    has_exponential_prefactor = true;
+    exponential_external_constant = in_exponential_constant;
+  } else {
+    has_exponential_prefactor = false;
+    exponential_external_constant =
+        std::numeric_limits<double>::signaling_NaN();
+  }
+}
+
+// Given an expansion h(x) = sum_i f_i(x) , compute int_a^x sum_i f_i(x) e^x +
+// F(a) where f_i(x) could be one of the basis functions  used, i.e. x^i/i!,
+// sin(ikx) or cos(ikx)
+template <typename LowDensityEoS>
+typename Enthalpy<LowDensityEoS>::Coefficients
+Enthalpy<LowDensityEoS>::Coefficients::compute_exponential_integral(
+    const std::pair<double, double>& initial_condition) {
+  // Doing the exponential integral of something already with an expoenetial
+  // prefactor shouldn't be happening
+  if (has_exponential_prefactor) {
+    // No code currently calls this
+    ERROR(
+        "Attempting to exponentially integrate an EoS decomposition series "
+        "with an exponential prefactor!  This is not yet implemented, if you "
+        "need this, please file an issue to get it added.");
+  }
+  std::vector<double> integral_poly_coeffs(polynomial_coefficients.size(), 0.0);
+  std::vector<double> integral_sin_coeffs(sin_coefficients.size(), 0.0);
+  std::vector<double> integral_cos_coeffs(cos_coefficients.size(), 0.0);
+  Enthalpy::Coefficients exponential_integral_coefficients = *this;
+  // Preprocessing to put coefficients in better basis c_i z^i  = c_i' z^i/i!
+  std::vector<double> taylor_series_coefficients(
+      polynomial_coefficients.size());
+  for (size_t i = 0; i < integral_poly_coeffs.size(); i++) {
+    taylor_series_coefficients[i] =
+        polynomial_coefficients[i] * static_cast<double>(factorial(i));
+  }
+  // i indexes terms of the integrand, each of which contributes i+1 terms (of
+  // degree r <= i) to the integral indexed by r.  Therefore, r indexes terms
+  // of the integral.
+  for (size_t i = 0; i < taylor_series_coefficients.size(); i++) {
+    for (size_t r = 0; r <= i; r++) {
+      integral_poly_coeffs[r] +=
+          ((i - r) % 2 == 0 ? 1.0 : -1.0) * taylor_series_coefficients[i];
+    }
+  }
+  // restore the default normalization for the coefficients
+  for (size_t r = 0; r < integral_poly_coeffs.size(); r++) {
+    integral_poly_coeffs[r] /= static_cast<double>(factorial(r));
+  }
+
+  // note again sum starts from 0, basis functions are sin([j+1]kx)
+  for (size_t j = 0; j < sin_coefficients.size(); j++) {
+    // contribution from the sine terms
+    double k = trig_scale;
+    integral_sin_coeffs[j] +=
+        1.0 / (square(j + 1) * square(k) + 1.0) * sin_coefficients[j];
+    integral_cos_coeffs[j] -= (static_cast<double>(j + 1) * k) /
+                              (square(j + 1) * square(k) + 1.0) *
+                              sin_coefficients[j];
+    // contribution from the cosine terms
+    integral_cos_coeffs[j] +=
+        1.0 / (square(j + 1) * square(k) + 1.0) * cos_coefficients[j];
+    integral_sin_coeffs[j] += (static_cast<double>(j + 1) * k) /
+                              (square(j + 1) * square(k) + 1.0) *
+                              cos_coefficients[j];
+  }
+  exponential_integral_coefficients.has_exponential_prefactor = true;
+  exponential_integral_coefficients.exponential_external_constant = 0.0;
+  exponential_integral_coefficients.polynomial_coefficients =
+      std::move(integral_poly_coeffs);
+  exponential_integral_coefficients.sin_coefficients =
+      std::move(integral_sin_coeffs);
+  exponential_integral_coefficients.cos_coefficients =
+      std::move(integral_cos_coeffs);
+  evaluate_coefficients(exponential_integral_coefficients,
+                        initial_condition.first);
+  double new_constant = initial_condition.second -
+                        evaluate_coefficients(exponential_integral_coefficients,
+                                              initial_condition.first);
+  exponential_integral_coefficients.exponential_external_constant =
+      new_constant;
+  return exponential_integral_coefficients;
+}
+template <typename LowDensityEoS>
+typename Enthalpy<LowDensityEoS>::Coefficients
+Enthalpy<LowDensityEoS>::Coefficients::compute_derivative() {
+  std::vector<double> derivative_poly_coeffs(polynomial_coefficients.size());
+  std::vector<double> derivative_sin_coeffs(sin_coefficients.size());
+  std::vector<double> derivative_cos_coeffs(cos_coefficients.size());
+  Enthalpy::Coefficients derivative_coefficients = *this;
+  // d/dz e^z \sum_i a_i f(z) = e^z \sum_i a_i f_i(z)  + e^z \sum_i a_i f_i'(z)
+  if (has_exponential_prefactor) {
+    // Currently unused, but may be useful in the future
+    ERROR(
+        "This branch is untested, it may be "
+        "used to compute derivatives of internal"
+        "energy (or related quantities) in the future. ");
+    derivative_poly_coeffs = polynomial_coefficients;
+    derivative_sin_coeffs = sin_coefficients;
+    derivative_cos_coeffs = cos_coefficients;
+    derivative_poly_coeffs[polynomial_coefficients.size() - 1] = 0.0;
+    for (size_t i = 0; i < polynomial_coefficients.size() - 1; i++) {
+      derivative_poly_coeffs[i] +=
+          polynomial_coefficients[i + 1] * static_cast<double>(i + 1);
+    }
+    // Again sum starts from 0
+    for (size_t j = 0; j < sin_coefficients.size(); j++) {
+      derivative_cos_coeffs[j] +=
+          sin_coefficients[j] * (static_cast<double>(j + 1) * trig_scale);
+      derivative_sin_coeffs[j] +=
+          -cos_coefficients[j] * (static_cast<double>(j + 1) * trig_scale);
+    }
+  } else {  // There is no exponential prefactor
+    // The final coefficient will be zero because nothing differentiates to it
+    derivative_poly_coeffs[polynomial_coefficients.size() - 1] = 0.0;
+    for (size_t i = 0; i < polynomial_coefficients.size() - 1; i++) {
+      derivative_poly_coeffs[i] =
+          polynomial_coefficients[i + 1] * static_cast<double>(i + 1);
+    }
+    for (size_t j = 0; j < sin_coefficients.size(); j++) {
+      derivative_cos_coeffs[j] =
+          sin_coefficients[j] * (static_cast<double>(j + 1) * trig_scale);
+      derivative_sin_coeffs[j] =
+          -cos_coefficients[j] * (static_cast<double>(j + 1) * trig_scale);
+    }
+  }
+  derivative_coefficients.polynomial_coefficients =
+      std::move(derivative_poly_coeffs);
+  derivative_coefficients.sin_coefficients = std::move(derivative_sin_coeffs);
+  derivative_coefficients.cos_coefficients = std::move(derivative_cos_coeffs);
+  return derivative_coefficients;
+}
+template <typename LowDensityEoS>
+void Enthalpy<LowDensityEoS>::Coefficients::pup(PUP::er& p) {
+  p | polynomial_coefficients;
+  p | sin_coefficients;
+  p | cos_coefficients;
+  p | trig_scale;
+  p | reference_density;
+  p | has_exponential_prefactor;
+  p | exponential_external_constant;
+}
+template <typename LowDensityEoS>
+Enthalpy<LowDensityEoS>::Enthalpy(
+    const double reference_density, const double max_density,
+    const double min_density, const double trig_scale,
+    const std::vector<double>& polynomial_coefficients,
+    const std::vector<double>& sin_coefficients,
+    const std::vector<double>& cos_coefficients,
+    const LowDensityEoS& low_density_eos, const double transition_delta_epsilon)
+    : reference_density_(reference_density),
+      minimum_density_(min_density),
+      maximum_density_(max_density),
+      low_density_eos_(low_density_eos),
+      coefficients_(polynomial_coefficients, sin_coefficients, cos_coefficients,
+                    trig_scale, reference_density)
+
+{
+  minimum_enthalpy_ = specific_enthalpy_from_density(minimum_density_);
+  // Compute based on low density behavior
+  double min_energy_density =
+      minimum_density_ +
+      get(low_density_eos_.specific_internal_energy_from_density(
+          Scalar<double>(minimum_density_))) *
+          minimum_density_ +
+      transition_delta_epsilon;
+  exponential_integral_coefficients_ =
+      coefficients_.compute_exponential_integral(
+          {x_from_density(min_density),
+           1.0 / reference_density * min_energy_density});
+  derivative_coefficients_ = coefficients_.compute_derivative();
+}
+
+EQUATION_OF_STATE_MEMBER_DEFINITIONS(template <typename LowDensityEoS>,
+                                     Enthalpy<LowDensityEoS>, double, 1)
+EQUATION_OF_STATE_MEMBER_DEFINITIONS(template <typename LowDensityEoS>,
+                                     Enthalpy<LowDensityEoS>, DataVector, 1)
+
+template <typename LowDensityEoS>
+Enthalpy<LowDensityEoS>::Enthalpy(CkMigrateMessage* /*unused*/) {}
+
+template <typename LowDensityEoS>
+void Enthalpy<LowDensityEoS>::pup(PUP::er& p) {
+  EquationOfState<true, 1>::pup(p);
+  p | reference_density_;
+  p | maximum_density_;
+  p | minimum_density_;
+  p | minimum_enthalpy_;
+  p | low_density_eos_;
+  p | coefficients_;
+  p | exponential_integral_coefficients_;
+  p | derivative_coefficients_;
+}
+
+template <typename LowDensityEoS>
+double Enthalpy<LowDensityEoS>::x_from_density(const double density) const {
+  return log(density / reference_density_);
+}
+template <typename LowDensityEoS>
+double Enthalpy<LowDensityEoS>::density_from_x(const double x) const {
+  return reference_density_ * exp(x);
+}
+// Only works for rho > rho_min
+template <typename LowDensityEoS>
+double Enthalpy<LowDensityEoS>::energy_density_from_log_density(
+    const double x) const {
+  return reference_density_ *
+         evaluate_coefficients(exponential_integral_coefficients_, x);
+}
+
+// Evaluate the function represented by the coefficinets at x  = log(rho/rho_0)
+template <typename LowDensityEoS>
+double Enthalpy<LowDensityEoS>::evaluate_coefficients(
+    const Enthalpy<LowDensityEoS>::Coefficients& coefficients, const double x) {
+  // Not as good as Horner's rule, so don't use for polynomials
+  // The basis_function should be a family of functions indexed by
+  // an integer
+  auto evaluate_with_function_basis =
+      [](const auto& basis_function, const double evaluation_point,
+         const std::vector<double>& basis_coefficients, const double initial) {
+        double sum = initial;
+        for (size_t index = 0; index < basis_coefficients.size(); index++) {
+          sum += basis_coefficients[index] *
+                 basis_function(evaluation_point, index);
+        }
+        return sum;
+      };
+  const double k = coefficients.trig_scale;
+  const double polynomial_contribution =
+      evaluate_polynomial(coefficients.polynomial_coefficients, x);
+  const double sin_contribution = evaluate_with_function_basis(
+      [k](double z, int n) { return sin((n + 1) * k * z); }, x,
+      coefficients.sin_coefficients, 0.0);
+  const double cos_contribution = evaluate_with_function_basis(
+      [k](double z, int n) { return cos((n + 1) * k * z); }, x,
+      coefficients.cos_coefficients, 0.0);
+  double value =
+      polynomial_contribution + (sin_contribution + cos_contribution);
+  if (coefficients.has_exponential_prefactor) {
+    value *= exp(x);
+    value += coefficients.exponential_external_constant;
+  }
+  return value;
+}
+template <typename LowDensityEoS>
+template <typename DataType>
+Scalar<DataType> Enthalpy<LowDensityEoS>::pressure_from_density_impl(
+    const Scalar<DataType>& rest_mass_density) const {
+  if constexpr (std::is_same_v<DataType, double>) {
+    return Scalar<double>{pressure_from_density(get(rest_mass_density))};
+  } else if constexpr (std::is_same_v<DataType, DataVector>) {
+    auto result = make_with_value<Scalar<DataVector>>(rest_mass_density, 0.0);
+    for (size_t i = 0; i < get(result).size(); ++i) {
+      get(result)[i] = pressure_from_density(get(rest_mass_density)[i]);
+    }
+    return result;
+  }
+}
+template <typename LowDensityEoS>
+template <class DataType>
+Scalar<DataType> Enthalpy<LowDensityEoS>::rest_mass_density_from_enthalpy_impl(
+    const Scalar<DataType>& specific_enthalpy) const {
+  if constexpr (std::is_same_v<DataType, double>) {
+    return Scalar<double>{
+        rest_mass_density_from_enthalpy(get(specific_enthalpy))};
+  } else if constexpr (std::is_same_v<DataType, DataVector>) {
+    auto result = make_with_value<Scalar<DataVector>>(specific_enthalpy, 0.0);
+    for (size_t i = 0; i < get(result).size(); ++i) {
+      get(result)[i] =
+          rest_mass_density_from_enthalpy(get(specific_enthalpy)[i]);
+    }
+    return result;
+  }
+}
+
+template <typename LowDensityEoS>
+template <class DataType>
+Scalar<DataType> Enthalpy<LowDensityEoS>::specific_enthalpy_from_density_impl(
+    const Scalar<DataType>& rest_mass_density) const {
+  if constexpr (std::is_same_v<DataType, double>) {
+    return Scalar<double>{
+        specific_enthalpy_from_density(get(rest_mass_density))};
+  } else if constexpr (std::is_same_v<DataType, DataVector>) {
+    auto result = make_with_value<Scalar<DataVector>>(rest_mass_density, 0.0);
+    for (size_t i = 0; i < get(result).size(); ++i) {
+      get(result)[i] =
+          specific_enthalpy_from_density(get(rest_mass_density)[i]);
+    }
+    return result;
+  }
+}
+
+template <typename LowDensityEoS>
+template <class DataType>
+Scalar<DataType>
+Enthalpy<LowDensityEoS>::specific_internal_energy_from_density_impl(
+    const Scalar<DataType>& rest_mass_density) const {
+  if constexpr (std::is_same_v<DataType, double>) {
+    return Scalar<double>{
+        specific_internal_energy_from_density(get(rest_mass_density))};
+  } else if constexpr (std::is_same_v<DataType, DataVector>) {
+    auto result = make_with_value<Scalar<DataVector>>(rest_mass_density, 0.0);
+    for (size_t i = 0; i < get(result).size(); ++i) {
+      get(result)[i] =
+          specific_internal_energy_from_density(get(rest_mass_density)[i]);
+    }
+    return result;
+  }
+}
+
+template <typename LowDensityEoS>
+template <class DataType>
+Scalar<DataType> Enthalpy<LowDensityEoS>::chi_from_density_impl(
+    const Scalar<DataType>& rest_mass_density) const {
+  if constexpr (std::is_same_v<DataType, double>) {
+    return Scalar<double>{chi_from_density(get(rest_mass_density))};
+  } else if constexpr (std::is_same_v<DataType, DataVector>) {
+    auto result = make_with_value<Scalar<DataVector>>(rest_mass_density, 0.0);
+    for (size_t i = 0; i < get(result).size(); ++i) {
+      get(result)[i] = chi_from_density(get(rest_mass_density)[i]);
+    }
+    return result;
+  }
+}
+
+template <typename LowDensityEoS>
+template <class DataType>
+Scalar<DataType>
+Enthalpy<LowDensityEoS>::kappa_times_p_over_rho_squared_from_density_impl(
+    const Scalar<DataType>& rest_mass_density) const {
+  return make_with_value<Scalar<DataType>>(get(rest_mass_density), 0.0);
+}
+template <typename LowDensityEoS>
+double Enthalpy<LowDensityEoS>::chi_from_density(
+    const double rest_mass_density) const {
+  if (Enthalpy::in_low_density_domain(rest_mass_density)) {
+    return get(
+        low_density_eos_.chi_from_density(Scalar<double>(rest_mass_density)));
+  } else {
+    const double x = x_from_density(rest_mass_density);
+    return evaluate_coefficients(derivative_coefficients_, x);
+  }
+}
+
+template <typename LowDensityEoS>
+double Enthalpy<LowDensityEoS>::specific_internal_energy_from_density(
+    const double rest_mass_density) const {
+  if (Enthalpy::in_low_density_domain(rest_mass_density)) {
+    return get(low_density_eos_.specific_internal_energy_from_density(
+        Scalar<double>(rest_mass_density)));
+  } else {
+    return 1.0 / rest_mass_density *
+               energy_density_from_log_density(
+                   x_from_density(rest_mass_density)) -
+           1.0;
+  }
+}
+template <typename LowDensityEoS>
+double Enthalpy<LowDensityEoS>::specific_enthalpy_from_density(
+    const double rest_mass_density) const {
+  if (Enthalpy::in_low_density_domain(rest_mass_density)) {
+    return get(low_density_eos_.specific_enthalpy_from_density(
+        Scalar<double>(rest_mass_density)));
+  } else {
+    return evaluate_coefficients(coefficients_,
+                                 x_from_density(rest_mass_density));
+  }
+}
+
+// P(x) = rho(x)h(x) - e(x) with h the specific enthalpy, and e
+// the energy density.
+template <typename LowDensityEoS>
+double Enthalpy<LowDensityEoS>::pressure_from_log_density(
+    const double x) const {
+  auto rest_mass_density = density_from_x(x);
+  if (in_low_density_domain(rest_mass_density)) {
+    // Currently this branch is inaccessible
+    ERROR(
+        "This branch is untested, it may be useful in "
+        "the future for implementing numerical integrals "
+        "of thermodynamic quantities");
+    return get(low_density_eos_.pressure_from_density(
+        Scalar<double>(rest_mass_density)));
+  } else {
+    return rest_mass_density * evaluate_coefficients(coefficients_, x) -
+           energy_density_from_log_density(x);
+  }
+}
+template <typename LowDensityEoS>
+double Enthalpy<LowDensityEoS>::pressure_from_density(
+    const double rest_mass_density) const {
+  if (in_low_density_domain(rest_mass_density)) {
+    return get(low_density_eos_.pressure_from_density(
+        Scalar<double>(rest_mass_density)));
+  } else {
+    const double x = x_from_density(rest_mass_density);
+    return pressure_from_log_density(x);
+  }
+}
+
+// Solve for h(rho)=h0, which requires rootfinding for this EoS
+template <typename LowDensityEoS>
+double Enthalpy<LowDensityEoS>::rest_mass_density_from_enthalpy(
+    const double specific_enthalpy) const {
+  if (specific_enthalpy <= minimum_enthalpy_) {
+    return get(low_density_eos_.rest_mass_density_from_enthalpy(
+        Scalar<double>(specific_enthalpy)));
+  } else {
+    // Root-finding appropriate between reference density and maximum density
+    // We can use x=0 and x=x_max as bounds
+    const auto f_df_lambda = [this, &specific_enthalpy](const double density) {
+      const auto x = x_from_density(density);
+      const double f =
+          evaluate_coefficients(coefficients_, x) - specific_enthalpy;
+
+      const double df =
+          1.0 / density * evaluate_coefficients(derivative_coefficients_, x);
+      return std::make_pair(f, df);
+    };
+    const size_t digits = 14;
+    const double intial_guess = 0.5 * (minimum_density_ + maximum_density_);
+    const auto root_from_lambda = RootFinder::newton_raphson(
+        f_df_lambda, intial_guess, reference_density_, maximum_density_,
+        digits);
+    return root_from_lambda;
+  }
+}
+template <typename LowDensityEoS>
+PUP::able::PUP_ID EquationsOfState::Enthalpy<LowDensityEoS>::my_PUP_ID = 0;
+
+template class EquationsOfState::Enthalpy<Spectral>;
+
+}  // namespace EquationsOfState

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.hpp
@@ -1,0 +1,283 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <boost/preprocessor/arithmetic/dec.hpp>
+#include <boost/preprocessor/arithmetic/inc.hpp>
+#include <boost/preprocessor/control/expr_iif.hpp>
+#include <boost/preprocessor/list/adt.hpp>
+#include <boost/preprocessor/repetition/for.hpp>
+#include <boost/preprocessor/repetition/repeat.hpp>
+#include <boost/preprocessor/tuple/to_list.hpp>
+#include <limits>
+#include <pup.h>
+#include <vector>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"  // IWYU pragma: keep
+#include "Utilities/Math.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+
+/// \endcond
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace EquationsOfState {
+
+/*!
+ * \ingroup EquationsOfStateGroup
+ * \brief An equation of state given by parametrized enthalpy
+ *
+ * This equation of state is determined as a function of \f$x =
+ * \ln(\rho/\rho_0)\f$ where \f$\rho\f$ is the rest mass density and
+ * \f$\rho_0\f$ is the provided reference density.
+ * The pseudo-enthalpy \f$h \equiv (p + rho  + u)/rho\f$
+ * is expanded as
+ *
+ * \f{equation}
+ * h(x) = \sum_i a_i x^i + \sum_j b_j \sin(jkx) + c_j \cos(jkx)
+ * \f}
+ *
+ * This form allows for convenient calculation of thermodynamic
+ * quantities for a cold equation of state. For example
+ *
+ * \f{equation}
+ * h(x) = \frac{d e} {d \rho} |_{x = \log(\rho/\rho_0)}
+ * \f}
+ *
+ * where \f$e\f$ is the total energy density.  At the same time \f$ dx =
+ * d\rho/\rho \f$ so \f$ \rho_0 e^x dx = d \rho \f$ Therefore,
+ *
+ * \f{equation}
+ * e(x) - e(x_0) = \int_{x_0}^x h(x') e^{x'} dx '
+ * \f}
+ *
+ * This can be computed analytically because
+ *
+ * \f{equation}
+ *  \int a_i \frac{x^i}{i!} e^{x} dx = \sum_{j \leq i} a_i (-1)^{i-j}
+ * \frac{(x)^{j}}{j!}
+ * + C \f}
+ *
+ * and
+ *
+ * \f{equation}
+ * \int b_j \sin(j k x) e^x dx = b_j e^x \frac{\sin(jkx) - j k \cos(jkx)}{j^2
+ * k^2 + 1} \f}
+ *
+ * \f{equation}
+ * \int c_j \cos(j k x) e^x dx = b_j e^x \frac{\cos(jkx) + j k \sin(jkx)}{j^2
+ * k^2 + 1} \f}
+ *
+ * From this most other thermodynamic quantities can be computed
+ * analytically
+ *
+ * The internal energy density
+ * \f{equation}
+ * \epsilon(x)\rho(x) = e(x)  - \rho(x)
+ * \f}
+ *
+ * The pressure
+ * \f{equation}
+ * p(x) = \rho(x) h(x) - e(x)
+ * \f}
+ *
+ * The derivative of the pressure with respect to the rest mass density
+ * \f{equation}
+ * \chi(x) = \frac{dp}{d\rho} |_{x = x(\rho)} = \frac{dh}{dx}
+ * \f}
+ *
+ * Below the minimum density, a spectral parameterization
+ * is used.
+ *
+ *
+ *
+ */
+template <typename LowDensityEoS>
+class Enthalpy : public EquationOfState<true, 1> {
+ private:
+  struct Coefficients {
+    std::vector<double> polynomial_coefficients;
+    std::vector<double> sin_coefficients;
+    std::vector<double> cos_coefficients;
+    double trig_scale;
+    double reference_density;
+    bool has_exponential_prefactor;
+    double exponential_external_constant;
+    Coefficients() = default;
+    ~Coefficients() = default;
+    Coefficients(const Coefficients& coefficients) = default;
+    Coefficients(std::vector<double> in_polynomial_coefficients,
+                 std::vector<double> in_sin_coefficients,
+                 std::vector<double> in_cos_coefficients, double in_trig_scale,
+                 double in_reference_density,
+                 double in_exponential_constant =
+                     std::numeric_limits<double>::quiet_NaN());
+
+    Enthalpy<LowDensityEoS>::Coefficients compute_exponential_integral(
+        const std::pair<double, double>& initial_condition);
+    Enthalpy<LowDensityEoS>::Coefficients compute_derivative();
+    void pup(PUP::er& p);
+  };
+
+ public:
+  static constexpr size_t thermodynamic_dim = 1;
+  static constexpr bool is_relativistic = true;
+
+  struct ReferenceDensity {
+    using type = double;
+    static constexpr Options::String help = {"Reference density rho_0"};
+    static double lower_bound() { return 0.0; }
+  };
+
+  struct MinimumDensity {
+    using type = double;
+    static constexpr Options::String help = {
+        "Minimum valid density rho_min,"
+        " for this parametrization"};
+    static double lower_bound() { return 0.0; }
+  };
+  struct MaximumDensity {
+    using type = double;
+    static constexpr Options::String help = {"Maximum density for this EoS"};
+    static double lower_bound() { return 0.0; }
+  };
+
+  struct PolynomialCoefficients {
+    using type = std::vector<double>;
+    static constexpr Options::String help = {"Polynomial coefficients a_i"};
+  };
+
+  struct TrigScaling {
+    using type = double;
+    static constexpr Options::String help = {
+        "Fundamental wavenumber of trig "
+        "functions, k"};
+    static double lower_bound() { return 0.0; }
+  };
+
+  struct SinCoefficients {
+    using type = std::vector<double>;
+    static constexpr Options::String help = {"Sine coefficients b_j"};
+  };
+  struct CosCoefficients {
+    using type = std::vector<double>;
+    static constexpr Options::String help = {"Cosine coefficients c_j"};
+  };
+  struct StitchedLowDensityEoS {
+    using type = LowDensityEoS;
+    static std::string name() {
+      return pretty_type::short_name<LowDensityEoS>();
+    }
+    static constexpr Options::String help = {
+        "Low density EoS stitched at the MinimumDensity"};
+  };
+
+  struct TransitionDeltaEpsilon {
+    using type = double;
+    static constexpr Options::String help = {
+        "the change in internal energy across the low-"
+        "to-high-density transition, generically 0.0"};
+    static double lower_bound() { return 0.0; }
+  };
+
+  static constexpr Options::String help = {
+      "An EoS with a parametrized value h(log(rho/rho_0)) with h the specific "
+      "enthalpy and rho the baryon rest mass density.  The enthalpy is "
+      "expanded as a sum of polynomial terms and trigonometric corrections. "
+      "let x = log(rho/rho_0) in"
+      "h(x) = \\sum_i a_ix^i + \\sum_j b_jsin(k * j * x) + c_jcos(k * j * x) "
+      "Note that rho(x)(1+epsilon(x)) = int_0^x e^x' h((x') dx' can be "
+      "computed "
+      "analytically, and therefore so can "
+      "P(x) = rho(x) * (h(x) - (1 + epsilon(x))) "};
+
+  using options =
+      tmpl::list<ReferenceDensity, MaximumDensity, MinimumDensity, TrigScaling,
+                 PolynomialCoefficients, SinCoefficients, CosCoefficients,
+                 StitchedLowDensityEoS, TransitionDeltaEpsilon>;
+
+  Enthalpy() = default;
+  Enthalpy(const Enthalpy&) = default;
+  Enthalpy& operator=(const Enthalpy&) = default;
+  Enthalpy(Enthalpy&&) = default;
+  Enthalpy& operator=(Enthalpy&&) = default;
+  ~Enthalpy() override = default;
+
+  Enthalpy(double reference_density, double max_density, double min_density,
+           double trig_scale,
+           const std::vector<double>& polynomial_coefficients,
+           const std::vector<double>& sin_coefficients,
+           const std::vector<double>& cos_coefficients,
+           const LowDensityEoS& low_density_eos,
+           const double transition_delta_epsilon);
+
+  EQUATION_OF_STATE_FORWARD_DECLARE_MEMBERS(Enthalpy, 1)
+
+  WRAPPED_PUPable_decl_base_template(  // NOLINT
+      SINGLE_ARG(EquationOfState<true, 1>), Enthalpy);
+
+  /// The lower bound of the rest mass density that is valid for this EOS
+  double rest_mass_density_lower_bound() const override { return 0.0; }
+
+  /// The upper bound of the rest mass density that is valid for this EOS
+  double rest_mass_density_upper_bound() const override {
+    return std::numeric_limits<double>::max();
+  }
+
+  /// The lower bound of the specific internal energy that is valid for this EOS
+  /// at the given rest mass density \f$\rho\f$
+  double specific_internal_energy_lower_bound(
+      const double /* rest_mass_density */) const override {
+    return 0.0;
+  }
+
+  /// The upper bound of the specific internal energy that is valid for this EOS
+  /// at the given rest mass density \f$\rho\f$
+  double specific_internal_energy_upper_bound(
+      const double /* rest_mass_density */) const override {
+    return std::numeric_limits<double>::max();
+  }
+
+  /// The lower bound of the specific enthalpy that is valid for this EOS
+  double specific_enthalpy_lower_bound() const override { return 1.0; }
+
+ private:
+  EQUATION_OF_STATE_FORWARD_DECLARE_MEMBER_IMPLS(1)
+
+  SPECTRE_ALWAYS_INLINE
+  bool in_low_density_domain(const double density) const {
+    return density < minimum_density_;
+  }
+
+  double x_from_density(const double density) const;
+  double density_from_x(const double x) const;
+  double energy_density_from_log_density(const double x) const;
+  static double evaluate_coefficients(
+      const Enthalpy::Coefficients& coefficients, const double x);
+
+  double chi_from_density(const double density) const;
+  double specific_internal_energy_from_density(const double density) const;
+  double specific_enthalpy_from_density(const double density) const;
+  double pressure_from_density(const double density) const;
+  double pressure_from_log_density(const double x) const;
+  double rest_mass_density_from_enthalpy(const double specific_enthalpy) const;
+
+  double reference_density_ = std::numeric_limits<double>::signaling_NaN();
+  double minimum_density_ = std::numeric_limits<double>::signaling_NaN();
+  double maximum_density_ = std::numeric_limits<double>::signaling_NaN();
+  double minimum_enthalpy_ = std::numeric_limits<double>::signaling_NaN();
+
+  LowDensityEoS low_density_eos_;
+  Coefficients coefficients_;
+  Coefficients exponential_integral_coefficients_;
+  Coefficients derivative_coefficients_;
+};
+
+}  // namespace EquationsOfState

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp
@@ -25,6 +25,8 @@ class IdealFluid;
 template <bool IsRelativistic>
 class PolytropicFluid;
 class Spectral;
+template <typename LowDensityEoS>
+class Enthalpy;
 }  // namespace EquationsOfState
 /// \endcond
 
@@ -37,7 +39,7 @@ struct DerivedClasses {};
 
 template <>
 struct DerivedClasses<true, 1> {
-  using type = tmpl::list<Spectral, PolytropicFluid<true>>;
+  using type = tmpl::list<Spectral, Enthalpy<Spectral>, PolytropicFluid<true>>;
 };
 
 template <>
@@ -78,8 +80,7 @@ class EquationOfState;
  * of state and `false` for non-relativistic equations of state.
  */
 template <bool IsRelativistic>
-class EquationOfState<IsRelativistic, 1>
-    : public PUP::able {
+class EquationOfState<IsRelativistic, 1> : public PUP::able {
  public:
   static constexpr bool is_relativistic = IsRelativistic;
   static constexpr size_t thermodynamic_dim = 1;
@@ -194,8 +195,7 @@ class EquationOfState<IsRelativistic, 1>
  * of state and `false` for non-relativistic equations of state.
  */
 template <bool IsRelativistic>
-class EquationOfState<IsRelativistic, 2>
-    : public PUP::able {
+class EquationOfState<IsRelativistic, 2> : public PUP::able {
  public:
   static constexpr bool is_relativistic = IsRelativistic;
   static constexpr size_t thermodynamic_dim = 2;

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp
@@ -4,7 +4,9 @@
 #pragma once
 
 #include "PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp"
+

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Spectral.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Spectral.cpp
@@ -8,7 +8,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "NumericalAlgorithms/RootFinding/NewtonRaphson.hpp"
-#include "Parallel/Printf.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
 namespace {

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp
@@ -10,6 +10,7 @@
 #include <boost/preprocessor/repetition/for.hpp>
 #include <boost/preprocessor/repetition/repeat.hpp>
 #include <boost/preprocessor/tuple/to_list.hpp>
+#include <cstddef>
 #include <limits>
 #include <pup.h>
 #include <vector>

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_EquationsOfState")
 
 set(LIBRARY_SOURCES
   Test_DarkEnergyFluid.cpp
+  Test_Enthalpy.cpp
   Test_IdealFluid.cpp
   Test_PolytropicFluid.cpp
   Test_SpectralEoS.cpp

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Enthalpy.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Enthalpy.cpp
@@ -1,0 +1,144 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <limits>
+#include <pup.h>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Helpers/PointwiseFunctions/Hydro/EquationsOfState/TestHelpers.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
+
+namespace EquationsOfState {
+namespace {
+
+void check_exact() {
+  // Test creation
+  Parallel::register_derived_classes_with_charm<EquationOfState<true, 1>>();
+  const auto eos_pointer = serialize_and_deserialize(
+      TestHelpers::test_creation<std::unique_ptr<EquationOfState<true, 1>>>(
+          {"Enthalpy:\n"
+           "  ReferenceDensity: 2.0\n"
+           "  MinimumDensity: 4.0\n"
+           "  MaximumDensity: 100.0\n"
+           "  TrigScaling: 1.5\n"
+           "  PolynomialCoefficients: [1.0,0.2,0.0,0.0,0.0001]\n"
+           "  SinCoefficients: [0.01,0.003,-0.0001,0.0001]\n"
+           "  CosCoefficients: [0.01,0.003,0.0001,0.00001]\n"
+           "  TransitionDeltaEpsilon: 0.0\n"
+           "  Spectral:\n"
+           "    ReferenceDensity: 1.054388552462907080\n"
+           "    ReferencePressure: 0.02168181441607176\n"
+           "    Coefficients: [1.4, 0, -0.022880893142188646, "
+           "0.7099134558804311]\n"
+           "    UpperDensity: 4.0\n"}));
+
+  const Enthalpy<Spectral>& eos =
+      dynamic_cast<const Enthalpy<Spectral>&>(*eos_pointer);
+  // Test DataVector functions
+  {
+    const Scalar<DataVector> rho{DataVector{1.5 * exp(1.0), 1.5 * exp(2.0),
+                                            1.5 * exp(3.0), 1.5 * exp(4.0)}};
+    const Scalar<DataVector> p = eos.pressure_from_density(rho);
+    CAPTURE(rho);
+    CAPTURE(p);
+    const Scalar<DataVector> p_expected{
+        DataVector{0.25505331617202415, 1.53718607768077375,
+                   5.29831173857097415, 17.13581872708278553}};
+    CHECK_ITERABLE_APPROX(p, p_expected);
+    const auto eps_c = eos.specific_internal_energy_from_density(rho);
+    const Scalar<DataVector> eps_expected{
+        DataVector{0.09425055282366418, 0.19998963900481931,
+                   0.36012641619526214, 0.55066416955025821}};
+    CHECK_ITERABLE_APPROX(eps_c, eps_expected);
+    const auto h_c = eos.specific_enthalpy_from_density(rho);
+    const auto h_expected =
+        get(eps_expected) + 1.0 + get(p_expected) / get(rho);
+    CHECK_ITERABLE_APPROX(get(h_c), h_expected);
+    const auto chi_c = eos.chi_from_density(rho);
+    const Scalar<DataVector> chi_expected{
+        DataVector{0.18207356789438428, 0.1923165022214991, 0.19908149093638267,
+                   0.25186554704031844}};
+    CHECK_ITERABLE_APPROX(get(chi_expected), get(chi_c));
+    const Scalar<DataVector> p_c_kappa_c_over_rho_sq_expected{
+        DataVector{0.0, 0.0, 0.0, 0.0}};
+    const auto p_c_kappa_c_over_rho_sq =
+        eos.kappa_times_p_over_rho_squared_from_density(rho);
+    CHECK_ITERABLE_APPROX(p_c_kappa_c_over_rho_sq_expected,
+                          p_c_kappa_c_over_rho_sq);
+    const auto rho_from_enthalpy = eos.rest_mass_density_from_enthalpy(h_c);
+    CHECK_ITERABLE_APPROX(rho, rho_from_enthalpy);
+  }
+  // Test low density stitched EoS
+  {
+    const Scalar<DataVector> rho{DataVector{1.5 * exp(-1.0), 1.5}};
+    const Scalar<DataVector> p = eos.pressure_from_density(rho);
+    const Scalar<DataVector> p_expected{
+        DataVector{0.00875810516598451, 0.03560143071808177}};
+    CHECK_ITERABLE_APPROX(p, p_expected);
+    const auto eps_c = eos.specific_internal_energy_from_density(rho);
+    const Scalar<DataVector> eps_expected{
+        DataVector{0.03967833020738167, 0.05919690661251007}};
+    CHECK_ITERABLE_APPROX(eps_c, eps_expected);
+    const auto h_c = eos.specific_enthalpy_from_density(rho);
+    const auto h_expected =
+        get(eps_expected) + 1.0 + get(p_expected) / get(rho);
+    CHECK_ITERABLE_APPROX(get(h_c), h_expected);
+    const auto chi_c = eos.chi_from_density(rho);
+    const Scalar<DataVector> chi_expected{
+        DataVector{0.02221986491613373, 0.03389855168318545}};
+    CHECK_ITERABLE_APPROX(get(chi_expected), get(chi_c));
+    const Scalar<DataVector> p_c_kappa_c_over_rho_sq_expected{
+        DataVector{0.0, 0.0}};
+    const auto p_c_kappa_c_over_rho_sq =
+        eos.kappa_times_p_over_rho_squared_from_density(rho);
+    CHECK_ITERABLE_APPROX(p_c_kappa_c_over_rho_sq_expected,
+                          p_c_kappa_c_over_rho_sq);
+    const auto rho_from_enthalpy = eos.rest_mass_density_from_enthalpy(h_c);
+    CHECK_ITERABLE_APPROX(rho, rho_from_enthalpy);
+  }
+  // Test double functions
+  {
+    const Scalar<double> rho{1.5 * exp(1.0)};
+    const auto p = eos.pressure_from_density(rho);
+    const double p_expected = 0.25505331617202415;
+    CHECK(get(p) == approx(p_expected));
+    const auto eps = eos.specific_internal_energy_from_density(rho);
+    const double eps_expected = 0.09425055282366418;
+    CHECK(get(eps) == approx(eps_expected));
+    const auto h = eos.specific_enthalpy_from_density(rho);
+    const double h_expected = eps_expected + 1.0 + p_expected / get(rho);
+    CHECK(get(h) == approx(h_expected));
+    const auto chi = eos.chi_from_density(rho);
+    const double chi_expected = 0.18207356789438428;
+    CHECK(get(chi) == approx(chi_expected));
+    const auto p_c_kappa_c_over_rho_sq =
+        eos.kappa_times_p_over_rho_squared_from_density(rho);
+    const double p_c_kappa_c_over_rho_sq_expected = 0.0;
+    CHECK(get(p_c_kappa_c_over_rho_sq) ==
+          approx(p_c_kappa_c_over_rho_sq_expected));
+    const auto rho_from_enthalpy = eos.rest_mass_density_from_enthalpy(h);
+    CHECK(get(rho) == approx(get(rho_from_enthalpy)));
+  }
+  // Test bounds
+  CHECK(0.0 == eos.rest_mass_density_lower_bound());
+  CHECK(0.0 == eos.specific_internal_energy_lower_bound(1.0));
+  CHECK(1.0 == eos.specific_enthalpy_lower_bound());
+  const double max_double = std::numeric_limits<double>::max();
+  CHECK(max_double == eos.rest_mass_density_upper_bound());
+  CHECK(max_double == eos.specific_internal_energy_upper_bound(1.0));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.Enthalpy",
+                  "[Unit][EquationsOfState]") {
+  check_exact();
+}
+}  // namespace EquationsOfState


### PR DESCRIPTION
Add parametrization of the enthalpy as a new equation of state

## Proposed changes

Using the enthalpy as a parametrized quantity allows the cold thermodynamic quantities to be computed analytically.  In addition, this EoS will allow for rapid changes in the speed of sound useful for modeling phase transitions.  At low densities, the equation of state is stitched to a simpler model, (for example a spectral model).  The degree of smoothness across the transition is left to the user, allowing even more flexibility in the overall behavior of the model. 
### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
