### PR TITLE
Add function to determine if element is zeroth element

### DIFF
--- a/src/Domain/Structure/ElementId.hpp
+++ b/src/Domain/Structure/ElementId.hpp
@@ -11,6 +11,7 @@
 #include <functional>
 #include <iosfwd>
 #include <limits>
+#include <optional>
 
 #include "Domain/Structure/SegmentId.hpp"
 #include "Domain/Structure/Side.hpp"
@@ -180,6 +181,39 @@ bool operator>=(const ElementId<VolumeDim>& lhs,
                 const ElementId<VolumeDim>& rhs) {
   return !(lhs < rhs);
 }
+
+/// \brief Returns a bool if the element is the zeroth element in the domain.
+///
+/// \details An element is considered to be the zeroth element if its ElementId
+/// `id` has
+/// 1. id.block_id() == 0
+/// 2. All id.segment_ids() have SegmentId.index() == 0
+/// 3. If the argument `grid_index` is specified, id.grid_index() == grid_index.
+///
+/// This means that the only element in a domain that this function will return
+/// `true` for is the element in the lower corner of Block0 of that domain. The
+/// `grid_index` will determine which domain is used for the comparison. During
+/// evolutions, only one domain will be active at a time so it doesn't make
+/// sense to compare the `grid_index`. However, during an elliptic solve
+/// when there are multiple grids, this `grid_index` is useful for specifying
+/// only one element over all domains.
+///
+/// This function is useful if you need a unique element in the domain because
+/// only one element in the whole domain can be the zeroth element.
+///
+/// \parblock
+/// \warning If you have multiple grids and you don't specify the `grid_index`
+/// argument, this function will return `true` for one element in every grid
+/// and thus can't be used to determine a unique element in a simulation; only a
+/// unique element in each grid.
+/// \endparblock
+/// \parblock
+/// \warning If the domain is re-gridded, a different ElementId may represent
+/// the zeroth element.
+/// \endparblock
+template <size_t Dim>
+bool is_zeroth_element(const ElementId<Dim>& id,
+                       const std::optional<size_t>& grid_index = std::nullopt);
 
 // ######################################################################
 // INLINE DEFINITIONS

--- a/tests/Unit/Domain/Structure/Test_ElementId.cpp
+++ b/tests/Unit/Domain/Structure/Test_ElementId.cpp
@@ -171,6 +171,39 @@ void test_element_id() {
   CHECK(ElementId<3>::external_boundary_id().segment_ids() ==
         make_array<3>(SegmentId(ElementId<3>::max_refinement_level - 1, 0)));
   CHECK(ElementId<3>::external_boundary_id().grid_index() == 0);
+
+  ElementId<3> element1(0);
+  ElementId<3> element2{0, 1};
+  ElementId<3> element3(1);
+  ElementId<3> element4{1, 1};
+  ElementId<3> element5{0, {{{1, 0}, {2, 0}, {1, 0}}}};
+  ElementId<3> element6{0, {{{1, 0}, {2, 0}, {1, 0}}}, 1};
+  ElementId<3> element7{0, {{{1, 0}, {2, 1}, {1, 0}}}};
+  ElementId<3> element8{0, {{{1, 0}, {2, 1}, {1, 0}}}, 1};
+  ElementId<3> element9{1, {{{1, 0}, {2, 0}, {1, 0}}}};
+  ElementId<3> element10{1, {{{1, 0}, {2, 0}, {1, 0}}}, 1};
+  ElementId<3> element11{1, {{{1, 0}, {2, 1}, {1, 0}}}};
+  ElementId<3> element12{1, {{{1, 0}, {2, 1}, {1, 0}}}, 1};
+
+  CHECK(is_zeroth_element(element1));
+  CHECK_FALSE(is_zeroth_element(element1, {1}));
+  CHECK(is_zeroth_element(element2));
+  CHECK_FALSE(is_zeroth_element(element2, {0}));
+  CHECK(is_zeroth_element(element2, {1}));
+  CHECK(is_zeroth_element(element5));
+  CHECK_FALSE(is_zeroth_element(element5, {1}));
+  CHECK(is_zeroth_element(element6));
+  CHECK_FALSE(is_zeroth_element(element6, {0}));
+  CHECK(is_zeroth_element(element6, {1}));
+  // Do this just so we don't duplicate the same two checks over and over for
+  // all elements that aren't the zeroth element
+  const std::vector<ElementId<3>> not_zeroth_elements{
+      {element3, element4, element7, element8, element9, element10, element11,
+       element12}};
+  for (const auto& element : not_zeroth_elements) {
+    CHECK_FALSE(is_zeroth_element(element));
+    CHECK_FALSE(is_zeroth_element(element, {1}));
+  }
 }
 
 template <size_t VolumeDim>


### PR DESCRIPTION
An element is considered to be the zeroth element if its ElementId `id` has
1. id.block_id() == 0
2. all id.segment_ids() have SegmentId.index() == 0
3. id.grid_index() == 0

This is a simple way to get a unique element from any domain we may use.

This will be useful in the memory monitors where we have to run an event on all the elements, but only need to invoke a simple action once on a (node)group or singleton.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
