### PR TITLE
Remove buffer from Ccz4::upper_spatial_z4_constraint

### DIFF
--- a/src/Evolution/Systems/Ccz4/TimeDerivative.cpp
+++ b/src/Evolution/Systems/Ccz4/TimeDerivative.cpp
@@ -63,7 +63,9 @@ void TimeDerivative<Dim>::apply(
     const gsl::not_null<tnsr::ijk<DataVector, Dim>*> field_b_times_field_d,
     const gsl::not_null<tnsr::i<DataVector, Dim>*> field_d_up_times_a_tilde,
     const gsl::not_null<tnsr::I<DataVector, Dim>*>
-        contracted_field_d_up,  // buffer for eq 18 -20
+        contracted_field_d_up,  // temp for eq 18 -20
+    const gsl::not_null<Scalar<DataVector>*>
+        half_conformal_factor_squared,  // temp for eq 25
     const gsl::not_null<tnsr::ij<DataVector, Dim>*>
         conformal_metric_times_field_b,
     const gsl::not_null<tnsr::ijk<DataVector, Dim>*>
@@ -77,9 +79,9 @@ void TimeDerivative<Dim>::apply(
     const gsl::not_null<tnsr::iJ<DataVector, Dim>*>
         d_gamma_hat_minus_contracted_conformal_christoffel,
     const gsl::not_null<tnsr::i<DataVector, Dim>*>
-        contracted_christoffel_second_kind,  // buffer for eq 18 -20
+        contracted_christoffel_second_kind,  // temp for eq 18 -20
     const gsl::not_null<tnsr::ij<DataVector, Dim>*>
-        contracted_d_conformal_christoffel_difference,  // buffer for eq 18 -20
+        contracted_d_conformal_christoffel_difference,  // temp for eq 18 -20
     const gsl::not_null<Scalar<DataVector>*> k_minus_2_theta_c,
     const gsl::not_null<Scalar<DataVector>*> k_minus_k0_minus_2_theta_c,
     const gsl::not_null<tnsr::ii<DataVector, Dim>*> lapse_times_a_tilde,
@@ -112,8 +114,6 @@ void TimeDerivative<Dim>::apply(
         d_contracted_conformal_christoffel_second_kind,  // eq 24
     const gsl::not_null<tnsr::i<DataVector, Dim>*>
         spatial_z4_constraint,  // eq 25
-    const gsl::not_null<Scalar<DataVector>*>
-        upper_spatial_z4_constraint_buffer,  // buffer for eq 25
     const gsl::not_null<tnsr::I<DataVector, Dim>*>
         upper_spatial_z4_constraint,  // eq 25
     const gsl::not_null<tnsr::ij<DataVector, Dim>*>
@@ -277,10 +277,13 @@ void TimeDerivative<Dim>::apply(
       spatial_z4_constraint, conformal_spatial_metric,
       *gamma_hat_minus_contracted_conformal_christoffel);
 
+  // temp for eq 25
+  ::tenex::evaluate(half_conformal_factor_squared,
+                    0.5 * (*conformal_factor_squared)());
+
   // eq 25
   ::Ccz4::upper_spatial_z4_constraint(
-      upper_spatial_z4_constraint, upper_spatial_z4_constraint_buffer,
-      *conformal_factor_squared,
+      upper_spatial_z4_constraint, *half_conformal_factor_squared,
       *gamma_hat_minus_contracted_conformal_christoffel);
 
   // temp for eq 26

--- a/src/Evolution/Systems/Ccz4/TimeDerivative.hpp
+++ b/src/Evolution/Systems/Ccz4/TimeDerivative.hpp
@@ -106,6 +106,7 @@ struct TimeDerivative {
       const gsl::not_null<tnsr::ijk<DataVector, Dim>*> field_b_times_field_d,
       const gsl::not_null<tnsr::i<DataVector, Dim>*> field_d_up_times_a_tilde,
       const gsl::not_null<tnsr::I<DataVector, Dim>*> contracted_field_d_up,
+      const gsl::not_null<Scalar<DataVector>*> half_conformal_factor_squared,
       const gsl::not_null<tnsr::ij<DataVector, Dim>*>
           conformal_metric_times_field_b,
       const gsl::not_null<tnsr::ijk<DataVector, Dim>*>
@@ -151,8 +152,6 @@ struct TimeDerivative {
       const gsl::not_null<tnsr::iJ<DataVector, Dim>*>
           d_contracted_conformal_christoffel_second_kind,
       const gsl::not_null<tnsr::i<DataVector, Dim>*> spatial_z4_constraint,
-      const gsl::not_null<Scalar<DataVector>*>
-          upper_spatial_z4_constraint_buffer,
       const gsl::not_null<tnsr::I<DataVector, Dim>*>
           upper_spatial_z4_constraint,
       const gsl::not_null<tnsr::ij<DataVector, Dim>*>

--- a/src/Evolution/Systems/Ccz4/Z4Constraint.cpp
+++ b/src/Evolution/Systems/Ccz4/Z4Constraint.cpp
@@ -40,30 +40,25 @@ tnsr::i<DataType, Dim, Frame> spatial_z4_constraint(
 template <size_t Dim, typename Frame, typename DataType>
 void upper_spatial_z4_constraint(
     const gsl::not_null<tnsr::I<DataType, Dim, Frame>*> result,
-    const gsl::not_null<Scalar<DataType>*> buffer,
-    const Scalar<DataType>& conformal_factor_squared,
+    const Scalar<DataType>& half_conformal_factor_squared,
     const tnsr::I<DataType, Dim, Frame>&
         gamma_hat_minus_contracted_conformal_christoffel) {
   destructive_resize_components(result,
-                                get_size(get(conformal_factor_squared)));
-  destructive_resize_components(buffer,
-                                get_size(get(conformal_factor_squared)));
+                                get_size(get(half_conformal_factor_squared)));
 
-  ::tenex::evaluate(buffer, 0.5 * conformal_factor_squared());
   ::tenex::evaluate<ti::I>(
-      result,
-      (*buffer)() * gamma_hat_minus_contracted_conformal_christoffel(ti::I));
+      result, half_conformal_factor_squared() *
+                  gamma_hat_minus_contracted_conformal_christoffel(ti::I));
 }
 
 template <size_t Dim, typename Frame, typename DataType>
 tnsr::I<DataType, Dim, Frame> upper_spatial_z4_constraint(
-    const Scalar<DataType>& conformal_factor_squared,
+    const Scalar<DataType>& half_conformal_factor_squared,
     const tnsr::I<DataType, Dim, Frame>&
         gamma_hat_minus_contracted_conformal_christoffel) {
   tnsr::I<DataType, Dim, Frame> result{};
-  Scalar<DataType> buffer{};
-  upper_spatial_z4_constraint(make_not_null(&result), make_not_null(&buffer),
-                              conformal_factor_squared,
+  upper_spatial_z4_constraint(make_not_null(&result),
+                              half_conformal_factor_squared,
                               gamma_hat_minus_contracted_conformal_christoffel);
   return result;
 }
@@ -90,13 +85,12 @@ tnsr::I<DataType, Dim, Frame> upper_spatial_z4_constraint(
   template void Ccz4::upper_spatial_z4_constraint(                       \
       const gsl::not_null<tnsr::I<DTYPE(data), DIM(data), FRAME(data)>*> \
           result,                                                        \
-      const gsl::not_null<Scalar<DTYPE(data)>*> buffer,                  \
-      const Scalar<DTYPE(data)>& conformal_factor_squared,               \
+      const Scalar<DTYPE(data)>& half_conformal_factor_squared,          \
       const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>&                \
           gamma_hat_minus_contracted_conformal_christoffel);             \
   template tnsr::I<DTYPE(data), DIM(data), FRAME(data)>                  \
   Ccz4::upper_spatial_z4_constraint(                                     \
-      const Scalar<DTYPE(data)>& conformal_factor_squared,               \
+      const Scalar<DTYPE(data)>& half_conformal_factor_squared,          \
       const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>&                \
           gamma_hat_minus_contracted_conformal_christoffel);
 

--- a/src/Evolution/Systems/Ccz4/Z4Constraint.hpp
+++ b/src/Evolution/Systems/Ccz4/Z4Constraint.hpp
@@ -60,14 +60,13 @@ tnsr::i<DataType, Dim, Frame> spatial_z4_constraint(
 template <size_t Dim, typename Frame, typename DataType>
 void upper_spatial_z4_constraint(
     const gsl::not_null<tnsr::I<DataType, Dim, Frame>*> result,
-    const gsl::not_null<Scalar<DataType>*> buffer,
-    const Scalar<DataType>& conformal_factor_squared,
+    const Scalar<DataType>& half_conformal_factor_squared,
     const tnsr::I<DataType, Dim, Frame>&
         gamma_hat_minus_contracted_conformal_christoffel);
 
 template <size_t Dim, typename Frame, typename DataType>
 tnsr::I<DataType, Dim, Frame> upper_spatial_z4_constraint(
-    const Scalar<DataType>& conformal_factor_squared,
+    const Scalar<DataType>& half_conformal_factor_squared,
     const tnsr::I<DataType, Dim, Frame>&
         gamma_hat_minus_contracted_conformal_christoffel);
 /// @}

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_TimeDerivative.cpp
@@ -431,6 +431,7 @@ void test_minkowski(const Ccz4::EvolveShift evolve_shift,
   tnsr::i<DataVector, SpatialDim> field_d_up_times_a_tilde_actual(
       used_for_size);
   tnsr::I<DataVector, SpatialDim> contracted_field_d_up_actual(used_for_size);
+  Scalar<DataVector> half_conformal_factor_squared_actual(used_for_size);
   tnsr::ij<DataVector, SpatialDim> conformal_metric_times_field_b_actual(
       used_for_size);
   tnsr::ijk<DataVector, SpatialDim>
@@ -479,7 +480,6 @@ void test_minkowski(const Ccz4::EvolveShift evolve_shift,
   tnsr::iJ<DataVector, SpatialDim>
       d_contracted_conformal_christoffel_second_kind_actual(used_for_size);
   tnsr::i<DataVector, SpatialDim> spatial_z4_constraint_actual(used_for_size);
-  Scalar<DataVector> upper_spatial_z4_constraint_buffer_actual(used_for_size);
   tnsr::I<DataVector, SpatialDim> upper_spatial_z4_constraint_actual(
       used_for_size);
   tnsr::ij<DataVector, SpatialDim> grad_spatial_z4_constraint_actual(
@@ -513,6 +513,7 @@ void test_minkowski(const Ccz4::EvolveShift evolve_shift,
       make_not_null(&field_b_times_field_d_actual),
       make_not_null(&field_d_up_times_a_tilde_actual),
       make_not_null(&contracted_field_d_up_actual),
+      make_not_null(&half_conformal_factor_squared_actual),
       make_not_null(&conformal_metric_times_field_b_actual),
       make_not_null(&conformal_metric_times_symmetrized_d_field_b_actual),
       make_not_null(&conformal_metric_times_trace_a_tilde_actual),
@@ -542,7 +543,6 @@ void test_minkowski(const Ccz4::EvolveShift evolve_shift,
       make_not_null(&contracted_conformal_christoffel_second_kind_actual),
       make_not_null(&d_contracted_conformal_christoffel_second_kind_actual),
       make_not_null(&spatial_z4_constraint_actual),
-      make_not_null(&upper_spatial_z4_constraint_buffer_actual),
       make_not_null(&upper_spatial_z4_constraint_actual),
       make_not_null(&grad_spatial_z4_constraint_actual),
       make_not_null(&ricci_scalar_plus_divergence_z4_constraint_actual), c,
@@ -1041,6 +1041,7 @@ void test_kerrschild(const Ccz4::EvolveShift evolve_shift,
   tnsr::i<DataVector, SpatialDim> field_d_up_times_a_tilde_actual(
       used_for_size);
   tnsr::I<DataVector, SpatialDim> contracted_field_d_up_actual(used_for_size);
+  Scalar<DataVector> half_conformal_factor_squared_actual(used_for_size);
   tnsr::ij<DataVector, SpatialDim> conformal_metric_times_field_b_actual(
       used_for_size);
   tnsr::ijk<DataVector, SpatialDim>
@@ -1089,7 +1090,6 @@ void test_kerrschild(const Ccz4::EvolveShift evolve_shift,
   tnsr::iJ<DataVector, SpatialDim>
       d_contracted_conformal_christoffel_second_kind_actual(used_for_size);
   tnsr::i<DataVector, SpatialDim> spatial_z4_constraint_actual(used_for_size);
-  Scalar<DataVector> upper_spatial_z4_constraint_buffer_actual(used_for_size);
   tnsr::I<DataVector, SpatialDim> upper_spatial_z4_constraint_actual(
       used_for_size);
   tnsr::ij<DataVector, SpatialDim> grad_spatial_z4_constraint_actual(
@@ -1123,6 +1123,7 @@ void test_kerrschild(const Ccz4::EvolveShift evolve_shift,
       make_not_null(&field_b_times_field_d_actual),
       make_not_null(&field_d_up_times_a_tilde_actual),
       make_not_null(&contracted_field_d_up_actual),
+      make_not_null(&half_conformal_factor_squared_actual),
       make_not_null(&conformal_metric_times_field_b_actual),
       make_not_null(&conformal_metric_times_symmetrized_d_field_b_actual),
       make_not_null(&conformal_metric_times_trace_a_tilde_actual),
@@ -1152,7 +1153,6 @@ void test_kerrschild(const Ccz4::EvolveShift evolve_shift,
       make_not_null(&contracted_conformal_christoffel_second_kind_actual),
       make_not_null(&d_contracted_conformal_christoffel_second_kind_actual),
       make_not_null(&spatial_z4_constraint_actual),
-      make_not_null(&upper_spatial_z4_constraint_buffer_actual),
       make_not_null(&upper_spatial_z4_constraint_actual),
       make_not_null(&grad_spatial_z4_constraint_actual),
       make_not_null(&ricci_scalar_plus_divergence_z4_constraint_actual), c,

--- a/tests/Unit/Evolution/Systems/Ccz4/Z4Constraint.py
+++ b/tests/Unit/Evolution/Systems/Ccz4/Z4Constraint.py
@@ -11,7 +11,7 @@ def spatial_z4_constraint(conformal_spatial_metric,
 
 
 def upper_spatial_z4_constraint(
-    conformal_factor_squared,
+    half_conformal_factor_squared,
     gamma_hat_minus_contracted_conformal_christoffel):
-    return (0.5 * conformal_factor_squared *
+    return (half_conformal_factor_squared *
             gamma_hat_minus_contracted_conformal_christoffel)


### PR DESCRIPTION
## Proposed changes

This removes a buffer argument in `Ccz4::upper_spatial_z4_constraint` for computing a temporary expression.

This temporary is only needed in `Ccz4::TimeDerivative::apply` for calling `Ccz4::upper_spatial_z4_constraint`, so the temporary is computed in the time derivative computation, instead, to avoid allocating for the buffer in each call to `Ccz4::upper_spatial_z4_constraint`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
