### PR TITLE
Use smaller random values for sin argument

### DIFF
--- a/tests/Unit/Utilities/Test_Functional.cpp
+++ b/tests/Unit/Utilities/Test_Functional.cpp
@@ -234,7 +234,7 @@ void test_functional_combinations(const gsl::not_null<Gen*> gen) {
       [](const auto& w, const auto& x, const auto& y, const auto& z) {
         return w * sin(x + y * z);
       },
-      gen, generic, std::make_index_sequence<4>());
+      gen, small, std::make_index_sequence<4>());
   // This function needs the distribution to be `small` to avoid rare
   // accumulation of error
   test_functional_against_function<Multiplies<Plus<Plus<>, Plus<>>, Identity>,


### PR DESCRIPTION
It seems that some implementations lose precision near large multiples
of pi.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
