### PR TITLE
Add function to get mutable cache proxy from GlobalCache

### DIFF
--- a/src/Parallel/GlobalCache.hpp
+++ b/src/Parallel/GlobalCache.hpp
@@ -93,9 +93,13 @@ using get_component_if_mocked =
 ///
 /// `MutableGlobalCache` is not intended to be visible to the end user; its
 /// interface is via the `GlobalCache` member functions
-/// `mutable_cache_item_is_ready`, `mutate`, and `get`.
-/// Accordingly, most documentation of `MutableGlobalCache` is provided
+/// `mutable_global_cache_proxy`, `mutable_cache_item_is_ready`, `mutate`, and
+/// `get`. Accordingly, most documentation of `MutableGlobalCache` is provided
 /// in the relevant `GlobalCache` member functions.
+///
+/// \note Very seldomly will a user need a proxy to the MutableGlobalCache. If
+/// you think that you need it, please consult a core developer to see if there
+/// is a better way to achieve what you are trying to do.
 template <typename Metavariables>
 class MutableGlobalCache : public CBase_MutableGlobalCache<Metavariables> {
  public:
@@ -292,6 +296,8 @@ class GlobalCache : public CBase_GlobalCache<Metavariables> {
  public:
   using proxy_type = CProxy_GlobalCache<Metavariables>;
   using main_proxy_type = CProxy_Main<Metavariables>;
+  using mutable_global_cache_proxy_type =
+      CProxy_MutableGlobalCache<Metavariables>;
   /// Access to the Metavariables template parameter
   using metavariables = Metavariables;
   /// Typelist of the ParallelComponents stored in the GlobalCache
@@ -376,6 +382,11 @@ class GlobalCache : public CBase_GlobalCache<Metavariables> {
   /// MutableGlobalCache (i.e. the GlobalCache is charm-aware).
   bool mutable_global_cache_proxy_is_set() const;
 
+  /// Returns a proxy to the MutableGlobalCache if the proxy has been set. If it
+  /// hasn't been set, an ERROR will occur meaning that this method can't be
+  /// used in the testing framework.
+  mutable_global_cache_proxy_type mutable_global_cache_proxy();
+
  private:
   // clang-tidy: false positive, redundant declaration
   template <typename GlobalCacheTag, typename MV>
@@ -414,7 +425,7 @@ class GlobalCache : public CBase_GlobalCache<Metavariables> {
   // MutableGlobalCache should use the pointer if it is not nullptr,
   // otherwise use the proxy.
   MutableGlobalCache<Metavariables>* mutable_global_cache_{nullptr};
-  CProxy_MutableGlobalCache<Metavariables> mutable_global_cache_proxy_{};
+  mutable_global_cache_proxy_type mutable_global_cache_proxy_{};
   bool parallel_components_have_been_set_{false};
   std::optional<main_proxy_type> main_proxy_;
 };
@@ -509,6 +520,17 @@ GlobalCache<Metavariables>::get_main_proxy() {
 template <typename Metavariables>
 bool GlobalCache<Metavariables>::mutable_global_cache_proxy_is_set() const {
   return mutable_global_cache_ == nullptr;
+}
+
+template <typename Metavariables>
+typename Parallel::GlobalCache<Metavariables>::mutable_global_cache_proxy_type
+GlobalCache<Metavariables>::mutable_global_cache_proxy() {
+  if (not mutable_global_cache_proxy_is_set()) {
+    ERROR(
+        "Cannot get a proxy to the mutable global cache because the proxy "
+        "isn't set.");
+  }
+  return mutable_global_cache_proxy_;
 }
 
 #if defined(__GNUC__) && !defined(__clang__)

--- a/tests/Unit/Parallel/Test_GlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_GlobalCache.cpp
@@ -529,6 +529,11 @@ Test_GlobalCache<Metavariables>::Test_GlobalCache(CkArgMsg*
       const_data_to_be_cached, mutable_global_cache_proxy_, std::nullopt,
       &mutable_global_cache_dependency);
 
+  const auto local_cache = Parallel::local_branch(global_cache_proxy_);
+  auto mutable_global_cache_proxy = local_cache->mutable_global_cache_proxy();
+  SPECTRE_PARALLEL_REQUIRE(mutable_global_cache_proxy ==
+                           mutable_global_cache_proxy_);
+
   CkEntryOptions global_cache_dependency;
   global_cache_dependency.setGroupDepID(global_cache_proxy_.ckGetGroupID());
 

--- a/tests/Unit/Parallel/Test_GlobalCacheDataBox.cpp
+++ b/tests/Unit/Parallel/Test_GlobalCacheDataBox.cpp
@@ -37,9 +37,31 @@ struct Metavars {
       tmpl::list<Tags::IntegerList, Tags::UniquePtrIntegerList>;
   using component_list = tmpl::list<>;
 };
+
+struct EmptyMetavars {
+  using component_list = tmpl::list<>;
+};
+
+void test_mutable_cache_proxy_error() {
+  CHECK_THROWS_WITH(
+      ([]() {
+        MutableGlobalCache<EmptyMetavars> mutable_cache{
+            tuples::TaggedTuple<>{}};
+        GlobalCache<EmptyMetavars> cache{tuples::TaggedTuple<>{},
+                                         &mutable_cache};
+
+        auto mutable_cache_proxy = cache.mutable_global_cache_proxy();
+      })(),
+      Catch::Contains(
+          "Cannot get a proxy to the mutable global cache because the proxy "
+          "isn't set."));
+}
+
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Parallel.GlobalCacheDataBox", "[Unit][Parallel]") {
+  test_mutable_cache_proxy_error();
+
   tuples::TaggedTuple<Tags::IntegerList, Tags::UniquePtrIntegerList> tuple{};
   tuples::get<Tags::IntegerList>(tuple) = std::array<int, 3>{{-1, 3, 7}};
   tuples::get<Tags::UniquePtrIntegerList>(tuple) =


### PR DESCRIPTION
## Proposed changes

This will be needed for the memory monitor in order to get the size of the local mutable cache.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
