### PR TITLE
Increase timeout in RotScaleTrans test

### DIFF
--- a/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
@@ -223,7 +223,9 @@ void test_rotscaletrans_control_system(const double rotation_eps = 5.0e-5) {
 }
 }  // namespace
 
-// [[Timeout, 15]]
+// Currently the test takes a long time because the logic for the control system
+// isn't the most optimal. This should be fixed in the near future.
+// [[Timeout, 25]]
 SPECTRE_TEST_CASE("Unit.ControlSystem.Systems.RotScaleTrans",
                   "[ControlSystem][Unit]") {
   // For rotation deriv order 2, we need a different epsilon because controlling


### PR DESCRIPTION
## Proposed changes

This is a fairly large increase in the timeout time just to avoid having to change it again. I am currently working on the control system logic so that this test (and the whole control system in general) damps things out faster than it currently does. Once that is in the timeout time can be reduced.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
