### PR TITLE
Handle late calls to InterpolatorReceiveVolumeData

### DIFF
--- a/src/ParallelAlgorithms/Interpolation/Actions/CleanUpInterpolator.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/CleanUpInterpolator.hpp
@@ -3,10 +3,13 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
+#include <deque>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Utilities/Algorithm.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
@@ -73,7 +76,8 @@ struct CleanUpInterpolator {
                 typename Tags::InterpolatedVarsHolders<Metavariables>::type*>
                 holders) {
           get<Vars::HolderTag<InterpolationTargetTag, Metavariables>>(*holders)
-              .temporal_ids_when_data_has_been_interpolated.insert(temporal_id);
+              .temporal_ids_when_data_has_been_interpolated.push_back(
+                  temporal_id);
         });
 
     // If we don't need any of the volume data anymore for this
@@ -82,15 +86,15 @@ struct CleanUpInterpolator {
     const auto& holders =
         db::get<Tags::InterpolatedVarsHolders<Metavariables>>(box);
     tmpl::for_each<typename Metavariables::interpolation_target_tags>(
-        [&](auto tag) {
+        [&holders, &this_temporal_id_is_done, &temporal_id](auto tag) {
           using Tag = typename decltype(tag)::type;
           if constexpr (std::is_same_v<
                             typename InterpolationTargetTag::temporal_id,
                             typename Tag::temporal_id>) {
-            const auto& found =
+            const auto& finished_temporal_ids =
                 get<Vars::HolderTag<Tag, Metavariables>>(holders)
                     .temporal_ids_when_data_has_been_interpolated;
-            if (found.count(temporal_id) == 0) {
+            if (not alg::found(finished_temporal_ids, temporal_id)) {
               this_temporal_id_is_done = false;
             }
           }
@@ -110,6 +114,39 @@ struct CleanUpInterpolator {
                   Metavariables,
                   typename InterpolationTargetTag::temporal_id>::type*>
                   volume_vars_info) { volume_vars_info->erase(temporal_id); });
+
+      // Clean up temporal_ids_when_data_has_been_interpolated, if
+      // it is too large.
+      [[maybe_unused]] constexpr size_t finished_temporal_ids_max_size = 1000;
+
+      db::mutate<Tags::InterpolatedVarsHolders<Metavariables>>(
+          make_not_null(&box),
+          [](const gsl::not_null<
+              typename Tags::InterpolatedVarsHolders<Metavariables>::type*>
+                 holders_l) {
+            tmpl::for_each<typename Metavariables::interpolation_target_tags>(
+                [&](auto tag) {
+                  using Tag = typename decltype(tag)::type;
+                  if constexpr (std::is_same_v<typename InterpolationTargetTag::
+                                                   temporal_id,
+                                               typename Tag::temporal_id>) {
+                    auto& finished_temporal_ids =
+                        get<Vars::HolderTag<Tag, Metavariables>>(*holders_l)
+                            .temporal_ids_when_data_has_been_interpolated;
+                    if (finished_temporal_ids.size() >
+                        finished_temporal_ids_max_size) {
+                      const size_t num_to_remove =
+                          finished_temporal_ids.size() -
+                          finished_temporal_ids_max_size;
+                      for (size_t i = 0; i < num_to_remove; ++i) {
+                        // All the new temporal_ids are added with push_back,
+                        // so we remove the oldest ones by using pop_front.
+                        finished_temporal_ids.pop_front();
+                      }
+                    }
+                  }
+                });
+          });
     }
   }
 };

--- a/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorReceiveVolumeData.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorReceiveVolumeData.hpp
@@ -48,6 +48,41 @@ struct InterpolatorReceiveVolumeData {
       const typename TemporalId::type& temporal_id,
       const ElementId<VolumeDim>& element_id, const ::Mesh<VolumeDim>& mesh,
       Variables<typename Metavariables::interpolator_source_vars>&& vars) {
+    // Determine if we have already finished interpolating on this
+    // temporal_id.  If so, then we simply return, ignore the incoming
+    // data, and do not interpolate.
+    //
+    // This scenario can happen if there is an element that is not
+    // used or needed for any InterpolationTarget, and if that element
+    // calls InterpolatorReceiveVolumeData so late that all the
+    // InterpolationTargets for the current temporal_id have already
+    // finished.
+    bool this_temporal_id_is_done = true;
+    const auto& holders =
+        db::get<Tags::InterpolatedVarsHolders<Metavariables>>(box);
+    tmpl::for_each<typename Metavariables::interpolation_target_tags>(
+        [&](auto tag_v) {
+          using tag = typename decltype(tag_v)::type;
+          if constexpr (std::is_same_v<TemporalId, typename tag::temporal_id>) {
+            const auto& finished_temporal_ids =
+                get<Vars::HolderTag<tag, Metavariables>>(holders)
+                    .temporal_ids_when_data_has_been_interpolated;
+            if (finished_temporal_ids.count(temporal_id) == 0) {
+              this_temporal_id_is_done = false;
+            }
+          }
+        });
+
+    if (this_temporal_id_is_done) {
+      return;
+    }
+
+    // Add to the VolumeVarsInfo for this TemporalId type.  (Note that
+    // multiple VolumeVarsInfos, each with a different TemporalId
+    // type, can be in the databox.  Note also that the above check
+    // for this_temporal_id_is_done and the interpolation below are
+    // done only for this TemporalId type and not for any other
+    // VolumeVarsInfos that might be in the DataBox.)
     db::mutate<Tags::VolumeVarsInfo<Metavariables, TemporalId>>(
         make_not_null(&box),
         [&temporal_id, &element_id, &mesh,
@@ -68,7 +103,8 @@ struct InterpolatorReceiveVolumeData {
                                   mesh, std::move(vars), {}}));
         });
 
-    // Try to interpolate data for all InterpolationTargets.
+    // Try to interpolate data for all InterpolationTargets for this
+    // temporal_id.
     tmpl::for_each<typename Metavariables::interpolation_target_tags>(
         [&box, &cache, &temporal_id](auto tag_v) {
           using tag = typename decltype(tag_v)::type;

--- a/src/ParallelAlgorithms/Interpolation/InterpolatedVars.hpp
+++ b/src/ParallelAlgorithms/Interpolation/InterpolatedVars.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstddef>
+#include <deque>
 #include <optional>
 #include <unordered_map>
 #include <unordered_set>
@@ -86,7 +87,7 @@ struct Holder {
   std::unordered_map<typename InterpolationTargetTag::temporal_id::type,
                      Info<Metavariables::volume_dim, TagList>>
       infos;
-  std::unordered_set<typename InterpolationTargetTag::temporal_id::type>
+  std::deque<typename InterpolationTargetTag::temporal_id::type>
       temporal_ids_when_data_has_been_interpolated;
 };
 

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_CleanUpInterpolator.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_CleanUpInterpolator.cpp
@@ -160,13 +160,20 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.CleanUp", "[Unit]") {
           .size() == 1);
 
   // temporal_ids_when_data_has_been_interpolated should be empty for B and C,
-  // and should have already been cleaned up for A.
+  // but should have a single entry for A with the correct value.
   CHECK(
       get<intrp::Vars::HolderTag<metavars::InterpolationTagA, metavars>>(
           ActionTesting::get_databox_tag<
               interp_component, intrp::Tags::InterpolatedVarsHolders<metavars>>(
               runner, 0))
-          .temporal_ids_when_data_has_been_interpolated.empty());
+          .temporal_ids_when_data_has_been_interpolated.size() == 1);
+  CHECK(
+      get<intrp::Vars::HolderTag<metavars::InterpolationTagA, metavars>>(
+          ActionTesting::get_databox_tag<
+              interp_component, intrp::Tags::InterpolatedVarsHolders<metavars>>(
+              runner, 0))
+          .temporal_ids_when_data_has_been_interpolated.count(
+              temporal_id.substep_time().value()) == 1);
   CHECK(
       get<intrp::Vars::HolderTag<metavars::InterpolationTagB, metavars>>(
           ActionTesting::get_databox_tag<
@@ -204,7 +211,14 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.CleanUp", "[Unit]") {
           ActionTesting::get_databox_tag<
               interp_component, intrp::Tags::InterpolatedVarsHolders<metavars>>(
               runner, 0))
-          .temporal_ids_when_data_has_been_interpolated.empty());
+          .temporal_ids_when_data_has_been_interpolated.size() == 1);
+  CHECK(
+      get<intrp::Vars::HolderTag<metavars::InterpolationTagA, metavars>>(
+          ActionTesting::get_databox_tag<
+              interp_component, intrp::Tags::InterpolatedVarsHolders<metavars>>(
+              runner, 0))
+          .temporal_ids_when_data_has_been_interpolated.count(
+              temporal_id.substep_time().value()) == 1);
   CHECK(
       get<intrp::Vars::HolderTag<metavars::InterpolationTagC, metavars>>(
           ActionTesting::get_databox_tag<
@@ -243,25 +257,47 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.CleanUp", "[Unit]") {
           intrp::Tags::VolumeVarsInfo<metavars, ::Tags::TimeStepId>>(runner, 0)
           .empty());
 
-  // temporal_ids_when_data_has_been_interpolated should be empty for each tag.
+  // temporal_ids_when_data_has_been_interpolated should contain the correct
+  // values for each tag.  One entry per tag.
   CHECK(
       get<intrp::Vars::HolderTag<metavars::InterpolationTagA, metavars>>(
           ActionTesting::get_databox_tag<
               interp_component, intrp::Tags::InterpolatedVarsHolders<metavars>>(
               runner, 0))
-          .temporal_ids_when_data_has_been_interpolated.empty());
+          .temporal_ids_when_data_has_been_interpolated.size() == 1);
+  CHECK(
+      get<intrp::Vars::HolderTag<metavars::InterpolationTagA, metavars>>(
+          ActionTesting::get_databox_tag<
+              interp_component, intrp::Tags::InterpolatedVarsHolders<metavars>>(
+              runner, 0))
+          .temporal_ids_when_data_has_been_interpolated.count(
+              temporal_id.substep_time().value()) == 1);
   CHECK(
       get<intrp::Vars::HolderTag<metavars::InterpolationTagB, metavars>>(
           ActionTesting::get_databox_tag<
               interp_component, intrp::Tags::InterpolatedVarsHolders<metavars>>(
               runner, 0))
-          .temporal_ids_when_data_has_been_interpolated.empty());
+          .temporal_ids_when_data_has_been_interpolated.size() == 1);
+  CHECK(
+      get<intrp::Vars::HolderTag<metavars::InterpolationTagB, metavars>>(
+          ActionTesting::get_databox_tag<
+              interp_component, intrp::Tags::InterpolatedVarsHolders<metavars>>(
+              runner, 0))
+          .temporal_ids_when_data_has_been_interpolated.count(temporal_id) ==
+      1);
   CHECK(
       get<intrp::Vars::HolderTag<metavars::InterpolationTagC, metavars>>(
           ActionTesting::get_databox_tag<
               interp_component, intrp::Tags::InterpolatedVarsHolders<metavars>>(
               runner, 0))
-          .temporal_ids_when_data_has_been_interpolated.empty());
+          .temporal_ids_when_data_has_been_interpolated.size() == 1);
+  CHECK(
+      get<intrp::Vars::HolderTag<metavars::InterpolationTagC, metavars>>(
+          ActionTesting::get_databox_tag<
+              interp_component, intrp::Tags::InterpolatedVarsHolders<metavars>>(
+              runner, 0))
+          .temporal_ids_when_data_has_been_interpolated.count(temporal_id) ==
+      1);
 
   // There should be no queued actions; verify this.
   CHECK(runner.is_simple_action_queue_empty<mock_interpolator<metavars>>(0));

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_CleanUpInterpolator.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_CleanUpInterpolator.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <deque>
 #include <functional>
 #include <pup.h>
 #include <unordered_map>
@@ -22,6 +23,7 @@
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
 #include "Time/TimeStepId.hpp"
+#include "Utilities/Algorithm.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
 #include "Utilities/Rational.hpp"
@@ -78,6 +80,20 @@ struct MockMetavariables {
   using component_list = tmpl::list<mock_interpolator<MockMetavariables>>;
   enum class Phase { Initialization, Testing, Exit };
 };
+
+template <typename interp_component, typename InterpolationTargetTag,
+          typename Metavariables, typename TemporalId>
+bool temporal_ids_when_data_has_been_interpolated_contains(
+    const ActionTesting::MockRuntimeSystem<Metavariables>& runner,
+    const TemporalId& temporal_id) {
+  const auto& finished_temporal_ids =
+      get<intrp::Vars::HolderTag<InterpolationTargetTag, Metavariables>>(
+          ActionTesting::get_databox_tag<
+              interp_component,
+              intrp::Tags::InterpolatedVarsHolders<Metavariables>>(runner, 0))
+          .temporal_ids_when_data_has_been_interpolated;
+  return alg::found(finished_temporal_ids, temporal_id);
+}
 
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.CleanUp", "[Unit]") {
   using metavars = MockMetavariables;
@@ -167,13 +183,9 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.CleanUp", "[Unit]") {
               interp_component, intrp::Tags::InterpolatedVarsHolders<metavars>>(
               runner, 0))
           .temporal_ids_when_data_has_been_interpolated.size() == 1);
-  CHECK(
-      get<intrp::Vars::HolderTag<metavars::InterpolationTagA, metavars>>(
-          ActionTesting::get_databox_tag<
-              interp_component, intrp::Tags::InterpolatedVarsHolders<metavars>>(
-              runner, 0))
-          .temporal_ids_when_data_has_been_interpolated.count(
-              temporal_id.substep_time().value()) == 1);
+  CHECK(temporal_ids_when_data_has_been_interpolated_contains<
+        interp_component, metavars::InterpolationTagA>(
+      runner, temporal_id.substep_time().value()));
   CHECK(
       get<intrp::Vars::HolderTag<metavars::InterpolationTagB, metavars>>(
           ActionTesting::get_databox_tag<
@@ -212,26 +224,17 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.CleanUp", "[Unit]") {
               interp_component, intrp::Tags::InterpolatedVarsHolders<metavars>>(
               runner, 0))
           .temporal_ids_when_data_has_been_interpolated.size() == 1);
-  CHECK(
-      get<intrp::Vars::HolderTag<metavars::InterpolationTagA, metavars>>(
-          ActionTesting::get_databox_tag<
-              interp_component, intrp::Tags::InterpolatedVarsHolders<metavars>>(
-              runner, 0))
-          .temporal_ids_when_data_has_been_interpolated.count(
-              temporal_id.substep_time().value()) == 1);
+  CHECK(temporal_ids_when_data_has_been_interpolated_contains<
+        interp_component, metavars::InterpolationTagA>(
+      runner, temporal_id.substep_time().value()));
   CHECK(
       get<intrp::Vars::HolderTag<metavars::InterpolationTagC, metavars>>(
           ActionTesting::get_databox_tag<
               interp_component, intrp::Tags::InterpolatedVarsHolders<metavars>>(
               runner, 0))
           .temporal_ids_when_data_has_been_interpolated.size() == 1);
-  CHECK(
-      get<intrp::Vars::HolderTag<metavars::InterpolationTagC, metavars>>(
-          ActionTesting::get_databox_tag<
-              interp_component, intrp::Tags::InterpolatedVarsHolders<metavars>>(
-              runner, 0))
-          .temporal_ids_when_data_has_been_interpolated.count(temporal_id) ==
-      1);
+  CHECK(temporal_ids_when_data_has_been_interpolated_contains<
+        interp_component, metavars::InterpolationTagC>(runner, temporal_id));
   CHECK(
       get<intrp::Vars::HolderTag<metavars::InterpolationTagB, metavars>>(
           ActionTesting::get_databox_tag<
@@ -265,42 +268,54 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.CleanUp", "[Unit]") {
               interp_component, intrp::Tags::InterpolatedVarsHolders<metavars>>(
               runner, 0))
           .temporal_ids_when_data_has_been_interpolated.size() == 1);
+  CHECK(temporal_ids_when_data_has_been_interpolated_contains<
+        interp_component, metavars::InterpolationTagA>(
+      runner, temporal_id.substep_time().value()));
+  CHECK(
+      get<intrp::Vars::HolderTag<metavars::InterpolationTagB, metavars>>(
+          ActionTesting::get_databox_tag<
+              interp_component, intrp::Tags::InterpolatedVarsHolders<metavars>>(
+              runner, 0))
+          .temporal_ids_when_data_has_been_interpolated.size() == 1);
+  CHECK(temporal_ids_when_data_has_been_interpolated_contains<
+        interp_component, metavars::InterpolationTagB>(runner, temporal_id));
+  CHECK(
+      get<intrp::Vars::HolderTag<metavars::InterpolationTagC, metavars>>(
+          ActionTesting::get_databox_tag<
+              interp_component, intrp::Tags::InterpolatedVarsHolders<metavars>>(
+              runner, 0))
+          .temporal_ids_when_data_has_been_interpolated.size() == 1);
+  CHECK(temporal_ids_when_data_has_been_interpolated_contains<
+        interp_component, metavars::InterpolationTagC>(runner, temporal_id));
+
+  // There should be no queued actions; verify this.
+  CHECK(runner.is_simple_action_queue_empty<mock_interpolator<metavars>>(0));
+
+  // Now ensure that cleaning up the interpolator more than 1000 times
+  // does not result in more than 1000 entries in
+  // temporal_ids_when_data_has_been_interpolated.  (The number 1000
+  // is hardcoded in CleanUpInterpolator.hpp and must agree with the next
+  // line)
+  constexpr size_t finished_temporal_ids_max_size = 1000;
+  constexpr size_t number_of_test_calls = finished_temporal_ids_max_size + 10;
+  for (size_t i = 0; i < number_of_test_calls; ++i) {
+    // In normal usage, different calls to CleanUpInterpolator are
+    // made for different temporal_ids, but the test should work fine
+    // if the same temporal_id is duplicated multiple times.
+    runner.simple_action<
+        mock_interpolator<metavars>,
+        intrp::Actions::CleanUpInterpolator<metavars::InterpolationTagA>>(
+        0, temporal_id.substep_time().value());
+  }
+  // There should be exactly 1000 entries, even though it was called
+  // more than 1000 times.
   CHECK(
       get<intrp::Vars::HolderTag<metavars::InterpolationTagA, metavars>>(
           ActionTesting::get_databox_tag<
               interp_component, intrp::Tags::InterpolatedVarsHolders<metavars>>(
               runner, 0))
-          .temporal_ids_when_data_has_been_interpolated.count(
-              temporal_id.substep_time().value()) == 1);
-  CHECK(
-      get<intrp::Vars::HolderTag<metavars::InterpolationTagB, metavars>>(
-          ActionTesting::get_databox_tag<
-              interp_component, intrp::Tags::InterpolatedVarsHolders<metavars>>(
-              runner, 0))
-          .temporal_ids_when_data_has_been_interpolated.size() == 1);
-  CHECK(
-      get<intrp::Vars::HolderTag<metavars::InterpolationTagB, metavars>>(
-          ActionTesting::get_databox_tag<
-              interp_component, intrp::Tags::InterpolatedVarsHolders<metavars>>(
-              runner, 0))
-          .temporal_ids_when_data_has_been_interpolated.count(temporal_id) ==
-      1);
-  CHECK(
-      get<intrp::Vars::HolderTag<metavars::InterpolationTagC, metavars>>(
-          ActionTesting::get_databox_tag<
-              interp_component, intrp::Tags::InterpolatedVarsHolders<metavars>>(
-              runner, 0))
-          .temporal_ids_when_data_has_been_interpolated.size() == 1);
-  CHECK(
-      get<intrp::Vars::HolderTag<metavars::InterpolationTagC, metavars>>(
-          ActionTesting::get_databox_tag<
-              interp_component, intrp::Tags::InterpolatedVarsHolders<metavars>>(
-              runner, 0))
-          .temporal_ids_when_data_has_been_interpolated.count(temporal_id) ==
-      1);
-
-  // There should be no queued actions; verify this.
-  CHECK(runner.is_simple_action_queue_empty<mock_interpolator<metavars>>(0));
+          .temporal_ids_when_data_has_been_interpolated.size() ==
+      finished_temporal_ids_max_size);
 }
 
 }  // namespace


### PR DESCRIPTION
## Proposed changes

There can be elements that are unneeded for interpolation,
but yet these elements still call InterpolatorReceiveVolumeData.
(This is necessary, because e.g. the 7th apparent-horizon iteration
might move the surface into a new element).
However, an unneeded element may call InterpolatorReceiveVolumeData
after the interpolation is complete; in that case we now ignore that
call to InterpolatorReceiveVolumeData.

This should fix the memory problems Kyle found with the interpolator.

This was broken into several commits for (hopefully) easier review.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
