### PR TITLE
Add check for currently open H5 objects before insert/get

### DIFF
--- a/src/Domain/FunctionsOfTime/ReadSpecPiecewisePolynomial.cpp
+++ b/src/Domain/FunctionsOfTime/ReadSpecPiecewisePolynomial.cpp
@@ -31,6 +31,7 @@ void read_spec_piecewise_polynomial(
     const bool quaternion_rotation) {
   h5::H5File<h5::AccessType::ReadOnly> file{file_name};
   for (const auto& [spec_name, spectre_name] : dataset_name_map) {
+    file.close_current_object();
     const auto& dat_file = file.get<h5::Dat>("/" + spec_name);
     const auto& dat_data = dat_file.get_data();
 

--- a/src/IO/H5/Dat.cpp
+++ b/src/IO/H5/Dat.cpp
@@ -47,6 +47,7 @@ Dat::Dat(const bool exists, detail::OpenGroup&& group, const hid_t location,
                                            : 0)
                 ? name
                 : name + extension()),
+      path_(group_.group_path_with_trailing_slash() + name),
       version_(version),
       legend_(std::move(legend)),
       size_{{0, legend_.size()}} {

--- a/src/IO/H5/Dat.hpp
+++ b/src/IO/H5/Dat.hpp
@@ -118,12 +118,15 @@ class Dat : public h5::Object {
    */
   uint32_t get_version() const { return version_; }
 
+  const std::string& subfile_path() const override { return path_; }
+
  private:
   void append_impl(hsize_t number_of_rows, const std::vector<double>& data);
 
   /// \cond HIDDEN_SYMBOLS
   detail::OpenGroup group_;
   std::string name_;
+  std::string path_;
   uint32_t version_;
   std::vector<std::string> legend_;
   std::array<hsize_t, 2> size_;

--- a/src/IO/H5/File.cpp
+++ b/src/IO/H5/File.cpp
@@ -59,9 +59,12 @@ H5File<Access_t>::H5File(std::string file_name, bool append_to_file)
                          << ". Writing from directory: " << file_system::cwd()
                          << ". Trying to open in mode: " << Access_t);
   if (not file_exists) {
+    close_current_object();
     insert_header();
+    close_current_object();
     insert_source_archive();
   }
+  close_current_object();
 }
 
 template <AccessType Access_t>

--- a/src/IO/H5/Header.cpp
+++ b/src/IO/H5/Header.cpp
@@ -17,7 +17,8 @@
 namespace h5 {
 Header::Header(const bool exists, detail::OpenGroup&& group,
                const hid_t location, const std::string& name)
-    : group_(std::move(group)) {
+    : group_(std::move(group)),
+      path_(group_.group_path_with_trailing_slash() + name) {
   if (exists) {
     header_info_ =
         h5::read_rank1_attribute<std::string>(location, name + extension())[0];

--- a/src/IO/H5/Header.hpp
+++ b/src/IO/H5/Header.hpp
@@ -52,12 +52,15 @@ class Header : public h5::Object {
   /// of the simulation that produced the file.
   std::string get_build_info() const;
 
+  const std::string& subfile_path() const override { return path_; }
+
  private:
   /// \cond HIDDEN_SYMBOLS
   detail::OpenGroup group_;
   std::string environment_variables_;
   std::string build_info_;
   std::string header_info_;
+  std::string path_;
 
   static const std::string printenv_delimiter_;
   static const std::string build_info_delimiter_;

--- a/src/IO/H5/Object.hpp
+++ b/src/IO/H5/Object.hpp
@@ -21,5 +21,8 @@ class Object {
   Object& operator=(Object&& /*rhs*/) = delete;  // NOLINT
   virtual ~Object() = default;
   /// \endcond
+
+  /// Return the path to the subfile where this object is stored
+  virtual const std::string& subfile_path() const = 0;
 };
 }  // namespace h5

--- a/src/IO/H5/OpenGroup.cpp
+++ b/src/IO/H5/OpenGroup.cpp
@@ -31,8 +31,9 @@ std::vector<std::string> split_strings(const std::string& s,
 
 namespace h5::detail {
 OpenGroup::OpenGroup(hid_t file_id, const std::string& group_name,
-                     const h5::AccessType access_type) {
-  const std::vector<std::string> path(split_strings(group_name));
+                     const h5::AccessType access_type)
+    : group_path_str_(group_name == "/" ? group_name : group_name + "/") {
+  const std::vector<std::string> path(split_strings(group_path_str_));
   hid_t group_id = file_id;
   group_path_.reserve(path.size());
   for (const auto& current_group : path) {
@@ -66,6 +67,7 @@ OpenGroup::OpenGroup(OpenGroup&& rhs) {
   group_path_ = std::move(rhs.group_path_);
   // clang-tidy: moving trivial type has no effect: might change in future
   group_id_ = std::move(rhs.group_id_);  // NOLINT
+  group_path_str_ = rhs.group_path_str_;
 
   rhs.group_id_ = -1;
 }
@@ -80,6 +82,7 @@ OpenGroup& OpenGroup::operator=(OpenGroup&& rhs) {
   group_path_ = std::move(rhs.group_path_);
   // clang-tidy: moving trivial type has no effect: might change in future
   group_id_ = std::move(rhs.group_id_);  // NOLINT
+  group_path_str_ = rhs.group_path_str_;
 
   rhs.group_id_ = -1;
   return *this;

--- a/src/IO/H5/OpenGroup.hpp
+++ b/src/IO/H5/OpenGroup.hpp
@@ -49,8 +49,13 @@ class OpenGroup {
 
   const hid_t& id() const { return group_id_; }
 
+  const std::string& group_path_with_trailing_slash() const {
+    return group_path_str_;
+  }
+
  private:
   /// \cond HIDDEN_SYMBOLS
+  std::string group_path_str_;
   std::vector<hid_t> group_path_;
   hid_t group_id_{-1};
   /// \endcond

--- a/src/IO/H5/SourceArchive.cpp
+++ b/src/IO/H5/SourceArchive.cpp
@@ -14,7 +14,8 @@
 namespace h5 {
 SourceArchive::SourceArchive(const bool exists, detail::OpenGroup&& group,
                              const hid_t location, const std::string& name)
-    : group_(std::move(group)) {
+    : group_(std::move(group)),
+      path_(group_.group_path_with_trailing_slash() + name) {
   if (exists) {
     source_archive_ =
         read_data<1, std::vector<char>>(location, name + extension());

--- a/src/IO/H5/SourceArchive.hpp
+++ b/src/IO/H5/SourceArchive.hpp
@@ -34,10 +34,13 @@ class SourceArchive : public h5::Object {
 
   const std::vector<char>& get_archive() const { return source_archive_; }
 
+  const std::string& subfile_path() const override { return path_; }
+
  private:
   /// \cond HIDDEN_SYMBOLS
   detail::OpenGroup group_;
   std::vector<char> source_archive_;
+  std::string path_;
   /// \endcond
 };
 }  // namespace h5

--- a/src/IO/H5/StellarCollapseEos.cpp
+++ b/src/IO/H5/StellarCollapseEos.cpp
@@ -15,7 +15,9 @@ namespace h5 {
 StellarCollapseEos::StellarCollapseEos(bool exists, detail::OpenGroup&& group,
                                        const hid_t /*location*/,
                                        const std::string& name)
-    : group_(std::move(group)) {
+    : group_(std::move(group)),
+      path_(name == "/" ? name
+                        : group_.group_path_with_trailing_slash() + name) {
   if (not exists) {
     ERROR("The subfile '" << name << "' does not exist");
   }

--- a/src/IO/H5/StellarCollapseEos.hpp
+++ b/src/IO/H5/StellarCollapseEos.hpp
@@ -43,7 +43,7 @@ class StellarCollapseEos : public h5::Object {
   static std::string extension() { return ""; }
 
   StellarCollapseEos(bool exists, detail::OpenGroup&& group, hid_t location,
-                     const std::string& /*name*/);
+                     const std::string& name);
 
   StellarCollapseEos(const StellarCollapseEos& /*rhs*/) = delete;
   StellarCollapseEos& operator=(const StellarCollapseEos& /*rhs*/) = delete;
@@ -73,8 +73,11 @@ class StellarCollapseEos : public h5::Object {
   boost::multi_array<double, 3> get_rank3_dataset(
       const std::string& dataset_name) const;
 
+  const std::string& subfile_path() const override { return path_; }
+
  private:
   detail::OpenGroup root_group_;
   detail::OpenGroup group_;
+  std::string path_;
 };
 }  // namespace h5

--- a/src/IO/H5/Version.cpp
+++ b/src/IO/H5/Version.cpp
@@ -10,7 +10,8 @@
 namespace h5 {
 Version::Version(bool exists, detail::OpenGroup&& group, hid_t location,
                  std::string name, const uint32_t version)
-    : version_([&exists, &location, &version, &name]() {
+    : path_(group.group_path_with_trailing_slash() + name),
+      version_([&exists, &location, &version, &name]() {
         if (exists) {
           return read_value_attribute<uint32_t>(location, name + extension());
         }
@@ -21,7 +22,8 @@ Version::Version(bool exists, detail::OpenGroup&& group, hid_t location,
 
 Version::Version(bool exists, detail::OpenGroup&& group, hid_t location,
                  std::string name, const std::string version)
-    : version_([&exists, &location, &version, &name]() {
+    : path_(group.group_path_with_trailing_slash() + name),
+      version_([&exists, &location, &version, &name]() {
         if (exists) {
           return read_value_attribute<uint32_t>(location, name + extension());
         }

--- a/src/IO/H5/Version.hpp
+++ b/src/IO/H5/Version.hpp
@@ -54,8 +54,11 @@ class Version : public h5::Object {
 
   uint32_t get_version() const { return version_; }
 
+  const std::string& subfile_path() const override { return path_; }
+
  private:
   /// \cond HIDDEN_SYMBOLS
+  std::string path_;
   uint32_t version_;
   // group_ is necessary since the when the h5::Object is destroyed it closes
   // all groups that were opened to get to it.

--- a/src/IO/H5/VolumeData.cpp
+++ b/src/IO/H5/VolumeData.cpp
@@ -179,6 +179,7 @@ VolumeData::VolumeData(const bool subfile_exists, detail::OpenGroup&& group,
                        ? name
                        : name + extension())
                 : name + extension()),
+      path_(group_.group_path_with_trailing_slash() + name),
       version_(version),
       volume_data_group_(group_.id(), name_, h5::AccessType::ReadWrite) {
   if (subfile_exists) {

--- a/src/IO/H5/VolumeData.hpp
+++ b/src/IO/H5/VolumeData.hpp
@@ -152,9 +152,12 @@ class VolumeData : public h5::Object {
   std::vector<std::vector<std::string>> get_quadratures(
       size_t observation_id) const;
 
+  const std::string& subfile_path() const override { return path_; }
+
  private:
   detail::OpenGroup group_{};
   std::string name_{};
+  std::string path_{};
   uint32_t version_{};
   detail::OpenGroup volume_data_group_{};
   std::string header_{};

--- a/tests/Unit/ControlSystem/Test_WriteData.cpp
+++ b/tests/Unit/ControlSystem/Test_WriteData.cpp
@@ -147,6 +147,7 @@ void check_written_data(
   for (size_t component_num = 0; component_num < total_components;
        component_num++) {
     // per file checks
+    read_file.close_current_object();
     const auto& dataset = read_file.get<h5::Dat>(
         "/ControlSystems/" + ControlSystem::name() + "/" +
         ControlSystem::component_name(component_num));

--- a/tests/Unit/Domain/FunctionsOfTime/Test_ReadSpecPiecewisePolynomial.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_ReadSpecPiecewisePolynomial.cpp
@@ -194,6 +194,7 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.ReadSpecPiecewisePolynomial",
   const std::vector<std::string> expansion_legend{
       "Time", "TLastUpdate", "Nc",  "DerivOrder", "Version",
       "a",    "da",          "d2a", "d3a"};
+  test_file.close_current_object();
   auto& expansion_file = test_file.insert<h5::Dat>(
       "/" + source_names[0], expansion_legend, version_number);
   expansion_file.append(test_expansion);
@@ -215,6 +216,7 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.ReadSpecPiecewisePolynomial",
   const std::vector<std::string> rotation_legend{
       "Time", "TLastUpdate", "Nc",    "DerivOrder", "Version",
       "Phi",  "dPhi",        "d2Phi", "d3Phi"};
+  test_file.close_current_object();
   auto& rotation_file = test_file.insert<h5::Dat>(
       "/" + source_names[1], rotation_legend, version_number);
   rotation_file.append(test_rotation);
@@ -227,6 +229,7 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.ReadSpecPiecewisePolynomial",
   const std::vector<std::string> unity_legend{
       "Time",  "TLastUpdate", "Nc",      "DerivOrder", "Version",
       "Unity", "dUnity",      "d2Unity", "d3Unity"};
+  test_file.close_current_object();
   auto& unity_file = test_file.insert<h5::Dat>("/" + source_names[2],
                                                unity_legend, version_number);
   unity_file.append(test_unity);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
@@ -384,6 +384,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.ScriObserveInterpolated",
         [&random_scri_values, &linear_coefficient, &quadratic_coefficient,
          &l_max, &interpolation_approx, &read_file](auto tag_v) {
           using tag = typename decltype(tag_v)::type;
+          read_file.close_current_object();
           const auto& dataset = read_file.get<h5::Dat>(
               "/" + Actions::detail::ScriOutput<tag>::name());
           const Matrix data_matrix = dataset.get_data();
@@ -409,6 +410,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.ScriObserveInterpolated",
             }
           }
         });
+    read_file.close_current_object();
     const auto& dataset = read_file.get<h5::Dat>("/News_expected");
     const Matrix data_matrix = dataset.get_data();
     for (size_t i = 1; i < data_matrix.rows(); ++i) {

--- a/tests/Unit/IO/H5/Test_H5.cpp
+++ b/tests/Unit/IO/H5/Test_H5.cpp
@@ -742,6 +742,18 @@ SPECTRE_TEST_CASE("Unit.IO.H5.OpenGroupMove", "[Unit][IO][H5]") {
       file_system::rm(file_name2, true);
     }
   }
+  {
+    if (file_system::check_if_file_exists(file_name)) {
+      file_system::rm(file_name, true);
+    }
+    const hid_t file_id = H5Fcreate(file_name.c_str(), h5::h5f_acc_trunc(),
+                                    h5::h5p_default(), h5::h5p_default());
+    h5::detail::OpenGroup group(file_id, "/", h5::AccessType::ReadWrite);
+    CHECK(group.group_path_with_trailing_slash() == "/");
+    h5::detail::OpenGroup group2(file_id, "/group/group2/group3",
+                                 h5::AccessType::ReadWrite);
+    CHECK(group2.group_path_with_trailing_slash() == "/group/group2/group3/");
+  }
 }
 
 SPECTRE_TEST_CASE("Unit.IO.H5.TopologyStreams", "[Unit][IO][H5]") {

--- a/tests/Unit/IO/H5/Test_H5.cpp
+++ b/tests/Unit/IO/H5/Test_H5.cpp
@@ -62,9 +62,10 @@ SPECTRE_TEST_CASE("Unit.IO.H5.File", "[Unit][IO][H5]") {
   my_file0.close_current_object();
 
   const auto check_header = [&h5_file_name](const auto& my_file) {
+    const auto& header_obj = my_file.template get<h5::Header>("/header");
+    CHECK(header_obj.subfile_path() == "/header");
     // Check that the header was written correctly
-    const std::string my_header =
-        my_file.template get<h5::Header>("/header").get_header();
+    const std::string my_header = header_obj.get_header();
 
     CHECK(my_file.name() == h5_file_name);
 
@@ -79,10 +80,9 @@ SPECTRE_TEST_CASE("Unit.IO.H5.File", "[Unit][IO][H5]") {
                       << "# "
                       << std::regex_replace(info_from_build(), std::regex{"\n"},
                                             "\n# ")});
-    CHECK(my_file.template get<h5::Header>("/header").get_env_variables() ==
+    CHECK(header_obj.get_env_variables() ==
           formaline::get_environment_variables());
-    CHECK(my_file.template get<h5::Header>("/header").get_build_info() ==
-          formaline::get_build_info());
+    CHECK(header_obj.get_build_info() == formaline::get_build_info());
   };
   check_header(my_file0);
   check_header(h5::H5File<h5::AccessType::ReadOnly>(h5_file_name));
@@ -251,6 +251,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.Version", "[Unit][IO][H5]") {
   // [h5file_read_version]
   const auto& const_version = my_file.get<h5::Version>("/the_version");
   // [h5file_read_version]
+  CHECK(const_version.subfile_path() == "/the_version");
   CHECK(version_number == const_version.get_version());
   auto& version = my_file.get<h5::Version>("/the_version");
   CHECK(version_number == version.get_version());
@@ -419,6 +420,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.DatRead", "[Unit][IO][H5]") {
   }
   h5::H5File<h5::AccessType::ReadOnly> my_file(h5_file_name);
   const auto& error_file = my_file.get<h5::Dat>("/L2_errors");
+  CHECK(error_file.subfile_path() == "/L2_errors");
 
   // Check version info is correctly retrieved from Dat file
   CHECK(error_file.get_version() == version_number);

--- a/tests/Unit/IO/H5/Test_H5.py
+++ b/tests/Unit/IO/H5/Test_H5.py
@@ -41,6 +41,7 @@ class TestIOH5File(unittest.TestCase):
         file_spec.insert_dat(path="/element_data",
                              legend=["Time", "Value"],
                              version=0)
+        file_spec.close()
         datfile = file_spec.get_dat(path="/element_data")
         self.assertEqual(datfile.get_version(), 0)
         file_spec.close()
@@ -51,6 +52,7 @@ class TestIOH5File(unittest.TestCase):
         file_spec.insert_dat(path="/element_data",
                              legend=["Time", "Value"],
                              version=0)
+        file_spec.close()
         datfile = file_spec.get_dat(path="/element_data")
         datfile.append(self.data_1)
         outdata_array = np.asarray(datfile.get_data())
@@ -63,6 +65,7 @@ class TestIOH5File(unittest.TestCase):
         file_spec.insert_dat(path="/element_data",
                              legend=["Time", "Value"],
                              version=0)
+        file_spec.close()
         datfile = file_spec.get_dat(path="/element_data")
         datfile.append(self.data_1)
         datfile.append(self.data_2)
@@ -80,6 +83,7 @@ class TestIOH5File(unittest.TestCase):
         file_spec.insert_dat(path="/element_data",
                              legend=["Time", "Value"],
                              version=0)
+        file_spec.close()
         datfile = file_spec.get_dat(path="/element_data")
         self.assertEqual(datfile.get_legend(), ["Time", "Value"])
         self.assertEqual(datfile.get_version(), 0)
@@ -91,6 +95,7 @@ class TestIOH5File(unittest.TestCase):
         file_spec.insert_dat(path="/element_data",
                              legend=["Time", "Value"],
                              version=0)
+        file_spec.close()
         datfile = file_spec.get_dat(path="/element_data")
         self.assertEqual(datfile.get_header()[0:16], "#\n# File created")
         file_spec.close()
@@ -100,12 +105,15 @@ class TestIOH5File(unittest.TestCase):
         file_spec.insert_dat(path="/element_data",
                              legend=["Time", "Value"],
                              version=0)
+        file_spec.close()
         file_spec.insert_dat(path="/element_position",
                              legend=["x", "y", "z"],
                              version=0)
+        file_spec.close()
         file_spec.insert_dat(path="/element_size",
                              legend=["Time", "Size"],
                              version=0)
+        file_spec.close()
         groups_spec = [
             "element_data.dat", "element_position.dat", "element_size.dat",
             "src.tar.gz"
@@ -141,6 +149,7 @@ class TestIOH5File(unittest.TestCase):
                 "\n.*element_data.dat"):
             file_spec.get_vol("/element_dat")
 
+        file_spec.close()
         file_spec.insert_vol(path="/volume_data", version=0)
 
         #insert existing volume data file

--- a/tests/Unit/IO/H5/Test_StellarCollapseEos.cpp
+++ b/tests/Unit/IO/H5/Test_StellarCollapseEos.cpp
@@ -33,6 +33,7 @@ void test_tabulated(const std::string& file_path,
   h5::H5File<h5::AccessType::ReadOnly> sample_file(file_path);
   const auto& sample_data =
       sample_file.get<h5::StellarCollapseEos>(subgroup_path);
+  CHECK(sample_data.subfile_path() == subgroup_path);
 
   // The group /sample_data has the additional dataset "test_data" which
   // is read to verify that we are not in "/"

--- a/tests/Unit/IO/H5/Test_VolumeData.cpp
+++ b/tests/Unit/IO/H5/Test_VolumeData.cpp
@@ -323,6 +323,7 @@ void test() {
   // correct.
   const auto& volume_file =
       my_file.get<h5::VolumeData>("/element_data", version_number);
+  CHECK(volume_file.subfile_path() == "/element_data");
   const auto read_observation_ids = volume_file.list_observation_ids();
   // The observation IDs should be sorted by their observation value
   CHECK(read_observation_ids == std::vector<size_t>{size_t(-1), 8435087234});

--- a/tests/Unit/IO/H5/Test_VolumeData.cpp
+++ b/tests/Unit/IO/H5/Test_VolumeData.cpp
@@ -318,6 +318,7 @@ void test() {
     for (size_t i = 0; i < observation_ids.size(); ++i) {
       write_to_file(observation_ids[i], observation_values[i]);
     }
+    my_file.close_current_object();
   }
   // Open the read volume file and check that the observation id and values are
   // correct.

--- a/tests/Unit/IO/H5/Test_VolumeData.py
+++ b/tests/Unit/IO/H5/Test_VolumeData.py
@@ -30,12 +30,14 @@ class TestVolumeDataWriting(unittest.TestCase):
     # Testing the VolumeData Insert Function
     def test_insert_vol(self):
         self.h5_file.insert_vol(path="/element_data", version=0)
+        self.h5_file.close()
         vol_file = self.h5_file.get_vol(path="/element_data")
         self.assertEqual(vol_file.get_version(), 0)
 
     # Test the header was generated correctly
     def test_vol_get_header(self):
         self.h5_file.insert_vol(path="/element_data", version=0)
+        self.h5_file.close()
         vol_file = self.h5_file.get_vol(path="/element_data")
         self.assertEqual(vol_file.get_header()[0:20], "#\n# File created on ")
 
@@ -61,6 +63,7 @@ class TestVolumeData(unittest.TestCase):
 
         # Insert .vol file to h5 file
         self.h5_file.insert_vol("/element_data", version=0)
+        self.h5_file.close()
         self.vol_file = self.h5_file.get_vol(path="/element_data")
 
         # Set TensorComponent and ExtentsAndTensorVolumeData to

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
@@ -499,6 +499,7 @@ SPECTRE_TEST_CASE(
       [&file](const std::vector<double>& expected_integral,
               const std::vector<std::string>& expected_legend,
               const std::string& group_name) {
+        file.close_current_object();
         const auto& dat_file = file.get<h5::Dat>(group_name);
         const Matrix written_data = dat_file.get_data();
         const auto& written_legend = dat_file.get_legend();

--- a/tests/Unit/Visualization/Python/Test_InterpolateVolumeData.py
+++ b/tests/Unit/Visualization/Python/Test_InterpolateVolumeData.py
@@ -30,6 +30,7 @@ class TestInterpolateH5(unittest.TestCase):
         file1 = spectre_h5.H5File(self.file_name, "a")
         self.volume_name = "/VolumeData"
         file1.insert_vol(self.volume_name, 0)
+        file1.close()
 
         # interpolated solution
         self.sol1 = np.array([


### PR DESCRIPTION
## Proposed changes

Previously, if you had an object open from an H5 file and you tried to either `insert`/`get` another object, the H5 file would allow you to do that by silently closing the previous object internally. This is correct behavior in the sense that only one object can be open at a time. However, this leads to a very poor error message if you do accidentally try to get a reference to two different objects and then use them both (some low level h5 error about the dataset not existing). This PR adds a check in the `get`, `insert`, and `try_insert` functions of an H5 file to ensure there are no currently open objects. If you forgot to close a previous object before using a new one an ERROR is thrown.

To make the error messages more helpful, the path of the currently open object is given along with the path of the object you are trying to get. This is done by adding a `subfile_path()` function to the `Object` base class.

Also, makes this clearer in the docs of the H5 file by making it a warning. Before, the requirement that only one object could be open at a time was sort of hidden in the middle of the docs.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

When `insert`ing or `get`ing an object in an H5 file, you must `close_current_object()` before you can `get`/`insert` a new object.

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
