### PR TITLE
Add Expansion and Rotation control systems to BBH exec

### DIFF
--- a/src/ControlSystem/ApparentHorizons/Measurements.hpp
+++ b/src/ControlSystem/ApparentHorizons/Measurements.hpp
@@ -15,6 +15,7 @@
 #include "ControlSystem/RunCallbacks.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/LinkedMessageId.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/ErrorOnFailedApparentHorizon.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp"
 #include "ParallelAlgorithms/Interpolation/Interpolate.hpp"
@@ -78,18 +79,21 @@ struct BothHorizons : tt::ConformsTo<protocols::Measurement> {
     using argument_tags =
         tmpl::push_front<::ah::source_vars<3>, domain::Tags::Mesh<3>>;
 
-    template <typename... InterpolatorSourceVars, typename Metavariables,
-              typename ParallelComponent, typename ControlSystems>
-    static void apply(const Mesh<3>& mesh,
-                      const InterpolatorSourceVars&... interpolator_source_vars,
-                      const LinkedMessageId<double>& measurement_id,
-                      Parallel::GlobalCache<Metavariables>& cache,
-                      const ElementId<3>& array_index,
-                      const ParallelComponent* const /*meta*/,
-                      ControlSystems /*meta*/) {
+    template <typename Metavariables, typename ParallelComponent,
+              typename ControlSystems>
+    static void apply(
+        const Mesh<3>& mesh,
+        const tnsr::aa<DataVector, 3, ::Frame::Inertial>& spacetime_metric,
+        const tnsr::aa<DataVector, 3, ::Frame::Inertial>& pi,
+        const tnsr::iaa<DataVector, 3, ::Frame::Inertial>& phi,
+        const tnsr::ijaa<DataVector, 3, ::Frame::Inertial>& deriv_phi,
+        const LinkedMessageId<double>& measurement_id,
+        Parallel::GlobalCache<Metavariables>& cache,
+        const ElementId<3>& array_index,
+        const ParallelComponent* const /*meta*/, ControlSystems /*meta*/) {
       intrp::interpolate<interpolation_target_tag<ControlSystems>>(
-          measurement_id, mesh, cache, array_index,
-          interpolator_source_vars...);
+          measurement_id, mesh, cache, array_index, spacetime_metric, pi, phi,
+          deriv_phi);
     }
   };
 

--- a/src/ControlSystem/Systems/Rotation.hpp
+++ b/src/ControlSystem/Systems/Rotation.hpp
@@ -96,8 +96,7 @@ struct Rotation : tt::ConformsTo<protocols::ControlSystem> {
                                       QueueTags::Center<::ah::ObjectLabel::B>>>;
   };
 
-  using simple_tags =
-      tmpl::list<MeasurementQueue, Tags::ControlError<Rotation>>;
+  using simple_tags = tmpl::list<MeasurementQueue>;
 
   struct process_measurement {
     template <typename Submeasurement>

--- a/src/ControlSystem/Tags/CMakeLists.txt
+++ b/src/ControlSystem/Tags/CMakeLists.txt
@@ -1,6 +1,12 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+spectre_target_sources(
+  ${LIBRARY}
+  PUBLIC
+  FunctionsOfTimeInitialize.cpp
+  )
+
 spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src

--- a/src/ControlSystem/Tags/FunctionsOfTimeInitialize.cpp
+++ b/src/ControlSystem/Tags/FunctionsOfTimeInitialize.cpp
@@ -1,0 +1,40 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ControlSystem/Tags/FunctionsOfTimeInitialize.hpp"
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+
+namespace control_system::Tags::detail {
+
+void check_expiration_time_consistency(
+    const std::unordered_map<std::string, double>& initial_expiration_times,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) {
+  for (const auto& [name, expr_time] : initial_expiration_times) {
+    if (functions_of_time.count(name) == 0) {
+      ERROR("The control system '"
+            << name
+            << "' is not controlling a function of time. Check that the "
+               "DomainCreator you have chosen uses all of the control "
+               "systems in the executable. The existing functions of time are: "
+            << keys_of(functions_of_time));
+    }
+
+    if (functions_of_time.at(name)->time_bounds()[1] != expr_time) {
+      ERROR("The expiration time for the function of time '"
+            << name << "' has been set improperly. It is supposed to be "
+            << expr_time << " but is currently set to "
+            << functions_of_time.at(name)->time_bounds()[1]
+            << ". It is possible that the DomainCreator you are using isn't "
+               "compatible with the control systems.");
+    }
+  }
+}
+}  // namespace control_system::Tags::detail

--- a/src/ControlSystem/Tags/FunctionsOfTimeInitialize.hpp
+++ b/src/ControlSystem/Tags/FunctionsOfTimeInitialize.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <type_traits>
 #include <unordered_map>
@@ -12,10 +13,12 @@
 #include "ControlSystem/Tags.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/ReadSpecPiecewisePolynomial.hpp"
 #include "Domain/FunctionsOfTime/Tags.hpp"
 #include "Domain/OptionTags.hpp"
 #include "Time/Tags.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/StdHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits/IsA.hpp"
@@ -26,6 +29,69 @@ struct ControlComponent;
 /// \endcond
 
 namespace control_system::Tags {
+namespace detail {
+
+template <typename Metavariables, bool NeedDomainCreator,
+          bool HasOverrideCubicFunctionsOfTime>
+struct OptionList {
+  using option_holders = control_system::inputs<
+      tmpl::transform<tmpl::filter<typename Metavariables::component_list,
+                                   tt::is_a<ControlComponent, tmpl::_1>>,
+                      tmpl::bind<tmpl::back, tmpl::_1>>>;
+  static constexpr bool metavars_has_control_systems =
+      tmpl::size<option_holders>::value > 0;
+
+  using type = tmpl::flatten<tmpl::list<
+      tmpl::conditional_t<NeedDomainCreator,
+                          tmpl::list<domain::OptionTags::DomainCreator<
+                              Metavariables::volume_dim>>,
+                          tmpl::list<>>,
+      tmpl::conditional_t<
+          Metavariables::override_functions_of_time,
+          tmpl::list<
+              domain::FunctionsOfTime::OptionTags::FunctionOfTimeFile,
+              domain::FunctionsOfTime::OptionTags::FunctionOfTimeNameMap>,
+          tmpl::list<>>,
+      tmpl::conditional_t<
+          metavars_has_control_systems,
+          tmpl::list<::OptionTags::InitialTime, ::OptionTags::InitialTimeStep,
+                     option_holders>,
+          tmpl::list<>>>>;
+};
+
+template <typename Metavariables, bool NeedDomainCreator>
+struct OptionList<Metavariables, NeedDomainCreator, false> {
+  using option_holders = control_system::inputs<
+      tmpl::transform<tmpl::filter<typename Metavariables::component_list,
+                                   tt::is_a<ControlComponent, tmpl::_1>>,
+                      tmpl::bind<tmpl::back, tmpl::_1>>>;
+  static constexpr bool metavars_has_control_systems =
+      tmpl::size<option_holders>::value > 0;
+
+  using type = tmpl::flatten<tmpl::list<
+      tmpl::conditional_t<NeedDomainCreator,
+                          tmpl::list<domain::OptionTags::DomainCreator<
+                              Metavariables::volume_dim>>,
+                          tmpl::list<>>,
+      tmpl::conditional_t<
+          metavars_has_control_systems,
+          tmpl::list<::OptionTags::InitialTime, ::OptionTags::InitialTimeStep,
+                     option_holders>,
+          tmpl::list<>>>>;
+};
+
+// Check that all control systems are actually controlling a function of
+// time, and that the expiration times have been set appropriately. If there
+// exists a control system that isn't controlling a function of time, or the
+// expiration times were set improperly, this is an error and we shouldn't
+// continue.
+void check_expiration_time_consistency(
+    const std::unordered_map<std::string, double>& initial_expiration_times,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time);
+}  // namespace detail
+
 /// \ingroup ControlSystemGroup
 /// The FunctionsOfTime initialized from a DomainCreator, initial time
 /// step, and control system OptionHolders.
@@ -39,54 +105,81 @@ struct FunctionsOfTimeInitialize : domain::Tags::FunctionsOfTime,
   static std::string name() { return "FunctionsOfTime"; }
 
   template <typename Metavariables>
-  using option_tags = tmpl::flatten<
-      tmpl::list<domain::OptionTags::DomainCreator<Metavariables::volume_dim>,
-                 ::OptionTags::InitialTime, ::OptionTags::InitialTimeStep,
-                 control_system::inputs<tmpl::transform<
-                     tmpl::filter<typename Metavariables::component_list,
-                                  tt::is_a<ControlComponent, tmpl::_1>>,
-                     tmpl::bind<tmpl::back, tmpl::_1>>>>>;
+  using option_tags = typename detail::OptionList<
+      Metavariables, true,
+      ::detail::has_override_functions_of_time_v<Metavariables>>::type;
 
+  /// This version of create_from_options is used if the metavariables defined a
+  /// constexpr bool `override_functions_of_time` and it is `true`, and there
+  /// are control systems in the metavariables
+  template <typename Metavariables, typename... OptionHolders>
+  static type create_from_options(
+      const std::unique_ptr<::DomainCreator<Metavariables::volume_dim>>&
+          domain_creator,
+      const std::optional<std::string>& function_of_time_file,
+      const std::map<std::string, std::string>& function_of_time_name_map,
+      const double initial_time, const double initial_time_step,
+      const OptionHolders&... option_holders) {
+    const auto initial_expiration_times =
+        control_system::initial_expiration_times(
+            initial_time, initial_time_step, option_holders...);
+
+    // We need to check the expiration times before we replace functions of
+    // time (if we're going to do so) so we can ensure a proper domain creator
+    // was chosen from options.
+    auto functions_of_time =
+        domain_creator->functions_of_time(initial_expiration_times);
+
+    detail::check_expiration_time_consistency(initial_expiration_times,
+                                              functions_of_time);
+
+    if (function_of_time_file.has_value()) {
+      domain::FunctionsOfTime::override_functions_of_time(
+          make_not_null(&functions_of_time), *function_of_time_file,
+          function_of_time_name_map);
+    }
+
+    return functions_of_time;
+  }
+
+  /// This version of create_from_options is used if the metavariables defined a
+  /// constexpr bool `override_functions_of_time` and it is `true`, but there
+  /// are no control systems in the metavariables
+  template <typename Metavariables>
+  static type create_from_options(
+      const std::unique_ptr<::DomainCreator<Metavariables::volume_dim>>&
+          domain_creator,
+      const std::optional<std::string>& function_of_time_file,
+      const std::map<std::string, std::string>& function_of_time_name_map) {
+    // Just use 0.0 for initial time and time step. Since there are no
+    // control systems, these values won't be used anyways
+    return FunctionsOfTimeInitialize::create_from_options<Metavariables>(
+        domain_creator, function_of_time_file, function_of_time_name_map, 0.0,
+        0.0);
+  }
+
+  /// This version of create_from_options is used if the metavariables did not
+  /// define a constexpr bool `override_functions_of_time` or it did define it
+  /// and it is `false`, and the metavariables did define control systems
   template <typename Metavariables, typename... OptionHolders>
   static type create_from_options(
       const std::unique_ptr<::DomainCreator<Metavariables::volume_dim>>&
           domain_creator,
       const double initial_time, const double initial_time_step,
       const OptionHolders&... option_holders) {
-    const std::unordered_map<std::string, double> initial_expiration_times =
-        control_system::initial_expiration_times(
-            initial_time, initial_time_step, option_holders...);
+    return FunctionsOfTimeInitialize::create_from_options<Metavariables>(
+        domain_creator, std::nullopt, {}, initial_time, initial_time_step,
+        option_holders...);
+  }
 
-    auto functions_of_time =
-        domain_creator->functions_of_time(initial_expiration_times);
-
-    // Check that all control systems are actually controlling a function of
-    // time, and that the expiration times have been set appropriately. If there
-    // exists a control system that isn't controlling a function of time, or the
-    // expiration times were set improperly, this is an error and we shouldn't
-    // continue.
-    for (const auto& [name, expr_time] : initial_expiration_times) {
-      if (functions_of_time.count(name) == 0) {
-        ERROR(
-            "The control system '"
-            << name
-            << "' is not controlling a function of time. Check that the "
-               "DomainCreator you have chosen uses all of the control "
-               "systems in the executable. The existing functions of time are: "
-            << keys_of(functions_of_time));
-      }
-
-      if (functions_of_time.at(name)->time_bounds()[1] != expr_time) {
-        ERROR("The expiration time for the function of time '"
-              << name << "' has been set improperly. It is supposed to be "
-              << expr_time << " but is currently set to "
-              << functions_of_time.at(name)->time_bounds()[1]
-              << ". It is possible that the DomainCreator you are using isn't "
-                 "compatible with the control systems.");
-      }
-    }
-
-    return functions_of_time;
+  /// This version of create_from_options is used if the metavariables did not
+  /// define a constexpr bool `override_functions_of_time` or it did define it
+  /// and it is `false`, and the metavariables did not define control systems
+  template <typename Metavariables>
+  static type create_from_options(
+      const std::unique_ptr<::DomainCreator<Metavariables::volume_dim>>&
+          domain_creator) {
+    return domain_creator->functions_of_time();
   }
 };
 }  // namespace control_system::Tags

--- a/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
@@ -91,5 +91,5 @@ add_spectre_parallel_executable(
   EvolveGhBinaryBlackHole
   Evolution/Executables/GeneralizedHarmonic
   "EvolutionMetavars"
-  "${LIBS_TO_LINK};GeneralRelativitySolutions;Importers"
+  "${LIBS_TO_LINK};ControlSystem;GeneralRelativitySolutions;Importers"
 )

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -12,6 +12,12 @@
 #include "ApparentHorizons/HorizonAliases.hpp"
 #include "ApparentHorizons/ObserveCenters.hpp"
 #include "ApparentHorizons/Tags.hpp"
+#include "ControlSystem/Actions/InitializeMeasurements.hpp"
+#include "ControlSystem/Component.hpp"
+#include "ControlSystem/Event.hpp"
+#include "ControlSystem/Systems/Expansion.hpp"
+#include "ControlSystem/Systems/Rotation.hpp"
+#include "ControlSystem/Trigger.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "Domain/Creators/Factory1D.hpp"
@@ -19,6 +25,7 @@
 #include "Domain/Creators/Factory3D.hpp"
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
+#include "Domain/FunctionsOfTime/FunctionsOfTimeAreReady.hpp"
 #include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
 #include "Domain/Protocols/Metavariables.hpp"
 #include "Domain/Tags.hpp"
@@ -235,7 +242,15 @@ struct EvolutionMetavars {
         ah::callbacks::ObserveCenters<AhB>>;
   };
 
-  using interpolation_target_tags = tmpl::list<AhA, AhB>;
+  using control_systems = tmpl::list<control_system::Systems::Rotation<3>,
+                                     control_system::Systems::Expansion<2>>;
+
+  static constexpr bool use_control_systems =
+      tmpl::size<control_systems>::value > 0;
+
+  using interpolation_target_tags = tmpl::push_back<
+      control_system::metafunctions::interpolation_target_tags<control_systems>,
+      AhA, AhB>;
   using interpolator_source_vars = ::ah::source_vars<volume_dim>;
 
   using observe_fields = tmpl::append<
@@ -295,7 +310,10 @@ struct EvolutionMetavars {
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes = tmpl::map<
-        tmpl::pair<DenseTrigger, DenseTriggers::standard_dense_triggers>,
+        tmpl::pair<DenseTrigger,
+                   tmpl::flatten<tmpl::list<
+                       control_system::control_system_triggers<control_systems>,
+                       DenseTriggers::standard_dense_triggers>>>,
         tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
         tmpl::pair<
             Event,
@@ -306,6 +324,7 @@ struct EvolutionMetavars {
                 dg::Events::field_observations<volume_dim, Tags::Time,
                                                observe_fields,
                                                non_tensor_compute_tags>,
+                control_system::control_system_events<control_systems>,
                 Events::time_events<system>>>>,
         tmpl::pair<GeneralizedHarmonic::BoundaryConditions::BoundaryCondition<
                        volume_dim>,
@@ -417,8 +436,8 @@ struct EvolutionMetavars {
   using initialization_actions = tmpl::list<
       Actions::SetupDataBox,
       Initialization::Actions::TimeAndTimeStep<EvolutionMetavars>,
-      evolution::dg::Initialization::Domain<volume_dim,
-                                            override_functions_of_time>,
+      evolution::dg::Initialization::Domain<
+          volume_dim, override_functions_of_time, use_control_systems>,
       Initialization::Actions::NonconservativeSystem<system>,
       Initialization::Actions::AddComputeTags<::Tags::DerivCompute<
           typename system::variables_tag,
@@ -431,6 +450,7 @@ struct EvolutionMetavars {
           StepChoosers::step_chooser_compute_tags<EvolutionMetavars>>>,
       ::evolution::dg::Initialization::Mortars<volume_dim, system>,
       evolution::Actions::InitializeRunEventsAndDenseTriggers,
+      control_system::Actions::InitializeMeasurements<control_systems>,
       Initialization::Actions::RemoveOptionsAndTerminatePhase>;
 
   using gh_dg_element_array = DgElementArray<
@@ -460,7 +480,8 @@ struct EvolutionMetavars {
                                             Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
+              tmpl::list<::domain::Actions::CheckFunctionsOfTimeAreReady,
+                         Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
                          step_actions, Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
@@ -477,8 +498,11 @@ struct EvolutionMetavars {
       importers::ElementDataReader<EvolutionMetavars>,
       mem_monitor::MemoryMonitor<EvolutionMetavars>,
       intrp::Interpolator<EvolutionMetavars>,
-      intrp::InterpolationTarget<EvolutionMetavars, AhA>,
-      intrp::InterpolationTarget<EvolutionMetavars, AhB>, gh_dg_element_array>>;
+      tmpl::transform<interpolation_target_tags,
+                      tmpl::bind<intrp::InterpolationTarget,
+                                 tmpl::pin<EvolutionMetavars>, tmpl::_1>>,
+      control_system::control_components<EvolutionMetavars, control_systems>,
+      gh_dg_element_array>>;
 
   static constexpr Options::String help{
       "Evolve a binary black hole using the Generalized Harmonic "

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -207,7 +207,7 @@ Observers:
   SurfaceFileName: "GhBinaryBlackHoleSurfacesData"
 
 ApparentHorizons:
-  AhA:
+  AhA: &AhA
     InitialGuess:
       Lmax: 10
       Radius: 2.2
@@ -222,13 +222,48 @@ ApparentHorizons:
       DivergenceIter: 5
       MaxIts: 100
     Verbosity: Verbose
-  AhB:
+  AhB: &AhB
     InitialGuess:
       Lmax: 10
       Radius: 2.2
       Center: [*XCoordB, 0.0, 0.0]
     FastFlow: *DefaultFastFlow
     Verbosity: Verbose
+  ControlSystemAhA: *AhA
+  ControlSystemAhB: *AhB
+
+ControlSystems:
+  WriteDataToDisk: true
+  Expansion:
+    Averager:
+      AverageTimescaleFraction: 0.25
+      Average0thDeriv: false
+    Controller:
+      UpdateFraction: 0.03
+    TimescaleTuner:
+      InitialTimescales: [0.2]
+      MinTimescale: 1.0e-2
+      MaxTimescale: 10.0
+      IncreaseThreshold: 2.5e-4
+      DecreaseThreshold: 1.0e-3
+      IncreaseFactor: 1.01
+      DecreaseFactor: 0.98
+    ControlError:
+  Rotation:
+    Averager:
+      AverageTimescaleFraction: 0.25
+      Average0thDeriv: false
+    Controller:
+      UpdateFraction: 0.03
+    TimescaleTuner:
+      InitialTimescales: [0.2, 0.2, 0.2]
+      MinTimescale: 1.0e-2
+      MaxTimescale: 10.0
+      IncreaseThreshold: 2.5e-4
+      DecreaseThreshold: 1.0e-3
+      IncreaseFactor: 1.01
+      DecreaseFactor: 0.98
+    ControlError:
 
 # initial_data.h5 should contain numerical initial data
 # on the same grid as specified by the domain given above
@@ -252,8 +287,12 @@ Importers:
       SpatialMetric: SpatialMetric
       ExtrinsicCurvature: ExtrinsicCurvature
 
-# control.h5 should contain data for FunctionsOfTime that can be
-# read by ReadSpecPiecewisePolynomial.
+# control.h5 should contain data for FunctionsOfTime that can be read by
+# ReadSpecPiecewisePolynomial. By default, this will override the spectre
+# control systems. To not replace any FunctionsOfTime, replace
+# "/path/to/control.h5" with None. To use spectre control systems, remove
+# Expansion or Rotation from the NameMap. Currently only Expansion and
+# Rotation control systems are supported in spectre.
 CubicFunctionOfTimeOverride:
   FunctionOfTimeFile: "/path/to/control.h5"
   # Note: SpEC calls the hole on the right hole A, but spectre calls hole A

--- a/tests/Unit/Evolution/Initialization/Test_DgDomain.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_DgDomain.cpp
@@ -37,6 +37,10 @@
 #include "Utilities/Literals.hpp"
 #include "Utilities/TMPL.hpp"
 
+namespace control_system::Tags {
+struct FunctionsOfTimeInitialize;
+}  // namespace control_system::Tags
+
 namespace {
 template <size_t MeshDim>
 using TranslationMap =
@@ -160,6 +164,15 @@ void test(const Spectral::Quadrature quadrature) {
   CAPTURE(quadrature);
   using metavars = Metavariables<Dim>;
   using component = Component<metavars>;
+
+  static_assert(
+      std::is_same_v<typename evolution::dg::Initialization::Domain<
+                         Dim>::mutable_global_cache_tags,
+                     tmpl::list<::domain::Tags::FunctionsOfTimeInitialize>>);
+  static_assert(std::is_same_v<
+                typename evolution::dg::Initialization::Domain<
+                    Dim, false, true>::mutable_global_cache_tags,
+                tmpl::list<control_system::Tags::FunctionsOfTimeInitialize>>);
 
   PUPable_reg(SINGLE_ARG(
       TimeIndependentMap<Dim, Frame::BlockLogical, Frame::Inertial>));


### PR DESCRIPTION
## Proposed changes

To do this

1. Modify the control system FunctionsOfTimeInitialize tag to allow functions of time to be overridden even if they have control systems
2. If all controlled functions of time are overridden, have the control system trigger return that it's never triggered (so we don't do extra horizon finds)
3. Use the control system FunctionsOfTimeInitialize tag in the DgDomain initialization action if we have control systems.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
