### PR TITLE
Fix ci by adding cache clear

### DIFF
--- a/.github/workflows/ClobberCache.yaml
+++ b/.github/workflows/ClobberCache.yaml
@@ -1,0 +1,36 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Dump a large file into the cache to force GitHub to clobber it.
+name: Clobber Cache
+
+on:
+  workflow_dispatch:
+
+jobs:
+  clobber_cache:
+    name: Clobber Cache
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      # Configure the clobber cache
+      - name: Restore cache
+        uses: actions/cache@v3
+        with:
+          path:  cache
+          key: "clobber-cache"
+          restore-keys: |
+            clobber-cache
+      # Generate the random file to clobber the cache.
+      # Note that the file size must be updated as GitHub expands the cache
+      # size limits.
+      - name: Clobber cache
+        run: >
+          mkdir -p cache
+
+          cd ./cache
+
+          rm -rf ./*
+
+          head -c 9900MB /dev/urandom > clobber.txt

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -38,6 +38,12 @@ on:
           Enter a version name YYYY.MM.DD[.TWEAK] to create a release on success
         required: false
         default: ''
+      clear_ccache:
+        description: >
+          Enter 'yes' without quotes to clear ccache before running
+        required: false
+        default: ''
+
 
 # Cancel all other queued or in-progress runs of this workflow when it is
 # scheduled, so repeated pushes to a branch or a PR don't block CI. Repeated
@@ -417,6 +423,13 @@ ${{ env.CACHE_KEY_SUFFIX }}"
         # Print the ccache configuration and reset statistics
         run: |
           ccache -pz
+      - name: Clear ccache
+        # Clear ccache if requested
+        if: >
+          github.event_name == 'workflow_dispatch'
+            && github.event.inputs.clear_ccache == 'yes'
+        run: |
+          ccache -C
       - name: Configure build with cmake
         working-directory: /work
         # Notes on the build configuration:
@@ -725,6 +738,13 @@ ${{ env.CACHE_KEY_SUFFIX }}"
       - name: Configure ccache
         run: |
           ccache -pz
+      - name: Clear ccache
+        # Clear ccache if requested
+        if: >
+          github.event_name == 'workflow_dispatch'
+            && github.event.inputs.clear_ccache == 'yes'
+        run: |
+          ccache -C
       # Configure, build and run tests. See the `unit_tests` job above for
       # details.
       # - We increase the timeout for tests because the GitHub-hosted macOS VMs

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -403,7 +403,7 @@ jobs:
           CACHE_KEY_SUFFIX=$(date +%s)
           echo "CACHE_KEY_SUFFIX=$CACHE_KEY_SUFFIX" >> $GITHUB_ENV
       - name: Restore ccache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           CACHE_KEY_PREFIX: "ccache-${{ matrix.compiler }}-\
 ${{ matrix.build_type }}-pch-${{ matrix.use_pch }}"
@@ -672,7 +672,7 @@ ${{ env.CACHE_KEY_SUFFIX }}"
           CACHE_KEY_SUFFIX=$(date +%s)
           echo "CACHE_KEY_SUFFIX=$CACHE_KEY_SUFFIX" >> $GITHUB_ENV
       - name: Restore dependency cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-dependencies
         with:
           path: ~/dependencies
@@ -716,7 +716,7 @@ ${{ env.CACHE_KEY_SUFFIX }}"
           rm -rf $CCACHE_DIR
           mkdir -p $CCACHE_DIR
       - name: Restore ccache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/ccache
           key: "ccache-macos-${{ github.ref }}-${{ env.CACHE_KEY_SUFFIX }}"


### PR DESCRIPTION
## Proposed changes

The current CI failures with clang are because of some weird caching bug. Clearing the cache fixes the issue. However, currently we have no easy way of clearing the cache. This PR adds two methods of "clearing" the cache from the GitHub web interface. Unfortunately GitHub does not provide such a feature, even though it was requested 4 years ago.

- Update cache action. Fixes some bugs with large caches
- Add a ClobberCache workflow that dumps 9.9GB of random data into GitHub's cache, forcing it to clear the old cache.
- Add a workflow input that clear ccache before running.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
