### PR TITLE
Fix ObserveSurfaceData when center not origin

### DIFF
--- a/src/ParallelAlgorithms/Interpolation/Callbacks/ObserveSurfaceData.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Callbacks/ObserveSurfaceData.hpp
@@ -72,10 +72,11 @@ struct ObserveSurfaceData
         pretty_type::name<InterpolationTargetTag>();
     std::vector<TensorComponent> tensor_components{
         {surface_name + "/InertialCoordinates_x"s,
-         radius * sin_theta * cos(phi)},
+         radius * sin_theta * cos(phi) + strahlkorper.expansion_center()[0]},
         {surface_name + "/InertialCoordinates_y"s,
-         radius * sin_theta * sin(phi)},
-        {surface_name + "/InertialCoordinates_z"s, radius * cos(theta)}};
+         radius * sin_theta * sin(phi) + strahlkorper.expansion_center()[1]},
+        {surface_name + "/InertialCoordinates_z"s,
+         radius * cos(theta) + strahlkorper.expansion_center()[2]}};
 
     // Output each tag if it is a scalar. Otherwise, throw a compile-time
     // error. This could be generalized to handle tensors of nonzero rank by

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveTimeSeriesAndSurfaceData.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveTimeSeriesAndSurfaceData.cpp
@@ -88,7 +88,7 @@ void check_surface_volume_data(const std::string& surfaces_file_prefix) {
   constexpr size_t l_max = 10;
   constexpr size_t m_max = 10;
   constexpr double sphere_radius = 2.8;
-  constexpr std::array<double, 3> center{{0.0, 0.0, 0.0}};
+  constexpr std::array<double, 3> center{{0.01, 0.02, 0.03}};
   const Strahlkorper<Frame::Inertial> strahlkorper{l_max, m_max, sphere_radius,
                                                    center};
   const YlmSpherepack& ylm = strahlkorper.ylm_spherepack();
@@ -101,9 +101,9 @@ void check_surface_volume_data(const std::string& surfaces_file_prefix) {
   const DataVector radius = ylm.spec_to_phys(strahlkorper.coefficients());
   const std::string grid_name{"SurfaceD"};
 
-  const auto x{radius * sin_theta * cos(phi)};
-  const auto y{radius * sin_theta * sin(phi)};
-  const auto z{radius * cos(theta)};
+  const auto x{radius * sin_theta * cos(phi) + center[0]};
+  const auto y{radius * sin_theta * sin(phi) + center[1]};
+  const auto z{radius * cos(theta) + center[2]};
   const std::vector<DataVector> tensor_and_coord_data{
       x, y, z, square(2.0 * x + 3.0 * y + 5.0 * z)};
   const std::vector<TensorComponent> tensor_components{
@@ -376,8 +376,8 @@ SPECTRE_TEST_CASE(
                                                         2.0, {{0.0, 0.0, 0.0}});
   intrp::OptionHolders::KerrHorizon kerr_horizon_opts_C(10, {{0.0, 0.0, 0.0}},
                                                         1.5, {{0.0, 0.0, 0.0}});
-  intrp::OptionHolders::KerrHorizon kerr_horizon_opts_D(10, {{0.0, 0.0, 0.0}},
-                                                        1.4, {{0.0, 0.0, 0.0}});
+  intrp::OptionHolders::KerrHorizon kerr_horizon_opts_D(
+      10, {{0.01, 0.02, 0.03}}, 1.4, {{0.0, 0.0, 0.0}});
   const auto domain_creator =
       domain::creators::Shell(0.9, 4.9, 1, {{5, 5}}, false);
   tuples::TaggedTuple<


### PR DESCRIPTION
## Proposed changes


The ObserveSurfaceData callback incorrectly did not add the center to the inertial coordinates when computing them. This PR fixes both the callback and the test to check for this.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
