### PR TITLE
Change TensorExpressions interface via changing namespaces

### DIFF
--- a/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
+++ b/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
@@ -28,17 +28,17 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
-namespace TensorExpressions {
+namespace tenex {
 template <typename T1, typename T2, typename ArgsList1, typename ArgsList2,
           int Sign>
 struct AddSub;
-}  // namespace TensorExpressions
+}  // namespace tenex
 template <typename Derived, typename DataType, typename Symm,
           typename IndexList, typename Args, typename ReducedArgs>
 struct TensorExpression;
 /// \endcond
 
-namespace TensorExpressions {
+namespace tenex {
 namespace detail {
 /// \brief Computes the rearranged symmetry of one operand according to the
 /// generic index order of the other operand
@@ -224,8 +224,8 @@ struct AddSubSymmetry<SymmList1<Symm1...>, SymmList2<Symm2...>,
       {TensorIndices2::value...}};
   // positions of tensorindex_values1 in tensorindex_values2
   static constexpr std::array<size_t, NumIndices1> op2_to_op1_map =
-      ::TensorExpressions::compute_tensorindex_transformation(
-          tensorindex_values2, tensorindex_values1);
+      ::tenex::compute_tensorindex_transformation(tensorindex_values2,
+                                                  tensorindex_values1);
 
   static constexpr std::array<std::int32_t, NumIndices1> symm1 = {
       {Symm1::value...}};
@@ -483,7 +483,7 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
   T1 t1_;
   T2 t2_;
 };
-}  // namespace TensorExpressions
+}  // namespace tenex
 
 /*!
  * \ingroup TensorExpressionsGroup
@@ -495,9 +495,9 @@ SPECTRE_ALWAYS_INLINE auto operator+(
     const TensorExpression<T1, X1, Symm1, IndexList1, Args1>& t1,
     const TensorExpression<T2, X2, Symm2, IndexList2, Args2>& t2) {
   using op1_generic_indices =
-      typename TensorExpressions::detail::remove_time_indices<Args1>::type;
+      typename tenex::detail::remove_time_indices<Args1>::type;
   using op2_generic_indices =
-      typename TensorExpressions::detail::remove_time_indices<Args2>::type;
+      typename tenex::detail::remove_time_indices<Args2>::type;
   static_assert(tmpl::size<op1_generic_indices>::value ==
                     tmpl::size<op2_generic_indices>::value,
                 "Tensor addition is only possible when the same number of "
@@ -506,7 +506,7 @@ SPECTRE_ALWAYS_INLINE auto operator+(
       tmpl::equal_members<op1_generic_indices, op2_generic_indices>::value,
       "The generic indices when adding two tensors must be equal. This error "
       "occurs from expressions like R(ti_a, ti_b) + S(ti_c, ti_a)");
-  return TensorExpressions::AddSub<T1, T2, Args1, Args2, 1>(~t1, ~t2);
+  return tenex::AddSub<T1, T2, Args1, Args2, 1>(~t1, ~t2);
 }
 
 /// @{
@@ -547,7 +547,7 @@ SPECTRE_ALWAYS_INLINE auto operator+(
       (... and tt::is_time_index<Args>::value),
       "Can only add a number to a tensor expression that evaluates to a rank 0"
       "tensor.");
-  return t + TensorExpressions::NumberAsExpression(number);
+  return t + tenex::NumberAsExpression(number);
 }
 template <typename T, typename X, typename Symm, typename IndexList,
           typename... Args>
@@ -558,7 +558,7 @@ SPECTRE_ALWAYS_INLINE auto operator+(
       (... and tt::is_time_index<Args>::value),
       "Can only add a number to a tensor expression that evaluates to a rank 0"
       "tensor.");
-  return TensorExpressions::NumberAsExpression(number) + t;
+  return tenex::NumberAsExpression(number) + t;
 }
 /// @}
 
@@ -572,9 +572,9 @@ SPECTRE_ALWAYS_INLINE auto operator-(
     const TensorExpression<T1, X1, Symm1, IndexList1, Args1>& t1,
     const TensorExpression<T2, X2, Symm2, IndexList2, Args2>& t2) {
   using op1_generic_indices =
-      typename TensorExpressions::detail::remove_time_indices<Args1>::type;
+      typename tenex::detail::remove_time_indices<Args1>::type;
   using op2_generic_indices =
-      typename TensorExpressions::detail::remove_time_indices<Args2>::type;
+      typename tenex::detail::remove_time_indices<Args2>::type;
   static_assert(tmpl::size<op1_generic_indices>::value ==
                     tmpl::size<op2_generic_indices>::value,
                 "Tensor subtraction is only possible when the same number of "
@@ -584,7 +584,7 @@ SPECTRE_ALWAYS_INLINE auto operator-(
       "The generic indices when subtracting two tensors must be equal. This "
       "error "
       "occurs from expressions like R(ti_a, ti_b) - S(ti_c, ti_a)");
-  return TensorExpressions::AddSub<T1, T2, Args1, Args2, -1>(~t1, ~t2);
+  return tenex::AddSub<T1, T2, Args1, Args2, -1>(~t1, ~t2);
 }
 
 /// @{
@@ -625,7 +625,7 @@ SPECTRE_ALWAYS_INLINE auto operator-(
       (... and tt::is_time_index<Args>::value),
       "Can only subtract a number from a tensor expression that evaluates to a "
       "rank 0 tensor.");
-  return t - TensorExpressions::NumberAsExpression(number);
+  return t - tenex::NumberAsExpression(number);
 }
 template <typename T, typename X, typename Symm, typename IndexList,
           typename... Args>
@@ -636,6 +636,6 @@ SPECTRE_ALWAYS_INLINE auto operator-(
       (... and tt::is_time_index<Args>::value),
       "Can only subtract a number from a tensor expression that evaluates to a "
       "rank 0 tensor.");
-  return TensorExpressions::NumberAsExpression(number) - t;
+  return tenex::NumberAsExpression(number) - t;
 }
 /// @}

--- a/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
+++ b/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
@@ -505,7 +505,7 @@ SPECTRE_ALWAYS_INLINE auto operator+(
   static_assert(
       tmpl::equal_members<op1_generic_indices, op2_generic_indices>::value,
       "The generic indices when adding two tensors must be equal. This error "
-      "occurs from expressions like R(ti_a, ti_b) + S(ti_c, ti_a)");
+      "occurs from expressions like R(ti::a, ti::b) + S(ti::c, ti::a)");
   return tenex::AddSub<T1, T2, Args1, Args2, 1>(~t1, ~t2);
 }
 
@@ -520,9 +520,9 @@ SPECTRE_ALWAYS_INLINE auto operator+(
 /// Tensors, here is a non-exhaustive list of some of the acceptable forms that
 /// the tensor expression operand could take:
 /// - `R()`
-/// - `R(ti_A, ti_a)`
-/// - `(R(ti_A, ti_B) * S(ti_a, ti_b))`
-/// - `R(ti_t, ti_t)`
+/// - `R(ti::A, ti::a)`
+/// - `(R(ti::A, ti::B) * S(ti::a, ti::b))`
+/// - `R(ti::t, ti::t)`
 ///
 /// \tparam T the derived TensorExpression type of the tensor expression operand
 /// of the sum
@@ -583,7 +583,7 @@ SPECTRE_ALWAYS_INLINE auto operator-(
       tmpl::equal_members<op1_generic_indices, op2_generic_indices>::value,
       "The generic indices when subtracting two tensors must be equal. This "
       "error "
-      "occurs from expressions like R(ti_a, ti_b) - S(ti_c, ti_a)");
+      "occurs from expressions like R(ti::a, ti::b) - S(ti::c, ti::a)");
   return tenex::AddSub<T1, T2, Args1, Args2, -1>(~t1, ~t2);
 }
 
@@ -598,9 +598,9 @@ SPECTRE_ALWAYS_INLINE auto operator-(
 /// Tensors, here is a non-exhaustive list of some of the acceptable forms that
 /// the tensor expression operand could take:
 /// - `R()`
-/// - `R(ti_A, ti_a)`
-/// - `(R(ti_A, ti_B) * S(ti_a, ti_b))`
-/// - `R(ti_t, ti_t)`
+/// - `R(ti::A, ti::a)`
+/// - `(R(ti::A, ti::B) * S(ti::a, ti::b))`
+/// - `R(ti::t, ti::t)`
 ///
 /// \tparam T the derived TensorExpression type of the tensor expression operand
 /// of the difference

--- a/src/DataStructures/Tensor/Expressions/Contract.hpp
+++ b/src/DataStructures/Tensor/Expressions/Contract.hpp
@@ -97,11 +97,11 @@ struct TensorContract
   // "first" and "second" here refer to the position of the indices to contract
   // in the list of indices, with "first" denoting leftmost
   //
-  // e.g. `R(ti_A, ti_b, ti_a)` :
+  // e.g. `R(ti::A, ti::b, ti::a)` :
   // - `first_contracted_index` refers to the
-  //   \ref SpacetimeIndex "TensorIndexType" refered to by `ti_A`
+  //   \ref SpacetimeIndex "TensorIndexType" refered to by `ti::A`
   // - `second_contracted_index` refers to the
-  //   \ref SpacetimeIndex "TensorIndexType" refered to by `ti_a`
+  //   \ref SpacetimeIndex "TensorIndexType" refered to by `ti::a`
   using first_contracted_index = tmpl::at_c<IndexList, FirstContractedIndexPos>;
   using second_contracted_index =
       tmpl::at_c<IndexList, SecondContractedIndexPos>;
@@ -139,7 +139,7 @@ struct TensorContract
   /// `contracted_multi_index` and inserting the maximum `size_t` value at the
   /// two positions of the pair of indices to contract.
   ///
-  /// e.g. `R(ti_A, ti_a, ti_b, ti_c)` represents contracting some
+  /// e.g. `R(ti::A, ti::a, ti::b, ti::c)` represents contracting some
   /// \f$R^{a}{}_{abc}\f$ to \f$R_{bc}\f$. If `contracted_multi_index` is
   /// `[5, 4]` (i.e. `b == 5`, `c == 4`), the returned
   /// `uncontracted_multi_index` is
@@ -191,7 +191,7 @@ struct TensorContract
   /// `SecondContractedIndexValue` is necessary to properly compute the
   /// contraction of special cases where the "starting" index values to insert
   /// at the contracted index positions are not equal. One such case:
-  /// `R(ti_J, ti_j)`, where R is a rank 2 tensor whose first index is spatial
+  /// `R(ti::J, ti::j)`, where R is a rank 2 tensor whose first index is spatial
   /// and whose second index is spacetime. The external call to this function
   /// would require `FirstContractedIndexValue == 0` and
   /// `SecondContractedIndexValue == 1` to ensure the correct "starting" index
@@ -273,13 +273,14 @@ struct TensorContract
  * \details Given a list of values that represent an expression's generic index
  * encodings, this function looks to see if it can find a pair of values that
  * encode one generic index and the generic index with opposite valence, such as
- * `ti_A` and `ti_a`. This denotes a pair of indices that will need to be
+ * `ti::A` and `ti::a`. This denotes a pair of indices that will need to be
  * contracted. If there exists more than one such pair of indices in the
  * expression, the first pair of values found will be returned.
  *
  * For example, if we have tensor \f$R^{ab}{}_{ab}\f$ represented by the tensor
- * expression, `R(ti_A, ti_B, ti_a, ti_b)`, then this will return the positions
- * of the pair of values encoding `ti_A` and `ti_a`, which would be (0, 2)
+ * expression, `R(ti::A, ti::B, ti::a, ti::b)`, then this will return the
+ * positions of the pair of values encoding `ti::A` and `ti::a`, which would be
+ * (0, 2).
  *
  * @param tensorindex_values the TensorIndex values of a tensor expression
  * @return the positions of the first pair of TensorIndex values to contract
@@ -320,8 +321,8 @@ get_first_index_positions_to_contract(
  * recursively created, nesting one contraction expression inside another.
  *
  * For example, if we have tensor \f$R^{ab}{}_{ab}\f$ represented by the tensor
- * expression, `R(ti_A, ti_B, ti_a, ti_b)`, then one contraction expression is
- * created to represent contracting \f$R^{ab}{}_ab\f$ to \f$R^b{}_b\f$, and a
+ * expression, `R(ti::A, ti::B, ti::a, ti::b)`, then one contraction expression
+ * is created to represent contracting \f$R^{ab}{}_ab\f$ to \f$R^b{}_b\f$, and a
  * second to represent contracting \f$R^b{}_b\f$ to the scalar, \f$R\f$.
  *
  * @param t the TensorExpression to potentially contract

--- a/src/DataStructures/Tensor/Expressions/Contract.hpp
+++ b/src/DataStructures/Tensor/Expressions/Contract.hpp
@@ -26,7 +26,7 @@
  * \ingroup TensorExpressionsGroup
  * Holds all possible TensorExpressions currently implemented
  */
-namespace TensorExpressions {
+namespace tenex {
 
 namespace detail {
 
@@ -351,4 +351,4 @@ SPECTRE_ALWAYS_INLINE static constexpr auto contract(
                        IndexList, tmpl::list<TensorIndices...>>{t});
   }
 }
-}  // namespace TensorExpressions
+}  // namespace tenex

--- a/src/DataStructures/Tensor/Expressions/Divide.hpp
+++ b/src/DataStructures/Tensor/Expressions/Divide.hpp
@@ -90,9 +90,9 @@ struct Divide : public TensorExpression<
 /// For example, if `R` and `S` are Tensors, here is a non-exhaustive list of
 /// some of the acceptable forms that `t2` could take:
 /// - `R()`
-/// - `R(ti_A, ti_a)`
-/// - `(R(ti_A, ti_B) * S(ti_a, ti_b))`
-/// - `R(ti_t, ti_t) + 1.0`
+/// - `R(ti::A, ti::a)`
+/// - `(R(ti::A, ti::B) * S(ti::a, ti::b))`
+/// - `R(ti::t, ti::t) + 1.0`
 ///
 /// \param t1 the tensor expression numerator
 /// \param t2 the rank 0 tensor expression denominator

--- a/src/DataStructures/Tensor/Expressions/Divide.hpp
+++ b/src/DataStructures/Tensor/Expressions/Divide.hpp
@@ -19,7 +19,7 @@
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/TMPL.hpp"
 
-namespace TensorExpressions {
+namespace tenex {
 /// \ingroup TensorExpressionsGroup
 /// \brief Defines the tensor expression representing the quotient of one tensor
 /// expression divided by another tensor expression that evaluates to a rank 0
@@ -79,7 +79,7 @@ struct Divide : public TensorExpression<
   T1 t1_;
   T2 t2_;
 };
-}  // namespace TensorExpressions
+}  // namespace tenex
 
 /// \ingroup TensorExpressionsGroup
 /// \brief Returns the tensor expression representing the quotient of one tensor
@@ -102,7 +102,7 @@ SPECTRE_ALWAYS_INLINE auto operator/(
                            typename T1::index_list, typename T1::args_list>& t1,
     const TensorExpression<T2, typename T2::type, typename T2::symmetry,
                            typename T2::index_list, tmpl::list<Args2...>>& t2) {
-  return TensorExpressions::Divide<T1, T2, Args2...>(~t1, ~t2);
+  return tenex::Divide<T1, T2, Args2...>(~t1, ~t2);
 }
 
 /// \ingroup TensorExpressionsGroup
@@ -120,7 +120,7 @@ SPECTRE_ALWAYS_INLINE auto operator/(
     const TensorExpression<T, typename T::type, typename T::symmetry,
                            typename T::index_list, typename T::args_list>& t,
     const double number) {
-  return t * TensorExpressions::NumberAsExpression(1.0 / number);
+  return t * tenex::NumberAsExpression(1.0 / number);
 }
 
 /// \ingroup TensorExpressionsGroup
@@ -136,5 +136,5 @@ SPECTRE_ALWAYS_INLINE auto operator/(
     const double number,
     const TensorExpression<T, typename T::type, typename T::symmetry,
                            typename T::index_list, typename T::args_list>& t) {
-  return TensorExpressions::NumberAsExpression(number) / t;
+  return tenex::NumberAsExpression(number) / t;
 }

--- a/src/DataStructures/Tensor/Expressions/Evaluate.hpp
+++ b/src/DataStructures/Tensor/Expressions/Evaluate.hpp
@@ -2,7 +2,7 @@
 // See LICENSE.txt for details.
 
 /// \file
-/// Defines function TensorExpressions::evaluate(TensorExpression)
+/// Defines function tenex::evaluate(TensorExpression)
 
 #pragma once
 
@@ -22,7 +22,7 @@
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 
-namespace TensorExpressions {
+namespace tenex {
 namespace detail {
 template <size_t NumIndices>
 constexpr bool contains_indices_to_contract(
@@ -113,7 +113,7 @@ constexpr bool is_evaluated_lhs_multi_index(
  * together and fill the provided resultant LHS Tensor `L` with index order
  * (b, a):
  * \code{.cpp}
- * TensorExpressions::evaluate<ti_b, ti_a>(
+ * tenex::evaluate<ti_b, ti_a>(
  *     make_not_null(&L), R(ti_a, ti_b) + S(ti_a, ti_b));
  * \endcode
  *
@@ -250,7 +250,7 @@ void evaluate(
  * Given two rank 2 Tensors `R` and `S` with index order (a, b), add them
  * together and generate the resultant LHS Tensor `L` with index order (b, a):
  * \code{.cpp}
- * auto L = TensorExpressions::evaluate<ti_b, ti_a>(
+ * auto L = tenex::evaluate<ti_b, ti_a>(
  *     R(ti_a, ti_b) + S(ti_a, ti_b));
  * \endcode
  * \metareturns Tensor
@@ -296,4 +296,4 @@ auto evaluate(const RhsTE& rhs_tensorexpression) {
                                 rhs_tensorexpression);
   return lhs_tensor;
 }
-}  // namespace TensorExpressions
+}  // namespace tenex

--- a/src/DataStructures/Tensor/Expressions/Evaluate.hpp
+++ b/src/DataStructures/Tensor/Expressions/Evaluate.hpp
@@ -113,8 +113,8 @@ constexpr bool is_evaluated_lhs_multi_index(
  * together and fill the provided resultant LHS Tensor `L` with index order
  * (b, a):
  * \code{.cpp}
- * tenex::evaluate<ti_b, ti_a>(
- *     make_not_null(&L), R(ti_a, ti_b) + S(ti_a, ti_b));
+ * tenex::evaluate<ti::b, ti::a>(
+ *     make_not_null(&L), R(ti::a, ti::b) + S(ti::a, ti::b));
  * \endcode
  *
  * This represents evaluating: \f$L_{ba} = R_{ab} + S_{ab}\f$
@@ -123,7 +123,7 @@ constexpr bool is_evaluated_lhs_multi_index(
  * template parameters cannot be class types until C++20.
  *
  * @tparam LhsTensorIndices the TensorIndexs of the Tensor on the LHS of the
- * tensor expression, e.g. `ti_a`, `ti_b`, `ti_c`
+ * tensor expression, e.g. `ti::a`, `ti::b`, `ti::c`
  * @param lhs_tensor pointer to the resultant LHS Tensor to fill
  * @param rhs_tensorexpression the RHS TensorExpression to be evaluated
  */
@@ -150,19 +150,20 @@ void evaluate(
       "The generic indices on the LHS of a tensor equation (that is, the "
       "template parameters specified in evaluate<...>) must match the generic "
       "indices of the RHS TensorExpression. This error occurs as a result of a "
-      "call like evaluate<ti_a, ti_b>(R(ti_A, ti_b) * S(ti_a, ti_c)), where "
-      "the generic indices of the evaluated RHS expression are ti_b and ti_c, "
-      "but the generic indices provided for the LHS are ti_a and ti_b.");
+      "call like evaluate<ti::a, ti::b>(R(ti::A, ti::b) * S(ti::a, ti::c)), "
+      "where the generic indices of the evaluated RHS expression are ti::b and "
+      "ti::c, but the generic indices provided for the LHS are ti::a and "
+      "ti::b.");
   static_assert(
       tensorindex_list_is_valid<lhs_tensorindex_list>::value,
       "Cannot evaluate a tensor expression to a LHS tensor with a repeated "
-      "generic index, e.g. evaluate<ti_a, ti_a>. (Note that the concrete "
-      "time indices (ti_T and ti_t) can be repeated.)");
+      "generic index, e.g. evaluate<ti::a, ti::a>. (Note that the concrete "
+      "time indices (ti::T and ti::t) can be repeated.)");
   static_assert(
       not detail::contains_indices_to_contract<num_lhs_indices>(
           {{std::decay_t<decltype(LhsTensorIndices)>::value...}}),
       "Cannot evaluate a tensor expression to a LHS tensor with generic "
-      "indices that would be contracted, e.g. evaluate<ti_A, ti_a>.");
+      "indices that would be contracted, e.g. evaluate<ti::A, ti::a>.");
   // `IndexPropertyCheck` does also check that valence (Up/Lo) of indices that
   // correspond in the RHS and LHS tensors are equal, but the assertion message
   // below does not mention this because a mismatch in valence should have been
@@ -178,7 +179,7 @@ void evaluate(
       "cannot be evaluated to its corresponding index in the LHS tensor. This "
       "is due to a difference in number of spatial dimensions or Frame type "
       "between the index on the RHS and LHS. "
-      "e.g. evaluate<ti_a, ti_b>(L, R(ti_b, ti_a));, where R's first "
+      "e.g. evaluate<ti::a, ti::b>(L, R(ti::b, ti::a));, where R's first "
       "index has 2 spatial dimensions but L's second index has 3 spatial "
       "dimensions. Check RHS and LHS indices that use the same generic index.");
 
@@ -250,8 +251,7 @@ void evaluate(
  * Given two rank 2 Tensors `R` and `S` with index order (a, b), add them
  * together and generate the resultant LHS Tensor `L` with index order (b, a):
  * \code{.cpp}
- * auto L = tenex::evaluate<ti_b, ti_a>(
- *     R(ti_a, ti_b) + S(ti_a, ti_b));
+ * auto L = tenex::evaluate<ti::b, ti::a>(R(ti::a, ti::b) + S(ti::a, ti::b));
  * \endcode
  * \metareturns Tensor
  *
@@ -269,7 +269,7 @@ void evaluate(
  * template parameters cannot be class types until C++20.
  *
  * @tparam LhsTensorIndices the TensorIndexs of the Tensor on the LHS of the
- * tensor expression, e.g. `ti_a`, `ti_b`, `ti_c`
+ * tensor expression, e.g. `ti::a`, `ti::b`, `ti::c`
  * @param rhs_tensorexpression the RHS TensorExpression to be evaluated
  * @return the resultant LHS Tensor with index order specified by
  * LhsTensorIndices

--- a/src/DataStructures/Tensor/Expressions/IndexPropertyCheck.hpp
+++ b/src/DataStructures/Tensor/Expressions/IndexPropertyCheck.hpp
@@ -20,7 +20,7 @@ namespace detail {
 ///
 /// \details
 /// Indices in one tensor correspond to those in another that use the same
-/// generic index, such as `ti_a`. For it to be possible to add, subtract, or
+/// generic index, such as `ti::a`. For it to be possible to add, subtract, or
 /// assign one index to another, this checks that the following is true for the
 /// index and its corresponding index in another tensor:
 /// - has the same valence (`UpLo`)
@@ -35,9 +35,9 @@ namespace detail {
 /// \tparam TensorIndexList1 the first tensor's generic index list
 /// \tparam TensorIndexList2 the second tensor's generic index list
 /// \tparam CurrentTensorIndex1 the current generic index of the first tensor
-/// that is being checked, e.g. the type of `ti_a`
+/// that is being checked, e.g. the type of `ti::a`
 /// \tparam Iteration the position of the current index of the first tensor
-/// being checked, e.g. the position of `ti_a` in the first tensor
+/// being checked, e.g. the position of `ti::a` in the first tensor
 template <typename IndexList1, typename IndexList2, typename TensorIndexList1,
           typename TensorIndexList2, typename CurrentTensorIndex1,
           typename Iteration>
@@ -61,7 +61,7 @@ struct IndexPropertyCheckImpl {
 template <typename IndexList1, typename IndexList2, typename TensorIndexList1,
           typename TensorIndexList2, typename Iteration>
 struct IndexPropertyCheckImpl<IndexList1, IndexList2, TensorIndexList1,
-                              TensorIndexList2, std::decay_t<decltype(ti_T)>,
+                              TensorIndexList2, std::decay_t<decltype(ti::T)>,
                               Iteration> {
   using index1 = tmpl::at<IndexList1, Iteration>;
   using type = std::bool_constant<index1::index_type == IndexType::Spacetime>;
@@ -70,7 +70,7 @@ struct IndexPropertyCheckImpl<IndexList1, IndexList2, TensorIndexList1,
 template <typename IndexList1, typename IndexList2, typename TensorIndexList1,
           typename TensorIndexList2, typename Iteration>
 struct IndexPropertyCheckImpl<IndexList1, IndexList2, TensorIndexList1,
-                              TensorIndexList2, std::decay_t<decltype(ti_t)>,
+                              TensorIndexList2, std::decay_t<decltype(ti::t)>,
                               Iteration> {
   using index1 = tmpl::at<IndexList1, Iteration>;
   using type = std::bool_constant<index1::index_type == IndexType::Spacetime>;

--- a/src/DataStructures/Tensor/Expressions/IndexPropertyCheck.hpp
+++ b/src/DataStructures/Tensor/Expressions/IndexPropertyCheck.hpp
@@ -10,7 +10,7 @@
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "Utilities/TMPL.hpp"
 
-namespace TensorExpressions {
+namespace tenex {
 namespace detail {
 /// @{
 /// \brief Helper struct for checking that one tensor's index is either a
@@ -150,4 +150,4 @@ using IndexPropertyCheck =
     IndexPropertyCheckHelper<IndexList1, IndexList2, TensorIndexList1,
                              TensorIndexList2>;
 }  // namespace detail
-}  // namespace TensorExpressions
+}  // namespace tenex

--- a/src/DataStructures/Tensor/Expressions/LhsTensorSymmAndIndices.hpp
+++ b/src/DataStructures/Tensor/Expressions/LhsTensorSymmAndIndices.hpp
@@ -38,7 +38,7 @@ namespace tenex {
  * index will not appear in the LHS tensor (i.e. there will NOT be a
  * corresponding LHS index where only the time index of that index has been
  * computed and its spatial indices are empty). Therefore, the
- * `LhsTensorIndexList` may not contain time indices (`ti_t` nor `ti_T`).
+ * `LhsTensorIndexList` may not contain time indices (`ti::t` nor `ti::T`).
  *
  * @tparam RhsTensorIndexList the typelist of TensorIndex of the RHS
  * TensorExpression

--- a/src/DataStructures/Tensor/Expressions/LhsTensorSymmAndIndices.hpp
+++ b/src/DataStructures/Tensor/Expressions/LhsTensorSymmAndIndices.hpp
@@ -15,7 +15,7 @@
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/TMPL.hpp"
 
-namespace TensorExpressions {
+namespace tenex {
 /*!
  * \ingroup TensorExpressionsGroup
  * \brief Determines and stores a LHS tensor's symmetry and index list from a
@@ -106,4 +106,4 @@ struct LhsTensorSymmAndIndices<
       Tensor_detail::Structure<symmetry,
                                tmpl::at_c<tensorindextype_list, LhsInts>...>;
 };
-}  // namespace TensorExpressions
+}  // namespace tenex

--- a/src/DataStructures/Tensor/Expressions/Negate.hpp
+++ b/src/DataStructures/Tensor/Expressions/Negate.hpp
@@ -15,7 +15,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
-namespace TensorExpressions {
+namespace tenex {
 /// \ingroup TensorExpressionsGroup
 /// \brief Defines the tensor expression representing the negation of a tensor
 /// expression
@@ -49,7 +49,7 @@ struct Negate
  private:
   T t_;
 };
-}  // namespace TensorExpressions
+}  // namespace tenex
 
 /// \ingroup TensorExpressionsGroup
 /// \brief Returns the tensor expression representing the negation of a tensor
@@ -61,5 +61,5 @@ template <typename T>
 SPECTRE_ALWAYS_INLINE auto operator-(
     const TensorExpression<T, typename T::type, typename T::symmetry,
                            typename T::index_list, typename T::args_list>& t) {
-  return TensorExpressions::Negate<T>(~t);
+  return tenex::Negate<T>(~t);
 }

--- a/src/DataStructures/Tensor/Expressions/NumberAsExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/NumberAsExpression.hpp
@@ -10,7 +10,7 @@
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/TMPL.hpp"
 
-namespace TensorExpressions {
+namespace tenex {
 /// \ingroup TensorExpressionsGroup
 /// \brief Defines an expression representing a `double`
 struct NumberAsExpression
@@ -41,4 +41,4 @@ struct NumberAsExpression
  private:
   double number_;
 };
-}  // namespace TensorExpressions
+}  // namespace tenex

--- a/src/DataStructures/Tensor/Expressions/Product.hpp
+++ b/src/DataStructures/Tensor/Expressions/Product.hpp
@@ -19,7 +19,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
-namespace TensorExpressions {
+namespace tenex {
 namespace detail {
 template <typename T1, typename T2, typename SymmList1 = typename T1::symmetry,
           typename SymmList2 = typename T2::symmetry>
@@ -124,7 +124,7 @@ struct OuterProduct<T1, T2, IndexList1<Indices1...>, IndexList2<Indices2...>,
   T1 t1_;
   T2 t2_;
 };
-}  // namespace TensorExpressions
+}  // namespace tenex
 
 /// \ingroup TensorExpressionsGroup
 /// \brief Returns the tensor expression representing the product of two tensor
@@ -156,8 +156,7 @@ SPECTRE_ALWAYS_INLINE auto operator*(
                            typename T1::index_list, ArgsList1>& t1,
     const TensorExpression<T2, typename T2::type, typename T2::symmetry,
                            typename T2::index_list, ArgsList2>& t2) {
-  return TensorExpressions::contract(
-      TensorExpressions::OuterProduct<T1, T2>(~t1, ~t2));
+  return tenex::contract(tenex::OuterProduct<T1, T2>(~t1, ~t2));
 }
 
 /// @{
@@ -180,13 +179,13 @@ SPECTRE_ALWAYS_INLINE auto operator*(
     const TensorExpression<T, X, typename T::symmetry, typename T::index_list,
                            ArgsList>& t,
     const double number) {
-  return t * TensorExpressions::NumberAsExpression(number);
+  return t * tenex::NumberAsExpression(number);
 }
 template <typename T, typename X, typename ArgsList>
 SPECTRE_ALWAYS_INLINE auto operator*(
     const double number,
     const TensorExpression<T, X, typename T::symmetry, typename T::index_list,
                            ArgsList>& t) {
-  return TensorExpressions::NumberAsExpression(number) * t;
+  return tenex::NumberAsExpression(number) * t;
 }
 /// @}

--- a/src/DataStructures/Tensor/Expressions/SpatialSpacetimeIndex.hpp
+++ b/src/DataStructures/Tensor/Expressions/SpatialSpacetimeIndex.hpp
@@ -21,7 +21,7 @@
 /// TensorExpression equations where generic spatial indices are used for
 /// spacetime indices
 
-namespace TensorExpressions {
+namespace tenex {
 namespace detail {
 template <typename State, typename Element, typename Iteration,
           typename TensorIndexList>
@@ -173,4 +173,4 @@ spatial_spacetime_index_transformation_from_positions(
   return transformation;
 }
 }  // namespace detail
-}  // namespace TensorExpressions
+}  // namespace tenex

--- a/src/DataStructures/Tensor/Expressions/SquareRoot.hpp
+++ b/src/DataStructures/Tensor/Expressions/SquareRoot.hpp
@@ -74,9 +74,9 @@ struct SquareRoot
 /// For example, if `R` and `S` are Tensors, here is a non-exhaustive list of
 /// some of the acceptable forms that `t` could take:
 /// - `R()`
-/// - `R(ti_A, ti_a)`
-/// - `(R(ti_A, ti_B) * S(ti_a, ti_b))`
-/// - `R(ti_t, ti_t) + 1.0`
+/// - `R(ti::A, ti::a)`
+/// - `(R(ti::A, ti::B) * S(ti::a, ti::b))`
+/// - `R(ti::t, ti::t) + 1.0`
 ///
 /// \param t the tensor expression of which to take the square root
 template <typename T, typename X, typename Symm, typename IndexList,

--- a/src/DataStructures/Tensor/Expressions/SquareRoot.hpp
+++ b/src/DataStructures/Tensor/Expressions/SquareRoot.hpp
@@ -14,7 +14,7 @@
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/TMPL.hpp"
 
-namespace TensorExpressions {
+namespace tenex {
 /// \ingroup TensorExpressionsGroup
 /// \brief Defines the tensor expression representing the square root of a
 /// tensor expression that evaluates to a rank 0 tensor
@@ -63,7 +63,7 @@ struct SquareRoot
  private:
   T t_;
 };
-}  // namespace TensorExpressions
+}  // namespace tenex
 
 /// \ingroup TensorExpressionsGroup
 /// \brief Returns the tensor expression representing the square root of a
@@ -83,5 +83,5 @@ template <typename T, typename X, typename Symm, typename IndexList,
           typename... Args>
 SPECTRE_ALWAYS_INLINE auto sqrt(
     const TensorExpression<T, X, Symm, IndexList, tmpl::list<Args...>>& t) {
-  return TensorExpressions::SquareRoot<T, Args...>(~t);
+  return tenex::SquareRoot<T, Args...>(~t);
 }

--- a/src/DataStructures/Tensor/Expressions/TensorAsExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorAsExpression.hpp
@@ -20,7 +20,7 @@
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 
-namespace TensorExpressions {
+namespace tenex {
 namespace detail {
 /// @{
 /// \brief Given a tensor symmetry and the positions of indices where a generic
@@ -209,4 +209,4 @@ struct TensorAsExpression<Tensor<X, Symm, IndexList<Indices...>>,
  private:
   const Tensor<X, Symm, IndexList<Indices...>>* t_ = nullptr;
 };
-}  // namespace TensorExpressions
+}  // namespace tenex

--- a/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
@@ -27,7 +27,7 @@ struct Expression {};
 /// \tparam DataType the type of the data being stored in the Tensor's
 /// \tparam Symm the ::Symmetry of the Derived class
 /// \tparam IndexList the list of \ref SpacetimeIndex "TensorIndex"'s
-/// \tparam Args the tensor indices, e.g. `_a` and `_b` in `F(_a, _b)`
+/// \tparam Args the tensor indices, e.g. `a` and `b` in `F(ti::a, ti::b)`
 /// \cond HIDDEN_SYMBOLS
 template <typename Derived, typename DataType, typename Symm,
           typename IndexList, typename Args = tmpl::list<>,

--- a/src/DataStructures/Tensor/Expressions/TensorIndex.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorIndex.hpp
@@ -16,7 +16,7 @@
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 
-namespace TensorExpressions {
+namespace tenex {
 namespace TensorIndex_detail {
 // The below values are used to separate upper indices from lower indices and
 // spatial indices from spacetime indices.
@@ -49,7 +49,7 @@ static constexpr size_t upper_spatial_sentinel =
     spatial_sentinel + upper_sentinel;
 static constexpr size_t max_sentinel = 2000;
 }  // namespace TensorIndex_detail
-}  // namespace TensorExpressions
+}  // namespace tenex
 
 /*!
  * \ingroup TensorExpressionsGroup
@@ -67,23 +67,22 @@ static constexpr size_t max_sentinel = 2000;
  * respectively.
  */
 template <std::size_t I,
-          Requires<(I < TensorExpressions::TensorIndex_detail::max_sentinel)> =
-              nullptr>
+          Requires<(I < tenex::TensorIndex_detail::max_sentinel)> = nullptr>
 struct TensorIndex {
   using value_type = std::size_t;
   using type = TensorIndex<I>;
   static constexpr value_type value = I;
   static constexpr UpLo valence =
-      ((I < TensorExpressions::TensorIndex_detail::upper_sentinel) or
-       (I >= TensorExpressions::TensorIndex_detail::spatial_sentinel and
-        I < TensorExpressions::TensorIndex_detail::upper_spatial_sentinel))
+      ((I < tenex::TensorIndex_detail::upper_sentinel) or
+       (I >= tenex::TensorIndex_detail::spatial_sentinel and
+        I < tenex::TensorIndex_detail::upper_spatial_sentinel))
           ? UpLo::Lo
           : UpLo::Up;
   static constexpr bool is_spacetime =
-      I < TensorExpressions::TensorIndex_detail::spatial_sentinel;
+      I < tenex::TensorIndex_detail::spatial_sentinel;
 };
 
-namespace TensorExpressions {
+namespace tenex {
 /*!
  * \ingroup TensorExpressionsGroup
  * \brief Returns the TensorIndex value of with opposite valence.
@@ -114,7 +113,7 @@ get_tensorindex_value_with_opposite_valence(const size_t i) {
     return i + TensorIndex_detail::upper_sentinel;
   }
 }
-}  //  namespace TensorExpressions
+}  //  namespace tenex
 
 /// @{
 /*!
@@ -155,80 +154,62 @@ get_tensorindex_value_with_opposite_valence(const size_t i) {
  * highest-valued currently defined generic spacetime `TensorIndex`.
  */
 static constexpr TensorIndex<0> ti_a{};
-static constexpr TensorIndex<
-    TensorExpressions::TensorIndex_detail::upper_sentinel>
-    ti_A{};
+static constexpr TensorIndex<tenex::TensorIndex_detail::upper_sentinel> ti_A{};
 static constexpr TensorIndex<1> ti_b{};
-static constexpr TensorIndex<
-    TensorExpressions::TensorIndex_detail::upper_sentinel + 1>
+static constexpr TensorIndex<tenex::TensorIndex_detail::upper_sentinel + 1>
     ti_B{};
 static constexpr TensorIndex<2> ti_c{};
-static constexpr TensorIndex<
-    TensorExpressions::TensorIndex_detail::upper_sentinel + 2>
+static constexpr TensorIndex<tenex::TensorIndex_detail::upper_sentinel + 2>
     ti_C{};
 static constexpr TensorIndex<3> ti_d{};
-static constexpr TensorIndex<
-    TensorExpressions::TensorIndex_detail::upper_sentinel + 3>
+static constexpr TensorIndex<tenex::TensorIndex_detail::upper_sentinel + 3>
     ti_D{};
 static constexpr TensorIndex<4> ti_e{};
-static constexpr TensorIndex<
-    TensorExpressions::TensorIndex_detail::upper_sentinel + 4>
+static constexpr TensorIndex<tenex::TensorIndex_detail::upper_sentinel + 4>
     ti_E{};
 static constexpr TensorIndex<5> ti_f{};
-static constexpr TensorIndex<
-    TensorExpressions::TensorIndex_detail::upper_sentinel + 5>
+static constexpr TensorIndex<tenex::TensorIndex_detail::upper_sentinel + 5>
     ti_F{};
 static constexpr TensorIndex<6> ti_g{};
-static constexpr TensorIndex<
-    TensorExpressions::TensorIndex_detail::upper_sentinel + 6>
+static constexpr TensorIndex<tenex::TensorIndex_detail::upper_sentinel + 6>
     ti_G{};
 static constexpr TensorIndex<7> ti_h{};
-static constexpr TensorIndex<
-    TensorExpressions::TensorIndex_detail::upper_sentinel + 7>
+static constexpr TensorIndex<tenex::TensorIndex_detail::upper_sentinel + 7>
     ti_H{};
 
-static constexpr TensorIndex<
-    TensorExpressions::TensorIndex_detail::upper_sentinel - 1>
+static constexpr TensorIndex<tenex::TensorIndex_detail::upper_sentinel - 1>
     ti_t{};
-static constexpr TensorIndex<
-    TensorExpressions::TensorIndex_detail::spatial_sentinel - 1>
+static constexpr TensorIndex<tenex::TensorIndex_detail::spatial_sentinel - 1>
     ti_T{};
 
-static constexpr TensorIndex<
-    TensorExpressions::TensorIndex_detail::spatial_sentinel>
+static constexpr TensorIndex<tenex::TensorIndex_detail::spatial_sentinel>
     ti_i{};
-static constexpr TensorIndex<
-    TensorExpressions::TensorIndex_detail::upper_spatial_sentinel>
+static constexpr TensorIndex<tenex::TensorIndex_detail::upper_spatial_sentinel>
     ti_I{};
-static constexpr TensorIndex<
-    TensorExpressions::TensorIndex_detail::spatial_sentinel + 1>
+static constexpr TensorIndex<tenex::TensorIndex_detail::spatial_sentinel + 1>
     ti_j{};
-static constexpr TensorIndex<
-    TensorExpressions::TensorIndex_detail::upper_spatial_sentinel + 1>
+static constexpr TensorIndex<tenex::TensorIndex_detail::upper_spatial_sentinel +
+                             1>
     ti_J{};
-static constexpr TensorIndex<
-    TensorExpressions::TensorIndex_detail::spatial_sentinel + 2>
+static constexpr TensorIndex<tenex::TensorIndex_detail::spatial_sentinel + 2>
     ti_k{};
-static constexpr TensorIndex<
-    TensorExpressions::TensorIndex_detail::upper_spatial_sentinel + 2>
+static constexpr TensorIndex<tenex::TensorIndex_detail::upper_spatial_sentinel +
+                             2>
     ti_K{};
-static constexpr TensorIndex<
-    TensorExpressions::TensorIndex_detail::spatial_sentinel + 3>
+static constexpr TensorIndex<tenex::TensorIndex_detail::spatial_sentinel + 3>
     ti_l{};
-static constexpr TensorIndex<
-    TensorExpressions::TensorIndex_detail::upper_spatial_sentinel + 3>
+static constexpr TensorIndex<tenex::TensorIndex_detail::upper_spatial_sentinel +
+                             3>
     ti_L{};
-static constexpr TensorIndex<
-    TensorExpressions::TensorIndex_detail::spatial_sentinel + 4>
+static constexpr TensorIndex<tenex::TensorIndex_detail::spatial_sentinel + 4>
     ti_m{};
-static constexpr TensorIndex<
-    TensorExpressions::TensorIndex_detail::upper_spatial_sentinel + 4>
+static constexpr TensorIndex<tenex::TensorIndex_detail::upper_spatial_sentinel +
+                             4>
     ti_M{};
-static constexpr TensorIndex<
-    TensorExpressions::TensorIndex_detail::spatial_sentinel + 5>
+static constexpr TensorIndex<tenex::TensorIndex_detail::spatial_sentinel + 5>
     ti_n{};
-static constexpr TensorIndex<
-    TensorExpressions::TensorIndex_detail::upper_spatial_sentinel + 5>
+static constexpr TensorIndex<tenex::TensorIndex_detail::upper_spatial_sentinel +
+                             5>
     ti_N{};
 /// @}
 
@@ -246,7 +227,7 @@ template <typename T>
 struct is_time_index;
 }  // namespace tt
 
-namespace TensorExpressions {
+namespace tenex {
 namespace detail {
 template <auto&... TensorIndices>
 struct make_tensorindex_list_impl {
@@ -342,7 +323,7 @@ using generic_indices_at_same_positions =
         TensorIndexList1, TensorIndexList2,
         tmpl::size<TensorIndexList1>::value ==
             tmpl::size<TensorIndexList2>::value>::type;
-}  // namespace TensorExpressions
+}  // namespace tenex
 
 /*!
  * \ingroup TensorExpressionsGroup
@@ -352,5 +333,4 @@ using generic_indices_at_same_positions =
  */
 template <auto&... TensorIndices>
 using make_tensorindex_list =
-    typename TensorExpressions::detail::make_tensorindex_list_impl<
-        TensorIndices...>::type;
+    typename tenex::detail::make_tensorindex_list_impl<TensorIndices...>::type;

--- a/src/DataStructures/Tensor/Expressions/TensorIndex.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorIndex.hpp
@@ -59,10 +59,10 @@ static constexpr size_t max_sentinel = 2000;
  * Used to denote a tensor index in a tensor slot. This allows the following
  * type of expressions to work:
  * \code{.cpp}
- * auto T = evaluate<ti_a, ti_b>(F(ti_a, ti_b) + S(ti_b, ti_a));
+ * auto T = evaluate<ti::a, ti::b>(F(ti::a, ti::b) + S(ti::b, ti::a));
  * \endcode
- * where `decltype(ti_a) == TensorIndex<0>` and
- * `decltype(ti_b) == TensorIndex<1>`. That is, `ti_a` and `ti_b` are
+ * where `decltype(ti::a) == TensorIndex<0>` and
+ * `decltype(ti::b) == TensorIndex<1>`. That is, `ti::a` and `ti::b` are
  * placeholders for objects of type `TensorIndex<0>` and `TensorIndex<1>`,
  * respectively.
  */
@@ -82,6 +82,102 @@ struct TensorIndex {
       I < tenex::TensorIndex_detail::spatial_sentinel;
 };
 
+/*!
+ * \ingroup TensorExpressionsGroup
+ * \brief Contains definitions for the available `TensorIndex`s to use in a
+ * `TensorExpression`
+ */
+namespace ti {
+/// @{
+/*!
+ * \brief The available `TensorIndex`s to use in a `TensorExpression`
+ *
+ * \details The suffix following `ti::` indicates index properties:
+ * - Uppercase: contravariant/upper index
+ * - Lowercase: covariant/lower index
+ * - A/a - H/h: generic spacetime index
+ * - I/i - M/m: generic spatial index
+ * - T/t: concrete time index (defined as a spacetime `TensorIndex`)
+ *
+ * \snippet Test_AddSubtract.cpp use_tensor_index
+ *
+ * If you want to support a new generic index, definitions for the upper and
+ * lower versions of the index must be added as unique `TensorIndex` types, e.g.
+ * \code
+ * static constexpr TensorIndex<UNIQUE_INTEGER_IN_PROPER_RANGE_LOWER> ti::x{};
+ * static constexpr TensorIndex<UNIQUE_INTEGER_IN_PROPER_RANGE_UPPER> ti::X{};
+ * \endcode
+ * where `UNIQUE_INTEGER_IN_PROPER_RANGE_LOWER` and
+ * `UNIQUE_INTEGER_IN_PROPER_RANGE_UPPER` are unique, but related integers that
+ * fall in the integer ranges that properly encode the index's properties
+ * according to the `_sentinel` values defined at the top of
+ * `src/DataStructures/Tensor/Expressions/TensorIndex.hpp`. This enables the new
+ * index to be distinguishable from others and for the upper and lower versions
+ * to be recognized as related by opposite valence. See comments there on these
+ * integer ranges to properly encode the new index (both upper and lower
+ * definitions) that you wish to add. In short, you should simply be able to
+ * continue the pattern used for the existing `TensorIndex` types that are
+ * already defined. For example, if `ti::M`/`ti::m` is the highest-valued
+ * generic spatial index currently defined and you want to add `ti::N`/`ti::n`
+ * as a new generic spatial index, you can simply define `ti::N` and `ti::n`'s
+ * unique integer values to be `INTEGER_VALUE_FOR_M + 1` and
+ * `INTEGER_VALUE_FOR_m + 1`, respectively. For adding a new generic spacetime
+ * index, you should be able to do the same thing with respect to the upper and
+ * lower versions of the highest-valued currently defined generic spacetime
+ * `TensorIndex`.
+ */
+static constexpr TensorIndex<0> a{};
+static constexpr TensorIndex<tenex::TensorIndex_detail::upper_sentinel> A{};
+static constexpr TensorIndex<1> b{};
+static constexpr TensorIndex<tenex::TensorIndex_detail::upper_sentinel + 1> B{};
+static constexpr TensorIndex<2> c{};
+static constexpr TensorIndex<tenex::TensorIndex_detail::upper_sentinel + 2> C{};
+static constexpr TensorIndex<3> d{};
+static constexpr TensorIndex<tenex::TensorIndex_detail::upper_sentinel + 3> D{};
+static constexpr TensorIndex<4> e{};
+static constexpr TensorIndex<tenex::TensorIndex_detail::upper_sentinel + 4> E{};
+static constexpr TensorIndex<5> f{};
+static constexpr TensorIndex<tenex::TensorIndex_detail::upper_sentinel + 5> F{};
+static constexpr TensorIndex<6> g{};
+static constexpr TensorIndex<tenex::TensorIndex_detail::upper_sentinel + 6> G{};
+static constexpr TensorIndex<7> h{};
+static constexpr TensorIndex<tenex::TensorIndex_detail::upper_sentinel + 7> H{};
+
+static constexpr TensorIndex<tenex::TensorIndex_detail::upper_sentinel - 1> t{};
+static constexpr TensorIndex<tenex::TensorIndex_detail::spatial_sentinel - 1>
+    T{};
+
+static constexpr TensorIndex<tenex::TensorIndex_detail::spatial_sentinel> i{};
+static constexpr TensorIndex<tenex::TensorIndex_detail::upper_spatial_sentinel>
+    I{};
+static constexpr TensorIndex<tenex::TensorIndex_detail::spatial_sentinel + 1>
+    j{};
+static constexpr TensorIndex<tenex::TensorIndex_detail::upper_spatial_sentinel +
+                             1>
+    J{};
+static constexpr TensorIndex<tenex::TensorIndex_detail::spatial_sentinel + 2>
+    k{};
+static constexpr TensorIndex<tenex::TensorIndex_detail::upper_spatial_sentinel +
+                             2>
+    K{};
+static constexpr TensorIndex<tenex::TensorIndex_detail::spatial_sentinel + 3>
+    l{};
+static constexpr TensorIndex<tenex::TensorIndex_detail::upper_spatial_sentinel +
+                             3>
+    L{};
+static constexpr TensorIndex<tenex::TensorIndex_detail::spatial_sentinel + 4>
+    m{};
+static constexpr TensorIndex<tenex::TensorIndex_detail::upper_spatial_sentinel +
+                             4>
+    M{};
+static constexpr TensorIndex<tenex::TensorIndex_detail::spatial_sentinel + 5>
+    n{};
+static constexpr TensorIndex<tenex::TensorIndex_detail::upper_spatial_sentinel +
+                             5>
+    N{};
+/// @}
+}  // namespace ti
+
 namespace tenex {
 /*!
  * \ingroup TensorExpressionsGroup
@@ -92,9 +188,9 @@ namespace tenex {
  * spatial. This function returns the value that corresponds to the encoding of
  * the TensorIndex with the same index type, but opposite valence.
  *
- * For example, 0 is the TensorIndex value for `ti_a`. If `i == 0`, then 500
- * will be returned, which is the TensorIndex value for `ti_A`. If `i == 500`
- * (representing `ti_A`), then 0 (representing `ti_a`) is returned.
+ * For example, 0 is the TensorIndex value for `ti::a`. If `i == 0`, then 500
+ * will be returned, which is the TensorIndex value for `ti::A`. If `i == 500`
+ * (representing `ti::A`), then 0 (representing `ti::a`) is returned.
  *
  * @param i a TensorIndex value that represents a generic index
  * @return the TensorIndex value that encodes the generic index with the
@@ -114,104 +210,6 @@ get_tensorindex_value_with_opposite_valence(const size_t i) {
   }
 }
 }  //  namespace tenex
-
-/// @{
-/*!
- * \ingroup TensorExpressionsGroup
- * \brief The available TensorIndexs to use in a TensorExpression
- *
- * \details The suffix following `ti_` indicates index properties:
- * - Uppercase: contravariant/upper index
- * - Lowercase: covariant/lower index
- * - A/a - H/h: generic spacetime index
- * - I/i - M/m: generic spatial index
- * - T/t: concrete time index (defined as a spacetime `TensorIndex`)
- *
- * \snippet Test_AddSubtract.cpp use_tensor_index
- *
- * If you want to support a new generic index, definitions for the upper and
- * lower versions of the index must be added as unique `TensorIndex` types, e.g.
- * \code
- * static constexpr TensorIndex<UNIQUE_INTEGER_IN_PROPER_RANGE_LOWER> ti_x{};
- * static constexpr TensorIndex<UNIQUE_INTEGER_IN_PROPER_RANGE_UPPER> ti_X{};
- * \endcode
- * where `UNIQUE_INTEGER_IN_PROPER_RANGE_LOWER` and
- * `UNIQUE_INTEGER_IN_PROPER_RANGE_UPPER` are unique, but related integers that
- * fall in the integer ranges that properly encode the index's properties
- * according to the `_sentinel` values defined at the top of
- * `src/DataStructures/Tensor/Expressions/TensorIndex.hpp`. This enables the new
- * index to be distinguishable from others and for the upper and lower versions
- * to be recognized as related by opposite valence. See comments there on these
- * integer ranges to properly encode the new index (both upper and lower
- * definitions) that you wish to add. In short, you should simply be able to
- * continue the pattern used for the existing `TensorIndex` types that are
- * already defined. For example, if `ti_M`/`ti_m` is the highest-valued generic
- * spatial index currently defined and you want to add `ti_N`/`ti_n` as a new
- * generic spatial index, you can simply define `ti_N` and `ti_n`'s unique
- * integer values to be `INTEGER_VALUE_FOR_M + 1` and `INTEGER_VALUE_FOR_m + 1`,
- * respectively. For adding a new generic spacetime index, you should be able to
- * do the same thing with respect to the upper and lower versions of the
- * highest-valued currently defined generic spacetime `TensorIndex`.
- */
-static constexpr TensorIndex<0> ti_a{};
-static constexpr TensorIndex<tenex::TensorIndex_detail::upper_sentinel> ti_A{};
-static constexpr TensorIndex<1> ti_b{};
-static constexpr TensorIndex<tenex::TensorIndex_detail::upper_sentinel + 1>
-    ti_B{};
-static constexpr TensorIndex<2> ti_c{};
-static constexpr TensorIndex<tenex::TensorIndex_detail::upper_sentinel + 2>
-    ti_C{};
-static constexpr TensorIndex<3> ti_d{};
-static constexpr TensorIndex<tenex::TensorIndex_detail::upper_sentinel + 3>
-    ti_D{};
-static constexpr TensorIndex<4> ti_e{};
-static constexpr TensorIndex<tenex::TensorIndex_detail::upper_sentinel + 4>
-    ti_E{};
-static constexpr TensorIndex<5> ti_f{};
-static constexpr TensorIndex<tenex::TensorIndex_detail::upper_sentinel + 5>
-    ti_F{};
-static constexpr TensorIndex<6> ti_g{};
-static constexpr TensorIndex<tenex::TensorIndex_detail::upper_sentinel + 6>
-    ti_G{};
-static constexpr TensorIndex<7> ti_h{};
-static constexpr TensorIndex<tenex::TensorIndex_detail::upper_sentinel + 7>
-    ti_H{};
-
-static constexpr TensorIndex<tenex::TensorIndex_detail::upper_sentinel - 1>
-    ti_t{};
-static constexpr TensorIndex<tenex::TensorIndex_detail::spatial_sentinel - 1>
-    ti_T{};
-
-static constexpr TensorIndex<tenex::TensorIndex_detail::spatial_sentinel>
-    ti_i{};
-static constexpr TensorIndex<tenex::TensorIndex_detail::upper_spatial_sentinel>
-    ti_I{};
-static constexpr TensorIndex<tenex::TensorIndex_detail::spatial_sentinel + 1>
-    ti_j{};
-static constexpr TensorIndex<tenex::TensorIndex_detail::upper_spatial_sentinel +
-                             1>
-    ti_J{};
-static constexpr TensorIndex<tenex::TensorIndex_detail::spatial_sentinel + 2>
-    ti_k{};
-static constexpr TensorIndex<tenex::TensorIndex_detail::upper_spatial_sentinel +
-                             2>
-    ti_K{};
-static constexpr TensorIndex<tenex::TensorIndex_detail::spatial_sentinel + 3>
-    ti_l{};
-static constexpr TensorIndex<tenex::TensorIndex_detail::upper_spatial_sentinel +
-                             3>
-    ti_L{};
-static constexpr TensorIndex<tenex::TensorIndex_detail::spatial_sentinel + 4>
-    ti_m{};
-static constexpr TensorIndex<tenex::TensorIndex_detail::upper_spatial_sentinel +
-                             4>
-    ti_M{};
-static constexpr TensorIndex<tenex::TensorIndex_detail::spatial_sentinel + 5>
-    ti_n{};
-static constexpr TensorIndex<tenex::TensorIndex_detail::upper_spatial_sentinel +
-                             5>
-    ti_N{};
-/// @}
 
 namespace tt {
 /*!
@@ -293,11 +291,11 @@ struct remove_time_indices;
  *
  * \details A list of TensorIndexs is considered valid if the subset of generic
  * indices are a set. Indices with opposite valences are unique, e.g. one
- * instance each of `ti_a` and `ti_A` is valid. An arbitrary number of concrete
- * time indices, regardless of valence, is also valid.
+ * instance each of `ti::a` and `ti::A` is valid. An arbitrary number of
+ * concrete time indices, regardless of valence, is also valid.
  *
  * @tparam TensorIndexList list of generic index types, e.g. the types of
- * `ti_a, ti_b`
+ * `ti::a, ti::b`
  */
 template <typename TensorIndexList>
 struct tensorindex_list_is_valid;
@@ -329,7 +327,7 @@ using generic_indices_at_same_positions =
  * \ingroup TensorExpressionsGroup
  * \brief Creates a TensorIndex type list from a list of TensorIndex objects
  *
- * @tparam TensorIndices list of generic index objects, e.g. `ti_a, ti_b`
+ * @tparam TensorIndices list of generic index objects, e.g. `ti::a, ti::b`
  */
 template <auto&... TensorIndices>
 using make_tensorindex_list =

--- a/src/DataStructures/Tensor/Expressions/TensorIndexTransformation.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorIndexTransformation.hpp
@@ -19,7 +19,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
 
-namespace TensorExpressions {
+namespace tenex {
 namespace TensorIndexTransformation_detail {
 static constexpr size_t time_index_position_placeholder =
     std::numeric_limits<size_t>::max();
@@ -159,4 +159,4 @@ transform_multi_index(
   }
   return output_multi_index;
 }
-}  // namespace TensorExpressions
+}  // namespace tenex

--- a/src/DataStructures/Tensor/Expressions/TimeIndex.hpp
+++ b/src/DataStructures/Tensor/Expressions/TimeIndex.hpp
@@ -32,7 +32,7 @@ template <>
 struct is_time_index<std::decay_t<decltype(ti_T)>> : std::true_type {};
 }  // namespace tt
 
-namespace TensorExpressions {
+namespace tenex {
 namespace detail {
 /// \brief Returns whether or not the provided value is the TensorIndex value
 /// that encodes the upper or lower concrete time index (`ti_T` or `ti_t`)
@@ -93,4 +93,4 @@ constexpr auto get_time_index_positions() {
   return make_array_from_list<make_list_type>();
 }
 }  // namespace detail
-}  // namespace TensorExpressions
+}  // namespace tenex

--- a/src/DataStructures/Tensor/Expressions/TimeIndex.hpp
+++ b/src/DataStructures/Tensor/Expressions/TimeIndex.hpp
@@ -27,21 +27,21 @@ namespace tt {
 template <typename T>
 struct is_time_index : std::false_type {};
 template <>
-struct is_time_index<std::decay_t<decltype(ti_t)>> : std::true_type {};
+struct is_time_index<std::decay_t<decltype(ti::t)>> : std::true_type {};
 template <>
-struct is_time_index<std::decay_t<decltype(ti_T)>> : std::true_type {};
+struct is_time_index<std::decay_t<decltype(ti::T)>> : std::true_type {};
 }  // namespace tt
 
 namespace tenex {
 namespace detail {
 /// \brief Returns whether or not the provided value is the TensorIndex value
-/// that encodes the upper or lower concrete time index (`ti_T` or `ti_t`)
+/// that encodes the upper or lower concrete time index (`ti::T` or `ti::t`)
 ///
 /// \param value the value to check
 /// \return whether or not the value encodes the upper or lower concrete time
 /// index
 constexpr bool is_time_index_value(const size_t value) {
-  return value == ti_t.value or value == ti_T.value;
+  return value == ti::t.value or value == ti::T.value;
 }
 
 template <typename State, typename Element>

--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -142,8 +142,8 @@ class Tensor<X, Symm, IndexList<Indices...>> {
   /// The type of the TensorExpression that would represent this Tensor in a
   /// tensor expression.
   template <typename ArgsList>
-  using TE = TensorExpressions::TensorAsExpression<
-      Tensor<X, Symm, IndexList<Indices...>>, ArgsList>;
+  using TE = tenex::TensorAsExpression<Tensor<X, Symm, IndexList<Indices...>>,
+                                       ArgsList>;
 
   Tensor() = default;
   ~Tensor() = default;
@@ -262,12 +262,12 @@ class Tensor<X, Symm, IndexList<Indices...>> {
                   "The tensor expression must be created using TensorIndex "
                   "objects to represent generic indices, e.g. ti_a, ti_b, "
                   "etc.");
-    static_assert(TensorExpressions::tensorindex_list_is_valid<
-                      tmpl::list<TensorIndices...>>::value,
-                  "Cannot create a tensor expression with a repeated generic "
-                  "index. (Note that the concrete time indices, ti_T and ti_t, "
-                  "can be repeated.) If you intend to contract, ensure that "
-                  "the indices to contract have opposite valences.");
+    static_assert(
+        tenex::tensorindex_list_is_valid<tmpl::list<TensorIndices...>>::value,
+        "Cannot create a tensor expression with a repeated generic "
+        "index. (Note that the concrete time indices, ti_T and ti_t, "
+        "can be repeated.) If you intend to contract, ensure that "
+        "the indices to contract have opposite valences.");
     static_assert(
         std::is_same_v<tmpl::integral_list<UpLo, TensorIndices::valence...>,
                        tmpl::integral_list<UpLo, Indices::ul...>>,
@@ -278,7 +278,7 @@ class Tensor<X, Symm, IndexList<Indices...>> {
                   "Cannot use a spacetime index for a spatial index. e.g. "
                   "Cannot do R(ti_a), where R's index is spatial, because ti_a "
                   "denotes a generic spacetime index.");
-    return TensorExpressions::contract(TE<tmpl::list<TensorIndices...>>{*this});
+    return tenex::contract(TE<tmpl::list<TensorIndices...>>{*this});
   }
   /// @}
 

--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -260,14 +260,14 @@ class Tensor<X, Symm, IndexList<Indices...>> {
       TensorIndices... /*meta*/) const {
     static_assert((... and tt::is_tensor_index<TensorIndices>::value),
                   "The tensor expression must be created using TensorIndex "
-                  "objects to represent generic indices, e.g. ti_a, ti_b, "
+                  "objects to represent generic indices, e.g. ti::a, ti::b, "
                   "etc.");
     static_assert(
         tenex::tensorindex_list_is_valid<tmpl::list<TensorIndices...>>::value,
-        "Cannot create a tensor expression with a repeated generic "
-        "index. (Note that the concrete time indices, ti_T and ti_t, "
-        "can be repeated.) If you intend to contract, ensure that "
-        "the indices to contract have opposite valences.");
+        "Cannot create a tensor expression with a repeated generic index. "
+        "(Note that the concrete time indices, ti::T and ti::t, can be "
+        "repeated.) If you intend to contract, ensure that the indices to "
+        "contract have opposite valences.");
     static_assert(
         std::is_same_v<tmpl::integral_list<UpLo, TensorIndices::valence...>,
                        tmpl::integral_list<UpLo, Indices::ul...>>,
@@ -276,8 +276,8 @@ class Tensor<X, Symm, IndexList<Indices...>> {
     static_assert((... and (not(TensorIndices::is_spacetime and
                                 (Indices::index_type == IndexType::Spatial)))),
                   "Cannot use a spacetime index for a spatial index. e.g. "
-                  "Cannot do R(ti_a), where R's index is spatial, because ti_a "
-                  "denotes a generic spacetime index.");
+                  "Cannot do R(ti::a), where R's index is spatial, because "
+                  "ti::a denotes a generic spacetime index.");
     return tenex::contract(TE<tmpl::list<TensorIndices...>>{*this});
   }
   /// @}

--- a/src/Evolution/Systems/Ccz4/ATilde.cpp
+++ b/src/Evolution/Systems/Ccz4/ATilde.cpp
@@ -24,8 +24,8 @@ void a_tilde(const gsl::not_null<tnsr::ii<DataType, Dim, Frame>*> result,
   destructive_resize_components(buffer,
                                 get_size(get(conformal_factor_squared)));
 
-  ::TensorExpressions::evaluate(buffer, trace_extrinsic_curvature() / 3.0);
-  ::TensorExpressions::evaluate<ti_i, ti_j>(
+  ::tenex::evaluate(buffer, trace_extrinsic_curvature() / 3.0);
+  ::tenex::evaluate<ti_i, ti_j>(
       result,
       conformal_factor_squared() * (extrinsic_curvature(ti_i, ti_j) -
                                     (*buffer)() * spatial_metric(ti_i, ti_j)));

--- a/src/Evolution/Systems/Ccz4/ATilde.cpp
+++ b/src/Evolution/Systems/Ccz4/ATilde.cpp
@@ -25,10 +25,10 @@ void a_tilde(const gsl::not_null<tnsr::ii<DataType, Dim, Frame>*> result,
                                 get_size(get(conformal_factor_squared)));
 
   ::tenex::evaluate(buffer, trace_extrinsic_curvature() / 3.0);
-  ::tenex::evaluate<ti_i, ti_j>(
-      result,
-      conformal_factor_squared() * (extrinsic_curvature(ti_i, ti_j) -
-                                    (*buffer)() * spatial_metric(ti_i, ti_j)));
+  ::tenex::evaluate<ti::i, ti::j>(
+      result, conformal_factor_squared() *
+                  (extrinsic_curvature(ti::i, ti::j) -
+                   (*buffer)() * spatial_metric(ti::i, ti::j)));
 }
 
 template <size_t Dim, typename Frame, typename DataType>

--- a/src/Evolution/Systems/Ccz4/Christoffel.cpp
+++ b/src/Evolution/Systems/Ccz4/Christoffel.cpp
@@ -20,10 +20,10 @@ void conformal_christoffel_second_kind(
   destructive_resize_components(
       result, get_size(get<0, 0>(inverse_conformal_spatial_metric)));
 
-  ::tenex::evaluate<ti_K, ti_i, ti_j>(
-      result, inverse_conformal_spatial_metric(ti_K, ti_L) *
-                  (field_d(ti_i, ti_j, ti_l) + field_d(ti_j, ti_i, ti_l) -
-                   field_d(ti_l, ti_i, ti_j)));
+  ::tenex::evaluate<ti::K, ti::i, ti::j>(
+      result, inverse_conformal_spatial_metric(ti::K, ti::L) *
+                  (field_d(ti::i, ti::j, ti::l) + field_d(ti::j, ti::i, ti::l) -
+                   field_d(ti::l, ti::i, ti::j)));
 }
 
 template <size_t Dim, typename Frame, typename DataType>
@@ -46,12 +46,13 @@ void christoffel_second_kind(
   destructive_resize_components(result,
                                 get_size(get<0, 0>(conformal_spatial_metric)));
 
-  ::tenex::evaluate<ti_K, ti_i, ti_j>(
-      result, conformal_christoffel_second_kind(ti_K, ti_i, ti_j) -
-                  inverse_conformal_spatial_metric(ti_K, ti_L) *
-                      (conformal_spatial_metric(ti_j, ti_l) * field_p(ti_i) +
-                       conformal_spatial_metric(ti_i, ti_l) * field_p(ti_j) -
-                       conformal_spatial_metric(ti_i, ti_j) * field_p(ti_l)));
+  ::tenex::evaluate<ti::K, ti::i, ti::j>(
+      result,
+      conformal_christoffel_second_kind(ti::K, ti::i, ti::j) -
+          inverse_conformal_spatial_metric(ti::K, ti::L) *
+              (conformal_spatial_metric(ti::j, ti::l) * field_p(ti::i) +
+               conformal_spatial_metric(ti::i, ti::l) * field_p(ti::j) -
+               conformal_spatial_metric(ti::i, ti::j) * field_p(ti::l)));
 }
 
 template <size_t Dim, typename Frame, typename DataType>
@@ -75,9 +76,9 @@ void contracted_conformal_christoffel_second_kind(
   destructive_resize_components(
       result, get_size(get<0, 0>(inverse_conformal_spatial_metric)));
 
-  ::tenex::evaluate<ti_I>(
-      result, inverse_conformal_spatial_metric(ti_J, ti_L) *
-                  conformal_christoffel_second_kind(ti_I, ti_j, ti_l));
+  ::tenex::evaluate<ti::I>(
+      result, inverse_conformal_spatial_metric(ti::J, ti::L) *
+                  conformal_christoffel_second_kind(ti::I, ti::j, ti::l));
 }
 
 template <size_t Dim, typename Frame, typename DataType>

--- a/src/Evolution/Systems/Ccz4/Christoffel.cpp
+++ b/src/Evolution/Systems/Ccz4/Christoffel.cpp
@@ -20,7 +20,7 @@ void conformal_christoffel_second_kind(
   destructive_resize_components(
       result, get_size(get<0, 0>(inverse_conformal_spatial_metric)));
 
-  ::TensorExpressions::evaluate<ti_K, ti_i, ti_j>(
+  ::tenex::evaluate<ti_K, ti_i, ti_j>(
       result, inverse_conformal_spatial_metric(ti_K, ti_L) *
                   (field_d(ti_i, ti_j, ti_l) + field_d(ti_j, ti_i, ti_l) -
                    field_d(ti_l, ti_i, ti_j)));
@@ -46,7 +46,7 @@ void christoffel_second_kind(
   destructive_resize_components(result,
                                 get_size(get<0, 0>(conformal_spatial_metric)));
 
-  ::TensorExpressions::evaluate<ti_K, ti_i, ti_j>(
+  ::tenex::evaluate<ti_K, ti_i, ti_j>(
       result, conformal_christoffel_second_kind(ti_K, ti_i, ti_j) -
                   inverse_conformal_spatial_metric(ti_K, ti_L) *
                       (conformal_spatial_metric(ti_j, ti_l) * field_p(ti_i) +
@@ -75,7 +75,7 @@ void contracted_conformal_christoffel_second_kind(
   destructive_resize_components(
       result, get_size(get<0, 0>(inverse_conformal_spatial_metric)));
 
-  ::TensorExpressions::evaluate<ti_I>(
+  ::tenex::evaluate<ti_I>(
       result, inverse_conformal_spatial_metric(ti_J, ti_L) *
                   conformal_christoffel_second_kind(ti_I, ti_j, ti_l));
 }

--- a/src/Evolution/Systems/Ccz4/DerivChristoffel.cpp
+++ b/src/Evolution/Systems/Ccz4/DerivChristoffel.cpp
@@ -74,12 +74,12 @@ void deriv_contracted_conformal_christoffel_second_kind(
   destructive_resize_components(
       result, get_size(get<0, 0>(inverse_conformal_spatial_metric)));
 
-  ::tenex::evaluate<ti_k, ti_I>(
+  ::tenex::evaluate<ti::k, ti::I>(
       result,
-      -2.0 * field_d_up(ti_k, ti_J, ti_L) *
-              conformal_christoffel_second_kind(ti_I, ti_j, ti_l) +
-          inverse_conformal_spatial_metric(ti_J, ti_L) *
-              d_conformal_christoffel_second_kind(ti_k, ti_I, ti_j, ti_l));
+      -2.0 * field_d_up(ti::k, ti::J, ti::L) *
+              conformal_christoffel_second_kind(ti::I, ti::j, ti::l) +
+          inverse_conformal_spatial_metric(ti::J, ti::L) *
+              d_conformal_christoffel_second_kind(ti::k, ti::I, ti::j, ti::l));
 }
 
 template <size_t Dim, typename Frame, typename DataType>

--- a/src/Evolution/Systems/Ccz4/DerivChristoffel.cpp
+++ b/src/Evolution/Systems/Ccz4/DerivChristoffel.cpp
@@ -74,7 +74,7 @@ void deriv_contracted_conformal_christoffel_second_kind(
   destructive_resize_components(
       result, get_size(get<0, 0>(inverse_conformal_spatial_metric)));
 
-  ::TensorExpressions::evaluate<ti_k, ti_I>(
+  ::tenex::evaluate<ti_k, ti_I>(
       result,
       -2.0 * field_d_up(ti_k, ti_J, ti_L) *
               conformal_christoffel_second_kind(ti_I, ti_j, ti_l) +

--- a/src/Evolution/Systems/Ccz4/DerivZ4Constraint.cpp
+++ b/src/Evolution/Systems/Ccz4/DerivZ4Constraint.cpp
@@ -26,14 +26,14 @@ void grad_spatial_z4_constraint(
   destructive_resize_components(result,
                                 get_size(get<0, 0>(conformal_spatial_metric)));
 
-  ::tenex::evaluate<ti_i, ti_j>(
+  ::tenex::evaluate<ti::i, ti::j>(
       result,
-      field_d(ti_i, ti_j, ti_l) *
-              gamma_hat_minus_contracted_conformal_christoffel(ti_L) +
-          0.5 * conformal_spatial_metric(ti_j, ti_l) *
-              d_gamma_hat_minus_contracted_conformal_christoffel(ti_i, ti_L) -
-          christoffel_second_kind(ti_L, ti_i, ti_j) *
-              spatial_z4_constraint(ti_l));
+      field_d(ti::i, ti::j, ti::l) *
+              gamma_hat_minus_contracted_conformal_christoffel(ti::L) +
+          0.5 * conformal_spatial_metric(ti::j, ti::l) *
+              d_gamma_hat_minus_contracted_conformal_christoffel(ti::i, ti::L) -
+          christoffel_second_kind(ti::L, ti::i, ti::j) *
+              spatial_z4_constraint(ti::l));
 }
 
 template <size_t Dim, typename Frame, typename DataType>

--- a/src/Evolution/Systems/Ccz4/DerivZ4Constraint.cpp
+++ b/src/Evolution/Systems/Ccz4/DerivZ4Constraint.cpp
@@ -26,7 +26,7 @@ void grad_spatial_z4_constraint(
   destructive_resize_components(result,
                                 get_size(get<0, 0>(conformal_spatial_metric)));
 
-  ::TensorExpressions::evaluate<ti_i, ti_j>(
+  ::tenex::evaluate<ti_i, ti_j>(
       result,
       field_d(ti_i, ti_j, ti_l) *
               gamma_hat_minus_contracted_conformal_christoffel(ti_L) +

--- a/src/Evolution/Systems/Ccz4/Ricci.cpp
+++ b/src/Evolution/Systems/Ccz4/Ricci.cpp
@@ -29,7 +29,7 @@ void spatial_ricci_tensor(
   destructive_resize_components(result,
                                 get_size(get<0, 0>(conformal_spatial_metric)));
 
-  TensorExpressions::evaluate<ti_i, ti_j>(
+  tenex::evaluate<ti_i, ti_j>(
       result,
       contracted_d_conformal_christoffel_difference(ti_i, ti_j) +
           // Add terms of \partial_m \Gamma^m_{ij} and

--- a/src/Evolution/Systems/Ccz4/Ricci.cpp
+++ b/src/Evolution/Systems/Ccz4/Ricci.cpp
@@ -29,46 +29,46 @@ void spatial_ricci_tensor(
   destructive_resize_components(result,
                                 get_size(get<0, 0>(conformal_spatial_metric)));
 
-  tenex::evaluate<ti_i, ti_j>(
+  tenex::evaluate<ti::i, ti::j>(
       result,
-      contracted_d_conformal_christoffel_difference(ti_i, ti_j) +
+      contracted_d_conformal_christoffel_difference(ti::i, ti::j) +
           // Add terms of \partial_m \Gamma^m_{ij} and
           // -\partial_j \Gamma^m_{im} that have a coefficient of 2
-          2.0 * (contracted_field_d_up(ti_L) *
-                     (conformal_spatial_metric(ti_j, ti_l) * field_p(ti_i) +
-                      conformal_spatial_metric(ti_i, ti_l) * field_p(ti_j) -
-                      conformal_spatial_metric(ti_i, ti_j) * field_p(ti_l)) -
-                 inverse_conformal_spatial_metric(ti_M, ti_L) *
-                     (field_d(ti_m, ti_j, ti_l) * field_p(ti_i) +
-                      field_d(ti_m, ti_i, ti_l) * field_p(ti_j) -
-                      field_d(ti_m, ti_i, ti_j) * field_p(ti_l)) -
-                 field_d_up(ti_j, ti_M, ti_L) *
-                     (conformal_spatial_metric(ti_m, ti_l) * field_p(ti_i) +
-                      conformal_spatial_metric(ti_i, ti_l) * field_p(ti_m) -
-                      conformal_spatial_metric(ti_i, ti_m) * field_p(ti_l)) +
-                 inverse_conformal_spatial_metric(ti_M, ti_L) *
-                     (field_d(ti_j, ti_m, ti_l) * field_p(ti_i) +
-                      field_d(ti_j, ti_i, ti_l) * field_p(ti_m) -
-                      field_d(ti_j, ti_i, ti_m) * field_p(ti_l))) -
+          2.0 * (contracted_field_d_up(ti::L) *
+                     (conformal_spatial_metric(ti::j, ti::l) * field_p(ti::i) +
+                      conformal_spatial_metric(ti::i, ti::l) * field_p(ti::j) -
+                      conformal_spatial_metric(ti::i, ti::j) * field_p(ti::l)) -
+                 inverse_conformal_spatial_metric(ti::M, ti::L) *
+                     (field_d(ti::m, ti::j, ti::l) * field_p(ti::i) +
+                      field_d(ti::m, ti::i, ti::l) * field_p(ti::j) -
+                      field_d(ti::m, ti::i, ti::j) * field_p(ti::l)) -
+                 field_d_up(ti::j, ti::M, ti::L) *
+                     (conformal_spatial_metric(ti::m, ti::l) * field_p(ti::i) +
+                      conformal_spatial_metric(ti::i, ti::l) * field_p(ti::m) -
+                      conformal_spatial_metric(ti::i, ti::m) * field_p(ti::l)) +
+                 inverse_conformal_spatial_metric(ti::M, ti::L) *
+                     (field_d(ti::j, ti::m, ti::l) * field_p(ti::i) +
+                      field_d(ti::j, ti::i, ti::l) * field_p(ti::m) -
+                      field_d(ti::j, ti::i, ti::m) * field_p(ti::l))) -
           // Add \partial_{(i} P_{j)} type terms
-          0.5 * inverse_conformal_spatial_metric(ti_M, ti_L) *
-              (conformal_spatial_metric(ti_j, ti_l) *
-                   (d_field_p(ti_m, ti_i) + d_field_p(ti_i, ti_m)) +
-               conformal_spatial_metric(ti_i, ti_l) *
-                   (d_field_p(ti_m, ti_j) + d_field_p(ti_j, ti_m)) -
-               conformal_spatial_metric(ti_i, ti_j) *
-                   (d_field_p(ti_m, ti_l) + d_field_p(ti_l, ti_m)) -
-               conformal_spatial_metric(ti_m, ti_l) *
-                   (d_field_p(ti_j, ti_i) + d_field_p(ti_i, ti_j)) -
-               conformal_spatial_metric(ti_i, ti_l) *
-                   (d_field_p(ti_j, ti_m) + d_field_p(ti_m, ti_j)) +
-               conformal_spatial_metric(ti_i, ti_m) *
-                   (d_field_p(ti_j, ti_l) + d_field_p(ti_l, ti_j))) +
+          0.5 * inverse_conformal_spatial_metric(ti::M, ti::L) *
+              (conformal_spatial_metric(ti::j, ti::l) *
+                   (d_field_p(ti::m, ti::i) + d_field_p(ti::i, ti::m)) +
+               conformal_spatial_metric(ti::i, ti::l) *
+                   (d_field_p(ti::m, ti::j) + d_field_p(ti::j, ti::m)) -
+               conformal_spatial_metric(ti::i, ti::j) *
+                   (d_field_p(ti::m, ti::l) + d_field_p(ti::l, ti::m)) -
+               conformal_spatial_metric(ti::m, ti::l) *
+                   (d_field_p(ti::j, ti::i) + d_field_p(ti::i, ti::j)) -
+               conformal_spatial_metric(ti::i, ti::l) *
+                   (d_field_p(ti::j, ti::m) + d_field_p(ti::m, ti::j)) +
+               conformal_spatial_metric(ti::i, ti::m) *
+                   (d_field_p(ti::j, ti::l) + d_field_p(ti::l, ti::j))) +
           // Add last two terms for R_{ij}
-          christoffel_second_kind(ti_L, ti_i, ti_j) *
-              contracted_christoffel_second_kind(ti_l) -
-          christoffel_second_kind(ti_L, ti_i, ti_m) *
-              christoffel_second_kind(ti_M, ti_l, ti_j));
+          christoffel_second_kind(ti::L, ti::i, ti::j) *
+              contracted_christoffel_second_kind(ti::l) -
+          christoffel_second_kind(ti::L, ti::i, ti::m) *
+              christoffel_second_kind(ti::M, ti::l, ti::j));
 }
 
 template <size_t Dim, typename Frame, typename DataType>

--- a/src/Evolution/Systems/Ccz4/RicciScalarPlusDivergenceZ4Constraint.cpp
+++ b/src/Evolution/Systems/Ccz4/RicciScalarPlusDivergenceZ4Constraint.cpp
@@ -22,12 +22,11 @@ void ricci_scalar_plus_divergence_z4_constraint(
   destructive_resize_components(result,
                                 get_size(get(conformal_factor_squared)));
 
-  ::TensorExpressions::evaluate(
-      result, conformal_factor_squared() *
-                  inverse_conformal_spatial_metric(ti_I, ti_J) *
-                  (spatial_ricci_tensor(ti_i, ti_j) +
-                   grad_spatial_z4_constraint(ti_i, ti_j) +
-                   grad_spatial_z4_constraint(ti_j, ti_i)));
+  ::tenex::evaluate(result, conformal_factor_squared() *
+                                inverse_conformal_spatial_metric(ti_I, ti_J) *
+                                (spatial_ricci_tensor(ti_i, ti_j) +
+                                 grad_spatial_z4_constraint(ti_i, ti_j) +
+                                 grad_spatial_z4_constraint(ti_j, ti_i)));
 }
 
 template <size_t Dim, typename Frame, typename DataType>

--- a/src/Evolution/Systems/Ccz4/RicciScalarPlusDivergenceZ4Constraint.cpp
+++ b/src/Evolution/Systems/Ccz4/RicciScalarPlusDivergenceZ4Constraint.cpp
@@ -23,10 +23,10 @@ void ricci_scalar_plus_divergence_z4_constraint(
                                 get_size(get(conformal_factor_squared)));
 
   ::tenex::evaluate(result, conformal_factor_squared() *
-                                inverse_conformal_spatial_metric(ti_I, ti_J) *
-                                (spatial_ricci_tensor(ti_i, ti_j) +
-                                 grad_spatial_z4_constraint(ti_i, ti_j) +
-                                 grad_spatial_z4_constraint(ti_j, ti_i)));
+                                inverse_conformal_spatial_metric(ti::I, ti::J) *
+                                (spatial_ricci_tensor(ti::i, ti::j) +
+                                 grad_spatial_z4_constraint(ti::i, ti::j) +
+                                 grad_spatial_z4_constraint(ti::j, ti::i)));
 }
 
 template <size_t Dim, typename Frame, typename DataType>

--- a/src/Evolution/Systems/Ccz4/TimeDerivative.cpp
+++ b/src/Evolution/Systems/Ccz4/TimeDerivative.cpp
@@ -166,14 +166,14 @@ void TimeDerivative<Dim>::apply(
     get(*conformal_factor_squared)[i] = exp(2.0 * get(ln_conformal_factor)[i]);
   }
 
-  ::tenex::evaluate<ti_I, ti_J>(
+  ::tenex::evaluate<ti::I, ti::J>(
       inv_spatial_metric, (*conformal_factor_squared)() *
-                              (*inv_conformal_spatial_metric)(ti_I, ti_J));
+                              (*inv_conformal_spatial_metric)(ti::I, ti::J));
 
-  ::tenex::evaluate<ti_I, ti_J>(
-      inv_a_tilde, a_tilde(ti_k, ti_l) *
-                       (*inv_conformal_spatial_metric)(ti_I, ti_K) *
-                       (*inv_conformal_spatial_metric)(ti_J, ti_L));
+  ::tenex::evaluate<ti::I, ti::J>(
+      inv_a_tilde, a_tilde(ti::k, ti::l) *
+                       (*inv_conformal_spatial_metric)(ti::I, ti::K) *
+                       (*inv_conformal_spatial_metric)(ti::J, ti::L));
 
   for (size_t i = 0; i < num_points; i++) {
     get(*lapse)[i] = exp(get(ln_lapse)[i]);
@@ -201,14 +201,15 @@ void TimeDerivative<Dim>::apply(
   // expressions and identities needed for evolution equations: eq 13 - 27
 
   // eq 13
-  ::tenex::evaluate(trace_a_tilde, (*inv_conformal_spatial_metric)(ti_I, ti_J) *
-                                       a_tilde(ti_i, ti_j));
+  ::tenex::evaluate(
+      trace_a_tilde,
+      (*inv_conformal_spatial_metric)(ti::I, ti::J) * a_tilde(ti::i, ti::j));
 
   // eq 14
-  ::tenex::evaluate<ti_k, ti_I, ti_J>(
-      field_d_up, (*inv_conformal_spatial_metric)(ti_I, ti_N) *
-                      (*inv_conformal_spatial_metric)(ti_M, ti_J) *
-                      field_d(ti_k, ti_n, ti_m));
+  ::tenex::evaluate<ti::k, ti::I, ti::J>(
+      field_d_up, (*inv_conformal_spatial_metric)(ti::I, ti::N) *
+                      (*inv_conformal_spatial_metric)(ti::M, ti::J) *
+                      field_d(ti::k, ti::n, ti::m));
 
   // eq 15
   ::Ccz4::conformal_christoffel_second_kind(conformal_christoffel_second_kind,
@@ -227,16 +228,16 @@ void TimeDerivative<Dim>::apply(
                                   *conformal_christoffel_second_kind);
 
   // temporary expressions needed for eq 18 - 20
-  ::tenex::evaluate<ti_l>(contracted_christoffel_second_kind,
-                          (*christoffel_second_kind)(ti_M, ti_l, ti_m));
+  ::tenex::evaluate<ti::l>(contracted_christoffel_second_kind,
+                           (*christoffel_second_kind)(ti::M, ti::l, ti::m));
 
-  ::tenex::evaluate<ti_i, ti_j>(
+  ::tenex::evaluate<ti::i, ti::j>(
       contracted_d_conformal_christoffel_difference,
-      (*d_conformal_christoffel_second_kind)(ti_m, ti_M, ti_i, ti_j) -
-          (*d_conformal_christoffel_second_kind)(ti_j, ti_M, ti_i, ti_m));
+      (*d_conformal_christoffel_second_kind)(ti::m, ti::M, ti::i, ti::j) -
+          (*d_conformal_christoffel_second_kind)(ti::j, ti::M, ti::i, ti::m));
 
-  ::tenex::evaluate<ti_L>(contracted_field_d_up,
-                          (*field_d_up)(ti_m, ti_M, ti_L));
+  ::tenex::evaluate<ti::L>(contracted_field_d_up,
+                           (*field_d_up)(ti::m, ti::M, ti::L));
 
   // eq 18 - 20
   ::Ccz4::spatial_ricci_tensor(
@@ -266,9 +267,10 @@ void TimeDerivative<Dim>::apply(
       *conformal_christoffel_second_kind, *d_conformal_christoffel_second_kind);
 
   // temp for eq 25
-  ::tenex::evaluate<ti_I>(
+  ::tenex::evaluate<ti::I>(
       gamma_hat_minus_contracted_conformal_christoffel,
-      gamma_hat(ti_I) - (*contracted_conformal_christoffel_second_kind)(ti_I));
+      gamma_hat(ti::I) -
+          (*contracted_conformal_christoffel_second_kind)(ti::I));
 
   // eq 25
   ::Ccz4::spatial_z4_constraint(
@@ -282,10 +284,10 @@ void TimeDerivative<Dim>::apply(
       *gamma_hat_minus_contracted_conformal_christoffel);
 
   // temp for eq 26
-  ::tenex::evaluate<ti_i, ti_L>(
+  ::tenex::evaluate<ti::i, ti::L>(
       d_gamma_hat_minus_contracted_conformal_christoffel,
-      d_gamma_hat(ti_i, ti_L) -
-          (*d_contracted_conformal_christoffel_second_kind)(ti_i, ti_L));
+      d_gamma_hat(ti::i, ti::L) -
+          (*d_contracted_conformal_christoffel_second_kind)(ti::i, ti::L));
 
   // eq 26
   ::Ccz4::grad_spatial_z4_constraint(
@@ -302,11 +304,11 @@ void TimeDerivative<Dim>::apply(
 
   // temporary expressions not already computed above
 
-  ::tenex::evaluate(contracted_field_b, field_b(ti_k, ti_K));
+  ::tenex::evaluate(contracted_field_b, field_b(ti::k, ti::K));
 
-  ::tenex::evaluate<ti_k, ti_j, ti_I>(
+  ::tenex::evaluate<ti::k, ti::j, ti::I>(
       symmetrized_d_field_b,
-      0.5 * (d_field_b(ti_k, ti_j, ti_I) + d_field_b(ti_j, ti_k, ti_I)));
+      0.5 * (d_field_b(ti::k, ti::j, ti::I) + d_field_b(ti::j, ti::k, ti::I)));
 
   for (size_t k = 0; k < Dim; k++) {
     contracted_symmetrized_d_field_b->get(k) = d_field_b.get(k, 0, 0);
@@ -315,84 +317,85 @@ void TimeDerivative<Dim>::apply(
     }
   }
 
-  ::tenex::evaluate<ti_i, ti_j, ti_k>(
-      field_b_times_field_d, field_b(ti_i, ti_L) * field_d(ti_j, ti_l, ti_k));
+  ::tenex::evaluate<ti::i, ti::j, ti::k>(
+      field_b_times_field_d,
+      field_b(ti::i, ti::L) * field_d(ti::j, ti::l, ti::k));
 
-  ::tenex::evaluate<ti_k>(
+  ::tenex::evaluate<ti::k>(
       field_d_up_times_a_tilde,
-      (*field_d_up)(ti_k, ti_I, ti_J) * a_tilde(ti_i, ti_j));
+      (*field_d_up)(ti::k, ti::I, ti::J) * a_tilde(ti::i, ti::j));
 
-  ::tenex::evaluate<ti_i, ti_j>(
+  ::tenex::evaluate<ti::i, ti::j>(
       conformal_metric_times_field_b,
-      conformal_spatial_metric(ti_k, ti_i) * field_b(ti_j, ti_K));
+      conformal_spatial_metric(ti::k, ti::i) * field_b(ti::j, ti::K));
 
-  ::tenex::evaluate<ti_i, ti_k, ti_j>(
+  ::tenex::evaluate<ti::i, ti::k, ti::j>(
       conformal_metric_times_symmetrized_d_field_b,
-      conformal_spatial_metric(ti_m, ti_i) *
-          (*symmetrized_d_field_b)(ti_k, ti_j, ti_M));
+      conformal_spatial_metric(ti::m, ti::i) *
+          (*symmetrized_d_field_b)(ti::k, ti::j, ti::M));
 
-  ::tenex::evaluate<ti_i, ti_j>(
+  ::tenex::evaluate<ti::i, ti::j>(
       conformal_metric_times_trace_a_tilde,
-      conformal_spatial_metric(ti_i, ti_j) * (*trace_a_tilde)());
+      conformal_spatial_metric(ti::i, ti::j) * (*trace_a_tilde)());
 
-  ::tenex::evaluate<ti_k>(inv_conformal_metric_times_d_a_tilde,
-                          (*inv_conformal_spatial_metric)(ti_I, ti_J) *
-                              d_a_tilde(ti_k, ti_i, ti_j));
+  ::tenex::evaluate<ti::k>(inv_conformal_metric_times_d_a_tilde,
+                           (*inv_conformal_spatial_metric)(ti::I, ti::J) *
+                               d_a_tilde(ti::k, ti::i, ti::j));
 
-  ::tenex::evaluate<ti_i, ti_j>(a_tilde_times_field_b,
-                                a_tilde(ti_k, ti_i) * field_b(ti_j, ti_K));
+  ::tenex::evaluate<ti::i, ti::j>(
+      a_tilde_times_field_b, a_tilde(ti::k, ti::i) * field_b(ti::j, ti::K));
 
-  ::tenex::evaluate<ti_i, ti_j>(
+  ::tenex::evaluate<ti::i, ti::j>(
       a_tilde_minus_one_third_conformal_metric_times_trace_a_tilde,
-      a_tilde(ti_i, ti_j) -
-          one_third * (*conformal_metric_times_trace_a_tilde)(ti_i, ti_j));
+      a_tilde(ti::i, ti::j) -
+          one_third * (*conformal_metric_times_trace_a_tilde)(ti::i, ti::j));
 
   ::tenex::evaluate(k_minus_2_theta_c,
                     trace_extrinsic_curvature() - 2.0 * c * theta());
 
   ::tenex::evaluate(k_minus_k0_minus_2_theta_c, (*k_minus_2_theta_c)() - k_0());
 
-  ::tenex::evaluate<ti_i, ti_j>(lapse_times_a_tilde,
-                                (*lapse)() * a_tilde(ti_i, ti_j));
+  ::tenex::evaluate<ti::i, ti::j>(lapse_times_a_tilde,
+                                  (*lapse)() * a_tilde(ti::i, ti::j));
 
-  tenex::evaluate<ti_k, ti_i, ti_j>(lapse_times_d_a_tilde,
-                                    (*lapse)() * d_a_tilde(ti_k, ti_i, ti_j));
+  tenex::evaluate<ti::k, ti::i, ti::j>(
+      lapse_times_d_a_tilde, (*lapse)() * d_a_tilde(ti::k, ti::i, ti::j));
 
-  ::tenex::evaluate<ti_k>(lapse_times_field_a, (*lapse)() * field_a(ti_k));
+  ::tenex::evaluate<ti::k>(lapse_times_field_a, (*lapse)() * field_a(ti::k));
 
-  ::tenex::evaluate<ti_i, ti_j>(
+  ::tenex::evaluate<ti::i, ti::j>(
       lapse_times_conformal_spatial_metric,
-      (*lapse)() * conformal_spatial_metric(ti_i, ti_j));
+      (*lapse)() * conformal_spatial_metric(ti::i, ti::j));
 
   ::tenex::evaluate(
       lapse_times_ricci_scalar_plus_divergence_z4_constraint,
       (*lapse)() * (*ricci_scalar_plus_divergence_z4_constraint)());
 
-  ::tenex::evaluate<ti_I>(shift_times_deriv_gamma_hat,
-                          shift(ti_K) * d_gamma_hat(ti_k, ti_I));
+  ::tenex::evaluate<ti::I>(shift_times_deriv_gamma_hat,
+                           shift(ti::K) * d_gamma_hat(ti::k, ti::I));
 
-  ::tenex::evaluate<ti_i, ti_j>(
+  ::tenex::evaluate<ti::i, ti::j>(
       inv_tau_times_conformal_metric,
-      one_over_relaxation_time * conformal_spatial_metric(ti_i, ti_j));
+      one_over_relaxation_time * conformal_spatial_metric(ti::i, ti::j));
 
   // time derivative computation: eq 12a - 12m
 
   // eq 12a : time derivative of the conformal spatial metric
-  ::tenex::evaluate<ti_i, ti_j>(
+  ::tenex::evaluate<ti::i, ti::j>(
       dt_conformal_spatial_metric,
-      2.0 * shift(ti_K) * field_d(ti_k, ti_i, ti_j) +
-          (*conformal_metric_times_field_b)(ti_i, ti_j) +
-          (*conformal_metric_times_field_b)(ti_j, ti_i) -
-          2.0 * one_third * conformal_spatial_metric(ti_i, ti_j) *
+      2.0 * shift(ti::K) * field_d(ti::k, ti::i, ti::j) +
+          (*conformal_metric_times_field_b)(ti::i, ti::j) +
+          (*conformal_metric_times_field_b)(ti::j, ti::i) -
+          2.0 * one_third * conformal_spatial_metric(ti::i, ti::j) *
               (*contracted_field_b)() -
           2.0 * (*lapse)() *
               (*a_tilde_minus_one_third_conformal_metric_times_trace_a_tilde)(
-                  ti_i, ti_j) -
-          (*inv_tau_times_conformal_metric)(ti_i, ti_j) *
+                  ti::i, ti::j) -
+          (*inv_tau_times_conformal_metric)(ti::i, ti::j) *
               ((*det_conformal_spatial_metric)() - 1.0));
 
   // eq 12b : time derivative of the natural log of the lapse
-  ::tenex::evaluate(dt_ln_lapse, shift(ti_K) * field_a(ti_k) -
+  ::tenex::evaluate(dt_ln_lapse, shift(ti::K) * field_a(ti::k) -
                                      (*lapse_times_slicing_condition)() *
                                          (*k_minus_k0_minus_2_theta_c)());
 
@@ -403,41 +406,42 @@ void TimeDerivative<Dim>::apply(
       component = 0.0;
     }
   } else {
-    ::tenex::evaluate<ti_I>(dt_shift,
-                            f * b(ti_I) + shift(ti_K) * field_b(ti_k, ti_I));
+    ::tenex::evaluate<ti::I>(
+        dt_shift, f * b(ti::I) + shift(ti::K) * field_b(ti::k, ti::I));
   }
 
   // eq 12d : time derivative of the natural log of the conformal factor
   ::tenex::evaluate(dt_ln_conformal_factor,
-                    shift(ti_K) * field_p(ti_k) +
+                    shift(ti::K) * field_p(ti::k) +
                         one_third * ((*lapse)() * trace_extrinsic_curvature() -
                                      (*contracted_field_b)()));
 
   // eq 12e : time derivative of the trace-free part of the extrinsic curvature
-  ::tenex::evaluate<ti_i, ti_j>(
+  ::tenex::evaluate<ti::i, ti::j>(
       dt_a_tilde,
-      shift(ti_K) * d_a_tilde(ti_k, ti_i, ti_j) +
+      shift(ti::K) * d_a_tilde(ti::k, ti::i, ti::j) +
           (*conformal_factor_squared)() *
-              ((*lapse)() * ((*spatial_ricci_tensor)(ti_i, ti_j) +
-                             (*grad_spatial_z4_constraint)(ti_i, ti_j) +
-                             (*grad_spatial_z4_constraint)(ti_j, ti_i)) -
-               (*grad_grad_lapse)(ti_i, ti_j)) -
-          one_third * conformal_spatial_metric(ti_i, ti_j) *
+              ((*lapse)() * ((*spatial_ricci_tensor)(ti::i, ti::j) +
+                             (*grad_spatial_z4_constraint)(ti::i, ti::j) +
+                             (*grad_spatial_z4_constraint)(ti::j, ti::i)) -
+               (*grad_grad_lapse)(ti::i, ti::j)) -
+          one_third * conformal_spatial_metric(ti::i, ti::j) *
               ((*lapse_times_ricci_scalar_plus_divergence_z4_constraint)() -
                (*divergence_lapse)()) +
-          (*a_tilde_times_field_b)(ti_i, ti_j) +
-          (*a_tilde_times_field_b)(ti_j, ti_i) -
-          2.0 * one_third * a_tilde(ti_i, ti_j) * (*contracted_field_b)() +
-          (*lapse_times_a_tilde)(ti_i, ti_j) * (*k_minus_2_theta_c)() -
-          2.0 * (*lapse_times_a_tilde)(ti_i, ti_l) *
-              (*inv_conformal_spatial_metric)(ti_L, ti_M) *
-              a_tilde(ti_m, ti_j) -
-          (*inv_tau_times_conformal_metric)(ti_i, ti_j) * (*trace_a_tilde)());
+          (*a_tilde_times_field_b)(ti::i, ti::j) +
+          (*a_tilde_times_field_b)(ti::j, ti::i) -
+          2.0 * one_third * a_tilde(ti::i, ti::j) * (*contracted_field_b)() +
+          (*lapse_times_a_tilde)(ti::i, ti::j) * (*k_minus_2_theta_c)() -
+          2.0 * (*lapse_times_a_tilde)(ti::i, ti::l) *
+              (*inv_conformal_spatial_metric)(ti::L, ti::M) *
+              a_tilde(ti::m, ti::j) -
+          (*inv_tau_times_conformal_metric)(ti::i, ti::j) * (*trace_a_tilde)());
 
   // eq. (12f) : time derivative of the trace of the extrinsic curvature
   ::tenex::evaluate(
       dt_trace_extrinsic_curvature,
-      shift(ti_K) * d_trace_extrinsic_curvature(ti_k) - (*divergence_lapse)() +
+      shift(ti::K) * d_trace_extrinsic_curvature(ti::k) -
+          (*divergence_lapse)() +
           (*lapse_times_ricci_scalar_plus_divergence_z4_constraint)() +
           (*lapse)() * (trace_extrinsic_curvature() * (*k_minus_2_theta_c)() -
                         3.0 * kappa_1 * (1.0 + kappa_2) * theta()));
@@ -446,64 +450,66 @@ void TimeDerivative<Dim>::apply(
   // the normal direction
   ::tenex::evaluate(
       dt_theta,
-      shift(ti_K) * d_theta(ti_k) +
+      shift(ti::K) * d_theta(ti::k) +
           (*lapse)() *
               (0.5 * square(cleaning_speed) *
                    ((*ricci_scalar_plus_divergence_z4_constraint)() +
                     2.0 * one_third * square(trace_extrinsic_curvature()) -
-                    a_tilde(ti_i, ti_j) * (*inv_a_tilde)(ti_I, ti_J)) -
+                    a_tilde(ti::i, ti::j) * (*inv_a_tilde)(ti::I, ti::J)) -
                c * theta() * trace_extrinsic_curvature() -
-               (*upper_spatial_z4_constraint)(ti_I)*field_a(ti_i) -
+               (*upper_spatial_z4_constraint)(ti::I)*field_a(ti::i) -
                kappa_1 * (2.0 + kappa_2) * theta()));
 
   // eq. (12h) : time derivative \hat{\Gamma}^i
   // first, compute terms without s
-  ::tenex::evaluate<ti_I>(
+  ::tenex::evaluate<ti::I>(
       dt_gamma_hat,
       // terms without lapse nor s
-      (*shift_times_deriv_gamma_hat)(ti_I) +
+      (*shift_times_deriv_gamma_hat)(ti::I) +
           2.0 * one_third *
-              (*contracted_conformal_christoffel_second_kind)(ti_I) *
+              (*contracted_conformal_christoffel_second_kind)(ti::I) *
               (*contracted_field_b)() -
-          (*contracted_conformal_christoffel_second_kind)(ti_K)*field_b(ti_k,
-                                                                        ti_I) +
-          2.0 * kappa_3 * (*spatial_z4_constraint)(ti_j) *
-              (2.0 * one_third * (*inv_conformal_spatial_metric)(ti_I, ti_J) *
+          (*contracted_conformal_christoffel_second_kind)(ti::K)*field_b(
+              ti::k, ti::I) +
+          2.0 * kappa_3 * (*spatial_z4_constraint)(ti::j) *
+              (2.0 * one_third * (*inv_conformal_spatial_metric)(ti::I, ti::J) *
                    (*contracted_field_b)() -
-               (*inv_conformal_spatial_metric)(ti_J, ti_K) *
-                   field_b(ti_k, ti_I)) +
+               (*inv_conformal_spatial_metric)(ti::J, ti::K) *
+                   field_b(ti::k, ti::I)) +
           // terms with lapse but not s
           2.0 * (*lapse)() *
-              (-2.0 * one_third * (*inv_conformal_spatial_metric)(ti_I, ti_J) *
-                   d_trace_extrinsic_curvature(ti_j) +
-               (*inv_conformal_spatial_metric)(ti_K, ti_I) * d_theta(ti_k) +
-               (*conformal_christoffel_second_kind)(ti_I, ti_j, ti_k) *
-                   (*inv_a_tilde)(ti_J, ti_K) -
-               3.0 * (*inv_a_tilde)(ti_I, ti_J) * field_p(ti_j) -
-               (*inv_conformal_spatial_metric)(ti_K, ti_I) *
-                   (theta() * field_a(ti_k) +
+              (-2.0 * one_third *
+                   (*inv_conformal_spatial_metric)(ti::I, ti::J) *
+                   d_trace_extrinsic_curvature(ti::j) +
+               (*inv_conformal_spatial_metric)(ti::K, ti::I) * d_theta(ti::k) +
+               (*conformal_christoffel_second_kind)(ti::I, ti::j, ti::k) *
+                   (*inv_a_tilde)(ti::J, ti::K) -
+               3.0 * (*inv_a_tilde)(ti::I, ti::J) * field_p(ti::j) -
+               (*inv_conformal_spatial_metric)(ti::K, ti::I) *
+                   (theta() * field_a(ti::k) +
                     2.0 * one_third * trace_extrinsic_curvature() *
-                        (*spatial_z4_constraint)(ti_k)) -
-               (*inv_a_tilde)(ti_I, ti_J) * field_a(ti_j) -
-               kappa_1 * (*inv_conformal_spatial_metric)(ti_I, ti_J) *
-                   (*spatial_z4_constraint)(ti_j)));
+                        (*spatial_z4_constraint)(ti::k)) -
+               (*inv_a_tilde)(ti::I, ti::J) * field_a(ti::j) -
+               kappa_1 * (*inv_conformal_spatial_metric)(ti::I, ti::J) *
+                   (*spatial_z4_constraint)(ti::j)));
   // now, if s == 1, also add terms with s
   if (static_cast<bool>(evolve_shift)) {
-    ::tenex::evaluate<ti_I>(
+    ::tenex::evaluate<ti::I>(
         dt_gamma_hat,
-        (*dt_gamma_hat)(ti_I) +
+        (*dt_gamma_hat)(ti::I) +
             // terms with lapse and s
             2.0 * (*lapse)() *
-                ((*inv_conformal_spatial_metric)(ti_I, ti_K) *
-                     (*inv_conformal_spatial_metric)(ti_N, ti_M) *
-                     d_a_tilde(ti_k, ti_n, ti_m) -
-                 2.0 * (*inv_conformal_spatial_metric)(ti_I, ti_K) *
-                     (*field_d_up)(ti_k, ti_N, ti_M) * a_tilde(ti_n, ti_m)) +
+                ((*inv_conformal_spatial_metric)(ti::I, ti::K) *
+                     (*inv_conformal_spatial_metric)(ti::N, ti::M) *
+                     d_a_tilde(ti::k, ti::n, ti::m) -
+                 2.0 * (*inv_conformal_spatial_metric)(ti::I, ti::K) *
+                     (*field_d_up)(ti::k, ti::N, ti::M) *
+                     a_tilde(ti::n, ti::m)) +
             // terms with s but not not lapse
-            (*inv_conformal_spatial_metric)(ti_K, ti_L) *
-                (*symmetrized_d_field_b)(ti_k, ti_l, ti_I) +
-            one_third * (*inv_conformal_spatial_metric)(ti_I, ti_K) *
-                (*contracted_symmetrized_d_field_b)(ti_k));
+            (*inv_conformal_spatial_metric)(ti::K, ti::L) *
+                (*symmetrized_d_field_b)(ti::k, ti::l, ti::I) +
+            one_third * (*inv_conformal_spatial_metric)(ti::I, ti::K) *
+                (*contracted_symmetrized_d_field_b)(ti::k));
   }
 
   // eq. (12i) : time derivative b^i
@@ -513,29 +519,30 @@ void TimeDerivative<Dim>::apply(
       component = 0.0;
     }
   } else {
-    ::tenex::evaluate<ti_I>(
-        dt_b, (*dt_gamma_hat)(ti_I)-eta() * b(ti_I) +
-                  shift(ti_K) * (d_b(ti_k, ti_I) - d_gamma_hat(ti_k, ti_I)));
+    ::tenex::evaluate<ti::I>(
+        dt_b,
+        (*dt_gamma_hat)(ti::I)-eta() * b(ti::I) +
+            shift(ti::K) * (d_b(ti::k, ti::I) - d_gamma_hat(ti::k, ti::I)));
   }
 
   // eq. (12j) : time derivative of auxiliary variable A_i
   // first, compute terms without s
-  ::tenex::evaluate<ti_k>(
+  ::tenex::evaluate<ti::k>(
       dt_field_a,
-      shift(ti_L) * d_field_a(ti_l, ti_k) -
-          (*lapse_times_field_a)(ti_k) * (*k_minus_k0_minus_2_theta_c)() *
+      shift(ti::L) * d_field_a(ti::l, ti::k) -
+          (*lapse_times_field_a)(ti::k) * (*k_minus_k0_minus_2_theta_c)() *
               ((*slicing_condition)() + (*lapse)() * (*d_slicing_condition)()) +
-          field_b(ti_k, ti_L) * field_a(ti_l) -
+          field_b(ti::k, ti::L) * field_a(ti::l) -
           (*lapse_times_slicing_condition)() *
-              (d_trace_extrinsic_curvature(ti_k) - d_k_0(ti_k) -
-               2.0 * c * d_theta(ti_k)));
+              (d_trace_extrinsic_curvature(ti::k) - d_k_0(ti::k) -
+               2.0 * c * d_theta(ti::k)));
   // now, if s == 1, also add terms with s
   if (static_cast<bool>(evolve_shift)) {
-    ::tenex::evaluate<ti_k>(
-        dt_field_a, (*dt_field_a)(ti_k) -
+    ::tenex::evaluate<ti::k>(
+        dt_field_a, (*dt_field_a)(ti::k) -
                         (*lapse_times_slicing_condition)() *
-                            ((*inv_conformal_metric_times_d_a_tilde)(ti_k) -
-                             (2.0 * (*field_d_up_times_a_tilde)(ti_k))));
+                            ((*inv_conformal_metric_times_d_a_tilde)(ti::k) -
+                             (2.0 * (*field_d_up_times_a_tilde)(ti::k))));
   }
 
   // eq. (12k) : time derivative of auxiliary variable B_k{}^i
@@ -546,65 +553,65 @@ void TimeDerivative<Dim>::apply(
     }
   } else {
     // first, compute expression without advective terms
-    ::tenex::evaluate<ti_k, ti_I>(
-        dt_field_b, shift(ti_L) * d_field_b(ti_l, ti_k, ti_I) +
-                        f * d_b(ti_k, ti_I) +
+    ::tenex::evaluate<ti::k, ti::I>(
+        dt_field_b, shift(ti::L) * d_field_b(ti::l, ti::k, ti::I) +
+                        f * d_b(ti::k, ti::I) +
                         mu * square((*lapse)()) *
-                            (*inv_conformal_spatial_metric)(ti_I, ti_J) *
-                            (d_field_p(ti_k, ti_j) - d_field_p(ti_j, ti_k) -
-                             (*inv_conformal_spatial_metric)(ti_N, ti_L) *
-                                 (d_field_d(ti_k, ti_l, ti_j, ti_n) -
-                                  d_field_d(ti_l, ti_k, ti_j, ti_n))) +
-                        field_b(ti_k, ti_L) * field_b(ti_l, ti_I));
+                            (*inv_conformal_spatial_metric)(ti::I, ti::J) *
+                            (d_field_p(ti::k, ti::j) - d_field_p(ti::j, ti::k) -
+                             (*inv_conformal_spatial_metric)(ti::N, ti::L) *
+                                 (d_field_d(ti::k, ti::l, ti::j, ti::n) -
+                                  d_field_d(ti::l, ti::k, ti::j, ti::n))) +
+                        field_b(ti::k, ti::L) * field_b(ti::l, ti::I));
   }
 
   // eq. (12l) : time derivative of auxiliary variable D_{kij}
   // first, compute terms without s
-  ::tenex::evaluate<ti_k, ti_i, ti_j>(
+  ::tenex::evaluate<ti::k, ti::i, ti::j>(
       dt_field_d,
-      shift(ti_L) * d_field_d(ti_l, ti_k, ti_i, ti_j) -
-          (*lapse_times_d_a_tilde)(ti_k, ti_i, ti_j) +
-          field_b(ti_k, ti_L) * field_d(ti_l, ti_i, ti_j) +
-          (*field_b_times_field_d)(ti_j, ti_k, ti_i) +
-          (*field_b_times_field_d)(ti_i, ti_k, ti_j) -
-          (*lapse_times_field_a)(ti_k) *
+      shift(ti::L) * d_field_d(ti::l, ti::k, ti::i, ti::j) -
+          (*lapse_times_d_a_tilde)(ti::k, ti::i, ti::j) +
+          field_b(ti::k, ti::L) * field_d(ti::l, ti::i, ti::j) +
+          (*field_b_times_field_d)(ti::j, ti::k, ti::i) +
+          (*field_b_times_field_d)(ti::i, ti::k, ti::j) -
+          (*lapse_times_field_a)(ti::k) *
               (*a_tilde_minus_one_third_conformal_metric_times_trace_a_tilde)(
-                  ti_i, ti_j) +
+                  ti::i, ti::j) +
           one_third *
-              ((*lapse_times_conformal_spatial_metric)(ti_i, ti_j) *
-                   (*inv_conformal_metric_times_d_a_tilde)(ti_k) -
-               (2.0 * (*contracted_field_b)() * field_d(ti_k, ti_i, ti_j)) -
-               2.0 * (*lapse_times_conformal_spatial_metric)(ti_i, ti_j) *
-                   (*field_d_up_times_a_tilde)(ti_k)));
+              ((*lapse_times_conformal_spatial_metric)(ti::i, ti::j) *
+                   (*inv_conformal_metric_times_d_a_tilde)(ti::k) -
+               (2.0 * (*contracted_field_b)() * field_d(ti::k, ti::i, ti::j)) -
+               2.0 * (*lapse_times_conformal_spatial_metric)(ti::i, ti::j) *
+                   (*field_d_up_times_a_tilde)(ti::k)));
   // now, if s == 1, also add terms with s
   if (static_cast<bool>(evolve_shift)) {
-    ::tenex::evaluate<ti_k, ti_i, ti_j>(
-        dt_field_d, (*dt_field_d)(ti_k, ti_i, ti_j) +
+    ::tenex::evaluate<ti::k, ti::i, ti::j>(
+        dt_field_d, (*dt_field_d)(ti::k, ti::i, ti::j) +
                         0.5 * ((*conformal_metric_times_symmetrized_d_field_b)(
-                                   ti_i, ti_k, ti_j) +
+                                   ti::i, ti::k, ti::j) +
                                (*conformal_metric_times_symmetrized_d_field_b)(
-                                   ti_j, ti_k, ti_i)) -
-                        one_third * conformal_spatial_metric(ti_i, ti_j) *
-                            (*contracted_symmetrized_d_field_b)(ti_k));
+                                   ti::j, ti::k, ti::i)) -
+                        one_third * conformal_spatial_metric(ti::i, ti::j) *
+                            (*contracted_symmetrized_d_field_b)(ti::k));
   }
 
   // eq. (12m) : time derivative of auxiliary variable P_i
   // first, compute terms without s
-  ::tenex::evaluate<ti_k>(
-      dt_field_p, shift(ti_L) * d_field_p(ti_l, ti_k) +
-                      field_b(ti_k, ti_L) * field_p(ti_l) +
+  ::tenex::evaluate<ti::k>(
+      dt_field_p, shift(ti::L) * d_field_p(ti::l, ti::k) +
+                      field_b(ti::k, ti::L) * field_p(ti::l) +
                       one_third * (*lapse)() *
-                          (d_trace_extrinsic_curvature(ti_k) +
-                           field_a(ti_k) * trace_extrinsic_curvature()));
+                          (d_trace_extrinsic_curvature(ti::k) +
+                           field_a(ti::k) * trace_extrinsic_curvature()));
   // now, if s == 1, also add terms with s
   if (static_cast<bool>(evolve_shift)) {
-    ::tenex::evaluate<ti_k>(
+    ::tenex::evaluate<ti::k>(
         dt_field_p,
-        (*dt_field_p)(ti_k) +
+        (*dt_field_p)(ti::k) +
             one_third *
-                ((*lapse)() * ((*inv_conformal_metric_times_d_a_tilde)(ti_k) -
-                               (2.0 * (*field_d_up_times_a_tilde)(ti_k))) -
-                 (*contracted_symmetrized_d_field_b)(ti_k)));
+                ((*lapse)() * ((*inv_conformal_metric_times_d_a_tilde)(ti::k) -
+                               (2.0 * (*field_d_up_times_a_tilde)(ti::k))) -
+                 (*contracted_symmetrized_d_field_b)(ti::k)));
   }
 }
 }  // namespace Ccz4

--- a/src/Evolution/Systems/Ccz4/TimeDerivative.cpp
+++ b/src/Evolution/Systems/Ccz4/TimeDerivative.cpp
@@ -166,11 +166,11 @@ void TimeDerivative<Dim>::apply(
     get(*conformal_factor_squared)[i] = exp(2.0 * get(ln_conformal_factor)[i]);
   }
 
-  ::TensorExpressions::evaluate<ti_I, ti_J>(
+  ::tenex::evaluate<ti_I, ti_J>(
       inv_spatial_metric, (*conformal_factor_squared)() *
                               (*inv_conformal_spatial_metric)(ti_I, ti_J));
 
-  ::TensorExpressions::evaluate<ti_I, ti_J>(
+  ::tenex::evaluate<ti_I, ti_J>(
       inv_a_tilde, a_tilde(ti_k, ti_l) *
                        (*inv_conformal_spatial_metric)(ti_I, ti_K) *
                        (*inv_conformal_spatial_metric)(ti_J, ti_L));
@@ -201,12 +201,11 @@ void TimeDerivative<Dim>::apply(
   // expressions and identities needed for evolution equations: eq 13 - 27
 
   // eq 13
-  ::TensorExpressions::evaluate(
-      trace_a_tilde,
-      (*inv_conformal_spatial_metric)(ti_I, ti_J) * a_tilde(ti_i, ti_j));
+  ::tenex::evaluate(trace_a_tilde, (*inv_conformal_spatial_metric)(ti_I, ti_J) *
+                                       a_tilde(ti_i, ti_j));
 
   // eq 14
-  ::TensorExpressions::evaluate<ti_k, ti_I, ti_J>(
+  ::tenex::evaluate<ti_k, ti_I, ti_J>(
       field_d_up, (*inv_conformal_spatial_metric)(ti_I, ti_N) *
                       (*inv_conformal_spatial_metric)(ti_M, ti_J) *
                       field_d(ti_k, ti_n, ti_m));
@@ -228,17 +227,16 @@ void TimeDerivative<Dim>::apply(
                                   *conformal_christoffel_second_kind);
 
   // temporary expressions needed for eq 18 - 20
-  ::TensorExpressions::evaluate<ti_l>(
-      contracted_christoffel_second_kind,
-      (*christoffel_second_kind)(ti_M, ti_l, ti_m));
+  ::tenex::evaluate<ti_l>(contracted_christoffel_second_kind,
+                          (*christoffel_second_kind)(ti_M, ti_l, ti_m));
 
-  ::TensorExpressions::evaluate<ti_i, ti_j>(
+  ::tenex::evaluate<ti_i, ti_j>(
       contracted_d_conformal_christoffel_difference,
       (*d_conformal_christoffel_second_kind)(ti_m, ti_M, ti_i, ti_j) -
           (*d_conformal_christoffel_second_kind)(ti_j, ti_M, ti_i, ti_m));
 
-  ::TensorExpressions::evaluate<ti_L>(contracted_field_d_up,
-                                      (*field_d_up)(ti_m, ti_M, ti_L));
+  ::tenex::evaluate<ti_L>(contracted_field_d_up,
+                          (*field_d_up)(ti_m, ti_M, ti_L));
 
   // eq 18 - 20
   ::Ccz4::spatial_ricci_tensor(
@@ -268,7 +266,7 @@ void TimeDerivative<Dim>::apply(
       *conformal_christoffel_second_kind, *d_conformal_christoffel_second_kind);
 
   // temp for eq 25
-  ::TensorExpressions::evaluate<ti_I>(
+  ::tenex::evaluate<ti_I>(
       gamma_hat_minus_contracted_conformal_christoffel,
       gamma_hat(ti_I) - (*contracted_conformal_christoffel_second_kind)(ti_I));
 
@@ -284,7 +282,7 @@ void TimeDerivative<Dim>::apply(
       *gamma_hat_minus_contracted_conformal_christoffel);
 
   // temp for eq 26
-  ::TensorExpressions::evaluate<ti_i, ti_L>(
+  ::tenex::evaluate<ti_i, ti_L>(
       d_gamma_hat_minus_contracted_conformal_christoffel,
       d_gamma_hat(ti_i, ti_L) -
           (*d_contracted_conformal_christoffel_second_kind)(ti_i, ti_L));
@@ -304,9 +302,9 @@ void TimeDerivative<Dim>::apply(
 
   // temporary expressions not already computed above
 
-  ::TensorExpressions::evaluate(contracted_field_b, field_b(ti_k, ti_K));
+  ::tenex::evaluate(contracted_field_b, field_b(ti_k, ti_K));
 
-  ::TensorExpressions::evaluate<ti_k, ti_j, ti_I>(
+  ::tenex::evaluate<ti_k, ti_j, ti_I>(
       symmetrized_d_field_b,
       0.5 * (d_field_b(ti_k, ti_j, ti_I) + d_field_b(ti_j, ti_k, ti_I)));
 
@@ -317,73 +315,70 @@ void TimeDerivative<Dim>::apply(
     }
   }
 
-  ::TensorExpressions::evaluate<ti_i, ti_j, ti_k>(
+  ::tenex::evaluate<ti_i, ti_j, ti_k>(
       field_b_times_field_d, field_b(ti_i, ti_L) * field_d(ti_j, ti_l, ti_k));
 
-  ::TensorExpressions::evaluate<ti_k>(
+  ::tenex::evaluate<ti_k>(
       field_d_up_times_a_tilde,
       (*field_d_up)(ti_k, ti_I, ti_J) * a_tilde(ti_i, ti_j));
 
-  ::TensorExpressions::evaluate<ti_i, ti_j>(
+  ::tenex::evaluate<ti_i, ti_j>(
       conformal_metric_times_field_b,
       conformal_spatial_metric(ti_k, ti_i) * field_b(ti_j, ti_K));
 
-  ::TensorExpressions::evaluate<ti_i, ti_k, ti_j>(
+  ::tenex::evaluate<ti_i, ti_k, ti_j>(
       conformal_metric_times_symmetrized_d_field_b,
       conformal_spatial_metric(ti_m, ti_i) *
           (*symmetrized_d_field_b)(ti_k, ti_j, ti_M));
 
-  ::TensorExpressions::evaluate<ti_i, ti_j>(
+  ::tenex::evaluate<ti_i, ti_j>(
       conformal_metric_times_trace_a_tilde,
       conformal_spatial_metric(ti_i, ti_j) * (*trace_a_tilde)());
 
-  ::TensorExpressions::evaluate<ti_k>(
-      inv_conformal_metric_times_d_a_tilde,
-      (*inv_conformal_spatial_metric)(ti_I, ti_J) *
-          d_a_tilde(ti_k, ti_i, ti_j));
+  ::tenex::evaluate<ti_k>(inv_conformal_metric_times_d_a_tilde,
+                          (*inv_conformal_spatial_metric)(ti_I, ti_J) *
+                              d_a_tilde(ti_k, ti_i, ti_j));
 
-  ::TensorExpressions::evaluate<ti_i, ti_j>(
-      a_tilde_times_field_b, a_tilde(ti_k, ti_i) * field_b(ti_j, ti_K));
+  ::tenex::evaluate<ti_i, ti_j>(a_tilde_times_field_b,
+                                a_tilde(ti_k, ti_i) * field_b(ti_j, ti_K));
 
-  ::TensorExpressions::evaluate<ti_i, ti_j>(
+  ::tenex::evaluate<ti_i, ti_j>(
       a_tilde_minus_one_third_conformal_metric_times_trace_a_tilde,
       a_tilde(ti_i, ti_j) -
           one_third * (*conformal_metric_times_trace_a_tilde)(ti_i, ti_j));
 
-  ::TensorExpressions::evaluate(
-      k_minus_2_theta_c, trace_extrinsic_curvature() - 2.0 * c * theta());
+  ::tenex::evaluate(k_minus_2_theta_c,
+                    trace_extrinsic_curvature() - 2.0 * c * theta());
 
-  ::TensorExpressions::evaluate(k_minus_k0_minus_2_theta_c,
-                                (*k_minus_2_theta_c)() - k_0());
+  ::tenex::evaluate(k_minus_k0_minus_2_theta_c, (*k_minus_2_theta_c)() - k_0());
 
-  ::TensorExpressions::evaluate<ti_i, ti_j>(lapse_times_a_tilde,
-                                            (*lapse)() * a_tilde(ti_i, ti_j));
+  ::tenex::evaluate<ti_i, ti_j>(lapse_times_a_tilde,
+                                (*lapse)() * a_tilde(ti_i, ti_j));
 
-  TensorExpressions::evaluate<ti_k, ti_i, ti_j>(
-      lapse_times_d_a_tilde, (*lapse)() * d_a_tilde(ti_k, ti_i, ti_j));
+  tenex::evaluate<ti_k, ti_i, ti_j>(lapse_times_d_a_tilde,
+                                    (*lapse)() * d_a_tilde(ti_k, ti_i, ti_j));
 
-  ::TensorExpressions::evaluate<ti_k>(lapse_times_field_a,
-                                      (*lapse)() * field_a(ti_k));
+  ::tenex::evaluate<ti_k>(lapse_times_field_a, (*lapse)() * field_a(ti_k));
 
-  ::TensorExpressions::evaluate<ti_i, ti_j>(
+  ::tenex::evaluate<ti_i, ti_j>(
       lapse_times_conformal_spatial_metric,
       (*lapse)() * conformal_spatial_metric(ti_i, ti_j));
 
-  ::TensorExpressions::evaluate(
+  ::tenex::evaluate(
       lapse_times_ricci_scalar_plus_divergence_z4_constraint,
       (*lapse)() * (*ricci_scalar_plus_divergence_z4_constraint)());
 
-  ::TensorExpressions::evaluate<ti_I>(shift_times_deriv_gamma_hat,
-                                      shift(ti_K) * d_gamma_hat(ti_k, ti_I));
+  ::tenex::evaluate<ti_I>(shift_times_deriv_gamma_hat,
+                          shift(ti_K) * d_gamma_hat(ti_k, ti_I));
 
-  ::TensorExpressions::evaluate<ti_i, ti_j>(
+  ::tenex::evaluate<ti_i, ti_j>(
       inv_tau_times_conformal_metric,
       one_over_relaxation_time * conformal_spatial_metric(ti_i, ti_j));
 
   // time derivative computation: eq 12a - 12m
 
   // eq 12a : time derivative of the conformal spatial metric
-  ::TensorExpressions::evaluate<ti_i, ti_j>(
+  ::tenex::evaluate<ti_i, ti_j>(
       dt_conformal_spatial_metric,
       2.0 * shift(ti_K) * field_d(ti_k, ti_i, ti_j) +
           (*conformal_metric_times_field_b)(ti_i, ti_j) +
@@ -397,10 +392,9 @@ void TimeDerivative<Dim>::apply(
               ((*det_conformal_spatial_metric)() - 1.0));
 
   // eq 12b : time derivative of the natural log of the lapse
-  ::TensorExpressions::evaluate(
-      dt_ln_lapse,
-      shift(ti_K) * field_a(ti_k) -
-          (*lapse_times_slicing_condition)() * (*k_minus_k0_minus_2_theta_c)());
+  ::tenex::evaluate(dt_ln_lapse, shift(ti_K) * field_a(ti_k) -
+                                     (*lapse_times_slicing_condition)() *
+                                         (*k_minus_k0_minus_2_theta_c)());
 
   // eq 12c : time derivative of the shift
   // if s == 0
@@ -409,19 +403,18 @@ void TimeDerivative<Dim>::apply(
       component = 0.0;
     }
   } else {
-    ::TensorExpressions::evaluate<ti_I>(
-        dt_shift, f * b(ti_I) + shift(ti_K) * field_b(ti_k, ti_I));
+    ::tenex::evaluate<ti_I>(dt_shift,
+                            f * b(ti_I) + shift(ti_K) * field_b(ti_k, ti_I));
   }
 
   // eq 12d : time derivative of the natural log of the conformal factor
-  ::TensorExpressions::evaluate(
-      dt_ln_conformal_factor,
-      shift(ti_K) * field_p(ti_k) +
-          one_third * ((*lapse)() * trace_extrinsic_curvature() -
-                       (*contracted_field_b)()));
+  ::tenex::evaluate(dt_ln_conformal_factor,
+                    shift(ti_K) * field_p(ti_k) +
+                        one_third * ((*lapse)() * trace_extrinsic_curvature() -
+                                     (*contracted_field_b)()));
 
   // eq 12e : time derivative of the trace-free part of the extrinsic curvature
-  ::TensorExpressions::evaluate<ti_i, ti_j>(
+  ::tenex::evaluate<ti_i, ti_j>(
       dt_a_tilde,
       shift(ti_K) * d_a_tilde(ti_k, ti_i, ti_j) +
           (*conformal_factor_squared)() *
@@ -442,7 +435,7 @@ void TimeDerivative<Dim>::apply(
           (*inv_tau_times_conformal_metric)(ti_i, ti_j) * (*trace_a_tilde)());
 
   // eq. (12f) : time derivative of the trace of the extrinsic curvature
-  ::TensorExpressions::evaluate(
+  ::tenex::evaluate(
       dt_trace_extrinsic_curvature,
       shift(ti_K) * d_trace_extrinsic_curvature(ti_k) - (*divergence_lapse)() +
           (*lapse_times_ricci_scalar_plus_divergence_z4_constraint)() +
@@ -451,7 +444,7 @@ void TimeDerivative<Dim>::apply(
 
   // eq. (12g) : time derivative of the projection of the Z4 four-vector along
   // the normal direction
-  ::TensorExpressions::evaluate(
+  ::tenex::evaluate(
       dt_theta,
       shift(ti_K) * d_theta(ti_k) +
           (*lapse)() *
@@ -465,7 +458,7 @@ void TimeDerivative<Dim>::apply(
 
   // eq. (12h) : time derivative \hat{\Gamma}^i
   // first, compute terms without s
-  ::TensorExpressions::evaluate<ti_I>(
+  ::tenex::evaluate<ti_I>(
       dt_gamma_hat,
       // terms without lapse nor s
       (*shift_times_deriv_gamma_hat)(ti_I) +
@@ -496,7 +489,7 @@ void TimeDerivative<Dim>::apply(
                    (*spatial_z4_constraint)(ti_j)));
   // now, if s == 1, also add terms with s
   if (static_cast<bool>(evolve_shift)) {
-    ::TensorExpressions::evaluate<ti_I>(
+    ::tenex::evaluate<ti_I>(
         dt_gamma_hat,
         (*dt_gamma_hat)(ti_I) +
             // terms with lapse and s
@@ -520,14 +513,14 @@ void TimeDerivative<Dim>::apply(
       component = 0.0;
     }
   } else {
-    ::TensorExpressions::evaluate<ti_I>(
+    ::tenex::evaluate<ti_I>(
         dt_b, (*dt_gamma_hat)(ti_I)-eta() * b(ti_I) +
                   shift(ti_K) * (d_b(ti_k, ti_I) - d_gamma_hat(ti_k, ti_I)));
   }
 
   // eq. (12j) : time derivative of auxiliary variable A_i
   // first, compute terms without s
-  ::TensorExpressions::evaluate<ti_k>(
+  ::tenex::evaluate<ti_k>(
       dt_field_a,
       shift(ti_L) * d_field_a(ti_l, ti_k) -
           (*lapse_times_field_a)(ti_k) * (*k_minus_k0_minus_2_theta_c)() *
@@ -538,7 +531,7 @@ void TimeDerivative<Dim>::apply(
                2.0 * c * d_theta(ti_k)));
   // now, if s == 1, also add terms with s
   if (static_cast<bool>(evolve_shift)) {
-    ::TensorExpressions::evaluate<ti_k>(
+    ::tenex::evaluate<ti_k>(
         dt_field_a, (*dt_field_a)(ti_k) -
                         (*lapse_times_slicing_condition)() *
                             ((*inv_conformal_metric_times_d_a_tilde)(ti_k) -
@@ -553,7 +546,7 @@ void TimeDerivative<Dim>::apply(
     }
   } else {
     // first, compute expression without advective terms
-    ::TensorExpressions::evaluate<ti_k, ti_I>(
+    ::tenex::evaluate<ti_k, ti_I>(
         dt_field_b, shift(ti_L) * d_field_b(ti_l, ti_k, ti_I) +
                         f * d_b(ti_k, ti_I) +
                         mu * square((*lapse)()) *
@@ -567,7 +560,7 @@ void TimeDerivative<Dim>::apply(
 
   // eq. (12l) : time derivative of auxiliary variable D_{kij}
   // first, compute terms without s
-  ::TensorExpressions::evaluate<ti_k, ti_i, ti_j>(
+  ::tenex::evaluate<ti_k, ti_i, ti_j>(
       dt_field_d,
       shift(ti_L) * d_field_d(ti_l, ti_k, ti_i, ti_j) -
           (*lapse_times_d_a_tilde)(ti_k, ti_i, ti_j) +
@@ -585,7 +578,7 @@ void TimeDerivative<Dim>::apply(
                    (*field_d_up_times_a_tilde)(ti_k)));
   // now, if s == 1, also add terms with s
   if (static_cast<bool>(evolve_shift)) {
-    ::TensorExpressions::evaluate<ti_k, ti_i, ti_j>(
+    ::tenex::evaluate<ti_k, ti_i, ti_j>(
         dt_field_d, (*dt_field_d)(ti_k, ti_i, ti_j) +
                         0.5 * ((*conformal_metric_times_symmetrized_d_field_b)(
                                    ti_i, ti_k, ti_j) +
@@ -597,7 +590,7 @@ void TimeDerivative<Dim>::apply(
 
   // eq. (12m) : time derivative of auxiliary variable P_i
   // first, compute terms without s
-  ::TensorExpressions::evaluate<ti_k>(
+  ::tenex::evaluate<ti_k>(
       dt_field_p, shift(ti_L) * d_field_p(ti_l, ti_k) +
                       field_b(ti_k, ti_L) * field_p(ti_l) +
                       one_third * (*lapse)() *
@@ -605,7 +598,7 @@ void TimeDerivative<Dim>::apply(
                            field_a(ti_k) * trace_extrinsic_curvature()));
   // now, if s == 1, also add terms with s
   if (static_cast<bool>(evolve_shift)) {
-    ::TensorExpressions::evaluate<ti_k>(
+    ::tenex::evaluate<ti_k>(
         dt_field_p,
         (*dt_field_p)(ti_k) +
             one_third *

--- a/src/Evolution/Systems/Ccz4/Z4Constraint.cpp
+++ b/src/Evolution/Systems/Ccz4/Z4Constraint.cpp
@@ -21,7 +21,7 @@ void spatial_z4_constraint(
   destructive_resize_components(result,
                                 get_size(get<0, 0>(conformal_spatial_metric)));
 
-  ::TensorExpressions::evaluate<ti_i>(
+  ::tenex::evaluate<ti_i>(
       result, 0.5 * (conformal_spatial_metric(ti_i, ti_j) *
                      gamma_hat_minus_contracted_conformal_christoffel(ti_J)));
 }
@@ -49,8 +49,8 @@ void upper_spatial_z4_constraint(
   destructive_resize_components(buffer,
                                 get_size(get(conformal_factor_squared)));
 
-  ::TensorExpressions::evaluate(buffer, 0.5 * conformal_factor_squared());
-  ::TensorExpressions::evaluate<ti_I>(
+  ::tenex::evaluate(buffer, 0.5 * conformal_factor_squared());
+  ::tenex::evaluate<ti_I>(
       result,
       (*buffer)() * gamma_hat_minus_contracted_conformal_christoffel(ti_I));
 }

--- a/src/Evolution/Systems/Ccz4/Z4Constraint.cpp
+++ b/src/Evolution/Systems/Ccz4/Z4Constraint.cpp
@@ -21,9 +21,9 @@ void spatial_z4_constraint(
   destructive_resize_components(result,
                                 get_size(get<0, 0>(conformal_spatial_metric)));
 
-  ::tenex::evaluate<ti_i>(
-      result, 0.5 * (conformal_spatial_metric(ti_i, ti_j) *
-                     gamma_hat_minus_contracted_conformal_christoffel(ti_J)));
+  ::tenex::evaluate<ti::i>(
+      result, 0.5 * (conformal_spatial_metric(ti::i, ti::j) *
+                     gamma_hat_minus_contracted_conformal_christoffel(ti::J)));
 }
 
 template <size_t Dim, typename Frame, typename DataType>
@@ -50,9 +50,9 @@ void upper_spatial_z4_constraint(
                                 get_size(get(conformal_factor_squared)));
 
   ::tenex::evaluate(buffer, 0.5 * conformal_factor_squared());
-  ::tenex::evaluate<ti_I>(
+  ::tenex::evaluate<ti::I>(
       result,
-      (*buffer)() * gamma_hat_minus_contracted_conformal_christoffel(ti_I));
+      (*buffer)() * gamma_hat_minus_contracted_conformal_christoffel(ti::I));
 }
 
 template <size_t Dim, typename Frame, typename DataType>

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/HarmonicSchwarzschild.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/HarmonicSchwarzschild.cpp
@@ -90,7 +90,7 @@ void HarmonicSchwarzschild::IntermediateComputer<DataType, Frame>::operator()(
   const auto& x_minus_center =
       cache->get_var(*this, internal_tags::x_minus_center<DataType, Frame>{});
 
-  tenex::evaluate<ti_I>(x_over_r, x_minus_center(ti_I) * one_over_r());
+  tenex::evaluate<ti::I>(x_over_r, x_minus_center(ti::I) * one_over_r());
 }
 
 template <typename DataType, typename Frame>
@@ -384,9 +384,9 @@ void HarmonicSchwarzschild::IntermediateComputer<DataType, Frame>::operator()(
   const auto& one_over_spatial_metric_rr = cache->get_var(
       *this, internal_tags::one_over_spatial_metric_rr<DataType>{});
 
-  ::tenex::evaluate<ti_I>(shift, two_m_over_m_plus_r_squared() *
-                                     x_over_r(ti_I) *
-                                     one_over_spatial_metric_rr());
+  ::tenex::evaluate<ti::I>(shift, two_m_over_m_plus_r_squared() *
+                                      x_over_r(ti::I) *
+                                      one_over_spatial_metric_rr());
 }
 
 template <typename DataType, typename Frame>

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/HarmonicSchwarzschild.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/HarmonicSchwarzschild.cpp
@@ -90,8 +90,7 @@ void HarmonicSchwarzschild::IntermediateComputer<DataType, Frame>::operator()(
   const auto& x_minus_center =
       cache->get_var(*this, internal_tags::x_minus_center<DataType, Frame>{});
 
-  TensorExpressions::evaluate<ti_I>(x_over_r,
-                                    x_minus_center(ti_I) * one_over_r());
+  tenex::evaluate<ti_I>(x_over_r, x_minus_center(ti_I) * one_over_r());
 }
 
 template <typename DataType, typename Frame>
@@ -385,9 +384,9 @@ void HarmonicSchwarzschild::IntermediateComputer<DataType, Frame>::operator()(
   const auto& one_over_spatial_metric_rr = cache->get_var(
       *this, internal_tags::one_over_spatial_metric_rr<DataType>{});
 
-  ::TensorExpressions::evaluate<ti_I>(shift, two_m_over_m_plus_r_squared() *
-                                                 x_over_r(ti_I) *
-                                                 one_over_spatial_metric_rr());
+  ::tenex::evaluate<ti_I>(shift, two_m_over_m_plus_r_squared() *
+                                     x_over_r(ti_I) *
+                                     one_over_spatial_metric_rr());
 }
 
 template <typename DataType, typename Frame>

--- a/src/PointwiseFunctions/Xcts/ExtrinsicCurvature.cpp
+++ b/src/PointwiseFunctions/Xcts/ExtrinsicCurvature.cpp
@@ -20,13 +20,13 @@ void extrinsic_curvature(
     const tnsr::ii<DataType, 3>& conformal_metric,
     const tnsr::II<DataType, 3>& longitudinal_shift_minus_dt_conformal_metric,
     const Scalar<DataType>& trace_extrinsic_curvature) {
-  tenex::evaluate<ti_i, ti_j>(
+  tenex::evaluate<ti::i, ti::j>(
       result,
       pow<4>(conformal_factor()) *
-          (conformal_metric(ti_i, ti_k) * conformal_metric(ti_j, ti_l) *
-               longitudinal_shift_minus_dt_conformal_metric(ti_K, ti_L) /
+          (conformal_metric(ti::i, ti::k) * conformal_metric(ti::j, ti::l) *
+               longitudinal_shift_minus_dt_conformal_metric(ti::K, ti::L) /
                (2. * lapse()) +
-           conformal_metric(ti_i, ti_j) * trace_extrinsic_curvature() / 3.));
+           conformal_metric(ti::i, ti::j) * trace_extrinsic_curvature() / 3.));
 }
 
 template <typename DataType>

--- a/src/PointwiseFunctions/Xcts/ExtrinsicCurvature.cpp
+++ b/src/PointwiseFunctions/Xcts/ExtrinsicCurvature.cpp
@@ -20,7 +20,7 @@ void extrinsic_curvature(
     const tnsr::ii<DataType, 3>& conformal_metric,
     const tnsr::II<DataType, 3>& longitudinal_shift_minus_dt_conformal_metric,
     const Scalar<DataType>& trace_extrinsic_curvature) {
-  TensorExpressions::evaluate<ti_i, ti_j>(
+  tenex::evaluate<ti_i, ti_j>(
       result,
       pow<4>(conformal_factor()) *
           (conformal_metric(ti_i, ti_k) * conformal_metric(ti_j, ti_l) *

--- a/src/PointwiseFunctions/Xcts/SpacetimeQuantities.cpp
+++ b/src/PointwiseFunctions/Xcts/SpacetimeQuantities.cpp
@@ -62,11 +62,11 @@ void SpacetimeQuantitiesComputer::operator()(
   const auto& deriv_conformal_factor =
       cache->get_var(*this, ::Tags::deriv<Tags::ConformalFactor<DataVector>,
                                           tmpl::size_t<3>, Frame::Inertial>{});
-  const auto conformal_factor_flux = TensorExpressions::evaluate<ti_I>(
+  const auto conformal_factor_flux = tenex::evaluate<ti_I>(
       inv_conformal_metric(ti_I, ti_J) * deriv_conformal_factor(ti_j));
   const auto deriv_conformal_factor_flux =
       partial_derivative(conformal_factor_flux, mesh, inv_jacobian);
-  TensorExpressions::evaluate(
+  tenex::evaluate(
       conformal_laplacian_of_conformal_factor,
       deriv_conformal_factor_flux(ti_i, ti_I) +
           conformal_christoffel_contracted(ti_i) * conformal_factor_flux(ti_I));
@@ -159,7 +159,7 @@ void SpacetimeQuantitiesComputer::operator()(
     const {
   const auto& longitudinal_shift_excess = cache->get_var(
       *this, Tags::LongitudinalShiftExcess<DataVector, 3, Frame::Inertial>{});
-  TensorExpressions::evaluate<ti_I, ti_J>(
+  tenex::evaluate<ti_I, ti_J>(
       longitudinal_shift_minus_dt_conformal_metric,
       longitudinal_shift_excess(ti_I, ti_J) +
           longitudinal_shift_background_minus_dt_conformal_metric(ti_I, ti_J));
@@ -189,17 +189,16 @@ void SpacetimeQuantitiesComputer::operator()(
   const auto& extrinsic_curvature = cache->get_var(
       *this, gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>{});
   // Eq. 3.12 in BaumgarteShapiro, divided by 2 for consistency with SpEC
-  TensorExpressions::evaluate(
-      hamiltonian_constraint,
-      4. * conformal_laplacian_of_conformal_factor() -
-          0.5 * (conformal_factor() * conformal_ricci_scalar() +
-                 pow<5>(conformal_factor()) *
-                     (square(trace_extrinsic_curvature()) -
-                      inv_spatial_metric(ti_I, ti_K) *
-                          inv_spatial_metric(ti_J, ti_L) *
-                          extrinsic_curvature(ti_i, ti_j) *
-                          extrinsic_curvature(ti_k, ti_l) -
-                      16. * M_PI * energy_density())));
+  tenex::evaluate(hamiltonian_constraint,
+                  4. * conformal_laplacian_of_conformal_factor() -
+                      0.5 * (conformal_factor() * conformal_ricci_scalar() +
+                             pow<5>(conformal_factor()) *
+                                 (square(trace_extrinsic_curvature()) -
+                                  inv_spatial_metric(ti_I, ti_K) *
+                                      inv_spatial_metric(ti_J, ti_L) *
+                                      extrinsic_curvature(ti_i, ti_j) *
+                                      extrinsic_curvature(ti_k, ti_l) -
+                                  16. * M_PI * energy_density())));
 }
 
 void SpacetimeQuantitiesComputer::operator()(
@@ -220,7 +219,7 @@ void SpacetimeQuantitiesComputer::operator()(
   const auto& longitudinal_shift_minus_dt_conformal_metric = cache->get_var(
       *this, detail::LongitudinalShiftMinusDtConformalMetric<DataVector>{});
   // Eq. 3.109 in BaumgarteShapiro
-  TensorExpressions::evaluate<ti_I>(
+  tenex::evaluate<ti_I>(
       momentum_constraint,
       0.5 * (div_longitudinal_shift_excess(ti_I) +
              div_longitudinal_shift_background_minus_dt_conformal_metric(ti_I) +

--- a/src/PointwiseFunctions/Xcts/SpacetimeQuantities.cpp
+++ b/src/PointwiseFunctions/Xcts/SpacetimeQuantities.cpp
@@ -62,14 +62,14 @@ void SpacetimeQuantitiesComputer::operator()(
   const auto& deriv_conformal_factor =
       cache->get_var(*this, ::Tags::deriv<Tags::ConformalFactor<DataVector>,
                                           tmpl::size_t<3>, Frame::Inertial>{});
-  const auto conformal_factor_flux = tenex::evaluate<ti_I>(
-      inv_conformal_metric(ti_I, ti_J) * deriv_conformal_factor(ti_j));
+  const auto conformal_factor_flux = tenex::evaluate<ti::I>(
+      inv_conformal_metric(ti::I, ti::J) * deriv_conformal_factor(ti::j));
   const auto deriv_conformal_factor_flux =
       partial_derivative(conformal_factor_flux, mesh, inv_jacobian);
-  tenex::evaluate(
-      conformal_laplacian_of_conformal_factor,
-      deriv_conformal_factor_flux(ti_i, ti_I) +
-          conformal_christoffel_contracted(ti_i) * conformal_factor_flux(ti_I));
+  tenex::evaluate(conformal_laplacian_of_conformal_factor,
+                  deriv_conformal_factor_flux(ti::i, ti::I) +
+                      conformal_christoffel_contracted(ti::i) *
+                          conformal_factor_flux(ti::I));
 }
 
 void SpacetimeQuantitiesComputer::operator()(
@@ -159,10 +159,11 @@ void SpacetimeQuantitiesComputer::operator()(
     const {
   const auto& longitudinal_shift_excess = cache->get_var(
       *this, Tags::LongitudinalShiftExcess<DataVector, 3, Frame::Inertial>{});
-  tenex::evaluate<ti_I, ti_J>(
+  tenex::evaluate<ti::I, ti::J>(
       longitudinal_shift_minus_dt_conformal_metric,
-      longitudinal_shift_excess(ti_I, ti_J) +
-          longitudinal_shift_background_minus_dt_conformal_metric(ti_I, ti_J));
+      longitudinal_shift_excess(ti::I, ti::J) +
+          longitudinal_shift_background_minus_dt_conformal_metric(ti::I,
+                                                                  ti::J));
 }
 
 void SpacetimeQuantitiesComputer::operator()(
@@ -194,10 +195,10 @@ void SpacetimeQuantitiesComputer::operator()(
                       0.5 * (conformal_factor() * conformal_ricci_scalar() +
                              pow<5>(conformal_factor()) *
                                  (square(trace_extrinsic_curvature()) -
-                                  inv_spatial_metric(ti_I, ti_K) *
-                                      inv_spatial_metric(ti_J, ti_L) *
-                                      extrinsic_curvature(ti_i, ti_j) *
-                                      extrinsic_curvature(ti_k, ti_l) -
+                                  inv_spatial_metric(ti::I, ti::K) *
+                                      inv_spatial_metric(ti::J, ti::L) *
+                                      extrinsic_curvature(ti::i, ti::j) *
+                                      extrinsic_curvature(ti::k, ti::l) -
                                   16. * M_PI * energy_density())));
 }
 
@@ -219,23 +220,24 @@ void SpacetimeQuantitiesComputer::operator()(
   const auto& longitudinal_shift_minus_dt_conformal_metric = cache->get_var(
       *this, detail::LongitudinalShiftMinusDtConformalMetric<DataVector>{});
   // Eq. 3.109 in BaumgarteShapiro
-  tenex::evaluate<ti_I>(
+  tenex::evaluate<ti::I>(
       momentum_constraint,
-      0.5 * (div_longitudinal_shift_excess(ti_I) +
-             div_longitudinal_shift_background_minus_dt_conformal_metric(ti_I) +
-             conformal_christoffel_second_kind(ti_I, ti_j, ti_k) *
-                 longitudinal_shift_minus_dt_conformal_metric(ti_J, ti_K) +
-             conformal_christoffel_contracted(ti_j) *
-                 longitudinal_shift_minus_dt_conformal_metric(ti_I, ti_J) -
-             longitudinal_shift_minus_dt_conformal_metric(ti_I, ti_J) *
-                 (deriv_lapse_times_conformal_factor(ti_j) /
+      0.5 * (div_longitudinal_shift_excess(ti::I) +
+             div_longitudinal_shift_background_minus_dt_conformal_metric(
+                 ti::I) +
+             conformal_christoffel_second_kind(ti::I, ti::j, ti::k) *
+                 longitudinal_shift_minus_dt_conformal_metric(ti::J, ti::K) +
+             conformal_christoffel_contracted(ti::j) *
+                 longitudinal_shift_minus_dt_conformal_metric(ti::I, ti::J) -
+             longitudinal_shift_minus_dt_conformal_metric(ti::I, ti::J) *
+                 (deriv_lapse_times_conformal_factor(ti::j) /
                       lapse_times_conformal_factor() -
-                  7. * deriv_conformal_factor(ti_j) / conformal_factor()) -
+                  7. * deriv_conformal_factor(ti::j) / conformal_factor()) -
              4. / 3. * lapse_times_conformal_factor() / conformal_factor() *
-                 inv_conformal_metric(ti_I, ti_J) *
-                 deriv_trace_extrinsic_curvature(ti_j)) -
+                 inv_conformal_metric(ti::I, ti::J) *
+                 deriv_trace_extrinsic_curvature(ti::j)) -
           8. * M_PI * lapse_times_conformal_factor() *
-              cube(conformal_factor()) * momentum_density(ti_I));
+              cube(conformal_factor()) * momentum_density(ti::I));
 }
 
 }  // namespace Xcts

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_AddSubSymmetry.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_AddSubSymmetry.cpp
@@ -17,9 +17,9 @@ void test_impl_consistency() {
   const std::string error_msg =
       "Symmetry and AddSubSymmetry are no longer using the same canonical "
       "form. You must update the implementation for "
-      "TensorExpressions::detail::get_addsub_symm to use the same canonical "
-      "form as Symmetry and update the expected result symmetries for the unit "
-      "test cases in this file.";
+      "tenex::detail::get_addsub_symm to use the same canonical form as "
+      "Symmetry and update the expected result symmetries for the unit test "
+      "cases in this file.";
 
   if (not std::is_same_v<Symmetry<>, tmpl::integral_list<std::int32_t>>) {
     ERROR(error_msg);
@@ -50,7 +50,7 @@ void test_rank0() {
   using tensorindex_list = make_tensorindex_list<>;
 
   CHECK(
-      std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+      std::is_same_v<typename tenex::detail::AddSubSymmetry<
                          symm, symm, tensorindex_list, tensorindex_list>::type,
                      tmpl::integral_list<std::int32_t>>);
 }
@@ -60,7 +60,7 @@ void test_rank1() {
   using tensorindex_list = make_tensorindex_list<ti_a>;
 
   CHECK(
-      std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+      std::is_same_v<typename tenex::detail::AddSubSymmetry<
                          symm, symm, tensorindex_list, tensorindex_list>::type,
                      tmpl::integral_list<std::int32_t, 1>>);
 }
@@ -71,32 +71,32 @@ void test_rank2() {
   using tensorindex_list_ij = make_tensorindex_list<ti_i, ti_j>;
   using tensorindex_list_ji = make_tensorindex_list<ti_j, ti_i>;
 
-  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+  CHECK(std::is_same_v<typename tenex::detail::AddSubSymmetry<
                            symmetric_symm, symmetric_symm, tensorindex_list_ij,
                            tensorindex_list_ij>::type,
                        tmpl::integral_list<std::int32_t, 1, 1>>);
 
-  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+  CHECK(std::is_same_v<typename tenex::detail::AddSubSymmetry<
                            symmetric_symm, symmetric_symm, tensorindex_list_ij,
                            tensorindex_list_ji>::type,
                        tmpl::integral_list<std::int32_t, 1, 1>>);
 
-  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+  CHECK(std::is_same_v<typename tenex::detail::AddSubSymmetry<
                            asymmetric_symm, symmetric_symm, tensorindex_list_ij,
                            tensorindex_list_ij>::type,
                        tmpl::integral_list<std::int32_t, 2, 1>>);
 
-  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+  CHECK(std::is_same_v<typename tenex::detail::AddSubSymmetry<
                            asymmetric_symm, symmetric_symm, tensorindex_list_ij,
                            tensorindex_list_ji>::type,
                        tmpl::integral_list<std::int32_t, 2, 1>>);
 
-  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+  CHECK(std::is_same_v<typename tenex::detail::AddSubSymmetry<
                            symmetric_symm, asymmetric_symm, tensorindex_list_ij,
                            tensorindex_list_ij>::type,
                        tmpl::integral_list<std::int32_t, 2, 1>>);
 
-  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+  CHECK(std::is_same_v<typename tenex::detail::AddSubSymmetry<
                            symmetric_symm, asymmetric_symm, tensorindex_list_ij,
                            tensorindex_list_ji>::type,
                        tmpl::integral_list<std::int32_t, 2, 1>>);
@@ -116,72 +116,72 @@ void test_rank3() {
   using tensorindex_list_cab = make_tensorindex_list<ti_c, ti_a, ti_b>;
   using tensorindex_list_cba = make_tensorindex_list<ti_c, ti_b, ti_a>;
 
-  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+  CHECK(std::is_same_v<typename tenex::detail::AddSubSymmetry<
                            symm_111, symm_121, tensorindex_list_abc,
                            tensorindex_list_bca>::type,
                        tmpl::integral_list<std::int32_t, 2, 2, 1>>);
 
-  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+  CHECK(std::is_same_v<typename tenex::detail::AddSubSymmetry<
                            symm_121, symm_111, tensorindex_list_abc,
                            tensorindex_list_bca>::type,
                        tmpl::integral_list<std::int32_t, 1, 2, 1>>);
 
-  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+  CHECK(std::is_same_v<typename tenex::detail::AddSubSymmetry<
                            symm_111, symm_221, tensorindex_list_abc,
                            tensorindex_list_acb>::type,
                        tmpl::integral_list<std::int32_t, 1, 2, 1>>);
 
-  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+  CHECK(std::is_same_v<typename tenex::detail::AddSubSymmetry<
                            symm_221, symm_111, tensorindex_list_abc,
                            tensorindex_list_acb>::type,
                        tmpl::integral_list<std::int32_t, 2, 2, 1>>);
 
-  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+  CHECK(std::is_same_v<typename tenex::detail::AddSubSymmetry<
                            symm_121, symm_221, tensorindex_list_abc,
                            tensorindex_list_cab>::type,
                        tmpl::integral_list<std::int32_t, 1, 2, 1>>);
 
-  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+  CHECK(std::is_same_v<typename tenex::detail::AddSubSymmetry<
                            symm_221, symm_121, tensorindex_list_abc,
                            tensorindex_list_cab>::type,
                        tmpl::integral_list<std::int32_t, 3, 2, 1>>);
 
-  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+  CHECK(std::is_same_v<typename tenex::detail::AddSubSymmetry<
                            symm_221, symm_121, tensorindex_list_cab,
                            tensorindex_list_abc>::type,
                        tmpl::integral_list<std::int32_t, 2, 2, 1>>);
 
-  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+  CHECK(std::is_same_v<typename tenex::detail::AddSubSymmetry<
                            symm_121, symm_221, tensorindex_list_cab,
                            tensorindex_list_abc>::type,
                        tmpl::integral_list<std::int32_t, 3, 2, 1>>);
 
-  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+  CHECK(std::is_same_v<typename tenex::detail::AddSubSymmetry<
                            symm_121, symm_221, tensorindex_list_abc,
                            tensorindex_list_acb>::type,
                        tmpl::integral_list<std::int32_t, 1, 2, 1>>);
 
-  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+  CHECK(std::is_same_v<typename tenex::detail::AddSubSymmetry<
                            symm_221, symm_121, tensorindex_list_abc,
                            tensorindex_list_acb>::type,
                        tmpl::integral_list<std::int32_t, 2, 2, 1>>);
 
-  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+  CHECK(std::is_same_v<typename tenex::detail::AddSubSymmetry<
                            symm_111, symm_321, tensorindex_list_abc,
                            tensorindex_list_bac>::type,
                        tmpl::integral_list<std::int32_t, 3, 2, 1>>);
 
-  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+  CHECK(std::is_same_v<typename tenex::detail::AddSubSymmetry<
                            symm_321, symm_111, tensorindex_list_abc,
                            tensorindex_list_bac>::type,
                        tmpl::integral_list<std::int32_t, 3, 2, 1>>);
 
-  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+  CHECK(std::is_same_v<typename tenex::detail::AddSubSymmetry<
                            symm_211, symm_321, tensorindex_list_abc,
                            tensorindex_list_cba>::type,
                        tmpl::integral_list<std::int32_t, 3, 2, 1>>);
 
-  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+  CHECK(std::is_same_v<typename tenex::detail::AddSubSymmetry<
                            symm_321, symm_211, tensorindex_list_abc,
                            tensorindex_list_cba>::type,
                        tmpl::integral_list<std::int32_t, 3, 2, 1>>);
@@ -190,32 +190,32 @@ void test_rank3() {
 void test_high_rank() {
   using tensorindex_list = make_tensorindex_list<ti_a, ti_b, ti_c, ti_d, ti_e>;
 
-  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+  CHECK(std::is_same_v<typename tenex::detail::AddSubSymmetry<
                            Symmetry<2, 1, 1, 1, 1>, Symmetry<3, 2, 2, 1, 1>,
                            tensorindex_list, tensorindex_list>::type,
                        tmpl::integral_list<std::int32_t, 3, 2, 2, 1, 1>>);
 
-  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+  CHECK(std::is_same_v<typename tenex::detail::AddSubSymmetry<
                            Symmetry<3, 2, 2, 1, 1>, Symmetry<2, 1, 1, 1, 1>,
                            tensorindex_list, tensorindex_list>::type,
                        tmpl::integral_list<std::int32_t, 3, 2, 2, 1, 1>>);
 
-  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+  CHECK(std::is_same_v<typename tenex::detail::AddSubSymmetry<
                            Symmetry<1, 1, 2, 1, 1>, Symmetry<4, 3, 1, 2, 1>,
                            tensorindex_list, tensorindex_list>::type,
                        tmpl::integral_list<std::int32_t, 5, 4, 3, 2, 1>>);
 
-  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+  CHECK(std::is_same_v<typename tenex::detail::AddSubSymmetry<
                            Symmetry<4, 3, 1, 2, 1>, Symmetry<1, 1, 2, 1, 1>,
                            tensorindex_list, tensorindex_list>::type,
                        tmpl::integral_list<std::int32_t, 5, 4, 3, 2, 1>>);
 
-  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+  CHECK(std::is_same_v<typename tenex::detail::AddSubSymmetry<
                            Symmetry<1, 2, 2, 2, 1>, Symmetry<1, 2, 1, 1, 1>,
                            tensorindex_list, tensorindex_list>::type,
                        tmpl::integral_list<std::int32_t, 1, 3, 2, 2, 1>>);
 
-  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+  CHECK(std::is_same_v<typename tenex::detail::AddSubSymmetry<
                            Symmetry<1, 2, 1, 1, 1>, Symmetry<1, 2, 2, 2, 1>,
                            tensorindex_list, tensorindex_list>::type,
                        tmpl::integral_list<std::int32_t, 1, 3, 2, 2, 1>>);

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_AddSubSymmetry.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_AddSubSymmetry.cpp
@@ -57,7 +57,7 @@ void test_rank0() {
 
 void test_rank1() {
   using symm = Symmetry<1>;
-  using tensorindex_list = make_tensorindex_list<ti_a>;
+  using tensorindex_list = make_tensorindex_list<ti::a>;
 
   CHECK(
       std::is_same_v<typename tenex::detail::AddSubSymmetry<
@@ -68,8 +68,8 @@ void test_rank1() {
 void test_rank2() {
   using symmetric_symm = Symmetry<1, 1>;
   using asymmetric_symm = Symmetry<2, 1>;
-  using tensorindex_list_ij = make_tensorindex_list<ti_i, ti_j>;
-  using tensorindex_list_ji = make_tensorindex_list<ti_j, ti_i>;
+  using tensorindex_list_ij = make_tensorindex_list<ti::i, ti::j>;
+  using tensorindex_list_ji = make_tensorindex_list<ti::j, ti::i>;
 
   CHECK(std::is_same_v<typename tenex::detail::AddSubSymmetry<
                            symmetric_symm, symmetric_symm, tensorindex_list_ij,
@@ -109,12 +109,12 @@ void test_rank3() {
   using symm_221 = Symmetry<2, 2, 1>;
   using symm_321 = Symmetry<3, 2, 1>;
 
-  using tensorindex_list_abc = make_tensorindex_list<ti_a, ti_b, ti_c>;
-  using tensorindex_list_acb = make_tensorindex_list<ti_a, ti_c, ti_b>;
-  using tensorindex_list_bac = make_tensorindex_list<ti_b, ti_a, ti_c>;
-  using tensorindex_list_bca = make_tensorindex_list<ti_b, ti_c, ti_a>;
-  using tensorindex_list_cab = make_tensorindex_list<ti_c, ti_a, ti_b>;
-  using tensorindex_list_cba = make_tensorindex_list<ti_c, ti_b, ti_a>;
+  using tensorindex_list_abc = make_tensorindex_list<ti::a, ti::b, ti::c>;
+  using tensorindex_list_acb = make_tensorindex_list<ti::a, ti::c, ti::b>;
+  using tensorindex_list_bac = make_tensorindex_list<ti::b, ti::a, ti::c>;
+  using tensorindex_list_bca = make_tensorindex_list<ti::b, ti::c, ti::a>;
+  using tensorindex_list_cab = make_tensorindex_list<ti::c, ti::a, ti::b>;
+  using tensorindex_list_cba = make_tensorindex_list<ti::c, ti::b, ti::a>;
 
   CHECK(std::is_same_v<typename tenex::detail::AddSubSymmetry<
                            symm_111, symm_121, tensorindex_list_abc,
@@ -188,7 +188,8 @@ void test_rank3() {
 }
 
 void test_high_rank() {
-  using tensorindex_list = make_tensorindex_list<ti_a, ti_b, ti_c, ti_d, ti_e>;
+  using tensorindex_list =
+      make_tensorindex_list<ti::a, ti::b, ti::c, ti::d, ti::e>;
 
   CHECK(std::is_same_v<typename tenex::detail::AddSubSymmetry<
                            Symmetry<2, 1, 1, 1, 1>, Symmetry<3, 2, 2, 1, 1>,

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_AddSubtract.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_AddSubtract.cpp
@@ -75,21 +75,18 @@ void test_addsub_double(const DataType& used_for_size) {
   }
 
   // \f$L = R + S\f$
-  const Tensor<DataType> R_plus_S = TensorExpressions::evaluate(5.6 + S());
+  const Tensor<DataType> R_plus_S = tenex::evaluate(5.6 + S());
   // \f$L = R - S\f$
-  const Tensor<DataType> R_minus_S = TensorExpressions::evaluate(1.1 - S());
+  const Tensor<DataType> R_minus_S = tenex::evaluate(1.1 - S());
   // \f$L = G^{i}{}_{i} + R\f$
-  const Tensor<DataType> G_plus_R =
-      TensorExpressions::evaluate(G(ti_I, ti_i) + 8.2);
+  const Tensor<DataType> G_plus_R = tenex::evaluate(G(ti_I, ti_i) + 8.2);
   // \f$L = G^{i}{}_{i} - R\f$
-  const Tensor<DataType> G_minus_R =
-      TensorExpressions::evaluate(G(ti_I, ti_i) - 3.5);
+  const Tensor<DataType> G_minus_R = tenex::evaluate(G(ti_I, ti_i) - 3.5);
   // \f$L = R + S + T\f$
-  const Tensor<DataType> R_plus_S_plus_T =
-      TensorExpressions::evaluate(0.7 + S() + 9.8);
+  const Tensor<DataType> R_plus_S_plus_T = tenex::evaluate(0.7 + S() + 9.8);
   // \f$L = R - G^{i}{}_{i} + T\f$
   const Tensor<DataType> R_minus_G_plus_T =
-      TensorExpressions::evaluate(5.9 - G(ti_I, ti_i) + 4.7);
+      tenex::evaluate(5.9 - G(ti_I, ti_i) + 4.7);
 
   CHECK(R_plus_S.get() == 5.6 + S.get());
   CHECK(R_minus_S.get() == 1.1 - S.get());
@@ -109,8 +106,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
   // Test adding scalars
   const Tensor<double> scalar_1{{{2.1}}};
   const Tensor<double> scalar_2{{{-0.8}}};
-  Tensor<double> lhs_scalar =
-      TensorExpressions::evaluate(scalar_1() + scalar_2());
+  Tensor<double> lhs_scalar = tenex::evaluate(scalar_1() + scalar_2());
   CHECK(lhs_scalar.get() == 1.3);
 
   Tensor<double, Symmetry<1, 1>,
@@ -127,19 +123,16 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
   const Tensor<double, Symmetry<2, 1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Gll = TensorExpressions::evaluate<ti_a, ti_b>(All(ti_a, ti_b) +
-                                                    Hll(ti_a, ti_b));
+      Gll = tenex::evaluate<ti_a, ti_b>(All(ti_a, ti_b) + Hll(ti_a, ti_b));
   const Tensor<double, Symmetry<2, 1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Gll2 = TensorExpressions::evaluate<ti_a, ti_b>(All(ti_a, ti_b) +
-                                                     Hll(ti_b, ti_a));
+      Gll2 = tenex::evaluate<ti_a, ti_b>(All(ti_a, ti_b) + Hll(ti_b, ti_a));
   const Tensor<double, Symmetry<2, 1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Gll3 = TensorExpressions::evaluate<ti_a, ti_b>(
-          All(ti_a, ti_b) + Hll(ti_b, ti_a) + All(ti_b, ti_a) -
-          Hll(ti_b, ti_a));
+      Gll3 = tenex::evaluate<ti_a, ti_b>(All(ti_a, ti_b) + Hll(ti_b, ti_a) +
+                                         All(ti_b, ti_a) - Hll(ti_b, ti_a));
   // [use_tensor_index]
   for (int i = 0; i < 4; ++i) {
     for (int j = 0; j < 4; ++j) {
@@ -178,19 +171,19 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Glll = TensorExpressions::evaluate<ti_a, ti_b, ti_c>(
-          Alll(ti_a, ti_b, ti_c) + Hlll(ti_a, ti_b, ti_c));
+      Glll = tenex::evaluate<ti_a, ti_b, ti_c>(Alll(ti_a, ti_b, ti_c) +
+                                               Hlll(ti_a, ti_b, ti_c));
   const Tensor<double, Symmetry<3, 2, 1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Glll2 = TensorExpressions::evaluate<ti_a, ti_b, ti_c>(
-          Alll(ti_a, ti_b, ti_c) + Hlll(ti_b, ti_a, ti_c));
+      Glll2 = tenex::evaluate<ti_a, ti_b, ti_c>(Alll(ti_a, ti_b, ti_c) +
+                                                Hlll(ti_b, ti_a, ti_c));
   const Tensor<double, Symmetry<3, 2, 1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Glll3 = TensorExpressions::evaluate<ti_a, ti_b, ti_c>(
+      Glll3 = tenex::evaluate<ti_a, ti_b, ti_c>(
           Alll(ti_a, ti_b, ti_c) + Hlll(ti_b, ti_a, ti_c) +
           Alll(ti_b, ti_a, ti_c) - Hlll(ti_b, ti_a, ti_c));
   // testing LHS symmetry is nonsymmetric when RHS operands do not have
@@ -199,16 +192,16 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Glll4 = TensorExpressions::evaluate<ti_a, ti_b, ti_c>(
-          Alll(ti_b, ti_c, ti_a) + Rlll(ti_c, ti_a, ti_b));
+      Glll4 = tenex::evaluate<ti_a, ti_b, ti_c>(Alll(ti_b, ti_c, ti_a) +
+                                                Rlll(ti_c, ti_a, ti_b));
   // testing LHS symmetry preserves shared RHS symmetry when RHS operands have
   // symmetries in common
   const Tensor<double, Symmetry<2, 1, 1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Glll5 = TensorExpressions::evaluate<ti_a, ti_b, ti_c>(
-          Alll(ti_b, ti_c, ti_a) - Rlll(ti_a, ti_c, ti_b));
+      Glll5 = tenex::evaluate<ti_a, ti_b, ti_c>(Alll(ti_b, ti_c, ti_a) -
+                                                Rlll(ti_a, ti_c, ti_b));
 
   for (int i = 0; i < 4; ++i) {
     for (int j = 0; j < 4; ++j) {
@@ -227,14 +220,14 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpatialIndex<3, UpLo::Lo, Frame::Grid>,
                           SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
-      Glll6 = TensorExpressions::evaluate<ti_a, ti_j, ti_k>(
-          Rlll(ti_a, ti_j, ti_k) + Slll(ti_a, ti_j, ti_k));
+      Glll6 = tenex::evaluate<ti_a, ti_j, ti_k>(Rlll(ti_a, ti_j, ti_k) +
+                                                Slll(ti_a, ti_j, ti_k));
   Tensor<double, Symmetry<3, 2, 1>,
          index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
                     SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                     SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
       Glll7{};
-  TensorExpressions::evaluate<ti_j, ti_a, ti_k>(
+  tenex::evaluate<ti_j, ti_a, ti_k>(
       make_not_null(&Glll7), Slll(ti_j, ti_k, ti_a) - Rlll(ti_k, ti_a, ti_j));
 
   for (int a = 0; a < 4; ++a) {
@@ -252,8 +245,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
   const Tensor<double, Symmetry<2, 1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Gll7 = TensorExpressions::evaluate<ti_c, ti_b>(Alll(ti_c, ti_t, ti_b) +
-                                                     Hlll(ti_b, ti_c, ti_t));
+      Gll7 = tenex::evaluate<ti_c, ti_b>(Alll(ti_c, ti_t, ti_b) +
+                                         Hlll(ti_b, ti_c, ti_t));
 
   for (int c = 0; c < 4; ++c) {
     for (int b = 0; b < 4; ++b) {
@@ -264,8 +257,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
   const Tensor<double, Symmetry<1, 1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Gll8 = TensorExpressions::evaluate<ti_d, ti_c>(Alll(ti_c, ti_d, ti_t) -
-                                                     All(ti_d, ti_c));
+      Gll8 =
+          tenex::evaluate<ti_d, ti_c>(Alll(ti_c, ti_d, ti_t) - All(ti_d, ti_c));
 
   for (int d = 0; d < 4; ++d) {
     for (int c = 0; c < 4; ++c) {
@@ -276,8 +269,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
   const Tensor<double, Symmetry<1, 1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Gll9 = TensorExpressions::evaluate<ti_a, ti_b>(All(ti_b, ti_a) +
-                                                     Alll(ti_b, ti_a, ti_t));
+      Gll9 =
+          tenex::evaluate<ti_a, ti_b>(All(ti_b, ti_a) + Alll(ti_b, ti_a, ti_t));
 
   for (int a = 0; a < 4; ++a) {
     for (int b = 0; b < 4; ++b) {
@@ -298,8 +291,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
                         SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                         SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>>(
       0.0, spatial_component_placeholder);
-  TensorExpressions::evaluate<ti_t, ti_d, ti_b, ti_T>(
-      make_not_null(&Gll10), All(ti_b, ti_d) - Hll(ti_b, ti_d));
+  tenex::evaluate<ti_t, ti_d, ti_b, ti_T>(make_not_null(&Gll10),
+                                          All(ti_b, ti_d) - Hll(ti_b, ti_d));
 
   for (int d = 0; d < 4; ++d) {
     for (int b = 0; b < 4; ++b) {
@@ -318,8 +311,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
                         SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                         SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>>(
       0.0, spatial_component_placeholder);
-  TensorExpressions::evaluate<ti_a, ti_c, ti_t>(
-      make_not_null(&Gll11), Rlll(ti_t, ti_c, ti_a) + All(ti_a, ti_c));
+  tenex::evaluate<ti_a, ti_c, ti_t>(make_not_null(&Gll11),
+                                    Rlll(ti_t, ti_c, ti_a) + All(ti_a, ti_c));
 
   for (int a = 0; a < 4; ++a) {
     for (int c = 0; c < 4; ++c) {
@@ -336,8 +329,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
                         SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                         SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>>(
       0.0, spatial_component_placeholder);
-  TensorExpressions::evaluate<ti_g, ti_t, ti_h>(
-      make_not_null(&Gll12), Hll(ti_h, ti_g) - Alll(ti_g, ti_t, ti_h));
+  tenex::evaluate<ti_g, ti_t, ti_h>(make_not_null(&Gll12),
+                                    Hll(ti_h, ti_g) - Alll(ti_g, ti_t, ti_h));
 
   for (int g = 0; g < 4; ++g) {
     for (int h = 0; h < 4; ++h) {
@@ -353,8 +346,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
              index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                         SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>>(
       0.0, spatial_component_placeholder);
-  TensorExpressions::evaluate<ti_t, ti_f>(
-      make_not_null(&Gll13), Rlll(ti_t, ti_t, ti_f) - Hll(ti_f, ti_t));
+  tenex::evaluate<ti_t, ti_f>(make_not_null(&Gll13),
+                              Rlll(ti_t, ti_t, ti_f) - Hll(ti_f, ti_t));
 
   for (int f = 0; f < 4; ++f) {
     CHECK(Gll13.get(0, f) == Rlll.get(0, 0, f) - Hll.get(f, 0));
@@ -370,7 +363,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
              index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                         SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>>(
       0.0, spatial_component_placeholder);
-  TensorExpressions::evaluate<ti_T, ti_t>(
+  tenex::evaluate<ti_T, ti_t>(
       make_not_null(&Gll14),
       Hll(ti_t, ti_t) - T() - Rlll(ti_t, ti_t, ti_t) + 9.1);
 

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_AddSubtract.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_AddSubtract.cpp
@@ -79,14 +79,14 @@ void test_addsub_double(const DataType& used_for_size) {
   // \f$L = R - S\f$
   const Tensor<DataType> R_minus_S = tenex::evaluate(1.1 - S());
   // \f$L = G^{i}{}_{i} + R\f$
-  const Tensor<DataType> G_plus_R = tenex::evaluate(G(ti_I, ti_i) + 8.2);
+  const Tensor<DataType> G_plus_R = tenex::evaluate(G(ti::I, ti::i) + 8.2);
   // \f$L = G^{i}{}_{i} - R\f$
-  const Tensor<DataType> G_minus_R = tenex::evaluate(G(ti_I, ti_i) - 3.5);
+  const Tensor<DataType> G_minus_R = tenex::evaluate(G(ti::I, ti::i) - 3.5);
   // \f$L = R + S + T\f$
   const Tensor<DataType> R_plus_S_plus_T = tenex::evaluate(0.7 + S() + 9.8);
   // \f$L = R - G^{i}{}_{i} + T\f$
   const Tensor<DataType> R_minus_G_plus_T =
-      tenex::evaluate(5.9 - G(ti_I, ti_i) + 4.7);
+      tenex::evaluate(5.9 - G(ti::I, ti::i) + 4.7);
 
   CHECK(R_plus_S.get() == 5.6 + S.get());
   CHECK(R_minus_S.get() == 1.1 - S.get());
@@ -123,16 +123,19 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
   const Tensor<double, Symmetry<2, 1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Gll = tenex::evaluate<ti_a, ti_b>(All(ti_a, ti_b) + Hll(ti_a, ti_b));
+      Gll =
+          tenex::evaluate<ti::a, ti::b>(All(ti::a, ti::b) + Hll(ti::a, ti::b));
   const Tensor<double, Symmetry<2, 1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Gll2 = tenex::evaluate<ti_a, ti_b>(All(ti_a, ti_b) + Hll(ti_b, ti_a));
+      Gll2 =
+          tenex::evaluate<ti::a, ti::b>(All(ti::a, ti::b) + Hll(ti::b, ti::a));
   const Tensor<double, Symmetry<2, 1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Gll3 = tenex::evaluate<ti_a, ti_b>(All(ti_a, ti_b) + Hll(ti_b, ti_a) +
-                                         All(ti_b, ti_a) - Hll(ti_b, ti_a));
+      Gll3 =
+          tenex::evaluate<ti::a, ti::b>(All(ti::a, ti::b) + Hll(ti::b, ti::a) +
+                                        All(ti::b, ti::a) - Hll(ti::b, ti::a));
   // [use_tensor_index]
   for (int i = 0; i < 4; ++i) {
     for (int j = 0; j < 4; ++j) {
@@ -171,37 +174,37 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Glll = tenex::evaluate<ti_a, ti_b, ti_c>(Alll(ti_a, ti_b, ti_c) +
-                                               Hlll(ti_a, ti_b, ti_c));
+      Glll = tenex::evaluate<ti::a, ti::b, ti::c>(Alll(ti::a, ti::b, ti::c) +
+                                                  Hlll(ti::a, ti::b, ti::c));
   const Tensor<double, Symmetry<3, 2, 1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Glll2 = tenex::evaluate<ti_a, ti_b, ti_c>(Alll(ti_a, ti_b, ti_c) +
-                                                Hlll(ti_b, ti_a, ti_c));
+      Glll2 = tenex::evaluate<ti::a, ti::b, ti::c>(Alll(ti::a, ti::b, ti::c) +
+                                                   Hlll(ti::b, ti::a, ti::c));
   const Tensor<double, Symmetry<3, 2, 1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Glll3 = tenex::evaluate<ti_a, ti_b, ti_c>(
-          Alll(ti_a, ti_b, ti_c) + Hlll(ti_b, ti_a, ti_c) +
-          Alll(ti_b, ti_a, ti_c) - Hlll(ti_b, ti_a, ti_c));
+      Glll3 = tenex::evaluate<ti::a, ti::b, ti::c>(
+          Alll(ti::a, ti::b, ti::c) + Hlll(ti::b, ti::a, ti::c) +
+          Alll(ti::b, ti::a, ti::c) - Hlll(ti::b, ti::a, ti::c));
   // testing LHS symmetry is nonsymmetric when RHS operands do not have
   // symmetries in common
   const Tensor<double, Symmetry<3, 2, 1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Glll4 = tenex::evaluate<ti_a, ti_b, ti_c>(Alll(ti_b, ti_c, ti_a) +
-                                                Rlll(ti_c, ti_a, ti_b));
+      Glll4 = tenex::evaluate<ti::a, ti::b, ti::c>(Alll(ti::b, ti::c, ti::a) +
+                                                   Rlll(ti::c, ti::a, ti::b));
   // testing LHS symmetry preserves shared RHS symmetry when RHS operands have
   // symmetries in common
   const Tensor<double, Symmetry<2, 1, 1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Glll5 = tenex::evaluate<ti_a, ti_b, ti_c>(Alll(ti_b, ti_c, ti_a) -
-                                                Rlll(ti_a, ti_c, ti_b));
+      Glll5 = tenex::evaluate<ti::a, ti::b, ti::c>(Alll(ti::b, ti::c, ti::a) -
+                                                   Rlll(ti::a, ti::c, ti::b));
 
   for (int i = 0; i < 4; ++i) {
     for (int j = 0; j < 4; ++j) {
@@ -220,15 +223,16 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpatialIndex<3, UpLo::Lo, Frame::Grid>,
                           SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
-      Glll6 = tenex::evaluate<ti_a, ti_j, ti_k>(Rlll(ti_a, ti_j, ti_k) +
-                                                Slll(ti_a, ti_j, ti_k));
+      Glll6 = tenex::evaluate<ti::a, ti::j, ti::k>(Rlll(ti::a, ti::j, ti::k) +
+                                                   Slll(ti::a, ti::j, ti::k));
   Tensor<double, Symmetry<3, 2, 1>,
          index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
                     SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                     SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
       Glll7{};
-  tenex::evaluate<ti_j, ti_a, ti_k>(
-      make_not_null(&Glll7), Slll(ti_j, ti_k, ti_a) - Rlll(ti_k, ti_a, ti_j));
+  tenex::evaluate<ti::j, ti::a, ti::k>(
+      make_not_null(&Glll7),
+      Slll(ti::j, ti::k, ti::a) - Rlll(ti::k, ti::a, ti::j));
 
   for (int a = 0; a < 4; ++a) {
     for (int j = 0; j < 3; ++j) {
@@ -245,8 +249,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
   const Tensor<double, Symmetry<2, 1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Gll7 = tenex::evaluate<ti_c, ti_b>(Alll(ti_c, ti_t, ti_b) +
-                                         Hlll(ti_b, ti_c, ti_t));
+      Gll7 = tenex::evaluate<ti::c, ti::b>(Alll(ti::c, ti::t, ti::b) +
+                                           Hlll(ti::b, ti::c, ti::t));
 
   for (int c = 0; c < 4; ++c) {
     for (int b = 0; b < 4; ++b) {
@@ -257,8 +261,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
   const Tensor<double, Symmetry<1, 1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Gll8 =
-          tenex::evaluate<ti_d, ti_c>(Alll(ti_c, ti_d, ti_t) - All(ti_d, ti_c));
+      Gll8 = tenex::evaluate<ti::d, ti::c>(Alll(ti::c, ti::d, ti::t) -
+                                           All(ti::d, ti::c));
 
   for (int d = 0; d < 4; ++d) {
     for (int c = 0; c < 4; ++c) {
@@ -269,8 +273,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
   const Tensor<double, Symmetry<1, 1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Gll9 =
-          tenex::evaluate<ti_a, ti_b>(All(ti_b, ti_a) + Alll(ti_b, ti_a, ti_t));
+      Gll9 = tenex::evaluate<ti::a, ti::b>(All(ti::b, ti::a) +
+                                           Alll(ti::b, ti::a, ti::t));
 
   for (int a = 0; a < 4; ++a) {
     for (int b = 0; b < 4; ++b) {
@@ -291,8 +295,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
                         SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                         SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>>(
       0.0, spatial_component_placeholder);
-  tenex::evaluate<ti_t, ti_d, ti_b, ti_T>(make_not_null(&Gll10),
-                                          All(ti_b, ti_d) - Hll(ti_b, ti_d));
+  tenex::evaluate<ti::t, ti::d, ti::b, ti::T>(
+      make_not_null(&Gll10), All(ti::b, ti::d) - Hll(ti::b, ti::d));
 
   for (int d = 0; d < 4; ++d) {
     for (int b = 0; b < 4; ++b) {
@@ -311,8 +315,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
                         SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                         SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>>(
       0.0, spatial_component_placeholder);
-  tenex::evaluate<ti_a, ti_c, ti_t>(make_not_null(&Gll11),
-                                    Rlll(ti_t, ti_c, ti_a) + All(ti_a, ti_c));
+  tenex::evaluate<ti::a, ti::c, ti::t>(
+      make_not_null(&Gll11), Rlll(ti::t, ti::c, ti::a) + All(ti::a, ti::c));
 
   for (int a = 0; a < 4; ++a) {
     for (int c = 0; c < 4; ++c) {
@@ -329,8 +333,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
                         SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                         SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>>(
       0.0, spatial_component_placeholder);
-  tenex::evaluate<ti_g, ti_t, ti_h>(make_not_null(&Gll12),
-                                    Hll(ti_h, ti_g) - Alll(ti_g, ti_t, ti_h));
+  tenex::evaluate<ti::g, ti::t, ti::h>(
+      make_not_null(&Gll12), Hll(ti::h, ti::g) - Alll(ti::g, ti::t, ti::h));
 
   for (int g = 0; g < 4; ++g) {
     for (int h = 0; h < 4; ++h) {
@@ -346,8 +350,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
              index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                         SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>>(
       0.0, spatial_component_placeholder);
-  tenex::evaluate<ti_t, ti_f>(make_not_null(&Gll13),
-                              Rlll(ti_t, ti_t, ti_f) - Hll(ti_f, ti_t));
+  tenex::evaluate<ti::t, ti::f>(make_not_null(&Gll13),
+                                Rlll(ti::t, ti::t, ti::f) - Hll(ti::f, ti::t));
 
   for (int f = 0; f < 4; ++f) {
     CHECK(Gll13.get(0, f) == Rlll.get(0, 0, f) - Hll.get(f, 0));
@@ -363,9 +367,9 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
              index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                         SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>>(
       0.0, spatial_component_placeholder);
-  tenex::evaluate<ti_T, ti_t>(
+  tenex::evaluate<ti::T, ti::t>(
       make_not_null(&Gll14),
-      Hll(ti_t, ti_t) - T() - Rlll(ti_t, ti_t, ti_t) + 9.1);
+      Hll(ti::t, ti::t) - T() - Rlll(ti::t, ti::t, ti::t) + 9.1);
 
   CHECK(Gll14.get(0, 0) == Hll.get(0, 0) - get(T) - Rlll.get(0, 0, 0) + 9.1);
   for (size_t i = 0; i < 3; ++i) {

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Contract.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Contract.cpp
@@ -53,7 +53,7 @@ void test_contractions_rank2(const DataType& used_for_size) {
   CHECK(RIi_expr.get_uncontracted_multi_index_with_uncontracted_values({{}}) ==
         expected_multi_index);
 
-  const Tensor<DataType> RIi_contracted = TensorExpressions::evaluate(RIi_expr);
+  const Tensor<DataType> RIi_contracted = tenex::evaluate(RIi_expr);
 
   DataType expected_RIi_sum = make_with_value<DataType>(used_for_size, 0.0);
   for (size_t i = 0; i < 3; i++) {
@@ -72,7 +72,7 @@ void test_contractions_rank2(const DataType& used_for_size) {
   CHECK(RgG_expr.get_uncontracted_multi_index_with_uncontracted_values({{}}) ==
         expected_multi_index);
 
-  const Tensor<DataType> RgG_contracted = TensorExpressions::evaluate(RgG_expr);
+  const Tensor<DataType> RgG_contracted = tenex::evaluate(RgG_expr);
 
   DataType expected_RgG_sum = make_with_value<DataType>(used_for_size, 0.0);
   for (size_t g = 0; g < 4; g++) {
@@ -96,7 +96,7 @@ void test_contractions_rank3(const DataType& used_for_size) {
   const auto RiIj_expr = Rlul(ti_i, ti_I, ti_j);
   const Tensor<DataType, Symmetry<1>,
                index_list<SpatialIndex<4, UpLo::Lo, Frame::Grid>>>
-      RiIj_contracted = TensorExpressions::evaluate<ti_j>(RiIj_expr);
+      RiIj_contracted = tenex::evaluate<ti_j>(RiIj_expr);
 
   for (size_t j = 0; j < 4; j++) {
     const std::array<size_t, 3> expected_multi_index{
@@ -122,7 +122,7 @@ void test_contractions_rank3(const DataType& used_for_size) {
   const auto RJLj_expr = Ruul(ti_J, ti_L, ti_j);
   const Tensor<DataType, Symmetry<1>,
                index_list<SpatialIndex<3, UpLo::Up, Frame::Grid>>>
-      RJLj_contracted = TensorExpressions::evaluate<ti_L>(RJLj_expr);
+      RJLj_contracted = tenex::evaluate<ti_L>(RJLj_expr);
 
   for (size_t l = 0; l < 3; l++) {
     const std::array<size_t, 3> expected_multi_index{
@@ -148,7 +148,7 @@ void test_contractions_rank3(const DataType& used_for_size) {
   const auto RBfF_expr = Rulu(ti_B, ti_f, ti_F);
   const Tensor<DataType, Symmetry<1>,
                index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>>
-      RBfF_contracted = TensorExpressions::evaluate<ti_B>(RBfF_expr);
+      RBfF_contracted = tenex::evaluate<ti_B>(RBfF_expr);
 
   for (size_t b = 0; b < 4; b++) {
     const std::array<size_t, 3> expected_multi_index{
@@ -175,7 +175,7 @@ void test_contractions_rank3(const DataType& used_for_size) {
   const auto RiaI_expr = Rllu(ti_i, ti_a, ti_I);
   const Tensor<DataType, Symmetry<1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      RiaI_contracted = TensorExpressions::evaluate<ti_a>(RiaI_expr);
+      RiaI_contracted = tenex::evaluate<ti_a>(RiaI_expr);
 
   for (size_t a = 0; a < 4; a++) {
     const std::array<size_t, 3> expected_multi_index{
@@ -209,8 +209,7 @@ void test_contractions_rank4(const DataType& used_for_size) {
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<4, UpLo::Up, Frame::Inertial>,
                           SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>
-      RiIKj_contracted =
-          TensorExpressions::evaluate<ti_K, ti_j>(RiIKj_expr);
+      RiIKj_contracted = tenex::evaluate<ti_K, ti_j>(RiIKj_expr);
 
   for (size_t k = 0; k < 4; k++) {
     for (size_t j = 0; j < 3; j++) {
@@ -241,8 +240,7 @@ void test_contractions_rank4(const DataType& used_for_size) {
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                           SpacetimeIndex<4, UpLo::Lo, Frame::Grid>>>
-      RABac_contracted =
-          TensorExpressions::evaluate<ti_B, ti_c>(RABac_expr);
+      RABac_contracted = tenex::evaluate<ti_B, ti_c>(RABac_expr);
 
   for (size_t b = 0; b < 4; b++) {
     for (size_t c = 0; c < 5; c++) {
@@ -273,8 +271,7 @@ void test_contractions_rank4(const DataType& used_for_size) {
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<4, UpLo::Up, Frame::Grid>,
                           SpatialIndex<3, UpLo::Up, Frame::Grid>>>
-      RLJIl_contracted =
-          TensorExpressions::evaluate<ti_J, ti_I>(RLJIl_expr);
+      RLJIl_contracted = tenex::evaluate<ti_J, ti_I>(RLJIl_expr);
 
   for (size_t j = 0; j < 4; j++) {
     for (size_t i = 0; i < 3; i++) {
@@ -305,8 +302,7 @@ void test_contractions_rank4(const DataType& used_for_size) {
   const Tensor<DataType, Symmetry<1, 1>,
                index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>
-      REDdA_contracted =
-          TensorExpressions::evaluate<ti_E, ti_A>(REDdA_expr);
+      REDdA_contracted = tenex::evaluate<ti_E, ti_A>(REDdA_expr);
 
   for (size_t e = 0; e < 4; e++) {
     for (size_t a = 0; a < 4; a++) {
@@ -337,8 +333,7 @@ void test_contractions_rank4(const DataType& used_for_size) {
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
                           SpatialIndex<4, UpLo::Lo, Frame::Inertial>>>
-      RkJij_contracted =
-          TensorExpressions::evaluate<ti_k, ti_i>(RkJij_expr);
+      RkJij_contracted = tenex::evaluate<ti_k, ti_i>(RkJij_expr);
 
   for (size_t k = 0; k < 3; k++) {
     for (size_t i = 0; i < 4; i++) {
@@ -369,8 +364,7 @@ void test_contractions_rank4(const DataType& used_for_size) {
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpacetimeIndex<4, UpLo::Up, Frame::Inertial>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>
-      RFcgG_contracted =
-          TensorExpressions::evaluate<ti_F, ti_c>(RFcgG_expr);
+      RFcgG_contracted = tenex::evaluate<ti_F, ti_c>(RFcgG_expr);
 
   for (size_t f = 0; f < 5; f++) {
     for (size_t c = 0; c < 4; c++) {
@@ -401,8 +395,7 @@ void test_contractions_rank4(const DataType& used_for_size) {
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<2, UpLo::Up, Frame::Grid>,
                           SpatialIndex<3, UpLo::Up, Frame::Grid>>>
-      RKkIJ_contracted_to_JI =
-          TensorExpressions::evaluate<ti_J, ti_I>(RKkIJ_expr);
+      RKkIJ_contracted_to_JI = tenex::evaluate<ti_J, ti_I>(RKkIJ_expr);
 
   for (size_t j = 0; j < 2; j++) {
     for (size_t i = 0; i < 3; i++) {
@@ -433,8 +426,7 @@ void test_contractions_rank4(const DataType& used_for_size) {
   const Tensor<DataType, Symmetry<1, 1>,
                index_list<SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
                           SpacetimeIndex<2, UpLo::Up, Frame::Grid>>>
-      RbCBE_contracted_to_EC =
-          TensorExpressions::evaluate<ti_E, ti_C>(RbCBE_expr);
+      RbCBE_contracted_to_EC = tenex::evaluate<ti_E, ti_C>(RbCBE_expr);
 
   for (size_t e = 0; e < 3; e++) {
     for (size_t c = 0; c < 3; c++) {
@@ -465,8 +457,7 @@ void test_contractions_rank4(const DataType& used_for_size) {
   const Tensor<DataType, Symmetry<1, 1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      RAdba_contracted_to_bd =
-          TensorExpressions::evaluate<ti_b, ti_d>(RAdba_expr);
+      RAdba_contracted_to_bd = tenex::evaluate<ti_b, ti_d>(RAdba_expr);
 
   for (size_t b = 0; b < 4; b++) {
     for (size_t d = 0; d < 4; d++) {
@@ -497,8 +488,7 @@ void test_contractions_rank4(const DataType& used_for_size) {
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<4, UpLo::Lo, Frame::Grid>,
                           SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
-      RljJi_contracted_to_il =
-          TensorExpressions::evaluate<ti_i, ti_l>(RljJi_expr);
+      RljJi_contracted_to_il = tenex::evaluate<ti_i, ti_l>(RljJi_expr);
 
   for (size_t i = 0; i < 4; i++) {
     for (size_t l = 0; l < 3; l++) {
@@ -529,8 +519,7 @@ void test_contractions_rank4(const DataType& used_for_size) {
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>
-      RagDG_contracted_to_Da =
-          TensorExpressions::evaluate<ti_D, ti_a>(RagDG_expr);
+      RagDG_contracted_to_Da = tenex::evaluate<ti_D, ti_a>(RagDG_expr);
 
   for (size_t d = 0; d < 4; d++) {
     for (size_t a = 0; a < 4; a++) {
@@ -561,8 +550,7 @@ void test_contractions_rank4(const DataType& used_for_size) {
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<3, UpLo::Up, Frame::Inertial>,
                           SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>
-      RlJiI_contracted_to_Jl =
-          TensorExpressions::evaluate<ti_J, ti_l>(RlJiI_expr);
+      RlJiI_contracted_to_Jl = tenex::evaluate<ti_J, ti_l>(RlJiI_expr);
 
   for (size_t j = 0; j < 3; j++) {
     for (size_t l = 0; l < 3; l++) {
@@ -606,8 +594,7 @@ void test_contractions_rank4(const DataType& used_for_size) {
   CHECK(RKkLl_expr.get_uncontracted_multi_index_with_uncontracted_values(
             {{}}) == expected_multi_index);
 
-  const Tensor<DataType> RKkLl_contracted =
-      TensorExpressions::evaluate(RKkLl_expr);
+  const Tensor<DataType> RKkLl_contracted = tenex::evaluate(RKkLl_expr);
 
   DataType expected_RKkLl_sum = make_with_value<DataType>(used_for_size, 0.0);
   for (size_t k = 0; k < 3; k++) {
@@ -623,8 +610,7 @@ void test_contractions_rank4(const DataType& used_for_size) {
   CHECK(RcaCA_expr.get_uncontracted_multi_index_with_uncontracted_values(
             {{}}) == expected_multi_index);
 
-  const Tensor<DataType> RcaCA_contracted =
-      TensorExpressions::evaluate(RcaCA_expr);
+  const Tensor<DataType> RcaCA_contracted = tenex::evaluate(RcaCA_expr);
 
   DataType expected_RcaCA_sum = make_with_value<DataType>(used_for_size, 0.0);
   for (size_t c = 0; c < 4; c++) {
@@ -640,8 +626,7 @@ void test_contractions_rank4(const DataType& used_for_size) {
   CHECK(RjIiJ_expr.get_uncontracted_multi_index_with_uncontracted_values(
             {{}}) == expected_multi_index);
 
-  const Tensor<DataType> RjIiJ_contracted =
-      TensorExpressions::evaluate(RjIiJ_expr);
+  const Tensor<DataType> RjIiJ_contracted = tenex::evaluate(RjIiJ_expr);
 
   DataType expected_RjIiJ_sum = make_with_value<DataType>(used_for_size, 0.0);
   for (size_t j = 0; j < 3; j++) {
@@ -663,8 +648,7 @@ void test_spatial_spacetime_index(const DataType& used_for_size) {
 
       R(used_for_size);
   create_tensor(make_not_null(&R));
-  const Tensor<DataType> R_contracted =
-      TensorExpressions::evaluate(R(ti_I, ti_i));
+  const Tensor<DataType> R_contracted = tenex::evaluate(R(ti_I, ti_i));
 
   // Contract (spacetime, spatial) tensor
   Tensor<DataType, Symmetry<2, 1>,
@@ -672,8 +656,7 @@ void test_spatial_spacetime_index(const DataType& used_for_size) {
                     SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>
       S(used_for_size);
   create_tensor(make_not_null(&S));
-  const Tensor<DataType> S_contracted =
-      TensorExpressions::evaluate(S(ti_K, ti_k));
+  const Tensor<DataType> S_contracted = tenex::evaluate(S(ti_K, ti_k));
 
   // Contract (spacetime, spacetime) tensor using generic spatial indices
   Tensor<DataType, Symmetry<2, 1>,
@@ -681,8 +664,7 @@ void test_spatial_spacetime_index(const DataType& used_for_size) {
                     SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>
       T(used_for_size);
   create_tensor(make_not_null(&T));
-  const Tensor<DataType> T_contracted =
-      TensorExpressions::evaluate(T(ti_j, ti_J));
+  const Tensor<DataType> T_contracted = tenex::evaluate(T(ti_j, ti_J));
 
   DataType expected_R_sum = make_with_value<DataType>(used_for_size, 0.0);
   DataType expected_S_sum = make_with_value<DataType>(used_for_size, 0.0);
@@ -711,8 +693,7 @@ void test_spatial_spacetime_index(const DataType& used_for_size) {
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
                           SpatialIndex<3, UpLo::Up, Frame::Grid>>>
-      G_contracted_1 =
-          TensorExpressions::evaluate<ti_i, ti_K>(G(ti_K, ti_j, ti_i, ti_J));
+      G_contracted_1 = tenex::evaluate<ti_i, ti_K>(G(ti_K, ti_j, ti_i, ti_J));
 
   for (size_t i = 0; i < 3; i++) {
     for (size_t k = 0; k < 3; k++) {
@@ -727,7 +708,7 @@ void test_spatial_spacetime_index(const DataType& used_for_size) {
   // Contract one (spacetime, spacetime) pair of indices using generic spatial
   // indices and then one (spatial, spatial) pair of indices
   const Tensor<DataType> G_contracted_2 =
-      TensorExpressions::evaluate(G(ti_I, ti_i, ti_j, ti_J));
+      tenex::evaluate(G(ti_I, ti_i, ti_j, ti_J));
 
   DataType expected_G_sum_2 = make_with_value<DataType>(used_for_size, 0.0);
   for (size_t i = 0; i < 3; i++) {
@@ -739,7 +720,7 @@ void test_spatial_spacetime_index(const DataType& used_for_size) {
 
   // Contract two (spatial, spacetime) pairs of indices
   const Tensor<DataType> G_contracted_3 =
-      TensorExpressions::evaluate(G(ti_I, ti_j, ti_i, ti_J));
+      tenex::evaluate(G(ti_I, ti_j, ti_i, ti_J));
 
   DataType expected_G_sum_3 = make_with_value<DataType>(used_for_size, 0.0);
   for (size_t i = 0; i < 3; i++) {
@@ -761,7 +742,7 @@ void test_spatial_spacetime_index(const DataType& used_for_size) {
   // indices and then one (spacetime, spacetime) pair of indices using generic
   // spatial indices
   const Tensor<DataType> H_contracted_1 =
-      TensorExpressions::evaluate(H(ti_i, ti_I, ti_a, ti_A));
+      tenex::evaluate(H(ti_i, ti_I, ti_a, ti_A));
 
   DataType expected_H_sum_1 = make_with_value<DataType>(used_for_size, 0.0);
   for (size_t i = 0; i < 3; i++) {
@@ -774,7 +755,7 @@ void test_spatial_spacetime_index(const DataType& used_for_size) {
   // Contract two (spacetime, spacetime) pair of indices using generic spatial
   // indices
   const Tensor<DataType> H_contracted_2 =
-      TensorExpressions::evaluate(H(ti_j, ti_I, ti_i, ti_J));
+      tenex::evaluate(H(ti_j, ti_I, ti_i, ti_J));
 
   DataType expected_H_sum_2 = make_with_value<DataType>(used_for_size, 0.0);
   for (size_t j = 0; j < 3; j++) {
@@ -800,8 +781,7 @@ void test_time_index(const DataType& used_for_size) {
   // \f$L_{b} = R^{at}{}_{ab}\f$
   const Tensor<DataType, Symmetry<1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>
-      R_contracted_1 =
-          TensorExpressions::evaluate<ti_b>(R(ti_A, ti_T, ti_a, ti_b));
+      R_contracted_1 = tenex::evaluate<ti_b>(R(ti_A, ti_T, ti_a, ti_b));
 
   for (size_t b = 0; b < 4; b++) {
     DataType expected_R_sum_1 = make_with_value<DataType>(used_for_size, 0.0);
@@ -819,7 +799,7 @@ void test_time_index(const DataType& used_for_size) {
   // an upper and lower time index in the RHS tensor, which is different than
   // the presence of an upper and lower generic index
   const Tensor<DataType> R_contracted_2 =
-      TensorExpressions::evaluate(R(ti_A, ti_T, ti_a, ti_t));
+      tenex::evaluate(R(ti_A, ti_T, ti_a, ti_t));
   DataType expected_R_sum_2 = make_with_value<DataType>(used_for_size, 0.0);
   for (size_t a = 0; a < 4; a++) {
     expected_R_sum_2 += R.get(a, 0, a, 0);
@@ -854,8 +834,8 @@ void test_time_index(const DataType& used_for_size) {
   // the presence of an upper and lower generic index. Also makes sure that
   // a contraction can be evaluated to a LHS tensor of higher rank than the
   // rank that results from contracting the RHS
-  ::TensorExpressions::evaluate<ti_t, ti_t, ti_B, ti_T>(
-      make_not_null(&S_contracted), S(ti_B, ti_A, ti_a));
+  ::tenex::evaluate<ti_t, ti_t, ti_B, ti_T>(make_not_null(&S_contracted),
+                                            S(ti_B, ti_A, ti_a));
 
   for (size_t b = 0; b < 4; b++) {
     DataType expected_S_sum = make_with_value<DataType>(used_for_size, 0.0);
@@ -890,8 +870,8 @@ void test_time_index(const DataType& used_for_size) {
 
   // Contract a RHS tensor with time indices to a LHS tensor with time indices
   // \f$L^{tb}{}_{t} = R_{at}{}^{ab}\f$
-  ::TensorExpressions::evaluate<ti_T, ti_B, ti_t>(make_not_null(&T_contracted),
-                                                  T(ti_a, ti_t, ti_A, ti_B));
+  ::tenex::evaluate<ti_T, ti_B, ti_t>(make_not_null(&T_contracted),
+                                      T(ti_a, ti_t, ti_A, ti_B));
 
   for (size_t b = 0; b < 4; b++) {
     DataType expected_T_sum = make_with_value<DataType>(used_for_size, 0.0);

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Contract.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Contract.cpp
@@ -47,7 +47,7 @@ void test_contractions_rank2(const DataType& used_for_size) {
       Rul(used_for_size);
   create_tensor(make_not_null(&Rul));
 
-  const auto RIi_expr = Rul(ti_I, ti_i);
+  const auto RIi_expr = Rul(ti::I, ti::i);
   const std::array<size_t, 2> expected_multi_index{
       {contracted_value_placeholder, contracted_value_placeholder}};
   CHECK(RIi_expr.get_uncontracted_multi_index_with_uncontracted_values({{}}) ==
@@ -68,7 +68,7 @@ void test_contractions_rank2(const DataType& used_for_size) {
       Rlu(used_for_size);
   create_tensor(make_not_null(&Rlu));
 
-  const auto RgG_expr = Rlu(ti_g, ti_G);
+  const auto RgG_expr = Rlu(ti::g, ti::G);
   CHECK(RgG_expr.get_uncontracted_multi_index_with_uncontracted_values({{}}) ==
         expected_multi_index);
 
@@ -93,10 +93,10 @@ void test_contractions_rank3(const DataType& used_for_size) {
       Rlul(used_for_size);
   create_tensor(make_not_null(&Rlul));
 
-  const auto RiIj_expr = Rlul(ti_i, ti_I, ti_j);
+  const auto RiIj_expr = Rlul(ti::i, ti::I, ti::j);
   const Tensor<DataType, Symmetry<1>,
                index_list<SpatialIndex<4, UpLo::Lo, Frame::Grid>>>
-      RiIj_contracted = tenex::evaluate<ti_j>(RiIj_expr);
+      RiIj_contracted = tenex::evaluate<ti::j>(RiIj_expr);
 
   for (size_t j = 0; j < 4; j++) {
     const std::array<size_t, 3> expected_multi_index{
@@ -119,10 +119,10 @@ void test_contractions_rank3(const DataType& used_for_size) {
       Ruul(used_for_size);
   create_tensor(make_not_null(&Ruul));
 
-  const auto RJLj_expr = Ruul(ti_J, ti_L, ti_j);
+  const auto RJLj_expr = Ruul(ti::J, ti::L, ti::j);
   const Tensor<DataType, Symmetry<1>,
                index_list<SpatialIndex<3, UpLo::Up, Frame::Grid>>>
-      RJLj_contracted = tenex::evaluate<ti_L>(RJLj_expr);
+      RJLj_contracted = tenex::evaluate<ti::L>(RJLj_expr);
 
   for (size_t l = 0; l < 3; l++) {
     const std::array<size_t, 3> expected_multi_index{
@@ -145,10 +145,10 @@ void test_contractions_rank3(const DataType& used_for_size) {
       Rulu(used_for_size);
   create_tensor(make_not_null(&Rulu));
 
-  const auto RBfF_expr = Rulu(ti_B, ti_f, ti_F);
+  const auto RBfF_expr = Rulu(ti::B, ti::f, ti::F);
   const Tensor<DataType, Symmetry<1>,
                index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>>
-      RBfF_contracted = tenex::evaluate<ti_B>(RBfF_expr);
+      RBfF_contracted = tenex::evaluate<ti::B>(RBfF_expr);
 
   for (size_t b = 0; b < 4; b++) {
     const std::array<size_t, 3> expected_multi_index{
@@ -172,10 +172,10 @@ void test_contractions_rank3(const DataType& used_for_size) {
       Rllu(used_for_size);
   create_tensor(make_not_null(&Rllu));
 
-  const auto RiaI_expr = Rllu(ti_i, ti_a, ti_I);
+  const auto RiaI_expr = Rllu(ti::i, ti::a, ti::I);
   const Tensor<DataType, Symmetry<1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      RiaI_contracted = tenex::evaluate<ti_a>(RiaI_expr);
+      RiaI_contracted = tenex::evaluate<ti::a>(RiaI_expr);
 
   for (size_t a = 0; a < 4; a++) {
     const std::array<size_t, 3> expected_multi_index{
@@ -205,11 +205,11 @@ void test_contractions_rank4(const DataType& used_for_size) {
       Rluul(used_for_size);
   create_tensor(make_not_null(&Rluul));
 
-  const auto RiIKj_expr = Rluul(ti_i, ti_I, ti_K, ti_j);
+  const auto RiIKj_expr = Rluul(ti::i, ti::I, ti::K, ti::j);
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<4, UpLo::Up, Frame::Inertial>,
                           SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>
-      RiIKj_contracted = tenex::evaluate<ti_K, ti_j>(RiIKj_expr);
+      RiIKj_contracted = tenex::evaluate<ti::K, ti::j>(RiIKj_expr);
 
   for (size_t k = 0; k < 4; k++) {
     for (size_t j = 0; j < 3; j++) {
@@ -236,11 +236,11 @@ void test_contractions_rank4(const DataType& used_for_size) {
       Ruull(used_for_size);
   create_tensor(make_not_null(&Ruull));
 
-  const auto RABac_expr = Ruull(ti_A, ti_B, ti_a, ti_c);
+  const auto RABac_expr = Ruull(ti::A, ti::B, ti::a, ti::c);
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                           SpacetimeIndex<4, UpLo::Lo, Frame::Grid>>>
-      RABac_contracted = tenex::evaluate<ti_B, ti_c>(RABac_expr);
+      RABac_contracted = tenex::evaluate<ti::B, ti::c>(RABac_expr);
 
   for (size_t b = 0; b < 4; b++) {
     for (size_t c = 0; c < 5; c++) {
@@ -267,11 +267,11 @@ void test_contractions_rank4(const DataType& used_for_size) {
       Ruuul(used_for_size);
   create_tensor(make_not_null(&Ruuul));
 
-  const auto RLJIl_expr = Ruuul(ti_L, ti_J, ti_I, ti_l);
+  const auto RLJIl_expr = Ruuul(ti::L, ti::J, ti::I, ti::l);
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<4, UpLo::Up, Frame::Grid>,
                           SpatialIndex<3, UpLo::Up, Frame::Grid>>>
-      RLJIl_contracted = tenex::evaluate<ti_J, ti_I>(RLJIl_expr);
+      RLJIl_contracted = tenex::evaluate<ti::J, ti::I>(RLJIl_expr);
 
   for (size_t j = 0; j < 4; j++) {
     for (size_t i = 0; i < 3; i++) {
@@ -298,11 +298,11 @@ void test_contractions_rank4(const DataType& used_for_size) {
       Ruulu(used_for_size);
   create_tensor(make_not_null(&Ruulu));
 
-  const auto REDdA_expr = Ruulu(ti_E, ti_D, ti_d, ti_A);
+  const auto REDdA_expr = Ruulu(ti::E, ti::D, ti::d, ti::A);
   const Tensor<DataType, Symmetry<1, 1>,
                index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>
-      REDdA_contracted = tenex::evaluate<ti_E, ti_A>(REDdA_expr);
+      REDdA_contracted = tenex::evaluate<ti::E, ti::A>(REDdA_expr);
 
   for (size_t e = 0; e < 4; e++) {
     for (size_t a = 0; a < 4; a++) {
@@ -329,11 +329,11 @@ void test_contractions_rank4(const DataType& used_for_size) {
       Rlull(used_for_size);
   create_tensor(make_not_null(&Rlull));
 
-  const auto RkJij_expr = Rlull(ti_k, ti_J, ti_i, ti_j);
+  const auto RkJij_expr = Rlull(ti::k, ti::J, ti::i, ti::j);
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
                           SpatialIndex<4, UpLo::Lo, Frame::Inertial>>>
-      RkJij_contracted = tenex::evaluate<ti_k, ti_i>(RkJij_expr);
+      RkJij_contracted = tenex::evaluate<ti::k, ti::i>(RkJij_expr);
 
   for (size_t k = 0; k < 3; k++) {
     for (size_t i = 0; i < 4; i++) {
@@ -360,11 +360,11 @@ void test_contractions_rank4(const DataType& used_for_size) {
       Rullu(used_for_size);
   create_tensor(make_not_null(&Rullu));
 
-  const auto RFcgG_expr = Rullu(ti_F, ti_c, ti_g, ti_G);
+  const auto RFcgG_expr = Rullu(ti::F, ti::c, ti::g, ti::G);
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpacetimeIndex<4, UpLo::Up, Frame::Inertial>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>
-      RFcgG_contracted = tenex::evaluate<ti_F, ti_c>(RFcgG_expr);
+      RFcgG_contracted = tenex::evaluate<ti::F, ti::c>(RFcgG_expr);
 
   for (size_t f = 0; f < 5; f++) {
     for (size_t c = 0; c < 4; c++) {
@@ -391,11 +391,11 @@ void test_contractions_rank4(const DataType& used_for_size) {
       Ruluu(used_for_size);
   create_tensor(make_not_null(&Ruluu));
 
-  const auto RKkIJ_expr = Ruluu(ti_K, ti_k, ti_I, ti_J);
+  const auto RKkIJ_expr = Ruluu(ti::K, ti::k, ti::I, ti::J);
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<2, UpLo::Up, Frame::Grid>,
                           SpatialIndex<3, UpLo::Up, Frame::Grid>>>
-      RKkIJ_contracted_to_JI = tenex::evaluate<ti_J, ti_I>(RKkIJ_expr);
+      RKkIJ_contracted_to_JI = tenex::evaluate<ti::J, ti::I>(RKkIJ_expr);
 
   for (size_t j = 0; j < 2; j++) {
     for (size_t i = 0; i < 3; i++) {
@@ -422,11 +422,11 @@ void test_contractions_rank4(const DataType& used_for_size) {
       Rluuu(used_for_size);
   create_tensor(make_not_null(&Rluuu));
 
-  const auto RbCBE_expr = Rluuu(ti_b, ti_C, ti_B, ti_E);
+  const auto RbCBE_expr = Rluuu(ti::b, ti::C, ti::B, ti::E);
   const Tensor<DataType, Symmetry<1, 1>,
                index_list<SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
                           SpacetimeIndex<2, UpLo::Up, Frame::Grid>>>
-      RbCBE_contracted_to_EC = tenex::evaluate<ti_E, ti_C>(RbCBE_expr);
+      RbCBE_contracted_to_EC = tenex::evaluate<ti::E, ti::C>(RbCBE_expr);
 
   for (size_t e = 0; e < 3; e++) {
     for (size_t c = 0; c < 3; c++) {
@@ -453,11 +453,11 @@ void test_contractions_rank4(const DataType& used_for_size) {
       Rulll(used_for_size);
   create_tensor(make_not_null(&Rulll));
 
-  const auto RAdba_expr = Rulll(ti_A, ti_d, ti_b, ti_a);
+  const auto RAdba_expr = Rulll(ti::A, ti::d, ti::b, ti::a);
   const Tensor<DataType, Symmetry<1, 1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      RAdba_contracted_to_bd = tenex::evaluate<ti_b, ti_d>(RAdba_expr);
+      RAdba_contracted_to_bd = tenex::evaluate<ti::b, ti::d>(RAdba_expr);
 
   for (size_t b = 0; b < 4; b++) {
     for (size_t d = 0; d < 4; d++) {
@@ -484,11 +484,11 @@ void test_contractions_rank4(const DataType& used_for_size) {
       Rllul(used_for_size);
   create_tensor(make_not_null(&Rllul));
 
-  const auto RljJi_expr = Rllul(ti_l, ti_j, ti_J, ti_i);
+  const auto RljJi_expr = Rllul(ti::l, ti::j, ti::J, ti::i);
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<4, UpLo::Lo, Frame::Grid>,
                           SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
-      RljJi_contracted_to_il = tenex::evaluate<ti_i, ti_l>(RljJi_expr);
+      RljJi_contracted_to_il = tenex::evaluate<ti::i, ti::l>(RljJi_expr);
 
   for (size_t i = 0; i < 4; i++) {
     for (size_t l = 0; l < 3; l++) {
@@ -515,11 +515,11 @@ void test_contractions_rank4(const DataType& used_for_size) {
       Rlluu(used_for_size);
   create_tensor(make_not_null(&Rlluu));
 
-  const auto RagDG_expr = Rlluu(ti_a, ti_g, ti_D, ti_G);
+  const auto RagDG_expr = Rlluu(ti::a, ti::g, ti::D, ti::G);
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>
-      RagDG_contracted_to_Da = tenex::evaluate<ti_D, ti_a>(RagDG_expr);
+      RagDG_contracted_to_Da = tenex::evaluate<ti::D, ti::a>(RagDG_expr);
 
   for (size_t d = 0; d < 4; d++) {
     for (size_t a = 0; a < 4; a++) {
@@ -546,11 +546,11 @@ void test_contractions_rank4(const DataType& used_for_size) {
       Rlulu(used_for_size);
   create_tensor(make_not_null(&Rlulu));
 
-  const auto RlJiI_expr = Rlulu(ti_l, ti_J, ti_i, ti_I);
+  const auto RlJiI_expr = Rlulu(ti::l, ti::J, ti::i, ti::I);
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<3, UpLo::Up, Frame::Inertial>,
                           SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>
-      RlJiI_contracted_to_Jl = tenex::evaluate<ti_J, ti_l>(RlJiI_expr);
+      RlJiI_contracted_to_Jl = tenex::evaluate<ti::J, ti::l>(RlJiI_expr);
 
   for (size_t j = 0; j < 3; j++) {
     for (size_t l = 0; l < 3; l++) {
@@ -577,7 +577,7 @@ void test_contractions_rank4(const DataType& used_for_size) {
       Rulul(used_for_size);
   create_tensor(make_not_null(&Rulul));
 
-  const auto RKkLl_expr = Rulul(ti_K, ti_k, ti_L, ti_l);
+  const auto RKkLl_expr = Rulul(ti::K, ti::k, ti::L, ti::l);
   // `RKkLl_expr` is a TensorContract expression that contains another
   // TensorContract expression. The "inner" expression will contract the L/l
   // indices, representing contracting the 3rd and 4th indices of the rank 4
@@ -606,7 +606,7 @@ void test_contractions_rank4(const DataType& used_for_size) {
 
   // Contract first and third indices and second and fourth indices to rank 0
   // tensor
-  const auto RcaCA_expr = Rlluu(ti_c, ti_a, ti_C, ti_A);
+  const auto RcaCA_expr = Rlluu(ti::c, ti::a, ti::C, ti::A);
   CHECK(RcaCA_expr.get_uncontracted_multi_index_with_uncontracted_values(
             {{}}) == expected_multi_index);
 
@@ -622,7 +622,7 @@ void test_contractions_rank4(const DataType& used_for_size) {
 
   // Contract first and fourth indices and second and third indices to rank 0
   // tensor
-  const auto RjIiJ_expr = Rlulu(ti_j, ti_I, ti_i, ti_J);
+  const auto RjIiJ_expr = Rlulu(ti::j, ti::I, ti::i, ti::J);
   CHECK(RjIiJ_expr.get_uncontracted_multi_index_with_uncontracted_values(
             {{}}) == expected_multi_index);
 
@@ -648,7 +648,7 @@ void test_spatial_spacetime_index(const DataType& used_for_size) {
 
       R(used_for_size);
   create_tensor(make_not_null(&R));
-  const Tensor<DataType> R_contracted = tenex::evaluate(R(ti_I, ti_i));
+  const Tensor<DataType> R_contracted = tenex::evaluate(R(ti::I, ti::i));
 
   // Contract (spacetime, spatial) tensor
   Tensor<DataType, Symmetry<2, 1>,
@@ -656,7 +656,7 @@ void test_spatial_spacetime_index(const DataType& used_for_size) {
                     SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>
       S(used_for_size);
   create_tensor(make_not_null(&S));
-  const Tensor<DataType> S_contracted = tenex::evaluate(S(ti_K, ti_k));
+  const Tensor<DataType> S_contracted = tenex::evaluate(S(ti::K, ti::k));
 
   // Contract (spacetime, spacetime) tensor using generic spatial indices
   Tensor<DataType, Symmetry<2, 1>,
@@ -664,7 +664,7 @@ void test_spatial_spacetime_index(const DataType& used_for_size) {
                     SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>
       T(used_for_size);
   create_tensor(make_not_null(&T));
-  const Tensor<DataType> T_contracted = tenex::evaluate(T(ti_j, ti_J));
+  const Tensor<DataType> T_contracted = tenex::evaluate(T(ti::j, ti::J));
 
   DataType expected_R_sum = make_with_value<DataType>(used_for_size, 0.0);
   DataType expected_S_sum = make_with_value<DataType>(used_for_size, 0.0);
@@ -693,7 +693,8 @@ void test_spatial_spacetime_index(const DataType& used_for_size) {
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
                           SpatialIndex<3, UpLo::Up, Frame::Grid>>>
-      G_contracted_1 = tenex::evaluate<ti_i, ti_K>(G(ti_K, ti_j, ti_i, ti_J));
+      G_contracted_1 =
+          tenex::evaluate<ti::i, ti::K>(G(ti::K, ti::j, ti::i, ti::J));
 
   for (size_t i = 0; i < 3; i++) {
     for (size_t k = 0; k < 3; k++) {
@@ -708,7 +709,7 @@ void test_spatial_spacetime_index(const DataType& used_for_size) {
   // Contract one (spacetime, spacetime) pair of indices using generic spatial
   // indices and then one (spatial, spatial) pair of indices
   const Tensor<DataType> G_contracted_2 =
-      tenex::evaluate(G(ti_I, ti_i, ti_j, ti_J));
+      tenex::evaluate(G(ti::I, ti::i, ti::j, ti::J));
 
   DataType expected_G_sum_2 = make_with_value<DataType>(used_for_size, 0.0);
   for (size_t i = 0; i < 3; i++) {
@@ -720,7 +721,7 @@ void test_spatial_spacetime_index(const DataType& used_for_size) {
 
   // Contract two (spatial, spacetime) pairs of indices
   const Tensor<DataType> G_contracted_3 =
-      tenex::evaluate(G(ti_I, ti_j, ti_i, ti_J));
+      tenex::evaluate(G(ti::I, ti::j, ti::i, ti::J));
 
   DataType expected_G_sum_3 = make_with_value<DataType>(used_for_size, 0.0);
   for (size_t i = 0; i < 3; i++) {
@@ -742,7 +743,7 @@ void test_spatial_spacetime_index(const DataType& used_for_size) {
   // indices and then one (spacetime, spacetime) pair of indices using generic
   // spatial indices
   const Tensor<DataType> H_contracted_1 =
-      tenex::evaluate(H(ti_i, ti_I, ti_a, ti_A));
+      tenex::evaluate(H(ti::i, ti::I, ti::a, ti::A));
 
   DataType expected_H_sum_1 = make_with_value<DataType>(used_for_size, 0.0);
   for (size_t i = 0; i < 3; i++) {
@@ -755,7 +756,7 @@ void test_spatial_spacetime_index(const DataType& used_for_size) {
   // Contract two (spacetime, spacetime) pair of indices using generic spatial
   // indices
   const Tensor<DataType> H_contracted_2 =
-      tenex::evaluate(H(ti_j, ti_I, ti_i, ti_J));
+      tenex::evaluate(H(ti::j, ti::I, ti::i, ti::J));
 
   DataType expected_H_sum_2 = make_with_value<DataType>(used_for_size, 0.0);
   for (size_t j = 0; j < 3; j++) {
@@ -781,7 +782,7 @@ void test_time_index(const DataType& used_for_size) {
   // \f$L_{b} = R^{at}{}_{ab}\f$
   const Tensor<DataType, Symmetry<1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>
-      R_contracted_1 = tenex::evaluate<ti_b>(R(ti_A, ti_T, ti_a, ti_b));
+      R_contracted_1 = tenex::evaluate<ti::b>(R(ti::A, ti::T, ti::a, ti::b));
 
   for (size_t b = 0; b < 4; b++) {
     DataType expected_R_sum_1 = make_with_value<DataType>(used_for_size, 0.0);
@@ -799,7 +800,7 @@ void test_time_index(const DataType& used_for_size) {
   // an upper and lower time index in the RHS tensor, which is different than
   // the presence of an upper and lower generic index
   const Tensor<DataType> R_contracted_2 =
-      tenex::evaluate(R(ti_A, ti_T, ti_a, ti_t));
+      tenex::evaluate(R(ti::A, ti::T, ti::a, ti::t));
   DataType expected_R_sum_2 = make_with_value<DataType>(used_for_size, 0.0);
   for (size_t a = 0; a < 4; a++) {
     expected_R_sum_2 += R.get(a, 0, a, 0);
@@ -834,8 +835,8 @@ void test_time_index(const DataType& used_for_size) {
   // the presence of an upper and lower generic index. Also makes sure that
   // a contraction can be evaluated to a LHS tensor of higher rank than the
   // rank that results from contracting the RHS
-  ::tenex::evaluate<ti_t, ti_t, ti_B, ti_T>(make_not_null(&S_contracted),
-                                            S(ti_B, ti_A, ti_a));
+  ::tenex::evaluate<ti::t, ti::t, ti::B, ti::T>(make_not_null(&S_contracted),
+                                                S(ti::B, ti::A, ti::a));
 
   for (size_t b = 0; b < 4; b++) {
     DataType expected_S_sum = make_with_value<DataType>(used_for_size, 0.0);
@@ -870,8 +871,8 @@ void test_time_index(const DataType& used_for_size) {
 
   // Contract a RHS tensor with time indices to a LHS tensor with time indices
   // \f$L^{tb}{}_{t} = R_{at}{}^{ab}\f$
-  ::tenex::evaluate<ti_T, ti_B, ti_t>(make_not_null(&T_contracted),
-                                      T(ti_a, ti_t, ti_A, ti_B));
+  ::tenex::evaluate<ti::T, ti::B, ti::t>(make_not_null(&T_contracted),
+                                         T(ti::a, ti::t, ti::A, ti::B));
 
   for (size_t b = 0; b < 4; b++) {
     DataType expected_T_sum = make_with_value<DataType>(used_for_size, 0.0);

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Divide.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Divide.cpp
@@ -41,10 +41,10 @@ void test_divide_double_denominator(const gsl::not_null<Generator*> generator,
   // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
   // return type of `evaluate`
   const tnsr::ii<DataType, dim> Lij_from_Sij_over_R =
-      tenex::evaluate<ti_i, ti_j>(S(ti_i, ti_j) / 4.3);
+      tenex::evaluate<ti::i, ti::j>(S(ti::i, ti::j) / 4.3);
   // \f$L_{ij} = (R * S_{ij} / T / G)\f$
   const tnsr::ii<DataType, dim> Lij_from_R_Sij_over_T =
-      tenex::evaluate<ti_i, ti_j>((-5.2 * S(ti_i, ti_j) / 1.6) / 2.1);
+      tenex::evaluate<ti::i, ti::j>((-5.2 * S(ti::i, ti::j) / 1.6) / 2.1);
 
   for (size_t i = 0; i < dim; i++) {
     for (size_t j = 0; j < dim; j++) {
@@ -85,7 +85,8 @@ void test_divide_double_numerator(const gsl::not_null<Generator*> generator,
   CHECK(get(result1) == 2.1 / get(S));
 
   // \f$L = R / \sqrt{T^j{}_j}\f$
-  const Scalar<DataType> result2 = tenex::evaluate(-5.7 / sqrt(T(ti_J, ti_j)));
+  const Scalar<DataType> result2 =
+      tenex::evaluate(-5.7 / sqrt(T(ti::J, ti::j)));
 
   DataType trace_T = make_with_value<DataType>(used_for_size, 0.0);
   for (size_t j = 0; j < dim; j++) {
@@ -124,7 +125,7 @@ void test_divide_rank0_denominator(const gsl::not_null<Generator*> generator,
   // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
   // return type of `evaluate`
   const tnsr::iJ<DataType, dim> result1 =
-      tenex::evaluate<ti_j, ti_I>(S(ti_I, ti_j) / R());
+      tenex::evaluate<ti::j, ti::I>(S(ti::I, ti::j) / R());
 
   for (size_t i = 0; i < dim; i++) {
     for (size_t j = 0; j < dim; j++) {
@@ -133,8 +134,8 @@ void test_divide_rank0_denominator(const gsl::not_null<Generator*> generator,
   }
 
   // \f$L^{k}{}_{i} = (R T_{i}{}^{k}) / (T_{j}{}^{l} S^{j}{}_{l})\f$
-  const tnsr::Ij<DataType, dim> result2 = tenex::evaluate<ti_K, ti_i>(
-      (R() * T(ti_i, ti_K)) / ((T(ti_j, ti_L) * S(ti_J, ti_l))));
+  const tnsr::Ij<DataType, dim> result2 = tenex::evaluate<ti::K, ti::i>(
+      (R() * T(ti::i, ti::K)) / ((T(ti::j, ti::L) * S(ti::J, ti::l))));
 
   DataType result2_expected_denominator =
       make_with_value<DataType>(used_for_size, 0.0);
@@ -154,7 +155,7 @@ void test_divide_rank0_denominator(const gsl::not_null<Generator*> generator,
 
   // \f$L_{i}{}^{k} = T_{i}{}^{k} / R^2 / R\f$
   const tnsr::iJ<DataType, dim> result3 =
-      tenex::evaluate<ti_i, ti_K>(T(ti_i, ti_K) / square(R()) / R());
+      tenex::evaluate<ti::i, ti::K>(T(ti::i, ti::K) / square(R()) / R());
 
   DataType result3_expected_denominator = get(R) * get(R) * get(R);
   for (size_t i = 0; i < dim; i++) {
@@ -198,7 +199,7 @@ void test_divide_spatial_spacetime_index(
   // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
   // return type of `evaluate`
   const aI result1 =
-      tenex::evaluate<ti_a, ti_I>((T(ti_a, ti_I) - S(ti_I, ti_a)) / R());
+      tenex::evaluate<ti::a, ti::I>((T(ti::a, ti::I) - S(ti::I, ti::a)) / R());
 
   for (size_t a = 0; a < dim + 1; a++) {
     for (size_t i = 0; i < dim; i++) {
@@ -209,7 +210,7 @@ void test_divide_spatial_spacetime_index(
 
   // \f$L = (R / (T_{j}{}^{l} S^{j}{}_{l}) / 2\f$
   const Scalar<DataType> result2 =
-      tenex::evaluate(R() / (T(ti_j, ti_L) * S(ti_J, ti_l)) / 2.0);
+      tenex::evaluate(R() / (T(ti::j, ti::L) * S(ti::J, ti::l)) / 2.0);
 
   DataType result2_expected_denominator =
       make_with_value<DataType>(used_for_size, 0.0);
@@ -253,7 +254,7 @@ void test_divide_time_index(const gsl::not_null<Generator*> generator,
   // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
   // return type of `evaluate`
   const tnsr::A<DataType, dim> result1 =
-      tenex::evaluate<ti_A>((S(ti_A, ti_t)) / sqrt(R()));
+      tenex::evaluate<ti::A>((S(ti::A, ti::t)) / sqrt(R()));
 
   for (size_t a = 0; a < dim + 1; a++) {
     CHECK_ITERABLE_APPROX(result1.get(a), (S.get(a, 0)) / sqrt(get(R)));
@@ -261,7 +262,7 @@ void test_divide_time_index(const gsl::not_null<Generator*> generator,
 
   // \f$L = R / (T_{tt} / S^{t}{}_{t} \f$
   const Scalar<DataType> result2 =
-      tenex::evaluate(R() / T(ti_t, ti_t) / S(ti_T, ti_t));
+      tenex::evaluate(R() / T(ti::t, ti::t) / S(ti::T, ti::t));
 
   CHECK_ITERABLE_APPROX(get(result2), get(R) / T.get(0, 0) / S.get(0, 0));
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Divide.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Divide.cpp
@@ -41,11 +41,10 @@ void test_divide_double_denominator(const gsl::not_null<Generator*> generator,
   // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
   // return type of `evaluate`
   const tnsr::ii<DataType, dim> Lij_from_Sij_over_R =
-      TensorExpressions::evaluate<ti_i, ti_j>(S(ti_i, ti_j) / 4.3);
+      tenex::evaluate<ti_i, ti_j>(S(ti_i, ti_j) / 4.3);
   // \f$L_{ij} = (R * S_{ij} / T / G)\f$
   const tnsr::ii<DataType, dim> Lij_from_R_Sij_over_T =
-      TensorExpressions::evaluate<ti_i, ti_j>((-5.2 * S(ti_i, ti_j) / 1.6) /
-                                              2.1);
+      tenex::evaluate<ti_i, ti_j>((-5.2 * S(ti_i, ti_j) / 1.6) / 2.1);
 
   for (size_t i = 0; i < dim; i++) {
     for (size_t j = 0; j < dim; j++) {
@@ -82,12 +81,11 @@ void test_divide_double_numerator(const gsl::not_null<Generator*> generator,
   // \f$L = R / S\f$
   // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
   // return type of `evaluate`
-  const Scalar<DataType> result1 = TensorExpressions::evaluate(2.1 / S());
+  const Scalar<DataType> result1 = tenex::evaluate(2.1 / S());
   CHECK(get(result1) == 2.1 / get(S));
 
   // \f$L = R / \sqrt{T^j{}_j}\f$
-  const Scalar<DataType> result2 =
-      TensorExpressions::evaluate(-5.7 / sqrt(T(ti_J, ti_j)));
+  const Scalar<DataType> result2 = tenex::evaluate(-5.7 / sqrt(T(ti_J, ti_j)));
 
   DataType trace_T = make_with_value<DataType>(used_for_size, 0.0);
   for (size_t j = 0; j < dim; j++) {
@@ -126,7 +124,7 @@ void test_divide_rank0_denominator(const gsl::not_null<Generator*> generator,
   // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
   // return type of `evaluate`
   const tnsr::iJ<DataType, dim> result1 =
-      TensorExpressions::evaluate<ti_j, ti_I>(S(ti_I, ti_j) / R());
+      tenex::evaluate<ti_j, ti_I>(S(ti_I, ti_j) / R());
 
   for (size_t i = 0; i < dim; i++) {
     for (size_t j = 0; j < dim; j++) {
@@ -135,9 +133,8 @@ void test_divide_rank0_denominator(const gsl::not_null<Generator*> generator,
   }
 
   // \f$L^{k}{}_{i} = (R T_{i}{}^{k}) / (T_{j}{}^{l} S^{j}{}_{l})\f$
-  const tnsr::Ij<DataType, dim> result2 =
-      TensorExpressions::evaluate<ti_K, ti_i>(
-          (R() * T(ti_i, ti_K)) / ((T(ti_j, ti_L) * S(ti_J, ti_l))));
+  const tnsr::Ij<DataType, dim> result2 = tenex::evaluate<ti_K, ti_i>(
+      (R() * T(ti_i, ti_K)) / ((T(ti_j, ti_L) * S(ti_J, ti_l))));
 
   DataType result2_expected_denominator =
       make_with_value<DataType>(used_for_size, 0.0);
@@ -157,8 +154,7 @@ void test_divide_rank0_denominator(const gsl::not_null<Generator*> generator,
 
   // \f$L_{i}{}^{k} = T_{i}{}^{k} / R^2 / R\f$
   const tnsr::iJ<DataType, dim> result3 =
-      TensorExpressions::evaluate<ti_i, ti_K>(T(ti_i, ti_K) / square(R()) /
-                                              R());
+      tenex::evaluate<ti_i, ti_K>(T(ti_i, ti_K) / square(R()) / R());
 
   DataType result3_expected_denominator = get(R) * get(R) * get(R);
   for (size_t i = 0; i < dim; i++) {
@@ -201,8 +197,8 @@ void test_divide_spatial_spacetime_index(
   // \f$L_{ai} = (T_{a}{}^{i} - S^{i}{}_{a}) / R\f$
   // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
   // return type of `evaluate`
-  const aI result1 = TensorExpressions::evaluate<ti_a, ti_I>(
-      (T(ti_a, ti_I) - S(ti_I, ti_a)) / R());
+  const aI result1 =
+      tenex::evaluate<ti_a, ti_I>((T(ti_a, ti_I) - S(ti_I, ti_a)) / R());
 
   for (size_t a = 0; a < dim + 1; a++) {
     for (size_t i = 0; i < dim; i++) {
@@ -213,7 +209,7 @@ void test_divide_spatial_spacetime_index(
 
   // \f$L = (R / (T_{j}{}^{l} S^{j}{}_{l}) / 2\f$
   const Scalar<DataType> result2 =
-      TensorExpressions::evaluate(R() / (T(ti_j, ti_L) * S(ti_J, ti_l)) / 2.0);
+      tenex::evaluate(R() / (T(ti_j, ti_L) * S(ti_J, ti_l)) / 2.0);
 
   DataType result2_expected_denominator =
       make_with_value<DataType>(used_for_size, 0.0);
@@ -257,7 +253,7 @@ void test_divide_time_index(const gsl::not_null<Generator*> generator,
   // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
   // return type of `evaluate`
   const tnsr::A<DataType, dim> result1 =
-      TensorExpressions::evaluate<ti_A>((S(ti_A, ti_t)) / sqrt(R()));
+      tenex::evaluate<ti_A>((S(ti_A, ti_t)) / sqrt(R()));
 
   for (size_t a = 0; a < dim + 1; a++) {
     CHECK_ITERABLE_APPROX(result1.get(a), (S.get(a, 0)) / sqrt(get(R)));
@@ -265,7 +261,7 @@ void test_divide_time_index(const gsl::not_null<Generator*> generator,
 
   // \f$L = R / (T_{tt} / S^{t}{}_{t} \f$
   const Scalar<DataType> result2 =
-      TensorExpressions::evaluate(R() / T(ti_t, ti_t) / S(ti_T, ti_t));
+      tenex::evaluate(R() / T(ti_t, ti_t) / S(ti_T, ti_t));
 
   CHECK_ITERABLE_APPROX(get(result2), get(R) / T.get(0, 0) / S.get(0, 0));
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Evaluate.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Evaluate.cpp
@@ -21,15 +21,16 @@ void test_contains_indices_to_contract_impl(const bool expected) {
 }
 
 void test_contains_indices_to_contract() {
-  test_contains_indices_to_contract_impl<ti_a, ti_b, ti_c>(false);
-  test_contains_indices_to_contract_impl<ti_I, ti_j>(false);
-  test_contains_indices_to_contract_impl<ti_j>(false);
+  test_contains_indices_to_contract_impl<ti::a, ti::b, ti::c>(false);
+  test_contains_indices_to_contract_impl<ti::I, ti::j>(false);
+  test_contains_indices_to_contract_impl<ti::j>(false);
   test_contains_indices_to_contract_impl(false);
 
-  test_contains_indices_to_contract_impl<ti_d, ti_D>(true);
-  test_contains_indices_to_contract_impl<ti_I, ti_i>(true);
-  test_contains_indices_to_contract_impl<ti_a, ti_K, ti_B, ti_b>(true);
-  test_contains_indices_to_contract_impl<ti_j, ti_c, ti_J, ti_A, ti_a>(true);
+  test_contains_indices_to_contract_impl<ti::d, ti::D>(true);
+  test_contains_indices_to_contract_impl<ti::I, ti::i>(true);
+  test_contains_indices_to_contract_impl<ti::a, ti::K, ti::B, ti::b>(true);
+  test_contains_indices_to_contract_impl<ti::j, ti::c, ti::J, ti::A, ti::a>(
+      true);
 }
 }  // namespace
 
@@ -46,100 +47,108 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Evaluate",
 
   // Rank 1: double; spacetime
   TestHelpers::tenex::test_evaluate_rank_1<double, SpacetimeIndex, UpLo::Lo,
-                                           ti_a>();
+                                           ti::a>();
   TestHelpers::tenex::test_evaluate_rank_1<double, SpacetimeIndex, UpLo::Lo,
-                                           ti_b>();
+                                           ti::b>();
   TestHelpers::tenex::test_evaluate_rank_1<double, SpacetimeIndex, UpLo::Up,
-                                           ti_A>();
+                                           ti::A>();
   TestHelpers::tenex::test_evaluate_rank_1<double, SpacetimeIndex, UpLo::Up,
-                                           ti_B>();
+                                           ti::B>();
 
   // Rank 1: double; spatial
   TestHelpers::tenex::test_evaluate_rank_1<double, SpatialIndex, UpLo::Lo,
-                                           ti_i>();
+                                           ti::i>();
   TestHelpers::tenex::test_evaluate_rank_1<double, SpatialIndex, UpLo::Lo,
-                                           ti_j>();
+                                           ti::j>();
   TestHelpers::tenex::test_evaluate_rank_1<double, SpatialIndex, UpLo::Up,
-                                           ti_I>();
+                                           ti::I>();
   TestHelpers::tenex::test_evaluate_rank_1<double, SpatialIndex, UpLo::Up,
-                                           ti_J>();
+                                           ti::J>();
 
   // Rank 1: DataVector
   TestHelpers::tenex::test_evaluate_rank_1<DataVector, SpatialIndex, UpLo::Up,
-                                           ti_L>();
+                                           ti::L>();
 
   // Rank 2: double; nonsymmetric; spacetime only
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo, ti_a, ti_b>();
+      double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo, ti::a,
+      ti::b>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, UpLo::Up, UpLo::Up, ti_A, ti_B>();
+      double, SpacetimeIndex, SpacetimeIndex, UpLo::Up, UpLo::Up, ti::A,
+      ti::B>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo, ti_d, ti_c>();
+      double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo, ti::d,
+      ti::c>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, UpLo::Up, UpLo::Up, ti_D, ti_C>();
+      double, SpacetimeIndex, SpacetimeIndex, UpLo::Up, UpLo::Up, ti::D,
+      ti::C>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti_e, ti_F>();
+      double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti::e,
+      ti::F>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo, ti_F, ti_e>();
+      double, SpacetimeIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo, ti::F,
+      ti::e>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti_g, ti_B>();
+      double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti::g,
+      ti::B>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo, ti_G, ti_b>();
+      double, SpacetimeIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo, ti::G,
+      ti::b>();
 
   // Rank 2: double; nonsymmetric; spatial only
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, UpLo::Lo, UpLo::Lo, ti_i, ti_j>();
+      double, SpatialIndex, SpatialIndex, UpLo::Lo, UpLo::Lo, ti::i, ti::j>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, UpLo::Up, UpLo::Up, ti_I, ti_J>();
+      double, SpatialIndex, SpatialIndex, UpLo::Up, UpLo::Up, ti::I, ti::J>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, UpLo::Lo, UpLo::Lo, ti_j, ti_i>();
+      double, SpatialIndex, SpatialIndex, UpLo::Lo, UpLo::Lo, ti::j, ti::i>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, UpLo::Up, UpLo::Up, ti_J, ti_I>();
+      double, SpatialIndex, SpatialIndex, UpLo::Up, UpLo::Up, ti::J, ti::I>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, UpLo::Lo, UpLo::Up, ti_i, ti_J>();
+      double, SpatialIndex, SpatialIndex, UpLo::Lo, UpLo::Up, ti::i, ti::J>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, UpLo::Up, UpLo::Lo, ti_I, ti_j>();
+      double, SpatialIndex, SpatialIndex, UpLo::Up, UpLo::Lo, ti::I, ti::j>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, UpLo::Lo, UpLo::Up, ti_j, ti_I>();
+      double, SpatialIndex, SpatialIndex, UpLo::Lo, UpLo::Up, ti::j, ti::I>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, UpLo::Up, UpLo::Lo, ti_J, ti_i>();
+      double, SpatialIndex, SpatialIndex, UpLo::Up, UpLo::Lo, ti::J, ti::i>();
 
   // Rank 2: double; nonsymmetric; spacetime and spatial mixed
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Up, ti_c, ti_I>();
+      double, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Up, ti::c, ti::I>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpatialIndex, UpLo::Up, UpLo::Lo, ti_A, ti_i>();
+      double, SpacetimeIndex, SpatialIndex, UpLo::Up, UpLo::Lo, ti::A, ti::i>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo, ti_J, ti_a>();
+      double, SpatialIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo, ti::J, ti::a>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti_i, ti_B>();
+      double, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti::i, ti::B>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Lo, ti_e, ti_j>();
+      double, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Lo, ti::e, ti::j>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo, ti_i, ti_d>();
+      double, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo, ti::i, ti::d>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpatialIndex, UpLo::Up, UpLo::Up, ti_C, ti_I>();
+      double, SpacetimeIndex, SpatialIndex, UpLo::Up, UpLo::Up, ti::C, ti::I>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpacetimeIndex, UpLo::Up, UpLo::Up, ti_J, ti_A>();
+      double, SpatialIndex, SpacetimeIndex, UpLo::Up, UpLo::Up, ti::J, ti::A>();
 
   // Rank 2: double; symmetric; spacetime
   TestHelpers::tenex::test_evaluate_rank_2_symmetric<double, SpacetimeIndex,
-                                                     UpLo::Lo, ti_a, ti_d>();
+                                                     UpLo::Lo, ti::a, ti::d>();
   TestHelpers::tenex::test_evaluate_rank_2_symmetric<double, SpacetimeIndex,
-                                                     UpLo::Up, ti_G, ti_B>();
+                                                     UpLo::Up, ti::G, ti::B>();
 
   // Rank 2: double; symmetric; spatial
   TestHelpers::tenex::test_evaluate_rank_2_symmetric<double, SpatialIndex,
-                                                     UpLo::Lo, ti_j, ti_i>();
+                                                     UpLo::Lo, ti::j, ti::i>();
   TestHelpers::tenex::test_evaluate_rank_2_symmetric<double, SpatialIndex,
-                                                     UpLo::Up, ti_I, ti_J>();
+                                                     UpLo::Up, ti::I, ti::J>();
 
   // Rank 2: DataVector; nonsymmetric
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      DataVector, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti_f,
-      ti_G>();
+      DataVector, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti::f,
+      ti::G>();
 
   // Rank 2: DataVector; symmetric
   TestHelpers::tenex::test_evaluate_rank_2_symmetric<DataVector, SpatialIndex,
-                                                     UpLo::Lo, ti_j, ti_i>();
+                                                     UpLo::Lo, ti::j, ti::i>();
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Evaluate.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Evaluate.cpp
@@ -16,8 +16,7 @@
 namespace {
 template <auto&... TensorIndices>
 void test_contains_indices_to_contract_impl(const bool expected) {
-  CHECK(TensorExpressions::detail::contains_indices_to_contract<sizeof...(
-            TensorIndices)>(
+  CHECK(tenex::detail::contains_indices_to_contract<sizeof...(TensorIndices)>(
             {{std::decay_t<decltype(TensorIndices)>::value...}}) == expected);
 }
 
@@ -39,108 +38,108 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Evaluate",
   test_contains_indices_to_contract();
 
   // Rank 0: double
-  TestHelpers::TensorExpressions::test_evaluate_rank_0<double>(-7.31);
+  TestHelpers::tenex::test_evaluate_rank_0<double>(-7.31);
 
   // Rank 0: DataVector
-  TestHelpers::TensorExpressions::test_evaluate_rank_0<DataVector>(
+  TestHelpers::tenex::test_evaluate_rank_0<DataVector>(
       DataVector{-3.1, 9.4, 0.0, -3.1, 2.4, 9.8});
 
   // Rank 1: double; spacetime
-  TestHelpers::TensorExpressions::test_evaluate_rank_1<double, SpacetimeIndex,
-                                                       UpLo::Lo, ti_a>();
-  TestHelpers::TensorExpressions::test_evaluate_rank_1<double, SpacetimeIndex,
-                                                       UpLo::Lo, ti_b>();
-  TestHelpers::TensorExpressions::test_evaluate_rank_1<double, SpacetimeIndex,
-                                                       UpLo::Up, ti_A>();
-  TestHelpers::TensorExpressions::test_evaluate_rank_1<double, SpacetimeIndex,
-                                                       UpLo::Up, ti_B>();
+  TestHelpers::tenex::test_evaluate_rank_1<double, SpacetimeIndex, UpLo::Lo,
+                                           ti_a>();
+  TestHelpers::tenex::test_evaluate_rank_1<double, SpacetimeIndex, UpLo::Lo,
+                                           ti_b>();
+  TestHelpers::tenex::test_evaluate_rank_1<double, SpacetimeIndex, UpLo::Up,
+                                           ti_A>();
+  TestHelpers::tenex::test_evaluate_rank_1<double, SpacetimeIndex, UpLo::Up,
+                                           ti_B>();
 
   // Rank 1: double; spatial
-  TestHelpers::TensorExpressions::test_evaluate_rank_1<double, SpatialIndex,
-                                                       UpLo::Lo, ti_i>();
-  TestHelpers::TensorExpressions::test_evaluate_rank_1<double, SpatialIndex,
-                                                       UpLo::Lo, ti_j>();
-  TestHelpers::TensorExpressions::test_evaluate_rank_1<double, SpatialIndex,
-                                                       UpLo::Up, ti_I>();
-  TestHelpers::TensorExpressions::test_evaluate_rank_1<double, SpatialIndex,
-                                                       UpLo::Up, ti_J>();
+  TestHelpers::tenex::test_evaluate_rank_1<double, SpatialIndex, UpLo::Lo,
+                                           ti_i>();
+  TestHelpers::tenex::test_evaluate_rank_1<double, SpatialIndex, UpLo::Lo,
+                                           ti_j>();
+  TestHelpers::tenex::test_evaluate_rank_1<double, SpatialIndex, UpLo::Up,
+                                           ti_I>();
+  TestHelpers::tenex::test_evaluate_rank_1<double, SpatialIndex, UpLo::Up,
+                                           ti_J>();
 
   // Rank 1: DataVector
-  TestHelpers::TensorExpressions::test_evaluate_rank_1<DataVector, SpatialIndex,
-                                                       UpLo::Up, ti_L>();
+  TestHelpers::tenex::test_evaluate_rank_1<DataVector, SpatialIndex, UpLo::Up,
+                                           ti_L>();
 
   // Rank 2: double; nonsymmetric; spacetime only
-  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
       double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo, ti_a, ti_b>();
-  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
       double, SpacetimeIndex, SpacetimeIndex, UpLo::Up, UpLo::Up, ti_A, ti_B>();
-  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
       double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo, ti_d, ti_c>();
-  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
       double, SpacetimeIndex, SpacetimeIndex, UpLo::Up, UpLo::Up, ti_D, ti_C>();
-  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
       double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti_e, ti_F>();
-  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
       double, SpacetimeIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo, ti_F, ti_e>();
-  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
       double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti_g, ti_B>();
-  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
       double, SpacetimeIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo, ti_G, ti_b>();
 
   // Rank 2: double; nonsymmetric; spatial only
-  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
       double, SpatialIndex, SpatialIndex, UpLo::Lo, UpLo::Lo, ti_i, ti_j>();
-  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
       double, SpatialIndex, SpatialIndex, UpLo::Up, UpLo::Up, ti_I, ti_J>();
-  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
       double, SpatialIndex, SpatialIndex, UpLo::Lo, UpLo::Lo, ti_j, ti_i>();
-  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
       double, SpatialIndex, SpatialIndex, UpLo::Up, UpLo::Up, ti_J, ti_I>();
-  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
       double, SpatialIndex, SpatialIndex, UpLo::Lo, UpLo::Up, ti_i, ti_J>();
-  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
       double, SpatialIndex, SpatialIndex, UpLo::Up, UpLo::Lo, ti_I, ti_j>();
-  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
       double, SpatialIndex, SpatialIndex, UpLo::Lo, UpLo::Up, ti_j, ti_I>();
-  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
       double, SpatialIndex, SpatialIndex, UpLo::Up, UpLo::Lo, ti_J, ti_i>();
 
   // Rank 2: double; nonsymmetric; spacetime and spatial mixed
-  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
       double, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Up, ti_c, ti_I>();
-  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
       double, SpacetimeIndex, SpatialIndex, UpLo::Up, UpLo::Lo, ti_A, ti_i>();
-  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
       double, SpatialIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo, ti_J, ti_a>();
-  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
       double, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti_i, ti_B>();
-  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
       double, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Lo, ti_e, ti_j>();
-  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
       double, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo, ti_i, ti_d>();
-  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
       double, SpacetimeIndex, SpatialIndex, UpLo::Up, UpLo::Up, ti_C, ti_I>();
-  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
       double, SpatialIndex, SpacetimeIndex, UpLo::Up, UpLo::Up, ti_J, ti_A>();
 
   // Rank 2: double; symmetric; spacetime
-  TestHelpers::TensorExpressions::test_evaluate_rank_2_symmetric<
-      double, SpacetimeIndex, UpLo::Lo, ti_a, ti_d>();
-  TestHelpers::TensorExpressions::test_evaluate_rank_2_symmetric<
-      double, SpacetimeIndex, UpLo::Up, ti_G, ti_B>();
+  TestHelpers::tenex::test_evaluate_rank_2_symmetric<double, SpacetimeIndex,
+                                                     UpLo::Lo, ti_a, ti_d>();
+  TestHelpers::tenex::test_evaluate_rank_2_symmetric<double, SpacetimeIndex,
+                                                     UpLo::Up, ti_G, ti_B>();
 
   // Rank 2: double; symmetric; spatial
-  TestHelpers::TensorExpressions::test_evaluate_rank_2_symmetric<
-      double, SpatialIndex, UpLo::Lo, ti_j, ti_i>();
-  TestHelpers::TensorExpressions::test_evaluate_rank_2_symmetric<
-      double, SpatialIndex, UpLo::Up, ti_I, ti_J>();
+  TestHelpers::tenex::test_evaluate_rank_2_symmetric<double, SpatialIndex,
+                                                     UpLo::Lo, ti_j, ti_i>();
+  TestHelpers::tenex::test_evaluate_rank_2_symmetric<double, SpatialIndex,
+                                                     UpLo::Up, ti_I, ti_J>();
 
   // Rank 2: DataVector; nonsymmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
       DataVector, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti_f,
       ti_G>();
 
   // Rank 2: DataVector; symmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_2_symmetric<
-      DataVector, SpatialIndex, UpLo::Lo, ti_j, ti_i>();
+  TestHelpers::tenex::test_evaluate_rank_2_symmetric<DataVector, SpatialIndex,
+                                                     UpLo::Lo, ti_j, ti_i>();
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3NonSymmetric.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3NonSymmetric.cpp
@@ -18,10 +18,10 @@ SPECTRE_TEST_CASE(
   // Rank 3: double; nonsymmetric
   TestHelpers::tenex::test_evaluate_rank_3_no_symmetry<
       double, SpacetimeIndex, SpatialIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo,
-      UpLo::Up, ti_D, ti_j, ti_B>();
+      UpLo::Up, ti::D, ti::j, ti::B>();
 
   // Rank 3: DataVector; nonsymmetric
   TestHelpers::tenex::test_evaluate_rank_3_no_symmetry<
       DataVector, SpacetimeIndex, SpatialIndex, SpacetimeIndex, UpLo::Up,
-      UpLo::Lo, UpLo::Up, ti_D, ti_j, ti_B>();
+      UpLo::Lo, UpLo::Up, ti::D, ti::j, ti::B>();
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3NonSymmetric.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3NonSymmetric.cpp
@@ -1,9 +1,9 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-// Rank 3 test cases for TensorExpressions::evaluate are split into this file
-// and Test_EvaluateRank3Symmetric.cpp in order to reduce compile time memory
-// usage per cpp file.
+// Rank 3 test cases for tenex::evaluate are split into this file and
+// Test_EvaluateRank3Symmetric.cpp in order to reduce compile time memory usage
+// per cpp file.
 
 #include "Framework/TestingFramework.hpp"
 
@@ -16,12 +16,12 @@ SPECTRE_TEST_CASE(
     "Unit.DataStructures.Tensor.Expression.EvaluateRank3NonSymmetric",
     "[DataStructures][Unit]") {
   // Rank 3: double; nonsymmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_3_no_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_3_no_symmetry<
       double, SpacetimeIndex, SpatialIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo,
       UpLo::Up, ti_D, ti_j, ti_B>();
 
   // Rank 3: DataVector; nonsymmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_3_no_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_3_no_symmetry<
       DataVector, SpacetimeIndex, SpatialIndex, SpacetimeIndex, UpLo::Up,
       UpLo::Lo, UpLo::Up, ti_D, ti_j, ti_B>();
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3Symmetric.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3Symmetric.cpp
@@ -17,39 +17,39 @@ SPECTRE_TEST_CASE(
     "[DataStructures][Unit]") {
   // Rank 3: double; first and second indices symmetric
   TestHelpers::tenex::test_evaluate_rank_3_ab_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti_b, ti_a,
-      ti_C>();
+      double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti::b, ti::a,
+      ti::C>();
 
   // Rank 3: double; first and third indices symmetric
   TestHelpers::tenex::test_evaluate_rank_3_ac_symmetry<
-      double, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo, ti_i, ti_f,
-      ti_j>();
+      double, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo, ti::i, ti::f,
+      ti::j>();
 
   // Rank 3: double; second and third indices symmetric
   TestHelpers::tenex::test_evaluate_rank_3_bc_symmetry<
-      double, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Up, ti_d, ti_J,
-      ti_I>();
+      double, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Up, ti::d, ti::J,
+      ti::I>();
 
   // Rank 3: double; symmetric
   TestHelpers::tenex::test_evaluate_rank_3_abc_symmetry<
-      double, SpacetimeIndex, UpLo::Lo, ti_f, ti_d, ti_a>();
+      double, SpacetimeIndex, UpLo::Lo, ti::f, ti::d, ti::a>();
 
   // Rank 3: DataVector; first and second indices symmetric
   TestHelpers::tenex::test_evaluate_rank_3_ab_symmetry<
-      DataVector, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti_b,
-      ti_a, ti_C>();
+      DataVector, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti::b,
+      ti::a, ti::C>();
 
   // Rank 3: DataVector; first and third indices symmetric
   TestHelpers::tenex::test_evaluate_rank_3_ac_symmetry<
-      DataVector, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo, ti_i, ti_f,
-      ti_j>();
+      DataVector, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo, ti::i,
+      ti::f, ti::j>();
 
   // Rank 3: DataVector; second and third indices symmetric
   TestHelpers::tenex::test_evaluate_rank_3_bc_symmetry<
-      DataVector, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Up, ti_d, ti_J,
-      ti_I>();
+      DataVector, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Up, ti::d,
+      ti::J, ti::I>();
 
   // Rank 3: DataVector; symmetric
   TestHelpers::tenex::test_evaluate_rank_3_abc_symmetry<
-      DataVector, SpacetimeIndex, UpLo::Lo, ti_f, ti_d, ti_a>();
+      DataVector, SpacetimeIndex, UpLo::Lo, ti::f, ti::d, ti::a>();
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3Symmetric.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3Symmetric.cpp
@@ -1,8 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-// Rank 3 test cases for TensorExpressions::evaluate are split into this file
-// and Test_EvaluateRank3NonSymmetric.cpp in order to reduce compile time memory
+// Rank 3 test cases for tenex::evaluate are split into this file and
+// Test_EvaluateRank3NonSymmetric.cpp in order to reduce compile time memory
 // usage per cpp file.
 
 #include "Framework/TestingFramework.hpp"
@@ -16,40 +16,40 @@ SPECTRE_TEST_CASE(
     "Unit.DataStructures.Tensor.Expression.EvaluateRank3Symmetric",
     "[DataStructures][Unit]") {
   // Rank 3: double; first and second indices symmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_3_ab_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_3_ab_symmetry<
       double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti_b, ti_a,
       ti_C>();
 
   // Rank 3: double; first and third indices symmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_3_ac_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_3_ac_symmetry<
       double, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo, ti_i, ti_f,
       ti_j>();
 
   // Rank 3: double; second and third indices symmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_3_bc_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_3_bc_symmetry<
       double, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Up, ti_d, ti_J,
       ti_I>();
 
   // Rank 3: double; symmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_3_abc_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_3_abc_symmetry<
       double, SpacetimeIndex, UpLo::Lo, ti_f, ti_d, ti_a>();
 
   // Rank 3: DataVector; first and second indices symmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_3_ab_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_3_ab_symmetry<
       DataVector, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti_b,
       ti_a, ti_C>();
 
   // Rank 3: DataVector; first and third indices symmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_3_ac_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_3_ac_symmetry<
       DataVector, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo, ti_i, ti_f,
       ti_j>();
 
   // Rank 3: DataVector; second and third indices symmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_3_bc_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_3_bc_symmetry<
       DataVector, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Up, ti_d, ti_J,
       ti_I>();
 
   // Rank 3: DataVector; symmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_3_abc_symmetry<
+  TestHelpers::tenex::test_evaluate_rank_3_abc_symmetry<
       DataVector, SpacetimeIndex, UpLo::Lo, ti_f, ti_d, ti_a>();
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank4.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank4.cpp
@@ -12,7 +12,7 @@
 SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateRank4",
                   "[DataStructures][Unit]") {
   // Rank 4: double; nonsymmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_4<
+  TestHelpers::tenex::test_evaluate_rank_4<
       double, Symmetry<4, 3, 2, 1>,
       index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
                  SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
@@ -21,7 +21,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateRank4",
       ti_b, ti_A, ti_k, ti_l>();
 
   // Rank 4: double; second and third indices symmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_4<
+  TestHelpers::tenex::test_evaluate_rank_4<
       double, Symmetry<3, 2, 2, 1>,
       index_list<SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
                  SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
@@ -30,7 +30,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateRank4",
       ti_G, ti_d, ti_a, ti_j>();
 
   // Rank 4: double; first, second, and fourth indices symmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_4<
+  TestHelpers::tenex::test_evaluate_rank_4<
       double, Symmetry<2, 2, 1, 2>,
       index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
                  SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
@@ -39,7 +39,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateRank4",
       ti_j, ti_i, ti_k, ti_l>();
 
   // Rank 4: double; symmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_4<
+  TestHelpers::tenex::test_evaluate_rank_4<
       double, Symmetry<1, 1, 1, 1>,
       index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                  SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
@@ -48,7 +48,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateRank4",
       ti_F, ti_A, ti_C, ti_D>();
 
   // Rank 4: DataVector; nonsymmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_4<
+  TestHelpers::tenex::test_evaluate_rank_4<
       DataVector, Symmetry<4, 3, 2, 1>,
       index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
                  SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
@@ -57,7 +57,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateRank4",
       ti_b, ti_A, ti_k, ti_l>();
 
   // Rank 4: DataVector; second and third indices symmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_4<
+  TestHelpers::tenex::test_evaluate_rank_4<
       DataVector, Symmetry<3, 2, 2, 1>,
       index_list<SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
                  SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
@@ -66,7 +66,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateRank4",
       ti_G, ti_d, ti_a, ti_j>();
 
   // Rank 4: DataVector; first, second, and fourth indices symmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_4<
+  TestHelpers::tenex::test_evaluate_rank_4<
       DataVector, Symmetry<2, 2, 1, 2>,
       index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
                  SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
@@ -75,7 +75,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateRank4",
       ti_j, ti_i, ti_k, ti_l>();
 
   // Rank 4: DataVector; symmetric
-  TestHelpers::TensorExpressions::test_evaluate_rank_4<
+  TestHelpers::tenex::test_evaluate_rank_4<
       DataVector, Symmetry<1, 1, 1, 1>,
       index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                  SpacetimeIndex<3, UpLo::Up, Frame::Grid>,

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank4.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank4.cpp
@@ -18,7 +18,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateRank4",
                  SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
                  SpatialIndex<1, UpLo::Lo, Frame::Inertial>,
                  SpatialIndex<2, UpLo::Lo, Frame::Inertial>>,
-      ti_b, ti_A, ti_k, ti_l>();
+      ti::b, ti::A, ti::k, ti::l>();
 
   // Rank 4: double; second and third indices symmetric
   TestHelpers::tenex::test_evaluate_rank_4<
@@ -27,7 +27,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateRank4",
                  SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                  SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                  SpatialIndex<1, UpLo::Lo, Frame::Grid>>,
-      ti_G, ti_d, ti_a, ti_j>();
+      ti::G, ti::d, ti::a, ti::j>();
 
   // Rank 4: double; first, second, and fourth indices symmetric
   TestHelpers::tenex::test_evaluate_rank_4<
@@ -36,7 +36,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateRank4",
                  SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
                  SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
                  SpatialIndex<3, UpLo::Lo, Frame::Inertial>>,
-      ti_j, ti_i, ti_k, ti_l>();
+      ti::j, ti::i, ti::k, ti::l>();
 
   // Rank 4: double; symmetric
   TestHelpers::tenex::test_evaluate_rank_4<
@@ -45,7 +45,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateRank4",
                  SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                  SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                  SpacetimeIndex<3, UpLo::Up, Frame::Grid>>,
-      ti_F, ti_A, ti_C, ti_D>();
+      ti::F, ti::A, ti::C, ti::D>();
 
   // Rank 4: DataVector; nonsymmetric
   TestHelpers::tenex::test_evaluate_rank_4<
@@ -54,7 +54,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateRank4",
                  SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
                  SpatialIndex<1, UpLo::Lo, Frame::Inertial>,
                  SpatialIndex<2, UpLo::Lo, Frame::Inertial>>,
-      ti_b, ti_A, ti_k, ti_l>();
+      ti::b, ti::A, ti::k, ti::l>();
 
   // Rank 4: DataVector; second and third indices symmetric
   TestHelpers::tenex::test_evaluate_rank_4<
@@ -63,7 +63,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateRank4",
                  SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                  SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                  SpatialIndex<1, UpLo::Lo, Frame::Grid>>,
-      ti_G, ti_d, ti_a, ti_j>();
+      ti::G, ti::d, ti::a, ti::j>();
 
   // Rank 4: DataVector; first, second, and fourth indices symmetric
   TestHelpers::tenex::test_evaluate_rank_4<
@@ -72,7 +72,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateRank4",
                  SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
                  SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
                  SpatialIndex<3, UpLo::Lo, Frame::Inertial>>,
-      ti_j, ti_i, ti_k, ti_l>();
+      ti::j, ti::i, ti::k, ti::l>();
 
   // Rank 4: DataVector; symmetric
   TestHelpers::tenex::test_evaluate_rank_4<
@@ -81,5 +81,5 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateRank4",
                  SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                  SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                  SpacetimeIndex<3, UpLo::Up, Frame::Grid>>,
-      ti_F, ti_A, ti_C, ti_D>();
+      ti::F, ti::A, ti::C, ti::D>();
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateSpatialSpacetimeIndex.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateSpatialSpacetimeIndex.cpp
@@ -37,25 +37,25 @@ void test_rhs(const DataType& used_for_size,
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
                           SpatialIndex<dim, UpLo::Lo, Frame::Inertial>>>
-      Lai_from_R_ai = tenex::evaluate<ti_a, ti_i>(R(ti_a, ti_i));
+      Lai_from_R_ai = tenex::evaluate<ti::a, ti::i>(R(ti::a, ti::i));
 
   // \f$L_{ia} = R_{ai}\f$
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<dim, UpLo::Lo, Frame::Inertial>,
                           SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
-      Lia_from_R_ai = tenex::evaluate<ti_i, ti_a>(R(ti_a, ti_i));
+      Lia_from_R_ai = tenex::evaluate<ti::i, ti::a>(R(ti::a, ti::i));
 
   // \f$L_{ai} = R_{ia}\f$
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
                           SpatialIndex<dim, UpLo::Lo, Frame::Inertial>>>
-      Lai_from_R_ia = tenex::evaluate<ti_a, ti_i>(R(ti_i, ti_a));
+      Lai_from_R_ia = tenex::evaluate<ti::a, ti::i>(R(ti::i, ti::a));
 
   // \f$L_{ia} = R_{ia}\f$
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<dim, UpLo::Lo, Frame::Inertial>,
                           SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
-      Lia_from_R_ia = tenex::evaluate<ti_i, ti_a>(R(ti_i, ti_a));
+      Lia_from_R_ia = tenex::evaluate<ti::i, ti::a>(R(ti::i, ti::a));
 
   for (size_t a = 0; a < dim + 1; a++) {
     for (size_t i = 0; i < dim; i++) {
@@ -90,14 +90,14 @@ void test_lhs(const DataType& used_for_size,
          index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
                     SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
       Lai_from_R_ai(used_for_size);
-  tenex::evaluate<ti_a, ti_i>(make_not_null(&Lai_from_R_ai), R(ti_a, ti_i));
+  tenex::evaluate<ti::a, ti::i>(make_not_null(&Lai_from_R_ai), R(ti::a, ti::i));
 
   // \f$L_{ia} = R_{ai}\f$
   Tensor<DataType, Symmetry<2, 1>,
          index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
                     SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
       Lia_from_R_ai(used_for_size);
-  tenex::evaluate<ti_i, ti_a>(make_not_null(&Lia_from_R_ai), R(ti_a, ti_i));
+  tenex::evaluate<ti::i, ti::a>(make_not_null(&Lia_from_R_ai), R(ti::a, ti::i));
 
   const auto S = make_with_random_values<
       Tensor<DataType, Symmetry<2, 1>,
@@ -110,14 +110,14 @@ void test_lhs(const DataType& used_for_size,
          index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
                     SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
       Lia_from_S_ia(used_for_size);
-  tenex::evaluate<ti_i, ti_a>(make_not_null(&Lia_from_S_ia), S(ti_i, ti_a));
+  tenex::evaluate<ti::i, ti::a>(make_not_null(&Lia_from_S_ia), S(ti::i, ti::a));
 
   // \f$L_{ai} = S_{ia}\f$
   Tensor<DataType, Symmetry<2, 1>,
          index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
                     SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
       Lai_from_S_ia(used_for_size);
-  tenex::evaluate<ti_a, ti_i>(make_not_null(&Lai_from_S_ia), S(ti_i, ti_a));
+  tenex::evaluate<ti::a, ti::i>(make_not_null(&Lai_from_S_ia), S(ti::i, ti::a));
 
   for (size_t a = 0; a < dim + 1; a++) {
     for (size_t i = 0; i < dim; i++) {
@@ -152,28 +152,28 @@ void test_rhs_and_lhs_rank2(const DataType& used_for_size,
          index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
                     SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
       Lai_from_R_ai(used_for_size);
-  tenex::evaluate<ti_a, ti_i>(make_not_null(&Lai_from_R_ai), R(ti_a, ti_i));
+  tenex::evaluate<ti::a, ti::i>(make_not_null(&Lai_from_R_ai), R(ti::a, ti::i));
 
   // \f$L_{ia} = R_{ai}\f$
   Tensor<DataType, Symmetry<2, 1>,
          index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
                     SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
       Lia_from_R_ai(used_for_size);
-  tenex::evaluate<ti_i, ti_a>(make_not_null(&Lia_from_R_ai), R(ti_a, ti_i));
+  tenex::evaluate<ti::i, ti::a>(make_not_null(&Lia_from_R_ai), R(ti::a, ti::i));
 
   // \f$L_{ai} = R_{ia}\f$
   Tensor<DataType, Symmetry<2, 1>,
          index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
                     SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
       Lai_from_R_ia(used_for_size);
-  tenex::evaluate<ti_a, ti_i>(make_not_null(&Lai_from_R_ia), R(ti_i, ti_a));
+  tenex::evaluate<ti::a, ti::i>(make_not_null(&Lai_from_R_ia), R(ti::i, ti::a));
 
   // \f$L_{ia} = R_{ia}\f$
   Tensor<DataType, Symmetry<2, 1>,
          index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
                     SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
       Lia_from_R_ia(used_for_size);
-  tenex::evaluate<ti_i, ti_a>(make_not_null(&Lia_from_R_ia), R(ti_i, ti_a));
+  tenex::evaluate<ti::i, ti::a>(make_not_null(&Lia_from_R_ia), R(ti::i, ti::a));
 
   for (size_t a = 0; a < dim + 1; a++) {
     for (size_t i = 0; i < dim; i++) {
@@ -212,8 +212,8 @@ void test_rhs_and_lhs_rank4(const DataType& used_for_size,
                     SpacetimeIndex<dim, UpLo::Lo, Frame::Grid>,
                     SpatialIndex<dim, UpLo::Lo, Frame::Grid>>>
       Likaj_from_R_jaik(used_for_size);
-  tenex::evaluate<ti_i, ti_k, ti_a, ti_j>(make_not_null(&Likaj_from_R_jaik),
-                                          R(ti_j, ti_a, ti_i, ti_k));
+  tenex::evaluate<ti::i, ti::k, ti::a, ti::j>(make_not_null(&Likaj_from_R_jaik),
+                                              R(ti::j, ti::a, ti::i, ti::k));
 
   for (size_t i = 0; i < dim; i++) {
     for (size_t k = 0; k < dim; k++) {

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateSpatialSpacetimeIndex.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateSpatialSpacetimeIndex.cpp
@@ -37,25 +37,25 @@ void test_rhs(const DataType& used_for_size,
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
                           SpatialIndex<dim, UpLo::Lo, Frame::Inertial>>>
-      Lai_from_R_ai = TensorExpressions::evaluate<ti_a, ti_i>(R(ti_a, ti_i));
+      Lai_from_R_ai = tenex::evaluate<ti_a, ti_i>(R(ti_a, ti_i));
 
   // \f$L_{ia} = R_{ai}\f$
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<dim, UpLo::Lo, Frame::Inertial>,
                           SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
-      Lia_from_R_ai = TensorExpressions::evaluate<ti_i, ti_a>(R(ti_a, ti_i));
+      Lia_from_R_ai = tenex::evaluate<ti_i, ti_a>(R(ti_a, ti_i));
 
   // \f$L_{ai} = R_{ia}\f$
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
                           SpatialIndex<dim, UpLo::Lo, Frame::Inertial>>>
-      Lai_from_R_ia = TensorExpressions::evaluate<ti_a, ti_i>(R(ti_i, ti_a));
+      Lai_from_R_ia = tenex::evaluate<ti_a, ti_i>(R(ti_i, ti_a));
 
   // \f$L_{ia} = R_{ia}\f$
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<dim, UpLo::Lo, Frame::Inertial>,
                           SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
-      Lia_from_R_ia = TensorExpressions::evaluate<ti_i, ti_a>(R(ti_i, ti_a));
+      Lia_from_R_ia = tenex::evaluate<ti_i, ti_a>(R(ti_i, ti_a));
 
   for (size_t a = 0; a < dim + 1; a++) {
     for (size_t i = 0; i < dim; i++) {
@@ -90,16 +90,14 @@ void test_lhs(const DataType& used_for_size,
          index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
                     SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
       Lai_from_R_ai(used_for_size);
-  TensorExpressions::evaluate<ti_a, ti_i>(make_not_null(&Lai_from_R_ai),
-                                          R(ti_a, ti_i));
+  tenex::evaluate<ti_a, ti_i>(make_not_null(&Lai_from_R_ai), R(ti_a, ti_i));
 
   // \f$L_{ia} = R_{ai}\f$
   Tensor<DataType, Symmetry<2, 1>,
          index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
                     SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
       Lia_from_R_ai(used_for_size);
-  TensorExpressions::evaluate<ti_i, ti_a>(make_not_null(&Lia_from_R_ai),
-                                          R(ti_a, ti_i));
+  tenex::evaluate<ti_i, ti_a>(make_not_null(&Lia_from_R_ai), R(ti_a, ti_i));
 
   const auto S = make_with_random_values<
       Tensor<DataType, Symmetry<2, 1>,
@@ -112,16 +110,14 @@ void test_lhs(const DataType& used_for_size,
          index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
                     SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
       Lia_from_S_ia(used_for_size);
-  TensorExpressions::evaluate<ti_i, ti_a>(make_not_null(&Lia_from_S_ia),
-                                          S(ti_i, ti_a));
+  tenex::evaluate<ti_i, ti_a>(make_not_null(&Lia_from_S_ia), S(ti_i, ti_a));
 
   // \f$L_{ai} = S_{ia}\f$
   Tensor<DataType, Symmetry<2, 1>,
          index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
                     SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
       Lai_from_S_ia(used_for_size);
-  TensorExpressions::evaluate<ti_a, ti_i>(make_not_null(&Lai_from_S_ia),
-                                          S(ti_i, ti_a));
+  tenex::evaluate<ti_a, ti_i>(make_not_null(&Lai_from_S_ia), S(ti_i, ti_a));
 
   for (size_t a = 0; a < dim + 1; a++) {
     for (size_t i = 0; i < dim; i++) {
@@ -156,32 +152,28 @@ void test_rhs_and_lhs_rank2(const DataType& used_for_size,
          index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
                     SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
       Lai_from_R_ai(used_for_size);
-  TensorExpressions::evaluate<ti_a, ti_i>(make_not_null(&Lai_from_R_ai),
-                                          R(ti_a, ti_i));
+  tenex::evaluate<ti_a, ti_i>(make_not_null(&Lai_from_R_ai), R(ti_a, ti_i));
 
   // \f$L_{ia} = R_{ai}\f$
   Tensor<DataType, Symmetry<2, 1>,
          index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
                     SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
       Lia_from_R_ai(used_for_size);
-  TensorExpressions::evaluate<ti_i, ti_a>(make_not_null(&Lia_from_R_ai),
-                                          R(ti_a, ti_i));
+  tenex::evaluate<ti_i, ti_a>(make_not_null(&Lia_from_R_ai), R(ti_a, ti_i));
 
   // \f$L_{ai} = R_{ia}\f$
   Tensor<DataType, Symmetry<2, 1>,
          index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
                     SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
       Lai_from_R_ia(used_for_size);
-  TensorExpressions::evaluate<ti_a, ti_i>(make_not_null(&Lai_from_R_ia),
-                                          R(ti_i, ti_a));
+  tenex::evaluate<ti_a, ti_i>(make_not_null(&Lai_from_R_ia), R(ti_i, ti_a));
 
   // \f$L_{ia} = R_{ia}\f$
   Tensor<DataType, Symmetry<2, 1>,
          index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
                     SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
       Lia_from_R_ia(used_for_size);
-  TensorExpressions::evaluate<ti_i, ti_a>(make_not_null(&Lia_from_R_ia),
-                                          R(ti_i, ti_a));
+  tenex::evaluate<ti_i, ti_a>(make_not_null(&Lia_from_R_ia), R(ti_i, ti_a));
 
   for (size_t a = 0; a < dim + 1; a++) {
     for (size_t i = 0; i < dim; i++) {
@@ -220,8 +212,8 @@ void test_rhs_and_lhs_rank4(const DataType& used_for_size,
                     SpacetimeIndex<dim, UpLo::Lo, Frame::Grid>,
                     SpatialIndex<dim, UpLo::Lo, Frame::Grid>>>
       Likaj_from_R_jaik(used_for_size);
-  TensorExpressions::evaluate<ti_i, ti_k, ti_a, ti_j>(
-      make_not_null(&Likaj_from_R_jaik), R(ti_j, ti_a, ti_i, ti_k));
+  tenex::evaluate<ti_i, ti_k, ti_a, ti_j>(make_not_null(&Likaj_from_R_jaik),
+                                          R(ti_j, ti_a, ti_i, ti_k));
 
   for (size_t i = 0; i < dim; i++) {
     for (size_t k = 0; k < dim; k++) {

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateTimeIndex.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateTimeIndex.cpp
@@ -37,7 +37,7 @@ void test_rhs(const gsl::not_null<Generator*> generator,
   // return type of `evaluate`
   const Tensor<DataType, Symmetry<1>,
                index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
-      La_from_R_at = tenex::evaluate<ti_a>(R(ti_a, ti_t));
+      La_from_R_at = tenex::evaluate<ti::a>(R(ti::a, ti::t));
 
   for (size_t a = 0; a < dim + 1; a++) {
     CHECK(La_from_R_at.get(a) == R.get(a, 0));
@@ -72,7 +72,7 @@ void test_lhs(const gsl::not_null<Generator*> generator,
              index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
                         SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>>(
       used_for_size, spatial_component_placeholder);
-  tenex::evaluate<ti_a, ti_t>(make_not_null(&Lat_from_R_a), R(ti_a));
+  tenex::evaluate<ti::a, ti::t>(make_not_null(&Lat_from_R_a), R(ti::a));
 
   for (size_t a = 0; a < dim + 1; a++) {
     CHECK(Lat_from_R_a.get(a, 0) == R.get(a));
@@ -114,8 +114,8 @@ void test_rhs_and_lhs(const gsl::not_null<Generator*> generator,
                         SpacetimeIndex<dim, UpLo::Lo, Frame::Grid>,
                         SpacetimeIndex<dim, UpLo::Lo, Frame::Grid>>>>(
       used_for_size, spatial_component_placeholder);
-  tenex::evaluate<ti_a, ti_T, ti_t, ti_b>(make_not_null(&LaTtb_from_R_tba),
-                                          R(ti_t, ti_b, ti_a));
+  tenex::evaluate<ti::a, ti::T, ti::t, ti::b>(make_not_null(&LaTtb_from_R_tba),
+                                              R(ti::t, ti::b, ti::a));
 
   for (size_t a = 0; a < dim + 1; a++) {
     for (size_t b = 0; b < dim + 1; b++) {

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateTimeIndex.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateTimeIndex.cpp
@@ -37,7 +37,7 @@ void test_rhs(const gsl::not_null<Generator*> generator,
   // return type of `evaluate`
   const Tensor<DataType, Symmetry<1>,
                index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
-      La_from_R_at = TensorExpressions::evaluate<ti_a>(R(ti_a, ti_t));
+      La_from_R_at = tenex::evaluate<ti_a>(R(ti_a, ti_t));
 
   for (size_t a = 0; a < dim + 1; a++) {
     CHECK(La_from_R_at.get(a) == R.get(a, 0));
@@ -72,8 +72,7 @@ void test_lhs(const gsl::not_null<Generator*> generator,
              index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
                         SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>>(
       used_for_size, spatial_component_placeholder);
-  TensorExpressions::evaluate<ti_a, ti_t>(make_not_null(&Lat_from_R_a),
-                                          R(ti_a));
+  tenex::evaluate<ti_a, ti_t>(make_not_null(&Lat_from_R_a), R(ti_a));
 
   for (size_t a = 0; a < dim + 1; a++) {
     CHECK(Lat_from_R_a.get(a, 0) == R.get(a));
@@ -115,8 +114,8 @@ void test_rhs_and_lhs(const gsl::not_null<Generator*> generator,
                         SpacetimeIndex<dim, UpLo::Lo, Frame::Grid>,
                         SpacetimeIndex<dim, UpLo::Lo, Frame::Grid>>>>(
       used_for_size, spatial_component_placeholder);
-  TensorExpressions::evaluate<ti_a, ti_T, ti_t, ti_b>(
-      make_not_null(&LaTtb_from_R_tba), R(ti_t, ti_b, ti_a));
+  tenex::evaluate<ti_a, ti_T, ti_t, ti_b>(make_not_null(&LaTtb_from_R_tba),
+                                          R(ti_t, ti_b, ti_a));
 
   for (size_t a = 0; a < dim + 1; a++) {
     for (size_t b = 0; b < dim + 1; b++) {

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_MixedOperations.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_MixedOperations.cpp
@@ -126,12 +126,12 @@ void test_case1(const DataType& used_for_size,
   result_tensor_type expected_result_tensor =
       compute_expected_result1(R, S, G, H, T, used_for_size);
   // \f$L_{a} = R_{ab} S^{b} + G_{a} - H_{ba}{}^{b} T\f$
-  result_tensor_type actual_result_tensor_returned = tenex::evaluate<ti_a>(
-      R(ti_a, ti_b) * S(ti_B) + G(ti_a) - H(ti_b, ti_a, ti_B) * T());
+  result_tensor_type actual_result_tensor_returned = tenex::evaluate<ti::a>(
+      R(ti::a, ti::b) * S(ti::B) + G(ti::a) - H(ti::b, ti::a, ti::B) * T());
   result_tensor_type actual_result_tensor_filled{};
-  tenex::evaluate<ti_a>(
+  tenex::evaluate<ti::a>(
       make_not_null(&actual_result_tensor_filled),
-      R(ti_a, ti_b) * S(ti_B) + G(ti_a) - H(ti_b, ti_a, ti_B) * T());
+      R(ti::a, ti::b) * S(ti::B) + G(ti::a) - H(ti::b, ti::a, ti::B) * T());
 
   for (size_t a = 0; a < 4; a++) {
     CHECK_ITERABLE_APPROX(actual_result_tensor_returned.get(a),
@@ -147,9 +147,9 @@ void test_case1(const DataType& used_for_size,
     result_tensor_type& actual_result_tensor_temp =
         get<::Tags::TempTensor<1, result_tensor_type>>(
             actual_result_tensor_temp_var);
-    ::tenex::evaluate<ti_a>(
+    ::tenex::evaluate<ti::a>(
         make_not_null(&actual_result_tensor_temp),
-        R(ti_a, ti_b) * S(ti_B) + G(ti_a) - H(ti_b, ti_a, ti_B) * T());
+        R(ti::a, ti::b) * S(ti::B) + G(ti::a) - H(ti::b, ti::a, ti::B) * T());
 
     for (size_t a = 0; a < 4; a++) {
       CHECK_ITERABLE_APPROX(actual_result_tensor_temp.get(a),
@@ -187,15 +187,15 @@ void test_case2(const DataType& used_for_size,
       compute_expected_result2(spatial_metric, spacetime_metric, used_for_size);
   // \f$\alpha = \sqrt{\gamma^{ij} g_{jt} g_{it} - g_{tt}}\f$
   const Scalar<DataType> actual_result_tensor_returned = tenex::evaluate(
-      sqrt(spatial_metric(ti_I, ti_J) * spacetime_metric(ti_j, ti_t) *
-               spacetime_metric(ti_i, ti_t) -
-           spacetime_metric(ti_t, ti_t)));
+      sqrt(spatial_metric(ti::I, ti::J) * spacetime_metric(ti::j, ti::t) *
+               spacetime_metric(ti::i, ti::t) -
+           spacetime_metric(ti::t, ti::t)));
   Scalar<DataType> actual_result_tensor_filled{};
   tenex::evaluate(
       make_not_null(&actual_result_tensor_filled),
-      sqrt(spatial_metric(ti_I, ti_J) * spacetime_metric(ti_j, ti_t) *
-               spacetime_metric(ti_i, ti_t) -
-           spacetime_metric(ti_t, ti_t)));
+      sqrt(spatial_metric(ti::I, ti::J) * spacetime_metric(ti::j, ti::t) *
+               spacetime_metric(ti::i, ti::t) -
+           spacetime_metric(ti::t, ti::t)));
 
   CHECK_ITERABLE_APPROX(actual_result_tensor_returned.get(),
                         expected_result_tensor.get());
@@ -209,9 +209,9 @@ void test_case2(const DataType& used_for_size,
             actual_result_tensor_temp_var);
     ::tenex::evaluate(
         make_not_null(&actual_result_tensor_temp),
-        sqrt(spatial_metric(ti_I, ti_J) * spacetime_metric(ti_j, ti_t) *
-                 spacetime_metric(ti_i, ti_t) -
-             spacetime_metric(ti_t, ti_t)));
+        sqrt(spatial_metric(ti::I, ti::J) * spacetime_metric(ti::j, ti::t) *
+                 spacetime_metric(ti::i, ti::t) -
+             spacetime_metric(ti::t, ti::t)));
 
     CHECK_ITERABLE_APPROX(actual_result_tensor_temp.get(),
                           expected_result_tensor.get());
@@ -249,12 +249,13 @@ void test_case3(const DataType& used_for_size,
       compute_expected_result3(alpha, beta, pi, phi, used_for_size);
   result_tensor_type actual_result_tensor_filled{};
   // \f$\partial_t g_{ab} = -\alpha \Pi_{ab} + \beta^i \Phi_{iab}\f$
-  tenex::evaluate<ti_t, ti_a, ti_b>(
+  tenex::evaluate<ti::t, ti::a, ti::b>(
       make_not_null(&actual_result_tensor_filled),
-      -1.0 * alpha() * pi(ti_a, ti_b) + beta(ti_I) * phi(ti_i, ti_a, ti_b));
+      -1.0 * alpha() * pi(ti::a, ti::b) +
+          beta(ti::I) * phi(ti::i, ti::a, ti::b));
   // \f$\partial_i g_{ab} = \Phi_{iab}\f$
-  tenex::evaluate<ti_i, ti_a, ti_b>(make_not_null(&actual_result_tensor_filled),
-                                    phi(ti_i, ti_a, ti_b));
+  tenex::evaluate<ti::i, ti::a, ti::b>(
+      make_not_null(&actual_result_tensor_filled), phi(ti::i, ti::a, ti::b));
 
   for (size_t c = 0; c < 4; c++) {
     for (size_t a = 0; a < 4; a++) {
@@ -272,11 +273,12 @@ void test_case3(const DataType& used_for_size,
     result_tensor_type& actual_result_tensor_temp =
         get<::Tags::TempTensor<1, result_tensor_type>>(
             actual_result_tensor_temp_var);
-    tenex::evaluate<ti_t, ti_a, ti_b>(
+    tenex::evaluate<ti::t, ti::a, ti::b>(
         make_not_null(&actual_result_tensor_temp),
-        -1.0 * alpha() * pi(ti_a, ti_b) + beta(ti_I) * phi(ti_i, ti_a, ti_b));
-    tenex::evaluate<ti_i, ti_a, ti_b>(make_not_null(&actual_result_tensor_temp),
-                                      phi(ti_i, ti_a, ti_b));
+        -1.0 * alpha() * pi(ti::a, ti::b) +
+            beta(ti::I) * phi(ti::i, ti::a, ti::b));
+    tenex::evaluate<ti::i, ti::a, ti::b>(
+        make_not_null(&actual_result_tensor_temp), phi(ti::i, ti::a, ti::b));
 
     for (size_t c = 0; c < 4; c++) {
       for (size_t a = 0; a < 4; a++) {

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_MixedOperations.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_MixedOperations.cpp
@@ -126,11 +126,10 @@ void test_case1(const DataType& used_for_size,
   result_tensor_type expected_result_tensor =
       compute_expected_result1(R, S, G, H, T, used_for_size);
   // \f$L_{a} = R_{ab} S^{b} + G_{a} - H_{ba}{}^{b} T\f$
-  result_tensor_type actual_result_tensor_returned =
-      TensorExpressions::evaluate<ti_a>(R(ti_a, ti_b) * S(ti_B) + G(ti_a) -
-                                        H(ti_b, ti_a, ti_B) * T());
+  result_tensor_type actual_result_tensor_returned = tenex::evaluate<ti_a>(
+      R(ti_a, ti_b) * S(ti_B) + G(ti_a) - H(ti_b, ti_a, ti_B) * T());
   result_tensor_type actual_result_tensor_filled{};
-  TensorExpressions::evaluate<ti_a>(
+  tenex::evaluate<ti_a>(
       make_not_null(&actual_result_tensor_filled),
       R(ti_a, ti_b) * S(ti_B) + G(ti_a) - H(ti_b, ti_a, ti_B) * T());
 
@@ -148,7 +147,7 @@ void test_case1(const DataType& used_for_size,
     result_tensor_type& actual_result_tensor_temp =
         get<::Tags::TempTensor<1, result_tensor_type>>(
             actual_result_tensor_temp_var);
-    ::TensorExpressions::evaluate<ti_a>(
+    ::tenex::evaluate<ti_a>(
         make_not_null(&actual_result_tensor_temp),
         R(ti_a, ti_b) * S(ti_B) + G(ti_a) - H(ti_b, ti_a, ti_B) * T());
 
@@ -187,13 +186,12 @@ void test_case2(const DataType& used_for_size,
   const Scalar<DataType> expected_result_tensor =
       compute_expected_result2(spatial_metric, spacetime_metric, used_for_size);
   // \f$\alpha = \sqrt{\gamma^{ij} g_{jt} g_{it} - g_{tt}}\f$
-  const Scalar<DataType> actual_result_tensor_returned =
-      TensorExpressions::evaluate(
-          sqrt(spatial_metric(ti_I, ti_J) * spacetime_metric(ti_j, ti_t) *
-                   spacetime_metric(ti_i, ti_t) -
-               spacetime_metric(ti_t, ti_t)));
+  const Scalar<DataType> actual_result_tensor_returned = tenex::evaluate(
+      sqrt(spatial_metric(ti_I, ti_J) * spacetime_metric(ti_j, ti_t) *
+               spacetime_metric(ti_i, ti_t) -
+           spacetime_metric(ti_t, ti_t)));
   Scalar<DataType> actual_result_tensor_filled{};
-  TensorExpressions::evaluate(
+  tenex::evaluate(
       make_not_null(&actual_result_tensor_filled),
       sqrt(spatial_metric(ti_I, ti_J) * spacetime_metric(ti_j, ti_t) *
                spacetime_metric(ti_i, ti_t) -
@@ -209,7 +207,7 @@ void test_case2(const DataType& used_for_size,
     Scalar<DataType>& actual_result_tensor_temp =
         get<::Tags::TempTensor<1, Tensor<DataType>>>(
             actual_result_tensor_temp_var);
-    ::TensorExpressions::evaluate(
+    ::tenex::evaluate(
         make_not_null(&actual_result_tensor_temp),
         sqrt(spatial_metric(ti_I, ti_J) * spacetime_metric(ti_j, ti_t) *
                  spacetime_metric(ti_i, ti_t) -
@@ -251,12 +249,12 @@ void test_case3(const DataType& used_for_size,
       compute_expected_result3(alpha, beta, pi, phi, used_for_size);
   result_tensor_type actual_result_tensor_filled{};
   // \f$\partial_t g_{ab} = -\alpha \Pi_{ab} + \beta^i \Phi_{iab}\f$
-  TensorExpressions::evaluate<ti_t, ti_a, ti_b>(
+  tenex::evaluate<ti_t, ti_a, ti_b>(
       make_not_null(&actual_result_tensor_filled),
       -1.0 * alpha() * pi(ti_a, ti_b) + beta(ti_I) * phi(ti_i, ti_a, ti_b));
   // \f$\partial_i g_{ab} = \Phi_{iab}\f$
-  TensorExpressions::evaluate<ti_i, ti_a, ti_b>(
-      make_not_null(&actual_result_tensor_filled), phi(ti_i, ti_a, ti_b));
+  tenex::evaluate<ti_i, ti_a, ti_b>(make_not_null(&actual_result_tensor_filled),
+                                    phi(ti_i, ti_a, ti_b));
 
   for (size_t c = 0; c < 4; c++) {
     for (size_t a = 0; a < 4; a++) {
@@ -274,11 +272,11 @@ void test_case3(const DataType& used_for_size,
     result_tensor_type& actual_result_tensor_temp =
         get<::Tags::TempTensor<1, result_tensor_type>>(
             actual_result_tensor_temp_var);
-    TensorExpressions::evaluate<ti_t, ti_a, ti_b>(
+    tenex::evaluate<ti_t, ti_a, ti_b>(
         make_not_null(&actual_result_tensor_temp),
         -1.0 * alpha() * pi(ti_a, ti_b) + beta(ti_I) * phi(ti_i, ti_a, ti_b));
-    TensorExpressions::evaluate<ti_i, ti_a, ti_b>(
-        make_not_null(&actual_result_tensor_temp), phi(ti_i, ti_a, ti_b));
+    tenex::evaluate<ti_i, ti_a, ti_b>(make_not_null(&actual_result_tensor_temp),
+                                      phi(ti_i, ti_a, ti_b));
 
     for (size_t c = 0; c < 4; c++) {
       for (size_t a = 0; a < 4; a++) {

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Negate.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Negate.cpp
@@ -41,12 +41,10 @@ void test_negate(const gsl::not_null<Generator*> generator,
                index_list<SpatialIndex<dim, UpLo::Lo, Frame::Inertial>,
                           SpatialIndex<dim, UpLo::Lo, Frame::Inertial>,
                           SpatialIndex<dim, UpLo::Up, Frame::Inertial>>>
-      result1 =
-          TensorExpressions::evaluate<ti_j, ti_i, ti_K>(-R(ti_K, ti_j, ti_i));
+      result1 = tenex::evaluate<ti_j, ti_i, ti_K>(-R(ti_K, ti_j, ti_i));
   // \f$L^{i}{}_{kj} = -(R^{i}_{kj} + S^{i}_{kj})\f$
-  const tnsr::Ijj<DataType, dim> result2 =
-      TensorExpressions::evaluate<ti_I, ti_k, ti_j>(
-          -(R(ti_I, ti_k, ti_j) + S(ti_I, ti_k, ti_j)));
+  const tnsr::Ijj<DataType, dim> result2 = tenex::evaluate<ti_I, ti_k, ti_j>(
+      -(R(ti_I, ti_k, ti_j) + S(ti_I, ti_k, ti_j)));
 
   for (size_t i = 0; i < dim; i++) {
     for (size_t j = 0; j < dim; j++) {

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Negate.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Negate.cpp
@@ -41,10 +41,10 @@ void test_negate(const gsl::not_null<Generator*> generator,
                index_list<SpatialIndex<dim, UpLo::Lo, Frame::Inertial>,
                           SpatialIndex<dim, UpLo::Lo, Frame::Inertial>,
                           SpatialIndex<dim, UpLo::Up, Frame::Inertial>>>
-      result1 = tenex::evaluate<ti_j, ti_i, ti_K>(-R(ti_K, ti_j, ti_i));
+      result1 = tenex::evaluate<ti::j, ti::i, ti::K>(-R(ti::K, ti::j, ti::i));
   // \f$L^{i}{}_{kj} = -(R^{i}_{kj} + S^{i}_{kj})\f$
-  const tnsr::Ijj<DataType, dim> result2 = tenex::evaluate<ti_I, ti_k, ti_j>(
-      -(R(ti_I, ti_k, ti_j) + S(ti_I, ti_k, ti_j)));
+  const tnsr::Ijj<DataType, dim> result2 = tenex::evaluate<ti::I, ti::k, ti::j>(
+      -(R(ti::I, ti::k, ti::j) + S(ti::I, ti::k, ti::j)));
 
   for (size_t i = 0; i < dim; i++) {
     for (size_t j = 0; j < dim; j++) {

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Product.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Product.cpp
@@ -66,13 +66,13 @@ void test_outer_product_double(const DataType& used_for_size) {
   // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
   // return type of `evaluate`
   const tensor_type Lij_from_R_Sij =
-      TensorExpressions::evaluate<ti_i, ti_j>(5.6 * S(ti_i, ti_j));
+      tenex::evaluate<ti_i, ti_j>(5.6 * S(ti_i, ti_j));
   // \f$L_{ij} = S_{ij} * R\f$
   const tensor_type Lij_from_Sij_R =
-      TensorExpressions::evaluate<ti_i, ti_j>(S(ti_i, ti_j) * -8.1);
+      tenex::evaluate<ti_i, ti_j>(S(ti_i, ti_j) * -8.1);
   // \f$L_{ij} = R * S_{ij} * T\f$
   const tensor_type Lij_from_R_Sij_T =
-      TensorExpressions::evaluate<ti_i, ti_j>(-1.7 * S(ti_i, ti_j) * 0.6);
+      tenex::evaluate<ti_i, ti_j>(-1.7 * S(ti_i, ti_j) * 0.6);
 
   for (size_t i = 0; i < dim; i++) {
     for (size_t j = 0; j < dim; j++) {
@@ -108,10 +108,9 @@ void test_outer_product_rank_0_operand(const DataType& used_for_size) {
   }
 
   // \f$L = R * R\f$
-  CHECK(TensorExpressions::evaluate(R() * R()).get() == R.get() * R.get());
+  CHECK(tenex::evaluate(R() * R()).get() == R.get() * R.get());
   // \f$L = R * R * R\f$
-  CHECK(TensorExpressions::evaluate(R() * R() * R()).get() ==
-        R.get() * R.get() * R.get());
+  CHECK(tenex::evaluate(R() * R() * R()).get() == R.get() * R.get() * R.get());
 
   Tensor<DataType, Symmetry<1>,
          index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>>
@@ -121,11 +120,9 @@ void test_outer_product_rank_0_operand(const DataType& used_for_size) {
   // \f$L^{a} = R * S^{a}\f$
   // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
   // return type of `evaluate`
-  const decltype(Su) LA_from_R_SA =
-      TensorExpressions::evaluate<ti_A>(R() * Su(ti_A));
+  const decltype(Su) LA_from_R_SA = tenex::evaluate<ti_A>(R() * Su(ti_A));
   // \f$L^{a} = S^{a} * R\f$
-  const decltype(Su) LA_from_SA_R =
-      TensorExpressions::evaluate<ti_A>(Su(ti_A) * R());
+  const decltype(Su) LA_from_SA_R = tenex::evaluate<ti_A>(Su(ti_A) * R());
 
   for (size_t a = 0; a < 4; a++) {
     CHECK(LA_from_R_SA.get(a) == R.get() * Su.get(a));
@@ -142,26 +139,22 @@ void test_outer_product_rank_0_operand(const DataType& used_for_size) {
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
                           SpatialIndex<4, UpLo::Lo, Frame::Inertial>>>
-      Lai_from_R_Tai =
-          TensorExpressions::evaluate<ti_a, ti_i>(R() * Tll(ti_a, ti_i));
+      Lai_from_R_Tai = tenex::evaluate<ti_a, ti_i>(R() * Tll(ti_a, ti_i));
   // \f$L_{ia} = R * T_{ai}\f$
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<4, UpLo::Lo, Frame::Inertial>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>
-      Lia_from_R_Tai =
-          TensorExpressions::evaluate<ti_i, ti_a>(R() * Tll(ti_a, ti_i));
+      Lia_from_R_Tai = tenex::evaluate<ti_i, ti_a>(R() * Tll(ti_a, ti_i));
   // \f$L_{ai} = T_{ai} * R\f$
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
                           SpatialIndex<4, UpLo::Lo, Frame::Inertial>>>
-      Lai_from_Tai_R =
-          TensorExpressions::evaluate<ti_a, ti_i>(Tll(ti_a, ti_i) * R());
+      Lai_from_Tai_R = tenex::evaluate<ti_a, ti_i>(Tll(ti_a, ti_i) * R());
   // \f$L_{ia} = T_{ai} * R\f$
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<4, UpLo::Lo, Frame::Inertial>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>
-      Lia_from_Tai_R =
-          TensorExpressions::evaluate<ti_i, ti_a>(Tll(ti_a, ti_i) * R());
+      Lia_from_Tai_R = tenex::evaluate<ti_i, ti_a>(Tll(ti_a, ti_i) * R());
 
   for (size_t a = 0; a < 4; a++) {
     for (size_t i = 0; i < 4; i++) {
@@ -208,8 +201,7 @@ void test_outer_product_rank_1_operand(const DataType& used_for_size) {
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                           SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
-      LAi_from_Ri_SA =
-          TensorExpressions::evaluate<ti_A, ti_i>(Rl(ti_i) * Su(ti_A));
+      LAi_from_Ri_SA = tenex::evaluate<ti_A, ti_i>(Rl(ti_i) * Su(ti_A));
 
   for (size_t i = 0; i < 3; i++) {
     for (size_t a = 0; a < 4; a++) {
@@ -227,8 +219,8 @@ void test_outer_product_rank_1_operand(const DataType& used_for_size) {
                index_list<SpatialIndex<3, UpLo::Up, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                           SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
-      LJAi_from_Ri_SA_TJ = TensorExpressions::evaluate<ti_J, ti_A, ti_i>(
-          Rl(ti_i) * Su(ti_A) * Tu(ti_J));
+      LJAi_from_Ri_SA_TJ =
+          tenex::evaluate<ti_J, ti_A, ti_i>(Rl(ti_i) * Su(ti_A) * Tu(ti_J));
 
   for (size_t j = 0; j < 3; j++) {
     for (size_t a = 0; a < 4; a++) {
@@ -250,15 +242,15 @@ void test_outer_product_rank_1_operand(const DataType& used_for_size) {
                index_list<SpatialIndex<4, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      LkCd_from_SC_Gdk = TensorExpressions::evaluate<ti_k, ti_C, ti_d>(
-          Su(ti_C) * Gll(ti_d, ti_k));
+      LkCd_from_SC_Gdk =
+          tenex::evaluate<ti_k, ti_C, ti_d>(Su(ti_C) * Gll(ti_d, ti_k));
   // \f$L^{c}{}_{dk} = G_{dk} * S^{c}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpatialIndex<4, UpLo::Lo, Frame::Grid>>>
-      LCdk_from_Gdk_SC = TensorExpressions::evaluate<ti_C, ti_d, ti_k>(
-          Gll(ti_d, ti_k) * Su(ti_C));
+      LCdk_from_Gdk_SC =
+          tenex::evaluate<ti_C, ti_d, ti_k>(Gll(ti_d, ti_k) * Su(ti_C));
 
   for (size_t k = 0; k < 4; k++) {
     for (size_t c = 0; c < 4; c++) {
@@ -294,103 +286,103 @@ void test_outer_product_rank_2x2_operands(const DataType& used_for_size) {
   // return type of `evaluate`
   const Tensor<DataType, Symmetry<3, 3, 2, 1>,
                index_list<R_index, R_index, S_first_index, S_second_index>>
-      L_abIc = TensorExpressions::evaluate<ti_a, ti_b, ti_I, ti_c>(
-          Rll(ti_a, ti_b) * Sul(ti_I, ti_c));
+      L_abIc = tenex::evaluate<ti_a, ti_b, ti_I, ti_c>(Rll(ti_a, ti_b) *
+                                                       Sul(ti_I, ti_c));
   const Tensor<DataType, Symmetry<3, 3, 2, 1>,
                index_list<R_index, R_index, S_second_index, S_first_index>>
-      L_abcI = TensorExpressions::evaluate<ti_a, ti_b, ti_c, ti_I>(
-          Rll(ti_a, ti_b) * Sul(ti_I, ti_c));
+      L_abcI = tenex::evaluate<ti_a, ti_b, ti_c, ti_I>(Rll(ti_a, ti_b) *
+                                                       Sul(ti_I, ti_c));
   const Tensor<DataType, Symmetry<3, 2, 3, 1>,
                index_list<R_index, S_first_index, R_index, S_second_index>>
-      L_aIbc = TensorExpressions::evaluate<ti_a, ti_I, ti_b, ti_c>(
-          Rll(ti_a, ti_b) * Sul(ti_I, ti_c));
+      L_aIbc = tenex::evaluate<ti_a, ti_I, ti_b, ti_c>(Rll(ti_a, ti_b) *
+                                                       Sul(ti_I, ti_c));
   const Tensor<DataType, Symmetry<3, 2, 1, 3>,
                index_list<R_index, S_first_index, S_second_index, R_index>>
-      L_aIcb = TensorExpressions::evaluate<ti_a, ti_I, ti_c, ti_b>(
-          Rll(ti_a, ti_b) * Sul(ti_I, ti_c));
+      L_aIcb = tenex::evaluate<ti_a, ti_I, ti_c, ti_b>(Rll(ti_a, ti_b) *
+                                                       Sul(ti_I, ti_c));
   const Tensor<DataType, Symmetry<3, 2, 3, 1>,
                index_list<R_index, S_second_index, R_index, S_first_index>>
-      L_acbI = TensorExpressions::evaluate<ti_a, ti_c, ti_b, ti_I>(
-          Rll(ti_a, ti_b) * Sul(ti_I, ti_c));
+      L_acbI = tenex::evaluate<ti_a, ti_c, ti_b, ti_I>(Rll(ti_a, ti_b) *
+                                                       Sul(ti_I, ti_c));
   const Tensor<DataType, Symmetry<3, 2, 1, 3>,
                index_list<R_index, S_second_index, S_first_index, R_index>>
-      L_acIb = TensorExpressions::evaluate<ti_a, ti_c, ti_I, ti_b>(
-          Rll(ti_a, ti_b) * Sul(ti_I, ti_c));
+      L_acIb = tenex::evaluate<ti_a, ti_c, ti_I, ti_b>(Rll(ti_a, ti_b) *
+                                                       Sul(ti_I, ti_c));
 
   const Tensor<DataType, Symmetry<3, 3, 2, 1>,
                index_list<R_index, R_index, S_first_index, S_second_index>>
-      L_baIc = TensorExpressions::evaluate<ti_b, ti_a, ti_I, ti_c>(
-          Rll(ti_a, ti_b) * Sul(ti_I, ti_c));
+      L_baIc = tenex::evaluate<ti_b, ti_a, ti_I, ti_c>(Rll(ti_a, ti_b) *
+                                                       Sul(ti_I, ti_c));
   const Tensor<DataType, Symmetry<3, 3, 2, 1>,
                index_list<R_index, R_index, S_second_index, S_first_index>>
-      L_bacI = TensorExpressions::evaluate<ti_b, ti_a, ti_c, ti_I>(
-          Rll(ti_a, ti_b) * Sul(ti_I, ti_c));
+      L_bacI = tenex::evaluate<ti_b, ti_a, ti_c, ti_I>(Rll(ti_a, ti_b) *
+                                                       Sul(ti_I, ti_c));
   const Tensor<DataType, Symmetry<3, 2, 3, 1>,
                index_list<R_index, S_first_index, R_index, S_second_index>>
-      L_bIac = TensorExpressions::evaluate<ti_b, ti_I, ti_a, ti_c>(
-          Rll(ti_a, ti_b) * Sul(ti_I, ti_c));
+      L_bIac = tenex::evaluate<ti_b, ti_I, ti_a, ti_c>(Rll(ti_a, ti_b) *
+                                                       Sul(ti_I, ti_c));
   const Tensor<DataType, Symmetry<3, 2, 1, 3>,
                index_list<R_index, S_first_index, S_second_index, R_index>>
-      L_bIca = TensorExpressions::evaluate<ti_b, ti_I, ti_c, ti_a>(
-          Rll(ti_a, ti_b) * Sul(ti_I, ti_c));
+      L_bIca = tenex::evaluate<ti_b, ti_I, ti_c, ti_a>(Rll(ti_a, ti_b) *
+                                                       Sul(ti_I, ti_c));
   const Tensor<DataType, Symmetry<3, 2, 3, 1>,
                index_list<R_index, S_second_index, R_index, S_first_index>>
-      L_bcaI = TensorExpressions::evaluate<ti_b, ti_c, ti_a, ti_I>(
-          Rll(ti_a, ti_b) * Sul(ti_I, ti_c));
+      L_bcaI = tenex::evaluate<ti_b, ti_c, ti_a, ti_I>(Rll(ti_a, ti_b) *
+                                                       Sul(ti_I, ti_c));
   const Tensor<DataType, Symmetry<3, 2, 1, 3>,
                index_list<R_index, S_second_index, S_first_index, R_index>>
-      L_bcIa = TensorExpressions::evaluate<ti_b, ti_c, ti_I, ti_a>(
-          Rll(ti_a, ti_b) * Sul(ti_I, ti_c));
+      L_bcIa = tenex::evaluate<ti_b, ti_c, ti_I, ti_a>(Rll(ti_a, ti_b) *
+                                                       Sul(ti_I, ti_c));
 
   const Tensor<DataType, Symmetry<3, 2, 2, 1>,
                index_list<S_first_index, R_index, R_index, S_second_index>>
-      L_Iabc = TensorExpressions::evaluate<ti_I, ti_a, ti_b, ti_c>(
-          Rll(ti_a, ti_b) * Sul(ti_I, ti_c));
+      L_Iabc = tenex::evaluate<ti_I, ti_a, ti_b, ti_c>(Rll(ti_a, ti_b) *
+                                                       Sul(ti_I, ti_c));
   const Tensor<DataType, Symmetry<3, 2, 1, 2>,
                index_list<S_first_index, R_index, S_second_index, R_index>>
-      L_Iacb = TensorExpressions::evaluate<ti_I, ti_a, ti_c, ti_b>(
-          Rll(ti_a, ti_b) * Sul(ti_I, ti_c));
+      L_Iacb = tenex::evaluate<ti_I, ti_a, ti_c, ti_b>(Rll(ti_a, ti_b) *
+                                                       Sul(ti_I, ti_c));
   const Tensor<DataType, Symmetry<3, 2, 2, 1>,
                index_list<S_first_index, R_index, R_index, S_second_index>>
-      L_Ibac = TensorExpressions::evaluate<ti_I, ti_b, ti_a, ti_c>(
-          Rll(ti_a, ti_b) * Sul(ti_I, ti_c));
+      L_Ibac = tenex::evaluate<ti_I, ti_b, ti_a, ti_c>(Rll(ti_a, ti_b) *
+                                                       Sul(ti_I, ti_c));
   const Tensor<DataType, Symmetry<3, 2, 1, 2>,
                index_list<S_first_index, R_index, S_second_index, R_index>>
-      L_Ibca = TensorExpressions::evaluate<ti_I, ti_b, ti_c, ti_a>(
-          Rll(ti_a, ti_b) * Sul(ti_I, ti_c));
+      L_Ibca = tenex::evaluate<ti_I, ti_b, ti_c, ti_a>(Rll(ti_a, ti_b) *
+                                                       Sul(ti_I, ti_c));
   const Tensor<DataType, Symmetry<3, 2, 1, 1>,
                index_list<S_first_index, S_second_index, R_index, R_index>>
-      L_Icab = TensorExpressions::evaluate<ti_I, ti_c, ti_a, ti_b>(
-          Rll(ti_a, ti_b) * Sul(ti_I, ti_c));
+      L_Icab = tenex::evaluate<ti_I, ti_c, ti_a, ti_b>(Rll(ti_a, ti_b) *
+                                                       Sul(ti_I, ti_c));
   const Tensor<DataType, Symmetry<3, 2, 1, 1>,
                index_list<S_first_index, S_second_index, R_index, R_index>>
-      L_Icba = TensorExpressions::evaluate<ti_I, ti_c, ti_b, ti_a>(
-          Rll(ti_a, ti_b) * Sul(ti_I, ti_c));
+      L_Icba = tenex::evaluate<ti_I, ti_c, ti_b, ti_a>(Rll(ti_a, ti_b) *
+                                                       Sul(ti_I, ti_c));
 
   const Tensor<DataType, Symmetry<3, 2, 2, 1>,
                index_list<S_second_index, R_index, R_index, S_first_index>>
-      L_cabI = TensorExpressions::evaluate<ti_c, ti_a, ti_b, ti_I>(
-          Rll(ti_a, ti_b) * Sul(ti_I, ti_c));
+      L_cabI = tenex::evaluate<ti_c, ti_a, ti_b, ti_I>(Rll(ti_a, ti_b) *
+                                                       Sul(ti_I, ti_c));
   const Tensor<DataType, Symmetry<3, 2, 1, 2>,
                index_list<S_second_index, R_index, S_first_index, R_index>>
-      L_caIb = TensorExpressions::evaluate<ti_c, ti_a, ti_I, ti_b>(
-          Rll(ti_a, ti_b) * Sul(ti_I, ti_c));
+      L_caIb = tenex::evaluate<ti_c, ti_a, ti_I, ti_b>(Rll(ti_a, ti_b) *
+                                                       Sul(ti_I, ti_c));
   const Tensor<DataType, Symmetry<3, 2, 2, 1>,
                index_list<S_second_index, R_index, R_index, S_first_index>>
-      L_cbaI = TensorExpressions::evaluate<ti_c, ti_b, ti_a, ti_I>(
-          Rll(ti_a, ti_b) * Sul(ti_I, ti_c));
+      L_cbaI = tenex::evaluate<ti_c, ti_b, ti_a, ti_I>(Rll(ti_a, ti_b) *
+                                                       Sul(ti_I, ti_c));
   const Tensor<DataType, Symmetry<3, 2, 1, 2>,
                index_list<S_second_index, R_index, S_first_index, R_index>>
-      L_cbIa = TensorExpressions::evaluate<ti_c, ti_b, ti_I, ti_a>(
-          Rll(ti_a, ti_b) * Sul(ti_I, ti_c));
+      L_cbIa = tenex::evaluate<ti_c, ti_b, ti_I, ti_a>(Rll(ti_a, ti_b) *
+                                                       Sul(ti_I, ti_c));
   const Tensor<DataType, Symmetry<3, 2, 1, 1>,
                index_list<S_second_index, S_first_index, R_index, R_index>>
-      L_cIab = TensorExpressions::evaluate<ti_c, ti_I, ti_a, ti_b>(
-          Rll(ti_a, ti_b) * Sul(ti_I, ti_c));
+      L_cIab = tenex::evaluate<ti_c, ti_I, ti_a, ti_b>(Rll(ti_a, ti_b) *
+                                                       Sul(ti_I, ti_c));
   const Tensor<DataType, Symmetry<3, 2, 1, 1>,
                index_list<S_second_index, S_first_index, R_index, R_index>>
-      L_cIba = TensorExpressions::evaluate<ti_c, ti_I, ti_b, ti_a>(
-          Rll(ti_a, ti_b) * Sul(ti_I, ti_c));
+      L_cIba = tenex::evaluate<ti_c, ti_I, ti_b, ti_a>(Rll(ti_a, ti_b) *
+                                                       Sul(ti_I, ti_c));
 
   for (size_t a = 0; a < R_index::dim; a++) {
     for (size_t b = 0; b < R_index::dim; b++) {
@@ -467,198 +459,162 @@ void test_outer_product_rank_0x1x2_operands(const DataType& used_for_size) {
   // return type of `evaluate`
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<S_index, T_first_index, T_second_index>>
-      LAbi_from_R_SA_Tbi =
-          TensorExpressions::evaluate<ti_A, ti_b, ti_i>(R_SA_Tbi_expr);
+      LAbi_from_R_SA_Tbi = tenex::evaluate<ti_A, ti_b, ti_i>(R_SA_Tbi_expr);
   // \f$L^{a}{}_{ib} = R * S^{a} * T_{bi}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<S_index, T_second_index, T_first_index>>
-      LAib_from_R_SA_Tbi =
-          TensorExpressions::evaluate<ti_A, ti_i, ti_b>(R_SA_Tbi_expr);
+      LAib_from_R_SA_Tbi = tenex::evaluate<ti_A, ti_i, ti_b>(R_SA_Tbi_expr);
   // \f$L_{b}{}^{a}{}_{i} = R * S^{a} * T_{bi}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_first_index, S_index, T_second_index>>
-      LbAi_from_R_SA_Tbi =
-          TensorExpressions::evaluate<ti_b, ti_A, ti_i>(R_SA_Tbi_expr);
+      LbAi_from_R_SA_Tbi = tenex::evaluate<ti_b, ti_A, ti_i>(R_SA_Tbi_expr);
   // \f$L_{bi}{}^{a} = R * S^{a} * T_{bi}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_first_index, T_second_index, S_index>>
-      LbiA_from_R_SA_Tbi =
-          TensorExpressions::evaluate<ti_b, ti_i, ti_A>(R_SA_Tbi_expr);
+      LbiA_from_R_SA_Tbi = tenex::evaluate<ti_b, ti_i, ti_A>(R_SA_Tbi_expr);
   // \f$L_{i}{}^{a}{}_{b} = R * S^{a} * T_{bi}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_second_index, S_index, T_first_index>>
-      LiAb_from_R_SA_Tbi =
-          TensorExpressions::evaluate<ti_i, ti_A, ti_b>(R_SA_Tbi_expr);
+      LiAb_from_R_SA_Tbi = tenex::evaluate<ti_i, ti_A, ti_b>(R_SA_Tbi_expr);
   // \f$L_{ib}{}^{a} = R * S^{a} * T_{bi}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_second_index, T_first_index, S_index>>
-      LibA_from_R_SA_Tbi =
-          TensorExpressions::evaluate<ti_i, ti_b, ti_A>(R_SA_Tbi_expr);
+      LibA_from_R_SA_Tbi = tenex::evaluate<ti_i, ti_b, ti_A>(R_SA_Tbi_expr);
 
   // \f$R * T_{bi} * S^{a}\f$
   const auto R_Tbi_SA_expr = R() * Tll(ti_b, ti_i) * Su(ti_A);
   // \f$L^{a}{}_{bi} = R * T_{bi} * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<S_index, T_first_index, T_second_index>>
-      LAbi_from_R_Tbi_SA =
-          TensorExpressions::evaluate<ti_A, ti_b, ti_i>(R_Tbi_SA_expr);
+      LAbi_from_R_Tbi_SA = tenex::evaluate<ti_A, ti_b, ti_i>(R_Tbi_SA_expr);
   // \f$L^{a}{}_{ib} = R * T_{bi} * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<S_index, T_second_index, T_first_index>>
-      LAib_from_R_Tbi_SA =
-          TensorExpressions::evaluate<ti_A, ti_i, ti_b>(R_Tbi_SA_expr);
+      LAib_from_R_Tbi_SA = tenex::evaluate<ti_A, ti_i, ti_b>(R_Tbi_SA_expr);
   // \f$L_{b}{}^{a}{}_{i} = R * T_{bi} * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_first_index, S_index, T_second_index>>
-      LbAi_from_R_Tbi_SA =
-          TensorExpressions::evaluate<ti_b, ti_A, ti_i>(R_Tbi_SA_expr);
+      LbAi_from_R_Tbi_SA = tenex::evaluate<ti_b, ti_A, ti_i>(R_Tbi_SA_expr);
   // \f$L_{bi}{}^{a} = R * R * T_{bi} * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_first_index, T_second_index, S_index>>
-      LbiA_from_R_Tbi_SA =
-          TensorExpressions::evaluate<ti_b, ti_i, ti_A>(R_Tbi_SA_expr);
+      LbiA_from_R_Tbi_SA = tenex::evaluate<ti_b, ti_i, ti_A>(R_Tbi_SA_expr);
   // \f$L_{i}{}^{a}{}_{b} = R * T_{bi} * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_second_index, S_index, T_first_index>>
-      LiAb_from_R_Tbi_SA =
-          TensorExpressions::evaluate<ti_i, ti_A, ti_b>(R_Tbi_SA_expr);
+      LiAb_from_R_Tbi_SA = tenex::evaluate<ti_i, ti_A, ti_b>(R_Tbi_SA_expr);
   // \f$L_{ib}{}^{a} = R * T_{bi} * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_second_index, T_first_index, S_index>>
-      LibA_from_R_Tbi_SA =
-          TensorExpressions::evaluate<ti_i, ti_b, ti_A>(R_Tbi_SA_expr);
+      LibA_from_R_Tbi_SA = tenex::evaluate<ti_i, ti_b, ti_A>(R_Tbi_SA_expr);
 
   // \f$S^{a} * R * T_{bi}\f$
   const auto SA_R_Tbi_expr = Su(ti_A) * R() * Tll(ti_b, ti_i);
   // \f$L^{a}{}_{bi} = S^{a} * R * T_{bi}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<S_index, T_first_index, T_second_index>>
-      LAbi_from_SA_R_Tbi =
-          TensorExpressions::evaluate<ti_A, ti_b, ti_i>(SA_R_Tbi_expr);
+      LAbi_from_SA_R_Tbi = tenex::evaluate<ti_A, ti_b, ti_i>(SA_R_Tbi_expr);
   // \f$L^{a}{}_{ib} = S^{a} * R * T_{bi}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<S_index, T_second_index, T_first_index>>
-      LAib_from_SA_R_Tbi =
-          TensorExpressions::evaluate<ti_A, ti_i, ti_b>(SA_R_Tbi_expr);
+      LAib_from_SA_R_Tbi = tenex::evaluate<ti_A, ti_i, ti_b>(SA_R_Tbi_expr);
   // \f$L_{b}{}^{a}{}_{i} = S^{a} * R * T_{bi}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_first_index, S_index, T_second_index>>
-      LbAi_from_SA_R_Tbi =
-          TensorExpressions::evaluate<ti_b, ti_A, ti_i>(SA_R_Tbi_expr);
+      LbAi_from_SA_R_Tbi = tenex::evaluate<ti_b, ti_A, ti_i>(SA_R_Tbi_expr);
   // \f$L_{bi}{}^{a} = S^{a} * R * T_{bi}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_first_index, T_second_index, S_index>>
-      LbiA_from_SA_R_Tbi =
-          TensorExpressions::evaluate<ti_b, ti_i, ti_A>(SA_R_Tbi_expr);
+      LbiA_from_SA_R_Tbi = tenex::evaluate<ti_b, ti_i, ti_A>(SA_R_Tbi_expr);
   // \f$L_{i}{}^{a}{}_{b} = S^{a} * R * T_{bi}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_second_index, S_index, T_first_index>>
-      LiAb_from_SA_R_Tbi =
-          TensorExpressions::evaluate<ti_i, ti_A, ti_b>(SA_R_Tbi_expr);
+      LiAb_from_SA_R_Tbi = tenex::evaluate<ti_i, ti_A, ti_b>(SA_R_Tbi_expr);
   // \f$L_{ib}{}^{a} = S^{a} * R * T_{bi}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_second_index, T_first_index, S_index>>
-      LibA_from_SA_R_Tbi =
-          TensorExpressions::evaluate<ti_i, ti_b, ti_A>(SA_R_Tbi_expr);
+      LibA_from_SA_R_Tbi = tenex::evaluate<ti_i, ti_b, ti_A>(SA_R_Tbi_expr);
 
   // \f$S^{a} * T_{bi} * R\f$
   const auto SA_Tbi_R_expr = Su(ti_A) * Tll(ti_b, ti_i) * R();
   // \f$L^{a}{}_{bi} = S^{a} * T_{bi} * R\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<S_index, T_first_index, T_second_index>>
-      LAbi_from_SA_Tbi_R =
-          TensorExpressions::evaluate<ti_A, ti_b, ti_i>(SA_Tbi_R_expr);
+      LAbi_from_SA_Tbi_R = tenex::evaluate<ti_A, ti_b, ti_i>(SA_Tbi_R_expr);
   // \f$L^{a}{}_{ib} = S^{a} * T_{bi} * R\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<S_index, T_second_index, T_first_index>>
-      LAib_from_SA_Tbi_R =
-          TensorExpressions::evaluate<ti_A, ti_i, ti_b>(SA_Tbi_R_expr);
+      LAib_from_SA_Tbi_R = tenex::evaluate<ti_A, ti_i, ti_b>(SA_Tbi_R_expr);
   // \f$L_{b}{}^{a}{}_{i} = S^{a} * T_{bi} * R\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_first_index, S_index, T_second_index>>
-      LbAi_from_SA_Tbi_R =
-          TensorExpressions::evaluate<ti_b, ti_A, ti_i>(SA_Tbi_R_expr);
+      LbAi_from_SA_Tbi_R = tenex::evaluate<ti_b, ti_A, ti_i>(SA_Tbi_R_expr);
   // \f$L_{bi}{}^{a} = S^{a} * T_{bi} * R\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_first_index, T_second_index, S_index>>
-      LbiA_from_SA_Tbi_R =
-          TensorExpressions::evaluate<ti_b, ti_i, ti_A>(SA_Tbi_R_expr);
+      LbiA_from_SA_Tbi_R = tenex::evaluate<ti_b, ti_i, ti_A>(SA_Tbi_R_expr);
   // \f$L_{i}{}^{a}{}_{b} = S^{a} * T_{bi} * R\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_second_index, S_index, T_first_index>>
-      LiAb_from_SA_Tbi_R =
-          TensorExpressions::evaluate<ti_i, ti_A, ti_b>(SA_Tbi_R_expr);
+      LiAb_from_SA_Tbi_R = tenex::evaluate<ti_i, ti_A, ti_b>(SA_Tbi_R_expr);
   // \f$L_{ib}{}^{a} = S^{a} * T_{bi} * R\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_second_index, T_first_index, S_index>>
-      LibA_from_SA_Tbi_R =
-          TensorExpressions::evaluate<ti_i, ti_b, ti_A>(SA_Tbi_R_expr);
+      LibA_from_SA_Tbi_R = tenex::evaluate<ti_i, ti_b, ti_A>(SA_Tbi_R_expr);
 
   // \f$T_{bi} * R * S^{a}\f$
   const auto Tbi_R_SA_expr = Tll(ti_b, ti_i) * R() * Su(ti_A);
   // \f$L^{a}{}_{bi} = T_{bi} * R * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<S_index, T_first_index, T_second_index>>
-      LAbi_from_Tbi_R_SA =
-          TensorExpressions::evaluate<ti_A, ti_b, ti_i>(Tbi_R_SA_expr);
+      LAbi_from_Tbi_R_SA = tenex::evaluate<ti_A, ti_b, ti_i>(Tbi_R_SA_expr);
   // \f$L^{a}{}_{ib} = T_{bi} * R * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<S_index, T_second_index, T_first_index>>
-      LAib_from_Tbi_R_SA =
-          TensorExpressions::evaluate<ti_A, ti_i, ti_b>(Tbi_R_SA_expr);
+      LAib_from_Tbi_R_SA = tenex::evaluate<ti_A, ti_i, ti_b>(Tbi_R_SA_expr);
   // \f$L_{b}{}^{a}{}_{i} = T_{bi} * R * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_first_index, S_index, T_second_index>>
-      LbAi_from_Tbi_R_SA =
-          TensorExpressions::evaluate<ti_b, ti_A, ti_i>(Tbi_R_SA_expr);
+      LbAi_from_Tbi_R_SA = tenex::evaluate<ti_b, ti_A, ti_i>(Tbi_R_SA_expr);
   // \f$L_{bi}{}^{a} = T_{bi} * R * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_first_index, T_second_index, S_index>>
-      LbiA_from_Tbi_R_SA =
-          TensorExpressions::evaluate<ti_b, ti_i, ti_A>(Tbi_R_SA_expr);
+      LbiA_from_Tbi_R_SA = tenex::evaluate<ti_b, ti_i, ti_A>(Tbi_R_SA_expr);
   // \f$L_{i}{}^{a}{}_{b} = T_{bi} * R * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_second_index, S_index, T_first_index>>
-      LiAb_from_Tbi_R_SA =
-          TensorExpressions::evaluate<ti_i, ti_A, ti_b>(Tbi_R_SA_expr);
+      LiAb_from_Tbi_R_SA = tenex::evaluate<ti_i, ti_A, ti_b>(Tbi_R_SA_expr);
   // \f$L_{ib}{}^{a} = T_{bi} * R * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_second_index, T_first_index, S_index>>
-      LibA_from_Tbi_R_SA =
-          TensorExpressions::evaluate<ti_i, ti_b, ti_A>(Tbi_R_SA_expr);
+      LibA_from_Tbi_R_SA = tenex::evaluate<ti_i, ti_b, ti_A>(Tbi_R_SA_expr);
 
   // \f$T_{bi} * S^{a} * R\f$
   const auto Tbi_SA_R_expr = Tll(ti_b, ti_i) * Su(ti_A) * R();
   // \f$L^{a}{}_{bi} = T_{bi} * R * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<S_index, T_first_index, T_second_index>>
-      LAbi_from_Tbi_SA_R =
-          TensorExpressions::evaluate<ti_A, ti_b, ti_i>(Tbi_SA_R_expr);
+      LAbi_from_Tbi_SA_R = tenex::evaluate<ti_A, ti_b, ti_i>(Tbi_SA_R_expr);
   // \f$L^{a}{}_{ib} = T_{bi} * R * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<S_index, T_second_index, T_first_index>>
-      LAib_from_Tbi_SA_R =
-          TensorExpressions::evaluate<ti_A, ti_i, ti_b>(Tbi_SA_R_expr);
+      LAib_from_Tbi_SA_R = tenex::evaluate<ti_A, ti_i, ti_b>(Tbi_SA_R_expr);
   // \f$L_{b}{}^{a}{}_{i} = T_{bi} * R * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_first_index, S_index, T_second_index>>
-      LbAi_from_Tbi_SA_R =
-          TensorExpressions::evaluate<ti_b, ti_A, ti_i>(Tbi_SA_R_expr);
+      LbAi_from_Tbi_SA_R = tenex::evaluate<ti_b, ti_A, ti_i>(Tbi_SA_R_expr);
   // \f$L_{bi}{}^{a} = T_{bi} * R * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_first_index, T_second_index, S_index>>
-      LbiA_from_Tbi_SA_R =
-          TensorExpressions::evaluate<ti_b, ti_i, ti_A>(Tbi_SA_R_expr);
+      LbiA_from_Tbi_SA_R = tenex::evaluate<ti_b, ti_i, ti_A>(Tbi_SA_R_expr);
   // \f$L_{i}{}^{a}{}_{b} = T_{bi} * R * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_second_index, S_index, T_first_index>>
-      LiAb_from_Tbi_SA_R =
-          TensorExpressions::evaluate<ti_i, ti_A, ti_b>(Tbi_SA_R_expr);
+      LiAb_from_Tbi_SA_R = tenex::evaluate<ti_i, ti_A, ti_b>(Tbi_SA_R_expr);
   // \f$L_{ib}{}^{a} = T_{bi} * R * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_second_index, T_first_index, S_index>>
-      LibA_from_Tbi_SA_R =
-          TensorExpressions::evaluate<ti_i, ti_b, ti_A>(Tbi_SA_R_expr);
+      LibA_from_Tbi_SA_R = tenex::evaluate<ti_i, ti_b, ti_A>(Tbi_SA_R_expr);
 
   for (size_t a = 0; a < S_index::dim; a++) {
     for (size_t b = 0; b < T_first_index::dim; b++) {
@@ -732,11 +688,9 @@ void test_inner_product_rank_1x1_operands(const DataType& used_for_size) {
   assign_unique_values_to_tensor(make_not_null(&Sl));
 
   // \f$L = R^{a} * S_{a}\f$
-  const Tensor<DataType> L_from_RA_Sa =
-      TensorExpressions::evaluate(Ru(ti_A) * Sl(ti_a));
+  const Tensor<DataType> L_from_RA_Sa = tenex::evaluate(Ru(ti_A) * Sl(ti_a));
   // \f$L = S_{a} * R^{a}\f$
-  const Tensor<DataType> L_from_Sa_RA =
-      TensorExpressions::evaluate(Sl(ti_a) * Ru(ti_A));
+  const Tensor<DataType> L_from_Sa_RA = tenex::evaluate(Sl(ti_a) * Ru(ti_A));
 
   DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
   for (size_t a = 0; a < 4; a++) {
@@ -802,28 +756,28 @@ void test_inner_product_rank_2x2_operands(const DataType& used_for_size) {
 
   // \f$L = Rll_{ai} * Ruu^{ai}\f$
   const Tensor<DataType> L_aiAI_product =
-      TensorExpressions::evaluate(Rll(ti_a, ti_i) * Ruu(ti_A, ti_I));
+      tenex::evaluate(Rll(ti_a, ti_i) * Ruu(ti_A, ti_I));
   // \f$L = Rll_{ai} * Suu^{ia}\f$
   const Tensor<DataType> L_aiIA_product =
-      TensorExpressions::evaluate(Rll(ti_a, ti_i) * Suu(ti_I, ti_A));
+      tenex::evaluate(Rll(ti_a, ti_i) * Suu(ti_I, ti_A));
   // \f$L = Ruu^{ai} * Rll_{ai}\f$
   const Tensor<DataType> L_AIai_product =
-      TensorExpressions::evaluate(Ruu(ti_A, ti_I) * Rll(ti_a, ti_i));
+      tenex::evaluate(Ruu(ti_A, ti_I) * Rll(ti_a, ti_i));
   // \f$L = Ruu^{ai} * Sll_{ia}\f$
   const Tensor<DataType> L_AIia_product =
-      TensorExpressions::evaluate(Ruu(ti_A, ti_I) * Sll(ti_i, ti_a));
+      tenex::evaluate(Ruu(ti_A, ti_I) * Sll(ti_i, ti_a));
   // \f$L = Rlu_{a}{}^{i} * Rul^{a}{}_{i}\f$
   const Tensor<DataType> L_aIAi_product =
-      TensorExpressions::evaluate(Rlu(ti_a, ti_I) * Rul(ti_A, ti_i));
+      tenex::evaluate(Rlu(ti_a, ti_I) * Rul(ti_A, ti_i));
   // \f$L = Rlu_{a}{}^{i} * Slu_{i}{}^{a}\f$
   const Tensor<DataType> L_aIiA_product =
-      TensorExpressions::evaluate(Rlu(ti_a, ti_I) * Slu(ti_i, ti_A));
+      tenex::evaluate(Rlu(ti_a, ti_I) * Slu(ti_i, ti_A));
   // \f$L = Rul^{a}{}_{i} * Rlu_{a}{}^{i}\f$
   const Tensor<DataType> L_AiaI_product =
-      TensorExpressions::evaluate(Rul(ti_A, ti_i) * Rlu(ti_a, ti_I));
+      tenex::evaluate(Rul(ti_A, ti_i) * Rlu(ti_a, ti_I));
   // \f$L = Rul^{a}{}_{i} * Sul^{i}{}_{a}\f$
   const Tensor<DataType> L_AiIa_product =
-      TensorExpressions::evaluate(Rul(ti_A, ti_i) * Sul(ti_I, ti_a));
+      tenex::evaluate(Rul(ti_A, ti_i) * Sul(ti_I, ti_a));
 
   DataType L_aiAI_expected_product =
       make_with_value<DataType>(used_for_size, 0.0);
@@ -892,17 +846,13 @@ void test_two_term_inner_outer_product(const DataType& used_for_size) {
   // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
   // return type of `evaluate`
   using Lb = Tensor<DataType, Symmetry<1>, index_list<R_index>>;
-  const Lb Lb_from_Rab_TA =
-      TensorExpressions::evaluate<ti_b>(Rll(ti_a, ti_b) * Tu(ti_A));
+  const Lb Lb_from_Rab_TA = tenex::evaluate<ti_b>(Rll(ti_a, ti_b) * Tu(ti_A));
   // \f$L_{b} = R_{ba} * T^{a}\f$
-  const Lb Lb_from_Rba_TA =
-      TensorExpressions::evaluate<ti_b>(Rll(ti_b, ti_a) * Tu(ti_A));
+  const Lb Lb_from_Rba_TA = tenex::evaluate<ti_b>(Rll(ti_b, ti_a) * Tu(ti_A));
   // \f$L_{b} = T^{a} * R_{ab}\f$
-  const Lb Lb_from_TA_Rab =
-      TensorExpressions::evaluate<ti_b>(Tu(ti_A) * Rll(ti_a, ti_b));
+  const Lb Lb_from_TA_Rab = tenex::evaluate<ti_b>(Tu(ti_A) * Rll(ti_a, ti_b));
   // \f$L_{b} = T^{a} * R_{ba}\f$
-  const Lb Lb_from_TA_Rba =
-      TensorExpressions::evaluate<ti_b>(Tu(ti_A) * Rll(ti_b, ti_a));
+  const Lb Lb_from_TA_Rba = tenex::evaluate<ti_b>(Tu(ti_A) * Rll(ti_b, ti_a));
 
   for (size_t b = 0; b < R_index::dim; b++) {
     DataType expected_product = make_with_value<DataType>(used_for_size, 0.0);
@@ -927,36 +877,36 @@ void test_two_term_inner_outer_product(const DataType& used_for_size) {
 
   // \f$L_{ac} = R_{ab} * S^{b}_{c}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<R_index, S_lower_index>>
-      L_abBc_to_ac = TensorExpressions::evaluate<ti_a, ti_c>(Rll(ti_a, ti_b) *
-                                                             Sul(ti_B, ti_c));
+      L_abBc_to_ac =
+          tenex::evaluate<ti_a, ti_c>(Rll(ti_a, ti_b) * Sul(ti_B, ti_c));
   // \f$L_{ca} = R_{ab} * S^{b}_{c}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<S_lower_index, R_index>>
-      L_abBc_to_ca = TensorExpressions::evaluate<ti_c, ti_a>(Rll(ti_a, ti_b) *
-                                                             Sul(ti_B, ti_c));
+      L_abBc_to_ca =
+          tenex::evaluate<ti_c, ti_a>(Rll(ti_a, ti_b) * Sul(ti_B, ti_c));
   // \f$L_{ac} = R_{ab} * S_{c}^{b}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<R_index, S_lower_index>>
-      L_abcB_to_ac = TensorExpressions::evaluate<ti_a, ti_c>(Rll(ti_a, ti_b) *
-                                                             Slu(ti_c, ti_B));
+      L_abcB_to_ac =
+          tenex::evaluate<ti_a, ti_c>(Rll(ti_a, ti_b) * Slu(ti_c, ti_B));
   // \f$L_{ca} = R_{ab} * S_{c}^{b}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<S_lower_index, R_index>>
-      L_abcB_to_ca = TensorExpressions::evaluate<ti_c, ti_a>(Rll(ti_a, ti_b) *
-                                                             Slu(ti_c, ti_B));
+      L_abcB_to_ca =
+          tenex::evaluate<ti_c, ti_a>(Rll(ti_a, ti_b) * Slu(ti_c, ti_B));
   // \f$L_{ac} = R_{ba} * S^{b}_{c}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<R_index, S_lower_index>>
-      L_baBc_to_ac = TensorExpressions::evaluate<ti_a, ti_c>(Rll(ti_b, ti_a) *
-                                                             Sul(ti_B, ti_c));
+      L_baBc_to_ac =
+          tenex::evaluate<ti_a, ti_c>(Rll(ti_b, ti_a) * Sul(ti_B, ti_c));
   // \f$L_{ca} = R_{ba} * S^{b}_{c}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<S_lower_index, R_index>>
-      L_baBc_to_ca = TensorExpressions::evaluate<ti_c, ti_a>(Rll(ti_b, ti_a) *
-                                                             Sul(ti_B, ti_c));
+      L_baBc_to_ca =
+          tenex::evaluate<ti_c, ti_a>(Rll(ti_b, ti_a) * Sul(ti_B, ti_c));
   // \f$L_{ac} = R_{ba} * S_{c}^{b}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<R_index, S_lower_index>>
-      L_bacB_to_ac = TensorExpressions::evaluate<ti_a, ti_c>(Rll(ti_b, ti_a) *
-                                                             Slu(ti_c, ti_B));
+      L_bacB_to_ac =
+          tenex::evaluate<ti_a, ti_c>(Rll(ti_b, ti_a) * Slu(ti_c, ti_B));
   // \f$L_{ca} = R_{ba} * S_{c}^{b}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<S_lower_index, R_index>>
-      L_bacB_to_ca = TensorExpressions::evaluate<ti_c, ti_a>(Rll(ti_b, ti_a) *
-                                                             Slu(ti_c, ti_B));
+      L_bacB_to_ca =
+          tenex::evaluate<ti_c, ti_a>(Rll(ti_b, ti_a) * Slu(ti_c, ti_B));
 
   for (size_t a = 0; a < R_index::dim; a++) {
     for (size_t c = 0; c < S_lower_index::dim; c++) {
@@ -1015,13 +965,13 @@ void test_three_term_inner_outer_product(const DataType& used_for_size) {
 
   // \f$L_{i} = R^{j} * S_{j} * T_{i}\f$
   const decltype(Tl) Li_from_Jji =
-      TensorExpressions::evaluate<ti_i>(Ru(ti_J) * Sl(ti_j) * Tl(ti_i));
+      tenex::evaluate<ti_i>(Ru(ti_J) * Sl(ti_j) * Tl(ti_i));
   // \f$L_{i} = R^{j} * T_{i} * S_{j}\f$
   const decltype(Tl) Li_from_Jij =
-      TensorExpressions::evaluate<ti_i>(Ru(ti_J) * Tl(ti_i) * Sl(ti_j));
+      tenex::evaluate<ti_i>(Ru(ti_J) * Tl(ti_i) * Sl(ti_j));
   // \f$L_{i} = T_{i} * S_{j} * R^{j}\f$
   const decltype(Tl) Li_from_ijJ =
-      TensorExpressions::evaluate<ti_i>(Tl(ti_i) * Sl(ti_j) * Ru(ti_J));
+      tenex::evaluate<ti_i>(Tl(ti_i) * Sl(ti_j) * Ru(ti_J));
 
   for (size_t i = 0; i < 3; i++) {
     DataType expected_product = make_with_value<DataType>(used_for_size, 0.0);
@@ -1042,52 +992,52 @@ void test_three_term_inner_outer_product(const DataType& used_for_size) {
 
   // \f$L_{i}{}^{k} = S_{j} * T_{i} * G^{jk}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<T_index, G_index>>
-      LiK_from_Sj_Ti_GJK = TensorExpressions::evaluate<ti_i, ti_K>(
-          Sl(ti_j) * Tl(ti_i) * Guu(ti_J, ti_K));
+      LiK_from_Sj_Ti_GJK =
+          tenex::evaluate<ti_i, ti_K>(Sl(ti_j) * Tl(ti_i) * Guu(ti_J, ti_K));
   // \f$L^{k}{}_{i} = S_{j} * T_{i} * G^{jk}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<G_index, T_index>>
-      LKi_from_Sj_Ti_GJK = TensorExpressions::evaluate<ti_K, ti_i>(
-          Sl(ti_j) * Tl(ti_i) * Guu(ti_J, ti_K));
+      LKi_from_Sj_Ti_GJK =
+          tenex::evaluate<ti_K, ti_i>(Sl(ti_j) * Tl(ti_i) * Guu(ti_J, ti_K));
   // \f$L_{i}{}^{k} = S_{j} *  G^{jk} * T_{i}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<T_index, G_index>>
-      LiK_from_Sj_GJK_Ti = TensorExpressions::evaluate<ti_i, ti_K>(
-          Sl(ti_j) * Guu(ti_J, ti_K) * Tl(ti_i));
+      LiK_from_Sj_GJK_Ti =
+          tenex::evaluate<ti_i, ti_K>(Sl(ti_j) * Guu(ti_J, ti_K) * Tl(ti_i));
   // \f$L^{k}{}_{i} = S_{j} *  G^{jk} * T_{i}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<G_index, T_index>>
-      LKi_from_Sj_GJK_Ti = TensorExpressions::evaluate<ti_K, ti_i>(
-          Sl(ti_j) * Guu(ti_J, ti_K) * Tl(ti_i));
+      LKi_from_Sj_GJK_Ti =
+          tenex::evaluate<ti_K, ti_i>(Sl(ti_j) * Guu(ti_J, ti_K) * Tl(ti_i));
   // \f$L_{i}{}^{k} = T_{i} * S_{j} * G^{jk}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<T_index, G_index>>
-      LiK_from_Ti_Sj_GJK = TensorExpressions::evaluate<ti_i, ti_K>(
-          Tl(ti_i) * Sl(ti_j) * Guu(ti_J, ti_K));
+      LiK_from_Ti_Sj_GJK =
+          tenex::evaluate<ti_i, ti_K>(Tl(ti_i) * Sl(ti_j) * Guu(ti_J, ti_K));
   // \f$L^{k}{}_{i} = T_{i} * S_{j} * G^{jk}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<G_index, T_index>>
-      LKi_from_Ti_Sj_GJK = TensorExpressions::evaluate<ti_K, ti_i>(
-          Tl(ti_i) * Sl(ti_j) * Guu(ti_J, ti_K));
+      LKi_from_Ti_Sj_GJK =
+          tenex::evaluate<ti_K, ti_i>(Tl(ti_i) * Sl(ti_j) * Guu(ti_J, ti_K));
   // \f$L_{i}{}^{k} = T_{i} * G^{jk} * S_{j}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<T_index, G_index>>
-      LiK_from_Ti_GJK_Sj = TensorExpressions::evaluate<ti_i, ti_K>(
-          Tl(ti_i) * Guu(ti_J, ti_K) * Sl(ti_j));
+      LiK_from_Ti_GJK_Sj =
+          tenex::evaluate<ti_i, ti_K>(Tl(ti_i) * Guu(ti_J, ti_K) * Sl(ti_j));
   // \f$L^{k}{}_{i} = T_{i} * G^{jk} * S_{j}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<G_index, T_index>>
-      LKi_from_Ti_GJK_Sj = TensorExpressions::evaluate<ti_K, ti_i>(
-          Tl(ti_i) * Guu(ti_J, ti_K) * Sl(ti_j));
+      LKi_from_Ti_GJK_Sj =
+          tenex::evaluate<ti_K, ti_i>(Tl(ti_i) * Guu(ti_J, ti_K) * Sl(ti_j));
   // \f$L_{i}{}^{k} = G^{jk} * S_{j} * T_{i}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<T_index, G_index>>
-      LiK_from_GJK_Sj_Ti = TensorExpressions::evaluate<ti_i, ti_K>(
-          Guu(ti_J, ti_K) * Sl(ti_j) * Tl(ti_i));
+      LiK_from_GJK_Sj_Ti =
+          tenex::evaluate<ti_i, ti_K>(Guu(ti_J, ti_K) * Sl(ti_j) * Tl(ti_i));
   // \f$L^{k}{}_{i} = G^{jk} * S_{j} * T_{i}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<G_index, T_index>>
-      LKi_from_GJK_Sj_Ti = TensorExpressions::evaluate<ti_K, ti_i>(
-          Guu(ti_J, ti_K) * Sl(ti_j) * Tl(ti_i));
+      LKi_from_GJK_Sj_Ti =
+          tenex::evaluate<ti_K, ti_i>(Guu(ti_J, ti_K) * Sl(ti_j) * Tl(ti_i));
   // \f$L_{i}{}^{k} = G^{jk} * T_{i} * S_{j}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<T_index, G_index>>
-      LiK_from_GJK_Ti_Sj = TensorExpressions::evaluate<ti_i, ti_K>(
-          Guu(ti_J, ti_K) * Tl(ti_i) * Sl(ti_j));
+      LiK_from_GJK_Ti_Sj =
+          tenex::evaluate<ti_i, ti_K>(Guu(ti_J, ti_K) * Tl(ti_i) * Sl(ti_j));
   // \f$L^{k}{}_{i} = G^{jk} * T_{i} * S_{j}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<G_index, T_index>>
-      LKi_from_GJK_Ti_Sj = TensorExpressions::evaluate<ti_K, ti_i>(
-          Guu(ti_J, ti_K) * Tl(ti_i) * Sl(ti_j));
+      LKi_from_GJK_Ti_Sj =
+          tenex::evaluate<ti_K, ti_i>(Guu(ti_J, ti_K) * Tl(ti_i) * Sl(ti_j));
 
   for (size_t k = 0; k < G_index::dim; k++) {
     for (size_t i = 0; i < T_index::dim; i++) {
@@ -1149,10 +1099,10 @@ void test_spatial_spacetime_index(const DataType& used_for_size) {
   // (spatial) * (spacetime) inner product with generic spatial indices
   // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
   // return type of `evaluate`
-  const Tensor<DataType> RS = TensorExpressions::evaluate(R(ti_I) * S(ti_i));
+  const Tensor<DataType> RS = tenex::evaluate(R(ti_I) * S(ti_i));
   // \f$L = R^{k} * T_{k}\f$
   // (spacetime) * (spacetime) inner product with generic spatial indices
-  const Tensor<DataType> RT = TensorExpressions::evaluate(R(ti_K) * T(ti_k));
+  const Tensor<DataType> RT = tenex::evaluate(R(ti_K) * T(ti_k));
 
   DataType expected_RS_product = make_with_value<DataType>(used_for_size, 0.0);
   DataType expected_RT_product = make_with_value<DataType>(used_for_size, 0.0);
@@ -1182,8 +1132,8 @@ void test_spatial_spacetime_index(const DataType& used_for_size) {
                           SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
                           SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
                           SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>>
-      GH = TensorExpressions::evaluate<ti_j, ti_a, ti_i, ti_B>(G(ti_i, ti_a) *
-                                                               H(ti_j, ti_B));
+      GH = tenex::evaluate<ti_j, ti_a, ti_i, ti_B>(G(ti_i, ti_a) *
+                                                   H(ti_j, ti_B));
   for (size_t j = 0; j < 3; j++) {
     for (size_t a = 0; a < 4; a++) {
       for (size_t i = 0; i < 3; i++) {
@@ -1201,8 +1151,7 @@ void test_spatial_spacetime_index(const DataType& used_for_size) {
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
                           SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>
-      HG = TensorExpressions::evaluate<ti_k, ti_i>(H(ti_i, ti_J) *
-                                                   G(ti_k, ti_j));
+      HG = tenex::evaluate<ti_k, ti_i>(H(ti_i, ti_J) * G(ti_k, ti_j));
   for (size_t k = 0; k < 3; k++) {
     for (size_t i = 0; i < 3; i++) {
       DataType expected_product = make_with_value<DataType>(used_for_size, 0.0);
@@ -1242,8 +1191,7 @@ void test_time_index(const DataType& used_for_size) {
   }
 
   // \f$L = R_{t} * S * R_{t}\f$
-  const Tensor<DataType> L =
-      TensorExpressions::evaluate(R(ti_t) * S() * R(ti_t));
+  const Tensor<DataType> L = tenex::evaluate(R(ti_t) * S() * R(ti_t));
   CHECK(L.get() == R.get(0) * S.get() * R.get(0));
 
   Tensor<DataType, Symmetry<2, 1>,
@@ -1262,8 +1210,7 @@ void test_time_index(const DataType& used_for_size) {
   // \f$L^{b} = G_{t}{}^{a} * H_{a}{}^{tb}\f$
   const Tensor<DataType, Symmetry<1>,
                index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>
-      L_B = TensorExpressions::evaluate<ti_B>(G(ti_t, ti_A) *
-                                              H(ti_a, ti_T, ti_B));
+      L_B = tenex::evaluate<ti_B>(G(ti_t, ti_A) * H(ti_a, ti_T, ti_B));
 
   for (size_t b = 0; b < 4; b++) {
     DataType expected_product = make_with_value<DataType>(used_for_size, 0.0);
@@ -1285,8 +1232,7 @@ void test_time_index(const DataType& used_for_size) {
                         SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>>(
       used_for_size, spatial_component_placeholder);
   // \f$L^{T}{}_{ba} = R_{a} * R_{b}\f$
-  TensorExpressions::evaluate<ti_T, ti_b, ti_a>(make_not_null(&L_Tba),
-                                                R(ti_a) * R(ti_b));
+  tenex::evaluate<ti_T, ti_b, ti_a>(make_not_null(&L_Tba), R(ti_a) * R(ti_b));
 
   for (size_t b = 0; b < 4; b++) {
     for (size_t a = 0; a < 4; a++) {
@@ -1303,7 +1249,7 @@ void test_time_index(const DataType& used_for_size) {
                         SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>>(
       used_for_size, spatial_component_placeholder);
   // \f$L_^{ct} = G_{t}{}^{b} * R_{b} * H_{t}^{ta}\f$
-  TensorExpressions::evaluate<ti_C, ti_T>(
+  tenex::evaluate<ti_C, ti_T>(
       make_not_null(&L_CT),
       G(ti_t, ti_B) * H(ti_b, ti_A, ti_C) * G(ti_a, ti_T));
 

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Product.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Product.cpp
@@ -66,13 +66,13 @@ void test_outer_product_double(const DataType& used_for_size) {
   // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
   // return type of `evaluate`
   const tensor_type Lij_from_R_Sij =
-      tenex::evaluate<ti_i, ti_j>(5.6 * S(ti_i, ti_j));
+      tenex::evaluate<ti::i, ti::j>(5.6 * S(ti::i, ti::j));
   // \f$L_{ij} = S_{ij} * R\f$
   const tensor_type Lij_from_Sij_R =
-      tenex::evaluate<ti_i, ti_j>(S(ti_i, ti_j) * -8.1);
+      tenex::evaluate<ti::i, ti::j>(S(ti::i, ti::j) * -8.1);
   // \f$L_{ij} = R * S_{ij} * T\f$
   const tensor_type Lij_from_R_Sij_T =
-      tenex::evaluate<ti_i, ti_j>(-1.7 * S(ti_i, ti_j) * 0.6);
+      tenex::evaluate<ti::i, ti::j>(-1.7 * S(ti::i, ti::j) * 0.6);
 
   for (size_t i = 0; i < dim; i++) {
     for (size_t j = 0; j < dim; j++) {
@@ -120,9 +120,9 @@ void test_outer_product_rank_0_operand(const DataType& used_for_size) {
   // \f$L^{a} = R * S^{a}\f$
   // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
   // return type of `evaluate`
-  const decltype(Su) LA_from_R_SA = tenex::evaluate<ti_A>(R() * Su(ti_A));
+  const decltype(Su) LA_from_R_SA = tenex::evaluate<ti::A>(R() * Su(ti::A));
   // \f$L^{a} = S^{a} * R\f$
-  const decltype(Su) LA_from_SA_R = tenex::evaluate<ti_A>(Su(ti_A) * R());
+  const decltype(Su) LA_from_SA_R = tenex::evaluate<ti::A>(Su(ti::A) * R());
 
   for (size_t a = 0; a < 4; a++) {
     CHECK(LA_from_R_SA.get(a) == R.get() * Su.get(a));
@@ -139,22 +139,22 @@ void test_outer_product_rank_0_operand(const DataType& used_for_size) {
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
                           SpatialIndex<4, UpLo::Lo, Frame::Inertial>>>
-      Lai_from_R_Tai = tenex::evaluate<ti_a, ti_i>(R() * Tll(ti_a, ti_i));
+      Lai_from_R_Tai = tenex::evaluate<ti::a, ti::i>(R() * Tll(ti::a, ti::i));
   // \f$L_{ia} = R * T_{ai}\f$
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<4, UpLo::Lo, Frame::Inertial>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>
-      Lia_from_R_Tai = tenex::evaluate<ti_i, ti_a>(R() * Tll(ti_a, ti_i));
+      Lia_from_R_Tai = tenex::evaluate<ti::i, ti::a>(R() * Tll(ti::a, ti::i));
   // \f$L_{ai} = T_{ai} * R\f$
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
                           SpatialIndex<4, UpLo::Lo, Frame::Inertial>>>
-      Lai_from_Tai_R = tenex::evaluate<ti_a, ti_i>(Tll(ti_a, ti_i) * R());
+      Lai_from_Tai_R = tenex::evaluate<ti::a, ti::i>(Tll(ti::a, ti::i) * R());
   // \f$L_{ia} = T_{ai} * R\f$
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<4, UpLo::Lo, Frame::Inertial>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>
-      Lia_from_Tai_R = tenex::evaluate<ti_i, ti_a>(Tll(ti_a, ti_i) * R());
+      Lia_from_Tai_R = tenex::evaluate<ti::i, ti::a>(Tll(ti::a, ti::i) * R());
 
   for (size_t a = 0; a < 4; a++) {
     for (size_t i = 0; i < 4; i++) {
@@ -201,7 +201,7 @@ void test_outer_product_rank_1_operand(const DataType& used_for_size) {
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                           SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
-      LAi_from_Ri_SA = tenex::evaluate<ti_A, ti_i>(Rl(ti_i) * Su(ti_A));
+      LAi_from_Ri_SA = tenex::evaluate<ti::A, ti::i>(Rl(ti::i) * Su(ti::A));
 
   for (size_t i = 0; i < 3; i++) {
     for (size_t a = 0; a < 4; a++) {
@@ -219,8 +219,8 @@ void test_outer_product_rank_1_operand(const DataType& used_for_size) {
                index_list<SpatialIndex<3, UpLo::Up, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                           SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
-      LJAi_from_Ri_SA_TJ =
-          tenex::evaluate<ti_J, ti_A, ti_i>(Rl(ti_i) * Su(ti_A) * Tu(ti_J));
+      LJAi_from_Ri_SA_TJ = tenex::evaluate<ti::J, ti::A, ti::i>(
+          Rl(ti::i) * Su(ti::A) * Tu(ti::J));
 
   for (size_t j = 0; j < 3; j++) {
     for (size_t a = 0; a < 4; a++) {
@@ -243,14 +243,14 @@ void test_outer_product_rank_1_operand(const DataType& used_for_size) {
                           SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
       LkCd_from_SC_Gdk =
-          tenex::evaluate<ti_k, ti_C, ti_d>(Su(ti_C) * Gll(ti_d, ti_k));
+          tenex::evaluate<ti::k, ti::C, ti::d>(Su(ti::C) * Gll(ti::d, ti::k));
   // \f$L^{c}{}_{dk} = G_{dk} * S^{c}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpatialIndex<4, UpLo::Lo, Frame::Grid>>>
       LCdk_from_Gdk_SC =
-          tenex::evaluate<ti_C, ti_d, ti_k>(Gll(ti_d, ti_k) * Su(ti_C));
+          tenex::evaluate<ti::C, ti::d, ti::k>(Gll(ti::d, ti::k) * Su(ti::C));
 
   for (size_t k = 0; k < 4; k++) {
     for (size_t c = 0; c < 4; c++) {
@@ -286,103 +286,103 @@ void test_outer_product_rank_2x2_operands(const DataType& used_for_size) {
   // return type of `evaluate`
   const Tensor<DataType, Symmetry<3, 3, 2, 1>,
                index_list<R_index, R_index, S_first_index, S_second_index>>
-      L_abIc = tenex::evaluate<ti_a, ti_b, ti_I, ti_c>(Rll(ti_a, ti_b) *
-                                                       Sul(ti_I, ti_c));
+      L_abIc = tenex::evaluate<ti::a, ti::b, ti::I, ti::c>(Rll(ti::a, ti::b) *
+                                                           Sul(ti::I, ti::c));
   const Tensor<DataType, Symmetry<3, 3, 2, 1>,
                index_list<R_index, R_index, S_second_index, S_first_index>>
-      L_abcI = tenex::evaluate<ti_a, ti_b, ti_c, ti_I>(Rll(ti_a, ti_b) *
-                                                       Sul(ti_I, ti_c));
+      L_abcI = tenex::evaluate<ti::a, ti::b, ti::c, ti::I>(Rll(ti::a, ti::b) *
+                                                           Sul(ti::I, ti::c));
   const Tensor<DataType, Symmetry<3, 2, 3, 1>,
                index_list<R_index, S_first_index, R_index, S_second_index>>
-      L_aIbc = tenex::evaluate<ti_a, ti_I, ti_b, ti_c>(Rll(ti_a, ti_b) *
-                                                       Sul(ti_I, ti_c));
+      L_aIbc = tenex::evaluate<ti::a, ti::I, ti::b, ti::c>(Rll(ti::a, ti::b) *
+                                                           Sul(ti::I, ti::c));
   const Tensor<DataType, Symmetry<3, 2, 1, 3>,
                index_list<R_index, S_first_index, S_second_index, R_index>>
-      L_aIcb = tenex::evaluate<ti_a, ti_I, ti_c, ti_b>(Rll(ti_a, ti_b) *
-                                                       Sul(ti_I, ti_c));
+      L_aIcb = tenex::evaluate<ti::a, ti::I, ti::c, ti::b>(Rll(ti::a, ti::b) *
+                                                           Sul(ti::I, ti::c));
   const Tensor<DataType, Symmetry<3, 2, 3, 1>,
                index_list<R_index, S_second_index, R_index, S_first_index>>
-      L_acbI = tenex::evaluate<ti_a, ti_c, ti_b, ti_I>(Rll(ti_a, ti_b) *
-                                                       Sul(ti_I, ti_c));
+      L_acbI = tenex::evaluate<ti::a, ti::c, ti::b, ti::I>(Rll(ti::a, ti::b) *
+                                                           Sul(ti::I, ti::c));
   const Tensor<DataType, Symmetry<3, 2, 1, 3>,
                index_list<R_index, S_second_index, S_first_index, R_index>>
-      L_acIb = tenex::evaluate<ti_a, ti_c, ti_I, ti_b>(Rll(ti_a, ti_b) *
-                                                       Sul(ti_I, ti_c));
+      L_acIb = tenex::evaluate<ti::a, ti::c, ti::I, ti::b>(Rll(ti::a, ti::b) *
+                                                           Sul(ti::I, ti::c));
 
   const Tensor<DataType, Symmetry<3, 3, 2, 1>,
                index_list<R_index, R_index, S_first_index, S_second_index>>
-      L_baIc = tenex::evaluate<ti_b, ti_a, ti_I, ti_c>(Rll(ti_a, ti_b) *
-                                                       Sul(ti_I, ti_c));
+      L_baIc = tenex::evaluate<ti::b, ti::a, ti::I, ti::c>(Rll(ti::a, ti::b) *
+                                                           Sul(ti::I, ti::c));
   const Tensor<DataType, Symmetry<3, 3, 2, 1>,
                index_list<R_index, R_index, S_second_index, S_first_index>>
-      L_bacI = tenex::evaluate<ti_b, ti_a, ti_c, ti_I>(Rll(ti_a, ti_b) *
-                                                       Sul(ti_I, ti_c));
+      L_bacI = tenex::evaluate<ti::b, ti::a, ti::c, ti::I>(Rll(ti::a, ti::b) *
+                                                           Sul(ti::I, ti::c));
   const Tensor<DataType, Symmetry<3, 2, 3, 1>,
                index_list<R_index, S_first_index, R_index, S_second_index>>
-      L_bIac = tenex::evaluate<ti_b, ti_I, ti_a, ti_c>(Rll(ti_a, ti_b) *
-                                                       Sul(ti_I, ti_c));
+      L_bIac = tenex::evaluate<ti::b, ti::I, ti::a, ti::c>(Rll(ti::a, ti::b) *
+                                                           Sul(ti::I, ti::c));
   const Tensor<DataType, Symmetry<3, 2, 1, 3>,
                index_list<R_index, S_first_index, S_second_index, R_index>>
-      L_bIca = tenex::evaluate<ti_b, ti_I, ti_c, ti_a>(Rll(ti_a, ti_b) *
-                                                       Sul(ti_I, ti_c));
+      L_bIca = tenex::evaluate<ti::b, ti::I, ti::c, ti::a>(Rll(ti::a, ti::b) *
+                                                           Sul(ti::I, ti::c));
   const Tensor<DataType, Symmetry<3, 2, 3, 1>,
                index_list<R_index, S_second_index, R_index, S_first_index>>
-      L_bcaI = tenex::evaluate<ti_b, ti_c, ti_a, ti_I>(Rll(ti_a, ti_b) *
-                                                       Sul(ti_I, ti_c));
+      L_bcaI = tenex::evaluate<ti::b, ti::c, ti::a, ti::I>(Rll(ti::a, ti::b) *
+                                                           Sul(ti::I, ti::c));
   const Tensor<DataType, Symmetry<3, 2, 1, 3>,
                index_list<R_index, S_second_index, S_first_index, R_index>>
-      L_bcIa = tenex::evaluate<ti_b, ti_c, ti_I, ti_a>(Rll(ti_a, ti_b) *
-                                                       Sul(ti_I, ti_c));
+      L_bcIa = tenex::evaluate<ti::b, ti::c, ti::I, ti::a>(Rll(ti::a, ti::b) *
+                                                           Sul(ti::I, ti::c));
 
   const Tensor<DataType, Symmetry<3, 2, 2, 1>,
                index_list<S_first_index, R_index, R_index, S_second_index>>
-      L_Iabc = tenex::evaluate<ti_I, ti_a, ti_b, ti_c>(Rll(ti_a, ti_b) *
-                                                       Sul(ti_I, ti_c));
+      L_Iabc = tenex::evaluate<ti::I, ti::a, ti::b, ti::c>(Rll(ti::a, ti::b) *
+                                                           Sul(ti::I, ti::c));
   const Tensor<DataType, Symmetry<3, 2, 1, 2>,
                index_list<S_first_index, R_index, S_second_index, R_index>>
-      L_Iacb = tenex::evaluate<ti_I, ti_a, ti_c, ti_b>(Rll(ti_a, ti_b) *
-                                                       Sul(ti_I, ti_c));
+      L_Iacb = tenex::evaluate<ti::I, ti::a, ti::c, ti::b>(Rll(ti::a, ti::b) *
+                                                           Sul(ti::I, ti::c));
   const Tensor<DataType, Symmetry<3, 2, 2, 1>,
                index_list<S_first_index, R_index, R_index, S_second_index>>
-      L_Ibac = tenex::evaluate<ti_I, ti_b, ti_a, ti_c>(Rll(ti_a, ti_b) *
-                                                       Sul(ti_I, ti_c));
+      L_Ibac = tenex::evaluate<ti::I, ti::b, ti::a, ti::c>(Rll(ti::a, ti::b) *
+                                                           Sul(ti::I, ti::c));
   const Tensor<DataType, Symmetry<3, 2, 1, 2>,
                index_list<S_first_index, R_index, S_second_index, R_index>>
-      L_Ibca = tenex::evaluate<ti_I, ti_b, ti_c, ti_a>(Rll(ti_a, ti_b) *
-                                                       Sul(ti_I, ti_c));
+      L_Ibca = tenex::evaluate<ti::I, ti::b, ti::c, ti::a>(Rll(ti::a, ti::b) *
+                                                           Sul(ti::I, ti::c));
   const Tensor<DataType, Symmetry<3, 2, 1, 1>,
                index_list<S_first_index, S_second_index, R_index, R_index>>
-      L_Icab = tenex::evaluate<ti_I, ti_c, ti_a, ti_b>(Rll(ti_a, ti_b) *
-                                                       Sul(ti_I, ti_c));
+      L_Icab = tenex::evaluate<ti::I, ti::c, ti::a, ti::b>(Rll(ti::a, ti::b) *
+                                                           Sul(ti::I, ti::c));
   const Tensor<DataType, Symmetry<3, 2, 1, 1>,
                index_list<S_first_index, S_second_index, R_index, R_index>>
-      L_Icba = tenex::evaluate<ti_I, ti_c, ti_b, ti_a>(Rll(ti_a, ti_b) *
-                                                       Sul(ti_I, ti_c));
+      L_Icba = tenex::evaluate<ti::I, ti::c, ti::b, ti::a>(Rll(ti::a, ti::b) *
+                                                           Sul(ti::I, ti::c));
 
   const Tensor<DataType, Symmetry<3, 2, 2, 1>,
                index_list<S_second_index, R_index, R_index, S_first_index>>
-      L_cabI = tenex::evaluate<ti_c, ti_a, ti_b, ti_I>(Rll(ti_a, ti_b) *
-                                                       Sul(ti_I, ti_c));
+      L_cabI = tenex::evaluate<ti::c, ti::a, ti::b, ti::I>(Rll(ti::a, ti::b) *
+                                                           Sul(ti::I, ti::c));
   const Tensor<DataType, Symmetry<3, 2, 1, 2>,
                index_list<S_second_index, R_index, S_first_index, R_index>>
-      L_caIb = tenex::evaluate<ti_c, ti_a, ti_I, ti_b>(Rll(ti_a, ti_b) *
-                                                       Sul(ti_I, ti_c));
+      L_caIb = tenex::evaluate<ti::c, ti::a, ti::I, ti::b>(Rll(ti::a, ti::b) *
+                                                           Sul(ti::I, ti::c));
   const Tensor<DataType, Symmetry<3, 2, 2, 1>,
                index_list<S_second_index, R_index, R_index, S_first_index>>
-      L_cbaI = tenex::evaluate<ti_c, ti_b, ti_a, ti_I>(Rll(ti_a, ti_b) *
-                                                       Sul(ti_I, ti_c));
+      L_cbaI = tenex::evaluate<ti::c, ti::b, ti::a, ti::I>(Rll(ti::a, ti::b) *
+                                                           Sul(ti::I, ti::c));
   const Tensor<DataType, Symmetry<3, 2, 1, 2>,
                index_list<S_second_index, R_index, S_first_index, R_index>>
-      L_cbIa = tenex::evaluate<ti_c, ti_b, ti_I, ti_a>(Rll(ti_a, ti_b) *
-                                                       Sul(ti_I, ti_c));
+      L_cbIa = tenex::evaluate<ti::c, ti::b, ti::I, ti::a>(Rll(ti::a, ti::b) *
+                                                           Sul(ti::I, ti::c));
   const Tensor<DataType, Symmetry<3, 2, 1, 1>,
                index_list<S_second_index, S_first_index, R_index, R_index>>
-      L_cIab = tenex::evaluate<ti_c, ti_I, ti_a, ti_b>(Rll(ti_a, ti_b) *
-                                                       Sul(ti_I, ti_c));
+      L_cIab = tenex::evaluate<ti::c, ti::I, ti::a, ti::b>(Rll(ti::a, ti::b) *
+                                                           Sul(ti::I, ti::c));
   const Tensor<DataType, Symmetry<3, 2, 1, 1>,
                index_list<S_second_index, S_first_index, R_index, R_index>>
-      L_cIba = tenex::evaluate<ti_c, ti_I, ti_b, ti_a>(Rll(ti_a, ti_b) *
-                                                       Sul(ti_I, ti_c));
+      L_cIba = tenex::evaluate<ti::c, ti::I, ti::b, ti::a>(Rll(ti::a, ti::b) *
+                                                           Sul(ti::I, ti::c));
 
   for (size_t a = 0; a < R_index::dim; a++) {
     for (size_t b = 0; b < R_index::dim; b++) {
@@ -453,168 +453,168 @@ void test_outer_product_rank_0x1x2_operands(const DataType& used_for_size) {
   assign_unique_values_to_tensor(make_not_null(&Tll));
 
   // \f$R * S^{a} * T_{bi}\f$
-  const auto R_SA_Tbi_expr = R() * Su(ti_A) * Tll(ti_b, ti_i);
+  const auto R_SA_Tbi_expr = R() * Su(ti::A) * Tll(ti::b, ti::i);
   // \f$L^{a}{}_{bi} = R * S^{a} * T_{bi}\f$
   // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
   // return type of `evaluate`
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<S_index, T_first_index, T_second_index>>
-      LAbi_from_R_SA_Tbi = tenex::evaluate<ti_A, ti_b, ti_i>(R_SA_Tbi_expr);
+      LAbi_from_R_SA_Tbi = tenex::evaluate<ti::A, ti::b, ti::i>(R_SA_Tbi_expr);
   // \f$L^{a}{}_{ib} = R * S^{a} * T_{bi}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<S_index, T_second_index, T_first_index>>
-      LAib_from_R_SA_Tbi = tenex::evaluate<ti_A, ti_i, ti_b>(R_SA_Tbi_expr);
+      LAib_from_R_SA_Tbi = tenex::evaluate<ti::A, ti::i, ti::b>(R_SA_Tbi_expr);
   // \f$L_{b}{}^{a}{}_{i} = R * S^{a} * T_{bi}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_first_index, S_index, T_second_index>>
-      LbAi_from_R_SA_Tbi = tenex::evaluate<ti_b, ti_A, ti_i>(R_SA_Tbi_expr);
+      LbAi_from_R_SA_Tbi = tenex::evaluate<ti::b, ti::A, ti::i>(R_SA_Tbi_expr);
   // \f$L_{bi}{}^{a} = R * S^{a} * T_{bi}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_first_index, T_second_index, S_index>>
-      LbiA_from_R_SA_Tbi = tenex::evaluate<ti_b, ti_i, ti_A>(R_SA_Tbi_expr);
+      LbiA_from_R_SA_Tbi = tenex::evaluate<ti::b, ti::i, ti::A>(R_SA_Tbi_expr);
   // \f$L_{i}{}^{a}{}_{b} = R * S^{a} * T_{bi}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_second_index, S_index, T_first_index>>
-      LiAb_from_R_SA_Tbi = tenex::evaluate<ti_i, ti_A, ti_b>(R_SA_Tbi_expr);
+      LiAb_from_R_SA_Tbi = tenex::evaluate<ti::i, ti::A, ti::b>(R_SA_Tbi_expr);
   // \f$L_{ib}{}^{a} = R * S^{a} * T_{bi}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_second_index, T_first_index, S_index>>
-      LibA_from_R_SA_Tbi = tenex::evaluate<ti_i, ti_b, ti_A>(R_SA_Tbi_expr);
+      LibA_from_R_SA_Tbi = tenex::evaluate<ti::i, ti::b, ti::A>(R_SA_Tbi_expr);
 
   // \f$R * T_{bi} * S^{a}\f$
-  const auto R_Tbi_SA_expr = R() * Tll(ti_b, ti_i) * Su(ti_A);
+  const auto R_Tbi_SA_expr = R() * Tll(ti::b, ti::i) * Su(ti::A);
   // \f$L^{a}{}_{bi} = R * T_{bi} * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<S_index, T_first_index, T_second_index>>
-      LAbi_from_R_Tbi_SA = tenex::evaluate<ti_A, ti_b, ti_i>(R_Tbi_SA_expr);
+      LAbi_from_R_Tbi_SA = tenex::evaluate<ti::A, ti::b, ti::i>(R_Tbi_SA_expr);
   // \f$L^{a}{}_{ib} = R * T_{bi} * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<S_index, T_second_index, T_first_index>>
-      LAib_from_R_Tbi_SA = tenex::evaluate<ti_A, ti_i, ti_b>(R_Tbi_SA_expr);
+      LAib_from_R_Tbi_SA = tenex::evaluate<ti::A, ti::i, ti::b>(R_Tbi_SA_expr);
   // \f$L_{b}{}^{a}{}_{i} = R * T_{bi} * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_first_index, S_index, T_second_index>>
-      LbAi_from_R_Tbi_SA = tenex::evaluate<ti_b, ti_A, ti_i>(R_Tbi_SA_expr);
+      LbAi_from_R_Tbi_SA = tenex::evaluate<ti::b, ti::A, ti::i>(R_Tbi_SA_expr);
   // \f$L_{bi}{}^{a} = R * R * T_{bi} * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_first_index, T_second_index, S_index>>
-      LbiA_from_R_Tbi_SA = tenex::evaluate<ti_b, ti_i, ti_A>(R_Tbi_SA_expr);
+      LbiA_from_R_Tbi_SA = tenex::evaluate<ti::b, ti::i, ti::A>(R_Tbi_SA_expr);
   // \f$L_{i}{}^{a}{}_{b} = R * T_{bi} * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_second_index, S_index, T_first_index>>
-      LiAb_from_R_Tbi_SA = tenex::evaluate<ti_i, ti_A, ti_b>(R_Tbi_SA_expr);
+      LiAb_from_R_Tbi_SA = tenex::evaluate<ti::i, ti::A, ti::b>(R_Tbi_SA_expr);
   // \f$L_{ib}{}^{a} = R * T_{bi} * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_second_index, T_first_index, S_index>>
-      LibA_from_R_Tbi_SA = tenex::evaluate<ti_i, ti_b, ti_A>(R_Tbi_SA_expr);
+      LibA_from_R_Tbi_SA = tenex::evaluate<ti::i, ti::b, ti::A>(R_Tbi_SA_expr);
 
   // \f$S^{a} * R * T_{bi}\f$
-  const auto SA_R_Tbi_expr = Su(ti_A) * R() * Tll(ti_b, ti_i);
+  const auto SA_R_Tbi_expr = Su(ti::A) * R() * Tll(ti::b, ti::i);
   // \f$L^{a}{}_{bi} = S^{a} * R * T_{bi}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<S_index, T_first_index, T_second_index>>
-      LAbi_from_SA_R_Tbi = tenex::evaluate<ti_A, ti_b, ti_i>(SA_R_Tbi_expr);
+      LAbi_from_SA_R_Tbi = tenex::evaluate<ti::A, ti::b, ti::i>(SA_R_Tbi_expr);
   // \f$L^{a}{}_{ib} = S^{a} * R * T_{bi}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<S_index, T_second_index, T_first_index>>
-      LAib_from_SA_R_Tbi = tenex::evaluate<ti_A, ti_i, ti_b>(SA_R_Tbi_expr);
+      LAib_from_SA_R_Tbi = tenex::evaluate<ti::A, ti::i, ti::b>(SA_R_Tbi_expr);
   // \f$L_{b}{}^{a}{}_{i} = S^{a} * R * T_{bi}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_first_index, S_index, T_second_index>>
-      LbAi_from_SA_R_Tbi = tenex::evaluate<ti_b, ti_A, ti_i>(SA_R_Tbi_expr);
+      LbAi_from_SA_R_Tbi = tenex::evaluate<ti::b, ti::A, ti::i>(SA_R_Tbi_expr);
   // \f$L_{bi}{}^{a} = S^{a} * R * T_{bi}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_first_index, T_second_index, S_index>>
-      LbiA_from_SA_R_Tbi = tenex::evaluate<ti_b, ti_i, ti_A>(SA_R_Tbi_expr);
+      LbiA_from_SA_R_Tbi = tenex::evaluate<ti::b, ti::i, ti::A>(SA_R_Tbi_expr);
   // \f$L_{i}{}^{a}{}_{b} = S^{a} * R * T_{bi}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_second_index, S_index, T_first_index>>
-      LiAb_from_SA_R_Tbi = tenex::evaluate<ti_i, ti_A, ti_b>(SA_R_Tbi_expr);
+      LiAb_from_SA_R_Tbi = tenex::evaluate<ti::i, ti::A, ti::b>(SA_R_Tbi_expr);
   // \f$L_{ib}{}^{a} = S^{a} * R * T_{bi}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_second_index, T_first_index, S_index>>
-      LibA_from_SA_R_Tbi = tenex::evaluate<ti_i, ti_b, ti_A>(SA_R_Tbi_expr);
+      LibA_from_SA_R_Tbi = tenex::evaluate<ti::i, ti::b, ti::A>(SA_R_Tbi_expr);
 
   // \f$S^{a} * T_{bi} * R\f$
-  const auto SA_Tbi_R_expr = Su(ti_A) * Tll(ti_b, ti_i) * R();
+  const auto SA_Tbi_R_expr = Su(ti::A) * Tll(ti::b, ti::i) * R();
   // \f$L^{a}{}_{bi} = S^{a} * T_{bi} * R\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<S_index, T_first_index, T_second_index>>
-      LAbi_from_SA_Tbi_R = tenex::evaluate<ti_A, ti_b, ti_i>(SA_Tbi_R_expr);
+      LAbi_from_SA_Tbi_R = tenex::evaluate<ti::A, ti::b, ti::i>(SA_Tbi_R_expr);
   // \f$L^{a}{}_{ib} = S^{a} * T_{bi} * R\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<S_index, T_second_index, T_first_index>>
-      LAib_from_SA_Tbi_R = tenex::evaluate<ti_A, ti_i, ti_b>(SA_Tbi_R_expr);
+      LAib_from_SA_Tbi_R = tenex::evaluate<ti::A, ti::i, ti::b>(SA_Tbi_R_expr);
   // \f$L_{b}{}^{a}{}_{i} = S^{a} * T_{bi} * R\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_first_index, S_index, T_second_index>>
-      LbAi_from_SA_Tbi_R = tenex::evaluate<ti_b, ti_A, ti_i>(SA_Tbi_R_expr);
+      LbAi_from_SA_Tbi_R = tenex::evaluate<ti::b, ti::A, ti::i>(SA_Tbi_R_expr);
   // \f$L_{bi}{}^{a} = S^{a} * T_{bi} * R\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_first_index, T_second_index, S_index>>
-      LbiA_from_SA_Tbi_R = tenex::evaluate<ti_b, ti_i, ti_A>(SA_Tbi_R_expr);
+      LbiA_from_SA_Tbi_R = tenex::evaluate<ti::b, ti::i, ti::A>(SA_Tbi_R_expr);
   // \f$L_{i}{}^{a}{}_{b} = S^{a} * T_{bi} * R\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_second_index, S_index, T_first_index>>
-      LiAb_from_SA_Tbi_R = tenex::evaluate<ti_i, ti_A, ti_b>(SA_Tbi_R_expr);
+      LiAb_from_SA_Tbi_R = tenex::evaluate<ti::i, ti::A, ti::b>(SA_Tbi_R_expr);
   // \f$L_{ib}{}^{a} = S^{a} * T_{bi} * R\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_second_index, T_first_index, S_index>>
-      LibA_from_SA_Tbi_R = tenex::evaluate<ti_i, ti_b, ti_A>(SA_Tbi_R_expr);
+      LibA_from_SA_Tbi_R = tenex::evaluate<ti::i, ti::b, ti::A>(SA_Tbi_R_expr);
 
   // \f$T_{bi} * R * S^{a}\f$
-  const auto Tbi_R_SA_expr = Tll(ti_b, ti_i) * R() * Su(ti_A);
+  const auto Tbi_R_SA_expr = Tll(ti::b, ti::i) * R() * Su(ti::A);
   // \f$L^{a}{}_{bi} = T_{bi} * R * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<S_index, T_first_index, T_second_index>>
-      LAbi_from_Tbi_R_SA = tenex::evaluate<ti_A, ti_b, ti_i>(Tbi_R_SA_expr);
+      LAbi_from_Tbi_R_SA = tenex::evaluate<ti::A, ti::b, ti::i>(Tbi_R_SA_expr);
   // \f$L^{a}{}_{ib} = T_{bi} * R * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<S_index, T_second_index, T_first_index>>
-      LAib_from_Tbi_R_SA = tenex::evaluate<ti_A, ti_i, ti_b>(Tbi_R_SA_expr);
+      LAib_from_Tbi_R_SA = tenex::evaluate<ti::A, ti::i, ti::b>(Tbi_R_SA_expr);
   // \f$L_{b}{}^{a}{}_{i} = T_{bi} * R * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_first_index, S_index, T_second_index>>
-      LbAi_from_Tbi_R_SA = tenex::evaluate<ti_b, ti_A, ti_i>(Tbi_R_SA_expr);
+      LbAi_from_Tbi_R_SA = tenex::evaluate<ti::b, ti::A, ti::i>(Tbi_R_SA_expr);
   // \f$L_{bi}{}^{a} = T_{bi} * R * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_first_index, T_second_index, S_index>>
-      LbiA_from_Tbi_R_SA = tenex::evaluate<ti_b, ti_i, ti_A>(Tbi_R_SA_expr);
+      LbiA_from_Tbi_R_SA = tenex::evaluate<ti::b, ti::i, ti::A>(Tbi_R_SA_expr);
   // \f$L_{i}{}^{a}{}_{b} = T_{bi} * R * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_second_index, S_index, T_first_index>>
-      LiAb_from_Tbi_R_SA = tenex::evaluate<ti_i, ti_A, ti_b>(Tbi_R_SA_expr);
+      LiAb_from_Tbi_R_SA = tenex::evaluate<ti::i, ti::A, ti::b>(Tbi_R_SA_expr);
   // \f$L_{ib}{}^{a} = T_{bi} * R * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_second_index, T_first_index, S_index>>
-      LibA_from_Tbi_R_SA = tenex::evaluate<ti_i, ti_b, ti_A>(Tbi_R_SA_expr);
+      LibA_from_Tbi_R_SA = tenex::evaluate<ti::i, ti::b, ti::A>(Tbi_R_SA_expr);
 
   // \f$T_{bi} * S^{a} * R\f$
-  const auto Tbi_SA_R_expr = Tll(ti_b, ti_i) * Su(ti_A) * R();
+  const auto Tbi_SA_R_expr = Tll(ti::b, ti::i) * Su(ti::A) * R();
   // \f$L^{a}{}_{bi} = T_{bi} * R * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<S_index, T_first_index, T_second_index>>
-      LAbi_from_Tbi_SA_R = tenex::evaluate<ti_A, ti_b, ti_i>(Tbi_SA_R_expr);
+      LAbi_from_Tbi_SA_R = tenex::evaluate<ti::A, ti::b, ti::i>(Tbi_SA_R_expr);
   // \f$L^{a}{}_{ib} = T_{bi} * R * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<S_index, T_second_index, T_first_index>>
-      LAib_from_Tbi_SA_R = tenex::evaluate<ti_A, ti_i, ti_b>(Tbi_SA_R_expr);
+      LAib_from_Tbi_SA_R = tenex::evaluate<ti::A, ti::i, ti::b>(Tbi_SA_R_expr);
   // \f$L_{b}{}^{a}{}_{i} = T_{bi} * R * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_first_index, S_index, T_second_index>>
-      LbAi_from_Tbi_SA_R = tenex::evaluate<ti_b, ti_A, ti_i>(Tbi_SA_R_expr);
+      LbAi_from_Tbi_SA_R = tenex::evaluate<ti::b, ti::A, ti::i>(Tbi_SA_R_expr);
   // \f$L_{bi}{}^{a} = T_{bi} * R * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_first_index, T_second_index, S_index>>
-      LbiA_from_Tbi_SA_R = tenex::evaluate<ti_b, ti_i, ti_A>(Tbi_SA_R_expr);
+      LbiA_from_Tbi_SA_R = tenex::evaluate<ti::b, ti::i, ti::A>(Tbi_SA_R_expr);
   // \f$L_{i}{}^{a}{}_{b} = T_{bi} * R * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_second_index, S_index, T_first_index>>
-      LiAb_from_Tbi_SA_R = tenex::evaluate<ti_i, ti_A, ti_b>(Tbi_SA_R_expr);
+      LiAb_from_Tbi_SA_R = tenex::evaluate<ti::i, ti::A, ti::b>(Tbi_SA_R_expr);
   // \f$L_{ib}{}^{a} = T_{bi} * R * S^{a}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<T_second_index, T_first_index, S_index>>
-      LibA_from_Tbi_SA_R = tenex::evaluate<ti_i, ti_b, ti_A>(Tbi_SA_R_expr);
+      LibA_from_Tbi_SA_R = tenex::evaluate<ti::i, ti::b, ti::A>(Tbi_SA_R_expr);
 
   for (size_t a = 0; a < S_index::dim; a++) {
     for (size_t b = 0; b < T_first_index::dim; b++) {
@@ -688,9 +688,9 @@ void test_inner_product_rank_1x1_operands(const DataType& used_for_size) {
   assign_unique_values_to_tensor(make_not_null(&Sl));
 
   // \f$L = R^{a} * S_{a}\f$
-  const Tensor<DataType> L_from_RA_Sa = tenex::evaluate(Ru(ti_A) * Sl(ti_a));
+  const Tensor<DataType> L_from_RA_Sa = tenex::evaluate(Ru(ti::A) * Sl(ti::a));
   // \f$L = S_{a} * R^{a}\f$
-  const Tensor<DataType> L_from_Sa_RA = tenex::evaluate(Sl(ti_a) * Ru(ti_A));
+  const Tensor<DataType> L_from_Sa_RA = tenex::evaluate(Sl(ti::a) * Ru(ti::A));
 
   DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
   for (size_t a = 0; a < 4; a++) {
@@ -756,28 +756,28 @@ void test_inner_product_rank_2x2_operands(const DataType& used_for_size) {
 
   // \f$L = Rll_{ai} * Ruu^{ai}\f$
   const Tensor<DataType> L_aiAI_product =
-      tenex::evaluate(Rll(ti_a, ti_i) * Ruu(ti_A, ti_I));
+      tenex::evaluate(Rll(ti::a, ti::i) * Ruu(ti::A, ti::I));
   // \f$L = Rll_{ai} * Suu^{ia}\f$
   const Tensor<DataType> L_aiIA_product =
-      tenex::evaluate(Rll(ti_a, ti_i) * Suu(ti_I, ti_A));
+      tenex::evaluate(Rll(ti::a, ti::i) * Suu(ti::I, ti::A));
   // \f$L = Ruu^{ai} * Rll_{ai}\f$
   const Tensor<DataType> L_AIai_product =
-      tenex::evaluate(Ruu(ti_A, ti_I) * Rll(ti_a, ti_i));
+      tenex::evaluate(Ruu(ti::A, ti::I) * Rll(ti::a, ti::i));
   // \f$L = Ruu^{ai} * Sll_{ia}\f$
   const Tensor<DataType> L_AIia_product =
-      tenex::evaluate(Ruu(ti_A, ti_I) * Sll(ti_i, ti_a));
+      tenex::evaluate(Ruu(ti::A, ti::I) * Sll(ti::i, ti::a));
   // \f$L = Rlu_{a}{}^{i} * Rul^{a}{}_{i}\f$
   const Tensor<DataType> L_aIAi_product =
-      tenex::evaluate(Rlu(ti_a, ti_I) * Rul(ti_A, ti_i));
+      tenex::evaluate(Rlu(ti::a, ti::I) * Rul(ti::A, ti::i));
   // \f$L = Rlu_{a}{}^{i} * Slu_{i}{}^{a}\f$
   const Tensor<DataType> L_aIiA_product =
-      tenex::evaluate(Rlu(ti_a, ti_I) * Slu(ti_i, ti_A));
+      tenex::evaluate(Rlu(ti::a, ti::I) * Slu(ti::i, ti::A));
   // \f$L = Rul^{a}{}_{i} * Rlu_{a}{}^{i}\f$
   const Tensor<DataType> L_AiaI_product =
-      tenex::evaluate(Rul(ti_A, ti_i) * Rlu(ti_a, ti_I));
+      tenex::evaluate(Rul(ti::A, ti::i) * Rlu(ti::a, ti::I));
   // \f$L = Rul^{a}{}_{i} * Sul^{i}{}_{a}\f$
   const Tensor<DataType> L_AiIa_product =
-      tenex::evaluate(Rul(ti_A, ti_i) * Sul(ti_I, ti_a));
+      tenex::evaluate(Rul(ti::A, ti::i) * Sul(ti::I, ti::a));
 
   DataType L_aiAI_expected_product =
       make_with_value<DataType>(used_for_size, 0.0);
@@ -846,13 +846,17 @@ void test_two_term_inner_outer_product(const DataType& used_for_size) {
   // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
   // return type of `evaluate`
   using Lb = Tensor<DataType, Symmetry<1>, index_list<R_index>>;
-  const Lb Lb_from_Rab_TA = tenex::evaluate<ti_b>(Rll(ti_a, ti_b) * Tu(ti_A));
+  const Lb Lb_from_Rab_TA =
+      tenex::evaluate<ti::b>(Rll(ti::a, ti::b) * Tu(ti::A));
   // \f$L_{b} = R_{ba} * T^{a}\f$
-  const Lb Lb_from_Rba_TA = tenex::evaluate<ti_b>(Rll(ti_b, ti_a) * Tu(ti_A));
+  const Lb Lb_from_Rba_TA =
+      tenex::evaluate<ti::b>(Rll(ti::b, ti::a) * Tu(ti::A));
   // \f$L_{b} = T^{a} * R_{ab}\f$
-  const Lb Lb_from_TA_Rab = tenex::evaluate<ti_b>(Tu(ti_A) * Rll(ti_a, ti_b));
+  const Lb Lb_from_TA_Rab =
+      tenex::evaluate<ti::b>(Tu(ti::A) * Rll(ti::a, ti::b));
   // \f$L_{b} = T^{a} * R_{ba}\f$
-  const Lb Lb_from_TA_Rba = tenex::evaluate<ti_b>(Tu(ti_A) * Rll(ti_b, ti_a));
+  const Lb Lb_from_TA_Rba =
+      tenex::evaluate<ti::b>(Tu(ti::A) * Rll(ti::b, ti::a));
 
   for (size_t b = 0; b < R_index::dim; b++) {
     DataType expected_product = make_with_value<DataType>(used_for_size, 0.0);
@@ -878,35 +882,35 @@ void test_two_term_inner_outer_product(const DataType& used_for_size) {
   // \f$L_{ac} = R_{ab} * S^{b}_{c}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<R_index, S_lower_index>>
       L_abBc_to_ac =
-          tenex::evaluate<ti_a, ti_c>(Rll(ti_a, ti_b) * Sul(ti_B, ti_c));
+          tenex::evaluate<ti::a, ti::c>(Rll(ti::a, ti::b) * Sul(ti::B, ti::c));
   // \f$L_{ca} = R_{ab} * S^{b}_{c}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<S_lower_index, R_index>>
       L_abBc_to_ca =
-          tenex::evaluate<ti_c, ti_a>(Rll(ti_a, ti_b) * Sul(ti_B, ti_c));
+          tenex::evaluate<ti::c, ti::a>(Rll(ti::a, ti::b) * Sul(ti::B, ti::c));
   // \f$L_{ac} = R_{ab} * S_{c}^{b}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<R_index, S_lower_index>>
       L_abcB_to_ac =
-          tenex::evaluate<ti_a, ti_c>(Rll(ti_a, ti_b) * Slu(ti_c, ti_B));
+          tenex::evaluate<ti::a, ti::c>(Rll(ti::a, ti::b) * Slu(ti::c, ti::B));
   // \f$L_{ca} = R_{ab} * S_{c}^{b}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<S_lower_index, R_index>>
       L_abcB_to_ca =
-          tenex::evaluate<ti_c, ti_a>(Rll(ti_a, ti_b) * Slu(ti_c, ti_B));
+          tenex::evaluate<ti::c, ti::a>(Rll(ti::a, ti::b) * Slu(ti::c, ti::B));
   // \f$L_{ac} = R_{ba} * S^{b}_{c}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<R_index, S_lower_index>>
       L_baBc_to_ac =
-          tenex::evaluate<ti_a, ti_c>(Rll(ti_b, ti_a) * Sul(ti_B, ti_c));
+          tenex::evaluate<ti::a, ti::c>(Rll(ti::b, ti::a) * Sul(ti::B, ti::c));
   // \f$L_{ca} = R_{ba} * S^{b}_{c}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<S_lower_index, R_index>>
       L_baBc_to_ca =
-          tenex::evaluate<ti_c, ti_a>(Rll(ti_b, ti_a) * Sul(ti_B, ti_c));
+          tenex::evaluate<ti::c, ti::a>(Rll(ti::b, ti::a) * Sul(ti::B, ti::c));
   // \f$L_{ac} = R_{ba} * S_{c}^{b}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<R_index, S_lower_index>>
       L_bacB_to_ac =
-          tenex::evaluate<ti_a, ti_c>(Rll(ti_b, ti_a) * Slu(ti_c, ti_B));
+          tenex::evaluate<ti::a, ti::c>(Rll(ti::b, ti::a) * Slu(ti::c, ti::B));
   // \f$L_{ca} = R_{ba} * S_{c}^{b}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<S_lower_index, R_index>>
       L_bacB_to_ca =
-          tenex::evaluate<ti_c, ti_a>(Rll(ti_b, ti_a) * Slu(ti_c, ti_B));
+          tenex::evaluate<ti::c, ti::a>(Rll(ti::b, ti::a) * Slu(ti::c, ti::B));
 
   for (size_t a = 0; a < R_index::dim; a++) {
     for (size_t c = 0; c < S_lower_index::dim; c++) {
@@ -965,13 +969,13 @@ void test_three_term_inner_outer_product(const DataType& used_for_size) {
 
   // \f$L_{i} = R^{j} * S_{j} * T_{i}\f$
   const decltype(Tl) Li_from_Jji =
-      tenex::evaluate<ti_i>(Ru(ti_J) * Sl(ti_j) * Tl(ti_i));
+      tenex::evaluate<ti::i>(Ru(ti::J) * Sl(ti::j) * Tl(ti::i));
   // \f$L_{i} = R^{j} * T_{i} * S_{j}\f$
   const decltype(Tl) Li_from_Jij =
-      tenex::evaluate<ti_i>(Ru(ti_J) * Tl(ti_i) * Sl(ti_j));
+      tenex::evaluate<ti::i>(Ru(ti::J) * Tl(ti::i) * Sl(ti::j));
   // \f$L_{i} = T_{i} * S_{j} * R^{j}\f$
   const decltype(Tl) Li_from_ijJ =
-      tenex::evaluate<ti_i>(Tl(ti_i) * Sl(ti_j) * Ru(ti_J));
+      tenex::evaluate<ti::i>(Tl(ti::i) * Sl(ti::j) * Ru(ti::J));
 
   for (size_t i = 0; i < 3; i++) {
     DataType expected_product = make_with_value<DataType>(used_for_size, 0.0);
@@ -992,52 +996,52 @@ void test_three_term_inner_outer_product(const DataType& used_for_size) {
 
   // \f$L_{i}{}^{k} = S_{j} * T_{i} * G^{jk}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<T_index, G_index>>
-      LiK_from_Sj_Ti_GJK =
-          tenex::evaluate<ti_i, ti_K>(Sl(ti_j) * Tl(ti_i) * Guu(ti_J, ti_K));
+      LiK_from_Sj_Ti_GJK = tenex::evaluate<ti::i, ti::K>(Sl(ti::j) * Tl(ti::i) *
+                                                         Guu(ti::J, ti::K));
   // \f$L^{k}{}_{i} = S_{j} * T_{i} * G^{jk}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<G_index, T_index>>
-      LKi_from_Sj_Ti_GJK =
-          tenex::evaluate<ti_K, ti_i>(Sl(ti_j) * Tl(ti_i) * Guu(ti_J, ti_K));
+      LKi_from_Sj_Ti_GJK = tenex::evaluate<ti::K, ti::i>(Sl(ti::j) * Tl(ti::i) *
+                                                         Guu(ti::J, ti::K));
   // \f$L_{i}{}^{k} = S_{j} *  G^{jk} * T_{i}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<T_index, G_index>>
-      LiK_from_Sj_GJK_Ti =
-          tenex::evaluate<ti_i, ti_K>(Sl(ti_j) * Guu(ti_J, ti_K) * Tl(ti_i));
+      LiK_from_Sj_GJK_Ti = tenex::evaluate<ti::i, ti::K>(
+          Sl(ti::j) * Guu(ti::J, ti::K) * Tl(ti::i));
   // \f$L^{k}{}_{i} = S_{j} *  G^{jk} * T_{i}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<G_index, T_index>>
-      LKi_from_Sj_GJK_Ti =
-          tenex::evaluate<ti_K, ti_i>(Sl(ti_j) * Guu(ti_J, ti_K) * Tl(ti_i));
+      LKi_from_Sj_GJK_Ti = tenex::evaluate<ti::K, ti::i>(
+          Sl(ti::j) * Guu(ti::J, ti::K) * Tl(ti::i));
   // \f$L_{i}{}^{k} = T_{i} * S_{j} * G^{jk}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<T_index, G_index>>
-      LiK_from_Ti_Sj_GJK =
-          tenex::evaluate<ti_i, ti_K>(Tl(ti_i) * Sl(ti_j) * Guu(ti_J, ti_K));
+      LiK_from_Ti_Sj_GJK = tenex::evaluate<ti::i, ti::K>(Tl(ti::i) * Sl(ti::j) *
+                                                         Guu(ti::J, ti::K));
   // \f$L^{k}{}_{i} = T_{i} * S_{j} * G^{jk}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<G_index, T_index>>
-      LKi_from_Ti_Sj_GJK =
-          tenex::evaluate<ti_K, ti_i>(Tl(ti_i) * Sl(ti_j) * Guu(ti_J, ti_K));
+      LKi_from_Ti_Sj_GJK = tenex::evaluate<ti::K, ti::i>(Tl(ti::i) * Sl(ti::j) *
+                                                         Guu(ti::J, ti::K));
   // \f$L_{i}{}^{k} = T_{i} * G^{jk} * S_{j}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<T_index, G_index>>
-      LiK_from_Ti_GJK_Sj =
-          tenex::evaluate<ti_i, ti_K>(Tl(ti_i) * Guu(ti_J, ti_K) * Sl(ti_j));
+      LiK_from_Ti_GJK_Sj = tenex::evaluate<ti::i, ti::K>(
+          Tl(ti::i) * Guu(ti::J, ti::K) * Sl(ti::j));
   // \f$L^{k}{}_{i} = T_{i} * G^{jk} * S_{j}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<G_index, T_index>>
-      LKi_from_Ti_GJK_Sj =
-          tenex::evaluate<ti_K, ti_i>(Tl(ti_i) * Guu(ti_J, ti_K) * Sl(ti_j));
+      LKi_from_Ti_GJK_Sj = tenex::evaluate<ti::K, ti::i>(
+          Tl(ti::i) * Guu(ti::J, ti::K) * Sl(ti::j));
   // \f$L_{i}{}^{k} = G^{jk} * S_{j} * T_{i}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<T_index, G_index>>
-      LiK_from_GJK_Sj_Ti =
-          tenex::evaluate<ti_i, ti_K>(Guu(ti_J, ti_K) * Sl(ti_j) * Tl(ti_i));
+      LiK_from_GJK_Sj_Ti = tenex::evaluate<ti::i, ti::K>(Guu(ti::J, ti::K) *
+                                                         Sl(ti::j) * Tl(ti::i));
   // \f$L^{k}{}_{i} = G^{jk} * S_{j} * T_{i}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<G_index, T_index>>
-      LKi_from_GJK_Sj_Ti =
-          tenex::evaluate<ti_K, ti_i>(Guu(ti_J, ti_K) * Sl(ti_j) * Tl(ti_i));
+      LKi_from_GJK_Sj_Ti = tenex::evaluate<ti::K, ti::i>(Guu(ti::J, ti::K) *
+                                                         Sl(ti::j) * Tl(ti::i));
   // \f$L_{i}{}^{k} = G^{jk} * T_{i} * S_{j}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<T_index, G_index>>
-      LiK_from_GJK_Ti_Sj =
-          tenex::evaluate<ti_i, ti_K>(Guu(ti_J, ti_K) * Tl(ti_i) * Sl(ti_j));
+      LiK_from_GJK_Ti_Sj = tenex::evaluate<ti::i, ti::K>(Guu(ti::J, ti::K) *
+                                                         Tl(ti::i) * Sl(ti::j));
   // \f$L^{k}{}_{i} = G^{jk} * T_{i} * S_{j}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<G_index, T_index>>
-      LKi_from_GJK_Ti_Sj =
-          tenex::evaluate<ti_K, ti_i>(Guu(ti_J, ti_K) * Tl(ti_i) * Sl(ti_j));
+      LKi_from_GJK_Ti_Sj = tenex::evaluate<ti::K, ti::i>(Guu(ti::J, ti::K) *
+                                                         Tl(ti::i) * Sl(ti::j));
 
   for (size_t k = 0; k < G_index::dim; k++) {
     for (size_t i = 0; i < T_index::dim; i++) {
@@ -1099,10 +1103,10 @@ void test_spatial_spacetime_index(const DataType& used_for_size) {
   // (spatial) * (spacetime) inner product with generic spatial indices
   // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
   // return type of `evaluate`
-  const Tensor<DataType> RS = tenex::evaluate(R(ti_I) * S(ti_i));
+  const Tensor<DataType> RS = tenex::evaluate(R(ti::I) * S(ti::i));
   // \f$L = R^{k} * T_{k}\f$
   // (spacetime) * (spacetime) inner product with generic spatial indices
-  const Tensor<DataType> RT = tenex::evaluate(R(ti_K) * T(ti_k));
+  const Tensor<DataType> RT = tenex::evaluate(R(ti::K) * T(ti::k));
 
   DataType expected_RS_product = make_with_value<DataType>(used_for_size, 0.0);
   DataType expected_RT_product = make_with_value<DataType>(used_for_size, 0.0);
@@ -1132,8 +1136,8 @@ void test_spatial_spacetime_index(const DataType& used_for_size) {
                           SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
                           SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
                           SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>>
-      GH = tenex::evaluate<ti_j, ti_a, ti_i, ti_B>(G(ti_i, ti_a) *
-                                                   H(ti_j, ti_B));
+      GH = tenex::evaluate<ti::j, ti::a, ti::i, ti::B>(G(ti::i, ti::a) *
+                                                       H(ti::j, ti::B));
   for (size_t j = 0; j < 3; j++) {
     for (size_t a = 0; a < 4; a++) {
       for (size_t i = 0; i < 3; i++) {
@@ -1151,7 +1155,7 @@ void test_spatial_spacetime_index(const DataType& used_for_size) {
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
                           SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>
-      HG = tenex::evaluate<ti_k, ti_i>(H(ti_i, ti_J) * G(ti_k, ti_j));
+      HG = tenex::evaluate<ti::k, ti::i>(H(ti::i, ti::J) * G(ti::k, ti::j));
   for (size_t k = 0; k < 3; k++) {
     for (size_t i = 0; i < 3; i++) {
       DataType expected_product = make_with_value<DataType>(used_for_size, 0.0);
@@ -1191,7 +1195,7 @@ void test_time_index(const DataType& used_for_size) {
   }
 
   // \f$L = R_{t} * S * R_{t}\f$
-  const Tensor<DataType> L = tenex::evaluate(R(ti_t) * S() * R(ti_t));
+  const Tensor<DataType> L = tenex::evaluate(R(ti::t) * S() * R(ti::t));
   CHECK(L.get() == R.get(0) * S.get() * R.get(0));
 
   Tensor<DataType, Symmetry<2, 1>,
@@ -1210,7 +1214,7 @@ void test_time_index(const DataType& used_for_size) {
   // \f$L^{b} = G_{t}{}^{a} * H_{a}{}^{tb}\f$
   const Tensor<DataType, Symmetry<1>,
                index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>
-      L_B = tenex::evaluate<ti_B>(G(ti_t, ti_A) * H(ti_a, ti_T, ti_B));
+      L_B = tenex::evaluate<ti::B>(G(ti::t, ti::A) * H(ti::a, ti::T, ti::B));
 
   for (size_t b = 0; b < 4; b++) {
     DataType expected_product = make_with_value<DataType>(used_for_size, 0.0);
@@ -1232,7 +1236,8 @@ void test_time_index(const DataType& used_for_size) {
                         SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>>(
       used_for_size, spatial_component_placeholder);
   // \f$L^{T}{}_{ba} = R_{a} * R_{b}\f$
-  tenex::evaluate<ti_T, ti_b, ti_a>(make_not_null(&L_Tba), R(ti_a) * R(ti_b));
+  tenex::evaluate<ti::T, ti::b, ti::a>(make_not_null(&L_Tba),
+                                       R(ti::a) * R(ti::b));
 
   for (size_t b = 0; b < 4; b++) {
     for (size_t a = 0; a < 4; a++) {
@@ -1249,9 +1254,9 @@ void test_time_index(const DataType& used_for_size) {
                         SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>>(
       used_for_size, spatial_component_placeholder);
   // \f$L_^{ct} = G_{t}{}^{b} * R_{b} * H_{t}^{ta}\f$
-  tenex::evaluate<ti_C, ti_T>(
+  tenex::evaluate<ti::C, ti::T>(
       make_not_null(&L_CT),
-      G(ti_t, ti_B) * H(ti_b, ti_A, ti_C) * G(ti_a, ti_T));
+      G(ti::t, ti::B) * H(ti::b, ti::A, ti::C) * G(ti::a, ti::T));
 
   for (size_t c = 0; c < 4; c++) {
     DataType expected_product = make_with_value<DataType>(used_for_size, 0.0);

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_ProductHighRankIntermediate.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_ProductHighRankIntermediate.cpp
@@ -87,9 +87,9 @@ void test_high_rank_intermediate(const DataType& used_for_size) {
   // \f$L^{c}{}_{dkl} = R_{jb}{}^{a} * (S_{da}{}^{BC} * T^{j}{}_{kl})\f$
   const Tensor<DataType, Symmetry<4, 3, 2, 1>,
                index_list<C_index, d_index, k_index, l_index>>
-      actual_result = tenex::evaluate<ti_C, ti_d, ti_k, ti_l>(
-          R(ti_j, ti_b, ti_A) *
-          (S(ti_d, ti_a, ti_B, ti_C) * T(ti_J, ti_k, ti_l)));
+      actual_result = tenex::evaluate<ti::C, ti::d, ti::k, ti::l>(
+          R(ti::j, ti::b, ti::A) *
+          (S(ti::d, ti::a, ti::B, ti::C) * T(ti::J, ti::k, ti::l)));
 
   for (size_t c = 0; c < C_index::dim; c++) {
     for (size_t d = 0; d < d_index::dim; d++) {

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_ProductHighRankIntermediate.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_ProductHighRankIntermediate.cpp
@@ -87,7 +87,7 @@ void test_high_rank_intermediate(const DataType& used_for_size) {
   // \f$L^{c}{}_{dkl} = R_{jb}{}^{a} * (S_{da}{}^{BC} * T^{j}{}_{kl})\f$
   const Tensor<DataType, Symmetry<4, 3, 2, 1>,
                index_list<C_index, d_index, k_index, l_index>>
-      actual_result = TensorExpressions::evaluate<ti_C, ti_d, ti_k, ti_l>(
+      actual_result = tenex::evaluate<ti_C, ti_d, ti_k, ti_l>(
           R(ti_j, ti_b, ti_A) *
           (S(ti_d, ti_a, ti_B, ti_C) * T(ti_J, ti_k, ti_l)));
 

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_SpatialSpacetimeIndex.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_SpatialSpacetimeIndex.cpp
@@ -67,34 +67,27 @@ using positions_list_02 = tmpl::integral_list<size_t, 0, 2>;
 using positions_list_012 = tmpl::integral_list<size_t, 0, 1, 2>;
 
 void test_spatial_spacetime_index_positions() {
-  CHECK(std::is_same_v<
-        TensorExpressions::detail::spatial_spacetime_index_positions<
-            index_list_empty, ti_list_empty>,
-        positions_list_empty>);
-  CHECK(std::is_same_v<
-        TensorExpressions::detail::spatial_spacetime_index_positions<
-            index_list_a, ti_list_a>,
-        positions_list_empty>);
-  CHECK(std::is_same_v<
-        TensorExpressions::detail::spatial_spacetime_index_positions<
-            index_list_a, ti_list_i>,
-        positions_list_0>);
-  CHECK(std::is_same_v<
-        TensorExpressions::detail::spatial_spacetime_index_positions<
-            index_list_aBC, ti_list_abc>,
-        positions_list_empty>);
-  CHECK(std::is_same_v<
-        TensorExpressions::detail::spatial_spacetime_index_positions<
-            index_list_aBC, ti_list_iaj>,
-        positions_list_02>);
-  CHECK(std::is_same_v<
-        TensorExpressions::detail::spatial_spacetime_index_positions<
-            index_list_aBC, ti_list_abc>,
-        positions_list_empty>);
-  CHECK(std::is_same_v<
-        TensorExpressions::detail::spatial_spacetime_index_positions<
-            index_list_aBC, ti_list_abi>,
-        positions_list_2>);
+  CHECK(std::is_same_v<tenex::detail::spatial_spacetime_index_positions<
+                           index_list_empty, ti_list_empty>,
+                       positions_list_empty>);
+  CHECK(std::is_same_v<tenex::detail::spatial_spacetime_index_positions<
+                           index_list_a, ti_list_a>,
+                       positions_list_empty>);
+  CHECK(std::is_same_v<tenex::detail::spatial_spacetime_index_positions<
+                           index_list_a, ti_list_i>,
+                       positions_list_0>);
+  CHECK(std::is_same_v<tenex::detail::spatial_spacetime_index_positions<
+                           index_list_aBC, ti_list_abc>,
+                       positions_list_empty>);
+  CHECK(std::is_same_v<tenex::detail::spatial_spacetime_index_positions<
+                           index_list_aBC, ti_list_iaj>,
+                       positions_list_02>);
+  CHECK(std::is_same_v<tenex::detail::spatial_spacetime_index_positions<
+                           index_list_aBC, ti_list_abc>,
+                       positions_list_empty>);
+  CHECK(std::is_same_v<tenex::detail::spatial_spacetime_index_positions<
+                           index_list_aBC, ti_list_abi>,
+                       positions_list_2>);
 }
 
 void test_get_spatial_spacetime_index_symmetry() {
@@ -116,172 +109,129 @@ void test_get_spatial_spacetime_index_symmetry() {
   constexpr std::array<size_t, 3> positions_012 = {{0, 1, 2}};
 
   // Rank 0
-  CHECK(detail::symmetry(
-            TensorExpressions::detail::get_spatial_spacetime_index_symmetry(
-                symm_empty, positions_empty)) == detail::symmetry(symm_empty));
+  CHECK(detail::symmetry(tenex::detail::get_spatial_spacetime_index_symmetry(
+            symm_empty, positions_empty)) == detail::symmetry(symm_empty));
 
   // Rank 1
-  CHECK(detail::symmetry(
-            TensorExpressions::detail::get_spatial_spacetime_index_symmetry(
-                symm_1, positions_empty)) == detail::symmetry(symm_1));
-  CHECK(detail::symmetry(
-            TensorExpressions::detail::get_spatial_spacetime_index_symmetry(
-                symm_1, positions_0)) == detail::symmetry(symm_1));
+  CHECK(detail::symmetry(tenex::detail::get_spatial_spacetime_index_symmetry(
+            symm_1, positions_empty)) == detail::symmetry(symm_1));
+  CHECK(detail::symmetry(tenex::detail::get_spatial_spacetime_index_symmetry(
+            symm_1, positions_0)) == detail::symmetry(symm_1));
 
   // Rank 3, input symmetry with three symmetric indices
-  CHECK(detail::symmetry(
-            TensorExpressions::detail::get_spatial_spacetime_index_symmetry(
-                symm_111, positions_0)) == detail::symmetry(symm_211));
-  CHECK(detail::symmetry(
-            TensorExpressions::detail::get_spatial_spacetime_index_symmetry(
-                symm_111, positions_1)) == detail::symmetry(symm_121));
-  CHECK(detail::symmetry(
-            TensorExpressions::detail::get_spatial_spacetime_index_symmetry(
-                symm_111, positions_2)) == detail::symmetry(symm_221));
-  CHECK(detail::symmetry(
-            TensorExpressions::detail::get_spatial_spacetime_index_symmetry(
-                symm_111, positions_01)) == detail::symmetry(symm_221));
-  CHECK(detail::symmetry(
-            TensorExpressions::detail::get_spatial_spacetime_index_symmetry(
-                symm_111, positions_02)) == detail::symmetry(symm_121));
-  CHECK(detail::symmetry(
-            TensorExpressions::detail::get_spatial_spacetime_index_symmetry(
-                symm_111, positions_12)) == detail::symmetry(symm_211));
-  CHECK(detail::symmetry(
-            TensorExpressions::detail::get_spatial_spacetime_index_symmetry(
-                symm_111, positions_012)) == detail::symmetry(symm_111));
+  CHECK(detail::symmetry(tenex::detail::get_spatial_spacetime_index_symmetry(
+            symm_111, positions_0)) == detail::symmetry(symm_211));
+  CHECK(detail::symmetry(tenex::detail::get_spatial_spacetime_index_symmetry(
+            symm_111, positions_1)) == detail::symmetry(symm_121));
+  CHECK(detail::symmetry(tenex::detail::get_spatial_spacetime_index_symmetry(
+            symm_111, positions_2)) == detail::symmetry(symm_221));
+  CHECK(detail::symmetry(tenex::detail::get_spatial_spacetime_index_symmetry(
+            symm_111, positions_01)) == detail::symmetry(symm_221));
+  CHECK(detail::symmetry(tenex::detail::get_spatial_spacetime_index_symmetry(
+            symm_111, positions_02)) == detail::symmetry(symm_121));
+  CHECK(detail::symmetry(tenex::detail::get_spatial_spacetime_index_symmetry(
+            symm_111, positions_12)) == detail::symmetry(symm_211));
+  CHECK(detail::symmetry(tenex::detail::get_spatial_spacetime_index_symmetry(
+            symm_111, positions_012)) == detail::symmetry(symm_111));
 
   // Rank 3, input symmetry with two symmetric indices
-  CHECK(detail::symmetry(
-            TensorExpressions::detail::get_spatial_spacetime_index_symmetry(
-                symm_121, positions_empty)) == detail::symmetry(symm_121));
-  CHECK(detail::symmetry(
-            TensorExpressions::detail::get_spatial_spacetime_index_symmetry(
-                symm_121, positions_0)) == detail::symmetry(symm_321));
-  CHECK(detail::symmetry(
-            TensorExpressions::detail::get_spatial_spacetime_index_symmetry(
-                symm_121, positions_1)) == detail::symmetry(symm_121));
-  CHECK(detail::symmetry(
-            TensorExpressions::detail::get_spatial_spacetime_index_symmetry(
-                symm_121, positions_2)) == detail::symmetry(symm_321));
-  CHECK(detail::symmetry(
-            TensorExpressions::detail::get_spatial_spacetime_index_symmetry(
-                symm_121, positions_01)) == detail::symmetry(symm_321));
-  CHECK(detail::symmetry(
-            TensorExpressions::detail::get_spatial_spacetime_index_symmetry(
-                symm_121, positions_02)) == detail::symmetry(symm_121));
-  CHECK(detail::symmetry(
-            TensorExpressions::detail::get_spatial_spacetime_index_symmetry(
-                symm_121, positions_12)) == detail::symmetry(symm_321));
-  CHECK(detail::symmetry(
-            TensorExpressions::detail::get_spatial_spacetime_index_symmetry(
-                symm_121, positions_012)) == detail::symmetry(symm_121));
+  CHECK(detail::symmetry(tenex::detail::get_spatial_spacetime_index_symmetry(
+            symm_121, positions_empty)) == detail::symmetry(symm_121));
+  CHECK(detail::symmetry(tenex::detail::get_spatial_spacetime_index_symmetry(
+            symm_121, positions_0)) == detail::symmetry(symm_321));
+  CHECK(detail::symmetry(tenex::detail::get_spatial_spacetime_index_symmetry(
+            symm_121, positions_1)) == detail::symmetry(symm_121));
+  CHECK(detail::symmetry(tenex::detail::get_spatial_spacetime_index_symmetry(
+            symm_121, positions_2)) == detail::symmetry(symm_321));
+  CHECK(detail::symmetry(tenex::detail::get_spatial_spacetime_index_symmetry(
+            symm_121, positions_01)) == detail::symmetry(symm_321));
+  CHECK(detail::symmetry(tenex::detail::get_spatial_spacetime_index_symmetry(
+            symm_121, positions_02)) == detail::symmetry(symm_121));
+  CHECK(detail::symmetry(tenex::detail::get_spatial_spacetime_index_symmetry(
+            symm_121, positions_12)) == detail::symmetry(symm_321));
+  CHECK(detail::symmetry(tenex::detail::get_spatial_spacetime_index_symmetry(
+            symm_121, positions_012)) == detail::symmetry(symm_121));
 
   // Rank 3, input symmetry with no symmetric indices
-  CHECK(detail::symmetry(
-            TensorExpressions::detail::get_spatial_spacetime_index_symmetry(
-                symm_321, positions_empty)) == detail::symmetry(symm_321));
-  CHECK(detail::symmetry(
-            TensorExpressions::detail::get_spatial_spacetime_index_symmetry(
-                symm_321, positions_0)) == detail::symmetry(symm_321));
-  CHECK(detail::symmetry(
-            TensorExpressions::detail::get_spatial_spacetime_index_symmetry(
-                symm_321, positions_1)) == detail::symmetry(symm_321));
-  CHECK(detail::symmetry(
-            TensorExpressions::detail::get_spatial_spacetime_index_symmetry(
-                symm_321, positions_2)) == detail::symmetry(symm_321));
-  CHECK(detail::symmetry(
-            TensorExpressions::detail::get_spatial_spacetime_index_symmetry(
-                symm_321, positions_01)) == detail::symmetry(symm_321));
-  CHECK(detail::symmetry(
-            TensorExpressions::detail::get_spatial_spacetime_index_symmetry(
-                symm_321, positions_02)) == detail::symmetry(symm_321));
-  CHECK(detail::symmetry(
-            TensorExpressions::detail::get_spatial_spacetime_index_symmetry(
-                symm_321, positions_12)) == detail::symmetry(symm_321));
-  CHECK(detail::symmetry(
-            TensorExpressions::detail::get_spatial_spacetime_index_symmetry(
-                symm_321, positions_012)) == detail::symmetry(symm_321));
+  CHECK(detail::symmetry(tenex::detail::get_spatial_spacetime_index_symmetry(
+            symm_321, positions_empty)) == detail::symmetry(symm_321));
+  CHECK(detail::symmetry(tenex::detail::get_spatial_spacetime_index_symmetry(
+            symm_321, positions_0)) == detail::symmetry(symm_321));
+  CHECK(detail::symmetry(tenex::detail::get_spatial_spacetime_index_symmetry(
+            symm_321, positions_1)) == detail::symmetry(symm_321));
+  CHECK(detail::symmetry(tenex::detail::get_spatial_spacetime_index_symmetry(
+            symm_321, positions_2)) == detail::symmetry(symm_321));
+  CHECK(detail::symmetry(tenex::detail::get_spatial_spacetime_index_symmetry(
+            symm_321, positions_01)) == detail::symmetry(symm_321));
+  CHECK(detail::symmetry(tenex::detail::get_spatial_spacetime_index_symmetry(
+            symm_321, positions_02)) == detail::symmetry(symm_321));
+  CHECK(detail::symmetry(tenex::detail::get_spatial_spacetime_index_symmetry(
+            symm_321, positions_12)) == detail::symmetry(symm_321));
+  CHECK(detail::symmetry(tenex::detail::get_spatial_spacetime_index_symmetry(
+            symm_321, positions_012)) == detail::symmetry(symm_321));
 }
 
 void test_replace_spatial_spacetime_indices() {
   // Rank 0
-  CHECK(std::is_same_v<
-        TensorExpressions::detail::replace_spatial_spacetime_indices<
-            index_list_empty, positions_list_empty>,
-        index_list_empty>);
+  CHECK(std::is_same_v<tenex::detail::replace_spatial_spacetime_indices<
+                           index_list_empty, positions_list_empty>,
+                       index_list_empty>);
 
   // Rank 1
-  CHECK(std::is_same_v<
-        TensorExpressions::detail::replace_spatial_spacetime_indices<
-            index_list_a, positions_list_empty>,
-        index_list_a>);
-  CHECK(std::is_same_v<
-        TensorExpressions::detail::replace_spatial_spacetime_indices<
-            index_list_a, positions_list_0>,
-        index_list_i>);
+  CHECK(std::is_same_v<tenex::detail::replace_spatial_spacetime_indices<
+                           index_list_a, positions_list_empty>,
+                       index_list_a>);
+  CHECK(std::is_same_v<tenex::detail::replace_spatial_spacetime_indices<
+                           index_list_a, positions_list_0>,
+                       index_list_i>);
 
   // Rank 3, one spacetime index
-  CHECK(std::is_same_v<
-        TensorExpressions::detail::replace_spatial_spacetime_indices<
-            index_list_iJA, positions_list_empty>,
-        index_list_iJA>);
-  CHECK(std::is_same_v<
-        TensorExpressions::detail::replace_spatial_spacetime_indices<
-            index_list_iJA, positions_list_2>,
-        index_list_iJK>);
+  CHECK(std::is_same_v<tenex::detail::replace_spatial_spacetime_indices<
+                           index_list_iJA, positions_list_empty>,
+                       index_list_iJA>);
+  CHECK(std::is_same_v<tenex::detail::replace_spatial_spacetime_indices<
+                           index_list_iJA, positions_list_2>,
+                       index_list_iJK>);
 
   // Rank 3, two spacetime indices
-  CHECK(std::is_same_v<
-        TensorExpressions::detail::replace_spatial_spacetime_indices<
-            index_list_iAB, positions_list_empty>,
-        index_list_iAB>);
-  CHECK(std::is_same_v<
-        TensorExpressions::detail::replace_spatial_spacetime_indices<
-            index_list_iAB, positions_list_1>,
-        index_list_iJA>);
-  CHECK(std::is_same_v<
-        TensorExpressions::detail::replace_spatial_spacetime_indices<
-            index_list_iAB, positions_list_2>,
-        index_list_iAJ>);
-  CHECK(std::is_same_v<
-        TensorExpressions::detail::replace_spatial_spacetime_indices<
-            index_list_iAB, positions_list_12>,
-        index_list_iJK>);
+  CHECK(std::is_same_v<tenex::detail::replace_spatial_spacetime_indices<
+                           index_list_iAB, positions_list_empty>,
+                       index_list_iAB>);
+  CHECK(std::is_same_v<tenex::detail::replace_spatial_spacetime_indices<
+                           index_list_iAB, positions_list_1>,
+                       index_list_iJA>);
+  CHECK(std::is_same_v<tenex::detail::replace_spatial_spacetime_indices<
+                           index_list_iAB, positions_list_2>,
+                       index_list_iAJ>);
+  CHECK(std::is_same_v<tenex::detail::replace_spatial_spacetime_indices<
+                           index_list_iAB, positions_list_12>,
+                       index_list_iJK>);
 
   // Rank 3, three spacetime indices
-  CHECK(std::is_same_v<
-        TensorExpressions::detail::replace_spatial_spacetime_indices<
-            index_list_aBC, positions_list_empty>,
-        index_list_aBC>);
-  CHECK(std::is_same_v<
-        TensorExpressions::detail::replace_spatial_spacetime_indices<
-            index_list_aBC, positions_list_0>,
-        index_list_iAB>);
-  CHECK(std::is_same_v<
-        TensorExpressions::detail::replace_spatial_spacetime_indices<
-            index_list_aBC, positions_list_1>,
-        index_list_aIB>);
-  CHECK(std::is_same_v<
-        TensorExpressions::detail::replace_spatial_spacetime_indices<
-            index_list_aBC, positions_list_2>,
-        index_list_aBI>);
-  CHECK(std::is_same_v<
-        TensorExpressions::detail::replace_spatial_spacetime_indices<
-            index_list_aBC, positions_list_01>,
-        index_list_iJA>);
-  CHECK(std::is_same_v<
-        TensorExpressions::detail::replace_spatial_spacetime_indices<
-            index_list_aBC, positions_list_02>,
-        index_list_iAJ>);
-  CHECK(std::is_same_v<
-        TensorExpressions::detail::replace_spatial_spacetime_indices<
-            index_list_aBC, positions_list_12>,
-        index_list_aIJ>);
-  CHECK(std::is_same_v<
-        TensorExpressions::detail::replace_spatial_spacetime_indices<
-            index_list_aBC, positions_list_012>,
-        index_list_iJK>);
+  CHECK(std::is_same_v<tenex::detail::replace_spatial_spacetime_indices<
+                           index_list_aBC, positions_list_empty>,
+                       index_list_aBC>);
+  CHECK(std::is_same_v<tenex::detail::replace_spatial_spacetime_indices<
+                           index_list_aBC, positions_list_0>,
+                       index_list_iAB>);
+  CHECK(std::is_same_v<tenex::detail::replace_spatial_spacetime_indices<
+                           index_list_aBC, positions_list_1>,
+                       index_list_aIB>);
+  CHECK(std::is_same_v<tenex::detail::replace_spatial_spacetime_indices<
+                           index_list_aBC, positions_list_2>,
+                       index_list_aBI>);
+  CHECK(std::is_same_v<tenex::detail::replace_spatial_spacetime_indices<
+                           index_list_aBC, positions_list_01>,
+                       index_list_iJA>);
+  CHECK(std::is_same_v<tenex::detail::replace_spatial_spacetime_indices<
+                           index_list_aBC, positions_list_02>,
+                       index_list_iAJ>);
+  CHECK(std::is_same_v<tenex::detail::replace_spatial_spacetime_indices<
+                           index_list_aBC, positions_list_12>,
+                       index_list_aIJ>);
+  CHECK(std::is_same_v<tenex::detail::replace_spatial_spacetime_indices<
+                           index_list_aBC, positions_list_012>,
+                       index_list_iJK>);
 }
 
 void test_spatial_spacetime_index_transformation_from_positions() {
@@ -300,34 +250,26 @@ void test_spatial_spacetime_index_transformation_from_positions() {
   constexpr std::array<std::int32_t, 3> transformation_00m1 = {{0, 0, -1}};
 
   // Rank 0
-  CHECK(TensorExpressions::detail::
-            spatial_spacetime_index_transformation_from_positions<0>(
-                positions_empty, positions_empty) == transformation_empty);
+  CHECK(tenex::detail::spatial_spacetime_index_transformation_from_positions<0>(
+            positions_empty, positions_empty) == transformation_empty);
 
   // Rank 1
-  CHECK(TensorExpressions::detail::
-            spatial_spacetime_index_transformation_from_positions<1>(
-                positions_empty, positions_empty) == transformation_0);
-  CHECK(TensorExpressions::detail::
-            spatial_spacetime_index_transformation_from_positions<1>(
-                positions_0, positions_0) == transformation_0);
-  CHECK(TensorExpressions::detail::
-            spatial_spacetime_index_transformation_from_positions<1>(
-                positions_0, positions_empty) == transformation_m1);
-  CHECK(TensorExpressions::detail::
-            spatial_spacetime_index_transformation_from_positions<1>(
-                positions_empty, positions_0) == transformation_p1);
+  CHECK(tenex::detail::spatial_spacetime_index_transformation_from_positions<1>(
+            positions_empty, positions_empty) == transformation_0);
+  CHECK(tenex::detail::spatial_spacetime_index_transformation_from_positions<1>(
+            positions_0, positions_0) == transformation_0);
+  CHECK(tenex::detail::spatial_spacetime_index_transformation_from_positions<1>(
+            positions_0, positions_empty) == transformation_m1);
+  CHECK(tenex::detail::spatial_spacetime_index_transformation_from_positions<1>(
+            positions_empty, positions_0) == transformation_p1);
 
   // Rank 3
-  CHECK(TensorExpressions::detail::
-            spatial_spacetime_index_transformation_from_positions<3>(
-                positions_empty, positions_empty) == transformation_000);
-  CHECK(TensorExpressions::detail::
-            spatial_spacetime_index_transformation_from_positions<3>(
-                positions_0, positions_2) == transformation_m10p10);
-  CHECK(TensorExpressions::detail::
-            spatial_spacetime_index_transformation_from_positions<3>(
-                positions_12, positions_1) == transformation_00m1);
+  CHECK(tenex::detail::spatial_spacetime_index_transformation_from_positions<3>(
+            positions_empty, positions_empty) == transformation_000);
+  CHECK(tenex::detail::spatial_spacetime_index_transformation_from_positions<3>(
+            positions_0, positions_2) == transformation_m10p10);
+  CHECK(tenex::detail::spatial_spacetime_index_transformation_from_positions<3>(
+            positions_12, positions_1) == transformation_00m1);
 }
 }  // namespace
 

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_SpatialSpacetimeIndex.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_SpatialSpacetimeIndex.cpp
@@ -48,14 +48,14 @@ using index_list_iJK = index_list<SpatialIndex<dim, UpLo::Lo, frame>,
                                   SpatialIndex<dim, UpLo::Up, frame>>;
 
 using ti_list_empty = tmpl::list<>;
-using ti_list_a = make_tensorindex_list<ti_a>;
-using ti_list_i = make_tensorindex_list<ti_i>;
-using ti_list_abc = make_tensorindex_list<ti_a, ti_b, ti_c>;
-using ti_list_ijk = make_tensorindex_list<ti_i, ti_j, ti_k>;
-using ti_list_abi = make_tensorindex_list<ti_a, ti_b, ti_i>;
-using ti_list_aij = make_tensorindex_list<ti_a, ti_i, ti_j>;
-using ti_list_iaj = make_tensorindex_list<ti_i, ti_a, ti_j>;
-using ti_list_ija = make_tensorindex_list<ti_i, ti_j, ti_a>;
+using ti_list_a = make_tensorindex_list<ti::a>;
+using ti_list_i = make_tensorindex_list<ti::i>;
+using ti_list_abc = make_tensorindex_list<ti::a, ti::b, ti::c>;
+using ti_list_ijk = make_tensorindex_list<ti::i, ti::j, ti::k>;
+using ti_list_abi = make_tensorindex_list<ti::a, ti::b, ti::i>;
+using ti_list_aij = make_tensorindex_list<ti::a, ti::i, ti::j>;
+using ti_list_iaj = make_tensorindex_list<ti::i, ti::a, ti::j>;
+using ti_list_ija = make_tensorindex_list<ti::i, ti::j, ti::a>;
 
 using positions_list_empty = tmpl::integral_list<size_t>;
 using positions_list_0 = tmpl::integral_list<size_t, 0>;

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_SquareRoot.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_SquareRoot.cpp
@@ -76,9 +76,10 @@ void test_sqrt(const DataType& used_for_size) {
   }
 
   // \f$L = \sqrt{S_{k}{}^{k}}\f$
-  const Tensor<DataType> sqrt_S = tenex::evaluate(sqrt(S(ti_k, ti_K)));
+  const Tensor<DataType> sqrt_S = tenex::evaluate(sqrt(S(ti::k, ti::K)));
   // \f$L = \sqrt{S_{k}{}^{k} * T}\f$
-  const Tensor<DataType> sqrt_S_T = tenex::evaluate(sqrt(S(ti_k, ti_K) * 3.6));
+  const Tensor<DataType> sqrt_S_T =
+      tenex::evaluate(sqrt(S(ti::k, ti::K) * 3.6));
   CHECK(sqrt_S.get() == sqrt(S_trace));
   CHECK(sqrt_S_T.get() == sqrt(S_trace * 3.6));
 
@@ -100,7 +101,7 @@ void test_sqrt(const DataType& used_for_size) {
   // Test expression that uses generic spatial index for a spacetime index
   // \f$L = \sqrt{G^{j} H_{j}\f$
   const Tensor<DataType> sqrt_GH_product =
-      tenex::evaluate(sqrt(G(ti_J) * H(ti_j)));
+      tenex::evaluate(sqrt(G(ti::J) * H(ti::j)));
   CHECK(sqrt_GH_product.get() == sqrt(GH_product));
 
   Tensor<DataType, Symmetry<2, 1>,
@@ -111,7 +112,7 @@ void test_sqrt(const DataType& used_for_size) {
 
   // Test expression that uses concrete time index for a spacetime index
   // \f$L = \sqrt{T_{t, t}\f$
-  const Scalar<DataType> sqrt_T_time = tenex::evaluate(sqrt(T(ti_t, ti_t)));
+  const Scalar<DataType> sqrt_T_time = tenex::evaluate(sqrt(T(ti::t, ti::t)));
   CHECK(sqrt_T_time.get() == sqrt(T.get(0, 0)));
 }
 }  // namespace

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_SquareRoot.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_SquareRoot.cpp
@@ -61,7 +61,7 @@ void test_sqrt(const DataType& used_for_size) {
   }
 
   // \f$L = \sqrt{R}\f$
-  Tensor<DataType> sqrt_R = TensorExpressions::evaluate(sqrt(R()));
+  Tensor<DataType> sqrt_R = tenex::evaluate(sqrt(R()));
   CHECK(sqrt_R.get() == sqrt(R.get()));
 
   Tensor<DataType, Symmetry<2, 1>,
@@ -76,11 +76,9 @@ void test_sqrt(const DataType& used_for_size) {
   }
 
   // \f$L = \sqrt{S_{k}{}^{k}}\f$
-  const Tensor<DataType> sqrt_S =
-      TensorExpressions::evaluate(sqrt(S(ti_k, ti_K)));
+  const Tensor<DataType> sqrt_S = tenex::evaluate(sqrt(S(ti_k, ti_K)));
   // \f$L = \sqrt{S_{k}{}^{k} * T}\f$
-  const Tensor<DataType> sqrt_S_T =
-      TensorExpressions::evaluate(sqrt(S(ti_k, ti_K) * 3.6));
+  const Tensor<DataType> sqrt_S_T = tenex::evaluate(sqrt(S(ti_k, ti_K) * 3.6));
   CHECK(sqrt_S.get() == sqrt(S_trace));
   CHECK(sqrt_S_T.get() == sqrt(S_trace * 3.6));
 
@@ -102,7 +100,7 @@ void test_sqrt(const DataType& used_for_size) {
   // Test expression that uses generic spatial index for a spacetime index
   // \f$L = \sqrt{G^{j} H_{j}\f$
   const Tensor<DataType> sqrt_GH_product =
-      TensorExpressions::evaluate(sqrt(G(ti_J) * H(ti_j)));
+      tenex::evaluate(sqrt(G(ti_J) * H(ti_j)));
   CHECK(sqrt_GH_product.get() == sqrt(GH_product));
 
   Tensor<DataType, Symmetry<2, 1>,
@@ -113,8 +111,7 @@ void test_sqrt(const DataType& used_for_size) {
 
   // Test expression that uses concrete time index for a spacetime index
   // \f$L = \sqrt{T_{t, t}\f$
-  const Scalar<DataType> sqrt_T_time =
-      TensorExpressions::evaluate(sqrt(T(ti_t, ti_t)));
+  const Scalar<DataType> sqrt_T_time = tenex::evaluate(sqrt(T(ti_t, ti_t)));
   CHECK(sqrt_T_time.get() == sqrt(T.get(0, 0)));
 }
 }  // namespace

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_TensorIndex.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_TensorIndex.cpp
@@ -10,12 +10,11 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.TensorIndex",
                   "[DataStructures][Unit]") {
   // Test `make_tensorindex_list`
   // Check at compile time since some other tests use this metafunction
-  static_assert(
-      std::is_same_v<
-          make_tensorindex_list<ti_j, ti_A, ti_b>,
-          tmpl::list<std::decay_t<decltype(ti_j)>, std::decay_t<decltype(ti_A)>,
-                     std::decay_t<decltype(ti_b)>>>,
-      "make_tensorindex_list failed for non-empty list");
+  static_assert(std::is_same_v<make_tensorindex_list<ti::j, ti::A, ti::b>,
+                               tmpl::list<std::decay_t<decltype(ti::j)>,
+                                          std::decay_t<decltype(ti::A)>,
+                                          std::decay_t<decltype(ti::b)>>>,
+                "make_tensorindex_list failed for non-empty list");
   static_assert(std::is_same_v<make_tensorindex_list<>, tmpl::list<>>,
                 "make_tensorindex_list failed for empty list");
 
@@ -69,53 +68,53 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.TensorIndex",
 
   // Test tensorindex_list_is_valid
   CHECK(tenex::tensorindex_list_is_valid<make_tensorindex_list<>>::value);
-  CHECK(tenex::tensorindex_list_is_valid<make_tensorindex_list<ti_J>>::value);
+  CHECK(tenex::tensorindex_list_is_valid<make_tensorindex_list<ti::J>>::value);
   CHECK(tenex::tensorindex_list_is_valid<
-        make_tensorindex_list<ti_a, ti_c, ti_I, ti_B>>::value);
+        make_tensorindex_list<ti::a, ti::c, ti::I, ti::B>>::value);
   CHECK(tenex::tensorindex_list_is_valid<
-        make_tensorindex_list<ti_t, ti_T, ti_T, ti_T, ti_t>>::value);
+        make_tensorindex_list<ti::t, ti::T, ti::T, ti::T, ti::t>>::value);
   CHECK(tenex::tensorindex_list_is_valid<
-        make_tensorindex_list<ti_d, ti_T, ti_D>>::value);
+        make_tensorindex_list<ti::d, ti::T, ti::D>>::value);
   CHECK(not tenex::tensorindex_list_is_valid<
-        make_tensorindex_list<ti_I, ti_a, ti_I>>::value);
+        make_tensorindex_list<ti::I, ti::a, ti::I>>::value);
 
   // Test tensorindex_list_is_valid
   CHECK(tenex::tensorindex_list_is_valid<make_tensorindex_list<>>::value);
-  CHECK(tenex::tensorindex_list_is_valid<make_tensorindex_list<ti_J>>::value);
+  CHECK(tenex::tensorindex_list_is_valid<make_tensorindex_list<ti::J>>::value);
   CHECK(tenex::tensorindex_list_is_valid<
-        make_tensorindex_list<ti_a, ti_c, ti_I, ti_B>>::value);
+        make_tensorindex_list<ti::a, ti::c, ti::I, ti::B>>::value);
   CHECK(tenex::tensorindex_list_is_valid<
-        make_tensorindex_list<ti_t, ti_T, ti_T, ti_T, ti_t>>::value);
+        make_tensorindex_list<ti::t, ti::T, ti::T, ti::T, ti::t>>::value);
   CHECK(tenex::tensorindex_list_is_valid<
-        make_tensorindex_list<ti_d, ti_T, ti_D>>::value);
+        make_tensorindex_list<ti::d, ti::T, ti::D>>::value);
   CHECK(not tenex::tensorindex_list_is_valid<
-        make_tensorindex_list<ti_I, ti_a, ti_I>>::value);
+        make_tensorindex_list<ti::I, ti::a, ti::I>>::value);
 
   // Test generic_indices_at_same_positions
   CHECK(
       tenex::generic_indices_at_same_positions<make_tensorindex_list<>,
                                                make_tensorindex_list<>>::value);
   CHECK(tenex::generic_indices_at_same_positions<
-        make_tensorindex_list<ti_a, ti_c, ti_I, ti_B>,
-        make_tensorindex_list<ti_a, ti_c, ti_I, ti_B>>::value);
+        make_tensorindex_list<ti::a, ti::c, ti::I, ti::B>,
+        make_tensorindex_list<ti::a, ti::c, ti::I, ti::B>>::value);
   CHECK(not tenex::generic_indices_at_same_positions<
-        make_tensorindex_list<ti_a, ti_c, ti_I, ti_B>,
-        make_tensorindex_list<ti_a, ti_c, ti_i, ti_B>>::value);
+        make_tensorindex_list<ti::a, ti::c, ti::I, ti::B>,
+        make_tensorindex_list<ti::a, ti::c, ti::i, ti::B>>::value);
   CHECK(not tenex::generic_indices_at_same_positions<
-        make_tensorindex_list<ti_a, ti_c, ti_I, ti_B>,
-        make_tensorindex_list<ti_a, ti_c, ti_I>>::value);
+        make_tensorindex_list<ti::a, ti::c, ti::I, ti::B>,
+        make_tensorindex_list<ti::a, ti::c, ti::I>>::value);
   CHECK(not tenex::generic_indices_at_same_positions<
-        make_tensorindex_list<ti_a, ti_c, ti_I>,
-        make_tensorindex_list<ti_a, ti_c, ti_I, ti_B>>::value);
+        make_tensorindex_list<ti::a, ti::c, ti::I>,
+        make_tensorindex_list<ti::a, ti::c, ti::I, ti::B>>::value);
   CHECK(not tenex::generic_indices_at_same_positions<
-        make_tensorindex_list<ti_j, ti_B>,
-        make_tensorindex_list<ti_B, ti_j>>::value);
+        make_tensorindex_list<ti::j, ti::B>,
+        make_tensorindex_list<ti::B, ti::j>>::value);
   CHECK(tenex::generic_indices_at_same_positions<
-        make_tensorindex_list<ti_T>, make_tensorindex_list<ti_t>>::value);
+        make_tensorindex_list<ti::T>, make_tensorindex_list<ti::t>>::value);
   CHECK(tenex::generic_indices_at_same_positions<
-        make_tensorindex_list<ti_t, ti_T, ti_T>,
-        make_tensorindex_list<ti_T, ti_t, ti_T>>::value);
+        make_tensorindex_list<ti::t, ti::T, ti::T>,
+        make_tensorindex_list<ti::T, ti::t, ti::T>>::value);
   CHECK(tenex::generic_indices_at_same_positions<
-        make_tensorindex_list<ti_i, ti_t, ti_C>,
-        make_tensorindex_list<ti_i, ti_T, ti_C>>::value);
+        make_tensorindex_list<ti::i, ti::t, ti::C>,
+        make_tensorindex_list<ti::i, ti::T, ti::C>>::value);
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_TensorIndex.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_TensorIndex.cpp
@@ -28,97 +28,94 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.TensorIndex",
   // value in between.
 
   // Lower spacetime
-  CHECK(TensorExpressions::get_tensorindex_value_with_opposite_valence(0) ==
-        TensorExpressions::TensorIndex_detail::upper_sentinel);
-  CHECK(TensorExpressions::get_tensorindex_value_with_opposite_valence(
-            TensorExpressions::TensorIndex_detail::upper_sentinel - 1) ==
-        TensorExpressions::TensorIndex_detail::spatial_sentinel - 1);
-  CHECK(TensorExpressions::get_tensorindex_value_with_opposite_valence(115) ==
-        TensorExpressions::TensorIndex_detail::upper_sentinel + 115);
+  CHECK(tenex::get_tensorindex_value_with_opposite_valence(0) ==
+        tenex::TensorIndex_detail::upper_sentinel);
+  CHECK(tenex::get_tensorindex_value_with_opposite_valence(
+            tenex::TensorIndex_detail::upper_sentinel - 1) ==
+        tenex::TensorIndex_detail::spatial_sentinel - 1);
+  CHECK(tenex::get_tensorindex_value_with_opposite_valence(115) ==
+        tenex::TensorIndex_detail::upper_sentinel + 115);
 
   // Upper spacetime
-  CHECK(TensorExpressions::get_tensorindex_value_with_opposite_valence(
-            TensorExpressions::TensorIndex_detail::upper_sentinel) == 0);
-  CHECK(TensorExpressions::get_tensorindex_value_with_opposite_valence(
-            TensorExpressions::TensorIndex_detail::spatial_sentinel - 1) ==
-        TensorExpressions::TensorIndex_detail::upper_sentinel - 1);
-  CHECK(TensorExpressions::get_tensorindex_value_with_opposite_valence(
-            TensorExpressions::TensorIndex_detail::upper_sentinel + 88) == 88);
+  CHECK(tenex::get_tensorindex_value_with_opposite_valence(
+            tenex::TensorIndex_detail::upper_sentinel) == 0);
+  CHECK(tenex::get_tensorindex_value_with_opposite_valence(
+            tenex::TensorIndex_detail::spatial_sentinel - 1) ==
+        tenex::TensorIndex_detail::upper_sentinel - 1);
+  CHECK(tenex::get_tensorindex_value_with_opposite_valence(
+            tenex::TensorIndex_detail::upper_sentinel + 88) == 88);
 
   // Lower spatial
-  CHECK(TensorExpressions::get_tensorindex_value_with_opposite_valence(
-            TensorExpressions::TensorIndex_detail::spatial_sentinel) ==
-        TensorExpressions::TensorIndex_detail::upper_spatial_sentinel);
-  CHECK(TensorExpressions::get_tensorindex_value_with_opposite_valence(
-            TensorExpressions::TensorIndex_detail::upper_spatial_sentinel -
-            1) == TensorExpressions::TensorIndex_detail::max_sentinel - 1);
-  CHECK(TensorExpressions::get_tensorindex_value_with_opposite_valence(
-            TensorExpressions::TensorIndex_detail::spatial_sentinel + 232) ==
-        TensorExpressions::TensorIndex_detail::upper_spatial_sentinel + 232);
+  CHECK(tenex::get_tensorindex_value_with_opposite_valence(
+            tenex::TensorIndex_detail::spatial_sentinel) ==
+        tenex::TensorIndex_detail::upper_spatial_sentinel);
+  CHECK(tenex::get_tensorindex_value_with_opposite_valence(
+            tenex::TensorIndex_detail::upper_spatial_sentinel - 1) ==
+        tenex::TensorIndex_detail::max_sentinel - 1);
+  CHECK(tenex::get_tensorindex_value_with_opposite_valence(
+            tenex::TensorIndex_detail::spatial_sentinel + 232) ==
+        tenex::TensorIndex_detail::upper_spatial_sentinel + 232);
 
   // Upper spatial
-  CHECK(TensorExpressions::get_tensorindex_value_with_opposite_valence(
-            TensorExpressions::TensorIndex_detail::upper_spatial_sentinel) ==
-        TensorExpressions::TensorIndex_detail::spatial_sentinel);
-  CHECK(TensorExpressions::get_tensorindex_value_with_opposite_valence(
-            TensorExpressions::TensorIndex_detail::max_sentinel - 1) ==
-        TensorExpressions::TensorIndex_detail::upper_spatial_sentinel - 1);
-  CHECK(TensorExpressions::get_tensorindex_value_with_opposite_valence(
-            TensorExpressions::TensorIndex_detail::upper_spatial_sentinel +
-            3) == TensorExpressions::TensorIndex_detail::spatial_sentinel + 3);
+  CHECK(tenex::get_tensorindex_value_with_opposite_valence(
+            tenex::TensorIndex_detail::upper_spatial_sentinel) ==
+        tenex::TensorIndex_detail::spatial_sentinel);
+  CHECK(tenex::get_tensorindex_value_with_opposite_valence(
+            tenex::TensorIndex_detail::max_sentinel - 1) ==
+        tenex::TensorIndex_detail::upper_spatial_sentinel - 1);
+  CHECK(tenex::get_tensorindex_value_with_opposite_valence(
+            tenex::TensorIndex_detail::upper_spatial_sentinel + 3) ==
+        tenex::TensorIndex_detail::spatial_sentinel + 3);
 
   // Test tensorindex_list_is_valid
-  CHECK(TensorExpressions::tensorindex_list_is_valid<
-        make_tensorindex_list<>>::value);
-  CHECK(TensorExpressions::tensorindex_list_is_valid<
-        make_tensorindex_list<ti_J>>::value);
-  CHECK(TensorExpressions::tensorindex_list_is_valid<
+  CHECK(tenex::tensorindex_list_is_valid<make_tensorindex_list<>>::value);
+  CHECK(tenex::tensorindex_list_is_valid<make_tensorindex_list<ti_J>>::value);
+  CHECK(tenex::tensorindex_list_is_valid<
         make_tensorindex_list<ti_a, ti_c, ti_I, ti_B>>::value);
-  CHECK(TensorExpressions::tensorindex_list_is_valid<
+  CHECK(tenex::tensorindex_list_is_valid<
         make_tensorindex_list<ti_t, ti_T, ti_T, ti_T, ti_t>>::value);
-  CHECK(TensorExpressions::tensorindex_list_is_valid<
+  CHECK(tenex::tensorindex_list_is_valid<
         make_tensorindex_list<ti_d, ti_T, ti_D>>::value);
-  CHECK(not TensorExpressions::tensorindex_list_is_valid<
+  CHECK(not tenex::tensorindex_list_is_valid<
         make_tensorindex_list<ti_I, ti_a, ti_I>>::value);
 
   // Test tensorindex_list_is_valid
-  CHECK(TensorExpressions::tensorindex_list_is_valid<
-        make_tensorindex_list<>>::value);
-  CHECK(TensorExpressions::tensorindex_list_is_valid<
-        make_tensorindex_list<ti_J>>::value);
-  CHECK(TensorExpressions::tensorindex_list_is_valid<
+  CHECK(tenex::tensorindex_list_is_valid<make_tensorindex_list<>>::value);
+  CHECK(tenex::tensorindex_list_is_valid<make_tensorindex_list<ti_J>>::value);
+  CHECK(tenex::tensorindex_list_is_valid<
         make_tensorindex_list<ti_a, ti_c, ti_I, ti_B>>::value);
-  CHECK(TensorExpressions::tensorindex_list_is_valid<
+  CHECK(tenex::tensorindex_list_is_valid<
         make_tensorindex_list<ti_t, ti_T, ti_T, ti_T, ti_t>>::value);
-  CHECK(TensorExpressions::tensorindex_list_is_valid<
+  CHECK(tenex::tensorindex_list_is_valid<
         make_tensorindex_list<ti_d, ti_T, ti_D>>::value);
-  CHECK(not TensorExpressions::tensorindex_list_is_valid<
+  CHECK(not tenex::tensorindex_list_is_valid<
         make_tensorindex_list<ti_I, ti_a, ti_I>>::value);
 
   // Test generic_indices_at_same_positions
-  CHECK(TensorExpressions::generic_indices_at_same_positions<
-        make_tensorindex_list<>, make_tensorindex_list<>>::value);
-  CHECK(TensorExpressions::generic_indices_at_same_positions<
+  CHECK(
+      tenex::generic_indices_at_same_positions<make_tensorindex_list<>,
+                                               make_tensorindex_list<>>::value);
+  CHECK(tenex::generic_indices_at_same_positions<
         make_tensorindex_list<ti_a, ti_c, ti_I, ti_B>,
         make_tensorindex_list<ti_a, ti_c, ti_I, ti_B>>::value);
-  CHECK(not TensorExpressions::generic_indices_at_same_positions<
+  CHECK(not tenex::generic_indices_at_same_positions<
         make_tensorindex_list<ti_a, ti_c, ti_I, ti_B>,
         make_tensorindex_list<ti_a, ti_c, ti_i, ti_B>>::value);
-  CHECK(not TensorExpressions::generic_indices_at_same_positions<
+  CHECK(not tenex::generic_indices_at_same_positions<
         make_tensorindex_list<ti_a, ti_c, ti_I, ti_B>,
         make_tensorindex_list<ti_a, ti_c, ti_I>>::value);
-  CHECK(not TensorExpressions::generic_indices_at_same_positions<
+  CHECK(not tenex::generic_indices_at_same_positions<
         make_tensorindex_list<ti_a, ti_c, ti_I>,
         make_tensorindex_list<ti_a, ti_c, ti_I, ti_B>>::value);
-  CHECK(not TensorExpressions::generic_indices_at_same_positions<
+  CHECK(not tenex::generic_indices_at_same_positions<
         make_tensorindex_list<ti_j, ti_B>,
         make_tensorindex_list<ti_B, ti_j>>::value);
-  CHECK(TensorExpressions::generic_indices_at_same_positions<
+  CHECK(tenex::generic_indices_at_same_positions<
         make_tensorindex_list<ti_T>, make_tensorindex_list<ti_t>>::value);
-  CHECK(TensorExpressions::generic_indices_at_same_positions<
+  CHECK(tenex::generic_indices_at_same_positions<
         make_tensorindex_list<ti_t, ti_T, ti_T>,
         make_tensorindex_list<ti_T, ti_t, ti_T>>::value);
-  CHECK(TensorExpressions::generic_indices_at_same_positions<
+  CHECK(tenex::generic_indices_at_same_positions<
         make_tensorindex_list<ti_i, ti_t, ti_C>,
         make_tensorindex_list<ti_i, ti_T, ti_C>>::value);
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_TensorIndexTransformation.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_TensorIndexTransformation.cpp
@@ -15,85 +15,76 @@ SPECTRE_TEST_CASE(
     "Unit.DataStructures.Tensor.Expression.TensorIndexTransformation",
     "[DataStructures][Unit]") {
   // Rank 0
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_0();
+  TestHelpers::tenex::test_tensor_index_transformation_rank_0();
 
   // Rank 1
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_1(ti_k);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_1(ti_k);
 
   // Rank 2
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_2(ti_i,
-                                                                          ti_j);
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_2(ti_j,
-                                                                          ti_i);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_2(ti_i, ti_j);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_2(ti_j, ti_i);
 
   // Rank 3
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_3(
-      ti_a, ti_b, ti_c);
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_3(
-      ti_a, ti_c, ti_b);
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_3(
-      ti_b, ti_a, ti_c);
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_3(
-      ti_b, ti_c, ti_a);
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_3(
-      ti_c, ti_a, ti_b);
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_3(
-      ti_c, ti_b, ti_a);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_3(ti_a, ti_b, ti_c);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_3(ti_a, ti_c, ti_b);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_3(ti_b, ti_a, ti_c);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_3(ti_b, ti_c, ti_a);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_3(ti_c, ti_a, ti_b);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_3(ti_c, ti_b, ti_a);
 
   // Rank 4
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_4(
-      ti_a, ti_b, ti_c, ti_d);
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_4(
-      ti_a, ti_b, ti_d, ti_c);
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_4(
-      ti_a, ti_c, ti_b, ti_d);
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_4(
-      ti_a, ti_c, ti_d, ti_b);
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_4(
-      ti_a, ti_d, ti_b, ti_c);
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_4(
-      ti_a, ti_d, ti_c, ti_b);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_a, ti_b, ti_c,
+                                                              ti_d);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_a, ti_b, ti_d,
+                                                              ti_c);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_a, ti_c, ti_b,
+                                                              ti_d);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_a, ti_c, ti_d,
+                                                              ti_b);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_a, ti_d, ti_b,
+                                                              ti_c);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_a, ti_d, ti_c,
+                                                              ti_b);
 
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_4(
-      ti_b, ti_a, ti_c, ti_d);
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_4(
-      ti_b, ti_a, ti_c, ti_d);
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_4(
-      ti_b, ti_c, ti_a, ti_d);
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_4(
-      ti_b, ti_c, ti_d, ti_a);
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_4(
-      ti_b, ti_d, ti_a, ti_c);
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_4(
-      ti_b, ti_d, ti_c, ti_a);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_b, ti_a, ti_c,
+                                                              ti_d);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_b, ti_a, ti_c,
+                                                              ti_d);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_b, ti_c, ti_a,
+                                                              ti_d);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_b, ti_c, ti_d,
+                                                              ti_a);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_b, ti_d, ti_a,
+                                                              ti_c);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_b, ti_d, ti_c,
+                                                              ti_a);
 
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_4(
-      ti_c, ti_a, ti_b, ti_d);
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_4(
-      ti_c, ti_a, ti_d, ti_b);
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_4(
-      ti_c, ti_b, ti_a, ti_d);
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_4(
-      ti_c, ti_b, ti_d, ti_a);
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_4(
-      ti_c, ti_d, ti_a, ti_b);
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_4(
-      ti_c, ti_d, ti_b, ti_a);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_c, ti_a, ti_b,
+                                                              ti_d);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_c, ti_a, ti_d,
+                                                              ti_b);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_c, ti_b, ti_a,
+                                                              ti_d);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_c, ti_b, ti_d,
+                                                              ti_a);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_c, ti_d, ti_a,
+                                                              ti_b);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_c, ti_d, ti_b,
+                                                              ti_a);
 
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_4(
-      ti_d, ti_a, ti_b, ti_c);
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_4(
-      ti_d, ti_a, ti_c, ti_b);
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_4(
-      ti_d, ti_b, ti_a, ti_c);
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_4(
-      ti_d, ti_b, ti_c, ti_a);
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_4(
-      ti_d, ti_c, ti_a, ti_b);
-  TestHelpers::TensorExpressions::test_tensor_index_transformation_rank_4(
-      ti_d, ti_c, ti_b, ti_a);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_d, ti_a, ti_b,
+                                                              ti_c);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_d, ti_a, ti_c,
+                                                              ti_b);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_d, ti_b, ti_a,
+                                                              ti_c);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_d, ti_b, ti_c,
+                                                              ti_a);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_d, ti_c, ti_a,
+                                                              ti_b);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_d, ti_c, ti_b,
+                                                              ti_a);
 
   // Test transformations involving time indices
-  TestHelpers::TensorExpressions::
-      test_tensor_index_transformation_with_time_indices();
+  TestHelpers::tenex::test_tensor_index_transformation_with_time_indices();
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_TensorIndexTransformation.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_TensorIndexTransformation.cpp
@@ -18,72 +18,78 @@ SPECTRE_TEST_CASE(
   TestHelpers::tenex::test_tensor_index_transformation_rank_0();
 
   // Rank 1
-  TestHelpers::tenex::test_tensor_index_transformation_rank_1(ti_k);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_1(ti::k);
 
   // Rank 2
-  TestHelpers::tenex::test_tensor_index_transformation_rank_2(ti_i, ti_j);
-  TestHelpers::tenex::test_tensor_index_transformation_rank_2(ti_j, ti_i);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_2(ti::i, ti::j);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_2(ti::j, ti::i);
 
   // Rank 3
-  TestHelpers::tenex::test_tensor_index_transformation_rank_3(ti_a, ti_b, ti_c);
-  TestHelpers::tenex::test_tensor_index_transformation_rank_3(ti_a, ti_c, ti_b);
-  TestHelpers::tenex::test_tensor_index_transformation_rank_3(ti_b, ti_a, ti_c);
-  TestHelpers::tenex::test_tensor_index_transformation_rank_3(ti_b, ti_c, ti_a);
-  TestHelpers::tenex::test_tensor_index_transformation_rank_3(ti_c, ti_a, ti_b);
-  TestHelpers::tenex::test_tensor_index_transformation_rank_3(ti_c, ti_b, ti_a);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_3(ti::a, ti::b,
+                                                              ti::c);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_3(ti::a, ti::c,
+                                                              ti::b);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_3(ti::b, ti::a,
+                                                              ti::c);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_3(ti::b, ti::c,
+                                                              ti::a);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_3(ti::c, ti::a,
+                                                              ti::b);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_3(ti::c, ti::b,
+                                                              ti::a);
 
   // Rank 4
-  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_a, ti_b, ti_c,
-                                                              ti_d);
-  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_a, ti_b, ti_d,
-                                                              ti_c);
-  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_a, ti_c, ti_b,
-                                                              ti_d);
-  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_a, ti_c, ti_d,
-                                                              ti_b);
-  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_a, ti_d, ti_b,
-                                                              ti_c);
-  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_a, ti_d, ti_c,
-                                                              ti_b);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti::a, ti::b,
+                                                              ti::c, ti::d);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti::a, ti::b,
+                                                              ti::d, ti::c);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti::a, ti::c,
+                                                              ti::b, ti::d);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti::a, ti::c,
+                                                              ti::d, ti::b);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti::a, ti::d,
+                                                              ti::b, ti::c);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti::a, ti::d,
+                                                              ti::c, ti::b);
 
-  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_b, ti_a, ti_c,
-                                                              ti_d);
-  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_b, ti_a, ti_c,
-                                                              ti_d);
-  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_b, ti_c, ti_a,
-                                                              ti_d);
-  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_b, ti_c, ti_d,
-                                                              ti_a);
-  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_b, ti_d, ti_a,
-                                                              ti_c);
-  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_b, ti_d, ti_c,
-                                                              ti_a);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti::b, ti::a,
+                                                              ti::c, ti::d);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti::b, ti::a,
+                                                              ti::c, ti::d);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti::b, ti::c,
+                                                              ti::a, ti::d);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti::b, ti::c,
+                                                              ti::d, ti::a);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti::b, ti::d,
+                                                              ti::a, ti::c);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti::b, ti::d,
+                                                              ti::c, ti::a);
 
-  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_c, ti_a, ti_b,
-                                                              ti_d);
-  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_c, ti_a, ti_d,
-                                                              ti_b);
-  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_c, ti_b, ti_a,
-                                                              ti_d);
-  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_c, ti_b, ti_d,
-                                                              ti_a);
-  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_c, ti_d, ti_a,
-                                                              ti_b);
-  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_c, ti_d, ti_b,
-                                                              ti_a);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti::c, ti::a,
+                                                              ti::b, ti::d);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti::c, ti::a,
+                                                              ti::d, ti::b);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti::c, ti::b,
+                                                              ti::a, ti::d);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti::c, ti::b,
+                                                              ti::d, ti::a);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti::c, ti::d,
+                                                              ti::a, ti::b);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti::c, ti::d,
+                                                              ti::b, ti::a);
 
-  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_d, ti_a, ti_b,
-                                                              ti_c);
-  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_d, ti_a, ti_c,
-                                                              ti_b);
-  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_d, ti_b, ti_a,
-                                                              ti_c);
-  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_d, ti_b, ti_c,
-                                                              ti_a);
-  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_d, ti_c, ti_a,
-                                                              ti_b);
-  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti_d, ti_c, ti_b,
-                                                              ti_a);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti::d, ti::a,
+                                                              ti::b, ti::c);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti::d, ti::a,
+                                                              ti::c, ti::b);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti::d, ti::b,
+                                                              ti::a, ti::c);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti::d, ti::b,
+                                                              ti::c, ti::a);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti::d, ti::c,
+                                                              ti::a, ti::b);
+  TestHelpers::tenex::test_tensor_index_transformation_rank_4(ti::d, ti::c,
+                                                              ti::b, ti::a);
 
   // Test transformations involving time indices
   TestHelpers::tenex::test_tensor_index_transformation_with_time_indices();

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_TimeIndex.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_TimeIndex.cpp
@@ -18,10 +18,10 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.TimeIndex",
   CHECK(not tt::is_time_index<std::decay_t<decltype(ti_I)>>::value);
 
   // Test is_time_index_value
-  CHECK(TensorExpressions::detail::is_time_index_value(ti_t.value));
-  CHECK(TensorExpressions::detail::is_time_index_value(ti_T.value));
-  CHECK(not TensorExpressions::detail::is_time_index_value(ti_C.value));
-  CHECK(not TensorExpressions::detail::is_time_index_value(ti_j.value));
+  CHECK(tenex::detail::is_time_index_value(ti_t.value));
+  CHECK(tenex::detail::is_time_index_value(ti_T.value));
+  CHECK(not tenex::detail::is_time_index_value(ti_C.value));
+  CHECK(not tenex::detail::is_time_index_value(ti_j.value));
 
   // Lists of TensorIndexs used for testing below
   using empty_index_list = make_tensorindex_list<>;
@@ -35,42 +35,33 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.TimeIndex",
   using aBj = make_tensorindex_list<ti_a, ti_B, ti_j>;
 
   // Test remove_time_indices
-  CHECK(std::is_same_v<
-        TensorExpressions::detail::remove_time_indices<empty_index_list>::type,
-        empty_index_list>);
-  CHECK(std::is_same_v<TensorExpressions::detail::remove_time_indices<a>::type,
-                       a>);
   CHECK(
-      std::is_same_v<TensorExpressions::detail::remove_time_indices<aiC>::type,
-                     aiC>);
-  CHECK(std::is_same_v<TensorExpressions::detail::remove_time_indices<t>::type,
+      std::is_same_v<tenex::detail::remove_time_indices<empty_index_list>::type,
+                     empty_index_list>);
+  CHECK(std::is_same_v<tenex::detail::remove_time_indices<a>::type, a>);
+  CHECK(std::is_same_v<tenex::detail::remove_time_indices<aiC>::type, aiC>);
+  CHECK(std::is_same_v<tenex::detail::remove_time_indices<t>::type,
                        empty_index_list>);
-  CHECK(std::is_same_v<TensorExpressions::detail::remove_time_indices<TT>::type,
+  CHECK(std::is_same_v<tenex::detail::remove_time_indices<TT>::type,
                        empty_index_list>);
-  CHECK(std::is_same_v<TensorExpressions::detail::remove_time_indices<tc>::type,
-                       c>);
-  CHECK(std::is_same_v<
-        TensorExpressions::detail::remove_time_indices<atTBjT>::type, aBj>);
+  CHECK(std::is_same_v<tenex::detail::remove_time_indices<tc>::type, c>);
+  CHECK(std::is_same_v<tenex::detail::remove_time_indices<atTBjT>::type, aBj>);
 
   // Test get_time_index_positions
   const std::array<size_t, 0> expected_empty_positions{};
-  CHECK(
-      TensorExpressions::detail::get_time_index_positions<empty_index_list>() ==
-      expected_empty_positions);
-  CHECK(TensorExpressions::detail::get_time_index_positions<a>() ==
+  CHECK(tenex::detail::get_time_index_positions<empty_index_list>() ==
         expected_empty_positions);
-  CHECK(TensorExpressions::detail::get_time_index_positions<aiC>() ==
+  CHECK(tenex::detail::get_time_index_positions<a>() ==
+        expected_empty_positions);
+  CHECK(tenex::detail::get_time_index_positions<aiC>() ==
         expected_empty_positions);
   const std::array<size_t, 1> expected_t_positions{0};
-  CHECK(TensorExpressions::detail::get_time_index_positions<t>() ==
-        expected_t_positions);
+  CHECK(tenex::detail::get_time_index_positions<t>() == expected_t_positions);
   const std::array<size_t, 2> expected_TT_positions{0, 1};
-  CHECK(TensorExpressions::detail::get_time_index_positions<TT>() ==
-        expected_TT_positions);
+  CHECK(tenex::detail::get_time_index_positions<TT>() == expected_TT_positions);
   const std::array<size_t, 1> expected_tc_positions{0};
-  CHECK(TensorExpressions::detail::get_time_index_positions<tc>() ==
-        expected_tc_positions);
+  CHECK(tenex::detail::get_time_index_positions<tc>() == expected_tc_positions);
   const std::array<size_t, 3> expected_atTBjT_positions{1, 2, 5};
-  CHECK(TensorExpressions::detail::get_time_index_positions<atTBjT>() ==
+  CHECK(tenex::detail::get_time_index_positions<atTBjT>() ==
         expected_atTBjT_positions);
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_TimeIndex.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_TimeIndex.cpp
@@ -12,27 +12,28 @@
 SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.TimeIndex",
                   "[DataStructures][Unit]") {
   // Test tt::is_time_index
-  CHECK(tt::is_time_index<std::decay_t<decltype(ti_t)>>::value);
-  CHECK(tt::is_time_index<std::decay_t<decltype(ti_T)>>::value);
-  CHECK(not tt::is_time_index<std::decay_t<decltype(ti_b)>>::value);
-  CHECK(not tt::is_time_index<std::decay_t<decltype(ti_I)>>::value);
+  CHECK(tt::is_time_index<std::decay_t<decltype(ti::t)>>::value);
+  CHECK(tt::is_time_index<std::decay_t<decltype(ti::T)>>::value);
+  CHECK(not tt::is_time_index<std::decay_t<decltype(ti::b)>>::value);
+  CHECK(not tt::is_time_index<std::decay_t<decltype(ti::I)>>::value);
 
   // Test is_time_index_value
-  CHECK(tenex::detail::is_time_index_value(ti_t.value));
-  CHECK(tenex::detail::is_time_index_value(ti_T.value));
-  CHECK(not tenex::detail::is_time_index_value(ti_C.value));
-  CHECK(not tenex::detail::is_time_index_value(ti_j.value));
+  CHECK(tenex::detail::is_time_index_value(ti::t.value));
+  CHECK(tenex::detail::is_time_index_value(ti::T.value));
+  CHECK(not tenex::detail::is_time_index_value(ti::C.value));
+  CHECK(not tenex::detail::is_time_index_value(ti::j.value));
 
   // Lists of TensorIndexs used for testing below
   using empty_index_list = make_tensorindex_list<>;
-  using a = make_tensorindex_list<ti_a>;
-  using aiC = make_tensorindex_list<ti_a, ti_i, ti_C>;
-  using t = make_tensorindex_list<ti_t>;
-  using TT = make_tensorindex_list<ti_T, ti_T>;
-  using tc = make_tensorindex_list<ti_t, ti_c>;
-  using c = make_tensorindex_list<ti_c>;
-  using atTBjT = make_tensorindex_list<ti_a, ti_t, ti_T, ti_B, ti_j, ti_T>;
-  using aBj = make_tensorindex_list<ti_a, ti_B, ti_j>;
+  using a = make_tensorindex_list<ti::a>;
+  using aiC = make_tensorindex_list<ti::a, ti::i, ti::C>;
+  using t = make_tensorindex_list<ti::t>;
+  using TT = make_tensorindex_list<ti::T, ti::T>;
+  using tc = make_tensorindex_list<ti::t, ti::c>;
+  using c = make_tensorindex_list<ti::c>;
+  using atTBjT =
+      make_tensorindex_list<ti::a, ti::t, ti::T, ti::B, ti::j, ti::T>;
+  using aBj = make_tensorindex_list<ti::a, ti::B, ti::j>;
 
   // Test remove_time_indices
   CHECK(

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_Ricci.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_Ricci.cpp
@@ -125,7 +125,7 @@ void test_compute_spatial_ricci_tensor(
   }
 
   const auto contracted_field_d_up =
-      ::tenex::evaluate<ti_L>(field_d_up(ti_m, ti_M, ti_L));
+      ::tenex::evaluate<ti::L>(field_d_up(ti::m, ti::M, ti::L));
 
   using field_d_tag =
       Ccz4::Tags::FieldD<SpatialDim, Frame::Inertial, DataVector>;
@@ -166,7 +166,7 @@ void test_compute_spatial_ricci_tensor(
       conformal_christoffel_second_kind);
 
   const auto contracted_christoffel_second_kind =
-      tenex::evaluate<ti_l>(christoffel_second_kind(ti_M, ti_l, ti_m));
+      tenex::evaluate<ti::l>(christoffel_second_kind(ti::M, ti::l, ti::m));
 
   using christoffel_second_kind_tag =
       gr::Tags::SpatialChristoffelSecondKind<SpatialDim, Frame::Inertial,
@@ -183,9 +183,9 @@ void test_compute_spatial_ricci_tensor(
                       Frame::Inertial>>(d_christoffel_second_kind_var);
 
   const auto contracted_d_conformal_christoffel_difference =
-      ::tenex::evaluate<ti_i, ti_j>(
-          d_conformal_christoffel_second_kind(ti_m, ti_M, ti_i, ti_j) -
-          d_conformal_christoffel_second_kind(ti_j, ti_M, ti_i, ti_m));
+      ::tenex::evaluate<ti::i, ti::j>(
+          d_conformal_christoffel_second_kind(ti::m, ti::M, ti::i, ti::j) -
+          d_conformal_christoffel_second_kind(ti::j, ti::M, ti::i, ti::m));
 
   // Compute expected and actual ricci tensors using above computed arguments
   const auto expected_py_ricci_tensor{

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_Ricci.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_Ricci.cpp
@@ -125,7 +125,7 @@ void test_compute_spatial_ricci_tensor(
   }
 
   const auto contracted_field_d_up =
-      ::TensorExpressions::evaluate<ti_L>(field_d_up(ti_m, ti_M, ti_L));
+      ::tenex::evaluate<ti_L>(field_d_up(ti_m, ti_M, ti_L));
 
   using field_d_tag =
       Ccz4::Tags::FieldD<SpatialDim, Frame::Inertial, DataVector>;
@@ -166,8 +166,7 @@ void test_compute_spatial_ricci_tensor(
       conformal_christoffel_second_kind);
 
   const auto contracted_christoffel_second_kind =
-      TensorExpressions::evaluate<ti_l>(
-          christoffel_second_kind(ti_M, ti_l, ti_m));
+      tenex::evaluate<ti_l>(christoffel_second_kind(ti_M, ti_l, ti_m));
 
   using christoffel_second_kind_tag =
       gr::Tags::SpatialChristoffelSecondKind<SpatialDim, Frame::Inertial,
@@ -184,7 +183,7 @@ void test_compute_spatial_ricci_tensor(
                       Frame::Inertial>>(d_christoffel_second_kind_var);
 
   const auto contracted_d_conformal_christoffel_difference =
-      ::TensorExpressions::evaluate<ti_i, ti_j>(
+      ::tenex::evaluate<ti_i, ti_j>(
           d_conformal_christoffel_second_kind(ti_m, ti_M, ti_i, ti_j) -
           d_conformal_christoffel_second_kind(ti_j, ti_M, ti_i, ti_m));
 

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank0.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank0.hpp
@@ -11,7 +11,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
-namespace TestHelpers::TensorExpressions {
+namespace TestHelpers::tenex {
 
 /// \ingroup TestingFrameworkGroup
 /// \brief Test that evaluating a right hand side tensor expression containing a
@@ -25,9 +25,9 @@ void test_evaluate_rank_0(const DataType& data) {
 
   // Use explicit type (vs auto) so the compiler checks the return type of
   // `evaluate`
-  const Tensor<DataType> L_returned = ::TensorExpressions::evaluate(R());
+  const Tensor<DataType> L_returned = ::tenex::evaluate(R());
   Tensor<DataType> L_filled{};
-  ::TensorExpressions::evaluate(make_not_null(&L_filled), R());
+  ::tenex::evaluate(make_not_null(&L_filled), R());
 
   CHECK(L_returned.get() == data);
   CHECK(L_filled.get() == data);
@@ -38,10 +38,10 @@ void test_evaluate_rank_0(const DataType& data) {
         data.size()};
     Tensor<DataType>& L_temp =
         get<::Tags::TempTensor<1, Tensor<DataType>>>(L_var);
-    ::TensorExpressions::evaluate(make_not_null(&L_temp), R());
+    ::tenex::evaluate(make_not_null(&L_temp), R());
 
     CHECK(L_temp.get() == data);
   }
 }
 
-}  // namespace TestHelpers::TensorExpressions
+}  // namespace TestHelpers::tenex

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank1.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank1.hpp
@@ -17,7 +17,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
-namespace TestHelpers::TensorExpressions {
+namespace TestHelpers::tenex {
 
 /// \ingroup TestingFrameworkGroup
 /// \brief Test that evaluating a right hand side tensor expression containing a
@@ -40,10 +40,9 @@ void test_evaluate_rank_1_impl() {
   // Use explicit type (vs auto) so the compiler checks return type of
   // `evaluate`
   const tensor_type L_a_returned =
-      ::TensorExpressions::evaluate<TensorIndex>(R_a(TensorIndex));
+      ::tenex::evaluate<TensorIndex>(R_a(TensorIndex));
   tensor_type L_a_filled{};
-  ::TensorExpressions::evaluate<TensorIndex>(make_not_null(&L_a_filled),
-                                             R_a(TensorIndex));
+  ::tenex::evaluate<TensorIndex>(make_not_null(&L_a_filled), R_a(TensorIndex));
 
   const size_t dim = tmpl::at_c<TensorIndexTypeList, 0>::dim;
 
@@ -59,8 +58,7 @@ void test_evaluate_rank_1_impl() {
     Variables<tmpl::list<::Tags::TempTensor<1, tensor_type>>> L_a_var{
         used_for_size};
     tensor_type& L_a_temp = get<::Tags::TempTensor<1, tensor_type>>(L_a_var);
-    ::TensorExpressions::evaluate<TensorIndex>(make_not_null(&L_a_temp),
-                                               R_a(TensorIndex));
+    ::tenex::evaluate<TensorIndex>(make_not_null(&L_a_temp), R_a(TensorIndex));
 
     // For L_a = R_a, check that L_i == R_i
     for (size_t i = 0; i < dim; ++i) {
@@ -98,4 +96,4 @@ void test_evaluate_rank_1() {
 #undef DIM
 }
 
-}  // namespace TestHelpers::TensorExpressions
+}  // namespace TestHelpers::tenex

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank1.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank1.hpp
@@ -28,7 +28,7 @@ namespace TestHelpers::tenex {
 /// \tparam TensorIndexTypeList the Tensors' typelist containing their
 /// \ref SpacetimeIndex "TensorIndexType"
 /// \tparam TensorIndex the TensorIndex used in the the TensorExpression,
-/// e.g. `ti_a`
+/// e.g. `ti::a`
 template <typename DataType, typename TensorIndexTypeList, auto& TensorIndex>
 void test_evaluate_rank_1_impl() {
   const size_t used_for_size = 5;
@@ -75,7 +75,7 @@ void test_evaluate_rank_1_impl() {
 /// \tparam TensorIndexType the Tensors' \ref SpacetimeIndex "TensorIndexType"
 /// \tparam Valence the valence of the Tensors' index
 /// \tparam TensorIndex the TensorIndex used in the the TensorExpression,
-/// e.g. `ti_a`
+/// e.g. `ti::a`
 template <typename DataType,
           template <size_t, UpLo, typename> class TensorIndexType, UpLo Valence,
           auto& TensorIndex>

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank2.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank2.hpp
@@ -25,7 +25,7 @@ namespace TestHelpers::tenex {
 /// side tensor
 ///
 /// \details `TensorIndexA` and `TensorIndexB` can be any type of TensorIndex
-/// and are not necessarily `ti_a` and `ti_b`. The "A" and "B" suffixes just
+/// and are not necessarily `ti::a` and `ti::b`. The "A" and "B" suffixes just
 /// denote the ordering of the generic indices of the RHS tensor expression. In
 /// the RHS tensor expression, it means `TensorIndexA` is the first index used
 /// and `TensorIndexB` is the second index used.
@@ -41,9 +41,9 @@ namespace TestHelpers::tenex {
 /// \tparam RhsTensorIndexTypeList the RHS Tensor's typelist of
 /// \ref SpacetimeIndex "TensorIndexType"s
 /// \tparam TensorIndexA the first TensorIndex used on the RHS of the
-/// TensorExpression, e.g. `ti_a`
+/// TensorExpression, e.g. `ti::a`
 /// \tparam TensorIndexB the second TensorIndex used on the RHS of the
-/// TensorExpression, e.g. `ti_B`
+/// TensorExpression, e.g. `ti::B`
 template <typename DataType, typename RhsSymmetry,
           typename RhsTensorIndexTypeList, auto& TensorIndexA,
           auto& TensorIndexB>
@@ -125,7 +125,7 @@ void test_evaluate_rank_2_impl() {
 /// - <1, 1> (`test_evaluate_rank_2_symmetric`)
 ///
 /// \details `TensorIndexA` and `TensorIndexB` can be any type of TensorIndex
-/// and are not necessarily `ti_a` and `ti_b`. The "A" and "B" suffixes just
+/// and are not necessarily `ti::a` and `ti::b`. The "A" and "B" suffixes just
 /// denote the ordering of the generic indices of the RHS tensor expression. In
 /// the RHS tensor expression, it means `TensorIndexA` is the first index used
 /// and `TensorIndexB` is the second index used.
@@ -144,9 +144,9 @@ void test_evaluate_rank_2_impl() {
 /// \tparam ValenceB the valence of the second index used on the RHS of the
 /// TensorExpression
 /// \tparam TensorIndexA the first TensorIndex used on the RHS of the
-/// TensorExpression, e.g. `ti_a`
+/// TensorExpression, e.g. `ti::a`
 /// \tparam TensorIndexB the second TensorIndex used on the RHS of the
-/// TensorExpression, e.g. `ti_B`
+/// TensorExpression, e.g. `ti::B`
 template <typename DataType,
           template <size_t, UpLo, typename> class TensorIndexTypeA,
           template <size_t, UpLo, typename> class TensorIndexTypeB,

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank2.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank2.hpp
@@ -17,7 +17,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
-namespace TestHelpers::TensorExpressions {
+namespace TestHelpers::tenex {
 
 /// \ingroup TestingFrameworkGroup
 /// \brief Test that evaluating a right hand side tensor expression containing a
@@ -56,11 +56,10 @@ void test_evaluate_rank_2_impl() {
   // Use explicit type (vs auto) so the compiler checks the return type of
   // `evaluate`
   using L_ab_type = decltype(R_ab);
-  const L_ab_type L_ab_returned =
-      ::TensorExpressions::evaluate<TensorIndexA, TensorIndexB>(
-          R_ab(TensorIndexA, TensorIndexB));
+  const L_ab_type L_ab_returned = ::tenex::evaluate<TensorIndexA, TensorIndexB>(
+      R_ab(TensorIndexA, TensorIndexB));
   L_ab_type L_ab_filled{};
-  ::TensorExpressions::evaluate<TensorIndexA, TensorIndexB>(
+  ::tenex::evaluate<TensorIndexA, TensorIndexB>(
       make_not_null(&L_ab_filled), R_ab(TensorIndexA, TensorIndexB));
 
   // L_{ba} = R_{ab}
@@ -68,11 +67,10 @@ void test_evaluate_rank_2_impl() {
       tmpl::list<tmpl::at_c<RhsTensorIndexTypeList, 1>,
                  tmpl::at_c<RhsTensorIndexTypeList, 0>>;
   using L_ba_type = Tensor<DataType, RhsSymmetry, L_ba_tensorindextype_list>;
-  const L_ba_type L_ba_returned =
-      ::TensorExpressions::evaluate<TensorIndexB, TensorIndexA>(
-          R_ab(TensorIndexA, TensorIndexB));
+  const L_ba_type L_ba_returned = ::tenex::evaluate<TensorIndexB, TensorIndexA>(
+      R_ab(TensorIndexA, TensorIndexB));
   L_ba_type L_ba_filled{};
-  ::TensorExpressions::evaluate<TensorIndexB, TensorIndexA>(
+  ::tenex::evaluate<TensorIndexB, TensorIndexA>(
       make_not_null(&L_ba_filled), R_ab(TensorIndexA, TensorIndexB));
 
   const size_t dim_a = tmpl::at_c<RhsTensorIndexTypeList, 0>::dim;
@@ -95,14 +93,14 @@ void test_evaluate_rank_2_impl() {
     Variables<tmpl::list<::Tags::TempTensor<1, L_ab_type>>> L_ab_var{
         used_for_size};
     L_ab_type& L_ab_temp = get<::Tags::TempTensor<1, L_ab_type>>(L_ab_var);
-    ::TensorExpressions::evaluate<TensorIndexA, TensorIndexB>(
+    ::tenex::evaluate<TensorIndexA, TensorIndexB>(
         make_not_null(&L_ab_temp), R_ab(TensorIndexA, TensorIndexB));
 
     // L_{ba} = R_{ab}
     Variables<tmpl::list<::Tags::TempTensor<1, L_ba_type>>> L_ba_var{
         used_for_size};
     L_ba_type& L_ba_temp = get<::Tags::TempTensor<1, L_ba_type>>(L_ba_var);
-    ::TensorExpressions::evaluate<TensorIndexB, TensorIndexA>(
+    ::tenex::evaluate<TensorIndexB, TensorIndexA>(
         make_not_null(&L_ba_temp), R_ab(TensorIndexA, TensorIndexB));
 
     for (size_t i = 0; i < dim_a; ++i) {
@@ -198,4 +196,4 @@ void test_evaluate_rank_2_symmetric() {
 #undef DIM
 }
 
-}  // namespace TestHelpers::TensorExpressions
+}  // namespace TestHelpers::tenex

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank3.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank3.hpp
@@ -18,7 +18,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
-namespace TestHelpers::TensorExpressions {
+namespace TestHelpers::tenex {
 
 /// \ingroup TestingFrameworkGroup
 /// \brief Test that evaluating a right hand side tensor expression containing a
@@ -70,10 +70,10 @@ void test_evaluate_rank_3_impl() {
   // `evaluate`
   using L_abc_type = Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList>;
   const L_abc_type L_abc_returned =
-      ::TensorExpressions::evaluate<TensorIndexA, TensorIndexB, TensorIndexC>(
+      ::tenex::evaluate<TensorIndexA, TensorIndexB, TensorIndexC>(
           R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
   L_abc_type L_abc_filled{};
-  ::TensorExpressions::evaluate<TensorIndexA, TensorIndexB, TensorIndexC>(
+  ::tenex::evaluate<TensorIndexA, TensorIndexB, TensorIndexC>(
       make_not_null(&L_abc_filled),
       R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
 
@@ -87,10 +87,10 @@ void test_evaluate_rank_3_impl() {
   using L_acb_type =
       Tensor<DataType, L_acb_symmetry, L_acb_tensorindextype_list>;
   const L_acb_type L_acb_returned =
-      ::TensorExpressions::evaluate<TensorIndexA, TensorIndexC, TensorIndexB>(
+      ::tenex::evaluate<TensorIndexA, TensorIndexC, TensorIndexB>(
           R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
   L_acb_type L_acb_filled{};
-  ::TensorExpressions::evaluate<TensorIndexA, TensorIndexC, TensorIndexB>(
+  ::tenex::evaluate<TensorIndexA, TensorIndexC, TensorIndexB>(
       make_not_null(&L_acb_filled),
       R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
 
@@ -104,10 +104,10 @@ void test_evaluate_rank_3_impl() {
   using L_bac_type =
       Tensor<DataType, L_bac_symmetry, L_bac_tensorindextype_list>;
   const L_bac_type L_bac_returned =
-      ::TensorExpressions::evaluate<TensorIndexB, TensorIndexA, TensorIndexC>(
+      ::tenex::evaluate<TensorIndexB, TensorIndexA, TensorIndexC>(
           R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
   L_bac_type L_bac_filled{};
-  ::TensorExpressions::evaluate<TensorIndexB, TensorIndexA, TensorIndexC>(
+  ::tenex::evaluate<TensorIndexB, TensorIndexA, TensorIndexC>(
       make_not_null(&L_bac_filled),
       R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
 
@@ -121,10 +121,10 @@ void test_evaluate_rank_3_impl() {
   using L_bca_type =
       Tensor<DataType, L_bca_symmetry, L_bca_tensorindextype_list>;
   const L_bca_type L_bca_returned =
-      ::TensorExpressions::evaluate<TensorIndexB, TensorIndexC, TensorIndexA>(
+      ::tenex::evaluate<TensorIndexB, TensorIndexC, TensorIndexA>(
           R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
   L_bca_type L_bca_filled{};
-  ::TensorExpressions::evaluate<TensorIndexB, TensorIndexC, TensorIndexA>(
+  ::tenex::evaluate<TensorIndexB, TensorIndexC, TensorIndexA>(
       make_not_null(&L_bca_filled),
       R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
 
@@ -138,10 +138,10 @@ void test_evaluate_rank_3_impl() {
   using L_cab_type =
       Tensor<DataType, L_cab_symmetry, L_cab_tensorindextype_list>;
   const L_cab_type L_cab_returned =
-      ::TensorExpressions::evaluate<TensorIndexC, TensorIndexA, TensorIndexB>(
+      ::tenex::evaluate<TensorIndexC, TensorIndexA, TensorIndexB>(
           R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
   L_cab_type L_cab_filled{};
-  ::TensorExpressions::evaluate<TensorIndexC, TensorIndexA, TensorIndexB>(
+  ::tenex::evaluate<TensorIndexC, TensorIndexA, TensorIndexB>(
       make_not_null(&L_cab_filled),
       R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
 
@@ -155,10 +155,10 @@ void test_evaluate_rank_3_impl() {
   using L_cba_type =
       Tensor<DataType, L_cba_symmetry, L_cba_tensorindextype_list>;
   const L_cba_type L_cba_returned =
-      ::TensorExpressions::evaluate<TensorIndexC, TensorIndexB, TensorIndexA>(
+      ::tenex::evaluate<TensorIndexC, TensorIndexB, TensorIndexA>(
           R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
   L_cba_type L_cba_filled{};
-  ::TensorExpressions::evaluate<TensorIndexC, TensorIndexB, TensorIndexA>(
+  ::tenex::evaluate<TensorIndexC, TensorIndexB, TensorIndexA>(
       make_not_null(&L_cba_filled),
       R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
 
@@ -197,7 +197,7 @@ void test_evaluate_rank_3_impl() {
     Variables<tmpl::list<::Tags::TempTensor<1, L_abc_type>>> L_abc_var{
         used_for_size};
     L_abc_type& L_abc_temp = get<::Tags::TempTensor<1, L_abc_type>>(L_abc_var);
-    ::TensorExpressions::evaluate<TensorIndexA, TensorIndexB, TensorIndexC>(
+    ::tenex::evaluate<TensorIndexA, TensorIndexB, TensorIndexC>(
         make_not_null(&L_abc_temp),
         R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
 
@@ -205,7 +205,7 @@ void test_evaluate_rank_3_impl() {
     Variables<tmpl::list<::Tags::TempTensor<1, L_acb_type>>> L_acb_var{
         used_for_size};
     L_acb_type& L_acb_temp = get<::Tags::TempTensor<1, L_acb_type>>(L_acb_var);
-    ::TensorExpressions::evaluate<TensorIndexA, TensorIndexC, TensorIndexB>(
+    ::tenex::evaluate<TensorIndexA, TensorIndexC, TensorIndexB>(
         make_not_null(&L_acb_temp),
         R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
 
@@ -213,7 +213,7 @@ void test_evaluate_rank_3_impl() {
     Variables<tmpl::list<::Tags::TempTensor<1, L_bac_type>>> L_bac_var{
         used_for_size};
     L_bac_type& L_bac_temp = get<::Tags::TempTensor<1, L_bac_type>>(L_bac_var);
-    ::TensorExpressions::evaluate<TensorIndexB, TensorIndexA, TensorIndexC>(
+    ::tenex::evaluate<TensorIndexB, TensorIndexA, TensorIndexC>(
         make_not_null(&L_bac_temp),
         R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
 
@@ -221,7 +221,7 @@ void test_evaluate_rank_3_impl() {
     Variables<tmpl::list<::Tags::TempTensor<1, L_bca_type>>> L_bca_var{
         used_for_size};
     L_bca_type& L_bca_temp = get<::Tags::TempTensor<1, L_bca_type>>(L_bca_var);
-    ::TensorExpressions::evaluate<TensorIndexB, TensorIndexC, TensorIndexA>(
+    ::tenex::evaluate<TensorIndexB, TensorIndexC, TensorIndexA>(
         make_not_null(&L_bca_temp),
         R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
 
@@ -229,7 +229,7 @@ void test_evaluate_rank_3_impl() {
     Variables<tmpl::list<::Tags::TempTensor<1, L_cab_type>>> L_cab_var{
         used_for_size};
     L_cab_type& L_cab_temp = get<::Tags::TempTensor<1, L_cab_type>>(L_cab_var);
-    ::TensorExpressions::evaluate<TensorIndexC, TensorIndexA, TensorIndexB>(
+    ::tenex::evaluate<TensorIndexC, TensorIndexA, TensorIndexB>(
         make_not_null(&L_cab_temp),
         R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
 
@@ -237,7 +237,7 @@ void test_evaluate_rank_3_impl() {
     Variables<tmpl::list<::Tags::TempTensor<1, L_cba_type>>> L_cba_var{
         used_for_size};
     L_cba_type& L_cba_temp = get<::Tags::TempTensor<1, L_cba_type>>(L_cba_var);
-    ::TensorExpressions::evaluate<TensorIndexC, TensorIndexB, TensorIndexA>(
+    ::tenex::evaluate<TensorIndexC, TensorIndexB, TensorIndexA>(
         make_not_null(&L_cba_temp),
         R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
 
@@ -446,4 +446,4 @@ void test_evaluate_rank_3_abc_symmetry() {
 #undef DIM
 }
 
-}  // namespace TestHelpers::TensorExpressions
+}  // namespace TestHelpers::tenex

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank3.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank3.hpp
@@ -26,7 +26,7 @@ namespace TestHelpers::tenex {
 /// side tensor
 ///
 /// \details `TensorIndexA`, `TensorIndexB`, and `TensorIndexC` can be any type
-/// of TensorIndex and are not necessarily `ti_a`, `ti_b`, and `ti_c`. The
+/// of TensorIndex and are not necessarily `ti::a`, `ti::b`, and `ti::c`. The
 /// "A", "B", and "C" suffixes just denote the ordering of the generic indices
 /// of the RHS tensor expression. In the RHS tensor expression, it means
 /// `TensorIndexA` is the first index used, `TensorIndexB` is the second index
@@ -43,11 +43,11 @@ namespace TestHelpers::tenex {
 /// \tparam RhsTensorIndexTypeList the RHS Tensor's typelist of
 /// \ref SpacetimeIndex "TensorIndexType"s
 /// \tparam TensorIndexA the first TensorIndex used on the RHS of the
-/// TensorExpression, e.g. `ti_a`
+/// TensorExpression, e.g. `ti::a`
 /// \tparam TensorIndexB the second TensorIndex used on the RHS of the
-/// TensorExpression, e.g. `ti_B`
+/// TensorExpression, e.g. `ti::B`
 /// \tparam TensorIndexC the third TensorIndex used on the RHS of the
-/// TensorExpression, e.g. `ti_c`
+/// TensorExpression, e.g. `ti::c`
 template <typename DataType, typename RhsSymmetry,
           typename RhsTensorIndexTypeList, auto& TensorIndexA,
           auto& TensorIndexB, auto& TensorIndexC>
@@ -276,7 +276,7 @@ void test_evaluate_rank_3_impl() {
 /// - <1, 1, 1> (`test_evaluate_rank_3_abc_symmetry`)
 ///
 /// \details `TensorIndexA`, `TensorIndexB`, and `TensorIndexC` can be any type
-/// of TensorIndex and are not necessarily `ti_a`, `ti_b`, and `ti_c`. The
+/// of TensorIndex and are not necessarily `ti::a`, `ti::b`, and `ti::c`. The
 /// "A", "B", and "C" suffixes just denote the ordering of the generic indices
 /// of the RHS tensor expression. In the RHS tensor expression, it means
 /// `TensorIndexA` is the first index used, `TensorIndexB` is the second index
@@ -300,11 +300,11 @@ void test_evaluate_rank_3_impl() {
 /// \tparam ValenceC the valence of the third index used on the RHS of the
 /// TensorExpression
 /// \tparam TensorIndexA the first TensorIndex used on the RHS of the
-/// TensorExpression, e.g. `ti_a`
+/// TensorExpression, e.g. `ti::a`
 /// \tparam TensorIndexB the second TensorIndex used on the RHS of the
-/// TensorExpression, e.g. `ti_B`
+/// TensorExpression, e.g. `ti::B`
 /// \tparam TensorIndexC the third TensorIndex used on the RHS of the
-/// TensorExpression, e.g. `ti_c`
+/// TensorExpression, e.g. `ti::c`
 template <typename DataType,
           template <size_t, UpLo, typename> class TensorIndexTypeA,
           template <size_t, UpLo, typename> class TensorIndexTypeB,

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank4.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank4.hpp
@@ -24,8 +24,8 @@ namespace TestHelpers::tenex {
 /// side tensor
 ///
 /// \details `TensorIndexA`, `TensorIndexB`, `TensorIndexC`, and  `TensorIndexD`
-/// can be any type of TensorIndex and are not necessarily `ti_a`, `ti_b`,
-/// `ti_c`, and `ti_d`. The "A", "B", "C", and "D" suffixes just denote the
+/// can be any type of TensorIndex and are not necessarily `ti::a`, `ti::b`,
+/// `ti::c`, and `ti::d`. The "A", "B", "C", and "D" suffixes just denote the
 /// ordering of the generic indices of the RHS tensor expression. In the RHS
 /// tensor expression, it means `TensorIndexA` is the first index used,
 /// `TensorIndexB` is the second index used, `TensorIndexC` is the third index
@@ -42,13 +42,13 @@ namespace TestHelpers::tenex {
 /// \tparam RhsTensorIndexTypeList the RHS Tensor's typelist of
 /// \ref SpacetimeIndex "TensorIndexType"s
 /// \tparam TensorIndexA the first TensorIndex used on the RHS of the
-/// TensorExpression, e.g. `ti_a`
+/// TensorExpression, e.g. `ti::a`
 /// \tparam TensorIndexB the second TensorIndex used on the RHS of the
-/// TensorExpression, e.g. `ti_B`
+/// TensorExpression, e.g. `ti::B`
 /// \tparam TensorIndexC the third TensorIndex used on the RHS of the
-/// TensorExpression, e.g. `ti_c`
+/// TensorExpression, e.g. `ti::c`
 /// \tparam TensorIndexD the fourth TensorIndex used on the RHS of the
-/// TensorExpression, e.g. `ti_D`
+/// TensorExpression, e.g. `ti::D`
 template <typename DataType, typename RhsSymmetry,
           typename RhsTensorIndexTypeList, auto& TensorIndexA,
           auto& TensorIndexB, auto& TensorIndexC, auto& TensorIndexD>

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank4.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank4.hpp
@@ -16,7 +16,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
-namespace TestHelpers::TensorExpressions {
+namespace TestHelpers::tenex {
 
 /// \ingroup TestingFrameworkGroup
 /// \brief Test that evaluating a right hand side tensor expression containing a
@@ -73,12 +73,10 @@ void test_evaluate_rank_4() {
   // `evaluate`
   using L_abcd_type = Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList>;
   const L_abcd_type L_abcd_returned =
-      ::TensorExpressions::evaluate<TensorIndexA, TensorIndexB, TensorIndexC,
-                                    TensorIndexD>(
+      ::tenex::evaluate<TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
   L_abcd_type L_abcd_filled{};
-  ::TensorExpressions::evaluate<TensorIndexA, TensorIndexB, TensorIndexC,
-                                TensorIndexD>(
+  ::tenex::evaluate<TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD>(
       make_not_null(&L_abcd_filled),
       R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -92,12 +90,10 @@ void test_evaluate_rank_4() {
   using L_abdc_type =
       Tensor<DataType, L_abdc_symmetry, L_abdc_tensorindextype_list>;
   const L_abdc_type L_abdc_returned =
-      ::TensorExpressions::evaluate<TensorIndexA, TensorIndexB, TensorIndexD,
-                                    TensorIndexC>(
+      ::tenex::evaluate<TensorIndexA, TensorIndexB, TensorIndexD, TensorIndexC>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
   L_abdc_type L_abdc_filled{};
-  ::TensorExpressions::evaluate<TensorIndexA, TensorIndexB, TensorIndexD,
-                                TensorIndexC>(
+  ::tenex::evaluate<TensorIndexA, TensorIndexB, TensorIndexD, TensorIndexC>(
       make_not_null(&L_abdc_filled),
       R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -111,12 +107,10 @@ void test_evaluate_rank_4() {
   using L_acbd_type =
       Tensor<DataType, L_acbd_symmetry, L_acbd_tensorindextype_list>;
   const L_acbd_type L_acbd_returned =
-      ::TensorExpressions::evaluate<TensorIndexA, TensorIndexC, TensorIndexB,
-                                    TensorIndexD>(
+      ::tenex::evaluate<TensorIndexA, TensorIndexC, TensorIndexB, TensorIndexD>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
   L_acbd_type L_acbd_filled{};
-  ::TensorExpressions::evaluate<TensorIndexA, TensorIndexC, TensorIndexB,
-                                TensorIndexD>(
+  ::tenex::evaluate<TensorIndexA, TensorIndexC, TensorIndexB, TensorIndexD>(
       make_not_null(&L_acbd_filled),
       R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -130,12 +124,10 @@ void test_evaluate_rank_4() {
   using L_acdb_type =
       Tensor<DataType, L_acdb_symmetry, L_acdb_tensorindextype_list>;
   const L_acdb_type L_acdb_returned =
-      ::TensorExpressions::evaluate<TensorIndexA, TensorIndexC, TensorIndexD,
-                                    TensorIndexB>(
+      ::tenex::evaluate<TensorIndexA, TensorIndexC, TensorIndexD, TensorIndexB>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
   L_acdb_type L_acdb_filled{};
-  ::TensorExpressions::evaluate<TensorIndexA, TensorIndexC, TensorIndexD,
-                                TensorIndexB>(
+  ::tenex::evaluate<TensorIndexA, TensorIndexC, TensorIndexD, TensorIndexB>(
       make_not_null(&L_acdb_filled),
       R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -149,12 +141,10 @@ void test_evaluate_rank_4() {
   using L_adbc_type =
       Tensor<DataType, L_adbc_symmetry, L_adbc_tensorindextype_list>;
   const L_adbc_type L_adbc_returned =
-      ::TensorExpressions::evaluate<TensorIndexA, TensorIndexD, TensorIndexB,
-                                    TensorIndexC>(
+      ::tenex::evaluate<TensorIndexA, TensorIndexD, TensorIndexB, TensorIndexC>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
   L_adbc_type L_adbc_filled{};
-  ::TensorExpressions::evaluate<TensorIndexA, TensorIndexD, TensorIndexB,
-                                TensorIndexC>(
+  ::tenex::evaluate<TensorIndexA, TensorIndexD, TensorIndexB, TensorIndexC>(
       make_not_null(&L_adbc_filled),
       R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -168,12 +158,10 @@ void test_evaluate_rank_4() {
   using L_adcb_type =
       Tensor<DataType, L_adcb_symmetry, L_adcb_tensorindextype_list>;
   const L_adcb_type L_adcb_returned =
-      ::TensorExpressions::evaluate<TensorIndexA, TensorIndexD, TensorIndexC,
-                                    TensorIndexB>(
+      ::tenex::evaluate<TensorIndexA, TensorIndexD, TensorIndexC, TensorIndexB>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
   L_adcb_type L_adcb_filled{};
-  ::TensorExpressions::evaluate<TensorIndexA, TensorIndexD, TensorIndexC,
-                                TensorIndexB>(
+  ::tenex::evaluate<TensorIndexA, TensorIndexD, TensorIndexC, TensorIndexB>(
       make_not_null(&L_adcb_filled),
       R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -187,12 +175,10 @@ void test_evaluate_rank_4() {
   using L_bacd_type =
       Tensor<DataType, L_bacd_symmetry, L_bacd_tensorindextype_list>;
   const L_bacd_type L_bacd_returned =
-      ::TensorExpressions::evaluate<TensorIndexB, TensorIndexA, TensorIndexC,
-                                    TensorIndexD>(
+      ::tenex::evaluate<TensorIndexB, TensorIndexA, TensorIndexC, TensorIndexD>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
   L_bacd_type L_bacd_filled{};
-  ::TensorExpressions::evaluate<TensorIndexB, TensorIndexA, TensorIndexC,
-                                TensorIndexD>(
+  ::tenex::evaluate<TensorIndexB, TensorIndexA, TensorIndexC, TensorIndexD>(
       make_not_null(&L_bacd_filled),
       R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -206,12 +192,10 @@ void test_evaluate_rank_4() {
   using L_badc_type =
       Tensor<DataType, L_badc_symmetry, L_badc_tensorindextype_list>;
   const L_badc_type L_badc_returned =
-      ::TensorExpressions::evaluate<TensorIndexB, TensorIndexA, TensorIndexD,
-                                    TensorIndexC>(
+      ::tenex::evaluate<TensorIndexB, TensorIndexA, TensorIndexD, TensorIndexC>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
   L_badc_type L_badc_filled{};
-  ::TensorExpressions::evaluate<TensorIndexB, TensorIndexA, TensorIndexD,
-                                TensorIndexC>(
+  ::tenex::evaluate<TensorIndexB, TensorIndexA, TensorIndexD, TensorIndexC>(
       make_not_null(&L_badc_filled),
       R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -225,12 +209,10 @@ void test_evaluate_rank_4() {
   using L_bcad_type =
       Tensor<DataType, L_bcad_symmetry, L_bcad_tensorindextype_list>;
   const L_bcad_type L_bcad_returned =
-      ::TensorExpressions::evaluate<TensorIndexB, TensorIndexC, TensorIndexA,
-                                    TensorIndexD>(
+      ::tenex::evaluate<TensorIndexB, TensorIndexC, TensorIndexA, TensorIndexD>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
   L_bcad_type L_bcad_filled{};
-  ::TensorExpressions::evaluate<TensorIndexB, TensorIndexC, TensorIndexA,
-                                TensorIndexD>(
+  ::tenex::evaluate<TensorIndexB, TensorIndexC, TensorIndexA, TensorIndexD>(
       make_not_null(&L_bcad_filled),
       R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -244,12 +226,10 @@ void test_evaluate_rank_4() {
   using L_bcda_type =
       Tensor<DataType, L_bcda_symmetry, L_bcda_tensorindextype_list>;
   const L_bcda_type L_bcda_returned =
-      ::TensorExpressions::evaluate<TensorIndexB, TensorIndexC, TensorIndexD,
-                                    TensorIndexA>(
+      ::tenex::evaluate<TensorIndexB, TensorIndexC, TensorIndexD, TensorIndexA>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
   L_bcda_type L_bcda_filled{};
-  ::TensorExpressions::evaluate<TensorIndexB, TensorIndexC, TensorIndexD,
-                                TensorIndexA>(
+  ::tenex::evaluate<TensorIndexB, TensorIndexC, TensorIndexD, TensorIndexA>(
       make_not_null(&L_bcda_filled),
       R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -263,12 +243,10 @@ void test_evaluate_rank_4() {
   using L_bdac_type =
       Tensor<DataType, L_bdac_symmetry, L_bdac_tensorindextype_list>;
   const L_bdac_type L_bdac_returned =
-      ::TensorExpressions::evaluate<TensorIndexB, TensorIndexD, TensorIndexA,
-                                    TensorIndexC>(
+      ::tenex::evaluate<TensorIndexB, TensorIndexD, TensorIndexA, TensorIndexC>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
   L_bdac_type L_bdac_filled{};
-  ::TensorExpressions::evaluate<TensorIndexB, TensorIndexD, TensorIndexA,
-                                TensorIndexC>(
+  ::tenex::evaluate<TensorIndexB, TensorIndexD, TensorIndexA, TensorIndexC>(
       make_not_null(&L_bdac_filled),
       R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -282,12 +260,10 @@ void test_evaluate_rank_4() {
   using L_bdca_type =
       Tensor<DataType, L_bdca_symmetry, L_bdca_tensorindextype_list>;
   const L_bdca_type L_bdca_returned =
-      ::TensorExpressions::evaluate<TensorIndexB, TensorIndexD, TensorIndexC,
-                                    TensorIndexA>(
+      ::tenex::evaluate<TensorIndexB, TensorIndexD, TensorIndexC, TensorIndexA>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
   L_bdca_type L_bdca_filled{};
-  ::TensorExpressions::evaluate<TensorIndexB, TensorIndexD, TensorIndexC,
-                                TensorIndexA>(
+  ::tenex::evaluate<TensorIndexB, TensorIndexD, TensorIndexC, TensorIndexA>(
       make_not_null(&L_bdca_filled),
       R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -301,12 +277,10 @@ void test_evaluate_rank_4() {
   using L_cabd_type =
       Tensor<DataType, L_cabd_symmetry, L_cabd_tensorindextype_list>;
   const L_cabd_type L_cabd_returned =
-      ::TensorExpressions::evaluate<TensorIndexC, TensorIndexA, TensorIndexB,
-                                    TensorIndexD>(
+      ::tenex::evaluate<TensorIndexC, TensorIndexA, TensorIndexB, TensorIndexD>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
   L_cabd_type L_cabd_filled{};
-  ::TensorExpressions::evaluate<TensorIndexC, TensorIndexA, TensorIndexB,
-                                TensorIndexD>(
+  ::tenex::evaluate<TensorIndexC, TensorIndexA, TensorIndexB, TensorIndexD>(
       make_not_null(&L_cabd_filled),
       R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -320,12 +294,10 @@ void test_evaluate_rank_4() {
   using L_cadb_type =
       Tensor<DataType, L_cadb_symmetry, L_cadb_tensorindextype_list>;
   const L_cadb_type L_cadb_returned =
-      ::TensorExpressions::evaluate<TensorIndexC, TensorIndexA, TensorIndexD,
-                                    TensorIndexB>(
+      ::tenex::evaluate<TensorIndexC, TensorIndexA, TensorIndexD, TensorIndexB>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
   L_cadb_type L_cadb_filled{};
-  ::TensorExpressions::evaluate<TensorIndexC, TensorIndexA, TensorIndexD,
-                                TensorIndexB>(
+  ::tenex::evaluate<TensorIndexC, TensorIndexA, TensorIndexD, TensorIndexB>(
       make_not_null(&L_cadb_filled),
       R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -339,12 +311,10 @@ void test_evaluate_rank_4() {
   using L_cbad_type =
       Tensor<DataType, L_cbad_symmetry, L_cbad_tensorindextype_list>;
   const L_cbad_type L_cbad_returned =
-      ::TensorExpressions::evaluate<TensorIndexC, TensorIndexB, TensorIndexA,
-                                    TensorIndexD>(
+      ::tenex::evaluate<TensorIndexC, TensorIndexB, TensorIndexA, TensorIndexD>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
   L_cbad_type L_cbad_filled{};
-  ::TensorExpressions::evaluate<TensorIndexC, TensorIndexB, TensorIndexA,
-                                TensorIndexD>(
+  ::tenex::evaluate<TensorIndexC, TensorIndexB, TensorIndexA, TensorIndexD>(
       make_not_null(&L_cbad_filled),
       R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -358,12 +328,10 @@ void test_evaluate_rank_4() {
   using L_cbda_type =
       Tensor<DataType, L_cbda_symmetry, L_cbda_tensorindextype_list>;
   const L_cbda_type L_cbda_returned =
-      ::TensorExpressions::evaluate<TensorIndexC, TensorIndexB, TensorIndexD,
-                                    TensorIndexA>(
+      ::tenex::evaluate<TensorIndexC, TensorIndexB, TensorIndexD, TensorIndexA>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
   L_cbda_type L_cbda_filled{};
-  ::TensorExpressions::evaluate<TensorIndexC, TensorIndexB, TensorIndexD,
-                                TensorIndexA>(
+  ::tenex::evaluate<TensorIndexC, TensorIndexB, TensorIndexD, TensorIndexA>(
       make_not_null(&L_cbda_filled),
       R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -377,12 +345,10 @@ void test_evaluate_rank_4() {
   using L_cdab_type =
       Tensor<DataType, L_cdab_symmetry, L_cdab_tensorindextype_list>;
   const L_cdab_type L_cdab_returned =
-      ::TensorExpressions::evaluate<TensorIndexC, TensorIndexD, TensorIndexA,
-                                    TensorIndexB>(
+      ::tenex::evaluate<TensorIndexC, TensorIndexD, TensorIndexA, TensorIndexB>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
   L_cdab_type L_cdab_filled{};
-  ::TensorExpressions::evaluate<TensorIndexC, TensorIndexD, TensorIndexA,
-                                TensorIndexB>(
+  ::tenex::evaluate<TensorIndexC, TensorIndexD, TensorIndexA, TensorIndexB>(
       make_not_null(&L_cdab_filled),
       R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -396,12 +362,10 @@ void test_evaluate_rank_4() {
   using L_cdba_type =
       Tensor<DataType, L_cdba_symmetry, L_cdba_tensorindextype_list>;
   const L_cdba_type L_cdba_returned =
-      ::TensorExpressions::evaluate<TensorIndexC, TensorIndexD, TensorIndexB,
-                                    TensorIndexA>(
+      ::tenex::evaluate<TensorIndexC, TensorIndexD, TensorIndexB, TensorIndexA>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
   L_cdba_type L_cdba_filled{};
-  ::TensorExpressions::evaluate<TensorIndexC, TensorIndexD, TensorIndexB,
-                                TensorIndexA>(
+  ::tenex::evaluate<TensorIndexC, TensorIndexD, TensorIndexB, TensorIndexA>(
       make_not_null(&L_cdba_filled),
       R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -415,12 +379,10 @@ void test_evaluate_rank_4() {
   using L_dabc_type =
       Tensor<DataType, L_dabc_symmetry, L_dabc_tensorindextype_list>;
   const L_dabc_type L_dabc_returned =
-      ::TensorExpressions::evaluate<TensorIndexD, TensorIndexA, TensorIndexB,
-                                    TensorIndexC>(
+      ::tenex::evaluate<TensorIndexD, TensorIndexA, TensorIndexB, TensorIndexC>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
   L_dabc_type L_dabc_filled{};
-  ::TensorExpressions::evaluate<TensorIndexD, TensorIndexA, TensorIndexB,
-                                TensorIndexC>(
+  ::tenex::evaluate<TensorIndexD, TensorIndexA, TensorIndexB, TensorIndexC>(
       make_not_null(&L_dabc_filled),
       R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -434,12 +396,10 @@ void test_evaluate_rank_4() {
   using L_dacb_type =
       Tensor<DataType, L_dacb_symmetry, L_dacb_tensorindextype_list>;
   const L_dacb_type L_dacb_returned =
-      ::TensorExpressions::evaluate<TensorIndexD, TensorIndexA, TensorIndexC,
-                                    TensorIndexB>(
+      ::tenex::evaluate<TensorIndexD, TensorIndexA, TensorIndexC, TensorIndexB>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
   L_dacb_type L_dacb_filled{};
-  ::TensorExpressions::evaluate<TensorIndexD, TensorIndexA, TensorIndexC,
-                                TensorIndexB>(
+  ::tenex::evaluate<TensorIndexD, TensorIndexA, TensorIndexC, TensorIndexB>(
       make_not_null(&L_dacb_filled),
       R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -453,12 +413,10 @@ void test_evaluate_rank_4() {
   using L_dbac_type =
       Tensor<DataType, L_dbac_symmetry, L_dbac_tensorindextype_list>;
   const L_dbac_type L_dbac_returned =
-      ::TensorExpressions::evaluate<TensorIndexD, TensorIndexB, TensorIndexA,
-                                    TensorIndexC>(
+      ::tenex::evaluate<TensorIndexD, TensorIndexB, TensorIndexA, TensorIndexC>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
   L_dbac_type L_dbac_filled{};
-  ::TensorExpressions::evaluate<TensorIndexD, TensorIndexB, TensorIndexA,
-                                TensorIndexC>(
+  ::tenex::evaluate<TensorIndexD, TensorIndexB, TensorIndexA, TensorIndexC>(
       make_not_null(&L_dbac_filled),
       R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -472,12 +430,10 @@ void test_evaluate_rank_4() {
   using L_dbca_type =
       Tensor<DataType, L_dbca_symmetry, L_dbca_tensorindextype_list>;
   const L_dbca_type L_dbca_returned =
-      ::TensorExpressions::evaluate<TensorIndexD, TensorIndexB, TensorIndexC,
-                                    TensorIndexA>(
+      ::tenex::evaluate<TensorIndexD, TensorIndexB, TensorIndexC, TensorIndexA>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
   L_dbca_type L_dbca_filled{};
-  ::TensorExpressions::evaluate<TensorIndexD, TensorIndexB, TensorIndexC,
-                                TensorIndexA>(
+  ::tenex::evaluate<TensorIndexD, TensorIndexB, TensorIndexC, TensorIndexA>(
       make_not_null(&L_dbca_filled),
       R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -491,12 +447,10 @@ void test_evaluate_rank_4() {
   using L_dcab_type =
       Tensor<DataType, L_dcab_symmetry, L_dcab_tensorindextype_list>;
   const L_dcab_type L_dcab_returned =
-      ::TensorExpressions::evaluate<TensorIndexD, TensorIndexC, TensorIndexA,
-                                    TensorIndexB>(
+      ::tenex::evaluate<TensorIndexD, TensorIndexC, TensorIndexA, TensorIndexB>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
   L_dcab_type L_dcab_filled{};
-  ::TensorExpressions::evaluate<TensorIndexD, TensorIndexC, TensorIndexA,
-                                TensorIndexB>(
+  ::tenex::evaluate<TensorIndexD, TensorIndexC, TensorIndexA, TensorIndexB>(
       make_not_null(&L_dcab_filled),
       R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -510,12 +464,10 @@ void test_evaluate_rank_4() {
   using L_dcba_type =
       Tensor<DataType, L_dcba_symmetry, L_dcba_tensorindextype_list>;
   const L_dcba_type L_dcba_returned =
-      ::TensorExpressions::evaluate<TensorIndexD, TensorIndexC, TensorIndexB,
-                                    TensorIndexA>(
+      ::tenex::evaluate<TensorIndexD, TensorIndexC, TensorIndexB, TensorIndexA>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
   L_dcba_type L_dcba_filled{};
-  ::TensorExpressions::evaluate<TensorIndexD, TensorIndexC, TensorIndexB,
-                                TensorIndexA>(
+  ::tenex::evaluate<TensorIndexD, TensorIndexC, TensorIndexB, TensorIndexA>(
       make_not_null(&L_dcba_filled),
       R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -612,8 +564,7 @@ void test_evaluate_rank_4() {
         used_for_size};
     L_abcd_type& L_abcd_temp =
         get<::Tags::TempTensor<1, L_abcd_type>>(L_abcd_var);
-    ::TensorExpressions::evaluate<TensorIndexA, TensorIndexB, TensorIndexC,
-                                  TensorIndexD>(
+    ::tenex::evaluate<TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD>(
         make_not_null(&L_abcd_temp),
         R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -622,8 +573,7 @@ void test_evaluate_rank_4() {
         used_for_size};
     L_abdc_type& L_abdc_temp =
         get<::Tags::TempTensor<1, L_abdc_type>>(L_abdc_var);
-    ::TensorExpressions::evaluate<TensorIndexA, TensorIndexB, TensorIndexD,
-                                  TensorIndexC>(
+    ::tenex::evaluate<TensorIndexA, TensorIndexB, TensorIndexD, TensorIndexC>(
         make_not_null(&L_abdc_temp),
         R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -632,8 +582,7 @@ void test_evaluate_rank_4() {
         used_for_size};
     L_acbd_type& L_acbd_temp =
         get<::Tags::TempTensor<1, L_acbd_type>>(L_acbd_var);
-    ::TensorExpressions::evaluate<TensorIndexA, TensorIndexC, TensorIndexB,
-                                  TensorIndexD>(
+    ::tenex::evaluate<TensorIndexA, TensorIndexC, TensorIndexB, TensorIndexD>(
         make_not_null(&L_acbd_temp),
         R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -642,8 +591,7 @@ void test_evaluate_rank_4() {
         used_for_size};
     L_acdb_type& L_acdb_temp =
         get<::Tags::TempTensor<1, L_acdb_type>>(L_acdb_var);
-    ::TensorExpressions::evaluate<TensorIndexA, TensorIndexC, TensorIndexD,
-                                  TensorIndexB>(
+    ::tenex::evaluate<TensorIndexA, TensorIndexC, TensorIndexD, TensorIndexB>(
         make_not_null(&L_acdb_temp),
         R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -652,8 +600,7 @@ void test_evaluate_rank_4() {
         used_for_size};
     L_adbc_type& L_adbc_temp =
         get<::Tags::TempTensor<1, L_adbc_type>>(L_adbc_var);
-    ::TensorExpressions::evaluate<TensorIndexA, TensorIndexD, TensorIndexB,
-                                  TensorIndexC>(
+    ::tenex::evaluate<TensorIndexA, TensorIndexD, TensorIndexB, TensorIndexC>(
         make_not_null(&L_adbc_temp),
         R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -662,8 +609,7 @@ void test_evaluate_rank_4() {
         used_for_size};
     L_adcb_type& L_adcb_temp =
         get<::Tags::TempTensor<1, L_adcb_type>>(L_adcb_var);
-    ::TensorExpressions::evaluate<TensorIndexA, TensorIndexD, TensorIndexC,
-                                  TensorIndexB>(
+    ::tenex::evaluate<TensorIndexA, TensorIndexD, TensorIndexC, TensorIndexB>(
         make_not_null(&L_adcb_temp),
         R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -672,8 +618,7 @@ void test_evaluate_rank_4() {
         used_for_size};
     L_bacd_type& L_bacd_temp =
         get<::Tags::TempTensor<1, L_bacd_type>>(L_bacd_var);
-    ::TensorExpressions::evaluate<TensorIndexB, TensorIndexA, TensorIndexC,
-                                  TensorIndexD>(
+    ::tenex::evaluate<TensorIndexB, TensorIndexA, TensorIndexC, TensorIndexD>(
         make_not_null(&L_bacd_temp),
         R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -682,8 +627,7 @@ void test_evaluate_rank_4() {
         used_for_size};
     L_badc_type& L_badc_temp =
         get<::Tags::TempTensor<1, L_badc_type>>(L_badc_var);
-    ::TensorExpressions::evaluate<TensorIndexB, TensorIndexA, TensorIndexD,
-                                  TensorIndexC>(
+    ::tenex::evaluate<TensorIndexB, TensorIndexA, TensorIndexD, TensorIndexC>(
         make_not_null(&L_badc_temp),
         R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -692,8 +636,7 @@ void test_evaluate_rank_4() {
         used_for_size};
     L_bcad_type& L_bcad_temp =
         get<::Tags::TempTensor<1, L_bcad_type>>(L_bcad_var);
-    ::TensorExpressions::evaluate<TensorIndexB, TensorIndexC, TensorIndexA,
-                                  TensorIndexD>(
+    ::tenex::evaluate<TensorIndexB, TensorIndexC, TensorIndexA, TensorIndexD>(
         make_not_null(&L_bcad_temp),
         R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -702,8 +645,7 @@ void test_evaluate_rank_4() {
         used_for_size};
     L_bcda_type& L_bcda_temp =
         get<::Tags::TempTensor<1, L_bcda_type>>(L_bcda_var);
-    ::TensorExpressions::evaluate<TensorIndexB, TensorIndexC, TensorIndexD,
-                                  TensorIndexA>(
+    ::tenex::evaluate<TensorIndexB, TensorIndexC, TensorIndexD, TensorIndexA>(
         make_not_null(&L_bcda_temp),
         R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -712,8 +654,7 @@ void test_evaluate_rank_4() {
         used_for_size};
     L_bdac_type& L_bdac_temp =
         get<::Tags::TempTensor<1, L_bdac_type>>(L_bdac_var);
-    ::TensorExpressions::evaluate<TensorIndexB, TensorIndexD, TensorIndexA,
-                                  TensorIndexC>(
+    ::tenex::evaluate<TensorIndexB, TensorIndexD, TensorIndexA, TensorIndexC>(
         make_not_null(&L_bdac_temp),
         R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -722,8 +663,7 @@ void test_evaluate_rank_4() {
         used_for_size};
     L_bdca_type& L_bdca_temp =
         get<::Tags::TempTensor<1, L_bdca_type>>(L_bdca_var);
-    ::TensorExpressions::evaluate<TensorIndexB, TensorIndexD, TensorIndexC,
-                                  TensorIndexA>(
+    ::tenex::evaluate<TensorIndexB, TensorIndexD, TensorIndexC, TensorIndexA>(
         make_not_null(&L_bdca_temp),
         R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -732,8 +672,7 @@ void test_evaluate_rank_4() {
         used_for_size};
     L_cabd_type& L_cabd_temp =
         get<::Tags::TempTensor<1, L_cabd_type>>(L_cabd_var);
-    ::TensorExpressions::evaluate<TensorIndexC, TensorIndexA, TensorIndexB,
-                                  TensorIndexD>(
+    ::tenex::evaluate<TensorIndexC, TensorIndexA, TensorIndexB, TensorIndexD>(
         make_not_null(&L_cabd_temp),
         R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -742,8 +681,7 @@ void test_evaluate_rank_4() {
         used_for_size};
     L_cadb_type& L_cadb_temp =
         get<::Tags::TempTensor<1, L_cadb_type>>(L_cadb_var);
-    ::TensorExpressions::evaluate<TensorIndexC, TensorIndexA, TensorIndexD,
-                                  TensorIndexB>(
+    ::tenex::evaluate<TensorIndexC, TensorIndexA, TensorIndexD, TensorIndexB>(
         make_not_null(&L_cadb_temp),
         R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -752,8 +690,7 @@ void test_evaluate_rank_4() {
         used_for_size};
     L_cbad_type& L_cbad_temp =
         get<::Tags::TempTensor<1, L_cbad_type>>(L_cbad_var);
-    ::TensorExpressions::evaluate<TensorIndexC, TensorIndexB, TensorIndexA,
-                                  TensorIndexD>(
+    ::tenex::evaluate<TensorIndexC, TensorIndexB, TensorIndexA, TensorIndexD>(
         make_not_null(&L_cbad_temp),
         R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -762,8 +699,7 @@ void test_evaluate_rank_4() {
         used_for_size};
     L_cbda_type& L_cbda_temp =
         get<::Tags::TempTensor<1, L_cbda_type>>(L_cbda_var);
-    ::TensorExpressions::evaluate<TensorIndexC, TensorIndexB, TensorIndexD,
-                                  TensorIndexA>(
+    ::tenex::evaluate<TensorIndexC, TensorIndexB, TensorIndexD, TensorIndexA>(
         make_not_null(&L_cbda_temp),
         R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -772,8 +708,7 @@ void test_evaluate_rank_4() {
         used_for_size};
     L_cdab_type& L_cdab_temp =
         get<::Tags::TempTensor<1, L_cdab_type>>(L_cdab_var);
-    ::TensorExpressions::evaluate<TensorIndexC, TensorIndexD, TensorIndexA,
-                                  TensorIndexB>(
+    ::tenex::evaluate<TensorIndexC, TensorIndexD, TensorIndexA, TensorIndexB>(
         make_not_null(&L_cdab_temp),
         R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -782,8 +717,7 @@ void test_evaluate_rank_4() {
         used_for_size};
     L_cdba_type& L_cdba_temp =
         get<::Tags::TempTensor<1, L_cdba_type>>(L_cdba_var);
-    ::TensorExpressions::evaluate<TensorIndexC, TensorIndexD, TensorIndexB,
-                                  TensorIndexA>(
+    ::tenex::evaluate<TensorIndexC, TensorIndexD, TensorIndexB, TensorIndexA>(
         make_not_null(&L_cdba_temp),
         R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -792,8 +726,7 @@ void test_evaluate_rank_4() {
         used_for_size};
     L_dabc_type& L_dabc_temp =
         get<::Tags::TempTensor<1, L_dabc_type>>(L_dabc_var);
-    ::TensorExpressions::evaluate<TensorIndexD, TensorIndexA, TensorIndexB,
-                                  TensorIndexC>(
+    ::tenex::evaluate<TensorIndexD, TensorIndexA, TensorIndexB, TensorIndexC>(
         make_not_null(&L_dabc_temp),
         R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -802,8 +735,7 @@ void test_evaluate_rank_4() {
         used_for_size};
     L_dacb_type& L_dacb_temp =
         get<::Tags::TempTensor<1, L_dacb_type>>(L_dacb_var);
-    ::TensorExpressions::evaluate<TensorIndexD, TensorIndexA, TensorIndexC,
-                                  TensorIndexB>(
+    ::tenex::evaluate<TensorIndexD, TensorIndexA, TensorIndexC, TensorIndexB>(
         make_not_null(&L_dacb_temp),
         R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -812,8 +744,7 @@ void test_evaluate_rank_4() {
         used_for_size};
     L_dbac_type& L_dbac_temp =
         get<::Tags::TempTensor<1, L_dbac_type>>(L_dbac_var);
-    ::TensorExpressions::evaluate<TensorIndexD, TensorIndexB, TensorIndexA,
-                                  TensorIndexC>(
+    ::tenex::evaluate<TensorIndexD, TensorIndexB, TensorIndexA, TensorIndexC>(
         make_not_null(&L_dbac_temp),
         R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -822,8 +753,7 @@ void test_evaluate_rank_4() {
         used_for_size};
     L_dbca_type& L_dbca_temp =
         get<::Tags::TempTensor<1, L_dbca_type>>(L_dbca_var);
-    ::TensorExpressions::evaluate<TensorIndexD, TensorIndexB, TensorIndexC,
-                                  TensorIndexA>(
+    ::tenex::evaluate<TensorIndexD, TensorIndexB, TensorIndexC, TensorIndexA>(
         make_not_null(&L_dbca_temp),
         R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -832,8 +762,7 @@ void test_evaluate_rank_4() {
         used_for_size};
     L_dcab_type& L_dcab_temp =
         get<::Tags::TempTensor<1, L_dcab_type>>(L_dcab_var);
-    ::TensorExpressions::evaluate<TensorIndexD, TensorIndexC, TensorIndexA,
-                                  TensorIndexB>(
+    ::tenex::evaluate<TensorIndexD, TensorIndexC, TensorIndexA, TensorIndexB>(
         make_not_null(&L_dcab_temp),
         R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -842,8 +771,7 @@ void test_evaluate_rank_4() {
         used_for_size};
     L_dcba_type& L_dcba_temp =
         get<::Tags::TempTensor<1, L_dcba_type>>(L_dcba_var);
-    ::TensorExpressions::evaluate<TensorIndexD, TensorIndexC, TensorIndexB,
-                                  TensorIndexA>(
+    ::tenex::evaluate<TensorIndexD, TensorIndexC, TensorIndexB, TensorIndexA>(
         make_not_null(&L_dcba_temp),
         R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
@@ -906,4 +834,4 @@ void test_evaluate_rank_4() {
   }
 }
 
-}  // namespace TestHelpers::TensorExpressions
+}  // namespace TestHelpers::tenex

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorIndexTransformationRank0.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorIndexTransformationRank0.hpp
@@ -8,25 +8,24 @@
 
 #include "DataStructures/Tensor/Expressions/TensorIndexTransformation.hpp"
 
-namespace TestHelpers::TensorExpressions {
+namespace TestHelpers::tenex {
 /// \ingroup TestingFrameworkGroup
 /// \brief Test that the transformation between two rank 0 tensors' generic
 /// indices and the subsequent transformed multi-index is correctly computed
 ///
 /// \details The functions tested are:
-/// - `TensorExpressions::compute_tensorindex_transformation`
-/// - `TensorExpressions::transform_multi_index`
+/// - `tenex::compute_tensorindex_transformation`
+/// - `tenex::transform_multi_index`
 void test_tensor_index_transformation_rank_0() {
   const std::array<size_t, 0> index_order = {};
 
   const std::array<size_t, 0> actual_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order,
-                                                              index_order);
+      ::tenex::compute_tensorindex_transformation(index_order, index_order);
   const std::array<size_t, 0> expected_transformation = {};
   CHECK(actual_transformation == expected_transformation);
 
   const std::array<size_t, 0> tensor_multi_index = {};
-  CHECK(::TensorExpressions::transform_multi_index(
+  CHECK(::tenex::transform_multi_index(
             tensor_multi_index, expected_transformation) == tensor_multi_index);
 }
-}  // namespace TestHelpers::TensorExpressions
+}  // namespace TestHelpers::tenex

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorIndexTransformationRank1.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorIndexTransformationRank1.hpp
@@ -10,14 +10,14 @@
 
 #include "DataStructures/Tensor/Expressions/TensorIndexTransformation.hpp"
 
-namespace TestHelpers::TensorExpressions {
+namespace TestHelpers::tenex {
 /// \ingroup TestingFrameworkGroup
 /// \brief Test that the transformation between two rank 1 tensors' generic
 /// indices and the subsequent transformed multi-indices are correctly computed
 ///
 /// \details The functions tested are:
-/// - `TensorExpressions::compute_tensorindex_transformation`
-/// - `TensorExpressions::transform_multi_index`
+/// - `tenex::compute_tensorindex_transformation`
+/// - `tenex::transform_multi_index`
 ///
 /// \tparam TensorIndex the first generic tensor index, e.g. type of `ti_a`
 template <typename TensorIndex>
@@ -28,17 +28,16 @@ void test_tensor_index_transformation_rank_1(
   const std::array<size_t, 1> index_order = {TensorIndex::value};
 
   const std::array<size_t, 1> actual_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order,
-                                                              index_order);
+      ::tenex::compute_tensorindex_transformation(index_order, index_order);
   const std::array<size_t, 1> expected_transformation = {0};
   CHECK(actual_transformation == expected_transformation);
 
   // For L_a = R_a, check that L_i == R_i
   for (size_t i = 0; i < dim; i++) {
     const std::array<size_t, 1> tensor_multi_index = {i};
-    CHECK(::TensorExpressions::transform_multi_index(tensor_multi_index,
-                                                     expected_transformation) ==
+    CHECK(::tenex::transform_multi_index(tensor_multi_index,
+                                         expected_transformation) ==
           tensor_multi_index);
   }
 }
-}  // namespace TestHelpers::TensorExpressions
+}  // namespace TestHelpers::tenex

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorIndexTransformationRank1.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorIndexTransformationRank1.hpp
@@ -19,7 +19,7 @@ namespace TestHelpers::tenex {
 /// - `tenex::compute_tensorindex_transformation`
 /// - `tenex::transform_multi_index`
 ///
-/// \tparam TensorIndex the first generic tensor index, e.g. type of `ti_a`
+/// \tparam TensorIndex the first generic tensor index, e.g. type of `ti::a`
 template <typename TensorIndex>
 void test_tensor_index_transformation_rank_1(
     const TensorIndex& /*tensorindex*/) {

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorIndexTransformationRank2.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorIndexTransformationRank2.hpp
@@ -10,14 +10,14 @@
 
 #include "DataStructures/Tensor/Expressions/TensorIndexTransformation.hpp"
 
-namespace TestHelpers::TensorExpressions {
+namespace TestHelpers::tenex {
 /// \ingroup TestingFrameworkGroup
 /// \brief Test that the transformation between two rank 2 tensors' generic
 /// indices and the subsequent transformed multi-indices are correctly computed
 ///
 /// \details The functions tested are:
-/// - `TensorExpressions::compute_tensorindex_transformation`
-/// - `TensorExpressions::transform_multi_index`
+/// - `tenex::compute_tensorindex_transformation`
+/// - `tenex::transform_multi_index`
 ///
 /// If we consider the first tensor's generic indices to be (a, b), the possible
 /// orderings of the second tensor's generic indices are: (a, b) and (b, a). For
@@ -40,12 +40,12 @@ void test_tensor_index_transformation_rank_2(
                                                 TensorIndexA::value};
 
   const std::array<size_t, 2> actual_ab_to_ab_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_ab,
-                                                              index_order_ab);
+      ::tenex::compute_tensorindex_transformation(index_order_ab,
+                                                  index_order_ab);
   const std::array<size_t, 2> expected_ab_to_ab_transformation = {0, 1};
   const std::array<size_t, 2> actual_ba_to_ab_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_ba,
-                                                              index_order_ab);
+      ::tenex::compute_tensorindex_transformation(index_order_ba,
+                                                  index_order_ab);
   const std::array<size_t, 2> expected_ba_to_ab_transformation = {1, 0};
 
   CHECK(actual_ab_to_ab_transformation == expected_ab_to_ab_transformation);
@@ -57,12 +57,12 @@ void test_tensor_index_transformation_rank_2(
       const std::array<size_t, 2> ji = {j, i};
 
       // For L_{ab} = R_{ab}, check that L_{ij} == R_{ij}
-      CHECK(::TensorExpressions::transform_multi_index(
+      CHECK(::tenex::transform_multi_index(
                 ij, expected_ab_to_ab_transformation) == ij);
       // For L_{ba} = R_{ab}, check that L_{ij} == R_{ji}
-      CHECK(::TensorExpressions::transform_multi_index(
+      CHECK(::tenex::transform_multi_index(
                 ij, expected_ba_to_ab_transformation) == ji);
     }
   }
 }
-}  // namespace TestHelpers::TensorExpressions
+}  // namespace TestHelpers::tenex

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorIndexTransformationRank2.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorIndexTransformationRank2.hpp
@@ -25,8 +25,8 @@ namespace TestHelpers::tenex {
 /// first generic index ordering, the equivalent multi-index with the second
 /// ordering is correctly computed.
 ///
-/// \tparam TensorIndexA the first generic tensor index, e.g. type of `ti_a`
-/// \tparam TensorIndexB the second generic tensor index, e.g. type of `ti_B`
+/// \tparam TensorIndexA the first generic tensor index, e.g. type of `ti::a`
+/// \tparam TensorIndexB the second generic tensor index, e.g. type of `ti::B`
 template <typename TensorIndexA, typename TensorIndexB>
 void test_tensor_index_transformation_rank_2(
     const TensorIndexA& /*tensorindex_a*/,

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorIndexTransformationRank3.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorIndexTransformationRank3.hpp
@@ -26,9 +26,9 @@ namespace TestHelpers::tenex {
 /// generic index ordering, the equivalent multi-index with the second ordering
 /// is correctly computed.
 ///
-/// \tparam TensorIndexA the first generic tensor index, e.g. type of `ti_a`
-/// \tparam TensorIndexB the second generic tensor index, e.g. type of `ti_B`
-/// \tparam TensorIndexC the third generic tensor index, e.g. type of `ti_c`
+/// \tparam TensorIndexA the first generic tensor index, e.g. type of `ti::a`
+/// \tparam TensorIndexB the second generic tensor index, e.g. type of `ti::B`
+/// \tparam TensorIndexC the third generic tensor index, e.g. type of `ti::c`
 template <typename TensorIndexA, typename TensorIndexB, typename TensorIndexC>
 void test_tensor_index_transformation_rank_3(
     const TensorIndexA& /*tensorindex_a*/,

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorIndexTransformationRank3.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorIndexTransformationRank3.hpp
@@ -10,14 +10,14 @@
 
 #include "DataStructures/Tensor/Expressions/TensorIndexTransformation.hpp"
 
-namespace TestHelpers::TensorExpressions {
+namespace TestHelpers::tenex {
 /// \ingroup TestingFrameworkGroup
 /// \brief Test that the transformation between two rank 3 tensors' generic
 /// indices and the subsequent transformed multi-indices are correctly computed
 ///
 /// \details The functions tested are:
-/// - `TensorExpressions::compute_tensorindex_transformation`
-/// - `TensorExpressions::transform_multi_index`
+/// - `tenex::compute_tensorindex_transformation`
+/// - `tenex::transform_multi_index`
 ///
 /// If we consider the first tensor's generic indices to be (a, b, c), the
 /// possible orderings of the second tensor's generic indices are: (a, b, c),
@@ -52,28 +52,28 @@ void test_tensor_index_transformation_rank_3(
       TensorIndexC::value, TensorIndexB::value, TensorIndexA::value};
 
   const std::array<size_t, 3> actual_abc_to_abc_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_abc,
-                                                              index_order_abc);
+      ::tenex::compute_tensorindex_transformation(index_order_abc,
+                                                  index_order_abc);
   const std::array<size_t, 3> expected_abc_to_abc_transformation = {0, 1, 2};
   const std::array<size_t, 3> actual_acb_to_abc_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_acb,
-                                                              index_order_abc);
+      ::tenex::compute_tensorindex_transformation(index_order_acb,
+                                                  index_order_abc);
   const std::array<size_t, 3> expected_acb_to_abc_transformation = {0, 2, 1};
   const std::array<size_t, 3> actual_bac_to_abc_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_bac,
-                                                              index_order_abc);
+      ::tenex::compute_tensorindex_transformation(index_order_bac,
+                                                  index_order_abc);
   const std::array<size_t, 3> expected_bac_to_abc_transformation = {1, 0, 2};
   const std::array<size_t, 3> actual_bca_to_abc_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_bca,
-                                                              index_order_abc);
+      ::tenex::compute_tensorindex_transformation(index_order_bca,
+                                                  index_order_abc);
   const std::array<size_t, 3> expected_bca_to_abc_transformation = {2, 0, 1};
   const std::array<size_t, 3> actual_cab_to_abc_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_cab,
-                                                              index_order_abc);
+      ::tenex::compute_tensorindex_transformation(index_order_cab,
+                                                  index_order_abc);
   const std::array<size_t, 3> expected_cab_to_abc_transformation = {1, 2, 0};
   const std::array<size_t, 3> actual_cba_to_abc_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_cba,
-                                                              index_order_abc);
+      ::tenex::compute_tensorindex_transformation(index_order_cba,
+                                                  index_order_abc);
   const std::array<size_t, 3> expected_cba_to_abc_transformation = {2, 1, 0};
 
   CHECK(actual_abc_to_abc_transformation == expected_abc_to_abc_transformation);
@@ -94,25 +94,25 @@ void test_tensor_index_transformation_rank_3(
         const std::array<size_t, 3> kji = {k, j, i};
 
         // For L_{abc} = R_{abc}, check that L_{ijk} == R_{ijk}
-        CHECK(::TensorExpressions::transform_multi_index(
+        CHECK(::tenex::transform_multi_index(
                   ijk, expected_abc_to_abc_transformation) == ijk);
         // For L_{acb} = R_{abc}, check that L_{ijk} == R_{ikj}
-        CHECK(::TensorExpressions::transform_multi_index(
+        CHECK(::tenex::transform_multi_index(
                   ijk, expected_acb_to_abc_transformation) == ikj);
         // For L_{bac} = R_{abc}, check that L_{ijk} == R_{jik}
-        CHECK(::TensorExpressions::transform_multi_index(
+        CHECK(::tenex::transform_multi_index(
                   ijk, expected_bac_to_abc_transformation) == jik);
         // For L_{bca} = R_{abc}, check that L_{ijk} == R_{kij}
-        CHECK(::TensorExpressions::transform_multi_index(
+        CHECK(::tenex::transform_multi_index(
                   ijk, expected_bca_to_abc_transformation) == kij);
         // For L_{cab} = R_{abc}, check that L_{ijk} == R_{jki}
-        CHECK(::TensorExpressions::transform_multi_index(
+        CHECK(::tenex::transform_multi_index(
                   ijk, expected_cab_to_abc_transformation) == jki);
         // For L_{cba} = R_{abc}, check that L_{ijk} == R_{kji}
-        CHECK(::TensorExpressions::transform_multi_index(
+        CHECK(::tenex::transform_multi_index(
                   ijk, expected_cba_to_abc_transformation) == kji);
       }
     }
   }
 }
-}  // namespace TestHelpers::TensorExpressions
+}  // namespace TestHelpers::tenex

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorIndexTransformationRank4.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorIndexTransformationRank4.hpp
@@ -10,14 +10,14 @@
 
 #include "DataStructures/Tensor/Expressions/TensorIndexTransformation.hpp"
 
-namespace TestHelpers::TensorExpressions {
+namespace TestHelpers::tenex {
 /// \ingroup TestingFrameworkGroup
 /// \brief Test that the transformation between two rank 4 tensors' generic
 /// indices and the subsequent transformed multi-indices are correctly computed
 ///
 /// \details The functions tested are:
-/// - `TensorExpressions::compute_tensorindex_transformation`
-/// - `TensorExpressions::transform_multi_index`
+/// - `tenex::compute_tensorindex_transformation`
+/// - `tenex::transform_multi_index`
 ///
 /// If we consider the first tensor's generic indices to be (a, b, c, d), there
 /// are 24 permutations that are possible orderings of the second tensor's
@@ -119,126 +119,126 @@ void test_tensor_index_transformation_rank_4(
       TensorIndexA::value};
 
   const std::array<size_t, 4> actual_abcd_to_abcd_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_abcd,
-                                                              index_order_abcd);
+      ::tenex::compute_tensorindex_transformation(index_order_abcd,
+                                                  index_order_abcd);
   const std::array<size_t, 4> expected_abcd_to_abcd_transformation = {0, 1, 2,
                                                                       3};
   const std::array<size_t, 4> actual_abdc_to_abcd_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_abdc,
-                                                              index_order_abcd);
+      ::tenex::compute_tensorindex_transformation(index_order_abdc,
+                                                  index_order_abcd);
   const std::array<size_t, 4> expected_abdc_to_abcd_transformation = {0, 1, 3,
                                                                       2};
   const std::array<size_t, 4> actual_acbd_to_abcd_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_acbd,
-                                                              index_order_abcd);
+      ::tenex::compute_tensorindex_transformation(index_order_acbd,
+                                                  index_order_abcd);
   const std::array<size_t, 4> expected_acbd_to_abcd_transformation = {0, 2, 1,
                                                                       3};
   const std::array<size_t, 4> actual_acdb_to_abcd_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_acdb,
-                                                              index_order_abcd);
+      ::tenex::compute_tensorindex_transformation(index_order_acdb,
+                                                  index_order_abcd);
   const std::array<size_t, 4> expected_acdb_to_abcd_transformation = {0, 3, 1,
                                                                       2};
   const std::array<size_t, 4> actual_adbc_to_abcd_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_adbc,
-                                                              index_order_abcd);
+      ::tenex::compute_tensorindex_transformation(index_order_adbc,
+                                                  index_order_abcd);
   const std::array<size_t, 4> expected_adbc_to_abcd_transformation = {0, 2, 3,
                                                                       1};
   const std::array<size_t, 4> actual_adcb_to_abcd_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_adcb,
-                                                              index_order_abcd);
+      ::tenex::compute_tensorindex_transformation(index_order_adcb,
+                                                  index_order_abcd);
   const std::array<size_t, 4> expected_adcb_to_abcd_transformation = {0, 3, 2,
                                                                       1};
 
   const std::array<size_t, 4> actual_bacd_to_abcd_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_bacd,
-                                                              index_order_abcd);
+      ::tenex::compute_tensorindex_transformation(index_order_bacd,
+                                                  index_order_abcd);
   const std::array<size_t, 4> expected_bacd_to_abcd_transformation = {1, 0, 2,
                                                                       3};
   const std::array<size_t, 4> actual_badc_to_abcd_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_badc,
-                                                              index_order_abcd);
+      ::tenex::compute_tensorindex_transformation(index_order_badc,
+                                                  index_order_abcd);
   const std::array<size_t, 4> expected_badc_to_abcd_transformation = {1, 0, 3,
                                                                       2};
   const std::array<size_t, 4> actual_bcad_to_abcd_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_bcad,
-                                                              index_order_abcd);
+      ::tenex::compute_tensorindex_transformation(index_order_bcad,
+                                                  index_order_abcd);
   const std::array<size_t, 4> expected_bcad_to_abcd_transformation = {2, 0, 1,
                                                                       3};
   const std::array<size_t, 4> actual_bcda_to_abcd_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_bcda,
-                                                              index_order_abcd);
+      ::tenex::compute_tensorindex_transformation(index_order_bcda,
+                                                  index_order_abcd);
   const std::array<size_t, 4> expected_bcda_to_abcd_transformation = {3, 0, 1,
                                                                       2};
   const std::array<size_t, 4> actual_bdac_to_abcd_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_bdac,
-                                                              index_order_abcd);
+      ::tenex::compute_tensorindex_transformation(index_order_bdac,
+                                                  index_order_abcd);
   const std::array<size_t, 4> expected_bdac_to_abcd_transformation = {2, 0, 3,
                                                                       1};
   const std::array<size_t, 4> actual_bdca_to_abcd_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_bdca,
-                                                              index_order_abcd);
+      ::tenex::compute_tensorindex_transformation(index_order_bdca,
+                                                  index_order_abcd);
   const std::array<size_t, 4> expected_bdca_to_abcd_transformation = {3, 0, 2,
                                                                       1};
 
   const std::array<size_t, 4> actual_cabd_to_abcd_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_cabd,
-                                                              index_order_abcd);
+      ::tenex::compute_tensorindex_transformation(index_order_cabd,
+                                                  index_order_abcd);
   const std::array<size_t, 4> expected_cabd_to_abcd_transformation = {1, 2, 0,
                                                                       3};
   const std::array<size_t, 4> actual_cadb_to_abcd_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_cadb,
-                                                              index_order_abcd);
+      ::tenex::compute_tensorindex_transformation(index_order_cadb,
+                                                  index_order_abcd);
   const std::array<size_t, 4> expected_cadb_to_abcd_transformation = {1, 3, 0,
                                                                       2};
   const std::array<size_t, 4> actual_cbad_to_abcd_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_cbad,
-                                                              index_order_abcd);
+      ::tenex::compute_tensorindex_transformation(index_order_cbad,
+                                                  index_order_abcd);
   const std::array<size_t, 4> expected_cbad_to_abcd_transformation = {2, 1, 0,
                                                                       3};
   const std::array<size_t, 4> actual_cbda_to_abcd_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_cbda,
-                                                              index_order_abcd);
+      ::tenex::compute_tensorindex_transformation(index_order_cbda,
+                                                  index_order_abcd);
   const std::array<size_t, 4> expected_cbda_to_abcd_transformation = {3, 1, 0,
                                                                       2};
   const std::array<size_t, 4> actual_cdab_to_abcd_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_cdab,
-                                                              index_order_abcd);
+      ::tenex::compute_tensorindex_transformation(index_order_cdab,
+                                                  index_order_abcd);
   const std::array<size_t, 4> expected_cdab_to_abcd_transformation = {2, 3, 0,
                                                                       1};
   const std::array<size_t, 4> actual_cdba_to_abcd_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_cdba,
-                                                              index_order_abcd);
+      ::tenex::compute_tensorindex_transformation(index_order_cdba,
+                                                  index_order_abcd);
   const std::array<size_t, 4> expected_cdba_to_abcd_transformation = {3, 2, 0,
                                                                       1};
 
   const std::array<size_t, 4> actual_dabc_to_abcd_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_dabc,
-                                                              index_order_abcd);
+      ::tenex::compute_tensorindex_transformation(index_order_dabc,
+                                                  index_order_abcd);
   const std::array<size_t, 4> expected_dabc_to_abcd_transformation = {1, 2, 3,
                                                                       0};
   const std::array<size_t, 4> actual_dacb_to_abcd_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_dacb,
-                                                              index_order_abcd);
+      ::tenex::compute_tensorindex_transformation(index_order_dacb,
+                                                  index_order_abcd);
   const std::array<size_t, 4> expected_dacb_to_abcd_transformation = {1, 3, 2,
                                                                       0};
   const std::array<size_t, 4> actual_dbac_to_abcd_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_dbac,
-                                                              index_order_abcd);
+      ::tenex::compute_tensorindex_transformation(index_order_dbac,
+                                                  index_order_abcd);
   const std::array<size_t, 4> expected_dbac_to_abcd_transformation = {2, 1, 3,
                                                                       0};
   const std::array<size_t, 4> actual_dbca_to_abcd_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_dbca,
-                                                              index_order_abcd);
+      ::tenex::compute_tensorindex_transformation(index_order_dbca,
+                                                  index_order_abcd);
   const std::array<size_t, 4> expected_dbca_to_abcd_transformation = {3, 1, 2,
                                                                       0};
   const std::array<size_t, 4> actual_dcab_to_abcd_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_dcab,
-                                                              index_order_abcd);
+      ::tenex::compute_tensorindex_transformation(index_order_dcab,
+                                                  index_order_abcd);
   const std::array<size_t, 4> expected_dcab_to_abcd_transformation = {2, 3, 1,
                                                                       0};
   const std::array<size_t, 4> actual_dcba_to_abcd_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_dcba,
-                                                              index_order_abcd);
+      ::tenex::compute_tensorindex_transformation(index_order_dcba,
+                                                  index_order_abcd);
   const std::array<size_t, 4> expected_dcba_to_abcd_transformation = {3, 2, 1,
                                                                       0};
 
@@ -327,83 +327,83 @@ void test_tensor_index_transformation_rank_4(
           const std::array<size_t, 4> lkji = {l, k, j, i};
 
           // For L_{abcd} = R_{abcd}, check that L_{ijkl} == R_{ijkl}
-          CHECK(::TensorExpressions::transform_multi_index(
+          CHECK(::tenex::transform_multi_index(
                     ijkl, expected_abcd_to_abcd_transformation) == ijkl);
           // For L_{abdc} = R_{abcd}, check that L_{ijkl} == R_{ijlk}
-          CHECK(::TensorExpressions::transform_multi_index(
+          CHECK(::tenex::transform_multi_index(
                     ijkl, expected_abdc_to_abcd_transformation) == ijlk);
           // For L_{acbd} = R_{abcd}, check that L_{ijkl} == R_{ikjl}
-          CHECK(::TensorExpressions::transform_multi_index(
+          CHECK(::tenex::transform_multi_index(
                     ijkl, expected_acbd_to_abcd_transformation) == ikjl);
           // For L_{acdb} = R_{abcd}, check that L_{ijkl} == R_{iljk}
-          CHECK(::TensorExpressions::transform_multi_index(
+          CHECK(::tenex::transform_multi_index(
                     ijkl, expected_acdb_to_abcd_transformation) == iljk);
           // For L_{adbc} = R_{abcd}, check that L_{ijkl} == R_{iklj}
-          CHECK(::TensorExpressions::transform_multi_index(
+          CHECK(::tenex::transform_multi_index(
                     ijkl, expected_adbc_to_abcd_transformation) == iklj);
           // For L_{adcb} = R_{abcd}, check that L_{ijkl} == R_{ilkj}
-          CHECK(::TensorExpressions::transform_multi_index(
+          CHECK(::tenex::transform_multi_index(
                     ijkl, expected_adcb_to_abcd_transformation) == ilkj);
 
           // For L_{bacd} = R_{abcd}, check that L_{ijkl} == R_{jikl}
-          CHECK(::TensorExpressions::transform_multi_index(
+          CHECK(::tenex::transform_multi_index(
                     ijkl, expected_bacd_to_abcd_transformation) == jikl);
           // For L_{badc} = R_{abcd}, check that L_{ijkl} == R_{jilk}
-          CHECK(::TensorExpressions::transform_multi_index(
+          CHECK(::tenex::transform_multi_index(
                     ijkl, expected_badc_to_abcd_transformation) == jilk);
           // For L_{bcad} = R_{abcd}, check that L_{ijkl} == R_{kijl}
-          CHECK(::TensorExpressions::transform_multi_index(
+          CHECK(::tenex::transform_multi_index(
                     ijkl, expected_bcad_to_abcd_transformation) == kijl);
           // For L_{bcda} = R_{abcd}, check that L_{ijkl} == R_{lijk}
-          CHECK(::TensorExpressions::transform_multi_index(
+          CHECK(::tenex::transform_multi_index(
                     ijkl, expected_bcda_to_abcd_transformation) == lijk);
           // For L_{bdac} = R_{abcd}, check that L_{ijkl} == R_{kilj}
-          CHECK(::TensorExpressions::transform_multi_index(
+          CHECK(::tenex::transform_multi_index(
                     ijkl, expected_bdac_to_abcd_transformation) == kilj);
           // For L_{bdca} = R_{abcd}, check that L_{ijkl} == R_{likj}
-          CHECK(::TensorExpressions::transform_multi_index(
+          CHECK(::tenex::transform_multi_index(
                     ijkl, expected_bdca_to_abcd_transformation) == likj);
 
           // For L_{cabd} = R_{abcd}, check that L_{ijkl} == R_{jkil}
-          CHECK(::TensorExpressions::transform_multi_index(
+          CHECK(::tenex::transform_multi_index(
                     ijkl, expected_cabd_to_abcd_transformation) == jkil);
           // For L_{cadb} = R_{abcd}, check that L_{ijkl} == R_{jlik}
-          CHECK(::TensorExpressions::transform_multi_index(
+          CHECK(::tenex::transform_multi_index(
                     ijkl, expected_cadb_to_abcd_transformation) == jlik);
           // For L_{cbad} = R_{abcd}, check that L_{ijkl} == R_{kjil}
-          CHECK(::TensorExpressions::transform_multi_index(
+          CHECK(::tenex::transform_multi_index(
                     ijkl, expected_cbad_to_abcd_transformation) == kjil);
           // For L_{cbda} = R_{abcd}, check that L_{ijkl} == R_{ljik}
-          CHECK(::TensorExpressions::transform_multi_index(
+          CHECK(::tenex::transform_multi_index(
                     ijkl, expected_cbda_to_abcd_transformation) == ljik);
           // For L_{cdab} = R_{abcd}, check that L_{ijkl} == R_{klij}
-          CHECK(::TensorExpressions::transform_multi_index(
+          CHECK(::tenex::transform_multi_index(
                     ijkl, expected_cdab_to_abcd_transformation) == klij);
           // For L_{cdba} = R_{abcd}, check that L_{ijkl} == R_{lkij}
-          CHECK(::TensorExpressions::transform_multi_index(
+          CHECK(::tenex::transform_multi_index(
                     ijkl, expected_cdba_to_abcd_transformation) == lkij);
 
           // For L_{dabc} = R_{abcd}, check that L_{ijkl} == R_{jkli}
-          CHECK(::TensorExpressions::transform_multi_index(
+          CHECK(::tenex::transform_multi_index(
                     ijkl, expected_dabc_to_abcd_transformation) == jkli);
           // For L_{dacb} = R_{abcd}, check that L_{ijkl} == R_{jlki}
-          CHECK(::TensorExpressions::transform_multi_index(
+          CHECK(::tenex::transform_multi_index(
                     ijkl, expected_dacb_to_abcd_transformation) == jlki);
           // For L_{dbac} = R_{abcd}, check that L_{ijkl} == R_{kjli}
-          CHECK(::TensorExpressions::transform_multi_index(
+          CHECK(::tenex::transform_multi_index(
                     ijkl, expected_dbac_to_abcd_transformation) == kjli);
           // For L_{dbca} = R_{abcd}, check that L_{ijkl} == R_{ljki}
-          CHECK(::TensorExpressions::transform_multi_index(
+          CHECK(::tenex::transform_multi_index(
                     ijkl, expected_dbca_to_abcd_transformation) == ljki);
           // For L_{dcab} = R_{abcd}, check that L_{ijkl} == R_{klji}
-          CHECK(::TensorExpressions::transform_multi_index(
+          CHECK(::tenex::transform_multi_index(
                     ijkl, expected_dcab_to_abcd_transformation) == klji);
           // For L_{dcba} = R_{abcd}, check that L_{ijkl} == R_{lkji}
-          CHECK(::TensorExpressions::transform_multi_index(
+          CHECK(::tenex::transform_multi_index(
                     ijkl, expected_dcba_to_abcd_transformation) == lkji);
         }
       }
     }
   }
 }
-}  // namespace TestHelpers::TensorExpressions
+}  // namespace TestHelpers::tenex

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorIndexTransformationRank4.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorIndexTransformationRank4.hpp
@@ -26,10 +26,10 @@ namespace TestHelpers::tenex {
 /// first generic index ordering, the equivalent multi-index with the second
 /// ordering is correctly computed.
 ///
-/// \tparam TensorIndexA the first generic tensor index, e.g. type of `ti_a`
-/// \tparam TensorIndexB the second generic tensor index, e.g. type of `ti_B`
-/// \tparam TensorIndexC the third generic tensor index, e.g. type of `ti_c`
-/// \tparam TensorIndexD the fourth generic tensor index, e.g. type of `ti_D`
+/// \tparam TensorIndexA the first generic tensor index, e.g. type of `ti::a`
+/// \tparam TensorIndexB the second generic tensor index, e.g. type of `ti::B`
+/// \tparam TensorIndexC the third generic tensor index, e.g. type of `ti::c`
+/// \tparam TensorIndexD the fourth generic tensor index, e.g. type of `ti::D`
 template <typename TensorIndexA, typename TensorIndexB, typename TensorIndexC,
           typename TensorIndexD>
 void test_tensor_index_transformation_rank_4(

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorIndexTransformationTimeIndex.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorIndexTransformationTimeIndex.hpp
@@ -9,15 +9,15 @@
 #include "DataStructures/Tensor/Expressions/TensorIndex.hpp"
 #include "DataStructures/Tensor/Expressions/TensorIndexTransformation.hpp"
 
-namespace TestHelpers::TensorExpressions {
+namespace TestHelpers::tenex {
 /// \ingroup TestingFrameworkGroup
 /// \brief Test that the transformation between two tensors generic
 /// indices and the subsequent transformed multi-indices are correctly computed
 /// when time indices are used with at least one of the tensors
 ///
 /// \details The functions tested are:
-/// - `TensorExpressions::compute_tensorindex_transformation`
-/// - `TensorExpressions::transform_multi_index`
+/// - `tenex::compute_tensorindex_transformation`
+/// - `tenex::transform_multi_index`
 void test_tensor_index_transformation_with_time_indices() {
   const std::array<size_t, 0> index_order_empty = {};
   const std::array<size_t, 1> index_order_t = {ti_t.value};
@@ -28,62 +28,62 @@ void test_tensor_index_transformation_with_time_indices() {
   const std::array<size_t, 5> index_order_tbatT = {
       ti_t.value, ti_b.value, ti_a.value, ti_t.value, ti_T.value};
 
-  const size_t time_index_placeholder = ::TensorExpressions::
+  const size_t time_index_placeholder = ::tenex::
       TensorIndexTransformation_detail::time_index_position_placeholder;
 
   // Transform multi-index for rank 0 tensor to multi-index for rank 1 tensor
   // with time index
   // e.g. transform multi-index for L to multi-index for R_{t}
   const std::array<size_t, 1> actual_empty_to_t_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_empty,
-                                                              index_order_t);
+      ::tenex::compute_tensorindex_transformation(index_order_empty,
+                                                  index_order_t);
   const std::array<size_t, 1> expected_empty_to_t_transformation = {
       time_index_placeholder};
   CHECK(actual_empty_to_t_transformation == expected_empty_to_t_transformation);
   const std::array<size_t, 0> multi_index_empty = {};
   const std::array<size_t, 1> multi_index_t = {0};
-  CHECK(::TensorExpressions::transform_multi_index(
-            multi_index_empty, expected_empty_to_t_transformation) ==
+  CHECK(::tenex::transform_multi_index(multi_index_empty,
+                                       expected_empty_to_t_transformation) ==
         multi_index_t);
 
   // Transform multi-index for rank 1 tensor with time index to multi-index for
   // rank 0 tensor
   // e.g. transform multi-index for L_{t} to multi-index for R
   const std::array<size_t, 0> actual_t_to_empty_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(
-          index_order_t, index_order_empty);
+      ::tenex::compute_tensorindex_transformation(index_order_t,
+                                                  index_order_empty);
   const std::array<size_t, 0> expected_t_to_empty_transformation = {};
   CHECK(actual_t_to_empty_transformation == expected_t_to_empty_transformation);
-  CHECK(::TensorExpressions::transform_multi_index(
-            multi_index_t, expected_t_to_empty_transformation) ==
+  CHECK(::tenex::transform_multi_index(multi_index_t,
+                                       expected_t_to_empty_transformation) ==
         multi_index_empty);
 
   // Transform multi-index for rank 0 tensor to multi-index for rank 3 tensor
   // with three time indices
   // e.g. transform multi-index for L to multi-index for R^{t}{}_{tt}
   const std::array<size_t, 3> actual_empty_to_Ttt_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_empty,
-                                                              index_order_Ttt);
+      ::tenex::compute_tensorindex_transformation(index_order_empty,
+                                                  index_order_Ttt);
   const std::array<size_t, 3> expected_empty_to_Ttt_transformation = {
       time_index_placeholder, time_index_placeholder, time_index_placeholder};
   CHECK(actual_empty_to_Ttt_transformation ==
         expected_empty_to_Ttt_transformation);
   const std::array<size_t, 3> multi_index_Ttt = {0, 0, 0};
-  CHECK(::TensorExpressions::transform_multi_index(
-            multi_index_empty, expected_empty_to_Ttt_transformation) ==
+  CHECK(::tenex::transform_multi_index(multi_index_empty,
+                                       expected_empty_to_Ttt_transformation) ==
         multi_index_Ttt);
 
   // Transform multi-index for rank 3 tensor with three time indices to
   // multi-index for rank 0 tensor
   // e.g. transform multi-index for L^{t}{}_{tt} to multi-index for R
   const std::array<size_t, 0> actual_Ttt_to_empty_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(
-          index_order_Ttt, index_order_empty);
+      ::tenex::compute_tensorindex_transformation(index_order_Ttt,
+                                                  index_order_empty);
   const std::array<size_t, 0> expected_Ttt_to_empty_transformation = {};
   CHECK(actual_Ttt_to_empty_transformation ==
         expected_Ttt_to_empty_transformation);
-  CHECK(::TensorExpressions::transform_multi_index(
-            multi_index_Ttt, expected_Ttt_to_empty_transformation) ==
+  CHECK(::tenex::transform_multi_index(multi_index_Ttt,
+                                       expected_Ttt_to_empty_transformation) ==
         multi_index_empty);
 
   // Transform multi-indices for rank 3 tensor with one time index to
@@ -97,8 +97,8 @@ void test_tensor_index_transformation_with_time_indices() {
   // time indices on either side in addition to a different relative index order
   // for generic indices (i.e. a and b)
   const std::array<size_t, 5> actual_atb_to_tbatT_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(
-          index_order_atb, index_order_tbatT);
+      ::tenex::compute_tensorindex_transformation(index_order_atb,
+                                                  index_order_tbatT);
   const std::array<size_t, 5> expected_atb_to_tbatT_transformation = {
       time_index_placeholder, 2, 0, time_index_placeholder,
       time_index_placeholder};
@@ -109,7 +109,7 @@ void test_tensor_index_transformation_with_time_indices() {
     for (size_t b = 0; b < 4; b++) {
       const std::array<size_t, 3> multi_index_atb = {a, 0, b};
       const std::array<size_t, 5> multi_index_tbatT = {0, b, a, 0, 0};
-      CHECK(::TensorExpressions::transform_multi_index(
+      CHECK(::tenex::transform_multi_index(
                 multi_index_atb, expected_atb_to_tbatT_transformation) ==
             multi_index_tbatT);
     }
@@ -120,8 +120,8 @@ void test_tensor_index_transformation_with_time_indices() {
   // e.g. transform multi-indices for L_{tbat}{}^{t} to multi-indices for
   // R_{atb}
   const std::array<size_t, 3> actual_tbatT_to_atb_transformation =
-      ::TensorExpressions::compute_tensorindex_transformation(index_order_tbatT,
-                                                              index_order_atb);
+      ::tenex::compute_tensorindex_transformation(index_order_tbatT,
+                                                  index_order_atb);
   const std::array<size_t, 3> expected_tbatT_to_atb_transformation = {
       2, time_index_placeholder, 1};
   CHECK(actual_tbatT_to_atb_transformation ==
@@ -131,10 +131,10 @@ void test_tensor_index_transformation_with_time_indices() {
     for (size_t a = 0; a < 4; a++) {
       const std::array<size_t, 5> multi_index_tbatT = {0, b, a, 0, 0};
       const std::array<size_t, 3> multi_index_atb = {a, 0, b};
-      CHECK(::TensorExpressions::transform_multi_index(
+      CHECK(::tenex::transform_multi_index(
                 multi_index_tbatT, expected_tbatT_to_atb_transformation) ==
             multi_index_atb);
     }
   }
 }
-}  // namespace TestHelpers::TensorExpressions
+}  // namespace TestHelpers::tenex

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorIndexTransformationTimeIndex.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorIndexTransformationTimeIndex.hpp
@@ -20,13 +20,13 @@ namespace TestHelpers::tenex {
 /// - `tenex::transform_multi_index`
 void test_tensor_index_transformation_with_time_indices() {
   const std::array<size_t, 0> index_order_empty = {};
-  const std::array<size_t, 1> index_order_t = {ti_t.value};
-  const std::array<size_t, 3> index_order_atb = {ti_a.value, ti_t.value,
-                                                 ti_b.value};
-  const std::array<size_t, 3> index_order_Ttt = {ti_T.value, ti_t.value,
-                                                 ti_t.value};
+  const std::array<size_t, 1> index_order_t = {ti::t.value};
+  const std::array<size_t, 3> index_order_atb = {ti::a.value, ti::t.value,
+                                                 ti::b.value};
+  const std::array<size_t, 3> index_order_Ttt = {ti::T.value, ti::t.value,
+                                                 ti::t.value};
   const std::array<size_t, 5> index_order_tbatT = {
-      ti_t.value, ti_b.value, ti_a.value, ti_t.value, ti_T.value};
+      ti::t.value, ti::b.value, ti::a.value, ti::t.value, ti::T.value};
 
   const size_t time_index_placeholder = ::tenex::
       TensorIndexTransformation_detail::time_index_position_placeholder;

--- a/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/Xcts/VerifySolution.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/Xcts/VerifySolution.hpp
@@ -174,16 +174,16 @@ void verify_adm_constraints(const Solution& solution,
                         trace_extrinsic_curvature);
   CHECK_ITERABLE_APPROX(get(lapse) * get(conformal_factor),
                         get(lapse_times_conformal_factor));
-  CHECK_ITERABLE_APPROX(TensorExpressions::evaluate<ti_I>(
-                            shift_background(ti_I) + shift_excess(ti_I)),
-                        shift);
+  CHECK_ITERABLE_APPROX(
+      tenex::evaluate<ti_I>(shift_background(ti_I) + shift_excess(ti_I)),
+      shift);
 
   // Check extrinsic curvature decomposition
   //   K_ij = \psi^-2 \bar{A}_ij + 1/3 \gamma_ij K
   // with
   //   \bar{A}^ij = \psi^6 / (2 \alpha) * (\bar{L}\beta^ij - \bar{u}^ij)
   tnsr::ii<DataVector, 3> composed_extcurv{};
-  TensorExpressions::evaluate<ti_i, ti_j>(
+  tenex::evaluate<ti_i, ti_j>(
       make_not_null(&composed_extcurv),
       pow<4>(conformal_factor()) / (2. * lapse()) *
               (longitudinal_shift_excess(ti_K, ti_L) +
@@ -196,7 +196,7 @@ void verify_adm_constraints(const Solution& solution,
   // Check Hamiltonian constraint R + K^2 + K_ij K^ij = 16 \pi \rho, divided by
   // two for consistency with SpEC (the factor of two doesn't really matter)
   // here since we are comparing with zero)
-  const Scalar<DataVector> hamiltonian_constraint = TensorExpressions::evaluate(
+  const Scalar<DataVector> hamiltonian_constraint = tenex::evaluate(
       0.5 * (ricci_scalar() + square(trace_extrinsic_curvature()) -
              extrinsic_curvature(ti_i, ti_j) * extrinsic_curvature(ti_k, ti_l) *
                  inv_spatial_metric(ti_I, ti_K) *
@@ -207,21 +207,18 @@ void verify_adm_constraints(const Solution& solution,
 
   // Check momentum constraint \nabla_j (K^ij - K \gamma^ij) = 8 \pi S^i
   tnsr::II<DataVector, 3> extcurv_min_trace{};
-  TensorExpressions::evaluate<ti_I, ti_J>(
+  tenex::evaluate<ti_I, ti_J>(
       make_not_null(&extcurv_min_trace),
       extrinsic_curvature(ti_k, ti_l) * inv_spatial_metric(ti_I, ti_K) *
               inv_spatial_metric(ti_J, ti_L) -
           trace_extrinsic_curvature() * inv_spatial_metric(ti_I, ti_J));
   const tnsr::iJJ<DataVector, 3> deriv_extcurv_min_trace =
       partial_derivative(extcurv_min_trace, mesh, inv_jacobian);
-  const tnsr::I<DataVector, 3> momentum_constraint =
-      TensorExpressions::evaluate<ti_I>(
-          deriv_extcurv_min_trace(ti_j, ti_I, ti_J) +
-          spatial_christoffel(ti_I, ti_k, ti_j) *
-              extcurv_min_trace(ti_K, ti_J) +
-          spatial_christoffel(ti_J, ti_k, ti_j) *
-              extcurv_min_trace(ti_I, ti_K) -
-          8. * M_PI * momentum_density(ti_I));
+  const tnsr::I<DataVector, 3> momentum_constraint = tenex::evaluate<ti_I>(
+      deriv_extcurv_min_trace(ti_j, ti_I, ti_J) +
+      spatial_christoffel(ti_I, ti_k, ti_j) * extcurv_min_trace(ti_K, ti_J) +
+      spatial_christoffel(ti_J, ti_k, ti_j) * extcurv_min_trace(ti_I, ti_K) -
+      8. * M_PI * momentum_density(ti_I));
   CHECK_ITERABLE_CUSTOM_APPROX(momentum_constraint,
                                (tnsr::I<DataVector, 3>(num_points, 0.)),
                                custom_approx);

--- a/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/Xcts/VerifySolution.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/Xcts/VerifySolution.hpp
@@ -175,7 +175,7 @@ void verify_adm_constraints(const Solution& solution,
   CHECK_ITERABLE_APPROX(get(lapse) * get(conformal_factor),
                         get(lapse_times_conformal_factor));
   CHECK_ITERABLE_APPROX(
-      tenex::evaluate<ti_I>(shift_background(ti_I) + shift_excess(ti_I)),
+      tenex::evaluate<ti::I>(shift_background(ti::I) + shift_excess(ti::I)),
       shift);
 
   // Check extrinsic curvature decomposition
@@ -183,14 +183,14 @@ void verify_adm_constraints(const Solution& solution,
   // with
   //   \bar{A}^ij = \psi^6 / (2 \alpha) * (\bar{L}\beta^ij - \bar{u}^ij)
   tnsr::ii<DataVector, 3> composed_extcurv{};
-  tenex::evaluate<ti_i, ti_j>(
+  tenex::evaluate<ti::i, ti::j>(
       make_not_null(&composed_extcurv),
       pow<4>(conformal_factor()) / (2. * lapse()) *
-              (longitudinal_shift_excess(ti_K, ti_L) +
-               longitudinal_shift_background_minus_dt_conformal_metric(ti_K,
-                                                                       ti_L)) *
-              conformal_metric(ti_i, ti_k) * conformal_metric(ti_l, ti_j) +
-          spatial_metric(ti_i, ti_j) * trace_extrinsic_curvature() / 3.);
+              (longitudinal_shift_excess(ti::K, ti::L) +
+               longitudinal_shift_background_minus_dt_conformal_metric(ti::K,
+                                                                       ti::L)) *
+              conformal_metric(ti::i, ti::k) * conformal_metric(ti::l, ti::j) +
+          spatial_metric(ti::i, ti::j) * trace_extrinsic_curvature() / 3.);
   CHECK_ITERABLE_APPROX(composed_extcurv, extrinsic_curvature);
 
   // Check Hamiltonian constraint R + K^2 + K_ij K^ij = 16 \pi \rho, divided by
@@ -198,27 +198,30 @@ void verify_adm_constraints(const Solution& solution,
   // here since we are comparing with zero)
   const Scalar<DataVector> hamiltonian_constraint = tenex::evaluate(
       0.5 * (ricci_scalar() + square(trace_extrinsic_curvature()) -
-             extrinsic_curvature(ti_i, ti_j) * extrinsic_curvature(ti_k, ti_l) *
-                 inv_spatial_metric(ti_I, ti_K) *
-                 inv_spatial_metric(ti_J, ti_L)) -
+             extrinsic_curvature(ti::i, ti::j) *
+                 extrinsic_curvature(ti::k, ti::l) *
+                 inv_spatial_metric(ti::I, ti::K) *
+                 inv_spatial_metric(ti::J, ti::L)) -
       8. * M_PI * energy_density());
   CHECK_ITERABLE_CUSTOM_APPROX(get(hamiltonian_constraint),
                                DataVector(num_points, 0.), custom_approx);
 
   // Check momentum constraint \nabla_j (K^ij - K \gamma^ij) = 8 \pi S^i
   tnsr::II<DataVector, 3> extcurv_min_trace{};
-  tenex::evaluate<ti_I, ti_J>(
+  tenex::evaluate<ti::I, ti::J>(
       make_not_null(&extcurv_min_trace),
-      extrinsic_curvature(ti_k, ti_l) * inv_spatial_metric(ti_I, ti_K) *
-              inv_spatial_metric(ti_J, ti_L) -
-          trace_extrinsic_curvature() * inv_spatial_metric(ti_I, ti_J));
+      extrinsic_curvature(ti::k, ti::l) * inv_spatial_metric(ti::I, ti::K) *
+              inv_spatial_metric(ti::J, ti::L) -
+          trace_extrinsic_curvature() * inv_spatial_metric(ti::I, ti::J));
   const tnsr::iJJ<DataVector, 3> deriv_extcurv_min_trace =
       partial_derivative(extcurv_min_trace, mesh, inv_jacobian);
-  const tnsr::I<DataVector, 3> momentum_constraint = tenex::evaluate<ti_I>(
-      deriv_extcurv_min_trace(ti_j, ti_I, ti_J) +
-      spatial_christoffel(ti_I, ti_k, ti_j) * extcurv_min_trace(ti_K, ti_J) +
-      spatial_christoffel(ti_J, ti_k, ti_j) * extcurv_min_trace(ti_I, ti_K) -
-      8. * M_PI * momentum_density(ti_I));
+  const tnsr::I<DataVector, 3> momentum_constraint =
+      tenex::evaluate<ti::I>(deriv_extcurv_min_trace(ti::j, ti::I, ti::J) +
+                             spatial_christoffel(ti::I, ti::k, ti::j) *
+                                 extcurv_min_trace(ti::K, ti::J) +
+                             spatial_christoffel(ti::J, ti::k, ti::j) *
+                                 extcurv_min_trace(ti::I, ti::K) -
+                             8. * M_PI * momentum_density(ti::I));
   CHECK_ITERABLE_CUSTOM_APPROX(momentum_constraint,
                                (tnsr::I<DataVector, 3>(num_points, 0.)),
                                custom_approx);

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_HarmonicSchwarzschild.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_HarmonicSchwarzschild.cpp
@@ -569,17 +569,17 @@ void test_harmonic_conditions_satisfied(const DataType& used_for_size) {
       make_with_value<tnsr::A<DataType, 3, Frame>>(used_for_size, 0.0);
 
   CHECK_ITERABLE_APPROX(
-      tenex::evaluate<ti_A>(
-          inverse_spacetime_metric(ti_B, ti_C) *
-          spacetime_christoffel_second_kind(ti_A, ti_b, ti_c)),
+      tenex::evaluate<ti::A>(
+          inverse_spacetime_metric(ti::B, ti::C) *
+          spacetime_christoffel_second_kind(ti::A, ti::b, ti::c)),
       expected_contracted_spacetime_christoffel_second_kind);
 
   // Check that eq 4.44 of \cite BaumgarteShapiro is satisfied:
   //   (\partial_t - \beta^j \partial_j)\alpha = -\alpha^2 K
   CHECK_ITERABLE_APPROX(
-      tenex::evaluate(dt_lapse() - shift(ti_J) * d_lapse(ti_j)),
-      tenex::evaluate(-square(lapse()) * extrinsic_curvature(ti_i, ti_j) *
-                      inverse_spatial_metric(ti_I, ti_J)));
+      tenex::evaluate(dt_lapse() - shift(ti::J) * d_lapse(ti::j)),
+      tenex::evaluate(-square(lapse()) * extrinsic_curvature(ti::i, ti::j) *
+                      inverse_spatial_metric(ti::I, ti::J)));
 
   // Check that eq 4.45 of \cite BaumgarteShapiro is satisfied:
   //   (\partial_t - \beta^j \partial_j)\beta^i =
@@ -592,12 +592,13 @@ void test_harmonic_conditions_satisfied(const DataType& used_for_size) {
       gr::christoffel_second_kind(d_spatial_metric, inverse_spatial_metric);
 
   CHECK_ITERABLE_APPROX(
-      tenex::evaluate<ti_I>(dt_shift(ti_I) - shift(ti_J) * d_shift(ti_j, ti_I)),
-      tenex::evaluate<ti_I>(
+      tenex::evaluate<ti::I>(dt_shift(ti::I) -
+                             shift(ti::J) * d_shift(ti::j, ti::I)),
+      tenex::evaluate<ti::I>(
           -square(lapse()) *
-          (inverse_spatial_metric(ti_I, ti_J) * d_lapse(ti_j) / lapse() -
-           inverse_spatial_metric(ti_J, ti_K) *
-               spatial_christoffel_second_kind(ti_I, ti_j, ti_k))));
+          (inverse_spatial_metric(ti::I, ti::J) * d_lapse(ti::j) / lapse() -
+           inverse_spatial_metric(ti::J, ti::K) *
+               spatial_christoffel_second_kind(ti::I, ti::j, ti::k))));
 }
 }  // namespace
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_HarmonicSchwarzschild.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_HarmonicSchwarzschild.cpp
@@ -569,7 +569,7 @@ void test_harmonic_conditions_satisfied(const DataType& used_for_size) {
       make_with_value<tnsr::A<DataType, 3, Frame>>(used_for_size, 0.0);
 
   CHECK_ITERABLE_APPROX(
-      TensorExpressions::evaluate<ti_A>(
+      tenex::evaluate<ti_A>(
           inverse_spacetime_metric(ti_B, ti_C) *
           spacetime_christoffel_second_kind(ti_A, ti_b, ti_c)),
       expected_contracted_spacetime_christoffel_second_kind);
@@ -577,10 +577,9 @@ void test_harmonic_conditions_satisfied(const DataType& used_for_size) {
   // Check that eq 4.44 of \cite BaumgarteShapiro is satisfied:
   //   (\partial_t - \beta^j \partial_j)\alpha = -\alpha^2 K
   CHECK_ITERABLE_APPROX(
-      TensorExpressions::evaluate(dt_lapse() - shift(ti_J) * d_lapse(ti_j)),
-      TensorExpressions::evaluate(-square(lapse()) *
-                                  extrinsic_curvature(ti_i, ti_j) *
-                                  inverse_spatial_metric(ti_I, ti_J)));
+      tenex::evaluate(dt_lapse() - shift(ti_J) * d_lapse(ti_j)),
+      tenex::evaluate(-square(lapse()) * extrinsic_curvature(ti_i, ti_j) *
+                      inverse_spatial_metric(ti_I, ti_J)));
 
   // Check that eq 4.45 of \cite BaumgarteShapiro is satisfied:
   //   (\partial_t - \beta^j \partial_j)\beta^i =
@@ -593,9 +592,8 @@ void test_harmonic_conditions_satisfied(const DataType& used_for_size) {
       gr::christoffel_second_kind(d_spatial_metric, inverse_spatial_metric);
 
   CHECK_ITERABLE_APPROX(
-      TensorExpressions::evaluate<ti_I>(dt_shift(ti_I) -
-                                        shift(ti_J) * d_shift(ti_j, ti_I)),
-      TensorExpressions::evaluate<ti_I>(
+      tenex::evaluate<ti_I>(dt_shift(ti_I) - shift(ti_J) * d_shift(ti_j, ti_I)),
+      tenex::evaluate<ti_I>(
           -square(lapse()) *
           (inverse_spatial_metric(ti_I, ti_J) * d_lapse(ti_j) / lapse() -
            inverse_spatial_metric(ti_J, ti_K) *


### PR DESCRIPTION
## Proposed changes

This PR changes two things about the `TensorExpression` interface:
- `namespace TensorExpressions` -> `namespace tenex` to reduce keystrokes for calling `TensorExpressions::evaluate` and `TensorExpressions::update`
- Generic tensor indices `ti_a`, etc. are now in their own `ti` namespace and are accessed via `ti::a`, etc. to make it more consistent with our `tnsr::ij`, etc. aliases

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
- Anywhere using `TensorExpressions` namespace should now use `tenex`
- Anywhere using `ti_a` (tensor indices) should now use `ti::a`
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
