### PR TITLE
Add type trait for component type

### DIFF
--- a/src/Parallel/Algorithms/AlgorithmArrayDeclarations.hpp
+++ b/src/Parallel/Algorithms/AlgorithmArrayDeclarations.hpp
@@ -27,6 +27,8 @@ namespace Algorithms {
  *   https://charm.readthedocs.io/en/latest/charm++/manual.html#creating-a-ckcallback-object
  * - `cproxy_section`: The charm++ section proxy class. See
  *   https://charm.readthedocs.io/en/latest/charm++/manual.html?#sections-subsets-of-a-chare-array-group
+ * - component_type: this object. Serves to allow checking the component type in
+ *   both source code and the testing framework.
  */
 struct Array {
   template <typename ParallelComponent,
@@ -52,6 +54,8 @@ struct Array {
   template <typename ParallelComponent, typename SpectreArrayIndex>
   using cproxy_section =
       CProxySection_AlgorithmArray<ParallelComponent, SpectreArrayIndex>;
+
+  using component_type = Array;
 };
 }  // namespace Algorithms
 }  // namespace Parallel

--- a/src/Parallel/Algorithms/AlgorithmGroupDeclarations.hpp
+++ b/src/Parallel/Algorithms/AlgorithmGroupDeclarations.hpp
@@ -27,6 +27,8 @@ namespace Algorithms {
  *   https://charm.readthedocs.io/en/latest/charm++/manual.html#creating-a-ckcallback-object
  * - `cproxy_section`: The charm++ section proxy class. See
  *   https://charm.readthedocs.io/en/latest/charm++/manual.html?#sections-subsets-of-a-chare-array-group
+ * - component_type: this object. Serves to allow checking the component type in
+ *   both source code and the testing framework.
  */
 struct Group {
   template <typename ParallelComponent,
@@ -52,6 +54,8 @@ struct Group {
   template <typename ParallelComponent, typename SpectreArrayIndex>
   using cproxy_section =
       CProxySection_AlgorithmGroup<ParallelComponent, SpectreArrayIndex>;
+
+  using component_type = Group;
 };
 }  // namespace Algorithms
 }  // namespace Parallel

--- a/src/Parallel/Algorithms/AlgorithmNodegroupDeclarations.hpp
+++ b/src/Parallel/Algorithms/AlgorithmNodegroupDeclarations.hpp
@@ -27,6 +27,8 @@ namespace Algorithms {
  *   https://charm.readthedocs.io/en/latest/charm++/manual.html#creating-a-ckcallback-object
  * - `cproxy_section`: The charm++ section proxy class. See
  *   https://charm.readthedocs.io/en/latest/charm++/manual.html?#sections-subsets-of-a-chare-array-group
+ * - component_type: this object. Serves to allow checking the component type in
+ *   both source code and the testing framework.
  */
 struct Nodegroup {
   template <typename ParallelComponent,
@@ -52,6 +54,8 @@ struct Nodegroup {
   template <typename ParallelComponent, typename SpectreArrayIndex>
   using cproxy_section =
       CProxySection_AlgorithmNodegroup<ParallelComponent, SpectreArrayIndex>;
+
+  using component_type = Nodegroup;
 };
 }  // namespace Algorithms
 }  // namespace Parallel

--- a/src/Parallel/Algorithms/AlgorithmSingletonDeclarations.hpp
+++ b/src/Parallel/Algorithms/AlgorithmSingletonDeclarations.hpp
@@ -25,6 +25,8 @@ namespace Algorithms {
  * - `ckindex`: A charm++ chare index object. Useful for obtaining entry
  *   method indices that are needed for creating callbacks. See
  *   https://charm.readthedocs.io/en/latest/charm++/manual.html#creating-a-ckcallback-object
+ * - component_type: this object. Serves to allow checking the component type in
+ *   both source code and the testing framework.
  */
 struct Singleton {
   template <typename ParallelComponent, typename SpectreArrayIndex>
@@ -41,6 +43,8 @@ struct Singleton {
 
   template <typename ParallelComponent, typename SpectreArrayIndex>
   using cproxy_section = void;
+
+  using component_type = Singleton;
 };
 }  // namespace Algorithms
 }  // namespace Parallel

--- a/src/Parallel/GlobalCache.hpp
+++ b/src/Parallel/GlobalCache.hpp
@@ -99,6 +99,11 @@ using get_component_if_mocked =
 template <typename Metavariables>
 class MutableGlobalCache : public CBase_MutableGlobalCache<Metavariables> {
  public:
+  // Even though the MutableGlobalCache doesn't run the Algorithm, this type
+  // alias helps in identifying that the MutableGlobalCache is a Group using
+  // Parallel::is_group_v
+  using chare_type = Parallel::Algorithms::Group;
+
   explicit MutableGlobalCache(tuples::tagged_tuple_from_typelist<
                               get_mutable_global_cache_tags<Metavariables>>
                                   mutable_global_cache);
@@ -296,6 +301,10 @@ class GlobalCache : public CBase_GlobalCache<Metavariables> {
   using metavariables = Metavariables;
   /// Typelist of the ParallelComponents stored in the GlobalCache
   using component_list = typename Metavariables::component_list;
+  // Even though the GlobalCache doesn't run the Algorithm, this type alias
+  // helps in identifying that the GlobalCache is a Nodegroup using
+  // Parallel::is_nodegroup_v
+  using chare_type = Parallel::Algorithms::Nodegroup;
 
   /// Constructor used only by the ActionTesting framework and other
   /// non-charm++ tests that don't know about proxies.

--- a/src/Parallel/TypeTraits.hpp
+++ b/src/Parallel/TypeTraits.hpp
@@ -11,6 +11,15 @@
 
 #include "Utilities/TypeTraits.hpp"
 
+/// \cond
+namespace Parallel::Algorithms {
+struct Array;
+struct Singleton;
+struct Group;
+struct Nodegroup;
+}  // namespace Parallel::Algorithms
+/// \endcond
+
 namespace Parallel {
 
 /// \ingroup ParallelGroup
@@ -47,6 +56,34 @@ struct is_bound_array<T, std::void_t<typename T::bind_to>> : std::true_type {
   static_assert(Parallel::is_array_proxy<typename T::bind_to::type>::value,
                 "Can only bind to an array chare");
 };
+
+/// \ingroup ParallelGroup
+/// Check if `T` is a SpECTRE Array
+template <typename T>
+constexpr bool is_array_v =
+    std::is_same_v<Parallel::Algorithms::Array,
+                   typename T::chare_type::component_type>;
+
+/// \ingroup ParallelGroup
+/// Check if `T` is a SpECTRE Singleton
+template <typename T>
+constexpr bool is_singleton_v =
+    std::is_same_v<Parallel::Algorithms::Singleton,
+                   typename T::chare_type::component_type>;
+
+/// \ingroup ParallelGroup
+/// Check if `T` is a SpECTRE Group
+template <typename T>
+constexpr bool is_group_v =
+    std::is_same_v<Parallel::Algorithms::Group,
+                   typename T::chare_type::component_type>;
+
+/// \ingroup ParallelGroup
+/// Check if `T` is a SpECTRE Nodegroup
+template <typename T>
+constexpr bool is_nodegroup_v =
+    std::is_same_v<Parallel::Algorithms::Nodegroup,
+                   typename T::chare_type::component_type>;
 
 /// @{
 /// \ingroup ParallelGroup

--- a/tests/Unit/Framework/ActionTesting.hpp
+++ b/tests/Unit/Framework/ActionTesting.hpp
@@ -707,6 +707,8 @@ struct MockArrayChare {
       Component, Index,
       typename MockDistributedObject<Component>::inbox_tags_list,
       MockArrayChare>;
+  static std::string name() { return "Array"; }
+  using component_type = Parallel::Algorithms::Array;
 };
 /// A mock class for the CMake-generated `Parallel::Algorithms::Group`
 struct MockGroupChare {
@@ -715,6 +717,8 @@ struct MockGroupChare {
       Component, Index,
       typename MockDistributedObject<Component>::inbox_tags_list,
       MockGroupChare>;
+  static std::string name() { return "Group"; }
+  using component_type = Parallel::Algorithms::Group;
 };
 /// A mock class for the CMake-generated `Parallel::Algorithms::NodeGroup`
 struct MockNodeGroupChare {
@@ -723,6 +727,8 @@ struct MockNodeGroupChare {
       Component, Index,
       typename MockDistributedObject<Component>::inbox_tags_list,
       MockNodeGroupChare>;
+  static std::string name() { return "Nodegroup"; }
+  using component_type = Parallel::Algorithms::Nodegroup;
 };
 /// A mock class for the CMake-generated `Parallel::Algorithms::Singleton`
 struct MockSingletonChare {
@@ -731,6 +737,8 @@ struct MockSingletonChare {
       Component, Index,
       typename MockDistributedObject<Component>::inbox_tags_list,
       MockSingletonChare>;
+  static std::string name() { return "Singleton"; }
+  using component_type = Parallel::Algorithms::Singleton;
 };
 }  // namespace ActionTesting
 

--- a/tests/Unit/Framework/Tests/Test_ActionTesting.cpp
+++ b/tests/Unit/Framework/Tests/Test_ActionTesting.cpp
@@ -28,6 +28,24 @@
 
 namespace {
 namespace TestSimpleAndThreadedActions {
+struct MockSingleton {
+  using chare_type = ActionTesting::MockSingletonChare;
+};
+struct MockArray {
+  using chare_type = ActionTesting::MockArrayChare;
+};
+struct MockGroup {
+  using chare_type = ActionTesting::MockGroupChare;
+};
+struct MockNodegroup {
+  using chare_type = ActionTesting::MockNodeGroupChare;
+};
+
+static_assert(Parallel::is_singleton_v<MockSingleton>);
+static_assert(Parallel::is_array_v<MockArray>);
+static_assert(Parallel::is_group_v<MockGroup>);
+static_assert(Parallel::is_nodegroup_v<MockNodegroup>);
+
 struct simple_action_a;
 struct simple_action_a_mock;
 struct simple_action_c;

--- a/tests/Unit/Parallel/Test_TypeTraits.cpp
+++ b/tests/Unit/Parallel/Test_TypeTraits.cpp
@@ -23,23 +23,28 @@ class NonpupableClass {};
 
 struct Metavariables {
   enum class Phase { Initialization, Exit };
+  using component_list = tmpl::list<>;
 };
 
 struct SingletonParallelComponent {
   using metavariables = Metavariables;
   using initialization_tags = tmpl::list<>;
+  using chare_type = Parallel::Algorithms::Singleton;
 };
 struct ArrayParallelComponent {
   using metavariables = Metavariables;
   using initialization_tags = tmpl::list<>;
+  using chare_type = Parallel::Algorithms::Array;
 };
 struct GroupParallelComponent {
   using metavariables = Metavariables;
   using initialization_tags = tmpl::list<>;
+  using chare_type = Parallel::Algorithms::Group;
 };
 struct NodegroupParallelComponent {
   using metavariables = Metavariables;
   using initialization_tags = tmpl::list<>;
+  using chare_type = Parallel::Algorithms::Nodegroup;
 };
 
 // If passing proxy to a full array, we expect it to be from a
@@ -124,3 +129,13 @@ static_assert(
     std::is_same_v<
         NodegroupParallelComponent,
         Parallel::get_parallel_component_from_proxy<nodegroup_proxy>::type>);
+
+static_assert(Parallel::is_singleton_v<SingletonParallelComponent>);
+static_assert(Parallel::is_array_v<ArrayParallelComponent>);
+static_assert(Parallel::is_group_v<GroupParallelComponent>);
+static_assert(Parallel::is_nodegroup_v<NodegroupParallelComponent>);
+// These are special because they are (node)groups, but they don't run the
+// Algorithm but they still have a `chare_type` type alias.
+static_assert(
+    Parallel::is_group_v<Parallel::MutableGlobalCache<Metavariables>>);
+static_assert(Parallel::is_nodegroup_v<Parallel::GlobalCache<Metavariables>>);


### PR DESCRIPTION
## Proposed changes

Now that singletons are single-element charm arrays in #3787, determining the type of a parallel component based off its proxy type no longer works. Both Singletons and Arrays now have CProxy_AlgorithmArray as thier proxy type.

These type traits use a new alias `component_type` defined inside the chare type declarations. The MockChares also have this type alias so these new type traits work in both source code and the testing framework.

The GlobalCache and MutableGlobalCache are still parallel components, however, they don't have a `chare_type` alias because they don't run the Algorithm. This adds the `chare_type` alias so that these type traits will work on *any* parallel component (except the mainchare).

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

If you need to know what chare type a parallel component is, a Group, Nodegroup, Singleton, Array, use the `Parallel::is_group_v<Component>`, `Parallel::is_nodegroup_v<Component>`, `Parallel::is_singleton_v<Component>`, `Parallel::is_array_v<Component>` type traits, respectively.

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
