### PR TITLE
Add SingletonInfoHolder

### DIFF
--- a/src/Parallel/CMakeLists.txt
+++ b/src/Parallel/CMakeLists.txt
@@ -47,6 +47,7 @@ spectre_target_headers(
   Reduction.hpp
   ReductionDeclare.hpp
   RegisterDerivedClassesWithCharm.hpp
+  ResourceInfo.hpp
   Section.hpp
   Serialize.hpp
   SimpleActionVisitation.hpp

--- a/src/Parallel/ResourceInfo.hpp
+++ b/src/Parallel/ResourceInfo.hpp
@@ -1,0 +1,87 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <pup.h>
+
+#include "Options/Auto.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/PupStlCpp17.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Parallel {
+/*!
+ * \ingroup ParallelGroup
+ * \brief Holds resource info for a single singleton component
+ *
+ * \details Holds what proc the singleton is to be placed on and whether that
+ * proc should be exclusive, i.e. no array component elements or other
+ * singletons placed on that proc. Instead of specifying a proc, the proc can be
+ * chosen automatically by using the `Options::Auto` option.
+ */
+struct SingletonInfoHolder {
+  struct Proc {
+    using type = Options::Auto<int>;
+    static constexpr Options::String help = {
+        "Proc to put singleton on. This can be determined automatically if "
+        "desired by specifying 'Auto' (without quotes)."};
+  };
+
+  struct Exclusive {
+    using type = bool;
+    static constexpr Options::String help = {
+        "Reserve this proc for this singleton. No array component elements or "
+        "other singleton components will be placed on this proc."};
+  };
+
+  using options = tmpl::list<Proc, Exclusive>;
+  static constexpr Options::String help = {
+      "Resource options for a single singleton."};
+
+  SingletonInfoHolder(std::optional<int> input_proc, const bool input_exclusive,
+                      const Options::Context& context = {})
+      : exclusive_(input_exclusive) {
+    // If there is no value, we don't need to error so use 0 as a comparator
+    // in both cases
+    if (input_proc.value_or(0) < 0) {
+      PARSE_ERROR(
+          context,
+          "Proc must be a non-negative integer. Please choose another proc.");
+    }
+
+    proc_ = input_proc.has_value()
+                ? std::optional<size_t>(static_cast<size_t>(input_proc.value()))
+                : std::nullopt;
+  }
+
+  SingletonInfoHolder() = default;
+  SingletonInfoHolder(const SingletonInfoHolder& /*rhs*/) = default;
+  SingletonInfoHolder& operator=(const SingletonInfoHolder& /*rhs*/) = default;
+  SingletonInfoHolder(SingletonInfoHolder&& /*rhs*/) = default;
+  SingletonInfoHolder& operator=(SingletonInfoHolder&& /*rhs*/) = default;
+  ~SingletonInfoHolder() = default;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) {
+    p | proc_;
+    p | exclusive_;
+  };
+
+  /// Proc that singleton is to be placed on. If the optional is a std::nullopt,
+  /// then the proc should be chosen automatically.
+  std::optional<size_t> proc() const { return proc_; }
+
+  /// Whether or not the singleton wants to be exclusive on the proc.
+  bool is_exclusive() const { return exclusive_; }
+
+ private:
+  // We use size_t here because we want a non-negative integer, but we use int
+  // in the option because we want to protect against negative numbers. And a
+  // negative size_t is actually a really large value (it wraps around)
+  std::optional<size_t> proc_{std::nullopt};
+  bool exclusive_{false};
+};
+}  // namespace Parallel

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -176,6 +176,7 @@ set(LIBRARY_SOURCES
   Test_ParallelComponentHelpers.cpp
   Test_PupStlCpp11.cpp
   Test_PupStlCpp17.cpp
+  Test_ResourceInfo.cpp
   Test_Serialize.cpp
   Test_TypeTraits.cpp
   )

--- a/tests/Unit/Parallel/Test_ResourceInfo.cpp
+++ b/tests/Unit/Parallel/Test_ResourceInfo.cpp
@@ -1,0 +1,56 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <optional>
+
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Parallel/ResourceInfo.hpp"
+
+namespace Parallel {
+namespace {
+void test_singleton_info() {
+  SingletonInfoHolder info_holder{};
+  CHECK(info_holder.proc() == std::nullopt);
+  CHECK_FALSE(info_holder.is_exclusive());
+
+  info_holder = TestHelpers::test_creation<Parallel::SingletonInfoHolder>(
+      "Proc: 0\n"
+      "Exclusive: false\n");
+  CHECK(info_holder.proc().value() == 0);
+  CHECK_FALSE(info_holder.is_exclusive());
+
+  auto serialized_info_holder = serialize_and_deserialize(info_holder);
+  CHECK(info_holder.proc().value() == serialized_info_holder.proc().value());
+  CHECK(info_holder.is_exclusive() == serialized_info_holder.is_exclusive());
+
+  info_holder = TestHelpers::test_creation<Parallel::SingletonInfoHolder>(
+      "Proc: Auto\n"
+      "Exclusive: false\n");
+  CHECK(info_holder.proc() == std::nullopt);
+  CHECK_FALSE(info_holder.is_exclusive());
+
+  info_holder = TestHelpers::test_creation<Parallel::SingletonInfoHolder>(
+      "Proc: 4\n"
+      "Exclusive: true\n");
+  CHECK(info_holder.proc().value() == 4);
+  CHECK(info_holder.is_exclusive());
+
+  CHECK_THROWS_WITH(
+      ([]() {
+        auto info_holder_error =
+            TestHelpers::test_creation<Parallel::SingletonInfoHolder>(
+                "Proc: -2\n"
+                "Exclusive: true\n");
+        (void)info_holder_error;
+      })(),
+      Catch::Contains("Proc must be a non-negative integer."));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Parallel.ResourceInfo", "[Unit][Parallel]") {
+  test_singleton_info();
+}
+}  // namespace Parallel


### PR DESCRIPTION
To be able to place singletons on specific procs, we need to get this info from options.

You can specify which proc to place the singleton on and whether that proc is exclusive. An exclusive singleton will have no DG-elements or other singletons placed on it's proc. This will be useful for the horizon finder, having one core solely dedicated to finding horizons.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
