### PR TITLE
Use global phase to simplify some code

### DIFF
--- a/src/ControlSystem/Component.hpp
+++ b/src/ControlSystem/Component.hpp
@@ -14,6 +14,7 @@
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Local.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
@@ -38,7 +39,7 @@ struct ControlComponent {
   using metavariables = Metavariables;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename metavariables::Phase, metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<
           Actions::SetupDataBox,
           control_system::Actions::Initialize<Metavariables, ControlSystem>,

--- a/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
+++ b/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
@@ -275,11 +275,11 @@ struct Metavariables {
 
   using dg_element_array = elliptic::DgElementArray<
       Metavariables,
-      tmpl::list<Parallel::PhaseActions<Phase, Phase::Initialization,
+      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
                                         initialization_actions>,
-                 Parallel::PhaseActions<Phase, Phase::RegisterWithObserver,
+                 Parallel::PhaseActions<Parallel::Phase::RegisterWithObserver,
                                         register_actions>,
-                 Parallel::PhaseActions<Phase, Phase::Solve, solve_actions>>,
+                 Parallel::PhaseActions<Parallel::Phase::Solve, solve_actions>>,
       LinearSolver::multigrid::ElementsAllocator<
           volume_dim, typename multigrid::options_group>>;
 

--- a/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
@@ -255,11 +255,11 @@ struct Metavariables {
 
   using dg_element_array = elliptic::DgElementArray<
       Metavariables,
-      tmpl::list<Parallel::PhaseActions<Phase, Phase::Initialization,
+      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
                                         initialization_actions>,
-                 Parallel::PhaseActions<Phase, Phase::RegisterWithObserver,
+                 Parallel::PhaseActions<Parallel::Phase::RegisterWithObserver,
                                         register_actions>,
-                 Parallel::PhaseActions<Phase, Phase::Solve, solve_actions>>,
+                 Parallel::PhaseActions<Parallel::Phase::Solve, solve_actions>>,
       LinearSolver::multigrid::ElementsAllocator<
           volume_dim, typename multigrid::options_group>>;
 

--- a/src/Elliptic/Executables/Xcts/SolveXcts.hpp
+++ b/src/Elliptic/Executables/Xcts/SolveXcts.hpp
@@ -321,11 +321,11 @@ struct Metavariables {
 
   using dg_element_array = elliptic::DgElementArray<
       Metavariables,
-      tmpl::list<Parallel::PhaseActions<Phase, Phase::Initialization,
+      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
                                         initialization_actions>,
-                 Parallel::PhaseActions<Phase, Phase::RegisterWithObserver,
+                 Parallel::PhaseActions<Parallel::Phase::RegisterWithObserver,
                                         register_actions>,
-                 Parallel::PhaseActions<Phase, Phase::Solve, solve_actions>>,
+                 Parallel::PhaseActions<Parallel::Phase::Solve, solve_actions>>,
       LinearSolver::multigrid::ElementsAllocator<
           volume_dim, typename multigrid::options_group>>;
 

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -201,8 +201,7 @@ struct EvolutionMetavars {
         tmpl::pair<PhaseChange,
                    tmpl::list<PhaseControl::VisitAndReturn<
                                   EvolutionMetavars, Phase::LoadBalancing>,
-                              PhaseControl::CheckpointAndExitAfterWallclock<
-                                  EvolutionMetavars>>>,
+                              PhaseControl::CheckpointAndExitAfterWallclock>>,
         tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
                    StepChoosers::standard_step_choosers<system>>,
         tmpl::pair<

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -324,19 +324,19 @@ struct EvolutionMetavars {
   using dg_element_array = DgElementArray<
       EvolutionMetavars,
       tmpl::list<
-          Parallel::PhaseActions<Phase, Phase::Initialization,
+          Parallel::PhaseActions<Parallel::Phase::Initialization,
                                  initialization_actions>,
 
-          Parallel::PhaseActions<Phase, Phase::RegisterWithObserver,
+          Parallel::PhaseActions<Parallel::Phase::RegisterWithObserver,
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,
 
           Parallel::PhaseActions<
-              Phase, Phase::InitializeTimeStepperHistory,
+              Parallel::Phase::InitializeTimeStepperHistory,
               SelfStart::self_start_procedure<step_actions, system>>,
 
           Parallel::PhaseActions<
-              Phase, Phase::Evolve,
+              Parallel::Phase::Evolve,
               tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
                          step_actions, Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>;

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -321,16 +321,16 @@ struct EvolutionMetavars {
   using dg_element_array = DgElementArray<
       EvolutionMetavars,
       tmpl::list<
-          Parallel::PhaseActions<Phase, Phase::Initialization,
+          Parallel::PhaseActions<Parallel::Phase::Initialization,
                                  initialization_actions>,
           Parallel::PhaseActions<
-              Phase, Phase::InitializeTimeStepperHistory,
+              Parallel::Phase::InitializeTimeStepperHistory,
               SelfStart::self_start_procedure<step_actions, system>>,
-          Parallel::PhaseActions<Phase, Phase::Register,
+          Parallel::PhaseActions<Parallel::Phase::Register,
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
-              Phase, Phase::Evolve,
+              Parallel::Phase::Evolve,
               tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
                          step_actions, Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>;

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -235,8 +235,7 @@ struct EvolutionMetavars {
         tmpl::pair<PhaseChange,
                    tmpl::list<PhaseControl::VisitAndReturn<
                                   EvolutionMetavars, Phase::LoadBalancing>,
-                              PhaseControl::CheckpointAndExitAfterWallclock<
-                                  EvolutionMetavars>>>,
+                              PhaseControl::CheckpointAndExitAfterWallclock>>,
         tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
                    tmpl::push_back<StepChoosers::standard_step_choosers<system>,
                                    StepChoosers::ByBlock<

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
@@ -127,18 +127,18 @@ struct EvolutionMetavars<3, InitialData, BoundaryConditions>
   using gh_dg_element_array = DgElementArray<
       EvolutionMetavars,
       tmpl::flatten<tmpl::list<
-          Parallel::PhaseActions<Phase, Phase::Initialization,
+          Parallel::PhaseActions<Parallel::Phase::Initialization,
                                  initialization_actions>,
           tmpl::conditional_t<
               evolution::is_numeric_initial_data_v<InitialData>,
               tmpl::list<
                   Parallel::PhaseActions<
-                      Phase, Phase::RegisterWithElementDataReader,
+                      Parallel::Phase::RegisterWithElementDataReader,
                       tmpl::list<
                           importers::Actions::RegisterWithElementDataReader,
                           Parallel::Actions::TerminatePhase>>,
                   Parallel::PhaseActions<
-                      Phase, Phase::ImportInitialData,
+                      Parallel::Phase::ImportInitialData,
                       tmpl::list<
                           GeneralizedHarmonic::Actions::ReadNumericInitialData<
                               evolution::OptionTags::NumericInitialData>,
@@ -147,16 +147,16 @@ struct EvolutionMetavars<3, InitialData, BoundaryConditions>
                           Parallel::Actions::TerminatePhase>>>,
               tmpl::list<>>,
           Parallel::PhaseActions<
-              Phase, Phase::InitializeInitialDataDependentQuantities,
+              Parallel::Phase::InitializeInitialDataDependentQuantities,
               initialize_initial_data_dependent_quantities_actions>,
           Parallel::PhaseActions<
-              Phase, Phase::InitializeTimeStepperHistory,
+              Parallel::Phase::InitializeTimeStepperHistory,
               SelfStart::self_start_procedure<step_actions, system>>,
-          Parallel::PhaseActions<Phase, Phase::Register,
+          Parallel::PhaseActions<Parallel::Phase::Register,
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
-              Phase, Phase::Evolve,
+              Parallel::Phase::Evolve,
               tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
                          step_actions, Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>>;

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -437,30 +437,30 @@ struct EvolutionMetavars {
   using gh_dg_element_array = DgElementArray<
       EvolutionMetavars,
       tmpl::flatten<tmpl::list<
-          Parallel::PhaseActions<Phase, Phase::Initialization,
+          Parallel::PhaseActions<Parallel::Phase::Initialization,
                                  initialization_actions>,
           Parallel::PhaseActions<
-              Phase, Phase::RegisterWithElementDataReader,
+              Parallel::Phase::RegisterWithElementDataReader,
               tmpl::list<importers::Actions::RegisterWithElementDataReader,
                          Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
-              Phase, Phase::ImportInitialData,
+              Parallel::Phase::ImportInitialData,
               tmpl::list<GeneralizedHarmonic::Actions::ReadNumericInitialData<
                              evolution::OptionTags::NumericInitialData>,
                          GeneralizedHarmonic::Actions::SetNumericInitialData<
                              evolution::OptionTags::NumericInitialData>,
                          Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
-              Phase, Phase::InitializeInitialDataDependentQuantities,
+              Parallel::Phase::InitializeInitialDataDependentQuantities,
               initialize_initial_data_dependent_quantities_actions>,
           Parallel::PhaseActions<
-              Phase, Phase::InitializeTimeStepperHistory,
+              Parallel::Phase::InitializeTimeStepperHistory,
               SelfStart::self_start_procedure<step_actions, system>>,
-          Parallel::PhaseActions<Phase, Phase::Register,
+          Parallel::PhaseActions<Parallel::Phase::Register,
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
-              Phase, Phase::Evolve,
+              Parallel::Phase::Evolve,
               tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
                          step_actions, Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>>;

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -321,8 +321,7 @@ struct EvolutionMetavars {
                                   EvolutionMetavars, Phase::LoadBalancing>,
                               PhaseControl::VisitAndReturn<
                                   EvolutionMetavars, Phase::WriteCheckpoint>,
-                              PhaseControl::CheckpointAndExitAfterWallclock<
-                                  EvolutionMetavars>>>,
+                              PhaseControl::CheckpointAndExitAfterWallclock>>,
         tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
                    StepChoosers::standard_step_choosers<system>>,
         tmpl::pair<

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -393,18 +393,18 @@ struct GeneralizedHarmonicTemplateBase<
   using gh_dg_element_array = DgElementArray<
       derived_metavars,
       tmpl::flatten<tmpl::list<
-          Parallel::PhaseActions<Phase, Phase::Initialization,
+          Parallel::PhaseActions<Parallel::Phase::Initialization,
                                  initialization_actions>,
           tmpl::conditional_t<
               evolution::is_numeric_initial_data_v<initial_data>,
               tmpl::list<
                   Parallel::PhaseActions<
-                      Phase, Phase::RegisterWithElementDataReader,
+                      Parallel::Phase::RegisterWithElementDataReader,
                       tmpl::list<
                           importers::Actions::RegisterWithElementDataReader,
                           Parallel::Actions::TerminatePhase>>,
                   Parallel::PhaseActions<
-                      Phase, Phase::ImportInitialData,
+                      Parallel::Phase::ImportInitialData,
                       tmpl::list<
                           GeneralizedHarmonic::Actions::ReadNumericInitialData<
                               evolution::OptionTags::NumericInitialData>,
@@ -413,16 +413,16 @@ struct GeneralizedHarmonicTemplateBase<
                           Parallel::Actions::TerminatePhase>>>,
               tmpl::list<>>,
           Parallel::PhaseActions<
-              Phase, Phase::InitializeInitialDataDependentQuantities,
+              Parallel::Phase::InitializeInitialDataDependentQuantities,
               initialize_initial_data_dependent_quantities_actions>,
           Parallel::PhaseActions<
-              Phase, Phase::InitializeTimeStepperHistory,
+              Parallel::Phase::InitializeTimeStepperHistory,
               SelfStart::self_start_procedure<step_actions, system>>,
-          Parallel::PhaseActions<Phase, Phase::Register,
+          Parallel::PhaseActions<Parallel::Phase::Register,
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
-              Phase, Phase::Evolve,
+              Parallel::Phase::Evolve,
               tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
                          step_actions, Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>>;

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -269,8 +269,7 @@ struct GeneralizedHarmonicTemplateBase<
                    tmpl::list<PhaseControl::VisitAndReturn<
                                   GeneralizedHarmonicTemplateBase,
                                   Phase::LoadBalancing>,
-                              PhaseControl::CheckpointAndExitAfterWallclock<
-                                  GeneralizedHarmonicTemplateBase>>>,
+                              PhaseControl::CheckpointAndExitAfterWallclock>>,
         tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
                    StepChoosers::standard_step_choosers<system>>,
         tmpl::pair<

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -425,18 +425,18 @@ struct GhValenciaDivCleanTemplateBase<
   using dg_element_array_component = DgElementArray<
       derived_metavars,
       tmpl::flatten<tmpl::list<
-          Parallel::PhaseActions<Phase, Phase::Initialization,
+          Parallel::PhaseActions<Parallel::Phase::Initialization,
                                  initialization_actions>,
           tmpl::conditional_t<
               evolution::is_numeric_initial_data_v<initial_data>,
               tmpl::list<
                   Parallel::PhaseActions<
-                      Phase, Phase::RegisterWithElementDataReader,
+                      Parallel::Phase::RegisterWithElementDataReader,
                       tmpl::list<
                           importers::Actions::RegisterWithElementDataReader,
                           Parallel::Actions::TerminatePhase>>,
                   Parallel::PhaseActions<
-                      Phase, Phase::ImportInitialData,
+                      Parallel::Phase::ImportInitialData,
                       tmpl::list<importers::Actions::ReadVolumeData<
                                      evolution::OptionTags::NumericInitialData,
                                      typename system::variables_tag::tags_list>,
@@ -446,16 +446,16 @@ struct GhValenciaDivCleanTemplateBase<
                                  Parallel::Actions::TerminatePhase>>>,
               tmpl::list<>>,
           Parallel::PhaseActions<
-              Phase, Phase::InitializeInitialDataDependentQuantities,
+              Parallel::Phase::InitializeInitialDataDependentQuantities,
               initialize_initial_data_dependent_quantities_actions>,
           Parallel::PhaseActions<
-              Phase, Phase::InitializeTimeStepperHistory,
+              Parallel::Phase::InitializeTimeStepperHistory,
               SelfStart::self_start_procedure<step_actions, system>>,
-          Parallel::PhaseActions<Phase, Phase::Register,
+          Parallel::PhaseActions<Parallel::Phase::Register,
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
-              Phase, Phase::Evolve,
+              Parallel::Phase::Evolve,
               tmpl::list<VariableFixing::Actions::FixVariables<
                              VariableFixing::FixToAtmosphere<volume_dim>>,
                          Actions::UpdateConservatives,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -480,20 +480,20 @@ struct EvolutionMetavars {
   using dg_element_array_component = DgElementArray<
       EvolutionMetavars,
       tmpl::list<
-          Parallel::PhaseActions<Phase, Phase::Initialization,
+          Parallel::PhaseActions<Parallel::Phase::Initialization,
                                  initialization_actions>,
 
           Parallel::PhaseActions<
-              Phase, Phase::InitializeTimeStepperHistory,
+              Parallel::Phase::InitializeTimeStepperHistory,
               SelfStart::self_start_procedure<step_actions, system>>,
 
           Parallel::PhaseActions<
-              Phase, Phase::Register,
+              Parallel::Phase::Register,
               tmpl::push_back<dg_registration_list,
                               Parallel::Actions::TerminatePhase>>,
 
           Parallel::PhaseActions<
-              Phase, Phase::Evolve,
+              Parallel::Phase::Evolve,
               tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
                          step_actions, Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>;

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -298,8 +298,7 @@ struct EvolutionMetavars {
                                   EvolutionMetavars, Phase::LoadBalancing>,
                               PhaseControl::VisitAndReturn<
                                   EvolutionMetavars, Phase::WriteCheckpoint>,
-                              PhaseControl::CheckpointAndExitAfterWallclock<
-                                  EvolutionMetavars>>>,
+                              PhaseControl::CheckpointAndExitAfterWallclock>>,
         tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
                    StepChoosers::standard_step_choosers<system>>,
         tmpl::pair<

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -237,8 +237,7 @@ struct EvolutionMetavars {
                                   EvolutionMetavars, Phase::LoadBalancing>,
                               PhaseControl::VisitAndReturn<
                                   EvolutionMetavars, Phase::WriteCheckpoint>,
-                              PhaseControl::CheckpointAndExitAfterWallclock<
-                                  EvolutionMetavars>>>,
+                              PhaseControl::CheckpointAndExitAfterWallclock>>,
         tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
                    StepChoosers::standard_step_choosers<system>>,
         tmpl::pair<

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -374,19 +374,19 @@ struct EvolutionMetavars {
   using dg_element_array = DgElementArray<
       EvolutionMetavars,
       tmpl::list<
-          Parallel::PhaseActions<Phase, Phase::Initialization,
+          Parallel::PhaseActions<Parallel::Phase::Initialization,
                                  initialization_actions>,
 
           Parallel::PhaseActions<
-              Phase, Phase::InitializeTimeStepperHistory,
+              Parallel::Phase::InitializeTimeStepperHistory,
               SelfStart::self_start_procedure<step_actions, system>>,
 
-          Parallel::PhaseActions<Phase, Phase::Register,
+          Parallel::PhaseActions<Parallel::Phase::Register,
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,
 
           Parallel::PhaseActions<
-              Phase, Phase::Evolve,
+              Parallel::Phase::Evolve,
               tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
                          step_actions, Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>;

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -175,8 +175,7 @@ struct EvolutionMetavars {
         tmpl::pair<PhaseChange,
                    tmpl::list<PhaseControl::VisitAndReturn<
                                   EvolutionMetavars, Phase::LoadBalancing>,
-                              PhaseControl::CheckpointAndExitAfterWallclock<
-                                  EvolutionMetavars>>>,
+                              PhaseControl::CheckpointAndExitAfterWallclock>>,
         tmpl::pair<
             RadiationTransport::M1Grey::BoundaryConditions::BoundaryCondition<
                 metavariables::neutrino_species>,

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -248,19 +248,19 @@ struct EvolutionMetavars {
   using dg_element_array = DgElementArray<
       EvolutionMetavars,
       tmpl::list<
-          Parallel::PhaseActions<Phase, Phase::Initialization,
+          Parallel::PhaseActions<Parallel::Phase::Initialization,
                                  initialization_actions>,
 
           Parallel::PhaseActions<
-              Phase, Phase::InitializeTimeStepperHistory,
+              Parallel::Phase::InitializeTimeStepperHistory,
               SelfStart::self_start_procedure<step_actions, system>>,
 
-          Parallel::PhaseActions<Phase, Phase::RegisterWithObserver,
+          Parallel::PhaseActions<Parallel::Phase::RegisterWithObserver,
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,
 
           Parallel::PhaseActions<
-              Phase, Phase::Evolve,
+              Parallel::Phase::Evolve,
               tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
                          step_actions, Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>;

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -187,8 +187,7 @@ struct EvolutionMetavars {
         tmpl::pair<PhaseChange,
                    tmpl::list<PhaseControl::VisitAndReturn<
                                   EvolutionMetavars, Phase::LoadBalancing>,
-                              PhaseControl::CheckpointAndExitAfterWallclock<
-                                  EvolutionMetavars>>>,
+                              PhaseControl::CheckpointAndExitAfterWallclock>>,
         tmpl::pair<RelativisticEuler::Valencia::BoundaryConditions::
                        BoundaryCondition<volume_dim>,
                    RelativisticEuler::Valencia::BoundaryConditions::

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -263,19 +263,19 @@ struct EvolutionMetavars {
   using dg_element_array = DgElementArray<
       EvolutionMetavars,
       tmpl::list<
-          Parallel::PhaseActions<Phase, Phase::Initialization,
+          Parallel::PhaseActions<Parallel::Phase::Initialization,
                                  initialization_actions>,
 
           Parallel::PhaseActions<
-              Phase, Phase::InitializeTimeStepperHistory,
+              Parallel::Phase::InitializeTimeStepperHistory,
               SelfStart::self_start_procedure<step_actions, system>>,
 
-          Parallel::PhaseActions<Phase, Phase::RegisterWithObserver,
+          Parallel::PhaseActions<Parallel::Phase::RegisterWithObserver,
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,
 
           Parallel::PhaseActions<
-              Phase, Phase::Evolve,
+              Parallel::Phase::Evolve,
               tmpl::list<VariableFixing::Actions::FixVariables<
                              VariableFixing::FixToAtmosphere<volume_dim>>,
                          Actions::UpdateConservatives,

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -331,19 +331,19 @@ struct EvolutionMetavars {
   using dg_element_array = DgElementArray<
       EvolutionMetavars,
       tmpl::list<
-          Parallel::PhaseActions<Phase, Phase::Initialization,
+          Parallel::PhaseActions<Parallel::Phase::Initialization,
                                  initialization_actions>,
 
-          Parallel::PhaseActions<Phase, Phase::RegisterWithObserver,
+          Parallel::PhaseActions<Parallel::Phase::RegisterWithObserver,
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,
 
           Parallel::PhaseActions<
-              Phase, Phase::InitializeTimeStepperHistory,
+              Parallel::Phase::InitializeTimeStepperHistory,
               SelfStart::self_start_procedure<step_actions, system>>,
 
           Parallel::PhaseActions<
-              Phase, Phase::Evolve,
+              Parallel::Phase::Evolve,
               tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
                          step_actions, Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>;

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -188,8 +188,7 @@ struct EvolutionMetavars {
         tmpl::pair<PhaseChange,
                    tmpl::list<PhaseControl::VisitAndReturn<
                                   EvolutionMetavars, Phase::LoadBalancing>,
-                              PhaseControl::CheckpointAndExitAfterWallclock<
-                                  EvolutionMetavars>>>,
+                              PhaseControl::CheckpointAndExitAfterWallclock>>,
         tmpl::pair<
             ScalarWave::BoundaryConditions::BoundaryCondition<volume_dim>,
             ScalarWave::BoundaryConditions::standard_boundary_conditions<

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -267,19 +267,19 @@ struct EvolutionMetavars {
   using dg_element_array = DgElementArray<
       EvolutionMetavars,
       tmpl::list<
-          Parallel::PhaseActions<Phase, Phase::Initialization,
+          Parallel::PhaseActions<Parallel::Phase::Initialization,
                                  initialization_actions>,
 
           Parallel::PhaseActions<
-              Phase, Phase::InitializeTimeStepperHistory,
+              Parallel::Phase::InitializeTimeStepperHistory,
               SelfStart::self_start_procedure<step_actions, system>>,
 
-          Parallel::PhaseActions<Phase, Phase::RegisterWithObserver,
+          Parallel::PhaseActions<Parallel::Phase::RegisterWithObserver,
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,
 
           Parallel::PhaseActions<
-              Phase, Phase::Evolve,
+              Parallel::Phase::Evolve,
               tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
                          step_actions, Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>;

--- a/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
@@ -31,6 +31,7 @@
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Local.hpp"
+#include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
@@ -216,19 +217,15 @@ struct CharacteristicEvolution {
       ::Actions::Goto<CceEvolutionLabelTag>>;
 
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Initialization,
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
                              initialize_action_list>,
       Parallel::PhaseActions<
-          typename Metavariables::Phase,
-          Metavariables::Phase::InitializeTimeStepperHistory,
+          Parallel::Phase::InitializeTimeStepperHistory,
           SelfStart::self_start_procedure<
               self_start_extract_action_list,
               Cce::System<
                   Metavariables::uses_partially_flat_cartesian_coordinates>>>,
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Evolve,
-                             extract_action_list>>;
+      Parallel::PhaseActions<Parallel::Phase::Evolve, extract_action_list>>;
 
   static void initialize(
       Parallel::CProxy_GlobalCache<Metavariables>& /*global_cache*/) {}

--- a/src/Evolution/Systems/Cce/Components/WorldtubeBoundary.hpp
+++ b/src/Evolution/Systems/Cce/Components/WorldtubeBoundary.hpp
@@ -10,6 +10,7 @@
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Local.hpp"
+#include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
 
 namespace Cce {
@@ -33,11 +34,9 @@ struct WorldtubeComponentBase {
   using worldtube_boundary_computation_steps = tmpl::list<>;
 
   using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
+      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
                                         initialize_action_list>,
-                 Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Evolve,
+                 Parallel::PhaseActions<Parallel::Phase::Evolve,
                                         worldtube_boundary_computation_steps>>;
 
   using options = tmpl::list<>;

--- a/src/Executables/Examples/HelloWorld/SingletonHelloWorld.hpp
+++ b/src/Executables/Examples/HelloWorld/SingletonHelloWorld.hpp
@@ -71,8 +71,7 @@ struct HelloWorld {
   using chare_type = Parallel::Algorithms::Singleton;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Execute, tmpl::list<>>>;
+      Parallel::PhaseActions<Parallel::Phase::Execute, tmpl::list<>>>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
   static void execute_next_phase(

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -237,8 +237,7 @@ struct Metavariables {
           Metavariables,
           tmpl::list<
               Parallel::PhaseActions<
-                  typename Metavariables::Phase,
-                  Metavariables::Phase::Initialization,
+                  Parallel::Phase::Initialization,
                   tmpl::list<
                       Actions::SetupDataBox,
                       Initialization::Actions::TimeAndTimeStep<Metavariables>,
@@ -249,15 +248,14 @@ struct Metavariables {
                       ::Initialization::Actions::
                           RemoveOptionsAndTerminatePhase>>,
               Parallel::PhaseActions<
-                  typename Metavariables::Phase,
-                  Metavariables::Phase::RegisterWithObserver,
+                  Parallel::Phase::RegisterWithObserver,
                   tmpl::list<observers::Actions::RegisterWithObservers<
                                  Actions::ExportCoordinates<Dim>>,
                              observers::Actions::RegisterWithObservers<
                                  Actions::FindGlobalMinimumGridSpacing>,
                              Parallel::Actions::TerminatePhase>>,
               Parallel::PhaseActions<
-                  typename Metavariables::Phase, Metavariables::Phase::Execute,
+                  Parallel::Phase::Execute,
                   tmpl::list<Actions::AdvanceTime,
                              Actions::ExportCoordinates<Dim>,
                              Actions::FindGlobalMinimumGridSpacing,

--- a/src/IO/Importers/ElementDataReader.hpp
+++ b/src/IO/Importers/ElementDataReader.hpp
@@ -12,6 +12,7 @@
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Local.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
 
@@ -39,10 +40,10 @@ template <typename Metavariables>
 struct ElementDataReader {
   using chare_type = Parallel::Algorithms::Nodegroup;
   using metavariables = Metavariables;
-  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
-      tmpl::list<::Actions::SetupDataBox,
-                 detail::InitializeElementDataReader>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
+                             tmpl::list<::Actions::SetupDataBox,
+                                        detail::InitializeElementDataReader>>>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 

--- a/src/IO/Observer/ObserverComponent.hpp
+++ b/src/IO/Observer/ObserverComponent.hpp
@@ -11,6 +11,7 @@
 #include "Parallel/Algorithms/AlgorithmNodegroup.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
 #include "Utilities/TMPL.hpp"
@@ -30,7 +31,7 @@ struct Observer {
   using chare_type = Parallel::Algorithms::Group;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename metavariables::Phase, metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<::Actions::SetupDataBox, Actions::Initialize<Metavariables>,
                  Initialization::Actions::RemoveOptionsAndTerminatePhase>>>;
   using initialization_tags = Parallel::get_initialization_tags<
@@ -53,7 +54,7 @@ struct ObserverWriter {
       tmpl::list<Tags::ReductionFileName, Tags::VolumeFileName>;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename metavariables::Phase, metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<::Actions::SetupDataBox,
                  Actions::InitializeWriter<Metavariables>,
                  Initialization::Actions::RemoveOptionsAndTerminatePhase>>>;

--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -180,8 +180,6 @@ class AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>
   /// The Charm++ base object type
   using cbase_type =
       typename chare_type::template cbase<parallel_component, array_index>;
-  /// The type of the phases
-  using PhaseType = Parallel::Phase;
 
   using phase_dependent_action_lists = tmpl::list<PhaseDepActionListsPack...>;
 
@@ -296,7 +294,7 @@ class AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>
   /// Start execution of the phase-dependent action list in `next_phase`. If
   /// `next_phase` has already been visited, execution will resume at the point
   /// where the previous execution of the same phase left off.
-  void start_phase(const PhaseType next_phase);
+  void start_phase(const Parallel::Phase next_phase);
 
   /// Tell the Algorithm it should no longer execute the algorithm. This does
   /// not mean that the execution of the program is terminated, but only that
@@ -380,7 +378,7 @@ class AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>
   void forward_tuple_to_threaded_action(
       std::tuple<Args...>&& args, std::index_sequence<Is...> /*meta*/);
 
-  size_t number_of_actions_in_phase(const PhaseType phase) const;
+  size_t number_of_actions_in_phase(const Parallel::Phase phase) const;
 
   // Invoke the static `apply` method of `ThisAction`. The if constexprs are for
   // handling the cases where the `apply` method returns a tuple of one, two,
@@ -410,8 +408,8 @@ class AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>
 
   Parallel::CProxy_GlobalCache<metavariables> global_cache_proxy_;
   bool performing_action_ = false;
-  PhaseType phase_{Parallel::Phase::Initialization};
-  std::unordered_map<PhaseType, size_t> phase_bookmarks_{};
+  Parallel::Phase phase_{Parallel::Phase::Initialization};
+  std::unordered_map<Parallel::Phase, size_t> phase_bookmarks_{};
   std::size_t algorithm_step_ = 0;
   tmpl::conditional_t<Parallel::is_node_group_proxy<cproxy_type>::value,
                       Parallel::NodeLock, NoSuchType>
@@ -535,7 +533,6 @@ std::string AlgorithmImpl<ParallelComponent,
   os << "using chare_type = " << pretty_type::get_name<chare_type>() << ";\n";
   os << "using cproxy_type = " << pretty_type::get_name<cproxy_type>() << ";\n";
   os << "using cbase_type = " << pretty_type::get_name<cbase_type>() << ";\n";
-  os << "using PhaseType = " << pretty_type::get_name<PhaseType>() << ";\n";
   os << "using phase_dependent_action_lists = "
      << pretty_type::get_name<phase_dependent_action_lists>() << ";\n";
   os << "using all_cache_tags = " << pretty_type::get_name<all_cache_tags>()
@@ -802,7 +799,7 @@ void AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>::
     }
     const auto invoke_for_phase = [this](auto phase_dep_v) {
       using PhaseDep = decltype(phase_dep_v);
-      constexpr PhaseType phase = PhaseDep::phase;
+      constexpr Parallel::Phase phase = PhaseDep::phase;
       using actions_list = typename PhaseDep::action_list;
       if (phase_ == phase) {
         while (
@@ -845,7 +842,7 @@ void AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>::
 
 template <typename ParallelComponent, typename... PhaseDepActionListsPack>
 void AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>::
-    start_phase(const PhaseType next_phase) {
+    start_phase(const Parallel::Phase next_phase) {
   try {
     // terminate should be true since we exited a phase previously.
     if (not get_terminate() and not halt_algorithm_until_next_phase_) {
@@ -1075,7 +1072,7 @@ void AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>::
 template <typename ParallelComponent, typename... PhaseDepActionListsPack>
 size_t
 AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>::
-    number_of_actions_in_phase(const PhaseType phase) const {
+    number_of_actions_in_phase(const Parallel::Phase phase) const {
   size_t number_of_actions = 0;
   const auto helper = [&number_of_actions, phase](auto pdal_v) {
     if (pdal_v.phase == phase) {

--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -32,6 +32,7 @@
 #include "Parallel/Local.hpp"
 #include "Parallel/NodeLock.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/PupStlCpp11.hpp"
 #include "Parallel/SimpleActionVisitation.hpp"
@@ -180,8 +181,7 @@ class AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>
   using cbase_type =
       typename chare_type::template cbase<parallel_component, array_index>;
   /// The type of the phases
-  using PhaseType =
-      typename tmpl::front<tmpl::list<PhaseDepActionListsPack...>>::phase_type;
+  using PhaseType = Parallel::Phase;
 
   using phase_dependent_action_lists = tmpl::list<PhaseDepActionListsPack...>;
 
@@ -555,6 +555,7 @@ template <typename ParallelComponent, typename... PhaseDepActionListsPack>
 std::string AlgorithmImpl<ParallelComponent,
                           tmpl::list<PhaseDepActionListsPack...>>::print_state()
     const {
+  using ::operator<<;
   std::ostringstream os;
   os << "State:\n";
   os << "performing_action_ = " << std::boolalpha << performing_action_

--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -410,7 +410,7 @@ class AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>
 
   Parallel::CProxy_GlobalCache<metavariables> global_cache_proxy_;
   bool performing_action_ = false;
-  PhaseType phase_{};
+  PhaseType phase_{Parallel::Phase::Initialization};
   std::unordered_map<PhaseType, size_t> phase_bookmarks_{};
   std::size_t algorithm_step_ = 0;
   tmpl::conditional_t<Parallel::is_node_group_proxy<cproxy_type>::value,

--- a/src/Parallel/AlgorithmMetafunctions.hpp
+++ b/src/Parallel/AlgorithmMetafunctions.hpp
@@ -7,6 +7,7 @@
 #include <type_traits>
 #include <utility>  // for declval
 
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -93,11 +94,10 @@ struct build_action_return_types<tmpl::list<AllActions...>> {
       template f<FirstInputParameterType, tmpl::list<>, AllActions...>;
 };
 
-template <typename PhaseType, PhaseType Phase, typename DataBoxTypes>
+template <Parallel::Phase Phase, typename DataBoxTypes>
 struct PhaseDependentDataBoxTypes {
   using databox_types = DataBoxTypes;
-  using phase_type = PhaseType;
-  static constexpr phase_type phase = Phase;
+  static constexpr Parallel::Phase phase = Phase;
 };
 
 template <typename CumulativeDataboxTypes, typename PhaseDepActionLists,
@@ -147,8 +147,7 @@ struct build_databox_types<
       typename build_action_return_types<action_list_of_this_phase>::template f<
           InputDataBox, additional_args_list>;
   using current_phase_dep_databox_types =
-      PhaseDependentDataBoxTypes<typename CurrentPhaseDepActionList::phase_type,
-                                 CurrentPhaseDepActionList::phase,
+      PhaseDependentDataBoxTypes<CurrentPhaseDepActionList::phase,
                                  databox_types_for_this_phase>;
   using cumulative_databox_types =
       tmpl::push_back<CumulativeDataboxTypes, current_phase_dep_databox_types>;

--- a/src/Parallel/MemoryMonitor/MemoryMonitor.hpp
+++ b/src/Parallel/MemoryMonitor/MemoryMonitor.hpp
@@ -9,6 +9,7 @@
 #include "Parallel/Local.hpp"
 #include "Parallel/MemoryMonitor/Tags.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/AddSimpleTags.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
 #include "Utilities/Gsl.hpp"
@@ -44,7 +45,7 @@ struct MemoryMonitor {
   using metavariables = Metavariables;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename metavariables::Phase, metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<Actions::SetupDataBox,
                  Initialization::Actions::AddSimpleTags<
                      mem_monitor::detail::InitializeMutator>,

--- a/src/Parallel/ParallelComponentHelpers.hpp
+++ b/src/Parallel/ParallelComponentHelpers.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "Parallel/Callback.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -233,9 +234,9 @@ struct get_initialization_actions_list {
   using type = tmpl::list<>;
 };
 
-template <typename PhaseType, typename InitializationActionsList>
+template <typename InitializationActionsList>
 struct get_initialization_actions_list<Parallel::PhaseActions<
-    PhaseType, PhaseType::Initialization, InitializationActionsList>> {
+    Parallel::Phase::Initialization, InitializationActionsList>> {
   using type = InitializationActionsList;
 };
 }  // namespace detail

--- a/src/Parallel/Phase.cpp
+++ b/src/Parallel/Phase.cpp
@@ -15,7 +15,8 @@
 
 namespace Parallel {
 std::vector<Phase> known_phases() {
-  return {Phase::Evolve,
+  return {Phase::Cleanup,
+          Phase::Evolve,
           Phase::Execute,
           Phase::Exit,
           Phase::ImportInitialData,
@@ -27,12 +28,14 @@ std::vector<Phase> known_phases() {
           Phase::RegisterWithElementDataReader,
           Phase::RegisterWithObserver,
           Phase::Solve,
-          Phase::Test,
+          Phase::Testing,
           Phase::WriteCheckpoint};
 }
 
 std::ostream& operator<<(std::ostream& os, const Phase& phase) {
   switch (phase) {
+    case Parallel::Phase::Cleanup:
+      return os << "Cleanup";
     case Parallel::Phase::Evolve:
       return os << "Evolve";
     case Parallel::Phase::Execute:
@@ -57,8 +60,8 @@ std::ostream& operator<<(std::ostream& os, const Phase& phase) {
       return os << "RegisterWithObserver";
     case Parallel::Phase::Solve:
       return os << "Solve";
-    case Parallel::Phase::Test:
-      return os << "Test";
+    case Parallel::Phase::Testing:
+      return os << "Testing";
     case Parallel::Phase::WriteCheckpoint:
       return os << "WriteCheckpoint";
     default:  // LCOV_EXCL_LINE

--- a/src/Parallel/Phase.hpp
+++ b/src/Parallel/Phase.hpp
@@ -48,6 +48,8 @@ enum class Phase {
   // vector created by known_phases() below, and add it to the stream operator
   // If the new phase is the first or last in the list, update Test_Phase.
 
+  ///  a cleanup phase
+  Cleanup,
   ///  phase in which time steps are taken for an evolution executable
   Evolve,
   ///  generic execution phase of an executable
@@ -74,7 +76,7 @@ enum class Phase {
   ///  phase in which something is solved
   Solve,
   ///  phase in which something is tested
-  Test,
+  Testing,
   ///  phase in which checkpoint files are written to disk
   WriteCheckpoint
 };

--- a/src/Parallel/PhaseControl/CMakeLists.txt
+++ b/src/Parallel/PhaseControl/CMakeLists.txt
@@ -3,7 +3,13 @@
 
 set(LIBRARY PhaseControl)
 
-add_spectre_library(${LIBRARY} INTERFACE)
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  CheckpointAndExitAfterWallclock.cpp
+  )
 
 spectre_target_headers(
   ${LIBRARY}
@@ -22,6 +28,8 @@ target_link_libraries(
   INTERFACE
   DataStructures
   EventsAndTriggers
+  PUBLIC
+  Charmxx::charmxx
   Options
   Parallel
   Utilities

--- a/src/Parallel/PhaseControl/CheckpointAndExitAfterWallclock.cpp
+++ b/src/Parallel/PhaseControl/CheckpointAndExitAfterWallclock.cpp
@@ -1,0 +1,55 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp"
+
+#include <optional>
+#include <pup.h>
+
+#include "Options/Options.hpp"
+#include "Parallel/Phase.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+
+namespace PhaseControl {
+
+namespace Tags {
+std::optional<Parallel::Phase> RestartPhase::combine_method::operator()(
+    const std::optional<Parallel::Phase> /*first_phase*/,
+    const std::optional<Parallel::Phase>& /*second_phase*/) {
+  ERROR(
+      "The restart phase should only be altered by the phase change "
+      "arbitration in the Main chare, so no reduction data should be "
+      "provided.");
+}
+
+std::optional<double> WallclockHoursAtCheckpoint::combine_method::operator()(
+    const std::optional<double> /*first_time*/,
+    const std::optional<double>& /*second_time*/) {
+  ERROR(
+      "The wallclock time at which a checkpoint was requested should "
+      "only be altered by the phase change arbitration in the Main "
+      "chare, so no reduction data should be provided.");
+}
+}  // namespace Tags
+
+CheckpointAndExitAfterWallclock::CheckpointAndExitAfterWallclock(
+    const std::optional<double> wallclock_hours,
+    const Options::Context& context)
+    : wallclock_hours_for_checkpoint_and_exit_(wallclock_hours) {
+  if (wallclock_hours.has_value() and wallclock_hours.value() < 0.0) {
+    PARSE_ERROR(context, "Must give a positive time in hours, but got "
+                             << wallclock_hours.value());
+  }
+}
+
+CheckpointAndExitAfterWallclock::CheckpointAndExitAfterWallclock(
+    CkMigrateMessage* msg)
+    : PhaseChange(msg) {}
+
+void CheckpointAndExitAfterWallclock::pup(PUP::er& p) {
+  PhaseChange::pup(p);
+  p | wallclock_hours_for_checkpoint_and_exit_;
+}
+}  // namespace PhaseControl
+
+PUP::able::PUP_ID PhaseControl::CheckpointAndExitAfterWallclock::my_PUP_ID = 0;

--- a/src/Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp
+++ b/src/Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp
@@ -15,8 +15,9 @@
 #include "Parallel/CharmPupable.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Main.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseControl/PhaseChange.hpp"
-#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Functional.hpp"
 #include "Utilities/System/ParallelInfo.hpp"
 #include "Utilities/TMPL.hpp"
@@ -30,19 +31,13 @@ namespace Tags {
 ///
 /// \note This tag is not intended to participate in any of the reduction
 /// procedures, so will error if the combine method is called.
-template <typename PhaseType>
 struct RestartPhase {
-  using type = std::optional<PhaseType>;
+  using type = std::optional<Parallel::Phase>;
 
   struct combine_method {
-    std::optional<PhaseType> operator()(
-        const std::optional<PhaseType> /*first_phase*/,
-        const std::optional<PhaseType>& /*second_phase*/) {
-      ERROR(
-          "The restart phase should only be altered by the phase change "
-          "arbitration in the Main chare, so no reduction data should be "
-          "provided.");
-    }
+    [[noreturn]] std::optional<Parallel::Phase> operator()(
+        const std::optional<Parallel::Phase> /*first_phase*/,
+        const std::optional<Parallel::Phase>& /*second_phase*/);
   };
 
   using main_combine_method = combine_method;
@@ -57,14 +52,9 @@ struct WallclockHoursAtCheckpoint {
   using type = std::optional<double>;
 
   struct combine_method {
-    std::optional<double> operator()(
+    [[noreturn]] std::optional<double> operator()(
         const std::optional<double> /*first_time*/,
-        const std::optional<double>& /*second_time*/) {
-      ERROR(
-          "The wallclock time at which a checkpoint was requested should "
-          "only be altered by the phase change arbitration in the Main "
-          "chare, so no reduction data should be provided.");
-    }
+        const std::optional<double>& /*second_time*/);
   };
   using main_combine_method = combine_method;
 };
@@ -110,24 +100,11 @@ struct CheckpointAndExitRequested {
  * 2-10 minutes might be desirable. Matching the global sync frequency with the
  * time window for checkpoint and exit is the responsibility of the user!
  */
-template <typename Metavariables>
 struct CheckpointAndExitAfterWallclock : public PhaseChange {
-  // This PhaseChange only makes sense if Metavars has a WriteCheckpoint phase
-  static_assert(Parallel::Algorithm_detail::has_WriteCheckpoint_v<
-                    typename Metavariables::Phase>,
-                "Requested to write checkpoints but Metavariables::Phase "
-                "doesn't have a WriteCheckpoint phase");
-
   CheckpointAndExitAfterWallclock(const std::optional<double> wallclock_hours,
-                                  const Options::Context& context = {})
-      : wallclock_hours_for_checkpoint_and_exit_(wallclock_hours) {
-    if (wallclock_hours.has_value() and wallclock_hours.value() < 0.0) {
-      PARSE_ERROR(context, "Must give a positive time in hours, but got "
-                               << wallclock_hours.value());
-    }
-  }
-  explicit CheckpointAndExitAfterWallclock(CkMigrateMessage* msg)
-      : PhaseChange(msg) {}
+                                  const Options::Context& context = {});
+
+  explicit CheckpointAndExitAfterWallclock(CkMigrateMessage* msg);
 
   /// \cond
   CheckpointAndExitAfterWallclock() = default;
@@ -141,6 +118,7 @@ struct CheckpointAndExitAfterWallclock : public PhaseChange {
         "Time in hours after which to write the checkpoint and exit. "
         "If 'None' is specified, no action will be taken."};
   };
+
   using options = tmpl::list<WallclockHours>;
   static constexpr Options::String help{
       "Once the wallclock time has exceeded the specified amount, trigger "
@@ -150,114 +128,119 @@ struct CheckpointAndExitAfterWallclock : public PhaseChange {
   using return_tags = tmpl::list<>;
 
   using phase_change_tags_and_combines =
-      tmpl::list<Tags::RestartPhase<typename Metavariables::Phase>,
-                 Tags::WallclockHoursAtCheckpoint,
+      tmpl::list<Tags::RestartPhase, Tags::WallclockHoursAtCheckpoint,
                  Tags::CheckpointAndExitRequested>;
 
-  template <typename LocalMetavariables>
-  using participating_components = typename LocalMetavariables::component_list;
+  template <typename Metavariables>
+  using participating_components = typename Metavariables::component_list;
 
   template <typename... DecisionTags>
   void initialize_phase_data_impl(
       const gsl::not_null<tuples::TaggedTuple<DecisionTags...>*>
-          phase_change_decision_data) const {
-    tuples::get<Tags::RestartPhase<typename Metavariables::Phase>>(
-        *phase_change_decision_data) = std::nullopt;
-    tuples::get<Tags::WallclockHoursAtCheckpoint>(*phase_change_decision_data) =
-        std::nullopt;
-    tuples::get<Tags::CheckpointAndExitRequested>(*phase_change_decision_data) =
-        false;
-  }
+          phase_change_decision_data) const;
 
   template <typename ParallelComponent, typename ArrayIndex,
-            typename LocalMetavariables>
-  void contribute_phase_data_impl(
-      Parallel::GlobalCache<LocalMetavariables>& cache,
-      const ArrayIndex& array_index) const {
-    if constexpr (std::is_same_v<typename ParallelComponent::chare_type,
-                                 Parallel::Algorithms::Array>) {
-      Parallel::contribute_to_phase_change_reduction<ParallelComponent>(
-          tuples::TaggedTuple<Tags::CheckpointAndExitRequested>{true}, cache,
-          array_index);
-    } else {
-      Parallel::contribute_to_phase_change_reduction<ParallelComponent>(
-          tuples::TaggedTuple<Tags::CheckpointAndExitRequested>{true}, cache);
-    }
-  }
+            typename Metavariables>
+  void contribute_phase_data_impl(Parallel::GlobalCache<Metavariables>& cache,
+                                  const ArrayIndex& array_index) const;
 
-  template <typename... DecisionTags, typename LocalMetavariables>
-  typename std::optional<
-      std::pair<typename Metavariables::Phase, ArbitrationStrategy>>
+  template <typename... DecisionTags, typename Metavariables>
+  typename std::optional<std::pair<Parallel::Phase, ArbitrationStrategy>>
   arbitrate_phase_change_impl(
       const gsl::not_null<tuples::TaggedTuple<DecisionTags...>*>
           phase_change_decision_data,
-      const typename LocalMetavariables::Phase current_phase,
-      const Parallel::GlobalCache<LocalMetavariables>& /*cache*/) const {
-    // If no checkpoint-and-exit time given, then do nothing
-    if (not wallclock_hours_for_checkpoint_and_exit_.has_value()) {
-      return std::nullopt;
-    }
+      const Parallel::Phase current_phase,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/) const;
 
-    const double elapsed_hours = sys::wall_time() / 3600.0;
-
-    auto& restart_phase =
-        tuples::get<Tags::RestartPhase<typename Metavariables::Phase>>(
-            *phase_change_decision_data);
-    auto& wallclock_hours_at_checkpoint =
-        tuples::get<Tags::WallclockHoursAtCheckpoint>(
-            *phase_change_decision_data);
-    if (restart_phase.has_value()) {
-      ASSERT(wallclock_hours_at_checkpoint.has_value(),
-             "Consistency error: Should have recorded the Wallclock time "
-             "while recording a phase to restart from.");
-      // This `if` branch, where restart_phase has a value, is the
-      // post-checkpoint call to arbitrate_phase_change. Depending on the time
-      // elapsed so far in this run, next phase is...
-      // - Exit, if the time is large
-      // - restart_phase, if the time is small
-      if (elapsed_hours >= wallclock_hours_at_checkpoint.value()) {
-        // Preserve restart_phase for use after restarting from the checkpoint
-        return std::make_pair(Metavariables::Phase::Exit,
-                              ArbitrationStrategy::RunPhaseImmediately);
-      } else {
-        // Reset restart_phase until it is needed for the next checkpoint
-        const auto result = restart_phase;
-        restart_phase.reset();
-        wallclock_hours_at_checkpoint.reset();
-        return std::make_pair(result.value(),
-                              ArbitrationStrategy::PermitAdditionalJumps);
-      }
-    }
-
-    auto& checkpoint_and_exit_requested =
-        tuples::get<Tags::CheckpointAndExitRequested>(
-            *phase_change_decision_data);
-    if (checkpoint_and_exit_requested) {
-      checkpoint_and_exit_requested = false;
-      // We checked wallclock_hours_for_checkpoint_and_exit_ has value above
-      if (elapsed_hours >= wallclock_hours_for_checkpoint_and_exit_.value()) {
-        // Record phase and actual elapsed time for determining following phase
-        restart_phase = current_phase;
-        wallclock_hours_at_checkpoint = elapsed_hours;
-        return std::make_pair(Metavariables::Phase::WriteCheckpoint,
-                              ArbitrationStrategy::RunPhaseImmediately);
-      }
-    }
-    return std::nullopt;
-  }
-
-  void pup(PUP::er& p) override {
-    PhaseChange::pup(p);
-    p | wallclock_hours_for_checkpoint_and_exit_;
-  }
+  void pup(PUP::er& p) override;
 
  private:
   std::optional<double> wallclock_hours_for_checkpoint_and_exit_ = std::nullopt;
 };
-}  // namespace PhaseControl
 
-/// \cond
-template <typename Metavariables>
-PUP::able::PUP_ID
-    PhaseControl::CheckpointAndExitAfterWallclock<Metavariables>::my_PUP_ID = 0;
-/// \endcond
+template <typename... DecisionTags>
+void CheckpointAndExitAfterWallclock::initialize_phase_data_impl(
+    const gsl::not_null<tuples::TaggedTuple<DecisionTags...>*>
+        phase_change_decision_data) const {
+  tuples::get<Tags::RestartPhase>(*phase_change_decision_data) = std::nullopt;
+  tuples::get<Tags::WallclockHoursAtCheckpoint>(*phase_change_decision_data) =
+      std::nullopt;
+  tuples::get<Tags::CheckpointAndExitRequested>(*phase_change_decision_data) =
+      false;
+}
+
+template <typename ParallelComponent, typename ArrayIndex,
+          typename Metavariables>
+void CheckpointAndExitAfterWallclock::contribute_phase_data_impl(
+    Parallel::GlobalCache<Metavariables>& cache,
+    const ArrayIndex& array_index) const {
+  if constexpr (std::is_same_v<typename ParallelComponent::chare_type,
+                               Parallel::Algorithms::Array>) {
+    Parallel::contribute_to_phase_change_reduction<ParallelComponent>(
+        tuples::TaggedTuple<Tags::CheckpointAndExitRequested>{true}, cache,
+        array_index);
+  } else {
+    Parallel::contribute_to_phase_change_reduction<ParallelComponent>(
+        tuples::TaggedTuple<Tags::CheckpointAndExitRequested>{true}, cache);
+  }
+}
+
+template <typename... DecisionTags, typename Metavariables>
+typename std::optional<std::pair<Parallel::Phase, ArbitrationStrategy>>
+CheckpointAndExitAfterWallclock::arbitrate_phase_change_impl(
+    const gsl::not_null<tuples::TaggedTuple<DecisionTags...>*>
+        phase_change_decision_data,
+    const Parallel::Phase current_phase,
+    const Parallel::GlobalCache<Metavariables>& /*cache*/) const {
+  // If no checkpoint-and-exit time given, then do nothing
+  if (not wallclock_hours_for_checkpoint_and_exit_.has_value()) {
+    return std::nullopt;
+  }
+
+  const double elapsed_hours = sys::wall_time() / 3600.0;
+
+  auto& restart_phase =
+      tuples::get<Tags::RestartPhase>(*phase_change_decision_data);
+  auto& wallclock_hours_at_checkpoint =
+      tuples::get<Tags::WallclockHoursAtCheckpoint>(
+          *phase_change_decision_data);
+  if (restart_phase.has_value()) {
+    ASSERT(wallclock_hours_at_checkpoint.has_value(),
+           "Consistency error: Should have recorded the Wallclock time "
+           "while recording a phase to restart from.");
+    // This `if` branch, where restart_phase has a value, is the
+    // post-checkpoint call to arbitrate_phase_change. Depending on the time
+    // elapsed so far in this run, next phase is...
+    // - Exit, if the time is large
+    // - restart_phase, if the time is small
+    if (elapsed_hours >= wallclock_hours_at_checkpoint.value()) {
+      // Preserve restart_phase for use after restarting from the checkpoint
+      return std::make_pair(Parallel::Phase::Exit,
+                            ArbitrationStrategy::RunPhaseImmediately);
+    } else {
+      // Reset restart_phase until it is needed for the next checkpoint
+      const auto result = restart_phase;
+      restart_phase.reset();
+      wallclock_hours_at_checkpoint.reset();
+      return std::make_pair(result.value(),
+                            ArbitrationStrategy::PermitAdditionalJumps);
+    }
+  }
+
+  auto& checkpoint_and_exit_requested =
+      tuples::get<Tags::CheckpointAndExitRequested>(
+          *phase_change_decision_data);
+  if (checkpoint_and_exit_requested) {
+    checkpoint_and_exit_requested = false;
+    // We checked wallclock_hours_for_checkpoint_and_exit_ has value above
+    if (elapsed_hours >= wallclock_hours_for_checkpoint_and_exit_.value()) {
+      // Record phase and actual elapsed time for determining following phase
+      restart_phase = current_phase;
+      wallclock_hours_at_checkpoint = elapsed_hours;
+      return std::make_pair(Parallel::Phase::WriteCheckpoint,
+                            ArbitrationStrategy::RunPhaseImmediately);
+    }
+  }
+  return std::nullopt;
+}
+}  // namespace PhaseControl

--- a/src/Parallel/PhaseDependentActionList.hpp
+++ b/src/Parallel/PhaseDependentActionList.hpp
@@ -5,6 +5,7 @@
 
 #include <type_traits>
 
+#include "Parallel/Phase.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace Parallel {
@@ -12,12 +13,13 @@ namespace Parallel {
  * \ingroup ParallelGroup
  * \brief List of all the actions to be executed in the specified phase.
  */
-template <typename PhaseType, PhaseType Phase, typename ActionsList>
+template <Parallel::Phase Phase, typename ActionsList>
 struct PhaseActions {
   using action_list = tmpl::flatten<ActionsList>;
-  using phase_type = PhaseType;
-  static constexpr phase_type phase = Phase;
-  using integral_constant_phase = std::integral_constant<PhaseType, Phase>;
+  using phase_type = Parallel::Phase;
+  static constexpr Parallel::Phase phase = Phase;
+  using integral_constant_phase =
+      std::integral_constant<Parallel::Phase, Phase>;
   static constexpr size_t number_of_actions = tmpl::size<action_list>::value;
 };
 
@@ -36,7 +38,7 @@ struct get_action_list_from_phase_dep_action_list {
  */
 template <typename PhaseDepActionList>
 struct get_phase_type_from_phase_dep_action_list {
-  using type = typename PhaseDepActionList::phase_type;
+  using type = Parallel::Phase;
 };
 
 /*!

--- a/src/Parallel/PhaseDependentActionList.hpp
+++ b/src/Parallel/PhaseDependentActionList.hpp
@@ -16,10 +16,7 @@ namespace Parallel {
 template <Parallel::Phase Phase, typename ActionsList>
 struct PhaseActions {
   using action_list = tmpl::flatten<ActionsList>;
-  using phase_type = Parallel::Phase;
   static constexpr Parallel::Phase phase = Phase;
-  using integral_constant_phase =
-      std::integral_constant<Parallel::Phase, Phase>;
   static constexpr size_t number_of_actions = tmpl::size<action_list>::value;
 };
 
@@ -30,24 +27,5 @@ struct PhaseActions {
 template <typename PhaseDepActionList>
 struct get_action_list_from_phase_dep_action_list {
   using type = typename PhaseDepActionList::action_list;
-};
-
-/*!
- * \ingroup ParallelGroup
- * \brief (Lazy) metafunction to get the phase type from a `PhaseActions`
- */
-template <typename PhaseDepActionList>
-struct get_phase_type_from_phase_dep_action_list {
-  using type = Parallel::Phase;
-};
-
-/*!
- * \ingroup ParallelGroup
- * \brief (Lazy) metafunction to get the phase as a `std::integral_constant`
- * from a `PhaseActions`
- */
-template <typename PhaseDepActionList>
-struct get_phase_from_phase_dep_action_list {
-  using type = typename PhaseDepActionList::integral_constant_phase;
 };
 }  // namespace Parallel

--- a/src/Parallel/ResourceInfo.hpp
+++ b/src/Parallel/ResourceInfo.hpp
@@ -540,7 +540,6 @@ ResourceInfo<Metavariables>::ResourceInfo(
   // proc it wants to be on. Use nullopt as a sentinel for choosing the proc
   // automatically.
   tmpl::for_each<singletons>(parse_singletons);
-  using ::operator<<;
   [[maybe_unused]] const auto sanity_checks =
       [this, &context, &requested_procs](const auto component_v) {
         using component = tmpl::type_from<decltype(component_v)>;
@@ -556,7 +555,7 @@ ResourceInfo<Metavariables>::ResourceInfo(
             requested_procs.count(*proc) > 1) {
           PARSE_ERROR(context,
                       "Two singletons have requested to be on proc "
-                          << proc
+                          << proc.value()
                           << ", but at least one of them has requested to be "
                              "exclusively on this proc.");
         }

--- a/src/Parallel/ResourceInfo.hpp
+++ b/src/Parallel/ResourceInfo.hpp
@@ -23,6 +23,7 @@
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Numeric.hpp"
 #include "Utilities/PrettyType.hpp"
+#include "Utilities/StdHelpers.hpp"
 #include "Utilities/System/ParallelInfo.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -539,7 +540,7 @@ ResourceInfo<Metavariables>::ResourceInfo(
   // proc it wants to be on. Use nullopt as a sentinel for choosing the proc
   // automatically.
   tmpl::for_each<singletons>(parse_singletons);
-
+  using ::operator<<;
   [[maybe_unused]] const auto sanity_checks =
       [this, &context, &requested_procs](const auto component_v) {
         using component = tmpl::type_from<decltype(component_v)>;

--- a/src/ParallelAlgorithms/Interpolation/InterpolationTarget.hpp
+++ b/src/ParallelAlgorithms/Interpolation/InterpolationTarget.hpp
@@ -12,6 +12,7 @@
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Local.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InterpolationTargetSendPoints.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
@@ -274,13 +275,13 @@ struct InterpolationTarget {
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          Parallel::Phase::Initialization,
           tmpl::list<::Actions::SetupDataBox,
                      intrp::Actions::InitializeInterpolationTarget<
                          Metavariables, InterpolationTargetTag>,
                      Parallel::Actions::TerminatePhase>>,
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Register,
+          Parallel::Phase::Register,
           tmpl::list<
               tmpl::conditional_t<
                   InterpolationTargetTag::compute_target_points::is_sequential::

--- a/src/ParallelAlgorithms/Interpolation/Interpolator.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Interpolator.hpp
@@ -10,6 +10,7 @@
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Local.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InitializeInterpolator.hpp"
 #include "Utilities/TMPL.hpp"
@@ -43,7 +44,7 @@ struct Interpolator {
   using all_temporal_ids = tmpl::remove_duplicates<tmpl::transform<
       all_interpolation_target_tags, detail::get_temporal_id<tmpl::_1>>>;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename metavariables::Phase, metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<
           ::Actions::SetupDataBox,
           Actions::InitializeInterpolator<

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp
@@ -17,6 +17,7 @@
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Local.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
@@ -47,7 +48,7 @@ struct ResidualMonitor {
   // `ElementActions.hpp`. See `LinearSolver::cg::ConjugateGradient` for
   // details.
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<::Actions::SetupDataBox,
                  InitializeResidualMonitor<FieldsTag, OptionsGroup>>>>;
   using initialization_tags = Parallel::get_initialization_tags<

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp
@@ -16,6 +16,7 @@
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Local.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
@@ -45,7 +46,7 @@ struct ResidualMonitor {
   // on this component as the result of reductions from the actions in
   // `ElementActions.hpp`. See `LinearSolver::gmres::Gmres` for details.
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<::Actions::SetupDataBox,
                  InitializeResidualMonitor<FieldsTag, OptionsGroup>>>>;
   using initialization_tags = Parallel::get_initialization_tags<

--- a/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/ResidualMonitor.hpp
+++ b/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/ResidualMonitor.hpp
@@ -13,6 +13,7 @@
 #include "Parallel/Algorithms/AlgorithmSingleton.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Local.hpp"
+#include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
 #include "ParallelAlgorithms/NonlinearSolver/Tags.hpp"
@@ -40,7 +41,7 @@ struct ResidualMonitor {
                  NonlinearSolver::Tags::MaxGlobalizationSteps<OptionsGroup>>;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<::Actions::SetupDataBox,
                  InitializeResidualMonitor<FieldsTag, OptionsGroup>>>>;
 

--- a/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
@@ -45,6 +45,7 @@
 #include "NumericalAlgorithms/SphericalHarmonics/YlmSpherepack.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "ParallelAlgorithms/Interpolation/Actions/AddTemporalIdsToInterpolationTarget.hpp"  // IWYU pragma: keep
 #include "ParallelAlgorithms/Interpolation/Actions/CleanUpInterpolator.hpp"  // IWYU pragma: keep
@@ -230,7 +231,7 @@ struct mock_interpolation_target {
                           tmpl::list<domain::Tags::FunctionsOfTimeInitialize>,
                           tmpl::list<>>;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<Actions::SetupDataBox,
                  intrp::Actions::InitializeInterpolationTarget<
                      Metavariables, InterpolationTargetTag>>>>;
@@ -245,7 +246,7 @@ struct mock_interpolator {
   using chare_type = ActionTesting::MockGroupChare;
   using array_index = size_t;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<Actions::SetupDataBox,
                  intrp::Actions::InitializeInterpolator<
                      intrp::Tags::VolumeVarsInfo<Metavariables, ::Tags::Time>,
@@ -284,7 +285,7 @@ struct MockMetavariables {
                  mock_interpolator<MockMetavariables>>;
   using const_global_cache_tags = tmpl::list<domain::Tags::Domain<3>>;
 
-  enum class Phase { Initialization, Registration, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 template <typename PostHorizonFindCallbacks, typename IsTimeDependent,
@@ -379,8 +380,7 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
   for (size_t i = 0; i < 2; ++i) {
     ActionTesting::next_action<target_component>(make_not_null(&runner), 0);
   }
-  ActionTesting::set_phase(make_not_null(&runner),
-                           metavars::Phase::Registration);
+  ActionTesting::set_phase(make_not_null(&runner), metavars::Phase::Register);
 
   // Find horizon at three temporal_ids.  The horizon find at the
   // second temporal_id will use the result from the first temporal_id

--- a/tests/Unit/ApparentHorizons/Test_ObserveCenters.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ObserveCenters.cpp
@@ -29,7 +29,7 @@ namespace {
 struct AhA {};
 
 struct TestMetavars {
-  enum class Phase { Initialization, WriteData, Exit };
+  using Phase = Parallel::Phase;
 
   using component_list =
       tmpl::list<TestHelpers::observers::MockObserverWriter<TestMetavars>>;
@@ -51,7 +51,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.ObserveCenters",
       make_not_null(&runner), {});
   auto& cache = ActionTesting::cache<observer_writer>(runner, 0);
 
-  runner.set_phase(TestMetavars::Phase::WriteData);
+  runner.set_phase(TestMetavars::Phase::Execute);
 
   const auto make_center = [&gen, &center_dist]() -> std::array<double, 3> {
     return make_with_random_values<std::array<double, 3>>(

--- a/tests/Unit/ControlSystem/Actions/Test_Initialization.cpp
+++ b/tests/Unit/ControlSystem/Actions/Test_Initialization.cpp
@@ -22,6 +22,7 @@
 #include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "Helpers/ControlSystem/TestStructs.hpp"
+#include "Parallel/Phase.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
@@ -69,7 +70,7 @@ struct MockControlComponent {
                  control_system::Tags::Controller<mock_control_sys>>;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename metavariables::Phase, metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<ActionTesting::InitializeDataBox<simple_tags>,
                  control_system::Actions::Initialize<Metavariables,
                                                      mock_control_sys>>>>;
@@ -77,7 +78,7 @@ struct MockControlComponent {
 
 struct MockMetavars {
   using component_list = tmpl::list<MockControlComponent<MockMetavars>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 }  // namespace
 

--- a/tests/Unit/ControlSystem/Actions/Test_InitializeMeasurements.cpp
+++ b/tests/Unit/ControlSystem/Actions/Test_InitializeMeasurements.cpp
@@ -33,6 +33,7 @@
 #include "Helpers/ControlSystem/TestStructs.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
@@ -151,7 +152,7 @@ struct Component {
                  evolution::Tags::EventsAndDenseTriggers>;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<
           Actions::SetupDataBox,
           evolution::Actions::InitializeRunEventsAndDenseTriggers,
@@ -170,7 +171,7 @@ struct Metavariables {
                    control_system::control_system_triggers<control_systems>>>;
   };
 
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 SPECTRE_TEST_CASE("Unit.ControlSystem.InitializeMeasurements",

--- a/tests/Unit/ControlSystem/Test_Measurement.cpp
+++ b/tests/Unit/ControlSystem/Test_Measurement.cpp
@@ -14,6 +14,7 @@
 #include "Framework/ActionTesting.hpp"
 #include "Helpers/ControlSystem/Examples.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/Tags/Metavariables.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
@@ -32,8 +33,7 @@ struct ElementComponent {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Testing, tmpl::list<>>>;
+      Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
 };
 
 template <typename Metavariables>
@@ -49,8 +49,7 @@ struct MockControlSystemComponent {
       control_system::TestHelpers::MeasurementResultTime,
       control_system::TestHelpers::MeasurementResultTag>;
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Testing, tmpl::list<>>>;
+      Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
 };
 
 struct Metavariables {
@@ -63,7 +62,7 @@ struct Metavariables {
         tmpl::map<tmpl::pair<Event, tmpl::list<MeasureEvent>>>;
   };
 
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 }  // namespace
 

--- a/tests/Unit/ControlSystem/Test_Trigger.cpp
+++ b/tests/Unit/ControlSystem/Test_Trigger.cpp
@@ -21,6 +21,7 @@
 #include "Helpers/ControlSystem/TestStructs.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/GlobalCache.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Time/Tags.hpp"
@@ -53,7 +54,7 @@ struct Component {
       tmpl::list<control_system::Tags::MeasurementTimescales>;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<ActionTesting::InitializeDataBox<simple_tags, compute_tags>>>>;
 };
 
@@ -66,7 +67,7 @@ struct Metavariables {
         tmpl::map<tmpl::pair<DenseTrigger, tmpl::list<MeasureTrigger>>>;
   };
 
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 }  // namespace
 

--- a/tests/Unit/ControlSystem/Test_UpdateFunctionOfTime.cpp
+++ b/tests/Unit/ControlSystem/Test_UpdateFunctionOfTime.cpp
@@ -18,6 +18,7 @@
 #include "Domain/FunctionsOfTime/SettleToConstant.hpp"
 #include "Domain/FunctionsOfTime/Tags.hpp"
 #include "Framework/ActionTesting.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -31,14 +32,12 @@ struct TestSingleton {
   using get_const_global_cache_tags = tmpl::list<>;
   using mutable_global_cache_tags =
       tmpl::list<domain::Tags::FunctionsOfTimeInitialize>;
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename metavariables::Phase,
-                                        metavariables::Phase::Initialization,
-                                        tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
 };
 
 struct TestingMetavariables {
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
   using component_list = tmpl::list<TestSingleton<TestingMetavariables>>;
 };
 

--- a/tests/Unit/ControlSystem/Test_WriteData.cpp
+++ b/tests/Unit/ControlSystem/Test_WriteData.cpp
@@ -34,6 +34,7 @@
 #include "IO/Observer/Tags.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/GlobalCache.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/FileSystem.hpp"
 #include "Utilities/GetOutput.hpp"
@@ -93,16 +94,14 @@ struct MockControlComponent {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockSingletonChare;
 
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
-                                        tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
 };
 
 struct TestMetavars {
   using observed_reduction_data_tags = tmpl::list<>;
 
-  enum class Phase { Initialization, Register, WriteData, Exit };
+  using Phase = Parallel::Phase;
 
   using component_list =
       tmpl::list<::TestHelpers::observers::MockObserverWriter<TestMetavars>,
@@ -210,7 +209,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.WriteData", "[Unit][ControlSystem]") {
       ActionTesting::LocalCoreId{0});
   auto& cache = ActionTesting::cache<observer>(runner, 0);
 
-  runner.set_phase(TestMetavars::Phase::WriteData);
+  runner.set_phase(TestMetavars::Phase::Execute);
 
   // set up data to write
   FoTPtr normal_fot = std::make_unique<

--- a/tests/Unit/Domain/FunctionsOfTime/Test_FunctionsOfTimeAreReady.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_FunctionsOfTimeAreReady.cpp
@@ -18,6 +18,7 @@
 #include "Framework/MockRuntimeSystem.hpp"
 #include "Framework/MockRuntimeSystemFreeFunctions.hpp"
 #include "Parallel/GlobalCache.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Time/Tags.hpp"
@@ -49,13 +50,13 @@ struct Component {
       tmpl::list<domain::Tags::FunctionsOfTimeInitialize, OtherFunctionsOfTime>;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Testing,
+      Parallel::Phase::Testing,
       tmpl::list<domain::Actions::CheckFunctionsOfTimeAreReady>>>;
 };
 
 struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 }  // namespace
 

--- a/tests/Unit/Elliptic/Actions/Test_InitializeAnalyticSolution.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeAnalyticSolution.cpp
@@ -20,6 +20,7 @@
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/AnalyticSolution.hpp"
@@ -74,12 +75,12 @@ struct ElementArray {
   using array_index = ElementId<1>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          Parallel::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<
               tmpl::list<domain::Tags::Coordinates<1, Frame::Inertial>>>>>,
 
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          Parallel::Phase::Testing,
           tmpl::list<Actions::SetupDataBox,
                      elliptic::Actions::InitializeOptionalAnalyticSolution<
                          elliptic::Tags::Background<
@@ -93,7 +94,7 @@ struct Metavariables {
   using const_global_cache_tags = tmpl::list<
       elliptic::Tags::Background<elliptic::analytic_data::Background>>;
   using component_list = tmpl::list<element_array>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes =

--- a/tests/Unit/Elliptic/Actions/Test_InitializeBackgroundFields.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeBackgroundFields.cpp
@@ -20,6 +20,7 @@
 #include "Elliptic/Tags.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/Phase.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -52,19 +53,19 @@ struct ElementArray {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementId<1>;
   using const_global_cache_tags = tmpl::list<domain::Tags::Domain<1>>;
-  using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<ActionTesting::InitializeDataBox<
-                         tmpl::list<domain::Tags::InitialRefinementLevels<1>,
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<
+                     Parallel::Phase::Initialization,
+                     tmpl::list<ActionTesting::InitializeDataBox<tmpl::list<
+                                    domain::Tags::InitialRefinementLevels<1>,
                                     domain::Tags::InitialExtents<1>>>,
-                     Actions::SetupDataBox,
-                     elliptic::dg::Actions::InitializeDomain<1>>>,
-      Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Testing,
-          tmpl::list<::elliptic::Actions::InitializeBackgroundFields<
-              typename Metavariables::system,
-              elliptic::Tags::Background<Background>>>>>;
+                                Actions::SetupDataBox,
+                                elliptic::dg::Actions::InitializeDomain<1>>>,
+                 Parallel::PhaseActions<
+                     Parallel::Phase::Testing,
+                     tmpl::list<::elliptic::Actions::InitializeBackgroundFields<
+                         typename Metavariables::system,
+                         elliptic::Tags::Background<Background>>>>>;
 };
 
 struct Metavariables {
@@ -72,7 +73,7 @@ struct Metavariables {
   using component_list = tmpl::list<ElementArray<Metavariables>>;
   using const_global_cache_tags =
       tmpl::list<elliptic::Tags::Background<Background>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 }  // namespace

--- a/tests/Unit/Elliptic/Actions/Test_InitializeFields.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeFields.cpp
@@ -29,6 +29,7 @@
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/CharmPupable.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/InitialGuess.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
@@ -75,14 +76,13 @@ struct ElementArray {
   using const_global_cache_tags = tmpl::list<domain::Tags::Domain<1>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          Parallel::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<
                          tmpl::list<domain::Tags::InitialRefinementLevels<1>,
                                     domain::Tags::InitialExtents<1>>>,
                      Actions::SetupDataBox,
                      elliptic::dg::Actions::InitializeDomain<1>>>,
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Testing,
+      Parallel::PhaseActions<Parallel::Phase::Testing,
                              tmpl::list<elliptic::Actions::InitializeFields<
                                  typename Metavariables::system,
                                  elliptic::Tags::InitialGuess<
@@ -94,7 +94,7 @@ struct Metavariables {
   using component_list = tmpl::list<ElementArray<Metavariables>>;
   using const_global_cache_tags = tmpl::list<
       elliptic::Tags::InitialGuess<elliptic::analytic_data::InitialGuess>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes =

--- a/tests/Unit/Elliptic/Actions/Test_InitializeFixedSources.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeFixedSources.cpp
@@ -25,6 +25,7 @@
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/CharmPupable.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/Background.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
@@ -69,20 +70,20 @@ struct ElementArray {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementId<1>;
   using const_global_cache_tags = tmpl::list<domain::Tags::Domain<1>>;
-  using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<ActionTesting::InitializeDataBox<
-                         tmpl::list<domain::Tags::InitialRefinementLevels<1>,
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<
+                     Parallel::Phase::Initialization,
+                     tmpl::list<ActionTesting::InitializeDataBox<tmpl::list<
+                                    domain::Tags::InitialRefinementLevels<1>,
                                     domain::Tags::InitialExtents<1>>>,
-                     Actions::SetupDataBox,
-                     elliptic::dg::Actions::InitializeDomain<1>>>,
-      Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Testing,
-          tmpl::list<elliptic::Actions::InitializeFixedSources<
-              typename Metavariables::system,
-              elliptic::Tags::Background<
-                  elliptic::analytic_data::Background>>>>>;
+                                Actions::SetupDataBox,
+                                elliptic::dg::Actions::InitializeDomain<1>>>,
+                 Parallel::PhaseActions<
+                     Parallel::Phase::Testing,
+                     tmpl::list<elliptic::Actions::InitializeFixedSources<
+                         typename Metavariables::system,
+                         elliptic::Tags::Background<
+                             elliptic::analytic_data::Background>>>>>;
 };
 
 struct Metavariables {
@@ -90,7 +91,7 @@ struct Metavariables {
   using component_list = tmpl::list<ElementArray<Metavariables>>;
   using const_global_cache_tags = tmpl::list<
       elliptic::Tags::Background<elliptic::analytic_data::Background>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes =

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Actions/Test_InitializeDomain.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Actions/Test_InitializeDomain.cpp
@@ -28,6 +28,7 @@
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -41,13 +42,13 @@ struct ElementArray {
   using const_global_cache_tags = tmpl::list<domain::Tags::Domain<Dim>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          Parallel::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<
               tmpl::list<domain::Tags::InitialRefinementLevels<Dim>,
                          domain::Tags::InitialExtents<Dim>>>>>,
 
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          Parallel::Phase::Testing,
           tmpl::list<Actions::SetupDataBox,
                      ::elliptic::dg::Actions::InitializeDomain<Dim>>>>;
 };
@@ -55,7 +56,7 @@ struct ElementArray {
 template <size_t Dim>
 struct Metavariables {
   using component_list = tmpl::list<ElementArray<Dim, Metavariables>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 }  // namespace

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
@@ -54,6 +54,7 @@
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/CharmPupable.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "ParallelAlgorithms/Actions/SetData.hpp"
@@ -380,7 +381,7 @@ struct ElementArray {
       tmpl::list<domain::Tags::Domain<Dim>, background_tag>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          Parallel::Phase::Initialization,
           tmpl::list<
               ActionTesting::InitializeDataBox<
                   tmpl::list<domain::Tags::InitialRefinementLevels<Dim>,
@@ -401,7 +402,7 @@ struct ElementArray {
                                             typename fields_tag::tags_list>,
               ExtraInitActions, Parallel::Actions::TerminatePhase>>,
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          Parallel::Phase::Testing,
           tmpl::list<apply_full_dg_operator_actions,
                      // Break here so it's easy to apply the subdomain operator
                      // only on a particular element
@@ -420,7 +421,7 @@ struct Metavariables {
       ElementArray<Metavariables, System, SubdomainOperator, ExtraInitActions>;
   using component_list = tmpl::list<element_array>;
   using const_global_cache_tags = tmpl::list<>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes = tmpl::map<

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
@@ -36,6 +36,7 @@
 #include "Parallel/Actions/Goto.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "ParallelAlgorithms/Actions/SetData.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
@@ -116,7 +117,7 @@ struct ElementArray {
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          Parallel::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<
                          tmpl::list<domain::Tags::InitialRefinementLevels<Dim>,
                                     domain::Tags::InitialExtents<Dim>>>,
@@ -132,7 +133,7 @@ struct ElementArray {
                      ::elliptic::dg::Actions::initialize_operator<System>,
                      Parallel::Actions::TerminatePhase>>,
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          Parallel::Phase::Testing,
           tmpl::list<::elliptic::dg::Actions::
                          ImposeInhomogeneousBoundaryConditionsOnSource<
                              System, fixed_sources_tag>,
@@ -150,7 +151,7 @@ struct Metavariables {
   using component_list = tmpl::list<element_array>;
   using const_global_cache_tags =
       tmpl::list<::Tags::AnalyticSolution<AnalyticSolution>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes = tmpl::map<

--- a/tests/Unit/Evolution/Actions/Test_RunEventsAndDenseTriggers.cpp
+++ b/tests/Unit/Evolution/Actions/Test_RunEventsAndDenseTriggers.cpp
@@ -38,6 +38,7 @@
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/CharmPupable.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
@@ -277,7 +278,7 @@ struct Component {
       tmpl::list<evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<1>>;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Testing,
+      Parallel::Phase::Testing,
       tmpl::list<
           evolution::Actions::RunEventsAndDenseTriggers<prim_from_con>>>>;
 };
@@ -296,7 +297,7 @@ struct Metavariables {
         tmpl::map<tmpl::pair<DenseTrigger, tmpl::list<TestTrigger>>,
                   tmpl::pair<Event, tmpl::list<TestEvent>>>;
   };
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 template <typename Metavariables>

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_Initialize.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_Initialize.cpp
@@ -47,6 +47,7 @@
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/GlobalCache.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
@@ -103,7 +104,7 @@ struct Component {
                  Tags::Variables<tmpl::list<::Tags::dt<Var1>>>>;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<
           ActionTesting::InitializeDataBox<initial_tags>,
           ::Actions::SetupDataBox,
@@ -122,7 +123,7 @@ struct Metavariables {
   using analytic_variables_tags = typename system::variables_tag::tags_list;
   using const_global_cache_tags =
       tmpl::list<Tags::AnalyticSolution<analytic_solution>>;
-  enum class Phase { Initialization, Exit };
+  using Phase = Parallel::Phase;
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/) {}
 

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_ReconstructionCommunication.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_ReconstructionCommunication.cpp
@@ -40,6 +40,7 @@
 #include "Evolution/DgSubcell/Tags/TciGridHistory.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
@@ -78,7 +79,7 @@ struct component {
       evolution::dg::Tags::MortarNextTemporalId<Dim>>;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<
           ActionTesting::InitializeDataBox<initial_tags>,
           evolution::dg::subcell::Actions::SendDataForReconstruction<
@@ -93,7 +94,7 @@ struct Metavariables {
   using component_list = tmpl::list<component<Dim, Metavariables>>;
   using system = System<Dim>;
   using const_global_cache_tags = tmpl::list<>;
-  enum class Phase { Initialization, Exit };
+  using Phase = Parallel::Phase;
 
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static bool ghost_zone_size_invoked;

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_SelectNumericalMethod.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_SelectNumericalMethod.cpp
@@ -11,6 +11,7 @@
 #include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "Parallel/Actions/Goto.hpp"
+#include "Parallel/Phase.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace {
@@ -29,7 +30,7 @@ struct component {
   using initial_tags = tmpl::list<evolution::dg::subcell::Tags::ActiveGrid>;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<
           ActionTesting::InitializeDataBox<initial_tags>,
           evolution::dg::subcell::Actions::SelectNumericalMethod,
@@ -42,7 +43,7 @@ struct component {
 
 struct Metavariables {
   using component_list = tmpl::list<component<Metavariables>>;
-  enum class Phase { Initialization, Exit };
+  using Phase = Parallel::Phase;
 };
 
 void test(const evolution::dg::subcell::ActiveGrid active_grid) {

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_TakeTimeStep.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_TakeTimeStep.cpp
@@ -37,6 +37,7 @@
 #include "Evolution/DiscontinuousGalerkin/MortarTags.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Time/Slab.hpp"
 #include "Time/Time.hpp"
@@ -66,7 +67,7 @@ struct component {
       tmpl::list<evolution::dg::subcell::Tags::LogicalCoordinatesCompute<Dim>>;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<
           ActionTesting::InitializeDataBox<initial_tags, initial_compute_tags>,
           evolution::dg::subcell::fd::Actions::TakeTimeStep<
@@ -78,7 +79,7 @@ struct Metavariables {
   static constexpr size_t volume_dim = Dim;
   using component_list = tmpl::list<component<Dim, Metavariables>>;
   using const_global_cache_tags = tmpl::list<>;
-  enum class Phase { Initialization, Exit };
+  using Phase = Parallel::Phase;
 
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static bool time_derivative_invoked;

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndRollback.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndRollback.cpp
@@ -40,6 +40,7 @@
 #include "Evolution/DgSubcell/Tags/TciGridHistory.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/History.hpp"
@@ -99,7 +100,7 @@ struct component {
           tmpl::list<>>>;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<ActionTesting::InitializeDataBox<initial_tags>,
                  evolution::dg::subcell::Actions::TciAndRollback<
                      typename Metavariables::TciOnDgGrid>,
@@ -118,7 +119,7 @@ struct Metavariables {
   using analytic_variables_tags = typename system::variables_tag::tags_list;
   using const_global_cache_tags =
       tmpl::list<evolution::dg::subcell::Tags::SubcellOptions>;
-  enum class Phase { Initialization, Exit };
+  using Phase = Parallel::Phase;
 
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static bool rdmp_fails;

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndSwitchToDg.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndSwitchToDg.cpp
@@ -41,6 +41,7 @@
 #include "Evolution/DgSubcell/Tags/TciGridHistory.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Time/History.hpp"
 #include "Time/Slab.hpp"
@@ -86,7 +87,7 @@ struct component {
       Tags::TimeStepper<TimeStepper>>;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<ActionTesting::InitializeDataBox<initial_tags>,
                  evolution::dg::subcell::Actions::TciAndSwitchToDg<
                      typename Metavariables::TciOnSubcellGrid>>>>;
@@ -100,7 +101,7 @@ struct Metavariables {
   using analytic_variables_tags = typename system::variables_tag::tags_list;
   using const_global_cache_tags =
       tmpl::list<evolution::dg::subcell::Tags::SubcellOptions>;
-  enum class Phase { Initialization, Exit };
+  using Phase = Parallel::Phase;
 
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static bool rdmp_fails;

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
@@ -33,6 +33,7 @@
 #include "NumericalAlgorithms/Spectral/Projection.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/CharmPupable.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
@@ -403,7 +404,7 @@ struct component {
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          Parallel::Phase::Initialization,
           tmpl::list<
               ActionTesting::InitializeDataBox<simple_tags, compute_tags>,
               ::Actions::SetupDataBox,
@@ -411,7 +412,7 @@ struct component {
                   Metavariables::volume_dim, typename Metavariables::system>,
               SetLocalMortarData>>,
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          Parallel::Phase::Testing,
           tmpl::list<tmpl::conditional_t<
               Metavariables::local_time_stepping,
               ::evolution::dg::Actions::ApplyLtsBoundaryCorrections<
@@ -430,7 +431,7 @@ struct Metavariables {
   using const_global_cache_tags = tmpl::list<domain::Tags::InitialExtents<Dim>>;
 
   using component_list = tmpl::list<component<Metavariables>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 template <typename Tag, typename Metavariables, size_t Dim>

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Initialization/Test_Mortars.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Initialization/Test_Mortars.cpp
@@ -32,6 +32,7 @@
 #include "NumericalAlgorithms/Spectral/Projection.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/Phase.hpp"
 #include "Time/Slab.hpp"
 #include "Time/Time.hpp"
 #include "Time/TimeStepId.hpp"
@@ -58,16 +59,14 @@ struct component {
   using compute_tags = tmpl::list<>;
 
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<
-              ActionTesting::InitializeDataBox<simple_tags, compute_tags>>>,
-      Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Testing,
-          tmpl::list<
-              Actions::SetupDataBox,
-              evolution::dg::Initialization::Mortars<
-                  Metavariables::volume_dim, typename Metavariables::system>>>>;
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
+                             tmpl::list<ActionTesting::InitializeDataBox<
+                                 simple_tags, compute_tags>>>,
+      Parallel::PhaseActions<Parallel::Phase::Testing,
+                             tmpl::list<Actions::SetupDataBox,
+                                        evolution::dg::Initialization::Mortars<
+                                            Metavariables::volume_dim,
+                                            typename Metavariables::system>>>>;
 };
 
 struct Var1 : db::SimpleTag {
@@ -89,7 +88,7 @@ struct Metavariables {
   };
 
   using component_list = tmpl::list<component<Metavariables>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 template <size_t Dim, typename MappedType>

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActions.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActions.cpp
@@ -37,6 +37,7 @@
 #include "NumericalAlgorithms/LinearOperators/MeanValue.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -112,14 +113,14 @@ struct component {
   using simple_tags = db::AddSimpleTags<TemporalId, domain::Tags::Mesh<Dim>,
                                         domain::Tags::Element<Dim>,
                                         domain::Tags::ElementMap<Dim>, Var>;
-  using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
-      Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Testing,
-          tmpl::list<Limiters::Actions::SendData<Metavariables>,
-                     Limiters::Actions::Limit<Metavariables>>>>;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<
+                     Parallel::Phase::Initialization,
+                     tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
+                 Parallel::PhaseActions<
+                     Parallel::Phase::Testing,
+                     tmpl::list<Limiters::Actions::SendData<Metavariables>,
+                                Limiters::Actions::Limit<Metavariables>>>>;
 };
 
 template <size_t Dim>
@@ -129,7 +130,7 @@ struct Metavariables {
   using system = System<Dim>;
   using temporal_id = TemporalId;
   static constexpr bool local_time_stepping = false;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 }  // namespace
 

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActionsWithMinmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActionsWithMinmod.cpp
@@ -36,6 +36,7 @@
 #include "Framework/ActionTesting.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -80,12 +81,11 @@ struct component {
           ::domain::Tags::Coordinates<Dim, Frame::ElementLogical>>,
       domain::Tags::SizeOfElementCompute<Dim>>;
   using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
+                             tmpl::list<ActionTesting::InitializeDataBox<
+                                 simple_tags, compute_tags>>>,
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<
-              ActionTesting::InitializeDataBox<simple_tags, compute_tags>>>,
-      Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          Parallel::Phase::Testing,
           tmpl::list<Limiters::Actions::SendData<Metavariables>,
                      Limiters::Actions::Limit<Metavariables>>>>;
 };
@@ -97,7 +97,7 @@ struct Metavariables {
   using system = System<Dim>;
   using temporal_id = TemporalId;
   static constexpr bool local_time_stepping = false;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 }  // namespace
 

--- a/tests/Unit/Evolution/Initialization/Test_ConservativeSystem.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_ConservativeSystem.cpp
@@ -18,6 +18,7 @@
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/Phase.hpp"
 #include "PointwiseFunctions/AnalyticData/Tags.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
@@ -62,7 +63,7 @@ struct component {
   using initial_tags = tmpl::list<domain::Tags::Mesh<Dim>>;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<ActionTesting::InitializeDataBox<initial_tags>,
                  Actions::SetupDataBox,
                  Initialization::Actions::ConservativeSystem<
@@ -76,7 +77,7 @@ struct Metavariables {
   using system = System<Dim, HasPrimitives>;
   using const_global_cache_tags =
       tmpl::list<Tags::AnalyticSolution<SystemAnalyticSolution>>;
-  enum class Phase { Initialization, Exit };
+  using Phase = Parallel::Phase;
 
   struct equation_of_state_tag : db::SimpleTag {
     using type = int;

--- a/tests/Unit/Evolution/Initialization/Test_DgDomain.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_DgDomain.cpp
@@ -30,6 +30,7 @@
 #include "Evolution/Initialization/DgDomain.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/Phase.hpp"
 #include "Utilities/CloneUniquePtrs.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
@@ -134,11 +135,11 @@ struct Component {
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          Parallel::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
 
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          Parallel::Phase::Testing,
           tmpl::list<::Actions::SetupDataBox,
                      evolution::dg::Initialization::Domain<dim>,
                      Actions::IncrementTime, Actions::IncrementTime>>>;
@@ -149,7 +150,7 @@ struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
   static constexpr size_t dim = Dim;
 
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 template <size_t Dim, bool TimeDependent>

--- a/tests/Unit/Evolution/Initialization/Test_NonconservativeSystem.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_NonconservativeSystem.cpp
@@ -15,6 +15,7 @@
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/Phase.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -41,7 +42,7 @@ struct component {
   using initial_tags = tmpl::list<domain::Tags::Mesh<Dim>>;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<ActionTesting::InitializeDataBox<initial_tags>,
                  Actions::SetupDataBox,
                  Initialization::Actions::NonconservativeSystem<
@@ -53,7 +54,7 @@ struct Metavariables {
   using component_list = tmpl::list<component<Dim, Metavariables>>;
   using system = System<Dim>;
   using const_global_cache_tag_list = tmpl::list<>;
-  enum class Phase { Initialization, Exit };
+  using Phase = Parallel::Phase;
 };
 
 template <size_t Dim>

--- a/tests/Unit/Evolution/Initialization/Test_SetVariables.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_SetVariables.cpp
@@ -27,6 +27,7 @@
 #include "Framework/ActionTesting.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
 #include "PointwiseFunctions/AnalyticData/Tags.hpp"
@@ -193,7 +194,7 @@ struct component {
                  Tags::Variables<tmpl::list<PrimVar>>>;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<ActionTesting::InitializeDataBox<initial_tags>,
                  evolution::Initialization::Actions::SetVariables<
                      domain::Tags::Coordinates<Dim, Frame::ElementLogical>>>>>;
@@ -257,7 +258,7 @@ struct MetavariablesAnalyticSolution {
   using temporal_id = TimeId;
   using const_global_cache_tags =
       tmpl::list<Tags::AnalyticSolution<analytic_solution>>;
-  enum class Phase { Initialization, Exit };
+  using Phase = Parallel::Phase;
 };
 
 template <size_t Dim, bool HasPrimitives>
@@ -306,7 +307,7 @@ struct MetavariablesAnalyticData {
                           typename system::variables_tag::tags_list>;
   using temporal_id = TimeId;
   using const_global_cache_tags = tmpl::list<Tags::AnalyticData<analytic_data>>;
-  enum class Phase { Initialization, Exit };
+  using Phase = Parallel::Phase;
 };
 
 template <size_t Dim, bool HasPrimitives>

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
@@ -29,6 +29,7 @@
 #include "NumericalAlgorithms/Spectral/SwshTags.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/Phase.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
 #include "Time/StepChoosers/Factory.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
@@ -64,10 +65,9 @@ struct mock_analytic_worldtube_boundary {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
 
-  using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Initialization,
-                             initialize_action_list>>;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
+                                        initialize_action_list>>;
 };
 
 template <typename Metavariables>
@@ -97,11 +97,10 @@ struct mock_characteristic_evolution {
   using array_index = size_t;
 
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Initialization,
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
                              initialize_action_list>,
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Evolve,
+          Parallel::Phase::Evolve,
           tmpl::list<Actions::RequestBoundaryData<
                          AnalyticWorldtubeBoundary<Metavariables>,
                          mock_characteristic_evolution<Metavariables>>,
@@ -163,7 +162,7 @@ struct test_metavariables {
   using component_list =
       tmpl::list<mock_analytic_worldtube_boundary<test_metavariables>,
                  mock_characteristic_evolution<test_metavariables>>;
-  enum class Phase { Initialization, Evolve, Exit };
+  using Phase = Parallel::Phase;
 };
 }  // namespace
 

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_CalculateScriInputs.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_CalculateScriInputs.cpp
@@ -29,6 +29,7 @@
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
 #include "NumericalAlgorithms/Spectral/SwshFiltering.hpp"
 #include "NumericalAlgorithms/Spectral/SwshTransform.hpp"
+#include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/Tags.hpp"
@@ -87,10 +88,10 @@ struct mock_characteristic_evolution {
   using local_precompute = PrecomputeCceDependencies<Tags::BoundaryValue, Tag>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          Parallel::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Evolve,
+          Parallel::Phase::Evolve,
           tmpl::list<tmpl::transform<
                          extra_pre_swsh_derivative_scri_tags,
                          tmpl::bind<::Actions::MutateApply,
@@ -105,7 +106,7 @@ struct mock_characteristic_evolution {
 struct metavariables {
   using component_list =
       tmpl::list<mock_characteristic_evolution<metavariables>>;
-  enum class Phase { Initialization, Evolve, Exit };
+  using Phase = Parallel::Phase;
 };
 }  // namespace
 

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
@@ -35,6 +35,7 @@
 #include "NumericalAlgorithms/Spectral/SwshTags.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
@@ -71,7 +72,7 @@ struct mock_observer_writer {
   using array_index = size_t;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>>;
 };
 
@@ -112,11 +113,10 @@ struct mock_characteristic_evolution {
 
   using simple_tags = tmpl::list<>;
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Initialization,
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
                              initialize_action_list>,
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Evolve,
+          Parallel::Phase::Evolve,
           tmpl::list<Actions::CalculateIntegrandInputsForTag<Tags::BondiBeta>,
                      Actions::PrecomputeGlobalCceDependencies>>>;
   using const_global_cache_tags =
@@ -180,7 +180,7 @@ struct metavariables {
   using component_list =
       tmpl::list<mock_characteristic_evolution<metavariables>,
                  mock_observer_writer<metavariables>>;
-  enum class Phase { Initialization, Evolve, Exit };
+  using Phase = Parallel::Phase;
 };
 
 struct TestSendToEvolution {

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_FilterSwshVolumeQuantity.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_FilterSwshVolumeQuantity.cpp
@@ -25,6 +25,7 @@
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
 #include "NumericalAlgorithms/Spectral/SwshFiltering.hpp"
 #include "NumericalAlgorithms/Spectral/SwshTransform.hpp"
+#include "Parallel/Phase.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/Tags.hpp"
 #include "Utilities/Literals.hpp"
@@ -54,11 +55,10 @@ struct mock_characteristic_evolution {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Initialization,
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
                              initialize_action_list>,
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Evolve,
+          Parallel::Phase::Evolve,
           tmpl::list<Actions::FilterSwshVolumeQuantity<Tags::BondiJ>>>>;
   using const_global_cache_tags =
       Parallel::get_const_global_cache_tags_from_actions<
@@ -68,7 +68,7 @@ struct mock_characteristic_evolution {
 struct metavariables {
   using component_list =
       tmpl::list<mock_characteristic_evolution<metavariables>>;
-  enum class Phase { Initialization, Evolve, Exit };
+  using Phase = Parallel::Phase;
 };
 }  // namespace
 

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
@@ -40,6 +40,7 @@
 #include "NumericalAlgorithms/Spectral/SwshTags.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/Phase.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
 #include "Time/Slab.hpp"
@@ -77,10 +78,9 @@ struct mock_gh_worldtube_boundary : GhWorldtubeBoundary<Metavariables> {
   using array_index = size_t;
 
   using simple_tags = tmpl::list<>;
-  using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Initialization,
-                             initialize_action_list>>;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
+                                        initialize_action_list>>;
   using const_global_cache_tags =
       Parallel::get_const_global_cache_tags_from_actions<
           phase_dependent_action_list>;
@@ -113,11 +113,10 @@ struct mock_characteristic_evolution {
 
   using simple_tags = tmpl::list<>;
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Initialization,
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
                              initialize_action_list>,
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Evolve,
+          Parallel::Phase::Evolve,
           tmpl::list<Actions::RequestBoundaryData<
                          GhWorldtubeBoundary<Metavariables>,
                          mock_characteristic_evolution<Metavariables>>,
@@ -185,7 +184,7 @@ struct test_metavariables {
 
   static constexpr bool uses_partially_flat_cartesian_coordinates = false;
 
-  enum class Phase { Initialization, Evolve, Exit };
+  using Phase = Parallel::Phase;
 };
 }  // namespace
 

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
@@ -37,6 +37,7 @@
 #include "NumericalAlgorithms/Spectral/SwshTags.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/Phase.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
 #include "Time/StepChoosers/Factory.hpp"
@@ -69,7 +70,7 @@ struct mock_observer_writer {
   using array_index = size_t;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>>;
 };
 
@@ -90,12 +91,10 @@ struct mock_h5_worldtube_boundary {
   using array_index = size_t;
 
   using simple_tags = tmpl::list<>;
-  using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Initialization,
-                             initialize_action_list>,
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Evolve, tmpl::list<>>>;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
+                                        initialize_action_list>,
+                 Parallel::PhaseActions<Parallel::Phase::Evolve, tmpl::list<>>>;
   using const_global_cache_tags =
       Parallel::get_const_global_cache_tags_from_actions<
           phase_dependent_action_list>;
@@ -126,11 +125,10 @@ struct mock_characteristic_evolution {
 
   using simple_tags = tmpl::list<>;
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Initialization,
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
                              initialize_action_list>,
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Evolve,
+          Parallel::Phase::Evolve,
           tmpl::list<Actions::RequestBoundaryData<
                          H5WorldtubeBoundary<Metavariables>,
                          mock_characteristic_evolution<Metavariables>>,
@@ -199,7 +197,7 @@ struct test_metavariables {
 
   static constexpr bool uses_partially_flat_cartesian_coordinates = false;
 
-  enum class Phase { Initialization, Evolve, Exit };
+  using Phase = Parallel::Phase;
 };
 }  // namespace
 

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
@@ -29,6 +29,7 @@
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/GlobalCache.hpp"
+#include "Parallel/Phase.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
 #include "Time/StepChoosers/Factory.hpp"
@@ -74,12 +75,10 @@ struct mock_characteristic_evolution {
   using array_index = size_t;
 
   using simple_tags = tmpl::list<>;
-  using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Initialization,
-                             initialize_action_list>,
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Evolve, tmpl::list<>>>;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
+                                        initialize_action_list>,
+                 Parallel::PhaseActions<Parallel::Phase::Evolve, tmpl::list<>>>;
   using const_global_cache_tags =
       Parallel::get_const_global_cache_tags_from_actions<
           phase_dependent_action_list>;
@@ -143,7 +142,7 @@ struct metavariables {
 
   using component_list =
       tmpl::list<mock_characteristic_evolution<metavariables>>;
-  enum class Phase { Initialization, Evolve, Exit };
+  using Phase = Parallel::Phase;
 };
 }  // namespace
 

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeFirstHypersurface.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeFirstHypersurface.cpp
@@ -28,6 +28,7 @@
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
 #include "NumericalAlgorithms/Spectral/SwshFiltering.hpp"
 #include "NumericalAlgorithms/Spectral/SwshTransform.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
 #include "Time/Slab.hpp"
@@ -80,7 +81,7 @@ struct mock_observer_writer {
   using array_index = size_t;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>>;
 };
 
@@ -102,10 +103,10 @@ struct mock_characteristic_evolution {
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          Parallel::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          Parallel::Phase::Testing,
           tmpl::list<
               Actions::InitializeFirstHypersurface<
                   metavariables::uses_partially_flat_cartesian_coordinates>,
@@ -136,7 +137,7 @@ struct metavariables {
   static constexpr bool uses_partially_flat_cartesian_coordinates =
       EvolvePartiallyFlatCartesianCoordinates;
 
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 template <bool EvolvePartiallyFlatCartesianCoordinates>

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
@@ -27,6 +27,7 @@
 #include "Helpers/Evolution/Systems/Cce/BoundaryTestHelpers.hpp"
 #include "NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.hpp"
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "Parallel/Phase.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/TimeSteppers/RungeKutta3.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
@@ -52,12 +53,10 @@ struct mock_analytic_worldtube_boundary {
   using array_index = size_t;
 
   using simple_tags = tmpl::list<>;
-  using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Initialization,
-                             initialize_action_list>,
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Evolve, tmpl::list<>>>;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
+                                        initialize_action_list>,
+                 Parallel::PhaseActions<Parallel::Phase::Evolve, tmpl::list<>>>;
   using const_global_cache_tags =
       Parallel::get_const_global_cache_tags_from_actions<
     phase_dependent_action_list>;
@@ -69,7 +68,7 @@ struct H5Metavariables {
   using component_list =
       tmpl::list<mock_h5_worldtube_boundary<H5Metavariables>>;
   static constexpr bool uses_partially_flat_cartesian_coordinates = false;
-  enum class Phase { Initialization, Evolve, Exit };
+  using Phase = Parallel::Phase;
 };
 
 struct GhMetavariables {
@@ -78,7 +77,7 @@ struct GhMetavariables {
   using component_list =
       tmpl::list<mock_gh_worldtube_boundary<GhMetavariables>>;
   static constexpr bool uses_partially_flat_cartesian_coordinates = false;
-  enum class Phase { Initialization, Evolve, Exit };
+  using Phase = Parallel::Phase;
 };
 
 struct AnalyticMetavariables {
@@ -87,7 +86,7 @@ struct AnalyticMetavariables {
       Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>;
   using component_list =
       tmpl::list<mock_analytic_worldtube_boundary<AnalyticMetavariables>>;
-  enum class Phase { Initialization, Evolve, Exit };
+  using Phase = Parallel::Phase;
 };
 
 template <typename Generator>

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
@@ -23,6 +23,7 @@
 #include "NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
@@ -132,12 +133,10 @@ struct MockObserver {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
 
-  using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Initialization,
-                             initialize_action_list>,
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Evolve, tmpl::list<>>>;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
+                                        initialize_action_list>,
+                 Parallel::PhaseActions<Parallel::Phase::Evolve, tmpl::list<>>>;
 };
 
 template <typename Metavariables>
@@ -168,11 +167,10 @@ struct MockCharacteristicEvolution {
 
   using simple_tags = tmpl::list<>;
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Initialization,
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
                              initialize_action_list>,
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Evolve,
+          Parallel::Phase::Evolve,
           tmpl::list<
               SetRandomBoundaryValues,
               tmpl::transform<
@@ -250,7 +248,7 @@ struct test_metavariables {
   using component_list =
       tmpl::list<MockCharacteristicEvolution<test_metavariables>,
                  MockObserver<test_metavariables>>;
-  enum class Phase { Initialization, Evolve, Exit };
+  using Phase = Parallel::Phase;
 };
 }  // namespace
 

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InterpolateDuringSelfStart.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InterpolateDuringSelfStart.cpp
@@ -14,6 +14,7 @@
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/ParallelAlgorithms/Interpolation/InterpolateOnElementTestHelpers.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/ComputeTargetPoints.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
@@ -37,12 +38,11 @@ struct mock_element {
                  intrp::Tags::InterpPointInfo<Metavariables>>;
   using compute_tags = tmpl::list<>;
   using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
+                             tmpl::list<ActionTesting::InitializeDataBox<
+                                 simple_tags, compute_tags>>>,
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<
-              ActionTesting::InitializeDataBox<simple_tags, compute_tags>>>,
-      Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          Parallel::Phase::Testing,
           tmpl::list<Cce::Actions::InterpolateDuringSelfStart<
               typename Metavariables::InterpolationTargetA>>>>;
 };
@@ -134,7 +134,7 @@ struct MockMetavariables {
       tmpl::list<InterpolateOnElementTestHelpers::mock_interpolation_target<
                      MockMetavariables, InterpolationTargetA>,
                  mock_element<MockMetavariables>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 template <typename MockMetavariables>

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
@@ -25,6 +25,7 @@
 #include "NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/Phase.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
 #include "Time/StepChoosers/Factory.hpp"
@@ -90,11 +91,10 @@ struct mock_characteristic_evolution {
 
   using simple_tags = tmpl::list<>;
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Initialization,
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
                              initialize_action_list>,
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Evolve,
+          Parallel::Phase::Evolve,
           tmpl::list<Actions::RequestBoundaryData<
                          H5WorldtubeBoundary<Metavariables>,
                          mock_characteristic_evolution<Metavariables>>,
@@ -161,7 +161,7 @@ struct test_metavariables {
 
   static constexpr bool uses_partially_flat_cartesian_coordinates = false;
 
-  enum class Phase { Initialization, Evolve, Exit };
+  using Phase = Parallel::Phase;
 };
 }  // namespace
 

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
@@ -37,6 +37,7 @@
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/GlobalCache.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
 #include "Time/StepChoosers/Factory.hpp"
@@ -108,12 +109,10 @@ struct mock_observer {
   using chare_type = ActionTesting::MockGroupChare;
   using array_index = size_t;
 
-  using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Initialization,
-                             initialize_action_list>,
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Evolve, tmpl::list<>>>;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
+                                        initialize_action_list>,
+                 Parallel::PhaseActions<Parallel::Phase::Evolve, tmpl::list<>>>;
 };
 
 template <typename Metavariables>
@@ -140,11 +139,10 @@ struct mock_characteristic_evolution {
   using array_index = size_t;
 
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Initialization,
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
                              initialize_action_list>,
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Evolve,
+          Parallel::Phase::Evolve,
           tmpl::list<
               tmpl::transform<
                   typename Metavariables::scri_values_to_observe,
@@ -219,7 +217,7 @@ struct test_metavariables {
   using component_list =
       tmpl::list<mock_characteristic_evolution<test_metavariables>,
                  mock_observer<test_metavariables>>;
-  enum class Phase { Initialization, Evolve, Exit };
+  using Phase = Parallel::Phase;
 };
 }  // namespace
 

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_TimeManagement.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_TimeManagement.cpp
@@ -16,6 +16,7 @@
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Helpers/Evolution/Systems/Cce/BoundaryTestHelpers.hpp"
 #include "NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.hpp"
+#include "Parallel/Phase.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
@@ -46,11 +47,9 @@ struct mock_characteristic_evolution {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Initialization,
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
                              initialize_action_list>,
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Evolve,
+      Parallel::PhaseActions<Parallel::Phase::Evolve,
                              tmpl::list<Actions::ExitIfEndTimeReached>>>;
   using const_global_cache_tags =
       Parallel::get_const_global_cache_tags_from_actions<
@@ -60,7 +59,7 @@ struct mock_characteristic_evolution {
 struct metavariables {
   using component_list =
       tmpl::list<mock_characteristic_evolution<metavariables>>;
-  enum class Phase { Initialization, Evolve, Exit };
+  using Phase = Parallel::Phase;
 };
 }  // namespace
 

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_UpdateGauge.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_UpdateGauge.cpp
@@ -24,6 +24,7 @@
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
 #include "NumericalAlgorithms/Spectral/SwshFiltering.hpp"
 #include "NumericalAlgorithms/Spectral/SwshTransform.hpp"
+#include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -61,10 +62,10 @@ struct mock_characteristic_evolution {
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          Parallel::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Evolve,
+          Parallel::Phase::Evolve,
           tmpl::list<Actions::UpdateGauge<
               Metavariables::uses_partially_flat_cartesian_coordinates>>>>;
 };
@@ -73,7 +74,7 @@ struct metavariables {
   static constexpr bool uses_partially_flat_cartesian_coordinates = true;
   using component_list =
       tmpl::list<mock_characteristic_evolution<metavariables>>;
-  enum class Phase { Initialization, Evolve, Exit };
+  using Phase = Parallel::Phase;
 };
 }  // namespace
 

--- a/tests/Unit/Evolution/Systems/Cce/Test_AnalyticBoundaryDataManager.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_AnalyticBoundaryDataManager.cpp
@@ -22,6 +22,7 @@
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "IO/Observer/Initialize.hpp"
 #include "IO/Observer/Tags.hpp"
+#include "Parallel/Phase.hpp"
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
@@ -73,10 +74,8 @@ struct mock_observer_writer {
   using array_index = size_t;
   using const_global_cache_tags = tmpl::list<>;
 
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
-                                        tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
 };
 
 template <typename Metavariables>
@@ -88,17 +87,17 @@ struct mock_boundary {
   using array_index = size_t;
   using const_global_cache_tags = tmpl::list<Tags::ObservationLMax>;
 
-  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
-      tmpl::list<ActionTesting::InitializeDataBox<simple_tags,
-                                                  db::AddComputeTags<>>>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
+                             tmpl::list<ActionTesting::InitializeDataBox<
+                                 simple_tags, db::AddComputeTags<>>>>>;
 };
 
 struct metavariables {
   using component_list = tmpl::list<mock_observer_writer<metavariables>,
                                     mock_boundary<metavariables>>;
   using observed_reduction_data_tags = tmpl::list<>;
-  enum class Phase { Initialization, Exit };
+  using Phase = Parallel::Phase;
 };
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.AnalyticBoundaryDataManager",

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Actions/Test_NumericInitialData.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Actions/Test_NumericInitialData.cpp
@@ -29,6 +29,7 @@
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Options/Options.hpp"
+#include "Parallel/Phase.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.tpp"
 #include "Utilities/GetOutput.hpp"
@@ -52,14 +53,14 @@ struct MockElementArray {
   using array_index = ElementId<3>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          Parallel::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<tmpl::append<
               gh_system_vars,
               tmpl::list<domain::Tags::Mesh<3>,
                          domain::Tags::InverseJacobian<3, Frame::ElementLogical,
                                                        Frame::Inertial>>>>>>,
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          Parallel::Phase::Testing,
           tmpl::list<GeneralizedHarmonic::Actions::ReadNumericInitialData<
                          TestOptionGroup>,
                      GeneralizedHarmonic::Actions::SetNumericInitialData<
@@ -129,10 +130,8 @@ struct MockVolumeDataReader {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockNodeGroupChare;
   using array_index = size_t;
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
-                                        tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
   using replace_these_simple_actions =
       tmpl::list<importers::Actions::ReadAllVolumeDataAndDistribute<
           TestOptionGroup, detail::all_numeric_vars,
@@ -143,7 +142,7 @@ struct MockVolumeDataReader {
 struct Metavariables {
   using component_list = tmpl::list<MockElementArray<Metavariables>,
                                     MockVolumeDataReader<Metavariables>>;
-  enum class Phase { Initialization, Testing };
+  using Phase = Parallel::Phase;
 };
 
 }  // namespace

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_InitializeDampedHarmonic.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_InitializeDampedHarmonic.cpp
@@ -43,6 +43,7 @@
 #include "Options/Options.hpp"
 #include "Options/ParseOptions.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/GeneralRelativity/SpacetimeMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
@@ -90,7 +91,7 @@ struct component {
                            typename Metavariables::evolved_vars>>;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<
           ActionTesting::InitializeDataBox<initial_tags, initial_compute_tags>,
           Actions::SetupDataBox,
@@ -109,7 +110,7 @@ struct Metavariables {
   using variables_tag = Tags::Variables<evolved_vars>;
   static constexpr size_t volume_dim = Dim;
   using component_list = tmpl::list<component<Dim, Metavariables>>;
-  enum class Phase { Initialization, Exit };
+  using Phase = Parallel::Phase;
 };
 
 template <size_t Dim, bool UseRollon>

--- a/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/Test_Actions.cpp
+++ b/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/Test_Actions.cpp
@@ -15,6 +15,7 @@
 #include "Evolution/Systems/RadiationTransport/M1Grey/Tags.hpp"  // IWYU pragma: keep
 #include "Evolution/Systems/RadiationTransport/Tags.hpp"  // IWYU pragma: keep
 #include "Framework/ActionTesting.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
 #include "Utilities/Gsl.hpp"
@@ -36,22 +37,22 @@ struct mock_component {
   using simple_tags = db::AddSimpleTags<tmpl::flatten<
       tmpl::list<typename Closure::return_tags, typename Closure::argument_tags,
                  domain::Tags::Coordinates<3, Frame::Inertial>>>>;
-  using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
-      Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Testing,
-          tmpl::list<Actions::MutateApply<
-              typename RadiationTransport::M1Grey::ComputeM1Closure<
-                  typename metavariables::neutrino_species>>>>>;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<
+                     Parallel::Phase::Initialization,
+                     tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
+                 Parallel::PhaseActions<
+                     Parallel::Phase::Testing,
+                     tmpl::list<Actions::MutateApply<
+                         typename RadiationTransport::M1Grey::ComputeM1Closure<
+                             typename metavariables::neutrino_species>>>>>;
 };
 
 struct Metavariables {
   using component_list = tmpl::list<mock_component<Metavariables>>;
   using neutrino_species = tmpl::list<neutrinos::ElectronNeutrinos<1>,
                                       neutrinos::HeavyLeptonNeutrinos<0>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 }  // namespace
 

--- a/tests/Unit/Evolution/VariableFixing/Test_Actions.cpp
+++ b/tests/Unit/Evolution/VariableFixing/Test_Actions.cpp
@@ -16,6 +16,7 @@
 #include "Framework/ActionTesting.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/Hydro/Tags.hpp"      // IWYU pragma: keep
 #include "Utilities/Gsl.hpp"
@@ -38,17 +39,16 @@ struct mock_component {
                                  domain::Tags::Coordinates<3, Frame::Inertial>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          Parallel::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Testing,
+      Parallel::PhaseActions<Parallel::Phase::Testing,
                              tmpl::list<VariableFixing::Actions::FixVariables<
                                  VariableFixing::RadiallyFallingFloor<3>>>>>;
 };
 
 struct Metavariables {
   using component_list = tmpl::list<mock_component<Metavariables>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 struct SomeType {};

--- a/tests/Unit/Framework/MockDistributedObject.hpp
+++ b/tests/Unit/Framework/MockDistributedObject.hpp
@@ -344,8 +344,6 @@ class MockDistributedObject {
 
   using parallel_component = Component;
 
-  using PhaseType = Parallel::Phase;
-
   using all_cache_tags = Parallel::get_const_global_cache_tags<metavariables>;
   using initialization_tags =
       typename detail::get_initialization_tags_from_component<Component>::type;
@@ -401,13 +399,13 @@ class MockDistributedObject {
         std::forward<Options>(opts)...);
   }
 
-  void set_phase(PhaseType phase) {
+  void set_phase(Parallel::Phase phase) {
     phase_ = phase;
     algorithm_step_ = 0;
     terminate_ = number_of_actions_in_phase(phase) == 0;
     halt_algorithm_until_next_phase_ = false;
   }
-  PhaseType get_phase() const { return phase_; }
+  Parallel::Phase get_phase() const { return phase_; }
 
   void set_terminate(bool t) { terminate_ = t; }
   bool get_terminate() const { return terminate_; }
@@ -416,7 +414,7 @@ class MockDistributedObject {
   // no effect.
   void perform_algorithm() {}
 
-  size_t number_of_actions_in_phase(const PhaseType phase) const {
+  size_t number_of_actions_in_phase(const Parallel::Phase phase) const {
     size_t number_of_actions = 0;
     tmpl::for_each<phase_dependent_action_lists>(
         [&number_of_actions, phase](auto pdal_v) {
@@ -876,7 +874,7 @@ class MockDistributedObject {
   // The next action we should execute.
   size_t algorithm_step_ = 0;
   bool performing_action_ = false;
-  PhaseType phase_{Parallel::Phase::Initialization};
+  Parallel::Phase phase_{Parallel::Phase::Initialization};
 
   size_t mock_node_{0};
   size_t mock_local_core_{0};
@@ -922,7 +920,7 @@ bool MockDistributedObject<Component>::next_action_if_ready() {
   const auto invoke_for_phase =
       [this, &found_matching_phase, &was_ready](auto phase_dep_v) {
         using PhaseDep = typename decltype(phase_dep_v)::type;
-        constexpr PhaseType phase = PhaseDep::phase;
+        constexpr Parallel::Phase phase = PhaseDep::phase;
         using actions_list = typename PhaseDep::action_list;
         if (phase_ == phase) {
           found_matching_phase = true;

--- a/tests/Unit/Framework/MockDistributedObject.hpp
+++ b/tests/Unit/Framework/MockDistributedObject.hpp
@@ -24,6 +24,7 @@
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/NodeLock.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/SimpleActionVisitation.hpp"
 #include "Parallel/Tags/Metavariables.hpp"
@@ -343,8 +344,7 @@ class MockDistributedObject {
 
   using parallel_component = Component;
 
-  using PhaseType =
-      typename tmpl::front<phase_dependent_action_lists>::phase_type;
+  using PhaseType = Parallel::Phase;
 
   using all_cache_tags = Parallel::get_const_global_cache_tags<metavariables>;
   using initialization_tags =
@@ -876,7 +876,7 @@ class MockDistributedObject {
   // The next action we should execute.
   size_t algorithm_step_ = 0;
   bool performing_action_ = false;
-  PhaseType phase_{};
+  PhaseType phase_{Parallel::Phase::Initialization};
 
   size_t mock_node_{0};
   size_t mock_local_core_{0};
@@ -932,8 +932,9 @@ bool MockDistributedObject<Component>::next_action_if_ready() {
       };
   tmpl::for_each<phase_dependent_action_lists>(invoke_for_phase);
   if (not found_matching_phase) {
-    ERROR("Could not find any actions in the current phase for the component '"
-          << pretty_type::name<Component>() << "'.");
+    ERROR("Could not find any actions in the current phase ("
+          << phase_ << ") for the component '" << pretty_type::name<Component>()
+          << "'.");
   }
   return was_ready;
 }

--- a/tests/Unit/Framework/Tests/Test_ActionTesting.cpp
+++ b/tests/Unit/Framework/Tests/Test_ActionTesting.cpp
@@ -16,6 +16,7 @@
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Local.hpp"
 #include "Parallel/NodeLock.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "Parallel/Serialize.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
@@ -74,12 +75,10 @@ struct component_for_simple_action_mock {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Initialization,
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
                              tmpl::list<ActionTesting::InitializeDataBox<
                                  db::AddSimpleTags<ValueTag, PassedToB>>>>,
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Testing, tmpl::list<>>>;
+      Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
 
   // [simple action replace]
   using replace_these_simple_actions =
@@ -196,7 +195,7 @@ struct SimpleActionMockMetavariables {
   using component_list = tmpl::list<
       component_for_simple_action_mock<SimpleActionMockMetavariables>>;
 
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 struct MockMetavariablesWithGlobalCacheTags {
@@ -206,7 +205,7 @@ struct MockMetavariablesWithGlobalCacheTags {
   using const_global_cache_tags = tmpl::list<ValueTag, PassedToB>;
   // [const global cache metavars]
 
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 void test_mock_runtime_system_constructors() {
@@ -347,16 +346,14 @@ struct Component {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
 
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Testing,
-                                        tmpl::list<Action0>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<Action0>>>;
 };
 
 struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
 
-  enum class Phase { Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 SPECTRE_TEST_CASE("Unit.ActionTesting.IsRetrievable", "[Unit]") {
@@ -418,15 +415,14 @@ struct Component {
   using array_index = int;
 
   using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Testing,
+      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Testing,
                                         tmpl::list<Actions::SendValue>>>;
 };
 
 struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
 
-  enum class Phase { Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 SPECTRE_TEST_CASE("Unit.ActionTesting.GetInboxTags", "[Unit]") {
@@ -472,8 +468,7 @@ struct ComponentA {
   using array_index = size_t;
 
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Testing, tmpl::list<>>>;
+      Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
 };
 
 template <typename Metavariables>
@@ -489,13 +484,10 @@ struct ComponentBMock {
   using component_being_mocked = ComponentB<Metavariables>;
 
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<
-              ActionTesting::InitializeDataBox<db::AddSimpleTags<ValueTag>>>>,
-
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Testing, tmpl::list<>>>;
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
+                             tmpl::list<ActionTesting::InitializeDataBox<
+                                 db::AddSimpleTags<ValueTag>>>>,
+      Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
 };
 // [mock component b]
 
@@ -528,7 +520,7 @@ struct Metavariables {
   using component_list =
       tmpl::list<ComponentA<Metavariables>, ComponentBMock<Metavariables>>;
 
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 SPECTRE_TEST_CASE("Unit.ActionTesting.MockComponent", "[Unit]") {
@@ -576,12 +568,10 @@ struct ComponentA {
   using array_index = size_t;
 
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Initialization,
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
                              tmpl::list<ActionTesting::InitializeDataBox<
                                  db::AddSimpleTags<ValueTag, ValueTagSizeT>>>>,
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Testing, tmpl::list<>>>;
+      Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
 };
 
 struct MyProc {
@@ -702,7 +692,7 @@ struct ActionSetValueTo {
 struct MetavariablesOneComponent {
   using component_list = tmpl::list<ComponentA<MetavariablesOneComponent>>;
 
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 void test_parallel_info_functions() {
@@ -950,19 +940,17 @@ struct GroupComponent {
   using array_index = size_t;
 
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<
-              ActionTesting::InitializeDataBox<db::AddSimpleTags<ValueTag>>>>,
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Testing, tmpl::list<>>>;
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
+                             tmpl::list<ActionTesting::InitializeDataBox<
+                                 db::AddSimpleTags<ValueTag>>>>,
+      Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
 };
 
 struct MetavariablesGroupComponent {
   using component_list =
       tmpl::list<GroupComponent<MetavariablesGroupComponent>>;
 
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 void test_group_emplace() {
@@ -1029,19 +1017,17 @@ struct NodeGroupComponent {
   using array_index = size_t;
 
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<
-              ActionTesting::InitializeDataBox<db::AddSimpleTags<ValueTag>>>>,
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Testing, tmpl::list<>>>;
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
+                             tmpl::list<ActionTesting::InitializeDataBox<
+                                 db::AddSimpleTags<ValueTag>>>>,
+      Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
 };
 
 struct MetavariablesNodeGroupComponent {
   using component_list =
       tmpl::list<NodeGroupComponent<MetavariablesNodeGroupComponent>>;
 
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 void test_nodegroup_emplace() {
@@ -1098,7 +1084,7 @@ void test_nodegroup_emplace() {
 struct MetavariablesWithPup {
   using component_list = tmpl::list<NodeGroupComponent<MetavariablesWithPup>>;
 
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 
   void pup(PUP::er& /*p*/) {}
 };
@@ -1153,10 +1139,8 @@ struct Component {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
 
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
-                                        tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
 };
 
 // This Action does nothing other than set a bool so that we can
@@ -1179,7 +1163,7 @@ struct Metavariables {
   using mutable_global_cache_tags = tmpl::list<CacheTag>;
   // [mutable global cache metavars]
 
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 SPECTRE_TEST_CASE("Unit.ActionTesting.MutableGlobalCache", "[Unit]") {

--- a/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
+++ b/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
@@ -47,6 +47,7 @@
 #include "Parallel/CreateFromOptions.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/TMPL.hpp"
@@ -81,7 +82,7 @@ struct MockControlComponent {
   using simple_tags = init_simple_tags<ControlSystem>;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename metavariables::Phase, metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>>;
 };
 
@@ -101,10 +102,8 @@ struct MockElementComponent {
       tmpl::list<domain::Tags::FunctionsOfTimeInitialize,
                  control_system::Tags::MeasurementTimescales>;
 
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename metavariables::Phase,
-                                        metavariables::Phase::Initialization,
-                                        tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
 };
 
 template <typename Metavars>
@@ -121,15 +120,15 @@ struct MockObserverWriter {
   using chare_type = ActionTesting::MockNodeGroupChare;
   using array_index = int;
 
-  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavars::Phase, Metavars::Phase::Initialization, tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
 };
 
 template <size_t RotationDerivOrder, size_t ExpansionDerivOrder>
 struct MockMetavars {
   static constexpr size_t volume_dim = 3;
 
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 
   using metavars = MockMetavars<RotationDerivOrder, ExpansionDerivOrder>;
 

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -55,6 +55,7 @@
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Time/History.hpp"
@@ -823,14 +824,14 @@ struct component {
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          Parallel::Phase::Initialization,
           tmpl::flatten<tmpl::list<
               ActionTesting::InitializeDataBox<simple_tags, compute_tags>,
               ::Actions::SetupDataBox,
               ::evolution::dg::Initialization::Mortars<
                   Metavariables::volume_dim, typename Metavariables::system>>>>,
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          Parallel::Phase::Testing,
           tmpl::list<
               ::evolution::dg::Actions::ComputeTimeDerivative<Metavariables>>>>;
 };
@@ -858,7 +859,7 @@ struct Metavariables {
   };
 
   using component_list = tmpl::list<component<Metavariables>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 template <typename BoundaryCorrection, typename... PackagedFieldTags,

--- a/tests/Unit/Helpers/Evolution/Systems/Cce/Actions/WorldtubeBoundaryMocking.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Cce/Actions/WorldtubeBoundaryMocking.hpp
@@ -13,6 +13,7 @@
 #include "Framework/ActionTesting.hpp"
 #include "NumericalAlgorithms/Spectral/SwshTags.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -55,12 +56,10 @@ struct mock_h5_worldtube_boundary {
   using array_index = size_t;
 
   using simple_tags = tmpl::list<>;
-  using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Initialization,
-                             initialize_action_list>,
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Evolve, tmpl::list<>>>;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
+                                        initialize_action_list>,
+                 Parallel::PhaseActions<Parallel::Phase::Evolve, tmpl::list<>>>;
 };
 
 template <typename Metavariables>
@@ -87,12 +86,10 @@ struct mock_gh_worldtube_boundary {
   using array_index = size_t;
 
   using simple_tags = tmpl::list<>;
-  using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Initialization,
-                             initialize_action_list>,
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Evolve, tmpl::list<>>>;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
+                                        initialize_action_list>,
+                 Parallel::PhaseActions<Parallel::Phase::Evolve, tmpl::list<>>>;
   using const_global_cache_tags =
       Parallel::get_const_global_cache_tags_from_actions<
     phase_dependent_action_list>;

--- a/tests/Unit/Helpers/IO/Observers/MockWriteReductionDataRow.hpp
+++ b/tests/Unit/Helpers/IO/Observers/MockWriteReductionDataRow.hpp
@@ -10,6 +10,7 @@
 #include "IO/Observer/ObserverComponent.hpp"
 #include "IO/Observer/ReductionActions.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
@@ -94,10 +95,10 @@ struct MockObserverWriter {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockNodeGroupChare;
   using array_index = int;
-  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
-      tmpl::list<
-          ActionTesting::InitializeDataBox<tmpl::list<MockReductionFileTag>>>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
+                             tmpl::list<ActionTesting::InitializeDataBox<
+                                 tmpl::list<MockReductionFileTag>>>>>;
   using component_being_mocked = ::observers::ObserverWriter<Metavariables>;
 
   using replace_these_threaded_actions =

--- a/tests/Unit/Helpers/IO/Observers/ObserverHelpers.hpp
+++ b/tests/Unit/Helpers/IO/Observers/ObserverHelpers.hpp
@@ -16,6 +16,7 @@
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/ArrayIndex.hpp"
+#include "Parallel/Phase.hpp"
 #include "Utilities/Functional.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -48,9 +49,9 @@ struct element_component {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIdType;
 
-  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase,
-      Metavariables::Phase::RegisterWithObservers, RegistrationActionsList>>;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<Parallel::Phase::RegisterWithObserver,
+                                        RegistrationActionsList>>;
 };
 
 template <typename Metavariables>
@@ -66,7 +67,7 @@ struct observer_component {
       typename observers::Actions::Initialize<Metavariables>::compute_tags;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<Actions::SetupDataBox,
                  observers::Actions::Initialize<Metavariables>>>>;
 };
@@ -86,7 +87,7 @@ struct observer_writer_component {
       Metavariables>::compute_tags;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<Actions::SetupDataBox,
                  observers::Actions::InitializeWriter<Metavariables>>>>;
 };
@@ -128,6 +129,6 @@ struct Metavariables {
                  reduction_data_from_ds_and_vs>>;
   /// [make_reduction_data_tags]
 
-  enum class Phase { Initialization, RegisterWithObservers, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 }  // namespace TestObservers_detail

--- a/tests/Unit/Helpers/ParallelAlgorithms/Events/ObserveFields.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Events/ObserveFields.hpp
@@ -26,6 +26,7 @@
 #include "IO/Observer/ObserverComponent.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
@@ -100,10 +101,8 @@ struct ElementComponent {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementId<Metavariables::system::volume_dim>;
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
-                                        tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
 };
 
 template <typename Metavariables>
@@ -116,10 +115,8 @@ struct MockObserverComponent {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockGroupChare;
   using array_index = int;
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
-                                        tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
 };
 
 template <typename System, bool HasAnalyticSolution>
@@ -137,7 +134,7 @@ struct Metavariables {
     using factory_classes =
         tmpl::map<tmpl::pair<Event, tmpl::list<typename system::ObserveEvent>>>;
   };
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 // Helper tags

--- a/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolateOnElementTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolateOnElementTestHelpers.hpp
@@ -23,6 +23,7 @@
 #include "Framework/MockRuntimeSystemFreeFunctions.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InterpolationTargetVarsFromElement.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolationTarget.hpp"
@@ -176,7 +177,7 @@ struct mock_interpolation_target {
       intrp::InterpolationTarget<Metavariables, InterpolationTargetTag>;
   using simple_tags = tmpl::list<Tags::TestTargetPoints>;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>>;
   using replace_these_simple_actions =
       tmpl::list<intrp::Actions::InterpolationTargetVarsFromElement<

--- a/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
@@ -16,6 +16,7 @@
 #include "Framework/ActionTesting.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InitializeInterpolationTarget.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InitializeInterpolator.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/SendPointsToInterpolator.hpp"
@@ -80,12 +81,11 @@ struct mock_interpolation_target {
       tmpl::list<domain::Tags::Domain<Metavariables::volume_dim>>>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          Parallel::Phase::Initialization,
           tmpl::list<Actions::SetupDataBox,
                      intrp::Actions::InitializeInterpolationTarget<
                          Metavariables, InterpolationTargetTag>>>,
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Testing, tmpl::list<>>>;
+      Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
 };
 
 template <typename InterpolationTargetTag>
@@ -132,7 +132,7 @@ struct mock_interpolator {
   using array_index = size_t;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          Parallel::Phase::Initialization,
           tmpl::list<
               Actions::SetupDataBox,
               intrp::Actions::InitializeInterpolator<
@@ -140,8 +140,7 @@ struct mock_interpolator {
                       Metavariables, typename Metavariables::
                                          InterpolationTargetA::temporal_id>,
                   intrp::Tags::InterpolatedVarsHolders<Metavariables>>>>,
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Testing, tmpl::list<>>>;
+      Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
 
   using component_being_mocked = intrp::Interpolator<Metavariables>;
   using replace_these_simple_actions = tmpl::list<intrp::Actions::ReceivePoints<

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
@@ -41,6 +41,7 @@
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Main.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/Reduction.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
@@ -353,19 +354,14 @@ using test_actions =
 template <typename Metavariables>
 using ElementArray = elliptic::DgElementArray<
     Metavariables,
-    tmpl::list<
-        Parallel::PhaseActions<typename Metavariables::Phase,
-                               Metavariables::Phase::Initialization,
-                               initialization_actions<Metavariables>>,
-        Parallel::PhaseActions<typename Metavariables::Phase,
-                               Metavariables::Phase::RegisterWithObserver,
-                               register_actions<Metavariables>>,
-        Parallel::PhaseActions<typename Metavariables::Phase,
-                               Metavariables::Phase::PerformLinearSolve,
-                               solve_actions<Metavariables>>,
-        Parallel::PhaseActions<typename Metavariables::Phase,
-                               Metavariables::Phase::TestResult,
-                               test_actions<Metavariables>>>>;
+    tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
+                                      initialization_actions<Metavariables>>,
+               Parallel::PhaseActions<Parallel::Phase::RegisterWithObserver,
+                                      register_actions<Metavariables>>,
+               Parallel::PhaseActions<Parallel::Phase::Solve,
+                                      solve_actions<Metavariables>>,
+               Parallel::PhaseActions<Parallel::Phase::Testing,
+                                      test_actions<Metavariables>>>>;
 
 template <typename Metavariables>
 using component_list =

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/ResidualMonitorActionsTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/ResidualMonitorActionsTestHelpers.hpp
@@ -12,6 +12,7 @@
 #include "Framework/ActionTesting.hpp"
 #include "IO/Observer/ObservationId.hpp"
 #include "IO/Observer/ReductionActions.hpp"
+#include "Parallel/Phase.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -109,7 +110,7 @@ struct MockObserverWriter {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<ActionTesting::InitializeDataBox<observer_writer_tags>>>>;
   using component_being_mocked = observers::ObserverWriter<Metavariables>;
 

--- a/tests/Unit/Helpers/Tests/IO/Observers/Test_MockWriteReductionDataRow.cpp
+++ b/tests/Unit/Helpers/Tests/IO/Observers/Test_MockWriteReductionDataRow.cpp
@@ -13,6 +13,7 @@
 #include "Helpers/IO/Observers/MockWriteReductionDataRow.hpp"
 #include "IO/Observer/ReductionActions.hpp"
 #include "Parallel/Invoke.hpp"
+#include "Parallel/Phase.hpp"
 #include "Utilities/Gsl.hpp"
 
 namespace TestHelpers::observers {
@@ -23,7 +24,7 @@ using mock_observer_writer = MockObserverWriter<TestMetavariables>;
 struct TestMetavariables {
   using component_list = tmpl::list<mock_observer_writer>;
 
-  enum class Phase { Initialization, Test, Exit };
+  using Phase = Parallel::Phase;
 };
 
 void run_test() {
@@ -37,8 +38,7 @@ void run_test() {
   REQUIRE(ActionTesting::tag_is_retrievable<mock_observer_writer,
                                             MockReductionFileTag>(runner, 0));
 
-  ActionTesting::set_phase(make_not_null(&runner),
-                           TestMetavariables::Phase::Test);
+  ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
 
   auto& cache = ActionTesting::cache<mock_observer_writer>(runner, 0);
 

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderActions.cpp
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderActions.cpp
@@ -30,6 +30,7 @@
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/ArrayIndex.hpp"
+#include "Parallel/Phase.hpp"
 #include "Utilities/FileSystem.hpp"
 #include "Utilities/MakeString.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -62,11 +63,11 @@ struct MockElementArray {
   using array_index = ElementIdType;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          Parallel::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<import_tags_list>,
                      importers::Actions::RegisterWithElementDataReader>>,
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          Parallel::Phase::Testing,
           tmpl::list<importers::Actions::ReadVolumeData<TestVolumeData,
                                                         import_tags_list>,
                      importers::Actions::ReceiveVolumeData<TestVolumeData,
@@ -80,8 +81,7 @@ struct MockVolumeDataReader {
   using chare_type = ActionTesting::MockNodeGroupChare;
   using array_index = size_t;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
-
+      Parallel::Phase::Initialization,
       tmpl::list<Actions::SetupDataBox,
                  importers::detail::InitializeElementDataReader>>>;
 };
@@ -89,7 +89,7 @@ struct MockVolumeDataReader {
 struct Metavariables {
   using component_list = tmpl::list<MockElementArray<Metavariables>,
                                     MockVolumeDataReader<Metavariables>>;
-  enum class Phase { Initialization, Testing };
+  using Phase = Parallel::Phase;
 };
 
 }  // namespace

--- a/tests/Unit/IO/Observers/Test_GetLockPointer.cpp
+++ b/tests/Unit/IO/Observers/Test_GetLockPointer.cpp
@@ -14,6 +14,7 @@
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Local.hpp"
 #include "Parallel/NodeLock.hpp"
+#include "Parallel/Phase.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -57,7 +58,7 @@ struct mock_observer_writer {
   using array_index = size_t;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>>;
 };
 
@@ -72,16 +73,14 @@ struct mock_array {
   using metavariables = Metavariables;
   using array_index = size_t;
 
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
-                                        tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
 };
 
 struct test_metavariables {
   using component_list = tmpl::list<mock_observer_writer<test_metavariables>,
                                     mock_array<test_metavariables>>;
-  enum class Phase { Initialization, Evolve, Exit };
+  using Phase = Parallel::Phase;
 };
 }  // namespace
 

--- a/tests/Unit/IO/Observers/Test_Initialize.cpp
+++ b/tests/Unit/IO/Observers/Test_Initialize.cpp
@@ -12,6 +12,7 @@
 #include "IO/Observer/Initialize.hpp"
 #include "IO/Observer/Tags.hpp"                   // IWYU pragma: keep
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -31,7 +32,7 @@ struct observer_component {
       typename observers::Actions::Initialize<Metavariables>::compute_tags;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<Actions::SetupDataBox,
                  observers::Actions::Initialize<Metavariables>>>>;
 };
@@ -40,7 +41,7 @@ struct Metavariables {
   using component_list = tmpl::list<observer_component<Metavariables>>;
   using observed_reduction_data_tags = tmpl::list<>;
 
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 SPECTRE_TEST_CASE("Unit.IO.Observers.Initialize", "[Unit][Observers]") {

--- a/tests/Unit/IO/Observers/Test_ReductionObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_ReductionObserver.cpp
@@ -115,7 +115,7 @@ void test_reduction_observer(const bool observe_per_core) {
         ActionTesting::LocalCoreId{get_local_core_id(id)}, id);
   }
   ActionTesting::set_phase(make_not_null(&runner),
-                           metavariables::Phase::RegisterWithObservers);
+                           metavariables::Phase::RegisterWithObserver);
 
   // Register elements
   for (const auto& id : element_ids) {

--- a/tests/Unit/IO/Observers/Test_RegisterElements.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterElements.cpp
@@ -58,7 +58,7 @@ void check_observer_registration() {
     ActionTesting::emplace_component<element_comp>(&runner, id);
   }
   ActionTesting::set_phase(make_not_null(&runner),
-                           metavariables::Phase::RegisterWithObservers);
+                           metavariables::Phase::RegisterWithObserver);
 
   // Check observer component
   CHECK(

--- a/tests/Unit/IO/Observers/Test_RegisterEvents.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterEvents.cpp
@@ -23,6 +23,7 @@
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/ArrayIndex.hpp"
 #include "Parallel/Invoke.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/EventsAndTriggers.hpp"
@@ -87,7 +88,7 @@ struct Component {
   using array_index = int;
   using const_global_cache_tags = tmpl::list<Tags::EventsAndTriggers>;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Testing,
+      Parallel::Phase::Testing,
       tmpl::list<observers::Actions::RegisterEventsWithObservers>>>;
 };
 
@@ -148,8 +149,7 @@ struct MockObserverComponent {
   using array_index = int;
   using const_global_cache_tags = tmpl::list<>;
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Testing, tmpl::list<>>>;
+      Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
 
   using component_being_mocked = observers::Observer<Metavariables>;
   using replace_these_simple_actions =
@@ -169,7 +169,7 @@ struct Metavariables {
         tmpl::map<tmpl::pair<Event, tmpl::list<SomeEvent>>,
                   tmpl::pair<Trigger, Triggers::logical_triggers>>;
   };
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 SPECTRE_TEST_CASE("Unit.IO.Observers.RegisterEvents", "[Unit][Observers]") {

--- a/tests/Unit/IO/Observers/Test_RegisterSingleton.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterSingleton.cpp
@@ -18,6 +18,7 @@
 #include "IO/Observer/TypeOfObservation.hpp"
 #include "Parallel/ArrayIndex.hpp"
 #include "Parallel/Invoke.hpp"
+#include "Parallel/Phase.hpp"
 
 namespace {
 struct RegistrationHelper {
@@ -39,7 +40,7 @@ struct Component {
   using array_index = int;
   using const_global_cache_tags = tmpl::list<>;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Testing,
+      Parallel::Phase::Testing,
       tmpl::list<observers::Actions::RegisterSingletonWithObserverWriter<
           RegistrationHelper>>>>;
 };
@@ -73,8 +74,7 @@ struct MockObserverWriterComponent {
   using array_index = int;
   using const_global_cache_tags = tmpl::list<>;
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Testing, tmpl::list<>>>;
+      Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
 
   using component_being_mocked = observers::ObserverWriter<Metavariables>;
   using replace_these_simple_actions =
@@ -86,7 +86,7 @@ struct MockObserverWriterComponent {
 struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>,
                                     MockObserverWriterComponent<Metavariables>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 SPECTRE_TEST_CASE("Unit.IO.Observers.RegisterSingleton", "[Unit][Observers]") {

--- a/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
@@ -195,7 +195,7 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.VolumeObserver", "[Unit][Observers]") {
     ActionTesting::emplace_component<element_comp>(&runner, id);
   }
   ActionTesting::set_phase(make_not_null(&runner),
-                           metavariables::Phase::RegisterWithObservers);
+                           metavariables::Phase::RegisterWithObserver);
 
   // Register elements
   for (const auto& id : element_ids) {

--- a/tests/Unit/IO/Observers/Test_WriteSimpleData.cpp
+++ b/tests/Unit/IO/Observers/Test_WriteSimpleData.cpp
@@ -26,6 +26,7 @@
 #include "IO/Observer/Tags.hpp"
 #include "IO/Observer/TypeOfObservation.hpp"
 #include "IO/Observer/WriteSimpleData.hpp"
+#include "Parallel/Phase.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/FileSystem.hpp"
 #include "Utilities/Gsl.hpp"
@@ -44,7 +45,7 @@ struct test_metavariables {
   using observed_reduction_data_tags = observers::make_reduction_data_tags<
       tmpl::list<helpers::reduction_data_from_doubles>>;
 
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 }  // namespace
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_SendGhWorldtubeData.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_SendGhWorldtubeData.cpp
@@ -15,6 +15,7 @@
 #include "Framework/ActionTesting.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/SendGhWorldtubeData.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/PostInterpolationCallback.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
@@ -74,7 +75,7 @@ struct mock_interpolation_target {
                      GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>>>,
                  ::Tags::Time>;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<ActionTesting::InitializeDataBox<simple_tags, tmpl::list<>>>>>;
 };
 
@@ -88,17 +89,15 @@ struct mock_gh_worldtube_boundary {
   using with_these_simple_actions = tmpl::list<test_receive_gh_data>;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
-                                        tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
 };
 
 struct test_metavariables {
   using component_list =
       tmpl::list<mock_gh_worldtube_boundary<test_metavariables>,
                  mock_interpolation_target<test_metavariables>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 SPECTRE_TEST_CASE(

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Filtering.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Filtering.cpp
@@ -24,6 +24,7 @@
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Requires.hpp"
@@ -64,11 +65,11 @@ struct Component {
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          Parallel::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
       // [action_list_example]
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          Parallel::Phase::Testing,
           tmpl::conditional_t<
               metavariables::filter_individually,
               tmpl::list<dg::Actions::Filter<Filters::Exponential<0>,
@@ -88,7 +89,7 @@ struct Metavariables {
   using system = System<Dim>;
   static constexpr bool local_time_stepping = true;
   using component_list = tmpl::list<Component<Metavariables>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 template <typename Metavariables,

--- a/tests/Unit/Parallel/Actions/Test_SetupDataBox.cpp
+++ b/tests/Unit/Parallel/Actions/Test_SetupDataBox.cpp
@@ -11,6 +11,7 @@
 #include "Framework/ActionTesting.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"  // IWYU pragma: keep
 #include "Parallel/Actions/TerminatePhase.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "Utilities/Gsl.hpp"
@@ -86,14 +87,14 @@ struct Component {
   using array_index = int;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<Actions::SetupDataBox, InitializationAction, MutateAction>>>;
 };
 
 struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
 
-  enum class Phase { Initialization, Exit };
+  using Phase = Parallel::Phase;
 };
 }  // namespace
 

--- a/tests/Unit/Parallel/Actions/Test_TerminatePhase.cpp
+++ b/tests/Unit/Parallel/Actions/Test_TerminatePhase.cpp
@@ -5,6 +5,7 @@
 
 #include "Framework/ActionTesting.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
+#include "Parallel/Phase.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace {
@@ -15,15 +16,14 @@ struct Component {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Testing,
-      tmpl::list<Parallel::Actions::TerminatePhase>>>;
+      Parallel::Phase::Testing, tmpl::list<Parallel::Actions::TerminatePhase>>>;
 };
 // [component]
 
 // [metavariables]
 struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 // [metavariables]
 }  // namespace

--- a/tests/Unit/Parallel/Test_AlgorithmBadBoxApply.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmBadBoxApply.cpp
@@ -12,6 +12,7 @@
 #include "Parallel/Local.hpp"
 #include "Parallel/Main.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/MemoryHelpers.hpp"
@@ -44,10 +45,8 @@ template <class Metavariables>
 struct Component {
   using chare_type = Parallel::Algorithms::Singleton;
   using metavariables = Metavariables;
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
-                                        tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
@@ -65,7 +64,7 @@ struct Component {
 struct TestMetavariables {
   using component_list = tmpl::list<Component<TestMetavariables>>;
 
-  enum class Phase { Initialization, Execute, Exit };
+  using Phase = Parallel::Phase;
 
   static constexpr Options::String help = "Executable for testing";
 

--- a/tests/Unit/Parallel/Test_AlgorithmLocalSyncAction.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmLocalSyncAction.cpp
@@ -24,6 +24,7 @@
 #include "Parallel/Main.hpp"
 #include "Parallel/NodeLock.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
@@ -189,8 +190,7 @@ struct NodegroupComponent {
   using metavariables = Metavariables;
 
   using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
+      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
                                         tmpl::list<InitializeNodegroup>>>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
@@ -211,7 +211,7 @@ struct ArrayComponent {
   using array_index = int;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Evolve,
+      Parallel::Phase::Evolve,
       tmpl::list<TestSyncActionIncrement, Parallel::Actions::TerminatePhase>>>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
@@ -245,11 +245,7 @@ struct TestMetavariables {
 
   static constexpr Options::String help = "";
 
-  enum class Phase {
-    Initialization,
-    Evolve,
-    Exit
-  };
+  using Phase = Parallel::Phase;
 
   template <typename... Tags>
   static Phase determine_next_phase(

--- a/tests/Unit/Parallel/Test_AlgorithmNestedApply1.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNestedApply1.cpp
@@ -12,6 +12,7 @@
 #include "Parallel/Local.hpp"
 #include "Parallel/Main.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/MemoryHelpers.hpp"
@@ -44,10 +45,8 @@ template <class Metavariables>
 struct Component {
   using chare_type = Parallel::Algorithms::Singleton;
   using metavariables = Metavariables;
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
-                                        tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
@@ -66,7 +65,7 @@ struct Component {
 struct TestMetavariables {
   using component_list = tmpl::list<Component<TestMetavariables>>;
 
-  enum class Phase { Initialization, Execute, Exit };
+  using Phase = Parallel::Phase;
 
   static constexpr Options::String help = "Executable for testing";
 

--- a/tests/Unit/Parallel/Test_AlgorithmNestedApply2.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNestedApply2.cpp
@@ -12,6 +12,7 @@
 #include "Parallel/Local.hpp"
 #include "Parallel/Main.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/MemoryHelpers.hpp"
@@ -48,10 +49,8 @@ template <class Metavariables>
 struct Component {
   using chare_type = Parallel::Algorithms::Singleton;
   using metavariables = Metavariables;
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
-                                        tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
@@ -70,7 +69,7 @@ struct Component {
 struct TestMetavariables {
   using component_list = tmpl::list<Component<TestMetavariables>>;
 
-  enum class Phase { Initialization, Execute, Exit };
+  using Phase = Parallel::Phase;
 
   static constexpr Options::String help = "Executable for testing";
 

--- a/tests/Unit/Parallel/Test_AlgorithmPhaseControl.yaml
+++ b/tests/Unit/Parallel/Test_AlgorithmPhaseControl.yaml
@@ -4,7 +4,7 @@
 # note that this is a vector of pairs, so has the peculiar '- -' for the
 # elements
 PhaseChangeAndTriggers:
-  - - TempPhaseATrigger:
-    - - VisitAndReturn(TempPhaseA)
-  - - TempPhaseBTrigger:
-    - - VisitAndReturn(TempPhaseB)
+  - - RegisterTrigger:
+    - - VisitAndReturn(Register)
+  - - SolveTrigger:
+    - - VisitAndReturn(Solve)

--- a/tests/Unit/Parallel/Test_GlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_GlobalCache.cpp
@@ -28,6 +28,7 @@
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Local.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
@@ -157,8 +158,7 @@ struct SingletonParallelComponent {
   using mutable_global_cache_tags = tmpl::list<weight, animal>;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Testing, tmpl::list<>>>;
+      Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 };
@@ -171,8 +171,7 @@ struct ArrayParallelComponent {
   using array_index = int;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Testing, tmpl::list<>>>;
+      Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 };
@@ -184,8 +183,7 @@ struct GroupParallelComponent {
   using mutable_global_cache_tags = tmpl::list<email>;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Testing, tmpl::list<>>>;
+      Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 };
@@ -197,8 +195,7 @@ struct NodegroupParallelComponent {
   using mutable_global_cache_tags = tmpl::list<animal>;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Testing, tmpl::list<>>>;
+      Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 };
@@ -209,7 +206,7 @@ struct TestMetavariables {
                  ArrayParallelComponent<TestMetavariables>,
                  GroupParallelComponent<TestMetavariables>,
                  NodegroupParallelComponent<TestMetavariables>>;
-  enum class Phase { Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 }  // namespace

--- a/tests/Unit/Parallel/Test_InboxInserters.cpp
+++ b/tests/Unit/Parallel/Test_InboxInserters.cpp
@@ -18,6 +18,7 @@
 #include "Parallel/InboxInserters.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
@@ -256,13 +257,12 @@ struct Component {
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          Parallel::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<
               db::AddSimpleTags<Tags::MapCounter, Tags::MemberInsertCounter,
                                 Tags::ValueCounter, Tags::PushbackCounter>>>>,
-
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          Parallel::Phase::Testing,
           tmpl::list<Actions::SendMap, Actions::ReceiveMap,
                      Actions::SendMemberInsert, Actions::ReceiveMemberInsert,
                      Actions::SendValue, Actions::ReceiveValue,
@@ -272,7 +272,7 @@ struct Component {
 struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
 
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 SPECTRE_TEST_CASE("Unit.Parallel.InboxInserters", "[Parallel][Unit]") {

--- a/tests/Unit/Parallel/Test_MemoryMonitor.cpp
+++ b/tests/Unit/Parallel/Test_MemoryMonitor.cpp
@@ -19,6 +19,7 @@
 #include "Parallel/Local.hpp"
 #include "Parallel/MemoryMonitor/MemoryMonitor.hpp"
 #include "Parallel/MemoryMonitor/Tags.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/Serialize.hpp"
 #include "Parallel/TypeTraits.hpp"
 #include "ParallelAlgorithms/Actions/MemoryMonitor/ContributeMemoryData.hpp"
@@ -44,7 +45,7 @@ struct MockMemoryMonitor {
   using metavariables = Metavariables;
   using simple_tags = tmpl::list<mem_monitor::Tags::MemoryHolder>;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>>;
 };
 
@@ -53,10 +54,8 @@ struct SingletonParallelComponent {
   using chare_type = ActionTesting::MockSingletonChare;
   using array_index = int;
   using metavariables = Metavariables;
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
-                                        tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
 };
 
 template <typename Metavariables>
@@ -64,10 +63,8 @@ struct GroupParallelComponent {
   using chare_type = ActionTesting::MockGroupChare;
   using array_index = int;
   using metavariables = Metavariables;
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
-                                        tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
 };
 
 template <typename Metavariables>
@@ -75,10 +72,8 @@ struct NodegroupParallelComponent {
   using chare_type = ActionTesting::MockNodeGroupChare;
   using array_index = int;
   using metavariables = Metavariables;
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
-                                        tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
 };
 
 template <typename Metavariables>
@@ -86,10 +81,8 @@ struct ArrayParallelComponent {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
   using metavariables = Metavariables;
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
-                                        tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
 };
 
 // This component deserves special mention. It is supposed to be playing the
@@ -107,10 +100,10 @@ struct FakeDgElementArray {
   using chare_type = ActionTesting::MockSingletonChare;
   using array_index = int;
   using metavariables = Metavariables;
-  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
-      tmpl::list<ActionTesting::InitializeDataBox<
-          tmpl::list<domain::Tags::Element<3>>>>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
+                             tmpl::list<ActionTesting::InitializeDataBox<
+                                 tmpl::list<domain::Tags::Element<3>>>>>>;
 };
 
 struct TestMetavariables {
@@ -122,7 +115,7 @@ struct TestMetavariables {
                  FakeDgElementArray<TestMetavariables>,
                  NodegroupParallelComponent<TestMetavariables>>;
 
-  enum class Phase { Initialization, Monitor, Exit };
+  using Phase = Parallel::Phase;
 
   void pup(PUP::er& /*p*/) {}
 };
@@ -149,7 +142,7 @@ struct TestMetavarsActions {
       ArrayParallelComponent<TestMetavarsActions>,
       NodegroupParallelComponent<TestMetavarsActions>>;
 
-  enum class Phase { Initialization, Monitor, Exit };
+  using Phase = Parallel::Phase;
 
   void pup(PUP::er& /*p*/) {}
 };
@@ -205,7 +198,7 @@ void setup_runner(
                                      ActionTesting::LocalCoreId{0}, {element});
   }
 
-  runner->set_phase(Metavariables::Phase::Monitor);
+  runner->set_phase(Metavariables::Phase::Testing);
 }
 
 template <typename Component, typename Metavariables>
@@ -500,7 +493,7 @@ struct BadArrayChareMetavariables {
   using component_list =
       tmpl::list<ArrayParallelComponent<BadArrayChareMetavariables>>;
 
-  enum class Phase { Initialization, Monitor, Exit };
+  using Phase = Parallel::Phase;
 };
 
 void test_event_construction() {

--- a/tests/Unit/Parallel/Test_ParallelComponentHelpers.cpp
+++ b/tests/Unit/Parallel/Test_ParallelComponentHelpers.cpp
@@ -8,6 +8,7 @@
 #include "Options/ParseOptions.hpp"
 #include "Parallel/CreateFromOptions.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"  // IWYU pragma: keep
+#include "Parallel/Phase.hpp"
 #include "Utilities/NoSuchType.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -52,11 +53,9 @@ struct InitAction3 {
   using initialization_tags = tmpl::list<InitTag0, InitTag1, InitTag3>;
 };
 
-enum class Phase { Initialization, Execute, Exit };
-
 struct ComponentInit {
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      Phase, Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<InitAction0, InitAction1, InitAction2>>>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
@@ -64,7 +63,7 @@ struct ComponentInit {
 
 struct ComponentExecute {
   using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<Phase, Phase::Execute,
+      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Execute,
                                         tmpl::list<Action0, Action1>>>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
@@ -73,9 +72,9 @@ struct ComponentExecute {
 
 struct ComponentInitAndExecute {
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<Phase, Phase::Initialization,
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
                              tmpl::list<InitAction3>>,
-      Parallel::PhaseActions<Phase, Phase::Execute,
+      Parallel::PhaseActions<Parallel::Phase::Execute,
                              tmpl::list<InitAction2, Action0, Action2>>>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
@@ -83,7 +82,7 @@ struct ComponentInitAndExecute {
 
 struct ComponentInitWithAllocate {
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      Phase, Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<InitAction0, InitAction1, InitAction2>>>;
   using array_allocation_tags = tmpl::list<InitTag4, InitTag5>;
   using initialization_tags = Parallel::get_initialization_tags<
@@ -94,7 +93,7 @@ struct ComponentInitWithAllocate {
 
 struct ComponentExecuteWithAllocate {
   using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<Phase, Phase::Execute,
+      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Execute,
                                         tmpl::list<Action0, Action1>>>;
   using array_allocation_tags = tmpl::list<InitTag6, InitTag7>;
   using initialization_tags = Parallel::get_initialization_tags<
@@ -104,9 +103,9 @@ struct ComponentExecuteWithAllocate {
 
 struct ComponentInitAndExecuteWithAllocate {
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<Phase, Phase::Initialization,
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
                              tmpl::list<InitAction3>>,
-      Parallel::PhaseActions<Phase, Phase::Execute,
+      Parallel::PhaseActions<Parallel::Phase::Execute,
                              tmpl::list<InitAction2, Action0, Action2>>>;
   using array_allocation_tags = tmpl::list<InitTag3, InitTag4>;
   using initialization_tags = Parallel::get_initialization_tags<

--- a/tests/Unit/Parallel/Test_Phase.cpp
+++ b/tests/Unit/Parallel/Test_Phase.cpp
@@ -10,7 +10,7 @@
 SPECTRE_TEST_CASE("Unit.Parallel.Phase", "[Parallel][Unit]") {
   // These two variables must correspond to the first and last
   // enum values of Parallel::Phase for the test to work properly
-  const Parallel::Phase first_enum = Parallel::Phase::Evolve;
+  const Parallel::Phase first_enum = Parallel::Phase::Cleanup;
   const Parallel::Phase last_enum = Parallel::Phase::WriteCheckpoint;
 
   using enum_t = std::underlying_type_t<Parallel::Phase>;

--- a/tests/Unit/Parallel/Test_ResourceInfo.cpp
+++ b/tests/Unit/Parallel/Test_ResourceInfo.cpp
@@ -15,6 +15,7 @@
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "Parallel/Algorithms/AlgorithmSingletonDeclarations.hpp"
 #include "Parallel/GlobalCache.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/ResourceInfo.hpp"
 #include "Parallel/Tags/ResourceInfo.hpp"
 #include "Utilities/GetOutput.hpp"
@@ -28,10 +29,8 @@ struct FakeSingleton {
   using chare_type = Parallel::Algorithms::Singleton;
   using metavariables = Metavariables;
   static std::string name() { return "FakeSingleton" + get_output(Index); }
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
-                                        tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
   using initialization_tags = tmpl::list<
       Parallel::Tags::AvoidGlobalProc0,
       Parallel::Tags::SingletonInfo<FakeSingleton<Metavariables, Index>>>;
@@ -42,10 +41,8 @@ struct FakeSingletonInfoOnly {
   using chare_type = Parallel::Algorithms::Singleton;
   using metavariables = Metavariables;
   static std::string name() { return "FakeSingleton" + get_output(Index); }
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
-                                        tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
   using initialization_tags = tmpl::list<Parallel::Tags::SingletonInfo<
       FakeSingletonInfoOnly<Metavariables, Index>>>;
 };
@@ -53,10 +50,8 @@ template <typename Metavariables>
 struct FakeSingletonAvoidGlobalProc0 {
   using chare_type = Parallel::Algorithms::Singleton;
   using metavariables = Metavariables;
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
-                                        tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
   using initialization_tags = tmpl::list<Parallel::Tags::AvoidGlobalProc0>;
 };
 
@@ -64,22 +59,22 @@ template <size_t... Indices>
 struct MetavariablesBoth {
   using component_list =
       tmpl::list<FakeSingleton<MetavariablesBoth, Indices>...>;
-  enum class Phase { Initialization, Exit };
+  using Phase = Parallel::Phase;
 };
 template <size_t... Indices>
 struct MetavariablesInfoOnly {
   using component_list =
       tmpl::list<FakeSingletonInfoOnly<MetavariablesInfoOnly, Indices>...>;
-  enum class Phase { Initialization, Exit };
+  using Phase = Parallel::Phase;
 };
 struct MetavariablesAvoidGlobalProc0 {
   using component_list =
       tmpl::list<FakeSingletonAvoidGlobalProc0<MetavariablesAvoidGlobalProc0>>;
-  enum class Phase { Initialization, Exit };
+  using Phase = Parallel::Phase;
 };
 
 struct EmptyMetavars {
-  enum class Phase { Initialization, Exit };
+  using Phase = Parallel::Phase;
 };
 
 template <size_t Index>

--- a/tests/Unit/ParallelAlgorithms/Actions/Test_MutateApply.cpp
+++ b/tests/Unit/ParallelAlgorithms/Actions/Test_MutateApply.cpp
@@ -7,6 +7,7 @@
 
 #include "DataStructures/DataBox/Tag.hpp"
 #include "Framework/ActionTesting.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
 #include "Utilities/Gsl.hpp"
@@ -37,19 +38,16 @@ struct Component {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Initialization,
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
                              tmpl::list<ActionTesting::InitializeDataBox<
                                  tmpl::list<TestValue, SomeNumber>>>>,
-
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Testing,
+      Parallel::PhaseActions<Parallel::Phase::Testing,
                              tmpl::list<::Actions::MutateApply<AddTheNumber>>>>;
 };
 
 struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 }  // namespace

--- a/tests/Unit/ParallelAlgorithms/Actions/Test_RandomizeVariables.cpp
+++ b/tests/Unit/ParallelAlgorithms/Actions/Test_RandomizeVariables.cpp
@@ -19,6 +19,7 @@
 #include "Framework/ActionTesting.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/Actions/RandomizeVariables.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -41,19 +42,18 @@ struct ElementArray {
   using const_global_cache_tags = tmpl::list<>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          Parallel::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<
               tmpl::list<::Tags::Variables<tmpl::list<ScalarFieldTag>>>>>>,
-      Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Testing,
-          tmpl::list<
-              Actions::RandomizeVariables<VariablesTag, RandomizeVariables>>>>;
+      Parallel::PhaseActions<Parallel::Phase::Testing,
+                             tmpl::list<Actions::RandomizeVariables<
+                                 VariablesTag, RandomizeVariables>>>>;
 };
 
 struct Metavariables {
   using component_list = tmpl::list<ElementArray<Metavariables>>;
   using const_global_cache_tags = tmpl::list<>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 void test_randomize_variables(

--- a/tests/Unit/ParallelAlgorithms/Actions/Test_SetData.cpp
+++ b/tests/Unit/ParallelAlgorithms/Actions/Test_SetData.cpp
@@ -7,6 +7,7 @@
 
 #include "DataStructures/DataBox/Tag.hpp"
 #include "Framework/ActionTesting.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Actions/SetData.hpp"
 #include "Utilities/TMPL.hpp"
@@ -24,13 +25,13 @@ struct Component {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<ActionTesting::InitializeDataBox<tmpl::list<SomeNumber>>>>>;
 };
 
 struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 }  // namespace

--- a/tests/Unit/ParallelAlgorithms/Actions/Test_UpdateMessageQueue.cpp
+++ b/tests/Unit/ParallelAlgorithms/Actions/Test_UpdateMessageQueue.cpp
@@ -12,6 +12,7 @@
 #include "DataStructures/LinkedMessageId.hpp"
 #include "DataStructures/LinkedMessageQueue.hpp"
 #include "Framework/ActionTesting.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Actions/UpdateMessageQueue.hpp"
 #include "Utilities/Gsl.hpp"
@@ -61,15 +62,13 @@ struct Component {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
   using initialization_tags = tmpl::list<LinkedMessageQueueTag, ProcessorCalls>;
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
-                                        tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
 };
 
 struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 }  // namespace
 

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveNorms.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveNorms.cpp
@@ -25,6 +25,7 @@
 #include "IO/Observer/ObserverComponent.hpp"
 #include "IO/Observer/Tags.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/Reduction.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
@@ -129,10 +130,8 @@ struct ElementComponent {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementId<Metavariables::volume_dim>;
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
-                                        tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
 };
 
 template <typename Metavariables>
@@ -145,10 +144,8 @@ struct MockObserverComponent {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockGroupChare;
   using array_index = int;
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
-                                        tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
 };
 
 template <typename ArraySectionIdTag>
@@ -168,7 +165,7 @@ struct Metavariables {
         tmpl::pair<Event, tmpl::list<ObserveNormsEvent<ArraySectionIdTag>>>>;
   };
 
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 template <typename ArraySectionIdTag, typename ObserveEvent>

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStep.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStep.cpp
@@ -28,6 +28,7 @@
 #include "IO/Observer/Protocols/ReductionDataFormatter.hpp"
 #include "IO/Observer/TypeOfObservation.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/Reduction.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
@@ -120,10 +121,8 @@ struct ElementComponent {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
-                                        tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
 };
 
 template <typename Metavariables>
@@ -137,10 +136,8 @@ struct MockObserverComponent {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockGroupChare;
   using array_index = int;
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
-                                        tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
 };
 
 struct Var : db::SimpleTag {
@@ -164,7 +161,7 @@ struct Metavariables {
         tmpl::list<Events::ObserveTimeStep<typename Metavariables::system>>>>;
   };
 
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 template <typename Observer>

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveVolumeIntegrals.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveVolumeIntegrals.cpp
@@ -38,6 +38,7 @@
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/Reduction.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
@@ -110,10 +111,8 @@ struct ElementComponent {
   using metavariables = Metavariables;
   using array_index = int;
   using chare_type = ActionTesting::MockArrayChare;
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
-                                        tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
 };
 
 template <typename Metavariables>
@@ -126,10 +125,8 @@ struct MockObserverComponent {
   using metavariables = Metavariables;
   using array_index = int;
   using chare_type = ActionTesting::MockGroupChare;
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
-                                        tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
 };
 
 struct ScalarVar : db::SimpleTag {
@@ -182,7 +179,7 @@ struct Metavariables {
     using factory_classes =
         tmpl::map<tmpl::pair<Event, tmpl::list<ObserveEvent>>>;
   };
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 template <size_t SpatialDim>

--- a/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_EventsAndTriggers.cpp
+++ b/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_EventsAndTriggers.cpp
@@ -15,6 +15,7 @@
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp"  // IWYU pragma: keep
@@ -39,8 +40,7 @@ struct Component {
   using array_index = int;
   using const_global_cache_tags = tmpl::list<Tags::EventsAndTriggers>;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Testing,
-      tmpl::list<Actions::RunEventsAndTriggers>>>;
+      Parallel::Phase::Testing, tmpl::list<Actions::RunEventsAndTriggers>>>;
 };
 
 struct Metavariables {
@@ -51,7 +51,7 @@ struct Metavariables {
         tmpl::map<tmpl::pair<Event, tmpl::list<Events::Completion>>,
                   tmpl::pair<Trigger, Triggers::logical_triggers>>;
   };
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 void run_events_and_triggers(const EventsAndTriggers& events_and_triggers,

--- a/tests/Unit/ParallelAlgorithms/Initialization/Actions/Test_AddComputeTags.cpp
+++ b/tests/Unit/ParallelAlgorithms/Initialization/Actions/Test_AddComputeTags.cpp
@@ -11,6 +11,7 @@
 #include "Framework/ActionTesting.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/GlobalCache.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/AddComputeTags.hpp"
 #include "Utilities/Gsl.hpp"
@@ -44,20 +45,18 @@ struct Component {
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          Parallel::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<tmpl::list<SomeNumber>>>>,
-
-      Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Testing,
-          tmpl::list<
-              Actions::SetupDataBox,
-              Initialization::Actions::AddComputeTags<SquareNumberCompute>>>>;
+      Parallel::PhaseActions<Parallel::Phase::Testing,
+                             tmpl::list<Actions::SetupDataBox,
+                                        Initialization::Actions::AddComputeTags<
+                                            SquareNumberCompute>>>>;
 };
 
 struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
 
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 }  // namespace

--- a/tests/Unit/ParallelAlgorithms/Initialization/Actions/Test_AddSimpleTags.cpp
+++ b/tests/Unit/ParallelAlgorithms/Initialization/Actions/Test_AddSimpleTags.cpp
@@ -10,6 +10,7 @@
 #include "Framework/ActionTesting.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/GlobalCache.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/AddSimpleTags.hpp"
 #include "Utilities/Gsl.hpp"
@@ -55,7 +56,7 @@ struct Component {
   using array_index = int;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Testing,
+      Parallel::Phase::Testing,
       tmpl::list<Actions::SetupDataBox,
                  Initialization::Actions::AddSimpleTags<
                      tmpl::list<AddSomeAndOtherNumber, AddSquareNumber>>>>>;
@@ -64,7 +65,7 @@ struct Component {
 struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
 
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 }  // namespace

--- a/tests/Unit/ParallelAlgorithms/Initialization/Actions/Test_RemoveOptionsAndTerminatePhase.cpp
+++ b/tests/Unit/ParallelAlgorithms/Initialization/Actions/Test_RemoveOptionsAndTerminatePhase.cpp
@@ -13,6 +13,7 @@
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
 #include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
@@ -114,8 +115,7 @@ struct Component {
   // [actions]
 
   using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
+      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
                                         initialization_actions>>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
@@ -124,7 +124,7 @@ struct Component {
 struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
 
-  enum class Phase { Initialization, Exit };
+  using Phase = Parallel::Phase;
 };
 }  // namespace
 

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
@@ -22,6 +22,7 @@
 #include "Domain/Tags.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "ParallelAlgorithms/Interpolation/Actions/AddTemporalIdsToInterpolationTarget.hpp"  // IWYU pragma: keep
 #include "ParallelAlgorithms/Interpolation/Actions/InitializeInterpolationTarget.hpp"
@@ -96,12 +97,11 @@ struct mock_interpolation_target {
                           tmpl::list<>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          Parallel::Phase::Initialization,
           tmpl::list<Actions::SetupDataBox,
                      intrp::Actions::InitializeInterpolationTarget<
                          Metavariables, InterpolationTargetTag>>>,
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Testing, tmpl::list<>>>;
+      Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
   using replace_these_simple_actions = tmpl::list<
       intrp::Actions::SendPointsToInterpolator<InterpolationTargetTag>>;
   using with_these_simple_actions = tmpl::list<MockSendPointsToInterpolator>;
@@ -139,7 +139,7 @@ struct MockMetavariables {
 
   using component_list = tmpl::list<
       mock_interpolation_target<MockMetavariables, InterpolationTargetA>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 template <typename IsSequential>

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_CleanUpInterpolator.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_CleanUpInterpolator.cpp
@@ -13,6 +13,7 @@
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "Framework/ActionTesting.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "ParallelAlgorithms/Interpolation/Actions/CleanUpInterpolator.hpp"  // IWYU pragma: keep
 #include "ParallelAlgorithms/Interpolation/Actions/InitializeInterpolator.hpp"  // IWYU pragma: keep
@@ -50,10 +51,9 @@ struct mock_interpolator {
       intrp::Tags::InterpolatedVarsHolders<Metavariables>>::simple_tags;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          Parallel::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Testing, tmpl::list<>>>;
+      Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
 };
 
 struct MockMetavariables {
@@ -78,7 +78,7 @@ struct MockMetavariables {
       tmpl::list<InterpolationTagA, InterpolationTagB, InterpolationTagC>;
 
   using component_list = tmpl::list<mock_interpolator<MockMetavariables>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 template <typename interp_component, typename InterpolationTargetTag,

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
@@ -18,6 +18,7 @@
 #include "Domain/Tags.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "ParallelAlgorithms/Interpolation/Actions/InitializeInterpolationTarget.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp"
@@ -44,7 +45,7 @@ struct mock_interpolation_target {
   using array_index = size_t;
   using const_global_cache_tags = tmpl::list<domain::Tags::Domain<3>>;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<Actions::SetupDataBox,
                  intrp::Actions::InitializeInterpolationTarget<
                      Metavariables, InterpolationTargetTag>>>>;
@@ -66,7 +67,7 @@ struct Metavariables {
 
   using component_list = tmpl::list<
       mock_interpolation_target<Metavariables, InterpolationTargetA>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.Initialize",

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InitializeInterpolator.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InitializeInterpolator.cpp
@@ -9,6 +9,7 @@
 
 #include "Framework/ActionTesting.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "ParallelAlgorithms/Interpolation/Actions/InitializeInterpolator.hpp"  // IWYU pragma: keep
 #include "ParallelAlgorithms/Interpolation/InterpolatedVars.hpp"
@@ -31,7 +32,7 @@ struct mock_interpolator {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<Actions::SetupDataBox,
                  intrp::Actions::InitializeInterpolator<
                      tmpl::list<intrp::Tags::VolumeVarsInfo<Metavariables,
@@ -52,7 +53,7 @@ struct Metavariables {
   using interpolation_target_tags = tmpl::list<InterpolatorTargetA>;
 
   using component_list = tmpl::list<mock_interpolator<Metavariables>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.Initialize",

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_Interpolate.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_Interpolate.cpp
@@ -21,6 +21,7 @@
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "Parallel/Tags/Metavariables.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InitializeInterpolator.hpp"
@@ -123,7 +124,7 @@ struct mock_interpolator {
   using chare_type = ActionTesting::MockGroupChare;
   using array_index = size_t;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<
           Actions::SetupDataBox,
           ::intrp::Actions::InitializeInterpolator<
@@ -147,10 +148,8 @@ struct mock_interpolation_target {
   using component_being_mocked =
       intrp::InterpolationTarget<Metavariables, InterpolationTargetTag>;
 
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
-                                        tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
 
   using replace_these_simple_actions =
       tmpl::list<intrp::Actions::AddTemporalIdsToInterpolationTarget<
@@ -165,10 +164,8 @@ struct mock_element {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementId<Metavariables::volume_dim>;
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
-                                        tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
   using initial_databox = db::compute_databox_type<db::AddSimpleTags<>>;
 };
 
@@ -201,7 +198,7 @@ struct MockMetavariables {
     using factory_classes = tmpl::map<tmpl::pair<Event, tmpl::list<event>>>;
   };
 
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.InterpolateEvent",

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolateWithoutInterpComponent.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolateWithoutInterpComponent.cpp
@@ -19,6 +19,7 @@
 #include "Helpers/ParallelAlgorithms/Interpolation/InterpolateOnElementTestHelpers.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/Tags/Metavariables.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp"
@@ -38,10 +39,8 @@ struct mock_element {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementId<Metavariables::volume_dim>;
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
-                                        tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
   using initial_databox = db::compute_databox_type<db::AddSimpleTags<>>;
 };
 
@@ -156,7 +155,7 @@ struct MockMetavariables {
     using factory_classes = tmpl::map<tmpl::pair<Event, tmpl::list<event>>>;
   };
 
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 template <typename MockMetavariables>

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetApparentHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetApparentHorizon.cpp
@@ -22,6 +22,7 @@
 #include "IO/Logging/Tags.hpp"  // IWYU pragma: keep
 #include "IO/Logging/Verbosity.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
 #include "ParallelAlgorithms/Interpolation/Targets/ApparentHorizon.hpp"
@@ -55,7 +56,7 @@ struct MockMetavariables {
       tmpl::list<InterpTargetTestHelpers::mock_interpolation_target<
                      MockMetavariables, InterpolationTargetA>,
                  InterpTargetTestHelpers::mock_interpolator<MockMetavariables>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 }  // namespace
 

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
@@ -18,6 +18,7 @@
 #include "Framework/TestCreation.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp"
+#include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
 #include "ParallelAlgorithms/Interpolation/Targets/KerrHorizon.hpp"
@@ -52,7 +53,7 @@ struct MockMetavariables {
       tmpl::list<InterpTargetTestHelpers::mock_interpolation_target<
                      MockMetavariables, InterpolationTargetA>,
                  InterpTargetTestHelpers::mock_interpolator<MockMetavariables>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 }  // namespace
 

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
@@ -17,6 +17,7 @@
 #include "Framework/TestCreation.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp"
+#include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
 #include "ParallelAlgorithms/Interpolation/Targets/LineSegment.hpp"
@@ -47,7 +48,7 @@ struct MockMetavariables {
       tmpl::list<InterpTargetTestHelpers::mock_interpolation_target<
                      MockMetavariables, InterpolationTargetA>,
                  InterpTargetTestHelpers::mock_interpolator<MockMetavariables>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 }  // namespace
 

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetSpecifiedPoints.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetSpecifiedPoints.cpp
@@ -19,6 +19,7 @@
 #include "Framework/TestCreation.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp"
+#include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
 #include "ParallelAlgorithms/Interpolation/Targets/SpecifiedPoints.hpp"
@@ -50,7 +51,7 @@ struct MockMetavariables {
       InterpTargetTestHelpers::mock_interpolation_target<MockMetavariables<Dim>,
                                                          InterpolationTargetA>,
       InterpTargetTestHelpers::mock_interpolator<MockMetavariables<Dim>>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 void test_1d() {

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetSphere.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetSphere.cpp
@@ -18,6 +18,7 @@
 #include "Framework/TestCreation.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp"
+#include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
 #include "ParallelAlgorithms/Interpolation/Targets/Sphere.hpp"
@@ -50,7 +51,7 @@ struct MockMetavariables {
       tmpl::list<InterpTargetTestHelpers::mock_interpolation_target<
                      MockMetavariables, InterpolationTargetA>,
                  InterpTargetTestHelpers::mock_interpolator<MockMetavariables>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 }  // namespace
 

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetVarsFromElement.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetVarsFromElement.cpp
@@ -15,6 +15,7 @@
 #include "Domain/Domain.hpp"
 #include "Domain/Tags.hpp"
 #include "Framework/ActionTesting.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InitializeInterpolationTarget.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InterpolationTargetVarsFromElement.hpp"
@@ -128,7 +129,7 @@ struct mock_interpolation_target {
   using simple_tags = typename intrp::Actions::InitializeInterpolationTarget<
       Metavariables, InterpolationTargetTag>::simple_tags;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<ActionTesting::InitializeDataBox<
           simple_tags,
           typename InterpolationTargetTag::compute_items_on_target>>>>;
@@ -148,7 +149,7 @@ struct MockMetavariables {
 
   using component_list = tmpl::list<
       mock_interpolation_target<MockMetavariables, InterpolationTargetA>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.TargetVarsFromElement",

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
@@ -19,6 +19,7 @@
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
 #include "ParallelAlgorithms/Interpolation/Targets/WedgeSectionTorus.hpp"
@@ -49,7 +50,7 @@ struct MockMetavariables {
       tmpl::list<InterpTargetTestHelpers::mock_interpolation_target<
                      MockMetavariables, InterpolationTargetA>,
                  InterpTargetTestHelpers::mock_interpolator<MockMetavariables>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 void test_r_theta_lgl() {

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
@@ -22,6 +22,7 @@
 #include "Domain/Tags.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "ParallelAlgorithms/Interpolation/Actions/InitializeInterpolationTarget.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InitializeInterpolator.hpp"  // IWYU pragma: keep
@@ -117,12 +118,11 @@ struct mock_interpolation_target {
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          Parallel::Phase::Initialization,
           tmpl::list<::Actions::SetupDataBox,
                      intrp::Actions::InitializeInterpolationTarget<
                          Metavariables, InterpolationTargetTag>>>,
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Testing, tmpl::list<>>>;
+      Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
 
   using replace_these_simple_actions =
       tmpl::list<intrp::Actions::InterpolationTargetReceiveVars<
@@ -140,14 +140,13 @@ struct mock_interpolator {
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          Parallel::Phase::Initialization,
           tmpl::list<::Actions::SetupDataBox,
                      ::intrp::Actions::InitializeInterpolator<
                          intrp::Tags::VolumeVarsInfo<Metavariables,
                                                      ::Tags::TimeStepId>,
                          intrp::Tags::InterpolatedVarsHolders<Metavariables>>>>,
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Testing, tmpl::list<>>>;
+      Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
   using component_being_mocked = void;  // not needed.
 };
 
@@ -170,7 +169,7 @@ struct Metavariables {
   using component_list =
       tmpl::list<mock_interpolation_target<Metavariables, InterpolationTargetA>,
                  mock_interpolator<Metavariables>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ReceivePoints",

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Actions/Test_MakeIdentityIfSkipped.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Actions/Test_MakeIdentityIfSkipped.cpp
@@ -13,6 +13,7 @@
 #include "Framework/ActionTesting.hpp"
 #include "NumericalAlgorithms/Convergence/Tags.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/LinearSolver/Actions/MakeIdentityIfSkipped.hpp"
 #include "Utilities/Gsl.hpp"
@@ -67,12 +68,12 @@ struct ElementArray {
   using array_index = int;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          Parallel::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<
               tmpl::list<Convergence::Tags::HasConverged<TestOptionsGroup>,
                          FieldsTag, SourceTag, CheckRunIfSkippedTag>>>>,
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          Parallel::Phase::Testing,
           tmpl::list<TestActions, Parallel::Actions::TerminatePhase>>>;
 };
 
@@ -80,7 +81,7 @@ template <typename TestActions>
 struct Metavariables {
   using element_array = ElementArray<Metavariables, TestActions>;
   using component_list = tmpl::list<element_array>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 template <typename TestActions>

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ElementActions.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ElementActions.cpp
@@ -14,6 +14,7 @@
 #include "NumericalAlgorithms/Convergence/HasConverged.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
+#include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/Actions/SetData.hpp"
 #include "ParallelAlgorithms/LinearSolver/ConjugateGradient/ElementActions.hpp"
 #include "ParallelAlgorithms/LinearSolver/ConjugateGradient/InitializeElement.hpp"
@@ -46,13 +47,13 @@ struct ElementArray {
   using array_index = int;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          Parallel::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<tmpl::list<VectorTag>>,
                      Actions::SetupDataBox,
                      LinearSolver::cg::detail::InitializeElement<
                          fields_tag, DummyOptionsGroup>>>,
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          Parallel::Phase::Testing,
           tmpl::list<LinearSolver::cg::detail::InitializeHasConverged<
                          fields_tag, DummyOptionsGroup, DummyOptionsGroup>,
                      LinearSolver::cg::detail::UpdateOperand<
@@ -62,7 +63,7 @@ struct ElementArray {
 
 struct Metavariables {
   using component_list = tmpl::list<ElementArray<Metavariables>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 }  // namespace

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ResidualMonitorActions.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ResidualMonitorActions.cpp
@@ -22,6 +22,7 @@
 #include "NumericalAlgorithms/Convergence/HasConverged.hpp"
 #include "NumericalAlgorithms/Convergence/Reason.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp"
 #include "ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp"
 #include "ParallelAlgorithms/LinearSolver/Observe.hpp"
@@ -64,7 +65,7 @@ struct MockResidualMonitor {
       typename LinearSolver::cg::detail::ResidualMonitor<
           Metavariables, fields_tag, TestLinearSolver>::const_global_cache_tags;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<Actions::SetupDataBox,
                  LinearSolver::cg::detail::InitializeResidualMonitor<
                      fields_tag, TestLinearSolver>>>>;
@@ -77,10 +78,8 @@ struct MockElementArray {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
-                                        tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
   using inbox_tags = tmpl::list<
       LinearSolver::cg::detail::Tags::InitialHasConverged<TestLinearSolver>,
       LinearSolver::cg::detail::Tags::Alpha<TestLinearSolver>,
@@ -92,7 +91,7 @@ struct Metavariables {
   using component_list = tmpl::list<MockResidualMonitor<Metavariables>,
                                     MockElementArray<Metavariables>,
                                     helpers::MockObserverWriter<Metavariables>>;
-  enum class Phase { Initialization, RegisterWithObserver, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 }  // namespace
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_ElementActions.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_ElementActions.cpp
@@ -16,6 +16,7 @@
 #include "NumericalAlgorithms/Convergence/HasConverged.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
+#include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/Actions/SetData.hpp"
 #include "ParallelAlgorithms/LinearSolver/Gmres/ElementActions.hpp"
 #include "ParallelAlgorithms/LinearSolver/Gmres/InitializeElement.hpp"
@@ -58,13 +59,13 @@ struct ElementArray {
   using array_index = int;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          Parallel::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<tmpl::list<VectorTag>>,
                      Actions::SetupDataBox,
                      LinearSolver::gmres::detail::InitializeElement<
                          fields_tag, DummyOptionsGroup, Preconditioned>>>,
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          Parallel::Phase::Testing,
           tmpl::list<
               LinearSolver::gmres::detail::NormalizeInitialOperand<
                   fields_tag, DummyOptionsGroup, Preconditioned,
@@ -82,7 +83,7 @@ template <bool Preconditioned>
 struct Metavariables {
   using element_array = ElementArray<Metavariables, Preconditioned>;
   using component_list = tmpl::list<element_array>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 template <bool Preconditioned>

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_ResidualMonitorActions.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_ResidualMonitorActions.cpp
@@ -23,6 +23,7 @@
 #include "NumericalAlgorithms/Convergence/HasConverged.hpp"
 #include "NumericalAlgorithms/Convergence/Reason.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp"
 #include "ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitorActions.hpp"
 #include "ParallelAlgorithms/LinearSolver/Observe.hpp"
@@ -65,7 +66,7 @@ struct MockResidualMonitor {
       typename LinearSolver::gmres::detail::ResidualMonitor<
           Metavariables, fields_tag, TestLinearSolver>::const_global_cache_tags;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      Parallel::Phase::Initialization,
       tmpl::list<Actions::SetupDataBox,
                  LinearSolver::gmres::detail::InitializeResidualMonitor<
                      fields_tag, TestLinearSolver>>>>;
@@ -78,10 +79,8 @@ struct MockElementArray {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
-                                        Metavariables::Phase::Initialization,
-                                        tmpl::list<>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
   using inbox_tags = tmpl::list<
       LinearSolver::gmres::detail::Tags::InitialOrthogonalization<
           TestLinearSolver>,
@@ -94,7 +93,7 @@ struct Metavariables {
   using component_list = tmpl::list<MockResidualMonitor<Metavariables>,
                                     MockElementArray<Metavariables>,
                                     helpers::MockObserverWriter<Metavariables>>;
-  enum class Phase { Initialization, RegisterWithObserver, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 }  // namespace

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Actions/Test_RestrictFields.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Actions/Test_RestrictFields.cpp
@@ -25,6 +25,7 @@
 #include "NumericalAlgorithms/Convergence/Tags.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/LinearSolver/Multigrid/Actions/RestrictFields.hpp"
 #include "ParallelAlgorithms/LinearSolver/Multigrid/Tags.hpp"
@@ -57,7 +58,7 @@ struct ElementArray {
   using array_index = ElementId<Dim>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          Parallel::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<tmpl::list<
               LinearSolver::multigrid::Tags::ParentId<Dim>,
               LinearSolver::multigrid::Tags::ChildIds<Dim>,
@@ -65,7 +66,7 @@ struct ElementArray {
               LinearSolver::multigrid::Tags::ParentMesh<Dim>,
               Convergence::Tags::IterationId<DummyOptionsGroup>, fields_tag>>>>,
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          Parallel::Phase::Testing,
           tmpl::list<
               LinearSolver::multigrid::Actions::SendFieldsToCoarserGrid<
                   tmpl::list<fields_tag>, DummyOptionsGroup,
@@ -82,7 +83,7 @@ struct Metavariables {
   using const_global_cache_tags =
       tmpl::conditional_t<std::is_same_v<FieldsAreMassiveTag, void>,
                           tmpl::list<>, tmpl::list<FieldsAreMassiveTag>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 template <typename FieldsAreMassiveTag>

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithm.cpp
@@ -18,6 +18,7 @@
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Main.hpp"
+#include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
 #include "ParallelAlgorithms/LinearSolver/Multigrid/ElementsAllocator.hpp"
 #include "ParallelAlgorithms/LinearSolver/Multigrid/Multigrid.hpp"
@@ -114,13 +115,12 @@ struct Metavariables {
       elliptic::DgElementArray<
           Metavariables,
           tmpl::list<
-              Parallel::PhaseActions<Phase, Phase::Initialization,
+              Parallel::PhaseActions<Parallel::Phase::Initialization,
                                      initialization_actions>,
-              Parallel::PhaseActions<Phase, Phase::RegisterWithObserver,
+              Parallel::PhaseActions<Parallel::Phase::RegisterWithObserver,
                                      register_actions>,
-              Parallel::PhaseActions<Phase, Phase::PerformLinearSolve,
-                                     solve_actions>,
-              Parallel::PhaseActions<Phase, Phase::TestResult, test_actions>>,
+              Parallel::PhaseActions<Parallel::Phase::Solve, solve_actions>,
+              Parallel::PhaseActions<Parallel::Phase::Testing, test_actions>>,
           LinearSolver::multigrid::ElementsAllocator<1, MultigridSolver>>,
       observers::Observer<Metavariables>,
       observers::ObserverWriter<Metavariables>,

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridPreconditionedGmresAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridPreconditionedGmresAlgorithm.cpp
@@ -17,6 +17,7 @@
 #include "Parallel/Actions/Goto.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Main.hpp"
+#include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
 #include "ParallelAlgorithms/LinearSolver/Actions/MakeIdentityIfSkipped.hpp"
 #include "ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp"
@@ -147,13 +148,12 @@ struct Metavariables {
       elliptic::DgElementArray<
           Metavariables,
           tmpl::list<
-              Parallel::PhaseActions<Phase, Phase::Initialization,
+              Parallel::PhaseActions<Parallel::Phase::Initialization,
                                      initialization_actions>,
-              Parallel::PhaseActions<Phase, Phase::RegisterWithObserver,
+              Parallel::PhaseActions<Parallel::Phase::RegisterWithObserver,
                                      register_actions>,
-              Parallel::PhaseActions<Phase, Phase::PerformLinearSolve,
-                                     solve_actions>,
-              Parallel::PhaseActions<Phase, Phase::TestResult, test_actions>>,
+              Parallel::PhaseActions<Parallel::Phase::Solve, solve_actions>,
+              Parallel::PhaseActions<Parallel::Phase::Testing, test_actions>>,
           LinearSolver::multigrid::ElementsAllocator<1, MultigridSolver>>,
       observers::Observer<Metavariables>,
       observers::ObserverWriter<Metavariables>,

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Actions/Test_CommunicateOverlapFields.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Actions/Test_CommunicateOverlapFields.cpp
@@ -20,6 +20,7 @@
 #include "NumericalAlgorithms/Convergence/Tags.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/LinearSolver/Schwarz/Actions/CommunicateOverlapFields.hpp"
 #include "ParallelAlgorithms/LinearSolver/Schwarz/OverlapHelpers.hpp"
@@ -48,7 +49,7 @@ struct ElementArray {
   using array_index = ElementId<Dim>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          Parallel::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<tmpl::list<
               domain::Tags::Element<Dim>, domain::Tags::Mesh<Dim>,
               LinearSolver::Schwarz::Tags::IntrudingExtents<Dim,
@@ -57,7 +58,7 @@ struct ElementArray {
               LinearSolver::Schwarz::Tags::Overlaps<fields_tag, Dim,
                                                     DummyOptionsGroup>>>>>,
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          Parallel::Phase::Testing,
           tmpl::list<
               LinearSolver::Schwarz::Actions::SendOverlapFields<
                   tmpl::list<fields_tag>, DummyOptionsGroup, RestrictToOverlap>,
@@ -70,7 +71,7 @@ template <size_t Dim, bool RestrictToOverlap>
 struct Metavariables {
   using element_array = ElementArray<Dim, RestrictToOverlap, Metavariables>;
   using component_list = tmpl::list<element_array>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 template <size_t Dim, bool RestrictToOverlap>

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Actions/Test_ResetSubdomainSolver.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Actions/Test_ResetSubdomainSolver.cpp
@@ -12,6 +12,7 @@
 #include "Framework/ActionTesting.hpp"
 #include "IO/Logging/Tags.hpp"
 #include "IO/Logging/Verbosity.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/LinearSolver/Schwarz/Actions/ResetSubdomainSolver.hpp"
 #include "ParallelAlgorithms/LinearSolver/Schwarz/Tags.hpp"
@@ -36,12 +37,12 @@ struct ElementArray {
   using array_index = ElementId<1>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          Parallel::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<
               tmpl::list<LinearSolver::Schwarz::Tags::SubdomainSolver<
                   std::unique_ptr<SubdomainSolver>, DummyOptionsGroup>>>>>,
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          Parallel::Phase::Testing,
           tmpl::list<LinearSolver::Schwarz::Actions::ResetSubdomainSolver<
               DummyOptionsGroup>>>>;
 };
@@ -49,7 +50,7 @@ struct ElementArray {
 struct Metavariables {
   using element_array = ElementArray<Metavariables>;
   using component_list = tmpl::list<element_array>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 void test_reset_subdomain_solver(const bool skip_resets) {

--- a/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
+++ b/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
@@ -10,6 +10,7 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
 #include "Framework/ActionTesting.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Time/Actions/AdvanceTime.hpp"  // IWYU pragma: keep
@@ -41,19 +42,18 @@ struct Component {
       db::AddSimpleTags<Tags::TimeStepId, Tags::Next<Tags::TimeStepId>,
                         Tags::TimeStep, Tags::Next<Tags::TimeStep>, Tags::Time>;
 
-  using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Testing,
-                             tmpl::list<Actions::AdvanceTime>>>;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<
+                     Parallel::Phase::Initialization,
+                     tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
+                 Parallel::PhaseActions<Parallel::Phase::Testing,
+                                        tmpl::list<Actions::AdvanceTime>>>;
 };
 
 struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
 
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 void check_rk3(const Time& start, const TimeDelta& time_step) {

--- a/tests/Unit/Time/Actions/Test_ChangeSlabSize.cpp
+++ b/tests/Unit/Time/Actions/Test_ChangeSlabSize.cpp
@@ -15,6 +15,7 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "Framework/ActionTesting.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Time/Actions/ChangeSlabSize.hpp"
@@ -45,7 +46,7 @@ struct Component;
 
 struct Metavariables {
   using component_list = tmpl::list<Component>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 struct Component {
@@ -58,13 +59,12 @@ struct Component {
   using simple_tags = tmpl::list<Tags::TimeStepId, Tags::Next<Tags::TimeStepId>,
                                  Tags::TimeStep, Tags::Next<Tags::TimeStep>,
                                  Tags::HistoryEvolvedVariables<Var>>;
-  using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Testing,
-                             tmpl::list<Actions::ChangeSlabSize>>>;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<
+                     Parallel::Phase::Initialization,
+                     tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
+                 Parallel::PhaseActions<Parallel::Phase::Testing,
+                                        tmpl::list<Actions::ChangeSlabSize>>>;
 };
 }  // namespace
 

--- a/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
+++ b/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
@@ -13,6 +13,7 @@
 #include "Framework/ActionTesting.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Actions/Goto.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Time/Actions/ChangeStepSize.hpp"
@@ -88,10 +89,10 @@ struct Component {
                                  history_tag, typename System::variables_tag>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          Parallel::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          Parallel::Phase::Testing,
           tmpl::list<Actions::ChangeStepSize<
                          typename Metavariables::step_choosers_to_use>,
                      ::Actions::Label<NoOpLabel>,
@@ -113,7 +114,7 @@ struct Metavariables {
                               StepRejector>>>;
   };
   using component_list = tmpl::list<Component<Metavariables>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 template <typename StepChoosersToUse = AllStepChoosers>

--- a/tests/Unit/Time/Actions/Test_RecordTimeStepperData.cpp
+++ b/tests/Unit/Time/Actions/Test_RecordTimeStepperData.cpp
@@ -15,6 +15,7 @@
 #include "Framework/ActionTesting.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"   // IWYU pragma: keep
 #include "Time/Actions/RecordTimeStepperData.hpp"  // IWYU pragma: keep
 #include "Time/Slab.hpp"
@@ -59,13 +60,11 @@ struct Component {
                         history_tag>;
   using compute_tags = db::AddComputeTags<>;
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<
-              ActionTesting::InitializeDataBox<simple_tags, compute_tags>>>,
-      Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Testing,
-          tmpl::list<Actions::RecordTimeStepperData<>>>>;
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
+                             tmpl::list<ActionTesting::InitializeDataBox<
+                                 simple_tags, compute_tags>>>,
+      Parallel::PhaseActions<Parallel::Phase::Testing,
+                             tmpl::list<Actions::RecordTimeStepperData<>>>>;
 };
 
 template <typename Metavariables>
@@ -78,12 +77,11 @@ struct ComponentWithTemplateSpecifiedVariables {
                         dt_alternative_variables_tag, alternative_history_tag>;
   using compute_tags = db::AddComputeTags<>;
   using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
+                             tmpl::list<ActionTesting::InitializeDataBox<
+                                 simple_tags, compute_tags>>>,
       Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<
-              ActionTesting::InitializeDataBox<simple_tags, compute_tags>>>,
-      Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          Parallel::Phase::Testing,
           tmpl::list<Actions::RecordTimeStepperData<AlternativeVar>>>>;
 };
 
@@ -92,7 +90,7 @@ struct Metavariables {
   using component_list =
       tmpl::list<Component<Metavariables>,
                  ComponentWithTemplateSpecifiedVariables<Metavariables>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 }  // namespace
 

--- a/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
+++ b/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
@@ -20,6 +20,7 @@
 #include "Evolution/Conservative/UpdatePrimitives.hpp"  // IWYU pragma: keep
 #include "Framework/ActionTesting.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Time/Actions/RecordTimeStepperData.hpp"  // IWYU pragma: keep
@@ -129,7 +130,7 @@ struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
   using ordered_list_of_primitive_recovery_schemes = tmpl::list<>;
   using temporal_id = TemporalId;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 
 template <typename Metavariables>
@@ -164,13 +165,11 @@ struct Component {
                      step_actions, typename metavariables::system>,
                  step_actions>>;
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<
-              ActionTesting::InitializeDataBox<simple_tags, compute_tags>,
-              Actions::SetupDataBox>>,
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Testing, action_list>>;
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
+                             tmpl::list<ActionTesting::InitializeDataBox<
+                                            simple_tags, compute_tags>,
+                                        Actions::SetupDataBox>>,
+      Parallel::PhaseActions<Parallel::Phase::Testing, action_list>>;
 };
 
 template <bool HasPrimitives = false, bool MultipleHistories = false>

--- a/tests/Unit/Time/Actions/Test_UpdateU.cpp
+++ b/tests/Unit/Time/Actions/Test_UpdateU.cpp
@@ -15,6 +15,7 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Framework/ActionTesting.hpp"
+#include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Time/Actions/UpdateU.hpp"  // IWYU pragma: keep
@@ -65,13 +66,12 @@ struct Component {
       db::AddSimpleTags<Tags::TimeStep, variables_tag, history_tag,
                         ::Tags::IsUsingTimeSteppingErrorControl<>>;
 
-  using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Testing,
-                             tmpl::list<Actions::UpdateU<>>>>;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<
+                     Parallel::Phase::Initialization,
+                     tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
+                 Parallel::PhaseActions<Parallel::Phase::Testing,
+                                        tmpl::list<Actions::UpdateU<>>>>;
 };
 
 template <typename Metavariables>
@@ -85,12 +85,10 @@ struct ComponentWithTemplateSpecifiedVariables {
                         ::Tags::IsUsingTimeSteppingErrorControl<>>;
   using compute_tags = db::AddComputeTags<>;
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<
-              ActionTesting::InitializeDataBox<simple_tags, compute_tags>>>,
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Testing,
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
+                             tmpl::list<ActionTesting::InitializeDataBox<
+                                 simple_tags, compute_tags>>>,
+      Parallel::PhaseActions<Parallel::Phase::Testing,
                              tmpl::list<Actions::UpdateU<AlternativeVar>>>>;
 };
 
@@ -99,7 +97,7 @@ struct Metavariables {
   using component_list =
       tmpl::list<Component<Metavariables>,
                  ComponentWithTemplateSpecifiedVariables<Metavariables>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using Phase = Parallel::Phase;
 };
 }  // namespace
 


### PR DESCRIPTION
## Proposed changes

- Add cleanup phase and rename Test -> Testing
- Remove phase type parameter from Parallel::PhaseActions
   -  This required replacing the Phase enum class in the test metavariables with Parallel::Phase
   -  Rather than add random testing phases to Parallel::Phase, in some of the tests in `tests/Unit/Parallel` I renamed phases to existing ones in Parallel::Phase
- Removed some unused or unnecessary type aliases, metafunctions and template parameters 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
- In a PhaseAction, the first template parameter should be removed.  
- Also restrict phase names to those in Parallel::Phase
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
