### PR TITLE
Add Charm++ version 7.0.0 support

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -211,7 +211,7 @@ jobs:
           -D CMAKE_C_COMPILER=clang
           -D CMAKE_CXX_COMPILER=clang++
           -D CMAKE_Fortran_COMPILER=gfortran-8
-          -D CHARM_ROOT=/work/charm_6_10_2/multicore-linux-x86_64-clang
+          -D CHARM_ROOT=/work/charm_7_0_0/multicore-linux-x86_64-clang
           -D CMAKE_BUILD_TYPE=${{ matrix.build_type }}
           -D OVERRIDE_ARCH=x86-64
           -D USE_CCACHE=OFF
@@ -252,7 +252,7 @@ jobs:
           -D CMAKE_C_COMPILER=clang
           -D CMAKE_CXX_COMPILER=clang++
           -D CMAKE_Fortran_COMPILER=gfortran-8
-          -D CHARM_ROOT=/work/charm_6_10_2/multicore-linux-x86_64-clang
+          -D CHARM_ROOT=/work/charm_7_0_0/multicore-linux-x86_64-clang
           -D CMAKE_BUILD_TYPE=Debug
           -D DEBUG_SYMBOLS=OFF
           -D BUILD_PYTHON_BINDINGS=ON
@@ -308,6 +308,7 @@ jobs:
           - clang-11
         build_type: [Debug, Release]
         use_pch: [ON]
+        charm_name: ["Charm 7.0.0"]
         include:
           # Configure ccache sizes. The cache becomes ineffective if it can't
           # hold at least one full build. The sizes for the build configurations
@@ -347,6 +348,8 @@ jobs:
           - compiler: gcc-9
             build_type: Debug
             CMAKE_EXECUTABLE: /opt/local/cmake/3.12.4/bin/cmake
+            CHARM_DIR: /work/charm_6_10_2/multicore-linux-x86_64-
+            charm_name: ["Charm 6.10.2"]
           # Test building with static libraries. Do so with clang in release
           # mode because these builds use up little disk space compared to GCC
           # builds or clang Debug builds
@@ -438,6 +441,8 @@ ${{ env.CACHE_KEY_SUFFIX }}"
           BUILD_SHARED_LIBS=${{ matrix.BUILD_SHARED_LIBS }}
           PYTHON_EXECUTABLE=${{ matrix.PYTHON_EXECUTABLE }}
           CMAKE_EXECUTABLE=${{ matrix.CMAKE_EXECUTABLE }}
+          CHARM_DIR_DEFAULT=/work/charm_7_0_0/multicore-linux-x86_64-
+          CHARM_DIR=${{ matrix.CHARM_DIR }}
           ASAN=${{ matrix.ASAN }}
           MEMORY_ALLOCATOR=${{ matrix.MEMORY_ALLOCATOR }}
           UBSAN_UNDEFINED=${{ matrix.UBSAN_UNDEFINED }}
@@ -452,7 +457,7 @@ ${{ env.CACHE_KEY_SUFFIX }}"
           -D CMAKE_Fortran_COMPILER=${FC}
           -D CMAKE_CXX_FLAGS="${CXXFLAGS} ${{ matrix.EXTRA_CXX_FLAGS }}"
           -D OVERRIDE_ARCH=x86-64
-          -D CHARM_ROOT=/work/charm_6_10_2/multicore-linux-x86_64-${CHARM_CC}
+          -D CHARM_ROOT=${CHARM_DIR:-${CHARM_DIR_DEFAULT}}${CHARM_CC}
           -D CMAKE_BUILD_TYPE=${{ matrix.build_type }}
           -D DEBUG_SYMBOLS=OFF
           -D UNIT_TESTS_IN_TEST_EXECUTABLES=OFF
@@ -604,7 +609,7 @@ ${{ env.CACHE_KEY_SUFFIX }}"
           -D CMAKE_CXX_FLAGS="${CXXFLAGS} ${{ matrix.EXTRA_CXX_FLAGS }}"
           -D OVERRIDE_ARCH=x86-64
           -D BUILD_SHARED_LIBS=ON
-          -D CHARM_ROOT=/work/charm_6_10_2/multicore-linux-x86_64-${CHARM_CC}
+          -D CHARM_ROOT=/work/charm_7_0_0/multicore-linux-x86_64-${CHARM_CC}
           -D CMAKE_BUILD_TYPE=${{ matrix.build_type }}
           -D DEBUG_SYMBOLS=OFF
           -D UNIT_TESTS_IN_TEST_EXECUTABLES=OFF
@@ -981,7 +986,7 @@ ${{ env.CACHE_KEY_SUFFIX }}"
             -D CMAKE_Fortran_COMPILER=${FC}\
             -D CMAKE_CXX_FLAGS="${CXXFLAGS}"\
             -D OVERRIDE_ARCH=${OVERRIDE_ARCH}\
-            -D CHARM_ROOT=/work/charm_6_10_2/multicore-linux-x86_64-${CHARM_CC}\
+            -D CHARM_ROOT=/work/charm_7_0_0/multicore-linux-x86_64-${CHARM_CC}\
             -D CMAKE_BUILD_TYPE=Debug\
             -D DEBUG_SYMBOLS=OFF\
             -D STRIP_SYMBOLS=ON\

--- a/cmake/FindCharm.cmake
+++ b/cmake/FindCharm.cmake
@@ -398,6 +398,7 @@ find_package_handle_standard_args(
 
 mark_as_advanced(
   CHARM_COMPILER
+  CHARM_INCLUDE_DIR
   CHARM_VERSION_MAJOR
   CHARM_VERSION_MINOR
   CHARM_VERSION_PATCH

--- a/cmake/SetupCharm.cmake
+++ b/cmake/SetupCharm.cmake
@@ -42,9 +42,13 @@ find_package(Charm ${SPECTRE_REQUIRED_CHARM_VERSION} REQUIRED
   EveryLB
   ${SCOTCHLB_COMPONENT}
   )
-if(CHARM_VERSION VERSION_GREATER 6.10.2)
-  message(WARNING "Builds with Charm++ versions greater than 6.10.2 are \
+if(CHARM_VERSION VERSION_GREATER 7.0.0)
+  message(WARNING "Builds with Charm++ versions greater than 7.0.0 are \
 considered experimental. Please file any issues you encounter.")
+endif()
+if(CHARM_VERSION VERSION_LESS 7.0.0)
+  message(STATUS "You are using a Charm++ version below the recommended \
+7.0.0. Please upgrade Charm++ if you run into issues.")
 endif()
 
 if (USE_SCOTCH_LB)
@@ -86,3 +90,25 @@ configure_file(
 )
 
 include(SetupCharmModuleFunctions)
+
+# Make sure Charm++ was patched. If not you can get thread local storage errors
+# when loading the python bindings.
+if(NOT APPLE AND CHARM_VERSION VERSION_EQUAL 7.0.0 AND BUILD_PYTHON_BINDINGS)
+  # Check that the patch was applied:
+  set(CHARM_CHECK_FILE "${CHARM_INCLUDE_DIR}/conv-mach-opt.sh")
+  if (EXISTS ${CHARM_CHECK_FILE})
+    set(_CHARM_CMAKE_FILE_TO_CHECK ${CHARM_CHECK_FILE})
+    file(READ ${_CHARM_CMAKE_FILE_TO_CHECK} FILE_CONTENTS)
+    set(_EXPECTED_TLS_STRING "-ftls-model=initial-exec")
+    string(FIND "${FILE_CONTENTS}"
+      ${_EXPECTED_TLS_STRING} _LOCATION_OF_TLS)
+    if (NOT ${_LOCATION_OF_TLS} EQUAL -1)
+      message(FATAL_ERROR "Found -ftls-model=initial-exec flag. "
+        "It looks like you forgot to apply the Charm++ patch. "
+        "This is necessary when using the python bindings.")
+    endif()
+  else()
+    message(STATUS "Unable to check if Charm++ was patched. "
+      "Missing file ${CHARM_CHECK_FILE}")
+  endif()
+endif()

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -251,6 +251,19 @@ RUN git clone --single-branch --branch v6.10.2 --depth 1 \
       ${PARALLEL_MAKE_ARG} -g -O2 --build-shared\
     && rm -r /work/charm_6_10_2/doc /work/charm_6_10_2/examples
 
+RUN wget https://raw.githubusercontent.com/sxs-collaboration/spectre/develop/support/Charm/v7.0.0.patch
+
+RUN git clone --single-branch --branch v7.0.0 --depth 1 \
+        https://github.com/UIUC-PPL/charm charm_7_0_0 \
+    && cd /work/charm_7_0_0 \
+    && git checkout v7.0.0 \
+    && git apply /work/v7.0.0.patch \
+    && ./build LIBS multicore-linux-x86_64 gcc \
+      ${PARALLEL_MAKE_ARG} -g -O2 --build-shared \
+    && ./build LIBS multicore-linux-x86_64 clang \
+      ${PARALLEL_MAKE_ARG} -g -O2 --build-shared\
+    && rm -r /work/charm_7_0_0/doc /work/charm_7_0_0/examples
+
 # - Set the environment variable SPECTRE_CONTAINER so we can check if we are
 #   inside a container (0 is true in bash)
 # - The singularity containers work better if the locale is set properly

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -56,7 +56,7 @@ all of these dependencies.
 * [GCC](https://gcc.gnu.org/) 7.0 or later,
 [Clang](https://clang.llvm.org/) 8.0 or later, or AppleClang 11.0.0 or later
 * [CMake](https://cmake.org/) 3.12.0 or later
-* [Charm++](http://charm.cs.illinois.edu/) 6.10.2, or 7.0.0 or later (experimental)
+* [Charm++](http://charm.cs.illinois.edu/) 6.10.2, 7.0.0, or later (experimental)
 * [Git](https://git-scm.com/)
 * BLAS (e.g. [OpenBLAS](http://www.openblas.net))
 * [Blaze](https://bitbucket.org/blaze-lib/blaze/overview) v3.8. It can be
@@ -171,7 +171,7 @@ To build with the Docker image:
    You will end up in a bash shell in the docker container,
    as root (you need to be root).
    Within the container, the files in SPECTRE_ROOT are available and Charm++ is
-   installed in `/work/charm_6_10_2`. For the following steps, stay inside the
+   installed in `/work/charm_7_0_0`. For the following steps, stay inside the
    docker container as root.
 3. Proceed with [building SpECTRE](#building-spectre).
 
@@ -302,8 +302,6 @@ with a plain `spack install` if you prefer.
   modules](https://spack.readthedocs.io/en/latest/module_file_support.html) for
   details.
 - On macOS:
-  - Spack's Charm++ 6.10.2 installation is broken, so install `charmpp@7.0.0` or
-    [build Charm++ manually](#building-charm).
   - Brigand has an issue with AppleClang 13 when compiling tests (see
     https://github.com/edouarda/brigand/issues/274). Since it is header-only,
     you can simply clone the [Brigand repository](https://github.com/edouarda/brigand)
@@ -318,8 +316,11 @@ and in their [documentation](https://charm.readthedocs.io/en/latest/quickstart.h
 Here are a few notes:
 
 - Once you cloned the [Charm++ repository](https://github.com/UIUC-PPL/charm),
-  run `git checkout v6.10.2` to switch to a supported, stable release of
+  run `git checkout v7.0.0` to switch to a supported, stable release of
   Charm++.
+- Apply the appropriate patch (if there is one) for the version from
+  `${SPECTRE_ROOT}/support/Charm`. For example, if you have Charm++ v7.0.0
+  then the patch will be `v7.0.0.patch`.
 - Choose the `LIBS` target to compile. This is needed so that we can support the
   more sophisticated load balancers in SpECTRE executables.
 - On a personal machine the correct target architecture is likely
@@ -347,8 +348,8 @@ Follow these steps:
    you may create more later, e.g., `build-clang-Debug`. Then, `cd` into the
    build directory.
 2. Determine the location of your Charm++ installation. In the Docker container
-   it is `/work/charm_6_10_2/multicore-linux-x86_64-gcc` for GCC builds and
-   `/work/charm_6_10_2/multicore-linux-x86_64-clang` for clang builds. For Spack
+   it is `/work/charm_7_0_0/multicore-linux-x86_64-gcc` for GCC builds and
+   `/work/charm_7_0_0/multicore-linux-x86_64-clang` for clang builds. For Spack
    installations you can determine it with
    `spack location --install-dir charmpp`. We refer to the install directory as
    `CHARM_ROOT` below.

--- a/support/Charm/v7.0.0.patch
+++ b/support/Charm/v7.0.0.patch
@@ -1,0 +1,52 @@
+diff --git a/cmake/detect-features-cxx.cmake b/cmake/detect-features-cxx.cmake
+index d3aa6ab94..830da9cf1 100644
+--- a/cmake/detect-features-cxx.cmake
++++ b/cmake/detect-features-cxx.cmake
+@@ -38,12 +38,12 @@ endif()
+ 
+ # Needed so that tlsglobals works correctly with --build-shared
+ # See https://github.com/UIUC-PPL/charm/issues/3168 for details.
+-check_cxx_compiler_flag("-ftls-model=initial-exec" CMK_COMPILER_KNOWS_FTLS_MODEL)
+-if(CMK_COMPILER_KNOWS_FTLS_MODEL)
+-  set(OPTS_CC "${OPTS_CC} -ftls-model=initial-exec")
+-  set(OPTS_CXX "${OPTS_CXX} -ftls-model=initial-exec")
+-  set(OPTS_LD "${OPTS_LD} -ftls-model=initial-exec")
+-endif()
++# check_cxx_compiler_flag("-ftls-model=initial-exec" CMK_COMPILER_KNOWS_FTLS_MODEL)
++# if(CMK_COMPILER_KNOWS_FTLS_MODEL)
++#   set(OPTS_CC "${OPTS_CC} -ftls-model=initial-exec")
++#   set(OPTS_CXX "${OPTS_CXX} -ftls-model=initial-exec")
++#   set(OPTS_LD "${OPTS_LD} -ftls-model=initial-exec")
++# endif()
+ 
+ # Allow seeing own symbols dynamically, needed for programmatic backtraces
+ check_cxx_compiler_flag("-rdynamic" CMK_COMPILER_KNOWS_RDYNAMIC)
+diff --git a/src/scripts/configure.ac b/src/scripts/configure.ac
+index f6c0f311b..41a7c9f46 100644
+--- a/src/scripts/configure.ac
++++ b/src/scripts/configure.ac
+@@ -820,15 +820,15 @@ then
+ fi
+ 
+ # Needed so that tlsglobals works correctly with --build-shared
+-# See https://github.com/UIUC-PPL/charm/issues/3168 for details.
+-test_cxx "whether C++ compiler accepts -ftls-model=initial-exec" "yes" "no" "-ftls-model=initial-exec"
+-if test $strictpass -eq 1
+-then
+-    add_flag 'CMK_COMPILER_KNOWS_FTLS_MODEL="1"' "tlsglobals"
+-    OPTS_CC="$OPTS_CC -ftls-model=initial-exec"
+-    OPTS_CXX="$OPTS_CXX -ftls-model=initial-exec"
+-    OPTS_LD="$OPTS_LD -ftls-model=initial-exec"
+-fi
++# # See https://github.com/UIUC-PPL/charm/issues/3168 for details.
++# test_cxx "whether C++ compiler accepts -ftls-model=initial-exec" "yes" "no" "-ftls-model=initial-exec"
++# if test $strictpass -eq 1
++# then
++#     add_flag 'CMK_COMPILER_KNOWS_FTLS_MODEL="1"' "tlsglobals"
++#     OPTS_CC="$OPTS_CC -ftls-model=initial-exec"
++#     OPTS_CXX="$OPTS_CXX -ftls-model=initial-exec"
++#     OPTS_LD="$OPTS_LD -ftls-model=initial-exec"
++# fi
+ 
+ # Test for a flag important for shared linking
+ test_cxx "whether C++ compiler accepts -fvisibility=hidden" "yes" "no" "-fvisibility=hidden"

--- a/support/Environments/expanse_gcc.sh
+++ b/support/Environments/expanse_gcc.sh
@@ -245,15 +245,19 @@ EOF
         echo "Charm++ is already installed"
     else
         echo "Installing Charm++..."
-        wget https://github.com/UIUC-PPL/charm/archive/v6.10.2.tar.gz
-        tar xzf v6.10.2.tar.gz
-        mv charm-6.10.2 charm
+        CHARM_VERSION=7.0.0
+        wget https://github.com/UIUC-PPL/charm/archive/v${CHARM_VERSION}.tar.gz
+        tar xzf v${CHARM_VERSION}.tar.gz
+        mv charm-${CHARM_VERSION} charm
         cd $dep_dir/charm
-        ./build charm++ verbs-linux-x86_64-smp --with-production -j4
-        ./build EveryLB verbs-linux-x86_64-smp --with-production -j4
-        ./build ScotchLB verbs-linux-x86_64-smp --with-production -j4
+        if [ -f ${SPECTRE_HOME}/support/Charm/v${CHARM_VERSION}.patch ]; then
+            git apply ${SPECTRE_HOME}/support/Charm/v${CHARM_VERSION}.patch
+        fi
+        ./build LIBS verbs-linux-x86_64-smp --with-production -j4
+        cd verbs-linux-x86_64-smp
+        make ScotchLB
         cd $dep_dir
-        rm v6.10.2.tar.gz
+        rm v${CHARM_VERSION}.tar.gz
         echo "Installed Charm++ into $dep_dir/charm"
         cat >$dep_dir/modules/charm <<EOF
 #%Module1.0
@@ -262,7 +266,7 @@ prepend-path LD_LIBRARY_PATH "$dep_dir/charm/verbs-linux-x86_64-smp/lib"
 prepend-path CPATH "$dep_dir/charm/verbs-linux-x86_64-smp/include"
 prepend-path CMAKE_PREFIX_PATH "$dep_dir/charm/verbs-linux-x86_64-smp/"
 prepend-path PATH "$dep_dir/charm/verbs-linux-x86_64-smp/bin"
-setenv CHARM_VERSION 6.10.2
+setenv CHARM_VERSION ${CHARM_VERSION}
 setenv CHARM_HOME $dep_dir/charm/verbs-linux-x86_64-smp
 setenv CHARM_ROOT $dep_dir/charm/verbs-linux-x86_64-smp
 EOF

--- a/support/Environments/ocean_clang.sh
+++ b/support/Environments/ocean_clang.sh
@@ -36,7 +36,7 @@ spectre_unload_modules() {
     module unload hdf5-1.12.0-gcc-7.3.0-mknp6xv
     module unload openblas-0.3.4-gcc-7.3.0-tt2coe7
     module unload python/3.9.5
-    module unload charm-6.10.2-libs
+    module unload charm-7.0.0-nosmp
     module unload doxygen-1.9.1-gcc-7.3.0-nxmwu4a
     module unload zlib-1.2.11-gcc-7.3.0-h3h2oa4
 }
@@ -62,7 +62,7 @@ spectre_load_modules() {
     module load boost-1.68.0-gcc-7.3.0-vgl6ofr
     module load hdf5-1.12.0-gcc-7.3.0-mknp6xv
     module load openblas-0.3.4-gcc-7.3.0-tt2coe7
-    module load charm-6.10.2-libs
+    module load charm-7.0.0-nosmp
     module load doxygen-1.9.1-gcc-7.3.0-nxmwu4a
     module load zlib-1.2.11-gcc-7.3.0-h3h2oa4
 }

--- a/support/Environments/ocean_gcc.sh
+++ b/support/Environments/ocean_gcc.sh
@@ -36,7 +36,7 @@ spectre_unload_modules() {
     module unload hdf5-1.12.0-gcc-7.3.0-mknp6xv
     module unload openblas-0.3.4-gcc-7.3.0-tt2coe7
     module unload python/3.9.5
-    module unload charm-6.10.2-libs
+    module unload charm-7.0.0-nosmp
     module unload zlib-1.2.11-gcc-7.3.0-h3h2oa4
 }
 
@@ -61,7 +61,7 @@ spectre_load_modules() {
     module load boost-1.68.0-gcc-7.3.0-vgl6ofr
     module load hdf5-1.12.0-gcc-7.3.0-mknp6xv
     module load openblas-0.3.4-gcc-7.3.0-tt2coe7
-    module load charm-6.10.2-libs
+    module load charm-7.0.0-nosmp
     module load zlib-1.2.11-gcc-7.3.0-h3h2oa4
 }
 

--- a/support/Environments/setup/frontera_gcc.sh
+++ b/support/Environments/setup/frontera_gcc.sh
@@ -156,7 +156,7 @@ fi
 cd $dep_dir
 
 # Set up Charm++ because that can be difficult
-charm_version=6.10.2
+charm_version=7.0.0
 charm_config=ucx-linux-x86_64-smp
 if [ -f $dep_dir/charm/${charm_config}/lib/libck.a ]; then
     echo "Charm++ is already installed"
@@ -166,6 +166,9 @@ else
     tar xzf v${charm_version}.tar.gz
     mv charm-${charm_version} charm
     cd $dep_dir/charm
+    if [ -f ${SPECTRE_HOME}/support/Charm/v${charm_version}.patch ]; then
+        git apply ${SPECTRE_HOME}/support/Charm/v${charm_version}.patch
+    fi
     ./build LIBS ${charm_config} --with-production -j6
     cd $dep_dir
     rm v${charm_version}.tar.gz

--- a/support/Environments/wheeler_clang.sh
+++ b/support/Environments/wheeler_clang.sh
@@ -3,6 +3,11 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+# If Intel MPI gets updated or Charm++ changes the way it builds MPI
+# configurations we might be able to enable clang again.
+echo "Cannot use Clang with Intel MPI v2017.1."
+return 1
+
 spectre_setup_modules() {
     echo "All modules on Wheeler are provided by the system"
 }
@@ -25,7 +30,7 @@ spectre_unload_modules() {
     module unload doxygen/1.8.13
     module unload git/2.8.4
     module unload llvm/10.0.0
-    module unload charm/6.10.2-intelmpi-smp
+    module unload charm/7.0.0-intelmpi-smp
     module unload python/anaconda3-2019.10
     module unload pybind11/2.6.1
 }
@@ -48,7 +53,7 @@ spectre_load_modules() {
     module load doxygen/1.8.13
     module load git/2.8.4
     module load llvm/10.0.0
-    module load charm/6.10.2-intelmpi-smp
+    module load charm/7.0.0-intelmpi-smp
     module load python/anaconda3-2019.10
     module load pybind11/2.6.1
 }

--- a/support/Environments/wheeler_gcc.sh
+++ b/support/Environments/wheeler_gcc.sh
@@ -25,7 +25,7 @@ spectre_unload_modules() {
     module unload doxygen/1.8.13
     module unload git/2.8.4
     module unload lcov/1.13
-    module unload charm/6.10.2-intelmpi-smp
+    module unload charm/7.0.0-intelmpi-smp
     module unload python/anaconda3-2019.10
     module unload pybind11/2.6.1
 }
@@ -48,7 +48,7 @@ spectre_load_modules() {
     module load doxygen/1.8.13
     module load git/2.8.4
     module load lcov/1.13
-    module load charm/6.10.2-intelmpi-smp
+    module load charm/7.0.0-intelmpi-smp
     module load python/anaconda3-2019.10
     module load pybind11/2.6.1
 }

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -356,7 +356,7 @@ standard_checks+=(tabs)
 
 # Check for end-of-line spaces
 trailing_space() {
-    whitelist "$1" '.h5' '.png' &&
+    whitelist "$1" '.h5' '.png' '.patch' &&
     staged_grep -q -E ' +$' "$1"
 }
 trailing_space_report() {
@@ -399,6 +399,7 @@ license() {
               '.png' \
               '.style.yapf' \
               '.svg' \
+              '.patch' \
               'LICENSE' \
               'citation.bib' \
               'cmake/CodeCoverage.cmake$' \


### PR DESCRIPTION
## Proposed changes

- Don't check for version & license in `.patch` files
- Add support for Charm++ v7.0.0
- Keep v6.10.2 support and test it in CI in addition to 7.0.0
- Disable load balancing test that doesn't work with Charm 7
- We need to patch Charm 7 on Linux to get Python bindings to work
- Update HPC systems that I have access to to Charm++ v7.0.0
- Caltech HPC target arch is changed to `skyle-avx512`. They have 2 different types of nodes on that system, and that's the common instruction set between the different nodes.

Note: I still need to test Expanse. It's been down for maintenance. Wheeler I've done unit tests but not a BBH simulations. @knelli2 is working on that right now

Note: Clang no longer works on Wheeler. This because Intel MPI 2017.1 doesn't accept clang as a compiler, and Charm++ doesn't link MPI correctly if we don't use the wrapper. It's the wrapper usage that changed from 6.10.2 to 7.0.0 that causes this to stop working.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
