### PR TITLE
Fix IgnoreFailedApparentHorizon

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
@@ -31,6 +31,7 @@
 #include "ParallelAlgorithms/Interpolation/Actions/TryToInterpolate.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/ErrorOnFailedApparentHorizon.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp"
+#include "ParallelAlgorithms/Interpolation/Callbacks/IgnoreFailedApparentHorizon.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/ObserveSurfaceData.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp"
 #include "ParallelAlgorithms/Interpolation/Events/Interpolate.hpp"
@@ -111,7 +112,7 @@ struct EvolutionMetavars<3, InitialData, BoundaryConditions>
     using post_interpolation_callback =
         intrp::callbacks::FindApparentHorizon<AhA, ::Frame::Inertial>;
     using horizon_find_failure_callback =
-        intrp::callbacks::ErrorOnFailedApparentHorizon;
+        intrp::callbacks::IgnoreFailedApparentHorizon;
     using post_horizon_find_callbacks = tmpl::list<
         intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, AhA>,
         intrp::callbacks::ObserveSurfaceData<surface_tags_to_observe, AhA>>;

--- a/src/ParallelAlgorithms/Interpolation/Callbacks/IgnoreFailedApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Callbacks/IgnoreFailedApparentHorizon.hpp
@@ -5,7 +5,6 @@
 
 #include "ApparentHorizons/FastFlow.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"
-#include "Informer/Tags.hpp"
 #include "Parallel/Printf.hpp"
 #include "Utilities/PrettyType.hpp"
 


### PR DESCRIPTION
## Proposed changes

IgnoreFailedApparentHorizon.hpp includes a nonexistent file, Informer/Tags.hpp. This wasn't caught previously because nowhere in the code actually uses the IgnoreFailedApparentHorizon callback. I updated the KerrSchild executable to ignore AH failures, which are unlikely unless they are deliberate (such as by not including location of the horizon in the domain) for KerrSchild, since the black hole in Kerr Schild doesn't move. This is just to ensure that the code uses IgnoreFailedApparentHorizon somewhere, to catch similar problems in the future.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
