### PR TITLE
Fix OrientationMap for Mesh

### DIFF
--- a/src/Domain/Structure/OrientationMap.cpp
+++ b/src/Domain/Structure/OrientationMap.cpp
@@ -83,9 +83,9 @@ std::array<SegmentId, VolumeDim> OrientationMap<VolumeDim>::operator()(
 template <size_t VolumeDim>
 Mesh<VolumeDim> OrientationMap<VolumeDim>::operator()(
     const Mesh<VolumeDim>& mesh) const {
-  return Mesh<VolumeDim>(this->permute_from_neighbor(mesh.extents().indices()),
-                         this->permute_from_neighbor(mesh.basis()),
-                         this->permute_from_neighbor(mesh.quadrature()));
+  return Mesh<VolumeDim>(this->permute_to_neighbor(mesh.extents().indices()),
+                         this->permute_to_neighbor(mesh.basis()),
+                         this->permute_to_neighbor(mesh.quadrature()));
 }
 
 template <size_t VolumeDim>

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Krivodonova.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Krivodonova.hpp
@@ -591,6 +591,8 @@ void Krivodonova<VolumeDim, tmpl::list<Tags...>>::package_data(
   packaged_data->modal_volume_data = orient_variables(
       packaged_data->modal_volume_data, mesh.extents(), orientation_map);
 
+  // This doesn't currently do anything because the mesh is assumed to be the
+  // same in all dimensions
   packaged_data->mesh = orientation_map(mesh);
 }
 

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp
@@ -333,6 +333,10 @@ void Weno<VolumeDim, tmpl::list<Tags...>>::package_data(
   packaged_data->volume_data = orient_variables(
       packaged_data->volume_data, mesh.extents(), orientation_map);
 
+  // Warning: the WENO limiter is currently only tested with aligned meshes.
+  // The orientation of the mesh, the `element_size` computed above, and the
+  // variables should be carefully tested when used with domains that involve
+  // orientation maps
   packaged_data->mesh = orientation_map(mesh);
 }
 

--- a/tests/Unit/Domain/Structure/Test_OrientationMap.cpp
+++ b/tests/Unit/Domain/Structure/Test_OrientationMap.cpp
@@ -296,20 +296,25 @@ void test_3d() {
       {Direction<3>::upper_zeta(), Direction<3>::lower_xi(),
        Direction<3>::lower_eta()}}};
   CHECK(custom3.inverse_map() == custom4);
-  CHECK(Mesh<3>({{4, 5, 3}}, Spectral::Basis::Legendre,
-                Spectral::Quadrature::GaussLobatto) ==
-        custom3(Mesh<3>({{3, 4, 5}}, Spectral::Basis::Legendre,
-                        Spectral::Quadrature::GaussLobatto)));
-  CHECK(Mesh<3>({{5, 3, 4}}, Spectral::Basis::Legendre,
-                Spectral::Quadrature::GaussLobatto) ==
-        custom4(Mesh<3>({{3, 4, 5}}, Spectral::Basis::Legendre,
-                        Spectral::Quadrature::GaussLobatto)));
+  CHECK(custom1.inverse_map().inverse_map() == custom1);
+  CHECK(custom2.inverse_map().inverse_map() == custom2);
+
+  // Test permutations and mesh
+  const Mesh<3> mesh{{{3, 4, 5}},
+                     Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto};
+  CHECK(custom3(mesh) == Mesh<3>({{5, 3, 4}}, Spectral::Basis::Legendre,
+                                 Spectral::Quadrature::GaussLobatto));
+  CHECK(custom4(mesh) == Mesh<3>({{4, 5, 3}}, Spectral::Basis::Legendre,
+                                 Spectral::Quadrature::GaussLobatto));
+  CHECK(custom3.permute_to_neighbor(std::array<int, 3>{{4, -8, 12}}) ==
+        std::array<int, 3>{{12, 4, -8}});
+  CHECK(custom4.permute_to_neighbor(std::array<int, 3>{{4, -8, 12}}) ==
+        std::array<int, 3>{{-8, 12, 4}});
   CHECK(std::array<int, 3>{{-8, 12, 4}} ==
         custom3.permute_from_neighbor(std::array<int, 3>{{4, -8, 12}}));
   CHECK(std::array<int, 3>{{12, 4, -8}} ==
         custom4.permute_from_neighbor(std::array<int, 3>{{4, -8, 12}}));
-  CHECK(custom1.inverse_map().inverse_map() == custom1);
-  CHECK(custom2.inverse_map().inverse_map() == custom2);
 }
 
 }  // namespace

--- a/tests/Unit/Domain/Structure/Test_OrientationMapHelpers.cpp
+++ b/tests/Unit/Domain/Structure/Test_OrientationMapHelpers.cpp
@@ -136,9 +136,8 @@ void test_2d_with_orientation(const OrientationMap<2>& orientation_map) {
       extents.product());
   const std::array<DataVector, 2> oriented_logical_coords = discrete_rotation(
       orientation_map,
-      std::array{
-          get<0>(logical_coordinates(orientation_map.inverse_map()(mesh))),
-          get<1>(logical_coordinates(orientation_map.inverse_map()(mesh)))});
+      std::array{get<0>(logical_coordinates(orientation_map(mesh))),
+                 get<1>(logical_coordinates(orientation_map(mesh)))});
   const auto oriented_mapped_coords = map(
       tnsr::I<DataVector, 2, Frame::ElementLogical>{oriented_logical_coords});
   get(get<ScalarTensor>(expected_vars)) = oriented_mapped_coords[0];
@@ -232,10 +231,9 @@ void test_3d_with_orientation(const OrientationMap<3>& orientation_map) {
       extents.product());
   const std::array<DataVector, 3> oriented_logical_coords = discrete_rotation(
       orientation_map,
-      std::array{
-          get<0>(logical_coordinates(orientation_map.inverse_map()(mesh))),
-          get<1>(logical_coordinates(orientation_map.inverse_map()(mesh))),
-          get<2>(logical_coordinates(orientation_map.inverse_map()(mesh)))});
+      std::array{get<0>(logical_coordinates(orientation_map(mesh))),
+                 get<1>(logical_coordinates(orientation_map(mesh))),
+                 get<2>(logical_coordinates(orientation_map(mesh)))});
   const auto oriented_mapped_coords = map(
       tnsr::I<DataVector, 3, Frame::ElementLogical>{oriented_logical_coords});
   get(get<ScalarTensor>(expected_vars)) = oriented_mapped_coords[0];
@@ -336,10 +334,10 @@ void test_1d_slice_with_orientation(const OrientationMap<2>& orientation_map) {
 
     Variables<tmpl::list<ScalarTensor, Coords<1>>> expected_vars(
         slice_extents.product());
-    get(get<ScalarTensor>(expected_vars)) = get<0>(map_oriented(
-        logical_coordinates(slice_orientation_map.inverse_map()(slice_mesh))));
-    get<Coords<1>>(expected_vars) = map_oriented(
-        logical_coordinates(slice_orientation_map.inverse_map()(slice_mesh)));
+    get(get<ScalarTensor>(expected_vars)) = get<0>(
+        map_oriented(logical_coordinates(slice_orientation_map(slice_mesh))));
+    get<Coords<1>>(expected_vars) =
+        map_oriented(logical_coordinates(slice_orientation_map(slice_mesh)));
     CHECK(oriented_vars == expected_vars);
 
     check_vector(vars, oriented_vars, slice_extents, sliced_dim,
@@ -411,10 +409,9 @@ void test_2d_slice_with_orientation(const OrientationMap<3>& orientation_map) {
     const auto logical_coords = logical_coordinates(slice_mesh);
     const std::array<DataVector, 2> oriented_logical_coords = discrete_rotation(
         slice_orientation_map,
-        std::array{get<0>(logical_coordinates(
-                       slice_orientation_map.inverse_map()(slice_mesh))),
-                   get<1>(logical_coordinates(
-                       slice_orientation_map.inverse_map()(slice_mesh)))});
+        std::array{
+            get<0>(logical_coordinates(slice_orientation_map(slice_mesh))),
+            get<1>(logical_coordinates(slice_orientation_map(slice_mesh)))});
     const auto oriented_mapped_coords = map(
         tnsr::I<DataVector, 2, Frame::ElementLogical>{oriented_logical_coords});
 


### PR DESCRIPTION
## Proposed changes

The orientation map should take an object in the element and transform it to the neighbor's orientation. The logic of the OrientationMap::operator()(Mesh) was the reverse.

Reviewers: please check that I didn't mess this up.

This PR fixes a bug in the elliptic DG subdomain operator on the BNS domain (the BinaryCompactObject domain without excisions).

<s>To make sure that no existing code implicitly assumes the wrong behavior of the function, I made the old function emit an error, so any occurrences of it should be caught by the unit tests. I'll replace the old with the new function once we've confirmed all occurrences are updated.</s> done.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
