### PR TITLE
YlmSpherepack: Replace mutable non-dynamic storage

### DIFF
--- a/src/NumericalAlgorithms/SphericalHarmonics/YlmSpherepack.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/YlmSpherepack.hpp
@@ -84,7 +84,7 @@ class YlmSpherepack {
   template <typename T>
   struct InterpolationInfo {
     InterpolationInfo(size_t l_max, size_t m_max,
-                      const std::vector<double>& pmm,
+                      const gsl::span<double> pmm,
                       const std::array<T, 2>& target_points);
     T cos_theta;
     // cos(m*phi)
@@ -149,8 +149,12 @@ class YlmSpherepack {
   ///
   /// The theta points are Gauss-Legendre in \f$\cos(\theta)\f$,
   /// so there are no points at the poles.
-  const std::vector<double>& theta_points() const;
-  const std::vector<double>& phi_points() const;
+  SPECTRE_ALWAYS_INLINE const std::vector<double>& theta_points() const {
+    return storage_.theta;
+  }
+  SPECTRE_ALWAYS_INLINE const std::vector<double>& phi_points() const {
+    return storage_.phi;
+  }
   std::array<DataVector, 2> theta_phi_points() const;
   /// @}
 
@@ -437,15 +441,15 @@ class YlmSpherepack {
                                 size_t physical_stride = 1,
                                 size_t physical_offset = 0,
                                 bool loop_over_offset = false) const;
-  void calculate_interpolation_data() const;
-  void fill_scalar_work_arrays() const;
-  void fill_vector_work_arrays() const;
+  void calculate_collocation_points();
+  void calculate_interpolation_data();
+  void fill_scalar_work_arrays();
+  void fill_vector_work_arrays();
   size_t l_max_, m_max_, n_theta_, n_phi_;
   size_t spectral_size_;
   // NOLINTNEXTLINE(spectre-mutable)
   mutable YlmSpherepack_detail::MemoryPool memory_pool_;
-  // NOLINTNEXTLINE(spectre-mutable)
-  mutable YlmSpherepack_detail::Storage storage_;
+  YlmSpherepack_detail::ConstStorage storage_;
 };  // class YlmSpherepack
 
 bool operator==(const YlmSpherepack& lhs, const YlmSpherepack& rhs);

--- a/src/NumericalAlgorithms/SphericalHarmonics/YlmSpherepackHelper.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/YlmSpherepackHelper.cpp
@@ -8,6 +8,126 @@
 
 namespace YlmSpherepack_detail {
 
+ConstStorage::ConstStorage(const size_t l_max, const size_t m_max)
+    : l_max_(l_max), m_max_(m_max) {
+  point_spans_to_data_vector(true);
+}
+
+ConstStorage::ConstStorage(const ConstStorage& rhs)
+    : work_interp_index(rhs.work_interp_index),
+      quadrature_weights(rhs.quadrature_weights),
+      theta(rhs.theta),
+      phi(rhs.phi),
+      storage_(rhs.storage_),
+      l_max_(rhs.l_max_),
+      m_max_(rhs.m_max_) {
+  point_spans_to_data_vector();
+}
+
+ConstStorage& ConstStorage::operator=(const ConstStorage& rhs) {
+  l_max_ = rhs.l_max_;
+  m_max_ = rhs.m_max_;
+  work_interp_index = rhs.work_interp_index;
+  quadrature_weights = rhs.quadrature_weights;
+  theta = rhs.theta;
+  phi = rhs.phi;
+  storage_ = rhs.storage_;
+  point_spans_to_data_vector();
+  return *this;
+}
+
+ConstStorage::ConstStorage(ConstStorage&& rhs)
+    : work_interp_index(std::move(rhs.work_interp_index)),
+      quadrature_weights(std::move(rhs.quadrature_weights)),
+      theta(std::move(rhs.theta)),
+      phi(std::move(rhs.phi)),
+      storage_(std::move(rhs.storage_)),
+      l_max_(rhs.l_max_),
+      m_max_(rhs.m_max_) {
+  point_spans_to_data_vector();
+}
+
+ConstStorage& ConstStorage::operator=(ConstStorage&& rhs) {
+  l_max_ = rhs.l_max_;
+  m_max_ = rhs.m_max_;
+  work_interp_index = std::move(rhs.work_interp_index);
+  quadrature_weights = std::move(rhs.quadrature_weights);
+  theta = std::move(rhs.theta);
+  phi = std::move(rhs.phi);
+  storage_ = std::move(rhs.storage_);
+  point_spans_to_data_vector();
+  return *this;
+}
+
+void ConstStorage::point_spans_to_data_vector(const bool allocate) {
+  // Below note that n_theta, n_phi, l1, l2, and int_work_size are
+  // ints, not size_ts. The reason for this: The last term in the
+  // expression for int_work_size can sometimes be negative. If
+  // evaluated using unsigned ints instead of ints, it can underflow
+  // and give a huge number.
+  const auto n_theta = static_cast<int>(l_max_ + 1);
+  const auto n_phi = static_cast<int>(2 * m_max_ + 1);
+  const auto l1 = static_cast<int>(m_max_ + 1);
+  const auto l2 = (n_theta + 1) / 2;
+  const int int_work_size = n_phi + 15 + n_theta * (3 * (l1 + l2) - 2) +
+                            (l1 - 1) * (l2 * (2 * n_theta - l1) - 3 * l1) / 2;
+  ASSERT(int_work_size >= 0, "Bad size " << int_work_size);
+  const auto scalar_work_size = static_cast<size_t>(int_work_size);
+
+  // For vectors, the things that SPHEREPACK internally calls l1, mdb,
+  // and mdc have a minimum allowed size of
+  // min(n_theta_,(n_phi_+1)/2)).  However, here we set those
+  // quantities to min(n_theta_, (n_phi_+2)/2)) which is what
+  // SPHEREPACK requires for what it internally calls l1 and mdab for
+  // scalars.  This results in a simplification, but also a (very
+  // slightly) larger vector work array than technically required, for
+  // some choices of parameters.
+
+  // NOLINTNEXTLINE bugprone-misplaced-widening-cast
+  const auto vector_work_size = static_cast<size_t>(
+      n_theta * l2 * (n_theta + 1) + n_phi + 15 + 2 * n_theta);
+  // NOLINTNEXTLINE bugprone-misplaced-widening-cast
+  const auto quad_work_size = static_cast<size_t>(n_theta * n_phi);
+  const size_t theta_work_size = l_max_ + 1;
+  const size_t phi_work_size = 2 * m_max_ + 1;
+  const auto interp_work_size =
+      static_cast<size_t>(n_theta * l1 - l1 * (l1 - 1) / 2);
+  const size_t interp_work_pmm_size = m_max_ + 1;
+
+  const size_t full_size = 2 * scalar_work_size + vector_work_size +
+                           4 * theta_work_size + 2 * phi_work_size +
+                           2 * interp_work_size + interp_work_pmm_size;
+
+  if(allocate) {
+    work_interp_index.resize(interp_work_size);
+    quadrature_weights.resize(quad_work_size);
+    theta.resize(theta_work_size);
+    phi.resize(phi_work_size);
+    storage_ = DataVector(full_size);
+  }
+
+  size_t offset = 0;
+  auto set_up_span = [&offset, this](const size_t size) -> gsl::span<double> {
+    auto result = gsl::make_span(this->storage_.data() + offset, size);
+    offset += size;
+    return result;
+  };
+  work_phys_to_spec = set_up_span(scalar_work_size);
+  work_scalar_spec_to_phys = set_up_span(scalar_work_size);
+  work_vector_spec_to_phys = set_up_span(vector_work_size);
+  sin_theta = set_up_span(theta_work_size);
+  cos_theta = set_up_span(theta_work_size);
+  cosec_theta = set_up_span(theta_work_size);
+  cot_theta = set_up_span(theta_work_size);
+  sin_phi = set_up_span(phi_work_size);
+  cos_phi = set_up_span(phi_work_size);
+  work_interp_alpha = set_up_span(interp_work_size);
+  work_interp_beta = set_up_span(interp_work_size);
+  work_interp_pmm = set_up_span(interp_work_pmm_size);
+
+  ASSERT(offset == full_size, "Bug in dividing up memory");
+}
+
 std::vector<double>& MemoryPool::get(size_t n_pts) {
   for (auto& elem : memory_pool_) {
     if (not elem.currently_in_use) {

--- a/src/NumericalAlgorithms/SphericalHarmonics/YlmSpherepackHelper.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/YlmSpherepackHelper.hpp
@@ -7,22 +7,40 @@
 #include <cstddef>
 #include <vector>
 
+#include "DataStructures/DataVector.hpp"
 #include "Utilities/Gsl.hpp"
 
 namespace YlmSpherepack_detail {
 
-/// Holds the various 'work' arrays for YlmSpherepack.
-struct Storage {
-  std::vector<double> work_phys_to_spec;
-  std::vector<double> work_scalar_spec_to_phys;
-  std::vector<double> work_vector_spec_to_phys;
-  std::vector<double> theta, phi, sin_theta, cos_theta;
-  std::vector<double> cos_phi, sin_phi, cosec_theta, cot_theta;
-  std::vector<double> quadrature_weights;
-  std::vector<double> work_interp_alpha;
-  std::vector<double> work_interp_beta;
-  std::vector<double> work_interp_pmm;
+/// Holds the various constant 'work' arrays for YlmSpherepack.
+/// These are computed only once during YlmSpherepack construction
+/// and are re-used over and over again.
+class ConstStorage {
+ public:
+  ConstStorage(const size_t l_max, const size_t m_max);
+  ~ConstStorage() = default;
+  ConstStorage(const ConstStorage& rhs);
+  ConstStorage& operator=(const ConstStorage& rhs);
+  ConstStorage(ConstStorage&& rhs);
+  ConstStorage& operator=(ConstStorage&& rhs);
+
   std::vector<size_t> work_interp_index;
+  // The following are vectors because they are returnable by
+  // member functions.
+  std::vector<double> quadrature_weights, theta, phi;
+  // All other storage is allocated in a single DataVector and then
+  // pointed to by gsl::spans.
+  DataVector storage_;
+  gsl::span<double> work_phys_to_spec, work_scalar_spec_to_phys;
+  gsl::span<double> work_vector_spec_to_phys;
+  gsl::span<double> sin_theta, cos_theta, cosec_theta, cot_theta;
+  gsl::span<double> sin_phi, cos_phi;
+  gsl::span<double> work_interp_alpha, work_interp_beta, work_interp_pmm;
+
+ private:
+  size_t l_max_;
+  size_t m_max_;
+  void point_spans_to_data_vector(const bool allocate = false);
 };
 
 /// This is a quick way of providing temporary space that is

--- a/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
+++ b/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
@@ -1169,12 +1169,12 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperGr.RadialDistance",
   // Check cases where one has more resolution than the other
   StrahlkorperGr::radial_distance(
       make_not_null(&radial_dist), strahlkorper_a,
-      Strahlkorper(strahlkorper_b.l_max() - 1, strahlkorper_b.m_max(),
+      Strahlkorper(strahlkorper_b.l_max() - 1, strahlkorper_b.m_max() - 1,
                    strahlkorper_b));
   CHECK_ITERABLE_APPROX(radial_dist, expected_radial_dist_a_minus_b);
   StrahlkorperGr::radial_distance(
       make_not_null(&radial_dist),
-      Strahlkorper(strahlkorper_b.l_max() - 1, strahlkorper_b.m_max(),
+      Strahlkorper(strahlkorper_b.l_max() - 1, strahlkorper_b.m_max() - 1,
                    strahlkorper_b),
       strahlkorper_a);
   CHECK_ITERABLE_APPROX(radial_dist, expected_radial_dist_b_minus_a);


### PR DESCRIPTION
## Proposed changes

This addresses part of #3929 but not all of it.
    
YlmSpherepack has 2 types of internal storage:
1. Quantities computed only once and reused often, but forever constant.
 2. Temporary buffers that are overwritten frequently.
    
 This PR changes 1. and does not address 2.
    
Previously, the temporary quantities in 1. were computed using
lazy evaluation: if a member function that needed them was
called, then they were computed and then forever held fixed.
This was accomplished via a mutable member variable that holds the
storage.  Now, the temporary quantities in 1. are all computed
in the YlmSpherepack constructor, and are never changed.  The
corresponding member variable is no longer mutable.  In the
constructor, certain temporary quantities are allocated on the heap
on the fly and then thrown away after use, but because this happens
only in the constructor we don't worry about these allocations.


### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
