### PR TITLE
Add ResourceInfo tags to DgElementArray and IntrpTarget

### DIFF
--- a/src/Elliptic/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/DgElementArray.hpp
@@ -21,6 +21,7 @@
 #include "Parallel/Local.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/Protocols/ArrayElementsAllocator.hpp"
+#include "Parallel/Tags/ResourceInfo.hpp"
 #include "Utilities/Numeric.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/System/ParallelInfo.hpp"
@@ -109,9 +110,12 @@ struct DgElementArray {
       typename ElementsAllocator::template array_allocation_tags<
           DgElementArray>;
 
-  using initialization_tags = Parallel::get_initialization_tags<
-      Parallel::get_initialization_actions_list<phase_dependent_action_list>,
-      array_allocation_tags>;
+  using initialization_tags =
+      tmpl::append<Parallel::get_initialization_tags<
+                       Parallel::get_initialization_actions_list<
+                           phase_dependent_action_list>,
+                       array_allocation_tags>,
+                   tmpl::list<Parallel::Tags::AvoidGlobalProc0>>;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,

--- a/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
@@ -19,6 +19,7 @@
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Local.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Tags/ResourceInfo.hpp"
 #include "Utilities/System/ParallelInfo.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits/CreateHasStaticMemberVariable.hpp"
@@ -57,9 +58,12 @@ struct DgElementArray {
   using array_allocation_tags =
       tmpl::list<domain::Tags::InitialRefinementLevels<volume_dim>>;
 
-  using initialization_tags = Parallel::get_initialization_tags<
-      Parallel::get_initialization_actions_list<phase_dependent_action_list>,
-      array_allocation_tags>;
+  using initialization_tags =
+      tmpl::append<Parallel::get_initialization_tags<
+                       Parallel::get_initialization_actions_list<
+                           phase_dependent_action_list>,
+                       array_allocation_tags>,
+                   tmpl::list<Parallel::Tags::AvoidGlobalProc0>>;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,

--- a/src/Parallel/Main.hpp
+++ b/src/Parallel/Main.hpp
@@ -436,6 +436,15 @@ Main<Metavariables>::Main(CkArgMsg* msg) {
   resource_info_.build_singleton_map(
       *Parallel::local_branch(global_cache_proxy_));
 
+  // Now that the singleton map has been built, we have to replace the
+  // ResourceInfo that was created from options with the one that has all the
+  // correct singleton assignments so simple tags can be created from options
+  // with a valid ResourceInfo.
+  if constexpr (Parallel::detail::using_resource_info<Metavariables>) {
+    get<Parallel::OptionTags::ResourceInfo<Metavariables>>(options_) =
+        resource_info_;
+  }
+
   if constexpr (Algorithm_detail::has_LoadBalancing_v<
                     typename Metavariables::Phase>) {
     at_sync_indicator_proxy_ =

--- a/src/ParallelAlgorithms/Interpolation/InterpolationTarget.hpp
+++ b/src/ParallelAlgorithms/Interpolation/InterpolationTarget.hpp
@@ -14,6 +14,7 @@
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Tags/ResourceInfo.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InterpolationTargetSendPoints.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
 #include "Utilities/PrettyType.hpp"
@@ -292,8 +293,12 @@ struct InterpolationTarget {
                           InterpolationTargetTag>>>,
               Parallel::Actions::TerminatePhase>>>;
 
-  using initialization_tags = Parallel::get_initialization_tags<
-      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+  using initialization_tags =
+      tmpl::append<Parallel::get_initialization_tags<
+                       Parallel::get_initialization_actions_list<
+                           phase_dependent_action_list>>,
+                   tmpl::list<Parallel::Tags::SingletonInfo<InterpolationTarget<
+                       Metavariables, InterpolationTargetTag>>>>;
 
   static void execute_next_phase(
       typename metavariables::Phase next_phase,

--- a/tests/InputFiles/Burgers/Step.yaml
+++ b/tests/InputFiles/Burgers/Step.yaml
@@ -6,6 +6,9 @@
 # Timeout: 5
 # Check: parse;execute
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 AnalyticSolution:
   Step:
     LeftValue: 2.

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski1D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski1D.yaml
@@ -4,6 +4,9 @@
 # Executable: EvolveCurvedScalarWavePlaneWaveMinkowski1D
 # Check: parse;execute
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 AnalyticData:
   ScalarWaveGr:
     Background:

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski2D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski2D.yaml
@@ -4,6 +4,9 @@
 # Executable: EvolveCurvedScalarWavePlaneWaveMinkowski2D
 # Check: parse;execute
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 AnalyticData:
   ScalarWaveGr:
     Background:

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
@@ -14,6 +14,9 @@
 #     SkipColumns: [0, 1, 2]
 #     AbsoluteTolerance: 0.02
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 AnalyticData:
   ScalarWaveGr:
     Background:

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
@@ -16,6 +16,10 @@
 
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons:
+    SphericalSurface:
+      Proc: Auto
+      Exclusive: false
 
 AnalyticData:
   ScalarWaveGr:

--- a/tests/InputFiles/Elasticity/BentBeam.yaml
+++ b/tests/InputFiles/Elasticity/BentBeam.yaml
@@ -13,6 +13,9 @@
 #     SkipColumns: [0, 1, 2]
 #     AbsoluteTolerance: 1.e-8
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 Background:
   BentBeam:
     Length: 2.

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -14,6 +14,9 @@
 #     SkipColumns: [0, 1, 2]
 #     AbsoluteTolerance: 5.e-4
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 Background:
   HalfSpaceMirror:
     BeamWidth: 0.177

--- a/tests/InputFiles/ExportCoordinates/Input1D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input1D.yaml
@@ -7,6 +7,9 @@
 #   ExportCoordinates1DVolume0.h5
 #   ExportCoordinates1DReductions.h5
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 DomainCreator:
   Interval:
     LowerBound: [0]

--- a/tests/InputFiles/ExportCoordinates/Input2D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input2D.yaml
@@ -7,6 +7,9 @@
 #   ExportCoordinates2DVolume0.h5
 #   ExportCoordinates2DReductions.h5
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 DomainCreator:
   Rectangle:
     LowerBound: [-0.5, -0.5]

--- a/tests/InputFiles/ExportCoordinates/Input3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input3D.yaml
@@ -7,6 +7,9 @@
 #   ExportCoordinates3DVolume0.h5
 #   ExportCoordinates3DReductions.h5
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 DomainCreator:
   Brick:
     LowerBound: [-0.5, -0.5, -0.5]

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -7,6 +7,9 @@
 #   ExportTimeDependentCoordinates3DVolume0.h5
 #   ExportTimeDependentCoordinates3DReductions.h5
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 DomainCreator:
   # Parameters are chosen for an equal-mass, non-spinning binary black hole
   # using superposed-Kerr-Schild initial data created with the

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -6,6 +6,13 @@
 
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons:
+    AhA:
+      Proc: Auto
+      Exclusive: true
+    AhB:
+      Proc: Auto
+      Exclusive: true
 
 Evolution:
   InitialTime: 0.0

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -4,6 +4,9 @@
 # Executable: EvolveGhBinaryBlackHole
 # Check: parse
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.01

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
@@ -8,6 +8,9 @@
 #   GhGaugeWave1DVolume0.h5
 #   GhGaugeWave1DReductions.h5
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.002

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
@@ -8,6 +8,9 @@
 #   GhGaugeWave3DVolume0.h5
 #   GhGaugeWave3DReductions.h5
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.0002

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -14,6 +14,9 @@
 #     FileGlob: "GhKerrSchildReductions.h5"
 #     AbsoluteTolerance: 1e2
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.01

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -16,6 +16,10 @@
 
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons:
+    AhA:
+      Proc: Auto
+      Exclusive: false
 
 Evolution:
   InitialTime: 0.0

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -8,6 +8,9 @@
 #   GhMhdBondiMichelVolume0.h5
 #   GhMhdBondiMichelReductions.h5
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.0001

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -10,6 +10,10 @@
 
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons:
+    AhA:
+      Proc: Auto
+      Exclusive: false
 
 Evolution:
   InitialTime: 0.0

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -8,6 +8,9 @@
 #   GhMhdTovStarVolume0.h5
 #   GhMhdTovStarReductions.h5
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.0001

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -4,6 +4,9 @@
 # Executable: EvolveValenciaDivCleanBlastWave
 # Check: parse;execute
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.01

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -6,6 +6,10 @@
 
 ResourceInfo:
   AvoidGlobalProc0: false
+  Singletons:
+    KerrHorizon:
+      Proc: Auto
+      Exclusive: false
 
 Evolution:
   InitialTime: 0.0

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -4,6 +4,9 @@
 # Executable: EvolveValenciaDivCleanFishboneMoncriefDisk
 # Check: parse;execute
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.01

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
@@ -4,6 +4,9 @@
 # Executable: EvolveNewtonianEulerRiemannProblem1D
 # Check: parse;execute
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.0001

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
@@ -4,6 +4,9 @@
 # Executable: EvolveNewtonianEulerRiemannProblem2D
 # Check: parse;execute
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.0001

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
@@ -4,6 +4,9 @@
 # Executable: EvolveNewtonianEulerRiemannProblem3D
 # Check: parse;execute
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.0001

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -13,6 +13,9 @@
 #     SkipColumns: [0, 1, 2]
 #     AbsoluteTolerance: 0.004
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 Background:
   ProductOfSinusoids:
     WaveNumbers: [1]

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -13,6 +13,9 @@
 #     SkipColumns: [0, 1, 2]
 #     AbsoluteTolerance: 0.007
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 Background:
   ProductOfSinusoids:
     WaveNumbers: [1, 1]

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -14,6 +14,9 @@
 #     SkipColumns: [0, 1, 2]
 #     AbsoluteTolerance: 0.004
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 Background:
   ProductOfSinusoids:
     WaveNumbers: [1, 1, 1]

--- a/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
+++ b/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
@@ -6,6 +6,9 @@
 # ExpectedOutput:
 #   M1GreyReductions.h5
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.01

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow1D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow1D.yaml
@@ -4,6 +4,9 @@
 # Executable: EvolveValenciaSmoothFlow1D
 # Check: parse;execute
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.01

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow2D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow2D.yaml
@@ -4,6 +4,9 @@
 # Executable: EvolveValenciaSmoothFlow2D
 # Check: parse;execute
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.001

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow3D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow3D.yaml
@@ -4,6 +4,9 @@
 # Executable: EvolveValenciaSmoothFlow3D
 # Check: parse;execute
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.001

--- a/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
@@ -6,6 +6,9 @@
 # ExpectedOutput:
 #   ScalarAdvectionKrivodonova1DVolume0.h5
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.001

--- a/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
@@ -6,6 +6,9 @@
 # ExpectedOutput:
 #   ScalarAdvectionKuzmin2DVolume0.h5
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.001

--- a/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
@@ -6,6 +6,9 @@
 # ExpectedOutput:
 #   ScalarAdvectionSinusoid1DVolume0.h5
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.001

--- a/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
@@ -4,6 +4,9 @@
 # Executable: EvolveScalarWavePlaneWave1D
 # Check: parse;execute
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 AnalyticSolution:
   PlaneWave:
     WaveVector: [1.0]

--- a/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
@@ -6,6 +6,9 @@
 # ExpectedOutput:
 #   ScalarWavePlaneWave1DEventsAndTriggersExampleVolume.h5
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 AnalyticSolution:
   PlaneWave:
     WaveVector: [1.0]

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -7,6 +7,9 @@
 #   ScalarWavePlaneWave1DObserveExampleVolume.h5
 #   ScalarWavePlaneWave1DObserveExampleReductions.h5
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 AnalyticSolution:
   PlaneWave:
     WaveVector: [1.0]

--- a/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
@@ -6,6 +6,9 @@
 # ExpectedOutput:
 #   ScalarWavePlaneWave2DReductions.h5
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 AnalyticSolution:
   PlaneWave:
     WaveVector: [1.0, 1.0]

--- a/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
@@ -4,6 +4,9 @@
 # Executable: EvolveScalarWavePlaneWave3D
 # Check: parse;execute
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 AnalyticSolution:
   PlaneWave:
     WaveVector: [1.0, 1.0, 1.0]

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -5,6 +5,9 @@
 # Check: parse
 # Timeout: 20
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 Background: &background
   Binary:
     XCoords: [&x_left -8., &x_right 8.]

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -14,6 +14,9 @@
 #     SkipColumns: [0, 1, 2]
 #     AbsoluteTolerance: 0.08
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 Background:
   KerrSchild:
     Mass: 1.

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.yaml
@@ -11,6 +11,9 @@
 # - Multiplied by mass matrix and no mass-lumping
 # - Internal penalty flux with sigma = 1.5 * (N_points - 1)^2 / h
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 DomainCreator:
   Interval:
     LowerBound: [0]

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.yaml
@@ -12,6 +12,9 @@
 # - Mass-lumping: inverse mass matrix is approximated by diagonal
 # - Internal penalty flux with sigma = 1.5 * (N_points - 1)^2 / h
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 DomainCreator:
   Interval:
     LowerBound: [0]

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresPreconditionedAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresPreconditionedAlgorithm.yaml
@@ -13,6 +13,9 @@
 # - The operator is symmetric, which helps the Richardson preconditioner
 #   converge.
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 DomainCreator:
   Interval:
     LowerBound: [0]

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithm.yaml
@@ -14,6 +14,9 @@
 #   restriction operation.
 # - Internal penalty flux with sigma = 1.5 * N_points^2 / h
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 DomainCreator:
   Interval:
     LowerBound: [0]

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithmMassive.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithmMassive.yaml
@@ -5,6 +5,9 @@
 # but the operator includes the mass matrix (with mass-lumping). This is
 # relevant for the multigrid restriction operation.
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 DomainCreator:
   Interval:
     LowerBound: [0]

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridPreconditionedGmresAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridPreconditionedGmresAlgorithm.yaml
@@ -4,6 +4,9 @@
 # This test problem is the same as detailed in `Test_MultigridAlgorithmMassive.yaml`,
 # but the multigrid solver is used to precondition a GMRES solver.
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 DomainCreator:
   Interval:
     LowerBound: [0]

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/Test_DistributedRichardsonAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/Test_DistributedRichardsonAlgorithm.yaml
@@ -11,6 +11,9 @@
 # - Multiplied by mass matrix and no mass-lumping
 # - Internal penalty flux with sigma = 1.5 * (N_points - 1)^2 / h
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 DomainCreator:
   Interval:
     LowerBound: [0]

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.yaml
@@ -12,6 +12,9 @@
 # - Mass-lumping: inverse mass matrix is approximated by diagonal
 # - Internal penalty flux with sigma = 1.5 * (N_points - 1)^2 / h
 
+ResourceInfo:
+  AvoidGlobalProc0: false
+
 DomainCreator:
   Interval:
     LowerBound: [0]


### PR DESCRIPTION
## Proposed changes

Adds the `Parallel::Tags::AvoidGlobalProc0` tag to both the evolution and elliptic DgElementArray parallel component.

Also add the `Parallel::Tags::SingletonInfo` tag to the InterpolationTarget parallel component

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
If your executable has the DgElementArray parallel component, add in the following block to the input file

```yaml
ResourceInfo:
  AvoidGlobalProc0: false
```

If your executable has at least one InterpolationTarget parallel component, add the following under the `ResourceInfo` block in the input file

```yaml
  Singletons:
    TargetName:
      Proc: Auto
      Exclusive: false
```
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
