### PR TITLE
Add MonitorMemory event

### DIFF
--- a/src/ControlSystem/Component.hpp
+++ b/src/ControlSystem/Component.hpp
@@ -33,6 +33,8 @@ struct ControlComponent {
                 ControlSystem, control_system::protocols::ControlSystem>);
   using chare_type = Parallel::Algorithms::Singleton;
 
+  static std::string name() { return ControlSystem::name(); }
+
   using metavariables = Metavariables;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -66,13 +66,16 @@
 #include "Parallel/Algorithms/AlgorithmSingleton.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Local.hpp"
+#include "Parallel/MemoryMonitor/MemoryMonitor.hpp"
 #include "Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp"
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/Reduction.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "ParallelAlgorithms/Actions/MemoryMonitor/ContributeMemoryData.hpp"
 #include "ParallelAlgorithms/Events/Factory.hpp"
+#include "ParallelAlgorithms/Events/MonitorMemory.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Completion.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
@@ -295,7 +298,7 @@ struct EvolutionMetavars {
             tmpl::flatten<tmpl::list<
                 intrp::Events::Interpolate<3, AhA, interpolator_source_vars>,
                 intrp::Events::Interpolate<3, AhB, interpolator_source_vars>,
-                Events::Completion,
+                Events::MonitorMemory<3, ::Tags::Time>, Events::Completion,
                 dg::Events::field_observations<volume_dim, Tags::Time,
                                                observe_fields,
                                                non_tensor_compute_tags>,
@@ -469,6 +472,7 @@ struct EvolutionMetavars {
       observers::Observer<EvolutionMetavars>,
       observers::ObserverWriter<EvolutionMetavars>,
       importers::ElementDataReader<EvolutionMetavars>,
+      mem_monitor::MemoryMonitor<EvolutionMetavars>,
       intrp::Interpolator<EvolutionMetavars>,
       intrp::InterpolationTarget<EvolutionMetavars, AhA>,
       intrp::InterpolationTarget<EvolutionMetavars, AhB>, gh_dg_element_array>>;

--- a/src/Options/Auto.hpp
+++ b/src/Options/Auto.hpp
@@ -19,6 +19,8 @@ namespace AutoLabel {
 struct Auto {};
 /// 'None' label
 struct None {};
+/// 'All' label
+struct All {};
 }  // namespace AutoLabel
 
 /// \ingroup OptionParsingGroup

--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -593,7 +593,7 @@ void AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>::
 #ifdef SPECTRE_CHARM_PROJECTIONS
   p | non_action_time_start_;
 #endif
-  if (performing_action_) {
+  if (performing_action_ and not p.isSizing()) {
     ERROR("cannot serialize while performing action!");
   }
   p | performing_action_;

--- a/src/ParallelAlgorithms/Events/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Events/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Factory.hpp
+  MonitorMemory.hpp
   ObserveFields.hpp
   ObserveNorms.hpp
   ObserveTimeStep.hpp
@@ -28,6 +29,7 @@ target_link_libraries(
   Interpolation
   LinearOperators
   Options
+  Parallel
   Spectral
   Time
   Utilities

--- a/src/ParallelAlgorithms/Events/MonitorMemory.hpp
+++ b/src/ParallelAlgorithms/Events/MonitorMemory.hpp
@@ -1,0 +1,354 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <limits>
+#include <optional>
+#include <pup.h>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/TagName.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "IO/Observer/Helpers.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/ReductionActions.hpp"
+#include "IO/Observer/Tags.hpp"
+#include "IO/Observer/TypeOfObservation.hpp"
+#include "Options/Auto.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Info.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Local.hpp"
+#include "Parallel/MemoryMonitor/MemoryMonitor.hpp"
+#include "Parallel/MemoryMonitor/Tags.hpp"
+#include "Parallel/Reduction.hpp"
+#include "Parallel/Serialize.hpp"
+#include "Parallel/TypeTraits.hpp"
+#include "ParallelAlgorithms/Actions/MemoryMonitor/ProcessArray.hpp"
+#include "ParallelAlgorithms/Actions/MemoryMonitor/ProcessGroups.hpp"
+#include "ParallelAlgorithms/Actions/MemoryMonitor/ProcessSingleton.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Parallel::Algorithms {
+struct Array;
+struct Group;
+struct Nodegroup;
+struct Singleton;
+}  // namespace Parallel::Algorithms
+/// \endcond
+
+namespace Events {
+/*!
+ * \brief Event run on the DgElementArray that will monitor the memory usage of
+ * parallel components in megabytes.
+ *
+ * \details Given a list of parallel component names from Options, this will
+ * calculate the memory usage of each component and write it to disk in the
+ * reductions file under the `/MemoryMonitors/` group. The name of each file is
+ * the `pretty_type::name` of each parallel component.
+ *
+ * The parallel components available to monitor are the ones defined in the
+ * `component_list` type alias in the metavariables. In addition to these
+ * components, you can also monitor the size of the GlobalCache. Currently, you
+ * cannot monitor the size of the MutableGlobalCache. To see which parallel
+ * components are available to monitor, request to monitor an invalid parallel
+ * component ("Blah" for example) in the input file. An ERROR will occur and a
+ * list of the available components to monitor will be printed.
+ *
+ * \note Currently, the only Parallel::Algorithms::Array parallel component that
+ * can be monitored is the DgElementArray itself.
+ */
+
+template <size_t Dim, typename ObservationValueTag>
+class MonitorMemory : public Event {
+ private:
+  // Reduction data for arrays
+  using ReductionData = Parallel::ReductionData<
+      // Time
+      Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
+      // Vector of total mem usage on each node
+      Parallel::ReductionDatum<std::vector<double>,
+                               funcl::ElementWise<funcl::Plus<>>>>;
+
+ public:
+  explicit MonitorMemory(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(MonitorMemory);  // NOLINT
+
+  struct ComponentsToMonitor {
+    using type =
+        Options::Auto<std::vector<std::string>, Options::AutoLabel::All>;
+    static constexpr Options::String help = {
+        "Names of parallel components to monitor the memory usage of. If you'd "
+        "like to monitor all available parallel components, pass 'All' "
+        "instead."};
+  };
+
+  using options = tmpl::list<ComponentsToMonitor>;
+
+  static constexpr Options::String help =
+      "Observe memory usage of parallel components.";
+
+  MonitorMemory() = default;
+
+  template <typename Metavariables>
+  MonitorMemory(
+      const std::optional<std::vector<std::string>>& components_to_monitor,
+      const Options::Context& context, Metavariables /*meta*/);
+
+  using observed_reduction_data_tags =
+      observers::make_reduction_data_tags<tmpl::list<ReductionData>>;
+
+  using compute_tags_for_observation_box = tmpl::list<>;
+
+  using argument_tags =
+      tmpl::list<ObservationValueTag, domain::Tags::Element<Dim>>;
+
+  template <typename Metavariables, typename ArrayIndex,
+            typename ParallelComponent>
+  void operator()(const typename ObservationValueTag::type& observation_value,
+                  const ::Element<Dim>& element,
+                  Parallel::GlobalCache<Metavariables>& cache,
+                  const ArrayIndex& array_index,
+                  const ParallelComponent* const /*meta*/) const;
+
+  using observation_registration_tags = tmpl::list<>;
+
+  std::optional<
+      std::pair<observers::TypeOfObservation, observers::ObservationKey>>
+  get_observation_type_and_key_for_registration() const {
+    return {};
+  }
+
+  using is_ready_argument_tags = tmpl::list<>;
+
+  template <typename Metavariables, typename ArrayIndex, typename Component>
+  bool is_ready(Parallel::GlobalCache<Metavariables>& /*cache*/,
+                const ArrayIndex& /*array_index*/,
+                const Component* const /*meta*/) const {
+    return true;
+  }
+
+  bool needs_evolved_variables() const override { return false; }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override;
+
+ private:
+  std::unordered_set<std::string> components_to_monitor_{};
+};
+
+/// \cond
+template <size_t Dim, typename ObservationValueTag>
+MonitorMemory<Dim, ObservationValueTag>::MonitorMemory(CkMigrateMessage* msg)
+    : Event(msg) {}
+
+template <size_t Dim, typename ObservationValueTag>
+template <typename Metavariables>
+MonitorMemory<Dim, ObservationValueTag>::MonitorMemory(
+    const std::optional<std::vector<std::string>>& components_to_monitor,
+    const Options::Context& context, Metavariables /*meta*/) {
+  using component_list = tmpl::push_back<typename Metavariables::component_list,
+                                         Parallel::GlobalCache<Metavariables>>;
+  std::unordered_map<std::string, std::string> existing_components{};
+  std::string str_component_list{};
+
+  tmpl::for_each<component_list>(
+      [&existing_components, &str_component_list](auto component_v) {
+        using component = tmpl::type_from<decltype(component_v)>;
+        const std::string component_name = pretty_type::name<component>();
+        const std::string chare_type_name =
+            pretty_type::name<typename component::chare_type>();
+        existing_components[component_name] = chare_type_name;
+        // Only Array we can monitor is DgElementArray
+        if (chare_type_name != "Array") {
+          str_component_list += " - " + component_name + "\n";
+        } else if (component_name == "DgElementArray") {
+          str_component_list += " - " + component_name + "\n";
+        }
+      });
+
+  // A list of names was specified
+  if (components_to_monitor.has_value()) {
+    for (const auto& component : *components_to_monitor) {
+      // Do some checks:
+      //  1. Make sure the components requested are viable components. This
+      //     protects against spelling errors.
+      //  2. Currently the only charm Array you can monitor the memory of is
+      //     the DgElementArray so enforce this.
+      if (existing_components.count(component) != 1) {
+        PARSE_ERROR(
+            context,
+            "Cannot monitor memory usage of unknown parallel component '"
+                << component
+                << "'. Please choose from the existing parallel components:\n"
+                << str_component_list);
+      } else if (existing_components.at(component) == "Array" and
+                 component != "DgElementArray") {
+        PARSE_ERROR(
+            context,
+            "Cannot monitor the '"
+                << component
+                << "' parallel component. Currently, the only Array parallel "
+                   "component allowed to be monitored is the "
+                   "DgElementArray.");
+      }
+
+      components_to_monitor_.insert(component);
+    }
+  } else {
+    // 'All' was specified. Filter out Array components that are not the
+    // DgElementArray
+    for (const auto& [name, chare] : existing_components) {
+      if (chare != "Array") {
+        components_to_monitor_.insert(name);
+      } else if (name == "DgElementArray") {
+        components_to_monitor_.insert(name);
+      }
+    }
+  }
+}
+
+template <size_t Dim, typename ObservationValueTag>
+template <typename Metavariables, typename ArrayIndex,
+          typename ParallelComponent>
+void MonitorMemory<Dim, ObservationValueTag>::operator()(
+    const typename ObservationValueTag::type& observation_value,
+    const ::Element<Dim>& element, Parallel::GlobalCache<Metavariables>& cache,
+    const ArrayIndex& array_index,
+    const ParallelComponent* const /*meta*/) const {
+  using component_list = tmpl::push_back<typename Metavariables::component_list,
+                                         Parallel::GlobalCache<Metavariables>>;
+
+  tmpl::for_each<component_list>([this, &observation_value, &element, &cache,
+                                  &array_index](auto component_v) {
+    using component = tmpl::type_from<decltype(component_v)>;
+
+    // If we aren't monitoring this parallel component, then just exit now
+    if (components_to_monitor_.count(pretty_type::name<component>()) != 1) {
+      return;
+    }
+
+    // Certain components only need to be triggered once, so we have a special
+    // element designated to be the one that triggers memory monitoring, the
+    // 0th element.
+    const auto& element_id = element.id();
+    // Avoid GCC-7 compiler warning about unused variable (in the Array if
+    // constexpr branch)
+    [[maybe_unused]] const bool designated_element =
+        is_zeroth_element(element_id);
+
+    // If this is an array, this is run on every element. It has already
+    // been asserted in the constructor that the only Array the MemoryMonitor
+    // can monitor is the DgElementArray itself. If you want to monitor other
+    // Arrays, the implementation will need to be generalized.
+    if constexpr (Parallel::is_array_v<component>) {
+      auto& memory_monitor_proxy = Parallel::get_parallel_component<
+          mem_monitor::MemoryMonitor<Metavariables>>(cache);
+      auto array_element_proxy =
+          Parallel::get_parallel_component<component>(cache)[array_index];
+      const double size_in_bytes = static_cast<double>(
+          size_of_object_in_bytes(*Parallel::local(array_element_proxy)));
+      const double size_in_megabytes = size_in_bytes / 1.0e6;
+
+      // vector the size of the number of nodes we are running on. Set the
+      // 'my_node'th element of the vector to the size of this Element. Then
+      // when we reduce, we will have a vector with 'num_nodes' elements, each
+      // of which represents the total memory usage of all Elements on that
+      // node.
+      const size_t num_nodes = Parallel::number_of_nodes<size_t>(
+          *Parallel::local(array_element_proxy));
+      const size_t my_node =
+          Parallel::my_node<size_t>(*Parallel::local(array_element_proxy));
+      std::vector<double> data(num_nodes, 0.0);
+      data[my_node] = size_in_megabytes;
+
+      Parallel::contribute_to_reduction<
+          mem_monitor::ProcessArray<ParallelComponent>>(
+          ReductionData{static_cast<double>(observation_value), data},
+          array_element_proxy, memory_monitor_proxy);
+    } else if constexpr (Parallel::is_singleton_v<component>) {
+      // If this is a singleton, we only run this once so use the designated
+      // element. Nothing to reduce with singletons so just call the simple
+      // action on the singleton
+      if (designated_element) {
+        auto& singleton_proxy =
+            Parallel::get_parallel_component<component>(cache);
+
+        Parallel::simple_action<mem_monitor::ProcessSingleton>(
+            singleton_proxy, static_cast<double>(observation_value));
+      }
+    } else if constexpr (Parallel::is_nodegroup_v<component> or
+                         Parallel::is_group_v<component>) {
+      // If this is a (node)group, call a simple action on each branch if on
+      // the designated element
+      if (designated_element) {
+        // Can't run simple actions on the cache so broadcast a specific entry
+        // method that will calculate the size and send it to the memory
+        // monitor
+        if constexpr (std::is_same_v<component,
+                                     Parallel::GlobalCache<Metavariables>>) {
+          auto cache_proxy = cache.get_this_proxy();
+
+          // This will be called on all branches of the GlobalCache
+          cache_proxy.compute_size_for_memory_monitor(
+              static_cast<double>(observation_value));
+        } else if constexpr (std::is_same_v<
+                                 component,
+                                 Parallel::MutableGlobalCache<Metavariables>>) {
+          // Currently, this branch is unreachable because the
+          // MutableGlobalCache is not in `component_list` above. We keep the
+          // branch in anyways for consistency and because we anticipate to be
+          // able to monitor the MutableGlobalCache in the future.
+
+          // Can't run simple actions on the mutable cache so broadcast a
+          // specific entry method that will calculate the size and send it to
+          // the memory monitor
+          auto mutable_global_cache_proxy = cache.mutable_global_cache_proxy();
+
+          // This will be called on all branches of the MutableGlobalCache
+          mutable_global_cache_proxy.compute_size_for_memory_monitor(
+              cache.get_this_proxy(), static_cast<double>(observation_value));
+        } else {
+          // Groups and nodegroups share an action
+          auto& group_proxy =
+              Parallel::get_parallel_component<component>(cache);
+
+          // This will be called on all branches of the (node)group
+          Parallel::simple_action<mem_monitor::ProcessGroups>(
+              group_proxy, static_cast<double>(observation_value));
+        }
+      }
+    }
+  });
+}
+
+template <size_t Dim, typename ObservationValueTag>
+void MonitorMemory<Dim, ObservationValueTag>::pup(PUP::er& p) {
+  Event::pup(p);
+  p | components_to_monitor_;
+}
+
+template <size_t Dim, typename ObservationValueTag>
+PUP::able::PUP_ID MonitorMemory<Dim, ObservationValueTag>::my_PUP_ID =
+    0;  // NOLINT
+/// \endcond
+
+}  // namespace Events

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -190,6 +190,12 @@ EventsAndTriggers:
         Offset: 0
   : - AhA
     - AhB
+  ? Slabs:
+      EvenlySpaced:
+        Interval: 100
+        Offset: 0
+  : - MonitorMemory:
+        ComponentsToMonitor: All
   ? TimeCompares:
       Comparison: GreaterThan
       Value: 0.02

--- a/tests/Unit/Helpers/IO/Observers/MockWriteReductionDataRow.hpp
+++ b/tests/Unit/Helpers/IO/Observers/MockWriteReductionDataRow.hpp
@@ -19,7 +19,7 @@ namespace TestHelpers::observers {
 /*!
  * Tag that holds a MockH5File object for the MockObserverWriter
  */
-struct MockReductionFileTag : db::SimpleTag {
+struct MockReductionFileTag : ::db::SimpleTag {
   using type = MockH5File;
 };
 
@@ -39,16 +39,16 @@ struct MockReductionFileTag : db::SimpleTag {
 struct MockWriteReductionDataRow {
   template <typename ParallelComponent, typename DbTagsList,
             typename Metavariables, typename ArrayIndex, typename... Ts>
-  static void apply(db::DataBox<DbTagsList>& box,
+  static void apply(::db::DataBox<DbTagsList>& box,
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/,
                     const gsl::not_null<Parallel::NodeLock*> /*node_lock*/,
                     const std::string& subfile_name,
                     std::vector<std::string>&& legend,
                     std::tuple<Ts...>&& in_reduction_data) {
-    if constexpr (db::tag_is_retrievable_v<MockReductionFileTag,
-                                           db::DataBox<DbTagsList>>) {
-      db::mutate<MockReductionFileTag>(
+    if constexpr (::db::tag_is_retrievable_v<MockReductionFileTag,
+                                             ::db::DataBox<DbTagsList>>) {
+      ::db::mutate<MockReductionFileTag>(
           make_not_null(&box),
           [subfile_name, legend,
            in_reduction_data](const gsl::not_null<MockH5File*> mock_h5_file) {

--- a/tests/Unit/Options/Test_Auto.cpp
+++ b/tests/Unit/Options/Test_Auto.cpp
@@ -131,17 +131,25 @@ class ExampleClass {
     using type = Options::Auto<double, Options::AutoLabel::None>;
     static constexpr Options::String help = "Optional parameter";
   };
+  struct AllArg {
+    using type = Options::Auto<std::vector<int>, Options::AutoLabel::All>;
+    static constexpr Options::String help = "Optional parameter all";
+  };
 
   static constexpr Options::String help =
       "A class that can automatically choose an argument";
-  using options = tmpl::list<AutoArg, OptionalArg>;
+  using options = tmpl::list<AutoArg, OptionalArg, AllArg>;
 
   explicit ExampleClass(std::optional<int> auto_arg,
-                        std::optional<double> opt_arg)
-      : value(auto_arg ? *auto_arg : -12), optional_value(opt_arg) {}
+                        std::optional<double> opt_arg,
+                        std::optional<std::vector<int>> all_arg)
+      : value(auto_arg ? *auto_arg : -12),
+        optional_value(opt_arg),
+        all_value(all_arg) {}
 
   int value{};
   std::optional<double> optional_value{};
+  std::optional<std::vector<int>> all_value{};
 };
 // [example_class]
 #if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 8 && __GNUC__ < 11
@@ -168,14 +176,25 @@ void test_use_as_option() {
   // [example_create]
   const auto example1 = TestHelpers::test_creation<ExampleClass>(
       "AutoArg: 7\n"
-      "OptionalArg: 10.");
+      "OptionalArg: 10.\n"
+      "AllArg: [0, 1, 2]");
   CHECK(example1.value == 7);
   CHECK(example1.optional_value == 10.);
+  CHECK(example1.all_value == std::vector<int>{{0, 1, 2}});
   const auto example2 = TestHelpers::test_creation<ExampleClass>(
       "AutoArg: Auto\n"
-      "OptionalArg: None");
+      "OptionalArg: None\n"
+      "AllArg: [0, 1, 2]");
   CHECK(example2.value == -12);
   CHECK(example2.optional_value == std::nullopt);
+  CHECK(example2.all_value == std::vector<int>{{0, 1, 2}});
+  const auto example3 = TestHelpers::test_creation<ExampleClass>(
+      "AutoArg: 7\n"
+      "OptionalArg: 10.\n"
+      "AllArg: All");
+  CHECK(example3.value == 7);
+  CHECK(example3.optional_value == 10.);
+  CHECK(example3.all_value == std::nullopt);
   // [example_create]
 
   // Make sure this compiles.

--- a/tests/Unit/Parallel/Test_MemoryMonitor.cpp
+++ b/tests/Unit/Parallel/Test_MemoryMonitor.cpp
@@ -8,6 +8,8 @@
 #include <unordered_map>
 
 #include "DataStructures/Matrix.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
@@ -18,16 +20,22 @@
 #include "Parallel/MemoryMonitor/MemoryMonitor.hpp"
 #include "Parallel/MemoryMonitor/Tags.hpp"
 #include "Parallel/Serialize.hpp"
+#include "Parallel/TypeTraits.hpp"
 #include "ParallelAlgorithms/Actions/MemoryMonitor/ContributeMemoryData.hpp"
 #include "ParallelAlgorithms/Actions/MemoryMonitor/ProcessArray.hpp"
 #include "ParallelAlgorithms/Actions/MemoryMonitor/ProcessGroups.hpp"
 #include "ParallelAlgorithms/Actions/MemoryMonitor/ProcessSingleton.hpp"
+#include "ParallelAlgorithms/Events/MonitorMemory.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Numeric.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
 
 namespace {
+struct TimeTag {
+  using type = double;
+};
+
 template <typename Metavariables>
 struct MockMemoryMonitor {
   using chare_type = ActionTesting::MockSingletonChare;
@@ -84,12 +92,34 @@ struct ArrayParallelComponent {
                                         tmpl::list<>>>;
 };
 
+// This component deserves special mention. It is supposed to be playing the
+// role of the DgElementArray, the component where we run the MonitorMemory
+// event. However, inside MonitorMemory, there is an `if constexpr` check if the
+// component we are monitoring is an array. If we are monitoring an array, then
+// Parallel::contribute_to_reduction is called. If we make this component a
+// MockArray, the test fails to build because the ATF doesn't support
+// reductions yet. To get around this, we make this component a MockSingleton
+// because the event only needs to be run on one "element". We also remove it
+// from the components to monitor. Once the ATF supports reductions, this can be
+// changed to a MockArray.
+template <typename Metavariables>
+struct FakeDgElementArray {
+  using chare_type = ActionTesting::MockSingletonChare;
+  using array_index = int;
+  using metavariables = Metavariables;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<
+          tmpl::list<domain::Tags::Element<3>>>>>>;
+};
+
 struct TestMetavariables {
   using component_list =
       tmpl::list<MockMemoryMonitor<TestMetavariables>,
                  SingletonParallelComponent<TestMetavariables>,
+                 TestHelpers::observers::MockObserverWriter<TestMetavariables>,
                  GroupParallelComponent<TestMetavariables>,
-                 ArrayParallelComponent<TestMetavariables>,
+                 FakeDgElementArray<TestMetavariables>,
                  NodegroupParallelComponent<TestMetavariables>>;
 
   enum class Phase { Initialization, Monitor, Exit };
@@ -125,32 +155,57 @@ struct TestMetavarsActions {
 };
 
 using metavars = TestMetavarsActions;
-using mem_mon_comp = MockMemoryMonitor<metavars>;
-using obs_writer_comp = TestHelpers::observers::MockObserverWriter<metavars>;
-using sing_comp = SingletonParallelComponent<metavars>;
-using group_comp = GroupParallelComponent<metavars>;
-using array_comp = ArrayParallelComponent<metavars>;
-using nodegroup_comp = NodegroupParallelComponent<metavars>;
+template <typename Metavars>
+using mem_mon_comp = MockMemoryMonitor<Metavars>;
+template <typename Metavars>
+using obs_writer_comp = TestHelpers::observers::MockObserverWriter<Metavars>;
+template <typename Metavars>
+using sing_comp = SingletonParallelComponent<Metavars>;
+template <typename Metavars>
+using group_comp = GroupParallelComponent<Metavars>;
+template <typename Metavars>
+using array_comp = ArrayParallelComponent<Metavars>;
+template <typename Metavars>
+using nodegroup_comp = NodegroupParallelComponent<Metavars>;
+template <typename Metavars>
+using dg_elem_comp = FakeDgElementArray<Metavars>;
 
+template <typename Metavariables>
 void setup_runner(
-    const gsl::not_null<ActionTesting::MockRuntimeSystem<metavars>*> runner) {
+    const gsl::not_null<ActionTesting::MockRuntimeSystem<Metavariables>*>
+        runner) {
   // Setup all components even if we aren't using all of them
-  ActionTesting::emplace_singleton_component<sing_comp>(
+  ActionTesting::emplace_singleton_component<sing_comp<Metavariables>>(
       runner, ActionTesting::NodeId{1}, ActionTesting::LocalCoreId{1});
-  ActionTesting::emplace_group_component<group_comp>(runner);
-  ActionTesting::emplace_nodegroup_component<nodegroup_comp>(runner);
-  ActionTesting::emplace_array_component<array_comp>(
-      runner, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{0}, 0);
+  ActionTesting::emplace_group_component<group_comp<Metavariables>>(runner);
+  ActionTesting::emplace_nodegroup_component<nodegroup_comp<Metavariables>>(
+      runner);
+  if constexpr (tmpl::list_contains_v<typename Metavariables::component_list,
+                                      array_comp<Metavariables>>) {
+    ActionTesting::emplace_array_component<array_comp<Metavariables>>(
+        runner, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{0}, 0);
+  }
 
   // ObserverWriter
-  ActionTesting::emplace_nodegroup_component_and_initialize<obs_writer_comp>(
-      runner, {});
+  ActionTesting::emplace_nodegroup_component_and_initialize<
+      obs_writer_comp<Metavariables>>(runner, {});
 
   // MemoryMonitor
-  ActionTesting::emplace_singleton_component_and_initialize<mem_mon_comp>(
-      runner, ActionTesting::NodeId{2}, ActionTesting::LocalCoreId{2}, {});
+  ActionTesting::emplace_singleton_component_and_initialize<
+      mem_mon_comp<Metavariables>>(runner, ActionTesting::NodeId{2},
+                                   ActionTesting::LocalCoreId{2}, {});
 
-  runner->set_phase(metavars::Phase::Monitor);
+  if constexpr (tmpl::list_contains_v<typename Metavariables::component_list,
+                                      dg_elem_comp<Metavariables>>) {
+    // FakeDgElementArray that's actually a singleton
+    const ElementId<3> element_id{0};
+    const Element<3> element{element_id, {}};
+    ActionTesting::emplace_singleton_component_and_initialize<
+        dg_elem_comp<Metavariables>>(runner, ActionTesting::NodeId{0},
+                                     ActionTesting::LocalCoreId{0}, {element});
+  }
+
+  runner->set_phase(Metavariables::Phase::Monitor);
 }
 
 template <typename Component, typename Metavariables>
@@ -158,7 +213,8 @@ void check_output(const ActionTesting::MockRuntimeSystem<Metavariables>& runner,
                   const double time, const size_t num_nodes,
                   const std::vector<double>& sizes) {
   auto& read_file = ActionTesting::get_databox_tag<
-      obs_writer_comp, TestHelpers::observers::MockReductionFileTag>(runner, 0);
+      obs_writer_comp<Metavariables>,
+      TestHelpers::observers::MockReductionFileTag>(runner, 0);
   INFO("Checking output of " + pretty_type::name<Component>());
   const auto& dataset =
       read_file.get_dat(mem_monitor::subfile_name<Component>());
@@ -192,15 +248,17 @@ void check_output(const ActionTesting::MockRuntimeSystem<Metavariables>& runner,
   // measurement
   if constexpr (not Parallel::is_singleton_v<Component>) {
     for (size_t i = 0; i < num_nodes; i++) {
+      INFO("i = " + get_output(i));
       CHECK(data(0, i + 1) == sizes[i]);
     }
   }
   CHECK(data(0, num_columns - 1) == average);
 }
 
-template <typename Component>
+template <typename Component, typename Metavariables>
 void run_group_actions(
-    const gsl::not_null<ActionTesting::MockRuntimeSystem<metavars>*> runner,
+    const gsl::not_null<ActionTesting::MockRuntimeSystem<Metavariables>*>
+        runner,
     const int num_nodes, const int num_procs, const double time,
     const std::vector<double>& sizes) {
   INFO("Checking actions of " + pretty_type::name<Component>());
@@ -213,11 +271,11 @@ void run_group_actions(
     (void)num_procs;
   }
 
-  CHECK(ActionTesting::number_of_queued_simple_actions<mem_mon_comp>(
-            *runner, 0) == num_branches);
+  CHECK(ActionTesting::number_of_queued_simple_actions<
+            mem_mon_comp<Metavariables>>(*runner, 0) == num_branches);
 
   const auto& mem_holder_tag =
-      ActionTesting::get_databox_tag<mem_mon_comp,
+      ActionTesting::get_databox_tag<mem_mon_comp<Metavariables>,
                                      mem_monitor::Tags::MemoryHolder>(*runner,
                                                                       0);
 
@@ -236,7 +294,8 @@ void run_group_actions(
     if (i != 0) {
       CHECK(mem_holder_tag.at(name).at(time).size() == i);
     }
-    ActionTesting::invoke_queued_simple_action<mem_mon_comp>(runner, 0);
+    ActionTesting::invoke_queued_simple_action<mem_mon_comp<Metavariables>>(
+        runner, 0);
   }
 
   // After we invoke the actions, the map for the current component should be
@@ -244,9 +303,10 @@ void run_group_actions(
   CHECK(mem_holder_tag.at(name).empty());
 
   // The last action should have called a threaded action to write data
-  CHECK(ActionTesting::number_of_queued_threaded_actions<obs_writer_comp>(
-            *runner, 0) == 1);
-  ActionTesting::invoke_queued_threaded_action<obs_writer_comp>(runner, 0);
+  CHECK(ActionTesting::number_of_queued_threaded_actions<
+            obs_writer_comp<Metavariables>>(*runner, 0) == 1);
+  ActionTesting::invoke_queued_threaded_action<obs_writer_comp<Metavariables>>(
+      runner, 0);
 
   check_output<Component>(*runner, time, static_cast<size_t>(num_nodes), sizes);
 }
@@ -257,8 +317,8 @@ void test_wrong_box() {
         db::DataBox<tmpl::list<>> empty_box{};
         Parallel::GlobalCache<metavars> cache{};
 
-        mem_monitor::ContributeMemoryData<group_comp>::template apply<
-            mem_mon_comp>(empty_box, cache, 0, 0.0, 0_st, 0.0);
+        mem_monitor::ContributeMemoryData<group_comp<metavars>>::template apply<
+            mem_mon_comp<metavars>>(empty_box, cache, 0, 0.0, 0_st, 0.0);
       }()),
       Catch::Contains("Expected the DataBox for the MemoryMonitor"));
 }
@@ -280,9 +340,9 @@ void test_contribute_memory_data(const gsl::not_null<Gen*> gen,
 
   setup_runner(make_not_null(&runner));
 
-  auto& cache = ActionTesting::cache<mem_mon_comp>(runner, 0);
+  auto& cache = ActionTesting::cache<mem_mon_comp<metavars>>(runner, 0);
   auto& mem_monitor_proxy =
-      Parallel::get_parallel_component<mem_mon_comp>(cache);
+      Parallel::get_parallel_component<mem_mon_comp<metavars>>(cache);
 
   const double time = 0.5;
   std::vector<double> sizes(num_nodes);
@@ -292,18 +352,20 @@ void test_contribute_memory_data(const gsl::not_null<Gen*> gen,
   // can compare, otherwise call the ContributeMemoryData action directly with a
   // random size
   if (use_process_component_actions) {
-    auto& group_proxy = Parallel::get_parallel_component<group_comp>(cache);
+    auto& group_proxy =
+        Parallel::get_parallel_component<group_comp<metavars>>(cache);
     Parallel::simple_action<mem_monitor::ProcessGroups>(group_proxy, time);
 
     for (size_t proc = 0; proc < num_procs; proc++) {
-      CHECK(ActionTesting::number_of_queued_simple_actions<group_comp>(
-                runner, proc) == 1);
+      CHECK(
+          ActionTesting::number_of_queued_simple_actions<group_comp<metavars>>(
+              runner, proc) == 1);
       if (proc != 0 and proc % num_procs_per_node == 0) {
         ++index;
       }
       sizes[index] +=
           size_of_object_in_bytes(*Parallel::local_branch(group_proxy)) / 1.0e6;
-      ActionTesting::invoke_queued_simple_action<group_comp>(
+      ActionTesting::invoke_queued_simple_action<group_comp<metavars>>(
           make_not_null(&runner), proc);
     }
   } else {
@@ -313,14 +375,15 @@ void test_contribute_memory_data(const gsl::not_null<Gen*> gen,
         ++index;
       }
       sizes[index] += size;
-      Parallel::simple_action<mem_monitor::ContributeMemoryData<group_comp>>(
+      Parallel::simple_action<
+          mem_monitor::ContributeMemoryData<group_comp<metavars>>>(
           mem_monitor_proxy, time, static_cast<int>(proc), size);
     }
   }
 
-  run_group_actions<group_comp>(make_not_null(&runner),
-                                static_cast<int>(num_nodes),
-                                static_cast<int>(num_procs), time, sizes);
+  run_group_actions<group_comp<metavars>>(
+      make_not_null(&runner), static_cast<int>(num_nodes),
+      static_cast<int>(num_procs), time, sizes);
 
   sizes.clear();
   sizes.resize(num_nodes);
@@ -328,16 +391,16 @@ void test_contribute_memory_data(const gsl::not_null<Gen*> gen,
   // Now for the nodegroup
   if (use_process_component_actions) {
     auto& nodegroup_proxy =
-        Parallel::get_parallel_component<nodegroup_comp>(cache);
+        Parallel::get_parallel_component<nodegroup_comp<metavars>>(cache);
     Parallel::simple_action<mem_monitor::ProcessGroups>(nodegroup_proxy, time);
 
     for (size_t node = 0; node < num_nodes; node++) {
-      CHECK(ActionTesting::number_of_queued_simple_actions<nodegroup_comp>(
-                runner, node) == 1);
+      CHECK(ActionTesting::number_of_queued_simple_actions<
+                nodegroup_comp<metavars>>(runner, node) == 1);
       sizes[node] =
           size_of_object_in_bytes(*Parallel::local_branch(nodegroup_proxy)) /
           1.0e6;
-      ActionTesting::invoke_queued_simple_action<nodegroup_comp>(
+      ActionTesting::invoke_queued_simple_action<nodegroup_comp<metavars>>(
           make_not_null(&runner), node);
     }
   } else {
@@ -345,14 +408,14 @@ void test_contribute_memory_data(const gsl::not_null<Gen*> gen,
       const double size = dist(*gen);
       sizes[node] = size;
       Parallel::simple_action<
-          mem_monitor::ContributeMemoryData<nodegroup_comp>>(
+          mem_monitor::ContributeMemoryData<nodegroup_comp<metavars>>>(
           mem_monitor_proxy, time, static_cast<int>(node), size);
     }
   }
 
-  run_group_actions<nodegroup_comp>(make_not_null(&runner),
-                                    static_cast<int>(num_nodes),
-                                    static_cast<int>(num_procs), time, sizes);
+  run_group_actions<nodegroup_comp<metavars>>(
+      make_not_null(&runner), static_cast<int>(num_nodes),
+      static_cast<int>(num_procs), time, sizes);
 }
 
 template <typename Gen>
@@ -368,28 +431,28 @@ void test_process_array(const gsl::not_null<Gen*> gen) {
 
   setup_runner(make_not_null(&runner));
 
-  auto& cache = ActionTesting::cache<mem_mon_comp>(runner, 0);
+  auto& cache = ActionTesting::cache<mem_mon_comp<metavars>>(runner, 0);
   auto& mem_monitor_proxy =
-      Parallel::get_parallel_component<mem_mon_comp>(cache);
+      Parallel::get_parallel_component<mem_mon_comp<metavars>>(cache);
 
   const double time = 0.5;
   std::vector<double> size_per_node(num_nodes);
   fill_with_random_values(make_not_null(&size_per_node), gen,
                           make_not_null(&dist));
 
-  Parallel::simple_action<mem_monitor::ProcessArray<array_comp>>(
+  Parallel::simple_action<mem_monitor::ProcessArray<array_comp<metavars>>>(
       mem_monitor_proxy, time, size_per_node);
-  CHECK(ActionTesting::number_of_queued_simple_actions<mem_mon_comp>(runner,
-                                                                     0) == 1);
-  ActionTesting::invoke_queued_simple_action<mem_mon_comp>(
-      make_not_null(&runner), 0);
-
-  CHECK(ActionTesting::number_of_queued_threaded_actions<obs_writer_comp>(
+  CHECK(ActionTesting::number_of_queued_simple_actions<mem_mon_comp<metavars>>(
             runner, 0) == 1);
-  ActionTesting::invoke_queued_threaded_action<obs_writer_comp>(
+  ActionTesting::invoke_queued_simple_action<mem_mon_comp<metavars>>(
       make_not_null(&runner), 0);
 
-  check_output<array_comp>(runner, time, num_nodes, size_per_node);
+  CHECK(ActionTesting::number_of_queued_threaded_actions<
+            obs_writer_comp<metavars>>(runner, 0) == 1);
+  ActionTesting::invoke_queued_threaded_action<obs_writer_comp<metavars>>(
+      make_not_null(&runner), 0);
+
+  check_output<array_comp<metavars>>(runner, time, num_nodes, size_per_node);
 }
 
 void test_process_singleton() {
@@ -403,15 +466,16 @@ void test_process_singleton() {
 
   setup_runner(make_not_null(&runner));
 
-  auto& cache = ActionTesting::cache<sing_comp>(runner, 0);
-  auto& singleton_proxy = Parallel::get_parallel_component<sing_comp>(cache);
+  auto& cache = ActionTesting::cache<sing_comp<metavars>>(runner, 0);
+  auto& singleton_proxy =
+      Parallel::get_parallel_component<sing_comp<metavars>>(cache);
 
   const double time = 0.5;
   std::vector<double> sizes(num_nodes, 0.0);
 
   Parallel::simple_action<mem_monitor::ProcessSingleton>(singleton_proxy, time);
-  CHECK(ActionTesting::number_of_queued_simple_actions<sing_comp>(runner, 0) ==
-        1);
+  CHECK(ActionTesting::number_of_queued_simple_actions<sing_comp<metavars>>(
+            runner, 0) == 1);
 
   // We multiply by the number of nodes here because in the checK_output()
   // function, it takes an average over number of nodes to accommodate arrays
@@ -421,15 +485,195 @@ void test_process_singleton() {
   sizes[0] = static_cast<double>(num_nodes) *
              size_of_object_in_bytes(*Parallel::local(singleton_proxy)) / 1.0e6;
 
-  ActionTesting::invoke_queued_simple_action<sing_comp>(make_not_null(&runner),
-                                                        0);
-
-  CHECK(ActionTesting::number_of_queued_threaded_actions<obs_writer_comp>(
-            runner, 0) == 1);
-  ActionTesting::invoke_queued_threaded_action<obs_writer_comp>(
+  ActionTesting::invoke_queued_simple_action<sing_comp<metavars>>(
       make_not_null(&runner), 0);
 
-  check_output<sing_comp>(runner, time, num_nodes, sizes);
+  CHECK(ActionTesting::number_of_queued_threaded_actions<
+            obs_writer_comp<metavars>>(runner, 0) == 1);
+  ActionTesting::invoke_queued_threaded_action<obs_writer_comp<metavars>>(
+      make_not_null(&runner), 0);
+
+  check_output<sing_comp<metavars>>(runner, time, num_nodes, sizes);
+}
+
+struct BadArrayChareMetavariables {
+  using component_list =
+      tmpl::list<ArrayParallelComponent<BadArrayChareMetavariables>>;
+
+  enum class Phase { Initialization, Monitor, Exit };
+};
+
+void test_event_construction() {
+  CHECK_THROWS_WITH(
+      ([]() {
+        std::vector<std::string> misspelled_component{"GlabolCahce"};
+
+        Events::MonitorMemory<1, TimeTag> event{
+            {misspelled_component}, Options::Context{}, metavars{}};
+      }()),
+      Catch::Contains(
+          "Cannot monitor memory usage of unknown parallel component"));
+
+  CHECK_THROWS_WITH(
+      ([]() {
+        std::vector<std::string> array_component{"ArrayParallelComponent"};
+
+        Events::MonitorMemory<2, TimeTag> event{{array_component},
+                                                Options::Context{},
+                                                BadArrayChareMetavariables{}};
+      }()),
+      Catch::Contains("Currently, the only Array parallel component allowed to "
+                      "be monitored is the DgElementArray."));
+}
+
+void test_monitor_memory_event() {
+  using event_metavars = TestMetavariables;
+  INFO("Checking MonitorMemory event");
+
+  // 4 mock nodes, 3 mock cores per node
+  const size_t num_nodes = 4;
+  const size_t num_procs_per_node = 3;
+  const size_t num_procs = num_nodes * num_procs_per_node;
+  ActionTesting::MockRuntimeSystem<event_metavars> runner{
+      {}, {}, std::vector<size_t>(num_nodes, num_procs_per_node)};
+
+  setup_runner(make_not_null(&runner));
+
+  auto& cache = ActionTesting::cache<mem_mon_comp<event_metavars>>(runner, 0);
+
+  std::vector<std::string> components_to_monitor{};
+  // Note that we don't monitor the global caches here. This is because the
+  // entry methods of the global caches used to compute memory and send it to
+  // the MemoryMonitor are not compatible with the ATF. Also don't monitor the
+  // DgElementArray or the array component (because we can't in the ATF)
+  using component_list =
+      tmpl::list_difference<typename event_metavars::component_list,
+                            tmpl::list<dg_elem_comp<event_metavars>>>;
+  tmpl::for_each<component_list>([&components_to_monitor](auto component_v) {
+    using component = tmpl::type_from<decltype(component_v)>;
+    components_to_monitor.emplace_back(pretty_type::name<component>());
+  });
+
+  // Create event
+  Events::MonitorMemory<3, TimeTag> monitor_memory{
+      {components_to_monitor}, Options::Context{}, metavars{}};
+
+  const auto& element =
+      ActionTesting::get_databox_tag<dg_elem_comp<event_metavars>,
+                                     domain::Tags::Element<3>>(runner, 0);
+
+  // Run the event. This will queue a lot of actions
+  const double time = 1.4;
+  monitor_memory(time, element, cache, 0,
+                 std::add_pointer_t<dg_elem_comp<event_metavars>>{});
+
+  // Check how many simple actions are queued:
+  // - MemoryMonitor: 1
+  // - ObserverWriter: 4 (one per node)
+  // - Singleton: 1
+  // - Group: 12 (one per core)
+  // - NodeGroup: 4 (one per node)
+  tmpl::for_each<component_list>([&runner](auto component_v) {
+    using component = tmpl::type_from<decltype(component_v)>;
+    if constexpr (Parallel::is_singleton_v<component>) {
+      CHECK(ActionTesting::number_of_queued_simple_actions<component>(runner,
+                                                                      0) == 1);
+    } else if constexpr (Parallel::is_group_v<component>) {
+      for (int i = 0; i < static_cast<int>(num_procs); i++) {
+        CHECK(ActionTesting::number_of_queued_simple_actions<component>(
+                  runner, i) == 1);
+      }
+    } else if constexpr (Parallel::is_nodegroup_v<component>) {
+      for (int i = 0; i < static_cast<int>(num_nodes); i++) {
+        CHECK(ActionTesting::number_of_queued_simple_actions<component>(
+                  runner, i) == 1);
+      }
+    }
+  });
+
+  // First invoke the simple actions on the singletons.
+  ActionTesting::invoke_queued_simple_action<mem_mon_comp<event_metavars>>(
+      make_not_null(&runner), 0);
+  ActionTesting::invoke_queued_simple_action<sing_comp<event_metavars>>(
+      make_not_null(&runner), 0);
+
+  // These immediately call the observer writer to write data to disk
+  CHECK(ActionTesting::number_of_queued_threaded_actions<
+            obs_writer_comp<event_metavars>>(runner, 0) == 2);
+
+  ActionTesting::invoke_queued_threaded_action<obs_writer_comp<event_metavars>>(
+      make_not_null(&runner), 0);
+  ActionTesting::invoke_queued_threaded_action<obs_writer_comp<event_metavars>>(
+      make_not_null(&runner), 0);
+
+  // Check that the data was written correctly
+  std::vector<double> sing_sizes(num_nodes, 0.0);
+  // We multiply by the number of nodes for same reason as in
+  // test_process_singleton()
+  auto& mem_mon_proxy =
+      Parallel::get_parallel_component<mem_mon_comp<event_metavars>>(cache);
+  sing_sizes[0] = static_cast<double>(num_nodes) *
+                  size_of_object_in_bytes(*Parallel::local(mem_mon_proxy)) /
+                  1.0e6;
+  check_output<mem_mon_comp<event_metavars>>(runner, time, num_nodes,
+                                             sing_sizes);
+
+  auto& sing_cache = ActionTesting::cache<sing_comp<event_metavars>>(runner, 0);
+  auto& sing_proxy =
+      Parallel::get_parallel_component<sing_comp<event_metavars>>(sing_cache);
+  sing_sizes[0] = static_cast<double>(num_nodes) *
+                  size_of_object_in_bytes(*Parallel::local(sing_proxy)) / 1.0e6;
+  check_output<sing_comp<event_metavars>>(runner, time, num_nodes, sing_sizes);
+
+  // Now for the groups and nodegroups
+  using group_list =
+      tmpl::list<obs_writer_comp<event_metavars>, group_comp<event_metavars>,
+                 nodegroup_comp<event_metavars>>;
+  tmpl::for_each<group_list>([&runner, &num_nodes, &num_procs, &time,
+                              &cache](auto component_v) {
+    using component = tmpl::type_from<decltype(component_v)>;
+    std::vector<double> sizes(num_nodes);
+    auto& proxy = Parallel::get_parallel_component<component>(cache);
+    Parallel::simple_action<mem_monitor::ProcessGroups>(proxy, time);
+
+    for (size_t node = 0; node < num_nodes; node++) {
+      if constexpr (Parallel::is_nodegroup_v<component>) {
+        // Need the cache of this specific component to get the proper size
+        auto& local_cache = ActionTesting::cache<component>(runner, node);
+        auto& local_proxy =
+            Parallel::get_parallel_component<component>(local_cache);
+        sizes[node] =
+            size_of_object_in_bytes(*Parallel::local_branch(local_proxy)) /
+            1.0e6;
+        ActionTesting::invoke_queued_simple_action<component>(
+            make_not_null(&runner), node);
+
+      } else {
+        for (size_t proc = 0; proc < num_procs_per_node; proc++) {
+          const size_t global_proc = node * num_procs_per_node + proc;
+          // Need the local cache to get the proper size
+          auto& local_cache =
+              ActionTesting::cache<component>(runner, global_proc);
+          auto& local_proxy =
+              Parallel::get_parallel_component<component>(local_cache);
+          sizes[node] +=
+              size_of_object_in_bytes(*Parallel::local_branch(local_proxy)) /
+              1.0e6;
+          ActionTesting::invoke_queued_simple_action<component>(
+              make_not_null(&runner), global_proc);
+        }
+      }
+    }
+
+    run_group_actions<component>(make_not_null(&runner), num_nodes, num_procs,
+                                 time, sizes);
+  });
+
+  // All actions should be completed now
+  CHECK(ActionTesting::number_of_queued_simple_actions<
+            mem_mon_comp<event_metavars>>(runner, 0) == 0);
+  CHECK(ActionTesting::number_of_queued_threaded_actions<
+            obs_writer_comp<event_metavars>>(runner, 0) == 0);
 }
 
 SPECTRE_TEST_CASE("Unit.Parallel.MemoryMonitor", "[Unit][Parallel]") {
@@ -442,5 +686,7 @@ SPECTRE_TEST_CASE("Unit.Parallel.MemoryMonitor", "[Unit][Parallel]") {
   test_contribute_memory_data(make_not_null(&gen), true);
   test_process_array(make_not_null(&gen));
   test_process_singleton();
+  test_event_construction();
+  test_monitor_memory_event();
 }
 }  // namespace


### PR DESCRIPTION
## Proposed changes

Adds an event to be run on the DgElementArray that will monitor the memory usage of parallel components in an executable. You can specify which parallel components to monitor in the input file.

To make this simpler in the input file, I also added a new `Options::AutoLabel` called `All`. That way if users want to monitor the memory usage, but don't care which components they monitor, they can just monitor `All` of the components without having to explicitly specify them in the input file.

Also add the memory monitor component and monitor memory event to the BBH executable.

Depends on and includes #4008.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
