### PR TITLE
Update running and visualizing tutorial

### DIFF
--- a/docs/Tutorials/Visualization.md
+++ b/docs/Tutorials/Visualization.md
@@ -12,8 +12,8 @@ SpECTRE source files for evolution executables are located in
 as defined in the `CMakeLists.txt` file located in the same directory as the
 source file. For example, to compile the executable that evolves a scalar wave
 using a three-dimensional domain, one runs the command:
-`make EvolvePlaneWave3D`, which then results in an executable of the same name
-in the `bin` directory of the user's build directory.
+`make EvolveScalarWavePlaneWave3D`, which then results in an executable of the
+same name in the `bin` directory of the user's build directory.
 
 ### Running an Evolution Executable
 
@@ -25,7 +25,7 @@ which the user can then modify as desired. Copy the executable and YAML file
 to a directory of your choice. The YAML file is then passed as an argument to
 the executable using the flag `--input-file`. For example, for a scalar wave
 evolution, run the command:
-`./EvolvePlaneWave3D --input-file Input3DPeriodic.yaml`.
+`./EvolveScalarWavePlaneWave3D --input-file PlaneWave3D.yaml`.
 By default, the example input files do not produce any output. This can be
 changed by modifying the options passed to `EventsAndTriggers` or
 `EventsAndDenseTriggers`:


### PR DESCRIPTION
## Proposed changes

The user tutorial for running and visualizing had depreciated naming conventions for both the scalar wave executable and YAML file. Both outdated naming conventions are updated to avoid confusion.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
