### PR TITLE
Add RicciScalar to GeneralRelativity

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/Ricci.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Ricci.hpp
@@ -46,6 +46,27 @@ tnsr::aa<DataType, SpatialDim, Frame, Index> ricci_tensor(
         d_christoffel_2nd_kind);
 /// @}
 
+/// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes the Ricci Scalar from the (spatial or spacetime) Ricci Tensor
+ * and inverse metrics.
+ *
+ * \details Computes Ricci scalar using the inverse metric (spatial or
+ * spacetime) and Ricci tensor \f$R = g^{ab}R_{ab}\f$
+ */
+template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
+void ricci_scalar(
+    const gsl::not_null<Scalar<DataType>*> ricci_scalar_result,
+    const tnsr::aa<DataType, SpatialDim, Frame, Index>& ricci_tensor,
+    const tnsr::AA<DataType, SpatialDim, Frame, Index>& inverse_metric);
+
+template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
+Scalar<DataType> ricci_scalar(
+    const tnsr::aa<DataType, SpatialDim, Frame, Index>& ricci_tensor,
+    const tnsr::AA<DataType, SpatialDim, Frame, Index>& inverse_metric);
+/// @}
+
 namespace Tags {
 /// Compute item for spatial Ricci tensor \f$R_{ij}\f$
 /// computed from SpatialChristoffelSecondKind and its spatial derivatives.
@@ -69,6 +90,28 @@ struct SpatialRicciCompute : SpatialRicci<SpatialDim, Frame, DataType>,
       &ricci_tensor<SpatialDim, Frame, IndexType::Spatial, DataType>);
 
   using base = SpatialRicci<SpatialDim, Frame, DataType>;
+};
+
+/// Computes the spatial Ricci scalar using the spatial Ricci tensor and the
+/// inverse spatial metric.
+///
+/// Can be retrieved using `gr::Tags::SpatialRicciScalar`
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct SpatialRicciScalarCompute : SpatialRicciScalar<DataType>,
+                                   db::ComputeTag {
+  using argument_tags =
+      tmpl::list<gr::Tags::SpatialRicci<SpatialDim, Frame, DataType>,
+                 gr::Tags::InverseSpatialMetric<SpatialDim, Frame, DataType>>;
+
+  using return_type = Scalar<DataType>;
+
+  static constexpr auto function =
+      static_cast<void (*)(gsl::not_null<Scalar<DataType>*>,
+                           const tnsr::ii<DataType, SpatialDim, Frame>&,
+                           const tnsr::II<DataType, SpatialDim, Frame>&)>(
+          &ricci_scalar<SpatialDim, Frame, IndexType::Spatial, DataType>);
+
+  using base = SpatialRicciScalar<DataType>;
 };
 }  // namespace Tags
 } // namespace gr

--- a/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
@@ -145,6 +145,14 @@ struct SpatialRicci : db::SimpleTag {
 };
 
 /*!
+ * \brief Simple tag for the spatial Ricci scalar
+ */
+template <typename DataType>
+struct SpatialRicciScalar : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+/*!
  * \brief The energy density \f$E=n_a n_b T^{ab}\f$, where \f$n_a\f$ denotes the
  * normal to the spatial hypersurface
  */

--- a/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
@@ -84,6 +84,8 @@ template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
 struct SpatialRicci;
 template <typename DataType = DataVector>
+struct SpatialRicciScalar;
+template <typename DataType = DataVector>
 struct EnergyDensity;
 template <typename DataType = DataVector>
 struct StressTrace;

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/RicciScalar.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/RicciScalar.py
@@ -1,0 +1,8 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+import numpy as np
+
+
+def ricci_scalar(ricci_tensor, inverse_metric):
+    ricci_up_down = (np.einsum("cb,ac", ricci_tensor, inverse_metric))
+    return np.einsum("aa", ricci_up_down)


### PR DESCRIPTION
## Proposed changes


Adds the capability to compute the Ricci scalar from the spatial or spacetime Ricci tensor.


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments


I only added the tags for the SpatialRicciScalar because currently we only look at the SpatialRicci because the SpacetimeRicci in vacuum is pretty boring. If you'd like me to add a tag for the SpacetimeRicci and SpacetimeRicciScalar, I'd be happy to add it to this pr. Also, the reason I was coding this up is so that in a follow up pr, I can make this observable in BBH and GeneralizedHarmonicBase. (Also if you saw the first one congratulations and Will, I have taken out the bars so people can see this time)