### PR TITLE
Add predicted_zero_crossing function generalized for Datavectors

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/LinearLeastSquares.cpp
+++ b/src/NumericalAlgorithms/Interpolation/LinearLeastSquares.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <deque>
 #include <gsl/gsl_spline.h>
 #include <memory>
 #include <pup.h>
@@ -112,7 +113,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_ORDER, (1, 2, 3, 4))
 
 GENERATE_INSTANTIATIONS(INSTANTIATE_DTYPE1, (1, 2, 3, 4),
                         (std::vector<double>, DataVector, ModalVector,
-                         gsl::span<double>))
+                         gsl::span<double>, std::deque<double>))
 
 #define INSTANTIATE_DTYPE2(_, data)                         \
   template std::vector<std::array<double, ORDER(data) + 1>> \
@@ -120,7 +121,8 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_DTYPE1, (1, 2, 3, 4),
       const DTYPE(data) & x_values, const std::vector<DTYPE(data)>& y_values);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE_DTYPE2, (1, 2, 3, 4),
-                        (std::vector<double>, DataVector, ModalVector))
+                        (std::vector<double>, DataVector, ModalVector,
+                         std::deque<double>))
 #undef ORDER
 #undef DTYPE
 

--- a/src/NumericalAlgorithms/Interpolation/PredictedZeroCrossing.cpp
+++ b/src/NumericalAlgorithms/Interpolation/PredictedZeroCrossing.cpp
@@ -3,6 +3,7 @@
 
 #include "NumericalAlgorithms/Interpolation/PredictedZeroCrossing.hpp"
 
+#include <deque>
 #include <vector>
 
 #include "NumericalAlgorithms/Interpolation/LinearLeastSquares.hpp"
@@ -14,6 +15,27 @@ double predicted_zero_crossing_value(const std::vector<double>& x_values,
   intrp::LinearLeastSquares<1> predictor{x_values.size()};
   const auto coefficients = predictor.fit_coefficients(x_values, y_values);
   return -coefficients[0]/coefficients[1];
+}
+
+DataVector predicted_zero_crossing_value(
+    const std::deque<double>& x_values,
+    const std::deque<DataVector>& y_values) {
+  ASSERT(x_values.size() == y_values.size(),
+         "The x_values and y_values must be of the same size");
+  intrp::LinearLeastSquares<1> predictor{x_values.size()};
+
+  DataVector result(y_values.front().size());
+  std::deque<double> tmp_y_values(x_values.size());
+  for (size_t i = 0; i < result.size(); i++) {
+    for (size_t j = 0; j < tmp_y_values.size(); j++) {
+      tmp_y_values[j] = y_values[j][i];
+    }
+    const auto coefficients =
+        predictor.fit_coefficients(x_values, tmp_y_values);
+    result[i] = -coefficients[0] / coefficients[1];
+  }
+
+  return result;
 }
 
 }  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/PredictedZeroCrossing.hpp
+++ b/src/NumericalAlgorithms/Interpolation/PredictedZeroCrossing.hpp
@@ -3,7 +3,10 @@
 
 #pragma once
 
+#include <deque>
 #include <vector>
+
+#include "DataStructures/DataVector.hpp"
 
 namespace intrp {
 
@@ -15,5 +18,27 @@ namespace intrp {
  */
 double predicted_zero_crossing_value(const std::vector<double>& x_values,
                                      const std::vector<double>& y_values);
+
+/*!
+ * \brief Predicts the zero crossing of multiple functions contained in a deque
+ * of DataVectors.
+ *
+ * Fits a set of N linear functions, where N is the size of the returned
+ * DataVector and the size of each DataVector in the y_values.
+ * Each linear function is fit by M points, where M is the size of x_values and
+ * y_values. The Nth point in the returned DataVector is the value of x for
+ * which the linear fit to the points (x[:], y[:][N]) [using python notation]
+ * crosses y = 0. The x_values contain M points in the independent variable,
+ * while the y_values contain M DataVectors that each contain (for example) the
+ * set of points on a Strahlkorper. Each element of y_values is a DataVector of
+ * size N. The first index to y_values selects a DataVector of points
+ * corresponding to an x_value, and the second index selects a point in the
+ * DataVector, so the y_values are indexed by
+ * [x_value_index][point_in_datavector]. The x_values and y_values must be of
+ * size M. Each fit determines the zero-crossing for one of the sets of points
+ * in the y_values.
+ */
+DataVector predicted_zero_crossing_value(
+    const std::deque<double>& x_values, const std::deque<DataVector>& y_values);
 
 }  // namespace intrp

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_PredictedZeroCrossing.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_PredictedZeroCrossing.cpp
@@ -3,12 +3,59 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <deque>
 #include <random>
 #include <vector>
 
 #include "Framework/TestHelpers.hpp"
 #include "NumericalAlgorithms/Interpolation/LinearLeastSquares.hpp"
 #include "NumericalAlgorithms/Interpolation/PredictedZeroCrossing.hpp"
+
+namespace {
+
+void test_predicted_zero_crossing_datavector() {
+  // Set up random number generator
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> dist(-10., 10.);
+  std::uniform_real_distribution<> error_dist(-1e-8, 1e-8);
+
+  DataVector expected_zero_crossing_value(3, 0.);
+  for (size_t i = 0; i < expected_zero_crossing_value.size(); ++i) {
+    expected_zero_crossing_value[i] = dist(gen);
+  }
+  CAPTURE(expected_zero_crossing_value);
+
+  std::deque<double> slope{};
+  for (size_t i = 0; i < expected_zero_crossing_value.size(); ++i) {
+    slope.push_back(dist(gen));
+  }
+  CAPTURE(slope);
+
+  std::deque<double> y_intercept{};
+  for (size_t i = 0; i < expected_zero_crossing_value.size(); ++i) {
+    y_intercept.push_back(-slope[i] * expected_zero_crossing_value[i]);
+  }
+
+  std::deque<double> x_values{0., 1., 2., 3., 4., 5., 6., 7., 8., 9.};
+  std::deque<DataVector> y_values{};
+
+  for (size_t i = 0; i < x_values.size(); i++) {
+    DataVector tmp(expected_zero_crossing_value.size());
+    for (size_t j = 0; j < tmp.size(); j++) {
+      tmp[j] = y_intercept[j] + slope[j] * x_values[i] + error_dist(gen);
+    }
+    y_values.push_back(tmp);
+  }
+
+  DataVector compute_zero_crossing_value =
+      intrp::predicted_zero_crossing_value(x_values, y_values);
+
+  Approx custom_approx = Approx::custom().epsilon(1e-6);
+  CHECK_ITERABLE_CUSTOM_APPROX(compute_zero_crossing_value,
+                               expected_zero_crossing_value, custom_approx);
+}
+
+}  // namespace
 
 SPECTRE_TEST_CASE(
     "Unit.NumericalAlgorithms.Interpolation.PredictedZeroCrossing",
@@ -37,4 +84,7 @@ SPECTRE_TEST_CASE(
   Approx custom_approx = Approx::custom().epsilon(1.e-6);
   CHECK_ITERABLE_CUSTOM_APPROX(expected_zero_crossing_value,
                                compute_zero_crossing_value, custom_approx);
+
+  // Test the zero crossing value for a set of datavectors
+  test_predicted_zero_crossing_datavector();
 }


### PR DESCRIPTION
## Proposed changes

The Predicted Zero Crossing function fits a linear function to a set of y_values passed through as a set of DataVector 's at different times and uses the fit to predict what times the value zero will be crossed. This is a step toward measuring how long the surface will take to hit the excision surface so that the control system can adjust the grid to avoid the excision surface from coming out of the apparent horizon surface. The function now takes a `DataVector` for the x_values and a `std::vector<DataVector>` for the y_values.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
