### PR TITLE
Compute logical coordinates of FD ghost zone

### DIFF
--- a/src/Evolution/DgSubcell/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/CMakeLists.txt
@@ -14,6 +14,7 @@ spectre_target_headers(
   ComputeBoundaryTerms.hpp
   CorrectPackagedData.hpp
   DgSubcell.hpp
+  GhostZoneLogicalCoordinates.hpp
   Matrices.hpp
   Mesh.hpp
   NeighborReconstructedFaceSolution.hpp
@@ -37,6 +38,7 @@ spectre_target_sources(
   PRIVATE
   ActiveGrid.cpp
   CartesianFluxDivergence.cpp
+  GhostZoneLogicalCoordinates.cpp
   Matrices.cpp
   Mesh.cpp
   PerssonTci.cpp

--- a/src/Evolution/DgSubcell/GhostZoneLogicalCoordinates.cpp
+++ b/src/Evolution/DgSubcell/GhostZoneLogicalCoordinates.cpp
@@ -1,0 +1,104 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/DgSubcell/GhostZoneLogicalCoordinates.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/Index.hpp"
+#include "DataStructures/IndexIterator.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/Side.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace evolution::dg::subcell::fd {
+
+template <size_t Dim>
+void ghost_zone_logical_coordinates(
+    const gsl::not_null<tnsr::I<DataVector, Dim, Frame::ElementLogical>*>
+        ghost_logical_coords,
+    const Mesh<Dim>& subcell_mesh, const size_t ghost_zone_size,
+    const Direction<Dim>& direction) {
+  const size_t dim_direction = direction.dimension();
+  const auto subcell_extents = subcell_mesh.extents();
+  const size_t subcell_extent_to_direction = subcell_extents[dim_direction];
+
+  // Check if the `ghost_zone_size` has a valid value.
+  ASSERT(ghost_zone_size <= subcell_extent_to_direction,
+         " Ghost zone size ("
+             << ghost_zone_size << ") is larger than the volume extent ("
+             << subcell_extent_to_direction << ") to the direction");
+
+  destructive_resize_components(
+      ghost_logical_coords,
+      ghost_zone_size *
+          subcell_mesh.extents().slice_away(dim_direction).product());
+
+  Index<Dim> ghost_zone_extents{subcell_extents};
+  ghost_zone_extents[dim_direction] = ghost_zone_size;
+
+  for (size_t d = 0; d < Dim; ++d) {
+    const auto& collocation_points_in_this_dim =
+        Spectral::collocation_points<Spectral::Basis::FiniteDifference,
+                                     Spectral::Quadrature::CellCentered>(
+            subcell_extents[d]);
+
+    if (d == dim_direction) {
+      const size_t index_offset =
+          (direction.side() == Side::Upper)
+              ? subcell_extent_to_direction - ghost_zone_size
+              : 0;
+
+      const double delta_x{collocation_points_in_this_dim[1] -
+                           collocation_points_in_this_dim[0]};
+
+      for (IndexIterator<Dim> index(ghost_zone_extents); index; ++index) {
+        ghost_logical_coords->get(d)[index.collapsed_index()] =
+            collocation_points_in_this_dim[index()[d] + index_offset] +
+            direction.sign() * delta_x * ghost_zone_size;
+      }
+    } else {
+      for (IndexIterator<Dim> index(ghost_zone_extents); index; ++index) {
+        ghost_logical_coords->get(d)[index.collapsed_index()] =
+            collocation_points_in_this_dim[index()[d]];
+      }
+    }
+  }
+}
+
+template <size_t Dim>
+tnsr::I<DataVector, Dim, Frame::ElementLogical> ghost_zone_logical_coordinates(
+    const Mesh<Dim>& subcell_mesh, const size_t ghost_zone_size,
+    const Direction<Dim>& direction) {
+  tnsr::I<DataVector, Dim, Frame::ElementLogical> logical_coords(
+      subcell_mesh.extents().product());
+  ghost_zone_logical_coordinates(make_not_null(&logical_coords), subcell_mesh,
+                                 ghost_zone_size, direction);
+  return logical_coords;
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data)                                           \
+  template void ghost_zone_logical_coordinates(                          \
+      const gsl::not_null<                                               \
+          tnsr::I<DataVector, DIM(data), Frame::ElementLogical>*>        \
+          ghost_logical_coords,                                          \
+      const Mesh<DIM(data)>& subcell_mesh, const size_t ghost_zone_size, \
+      const Direction<DIM(data)>& direction);                            \
+  template tnsr::I<DataVector, DIM(data), Frame::ElementLogical>         \
+  ghost_zone_logical_coordinates(const Mesh<DIM(data)>& subcell_mesh,    \
+                                 const size_t ghost_zone_size,           \
+                                 const Direction<DIM(data)>& direction);
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef DIM
+#undef INSTANTIATION
+}  // namespace evolution::dg::subcell::fd

--- a/src/Evolution/DgSubcell/GhostZoneLogicalCoordinates.hpp
+++ b/src/Evolution/DgSubcell/GhostZoneLogicalCoordinates.hpp
@@ -1,0 +1,49 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+/// \cond
+class DataVector;
+template <size_t Dim>
+class Mesh;
+template <size_t Dim>
+class Direction;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace evolution::dg::subcell::fd {
+/// @{
+/*!
+ * \brief Computes the logical coordinates of ghost grid points for a given
+ * direction and ghost zone size.
+ *
+ * Let `d` be the axis dimension of the `direction`. The returned coordinate has
+ * extents that is same as the volume mesh extents but `[d]`-th value
+ * replaced by the ghost zone size.
+ *
+ * For instance if the (volume) subcell mesh has extents \f$(6,6,6)\f$, ghost
+ * zone size is 2, and the `direction` is along Xi axis, the resulting
+ * coordinates computed by this function has extents \f$(2,6,6)\f$.
+ *
+ */
+template <size_t Dim>
+void ghost_zone_logical_coordinates(
+    const gsl::not_null<tnsr::I<DataVector, Dim, Frame::ElementLogical>*>
+        ghost_logical_coords,
+    const Mesh<Dim>& subcell_mesh, const size_t ghost_zone_size,
+    const Direction<Dim>& direction);
+
+template <size_t Dim>
+tnsr::I<DataVector, Dim, Frame::ElementLogical> ghost_zone_logical_coordinates(
+    const Mesh<Dim>& subcell_mesh, const size_t ghost_zone_size,
+    const Direction<Dim>& direction);
+/// @}
+}  // namespace evolution::dg::subcell::fd

--- a/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
+++ b/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
@@ -14,6 +14,7 @@ set(LIBRARY_SOURCES
   Test_CartesianFluxDivergence.cpp
   Test_ComputeBoundaryTerms.cpp
   Test_CorrectPackagedData.cpp
+  Test_GhostZoneLogicalCoordinates.cpp
   Test_Matrices.cpp
   Test_Mesh.cpp
   Test_NeighborReconstructedFaceSolution.cpp

--- a/tests/Unit/Evolution/DgSubcell/Test_GhostZoneLogicalCoordinates.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_GhostZoneLogicalCoordinates.cpp
@@ -1,0 +1,81 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/Slice.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Evolution/DgSubcell/GhostZoneLogicalCoordinates.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
+#include "Evolution/DgSubcell/SliceTensor.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+
+namespace evolution::dg::subcell::fd {
+namespace {
+template <size_t Dim>
+void test() {
+  // Create a subcell mesh
+  const Mesh<Dim> dg_mesh{3, Spectral::Basis::Legendre,
+                          Spectral::Quadrature::GaussLobatto};
+  const Mesh<Dim> subcell_mesh = mesh(dg_mesh);
+  const Index<Dim> subcell_extents = subcell_mesh.extents();
+
+  for (const auto& direction : Direction<Dim>::all_directions()) {
+    const size_t dim_direction = direction.dimension();
+
+    // iterate ghost zone size up to the maximum possible value (mesh extent to
+    // the direction)
+    for (size_t ghost_zone_size = 1;
+         ghost_zone_size <= subcell_extents[dim_direction]; ++ghost_zone_size) {
+      const tnsr::I<DataVector, Dim, Frame::ElementLogical> ghost_zone_coords =
+          ghost_zone_logical_coordinates(subcell_mesh, ghost_zone_size,
+                                         direction);
+
+      // grid extents of ghost zone
+      Index<Dim> ghost_zone_extents{subcell_extents};
+      ghost_zone_extents[dim_direction] = ghost_zone_size;
+
+      // Check the computed ghost zone coords slice-by-slice.
+      // First we get the outermost slice of subcell (volume) logical
+      // coordinates to copy the coordinate components that remain same. i.e.
+      // For 3D if `direction` is along x-axis, y and z components would remain
+      // same as volume slice. (*)
+      auto expected_coordinates = slice_tensor_for_subcell(
+          logical_coordinates(subcell_mesh), subcell_extents, 1, direction);
+
+      for (size_t i_slice = 0; i_slice < ghost_zone_size; ++i_slice) {
+        auto ghost_zone_coords_ith_slice = data_on_slice(
+            ghost_zone_coords, ghost_zone_extents, dim_direction, i_slice);
+
+        // (*) Here we tweak the components that need to be shifted.
+        // - Since subcell mesh is cell-centered, it has logical coordinate
+        //   values [-0.8, -0.4, 0, 0.4, 0.8]. Depending on the `direction`,
+        //   we choose either -0.8 or 0.8 as a fiducial point.
+        // - Grid spacing for subcell mesh is 0.4
+        expected_coordinates.get(dim_direction) =
+            direction.side() == Side::Upper
+                ? 0.8 + 0.4 * (i_slice + 1)
+                : -0.8 - 0.4 * (ghost_zone_size - i_slice);
+
+        CHECK_ITERABLE_APPROX(expected_coordinates,
+                              ghost_zone_coords_ith_slice);
+      }
+    }
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Fd.GhostLogicalCoords",
+                  "[Evolution][Unit]") {
+  test<1>();
+  test<2>();
+  test<3>();
+}
+
+}  // namespace
+}  // namespace evolution::dg::subcell::fd


### PR DESCRIPTION
## Proposed changes

Add a function to compute logical coordinates of FD ghost points. In short term perspective `DirichletAnalytic` boundary conditions require this functionality when using subcell. Also would help a bit when we implement more sophisticated types of meshes and use subcell on those.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
