### PR TITLE
Fix Ccz4 temporary expression calculation

### DIFF
--- a/src/Evolution/Systems/Ccz4/TimeDerivative.cpp
+++ b/src/Evolution/Systems/Ccz4/TimeDerivative.cpp
@@ -310,12 +310,8 @@ void TimeDerivative<Dim>::apply(
       symmetrized_d_field_b,
       0.5 * (d_field_b(ti::k, ti::j, ti::I) + d_field_b(ti::j, ti::k, ti::I)));
 
-  for (size_t k = 0; k < Dim; k++) {
-    contracted_symmetrized_d_field_b->get(k) = d_field_b.get(k, 0, 0);
-    for (size_t i = 1; i < Dim; i++) {
-      contracted_symmetrized_d_field_b->get(k) += d_field_b.get(k, i, i);
-    }
-  }
+  ::tenex::evaluate<ti::k>(contracted_symmetrized_d_field_b,
+                           (*symmetrized_d_field_b)(ti::k, ti::i, ti::I));
 
   ::tenex::evaluate<ti::i, ti::j, ti::k>(
       field_b_times_field_d,


### PR DESCRIPTION
## Proposed changes

This fixes the calculation of a temporary expression in `Ccz4::TimeDerivative::apply`.

The value being computed is the contraction of the 3rd definition in eq 28 [here](https://arxiv.org/pdf/1707.09910.pdf), so the RHS computation should be the contraction of the *symmetrized* derivative, which is what this PR swaps in.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
