### PR TITLE
Add DataVector to LinearLeastSquares

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/LinearLeastSquares.hpp
+++ b/src/NumericalAlgorithms/Interpolation/LinearLeastSquares.hpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstddef>
 #include <gsl/gsl_multifit.h>
+#include <vector>
 
 /// \cond
 namespace PUP {
@@ -23,6 +24,8 @@ namespace intrp {
  * of data points `x_values` and `y_values` representing some function y(x).
  * Note that the `interpolate` function requires a set of fit coefficients,
  * which can be obtained by first calling the `fit_coefficients` function.
+ * The parameter `num_observations` refers to the number of entries in
+ * `x_values`.
  *
  * The details of the linear least squares solver can be seen here:
  * [GSL documentation](https://www.gnu.org/software/gsl/doc/html/lls.html#).
@@ -50,6 +53,21 @@ class LinearLeastSquares {
   template <typename T>
   std::array<double, Order + 1> fit_coefficients(const T& x_values,
                                                  const T& y_values);
+
+  /*!
+   * The `x_values` are a sequence of times, positions, or other abscissa.
+   * The `y_values` are a std::vector of sequences of ordinates corresponding
+   * to these abscissa, with each element of the
+   * std::vector containing one sequence. Therefore, one set of fit
+   * coefficients is found for each entry in the std::vector `y_values`.
+   * In other words, the data in `y_values` is stored as:
+   * `y_values[fit_index][x_value_index]`, where `fit_index` runs over the
+   * number of different sequences being fit to, and `x_value_index` runs over
+   * the different entries corrsponding to those in `x_values`.
+   */
+  template <typename T>
+  std::vector<std::array<double, Order + 1>> fit_coefficients(
+      const T& x_values, const std::vector<T>& y_values);
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p);

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_LinearLeastSquares.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_LinearLeastSquares.cpp
@@ -12,11 +12,13 @@
 #include "Framework/TestHelpers.hpp"
 #include "NumericalAlgorithms/Interpolation/LinearLeastSquares.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/Math.hpp"
 
 namespace {
 template <size_t Order>
-void test_linear_least_squares(const std::array<double, Order + 1>& coeffs,
-                               const std::vector<double>& x_values) {
+void test_linear_least_squares_double(
+    const std::array<double, Order + 1>& coeffs,
+    const std::vector<double>& x_values) {
   std::vector<double> y_values{};
   for (size_t i = 0; i < x_values.size(); i++) {
     double y_i = 0;
@@ -41,6 +43,51 @@ void test_linear_least_squares(const std::array<double, Order + 1>& coeffs,
           my_approx(gsl::at(y_values, i)));
   }
 }
+
+void test_linear_least_squares_datavector() {
+  const DataVector x_values{1.0, 2.0, 3.0, 4.0, 5.0};
+  const std::vector<std::array<double, 2>> coefficients{
+      {{6.0, 7.0}}, {{8.0, 9.0}}, {{10.0, 11.0}}, {{12.0, 13.0}}};
+  std::vector<DataVector> y_values{4, DataVector{5}};
+  for (size_t i = 0; i < y_values.size(); ++i) {
+    y_values[i] = x_values * coefficients[i][1] + coefficients[i][0];
+  }
+  intrp::LinearLeastSquares<1> lls(x_values.size());
+  const std::vector<std::array<double, 2>> computed_coefficients =
+      lls.fit_coefficients(x_values, y_values);
+  CHECK_ITERABLE_APPROX(coefficients, computed_coefficients);
+  const double x_rand = 2.31;
+  for (size_t i = 0; i < y_values.size(); ++i) {
+    double expected_y_value = x_rand * coefficients[i][1] + coefficients[i][0];
+    double computed_y_value = lls.interpolate(coefficients[i], x_rand);
+    CHECK(expected_y_value == computed_y_value);
+  }
+}
+
+template <size_t Order>
+void test_linear_least_squares_datavector2(
+    const std::vector<std::array<double, Order + 1>>& coeffs,
+    const DataVector& x_values) {
+  std::vector<DataVector> y_values{coeffs.size(),
+                                   DataVector{x_values.size(), 0.0}};
+  for (size_t i = 0; i < y_values.size(); ++i) {
+    y_values[i] = evaluate_polynomial(coeffs[i], x_values);
+  }
+  intrp::LinearLeastSquares<Order> lls(x_values.size());
+  const std::vector<std::array<double, Order + 1>> computed_coefficients =
+      lls.fit_coefficients(x_values, y_values);
+  Approx my_approx = Approx::custom().epsilon(1.e-11).scale(1.0);
+  CHECK_ITERABLE_CUSTOM_APPROX(coeffs, computed_coefficients, my_approx);
+  const double x_rand = 4.21;
+  for (size_t i = 0; i < y_values.size(); ++i) {
+    double expected_y_value = 0.0;
+    for (size_t j = 0; j < Order + 1; j++) {
+      expected_y_value += pow(x_rand, j) * coeffs[i][j];
+    }
+    double computed_y_value = lls.interpolate(coeffs[i], x_rand);
+    CHECK(expected_y_value == computed_y_value);
+  }
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Numerical.Interpolation.LinearLeastSquares",
@@ -56,10 +103,33 @@ SPECTRE_TEST_CASE("Unit.Numerical.Interpolation.LinearLeastSquares",
   CAPTURE(coeff2);
   const double coeff3 = coeff_dis(gen);
   CAPTURE(coeff3);
-
+  const double coeff4 = coeff_dis(gen);
+  CAPTURE(coeff4);
+  const double coeff5 = coeff_dis(gen);
+  CAPTURE(coeff5);
+  const double coeff6 = coeff_dis(gen);
+  CAPTURE(coeff6);
+  const double coeff7 = coeff_dis(gen);
+  CAPTURE(coeff7);
+  const double coeff8 = coeff_dis(gen);
+  CAPTURE(coeff8);
+  const double coeff9 = coeff_dis(gen);
+  CAPTURE(coeff9);
+  const double coeff10 = coeff_dis(gen);
+  CAPTURE(coeff10);
+  const double coeff11 = coeff_dis(gen);
+  CAPTURE(coeff11);
   const std::array<double, 4> coeffs = {coeff0, coeff1, coeff2, coeff3};
-  const std::vector<double> vecx = {0.0, 1.0, 2.0, 3.0, 4.0,
-                                    5.0, 6.0, 7.0, 8.0, 9.0};
+  const std::vector<std::array<double, 4>> datavector_coeffs = {
+      {{coeff0, coeff1, coeff2, coeff3}},
+      {{coeff4, coeff5, coeff6, coeff7}},
+      {{coeff8, coeff9, coeff10, coeff11}}};
+  const std::vector<double> vecx = {0.0, 1.0, 3.0, 2.0, 4.0,
+                                    5.0, 6.0, 8.0, 7.0, 9.0};
+  const DataVector datavecx = {0.0, 1.0, 2.0, 3.0, 4.0,
+                               5.0, 8.0, 7.0, 6.0, 9.0};
 
-  test_linear_least_squares<3>(coeffs, vecx);
+  test_linear_least_squares_double<3>(coeffs, vecx);
+  test_linear_least_squares_datavector();
+  test_linear_least_squares_datavector2<3>(datavector_coeffs, datavecx);
 }


### PR DESCRIPTION
## Proposed changes


The current LinearLeastSquares solver is able to find the linear fit to a set of `y_values` corresponding to a set of `x_values`. As written, `x_values` and `y_values` currently must have the same size and dimension, so only one linear fit is found. This PR allows the LinearLeastSquares solver to be used to find multiple linear fits to a multidimensional set of `y_values` corresponding to a set of `x_values`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
