### PR TITLE
Add function to compute the size of an object

### DIFF
--- a/src/Parallel/Serialize.hpp
+++ b/src/Parallel/Serialize.hpp
@@ -67,3 +67,14 @@ void deserialize(const gsl::not_null<T*> result,
   PUP::fromMem reader(data);
   reader | *result;
 }
+
+/*!
+ * \ingroup ParallelGroup
+ * \brief Returns the size of an object in bytes
+ */
+template <typename T>
+size_t size_of_object_in_bytes(const T& obj) {
+  PUP::sizer sizer;
+  sizer | const_cast<T&>(obj);  // NOLINT
+  return sizer.size();
+}

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -175,6 +175,7 @@ set(LIBRARY_SOURCES
   Test_ParallelComponentHelpers.cpp
   Test_PupStlCpp11.cpp
   Test_PupStlCpp17.cpp
+  Test_Serialize.cpp
   Test_TypeTraits.cpp
   )
 

--- a/tests/Unit/Parallel/Test_Serialize.cpp
+++ b/tests/Unit/Parallel/Test_Serialize.cpp
@@ -1,0 +1,17 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <vector>
+
+#include "Framework/TestHelpers.hpp"
+#include "Parallel/Serialize.hpp"
+
+SPECTRE_TEST_CASE("Unit.Parallel.Serialize", "[Unit][Parallel]") {
+  CHECK(size_of_object_in_bytes(std::array<double, 4>{}) == 4 * sizeof(double));
+  CHECK(
+      size_of_object_in_bytes(std::vector<double>(10)) ==
+      (10 * sizeof(double) + sizeof(decltype(std::vector<double>(10).size()))));
+}


### PR DESCRIPTION
## Proposed changes

Uses Charm++'s serialization framework to compute the size of an object in
bytes. This isn't completely exact, and varies a bit by what you mean with "size
of an object," but it'll give us a good idea of how much memory something is
consuming.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
