### PR TITLE
Modify component name function in control systems

### DIFF
--- a/src/ControlSystem/Protocols/ControlSystem.hpp
+++ b/src/ControlSystem/Protocols/ControlSystem.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstddef>
+#include <optional>
 #include <string>
 #include <type_traits>
 
@@ -23,11 +24,11 @@ namespace control_system::protocols {
 ///   corresponds to the name of the FunctionOfTime controlled by this
 ///   system.
 ///
-/// - a static function `component_name` returning a `std::string`.  This
-///   gives a name associated to each component of the FunctionOfTime that is
-///   being controlled. E.g. a FunctionOfTime controlling translation will have
-///   three components with names "X", "Y", and "Z". This is useful when writing
-///   data to disk.
+/// - a static function `component_name` returning a
+///   `std::optional<std::string>`.  This gives a name associated to each
+///   component of the FunctionOfTime that is being controlled. E.g. a
+///   FunctionOfTime controlling translation will have three components with
+///   names "X", "Y", and "Z". This is useful when writing data to disk.
 ///
 /// - a type alias `measurement` to a struct implementing the
 ///   Measurement protocol.
@@ -80,8 +81,9 @@ struct ControlSystem {
                                  std::string>);
 
     static_assert(std::is_same_v<decltype(ConformingType::component_name(
+                                     std::declval<const size_t>(),
                                      std::declval<const size_t>())),
-                                 std::string>);
+                                 std::optional<std::string>>);
 
     using measurement = typename ConformingType::measurement;
     static_assert(tt::assert_conforms_to<measurement, Measurement>);

--- a/src/ControlSystem/Systems/Expansion.hpp
+++ b/src/ControlSystem/Systems/Expansion.hpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cstddef>
+#include <optional>
 #include <string>
 
 #include "ApparentHorizons/ObjectLabel.hpp"
@@ -24,6 +25,7 @@
 #include "DataStructures/LinkedMessageQueue.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "ParallelAlgorithms/Actions/UpdateMessageQueue.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
@@ -64,7 +66,13 @@ struct Expansion : tt::ConformsTo<protocols::ControlSystem> {
   }
 
   // Expansion only has one component so just make it "Expansion"
-  static std::string component_name(const size_t /*i*/) { return name(); }
+  static std::optional<std::string> component_name(
+      const size_t /*i*/, const size_t num_components) {
+    ASSERT(num_components == 1,
+           "Expansion control expects 1 component but there are "
+               << num_components << " instead.");
+    return name();
+  }
 
   using measurement = ah::BothHorizons;
   static_assert(

--- a/src/ControlSystem/Systems/Rotation.hpp
+++ b/src/ControlSystem/Systems/Rotation.hpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cstddef>
+#include <optional>
 #include <string>
 
 #include "ApparentHorizons/ObjectLabel.hpp"
@@ -23,6 +24,7 @@
 #include "DataStructures/LinkedMessageQueue.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "ParallelAlgorithms/Actions/UpdateMessageQueue.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
@@ -70,7 +72,11 @@ struct Rotation : tt::ConformsTo<protocols::ControlSystem> {
     return pretty_type::short_name<Rotation<DerivOrder>>();
   }
 
-  static std::string component_name(const size_t component) {
+  static std::optional<std::string> component_name(
+      const size_t component, const size_t num_components) {
+    ASSERT(num_components == 3,
+           "Rotation control expects 3 components but there are "
+               << num_components << " instead.");
     return component == 0 ? "x" : component == 1 ? "y" : "z";
   }
 

--- a/src/ControlSystem/WriteData.hpp
+++ b/src/ControlSystem/WriteData.hpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -96,11 +97,15 @@ void write_components_to_disk(
   // ControlSystems/Translation/Z.dat
   const size_t num_components = function_at_current_time[0].size();
   for (size_t i = 0; i < num_components; ++i) {
-    const std::string component_name = ControlSystem::component_name(i);
+    const std::optional<std::string> component_name_opt =
+        ControlSystem::component_name(i, num_components);
+    if (not component_name_opt) {
+      continue;
+    }
     // Currently all reduction data is written to the reduction file so preface
     // everything with ControlSystems/
     const std::string subfile_name{"/ControlSystems/" + ControlSystem::name() +
-                                   "/" + component_name};
+                                   "/" + *component_name_opt};
     std::vector<std::string> legend{
         "Time",         "Lambda",         "dtLambda",     "d2tLambda",
         "ControlError", "dtControlError", "ControlSignal"};

--- a/tests/Unit/ControlSystem/Actions/Test_Initialization.cpp
+++ b/tests/Unit/ControlSystem/Actions/Test_Initialization.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -36,7 +37,10 @@ template <typename Label, typename Measurement>
 struct MockControlSystem
     : tt::ConformsTo<control_system::protocols::ControlSystem> {
   static std::string name() { return pretty_type::short_name<Label>(); }
-  static std::string component_name(const size_t i) { return get_output(i); }
+  static std::optional<std::string> component_name(
+      const size_t i, const size_t /*num_components*/) {
+    return get_output(i);
+  }
   using measurement = Measurement;
   using control_error = control_system::TestHelpers::ControlError;
   static constexpr size_t deriv_order = order;

--- a/tests/Unit/ControlSystem/Actions/Test_InitializeMeasurements.cpp
+++ b/tests/Unit/ControlSystem/Actions/Test_InitializeMeasurements.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
 #include <type_traits>
 #include <unordered_map>
@@ -87,7 +88,10 @@ struct SystemB;
 
 struct SystemA : tt::ConformsTo<control_system::protocols::ControlSystem> {
   static std::string name() { return "A"; }
-  static std::string component_name(const size_t i) { return get_output(i); }
+  static std::optional<std::string> component_name(
+      const size_t i, const size_t /*num_components*/) {
+    return get_output(i);
+  }
   using simple_tags = tmpl::list<>;
   using measurement = Measurement<tmpl::list<SystemA, SystemB>>;
   using control_error = control_system::TestHelpers::ControlError;
@@ -99,7 +103,10 @@ struct SystemA : tt::ConformsTo<control_system::protocols::ControlSystem> {
 
 struct SystemB : tt::ConformsTo<control_system::protocols::ControlSystem> {
   static std::string name() { return "B"; }
-  static std::string component_name(const size_t /*i*/) { return ""; }
+  static std::optional<std::string> component_name(
+      const size_t /*i*/, const size_t /*num_components*/) {
+    return std::nullopt;
+  }
   using simple_tags = tmpl::list<>;
   using measurement = Measurement<tmpl::list<SystemA, SystemB>>;
   using control_error = control_system::TestHelpers::ControlError;
@@ -111,7 +118,10 @@ struct SystemB : tt::ConformsTo<control_system::protocols::ControlSystem> {
 
 struct SystemC : tt::ConformsTo<control_system::protocols::ControlSystem> {
   static std::string name() { return "C"; }
-  static std::string component_name(const size_t /*i*/) { return ""; }
+  static std::optional<std::string> component_name(
+      const size_t /*i*/, const size_t /*num_components*/) {
+    return std::nullopt;
+  }
   using simple_tags = tmpl::list<>;
   using measurement = Measurement<tmpl::list<SystemC>>;
   using control_error = control_system::TestHelpers::ControlError;

--- a/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
@@ -165,8 +165,18 @@ void test_names() {
   using expansion = control_system::Systems::Expansion<2>;
 
   CHECK(pretty_type::name<expansion>() == "Expansion");
-  CHECK(expansion::component_name(0) == "Expansion");
-  CHECK(expansion::component_name(1) == "Expansion");
+  CHECK(*expansion::component_name(0, 1) == "Expansion");
+  CHECK(*expansion::component_name(1, 1) == "Expansion");
+
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(
+      ([]() {
+        const std::string component_name = *expansion::component_name(1, 2);
+        (void)component_name;
+      })(),
+      Catch::Contains(
+          "Expansion control expects 1 component but there are 2 instead."));
+#endif  // SPECTRE_DEBUG
 }
 
 SPECTRE_TEST_CASE("Unit.ControlSystem.Systems.Expansion",

--- a/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
@@ -169,9 +169,19 @@ void test_names() {
   using rotation = control_system::Systems::Rotation<2>;
 
   CHECK(pretty_type::name<rotation>() == "Rotation");
-  CHECK(rotation::component_name(0) == "x");
-  CHECK(rotation::component_name(1) == "y");
-  CHECK(rotation::component_name(2) == "z");
+  CHECK(*rotation::component_name(0, 3) == "x");
+  CHECK(*rotation::component_name(1, 3) == "y");
+  CHECK(*rotation::component_name(2, 3) == "z");
+
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(
+      ([]() {
+        const std::string component_name = *rotation::component_name(1, 4);
+        (void)component_name;
+      })(),
+      Catch::Contains(
+          "Rotation control expects 3 components but there are 4 instead."));
+#endif  // SPECTRE_DEBUG
 }
 }  // namespace
 

--- a/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -39,7 +40,10 @@ struct FakeControlSystem
     : tt::ConformsTo<control_system::protocols::ControlSystem> {
   static constexpr size_t deriv_order = 2;
   static std::string name() { return "Controlled"s + get_output(Index); }
-  static std::string component_name(const size_t i) { return get_output(i); }
+  static std::optional<std::string> component_name(
+      const size_t i, const size_t /*num_components*/) {
+    return get_output(i);
+  }
   using measurement = control_system::TestHelpers::Measurement<
       control_system::TestHelpers::TestStructs_detail::LabelA>;
   using simple_tags = tmpl::list<>;

--- a/tests/Unit/ControlSystem/Tags/Test_MeasurementTimescales.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_MeasurementTimescales.cpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cstddef>
+#include <optional>
 #include <string>
 
 #include "ControlSystem/Averager.hpp"
@@ -28,7 +29,10 @@ struct FakeControlSystem
     : tt::ConformsTo<control_system::protocols::ControlSystem> {
   static constexpr size_t deriv_order = 2;
   static std::string name() { return "Controlled"s + get_output(Index); }
-  static std::string component_name(const size_t i) { return get_output(i); }
+  static std::optional<std::string> component_name(
+      const size_t i, const size_t /*num_components*/) {
+    return get_output(i);
+  }
   using measurement = control_system::TestHelpers::Measurement<
       control_system::TestHelpers::TestStructs_detail::LabelA>;
   using simple_tags = tmpl::list<>;

--- a/tests/Unit/ControlSystem/Test_InitialExpirationTimes.cpp
+++ b/tests/Unit/ControlSystem/Test_InitialExpirationTimes.cpp
@@ -3,6 +3,7 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -21,7 +22,10 @@ struct FakeControlSystem
     : tt::ConformsTo<control_system::protocols::ControlSystem> {
   static constexpr size_t deriv_order = 2;
   static std::string name() { return "Controlled"s + get_output(Index); }
-  static std::string component_name(const size_t i) { return get_output(i); }
+  static std::optional<std::string> component_name(
+      const size_t i, const size_t /*num_components*/) {
+    return get_output(i);
+  }
   using measurement = control_system::TestHelpers::Measurement<
       control_system::TestHelpers::TestStructs_detail::LabelA>;
   using simple_tags = tmpl::list<>;

--- a/tests/Unit/Helpers/ControlSystem/Examples.hpp
+++ b/tests/Unit/Helpers/ControlSystem/Examples.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstddef>
+#include <optional>
 #include <pup.h>
 
 #include "ControlSystem/Component.hpp"
@@ -19,6 +20,7 @@
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
 #include "ParallelAlgorithms/Actions/UpdateMessageQueue.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
@@ -120,7 +122,11 @@ struct ExampleControlError
 struct ExampleControlSystem
     : tt::ConformsTo<control_system::protocols::ControlSystem> {
   static std::string name() { return "ExampleControlSystem"; }
-  static std::string component_name(const size_t i) {
+  static std::optional<std::string> component_name(
+      const size_t i, const size_t num_components) {
+    ASSERT(num_components == 3,
+           "This control system expected 3 components but there are "
+               << num_components << " instead.");
     return i == 0 ? "X" : (i == 1 ? "Y" : "Z");
   }
   using measurement = ExampleMeasurement;

--- a/tests/Unit/Helpers/ControlSystem/TestStructs.hpp
+++ b/tests/Unit/Helpers/ControlSystem/TestStructs.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstddef>
+#include <optional>
 #include <pup.h>
 #include <string>
 
@@ -50,7 +51,10 @@ static_assert(tt::assert_conforms_to<Measurement<TestStructs_detail::LabelA>,
 template <size_t DerivOrder, typename Label, typename Measurement>
 struct System : tt::ConformsTo<control_system::protocols::ControlSystem> {
   static std::string name() { return pretty_type::short_name<Label>(); }
-  static std::string component_name(const size_t i) { return get_output(i); }
+  static std::optional<std::string> component_name(
+      const size_t i, const size_t /*num_components*/) {
+    return get_output(i);
+  }
   using measurement = Measurement;
   using simple_tags = tmpl::list<>;
   using control_error = ControlError;


### PR DESCRIPTION
## Proposed changes

Changes two things about the `component_name` function required by the control system protocol:

1. Have it additionally take the total number of components
2. Return std::optional<string> (not all components may
   be used)

These will be useful/needed when we start controlling the shape map to get the names of the Ylm coefficients. The function of time for shape stores SPHEREPACK coefficients. The way SPHEREPACK stores coefficients, not all entries of the vector actually mean something. Thus, when we do a generic loop over the components of a function of time (like in `src/ControlSystem/WriteData.hpp`), we need to be able to ignore some components.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
