### PR TITLE
Subcell TCI improvements, step 0

### DIFF
--- a/src/Evolution/DgSubcell/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/CMakeLists.txt
@@ -43,6 +43,7 @@ spectre_target_sources(
   Mesh.cpp
   PerssonTci.cpp
   Projection.cpp
+  RdmpTci.cpp
   RdmpTciData.cpp
   Reconstruction.cpp
   ReconstructionMethod.cpp

--- a/src/Evolution/DgSubcell/NeighborReconstructedFaceSolution.hpp
+++ b/src/Evolution/DgSubcell/NeighborReconstructedFaceSolution.hpp
@@ -71,7 +71,8 @@ void neighbor_reconstructed_face_solution(
             maximum_number_of_neighbors(Metavariables::volume_dim),
             std::pair<Direction<Metavariables::volume_dim>,
                       ElementId<Metavariables::volume_dim>>,
-            std::tuple<Mesh<Metavariables::volume_dim - 1>,
+            std::tuple<Mesh<Metavariables::volume_dim>,
+                       Mesh<Metavariables::volume_dim - 1>,
                        std::optional<std::vector<double>>,
                        std::optional<std::vector<double>>, ::TimeStepId>,
             boost::hash<std::pair<Direction<Metavariables::volume_dim>,
@@ -88,13 +89,13 @@ void neighbor_reconstructed_face_solution(
         for (auto& received_mortar_data :
              received_temporal_id_and_data->second) {
           const auto& mortar_id = received_mortar_data.first;
-          ASSERT(std::get<1>(received_mortar_data.second).has_value(),
+          ASSERT(std::get<2>(received_mortar_data.second).has_value(),
                  "The subcell mortar data was not sent at TimeStepId "
                      << received_temporal_id_and_data->first
                      << " with mortar id (" << mortar_id.first << ','
                      << mortar_id.second << ")");
           const std::vector<double>& neighbor_ghost_and_subcell_data =
-              *std::get<1>(received_mortar_data.second);
+              *std::get<2>(received_mortar_data.second);
           // Compute min and max over neighbors
           const size_t offset_for_min =
               neighbor_ghost_and_subcell_data.size() - number_of_evolved_vars;
@@ -133,7 +134,7 @@ void neighbor_reconstructed_face_solution(
       mortars_to_reconstruct_to{};
   for (auto& received_mortar_data : received_temporal_id_and_data->second) {
     const auto& mortar_id = received_mortar_data.first;
-    if (not std::get<2>(received_mortar_data.second).has_value()) {
+    if (not std::get<3>(received_mortar_data.second).has_value()) {
       mortars_to_reconstruct_to.push_back(mortar_id);
     }
   }
@@ -155,13 +156,13 @@ void neighbor_reconstructed_face_solution(
   // src/Evolution/DiscontinuousGalerkin)
   for (auto& received_mortar_data : received_temporal_id_and_data->second) {
     const auto& mortar_id = received_mortar_data.first;
-    if (not std::get<2>(received_mortar_data.second).has_value()) {
+    if (not std::get<3>(received_mortar_data.second).has_value()) {
       ASSERT(neighbor_reconstructed_evolved_vars.find(mortar_id) !=
                  neighbor_reconstructed_evolved_vars.end(),
              "Could not find mortar id (" << mortar_id.first << ','
                                           << mortar_id.second
                                           << ") in reconstructed data map.");
-      std::get<2>(received_mortar_data.second) =
+      std::get<3>(received_mortar_data.second) =
           std::move(neighbor_reconstructed_evolved_vars.at(mortar_id));
     }
   }

--- a/src/Evolution/DgSubcell/RdmpTci.cpp
+++ b/src/Evolution/DgSubcell/RdmpTci.cpp
@@ -1,0 +1,36 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/DgSubcell/RdmpTci.hpp"
+
+#include <cstddef>
+#include <vector>
+
+#include "Utilities/ErrorHandling/Assert.hpp"
+
+namespace evolution::dg::subcell {
+bool rdmp_tci(const std::vector<double>& max_of_current_variables,
+              const std::vector<double>& min_of_current_variables,
+              const std::vector<double>& max_of_past_variables,
+              const std::vector<double>& min_of_past_variables,
+              const double rdmp_delta0, const double rdmp_epsilon) {
+  const size_t number_of_vars = max_of_current_variables.size();
+  ASSERT(min_of_current_variables.size() == number_of_vars and
+             max_of_past_variables.size() == number_of_vars and
+             min_of_past_variables.size() == number_of_vars,
+         "The max and min of the current and past variables must all have the "
+         "same size.");
+  for (size_t i = 0; i < number_of_vars; ++i) {
+    using std::max;
+    const double delta = max(
+        rdmp_delta0,
+        rdmp_epsilon * (max_of_past_variables[i] - min_of_past_variables[i]));
+
+    if (max_of_current_variables[i] > max_of_past_variables[i] + delta or
+        min_of_current_variables[i] < min_of_past_variables[i] - delta) {
+      return true;
+    }
+  }
+  return false;
+}
+}  // namespace evolution::dg::subcell

--- a/src/Evolution/DgSubcell/RdmpTci.hpp
+++ b/src/Evolution/DgSubcell/RdmpTci.hpp
@@ -167,4 +167,51 @@ std::pair<std::vector<double>, std::vector<double>> rdmp_max_min(
       });
   return {std::move(max_of_vars), std::move(min_of_vars)};
 }
+
+/*!
+ * \brief Check if the current variables satisfy the RDMP. Returns `true` if the
+ * cell is troubled.
+ *
+ * Let the candidate solution be denoted by \f$u^\star_{\alpha}(t^{n+1})\f$.
+ * Then the RDMP requires that
+ *
+ * \f{align*}{
+ *   \min_{\forall\mathcal{N}}\left(u_{\alpha}(t^n)\right)
+ *   - \delta_\alpha
+ *   \le
+ *   u^\star_{\alpha}(t^{n+1})
+ *   \le
+ *   \max_{\forall\mathcal{N}}
+ *   \left(u_{\alpha}(t^n)\right) + \delta_\alpha
+ * \f}
+ *
+ * where \f$\mathcal{N}\f$ are either the Neumann or Voronoi neighbors and the
+ * element itself,  and \f$\delta_\alpha\f$ is a parameter defined below that
+ * relaxes the discrete maximum principle (DMP). When computing
+ * \f$\max(u_\alpha)\f$ and \f$\min(u_\alpha)\f$ over a DG element that is not
+ * using subcells we first project the DG solution to the subcells and then
+ * compute the maximum and minimum over *both* the DG grid and the subcell grid.
+ * However, when a DG element is using subcells we compute the maximum and
+ * minimum of \f$u_\alpha(t^n)\f$ over the subcells only. Note that the maximum
+ * and minimum values of \f$u^\star_\alpha\f$ are always computed over both the
+ * DG and the subcell grids, even when using the RDMP to check if the
+ * reconstructed DG solution would be admissible.
+ *
+ * The parameter \f$\delta_\alpha\f$ is given by:
+ *
+ * \f{align*}{
+ *   \delta_\alpha =
+ *   \max\left(\delta_{0},\epsilon
+ *   \left(\max_{\forall\mathcal{N}}\left(u_{\alpha}(t^n)\right)
+ *   - \min_{\forall\mathcal{N}}\left(u_{\alpha}(t^n)\right)\right)
+ *   \right),
+ * \f}
+ *
+ * where we typically take \f$\delta_{0}=10^{-4}\f$ and \f$\epsilon=10^{-3}\f$.
+ */
+bool rdmp_tci(const std::vector<double>& max_of_current_variables,
+              const std::vector<double>& min_of_current_variables,
+              const std::vector<double>& max_of_past_variables,
+              const std::vector<double>& min_of_past_variables,
+              double rdmp_delta0, double rdmp_epsilon);
 }  // namespace evolution::dg::subcell

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
@@ -486,6 +486,10 @@ void ComputeTimeDerivative<Metavariables>::send_data_for_fluxes(
 
     std::optional<DirectionMap<volume_dim, std::vector<double>>>
         all_neighbor_data_for_reconstruction = std::nullopt;
+    // Set ghost_cell_mesh to the DG mesh, then update it below if we did a
+    // projection.
+    Mesh<volume_dim> ghost_cell_mesh =
+        db::get<domain::Tags::Mesh<volume_dim>>(*box);
     if constexpr (using_subcell_v<Metavariables>) {
       all_neighbor_data_for_reconstruction =
           evolution::dg::subcell::prepare_neighbor_data<Metavariables>(box);
@@ -537,9 +541,11 @@ void ComputeTimeDerivative<Metavariables>::send_data_for_fluxes(
           }
         }();
 
-        std::tuple<Mesh<volume_dim - 1>, std::optional<std::vector<double>>,
+        std::tuple<Mesh<volume_dim>, Mesh<volume_dim - 1>,
+                   std::optional<std::vector<double>>,
                    std::optional<std::vector<double>>, ::TimeStepId>
-            data{neighbor_boundary_data_on_mortar.first,
+            data{ghost_cell_mesh,
+                 neighbor_boundary_data_on_mortar.first,
                  ghost_and_subcell_data,
                  {std::move(neighbor_boundary_data_on_mortar.second)},
                  next_time_step_id};

--- a/tests/Unit/Evolution/Actions/Test_RunEventsAndDenseTriggers.cpp
+++ b/tests/Unit/Evolution/Actions/Test_RunEventsAndDenseTriggers.cpp
@@ -637,10 +637,14 @@ void test_lts(const bool time_runs_forward) {
         component,
         evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<1>>(
         make_not_null(&runner), 0)
-        .insert(
-            {quarter_time_step_id,
-             {{neighbor,
-               {Mesh<0>{}, {}, {{second_correction}}, half_time_step_id}}}});
+        .insert({quarter_time_step_id,
+                 {{neighbor,
+                   {// Set arbitrary ghost cell mesh since it won't be used.
+                    Mesh<1>{},
+                    Mesh<0>{},
+                    {},
+                    {{second_correction}},
+                    half_time_step_id}}}});
     CHECK(run_if_ready(make_not_null(&runner)));
     VarsType dense_var = initial_vars + 0.5 * step_size * deriv_vars;
     get(get<Var>(dense_var))[1] -=

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_ReconstructionCommunication.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_ReconstructionCommunication.cpp
@@ -307,7 +307,7 @@ void test() {
         runner, east_id);
     CHECK_ITERABLE_APPROX(
         expected_east_data,
-        *std::get<1>(east_data.at(time_step_id)
+        *std::get<2>(east_data.at(time_step_id)
                          .at(std::pair{Direction<Dim>::lower_xi(), self_id})));
   }
   if constexpr (Dim > 1) {
@@ -335,7 +335,7 @@ void test() {
         comp, evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<Dim>>(
         runner, south_id);
     CHECK(expected_south_data ==
-          *std::get<1>(
+          *std::get<2>(
               south_data.at(time_step_id)
                   .at(std::pair{orientation(direction.opposite()), self_id})));
   }
@@ -364,9 +364,12 @@ void test() {
     evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<Dim>::
         insert_into_inbox(
             make_not_null(&self_inbox), time_step_id,
-            std::pair{std::pair{Direction<Dim>::upper_xi(), east_id},
-                      std::tuple{face_mesh, east_ghost_cells_and_rdmp,
-                                 boundary_data, next_time_step_id}});
+            std::pair{
+                std::pair{Direction<Dim>::upper_xi(), east_id},
+                std::tuple{// subcell_mesh because we are sending the projected
+                           // data right now.
+                           subcell_mesh, face_mesh, east_ghost_cells_and_rdmp,
+                           boundary_data, next_time_step_id}});
   }
   [[maybe_unused]] std::vector<double> south_ghost_cells_and_rdmp{};
   if constexpr (Dim > 1) {
@@ -382,9 +385,12 @@ void test() {
     evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<Dim>::
         insert_into_inbox(
             make_not_null(&self_inbox), time_step_id,
-            std::pair{std::pair{Direction<Dim>::lower_eta(), south_id},
-                      std::tuple{face_mesh, south_ghost_cells_and_rdmp,
-                                 std::nullopt, next_time_step_id}});
+            std::pair{
+                std::pair{Direction<Dim>::lower_eta(), south_id},
+                std::tuple{// subcell_mesh because we are sending the projected
+                           // data right now.
+                           subcell_mesh, face_mesh, south_ghost_cells_and_rdmp,
+                           std::nullopt, next_time_step_id}});
   }
 
   // Run the ReceiveDataForReconstruction action on self_id

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
@@ -638,8 +638,9 @@ void test_impl(const Spectral::Quadrature quadrature,
     const Mesh<Dim - 1> face_mesh = mesh.slice_away(direction.dimension());
     const auto insert_neighbor_data = [&all_mortar_data, &count, &direction,
                                        &face_mesh, &local_next_time_step_id,
-                                       &mortar_data_history, &mortar_meshes,
-                                       &neighbor_id, &runner, &self_id](
+                                       &mesh, &mortar_data_history,
+                                       &mortar_meshes, &neighbor_id, &runner,
+                                       &self_id](
                                           const TimeStepId&
                                               neighbor_time_step_id,
                                           const TimeStepId&
@@ -654,9 +655,9 @@ void test_impl(const Spectral::Quadrature quadrature,
                 direction.dimension() +
                     10 * static_cast<unsigned long>(direction.side()) +
                     100 * count);
-      std::tuple<Mesh<Dim - 1>, std::optional<std::vector<double>>,
+      std::tuple<Mesh<Dim>, Mesh<Dim - 1>, std::optional<std::vector<double>>,
                  std::optional<std::vector<double>>, ::TimeStepId>
-          data{face_mesh, {}, {flux_data}, {neighbor_next_time_step_id}};
+          data{mesh, face_mesh, {}, {flux_data}, {neighbor_next_time_step_id}};
 
       runner.template mock_distributed_objects<component<metavars>>()
           .at(self_id)

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -1707,7 +1707,7 @@ void test_impl(const Spectral::Quadrature quadrature,
                                      mortar_id_east.second, true));
   }
   CHECK_ITERABLE_APPROX(
-      *std::get<2>(
+      *std::get<3>(
           ActionTesting::get_inbox_tag<
               component<metavars>,
               ::evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<Dim>>(
@@ -1721,7 +1721,7 @@ void test_impl(const Spectral::Quadrature quadrature,
                                    false));
 
   CHECK(
-      std::get<3>(
+      std::get<4>(
           ActionTesting::get_inbox_tag<
               component<metavars>,
               ::evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<Dim>>(
@@ -1736,7 +1736,7 @@ void test_impl(const Spectral::Quadrature quadrature,
   if constexpr (Dim > 1) {
     const auto mortar_id_south =
         std::make_pair(Direction<Dim>::lower_eta(), south_id);
-    CHECK(std::get<3>(
+    CHECK(std::get<4>(
               ActionTesting::get_inbox_tag<
                   component<metavars>,
                   ::evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<
@@ -1769,7 +1769,7 @@ void test_impl(const Spectral::Quadrature quadrature,
                                 Direction<Dim>::lower_eta(), south_id, true));
     }
     CHECK_ITERABLE_APPROX(
-        *std::get<2>(
+        *std::get<3>(
             ActionTesting::get_inbox_tag<
                 component<metavars>,
                 ::evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<


### PR DESCRIPTION
## Proposed changes

Some cleanup and refactoring that is needed for performance optimizations that are on the way. 

- Send the ghost zone mesh. This isn't used yet, but will be needed for eliding unnecessary projection operations.
- Add another RDMP TCI that doesn't take `Variables`. The old version can be replaced after some TCI cleanups.
- Allow different tags in the two-mesh RDMP TCI. This just makes some code more uniform for transitioning away from having `inactive` vars in the DataBox. It'll be used in the next PR (almost ready) that rewrites a bunch of the TCI code to reduce projection operations.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
