### PR TITLE
Add fallback reconstructor types to finite difference

### DIFF
--- a/src/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
+++ b/src/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   AoWeno.cpp
+  FallbackReconstructorType.cpp
   Minmod.cpp
   MonotonisedCentral.cpp
   Unlimited.cpp
@@ -21,6 +22,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   AoWeno.hpp
+  FallbackReconstructorType.hpp
   FiniteDifference.hpp
   Minmod.hpp
   MonotonisedCentral.hpp

--- a/src/NumericalAlgorithms/FiniteDifference/FallbackReconstructorType.cpp
+++ b/src/NumericalAlgorithms/FiniteDifference/FallbackReconstructorType.cpp
@@ -1,0 +1,47 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/FiniteDifference/FallbackReconstructorType.hpp"
+
+#include <ostream>
+#include <string>
+
+#include "Options/Options.hpp"
+#include "Options/ParseOptions.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+
+std::ostream& fd::reconstruction::operator<<(
+    std::ostream& os,
+    const fd::reconstruction::FallbackReconstructorType recons_type) {
+  switch (recons_type) {
+    case fd::reconstruction::FallbackReconstructorType::Minmod:
+      return os << "Minmod";
+    case fd::reconstruction::FallbackReconstructorType::MonotonisedCentral:
+      return os << "MonotonisedCentral";
+    case fd::reconstruction::FallbackReconstructorType::None:
+      return os << "None";
+    default:  // LCOV_EXCL_LINE
+      // LCOV_EXCL_START
+      ERROR("Missing a case for operator<<(FallbackReconstructorType)");
+      // LCOV_EXCL_STOP
+  }
+}
+
+template <>
+fd::reconstruction::FallbackReconstructorType
+Options::create_from_yaml<fd::reconstruction::FallbackReconstructorType>::
+    create<void>(const Options::Option& options) {
+  const auto recons_type_read = options.parse_as<std::string>();
+  if (recons_type_read == "Minmod") {
+    return fd::reconstruction::FallbackReconstructorType::Minmod;
+  } else if (recons_type_read == "MonotonisedCentral") {
+    return fd::reconstruction::FallbackReconstructorType::MonotonisedCentral;
+  } else if (recons_type_read == "None") {
+    return fd::reconstruction::FallbackReconstructorType::None;
+  }
+  PARSE_ERROR(options.context(),
+              "Failed to convert \""
+                  << recons_type_read
+                  << "\" to FallbackReconstructorType. Expected one of: "
+                     "{Minmod, MonotonisedCentral, None}.");
+}

--- a/src/NumericalAlgorithms/FiniteDifference/FallbackReconstructorType.hpp
+++ b/src/NumericalAlgorithms/FiniteDifference/FallbackReconstructorType.hpp
@@ -1,0 +1,45 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <ostream>
+
+namespace Options {
+class Option;
+template <typename T>
+struct create_from_yaml;
+}  // namespace Options
+
+namespace fd::reconstruction {
+/*!
+ * \ingroup FiniteDifferenceGroup
+ * \brief Possible types of reconstruction routines to fall back to from
+ * higher-order reconstruction when using adaptive method.
+ *
+ * \note FD reconstructions with input arguments or options (e.g. AoWeno,
+ * Wcns5z, ..) are currently not supported as fallback types. We _may_ need it
+ * at some point in the future but it would require using a different option
+ * parsing method (e.g. factory creation).
+ *
+ */
+enum class FallbackReconstructorType { Minmod, MonotonisedCentral, None };
+
+std::ostream& operator<<(
+    std::ostream& os,
+    fd::reconstruction::FallbackReconstructorType recons_type);
+}  // namespace fd::reconstruction
+
+template <>
+struct Options::create_from_yaml<
+    fd::reconstruction::FallbackReconstructorType> {
+  template <typename Metavariables>
+  static fd::reconstruction::FallbackReconstructorType create(
+      const Options::Option& options) {
+    return create<void>(options);
+  }
+};
+template <>
+fd::reconstruction::FallbackReconstructorType
+Options::create_from_yaml<fd::reconstruction::FallbackReconstructorType>::
+    create<void>(const Options::Option& options);

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_FiniteDifference")
 
 set(LIBRARY_SOURCES
   Test_AoWeno53.cpp
+  Test_FallbackReconstructorType.cpp
   Test_Minmod.cpp
   Test_MonotonisedCentral.cpp
   Test_Unlimited.cpp

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_FallbackReconstructorType.cpp
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_FallbackReconstructorType.cpp
@@ -1,0 +1,37 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "Framework/TestCreation.hpp"
+#include "NumericalAlgorithms/FiniteDifference/FallbackReconstructorType.hpp"
+#include "Utilities/GetOutput.hpp"
+
+namespace fd::reconstruction {
+
+SPECTRE_TEST_CASE("Unit.FiniteDifference.FallbackReconstructorType",
+                  "[Unit][NumericalAlgorithms]") {
+  CHECK(FallbackReconstructorType::Minmod ==
+        TestHelpers::test_creation<FallbackReconstructorType>("Minmod"));
+  CHECK(FallbackReconstructorType::MonotonisedCentral ==
+        TestHelpers::test_creation<FallbackReconstructorType>(
+            "MonotonisedCentral"));
+  CHECK(FallbackReconstructorType::None ==
+        TestHelpers::test_creation<FallbackReconstructorType>("None"));
+
+  CHECK(get_output(FallbackReconstructorType::Minmod) == "Minmod");
+  CHECK(get_output(FallbackReconstructorType::MonotonisedCentral) ==
+        "MonotonisedCentral");
+  CHECK(get_output(FallbackReconstructorType::None) == "None");
+
+  CHECK_THROWS_WITH(
+      ([]() {
+        TestHelpers::test_creation<FallbackReconstructorType>("BadType");
+      })(),
+      Catch::Contains(
+          "Failed to convert \"BadType\" to FallbackReconstructorType"));
+}
+
+}  // namespace fd::reconstruction


### PR DESCRIPTION
## Proposed changes

This `enum` class lists possible FD reconstruction methods that can be used as a fallback from higher order methods (e.g. Wcns5z).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
