### PR TITLE
Add ResourceInfo for allocating singletons

### DIFF
--- a/src/Parallel/ResourceInfo.hpp
+++ b/src/Parallel/ResourceInfo.hpp
@@ -3,18 +3,37 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 #include <optional>
 #include <pup.h>
 #include <string>
+#include <unordered_set>
+#include <utility>
 
+#include "DataStructures/DataBox/DataBox.hpp"
 #include "Options/Auto.hpp"
 #include "Options/Options.hpp"
+#include "Parallel/Algorithms/AlgorithmSingletonDeclarations.hpp"
+#include "Parallel/Info.hpp"
+#include "Parallel/Printf.hpp"
 #include "Parallel/PupStlCpp17.hpp"
 #include "Parallel/TypeTraits.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Numeric.hpp"
 #include "Utilities/PrettyType.hpp"
+#include "Utilities/System/ParallelInfo.hpp"
 #include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace Parallel::Tags {
+template <typename Component>
+struct SingletonInfo;
+struct AvoidGlobalProc0;
+}  // namespace Parallel::Tags
+/// \endcond
 
 namespace Parallel {
 /*!
@@ -186,4 +205,711 @@ struct SingletonPack<tmpl::list<ParallelComponents...>> {
  private:
   tuples::tagged_tuple_from_typelist<local_tags> procs_{};
 };
+
+namespace detail {
+template <typename Component>
+using component_has_singleton_info_tag =
+    tmpl::list_contains<typename Component::initialization_tags,
+                        Parallel::Tags::SingletonInfo<Component>>;
+
+template <typename Metavariables>
+using singleton_components =
+    tmpl::filter<typename Metavariables::component_list,
+                 Parallel::is_singleton<tmpl::_1>>;
+
+template <typename Component>
+using contains_avoid_global_proc_0 =
+    tmpl::list_contains<typename Component::initialization_tags,
+                        Parallel::Tags::AvoidGlobalProc0>;
+
+template <typename Metavariables>
+constexpr bool avoid_global_proc_0 =
+    tmpl::size<tmpl::filter<
+        typename Metavariables::component_list,
+        tmpl::bind<contains_avoid_global_proc_0, tmpl::_1>>>::value > 0;
+
+template <typename SingletonList>
+using singletons_with_singleton_info =
+    tmpl::filter<SingletonList,
+                 tmpl::bind<component_has_singleton_info_tag, tmpl::_1>>;
+
+template <typename Metavariables>
+constexpr bool using_resource_info =
+    avoid_global_proc_0<Metavariables> or
+    tmpl::size<singletons_with_singleton_info<
+        singleton_components<Metavariables>>>::value > 0;
+
+}  // namespace detail
+
+/*!
+ * \ingroup ParallelGroup
+ * \brief Holds resource info for all singletons and for avoiding placing array
+ * elements/singletons on the global proc 0.
+ *
+ * \details This can be used for placing all singletons in an executable. To
+ * have a singleton specify resource information, add the
+ * `Parallel::Tags::SingletonInfo` tag to the `initialization_tags` type alias
+ * in the singleton. To specify whether to avoid placing array elements and
+ * singletons on the global proc 0, add the `Parallel::Tags::AvoidGlobalProc0`
+ * tag to the `initialization_tags` of the parallel components in your
+ * executable.
+ *
+ * If you only add the `Parallel::Tags::AvoidGlobalProc0` tag to the
+ * initialization tags, you'll need the following block in the input file:
+ *
+ * \code {.yaml}
+ * ResourceInfo:
+ *   AvoidGlobalProc0: true
+ * \endcode
+ *
+ * If you only have `Parallel::Tags::SingletonInfo` tags in the initialization
+ * tags, you'll need the following block in the input file:
+ *
+ * \code {.yaml}
+ * ResourceInfo:
+ *   Singletons:
+ *     MySingleton1:
+ *       Proc: 2
+ *       Exclusive: true
+ *     MySingleton2:
+ *       Proc: Auto
+ *       Exclusive: false
+ * \endcode
+ *
+ * where `MySingleton1` is the `pretty_type::name` of the singleton component
+ * and the options for each singleton are described in
+ * `Parallel::SingletonInfoHolder`.
+ *
+ * If you have both `Parallel::Tags::AvoidGlobalProc0` and
+ * `Parallel::Tags::SingletonInfo` tags in the initialization tags, you can
+ * combine the blocks like so:
+ *
+ * \code {.yaml}
+ * ResourceInfo:
+ *   AvoidGlobalProc0: true
+ *   Singletons:
+ *     MySingleton1:
+ *       Proc: 2
+ *       Exclusive: true
+ *     MySingleton2:
+ *       Proc: Auto
+ *       Exclusive: false
+ * \endcode
+ *
+ * Several consistency checks are done during option parsing to avoid user
+ * error. However, some checks can't be done during option parsing because the
+ * number of nodes/procs is needed to determine if there is an inconsistency.
+ * These checks are done during runtime, just before the map of singletons is
+ * created.
+ *
+ * To automatically place singletons, we use a custom algorithm that will
+ * distribute singletons evenly over the number of nodes, and evenly over the
+ * procs on a node. This will help keep communication costs down by distributing
+ * the workload over all of the communication cores (one communication core per
+ * charm node), and ensure that our resources are being maximally utilized (i.e.
+ * one core doesn't have all the singletons on it).
+ *
+ * Defining some terminology for singletons: `requested` means that a specific
+ * processor was requested in the input file; `auto` means that the processor
+ * should be chosen automatically; `exclusive` means that no other singletons or
+ * array elements should be placed on this singleton's processor; `nonexclusive`
+ * means that you *can* place other singletons or array elements on this
+ * singleton's processor. The algorithm that distributes the singletons is as
+ * follows:
+ *
+ * 1. Allocate all singletons that `requested` specific processors, both
+ *    `exclusive` and `nonexclusive`. This is done during option parsing.
+ * 2. Allocate `auto exclusive` singletons, distributing the total number of
+ *    `exclusive` singletons (`auto` + `requested`) as evenly as possibly over
+ *    the number of nodes. We say "as evenly as possible" because this depends
+ *    on the `requested exclusive` singletons. For example, if we have 4 nodes
+ *    and 5 cores per node, the number of `requested exclusive` singletons on
+ *    each node is (0, 1, 4, 1), and we have 3 `auto exclusive` singletons to
+ *    place, the best distribution of `exclusive` singletons we can achieve
+ *    given our constraints is (2, 2, 4, 1). Clearly this is not the *most*
+ *    evenly distributed the `exclusive` singletons could be. However, this *is*
+ *    the most evenly distributed they could be given the starting distribution
+ *    from the input file.
+ * 3. Allocate `auto nonexclusive` singletons, distributing the total number of
+ *    `nonexclusive` singletons (`auto` + `requested`): First, as evenly as
+ *    possibly over the number of nodes. Then, on each node, distributing the
+ *    singletons as evenly as possibly over the number of processors on that
+ *    node. The same disclaimer about "as evenly as possibly" from the previous
+ *    step applies here.
+ *
+ * The goal of this algorithm is to mimic, as best as possible, how a human
+ * would distribute this workload. It isn't perfect, but is a significant
+ * improvement over placing singletons on one proc after another starting from
+ * global proc 0.
+ */
+template <typename Metavariables>
+struct ResourceInfo {
+ private:
+  using singletons = detail::singleton_components<Metavariables>;
+  using singletons_with_info =
+      detail::singletons_with_singleton_info<singletons>;
+
+  template <typename Component>
+  struct LocalTag {
+    // exclusive, proc
+    using type = std::pair<bool, std::optional<size_t>>;
+  };
+  using local_tags =
+      tmpl::transform<singletons, tmpl::bind<LocalTag, tmpl::_1>>;
+
+ public:
+  struct Singletons {
+    using type = SingletonPack<singletons_with_info>;
+    static constexpr Options::String help = {
+        "Resource options for all singletons."};
+  };
+
+  struct AvoidGlobalProc0 {
+    using type = bool;
+    static constexpr Options::String help = {
+        "Whether to avoid placing Array elements or singletons on global proc "
+        "0."};
+  };
+
+  using options = tmpl::flatten<tmpl::list<
+      tmpl::conditional_t<detail::avoid_global_proc_0<Metavariables>,
+                          tmpl::list<AvoidGlobalProc0>, tmpl::list<>>,
+      tmpl::conditional_t<tmpl::size<singletons_with_info>::value != 0,
+                          tmpl::list<Singletons>, tmpl::list<>>>>;
+  static constexpr Options::String help = {
+      "Resource options for a simulation. This information will be used when "
+      "placing Array and Singleton parallel components on the requested "
+      "resources."};
+
+  /// The main constructor. All other constructors that take options will call
+  /// this one. This constructor holds all checks able to be done during option
+  /// parsing.
+  ResourceInfo(const bool avoid_global_proc_0,
+               const SingletonPack<singletons_with_info>& singleton_pack,
+               const Options::Context& context = {});
+
+  /// This constructor is used when only AvoidGlobalProc0 is specified, but no
+  /// SingletonInfoHolders are specified. Calls the main constructor with an
+  /// empty SingletonPack.
+  ResourceInfo(const bool avoid_global_proc_0,
+               const Options::Context& context = {});
+
+  /// This constructor is used when only SingletonInfoHolders are specified, but
+  /// no AvoidGlobalProc0. Calls the main constructor with AvoidGlobalProc0
+  /// `false`.
+  ResourceInfo(const SingletonPack<singletons_with_info>& singleton_pack,
+               const Options::Context& context = {});
+
+  ResourceInfo() = default;
+  ResourceInfo(const ResourceInfo& /*rhs*/) = default;
+  ResourceInfo& operator=(const ResourceInfo& /*rhs*/) = default;
+  ResourceInfo(ResourceInfo&& /*rhs*/) = default;
+  ResourceInfo& operator=(ResourceInfo&& /*rhs*/) = default;
+  ~ResourceInfo() = default;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p);
+
+  /// Returns whether we should avoid placing array elements and singletons on
+  /// the global zeroth proc. Default `false`.
+  bool avoid_global_proc_0() const { return avoid_global_proc_0_; }
+
+  /// Return a SingletonInfoHolder corresponding to `Component`
+  template <typename Component>
+  auto get_singleton_info() const;
+
+  /// Returns a `std::unordered_set<size_t>` of processors that array components
+  /// should avoid placing elements on. This should be passed to the
+  /// `allocate_array` function of the array component
+  const std::unordered_set<size_t>& procs_to_ignore() const;
+
+  /// Returns the proc that the singleton `Component` should be placed on.
+  template <typename Component>
+  size_t proc_for() const;
+
+  /// \brief Actually builds the singleton map and allocates all the singletons.
+  ///
+  /// \details This could be done in the constructor, however, since we need the
+  /// number of nodes to do some sanity checks, it can't. If an executable is
+  /// run with the --check-options flag, we will be running on 1 proc and 1 node
+  /// so some of the checks done in this function would fail. Unfortunately,
+  /// that means the checks that require knowing the number of nodes now occur
+  /// at runtime instead of option parsing. This is why the
+  /// `singleton_map_has_been_set_` bool is necessary and why we check if this
+  /// function has been called in get_singleton_info(), procs_to_ignore(), and
+  /// proc_for().
+  ///
+  /// This function should only be called once.
+  void build_singleton_map(const Parallel::GlobalCache<Metavariables>& cache);
+
+ private:
+  void singleton_map_not_built() const {
+    ERROR(
+        "The singleton map has not been built yet. You must call "
+        "build_singleton_map() before you call this function.");
+  }
+  bool avoid_global_proc_0_{false};
+  bool singleton_map_has_been_set_{false};
+  // These are quantities that we will need for placing singletons which can be
+  // determined just by option parsing
+  size_t num_exclusive_singletons_{};
+  size_t num_procs_to_ignore_{};
+  size_t num_requested_exclusive_singletons_{};
+  size_t num_requested_nonexclusive_singletons_{};
+  std::unordered_multiset<size_t> requested_nonexclusive_procs_{};
+  // Procs that are exclusive. These may or may not be specifically requested
+  std::unordered_set<size_t> procs_to_ignore_{};
+  // For each singleton (whether it has a SingletonInfo or not), maps whether
+  // it's exclusive and what proc it is on.
+  tuples::tagged_tuple_from_typelist<local_tags> singleton_map_{};
+};
+
+template <typename Metavariables>
+ResourceInfo<Metavariables>::ResourceInfo(
+    const bool avoid_global_proc_0,
+    const SingletonPack<singletons_with_info>& singleton_pack,
+    const Options::Context& context)
+    : avoid_global_proc_0_(avoid_global_proc_0) {
+  if (avoid_global_proc_0_) {
+    procs_to_ignore_.insert(0);
+    ++num_procs_to_ignore_;
+  }
+
+  // Procs that were specifically requested. These may or may not be exclusive
+  std::unordered_multiset<int> requested_procs{};
+
+  [[maybe_unused]] const auto parse_singletons = [this, &context,
+                                                  &singleton_pack,
+                                                  &requested_procs](
+                                                     const auto component_v) {
+    using component = tmpl::type_from<decltype(component_v)>;
+    auto& singleton_map = tuples::get<LocalTag<component>>(singleton_map_);
+
+    // This singleton has a SingletonInfoHolder associated with it. Get all
+    // the info necessary from it
+    if constexpr (tmpl::list_contains_v<singletons_with_info, component>) {
+      const auto& info_holder = singleton_pack.template get<component>();
+      // Assign proc. If a specific proc is requested, add it to a map. We'll
+      // check that exclusive singletons have unique procs once we've gone
+      // through everything once
+      const auto proc = info_holder.proc();
+      singleton_map.second = proc;
+
+      if (proc.has_value()) {
+        requested_procs.insert(*proc);
+      }
+
+      if (info_holder.is_exclusive()) {
+        // Check that no singleton has requested to be on proc 0 while
+        // AvoidGlobalProc0 is simultaneously true.
+        if (avoid_global_proc_0_ and proc.has_value() and *proc == 0) {
+          PARSE_ERROR(context,
+                      "A singleton has requested to be exclusively on proc 0, "
+                      "but the AvoidGlobalProc0 option is also set to true.");
+        }
+
+        // This singleton is exclusive so set it.
+        singleton_map.first = true;
+        ++num_exclusive_singletons_;
+        ++num_procs_to_ignore_;
+        // If it requested a specific proc, ignore it when assigning the rest
+        // of the singletons
+        if (proc.has_value()) {
+          procs_to_ignore_.insert(static_cast<size_t>(*proc));
+          ++num_requested_exclusive_singletons_;
+        }
+      } else {
+        // This singleton is not exclusive.
+        singleton_map.first = false;
+        if (proc.has_value()) {
+          ++num_requested_nonexclusive_singletons_;
+          requested_nonexclusive_procs_.insert(static_cast<size_t>(*proc));
+        }
+      }
+    } else {
+      // This singleton doesn't have a SingletonInfoHolder so it automatically
+      // isn't exclusive and gets set assigned an automatic proc.
+      singleton_map.first = false;
+      // nullopt is a sentinel for auto
+      singleton_map.second = std::nullopt;
+    }
+  };
+
+  // Create a map between each singleton, whether it is exclusive, and which
+  // proc it wants to be on. Use nullopt as a sentinel for choosing the proc
+  // automatically.
+  tmpl::for_each<singletons>(parse_singletons);
+
+  [[maybe_unused]] const auto sanity_checks =
+      [this, &context, &requested_procs](const auto component_v) {
+        using component = tmpl::type_from<decltype(component_v)>;
+        auto& singleton_map = tuples::get<LocalTag<component>>(singleton_map_);
+
+        const bool exclusive = singleton_map.first;
+        const auto proc = singleton_map.second;
+
+        // Check exclusive singletons that requested to be on a specific proc
+        // if any other singletons requested to be on the same proc (exclusive
+        // or not)
+        if (exclusive and proc.has_value() and
+            requested_procs.count(*proc) > 1) {
+          PARSE_ERROR(context,
+                      "Two singletons have requested to be on proc "
+                          << proc
+                          << ", but at least one of them has requested to be "
+                             "exclusively on this proc.");
+        }
+      };
+
+  // Do some inter-singleton sanity checks to avoid inconsistencies
+  tmpl::for_each<singletons>(sanity_checks);
+}
+
+template <typename Metavariables>
+ResourceInfo<Metavariables>::ResourceInfo(const bool avoid_global_proc_0,
+                                          const Options::Context& context)
+    : ResourceInfo(avoid_global_proc_0, SingletonPack<singletons_with_info>{},
+                   context) {}
+
+template <typename Metavariables>
+ResourceInfo<Metavariables>::ResourceInfo(
+    const SingletonPack<singletons_with_info>& singleton_pack,
+    const Options::Context& context)
+    : ResourceInfo(false, singleton_pack, context) {}
+
+template <typename Metavariables>
+void ResourceInfo<Metavariables>::pup(PUP::er& p) {
+  p | avoid_global_proc_0_;
+  p | singleton_map_has_been_set_;
+  p | num_exclusive_singletons_;
+  p | num_procs_to_ignore_;
+  p | num_requested_exclusive_singletons_;
+  p | num_requested_nonexclusive_singletons_;
+  p | requested_nonexclusive_procs_;
+  p | procs_to_ignore_;
+  p | singleton_map_;
+}
+
+template <typename Metavariables>
+template <typename Component>
+auto ResourceInfo<Metavariables>::get_singleton_info() const {
+  if (not singleton_map_has_been_set_) {
+    singleton_map_not_built();
+  }
+
+  const auto& singleton_map = tuples::get<LocalTag<Component>>(singleton_map_);
+  return SingletonInfoHolder<Component>{
+      {static_cast<int>(*singleton_map.second)}, singleton_map.first};
+}
+
+template <typename Metavariables>
+const std::unordered_set<size_t>& ResourceInfo<Metavariables>::procs_to_ignore()
+    const {
+  if (not singleton_map_has_been_set_) {
+    singleton_map_not_built();
+  }
+  return procs_to_ignore_;
+}
+
+template <typename Metavariables>
+template <typename Component>
+size_t ResourceInfo<Metavariables>::proc_for() const {
+  if (not singleton_map_has_been_set_) {
+    singleton_map_not_built();
+  }
+  return *tuples::get<LocalTag<Component>>(singleton_map_).second;
+}
+
+template <typename Metavariables>
+void ResourceInfo<Metavariables>::build_singleton_map(
+    const Parallel::GlobalCache<Metavariables>& cache) {
+  const size_t num_procs = Parallel::number_of_procs<size_t>(cache);
+  const size_t num_nodes = Parallel::number_of_nodes<size_t>(cache);
+
+  // We don't do procs_to_ignore_.size() here because the auto singletons who
+  // requested to be exclusive haven't been assigned yet so their procs haven't
+  // been added to procs_to_ignore_
+  if (num_procs_to_ignore_ >= num_procs) {
+    ERROR(
+        "The total number of cores requested is less than or equal to the "
+        "number of cores that requested to be exclusive, i.e. without "
+        "array elements or multiple singletons. The array elements have "
+        "nowhere to be placed. Number of cores requested: "
+        << num_procs << ". Number of cores that requested to be exclusive: "
+        << num_procs_to_ignore_ << ".");
+  }
+
+  // Check if any singletons that requested to be on specific proc requested to
+  // be on a proc beyond the last proc.
+  tmpl::for_each<singletons>([this, &num_procs](const auto component_v) {
+    using component = tmpl::type_from<decltype(component_v)>;
+    auto& singleton_map = tuples::get<LocalTag<component>>(singleton_map_);
+    const auto proc = singleton_map.second;
+
+    if (proc.has_value() and *proc > num_procs - 1) {
+      ERROR("Singleton " << pretty_type::name<component>()
+                         << " requested to be placed on proc " << proc
+                         << ", but that proc is beyond the last proc "
+                         << num_procs - 1 << ".");
+    }
+  });
+
+  // At this point, all requested singletons have been allocated on their
+  // desired procs. This leaves just the auto singletons left, both exclusive
+  // and non-exclusive.
+
+  // First allocate auto exclusive singletons
+  // This first vector will keep track of the total number of singletons on each
+  // node so we can spread them out evenly
+  std::vector<size_t> singletons_on_each_node(num_nodes, 0_st);
+  // This second vector keeps track of only the auto exclusive singletons on
+  // each node
+  std::vector<size_t> auto_exclusive_singletons_on_each_node(num_nodes, 0_st);
+  // Populate requested exclusive singletons on each node with input options. We
+  // couldn't have done this in the constructor because we didn't know how many
+  // nodes there were or how many procs were on each node. We'll do the
+  // non-exclusive ones later.
+  tmpl::for_each<singletons>(
+      [this, &cache, &singletons_on_each_node](const auto component_v) {
+        using component = tmpl::type_from<decltype(component_v)>;
+        auto& singleton_map = tuples::get<LocalTag<component>>(singleton_map_);
+        const bool exclusive = singleton_map.first;
+        const auto proc = singleton_map.second;
+
+        if (exclusive and proc.has_value()) {
+          ++singletons_on_each_node[Parallel::node_of<size_t>(*proc, cache)];
+        }
+      });
+
+  size_t remaining_auto_exclusive_singletons =
+      num_exclusive_singletons_ - num_requested_exclusive_singletons_;
+  // Start with the min number of singletons on a node as our baseline. Then,
+  // while we still have auto exclusive singletons to place, we loop over all
+  // nodes and place singletons on nodes with this minimum number. Once all
+  // nodes have at least this minimum number, we increment the minimum number
+  // and loop over the nodes again
+  size_t min_num_singletons_on_a_node = *std::min_element(
+      singletons_on_each_node.begin(), singletons_on_each_node.end());
+  while (remaining_auto_exclusive_singletons > 0) {
+    for (size_t i = 0; i < num_nodes; i++) {
+      // If this node has more than the minimum number of singletons on it, skip
+      // it for now
+      if (singletons_on_each_node[i] > min_num_singletons_on_a_node) {
+        continue;
+      }
+      // Since nodes can have different number of procs, we check that we
+      // haven't exhausted the number of procs on this node. This check is ok
+      // right now because we haven't included any nonexclusive singletons in
+      // singletons_on_each_node yet.
+      if (not(singletons_on_each_node[i] <
+              Parallel::procs_on_node<size_t>(i, cache))) {
+        continue;
+      }
+
+      ++singletons_on_each_node[i];
+      ++auto_exclusive_singletons_on_each_node[i];
+      --remaining_auto_exclusive_singletons;
+
+      // We need to break out of both loops here. Use a goto.
+      if (remaining_auto_exclusive_singletons == 0) {
+        goto break_auto_exclusive_loops;
+      }
+    }  // for (size_t i = 0; i < num_nodes; i++)
+
+    ++min_num_singletons_on_a_node;
+  }  // while (remaining_auto_exclusive_singletons > 0)
+break_auto_exclusive_loops:
+
+  ASSERT(remaining_auto_exclusive_singletons == 0,
+         "Not all exclusive singletons have been allocated. The remaining "
+         "number of singletons to be allocated is "
+             << remaining_auto_exclusive_singletons << ".");
+
+  // Actually allocate the auto exclusive singletons
+  size_t current_node = 0;
+  tmpl::for_each<singletons>([this, &cache, &current_node,
+                              &auto_exclusive_singletons_on_each_node](
+                                 const auto component_v) {
+    using component = tmpl::type_from<decltype(component_v)>;
+    auto& singleton_map = tuples::get<LocalTag<component>>(singleton_map_);
+    const bool exclusive = singleton_map.first;
+    const auto int_proc = singleton_map.second;
+
+    // Only allocating auto exclusive at the moment
+    if (exclusive and not int_proc.has_value()) {
+      while (auto_exclusive_singletons_on_each_node[current_node] == 0) {
+        ++current_node;
+      }
+
+      size_t proc = Parallel::first_proc_on_node<size_t>(current_node, cache);
+      // Don't place two exclusive singletons on the same proc, but also if
+      // a singleton requested a specific proc, whether or not it is
+      // exclusive, we can't place an exclusive singleton on that proc. That
+      // defeats the whole purpose of requesting the specific proc...
+      while (procs_to_ignore_.find(proc) != procs_to_ignore_.end() or
+             requested_nonexclusive_procs_.count(proc) > 0) {
+        ++proc;
+      }
+
+      singleton_map.second = proc;
+      procs_to_ignore_.insert(proc);
+
+      --auto_exclusive_singletons_on_each_node[current_node];
+    }
+  });
+
+  ASSERT(alg::accumulate(auto_exclusive_singletons_on_each_node, 0_st) == 0,
+         "Not all auto exclusive singletons have been allocated. The remaining "
+         "number of auto exclusive singletons to be allocated is "
+             << alg::accumulate(auto_exclusive_singletons_on_each_node, 0_st));
+
+  // At this point, all auto exclusive singletons have been allocated. Now the
+  // only singletons left are auto non-exclusive. We use vectors of
+  // std::optional<size_t> here as sentinels for procs which should be avoided.
+  // A nullopt means that the proc shouldn't have auto nonexclusive singletons
+  // on it. When we have lots of cores to run on (hundreds of thousands or even
+  // millions), these vectors will take up a non-negligible amount of memory.
+  // However, we only need to do this once an executable at the very beginning
+  // so it shouldn't really matter
+  std::vector<std::optional<size_t>> nonexclusive_singletons_on_each_proc(
+      num_procs, std::optional<size_t>(0_st));
+  // This vector has the default be nullopt rather than 0, because this will
+  // only be used when we actually place singletons. We only care which procs
+  // have singletons, which will usually be a small subset of the total procs.
+  std::vector<std::optional<size_t>> auto_nonexclusive_singletons_on_each_proc(
+      num_procs, std::nullopt);
+  for (const size_t proc : procs_to_ignore_) {
+    nonexclusive_singletons_on_each_proc[proc] = std::nullopt;
+  }
+  // Now we add in the requested nonexclusive to the total number of singletons
+  // per node
+  for (const auto& proc : requested_nonexclusive_procs_) {
+    ++*nonexclusive_singletons_on_each_proc[proc];
+    ++singletons_on_each_node[Parallel::node_of<size_t>(proc, cache)];
+  }
+
+  size_t remaining_auto_nonexclusive_singletons =
+      tmpl::size<singletons>::value - num_exclusive_singletons_ -
+      num_requested_nonexclusive_singletons_;
+
+  // This serves the same purpose as before
+  min_num_singletons_on_a_node = *std::min_element(
+      singletons_on_each_node.begin(), singletons_on_each_node.end());
+  while (remaining_auto_nonexclusive_singletons > 0) {
+    for (size_t i = 0; i < num_nodes; i++) {
+      const int first_proc = Parallel::first_proc_on_node<int>(i, cache);
+      const int procs_on_node = Parallel::procs_on_node<int>(i, cache);
+      const int first_proc_next_node = first_proc + procs_on_node;
+
+      auto first_proc_iter =
+          std::next(nonexclusive_singletons_on_each_proc.begin(), first_proc);
+      auto first_proc_next_node_iter = std::next(
+          nonexclusive_singletons_on_each_proc.begin(), first_proc_next_node);
+
+      // Get the proc on this node with the minimum number of singletons. This
+      // serves the same purpose as min_num_singletons_on_a_node except now for
+      // procs on a specific node
+      auto& min_num_singletons_on_a_proc_opt =
+          *std::min_element(first_proc_iter, first_proc_next_node_iter,
+                            [](const auto& a, const auto& b) {
+                              if (a.has_value() and b.has_value()) {
+                                return a.value() < b.value();
+                              } else {
+                                return a.has_value();
+                              }
+                            });
+
+      // Check if this node can accommodate more singletons. Do two checks:
+      // 1. This node doesn't have more than the minimum number of singletons
+      // 2. That this node isn't filled up with exclusive singletons (nullopt =
+      //    all procs on this node are taken)
+      if (singletons_on_each_node[i] > min_num_singletons_on_a_node or
+          not min_num_singletons_on_a_proc_opt.has_value()) {
+        continue;
+      }
+
+      // At this point, we have guaranteed that this node should have an auto
+      // nonexclusive singleton on it somewhere. Now determine where
+      size_t min_num_singletons_on_a_proc =
+          min_num_singletons_on_a_proc_opt.value();
+
+      // Find the first available proc on this node. Check that
+      // 1. This proc is available (i.e. no exclusive singletons on it)
+      // 2. This proc has the minimum number of singletons on it for this node
+      //    so we distribute the singletons evenly over all the procs on this
+      //    node
+      auto proc_iter =
+          std::find_if(first_proc_iter, first_proc_next_node_iter,
+                       [&min_num_singletons_on_a_proc](const auto& proc_opt) {
+                         return proc_opt.has_value() and
+                                *proc_opt == min_num_singletons_on_a_proc;
+                       });
+
+      // Get the index of the overall vector. We need this because we're going
+      // to be indexing two separate vectors, otherwise we could have just used
+      // the value of the iterator
+      const size_t proc = static_cast<size_t>(std::distance(
+          nonexclusive_singletons_on_each_proc.begin(), proc_iter));
+
+      // Increment things
+      ++*nonexclusive_singletons_on_each_proc[proc];
+      ++singletons_on_each_node[i];
+      if (auto_nonexclusive_singletons_on_each_proc[proc].has_value()) {
+        ++*auto_nonexclusive_singletons_on_each_proc[proc];
+      } else {
+        auto_nonexclusive_singletons_on_each_proc[proc] = 1;
+      }
+      --remaining_auto_nonexclusive_singletons;
+
+      // We need to break out of both loops here. Use a goto.
+      if (remaining_auto_nonexclusive_singletons == 0) {
+        goto break_auto_nonexclusive_loops;
+      }
+    }  // for (size_t i = 0; i < num_nodes; i++)
+
+    ++min_num_singletons_on_a_node;
+  }  // while (remaining_auto_nonexclusive_singletons > 0)
+break_auto_nonexclusive_loops:
+
+  ASSERT(remaining_auto_nonexclusive_singletons == 0,
+         "Not all nonexclusive singletons have been allocated. The remaining "
+         "number of singletons to be allocated is "
+             << remaining_auto_nonexclusive_singletons << ".");
+
+  // Actually allocate the auto nonexclusive singletons
+  size_t current_proc = 0;
+  tmpl::for_each<singletons>([this, &current_proc,
+                              &auto_nonexclusive_singletons_on_each_proc](
+                                 const auto component_v) {
+    using component = tmpl::type_from<decltype(component_v)>;
+    auto& singleton_map = tuples::get<LocalTag<component>>(singleton_map_);
+    const auto proc_opt = singleton_map.second;
+
+    // At this point, the only singletons that have this are nonexclusive
+    if (not proc_opt.has_value()) {
+      while (not auto_nonexclusive_singletons_on_each_proc[current_proc]
+                     .has_value()) {
+        ++current_proc;
+      }
+
+      singleton_map.second = current_proc;
+
+      --*auto_nonexclusive_singletons_on_each_proc[current_proc];
+      // Indicate that there are no more singletons to be placed on this proc
+      if (*auto_nonexclusive_singletons_on_each_proc[current_proc] == 0) {
+        auto_nonexclusive_singletons_on_each_proc[current_proc] = std::nullopt;
+      }
+    }
+
+    // Print some diagnostic info to stdout for each singleton. This can aid in
+    // debugging.
+    Parallel::printf("Allocating %s on proc %d, exclusive = %s\n",
+                     pretty_type::name<component>(), *singleton_map.second,
+                     singleton_map.first ? "true" : "false");
+  });
+
+  // Now that everything has been set, signal that we don't have to do
+  // this again.
+  singleton_map_has_been_set_ = true;
+}
 }  // namespace Parallel

--- a/src/Parallel/Tags/CMakeLists.txt
+++ b/src/Parallel/Tags/CMakeLists.txt
@@ -6,5 +6,6 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Metavariables.hpp
+  ResourceInfo.hpp
   Section.hpp
   )

--- a/src/Parallel/Tags/ResourceInfo.hpp
+++ b/src/Parallel/Tags/ResourceInfo.hpp
@@ -1,0 +1,67 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <string>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/ResourceInfo.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/System/ParallelInfo.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Parallel {
+namespace OptionTags {
+/// \ingroup ParallelGroup
+/// Options group for resource allocation
+template <typename Metavariables>
+struct ResourceInfo {
+  using type = Parallel::ResourceInfo<Metavariables>;
+  static constexpr Options::String help = {
+      "Options for allocating resources. This information will be used when "
+      "placing Array and Singleton parallel components on the requested "
+      "resources."};
+};
+}  // namespace OptionTags
+
+namespace Tags {
+/// \ingroup ParallelGroup
+/// Tag that tells whether to avoid placing Singleton and Array components
+/// on the global proc 0
+struct AvoidGlobalProc0 : db::SimpleTag {
+  using type = bool;
+  template <typename Metavariables>
+  using option_tags =
+      tmpl::list<Parallel::OptionTags::ResourceInfo<Metavariables>>;
+
+  static constexpr bool pass_metavariables = true;
+  template <typename Metavariables>
+  static bool create_from_options(
+      const Parallel::ResourceInfo<Metavariables>& resource_info) {
+    return resource_info.avoid_global_proc_0();
+  }
+};
+
+/// \ingroup ParallelGroup
+/// Tag that holds resource info about a singleton.
+template <typename ParallelComponent>
+struct SingletonInfo : db::SimpleTag {
+  using type = Parallel::SingletonInfoHolder<ParallelComponent>;
+  static std::string name() { return pretty_type::name<ParallelComponent>(); }
+
+  static constexpr bool pass_metavariables = true;
+
+  template <typename Metavariables>
+  using option_tags =
+      tmpl::list<Parallel::OptionTags::ResourceInfo<Metavariables>>;
+
+  template <typename Metavariables>
+  static type create_from_options(
+      const Parallel::ResourceInfo<Metavariables>& resource_info) {
+    return resource_info.template get_singleton_info<ParallelComponent>();
+  }
+};
+}  // namespace Tags
+}  // namespace Parallel

--- a/src/Parallel/TypeTraits.hpp
+++ b/src/Parallel/TypeTraits.hpp
@@ -58,32 +58,44 @@ struct is_bound_array<T, std::void_t<typename T::bind_to>> : std::true_type {
 };
 
 /// \ingroup ParallelGroup
+/// @{
 /// Check if `T` is a SpECTRE Array
 template <typename T>
-constexpr bool is_array_v =
-    std::is_same_v<Parallel::Algorithms::Array,
-                   typename T::chare_type::component_type>;
+struct is_array : std::is_same<Parallel::Algorithms::Array,
+                               typename T::chare_type::component_type> {};
+template <typename T>
+constexpr bool is_array_v = is_array<T>::value;
+/// @}
 
 /// \ingroup ParallelGroup
+/// @{
 /// Check if `T` is a SpECTRE Singleton
 template <typename T>
-constexpr bool is_singleton_v =
-    std::is_same_v<Parallel::Algorithms::Singleton,
-                   typename T::chare_type::component_type>;
+struct is_singleton : std::is_same<Parallel::Algorithms::Singleton,
+                                   typename T::chare_type::component_type> {};
+template <typename T>
+constexpr bool is_singleton_v = is_singleton<T>::value;
+/// @}
 
 /// \ingroup ParallelGroup
+/// @{
 /// Check if `T` is a SpECTRE Group
 template <typename T>
-constexpr bool is_group_v =
-    std::is_same_v<Parallel::Algorithms::Group,
-                   typename T::chare_type::component_type>;
+struct is_group : std::is_same<Parallel::Algorithms::Group,
+                               typename T::chare_type::component_type> {};
+template <typename T>
+constexpr bool is_group_v = is_group<T>::value;
+/// @}
 
 /// \ingroup ParallelGroup
+/// @{
 /// Check if `T` is a SpECTRE Nodegroup
 template <typename T>
-constexpr bool is_nodegroup_v =
-    std::is_same_v<Parallel::Algorithms::Nodegroup,
-                   typename T::chare_type::component_type>;
+struct is_nodegroup : std::is_same<Parallel::Algorithms::Nodegroup,
+                                   typename T::chare_type::component_type> {};
+template <typename T>
+constexpr bool is_nodegroup_v = is_nodegroup<T>::value;
+/// @}
 
 /// @{
 /// \ingroup ParallelGroup

--- a/src/Utilities/StdHelpers.hpp
+++ b/src/Utilities/StdHelpers.hpp
@@ -156,6 +156,17 @@ inline std::ostream& operator<<(std::ostream& os,
 
 /*!
  * \ingroup UtilitiesGroup
+ * \brief Output the items of a std::unordered_multiset
+ */
+template <typename T, typename H>
+inline std::ostream& operator<<(std::ostream& os,
+                                const std::unordered_multiset<T, H>& v) {
+  unordered_print_helper(os, std::begin(v), std::end(v));
+  return os;
+}
+
+/*!
+ * \ingroup UtilitiesGroup
  * \brief Output the items of a std::set
  */
 template <typename T, typename C>

--- a/src/Utilities/StlStreamDeclarations.hpp
+++ b/src/Utilities/StlStreamDeclarations.hpp
@@ -58,6 +58,10 @@ inline std::ostream& operator<<(std::ostream& os, const std::map<K, V, C>& m);
 template <typename T, typename H>
 std::ostream& operator<<(std::ostream& os, const std::unordered_set<T, H>& v);
 
+template <typename T, typename H>
+std::ostream& operator<<(std::ostream& os,
+                         const std::unordered_multiset<T, H>& v);
+
 template <typename T, typename C>
 inline std::ostream& operator<<(std::ostream& os, const std::set<T, C>& v);
 

--- a/tests/Unit/Parallel/Test_ResourceInfo.cpp
+++ b/tests/Unit/Parallel/Test_ResourceInfo.cpp
@@ -6,29 +6,92 @@
 #include <cstddef>
 #include <optional>
 #include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
 
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "Parallel/Algorithms/AlgorithmSingletonDeclarations.hpp"
+#include "Parallel/GlobalCache.hpp"
 #include "Parallel/ResourceInfo.hpp"
+#include "Parallel/Tags/ResourceInfo.hpp"
 #include "Utilities/GetOutput.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace Parallel {
 namespace {
-template <size_t Index>
+template <typename Metavariables, size_t Index>
 struct FakeSingleton {
   using chare_type = Parallel::Algorithms::Singleton;
+  using metavariables = Metavariables;
   static std::string name() { return "FakeSingleton" + get_output(Index); }
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::Initialization,
+                                        tmpl::list<>>>;
+  using initialization_tags = tmpl::list<
+      Parallel::Tags::AvoidGlobalProc0,
+      Parallel::Tags::SingletonInfo<FakeSingleton<Metavariables, Index>>>;
 };
 
+template <typename Metavariables, size_t Index>
+struct FakeSingletonInfoOnly {
+  using chare_type = Parallel::Algorithms::Singleton;
+  using metavariables = Metavariables;
+  static std::string name() { return "FakeSingleton" + get_output(Index); }
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::Initialization,
+                                        tmpl::list<>>>;
+  using initialization_tags = tmpl::list<Parallel::Tags::SingletonInfo<
+      FakeSingletonInfoOnly<Metavariables, Index>>>;
+};
+template <typename Metavariables>
+struct FakeSingletonAvoidGlobalProc0 {
+  using chare_type = Parallel::Algorithms::Singleton;
+  using metavariables = Metavariables;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::Initialization,
+                                        tmpl::list<>>>;
+  using initialization_tags = tmpl::list<Parallel::Tags::AvoidGlobalProc0>;
+};
+
+template <size_t... Indices>
+struct MetavariablesBoth {
+  using component_list =
+      tmpl::list<FakeSingleton<MetavariablesBoth, Indices>...>;
+  enum class Phase { Initialization, Exit };
+};
+template <size_t... Indices>
+struct MetavariablesInfoOnly {
+  using component_list =
+      tmpl::list<FakeSingletonInfoOnly<MetavariablesInfoOnly, Indices>...>;
+  enum class Phase { Initialization, Exit };
+};
+struct MetavariablesAvoidGlobalProc0 {
+  using component_list =
+      tmpl::list<FakeSingletonAvoidGlobalProc0<MetavariablesAvoidGlobalProc0>>;
+  enum class Phase { Initialization, Exit };
+};
+
+struct EmptyMetavars {
+  enum class Phase { Initialization, Exit };
+};
+
+template <size_t Index>
+using fake_singleton = FakeSingleton<EmptyMetavars, Index>;
+
 void test_singleton_info() {
-  SingletonInfoHolder<FakeSingleton<0>> info_holder{};
+  SingletonInfoHolder<fake_singleton<0>> info_holder{};
   CHECK(info_holder.proc() == std::nullopt);
   CHECK_FALSE(info_holder.is_exclusive());
 
   info_holder = TestHelpers::test_creation<
-      Parallel::SingletonInfoHolder<FakeSingleton<0>>>(
+      Parallel::SingletonInfoHolder<fake_singleton<0>>>(
       "Proc: 0\n"
       "Exclusive: false\n");
   CHECK(info_holder.proc().value() == 0);
@@ -39,14 +102,14 @@ void test_singleton_info() {
   CHECK(info_holder.is_exclusive() == serialized_info_holder.is_exclusive());
 
   info_holder = TestHelpers::test_creation<
-      Parallel::SingletonInfoHolder<FakeSingleton<0>>>(
+      Parallel::SingletonInfoHolder<fake_singleton<0>>>(
       "Proc: Auto\n"
       "Exclusive: false\n");
   CHECK(info_holder.proc() == std::nullopt);
   CHECK_FALSE(info_holder.is_exclusive());
 
   info_holder = TestHelpers::test_creation<
-      Parallel::SingletonInfoHolder<FakeSingleton<0>>>(
+      Parallel::SingletonInfoHolder<fake_singleton<0>>>(
       "Proc: 4\n"
       "Exclusive: true\n");
   CHECK(info_holder.proc().value() == 4);
@@ -54,7 +117,7 @@ void test_singleton_info() {
 
   CHECK_THROWS_WITH(([]() {
                       auto info_holder_error = TestHelpers::test_creation<
-                          Parallel::SingletonInfoHolder<FakeSingleton<0>>>(
+                          Parallel::SingletonInfoHolder<fake_singleton<0>>>(
                           "Proc: -2\n"
                           "Exclusive: true\n");
                       (void)info_holder_error;
@@ -64,20 +127,20 @@ void test_singleton_info() {
 
 void test_singleton_pack() {
   const auto info0 = TestHelpers::test_creation<
-      Parallel::SingletonInfoHolder<FakeSingleton<0>>>(
+      Parallel::SingletonInfoHolder<fake_singleton<0>>>(
       "Proc: 0\n"
       "Exclusive: false\n");
   const auto info1 = TestHelpers::test_creation<
-      Parallel::SingletonInfoHolder<FakeSingleton<1>>>(
+      Parallel::SingletonInfoHolder<fake_singleton<1>>>(
       "Proc: 1\n"
       "Exclusive: true\n");
   const auto info2 = TestHelpers::test_creation<
-      Parallel::SingletonInfoHolder<FakeSingleton<2>>>(
+      Parallel::SingletonInfoHolder<fake_singleton<2>>>(
       "Proc: Auto\n"
       "Exclusive: true\n");
 
   using pack_list =
-      tmpl::list<FakeSingleton<0>, FakeSingleton<1>, FakeSingleton<2>>;
+      tmpl::list<fake_singleton<0>, fake_singleton<1>, fake_singleton<2>>;
   const auto singleton_pack =
       TestHelpers::test_creation<SingletonPack<pack_list>>(
           "FakeSingleton0:\n"
@@ -90,9 +153,9 @@ void test_singleton_pack() {
           "  Proc: Auto\n"
           "  Exclusive: true\n");
 
-  const auto& pack_info0 = singleton_pack.get<FakeSingleton<0>>();
-  const auto& pack_info1 = singleton_pack.get<FakeSingleton<1>>();
-  const auto& pack_info2 = singleton_pack.get<FakeSingleton<2>>();
+  const auto& pack_info0 = singleton_pack.get<fake_singleton<0>>();
+  const auto& pack_info1 = singleton_pack.get<fake_singleton<1>>();
+  const auto& pack_info2 = singleton_pack.get<fake_singleton<2>>();
 
   CHECK(info0.proc() == pack_info0.proc());
   CHECK(info0.is_exclusive() == pack_info0.is_exclusive());
@@ -102,9 +165,9 @@ void test_singleton_pack() {
   CHECK(info2.is_exclusive() == pack_info2.is_exclusive());
 
   const auto serialized_pack = serialize_and_deserialize(singleton_pack);
-  const auto& serialized_pack_info0 = serialized_pack.get<FakeSingleton<0>>();
-  const auto& serialized_pack_info1 = serialized_pack.get<FakeSingleton<1>>();
-  const auto& serialized_pack_info2 = serialized_pack.get<FakeSingleton<2>>();
+  const auto& serialized_pack_info0 = serialized_pack.get<fake_singleton<0>>();
+  const auto& serialized_pack_info1 = serialized_pack.get<fake_singleton<1>>();
+  const auto& serialized_pack_info2 = serialized_pack.get<fake_singleton<2>>();
 
   CHECK(serialized_pack_info0.proc() == pack_info0.proc());
   CHECK(serialized_pack_info0.is_exclusive() == pack_info0.is_exclusive());
@@ -119,16 +182,794 @@ void test_singleton_pack() {
         const auto serialized_empty_pack =
             serialize_and_deserialize(empty_pack);
         const auto& throws_error =
-            serialized_empty_pack.get<FakeSingleton<0>>();
+            serialized_empty_pack.get<fake_singleton<0>>();
         (void)throws_error;
       })(),
       Catch::Contains("Cannot call the get() member of a SingletonPack with an "
                       "empty component list."));
 }
+
+void test_tags() {
+  using metavars = MetavariablesBoth<0>;
+
+  TestHelpers::db::test_simple_tag<
+      Tags::SingletonInfo<FakeSingleton<metavars, 0>>>("FakeSingleton0");
+  TestHelpers::db::test_simple_tag<Tags::AvoidGlobalProc0>("AvoidGlobalProc0");
+
+  Parallel::MutableGlobalCache<metavars> mutable_cache{};
+  Parallel::GlobalCache<metavars> cache{{}, &mutable_cache};
+  const SingletonInfoHolder<FakeSingleton<metavars, 0>> info_holder{{0}, false};
+
+  ResourceInfo<metavars> resource_info{false, {info_holder}};
+  resource_info.build_singleton_map(cache);
+
+  const bool avoid_global_proc_0 =
+      Tags::AvoidGlobalProc0::create_from_options<metavars>(resource_info);
+  CHECK_FALSE(avoid_global_proc_0);
+
+  const auto tag_info_holder = Tags::SingletonInfo<
+      FakeSingleton<metavars, 0>>::create_from_options<metavars>(resource_info);
+  CHECK(info_holder.proc() == tag_info_holder.proc());
+  CHECK(info_holder.is_exclusive() == tag_info_holder.is_exclusive());
+}
+
+void test_single_core() {
+  {
+    INFO("AvoidGlobalProc0 and Singletons");
+    using metavars = MetavariablesBoth<0>;
+    Parallel::MutableGlobalCache<metavars> mutable_cache{};
+    Parallel::GlobalCache<metavars> cache{{}, &mutable_cache};
+    // Both of these should be identical since we are running on one proc
+    auto resource_info_0 =
+        TestHelpers::test_option_tag<OptionTags::ResourceInfo<metavars>>(
+            "AvoidGlobalProc0: false\n"
+            "Singletons:\n"
+            "  FakeSingleton0:\n"
+            "    Proc: 0\n"
+            "    Exclusive: false\n");
+    auto resource_info_auto =
+        TestHelpers::test_option_tag<OptionTags::ResourceInfo<metavars>>(
+            "AvoidGlobalProc0: false\n"
+            "Singletons:\n"
+            "  FakeSingleton0:\n"
+            "    Proc: Auto\n"
+            "    Exclusive: false\n");
+
+    resource_info_0.build_singleton_map(cache);
+    resource_info_auto.build_singleton_map(cache);
+
+    CHECK_FALSE(resource_info_0.avoid_global_proc_0());
+    CHECK_FALSE(resource_info_auto.avoid_global_proc_0());
+
+    const size_t proc_0 =
+        resource_info_0.template proc_for<FakeSingleton<metavars, 0>>();
+    const size_t proc_auto =
+        resource_info_auto.template proc_for<FakeSingleton<metavars, 0>>();
+
+    // Only running on once proc
+    CHECK(proc_0 == 0);
+    CHECK(proc_auto == 0);
+
+    const auto& info_0 =
+        resource_info_0.get_singleton_info<FakeSingleton<metavars, 0>>();
+    const auto& info_auto =
+        resource_info_auto.get_singleton_info<FakeSingleton<metavars, 0>>();
+
+    CHECK(info_0.proc().value() == 0);
+    CHECK(info_auto.proc().value() == 0);
+    CHECK_FALSE(info_0.is_exclusive());
+    CHECK_FALSE(info_auto.is_exclusive());
+
+    const auto serialized_resource_info_0 =
+        serialize_and_deserialize(resource_info_0);
+    const size_t serialized_proc_0 =
+        resource_info_0.template proc_for<FakeSingleton<metavars, 0>>();
+    const auto& serialized_info_0 =
+        resource_info_0.get_singleton_info<FakeSingleton<metavars, 0>>();
+
+    CHECK_FALSE(serialized_resource_info_0.avoid_global_proc_0());
+    CHECK(proc_0 == serialized_proc_0);
+    CHECK(info_0.proc() == serialized_info_0.proc());
+    CHECK(info_0.is_exclusive() == serialized_info_0.is_exclusive());
+  }
+  {
+    INFO("Only Singletons");
+    using metavars = MetavariablesInfoOnly<0, 1>;
+    Parallel::MutableGlobalCache<metavars> mutable_cache{};
+    Parallel::GlobalCache<metavars> cache{{}, &mutable_cache};
+    // Both of these should be identical since we are running on one proc
+    auto resource_info =
+        TestHelpers::test_option_tag<OptionTags::ResourceInfo<metavars>>(
+            "Singletons:\n"
+            "  FakeSingleton0:\n"
+            "    Proc: 0\n"
+            "    Exclusive: false\n"
+            "  FakeSingleton1:\n"
+            "    Proc: Auto\n"
+            "    Exclusive: false\n");
+
+    resource_info.build_singleton_map(cache);
+
+    const size_t proc_0 =
+        resource_info.template proc_for<FakeSingletonInfoOnly<metavars, 0>>();
+    const size_t proc_1 =
+        resource_info.template proc_for<FakeSingletonInfoOnly<metavars, 1>>();
+
+    // Only running on once proc
+    CHECK(proc_0 == 0);
+    CHECK(proc_1 == 0);
+
+    const auto& info_0 =
+        resource_info.get_singleton_info<FakeSingletonInfoOnly<metavars, 0>>();
+    const auto& info_1 =
+        resource_info.get_singleton_info<FakeSingletonInfoOnly<metavars, 1>>();
+
+    CHECK(info_0.proc().value() == 0);
+    CHECK(info_1.proc().value() == 0);
+    CHECK_FALSE(info_0.is_exclusive());
+    CHECK_FALSE(info_1.is_exclusive());
+  }
+  {
+    INFO("Only AvoidGlobalProc0");
+    const auto resource_info = TestHelpers::test_option_tag<
+        OptionTags::ResourceInfo<MetavariablesAvoidGlobalProc0>>(
+        "AvoidGlobalProc0: false\n");
+
+    CHECK_FALSE(resource_info.avoid_global_proc_0());
+  }
+}
+
+void test_errors() {
+  using metavars = MetavariablesBoth<0>;
+  Parallel::MutableGlobalCache<metavars> mutable_cache{};
+  Parallel::GlobalCache<metavars> cache{{}, &mutable_cache};
+
+  // Check as many errors as we can on one proc
+  CHECK_THROWS_WITH(
+      ([]() {
+        const auto resource_info =
+            TestHelpers::test_option_tag<OptionTags::ResourceInfo<metavars>>(
+                "AvoidGlobalProc0: false\n"
+                "Singletons:\n"
+                "  FakeSingleton0:\n"
+                "    Proc: -2\n"
+                "    Exclusive: false\n");
+      })(),
+      Catch::Contains("Proc must be a non-negative integer."));
+
+  CHECK_THROWS_WITH(
+      ([]() {
+        const auto resource_info =
+            TestHelpers::test_option_tag<OptionTags::ResourceInfo<metavars>>(
+                "AvoidGlobalProc0: true\n"
+                "Singletons:\n"
+                "  FakeSingleton0:\n"
+                "    Proc: 0\n"
+                "    Exclusive: true\n");
+      })(),
+      Catch::Contains("A singleton has requested to be exclusively on proc 0, "
+                      "but the AvoidGlobalProc0 option is also set to true."));
+
+  CHECK_THROWS_WITH(
+      ([]() {
+        const auto resource_info = TestHelpers::test_option_tag<
+            OptionTags::ResourceInfo<MetavariablesBoth<0, 1>>>(
+            "AvoidGlobalProc0: false\n"
+            "Singletons:\n"
+            "  FakeSingleton0:\n"
+            "    Proc: 0\n"
+            "    Exclusive: true\n"
+            "  FakeSingleton1:\n"
+            "    Proc: 0\n"
+            "    Exclusive: true\n");
+      })(),
+      Catch::Contains(
+          "Two singletons have requested to be on proc 0, but at least one of "
+          "them has requested to be exclusively on this proc."));
+
+  CHECK_THROWS_WITH(
+      ([&cache]() {
+        auto resource_info =
+            TestHelpers::test_option_tag<OptionTags::ResourceInfo<metavars>>(
+                "AvoidGlobalProc0: false\n"
+                "Singletons:\n"
+                "  FakeSingleton0:\n"
+                "    Proc: 2\n"
+                "    Exclusive: false\n");
+        resource_info.build_singleton_map(cache);
+      })(),
+      Catch::Contains("is beyond the last proc"));
+
+  CHECK_THROWS_WITH(
+      ([&cache]() {
+        auto resource_info =
+            TestHelpers::test_option_tag<OptionTags::ResourceInfo<metavars>>(
+                "AvoidGlobalProc0: false\n"
+                "Singletons:\n"
+                "  FakeSingleton0:\n"
+                "    Proc: 0\n"
+                "    Exclusive: true\n");
+        resource_info.build_singleton_map(cache);
+      })(),
+      Catch::Contains(
+          "The total number of cores requested is less than or equal to the "
+          "number of cores that requested to be exclusive, i.e. without"));
+
+  CHECK_THROWS_WITH(
+      ([]() {
+        auto resource_info =
+            TestHelpers::test_option_tag<OptionTags::ResourceInfo<metavars>>(
+                "AvoidGlobalProc0: true\n"
+                "Singletons:\n"
+                "  FakeSingleton0:\n"
+                "    Proc: 0\n"
+                "    Exclusive: false\n");
+        [[maybe_unused]] const size_t proc =
+            resource_info.template proc_for<FakeSingleton<metavars, 0>>();
+      })(),
+      Catch::Contains("The singleton map has not been built yet. You must call "
+                      "build_singleton_map() before you call this function."));
+
+  CHECK_THROWS_WITH(
+      ([]() {
+        auto resource_info =
+            TestHelpers::test_option_tag<OptionTags::ResourceInfo<metavars>>(
+                "AvoidGlobalProc0: true\n"
+                "Singletons:\n"
+                "  FakeSingleton0:\n"
+                "    Proc: 0\n"
+                "    Exclusive: false\n");
+        [[maybe_unused]] const auto& procs_to_ignore =
+            resource_info.procs_to_ignore();
+      })(),
+      Catch::Contains("The singleton map has not been built yet. You must call "
+                      "build_singleton_map() before you call this function."));
+
+  CHECK_THROWS_WITH(
+      ([]() {
+        auto resource_info =
+            TestHelpers::test_option_tag<OptionTags::ResourceInfo<metavars>>(
+                "AvoidGlobalProc0: true\n"
+                "Singletons:\n"
+                "  FakeSingleton0:\n"
+                "    Proc: 0\n"
+                "    Exclusive: false\n");
+        [[maybe_unused]] const auto singleton_info =
+            resource_info.get_singleton_info<FakeSingleton<metavars, 0>>();
+      })(),
+      Catch::Contains("The singleton map has not been built yet. You must call "
+                      "build_singleton_map() before you call this function."));
+}
+
+template <typename Metavariables>
+Parallel::ResourceInfo<Metavariables> create_resource_info(
+    const bool avoid_global_proc_0,
+    const std::vector<std::pair<bool, int>>& singletons) {
+  std::string option_str =
+      "AvoidGlobalProc0: " + (avoid_global_proc_0 ? "true"s : "false"s) + "\n";
+  option_str += "Singletons:\n";
+  for (size_t i = 0; i < singletons.size(); i++) {
+    const bool exclusive = singletons[i].first;
+    const int proc = singletons[i].second;
+    option_str += "  FakeSingleton" + get_output(i) + ":\n";
+    option_str +=
+        "    Proc: " + (proc == -1 ? "Auto"s : get_output(proc)) + "\n";
+    option_str += "    Exclusive: " + (exclusive ? "true"s : "false"s) + "\n";
+  }
+
+  return serialize_and_deserialize(
+      TestHelpers::test_option_tag<OptionTags::ResourceInfo<Metavariables>>(
+          option_str));
+}
+
+constexpr size_t num_singletons = 7;
+using metavars = MetavariablesBoth<0, 1, 2, 3, 4, 5, 6>;
+template <size_t Index>
+using component = FakeSingleton<metavars, Index>;
+
+void check_resource_info(
+    const Parallel::GlobalCache<metavars>& cache, bool avoid_global_proc_0,
+    const std::vector<std::pair<bool, int>>& singletons,
+    const std::vector<std::pair<bool, int>>& expected_singletons) {
+  auto resource_info =
+      create_resource_info<metavars>(avoid_global_proc_0, singletons);
+  resource_info.build_singleton_map(cache);
+
+  std::unordered_set<size_t> expected_exclusive_procs{};
+  for (auto& exclusive_and_proc : expected_singletons) {
+    if (exclusive_and_proc.first) {
+      expected_exclusive_procs.insert(
+          static_cast<size_t>(exclusive_and_proc.second));
+    }
+  }
+
+  if (avoid_global_proc_0) {
+    expected_exclusive_procs.insert(0);
+  }
+
+  const auto& procs_to_ignore = resource_info.procs_to_ignore();
+
+  CHECK(resource_info.avoid_global_proc_0() == avoid_global_proc_0);
+  CHECK(procs_to_ignore.size() == expected_exclusive_procs.size());
+  for (auto& exclusive_proc : expected_exclusive_procs) {
+    CHECK(procs_to_ignore.count(exclusive_proc) == 1);
+  }
+
+  tmpl::for_each<tmpl::range<size_t, 0, num_singletons>>(
+      [&expected_singletons, &resource_info](const auto size_holder) {
+        constexpr size_t index =
+            std::decay_t<decltype(size_holder)>::type::value;
+        INFO("Index: " + get_output(index));
+        auto singleton_info =
+            resource_info.get_singleton_info<component<index>>();
+        CHECK(singleton_info.is_exclusive() ==
+              expected_singletons[index].first);
+        CHECK(static_cast<int>(singleton_info.proc().value()) ==
+              expected_singletons[index].second);
+        CHECK(resource_info.template proc_for<component<index>>() ==
+              static_cast<size_t>(expected_singletons[index].second));
+      });
+}
+
+template <typename Gen>
+void test_single_node_multi_core(const gsl::not_null<Gen*> gen) {
+  Parallel::MutableGlobalCache<metavars> mutable_cache{};
+  // 1 node, 3 procs per node
+  Parallel::GlobalCache<metavars> cache{{}, &mutable_cache, {3}};
+
+  INFO("1 node, 3 procs per node");
+
+  {
+    INFO("AvoidGlobalProc0 false; All singletons Auto and not exclusive");
+    std::vector<std::pair<bool, int>> singletons{num_singletons};
+    for (size_t i = 0; i < num_singletons; i++) {
+      singletons[i] = std::pair<bool, int>{false, -1};
+    }
+    const std::vector<std::pair<bool, int>> expected{
+        {false, 0}, {false, 0}, {false, 0}, {false, 1},
+        {false, 1}, {false, 2}, {false, 2}};
+
+    check_resource_info(cache, false, singletons, expected);
+  }
+  {
+    INFO("AvoidGlobalProc0 true; All singletons Auto and not exclusive");
+    std::vector<std::pair<bool, int>> singletons{num_singletons};
+    for (size_t i = 0; i < num_singletons; i++) {
+      singletons[i] = std::pair<bool, int>{false, -1};
+    }
+    const std::vector<std::pair<bool, int>> expected{
+        {false, 1}, {false, 1}, {false, 1}, {false, 1},
+        {false, 2}, {false, 2}, {false, 2}};
+
+    check_resource_info(cache, true, singletons, expected);
+  }
+  {
+    INFO("AvoidGlobalProc0 false; One singleton exclusive Auto");
+    std::vector<std::pair<bool, int>> singletons{num_singletons};
+    for (size_t i = 0; i < num_singletons; i++) {
+      singletons[i] = std::pair<bool, int>{i == 4, -1};
+    }
+    const std::vector<std::pair<bool, int>> expected{
+        {false, 1}, {false, 1}, {false, 1}, {false, 2},
+        {true, 0},  {false, 2}, {false, 2}};
+
+    check_resource_info(cache, false, singletons, expected);
+  }
+  {
+    INFO("AvoidGlobalProc0 true; One singleton exclusive Auto");
+    std::vector<std::pair<bool, int>> singletons{num_singletons};
+    for (size_t i = 0; i < num_singletons; i++) {
+      singletons[i] = std::pair<bool, int>{i == 6, -1};
+    }
+    const std::vector<std::pair<bool, int>> expected{
+        {false, 2}, {false, 2}, {false, 2}, {false, 2},
+        {false, 2}, {false, 2}, {true, 1}};
+
+    check_resource_info(cache, true, singletons, expected);
+  }
+  {
+    INFO("AvoidGlobalProc0 false; All singletons requested and non-exclusive");
+    std::vector<std::pair<bool, int>> singletons{num_singletons};
+    std::uniform_int_distribution<int> dist{0, 2};
+    for (size_t i = 0; i < num_singletons; i++) {
+      singletons[i] = std::pair<bool, int>{false, dist(*gen)};
+    }
+
+    check_resource_info(cache, false, singletons, singletons);
+  }
+  {
+    INFO("AvoidGlobalProc0 false; Two singletons exclusive, both Auto");
+    std::vector<std::pair<bool, int>> singletons{num_singletons};
+    for (size_t i = 0; i < num_singletons; i++) {
+      singletons[i] = std::pair<bool, int>{i == 2 or i == 4, -1};
+    }
+    const std::vector<std::pair<bool, int>> expected{
+        {false, 2}, {false, 2}, {true, 0}, {false, 2},
+        {true, 1},  {false, 2}, {false, 2}};
+
+    check_resource_info(cache, false, singletons, expected);
+  }
+  {
+    INFO(
+        "AvoidGlobalProc0 false; Two singletons exclusive, one Auto one "
+        "requested");
+    std::vector<std::pair<bool, int>> singletons{num_singletons};
+    for (size_t i = 0; i < num_singletons; i++) {
+      singletons[i] = std::pair<bool, int>{i == 2 or i == 4, i == 2 ? 1 : -1};
+    }
+    const std::vector<std::pair<bool, int>> expected{
+        {false, 2}, {false, 2}, {true, 1}, {false, 2},
+        {true, 0},  {false, 2}, {false, 2}};
+
+    check_resource_info(cache, false, singletons, expected);
+  }
+  {
+    INFO("AvoidGlobalProc0 false; Two singletons exclusive, both requested");
+    std::vector<std::pair<bool, int>> singletons{num_singletons};
+    for (size_t i = 0; i < num_singletons; i++) {
+      singletons[i] =
+          std::pair<bool, int>{i == 2 or i == 4, i == 2 ? 0 : i == 4 ? 2 : -1};
+    }
+    const std::vector<std::pair<bool, int>> expected{
+        {false, 1}, {false, 1}, {true, 0}, {false, 1},
+        {true, 2},  {false, 1}, {false, 1}};
+
+    check_resource_info(cache, false, singletons, expected);
+  }
+  {
+    INFO(
+        "AvoidGlobalProc0 false; One singleton exclusive Auto, one "
+        "nonexclusive requested");
+    std::vector<std::pair<bool, int>> singletons{num_singletons};
+    for (size_t i = 0; i < num_singletons; i++) {
+      singletons[i] = std::pair<bool, int>{i == 4, i == 5 ? 0 : -1};
+    }
+    const std::vector<std::pair<bool, int>> expected{
+        {false, 0}, {false, 0}, {false, 2}, {false, 2},
+        {true, 1},  {false, 0}, {false, 2}};
+
+    check_resource_info(cache, false, singletons, expected);
+  }
+  {
+    INFO("AvoidGlobalProc0 false; All random");
+    const std::vector<std::pair<bool, int>> singletons{
+        {false, 2}, {false, 2},  {false, -1}, {false, 1},
+        {true, -1}, {false, -1}, {false, -1}};
+    const std::vector<std::pair<bool, int>> expected{
+        {false, 2}, {false, 2}, {false, 1}, {false, 1},
+        {true, 0},  {false, 1}, {false, 2}};
+
+    check_resource_info(cache, false, singletons, expected);
+  }
+}
+
+template <typename Gen>
+void test_multi_node_multi_core(const gsl::not_null<Gen*> gen) {
+  Parallel::MutableGlobalCache<metavars> mutable_cache{};
+  // 3 nodes, 2 procs per node
+  Parallel::GlobalCache<metavars> cache{{}, &mutable_cache, {2, 2, 2}};
+
+  INFO("3 nodes, 2 procs per node");
+
+  {
+    INFO("AvoidGlobalProc0 false; All singletons Auto and not exclusive");
+    std::vector<std::pair<bool, int>> singletons{num_singletons};
+    for (size_t i = 0; i < num_singletons; i++) {
+      singletons[i] = std::pair<bool, int>{false, -1};
+    }
+    const std::vector<std::pair<bool, int>> expected{
+        {false, 0}, {false, 0}, {false, 1}, {false, 2},
+        {false, 3}, {false, 4}, {false, 5}};
+
+    check_resource_info(cache, false, singletons, expected);
+  }
+  {
+    INFO("AvoidGlobalProc0 true; All singletons Auto and not exclusive");
+    std::vector<std::pair<bool, int>> singletons{num_singletons};
+    for (size_t i = 0; i < num_singletons; i++) {
+      singletons[i] = std::pair<bool, int>{false, -1};
+    }
+    const std::vector<std::pair<bool, int>> expected{
+        {false, 1}, {false, 1}, {false, 1}, {false, 2},
+        {false, 3}, {false, 4}, {false, 5}};
+
+    check_resource_info(cache, true, singletons, expected);
+  }
+  {
+    INFO(
+        "AvoidGlobalProc0 false; All singletons specific procs and not "
+        "exclusive");
+    std::vector<std::pair<bool, int>> singletons{num_singletons};
+    std::uniform_int_distribution<int> dist{0, 5};
+    for (size_t i = 0; i < num_singletons; i++) {
+      singletons[i] = std::pair<bool, int>{false, dist(*gen)};
+    }
+
+    check_resource_info(cache, false, singletons, singletons);
+  }
+  {
+    INFO(
+        "AvoidGlobalProc0 true; All singletons specific procs and not "
+        "exclusive");
+    std::vector<std::pair<bool, int>> singletons{num_singletons};
+    std::uniform_int_distribution<int> dist{1, 5};
+    for (size_t i = 0; i < num_singletons; i++) {
+      singletons[i] = std::pair<bool, int>{false, dist(*gen)};
+    }
+
+    check_resource_info(cache, true, singletons, singletons);
+  }
+  {
+    INFO("AvoidGlobalProc0 false; Mix and match singletons #1: Exclusive Auto");
+    std::vector<std::pair<bool, int>> singletons{num_singletons};
+    for (size_t i = 0; i < num_singletons; i++) {
+      singletons[i] = std::pair<bool, int>{i < 3, -1};
+    }
+    const std::vector<std::pair<bool, int>> expected{
+        {true, 0},  {true, 2},  {true, 4}, {false, 1},
+        {false, 1}, {false, 3}, {false, 5}};
+
+    check_resource_info(cache, false, singletons, expected);
+  }
+  {
+    INFO(
+        "AvoidGlobalProc0 false; Mix and match singletons #2: Exclusive "
+        "specific");
+    std::vector<std::pair<bool, int>> singletons{num_singletons};
+    std::uniform_int_distribution<int> dist{3, 5};
+    for (size_t i = 0; i < num_singletons; i++) {
+      singletons[i] =
+          std::pair<bool, int>{i < 3, i < 3 ? static_cast<int>(i) : dist(*gen)};
+    }
+
+    check_resource_info(cache, false, singletons, singletons);
+  }
+  {
+    INFO("AvoidGlobalProc0 true; Mix and match singletons #3: Exclusive Auto");
+    std::vector<std::pair<bool, int>> singletons{num_singletons};
+    for (size_t i = 0; i < num_singletons; i++) {
+      singletons[i] = std::pair<bool, int>{i < 3, -1};
+    }
+    const std::vector<std::pair<bool, int>> expected{
+        {true, 1},  {true, 2},  {true, 4}, {false, 3},
+        {false, 3}, {false, 5}, {false, 5}};
+
+    check_resource_info(cache, true, singletons, expected);
+  }
+  {
+    INFO(
+        "AvoidGlobalProc0 true; Mix and match singletons #4: Exclusive "
+        "specific");
+    std::vector<std::pair<bool, int>> singletons{num_singletons};
+    std::uniform_int_distribution<int> dist{4, 5};
+    for (size_t i = 0; i < num_singletons; i++) {
+      singletons[i] = std::pair<bool, int>{
+          i < 3, i < 3 ? static_cast<int>(i) + 1 : dist(*gen)};
+    }
+
+    check_resource_info(cache, true, singletons, singletons);
+  }
+  {
+    INFO("AvoidGlobalProc0 false; Mix and match singletons #5: All random");
+    std::vector<std::pair<bool, int>> singletons{
+        {false, -1}, {false, -1}, {false, 3}, {true, 2},
+        {false, 3},  {true, -1},  {false, -1}};
+    std::vector<std::pair<bool, int>> expected{
+        {false, 1}, {false, 4}, {false, 3}, {true, 2},
+        {false, 3}, {true, 0},  {false, 5}};
+
+    check_resource_info(cache, false, singletons, expected);
+  }
+  {
+    INFO("AvoidGlobalProc0 true; Mix and match singletons #6: All random");
+    std::vector<std::pair<bool, int>> singletons{
+        {true, 1},  {false, 2},  {false, -1}, {false, 5},
+        {true, -1}, {false, -1}, {false, -1}};
+    std::vector<std::pair<bool, int>> expected{
+        {true, 1}, {false, 2}, {false, 2}, {false, 5},
+        {true, 3}, {false, 4}, {false, 4}};
+
+    check_resource_info(cache, true, singletons, expected);
+  }
+  {
+    INFO("AvoidGlobalProc0 false; Mix and match singletons #7: All random");
+    std::vector<std::pair<bool, int>> singletons{
+        {true, 1},  {false, -1}, {true, 3},  {false, -1},
+        {true, -1}, {true, 5},   {false, -1}};
+    std::vector<std::pair<bool, int>> expected{
+        {true, 1}, {false, 2}, {true, 3}, {false, 2},
+        {true, 0}, {true, 5},  {false, 4}};
+
+    check_resource_info(cache, false, singletons, expected);
+  }
+  {
+    INFO("AvoidGlobalProc0 false; Mix and match singletons #8: All random");
+    std::vector<std::pair<bool, int>> singletons{
+        {true, 1},  {false, 0}, {true, 3},  {false, -1},
+        {true, -1}, {true, 5},  {false, -1}};
+    std::vector<std::pair<bool, int>> expected{
+        {true, 1}, {false, 0}, {true, 3}, {false, 4},
+        {true, 2}, {true, 5},  {false, 4}};
+
+    check_resource_info(cache, false, singletons, expected);
+  }
+  {
+    INFO(
+        "AvoidGlobalProc0 false; Mix and match singletons #9: Different number "
+        "of procs on node");
+    Parallel::MutableGlobalCache<metavars> local_mutable_cache{};
+    // 3 nodes, (1,2,2) procs on each node
+    Parallel::GlobalCache<metavars> local_cache{
+        {}, &local_mutable_cache, {1, 2, 2}};
+    std::vector<std::pair<bool, int>> singletons{
+        {false, -1}, {true, -1}, {false, -1}, {false, -1},
+        {true, -1},  {true, 0},  {true, 1}};
+    std::vector<std::pair<bool, int>> expected{
+        {false, 4}, {true, 2}, {false, 4}, {false, 4},
+        {true, 3},  {true, 0}, {true, 1}};
+
+    check_resource_info(local_cache, false, singletons, expected);
+  }
+}
+
+template <typename Gen>
+void test_multi_node_multi_core_large(const gsl::not_null<Gen*> gen) {
+  Parallel::MutableGlobalCache<metavars> mutable_cache{};
+  // 8 nodes, 25 procs per node
+  const size_t num_nodes = 8;
+  const size_t num_procs_per_node = 25;
+  const size_t num_procs = num_nodes * num_procs_per_node;
+  Parallel::GlobalCache<metavars> cache{
+      {}, &mutable_cache, std::vector<size_t>(num_nodes, num_procs_per_node)};
+
+  INFO("8 nodes, 25 procs per node");
+
+  {
+    INFO("AvoidGlobalProc0 false; All singletons Auto and not exclusive");
+    std::vector<std::pair<bool, int>> singletons{num_singletons};
+    for (size_t i = 0; i < num_singletons; i++) {
+      singletons[i] = std::pair<bool, int>{false, -1};
+    }
+    const std::vector<std::pair<bool, int>> expected{
+        {false, 0},   {false, 25},  {false, 50}, {false, 75},
+        {false, 100}, {false, 125}, {false, 150}};
+
+    check_resource_info(cache, false, singletons, expected);
+  }
+  {
+    INFO("AvoidGlobalProc0 true; All singletons Auto and not exclusive");
+    std::vector<std::pair<bool, int>> singletons{num_singletons};
+    for (size_t i = 0; i < num_singletons; i++) {
+      singletons[i] = std::pair<bool, int>{false, -1};
+    }
+    const std::vector<std::pair<bool, int>> expected{
+        {false, 1},   {false, 25},  {false, 50}, {false, 75},
+        {false, 100}, {false, 125}, {false, 150}};
+
+    check_resource_info(cache, true, singletons, expected);
+  }
+  {
+    INFO(
+        "AvoidGlobalProc0 false; All singletons specific procs and not "
+        "exclusive");
+    std::vector<std::pair<bool, int>> singletons{num_singletons};
+    std::uniform_int_distribution<int> dist{0, num_procs - 1};
+    for (size_t i = 0; i < num_singletons; i++) {
+      singletons[i] = std::pair<bool, int>{false, dist(*gen)};
+    }
+
+    check_resource_info(cache, false, singletons, singletons);
+  }
+  {
+    INFO(
+        "AvoidGlobalProc0 true; All singletons specific procs and not "
+        "exclusive");
+    std::vector<std::pair<bool, int>> singletons{num_singletons};
+    std::uniform_int_distribution<int> dist{1, num_procs - 1};
+    for (size_t i = 0; i < num_singletons; i++) {
+      singletons[i] = std::pair<bool, int>{false, dist(*gen)};
+    }
+
+    check_resource_info(cache, true, singletons, singletons);
+  }
+  {
+    INFO("AvoidGlobalProc0 false; Mix and match singletons #1: Exclusive Auto");
+    std::vector<std::pair<bool, int>> singletons{num_singletons};
+    for (size_t i = 0; i < num_singletons; i++) {
+      singletons[i] = std::pair<bool, int>{i < 3, -1};
+    }
+    const std::vector<std::pair<bool, int>> expected{
+        {true, 0},    {true, 25},   {true, 50},  {false, 75},
+        {false, 100}, {false, 125}, {false, 150}};
+
+    check_resource_info(cache, false, singletons, expected);
+  }
+  {
+    INFO(
+        "AvoidGlobalProc0 false; Mix and match singletons #2: Exclusive "
+        "specific");
+    std::vector<std::pair<bool, int>> singletons{num_singletons};
+    std::unordered_set<int> used_procs{};
+    std::uniform_int_distribution<int> dist_exclusive{0, 100};
+    std::uniform_int_distribution<int> dist_nonexclusive{101, num_procs - 1};
+    for (size_t i = 0; i < num_singletons; i++) {
+      int exclusive_proc = dist_exclusive(*gen);
+      while (used_procs.count(exclusive_proc) != 0) {
+        exclusive_proc = dist_exclusive(*gen);
+      }
+      used_procs.insert(exclusive_proc);
+      singletons[i] = std::pair<bool, int>{
+          i < 3, i < 3 ? exclusive_proc : dist_nonexclusive(*gen)};
+    }
+
+    check_resource_info(cache, false, singletons, singletons);
+  }
+  {
+    INFO("AvoidGlobalProc0 true; Mix and match singletons #3: Exclusive Auto");
+    std::vector<std::pair<bool, int>> singletons{num_singletons};
+    for (size_t i = 0; i < num_singletons; i++) {
+      singletons[i] = std::pair<bool, int>{i < 3, -1};
+    }
+    const std::vector<std::pair<bool, int>> expected{
+        {true, 1},    {true, 25},   {true, 50},  {false, 75},
+        {false, 100}, {false, 125}, {false, 150}};
+
+    check_resource_info(cache, true, singletons, expected);
+  }
+  {
+    INFO(
+        "AvoidGlobalProc0 true; Mix and match singletons #4: Exclusive "
+        "specific");
+    std::vector<std::pair<bool, int>> singletons{num_singletons};
+    std::unordered_set<int> used_procs{};
+    std::uniform_int_distribution<int> dist_exclusive{1, 100};
+    std::uniform_int_distribution<int> dist_nonexclusive{101, num_procs - 1};
+    for (size_t i = 0; i < num_singletons; i++) {
+      int exclusive_proc = dist_exclusive(*gen);
+      while (used_procs.count(exclusive_proc) != 0) {
+        exclusive_proc = dist_exclusive(*gen);
+      }
+      used_procs.insert(exclusive_proc);
+      singletons[i] = std::pair<bool, int>{
+          i < 3, i < 3 ? exclusive_proc : dist_nonexclusive(*gen)};
+    }
+
+    check_resource_info(cache, true, singletons, singletons);
+  }
+  {
+    INFO("AvoidGlobalProc0 false; Mix and match singletons #5: All random");
+    std::vector<std::pair<bool, int>> singletons{
+        {false, 57}, {false, 56}, {true, -1}, {true, 149},
+        {false, -1}, {false, -1}, {false, -1}};
+    std::vector<std::pair<bool, int>> expected{
+        {false, 57}, {false, 56}, {true, 0},   {true, 149},
+        {false, 25}, {false, 75}, {false, 100}};
+
+    check_resource_info(cache, false, singletons, expected);
+  }
+  {
+    INFO("AvoidGlobalProc0 true; Mix and match singletons #6: All random");
+    std::vector<std::pair<bool, int>> singletons{
+        {true, -1}, {true, 76}, {false, 77}, {false, 77},
+        {true, -1}, {true, -1}, {true, -1}};
+    std::vector<std::pair<bool, int>> expected{
+        {true, 1},  {true, 76}, {false, 77}, {false, 77},
+        {true, 25}, {true, 50}, {true, 100}};
+
+    check_resource_info(cache, true, singletons, expected);
+  }
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Parallel.ResourceInfo", "[Unit][Parallel]") {
+  MAKE_GENERATOR(gen)
   test_singleton_info();
   test_singleton_pack();
+  test_tags();
+  test_single_core();
+  test_single_node_multi_core(make_not_null(&gen));
+  test_multi_node_multi_core(make_not_null(&gen));
+  test_multi_node_multi_core_large(make_not_null(&gen));
+  test_errors();
 }
 }  // namespace Parallel

--- a/tests/Unit/Parallel/Test_TypeTraits.cpp
+++ b/tests/Unit/Parallel/Test_TypeTraits.cpp
@@ -139,3 +139,12 @@ static_assert(Parallel::is_nodegroup_v<NodegroupParallelComponent>);
 static_assert(
     Parallel::is_group_v<Parallel::MutableGlobalCache<Metavariables>>);
 static_assert(Parallel::is_nodegroup_v<Parallel::GlobalCache<Metavariables>>);
+
+static_assert(Parallel::is_singleton<SingletonParallelComponent>::value);
+static_assert(Parallel::is_array<ArrayParallelComponent>::value);
+static_assert(Parallel::is_group<GroupParallelComponent>::value);
+static_assert(Parallel::is_nodegroup<NodegroupParallelComponent>::value);
+static_assert(
+    Parallel::is_group<Parallel::MutableGlobalCache<Metavariables>>::value);
+static_assert(
+    Parallel::is_nodegroup<Parallel::GlobalCache<Metavariables>>::value);

--- a/tests/Unit/Utilities/Test_StdHelpers.cpp
+++ b/tests/Unit/Utilities/Test_StdHelpers.cpp
@@ -99,6 +99,12 @@ SPECTRE_TEST_CASE("Unit.Utilities.StdHelpers.Output", "[Utilities][Unit]") {
   std::unordered_set<int, boost::hash<int>> my_boost_unordered_set{1, 3, 4, 5};
   CHECK(get_output(my_boost_unordered_set) == "(1,3,4,5)");
 
+  std::unordered_multiset<int> my_unordered_multiset{1, 3, 1, 5};
+  CHECK(get_output(my_unordered_multiset) == "(1,1,3,5)");
+  std::unordered_multiset<int, boost::hash<int>> my_boost_unordered_multiset{
+      1, 3, 1, 5};
+  CHECK(get_output(my_boost_unordered_multiset) == "(1,1,3,5)");
+
   std::set<int> my_set{1, 3, 4, 5};
   CHECK(get_output(my_set) == "(1,3,4,5)");
 


### PR DESCRIPTION
## Proposed changes

Add a struct called `ResourceInfo` that will hold all information regarding placing singletons and array components on the given resources. This information includes whether to avoid placing singletons/array components on the global 0th processor, what processors to place the singletons on, and whether they are exclusively on that processor using a `SingletonPack` (see #3962). 

This struct uses a custom algorithm to spread the singletons in an executable evenly over the available resources to balance communication and computational costs. Also, this struct will gather info on which singletons want to be exclusively on a processor and return a set of processors to ignore that can be given to the `procs_to_ignore` argument of the `allocate_array` function of an array component (see #3950).

See the documentation of `ResourceInfo` for a description of how the algorithm places singletons.

I intend for this struct to be stored as a member variable of Main and be used to allocate the singletons for all executables. That change will happen in a future PR.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
