### PR TITLE
Explicitly use interpolator source vars in intrp framework

### DIFF
--- a/src/ControlSystem/ApparentHorizons/Measurements.hpp
+++ b/src/ControlSystem/ApparentHorizons/Measurements.hpp
@@ -16,13 +16,11 @@
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/LinkedMessageId.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
-#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/ErrorOnFailedApparentHorizon.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp"
 #include "ParallelAlgorithms/Interpolation/Interpolate.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
 #include "ParallelAlgorithms/Interpolation/Targets/ApparentHorizon.hpp"
-#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 

--- a/src/ControlSystem/ApparentHorizons/Measurements.hpp
+++ b/src/ControlSystem/ApparentHorizons/Measurements.hpp
@@ -15,7 +15,6 @@
 #include "ControlSystem/RunCallbacks.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/LinkedMessageId.hpp"
-#include "DataStructures/Tensor/TypeAliases.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/ErrorOnFailedApparentHorizon.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp"
 #include "ParallelAlgorithms/Interpolation/Interpolate.hpp"
@@ -79,22 +78,18 @@ struct BothHorizons : tt::ConformsTo<protocols::Measurement> {
     using argument_tags =
         tmpl::push_front<::ah::source_vars<3>, domain::Tags::Mesh<3>>;
 
-    template <typename Metavariables, typename ParallelComponent,
-              typename ControlSystems>
-    static void apply(
-        const Mesh<3>& mesh,
-        const tnsr::aa<DataVector, 3, ::Frame::Inertial>& spacetime_metric,
-        const tnsr::aa<DataVector, 3, ::Frame::Inertial>& pi,
-        const tnsr::iaa<DataVector, 3, ::Frame::Inertial>& phi,
-        const tnsr::ijaa<DataVector, 3, ::Frame::Inertial>& deriv_phi,
-        const LinkedMessageId<double>& measurement_id,
-        Parallel::GlobalCache<Metavariables>& cache,
-        const ElementId<3>& array_index,
-        const ParallelComponent* const /*meta*/, ControlSystems /*meta*/) {
-      intrp::interpolate<interpolation_target_tag<ControlSystems>,
-                         ::ah::source_vars<3>>(measurement_id, mesh, cache,
-                                               array_index, spacetime_metric,
-                                               pi, phi, deriv_phi);
+    template <typename... InterpolatorSourceVars, typename Metavariables,
+              typename ParallelComponent, typename ControlSystems>
+    static void apply(const Mesh<3>& mesh,
+                      const InterpolatorSourceVars&... interpolator_source_vars,
+                      const LinkedMessageId<double>& measurement_id,
+                      Parallel::GlobalCache<Metavariables>& cache,
+                      const ElementId<3>& array_index,
+                      const ParallelComponent* const /*meta*/,
+                      ControlSystems /*meta*/) {
+      intrp::interpolate<interpolation_target_tag<ControlSystems>>(
+          measurement_id, mesh, cache, array_index,
+          interpolator_source_vars...);
     }
   };
 

--- a/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorReceiveVolumeData.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorReceiveVolumeData.hpp
@@ -50,7 +50,8 @@ struct InterpolatorReceiveVolumeData {
       const ArrayIndex& /*array_index*/,
       const typename TemporalId::type& temporal_id,
       const ElementId<VolumeDim>& element_id, const ::Mesh<VolumeDim>& mesh,
-      Variables<typename Metavariables::interpolator_source_vars>&& vars) {
+      Variables<typename Metavariables::interpolator_source_vars>&&
+          interpolator_source_vars) {
     // Determine if we have already finished interpolating on this
     // temporal_id.  If so, then we simply return, ignore the incoming
     // data, and do not interpolate.
@@ -88,10 +89,10 @@ struct InterpolatorReceiveVolumeData {
     // VolumeVarsInfos that might be in the DataBox.)
     db::mutate<Tags::VolumeVarsInfo<Metavariables, TemporalId>>(
         make_not_null(&box),
-        [&temporal_id, &element_id, &mesh,
-         &vars](const gsl::not_null<
+        [&temporal_id, &element_id, &mesh, &interpolator_source_vars](
+            const gsl::not_null<
                 typename Tags::VolumeVarsInfo<Metavariables, TemporalId>::type*>
-                    container) {
+                container) {
           if (container->find(temporal_id) == container->end()) {
             container->emplace(
                 temporal_id,
@@ -101,9 +102,10 @@ struct InterpolatorReceiveVolumeData {
           }
           container->at(temporal_id)
               .emplace(std::make_pair(
-                  element_id, typename Tags::VolumeVarsInfo<Metavariables,
-                                                            TemporalId>::Info{
-                                  mesh, std::move(vars), {}}));
+                  element_id,
+                  typename Tags::VolumeVarsInfo<Metavariables,
+                                                TemporalId>::Info{
+                      mesh, std::move(interpolator_source_vars), {}}));
         });
 
     // Try to interpolate data for all InterpolationTargets for this

--- a/src/ParallelAlgorithms/Interpolation/Actions/TryToInterpolate.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/TryToInterpolate.hpp
@@ -105,13 +105,14 @@ void interpolate_data(
                 // vars_to_interpolate has not been filled for
                 // this element at this temporal_id.  So fill it.
                 vars_to_interpolate.initialize(
-                    volume_info.vars_from_element.number_of_grid_points());
+                    volume_info.source_vars_from_element
+                        .number_of_grid_points());
 
                 InterpolationTarget_detail::compute_dest_vars_from_source_vars<
-                    InterpolationTargetTag>(make_not_null(&vars_to_interpolate),
-                                            volume_info.vars_from_element,
-                                            domain, volume_info.mesh,
-                                            element_id, cache, temporal_id);
+                    InterpolationTargetTag>(
+                    make_not_null(&vars_to_interpolate),
+                    volume_info.source_vars_from_element, domain,
+                    volume_info.mesh, element_id, cache, temporal_id);
               }
             }
 
@@ -126,10 +127,10 @@ void interpolate_data(
                   interpolator.interpolate(vars_to_interpolate));
             } else {
               // If compute_vars_to_interpolate does not exist, then
-              // volume_info.vars_from_element is the same as
+              // volume_info.source_vars_from_element is the same as
               // volume_info.vars_to_interpolate.
-              interp_info.vars.emplace_back(
-                  interpolator.interpolate(volume_info.vars_from_element));
+              interp_info.vars.emplace_back(interpolator.interpolate(
+                  volume_info.source_vars_from_element));
             }
             interp_info.global_offsets.emplace_back(
                 element_coord_holder.offsets);

--- a/src/ParallelAlgorithms/Interpolation/Tags.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Tags.hpp
@@ -102,7 +102,7 @@ struct VolumeVarsInfo : db::SimpleTag {
     Mesh<Metavariables::volume_dim> mesh;
     // Variables that have been sent from the Elements.
     Variables<typename Metavariables::interpolator_source_vars>
-        vars_from_element;
+        source_vars_from_element;
     // Variables, for each InterpolationTargetTag, that have been
     // computed in the volume before interpolation, and that will
     // be interpolated.
@@ -113,7 +113,7 @@ struct VolumeVarsInfo : db::SimpleTag {
     // NOLINTNEXTLINE(google-runtime-references)
     void pup(PUP::er& p) {
       p | mesh;
-      p | vars_from_element;
+      p | source_vars_from_element;
       p | vars_to_interpolate;
     }
   };

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_Interpolate.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_Interpolate.cpp
@@ -259,8 +259,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.InterpolateEvent",
 
   const TimeStepId temporal_id(true, 0, Slab(0., observation_time).end());
 
-  intrp::interpolate<MockMetavariables::InterpolatorTargetA,
-                     tmpl::list<Tags::Lapse>>(
+  intrp::interpolate<MockMetavariables::InterpolatorTargetA>(
       temporal_id, mesh, cache, array_index, get<Tags::Lapse>(vars));
 
   check_results();


### PR DESCRIPTION
## Proposed changes

When using the Interpolator, the source variables passed around must be the ones defined in the `interpolator_source_vars` type alias in the metavariables. However this wasn't super clear to me as I was looking through the interpolation framework (see #3994). This PR mostly just renames template parameters and function arguments to make it obvious what tensors/variables we are talking about in these functions. I also added a couple `static_assert`s to enforce this as well. Hopefully this will aid in other people's understanding when they look at the interpolation framework.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

The reason for all this is because internally, the Interpolator parallel component stores a tag in its DataBox that has
```cpp
Variables<typename Metavariables::interpolator_source_vars> vars_from_element;
```
explicitly in it. That is why all these functions have to have the source vars from the metavariables. If this tag didn't explicitly reach into the metavariables, we wouldn't need to guarantee that the tensors passed in are the ones from the metavariables.

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
