### PR TITLE
Add MP5 reconstruction to finite difference

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -1705,6 +1705,19 @@ eprint = {https://doi.org/10.1137/0916035}
   primaryClass  = "cs.NA"
 }
 
+@article{Suresh1997,
+  author  = {A. Suresh and H.T. Huynh},
+  doi     = {https://doi.org/10.1006/jcph.1997.5745},
+  issn    = {0021-9991},
+  journal = {Journal of Computational Physics},
+  number  = {1},
+  pages   = {83-99},
+  title   = {Accurate Monotonicity-Preserving Schemes with Runge–Kutta Time
+  Stepping},
+  volume  = {136},
+  year    = {1997}
+}
+
 @article{Szilagyi2009qz,
   author         = "Szilagyi, Bela and Lindblom, Lee and Scheel, Mark A.",
   title          = "{Simulations of Binary Black Hole Mergers Using Spectral

--- a/src/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
+++ b/src/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_sources(
   AoWeno.cpp
   FallbackReconstructorType.cpp
   Minmod.cpp
+  MonotonicityPreserving5.cpp
   MonotonisedCentral.cpp
   Unlimited.cpp
   Wcns5z.cpp
@@ -24,6 +25,7 @@ spectre_target_headers(
   FallbackReconstructorType.hpp
   FiniteDifference.hpp
   Minmod.hpp
+  MonotonicityPreserving5.hpp
   MonotonisedCentral.hpp
   Reconstruct.hpp
   Reconstruct.tpp

--- a/src/NumericalAlgorithms/FiniteDifference/MonotonicityPreserving5.cpp
+++ b/src/NumericalAlgorithms/FiniteDifference/MonotonicityPreserving5.cpp
@@ -1,0 +1,49 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/FiniteDifference/MonotonicityPreserving5.hpp"
+
+#include <array>
+
+#include "NumericalAlgorithms/FiniteDifference/Reconstruct.tpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+// NOLINTNEXTLINE(modernize-concat-nested-namespaces)
+namespace fd::reconstruction {
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data)                                                 \
+  template void reconstruct<MonotonicityPreserving5Reconstructor>(             \
+      gsl::not_null<std::array<gsl::span<double>, DIM(data)>*>                 \
+          reconstructed_upper_side_of_face_vars,                               \
+      gsl::not_null<std::array<gsl::span<double>, DIM(data)>*>                 \
+          reconstructed_lower_side_of_face_vars,                               \
+      const gsl::span<const double>& volume_vars,                              \
+      const DirectionMap<DIM(data), gsl::span<const double>>& ghost_cell_vars, \
+      const Index<DIM(data)>& volume_extents,                                  \
+      const size_t number_of_variables, const double& alpha,                   \
+      const double& epsilon);
+
+namespace detail {
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+}  // namespace detail
+
+#undef INSTANTIATION
+
+#define SIDE(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATION(r, data)                                                 \
+  template void reconstruct_neighbor<                                          \
+      SIDE(data), detail::MonotonicityPreserving5Reconstructor>(               \
+      gsl::not_null<DataVector*> face_data, const DataVector& volume_data,     \
+      const DataVector& neighbor_data, const Index<DIM(data)>& volume_extents, \
+      const Index<DIM(data)>& ghost_data_extents,                              \
+      const Direction<DIM(data)>& direction_to_reconstruct,                    \
+      const double& alpha, const double& epsilon);
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (Side::Upper, Side::Lower))
+
+#undef INSTANTIATION
+#undef SIDE
+#undef DIM
+}  // namespace fd::reconstruction

--- a/src/NumericalAlgorithms/FiniteDifference/MonotonicityPreserving5.hpp
+++ b/src/NumericalAlgorithms/FiniteDifference/MonotonicityPreserving5.hpp
@@ -1,0 +1,194 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+
+#include "NumericalAlgorithms/FiniteDifference/Reconstruct.hpp"
+#include "NumericalAlgorithms/FiniteDifference/Unlimited.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ForceInline.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Math.hpp"
+
+/// \cond
+class DataVector;
+template <size_t>
+class Direction;
+template <size_t Dim, typename T>
+class DirectionMap;
+template <size_t Dim>
+class Index;
+/// \endcond
+
+namespace fd::reconstruction {
+namespace detail {
+struct MonotonicityPreserving5Reconstructor {
+  SPECTRE_ALWAYS_INLINE static std::array<double, 2> pointwise(
+      const double* const q, const int stride, const double alpha,
+      const double epsilon) {
+    using std::abs;
+    using std::max;
+    using std::min;
+
+    // define minmod function for 2 and 4 args
+    const auto minmod2 = [](const double x, const double y) {
+      return 0.5 * (sgn(x) + sgn(y)) * min(abs(x), abs(y));
+    };
+    const auto minmod4 = [](const double w, const double x, const double y,
+                            const double z) {
+      const double sign_w = sgn(w);
+      return 0.125 * (sign_w + sgn(x)) *
+             abs((sign_w + sgn(y)) * (sign_w + sgn(z))) *
+             min(abs(w), min(abs(x), min(abs(y), abs(z))));
+    };
+
+    // first, compute unlimited fifth-order finite difference reconstruction
+    // values
+    auto result = UnlimitedReconstructor<4>::pointwise(q, stride);
+
+    // compute q_{j+1/2}
+    const double q_mp_plus =
+        q[0] + minmod2(q[stride] - q[0], alpha * (q[0] - q[-stride]));
+    // compute q_{j-1/2}
+    const double q_mp_minus =
+        q[0] + minmod2(q[-stride] - q[0], alpha * (q[0] - q[stride]));
+
+    const bool limit_q_plus =
+        ((result[1] - q[0]) * (result[1] - q_mp_plus) > epsilon);
+    const bool limit_q_minus =
+        ((result[0] - q[0]) * (result[0] - q_mp_minus) > epsilon);
+
+    if (limit_q_plus or limit_q_minus) {
+      const double dp = q[2 * stride] + q[0] - 2.0 * q[stride];
+      const double dj = q[stride] + q[-stride] - 2.0 * q[0];
+      const double dm = q[0] + q[-2 * stride] - 2.0 * q[-stride];
+      const double dm4_plus = minmod4(4.0 * dj - dp, 4 * dp - dj, dj, dp);
+      const double dm4_minus = minmod4(4.0 * dj - dm, 4 * dm - dj, dj, dm);
+
+      if (limit_q_plus) {
+        const double q_ul = q[0] + alpha * (q[0] - q[-stride]);
+        const double q_md =
+            0.5 * (q[0] + q[stride] - dm4_plus);  // inline q^{AV}
+        const double q_lc =
+            q[0] + 0.5 * (q[0] - q[-stride]) + 1.3333333333333333 * dm4_minus;
+        const double q_min =
+            max(min(q[0], min(q[stride], q_md)), min(q[0], min(q_ul, q_lc)));
+        const double q_max =
+            min(max(q[0], max(q[stride], q_md)), max(q[0], max(q_ul, q_lc)));
+
+        result[1] = result[1] + minmod2(q_min - result[1], q_max - result[1]);
+      }
+
+      if (limit_q_minus) {
+        const double q_ul = q[0] + alpha * (q[0] - q[stride]);
+        const double q_md =
+            0.5 * (q[0] + q[-stride] - dm4_minus);  // inline q^{AV}
+        const double q_lc =
+            q[0] + 0.5 * (q[0] - q[stride]) + 1.3333333333333333 * dm4_plus;
+        const double q_min =
+            max(min(q[0], min(q[-stride], q_md)), min(q[0], min(q_ul, q_lc)));
+        const double q_max =
+            min(max(q[0], max(q[-stride], q_md)), max(q[0], max(q_ul, q_lc)));
+
+        result[0] = result[0] + minmod2(q_min - result[0], q_max - result[0]);
+      }
+    }
+
+    return result;
+  }
+
+  SPECTRE_ALWAYS_INLINE static constexpr size_t stencil_width() { return 5; }
+};
+}  // namespace detail
+
+/*!
+ * \ingroup FiniteDifferenceGroup
+ * \brief Performs the fifth order monotonicity-preserving (MP5) reconstruction
+ * \cite Suresh1997.
+ *
+ * First, calculate the original interface value \f$q_{j+1/2}^\text{OR}\f$ with
+ * the (unlimited) fifth order finite difference reconstruction
+ *
+ * \f{align}
+ *  q_{j+1/2}^\text{OR} = \frac{1}{128}( 3 q_{j-2} - 20 q_{j-1} + 90 q_{j}
+ *            + 60 q_{j+1} - 5 q_{j+2}) .
+ * \f}
+ *
+ * and compute
+ *
+ * \f{align}
+ *  q^\text{MP} = q_j + \text{minmod}(q_{j+1} - q_j, \alpha(q_j - q_{j-1}))
+ * \f}
+ *
+ * for a given value of \f$\alpha\f$, which is usually set to \f$\alpha=4\f$.
+ *
+ * If \f$ (q_{j+1/2}^\text{OR} - q_j)(q_{j+1/2}^\text{OR} - q^\text{MP}) \leq
+ * \epsilon\f$ where \f$\epsilon\f$ is a small tolerance value, use $q_{1/2}
+ * = q_{j+1/2}^\text{OR}$.
+ *
+ * \note A proper value of \f$\epsilon\f$ may depend on the scale of the
+ * quantity \f$q\f$ to be reconstructed; reference \cite Suresh1997 suggests
+ * 1e-10. For hydro simulations with atmosphere treatment, setting
+ * \f$\epsilon=0.0\f$ would be safe.
+ *
+ * Otherwise, calculate
+ *
+ * \f{align}
+ *  d_{j+1} & = q_{j+2} - 2q_{j+1} + q_{j}       \\
+ *  d_j     & = q_{j+1} - 2q_j + q_{j-1}         \\
+ *  d_{j-1} & = q_{j} - 2q_{j-1} + q_{j-2} ,
+ * \f}
+ *
+ * \f{align}
+ *  d^\text{M4}_{j+1/2} =
+ *                \text{minmod}(4d_j - d_{j+1}, 4d_{j+1}-d_j, d_j, d_{j+1}) \\
+ *  d^\text{M4}_{j-1/2} =
+ *                \text{minmod}(4d_j - d_{j-1}, 4d_{j-1}-d_j, d_j, d_{j-1}),
+ * \f}
+ *
+ * \f{align}
+ *  q^\text{UL} & = q_j + \alpha(q_j - q_{j-1})                             \\
+ *  q^\text{AV} & = (q_j + q_{j+1}) / 2                                     \\
+ *  q^\text{MD} & = q^\text{AV} -  d^\text{M4}_{j+1/2} / 2                  \\
+ *  q^\text{LC} & = q_j + (q_j - q_{j-1}) / 2 + (4/3) d^\text{M4}_{j-1/2}
+ * \f}
+ *
+ * and
+ * \f{align}
+ *  q^\text{min} & = \text{max}[ \text{min}(q_j, q_{j+1}, q^\text{MD}),
+ *                               \text{min}(q_j, q^\text{UL}, q^\text{LC}) ] \\
+ *  q^\text{max} & = \text{min}[ \text{max}(q_j, q_{j+1}, q^\text{MD}),
+ *                               \text{max}(q_j, q^\text{UL}, q^\text{LC}) ].
+ * \f}
+ *
+ * The reconstructed value is given as
+ * \f{align}
+ *  q_{i+1/2} = \text{median}(q_{j+1/2}^\text{OR},  q^\text{min}, q^\text{max})
+ * \f}
+ * where the median function can be expressed as
+ * \f{align}
+ *  \text{median}(x,y,z) = x + \text{minmod}(y-x, z-x).
+ * \f}
+ *
+ */
+template <size_t Dim>
+void monotonicity_preserving_5(
+    const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+        reconstructed_upper_side_of_face_vars,
+    const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+        reconstructed_lower_side_of_face_vars,
+    const gsl::span<const double>& volume_vars,
+    const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
+    const Index<Dim>& volume_extents, const size_t number_of_variables,
+    const double alpha, const double epsilon) {
+  detail::reconstruct<detail::MonotonicityPreserving5Reconstructor>(
+      reconstructed_upper_side_of_face_vars,
+      reconstructed_lower_side_of_face_vars, volume_vars, ghost_cell_vars,
+      volume_extents, number_of_variables, alpha, epsilon);
+}
+}  // namespace fd::reconstruction

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_AoWeno53.cpp
   Test_FallbackReconstructorType.cpp
   Test_Minmod.cpp
+  Test_MonotonicityPreserving5.cpp
   Test_MonotonisedCentral.cpp
   Test_Unlimited.cpp
   Test_Wcns5z.cpp

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/MonotonicityPreserving5.py
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/MonotonicityPreserving5.py
@@ -1,0 +1,79 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+from numpy import asarray, sign
+
+import Reconstruction
+import Minmod  # for minmod() function with 2 args
+
+
+def mp5(v):
+    # define the minmod() function with 4 args
+    def minmod_4(a, b, c, d):
+        return 0.125 * (sign(a) + sign(b)) * np.abs(
+            (sign(a) + sign(c)) *
+            (sign(a) + sign(d))) * np.min(np.abs([a, b, c, d]))
+
+    def mp5_oneside(v, s):
+        alpha = 4.0
+        eps = 1e-10
+
+        j = 2
+
+        vor = (3.0 * v[j - 2 * s] - 20.0 * v[j - s] + 90.0 * v[j] +
+               60.0 * v[j + s] - 5.0 * v[j + 2 * s]) / 128.0
+        vmp = v[j] + Minmod.minmod(v[j + s] - v[j], alpha * (v[j] - v[j - s]))
+
+        if (vor - v[j]) * (vor - vmp) > eps:
+            djm1 = v[j - 2 * s] - 2.0 * v[j - s] + v[j]
+            dj = v[j - s] - 2.0 * v[j] + v[j + s]
+            djp1 = v[j] - 2.0 * v[j + s] + v[j + 2 * s]
+            dm4jph = minmod_4(4.0 * dj - djp1, 4.0 * djp1 - dj, dj, djp1)
+            dm4jmh = minmod_4(4.0 * dj - djm1, 4.0 * djm1 - dj, dj, djm1)
+
+            vul = v[j] + alpha * (v[j] - v[j - s])
+            vav = 0.5 * (v[j] + v[j + s])
+            vmd = vav - 0.5 * dm4jph
+            vlc = v[j] + 0.5 * (v[j] - v[j - s]) + (4.0 / 3.0) * dm4jmh
+
+            vmin = max(np.min([v[j], v[j + s], vmd]), np.min([v[j], vul, vlc]))
+            vmax = min(np.max([v[j], v[j + s], vmd]), np.max([v[j], vul, vlc]))
+
+            return vor + Minmod.minmod(vmin - vor, vmax - vor)
+        else:
+            return vor
+
+    return [mp5_oneside(v, -1), mp5_oneside(v, 1)]
+
+
+def test_mp5(u, extents, dim):
+    def compute_face_values(recons_upper_of_cell, recons_lower_of_cell, v, i,
+                            j, k, dim_to_recons):
+        if dim_to_recons == 0:
+            lower, upper = mp5(
+                asarray([
+                    v[i - 2, j, k], v[i - 1, j, k], v[i, j, k], v[i + 1, j, k],
+                    v[i + 2, j, k]
+                ]))
+            recons_lower_of_cell.append(lower)
+            recons_upper_of_cell.append(upper)
+        if dim_to_recons == 1:
+            lower, upper = mp5(
+                asarray([
+                    v[i, j - 2, k], v[i, j - 1, k], v[i, j, k], v[i, j + 1, k],
+                    v[i, j + 2, k]
+                ]))
+            recons_lower_of_cell.append(lower)
+            recons_upper_of_cell.append(upper)
+        if dim_to_recons == 2:
+            lower, upper = mp5(
+                asarray([
+                    v[i, j, k - 2], v[i, j, k - 1], v[i, j, k], v[i, j, k + 1],
+                    v[i, j, k + 2]
+                ]))
+            recons_lower_of_cell.append(lower)
+            recons_upper_of_cell.append(upper)
+
+    return Reconstruction.reconstruct(u, extents, dim, [2, 2, 2],
+                                      compute_face_values)

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_MonotonicityPreserving5.cpp
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_MonotonicityPreserving5.cpp
@@ -1,0 +1,72 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/Index.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Framework/Pypp.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Helpers/NumericalAlgorithms/FiniteDifference/Exact.hpp"
+#include "Helpers/NumericalAlgorithms/FiniteDifference/Python.hpp"
+#include "NumericalAlgorithms/FiniteDifference/MonotonicityPreserving5.hpp"
+
+namespace {
+
+const double alpha = 4.0;
+const double epsilon = 1e-10;
+
+template <size_t Dim>
+void test() {
+  const auto recons =
+      [](const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+             reconstructed_upper_side_of_face_vars,
+         const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+             reconstructed_lower_side_of_face_vars,
+         const gsl::span<const double>& volume_vars,
+         const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
+         const Index<Dim>& volume_extents, const size_t number_of_variables) {
+        fd::reconstruction::monotonicity_preserving_5(
+            reconstructed_upper_side_of_face_vars,
+            reconstructed_lower_side_of_face_vars, volume_vars, ghost_cell_vars,
+            volume_extents, number_of_variables, alpha, epsilon);
+      };
+  const auto recons_neighbor_data =
+      [](const gsl::not_null<DataVector*> face_data,
+         const DataVector& volume_data, const DataVector& neighbor_data,
+         const Index<Dim>& volume_extents, const Index<Dim>& ghost_data_extents,
+         const Direction<Dim>& direction_to_reconstruct) {
+        if (direction_to_reconstruct.side() == Side::Upper) {
+          fd::reconstruction::reconstruct_neighbor<
+              Side::Upper,
+              fd::reconstruction::detail::MonotonicityPreserving5Reconstructor>(
+              face_data, volume_data, neighbor_data, volume_extents,
+              ghost_data_extents, direction_to_reconstruct, alpha, epsilon);
+        }
+        if (direction_to_reconstruct.side() == Side::Lower) {
+          fd::reconstruction::reconstruct_neighbor<
+              Side::Lower,
+              fd::reconstruction::detail::MonotonicityPreserving5Reconstructor>(
+              face_data, volume_data, neighbor_data, volume_extents,
+              ghost_data_extents, direction_to_reconstruct, alpha, epsilon);
+        }
+      };
+  TestHelpers::fd::reconstruction::test_reconstruction_is_exact_if_in_basis<
+      Dim>(4, 5, 5, recons, recons_neighbor_data);
+  TestHelpers::fd::reconstruction::test_with_python(
+      Index<Dim>{5}, 5, "MonotonicityPreserving5", "test_mp5", recons,
+      recons_neighbor_data);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.FiniteDifference.MonotonicityPreserving5",
+                  "[Unit][NumericalAlgorithms]") {
+  pypp::SetupLocalPythonEnvironment local_python_env(
+      "NumericalAlgorithms/FiniteDifference/");
+  test<1>();
+  test<2>();
+  test<3>();
+}


### PR DESCRIPTION
## Proposed changes

The first commit (moving minmod function in `Minmod.py`) is the same one present at #4058 and I included here as well because it's used for test here too.


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
