### PR TITLE
Make YlmSpherepack threadsafe

### DIFF
--- a/src/NumericalAlgorithms/SphericalHarmonics/YlmSpherepack.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/YlmSpherepack.cpp
@@ -47,6 +47,20 @@
 //   (as opposed to m_max = m_max_represented+1)
 //============================================================================
 
+// Need to initialize memory_pool_ here because it is static.  Note
+// that memory_pool_ is never destroyed or cleared, except at the end
+// of execution when static variables are destroyed.  One alternative
+// would be to reference-count the instances of YlmSpherepack on the
+// local thread, and to clear the memory_pool_ when the reference
+// count drops to zero.  Another alternative would be to clear the
+// memory_pool_ in the destructor (so it is cleared when *any*
+// instance of YlmSpherepack is destroyed), but there is no need to do
+// so, and doing so would increase the number of memory allocations
+// because other instances of YlmSpherepack would then re-allocate
+// memory_pool.
+thread_local YlmSpherepack_detail::MemoryPool YlmSpherepack::memory_pool_ =
+    YlmSpherepack_detail::MemoryPool();
+
 YlmSpherepack::YlmSpherepack(const size_t l_max, const size_t m_max)
     : l_max_{l_max},
       m_max_{m_max},

--- a/src/NumericalAlgorithms/SphericalHarmonics/YlmSpherepack.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/YlmSpherepack.hpp
@@ -71,6 +71,11 @@
  * returning an expansion in nodal form as defined above. To evaluate the
  * function at arbitrary angles \f$\theta\f$, \f$\phi\f$, these values have to
  * be "interpolated" (i.e. the new expansion evaluated) using `interpolate`.
+ *
+ * YlmSpherepack stores two types of quantities:
+ *   1. storage_, which is filled in the constructor and is always const.
+ *   2. memory_pool_, which is dynamic and thread_local, and is overwritten
+ *      by various member functions that need temporary storage.
  */
 class YlmSpherepack {
  public:
@@ -447,8 +452,15 @@ class YlmSpherepack {
   void fill_vector_work_arrays();
   size_t l_max_, m_max_, n_theta_, n_phi_;
   size_t spectral_size_;
-  // NOLINTNEXTLINE(spectre-mutable)
-  mutable YlmSpherepack_detail::MemoryPool memory_pool_;
+  // memory_pool_ will be shared by multiple instances of
+  // YlmSpherepack on the same thread.  Because these instances are on
+  // the same thread, member functions of two or more of these
+  // instances cannot be called simultaneously.  Note that member
+  // functions do not make any assumptions about the contents of
+  // memory_pool_ on entry, so between calls to member functions it is
+  // safe to resize objects in memory_pool_ or to overwrite them with
+  // arbitrary data.
+  static thread_local YlmSpherepack_detail::MemoryPool memory_pool_;
   YlmSpherepack_detail::ConstStorage storage_;
 };  // class YlmSpherepack
 

--- a/src/NumericalAlgorithms/SphericalHarmonics/YlmSpherepackHelper.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/YlmSpherepackHelper.cpp
@@ -167,4 +167,13 @@ void MemoryPool::free(const gsl::not_null<double*> to_be_freed) {
   ERROR("Attempt to free temp that was never allocated.");
 }
 
+void MemoryPool::clear() {
+  for (auto& elem : memory_pool_) {
+    if(elem.currently_in_use) {
+      ERROR("Attempt to clear element that is in use");
+    }
+    elem.storage.clear();
+  }
+}
+
 }  // namespace YlmSpherepack_detail

--- a/src/NumericalAlgorithms/SphericalHarmonics/YlmSpherepackHelper.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/YlmSpherepackHelper.hpp
@@ -54,7 +54,7 @@ class MemoryPool {
   std::vector<double>& get(size_t n_pts);
   void free(const std::vector<double>& to_be_freed);
   void free(gsl::not_null<double*> to_be_freed);
-
+  void clear();
  private:
   struct StorageAndAvailability {
     std::vector<double> storage;


### PR DESCRIPTION
## Proposed changes

Uses thread_local storage to make YlmSpherepack threadsafe.  Fixes #3929

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
