### PR TITLE
Add ZeroCrossingPredictor function for `std::vector<doubles>`

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -16,6 +16,7 @@ spectre_target_sources(
   LinearLeastSquares.cpp
   LinearSpanInterpolator.cpp
   PolynomialInterpolation.cpp
+  PredictedZeroCrossing.cpp
   RegularGridInterpolant.cpp
   SpanInterpolator.cpp
   )
@@ -33,6 +34,7 @@ spectre_target_headers(
   LinearLeastSquares.hpp
   LinearSpanInterpolator.hpp
   PolynomialInterpolation.hpp
+  PredictedZeroCrossing.hpp
   RegularGridInterpolant.hpp
   SpanInterpolator.hpp
   )

--- a/src/NumericalAlgorithms/Interpolation/PredictedZeroCrossing.cpp
+++ b/src/NumericalAlgorithms/Interpolation/PredictedZeroCrossing.cpp
@@ -1,0 +1,19 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Interpolation/PredictedZeroCrossing.hpp"
+
+#include <vector>
+
+#include "NumericalAlgorithms/Interpolation/LinearLeastSquares.hpp"
+
+namespace intrp {
+
+double predicted_zero_crossing_value(const std::vector<double>& x_values,
+                                     const std::vector<double>& y_values) {
+  intrp::LinearLeastSquares<1> predictor{x_values.size()};
+  const auto coefficients = predictor.fit_coefficients(x_values, y_values);
+  return -coefficients[0]/coefficients[1];
+}
+
+}  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/PredictedZeroCrossing.hpp
+++ b/src/NumericalAlgorithms/Interpolation/PredictedZeroCrossing.hpp
@@ -1,0 +1,19 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <vector>
+
+namespace intrp {
+
+/*!
+ * \brief Predicts the zero crossing of a function.
+ *
+ * Fits a linear function to a set of y_values at different x_values
+ * and uses the fit to predict what x_value the y_value zero will be crossed.
+ */
+double predicted_zero_crossing_value(const std::vector<double>& x_values,
+                                     const std::vector<double>& y_values);
+
+}  // namespace intrp

--- a/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBRARY_SOURCES
   Test_LagrangePolynomial.cpp
   Test_LinearLeastSquares.cpp
   Test_PolynomialInterpolation.cpp
+  Test_PredictedZeroCrossing.cpp
   Test_RegularGridInterpolant.cpp
   Test_SendGhWorldtubeData.cpp
   Test_SpanInterpolators.cpp

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_PredictedZeroCrossing.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_PredictedZeroCrossing.cpp
@@ -1,0 +1,40 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <random>
+#include <vector>
+
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/Interpolation/LinearLeastSquares.hpp"
+#include "NumericalAlgorithms/Interpolation/PredictedZeroCrossing.hpp"
+
+SPECTRE_TEST_CASE(
+    "Unit.NumericalAlgorithms.Interpolation.PredictedZeroCrossing",
+    "[Unit][NumericalAlgorithms]") {
+  // Set up random number generator
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> dist(-10., 10.);
+  std::uniform_real_distribution<> error_dist(-1e-8, 1e-8);
+
+  const double expected_zero_crossing_value = dist(gen);
+  CAPTURE(expected_zero_crossing_value);
+  const double slope = dist(gen);
+  CAPTURE(slope);
+
+  std::vector<double> x_values = {0., 1., 2., 3., 4., 5., 6., 7., 8., 9.};
+  std::vector<double> y_values{};
+  double b = -slope * expected_zero_crossing_value;
+  for (size_t i = 0; i < x_values.size(); i++) {
+    double epsilon = error_dist(gen);
+    y_values.push_back(slope * gsl::at(x_values, i) + b + epsilon);
+  }
+
+  auto compute_zero_crossing_value =
+      intrp::predicted_zero_crossing_value(x_values, y_values);
+
+  Approx custom_approx = Approx::custom().epsilon(1.e-6);
+  CHECK_ITERABLE_CUSTOM_APPROX(expected_zero_crossing_value,
+                               compute_zero_crossing_value, custom_approx);
+}


### PR DESCRIPTION
## Proposed changes

The ZeroCrossingPredictor fits a linear function to a set of values at different times and uses the fit to predict what time the value zero will be crossed. This is a step toward measuring how long the surface will take to hit the excision surface so that the control system can adjust the grid to avoid the excision surface from coming out of the apparent horizon surface. The function currently takes a std::vector of doubles for the values and times. 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
