### PR TITLE
Ignore DataBox warning in gcc 11

### DIFF
--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -215,15 +215,19 @@ class DataBox<tmpl::list<Tags...>> : private detail::Item<Tags>... {
   DataBox(DataBox&& rhs) = default;
   DataBox& operator=(DataBox&& rhs) {
     if (&rhs != this) {
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 8
+#if defined(__GNUC__) && !defined(__clang__) && \
+    (__GNUC__ < 8 || (__GNUC__ > 10 && __GNUC__ < 12))
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif  // defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 8
+#endif  // defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 8 ||
+        // (__GNUC__ > 10 && __GNUC__ < 12))
       ::expand_pack(
           (get_item<Tags>() = std::move(rhs.template get_item<Tags>()))...);
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 8
+#if defined(__GNUC__) && !defined(__clang__) && \
+    (__GNUC__ < 8 || (__GNUC__ > 10 && __GNUC__ < 12))
 #pragma GCC diagnostic pop
-#endif  // defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 8
+#endif  // defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 8 ||
+        // (__GNUC__ > 10 && __GNUC__ < 12))
     }
     return *this;
   }


### PR DESCRIPTION
## Proposed changes

Missed a warning in #3987.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
