### PR TITLE
Observe surface data

### DIFF
--- a/docs/DevGuide/Observers.md
+++ b/docs/DevGuide/Observers.md
@@ -95,6 +95,13 @@ HDF5 file name is specified in the input file using the
 `observers::Tags::VolumeFileName` option. The data is written into a subfile of
 the HDF5 file using the `h5::VolumeFile` class.
 
+If a singleton parallel component or a specific chare needs to write volume data
+directly to disk, such as surface data from an apparent horizon, it should use
+the `observers::ThreadedActions::WriteVolumeData` action called on the zeroth
+element of the `observers::ObserverWriter` component. For surface data (such as
+output from horizon finds), this data should be written to a file specified by
+the `observers::Tags::SurfaceFileName` option.
+
 ### Threading and NodeLocks
 
 Since the `observers::ObserverWriter` class is a nodegroup, its entry methods

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
@@ -31,6 +31,7 @@
 #include "ParallelAlgorithms/Interpolation/Actions/TryToInterpolate.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/ErrorOnFailedApparentHorizon.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp"
+#include "ParallelAlgorithms/Interpolation/Callbacks/ObserveSurfaceData.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp"
 #include "ParallelAlgorithms/Interpolation/Events/Interpolate.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolationTarget.hpp"
@@ -77,6 +78,7 @@ struct EvolutionMetavars<3, InitialData, BoundaryConditions>
         StrahlkorperTags::MinRicciScalarCompute,
         StrahlkorperGr::Tags::ChristodoulouMassCompute<frame>,
         StrahlkorperGr::Tags::DimensionlessSpinMagnitudeCompute<frame>>;
+    using surface_tags_to_observe = tmpl::list<StrahlkorperTags::RicciScalar>;
     using compute_vars_to_interpolate = ah::ComputeHorizonVolumeQuantities;
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::SpatialMetric<volume_dim, frame, DataVector>,
@@ -111,7 +113,8 @@ struct EvolutionMetavars<3, InitialData, BoundaryConditions>
     using horizon_find_failure_callback =
         intrp::callbacks::ErrorOnFailedApparentHorizon;
     using post_horizon_find_callbacks = tmpl::list<
-        intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, AhA>>;
+        intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, AhA>,
+        intrp::callbacks::ObserveSurfaceData<surface_tags_to_observe, AhA>>;
   };
 
   using interpolation_target_tags = tmpl::list<AhA>;

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -88,6 +88,7 @@
 #include "ParallelAlgorithms/Interpolation/Actions/TryToInterpolate.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/ErrorOnFailedApparentHorizon.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp"
+#include "ParallelAlgorithms/Interpolation/Callbacks/ObserveSurfaceData.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp"
 #include "ParallelAlgorithms/Interpolation/Events/Interpolate.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolationTarget.hpp"
@@ -258,6 +259,7 @@ struct EvolutionMetavars {
         horizons_vars_to_interpolate_to_target;
     using compute_vars_to_interpolate = ah::ComputeHorizonVolumeQuantities;
     using tags_to_observe = horizons_tags_to_observe;
+    using surface_tags_to_observe = tmpl::list<StrahlkorperTags::RicciScalar>;
     using compute_items_on_target = horizons_compute_items_on_target;
     using compute_target_points =
         intrp::TargetPoints::ApparentHorizon<AhA, ::Frame::Grid>;
@@ -266,7 +268,8 @@ struct EvolutionMetavars {
     using horizon_find_failure_callback =
         intrp::callbacks::ErrorOnFailedApparentHorizon;
     using post_horizon_find_callbacks = tmpl::list<
-        intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, AhA>>;
+        intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, AhA>,
+        intrp::callbacks::ObserveSurfaceData<surface_tags_to_observe, AhA>>;
   };
 
   struct AhB : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
@@ -275,6 +278,7 @@ struct EvolutionMetavars {
         horizons_vars_to_interpolate_to_target;
     using compute_vars_to_interpolate = ah::ComputeHorizonVolumeQuantities;
     using tags_to_observe = horizons_tags_to_observe;
+    using surface_tags_to_observe = tmpl::list<StrahlkorperTags::RicciScalar>;
     using compute_items_on_target = horizons_compute_items_on_target;
     using compute_target_points =
         intrp::TargetPoints::ApparentHorizon<AhB, ::Frame::Grid>;
@@ -283,7 +287,8 @@ struct EvolutionMetavars {
     using horizon_find_failure_callback =
         intrp::callbacks::ErrorOnFailedApparentHorizon;
     using post_horizon_find_callbacks = tmpl::list<
-        intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, AhB>>;
+        intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, AhB>,
+        intrp::callbacks::ObserveSurfaceData<surface_tags_to_observe, AhB>>;
   };
 
   using interpolation_target_tags = tmpl::list<AhA, AhB>;

--- a/src/IO/Observer/CMakeLists.txt
+++ b/src/IO/Observer/CMakeLists.txt
@@ -8,6 +8,7 @@ spectre_target_sources(
   ObservationId.cpp
   ReductionActions.cpp
   TypeOfObservation.cpp
+  VolumeActions.cpp
   )
 
 spectre_target_headers(

--- a/src/IO/Observer/Tags.hpp
+++ b/src/IO/Observer/Tags.hpp
@@ -187,15 +187,26 @@ struct ReductionFileName {
       "Name of the reduction data file without extension"};
   using group = Group;
 };
+
+/// The name of the H5 file on disk to which all surface data is written.
+struct SurfaceFileName {
+  using type = std::string;
+  static constexpr Options::String help = {
+      "Name of the surface data file without extension"};
+  using group = Group;
+};
 }  // namespace OptionTags
 
 namespace Tags {
-/// \brief The name of the HDF5 file on disk into which volume data is written.
+/// \brief The name of the HDF5 file on disk into which volume data is
+/// written.
 ///
 /// By volume data we mean any data that is not written once across all nodes.
-/// For example, data on a 2d surface written from a 3d simulation is considered
-/// volume data, while an integral over the entire (or a subset of the) domain
-/// is considered reduction data.
+/// For example, data on a 2d surface written from a 2d simulation is
+/// considered volume data, while an integral over the entire (or a subset of
+/// the) domain is considered reduction data. Data for a 2d surface in
+/// a 3d simulation, such as a horizon, is considered surface data and
+/// is written to a file specified by SurfaceFileName.
 struct VolumeFileName : db::SimpleTag {
   using type = std::string;
   using option_tags = tmpl::list<::observers::OptionTags::VolumeFileName>;
@@ -211,8 +222,10 @@ struct VolumeFileName : db::SimpleTag {
 ///
 /// By reduction data we mean any data that is written once across all nodes.
 /// For example, an integral over the entire (or a subset of the) domain
-/// is considered reduction data, while data on a 2d surface written from a 3d
-/// simulation is considered volume data.
+/// is considered reduction data, while data on a 3d surface written from a 3d
+/// simulation is considered volume data. Data for a 2d surface in
+/// a 3d simulation, such as a horizon, is considered surface data and
+/// is written to a file specified by SurfaceFileName.
 struct ReductionFileName : db::SimpleTag {
   using type = std::string;
   using option_tags = tmpl::list<::observers::OptionTags::ReductionFileName>;
@@ -221,6 +234,24 @@ struct ReductionFileName : db::SimpleTag {
   static std::string create_from_options(
       const std::string& reduction_file_name) {
     return reduction_file_name;
+  }
+};
+
+/// \brief The name of the HDF5 file on disk into which surface data is
+/// written.
+///
+/// By surface data we mean data for a 2d surface in
+/// a 3d simulation, such as a horizon. Surface data is written once across
+/// all nodes. For example, data on a 2d surface written from a 2d simulation is
+/// considered volume data, while an integral over the entire (or a subset of
+/// the) domain is considered reduction data.
+struct SurfaceFileName : db::SimpleTag {
+  using type = std::string;
+  using option_tags = tmpl::list<::observers::OptionTags::SurfaceFileName>;
+
+  static constexpr bool pass_metavariables = false;
+  static std::string create_from_options(const std::string& surface_file_name) {
+    return surface_file_name;
   }
 };
 }  // namespace Tags

--- a/src/IO/Observer/VolumeActions.cpp
+++ b/src/IO/Observer/VolumeActions.cpp
@@ -1,0 +1,28 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "IO/Observer/VolumeActions.hpp"
+
+#include <string>
+#include <vector>
+
+#include "DataStructures/Tensor/TensorData.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/Observer/ObservationId.hpp"
+
+namespace observers::ThreadedActions::VolumeActions_detail {
+void write_data(const std::string& h5_file_name,
+                const std::string& subfile_path,
+                const observers::ObservationId& observation_id,
+                std::vector<ElementVolumeData>&& volume_data) {
+  const uint32_t version_number = 0;
+  {
+    h5::H5File<h5::AccessType::ReadWrite> h5_file{h5_file_name + ".h5"s, true};
+    auto& volume_file =
+        h5_file.try_insert<h5::VolumeData>(subfile_path, version_number);
+    volume_file.write_volume_data(observation_id.hash(), observation_id.value(),
+                                  volume_data);
+  }
+}
+}  // namespace observers::ThreadedActions::VolumeActions_detail

--- a/src/ParallelAlgorithms/Interpolation/Callbacks/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Interpolation/Callbacks/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_headers(
   ErrorOnFailedApparentHorizon.hpp
   FindApparentHorizon.hpp
   IgnoreFailedApparentHorizon.hpp
+  ObserveSurfaceData.hpp
   ObserveTimeSeriesOnSurface.hpp
   SendGhWorldtubeData.hpp
   )

--- a/src/ParallelAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp
@@ -19,6 +19,7 @@
 #include "NumericalAlgorithms/SphericalHarmonics/YlmSpherepack.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/Printf.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/SendPointsToInterpolator.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp"
@@ -138,6 +139,9 @@ namespace callbacks {
 template <typename InterpolationTargetTag, typename Frame>
 struct FindApparentHorizon
     : tt::ConformsTo<intrp::protocols::PostInterpolationCallback> {
+  using const_global_cache_tags =
+      Parallel::get_const_global_cache_tags_from_actions<
+          typename InterpolationTargetTag::post_horizon_find_callbacks>;
   template <typename DbTags, typename Metavariables, typename TemporalId>
   static bool apply(
       const gsl::not_null<db::DataBox<DbTags>*> box,

--- a/src/ParallelAlgorithms/Interpolation/Callbacks/ObserveSurfaceData.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Callbacks/ObserveSurfaceData.hpp
@@ -1,0 +1,122 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/TagName.hpp"
+#include "DataStructures/Tensor/TensorData.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/Tags.hpp"
+#include "IO/Observer/VolumeActions.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Tags.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/YlmSpherepack.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Local.hpp"
+#include "Parallel/Reduction.hpp"
+#include "ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp"
+#include "ParallelAlgorithms/Interpolation/Protocols/PostInterpolationCallback.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace intrp {
+namespace callbacks {
+
+/// \brief post_interpolation_callback that outputs
+/// 2D "volume" data on a surface.
+///
+/// Uses:
+/// - Metavariables
+///   - `temporal_id`
+/// - DataBox:
+///   - `TagsToObserve` (each tag must be a Scalar<DataVector>)
+///
+/// Conforms to the intrp::protocols::PostInterpolationCallback protocol
+///
+/// For requirements on InterpolationTargetTag, see
+/// intrp::protocols::InterpolationTargetTag
+template <typename TagsToObserve, typename InterpolationTargetTag>
+struct ObserveSurfaceData
+    : tt::ConformsTo<intrp::protocols::PostInterpolationCallback> {
+  static constexpr double fill_invalid_points_with =
+      std::numeric_limits<double>::quiet_NaN();
+
+  using const_global_cache_tags = tmpl::list<observers::Tags::SurfaceFileName>;
+
+  template <typename DbTags, typename Metavariables, typename TemporalId>
+  static void apply(const db::DataBox<DbTags>& box,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const TemporalId& temporal_id) {
+    const Strahlkorper<Frame::Inertial>& strahlkorper =
+        get<StrahlkorperTags::Strahlkorper<Frame::Inertial>>(box);
+    const YlmSpherepack& ylm = strahlkorper.ylm_spherepack();
+    const std::array<DataVector, 2> theta_phi = ylm.theta_phi_points();
+    const DataVector& theta = theta_phi[0];
+    const DataVector& phi = theta_phi[1];
+    const DataVector& sin_theta = sin(theta);
+    const DataVector& radius = ylm.spec_to_phys(strahlkorper.coefficients());
+
+    // Output the inertial-frame coordinates.
+    const std::string& surface_name =
+        pretty_type::name<InterpolationTargetTag>();
+    std::vector<TensorComponent> tensor_components{
+        {surface_name + "/InertialCoordinates_x"s,
+         radius * sin_theta * cos(phi)},
+        {surface_name + "/InertialCoordinates_y"s,
+         radius * sin_theta * sin(phi)},
+        {surface_name + "/InertialCoordinates_z"s, radius * cos(theta)}};
+
+    // Output each tag if it is a scalar. Otherwise, throw a compile-time
+    // error. This could be generalized to handle tensors of nonzero rank by
+    // looping over the components, so each component could be visualized
+    // separately as a scalar. But in practice, this generalization is
+    // probably unnecessary, because Strahlkorpers are typically only
+    // visualized with scalar quantities (used set the color at different
+    // points on the surface).
+    tmpl::for_each<TagsToObserve>([&box, &surface_name,
+                                   &tensor_components](auto tag_v) {
+      using Tag = tmpl::type_from<decltype(tag_v)>;
+      static_assert(std::is_same_v<typename Tag::type, Scalar<DataVector>>,
+                    "Each tag in TagsToObserve must be a Scalar<DataVector>. "
+                    "This could be generalized if needed; see the code comment "
+                    "above the static_assert.");
+      tensor_components.push_back(
+          {surface_name + "/"s + db::tag_name<Tag>(), get(get<Tag>(box))});
+    });
+
+    const std::string& subfile_path{std::string{"/"} + surface_name};
+    const std::vector<size_t> extents_vector{
+        {ylm.physical_extents()[0], ylm.physical_extents()[1]}};
+    const std::vector<Spectral::Basis> bases_vector{
+        2, Spectral::Basis::SphericalHarmonic};
+    const std::vector<Spectral::Quadrature> quadratures_vector{
+        {Spectral::Quadrature::Gauss, Spectral::Quadrature::Equiangular}};
+    const observers::ObservationId& observation_id = observers::ObservationId(
+        InterpolationTarget_detail::get_temporal_id_value(temporal_id),
+        subfile_path + ".vol");
+
+    auto& proxy = Parallel::get_parallel_component<
+        observers::ObserverWriter<Metavariables>>(cache);
+
+    // We call this on proxy[0] because the 0th element of a NodeGroup is
+    // always guaranteed to be present.
+    Parallel::threaded_action<observers::ThreadedActions::WriteVolumeData>(
+        proxy[0], Parallel::get<observers::Tags::SurfaceFileName>(cache),
+        std::string{"/" + surface_name}, observation_id,
+        std::vector<ElementVolumeData>{{extents_vector, tensor_components,
+                                        bases_vector, quadratures_vector}});
+  }
+};
+}  // namespace callbacks
+}  // namespace intrp

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -198,6 +198,7 @@ EventsAndTriggers:
 Observers:
   VolumeFileName: "GhBinaryBlackHoleVolumeData"
   ReductionFileName: "GhBinaryBlackHoleReductionData"
+  SurfaceFileName: "GhBinaryBlackHoleSurfacesData"
 
 ApparentHorizons:
   AhA:

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -7,6 +7,7 @@
 # ExpectedOutput:
 #   GhKerrSchildVolume0.h5
 #   GhKerrSchildReductions.h5
+#   GhKerrSchildSurfaces.h5
 # OutputFileChecks:
 #   - Label: "check_horizon_find"
 #     Subfile: "/AhA.dat"
@@ -161,6 +162,7 @@ EventsAndDenseTriggers:
 Observers:
   VolumeFileName: "GhKerrSchildVolume"
   ReductionFileName: "GhKerrSchildReductions"
+  SurfaceFileName: "GhKerrSchildSurfaces"
 
 ApparentHorizons:
   AhA:

--- a/tests/Unit/Helpers/IO/VolumeDataHelpers.hpp
+++ b/tests/Unit/Helpers/IO/VolumeDataHelpers.hpp
@@ -1,0 +1,184 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+#include <boost/iterator/transform_iterator.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/H5/VolumeData.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/Numeric.hpp"
+
+/// Functions for testing volume data output.
+namespace TestHelpers::io::VolumeData {
+/// Helper function that multiplies a tensor component by a double, which is
+/// typically the observation time, to generate different tensor values at
+/// different times for testing.
+template <typename T>
+T multiply(const double obs_value, const T& component) {
+  T result = component;
+  for (auto& t : result) {
+    t *= obs_value;
+  }
+  return result;
+}
+
+/// Helper function to check that volume data was written correctly.
+/// This function checks the following:
+///    0. That the provided observation_id is present in the file
+///    1. That the grid_names provided are present in the file
+///    2. That the provided bases and quadratures agree with the bases
+///       and quadratures in the file.
+///    3. That the expected_components are present in the file.
+///    4. That the expected_components, after rescaling them by a constant
+///       factor_to_rescale_components, agree with the components in the file.
+///       Note: if components_comparison_precision is defined, then the
+///       comparison is approximate, using *components_comparison_precision as
+///       the tolerance.
+template <typename DataType>
+void check_volume_data(
+    const std::string& h5_file_name, const uint32_t version_number,
+    const std::string& group_name, const size_t observation_id,
+    const double observation_value,
+    const std::vector<DataType>& tensor_components_and_coords,
+    const std::vector<std::string>& grid_names,
+    const std::vector<std::vector<Spectral::Basis>>& bases,
+    const std::vector<std::vector<Spectral::Quadrature>>& quadratures,
+    const std::vector<std::vector<size_t>>& extents,
+    const std::vector<std::string>& expected_components,
+    const std::vector<std::vector<size_t>>& grid_data_orders,
+    const std::optional<double>& components_comparison_precision,
+    const double factor_to_rescale_components = 1.0) {
+  h5::H5File<h5::AccessType::ReadOnly> file_read{h5_file_name};
+  const auto& volume_file =
+      file_read.get<h5::VolumeData>("/"s + group_name, version_number);
+
+  CHECK(extents == volume_file.get_extents(observation_id));
+  CHECK(volume_file.get_observation_value(observation_id) == observation_value);
+  // Check that all of the grid names were written correctly by checking their
+  // equality of elements
+  const std::vector<std::string> read_grid_names =
+      volume_file.get_grid_names(observation_id);
+  [&read_grid_names, &grid_names]() {
+    auto sortable_grid_names = grid_names;
+    auto sortable_read_grid_names = read_grid_names;
+    std::sort(sortable_grid_names.begin(), sortable_grid_names.end(),
+              std::less<>{});
+    std::sort(sortable_read_grid_names.begin(), sortable_read_grid_names.end(),
+              std::less<>{});
+    REQUIRE(sortable_read_grid_names == sortable_grid_names);
+  }();
+  // Find the order the grids were written in
+  std::vector<size_t> grid_positions(read_grid_names.size());
+  for (size_t i = 0; i < grid_positions.size(); i++) {
+    auto grid_name = grid_names[i];
+    auto position =
+        std::find(read_grid_names.begin(), read_grid_names.end(), grid_name);
+    // We know the grid name is in the read_grid_names because of the previous
+    // so we know `position` is an actual pointer to an element
+    grid_positions[i] =
+        static_cast<size_t>(std::distance(read_grid_names.begin(), position));
+  }
+  auto read_bases = volume_file.get_bases(observation_id);
+  alg::sort(read_bases, std::less<>{});
+  auto read_quadratures = volume_file.get_quadratures(observation_id);
+  alg::sort(read_quadratures, std::less<>{});
+  // We need non-const bases and quadratures in order to sort them, and we
+  // need them in their string form,
+  const auto& stringify = [](const auto& bases_or_quadratures) {
+    std::vector<std::vector<std::string>> local_target_data{};
+    local_target_data.reserve(bases_or_quadratures.size() + 1);
+    for (const auto& element_data : bases_or_quadratures) {
+      std::vector<std::string> target_axis_data{};
+      target_axis_data.reserve(element_data.size() + 1);
+      for (const auto& axis_datum : element_data) {
+        target_axis_data.emplace_back(MakeString{} << axis_datum);
+      }
+      local_target_data.push_back(target_axis_data);
+    }
+    return local_target_data;
+  };
+  auto target_bases = stringify(bases);
+  alg::sort(target_bases, std::less<>{});
+  auto target_quadratures = stringify(quadratures);
+  alg::sort(target_quadratures, std::less<>{});
+  CHECK(target_bases == read_bases);
+  CHECK(target_quadratures == read_quadratures);
+
+  const auto read_components =
+      volume_file.list_tensor_components(observation_id);
+  CHECK(alg::all_of(read_components,
+                    [&expected_components](const std::string& id) {
+                      return alg::found(expected_components, id);
+                    }));
+  // Helper Function to get number of points on a particular grid
+  const auto accumulate_extents = [](const std::vector<size_t>& grid_extents) {
+    return alg::accumulate(grid_extents, 1, std::multiplies<>{});
+  };
+
+  const auto read_extents = volume_file.get_extents(observation_id);
+  std::vector<size_t> element_num_points(
+      boost::make_transform_iterator(read_extents.begin(), accumulate_extents),
+      boost::make_transform_iterator(read_extents.end(), accumulate_extents));
+  const auto read_points_by_element = [&element_num_points]() {
+    std::vector<size_t> read_points(element_num_points.size());
+    read_points[0] = 0;
+    for (size_t index = 1; index < element_num_points.size(); index++) {
+      read_points[index] =
+          read_points[index - 1] + element_num_points[index - 1];
+    }
+    return read_points;
+  }();
+  // Given a DataType, corresponding to contiguous data read out of a
+  // file, find the data which was written by the grid whose extents are
+  // found at position `grid_index` in the vector of extents.
+  const auto get_grid_data = [&element_num_points, &read_points_by_element](
+                                 const DataVector& all_data,
+                                 const size_t grid_index) {
+    DataType result(element_num_points[grid_index]);
+    // clang-tidy: do not use pointer arithmetic
+    std::copy(&all_data[read_points_by_element[grid_index]],
+              &all_data[read_points_by_element[grid_index]] +  // NOLINT
+                  element_num_points[grid_index],
+              result.begin());
+    return result;
+  };
+  // The tensor components can be written in any order to the file, we loop
+  // over the expected components rather than the read components because they
+  // are in a particular order.
+  for (size_t i = 0; i < expected_components.size(); i++) {
+    const auto& component = expected_components[i];
+    // for each grid
+    for (size_t j = 0; j < grid_names.size(); j++) {
+      if (components_comparison_precision) {
+        Approx custom_approx = Approx::custom()
+                                   .epsilon(*components_comparison_precision)
+                                   .scale(1.0);
+        CHECK_ITERABLE_CUSTOM_APPROX(
+            get_grid_data(
+                volume_file.get_tensor_component(observation_id, component),
+                grid_positions[j]),
+            multiply(factor_to_rescale_components,
+                     tensor_components_and_coords[grid_data_orders[j][i]]),
+            custom_approx);
+      } else {
+        CHECK(get_grid_data(
+                  volume_file.get_tensor_component(observation_id, component),
+                  grid_positions[j]) ==
+              multiply(factor_to_rescale_components,
+                       tensor_components_and_coords[grid_data_orders[j][i]]));
+      }
+    }
+  }
+}
+}  // namespace TestHelpers::io::VolumeData

--- a/tests/Unit/IO/Observers/Test_Tags.cpp
+++ b/tests/Unit/IO/Observers/Test_Tags.cpp
@@ -37,6 +37,7 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.Tags", "[Unit][Observers]") {
       "ObservationKey(TestTag)");
   TestHelpers::db::test_simple_tag<VolumeFileName>("VolumeFileName");
   TestHelpers::db::test_simple_tag<ReductionFileName>("ReductionFileName");
+  TestHelpers::db::test_simple_tag<SurfaceFileName>("SurfaceFileName");
   static_assert(
       std::is_same_v<typename ReductionData<double, int, char>::names_tag,
                      ReductionDataNames<double, int, char>>,

--- a/tests/Unit/ParallelAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/CMakeLists.txt
@@ -22,7 +22,7 @@ set(LIBRARY_SOURCES
   Test_InterpolatorReceivePoints.cpp
   Test_InterpolatorReceiveVolumeData.cpp
   Test_InterpolatorRegisterElement.cpp
-  Test_ObserveTimeSeriesOnSurface.cpp
+  Test_ObserveTimeSeriesAndSurfaceData.cpp
   Test_ParallelInterpolator.cpp
   Test_Protocols.cpp
   Test_Tags.cpp


### PR DESCRIPTION
## Proposed changes

This PR 
  * factors existing checks that volume data is written correctly into a helper
  * adds an action (analogous to WriteReductionDataRow) suitable for writing volume data
  * adds a callback making use of this action to output surface "volume" data from the results of interpolation or an AH find
  * adds surface data output to the GH executables

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
