### PR TITLE
post_horizon_find_callbacks is now a tmpl::list.

### DIFF
--- a/src/ControlSystem/ApparentHorizons/Measurements.hpp
+++ b/src/ControlSystem/ApparentHorizons/Measurements.hpp
@@ -82,8 +82,8 @@ struct BothHorizons : tt::ConformsTo<protocols::Measurement> {
                                                 ::Frame::Grid>;
       using horizon_find_failure_callback =
           intrp::callbacks::ErrorOnFailedApparentHorizon;
-      using post_horizon_find_callback =
-          control_system::RunCallbacks<FindHorizon, ControlSystems>;
+      using post_horizon_find_callbacks =
+          tmpl::list<control_system::RunCallbacks<FindHorizon, ControlSystems>>;
     };
 
     using source_tensors =

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
@@ -107,8 +107,9 @@ struct EvolutionMetavars<3, InitialData, BoundaryConditions>
         intrp::callbacks::FindApparentHorizon<AhA, ::Frame::Inertial>;
     using horizon_find_failure_callback =
         intrp::callbacks::ErrorOnFailedApparentHorizon;
-    using post_horizon_find_callback =
-        intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, AhA, AhA>;
+    using post_horizon_find_callbacks =
+        tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe,
+                                                                AhA, AhA>>;
   };
 
   using interpolation_target_tags = tmpl::list<AhA>;
@@ -136,10 +137,9 @@ struct EvolutionMetavars<3, InitialData, BoundaryConditions>
       GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma2<
           volume_dim, Frame::Grid>>;
 
-  using observed_reduction_data_tags =
-      observers::collect_reduction_data_tags<tmpl::push_back<
-          tmpl::at<typename factory_creation::factory_classes, Event>,
-          typename AhA::post_horizon_find_callback>>;
+  using observed_reduction_data_tags = observers::collect_reduction_data_tags<
+      tmpl::append<tmpl::at<typename factory_creation::factory_classes, Event>,
+                   typename AhA::post_horizon_find_callbacks>>;
 
   using dg_registration_list =
       tmpl::push_back<typename gh_base::dg_registration_list,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -264,8 +264,9 @@ struct EvolutionMetavars {
         intrp::callbacks::FindApparentHorizon<AhA, ::Frame::Grid>;
     using horizon_find_failure_callback =
         intrp::callbacks::ErrorOnFailedApparentHorizon;
-    using post_horizon_find_callback =
-        intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, AhA, AhA>;
+    using post_horizon_find_callbacks =
+        tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe,
+                                                                AhA, AhA>>;
   };
 
   struct AhB {
@@ -281,8 +282,9 @@ struct EvolutionMetavars {
         intrp::callbacks::FindApparentHorizon<AhB, ::Frame::Grid>;
     using horizon_find_failure_callback =
         intrp::callbacks::ErrorOnFailedApparentHorizon;
-    using post_horizon_find_callback =
-        intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, AhB, AhB>;
+    using post_horizon_find_callbacks =
+        tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe,
+                                                                AhB, AhB>>;
   };
 
   using interpolation_target_tags = tmpl::list<AhA,AhB>;
@@ -377,11 +379,10 @@ struct EvolutionMetavars {
                                          Triggers::time_triggers>>>;
   };
 
-  using observed_reduction_data_tags =
-      observers::collect_reduction_data_tags<tmpl::push_back<
-          tmpl::at<typename factory_creation::factory_classes, Event>,
-          typename AhA::post_horizon_find_callback,
-          typename AhB::post_horizon_find_callback>>;
+  using observed_reduction_data_tags = observers::collect_reduction_data_tags<
+      tmpl::append<tmpl::at<typename factory_creation::factory_classes, Event>,
+                   typename AhA::post_horizon_find_callbacks,
+                   typename AhB::post_horizon_find_callbacks>>;
 
   // A tmpl::list of tags to be added to the GlobalCache by the
   // metavariables

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizon.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizon.hpp
@@ -76,8 +76,9 @@ struct EvolutionMetavars
         intrp::callbacks::FindApparentHorizon<AhA, ::Frame::Inertial>;
     using horizon_find_failure_callback =
         intrp::callbacks::ErrorOnFailedApparentHorizon;
-    using post_horizon_find_callback =
-        intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, AhA, AhA>;
+    using post_horizon_find_callbacks =
+        tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe,
+                                                                AhA, AhA>>;
   };
 
   using interpolation_target_tags = tmpl::list<AhA>;
@@ -116,8 +117,9 @@ struct EvolutionMetavars
 
   using observed_reduction_data_tags =
       observers::collect_reduction_data_tags<tmpl::push_back<
-          tmpl::at<typename factory_creation::factory_classes, Event>,
-          typename AhA::post_horizon_find_callback,
+          tmpl::append<
+              tmpl::at<typename factory_creation::factory_classes, Event>,
+              typename AhA::post_horizon_find_callbacks>,
           typename InterpolationTargetTags::post_interpolation_callback...>>;
 
   using dg_registration_list = typename GhValenciaDivCleanTemplateBase<

--- a/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
+++ b/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
@@ -600,6 +600,25 @@ void set_up_interpolation(
       });
 }
 
+namespace detail {
+template <typename Callback>
+struct get_observation_types {
+  using type = typename Callback::observation_types;
+};
+}  // namespace detail
+
+/// Given a list of post_interpolation_callbacks, obtain a list of distinct
+/// observation_types used by them.
+/// @{
+template <typename Callbacks>
+struct observation_types {
+  using type = tmpl::remove_duplicates<tmpl::flatten<
+      tmpl::transform<Callbacks, detail::get_observation_types<tmpl::_1>>>>;
+};
+template <typename Callbacks>
+using observation_types_t = typename observation_types<Callbacks>::type;
+/// @}
+
 CREATE_HAS_TYPE_ALIAS(compute_vars_to_interpolate)
 CREATE_HAS_TYPE_ALIAS_V(compute_vars_to_interpolate)
 


### PR DESCRIPTION
Previously it was a single callback that was called at the
end of a successful horizon find.

Each callback is called in the order it is listed.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
`post_horizon_find_callback` needs to be changed to `post_horizon_find_callbacks`, and is
a `tmpl::list` of structs instead of a single struct.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
