### PR TITLE
CCE preliminaries for GH+CCE executable

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
@@ -65,6 +65,11 @@ class TaggedTuple;
 /// \endcond
 
 namespace evolution::dg::Actions {
+namespace detail {
+CREATE_HAS_TYPE_ALIAS(dg_step_choosers)
+CREATE_HAS_TYPE_ALIAS_V(dg_step_choosers)
+CREATE_GET_TYPE_ALIAS_OR_DEFAULT(dg_step_choosers)
+}  // namespace detail
 /*!
  * \brief Computes the time derivative for a DG time step.
  *
@@ -453,7 +458,9 @@ ComputeTimeDerivative<Metavariables>::apply(
       });
 
   if constexpr (Metavariables::local_time_stepping) {
-    take_step(make_not_null(&box), cache);
+    take_step<detail::get_dg_step_choosers_or_default_t<Metavariables,
+                                                        AllStepChoosers>>(
+        make_not_null(&box), cache);
   }
 
   send_data_for_fluxes<ParallelComponent>(make_not_null(&cache),

--- a/src/Evolution/Executables/Cce/CharacteristicExtract.hpp
+++ b/src/Evolution/Executables/Cce/CharacteristicExtract.hpp
@@ -139,6 +139,13 @@ struct EvolutionMetavars {
                          tmpl::list<Cce::Tags::CauchyAngularCoords,
                                     Cce::Tags::PartiallyFlatAngularCoords>,
                          tmpl::list<Cce::Tags::CauchyAngularCoords>>;
+  using cce_step_choosers = tmpl::list<
+      StepChoosers::Constant<StepChooserUse::LtsStep>,
+      StepChoosers::Increase<StepChooserUse::LtsStep>,
+      StepChoosers::ErrorControl<Tags::Variables<tmpl::list<evolved_swsh_tag>>,
+                                 swsh_vars_selector>,
+      StepChoosers::ErrorControl<evolved_coordinates_variables_tag,
+                                 coord_vars_selector>>;
 
   using cce_boundary_component = BoundaryComponent<EvolutionMetavars>;
 

--- a/src/Evolution/Executables/Cce/CharacteristicExtract.hpp
+++ b/src/Evolution/Executables/Cce/CharacteristicExtract.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "Evolution/Executables/Cce/CharacteristicExtractBase.hpp"
 #include "Evolution/Systems/Cce/AnalyticSolutions/BouncingBlackHole.hpp"
 #include "Evolution/Systems/Cce/AnalyticSolutions/GaugeWave.hpp"
 #include "Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachs.hpp"
@@ -35,9 +36,7 @@
 #include "Parallel/Algorithms/AlgorithmSingleton.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
-#include "Time/StepChoosers/ErrorControl.hpp"
 #include "Time/StepChoosers/Factory.hpp"
-#include "Time/StepChoosers/Increase.hpp"
 #include "Time/StepControllers/Factory.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/Factory.hpp"
@@ -54,99 +53,8 @@ class er;
 /// \endcond
 
 template <template <typename> class BoundaryComponent>
-struct EvolutionMetavars {
-  static constexpr bool uses_partially_flat_cartesian_coordinates = false;
-  using system = Cce::System<uses_partially_flat_cartesian_coordinates>;
+struct EvolutionMetavars : CharacteristicExtractDefaults {
   static constexpr bool local_time_stepping = true;
-
-  using evolved_swsh_tag = Cce::Tags::BondiJ;
-  using evolved_swsh_dt_tag = Cce::Tags::BondiH;
-  using evolved_coordinates_variables_tag = Tags::Variables<
-      std::conditional_t<uses_partially_flat_cartesian_coordinates,
-                         tmpl::list<Cce::Tags::CauchyCartesianCoords,
-                                    Cce::Tags::PartiallyFlatCartesianCoords,
-                                    Cce::Tags::InertialRetardedTime>,
-                         tmpl::list<Cce::Tags::CauchyCartesianCoords,
-                                    Cce::Tags::InertialRetardedTime>>>;
-
-  struct swsh_vars_selector {
-    static std::string name() { return "SwshVars"; }
-  };
-
-  struct coord_vars_selector {
-    static std::string name() { return "CoordVars"; }
-  };
-
-  using cce_boundary_communication_tags =
-      Cce::Tags::characteristic_worldtube_boundary_tags<
-          Cce::Tags::BoundaryValue>;
-
-  using cce_gauge_boundary_tags = tmpl::flatten<tmpl::list<
-      tmpl::transform<
-          tmpl::list<Cce::Tags::BondiR, Cce::Tags::DuRDividedByR,
-                     Cce::Tags::BondiJ, Cce::Tags::Dr<Cce::Tags::BondiJ>,
-                     Cce::Tags::BondiBeta, Cce::Tags::BondiQ, Cce::Tags::BondiU,
-                     Cce::Tags::BondiW, Cce::Tags::BondiH>,
-          tmpl::bind<Cce::Tags::EvolutionGaugeBoundaryValue, tmpl::_1>>,
-      Cce::Tags::BondiUAtScri, Cce::Tags::PartiallyFlatGaugeC,
-      Cce::Tags::PartiallyFlatGaugeD, Cce::Tags::PartiallyFlatGaugeOmega,
-      Cce::Tags::Du<Cce::Tags::PartiallyFlatGaugeOmega>,
-      std::conditional_t<
-          uses_partially_flat_cartesian_coordinates,
-          tmpl::list<
-              Cce::Tags::CauchyGaugeC, Cce::Tags::CauchyGaugeD,
-              Cce::Tags::CauchyGaugeOmega,
-              Spectral::Swsh::Tags::Derivative<Cce::Tags::CauchyGaugeOmega,
-                                               Spectral::Swsh::Tags::Eth>>,
-          tmpl::list<>>,
-      Spectral::Swsh::Tags::Derivative<Cce::Tags::PartiallyFlatGaugeOmega,
-                                       Spectral::Swsh::Tags::Eth>,
-      Cce::all_boundary_pre_swsh_derivative_tags_for_scri,
-      Cce::all_boundary_swsh_derivative_tags_for_scri>>;
-
-  using scri_values_to_observe =
-      tmpl::list<Cce::Tags::News, Cce::Tags::ScriPlus<Cce::Tags::Strain>,
-                 Cce::Tags::ScriPlus<Cce::Tags::Psi3>,
-                 Cce::Tags::ScriPlus<Cce::Tags::Psi2>,
-                 Cce::Tags::ScriPlus<Cce::Tags::Psi1>,
-                 Cce::Tags::ScriPlus<Cce::Tags::Psi0>,
-                 Cce::Tags::Du<Cce::Tags::TimeIntegral<
-                     Cce::Tags::ScriPlus<Cce::Tags::Psi4>>>,
-                 Cce::Tags::EthInertialRetardedTime>;
-
-  using cce_scri_tags =
-      tmpl::list<Cce::Tags::News, Cce::Tags::ScriPlus<Cce::Tags::Strain>,
-                 Cce::Tags::ScriPlus<Cce::Tags::Psi3>,
-                 Cce::Tags::ScriPlus<Cce::Tags::Psi2>,
-                 Cce::Tags::ScriPlus<Cce::Tags::Psi1>,
-                 Cce::Tags::ScriPlus<Cce::Tags::Psi0>,
-                 Cce::Tags::TimeIntegral<Cce::Tags::ScriPlus<Cce::Tags::Psi4>>,
-                 Cce::Tags::EthInertialRetardedTime>;
-  using cce_integrand_tags = tmpl::flatten<tmpl::transform<
-      Cce::bondi_hypersurface_step_tags,
-      tmpl::bind<Cce::integrand_terms_to_compute_for_bondi_variable,
-                 tmpl::_1>>>;
-  using cce_integration_independent_tags =
-      tmpl::push_back<Cce::pre_computation_tags, Cce::Tags::DuRDividedByR>;
-  using cce_temporary_equations_tags = tmpl::remove_duplicates<tmpl::flatten<
-      tmpl::transform<cce_integrand_tags,
-                      tmpl::bind<Cce::integrand_temporary_tags, tmpl::_1>>>>;
-  using cce_pre_swsh_derivatives_tags = Cce::all_pre_swsh_derivative_tags;
-  using cce_transform_buffer_tags = Cce::all_transform_buffer_tags;
-  using cce_swsh_derivative_tags = Cce::all_swsh_derivative_tags;
-  using cce_angular_coordinate_tags =
-      std::conditional_t<uses_partially_flat_cartesian_coordinates,
-                         tmpl::list<Cce::Tags::CauchyAngularCoords,
-                                    Cce::Tags::PartiallyFlatAngularCoords>,
-                         tmpl::list<Cce::Tags::CauchyAngularCoords>>;
-  using cce_step_choosers = tmpl::list<
-      StepChoosers::Constant<StepChooserUse::LtsStep>,
-      StepChoosers::Increase<StepChooserUse::LtsStep>,
-      StepChoosers::ErrorControl<Tags::Variables<tmpl::list<evolved_swsh_tag>>,
-                                 swsh_vars_selector>,
-      StepChoosers::ErrorControl<evolved_coordinates_variables_tag,
-                                 coord_vars_selector>>;
-
   using cce_boundary_component = BoundaryComponent<EvolutionMetavars>;
 
   using component_list =
@@ -158,15 +66,7 @@ struct EvolutionMetavars {
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes = tmpl::map<
         tmpl::pair<LtsTimeStepper, TimeSteppers::lts_time_steppers>,
-        tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
-                   tmpl::list<StepChoosers::Constant<StepChooserUse::LtsStep>,
-                              StepChoosers::Increase<StepChooserUse::LtsStep>,
-                              StepChoosers::ErrorControl<
-                                  Tags::Variables<tmpl::list<evolved_swsh_tag>>,
-                                  swsh_vars_selector>,
-                              StepChoosers::ErrorControl<
-                                  evolved_coordinates_variables_tag,
-                                  coord_vars_selector>>>,
+        tmpl::pair<StepChooser<StepChooserUse::LtsStep>, cce_step_choosers>,
         tmpl::pair<StepController, StepControllers::standard_step_controllers>,
         tmpl::pair<TimeSequence<double>,
                    TimeSequences::all_time_sequences<double>>,

--- a/src/Evolution/Executables/Cce/CharacteristicExtractBase.hpp
+++ b/src/Evolution/Executables/Cce/CharacteristicExtractBase.hpp
@@ -1,0 +1,110 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <string>
+#include <type_traits>
+
+#include "DataStructures/VariablesTag.hpp"
+#include "Evolution/Systems/Cce/BoundaryData.hpp"
+#include "Evolution/Systems/Cce/IntegrandInputSteps.hpp"
+#include "Evolution/Systems/Cce/System.hpp"
+#include "Evolution/Systems/Cce/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/SwshTags.hpp"
+#include "Time/StepChoosers/Constant.hpp"
+#include "Time/StepChoosers/ErrorControl.hpp"
+#include "Time/StepChoosers/Increase.hpp"
+#include "Utilities/TMPL.hpp"
+
+struct CharacteristicExtractDefaults {
+  static constexpr bool uses_partially_flat_cartesian_coordinates = false;
+  using system = Cce::System<uses_partially_flat_cartesian_coordinates>;
+  using evolved_swsh_tag = Cce::Tags::BondiJ;
+  using evolved_swsh_dt_tag = Cce::Tags::BondiH;
+  using evolved_coordinates_variables_tag = Tags::Variables<
+      std::conditional_t<uses_partially_flat_cartesian_coordinates,
+                         tmpl::list<Cce::Tags::CauchyCartesianCoords,
+                                    Cce::Tags::PartiallyFlatCartesianCoords,
+                                    Cce::Tags::InertialRetardedTime>,
+                         tmpl::list<Cce::Tags::CauchyCartesianCoords,
+                                    Cce::Tags::InertialRetardedTime>>>;
+
+  struct swsh_vars_selector {
+    static std::string name() { return "SwshVars"; }
+  };
+
+  struct coord_vars_selector {
+    static std::string name() { return "CoordVars"; }
+  };
+
+  using cce_boundary_communication_tags =
+      Cce::Tags::characteristic_worldtube_boundary_tags<
+          Cce::Tags::BoundaryValue>;
+
+  using cce_gauge_boundary_tags = tmpl::flatten<tmpl::list<
+      tmpl::transform<
+          tmpl::list<Cce::Tags::BondiR, Cce::Tags::DuRDividedByR,
+                     Cce::Tags::BondiJ, Cce::Tags::Dr<Cce::Tags::BondiJ>,
+                     Cce::Tags::BondiBeta, Cce::Tags::BondiQ, Cce::Tags::BondiU,
+                     Cce::Tags::BondiW, Cce::Tags::BondiH>,
+          tmpl::bind<Cce::Tags::EvolutionGaugeBoundaryValue, tmpl::_1>>,
+      Cce::Tags::BondiUAtScri, Cce::Tags::PartiallyFlatGaugeC,
+      Cce::Tags::PartiallyFlatGaugeD, Cce::Tags::PartiallyFlatGaugeOmega,
+      Cce::Tags::Du<Cce::Tags::PartiallyFlatGaugeOmega>,
+      std::conditional_t<
+          uses_partially_flat_cartesian_coordinates,
+          tmpl::list<
+              Cce::Tags::CauchyGaugeC, Cce::Tags::CauchyGaugeD,
+              Cce::Tags::CauchyGaugeOmega,
+              Spectral::Swsh::Tags::Derivative<Cce::Tags::CauchyGaugeOmega,
+                                               Spectral::Swsh::Tags::Eth>>,
+          tmpl::list<>>,
+      Spectral::Swsh::Tags::Derivative<Cce::Tags::PartiallyFlatGaugeOmega,
+                                       Spectral::Swsh::Tags::Eth>,
+      Cce::all_boundary_pre_swsh_derivative_tags_for_scri,
+      Cce::all_boundary_swsh_derivative_tags_for_scri>>;
+
+  using scri_values_to_observe =
+      tmpl::list<Cce::Tags::News, Cce::Tags::ScriPlus<Cce::Tags::Strain>,
+                 Cce::Tags::ScriPlus<Cce::Tags::Psi3>,
+                 Cce::Tags::ScriPlus<Cce::Tags::Psi2>,
+                 Cce::Tags::ScriPlus<Cce::Tags::Psi1>,
+                 Cce::Tags::ScriPlus<Cce::Tags::Psi0>,
+                 Cce::Tags::Du<Cce::Tags::TimeIntegral<
+                     Cce::Tags::ScriPlus<Cce::Tags::Psi4>>>,
+                 Cce::Tags::EthInertialRetardedTime>;
+
+  using cce_scri_tags =
+      tmpl::list<Cce::Tags::News, Cce::Tags::ScriPlus<Cce::Tags::Strain>,
+                 Cce::Tags::ScriPlus<Cce::Tags::Psi3>,
+                 Cce::Tags::ScriPlus<Cce::Tags::Psi2>,
+                 Cce::Tags::ScriPlus<Cce::Tags::Psi1>,
+                 Cce::Tags::ScriPlus<Cce::Tags::Psi0>,
+                 Cce::Tags::TimeIntegral<Cce::Tags::ScriPlus<Cce::Tags::Psi4>>,
+                 Cce::Tags::EthInertialRetardedTime>;
+  using cce_integrand_tags = tmpl::flatten<tmpl::transform<
+      Cce::bondi_hypersurface_step_tags,
+      tmpl::bind<Cce::integrand_terms_to_compute_for_bondi_variable,
+                 tmpl::_1>>>;
+  using cce_integration_independent_tags =
+      tmpl::push_back<Cce::pre_computation_tags, Cce::Tags::DuRDividedByR>;
+  using cce_temporary_equations_tags = tmpl::remove_duplicates<tmpl::flatten<
+      tmpl::transform<cce_integrand_tags,
+                      tmpl::bind<Cce::integrand_temporary_tags, tmpl::_1>>>>;
+  using cce_pre_swsh_derivatives_tags = Cce::all_pre_swsh_derivative_tags;
+  using cce_transform_buffer_tags = Cce::all_transform_buffer_tags;
+  using cce_swsh_derivative_tags = Cce::all_swsh_derivative_tags;
+  using cce_angular_coordinate_tags =
+      std::conditional_t<uses_partially_flat_cartesian_coordinates,
+                         tmpl::list<Cce::Tags::CauchyAngularCoords,
+                                    Cce::Tags::PartiallyFlatAngularCoords>,
+                         tmpl::list<Cce::Tags::CauchyAngularCoords>>;
+  using cce_step_choosers = tmpl::list<
+      StepChoosers::Constant<StepChooserUse::LtsStep>,
+      StepChoosers::Increase<StepChooserUse::LtsStep>,
+      StepChoosers::ErrorControl<Tags::Variables<tmpl::list<evolved_swsh_tag>>,
+                                 swsh_vars_selector>,
+      StepChoosers::ErrorControl<evolved_coordinates_variables_tag,
+                                 coord_vars_selector>>;
+};

--- a/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
@@ -62,24 +62,15 @@ namespace Actions {
 template <typename EvolvedCoordinatesVariablesTag, typename EvolvedSwshTag,
           bool local_time_stepping>
 struct InitializeCharacteristicEvolutionTime {
-  using initialization_tags_to_keep =
-      tmpl::flatten<tmpl::list<tmpl::conditional_t<
-          local_time_stepping,
-          tmpl::list<
-              ::Tags::IsUsingTimeSteppingErrorControl<
-                  OptionTags::CceEvolutionPrefix>,
-              Tags::CceEvolutionPrefix<::Tags::TimeStepper<LtsTimeStepper>>,
-              Tags::CceEvolutionPrefix<::Tags::StepChoosers>,
-              Tags::CceEvolutionPrefix<::Tags::StepController>,
-              ::Initialization::Tags::InitialTimeDelta>,
-          tmpl::list<
-              ::Tags::NeverUsingTimeSteppingErrorControl,
-              Tags::CceEvolutionPrefix<::Tags::TimeStepper<TimeStepper>>>>>>;
+  using initialization_tags_to_keep = tmpl::flatten<tmpl::list<
+      Initialization::Tags::InitialSlabSize<local_time_stepping>,
+      ::Tags::IsUsingTimeSteppingErrorControl<OptionTags::CceEvolutionPrefix>,
+      Tags::CceEvolutionPrefix<::Tags::TimeStepper<LtsTimeStepper>>,
+      Tags::CceEvolutionPrefix<::Tags::StepChoosers>,
+      Tags::CceEvolutionPrefix<::Tags::StepController>,
+      ::Initialization::Tags::InitialTimeDelta>>;
 
-  using initialization_tags = tmpl::push_front<
-      initialization_tags_to_keep,
-      Tags::CceEvolutionPrefix<
-          Initialization::Tags::InitialSlabSize<local_time_stepping>>>;
+  using initialization_tags = initialization_tags_to_keep;
 
   using const_global_cache_tags = tmpl::list<>;
 
@@ -111,14 +102,15 @@ struct InitializeCharacteristicEvolutionTime {
                                 initial_time_value + slab_size};
     const Time initial_time = single_step_slab.start();
     TimeDelta initial_time_step;
+    const double initial_time_delta =
+        db::get<Initialization::Tags::InitialTimeDelta>(box);
     if constexpr (local_time_stepping) {
-      const double initial_time_delta =
-          db::get<Initialization::Tags::InitialTimeDelta>(box);
       initial_time_step =
           db::get<Tags::CceEvolutionPrefix<::Tags::StepController>>(box)
               .choose_step(initial_time, initial_time_delta);
     } else {
-      initial_time_step = TimeDelta{initial_time.slab().duration()};
+      (void)initial_time_delta;
+      initial_time_step = initial_time.slab().duration();
     }
 
     const auto& time_stepper = db::get<::Tags::TimeStepper<>>(box);

--- a/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionVariables.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionVariables.hpp
@@ -24,6 +24,12 @@ namespace Cce {
 /// \brief The set of actions for use in the CCE evolution system
 namespace Actions {
 
+namespace detail {
+CREATE_HAS_TYPE_ALIAS(compute_tags)
+CREATE_HAS_TYPE_ALIAS_V(compute_tags)
+CREATE_GET_TYPE_ALIAS_OR_DEFAULT(compute_tags)
+}  // namespace detail
+
 /*!
  * \ingroup ActionsGroup
  * \brief Initializes the main data storage for the  `CharacteristicEvolution`
@@ -113,7 +119,10 @@ struct InitializeCharacteristicEvolutionVariables {
       tmpl::append<StepChoosers::step_chooser_simple_tags<Metavariables>,
                    simple_tags_for_evolution>;
 
-  using compute_tags = StepChoosers::step_chooser_compute_tags<Metavariables>;
+  using compute_tags = tmpl::remove_duplicates<tmpl::join<
+      tmpl::transform<typename Metavariables::cce_step_choosers,
+                      tmpl::bind<detail::get_compute_tags_or_default_t,
+                                 tmpl::_1, tmpl::pin<tmpl::list<>>>>>>;
 
   template <typename DbTags, typename... InboxTags, typename ArrayIndex,
             typename ActionList, typename ParallelComponent>

--- a/src/Evolution/Systems/Cce/Actions/ReceiveWorldtubeData.hpp
+++ b/src/Evolution/Systems/Cce/Actions/ReceiveWorldtubeData.hpp
@@ -51,15 +51,16 @@ struct ReceiveWorldtubeData {
               Cce::ReceiveTags::BoundaryData<
                   typename Metavariables::cce_boundary_communication_tags>> and
           tmpl::list_contains_v<DbTags, ::Tags::TimeStepId>> = nullptr>
-  static std::tuple<db::DataBox<DbTags>&&, Parallel::AlgorithmExecution> apply(
-      db::DataBox<DbTags>& box, tuples::TaggedTuple<InboxTags...>& inboxes,
-      const Parallel::GlobalCache<Metavariables>& /*cache*/,
-      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
-      const ParallelComponent* const /*meta*/) {
+  static std::tuple<db::DataBox<DbTags>&&, Parallel::AlgorithmExecution, size_t>
+  apply(db::DataBox<DbTags>& box, tuples::TaggedTuple<InboxTags...>& inboxes,
+        const Parallel::GlobalCache<Metavariables>& /*cache*/,
+        const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+        const ParallelComponent* const /*meta*/) {
     auto& inbox = tuples::get<Cce::ReceiveTags::BoundaryData<
         typename Metavariables::cce_boundary_communication_tags>>(inboxes);
     if (inbox.count(db::get<::Tags::TimeStepId>(box)) != 1) {
-      return {std::move(box), Parallel::AlgorithmExecution::Retry};
+      return {std::move(box), Parallel::AlgorithmExecution::Pause,
+              tmpl::index_of<ActionList, ReceiveWorldtubeData>::value};
     }
 
     tmpl::for_each<typename Metavariables::cce_boundary_communication_tags>(
@@ -74,7 +75,8 @@ struct ReceiveWorldtubeData {
               db::get<::Tags::TimeStepId>(box));
         });
     inbox.erase(db::get<::Tags::TimeStepId>(box));
-    return {std::move(box), Parallel::AlgorithmExecution::Continue};
+    return {std::move(box), Parallel::AlgorithmExecution::Continue,
+            tmpl::index_of<ActionList, ReceiveWorldtubeData>::value + 1};
   }
   template <
       typename DbTags, typename... InboxTags, typename ArrayIndex,

--- a/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
@@ -195,10 +195,10 @@ struct CharacteristicEvolution {
       Actions::RequestBoundaryData<
           typename Metavariables::cce_boundary_component,
           CharacteristicEvolution<Metavariables>>,
+      ::Actions::Label<CceEvolutionLabelTag>,
       Actions::ReceiveWorldtubeData<Metavariables>,
       Actions::InitializeFirstHypersurface<
           Metavariables::uses_partially_flat_cartesian_coordinates>,
-      ::Actions::Label<CceEvolutionLabelTag>,
       Actions::UpdateGauge<
           Metavariables::uses_partially_flat_cartesian_coordinates>,
       Actions::PrecomputeGlobalCceDependencies,
@@ -213,7 +213,6 @@ struct CharacteristicEvolution {
           typename Metavariables::cce_boundary_component,
           CharacteristicEvolution<Metavariables>>,
       ::Actions::AdvanceTime, Actions::ExitIfEndTimeReached,
-      Actions::ReceiveWorldtubeData<Metavariables>,
       ::Actions::Goto<CceEvolutionLabelTag>>;
 
   using phase_dependent_action_list = tmpl::list<

--- a/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
@@ -206,7 +206,7 @@ struct CharacteristicEvolution {
                       tmpl::bind<hypersurface_computation, tmpl::_1>>,
       Actions::FilterSwshVolumeQuantity<Tags::BondiH>,
       compute_scri_quantities_and_observe, record_time_stepper_data_and_step,
-      ::Actions::ChangeStepSize,
+      ::Actions::ChangeStepSize<>,
       // We cannot know our next step for certain until after we've performed
       // step size selection, as we may need to reject a step.
       Actions::RequestNextBoundaryData<

--- a/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
@@ -206,7 +206,7 @@ struct CharacteristicEvolution {
                       tmpl::bind<hypersurface_computation, tmpl::_1>>,
       Actions::FilterSwshVolumeQuantity<Tags::BondiH>,
       compute_scri_quantities_and_observe, record_time_stepper_data_and_step,
-      ::Actions::ChangeStepSize<>,
+      ::Actions::ChangeStepSize<typename Metavariables::cce_step_choosers>,
       // We cannot know our next step for certain until after we've performed
       // step size selection, as we may need to reject a step.
       Actions::RequestNextBoundaryData<

--- a/src/Options/FactoryHelpers.hpp
+++ b/src/Options/FactoryHelpers.hpp
@@ -19,11 +19,11 @@ struct add_factory_classes<FactoryClasses, tmpl::pair<BaseClass, NewClasses>,
               tmpl::erase<FactoryClasses, BaseClass>,
               tmpl::pair<
                   BaseClass,
-                  tmpl::append<
+                  tmpl::remove_duplicates<tmpl::append<
                       tmpl::conditional_t<
                           tmpl::has_key<FactoryClasses, BaseClass>::value,
                           tmpl::at<FactoryClasses, BaseClass>, tmpl::list<>>,
-                      NewClasses>>>,
+                      NewClasses>>>>,
           RestNewClasses...> {};
 
 template <typename FactoryClasses>

--- a/src/ParallelAlgorithms/Interpolation/Targets/KerrHorizon.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Targets/KerrHorizon.hpp
@@ -184,8 +184,14 @@ struct KerrHorizon : tt::ConformsTo<intrp::protocols::ComputeTargetPoints> {
   template <typename Metavariables, typename DbTags, typename TemporalId>
   static tnsr::I<DataVector, 3, Frame> points(
       const db::DataBox<DbTags>& box,
-      const tmpl::type_<Metavariables>& /*meta*/,
+      const tmpl::type_<Metavariables>& metavariables_v,
       const TemporalId& /*temporal_id*/) {
+    return points(box, metavariables_v);
+  }
+  template <typename Metavariables, typename DbTags>
+  static tnsr::I<DataVector, 3, Frame> points(
+      const db::DataBox<DbTags>& box,
+      const tmpl::type_<Metavariables>& /*meta*/) {
     const auto& kerr_horizon =
         db::get<Tags::KerrHorizon<InterpolationTargetTag>>(box);
     if (kerr_horizon.theta_varies_fastest_memory_layout) {
@@ -205,12 +211,6 @@ struct KerrHorizon : tt::ConformsTo<intrp::protocols::ComputeTargetPoints> {
       }
       return transposed_coords;
     }
-  }
-  template <typename Metavariables, typename DbTags>
-  static tnsr::I<DataVector, 3, Frame> points(
-      const db::DataBox<DbTags>& box,
-      const tmpl::type_<Metavariables>& /*meta*/) {
-    return db::get<StrahlkorperTags::CartesianCoords<Frame>>(box);
   }
 };
 

--- a/src/Time/Actions/ChangeStepSize.hpp
+++ b/src/Time/Actions/ChangeStepSize.hpp
@@ -29,9 +29,17 @@ struct Next;
 // IWYU pragma: no_forward_declare db::DataBox
 /// \endcond
 
-/// Adjust the step size for local time stepping, returning true if the step
-/// just completed is accepted, and false if it is rejected.
-template <typename DbTags, typename Metavariables>
+/// \brief Adjust the step size for local time stepping, returning true if the
+/// step just completed is accepted, and false if it is rejected.
+///
+/// \details The optional template parameter `StepChoosersToUse` may be used to
+/// indicate a subset of the constructable step choosers to use for the current
+/// application of `ChangeStepSize`. Passing `AllStepChoosers` (default)
+/// indicates that any constructible step chooser may be used. This option is
+/// used when multiple components need to invoke `ChangeStepSize` with step
+/// choosers that may not be compatible with all components.
+template <typename StepChoosersToUse = AllStepChoosers, typename DbTags,
+          typename Metavariables>
 bool change_step_size(const gsl::not_null<db::DataBox<DbTags>*> box,
                       const Parallel::GlobalCache<Metavariables>& cache) {
   const LtsTimeStepper& time_stepper = db::get<Tags::TimeStepper<>>(*box);
@@ -66,7 +74,8 @@ bool change_step_size(const gsl::not_null<db::DataBox<DbTags>*> box,
   bool step_accepted = true;
   for (const auto& step_chooser : step_choosers) {
     const auto [step_choice, step_choice_accepted] =
-        step_chooser->desired_step(box, last_step_size, cache);
+        step_chooser->template desired_step<StepChoosersToUse>(
+            box, last_step_size, cache);
     desired_step = std::min(desired_step, step_choice);
     step_accepted = step_accepted and step_choice_accepted;
   }
@@ -114,6 +123,13 @@ namespace Actions {
 /// \ingroup TimeGroup
 /// \brief Adjust the step size for local time stepping
 ///
+/// \details The optional template parameter `StepChoosersToUse` may be used to
+/// indicate a subset of the constructable step choosers to use for the current
+/// application of `ChangeStepSize`. Passing `AllStepChoosers` (default)
+/// indicates that any constructible step chooser may be used. This option is
+/// used when multiple components need to invoke `ChangeStepSize` with step
+/// choosers that may not be compatible with all components.
+///
 /// Uses:
 /// - DataBox:
 ///   - Tags::StepChoosers<StepChooserRegistrars>
@@ -127,6 +143,7 @@ namespace Actions {
 /// - Adds: nothing
 /// - Removes: nothing
 /// - Modifies: Tags::Next<Tags::TimeStepId>, Tags::TimeStep
+template <typename StepChoosersToUse = AllStepChoosers>
 struct ChangeStepSize {
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
@@ -136,8 +153,6 @@ struct ChangeStepSize {
       const Parallel::GlobalCache<Metavariables>& cache,
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
-    static_assert(Metavariables::local_time_stepping,
-                  "ChangeStepSize can only be used with local time-stepping.");
     static_assert(
         tmpl::any<ActionList,
                   tt::is_a_lambda<Actions::UpdateU, tmpl::_1>>::value,
@@ -146,7 +161,8 @@ struct ChangeStepSize {
         "an action that is not UpdateU, consider using the take_step function "
         "to handle both stepping and step-choosing instead of the "
         "ChangeStepSize action.");
-    const bool step_successful = change_step_size(make_not_null(&box), cache);
+    const bool step_successful =
+        change_step_size<StepChoosersToUse>(make_not_null(&box), cache);
     if (step_successful) {
       return {std::move(box), false,
               tmpl::index_of<ActionList, ChangeStepSize>::value + 1};

--- a/src/Time/StepChoosers/StepChooser.hpp
+++ b/src/Time/StepChoosers/StepChooser.hpp
@@ -133,6 +133,11 @@ class StepChooser<StepChooserUse::Slab> : public PUP::able {
   }
 };
 
+/// A placeholder type to indicate that all constructible step choosers should
+/// be used in step chooser utilities that permit a list of choosers to be
+/// specified.
+struct AllStepChoosers {};
+
 template <>
 class StepChooser<StepChooserUse::LtsStep> : public PUP::able {
  protected:
@@ -161,7 +166,14 @@ class StepChooser<StepChooserUse::LtsStep> : public PUP::able {
   /// return a strictly smaller step than the `last_step_magnitude` when they
   /// return `false` for the second member of the pair (indicating step
   /// rejection).
-  template <typename Metavariables, typename DbTags>
+  /// The optional template parameter `StepChoosersToUse` may be used to
+  /// indicate a subset of the constructable step choosers to use for the
+  /// current application of `ChangeStepSize`. Passing `AllStepChoosers`
+  /// (default) indicates that any constructible step chooser may be used. This
+  /// option is used when multiple components need to invoke `ChangeStepSize`
+  /// with step choosers that may not be compatible with all components.
+  template <typename StepChoosersToUse = AllStepChoosers,
+            typename Metavariables, typename DbTags>
   std::pair<double, bool> desired_step(
       const gsl::not_null<db::DataBox<DbTags>*> box,
       const double last_step_magnitude,
@@ -171,9 +183,12 @@ class StepChooser<StepChooserUse::LtsStep> : public PUP::able {
     using factory_classes =
         typename std::decay_t<decltype(db::get<Parallel::Tags::Metavariables>(
             *box))>::factory_creation::factory_classes;
+    using step_choosers =
+        tmpl::conditional_t<std::is_same_v<StepChoosersToUse, AllStepChoosers>,
+                            tmpl::at<factory_classes, StepChooser>,
+                            StepChoosersToUse>;
     const auto result =
-        call_with_dynamic_type<std::pair<double, bool>,
-                               tmpl::at<factory_classes, StepChooser>>(
+        call_with_dynamic_type<std::pair<double, bool>, step_choosers>(
             this,
             [&last_step_magnitude, &box, &cache](const auto* const chooser) {
               using chooser_type = typename std::decay_t<decltype(*chooser)>;

--- a/src/Time/TakeStep.hpp
+++ b/src/Time/TakeStep.hpp
@@ -16,7 +16,8 @@
 /// This function is used to encapsulate any needed logic for updating the
 /// system, and in the case for which step parameters may need to be rejected
 /// and re-tried, looping until an acceptable step is performed.
-template <typename VariablesTag = NoSuchType, typename DbTags,
+template <typename StepChoosersToUse = AllStepChoosers,
+          typename VariablesTag = NoSuchType, typename DbTags,
           typename Metavariables>
 void take_step(const gsl::not_null<db::DataBox<DbTags>*> box,
                const Parallel::GlobalCache<Metavariables>& cache) {
@@ -24,5 +25,5 @@ void take_step(const gsl::not_null<db::DataBox<DbTags>*> box,
   do {
     update_u<typename Metavariables::system, VariablesTag>(box);
   } while (Metavariables::local_time_stepping and
-           not change_step_size(box, cache));
+           not change_step_size<StepChoosersToUse>(box, cache));
 }

--- a/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
@@ -15,6 +15,7 @@
 
 Evolution:
   InitialTimeStep: 0.01
+  InitialSlabSize: 0.8
 
 Observers:
   VolumeFileName: "CharacteristicExtractVolume"
@@ -25,7 +26,6 @@ Cce:
     TimeStepper:
       AdamsBashforthN:
         Order: 3
-    InitialSlabSize: 0.8
     StepChoosers:
       - Constant: 0.1
       - Increase:

--- a/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
@@ -15,6 +15,7 @@
 
 Evolution:
   InitialTimeStep: 0.1
+  InitialSlabSize: 0.8
 
 Observers:
   VolumeFileName: "CharacteristicExtractVolume"
@@ -25,7 +26,6 @@ Cce:
     TimeStepper:
       AdamsBashforthN:
         Order: 3
-    InitialSlabSize: 0.8
     StepChoosers:
       - Constant: 0.4
       - Increase:

--- a/tests/InputFiles/Cce/AnalyticTestLinearizedBondiSachs.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestLinearizedBondiSachs.yaml
@@ -15,6 +15,7 @@
 
 Evolution:
   InitialTimeStep: 0.1
+  InitialSlabSize: 0.8
 
 Observers:
   VolumeFileName: "CharacteristicExtractVolume"
@@ -25,7 +26,6 @@ Cce:
     TimeStepper:
       AdamsBashforthN:
         Order: 3
-    InitialSlabSize: 0.8
     StepChoosers:
       - Constant: 0.4
       - Increase:

--- a/tests/InputFiles/Cce/AnalyticTestRobinsonTrautman.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestRobinsonTrautman.yaml
@@ -15,6 +15,7 @@
 
 Evolution:
   InitialTimeStep: 0.1
+  InitialSlabSize: 0.6
 
 Observers:
   VolumeFileName: "CharacteristicExtractVolume"
@@ -25,7 +26,6 @@ Cce:
     TimeStepper:
       AdamsBashforthN:
         Order: 3
-    InitialSlabSize: 0.6
     StepChoosers:
       - Constant: 0.1
       - Increase:

--- a/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
@@ -15,6 +15,7 @@
 
 Evolution:
   InitialTimeStep: 0.1
+  InitialSlabSize: 0.8
 
 Observers:
   VolumeFileName: "CharacteristicExtractVolume"
@@ -25,7 +26,6 @@ Cce:
     TimeStepper:
       AdamsBashforthN:
         Order: 3
-    InitialSlabSize: 0.8
     StepChoosers:
       - Constant: 0.2
       - Increase:

--- a/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
@@ -15,6 +15,7 @@
 
 Evolution:
   InitialTimeStep: 0.1
+  InitialSlabSize: 1.0
 
 Observers:
   VolumeFileName: "CharacteristicExtractVolume"
@@ -25,7 +26,6 @@ Cce:
     TimeStepper:
       AdamsBashforthN:
         Order: 3
-    InitialSlabSize: 1.0
     StepChoosers:
       - Constant: 0.5
       - Increase:

--- a/tests/InputFiles/Cce/CharacteristicExtract.yaml
+++ b/tests/InputFiles/Cce/CharacteristicExtract.yaml
@@ -6,6 +6,7 @@
 
 Evolution:
   InitialTimeStep: 0.25
+  InitialSlabSize: 10.0
 
 Observers:
   VolumeFileName: "CharacteristicExtractVolume"
@@ -16,7 +17,6 @@ Cce:
     TimeStepper:
       AdamsBashforthN:
         Order: 3
-    InitialSlabSize: 10.0
     StepChoosers:
       - Constant: 1.0
       - Increase:

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
@@ -31,10 +31,12 @@
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
 #include "Time/StepChoosers/Factory.hpp"
+#include "Time/StepControllers/BinaryFraction.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/DormandPrince5.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeVector.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -109,6 +111,7 @@ struct test_metavariables {
   using evolved_swsh_tag = Tags::BondiJ;
   static constexpr bool local_time_stepping = false;
   using evolved_swsh_dt_tag = Tags::BondiH;
+  using cce_step_choosers = tmpl::list<>;
   using evolved_coordinates_variables_tag = ::Tags::Variables<
       tmpl::list<Tags::CauchyCartesianCoords, Tags::InertialRetardedTime>>;
   using cce_boundary_communication_tags =
@@ -194,9 +197,12 @@ SPECTRE_TEST_CASE(
   runner.set_phase(test_metavariables::Phase::Initialization);
   ActionTesting::emplace_component<evolution_component>(
       &runner, 0, target_step_size, false,
-      static_cast<std::unique_ptr<TimeStepper>>(
-          std::make_unique<::TimeSteppers::DormandPrince5>()),
-      scri_plus_interpolation_order,
+      static_cast<std::unique_ptr<LtsTimeStepper>>(
+          std::make_unique<::TimeSteppers::AdamsBashforthN>(3)),
+      make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>(),
+      static_cast<std::unique_ptr<StepController>>(
+          std::make_unique<StepControllers::BinaryFraction>()),
+      target_step_size, scri_plus_interpolation_order,
       serialize_and_deserialize(analytic_manager));
   // Serialize and deserialize to get around the lack of implicit copy
   // constructor.

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
@@ -217,8 +217,8 @@ SPECTRE_TEST_CASE(
   // Execute the first request for boundary data
   ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);
   // Check that the receive action is appropriately not ready
-  REQUIRE_FALSE(ActionTesting::next_action_if_ready<evolution_component>(
-      make_not_null(&runner), 0));
+  ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);
+  CHECK(ActionTesting::get_terminate<evolution_component>(runner, 0));
 
   // the response (`BoundaryComputeAndSendToEvolution`)
   ActionTesting::invoke_queued_simple_action<worldtube_component>(

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
@@ -40,10 +40,12 @@
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
 #include "Time/StepChoosers/Factory.hpp"
+#include "Time/StepControllers/BinaryFraction.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/RungeKutta3.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeVector.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -121,6 +123,7 @@ struct mock_characteristic_evolution {
 struct metavariables {
   using evolved_swsh_tag = Tags::BondiJ;
   using evolved_swsh_dt_tag = Tags::BondiH;
+  using cce_step_choosers = tmpl::list<>;
   using evolved_coordinates_variables_tag = ::Tags::Variables<
       tmpl::list<Tags::CauchyCartesianCoords, Tags::InertialRetardedTime>>;
   using cce_boundary_communication_tags =
@@ -237,8 +240,12 @@ SPECTRE_TEST_CASE(
       mock_observer_writer<metavariables>>(&runner, 0, {Parallel::NodeLock{}});
   ActionTesting::emplace_component<component>(
       &runner, 0, target_step_size, false,
-      static_cast<std::unique_ptr<TimeStepper>>(
-          std::make_unique<::TimeSteppers::RungeKutta3>()));
+      static_cast<std::unique_ptr<LtsTimeStepper>>(
+          std::make_unique<::TimeSteppers::AdamsBashforthN>(3)),
+      make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>(),
+      static_cast<std::unique_ptr<StepController>>(
+          std::make_unique<StepControllers::BinaryFraction>()),
+      target_step_size);
 
   // this should run the initialization
   for(size_t i = 0; i < 2; ++i) {

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
@@ -44,11 +44,13 @@
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
 #include "Time/StepChoosers/Factory.hpp"
+#include "Time/StepControllers/BinaryFraction.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/DormandPrince5.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/FileSystem.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeVector.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -127,6 +129,7 @@ struct mock_characteristic_evolution {
 struct test_metavariables {
   using evolved_swsh_tag = Tags::BondiJ;
   using evolved_swsh_dt_tag = Tags::BondiH;
+  using cce_step_choosers = tmpl::list<>;
   using evolved_coordinates_variables_tag = ::Tags::Variables<
       tmpl::list<Tags::CauchyCartesianCoords, Tags::InertialRetardedTime>>;
   using cce_boundary_communication_tags =
@@ -222,9 +225,12 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.GhBoundaryCommunication",
   runner.set_phase(test_metavariables::Phase::Initialization);
   ActionTesting::emplace_component<evolution_component>(
       &runner, 0, target_step_size, false,
-      static_cast<std::unique_ptr<TimeStepper>>(
-          std::make_unique<::TimeSteppers::DormandPrince5>()),
-      scri_plus_interpolation_order);
+      static_cast<std::unique_ptr<LtsTimeStepper>>(
+          std::make_unique<::TimeSteppers::AdamsBashforthN>(3)),
+      make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>(),
+      static_cast<std::unique_ptr<StepController>>(
+          std::make_unique<StepControllers::BinaryFraction>()),
+      target_step_size, scri_plus_interpolation_order);
   ActionTesting::emplace_component<worldtube_component>(
       &runner, 0,
       InterfaceManagers::GhLocalTimeStepping{
@@ -258,19 +264,10 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.GhBoundaryCommunication",
       solution, extraction_radius, amplitude, frequency, target_time, l_max);
   ActionTesting::simple_action<
       worldtube_component,
-      Actions::ReceiveGhWorldtubeData<evolution_component, false>>(
+      Actions::ReceiveGhWorldtubeData<evolution_component, true>>(
       make_not_null(&runner), 0,
-      LinkedMessageId<double>{target_time, std::nullopt}, spacetime_metric, phi,
-      pi);
-
-  TestHelpers::create_fake_time_varying_gh_nodal_data(
-      make_not_null(&spacetime_metric), make_not_null(&phi), make_not_null(&pi),
-      solution, extraction_radius, amplitude, frequency, target_time, l_max);
-  ActionTesting::simple_action<
-      worldtube_component,
-      Actions::ReceiveGhWorldtubeData<evolution_component, false>>(
-      make_not_null(&runner), 0,
-      LinkedMessageId<double>{target_time + target_step_size, target_time},
+      TimeStepId{true, -2,
+                 Time{{target_time, target_time + target_step_size}, {0, 1}}},
       spacetime_metric, phi, pi);
 
   // the first response (`BoundaryComputeAndSendToEvolution`)

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
@@ -243,8 +243,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.GhBoundaryCommunication",
   // the first request
   ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);
   // check that the 'block' appropriately reports that it's not ready:
-  CHECK_FALSE(ActionTesting::next_action_if_ready<evolution_component>(
-      make_not_null(&runner), 0));
+  ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);
+  CHECK(ActionTesting::get_terminate<evolution_component>(runner, 0));
 
   // send the current timestep data to the boundary component
   tnsr::aa<DataVector, 3> spacetime_metric{

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
@@ -272,8 +272,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.H5BoundaryCommunication",
   // the first request
   ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);
   // check that the 'block' appropriately reports that it's not ready:
-  REQUIRE_FALSE(ActionTesting::next_action_if_ready<evolution_component>(
-      make_not_null(&runner), 0));
+  ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);
+  CHECK(ActionTesting::get_terminate<evolution_component>(runner, 0));
 
   // the first response (`BoundaryComputeAndSendToEvolution`)
   ActionTesting::invoke_queued_simple_action<worldtube_component>(

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
@@ -26,10 +26,12 @@
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/StepChoosers/Factory.hpp"
+#include "Time/StepControllers/BinaryFraction.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/RungeKutta3.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeVector.hpp"
 #include "Utilities/NoSuchType.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 
@@ -179,6 +181,7 @@ struct MockCharacteristicEvolution {
 struct test_metavariables {
   using evolved_swsh_tag = Tags::BondiJ;
   using evolved_swsh_dt_tag = Tags::BondiH;
+  using cce_step_choosers = tmpl::list<>;
   static constexpr bool local_time_stepping = false;
   using evolved_coordinates_variables_tag = ::Tags::Variables<
       tmpl::list<Tags::CauchyCartesianCoords, Tags::InertialRetardedTime>>;
@@ -281,9 +284,13 @@ SPECTRE_TEST_CASE(
   // constructor.
   ActionTesting::emplace_component<evolution_component>(
       &runner, 0, target_step_size, false,
-      static_cast<std::unique_ptr<TimeStepper>>(
-          std::make_unique<::TimeSteppers::RungeKutta3>()),
-      buffer_size, serialize_and_deserialize(analytic_manager));
+      static_cast<std::unique_ptr<LtsTimeStepper>>(
+          std::make_unique<::TimeSteppers::AdamsBashforthN>(3)),
+      make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>(),
+      static_cast<std::unique_ptr<StepController>>(
+          std::make_unique<StepControllers::BinaryFraction>()),
+      target_step_size, buffer_size,
+      serialize_and_deserialize(analytic_manager));
   ActionTesting::emplace_component<MockObserver<test_metavariables>>(&runner,
                                                                      0);
   // the initialization actions

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
@@ -29,12 +29,14 @@
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
 #include "Time/StepChoosers/Factory.hpp"
+#include "Time/StepControllers/BinaryFraction.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/RungeKutta3.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/FileSystem.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
+#include "Utilities/MakeVector.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -104,6 +106,7 @@ struct mock_characteristic_evolution {
 struct test_metavariables {
   using evolved_swsh_tag = Tags::BondiJ;
   using evolved_swsh_dt_tag = Tags::BondiH;
+  using cce_step_choosers = tmpl::list<>;
   using evolved_coordinates_variables_tag = ::Tags::Variables<
       tmpl::list<Tags::CauchyCartesianCoords, Tags::InertialRetardedTime>>;
   using cce_boundary_communication_tags =
@@ -205,10 +208,17 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.RequestBoundaryData",
 
   ActionTesting::set_phase(make_not_null(&runner),
                            test_metavariables::Phase::Initialization);
+  // requested step size and slab size chosen to be sure that the step
+  // controller gives a predictable value (not subject to roundoff fluctuations
+  // in the generated value)
   ActionTesting::emplace_component<evolution_component>(
-      &runner, 0, target_step_size, false,
-      static_cast<std::unique_ptr<TimeStepper>>(
-          std::make_unique<::TimeSteppers::RungeKutta3>()));
+      &runner, 0, target_step_size * 0.75, false,
+      static_cast<std::unique_ptr<LtsTimeStepper>>(
+          std::make_unique<::TimeSteppers::AdamsBashforthN>(3)),
+      make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>(),
+      static_cast<std::unique_ptr<StepController>>(
+          std::make_unique<StepControllers::BinaryFraction>()),
+      target_step_size);
   ActionTesting::emplace_component<worldtube_component>(
       &runner, 0,
       Tags::H5WorldtubeBoundaryDataManager::create_from_options(
@@ -241,7 +251,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.RequestBoundaryData",
   ActionTesting::invoke_queued_simple_action<worldtube_component>(
       make_not_null(&runner), 0);
   CHECK(Actions::times_requested.size() == 2);
-  CHECK(Actions::times_requested[1] == start_time + target_step_size);
+  CHECK(Actions::times_requested[1] == start_time + target_step_size * 0.75);
   if (file_system::check_if_file_exists(filename)) {
     file_system::rm(filename, true);
   }

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
@@ -39,12 +39,14 @@
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Time/StepChoosers/Factory.hpp"
+#include "Time/StepControllers/BinaryFraction.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/RungeKutta3.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/FileSystem.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
+#include "Utilities/MakeVector.hpp"
 #include "Utilities/Numeric.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 
@@ -155,6 +157,7 @@ struct mock_characteristic_evolution {
 struct test_metavariables {
   using evolved_swsh_tag = Tags::BondiJ;
   using evolved_swsh_dt_tag = Tags::BondiH;
+  using cce_step_choosers = tmpl::list<>;
   static constexpr bool local_time_stepping = false;
   using evolved_coordinates_variables_tag = ::Tags::Variables<
       tmpl::list<Tags::CauchyCartesianCoords, Tags::InertialRetardedTime>>;
@@ -279,9 +282,13 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.ScriObserveInterpolated",
   // constructor.
   ActionTesting::emplace_component<evolution_component>(
       &runner, 0, target_step_size, false,
-      static_cast<std::unique_ptr<TimeStepper>>(
-          std::make_unique<::TimeSteppers::RungeKutta3>()),
-      scri_interpolation_size, serialize_and_deserialize(analytic_manager));
+      static_cast<std::unique_ptr<LtsTimeStepper>>(
+          std::make_unique<::TimeSteppers::AdamsBashforthN>(3)),
+      make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>(),
+      static_cast<std::unique_ptr<StepController>>(
+          std::make_unique<StepControllers::BinaryFraction>()),
+      target_step_size, scri_interpolation_size,
+      serialize_and_deserialize(analytic_manager));
   if (file_system::check_if_file_exists(filename + "0.h5")) {
     file_system::rm(filename + "0.h5", true);
   }

--- a/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
+++ b/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
@@ -93,13 +93,17 @@ struct Component {
           tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Testing,
-          tmpl::list<Actions::ChangeStepSize, ::Actions::Label<NoOpLabel>,
+          tmpl::list<Actions::ChangeStepSize<
+                         typename Metavariables::step_choosers_to_use>,
+                     ::Actions::Label<NoOpLabel>,
                      /*UpdateU action is required to satisfy internal checks of
                        `ChangeStepSize`. It is not used in the test.*/
                      Actions::UpdateU<>>>>;
 };
 
+template <typename StepChoosersToUse = AllStepChoosers>
 struct Metavariables {
+  using step_choosers_to_use = StepChoosersToUse;
   using system = System;
   static constexpr bool local_time_stepping = true;
   struct factory_creation
@@ -113,6 +117,7 @@ struct Metavariables {
   enum class Phase { Initialization, Testing, Exit };
 };
 
+template <typename StepChoosersToUse = AllStepChoosers>
 void check(const bool time_runs_forward,
            std::unique_ptr<LtsTimeStepper> time_stepper, const Time& time,
            const double request, const TimeDelta& expected_step,
@@ -123,8 +128,9 @@ void check(const bool time_runs_forward,
   const TimeDelta initial_step_size =
       (time_runs_forward ? 1 : -1) * time.slab().duration();
 
-  using component = Component<Metavariables>;
-  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
+  using component = Component<Metavariables<StepChoosersToUse>>;
+  using MockRuntimeSystem =
+      ActionTesting::MockRuntimeSystem<Metavariables<StepChoosersToUse>>;
   using Constant = StepChoosers::Constant<StepChooserUse::LtsStep>;
   MockRuntimeSystem runner{{std::move(time_stepper)}};
 
@@ -150,8 +156,8 @@ void check(const bool time_runs_forward,
        typename history_tag::type{}, 1.});
 
   ActionTesting::set_phase(make_not_null(&runner),
-                           Metavariables::Phase::Testing);
-  runner.next_action<component>(0);
+                           Metavariables<StepChoosersToUse>::Phase::Testing);
+  runner.template next_action<component>(0);
   const auto& box =
       ActionTesting::get_databox<component, typename component::simple_tags>(
           runner, 0);
@@ -171,7 +177,7 @@ void check(const bool time_runs_forward,
 SPECTRE_TEST_CASE("Unit.Time.Actions.ChangeStepSize", "[Unit][Time][Actions]") {
   Parallel::register_classes_with_charm<TimeSteppers::AdamsBashforthN>();
   Parallel::register_classes_with_charm<StepControllers::BinaryFraction>();
-  Parallel::register_factory_classes_with_charm<Metavariables>();
+  Parallel::register_factory_classes_with_charm<Metavariables<>>();
   const Slab slab(-5., -2.);
   const double slab_length = slab.duration().value();
   for (auto reject_step : {true, false}) {
@@ -188,4 +194,12 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.ChangeStepSize", "[Unit][Time][Actions]") {
           slab.end() - slab.duration() / 4, slab_length, -slab.duration() / 4,
           reject_step);
   }
+  CHECK_THROWS_WITH(
+      ([&slab, &slab_length]() {
+        check<tmpl::list<StepChoosers::Constant<StepChooserUse::LtsStep>>>(
+            true, std::make_unique<TimeSteppers::AdamsBashforthN>(1),
+            slab.start() + slab.duration() / 4, slab_length / 5.,
+            slab.duration() / 8, true);
+      })(),
+      Catch::Contains("is not registered"));
 }


### PR DESCRIPTION
## Proposed changes

This is a rebased version of #2323 that contains all of the commits except the one for the actual executable.
I added one commit that factored the metavariables for CharacteristicExtract into two structs, one of which contains information that will be common to the stand-alone CCE and the GH+CCE executables

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
