### PR TITLE
Fix Charm v7.0.0 AlgorithmArray.def.h patch

### DIFF
--- a/tools/CharmModulePatches/src/Parallel/Algorithms/AlgorithmArray_v7.0.0.def.h.patch
+++ b/tools/CharmModulePatches/src/Parallel/Algorithms/AlgorithmArray_v7.0.0.def.h.patch
@@ -1,11 +1,6 @@
 --- ./AlgorithmArray_orig.def.h	2022-06-16 14:42:37.978886843 -0700
 +++ src/Parallel/Algorithms/AlgorithmArray.def.h	2022-06-16 14:43:04.995671535 -0700
-@@ -547,7 +547,7 @@
-   envelope env;
-   env.setMsgtype(ForArrayEltMsg);
-   env.setTotalsize(0);
+@@ -550,2 +550,2 @@
 -  _TRACE_CREATION_DETAILED(&env, CkIndex_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::template idx_invoke_iterable_action_void<ThisAction, PhaseIndex, DataBoxIndex>());
 +  _TRACE_CREATION_DETAILED(&env, (CkIndex_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::template idx_invoke_iterable_action_void<ThisAction, PhaseIndex, DataBoxIndex>()));
    _TRACE_CREATION_DONE(1);
-   _TRACE_BEGIN_EXECUTE_DETAILED(CpvAccess(curPeEvent),ForArrayEltMsg,(CkIndex_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::template idx_invoke_iterable_action_void<ThisAction, PhaseIndex, DataBoxIndex>()),CkMyPe(), 0, ((CkArrayIndex&)ckGetIndex()).getProjectionID(), obj);
- #if CMK_LBDB_ON


### PR DESCRIPTION
## Proposed changes

Some builds of Charm++ swap the order of the `seTTotalsize` and `setMsgtype`
calls, causing the patch to fail.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
