### PR TITLE
Allow DgElementArray to ignore certain procs when placing elements

### DIFF
--- a/docs/DevGuide/Parallelization.md
+++ b/docs/DevGuide/Parallelization.md
@@ -241,7 +241,8 @@ signature of the `allocate_array` functions must be:
 static void allocate_array(
     Parallel::CProxy_GlobalCache<metavariables>& global_cache,
     const tuples::tagged_tuple_from_typelist<initialization_tags>&
-    initialization_items);
+    initialization_items,
+    const std::unordered_set<size_t>& procs_to_ignore);
 \endcode
 The `allocate_array` function is called by the Main parallel component
 when the execution starts and will typically insert elements into
@@ -249,7 +250,10 @@ array parallel components. If the `allocate_array` function depends
 upon input options, the array component must specify a `using
 array_allocation_tags` type alias that is a `tmpl::list` of tags which
 are db::SimpleTag%s that have have a `using option_tags` type alias
-and a static function `create_from_options`. An example is:
+and a static function `create_from_options`. If you want to ignore specific
+processors when placing array elements, you can pass in a
+`std::unordered_set<size_t>` to `allocate_array` that contains all the
+processors that shouldn't have array elements on them. An example is:
 \snippet DistributedLinearSolverAlgorithmTestHelpers.hpp array_allocation_tag
 
 The `allocate_array` functions of different

--- a/src/Domain/ElementDistribution.cpp
+++ b/src/Domain/ElementDistribution.cpp
@@ -93,8 +93,9 @@ size_t z_curve_index(const ElementId<Dim>& element_id) {
 
 template <size_t Dim>
 BlockZCurveProcDistribution<Dim>::BlockZCurveProcDistribution(
-    size_t number_of_procs,
-    const std::vector<std::array<size_t, Dim>>& refinements_by_block) {
+    size_t number_of_procs_with_elements,
+    const std::vector<std::array<size_t, Dim>>& refinements_by_block,
+    const std::unordered_set<size_t>& global_procs_to_ignore) {
   block_element_distribution_ =
       std::vector<std::vector<std::pair<size_t, size_t>>>(
           refinements_by_block.size());
@@ -117,15 +118,26 @@ BlockZCurveProcDistribution<Dim>::BlockZCurveProcDistribution(
   size_t remaining_elements_in_block =
       add_number_of_elements_for_refinement(0_st, refinements_by_block[0]);
   size_t current_block = 0;
-  for (size_t i = 0; i < number_of_procs; ++i) {
+  // This variable will keep track of how many global procs we've skipped over
+  // so far. This bookkeeping is necessary so the element gets placed on the
+  // correct global proc. The loop variable `i` does not correspond to global
+  // proc number. It's just an index
+  size_t number_of_ignored_procs_so_far = 0;
+  for (size_t i = 0; i < number_of_procs_with_elements; ++i) {
+    size_t global_proc_number = i + number_of_ignored_procs_so_far;
+    while (global_procs_to_ignore.find(global_proc_number) !=
+           global_procs_to_ignore.end()) {
+      ++number_of_ignored_procs_so_far;
+      ++global_proc_number;
+    }
     size_t remaining_elements_on_proc =
-        (number_of_elements / number_of_procs) +
-        (i < (number_of_elements % number_of_procs) ? 1 : 0);
+        (number_of_elements / number_of_procs_with_elements) +
+        (i < (number_of_elements % number_of_procs_with_elements) ? 1 : 0);
     while (remaining_elements_on_proc > 0) {
       block_element_distribution_.at(current_block)
-          .emplace_back(
-              std::make_pair(i, std::min(remaining_elements_in_block,
-                                         remaining_elements_on_proc)));
+          .emplace_back(std::make_pair(global_proc_number,
+                                       std::min(remaining_elements_in_block,
+                                                remaining_elements_on_proc)));
       if (remaining_elements_in_block <= remaining_elements_on_proc) {
         remaining_elements_on_proc -= remaining_elements_in_block;
         ++current_block;

--- a/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstddef>
+#include <unordered_set>
 #include <vector>
 
 #include "Domain/Block.hpp"
@@ -38,7 +39,9 @@ CREATE_HAS_STATIC_MEMBER_VARIABLE_V(use_z_order_distribution)
  * `domain::BlockZCurveProcDistribution` (using a Morton space-filling curve),
  * unless `static constexpr bool use_z_order_distribution = false;` is specified
  * in the `Metavariables`, in which case elements are assigned to processors via
- * round-robin assignment.
+ * round-robin assignment. In both cases, an unordered set of `size_t`s can be
+ * passed to the `allocate_array` function which represents physical processors
+ * to avoid placing elements on.
  */
 template <class Metavariables, class PhaseDepActionList>
 struct DgElementArray {
@@ -61,7 +64,8 @@ struct DgElementArray {
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
       const tuples::tagged_tuple_from_typelist<initialization_tags>&
-          initialization_items);
+          initialization_items,
+      const std::unordered_set<size_t>& procs_to_ignore = {});
 
   static void execute_next_phase(
       const typename Metavariables::Phase next_phase,
@@ -76,7 +80,8 @@ template <class Metavariables, class PhaseDepActionList>
 void DgElementArray<Metavariables, PhaseDepActionList>::allocate_array(
     Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
     const tuples::tagged_tuple_from_typelist<initialization_tags>&
-        initialization_items) {
+        initialization_items,
+    const std::unordered_set<size_t>& procs_to_ignore) {
   auto& local_cache = *Parallel::local_branch(global_cache);
   auto& dg_element_array =
       Parallel::get_parallel_component<DgElementArray>(local_cache);
@@ -89,9 +94,13 @@ void DgElementArray<Metavariables, PhaseDepActionList>::allocate_array(
   if constexpr (detail::has_use_z_order_distribution_v<Metavariables>) {
     use_z_order_distribution = Metavariables::use_z_order_distribution;
   }
-  int which_proc = 0;
+  const size_t total_number_of_procs =
+      static_cast<size_t>(sys::number_of_procs());
+  const size_t num_of_procs_to_use =
+      total_number_of_procs - procs_to_ignore.size();
+  size_t which_proc = 0;
   const domain::BlockZCurveProcDistribution<volume_dim> element_distribution{
-      static_cast<size_t>(sys::number_of_procs()), initial_refinement_levels};
+      num_of_procs_to_use, initial_refinement_levels, procs_to_ignore};
   for (const auto& block : domain.blocks()) {
     const auto initial_ref_levs = initial_refinement_levels[block.id()];
     const std::vector<ElementId<volume_dim>> element_ids =
@@ -104,11 +113,15 @@ void DgElementArray<Metavariables, PhaseDepActionList>::allocate_array(
             .insert(global_cache, initialization_items, target_proc);
       }
     } else {
-      const int number_of_procs = sys::number_of_procs();
+      while (procs_to_ignore.find(which_proc) != procs_to_ignore.end()) {
+        which_proc =
+            which_proc + 1 == total_number_of_procs ? 0 : which_proc + 1;
+      }
       for (size_t i = 0; i < element_ids.size(); ++i) {
         dg_element_array(ElementId<volume_dim>(element_ids[i]))
             .insert(global_cache, initialization_items, which_proc);
-        which_proc = which_proc + 1 == number_of_procs ? 0 : which_proc + 1;
+        which_proc =
+            which_proc + 1 == total_number_of_procs ? 0 : which_proc + 1;
       }
     }
   }

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <string>
 #include <tuple>
+#include <unordered_set>
 #include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
@@ -301,7 +302,8 @@ struct ElementArray {
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
       const tuples::tagged_tuple_from_typelist<initialization_tags>&
-          initialization_items) {
+          initialization_items,
+      const std::unordered_set<size_t>& /*procs_to_ignore*/ = {}) {
     auto& local_component = Parallel::get_parallel_component<ElementArray>(
         *Parallel::local_branch(global_cache));
     local_component[0].insert(global_cache, initialization_items, 0);

--- a/tests/Unit/Helpers/ParallelAlgorithms/NonlinearSolver/Algorithm.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/NonlinearSolver/Algorithm.hpp
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <string>
 #include <tuple>
+#include <unordered_set>
 #include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
@@ -164,7 +165,8 @@ struct ElementArray {
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
       const tuples::tagged_tuple_from_typelist<initialization_tags>&
-          initialization_items) {
+          initialization_items,
+      const std::unordered_set<size_t>& /*procs_to_ignore*/ = {}) {
     auto& local_component = Parallel::get_parallel_component<ElementArray>(
         *Parallel::local_branch(global_cache));
     local_component[0].insert(global_cache, initialization_items, 0);

--- a/tests/Unit/Parallel/Test_AlgorithmLocalSyncAction.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmLocalSyncAction.cpp
@@ -7,6 +7,7 @@
 
 #include <cstddef>
 #include <tuple>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -218,7 +219,8 @@ struct ArrayComponent {
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
       const tuples::tagged_tuple_from_typelist<initialization_tags>&
-      /*initialization_items*/) {
+      /*initialization_items*/,
+      const std::unordered_set<size_t>& /*procs_to_ignore*/ = {}) {
     auto& local_cache = *Parallel::local_branch(global_cache);
     auto& array_proxy =
         Parallel::get_parallel_component<ArrayComponent>(local_cache);

--- a/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <string>
 #include <tuple>
+#include <unordered_set>
 #include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
@@ -269,16 +270,21 @@ struct ArrayParallelComponent {
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
       const tuples::tagged_tuple_from_typelist<initialization_tags>&
-      /*initialization_items*/) {
+      /*initialization_items*/,
+      const std::unordered_set<size_t>& procs_to_ignore = {}) {
     auto& local_cache = *Parallel::local_branch(global_cache);
     auto& array_proxy =
         Parallel::get_parallel_component<ArrayParallelComponent>(local_cache);
 
-    int which_proc = 0;
-    const int number_of_procs = sys::number_of_procs();
-    for (int i = 0;
-         i < number_of_1d_array_elements_per_core * sys::number_of_procs();
+    const size_t number_of_procs = static_cast<size_t>(sys::number_of_procs());
+    size_t which_proc = 0;
+    for (size_t i = 0;
+         i < static_cast<size_t>(number_of_1d_array_elements_per_core) *
+                 number_of_procs;
          ++i) {
+      while (procs_to_ignore.find(which_proc) != procs_to_ignore.end()) {
+        which_proc = which_proc + 1 == number_of_procs ? 0 : which_proc + 1;
+      }
       array_proxy[i].insert(global_cache, {}, which_proc);
       which_proc = which_proc + 1 == number_of_procs ? 0 : which_proc + 1;
     }

--- a/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
@@ -562,13 +562,18 @@ struct ArrayParallelComponent {
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
       const tuples::tagged_tuple_from_typelist<initialization_tags>&
-      /*initialization_items*/) {
+      /*initialization_items*/,
+      const std::unordered_set<size_t>& procs_to_ignore = {}) {
     auto& local_cache = *Parallel::local_branch(global_cache);
     auto& array_proxy =
         Parallel::get_parallel_component<ArrayParallelComponent>(local_cache);
 
-    for (int i = 0, which_proc = 0, number_of_procs = sys::number_of_procs();
-         i < number_of_1d_array_elements; ++i) {
+    const size_t number_of_procs = static_cast<size_t>(sys::number_of_procs());
+    size_t which_proc = 0;
+    for (int i = 0; i < number_of_1d_array_elements; ++i) {
+      while (procs_to_ignore.find(which_proc) != procs_to_ignore.end()) {
+        which_proc = which_proc + 1 == number_of_procs ? 0 : which_proc + 1;
+      }
       array_proxy[i].insert(global_cache, {}, which_proc);
       which_proc = which_proc + 1 == number_of_procs ? 0 : which_proc + 1;
     }

--- a/tests/Unit/Parallel/Test_AlgorithmPhaseControl.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmPhaseControl.cpp
@@ -138,7 +138,8 @@ struct ComponentAlpha {
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
       const tuples::tagged_tuple_from_typelist<initialization_tags>&
-      /*initialization_items*/) {
+      /*initialization_items*/,
+      const std::unordered_set<size_t>& /*procs_to_ignore*/ = {}) {
     auto& local_cache = *Parallel::local_branch(global_cache);
     auto& array_proxy =
         Parallel::get_parallel_component<ComponentAlpha>(local_cache);

--- a/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
@@ -11,6 +11,7 @@
 #include <ostream>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -238,13 +239,18 @@ struct ArrayParallelComponent {
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
       const tuples::tagged_tuple_from_typelist<initialization_tags>&
-      /*initialization_items*/) {
+      /*initialization_items*/,
+      const std::unordered_set<size_t>& procs_to_ignore = {}) {
     auto& local_cache = *Parallel::local_branch(global_cache);
     auto& array_proxy =
         Parallel::get_parallel_component<ArrayParallelComponent>(local_cache);
 
-    for (int i = 0, which_proc = 0, number_of_procs = sys::number_of_procs();
-         i < number_of_1d_array_elements; ++i) {
+    const size_t number_of_procs = static_cast<size_t>(sys::number_of_procs());
+    size_t which_proc = 0;
+    for (int i = 0; i < number_of_1d_array_elements; ++i) {
+      while (procs_to_ignore.find(which_proc) != procs_to_ignore.end()) {
+        which_proc = which_proc + 1 == number_of_procs ? 0 : which_proc + 1;
+      }
       array_proxy[i].insert(global_cache, {}, which_proc);
       which_proc = which_proc + 1 == number_of_procs ? 0 : which_proc + 1;
     }

--- a/tests/Unit/Parallel/Test_PhaseChangeMain.cpp
+++ b/tests/Unit/Parallel/Test_PhaseChangeMain.cpp
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <string>
 #include <tuple>
+#include <unordered_set>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
@@ -172,13 +173,18 @@ struct ArrayComponent {
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
       const tuples::tagged_tuple_from_typelist<initialization_tags>&
-      /*initialization_items*/) {
+      /*initialization_items*/,
+      const std::unordered_set<size_t>& procs_to_ignore = {}) {
     auto& local_cache = *Parallel::local_branch(global_cache);
     auto& array_proxy =
         Parallel::get_parallel_component<ArrayComponent>(local_cache);
 
-    for (int i = 0, which_proc = 0, number_of_procs = sys::number_of_procs();
-         i < 2; ++i) {
+    const size_t number_of_procs = static_cast<size_t>(sys::number_of_procs());
+    size_t which_proc = 0;
+    for (int i = 0; i < 2; ++i) {
+      while (procs_to_ignore.find(which_proc) != procs_to_ignore.end()) {
+        which_proc = which_proc + 1 == number_of_procs ? 0 : which_proc + 1;
+      }
       array_proxy[i].insert(global_cache, {}, which_proc);
       which_proc = which_proc + 1 == number_of_procs ? 0 : which_proc + 1;
     }


### PR DESCRIPTION
## Proposed changes

In preparation to add a new feature where we can place singletons on specific processors and have no DG-elements be placed on those processors, the DgElementArray needs to know which processors it can't place elements on. This PR changes the `allocate_array` function of both the evolution and elliptic DgElementArray so it can ignore specific processors.

The BlockZCurveProcDistribution allocator is also modified in a similar way to avoid placing elements on specific processors, but nothing about the Morton Z-order curve is changed.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
