### PR TITLE
Subcell TCI improvements, step 1

### DIFF
--- a/src/Evolution/DgSubcell/NeighborReconstructedFaceSolution.hpp
+++ b/src/Evolution/DgSubcell/NeighborReconstructedFaceSolution.hpp
@@ -18,7 +18,6 @@
 #include "Domain/Structure/MaxNumberOfNeighbors.hpp"
 #include "Evolution/DgSubcell/RdmpTciData.hpp"
 #include "Evolution/DgSubcell/Tags/DataForRdmpTci.hpp"
-#include "Evolution/DgSubcell/Tags/Inactive.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/NeighborData.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"

--- a/src/Evolution/DgSubcell/Projection.hpp
+++ b/src/Evolution/DgSubcell/Projection.hpp
@@ -34,7 +34,7 @@ void project_impl(gsl::span<double> subcell_u, gsl::span<const double> dg_u,
  *
  * \note In the return-by-`gsl::not_null` with `Variables` interface, the
  * `SubcellTagList` and the `DgtagList` must be the same when all tag prefixes
- * are removed. Typically the `Tags::Inactive` prefix will be used.
+ * are removed.
  */
 template <size_t Dim>
 DataVector project(const DataVector& dg_u, const Mesh<Dim>& dg_mesh,

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -297,8 +297,10 @@ struct EvolutionMetavars {
 
       tmpl::conditional_t<
           use_dg_subcell,
-          tmpl::list<evolution::dg::subcell::Actions::Initialize<
-              volume_dim, system, Burgers::subcell::DgInitialDataTci>>,
+          tmpl::list<
+              evolution::dg::subcell::Actions::Initialize<
+                  volume_dim, system, Burgers::subcell::DgInitialDataTci>,
+              Actions::MutateApply<Burgers::subcell::SetInitialRdmpData>>,
           tmpl::list<>>,
 
       Initialization::Actions::AddComputeTags<

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -29,7 +29,6 @@
 #include "Evolution/DgSubcell/NeighborReconstructedFaceSolution.hpp"
 #include "Evolution/DgSubcell/PerssonTci.hpp"
 #include "Evolution/DgSubcell/PrepareNeighborData.hpp"
-#include "Evolution/DgSubcell/Tags/Inactive.hpp"
 #include "Evolution/DgSubcell/Tags/ObserverCoordinates.hpp"
 #include "Evolution/DgSubcell/Tags/ObserverMesh.hpp"
 #include "Evolution/DgSubcell/Tags/TciStatus.hpp"
@@ -450,7 +449,9 @@ struct EvolutionMetavars {
                   VariableFixing::FixToAtmosphere<volume_dim>>,
               Actions::MutateApply<
                   grmhd::ValenciaDivClean::subcell::SwapGrTags>,
-              Actions::UpdateConservatives>,
+              Actions::UpdateConservatives,
+              Actions::MutateApply<
+                  grmhd::ValenciaDivClean::subcell::SetInitialRdmpData>>,
           tmpl::list<>>,
 
       Initialization::Actions::AddComputeTags<

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -261,7 +261,9 @@ struct EvolutionMetavars {
           tmpl::list<evolution::dg::subcell::Actions::Initialize<
                          volume_dim, system,
                          NewtonianEuler::subcell::DgInitialDataTci<volume_dim>>,
-                     Actions::UpdateConservatives>,
+                     Actions::UpdateConservatives,
+                     Actions::MutateApply<NewtonianEuler::subcell::
+                                              SetInitialRdmpData<volume_dim>>>,
           tmpl::list<>>,
       Initialization::Actions::AddComputeTags<
           tmpl::list<NewtonianEuler::Tags::SoundSpeedSquaredCompute<DataVector>,

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -303,7 +303,9 @@ struct EvolutionMetavars {
                   volume_dim, system,
                   ScalarAdvection::subcell::DgInitialDataTci<volume_dim>>,
               Initialization::Actions::AddSimpleTags<
-                  ScalarAdvection::subcell::VelocityAtFace<volume_dim>>>,
+                  ScalarAdvection::subcell::VelocityAtFace<volume_dim>>,
+              Actions::MutateApply<
+                  ScalarAdvection::subcell::SetInitialRdmpData>>,
           tmpl::list<>>,
 
       Initialization::Actions::AddComputeTags<

--- a/src/Evolution/Systems/Burgers/FiniteDifference/ReconstructWork.tpp
+++ b/src/Evolution/Systems/Burgers/FiniteDifference/ReconstructWork.tpp
@@ -67,6 +67,11 @@ void reconstruct_work(
              "got "
                  << neighbors_in_direction.size() << " in direction "
                  << direction);
+      ASSERT(not neighbor_data
+                     .at(std::pair{direction, *neighbors_in_direction.begin()})
+                     .empty(),
+             "The neighber data is empty in direction "
+                 << direction << " on element id " << element.id());
 
       ghost_cell_vars[direction] =
           gsl::make_span(&neighbor_data.at(std::pair{

--- a/src/Evolution/Systems/Burgers/Subcell/InitialDataTci.cpp
+++ b/src/Evolution/Systems/Burgers/Subcell/InitialDataTci.cpp
@@ -3,20 +3,44 @@
 
 #include "Evolution/Systems/Burgers/Subcell/InitialDataTci.hpp"
 
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Evolution/DgSubcell/ActiveGrid.hpp"
 #include "Evolution/DgSubcell/PerssonTci.hpp"
+#include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/DgSubcell/TwoMeshRdmpTci.hpp"
+#include "Utilities/Gsl.hpp"
 
 namespace Burgers::subcell {
-bool DgInitialDataTci::apply(
-    const Variables<tmpl::list<Burgers::Tags::U>>& dg_vars,
-    const Variables<tmpl::list<Inactive<Burgers::Tags::U>>>& subcell_vars,
-    double rdmp_delta0, double rdmp_epsilon, double persson_exponent,
-    const Mesh<1>& dg_mesh) {
-  return evolution::dg::subcell::two_mesh_rdmp_tci(dg_vars, subcell_vars,
-                                                   rdmp_delta0, rdmp_epsilon) or
-         evolution::dg::subcell::persson_tci(get<Burgers::Tags::U>(dg_vars),
-                                             dg_mesh, persson_exponent);
+std::tuple<bool, evolution::dg::subcell::RdmpTciData> DgInitialDataTci::apply(
+    const Variables<tmpl::list<Burgers::Tags::U>>& dg_vars, double rdmp_delta0,
+    double rdmp_epsilon, double persson_exponent, const Mesh<1>& dg_mesh,
+    const Mesh<1>& subcell_mesh) {
+  const auto subcell_vars = evolution::dg::subcell::fd::project(
+      dg_vars, dg_mesh, subcell_mesh.extents());
+
+  const auto& dg_u = get<Burgers::Tags::U>(dg_vars);
+  const auto& subcell_u = get<Burgers::Tags::U>(subcell_vars);
+  using std::max;
+  using std::min;
+  evolution::dg::subcell::RdmpTciData rdmp_tci_data{
+      {max(max(get(dg_u)), max(get(subcell_u)))},
+      {min(min(get(dg_u)), min(get(subcell_u)))}};
+
+  return {evolution::dg::subcell::two_mesh_rdmp_tci(
+              dg_vars, subcell_vars, rdmp_delta0, rdmp_epsilon) or
+              evolution::dg::subcell::persson_tci(
+                  get<Burgers::Tags::U>(dg_vars), dg_mesh, persson_exponent),
+          std::move(rdmp_tci_data)};
+}
+
+void SetInitialRdmpData::apply(
+    const gsl::not_null<evolution::dg::subcell::RdmpTciData*> rdmp_tci_data,
+    const Scalar<DataVector>& subcell_u,
+    const evolution::dg::subcell::ActiveGrid active_grid) {
+  if (active_grid == evolution::dg::subcell::ActiveGrid::Subcell) {
+    *rdmp_tci_data = {{max(get(subcell_u))}, {min(get(subcell_u))}};
+  }
 }
 }  // namespace Burgers::subcell

--- a/src/Evolution/Systems/Burgers/Subcell/InitialDataTci.hpp
+++ b/src/Evolution/Systems/Burgers/Subcell/InitialDataTci.hpp
@@ -4,10 +4,16 @@
 #pragma once
 
 #include <cstddef>
+#include <tuple>
 
+#include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/Tags.hpp"
-#include "Evolution/DgSubcell/Tags/Inactive.hpp"
+#include "Evolution/DgSubcell/RdmpTciData.hpp"
+#include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Tags/DataForRdmpTci.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/Systems/Burgers/Tags.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -26,17 +32,26 @@ namespace Burgers::subcell {
  * TCI applied to \f$U\f$.
  */
 struct DgInitialDataTci {
- private:
-  template <typename Tag>
-  using Inactive = evolution::dg::subcell::Tags::Inactive<Tag>;
+  using argument_tags =
+      tmpl::list<domain::Tags::Mesh<1>, evolution::dg::subcell::Tags::Mesh<1>>;
 
- public:
-  using argument_tags = tmpl::list<domain::Tags::Mesh<1>>;
-
-  static bool apply(
+  static std::tuple<bool, evolution::dg::subcell::RdmpTciData> apply(
       const Variables<tmpl::list<Burgers::Tags::U>>& dg_vars,
-      const Variables<tmpl::list<Inactive<Burgers::Tags::U>>>& subcell_vars,
       double rdmp_delta0, double rdmp_epsilon, double persson_exponent,
-      const Mesh<1>& dg_mesh);
+      const Mesh<1>& dg_mesh, const Mesh<1>& subcell_mesh);
+};
+
+/// \brief Sets the initial RDMP data.
+///
+/// Used on the subcells after the TCI marked the DG solution as inadmissible.
+struct SetInitialRdmpData {
+  using argument_tags =
+      tmpl::list<Burgers::Tags::U, evolution::dg::subcell::Tags::ActiveGrid>;
+  using return_tags = tmpl::list<evolution::dg::subcell::Tags::DataForRdmpTci>;
+
+  static void apply(
+      gsl::not_null<evolution::dg::subcell::RdmpTciData*> rdmp_tci_data,
+      const Scalar<DataVector>& subcell_u,
+      evolution::dg::subcell::ActiveGrid active_grid);
 };
 }  // namespace Burgers::subcell

--- a/src/Evolution/Systems/Burgers/Subcell/TciOnDgGrid.cpp
+++ b/src/Evolution/Systems/Burgers/Subcell/TciOnDgGrid.cpp
@@ -3,11 +3,41 @@
 
 #include "Evolution/Systems/Burgers/Subcell/TciOnDgGrid.hpp"
 
+#include <algorithm>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/DgSubcell/PerssonTci.hpp"
+#include "Evolution/DgSubcell/Projection.hpp"
+#include "Evolution/DgSubcell/RdmpTci.hpp"
 
 namespace Burgers::subcell {
-bool TciOnDgGrid::apply(const Scalar<DataVector>& dg_u, const Mesh<1>& dg_mesh,
-                        double persson_exponent) {
-  return ::evolution::dg::subcell::persson_tci(dg_u, dg_mesh, persson_exponent);
+std::tuple<bool, evolution::dg::subcell::RdmpTciData> TciOnDgGrid::apply(
+    const Scalar<DataVector>& dg_u, const Mesh<1>& dg_mesh,
+    const Mesh<1>& subcell_mesh,
+    const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
+    const evolution::dg::subcell::SubcellOptions& subcell_options,
+    double persson_exponent) {
+  // Don't use buffer since we have only one memory allocation right now (until
+  // persson_tci can use a buffer)
+  const Scalar<DataVector> subcell_u{::evolution::dg::subcell::fd::project(
+      get(dg_u), dg_mesh, subcell_mesh.extents())};
+
+  using std::max;
+  using std::min;
+  evolution::dg::subcell::RdmpTciData rdmp_tci_data{
+      {max(max(get(dg_u)), max(get(subcell_u)))},
+      {min(min(get(dg_u)), min(get(subcell_u)))}};
+
+  const bool cell_is_troubled =
+      evolution::dg::subcell::rdmp_tci(rdmp_tci_data.max_variables_values,
+                                       rdmp_tci_data.min_variables_values,
+                                       past_rdmp_tci_data.max_variables_values,
+                                       past_rdmp_tci_data.min_variables_values,
+                                       subcell_options.rdmp_delta0(),
+                                       subcell_options.rdmp_epsilon()) or
+      ::evolution::dg::subcell::persson_tci(dg_u, dg_mesh, persson_exponent);
+
+  return {cell_is_troubled, std::move(rdmp_tci_data)};
 }
 }  // namespace Burgers::subcell

--- a/src/Evolution/Systems/Burgers/Subcell/TciOnDgGrid.hpp
+++ b/src/Evolution/Systems/Burgers/Subcell/TciOnDgGrid.hpp
@@ -4,9 +4,14 @@
 #pragma once
 
 #include <cstddef>
+#include <tuple>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/RdmpTciData.hpp"
+#include "Evolution/DgSubcell/Tags/DataForRdmpTci.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
 #include "Evolution/Systems/Burgers/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -21,14 +26,22 @@ namespace Burgers::subcell {
  * \brief The troubled-cell indicator run on the DG grid to check if the
  * solution is admissible.
  *
- * Applies the Persson TCI to \f$U\f$.
+ * Applies the Persson and RDMP TCI to \f$U\f$.
  */
 struct TciOnDgGrid {
  public:
   using return_tags = tmpl::list<>;
-  using argument_tags = tmpl::list<Burgers::Tags::U, domain::Tags::Mesh<1>>;
+  using argument_tags =
+      tmpl::list<Burgers::Tags::U, domain::Tags::Mesh<1>,
+                 evolution::dg::subcell::Tags::Mesh<1>,
+                 evolution::dg::subcell::Tags::DataForRdmpTci,
+                 evolution::dg::subcell::Tags::SubcellOptions>;
 
-  static bool apply(const Scalar<DataVector>& dg_u, const Mesh<1>& dg_mesh,
-                    double persson_exponent);
+  static std::tuple<bool, evolution::dg::subcell::RdmpTciData> apply(
+      const Scalar<DataVector>& dg_u, const Mesh<1>& dg_mesh,
+      const Mesh<1>& subcell_mesh,
+      const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
+      const evolution::dg::subcell::SubcellOptions& subcell_options,
+      double persson_exponent);
 };
 }  // namespace Burgers::subcell

--- a/src/Evolution/Systems/Burgers/Subcell/TciOnFdGrid.cpp
+++ b/src/Evolution/Systems/Burgers/Subcell/TciOnFdGrid.cpp
@@ -3,11 +3,41 @@
 
 #include "Evolution/Systems/Burgers/Subcell/TciOnFdGrid.hpp"
 
+#include <algorithm>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/DgSubcell/PerssonTci.hpp"
+#include "Evolution/DgSubcell/RdmpTci.hpp"
+#include "Evolution/DgSubcell/Reconstruction.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
 
 namespace Burgers::subcell {
-bool TciOnFdGrid::apply(const Scalar<DataVector>& dg_u, const Mesh<1>& dg_mesh,
-                        const double persson_exponent) {
-  return ::evolution::dg::subcell::persson_tci(dg_u, dg_mesh, persson_exponent);
+std::tuple<bool, evolution::dg::subcell::RdmpTciData> TciOnFdGrid::apply(
+    const Scalar<DataVector>& subcell_u, const Mesh<1>& dg_mesh,
+    const Mesh<1>& subcell_mesh,
+    const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
+    const evolution::dg::subcell::SubcellOptions& subcell_options,
+    const double persson_exponent) {
+  const Scalar<DataVector> dg_u{evolution::dg::subcell::fd::reconstruct(
+      get(subcell_u), dg_mesh, subcell_mesh.extents(),
+      evolution::dg::subcell::fd::ReconstructionMethod::DimByDim)};
+
+  using std::max;
+  using std::min;
+  const evolution::dg::subcell::RdmpTciData rdmp_data_for_tci{
+      {max(max(get(dg_u)), max(get(subcell_u)))},
+      {min(min(get(dg_u)), min(get(subcell_u)))}};
+
+  const bool cell_is_troubled = evolution::dg::subcell::rdmp_tci(
+      rdmp_data_for_tci.max_variables_values,
+      rdmp_data_for_tci.min_variables_values,
+      past_rdmp_tci_data.max_variables_values,
+      past_rdmp_tci_data.min_variables_values, subcell_options.rdmp_delta0(),
+      subcell_options.rdmp_epsilon());
+
+  return {cell_is_troubled or ::evolution::dg::subcell::persson_tci(
+                                  dg_u, dg_mesh, persson_exponent),
+          {{max(get(subcell_u))}, {min(get(subcell_u))}}};
 }
 }  // namespace Burgers::subcell

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/ReconstructWork.tpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/ReconstructWork.tpp
@@ -132,6 +132,11 @@ void reconstruct_prims_work(
              "got "
                  << neighbors_in_direction.size() << " in direction "
                  << direction);
+      ASSERT(not neighbor_data
+                     .at(std::pair{direction, *neighbors_in_direction.begin()})
+                     .empty(),
+             "The neighber data is empty in direction "
+                 << direction << " on element id " << element.id());
       ghost_cell_vars[direction] = gsl::make_span(
           &neighbor_data.at(std::pair{
               direction,

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/InitialDataTci.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/InitialDataTci.cpp
@@ -6,14 +6,16 @@
 #include <cstddef>
 
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/DgSubcell/TwoMeshRdmpTci.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/InitialDataTci.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 
 namespace grmhd::GhValenciaDivClean::subcell {
-bool DgInitialDataTci::apply(
+std::tuple<bool, evolution::dg::subcell::RdmpTciData> DgInitialDataTci::apply(
     const Variables<tmpl::list<
         gr::Tags::SpacetimeMetric<3, Frame::Inertial, DataVector>,
         GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
@@ -21,26 +23,26 @@ bool DgInitialDataTci::apply(
         ValenciaDivClean::Tags::TildeD, ValenciaDivClean::Tags::TildeTau,
         ValenciaDivClean::Tags::TildeS<>, ValenciaDivClean::Tags::TildeB<>,
         ValenciaDivClean::Tags::TildePhi>>& dg_vars,
-    const Variables<tmpl::list<
-        Inactive<gr::Tags::SpacetimeMetric<3, Frame::Inertial, DataVector>>,
-        Inactive<GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>>,
-        Inactive<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>>,
-        Inactive<ValenciaDivClean::Tags::TildeD>,
-        Inactive<ValenciaDivClean::Tags::TildeTau>,
-        Inactive<ValenciaDivClean::Tags::TildeS<>>,
-        Inactive<ValenciaDivClean::Tags::TildeB<>>,
-        Inactive<ValenciaDivClean::Tags::TildePhi>>>& subcell_vars,
     const double rdmp_delta0, const double rdmp_epsilon,
     const double persson_exponent, const Mesh<3>& dg_mesh,
+    const Mesh<3>& subcell_mesh,
     const ValenciaDivClean::subcell::TciOptions& tci_options) {
-  return ValenciaDivClean::subcell::detail::initial_data_tci_work(
-             get<ValenciaDivClean::Tags::TildeD>(dg_vars),
-             get<ValenciaDivClean::Tags::TildeTau>(dg_vars),
-             get<Inactive<ValenciaDivClean::Tags::TildeD>>(subcell_vars),
-             get<Inactive<ValenciaDivClean::Tags::TildeTau>>(subcell_vars),
-             get<ValenciaDivClean::Tags::TildeB<>>(dg_vars), persson_exponent,
-             dg_mesh, tci_options) or
-         evolution::dg::subcell::two_mesh_rdmp_tci(dg_vars, subcell_vars,
-                                                   rdmp_delta0, rdmp_epsilon);
+  const Scalar<DataVector> dg_tilde_b_magnitude =
+      magnitude(get<ValenciaDivClean::Tags::TildeB<>>(dg_vars));
+  const auto subcell_vars = evolution::dg::subcell::fd::project(
+      dg_vars, dg_mesh, subcell_mesh.extents());
+  const Scalar<DataVector> subcell_tilde_b_magnitude =
+      magnitude(get<ValenciaDivClean::Tags::TildeB<>>(subcell_vars));
+
+  auto result = grmhd::ValenciaDivClean::subcell::detail::initial_data_tci_work(
+      get<ValenciaDivClean::Tags::TildeD>(dg_vars),
+      get<ValenciaDivClean::Tags::TildeTau>(dg_vars), dg_tilde_b_magnitude,
+      get<ValenciaDivClean::Tags::TildeD>(subcell_vars),
+      get<ValenciaDivClean::Tags::TildeTau>(subcell_vars),
+      subcell_tilde_b_magnitude, persson_exponent, dg_mesh, tci_options);
+  return {std::get<0>(result) or
+              evolution::dg::subcell::two_mesh_rdmp_tci(
+                  dg_vars, subcell_vars, rdmp_delta0, rdmp_epsilon),
+          std::move(std::get<1>(result))};
 }
 }  // namespace grmhd::GhValenciaDivClean::subcell

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/InitialDataTci.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/InitialDataTci.hpp
@@ -7,7 +7,9 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/Tags.hpp"
-#include "Evolution/DgSubcell/Tags/Inactive.hpp"
+#include "Evolution/DgSubcell/RdmpTciData.hpp"
+#include "Evolution/DgSubcell/Tags/DataForRdmpTci.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOptions.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
@@ -34,21 +36,17 @@ namespace grmhd::GhValenciaDivClean::subcell {
  *   grid, not initialized to the initial data) is less than
  *   `tci_options.minimum_rest_mass_density_times_lorentz_factor`
  *   (`tci_options.minimum_tilde_tau`), then the element is flagged as troubled.
- * - apply the two-mesh relaxed discrete maximum principle TCI
  * - apply the Persson TCI to \f$\tilde{D}\f$ and \f$\tilde{\tau}\f$.
  * - apply the Persson TCI to the magnitude of \f$\tilde{B}\f$ if its magnitude
  *   on the DG grid is greater than `tci_options.magnetic_field_cutoff`.
+ * - apply the two-mesh relaxed discrete maximum principle TCI
  */
 struct DgInitialDataTci {
- private:
-  template <typename Tag>
-  using Inactive = evolution::dg::subcell::Tags::Inactive<Tag>;
+  using argument_tags =
+      tmpl::list<domain::Tags::Mesh<3>, evolution::dg::subcell::Tags::Mesh<3>,
+                 ValenciaDivClean::subcell::Tags::TciOptions>;
 
- public:
-  using argument_tags = tmpl::list<domain::Tags::Mesh<3>,
-                                   ValenciaDivClean::subcell::Tags::TciOptions>;
-
-  static bool apply(
+  static std::tuple<bool, evolution::dg::subcell::RdmpTciData> apply(
       const Variables<tmpl::list<
           gr::Tags::SpacetimeMetric<3, Frame::Inertial, DataVector>,
           GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
@@ -56,17 +54,8 @@ struct DgInitialDataTci {
           ValenciaDivClean::Tags::TildeD, ValenciaDivClean::Tags::TildeTau,
           ValenciaDivClean::Tags::TildeS<>, ValenciaDivClean::Tags::TildeB<>,
           ValenciaDivClean::Tags::TildePhi>>& dg_vars,
-      const Variables<tmpl::list<
-          Inactive<gr::Tags::SpacetimeMetric<3, Frame::Inertial, DataVector>>,
-          Inactive<GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>>,
-          Inactive<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>>,
-          Inactive<ValenciaDivClean::Tags::TildeD>,
-          Inactive<ValenciaDivClean::Tags::TildeTau>,
-          Inactive<ValenciaDivClean::Tags::TildeS<>>,
-          Inactive<ValenciaDivClean::Tags::TildeB<>>,
-          Inactive<ValenciaDivClean::Tags::TildePhi>>>& subcell_vars,
       double rdmp_delta0, double rdmp_epsilon, double persson_exponent,
-      const Mesh<3>& dg_mesh,
+      const Mesh<3>& dg_mesh, const Mesh<3>& subcell_mesh,
       const ValenciaDivClean::subcell::TciOptions& tci_options);
 };
 }  // namespace grmhd::GhValenciaDivClean::subcell

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonisedCentral.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonisedCentral.hpp
@@ -16,7 +16,6 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/Structure/MaxNumberOfNeighbors.hpp"
 #include "Domain/Tags.hpp"
-#include "Evolution/DgSubcell/Tags/Inactive.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/NeighborData.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Reconstructor.hpp"

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.tpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.tpp
@@ -193,6 +193,11 @@ void reconstruct_prims_work(
              "got "
                  << neighbors_in_direction.size() << " in direction "
                  << direction);
+      ASSERT(not neighbor_data
+                     .at(std::pair{direction, *neighbors_in_direction.begin()})
+                     .empty(),
+             "The neighber data is empty in direction "
+                 << direction << " on element id " << element.id());
       ghost_cell_vars[direction] = gsl::make_span(
           &neighbor_data.at(std::pair{
               direction,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/InitialDataTci.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/InitialDataTci.cpp
@@ -9,64 +9,97 @@
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Evolution/DgSubcell/ActiveGrid.hpp"
 #include "Evolution/DgSubcell/PerssonTci.hpp"
+#include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/DgSubcell/TwoMeshRdmpTci.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 
 namespace grmhd::ValenciaDivClean::subcell {
 namespace detail {
-bool initial_data_tci_work(
+std::tuple<bool, evolution::dg::subcell::RdmpTciData> initial_data_tci_work(
     const Scalar<DataVector>& dg_tilde_d,
     const Scalar<DataVector>& dg_tilde_tau,
+    const Scalar<DataVector>& dg_tilde_b_magnitude,
     const Scalar<DataVector>& subcell_tilde_d,
     const Scalar<DataVector>& subcell_tilde_tau,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& dg_tilde_b,
+    const Scalar<DataVector>& subcell_tilde_b_magnitude,
     const double persson_exponent, const Mesh<3>& dg_mesh,
     const TciOptions& tci_options) {
-  const Scalar<DataVector> tilde_b_magnitude =
-      tci_options.magnetic_field_cutoff.has_value() ? magnitude(dg_tilde_b)
-                                                    : Scalar<DataVector>{};
+  evolution::dg::subcell::RdmpTciData rdmp_tci_data{};
+  using std::max;
+  using std::min;
+  rdmp_tci_data.max_variables_values = std::vector<double>{
+      max(max(get(dg_tilde_d)), max(get(subcell_tilde_d))),
+      max(max(get(dg_tilde_tau)), max(get(subcell_tilde_tau))),
+      max(max(get(dg_tilde_b_magnitude)), max(get(subcell_tilde_b_magnitude)))};
+  rdmp_tci_data.min_variables_values = std::vector<double>{
+      min(min(get(dg_tilde_d)), min(get(subcell_tilde_d))),
+      min(min(get(dg_tilde_tau)), min(get(subcell_tilde_tau))),
+      min(min(get(dg_tilde_b_magnitude)), min(get(subcell_tilde_b_magnitude)))};
 
-  return min(get(dg_tilde_d)) <
-             tci_options.minimum_rest_mass_density_times_lorentz_factor or
-         min(get(subcell_tilde_d)) <
-             tci_options.minimum_rest_mass_density_times_lorentz_factor or
-         min(get(dg_tilde_tau)) < tci_options.minimum_tilde_tau or
-         min(get(subcell_tilde_tau)) < tci_options.minimum_tilde_tau or
-         evolution::dg::subcell::persson_tci(dg_tilde_d, dg_mesh,
-                                             persson_exponent) or
-         evolution::dg::subcell::persson_tci(dg_tilde_tau, dg_mesh,
-                                             persson_exponent) or
-         (tci_options.magnetic_field_cutoff.has_value() and
-          max(get(tilde_b_magnitude)) >
-              tci_options.magnetic_field_cutoff.value() and
-          evolution::dg::subcell::persson_tci(tilde_b_magnitude, dg_mesh,
-                                              persson_exponent));
+  return {min(get(dg_tilde_d)) <
+                  tci_options.minimum_rest_mass_density_times_lorentz_factor or
+              min(get(subcell_tilde_d)) <
+                  tci_options.minimum_rest_mass_density_times_lorentz_factor or
+              min(get(dg_tilde_tau)) < tci_options.minimum_tilde_tau or
+              min(get(subcell_tilde_tau)) < tci_options.minimum_tilde_tau or
+              evolution::dg::subcell::persson_tci(dg_tilde_d, dg_mesh,
+                                                  persson_exponent) or
+              evolution::dg::subcell::persson_tci(dg_tilde_tau, dg_mesh,
+                                                  persson_exponent) or
+              (tci_options.magnetic_field_cutoff.has_value() and
+               max(get(dg_tilde_b_magnitude)) >
+                   tci_options.magnetic_field_cutoff.value() and
+               evolution::dg::subcell::persson_tci(dg_tilde_b_magnitude,
+                                                   dg_mesh, persson_exponent)),
+          std::move(rdmp_tci_data)};
 }
 }  // namespace detail
 
-bool DgInitialDataTci::apply(
+std::tuple<bool, evolution::dg::subcell::RdmpTciData> DgInitialDataTci::apply(
     const Variables<tmpl::list<
         ValenciaDivClean::Tags::TildeD, ValenciaDivClean::Tags::TildeTau,
         ValenciaDivClean::Tags::TildeS<>, ValenciaDivClean::Tags::TildeB<>,
         ValenciaDivClean::Tags::TildePhi>>& dg_vars,
-    const Variables<tmpl::list<Inactive<ValenciaDivClean::Tags::TildeD>,
-                               Inactive<ValenciaDivClean::Tags::TildeTau>,
-                               Inactive<ValenciaDivClean::Tags::TildeS<>>,
-                               Inactive<ValenciaDivClean::Tags::TildeB<>>,
-                               Inactive<ValenciaDivClean::Tags::TildePhi>>>&
-        subcell_vars,
     const double rdmp_delta0, const double rdmp_epsilon,
     const double persson_exponent, const Mesh<3>& dg_mesh,
-    const TciOptions& tci_options) {
-  return detail::initial_data_tci_work(
-             get<ValenciaDivClean::Tags::TildeD>(dg_vars),
-             get<ValenciaDivClean::Tags::TildeTau>(dg_vars),
-             get<Inactive<ValenciaDivClean::Tags::TildeD>>(subcell_vars),
-             get<Inactive<ValenciaDivClean::Tags::TildeTau>>(subcell_vars),
-             get<ValenciaDivClean::Tags::TildeB<>>(dg_vars), persson_exponent,
-             dg_mesh, tci_options) or
-         evolution::dg::subcell::two_mesh_rdmp_tci(dg_vars, subcell_vars,
-                                                   rdmp_delta0, rdmp_epsilon);
+    const Mesh<3>& subcell_mesh, const TciOptions& tci_options) {
+  const Scalar<DataVector> dg_tilde_b_magnitude =
+      magnitude(get<ValenciaDivClean::Tags::TildeB<>>(dg_vars));
+  const auto subcell_vars = evolution::dg::subcell::fd::project(
+      dg_vars, dg_mesh, subcell_mesh.extents());
+  const Scalar<DataVector> subcell_tilde_b_magnitude =
+      magnitude(get<ValenciaDivClean::Tags::TildeB<>>(subcell_vars));
+
+  auto result = detail::initial_data_tci_work(
+      get<ValenciaDivClean::Tags::TildeD>(dg_vars),
+      get<ValenciaDivClean::Tags::TildeTau>(dg_vars), dg_tilde_b_magnitude,
+      get<ValenciaDivClean::Tags::TildeD>(subcell_vars),
+      get<ValenciaDivClean::Tags::TildeTau>(subcell_vars),
+      subcell_tilde_b_magnitude, persson_exponent, dg_mesh, tci_options);
+  return {std::get<0>(result) or
+              evolution::dg::subcell::two_mesh_rdmp_tci(
+                  dg_vars, subcell_vars, rdmp_delta0, rdmp_epsilon),
+          std::move(std::get<1>(result))};
+}
+
+void SetInitialRdmpData::apply(
+    const gsl::not_null<evolution::dg::subcell::RdmpTciData*> rdmp_tci_data,
+    const Scalar<DataVector>& subcell_tilde_d,
+    const Scalar<DataVector>& subcell_tilde_tau,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& subcell_tilde_b,
+    const evolution::dg::subcell::ActiveGrid active_grid) {
+  if (active_grid == evolution::dg::subcell::ActiveGrid::Subcell) {
+    const Scalar<DataVector> subcell_tilde_b_magnitude =
+        magnitude(subcell_tilde_b);
+
+    rdmp_tci_data->max_variables_values = std::vector<double>{
+        max(get(subcell_tilde_d)), max(get(subcell_tilde_tau)),
+        max(get(subcell_tilde_b_magnitude))};
+    rdmp_tci_data->min_variables_values = std::vector<double>{
+        min(get(subcell_tilde_d)), min(get(subcell_tilde_tau)),
+        min(get(subcell_tilde_b_magnitude))};
+  }
 }
 }  // namespace grmhd::ValenciaDivClean::subcell

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/InitialDataTci.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/InitialDataTci.hpp
@@ -4,10 +4,14 @@
 #pragma once
 
 #include <cstddef>
+#include <tuple>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/Tags.hpp"
-#include "Evolution/DgSubcell/Tags/Inactive.hpp"
+#include "Evolution/DgSubcell/RdmpTciData.hpp"
+#include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Tags/DataForRdmpTci.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOptions.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
 #include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
@@ -23,13 +27,14 @@ class Variables;
 
 namespace grmhd::ValenciaDivClean::subcell {
 namespace detail {
-bool initial_data_tci_work(
+std::tuple<bool, evolution::dg::subcell::RdmpTciData> initial_data_tci_work(
     const Scalar<DataVector>& dg_tilde_d,
     const Scalar<DataVector>& dg_tilde_tau,
+    const Scalar<DataVector>& dg_tilde_b_magnitude,
     const Scalar<DataVector>& subcell_tilde_d,
     const Scalar<DataVector>& subcell_tilde_tau,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& dg_tilde_b,
-    double persson_exponent, const Mesh<3>& dg_mesh,
+    const Scalar<DataVector>& subcell_tilde_b_magnitude,
+    const double persson_exponent, const Mesh<3>& dg_mesh,
     const TciOptions& tci_options);
 }  // namespace detail
 
@@ -43,31 +48,41 @@ bool initial_data_tci_work(
  *   grid, not initialized to the initial data) is less than
  *   `tci_options.minimum_rest_mass_density_times_lorentz_factor`
  *   (`tci_options.minimum_tilde_tau`), then the element is flagged as troubled.
- * - apply the two-mesh relaxed discrete maximum principle TCI
  * - apply the Persson TCI to \f$\tilde{D}\f$ and \f$\tilde{\tau}\f$.
  * - apply the Persson TCI to the magnitude of \f$\tilde{B}\f$ if its magnitude
  *   on the DG grid is greater than `tci_options.magnetic_field_cutoff`.
+ * - apply the two-mesh relaxed discrete maximum principle TCI
  */
 struct DgInitialDataTci {
- private:
-  template <typename Tag>
-  using Inactive = evolution::dg::subcell::Tags::Inactive<Tag>;
+  using argument_tags =
+      tmpl::list<domain::Tags::Mesh<3>, evolution::dg::subcell::Tags::Mesh<3>,
+                 Tags::TciOptions>;
 
- public:
-  using argument_tags = tmpl::list<domain::Tags::Mesh<3>, Tags::TciOptions>;
-
-  static bool apply(
+  static std::tuple<bool, evolution::dg::subcell::RdmpTciData> apply(
       const Variables<tmpl::list<
           ValenciaDivClean::Tags::TildeD, ValenciaDivClean::Tags::TildeTau,
           ValenciaDivClean::Tags::TildeS<>, ValenciaDivClean::Tags::TildeB<>,
           ValenciaDivClean::Tags::TildePhi>>& dg_vars,
-      const Variables<tmpl::list<Inactive<ValenciaDivClean::Tags::TildeD>,
-                                 Inactive<ValenciaDivClean::Tags::TildeTau>,
-                                 Inactive<ValenciaDivClean::Tags::TildeS<>>,
-                                 Inactive<ValenciaDivClean::Tags::TildeB<>>,
-                                 Inactive<ValenciaDivClean::Tags::TildePhi>>>&
-          subcell_vars,
       double rdmp_delta0, double rdmp_epsilon, double persson_exponent,
-      const Mesh<3>& dg_mesh, const TciOptions& tci_options);
+      const Mesh<3>& dg_mesh, const Mesh<3>& subcell_mesh,
+      const TciOptions& tci_options);
+};
+
+/// \brief Sets the initial RDMP data.
+///
+/// Used on the subcells after the TCI marked the DG solution as inadmissible.
+struct SetInitialRdmpData {
+  using argument_tags = tmpl::list<ValenciaDivClean::Tags::TildeD,
+                                   ValenciaDivClean::Tags::TildeTau,
+                                   ValenciaDivClean::Tags::TildeB<>,
+                                   evolution::dg::subcell::Tags::ActiveGrid>;
+  using return_tags = tmpl::list<evolution::dg::subcell::Tags::DataForRdmpTci>;
+
+  static void apply(
+      gsl::not_null<evolution::dg::subcell::RdmpTciData*> rdmp_tci_data,
+      const Scalar<DataVector>& subcell_tilde_d,
+      const Scalar<DataVector>& subcell_tilde_tau,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& subcell_tilde_b,
+      const evolution::dg::subcell::ActiveGrid active_grid);
 };
 }  // namespace grmhd::ValenciaDivClean::subcell

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.cpp
@@ -9,29 +9,111 @@
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/DgSubcell/PerssonTci.hpp"
+#include "Evolution/DgSubcell/RdmpTci.hpp"
+#include "Evolution/DgSubcell/RdmpTciData.hpp"
+#include "Evolution/DgSubcell/Reconstruction.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 
 namespace grmhd::ValenciaDivClean::subcell {
-bool TciOnFdGrid::apply(const Scalar<DataVector>& tilde_d,
-                        const Scalar<DataVector>& tilde_tau,
-                        const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
-                        const bool vars_needed_fixing, const Mesh<3>& dg_mesh,
-                        const TciOptions& tci_options,
-                        const double persson_exponent) {
+std::tuple<bool, evolution::dg::subcell::RdmpTciData> TciOnFdGrid::apply(
+    const Scalar<DataVector>& subcell_tilde_d,
+    const Scalar<DataVector>& subcell_tilde_tau,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& subcell_tilde_b,
+    const bool vars_needed_fixing, const Mesh<3>& dg_mesh,
+    const Mesh<3>& subcell_mesh,
+    const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
+    const TciOptions& tci_options,
+    const evolution::dg::subcell::SubcellOptions& subcell_options,
+    const double persson_exponent) {
+  const size_t num_dg_pts = dg_mesh.number_of_grid_points();
+  const size_t num_subcell_pts = subcell_mesh.number_of_grid_points();
+  DataVector temp_buffer{num_subcell_pts + 3 * num_dg_pts};
+  size_t offset_into_temp_buffer = 0;
+  const auto assign_data =
+      [&temp_buffer, &offset_into_temp_buffer](
+          const gsl::not_null<Scalar<DataVector>*> to_assign,
+          const size_t size) {
+        get(*to_assign)
+            .set_data_ref(temp_buffer.data() + offset_into_temp_buffer, size);
+        offset_into_temp_buffer += size;
+      };
+
+  Scalar<DataVector> subcell_mag_tilde_b{};
+  assign_data(make_not_null(&subcell_mag_tilde_b), num_subcell_pts);
+  magnitude(make_not_null(&subcell_mag_tilde_b), subcell_tilde_b);
+
+  evolution::dg::subcell::RdmpTciData rdmp_tci_data{};
+  rdmp_tci_data.max_variables_values =
+      std::vector{max(get(subcell_tilde_d)), max(get(subcell_tilde_tau)),
+                  max(get(subcell_mag_tilde_b))};
+  rdmp_tci_data.min_variables_values =
+      std::vector{min(get(subcell_tilde_d)), min(get(subcell_tilde_tau)),
+                  min(get(subcell_mag_tilde_b))};
+
+  Scalar<DataVector> dg_tilde_d{};
+  assign_data(make_not_null(&dg_tilde_d), num_dg_pts);
+  evolution::dg::subcell::fd::reconstruct(
+      make_not_null(&get(dg_tilde_d)), get(subcell_tilde_d), dg_mesh,
+      subcell_mesh.extents(),
+      evolution::dg::subcell::fd::ReconstructionMethod::DimByDim);
+  Scalar<DataVector> dg_tilde_tau{};
+  assign_data(make_not_null(&dg_tilde_tau), num_dg_pts);
+  evolution::dg::subcell::fd::reconstruct(
+      make_not_null(&get(dg_tilde_tau)), get(subcell_tilde_tau), dg_mesh,
+      subcell_mesh.extents(),
+      evolution::dg::subcell::fd::ReconstructionMethod::DimByDim);
+
+  // Note: `or` is short-circuiting, so if any of the first tests fail, we won't
+  // do the more expensive Persson TCI test.
   bool cell_is_troubled =
       vars_needed_fixing or
-      min(get(tilde_d)) <
+      min(get(dg_tilde_d)) <
           tci_options.minimum_rest_mass_density_times_lorentz_factor or
-      min(get(tilde_tau)) < tci_options.minimum_tilde_tau or
-      evolution::dg::subcell::persson_tci(tilde_d, dg_mesh, persson_exponent) or
-      evolution::dg::subcell::persson_tci(tilde_tau, dg_mesh, persson_exponent);
+      min(get(dg_tilde_tau)) < tci_options.minimum_tilde_tau or
+      evolution::dg::subcell::persson_tci(dg_tilde_d, dg_mesh,
+                                          persson_exponent) or
+      evolution::dg::subcell::persson_tci(dg_tilde_tau, dg_mesh,
+                                          persson_exponent);
+
+  if (cell_is_troubled) {
+    return {cell_is_troubled, rdmp_tci_data};
+  }
+
+  Scalar<DataVector> dg_mag_tilde_b{};
+  assign_data(make_not_null(&dg_mag_tilde_b), num_dg_pts);
+  evolution::dg::subcell::fd::reconstruct(
+      make_not_null(&get(dg_mag_tilde_b)), get(subcell_mag_tilde_b), dg_mesh,
+      subcell_mesh.extents(),
+      evolution::dg::subcell::fd::ReconstructionMethod::DimByDim);
+  // Add the reconstructed DG solution to the check. This is done so that we
+  // wouldn't violate RDMP if we switch back. However, we don't want to return
+  // max/mins from a bad DG solution.
+  using std::max;
+  using std::min;
+  evolution::dg::subcell::RdmpTciData rdmp_tci_data_for_check{};
+  rdmp_tci_data_for_check.max_variables_values = std::vector{
+      max(max(get(dg_tilde_d)), rdmp_tci_data.max_variables_values[0]),
+      max(max(get(dg_tilde_tau)), rdmp_tci_data.max_variables_values[1]),
+      max(max(get(dg_mag_tilde_b)), rdmp_tci_data.max_variables_values[2])};
+  rdmp_tci_data_for_check.min_variables_values = std::vector{
+      min(min(get(dg_tilde_d)), rdmp_tci_data.min_variables_values[0]),
+      min(min(get(dg_tilde_tau)), rdmp_tci_data.min_variables_values[1]),
+      min(min(get(dg_mag_tilde_b)), rdmp_tci_data.min_variables_values[2])};
+
+  cell_is_troubled |= evolution::dg::subcell::rdmp_tci(
+      rdmp_tci_data_for_check.max_variables_values,
+      rdmp_tci_data_for_check.min_variables_values,
+      past_rdmp_tci_data.max_variables_values,
+      past_rdmp_tci_data.min_variables_values, subcell_options.rdmp_delta0(),
+      subcell_options.rdmp_epsilon());
+
   if (tci_options.magnetic_field_cutoff.has_value() and not cell_is_troubled) {
-    const Scalar<DataVector> tilde_b_magnitude = magnitude(tilde_b);
-    cell_is_troubled = (max(get(tilde_b_magnitude)) >
+    cell_is_troubled = (max(get(dg_mag_tilde_b)) >
                             tci_options.magnetic_field_cutoff.value() and
                         evolution::dg::subcell::persson_tci(
-                            tilde_b_magnitude, dg_mesh, persson_exponent));
+                            dg_mag_tilde_b, dg_mesh, persson_exponent));
   }
-  return cell_is_troubled;
+
+  return {cell_is_troubled, rdmp_tci_data};
 }
 }  // namespace grmhd::ValenciaDivClean::subcell

--- a/src/Evolution/Systems/NewtonianEuler/FiniteDifference/ReconstructWork.tpp
+++ b/src/Evolution/Systems/NewtonianEuler/FiniteDifference/ReconstructWork.tpp
@@ -97,6 +97,12 @@ void reconstruct_prims_work(
                  "got "
                      << neighbors_in_direction.size() << " in direction "
                      << direction);
+          ASSERT(
+              not neighbor_data
+                      .at(std::pair{direction, *neighbors_in_direction.begin()})
+                      .empty(),
+              "The neighber data is empty in direction "
+                  << direction << " on element id " << element.id());
           ghost_cell_vars[direction] = gsl::make_span(
               &neighbor_data.at(std::pair{
                   direction,

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/InitialDataTci.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/InitialDataTci.cpp
@@ -8,32 +8,70 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Evolution/DgSubcell/ActiveGrid.hpp"
 #include "Evolution/DgSubcell/PerssonTci.hpp"
+#include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/DgSubcell/TwoMeshRdmpTci.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
 namespace NewtonianEuler::subcell {
 template <size_t Dim>
-bool DgInitialDataTci<Dim>::apply(
+std::tuple<bool, evolution::dg::subcell::RdmpTciData>
+DgInitialDataTci<Dim>::apply(
     const Variables<
         tmpl::list<MassDensityCons, MomentumDensity, EnergyDensity>>& dg_vars,
-    const Variables<
-        tmpl::list<Inactive<MassDensityCons>, Inactive<MomentumDensity>,
-                   Inactive<EnergyDensity>>>& subcell_vars,
     const double rdmp_delta0, const double rdmp_epsilon,
     const double persson_exponent, const Mesh<Dim>& dg_mesh,
-    const Scalar<DataVector>& dg_pressure) {
-  return evolution::dg::subcell::two_mesh_rdmp_tci(dg_vars, subcell_vars,
-                                                   rdmp_delta0, rdmp_epsilon) or
-         evolution::dg::subcell::persson_tci(get<MassDensityCons>(dg_vars),
-                                             dg_mesh, persson_exponent) or
-         evolution::dg::subcell::persson_tci(dg_pressure, dg_mesh,
-                                             persson_exponent);
+    const Mesh<Dim>& subcell_mesh) {
+  const auto subcell_vars = evolution::dg::subcell::fd::project(
+      dg_vars, dg_mesh, subcell_mesh.extents());
+
+  const Scalar<DataVector>& subcell_mass_density =
+      get<MassDensityCons>(subcell_vars);
+  const Scalar<DataVector>& subcell_energy_density =
+      get<EnergyDensity>(subcell_vars);
+  const Scalar<DataVector>& dg_mass_density = get<MassDensityCons>(dg_vars);
+  const Scalar<DataVector>& dg_energy_density = get<EnergyDensity>(dg_vars);
+
+  using std::max;
+  using std::min;
+  evolution::dg::subcell::RdmpTciData rdmp_tci_data{
+      {max(max(get(dg_mass_density)), max(get(subcell_mass_density))),
+       max(max(get(dg_energy_density)), max(get(subcell_energy_density)))},
+      {min(min(get(dg_mass_density)), min(get(subcell_mass_density))),
+       min(min(get(dg_energy_density)), min(get(subcell_energy_density)))}};
+
+  return {evolution::dg::subcell::two_mesh_rdmp_tci(
+              dg_vars, subcell_vars, rdmp_delta0, rdmp_epsilon) or
+              evolution::dg::subcell::persson_tci(dg_mass_density, dg_mesh,
+                                                  persson_exponent) or
+              evolution::dg::subcell::persson_tci(dg_energy_density, dg_mesh,
+                                                  persson_exponent),
+          std::move(rdmp_tci_data)};
+}
+
+template <size_t Dim>
+void SetInitialRdmpData<Dim>::apply(
+    const gsl::not_null<evolution::dg::subcell::RdmpTciData*> rdmp_tci_data,
+    const Variables<tmpl::list<MassDensityCons, MomentumDensity,
+                               EnergyDensity>>& subcell_vars,
+    const evolution::dg::subcell::ActiveGrid active_grid) {
+  if (active_grid == evolution::dg::subcell::ActiveGrid::Subcell) {
+    const Scalar<DataVector>& subcell_mass_density =
+        get<MassDensityCons>(subcell_vars);
+    const Scalar<DataVector>& subcell_energy_density =
+        get<EnergyDensity>(subcell_vars);
+    *rdmp_tci_data = {
+        {max(get(subcell_mass_density)), max(get(subcell_energy_density))},
+        {min(get(subcell_mass_density)), min(get(subcell_energy_density))}};
+  }
 }
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
-#define INSTANTIATION(r, data) template struct DgInitialDataTci<DIM(data)>;
+#define INSTANTIATION(r, data)                 \
+  template struct DgInitialDataTci<DIM(data)>; \
+  template struct SetInitialRdmpData<DIM(data)>;
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 #undef INSTANTIATION
 #undef DIM

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/InitialDataTci.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/InitialDataTci.hpp
@@ -7,7 +7,10 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/Tags.hpp"
-#include "Evolution/DgSubcell/Tags/Inactive.hpp"
+#include "Evolution/DgSubcell/RdmpTciData.hpp"
+#include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Tags/DataForRdmpTci.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/Systems/NewtonianEuler/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -25,7 +28,7 @@ namespace NewtonianEuler::subcell {
  * to switch to subcell.
  *
  * Uses the two-mesh relaxed discrete maximum principle as well as the Persson
- * TCI applied to the mass density and pressure.
+ * TCI applied to the mass density and energy density.
  */
 template <size_t Dim>
 struct DgInitialDataTci {
@@ -33,20 +36,39 @@ struct DgInitialDataTci {
   using MassDensityCons = NewtonianEuler::Tags::MassDensityCons;
   using EnergyDensity = NewtonianEuler::Tags::EnergyDensity;
   using MomentumDensity = NewtonianEuler::Tags::MomentumDensity<Dim>;
-  using Pressure = NewtonianEuler::Tags::Pressure<DataVector>;
-  template <typename Tag>
-  using Inactive = evolution::dg::subcell::Tags::Inactive<Tag>;
 
  public:
-  using argument_tags = tmpl::list<domain::Tags::Mesh<Dim>, Pressure>;
+  using argument_tags = tmpl::list<domain::Tags::Mesh<Dim>,
+                                   evolution::dg::subcell::Tags::Mesh<Dim>>;
 
-  static bool apply(
+  static std::tuple<bool, evolution::dg::subcell::RdmpTciData> apply(
       const Variables<
           tmpl::list<MassDensityCons, MomentumDensity, EnergyDensity>>& dg_vars,
-      const Variables<
-          tmpl::list<Inactive<MassDensityCons>, Inactive<MomentumDensity>,
-                     Inactive<EnergyDensity>>>& subcell_vars,
       double rdmp_delta0, double rdmp_epsilon, double persson_exponent,
-      const Mesh<Dim>& dg_mesh, const Scalar<DataVector>& dg_pressure);
+      const Mesh<Dim>& dg_mesh, const Mesh<Dim>& subcell_mesh);
+};
+
+/// \brief Sets the initial RDMP data.
+///
+/// Used on the subcells after the TCI marked the DG solution as inadmissible.
+template <size_t Dim>
+struct SetInitialRdmpData {
+ private:
+  using MassDensityCons = NewtonianEuler::Tags::MassDensityCons;
+  using EnergyDensity = NewtonianEuler::Tags::EnergyDensity;
+  using MomentumDensity = NewtonianEuler::Tags::MomentumDensity<Dim>;
+
+ public:
+  using argument_tags =
+      tmpl::list<::Tags::Variables<tmpl::list<MassDensityCons, MomentumDensity,
+                                              EnergyDensity>>,
+                 evolution::dg::subcell::Tags::ActiveGrid>;
+  using return_tags = tmpl::list<evolution::dg::subcell::Tags::DataForRdmpTci>;
+
+  static void apply(
+      gsl::not_null<evolution::dg::subcell::RdmpTciData*> rdmp_tci_data,
+      const Variables<tmpl::list<MassDensityCons, MomentumDensity,
+                                 EnergyDensity>>& subcell_vars,
+      evolution::dg::subcell::ActiveGrid active_grid);
 };
 }  // namespace NewtonianEuler::subcell

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnDgGrid.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnDgGrid.cpp
@@ -3,12 +3,15 @@
 
 #include "Evolution/Systems/NewtonianEuler/Subcell/TciOnDgGrid.hpp"
 
+#include <algorithm>
 #include <cstddef>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Evolution/DgSubcell/PerssonTci.hpp"
+#include "Evolution/DgSubcell/Projection.hpp"
+#include "Evolution/DgSubcell/RdmpTci.hpp"
 #include "Evolution/Systems/NewtonianEuler/PrimitiveFromConservative.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
@@ -19,27 +22,59 @@
 namespace NewtonianEuler::subcell {
 template <size_t Dim>
 template <size_t ThermodynamicDim>
-bool TciOnDgGrid<Dim>::apply(
+std::tuple<bool, evolution::dg::subcell::RdmpTciData> TciOnDgGrid<Dim>::apply(
     const gsl::not_null<Variables<
         tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>>*>
         dg_prim_vars,
-    const Scalar<DataVector>& mass_density,
-    const tnsr::I<DataVector, Dim, Frame::Inertial>& momentum_density,
-    const Scalar<DataVector>& energy_density,
+    const Variables<
+        tmpl::list<MassDensityCons, MomentumDensity, EnergyDensity>>& dg_vars,
     const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
-    const Mesh<Dim>& dg_mesh, const double persson_exponent) {
+    const Mesh<Dim>& dg_mesh, const Mesh<Dim>& subcell_mesh,
+    const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
+    const evolution::dg::subcell::SubcellOptions& subcell_options,
+    const double persson_exponent) {
+  const Variables<tmpl::list<MassDensityCons, MomentumDensity, EnergyDensity>>
+      subcell_vars = evolution::dg::subcell::fd::project(
+          dg_vars, dg_mesh, subcell_mesh.extents());
+  const Scalar<DataVector>& mass_density = get<MassDensityCons>(dg_vars);
+  const tnsr::I<DataVector, Dim, Frame::Inertial>& momentum_density =
+      get<MomentumDensity>(dg_vars);
+  const Scalar<DataVector>& energy_density = get<EnergyDensity>(dg_vars);
+
+  const Scalar<DataVector>& subcell_mass_density =
+      get<MassDensityCons>(subcell_vars);
+  const Scalar<DataVector>& subcell_energy_density =
+      get<EnergyDensity>(subcell_vars);
+
+  using std::max;
+  using std::min;
+  evolution::dg::subcell::RdmpTciData rdmp_tci_data{
+      {max(max(get(mass_density)), max(get(subcell_mass_density))),
+       max(max(get(energy_density)), max(get(subcell_energy_density)))},
+      {min(min(get(mass_density)), min(get(subcell_mass_density))),
+       min(min(get(energy_density)), min(get(subcell_energy_density)))}};
+
   NewtonianEuler::PrimitiveFromConservative<Dim>::apply(
       make_not_null(&get<MassDensity>(*dg_prim_vars)),
       make_not_null(&get<Velocity>(*dg_prim_vars)),
       make_not_null(&get<SpecificInternalEnergy>(*dg_prim_vars)),
       make_not_null(&get<Pressure>(*dg_prim_vars)), mass_density,
       momentum_density, energy_density, eos);
-  return min(get(mass_density)) < min_density_allowed or
-         min(get(get<Pressure>(*dg_prim_vars))) < min_pressure_allowed or
-         evolution::dg::subcell::persson_tci(mass_density, dg_mesh,
-                                             persson_exponent) or
-         evolution::dg::subcell::persson_tci(get<Pressure>(*dg_prim_vars),
-                                             dg_mesh, persson_exponent);
+
+  const bool cell_is_troubled =
+      evolution::dg::subcell::rdmp_tci(rdmp_tci_data.max_variables_values,
+                                       rdmp_tci_data.min_variables_values,
+                                       past_rdmp_tci_data.max_variables_values,
+                                       past_rdmp_tci_data.min_variables_values,
+                                       subcell_options.rdmp_delta0(),
+                                       subcell_options.rdmp_epsilon()) or
+      min(get(mass_density)) < min_density_allowed or
+      min(get(get<Pressure>(*dg_prim_vars))) < min_pressure_allowed or
+      evolution::dg::subcell::persson_tci(mass_density, dg_mesh,
+                                          persson_exponent) or
+      evolution::dg::subcell::persson_tci(energy_density, dg_mesh,
+                                          persson_exponent);
+  return {cell_is_troubled, std::move(rdmp_tci_data)};
 }
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
@@ -48,16 +83,21 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 #undef INSTANTIATION
 
 #define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
-#define INSTANTIATION(r, data)                                                 \
-  template bool TciOnDgGrid<DIM(data)>::apply<THERMO_DIM(data)>(               \
-      const gsl::not_null<Variables<tmpl::list<                                \
-          MassDensity, Velocity, SpecificInternalEnergy, Pressure>>*>          \
-          dg_prim_vars,                                                        \
-      const Scalar<DataVector>& mass_density,                                  \
-      const tnsr::I<DataVector, DIM(data), Frame::Inertial>& momentum_density, \
-      const Scalar<DataVector>& energy_density,                                \
-      const EquationsOfState::EquationOfState<false, THERMO_DIM(data)>& eos,   \
-      const Mesh<DIM(data)>& dg_mesh, const double persson_exponent);
+#define INSTANTIATION(r, data)                                                \
+  template std::tuple<bool, evolution::dg::subcell::RdmpTciData>              \
+  TciOnDgGrid<DIM(data)>::apply<THERMO_DIM(data)>(                            \
+      gsl::not_null<Variables<tmpl::list<MassDensity, Velocity,               \
+                                         SpecificInternalEnergy, Pressure>>*> \
+          dg_prim_vars,                                                       \
+      const Variables<                                                        \
+          tmpl::list<NewtonianEuler::Tags::MassDensityCons,                   \
+                     NewtonianEuler::Tags::MomentumDensity<DIM(data)>,        \
+                     NewtonianEuler::Tags::EnergyDensity>>& dg_vars,          \
+      const EquationsOfState::EquationOfState<false, THERMO_DIM(data)>& eos,  \
+      const Mesh<DIM(data)>& dg_mesh, const Mesh<DIM(data)>& subcell_mesh,    \
+      const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,          \
+      const evolution::dg::subcell::SubcellOptions& subcell_options,          \
+      double persson_exponent);
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2))
 #undef INSTANTIATION
 #undef THERMO_DIM

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnDgGrid.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnDgGrid.hpp
@@ -4,11 +4,15 @@
 #pragma once
 
 #include <cstddef>
+#include <tuple>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Domain/Tags.hpp"
-#include "Evolution/DgSubcell/Tags/Inactive.hpp"
+#include "Evolution/DgSubcell/RdmpTciData.hpp"
+#include "Evolution/DgSubcell/Tags/DataForRdmpTci.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
 #include "Evolution/Systems/NewtonianEuler/Tags.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
@@ -36,12 +40,13 @@ namespace NewtonianEuler::subcell {
  *
  * Computes the primitive variables on the DG grid, mutating them in the
  * DataBox. Then,
+ * - apply RDMP TCI to the mass and energy density
  * - if the minimum density or pressure are below \f$10^{-18}\f$ (the arbitrary
  *   threshold used to signal "negative" density and pressure), marks the
  *   element as troubled and returns
- * - runs the Persson TCI on the density and pressure. The reason for applying
- *   the Persson TCI to both the density and pressure is to flag cells at
- *   contact discontinuities.
+ * - runs the Persson TCI on the mass and energy density. The reason for
+ *   applying the Persson TCI to both the mass and energy density is to flag
+ *   cells at contact discontinuities.
  */
 template <size_t Dim>
 class TciOnDgGrid {
@@ -63,18 +68,24 @@ class TciOnDgGrid {
   using return_tags = tmpl::list<::Tags::Variables<
       tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>>>;
   using argument_tags =
-      tmpl::list<MassDensityCons, MomentumDensity, EnergyDensity,
-                 hydro::Tags::EquationOfStateBase, domain::Tags::Mesh<Dim>>;
+      tmpl::list<::Tags::Variables<tmpl::list<MassDensityCons, MomentumDensity,
+                                              EnergyDensity>>,
+                 hydro::Tags::EquationOfStateBase, domain::Tags::Mesh<Dim>,
+                 evolution::dg::subcell::Tags::Mesh<Dim>,
+                 evolution::dg::subcell::Tags::DataForRdmpTci,
+                 evolution::dg::subcell::Tags::SubcellOptions>;
 
   template <size_t ThermodynamicDim>
-  static bool apply(
-      const gsl::not_null<Variables<
+  static std::tuple<bool, evolution::dg::subcell::RdmpTciData> apply(
+      gsl::not_null<Variables<
           tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>>*>
           dg_prim_vars,
-      const Scalar<DataVector>& mass_density,
-      const tnsr::I<DataVector, Dim, Frame::Inertial>& momentum_density,
-      const Scalar<DataVector>& energy_density,
+      const Variables<
+          tmpl::list<MassDensityCons, MomentumDensity, EnergyDensity>>& dg_vars,
       const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
-      const Mesh<Dim>& dg_mesh, const double persson_exponent);
+      const Mesh<Dim>& dg_mesh, const Mesh<Dim>& subcell_mesh,
+      const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
+      const evolution::dg::subcell::SubcellOptions& subcell_options,
+      double persson_exponent);
 };
 }  // namespace NewtonianEuler::subcell

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnFdGrid.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnFdGrid.hpp
@@ -4,11 +4,16 @@
 #pragma once
 
 #include <cstddef>
+#include <tuple>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/RdmpTciData.hpp"
+#include "Evolution/DgSubcell/Tags/DataForRdmpTci.hpp"
 #include "Evolution/DgSubcell/Tags/Inactive.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
 #include "Evolution/Systems/NewtonianEuler/Tags.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
@@ -33,14 +38,15 @@ namespace NewtonianEuler::subcell {
  *
  * Computes the primitive variables on the DG and subcell grids, mutating the
  * subcell/active primitive variables in the DataBox. Then,
+ * - apply RDMP TCI to the mass and energy density
  * - if the minimum density or pressure on either the DG or subcell mesh are
  *   below \f$10^{-18}\f$, marks the element as troubled and returns. We check
  *   both the FD and DG grids since when a discontinuity is inside the element
  *   oscillations in the DG solution can result in negative values that aren't
  *   present in the FD solution.
- * - runs the Persson TCI on the density and pressure on the DG grid. The reason
- *   for applying the Persson TCI to both the density and pressure is to flag
- *   cells at contact discontinuities. The Persson TCI only works with
+ * - runs the Persson TCI on the mass and energy density on the DG grid. The
+ *   reason for applying the Persson TCI to both the mass and energy density is
+ *   to flag cells at contact discontinuities. The Persson TCI only works with
  *   spectral-type methods and is a direct check of whether or not the DG
  *   solution is a good representation of the underlying data.
  *
@@ -61,9 +67,6 @@ class TciOnFdGrid {
       NewtonianEuler::Tags::SpecificInternalEnergy<DataVector>;
   using Pressure = NewtonianEuler::Tags::Pressure<DataVector>;
 
-  template <typename Tag>
-  using Inactive = evolution::dg::subcell::Tags::Inactive<Tag>;
-
   static constexpr double min_density_allowed = 1.0e-18;
   static constexpr double min_pressure_allowed = 1.0e-18;
 
@@ -71,23 +74,24 @@ class TciOnFdGrid {
   using return_tags = tmpl::list<::Tags::Variables<
       tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>>>;
   using argument_tags =
-      tmpl::list<MassDensityCons, MomentumDensity, EnergyDensity,
-                 Inactive<MassDensityCons>, Inactive<MomentumDensity>,
-                 Inactive<EnergyDensity>, hydro::Tags::EquationOfStateBase,
-                 domain::Tags::Mesh<Dim>>;
+      tmpl::list<::Tags::Variables<tmpl::list<MassDensityCons, MomentumDensity,
+                                              EnergyDensity>>,
+                 hydro::Tags::EquationOfStateBase, domain::Tags::Mesh<Dim>,
+                 evolution::dg::subcell::Tags::Mesh<Dim>,
+                 evolution::dg::subcell::Tags::DataForRdmpTci,
+                 evolution::dg::subcell::Tags::SubcellOptions>;
 
   template <size_t ThermodynamicDim>
-  static bool apply(
+  static std::tuple<bool, evolution::dg::subcell::RdmpTciData> apply(
       gsl::not_null<Variables<
           tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>>*>
           subcell_grid_prim_vars,
-      const Scalar<DataVector>& subcell_mass_density,
-      const tnsr::I<DataVector, Dim, Frame::Inertial>& subcell_momentum_density,
-      const Scalar<DataVector>& subcell_energy_density,
-      const Scalar<DataVector>& dg_mass_density,
-      const tnsr::I<DataVector, Dim, Frame::Inertial>& dg_momentum_density,
-      const Scalar<DataVector>& dg_energy_density,
+      const Variables<tmpl::list<MassDensityCons, MomentumDensity,
+                                 EnergyDensity>>& subcell_vars,
       const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
-      const Mesh<Dim>& dg_mesh, double persson_exponent);
+      const Mesh<Dim>& dg_mesh, const Mesh<Dim>& subcell_mesh,
+      const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
+      const evolution::dg::subcell::SubcellOptions& subcell_options,
+      double persson_exponent);
 };
 }  // namespace NewtonianEuler::subcell

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/ReconstructWork.tpp
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/ReconstructWork.tpp
@@ -78,6 +78,11 @@ void reconstruct_work(
            "got "
                << neighbors_in_direction.size() << " in direction "
                << direction);
+    ASSERT(not neighbor_data
+                   .at(std::pair{direction, *neighbors_in_direction.begin()})
+                   .empty(),
+           "The neighber data is empty in direction "
+               << direction << " on element id " << element.id());
 
     ghost_cell_vars[direction] =
         gsl::make_span(&neighbor_data.at(std::pair{

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/InitialDataTci.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/InitialDataTci.cpp
@@ -5,24 +5,47 @@
 
 #include <cstddef>
 
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Evolution/DgSubcell/PerssonTci.hpp"
+#include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/DgSubcell/TwoMeshRdmpTci.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
 namespace ScalarAdvection::subcell {
 template <size_t Dim>
-bool DgInitialDataTci<Dim>::apply(
+std::tuple<bool, evolution::dg::subcell::RdmpTciData>
+DgInitialDataTci<Dim>::apply(
     const Variables<tmpl::list<ScalarAdvection::Tags::U>>& dg_vars,
-    const Variables<tmpl::list<Inactive<ScalarAdvection::Tags::U>>>&
-        subcell_vars,
     double rdmp_delta0, double rdmp_epsilon, double persson_exponent,
-    const Mesh<Dim>& dg_mesh) {
-  return evolution::dg::subcell::persson_tci(
-             get<ScalarAdvection::Tags::U>(dg_vars), dg_mesh,
-             persson_exponent) or
-         evolution::dg::subcell::two_mesh_rdmp_tci(dg_vars, subcell_vars,
-                                                   rdmp_delta0, rdmp_epsilon);
+    const Mesh<Dim>& dg_mesh, const Mesh<Dim>& subcell_mesh) {
+  const auto subcell_vars = evolution::dg::subcell::fd::project(
+      dg_vars, dg_mesh, subcell_mesh.extents());
+
+  const auto& dg_u = get<ScalarAdvection::Tags::U>(dg_vars);
+  const auto& subcell_u = get<ScalarAdvection::Tags::U>(subcell_vars);
+  using std::max;
+  using std::min;
+  evolution::dg::subcell::RdmpTciData rdmp_tci_data{
+      {max(max(get(dg_u)), max(get(subcell_u)))},
+      {min(min(get(dg_u)), min(get(subcell_u)))}};
+
+  return {evolution::dg::subcell::two_mesh_rdmp_tci(
+              dg_vars, subcell_vars, rdmp_delta0, rdmp_epsilon) or
+              evolution::dg::subcell::persson_tci(
+                  get<ScalarAdvection::Tags::U>(dg_vars), dg_mesh,
+                  persson_exponent),
+          std::move(rdmp_tci_data)};
+}
+
+void SetInitialRdmpData::apply(
+    const gsl::not_null<evolution::dg::subcell::RdmpTciData*> rdmp_tci_data,
+    const Scalar<DataVector>& subcell_u,
+    const evolution::dg::subcell::ActiveGrid active_grid) {
+  if (active_grid == evolution::dg::subcell::ActiveGrid::Subcell) {
+    *rdmp_tci_data = {{max(get(subcell_u))}, {min(get(subcell_u))}};
+  }
 }
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/InitialDataTci.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/InitialDataTci.hpp
@@ -4,10 +4,15 @@
 #pragma once
 
 #include <cstddef>
+#include <tuple>
 
 #include "Domain/Tags.hpp"
-#include "Evolution/DgSubcell/Tags/Inactive.hpp"
+#include "Evolution/DgSubcell/RdmpTciData.hpp"
+#include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Tags/DataForRdmpTci.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/Systems/ScalarAdvection/Tags.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -27,18 +32,26 @@ namespace ScalarAdvection::subcell {
  */
 template <size_t Dim>
 struct DgInitialDataTci {
- private:
-  template <typename Tag>
-  using Inactive = evolution::dg::subcell::Tags::Inactive<Tag>;
+  using argument_tags = tmpl::list<domain::Tags::Mesh<Dim>,
+                                   evolution::dg::subcell::Tags::Mesh<Dim>>;
 
- public:
-  using argument_tags = tmpl::list<domain::Tags::Mesh<Dim>>;
-
-  static bool apply(
+  static std::tuple<bool, evolution::dg::subcell::RdmpTciData> apply(
       const Variables<tmpl::list<ScalarAdvection::Tags::U>>& dg_vars,
-      const Variables<tmpl::list<Inactive<ScalarAdvection::Tags::U>>>&
-          subcell_vars,
       double rdmp_delta0, double rdmp_epsilon, double persson_exponent,
-      const Mesh<Dim>& dg_mesh);
+      const Mesh<Dim>& dg_mesh, const Mesh<Dim>& subcell_mesh);
+};
+
+/// \brief Sets the initial RDMP data.
+///
+/// Used on the subcells after the TCI marked the DG solution as inadmissible.
+struct SetInitialRdmpData {
+  using argument_tags = tmpl::list<ScalarAdvection::Tags::U,
+                                   evolution::dg::subcell::Tags::ActiveGrid>;
+  using return_tags = tmpl::list<evolution::dg::subcell::Tags::DataForRdmpTci>;
+
+  static void apply(
+      gsl::not_null<evolution::dg::subcell::RdmpTciData*> rdmp_tci_data,
+      const Scalar<DataVector>& subcell_u,
+      evolution::dg::subcell::ActiveGrid active_grid);
 };
 }  // namespace ScalarAdvection::subcell

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/TciOnDgGrid.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/TciOnDgGrid.cpp
@@ -3,17 +3,43 @@
 
 #include "Evolution/Systems/ScalarAdvection/Subcell/TciOnDgGrid.hpp"
 
+#include <algorithm>
 #include <cstddef>
 
 #include "Evolution/DgSubcell/PerssonTci.hpp"
+#include "Evolution/DgSubcell/Projection.hpp"
+#include "Evolution/DgSubcell/RdmpTci.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
 namespace ScalarAdvection::subcell {
 template <size_t Dim>
-bool TciOnDgGrid<Dim>::apply(const Scalar<DataVector>& dg_u,
-                             const Mesh<Dim>& dg_mesh,
-                             const double persson_exponent) {
-  return ::evolution::dg::subcell::persson_tci(dg_u, dg_mesh, persson_exponent);
+std::tuple<bool, evolution::dg::subcell::RdmpTciData> TciOnDgGrid<Dim>::apply(
+    const Scalar<DataVector>& dg_u, const Mesh<Dim>& dg_mesh,
+    const Mesh<Dim>& subcell_mesh,
+    const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
+    const evolution::dg::subcell::SubcellOptions& subcell_options,
+    const double persson_exponent) {
+  // Don't use buffer since we have only one memory allocation right now (until
+  // persson_tci can use a buffer)
+  const Scalar<DataVector> subcell_u{::evolution::dg::subcell::fd::project(
+      get(dg_u), dg_mesh, subcell_mesh.extents())};
+
+  using std::max;
+  using std::min;
+  evolution::dg::subcell::RdmpTciData rdmp_tci_data{
+      {max(max(get(dg_u)), max(get(subcell_u)))},
+      {min(min(get(dg_u)), min(get(subcell_u)))}};
+
+  const bool cell_is_troubled =
+      evolution::dg::subcell::rdmp_tci(rdmp_tci_data.max_variables_values,
+                                       rdmp_tci_data.min_variables_values,
+                                       past_rdmp_tci_data.max_variables_values,
+                                       past_rdmp_tci_data.min_variables_values,
+                                       subcell_options.rdmp_delta0(),
+                                       subcell_options.rdmp_epsilon()) or
+      ::evolution::dg::subcell::persson_tci(dg_u, dg_mesh, persson_exponent);
+
+  return {cell_is_troubled, std::move(rdmp_tci_data)};
 }
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/TciOnDgGrid.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/TciOnDgGrid.hpp
@@ -4,9 +4,14 @@
 #pragma once
 
 #include <cstddef>
+#include <tuple>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/RdmpTciData.hpp"
+#include "Evolution/DgSubcell/Tags/DataForRdmpTci.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
 #include "Evolution/Systems/ScalarAdvection/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -21,16 +26,23 @@ namespace ScalarAdvection::subcell {
  * \brief The troubled-cell indicator run on the DG grid to check if the
  * solution is admissible.
  *
- * Applies the Persson TCI to \f$U\f$.
+ * Applies the Persson and RDMP TCI to \f$U\f$.
  */
 template <size_t Dim>
 struct TciOnDgGrid {
  public:
   using return_tags = tmpl::list<>;
   using argument_tags =
-      tmpl::list<ScalarAdvection::Tags::U, ::domain::Tags::Mesh<Dim>>;
+      tmpl::list<ScalarAdvection::Tags::U, ::domain::Tags::Mesh<Dim>,
+                 evolution::dg::subcell::Tags::Mesh<Dim>,
+                 evolution::dg::subcell::Tags::DataForRdmpTci,
+                 evolution::dg::subcell::Tags::SubcellOptions>;
 
-  static bool apply(const Scalar<DataVector>& dg_u, const Mesh<Dim>& dg_mesh,
-                    const double persson_exponent);
+  static std::tuple<bool, evolution::dg::subcell::RdmpTciData> apply(
+      const Scalar<DataVector>& dg_u, const Mesh<Dim>& dg_mesh,
+      const Mesh<Dim>& subcell_mesh,
+      const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
+      const evolution::dg::subcell::SubcellOptions& subcell_options,
+      double persson_exponent);
 };
 }  // namespace ScalarAdvection::subcell

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/TciOnFdGrid.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/TciOnFdGrid.cpp
@@ -3,17 +3,42 @@
 
 #include "Evolution/Systems/ScalarAdvection/Subcell/TciOnFdGrid.hpp"
 
+#include <algorithm>
 #include <cstddef>
 
 #include "Evolution/DgSubcell/PerssonTci.hpp"
+#include "Evolution/DgSubcell/RdmpTci.hpp"
+#include "Evolution/DgSubcell/Reconstruction.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
 namespace ScalarAdvection::subcell {
 template <size_t Dim>
-bool TciOnFdGrid<Dim>::apply(const Scalar<DataVector>& dg_u,
-                             const Mesh<Dim>& dg_mesh,
-                             const double persson_exponent) {
-  return ::evolution::dg::subcell::persson_tci(dg_u, dg_mesh, persson_exponent);
+std::tuple<bool, evolution::dg::subcell::RdmpTciData> TciOnFdGrid<Dim>::apply(
+    const Scalar<DataVector>& subcell_u, const Mesh<Dim>& dg_mesh,
+    const Mesh<Dim>& subcell_mesh,
+    const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
+    const evolution::dg::subcell::SubcellOptions& subcell_options,
+    const double persson_exponent) {
+  const Scalar<DataVector> dg_u{evolution::dg::subcell::fd::reconstruct(
+      get(subcell_u), dg_mesh, subcell_mesh.extents(),
+      evolution::dg::subcell::fd::ReconstructionMethod::DimByDim)};
+
+  using std::max;
+  using std::min;
+  const evolution::dg::subcell::RdmpTciData rdmp_data_for_tci{
+      {max(max(get(dg_u)), max(get(subcell_u)))},
+      {min(min(get(dg_u)), min(get(subcell_u)))}};
+
+  const bool cell_is_troubled = evolution::dg::subcell::rdmp_tci(
+      rdmp_data_for_tci.max_variables_values,
+      rdmp_data_for_tci.min_variables_values,
+      past_rdmp_tci_data.max_variables_values,
+      past_rdmp_tci_data.min_variables_values, subcell_options.rdmp_delta0(),
+      subcell_options.rdmp_epsilon());
+
+  return {cell_is_troubled or ::evolution::dg::subcell::persson_tci(
+                                  dg_u, dg_mesh, persson_exponent),
+          {{max(get(subcell_u))}, {min(get(subcell_u))}}};
 }
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/TciOnFdGrid.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/TciOnFdGrid.hpp
@@ -4,10 +4,14 @@
 #pragma once
 
 #include <cstddef>
+#include <tuple>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/Tags.hpp"
-#include "Evolution/DgSubcell/Tags/Inactive.hpp"
+#include "Evolution/DgSubcell/RdmpTciData.hpp"
+#include "Evolution/DgSubcell/Tags/DataForRdmpTci.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
 #include "Evolution/Systems/ScalarAdvection/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -22,24 +26,22 @@ namespace ScalarAdvection::subcell {
  * \brief Troubled-cell indicator applied to the finite difference subcell
  * solution to check if the corresponding DG solution is admissible.
  *
- * Applies the Persson TCI to \f$U\f$ on the DG grid.
- *
- * \note TCI is run after reconstructing the solution to the DG grid during the
- * subcell(FD) time stepping procedure, therefore `Inactive<Tag>` is the
- * updated DG solution.
+ * Applies the Persson and RDMP TCI to \f$U\f$.
  */
 template <size_t Dim>
 struct TciOnFdGrid {
- private:
-  template <typename Tag>
-  using Inactive = ::evolution::dg::subcell::Tags::Inactive<Tag>;
-
- public:
   using return_tags = tmpl::list<>;
   using argument_tags =
-      tmpl::list<Inactive<ScalarAdvection::Tags::U>, ::domain::Tags::Mesh<Dim>>;
+      tmpl::list<ScalarAdvection::Tags::U, ::domain::Tags::Mesh<Dim>,
+                 evolution::dg::subcell::Tags::Mesh<Dim>,
+                 evolution::dg::subcell::Tags::DataForRdmpTci,
+                 evolution::dg::subcell::Tags::SubcellOptions>;
 
-  static bool apply(const Scalar<DataVector>& dg_u, const Mesh<Dim>& dg_mesh,
-                    const double persson_exponent);
+  static std::tuple<bool, evolution::dg::subcell::RdmpTciData> apply(
+      const Scalar<DataVector>& subcell_u, const Mesh<Dim>& dg_mesh,
+      const Mesh<Dim>& subcell_mesh,
+      const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
+      const evolution::dg::subcell::SubcellOptions& subcell_options,
+      double persson_exponent);
 };
 }  // namespace ScalarAdvection::subcell

--- a/tests/Unit/Evolution/Systems/Burgers/Subcell/Test_InitialDataTci.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/Subcell/Test_InitialDataTci.cpp
@@ -6,30 +6,23 @@
 #include <cstddef>
 
 #include "DataStructures/Variables.hpp"
+#include "Evolution/DgSubcell/ActiveGrid.hpp"
 #include "Evolution/DgSubcell/Mesh.hpp"
-#include "Evolution/DgSubcell/Tags/Inactive.hpp"
+#include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/Systems/Burgers/Subcell/InitialDataTci.hpp"
 #include "Evolution/Systems/Burgers/Tags.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Utilities/TMPL.hpp"
 
-namespace {
-template <typename Tag>
-using Inactive = evolution::dg::subcell::Tags::Inactive<Tag>;
-}  // namespace
-
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Burgers.Subcell.InitialDataTci",
                   "[Unit][Evolution]") {
   using Vars = Variables<tmpl::list<Burgers::Tags::U>>;
-  using InactiveVars = Variables<tmpl::list<Inactive<Burgers::Tags::U>>>;
 
   const Mesh<1> dg_mesh{5, Spectral::Basis::Legendre,
                         Spectral::Quadrature::GaussLobatto};
   const Mesh<1> subcell_mesh = evolution::dg::subcell::fd::mesh(dg_mesh);
   const size_t number_of_dg_grid_points{dg_mesh.number_of_grid_points()};
-  const size_t number_of_subcell_grid_points{
-      subcell_mesh.number_of_grid_points()};
 
   Vars dg_vars{number_of_dg_grid_points, 1.0};
 
@@ -38,33 +31,71 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Burgers.Subcell.InitialDataTci",
   const double rdmp_delta0{1.0e-4};
   const double rdmp_epsilon{1.0e-3};
 
+  const auto compute_expected_rdmp_tci_data = [&dg_vars, &dg_mesh,
+                                               &subcell_mesh]() {
+    const auto subcell_vars = evolution::dg::subcell::fd::project(
+        dg_vars, dg_mesh, subcell_mesh.extents());
+    using std::max;
+    using std::min;
+    evolution::dg::subcell::RdmpTciData rdmp_tci_data{
+        {max(max(get(get<Burgers::Tags::U>(dg_vars))),
+             max(get(get<Burgers::Tags::U>(subcell_vars))))},
+        {min(min(get(get<Burgers::Tags::U>(dg_vars))),
+             min(get(get<Burgers::Tags::U>(subcell_vars))))}};
+    return rdmp_tci_data;
+  };
+
   {
     INFO("TCI is happy");
-    // set dg_vars == subcell_vars
-    const InactiveVars subcell_vars{number_of_subcell_grid_points, 1.0};
-    CHECK_FALSE(Burgers::subcell::DgInitialDataTci::apply(
-        dg_vars, subcell_vars, rdmp_delta0, rdmp_epsilon, persson_exponent,
-        dg_mesh));
+    const auto result = Burgers::subcell::DgInitialDataTci::apply(
+        dg_vars, rdmp_delta0, rdmp_epsilon, persson_exponent, dg_mesh,
+        subcell_mesh);
+    CHECK_FALSE(std::get<0>(result));
+    CHECK(std::get<1>(result) == compute_expected_rdmp_tci_data());
   }
 
   {
     INFO("Two mesh RDMP fails");
-    // set subcell_vars to be smooth but quite different from dg_vars
-    const InactiveVars subcell_vars{number_of_subcell_grid_points, 2.0};
-    CHECK(Burgers::subcell::DgInitialDataTci::apply(dg_vars, subcell_vars,
-                                                    rdmp_delta0, rdmp_epsilon,
-                                                    persson_exponent, dg_mesh));
+    // Test that the 2-mesh RDMP fails be setting an absurdly small epsilon
+    // and delta_0 tolerance.
+    get(get<Burgers::Tags::U>(dg_vars))[dg_mesh.number_of_grid_points() / 2] *=
+        1.0 + std::numeric_limits<double>::epsilon() * 2.0;
+    const auto result = Burgers::subcell::DgInitialDataTci::apply(
+        dg_vars, 1.0e-100, 1.0e-18, persson_exponent, dg_mesh, subcell_mesh);
+    CHECK(std::get<0>(result));
+    CHECK(std::get<1>(result) == compute_expected_rdmp_tci_data());
+    get(get<Burgers::Tags::U>(dg_vars))[dg_mesh.number_of_grid_points() / 2] /=
+        1.0 + std::numeric_limits<double>::epsilon() * 2.0;
   }
 
   {
     INFO("Persson TCI fails");
-    InactiveVars subcell_vars{number_of_subcell_grid_points, 1.0};
     // set dg_vars to have a sharp peak
     get(get<Burgers::Tags::U>(dg_vars))[number_of_dg_grid_points / 2] += 1.0;
     // set rdmp_delta0 to be very large to ensure that it's the Persson TCI
     // which triggers alarm here
-    CHECK(Burgers::subcell::DgInitialDataTci::apply(dg_vars, subcell_vars,
-                                                    rdmp_delta0, rdmp_epsilon,
-                                                    persson_exponent, dg_mesh));
+    const auto result = Burgers::subcell::DgInitialDataTci::apply(
+        dg_vars, 1.0e100, rdmp_epsilon, persson_exponent, dg_mesh,
+        subcell_mesh);
+    CHECK(std::get<0>(result));
+    CHECK(std::get<1>(result) == compute_expected_rdmp_tci_data());
+  }
+
+  {
+    INFO("Test SetInitialRdmpData");
+    // While the code is supposed to be used on the subcells, that doesn't
+    // actually matter.
+    evolution::dg::subcell::RdmpTciData rdmp_data{};
+    Burgers::subcell::SetInitialRdmpData::apply(
+        make_not_null(&rdmp_data), get<Burgers::Tags::U>(dg_vars),
+        evolution::dg::subcell::ActiveGrid::Dg);
+    CHECK(rdmp_data == evolution::dg::subcell::RdmpTciData{});
+    Burgers::subcell::SetInitialRdmpData::apply(
+        make_not_null(&rdmp_data), get<Burgers::Tags::U>(dg_vars),
+        evolution::dg::subcell::ActiveGrid::Subcell);
+    const evolution::dg::subcell::RdmpTciData expected_rdmp_data{
+        {max(get(get<Burgers::Tags::U>(dg_vars)))},
+        {min(get(get<Burgers::Tags::U>(dg_vars)))}};
+    CHECK(rdmp_data == expected_rdmp_data);
   }
 }

--- a/tests/Unit/Evolution/Systems/Burgers/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/Subcell/Test_NeighborPackagedData.cpp
@@ -31,7 +31,6 @@
 #include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/DgSubcell/Reconstruction.hpp"
 #include "Evolution/DgSubcell/Tags/Coordinates.hpp"
-#include "Evolution/DgSubcell/Tags/Inactive.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/NeighborData.hpp"
 #include "Evolution/DiscontinuousGalerkin/Actions/NormalCovectorAndMagnitude.hpp"

--- a/tests/Unit/Evolution/Systems/Burgers/Subcell/Test_TciOnDgGrid.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/Subcell/Test_TciOnDgGrid.cpp
@@ -3,21 +3,26 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <algorithm>
 #include <cstddef>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
+#include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/Systems/Burgers/Subcell/TciOnDgGrid.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Burgers.Subcell.TciOnDgGrid",
                   "[Unit][Evolution]") {
-  enum class TestThis { AllGood, PerssonU };
+  enum class TestThis { AllGood, PerssonU, RdmpU };
 
-  for (const auto test_this : {TestThis::AllGood, TestThis::PerssonU}) {
+  for (const auto test_this :
+       {TestThis::AllGood, TestThis::PerssonU, TestThis::RdmpU}) {
     const Mesh<1> dg_mesh{5, Spectral::Basis::Legendre,
                           Spectral::Quadrature::GaussLobatto};
+    const Mesh<1> subcell_mesh = evolution::dg::subcell::fd::mesh(dg_mesh);
     const size_t number_of_points{dg_mesh.number_of_grid_points()};
 
     Scalar<DataVector> u{number_of_points, 1.0};
@@ -26,15 +31,45 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Burgers.Subcell.TciOnDgGrid",
       // make a troubled cell
       get(u)[number_of_points / 2] += 1.0;
     }
+    // Set the RDMP TCI past data.
+    using std::max;
+    using std::min;
+    evolution::dg::subcell::RdmpTciData past_rdmp_tci_data{
+        {max(max(get(u)), max(evolution::dg::subcell::fd::project(
+                              get(u), dg_mesh, subcell_mesh.extents())))},
+        {min(min(get(u)), min(evolution::dg::subcell::fd::project(
+                              get(u), dg_mesh, subcell_mesh.extents())))}};
+
+    const auto expected_rdmp_data = past_rdmp_tci_data;
+
+    if (test_this == TestThis::RdmpU) {
+      // Assumes min is positive, increase it so we fail the TCI
+      past_rdmp_tci_data.min_variables_values[0] *= 1.01;
+    }
 
     // check the result
     const double persson_exponent{4.0};
-    const bool result =
-        Burgers::subcell::TciOnDgGrid::apply(u, dg_mesh, persson_exponent);
+    const evolution::dg::subcell::SubcellOptions subcell_options{
+        1.0e-16,
+        1.0e-4,
+        1.0e-16,
+        1.0e-4,
+        persson_exponent,
+        persson_exponent,
+        false,
+        evolution::dg::subcell::fd::ReconstructionMethod::DimByDim};
+
+    const std::tuple<bool, evolution::dg::subcell::RdmpTciData> result =
+        Burgers::subcell::TciOnDgGrid::apply(u, dg_mesh, subcell_mesh,
+                                             past_rdmp_tci_data,
+                                             subcell_options, persson_exponent);
+
+    CHECK(std::get<1>(result) == expected_rdmp_data);
+
     if (test_this == TestThis::AllGood) {
-      CHECK_FALSE(result);
+      CHECK_FALSE(std::get<0>(result));
     } else {
-      CHECK(result);
+      CHECK(std::get<0>(result));
     }
   }
 }

--- a/tests/Unit/Evolution/Systems/Burgers/Subcell/Test_TciOnFdGrid.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/Subcell/Test_TciOnFdGrid.cpp
@@ -3,22 +3,27 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <algorithm>
 #include <cstddef>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
+#include "Evolution/DgSubcell/Reconstruction.hpp"
 #include "Evolution/Systems/Burgers/Subcell/TciOnFdGrid.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Burgers.Subcell.TciOnFdGrid",
                   "[Unit][Evolution]") {
-  enum class TestThis { AllGood, PerssonU };
+  enum class TestThis { AllGood, PerssonU, RdmpU };
 
-  for (const auto test_this : {TestThis::AllGood, TestThis::PerssonU}) {
+  for (const auto test_this :
+       {TestThis::AllGood, TestThis::PerssonU, TestThis::RdmpU}) {
     const Mesh<1> dg_mesh{5, Spectral::Basis::Legendre,
                           Spectral::Quadrature::GaussLobatto};
-    const size_t number_of_points{dg_mesh.number_of_grid_points()};
+    const Mesh<1> subcell_mesh = evolution::dg::subcell::fd::mesh(dg_mesh);
+    const size_t number_of_points{subcell_mesh.number_of_grid_points()};
 
     Scalar<DataVector> u{number_of_points, 1.0};
 
@@ -27,14 +32,48 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Burgers.Subcell.TciOnFdGrid",
       get(u)[number_of_points / 2] += 1.0;
     }
 
+    // Set the RDMP TCI past data.
+    using std::max;
+    using std::min;
+    evolution::dg::subcell::RdmpTciData past_rdmp_tci_data{
+        {max(max(get(u)),
+             max(evolution::dg::subcell::fd::reconstruct(
+                 get(u), dg_mesh, subcell_mesh.extents(),
+                 evolution::dg::subcell::fd::ReconstructionMethod::DimByDim)))},
+        {min(
+            min(get(u)),
+            min(evolution::dg::subcell::fd::reconstruct(
+                get(u), dg_mesh, subcell_mesh.extents(),
+                evolution::dg::subcell::fd::ReconstructionMethod::DimByDim)))}};
+
+    const evolution::dg::subcell::RdmpTciData expected_rdmp_tci_data{
+        {max(get(u))}, {min(get(u))}};
+
+    if (test_this == TestThis::RdmpU) {
+      // Assumes min is positive, increase it so we fail the TCI
+      past_rdmp_tci_data.min_variables_values[0] *= 1.01;
+    }
+
     // check the result
     const double persson_exponent{4.0};
-    const bool result =
-        Burgers::subcell::TciOnFdGrid::apply(u, dg_mesh, persson_exponent);
+    const evolution::dg::subcell::SubcellOptions subcell_options{
+        1.0e-16,
+        1.0e-4,
+        1.0e-16,
+        1.0e-4,
+        persson_exponent,
+        persson_exponent,
+        false,
+        evolution::dg::subcell::fd::ReconstructionMethod::DimByDim};
+    const std::tuple<bool, evolution::dg::subcell::RdmpTciData> result =
+        Burgers::subcell::TciOnFdGrid::apply(u, dg_mesh, subcell_mesh,
+                                             past_rdmp_tci_data,
+                                             subcell_options, persson_exponent);
+    CHECK(get<1>(result) == expected_rdmp_tci_data);
     if (test_this == TestThis::AllGood) {
-      CHECK_FALSE(result);
+      CHECK_FALSE(std::get<0>(result));
     } else {
-      CHECK(result);
+      CHECK(std::get<0>(result));
     }
   }
 }

--- a/tests/Unit/Evolution/Systems/Burgers/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/Subcell/Test_TimeDerivative.cpp
@@ -27,7 +27,6 @@
 #include "Domain/TagsTimeDependent.hpp"
 #include "Evolution/BoundaryCorrectionTags.hpp"
 #include "Evolution/DgSubcell/Mesh.hpp"
-#include "Evolution/DgSubcell/Tags/Inactive.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/NeighborData.hpp"
 #include "Evolution/DiscontinuousGalerkin/NormalVectorTags.hpp"

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_InitialDataTci.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_InitialDataTci.cpp
@@ -6,28 +6,22 @@
 #include <cstddef>
 
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Evolution/DgSubcell/Mesh.hpp"
-#include "Evolution/DgSubcell/Tags/Inactive.hpp"
+#include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/InitialDataTci.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/System.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 
-namespace {
-template <typename Tag>
-using Inactive = evolution::dg::subcell::Tags::Inactive<Tag>;
-}  // namespace
-
 SPECTRE_TEST_CASE(
     "Unit.Evolution.Systems.GhValenciaDivClean.Subcell.InitialDataTci",
     "[Unit][Evolution]") {
   using ConsVars =
       typename grmhd::GhValenciaDivClean::System::variables_tag::type;
-  using InactiveConsVars = typename evolution::dg::subcell::Tags::Inactive<
-      typename grmhd::GhValenciaDivClean::System::variables_tag>::type;
 
   const Mesh<3> dg_mesh{5, Spectral::Basis::Legendre,
                         Spectral::Quadrature::GaussLobatto};
@@ -39,48 +33,99 @@ SPECTRE_TEST_CASE(
   const grmhd::ValenciaDivClean::subcell::TciOptions tci_options{
       1.0e-20, 1.0e-40, 1.1e-12, 1.0e-12, std::optional<double>{1.0e-2}};
 
+  const auto compute_expected_rdmp_tci_data = [&dg_vars, &dg_mesh,
+                                               &subcell_mesh]() {
+    evolution::dg::subcell::RdmpTciData rdmp_tci_data{};
+    using std::max;
+    using std::min;
+    const auto& dg_tilde_d =
+        get<grmhd::ValenciaDivClean::Tags::TildeD>(dg_vars);
+    const auto& dg_tilde_tau =
+        get<grmhd::ValenciaDivClean::Tags::TildeTau>(dg_vars);
+    const auto dg_tilde_b_magnitude =
+        magnitude(get<grmhd::ValenciaDivClean::Tags::TildeB<>>(dg_vars));
+    const auto subcell_vars = evolution::dg::subcell::fd::project(
+        dg_vars, dg_mesh, subcell_mesh.extents());
+    const auto& subcell_tilde_d =
+        get<grmhd::ValenciaDivClean::Tags::TildeD>(subcell_vars);
+    const auto& subcell_tilde_tau =
+        get<grmhd::ValenciaDivClean::Tags::TildeTau>(subcell_vars);
+    const auto subcell_tilde_b_magnitude =
+        magnitude(get<grmhd::ValenciaDivClean::Tags::TildeB<>>(subcell_vars));
+    rdmp_tci_data.max_variables_values = std::vector<double>{
+        max(max(get(dg_tilde_d)), max(get(subcell_tilde_d))),
+        max(max(get(dg_tilde_tau)), max(get(subcell_tilde_tau))),
+        max(max(get(dg_tilde_b_magnitude)),
+            max(get(subcell_tilde_b_magnitude)))};
+    rdmp_tci_data.min_variables_values = std::vector<double>{
+        min(min(get(dg_tilde_d)), min(get(subcell_tilde_d))),
+        min(min(get(dg_tilde_tau)), min(get(subcell_tilde_tau))),
+        min(min(get(dg_tilde_b_magnitude)),
+            min(get(subcell_tilde_b_magnitude)))};
+    return rdmp_tci_data;
+  };
+
   {
     INFO("TCI is happy");
-    const InactiveConsVars subcell_vars{subcell_mesh.number_of_grid_points(),
-                                        1.0};
-    CHECK_FALSE(grmhd::GhValenciaDivClean::subcell::DgInitialDataTci::apply(
-        dg_vars, subcell_vars, delta0, epsilon, exponent, dg_mesh,
-        tci_options));
+    const auto result =
+        grmhd::GhValenciaDivClean::subcell::DgInitialDataTci::apply(
+            dg_vars, delta0, epsilon, exponent, dg_mesh, subcell_mesh,
+            tci_options);
+    CHECK_FALSE(std::get<0>(result));
+
+    CHECK(std::get<1>(result) == compute_expected_rdmp_tci_data());
   }
 
   {
     INFO("Two mesh RDMP fails");
-    const InactiveConsVars subcell_vars{subcell_mesh.number_of_grid_points(),
-                                        2.0};
-    CHECK(grmhd::GhValenciaDivClean::subcell::DgInitialDataTci::apply(
-        dg_vars, subcell_vars, delta0, epsilon, exponent, dg_mesh,
-        tci_options));
+    // Test that the 2-mesh RDMP fails be setting an absurdly small epsilon
+    // and delta_0 tolerance.
+    get(get<grmhd::ValenciaDivClean::Tags::TildeD>(
+        dg_vars))[dg_mesh.number_of_grid_points() / 2] *=
+        1.0 + std::numeric_limits<double>::epsilon() * 2.0;
+    const auto result =
+        grmhd::GhValenciaDivClean::subcell::DgInitialDataTci::apply(
+            dg_vars, 1.0e-100, 1.0e-18, exponent, dg_mesh, subcell_mesh,
+            tci_options);
+    CHECK(std::get<0>(result));
+    CHECK(std::get<1>(result) == compute_expected_rdmp_tci_data());
+    get(get<grmhd::ValenciaDivClean::Tags::TildeD>(
+        dg_vars))[dg_mesh.number_of_grid_points() / 2] /=
+        1.0 + std::numeric_limits<double>::epsilon() * 2.0;
+
+    // Verify TCI passes after restoring value
+    CHECK_FALSE(
+        std::get<0>(grmhd::GhValenciaDivClean::subcell::DgInitialDataTci::apply(
+            dg_vars, delta0, epsilon, exponent, dg_mesh, subcell_mesh,
+            tci_options)));
   }
 
   {
     INFO("Persson TCI TildeD fails");
-    const InactiveConsVars subcell_vars{subcell_mesh.number_of_grid_points(),
-                                        1.0};
     get(get<grmhd::ValenciaDivClean::Tags::TildeD>(
         dg_vars))[dg_mesh.number_of_grid_points() / 2] += 2.0e10;
-    CHECK(grmhd::GhValenciaDivClean::subcell::DgInitialDataTci::apply(
-        dg_vars, subcell_vars, 1.0e100, epsilon, exponent, dg_mesh,
-        tci_options));
+    const auto result =
+        grmhd::GhValenciaDivClean::subcell::DgInitialDataTci::apply(
+            dg_vars, 1.0e100, epsilon, exponent, dg_mesh, subcell_mesh,
+            tci_options);
+    CHECK(std::get<0>(result));
+    CHECK(std::get<1>(result) == compute_expected_rdmp_tci_data());
     get(get<grmhd::ValenciaDivClean::Tags::TildeD>(
         dg_vars))[dg_mesh.number_of_grid_points() / 2] = 1.0;
   }
 
   {
     INFO("Persson TCI TildeB fails");
-    const InactiveConsVars subcell_vars{subcell_mesh.number_of_grid_points(),
-                                        1.0};
     for (size_t i = 0; i < 3; ++i) {
       get<grmhd::ValenciaDivClean::Tags::TildeB<>>(dg_vars).get(
           i)[dg_mesh.number_of_grid_points() / 2] += 2.0e10;
     }
-    CHECK(grmhd::GhValenciaDivClean::subcell::DgInitialDataTci::apply(
-        dg_vars, subcell_vars, 1.0e100, epsilon, exponent, dg_mesh,
-        tci_options));
+    const auto result =
+        grmhd::GhValenciaDivClean::subcell::DgInitialDataTci::apply(
+            dg_vars, 1.0e100, epsilon, exponent, dg_mesh, subcell_mesh,
+            tci_options);
+    CHECK(std::get<0>(result));
+    CHECK(std::get<1>(result) == compute_expected_rdmp_tci_data());
     for (size_t i = 0; i < 3; ++i) {
       get<grmhd::ValenciaDivClean::Tags::TildeB<>>(dg_vars).get(
           i)[dg_mesh.number_of_grid_points() / 2] = 1.0;
@@ -89,56 +134,53 @@ SPECTRE_TEST_CASE(
 
   {
     INFO("Persson TCI TildeTau fails");
-    const InactiveConsVars subcell_vars{subcell_mesh.number_of_grid_points(),
-                                        1.0};
     get(get<grmhd::ValenciaDivClean::Tags::TildeTau>(
         dg_vars))[dg_mesh.number_of_grid_points() / 2] += 2.0e10;
-    CHECK(grmhd::GhValenciaDivClean::subcell::DgInitialDataTci::apply(
-        dg_vars, subcell_vars, 1.0e100, epsilon, exponent, dg_mesh,
-        tci_options));
+    const auto result =
+        grmhd::GhValenciaDivClean::subcell::DgInitialDataTci::apply(
+            dg_vars, 1.0e100, epsilon, exponent, dg_mesh, subcell_mesh,
+            tci_options);
+    CHECK(std::get<0>(result));
+    CHECK(std::get<1>(result) == compute_expected_rdmp_tci_data());
     get(get<grmhd::ValenciaDivClean::Tags::TildeTau>(
         dg_vars))[dg_mesh.number_of_grid_points() / 2] = 1.0;
   }
 
   {
     INFO("Negative TildeD");
-    InactiveConsVars subcell_vars{subcell_mesh.number_of_grid_points(), 1.0};
-
     get(get<grmhd::ValenciaDivClean::Tags::TildeD>(
         dg_vars))[dg_mesh.number_of_grid_points() / 2] = -1.0e-20;
-    CHECK(grmhd::GhValenciaDivClean::subcell::DgInitialDataTci::apply(
-        dg_vars, subcell_vars, 1.0e100, epsilon, 1.0, dg_mesh,
-        tci_options));
+    auto result = grmhd::GhValenciaDivClean::subcell::DgInitialDataTci::apply(
+        dg_vars, 1.0e100, epsilon, 1.0, dg_mesh, subcell_mesh, tci_options);
+    CHECK(std::get<0>(result));
+    CHECK(std::get<1>(result) == compute_expected_rdmp_tci_data());
     get(get<grmhd::ValenciaDivClean::Tags::TildeD>(
         dg_vars))[dg_mesh.number_of_grid_points() / 2] = 1.0;
 
-    get(get<Inactive<grmhd::ValenciaDivClean::Tags::TildeD>>(
-        subcell_vars))[subcell_mesh.number_of_grid_points() / 2] = -1.0e-20;
-    CHECK(grmhd::GhValenciaDivClean::subcell::DgInitialDataTci::apply(
-        dg_vars, subcell_vars, 1.0e100, epsilon, exponent, dg_mesh,
-        tci_options));
-    get(get<Inactive<grmhd::ValenciaDivClean::Tags::TildeD>>(
-        subcell_vars))[subcell_mesh.number_of_grid_points() / 2] = 1.0;
+    // Verify that the restored state is admissible by the TCI.
+    result = grmhd::GhValenciaDivClean::subcell::DgInitialDataTci::apply(
+        dg_vars, 1.0e100, epsilon, exponent, dg_mesh, subcell_mesh,
+        tci_options);
+    CHECK_FALSE(std::get<0>(result));
+    CHECK(std::get<1>(result) == compute_expected_rdmp_tci_data());
   }
 
   {
     INFO("Negative TildeTau");
-    InactiveConsVars subcell_vars{subcell_mesh.number_of_grid_points(), 1.0};
-
     get(get<grmhd::ValenciaDivClean::Tags::TildeTau>(
         dg_vars))[dg_mesh.number_of_grid_points() / 2] = -1.0e-20;
-    CHECK(grmhd::GhValenciaDivClean::subcell::DgInitialDataTci::apply(
-        dg_vars, subcell_vars, 1.0e100, epsilon, 1.0, dg_mesh,
-        tci_options));
+    auto result = grmhd::GhValenciaDivClean::subcell::DgInitialDataTci::apply(
+        dg_vars, 1.0e100, epsilon, exponent, dg_mesh, subcell_mesh,
+        tci_options);
+    CHECK(std::get<0>(result));
+    CHECK(std::get<1>(result) == compute_expected_rdmp_tci_data());
     get(get<grmhd::ValenciaDivClean::Tags::TildeTau>(
         dg_vars))[dg_mesh.number_of_grid_points() / 2] = 1.0;
 
-    get(get<Inactive<grmhd::ValenciaDivClean::Tags::TildeTau>>(
-        subcell_vars))[subcell_mesh.number_of_grid_points() / 2] = -1.0e-20;
-    CHECK(grmhd::GhValenciaDivClean::subcell::DgInitialDataTci::apply(
-        dg_vars, subcell_vars, 1.0e100, epsilon, exponent, dg_mesh,
-        tci_options));
-    get(get<Inactive<grmhd::ValenciaDivClean::Tags::TildeTau>>(
-        subcell_vars))[subcell_mesh.number_of_grid_points() / 2] = 1.0;
+    // Verify that the restored state is admissible by the TCI.
+    result = grmhd::GhValenciaDivClean::subcell::DgInitialDataTci::apply(
+        dg_vars, 1.0e100, epsilon, epsilon, dg_mesh, subcell_mesh, tci_options);
+    CHECK_FALSE(std::get<0>(result));
+    CHECK(std::get<1>(result) == compute_expected_rdmp_tci_data());
   }
 }

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnFdGrid.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnFdGrid.cpp
@@ -8,8 +8,12 @@
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
+#include "Evolution/DgSubcell/Reconstruction.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOptions.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
@@ -25,76 +29,152 @@ enum class TestThis {
   PerssonTildeTau,
   PerssonTildeB,
   NegativeTildeD,
-  NegativeTildeTau
+  NegativeTildeTau,
+  RdmpTildeD,
+  RdmpTildeTau,
+  RdmpMagnitudeTildeB
 };
 
 void test(const TestThis test_this) {
   const Mesh<3> mesh{6, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto};
+  const Mesh<3> subcell_mesh = evolution::dg::subcell::fd::mesh(mesh);
   const double persson_exponent = 5.0;
   const grmhd::ValenciaDivClean::subcell::TciOptions tci_options{
       1.0e-12, 1.0e-40, 1.0e-11, 1.0e-12,
       test_this == TestThis::PerssonTildeB ? std::optional<double>{1.0e-2}
                                            : std::nullopt};
 
-  auto box = db::create<
-      db::AddSimpleTags<evolution::dg::subcell::Tags::Inactive<
-                            grmhd::ValenciaDivClean::Tags::TildeD>,
-                        evolution::dg::subcell::Tags::Inactive<
-                            grmhd::ValenciaDivClean::Tags::TildeTau>,
-                        evolution::dg::subcell::Tags::Inactive<
-                            grmhd::ValenciaDivClean::Tags::TildeB<>>,
-                        grmhd::ValenciaDivClean::Tags::VariablesNeededFixing,
-                        domain::Tags::Mesh<3>,
-                        grmhd::ValenciaDivClean::subcell::Tags::TciOptions>>(
-      Scalar<DataVector>(mesh.number_of_grid_points(), 1.0),
-      Scalar<DataVector>(mesh.number_of_grid_points(), 1.0),
-      tnsr::I<DataVector, 3, Frame::Inertial>(mesh.number_of_grid_points(),
-                                              1.0),
-      test_this == TestThis::NeededFixing, mesh, tci_options);
+  const evolution::dg::subcell::SubcellOptions subcell_options{
+      1.0e-60,  // Tiny value because the magnetic field is so small
+      1.0e-4,
+      1.0e-60,  // Tiny value because the magnetic field is so small
+      1.0e-4,
+      persson_exponent,
+      persson_exponent,
+      false,
+      evolution::dg::subcell::fd::ReconstructionMethod::DimByDim};
+
+  auto box = db::create<db::AddSimpleTags<
+      grmhd::ValenciaDivClean::Tags::TildeD,
+      grmhd::ValenciaDivClean::Tags::TildeTau,
+      grmhd::ValenciaDivClean::Tags::TildeB<>,
+      grmhd::ValenciaDivClean::Tags::VariablesNeededFixing,
+      domain::Tags::Mesh<3>, ::evolution::dg::subcell::Tags::Mesh<3>,
+      grmhd::ValenciaDivClean::subcell::Tags::TciOptions,
+      evolution::dg::subcell::Tags::SubcellOptions,
+      evolution::dg::subcell::Tags::DataForRdmpTci>>(
+      Scalar<DataVector>(subcell_mesh.number_of_grid_points(), 1.0),
+      Scalar<DataVector>(subcell_mesh.number_of_grid_points(), 1.0),
+      tnsr::I<DataVector, 3, Frame::Inertial>(
+          subcell_mesh.number_of_grid_points(), 1.0),
+      test_this == TestThis::NeededFixing, mesh, subcell_mesh, tci_options,
+      subcell_options, evolution::dg::subcell::RdmpTciData{});
 
   const size_t point_to_change = mesh.number_of_grid_points() / 2;
   if (test_this == TestThis::PerssonTildeTau) {
-    db::mutate<evolution::dg::subcell::Tags::Inactive<
-        grmhd::ValenciaDivClean::Tags::TildeTau>>(
+    db::mutate<grmhd::ValenciaDivClean::Tags::TildeTau>(
         make_not_null(&box), [point_to_change](const auto tilde_tau_ptr) {
           get(*tilde_tau_ptr)[point_to_change] *= 2.0;
         });
   } else if (test_this == TestThis::PerssonTildeD) {
-    db::mutate<evolution::dg::subcell::Tags::Inactive<
-        grmhd::ValenciaDivClean::Tags::TildeD>>(
+    db::mutate<grmhd::ValenciaDivClean::Tags::TildeD>(
         make_not_null(&box), [point_to_change](const auto tilde_d_ptr) {
           get(*tilde_d_ptr)[point_to_change] *= 2.0;
         });
   } else if (test_this == TestThis::PerssonTildeB) {
-    db::mutate<evolution::dg::subcell::Tags::Inactive<
-        grmhd::ValenciaDivClean::Tags::TildeB<>>>(
+    db::mutate<grmhd::ValenciaDivClean::Tags::TildeB<>>(
         make_not_null(&box), [point_to_change](const auto tilde_b_ptr) {
           for (size_t i = 0; i < 3; ++i) {
             tilde_b_ptr->get(i)[point_to_change] *= 2.0;
           }
         });
   } else if (test_this == TestThis::NegativeTildeD) {
-    db::mutate<evolution::dg::subcell::Tags::Inactive<
-        grmhd::ValenciaDivClean::Tags::TildeD>>(
+    db::mutate<grmhd::ValenciaDivClean::Tags::TildeD>(
         make_not_null(&box), [point_to_change](const auto tilde_d_ptr) {
           get(*tilde_d_ptr)[point_to_change] = -1.0e-20;
         });
   } else if (test_this == TestThis::NegativeTildeTau) {
-    db::mutate<evolution::dg::subcell::Tags::Inactive<
-        grmhd::ValenciaDivClean::Tags::TildeTau>>(
+    db::mutate<grmhd::ValenciaDivClean::Tags::TildeTau>(
         make_not_null(&box), [point_to_change](const auto tilde_tau_ptr) {
           get(*tilde_tau_ptr)[point_to_change] = -1.0e-20;
         });
   }
 
-  const bool result =
+  // Set the RDMP TCI past data.
+  using std::max;
+  using std::min;
+  evolution::dg::subcell::RdmpTciData past_rdmp_tci_data{};
+  const auto magnitude_tilde_b =
+      magnitude(db::get<grmhd::ValenciaDivClean::Tags::TildeB<>>(box));
+
+  past_rdmp_tci_data.max_variables_values = std::vector<double>{
+      max(max(get(db::get<grmhd::ValenciaDivClean::Tags::TildeD>(box))),
+          max(evolution::dg::subcell::fd::reconstruct(
+              get(db::get<grmhd::ValenciaDivClean::Tags::TildeD>(box)), mesh,
+              subcell_mesh.extents(),
+              evolution::dg::subcell::fd::ReconstructionMethod::DimByDim))),
+      max(max(get(db::get<grmhd::ValenciaDivClean::Tags::TildeTau>(box))),
+          max(evolution::dg::subcell::fd::reconstruct(
+              get(db::get<grmhd::ValenciaDivClean::Tags::TildeTau>(box)), mesh,
+              subcell_mesh.extents(),
+              evolution::dg::subcell::fd::ReconstructionMethod::DimByDim))),
+      max(max(get(magnitude_tilde_b)),
+          max(evolution::dg::subcell::fd::reconstruct(
+              get(magnitude_tilde_b), mesh, subcell_mesh.extents(),
+              evolution::dg::subcell::fd::ReconstructionMethod::DimByDim)))};
+  past_rdmp_tci_data.min_variables_values = std::vector<double>{
+      min(min(get(db::get<grmhd::ValenciaDivClean::Tags::TildeD>(box))),
+          min(evolution::dg::subcell::fd::reconstruct(
+              get(db::get<grmhd::ValenciaDivClean::Tags::TildeD>(box)), mesh,
+              subcell_mesh.extents(),
+              evolution::dg::subcell::fd::ReconstructionMethod::DimByDim))),
+      min(min(get(db::get<grmhd::ValenciaDivClean::Tags::TildeTau>(box))),
+          min(evolution::dg::subcell::fd::reconstruct(
+              get(db::get<grmhd::ValenciaDivClean::Tags::TildeTau>(box)), mesh,
+              subcell_mesh.extents(),
+              evolution::dg::subcell::fd::ReconstructionMethod::DimByDim))),
+      min(min(get(magnitude_tilde_b)),
+          min(evolution::dg::subcell::fd::reconstruct(
+              get(magnitude_tilde_b), mesh, subcell_mesh.extents(),
+              evolution::dg::subcell::fd::ReconstructionMethod::DimByDim)))};
+
+  evolution::dg::subcell::RdmpTciData expected_rdmp_tci_data{};
+  expected_rdmp_tci_data.max_variables_values = std::vector<double>{
+      max(get(db::get<grmhd::ValenciaDivClean::Tags::TildeD>(box))),
+      max(get(db::get<grmhd::ValenciaDivClean::Tags::TildeTau>(box))),
+      max(get(magnitude_tilde_b))};
+  expected_rdmp_tci_data.min_variables_values = std::vector<double>{
+      min(get(db::get<grmhd::ValenciaDivClean::Tags::TildeD>(box))),
+      min(get(db::get<grmhd::ValenciaDivClean::Tags::TildeTau>(box))),
+      min(get(magnitude_tilde_b))};
+
+  // Modify past data if we are expected an RDMP TCI failure.
+  db::mutate<evolution::dg::subcell::Tags::DataForRdmpTci>(
+      make_not_null(&box),
+      [&past_rdmp_tci_data, &test_this](const auto rdmp_tci_data_ptr) {
+        *rdmp_tci_data_ptr = past_rdmp_tci_data;
+        if (test_this == TestThis::RdmpTildeD) {
+          // Assumes min is positive, increase it so we fail the TCI
+          rdmp_tci_data_ptr->min_variables_values[0] *= 1.01;
+        } else if (test_this == TestThis::RdmpTildeTau) {
+          // Assumes min is positive, increase it so we fail the TCI
+          rdmp_tci_data_ptr->min_variables_values[1] *= 1.01;
+        } else if (test_this == TestThis::RdmpMagnitudeTildeB) {
+          // Assumes min is positive, increase it so we fail the TCI
+          rdmp_tci_data_ptr->min_variables_values[2] *= 1.01;
+        }
+      });
+
+  const std::tuple<bool, evolution::dg::subcell::RdmpTciData> result =
       db::mutate_apply<grmhd::ValenciaDivClean::subcell::TciOnFdGrid>(
           make_not_null(&box), persson_exponent);
+  CHECK(get<1>(result) == expected_rdmp_tci_data);
+
   if (test_this == TestThis::AllGood) {
-    CHECK_FALSE(result);
+    CHECK_FALSE(get<0>(result));
   } else {
-    CHECK(result);
+    CHECK(get<0>(result));
   }
 }
 }  // namespace
@@ -104,7 +184,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ValenciaDivClean.Subcell.TciOnFdGrid",
   for (const TestThis& test_this :
        {TestThis::AllGood, TestThis::NeededFixing, TestThis::PerssonTildeD,
         TestThis::PerssonTildeTau, TestThis::PerssonTildeB,
-        TestThis::NegativeTildeD, TestThis::NegativeTildeTau}) {
+        TestThis::NegativeTildeD, TestThis::NegativeTildeTau,
+        TestThis::RdmpTildeD, TestThis::RdmpTildeTau,
+        TestThis::RdmpMagnitudeTildeB}) {
     test(test_this);
   }
 }

--- a/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_InitialDataTci.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_InitialDataTci.cpp
@@ -6,8 +6,9 @@
 #include <cstddef>
 
 #include "DataStructures/Variables.hpp"
+#include "Evolution/DgSubcell/ActiveGrid.hpp"
 #include "Evolution/DgSubcell/Mesh.hpp"
-#include "Evolution/DgSubcell/Tags/Inactive.hpp"
+#include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/Systems/ScalarAdvection/Subcell/InitialDataTci.hpp"
 #include "Evolution/Systems/ScalarAdvection/Tags.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
@@ -15,23 +16,16 @@
 #include "Utilities/TMPL.hpp"
 
 namespace {
-template <typename Tag>
-using Inactive = evolution::dg::subcell::Tags::Inactive<Tag>;
-
 template <size_t Dim>
 void test() {
   // type aliases
   using Vars = Variables<tmpl::list<ScalarAdvection::Tags::U>>;
-  using InactiveVars =
-      Variables<tmpl::list<Inactive<ScalarAdvection::Tags::U>>>;
 
   // create DG mesh and subcell mesh for test
   const Mesh<Dim> dg_mesh{5, Spectral::Basis::Legendre,
                           Spectral::Quadrature::GaussLobatto};
   const Mesh<Dim> subcell_mesh = evolution::dg::subcell::fd::mesh(dg_mesh);
   const size_t number_of_dg_grid_points{dg_mesh.number_of_grid_points()};
-  const size_t number_of_subcell_grid_points{
-      subcell_mesh.number_of_grid_points()};
 
   // create scalar field U for DG mesh
   Vars dg_vars{number_of_dg_grid_points, 1.0};
@@ -41,35 +35,76 @@ void test() {
   const double rdmp_delta0{1.0e-4};
   const double rdmp_epsilon{1.0e-3};
 
+  const auto compute_expected_rdmp_tci_data = [&dg_vars, &dg_mesh,
+                                               &subcell_mesh]() {
+    const auto subcell_vars = evolution::dg::subcell::fd::project(
+        dg_vars, dg_mesh, subcell_mesh.extents());
+    using std::max;
+    using std::min;
+    evolution::dg::subcell::RdmpTciData rdmp_tci_data{
+        {max(max(get(get<ScalarAdvection::Tags::U>(dg_vars))),
+             max(get(get<ScalarAdvection::Tags::U>(subcell_vars))))},
+        {min(min(get(get<ScalarAdvection::Tags::U>(dg_vars))),
+             min(get(get<ScalarAdvection::Tags::U>(subcell_vars))))}};
+    return rdmp_tci_data;
+  };
+
   {
     INFO("TCI is happy");
-    // set dg_vars == subcell_vars
-    const InactiveVars subcell_vars{number_of_subcell_grid_points, 1.0};
-    CHECK_FALSE(ScalarAdvection::subcell::DgInitialDataTci<Dim>::apply(
-        dg_vars, subcell_vars, rdmp_delta0, rdmp_epsilon, persson_exponent,
-        dg_mesh));
+    const auto result = ScalarAdvection::subcell::DgInitialDataTci<Dim>::apply(
+        dg_vars, rdmp_delta0, rdmp_epsilon, persson_exponent, dg_mesh,
+        subcell_mesh);
+    CHECK_FALSE(std::get<0>(result));
+    CHECK(std::get<1>(result) == compute_expected_rdmp_tci_data());
   }
 
   {
     INFO("Two mesh RDMP fails");
     // set subcell_vars to be smooth but quite different from dg_vars
-    const InactiveVars subcell_vars{number_of_subcell_grid_points, 2.0};
-    CHECK(ScalarAdvection::subcell::DgInitialDataTci<Dim>::apply(
-        dg_vars, subcell_vars, rdmp_delta0, rdmp_epsilon, persson_exponent,
-        dg_mesh));
+    // Test that the 2-mesh RDMP fails be setting an absurdly small epsilon
+    // and delta_0 tolerance.
+    get(get<ScalarAdvection::Tags::U>(
+        dg_vars))[dg_mesh.number_of_grid_points() / 2] *=
+        1.0 + std::numeric_limits<double>::epsilon() * 2.0;
+    const auto result = ScalarAdvection::subcell::DgInitialDataTci<Dim>::apply(
+        dg_vars, 1.0e-100, 1.0e-18, persson_exponent, dg_mesh, subcell_mesh);
+    CHECK(std::get<0>(result));
+    CHECK(std::get<1>(result) == compute_expected_rdmp_tci_data());
+    get(get<ScalarAdvection::Tags::U>(
+        dg_vars))[dg_mesh.number_of_grid_points() / 2] /=
+        1.0 + std::numeric_limits<double>::epsilon() * 2.0;
   }
 
   {
     INFO("Persson TCI fails");
-    InactiveVars subcell_vars{number_of_subcell_grid_points, 1.0};
     // set dg_vars to have a sharp peak
     get(get<ScalarAdvection::Tags::U>(dg_vars))[number_of_dg_grid_points / 2] +=
         1.0;
     // set rdmp_delta0 to be very large to ensure that it's the Persson TCI
     // which triggers alarm here
-    CHECK(ScalarAdvection::subcell::DgInitialDataTci<Dim>::apply(
-        dg_vars, subcell_vars, rdmp_delta0, rdmp_epsilon, persson_exponent,
-        dg_mesh));
+    const auto result = ScalarAdvection::subcell::DgInitialDataTci<Dim>::apply(
+        dg_vars, 1.0e100, rdmp_epsilon, persson_exponent, dg_mesh,
+        subcell_mesh);
+    CHECK(std::get<0>(result));
+    CHECK(std::get<1>(result) == compute_expected_rdmp_tci_data());
+  }
+
+  {
+    INFO("Test SetInitialRdmpData");
+    // While the code is supposed to be used on the subcells, that doesn't
+    // actually matter.
+    evolution::dg::subcell::RdmpTciData rdmp_data{};
+    ScalarAdvection::subcell::SetInitialRdmpData::apply(
+        make_not_null(&rdmp_data), get<ScalarAdvection::Tags::U>(dg_vars),
+        evolution::dg::subcell::ActiveGrid::Dg);
+    CHECK(rdmp_data == evolution::dg::subcell::RdmpTciData{});
+    ScalarAdvection::subcell::SetInitialRdmpData::apply(
+        make_not_null(&rdmp_data), get<ScalarAdvection::Tags::U>(dg_vars),
+        evolution::dg::subcell::ActiveGrid::Subcell);
+    const evolution::dg::subcell::RdmpTciData expected_rdmp_data{
+        {max(get(get<ScalarAdvection::Tags::U>(dg_vars)))},
+        {min(get(get<ScalarAdvection::Tags::U>(dg_vars)))}};
+    CHECK(rdmp_data == expected_rdmp_data);
   }
 }
 }  // namespace

--- a/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_TciOnFdGrid.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_TciOnFdGrid.cpp
@@ -3,25 +3,29 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <algorithm>
 #include <cstddef>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
+#include "Evolution/DgSubcell/Reconstruction.hpp"
 #include "Evolution/Systems/ScalarAdvection/Subcell/TciOnFdGrid.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 
 namespace {
 // test cases to be covered
-enum class TestThis { AllGood, PerssonU };
+enum class TestThis { AllGood, PerssonU, RdmpU };
 
 template <size_t Dim>
 void test(const TestThis& test_this) {
   // create DG mesh
   const Mesh<Dim> dg_mesh{5, Spectral::Basis::Legendre,
                           Spectral::Quadrature::GaussLobatto};
-  // create scalar field U on the DG mesh
-  const size_t number_of_points{dg_mesh.number_of_grid_points()};
+  const Mesh<Dim> subcell_mesh = evolution::dg::subcell::fd::mesh(dg_mesh);
+  // create scalar field U on the subcell mesh
+  const size_t number_of_points{subcell_mesh.number_of_grid_points()};
   Scalar<DataVector> u{number_of_points, 1.0};
 
   if (test_this == TestThis::PerssonU) {
@@ -29,22 +33,56 @@ void test(const TestThis& test_this) {
     get(u)[number_of_points / 2] += 1.0;
   }
 
+  // Set the RDMP TCI past data.
+  using std::max;
+  using std::min;
+  evolution::dg::subcell::RdmpTciData past_rdmp_tci_data{
+      {max(max(get(u)),
+           max(evolution::dg::subcell::fd::reconstruct(
+               get(u), dg_mesh, subcell_mesh.extents(),
+               evolution::dg::subcell::fd::ReconstructionMethod::DimByDim)))},
+      {min(min(get(u)),
+           min(evolution::dg::subcell::fd::reconstruct(
+               get(u), dg_mesh, subcell_mesh.extents(),
+               evolution::dg::subcell::fd::ReconstructionMethod::DimByDim)))}};
+
+  const evolution::dg::subcell::RdmpTciData expected_rdmp_tci_data{
+      {max(get(u))}, {min(get(u))}};
+
+  if (test_this == TestThis::RdmpU) {
+    // Assumes min is positive, increase it so we fail the TCI
+    past_rdmp_tci_data.min_variables_values[0] *= 1.01;
+  }
+
   // check the result
   const double persson_exponent{4.0};
-  const bool result = ScalarAdvection::subcell::TciOnFdGrid<Dim>::apply(
-      u, dg_mesh, persson_exponent);
+  const evolution::dg::subcell::SubcellOptions subcell_options{
+      1.0e-16,
+      1.0e-4,
+      1.0e-16,
+      1.0e-4,
+      persson_exponent,
+      persson_exponent,
+      false,
+      evolution::dg::subcell::fd::ReconstructionMethod::DimByDim};
+
+  const std::tuple<bool, evolution::dg::subcell::RdmpTciData> result =
+      ScalarAdvection::subcell::TciOnFdGrid<Dim>::apply(
+          u, dg_mesh, subcell_mesh, past_rdmp_tci_data, subcell_options,
+          persson_exponent);
 
   if (test_this == TestThis::AllGood) {
-    CHECK_FALSE(result);
+    CHECK_FALSE(std::get<0>(result));
   } else {
-    CHECK(result);
+    CHECK(std::get<0>(result));
   }
 }
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarAdvection.Subcell.TciOnFdGrid",
                   "[Unit][Evolution]") {
-  for (const auto test_this : {TestThis::AllGood, TestThis::PerssonU}) {
+  for (const auto test_this :
+       {TestThis::AllGood, TestThis::PerssonU, TestThis::RdmpU}) {
     test<1>(test_this);
     test<2>(test_this);
   }


### PR DESCRIPTION
## Proposed changes

Change the RDMP TCI to be part of the system-specific TCI. This allows removing the `inactive` variables, reducing memory usage, and also reduces the number of project operations necessary for the TCI. While only about a 15% reduction in runtime, the memory usage reduction will be important for GH+GRMHD, and since there are a lot more variables to project in that case, I suspect also in the runtime. Having said that, GH+GRMHD also has a more expensive RHS, so I'm not sure how big the runtime difference will be.

Only the "fixup" commits are new. I've split what ultimately needs to be one giant commit into several to make review easier.

Fixes #3587 

Depends on:
- [x] #4000 Actually needed
- [x] #4002 only in the sense of that it's included. Could be dropped.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
