### PR TITLE
Allow MockDistributedObject to be sized

### DIFF
--- a/tests/Unit/Framework/MockDistributedObject.hpp
+++ b/tests/Unit/Framework/MockDistributedObject.hpp
@@ -15,6 +15,7 @@
 #include <deque>
 #include <exception>
 #include <memory>
+#include <pup.h>
 #include <tuple>
 #include <unordered_map>
 #include <utility>
@@ -681,6 +682,10 @@ class MockDistributedObject {
   int local_rank_of(int proc_index) const;
   /// @}
 
+ public:
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p);
+
  private:
   template <typename Action, typename... Args, size_t... Is>
   void forward_tuple_to_simple_action(std::tuple<Args...>&& args,
@@ -890,6 +895,16 @@ class MockDistributedObject {
   std::deque<std::unique_ptr<InvokeActionBase>> threaded_action_queue_;
   Parallel::NodeLock node_lock_;
 };
+
+template <typename Component>
+void MockDistributedObject<Component>::pup(PUP::er& p) {
+  if (not p.isSizing()) {
+    ERROR(
+        "MockDistributedObject is not serializable. This pup member can only "
+        "be used for sizing.\n");
+  }
+  p | box_;
+}
 
 template <typename Component>
 void MockDistributedObject<Component>::next_action() {

--- a/tests/Unit/Framework/Tests/Test_ActionTesting.cpp
+++ b/tests/Unit/Framework/Tests/Test_ActionTesting.cpp
@@ -19,6 +19,7 @@
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Requires.hpp"
+#include "Parallel/Serialize.hpp"
 #include "Utilities/TMPL.hpp"
 
 // IWYU pragma: no_forward_declare db::DataBox
@@ -937,10 +938,41 @@ void test_nodegroup_emplace() {
   CHECK(ActionTesting::get_databox_tag<component, ValueTag>(runner, 1) == 1);
 }
 
+struct MetavariablesWithPup {
+  using component_list =
+      tmpl::list<NodeGroupComponent<MetavariablesWithPup>>;
+
+  enum class Phase { Initialization, Testing, Exit };
+
+  void pup(PUP::er& /*p*/) {}
+};
+
+void test_sizing() {
+  using metavars = MetavariablesWithPup;
+  using component = NodeGroupComponent<metavars>;
+  ActionTesting::MockRuntimeSystem<metavars> runner{{}};
+  ActionTesting::emplace_nodegroup_component_and_initialize<component>(&runner,
+                                                                       {-3});
+  auto& cache = ActionTesting::cache<component>(runner, 0_st);
+  auto& proxy = Parallel::get_parallel_component<component>(cache);
+  auto& local_branch = *Parallel::local_branch(proxy);
+
+  // The fact that this doesn't cause an error means it is successful. We aren't
+  // concerned with the actual value
+  const size_t size = size_of_object_in_bytes(local_branch);
+  (void)size;
+
+  CHECK_THROWS_WITH(
+      ([&local_branch]() { serialize(local_branch); }()),
+      Catch::Contains("MockDistributedObject is not serializable. This pup "
+                      "member can only be used for sizing."));
+}
+
 SPECTRE_TEST_CASE("Unit.ActionTesting.NodesAndCores", "[Unit]") {
   test_parallel_info_functions();
   test_group_emplace();
   test_nodegroup_emplace();
+  test_sizing();
 }
 
 }  // namespace TestNodesAndCores


### PR DESCRIPTION
## Proposed changes

This is so we can test memory monitors with the action testing framework. MockDistObj still is not serializable, though. Only sizable.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
