### PR TITLE
Generalize control system test helper

### DIFF
--- a/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
@@ -22,6 +22,7 @@ void test_expansion_control_error() {
   constexpr size_t deriv_order = 2;
   using metavars = TestHelpers::MockMetavars<0, 0, deriv_order>;
   using element_component = typename metavars::element_component;
+  using expansion_system = typename metavars::expansion_system;
 
   // Global things
   domain::FunctionsOfTime::register_derived_with_charm();
@@ -63,7 +64,8 @@ void test_expansion_control_error() {
   auto& initial_functions_of_time = system_helper.initial_functions_of_time();
   auto& initial_measurement_timescales =
       system_helper.initial_measurement_timescales();
-  const std::string& expansion_name = system_helper.expansion_name();
+  const std::string expansion_name =
+      system_helper.template name<expansion_system>();
 
   // Setup runner and element component because it's the easiest way to get the
   // global cache
@@ -90,7 +92,6 @@ void test_expansion_control_error() {
   QueueTuple fake_measurement_tuple{DataVector{pos_A_x, 0.0, 0.0},
                                     DataVector{pos_B_x, 0.0, 0.0}};
 
-  using expansion_system = typename metavars::expansion_system;
   using ControlError = expansion_system::control_error;
 
   // This is before the first expiration time

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
@@ -54,8 +54,9 @@ void test_expansion_control_error() {
       "    ControlError:\n";
 
   // Initialize everything within the system helper
-  system_helper.setup_control_system_test(initial_time, initial_separation,
-                                          input_options);
+  system_helper.setup_control_system_test(
+      initial_time, initial_separation, input_options,
+      TestHelpers::initialize_expansion_functions_of_time<expansion_system>);
 
   // Get references to everything that was set up inside the system helper. The
   // domain and two functions of time are not const references because they need

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
@@ -26,6 +26,7 @@ void test_rotation_control_error() {
   constexpr size_t deriv_order = 2;
   using metavars = TestHelpers::MockMetavars<0, deriv_order, 0>;
   using element_component = typename metavars::element_component;
+  using rotation_system = typename metavars::rotation_system;
   MAKE_GENERATOR(gen);
 
   // Global things
@@ -68,7 +69,8 @@ void test_rotation_control_error() {
   auto& initial_functions_of_time = system_helper.initial_functions_of_time();
   auto& initial_measurement_timescales =
       system_helper.initial_measurement_timescales();
-  const std::string& rotation_name = system_helper.rotation_name();
+  const std::string rotation_name =
+      system_helper.template name<rotation_system>();
 
   // Setup runner and element component because it's the easiest way to get the
   // global cache
@@ -90,7 +92,6 @@ void test_rotation_control_error() {
   const DataVector pos_B{{2.0, 3.0, 6.0}};
   QueueTuple fake_measurement_tuple{pos_A, pos_B};
 
-  using rotation_system = typename metavars::rotation_system;
   using ControlError = rotation_system::control_error;
 
   // This is before the first expiration time

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
@@ -59,8 +59,9 @@ void test_rotation_control_error() {
       "    ControlError:\n";
 
   // Initialize everything within the system helper
-  system_helper.setup_control_system_test(initial_time, initial_separation,
-                                          input_options);
+  system_helper.setup_control_system_test(
+      initial_time, initial_separation, input_options,
+      TestHelpers::initialize_rotation_functions_of_time<rotation_system>);
 
   // Get references to everything that was set up inside the system helper. The
   // domain and two functions of time are not const references because they need

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Translation.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Translation.cpp
@@ -60,8 +60,10 @@ void test_translation_control_error() {
       "    ControlError:\n";
 
   // Initialize everything within the system helper
-  system_helper.setup_control_system_test(initial_time, initial_separation,
-                                          input_options);
+  system_helper.setup_control_system_test(
+      initial_time, initial_separation, input_options,
+      TestHelpers::initialize_translation_functions_of_time<
+          translation_system>);
 
   // Get references to everything that was set up inside the system helper. The
   // domain and two functions of time are not const references because they need

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Translation.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Translation.cpp
@@ -28,6 +28,7 @@ void test_translation_control_error() {
   constexpr size_t deriv_order = 2;
   using metavars = TestHelpers::MockMetavars<deriv_order, 0, 0>;
   using element_component = typename metavars::element_component;
+  using translation_system = typename metavars::translation_system;
 
   // Global things
   domain::FunctionsOfTime::register_derived_with_charm();
@@ -69,7 +70,8 @@ void test_translation_control_error() {
   auto& initial_functions_of_time = system_helper.initial_functions_of_time();
   auto& initial_measurement_timescales =
       system_helper.initial_measurement_timescales();
-  const std::string& translation_name = system_helper.translation_name();
+  const std::string translation_name =
+      system_helper.template name<translation_system>();
 
   // Setup runner and element component because it's the easiest way to get the
   // global cache
@@ -92,7 +94,6 @@ void test_translation_control_error() {
   const DataVector grid_B{{initial_separation / 2.0, 0.0, 0.0}};
   QueueTuple fake_measurement_tuple{pos_A, pos_B};
 
-  using translation_system = typename metavars::translation_system;
   using ControlError = translation_system::control_error;
 
   // This is before the first expiration time

--- a/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
@@ -40,6 +40,7 @@ void test_expansion_control_system() {
   using expansion_component = typename metavars::expansion_component;
   using element_component = typename metavars::element_component;
   using observer_component = typename metavars::observer_component;
+  using expansion_system = typename metavars::expansion_system;
   MAKE_GENERATOR(gen);
 
   // Global things
@@ -85,7 +86,8 @@ void test_expansion_control_system() {
   auto& initial_functions_of_time = system_helper.initial_functions_of_time();
   auto& initial_measurement_timescales =
       system_helper.initial_measurement_timescales();
-  const auto& init_exp_tuple = system_helper.init_exp_tuple();
+  const auto& init_exp_tuple =
+      system_helper.template init_tuple<expansion_system>();
 
   // Setup runner and all components
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
@@ -105,7 +107,8 @@ void test_expansion_control_system() {
 
   const BinaryTrajectories binary_trajectories{initial_separation};
 
-  const std::string& expansion_name = system_helper.expansion_name();
+  const std::string expansion_name =
+      system_helper.template name<expansion_system>();
 
   // Create coordinate maps for mapping the PN expansion to the "grid" frame
   // where the control system does its calculations

--- a/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
@@ -76,8 +76,9 @@ void test_expansion_control_system() {
       "    ControlError:\n";
 
   // Initialize everything within the system helper
-  system_helper.setup_control_system_test(initial_time, initial_separation,
-                                          input_options);
+  system_helper.setup_control_system_test(
+      initial_time, initial_separation, input_options,
+      TestHelpers::initialize_expansion_functions_of_time<expansion_system>);
 
   // Get references to everything that was set up inside the system helper. The
   // domain and two functions of time are not const references because they need

--- a/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstddef>
 #include <string>
+#include <tuple>
 
 #include "ControlSystem/Systems/Expansion.hpp"
 #include "ControlSystem/Tags.hpp"
@@ -130,15 +131,22 @@ void test_expansion_control_system() {
         {-0.5 * separation, 0.0, 0.0}, {0.5 * separation, 0.0, 0.0}};
   };
 
+  const auto horizon_function = [&position_function, &runner,
+                                 &coord_map](const double time) {
+    return TestHelpers::build_horizons_for_basic_control_systems<
+        element_component>(time, runner, position_function, coord_map);
+  };
+
   // Run the actual control system test.
   system_helper.run_control_system_test(runner, final_time, make_not_null(&gen),
-                                        position_function, coord_map);
+                                        horizon_function, 2);
 
   // Grab results
-  const std::array<double, 3>& grid_position_of_a =
-      system_helper.grid_position_of_a();
-  const std::array<double, 3>& grid_position_of_b =
-      system_helper.grid_position_of_b();
+  std::array<double, 3> grid_position_of_a;
+  std::array<double, 3> grid_position_of_b;
+  std::tie(grid_position_of_a, grid_position_of_b) =
+      TestHelpers::grid_frame_horizon_centers_for_basic_control_systems<
+          element_component>(final_time, runner, position_function, coord_map);
 
   // Our expected positions are just the initial positions
   const std::array<double, 3> expected_grid_position_of_a{

--- a/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
@@ -80,6 +80,9 @@ void test_rotscaletrans_control_system(const double rotation_eps = 5.0e-5) {
   using translation_component = typename metavars::translation_component;
   using rotation_component = typename metavars::rotation_component;
   using expansion_component = typename metavars::expansion_component;
+  using translation_system = typename metavars::translation_system;
+  using rotation_system = typename metavars::rotation_system;
+  using expansion_system = typename metavars::expansion_system;
   MAKE_GENERATOR(gen);
 
   // Global things
@@ -93,9 +96,12 @@ void test_rotscaletrans_control_system(const double rotation_eps = 5.0e-5) {
   // Set up the system helper
   control_system::TestHelpers::SystemHelper<metavars> system_helper{};
 
-  const std::string& translation_name = system_helper.translation_name();
-  const std::string& rotation_name = system_helper.rotation_name();
-  const std::string& expansion_name = system_helper.expansion_name();
+  const std::string translation_name =
+      system_helper.template name<translation_system>();
+  const std::string rotation_name =
+      system_helper.template name<rotation_system>();
+  const std::string expansion_name =
+      system_helper.template name<expansion_system>();
 
   std::string input_options =
       "Evolution:\n"
@@ -117,9 +123,12 @@ void test_rotscaletrans_control_system(const double rotation_eps = 5.0e-5) {
   auto& initial_functions_of_time = system_helper.initial_functions_of_time();
   auto& initial_measurement_timescales =
       system_helper.initial_measurement_timescales();
-  const auto& init_trans_tuple = system_helper.init_trans_tuple();
-  const auto& init_rot_tuple = system_helper.init_rot_tuple();
-  const auto& init_exp_tuple = system_helper.init_exp_tuple();
+  const auto& init_trans_tuple =
+      system_helper.template init_tuple<translation_system>();
+  const auto& init_rot_tuple =
+      system_helper.template init_tuple<rotation_system>();
+  const auto& init_exp_tuple =
+      system_helper.template init_tuple<expansion_system>();
 
   // Setup runner and all components
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;

--- a/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <memory>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <utility>
 
@@ -194,15 +195,22 @@ void test_rotscaletrans_control_system(const double rotation_eps = 5.0e-5) {
     return binary_trajectories.positions(time);
   };
 
+  const auto horizon_function = [&position_function, &runner,
+                                 &coord_map](const double time) {
+    return TestHelpers::build_horizons_for_basic_control_systems<
+        element_component>(time, runner, position_function, coord_map);
+  };
+
   // Run the actual control system test.
   system_helper.run_control_system_test(runner, final_time, make_not_null(&gen),
-                                        position_function, coord_map);
+                                        horizon_function, 2);
 
   // Grab results
-  const std::array<double, 3> grid_position_of_a =
-      system_helper.grid_position_of_a();
-  const std::array<double, 3> grid_position_of_b =
-      system_helper.grid_position_of_b();
+  std::array<double, 3> grid_position_of_a;
+  std::array<double, 3> grid_position_of_b;
+  std::tie(grid_position_of_a, grid_position_of_b) =
+      TestHelpers::grid_frame_horizon_centers_for_basic_control_systems<
+          element_component>(final_time, runner, position_function, coord_map);
 
   // Our expected positions are just the initial positions
   const std::array<double, 3> expected_grid_position_of_a{

--- a/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
@@ -5,7 +5,9 @@
 
 #include <array>
 #include <cstddef>
+#include <memory>
 #include <string>
+#include <unordered_map>
 #include <utility>
 
 #include "ControlSystem/Tags.hpp"
@@ -112,9 +114,27 @@ void test_rotscaletrans_control_system(const double rotation_eps = 5.0e-5) {
   input_options += create_input_string(rotation_name);
   input_options += create_input_string(expansion_name);
 
+  const auto initialize_functions_of_time =
+      [](const gsl::not_null<std::unordered_map<
+             std::string,
+             std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>*>
+             functions_of_time,
+         const double local_initial_time,
+         const std::unordered_map<std::string, double>&
+             initial_expiration_times) {
+        TestHelpers::initialize_expansion_functions_of_time<expansion_system>(
+            functions_of_time, local_initial_time, initial_expiration_times);
+        TestHelpers::initialize_rotation_functions_of_time<rotation_system>(
+            functions_of_time, local_initial_time, initial_expiration_times);
+        return TestHelpers::initialize_translation_functions_of_time<
+            translation_system>(functions_of_time, local_initial_time,
+                                initial_expiration_times);
+      };
+
   // Initialize everything within the system helper
   system_helper.setup_control_system_test(initial_time, initial_separation,
-                                          input_options);
+                                          input_options,
+                                          initialize_functions_of_time);
 
   // Get references to everything that was set up inside the system helper. The
   // domain and two functions of time are not const references because they need

--- a/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
@@ -41,6 +41,7 @@ void test_rotation_control_system(const bool newtonian) {
   using metavars = TestHelpers::MockMetavars<0, DerivOrder, 0>;
   using rotation_component = typename metavars::rotation_component;
   using element_component = typename metavars::element_component;
+  using rotation_system = typename metavars::rotation_system;
   MAKE_GENERATOR(gen);
 
   // Global things
@@ -86,7 +87,8 @@ void test_rotation_control_system(const bool newtonian) {
   auto& initial_functions_of_time = system_helper.initial_functions_of_time();
   auto& initial_measurement_timescales =
       system_helper.initial_measurement_timescales();
-  const auto& init_rot_tuple = system_helper.init_rot_tuple();
+  const auto& init_rot_tuple =
+      system_helper.template init_tuple<rotation_system>();
 
   // Setup runner and all components
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
@@ -105,7 +107,8 @@ void test_rotation_control_system(const bool newtonian) {
   const BinaryTrajectories binary_trajectories{
       initial_separation, {0.0, 0.0, 0.0}, newtonian};
 
-  const std::string& rotation_name = system_helper.rotation_name();
+  const std::string rotation_name =
+      system_helper.template name<rotation_system>();
 
   // Create coordinate map for mapping the PN rotation to the "grid" frame
   // where the control system does its calculations

--- a/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstddef>
 #include <string>
+#include <tuple>
 
 #include "ControlSystem/Systems/Rotation.hpp"
 #include "ControlSystem/Tags.hpp"
@@ -126,15 +127,22 @@ void test_rotation_control_system(const bool newtonian) {
     return binary_trajectories.positions_no_expansion(time);
   };
 
+  const auto horizon_function = [&position_function, &runner,
+                                 &coord_map](const double time) {
+    return TestHelpers::build_horizons_for_basic_control_systems<
+        element_component>(time, runner, position_function, coord_map);
+  };
+
   // Run the actual control system test.
   system_helper.run_control_system_test(runner, final_time, make_not_null(&gen),
-                                        position_function, coord_map);
+                                        horizon_function, 2);
 
   // Grab results
-  const std::array<double, 3> grid_position_of_a =
-      system_helper.grid_position_of_a();
-  const std::array<double, 3> grid_position_of_b =
-      system_helper.grid_position_of_b();
+  std::array<double, 3> grid_position_of_a;
+  std::array<double, 3> grid_position_of_b;
+  std::tie(grid_position_of_a, grid_position_of_b) =
+      TestHelpers::grid_frame_horizon_centers_for_basic_control_systems<
+          element_component>(final_time, runner, position_function, coord_map);
 
   // Our expected positions are just the initial positions
   const std::array<double, 3> expected_grid_position_of_a{

--- a/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
@@ -77,8 +77,9 @@ void test_rotation_control_system(const bool newtonian) {
       "    ControlError:\n";
 
   // Initialize everything within the system helper
-  system_helper.setup_control_system_test(initial_time, initial_separation,
-                                          input_options);
+  system_helper.setup_control_system_test(
+      initial_time, initial_separation, input_options,
+      TestHelpers::initialize_rotation_functions_of_time<rotation_system>);
 
   // Get references to everything that was set up inside the system helper. The
   // domain and two functions of time are not const references because they need

--- a/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
@@ -83,8 +83,10 @@ void test_translation_control_system() {
       "    ControlError:\n";
 
   // Initialize everything within the system helper
-  system_helper.setup_control_system_test(initial_time, initial_separation,
-                                          input_options);
+  system_helper.setup_control_system_test(
+      initial_time, initial_separation, input_options,
+      TestHelpers::initialize_translation_functions_of_time<
+          translation_system>);
 
   // Get references to everything that was set up inside the system helper. The
   // domain and two functions of time are not const references because they need

--- a/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <memory>
 #include <string>
+#include <tuple>
 #include <utility>
 
 #include "ControlSystem/Systems/Translation.hpp"
@@ -134,15 +135,22 @@ void test_translation_control_system() {
         -init_pos + velocity * time, init_pos + velocity * time};
   };
 
+  const auto horizon_function = [&position_function, &runner,
+                                 &coord_map](const double time) {
+    return TestHelpers::build_horizons_for_basic_control_systems<
+        element_component>(time, runner, position_function, coord_map);
+  };
+
   // Run the actual control system test.
   system_helper.run_control_system_test(runner, final_time, make_not_null(&gen),
-                                        position_function, coord_map);
+                                        horizon_function, 2);
 
   // Grab results
-  const std::array<double, 3> grid_position_of_a =
-      system_helper.grid_position_of_a();
-  const std::array<double, 3> grid_position_of_b =
-      system_helper.grid_position_of_b();
+  std::array<double, 3> grid_position_of_a;
+  std::array<double, 3> grid_position_of_b;
+  std::tie(grid_position_of_a, grid_position_of_b) =
+      TestHelpers::grid_frame_horizon_centers_for_basic_control_systems<
+          element_component>(final_time, runner, position_function, coord_map);
 
   // Our expected positions are just the initial positions
   const std::array<double, 3> expected_grid_position_of_a{

--- a/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
@@ -47,6 +47,7 @@ void test_translation_control_system() {
   using metavars = TestHelpers::MockMetavars<DerivOrder, 0, 0>;
   using translation_component = typename metavars::translation_component;
   using element_component = typename metavars::element_component;
+  using translation_system = typename metavars::translation_system;
   MAKE_GENERATOR(gen);
 
   // Global things
@@ -92,8 +93,10 @@ void test_translation_control_system() {
   auto& initial_functions_of_time = system_helper.initial_functions_of_time();
   auto& initial_measurement_timescales =
       system_helper.initial_measurement_timescales();
-  const auto& init_trans_tuple = system_helper.init_trans_tuple();
-  const std::string& translation_name = system_helper.translation_name();
+  const auto& init_trans_tuple =
+      system_helper.template init_tuple<translation_system>();
+  const std::string translation_name =
+      system_helper.template name<translation_system>();
 
   // Setup runner and all components
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;

--- a/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
+++ b/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
@@ -143,9 +143,9 @@ struct MockMetavars {
   static constexpr bool using_translation = TranslationDerivOrder != 0;
 
   // Even if we aren't using certain control systems, we still need valid deriv
-  // orders becuse everything is constructed by default in the SystemHelper. The
-  // bool above just determines if the functions of time are actually created or
-  // not because that's what matters
+  // orders because everything is constructed by default in the SystemHelper.
+  // The bool above just determines if the functions of time are actually
+  // created or not because that's what matters
   static constexpr size_t exp_deriv_order =
       using_expansion ? ExpansionDerivOrder : 2;
   static constexpr size_t rot_deriv_order =
@@ -187,7 +187,7 @@ struct MockMetavars {
  * Ideally we'd construct the runner here and just pass that to the test to
  * simplify as must of the work as possible, but MockRuntimeSystems aren't
  * copy- or move-able so we have to make the necessary info available. The
- * simplist way to do this was to have functions that return references to the
+ * simplest way to do this was to have functions that return references to the
  * member variables.
  *
  * \note Translation control isn't supported yet. It will be added in the


### PR DESCRIPTION
## Proposed changes

Previously, anytime a new control system was added, you had to edit the `control_system::TestHelpers::SystemHelper` struct and add code specifically for that control system. This generalizes the test helper to instead be a wrapper around the basic setup/measurement infrastructure. It takes functions that do all the specific calculations. Some helper functions were defined for the basic control systems since they all use similar calculations for the positions of the horizons.

There shouldn't be any change in the results of tests. This was basically just moving code around and generalizing. I broke it up into smaller commits so it was easier to see what I did. These all build and pass tests on their own.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
