### PR TITLE
Fix constraint preserving boundary conditions

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
@@ -84,9 +84,12 @@ namespace evolution::dg::Actions {
  *
  * where \f$F^i_{\alpha}\f$ are the fluxes when the mesh isn't moving,
  * \f$v^i_g\f$ is the velocity of the mesh, \f$u_{\alpha}\f$ are the evolved
- * variables, \f$S_{\alpha}\f$ are the source terms, and \f$\hat{t}\f$ is the
- * time in the logical frame. For evolution equations that do not have any
- * fluxes and only nonconservative products we evolve:
+ * variables, \f$S_{\alpha}\f$ are the source terms, \f$\hat{t}\f$ is the
+ * time in the logical frame, \f$t\f$ is the time in the inertial frame, hatted
+ * indices correspond to logical frame quantites, and unhatted indices to
+ * inertial frame quantities (e.g. \f$\partial_i\f$ is the derivative with
+ * respect to the inertial coordinates). For evolution equations that do not
+ * have any fluxes and only nonconservative products we evolve:
  *
  * \f{align*}{
  * \frac{\partial u_\alpha}{\partial \hat{t}}
@@ -131,6 +134,12 @@ namespace evolution::dg::Actions {
  *
  * \note The term is always added in the `Frame::Inertial` frame, and the plus
  * sign arises because we add it to the time derivative.
+ *
+ * \warning The mesh velocity terms are added to the time derivatives before
+ * invoking the boundary conditions. This means that the time derivatives passed
+ * to the boundary conditions are with respect to \f$\hat{t}\f$, not \f$t\f$.
+ * This is especially important in the TimeDerivative/Bjorhus boundary
+ * conditions.
  *
  * Here are examples of the `TimeDerivative` struct used to compute the volume
  * time derivative. This struct is what the type alias

--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.hpp
@@ -144,6 +144,7 @@ class ConstraintPreservingSphericalRadiation final
                  ::Tags::dt<Tags::Phi<Dim>>>;
   using dg_interior_deriv_vars_tags = tmpl::list<
       ::Tags::deriv<Tags::Psi, tmpl::size_t<Dim>, Frame::Inertial>,
+      ::Tags::deriv<Tags::Pi, tmpl::size_t<Dim>, Frame::Inertial>,
       ::Tags::deriv<Tags::Phi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>>;
   using dg_gridless_tags = tmpl::list<>;
 
@@ -159,9 +160,11 @@ class ConstraintPreservingSphericalRadiation final
       const tnsr::I<DataVector, Dim, Frame::Inertial>& coords,
       const Scalar<DataVector>& gamma1, const Scalar<DataVector>& gamma2,
       const Scalar<DataVector>& lapse, const tnsr::I<DataVector, Dim>& shift,
-      const Scalar<DataVector>& dt_psi, const Scalar<DataVector>& dt_pi,
-      const tnsr::i<DataVector, Dim>& dt_phi,
+      const Scalar<DataVector>& logical_dt_psi,
+      const Scalar<DataVector>& logical_dt_pi,
+      const tnsr::i<DataVector, Dim>& logical_dt_phi,
       const tnsr::i<DataVector, Dim>& d_psi,
+      const tnsr::i<DataVector, Dim>& d_pi,
       const tnsr::ij<DataVector, Dim>& d_phi) const;
 };
 }  // namespace CurvedScalarWave::BoundaryConditions

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.hpp
@@ -204,9 +204,10 @@ class ConstraintPreservingBjorhus final : public BoundaryCondition<Dim> {
       const tnsr::ab<DataVector, Dim, Frame::Inertial>&
           spacetime_deriv_gauge_source,
       // c.f. dg_interior_dt_vars_tags
-      const tnsr::aa<DataVector, Dim, Frame::Inertial>& dt_spacetime_metric,
-      const tnsr::aa<DataVector, Dim, Frame::Inertial>& dt_pi,
-      const tnsr::iaa<DataVector, Dim, Frame::Inertial>& dt_phi,
+      const tnsr::aa<DataVector, Dim, Frame::Inertial>&
+          logical_dt_spacetime_metric,
+      const tnsr::aa<DataVector, Dim, Frame::Inertial>& logical_dt_pi,
+      const tnsr::iaa<DataVector, Dim, Frame::Inertial>& logical_dt_phi,
       // c.f. dg_interior_deriv_vars_tags
       const tnsr::iaa<DataVector, Dim, Frame::Inertial>& d_spacetime_metric,
       const tnsr::iaa<DataVector, Dim, Frame::Inertial>& d_pi,

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.hpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.hpp
@@ -139,10 +139,14 @@ convert_constraint_preserving_spherical_radiation_type_from_yaml(
  *     \partial_r^2+\frac{4}{r}\partial_t
  *     +\frac{4}{r}\partial_r + \frac{2}{r^2}\right)\Psi \notag \\
  *     &=n^i(\partial_t\Phi_i-\partial_i\Pi) + n^i n^j\partial_i\Phi_j -
+ *     \frac{4}{r}\Pi+\frac{4}{r}n^i\Phi_i + \frac{2}{r^2}\Psi \notag \\
+ *     &=n^i(\gamma_2(\partial_i\Psi - \Phi_i)-2\partial_i\Pi)
+ *     + n^i n^j\partial_i\Phi_j -
  *     \frac{4}{r}\Pi+\frac{4}{r}n^i\Phi_i + \frac{2}{r^2}\Psi,
  * \f}
  *
- * assuming \f$\partial_t n^i=0\f$ and \f$\partial_t r=0\f$.
+ * where \f$\partial_t\f$ is the derivative with respect to the inertial frame
+ * time, and we are assuming \f$\partial_t n^i=0\f$ and \f$\partial_t r=0\f$.
  *
  * The moving mesh can be accounted for by using
  *
@@ -163,6 +167,12 @@ convert_constraint_preserving_spherical_radiation_type_from_yaml(
  * is spherical. It might be possible to generalize the condition to
  * non-spherical boundaries by using \f$x^i/r\f$ instead of \f$n^i\f$, but this
  * hasn't been tested.
+ *
+ * \warning The received time derivatives are in the logical frame, not the
+ * inertial frame and would need to first be corrected by subtracting the mesh
+ * velocity. Similarly, the time derivative correction is in the logical frame.
+ * We instead substitute the evolution equations directly in since the scalar
+ * wave system is quite simple.
  */
 template <size_t Dim>
 class ConstraintPreservingSphericalRadiation final
@@ -218,10 +228,7 @@ class ConstraintPreservingSphericalRadiation final
   using dg_interior_temporary_tags =
       tmpl::list<domain::Tags::Coordinates<Dim, Frame::Inertial>,
                  Tags::ConstraintGamma2>;
-  using dg_interior_dt_vars_tags =
-      tmpl::list<::Tags::dt<ScalarWave::Tags::Psi>,
-                 ::Tags::dt<ScalarWave::Tags::Pi>,
-                 ::Tags::dt<ScalarWave::Tags::Phi<Dim>>>;
+  // using dg_interior_dt_vars_tags = tmpl::list<>;
   using dg_interior_deriv_vars_tags = tmpl::list<
       ::Tags::deriv<ScalarWave::Tags::Psi, tmpl::size_t<Dim>, Frame::Inertial>,
       ::Tags::deriv<ScalarWave::Tags::Pi, tmpl::size_t<Dim>, Frame::Inertial>,
@@ -244,9 +251,6 @@ class ConstraintPreservingSphericalRadiation final
 
       const tnsr::I<DataVector, Dim, Frame::Inertial>& coords,
       const Scalar<DataVector>& gamma2,
-
-      const Scalar<DataVector>& dt_psi, const Scalar<DataVector>& dt_pi,
-      const tnsr::i<DataVector, Dim, Frame::Inertial>& dt_phi,
 
       const tnsr::i<DataVector, Dim, Frame::Inertial>& d_psi,
       const tnsr::i<DataVector, Dim, Frame::Inertial>& d_pi,

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.py
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.py
@@ -8,14 +8,24 @@ from Evolution.Systems.CurvedScalarWave.Characteristics import (
 
 def error(face_mesh_velocity, normal_covector, normal_vector, psi, phi,
           inertial_coords, gamma1, gamma2, lapse, shift, dt_psi, dt_pi, dt_phi,
-          d_psi, d_phi):
+          d_psi, d_pi, d_phi):
     return None
+
+
+def subtract_mesh_velocity(face_mesh_velocity, dt_psi, dt_pi, dt_phi, d_psi,
+                           d_pi, d_phi):
+    if not (face_mesh_velocity is None):
+        dt_psi -= np.einsum("i,i->", face_mesh_velocity, d_psi)
+        dt_pi -= np.einsum("i,i->", face_mesh_velocity, d_pi)
+        dt_phi -= np.einsum("i,ij->j", face_mesh_velocity, d_phi)
 
 
 def dt_psi_constraint_preserving_spherical_radiation(
     face_mesh_velocity, normal_covector, normal_vector, psi, phi,
     inertial_coords, gamma1, gamma2, lapse, shift, dt_psi, dt_pi, dt_phi,
-    d_psi, d_phi):
+    d_psi, d_pi, d_phi):
+    subtract_mesh_velocity(face_mesh_velocity, dt_psi, dt_pi, dt_phi, d_psi,
+                           d_pi, d_phi)
     char_speed_psi = char_speed_vpsi(gamma1, lapse, shift, normal_covector)
 
     if face_mesh_velocity is not None:
@@ -27,7 +37,9 @@ def dt_psi_constraint_preserving_spherical_radiation(
 def dt_phi_constraint_preserving_spherical_radiation(
     face_mesh_velocity, normal_covector, normal_vector, psi, phi,
     inertial_coords, gamma1, gamma2, lapse, shift, dt_psi, dt_pi, dt_phi,
-    d_psi, d_phi):
+    d_psi, d_pi, d_phi):
+    subtract_mesh_velocity(face_mesh_velocity, dt_psi, dt_pi, dt_phi, d_psi,
+                           d_pi, d_phi)
     char_speed_zero = char_speed_vzero(gamma1, lapse, shift, normal_covector)
     if face_mesh_velocity is not None:
         char_speed_zero -= np.dot(normal_covector, face_mesh_velocity)
@@ -38,11 +50,12 @@ def dt_phi_constraint_preserving_spherical_radiation(
 def dt_pi_constraint_preserving_spherical_radiation(
     face_mesh_velocity, normal_covector, normal_vector, psi, phi,
     inertial_coords, gamma1, gamma2, lapse, shift, dt_psi, dt_pi, dt_phi,
-    d_psi, d_phi):
+    d_psi, d_pi, d_phi):
     dt_psi_correction = dt_psi_constraint_preserving_spherical_radiation(
         face_mesh_velocity, normal_covector, normal_vector, psi, phi,
         inertial_coords, gamma1, gamma2, lapse, shift, dt_psi, dt_pi, dt_phi,
-        d_psi, d_phi)
+        d_psi, d_pi, d_phi)
+    # dt's are already corrected in dt_psi
     inv_radius = 1. / np.linalg.norm(inertial_coords)
     bc_dt_pi = (2. * inv_radius**2 * psi + 4. * inv_radius * dt_psi +
                 4. * inv_radius * np.dot(normal_vector, phi) +

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.py
@@ -438,6 +438,15 @@ def dt_corrs_ConstraintPreservingPhysical(
     return dt_v_psi, dt_v_zero, dt_v_plus, dt_v_minus
 
 
+def subtract_mesh_velocity(face_mesh_velocity, dt_spacetime_metric, dt_pi,
+                           dt_phi, d_spacetime_metric, d_pi, d_phi):
+    if not (face_mesh_velocity is None):
+        dt_spacetime_metric -= np.einsum("i,iab->ab", face_mesh_velocity,
+                                         d_spacetime_metric)
+        dt_pi -= np.einsum("i,iab->ab", face_mesh_velocity, d_pi)
+        dt_phi -= np.einsum("i,ijab->jab", face_mesh_velocity, d_phi)
+
+
 def dt_spacetime_metric(face_mesh_velocity, normal_covector, normal_vector,
                         spacetime_metric, pi, phi, inertial_coords, gamma1,
                         gamma2, lapse, shift, inverse_spacetime_metric,
@@ -446,6 +455,8 @@ def dt_spacetime_metric(face_mesh_velocity, normal_covector, normal_vector,
                         gauge_source, spacetime_deriv_gauge_source,
                         dt_spacetime_metric, dt_pi, dt_phi, d_spacetime_metric,
                         d_pi, d_phi):
+    subtract_mesh_velocity(face_mesh_velocity, dt_spacetime_metric, dt_pi,
+                           dt_phi, d_spacetime_metric, d_pi, d_phi)
     (dt_v_psi, dt_v_zero, dt_v_plus,
      dt_v_minus) = dt_corrs_ConstraintPreserving(
          face_mesh_velocity, normal_covector, normal_vector, spacetime_metric,
@@ -457,6 +468,21 @@ def dt_spacetime_metric(face_mesh_velocity, normal_covector, normal_vector,
     return dt_v_psi
 
 
+def dt_spacetime_metric_static_mesh(
+    normal_covector, normal_vector, spacetime_metric, pi, phi, inertial_coords,
+    gamma1, gamma2, lapse, shift, inverse_spacetime_metric,
+    spacetime_unit_normal_vector, spacetime_unit_normal_one_form,
+    three_index_constraint, gauge_source, spacetime_deriv_gauge_source,
+    in_dt_spacetime_metric, dt_pi, dt_phi, d_spacetime_metric, d_pi, d_phi):
+    return dt_spacetime_metric(
+        0.0 * normal_vector, normal_covector, normal_vector, spacetime_metric,
+        pi, phi, inertial_coords, gamma1, gamma2, lapse, shift,
+        inverse_spacetime_metric, spacetime_unit_normal_vector,
+        spacetime_unit_normal_one_form, three_index_constraint, gauge_source,
+        spacetime_deriv_gauge_source, in_dt_spacetime_metric, dt_pi, dt_phi,
+        d_spacetime_metric, d_pi, d_phi)
+
+
 def dt_pi_ConstraintPreserving(
     face_mesh_velocity, normal_covector, normal_vector, spacetime_metric, pi,
     phi, inertial_coords, gamma1, gamma2, lapse, shift,
@@ -464,6 +490,8 @@ def dt_pi_ConstraintPreserving(
     spacetime_unit_normal_one_form, three_index_constraint, gauge_source,
     spacetime_deriv_gauge_source, dt_spacetime_metric, dt_pi, dt_phi,
     d_spacetime_metric, d_pi, d_phi):
+    subtract_mesh_velocity(face_mesh_velocity, dt_spacetime_metric, dt_pi,
+                           dt_phi, d_spacetime_metric, d_pi, d_phi)
     (dt_v_psi, dt_v_zero, dt_v_plus,
      dt_v_minus) = dt_corrs_ConstraintPreserving(
          face_mesh_velocity, normal_covector, normal_vector, spacetime_metric,
@@ -474,6 +502,21 @@ def dt_pi_ConstraintPreserving(
          d_spacetime_metric, d_pi, d_phi)
     return ght.evol_field_pi(gamma2, dt_v_psi, dt_v_zero, dt_v_plus,
                              dt_v_minus, normal_covector)
+
+
+def dt_pi_ConstraintPreserving_static_mesh(
+    normal_covector, normal_vector, spacetime_metric, pi, phi, inertial_coords,
+    gamma1, gamma2, lapse, shift, inverse_spacetime_metric,
+    spacetime_unit_normal_vector, spacetime_unit_normal_one_form,
+    three_index_constraint, gauge_source, spacetime_deriv_gauge_source,
+    dt_spacetime_metric, dt_pi, dt_phi, d_spacetime_metric, d_pi, d_phi):
+    return dt_pi_ConstraintPreserving(
+        0.0 * normal_vector, normal_covector, normal_vector, spacetime_metric,
+        pi, phi, inertial_coords, gamma1, gamma2, lapse, shift,
+        inverse_spacetime_metric, spacetime_unit_normal_vector,
+        spacetime_unit_normal_one_form, three_index_constraint, gauge_source,
+        spacetime_deriv_gauge_source, dt_spacetime_metric, dt_pi, dt_phi,
+        d_spacetime_metric, d_pi, d_phi)
 
 
 def dt_pi_ConstraintPreservingPhysical(
@@ -483,6 +526,8 @@ def dt_pi_ConstraintPreservingPhysical(
     spacetime_unit_normal_one_form, three_index_constraint, gauge_source,
     spacetime_deriv_gauge_source, dt_spacetime_metric, dt_pi, dt_phi,
     d_spacetime_metric, d_pi, d_phi):
+    subtract_mesh_velocity(face_mesh_velocity, dt_spacetime_metric, dt_pi,
+                           dt_phi, d_spacetime_metric, d_pi, d_phi)
     (dt_v_psi, dt_v_zero, dt_v_plus,
      dt_v_minus) = dt_corrs_ConstraintPreservingPhysical(
          face_mesh_velocity, normal_covector, normal_vector, spacetime_metric,
@@ -495,6 +540,21 @@ def dt_pi_ConstraintPreservingPhysical(
                              dt_v_minus, normal_covector)
 
 
+def dt_pi_ConstraintPreservingPhysical_static_mesh(
+    normal_covector, normal_vector, spacetime_metric, pi, phi, inertial_coords,
+    gamma1, gamma2, lapse, shift, inverse_spacetime_metric,
+    spacetime_unit_normal_vector, spacetime_unit_normal_one_form,
+    three_index_constraint, gauge_source, spacetime_deriv_gauge_source,
+    dt_spacetime_metric, dt_pi, dt_phi, d_spacetime_metric, d_pi, d_phi):
+    return dt_pi_ConstraintPreservingPhysical(
+        0.0 * normal_vector, normal_covector, normal_vector, spacetime_metric,
+        pi, phi, inertial_coords, gamma1, gamma2, lapse, shift,
+        inverse_spacetime_metric, spacetime_unit_normal_vector,
+        spacetime_unit_normal_one_form, three_index_constraint, gauge_source,
+        spacetime_deriv_gauge_source, dt_spacetime_metric, dt_pi, dt_phi,
+        d_spacetime_metric, d_pi, d_phi)
+
+
 def dt_phi_ConstraintPreserving(
     face_mesh_velocity, normal_covector, normal_vector, spacetime_metric, pi,
     phi, inertial_coords, gamma1, gamma2, lapse, shift,
@@ -502,6 +562,8 @@ def dt_phi_ConstraintPreserving(
     spacetime_unit_normal_one_form, three_index_constraint, gauge_source,
     spacetime_deriv_gauge_source, dt_spacetime_metric, dt_pi, dt_phi,
     d_spacetime_metric, d_pi, d_phi):
+    subtract_mesh_velocity(face_mesh_velocity, dt_spacetime_metric, dt_pi,
+                           dt_phi, d_spacetime_metric, d_pi, d_phi)
     (dt_v_psi, dt_v_zero, dt_v_plus,
      dt_v_minus) = dt_corrs_ConstraintPreserving(
          face_mesh_velocity, normal_covector, normal_vector, spacetime_metric,
@@ -514,6 +576,21 @@ def dt_phi_ConstraintPreserving(
                               dt_v_minus, normal_covector)
 
 
+def dt_phi_ConstraintPreserving_static_mesh(
+    normal_covector, normal_vector, spacetime_metric, pi, phi, inertial_coords,
+    gamma1, gamma2, lapse, shift, inverse_spacetime_metric,
+    spacetime_unit_normal_vector, spacetime_unit_normal_one_form,
+    three_index_constraint, gauge_source, spacetime_deriv_gauge_source,
+    dt_spacetime_metric, dt_pi, dt_phi, d_spacetime_metric, d_pi, d_phi):
+    return dt_phi_ConstraintPreserving(
+        0.0 * normal_vector, normal_covector, normal_vector, spacetime_metric,
+        pi, phi, inertial_coords, gamma1, gamma2, lapse, shift,
+        inverse_spacetime_metric, spacetime_unit_normal_vector,
+        spacetime_unit_normal_one_form, three_index_constraint, gauge_source,
+        spacetime_deriv_gauge_source, dt_spacetime_metric, dt_pi, dt_phi,
+        d_spacetime_metric, d_pi, d_phi)
+
+
 def dt_phi_ConstraintPreservingPhysical(
     face_mesh_velocity, normal_covector, normal_vector, spacetime_metric, pi,
     phi, inertial_coords, gamma1, gamma2, lapse, shift,
@@ -521,6 +598,8 @@ def dt_phi_ConstraintPreservingPhysical(
     spacetime_unit_normal_one_form, three_index_constraint, gauge_source,
     spacetime_deriv_gauge_source, dt_spacetime_metric, dt_pi, dt_phi,
     d_spacetime_metric, d_pi, d_phi):
+    subtract_mesh_velocity(face_mesh_velocity, dt_spacetime_metric, dt_pi,
+                           dt_phi, d_spacetime_metric, d_pi, d_phi)
     (dt_v_psi, dt_v_zero, dt_v_plus,
      dt_v_minus) = dt_corrs_ConstraintPreservingPhysical(
          face_mesh_velocity, normal_covector, normal_vector, spacetime_metric,
@@ -531,3 +610,18 @@ def dt_phi_ConstraintPreservingPhysical(
          d_spacetime_metric, d_pi, d_phi)
     return ght.evol_field_phi(gamma2, dt_v_psi, dt_v_zero, dt_v_plus,
                               dt_v_minus, normal_covector)
+
+
+def dt_phi_ConstraintPreservingPhysical_static_mesh(
+    normal_covector, normal_vector, spacetime_metric, pi, phi, inertial_coords,
+    gamma1, gamma2, lapse, shift, inverse_spacetime_metric,
+    spacetime_unit_normal_vector, spacetime_unit_normal_one_form,
+    three_index_constraint, gauge_source, spacetime_deriv_gauge_source,
+    dt_spacetime_metric, dt_pi, dt_phi, d_spacetime_metric, d_pi, d_phi):
+    return dt_phi_ConstraintPreservingPhysical(
+        0.0 * normal_vector, normal_covector, normal_vector, spacetime_metric,
+        pi, phi, inertial_coords, gamma1, gamma2, lapse, shift,
+        inverse_spacetime_metric, spacetime_unit_normal_vector,
+        spacetime_unit_normal_one_form, three_index_constraint, gauge_source,
+        spacetime_deriv_gauge_source, dt_spacetime_metric, dt_pi, dt_phi,
+        d_spacetime_metric, d_pi, d_phi)

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_Bjorhus.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_Bjorhus.cpp
@@ -120,6 +120,51 @@ void wrap_dt_vars_corrections_ConstraintPreserving(
 }
 
 template <size_t Dim>
+void wrap_dt_vars_corrections_ConstraintPreserving_static_mesh(
+    const gsl::not_null<tnsr::aa<DataVector, Dim, frame>*>
+        dt_spacetime_metric_correction,
+    const gsl::not_null<tnsr::aa<DataVector, Dim, frame>*> dt_pi_correction,
+    const gsl::not_null<tnsr::iaa<DataVector, Dim, frame>*> dt_phi_correction,
+    const tnsr::i<DataVector, Dim, frame>& normal_covector,
+    const tnsr::I<DataVector, Dim, frame>& normal_vector,
+    // c.f. dg_interior_evolved_variables_tags
+    const tnsr::aa<DataVector, Dim, frame>& spacetime_metric,
+    const tnsr::aa<DataVector, Dim, frame>& pi,
+    const tnsr::iaa<DataVector, Dim, frame>& phi,
+    // c.f. dg_interior_temporary_tags
+    const tnsr::I<DataVector, Dim, frame>& coords,
+    const Scalar<DataVector>& gamma1, const Scalar<DataVector>& gamma2,
+    const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& shift,
+    const tnsr::AA<DataVector, Dim, Frame::Inertial>& inverse_spacetime_metric,
+    const tnsr::A<DataVector, Dim, Frame::Inertial>&
+        spacetime_unit_normal_vector,
+    const tnsr::a<DataVector, Dim, Frame::Inertial>&
+        spacetime_unit_normal_one_form,
+    const tnsr::iaa<DataVector, Dim, Frame::Inertial>& three_index_constraint,
+    const tnsr::a<DataVector, Dim, frame>& gauge_source,
+    const tnsr::ab<DataVector, Dim, frame>& spacetime_deriv_gauge_source,
+    // c.f. dg_interior_dt_vars_tags
+    const tnsr::aa<DataVector, Dim, frame>& dt_spacetime_metric,
+    const tnsr::aa<DataVector, Dim, frame>& dt_pi,
+    const tnsr::iaa<DataVector, Dim, frame>& dt_phi,
+    // c.f. dg_interior_deriv_vars_tags
+    const tnsr::iaa<DataVector, Dim, frame>& d_spacetime_metric,
+    const tnsr::iaa<DataVector, Dim, frame>& d_pi,
+    const tnsr::ijaa<DataVector, Dim, frame>& d_phi) {
+  GeneralizedHarmonic::BoundaryConditions::ConstraintPreservingBjorhus<Dim>
+      bjorhus_obj{GeneralizedHarmonic::BoundaryConditions::detail::
+                      ConstraintPreservingBjorhusType::ConstraintPreserving};
+  bjorhus_obj.dg_time_derivative(
+      dt_spacetime_metric_correction, dt_pi_correction, dt_phi_correction,
+      std::nullopt, normal_covector, normal_vector, spacetime_metric, pi, phi,
+      coords, gamma1, gamma2, lapse, shift, inverse_spacetime_metric,
+      spacetime_unit_normal_vector, spacetime_unit_normal_one_form,
+      three_index_constraint, gauge_source, spacetime_deriv_gauge_source,
+      dt_spacetime_metric, dt_pi, dt_phi, d_spacetime_metric, d_pi, d_phi);
+}
+
+template <size_t Dim>
 void wrap_dt_vars_corrections_ConstraintPreservingPhysical(
     const gsl::not_null<tnsr::aa<DataVector, Dim, frame>*>
         dt_spacetime_metric_correction,
@@ -167,7 +212,70 @@ void wrap_dt_vars_corrections_ConstraintPreservingPhysical(
 }
 
 template <size_t Dim>
+void wrap_dt_vars_corrections_ConstraintPreservingPhysical_static_mesh(
+    const gsl::not_null<tnsr::aa<DataVector, Dim, frame>*>
+        dt_spacetime_metric_correction,
+    const gsl::not_null<tnsr::aa<DataVector, Dim, frame>*> dt_pi_correction,
+    const gsl::not_null<tnsr::iaa<DataVector, Dim, frame>*> dt_phi_correction,
+    const tnsr::i<DataVector, Dim, frame>& normal_covector,
+    const tnsr::I<DataVector, Dim, frame>& normal_vector,
+    // c.f. dg_interior_evolved_variables_tags
+    const tnsr::aa<DataVector, Dim, frame>& spacetime_metric,
+    const tnsr::aa<DataVector, Dim, frame>& pi,
+    const tnsr::iaa<DataVector, Dim, frame>& phi,
+    // c.f. dg_interior_temporary_tags
+    const tnsr::I<DataVector, Dim, frame>& coords,
+    const Scalar<DataVector>& gamma1, const Scalar<DataVector>& gamma2,
+    const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& shift,
+    const tnsr::AA<DataVector, Dim, Frame::Inertial>& inverse_spacetime_metric,
+    const tnsr::A<DataVector, Dim, Frame::Inertial>&
+        spacetime_unit_normal_vector,
+    const tnsr::a<DataVector, Dim, Frame::Inertial>&
+        spacetime_unit_normal_one_form,
+    const tnsr::iaa<DataVector, Dim, Frame::Inertial>& three_index_constraint,
+    const tnsr::a<DataVector, Dim, frame>& gauge_source,
+    const tnsr::ab<DataVector, Dim, frame>& spacetime_deriv_gauge_source,
+    // c.f. dg_interior_dt_vars_tags
+    const tnsr::aa<DataVector, Dim, frame>& dt_spacetime_metric,
+    const tnsr::aa<DataVector, Dim, frame>& dt_pi,
+    const tnsr::iaa<DataVector, Dim, frame>& dt_phi,
+    // c.f. dg_interior_deriv_vars_tags
+    const tnsr::iaa<DataVector, Dim, frame>& d_spacetime_metric,
+    const tnsr::iaa<DataVector, Dim, frame>& d_pi,
+    const tnsr::ijaa<DataVector, Dim, frame>& d_phi) {
+  GeneralizedHarmonic::BoundaryConditions::ConstraintPreservingBjorhus<Dim>
+      bjorhus_obj{
+          GeneralizedHarmonic::BoundaryConditions::detail::
+              ConstraintPreservingBjorhusType::ConstraintPreservingPhysical};
+  bjorhus_obj.dg_time_derivative(
+      dt_spacetime_metric_correction, dt_pi_correction, dt_phi_correction,
+      std::nullopt, normal_covector, normal_vector, spacetime_metric, pi, phi,
+      coords, gamma1, gamma2, lapse, shift, inverse_spacetime_metric,
+      spacetime_unit_normal_vector, spacetime_unit_normal_one_form,
+      three_index_constraint, gauge_source, spacetime_deriv_gauge_source,
+      dt_spacetime_metric, dt_pi, dt_phi, d_spacetime_metric, d_pi, d_phi);
+}
+
+template <size_t Dim>
 void test_with_random_values(const DataVector& used_for_size) {
+  // Static mesh
+  pypp::check_with_random_values<1>(
+      wrap_dt_vars_corrections_ConstraintPreserving_static_mesh<Dim>,
+      "Evolution.Systems.GeneralizedHarmonic.BoundaryConditions.Bjorhus",
+      {"dt_spacetime_metric_static_mesh",
+       "dt_pi_ConstraintPreserving_static_mesh",
+       "dt_phi_ConstraintPreserving_static_mesh"},
+      {{{0.1, 1.}}}, used_for_size, 1.e-6);
+  pypp::check_with_random_values<1>(
+      wrap_dt_vars_corrections_ConstraintPreservingPhysical_static_mesh<Dim>,
+      "Evolution.Systems.GeneralizedHarmonic.BoundaryConditions.Bjorhus",
+      {"dt_spacetime_metric_static_mesh",
+       "dt_pi_ConstraintPreservingPhysical_static_mesh",
+       "dt_phi_ConstraintPreservingPhysical_static_mesh"},
+      {{{0.1, 1.}}}, used_for_size, 1.e-6);
+
+  // Moving mesh
   pypp::check_with_random_values<1>(
       wrap_dt_vars_corrections_ConstraintPreserving<Dim>,
       "Evolution.Systems.GeneralizedHarmonic.BoundaryConditions.Bjorhus",

--- a/tests/Unit/Evolution/Systems/ScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.py
+++ b/tests/Unit/Evolution/Systems/ScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.py
@@ -5,7 +5,7 @@ import numpy as np
 
 
 def error(face_mesh_velocity, outward_directed_normal_covector, pi, phi, psi,
-          coords, interior_gamma2, dt_psi, dt_pi, dt_phi, d_psi, d_pi, d_phi):
+          coords, interior_gamma2, d_psi, d_pi, d_phi):
     if not face_mesh_velocity is None and -np.dot(
             face_mesh_velocity, outward_directed_normal_covector) < 0.0:
         return ("Incoming characteristic speeds for constraint preserving "
@@ -23,42 +23,44 @@ def _dt_psi(face_mesh_velocity, outward_directed_normal_covector, phi, d_psi):
 
 
 def dt_pi_Sommerfeld(face_mesh_velocity, outward_directed_normal_covector, psi,
-                     pi, phi, coords, interior_gamma2, dt_psi, dt_pi, dt_phi,
-                     d_psi, d_pi, d_phi):
-    return -dt_pi + np.dot(
-        outward_directed_normal_covector, dt_phi) + interior_gamma2 * _dt_psi(
+                     pi, phi, coords, interior_gamma2, d_psi, d_pi, d_phi):
+    return np.einsum("ii", d_phi) + np.einsum(
+        "i,i->", outward_directed_normal_covector,
+        interior_gamma2 * (d_psi - phi) - d_pi) + interior_gamma2 * _dt_psi(
             face_mesh_velocity, outward_directed_normal_covector, phi, d_psi)
 
 
 def dt_pi_FirstOrderBaylissTurkel(face_mesh_velocity,
                                   outward_directed_normal_covector, psi, pi,
-                                  phi, coords, interior_gamma2, dt_psi, dt_pi,
-                                  dt_phi, d_psi, d_pi, d_phi):
+                                  phi, coords, interior_gamma2, d_psi, d_pi,
+                                  d_phi):
     radius = np.sqrt(np.dot(coords, coords))
-    return -dt_pi + np.dot(
-        outward_directed_normal_covector,
-        dt_phi) + dt_psi / radius + interior_gamma2 * _dt_psi(
+    return np.einsum("ii", d_phi) + np.einsum(
+        "i,i->", outward_directed_normal_covector,
+        interior_gamma2 *
+        (d_psi - phi) - d_pi) - pi / radius + interior_gamma2 * _dt_psi(
             face_mesh_velocity, outward_directed_normal_covector, phi, d_psi)
 
 
 def dt_pi_SecondOrderBaylissTurkel(face_mesh_velocity,
                                    outward_directed_normal_covector, psi, pi,
-                                   phi, coords, interior_gamma2, dt_psi, dt_pi,
-                                   dt_phi, d_psi, d_pi, d_phi):
+                                   phi, coords, interior_gamma2, d_psi, d_pi,
+                                   d_phi):
     radius = np.sqrt(np.dot(coords, coords))
-    return -dt_pi + (
-        np.dot(outward_directed_normal_covector, dt_phi - d_pi) + np.einsum(
-            "i,j,ij->", outward_directed_normal_covector,
-            outward_directed_normal_covector, d_phi) - 4.0 / radius * pi +
-        4.0 / radius * np.dot(outward_directed_normal_covector, phi) +
+    return np.einsum("ii", d_phi) + (
+        np.dot(outward_directed_normal_covector,
+               -2.0 * d_pi + interior_gamma2 * (d_psi - phi)) +
+        np.einsum("i,j,ij->", outward_directed_normal_covector,
+                  outward_directed_normal_covector, d_phi) - 4.0 / radius * pi
+        + 4.0 / radius * np.dot(outward_directed_normal_covector, phi) +
         2.0 * psi / radius**2) + interior_gamma2 * _dt_psi(
             face_mesh_velocity, outward_directed_normal_covector, phi, d_psi)
 
 
 def dt_phi(face_mesh_velocity, outward_directed_normal_covector, psi, pi, phi,
-           coords, interior_gamma2, dt_psi, dt_pi, dt_phi, d_psi, d_pi, d_phi):
+           coords, interior_gamma2, d_psi, d_pi, d_phi):
     if face_mesh_velocity is None:
-        return 0.0 * dt_phi
+        return 0.0 * d_psi
 
     return -np.dot(outward_directed_normal_covector,
                    face_mesh_velocity) * 0.5 * np.einsum(
@@ -67,7 +69,7 @@ def dt_phi(face_mesh_velocity, outward_directed_normal_covector, psi, pi, phi,
 
 
 def dt_psi(face_mesh_velocity, outward_directed_normal_covector, psi, pi, phi,
-           coords, interior_gamma2, dt_psi, dt_pi, dt_phi, d_psi, d_pi, d_phi):
+           coords, interior_gamma2, d_psi, d_pi, d_phi):
     assert interior_gamma2 >= 0.0  # make sure random gamma_2 is positive
     return _dt_psi(face_mesh_velocity, outward_directed_normal_covector, phi,
                    d_psi)


### PR DESCRIPTION
## Proposed changes

- Document that it is the logical time derivative passed to boundary conditions
- Switch to inertial time derivative when computing constraint preserving BCs

Plot comparing BBH run by @knelli2:

![Compare_Norms](https://user-images.githubusercontent.com/13531030/168373824-31b03e36-babc-47e5-b657-bb4e25fe5ecc.png)

Looks like the fix improves things.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
