### PR TITLE
Add a global enum class Phase

### DIFF
--- a/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
+++ b/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
@@ -38,6 +38,7 @@
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/Reduction.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
@@ -220,7 +221,7 @@ struct Metavariables {
           linear_solver, multigrid, schwarz_smoother>>>;
 
   // Specify all global synchronization points.
-  enum class Phase { Initialization, RegisterWithObserver, Solve, Exit };
+  using Phase = Parallel::Phase;
 
   using initialization_actions = tmpl::list<
       Actions::SetupDataBox,

--- a/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
@@ -34,6 +34,7 @@
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/Reduction.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
@@ -194,7 +195,7 @@ struct Metavariables {
           linear_solver, multigrid, schwarz_smoother>>>;
 
   // Specify all global synchronization points.
-  enum class Phase { Initialization, RegisterWithObserver, Solve, Exit };
+  using Phase = Parallel::Phase;
 
   // For labeling the yaml option for RandomizeVariables
   struct RandomizeInitialGuess {};

--- a/src/Elliptic/Executables/Xcts/SolveXcts.hpp
+++ b/src/Elliptic/Executables/Xcts/SolveXcts.hpp
@@ -36,6 +36,7 @@
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/Reduction.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
@@ -244,7 +245,7 @@ struct Metavariables {
           linear_solver, multigrid, schwarz_smoother>>>;
 
   // Specify all global synchronization points.
-  enum class Phase { Initialization, RegisterWithObserver, Solve, Exit };
+  using Phase = Parallel::Phase;
 
   using initialization_actions = tmpl::list<
       Actions::SetupDataBox,

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -64,6 +64,7 @@
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Local.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp"
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
@@ -144,15 +145,7 @@ struct EvolutionMetavars {
   using limiter =
       Tags::Limiter<Limiters::Minmod<1, system::variables_tag::tags_list>>;
 
-  enum class Phase {
-    Initialization,
-    LoadBalancing,
-    WriteCheckpoint,
-    RegisterWithObserver,
-    InitializeTimeStepperHistory,
-    Evolve,
-    Exit
-  };
+  using Phase = Parallel::Phase;
 
   static std::string phase_name(Phase phase) {
     if (phase == Phase::LoadBalancing) {

--- a/src/Evolution/Executables/Cce/CharacteristicExtract.hpp
+++ b/src/Evolution/Executables/Cce/CharacteristicExtract.hpp
@@ -35,6 +35,7 @@
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Algorithms/AlgorithmSingleton.hpp"
 #include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Time/StepChoosers/Factory.hpp"
 #include "Time/StepControllers/Factory.hpp"
@@ -80,12 +81,7 @@ struct EvolutionMetavars : CharacteristicExtractDefaults {
       "Perform Cauchy Characteristic Extraction using .h5 input data.\n"
       "Uses regularity-preserving formulation."};
 
-  enum class Phase {
-    Initialization,
-    InitializeTimeStepperHistory,
-    Evolve,
-    Exit
-  };
+  using Phase = Parallel::Phase;
 
   template <typename... Tags>
   static Phase determine_next_phase(

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -51,6 +51,7 @@
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Local.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp"
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
@@ -141,15 +142,7 @@ struct EvolutionMetavars {
   using temporal_id = Tags::TimeStepId;
   static constexpr bool local_time_stepping = true;
 
-  enum class Phase {
-    Initialization,
-    Register,
-    InitializeTimeStepperHistory,
-    LoadBalancing,
-    WriteCheckpoint,
-    Evolve,
-    Exit
-  };
+  using Phase = Parallel::Phase;
 
   static std::string phase_name(Phase phase) {
     if (phase == Phase::LoadBalancing) {

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -67,6 +67,7 @@
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Local.hpp"
 #include "Parallel/MemoryMonitor/MemoryMonitor.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp"
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
@@ -168,18 +169,7 @@ struct EvolutionMetavars {
   // `read_spec_piecewise_polynomial()`
   static constexpr bool override_functions_of_time = true;
 
-  enum class Phase {
-    Initialization,
-    RegisterWithElementDataReader,
-    ImportInitialData,
-    InitializeInitialDataDependentQuantities,
-    InitializeTimeStepperHistory,
-    Register,
-    LoadBalancing,
-    WriteCheckpoint,
-    Evolve,
-    Exit
-  };
+  using Phase = Parallel::Phase;
 
   static std::string phase_name(Phase phase) {
     if (phase == Phase::LoadBalancing) {

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -57,6 +57,7 @@
 #include "Parallel/Algorithms/AlgorithmSingleton.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Local.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp"
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
@@ -163,18 +164,7 @@ struct GeneralizedHarmonicTemplateBase<
   // `read_spec_piecewise_polynomial()`
   static constexpr bool override_functions_of_time = false;
 
-  enum class Phase {
-    Initialization,
-    RegisterWithElementDataReader,
-    ImportInitialData,
-    InitializeInitialDataDependentQuantities,
-    InitializeTimeStepperHistory,
-    Register,
-    LoadBalancing,
-    WriteCheckpoint,
-    Evolve,
-    Exit
-  };
+  using Phase = Parallel::Phase;
 
   static std::string phase_name(Phase phase) {
     if (phase == Phase::LoadBalancing) {

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -76,6 +76,7 @@
 #include "Parallel/Algorithms/AlgorithmSingleton.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Local.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
@@ -203,17 +204,7 @@ struct GhValenciaDivCleanDefaults {
                                      grmhd::ValenciaDivClean::Tags::TildeS<>,
                                      grmhd::ValenciaDivClean::Tags::TildeB<>>>>;
 
-  enum class Phase {
-    Initialization,
-    RegisterWithElementDataReader,
-    ImportInitialData,
-    InitializeInitialDataDependentQuantities,
-    InitializeTimeStepperHistory,
-    Register,
-    LoadBalancing,
-    Evolve,
-    Exit
-  };
+  using Phase = Parallel::Phase;
 
   static std::string phase_name(Phase phase) {
     if (phase == Phase::LoadBalancing) {

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -93,6 +93,7 @@
 #include "Parallel/Algorithms/AlgorithmSingleton.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Local.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp"
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
@@ -223,15 +224,7 @@ struct EvolutionMetavars {
       tmpl::remove_duplicates<tmpl::flatten<tmpl::list<
           typename InterpolationTargetTags::vars_to_interpolate_to_target...>>>;
 
-  enum class Phase {
-    Initialization,
-    InitializeTimeStepperHistory,
-    Register,
-    LoadBalancing,
-    WriteCheckpoint,
-    Evolve,
-    Exit
-  };
+  using Phase = Parallel::Phase;
 
   static std::string phase_name(Phase phase) {
     if (phase == Phase::LoadBalancing) {

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -73,6 +73,7 @@
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Local.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp"
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
@@ -172,15 +173,7 @@ struct EvolutionMetavars {
 
   using limiter = Tags::Limiter<NewtonianEuler::Limiters::Minmod<Dim>>;
 
-  enum class Phase {
-    Initialization,
-    InitializeTimeStepperHistory,
-    Register,
-    LoadBalancing,
-    WriteCheckpoint,
-    Evolve,
-    Exit
-  };
+  using Phase = Parallel::Phase;
 
   static std::string phase_name(Phase phase) {
     if (phase == Phase::LoadBalancing) {

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -49,6 +49,7 @@
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Local.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp"
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
@@ -133,15 +134,7 @@ struct EvolutionMetavars {
   using limiter = Tags::Limiter<
       Limiters::Minmod<3, typename system::variables_tag::tags_list>>;
 
-  enum class Phase {
-    Initialization,
-    InitializeTimeStepperHistory,
-    RegisterWithObserver,
-    LoadBalancing,
-    WriteCheckpoint,
-    Evolve,
-    Exit
-  };
+  using Phase = Parallel::Phase;
 
   static std::string phase_name(Phase phase) {
     if (phase == Phase::LoadBalancing) {

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -53,6 +53,7 @@
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Local.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp"
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
@@ -145,15 +146,7 @@ struct EvolutionMetavars {
                       RelativisticEuler::Valencia::Tags::TildeTau,
                       RelativisticEuler::Valencia::Tags::TildeS<Dim>>>>;
 
-  enum class Phase {
-    Initialization,
-    InitializeTimeStepperHistory,
-    RegisterWithObserver,
-    LoadBalancing,
-    WriteCheckpoint,
-    Evolve,
-    Exit
-  };
+  using Phase = Parallel::Phase;
 
   static std::string phase_name(Phase phase) {
     if (phase == Phase::LoadBalancing) {

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -67,6 +67,7 @@
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Local.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
@@ -146,14 +147,7 @@ struct EvolutionMetavars {
   using limiter = Tags::Limiter<
       Limiters::Minmod<Dim, typename system::variables_tag::tags_list>>;
 
-  enum class Phase {
-    Initialization,
-    LoadBalancing,
-    RegisterWithObserver,
-    InitializeTimeStepperHistory,
-    Evolve,
-    Exit
-  };
+  using Phase = Parallel::Phase;
 
   static std::string phase_name(Phase phase) {
     if (phase == Phase::LoadBalancing) {

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -48,6 +48,7 @@
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Local.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp"
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
@@ -127,15 +128,7 @@ struct EvolutionMetavars {
   using temporal_id = Tags::TimeStepId;
   static constexpr bool local_time_stepping = true;
 
-  enum class Phase {
-    Initialization,
-    RegisterWithObserver,
-    InitializeTimeStepperHistory,
-    LoadBalancing,
-    WriteCheckpoint,
-    Evolve,
-    Exit
-  };
+  using Phase = Parallel::Phase;
 
   static std::string phase_name(Phase phase) {
     if (phase == Phase::LoadBalancing) {

--- a/src/Executables/Examples/HelloWorld/SingletonHelloWorld.hpp
+++ b/src/Executables/Examples/HelloWorld/SingletonHelloWorld.hpp
@@ -14,6 +14,7 @@
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Local.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/Printf.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
@@ -96,7 +97,7 @@ struct Metavars {
   static constexpr Options::String help{
       "Say hello from a singleton parallel component."};
 
-  enum class Phase { Initialization, Execute, Exit };
+  using Phase = Parallel::Phase;
 
   template <typename... Tags>
   static Phase determine_next_phase(

--- a/src/Executables/Examples/ParallelTutorial/MinimalExecutable.hpp
+++ b/src/Executables/Examples/ParallelTutorial/MinimalExecutable.hpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "Options/Options.hpp"
+#include "Parallel/Phase.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -19,7 +20,7 @@ class CProxy_GlobalCache;
 struct Metavariables {
   using component_list = tmpl::list<>;
 
-  enum class Phase { Initialization, Exit };
+  using Phase = Parallel::Phase;
 
   template <typename... Tags>
   static Phase determine_next_phase(

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -39,6 +39,7 @@
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Local.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/Reduction.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
@@ -229,7 +230,7 @@ struct Metavariables {
                    tmpl::list<Triggers::SlabCompares, Triggers::TimeCompares>>>;
   };
 
-  enum class Phase { Initialization, RegisterWithObserver, Export, Exit };
+  using Phase = Parallel::Phase;
 
   using component_list = tmpl::list<
       DgElementArray<
@@ -256,7 +257,7 @@ struct Metavariables {
                                  Actions::FindGlobalMinimumGridSpacing>,
                              Parallel::Actions::TerminatePhase>>,
               Parallel::PhaseActions<
-                  typename Metavariables::Phase, Metavariables::Phase::Export,
+                  typename Metavariables::Phase, Metavariables::Phase::Execute,
                   tmpl::list<Actions::AdvanceTime,
                              Actions::ExportCoordinates<Dim>,
                              Actions::FindGlobalMinimumGridSpacing,
@@ -277,8 +278,8 @@ struct Metavariables {
       case Phase::Initialization:
         return Phase::RegisterWithObserver;
       case Phase::RegisterWithObserver:
-        return Phase::Export;
-      case Phase::Export:
+        return Phase::Execute;
+      case Phase::Execute:
         return Phase::Exit;
       case Phase::Exit:
         ERROR(

--- a/src/Parallel/CMakeLists.txt
+++ b/src/Parallel/CMakeLists.txt
@@ -13,6 +13,7 @@ spectre_target_sources(
   PRIVATE
   InitializationFunctions.cpp
   NodeLock.cpp
+  Phase.cpp
   Reduction.cpp
   )
 
@@ -40,6 +41,7 @@ spectre_target_headers(
   MaxInlineMethodsReached.hpp
   NodeLock.hpp
   ParallelComponentHelpers.hpp
+  Phase.hpp
   PhaseControlReductionHelpers.hpp
   PhaseDependentActionList.hpp
   Printf.hpp
@@ -61,10 +63,10 @@ target_link_libraries(
   Boost::boost
   DataStructures
   Informer
-  Options
   PUBLIC
   Charmxx::charmxx
   ErrorHandling
+  Options
   SystemUtilities
   Utilities
   )

--- a/src/Parallel/Phase.cpp
+++ b/src/Parallel/Phase.cpp
@@ -1,0 +1,88 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Parallel/Phase.hpp"
+
+#include <ostream>
+#include <string>
+#include <utility>
+
+#include "Options/Options.hpp"
+#include "Options/ParseOptions.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/StdHelpers.hpp"
+
+namespace Parallel {
+std::vector<Phase> known_phases() {
+  return {Phase::Evolve,
+          Phase::Execute,
+          Phase::Exit,
+          Phase::ImportInitialData,
+          Phase::Initialization,
+          Phase::InitializeInitialDataDependentQuantities,
+          Phase::InitializeTimeStepperHistory,
+          Phase::LoadBalancing,
+          Phase::Register,
+          Phase::RegisterWithElementDataReader,
+          Phase::RegisterWithObserver,
+          Phase::Solve,
+          Phase::Test,
+          Phase::WriteCheckpoint};
+}
+
+std::ostream& operator<<(std::ostream& os, const Phase& phase) {
+  switch (phase) {
+    case Parallel::Phase::Evolve:
+      return os << "Evolve";
+    case Parallel::Phase::Execute:
+      return os << "Execute";
+    case Parallel::Phase::Exit:
+      return os << "Exit";
+    case Parallel::Phase::ImportInitialData:
+      return os << "ImportInitialData";
+    case Parallel::Phase::Initialization:
+      return os << "Initialization";
+    case Parallel::Phase::InitializeInitialDataDependentQuantities:
+      return os << "InitializeInitialDataDependentQuantities";
+    case Parallel::Phase::InitializeTimeStepperHistory:
+      return os << "InitializeTimeStepperHistory";
+    case Parallel::Phase::LoadBalancing:
+      return os << "LoadBalancing";
+    case Parallel::Phase::Register:
+      return os << "Register";
+    case Parallel::Phase::RegisterWithElementDataReader:
+      return os << "RegisterWithElementDataReader";
+    case Parallel::Phase::RegisterWithObserver:
+      return os << "RegisterWithObserver";
+    case Parallel::Phase::Solve:
+      return os << "Solve";
+    case Parallel::Phase::Test:
+      return os << "Test";
+    case Parallel::Phase::WriteCheckpoint:
+      return os << "WriteCheckpoint";
+    default:  // LCOV_EXCL_LINE
+      // LCOV_EXCL_START
+      ERROR("Stream operator does not have case for Phase with integral value "
+            << static_cast<std::underlying_type_t<Parallel::Phase>>(phase)
+            << "\n");
+      // LCOV_EXCL_STOP
+  }
+}
+}  // namespace Parallel
+
+template <>
+Parallel::Phase Options::create_from_yaml<Parallel::Phase>::create<void>(
+    const Options::Option& options) {
+  const auto type_read = options.parse_as<std::string>();
+  for (const auto phase : Parallel::known_phases()) {
+    if (type_read == get_output(phase)) {
+      return phase;
+    }
+  }
+  using ::operator<<;
+  PARSE_ERROR(options.context(),
+              "Failed to convert \""
+                  << type_read << "\" to Parallel::Phase.\nMust be one of "
+                  << Parallel::known_phases() << ".");
+}

--- a/src/Parallel/Phase.hpp
+++ b/src/Parallel/Phase.hpp
@@ -1,0 +1,98 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <iosfwd>
+#include <vector>
+
+/// \cond
+namespace Options {
+class Option;
+template <typename T>
+struct create_from_yaml;
+}  // namespace Options
+/// \endcond
+
+namespace Parallel {
+
+/*!
+ * \ingroup ParallelGroup
+ * \brief The possible phases of an executable
+ *
+ * \details Spectre executables are split into distinct phases separated by
+ * global synchronizations.  Each executable will start with phase
+ * `Initialization` and end with phase `Exit`.  The metavariables of each
+ * executable must define a static member function with the signature:
+ *
+ * \code
+ * static Parallel::Phase determine_next_phase(
+ *    const gsl::not_null<
+ *        tuples::TaggedTuple<Tags...>*> phase_change_decision_data,
+ *    const Parallel::Phase& current_phase,
+ *    const Parallel::CProxy_GlobalCache<Metavariables>& cache_proxy);
+ * \endcode
+ *
+ * that is used to determine the next phase once the current phase has ended.
+ *
+ * \warning The phases are in alphabetical order.  Do not use the values of the
+ * underlying integral type as they will change as new phases are added to the
+ * list!
+ *
+ * \see PhaseChange and \ref dev_guide_parallelization_foundations
+ * "Parallelization infrastructure" for details.
+ *
+ */
+enum class Phase {
+  // If you add a new phase: put it in the list alphabetically, add it to the
+  // vector created by known_phases() below, and add it to the stream operator
+  // If the new phase is the first or last in the list, update Test_Phase.
+
+  ///  phase in which time steps are taken for an evolution executable
+  Evolve,
+  ///  generic execution phase of an executable
+  Execute,
+  ///  final phase of an executable
+  Exit,
+  ///  phase in which initial data is imported from volume files
+  ImportInitialData,
+  ///  initial phase of an executable
+  Initialization,
+  ///  phase in which quantities dependent on imported initial data are
+  ///  initialized
+  InitializeInitialDataDependentQuantities,
+  ///  phase in which the time stepper executes a self-start procedure
+  InitializeTimeStepperHistory,
+  ///  phase in which components are migrated
+  LoadBalancing,
+  ///  phase in which components register with other components
+  Register,
+  ///  phase in which components register with the data importer components
+  RegisterWithElementDataReader,
+  ///  phase in which components register with the observer components
+  RegisterWithObserver,
+  ///  phase in which something is solved
+  Solve,
+  ///  phase in which something is tested
+  Test,
+  ///  phase in which checkpoint files are written to disk
+  WriteCheckpoint
+};
+
+std::vector<Phase> known_phases();
+
+/// Output operator for a Phase.
+std::ostream& operator<<(std::ostream& os, const Phase& phase);
+}  // namespace Parallel
+
+template <>
+struct Options::create_from_yaml<Parallel::Phase> {
+  template <typename Metavariables>
+  static Parallel::Phase create(const Options::Option& options) {
+    return create<void>(options);
+  }
+};
+
+template <>
+Parallel::Phase Options::create_from_yaml<Parallel::Phase>::create<void>(
+    const Options::Option& options);

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -178,6 +178,7 @@ set(LIBRARY_SOURCES
   Test_NodeLock.cpp
   Test_Parallel.cpp
   Test_ParallelComponentHelpers.cpp
+  Test_Phase.cpp
   Test_PupStlCpp11.cpp
   Test_PupStlCpp17.cpp
   Test_ResourceInfo.cpp
@@ -191,7 +192,7 @@ add_test_library(
   ${LIBRARY}
   "Parallel"
   "${LIBRARY_SOURCES}"
-  "IO;Options;SystemUtilities"
+  "IO;Options;Parallel;SystemUtilities"
   )
 
 add_dependencies(

--- a/tests/Unit/Parallel/Test_Phase.cpp
+++ b/tests/Unit/Parallel/Test_Phase.cpp
@@ -1,0 +1,32 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Framework/TestCreation.hpp"
+#include "Parallel/Phase.hpp"
+#include "Utilities/GetOutput.hpp"
+
+SPECTRE_TEST_CASE("Unit.Parallel.Phase", "[Parallel][Unit]") {
+  // These two variables must correspond to the first and last
+  // enum values of Parallel::Phase for the test to work properly
+  const Parallel::Phase first_enum = Parallel::Phase::Evolve;
+  const Parallel::Phase last_enum = Parallel::Phase::WriteCheckpoint;
+
+  using enum_t = std::underlying_type_t<Parallel::Phase>;
+  REQUIRE(enum_t(0) == static_cast<enum_t>(first_enum));
+  const auto known_phases = Parallel::known_phases();
+  REQUIRE(enum_t(known_phases.size()) == static_cast<enum_t>(last_enum) + 1);
+
+  for (const auto phase : known_phases) {
+    CHECK(phase ==
+          TestHelpers::test_creation<Parallel::Phase>(get_output(phase)));
+  }
+
+  CHECK_THROWS_WITH(
+      ([]() {
+        TestHelpers::test_creation<Parallel::Phase>("Bad phase name");
+      }()),
+      Catch::Contains(
+          "Failed to convert \"Bad phase name\" to Parallel::Phase."));
+}


### PR DESCRIPTION

## Proposed changes

Replace enum class Phase in each executable metavariables with the global one.

- This eliminates a lot of code duplication
- This adds the ability to stream Phases and parse them from an input file
- This makes it easy to add a new phase to all executables
- This will allow the elimination of some template parameters for the phase type
- This will allow the elimination of templating some things on the metavariables if they were only used for getting the phase type

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
If you have defined an `enum class Phase` in a metavariables, instead  `#include "Parallel/Phase.hpp"` and replace the enum definition with `using Phase = Parallel::Phase;`
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
