### PR TITLE
Relax more HwenoImpl test tolerances

### DIFF
--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_HwenoImpl.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_HwenoImpl.cpp
@@ -209,7 +209,10 @@ void test_constrained_fit_1d(const Spectral::Quadrature quadrature =
     }();
 
     // Fit procedure has somewhat larger error scale than default
-    Approx local_approx = Approx::custom().epsilon(1e-11).scale(1.);
+    // Error further increases when using Gauss points
+    const double gauss_tol =
+        (quadrature == Spectral::Quadrature::Gauss ? 10. : 1.);
+    Approx local_approx = Approx::custom().epsilon(gauss_tol * 1e-11).scale(1.);
     CHECK_ITERABLE_CUSTOM_APPROX(constrained_fit, expected, local_approx);
     // Verify that the constraint is in fact satisfied
     CHECK(mean_value(constrained_fit, mesh) ==
@@ -304,7 +307,10 @@ void test_constrained_fit_1d(const Spectral::Quadrature quadrature =
     }();
 
     // Fit procedure has somewhat larger error scale than default
-    Approx local_approx = Approx::custom().epsilon(1e-11).scale(1.);
+    // Error further increases when using Gauss points
+    const double gauss_tol =
+        (quadrature == Spectral::Quadrature::Gauss ? 10. : 1.);
+    Approx local_approx = Approx::custom().epsilon(gauss_tol * 1e-11).scale(1.);
     CHECK_ITERABLE_CUSTOM_APPROX(constrained_fit, expected, local_approx);
     CHECK(mean_value(constrained_fit, mesh) ==
           local_approx(mean_value(local_data, mesh)));


### PR DESCRIPTION
Similar changes to e2845c8eed6c459e7a6f6ea33d9b86effc697ef9 in more of
the checks.  Triggered with clang-14 on my machine.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
