### PR TITLE
Promote Options::name to pretty_type::name utility

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Tags.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Tags.hpp
@@ -7,6 +7,7 @@
 
 #include "DataStructures/DataBox/Tag.hpp"
 #include "Options/Options.hpp"
+#include "Utilities/PrettyType.hpp"
 
 namespace OptionTags {
 /*!
@@ -25,7 +26,7 @@ struct LimiterGroup {
  */
 template <typename LimiterType>
 struct Limiter {
-  static std::string name() { return Options::name<LimiterType>(); }
+  static std::string name() { return pretty_type::name<LimiterType>(); }
   static constexpr Options::String help = "Options for the limiter";
   using type = LimiterType;
   using group = LimiterGroup;

--- a/src/Evolution/Systems/Cce/OptionTags.hpp
+++ b/src/Evolution/Systems/Cce/OptionTags.hpp
@@ -20,6 +20,7 @@
 #include "Options/Options.hpp"
 #include "Parallel/Printf.hpp"
 #include "Time/Tags.hpp"
+#include "Utilities/PrettyType.hpp"
 
 namespace Cce {
 namespace OptionTags {
@@ -47,7 +48,7 @@ struct Evolution {
 template <typename OptionTag>
 struct CceEvolutionPrefix {
   using type = typename OptionTag::type;
-  static std::string name() { return Options::template name<OptionTag>(); }
+  static std::string name() { return pretty_type::name<OptionTag>(); }
   static constexpr Options::String help = OptionTag::help;
   using group = Evolution;
 };
@@ -250,7 +251,7 @@ struct CceEvolutionPrefix : Tag {
   using type = typename Tag::type;
   using option_tags = db::wrap_tags_in<OptionTags::CceEvolutionPrefix,
                                        typename Tag::option_tags>;
-  static std::string name() { return Options::template name<Tag>(); }
+  static std::string name() { return pretty_type::name<Tag>(); }
 
   static constexpr bool pass_metavariables = Tag::pass_metavariables;
   template <typename Metavariables, typename... Args>

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/ProductOfConditions.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/ProductOfConditions.hpp
@@ -646,14 +646,14 @@ class ProductOfConditions final : public BoundaryCondition {
       typename DerivedValenciaCondition::dg_gridless_tags, dg_gridless_tags>;
 
   static std::string name() {
-    return "Product" + Options::name<DerivedGhCondition>() + "And" +
-           Options::name<DerivedValenciaCondition>();
+    return "Product" + pretty_type::name<DerivedGhCondition>() + "And" +
+           pretty_type::name<DerivedValenciaCondition>();
   }
 
   struct GhCondition {
     using type = DerivedGhCondition;
     static std::string name() {
-      return "GeneralizedHarmonic" + Options::name<DerivedGhCondition>();
+      return "GeneralizedHarmonic" + pretty_type::name<DerivedGhCondition>();
     }
     static constexpr Options::String help{
         "The Generalized Harmonic part of the product boundary condition"};
@@ -661,7 +661,7 @@ class ProductOfConditions final : public BoundaryCondition {
   struct ValenciaCondition {
     using type = DerivedValenciaCondition;
     static std::string name() {
-      return "Valencia" + Options::name<DerivedValenciaCondition>();
+      return "Valencia" + pretty_type::name<DerivedValenciaCondition>();
     }
     static constexpr Options::String help{
         "The Valencia part of the product boundary condition"};

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryCorrections/ProductOfCorrections.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryCorrections/ProductOfCorrections.hpp
@@ -17,6 +17,7 @@
 #include "Options/Options.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace grmhd::GhValenciaDivClean::BoundaryCorrections {
@@ -172,20 +173,22 @@ class ProductOfCorrections final : public BoundaryCorrection {
       typename DerivedValenciaCorrection::dg_package_data_volume_tags>;
 
   static std::string name() {
-    return "Product" + Options::name<DerivedGhCorrection>() + "And" +
-           Options::name<DerivedValenciaCorrection>();
+    return "Product" + pretty_type::name<DerivedGhCorrection>() + "And" +
+           pretty_type::name<DerivedValenciaCorrection>();
   }
 
   struct GhCorrection {
     using type = DerivedGhCorrection;
-    static std::string name() { return Options::name<DerivedGhCorrection>(); }
+    static std::string name() {
+      return pretty_type::name<DerivedGhCorrection>();
+    }
     static constexpr Options::String help{
         "The Generalized Harmonic part of the product boundary condition"};
   };
   struct ValenciaCorrection {
     using type = DerivedValenciaCorrection;
     static std::string name() {
-      return Options::name<DerivedValenciaCorrection>();
+      return pretty_type::name<DerivedValenciaCorrection>();
     }
     static constexpr Options::String help{
         "The Valencia part of the product boundary condition"};

--- a/src/Evolution/VariableFixing/Tags.hpp
+++ b/src/Evolution/VariableFixing/Tags.hpp
@@ -7,6 +7,7 @@
 
 #include "DataStructures/DataBox/Tag.hpp"
 #include "Options/Options.hpp"
+#include "Utilities/PrettyType.hpp"
 
 namespace OptionTags {
 /*!
@@ -27,7 +28,7 @@ template <typename VariableFixerType>
 struct VariableFixer {
   static constexpr Options::String help = "Options for the variable fixer";
   using type = VariableFixerType;
-  static std::string name() { return Options::name<VariableFixerType>(); }
+  static std::string name() { return pretty_type::name<VariableFixerType>(); }
   using group = VariableFixingGroup;
 };
 }  // namespace OptionTags

--- a/src/IO/Importers/Tags.hpp
+++ b/src/IO/Importers/Tags.hpp
@@ -14,6 +14,7 @@
 #include "IO/Observer/ArrayComponentId.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/InboxInserters.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
 /// Items related to loading data from files
@@ -87,7 +88,7 @@ namespace Tags {
 template <typename ImporterOptionsGroup>
 struct FileGlob : db::SimpleTag {
   static std::string name() {
-    return "FileGlob(" + Options::name<ImporterOptionsGroup>() + ")";
+    return "FileGlob(" + pretty_type::name<ImporterOptionsGroup>() + ")";
   }
   using type = std::string;
   using option_tags = tmpl::list<OptionTags::FileGlob<ImporterOptionsGroup>>;
@@ -104,7 +105,7 @@ struct FileGlob : db::SimpleTag {
 template <typename ImporterOptionsGroup>
 struct Subgroup : db::SimpleTag {
   static std::string name() {
-    return "Subgroup(" + Options::name<ImporterOptionsGroup>() + ")";
+    return "Subgroup(" + pretty_type::name<ImporterOptionsGroup>() + ")";
   }
   using type = std::string;
   using option_tags = tmpl::list<OptionTags::Subgroup<ImporterOptionsGroup>>;
@@ -119,7 +120,7 @@ struct Subgroup : db::SimpleTag {
 template <typename ImporterOptionsGroup>
 struct ObservationValue : db::SimpleTag {
   static std::string name() {
-    return "ObservationValue(" + Options::name<ImporterOptionsGroup>() +
+    return "ObservationValue(" + pretty_type::name<ImporterOptionsGroup>() +
            ")";
   }
   using type = std::variant<double, ObservationSelector>;

--- a/src/IO/Logging/Tags.hpp
+++ b/src/IO/Logging/Tags.hpp
@@ -7,6 +7,7 @@
 
 #include "DataStructures/DataBox/Tag.hpp"
 #include "Options/Options.hpp"
+#include "Utilities/PrettyType.hpp"
 
 /// \cond
 enum class Verbosity;
@@ -33,7 +34,7 @@ template <typename OptionsGroup>
 struct Verbosity : db::SimpleTag {
   using type = ::Verbosity;
   static std::string name() {
-    return "Verbosity(" + Options::name<OptionsGroup>() + ")";
+    return "Verbosity(" + pretty_type::name<OptionsGroup>() + ")";
   }
 
   using option_tags = tmpl::list<OptionTags::Verbosity<OptionsGroup>>;

--- a/src/IO/Observer/Tags.hpp
+++ b/src/IO/Observer/Tags.hpp
@@ -21,6 +21,7 @@
 #include "Options/Options.hpp"
 #include "Parallel/NodeLock.hpp"
 #include "Parallel/Reduction.hpp"
+#include "Utilities/PrettyType.hpp"
 
 namespace observers {
 /// \ingroup ObserversGroup
@@ -156,7 +157,7 @@ template <typename Tag>
 struct ObservationKey : db::SimpleTag {
   using type = std::optional<std::string>;
   static std::string name() {
-    return "ObservationKey(" + Options::name<Tag>() + ")";
+    return "ObservationKey(" + pretty_type::name<Tag>() + ")";
   }
 };
 

--- a/src/NumericalAlgorithms/Convergence/Tags.hpp
+++ b/src/NumericalAlgorithms/Convergence/Tags.hpp
@@ -10,6 +10,7 @@
 #include "NumericalAlgorithms/Convergence/Criteria.hpp"
 #include "NumericalAlgorithms/Convergence/HasConverged.hpp"
 #include "Options/Options.hpp"
+#include "Utilities/PrettyType.hpp"
 
 namespace Convergence {
 /// Option tags related to the convergence of iterative algorithms
@@ -41,7 +42,7 @@ namespace Tags {
 template <typename OptionsGroup>
 struct Criteria : db::SimpleTag {
   static std::string name() {
-    return "ConvergenceCriteria(" + Options::name<OptionsGroup>() + ")";
+    return "ConvergenceCriteria(" + pretty_type::name<OptionsGroup>() + ")";
   }
   using type = Convergence::Criteria;
 
@@ -57,7 +58,7 @@ struct Criteria : db::SimpleTag {
 template <typename OptionsGroup>
 struct Iterations : db::SimpleTag {
   static std::string name() {
-    return "Iterations(" + Options::name<OptionsGroup>() + ")";
+    return "Iterations(" + pretty_type::name<OptionsGroup>() + ")";
   }
   using type = size_t;
 
@@ -72,7 +73,7 @@ struct Iterations : db::SimpleTag {
 template <typename Label>
 struct IterationId : db::SimpleTag {
   static std::string name() {
-    return "IterationId(" + Options::name<Label>() + ")";
+    return "IterationId(" + pretty_type::name<Label>() + ")";
   }
   using type = size_t;
 };
@@ -84,7 +85,7 @@ struct IterationId : db::SimpleTag {
 template <typename Label>
 struct HasConverged : db::SimpleTag {
   static std::string name() {
-    return "HasConverged(" + Options::name<Label>() + ")";
+    return "HasConverged(" + pretty_type::name<Label>() + ")";
   }
   using type = Convergence::HasConverged;
 };

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
@@ -17,6 +17,7 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/SimpleMortarData.hpp"
 #include "NumericalAlgorithms/Spectral/Projection.hpp"
 #include "Options/Options.hpp"
+#include "Utilities/PrettyType.hpp"
 
 /// Functionality related to discontinuous Galerkin schemes
 namespace dg {}
@@ -67,7 +68,7 @@ struct NumericalFluxGroup {
  */
 template <typename NumericalFluxType>
 struct NumericalFlux {
-  static std::string name() { return Options::name<NumericalFluxType>(); }
+  static std::string name() { return pretty_type::name<NumericalFluxType>(); }
   static constexpr Options::String help = "Options for the numerical flux";
   using type = NumericalFluxType;
   using group = NumericalFluxGroup;

--- a/src/NumericalAlgorithms/LinearOperators/Tags.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Tags.hpp
@@ -7,6 +7,7 @@
 
 #include "DataStructures/DataBox/Tag.hpp"
 #include "Options/Options.hpp"
+#include "Utilities/PrettyType.hpp"
 
 namespace OptionTags {
 /*!
@@ -25,7 +26,7 @@ struct FilteringGroup {
  */
 template <typename FilterType>
 struct Filter {
-  static std::string name() { return Options::name<FilterType>(); }
+  static std::string name() { return pretty_type::name<FilterType>(); }
   static constexpr Options::String help = "Options for the filter";
   using type = FilterType;
   using group = FilteringGroup;

--- a/src/Options/Auto.hpp
+++ b/src/Options/Auto.hpp
@@ -10,6 +10,7 @@
 
 #include "Options/Options.hpp"
 #include "Utilities/GetOutput.hpp"
+#include "Utilities/PrettyType.hpp"
 
 namespace Options {
 /// The label representing the absence of a value for `Options::Auto`
@@ -66,7 +67,7 @@ std::ostream& operator<<(std::ostream& os, const Auto<T, Label>& x) {
   if (value) {
     return os << get_output(*value);
   } else {
-    return os << Options::name<Label>();
+    return os << pretty_type::name<Label>();
   }
 }
 
@@ -75,7 +76,7 @@ struct create_from_yaml<Auto<T, Label>> {
   template <typename Metavariables>
   static Auto<T, Label> create(const Option& options) {
     try {
-      if (options.parse_as<std::string>() == Options::name<Label>()) {
+      if (options.parse_as<std::string>() == pretty_type::name<Label>()) {
 #if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 8 && __GNUC__ < 10
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"

--- a/src/Options/Factory.hpp
+++ b/src/Options/Factory.hpp
@@ -17,6 +17,7 @@
 #include "Options/Options.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/StdHelpers.hpp"
 #include "Utilities/TMPL.hpp"
@@ -35,9 +36,8 @@ struct print_derived {
     const size_t end_col = 80;
 
     std::ostringstream ss;
-    ss << std::left
-       << std::setw(name_col) << ""
-       << std::setw(help_col - name_col - 1) << name<T>();
+    ss << std::left << std::setw(name_col) << ""
+       << std::setw(help_col - name_col - 1) << pretty_type::name<T>();
     if (ss.str().size() >= help_col) {
       ss << "\n" << std::setw(help_col - 1) << "";
     }
@@ -99,7 +99,7 @@ std::unique_ptr<BaseClass> create(const Option& options) {
   const auto& node = options.node();
   Option derived_opts(options.context());
   derived_opts.append_context("While operating factory for " +
-                              name<BaseClass>());
+                              pretty_type::name<BaseClass>());
   std::string id;
   if (node.IsScalar()) {
     id = node.as<std::string>();
@@ -125,7 +125,7 @@ std::unique_ptr<BaseClass> create(const Option& options) {
   tmpl::for_each<creatable_classes>(
       [&id, &derived_opts, &result](auto derived_v) {
         using Derived = tmpl::type_from<decltype(derived_v)>;
-        if (name<Derived>() == id) {
+        if (pretty_type::name<Derived>() == id) {
           ASSERT(result == nullptr, "Duplicate factory id: " << id);
           result = std::make_unique<Derived>(
               derived_opts.parse_as<Derived, Metavariables>());

--- a/src/Options/Options.hpp
+++ b/src/Options/Options.hpp
@@ -150,24 +150,6 @@ struct create_from_yaml {
   static T create(const Option& options);
 };
 
-namespace Options_detail {
-template <typename T, typename = std::void_t<>>
-struct name_helper {
-  static std::string name() { return pretty_type::short_name<T>(); }
-};
-
-template <typename T>
-struct name_helper<T, std::void_t<decltype(T::name())>> {
-  static std::string name() { return T::name(); }
-};
-}  // namespace Options_detail
-
-// The name in the YAML file for a struct.
-template <typename T>
-std::string name() {
-  return Options_detail::name_helper<T>::name();
-}
-
 /// Provide multiple ways to construct a class.
 ///
 /// This type may be included in an option list along with option

--- a/src/Options/OptionsDetails.hpp
+++ b/src/Options/OptionsDetails.hpp
@@ -205,7 +205,7 @@ struct print_impl {
     if constexpr (tmpl::list_contains_v<OptionList, Tag>) {
       const std::string new_line = "\n" + indent + "  ";
       std::ostringstream ss;
-      ss << indent << name<Tag>() << ":" << new_line
+      ss << indent << pretty_type::name<Tag>() << ":" << new_line
          << "type=" << yaml_type<typename Tag::type>::value();
       if constexpr (has_suggested<Tag>::value) {
         if constexpr (tt::is_a_v<std::unique_ptr, typename Tag::type>) {
@@ -238,7 +238,7 @@ struct print_impl {
     } else {
       // A group
       std::ostringstream ss;
-      ss << indent << name<Tag>() << ":\n"
+      ss << indent << pretty_type::name<Tag>() << ":\n"
          << wrap_text(Tag::help, 77, indent + "  ") << "\n\n";
       return ss.str();
     }

--- a/src/Options/OptionsDetails.hpp
+++ b/src/Options/OptionsDetails.hpp
@@ -92,7 +92,7 @@ using options_in_group =
 // information.
 template <typename T>
 struct yaml_type {
-  static std::string value() { return pretty_type::short_name<T>(); }
+  static std::string value() { return pretty_type::name<T>(); }
 };
 
 template <typename T>

--- a/src/Options/ParseOptions.hpp
+++ b/src/Options/ParseOptions.hpp
@@ -1120,7 +1120,7 @@ struct YAML::convert<Options::Options_detail::CreateWrapper<T, Metavariables>> {
       Options::Options_detail::CreateWrapper<T, Metavariables>& rhs) {
     Options::Context context;
     context.top_level = false;
-    context.append("While creating a " + pretty_type::short_name<T>());
+    context.append("While creating a " + pretty_type::name<T>());
     Options::Option options(node, std::move(context));
     rhs = Options::Options_detail::CreateWrapper<T, Metavariables>{
         Options::create_from_yaml<T>::template create<Metavariables>(options)};

--- a/src/Options/ParseOptions.hpp
+++ b/src/Options/ParseOptions.hpp
@@ -369,7 +369,7 @@ Parser<OptionList, Group>::Parser(std::string help_text)
     : help_text_(std::move(help_text)) {
   tmpl::for_each<all_possible_options>([](auto t) {
     using T = typename decltype(t)::type;
-    const std::string label = name<T>();
+    const std::string label = pretty_type::name<T>();
     ASSERT(label.size() <= max_label_size_,
            "The option name " << label
                               << " is too long for nice formatting, "
@@ -473,7 +473,7 @@ std::pair<int, std::vector<size_t>> choose_alternatives(
                               &given_options](auto opt) {
     using Opt = tmpl::type_from<decltype(opt)>;
     if constexpr (not tt::is_a_v<Options::Alternatives, Opt>) {
-      if (given_options.count(name<Opt>()) == 1) {
+      if (given_options.count(pretty_type::name<Opt>()) == 1) {
         ++num_matched;
       }
     } else {
@@ -532,7 +532,7 @@ struct get_impl<Tag, Metavariables, Tag> {
             typename Parser<OptionList, Group>::all_possible_options, Tag>,
         "Could not find requested option in the list of options provided. Did "
         "you forget to add the option tag to the OptionList?");
-    const std::string label = name<Tag>();
+    const std::string label = pretty_type::name<Tag>();
 
     const auto supplied_option = opts.parsed_options_.find(label);
     ASSERT(supplied_option != opts.parsed_options_.end(),
@@ -558,7 +558,8 @@ struct get_impl<Tag, Metavariables, Tag> {
       const auto suggested_value = Tag::suggested_value();
       {
         Context context;
-        context.append("Checking SUGGESTED value for " + name<Tag>());
+        context.append("Checking SUGGESTED value for " +
+                       pretty_type::name<Tag>());
         opts.template check_lower_bound_on_size<Tag>(suggested_value, context);
         opts.template check_upper_bound_on_size<Tag>(suggested_value, context);
         opts.template check_lower_bound<Tag>(suggested_value, context);
@@ -705,7 +706,7 @@ void Parser<OptionList, Group>::parse(const YAML::Node& node) {
     result.reserve(tmpl::size<top_level_options_and_groups>{});
     tmpl::for_each<top_level_options_and_groups>([&result](auto opt) {
       using Opt = tmpl::type_from<decltype(opt)>;
-      const std::string label = name<Opt>();
+      const std::string label = pretty_type::name<Opt>();
       ASSERT(alg::find(result, label) == result.end(),
              "Duplicate option name: " << label);
       result.push_back(label);
@@ -732,7 +733,7 @@ void Parser<OptionList, Group>::parse(const YAML::Node& node) {
       tmpl::for_each<all_possible_options>([this, &context, &name,
                                             &node](auto tag) {
         using Tag = tmpl::type_from<decltype(tag)>;
-        if (name == Options::name<Tag>()) {
+        if (name == pretty_type::name<Tag>()) {
           PARSE_ERROR(context,
                       "Option '"
                           << name
@@ -759,8 +760,10 @@ void Parser<OptionList, Group>::parse(const YAML::Node& node) {
     auto& subgroup_parser =
         tuples::get<SubgroupParser<subgroup>>(subgroup_parsers_);
     subgroup_parser.context_ = context_;
-    subgroup_parser.context_.append("In group " + name<subgroup>());
-    subgroup_parser.parse(parsed_options_.find(name<subgroup>())->second);
+    subgroup_parser.context_.append("In group " +
+                                    pretty_type::name<subgroup>());
+    subgroup_parser.parse(
+        parsed_options_.find(pretty_type::name<subgroup>())->second);
   });
 
   // Any actual warnings will be printed by later calls to get or
@@ -811,8 +814,9 @@ void Parser<OptionList, Group>::overlay(const YAML::Node& node) {
     context.column = name_and_value.first.Mark().column;
 
     if (tmpl::as_pack<tags_and_subgroups_list>([&name](auto... opts) {
-          return ((name != Options::name<tmpl::type_from<decltype(opts)>>()) and
-                  ...);
+          return (
+              (name != pretty_type::name<tmpl::type_from<decltype(opts)>>()) and
+              ...);
         })) {
       PARSE_ERROR(context,
                   "Option '" << name << "' is not a valid option.\n"
@@ -821,9 +825,9 @@ void Parser<OptionList, Group>::overlay(const YAML::Node& node) {
 
     if (tmpl::as_pack<overlayable_tags_and_subgroups_list>(
             [&name](auto... opts) {
-              return (
-                  (name != Options::name<tmpl::type_from<decltype(opts)>>()) and
-                  ...);
+              return ((name !=
+                       pretty_type::name<tmpl::type_from<decltype(opts)>>()) and
+                      ...);
             })) {
       PARSE_ERROR(context,
                   "Option '" << name << "' is not overlayable.\n"
@@ -843,12 +847,12 @@ void Parser<OptionList, Group>::overlay(const YAML::Node& node) {
 
   tmpl::for_each<subgroups>([this, &overlaid_options](auto subgroup_v) {
     using subgroup = tmpl::type_from<decltype(subgroup_v)>;
-    if (overlaid_options.count(Options::name<subgroup>()) == 1) {
+    if (overlaid_options.count(pretty_type::name<subgroup>()) == 1) {
       auto& subgroup_parser =
           tuples::get<SubgroupParser<subgroup>>(subgroup_parsers_);
       subgroup_parser.template overlay<
           Options_detail::options_in_group<OverlayOptions, subgroup>>(
-          parsed_options_.find(name<subgroup>())->second);
+          parsed_options_.find(pretty_type::name<subgroup>())->second);
     }
   });
 }

--- a/src/Parallel/Main.hpp
+++ b/src/Parallel/Main.hpp
@@ -420,8 +420,8 @@ Main<Metavariables>::Main(CkArgMsg* msg) {
     using algorithm = typename charm_type::algorithm;
     using databox_types = typename algorithm::databox_types;
     Parallel::printf("  %s (%s) has %u DataBox variants with [",
-                     pretty_type::short_name<parallel_component>(),
-                     pretty_type::short_name<chare_type>(),
+                     pretty_type::name<parallel_component>(),
+                     pretty_type::name<chare_type>(),
                      tmpl::size<databox_types>::value);
     tmpl::for_each<databox_types>([&parallel_component_v](auto databox_type_v) {
       // gcc11 and clang12 don't agree on where parallel_component_v is used...

--- a/src/ParallelAlgorithms/Actions/RandomizeVariables.hpp
+++ b/src/ParallelAlgorithms/Actions/RandomizeVariables.hpp
@@ -21,6 +21,7 @@
 #include "Options/Options.hpp"
 #include "Parallel/PupStlCpp17.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -68,7 +69,7 @@ struct RandomizeVariables {
   };
 
   struct RandomParametersOptionTag {
-    static std::string name() { return Options::name<Label>(); }
+    static std::string name() { return pretty_type::name<Label>(); }
     using type = Options::Auto<RandomParameters, Options::AutoLabel::None>;
     static constexpr Options::String help =
         "Add uniform random noise to variables.";

--- a/src/ParallelAlgorithms/Interpolation/Callbacks/ErrorOnFailedApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Callbacks/ErrorOnFailedApparentHorizon.hpp
@@ -29,7 +29,7 @@ struct ErrorOnFailedApparentHorizon {
                     const TemporalId& /*temporal_id*/,
                     const FastFlow::Status failure_reason) {
     ERROR("Apparent horizon finder "
-          << pretty_type::short_name<InterpolationTargetTag>()
+          << pretty_type::name<InterpolationTargetTag>()
           << " failed, reason = " << failure_reason);
   }
 };

--- a/src/ParallelAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp
@@ -238,7 +238,7 @@ struct FindApparentHorizon {
         Parallel::printf(
             "%s: t=%.6g: its=%d: %.1e<R<%.0e, |R|=%.1g, "
             "|R_grid|=%.1g, %.4g<r<%.4g\n",
-            pretty_type::short_name<InterpolationTargetTag>(),
+            pretty_type::name<InterpolationTargetTag>(),
             InterpolationTarget_detail::get_temporal_id_value(temporal_id),
             info.iteration, info.min_residual, info.max_residual,
             info.residual_ylm, info.residual_mesh, info.r_min, info.r_max);

--- a/src/ParallelAlgorithms/Interpolation/Callbacks/IgnoreFailedApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Callbacks/IgnoreFailedApparentHorizon.hpp
@@ -32,7 +32,7 @@ struct IgnoreFailedApparentHorizon {
         db::get<logging::Tags::Verbosity<InterpolationTargetTag>>(box);
     if (verbosity > ::Verbosity::Quiet) {
       Parallel::printf("Remark: Horizon finder %s failed, reason = %s\n",
-                       pretty_type::short_name<InterpolationTargetTag>(),
+                       pretty_type::name<InterpolationTargetTag>(),
                        failure_reason);
     }
   }

--- a/src/ParallelAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp
@@ -79,7 +79,7 @@ struct ObserveTimeSeriesOnSurface {
     Parallel::threaded_action<
         observers::ThreadedActions::WriteReductionDataRow>(
         proxy[0],
-        std::string{"/" + pretty_type::short_name<InterpolationTargetTag>()},
+        std::string{"/" + pretty_type::name<InterpolationTargetTag>()},
         detail::make_legend(TagsToObserve{}),
         detail::make_reduction_data(
             box, InterpolationTarget_detail::get_temporal_id_value(temporal_id),

--- a/src/ParallelAlgorithms/Interpolation/Events/Interpolate.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Events/Interpolate.hpp
@@ -11,6 +11,7 @@
 #include "Parallel/CharmPupable.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
 #include "ParallelAlgorithms/Interpolation/Interpolate.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -49,7 +50,9 @@ class Interpolate<VolumeDim, InterpolationTargetTag, tmpl::list<Tensors...>>
   static constexpr Options::String help =
       "Starts interpolation onto the given InterpolationTargetTag.";
 
-  static std::string name() { return Options::name<InterpolationTargetTag>(); }
+  static std::string name() {
+    return pretty_type::name<InterpolationTargetTag>();
+  }
 
   Interpolate() = default;
 

--- a/src/ParallelAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp
@@ -20,6 +20,7 @@
 #include "ParallelAlgorithms/Interpolation/Actions/InterpolationTargetVarsFromElement.hpp"
 #include "ParallelAlgorithms/Interpolation/PointInfoTag.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits/CreateGetStaticMemberVariableOrDefault.hpp"
 
@@ -73,7 +74,9 @@ class InterpolateWithoutInterpComponent<VolumeDim, InterpolationTargetTag,
       "Does interpolation using the given InterpolationTargetTag, "
       "without an Interpolator ParallelComponent.";
 
-  static std::string name() { return Options::name<InterpolationTargetTag>(); }
+  static std::string name() {
+    return pretty_type::name<InterpolationTargetTag>();
+  }
 
   InterpolateWithoutInterpComponent() = default;
 

--- a/src/ParallelAlgorithms/Interpolation/Targets/ApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Targets/ApparentHorizon.hpp
@@ -20,6 +20,7 @@
 #include "Parallel/GlobalCache.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "ParallelAlgorithms/Interpolation/Tags.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -108,7 +109,9 @@ struct ApparentHorizon {
   using type = OptionHolders::ApparentHorizon<Frame>;
   static constexpr Options::String help{
       "Options for interpolation onto apparent horizon."};
-  static std::string name() { return Options::name<InterpolationTargetTag>(); }
+  static std::string name() {
+    return pretty_type::name<InterpolationTargetTag>();
+  }
   using group = ApparentHorizons;
 };
 }  // namespace OptionTags
@@ -174,9 +177,8 @@ struct ApparentHorizon {
     // here for StrahlkorperTags::Strahlkorper<::Frame::Inertial>.
     Initialization::mutate_assign<common_tags>(
         box, options.initial_guess, options.fast_flow, options.verbosity,
-        std::deque<std::pair<double, ::Strahlkorper<Frame>>>{
-            std::make_pair(std::numeric_limits<double>::quiet_NaN(),
-                           options.initial_guess)});
+        std::deque<std::pair<double, ::Strahlkorper<Frame>>>{std::make_pair(
+            std::numeric_limits<double>::quiet_NaN(), options.initial_guess)});
   }
 
   template <typename Metavariables, typename DbTags, typename TemporalId>

--- a/src/ParallelAlgorithms/Interpolation/Targets/KerrHorizon.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Targets/KerrHorizon.hpp
@@ -18,6 +18,7 @@
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "ParallelAlgorithms/Interpolation/Tags.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -114,7 +115,9 @@ struct KerrHorizon {
   using type = OptionHolders::KerrHorizon;
   static constexpr Options::String help{
       "Options for interpolation onto Kerr horizon."};
-  static std::string name() { return Options::name<InterpolationTargetTag>(); }
+  static std::string name() {
+    return pretty_type::name<InterpolationTargetTag>();
+  }
   using group = InterpolationTargets;
 };
 }  // namespace OptionTags

--- a/src/ParallelAlgorithms/Interpolation/Targets/LineSegment.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Targets/LineSegment.hpp
@@ -11,6 +11,7 @@
 #include "Options/Options.hpp"
 #include "ParallelAlgorithms/Interpolation/Tags.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -93,7 +94,9 @@ struct LineSegment {
   using type = OptionHolders::LineSegment<VolumeDim>;
   static constexpr Options::String help{
       "Options for interpolation onto line segment."};
-  static std::string name() { return Options::name<InterpolationTargetTag>(); }
+  static std::string name() {
+    return pretty_type::name<InterpolationTargetTag>();
+  }
   using group = InterpolationTargets;
 };
 }  // namespace OptionTags

--- a/src/ParallelAlgorithms/Interpolation/Targets/SpecifiedPoints.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Targets/SpecifiedPoints.hpp
@@ -12,6 +12,7 @@
 #include "Options/Options.hpp"
 #include "ParallelAlgorithms/Interpolation/Tags.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -77,7 +78,9 @@ struct SpecifiedPoints {
   using type = OptionHolders::SpecifiedPoints<VolumeDim>;
   static constexpr Options::String help{
       "Options for interpolation onto a specified list of points."};
-  static std::string name() { return Options::name<InterpolationTargetTag>(); }
+  static std::string name() {
+    return pretty_type::name<InterpolationTargetTag>();
+  }
   using group = InterpolationTargets;
 };
 }  // namespace OptionTags

--- a/src/ParallelAlgorithms/Interpolation/Targets/Sphere.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Targets/Sphere.hpp
@@ -14,6 +14,7 @@
 #include "Parallel/GlobalCache.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "ParallelAlgorithms/Interpolation/Tags.hpp"
+#include "Utilities/PrettyType.hpp"
 
 /// \cond
 class DataVector;
@@ -81,7 +82,9 @@ struct Sphere {
   using type = OptionHolders::Sphere;
   static constexpr Options::String help{
       "Options for interpolation onto a sphere."};
-  static std::string name() { return Options::name<InterpolationTargetTag>(); }
+  static std::string name() {
+    return pretty_type::name<InterpolationTargetTag>();
+  }
   using group = InterpolationTargets;
 };
 }  // namespace OptionTags

--- a/src/ParallelAlgorithms/Interpolation/Targets/WedgeSectionTorus.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Targets/WedgeSectionTorus.hpp
@@ -12,6 +12,7 @@
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Options/Options.hpp"
 #include "ParallelAlgorithms/Interpolation/Tags.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -159,7 +160,9 @@ struct WedgeSectionTorus {
   using type = OptionHolders::WedgeSectionTorus;
   static constexpr Options::String help{
       "Options for interpolation onto Kerr horizon."};
-  static std::string name() { return Options::name<InterpolationTargetTag>(); }
+  static std::string name() {
+    return pretty_type::name<InterpolationTargetTag>();
+  }
   using group = InterpolationTargets;
 };
 }  // namespace OptionTags

--- a/src/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/ElementActions.hpp
@@ -76,10 +76,10 @@ struct ResidualReductionFormatter
   std::string operator()(const size_t iteration_id,
                          const double residual) const {
     if (iteration_id == 0) {
-      return Options::name<OptionsGroup>() + section_observation_key +
+      return pretty_type::name<OptionsGroup>() + section_observation_key +
              " initialized with residual: " + get_output(residual);
     } else {
-      return Options::name<OptionsGroup>() + section_observation_key + "(" +
+      return pretty_type::name<OptionsGroup>() + section_observation_key + "(" +
              get_output(iteration_id) +
              ") iteration complete. Remaining residual: " +
              get_output(residual);
@@ -114,7 +114,7 @@ void contribute_to_residual_observation(
       observers::ArrayComponentId{
           std::add_pointer_t<ParallelComponent>{nullptr},
           Parallel::ArrayIndex<ArrayIndex>(array_index)},
-      std::string{"/" + Options::name<OptionsGroup>() +
+      std::string{"/" + pretty_type::name<OptionsGroup>() +
                   section_observation_key + "Residuals"},
       std::vector<std::string>{"Iteration", "Residual"},
       reduction_data{iteration_id, residual_magnitude_square},
@@ -122,16 +122,17 @@ void contribute_to_residual_observation(
   if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(cache) >=
                ::Verbosity::Debug)) {
     if (iteration_id == 0) {
-      Parallel::printf("%s %s initialized with local residual: %e\n",
-                       get_output(array_index),
-                       Options::name<OptionsGroup>() + section_observation_key,
-                       sqrt(residual_magnitude_square));
+      Parallel::printf(
+          "%s %s initialized with local residual: %e\n",
+          get_output(array_index),
+          pretty_type::name<OptionsGroup>() + section_observation_key,
+          sqrt(residual_magnitude_square));
     } else {
       Parallel::printf(
           "%s %s(%zu) iteration complete. Remaining local residual: %e\n",
           get_output(array_index),
-          Options::name<OptionsGroup>() + section_observation_key, iteration_id,
-          sqrt(residual_magnitude_square));
+          pretty_type::name<OptionsGroup>() + section_observation_key,
+          iteration_id, sqrt(residual_magnitude_square));
     }
   }
 }
@@ -261,7 +262,7 @@ struct PrepareSolve {
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                  ::Verbosity::Debug)) {
       Parallel::printf("%s %s: Prepare solve\n", get_output(array_index),
-                       Options::name<OptionsGroup>());
+                       pretty_type::name<OptionsGroup>());
     }
 
     db::mutate<Convergence::Tags::IterationId<OptionsGroup>,

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp
@@ -13,7 +13,6 @@
 #include "IO/Logging/Verbosity.hpp"
 #include "NumericalAlgorithms/Convergence/HasConverged.hpp"
 #include "NumericalAlgorithms/Convergence/Tags.hpp"
-#include "Options/Options.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Printf.hpp"
@@ -23,6 +22,7 @@
 #include "Utilities/EqualWithinRoundoff.hpp"
 #include "Utilities/Functional.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/Requires.hpp"
 
 /// \cond
@@ -79,13 +79,12 @@ struct InitializeResidual {
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(cache) >=
                  ::Verbosity::Quiet)) {
       Parallel::printf("%s initialized with residual: %e\n",
-                       Options::name<OptionsGroup>(), residual_magnitude);
+                       pretty_type::name<OptionsGroup>(), residual_magnitude);
     }
     if (UNLIKELY(has_converged and get<logging::Tags::Verbosity<OptionsGroup>>(
                                        cache) >= ::Verbosity::Quiet)) {
-      Parallel::printf(
-          "%s has converged without any iterations: %s\n",
-          Options::name<OptionsGroup>(), has_converged);
+      Parallel::printf("%s has converged without any iterations: %s\n",
+                       pretty_type::name<OptionsGroup>(), has_converged);
     }
 
     Parallel::receive_data<Tags::InitialHasConverged<OptionsGroup>>(
@@ -167,16 +166,15 @@ struct UpdateResidual {
     // Do some logging
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(cache) >=
                  ::Verbosity::Quiet)) {
-      Parallel::printf(
-          "%s(%zu) iteration complete. Remaining residual: %e\n",
-          Options::name<OptionsGroup>(), completed_iterations,
-          residual_magnitude);
+      Parallel::printf("%s(%zu) iteration complete. Remaining residual: %e\n",
+                       pretty_type::name<OptionsGroup>(), completed_iterations,
+                       residual_magnitude);
     }
     if (UNLIKELY(has_converged and get<logging::Tags::Verbosity<OptionsGroup>>(
                                        cache) >= ::Verbosity::Quiet)) {
-      Parallel::printf(
-          "%s has converged in %zu iterations: %s\n",
-          Options::name<OptionsGroup>(), completed_iterations, has_converged);
+      Parallel::printf("%s has converged in %zu iterations: %s\n",
+                       pretty_type::name<OptionsGroup>(), completed_iterations,
+                       has_converged);
     }
 
     Parallel::receive_data<Tags::ResidualRatioAndHasConverged<OptionsGroup>>(

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/ElementActions.hpp
@@ -29,6 +29,7 @@
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -91,7 +92,7 @@ struct PrepareSolve {
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                  ::Verbosity::Debug)) {
       Parallel::printf("%s %s: Prepare solve\n", get_output(array_index),
-                       Options::name<OptionsGroup>());
+                       pretty_type::name<OptionsGroup>());
     }
 
     db::mutate<operand_tag, initial_fields_tag, basis_history_tag>(
@@ -209,8 +210,8 @@ struct NormalizeInitialOperand {
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                  ::Verbosity::Debug)) {
       Parallel::printf("%s %s(%zu): Normalize initial operand\n",
-                       get_output(array_index), Options::name<OptionsGroup>(),
-                       iteration_id);
+                       get_output(array_index),
+                       pretty_type::name<OptionsGroup>(), iteration_id);
     }
 
     db::mutate<operand_tag, basis_history_tag>(
@@ -247,7 +248,7 @@ struct PrepareStep {
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                  ::Verbosity::Debug)) {
       Parallel::printf("%s %s(%zu): Prepare step\n", get_output(array_index),
-                       Options::name<OptionsGroup>(), iteration_id);
+                       pretty_type::name<OptionsGroup>(), iteration_id);
     }
 
     if constexpr (Preconditioned) {
@@ -331,7 +332,7 @@ struct PerformStep {
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                  ::Verbosity::Debug)) {
       Parallel::printf("%s %s(%zu): Perform step\n", get_output(array_index),
-                       Options::name<OptionsGroup>(), iteration_id);
+                       pretty_type::name<OptionsGroup>(), iteration_id);
     }
 
     using operator_tag = db::add_tag_prefix<
@@ -551,7 +552,7 @@ struct NormalizeOperandAndUpdateField {
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                  ::Verbosity::Debug)) {
       Parallel::printf("%s %s(%zu): Complete step\n", get_output(array_index),
-                       Options::name<OptionsGroup>(), iteration_id);
+                       pretty_type::name<OptionsGroup>(), iteration_id);
     }
 
     db::mutate<operand_tag, basis_history_tag, fields_tag>(

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitorActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitorActions.hpp
@@ -22,6 +22,7 @@
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
 #include "Utilities/EqualWithinRoundoff.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/Requires.hpp"
 
 /// \cond
@@ -75,12 +76,12 @@ struct InitializeResidualMagnitude {
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(cache) >=
                  ::Verbosity::Quiet)) {
       Parallel::printf("%s initialized with residual: %e\n",
-                       Options::name<OptionsGroup>(), residual_magnitude);
+                       pretty_type::name<OptionsGroup>(), residual_magnitude);
     }
     if (UNLIKELY(has_converged and get<logging::Tags::Verbosity<OptionsGroup>>(
                                        cache) >= ::Verbosity::Quiet)) {
       Parallel::printf("%s has converged without any iterations: %s\n",
-                       Options::name<OptionsGroup>(), has_converged);
+                       pretty_type::name<OptionsGroup>(), has_converged);
     }
 
     Parallel::receive_data<Tags::InitialOrthogonalization<OptionsGroup>>(
@@ -189,13 +190,13 @@ struct StoreOrthogonalization {
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(cache) >=
                  ::Verbosity::Quiet)) {
       Parallel::printf("%s(%zu) iteration complete. Remaining residual: %e\n",
-                       Options::name<OptionsGroup>(), completed_iterations,
+                       pretty_type::name<OptionsGroup>(), completed_iterations,
                        residual_magnitude);
     }
     if (UNLIKELY(has_converged and get<logging::Tags::Verbosity<OptionsGroup>>(
                                        cache) >= ::Verbosity::Quiet)) {
       Parallel::printf("%s has converged in %zu iterations: %s\n",
-                       Options::name<OptionsGroup>(), completed_iterations,
+                       pretty_type::name<OptionsGroup>(), completed_iterations,
                        has_converged);
     }
 

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/Actions/RestrictFields.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/Actions/RestrictFields.hpp
@@ -31,6 +31,7 @@
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -104,7 +105,7 @@ struct SendFieldsToCoarserGrid<tmpl::list<FieldsTags...>, OptionsGroup,
     if (UNLIKELY(db::get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                  ::Verbosity::Debug)) {
       Parallel::printf("%s %s(%zu): Send fields to coarser grid\n", element_id,
-                       Options::name<OptionsGroup>(), iteration_id);
+                       pretty_type::name<OptionsGroup>(), iteration_id);
     }
 
     // Restrict the fields to the coarser (parent) grid.
@@ -208,7 +209,8 @@ struct ReceiveFieldsFromFinerGrid<Dim, FieldsTags, OptionsGroup,
     if (UNLIKELY(db::get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                  ::Verbosity::Debug)) {
       Parallel::printf("%s %s(%zu): Receive fields from finer grid\n",
-                       element_id, Options::name<OptionsGroup>(), iteration_id);
+                       element_id, pretty_type::name<OptionsGroup>(),
+                       iteration_id);
     }
 
     // Assemble restricted data from children

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/ElementActions.hpp
@@ -32,6 +32,7 @@
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GetOutput.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
 namespace LinearSolver::multigrid::detail {
@@ -159,7 +160,7 @@ struct PreparePreSmoothing {
     if (UNLIKELY(db::get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                  ::Verbosity::Debug)) {
       Parallel::printf("%s %s(%zu): Prepare pre-smoothing\n", element_id,
-                       Options::name<OptionsGroup>(), iteration_id);
+                       pretty_type::name<OptionsGroup>(), iteration_id);
     }
 
     // On coarser grids the smoother solves for a correction to the finer-grid
@@ -334,7 +335,7 @@ struct SendCorrectionToFinerGrid {
     if (UNLIKELY(db::get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                  ::Verbosity::Debug)) {
       Parallel::printf("%s %s(%zu): Send correction to children\n", element_id,
-                       Options::name<OptionsGroup>(), iteration_id);
+                       pretty_type::name<OptionsGroup>(), iteration_id);
     }
 
     // Send a copy of the correction to all children
@@ -388,7 +389,8 @@ struct ReceiveCorrectionFromCoarserGrid {
     if (UNLIKELY(db::get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                  ::Verbosity::Debug)) {
       Parallel::printf("%s %s(%zu): Prolongate correction from parent\n",
-                       element_id, Options::name<OptionsGroup>(), iteration_id);
+                       element_id, pretty_type::name<OptionsGroup>(),
+                       iteration_id);
     }
 
     // Apply prolongation operator

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/ElementsAllocator.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/ElementsAllocator.hpp
@@ -13,7 +13,6 @@
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Tags.hpp"
 #include "NumericalAlgorithms/Convergence/Tags.hpp"
-#include "Options/Options.hpp"
 #include "Parallel/Printf.hpp"
 #include "Parallel/Protocols/ArrayElementsAllocator.hpp"
 #include "Parallel/Section.hpp"
@@ -22,6 +21,7 @@
 #include "ParallelAlgorithms/LinearSolver/Multigrid/Hierarchy.hpp"
 #include "ParallelAlgorithms/LinearSolver/Multigrid/Tags.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/System/ParallelInfo.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -109,7 +109,7 @@ struct ElementsAllocator
     if (UNLIKELY(num_iterations == 0)) {
       Parallel::printf(
           "%s is disabled (zero iterations). Only creating a single grid.\n",
-          Options::name<OptionsGroup>());
+          pretty_type::name<OptionsGroup>());
       max_levels = 1;
     }
     size_t multigrid_level = 0;
@@ -170,8 +170,8 @@ struct ElementsAllocator
       Parallel::printf(
           "%s level %zu has %zu elements in %zu blocks distributed on %d "
           "procs.\n",
-          Options::name<OptionsGroup>(), multigrid_level, element_ids.size(),
-          domain.blocks().size(), number_of_procs);
+          pretty_type::name<OptionsGroup>(), multigrid_level,
+          element_ids.size(), domain.blocks().size(), number_of_procs);
       ++multigrid_level;
     } while (initial_refinement_levels != parent_refinement_levels);
     element_array.doneInserting();

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/ObserveVolumeData.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/ObserveVolumeData.hpp
@@ -21,13 +21,13 @@
 #include "IO/Observer/TypeOfObservation.hpp"
 #include "IO/Observer/VolumeActions.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
-#include "Options/Options.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
 #include "ParallelAlgorithms/LinearSolver/Multigrid/Tags.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeString.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -43,7 +43,7 @@ struct RegisterWithVolumeObserver {
     const std::string& level_observation_key =
         *db::get<observers::Tags::ObservationKey<Tags::MultigridLevel>>(box);
     const std::string subfile_path =
-        "/" + Options::name<OptionsGroup>() + level_observation_key;
+        "/" + pretty_type::name<OptionsGroup>() + level_observation_key;
     return {observers::TypeOfObservation::Volume,
             observers::ObservationKey(subfile_path)};
   }
@@ -107,7 +107,7 @@ struct ObserveVolumeData {
     const auto& level_observation_key =
         *db::get<observers::Tags::ObservationKey<Tags::MultigridLevel>>(box);
     const std::string subfile_path =
-        "/" + Options::name<OptionsGroup>() + level_observation_key;
+        "/" + pretty_type::name<OptionsGroup>() + level_observation_key;
     Parallel::simple_action<observers::Actions::ContributeVolumeData>(
         local_observer, observers::ObservationId(observation_id, subfile_path),
         subfile_path,

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/Tags.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/Tags.hpp
@@ -18,6 +18,7 @@
 #include "Options/Auto.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/PupStlCpp17.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace LinearSolver::multigrid {
@@ -112,7 +113,7 @@ struct MaxLevels : db::SimpleTag {
   using option_tags = tmpl::list<OptionTags::MaxLevels<OptionsGroup>>;
   static type create_from_options(const type value) { return value; };
   static std::string name() {
-    return "MaxLevels(" + Options::name<OptionsGroup>() + ")";
+    return "MaxLevels(" + pretty_type::name<OptionsGroup>() + ")";
   }
 };
 
@@ -124,7 +125,7 @@ struct OutputVolumeData : db::SimpleTag {
   using option_tags = tmpl::list<OptionTags::OutputVolumeData<OptionsGroup>>;
   static type create_from_options(const type value) { return value; };
   static std::string name() {
-    return "OutputVolumeData(" + Options::name<OptionsGroup>() + ")";
+    return "OutputVolumeData(" + pretty_type::name<OptionsGroup>() + ")";
   }
 };
 
@@ -138,7 +139,7 @@ struct EnablePreSmoothing : db::SimpleTag {
       tmpl::list<OptionTags::EnablePreSmoothing<OptionsGroup>>;
   static type create_from_options(const type value) { return value; };
   static std::string name() {
-    return "EnablePreSmoothing(" + Options::name<OptionsGroup>() + ")";
+    return "EnablePreSmoothing(" + pretty_type::name<OptionsGroup>() + ")";
   }
 };
 
@@ -153,7 +154,8 @@ struct EnablePostSmoothingAtBottom : db::SimpleTag {
       tmpl::list<OptionTags::EnablePostSmoothingAtBottom<OptionsGroup>>;
   static type create_from_options(const type value) { return value; };
   static std::string name() {
-    return "EnablePostSmoothingAtBottom(" + Options::name<OptionsGroup>() + ")";
+    return "EnablePostSmoothingAtBottom(" + pretty_type::name<OptionsGroup>() +
+           ")";
   }
 };
 
@@ -194,7 +196,7 @@ template <typename OptionsGroup>
 struct ObservationId : db::SimpleTag {
   using type = size_t;
   static std::string name() {
-    return "ObservationId(" + Options::name<OptionsGroup>() + ")";
+    return "ObservationId(" + pretty_type::name<OptionsGroup>() + ")";
   }
 };
 /// @{
@@ -255,7 +257,7 @@ struct VolumeDataForOutput : db::SimpleTag {
                    db::wrap_tags_in<PostSmoothingResult, fields_tags>,
                    db::wrap_tags_in<PostSmoothingResidual, fields_tags>>>;
   static std::string name() {
-    return "VolumeDataForOutput(" + Options::name<OptionsGroup>() + ")";
+    return "VolumeDataForOutput(" + pretty_type::name<OptionsGroup>() + ")";
   }
 };
 

--- a/src/ParallelAlgorithms/LinearSolver/Observe.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Observe.hpp
@@ -15,6 +15,7 @@
 #include "Parallel/Invoke.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
 #include "Utilities/Functional.hpp"
+#include "Utilities/PrettyType.hpp"
 
 namespace LinearSolver {
 namespace observe_detail {
@@ -36,7 +37,7 @@ void contribute_to_reduction_observer(
       // When multiple linear solves are performed, e.g. for the nonlinear
       // solver, we'll need to write into separate subgroups, e.g.:
       // `/linear_residuals/<nonlinear_iteration_id>`
-      std::string{"/" + Options::name<OptionsGroup>() + "Residuals"},
+      std::string{"/" + pretty_type::name<OptionsGroup>() + "Residuals"},
       std::vector<std::string>{"Iteration", "Residual"},
       std::make_tuple(iteration_id, residual_magnitude));
 }

--- a/src/ParallelAlgorithms/LinearSolver/Richardson/Tags.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Richardson/Tags.hpp
@@ -7,6 +7,7 @@
 
 #include "DataStructures/DataBox/Tag.hpp"
 #include "Options/Options.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace LinearSolver::Richardson {
@@ -31,7 +32,7 @@ namespace Tags {
 template <typename OptionsGroup>
 struct RelaxationParameter : db::SimpleTag {
   static std::string name() {
-    return "RelaxationParameter(" + Options::name<OptionsGroup>() + ")";
+    return "RelaxationParameter(" + pretty_type::name<OptionsGroup>() + ")";
   }
   using type = double;
 

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/Actions/CommunicateOverlapFields.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/Actions/CommunicateOverlapFields.hpp
@@ -26,6 +26,7 @@
 #include "Parallel/Printf.hpp"
 #include "ParallelAlgorithms/LinearSolver/Schwarz/OverlapHelpers.hpp"
 #include "ParallelAlgorithms/LinearSolver/Schwarz/Tags.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -102,7 +103,7 @@ struct SendOverlapFields<tmpl::list<OverlapFields...>, OptionsGroup,
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                  ::Verbosity::Debug)) {
       Parallel::printf("%s %s(%zu): Send overlap fields\n", element_id,
-                       Options::name<OptionsGroup>(), iteration_id);
+                       pretty_type::name<OptionsGroup>(), iteration_id);
     }
 
     // Send data on intruding overlaps to the corresponding neighbors
@@ -215,7 +216,7 @@ struct ReceiveOverlapFields<Dim, tmpl::list<OverlapFields...>, OptionsGroup> {
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                  ::Verbosity::Debug)) {
       Parallel::printf("%s %s(%zu): Receive overlap fields\n", element_id,
-                       Options::name<OptionsGroup>(), iteration_id);
+                       pretty_type::name<OptionsGroup>(), iteration_id);
     }
 
     // Move received overlap data into DataBox

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/Actions/ResetSubdomainSolver.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/Actions/ResetSubdomainSolver.hpp
@@ -13,6 +13,7 @@
 #include "Parallel/Printf.hpp"
 #include "ParallelAlgorithms/LinearSolver/Schwarz/Tags.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -72,7 +73,7 @@ struct ResetSubdomainSolver {
       if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                    ::Verbosity::Debug)) {
         Parallel::printf("%s %s: Reset subdomain solver\n", element_id,
-                         Options::name<OptionsGroup>());
+                         pretty_type::name<OptionsGroup>());
       }
       db::mutate<
           LinearSolver::Schwarz::Tags::SubdomainSolverBase<OptionsGroup>>(

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementActions.hpp
@@ -38,7 +38,6 @@
 #include "NumericalAlgorithms/LinearSolver/Gmres.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
-#include "Options/Options.hpp"
 #include "Parallel/AlgorithmMetafunctions.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/InboxInserters.hpp"
@@ -90,7 +89,7 @@ struct SubdomainStatsFormatter
                          const size_t min_subdomain_its,
                          const size_t max_subdomain_its,
                          const size_t total_subdomain_its) const {
-    return Options::name<OptionsGroup>() + section_observation_key + "(" +
+    return pretty_type::name<OptionsGroup>() + section_observation_key + "(" +
            get_output(iteration_id) + ") completed all " +
            get_output(num_subdomains) +
            " subdomain solves. Average of number of iterations: " +
@@ -157,7 +156,7 @@ void contribute_to_subdomain_stats_observation(
       observers::ArrayComponentId{
           std::add_pointer_t<ParallelComponent>{nullptr},
           Parallel::ArrayIndex<ArrayIndex>(array_index)},
-      std::string{"/" + Options::name<OptionsGroup>() +
+      std::string{"/" + pretty_type::name<OptionsGroup>() +
                   section_observation_key + "SubdomainSolves"},
       std::vector<std::string>{"Iteration", "NumSubdomains", "AvgNumIterations",
                                "MinNumIterations", "MaxNumIterations",
@@ -172,7 +171,7 @@ void contribute_to_subdomain_stats_observation(
 template <typename SubdomainDataType, typename OptionsGroup>
 struct SubdomainDataBufferTag : db::SimpleTag {
   static std::string name() {
-    return "SubdomainData(" + Options::name<OptionsGroup>() + ")";
+    return "SubdomainData(" + pretty_type::name<OptionsGroup>() + ")";
   }
   using type = SubdomainDataType;
 };
@@ -351,7 +350,7 @@ struct SolveSubdomain {
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                  ::Verbosity::Debug)) {
       Parallel::printf("%s %s(%zu): Solve subdomain\n", element_id,
-                       Options::name<OptionsGroup>(), iteration_id);
+                       pretty_type::name<OptionsGroup>(), iteration_id);
     }
 
     // Assemble the subdomain data from the data on the element and the
@@ -397,7 +396,7 @@ struct SolveSubdomain {
         Parallel::printf(
             "%s %s(%zu): WARNING: Subdomain solver did not converge in %zu "
             "iterations: %e -> %e\n",
-            element_id, Options::name<OptionsGroup>(), iteration_id,
+            element_id, pretty_type::name<OptionsGroup>(), iteration_id,
             subdomain_solve_has_converged.num_iterations(),
             subdomain_solve_has_converged.initial_residual_magnitude(),
             subdomain_solve_has_converged.residual_magnitude());
@@ -406,7 +405,7 @@ struct SolveSubdomain {
         Parallel::printf(
             "%s %s(%zu): Subdomain solver converged in %zu iterations (%s): %e "
             "-> %e\n",
-            element_id, Options::name<OptionsGroup>(), iteration_id,
+            element_id, pretty_type::name<OptionsGroup>(), iteration_id,
             subdomain_solve_has_converged.num_iterations(),
             subdomain_solve_has_converged.reason(),
             subdomain_solve_has_converged.initial_residual_magnitude(),
@@ -504,7 +503,7 @@ struct ReceiveOverlapSolution {
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                  ::Verbosity::Debug)) {
       Parallel::printf("%s %s(%zu): Receive overlap solution\n", element_id,
-                       Options::name<OptionsGroup>(), iteration_id);
+                       pretty_type::name<OptionsGroup>(), iteration_id);
     }
 
     // Add solutions on overlaps to this element's solution in a weighted sum

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/Tags.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/Tags.hpp
@@ -17,6 +17,7 @@
 #include "Parallel/Serialize.hpp"
 #include "ParallelAlgorithms/LinearSolver/Schwarz/OverlapHelpers.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace LinearSolver::Schwarz {
@@ -71,7 +72,7 @@ namespace Tags {
 template <typename OptionsGroup>
 struct MaxOverlap : db::SimpleTag {
   static std::string name() {
-    return "MaxOverlap(" + Options::name<OptionsGroup>() + ")";
+    return "MaxOverlap(" + pretty_type::name<OptionsGroup>() + ")";
   }
   using type = size_t;
   static constexpr bool pass_metavariables = false;
@@ -83,7 +84,7 @@ struct MaxOverlap : db::SimpleTag {
 template <typename OptionsGroup>
 struct SubdomainSolverBase : db::BaseTag {
   static std::string name() {
-    return "SubdomainSolver(" + Options::name<OptionsGroup>() + ")";
+    return "SubdomainSolver(" + pretty_type::name<OptionsGroup>() + ")";
   }
 };
 
@@ -134,7 +135,7 @@ template <typename Tag, size_t Dim, typename OptionsGroup>
 struct Overlaps : db::SimpleTag {
   static std::string name() {
     return "Overlaps(" + db::tag_name<Tag>() + ", " +
-           Options::name<OptionsGroup>() + ")";
+           pretty_type::name<OptionsGroup>() + ")";
   }
   using tag = Tag;
   using type = OverlapMap<Dim, typename Tag::type>;
@@ -144,7 +145,7 @@ struct Overlaps : db::SimpleTag {
 template <size_t Dim, typename OptionsGroup>
 struct IntrudingExtents : db::SimpleTag {
   static std::string name() {
-    return "IntrudingExtents(" + Options::name<OptionsGroup>() + ")";
+    return "IntrudingExtents(" + pretty_type::name<OptionsGroup>() + ")";
   }
   using type = std::array<size_t, Dim>;
 };
@@ -154,7 +155,7 @@ struct IntrudingExtents : db::SimpleTag {
 template <size_t Dim, typename OptionsGroup>
 struct IntrudingOverlapWidths : db::SimpleTag {
   static std::string name() {
-    return "IntrudingOverlapWidths(" + Options::name<OptionsGroup>() + ")";
+    return "IntrudingOverlapWidths(" + pretty_type::name<OptionsGroup>() + ")";
   }
   using type = std::array<double, Dim>;
 };
@@ -163,7 +164,7 @@ struct IntrudingOverlapWidths : db::SimpleTag {
 template <typename OptionsGroup>
 struct Weight : db::SimpleTag {
   static std::string name() {
-    return "Weight(" + Options::name<OptionsGroup>() + ")";
+    return "Weight(" + pretty_type::name<OptionsGroup>() + ")";
   }
   using type = Scalar<DataVector>;
 };
@@ -178,8 +179,8 @@ struct Weight : db::SimpleTag {
 template <typename OptionsGroup>
 struct SummedIntrudingOverlapWeights : db::SimpleTag {
   static std::string name() {
-    return "SummedIntrudingOverlapWeights(" + Options::name<OptionsGroup>() +
-           ")";
+    return "SummedIntrudingOverlapWeights(" +
+           pretty_type::name<OptionsGroup>() + ")";
   }
   using type = Scalar<DataVector>;
 };

--- a/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/ElementActions.hpp
+++ b/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/ElementActions.hpp
@@ -34,6 +34,7 @@
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -157,7 +158,7 @@ struct PrepareSolve {
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                  ::Verbosity::Debug)) {
       Parallel::printf("%s %s: Prepare solve\n", get_output(array_index),
-                       Options::name<OptionsGroup>());
+                       pretty_type::name<OptionsGroup>());
     }
 
     constexpr size_t this_action_index =
@@ -328,7 +329,7 @@ struct PrepareStep {
                  ::Verbosity::Debug)) {
       Parallel::printf(
           "%s %s(%zu): Prepare step\n", get_output(array_index),
-          Options::name<OptionsGroup>(),
+          pretty_type::name<OptionsGroup>(),
           db::get<Convergence::Tags::IterationId<OptionsGroup>>(box) + 1);
     }
 
@@ -414,7 +415,7 @@ struct PerformStep {
                  ::Verbosity::Debug)) {
       Parallel::printf(
           "%s %s(%zu): Perform step with length: %g\n", get_output(array_index),
-          Options::name<OptionsGroup>(),
+          pretty_type::name<OptionsGroup>(),
           db::get<Convergence::Tags::IterationId<OptionsGroup>>(box),
           db::get<NonlinearSolver::Tags::StepLength<OptionsGroup>>(box));
     }
@@ -561,7 +562,7 @@ struct Globalize {
                    ::Verbosity::Debug)) {
         Parallel::printf(
             "%s %s(%zu): Globalize(%zu)\n", get_output(array_index),
-            Options::name<OptionsGroup>(),
+            pretty_type::name<OptionsGroup>(),
             db::get<Convergence::Tags::IterationId<OptionsGroup>>(box),
             db::get<NonlinearSolver::Tags::Globalization<
                 Convergence::Tags::IterationId<OptionsGroup>>>(box));
@@ -627,7 +628,7 @@ struct CompleteStep {
                  ::Verbosity::Debug)) {
       Parallel::printf(
           "%s %s(%zu): Complete step\n", get_output(array_index),
-          Options::name<OptionsGroup>(),
+          pretty_type::name<OptionsGroup>(),
           db::get<Convergence::Tags::IterationId<OptionsGroup>>(box));
     }
 

--- a/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/ResidualMonitorActions.hpp
+++ b/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/ResidualMonitorActions.hpp
@@ -20,6 +20,7 @@
 #include "ParallelAlgorithms/NonlinearSolver/Tags.hpp"
 #include "Utilities/EqualWithinRoundoff.hpp"
 #include "Utilities/Functional.hpp"
+#include "Utilities/PrettyType.hpp"
 
 /// \cond
 namespace tuples {
@@ -136,7 +137,7 @@ struct CheckResidualMagnitude {
                 "%s(%zu): Step with length %g didn't sufficiently decrease the "
                 "residual (possible overshoot). Residual: %e. Next step "
                 "length: %g.\n",
-                Options::name<OptionsGroup>(), iteration_id, step_length,
+                pretty_type::name<OptionsGroup>(), iteration_id, step_length,
                 residual_magnitude, next_step_length);
             if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                          ::Verbosity::Debug)) {
@@ -159,7 +160,7 @@ struct CheckResidualMagnitude {
               "in %zu globalization steps. This is usually indicative of an "
               "ill-posed problem, for example when the linearization of the "
               "nonlinear operator is not computed correctly.",
-              Options::name<OptionsGroup>(), iteration_id,
+              pretty_type::name<OptionsGroup>(), iteration_id,
               globalization_iteration_id);
         }  // min_step_length
       }    // sufficient decrease condition
@@ -185,12 +186,12 @@ struct CheckResidualMagnitude {
                  ::Verbosity::Quiet)) {
       if (UNLIKELY(iteration_id == 0)) {
         Parallel::printf("%s initialized with residual: %e\n",
-                         Options::name<OptionsGroup>(), residual_magnitude);
+                         pretty_type::name<OptionsGroup>(), residual_magnitude);
       } else {
         Parallel::printf(
             "%s(%zu) iteration complete (%zu globalization steps, step length "
             "%g). Remaining residual: %e\n",
-            Options::name<OptionsGroup>(), iteration_id,
+            pretty_type::name<OptionsGroup>(), iteration_id,
             globalization_iteration_id, step_length, residual_magnitude);
       }
     }
@@ -198,10 +199,10 @@ struct CheckResidualMagnitude {
                                        box) >= ::Verbosity::Quiet)) {
       if (UNLIKELY(iteration_id == 0)) {
         Parallel::printf("%s has converged without any iterations: %s\n",
-                         Options::name<OptionsGroup>(), has_converged);
+                         pretty_type::name<OptionsGroup>(), has_converged);
       } else {
         Parallel::printf("%s has converged in %zu iterations: %s\n",
-                         Options::name<OptionsGroup>(), iteration_id,
+                         pretty_type::name<OptionsGroup>(), iteration_id,
                          has_converged);
       }
     }

--- a/src/ParallelAlgorithms/NonlinearSolver/Observe.hpp
+++ b/src/ParallelAlgorithms/NonlinearSolver/Observe.hpp
@@ -15,6 +15,7 @@
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Reduction.hpp"
 #include "Utilities/Functional.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/System/ParallelInfo.hpp"
 
 namespace NonlinearSolver::observe_detail {
@@ -34,7 +35,7 @@ void contribute_to_reduction_observer(
       // Node 0 is always the writer, so directly call the component on that
       // node
       reduction_writer[0],
-      std::string{"/" + Options::name<OptionsGroup>() + "Residuals"},
+      std::string{"/" + pretty_type::name<OptionsGroup>() + "Residuals"},
       std::vector<std::string>{"Iteration", "GlobalizationStep", "Residual",
                                "StepLength"},
       std::make_tuple(iteration_id, globalization_iteration_id,

--- a/src/ParallelAlgorithms/NonlinearSolver/Tags.hpp
+++ b/src/ParallelAlgorithms/NonlinearSolver/Tags.hpp
@@ -13,6 +13,7 @@
 #include "DataStructures/DataBox/Tag.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/PrettyType.hpp"
 
 /// Functionality for solving nonlinear systems of equations
 namespace NonlinearSolver {
@@ -181,7 +182,7 @@ struct ResidualCompute : db::add_tag_prefix<Residual, FieldsTag>,
 template <typename OptionsGroup>
 struct StepLength : db::SimpleTag {
   static std::string name() {
-    return "StepLength(" + Options::name<OptionsGroup>() + ")";
+    return "StepLength(" + pretty_type::name<OptionsGroup>() + ")";
   }
   using type = double;
 };
@@ -194,7 +195,7 @@ struct StepLength : db::SimpleTag {
 template <typename OptionsGroup>
 struct SufficientDecrease : db::SimpleTag {
   static std::string name() {
-    return "SufficientDecrease(" + Options::name<OptionsGroup>() + ")";
+    return "SufficientDecrease(" + pretty_type::name<OptionsGroup>() + ")";
   }
   using type = double;
   static constexpr bool pass_metavariables = false;
@@ -210,7 +211,7 @@ struct SufficientDecrease : db::SimpleTag {
 template <typename OptionsGroup>
 struct DampingFactor : db::SimpleTag {
   static std::string name() {
-    return "DampingFactor(" + Options::name<OptionsGroup>() + ")";
+    return "DampingFactor(" + pretty_type::name<OptionsGroup>() + ")";
   }
   using type = double;
   static constexpr bool pass_metavariables = false;
@@ -226,7 +227,7 @@ struct DampingFactor : db::SimpleTag {
 template <typename OptionsGroup>
 struct MaxGlobalizationSteps : db::SimpleTag {
   static std::string name() {
-    return "MaxGlobalizationSteps(" + Options::name<OptionsGroup>() + ")";
+    return "MaxGlobalizationSteps(" + pretty_type::name<OptionsGroup>() + ")";
   }
   using type = size_t;
   static constexpr bool pass_metavariables = false;

--- a/src/PointwiseFunctions/AnalyticData/Tags.hpp
+++ b/src/PointwiseFunctions/AnalyticData/Tags.hpp
@@ -6,6 +6,7 @@
 #include "DataStructures/DataBox/Tag.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/Serialize.hpp"
+#include "Utilities/PrettyType.hpp"
 
 namespace OptionTags {
 /// \ingroup OptionGroupsGroup
@@ -21,7 +22,7 @@ struct AnalyticDataGroup {
 /// parameter
 template <typename DataType>
 struct AnalyticData {
-  static std::string name() { return Options::name<DataType>(); }
+  static std::string name() { return pretty_type::name<DataType>(); }
   static constexpr Options::String help = "Options for the analytic data";
   using type = DataType;
   using group = AnalyticDataGroup;

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.hpp
@@ -44,7 +44,7 @@ class WrappedGr : public SolutionType {
   static constexpr size_t volume_dim = SolutionType::volume_dim;
   using options = typename SolutionType::options;
   static constexpr Options::String help = SolutionType::help;
-  static std::string name() { return Options::name<SolutionType>(); }
+  static std::string name() { return pretty_type::name<SolutionType>(); }
 
   using DerivLapse = ::Tags::deriv<gr::Tags::Lapse<DataVector>,
                                    tmpl::size_t<volume_dim>, Frame::Inertial>;

--- a/src/PointwiseFunctions/AnalyticSolutions/Tags.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Tags.hpp
@@ -14,6 +14,7 @@
 #include "Parallel/Serialize.hpp"
 #include "PointwiseFunctions/AnalyticData/Tags.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace OptionTags {
@@ -30,7 +31,7 @@ struct AnalyticSolutionGroup {
 /// template parameter
 template <typename SolutionType>
 struct AnalyticSolution {
-  static std::string name() { return Options::name<SolutionType>(); }
+  static std::string name() { return pretty_type::name<SolutionType>(); }
   static constexpr Options::String help = "Options for the analytic solution";
   using type = SolutionType;
   using group = AnalyticSolutionGroup;

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.hpp
@@ -21,6 +21,7 @@
 #include "PointwiseFunctions/GeneralRelativity/Tags/Conformal.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/AnalyticSolution.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -218,7 +219,7 @@ class WrappedGr : public elliptic::analytic_data::AnalyticSolution,
 
   using options = typename GrSolution::options;
   static constexpr Options::String help = GrSolution::help;
-  static std::string name() { return Options::name<GrSolution>(); }
+  static std::string name() { return pretty_type::name<GrSolution>(); }
 
   using GrSolution::GrSolution;
   using PUP::able::register_constructor;

--- a/src/PythonBindings/BoundChecks.hpp
+++ b/src/PythonBindings/BoundChecks.hpp
@@ -19,8 +19,8 @@ template <typename T>
 void bounds_check(const T& t, const size_t i) {
   if (i >= t.size()) {
     throw std::runtime_error{"Out of bounds access (" + std::to_string(i) +
-                             ") into " + pretty_type::short_name<T>() +
-                             " of size " + std::to_string(t.size())};
+                             ") into " + pretty_type::name<T>() + " of size " +
+                             std::to_string(t.size())};
   }
 }
 /*!

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -904,7 +904,7 @@ void test_variables_from_tagged_tuple() {
 
 template <typename VectorType>
 void test_variables_equal_within_roundoff() {
-  INFO(pretty_type::short_name<VectorType>());
+  INFO(pretty_type::name<VectorType>());
   MAKE_GENERATOR(gen);
   using value_type = typename VectorType::value_type;
   UniformCustomDistribution<tt::get_fundamental_type_t<value_type>>

--- a/tests/Unit/Evolution/EventsAndDenseTriggers/Test_EventsAndDenseTriggers.cpp
+++ b/tests/Unit/Evolution/EventsAndDenseTriggers/Test_EventsAndDenseTriggers.cpp
@@ -22,6 +22,7 @@
 #include "Time/TimeStepId.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeVector.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -55,7 +56,7 @@ class TestEvent : public Event {
   WRAPPED_PUPable_decl_template(TestEvent);  // NOLINT
 
   static std::string name() {
-    return "TestEvent<" + Options::name<Label>() + ">";
+    return "TestEvent<" + pretty_type::name<Label>() + ">";
   }
 
   using options = tmpl::list<>;

--- a/tests/Unit/Framework/MockDistributedObject.hpp
+++ b/tests/Unit/Framework/MockDistributedObject.hpp
@@ -918,7 +918,7 @@ bool MockDistributedObject<Component>::next_action_if_ready() {
   tmpl::for_each<phase_dependent_action_lists>(invoke_for_phase);
   if (not found_matching_phase) {
     ERROR("Could not find any actions in the current phase for the component '"
-          << pretty_type::short_name<Component>() << "'.");
+          << pretty_type::name<Component>() << "'.");
   }
   return was_ready;
 }

--- a/tests/Unit/Framework/MockRuntimeSystem.hpp
+++ b/tests/Unit/Framework/MockRuntimeSystem.hpp
@@ -630,7 +630,7 @@ class MockRuntimeSystem {
     if (not found_matching_phase) {
       ERROR(
           "Could not find any actions in the current phase for the component '"
-          << pretty_type::short_name<Component>()
+          << pretty_type::name<Component>()
           << "'. Maybe you are not in the phase you expected to be in? The "
              "integer value corresponding to the current phase is "
           << static_cast<int>(this->mock_distributed_objects<Component>()

--- a/tests/Unit/Framework/TestCreation.hpp
+++ b/tests/Unit/Framework/TestCreation.hpp
@@ -12,6 +12,7 @@
 #include "Options/ParseOptions.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Utilities/NoSuchType.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits/IsA.hpp"
@@ -37,7 +38,7 @@ struct AddGroups {
     construction_string.insert(0, 2, ' ');
     construction_string =
         boost::algorithm::replace_all_copy(construction_string, "\n", "\n  ");
-    construction_string.insert(0, Options::name<OptionTag>() + ":\n");
+    construction_string.insert(0, pretty_type::name<OptionTag>() + ":\n");
     return construction_string;
   }
 };

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp
@@ -187,7 +187,7 @@ void test_boundary_condition_with_python_impl(
   CAPTURE(face_points);
   CAPTURE(use_moving_mesh);
   CAPTURE(epsilon);
-  CAPTURE(pretty_type::short_name<BoundaryCorrection>());
+  CAPTURE(pretty_type::name<BoundaryCorrection>());
   const size_t number_of_points_on_face = face_points.product();
 
   using variables_tag = typename System::variables_tag;

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp
@@ -656,7 +656,7 @@ void test_with_python(
           CAPTURE(python_module);
           CAPTURE(
               gsl::at(python_dg_package_data_functions, function_name_index));
-          CAPTURE(pretty_type::short_name<ResultType>());
+          CAPTURE(pretty_type::name<ResultType>());
           if constexpr (curved_background) {
             const auto python_result =
                 pypp::call<ResultType, ConversionClassList>(

--- a/tests/Unit/Helpers/Evolution/EventsAndDenseTriggers/DenseTriggers/TestTrigger.hpp
+++ b/tests/Unit/Helpers/Evolution/EventsAndDenseTriggers/DenseTriggers/TestTrigger.hpp
@@ -12,6 +12,7 @@
 #include "Evolution/EventsAndDenseTriggers/DenseTrigger.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/CharmPupable.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -94,7 +95,7 @@ class BoxTrigger : public DenseTrigger {
   /// \endcond
 
   static std::string name() {
-    return "BoxTrigger<" + Options::name<Label>() + ">";
+    return "BoxTrigger<" + pretty_type::name<Label>() + ">";
   }
 
   using options = tmpl::list<>;

--- a/tests/Unit/Options/Test_Factory.cpp
+++ b/tests/Unit/Options/Test_Factory.cpp
@@ -13,6 +13,7 @@
 #include "Options/Options.hpp"
 #include "Options/ParseOptions.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -74,7 +75,7 @@ class TestWithArg : public OptionTest {
 
 // Same as TestWithArg, except there is an TestWithArg2::name() that
 // returns something other than "TestWithArg2Arg" to test that class
-// is named in the input file using Options::name rather than
+// is named in the input file using pretty_type::name rather than
 // pretty_type::short_name
 class TestWithArg2 : public OptionTest {
  public:

--- a/tests/Unit/Parallel/Test_CheckpointRestart.cpp
+++ b/tests/Unit/Parallel/Test_CheckpointRestart.cpp
@@ -54,7 +54,7 @@ struct InitializeLog {
       const ArrayIndex& array_index, ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
     const std::string component_name =
-        pretty_type::short_name<ParallelComponent>() + " " +
+        pretty_type::name<ParallelComponent>() + " " +
         std::to_string(static_cast<int>(array_index));
     Initialization::mutate_assign<simple_tags>(
         make_not_null(&box),

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveNorms.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveNorms.cpp
@@ -175,7 +175,7 @@ template <typename ArraySectionIdTag, typename ObserveEvent>
 void test(const std::unique_ptr<ObserveEvent> observe,
           const Spectral::Basis basis, const Spectral::Quadrature quadrature,
           const std::optional<std::string>& section) {
-  CAPTURE(pretty_type::short_name<ArraySectionIdTag>());
+  CAPTURE(pretty_type::name<ArraySectionIdTag>());
   CAPTURE(section);
   using metavariables = Metavariables<3, ArraySectionIdTag>;
   using element_component = ElementComponent<metavariables>;

--- a/tests/Unit/Utilities/Test_PrettyType.cpp
+++ b/tests/Unit/Utilities/Test_PrettyType.cpp
@@ -186,61 +186,84 @@ struct GlobalEnumTemplate {};
 
 template <LocalEnum>
 struct LocalEnumTemplate {};
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Utilities.PrettyType.short_name", "[Utilities][Unit]") {
+template <typename>
+struct TemplateWithName {
+  static std::string name() { return "UniqueTemplateWithName"; }
+};
+
+struct NonTemplateWithName {
+  static std::string name() { return "UniqueNonTemplateWithName"; }
+};
+
+struct ShortName {
+  template <typename TestType>
+  static std::string name() {
+    return pretty_type::short_name<TestType>();
+  }
+};
+
+struct Name {
+  template <typename TestType>
+  static std::string name() {
+    return pretty_type::name<TestType>();
+  }
+};
+
+template <typename NameFunc>
+void test_name_func() {
   // Fundamentals
-  CHECK(pretty_type::short_name<bool>() == "bool");
-  CHECK(pretty_type::short_name<char>() == "char");
-  CHECK(pretty_type::short_name<signed char>() == "signed char");
-  CHECK(pretty_type::short_name<unsigned char>() == "unsigned char");
-  CHECK(pretty_type::short_name<short>() == "short");
-  CHECK(pretty_type::short_name<unsigned short>() == "unsigned short");
-  CHECK(pretty_type::short_name<int>() == "int");
-  CHECK(pretty_type::short_name<unsigned int>() == "unsigned int");
-  CHECK(pretty_type::short_name<long>() == "long");
-  CHECK(pretty_type::short_name<unsigned long>() == "unsigned long");
-  CHECK(pretty_type::short_name<long long>() == "long long");
-  CHECK(pretty_type::short_name<unsigned long long>() == "unsigned long long");
-  CHECK(pretty_type::short_name<void>() == "void");
-  CHECK(pretty_type::short_name<float>() == "float");
-  CHECK(pretty_type::short_name<double>() == "double");
-  CHECK(pretty_type::short_name<long double>() == "long double");
+  CHECK(NameFunc::template name<bool>() == "bool");
+  CHECK(NameFunc::template name<char>() == "char");
+  CHECK(NameFunc::template name<signed char>() == "signed char");
+  CHECK(NameFunc::template name<unsigned char>() == "unsigned char");
+  CHECK(NameFunc::template name<short>() == "short");
+  CHECK(NameFunc::template name<unsigned short>() == "unsigned short");
+  CHECK(NameFunc::template name<int>() == "int");
+  CHECK(NameFunc::template name<unsigned int>() == "unsigned int");
+  CHECK(NameFunc::template name<long>() == "long");
+  CHECK(NameFunc::template name<unsigned long>() == "unsigned long");
+  CHECK(NameFunc::template name<long long>() == "long long");
+  CHECK(NameFunc::template name<unsigned long long>() == "unsigned long long");
+  CHECK(NameFunc::template name<void>() == "void");
+  CHECK(NameFunc::template name<float>() == "float");
+  CHECK(NameFunc::template name<double>() == "double");
+  CHECK(NameFunc::template name<long double>() == "long double");
 
   // Standard library
   // Untemplated
-  CHECK(pretty_type::short_name<std::type_info>() == "type_info");
+  CHECK(NameFunc::template name<std::type_info>() == "type_info");
   // Templated
-  CHECK(pretty_type::short_name<std::vector<int>>() == "vector");
+  CHECK(NameFunc::template name<std::vector<int>>() == "vector");
   // (Probably) special cased in mangling
-  CHECK(pretty_type::short_name<std::ostream>() == "ostream");
+  CHECK(NameFunc::template name<std::ostream>() == "ostream");
   // Possibly special cased in mangling and a case we particularly care about
-  CHECK(pretty_type::short_name<std::string>() == "string");
+  CHECK(NameFunc::template name<std::string>() == "string");
 
   // Types and templates with no namespaces
-  CHECK(pretty_type::short_name<Test_PrettyType_struct>() ==
+  CHECK(NameFunc::template name<Test_PrettyType_struct>() ==
         "Test_PrettyType_struct");
-  CHECK(pretty_type::short_name<Test_PrettyType_templated_struct<int>>() ==
+  CHECK(NameFunc::template name<Test_PrettyType_templated_struct<int>>() ==
         "Test_PrettyType_templated_struct");
-  CHECK(pretty_type::short_name<
+  CHECK(NameFunc::template name<
             Test_PrettyType_templated_struct<Test_PrettyType_struct>>() ==
         "Test_PrettyType_templated_struct");
-  CHECK(pretty_type::short_name<Test_PrettyType_templated_struct<
+  CHECK(NameFunc::template name<Test_PrettyType_templated_struct<
             Test_PrettyType_templated_struct<int>>>() ==
         "Test_PrettyType_templated_struct");
-  CHECK(pretty_type::short_name<Test_PrettyType_templated_struct<
+  CHECK(NameFunc::template name<Test_PrettyType_templated_struct<
             Test_PrettyType_templated_struct<Test_PrettyType_struct>>>() ==
         "Test_PrettyType_templated_struct");
 
   // Named namespaces
-  CHECK(pretty_type::short_name<Test_PrettyType_namespace::NamedNamespace>() ==
+  CHECK(NameFunc::template name<Test_PrettyType_namespace::NamedNamespace>() ==
         "NamedNamespace");
 
   // Anonymous namespaces
-  CHECK(pretty_type::short_name<TestType>() == "TestType");
+  CHECK(NameFunc::template name<TestType>() == "TestType");
 
   // Digits (special meaning in mangled names)
-  CHECK(pretty_type::short_name<Type1Containing2Digits3>() ==
+  CHECK(NameFunc::template name<Type1Containing2Digits3>() ==
         "Type1Containing2Digits3");
 
   using Global = Test_PrettyType_struct;
@@ -249,190 +272,202 @@ SPECTRE_TEST_CASE("Unit.Utilities.PrettyType.short_name", "[Utilities][Unit]") {
   using Templated = Test_PrettyType_templated_struct<Test_PrettyType_struct>;
 
   // const
-  CHECK(pretty_type::short_name<const int>() == "int");
-  CHECK(pretty_type::short_name<const Global>() == "Test_PrettyType_struct");
-  CHECK(pretty_type::short_name<const TestType>() == "TestType");
-  CHECK(pretty_type::short_name<const Std>() == "type_info");
-  CHECK(pretty_type::short_name<const Special>() == "ostream");
-  CHECK(pretty_type::short_name<const Templated>() ==
+  CHECK(NameFunc::template name<const int>() == "int");
+  CHECK(NameFunc::template name<const Global>() == "Test_PrettyType_struct");
+  CHECK(NameFunc::template name<const TestType>() == "TestType");
+  CHECK(NameFunc::template name<const Std>() == "type_info");
+  CHECK(NameFunc::template name<const Special>() == "ostream");
+  CHECK(NameFunc::template name<const Templated>() ==
         "Test_PrettyType_templated_struct");
 
   // Template stuff
-  CHECK(pretty_type::short_name<Template<int>>() == "Template");
-  CHECK(pretty_type::short_name<Template<Global>>() == "Template");
-  CHECK(pretty_type::short_name<Template<TestType>>() == "Template");
-  CHECK(pretty_type::short_name<Template<Std>>() == "Template");
-  CHECK(pretty_type::short_name<Template<Special>>() == "Template");
-  CHECK(pretty_type::short_name<Template<Templated>>() == "Template");
-  CHECK(pretty_type::short_name<Template<const Global>>() == "Template");
-  CHECK(pretty_type::short_name<Template<const TestType>>() == "Template");
+  CHECK(NameFunc::template name<Template<int>>() == "Template");
+  CHECK(NameFunc::template name<Template<Global>>() == "Template");
+  CHECK(NameFunc::template name<Template<TestType>>() == "Template");
+  CHECK(NameFunc::template name<Template<Std>>() == "Template");
+  CHECK(NameFunc::template name<Template<Special>>() == "Template");
+  CHECK(NameFunc::template name<Template<Templated>>() == "Template");
+  CHECK(NameFunc::template name<Template<const Global>>() == "Template");
+  CHECK(NameFunc::template name<Template<const TestType>>() == "Template");
 
-  CHECK(pretty_type::short_name<Template2<int, int>>() == "Template2");
-  CHECK(pretty_type::short_name<Template2<int, Global>>() == "Template2");
-  CHECK(pretty_type::short_name<Template2<int, TestType>>() == "Template2");
-  CHECK(pretty_type::short_name<Template2<int, Std>>() == "Template2");
-  CHECK(pretty_type::short_name<Template2<int, Special>>() == "Template2");
-  CHECK(pretty_type::short_name<Template2<Global, int>>() == "Template2");
-  CHECK(pretty_type::short_name<Template2<Global, Global>>() == "Template2");
-  CHECK(pretty_type::short_name<Template2<Global, TestType>>() == "Template2");
-  CHECK(pretty_type::short_name<Template2<Global, Std>>() == "Template2");
-  CHECK(pretty_type::short_name<Template2<Global, Special>>() == "Template2");
-  CHECK(pretty_type::short_name<Template2<TestType, int>>() == "Template2");
-  CHECK(pretty_type::short_name<Template2<TestType, Global>>() == "Template2");
-  CHECK(pretty_type::short_name<Template2<TestType, TestType>>() ==
+  CHECK(NameFunc::template name<Template2<int, int>>() == "Template2");
+  CHECK(NameFunc::template name<Template2<int, Global>>() == "Template2");
+  CHECK(NameFunc::template name<Template2<int, TestType>>() == "Template2");
+  CHECK(NameFunc::template name<Template2<int, Std>>() == "Template2");
+  CHECK(NameFunc::template name<Template2<int, Special>>() == "Template2");
+  CHECK(NameFunc::template name<Template2<Global, int>>() == "Template2");
+  CHECK(NameFunc::template name<Template2<Global, Global>>() == "Template2");
+  CHECK(NameFunc::template name<Template2<Global, TestType>>() == "Template2");
+  CHECK(NameFunc::template name<Template2<Global, Std>>() == "Template2");
+  CHECK(NameFunc::template name<Template2<Global, Special>>() == "Template2");
+  CHECK(NameFunc::template name<Template2<TestType, int>>() == "Template2");
+  CHECK(NameFunc::template name<Template2<TestType, Global>>() == "Template2");
+  CHECK(NameFunc::template name<Template2<TestType, TestType>>() ==
         "Template2");
-  CHECK(pretty_type::short_name<Template2<TestType, Std>>() == "Template2");
-  CHECK(pretty_type::short_name<Template2<TestType, Special>>() == "Template2");
-  CHECK(pretty_type::short_name<Template2<Std, int>>() == "Template2");
-  CHECK(pretty_type::short_name<Template2<Std, Global>>() == "Template2");
-  CHECK(pretty_type::short_name<Template2<Std, TestType>>() == "Template2");
-  CHECK(pretty_type::short_name<Template2<Std, Std>>() == "Template2");
-  CHECK(pretty_type::short_name<Template2<Std, Special>>() == "Template2");
-  CHECK(pretty_type::short_name<Template2<Special, int>>() == "Template2");
-  CHECK(pretty_type::short_name<Template2<Special, Global>>() == "Template2");
-  CHECK(pretty_type::short_name<Template2<Special, TestType>>() == "Template2");
-  CHECK(pretty_type::short_name<Template2<Special, Std>>() == "Template2");
-  CHECK(pretty_type::short_name<Template2<Special, Special>>() == "Template2");
+  CHECK(NameFunc::template name<Template2<TestType, Std>>() == "Template2");
+  CHECK(NameFunc::template name<Template2<TestType, Special>>() == "Template2");
+  CHECK(NameFunc::template name<Template2<Std, int>>() == "Template2");
+  CHECK(NameFunc::template name<Template2<Std, Global>>() == "Template2");
+  CHECK(NameFunc::template name<Template2<Std, TestType>>() == "Template2");
+  CHECK(NameFunc::template name<Template2<Std, Std>>() == "Template2");
+  CHECK(NameFunc::template name<Template2<Std, Special>>() == "Template2");
+  CHECK(NameFunc::template name<Template2<Special, int>>() == "Template2");
+  CHECK(NameFunc::template name<Template2<Special, Global>>() == "Template2");
+  CHECK(NameFunc::template name<Template2<Special, TestType>>() == "Template2");
+  CHECK(NameFunc::template name<Template2<Special, Std>>() == "Template2");
+  CHECK(NameFunc::template name<Template2<Special, Special>>() == "Template2");
 
-  CHECK(pretty_type::short_name<Template2<Global, const Global>>() ==
+  CHECK(NameFunc::template name<Template2<Global, const Global>>() ==
         "Template2");
-  CHECK(pretty_type::short_name<Template2<Global, const TestType>>() ==
+  CHECK(NameFunc::template name<Template2<Global, const TestType>>() ==
         "Template2");
-  CHECK(pretty_type::short_name<Template2<const Global, Global>>() ==
+  CHECK(NameFunc::template name<Template2<const Global, Global>>() ==
         "Template2");
-  CHECK(pretty_type::short_name<Template2<const TestType, Global>>() ==
-        "Template2");
-
-  CHECK(pretty_type::short_name<Template<Template<int>>>() == "Template");
-  CHECK(pretty_type::short_name<Template2<Template<int>, Template<double>>>() ==
+  CHECK(NameFunc::template name<Template2<const TestType, Global>>() ==
         "Template2");
 
-  CHECK(pretty_type::short_name<Pack<>>() == "Pack");
-  CHECK(pretty_type::short_name<Pack<int>>() == "Pack");
-  CHECK(pretty_type::short_name<Pack<Global>>() == "Pack");
-  CHECK(pretty_type::short_name<Pack<TestType>>() == "Pack");
-  CHECK(pretty_type::short_name<Pack<Std>>() == "Pack");
-  CHECK(pretty_type::short_name<Pack<Special>>() == "Pack");
-  CHECK(pretty_type::short_name<Pack<Templated>>() == "Pack");
+  CHECK(NameFunc::template name<Template<Template<int>>>() == "Template");
+  CHECK(NameFunc::template name<Template2<Template<int>, Template<double>>>() ==
+        "Template2");
 
-  CHECK(pretty_type::short_name<Pack2<int>>() == "Pack2");
-  CHECK(pretty_type::short_name<Pack2<Global>>() == "Pack2");
-  CHECK(pretty_type::short_name<Pack2<TestType>>() == "Pack2");
-  CHECK(pretty_type::short_name<Pack2<Std>>() == "Pack2");
-  CHECK(pretty_type::short_name<Pack2<Special>>() == "Pack2");
-  CHECK(pretty_type::short_name<Pack2<Templated>>() == "Pack2");
-  CHECK(pretty_type::short_name<Pack2<TestType, TestType>>() == "Pack2");
-  CHECK(pretty_type::short_name<Pack2<Special, TestType>>() == "Pack2");
-  CHECK(pretty_type::short_name<Pack2<TestType, Special>>() == "Pack2");
+  CHECK(NameFunc::template name<Pack<>>() == "Pack");
+  CHECK(NameFunc::template name<Pack<int>>() == "Pack");
+  CHECK(NameFunc::template name<Pack<Global>>() == "Pack");
+  CHECK(NameFunc::template name<Pack<TestType>>() == "Pack");
+  CHECK(NameFunc::template name<Pack<Std>>() == "Pack");
+  CHECK(NameFunc::template name<Pack<Special>>() == "Pack");
+  CHECK(NameFunc::template name<Pack<Templated>>() == "Pack");
+
+  CHECK(NameFunc::template name<Pack2<int>>() == "Pack2");
+  CHECK(NameFunc::template name<Pack2<Global>>() == "Pack2");
+  CHECK(NameFunc::template name<Pack2<TestType>>() == "Pack2");
+  CHECK(NameFunc::template name<Pack2<Std>>() == "Pack2");
+  CHECK(NameFunc::template name<Pack2<Special>>() == "Pack2");
+  CHECK(NameFunc::template name<Pack2<Templated>>() == "Pack2");
+  CHECK(NameFunc::template name<Pack2<TestType, TestType>>() == "Pack2");
+  CHECK(NameFunc::template name<Pack2<Special, TestType>>() == "Pack2");
+  CHECK(NameFunc::template name<Pack2<TestType, Special>>() == "Pack2");
 
   // Nested types
-  CHECK(pretty_type::short_name<Outer::Inner>() == "Inner");
-  CHECK(pretty_type::short_name<Outer::InnerTemplate<int>>() ==
+  CHECK(NameFunc::template name<Outer::Inner>() == "Inner");
+  CHECK(NameFunc::template name<Outer::InnerTemplate<int>>() ==
         "InnerTemplate");
-  CHECK(pretty_type::short_name<Outer::InnerTemplate<Global>>() ==
+  CHECK(NameFunc::template name<Outer::InnerTemplate<Global>>() ==
         "InnerTemplate");
-  CHECK(pretty_type::short_name<Outer::InnerTemplate<TestType>>() ==
+  CHECK(NameFunc::template name<Outer::InnerTemplate<TestType>>() ==
         "InnerTemplate");
-  CHECK(pretty_type::short_name<Outer::InnerTemplate<Special>>() ==
+  CHECK(NameFunc::template name<Outer::InnerTemplate<Special>>() ==
         "InnerTemplate");
-  CHECK(pretty_type::short_name<OuterTemplate<int>::Inner>() == "Inner");
-  CHECK(pretty_type::short_name<OuterTemplate<Global>::Inner>() == "Inner");
-  CHECK(pretty_type::short_name<OuterTemplate<TestType>::Inner>() == "Inner");
-  CHECK(pretty_type::short_name<OuterTemplate<Special>::Inner>() == "Inner");
+  CHECK(NameFunc::template name<OuterTemplate<int>::Inner>() == "Inner");
+  CHECK(NameFunc::template name<OuterTemplate<Global>::Inner>() == "Inner");
+  CHECK(NameFunc::template name<OuterTemplate<TestType>::Inner>() == "Inner");
+  CHECK(NameFunc::template name<OuterTemplate<Special>::Inner>() == "Inner");
 
-  CHECK(pretty_type::short_name<Pack<>::Inner>() == "Inner");
-  CHECK(pretty_type::short_name<Pack<TestType>::Inner>() == "Inner");
+  CHECK(NameFunc::template name<Pack<>::Inner>() == "Inner");
+  CHECK(NameFunc::template name<Pack<TestType>::Inner>() == "Inner");
 
   // Non-type template parameters
-  CHECK(pretty_type::short_name<NonType<3>>() == "NonType");
-  CHECK(pretty_type::short_name<NonType<0>>() == "NonType");
-  CHECK(pretty_type::short_name<NonType<-3>>() == "NonType");
-  CHECK(pretty_type::short_name<NonTypeNonType<3, 3>>() == "NonTypeNonType");
-  CHECK(pretty_type::short_name<NonTypeNonType<3, 0>>() == "NonTypeNonType");
-  CHECK(pretty_type::short_name<NonTypeNonType<3, -3>>() == "NonTypeNonType");
-  CHECK(pretty_type::short_name<NonTypeNonType<0, 3>>() == "NonTypeNonType");
-  CHECK(pretty_type::short_name<NonTypeNonType<0, 0>>() == "NonTypeNonType");
-  CHECK(pretty_type::short_name<NonTypeNonType<0, -3>>() == "NonTypeNonType");
-  CHECK(pretty_type::short_name<NonTypeNonType<-3, 3>>() == "NonTypeNonType");
-  CHECK(pretty_type::short_name<NonTypeNonType<-3, 0>>() == "NonTypeNonType");
-  CHECK(pretty_type::short_name<NonTypeNonType<-3, -3>>() == "NonTypeNonType");
-  CHECK(pretty_type::short_name<TypeNonType<int, 3>>() == "TypeNonType");
-  CHECK(pretty_type::short_name<TypeNonType<Global, 3>>() == "TypeNonType");
-  CHECK(pretty_type::short_name<TypeNonType<TestType, 3>>() == "TypeNonType");
-  CHECK(pretty_type::short_name<TypeNonType<Special, 3>>() == "TypeNonType");
-  CHECK(pretty_type::short_name<TypeNonType<int, 0>>() == "TypeNonType");
-  CHECK(pretty_type::short_name<TypeNonType<Global, 0>>() == "TypeNonType");
-  CHECK(pretty_type::short_name<TypeNonType<TestType, 0>>() == "TypeNonType");
-  CHECK(pretty_type::short_name<TypeNonType<Special, 0>>() == "TypeNonType");
-  CHECK(pretty_type::short_name<TypeNonType<int, -3>>() == "TypeNonType");
-  CHECK(pretty_type::short_name<TypeNonType<Global, -3>>() == "TypeNonType");
-  CHECK(pretty_type::short_name<TypeNonType<TestType, -3>>() == "TypeNonType");
-  CHECK(pretty_type::short_name<TypeNonType<Special, -3>>() == "TypeNonType");
-  CHECK(pretty_type::short_name<NonTypeType<3, int>>() == "NonTypeType");
-  CHECK(pretty_type::short_name<NonTypeType<3, Global>>() == "NonTypeType");
-  CHECK(pretty_type::short_name<NonTypeType<3, TestType>>() == "NonTypeType");
-  CHECK(pretty_type::short_name<NonTypeType<3, Special>>() == "NonTypeType");
-  CHECK(pretty_type::short_name<NonTypeType<0, int>>() == "NonTypeType");
-  CHECK(pretty_type::short_name<NonTypeType<0, Global>>() == "NonTypeType");
-  CHECK(pretty_type::short_name<NonTypeType<0, TestType>>() == "NonTypeType");
-  CHECK(pretty_type::short_name<NonTypeType<0, Special>>() == "NonTypeType");
-  CHECK(pretty_type::short_name<NonTypeType<-3, int>>() == "NonTypeType");
-  CHECK(pretty_type::short_name<NonTypeType<-3, Global>>() == "NonTypeType");
-  CHECK(pretty_type::short_name<NonTypeType<-3, TestType>>() == "NonTypeType");
-  CHECK(pretty_type::short_name<NonTypeType<-3, Special>>() == "NonTypeType");
+  CHECK(NameFunc::template name<NonType<3>>() == "NonType");
+  CHECK(NameFunc::template name<NonType<0>>() == "NonType");
+  CHECK(NameFunc::template name<NonType<-3>>() == "NonType");
+  CHECK(NameFunc::template name<NonTypeNonType<3, 3>>() == "NonTypeNonType");
+  CHECK(NameFunc::template name<NonTypeNonType<3, 0>>() == "NonTypeNonType");
+  CHECK(NameFunc::template name<NonTypeNonType<3, -3>>() == "NonTypeNonType");
+  CHECK(NameFunc::template name<NonTypeNonType<0, 3>>() == "NonTypeNonType");
+  CHECK(NameFunc::template name<NonTypeNonType<0, 0>>() == "NonTypeNonType");
+  CHECK(NameFunc::template name<NonTypeNonType<0, -3>>() == "NonTypeNonType");
+  CHECK(NameFunc::template name<NonTypeNonType<-3, 3>>() == "NonTypeNonType");
+  CHECK(NameFunc::template name<NonTypeNonType<-3, 0>>() == "NonTypeNonType");
+  CHECK(NameFunc::template name<NonTypeNonType<-3, -3>>() == "NonTypeNonType");
+  CHECK(NameFunc::template name<TypeNonType<int, 3>>() == "TypeNonType");
+  CHECK(NameFunc::template name<TypeNonType<Global, 3>>() == "TypeNonType");
+  CHECK(NameFunc::template name<TypeNonType<TestType, 3>>() == "TypeNonType");
+  CHECK(NameFunc::template name<TypeNonType<Special, 3>>() == "TypeNonType");
+  CHECK(NameFunc::template name<TypeNonType<int, 0>>() == "TypeNonType");
+  CHECK(NameFunc::template name<TypeNonType<Global, 0>>() == "TypeNonType");
+  CHECK(NameFunc::template name<TypeNonType<TestType, 0>>() == "TypeNonType");
+  CHECK(NameFunc::template name<TypeNonType<Special, 0>>() == "TypeNonType");
+  CHECK(NameFunc::template name<TypeNonType<int, -3>>() == "TypeNonType");
+  CHECK(NameFunc::template name<TypeNonType<Global, -3>>() == "TypeNonType");
+  CHECK(NameFunc::template name<TypeNonType<TestType, -3>>() == "TypeNonType");
+  CHECK(NameFunc::template name<TypeNonType<Special, -3>>() == "TypeNonType");
+  CHECK(NameFunc::template name<NonTypeType<3, int>>() == "NonTypeType");
+  CHECK(NameFunc::template name<NonTypeType<3, Global>>() == "NonTypeType");
+  CHECK(NameFunc::template name<NonTypeType<3, TestType>>() == "NonTypeType");
+  CHECK(NameFunc::template name<NonTypeType<3, Special>>() == "NonTypeType");
+  CHECK(NameFunc::template name<NonTypeType<0, int>>() == "NonTypeType");
+  CHECK(NameFunc::template name<NonTypeType<0, Global>>() == "NonTypeType");
+  CHECK(NameFunc::template name<NonTypeType<0, TestType>>() == "NonTypeType");
+  CHECK(NameFunc::template name<NonTypeType<0, Special>>() == "NonTypeType");
+  CHECK(NameFunc::template name<NonTypeType<-3, int>>() == "NonTypeType");
+  CHECK(NameFunc::template name<NonTypeType<-3, Global>>() == "NonTypeType");
+  CHECK(NameFunc::template name<NonTypeType<-3, TestType>>() == "NonTypeType");
+  CHECK(NameFunc::template name<NonTypeType<-3, Special>>() == "NonTypeType");
 
   // nullptr-related things
-  CHECK(pretty_type::short_name<Template<std::nullptr_t>>() == "Template");
-  CHECK(pretty_type::short_name<Template2<std::nullptr_t, std::nullptr_t>>() ==
+  CHECK(NameFunc::template name<Template<std::nullptr_t>>() == "Template");
+  CHECK(NameFunc::template name<Template2<std::nullptr_t, std::nullptr_t>>() ==
         "Template2");
-  CHECK(pretty_type::short_name<Template2<int, std::nullptr_t>>() ==
+  CHECK(NameFunc::template name<Template2<int, std::nullptr_t>>() ==
         "Template2");
-  CHECK(pretty_type::short_name<Template2<Global, std::nullptr_t>>() ==
+  CHECK(NameFunc::template name<Template2<Global, std::nullptr_t>>() ==
         "Template2");
-  CHECK(pretty_type::short_name<Template2<TestType, std::nullptr_t>>() ==
+  CHECK(NameFunc::template name<Template2<TestType, std::nullptr_t>>() ==
         "Template2");
-  CHECK(pretty_type::short_name<Template2<Special, std::nullptr_t>>() ==
+  CHECK(NameFunc::template name<Template2<Special, std::nullptr_t>>() ==
         "Template2");
-  CHECK(pretty_type::short_name<Template2<std::nullptr_t, int>>() ==
+  CHECK(NameFunc::template name<Template2<std::nullptr_t, int>>() ==
         "Template2");
-  CHECK(pretty_type::short_name<Template2<std::nullptr_t, Global>>() ==
+  CHECK(NameFunc::template name<Template2<std::nullptr_t, Global>>() ==
         "Template2");
-  CHECK(pretty_type::short_name<Template2<std::nullptr_t, TestType>>() ==
+  CHECK(NameFunc::template name<Template2<std::nullptr_t, TestType>>() ==
         "Template2");
-  CHECK(pretty_type::short_name<Template2<std::nullptr_t, Special>>() ==
+  CHECK(NameFunc::template name<Template2<std::nullptr_t, Special>>() ==
         "Template2");
-  CHECK(pretty_type::short_name<NullptrTemplate<nullptr>>() ==
+  CHECK(NameFunc::template name<NullptrTemplate<nullptr>>() ==
         "NullptrTemplate");
 
   // Enum non-type template parameters
-  CHECK(pretty_type::short_name<
+  CHECK(NameFunc::template name<
             GlobalEnumTemplate<Test_PrettyType_Enum::Zero>>() ==
         "GlobalEnumTemplate");
-  CHECK(pretty_type::short_name<
+  CHECK(NameFunc::template name<
             GlobalEnumTemplate<Test_PrettyType_Enum::One>>() ==
         "GlobalEnumTemplate");
-  CHECK(pretty_type::short_name<
+  CHECK(NameFunc::template name<
             Template2<GlobalEnumTemplate<Test_PrettyType_Enum::One>,
                       GlobalEnumTemplate<Test_PrettyType_Enum::Two>>>() ==
         "Template2");
-  CHECK(pretty_type::short_name<LocalEnumTemplate<LocalEnum::Zero>>() ==
+  CHECK(NameFunc::template name<LocalEnumTemplate<LocalEnum::Zero>>() ==
         "LocalEnumTemplate");
-  CHECK(pretty_type::short_name<LocalEnumTemplate<LocalEnum::One>>() ==
+  CHECK(NameFunc::template name<LocalEnumTemplate<LocalEnum::One>>() ==
         "LocalEnumTemplate");
   CHECK(
-      pretty_type::short_name<Template2<LocalEnumTemplate<LocalEnum::One>,
+      NameFunc::template name<Template2<LocalEnumTemplate<LocalEnum::One>,
                                         LocalEnumTemplate<LocalEnum::Two>>>() ==
       "Template2");
-  CHECK(pretty_type::short_name<LocalEnumTemplate<LocalEnum::Negative>>() ==
+  CHECK(NameFunc::template name<LocalEnumTemplate<LocalEnum::Negative>>() ==
         "LocalEnumTemplate");
 
   // Complicated Test
-  CHECK(pretty_type::short_name<OuterTemplate<
+  CHECK(NameFunc::template name<OuterTemplate<
             Template2<OuterTemplate<Global>::InnerTemplate<TestType>,
                       OuterTemplate<Global>::InnerTemplate<TestType>>>::
                                     InnerTemplate<NonTypeType<1, Global>>>() ==
         "InnerTemplate");
 
   // Long test
-  CHECK(pretty_type::short_name<tmpl::range<int, 0, 1000>>() == "list");
+  CHECK(NameFunc::template name<tmpl::range<int, 0, 1000>>() == "list");
 }
+
+SPECTRE_TEST_CASE("Unit.Utilities.PrettyType.name_and_short_name",
+                  "[Utilities][Unit]") {
+  test_name_func<ShortName>();
+  // For all these types without a name() member, the results should be
+  // identical to that of pretty_type::short_name()
+  test_name_func<Name>();
+
+  CHECK(NonTemplateWithName::name() == "UniqueNonTemplateWithName");
+  CHECK(TemplateWithName<int>::name() == "UniqueTemplateWithName");
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

I've been finding myself using `Options::name<T>()` more and more outside of the context of options now that more structs have a `name()` member. This PR promotes `Options::name<T>()` to the `pretty_type::name<T>()` utility.

Also, some uses of `pretty_type::short_name<T>()` have been replaced with `pretty_type::name` where a struct might want to use it's `name()` member over the name of the struct itself.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
