### PR TITLE
Allow SpherepackIterator to convert offset to compact index

### DIFF
--- a/src/NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.cpp
@@ -93,11 +93,14 @@ SpherepackIterator::SpherepackIterator(const size_t l_max_input,
   offset_into_spherepack_array.assign(packed_size, 0);
   compact_l_.assign(packed_size, 0);
   compact_m_.assign(packed_size, 0);
+  offset_to_compact_index_.assign(spherepack_array_size() * stride_,
+                                  std::nullopt);
 
   // go through arrays and fill them
 
   // index corresponding to strided coefficient array
   size_t idx = 0;
+  size_t idx_no_stride = 0;
   // index for compact offset_into_spherepack_array, compact_l_, compact_m_
   size_t k = 0;
   for (size_t l = 0; l <= l_max_; ++l) {
@@ -105,11 +108,13 @@ SpherepackIterator::SpherepackIterator(const size_t l_max_input,
       // note: index m varies fastest in fortran array
       if (l >= m) {  // valid entry in a
         offset_into_spherepack_array[k] = idx;
+        offset_to_compact_index_[idx_no_stride] = k;
         compact_l_[k] = l;
         compact_m_[k] = m;
         ++k;
       }
       idx += stride;
+      ++idx_no_stride;
     }
   }
   for (size_t l = 0; l <= l_max_; ++l) {
@@ -117,11 +122,13 @@ SpherepackIterator::SpherepackIterator(const size_t l_max_input,
       // note: index m varies fastest in fortran array
       if (m >= 1 && l >= m) {  // valid entry in b
         offset_into_spherepack_array[k] = idx;
+        offset_to_compact_index_[idx_no_stride] = k;
         compact_l_[k] = l;
         compact_m_[k] = m;
         ++k;
       }
       idx += stride;
+      ++idx_no_stride;
     }
   }
 }

--- a/src/NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp
@@ -9,6 +9,7 @@
 
 #include <cmath>
 #include <cstddef>
+#include <optional>
 #include <ostream>
 #include <vector>
 
@@ -84,6 +85,21 @@ class SpherepackIterator {
     return offset_into_spherepack_array[current_compact_index_];
   }
 
+  /// Given an offset into a SPHEREPACK coefficient array, return the compact
+  /// index corresponding to that offset.
+  ///
+  /// Essentially the inverse of operator(). If the offset points to an element
+  /// that SPHEREPACK doesn't actually use (i.e. no compact index can reach the
+  /// given offset), then a std::nullopt is returned.
+  std::optional<size_t> compact_index(const size_t offset) const {
+    return offset_to_compact_index_[offset];
+  }
+
+  /// Returns the current compact index that SpherepackIterator uses internally.
+  /// This does not index a SPHEREPACK coefficient array. \see operator() for an
+  /// index into a SPHEREPACK coefficient array
+  size_t current_compact_index() const { return current_compact_index_; }
+
   /// Current values of l and m.
   size_t l() const { return compact_l_[current_compact_index_]; }
   size_t m() const { return compact_m_[current_compact_index_]; }
@@ -119,6 +135,7 @@ class SpherepackIterator {
   size_t current_compact_index_;
   std::vector<size_t> offset_into_spherepack_array;
   std::vector<size_t> compact_l_, compact_m_;
+  std::vector<std::optional<size_t>> offset_to_compact_index_;
 };
 
 inline bool operator==(const SpherepackIterator& lhs,

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_SpherepackIterator.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_SpherepackIterator.cpp
@@ -59,6 +59,17 @@ SPECTRE_TEST_CASE("Unit.SphericalHarmonics.SpherepackIterator",
     }
   }
 
+  // Check compact index
+  iter.reset();
+  for (size_t k = 0; k < array.size(); k++) {
+    const auto compact_index = iter.compact_index(k);
+    const size_t current_compact_index = iter.current_compact_index();
+    if (compact_index) {
+      CHECK(*compact_index == current_compact_index);
+      ++iter;
+    }
+  }
+
   // Test set functions
   CHECK(iter.set(2, 1, SpherepackIterator::CoefficientArray::b)() == 110);
   // Test the set function for the case l>m_max+1


### PR DESCRIPTION
## Proposed changes

In conjunction with #4006, this will allow us to output the component names of the Shape map properly given just the index of a SPHEREPACK array (which is what the shape map function of time holds).

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
