### PR TITLE
Add Ability to Observe Ricci Scalar

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -310,6 +310,21 @@ struct EvolutionMetavars {
                      volume_dim, ::Frame::Inertial>,
                  GeneralizedHarmonic::Tags::ThreeIndexConstraintCompute<
                      volume_dim, ::Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::DerivSpatialMetricCompute<
+                     volume_dim, ::Frame::Inertial>,
+                 gr::Tags::SpatialChristoffelFirstKindCompute<
+                     volume_dim, ::Frame::Inertial, DataVector>,
+                 gr::Tags::SpatialChristoffelSecondKindCompute<
+                     volume_dim, ::Frame::Inertial, DataVector>,
+                 ::Tags::DerivTensorCompute<
+                     gr::Tags::SpatialChristoffelSecondKind<
+                         volume_dim, ::Frame::Inertial, DataVector>,
+                     ::domain::Tags::InverseJacobian<
+                         volume_dim, Frame::ElementLogical, Frame::Inertial>>,
+                 gr::Tags::SpatialRicciCompute<volume_dim, ::Frame::Inertial,
+                                               DataVector>,
+                 gr::Tags::SpatialRicciScalarCompute<
+                     volume_dim, ::Frame::Inertial, DataVector>,
                  // following tags added to observe constraints
                  ::Tags::PointwiseL2NormCompute<
                      GeneralizedHarmonic::Tags::GaugeConstraint<

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -213,15 +213,29 @@ struct GeneralizedHarmonicTemplateBase<
           analytic_solution_fields, gr::Tags::Lapse<DataVector>,
           GeneralizedHarmonic::Tags::GaugeConstraintCompute<volume_dim, frame>,
           GeneralizedHarmonic::Tags::TwoIndexConstraintCompute<volume_dim,
-                                                                 frame>,
+                                                               frame>,
           GeneralizedHarmonic::Tags::ThreeIndexConstraintCompute<volume_dim,
                                                                  frame>,
+          GeneralizedHarmonic::Tags::DerivSpatialMetricCompute<
+              volume_dim, ::Frame::Inertial>,
+          gr::Tags::SpatialChristoffelFirstKindCompute<
+              volume_dim, ::Frame::Inertial, DataVector>,
+          gr::Tags::SpatialChristoffelSecondKindCompute<
+              volume_dim, ::Frame::Inertial, DataVector>,
+          ::Tags::DerivTensorCompute<
+              gr::Tags::SpatialChristoffelSecondKind<
+                  volume_dim, ::Frame::Inertial, DataVector>,
+              ::domain::Tags::InverseJacobian<volume_dim, Frame::ElementLogical,
+                                              Frame::Inertial>>,
+          gr::Tags::SpatialRicciCompute<volume_dim, ::Frame::Inertial,
+                                        DataVector>,
+          gr::Tags::SpatialRicciScalarCompute<volume_dim, ::Frame::Inertial,
+                                              DataVector>,
           // following tags added to observe constraints
           ::Tags::PointwiseL2NormCompute<
               GeneralizedHarmonic::Tags::GaugeConstraint<volume_dim, frame>>,
           ::Tags::PointwiseL2NormCompute<
-              GeneralizedHarmonic::Tags::TwoIndexConstraint<volume_dim,
-                                                              frame>>,
+              GeneralizedHarmonic::Tags::TwoIndexConstraint<volume_dim, frame>>,
           ::Tags::PointwiseL2NormCompute<
               GeneralizedHarmonic::Tags::ThreeIndexConstraint<volume_dim,
                                                               frame>>,
@@ -231,14 +245,16 @@ struct GeneralizedHarmonicTemplateBase<
       // The 4-index constraint is only implemented in 3d
       tmpl::conditional_t<
           volume_dim == 3,
-          tmpl::list<
-              GeneralizedHarmonic::Tags::FourIndexConstraintCompute<3, frame>,
-              GeneralizedHarmonic::Tags::FConstraintCompute<3, frame>,
-              ::Tags::PointwiseL2NormCompute<
-              GeneralizedHarmonic::Tags::FConstraint<3, frame>>,
-              ::Tags::PointwiseL2NormCompute<
-                  GeneralizedHarmonic::Tags::FourIndexConstraint<3, frame>>,
-              GeneralizedHarmonic::Tags::ConstraintEnergyCompute<3, frame>>,
+          tmpl::list<GeneralizedHarmonic::Tags::FourIndexConstraintCompute<
+                         3, frame>,
+                     GeneralizedHarmonic::Tags::FConstraintCompute<3, frame>,
+                     ::Tags::PointwiseL2NormCompute<
+                         GeneralizedHarmonic::Tags::FConstraint<3, frame>>,
+                     ::Tags::PointwiseL2NormCompute<
+                         GeneralizedHarmonic::Tags::FourIndexConstraint<3,
+                                                                        frame>>,
+                     GeneralizedHarmonic::Tags::ConstraintEnergyCompute<3,
+                                                                        frame>>,
           tmpl::list<>>>;
   using non_tensor_compute_tags =
       tmpl::list<::Events::Tags::ObserverMeshCompute<volume_dim>,


### PR DESCRIPTION
## Proposed changes

This PR is split into 2 commits, one that adds a compute tag to get the derivative of a single tensor using the partial derivatives functions that are already made and the other adds the ability to observe the spatial Ricci scalar to the BBH executable and the GenHarmonicBase executable.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

I wasn't sure if I should try to add prefix functionality to the new compute tag and would like some input on that. I didn't think it was necessary. Attached, are pictures of spatial Ricci scalar turned into a "height map" on paraview from a single black hole evolution which gives us this pseudo embedding diagram look. The colors show the different lapses as you get closer to the singularity.
![Spicci Scalar Slice 8](https://user-images.githubusercontent.com/47013010/172017784-2f4b5c72-40e6-4d35-ae36-81faff48d520.JPG)
![Spicci Scalar Slice 9](https://user-images.githubusercontent.com/47013010/172017787-b08d63b7-f1c5-44d9-b643-e2032b294a8f.JPG)
![Spicci Scalar Slice 10](https://user-images.githubusercontent.com/47013010/172017789-776463fd-68eb-4c5c-b300-7f0775b076b6.JPG)
![Spicci Scalar Slice 11](https://user-images.githubusercontent.com/47013010/172017790-2bb9e7b3-0eaf-49ea-8baa-a6aef0441177.JPG)

