### PR TITLE
Add WCNS-5Z + MC reconstruction to finite difference

### DIFF
--- a/src/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
+++ b/src/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
@@ -13,6 +13,7 @@ spectre_target_sources(
   MonotonisedCentral.cpp
   Unlimited.cpp
   Wcns5z.cpp
+  Wcns5zMc.cpp
   )
 
 spectre_target_headers(
@@ -27,6 +28,7 @@ spectre_target_headers(
   Reconstruct.tpp
   Unlimited.hpp
   Wcns5z.hpp
+  Wcns5zMc.hpp
   )
 
 target_link_libraries(

--- a/src/NumericalAlgorithms/FiniteDifference/Wcns5zMc.cpp
+++ b/src/NumericalAlgorithms/FiniteDifference/Wcns5zMc.cpp
@@ -1,0 +1,122 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/FiniteDifference/Wcns5zMc.hpp"
+
+#include <array>
+#include <cstddef>
+#include <tuple>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/Side.hpp"
+#include "NumericalAlgorithms/FiniteDifference/Reconstruct.tpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace fd::reconstruction {
+
+template <size_t Dim>
+std::tuple<void (*)(gsl::not_null<std::array<gsl::span<double>, Dim>*>,
+                    gsl::not_null<std::array<gsl::span<double>, Dim>*>,
+                    const gsl::span<const double>&,
+                    const DirectionMap<Dim, gsl::span<const double>>&,
+                    const Index<Dim>&, size_t, size_t, double),
+           void (*)(gsl::not_null<DataVector*>, const DataVector&,
+                    const DataVector&, const Index<Dim>&, const Index<Dim>&,
+                    const Direction<Dim>&, const size_t&, const double&),
+           void (*)(gsl::not_null<DataVector*>, const DataVector&,
+                    const DataVector&, const Index<Dim>&, const Index<Dim>&,
+                    const Direction<Dim>&, const size_t&, const double&)>
+wcns5z_mc_function_pointers(const size_t nonlinear_weight_exponent) {
+  switch (nonlinear_weight_exponent) {
+    case 1:
+      return {&wcns5z_mc<1, Dim>,
+              &::fd::reconstruction::reconstruct_neighbor<
+                  Side::Lower,
+                  ::fd::reconstruction::detail::Wcns5zMcReconstructor<1>, Dim>,
+              &::fd::reconstruction::reconstruct_neighbor<
+                  Side::Upper,
+                  ::fd::reconstruction::detail::Wcns5zMcReconstructor<1>, Dim>};
+    case 2:
+      return {&wcns5z_mc<2, Dim>,
+              &::fd::reconstruction::reconstruct_neighbor<
+                  Side::Lower,
+                  ::fd::reconstruction::detail::Wcns5zMcReconstructor<2>, Dim>,
+              &::fd::reconstruction::reconstruct_neighbor<
+                  Side::Upper,
+                  ::fd::reconstruction::detail::Wcns5zMcReconstructor<2>, Dim>};
+    default:
+      ERROR("Nonlinear weight exponent should be 1 or 2 but is : "
+            << nonlinear_weight_exponent << "\n");
+  };
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data)                                           \
+  template std::tuple<                                                   \
+      void (*)(gsl::not_null<std::array<gsl::span<double>, DIM(data)>*>, \
+               gsl::not_null<std::array<gsl::span<double>, DIM(data)>*>, \
+               const gsl::span<const double>&,                           \
+               const DirectionMap<DIM(data), gsl::span<const double>>&,  \
+               const Index<DIM(data)>&, size_t, size_t, double),         \
+      void (*)(gsl::not_null<DataVector*>, const DataVector&,            \
+               const DataVector&, const Index<DIM(data)>&,               \
+               const Index<DIM(data)>&, const Direction<DIM(data)>&,     \
+               const size_t&, const double&),                            \
+      void (*)(gsl::not_null<DataVector*>, const DataVector&,            \
+               const DataVector&, const Index<DIM(data)>&,               \
+               const Index<DIM(data)>&, const Direction<DIM(data)>&,     \
+               const size_t&, const double&)>                            \
+  wcns5z_mc_function_pointers(const size_t nonlinear_weight_exponent);
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+
+#define NONLINEAR_WEIGHT_EXPONENT(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATION(r, data)                                                 \
+  template void                                                                \
+  reconstruct<Wcns5zMcReconstructor<NONLINEAR_WEIGHT_EXPONENT(data)>>(         \
+      gsl::not_null<std::array<gsl::span<double>, DIM(data)>*>                 \
+          reconstructed_upper_side_of_face_vars,                               \
+      gsl::not_null<std::array<gsl::span<double>, DIM(data)>*>                 \
+          reconstructed_lower_side_of_face_vars,                               \
+      const gsl::span<const double>& volume_vars,                              \
+      const DirectionMap<DIM(data), gsl::span<const double>>& ghost_cell_vars, \
+      const Index<DIM(data)>& volume_extents,                                  \
+      const size_t number_of_variables, const size_t& max_num_of_extrema,      \
+      const double& epsilon);
+
+namespace detail {
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2))
+}  // namespace detail
+
+#undef INSTANTIATION
+
+#define SIDE(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATION(r, data)                                                 \
+  template void reconstruct_neighbor<                                          \
+      SIDE(data),                                                              \
+      detail::Wcns5zMcReconstructor<NONLINEAR_WEIGHT_EXPONENT(data)>>(         \
+      gsl::not_null<DataVector*> face_data, const DataVector& volume_data,     \
+      const DataVector& neighbor_data, const Index<DIM(data)>& volume_extents, \
+      const Index<DIM(data)>& ghost_data_extents,                              \
+      const Direction<DIM(data)>& direction_to_reconstruct,                    \
+      const size_t& max_num_of_extrema, const double& epsilon);
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2),
+                        (Side::Upper, Side::Lower))
+
+#undef INSTANTIATION
+#undef SIDE
+#undef NONLINEAR_WEIGHT_EXPONENT
+#undef DIM
+
+}  // namespace fd::reconstruction

--- a/src/NumericalAlgorithms/FiniteDifference/Wcns5zMc.hpp
+++ b/src/NumericalAlgorithms/FiniteDifference/Wcns5zMc.hpp
@@ -1,0 +1,118 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <tuple>
+
+#include "NumericalAlgorithms/FiniteDifference/MonotonisedCentral.hpp"
+#include "NumericalAlgorithms/FiniteDifference/Reconstruct.hpp"
+#include "NumericalAlgorithms/FiniteDifference/Wcns5z.hpp"
+#include "Utilities/ForceInline.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+class DataVector;
+template <size_t>
+class Direction;
+template <size_t Dim, typename T>
+class DirectionMap;
+template <size_t Dim>
+class Index;
+/// \endcond
+
+namespace fd::reconstruction {
+namespace detail {
+
+template <size_t NonlinearWeightExponent>
+struct Wcns5zMcReconstructor {
+  SPECTRE_ALWAYS_INLINE static std::array<double, 2> pointwise(
+      const double* const q, const int stride,
+      const size_t max_number_of_extrema, const double epsilon) {
+    // count the number of extrema in the given FD stencil
+    size_t n_extrema{0};
+    for (int i = -1; i < 2; ++i) {
+      // check if q[i * stride] is local maximum
+      n_extrema += (q[i * stride] > q[(i - 1) * stride]) and
+                   (q[i * stride] > q[(i + 1) * stride]);
+      // check if q[i * stride] is local minimum
+      n_extrema += (q[i * stride] < q[(i - 1) * stride]) and
+                   (q[i * stride] < q[(i + 1) * stride]);
+    }
+
+    // if `n_extrema` is equal or smaller than a specified number, use Wcns5z
+    // reconstruction
+    if (n_extrema < max_number_of_extrema + 1) {
+      return Wcns5zReconstructor<NonlinearWeightExponent>::pointwise(q, stride,
+                                                                     epsilon);
+    } else {
+      // otherwise use MC reconstruction
+      return MonotonisedCentralReconstructor::pointwise(q, stride);
+    }
+  }
+
+  SPECTRE_ALWAYS_INLINE static constexpr size_t stencil_width() { return 5; }
+};
+
+}  // namespace detail
+
+/*!
+ * \ingroup FiniteDifferenceGroup
+ * \brief Performs adaptive reconstruction using WCNS-5Z and MC schemes.
+ *
+ * For each finite difference stencils first check how many extrema are in a
+ * given stencil. If the number of extrema is less than or equal to a
+ * non-negative integer `max_number_of_extrema` which is given as an input
+ * parameter, perform fifth order weighted compact nonlinear reconstruction with
+ * Z oscillation indicator (WCNS-5Z); otherwise, switch to the monotonised
+ * central (MC) reconstruction.
+ *
+ * See the documentations of `wcns5z()` and `monotonised_central()` for
+ * descriptions on each reconstruction schemes.
+ *
+ */
+template <size_t NonlinearWeightExponent, size_t Dim>
+void wcns5z_mc(
+    const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+        reconstructed_upper_side_of_face_vars,
+    const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+        reconstructed_lower_side_of_face_vars,
+    const gsl::span<const double>& volume_vars,
+    const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
+    const Index<Dim>& volume_extents, const size_t number_of_variables,
+    const size_t max_number_of_extrema, const double epsilon) {
+  detail::reconstruct<detail::Wcns5zMcReconstructor<NonlinearWeightExponent>>(
+      reconstructed_upper_side_of_face_vars,
+      reconstructed_lower_side_of_face_vars, volume_vars, ghost_cell_vars,
+      volume_extents, number_of_variables, max_number_of_extrema, epsilon);
+}
+
+/*!
+ * \brief Returns function pointers to the `wcns5z_mc` function, lower neighbor
+ * reconstruction, and upper neighbor reconstruction.
+ *
+ * This is useful for controlling template parameters like the
+ * `NonlinearWeightExponent` from an input file by setting a function pointer.
+ * Note that the reason the reconstruction functions instead of say the
+ * `pointwise` member function is returned is to avoid function pointers inside
+ * tight loops.
+ */
+template <size_t Dim>
+auto wcns5z_mc_function_pointers(size_t nonlinear_weight_exponent)
+    -> std::tuple<
+        void (*)(gsl::not_null<std::array<gsl::span<double>, Dim>*>,
+                 gsl::not_null<std::array<gsl::span<double>, Dim>*>,
+                 const gsl::span<const double>&,
+                 const DirectionMap<Dim, gsl::span<const double>>&,
+                 const Index<Dim>&, size_t, size_t, double),
+        void (*)(gsl::not_null<DataVector*>, const DataVector&,
+                 const DataVector&, const Index<Dim>&, const Index<Dim>&,
+                 const Direction<Dim>&, const size_t&, const double&),
+        void (*)(gsl::not_null<DataVector*>, const DataVector&,
+                 const DataVector&, const Index<Dim>&, const Index<Dim>&,
+                 const Direction<Dim>&, const size_t&, const double&)>;
+
+}  // namespace fd::reconstruction

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   Test_MonotonisedCentral.cpp
   Test_Unlimited.cpp
   Test_Wcns5z.cpp
+  Test_Wcns5zMc.cpp
   )
 
 add_test_library(

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/MonotonisedCentral.py
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/MonotonisedCentral.py
@@ -4,14 +4,15 @@
 import Reconstruction
 
 
-def test_monotonised_central(u, extents, dim):
-    def monotonised_central(a, b):
-        sign = lambda x: -1 if x < 0 else 1
-        sign_a = sign(a)
-        sign_b = sign(b)
-        return 0.5 * (sign_a + sign_b) * min(0.5 * abs(a + b),
-                                             min(2.0 * abs(a), 2.0 * abs(b)))
+def monotonised_central(a, b):
+    sign = lambda x: -1 if x < 0 else 1
+    sign_a = sign(a)
+    sign_b = sign(b)
+    return 0.5 * (sign_a + sign_b) * min(0.5 * abs(a + b),
+                                         min(2.0 * abs(a), 2.0 * abs(b)))
 
+
+def test_monotonised_central(u, extents, dim):
     def compute_face_values(recons_upper_of_cell, recons_lower_of_cell, v, i,
                             j, k, dim_to_recons):
         if dim_to_recons == 0:

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_Wcns5zMc.cpp
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_Wcns5zMc.cpp
@@ -1,0 +1,129 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Framework/Pypp.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Helpers/NumericalAlgorithms/FiniteDifference/Exact.hpp"
+#include "Helpers/NumericalAlgorithms/FiniteDifference/Python.hpp"
+#include "NumericalAlgorithms/FiniteDifference/Wcns5zMc.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+
+template <size_t NonlinearWeightExponent, size_t Dim>
+void test_function_pointers() {
+  const auto function_ptrs =
+      fd::reconstruction::wcns5z_mc_function_pointers<Dim>(
+          NonlinearWeightExponent);
+  CHECK(get<0>(function_ptrs) ==
+        &fd::reconstruction::wcns5z_mc<NonlinearWeightExponent, Dim>);
+  using function_type =
+      void (*)(gsl::not_null<DataVector*>, const DataVector&, const DataVector&,
+               const Index<Dim>&, const Index<Dim>&, const Direction<Dim>&,
+               const size_t&, const double&);
+  CHECK(get<1>(function_ptrs) ==
+        static_cast<function_type>(
+            &fd::reconstruction::reconstruct_neighbor<
+                Side::Lower,
+                ::fd::reconstruction::detail::Wcns5zMcReconstructor<
+                    NonlinearWeightExponent>,
+                Dim>));
+  CHECK(get<2>(function_ptrs) ==
+        static_cast<function_type>(
+            &fd::reconstruction::reconstruct_neighbor<
+                Side::Upper,
+                ::fd::reconstruction::detail::Wcns5zMcReconstructor<
+                    NonlinearWeightExponent>,
+                Dim>));
+}
+
+template <size_t Dim>
+void test() {
+  // test for q=2 case
+
+  const auto recons =
+      [](const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+             reconstructed_upper_side_of_face_vars,
+         const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+             reconstructed_lower_side_of_face_vars,
+         const gsl::span<const double>& volume_vars,
+         const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
+         const Index<Dim>& volume_extents, const size_t number_of_variables) {
+        const size_t max_number_of_extrema = 1;
+        const double epsilon = 2.0e-16;
+
+        fd::reconstruction::wcns5z_mc<2>(reconstructed_upper_side_of_face_vars,
+                                         reconstructed_lower_side_of_face_vars,
+                                         volume_vars, ghost_cell_vars,
+                                         volume_extents, number_of_variables,
+                                         max_number_of_extrema, epsilon);
+      };
+  const auto recons_neighbor_data = [](const gsl::not_null<DataVector*>
+                                           face_data,
+                                       const DataVector& volume_data,
+                                       const DataVector& neighbor_data,
+                                       const Index<Dim>& volume_extents,
+                                       const Index<Dim>& ghost_data_extents,
+                                       const Direction<Dim>&
+                                           direction_to_reconstruct) {
+    const size_t max_number_of_extrema = 1;
+    const double epsilon = 2.0e-16;
+
+    if (direction_to_reconstruct.side() == Side::Upper) {
+      fd::reconstruction::reconstruct_neighbor<
+          Side::Upper, fd::reconstruction::detail::Wcns5zMcReconstructor<2>>(
+          face_data, volume_data, neighbor_data, volume_extents,
+          ghost_data_extents, direction_to_reconstruct, max_number_of_extrema,
+          epsilon);
+    }
+    if (direction_to_reconstruct.side() == Side::Lower) {
+      fd::reconstruction::reconstruct_neighbor<
+          Side::Lower, fd::reconstruction::detail::Wcns5zMcReconstructor<2>>(
+          face_data, volume_data, neighbor_data, volume_extents,
+          ghost_data_extents, direction_to_reconstruct, max_number_of_extrema,
+          epsilon);
+    }
+  };
+
+  // In general, if there are more than one extrema in any of finite difference
+  // stencils reconstruction would be switched to MC which is only exact up to
+  // the polynomial of degree 1. However, if we are testing with a single
+  // (global) degree 2 polynomial (which is used in
+  // `test_reconstruction_is_exact_if_in_basis`) there cannot be more than one
+  // extrema. So we are safe to use degree 2 case for our test here in order to
+  // confirm that Wcns5zMc reconstruction does reproduce the accuracy of Wcns5z
+  // if not switched to MC.
+  TestHelpers::fd::reconstruction::test_reconstruction_is_exact_if_in_basis<
+      Dim>(2, 5, 5, recons, recons_neighbor_data);
+
+  TestHelpers::fd::reconstruction::test_with_python(
+      Index<Dim>{5}, 5, "Wcns5zMc", "test_wcns5z_mc", recons,
+      recons_neighbor_data);
+
+  test_function_pointers<1, Dim>();
+  test_function_pointers<2, Dim>();
+
+  // check for failing case (nonlinear weight exponent = 3)
+  CHECK_THROWS_WITH(
+      ([]() { ::fd::reconstruction::wcns5z_mc_function_pointers<Dim>(3); })(),
+      Catch::Contains("Nonlinear weight exponent should be 1 or 2"));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.FiniteDifference.Wcns5zMc",
+                  "[Unit][NumericalAlgorithms]") {
+  pypp::SetupLocalPythonEnvironment local_python_env(
+      "NumericalAlgorithms/FiniteDifference/");
+  test<1>();
+  test<2>();
+  test<3>();
+}

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/Wcns5zMc.py
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/Wcns5zMc.py
@@ -1,0 +1,59 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+import Reconstruction
+import MonotonisedCentral
+import Wcns5z
+
+import scipy.signal
+
+
+def test_wcns5z_mc(u, extents, dim):
+    def wcns5z_mc(q):
+        j = 2
+
+        # indices of local maxima
+        idx_local_max = scipy.signal.argrelextrema(q, np.greater)[0]
+        # indices of local minima
+        idx_local_min = scipy.signal.argrelextrema(q, np.less)[0]
+
+        # number of local maxima and minima
+        n_extrema = len(idx_local_max) + len(idx_local_min)
+
+        if (n_extrema <= 1):
+            return Wcns5z.wcns5z(q)
+        else:
+            slope = MonotonisedCentral.monotonised_central(
+                q[j] - q[j - 1], q[j + 1] - q[j])
+            return [q[j] - 0.5 * slope, q[j] + 0.5 * slope]
+
+    def compute_face_values(recons_upper_of_cell, recons_lower_of_cell, v, i,
+                            j, k, dim_to_recons):
+        if dim_to_recons == 0:
+            lower, upper = wcns5z_mc(
+                np.asarray([
+                    v[i - 2, j, k], v[i - 1, j, k], v[i, j, k], v[i + 1, j, k],
+                    v[i + 2, j, k]
+                ]))
+            recons_lower_of_cell.append(lower)
+            recons_upper_of_cell.append(upper)
+        if dim_to_recons == 1:
+            lower, upper = wcns5z_mc(
+                np.asarray([
+                    v[i, j - 2, k], v[i, j - 1, k], v[i, j, k], v[i, j + 1, k],
+                    v[i, j + 2, k]
+                ]))
+            recons_lower_of_cell.append(lower)
+            recons_upper_of_cell.append(upper)
+        if dim_to_recons == 2:
+            lower, upper = wcns5z_mc(
+                np.asarray([
+                    v[i, j, k - 2], v[i, j, k - 1], v[i, j, k], v[i, j, k + 1],
+                    v[i, j, k + 2]
+                ]))
+            recons_lower_of_cell.append(lower)
+            recons_upper_of_cell.append(upper)
+
+    return Reconstruction.reconstruct(u, extents, dim, [2, 2, 2],
+                                      compute_face_values)


### PR DESCRIPTION
## Proposed changes

First two commits are from 
- [x] #3986 

A new `Wcns5zMc` reconstruction switches between WCNS-5Z and MC depending on how many extrema are in a given finite difference stencil. 
### Upgrade instructions 

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

I moved out a free function in `tests/Unit/NumericalAlgorithms/FiniteDifference/MonotonisedCentral.py` to the file scope so that it can be used from other python testing scripts.

