### PR TITLE
Split ApplyBoundaryCorrections action

### DIFF
--- a/src/Evolution/Actions/RunEventsAndDenseTriggers.hpp
+++ b/src/Evolution/Actions/RunEventsAndDenseTriggers.hpp
@@ -151,9 +151,9 @@ struct RunEventsAndDenseTriggers {
         case TriggeringState::NeedsEvolvedVariables:
           if (not already_at_correct_time) {
             if constexpr (Metavariables::local_time_stepping) {
-              if (not dg::Actions::ApplyBoundaryCorrections<Metavariables>::
-                      template receive_local_time_stepping<true>(
-                          make_not_null(&box), make_not_null(&inboxes))) {
+              if (not dg::receive_boundary_data_local_time_stepping<
+                      Metavariables, true>(make_not_null(&box),
+                                           make_not_null(&inboxes))) {
                 return {std::move(box), Parallel::AlgorithmExecution::Retry};
               }
             }
@@ -177,8 +177,8 @@ struct RunEventsAndDenseTriggers {
             }
 
             if constexpr (Metavariables::local_time_stepping) {
-              dg::Actions::ApplyBoundaryCorrections<Metavariables>::
-                  template complete_time_step<true>(make_not_null(&box));
+              dg::apply_boundary_corrections<system, true, true>(
+                  make_not_null(&box));
             }
 
             static_assert(system::has_primitive_and_conservative_vars !=

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -254,13 +254,14 @@ struct EvolutionMetavars {
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<>,
-                     evolution::dg::Actions::ApplyBoundaryCorrections<
+                     evolution::dg::Actions::ApplyLtsBoundaryCorrections<
                          EvolutionMetavars>>,
-          tmpl::list<evolution::dg::Actions::ApplyBoundaryCorrections<
-                         EvolutionMetavars>,
-                     Actions::RecordTimeStepperData<>,
-                     evolution::Actions::RunEventsAndDenseTriggers<>,
-                     Actions::UpdateU<>>>,
+          tmpl::list<
+              evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
+                  EvolutionMetavars>,
+              Actions::RecordTimeStepperData<>,
+              evolution::Actions::RunEventsAndDenseTriggers<>,
+              Actions::UpdateU<>>>,
       Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>>>;
 
@@ -268,7 +269,8 @@ struct EvolutionMetavars {
       evolution::dg::subcell::Actions::SelectNumericalMethod,
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginDg>,
       evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
-      evolution::dg::Actions::ApplyBoundaryCorrections<EvolutionMetavars>,
+      evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
+          EvolutionMetavars>,
       tmpl::conditional_t<
           local_time_stepping, tmpl::list<>,
           tmpl::list<Actions::RecordTimeStepperData<>,

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -271,13 +271,14 @@ struct EvolutionMetavars {
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<>,
-                     evolution::dg::Actions::ApplyBoundaryCorrections<
+                     evolution::dg::Actions::ApplyLtsBoundaryCorrections<
                          EvolutionMetavars>>,
-          tmpl::list<evolution::dg::Actions::ApplyBoundaryCorrections<
-                         EvolutionMetavars>,
-                     Actions::RecordTimeStepperData<>,
-                     evolution::Actions::RunEventsAndDenseTriggers<>,
-                     Actions::UpdateU<>>>,
+          tmpl::list<
+              evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
+                  EvolutionMetavars>,
+              Actions::RecordTimeStepperData<>,
+              evolution::Actions::RunEventsAndDenseTriggers<>,
+              Actions::UpdateU<>>>,
       tmpl::conditional_t<
           use_filtering,
           dg::Actions::Filter<Filters::Exponential<0>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -438,10 +438,10 @@ struct EvolutionMetavars {
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<>,
-                     evolution::dg::Actions::ApplyBoundaryCorrections<
+                     evolution::dg::Actions::ApplyLtsBoundaryCorrections<
                          EvolutionMetavars>>,
           tmpl::list<
-              evolution::dg::Actions::ApplyBoundaryCorrections<
+              evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
                   EvolutionMetavars>,
               Actions::RecordTimeStepperData<>,
               evolution::Actions::RunEventsAndDenseTriggers<>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -343,10 +343,10 @@ struct GeneralizedHarmonicTemplateBase<
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<>,
-                     evolution::dg::Actions::ApplyBoundaryCorrections<
+                     evolution::dg::Actions::ApplyLtsBoundaryCorrections<
                          derived_metavars>>,
           tmpl::list<
-              evolution::dg::Actions::ApplyBoundaryCorrections<
+              evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
                   derived_metavars>,
               Actions::RecordTimeStepperData<>,
               evolution::Actions::RunEventsAndDenseTriggers<>,

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -393,10 +393,14 @@ struct GhValenciaDivCleanTemplateBase<
 
   using step_actions = tmpl::flatten<tmpl::list<
       evolution::dg::Actions::ComputeTimeDerivative<derived_metavars>,
-      evolution::dg::Actions::ApplyBoundaryCorrections<derived_metavars>,
       tmpl::conditional_t<
-          local_time_stepping, tmpl::list<>,
-          tmpl::list<Actions::RecordTimeStepperData<>, Actions::UpdateU<>>>,
+          local_time_stepping,
+          tmpl::list<evolution::dg::Actions::ApplyLtsBoundaryCorrections<
+              derived_metavars>>,
+          tmpl::list<
+              evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
+                  derived_metavars>,
+              Actions::RecordTimeStepperData<>, Actions::UpdateU<>>>,
       Limiters::Actions::SendData<derived_metavars>,
       Limiters::Actions::Limit<derived_metavars>,
       VariableFixing::Actions::FixVariables<

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -362,15 +362,16 @@ struct EvolutionMetavars {
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<
                          system::primitive_from_conservative<
                              ordered_list_of_primitive_recovery_schemes>>,
-                     evolution::dg::Actions::ApplyBoundaryCorrections<
+                     evolution::dg::Actions::ApplyLtsBoundaryCorrections<
                          EvolutionMetavars>>,
-          tmpl::list<evolution::dg::Actions::ApplyBoundaryCorrections<
-                         EvolutionMetavars>,
-                     Actions::RecordTimeStepperData<>,
-                     evolution::Actions::RunEventsAndDenseTriggers<
-                         system::primitive_from_conservative<
-                             ordered_list_of_primitive_recovery_schemes>>,
-                     Actions::UpdateU<>>>,
+          tmpl::list<
+              evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
+                  EvolutionMetavars>,
+              Actions::RecordTimeStepperData<>,
+              evolution::Actions::RunEventsAndDenseTriggers<
+                  system::primitive_from_conservative<
+                      ordered_list_of_primitive_recovery_schemes>>,
+              Actions::UpdateU<>>>,
       Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>,
       VariableFixing::Actions::FixVariables<grmhd::ValenciaDivClean::Flattener<
@@ -384,7 +385,8 @@ struct EvolutionMetavars {
 
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginDg>,
       evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
-      evolution::dg::Actions::ApplyBoundaryCorrections<EvolutionMetavars>,
+      evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
+          EvolutionMetavars>,
       tmpl::conditional_t<
           local_time_stepping, tmpl::list<>,
           tmpl::list<Actions::RecordTimeStepperData<>,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -301,14 +301,15 @@ struct EvolutionMetavars {
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<
                          typename system::primitive_from_conservative>,
-                     evolution::dg::Actions::ApplyBoundaryCorrections<
+                     evolution::dg::Actions::ApplyLtsBoundaryCorrections<
                          EvolutionMetavars>>,
-          tmpl::list<evolution::dg::Actions::ApplyBoundaryCorrections<
-                         EvolutionMetavars>,
-                     Actions::RecordTimeStepperData<>,
-                     evolution::Actions::RunEventsAndDenseTriggers<
-                         typename system::primitive_from_conservative>,
-                     Actions::UpdateU<>>>,
+          tmpl::list<
+              evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
+                  EvolutionMetavars>,
+              Actions::RecordTimeStepperData<>,
+              evolution::Actions::RunEventsAndDenseTriggers<
+                  typename system::primitive_from_conservative>,
+              Actions::UpdateU<>>>,
       Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>,
       // Conservative `UpdatePrimitives` expects system to possess
@@ -342,7 +343,8 @@ struct EvolutionMetavars {
 
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginDg>,
       evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
-      evolution::dg::Actions::ApplyBoundaryCorrections<EvolutionMetavars>,
+      evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
+          EvolutionMetavars>,
       tmpl::conditional_t<
           local_time_stepping, tmpl::list<>,
           tmpl::list<Actions::RecordTimeStepperData<>, Actions::UpdateU<>>>,

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -213,13 +213,14 @@ struct EvolutionMetavars {
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<>,
-                     evolution::dg::Actions::ApplyBoundaryCorrections<
+                     evolution::dg::Actions::ApplyLtsBoundaryCorrections<
                          EvolutionMetavars>>,
-          tmpl::list<evolution::dg::Actions::ApplyBoundaryCorrections<
-                         EvolutionMetavars>,
-                     Actions::RecordTimeStepperData<>,
-                     evolution::Actions::RunEventsAndDenseTriggers<>,
-                     Actions::UpdateU<>>>,
+          tmpl::list<
+              evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
+                  EvolutionMetavars>,
+              Actions::RecordTimeStepperData<>,
+              evolution::Actions::RunEventsAndDenseTriggers<>,
+              Actions::UpdateU<>>>,
       Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>,
       Actions::MutateApply<typename RadiationTransport::M1Grey::

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -225,14 +225,15 @@ struct EvolutionMetavars {
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<
                          typename system::primitive_from_conservative>,
-                     evolution::dg::Actions::ApplyBoundaryCorrections<
+                     evolution::dg::Actions::ApplyLtsBoundaryCorrections<
                          EvolutionMetavars>>,
-          tmpl::list<evolution::dg::Actions::ApplyBoundaryCorrections<
-                         EvolutionMetavars>,
-                     Actions::RecordTimeStepperData<>,
-                     evolution::Actions::RunEventsAndDenseTriggers<
-                         typename system::primitive_from_conservative>,
-                     Actions::UpdateU<>>>,
+          tmpl::list<
+              evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
+                  EvolutionMetavars>,
+              Actions::RecordTimeStepperData<>,
+              evolution::Actions::RunEventsAndDenseTriggers<
+                  typename system::primitive_from_conservative>,
+              Actions::UpdateU<>>>,
       Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>,
       VariableFixing::Actions::FixVariables<

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -254,7 +254,8 @@ struct EvolutionMetavars {
 
   using dg_step_actions = tmpl::flatten<tmpl::list<
       evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
-      evolution::dg::Actions::ApplyBoundaryCorrections<EvolutionMetavars>,
+      evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
+          EvolutionMetavars>,
       tmpl::conditional_t<
           local_time_stepping, tmpl::list<>,
           tmpl::list<Actions::RecordTimeStepperData<>,
@@ -268,7 +269,8 @@ struct EvolutionMetavars {
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginDg>,
 
       evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
-      evolution::dg::Actions::ApplyBoundaryCorrections<EvolutionMetavars>,
+      evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
+          EvolutionMetavars>,
       tmpl::conditional_t<
           local_time_stepping, tmpl::list<>,
           tmpl::list<Actions::RecordTimeStepperData<>,

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -235,13 +235,14 @@ struct EvolutionMetavars {
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<>,
-                     evolution::dg::Actions::ApplyBoundaryCorrections<
+                     evolution::dg::Actions::ApplyLtsBoundaryCorrections<
                          EvolutionMetavars>>,
-          tmpl::list<evolution::dg::Actions::ApplyBoundaryCorrections<
-                         EvolutionMetavars>,
-                     Actions::RecordTimeStepperData<>,
-                     evolution::Actions::RunEventsAndDenseTriggers<>,
-                     Actions::UpdateU<>>>,
+          tmpl::list<
+              evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
+                  EvolutionMetavars>,
+              Actions::RecordTimeStepperData<>,
+              evolution::Actions::RunEventsAndDenseTriggers<>,
+              Actions::UpdateU<>>>,
       tmpl::conditional_t<
           use_filtering,
           dg::Actions::Filter<

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
@@ -414,8 +414,12 @@ struct component {
               SetLocalMortarData>>,
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Testing,
-          tmpl::list<::evolution::dg::Actions::ApplyBoundaryCorrections<
-              Metavariables>>>>;
+          tmpl::list<tmpl::conditional_t<
+              Metavariables::local_time_stepping,
+              ::evolution::dg::Actions::ApplyLtsBoundaryCorrections<
+                  Metavariables>,
+              ::evolution::dg::Actions::
+                  ApplyBoundaryCorrectionsToTimeDerivative<Metavariables>>>>>;
 };
 
 template <size_t Dim, TestHelpers::SystemType SystemType,


### PR DESCRIPTION
Having an action that did very different things depending on
Metavariables::local_time_stepping was confusing.

I did not make any attempt to maintain the LTS parts of executables
with obviously broken LTS support, but just substituted the new GTS
action.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
