### PR TITLE
Add Ricci Scalar to GeneralRelativity

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/Ricci.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Ricci.cpp
@@ -50,6 +50,43 @@ tnsr::aa<DataType, SpatialDim, Frame, Index> ricci_tensor(
                d_christoffel_2nd_kind);
   return result;
 }
+
+template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
+void ricci_scalar(
+    const gsl::not_null<Scalar<DataType>*> ricci_scalar_result,
+    const tnsr::aa<DataType, SpatialDim, Frame, Index>& ricci_tensor,
+    const tnsr::AA<DataType, SpatialDim, Frame, Index>& inverse_metric) {
+  destructive_resize_components(ricci_scalar_result,
+                                get_size(get<0, 0>(inverse_metric)));
+  *ricci_scalar_result =
+      make_with_value<Scalar<DataType>>(get<0, 0>(inverse_metric), 0.0);
+
+  const auto dimensionality = index_dim<0>(ricci_tensor);
+
+  auto ricci_up_down = make_with_value<tnsr::Ab<DataType, SpatialDim, Frame>>(
+      get<0, 0>(inverse_metric), 0.0);
+  for (size_t i = 0; i < dimensionality; ++i) {
+    for (size_t j = 0; j < dimensionality; ++j) {
+      for (size_t k = 0; k < dimensionality; ++k) {
+        ricci_up_down.get(j, k) +=
+            ricci_tensor.get(i, k) * inverse_metric.get(i, j);
+      }
+    }
+  }
+  for (size_t j = 0; j < dimensionality; ++j) {
+    get(*ricci_scalar_result) += ricci_up_down.get(j, j);
+  }
+}
+
+template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
+Scalar<DataType> ricci_scalar(
+    const tnsr::aa<DataType, SpatialDim, Frame, Index>& ricci_tensor,
+    const tnsr::AA<DataType, SpatialDim, Frame, Index>& inverse_metric) {
+  Scalar<DataType> ricci_scalar_result{get<0, 0>(inverse_metric)};
+  ricci_scalar(make_not_null(&ricci_scalar_result), ricci_tensor,
+               inverse_metric);
+  return ricci_scalar_result;
+}
 } // namespace gr
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
@@ -71,7 +108,18 @@ tnsr::aa<DataType, SpatialDim, Frame, Index> ricci_tensor(
       const tnsr::Abb<DTYPE(data), DIM(data), FRAME(data), INDEXTYPE(data)>&  \
           christoffel_2nd_kind,                                               \
       const tnsr::aBcc<DTYPE(data), DIM(data), FRAME(data), INDEXTYPE(data)>& \
-          d_christoffel_2nd_kind);
+          d_christoffel_2nd_kind);                                            \
+  template Scalar<DTYPE(data)> gr::ricci_scalar(                              \
+      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data), INDEXTYPE(data)>&   \
+          ricci_tensor,                                                       \
+      const tnsr::AA<DTYPE(data), DIM(data), FRAME(data), INDEXTYPE(data)>&   \
+          inverse_metric);                                                    \
+  template void gr::ricci_scalar(                                             \
+      const gsl::not_null<Scalar<DTYPE(data)>*> ricci_scalar_result,          \
+      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data), INDEXTYPE(data)>&   \
+          ricci_tensor,                                                       \
+      const tnsr::AA<DTYPE(data), DIM(data), FRAME(data), INDEXTYPE(data)>&   \
+          inverse_metric);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
                         (Frame::Grid, Frame::Inertial),

--- a/src/PointwiseFunctions/GeneralRelativity/Ricci.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Ricci.hpp
@@ -94,6 +94,10 @@ struct SpatialRicciCompute : SpatialRicci<SpatialDim, Frame, DataType>,
   using base = SpatialRicci<SpatialDim, Frame, DataType>;
 };
 
+/// Computes the patial ricci scalar using the spatial ricci tensor and the
+/// inverse spatial metric.
+///
+/// Can be retrieved using 'gr::Tags::SpatialRicciScalar'
 template <size_t SpatialDim, typename Frame, typename DataType>
 struct SpatialRicciScalarCompute : SpatialRicciScalar<DataType>,
                                    db::ComputeTag {

--- a/src/PointwiseFunctions/GeneralRelativity/Ricci.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Ricci.hpp
@@ -46,6 +46,29 @@ tnsr::aa<DataType, SpatialDim, Frame, Index> ricci_tensor(
         d_christoffel_2nd_kind);
 /// @}
 
+/// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes the Ricci Scalar from the (spatial or spacetime) Ricci Tensor
+ * and inverse metricss.
+ *
+ * \details Computes Ricci scalar using the inverse metric (spatial or
+ * spacetime) and Ricci tensor \f$R = \gamma^{ab}R_{ab}\f$
+ *
+ *
+ */
+template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
+void ricci_scalar(
+    const gsl::not_null<Scalar<DataType>*> ricci_scalar_result,
+    const tnsr::aa<DataType, SpatialDim, Frame, Index>& ricci_tensor,
+    const tnsr::AA<DataType, SpatialDim, Frame, Index>& inverse_metric);
+
+template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
+Scalar<DataType> ricci_scalar(
+    const tnsr::aa<DataType, SpatialDim, Frame, Index>& ricci_tensor,
+    const tnsr::AA<DataType, SpatialDim, Frame, Index>& inverse_metric);
+/// @}
+
 namespace Tags {
 /// Compute item for spatial Ricci tensor \f$R_{ij}\f$
 /// computed from SpatialChristoffelSecondKind and its spatial derivatives.
@@ -69,6 +92,28 @@ struct SpatialRicciCompute : SpatialRicci<SpatialDim, Frame, DataType>,
       &ricci_tensor<SpatialDim, Frame, IndexType::Spatial, DataType>);
 
   using base = SpatialRicci<SpatialDim, Frame, DataType>;
+};
+
+/// Computes the patial ricci scalar using the spatial ricci tensor and the
+/// inverse spatial metric.
+///
+/// Can be retrieved using 'gr::Tags::SpatialRicciScalar'
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct SpatialRicciScalarCompute : SpatialRicciScalar<DataType>,
+                                   db::ComputeTag {
+  using argument_tags =
+      tmpl::list<gr::Tags::SpatialRicci<SpatialDim, Frame, DataType>,
+                 gr::Tags::InverseSpatialMetric<SpatialDim, Frame, DataType>>;
+
+  using return_type = Scalar<DataType>;
+
+  static constexpr auto function =
+      static_cast<void (*)(gsl::not_null<Scalar<DataType>*>,
+                           const tnsr::ii<DataType, SpatialDim, Frame>&,
+                           const tnsr::II<DataType, SpatialDim, Frame>&)>(
+          &ricci_scalar<SpatialDim, Frame, IndexType::Spatial, DataType>);
+
+  using base = SpatialRicciScalar<DataType>;
 };
 }  // namespace Tags
 } // namespace gr

--- a/src/PointwiseFunctions/GeneralRelativity/Ricci.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Ricci.hpp
@@ -46,6 +46,29 @@ tnsr::aa<DataType, SpatialDim, Frame, Index> ricci_tensor(
         d_christoffel_2nd_kind);
 /// @}
 
+/// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes the Ricci Scalar from the (spatial or spacetime) Ricci Tensor
+ * and inverse metricss.
+ *
+ * \details Computes Ricci scalar using the inverse metric (spatial or
+ * spacetime) and Ricci tensor \f$R = \gamma^{ab}R_{ab}\f
+ *
+ *
+ */
+template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
+void ricci_scalar(
+    const gsl::not_null<Scalar<DataType>*> ricci_scalar_result,
+    const tnsr::aa<DataType, SpatialDim, Frame, Index>& ricci_tensor,
+    const tnsr::AA<DataType, SpatialDim, Frame, Index>& inverse_metric);
+
+template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
+Scalar<DataType> ricci_scalar(
+    const tnsr::aa<DataType, SpatialDim, Frame, Index>& ricci_tensor,
+    const tnsr::AA<DataType, SpatialDim, Frame, Index>& inverse_metric);
+/// @}
+
 namespace Tags {
 /// Compute item for spatial Ricci tensor \f$R_{ij}\f$
 /// computed from SpatialChristoffelSecondKind and its spatial derivatives.
@@ -69,6 +92,24 @@ struct SpatialRicciCompute : SpatialRicci<SpatialDim, Frame, DataType>,
       &ricci_tensor<SpatialDim, Frame, IndexType::Spatial, DataType>);
 
   using base = SpatialRicci<SpatialDim, Frame, DataType>;
+};
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct SpatialRicciScalarCompute : SpatialRicciScalar<DataType>,
+                                   db::ComputeTag {
+  using argument_tags =
+      tmpl::list<gr::Tags::SpatialRicci<SpatialDim, Frame, DataType>,
+                 gr::Tags::InverseSpatialMetric<SpatialDim, Frame, DataType>>;
+
+  using return_type = Scalar<DataType>;
+
+  static constexpr auto function =
+      static_cast<void (*)(gsl::not_null<Scalar<DataType>*>,
+                           const tnsr::ii<DataType, SpatialDim, Frame>&,
+                           const tnsr::II<DataType, SpatialDim, Frame>&)>(
+          &ricci_scalar<SpatialDim, Frame, IndexType::Spatial, DataType>);
+
+  using base = SpatialRicciScalar<DataType>;
 };
 }  // namespace Tags
 } // namespace gr

--- a/src/PointwiseFunctions/GeneralRelativity/Ricci.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Ricci.hpp
@@ -53,7 +53,7 @@ tnsr::aa<DataType, SpatialDim, Frame, Index> ricci_tensor(
  * and inverse metricss.
  *
  * \details Computes Ricci scalar using the inverse metric (spatial or
- * spacetime) and Ricci tensor \f$R = \gamma^{ab}R_{ab}\f
+ * spacetime) and Ricci tensor \f$R = \gamma^{ab}R_{ab}\f$
  *
  *
  */

--- a/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
@@ -145,6 +145,16 @@ struct SpatialRicci : db::SimpleTag {
 };
 
 /*!
+ * \brief Computes the scalar of the spatial Ricci tensor using the inverse
+ * spatial metric \f$R = \gamma^{ij}R_{ij}\f$
+ */
+
+template <typename DataType>
+struct SpatialRicciScalar : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+/*!
  * \brief The energy density \f$E=n_a n_b T^{ab}\f$, where \f$n_a\f$ denotes the
  * normal to the spatial hypersurface
  */

--- a/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
@@ -84,6 +84,8 @@ template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
 struct SpatialRicci;
 template <typename DataType = DataVector>
+struct SpatialRicciScalar;
+template <typename DataType = DataVector>
 struct EnergyDensity;
 template <typename DataType = DataVector>
 struct StressTrace;

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/RicciScalar.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/RicciScalar.py
@@ -1,0 +1,8 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+import numpy as np
+
+
+def ricci_scalar(ricci_tensor, inverse_metric):
+    ricci_up_down = (np.einsum("cb,ac", ricci_tensor, inverse_metric))
+    return np.einsum("aa", ricci_up_down)

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Ricci.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Ricci.cpp
@@ -21,11 +21,14 @@
 // IWYU pragma: no_include <boost/preprocessor/tuple/reverse.hpp>
 
 namespace {
-template <size_t Dim, IndexType TypeOfIndex, typename DataType>
+template <size_t Dim, typename DataType>
 void test_compute_item_in_databox(const DataType& used_for_size) {
   TestHelpers::db::test_compute_tag<
-      gr::Tags::SpatialRicciCompute<3, Frame::Inertial, DataType>>(
+      gr::Tags::SpatialRicciCompute<Dim, Frame::Inertial, DataType>>(
       "SpatialRicci");
+  TestHelpers::db::test_compute_tag<
+      gr::Tags::SpatialRicciScalarCompute<Dim, Frame::Inertial, DataType>>(
+      "SpatialRicciScalar");
 
   MAKE_GENERATOR(generator);
   std::uniform_real_distribution<> distribution(-3.0, 3.0);
@@ -33,27 +36,37 @@ void test_compute_item_in_databox(const DataType& used_for_size) {
   const auto nn_distribution = make_not_null(&distribution);
 
   const auto christoffel_2nd_kind = make_with_random_values<
-      tnsr::Abb<DataType, Dim, Frame::Inertial, TypeOfIndex>>(
+      tnsr::Abb<DataType, Dim, Frame::Inertial, IndexType::Spatial>>(
       nn_generator, nn_distribution, used_for_size);
   const auto d_christoffel_2nd_kind = make_with_random_values<
-      tnsr::aBcc<DataType, Dim, Frame::Inertial, TypeOfIndex>>(
+      tnsr::aBcc<DataType, Dim, Frame::Inertial, IndexType::Spatial>>(
+      nn_generator, nn_distribution, used_for_size);
+  const auto inverse_spatial_metric = make_with_random_values<
+      tnsr::AA<DataType, Dim, Frame::Inertial, IndexType::Spatial>>(
       nn_generator, nn_distribution, used_for_size);
 
   const auto box = db::create<
-      db::AddSimpleTags<gr::Tags::SpatialChristoffelSecondKind<
+      db::AddSimpleTags<
+          gr::Tags::SpatialChristoffelSecondKind<Dim, Frame::Inertial,
+                                                 DataType>,
+          ::Tags::deriv<gr::Tags::SpatialChristoffelSecondKind<
                             Dim, Frame::Inertial, DataType>,
-                        ::Tags::deriv<gr::Tags::SpatialChristoffelSecondKind<
-                                          Dim, Frame::Inertial, DataType>,
-                                      tmpl::size_t<Dim>, Frame::Inertial>>,
+                        tmpl::size_t<Dim>, Frame::Inertial>,
+          gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataType>>,
       db::AddComputeTags<
-          gr::Tags::SpatialRicciCompute<Dim, Frame::Inertial, DataType>>>(
-      christoffel_2nd_kind, d_christoffel_2nd_kind);
+          gr::Tags::SpatialRicciCompute<Dim, Frame::Inertial, DataType>,
+          gr::Tags::SpatialRicciScalarCompute<Dim, Frame::Inertial, DataType>>>(
+      christoffel_2nd_kind, d_christoffel_2nd_kind, inverse_spatial_metric);
 
   const auto expected =
       gr::ricci_tensor(christoffel_2nd_kind, d_christoffel_2nd_kind);
+  const auto expected_scalar =
+      gr::ricci_scalar(expected, inverse_spatial_metric);
   CHECK_ITERABLE_APPROX(
       (db::get<gr::Tags::SpatialRicci<Dim, Frame::Inertial, DataType>>(box)),
       expected);
+  CHECK_ITERABLE_APPROX((db::get<gr::Tags::SpatialRicciScalar<DataType>>(box)),
+                        expected_scalar);
 }
 
 template <size_t Dim, IndexType TypeOfIndex, typename DataType>
@@ -64,6 +77,16 @@ void test_ricci(const DataType& used_for_size) {
           const tnsr::aBcc<DataType, Dim, Frame::Inertial, TypeOfIndex>&)>(
           &gr::ricci_tensor<Dim, Frame::Inertial, TypeOfIndex, DataType>),
       "Ricci", "ricci_tensor", {{{-1., 1.}}}, used_for_size);
+}
+
+template <size_t Dim, IndexType TypeOfIndex, typename DataType>
+void test_ricci_scalar(const DataType& used_for_size) {
+  Scalar<DataType> (*f)(
+      const tnsr::aa<DataType, Dim, Frame::Inertial, TypeOfIndex>&,
+      const tnsr::AA<DataType, Dim, Frame::Inertial, TypeOfIndex>&) =
+      &gr::ricci_scalar<Dim, Frame::Inertial, TypeOfIndex, DataType>;
+  pypp::check_with_random_values<1>(f, "RicciScalar", "ricci_scalar",
+                                    {{{-1., 1.}}}, used_for_size);
 }
 }  // namespace
 
@@ -76,6 +99,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.Ricci.",
 
   CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_ricci, (1, 2, 3),
                                     (IndexType::Spatial, IndexType::Spacetime));
-  test_compute_item_in_databox<3, IndexType::Spatial>(d);
-  test_compute_item_in_databox<3, IndexType::Spatial>(dv);
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_ricci_scalar, (1, 2, 3),
+                                    (IndexType::Spatial, IndexType::Spacetime));
+  test_compute_item_in_databox<3>(d);
+  test_compute_item_in_databox<3>(dv);
 }


### PR DESCRIPTION
## Proposed changes

Adds the capability to compute the Ricci scalar from the spatial or spacetime Ricci tensor. 


### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

I only added the tags for the SpatialRicciScalar because currently we only look at the SpatialRicci because the SpacetimeRicci in vacuum is pretty boring. If you'd like me to add a tag for the SpacetimeRicci and SpacetimeRicciScalar, I'd be happy to add it to this pr. Also, the reason I was coding this up is so that in a follow up pr, I can make this observable in BBH and GeneralizedHarmonicBase.
