### PR TITLE
Add new entry menthod to GlobalCaches for memory monitor

### DIFF
--- a/src/Parallel/CMakeLists.txt
+++ b/src/Parallel/CMakeLists.txt
@@ -30,6 +30,7 @@ spectre_target_headers(
   CreateFromOptions.hpp
   GetSection.hpp
   GlobalCache.hpp
+  GlobalCacheDeclare.hpp
   InboxInserters.hpp
   Info.hpp
   InitializationFunctions.hpp

--- a/src/Parallel/GlobalCache.ci
+++ b/src/Parallel/GlobalCache.ci
@@ -4,6 +4,7 @@
 module GlobalCache {
 
   include "optional";
+  include "Parallel/GlobalCacheDeclare.hpp";
   include "Parallel/ParallelComponentHelpers.hpp";
   include "Utilities/TaggedTuple.hpp";
   include "Parallel/Main.decl.h";
@@ -16,6 +17,8 @@ module GlobalCache {
             get_mutable_global_cache_tags<Metavariables>>&);
     template <typename GlobalCacheTag, typename Function, typename... Args>
     entry void mutate(std::tuple<Args...> & args);
+    entry void compute_size_for_memory_monitor(
+      CProxy_GlobalCache<Metavariables> global_cache_proxy, double time);
   }
 
   template <typename Metavariables>
@@ -33,6 +36,7 @@ module GlobalCache {
         const CkCallback&);
     template <typename GlobalCacheTag, typename Function, typename... Args>
     entry void mutate(std::tuple<Args...> & args);
+    entry void compute_size_for_memory_monitor(double time);
   }
   }  // namespace Parallel
 }

--- a/src/Parallel/GlobalCacheDeclare.hpp
+++ b/src/Parallel/GlobalCacheDeclare.hpp
@@ -1,0 +1,15 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Forward-declares CProxy_GlobalCache which MutableGlobalCache needs, but
+/// GlobalCache is defined after MutableGlobalCache.
+
+#pragma once
+
+/// \cond
+namespace Parallel {
+template <class Metavariables>
+class CProxy_GlobalCache;
+}  // namespace Parallel
+/// \endcond

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -8,10 +8,12 @@ add_subdirectory(PhaseControl)
 set(ALGORITHM_TEST_LINK_LIBRARIES
   # Link against Boost::program_options for now until we have proper
   # dependency handling for header-only libs
+  Actions
   Boost::program_options
   Charmxx::main
   ErrorHandling
   Informer
+  IO
   Options
   Parallel
   ParallelHelpers

--- a/tests/Unit/Parallel/Test_AlgorithmGlobalCache.yaml
+++ b/tests/Unit/Parallel/Test_AlgorithmGlobalCache.yaml
@@ -3,3 +3,7 @@
 
 # Initialize to empty vector.
 VectorOfDoubles: []
+
+Observers:
+  ReductionFileName: "Test_AlgorithmGlobalCacheReduction"
+  VolumeFileName: "Test_AlgorithmGlobalCacheVolume"

--- a/tests/Unit/Parallel/Test_GlobalCacheDataBox.cpp
+++ b/tests/Unit/Parallel/Test_GlobalCacheDataBox.cpp
@@ -57,10 +57,40 @@ void test_mutable_cache_proxy_error() {
           "isn't set."));
 }
 
+void test_mem_monitor_entry_method_error() {
+  CHECK_THROWS_WITH(
+      ([]() {
+        MutableGlobalCache<EmptyMetavars> mutable_cache{
+            tuples::TaggedTuple<>{}};
+        CProxy_GlobalCache<EmptyMetavars> empty_cache_proxy{};
+
+        mutable_cache.compute_size_for_memory_monitor(empty_cache_proxy, 0.0);
+      })(),
+      Catch::Contains(
+          "MutableGlobalCache::compute_size_for_memory_monitor can only be "
+          "called if the MemoryMonitor is in the component list in the "
+          "metavariables.\n"));
+
+  CHECK_THROWS_WITH(
+      ([]() {
+        MutableGlobalCache<EmptyMetavars> mutable_cache{
+            tuples::TaggedTuple<>{}};
+        GlobalCache<EmptyMetavars> empty_cache{tuples::TaggedTuple<>{},
+                                               &mutable_cache};
+
+        empty_cache.compute_size_for_memory_monitor(0.0);
+      })(),
+      Catch::Contains(
+          "GlobalCache::compute_size_for_memory_monitor can only be called if "
+          "the MemoryMonitor is in the component list in the "
+          "metavariables.\n"));
+}
+
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Parallel.GlobalCacheDataBox", "[Unit][Parallel]") {
   test_mutable_cache_proxy_error();
+  test_mem_monitor_entry_method_error();
 
   tuples::TaggedTuple<Tags::IntegerList, Tags::UniquePtrIntegerList> tuple{};
   tuples::get<Tags::IntegerList>(tuple) = std::array<int, 3>{{-1, 3, 7}};


### PR DESCRIPTION
## Proposed changes

To compute the size of an component, the memory monitor needs to get the size of the local branch of a component. For (node)groups, this is accomplished by calling a simple action on the entire (node)group. However, this will not work with the (Mutable)GlobalCache because it cannot run simple actions as there is no `simple_action` entry method for the (Mutable)GlobalCache. This PR adds a new entry method that will compute the size of the local branch of the (Mutable)GlobalCache and send it to the memory monitor. This action can only be called when the MemoryMonitor singleton is in the component list in the metavariables.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Dependencies

Includes and depends on #3949. Only the most recent commit is for this PR.

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
