### PR TITLE
Enable output of Strahlkorper surface data

### DIFF
--- a/src/IO/H5/SpectralIo.cpp
+++ b/src/IO/H5/SpectralIo.cpp
@@ -13,15 +13,17 @@
 
 namespace h5_detail {
 
-std::array<Spectral::Basis, 3> allowed_bases() {
+std::array<Spectral::Basis, 4> allowed_bases() {
   return {Spectral::Basis::Chebyshev, Spectral::Basis::Legendre,
-          Spectral::Basis::FiniteDifference};
+          Spectral::Basis::FiniteDifference,
+          Spectral::Basis::SphericalHarmonic};
 }
 
-std::array<Spectral::Quadrature, 4> allowed_quadratures() {
+std::array<Spectral::Quadrature, 5> allowed_quadratures() {
   return {Spectral::Quadrature::Gauss, Spectral::Quadrature::GaussLobatto,
           Spectral::Quadrature::CellCentered,
-          Spectral::Quadrature::FaceCentered};
+          Spectral::Quadrature::FaceCentered,
+          Spectral::Quadrature::Equiangular};
 }
 
 void write_dictionary(const std::string& dict_name,

--- a/src/IO/H5/SpectralIo.hpp
+++ b/src/IO/H5/SpectralIo.hpp
@@ -16,13 +16,13 @@ class OpenGroup;
 namespace h5_detail {
 /// We maintain a list of bases and quadratures which are compatible
 /// with IO, this allows for efficient storage of Spectral::Basis in
-/// volume data files (currently there are 3 bases)
-std::array<Spectral::Basis, 3> allowed_bases();
+/// volume data files
+std::array<Spectral::Basis, 4> allowed_bases();
 
 /// We maintain a list of quadratures which are compatible
 /// with IO, this allows for efficient storage of Spectral::Quadrature in
-/// volume data files (currently there are 4 quadratures)
-std::array<Spectral::Quadrature, 4> allowed_quadratures();
+/// volume data files
+std::array<Spectral::Quadrature, 5> allowed_quadratures();
 
 /// Write a dictionary as an attribute to the volume file, can be used
 /// to decode integer sequence as values[i] represents the string

--- a/src/NumericalAlgorithms/Spectral/Spectral.cpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.cpp
@@ -49,6 +49,8 @@ std::ostream& operator<<(std::ostream& os, const Quadrature& quadrature) {
       return os << "CellCentered";
     case Quadrature::FaceCentered:
       return os << "FaceCentered";
+    case Quadrature::Equiangular:
+      return os << "Equiangular";
     default:
       ERROR("Invalid quadrature");
   }

--- a/src/NumericalAlgorithms/Spectral/Spectral.hpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.hpp
@@ -87,7 +87,13 @@ std::ostream& operator<<(std::ostream& os, const Basis& basis);
  * basis), and thus do not implement differentiation matrices, integration
  * weights, and interpolation matrices.
  */
-enum class Quadrature { Gauss, GaussLobatto, CellCentered, FaceCentered };
+enum class Quadrature {
+  Gauss,
+  GaussLobatto,
+  CellCentered,
+  FaceCentered,
+  Equiangular
+};
 
 /// \cond HIDDEN_SYMBOLS
 std::ostream& operator<<(std::ostream& os, const Quadrature& quadrature);
@@ -108,6 +114,8 @@ constexpr size_t minimum_number_of_points(const Basis /*basis*/,
     // NOLINTNEXTLINE(bugprone-branch-clone)
   } else if (quadrature == Quadrature::FaceCentered) {
     return 2;
+  } else if (quadrature == Quadrature::Equiangular) {
+    return 1;
   }
   return std::numeric_limits<size_t>::max();
 }

--- a/tests/Unit/IO/CMakeLists.txt
+++ b/tests/Unit/IO/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(
   EventsAndTriggers
   IO
   Parallel
+  SphericalHarmonics
   Utilities
   )
 

--- a/tests/Unit/IO/H5/Test_VolumeData.cpp
+++ b/tests/Unit/IO/H5/Test_VolumeData.cpp
@@ -17,6 +17,8 @@
 #include "IO/H5/File.hpp"
 #include "IO/H5/VolumeData.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/YlmSpherepack.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/FileSystem.hpp"
@@ -31,6 +33,199 @@ T multiply(const double obs_value, const T& component) {
     t *= obs_value;
   }
   return result;
+}
+
+// Check that the volume data is correct
+template <typename DataType>
+void check_volume_data(
+    const std::string& h5_file_name, const uint32_t version_number,
+    const size_t observation_id, const double observation_value,
+    const std::vector<DataType>& tensor_components_and_coords,
+    const std::vector<std::string>& grid_names,
+    const std::vector<std::vector<Spectral::Basis>>& bases,
+    const std::vector<std::vector<Spectral::Quadrature>>& quadratures,
+    const std::vector<std::vector<size_t>>& extents,
+    const std::vector<std::string>& expected_components,
+    const std::vector<std::vector<size_t>>& grid_data_orders) {
+  h5::H5File<h5::AccessType::ReadOnly> file_read{h5_file_name};
+  const auto& volume_file =
+      file_read.get<h5::VolumeData>("/element_data", version_number);
+
+  CHECK(extents == volume_file.get_extents(observation_id));
+  CHECK(volume_file.get_observation_value(observation_id) == observation_value);
+  // Check that all of the grid names were written correctly by checking their
+  // equality of elements
+  const std::vector<std::string> read_grid_names =
+      volume_file.get_grid_names(observation_id);
+  [&read_grid_names, &grid_names]() {
+    auto sortable_grid_names = grid_names;
+    auto sortable_read_grid_names = read_grid_names;
+    std::sort(sortable_grid_names.begin(), sortable_grid_names.end(),
+              std::less<>{});
+    std::sort(sortable_read_grid_names.begin(), sortable_read_grid_names.end(),
+              std::less<>{});
+    REQUIRE(sortable_read_grid_names == sortable_grid_names);
+  }();
+  // Find the order the grids were written in
+  std::vector<size_t> grid_positions(read_grid_names.size());
+  for (size_t i = 0; i < grid_positions.size(); i++) {
+    auto grid_name = grid_names[i];
+    auto position =
+        std::find(read_grid_names.begin(), read_grid_names.end(), grid_name);
+    // We know the grid name is in the read_grid_names because of the previous
+    // so we know `position` is an actual pointer to an element
+    grid_positions[i] =
+        static_cast<size_t>(std::distance(read_grid_names.begin(), position));
+  }
+  auto read_bases = volume_file.get_bases(observation_id);
+  alg::sort(read_bases, std::less<>{});
+  auto read_quadratures = volume_file.get_quadratures(observation_id);
+  alg::sort(read_quadratures, std::less<>{});
+  // We need non-const bases and quadratures in order to sort them, and we
+  // need them in their string form,
+  const auto& stringify = [](const auto& bases_or_quadratures) {
+    std::vector<std::vector<std::string>> local_target_data{};
+    local_target_data.reserve(bases_or_quadratures.size() + 1);
+    for (const auto& element_data : bases_or_quadratures) {
+      std::vector<std::string> target_axis_data{};
+      target_axis_data.reserve(element_data.size() + 1);
+      for (const auto& axis_datum : element_data) {
+        target_axis_data.emplace_back(MakeString{} << axis_datum);
+      }
+      local_target_data.push_back(target_axis_data);
+    }
+    return local_target_data;
+  };
+  auto target_bases = stringify(bases);
+  alg::sort(target_bases, std::less<>{});
+  auto target_quadratures = stringify(quadratures);
+  alg::sort(target_quadratures, std::less<>{});
+  CHECK(target_bases == read_bases);
+  CHECK(target_quadratures == read_quadratures);
+
+  const auto read_components =
+      volume_file.list_tensor_components(observation_id);
+  CHECK(alg::all_of(read_components,
+                    [&expected_components](const std::string& id) {
+                      return alg::found(expected_components, id);
+                    }));
+  // Helper Function to get number of points on a particular grid
+  const auto accumulate_extents = [](const std::vector<size_t>& grid_extents) {
+    return alg::accumulate(grid_extents, 1, std::multiplies<>{});
+  };
+
+  const auto read_extents = volume_file.get_extents(observation_id);
+  std::vector<size_t> element_num_points(
+      boost::make_transform_iterator(read_extents.begin(), accumulate_extents),
+      boost::make_transform_iterator(read_extents.end(), accumulate_extents));
+  const auto read_points_by_element = [&element_num_points]() {
+    std::vector<size_t> read_points(element_num_points.size());
+    read_points[0] = 0;
+    for (size_t index = 1; index < element_num_points.size(); index++) {
+      read_points[index] =
+          read_points[index - 1] + element_num_points[index - 1];
+    }
+    return read_points;
+  }();
+  // Given a DataType, corresponding to contiguous data read out of a
+  // file, find the data which was written by the grid whose extents are
+  // found at position `grid_index` in the vector of extents.
+  const auto get_grid_data = [&element_num_points, &read_points_by_element](
+                                 const DataVector& all_data,
+                                 const size_t grid_index) {
+    DataType result(element_num_points[grid_index]);
+    // clang-tidy: do not use pointer arithmetic
+    std::copy(&all_data[read_points_by_element[grid_index]],
+              &all_data[read_points_by_element[grid_index]] +  // NOLINT
+                  element_num_points[grid_index],
+              result.begin());
+    return result;
+  };
+  // The tensor components can be written in any order to the file, we loop
+  // over the expected components rather than the read components because they
+  // are in a particular order.
+  for (size_t i = 0; i < expected_components.size(); i++) {
+    const auto& component = expected_components[i];
+    // for each grid
+    for (size_t j = 0; j < grid_names.size(); j++) {
+      CHECK(get_grid_data(
+                volume_file.get_tensor_component(observation_id, component),
+                grid_positions[j]) ==
+            multiply(observation_value,
+                     tensor_components_and_coords[grid_data_orders[j][i]]));
+    }
+  }
+}
+
+void test_strahlkorper() {
+  constexpr size_t l_max = 12;
+  constexpr size_t m_max = 12;
+  constexpr double sphere_radius = 4.0;
+  constexpr std::array<double, 3> center{{5.0, 6.0, 7.0}};
+  const Strahlkorper<Frame::Inertial> strahlkorper{l_max, m_max, sphere_radius,
+                                                   center};
+  const YlmSpherepack& ylm = strahlkorper.ylm_spherepack();
+  const std::array<DataVector, 2> theta_phi = ylm.theta_phi_points();
+  const DataVector theta = theta_phi[0];
+  const DataVector phi = theta_phi[1];
+  const DataVector sin_theta = sin(theta);
+  const DataVector radius = ylm.spec_to_phys(strahlkorper.coefficients());
+  const std::string grid_name{"AhA"};
+  const std::vector<DataVector> tensor_and_coord_data{
+      radius * sin_theta * cos(phi), radius * sin_theta * sin(phi),
+      radius * cos(theta), cos(2.0 * theta)};
+  const std::vector<TensorComponent> tensor_components{
+      {grid_name + "/InertialCoordinates_x", tensor_and_coord_data[0]},
+      {grid_name + "/InertialCoordinates_y", tensor_and_coord_data[1]},
+      {grid_name + "/InertialCoordinates_z", tensor_and_coord_data[2]},
+      {grid_name + "/TestScalar", tensor_and_coord_data[3]}};
+
+  const std::vector<size_t> observation_ids{4444};
+  const std::vector<double> observation_values{1.0};
+  const std::vector<Spectral::Basis> bases{2,
+                                           Spectral::Basis::SphericalHarmonic};
+  const std::vector<Spectral::Quadrature> quadratures{
+      {Spectral::Quadrature::Gauss, Spectral::Quadrature::Equiangular}};
+
+  const std::string h5_file_name{"Unit.IO.H5.VolumeData.Strahlkorper.h5"};
+  const uint32_t version_number = 4;
+  if (file_system::check_if_file_exists(h5_file_name)) {
+    file_system::rm(h5_file_name, true);
+  }
+
+  const std::vector<size_t> extents{
+      {ylm.physical_extents()[0], ylm.physical_extents()[1]}};
+
+  {
+    h5::H5File<h5::AccessType::ReadWrite> strahlkorper_file{h5_file_name};
+    auto& volume_file = strahlkorper_file.insert<h5::VolumeData>(
+        "/element_data", version_number);
+    volume_file.write_volume_data(
+        observation_ids[0], observation_values[0],
+        std::vector<ElementVolumeData>{
+            {extents, tensor_components, bases, quadratures}});
+    strahlkorper_file.close_current_object();
+
+    // Open the read volume file and check that the observation id and values
+    // are correct.
+    const auto& volume_file_read =
+        strahlkorper_file.get<h5::VolumeData>("/element_data", version_number);
+    const auto read_observation_ids = volume_file_read.list_observation_ids();
+    CHECK(read_observation_ids == std::vector<size_t>{4444});
+    CHECK(volume_file_read.get_observation_value(observation_ids[0]) ==
+          observation_values[0]);
+  }
+
+  check_volume_data(h5_file_name, version_number, observation_ids[0],
+                    observation_values[0], tensor_and_coord_data, {{grid_name}},
+                    {bases}, {quadratures}, {extents},
+                    {"InertialCoordinates_x", "InertialCoordinates_y",
+                     "InertialCoordinates_z", "TestScalar"},
+                    {{0, 1, 2, 3}});
+
+  if (file_system::check_if_file_exists(h5_file_name)) {
+    file_system::rm(h5_file_name, true);
+  }
 }
 
 template <typename DataType>
@@ -141,127 +336,14 @@ void test() {
                    });
     CHECK(found_observation_ids == observation_ids);
   }
-  // Check that the volume data is correct
-  const auto check_time = [&volume_file, &tensor_components_and_coords,
-                           &grid_names, &bases,
-                           &quadratures](const size_t observation_id,
-                                         const double observation_value) {
-    CHECK(std::vector<std::vector<size_t>>{{2, 2, 2}, {2, 2, 2}} ==
-          volume_file.get_extents(observation_id));
-    CHECK(volume_file.get_observation_value(observation_id) ==
-          observation_value);
-    // Check that all of the grid names were written correctly by checking their
-    // equality of elements
-    const std::vector<std::string> read_grid_names =
-        volume_file.get_grid_names(observation_id);
-    [&read_grid_names, &grid_names]() {
-      auto sortable_grid_names = grid_names;
-      auto sortable_read_grid_names = read_grid_names;
-      std::sort(sortable_grid_names.begin(), sortable_grid_names.end(),
-                std::less<>{});
-      std::sort(sortable_read_grid_names.begin(),
-                sortable_read_grid_names.end(), std::less<>{});
-      REQUIRE(sortable_read_grid_names == sortable_grid_names);
-    }();
-    // Find the order the grids were written in
-    std::vector<size_t> grid_positions(read_grid_names.size());
-    for (size_t i = 0; i < grid_positions.size(); i++) {
-      auto grid_name = grid_names[i];
-      auto position =
-          std::find(read_grid_names.begin(), read_grid_names.end(), grid_name);
-      // We know the grid name is in the read_grid_names because of the previous
-      // so we know `position` is an actual pointer to an element
-      grid_positions[i] =
-          static_cast<size_t>(std::distance(read_grid_names.begin(), position));
-    }
-    auto read_bases = volume_file.get_bases(observation_id);
-    alg::sort(read_bases, std::less<>{});
-    auto read_quadratures = volume_file.get_quadratures(observation_id);
-    alg::sort(read_quadratures, std::less<>{});
-    // We need non-const bases and quadratures in order to sort them, and we
-    // need them in their string form,
-    const auto& stringify = [](const auto& bases_or_quadratures) {
-      std::vector<std::vector<std::string>> local_target_data{};
-      local_target_data.reserve(bases_or_quadratures.size() + 1);
-      for (const auto& element_data : bases_or_quadratures) {
-        std::vector<std::string> target_axis_data{};
-        target_axis_data.reserve(element_data.size() + 1);
-        for (const auto& axis_datum : element_data) {
-          target_axis_data.emplace_back(MakeString{} << axis_datum);
-        }
-        local_target_data.push_back(target_axis_data);
-      }
-      return local_target_data;
-    };
-    auto target_bases = stringify(bases);
-    alg::sort(target_bases, std::less<>{});
-    auto target_quadratures = stringify(quadratures);
-    alg::sort(target_quadratures, std::less<>{});
-    CHECK(target_bases == read_bases);
-    CHECK(target_quadratures == read_quadratures);
-    const std::vector<std::string> expected_components{
-        "S", "x-coord", "y-coord", "z-coord", "T_x", "T_y", "T_z",
-    };
-    const auto read_components =
-        volume_file.list_tensor_components(observation_id);
-    CHECK(alg::all_of(read_components,
-                      [&expected_components](const std::string& id) {
-                        return alg::found(expected_components, id);
-                      }));
-    // Helper Function to get number of points on a particular grid
-    const auto accumulate_extents =
-        [](const std::vector<size_t>& grid_extents) {
-          return alg::accumulate(grid_extents, 1, std::multiplies<>{});
-        };
 
-    const auto read_extents = volume_file.get_extents(observation_id);
-    std::vector<size_t> element_num_points(
-        boost::make_transform_iterator(read_extents.begin(),
-                                       accumulate_extents),
-        boost::make_transform_iterator(read_extents.end(), accumulate_extents));
-    const auto read_points_by_element = [&element_num_points]() {
-      std::vector<size_t> read_points(element_num_points.size());
-      read_points[0] = 0;
-      for (size_t index = 1; index < element_num_points.size(); index++) {
-        read_points[index] =
-            read_points[index - 1] + element_num_points[index - 1];
-      }
-      return read_points;
-    }();
-    // Given a DataType, corresponding to contiguous data read out of a
-    // file, find the data which was written by the grid whose extents are
-    // found at position `grid_index` in the vector of extents.
-    const auto get_grid_data = [&element_num_points, &read_points_by_element](
-                                   const DataVector& all_data,
-                                   const size_t grid_index) {
-      DataType result(element_num_points[grid_index]);
-      // clang-tidy: do not use pointer arithmetic
-      std::copy(&all_data[read_points_by_element[grid_index]],
-                &all_data[read_points_by_element[grid_index]] +  // NOLINT
-                    element_num_points[grid_index],
-                result.begin());
-      return result;
-    };
-    // The order the fake tensor data was assigned to the tensor components
-    std::vector<std::vector<size_t>> grid_data_orders{{0, 1, 2, 3, 4, 5, 6},
-                                                      {1, 0, 5, 3, 6, 4, 2}};
-    // The tensor components can be written in any order to the file, we loop
-    // over the expected components rather than the read components because they
-    // are in a particular order.
-    for (size_t i = 0; i < expected_components.size(); i++) {
-      const auto& component = expected_components[i];
-      // for each grid
-      for (size_t j = 0; j < grid_names.size(); j++) {
-        CHECK(get_grid_data(
-                  volume_file.get_tensor_component(observation_id, component),
-                  grid_positions[j]) ==
-              multiply(observation_value,
-                       tensor_components_and_coords[grid_data_orders[j][i]]));
-      }
-    }
-  };
   for (size_t i = 0; i < observation_ids.size(); ++i) {
-    check_time(observation_ids[i], observation_values[i]);
+    check_volume_data(
+        h5_file_name, version_number, observation_ids[i], observation_values[i],
+        tensor_components_and_coords, grid_names, bases, quadratures,
+        {{2, 2, 2}, {2, 2, 2}},
+        {"S", "x-coord", "y-coord", "z-coord", "T_x", "T_y", "T_z"},
+        {{0, 1, 2, 3, 4, 5, 6}, {1, 0, 5, 3, 6, 4, 2}});
   }
 
   {
@@ -290,6 +372,7 @@ void test() {
 SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData", "[Unit][IO][H5]") {
   test<DataVector>();
   test<std::vector<float>>();
+  test_strahlkorper();
 
 #ifdef SPECTRE_DEBUG
   CHECK_THROWS_WITH(


### PR DESCRIPTION
## Proposed changes

Enable H5 VolumeData output to output data on a Strahlkorper (2D surface).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
