### PR TITLE
YlmSpherepack: do interpolation_info sanity check always.

### DIFF
--- a/src/NumericalAlgorithms/SphericalHarmonics/YlmSpherepack.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/YlmSpherepack.cpp
@@ -611,17 +611,17 @@ void YlmSpherepack::interpolate_from_coefs(
     const gsl::not_null<T*> result, const R& spectral_coefs,
     const InterpolationInfo<T>& interpolation_info,
     const size_t spectral_stride, const size_t spectral_offset) const {
+  if (m_max_ != interpolation_info.m_max()) {
+    ERROR("Different m_max for InterpolationInfo ("
+          << interpolation_info.m_max() << ") and YlmSpherepack instance ("
+          << m_max_ << ")");
+  };
+  if (l_max_ != interpolation_info.l_max()) {
+    ERROR("Different l_max for InterpolationInfo ("
+          << interpolation_info.l_max() << ") and YlmSpherepack instance ("
+          << l_max_ << ")");
+  };
   if (storage_.work_interp_alpha.empty()) {
-    if (m_max_ != interpolation_info.m_max()) {
-      ERROR("Different m_max for InterpolationInfo ("
-            << interpolation_info.m_max() << ") and YlmSpherepack instance ("
-            << m_max_ << ")");
-    };
-    if (l_max_ != interpolation_info.l_max()) {
-      ERROR("Different l_max for InterpolationInfo ("
-            << interpolation_info.l_max() << ") and YlmSpherepack instance ("
-            << l_max_ << ")");
-    };
     calculate_interpolation_data();
   }
   const auto& alpha = storage_.work_interp_alpha;


### PR DESCRIPTION
## Proposed changes

Previously the check was done only if calculate_interpolation_data
had never been called, which means that if someone called
interpolate_from_coefs twice and the 2nd time was with a bad
interpolation_info, the check would not have occurred.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
