### PR TITLE
Lint "mutable" keyword and clean up "noexcept" test

### DIFF
--- a/src/DataStructures/DataBox/Item.hpp
+++ b/src/DataStructures/DataBox/Item.hpp
@@ -120,7 +120,9 @@ class Item<Tag, ItemType::Compute> {
   }
 
  private:
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable value_type value_{};
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable bool evaluated_{false};
 };
 

--- a/src/DataStructures/MathWrapper.hpp
+++ b/src/DataStructures/MathWrapper.hpp
@@ -56,6 +56,7 @@ class MathWrapper {
   template <typename U>
   struct Impl<U, true, false> {
     using scalar_type = typename U::value_type;
+    // NOLINTNEXTLINE(spectre-mutable)
     mutable T data;
     Impl(const gsl::not_null<T*> data_in) : data(std::move(*data_in)) {}
   };

--- a/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/SubdomainOperator.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/SubdomainOperator.hpp
@@ -702,30 +702,40 @@ struct SubdomainOperator
 
  private:
   // Memory buffers for repeated operator applications
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable Variables<typename System::auxiliary_fields>
       central_auxiliary_vars_{};
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable Variables<typename System::primal_fluxes> central_primal_fluxes_{};
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable Variables<typename System::auxiliary_fluxes>
       central_auxiliary_fluxes_{};
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable LinearSolver::Schwarz::OverlapMap<
       Dim, Variables<typename System::auxiliary_fields>>
       neighbors_auxiliary_vars_{};
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable LinearSolver::Schwarz::OverlapMap<
       Dim, Variables<typename System::primal_fluxes>>
       neighbors_primal_fluxes_{};
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable LinearSolver::Schwarz::OverlapMap<
       Dim, Variables<typename System::auxiliary_fluxes>>
       neighbors_auxiliary_fluxes_{};
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable LinearSolver::Schwarz::OverlapMap<
       Dim, Variables<typename System::primal_fields>>
       extended_operand_vars_{};
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable LinearSolver::Schwarz::OverlapMap<
       Dim, Variables<typename System::primal_fields>>
       extended_results_{};
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable ::dg::MortarMap<
       Dim, elliptic::dg::MortarData<size_t, typename System::primal_fields,
                                     typename System::primal_fluxes>>
       central_mortar_data_{};
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable LinearSolver::Schwarz::OverlapMap<
       Dim, ::dg::MortarMap<Dim, elliptic::dg::MortarData<
                                     size_t, typename System::primal_fields,

--- a/src/Elliptic/SubdomainPreconditioners/MinusLaplacian.hpp
+++ b/src/Elliptic/SubdomainPreconditioners/MinusLaplacian.hpp
@@ -377,12 +377,15 @@ class MinusLaplacian
   // - The boundary-condition configuration for each tensor component, or an
   //   empty list if the subdomain has no external boundaries, or `std::nullopt`
   //   to signal a clean cache.
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable std::optional<std::vector<BoundaryConditionsSignature>>
       bc_signatures_{};
   // - A clone of the `solver_` for each unique boundary-condition configuration
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable std::unordered_map<BoundaryConditionsSignature, StoredSolverType,
                              boost::hash<BoundaryConditionsSignature>>
       solvers_{};
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable std::unordered_map<
       BoundaryConditionsSignature,
       std::unordered_map<BoundaryId, const BoundaryConditionsBase&,
@@ -397,8 +400,11 @@ class MinusLaplacian
   // subdomain solves because it is cached as a matrix (see
   // LinearSolver::Serial::ExplicitInverse), so we don't need the memory anymore
   // at all.
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable SubdomainOperator subdomain_operator_{};
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable SubdomainData source_{};
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable SubdomainData initial_guess_in_solution_out_{};
 
   // These boundary condition instances can be re-used for all tensor components

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/RobinsonTrautman.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/RobinsonTrautman.hpp
@@ -311,16 +311,21 @@ struct RobinsonTrautman : public SphericalMetricData {
 
   using SphericalMetricData::variables_impl;
  private:
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable std::pair<double, double> step_range_;
 
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable boost::numeric::odeint::dense_output_runge_kutta<
       boost::numeric::odeint::controlled_runge_kutta<
           boost::numeric::odeint::runge_kutta_dopri5<ComplexDataVector>>>
       stepper_;
 
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable Scalar<SpinWeighted<ComplexDataVector, 0>> dense_output_rt_scalar_;
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable Scalar<SpinWeighted<ComplexDataVector, 0>> dense_output_du_rt_scalar_;
   size_t l_max_ = 0;
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable double prepared_time_ = std::numeric_limits<double>::signaling_NaN();
   double tolerance_ = std::numeric_limits<double>::signaling_NaN();
   double start_time_ = std::numeric_limits<double>::signaling_NaN();

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.hpp
@@ -281,6 +281,7 @@ struct WorldtubeData : public PUP::able {
               Tags::Dr<gr::Tags::Lapse<DataVector>>, Tags::News>,
           tmpl::bind<IntermediateCacheTag, tmpl::_1>>>;
 
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable IntermediateCacheTuple intermediate_cache_;
   double extraction_radius_ = std::numeric_limits<double>::quiet_NaN();
 };

--- a/src/Evolution/Systems/Cce/WorldtubeDataManager.hpp
+++ b/src/Evolution/Systems/Cce/WorldtubeDataManager.hpp
@@ -136,16 +136,20 @@ class MetricWorldtubeDataManager : public WorldtubeDataManager {
  private:
   std::unique_ptr<WorldtubeBufferUpdater<cce_metric_input_tags>>
       buffer_updater_;
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable size_t time_span_start_ = 0;
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable size_t time_span_end_ = 0;
   size_t l_max_ = 0;
   bool fix_spec_normalization_ = false;
 
   // These buffers are just kept around to avoid allocations; they're
   // updated every time a time is requested
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable Variables<cce_metric_input_tags> interpolated_coefficients_;
 
   // note: buffers store data in a 'time-varies-fastest' manner
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable Variables<cce_metric_input_tags> coefficients_buffers_;
 
   size_t buffer_depth_ = 0;
@@ -222,15 +226,19 @@ class BondiWorldtubeDataManager : public WorldtubeDataManager {
 
  private:
   std::unique_ptr<WorldtubeBufferUpdater<cce_bondi_input_tags>> buffer_updater_;
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable size_t time_span_start_ = 0;
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable size_t time_span_end_ = 0;
   size_t l_max_ = 0;
 
   // These buffers are just kept around to avoid allocations; they're
   // updated every time a time is requested
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable Variables<cce_bondi_input_tags> interpolated_coefficients_;
 
   // note: buffers store data in an 'time-varies-fastest' manner
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable Variables<cce_bondi_input_tags> coefficients_buffers_;
 
   size_t buffer_depth_ = 0;

--- a/src/IO/H5/File.hpp
+++ b/src/IO/H5/File.hpp
@@ -176,6 +176,7 @@ class H5File {
 
   std::string file_name_;
   hid_t file_id_{-1};
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable std::unique_ptr<h5::Object> current_object_{nullptr};
   std::vector<std::string> h5_groups_;
   /// \endcond HIDDEN_SYMBOLS

--- a/src/IO/Observer/ReductionActions.hpp
+++ b/src/IO/Observer/ReductionActions.hpp
@@ -146,7 +146,7 @@ struct ContributeReductionData {
                   reduction_observers_contributed,
               const std::unordered_map<ObservationKey,
                                        std::unordered_set<ArrayComponentId>>&
-                  observations_registered) mutable {
+                  observations_registered) mutable {  // NOLINT(spectre-mutable)
             ASSERT(observations_registered.find(
                        observation_id.observation_key()) !=
                        observations_registered.end(),

--- a/src/IO/Observer/VolumeActions.hpp
+++ b/src/IO/Observer/VolumeActions.hpp
@@ -77,7 +77,7 @@ struct ContributeVolumeData {
                 contributed_volume_data_ids,
             const std::unordered_map<ObservationKey,
                                      std::unordered_set<ArrayComponentId>>&
-                registered_array_component_ids) mutable {
+                registered_array_component_ids) mutable {  // NOLINT(spectre-mutable)
           const ObservationKey& key{observation_id.observation_key()};
           if (UNLIKELY(registered_array_component_ids.find(key) ==
                        registered_array_component_ids.end())) {

--- a/src/NumericalAlgorithms/Integration/GslQuadAdaptive.cpp
+++ b/src/NumericalAlgorithms/Integration/GslQuadAdaptive.cpp
@@ -15,7 +15,7 @@
 namespace integration::detail {
 
 GslQuadAdaptiveImpl::GslQuadAdaptiveImpl(const size_t max_intervals)
-    : max_intervals_(max_intervals), gsl_integrand_(gsl_function{}) {
+    : max_intervals_(max_intervals) {
   initialize();
 }
 

--- a/src/NumericalAlgorithms/LinearSolver/ExplicitInverse.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/ExplicitInverse.hpp
@@ -144,13 +144,17 @@ class ExplicitInverse : public LinearSolver<LinearSolverRegistrars> {
 
  private:
   // Caches for successive solves of the same operator
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable size_t size_ = std::numeric_limits<size_t>::max();
   // We currently store the matrix representation in a dense matrix because
   // Blaze doesn't support the inversion of sparse matrices (yet).
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable blaze::DynamicMatrix<double, blaze::columnMajor> inverse_{};
 
   // Buffers to avoid re-allocating memory for applying the operator
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable blaze::DynamicVector<double> source_workspace_{};
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable blaze::DynamicVector<double> solution_workspace_{};
 };
 

--- a/src/NumericalAlgorithms/LinearSolver/Gmres.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Gmres.hpp
@@ -282,22 +282,28 @@ class Gmres final : public PreconditionedLinearSolver<Preconditioner,
   // The `orthogonalization_history_` is built iteratively from inner products
   // between existing and potential basis vectors and then Givens-rotated to
   // become upper-triangular.
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable blaze::DynamicMatrix<double> orthogonalization_history_{};
   // The `residual_history_` holds the remaining residual in its last entry, and
   // the other entries `g` "source" the minimum residual vector `y` in
   // `R * y = g` where `R` is the upper-triangular `orthogonalization_history_`.
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable blaze::DynamicVector<double> residual_history_{};
   // These represent the accumulated Givens rotations up to the current
   // iteration.
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable blaze::DynamicVector<double> givens_sine_history_{};
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable blaze::DynamicVector<double> givens_cosine_history_{};
   // These represent the orthogonal Krylov-subspace basis that is constructed
   // iteratively by Arnoldi-orthogonalizing a new vector in each iteration and
   // appending it to the `basis_history_`.
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable std::vector<VarsType> basis_history_{};
   // When a preconditioner is used it is applied to each new basis vector. The
   // preconditioned basis is used to construct the solution when the algorithm
   // has converged.
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable std::vector<VarsType> preconditioned_basis_history_{};
 };
 

--- a/src/NumericalAlgorithms/Spectral/SwshInterpolation.hpp
+++ b/src/NumericalAlgorithms/Spectral/SwshInterpolation.hpp
@@ -366,7 +366,9 @@ class SwshInterpolator {
   DataVector sin_theta_over_two_;
   std::vector<DataVector> sin_m_phi_;
   std::vector<DataVector> cos_m_phi_;
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable ComplexModalVector raw_libsharp_coefficient_buffer_;
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable ComplexModalVector raw_goldberg_coefficient_buffer_;
 };
 }  // namespace Swsh

--- a/src/NumericalAlgorithms/SphericalHarmonics/YlmSpherepack.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/YlmSpherepack.hpp
@@ -442,7 +442,9 @@ class YlmSpherepack {
   void fill_vector_work_arrays() const;
   size_t l_max_, m_max_, n_theta_, n_phi_;
   size_t spectral_size_;
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable YlmSpherepack_detail::MemoryPool memory_pool_;
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable YlmSpherepack_detail::Storage storage_;
 };  // class YlmSpherepack
 

--- a/src/Options/Options.hpp
+++ b/src/Options/Options.hpp
@@ -89,7 +89,7 @@ class propagate_context : public std::exception {
   explicit propagate_context(std::string message)
       : message_(std::move(message)) {}
 
-  const char* what() const noexcept override { return message_.c_str(); }
+  const char* what() const noexcept(true) override { return message_.c_str(); }
   const std::string& message() const { return message_; }
 
  private:

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementCenteredSubdomainData.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementCenteredSubdomainData.hpp
@@ -175,6 +175,7 @@ struct ElementCenteredSubdomainData {
   private:
    // Cache for iterators, so they don't have to allocate, fill and sort this
    // vector every time
+   // NOLINTNEXTLINE(spectre-mutable)
    mutable std::vector<OverlapId<Dim>> ordered_overlap_ids_{};
 
    friend ElementCenteredSubdomainDataIterator<false, Dim, TagsList>;

--- a/src/Time/BoundaryHistory.hpp
+++ b/src/Time/BoundaryHistory.hpp
@@ -287,6 +287,7 @@ class BoundaryHistory {
   // We use pointers instead of iterators because deque invalidates
   // iterators when elements are inserted or removed at the ends, but
   // not pointers.
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable std::map<std::pair<const Time*, const Time*>, CouplingResult>
       coupling_cache_;
 };

--- a/tests/Unit/DataStructures/Test_IndexIterator.cpp
+++ b/tests/Unit/DataStructures/Test_IndexIterator.cpp
@@ -20,16 +20,19 @@ SPECTRE_TEST_CASE("Unit.DataStructures.IndexIterator",
   // [index_iterator_example]
 
   IndexIterator<3> index_iterator(elements);
-  auto check_next = [&index_iterator,
-                     call_num = 0](const Index<3>& expected) mutable {
-    CHECK(index_iterator);
-    CHECK(index_iterator() == expected);
-    CHECK(*index_iterator == expected);
-    CHECK(index_iterator->indices() == expected.indices());
-    CHECK(index_iterator.collapsed_index() == static_cast<size_t>(call_num));
-    ++index_iterator;
-    ++call_num;
-  };
+  auto check_next =
+      [&index_iterator,
+       call_num =
+           0](const Index<3>& expected) mutable {  // NOLINT(spectre-mutable)
+        CHECK(index_iterator);
+        CHECK(index_iterator() == expected);
+        CHECK(*index_iterator == expected);
+        CHECK(index_iterator->indices() == expected.indices());
+        CHECK(index_iterator.collapsed_index() ==
+              static_cast<size_t>(call_num));
+        ++index_iterator;
+        ++call_num;
+      };
   check_next(Index<3>(0, 0, 0));
   check_next(Index<3>(0, 1, 0));
   check_next(Index<3>(0, 0, 1));

--- a/tests/Unit/Elliptic/SubdomainPreconditioners/Test_MinusLaplacian.cpp
+++ b/tests/Unit/Elliptic/SubdomainPreconditioners/Test_MinusLaplacian.cpp
@@ -134,7 +134,9 @@ struct TestSolver {
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/) {}
 
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable std::vector<PoissonSubdomainData<Dim>> sources{};
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable std::vector<std::map<std::pair<size_t, Direction<Dim>>,
                                elliptic::BoundaryConditionType>>
       bc_types{};

--- a/tests/Unit/Helpers/NumericalAlgorithms/LinearSolver/TestHelpers.hpp
+++ b/tests/Unit/Helpers/NumericalAlgorithms/LinearSolver/TestHelpers.hpp
@@ -19,6 +19,7 @@ namespace TestHelpers::LinearSolver {
 
 struct ApplyMatrix {
   blaze::DynamicMatrix<double> matrix;
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable size_t invocations = 0;
   template <typename ResultVectorType, typename OperandVectorType>
   void operator()(const gsl::not_null<ResultVectorType*> result,
@@ -50,6 +51,7 @@ struct ExactInversePreconditioner {
   static constexpr Options::String help{"halp"};
 
  private:
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable std::optional<blaze::DynamicMatrix<double>> inv_matrix_{};
 };
 
@@ -76,6 +78,7 @@ struct JacobiPreconditioner {
   void pup(PUP::er& p) { p | inv_diagonal_; }  // NOLINT
 
  private:
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable std::optional<blaze::DynamicVector<double>> inv_diagonal_{};
 };
 
@@ -113,6 +116,7 @@ struct RichardsonPreconditioner {
  private:
   double relaxation_parameter_{};
   size_t num_iterations_{};
+  // NOLINTNEXTLINE(spectre-mutable)
   mutable blaze::DynamicVector<double> correction_buffer_{};
 };
 

--- a/tests/Unit/Helpers/Time/TimeSteppers/TimeStepperTestUtils.cpp
+++ b/tests/Unit/Helpers/Time/TimeSteppers/TimeStepperTestUtils.cpp
@@ -555,6 +555,7 @@ void check_boundary_dense_output(const LtsTimeStepper& stepper) {
 
   // We don't use any meaningful values.  We only care that the dense
   // output gives the same result as normal output.
+  // NOLINTNEXTLINE(spectre-mutable)
   auto get_value = [value = 1.]() mutable { return value *= 1.1; };
 
   const auto coupling = [](const double a, const double b) { return a * b; };

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_OrszagTangVortex.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_OrszagTangVortex.cpp
@@ -45,7 +45,8 @@ void test_variables(const DataType& used_for_size) {
       "divergence_cleaning_field"s);
 
   tmpl::for_each<tags>([&used_for_size,
-                        name = names.begin()](auto tag) mutable {
+                        name = names.begin()](
+                           auto tag) mutable {  // NOLINT(spectre-mutable)
     using Tag = tmpl::type_from<decltype(tag)>;
     pypp::check_with_random_values<1>(
         +[](const tnsr::I<DataType, 3>& x) {

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -539,11 +539,7 @@ standard_checks+=(enable_if)
 # Check for noexcept
 noexcept() {
     is_c++ "$1" && \
-        whitelist "$1" \
-                  'src/Options/Options.hpp$' \
-                  'src/Utilities/TypeTraits/FunctionInfo.hpp$' \
-                  'tests/Unit/Utilities/TypeTraits/Test_FunctionInfo.cpp$' && \
-        staged_grep -q noexcept "$1"
+        staged_grep -q 'noexcept ' "$1"
 }
 noexcept_report() {
     echo "Found occurrences of 'noexcept', please remove."
@@ -553,9 +549,12 @@ noexcept_test() {
     test_check pass foo.cpp ''
     test_check pass foo.hpp ''
     test_check pass foo.tpp ''
-    test_check fail foo.hpp 'noexcept'
-    test_check fail foo.cpp 'noexcept'
-    test_check fail foo.tpp 'noexcept'
+    test_check fail foo.hpp 'noexcept '
+    test_check fail foo.cpp 'noexcept '
+    test_check fail foo.tpp 'noexcept '
+    test_check pass foo.hpp 'noexcept(true)'
+    test_check pass foo.cpp 'noexcept(true)'
+    test_check pass foo.tpp 'noexcept(true)'
 }
 standard_checks+=(noexcept)
 

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -147,12 +147,14 @@ test_check() {
         if [ "${expected}" != fail ] ; then
             echo "${check} unexpectedly failed on ${file}:"
             cat "${file}"
+            echo
             failed=yes
         fi
     else
         if [ "${expected}" != pass ] ; then
             echo "${check} unexpectedly passed on ${file}:"
             cat "${file}"
+            echo
             failed=yes
         fi
     fi

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -712,7 +712,7 @@ standard_checks+=(check_throws)
 # Check for typos similar to Doxygen groups
 check_dox_groups() {
     is_c++ "$1" && staged_grep -E "^\s*//+\s*[\{\}\(\)]*@[\{\}\(\)]*" "$1" \
-            | grep -v -E "(^\s*/// @\{|^\s*/// @\})"
+            | grep -v -E -q "(^\s*/// @\{|^\s*/// @\})"
 }
 check_dox_groups_report() {
     echo "Found a likely typo similar to a valid doxygen grouping"


### PR DESCRIPTION
This implementation reuses the NOLINT and NOLINTNEXTLINE magic comments.  It's easy to change to another method of whitelisting if people don't like that overloading.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
