### PR TITLE
Remove repeated calculations in Ccz4::spatial_ricci_tensor

### DIFF
--- a/src/Evolution/Systems/Ccz4/Ricci.cpp
+++ b/src/Evolution/Systems/Ccz4/Ricci.cpp
@@ -15,64 +15,58 @@ namespace Ccz4 {
 template <size_t Dim, typename Frame, typename DataType>
 void spatial_ricci_tensor(
     const gsl::not_null<tnsr::ii<DataType, Dim, Frame>*> result,
-    const gsl::not_null<tnsr::ij<DataType, Dim, Frame>*> buffer,
     const tnsr::Ijj<DataType, Dim, Frame>& christoffel_second_kind,
-    const tnsr::iJkk<DataType, Dim, Frame>& d_conformal_christoffel_second_kind,
+    const tnsr::i<DataType, Dim, Frame>& contracted_christoffel_second_kind,
+    const tnsr::ij<DataType, Dim, Frame>&
+        contracted_d_conformal_christoffel_difference,
     const tnsr::ii<DataType, Dim, Frame>& conformal_spatial_metric,
     const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
     const tnsr::ijj<DataType, Dim, Frame>& field_d,
     const tnsr::iJJ<DataType, Dim, Frame>& field_d_up,
+    const tnsr::I<DataType, Dim, Frame>& contracted_field_d_up,
     const tnsr::i<DataType, Dim, Frame>& field_p,
     const tnsr::ij<DataType, Dim, Frame>& d_field_p) {
   destructive_resize_components(result,
                                 get_size(get<0, 0>(conformal_spatial_metric)));
-  destructive_resize_components(buffer,
-                                get_size(get<0, 0>(conformal_spatial_metric)));
-
-  // Add first terms of \partial_m \Gamma^m_{ij} and
-  // -\partial_j \Gamma^m_{im}
-  ::TensorExpressions::evaluate<ti_i, ti_j>(
-      buffer, d_conformal_christoffel_second_kind(ti_m, ti_M, ti_i, ti_j) -
-                  d_conformal_christoffel_second_kind(ti_j, ti_M, ti_i, ti_m));
 
   TensorExpressions::evaluate<ti_i, ti_j>(
       result,
-      (*buffer)(ti_i, ti_j) +
+      contracted_d_conformal_christoffel_difference(ti_i, ti_j) +
           // Add terms of \partial_m \Gamma^m_{ij} and
           // -\partial_j \Gamma^m_{im} that have a coefficient of 2
-          2.0 * ((field_d_up(ti_m, ti_M, ti_L) *
-                  (conformal_spatial_metric(ti_j, ti_l) * field_p(ti_i) +
-                   conformal_spatial_metric(ti_i, ti_l) * field_p(ti_j) -
-                   conformal_spatial_metric(ti_i, ti_j) * field_p(ti_l))) -
+          2.0 * (contracted_field_d_up(ti_L) *
+                     (conformal_spatial_metric(ti_j, ti_l) * field_p(ti_i) +
+                      conformal_spatial_metric(ti_i, ti_l) * field_p(ti_j) -
+                      conformal_spatial_metric(ti_i, ti_j) * field_p(ti_l)) -
                  inverse_conformal_spatial_metric(ti_M, ti_L) *
                      (field_d(ti_m, ti_j, ti_l) * field_p(ti_i) +
                       field_d(ti_m, ti_i, ti_l) * field_p(ti_j) -
                       field_d(ti_m, ti_i, ti_j) * field_p(ti_l)) -
-                 (field_d_up(ti_j, ti_M, ti_L) *
-                  (conformal_spatial_metric(ti_m, ti_l) * field_p(ti_i) +
-                   conformal_spatial_metric(ti_i, ti_l) * field_p(ti_m) -
-                   conformal_spatial_metric(ti_i, ti_m) * field_p(ti_l))) +
+                 field_d_up(ti_j, ti_M, ti_L) *
+                     (conformal_spatial_metric(ti_m, ti_l) * field_p(ti_i) +
+                      conformal_spatial_metric(ti_i, ti_l) * field_p(ti_m) -
+                      conformal_spatial_metric(ti_i, ti_m) * field_p(ti_l)) +
                  inverse_conformal_spatial_metric(ti_M, ti_L) *
                      (field_d(ti_j, ti_m, ti_l) * field_p(ti_i) +
                       field_d(ti_j, ti_i, ti_l) * field_p(ti_m) -
                       field_d(ti_j, ti_i, ti_m) * field_p(ti_l))) -
           // Add \partial_{(i} P_{j)} type terms
-          0.5 * (inverse_conformal_spatial_metric(ti_M, ti_L) *
-                 (conformal_spatial_metric(ti_j, ti_l) *
-                      (d_field_p(ti_m, ti_i) + d_field_p(ti_i, ti_m)) +
-                  conformal_spatial_metric(ti_i, ti_l) *
-                      (d_field_p(ti_m, ti_j) + d_field_p(ti_j, ti_m)) -
-                  conformal_spatial_metric(ti_i, ti_j) *
-                      (d_field_p(ti_m, ti_l) + d_field_p(ti_l, ti_m)) -
-                  conformal_spatial_metric(ti_m, ti_l) *
-                      (d_field_p(ti_j, ti_i) + d_field_p(ti_i, ti_j)) -
-                  conformal_spatial_metric(ti_i, ti_l) *
-                      (d_field_p(ti_j, ti_m) + d_field_p(ti_m, ti_j)) +
-                  conformal_spatial_metric(ti_i, ti_m) *
-                      (d_field_p(ti_j, ti_l) + d_field_p(ti_l, ti_j)))) +
+          0.5 * inverse_conformal_spatial_metric(ti_M, ti_L) *
+              (conformal_spatial_metric(ti_j, ti_l) *
+                   (d_field_p(ti_m, ti_i) + d_field_p(ti_i, ti_m)) +
+               conformal_spatial_metric(ti_i, ti_l) *
+                   (d_field_p(ti_m, ti_j) + d_field_p(ti_j, ti_m)) -
+               conformal_spatial_metric(ti_i, ti_j) *
+                   (d_field_p(ti_m, ti_l) + d_field_p(ti_l, ti_m)) -
+               conformal_spatial_metric(ti_m, ti_l) *
+                   (d_field_p(ti_j, ti_i) + d_field_p(ti_i, ti_j)) -
+               conformal_spatial_metric(ti_i, ti_l) *
+                   (d_field_p(ti_j, ti_m) + d_field_p(ti_m, ti_j)) +
+               conformal_spatial_metric(ti_i, ti_m) *
+                   (d_field_p(ti_j, ti_l) + d_field_p(ti_l, ti_j))) +
           // Add last two terms for R_{ij}
           christoffel_second_kind(ti_L, ti_i, ti_j) *
-              christoffel_second_kind(ti_M, ti_l, ti_m) -
+              contracted_christoffel_second_kind(ti_l) -
           christoffel_second_kind(ti_L, ti_i, ti_m) *
               christoffel_second_kind(ti_M, ti_l, ti_j));
 }
@@ -80,20 +74,23 @@ void spatial_ricci_tensor(
 template <size_t Dim, typename Frame, typename DataType>
 tnsr::ii<DataType, Dim, Frame> spatial_ricci_tensor(
     const tnsr::Ijj<DataType, Dim, Frame>& christoffel_second_kind,
-    const tnsr::iJkk<DataType, Dim, Frame>& d_conformal_christoffel_second_kind,
+    const tnsr::i<DataType, Dim, Frame>& contracted_christoffel_second_kind,
+    const tnsr::ij<DataType, Dim, Frame>&
+        contracted_d_conformal_christoffel_difference,
     const tnsr::ii<DataType, Dim, Frame>& conformal_spatial_metric,
     const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
     const tnsr::ijj<DataType, Dim, Frame>& field_d,
     const tnsr::iJJ<DataType, Dim, Frame>& field_d_up,
+    const tnsr::I<DataType, Dim, Frame>& contracted_field_d_up,
     const tnsr::i<DataType, Dim, Frame>& field_p,
     const tnsr::ij<DataType, Dim, Frame>& d_field_p) {
   tnsr::ii<DataType, Dim, Frame> result{};
-  tnsr::ij<DataType, Dim, Frame> buffer{};
-  spatial_ricci_tensor(
-      make_not_null(&result), make_not_null(&buffer), christoffel_second_kind,
-      d_conformal_christoffel_second_kind, conformal_spatial_metric,
-      inverse_conformal_spatial_metric, field_d, field_d_up, field_p,
-      d_field_p);
+  spatial_ricci_tensor(make_not_null(&result), christoffel_second_kind,
+                       contracted_christoffel_second_kind,
+                       contracted_d_conformal_christoffel_difference,
+                       conformal_spatial_metric,
+                       inverse_conformal_spatial_metric, field_d, field_d_up,
+                       contracted_field_d_up, field_p, d_field_p);
   return result;
 }
 }  // namespace Ccz4
@@ -106,32 +103,38 @@ tnsr::ii<DataType, Dim, Frame> spatial_ricci_tensor(
   template void Ccz4::spatial_ricci_tensor(                               \
       const gsl::not_null<tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>*> \
           result,                                                         \
-      const gsl::not_null<tnsr::ij<DTYPE(data), DIM(data), FRAME(data)>*> \
-          buffer,                                                         \
       const tnsr::Ijj<DTYPE(data), DIM(data), FRAME(data)>&               \
           christoffel_second_kind,                                        \
-      const tnsr::iJkk<DTYPE(data), DIM(data), FRAME(data)>&              \
-          d_conformal_christoffel_second_kind,                            \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>&                 \
+          contracted_christoffel_second_kind,                             \
+      const tnsr::ij<DTYPE(data), DIM(data), FRAME(data)>&                \
+          contracted_d_conformal_christoffel_difference,                  \
       const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&                \
           conformal_spatial_metric,                                       \
       const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                \
           inverse_conformal_spatial_metric,                               \
       const tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>& field_d,      \
       const tnsr::iJJ<DTYPE(data), DIM(data), FRAME(data)>& field_d_up,   \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>&                 \
+          contracted_field_d_up,                                          \
       const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>& field_p,        \
       const tnsr::ij<DTYPE(data), DIM(data), FRAME(data)>& d_field_p);    \
   template tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>                  \
   Ccz4::spatial_ricci_tensor(                                             \
       const tnsr::Ijj<DTYPE(data), DIM(data), FRAME(data)>&               \
           christoffel_second_kind,                                        \
-      const tnsr::iJkk<DTYPE(data), DIM(data), FRAME(data)>&              \
-          d_conformal_christoffel_second_kind,                            \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>&                 \
+          contracted_christoffel_second_kind,                             \
+      const tnsr::ij<DTYPE(data), DIM(data), FRAME(data)>&                \
+          contracted_d_conformal_christoffel_difference,                  \
       const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&                \
           conformal_spatial_metric,                                       \
       const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                \
           inverse_conformal_spatial_metric,                               \
       const tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>& field_d,      \
       const tnsr::iJJ<DTYPE(data), DIM(data), FRAME(data)>& field_d_up,   \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>&                 \
+          contracted_field_d_up,                                          \
       const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>& field_p,        \
       const tnsr::ij<DTYPE(data), DIM(data), FRAME(data)>& d_field_p);
 

--- a/src/Evolution/Systems/Ccz4/Ricci.hpp
+++ b/src/Evolution/Systems/Ccz4/Ricci.hpp
@@ -75,28 +75,39 @@ namespace Ccz4 {
  *       & + \Gamma^l_{ij} \Gamma^m_{lm} - \Gamma^l_{im} \Gamma^m_{lj}
  * \f}
  *
+ * The argument `contracted_christoffel_second_kind` corresponds to the
+ * \f$\Gamma^m_{lm}\f$ term, the argument
+ * `contracted_d_conformal_christoffel_difference` corresponds to the
+ * \f$\partial_m \tilde{\Gamma}^m_{ij} - \partial_j \tilde{\Gamma}^m_{im}\f$
+ * term, and the argument `contracted_field_d_up` corresponds to the
+ * \f$D_m{}^{ml}\f$ term.
  */
 template <size_t Dim, typename Frame, typename DataType>
 void spatial_ricci_tensor(
     const gsl::not_null<tnsr::ii<DataType, Dim, Frame>*> result,
-    const gsl::not_null<tnsr::ij<DataType, Dim, Frame>*> buffer,
     const tnsr::Ijj<DataType, Dim, Frame>& christoffel_second_kind,
-    const tnsr::iJkk<DataType, Dim, Frame>& d_conformal_christoffel_second_kind,
+    const tnsr::i<DataType, Dim, Frame>& contracted_christoffel_second_kind,
+    const tnsr::ij<DataType, Dim, Frame>&
+        contracted_d_conformal_christoffel_difference,
     const tnsr::ii<DataType, Dim, Frame>& conformal_spatial_metric,
     const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
     const tnsr::ijj<DataType, Dim, Frame>& field_d,
     const tnsr::iJJ<DataType, Dim, Frame>& field_d_up,
+    const tnsr::I<DataType, Dim, Frame>& contracted_field_d_up,
     const tnsr::i<DataType, Dim, Frame>& field_p,
     const tnsr::ij<DataType, Dim, Frame>& d_field_p);
 
 template <size_t Dim, typename Frame, typename DataType>
 tnsr::ii<DataType, Dim, Frame> spatial_ricci_tensor(
     const tnsr::Ijj<DataType, Dim, Frame>& christoffel_second_kind,
-    const tnsr::iJkk<DataType, Dim, Frame>& d_conformal_christoffel_second_kind,
+    const tnsr::i<DataType, Dim, Frame>& contracted_christoffel_second_kind,
+    const tnsr::ij<DataType, Dim, Frame>&
+        contracted_d_conformal_christoffel_difference,
     const tnsr::ii<DataType, Dim, Frame>& conformal_spatial_metric,
     const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
     const tnsr::ijj<DataType, Dim, Frame>& field_d,
     const tnsr::iJJ<DataType, Dim, Frame>& field_d_up,
+    const tnsr::I<DataType, Dim, Frame>& contracted_field_d_up,
     const tnsr::i<DataType, Dim, Frame>& field_p,
     const tnsr::ij<DataType, Dim, Frame>& d_field_p);
 /// @}


### PR DESCRIPTION
## Proposed changes

In the `TensorExpression` for the eq of the CCZ4 spatial Ricci tensor, two contraction expressions are recomputed for each LHS index (each i and j). The evaluation of these expressions have been moved out of the larger equation into their own temporary buffers to avoid recomputing them.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
