### PR TITLE
Remove colons from control system measurement names

### DIFF
--- a/docs/Tutorials/Visualization.md
+++ b/docs/Tutorials/Visualization.md
@@ -66,6 +66,9 @@ ignore under `Point Arrays` before clicking `Apply`. Also, don't forget to check
 which dataset is being used for the color under `Coloring`. The default won't
 necessarily be the dataset you want.
 
+\note ParaView cannot understand `.xmf` files when subfile names have colons in
+them. Please avoid subfile names like `My::Subfile:Name`.
+
 ### Helpful ParaView Filters
 
 Here we describe the usage of filters we've found to better visualize our data.

--- a/src/ControlSystem/ApparentHorizons/Measurements.hpp
+++ b/src/ControlSystem/ApparentHorizons/Measurements.hpp
@@ -51,7 +51,7 @@ struct BothHorizons : tt::ConformsTo<protocols::Measurement> {
     struct InterpolationTarget
         : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
       static std::string name() {
-        return "ControlSystem::BothHorizons::Ah" + ::ah::name(Horizon);
+        return "ControlSystemAh" + ::ah::name(Horizon);
       }
 
       struct temporal_id : db::SimpleTag {


### PR DESCRIPTION
## Proposed changes

ParaVeiw cannot understand subfile names in xmf files if there are colons in the name.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
If you have scripts that read out the names for the control system, they need to have the colons removed.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
