### PR TITLE
Wrap HarmonicSchwarzschild solution for initial data solver

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/Factory.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/Factory.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/HarmonicSchwarzschild.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/Flatness.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.hpp"
@@ -13,6 +14,7 @@ namespace Xcts {
 /// Analytic solutions of the XCTS equations
 namespace Solutions {
 using all_analytic_solutions =
-    tmpl::list<Flatness, WrappedGr<gr::Solutions::KerrSchild>, Schwarzschild>;
+    tmpl::list<Flatness, WrappedGr<gr::Solutions::KerrSchild>, Schwarzschild,
+               WrappedGr<gr::Solutions::HarmonicSchwarzschild>>;
 }  // namespace Solutions
 }  // namespace Xcts

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.cpp
@@ -12,6 +12,7 @@
 #include "Elliptic/Systems/Xcts/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "Options/Options.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/HarmonicSchwarzschild.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/CommonVariables.tpp"
 #include "PointwiseFunctions/Elasticity/Strain.hpp"
@@ -321,7 +322,8 @@ template class Xcts::AnalyticData::CommonVariables<
 #define INSTANTIATE(_, data) \
   template class Xcts::Solutions::WrappedGr<STYPE(data)>;
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (gr::Solutions::KerrSchild))
+GENERATE_INSTANTIATIONS(INSTANTIATE, (gr::Solutions::KerrSchild,
+                                      gr::Solutions::HarmonicSchwarzschild))
 
 #undef STYPE
 #undef INSTANTIATE

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_XctsSolutions")
 set(LIBRARY_SOURCES
   Test_ConstantDensityStar.cpp
   Test_Flatness.cpp
+  Test_HarmonicSchwarzschild.cpp
   Test_Kerr.cpp
   Test_Schwarzschild.cpp
   )

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_HarmonicSchwarzschild.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_HarmonicSchwarzschild.cpp
@@ -1,0 +1,62 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <string>
+#include <utility>
+
+#include "Elliptic/Systems/Xcts/Geometry.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/PointwiseFunctions/AnalyticSolutions/Xcts/VerifySolution.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/HarmonicSchwarzschild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/AnalyticSolution.hpp"
+
+namespace Xcts::Solutions {
+namespace {
+
+using HarmonicSchwarzschild = WrappedGr<gr::Solutions::HarmonicSchwarzschild>;
+
+void test_solution(const double mass, const std::array<double, 3>& center,
+                   const std::string& options_string) {
+  CAPTURE(mass);
+  CAPTURE(center);
+  const auto created = TestHelpers::test_factory_creation<
+      elliptic::analytic_data::AnalyticSolution, HarmonicSchwarzschild>(
+      options_string);
+  REQUIRE(dynamic_cast<const HarmonicSchwarzschild*>(created.get()) != nullptr);
+  const auto& solution = dynamic_cast<const HarmonicSchwarzschild&>(*created);
+  {
+    INFO("Properties");
+    CHECK(solution.mass() == mass);
+    CHECK(solution.center() == center);
+  }
+  {
+    INFO("Semantics");
+    test_serialization(solution);
+    test_copy_semantics(solution);
+    auto move_solution = solution;
+    test_move_semantics(std::move(move_solution), solution);
+  }
+  {
+    INFO("Verify the solution solves the XCTS system");
+    TestHelpers::Xcts::Solutions::verify_solution<Xcts::Geometry::Curved, 0>(
+        solution, center, 2. * mass, 6. * mass, 1.e-5);
+  }
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticSolutions.Xcts.HarmonicSchwarzschild",
+    "[PointwiseFunctions][Unit]") {
+  test_solution(0.43, {{1., 2., 3.}},
+                "HarmonicSchwarzschild:\n"
+                "  Mass: 0.43\n"
+                "  Center: [1., 2., 3.]");
+}
+
+}  // namespace Xcts::Solutions


### PR DESCRIPTION
## Proposed changes

Allows to use `gr::Solutions::HarmonicSchwarzschild` to generate BBH initial data, including mixed binaries (KS coords for one black hole and harmonic coords for the other). I haven't tested the resulting initial data much yet.

This PR enables quite a lot of exploration once we can evolve the data for a few orbits. #3883 is an important step toward that I think, and it's going to be important to interpolate the initial data to a different evolution domain.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
