### PR TITLE
Add ASSERT for checking subcell volume extents and stencil width.

### DIFF
--- a/src/NumericalAlgorithms/FiniteDifference/Reconstruct.tpp
+++ b/src/NumericalAlgorithms/FiniteDifference/Reconstruct.tpp
@@ -20,14 +20,14 @@
 namespace fd::reconstruction {
 namespace detail {
 template <typename Reconstructor, size_t Dim, typename... ArgsForReconstructor>
-void reconstruct_impl(
-    const gsl::not_null<gsl::span<double>*> recons_upper,
-    const gsl::not_null<gsl::span<double>*> recons_lower,
-    const gsl::span<const double>& volume_vars,
-    const gsl::span<const double>& lower_ghost_data,
-    const gsl::span<const double>& upper_ghost_data,
-    const Index<Dim>& volume_extents, const size_t number_of_variables,
-    const ArgsForReconstructor&... args_for_reconstructor) {
+void reconstruct_impl(const gsl::not_null<gsl::span<double>*> recons_upper,
+                      const gsl::not_null<gsl::span<double>*> recons_lower,
+                      const gsl::span<const double>& volume_vars,
+                      const gsl::span<const double>& lower_ghost_data,
+                      const gsl::span<const double>& upper_ghost_data,
+                      const Index<Dim>& volume_extents,
+                      const size_t number_of_variables,
+                      const ArgsForReconstructor&... args_for_reconstructor) {
   constexpr size_t stencil_width = Reconstructor::stencil_width();
   ASSERT(stencil_width % 2 == 1, "The stencil with should be odd but got "
                                      << stencil_width
@@ -114,6 +114,14 @@ void reconstruct_impl(
       //             ^
       //         c c c c | c
       //  c = points used for reconstruction
+
+      ASSERT(
+          volume_extents[0] >= stencil_width - 1,
+          " Subcell volume extent (current value: "
+              << volume_extents[0]
+              << ") must be not smaller than the stencil width (current value: "
+              << stencil_width << ") minus 1");
+
       size_t j = 0;
       for (size_t k =
                vars_slice_offset + volume_extents[0] - (stencil_width - 1 - i);


### PR DESCRIPTION

## Proposed changes

Subcell volume extent should not be smaller than (FD stencil width - 1), since otherwise it would cause invalid memory access in the reconstruction core routine.


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
