### PR TITLE
Consolidate lists of AH tags

### DIFF
--- a/src/ApparentHorizons/CMakeLists.txt
+++ b/src/ApparentHorizons/CMakeLists.txt
@@ -22,6 +22,7 @@ spectre_target_headers(
   ComputeHorizonVolumeQuantities.tpp
   ComputeItems.hpp
   FastFlow.hpp
+  HorizonAliases.hpp
   ObjectLabel.hpp
   ObserveCenters.hpp
   StrahlkorperGr.hpp

--- a/src/ApparentHorizons/HorizonAliases.hpp
+++ b/src/ApparentHorizons/HorizonAliases.hpp
@@ -1,0 +1,77 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "ApparentHorizons/TagsDeclarations.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Frame {
+struct Grid;
+struct Inertial;
+}  // namespace Frame
+struct DataVector;
+/// \endcond
+
+namespace ah {
+template <size_t Dim>
+using source_vars = tmpl::list<
+    gr::Tags::SpacetimeMetric<Dim, ::Frame::Inertial>,
+    GeneralizedHarmonic::Tags::Pi<Dim, ::Frame::Inertial>,
+    GeneralizedHarmonic::Tags::Phi<Dim, ::Frame::Inertial>,
+    ::Tags::deriv<GeneralizedHarmonic::Tags::Phi<Dim, Frame::Inertial>,
+                  tmpl::size_t<Dim>, Frame::Inertial>>;
+
+template <size_t Dim, typename Frame>
+using vars_to_interpolate_to_target =
+    tmpl::list<gr::Tags::SpatialMetric<Dim, Frame, DataVector>,
+               gr::Tags::InverseSpatialMetric<Dim, Frame>,
+               gr::Tags::ExtrinsicCurvature<Dim, Frame>,
+               gr::Tags::SpatialChristoffelSecondKind<Dim, Frame>,
+               gr::Tags::SpatialRicci<Dim, Frame>>;
+
+using tags_for_observing = tmpl::list<
+    StrahlkorperGr::Tags::AreaCompute<::Frame::Inertial>,
+    StrahlkorperGr::Tags::IrreducibleMassCompute<::Frame::Inertial>,
+    StrahlkorperTags::MaxRicciScalarCompute,
+    StrahlkorperTags::MinRicciScalarCompute,
+    StrahlkorperGr::Tags::ChristodoulouMassCompute<::Frame::Inertial>,
+    StrahlkorperGr::Tags::DimensionlessSpinMagnitudeCompute<::Frame::Inertial>>;
+
+using surface_tags_for_observing = tmpl::list<StrahlkorperTags::RicciScalar>;
+
+template <size_t Dim>
+using compute_items_on_target = tmpl::append<
+    tmpl::list<
+        StrahlkorperTags::ThetaPhiCompute<::Frame::Inertial>,
+        StrahlkorperTags::RadiusCompute<::Frame::Inertial>,
+        StrahlkorperTags::RhatCompute<::Frame::Inertial>,
+        StrahlkorperTags::InvJacobianCompute<::Frame::Inertial>,
+        StrahlkorperTags::InvHessianCompute<::Frame::Inertial>,
+        StrahlkorperTags::JacobianCompute<::Frame::Inertial>,
+        StrahlkorperTags::DxRadiusCompute<::Frame::Inertial>,
+        StrahlkorperTags::D2xRadiusCompute<::Frame::Inertial>,
+        StrahlkorperTags::NormalOneFormCompute<::Frame::Inertial>,
+        StrahlkorperTags::OneOverOneFormMagnitudeCompute<Dim, ::Frame::Inertial,
+                                                         DataVector>,
+        StrahlkorperTags::TangentsCompute<::Frame::Inertial>,
+        StrahlkorperTags::UnitNormalOneFormCompute<::Frame::Inertial>,
+        StrahlkorperTags::UnitNormalVectorCompute<::Frame::Inertial>,
+        StrahlkorperTags::GradUnitNormalOneFormCompute<::Frame::Inertial>,
+        // Note that StrahlkorperTags::ExtrinsicCurvatureCompute is the
+        // 2d extrinsic curvature of the strahlkorper embedded in the 3d
+        // slice, whereas gr::tags::ExtrinsicCurvature is the 3d extrinsic
+        // curvature of the slice embedded in 4d spacetime.  Both quantities
+        // are in the DataBox.
+        StrahlkorperGr::Tags::AreaElementCompute<::Frame::Inertial>,
+        StrahlkorperTags::ExtrinsicCurvatureCompute<::Frame::Inertial>,
+        StrahlkorperTags::RicciScalarCompute<::Frame::Inertial>,
+        StrahlkorperGr::Tags::SpinFunctionCompute<::Frame::Inertial>,
+        StrahlkorperGr::Tags::DimensionfulSpinMagnitudeCompute<
+            ::Frame::Inertial>>,
+    tags_for_observing>;
+}  // namespace ah

--- a/src/ApparentHorizons/TagsDeclarations.hpp
+++ b/src/ApparentHorizons/TagsDeclarations.hpp
@@ -43,6 +43,8 @@ struct DimensionfulSpinVectorCompute;
 namespace StrahlkorperGr::Tags {
 template <typename Frame>
 struct AreaElement;
+template <typename Frame>
+struct AreaElementCompute;
 template <typename IntegrandTag, typename Frame>
 struct SurfaceIntegral;
 struct Area;

--- a/src/ControlSystem/ApparentHorizons/Measurements.hpp
+++ b/src/ControlSystem/ApparentHorizons/Measurements.hpp
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "ApparentHorizons/ComputeHorizonVolumeQuantities.hpp"
+#include "ApparentHorizons/HorizonAliases.hpp"
 #include "ApparentHorizons/ObjectLabel.hpp"
 #include "ApparentHorizons/Tags.hpp"
 #include "ControlSystem/Protocols/Measurement.hpp"
@@ -58,24 +59,9 @@ struct BothHorizons : tt::ConformsTo<protocols::Measurement> {
       };
 
       using vars_to_interpolate_to_target =
-          tmpl::list<gr::Tags::SpatialMetric<3, ::Frame::Grid, DataVector>,
-                     gr::Tags::InverseSpatialMetric<3, ::Frame::Grid>,
-                     gr::Tags::ExtrinsicCurvature<3, ::Frame::Grid>,
-                     gr::Tags::SpatialChristoffelSecondKind<3, ::Frame::Grid>>;
+          ::ah::vars_to_interpolate_to_target<3, ::Frame::Grid>;
       using compute_vars_to_interpolate = ::ah::ComputeHorizonVolumeQuantities;
-      using compute_items_on_target = tmpl::list<
-          StrahlkorperTags::ThetaPhiCompute<::Frame::Grid>,
-          StrahlkorperTags::RadiusCompute<::Frame::Grid>,
-          StrahlkorperTags::RhatCompute<::Frame::Grid>,
-          StrahlkorperTags::InvJacobianCompute<::Frame::Grid>,
-          StrahlkorperTags::DxRadiusCompute<::Frame::Grid>,
-          StrahlkorperTags::OneOverOneFormMagnitudeCompute<3, ::Frame::Grid,
-                                                           DataVector>,
-          StrahlkorperTags::NormalOneFormCompute<::Frame::Grid>,
-          StrahlkorperTags::UnitNormalOneFormCompute<::Frame::Grid>,
-          StrahlkorperTags::UnitNormalVectorCompute<::Frame::Grid>,
-          StrahlkorperTags::GradUnitNormalOneFormCompute<::Frame::Grid>,
-          StrahlkorperTags::ExtrinsicCurvatureCompute<::Frame::Grid>>;
+      using compute_items_on_target = tmpl::list<>;
       using compute_target_points =
           intrp::TargetPoints::ApparentHorizon<InterpolationTarget,
                                                ::Frame::Grid>;
@@ -88,17 +74,12 @@ struct BothHorizons : tt::ConformsTo<protocols::Measurement> {
           tmpl::list<control_system::RunCallbacks<FindHorizon, ControlSystems>>;
     };
 
-    using source_tensors =
-        tmpl::list<gr::Tags::SpacetimeMetric<3, ::Frame::Inertial>,
-                   GeneralizedHarmonic::Tags::Pi<3, ::Frame::Inertial>,
-                   GeneralizedHarmonic::Tags::Phi<3, ::Frame::Inertial>>;
-
    public:
     template <typename ControlSystems>
     using interpolation_target_tag = InterpolationTarget<ControlSystems>;
 
     using argument_tags =
-        tmpl::push_front<source_tensors, domain::Tags::Mesh<3>>;
+        tmpl::push_front<::ah::source_vars<3>, domain::Tags::Mesh<3>>;
 
     template <typename Metavariables, typename ParallelComponent,
               typename ControlSystems>
@@ -107,13 +88,15 @@ struct BothHorizons : tt::ConformsTo<protocols::Measurement> {
         const tnsr::aa<DataVector, 3, ::Frame::Inertial>& spacetime_metric,
         const tnsr::aa<DataVector, 3, ::Frame::Inertial>& pi,
         const tnsr::iaa<DataVector, 3, ::Frame::Inertial>& phi,
+        const tnsr::ijaa<DataVector, 3, ::Frame::Inertial>& deriv_phi,
         const LinkedMessageId<double>& measurement_id,
         Parallel::GlobalCache<Metavariables>& cache,
         const ElementId<3>& array_index,
         const ParallelComponent* const /*meta*/, ControlSystems /*meta*/) {
       intrp::interpolate<interpolation_target_tag<ControlSystems>,
-                         source_tensors>(
-          measurement_id, mesh, cache, array_index, spacetime_metric, pi, phi);
+                         ::ah::source_vars<3>>(measurement_id, mesh, cache,
+                                               array_index, spacetime_metric,
+                                               pi, phi, deriv_phi);
     }
   };
 

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
@@ -9,6 +9,7 @@
 #include "ApparentHorizons/ComputeHorizonVolumeQuantities.hpp"
 #include "ApparentHorizons/ComputeHorizonVolumeQuantities.tpp"
 #include "ApparentHorizons/ComputeItems.hpp"
+#include "ApparentHorizons/HorizonAliases.hpp"
 #include "ApparentHorizons/Tags.hpp"
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
@@ -72,41 +73,12 @@ struct EvolutionMetavars<3, InitialData, BoundaryConditions>
 
   struct AhA : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
     using temporal_id = ::Tags::Time;
-    using tags_to_observe = tmpl::list<
-        StrahlkorperGr::Tags::AreaCompute<frame>,
-        StrahlkorperGr::Tags::IrreducibleMassCompute<frame>,
-        StrahlkorperTags::MaxRicciScalarCompute,
-        StrahlkorperTags::MinRicciScalarCompute,
-        StrahlkorperGr::Tags::ChristodoulouMassCompute<frame>,
-        StrahlkorperGr::Tags::DimensionlessSpinMagnitudeCompute<frame>>;
-    using surface_tags_to_observe = tmpl::list<StrahlkorperTags::RicciScalar>;
+    using tags_to_observe = ::ah::tags_for_observing;
+    using surface_tags_to_observe = ::ah::surface_tags_for_observing;
     using compute_vars_to_interpolate = ah::ComputeHorizonVolumeQuantities;
     using vars_to_interpolate_to_target =
-        tmpl::list<gr::Tags::SpatialMetric<volume_dim, frame, DataVector>,
-                   gr::Tags::InverseSpatialMetric<volume_dim, frame>,
-                   gr::Tags::ExtrinsicCurvature<volume_dim, frame>,
-                   gr::Tags::SpatialChristoffelSecondKind<volume_dim, frame>,
-                   gr::Tags::SpatialRicci<volume_dim, frame>>;
-    using compute_items_on_target = tmpl::append<
-        tmpl::list<
-            StrahlkorperGr::Tags::AreaElementCompute<frame>,
-            StrahlkorperTags::ThetaPhiCompute<frame>,
-            StrahlkorperTags::RadiusCompute<frame>,
-            StrahlkorperTags::RhatCompute<frame>,
-            StrahlkorperTags::TangentsCompute<frame>,
-            StrahlkorperTags::InvJacobianCompute<frame>,
-            StrahlkorperTags::DxRadiusCompute<frame>,
-            StrahlkorperTags::OneOverOneFormMagnitudeCompute<volume_dim, frame,
-                                                             DataVector>,
-            StrahlkorperTags::NormalOneFormCompute<frame>,
-            StrahlkorperTags::UnitNormalOneFormCompute<frame>,
-            StrahlkorperTags::UnitNormalVectorCompute<frame>,
-            StrahlkorperTags::GradUnitNormalOneFormCompute<frame>,
-            StrahlkorperTags::ExtrinsicCurvatureCompute<frame>,
-            StrahlkorperGr::Tags::SpinFunctionCompute<frame>,
-            StrahlkorperTags::RicciScalarCompute<frame>,
-            StrahlkorperGr::Tags::DimensionfulSpinMagnitudeCompute<frame>>,
-        tags_to_observe>;
+        ::ah::vars_to_interpolate_to_target<volume_dim, ::Frame::Inertial>;
+    using compute_items_on_target = ::ah::compute_items_on_target<volume_dim>;
     using compute_target_points =
         intrp::TargetPoints::ApparentHorizon<AhA, ::Frame::Inertial>;
     using post_interpolation_callback =
@@ -119,12 +91,7 @@ struct EvolutionMetavars<3, InitialData, BoundaryConditions>
   };
 
   using interpolation_target_tags = tmpl::list<AhA>;
-  using interpolator_source_vars = tmpl::list<
-      gr::Tags::SpacetimeMetric<volume_dim, Frame::Inertial>,
-      GeneralizedHarmonic::Tags::Pi<volume_dim, Frame::Inertial>,
-      GeneralizedHarmonic::Tags::Phi<volume_dim, Frame::Inertial>,
-      Tags::deriv<GeneralizedHarmonic::Tags::Phi<volume_dim, Frame::Inertial>,
-                  tmpl::size_t<3>, Frame::Inertial>>;
+  using interpolator_source_vars = ::ah::source_vars<volume_dim>;
 
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {


### PR DESCRIPTION
## Proposed changes

The lists of tags that go into the interpolation targets for AH finding were duplicated several times in the control system measurements, BBH exec, and GH exec with horizon. This PR creates a file to hold the tags necessary for AH finding so all three can use the same lists, that way we don't have to update all of them every time we make a change.

The changes to the control system measurements also occur in #3983. After one PR is merged (either #3983 or this one), I'll rebase the other.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
When making an InterpolationTargetTag for AH finding, use the type aliases defined in `ApparentHorizons/HorizonAliases.hpp` for the various lists of tags.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
