### PR TITLE
Simplify observer registration from interpolations

### DIFF
--- a/src/ControlSystem/RunCallbacks.hpp
+++ b/src/ControlSystem/RunCallbacks.hpp
@@ -43,8 +43,6 @@ struct RunCallbacks {
                           tmpl::bind<assert_conforms_to_t, tmpl::_1>>::value);
 
  public:
-  using observation_types = tmpl::list<>;
-
   template <typename DbTags, typename Metavariables>
   static void apply(const db::DataBox<DbTags>& box,
                     Parallel::GlobalCache<Metavariables>& cache,

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -206,7 +206,7 @@ struct EvolutionMetavars {
         intrp::callbacks::ObserveTimeSeriesOnSurface<
             tmpl::list<StrahlkorperGr::Tags::SurfaceIntegralCompute<
                 CurvedScalarWave::Tags::PsiSquared, ::Frame::Inertial>>,
-            SphericalSurface, SphericalSurface>;
+            SphericalSurface>;
     template <typename metavariables>
     using interpolating_component = typename metavariables::dg_element_array;
   };
@@ -264,10 +264,8 @@ struct EvolutionMetavars {
                                          Triggers::time_triggers>>>;
   };
 
-  using observed_reduction_data_tags =
-      observers::collect_reduction_data_tags<tmpl::flatten<tmpl::list<
-          tmpl::at<typename factory_creation::factory_classes, Event>,
-          typename SphericalSurface::post_interpolation_callback>>>;
+  using observed_reduction_data_tags = observers::collect_reduction_data_tags<
+      tmpl::at<typename factory_creation::factory_classes, Event>>;
 
   static constexpr bool use_filtering = true;
 

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
@@ -108,9 +108,8 @@ struct EvolutionMetavars<3, InitialData, BoundaryConditions>
         intrp::callbacks::FindApparentHorizon<AhA, ::Frame::Inertial>;
     using horizon_find_failure_callback =
         intrp::callbacks::ErrorOnFailedApparentHorizon;
-    using post_horizon_find_callbacks =
-        tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe,
-                                                                AhA, AhA>>;
+    using post_horizon_find_callbacks = tmpl::list<
+        intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, AhA>>;
   };
 
   using interpolation_target_tags = tmpl::list<AhA>;
@@ -139,8 +138,7 @@ struct EvolutionMetavars<3, InitialData, BoundaryConditions>
           volume_dim, Frame::Grid>>;
 
   using observed_reduction_data_tags = observers::collect_reduction_data_tags<
-      tmpl::append<tmpl::at<typename factory_creation::factory_classes, Event>,
-                   typename AhA::post_horizon_find_callbacks>>;
+      tmpl::at<typename factory_creation::factory_classes, Event>>;
 
   using dg_registration_list =
       tmpl::push_back<typename gh_base::dg_registration_list,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -266,9 +266,8 @@ struct EvolutionMetavars {
         intrp::callbacks::FindApparentHorizon<AhA, ::Frame::Grid>;
     using horizon_find_failure_callback =
         intrp::callbacks::ErrorOnFailedApparentHorizon;
-    using post_horizon_find_callbacks =
-        tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe,
-                                                                AhA, AhA>>;
+    using post_horizon_find_callbacks = tmpl::list<
+        intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, AhA>>;
   };
 
   struct AhB {
@@ -284,9 +283,8 @@ struct EvolutionMetavars {
         intrp::callbacks::FindApparentHorizon<AhB, ::Frame::Grid>;
     using horizon_find_failure_callback =
         intrp::callbacks::ErrorOnFailedApparentHorizon;
-    using post_horizon_find_callbacks =
-        tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe,
-                                                                AhB, AhB>>;
+    using post_horizon_find_callbacks = tmpl::list<
+        intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, AhB>>;
   };
 
   using interpolation_target_tags = tmpl::list<AhA,AhB>;
@@ -384,9 +382,7 @@ struct EvolutionMetavars {
   };
 
   using observed_reduction_data_tags = observers::collect_reduction_data_tags<
-      tmpl::append<tmpl::at<typename factory_creation::factory_classes, Event>,
-                   typename AhA::post_horizon_find_callbacks,
-                   typename AhB::post_horizon_find_callbacks>>;
+      tmpl::at<typename factory_creation::factory_classes, Event>>;
 
   // A tmpl::list of tags to be added to the GlobalCache by the
   // metavariables

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizon.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizon.hpp
@@ -76,9 +76,8 @@ struct EvolutionMetavars
         intrp::callbacks::FindApparentHorizon<AhA, ::Frame::Inertial>;
     using horizon_find_failure_callback =
         intrp::callbacks::ErrorOnFailedApparentHorizon;
-    using post_horizon_find_callbacks =
-        tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe,
-                                                                AhA, AhA>>;
+    using post_horizon_find_callbacks = tmpl::list<
+        intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, AhA>>;
   };
 
   using interpolation_target_tags = tmpl::list<AhA>;
@@ -115,12 +114,8 @@ struct EvolutionMetavars
       GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma2<
           volume_dim, Frame::Grid>>>;
 
-  using observed_reduction_data_tags =
-      observers::collect_reduction_data_tags<tmpl::push_back<
-          tmpl::append<
-              tmpl::at<typename factory_creation::factory_classes, Event>,
-              typename AhA::post_horizon_find_callbacks>,
-          typename InterpolationTargetTags::post_interpolation_callback...>>;
+  using observed_reduction_data_tags = observers::collect_reduction_data_tags<
+      tmpl::at<typename factory_creation::factory_classes, Event>>;
 
   using dg_registration_list = typename GhValenciaDivCleanTemplateBase<
       EvolutionMetavars>::dg_registration_list;

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -336,10 +336,8 @@ struct GhValenciaDivCleanTemplateBase<
 
   using interpolation_target_tags = tmpl::list<InterpolationTargetTags...>;
 
-  using observed_reduction_data_tags =
-      observers::collect_reduction_data_tags<tmpl::push_back<
-          tmpl::at<typename factory_creation::factory_classes, Event>,
-          typename InterpolationTargetTags::post_interpolation_callback...>>;
+  using observed_reduction_data_tags = observers::collect_reduction_data_tags<
+      tmpl::at<typename factory_creation::factory_classes, Event>>;
 
   using const_global_cache_tags = tmpl::flatten<tmpl::list<
       tmpl::conditional_t<evolution::is_numeric_initial_data_v<initial_data>,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -324,10 +324,8 @@ struct EvolutionMetavars {
                                          Triggers::time_triggers>>>;
   };
 
-  using observed_reduction_data_tags =
-      observers::collect_reduction_data_tags<tmpl::push_back<
-          tmpl::at<typename factory_creation::factory_classes, Event>,
-          typename InterpolationTargetTags::post_interpolation_callback...>>;
+  using observed_reduction_data_tags = observers::collect_reduction_data_tags<
+      tmpl::at<typename factory_creation::factory_classes, Event>>;
 
   struct SubcellOptions {
     using evolved_vars_tags = typename system::variables_tag::tags_list;
@@ -595,7 +593,7 @@ struct CenterOfStar {
       tmpl::list<hydro::Tags::RestMassDensity<DataVector>>;
   using post_interpolation_callback =
       intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe,
-                                                   CenterOfStar, CenterOfStar>;
+                                                   CenterOfStar>;
   using compute_target_points =
       intrp::TargetPoints::SpecifiedPoints<CenterOfStar, 3>;
   using compute_items_on_target = tags_to_observe;
@@ -626,7 +624,7 @@ struct KerrHorizon {
   using compute_target_points =
       intrp::TargetPoints::KerrHorizon<KerrHorizon, ::Frame::Inertial>;
   using post_interpolation_callback =
-      intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, KerrHorizon,
+      intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe,
                                                    KerrHorizon>;
 
   template <typename Metavariables>

--- a/src/ParallelAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp
@@ -133,9 +133,6 @@ namespace callbacks {
 ///
 template <typename InterpolationTargetTag, typename Frame>
 struct FindApparentHorizon {
-  using observation_types =
-      typename InterpolationTarget_detail::observation_types_t<
-          typename InterpolationTargetTag::post_horizon_find_callbacks>;
   template <typename DbTags, typename Metavariables, typename TemporalId>
   static bool apply(
       const gsl::not_null<db::DataBox<DbTags>*> box,

--- a/src/ParallelAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp
@@ -10,8 +10,7 @@
 #include <vector>
 
 #include "DataStructures/DataBox/TagName.hpp"
-#include "IO/Observer/Helpers.hpp"
-#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ReductionActions.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Info.hpp"
 #include "Parallel/Invoke.hpp"
@@ -28,9 +27,6 @@ template <typename TagsList>
 class DataBox;
 }  // namespace db
 namespace observers {
-namespace ThreadedActions {
-struct WriteReductionData;
-}  // namespace ThreadedActions
 template <class Metavariables>
 struct ObserverWriter;
 }  // namespace observers
@@ -41,23 +37,6 @@ namespace callbacks {
 
 namespace detail {
 
-template <typename T>
-struct reduction_data_type;
-
-template <typename... Ts>
-struct reduction_data_type<tmpl::list<Ts...>> {
-  // We use ReductionData because that is what is expected by the
-  // ObserverWriter.  We do a "reduction" that involves only one
-  // processing element (often equivalent to a core),
-  // so AssertEqual is used here as a no-op.
-
-  // The first argument is for Time, the others are for
-  // the list of things being observed.
-  using type = Parallel::ReductionData<
-      Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
-      Parallel::ReductionDatum<typename Ts::type, funcl::AssertEqual<>>...>;
-};
-
 template <typename... Ts>
 auto make_legend(tmpl::list<Ts...> /* meta */) {
   return std::vector<std::string>{"Time", db::tag_name<Ts>()...};
@@ -66,8 +45,7 @@ auto make_legend(tmpl::list<Ts...> /* meta */) {
 template <typename DbTags, typename... Ts>
 auto make_reduction_data(const db::DataBox<DbTags>& box, double time,
                          tmpl::list<Ts...> /* meta */) {
-  using reduction_data = typename reduction_data_type<tmpl::list<Ts...>>::type;
-  return reduction_data(time, get<Ts>(box)...);
+  return std::make_tuple(time, get<Ts>(box)...);
 }
 
 }  // namespace detail
@@ -81,19 +59,10 @@ auto make_reduction_data(const db::DataBox<DbTags>& box, double time,
 /// - DataBox:
 ///   - `TagsToObserve`
 ///
-/// `ObservationType` is a type that distinguishes this observation
-/// from other things that call observers::ThreadedActions::ObserverWriter,
-/// so that different observations do not collide.
-///
 /// This is an InterpolationTargetTag::post_interpolation_callback;
 /// see InterpolationTarget for a description of InterpolationTargetTag.
-template <typename TagsToObserve, typename ObservationType,
-          typename InterpolationTargetTag>
+template <typename TagsToObserve, typename InterpolationTargetTag>
 struct ObserveTimeSeriesOnSurface {
-  using observed_reduction_data_tags = observers::make_reduction_data_tags<
-      tmpl::list<typename detail::reduction_data_type<TagsToObserve>::type>>;
-  using observation_types = tmpl::list<ObservationType>;
-
   static constexpr double fill_invalid_points_with =
       std::numeric_limits<double>::quiet_NaN();
 
@@ -107,15 +76,9 @@ struct ObserveTimeSeriesOnSurface {
 
     // We call this on proxy[0] because the 0th element of a NodeGroup is
     // always guaranteed to be present.
-    using ParallelComponent =
-        intrp::InterpolationTarget<Metavariables, InterpolationTargetTag>;
-    auto& my_proxy = Parallel::get_parallel_component<ParallelComponent>(cache);
-    Parallel::threaded_action<observers::ThreadedActions::WriteReductionData>(
+    Parallel::threaded_action<
+        observers::ThreadedActions::WriteReductionDataRow>(
         proxy[0],
-        observers::ObservationId(
-            InterpolationTarget_detail::get_temporal_id_value(temporal_id),
-            pretty_type::get_name<ObservationType>()),
-        static_cast<size_t>(Parallel::my_node(*my_proxy.ckLocal())),
         std::string{"/" + pretty_type::short_name<InterpolationTargetTag>()},
         detail::make_legend(TagsToObserve{}),
         detail::make_reduction_data(

--- a/src/ParallelAlgorithms/Interpolation/Callbacks/SendGhWorldtubeData.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Callbacks/SendGhWorldtubeData.hpp
@@ -27,7 +27,6 @@ namespace callbacks {
 /// see InterpolationTarget for a description of InterpolationTargetTag.
 template <typename CceEvolutionComponent, typename TemporalId>
 struct SendGhWorldtubeData {
-  using observation_types = tmpl::list<>;
   template <typename DbTags, typename Metavariables>
   static void apply(const db::DataBox<DbTags>& box,
                     Parallel::GlobalCache<Metavariables>& cache,

--- a/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
+++ b/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
@@ -600,25 +600,6 @@ void set_up_interpolation(
       });
 }
 
-namespace detail {
-template <typename Callback>
-struct get_observation_types {
-  using type = typename Callback::observation_types;
-};
-}  // namespace detail
-
-/// Given a list of post_interpolation_callbacks, obtain a list of distinct
-/// observation_types used by them.
-/// @{
-template <typename Callbacks>
-struct observation_types {
-  using type = tmpl::remove_duplicates<tmpl::flatten<
-      tmpl::transform<Callbacks, detail::get_observation_types<tmpl::_1>>>>;
-};
-template <typename Callbacks>
-using observation_types_t = typename observation_types<Callbacks>::type;
-/// @}
-
 CREATE_HAS_TYPE_ALIAS(compute_vars_to_interpolate)
 CREATE_HAS_TYPE_ALIAS_V(compute_vars_to_interpolate)
 

--- a/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
@@ -145,7 +145,6 @@ void test_inertial_strahlkorper(
 size_t test_schwarzschild_horizon_called = 0;
 template <typename Frame>
 struct TestSchwarzschildHorizon {
-  using observation_types = tmpl::list<>;
   // [post_horizon_find_callback_example]
   template <typename DbTags, typename Metavariables>
   static void apply(
@@ -180,7 +179,6 @@ struct TestSchwarzschildHorizon {
 size_t test_kerr_horizon_called = 0;
 template <typename Frame>
 struct TestKerrHorizon {
-  using observation_types = tmpl::list<>;
   template <typename DbTags, typename Metavariables>
   static void apply(
       const db::DataBox<DbTags>& box,


### PR DESCRIPTION
## Proposed changes

Remove `observation_types` alias, reduction data tags, and registration helpers, because interpolation targets can just send rows of data to the observer writer without the need to do any reductions.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
