### PR TITLE
Fix check forbidding removing from a DataBox a subitem of an immutable item

### DIFF
--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -1035,7 +1035,7 @@ SPECTRE_ALWAYS_INLINE constexpr auto create_from(Box&& box, Args&&... args) {
 #ifdef SPECTRE_DEBUG
   // Check that we're not removing a subitem itself, should remove the parent.
   using old_immutable_subitem_tags =
-      tmpl::filter<typename std::decay_t<Box>::immutable_item_creation_tags,
+      tmpl::filter<typename std::decay_t<Box>::immutable_item_tags,
                    tt::is_a<::Tags::Subitem, tmpl::_1>>;
   using old_subitem_tags =
       tmpl::append<typename std::decay_t<Box>::mutable_subitem_tags,

--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -1973,6 +1973,38 @@ void test_subitems() {
         std::make_pair(Boxed<int>(std::make_shared<int>(5)),
                        Boxed<double>(std::make_shared<double>(3.5))));
 
+    static_assert(std::is_same_v<
+                  decltype(box)::tags_list,
+                  tmpl::list<Parent<0>, First<0>, Second<0>, ParentCompute<1>,
+                             Tags::Subitem<First<1>, ParentCompute<1>>,
+                             Tags::Subitem<Second<1>, ParentCompute<1>>>>);
+
+    static_assert(
+        std::is_same_v<decltype(box)::immutable_item_tags,
+                       tmpl::list<ParentCompute<1>,
+                                  Tags::Subitem<First<1>, ParentCompute<1>>,
+                                  Tags::Subitem<Second<1>, ParentCompute<1>>>>);
+
+    static_assert(std::is_same_v<decltype(box)::immutable_item_creation_tags,
+                                 tmpl::list<ParentCompute<1>>>);
+
+    static_assert(std::is_same_v<decltype(box)::mutable_item_tags,
+                                 tmpl::list<Parent<0>, First<0>, Second<0>>>);
+
+    static_assert(std::is_same_v<decltype(box)::mutable_subitem_tags,
+                                 tmpl::list<First<0>, Second<0>>>);
+
+    static_assert(std::is_same_v<decltype(box)::compute_item_tags,
+                                 tmpl::list<ParentCompute<1>>>);
+
+    using immutable_subitem_tags =
+        tmpl::filter<decltype(box)::immutable_item_tags,
+                     tt::is_a<::Tags::Subitem, tmpl::_1>>;
+    static_assert(
+        std::is_same_v<immutable_subitem_tags,
+                       tmpl::list<Tags::Subitem<First<1>, ParentCompute<1>>,
+                                  Tags::Subitem<Second<1>, ParentCompute<1>>>>);
+
     TestHelpers::db::test_reference_tag<
         ::Tags::Subitem<First<1>, ParentCompute<1>>>("First");
 


### PR DESCRIPTION
## Proposed changes

Fix #3996 

Add tests that would have exposed the bad code

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
