### PR TITLE
Switch sign in AH boundary condition spin term

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -376,6 +376,12 @@ eprint = {https://doi.org/10.1137/0916035}
     year = "2012"
 }
 
+@book{Carroll,
+  author   = {Sean M. Carroll},
+  title    = {Spacetime and Geometry},
+  subtitle = {An Introduction to General Relativity}
+}
+
 @article{Casoni2012,
   author  = {Casoni, E. and Peraire, J. and Huerta, A.},
   title   = {One-dimensional shock-capturing for high-order discontinuous

--- a/src/Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.cpp
+++ b/src/Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.cpp
@@ -276,7 +276,7 @@ void apparent_horizon_impl(
   // At this point we're done with `beta_orthogonal`, so we can re-purpose the
   // memory buffer.
   for (LeviCivitaIterator<3> it; it; ++it) {
-    shift_excess->get(it[0]) +=
+    shift_excess->get(it[0]) -=
         it.sign() * gsl::at(rotation, it[1]) * x.get(it[2]);
   }
 

--- a/src/Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.hpp
+++ b/src/Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.hpp
@@ -49,7 +49,7 @@ namespace Xcts::BoundaryConditions {
  * \\
  * \label{eq:ah_beta}
  * \beta_\mathrm{excess}^i &= \frac{\alpha}{\psi^2}\bar{s}^i
- * + \epsilon_{ijk}\Omega^j x^k
+ * - \epsilon_{ijk}\Omega_r^j x^k
  * \f}
  *
  * following section 7.2 of \cite Pfeiffer2005zm, section 12.3.2 of
@@ -61,13 +61,22 @@ namespace Xcts::BoundaryConditions {
  * covariant derivative w.r.t. to the conformal metric \f$\bar{\gamma}_{ij}\f$.
  * Note that e.g. in \cite Varma2018sqd Eq. (16) appears the surface-normal
  * \f$s^i\f$, not the _conformal_ surface normal \f$\bar{s}^i = \psi^2 s^i\f$.
+ * $\epsilon_{ijk}$ is the flat-space Levi-Civita symbol.
+ *
+ * \par Spin
  * To incur a spin on the apparent horizon we can freely choose the rotational
- * parameters \f$\boldsymbol{\Omega}\f$. Note that for a Kerr solution with
- * dimensionless spin \f$\boldsymbol{\chi}\f$ the rotational parameters at the
- * outer horizon are \f$\boldsymbol{\Omega} =
- * -\frac{\boldsymbol{\chi}}{2r_+}\f$, where \f$r_+ / M = 1 + \sqrt{1 -
- * \chi^2}\f$ (see e.g. Eq. (8) in \cite Ossokine2015yla). \f$\epsilon_{ijk}\f$
- * is the flat-space Levi-Civita symbol.
+ * parameters $\boldsymbol{\Omega_r}$. A choice for the rotational parameters
+ * that comes close to a Kerr solution with dimensionless spin
+ * $\boldsymbol{\chi}$, when the excision surface is at the outer horizon with
+ * constant Boyer-Lindquist radius $r_+ / M = 1 + \sqrt{1 - \chi^2}$, are the
+ * horizon angular velocities $\boldsymbol{\Omega}^H =
+ * \frac{\boldsymbol{\chi}}{2r_+}$ (see e.g. Eq. (6.92) in \cite Carroll and
+ * note that $r_+^2 + a^2 = 2M r_+$). However, this choice of rotational
+ * parameters does not reproduce the Kerr solution exactly because the excision
+ * surface is not a coordinate sphere.
+ * The sign of the spin term was chosen so it is consistent with the Kerr
+ * horizon angular velocities, which also corresponds to Eq. (20) in
+ * \cite Varma2018sqd .
  *
  * Note that the quasi-equilibrium conditions don't restrict the boundary
  * condition for the lapse. The choice for the lapse boundary condition is made

--- a/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.py
+++ b/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.py
@@ -135,7 +135,7 @@ def shift_excess(conformal_factor, lapse_times_conformal_factor,
                                              conformal_unit_normal)
     shift_orthogonal = lapse_times_conformal_factor / conformal_factor**3
     shift_parallel = np.cross(spin, x)
-    return (shift_orthogonal * conformal_unit_normal_raised + shift_parallel -
+    return (shift_orthogonal * conformal_unit_normal_raised - shift_parallel -
             shift_background)
 
 

--- a/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/Test_ApparentHorizon.cpp
+++ b/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/Test_ApparentHorizon.cpp
@@ -402,7 +402,7 @@ void test_consistency_with_kerr(const bool compute_expansion) {
   CAPTURE(horizon_kerrschild_radius);
   // Eq. (8) in https://arxiv.org/abs/1506.01689
   std::array<double, 3> rotation =
-      -0.5 * dimensionless_spin / horizon_kerrschild_radius;
+      0.5 * dimensionless_spin / horizon_kerrschild_radius;
   CAPTURE(rotation);
   const KerrSchild solution{mass, dimensionless_spin, {{0., 0., 0.}}};
   const ApparentHorizon<Xcts::Geometry::Curved> kerr_horizon{


### PR DESCRIPTION
## Proposed changes

I believe this is the sign convention chosen in SpEC and in https://arxiv.org/abs/1808.08228, and is consistent with the Kerr horizon angular velocity (see unit test).

Reviewers: please check that I haven't messed this up.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
