### PR TITLE
Add MemoryMonitor component and actions

### DIFF
--- a/src/Parallel/CMakeLists.txt
+++ b/src/Parallel/CMakeLists.txt
@@ -76,6 +76,7 @@ add_dependencies(
 
 add_subdirectory(Actions)
 add_subdirectory(Algorithms)
+add_subdirectory(MemoryMonitor)
 add_subdirectory(PhaseControl)
 add_subdirectory(Protocols)
 add_subdirectory(Tags)

--- a/src/Parallel/MemoryMonitor/CMakeLists.txt
+++ b/src/Parallel/MemoryMonitor/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Tags.hpp
+)

--- a/src/Parallel/MemoryMonitor/CMakeLists.txt
+++ b/src/Parallel/MemoryMonitor/CMakeLists.txt
@@ -5,5 +5,6 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  MemoryMonitor.hpp
   Tags.hpp
 )

--- a/src/Parallel/MemoryMonitor/MemoryMonitor.hpp
+++ b/src/Parallel/MemoryMonitor/MemoryMonitor.hpp
@@ -1,0 +1,64 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/Algorithms/AlgorithmSingletonDeclarations.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Local.hpp"
+#include "Parallel/MemoryMonitor/Tags.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "ParallelAlgorithms/Initialization/Actions/AddSimpleTags.hpp"
+#include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/*!
+ * \ingroup ParallelGroup
+ * Holds the MemoryMonitor parallel component and all actions and tags related
+ * to the memory monitor.
+ */
+namespace mem_monitor {}
+
+namespace mem_monitor {
+namespace detail {
+struct InitializeMutator {
+  using return_tags = tmpl::list<mem_monitor::Tags::MemoryHolder>;
+  using argument_tags = tmpl::list<>;
+
+  using tag_type = typename mem_monitor::Tags::MemoryHolder::type;
+
+  static void apply(const gsl::not_null<tag_type*> /*holder*/) {}
+};
+}  // namespace detail
+
+/*!
+ * \brief Singleton parallel component used for monitoring memory usage of other
+ * parallel components
+ */
+template <class Metavariables>
+struct MemoryMonitor {
+  using chare_type = Parallel::Algorithms::Singleton;
+
+  using metavariables = Metavariables;
+
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      typename metavariables::Phase, metavariables::Phase::Initialization,
+      tmpl::list<Actions::SetupDataBox,
+                 Initialization::Actions::AddSimpleTags<
+                     mem_monitor::detail::InitializeMutator>,
+                 Initialization::Actions::RemoveOptionsAndTerminatePhase>>>;
+
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+
+  static void execute_next_phase(
+      const typename Metavariables::Phase next_phase,
+      Parallel::CProxy_GlobalCache<Metavariables>& global_cache) {
+    auto& local_cache = *Parallel::local_branch(global_cache);
+    Parallel::get_parallel_component<MemoryMonitor<Metavariables>>(local_cache)
+        .start_phase(next_phase);
+  }
+};
+}  // namespace mem_monitor

--- a/src/Parallel/MemoryMonitor/Tags.hpp
+++ b/src/Parallel/MemoryMonitor/Tags.hpp
@@ -1,0 +1,41 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <unordered_map>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/PrettyType.hpp"
+
+namespace mem_monitor {
+/*!
+ * Gives full subfile path to the dat file for the memory monitor of a
+ * parallel component
+ */
+template <typename ParallelComponent>
+std::string subfile_name() {
+  return "/MemoryMonitors/" + pretty_type::name<ParallelComponent>();
+}
+
+namespace Tags {
+/*!
+ * \brief Tag to hold memory usage of parallel components before it is written
+ * to disk.
+ *
+ * \details The types in the unordered_map are as follows:
+ *
+ * \code
+ * std::unordered_map<ComponentName, std::unordered_map<%Time,
+ *      std::unordered_map<Node/Proc, Memory in MB>>>
+ * \endcode
+ */
+struct MemoryHolder : db::SimpleTag {
+  using type = std::unordered_map<
+      std::string, std::unordered_map<double, std::unordered_map<int, double>>>;
+};
+}  // namespace Tags
+}  // namespace mem_monitor

--- a/src/ParallelAlgorithms/Actions/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Actions/CMakeLists.txt
@@ -23,3 +23,5 @@ target_link_libraries(
   ErrorHandling
   Utilities
   )
+
+add_subdirectory(MemoryMonitor)

--- a/src/ParallelAlgorithms/Actions/MemoryMonitor/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Actions/MemoryMonitor/CMakeLists.txt
@@ -8,4 +8,5 @@ spectre_target_headers(
   ContributeMemoryData.hpp
   ProcessArray.hpp
   ProcessGroups.hpp
+  ProcessSingleton.hpp
   )

--- a/src/ParallelAlgorithms/Actions/MemoryMonitor/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Actions/MemoryMonitor/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  ContributeMemoryData.hpp
+  )

--- a/src/ParallelAlgorithms/Actions/MemoryMonitor/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Actions/MemoryMonitor/CMakeLists.txt
@@ -6,4 +6,5 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ContributeMemoryData.hpp
+  ProcessGroups.hpp
   )

--- a/src/ParallelAlgorithms/Actions/MemoryMonitor/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Actions/MemoryMonitor/CMakeLists.txt
@@ -6,5 +6,6 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ContributeMemoryData.hpp
+  ProcessArray.hpp
   ProcessGroups.hpp
   )

--- a/src/ParallelAlgorithms/Actions/MemoryMonitor/ContributeMemoryData.hpp
+++ b/src/ParallelAlgorithms/Actions/MemoryMonitor/ContributeMemoryData.hpp
@@ -1,0 +1,184 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <numeric>
+#include <string>
+#include <tuple>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/ReductionActions.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Info.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Local.hpp"
+#include "Parallel/MemoryMonitor/MemoryMonitor.hpp"
+#include "Parallel/MemoryMonitor/Tags.hpp"
+#include "Parallel/Serialize.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace mem_monitor {
+/*!
+ * \brief Simple action meant to be run on the MemoryMonitor component that
+ * collects sizes from Groups and Nodegroups.
+ *
+ * \details This action collects the sizes of all the local branches of a group
+ * or nodegroup component, computes the total memory usage on a node for each,
+ * then writes it to disk. For groups, the proc with the maximum memory usage is
+ * also reported along with the size on the proc.
+ *
+ * The columns in the dat file for a nodegroup when running on 3 nodes will be
+ *
+ * - %Time
+ * - Size on node 0 (MB)
+ * - Size on node 1 (MB)
+ * - Size on node 2 (MB)
+ * - Average size per node (MB)
+ *
+ * The columns in the dat file for a group when running on 3 nodes will be
+ *
+ * - %Time
+ * - Size on node 0 (MB)
+ * - Size on node 1 (MB)
+ * - Size on node 2 (MB)
+ * - Proc of max size
+ * - Size on proc of max size (MB)
+ * - Average size per node (MB)
+ *
+ * The dat file will be placed in the `/MemoryMonitors/` group in the reduction
+ * file. The name of the dat file is the `pretty_type::name` of the component.
+ */
+template <typename ContributingComponent>
+struct ContributeMemoryData {
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
+  static void apply(db::DataBox<DbTags>& box,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/, const double time,
+                    const int node_or_proc, const double size_in_megabytes) {
+    static_assert(Parallel::is_group_v<ContributingComponent> or
+                  Parallel::is_nodegroup_v<ContributingComponent>);
+
+    using tag = Tags::MemoryHolder;
+    if constexpr (db::tag_is_retrievable_v<tag, db::DataBox<DbTags>>) {
+      db::mutate<tag>(
+          make_not_null(&box),
+          [&cache, &time, &node_or_proc, &size_in_megabytes](
+              const gsl::not_null<std::unordered_map<
+                  std::string,
+                  std::unordered_map<double, std::unordered_map<int, double>>>*>
+                  memory_holder_all) {
+            auto memory_holder_pair = memory_holder_all->try_emplace(
+                pretty_type::name<ContributingComponent>());
+            auto& memory_holder = (*memory_holder_pair.first).second;
+
+            memory_holder.try_emplace(time);
+            memory_holder.at(time)[node_or_proc] = size_in_megabytes;
+
+            // If we have received data for every node/proc at a given
+            // time, get all the data, write it to disk, then remove the current
+            // time from the stored times as it's no longer needed
+
+            auto& mem_monitor_proxy =
+                Parallel::get_parallel_component<MemoryMonitor<Metavariables>>(
+                    cache);
+
+            constexpr bool is_group =
+                Parallel::is_group_v<ContributingComponent>;
+
+            const int num_nodes =
+                Parallel::number_of_nodes(*Parallel::local(mem_monitor_proxy));
+            const int num_procs =
+                Parallel::number_of_procs(*Parallel::local(mem_monitor_proxy));
+            const size_t expected_number =
+                static_cast<size_t>(is_group ? num_procs : num_nodes);
+            ASSERT(memory_holder.at(time).size() <= expected_number,
+                   "ContributeMemoryData received more data than it was "
+                   "expecting. Was expecting "
+                       << expected_number << " calls but instead got "
+                       << memory_holder.at(time).size());
+            if (memory_holder.at(time).size() == expected_number) {
+              // First column is always time
+              std::vector<double> data_to_append{time};
+              std::vector<std::string> legend{{"Time"}};
+
+              // Append a column for each node, and keep track of cumulative
+              // total. If we have proc data (from groups) do an additional loop
+              // over the procs to get the total on that node and get the proc
+              // of the maximum memory usage
+              double avg_size_per_node = 0.0;
+              double max_usage_on_proc = -std::numeric_limits<double>::max();
+              int proc_of_max = 0;
+              for (int node = 0; node < num_nodes; node++) {
+                double size_on_node = 0.0;
+                if (not is_group) {
+                  size_on_node = memory_holder.at(time).at(node);
+                } else {
+                  const int first_proc = Parallel::first_proc_on_node(
+                      node, *Parallel::local(mem_monitor_proxy));
+                  const int procs_on_node = Parallel::procs_on_node(
+                      node, *Parallel::local(mem_monitor_proxy));
+                  const int last_proc = first_proc + procs_on_node;
+                  for (int proc = first_proc; proc < last_proc; proc++) {
+                    size_on_node += memory_holder.at(time).at(proc);
+                    if (memory_holder.at(time).at(proc) > max_usage_on_proc) {
+                      max_usage_on_proc = memory_holder.at(time).at(proc);
+                      proc_of_max = proc;
+                    }
+                  }
+                }
+
+                data_to_append.push_back(size_on_node);
+                avg_size_per_node += size_on_node;
+                legend.emplace_back("Size on node " + get_output(node) +
+                                    " (MB)");
+              }
+
+              // If we have proc data, write the proc with the maximum usage to
+              // disk along with how much memory it's using
+              if (is_group) {
+                data_to_append.push_back(static_cast<double>(proc_of_max));
+                data_to_append.push_back(max_usage_on_proc);
+                legend.emplace_back("Proc of max size");
+                legend.emplace_back("Size on proc of max size (MB)");
+              }
+
+              avg_size_per_node /= static_cast<double>(num_nodes);
+
+              // Last column is average over all nodes
+              data_to_append.push_back(avg_size_per_node);
+              legend.emplace_back("Average size per node (MB)");
+
+              auto& observer_writer_proxy = Parallel::get_parallel_component<
+                  observers::ObserverWriter<Metavariables>>(cache);
+
+              Parallel::threaded_action<
+                  observers::ThreadedActions::WriteReductionDataRow>(
+                  // Node 0 is always the writer
+                  observer_writer_proxy[0],
+                  subfile_name<ContributingComponent>(), legend,
+                  std::make_tuple(data_to_append));
+
+              // Clean up finished time
+              auto finished_time_iter = memory_holder.find(time);
+              memory_holder.erase(finished_time_iter);
+            }
+          });
+    } else {
+      (void)box;
+      (void)cache;
+      (void)time;
+      (void)node_or_proc;
+      (void)size_in_megabytes;
+      ERROR(
+          "Wrong DataBox. Expected the DataBox for the MemoryMonitor which has "
+          "the mem_monitor::Tags::MemoryHolder tag.");
+    }
+  }
+};
+}  // namespace mem_monitor

--- a/src/ParallelAlgorithms/Actions/MemoryMonitor/ProcessArray.hpp
+++ b/src/ParallelAlgorithms/Actions/MemoryMonitor/ProcessArray.hpp
@@ -1,0 +1,62 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/ReductionActions.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/Numeric.hpp"
+
+namespace mem_monitor {
+/*!
+ * \brief Simple action meant to be used as a callback for
+ * Parallel::contribute_to_reduction that writes the size of an Array parallel
+ * component to disk.
+ *
+ * \details The columns in the dat file when running on 3 nodes will be
+ *
+ * - %Time
+ * - Size on node 0 (MB)
+ * - Size on node 1 (MB)
+ * - Size on node 2 (MB)
+ * - Average size per node (MB)
+ *
+ * The dat file will be placed in the `/MemoryMonitors/` group in the reduction
+ * file. The name of the dat file is the `pretty_type::name` of the component.
+ */
+template <typename ArrayComponent>
+struct ProcessArray {
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
+  static void apply(db::DataBox<DbTags>& /*box*/,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/, const double time,
+                    const std::vector<double>& size_per_node) {
+    auto& observer_writer_proxy = Parallel::get_parallel_component<
+        observers::ObserverWriter<Metavariables>>(cache);
+
+    std::vector<std::string> legend{{"Time"}};
+    for (size_t i = 0; i < size_per_node.size(); i++) {
+      legend.emplace_back("Size on node " + get_output(i) + " (MB)");
+    }
+    legend.emplace_back("Average size per node (MB)");
+
+    const double avg_size = alg::accumulate(size_per_node, 0.0) /
+                            static_cast<double>(size_per_node.size());
+
+    Parallel::threaded_action<
+        observers::ThreadedActions::WriteReductionDataRow>(
+        // Node 0 is always the writer
+        observer_writer_proxy[0], subfile_name<ArrayComponent>(), legend,
+        std::make_tuple(time, size_per_node, avg_size));
+  }
+};
+}  // namespace mem_monitor

--- a/src/ParallelAlgorithms/Actions/MemoryMonitor/ProcessGroups.hpp
+++ b/src/ParallelAlgorithms/Actions/MemoryMonitor/ProcessGroups.hpp
@@ -1,0 +1,62 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <type_traits>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Info.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Local.hpp"
+#include "Parallel/MemoryMonitor/MemoryMonitor.hpp"
+#include "Parallel/Serialize.hpp"
+#include "Parallel/TypeTraits.hpp"
+
+namespace mem_monitor {
+/*!
+ * \brief Simple action meant to be run on every branch of a Group or NodeGroup
+ * that computes the size of the local branch and reports that size to the
+ * MemoryMonitor using the ContributeMemoryData simple action.
+ */
+struct ProcessGroups {
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
+  static void apply(db::DataBox<DbTags>& /*box*/,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& array_index, const double time) {
+    static_assert(Parallel::is_group_v<ParallelComponent> or
+                      Parallel::is_nodegroup_v<ParallelComponent>,
+                  "ProcessGroups can only be run on Group or Nodegroup "
+                  "parallel components.");
+    static_assert(std::is_same_v<ArrayIndex, int>,
+                  "ArrayIndex of Group or Nodegroup parallel components must "
+                  "be an int to use the ProcessGroups action.");
+
+    auto& singleton_proxy =
+        Parallel::get_parallel_component<MemoryMonitor<Metavariables>>(cache);
+
+    auto& group_proxy =
+        Parallel::get_parallel_component<ParallelComponent>(cache);
+
+    const double size_in_bytes = static_cast<double>(
+        size_of_object_in_bytes(*Parallel::local_branch(group_proxy)));
+
+    const double size_in_MB = size_in_bytes / 1.0e6;
+
+    // Note that we don't call Parallel::contribute_to_reduction here. This is
+    // because Charm requires that all calls to contribute_to_reduction happen
+    // in the exact same order every time, otherwise it is undefined behavior.
+    // However, this simple action (ProcessGroups) is called on each branch
+    // of a group or nodegroup. Because this is a simple action, the order that
+    // the branches run the simple actions is completely random based on
+    // communication patterns in charm. Thus, calling contribute_to_reduction
+    // here would result in undefined behavior.
+    // Also note that `array_index` here is my_node for nodegroups and my_proc
+    // for groups
+    Parallel::simple_action<ContributeMemoryData<ParallelComponent>>(
+        singleton_proxy, time, array_index, size_in_MB);
+  }
+};
+}  // namespace mem_monitor

--- a/src/ParallelAlgorithms/Actions/MemoryMonitor/ProcessSingleton.hpp
+++ b/src/ParallelAlgorithms/Actions/MemoryMonitor/ProcessSingleton.hpp
@@ -1,0 +1,62 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/ReductionActions.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Info.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Local.hpp"
+#include "Parallel/Serialize.hpp"
+
+namespace mem_monitor {
+/*!
+ * \brief Simple action meant to be run on a Singleton that writes the size of
+ * the Singleton component to disk.
+ *
+ * \details The columns in the dat file are
+ *
+ * - %Time
+ * - Proc
+ * - Size (MB)
+ *
+ * The dat file will be placed in the `/MemoryMonitors/` group in the reduction
+ * file. The name of the dat file is the `pretty_type::name` of the component.
+ */
+struct ProcessSingleton {
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
+  static void apply(db::DataBox<DbTags>& /*box*/,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/, const double time) {
+    static_assert(
+        Parallel::is_singleton_v<ParallelComponent>,
+        "ProcessSingleton can only be run on a Singleton parallel component.");
+    auto& singleton_proxy =
+        Parallel::get_parallel_component<ParallelComponent>(cache);
+    const double size_in_bytes = static_cast<double>(
+        size_of_object_in_bytes(*Parallel::local(singleton_proxy)));
+    const double size_in_MB = size_in_bytes / 1.0e6;
+
+    const std::vector<std::string> legend{{"Time", "Proc", "Size (MB)"}};
+
+    auto& observer_writer_proxy = Parallel::get_parallel_component<
+        observers::ObserverWriter<Metavariables>>(cache);
+
+    Parallel::threaded_action<
+        observers::ThreadedActions::WriteReductionDataRow>(
+        // Node 0 is always the writer
+        observer_writer_proxy[0], subfile_name<ParallelComponent>(), legend,
+        std::make_tuple(time,
+                        Parallel::my_proc(*Parallel::local(singleton_proxy)),
+                        size_in_MB));
+  }
+};
+}  // namespace mem_monitor

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -189,7 +189,7 @@ add_test_library(
   ${LIBRARY}
   "Parallel"
   "${LIBRARY_SOURCES}"
-  "Options;SystemUtilities"
+  "IO;Options;SystemUtilities"
   )
 
 add_dependencies(

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -172,6 +172,7 @@ set(LIBRARY "Test_Parallel")
 set(LIBRARY_SOURCES
   Test_GlobalCacheDataBox.cpp
   Test_InboxInserters.cpp
+  Test_MemoryMonitor.cpp
   Test_NodeLock.cpp
   Test_Parallel.cpp
   Test_ParallelComponentHelpers.cpp

--- a/tests/Unit/Parallel/Test_MemoryMonitor.cpp
+++ b/tests/Unit/Parallel/Test_MemoryMonitor.cpp
@@ -4,14 +4,123 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <string>
+#include <type_traits>
+#include <unordered_map>
 
+#include "DataStructures/Matrix.hpp"
+#include "Framework/ActionTesting.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/Dat.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/Observer/Actions/RegisterEvents.hpp"
+#include "IO/Observer/Helpers.hpp"
+#include "IO/Observer/Initialize.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/Tags.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/MemoryMonitor/MemoryMonitor.hpp"
 #include "Parallel/MemoryMonitor/Tags.hpp"
+#include "ParallelAlgorithms/Actions/MemoryMonitor/ContributeMemoryData.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
 
 namespace {
 template <typename Metavariables>
-struct MockMemoryMonitor {};
-struct TestMetavariables {};
+struct MockMemoryMonitor {
+  using chare_type = ActionTesting::MockSingletonChare;
+  using array_index = int;
+  using component_being_mocked = mem_monitor::MemoryMonitor<Metavariables>;
+  using metavariables = Metavariables;
+  using simple_tags = tmpl::list<mem_monitor::Tags::MemoryHolder>;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>>;
+};
+
+template <typename Metavariables>
+struct MockObserverWriter {
+  using component_being_mocked = observers::ObserverWriter<Metavariables>;
+
+  using const_global_cache_tags =
+      tmpl::list<observers::Tags::ReductionFileName>;
+
+  using initialize_action_list =
+      tmpl::list<::Actions::SetupDataBox,
+                 observers::Actions::InitializeWriter<Metavariables>>;
+  using initialization_tags =
+      Parallel::get_initialization_tags<initialize_action_list>;
+
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockNodeGroupChare;
+  using array_index = int;
+
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::Initialization,
+                                        initialize_action_list>>;
+};
+
+template <typename Metavariables>
+struct SingletonParallelComponent {
+  using chare_type = ActionTesting::MockSingletonChare;
+  using array_index = int;
+  using metavariables = Metavariables;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::Initialization,
+                                        tmpl::list<>>>;
+};
+
+template <typename Metavariables>
+struct GroupParallelComponent {
+  using chare_type = ActionTesting::MockGroupChare;
+  using array_index = int;
+  using metavariables = Metavariables;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::Initialization,
+                                        tmpl::list<>>>;
+};
+
+template <typename Metavariables>
+struct NodegroupParallelComponent {
+  using chare_type = ActionTesting::MockNodeGroupChare;
+  using array_index = int;
+  using metavariables = Metavariables;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::Initialization,
+                                        tmpl::list<>>>;
+};
+
+template <typename Metavariables>
+struct ArrayParallelComponent {
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using metavariables = Metavariables;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::Initialization,
+                                        tmpl::list<>>>;
+};
+
+struct TestMetavariables {
+  using observed_reduction_data_tags = tmpl::list<>;
+
+  using component_list =
+      tmpl::list<MockMemoryMonitor<TestMetavariables>,
+                 SingletonParallelComponent<TestMetavariables>,
+                 GroupParallelComponent<TestMetavariables>,
+                 ArrayParallelComponent<TestMetavariables>,
+                 NodegroupParallelComponent<TestMetavariables>>;
+
+  enum class Phase { Initialization, Monitor, Exit };
+
+  void pup(PUP::er& /*p*/) {}
+};
 
 void test_tags() {
   INFO("Test Tags");
@@ -24,7 +133,216 @@ void test_tags() {
   CHECK(subpath == "/MemoryMonitors/MockMemoryMonitor");
 }
 
+struct TestMetavarsActions {
+  using observed_reduction_data_tags = tmpl::list<>;
+
+  using component_list =
+      tmpl::list<MockMemoryMonitor<TestMetavarsActions>,
+                 MockObserverWriter<TestMetavarsActions>,
+                 SingletonParallelComponent<TestMetavarsActions>,
+                 GroupParallelComponent<TestMetavarsActions>,
+                 ArrayParallelComponent<TestMetavarsActions>,
+                 NodegroupParallelComponent<TestMetavarsActions>>;
+
+  enum class Phase { Initialization, Monitor, Exit };
+
+  void pup(PUP::er& /*p*/) {}
+};
+
+using metavars = TestMetavarsActions;
+using mem_mon_comp = MockMemoryMonitor<metavars>;
+using obs_writer_comp = MockObserverWriter<metavars>;
+using sing_comp = SingletonParallelComponent<metavars>;
+using group_comp = GroupParallelComponent<metavars>;
+using array_comp = ArrayParallelComponent<metavars>;
+using nodegroup_comp = NodegroupParallelComponent<metavars>;
+
+void setup_runner(
+    const gsl::not_null<ActionTesting::MockRuntimeSystem<metavars>*> runner) {
+  // Setup all components even if we aren't using all of them
+  ActionTesting::emplace_singleton_component<sing_comp>(
+      runner, ActionTesting::NodeId{1}, ActionTesting::LocalCoreId{1});
+  ActionTesting::emplace_group_component<group_comp>(runner);
+  ActionTesting::emplace_nodegroup_component<nodegroup_comp>(runner);
+  ActionTesting::emplace_array_component<array_comp>(
+      runner, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{0}, 0);
+
+  // ObserverWriter
+  ActionTesting::emplace_nodegroup_component<obs_writer_comp>(runner);
+  ActionTesting::next_action<obs_writer_comp>(runner, 0);
+  ActionTesting::next_action<obs_writer_comp>(runner, 0);
+
+  // MemoryMonitor
+  ActionTesting::emplace_singleton_component_and_initialize<mem_mon_comp>(
+      runner, ActionTesting::NodeId{2}, ActionTesting::LocalCoreId{2}, {});
+
+  runner->set_phase(metavars::Phase::Monitor);
+}
+
+template <typename Component>
+void check_output(const std::string& filename, const double time,
+                  const size_t num_nodes, const std::vector<double>& sizes) {
+  h5::H5File<h5::AccessType::ReadOnly> read_file{filename + ".h5"};
+  INFO("Checking output of " + pretty_type::name<Component>());
+  const auto& dataset =
+      read_file.get<h5::Dat>(mem_monitor::subfile_name<Component>());
+  const std::vector<std::string>& legend = dataset.get_legend();
+
+  size_t num_columns;
+  if constexpr (Parallel::is_group_v<Component>) {
+    // time, size on node 0, size on node 1, ...,  proc of max size, max size,
+    // avg per node
+    num_columns = num_nodes + 4;
+  } else {
+    // time, size on node 0, size on node 1, ..., avg per node
+    num_columns = num_nodes + 2;
+  }
+
+  CHECK(legend.size() == num_columns);
+
+  const Matrix data = dataset.get_data();
+  // We only wrote one line of data for all components
+  CHECK(data.rows() == 1);
+  CHECK(data.columns() == num_columns);
+
+  const double average =
+      alg::accumulate(sizes, 0.0) / static_cast<double>(num_nodes);
+
+  CHECK(data(0, 0) == time);
+  for (size_t i = 0; i < num_nodes; i++) {
+    CHECK(data(0, i + 1) == sizes[i]);
+  }
+  CHECK(data(0, num_columns - 1) == average);
+}
+
+template <typename Component>
+void run_group_actions(
+    const gsl::not_null<ActionTesting::MockRuntimeSystem<metavars>*> runner,
+    const std::string& filename, const int num_nodes, const int num_procs,
+    const double time, const std::vector<double>& sizes) {
+  INFO("Checking actions of " + pretty_type::name<Component>());
+  size_t num_branches;
+  if constexpr (Parallel::is_group_v<Component>) {
+    num_branches = static_cast<size_t>(num_procs);
+  } else {
+    num_branches = static_cast<size_t>(num_nodes);
+    // Avoid unused parameter warning
+    (void)num_procs;
+  }
+
+  CHECK(ActionTesting::number_of_queued_simple_actions<mem_mon_comp>(
+            *runner, 0) == num_branches);
+
+  const auto& mem_holder_tag =
+      ActionTesting::get_databox_tag<mem_mon_comp,
+                                     mem_monitor::Tags::MemoryHolder>(*runner,
+                                                                      0);
+
+  // Before we invoke the actions, the map for this component shouldn't exist
+  // because this is the first time we are calling it.
+  const std::string name = pretty_type::name<Component>();
+  CHECK(mem_holder_tag.count(name) == 0);
+
+  for (size_t i = 0; i < num_branches; i++) {
+    // unordered_map<name, unordered_map<time, unordered_map<node/proc, size>>>
+    // Putting the CHECK before the action invocation is arbitrary. The map at a
+    // specific time is empty both before the first action is invoked and after
+    // the last action is invoked. Because of this, we need to put the CHECK in
+    // an if statement to avoid an access error, whether the check happens
+    // before or after the invocation.
+    if (i != 0) {
+      CHECK(mem_holder_tag.at(name).at(time).size() == i);
+    }
+    ActionTesting::invoke_queued_simple_action<mem_mon_comp>(runner, 0);
+  }
+
+  // After we invoke the actions, the map for the current component should be
+  // empty because the time should have been erased
+  CHECK(mem_holder_tag.at(name).empty());
+
+  // The last action should have called a threaded action to write data
+  CHECK(ActionTesting::number_of_queued_threaded_actions<obs_writer_comp>(
+            *runner, 0) == 1);
+  ActionTesting::invoke_queued_threaded_action<obs_writer_comp>(runner, 0);
+
+  check_output<Component>(filename, time, static_cast<size_t>(num_nodes),
+                          sizes);
+}
+
+void test_wrong_box() {
+  CHECK_THROWS_WITH(
+      ([]() {
+        db::DataBox<tmpl::list<>> empty_box{};
+        Parallel::GlobalCache<metavars> cache{};
+
+        mem_monitor::ContributeMemoryData<group_comp>::template apply<
+            mem_mon_comp>(empty_box, cache, 0, 0.0, 0_st, 0.0);
+      }()),
+      Catch::Contains("Expected the DataBox for the MemoryMonitor"));
+}
+
+// Contribute memory data can only be used with groups or nodegroups
+template <typename Gen>
+void test_contribute_memory_data(const gsl::not_null<Gen*> gen) {
+  INFO("Test ContributeMemoryData");
+  std::uniform_real_distribution<double> dist{0, 10.0};
+  const std::string outfile_name{"TestMemoryMonitorActions"};
+  // clean up just in case
+  if (file_system::check_if_file_exists(outfile_name + ".h5")) {
+    file_system::rm(outfile_name + ".h5", true);
+  }
+
+  // 4 mock nodes, 3 mock cores per node
+  const size_t num_nodes = 4;
+  const size_t num_procs_per_node = 3;
+  const size_t num_procs = num_nodes * num_procs_per_node;
+  ActionTesting::MockRuntimeSystem<metavars> runner{
+      {outfile_name}, {}, std::vector<size_t>(num_nodes, num_procs_per_node)};
+
+  setup_runner(make_not_null(&runner));
+
+  auto& cache = ActionTesting::cache<mem_mon_comp>(runner, 0);
+  auto& mem_monitor_proxy =
+      Parallel::get_parallel_component<mem_mon_comp>(cache);
+
+  const double time = 0.5;
+  std::vector<double> sizes(num_nodes);
+  size_t index = 0;
+  // Do the group first
+  for (size_t proc = 0; proc < num_procs; proc++) {
+    const double size = dist(*gen);
+    if (proc != 0 and proc % num_procs_per_node == 0) {
+      ++index;
+    }
+    sizes[index] += size;
+    Parallel::simple_action<mem_monitor::ContributeMemoryData<group_comp>>(
+        mem_monitor_proxy, time, static_cast<int>(proc), size);
+  }
+
+  run_group_actions<group_comp>(make_not_null(&runner), outfile_name,
+                                static_cast<int>(num_nodes),
+                                static_cast<int>(num_procs), time, sizes);
+
+  sizes.clear();
+  sizes.resize(num_nodes);
+
+  // Now for the nodegroup
+  for (size_t node = 0; node < num_nodes; node++) {
+    const double size = dist(*gen);
+    sizes[node] = size;
+    Parallel::simple_action<mem_monitor::ContributeMemoryData<nodegroup_comp>>(
+        mem_monitor_proxy, time, static_cast<int>(node), size);
+  }
+
+  run_group_actions<nodegroup_comp>(make_not_null(&runner), outfile_name,
+                                    static_cast<int>(num_nodes),
+                                    static_cast<int>(num_procs), time, sizes);
+}
+
 SPECTRE_TEST_CASE("Unit.Parallel.MemoryMonitor", "[Unit][Parallel]") {
+  MAKE_GENERATOR(gen);
   test_tags();
+  test_wrong_box();
+  test_contribute_memory_data(make_not_null(&gen));
 }
 }  // namespace

--- a/tests/Unit/Parallel/Test_MemoryMonitor.cpp
+++ b/tests/Unit/Parallel/Test_MemoryMonitor.cpp
@@ -1,0 +1,30 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Parallel/MemoryMonitor/Tags.hpp"
+
+namespace {
+template <typename Metavariables>
+struct MockMemoryMonitor {};
+struct TestMetavariables {};
+
+void test_tags() {
+  INFO("Test Tags");
+  using holder_tag = mem_monitor::Tags::MemoryHolder;
+  TestHelpers::db::test_simple_tag<holder_tag>("MemoryHolder");
+
+  const std::string subpath =
+      mem_monitor::subfile_name<MockMemoryMonitor<TestMetavariables>>();
+
+  CHECK(subpath == "/MemoryMonitors/MockMemoryMonitor");
+}
+
+SPECTRE_TEST_CASE("Unit.Parallel.MemoryMonitor", "[Unit][Parallel]") {
+  test_tags();
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

Adds a singleton parallel component responsible for monitoring the memory of each parallel component. Also adds simple actions for each type of parallel component that will either compute or process the size of the local branch of a parallel component.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
