### PR TITLE
change to gcc-9 for code coverage

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -325,7 +325,7 @@ jobs:
           - build_type: Release
             ccache_max_size: 400M
           # Generate code coverage report for a single build
-          - compiler: gcc-10
+          - compiler: gcc-9
             build_type: Debug
             COVERAGE: ON
             TEST_TIMEOUT_FACTOR: 3


### PR DESCRIPTION
## Proposed changes

using gcc-10 was producing warnings `version 'B03*', prefer 'A94*'` which seems to be related to a mismatch between the compiler and the gcov version

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
