### PR TITLE
Make element_logical_coordinates deterministic

### DIFF
--- a/src/Domain/ElementLogicalCoordinates.hpp
+++ b/src/Domain/ElementLogicalCoordinates.hpp
@@ -82,9 +82,32 @@ struct ElementLogicalCoordHolder {
 /// `ElementLogicalCoordHolder`s.
 /// It is expected that only a subset of the points will be found
 /// in the given `Element`s.
-/// If a point is on a shared boundary of two or more `Element`s, it
-/// will be returned only once, and will be considered to belong to
-/// the first `Element` in the list of `ElementId`s.
+/// Boundary points: If a point is on the boundary of an Element, it is
+/// considered contained in that Element only if it is on the lower bound
+/// of the Element, or if it is on the upper bound of the element and that
+/// upper bound coincides with the upper bound of the containing Block.
+/// This means that each boundary point is contained in one and only one
+/// Element.  We assume that the input block_coord_holders associates
+/// a point on a Block boundary with only a single Block, the one with
+/// the smaller BlockId, which is always the lower-bounding Block.
+///
+/// \code
+///  <---    Block 0   ---> <---   Block 1   --->
+///  |          |          |          |          |
+/// P_0   E0   P_1   E1   P_2   E2   P_3   E3   P_4
+///  |          |          |          |          |
+///
+/// For example, the above 1D diagram shows four Elements labeled E0
+/// through E3, and five boundary points labeled P_0 through P_4 (where
+/// P_0 and P_4 are external boundaries).  There are two Blocks.  This
+/// algorithm assigns each boundary point to one and only one Element as
+/// follows:
+/// P_0 -> E0
+/// P_1 -> E1
+/// P_2 -> E1 (Note: block_coord_holders includes P_2 only in Block 0)
+/// P_3 -> E3
+/// P_4 -> E3
+/// \endcode
 template <size_t Dim>
 auto element_logical_coordinates(
     const std::vector<ElementId<Dim>>& element_ids,


### PR DESCRIPTION
## Proposed changes

Changes element_logical_coordinates so that it will return the same output irregardless of the ordering of the input vector of ElementIds

For ease of review, I broke this into 4 commits which I will squash
- The first modifies one of the existing tests, but keeps the current behavior, the test case should always pass
- The second commit shuffles the input ElementIds which will randomly break the modified test.  The test case will randomly pass or fail
- The third commit adds a new test that will always fail (unless there is a very unlikely random shuffle of a large container that preserves the relative ordering of a large number of points on element boundaries).
- The fourth commit changes the behavior of element_logical_coordinates (which changes the expected values for one target point of the modified test); the test case should always pass.

See further discussion below...


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

This should eliminate random noise in iterations of the apparent horizon finder arising from a random Element being selected to interpolate to a point on the boundary of more than one Element.  

Previously the algorithm returned the first element in the list that shared the boundary point.  Now it selects an Element only if a boundary point is on the lower side of the element or on the boundary of its containing Block in all dimensions that the target point is on the boundary.  In other words, previously an Element was said to contain the point x if x was in the interval [x_l, x_u] where x_l and x_u are the lower and upper bounds of the BlockLogical coordinate frame.  Now, the Element will not contain the point if x = x_u unless x_u = 1.0 (which is on the boundary of the Block).  

Note that it is not the responsibility of this function to deal with choosing between elements on block boundaries (the input block_coord_holders should have associated such a point with the Block with the lowest BlockId

Note that with the previous behavior, if multiple Elements sharing a target boundary point were on different nodes (or maybe even cores) multiple Elements will provide data for the target point.  With the new behavior, each target point should only be claimed by a single Element.  This may allow simplifying some logic in the horizon finder.

Note the added test assumes all Elements are on the same refinement levels within a Block.  I will add a test for a randomly refined Block in a future commit or PR.


