### PR TITLE
Interpolation without Interpolator ParallelComponent for time-dependent maps.

### DIFF
--- a/src/ParallelAlgorithms/Interpolation/Actions/ElementReceiveInterpPoints.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/ElementReceiveInterpPoints.hpp
@@ -35,21 +35,20 @@ struct ElementReceiveInterpPoints {
             Requires<tmpl::list_contains_v<
                 DbTags, intrp::Tags::InterpPointInfo<Metavariables>>> = nullptr>
   static void apply(
-      db::DataBox<DbTags>& box, Parallel::GlobalCache<Metavariables>& /*cache*/,
+      db::DataBox<DbTags>& box,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/,
-      std::vector<std::optional<
-          IdPair<domain::BlockId, tnsr::I<double, Metavariables::volume_dim,
-                                          typename ::Frame::BlockLogical>>>>&&
-          block_logical_coords) {
+      tnsr::I<DataVector, Metavariables::volume_dim,
+              typename InterpolationTargetTag::compute_target_points::frame>&&
+          coords) {
     db::mutate<intrp::Tags::InterpPointInfo<Metavariables>>(
         make_not_null(&box),
-        [&block_logical_coords](
-            const gsl::not_null<
-                typename intrp::Tags::InterpPointInfo<Metavariables>::type*>
-                point_infos) {
+        [&coords](const gsl::not_null<
+                  typename intrp::Tags::InterpPointInfo<Metavariables>::type*>
+                      point_infos) {
           get<intrp::Vars::PointInfoTag<InterpolationTargetTag,
                                         Metavariables::volume_dim>>(
-              *point_infos) = std::move(block_logical_coords);
+              *point_infos) = std::move(coords);
         });
   }
 };

--- a/src/ParallelAlgorithms/Interpolation/Actions/InterpolationTargetSendPoints.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/InterpolationTargetSendPoints.hpp
@@ -18,7 +18,9 @@ namespace Actions {
 /// \ingroup ActionsGroup
 /// \brief Sends interpolation points to all the Elements.
 ///
-/// This action is for the case in which the points are time-independent.
+/// This action is for the case in which the points are time-independent
+/// in the frame of the InterpolationTarget (which may or may not mean that
+/// the points are time-independent in the grid frame).
 ///
 /// This action should be placed in the Registration PDAL for
 /// InterpolationTarget.
@@ -43,8 +45,13 @@ struct InterpolationTargetSendTimeIndepPointsToElements {
       Parallel::GlobalCache<Metavariables>& cache,
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
-    auto coords = InterpolationTarget_detail::block_logical_coords<
-        InterpolationTargetTag>(box, tmpl::type_<Metavariables>{});
+    static_assert(
+        not InterpolationTargetTag::compute_target_points::is_sequential::value,
+        "Actions::InterpolationTargetSendTimeIndepPointsToElement can be used "
+        "only with non-sequential targets, since a sequential target is "
+        "time-dependent by definition.");
+    auto coords = InterpolationTargetTag::compute_target_points::points(
+        box, tmpl::type_<Metavariables>{});
     auto& receiver_proxy = Parallel::get_parallel_component<
         typename InterpolationTargetTag::template interpolating_component<
             Metavariables>>(cache);

--- a/src/ParallelAlgorithms/Interpolation/Actions/InterpolationTargetVarsFromElement.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/InterpolationTargetVarsFromElement.hpp
@@ -56,6 +56,10 @@ namespace Actions {
 ///                   InterpolationTargetTag::vars_to_interpolate_to_target>`
 ///
 /// For requirements on InterpolationTargetTag, see InterpolationTarget
+/// and intrp::protocols::InterpolationTargetTag
+///
+/// \note This action can be used only with InterpolationTargets that are
+/// non-sequential.
 template <typename InterpolationTargetTag>
 struct InterpolationTargetVarsFromElement {
   /// For requirements on Metavariables, see InterpolationTarget
@@ -70,6 +74,10 @@ struct InterpolationTargetVarsFromElement {
       const std::vector<Variables<
           typename InterpolationTargetTag::vars_to_interpolate_to_target>>&
           vars_src,
+      const std::vector<std::optional<
+          IdPair<domain::BlockId, tnsr::I<double, Metavariables::volume_dim,
+                                          typename ::Frame::BlockLogical>>>>&
+          block_logical_coords,
       const std::vector<std::vector<size_t>>& global_offsets,
       const TemporalId& temporal_id) {
     static_assert(
@@ -127,9 +135,7 @@ struct InterpolationTargetVarsFromElement {
                                         std::vector<TemporalId>{{temporal_id}})
                 .empty()) {
       InterpolationTarget_detail::set_up_interpolation<InterpolationTargetTag>(
-          make_not_null(&box), temporal_id,
-          InterpolationTarget_detail::block_logical_coords<
-              InterpolationTargetTag>(box, tmpl::type_<Metavariables>{}));
+          make_not_null(&box), temporal_id, block_logical_coords);
     }
 
     InterpolationTarget_detail::add_received_variables<InterpolationTargetTag>(

--- a/src/ParallelAlgorithms/Interpolation/Actions/VerifyTemporalIdsAndSendPoints.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/VerifyTemporalIdsAndSendPoints.hpp
@@ -238,7 +238,7 @@ struct VerifyTemporalIdsAndSendPoints {
                                                      cache);
     } else {
       if (InterpolationTarget_detail::maps_are_time_dependent<
-              InterpolationTargetTag>(box, tmpl::type_<Metavariables>{})) {
+              InterpolationTargetTag>(cache)) {
         if constexpr (Parallel::is_in_mutable_global_cache<
                           Metavariables, domain::Tags::FunctionsOfTime>) {
           detail::verify_temporal_ids_and_send_points_time_dependent<

--- a/src/ParallelAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp
@@ -104,9 +104,13 @@ class InterpolateWithoutInterpComponent<VolumeDim, InterpolationTargetTag,
       Parallel::GlobalCache<Metavariables>& cache,
       const ElementId<VolumeDim>& array_index,
       const ParallelComponent* const /*meta*/) const {
-    // Get element logical coordinates of the target points.
     const auto& block_logical_coords =
-        get<Vars::PointInfoTag<InterpolationTargetTag, VolumeDim>>(point_infos);
+        InterpolationTarget_detail::block_logical_coords<
+            InterpolationTargetTag>(
+            cache,
+            get<Vars::PointInfoTag<InterpolationTargetTag, VolumeDim>>(
+                point_infos),
+            temporal_id);
     const std::vector<ElementId<VolumeDim>> element_ids{{array_index}};
     const auto element_coord_holders =
         element_logical_coordinates(element_ids, block_logical_coords);
@@ -190,6 +194,7 @@ class InterpolateWithoutInterpComponent<VolumeDim, InterpolationTargetTag,
         std::vector<Variables<
             typename InterpolationTargetTag::vars_to_interpolate_to_target>>(
             {interpolator.interpolate(interp_vars)}),
+        block_logical_coords,
         std::vector<std::vector<size_t>>({element_coord_holder.offsets}),
         temporal_id);
   }

--- a/src/ParallelAlgorithms/Interpolation/InterpolationTarget.hpp
+++ b/src/ParallelAlgorithms/Interpolation/InterpolationTarget.hpp
@@ -232,10 +232,6 @@ namespace intrp {
 ///
 /// ###### Current logic:
 ///
-/// >  `Actions::EnsureFunctionOfTimeUpToDate` does not exist
-///
-/// ###### New logic:
-///
 /// > `Actions::EnsureFunctionOfTimeUpToDate` is placed in `DgElementArray`s
 /// >  PDAL before any use of interpolation.
 ///
@@ -247,16 +243,19 @@ namespace intrp {
 ///
 /// ###### Current logic:
 ///
-/// > Call `block_logical_coordinates` and send points to `Element`s.
-///
-/// ###### New logic:
-///
 /// > Send the result of `compute_target_points` to all `Element`s.
 ///
 /// Note that this may need to be revisited because every `Element` has
-/// a copy of every target point, which will use a lot of memory.  An
-/// alternative is to invoke an Action on each `InterpolationTarget`
-/// (presumably from an `Event`).
+/// a copy of every target point, which may use a lot of memory.  An
+/// alternative is for each Element to invoke an Action on each
+/// `InterpolationTarget` (presumably from an `Event`) at each time,
+/// and then the InterpolationTarget invokes another Action to send points
+/// to only those `Elements` that contain the points; this alternative
+/// uses less memory but much more communication. Another alternative would
+/// be to place the points in the MutableGlobalCache (so that there is one
+/// copy per core, rather than one copy per Element), or even in the
+/// GlobalCache (one copy per node) since the points need be computed only
+/// once.
 ///
 template <class Metavariables, typename InterpolationTargetTag>
 struct InterpolationTarget {

--- a/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
+++ b/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
@@ -283,12 +283,11 @@ bool have_data_at_all_points(const db::DataBox<DbTags>& box,
 
 /// Returns true if at least one Block in the Domain has
 /// time-dependent maps.
-template <typename InterpolationTargetTag, typename DbTags,
-          typename Metavariables>
-bool maps_are_time_dependent(const db::DataBox<DbTags>& box,
-                             const tmpl::type_<Metavariables>& /*meta*/) {
+template <typename InterpolationTargetTag, typename Metavariables>
+bool maps_are_time_dependent(
+    const Parallel::GlobalCache<Metavariables>& cache) {
   const auto& domain =
-      db::get<domain::Tags::Domain<Metavariables::volume_dim>>(box);
+      get<domain::Tags::Domain<Metavariables::volume_dim>>(cache);
   return alg::any_of(domain.blocks(), [](const auto& block) {
     return block.is_time_dependent();
   });
@@ -492,8 +491,7 @@ auto block_logical_coords(const db::DataBox<DbTags>& box,
                     box, tmpl::type_<Metavariables>{}, temporal_id));
   }
 
-  if (maps_are_time_dependent<InterpolationTargetTag>(
-          box, tmpl::type_<Metavariables>{})) {
+  if (maps_are_time_dependent<InterpolationTargetTag>(cache)) {
     if constexpr (Parallel::is_in_mutable_global_cache<
                       Metavariables, domain::Tags::FunctionsOfTime>) {
       // Whoever calls block_logical_coords when the maps are

--- a/src/ParallelAlgorithms/Interpolation/PointInfoTag.hpp
+++ b/src/ParallelAlgorithms/Interpolation/PointInfoTag.hpp
@@ -14,16 +14,16 @@
 
 namespace intrp {
 namespace Vars {
+/// PointInfoTag holds the points to be interpolated onto,
+/// in whatever frame those points are to be held constant.
+/// PointInfoTag is used only for interpolation points that are
+/// time-independent in some frame, so that there is no `Interpolator`
+/// ParallelComponent.
 template <typename InterpolationTargetTag, size_t VolumeDim>
 struct PointInfoTag {
-  /// This is the type returned from BlockLogicalCoords.
-  /// It encodes the list of all points (in block
-  /// logical coordinates) that need to be interpolated onto for a
-  /// given `InterpolationTarget`.  Only a subset of those points
-  /// will be contained in the `Element` that uses this Tag.
-  using type = std::vector<std::optional<
-      IdPair<domain::BlockId,
-             tnsr::I<double, VolumeDim, typename ::Frame::BlockLogical>>>>;
+  using type =
+      tnsr::I<DataVector, VolumeDim,
+              typename InterpolationTargetTag::compute_target_points::frame>;
 };
 }  // namespace Vars
 

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InterpolateDuringSelfStart.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InterpolateDuringSelfStart.cpp
@@ -85,13 +85,13 @@ struct initialize_elements_and_queue_simple_actions {
 struct MockComputeTargetPoints
     : tt::ConformsTo<intrp::protocols::ComputeTargetPoints> {
   using is_sequential = std::false_type;
-  using frame = ::Frame::NoFrame;
+  using frame = ::Frame::Inertial;
   template <typename Metavariables, typename DbTags, typename TemporalId>
-  static tnsr::I<DataVector, 3, Frame::NoFrame> points(
+  static tnsr::I<DataVector, 3, Frame::Inertial> points(
       const db::DataBox<DbTags>& /*box*/,
       const tmpl::type_<Metavariables>& /*meta*/,
       const TemporalId& /*temporal_id*/) {
-    return tnsr::I<DataVector, 3, Frame::NoFrame>{};
+    return tnsr::I<DataVector, 3, Frame::Inertial>{};
   }
 };
 

--- a/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolateOnElementTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolateOnElementTestHelpers.hpp
@@ -267,10 +267,7 @@ void test_interpolate_on_element(
   const size_t num_points = 10;
   tnsr::I<DataVector, 3, Frame::Inertial> target_points(num_points);
   const typename intrp::Tags::InterpPointInfo<
-      metavars>::type interp_point_info = [&domain, &domain_creator,
-                                           &temporal_id,
-                                           &initial_expiration_times,
-                                           &target_points]() {
+      metavars>::type interp_point_info = [&target_points]() {
     MAKE_GENERATOR(gen);
     std::uniform_real_distribution<> r_dist(0.9001, 2.8999);
     std::uniform_real_distribution<> theta_dist(0.0, M_PI);
@@ -284,22 +281,8 @@ void test_interpolate_on_element(
       get<2>(target_points)[i] = r * cos(theta);
     }
     typename intrp::Tags::InterpPointInfo<metavars>::type interp_point_info_l{};
-
-    if constexpr (Metavariables::use_time_dependent_maps) {
-      get<intrp::Vars::PointInfoTag<typename metavars::InterpolationTargetA,
-                                    3>>(interp_point_info_l) =
-          block_logical_coordinates(
-              domain, target_points, temporal_id.substep_time().value(),
-              domain_creator.functions_of_time(initial_expiration_times));
-    } else {
-      get<intrp::Vars::PointInfoTag<typename metavars::InterpolationTargetA,
-                                    3>>(interp_point_info_l) =
-          block_logical_coordinates(domain, target_points);
-      (void)temporal_id;
-      (void)domain_creator;
-      (void)initial_expiration_times;
-    }
-
+    get<intrp::Vars::PointInfoTag<typename metavars::InterpolationTargetA, 3>>(
+        interp_point_info_l) = target_points;
     return interp_point_info_l;
   }();
 

--- a/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolateOnElementTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolateOnElementTestHelpers.hpp
@@ -123,6 +123,10 @@ struct MockInterpolationTargetVarsFromElement {
       const std::vector<Variables<
           typename InterpolationTargetTag::vars_to_interpolate_to_target>>&
           vars_src,
+      const std::vector<std::optional<
+          IdPair<domain::BlockId, tnsr::I<double, Metavariables::volume_dim,
+                                          typename ::Frame::BlockLogical>>>>&
+      /*block_logical_coords*/,
       const std::vector<std::vector<size_t>>& global_offsets,
       const TemporalId& /*temporal_id*/) {
     CHECK(global_offsets.size() == vars_src.size());


### PR DESCRIPTION
## Proposed changes

Previously, interpolation without an Interpolator ParallelComponent didn't work correctly if you had an InterpolationTarget that had points that were time-independent in any frame other than the Grid frame, and if you had a time-dependent map.  In particular, this PR does the following:
 - Previously, for interpolation without the Interpolator ParallelComponent, each Element stored the block_logical_coordinates of the interpolation points, which were computed in the registration phase; but block_logical_coordinates should be time-dependent in some cases, so that behavior was wrong.  So now each element stores the interpolation points in whatever frame the InterpolationTarget designates; the points must be time-independent in that frame, and those points are computed and stored during the Registration phase as before.  
 - The block_logical_coordinates are now computed in intrp::Events::InterpolateWithoutInterpComponent, which is able to pass the correct temporal_id and the correct FunctionsOfTime into that calculation.
 - Previously, some functions in InterpolationTarget_detail internally computed either the original coordinates of the interpolation points or the block_logical_coordinates. These functions were modified to be consistent with the new behavior.
 - InterpolationTargetVarsFromElement needs the block_logical_coordinates of the interpolation points (but uses only part of block_logical_coordinates: the size information and whether there are any points that are not in any blocks); Previously InterpolationTargetVarsFromElement was computing block_logical_coordnates internally (and inconsistently).  Now InterpolationTargetVarsFromElement takes block_logical_coordinates as a function argument, so the correct block_logical_coordinates can be passed in.
 - Tests were modified to be consistent with the new behavior.

Note that this PR conflicts with parts of #4022 and should replace those parts.  Other parts of #4022 (in particular some of the static_asserts for non-sequential InterpolationTargets and time-dependent maps) should be fine and might even be incorporated into this PR but I have not done that yet.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
No changes needed for the user, but anyone changing the interpolator code will see differences:
- intrp::Vars::PointInfoTag now has a different type.
- InterpolationTargetVarsFromElement and some of the functions in InterpolationTarget_detail now take different arguments.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
