### PR TITLE
Remove CERROR, specialize error macros for compile time and runtime

### DIFF
--- a/src/IO/H5/Dat.cpp
+++ b/src/IO/H5/Dat.cpp
@@ -102,7 +102,20 @@ Dat::Dat(const bool exists, detail::OpenGroup&& group, const hid_t location,
   }
 }
 
-Dat::~Dat() { CHECK_H5(H5Dclose(dataset_id_), "Failed to close dataset"); }
+Dat::~Dat() {
+#ifdef __clang__
+  CHECK_H5(H5Dclose(dataset_id_), "Failed to close dataset");
+#else
+// The pragma here is used to suppress the warning that the compile time branch
+// of `ERROR` will always call `terminate()` because it throws an error.
+// Throwing that error is a code path that will never actually be entered at
+// runtime, so we suppress the warning here.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wterminate"
+  CHECK_H5(H5Dclose(dataset_id_), "Failed to close dataset");
+#pragma GCC diagnostic pop
+#endif
+}
 
 void Dat::append_impl(const hsize_t number_of_rows,
                       const std::vector<double>& data) {

--- a/src/Utilities/ErrorHandling/Error.hpp
+++ b/src/Utilities/ErrorHandling/Error.hpp
@@ -6,13 +6,13 @@
 
 #pragma once
 
-#include <sstream>
 #include <string>
 
 #include "Utilities/ErrorHandling/AbortWithErrorMessage.hpp"
 #include "Utilities/ErrorHandling/Breakpoint.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/Literals.hpp"
+#include "Utilities/MakeString.hpp"
 #include "Utilities/System/Abort.hpp"
 
 /*!
@@ -23,6 +23,19 @@
  * ERROR should not be used for coding errors, but instead for user errors
  * or failure modes of numerical algorithms. An acceptable use for error is also
  * in the default case of a switch statement.
+ *
+ * \details
+ * The implementation is specialized so that in compile time contexts, a short
+ * error message will be thrown, but in runtime contexts, a more verbose error
+ * will be printed. This specialization of throwing a short error at compile
+ * time greatly reduces the compile time and memory consumption during debug
+ * builds of deep and heavily inlined `TensorExpression` tree traversals.
+ *
+ * To accomplish this, `__builtin_is_constant_evaluated()` is used directly
+ * instead of calling a wrapper function because calling a wrapper was found to
+ * slightly increase the compile time and memory usage of large
+ * `TensorExpression`s when compiling in debug mode.
+ *
  * \param m an arbitrary output stream.
  */
 // isocpp.org recommends using an `if (true)` instead of a `do
@@ -34,34 +47,16 @@
 // 20160415) can't figure out that the else branch and everything
 // after it is unreachable, causing warnings (and possibly suboptimal
 // code generation).
-#define ERROR(m)                                                            \
-  do {                                                                      \
-    disable_floating_point_exceptions();                                    \
-    std::ostringstream avoid_name_collisions_ERROR;                         \
-    /* clang-tidy: macro arg in parentheses */                              \
-    avoid_name_collisions_ERROR << m; /* NOLINT */                          \
-    abort_with_error_message(__FILE__, __LINE__,                            \
-                             static_cast<const char*>(__PRETTY_FUNCTION__), \
-                             avoid_name_collisions_ERROR.str());            \
-  } while (false)
-
-/*!
- * \ingroup ErrorHandlingGroup
- * \brief prints an error message to the standard error and aborts the
- * program.
- *
- * CERROR is just like ERROR and so the same guidelines apply. However, because
- * it does not use std::stringstream it can be used in some constexpr
- * functions where ERROR cannot be.
- * \param m error message as a string, may need to use string literals
- */
-#define CERROR(m)                                                             \
+#define ERROR(m)                                                              \
   do {                                                                        \
-    breakpoint();                                                             \
-    sys::abort("\n################ ERROR ################\nLine: "s +         \
-               std::to_string(__LINE__) + " of file '"s + __FILE__ + "'\n"s + \
-               m + /* NOLINT */                                               \
-               "\n#######################################\n"s);               \
+    if (__builtin_is_constant_evaluated()) {                                  \
+      throw std::runtime_error("Failed");                                     \
+    } else {                                                                  \
+      disable_floating_point_exceptions();                                    \
+      abort_with_error_message(__FILE__, __LINE__,                            \
+                               static_cast<const char*>(__PRETTY_FUNCTION__), \
+                               MakeString{} << m);                            \
+    }                                                                         \
   } while (false)
 
 /*!
@@ -69,13 +64,14 @@
  * \brief Same as ERROR but does not print a backtrace. Intended to be used for
  * user errors, such as incorrect values in an input file.
  */
-#define ERROR_NO_TRACE(m)                                                  \
-  do {                                                                     \
-    disable_floating_point_exceptions();                                   \
-    std::ostringstream avoid_name_collisions_ERROR;                        \
-    /* clang-tidy: macro arg in parentheses */                             \
-    avoid_name_collisions_ERROR << m; /* NOLINT */                         \
-    abort_with_error_message_no_trace(                                     \
-        __FILE__, __LINE__, static_cast<const char*>(__PRETTY_FUNCTION__), \
-        avoid_name_collisions_ERROR.str());                                \
+#define ERROR_NO_TRACE(m)                                                    \
+  do {                                                                       \
+    if (__builtin_is_constant_evaluated()) {                                 \
+      throw std::runtime_error("Failed");                                    \
+    } else {                                                                 \
+      disable_floating_point_exceptions();                                   \
+      abort_with_error_message_no_trace(                                     \
+          __FILE__, __LINE__, static_cast<const char*>(__PRETTY_FUNCTION__), \
+          MakeString{} << m);                                                \
+    }                                                                        \
   } while (false)

--- a/src/Utilities/ErrorHandling/ExpectsAndEnsures.hpp
+++ b/src/Utilities/ErrorHandling/ExpectsAndEnsures.hpp
@@ -27,10 +27,10 @@
  * \param cond the expression that is expected to be true
  */
 #if defined(SPECTRE_DEBUG) || defined(EXPECTS_ENSURES)
-#define Expects(cond)                      \
-  if (UNLIKELY(!(cond))) {                 \
-    CERROR("Expects violated: "s + #cond); \
-  } else                                   \
+#define Expects(cond)      \
+  if (UNLIKELY(!(cond))) { \
+    ERROR(#cond);          \
+  } else                   \
     static_cast<void>(0)
 #else
 #define Expects(cond)        \
@@ -49,10 +49,10 @@
  * \param cond the expression that is expected to be true
  */
 #if defined(SPECTRE_DEBUG) || defined(EXPECTS_ENSURES)
-#define Ensures(cond)                      \
-  if (UNLIKELY(!(cond))) {                 \
-    CERROR("Ensures violated: "s + #cond); \
-  } else                                   \
+#define Ensures(cond)      \
+  if (UNLIKELY(!(cond))) { \
+    ERROR(#cond);          \
+  } else                   \
     static_cast<void>(0)
 #else
 #define Ensures(cond)        \

--- a/tests/Unit/DataStructures/Tensor/Test_Tensor.cpp
+++ b/tests/Unit/DataStructures/Tensor/Test_Tensor.cpp
@@ -1313,7 +1313,7 @@ SPECTRE_TEST_CASE("Unit.Serialization.Tensor",
   test_serialization(tensor);
 }
 
-// [[OutputRegex, Expects violated: index >= 0 and index < narrow_cast<Size>]]
+// [[OutputRegex, index >= 0 and index < narrow_cast<Size>]]
 [[noreturn]] SPECTRE_TEST_CASE(
     "Unit.DataStructures.Tensor.out_of_bounds_subscript",
     "[DataStructures][Unit]") {
@@ -1325,7 +1325,7 @@ SPECTRE_TEST_CASE("Unit.Serialization.Tensor",
 #endif
 }
 
-// [[OutputRegex, Expects violated: index >= 0 and index < narrow_cast<Size>]]
+// [[OutputRegex, index >= 0 and index < narrow_cast<Size>]]
 [[noreturn]] SPECTRE_TEST_CASE(
     "Unit.DataStructures.Tensor.const_out_of_bounds_subscript",
     "[DataStructures][Unit]") {
@@ -1337,7 +1337,7 @@ SPECTRE_TEST_CASE("Unit.Serialization.Tensor",
 #endif
 }
 
-// [[OutputRegex, Expects violated: index >= 0 and index < narrow_cast<Size>]]
+// [[OutputRegex, index >= 0 and index < narrow_cast<Size>]]
 [[noreturn]] SPECTRE_TEST_CASE(
     "Unit.DataStructures.Tensor.const_out_of_bounds_multiplicity",
     "[DataStructures][Unit]") {
@@ -1349,7 +1349,7 @@ SPECTRE_TEST_CASE("Unit.Serialization.Tensor",
 #endif
 }
 
-// [[OutputRegex, Expects violated: index >= 0 and index < narrow_cast<Size>]]
+// [[OutputRegex, index >= 0 and index < narrow_cast<Size>]]
 [[noreturn]] SPECTRE_TEST_CASE(
     "Unit.DataStructures.Tensor.const_out_of_bounds_get_tensor_index_vector",
     "[DataStructures][Unit]") {


### PR DESCRIPTION
This PR removes the `CERROR` macro and updates the `ERROR` and `ERROR_NO_TRACE` macros to have specialized implementations for when they are evaluated at compile time and runtime. **Note:** this change requires >= gcc-9 or >= clang-9 

The motivation for this PR is that it was discovered that very large `TensorExpression`s with deep and heavily inlined expression tree traversals were using a lot of time and memory for compilation. The deeper the tree and the more recursive inlining, the worse Debug compilation got. The largest contributor to this is the length of the `sys::abort` message used in `CERROR`. To address this, this PR specializes `ERROR` and `ERROR_NO_TRACE` to throw a short error at compile time but still print a more verbose error at runtime.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
This requires updaying computing resources to use >= gcc-9 or >= clang-9
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
