### PR TITLE
Add IsActive tag for control systems

### DIFF
--- a/src/ControlSystem/Actions/Initialization.hpp
+++ b/src/ControlSystem/Actions/Initialization.hpp
@@ -38,6 +38,7 @@ namespace Actions {
  *   - `control_system::Tags::TimescaleTuner<ControlSystem>`
  *   - `control_system::Tags::ControlError<ControlSystem>`
  *   - `control_system::Tags::WriteDataToDisk`
+ *   - `control_system::Tags::IsActive<ControlSystem>`
  * - Removes: Nothing
  * - Modifies:
  *   - `control_system::Tags::Averager<ControlSystem>`
@@ -55,7 +56,8 @@ struct Initialize {
                  control_system::Tags::Averager<ControlSystem>,
                  control_system::Tags::Controller<ControlSystem>,
                  control_system::Tags::TimescaleTuner<ControlSystem>,
-                 control_system::Tags::ControlError<ControlSystem>>;
+                 control_system::Tags::ControlError<ControlSystem>,
+                 control_system::Tags::IsActive<ControlSystem>>;
 
   using initialization_tags_to_keep = initialization_tags;
 

--- a/src/ControlSystem/Actions/Initialization.hpp
+++ b/src/ControlSystem/Actions/Initialization.hpp
@@ -50,16 +50,16 @@ template <typename Metavariables, typename ControlSystem>
 struct Initialize {
   static constexpr size_t deriv_order = ControlSystem::deriv_order;
 
-  using initialization_tags = tmpl::list<control_system::Tags::WriteDataToDisk>;
+  using initialization_tags =
+      tmpl::list<control_system::Tags::WriteDataToDisk,
+                 control_system::Tags::Averager<ControlSystem>,
+                 control_system::Tags::Controller<ControlSystem>,
+                 control_system::Tags::TimescaleTuner<ControlSystem>,
+                 control_system::Tags::ControlError<ControlSystem>>;
 
   using initialization_tags_to_keep = initialization_tags;
 
-  using simple_tags = tmpl::append<
-      tmpl::list<control_system::Tags::Averager<ControlSystem>,
-                 control_system::Tags::Controller<ControlSystem>,
-                 control_system::Tags::TimescaleTuner<ControlSystem>,
-                 control_system::Tags::ControlError<ControlSystem>>,
-      typename ControlSystem::simple_tags>;
+  using simple_tags = typename ControlSystem::simple_tags;
 
   using compute_tags = tmpl::list<>;
 

--- a/src/ControlSystem/Systems/Expansion.hpp
+++ b/src/ControlSystem/Systems/Expansion.hpp
@@ -82,8 +82,7 @@ struct Expansion : tt::ConformsTo<protocols::ControlSystem> {
                                       QueueTags::Center<::ah::ObjectLabel::B>>>;
   };
 
-  using simple_tags =
-      tmpl::list<MeasurementQueue, Tags::ControlError<Expansion>>;
+  using simple_tags = tmpl::list<MeasurementQueue>;
 
   struct process_measurement {
     template <typename Submeasurement>

--- a/src/Domain/FunctionsOfTime/FunctionsOfTimeAreReady.hpp
+++ b/src/Domain/FunctionsOfTime/FunctionsOfTimeAreReady.hpp
@@ -73,7 +73,7 @@ bool functions_of_time_are_ready(
             continue;
           }
           const double expiration_time = f_of_t->time_bounds()[1];
-          if (time >= expiration_time) {
+          if (time > expiration_time) {
             return std::unique_ptr<Parallel::Callback>(
                 new Parallel::PerformAlgorithmCallback(proxy));
           }

--- a/src/Domain/FunctionsOfTime/OptionTags.hpp
+++ b/src/Domain/FunctionsOfTime/OptionTags.hpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <unordered_map>
 
+#include "Options/Auto.hpp"
 #include "Options/Options.hpp"
 
 namespace domain::FunctionsOfTime::OptionTags {
@@ -22,7 +23,7 @@ struct CubicFunctionOfTimeOverride {
  * \brief Path to an H5 file containing SpEC FunctionOfTime data
  */
 struct FunctionOfTimeFile {
-  using type = std::string;
+  using type = Options::Auto<std::string, Options::AutoLabel::None>;
   static constexpr Options::String help{
       "Path to an H5 file containing SpEC FunctionOfTime data"};
   using group = CubicFunctionOfTimeOverride;

--- a/src/Domain/FunctionsOfTime/ReadSpecPiecewisePolynomial.cpp
+++ b/src/Domain/FunctionsOfTime/ReadSpecPiecewisePolynomial.cpp
@@ -12,6 +12,8 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Matrix.hpp"
+#include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
 #include "IO/H5/AccessType.hpp"
@@ -196,6 +198,94 @@ void read_spec_piecewise_polynomial(
             << "), while in row 0 they have values (" << dat_data(0, 2) << ", "
             << dat_data(0, 3) << ", " << dat_data(0, 4) << ")");
       }
+    }
+  }
+}
+
+void override_functions_of_time(
+    const gsl::not_null<std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>*>
+        functions_of_time,
+    const std::string& function_of_time_file,
+    const std::map<std::string, std::string>& function_of_time_name_map) {
+  std::unordered_map<std::string,
+                     domain::FunctionsOfTime::PiecewisePolynomial<2>>
+      spec_functions_of_time_second_order{};
+  std::unordered_map<std::string,
+                     domain::FunctionsOfTime::PiecewisePolynomial<3>>
+      spec_functions_of_time_third_order{};
+  std::unordered_map<std::string,
+                     domain::FunctionsOfTime::QuaternionFunctionOfTime<3>>
+      spec_functions_of_time_quaternion{};
+
+  // Import those functions of time of each supported order
+  domain::FunctionsOfTime::read_spec_piecewise_polynomial(
+      make_not_null(&spec_functions_of_time_second_order),
+      function_of_time_file, function_of_time_name_map);
+  domain::FunctionsOfTime::read_spec_piecewise_polynomial(
+      make_not_null(&spec_functions_of_time_third_order), function_of_time_file,
+      function_of_time_name_map);
+
+  bool uses_quaternion_rotation = false;
+  for (const auto& name_and_fot : *functions_of_time) {
+    auto* maybe_quaternion_fot =
+        dynamic_cast<domain::FunctionsOfTime::QuaternionFunctionOfTime<3>*>(
+            name_and_fot.second.get());
+    if (maybe_quaternion_fot != nullptr) {
+      uses_quaternion_rotation = true;
+    }
+  }
+
+  // Only parse as quaternion function of time if it exists
+  if (uses_quaternion_rotation) {
+    domain::FunctionsOfTime::read_spec_piecewise_polynomial(
+        make_not_null(&spec_functions_of_time_quaternion),
+        function_of_time_file, function_of_time_name_map, true);
+  }
+
+  for (const auto& [spec_name, spectre_name] : function_of_time_name_map) {
+    (void)spec_name;
+    // The FunctionsOfTime we are mutating must already have
+    // an element with key==spectre_name; this action only
+    // mutates the value associated with that key
+    if (functions_of_time->count(spectre_name) == 0) {
+      ERROR("Trying to import data for key "
+            << spectre_name
+            << " in FunctionsOfTime, but FunctionsOfTime does not "
+               "contain that key. This might happen if the option "
+               "FunctionOfTimeNameMap is not specified correctly. Keys "
+               "contained in FunctionsOfTime: "
+            << keys_of(*functions_of_time) << "\n");
+    }
+    auto* piecewise_polynomial_second_order =
+        dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<2>*>(
+            (*functions_of_time)[spectre_name].get());
+    auto* piecewise_polynomial_third_order =
+        dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<3>*>(
+            (*functions_of_time)[spectre_name].get());
+    auto* quaternion_fot_third_order =
+        dynamic_cast<domain::FunctionsOfTime::QuaternionFunctionOfTime<3>*>(
+            (*functions_of_time)[spectre_name].get());
+    if (piecewise_polynomial_second_order == nullptr) {
+      if (piecewise_polynomial_third_order == nullptr) {
+        if (quaternion_fot_third_order == nullptr) {
+          ERROR("The function of time with name "
+                << spectre_name
+                << " is not a PiecewisePolynomial<2>, "
+                   "PiecewisePolynomial<3>, or QuaternionFunctionOfTime<3> "
+                   "and so cannot be set using "
+                   "read_spec_piecewise_polynomial\n");
+        } else {
+          *quaternion_fot_third_order =
+              spec_functions_of_time_quaternion.at(spectre_name);
+        }
+      } else {
+        *piecewise_polynomial_third_order =
+            spec_functions_of_time_third_order.at(spectre_name);
+      }
+    } else {
+      *piecewise_polynomial_second_order =
+          spec_functions_of_time_second_order.at(spectre_name);
     }
   }
 }

--- a/src/Domain/FunctionsOfTime/ReadSpecPiecewisePolynomial.hpp
+++ b/src/Domain/FunctionsOfTime/ReadSpecPiecewisePolynomial.hpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <map>
+#include <memory>
 #include <string>
 #include <unordered_map>
 
@@ -16,6 +17,7 @@ class not_null;
 namespace domain::FunctionsOfTime {
 template <size_t max_deriv>
 class PiecewisePolynomial;
+class FunctionOfTime;
 
 /// \brief Import SpEC `FunctionOfTime` data from an H5 file.
 ///
@@ -46,4 +48,17 @@ void read_spec_piecewise_polynomial(
     const std::string& file_name,
     const std::map<std::string, std::string>& dataset_name_map,
     const bool quaternion_rotation = false);
+
+/// \brief Replace the functions of time from the `domain_creator` with the ones
+/// read in from `function_of_time_file`.
+///
+/// \note Currently, only support order 2 or 3 piecewise polynomials. This could
+/// be generalized later, but the SpEC functions of time that we will read in
+/// with this action will always be 2nd-order or 3rd-order piecewise polynomials
+void override_functions_of_time(
+    const gsl::not_null<std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>*>
+        functions_of_time,
+    const std::string& function_of_time_file,
+    const std::map<std::string, std::string>& function_of_time_name_map);
 }  // namespace domain::FunctionsOfTime

--- a/src/Domain/FunctionsOfTime/Tags.hpp
+++ b/src/Domain/FunctionsOfTime/Tags.hpp
@@ -79,9 +79,8 @@ struct FunctionsOfTimeInitialize : FunctionsOfTime, db::SimpleTag {
       const std::unique_ptr<::DomainCreator<Metavariables::volume_dim>>&
           domain_creator,
       const std::optional<std::string>& function_of_time_file,
-      const std::optional<std::map<std::string, std::string>>&
-          function_of_time_name_map) {
-    if (function_of_time_file and function_of_time_name_map) {
+      const std::map<std::string, std::string>& function_of_time_name_map) {
+    if (function_of_time_file) {
       // Currently, only support order 2 or 3 piecewise polynomials.
       // This could be generalized later, but the SpEC functions of time
       // that we will read in with this action will always be 2nd-order or
@@ -99,10 +98,10 @@ struct FunctionsOfTimeInitialize : FunctionsOfTime, db::SimpleTag {
       // Import those functions of time of each supported order
       domain::FunctionsOfTime::read_spec_piecewise_polynomial(
           make_not_null(&spec_functions_of_time_second_order),
-          *function_of_time_file, *function_of_time_name_map);
+          *function_of_time_file, function_of_time_name_map);
       domain::FunctionsOfTime::read_spec_piecewise_polynomial(
           make_not_null(&spec_functions_of_time_third_order),
-          *function_of_time_file, *function_of_time_name_map);
+          *function_of_time_file, function_of_time_name_map);
 
       auto functions_of_time{domain_creator->functions_of_time()};
 
@@ -120,10 +119,10 @@ struct FunctionsOfTimeInitialize : FunctionsOfTime, db::SimpleTag {
       if (uses_quaternion_rotation) {
         domain::FunctionsOfTime::read_spec_piecewise_polynomial(
             make_not_null(&spec_functions_of_time_quaternion),
-            *function_of_time_file, *function_of_time_name_map, true);
+            *function_of_time_file, function_of_time_name_map, true);
       }
 
-      for (const auto& [spec_name, spectre_name] : *function_of_time_name_map) {
+      for (const auto& [spec_name, spectre_name] : function_of_time_name_map) {
         (void)spec_name;
         // The FunctionsOfTime we are mutating must already have
         // an element with key==spectre_name; this action only

--- a/src/Domain/FunctionsOfTime/Tags.hpp
+++ b/src/Domain/FunctionsOfTime/Tags.hpp
@@ -80,98 +80,15 @@ struct FunctionsOfTimeInitialize : FunctionsOfTime, db::SimpleTag {
           domain_creator,
       const std::optional<std::string>& function_of_time_file,
       const std::map<std::string, std::string>& function_of_time_name_map) {
-    if (function_of_time_file) {
-      // Currently, only support order 2 or 3 piecewise polynomials.
-      // This could be generalized later, but the SpEC functions of time
-      // that we will read in with this action will always be 2nd-order or
-      // 3rd-order piecewise polynomials
-      std::unordered_map<std::string,
-                         domain::FunctionsOfTime::PiecewisePolynomial<2>>
-          spec_functions_of_time_second_order{};
-      std::unordered_map<std::string,
-                         domain::FunctionsOfTime::PiecewisePolynomial<3>>
-          spec_functions_of_time_third_order{};
-      std::unordered_map<std::string,
-                         domain::FunctionsOfTime::QuaternionFunctionOfTime<3>>
-          spec_functions_of_time_quaternion{};
+    auto functions_of_time = domain_creator->functions_of_time();
 
-      // Import those functions of time of each supported order
-      domain::FunctionsOfTime::read_spec_piecewise_polynomial(
-          make_not_null(&spec_functions_of_time_second_order),
-          *function_of_time_file, function_of_time_name_map);
-      domain::FunctionsOfTime::read_spec_piecewise_polynomial(
-          make_not_null(&spec_functions_of_time_third_order),
-          *function_of_time_file, function_of_time_name_map);
-
-      auto functions_of_time{domain_creator->functions_of_time()};
-
-      bool uses_quaternion_rotation = false;
-      for (const auto& name_and_fot : functions_of_time) {
-        auto* maybe_quaternion_fot =
-            dynamic_cast<domain::FunctionsOfTime::QuaternionFunctionOfTime<3>*>(
-                name_and_fot.second.get());
-        if (maybe_quaternion_fot != nullptr) {
-          uses_quaternion_rotation = true;
-        }
-      }
-
-      // Only parse as quaternion function of time if it exists
-      if (uses_quaternion_rotation) {
-        domain::FunctionsOfTime::read_spec_piecewise_polynomial(
-            make_not_null(&spec_functions_of_time_quaternion),
-            *function_of_time_file, function_of_time_name_map, true);
-      }
-
-      for (const auto& [spec_name, spectre_name] : function_of_time_name_map) {
-        (void)spec_name;
-        // The FunctionsOfTime we are mutating must already have
-        // an element with key==spectre_name; this action only
-        // mutates the value associated with that key
-        if (functions_of_time.count(spectre_name) == 0) {
-          ERROR("Trying to import data for key "
-                << spectre_name
-                << " in FunctionsOfTime, but FunctionsOfTime does not "
-                   "contain that key. This might happen if the option "
-                   "FunctionOfTimeNameMap is not specified correctly. Keys "
-                   "contained in FunctionsOfTime: "
-                << keys_of(functions_of_time) << "\n");
-        }
-        auto* piecewise_polynomial_second_order =
-            dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<2>*>(
-                functions_of_time[spectre_name].get());
-        auto* piecewise_polynomial_third_order =
-            dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<3>*>(
-                functions_of_time[spectre_name].get());
-        auto* quaternion_fot_third_order =
-            dynamic_cast<domain::FunctionsOfTime::QuaternionFunctionOfTime<3>*>(
-                functions_of_time[spectre_name].get());
-        if (piecewise_polynomial_second_order == nullptr) {
-          if (piecewise_polynomial_third_order == nullptr) {
-            if (quaternion_fot_third_order == nullptr) {
-              ERROR("The function of time with name "
-                    << spectre_name
-                    << " is not a PiecewisePolynomial<2>, "
-                       "PiecewisePolynomial<3>, or QuaternionFunctionOfTime<3> "
-                       "and so cannot be set using "
-                       "read_spec_piecewise_polynomial\n");
-            } else {
-              *quaternion_fot_third_order =
-                  spec_functions_of_time_quaternion.at(spectre_name);
-            }
-          } else {
-            *piecewise_polynomial_third_order =
-                spec_functions_of_time_third_order.at(spectre_name);
-          }
-        } else {
-          *piecewise_polynomial_second_order =
-              spec_functions_of_time_second_order.at(spectre_name);
-        }
-      }
-
-      return functions_of_time;
-    } else {
-      return domain_creator->functions_of_time();
+    if (function_of_time_file.has_value()) {
+      domain::FunctionsOfTime::override_functions_of_time(
+          make_not_null(&functions_of_time), *function_of_time_file,
+          function_of_time_name_map);
     }
+
+    return functions_of_time;
   }
 
   template <typename Metavariables>

--- a/tests/Unit/Domain/FunctionsOfTime/Test_ReadSpecPiecewisePolynomial.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_ReadSpecPiecewisePolynomial.cpp
@@ -104,24 +104,42 @@ void test_options() {
             domain::FunctionsOfTime::OptionTags::FunctionOfTimeNameMap>() ==
         "FunctionOfTimeNameMap");
 
-  const std::string option_string{
-      "CubicFunctionOfTimeOverride:\n"
-      "  FunctionOfTimeFile: TestFile.h5\n"
-      "  FunctionOfTimeNameMap: {Set1: Name1, Set2: Name2}"};
   using option_tags =
       tmpl::list<domain::FunctionsOfTime::OptionTags::FunctionOfTimeFile,
                  domain::FunctionsOfTime::OptionTags::FunctionOfTimeNameMap>;
-  Options::Parser<option_tags> options{""};
-  options.parse(option_string);
-  CHECK(
-      options.get<domain::FunctionsOfTime::OptionTags::FunctionOfTimeFile>() ==
-      "TestFile.h5"s);
-  const std::map<std::string, std::string> expected_set_names{
-      {"Set1", "Name1"}, {"Set2", "Name2"}};
-  CHECK(
-      options
-          .get<domain::FunctionsOfTime::OptionTags::FunctionOfTimeNameMap>() ==
-      expected_set_names);
+  {
+    const std::string option_string{
+        "CubicFunctionOfTimeOverride:\n"
+        "  FunctionOfTimeFile: TestFile.h5\n"
+        "  FunctionOfTimeNameMap: {Set1: Name1, Set2: Name2}"};
+    Options::Parser<option_tags> options{""};
+    options.parse(option_string);
+    CHECK(*std::optional<std::string>(
+              options.get<
+                  domain::FunctionsOfTime::OptionTags::FunctionOfTimeFile>()) ==
+          "TestFile.h5"s);
+    const std::map<std::string, std::string> expected_set_names{
+        {"Set1", "Name1"}, {"Set2", "Name2"}};
+    CHECK(options.get<
+              domain::FunctionsOfTime::OptionTags::FunctionOfTimeNameMap>() ==
+          expected_set_names);
+  }
+  {
+    const std::string option_string{
+        "CubicFunctionOfTimeOverride:\n"
+        "  FunctionOfTimeFile: None\n"
+        "  FunctionOfTimeNameMap: {}"};
+    Options::Parser<option_tags> options{""};
+    options.parse(option_string);
+    CHECK(std::optional<std::string>(
+              options.get<
+                  domain::FunctionsOfTime::OptionTags::FunctionOfTimeFile>()) ==
+          std::nullopt);
+    const std::map<std::string, std::string> expected_set_names{};
+    CHECK(options.get<
+              domain::FunctionsOfTime::OptionTags::FunctionOfTimeNameMap>() ==
+          expected_set_names);
+  }
 }
 
 void test_errors();

--- a/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
+++ b/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
@@ -66,6 +66,7 @@ using init_simple_tags =
                control_system::Tags::Controller<ControlSystem>,
                control_system::Tags::ControlError<ControlSystem>,
                control_system::Tags::WriteDataToDisk,
+               control_system::Tags::IsActive<ControlSystem>,
                typename ControlSystem::MeasurementQueue>;
 
 template <typename Metavariables, typename ControlSystem>
@@ -478,7 +479,7 @@ struct SystemHelper {
         get<control_system::Tags::TimescaleTuner<System>>(created_tags),
         get<control_system::Tags::Controller<System>>(created_tags),
         get<control_system::Tags::ControlError<System>>(created_tags),
-        get<control_system::Tags::WriteDataToDisk>(created_tags),
+        get<control_system::Tags::WriteDataToDisk>(created_tags), true,
         // Just need an empty queue. It will get filled in as the control
         // system is updated
         LinkedMessageQueue<


### PR DESCRIPTION
## Proposed changes

To be able to pick and choose which SpECTRE control systems to use and which SpEC ones to read in from a file, we need a way to "turn off" a control system if it isn't active. Adding a different executable for every combination of control systems is way too tedious. This tag will effectively allow us to choose at runtime which control systems to use (given that the executable actually has those control systems in its metavariables).

This PR also does some code cleanup that didn't really fit anywhere else, such as:
- Updating the tensor list in the `BothHorizons` control system measurement. The list must be the same as `interpolator_source_vars` in the metavariables, otherwise there is a runtime error. This should be fixed so that we don't have to maintain two copies of the same list, but I believe that's a much larger change to the interpolation framework.
- Change the `FunctionsOfTimeAreReady` action so that functions of time are valid at expiration times (because they are)
- Make the `FunctionOfTimeFile` option tag take an `optional<string>` so you don't have to specify a file with SpEC control system data if you are only using SpECTRE control systems. The autolabel = `None`.
- Factor out the work of overriding the functions of time in the `FunctionsOfTimeInitialize` tag because the control system will need this code also in a future PR.
- Fix a mistake I made where I made all the control system tags creatable from options, but didn't move them to the `initialization_tags` list in the control system initialization action.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
