### PR TITLE
Add matplotlib to python on anvil

### DIFF
--- a/support/Environments/setup/anvil_gcc.sh
+++ b/support/Environments/setup/anvil_gcc.sh
@@ -230,6 +230,7 @@ EOF
 HDF5_DIR=$HDF5_HOME pip install --no-binary=h5py h5py
 pip install yapf==0.29.0
 pip install pyyaml
+pip install matplotlib
 
 module unload impi
 module unuse $dep_dir/modules


### PR DESCRIPTION
## Proposed changes

Unit test `Unit.Visualization.Python.Render1D` fails on anvil because matplotlib is not installed. This is a quick PR to install matplotlib on anvil, so this test passes.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
