### PR TITLE
Enable compiler flags for setting Blaze inlining settings

### DIFF
--- a/cmake/SetupBlaze.cmake
+++ b/cmake/SetupBlaze.cmake
@@ -57,6 +57,28 @@ if(SLEEF_FOUND)
   set(_BLAZE_USE_SLEEF 1)
 endif()
 
+# If BLAZE_USE_STRONG_INLINE=ON, Blaze will use this keyword to increase the
+# likelihood of inlining. If BLAZE_USE_STRONG_INLINE=OFF, uses inline keyword
+# as a fallback.
+option(BLAZE_USE_STRONG_INLINE "Increase likelihood of Blaze inlining." ON)
+
+set(_BLAZE_USE_STRONG_INLINE 0)
+
+if(BLAZE_USE_STRONG_INLINE)
+  set(_BLAZE_USE_STRONG_INLINE 1)
+endif()
+
+# If BLAZE_USE_ALWAYS_INLINE=ON, Blaze will use this keyword to force inlining.
+# If BLAZE_USE_ALWAYS_INLINE=OFF or if the platform being used cannot 100%
+# guarantee inlining, uses BLAZE_STRONG_INLINE as a fallback.
+option(BLAZE_USE_ALWAYS_INLINE "Force Blaze inlining." ON)
+
+set(_BLAZE_USE_ALWAYS_INLINE 0)
+
+if(BLAZE_USE_ALWAYS_INLINE)
+  set(_BLAZE_USE_ALWAYS_INLINE 1)
+endif()
+
 # Configure Blaze. Some of the Blaze configuration options could be optimized
 # for the machine we are running on. See documentation:
 # https://bitbucket.org/blaze-lib/blaze/wiki/Configuration%20and%20Installation#!step-2-configuration
@@ -92,6 +114,9 @@ target_compile_definitions(Blaze
   BLAZE_USE_DEFAULT_INITIALIZATON=0
   # Use Sleef for vectorization of more math functions
   BLAZE_USE_SLEEF=${_BLAZE_USE_SLEEF}
+  # Set inlining settings
+  BLAZE_USE_STRONG_INLINE=${_BLAZE_USE_STRONG_INLINE}
+  BLAZE_USE_ALWAYS_INLINE=${_BLAZE_USE_ALWAYS_INLINE}
   )
 
 add_interface_lib_headers(

--- a/docs/DevGuide/BuildSystem.md
+++ b/docs/DevGuide/BuildSystem.md
@@ -160,6 +160,23 @@ cmake -D FLAG1=OPT1 ... -D FLAGN=OPTN <SPECTRE_ROOT>
 - ASAN
   - Whether or not to turn on the address sanitizer compile flags
     (`-fsanitize=address`) (default is `OFF`)
+- BLAZE_USE_ALWAYS_INLINE
+  - Force Blaze inlining (default is `ON`)
+  - If disabled or if the platform is unable to 100% guarantee inlining,
+  replaces `BLAZE_ALWAYS_INLINE` in Blaze with `BLAZE_STRONG_INLINE` (see
+  `BLAZE_USE_STRONG_INLINE`)
+  - For SpECTRE build targets that use Blaze data structures and arithmetic,
+  it may affect runtime. If debug symbols are enabled (`-g`), disabling
+  `BLAZE_USE_ALWAYS_INLINE` may reduce compile time and compile time RAM. It
+  should also make it easier to step through Blaze with a debugger.
+- BLAZE_USE_STRONG_INLINE
+  - Increase the likelihood of Blaze inlining (default is `ON`)
+  - Disabling replaces `BLAZE_STRONG_INLINE` in Blaze with the `inline`
+  keyword
+  - For SpECTRE build targets that use Blaze data structures and arithmetic,
+  it may affect runtime. If debug symbols are enabled (`-g`), disabling
+  `BLAZE_USE_STRONG_INLINE` may reduce compile time and compile time RAM. It
+  should also make it easier to step through Blaze with a debugger.
 - BUILD_PYTHON_BINDINGS
   - Build python libraries to call SpECTRE C++ code from python
     (default is `OFF`)


### PR DESCRIPTION
## Proposed changes

This PR enables one to toggle inlining within Blaze with command line compilation flags `BLAZE_USE_STRONG_INLINE` and `BLAZE_USE_ALWAYS_INLINE`. The flags are defined in Blaze in [this file](https://bitbucket.org/blaze-lib/blaze/src/5074d1f16d4b0b33bb5dd4a9f9df0f4b5c01d120/cmake/Inline.h.in#lines-1).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
