### PR TITLE
Minor fixes for Burgers subcell

### DIFF
--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -288,7 +288,8 @@ struct EvolutionMetavars {
           evolution::dg::subcell::Actions::Labels::BeginSubcellAfterDgRollback>,
       evolution::dg::subcell::fd::Actions::TakeTimeStep<
           Burgers::subcell::TimeDerivative>,
-      Actions::RecordTimeStepperData<>, Actions::UpdateU<>,
+      Actions::RecordTimeStepperData<>,
+      evolution::Actions::RunEventsAndDenseTriggers<>, Actions::UpdateU<>,
       evolution::dg::subcell::Actions::TciAndSwitchToDg<
           Burgers::subcell::TciOnFdGrid>,
       Actions::Label<evolution::dg::subcell::Actions::Labels::EndOfSolvers>>>;


### PR DESCRIPTION
## Proposed changes

On Burgers subcell, 
* rename type keywords in Test_NeighborPackagedData.cpp
* add a missing action into evolution metavariables.

These were previously included in #3746, so I moved these commits to this small PR for facilitating reviewing #3746.