### PR TITLE
Simplify Overloader and remove make_overloader

### DIFF
--- a/src/IO/Importers/Actions/ReadVolumeData.hpp
+++ b/src/IO/Importers/Actions/ReadVolumeData.hpp
@@ -214,7 +214,7 @@ struct ReadAllVolumeDataAndDistribute {
 
       // Select observation ID
       const size_t observation_id = std::visit(
-          make_overloader(
+          Overloader{
               [&volume_file](const double local_obs_value) {
                 return volume_file.find_observation_id(local_obs_value);
               },
@@ -230,7 +230,7 @@ struct ReadAllVolumeDataAndDistribute {
                     ERROR("Unknown importers::ObservationSelector: "
                           << local_obs_selector);
                 }
-              }),
+              }},
           Parallel::get<Tags::ObservationValue<ImporterOptionsGroup>>(cache));
       if (prev_observation_id.has_value() and
           prev_observation_id.value() != observation_id) {

--- a/src/Parallel/Main.hpp
+++ b/src/Parallel/Main.hpp
@@ -261,11 +261,11 @@ Main<Metavariables>::Main(CkArgMsg* msg) {
 
     constexpr bool has_options = tmpl::size<option_list>::value > 0;
     // Add input-file option if it makes sense
-    make_overloader(
+    Overloader{
         [&command_line_options](std::true_type /*meta*/, auto mv,
                                 int /*gcc_bug*/)
-            -> std::void_t<decltype(
-                tmpl::type_from<decltype(mv)>::input_file)> {
+            -> std::void_t<
+                decltype(tmpl::type_from<decltype(mv)>::input_file)> {
           // Metavariables has options and default input file name
           command_line_options.add_options()(
               "input-file",
@@ -280,8 +280,8 @@ Main<Metavariables>::Main(CkArgMsg* msg) {
               "input-file", bpo::value<std::string>(), "Input file name");
         },
         [](std::false_type /*meta*/, auto mv, int /*gcc_bug*/)
-            -> std::void_t<decltype(
-                tmpl::type_from<decltype(mv)>::input_file)> {
+            -> std::void_t<
+                decltype(tmpl::type_from<decltype(mv)>::input_file)> {
           // Metavariables has no options and default input file name
 
           // always false, but must depend on mv
@@ -292,19 +292,19 @@ Main<Metavariables>::Main(CkArgMsg* msg) {
         },
         [](std::false_type /*meta*/, auto... /*unused*/) {
           // Metavariables has no options and no default input file name
-        })(std::bool_constant<has_options>{}, tmpl::type_<Metavariables>{}, 0);
+        }}(std::bool_constant<has_options>{}, tmpl::type_<Metavariables>{}, 0);
 
     bpo::command_line_parser command_line_parser(msg->argc, msg->argv);
     command_line_parser.options(command_line_options);
 
-    const bool ignore_unrecognized_command_line_options = make_overloader(
+    const bool ignore_unrecognized_command_line_options = Overloader{
         [](auto mv, int /*gcc_bug*/)
-            -> decltype(tmpl::type_from<decltype(
-                            mv)>::ignore_unrecognized_command_line_options) {
+            -> decltype(tmpl::type_from<decltype(mv)>::
+                            ignore_unrecognized_command_line_options) {
           return tmpl::type_from<decltype(
               mv)>::ignore_unrecognized_command_line_options;
         },
-        [](auto /*mv*/, auto... /*meta*/) { return false; })(
+        [](auto /*mv*/, auto... /*meta*/) { return false; }}(
         tmpl::type_<Metavariables>{}, 0);
     if (ignore_unrecognized_command_line_options) {
       // Allow unknown --options

--- a/src/Time/TimeSteppers/AdamsBashforthN.cpp
+++ b/src/Time/TimeSteppers/AdamsBashforthN.cpp
@@ -428,7 +428,7 @@ void AdamsBashforthN::boundary_impl(const gsl::not_null<T*> result,
   // Calculating the Adams-Bashforth coefficients is somewhat
   // expensive, so we cache them.  ab_coefs(it, step) returns the
   // coefficients used to step from *it to *it + step.
-  auto ab_coefs = make_overloader(
+  auto ab_coefs = Overloader{
       make_cached_function<std::tuple<UnionIter, TimeDelta>, std::map>(
           [order_s](const std::tuple<UnionIter, TimeDelta>& args) {
             return get_coefficients(
@@ -445,7 +445,7 @@ void AdamsBashforthN::boundary_impl(const gsl::not_null<T*> result,
                     static_cast<typename UnionIter::difference_type>(order_s -
                                                                      1),
                 std::get<0>(args) + 1, std::get<1>(args));
-          }));
+          })};
 
   // The value of the coefficient of `evaluation_step` when doing
   // a standard Adams-Bashforth integration over the union times

--- a/src/Utilities/Overloader.hpp
+++ b/src/Utilities/Overloader.hpp
@@ -7,17 +7,6 @@
 
 #include "Utilities/ForceInline.hpp"
 
-#if defined(__clang__) || __GNUC__ > 5
-#define OVERLOADER_CONSTEXPR \
-  constexpr
-#else
-#define OVERLOADER_CONSTEXPR
-#endif
-
-namespace overloader_detail {
-struct no_such_type;
-}  // namespace overloader_detail
-
 /*!
  * \ingroup UtilitiesGroup
  * \brief Used for overloading lambdas, useful for lambda-SFINAE
@@ -25,87 +14,9 @@ struct no_such_type;
  * \snippet Utilities/Test_Overloader.cpp overloader_example
  */
 template <class... Fs>
-class Overloader;
-
-template <class F1, class F2, class F3, class F4, class F5, class F6, class F7,
-          class F8, class... Fs>
-class Overloader<F1, F2, F3, F4, F5, F6, F7, F8, Fs...>
-    : F1, F2, F3, F4, F5, F6, F7, F8, Overloader<Fs...> {
- public:
-  OVERLOADER_CONSTEXPR Overloader(F1 f1, F2 f2, F3 f3, F4 f4, F5 f5, F6 f6,
-                                  F7 f7, F8 f8, Fs... fs)
-      : F1(std::move(f1)),
-        F2(std::move(f2)),
-        F3(std::move(f3)),
-        F4(std::move(f4)),
-        F5(std::move(f5)),
-        F6(std::move(f6)),
-        F7(std::move(f7)),
-        F8(std::move(f8)),
-        Overloader<Fs...>(std::move(fs)...) {}
-
-  using F1::operator();
-  using F2::operator();
-  using F3::operator();
-  using F4::operator();
-  using F5::operator();
-  using F6::operator();
-  using F7::operator();
-  using F8::operator();
-  using Overloader<Fs...>::operator();
+struct Overloader : Fs... {
+  using Fs::operator()...;
 };
 
-template <class F1, class F2, class F3, class F4, class... Fs>
-class Overloader<F1, F2, F3, F4, Fs...> : F1, F2, F3, F4, Overloader<Fs...> {
- public:
-  OVERLOADER_CONSTEXPR Overloader(F1 f1, F2 f2, F3 f3, F4 f4, Fs... fs)
-      : F1(std::move(f1)),
-        F2(std::move(f2)),
-        F3(std::move(f3)),
-        F4(std::move(f4)),
-        Overloader<Fs...>(std::move(fs)...) {}
-
-  using F1::operator();
-  using F2::operator();
-  using F3::operator();
-  using F4::operator();
-  using Overloader<Fs...>::operator();
-};
-
-template <class F1, class F2, class... Fs>
-class Overloader<F1, F2, Fs...> : F1, F2, Overloader<Fs...> {
- public:
-  OVERLOADER_CONSTEXPR Overloader(F1 f1, F2 f2, Fs... fs)
-      : F1(std::move(f1)),
-        F2(std::move(f2)),
-        Overloader<Fs...>(std::move(fs)...) {}
-
-  using F1::operator();
-  using F2::operator();
-  using Overloader<Fs...>::operator();
-};
-
-template <class F>
-class Overloader<F> : F {
- public:
-  explicit OVERLOADER_CONSTEXPR Overloader(F f) : F(std::move(f)) {}
-
-  using F::operator();
-};
-
-template <>
-class Overloader<> {
- public:
-  using type = Overloader;
-  SPECTRE_ALWAYS_INLINE void operator()(
-      const overloader_detail::no_such_type& /*unused*/) {}
-};
-
-/*!
- * \ingroup UtilitiesGroup
- * \brief Create `Overloader<Fs...>`, see Overloader for details
- */
 template <class... Fs>
-OVERLOADER_CONSTEXPR Overloader<Fs...> make_overloader(Fs... fs) {
-  return Overloader<Fs...>{std::move(fs)...};
-}
+Overloader(Fs...) -> Overloader<Fs...>;

--- a/src/Utilities/TaggedTuple.hpp
+++ b/src/Utilities/TaggedTuple.hpp
@@ -678,7 +678,7 @@ template <class... Tags>
 std::ostream& operator<<(std::ostream& os, const TaggedTuple<Tags...>& t) {
   os << "(";
   size_t current_value = 0;
-  auto helper = make_overloader(
+  auto helper = Overloader{
       [&current_value, &os](const auto& element,
                             const std::integral_constant<bool, true> /*meta*/) {
         using ::operator<<;
@@ -696,7 +696,7 @@ std::ostream& operator<<(std::ostream& os, const TaggedTuple<Tags...>& t) {
         if (current_value < sizeof...(Tags)) {
           os << ", ";
         }
-      });
+      }};
   // With empty TaggedTuple's helper is unused
   static_cast<void>(helper);
   static_cast<void>(std::initializer_list<char>{(

--- a/tests/Unit/DataStructures/Test_FixedHashMap.cpp
+++ b/tests/Unit/DataStructures/Test_FixedHashMap.cpp
@@ -323,13 +323,12 @@ void test_repeated_key() {
   CHECK(std::as_const(map).find(1) != map.end());
   CHECK(std::as_const(map).find(2) == map.end());
 
-  make_overloader(
-      [](const gsl::not_null<CopyableKeyMapType*> local_map) {
-        (*local_map)[2] = 12;
-      },
-      [](const gsl::not_null<NonCopyableKeyMapType*> local_map) {
-        local_map->insert({2, 12});
-      })(make_not_null(&map));
+  Overloader{[](const gsl::not_null<CopyableKeyMapType*> local_map) {
+               (*local_map)[2] = 12;
+             },
+             [](const gsl::not_null<NonCopyableKeyMapType*> local_map) {
+               local_map->insert({2, 12});
+             }}(make_not_null(&map));
   CHECK(map.size() == 2);
   CHECK_FALSE(map.empty());
   CHECK(map.at(2) == 12);
@@ -351,11 +350,10 @@ void test_repeated_key() {
   CHECK_FALSE(map.empty());
   CHECK(map.at(3) == 13);
   CHECK(std::as_const(map).at(3) == 13);
-  make_overloader(
-      [](const gsl::not_null<CopyableKeyMapType*> local_map) {
-        CHECK((*local_map)[3] == 13);
-      },
-      [](const gsl::not_null<NonCopyableKeyMapType*> /*local_map*/) {})(
+  Overloader{[](const gsl::not_null<CopyableKeyMapType*> local_map) {
+               CHECK((*local_map)[3] == 13);
+             },
+             [](const gsl::not_null<NonCopyableKeyMapType*> /*local_map*/) {}}(
       make_not_null(&map));
   CHECK(map.count(1) == 1);
   CHECK(map.count(2) == 1);
@@ -402,20 +400,18 @@ void test_repeated_key() {
   CHECK(map.find(4) != map.end());
   CHECK(map.at(4) == 14);
   CHECK(std::as_const(map).at(4) == 14);
-  make_overloader(
-      [](const gsl::not_null<CopyableKeyMapType*> local_map) {
-        CHECK((*local_map)[4] == 14);
-      },
-      [](const gsl::not_null<NonCopyableKeyMapType*> /*local_map*/) {})(
+  Overloader{[](const gsl::not_null<CopyableKeyMapType*> local_map) {
+               CHECK((*local_map)[4] == 14);
+             },
+             [](const gsl::not_null<NonCopyableKeyMapType*> /*local_map*/) {}}(
       make_not_null(&map));
 
-  make_overloader(
-      [](const gsl::not_null<CopyableKeyMapType*> local_map) {
-        (*local_map)[5] = 15;
-      },
-      [](const gsl::not_null<NonCopyableKeyMapType*> local_map) {
-        local_map->insert_or_assign(5, 15);
-      })(make_not_null(&map));
+  Overloader{[](const gsl::not_null<CopyableKeyMapType*> local_map) {
+               (*local_map)[5] = 15;
+             },
+             [](const gsl::not_null<NonCopyableKeyMapType*> local_map) {
+               local_map->insert_or_assign(5, 15);
+             }}(make_not_null(&map));
   CHECK(map.size() == 4);
   CHECK_FALSE(map.empty());
   CHECK(map.count(1) == 1);
@@ -432,11 +428,10 @@ void test_repeated_key() {
   CHECK(map.find(4) != map.find(5));
   CHECK(map.at(5) == 15);
   CHECK(std::as_const(map).at(5) == 15);
-  make_overloader(
-      [](const gsl::not_null<CopyableKeyMapType*> local_map) {
-        CHECK((*local_map)[5] == 15);
-      },
-      [](const gsl::not_null<NonCopyableKeyMapType*> /*local_map*/) {})(
+  Overloader{[](const gsl::not_null<CopyableKeyMapType*> local_map) {
+               CHECK((*local_map)[5] == 15);
+             },
+             [](const gsl::not_null<NonCopyableKeyMapType*> /*local_map*/) {}}(
       make_not_null(&map));
 
   map.erase(4);
@@ -455,11 +450,10 @@ void test_repeated_key() {
   CHECK(map.find(4) != map.find(5));
   CHECK(map.at(5) == 15);
   CHECK(std::as_const(map).at(5) == 15);
-  make_overloader(
-      [](const gsl::not_null<CopyableKeyMapType*> local_map) {
-        CHECK((*local_map)[5] == 15);
-      },
-      [](const gsl::not_null<NonCopyableKeyMapType*> /*local_map*/) {})(
+  Overloader{[](const gsl::not_null<CopyableKeyMapType*> local_map) {
+               CHECK((*local_map)[5] == 15);
+             },
+             [](const gsl::not_null<NonCopyableKeyMapType*> /*local_map*/) {}}(
       make_not_null(&map));
 
   const auto check_4 = [](const auto& l_it_bool_to_4, const size_t expected,
@@ -485,15 +479,15 @@ void test_repeated_key() {
     CHECK(check_4_local_map->find(4) == l_it_bool_to_4.first);
     CHECK(check_4_local_map->at(4) == expected);
     CHECK(std::as_const(*check_4_local_map).at(4) == expected);
-    make_overloader(
+    Overloader{
         [expected](const gsl::not_null<CopyableKeyMapType*> more_local_map) {
           CHECK((*more_local_map)[4] == expected);
         },
-        [](const gsl::not_null<NonCopyableKeyMapType*> /*local_map*/) {})(
+        [](const gsl::not_null<NonCopyableKeyMapType*> /*local_map*/) {}}(
         check_4_local_map);
   };
 
-  make_overloader(
+  Overloader{
       [&check_4](const gsl::not_null<CopyableKeyMapType*> local_map) {
         // Test serialization and that FixedHashMap works correctly after.
         test_serialization(*local_map);
@@ -532,16 +526,15 @@ void test_repeated_key() {
         const size_t key_4 = 4;
         check_4(local_map->insert_or_assign(key_4, 34), 34, true, local_map);
         check_4(local_map->insert_or_assign(key_4, 44), 44, false, local_map);
-      })(make_not_null(&map));
+      }}(make_not_null(&map));
 
   test_iterators(map);
-  make_overloader(
-      [](const gsl::not_null<CopyableKeyMapType*> local_map) {
-        test_copy_semantics(*local_map);
-        const auto map2 = *local_map;
-        test_move_semantics(std::move(*local_map), map2);
-      },
-      [](const gsl::not_null<NonCopyableKeyMapType*> /*local_map*/) {})(
+  Overloader{[](const gsl::not_null<CopyableKeyMapType*> local_map) {
+               test_copy_semantics(*local_map);
+               const auto map2 = *local_map;
+               test_move_semantics(std::move(*local_map), map2);
+             },
+             [](const gsl::not_null<NonCopyableKeyMapType*> /*local_map*/) {}}(
       make_not_null(&map));
 }
 

--- a/tests/Unit/IO/Observers/Test_ReductionObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_ReductionObserver.cpp
@@ -144,7 +144,7 @@ void test_reduction_observer(const bool observe_per_core) {
   ActionTesting::set_phase(make_not_null(&runner),
                            metavariables::Phase::Testing);
 
-  const auto make_fake_reduction_data = make_overloader(
+  const auto make_fake_reduction_data = Overloader{
       [](const observers::ArrayComponentId& id, const double time,
          const helpers::reduction_data_from_doubles& /*meta*/) {
         const auto hashed_id =
@@ -179,7 +179,7 @@ void test_reduction_observer(const bool observe_per_core) {
                                           1.0e-13 * hashed_id + 6.0 * time};
         return helpers::reduction_data_from_ds_and_vs{
             time, number_of_grid_points, error0, vector1, vector2, error1};
-      });
+      }};
 
   using reduction_data_list =
       tmpl::list<helpers::reduction_data_from_doubles,

--- a/tests/Unit/Utilities/Test_Overloader.cpp
+++ b/tests/Unit/Utilities/Test_Overloader.cpp
@@ -25,14 +25,14 @@ struct has_func<
 template <class T>
 void func(T t) {
   auto my_lambdas =
-      make_overloader([](auto& /*f*/, std::integral_constant<bool, false>,
-                         std::integral_constant<bool, false>) { return 0; },
-                      [](auto& /*f*/, std::integral_constant<bool, true>,
-                         std::integral_constant<bool, false>) { return 1; },
-                      [](auto& /*f*/, std::integral_constant<bool, false>,
-                         std::integral_constant<bool, true>) { return 2; },
-                      [](auto& /*f*/, std::integral_constant<bool, true>,
-                         std::integral_constant<bool, true>) { return 3; });
+      Overloader{[](auto& /*f*/, std::integral_constant<bool, false>,
+                    std::integral_constant<bool, false>) { return 0; },
+                 [](auto& /*f*/, std::integral_constant<bool, true>,
+                    std::integral_constant<bool, false>) { return 1; },
+                 [](auto& /*f*/, std::integral_constant<bool, false>,
+                    std::integral_constant<bool, true>) { return 2; },
+                 [](auto& /*f*/, std::integral_constant<bool, true>,
+                    std::integral_constant<bool, true>) { return 3; }};
   CHECK(static_cast<int>(has_func<T>::value) ==
         (my_lambdas(t, std::integral_constant<bool, has_func<T>::value>{},
                     std::integral_constant<bool, false>{})));
@@ -50,17 +50,17 @@ void caller() {
 
 SPECTRE_TEST_CASE("Unit.Utilities.Overloader", "[Unit][Utilities]") {
   auto my_lambdas =
-      make_overloader([](std::integral_constant<int, 0>) { return 0; },
-                      [](std::integral_constant<int, 1>) { return 1; },
-                      [](std::integral_constant<int, 2>) { return 2; },
-                      [](std::integral_constant<int, 3>) { return 3; },
-                      [](std::integral_constant<int, 4>) { return 4; },
-                      [](std::integral_constant<int, 5>) { return 5; },
-                      [](std::integral_constant<int, 6>) { return 6; },
-                      [](std::integral_constant<int, 7>) { return 7; },
-                      [](std::integral_constant<int, 8>) { return 8; },
-                      [](std::integral_constant<int, 9>) { return 9; },
-                      [](std::integral_constant<int, 10>) { return 10; });
+      Overloader{[](std::integral_constant<int, 0>) { return 0; },
+                 [](std::integral_constant<int, 1>) { return 1; },
+                 [](std::integral_constant<int, 2>) { return 2; },
+                 [](std::integral_constant<int, 3>) { return 3; },
+                 [](std::integral_constant<int, 4>) { return 4; },
+                 [](std::integral_constant<int, 5>) { return 5; },
+                 [](std::integral_constant<int, 6>) { return 6; },
+                 [](std::integral_constant<int, 7>) { return 7; },
+                 [](std::integral_constant<int, 8>) { return 8; },
+                 [](std::integral_constant<int, 9>) { return 9; },
+                 [](std::integral_constant<int, 10>) { return 10; }};
   CHECK((0 == my_lambdas(std::integral_constant<int, 0>{})));
   CHECK((1 == my_lambdas(std::integral_constant<int, 1>{})));
   CHECK((2 == my_lambdas(std::integral_constant<int, 2>{})));


### PR DESCRIPTION
## Proposed changes

Use C++17 to simplify the code (a lot). Partly addresses #2194 I'll replace `boost::variant` with `std::variant` in another PR where I make some other changes to AlgorithmImpl

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
