### PR TITLE
Add ability to place singletons on specific cores

### DIFF
--- a/docs/DevGuide/Parallelization.md
+++ b/docs/DevGuide/Parallelization.md
@@ -108,11 +108,11 @@ In contrast, an evolution executable might have phases
 similar `switch` or `if-else` logic in the `determine_next_phase`
 function. The first phase that is entered is always
 `Initialization`. During the `Initialization` phase the
-`Parallel::GlobalCache` is created, all non-array components are created,
-and empty array components are created.  Next, the function
-`allocate_array_components_and_execute_initialization_phase` is called
-which allocates the elements of each array component, and then starts
-the `Initialization` phase on all parallel components. Once all
+`Parallel::GlobalCache` is created, all (node)group components are created,
+and empty array and singleton components are created.  Next, the function
+`allocate_remaining_components_and_execute_initialization_phase` is called
+which allocates singleton components and the elements of each array component,
+and then starts the `Initialization` phase on all parallel components. Once all
 parallel components' `Initialization` phase is complete, the next
 phase is determined and the `execute_next_phase` function is called on
 all the parallel components.

--- a/src/Parallel/Main.ci
+++ b/src/Parallel/Main.ci
@@ -11,7 +11,7 @@ module Main {
   template <typename Metavariables>
   mainchare [migratable] Main {
     entry Main(CkArgMsg* msg);
-    entry void allocate_array_components_and_execute_initialization_phase();
+    entry void allocate_remaining_components_and_execute_initialization_phase();
 
     template <typename InvokeCombine, typename... Tags>
     entry [reductiontarget] void phase_change_reduction(

--- a/src/Parallel/ResourceInfo.hpp
+++ b/src/Parallel/ResourceInfo.hpp
@@ -648,7 +648,7 @@ void ResourceInfo<Metavariables>::build_singleton_map(
 
     if (proc.has_value() and *proc > num_procs - 1) {
       ERROR("Singleton " << pretty_type::name<component>()
-                         << " requested to be placed on proc " << proc
+                         << " requested to be placed on proc " << *proc
                          << ", but that proc is beyond the last proc "
                          << num_procs - 1 << ".");
     }


### PR DESCRIPTION
## Proposed changes

Adds `ResourceInfo` to Main which now allows us to

1. Place singletons on specific cores
2. Request that a singleton be exclusively on a core (i.e. no other singletons or Array-elements)
3. Avoid placing singletons or Array-elements on the global zeroth core.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
To be able to place a singleton on a specific core and specify that it should be exclusively on that core, add the `Parallel::Tags::SingletonInfo` tag to the `initialization_tags` of the singleton. To avoid placing singletons and Array-elements on the global zeroth core, add the `Parallel::Tags::AvoidGlobalProc0` tag to the `initialization_tags` of any singleton or Array component in your executable.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
