### PR TITLE
Template parallel info functions on return type

### DIFF
--- a/src/Evolution/Systems/Cce/Actions/InsertInterpolationScriData.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InsertInterpolationScriData.hpp
@@ -79,7 +79,7 @@ void output_impl(const size_t observation_l_max, const size_t l_max,
   auto& my_proxy = Parallel::get_parallel_component<ParallelComponent>(cache);
   auto observer_proxy = Parallel::get_parallel_component<
       observers::ObserverWriter<Metavariables>>(cache)[static_cast<size_t>(
-      Parallel::my_node(*Parallel::local(my_proxy)))];
+      Parallel::my_node<int>(*Parallel::local(my_proxy)))];
   // swsh transform
   const ComplexModalVector goldberg_modes =
       Spectral::Swsh::libsharp_to_goldberg_modes(

--- a/src/Evolution/Systems/Cce/Actions/ScriObserveInterpolated.hpp
+++ b/src/Evolution/Systems/Cce/Actions/ScriObserveInterpolated.hpp
@@ -253,8 +253,7 @@ struct ScriObserveInterpolated {
     auto& my_proxy = Parallel::get_parallel_component<ParallelComponent>(cache);
     auto observer_proxy =
         Parallel::get_parallel_component<ObserverWriterComponent>(
-            cache)[static_cast<size_t>(
-            Parallel::my_node(*Parallel::local(my_proxy)))];
+            cache)[Parallel::my_node<size_t>(*Parallel::local(my_proxy))];
     Parallel::threaded_action<observers::ThreadedActions::WriteSimpleData>(
         observer_proxy, legend, *data_to_write_buffer,
         "/" + detail::ScriOutput<Tag>::name());

--- a/src/Evolution/Systems/Cce/AnalyticBoundaryDataManager.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticBoundaryDataManager.hpp
@@ -108,8 +108,8 @@ void AnalyticBoundaryDataManager::write_news(
   }
   auto& my_proxy = Parallel::get_parallel_component<ParallelComponent>(cache);
   auto observer_proxy = Parallel::get_parallel_component<
-      observers::ObserverWriter<Metavariables>>(cache)[static_cast<size_t>(
-      Parallel::my_node(*Parallel::local(my_proxy)))];
+      observers::ObserverWriter<Metavariables>>(
+      cache)[Parallel::my_node<size_t>(*Parallel::local(my_proxy))];
   const std::string prefix =
       generator_->use_noninertial_news() ? "Noninertial_" : "";
   Parallel::threaded_action<observers::ThreadedActions::WriteSimpleData>(

--- a/src/IO/Observer/Actions/ObserverRegistration.hpp
+++ b/src/IO/Observer/Actions/ObserverRegistration.hpp
@@ -156,8 +156,8 @@ struct RegisterReductionNodeWithWritingNode {
                       DbTagsList, Tags::NodesExpectedToContributeReductions>) {
       auto& my_proxy =
           Parallel::get_parallel_component<ParallelComponent>(cache);
-      const auto node_id = static_cast<size_t>(
-          Parallel::my_node(*Parallel::local_branch(my_proxy)));
+      const auto node_id =
+          Parallel::my_node<size_t>(*Parallel::local_branch(my_proxy));
       ASSERT(node_id == 0, "Only node zero, not node "
                                << node_id
                                << ", should be called from another node");
@@ -211,8 +211,8 @@ struct DeregisterReductionNodeWithWritingNode {
                       DbTagsList, Tags::NodesExpectedToContributeReductions>) {
       auto& my_proxy =
           Parallel::get_parallel_component<ParallelComponent>(cache);
-      const auto node_id = static_cast<size_t>(
-          Parallel::my_node(*Parallel::local_branch(my_proxy)));
+      const auto node_id =
+          Parallel::my_node<size_t>(*Parallel::local_branch(my_proxy));
       ASSERT(node_id == 0,
              "Only node zero, not node "
                  << node_id
@@ -277,8 +277,8 @@ struct RegisterReductionContributorWithObserverWriter {
                       DbTagsList, Tags::ExpectedContributorsForObservations>) {
       auto& my_proxy =
           Parallel::get_parallel_component<ParallelComponent>(cache);
-      const auto node_id = static_cast<size_t>(
-          Parallel::my_node(*Parallel::local_branch(my_proxy)));
+      const auto node_id =
+          Parallel::my_node<size_t>(*Parallel::local_branch(my_proxy));
       db::mutate<Tags::ExpectedContributorsForObservations>(
           make_not_null(&box),
           [&cache, &id_of_caller, &node_id, &observation_key](
@@ -342,8 +342,8 @@ struct DeregisterReductionContributorWithObserverWriter {
                       DbTagsList, Tags::ExpectedContributorsForObservations>) {
       auto& my_proxy =
           Parallel::get_parallel_component<ParallelComponent>(cache);
-      const auto node_id = static_cast<size_t>(
-          Parallel::my_node(*Parallel::local_branch(my_proxy)));
+      const auto node_id =
+          Parallel::my_node<size_t>(*Parallel::local_branch(my_proxy));
       db::mutate<Tags::ExpectedContributorsForObservations>(
           make_not_null(&box),
           [&cache, &id_of_caller, &node_id, &observation_key](

--- a/src/IO/Observer/Actions/RegisterSingleton.hpp
+++ b/src/IO/Observer/Actions/RegisterSingleton.hpp
@@ -61,8 +61,7 @@ struct RegisterSingletonWithObserverWriter {
     Parallel::simple_action<Actions::RegisterReductionNodeWithWritingNode>(
         Parallel::get_parallel_component<
             observers::ObserverWriter<Metavariables>>(cache)[0],
-        observation_key,
-        static_cast<size_t>(Parallel::my_node(*Parallel::local(my_proxy))));
+        observation_key, Parallel::my_node<size_t>(*Parallel::local(my_proxy)));
     return {std::move(box), true};
   }
 };

--- a/src/IO/Observer/ReductionActions.hpp
+++ b/src/IO/Observer/ReductionActions.hpp
@@ -194,7 +194,7 @@ struct ContributeReductionData {
               auto& my_proxy =
                   Parallel::get_parallel_component<ParallelComponent>(cache);
               const std::optional<int> observe_with_core_id =
-                  observe_per_core ? std::make_optional(Parallel::my_proc(
+                  observe_per_core ? std::make_optional(Parallel::my_proc<int>(
                                          *Parallel::local_branch(my_proxy)))
                                    : std::nullopt;
               Parallel::threaded_action<
@@ -394,7 +394,7 @@ struct CollectReductionDataOnNode {
             std::move(reduction_data_this_core.data()),
             Parallel::get<Tags::ReductionFileName>(cache) +
                 std::to_string(
-                    Parallel::my_node(*Parallel::local_branch(my_proxy))),
+                    Parallel::my_node<int>(*Parallel::local_branch(my_proxy))),
             std::make_index_sequence<sizeof...(ReductionDatums)>{});
         reduction_file_lock->unlock();
       }
@@ -456,8 +456,7 @@ struct CollectReductionDataOnNode {
             Parallel::get_parallel_component<ObserverWriter<Metavariables>>(
                 cache)[0],
             observation_id,
-            static_cast<size_t>(
-                Parallel::my_node(*Parallel::local_branch(my_proxy))),
+            Parallel::my_node<size_t>(*Parallel::local_branch(my_proxy)),
             subfile_name,
             // NOLINTNEXTLINE(bugprone-use-after-move)
             std::move(reduction_names), std::move(received_reduction_data),

--- a/src/IO/Observer/VolumeActions.hpp
+++ b/src/IO/Observer/VolumeActions.hpp
@@ -310,8 +310,8 @@ struct ContributeVolumeDataToWriter {
               Parallel::get_parallel_component<ParallelComponent>(cache);
           h5::H5File<h5::AccessType::ReadWrite> h5file(
               file_prefix +
-                  std::to_string(
-                      Parallel::my_node(*Parallel::local_branch(my_proxy))) +
+                  std::to_string(Parallel::my_node<int>(
+                      *Parallel::local_branch(my_proxy))) +
                   ".h5",
               true);
           constexpr size_t version_number = 0;

--- a/src/IO/Observer/WriteSimpleData.hpp
+++ b/src/IO/Observer/WriteSimpleData.hpp
@@ -59,7 +59,7 @@ struct WriteSimpleData {
       h5::H5File<h5::AccessType::ReadWrite> h5file(
           file_prefix +
               std::to_string(
-                  Parallel::my_node(*Parallel::local_branch(my_proxy))) +
+                  Parallel::my_node<int>(*Parallel::local_branch(my_proxy))) +
               ".h5",
           true);
       const size_t version_number = 0;

--- a/src/Parallel/Info.hpp
+++ b/src/Parallel/Info.hpp
@@ -7,12 +7,14 @@
 
 #pragma once
 
+#include <cstddef>
+
 /// Functionality for parallelization.
 ///
 /// The functions in namespace `Parallel` that return information on
 /// nodes and cores are templated on DistribObject.  Actions should
 /// use these functions rather than the raw charm++ versions (in the
-/// sys namespace in Utilities/System/ParalleInfo.hpp) so that the
+/// sys namespace in Utilities/System/ParallelInfo.hpp) so that the
 /// mocking framework will see the mocked cores and nodes.
 namespace Parallel {
 
@@ -20,46 +22,46 @@ namespace Parallel {
  * \ingroup ParallelGroup
  * \brief Number of processing elements.
  */
-template <typename DistribObject>
-int number_of_procs(const DistribObject& distributed_object) {
-  return distributed_object.number_of_procs();
+template <typename T, typename DistribObject>
+T number_of_procs(const DistribObject& distributed_object) {
+  return static_cast<T>(distributed_object.number_of_procs());
 }
 
 /*!
  * \ingroup ParallelGroup
  * \brief %Index of my processing element.
  */
-template <typename DistribObject>
-int my_proc(const DistribObject& distributed_object) {
-  return distributed_object.my_proc();
+template <typename T, typename DistribObject>
+T my_proc(const DistribObject& distributed_object) {
+  return static_cast<T>(distributed_object.my_proc());
 }
 
 /*!
  * \ingroup ParallelGroup
  * \brief Number of nodes.
  */
-template <typename DistribObject>
-int number_of_nodes(const DistribObject& distributed_object) {
-  return distributed_object.number_of_nodes();
+template <typename T, typename DistribObject>
+T number_of_nodes(const DistribObject& distributed_object) {
+  return static_cast<T>(distributed_object.number_of_nodes());
 }
 
- /*!
-  * \ingroup ParallelGroup
-  * \brief %Index of my node.
-  */
-template <typename DistribObject>
-int my_node(const DistribObject& distributed_object) {
-  return distributed_object.my_node();
+/*!
+ * \ingroup ParallelGroup
+ * \brief %Index of my node.
+ */
+template <typename T, typename DistribObject>
+T my_node(const DistribObject& distributed_object) {
+  return static_cast<T>(distributed_object.my_node());
 }
 
 /*!
  * \ingroup ParallelGroup
  * \brief Number of processing elements on the given node.
  */
-template <typename DistribObject>
-int procs_on_node(const int node_index,
-                  const DistribObject& distributed_object) {
-  return distributed_object.procs_on_node(node_index);
+template <typename T, typename R, typename DistribObject>
+T procs_on_node(const R node_index, const DistribObject& distributed_object) {
+  return static_cast<T>(
+      distributed_object.procs_on_node(static_cast<int>(node_index)));
 }
 
 /*!
@@ -67,38 +69,39 @@ int procs_on_node(const int node_index,
  * \brief The local index of my processing element on my node.
  * This is in the interval 0, ..., procs_on_node(my_node()) - 1.
  */
-template <typename DistribObject>
-int my_local_rank(const DistribObject& distributed_object) {
-  return distributed_object.my_local_rank();
+template <typename T, typename DistribObject>
+T my_local_rank(const DistribObject& distributed_object) {
+  return static_cast<T>(distributed_object.my_local_rank());
 }
 
 /*!
  * \ingroup ParallelGroup
  * \brief %Index of first processing element on the given node.
  */
-template <typename DistribObject>
-int first_proc_on_node(const int node_index,
-                       const DistribObject& distributed_object) {
-  return distributed_object.first_proc_on_node(node_index);
+template <typename T, typename R, typename DistribObject>
+T first_proc_on_node(const R node_index,
+                     const DistribObject& distributed_object) {
+  return static_cast<T>(
+      distributed_object.first_proc_on_node(static_cast<int>(node_index)));
 }
 
 /*!
  * \ingroup ParallelGroup
  * \brief %Index of the node for the given processing element.
  */
-template <typename DistribObject>
-int node_of(const int proc_index, const DistribObject& distributed_object) {
-  return distributed_object.node_of(proc_index);
+template <typename T, typename R, typename DistribObject>
+T node_of(const R proc_index, const DistribObject& distributed_object) {
+  return static_cast<T>(
+      distributed_object.node_of(static_cast<int>(proc_index)));
 }
 
 /*!
  * \ingroup ParallelGroup
  * \brief The local index for the given processing element on its node.
  */
-template <typename DistribObject>
-int local_rank_of(const int proc_index,
-                  const DistribObject& distributed_object) {
-  return distributed_object.local_rank_of(proc_index);
+template <typename T, typename R, typename DistribObject>
+T local_rank_of(const R proc_index, const DistribObject& distributed_object) {
+  return static_cast<T>(
+      distributed_object.local_rank_of(static_cast<int>(proc_index)));
 }
-
 }  // namespace Parallel

--- a/src/ParallelAlgorithms/Actions/MemoryMonitor/ContributeMemoryData.hpp
+++ b/src/ParallelAlgorithms/Actions/MemoryMonitor/ContributeMemoryData.hpp
@@ -91,12 +91,11 @@ struct ContributeMemoryData {
             constexpr bool is_group =
                 Parallel::is_group_v<ContributingComponent>;
 
-            const int num_nodes =
-                Parallel::number_of_nodes(*Parallel::local(mem_monitor_proxy));
-            const int num_procs =
-                Parallel::number_of_procs(*Parallel::local(mem_monitor_proxy));
-            const size_t expected_number =
-                static_cast<size_t>(is_group ? num_procs : num_nodes);
+            const size_t num_nodes = Parallel::number_of_nodes<size_t>(
+                *Parallel::local(mem_monitor_proxy));
+            const size_t num_procs = Parallel::number_of_procs<size_t>(
+                *Parallel::local(mem_monitor_proxy));
+            const size_t expected_number = is_group ? num_procs : num_nodes;
             ASSERT(memory_holder.at(time).size() <= expected_number,
                    "ContributeMemoryData received more data than it was "
                    "expecting. Was expecting "
@@ -114,14 +113,14 @@ struct ContributeMemoryData {
               double avg_size_per_node = 0.0;
               double max_usage_on_proc = -std::numeric_limits<double>::max();
               int proc_of_max = 0;
-              for (int node = 0; node < num_nodes; node++) {
+              for (size_t node = 0; node < num_nodes; node++) {
                 double size_on_node = 0.0;
                 if (not is_group) {
                   size_on_node = memory_holder.at(time).at(node);
                 } else {
-                  const int first_proc = Parallel::first_proc_on_node(
+                  const int first_proc = Parallel::first_proc_on_node<int>(
                       node, *Parallel::local(mem_monitor_proxy));
-                  const int procs_on_node = Parallel::procs_on_node(
+                  const int procs_on_node = Parallel::procs_on_node<int>(
                       node, *Parallel::local(mem_monitor_proxy));
                   const int last_proc = first_proc + procs_on_node;
                   for (int proc = first_proc; proc < last_proc; proc++) {

--- a/src/ParallelAlgorithms/Actions/MemoryMonitor/ProcessSingleton.hpp
+++ b/src/ParallelAlgorithms/Actions/MemoryMonitor/ProcessSingleton.hpp
@@ -54,9 +54,9 @@ struct ProcessSingleton {
         observers::ThreadedActions::WriteReductionDataRow>(
         // Node 0 is always the writer
         observer_writer_proxy[0], subfile_name<ParallelComponent>(), legend,
-        std::make_tuple(time,
-                        Parallel::my_proc(*Parallel::local(singleton_proxy)),
-                        size_in_MB));
+        std::make_tuple(
+            time, Parallel::my_proc<size_t>(*Parallel::local(singleton_proxy)),
+            size_in_MB));
   }
 };
 }  // namespace mem_monitor

--- a/tests/Unit/Parallel/Test_AlgorithmGlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmGlobalCache.cpp
@@ -329,20 +329,21 @@ struct CheckParallelInfo {
       SPECTRE_PARALLEL_REQUIRE(cache.my_node() == sys::my_node());
       SPECTRE_PARALLEL_REQUIRE(cache.my_local_rank() == sys::my_local_rank());
       // const auto& const_cache = *Parallel::local_branch(global_cache_proxy_);
-      SPECTRE_PARALLEL_REQUIRE(Parallel::number_of_procs(cache) ==
+      SPECTRE_PARALLEL_REQUIRE(Parallel::number_of_procs<int>(cache) ==
                                sys::number_of_procs());
-      SPECTRE_PARALLEL_REQUIRE(Parallel::number_of_nodes(cache) ==
+      SPECTRE_PARALLEL_REQUIRE(Parallel::number_of_nodes<int>(cache) ==
                                sys::number_of_nodes());
-      SPECTRE_PARALLEL_REQUIRE(Parallel::procs_on_node(0, cache) ==
+      SPECTRE_PARALLEL_REQUIRE(Parallel::procs_on_node<int>(0, cache) ==
                                sys::procs_on_node(0));
-      SPECTRE_PARALLEL_REQUIRE(Parallel::first_proc_on_node(0, cache) ==
+      SPECTRE_PARALLEL_REQUIRE(Parallel::first_proc_on_node<int>(0, cache) ==
                                sys::first_proc_on_node(0));
-      SPECTRE_PARALLEL_REQUIRE(Parallel::node_of(0, cache) == sys::node_of(0));
-      SPECTRE_PARALLEL_REQUIRE(Parallel::local_rank_of(0, cache) ==
+      SPECTRE_PARALLEL_REQUIRE(Parallel::node_of<int>(0, cache) ==
+                               sys::node_of(0));
+      SPECTRE_PARALLEL_REQUIRE(Parallel::local_rank_of<int>(0, cache) ==
                                sys::local_rank_of(0));
-      SPECTRE_PARALLEL_REQUIRE(Parallel::my_proc(cache) == sys::my_proc());
-      SPECTRE_PARALLEL_REQUIRE(Parallel::my_node(cache) == sys::my_node());
-      SPECTRE_PARALLEL_REQUIRE(Parallel::my_local_rank(cache) ==
+      SPECTRE_PARALLEL_REQUIRE(Parallel::my_proc<int>(cache) == sys::my_proc());
+      SPECTRE_PARALLEL_REQUIRE(Parallel::my_node<int>(cache) == sys::my_node());
+      SPECTRE_PARALLEL_REQUIRE(Parallel::my_local_rank<int>(cache) ==
                                sys::my_local_rank());
     }
   }


### PR DESCRIPTION
## Proposed changes

I've needed parallel info (like number of nodes) as `size_t` rather than `int` many times and always having to `static_cast` was starting to become a hassle. Templates these functions on the return type.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
When using any parallel info functions (`Parallel::my_node`, etc...), you must specify the return type as a template parameter.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
