### PR TITLE
Cleanup execs and libs after running tests

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -568,9 +568,11 @@ ${{ env.CACHE_KEY_SUFFIX }}"
           make install
       - name: Print size of install directory
         working-directory: /work/spectre_install
+        # Remove files post-install to reduce disk space for later on.
         run: |
           ls | xargs du -sh
           du -sh .
+          rm -r ./*
       - name: Test formaline tar can be built
         if: matrix.build_type == 'Debug'
         working-directory: /work/build
@@ -641,6 +643,8 @@ ${{ env.CACHE_KEY_SUFFIX }}"
           make EvolveBurgersStep -j2
 
           ctest -j2 -R InputFiles.Burgers.Step.yaml
+
+          make clean
       - name: Diagnose ccache
         run: |
           ccache -s
@@ -651,6 +655,12 @@ ${{ env.CACHE_KEY_SUFFIX }}"
         if: github.ref != 'refs/heads/develop'
         run: |
           rm -rf $CCACHE_DIR
+      # Delete the built objects to ensure there is enough disk space for
+      # creating a tarball of the cache.
+      - name: Cleanup install
+        working-directory: /work/build
+        run: |
+          make clean
 
   # Build all test executables and run unit tests on macOS
   unit_tests_macos:
@@ -808,6 +818,7 @@ ${{ env.CACHE_KEY_SUFFIX }}"
         run: |
           ls | xargs du -sh
           du -sh .
+          rm -r ./*
       # Retain caches only on the 'develop' branch (see unit_tests job)
       - name: Clear caches
         if: github.ref != 'refs/heads/develop'
@@ -826,6 +837,12 @@ ${{ env.CACHE_KEY_SUFFIX }}"
         # Allow the buildcache creation to fail without failing the job, since
         # it sometimes runs out of memory
         continue-on-error: true
+      # Delete the built objects to ensure there is enough disk space for
+      # creating a tarball of the cache.
+      - name: Cleanup install
+        working-directory: build
+        run: |
+          make clean
 
   # Release a new version on manual events when requested and the tests pass.
   # Only enable this on the `sxs-collaboration/spectre` repository (not on

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -346,11 +346,13 @@ jobs:
             ccache_max_size: 400M
           # Full clang-9 build to catch any incompatibilities.
           - compiler: clang-9
+            use_pch: ON
             build_type: Release
             ccache_max_size: 400M
           # Test with ASAN
           - compiler: clang-10
             build_type: Debug
+            use_pch: ON
             # When building with ASAN we also need python bindings to be
             # disabled because otherwise we get link errors. See issue:
             # https://github.com/sxs-collaboration/spectre/issues/1890
@@ -364,11 +366,13 @@ jobs:
           # mode because these builds use up little disk space compared to GCC
           # builds or clang Debug builds
           - compiler: clang-11
+            use_pch: ON
             build_type: Release
             BUILD_SHARED_LIBS: OFF
             MEMORY_ALLOCATOR: JEMALLOC
           # Test compatibility with oldest supported CMake version
           - compiler: clang-13
+            use_pch: ON
             build_type: Debug
             CMAKE_EXECUTABLE: /opt/local/cmake/3.12.4/bin/cmake
             CHARM_DIR: /work/charm_6_10_2/multicore-linux-x86_64-


### PR DESCRIPTION
## Proposed changes

Storing the cache can sometimes run out of disk space. To avoid that, we clean
up the executables and libraries before storing the cache.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
