### PR TITLE
Replace tt::is_a with tt::is_a_lambda

### DIFF
--- a/src/ControlSystem/Tags/FunctionsOfTimeInitialize.hpp
+++ b/src/ControlSystem/Tags/FunctionsOfTimeInitialize.hpp
@@ -44,7 +44,7 @@ struct FunctionsOfTimeInitialize : domain::Tags::FunctionsOfTime,
                  ::OptionTags::InitialTime, ::OptionTags::InitialTimeStep,
                  control_system::inputs<tmpl::transform<
                      tmpl::filter<typename Metavariables::component_list,
-                                  tt::is_a_lambda<ControlComponent, tmpl::_1>>,
+                                  tt::is_a<ControlComponent, tmpl::_1>>,
                      tmpl::bind<tmpl::back, tmpl::_1>>>>>;
 
   template <typename Metavariables, typename... OptionHolders>

--- a/src/ControlSystem/Tags/MeasurementTimescales.hpp
+++ b/src/ControlSystem/Tags/MeasurementTimescales.hpp
@@ -70,7 +70,7 @@ struct MeasurementTimescales : db::SimpleTag {
       tmpl::list<::OptionTags::InitialTime, ::OptionTags::InitialTimeStep,
                  control_system::inputs<tmpl::transform<
                      tmpl::filter<typename Metavariables::component_list,
-                                  tt::is_a_lambda<ControlComponent, tmpl::_1>>,
+                                  tt::is_a<ControlComponent, tmpl::_1>>,
                      tmpl::bind<tmpl::back, tmpl::_1>>>>>;
 
   template <typename Metavariables, typename... OptionHolders>

--- a/src/ParallelAlgorithms/Interpolation/Interpolator.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Interpolator.hpp
@@ -38,7 +38,7 @@ struct Interpolator {
   using metavariables = Metavariables;
   using all_interpolation_target_tags = tmpl::transform<
       tmpl::filter<typename Metavariables::component_list,
-                   tt::is_a_lambda<intrp::InterpolationTarget, tmpl::_1>>,
+                   tt::is_a<intrp::InterpolationTarget, tmpl::_1>>,
       detail::get_interpolation_target_tag<tmpl::_1>>;
   using all_temporal_ids = tmpl::remove_duplicates<tmpl::transform<
       all_interpolation_target_tags, detail::get_temporal_id<tmpl::_1>>>;

--- a/src/Time/Actions/ChangeStepSize.hpp
+++ b/src/Time/Actions/ChangeStepSize.hpp
@@ -154,8 +154,7 @@ struct ChangeStepSize {
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
     static_assert(
-        tmpl::any<ActionList,
-                  tt::is_a_lambda<Actions::UpdateU, tmpl::_1>>::value,
+        tmpl::any<ActionList, tt::is_a<Actions::UpdateU, tmpl::_1>>::value,
         "The ChangeStepSize action requires that you also use the UpdateU "
         "action to permit step-unwinding. If you are stepping within "
         "an action that is not UpdateU, consider using the take_step function "
@@ -170,7 +169,7 @@ struct ChangeStepSize {
       return {
           std::move(box), false,
           tmpl::index_if<ActionList,
-                         tt::is_a_lambda<Actions::UpdateU, tmpl::_1>>::value};
+                         tt::is_a<Actions::UpdateU, tmpl::_1>>::value};
     }
   }
 };

--- a/src/Time/StepChoosers/StepChooser.hpp
+++ b/src/Time/StepChoosers/StepChooser.hpp
@@ -68,7 +68,7 @@ using all_step_choosers = tmpl::join<tmpl::transform<
     tmpl::filter<
         tmpl::wrap<typename Metavariables::factory_creation::factory_classes,
                    tmpl::list>,
-        tt::is_a_lambda<StepChooser, tmpl::bind<tmpl::front, tmpl::_1>>>,
+        tt::is_a<StepChooser, tmpl::bind<tmpl::front, tmpl::_1>>>,
     tmpl::bind<tmpl::back, tmpl::_1>>>;
 }  // namespace detail
 

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -75,8 +75,7 @@ struct HistoryEvolvedVariables : HistoryEvolvedVariables<>, db::SimpleTag {
 /// specializations of `HistoryEvolvedVariables`.
 template <typename TagList>
 using get_all_history_tags =
-    tmpl::filter<TagList,
-                 tt::is_a_lambda<::Tags::HistoryEvolvedVariables, tmpl::_1>>;
+    tmpl::filter<TagList, tt::is_a<::Tags::HistoryEvolvedVariables, tmpl::_1>>;
 
 /// \ingroup DataBoxTagsGroup
 /// \ingroup TimeGroup

--- a/src/Utilities/TypeTraits/IsA.hpp
+++ b/src/Utilities/TypeTraits/IsA.hpp
@@ -6,6 +6,23 @@
 #include <type_traits>
 
 namespace tt {
+namespace detail {
+template <template <typename...> class U, typename T>
+struct is_a : std::false_type {};
+
+template <template <typename...> class U, typename... Args>
+struct is_a<U, U<Args...>> : std::true_type {};
+
+template <template <typename...> class U>
+struct is_a_wrapper;
+
+template <typename U, typename T>
+struct wrapped_is_a;
+
+template <template <typename...> class U, typename T>
+struct wrapped_is_a<is_a_wrapper<U>, T> : detail::is_a<U, T> {};
+}  // namespace detail
+
 /// @{
 /// \ingroup TypeTraitsGroup
 /// \brief Check if type `T` is a template specialization of `U`
@@ -38,33 +55,14 @@ namespace tt {
 /// \tparam T type to check
 /// \tparam U the type that T might be a template specialization of
 template <template <typename...> class U, typename T>
-struct is_a : std::false_type {};
-
-/// \cond HIDDEN_SYMBOLS
-template <template <typename...> class U, typename... Args>
-struct is_a<U, U<Args...>> : std::true_type {};
-/// \endcond
+using is_a = detail::wrapped_is_a<detail::is_a_wrapper<U>, T>;
 
 /// \see is_a
-template <template <typename...> class U, typename... Args>
-constexpr bool is_a_v = is_a<U, Args...>::value;
+template <template <typename...> class U, typename T>
+constexpr bool is_a_v = is_a<U, T>::value;
 
 /// \see is_a
-template <template <typename...> class U, typename... Args>
-using is_a_t = typename is_a<U, Args...>::type;
+template <template <typename...> class U, typename T>
+using is_a_t = typename is_a<U, T>::type;
 /// @}
-
-namespace detail {
-template <template <typename...> class U>
-struct is_a_wrapper;
-
-template <typename U, typename T>
-struct wrapped_is_a;
-
-template <template <typename...> class U, typename T>
-struct wrapped_is_a<is_a_wrapper<U>, T> : tt::is_a<U, T> {};
-}  // namespace detail
-
-template <template <typename...> class U, typename T>
-using is_a_lambda = detail::wrapped_is_a<detail::is_a_wrapper<U>, T>;
 }  // namespace tt

--- a/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
+++ b/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
@@ -246,8 +246,8 @@ void emplace_component_and_initialize<true, true>(
 }
 
 using not_self_start_action = std::negation<std::disjunction<
-    tt::is_a_lambda<SelfStart::Actions::Initialize, tmpl::_1>,
-    tt::is_a_lambda<SelfStart::Actions::CheckForCompletion, tmpl::_1>,
+    tt::is_a<SelfStart::Actions::Initialize, tmpl::_1>,
+    tt::is_a<SelfStart::Actions::CheckForCompletion, tmpl::_1>,
     std::is_same<SelfStart::Actions::CheckForOrderIncrease, tmpl::_1>,
     std::is_same<SelfStart::Actions::Cleanup, tmpl::_1>>>;
 
@@ -310,7 +310,7 @@ void test_actions(const size_t order, const int step_denominator) {
   {
     INFO("Initialize");
     const bool jumped =
-        run_past<tt::is_a_lambda<SelfStart::Actions::Initialize, tmpl::_1>,
+        run_past<tt::is_a<SelfStart::Actions::Initialize, tmpl::_1>,
                  not_self_start_action>(make_not_null(&runner));
     CHECK(not jumped);
     CHECK(
@@ -337,7 +337,7 @@ void test_actions(const size_t order, const int step_denominator) {
       {
         INFO("CheckForCompletion");
         const bool jumped = run_past<
-            tt::is_a_lambda<SelfStart::Actions::CheckForCompletion, tmpl::_1>,
+            tt::is_a<SelfStart::Actions::CheckForCompletion, tmpl::_1>,
             not_self_start_action>(make_not_null(&runner));
         CHECK(not jumped);
         CHECK(ActionTesting::get_databox_tag<Component<Metavariables<>>,
@@ -363,7 +363,7 @@ void test_actions(const size_t order, const int step_denominator) {
   {
     INFO("CheckForCompletion");
     const bool jumped = run_past<
-        tt::is_a_lambda<SelfStart::Actions::CheckForCompletion, tmpl::_1>,
+        tt::is_a<SelfStart::Actions::CheckForCompletion, tmpl::_1>,
         not_self_start_action>(make_not_null(&runner));
     CHECK(jumped);
   }


### PR DESCRIPTION
They performed the same function, except that the latter could be used
in more circumstances.

Surprisingly, the existing incorrect uses of plain is_a don't seem to
have caused any problems.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
