### PR TITLE
Allow CCE singletons to be placed on specific cores

### DIFF
--- a/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
@@ -32,6 +32,7 @@
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Local.hpp"
 #include "Parallel/Phase.hpp"
+#include "Parallel/Tags/ResourceInfo.hpp"
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
@@ -113,8 +114,9 @@ struct CharacteristicEvolution {
           typename Metavariables::cce_boundary_component>,
       Initialization::Actions::RemoveOptionsAndTerminatePhase>;
 
-  using initialization_tags =
-      Parallel::get_initialization_tags<initialize_action_list>;
+  using initialization_tags = tmpl::push_back<
+      Parallel::get_initialization_tags<initialize_action_list>,
+      Parallel::Tags::SingletonInfo<CharacteristicEvolution<Metavariables>>>;
 
   // the list of actions that occur for each of the hypersurface-integrated
   // Bondi tags

--- a/src/Evolution/Systems/Cce/Components/WorldtubeBoundary.hpp
+++ b/src/Evolution/Systems/Cce/Components/WorldtubeBoundary.hpp
@@ -11,6 +11,7 @@
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Local.hpp"
 #include "Parallel/Phase.hpp"
+#include "Parallel/Tags/ResourceInfo.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
 
 namespace Cce {
@@ -29,7 +30,8 @@ struct WorldtubeComponentBase {
                  Initialization::Actions::RemoveOptionsAndTerminatePhase>;
 
   using initialization_tags =
-      Parallel::get_initialization_tags<initialize_action_list>;
+      tmpl::push_back<Parallel::get_initialization_tags<initialize_action_list>,
+                      Parallel::Tags::SingletonInfo<WorldtubeComponent>>;
 
   using worldtube_boundary_computation_steps = tmpl::list<>;
 

--- a/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
@@ -17,6 +17,15 @@ Evolution:
   InitialTimeStep: 0.01
   InitialSlabSize: 0.8
 
+ResourceInfo:
+  Singletons:
+    CharacteristicEvolution:
+      Proc: Auto
+      Exclusive: false
+    AnalyticWorldtubeBoundary:
+      Proc: Auto
+      Exclusive: false
+
 Observers:
   VolumeFileName: "CharacteristicExtractVolume"
   ReductionFileName: "CharacteristicExtractUnusedReduction"

--- a/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
@@ -17,6 +17,15 @@ Evolution:
   InitialTimeStep: 0.1
   InitialSlabSize: 0.8
 
+ResourceInfo:
+  Singletons:
+    CharacteristicEvolution:
+      Proc: Auto
+      Exclusive: false
+    AnalyticWorldtubeBoundary:
+      Proc: Auto
+      Exclusive: false
+
 Observers:
   VolumeFileName: "CharacteristicExtractVolume"
   ReductionFileName: "CharacteristicExtractUnusedReduction"

--- a/tests/InputFiles/Cce/AnalyticTestLinearizedBondiSachs.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestLinearizedBondiSachs.yaml
@@ -17,6 +17,15 @@ Evolution:
   InitialTimeStep: 0.1
   InitialSlabSize: 0.8
 
+ResourceInfo:
+  Singletons:
+    CharacteristicEvolution:
+      Proc: Auto
+      Exclusive: false
+    AnalyticWorldtubeBoundary:
+      Proc: Auto
+      Exclusive: false
+
 Observers:
   VolumeFileName: "CharacteristicExtractVolume"
   ReductionFileName: "CharacteristicExtractUnusedReduction"

--- a/tests/InputFiles/Cce/AnalyticTestRobinsonTrautman.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestRobinsonTrautman.yaml
@@ -17,6 +17,15 @@ Evolution:
   InitialTimeStep: 0.1
   InitialSlabSize: 0.6
 
+ResourceInfo:
+  Singletons:
+    CharacteristicEvolution:
+      Proc: Auto
+      Exclusive: false
+    AnalyticWorldtubeBoundary:
+      Proc: Auto
+      Exclusive: false
+
 Observers:
   VolumeFileName: "CharacteristicExtractVolume"
   ReductionFileName: "CharacteristicExtractUnusedReduction"

--- a/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
@@ -17,6 +17,15 @@ Evolution:
   InitialTimeStep: 0.1
   InitialSlabSize: 0.8
 
+ResourceInfo:
+  Singletons:
+    CharacteristicEvolution:
+      Proc: Auto
+      Exclusive: false
+    AnalyticWorldtubeBoundary:
+      Proc: Auto
+      Exclusive: false
+
 Observers:
   VolumeFileName: "CharacteristicExtractVolume"
   ReductionFileName: "CharacteristicExtractUnusedReduction"

--- a/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
@@ -17,6 +17,15 @@ Evolution:
   InitialTimeStep: 0.1
   InitialSlabSize: 1.0
 
+ResourceInfo:
+  Singletons:
+    CharacteristicEvolution:
+      Proc: Auto
+      Exclusive: false
+    AnalyticWorldtubeBoundary:
+      Proc: Auto
+      Exclusive: false
+
 Observers:
   VolumeFileName: "CharacteristicExtractVolume"
   ReductionFileName: "CharacteristicExtractUnusedReduction"

--- a/tests/InputFiles/Cce/CharacteristicExtract.yaml
+++ b/tests/InputFiles/Cce/CharacteristicExtract.yaml
@@ -8,6 +8,15 @@ Evolution:
   InitialTimeStep: 0.25
   InitialSlabSize: 10.0
 
+ResourceInfo:
+  Singletons:
+    CharacteristicEvolution:
+      Proc: Auto
+      Exclusive: false
+    H5WorldtubeBoundary:
+      Proc: Auto
+      Exclusive: false
+
 Observers:
   VolumeFileName: "CharacteristicExtractVolume"
   ReductionFileName: "CharacteristicExtractUnusedReduction"


### PR DESCRIPTION
## Proposed changes

For the CCE standalone executables this doesn't really make a difference, but for GH+CCE this helps a lot so that DG elements aren't being stalled so CCE evolution can run on the same core.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
If you have CCE in your executable, add the following block to your input file:
```yaml
ResourceInfo:
  Singletons:
    CharacteristicEvolution:
      Proc: Auto
      Exclusive: false
    BoundaryComponentName:
      Proc: Auto
      Exclusive: false
```

where `BoundaryComponentName` is one of `AnalyticWorldtubeBoundary`, `H5WorldtubeBoundary`, or `GhWorldtubeBoundary` depending on what your boundary component is.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

~Depends on and includes #4050 because the first commit from that PR, which edits Main, is necessary.~

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
