### PR TITLE
Print prettier stacktraces

### DIFF
--- a/cmake/AddSpectreExecutable.cmake
+++ b/cmake/AddSpectreExecutable.cmake
@@ -32,6 +32,8 @@ function(add_spectre_executable TARGET_NAME)
     PROPERTIES
     RULE_LAUNCH_LINK "${CMAKE_BINARY_DIR}/tmp/WrapExecutableLinker.sh"
     LINK_DEPENDS "${CMAKE_BINARY_DIR}/tmp/WrapExecutableLinker.sh"
+    # Expose readable symbol names in backtrace (adds flags like -rdynamic)
+    ENABLE_EXPORTS ON
     )
   target_link_options(${TARGET_NAME} PRIVATE "-DEXECUTABLE_NAME=${TARGET_NAME}")
   # The `WrapExecutableLinker.sh` script needs the `InfoAtLink_flags.txt` file

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -125,6 +125,10 @@ all of these dependencies.
 * [ffmpeg](https://www.ffmpeg.org/) - for animating 1d simulations with
   matplotlib
 * [xsimd](https://github.com/xtensor-stack/xsimd) - for manual vectorization
+* [libbacktrace](https://github.com/ianlancetaylor/libbacktrace) - to show
+  source files and line numbers in backtraces of errors and asserts. Available
+  by default on many systems, so you may not have to install it at all. The
+  CMake configuration will tell you if you have libbacktrace installed.
 * [ParaView](https://www.paraview.org/) - for visualization \cite Paraview1
   \cite Paraview2
 * [SpEC](https://www.black-holes.org/code/SpEC.html) - to load SpEC data.

--- a/src/Utilities/ErrorHandling/AbortWithErrorMessage.cpp
+++ b/src/Utilities/ErrorHandling/AbortWithErrorMessage.cpp
@@ -3,70 +3,18 @@
 
 #include "Utilities/ErrorHandling/AbortWithErrorMessage.hpp"
 
-#include <array>
+#include <boost/stacktrace.hpp>
 #include <charm++.h>
 #include <cstdlib>
-#include <execinfo.h>
-// link.h is not available on all platforms
-#if __has_include(<link.h>)
-#include <link.h>
-#endif
 #include <memory>
 #include <sstream>
 
 #include "Utilities/ErrorHandling/Breakpoint.hpp"
 #include "Utilities/ErrorHandling/Exceptions.hpp"
+#include "Utilities/ErrorHandling/FormatStacktrace.hpp"
 #include "Utilities/System/ParallelInfo.hpp"
 
 namespace {
-struct FillBacktrace {};
-
-#if __has_include(<link.h>)
-// Convert the address to the virtual memory address inside the
-// library/executable. This is the address that addr2line and llvm-addr2line
-// expect.
-void* convert_to_virtual_memory_address(const void* addr) {
-  Dl_info info;
-  link_map* link_map = nullptr;
-  dladdr1(addr, &info,
-          reinterpret_cast<void**>(&link_map),  // NOLINT
-          RTLD_DL_LINKMAP);
-  // NOLINTNEXTLINE
-  return reinterpret_cast<void*>(reinterpret_cast<size_t>(addr) -
-                                 link_map->l_addr);
-}
-#endif  // __has_include(<link.h>)
-
-std::ostream& operator<<(std::ostream& os, const FillBacktrace& /*unused*/) {
-  // 3 for the stream operator and abort_with_error_message, 10 for the
-  // stack.
-  constexpr size_t max_stack_depth_printed = 13;
-  std::array<void*, max_stack_depth_printed> trace_elems{};
-  int trace_elem_count = backtrace(trace_elems.data(), max_stack_depth_printed);
-  std::unique_ptr<char*, decltype(free)*> stack_syms{
-      backtrace_symbols(trace_elems.data(), trace_elem_count), free};
-  // Start at 3 to ignore stream operator and abort_with_error_message
-  for (int i = 3; i < trace_elem_count; ++i) {
-#if __has_include(<link.h>)
-    Dl_info info;
-    const auto i_st = static_cast<size_t>(i);
-    // clang-tidy wants us to use gsl::at, but it would be nice not to make
-    // error handling depend on GSL/Utilities libs to avoid cyclic dependencies.
-    if (dladdr(trace_elems[i_st], &info) != 0) {  // NOLINT
-      void* vma_addr =
-          convert_to_virtual_memory_address(trace_elems[i_st]);  // NOLINT
-      os << stack_syms.get()[i] << " Address for addr2line: " << vma_addr
-         << "\n";
-    } else {
-      os << stack_syms.get()[i] << "\n";
-    }
-#else  // __has_include(<link.h>)
-    os << stack_syms.get()[i] << "\n";
-#endif  // __has_include(<link.h>)
-  }
-  return os;
-}
-
 template <bool ShowTrace>
 [[noreturn]] void abort_with_error_message_impl(const char* file,
                                                 const int line,
@@ -76,8 +24,7 @@ template <bool ShowTrace>
   os << "\n"
      << "############ ERROR ############\n";
   if constexpr (ShowTrace) {
-    os << "Shortened stack trace is:\n"
-       << FillBacktrace{} << "End shortened stack trace.\n\n";
+    os << "Stack trace:\n\n" << boost::stacktrace::stacktrace() << "\n";
   }
   os << "Wall time: " << sys::pretty_wall_time() << "\n"
      << "Node: " << sys::my_node() << " Proc: " << sys::my_proc() << "\n"
@@ -97,8 +44,8 @@ void abort_with_error_message(const char* expression, const char* file,
   std::ostringstream os;
   os << "\n"
      << "############ ASSERT FAILED ############\n"
-     << "Shortened stack trace is:\n"
-     << FillBacktrace{} << "End shortened stack trace.\n\n"
+     << "Stack trace:\n\n"
+     << boost::stacktrace::stacktrace() << "\n"
      << "Wall time: " << sys::pretty_wall_time() << "\n"
      << "Node: " << sys::my_node() << " Proc: " << sys::my_proc() << "\n"
      << "Line: " << line << " of " << file << "\n"

--- a/src/Utilities/ErrorHandling/AbortWithErrorMessage.hpp
+++ b/src/Utilities/ErrorHandling/AbortWithErrorMessage.hpp
@@ -11,6 +11,10 @@
 /// \ingroup ErrorHandlingGroup
 /// Compose an error message with an expression and a backtrace, then abort the
 /// program.
+///
+/// We try to demangle and format the backtrace. Long symbol names are
+/// abbreviated, unless you set the `SPECTRE_SHOW_FULL_BACKTRACE_SYMBOLS`
+/// environment variable to a non-empty value (e.g. "1").
 [[noreturn]] void abort_with_error_message(const char* expression,
                                            const char* file, int line,
                                            const char* pretty_function,
@@ -18,6 +22,10 @@
 
 /// \ingroup ErrorHandlingGroup
 /// Compose an error message including a backtrace and abort the program.
+///
+/// We try to demangle and format the backtrace. Long symbol names are
+/// abbreviated, unless you set the `SPECTRE_SHOW_FULL_BACKTRACE_SYMBOLS`
+/// environment variable to a non-empty value (e.g. "1").
 [[noreturn]] void abort_with_error_message(const char* file, int line,
                                            const char* pretty_function,
                                            const std::string& message);

--- a/src/Utilities/ErrorHandling/CMakeLists.txt
+++ b/src/Utilities/ErrorHandling/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_sources(
   AbortWithErrorMessage.cpp
   Breakpoint.cpp
   FloatingPointExceptions.cpp
+  FormatStacktrace.cpp
   SegfaultHandler.cpp
   )
 
@@ -25,6 +26,7 @@ spectre_target_headers(
   Exceptions.hpp
   ExpectsAndEnsures.hpp
   FloatingPointExceptions.hpp
+  FormatStacktrace.hpp
   SegfaultHandler.hpp
   StaticAssert.hpp
   )
@@ -32,13 +34,54 @@ spectre_target_headers(
 target_link_libraries(
   ${LIBRARY}
   PRIVATE
+  Boost::boost
   Charmxx::charmxx
   PUBLIC
   SystemUtilities
   )
 
-# For `backtrace` functionality
+# Try to use libbacktrace for boost::stacktrace so it displays line numbers.
+# The build configuration is explained here:
+# https://www.boost.org/doc/libs/1_78_0/doc/html/stacktrace/configuration_and_build.html
+# Note that we don't try to use Boost's addr2line mode because it takes a long
+# time to run and doesn't work well:
+# https://github.com/boostorg/stacktrace/issues/97
+# On some systems (Debian) libbacktrace comes preinstalled with GCC (see notes
+# in the Boost docs linked above).
+find_library(
+  BACKTRACE_LIB
+  NAMES backtrace
+  PATH_SUFFIXES lib64 lib
+  HINTS ${CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES})
+find_path(
+  BACKTRACE_HEADER_DIR
+  NAMES backtrace.h
+  PATH_SUFFIXES include
+  HINTS ${CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES})
+if (NOT BACKTRACE_LIB STREQUAL "BACKTRACE_LIB-NOTFOUND"
+    AND NOT BACKTRACE_HEADER_DIR STREQUAL "BACKTRACE_HEADER_DIR-NOTFOUND")
+  message(STATUS "Using libbacktrace for stack traces: ${BACKTRACE_LIB}")
+  set(BACKTRACE_HEADER "<${BACKTRACE_HEADER_DIR}/backtrace.h>")
+  target_compile_definitions(${LIBRARY} PRIVATE
+    BOOST_STACKTRACE_USE_BACKTRACE
+    BOOST_STACKTRACE_BACKTRACE_INCLUDE_FILE=${BACKTRACE_HEADER})
+  target_link_libraries(${LIBRARY} PRIVATE ${BACKTRACE_LIB})
+else()
+  # Fall back to "basic" mode. It needs no configuration because it's Boost's
+  # default.
+  message(STATUS "Using basic mode for stack traces. Install libbacktrace "
+    "(https://github.com/ianlancetaylor/libbacktrace) to obtain more useful "
+    "traces in errors and asserts.")
+endif()
+# All modes use libdl (see https://www.boost.org/doc/libs/1_78_0/doc/html/stacktrace/configuration_and_build.html)
+# CMake provides the correct way to link with libdl.
+target_link_libraries(${LIBRARY} PRIVATE ${CMAKE_DL_LIBS})
+
+# Boost::stacktrace needs the `_Unwind_Backtrace` function to be available.
+# On macOS it is available without defining `_GNU_SOURCE`, so Boost wants us
+# to define `BOOST_STACKTRACE_GNU_SOURCE_NOT_REQUIRED`. Otherwise we get a
+# compiler error telling us to define this.
 if (APPLE)
-  target_compile_options(${LIBRARY} INTERFACE "-dynamic")
-  target_link_options(${LIBRARY} INTERFACE "-rdynamic")
+  target_compile_definitions(${LIBRARY} PRIVATE
+    BOOST_STACKTRACE_GNU_SOURCE_NOT_REQUIRED)
 endif()

--- a/src/Utilities/ErrorHandling/FormatStacktrace.cpp
+++ b/src/Utilities/ErrorHandling/FormatStacktrace.cpp
@@ -1,0 +1,125 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Utilities/ErrorHandling/FormatStacktrace.hpp"
+
+#include <array>
+#include <boost/core/demangle.hpp>
+#include <boost/stacktrace.hpp>
+#include <cstddef>
+#include <cstdlib>     // For std::getenv
+#include <execinfo.h>  // For backtrace_symbols
+// link.h is not available on all platforms
+#if __has_include(<link.h>)
+#include <link.h>
+#endif
+#include <memory>
+#include <sstream>
+#include <string>
+
+namespace {
+
+std::string abbreviated_symbol_name(const std::string& symbol_name) {
+  // We display the first `abbrev_length_from_start` characters of the symbol
+  // name, then " [...] ", and then the last `abbrev_length_from_end` characters
+  // of the symbol name.
+  constexpr size_t abbrev_length_from_start = 300;
+  constexpr size_t abbrev_length_from_end = 100;
+  // Length of " [...] "
+  constexpr size_t abbrev_length_separator = 7;
+  if (symbol_name.size() <= abbrev_length_from_start + abbrev_length_from_end +
+                                abbrev_length_separator) {
+    return symbol_name;
+  }
+  // Allow an environment variable to toggle the abbreviation
+  const char* show_full_symbol_env =
+      std::getenv("SPECTRE_SHOW_FULL_BACKTRACE_SYMBOLS");
+  if (show_full_symbol_env != nullptr and
+      not std::string{show_full_symbol_env}.empty()) {
+    return symbol_name;
+  }
+  return symbol_name.substr(0, abbrev_length_from_start) + " [...] " +
+         symbol_name.substr(symbol_name.size() - abbrev_length_from_end,
+                            abbrev_length_from_end);
+}
+
+std::string get_stack_frame(void* addr) {
+  std::unique_ptr<char*, decltype(free)*> stack_syms{
+      backtrace_symbols(&addr, 1), free};
+  return stack_syms.get()[0];
+}
+
+#if __has_include(<link.h>)
+std::string addr2line_command(const void* addr) {
+  std::stringstream ss;
+  ss << "addr2line -fCpe ";
+  // Convert the address to the virtual memory address inside the
+  // library/executable. This is the address that addr2line and llvm-addr2line
+  // expect.
+  Dl_info info;
+  link_map* link_map = nullptr;
+  dladdr1(addr, &info,
+          reinterpret_cast<void**>(&link_map),  // NOLINT
+          RTLD_DL_LINKMAP);
+  ss << info.dli_fname;
+  ss << " ";
+  // NOLINTNEXTLINE
+  ss << reinterpret_cast<void*>(reinterpret_cast<size_t>(addr) -
+                                link_map->l_addr);
+  return ss.str();
+}
+#endif  // __has_include(<link.h>)
+
+}  // namespace
+
+std::ostream& operator<<(std::ostream& os,
+                         const boost::stacktrace::stacktrace& backtrace) {
+  const std::streamsize standard_width = os.width();
+  const size_t frames = backtrace.size();
+  for (size_t i = 0; i < frames; ++i) {
+    const auto& frame = backtrace[i];
+    const std::string& symbol_name = frame.name();
+    const std::string& source_file = frame.source_file();
+    const size_t source_line = frame.source_line();
+    // Enumerate frame number
+    os.width(3);
+    os << i;
+    os.width(standard_width);
+    os << ". ";
+    if (frame.empty()) {
+      os << "[empty]";
+      continue;
+    }
+    // Skip frames originating in error handling code
+    if (symbol_name.find("abort_with_error_message") != std::string::npos or
+        source_file.find("src/Utilities/ErrorHandling/") != std::string::npos or
+        symbol_name.find("boost::stacktrace") != std::string::npos) {
+      os << "[error handling]\n";
+      continue;
+    }
+    if (symbol_name.empty()) {
+      // Boost was unable to get the symbol name (probably because dladdr
+      // can't find it either). Fall back to printing the default stack
+      // frame.
+      // NOLINTNEXTLINE
+      os << get_stack_frame(const_cast<void*>(frame.address()));
+    } else {
+      // Print symbol name. Abbreviate if necessary to avoid filling the
+      // screen with templates.
+      os << abbreviated_symbol_name(symbol_name);
+    }
+    if (source_line != 0) {
+      // Print location in source file if available
+      os << " in " << source_file << ":" << source_line;
+    } else {
+#if __has_include(<link.h>)
+      // Print addr2line information otherwise
+      os << " - Resolve source file and line with: "
+         << addr2line_command(frame.address());
+#endif
+    }
+    os << '\n';
+  }
+
+  return os;
+}

--- a/src/Utilities/ErrorHandling/FormatStacktrace.hpp
+++ b/src/Utilities/ErrorHandling/FormatStacktrace.hpp
@@ -1,0 +1,14 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Formatter for Boost stacktrace, following these docs:
+/// https://www.boost.org/doc/libs/1_78_0/doc/html/stacktrace/getting_started.html#stacktrace.getting_started.global_control_over_stacktrace_o
+
+#pragma once
+
+#include <boost/stacktrace/stacktrace_fwd.hpp>
+#include <ostream>
+
+std::ostream& operator<<(std::ostream& os,
+                         const boost::stacktrace::stacktrace& backtrace);

--- a/support/Environments/wheeler_gcc.sh
+++ b/support/Environments/wheeler_gcc.sh
@@ -30,6 +30,7 @@ spectre_unload_modules() {
     module unload envs/spectre-python
     module unload pybind11/2.6.1
     module unload hdf5/1.12.2
+    module unload libbacktrace/1.0
     module unload spec-exporter/2023-05
 }
 
@@ -56,6 +57,7 @@ spectre_load_modules() {
     module load envs/spectre-python
     module load pybind11/2.6.1
     module load hdf5/1.12.2
+    module load libbacktrace/1.0
     module load spec-exporter/2023-05
 }
 

--- a/tests/Unit/ErrorHandling/Test_AbortWithErrorMessage.cpp
+++ b/tests/Unit/ErrorHandling/Test_AbortWithErrorMessage.cpp
@@ -14,24 +14,32 @@ SPECTRE_TEST_CASE("Unit.ErrorHandling.AbortWithErrorMessage",
       Catch::Contains("ASSERT FAILED") && Catch::Contains("a == b") &&
           Catch::Contains("Test Abort") &&
           Catch::Contains("Test_AbortWithErrorMessage") &&
-          Catch::Contains("Shortened stack trace is"));
+          Catch::Contains("Stack trace:"));
   CHECK_THROWS_WITH(
       abort_with_error_message(__FILE__, __LINE__,
                                static_cast<const char*>(__PRETTY_FUNCTION__),
                                "Test Error"),
       Catch::Contains("ERROR") && Catch::Contains("Test Error") &&
           Catch::Contains("Test_AbortWithErrorMessage") &&
-          Catch::Contains("Shortened stack trace is"));
+          Catch::Contains("Stack trace:"));
   CHECK_THROWS_WITH(
       abort_with_error_message_no_trace(
           __FILE__, __LINE__, static_cast<const char*>(__PRETTY_FUNCTION__),
           "Test no trace"),
       Catch::Contains("ERROR") && Catch::Contains("Test no trace") &&
           Catch::Contains("Test_AbortWithErrorMessage") &&
-          not Catch::Contains("Shortened stack trace is"));
+          not Catch::Contains("Stack trace:"));
   CHECK_THROWS_AS(
       abort_with_error_message_no_trace(
           __FILE__, __LINE__, static_cast<const char*>(__PRETTY_FUNCTION__),
           "Test no trace"),
       std::runtime_error);
+  {
+    INFO("Demangling");
+    CHECK_THROWS_WITH(
+        abort_with_error_message(__FILE__, __LINE__,
+                                 static_cast<const char*>(__PRETTY_FUNCTION__),
+                                 "Test demangling"),
+        Catch::Contains("Catch::Session::run()"));
+  }
 }


### PR DESCRIPTION
## Proposed changes

- Use `boost::stacktrace::stacktrace` to demangle symbols in backtraces.
- Also show line numbers when available.
- Fall back to non-pretty frames when boost fails to demangle it.
- Add an option to abbreviate symbol names in backtraces, to avoid filling the screen with templates.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
