### PR TITLE
Fix ComputeVarsToInterpolate protocol

### DIFF
--- a/src/ParallelAlgorithms/Interpolation/Protocols/ComputeVarsToInterpolate.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Protocols/ComputeVarsToInterpolate.hpp
@@ -5,6 +5,8 @@
 
 #include <type_traits>
 
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Utilities/Gsl.hpp"
@@ -60,8 +62,12 @@ namespace intrp::protocols {
 struct ComputeVarsToInterpolate {
   template <typename ConformingType>
   struct test {
-    struct DummyTag;
-    using example_list = tmpl::list<DummyTag>;
+    template <size_t Dim>
+    struct DummyTag : db::SimpleTag {
+      using type = tnsr::a<DataVector, Dim, Frame::Grid>;
+    };
+    template <size_t Dim>
+    using example_list = tmpl::list<DummyTag<Dim>>;
 
     template <typename T, size_t Dim, typename = std::void_t<>>
     struct has_signature_1 : std::false_type {};
@@ -70,8 +76,8 @@ struct ComputeVarsToInterpolate {
     struct has_signature_1<
         T, Dim,
         std::void_t<decltype(T::apply(
-            std::declval<const gsl::not_null<Variables<example_list>*>>(),
-            std::declval<const Variables<example_list>&>(),
+            std::declval<const gsl::not_null<Variables<example_list<Dim>>*>>(),
+            std::declval<const Variables<example_list<Dim>>&>(),
             std::declval<const Mesh<Dim>&>()))>> : std::true_type {};
 
     template <typename T, size_t Dim, typename = std::void_t<>>
@@ -81,8 +87,8 @@ struct ComputeVarsToInterpolate {
     struct has_signature_2<
         T, Dim,
         std::void_t<decltype(T::apply(
-            std::declval<const gsl::not_null<Variables<example_list>*>>(),
-            std::declval<const Variables<example_list>&>(),
+            std::declval<const gsl::not_null<Variables<example_list<Dim>>*>>(),
+            std::declval<const Variables<example_list<Dim>>&>(),
             std::declval<const Mesh<Dim>&>(),
             std::declval<const Jacobian<DataVector, Dim, Frame::Grid,
                                         Frame::Inertial>&>(),


### PR DESCRIPTION
## Proposed changes

`Variables` require that the databox tags have actual instantiations and not just be forward declarations. This updates the ComputeVarsToInterpolate protocol to adhere to these requirements. Not sure how this passed CI before though...

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
