### PR TITLE
Add parallel info to GlobalCache

### DIFF
--- a/tests/Unit/Framework/MockRuntimeSystem.hpp
+++ b/tests/Unit/Framework/MockRuntimeSystem.hpp
@@ -187,16 +187,18 @@ class MockRuntimeSystem {
     for (const auto& [global_core_id, node_and_local_core] :
          mock_nodes_and_local_cores_) {
       const size_t global_core = global_core_id.value;
+      // Note that lambdas cannot capture structured bindings,
+      // so we define node and local_core here.
+      const auto& node = node_and_local_core.first.value;
+      const auto& local_core = node_and_local_core.second.value;
       mutable_caches_.at(global_core) =
           std::make_unique<Parallel::MutableGlobalCache<Metavariables>>(
               serialize_and_deserialize(mutable_cache_contents));
       caches_.at(global_core) = std::make_unique<GlobalCache>(
           serialize_and_deserialize(cache_contents),
-          mutable_caches_.at(global_core).get());
-      // Note that lambdas cannot capture structured bindings,
-      // so we define node and local_core here.
-      const auto& node = node_and_local_core.first.value;
-      const auto& local_core = node_and_local_core.second.value;
+          mutable_caches_.at(global_core).get(),
+          number_of_mock_cores_on_each_mock_node, static_cast<int>(global_core),
+          static_cast<int>(node), static_cast<int>(local_core));
       tmpl::for_each<typename Metavariables::component_list>(
           [this, &global_core, &node, &local_core](auto component) {
             using Component = tmpl::type_from<decltype(component)>;


### PR DESCRIPTION
## Proposed changes

We have access to the GlobalCache almost everywhere in SpECTRE. Because of that, I think it makes sense for the GlobalCache to be aware of the parallel info like number of nodes/procs. This PR adds the parallel info functions that all other parallel components have as members of the GlobalCache. These new member functions will also work in the ActionTesting framework and with the `Parallel::number_of_nodes()` etc... functions.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
