### PR TITLE
Add XCTS TOV solution, enabling simple head-on BNS initial data

### DIFF
--- a/src/Elliptic/Executables/Xcts/CMakeLists.txt
+++ b/src/Elliptic/Executables/Xcts/CMakeLists.txt
@@ -15,6 +15,7 @@ set(LIBS_TO_LINK
   ErrorHandling
   Events
   EventsAndTriggers
+  Hydro
   Informer
   Initialization
   LinearOperators

--- a/src/Elliptic/Executables/Xcts/SolveXcts.hpp
+++ b/src/Elliptic/Executables/Xcts/SolveXcts.hpp
@@ -39,6 +39,7 @@
 #include "ParallelAlgorithms/LinearSolver/Multigrid/Tags.hpp"
 #include "PointwiseFunctions/AnalyticData/Xcts/Binary.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/Factory.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/RegisterDerivedWithCharm.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/AnalyticSolution.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/Background.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/InitialGuess.hpp"
@@ -170,6 +171,7 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &Parallel::register_derived_classes_with_charm<
         metavariables::solver::schwarz_smoother::subdomain_solver>,
     &elliptic::subdomain_preconditioners::register_derived_with_charm,
+    &EquationsOfState::register_derived_with_charm,
     &Parallel::register_factory_classes_with_charm<metavariables>};
 static const std::vector<void (*)()> charm_init_proc_funcs{
     &enable_floating_point_exceptions};

--- a/src/PointwiseFunctions/AnalyticData/Xcts/CommonVariables.hpp
+++ b/src/PointwiseFunctions/AnalyticData/Xcts/CommonVariables.hpp
@@ -77,7 +77,7 @@ struct CommonVariables {
   CommonVariables(
       std::optional<std::reference_wrapper<const Mesh<Dim>>> local_mesh,
       std::optional<std::reference_wrapper<const InverseJacobian<
-          DataType, Dim, Frame::ElementLogical, Frame::Inertial>>>
+          DataVector, Dim, Frame::ElementLogical, Frame::Inertial>>>
           local_inv_jacobian)
       : mesh(std::move(local_mesh)),
         inv_jacobian(std::move(local_inv_jacobian)) {}
@@ -172,7 +172,7 @@ struct CommonVariables {
 
   std::optional<std::reference_wrapper<const Mesh<Dim>>> mesh;
   std::optional<std::reference_wrapper<const InverseJacobian<
-      DataType, Dim, Frame::ElementLogical, Frame::Inertial>>>
+      DataVector, Dim, Frame::ElementLogical, Frame::Inertial>>>
       inv_jacobian;
 };
 

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_sources(
   ConstantDensityStar.cpp
   Flatness.cpp
   Schwarzschild.cpp
+  TovStar.cpp
   WrappedGr.cpp
   )
 
@@ -24,6 +25,7 @@ spectre_target_headers(
   Factory.hpp
   Flatness.hpp
   Schwarzschild.hpp
+  TovStar.hpp
   WrappedGr.hpp
   )
 
@@ -38,6 +40,7 @@ target_link_libraries(
   InitialDataUtilities
   Options
   Parallel
+  RelativisticEulerSolutions
   Utilities
   Xcts
   XctsAnalyticData

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/Factory.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/Factory.hpp
@@ -8,6 +8,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/SphericalKerrSchild.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/Flatness.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Xcts/TovStar.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -17,6 +18,6 @@ namespace Solutions {
 using all_analytic_solutions =
     tmpl::list<Flatness, WrappedGr<gr::Solutions::KerrSchild>,
                WrappedGr<gr::Solutions::SphericalKerrSchild>, Schwarzschild,
-               WrappedGr<gr::Solutions::HarmonicSchwarzschild>>;
+               WrappedGr<gr::Solutions::HarmonicSchwarzschild>, TovStar>;
 }  // namespace Solutions
 }  // namespace Xcts

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.hpp
@@ -240,6 +240,8 @@ using SchwarzschildVariablesCache =
     cached_temp_buffer_from_typelist<tmpl::push_front<
         common_tags<DataType>, detail::Tags::Radius<DataType>,
         detail::Tags::ArealRadius<DataType>,
+        ::Tags::deriv<gr::Tags::Lapse<DataType>, tmpl::size_t<3>,
+                      Frame::Inertial>,
         gr::Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 0>,
         gr::Tags::Conformal<gr::Tags::StressTrace<DataType>, 0>,
         gr::Tags::Conformal<
@@ -317,6 +319,10 @@ struct SchwarzschildVariables
   void operator()(gsl::not_null<Scalar<DataType>*> lapse,
                   gsl::not_null<Cache*> cache,
                   gr::Tags::Lapse<DataType> /*meta*/) const override;
+  void operator()(gsl::not_null<tnsr::i<DataType, 3>*> deriv_lapse,
+                  gsl::not_null<Cache*> cache,
+                  ::Tags::deriv<gr::Tags::Lapse<DataType>, tmpl::size_t<3>,
+                                Frame::Inertial> /*meta*/) const;
   void operator()(
       gsl::not_null<Scalar<DataType>*> lapse_times_conformal_factor,
       gsl::not_null<Cache*> cache,

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.hpp
@@ -257,7 +257,7 @@ struct SchwarzschildVariables
   SchwarzschildVariables(
       std::optional<std::reference_wrapper<const Mesh<Dim>>> local_mesh,
       std::optional<std::reference_wrapper<const InverseJacobian<
-          DataType, Dim, Frame::ElementLogical, Frame::Inertial>>>
+          DataVector, Dim, Frame::ElementLogical, Frame::Inertial>>>
           local_inv_jacobian,
       const tnsr::I<DataType, 3>& local_x, const double local_mass,
       const SchwarzschildCoordinates local_coordinate_system)

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/TovStar.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/TovStar.cpp
@@ -1,0 +1,312 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticSolutions/Xcts/TovStar.hpp"
+
+#include <algorithm>
+#include <ostream>
+#include <pup.h>
+#include <utility>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Elliptic/Systems/Xcts/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Options/Options.hpp"
+#include "Options/ParseOptions.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Xcts/CommonVariables.tpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags/Conformal.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Xcts::Solutions::tov_detail {
+
+template <typename DataType>
+void TovVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::ii<DataType, 3>*> conformal_metric,
+    const gsl::not_null<Cache*> /* cache */,
+    Tags::ConformalMetric<DataType, 3, Frame::Inertial> /*meta*/) const {
+  if (tov_star.radial_solution().coordinate_system() ==
+      TovCoordinates::Isotropic) {
+    get<0, 0>(*conformal_metric) = 1.;
+    get<1, 1>(*conformal_metric) = 1.;
+    get<2, 2>(*conformal_metric) = 1.;
+    get<0, 1>(*conformal_metric) = 0.;
+    get<0, 2>(*conformal_metric) = 0.;
+    get<1, 2>(*conformal_metric) = 0.;
+  } else {
+    *conformal_metric =
+        get_tov_var(gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>{});
+  }
+}
+
+template <typename DataType>
+void TovVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::II<DataType, 3>*> inv_conformal_metric,
+    const gsl::not_null<Cache*> /* cache */,
+    Tags::InverseConformalMetric<DataType, 3, Frame::Inertial> /*meta*/) const {
+  if (tov_star.radial_solution().coordinate_system() ==
+      TovCoordinates::Isotropic) {
+    get<0, 0>(*inv_conformal_metric) = 1.;
+    get<1, 1>(*inv_conformal_metric) = 1.;
+    get<2, 2>(*inv_conformal_metric) = 1.;
+    get<0, 1>(*inv_conformal_metric) = 0.;
+    get<0, 2>(*inv_conformal_metric) = 0.;
+    get<1, 2>(*inv_conformal_metric) = 0.;
+  } else {
+    *inv_conformal_metric = get_tov_var(
+        gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataType>{});
+  }
+}
+
+template <typename DataType>
+void TovVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::ijj<DataType, 3>*> deriv_conformal_metric,
+    const gsl::not_null<Cache*> /* cache */,
+    ::Tags::deriv<Tags::ConformalMetric<DataType, 3, Frame::Inertial>,
+                  tmpl::size_t<3>, Frame::Inertial> /*meta*/) const {
+  if (tov_star.radial_solution().coordinate_system() ==
+      TovCoordinates::Isotropic) {
+    std::fill(deriv_conformal_metric->begin(), deriv_conformal_metric->end(),
+              0.);
+  } else {
+    *deriv_conformal_metric = get_tov_var(
+        ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>,
+                      tmpl::size_t<3>, Frame::Inertial>{});
+  }
+}
+
+template <typename DataType>
+void TovVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::ii<DataType, 3>*> extrinsic_curvature,
+    const gsl::not_null<Cache*> /* cache */,
+    gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataType> /*meta*/) const {
+  std::fill(extrinsic_curvature->begin(), extrinsic_curvature->end(), 0.);
+}
+
+template <typename DataType>
+void TovVariables<DataType>::operator()(
+    const gsl::not_null<Scalar<DataType>*> trace_extrinsic_curvature,
+    const gsl::not_null<Cache*> /* cache */,
+    gr::Tags::TraceExtrinsicCurvature<DataType> /*meta*/) const {
+  get(*trace_extrinsic_curvature) = 0.;
+}
+
+template <typename DataType>
+void TovVariables<DataType>::operator()(
+    const gsl::not_null<Scalar<DataType>*> dt_trace_extrinsic_curvature,
+    const gsl::not_null<Cache*> /* cache */,
+    ::Tags::dt<gr::Tags::TraceExtrinsicCurvature<DataType>> /*meta*/) const {
+  get(*dt_trace_extrinsic_curvature) = 0.;
+}
+
+template <typename DataType>
+void TovVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::i<DataType, 3>*> deriv_trace_extrinsic_curvature,
+    const gsl::not_null<Cache*> /* cache */,
+    ::Tags::deriv<gr::Tags::TraceExtrinsicCurvature<DataType>, tmpl::size_t<3>,
+                  Frame::Inertial> /*meta*/) const {
+  std::fill(deriv_trace_extrinsic_curvature->begin(),
+            deriv_trace_extrinsic_curvature->end(), 0.);
+}
+
+template <typename DataType>
+void TovVariables<DataType>::operator()(
+    const gsl::not_null<Scalar<DataType>*> conformal_factor,
+    const gsl::not_null<Cache*> /* cache */,
+    Tags::ConformalFactor<DataType> /*meta*/) const {
+  if (tov_star.radial_solution().coordinate_system() ==
+      TovCoordinates::Isotropic) {
+    *conformal_factor = get_tov_var(
+        RelativisticEuler::Solutions::tov_detail::Tags::ConformalFactor<
+            DataType>{});
+  } else {
+    get(*conformal_factor) = 1.;
+  }
+}
+
+template <typename DataType>
+void TovVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::i<DataType, 3>*> deriv_conformal_factor,
+    const gsl::not_null<Cache*> /* cache */,
+    ::Tags::deriv<Tags::ConformalFactor<DataType>, tmpl::size_t<3>,
+                  Frame::Inertial> /*meta*/) const {
+  if (tov_star.radial_solution().coordinate_system() ==
+      TovCoordinates::Isotropic) {
+    for (size_t i = 0; i < get_size(radius); ++i) {
+      if (get_element(radius, i) > 1.e-14) {
+        using tag =
+            RelativisticEuler::Solutions::tov_detail::Tags::DrConformalFactor<
+                double>;
+        const tnsr::I<double, 3> x_i{
+            {{get_element(get<0>(x), i), get_element(get<1>(x), i),
+              get_element(get<2>(x), i)}}};
+        const double dr_conformal_factor =
+            get(get<tag>(tov_star.variables(x_i, 0., tmpl::list<tag>{})));
+        get_element(get<0>(*deriv_conformal_factor), i) =
+            dr_conformal_factor / get_element(radius, i);
+      } else {
+        get_element(get<0>(*deriv_conformal_factor), i) = 0.;
+      }
+    }
+    get<1>(*deriv_conformal_factor) = get<0>(*deriv_conformal_factor);
+    get<2>(*deriv_conformal_factor) = get<0>(*deriv_conformal_factor);
+    get<0>(*deriv_conformal_factor) *= get<0>(x);
+    get<1>(*deriv_conformal_factor) *= get<1>(x);
+    get<2>(*deriv_conformal_factor) *= get<2>(x);
+  } else {
+    get<0>(*deriv_conformal_factor) = 0.;
+    get<1>(*deriv_conformal_factor) = 0.;
+    get<2>(*deriv_conformal_factor) = 0.;
+  }
+}
+
+template <typename DataType>
+void TovVariables<DataType>::operator()(
+    const gsl::not_null<Scalar<DataType>*> lapse,
+    const gsl::not_null<Cache*> /* cache */,
+    gr::Tags::Lapse<DataType> /*meta*/) const {
+  *lapse = get_tov_var(gr::Tags::Lapse<DataType>{});
+}
+
+template <typename DataType>
+void TovVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::i<DataType, 3>*> deriv_lapse,
+    const gsl::not_null<Cache*> /* cache */,
+    ::Tags::deriv<gr::Tags::Lapse<DataType>, tmpl::size_t<3>,
+                  Frame::Inertial> /*meta*/) const {
+  *deriv_lapse = get_tov_var(::Tags::deriv<gr::Tags::Lapse<DataType>,
+                                           tmpl::size_t<3>, Frame::Inertial>{});
+}
+
+template <typename DataType>
+void TovVariables<DataType>::operator()(
+    const gsl::not_null<Scalar<DataType>*> lapse_times_conformal_factor,
+    const gsl::not_null<Cache*> cache,
+    Tags::LapseTimesConformalFactor<DataType> /*meta*/) const {
+  const auto& conformal_factor =
+      get(cache->get_var(*this, Tags::ConformalFactor<DataType>{}));
+  const auto& lapse = get(cache->get_var(*this, gr::Tags::Lapse<DataType>{}));
+  get(*lapse_times_conformal_factor) = lapse * conformal_factor;
+}
+
+template <typename DataType>
+void TovVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::i<DataType, 3>*>
+        deriv_lapse_times_conformal_factor,
+    const gsl::not_null<Cache*> cache,
+    ::Tags::deriv<Tags::LapseTimesConformalFactor<DataType>, tmpl::size_t<3>,
+                  Frame::Inertial> /*meta*/) const {
+  const auto& conformal_factor =
+      get(cache->get_var(*this, Tags::ConformalFactor<DataType>{}));
+  const auto& lapse = get(cache->get_var(*this, gr::Tags::Lapse<DataType>{}));
+  const auto& deriv_conformal_factor =
+      cache->get_var(*this, ::Tags::deriv<Tags::ConformalFactor<DataType>,
+                                          tmpl::size_t<3>, Frame::Inertial>{});
+  const auto& deriv_lapse =
+      cache->get_var(*this, ::Tags::deriv<gr::Tags::Lapse<DataType>,
+                                          tmpl::size_t<3>, Frame::Inertial>{});
+  get<0>(*deriv_lapse_times_conformal_factor) =
+      lapse * get<0>(deriv_conformal_factor) +
+      get<0>(deriv_lapse) * conformal_factor;
+  get<1>(*deriv_lapse_times_conformal_factor) =
+      lapse * get<1>(deriv_conformal_factor) +
+      get<1>(deriv_lapse) * conformal_factor;
+  get<2>(*deriv_lapse_times_conformal_factor) =
+      lapse * get<2>(deriv_conformal_factor) +
+      get<2>(deriv_lapse) * conformal_factor;
+}
+
+template <typename DataType>
+void TovVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::I<DataType, 3>*> shift_background,
+    const gsl::not_null<Cache*> /* cache */,
+    Tags::ShiftBackground<DataType, 3, Frame::Inertial> /*meta*/) const {
+  std::fill(shift_background->begin(), shift_background->end(), 0.);
+}
+
+template <typename DataType>
+void TovVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::II<DataType, 3, Frame::Inertial>*>
+        longitudinal_shift_background_minus_dt_conformal_metric,
+    const gsl::not_null<Cache*> /* cache */,
+    Tags::LongitudinalShiftBackgroundMinusDtConformalMetric<
+        DataType, 3, Frame::Inertial> /*meta*/) const {
+  std::fill(longitudinal_shift_background_minus_dt_conformal_metric->begin(),
+            longitudinal_shift_background_minus_dt_conformal_metric->end(), 0.);
+}
+
+template <typename DataType>
+void TovVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::I<DataType, 3>*> shift_excess,
+    const gsl::not_null<Cache*> /* cache */,
+    Tags::ShiftExcess<DataType, 3, Frame::Inertial> /*meta*/) const {
+  std::fill(shift_excess->begin(), shift_excess->end(), 0.);
+}
+
+template <typename DataType>
+void TovVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::ii<DataType, 3>*> shift_strain,
+    const gsl::not_null<Cache*> /* cache */,
+    Tags::ShiftStrain<DataType, 3, Frame::Inertial> /*meta*/) const {
+  std::fill(shift_strain->begin(), shift_strain->end(), 0.);
+}
+
+template <typename DataType>
+void TovVariables<DataType>::operator()(
+    const gsl::not_null<Scalar<DataType>*> energy_density,
+    const gsl::not_null<Cache*> /* cache */,
+    gr::Tags::Conformal<gr::Tags::EnergyDensity<DataType>,
+                        ConformalMatterScale> /*meta*/) const {
+  *energy_density = get_tov_var(hydro::Tags::RestMassDensity<DataType>{});
+  get(*energy_density) *=
+      get(get_tov_var(hydro::Tags::SpecificEnthalpy<DataType>{}));
+  get(*energy_density) -= get(get_tov_var(hydro::Tags::Pressure<DataType>{}));
+}
+
+template <typename DataType>
+void TovVariables<DataType>::operator()(
+    const gsl::not_null<Scalar<DataType>*> stress_trace,
+    const gsl::not_null<Cache*> /* cache */,
+    gr::Tags::Conformal<gr::Tags::StressTrace<DataType>,
+                        ConformalMatterScale> /*meta*/) const {
+  get(*stress_trace) = 3. * get(get_tov_var(hydro::Tags::Pressure<DataType>{}));
+}
+
+template <typename DataType>
+void TovVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::I<DataType, 3>*> momentum_density,
+    const gsl::not_null<Cache*> /* cache */,
+    gr::Tags::Conformal<gr::Tags::MomentumDensity<3, Frame::Inertial, DataType>,
+                        ConformalMatterScale> /*meta*/) const {
+  std::fill(momentum_density->begin(), momentum_density->end(), 0.);
+}
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define INSTANTIATE(_, data) template class TovVariables<DTYPE(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
+
+#undef DTYPE
+#undef INSTANTIATE
+
+}  // namespace Xcts::Solutions::tov_detail
+
+PUP::able::PUP_ID Xcts::Solutions::TovStar::my_PUP_ID = 0;  // NOLINT
+
+// Instantiate implementations for common variables
+template class Xcts::Solutions::CommonVariables<
+    double, typename Xcts::Solutions::tov_detail::TovVariablesCache<double>>;
+template class Xcts::Solutions::CommonVariables<
+    DataVector,
+    typename Xcts::Solutions::tov_detail::TovVariablesCache<DataVector>>;
+template class Xcts::AnalyticData::CommonVariables<
+    double, typename Xcts::Solutions::tov_detail::TovVariablesCache<double>>;
+template class Xcts::AnalyticData::CommonVariables<
+    DataVector,
+    typename Xcts::Solutions::tov_detail::TovVariablesCache<DataVector>>;

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/TovStar.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/TovStar.hpp
@@ -1,0 +1,266 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <limits>
+#include <ostream>
+
+#include "DataStructures/CachedTempBuffer.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Elliptic/Systems/Xcts/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Xcts/CommonVariables.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags/Conformal.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/AnalyticSolution.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace Xcts::Solutions {
+namespace tov_detail {
+
+using TovCoordinates = RelativisticEuler::Solutions::TovCoordinates;
+
+template <typename DataType>
+using TovVariablesCache = cached_temp_buffer_from_typelist<tmpl::push_back<
+    common_tags<DataType>,
+    ::Tags::deriv<gr::Tags::Lapse<DataType>, tmpl::size_t<3>, Frame::Inertial>,
+    gr::Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 0>,
+    gr::Tags::Conformal<gr::Tags::StressTrace<DataType>, 0>,
+    gr::Tags::Conformal<gr::Tags::MomentumDensity<3, Frame::Inertial, DataType>,
+                        0>>>;
+
+template <typename DataType>
+struct TovVariables : CommonVariables<DataType, TovVariablesCache<DataType>> {
+  static constexpr size_t Dim = 3;
+  static constexpr int ConformalMatterScale = 0;
+  using Cache = TovVariablesCache<DataType>;
+  using Base = CommonVariables<DataType, TovVariablesCache<DataType>>;
+  using Base::operator();
+
+  const tnsr::I<DataType, 3>& x;
+  const DataType& radius;
+  const RelativisticEuler::Solutions::TovStar& tov_star;
+
+  TovVariables(
+      std::optional<std::reference_wrapper<const Mesh<Dim>>> local_mesh,
+      std::optional<std::reference_wrapper<const InverseJacobian<
+          DataVector, Dim, Frame::ElementLogical, Frame::Inertial>>>
+          local_inv_jacobian,
+      const tnsr::I<DataType, 3>& local_x, const DataType& local_radius,
+      const RelativisticEuler::Solutions::TovStar& local_tov_star)
+      : Base(std::move(local_mesh), std::move(local_inv_jacobian)),
+        x(local_x),
+        radius(local_radius),
+        tov_star(local_tov_star) {}
+
+  void operator()(gsl::not_null<tnsr::ii<DataType, 3>*> conformal_metric,
+                  gsl::not_null<Cache*> cache,
+                  Tags::ConformalMetric<DataType, 3, Frame::Inertial> /*meta*/)
+      const override;
+  void operator()(
+      gsl::not_null<tnsr::II<DataType, 3>*> inv_conformal_metric,
+      gsl::not_null<Cache*> cache,
+      Tags::InverseConformalMetric<DataType, 3, Frame::Inertial> /*meta*/)
+      const override;
+  void operator()(
+      gsl::not_null<tnsr::ijj<DataType, 3>*> deriv_conformal_metric,
+      gsl::not_null<Cache*> cache,
+      ::Tags::deriv<Tags::ConformalMetric<DataType, 3, Frame::Inertial>,
+                    tmpl::size_t<3>, Frame::Inertial> /*meta*/) const override;
+  void operator()(
+      gsl::not_null<tnsr::ii<DataType, 3>*> extrinsic_curvature,
+      gsl::not_null<Cache*> cache,
+      gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataType> /*meta*/)
+      const override;
+  void operator()(
+      gsl::not_null<Scalar<DataType>*> trace_extrinsic_curvature,
+      gsl::not_null<Cache*> cache,
+      gr::Tags::TraceExtrinsicCurvature<DataType> /*meta*/) const override;
+  void operator()(
+      gsl::not_null<tnsr::i<DataType, 3>*> deriv_trace_extrinsic_curvature,
+      gsl::not_null<Cache*> cache,
+      ::Tags::deriv<gr::Tags::TraceExtrinsicCurvature<DataType>,
+                    tmpl::size_t<3>, Frame::Inertial> /*meta*/) const override;
+  void operator()(
+      gsl::not_null<Scalar<DataType>*> dt_trace_extrinsic_curvature,
+      gsl::not_null<Cache*> cache,
+      ::Tags::dt<gr::Tags::TraceExtrinsicCurvature<DataType>> /*meta*/)
+      const override;
+  void operator()(gsl::not_null<Scalar<DataType>*> conformal_factor,
+                  gsl::not_null<Cache*> cache,
+                  Tags::ConformalFactor<DataType> /*meta*/) const override;
+  void operator()(
+      gsl::not_null<tnsr::i<DataType, 3>*> deriv_conformal_factor,
+      gsl::not_null<Cache*> cache,
+      ::Tags::deriv<Xcts::Tags::ConformalFactor<DataType>, tmpl::size_t<3>,
+                    Frame::Inertial> /*meta*/) const override;
+  void operator()(gsl::not_null<Scalar<DataType>*> lapse,
+                  gsl::not_null<Cache*> cache,
+                  gr::Tags::Lapse<DataType> /*meta*/) const override;
+  void operator()(gsl::not_null<tnsr::i<DataType, 3>*> deriv_lapse,
+                  gsl::not_null<Cache*> cache,
+                  ::Tags::deriv<gr::Tags::Lapse<DataType>, tmpl::size_t<3>,
+                                Frame::Inertial> /*meta*/) const;
+  void operator()(
+      gsl::not_null<Scalar<DataType>*> lapse_times_conformal_factor,
+      gsl::not_null<Cache*> cache,
+      Tags::LapseTimesConformalFactor<DataType> /*meta*/) const override;
+  void operator()(
+      gsl::not_null<tnsr::i<DataType, 3>*> deriv_lapse_times_conformal_factor,
+      gsl::not_null<Cache*> cache,
+      ::Tags::deriv<Tags::LapseTimesConformalFactor<DataType>, tmpl::size_t<3>,
+                    Frame::Inertial> /*meta*/) const override;
+  void operator()(gsl::not_null<tnsr::I<DataType, 3>*> shift_background,
+                  gsl::not_null<Cache*> cache,
+                  Tags::ShiftBackground<DataType, 3, Frame::Inertial> /*meta*/)
+      const override;
+  void operator()(gsl::not_null<tnsr::II<DataType, 3, Frame::Inertial>*>
+                      longitudinal_shift_background_minus_dt_conformal_metric,
+                  gsl::not_null<Cache*> cache,
+                  Tags::LongitudinalShiftBackgroundMinusDtConformalMetric<
+                      DataType, 3, Frame::Inertial> /*meta*/) const override;
+  void operator()(
+      gsl::not_null<tnsr::I<DataType, 3>*> shift_excess,
+      gsl::not_null<Cache*> cache,
+      Tags::ShiftExcess<DataType, 3, Frame::Inertial> /*meta*/) const override;
+  void operator()(
+      gsl::not_null<tnsr::ii<DataType, 3>*> shift_strain,
+      gsl::not_null<Cache*> cache,
+      Tags::ShiftStrain<DataType, 3, Frame::Inertial> /*meta*/) const override;
+  void operator()(gsl::not_null<Scalar<DataType>*> energy_density,
+                  gsl::not_null<Cache*> cache,
+                  gr::Tags::Conformal<gr::Tags::EnergyDensity<DataType>,
+                                      ConformalMatterScale> /*meta*/) const;
+  void operator()(gsl::not_null<Scalar<DataType>*> stress_trace,
+                  gsl::not_null<Cache*> cache,
+                  gr::Tags::Conformal<gr::Tags::StressTrace<DataType>,
+                                      ConformalMatterScale> /*meta*/) const;
+  void operator()(gsl::not_null<tnsr::I<DataType, 3>*> momentum_density,
+                  gsl::not_null<Cache*> cache,
+                  gr::Tags::Conformal<
+                      gr::Tags::MomentumDensity<3, Frame::Inertial, DataType>,
+                      ConformalMatterScale> /*meta*/) const;
+
+ private:
+  template <typename Tag>
+  typename Tag::type get_tov_var(Tag /*meta*/) const {
+    // Possible optimization: Access the cache of the RelEuler::TovStar solution
+    // so its intermediate quantities don't have to be re-computed repeatedly
+    return get<Tag>(tov_star.variables(
+        x, std::numeric_limits<double>::signaling_NaN(), tmpl::list<Tag>{}));
+  }
+};
+
+}  // namespace tov_detail
+
+/*!
+ * \brief TOV solution to the XCTS equations
+ *
+ * \see RelativisticEuler::Solutions::TovStar
+ * \see gr::Solutions::TovSolution
+ */
+class TovStar : public elliptic::analytic_data::AnalyticSolution {
+ private:
+  using RelEulerTovStar = RelativisticEuler::Solutions::TovStar;
+
+ public:
+  using options = RelEulerTovStar::options;
+  static constexpr Options::String help = RelEulerTovStar::help;
+
+  TovStar() = default;
+  TovStar(const TovStar&) = default;
+  TovStar& operator=(const TovStar&) = default;
+  TovStar(TovStar&&) = default;
+  TovStar& operator=(TovStar&&) = default;
+  ~TovStar() = default;
+
+  template <typename... OptionTypes>
+  TovStar(double central_rest_mass_density,
+          std::unique_ptr<EquationsOfState::EquationOfState<true, 1>>
+              equation_of_state,
+          const RelativisticEuler::Solutions::TovCoordinates coordinate_system)
+      : tov_star(central_rest_mass_density, std::move(equation_of_state),
+                 coordinate_system) {}
+
+  const EquationsOfState::EquationOfState<true, 1>& equation_of_state() const {
+    return tov_star.equation_of_state();
+  }
+
+  const RelativisticEuler::Solutions::TovSolution& radial_solution() const {
+    return tov_star.radial_solution();
+  }
+
+  /// \cond
+  explicit TovStar(CkMigrateMessage* m)
+      : elliptic::analytic_data::AnalyticSolution(m) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(TovStar);
+  std::unique_ptr<elliptic::analytic_data::AnalyticSolution> get_clone()
+      const override {
+    return std::make_unique<TovStar>(*this);
+  }
+  /// \endcond
+
+  template <typename DataType>
+  using tags = typename tov_detail::TovVariablesCache<DataType>::tags_list;
+
+  template <typename DataType, typename... RequestedTags>
+  tuples::TaggedTuple<RequestedTags...> variables(
+      const tnsr::I<DataType, 3, Frame::Inertial>& x,
+      tmpl::list<RequestedTags...> /*meta*/) const {
+    using VarsComputer = tov_detail::TovVariables<DataType>;
+    typename VarsComputer::Cache cache{get_size(*x.begin())};
+    const DataType radius = get(magnitude(x));
+    const VarsComputer computer{std::nullopt, std::nullopt, x, radius,
+                                tov_star};
+    return {cache.get_var(computer, RequestedTags{})...};
+  }
+
+  template <typename... RequestedTags>
+  tuples::TaggedTuple<RequestedTags...> variables(
+      const tnsr::I<DataVector, 3, Frame::Inertial>& x, const Mesh<3>& mesh,
+      const InverseJacobian<DataVector, 3, Frame::ElementLogical,
+                            Frame::Inertial>& inv_jacobian,
+      tmpl::list<RequestedTags...> /*meta*/) const {
+    using VarsComputer = tov_detail::TovVariables<DataVector>;
+    typename VarsComputer::Cache cache{get_size(*x.begin())};
+    const DataVector radius = get(magnitude(x));
+    const VarsComputer computer{mesh, inv_jacobian, x, radius, tov_star};
+    return {cache.get_var(computer, RequestedTags{})...};
+  }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override {
+    elliptic::analytic_data::AnalyticSolution::pup(p);
+    p | tov_star;
+  }
+
+ private:
+  friend bool operator==(const TovStar& lhs, const TovStar& rhs) {
+    return lhs.tov_star == rhs.tov_star;
+  }
+
+  // Instead of inheriting from the RelEuler::TovStar we use an aggregate
+  // pattern to avoid multiple-inheritance issues.
+  RelativisticEuler::Solutions::TovStar tov_star{};
+};
+
+inline bool operator!=(const TovStar& lhs, const TovStar& rhs) {
+  return not(lhs == rhs);
+}
+
+}  // namespace Xcts::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.hpp
@@ -62,7 +62,7 @@ struct WrappedGrVariables
   WrappedGrVariables(
       std::optional<std::reference_wrapper<const Mesh<Dim>>> local_mesh,
       std::optional<std::reference_wrapper<const InverseJacobian<
-          DataType, Dim, Frame::ElementLogical, Frame::Inertial>>>
+          DataVector, Dim, Frame::ElementLogical, Frame::Inertial>>>
           local_inv_jacobian,
       const tnsr::I<DataType, 3>& local_x,
       const tuples::tagged_tuple_from_typelist<gr_solution_vars<DataType, Dim>>&

--- a/tests/InputFiles/Xcts/TovStar.yaml
+++ b/tests/InputFiles/Xcts/TovStar.yaml
@@ -1,0 +1,138 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Executable: SolveXcts
+# Check: parse;execute_check_output
+# Timeout: 40
+# ExpectedOutput:
+#   TovStarReductions.h5
+#   TovStarVolume0.h5
+# OutputFileChecks:
+#   - Label: Discretization error
+#     Subfile: /ErrorNorms.dat
+#     FileGlob: TovStarReductions.h5
+#     SkipColumns: [0, 1, 2]
+#     AbsoluteTolerance: 1e-6
+
+ResourceInfo:
+  AvoidGlobalProc0: false
+  Singletons: Auto
+
+Background:
+  TovStar:
+    CentralDensity: 1.e-3
+    EquationOfState:
+      PolytropicFluid:
+        PolytropicConstant: 1.
+        PolytropicExponent: 2
+    Coordinates: Isotropic
+
+InitialGuess: Flatness
+
+DomainCreator:
+  Sphere:
+    InnerRadius: 0.2
+    OuterRadius: 1.24984447898
+    InnerCubeSphericity: 0.
+    InitialRefinement: 0
+    InitialGridPoints: [5, 5]
+    UseEquiangularMap: True
+    TimeDependence: None
+    BoundaryCondition:
+      AnalyticSolution:
+        ConformalFactor: Dirichlet
+        LapseTimesConformalFactor: Dirichlet
+        ShiftExcess: Dirichlet
+
+Discretization:
+  DiscontinuousGalerkin:
+    PenaltyParameter: 1.
+    Massive: True
+
+Observers:
+  VolumeFileName: "TovStarVolume"
+  ReductionFileName: "TovStarReductions"
+
+NonlinearSolver:
+  NewtonRaphson:
+    ConvergenceCriteria:
+      MaxIterations: 10
+      RelativeResidual: 1.e-8
+      AbsoluteResidual: 1.e-10
+    SufficientDecrease: 1.e-4
+    MaxGlobalizationSteps: 40
+    DampingFactor: 1.
+    Verbosity: Quiet
+
+LinearSolver:
+  Gmres:
+    ConvergenceCriteria:
+      MaxIterations: 30
+      RelativeResidual: 1.e-4
+      AbsoluteResidual: 1.e-12
+    Verbosity: Quiet
+
+  Multigrid:
+    Iterations: 1
+    MaxLevels: Auto
+    PreSmoothing: True
+    PostSmoothingAtBottom: False
+    Verbosity: Verbose
+    OutputVolumeData: False
+
+  SchwarzSmoother:
+    Iterations: 3
+    MaxOverlap: 2
+    Verbosity: Verbose
+    SubdomainSolver:
+      Gmres:
+        ConvergenceCriteria:
+          MaxIterations: 3
+          RelativeResidual: 1.e-4
+          AbsoluteResidual: 1.e-12
+        Verbosity: Silent
+        Restart: None
+        Preconditioner:
+          MinusLaplacian:
+            Solver: ExplicitInverse
+            BoundaryConditions: Auto
+    SkipResets: True
+    ObservePerCoreReductions: False
+
+EventsAndTriggers:
+  - - HasConverged
+    - - ObserveNorms:
+          SubfileName: ErrorNorms
+          TensorsToObserve:
+            - Name: Error(ConformalFactor)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(LapseTimesConformalFactor)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(ShiftExcess)
+              NormType: L2Norm
+              Components: Sum
+      - ObserveNorms:
+          SubfileName: Norms
+          TensorsToObserve:
+            - Name: HamiltonianConstraint
+              NormType: L2Norm
+              Components: Individual
+            - Name: MomentumConstraint
+              NormType: L2Norm
+              Components: Individual
+      - ObserveFields:
+          SubfileName: VolumeData
+          VariablesToObserve:
+            - ConformalFactor
+            - Lapse
+            - Error(ConformalFactor)
+            - Error(LapseTimesConformalFactor)
+            - Conformal(EnergyDensity)
+            - Conformal(StressTrace)
+            - HamiltonianConstraint
+          InterpolateToMesh: None
+          CoordinatesFloatingPointType: Float
+          FloatingPointTypes: [Float]
+          OverrideObservationValue: None

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBRARY_SOURCES
   Test_Kerr.cpp
   Test_Schwarzschild.cpp
   Test_SphericalKerr.cpp
+  Test_TovStar.cpp
   )
 
 add_test_library(

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_TovStar.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_TovStar.cpp
@@ -1,0 +1,131 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+#include <tuple>
+
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Elliptic/Systems/Xcts/Geometry.hpp"
+#include "Elliptic/Systems/Xcts/Tags.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/PointwiseFunctions/AnalyticSolutions/Xcts/VerifySolution.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Tov.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Xcts/TovStar.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags/Conformal.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/RegisterDerivedWithCharm.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace Xcts::Solutions {
+namespace {
+
+using TovCoordinates = RelativisticEuler::Solutions::TovCoordinates;
+
+void test_solution(const TovCoordinates coord_system) {
+  CAPTURE(coord_system);
+  EquationsOfState::register_derived_with_charm();
+  const auto created = TestHelpers::test_factory_creation<
+      elliptic::analytic_data::AnalyticSolution, TovStar>(
+      "TovStar:\n"
+      "  CentralDensity: 1.e-3\n"
+      "  EquationOfState:\n"
+      "    PolytropicFluid:\n"
+      "      PolytropicExponent: 2\n"
+      "      PolytropicConstant: 1.\n"
+      "  Coordinates: " +
+      get_output(coord_system));
+  REQUIRE(dynamic_cast<const TovStar*>(created.get()) != nullptr);
+  const auto& solution = dynamic_cast<const TovStar&>(*created);
+  {
+    INFO("Properties");
+    const auto& radial_solution = solution.radial_solution();
+    CHECK(radial_solution.coordinate_system() == coord_system);
+  }
+  {
+    INFO("Semantics");
+    test_serialization(solution);
+    test_copy_semantics(solution);
+    auto move_solution = solution;
+    test_move_semantics(std::move(move_solution), solution);
+  }
+  if (coord_system == TovCoordinates::Isotropic) {
+    INFO("Test exterior solution is Schwarzschild");
+    const auto& radial_solution = solution.radial_solution();
+    const double star_radius = radial_solution.outer_radius();
+    const double total_mass = radial_solution.total_mass();
+    CAPTURE(star_radius);
+    CAPTURE(total_mass);
+    const Schwarzschild schwarzschild{total_mass,
+                                      SchwarzschildCoordinates::Isotropic};
+    // Look at a cube just outside the star
+    const Mesh<3> mesh{5, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto};
+    const auto logical_coords = logical_coordinates(mesh);
+    const double dx = 0.1 * star_radius;
+    using AffineMap = domain::CoordinateMaps::Affine;
+    using AffineMap3D =
+        domain::CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
+    const domain::CoordinateMap<Frame::ElementLogical, Frame::Inertial,
+                                AffineMap3D>
+        coord_map{{{-1., 1., star_radius, star_radius + dx},
+                   {-1., 1., 0., dx},
+                   {-1., 1., 0., dx}}};
+    const auto x = coord_map(logical_coords);
+    const auto inv_jacobian = coord_map.inv_jacobian(logical_coords);
+    // Check the TOV solution is identical to the Schwarzschild solution
+    using all_fields = typename TovStar::template tags<DataVector>;
+    const auto tov_vars = variables_from_tagged_tuple(
+        solution.variables(x, mesh, inv_jacobian, all_fields{}));
+    const auto schwarzschild_vars = variables_from_tagged_tuple(
+        schwarzschild.variables(x, mesh, inv_jacobian, all_fields{}));
+    CHECK_VARIABLES_APPROX(tov_vars, schwarzschild_vars);
+  }
+  {
+    INFO("Verify the solution solves the XCTS equations");
+    const auto& radial_solution = solution.radial_solution();
+    const double star_radius = radial_solution.outer_radius();
+    CAPTURE(star_radius);
+    for (const double fraction_of_star_radius : {0., 0.5, 1., 1.5}) {
+      CAPTURE(fraction_of_star_radius);
+      const double inner_radius = fraction_of_star_radius * star_radius;
+      const double outer_radius =
+          (fraction_of_star_radius + 0.01) * star_radius;
+      CAPTURE(inner_radius);
+      CAPTURE(outer_radius);
+      if (coord_system == TovCoordinates::Isotropic) {
+        TestHelpers::Xcts::Solutions::verify_solution<
+            Xcts::Geometry::FlatCartesian, 0>(
+            solution, {{0., 0., 0.}}, inner_radius, outer_radius, 1.e-4);
+      } else {
+        TestHelpers::Xcts::Solutions::verify_solution<Xcts::Geometry::Curved,
+                                                      0>(
+            solution, {{0., 0., 0.}}, inner_radius, outer_radius, 1.e-4);
+      }
+    }
+  }
+}
+
+// [[Timeout, 20]]
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Xcts.TovStar",
+                  "[PointwiseFunctions][Unit]") {
+  test_solution(TovCoordinates::Schwarzschild);
+  test_solution(TovCoordinates::Isotropic);
+}
+
+}  // namespace
+}  // namespace Xcts::Solutions


### PR DESCRIPTION
## Proposed changes

This PR allows solving single TOV stars, and also composing binaries with TOV stars using the `Xcts::AnalyticData::Binary` class. Currently, the matter terms in the XCTS equations are just fixed to the TOV matter profile and the gravity is solved for this source. In the future I'll make the matter terms dynamic, so they solve the Euler equations with some equilibrium conditions (e.g. quasi circular orbits). Until then, this PR is probably enough to seed experimental head-on BNS evolutions to get the GRMHD code ready for BNS mergers.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
