### PR TITLE
Allow time dependent maps for non-sequential intrp targets

### DIFF
--- a/src/ParallelAlgorithms/Interpolation/Actions/InterpolationTargetVarsFromElement.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/InterpolationTargetVarsFromElement.hpp
@@ -55,7 +55,11 @@ namespace Actions {
 ///   - `::Tags::Variables<typename
 ///                   InterpolationTargetTag::vars_to_interpolate_to_target>`
 ///
-/// For requirements on InterpolationTargetTag, see InterpolationTarget
+/// For requirements on InterpolationTargetTag, see InterpolationTarget and
+/// intrp::protocols::InterpolationTargetTag
+///
+/// \note This action can only be used with InterpolationTargets that are
+/// non-sequential.
 template <typename InterpolationTargetTag>
 struct InterpolationTargetVarsFromElement {
   /// For requirements on Metavariables, see InterpolationTarget

--- a/src/ParallelAlgorithms/Interpolation/Actions/InterpolationTargetVarsFromElement.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/InterpolationTargetVarsFromElement.hpp
@@ -130,10 +130,20 @@ struct InterpolationTargetVarsFromElement {
                 InterpolationTargetTag>(make_not_null(&box),
                                         std::vector<TemporalId>{{temporal_id}})
                 .empty()) {
-      InterpolationTarget_detail::set_up_interpolation<InterpolationTargetTag>(
-          make_not_null(&box), temporal_id,
-          InterpolationTarget_detail::block_logical_coords<
-              InterpolationTargetTag>(box, tmpl::type_<Metavariables>{}));
+      if (InterpolationTarget_detail::maps_are_time_dependent<
+              InterpolationTargetTag>(box, tmpl::type_<Metavariables>{})) {
+        InterpolationTarget_detail::set_up_interpolation<
+            InterpolationTargetTag>(
+            make_not_null(&box), temporal_id,
+            InterpolationTarget_detail::block_logical_coords<
+                InterpolationTargetTag>(box, cache, temporal_id));
+      } else {
+        InterpolationTarget_detail::set_up_interpolation<
+            InterpolationTargetTag>(
+            make_not_null(&box), temporal_id,
+            InterpolationTarget_detail::block_logical_coords<
+                InterpolationTargetTag>(box, tmpl::type_<Metavariables>{}));
+      }
     }
 
     InterpolationTarget_detail::add_received_variables<InterpolationTargetTag>(

--- a/src/ParallelAlgorithms/Interpolation/InterpolationTarget.hpp
+++ b/src/ParallelAlgorithms/Interpolation/InterpolationTarget.hpp
@@ -238,11 +238,11 @@ namespace intrp {
 /// > `Actions::EnsureFunctionOfTimeUpToDate` is placed in `DgElementArray`s
 /// >  PDAL before any use of interpolation.
 ///
-/// ##### Actions::InterpolationTargetSendTimeIndepPointsToElements
+/// ##### Actions::InterpolationTargetSendPointsToElements
 ///
-/// `Actions::InterpolationTargetSendTimeIndepPointsToElements`
+/// `Actions::InterpolationTargetSendPointsToElements`
 /// is invoked on `InterpolationTarget` during the Registration PDAL,
-/// to send time-independent point information to `Element`s.
+/// to send non-sequential point information to `Element`s.
 ///
 /// ###### Current logic:
 ///
@@ -286,9 +286,8 @@ struct InterpolationTarget {
                   InterpolationTargetTag::compute_target_points::is_sequential::
                       value,
                   tmpl::list<>,
-                  tmpl::list<
-                      Actions::InterpolationTargetSendTimeIndepPointsToElements<
-                          InterpolationTargetTag>>>,
+                  tmpl::list<Actions::InterpolationTargetSendPointsToElements<
+                      InterpolationTargetTag>>>,
               Parallel::Actions::TerminatePhase>>>;
 
   using initialization_tags = Parallel::get_initialization_tags<

--- a/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
+++ b/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
@@ -473,7 +473,7 @@ void add_received_variables(
 /// - SendPointsToInterpolator (called by AddTemporalIdsToInterpolationTarget
 ///                             and by FindApparentHorizon)
 /// - InterpolationTargetVarsFromElement (called by DgElementArray)
-/// - InterpolationTargetSendTimeIndepPointsToElements
+/// - InterpolationTargetSendPointsToElements
 ///   (in InterpolationTarget ActionList)
 template <typename InterpolationTargetTag, typename DbTags,
           typename Metavariables, typename TemporalId>


### PR DESCRIPTION
## Proposed changes

You can now have time-dependent targets that are non-sequential.

Previously, if a target was sequential that also meant it was time dependent, and if it was non-sequential, then the maps were time-independent.

For sequential targets this makes sense. If you're relying on the previous interpolation before you can do the next one, that implicitly assumes some sort of time dependence, so it seems reasonable to assume that sequential $\implies$ time-dependent. And by that logic, it's reasonable to assume, then, that non-sequential $\implies$ time-independent.

However, for CCE this isn't the case. The worldtube target is non-sequential (in the sense that one interpolation of GH vars onto the worldtube doesn't depend on a previous interpolation), yet the points we are interpolating to are time dependent in an evolution where the maps are time dependent (like a BBH, which is where this issue arose). Thus, this wasn't accounted for in the previous framework.

There were surprisingly few changes needed for this to work. Just a few `if (maps_are_time_dependent)` calls.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
