### PR TITLE
Add derived TensorExpression type for the Kronecker delta

### DIFF
--- a/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
+++ b/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
@@ -294,10 +294,11 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
           typename detail::AddSubType<T1, T2>::symmetry,
           typename detail::AddSubType<T1, T2>::index_list,
           typename detail::AddSubType<T1, T2>::tensorindex_list> {
-  static_assert(std::is_same<typename T1::type, typename T2::type>::value or
-                    std::is_same<T1, NumberAsExpression>::value or
-                    std::is_same<T2, NumberAsExpression>::value,
-                "Cannot add or subtract Tensors holding different data types.");
+  static_assert(
+      std::is_same<typename T1::type, typename T2::type>::value or
+          std::is_base_of<MarkAsDoubleValuedLeafExpression, T1>::value or
+          std::is_base_of<MarkAsDoubleValuedLeafExpression, T2>::value,
+      "Cannot add or subtract Tensors holding different data types.");
   static_assert(
       detail::IndexPropertyCheck<typename T1::index_list,
                                  typename T2::index_list, ArgsList1<Args1...>,
@@ -426,10 +427,10 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
   template <typename LhsTensor>
   SPECTRE_ALWAYS_INLINE void assert_lhs_tensor_not_in_rhs_expression(
       const gsl::not_null<LhsTensor*> lhs_tensor) const {
-    if constexpr (not std::is_base_of_v<NumberAsExpression, T1>) {
+    if constexpr (not std::is_base_of_v<MarkAsNonTensorLeafExpression, T1>) {
       t1_.assert_lhs_tensor_not_in_rhs_expression(lhs_tensor);
     }
-    if constexpr (not std::is_base_of_v<NumberAsExpression, T2>) {
+    if constexpr (not std::is_base_of_v<MarkAsNonTensorLeafExpression, T2>) {
       t2_.assert_lhs_tensor_not_in_rhs_expression(lhs_tensor);
     }
   }
@@ -443,11 +444,11 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
   template <typename LhsTensorIndices, typename LhsTensor>
   SPECTRE_ALWAYS_INLINE void assert_lhs_tensorindices_same_in_rhs(
       const gsl::not_null<LhsTensor*> lhs_tensor) const {
-    if constexpr (not std::is_base_of_v<NumberAsExpression, T1>) {
+    if constexpr (not std::is_base_of_v<MarkAsNonTensorLeafExpression, T1>) {
       t1_.template assert_lhs_tensorindices_same_in_rhs<LhsTensorIndices>(
           lhs_tensor);
     }
-    if constexpr (not std::is_base_of_v<NumberAsExpression, T2>) {
+    if constexpr (not std::is_base_of_v<MarkAsNonTensorLeafExpression, T2>) {
       t2_.template assert_lhs_tensorindices_same_in_rhs<LhsTensorIndices>(
           lhs_tensor);
     }

--- a/src/DataStructures/Tensor/Expressions/CMakeLists.txt
+++ b/src/DataStructures/Tensor/Expressions/CMakeLists.txt
@@ -10,6 +10,8 @@ spectre_target_headers(
   Divide.hpp
   Evaluate.hpp
   IndexPropertyCheck.hpp
+  KroneckerDelta.hpp
+  KroneckerDeltaAsExpression.hpp
   LhsTensorSymmAndIndices.hpp
   Negate.hpp
   NumberAsExpression.hpp

--- a/src/DataStructures/Tensor/Expressions/Contract.hpp
+++ b/src/DataStructures/Tensor/Expressions/Contract.hpp
@@ -558,7 +558,7 @@ struct TensorContract
   template <typename LhsTensor>
   SPECTRE_ALWAYS_INLINE void assert_lhs_tensor_not_in_rhs_expression(
       const gsl::not_null<LhsTensor*> lhs_tensor) const {
-    if constexpr (not std::is_base_of_v<NumberAsExpression, T>) {
+    if constexpr (not std::is_base_of_v<MarkAsNonTensorLeafExpression, T>) {
       t_.assert_lhs_tensor_not_in_rhs_expression(lhs_tensor);
     }
   }
@@ -572,7 +572,7 @@ struct TensorContract
   template <typename LhsTensorIndices, typename LhsTensor>
   SPECTRE_ALWAYS_INLINE void assert_lhs_tensorindices_same_in_rhs(
       const gsl::not_null<LhsTensor*> lhs_tensor) const {
-    if constexpr (not std::is_base_of_v<NumberAsExpression, T>) {
+    if constexpr (not std::is_base_of_v<MarkAsNonTensorLeafExpression, T>) {
       t_.template assert_lhs_tensorindices_same_in_rhs<LhsTensorIndices>(
           lhs_tensor);
     }

--- a/src/DataStructures/Tensor/Expressions/Divide.hpp
+++ b/src/DataStructures/Tensor/Expressions/Divide.hpp
@@ -143,10 +143,10 @@ struct Divide : public TensorExpression<
   template <typename LhsTensor>
   SPECTRE_ALWAYS_INLINE void assert_lhs_tensor_not_in_rhs_expression(
       const gsl::not_null<LhsTensor*> lhs_tensor) const {
-    if constexpr (not std::is_base_of_v<NumberAsExpression, T1>) {
+    if constexpr (not std::is_base_of_v<MarkAsNonTensorLeafExpression, T1>) {
       t1_.assert_lhs_tensor_not_in_rhs_expression(lhs_tensor);
     }
-    if constexpr (not std::is_base_of_v<NumberAsExpression, T2>) {
+    if constexpr (not std::is_base_of_v<MarkAsNonTensorLeafExpression, T2>) {
       t2_.assert_lhs_tensor_not_in_rhs_expression(lhs_tensor);
     }
   }
@@ -160,10 +160,10 @@ struct Divide : public TensorExpression<
   template <typename LhsTensorIndices, typename LhsTensor>
   SPECTRE_ALWAYS_INLINE void assert_lhs_tensorindices_same_in_rhs(
       const gsl::not_null<LhsTensor*> lhs_tensor) const {
-    if constexpr (not std::is_base_of_v<NumberAsExpression, T1>) {
+    if constexpr (not std::is_base_of_v<MarkAsNonTensorLeafExpression, T1>) {
       t1_.assert_lhs_tensorindices_same_in_rhs(lhs_tensor);
     }
-    if constexpr (not std::is_base_of_v<NumberAsExpression, T2>) {
+    if constexpr (not std::is_base_of_v<MarkAsNonTensorLeafExpression, T2>) {
       t2_.assert_lhs_tensorindices_same_in_rhs(lhs_tensor);
     }
   }

--- a/src/DataStructures/Tensor/Expressions/KroneckerDelta.hpp
+++ b/src/DataStructures/Tensor/Expressions/KroneckerDelta.hpp
@@ -1,0 +1,109 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines Kronecker delta objects that can be used in a `TensorExpression`
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/Expressions/NumberAsExpression.hpp"
+#include "DataStructures/Tensor/Expressions/TensorIndex.hpp"
+#include "DataStructures/Tensor/Expressions/TimeIndex.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Symmetry.hpp"
+
+namespace tenex {
+template <typename K, typename TensorIndex1, typename TensorIndex2>
+struct KroneckerDeltaAsExpression;
+
+/// \ingroup TensorExpressionsGroup
+/// \brief Defines Kronecker delta objects that can be used in a
+/// `TensorExpression`
+///
+/// \details
+/// This is not a derived `TensorExpression` type, but when used with generic
+/// indices, you get a derived `TensorExpression` representing the Kronecker
+/// delta with those generic indices. Put another way, `KroneckerDelta` is to
+/// `KroneckerDeltaAsExpression` as `Tensor` is to `TensorAsExpression`.
+///
+/// \tparam Dim the dimension of the Kronecker delta
+template <size_t Dim>
+struct KroneckerDelta {
+  /// The ::Symmetry of the Kronecker delta
+  using symmetry = Symmetry<2, 1>;
+  /// The dimension of the Kronecker delta
+  static constexpr size_t dim = Dim;
+
+  /// \brief Retrieve a `TensorExpression` object with the specified generic
+  /// indices
+  ///
+  /// \tparam TensorIndex1 the first \ref TensorIndex "generic index"
+  /// \tparam TensorIndex2 the second \ref TensorIndex "generic index"
+  template <typename TensorIndex1, typename TensorIndex2>
+  SPECTRE_ALWAYS_INLINE constexpr auto operator()(TensorIndex1 /*meta*/,
+                                                  TensorIndex2 /*meta*/) const {
+    static_assert(
+        tt::is_tensor_index<TensorIndex1>::value and
+            tt::is_tensor_index<TensorIndex2>::value,
+        "A Kronecker delta expression must be created using TensorIndex "
+        "objects to represent generic indices, e.g. ti::I, ti::j.");
+    static_assert(
+        not tt::is_time_index<TensorIndex1>::value and
+            not tt::is_time_index<TensorIndex2>::value,
+        "A Kronecker delta expression cannot be created using time indices.");
+    static_assert(
+        TensorIndex1::valence != TensorIndex2::valence,
+        "Kronecker delta expressions need to be be created using one upper "
+        "index and one lower index.");
+    static_assert(
+        TensorIndex1::is_spacetime == TensorIndex2::is_spacetime,
+        "The TensorIndexs used to create a Kronecker delta expression must "
+        "either be both spatial or both spacetime generic indices.");
+
+    if constexpr (get_tensorindex_value_with_opposite_valence(
+                      TensorIndex1::value) != TensorIndex2::value) {
+      // don't contract indices
+      return KroneckerDeltaAsExpression<KroneckerDelta<Dim>, TensorIndex1,
+                                        TensorIndex2>{*this};
+    } else {
+      // contract indices, where trace of Kronecker delta = dim
+      return NumberAsExpression(1.0 * Dim);
+    }
+  }
+};
+}  // namespace tenex
+
+/// @{
+/// \ingroup TensorExpressionsGroup
+/// \brief The available Kronecker delta objects to use in a `TensorExpression`
+///
+/// \details
+/// The numeric suffix represents the dimension of the Kronecker delta. To use
+/// in a `TensorExpression`, you must supply one upper and one lower generic
+/// index (`TensorIndex`), e.g.:
+///
+/// \code
+/// kdelta3(ti::I, ti::j)
+/// \endcode
+///
+/// The upper and lower index can be in any order, but both need to be generic
+/// spatial indices or generic spacetime indices. Examples:
+///
+/// \code
+/// kdelta3(ti::I, ti::j)  // OK
+/// kdelta3(ti::i, ti::J)  // OK
+/// kdelta3(ti::A, ti::b)  // OK
+/// kdelta3(ti::J, ti::j)  // OK, but not recommended as this is just the dim
+///
+/// kdelta3(ti::I, ti::J)  // ERROR: both upper indices
+/// kdelta3(ti::I, ti::a)  // ERROR: spatial and spacetime index
+/// kdelta3(ti::I, ti::t)  // ERROR: concrete index (time index)
+/// \endcode
+// note: kept in global namespace to reduce keystrokes
+static constexpr tenex::KroneckerDelta<1> kdelta1{};
+static constexpr tenex::KroneckerDelta<2> kdelta2{};
+static constexpr tenex::KroneckerDelta<3> kdelta3{};
+static constexpr tenex::KroneckerDelta<4> kdelta4{};
+/// @}

--- a/src/DataStructures/Tensor/Expressions/KroneckerDeltaAsExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/KroneckerDeltaAsExpression.hpp
@@ -1,0 +1,174 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines expressions that represent the Kronecker delta
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Symmetry.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace tenex {
+using KroneckerDeltaFrame = Frame::NoFrame;
+
+/// \ingroup TensorExpressionsGroup
+/// \brief Defines an expression representing a
+/// \ref KroneckerDelta "Kronecker delta"
+///
+/// \tparam K the type of the \ref KroneckerDelta "Kronecker delta" being
+/// represented
+/// \tparam TensorIndex1 the first \ref TensorIndex "generic index"
+/// \tparam TensorIndex2 the second \ref TensorIndex "generic index"
+template <typename K, typename TensorIndex1, typename TensorIndex2>
+struct KroneckerDeltaAsExpression
+    : public TensorExpression<
+          KroneckerDeltaAsExpression<K, TensorIndex1, TensorIndex2>, double,
+          Symmetry<2, 1>,
+          index_list<Tensor_detail::TensorIndexType<
+                         K::dim, TensorIndex1::valence, KroneckerDeltaFrame,
+                         (TensorIndex1::is_spacetime ? IndexType::Spacetime
+                                                     : IndexType::Spatial)>,
+                     Tensor_detail::TensorIndexType<
+                         K::dim, TensorIndex2::valence, KroneckerDeltaFrame,
+                         (TensorIndex1::is_spacetime ? IndexType::Spacetime
+                                                     : IndexType::Spatial)>>,
+          tmpl::list<TensorIndex1, TensorIndex2>>,
+      MarkAsDoubleValuedLeafExpression,
+      MarkAsNonTensorLeafExpression {
+  // === Index properties ===
+  /// The type of the data being stored in the result of the expression
+  using type = double;
+  /// The ::Symmetry of the result of the expression
+  using symmetry = Symmetry<2, 1>;
+  /// The list of \ref SpacetimeIndex "TensorIndexType"s of the result of the
+  /// expression
+  using index_list =
+      tmpl::list<Tensor_detail::TensorIndexType<
+                     K::dim, TensorIndex1::valence, KroneckerDeltaFrame,
+                     (TensorIndex1::is_spacetime ? IndexType::Spacetime
+                                                 : IndexType::Spatial)>,
+                 Tensor_detail::TensorIndexType<
+                     K::dim, TensorIndex2::valence, KroneckerDeltaFrame,
+                     (TensorIndex1::is_spacetime ? IndexType::Spacetime
+                                                 : IndexType::Spatial)>>;
+  /// The list of generic `TensorIndex`s of the result of the expression
+  using args_list = tmpl::list<TensorIndex1, TensorIndex2>;
+  /// The number of tensor indices in the result of the expression
+  static constexpr size_t num_tensor_indices = 2;
+
+  // === Arithmetic tensor operations properties ===
+  /// The number of arithmetic tensor operations done in the subtree for the
+  /// left operand, which is 0 because this is a leaf expression
+  static constexpr size_t num_ops_left_child = 0;
+  /// The number of arithmetic tensor operations done in the subtree for the
+  /// right operand, which is 0 because this is a leaf expression
+  static constexpr size_t num_ops_right_child = 0;
+  /// The total number of arithmetic tensor operations done in this expression's
+  /// whole subtree, which is 0 because this is a leaf expression
+  static constexpr size_t num_ops_subtree = 0;
+
+  // === Properties for splitting up subexpressions along the primary path ===
+  // These definitions only have meaning if this expression actually ends up
+  // being along the primary path that is taken when evaluating the whole tree.
+  // See documentation for `TensorExpression` for more details.
+  /// If on the primary path, whether or not the expression is an ending point
+  /// of a leg
+  static constexpr bool is_primary_end = true;
+  /// If on the primary path, this is the remaining number of arithmetic tensor
+  /// operations that need to be done in the subtree of the child along the
+  /// primary path, given that we will have already computed the whole subtree
+  /// at the next lowest leg's starting point. This is just 0 because this
+  /// expression is a leaf.
+  static constexpr size_t num_ops_to_evaluate_primary_left_child = 0;
+  /// If on the primary path, this is the remaining number of arithmetic tensor
+  /// operations that need to be done in the right operand's subtree. This is
+  /// just 0 because this expression is a leaf.
+  static constexpr size_t num_ops_to_evaluate_primary_right_child = 0;
+  /// If on the primary path, this is the remaining number of arithmetic tensor
+  /// operations that need to be done for this expression's subtree, given that
+  /// we will have already computed the subtree at the next lowest leg's
+  /// starting point. This is just 0 because this expression is a leaf.
+  static constexpr size_t num_ops_to_evaluate_primary_subtree = 0;
+  /// If on the primary path, whether or not the expression is a starting point
+  /// of a leg
+  static constexpr bool is_primary_start = false;
+  /// If on the primary path, whether or not the expression's child along the
+  /// primary path is a subtree that contains a starting point of a leg along
+  /// the primary path. This is always falls because this expression is a leaf.
+  static constexpr bool primary_child_subtree_contains_primary_start = false;
+  /// If on the primary path, whether or not this subtree contains a starting
+  /// point of a leg along the primary path
+  static constexpr bool primary_subtree_contains_primary_start =
+      is_primary_start;
+
+  /// \brief Construct a `KroneckerDeltaAsExpression` from a `KroneckerDelta`
+  ///
+  /// \param k the `KroneckerDelta` to represent as a `TensorExpression`
+  KroneckerDeltaAsExpression(const K& k) : k_(&k) {}
+  ~KroneckerDeltaAsExpression() override = default;
+
+  // This expression does not represent a `Tensor`, nor does it have any
+  // children, so we should never need to assert that the LHS `Tensor` is not
+  // equal to the `KroneckerDelta` stored by this expression
+  template <typename LhsTensor>
+  void assert_lhs_tensor_not_in_rhs_expression(
+      const gsl::not_null<LhsTensor*>) const = delete;
+  // This expression does not represent a `Tensor`, nor does it have any
+  // children, so we should never need to assert that the LHS `Tensor` is not
+  // equal to the `KroneckerDelta` stored by this expression
+  template <typename LhsTensorIndices, typename LhsTensor>
+  void assert_lhs_tensorindices_same_in_rhs(
+      const gsl::not_null<LhsTensor*> lhs_tensor) const = delete;
+
+  /// \brief Returns the value of the contained Kronecker delta's multi-index
+  ///
+  /// \param multi_index the multi-index of the component to retrieve
+  /// \return the value of the component at `multi_index` in the Kronecker delta
+  constexpr SPECTRE_ALWAYS_INLINE double get(
+      const std::array<size_t, num_tensor_indices>& multi_index) const {
+    if (gsl::at(multi_index, 0) != gsl::at(multi_index, 1)) {
+      return 0.0;
+    } else {
+      return 1.0;
+    }
+  }
+
+  /// \brief Returns the value of the contained Kronecker delta's multi-index
+  ///
+  /// \param multi_index the multi-index of the component to retrieve
+  /// \return the value of the component at `multi_index` in the Kronecker delta
+  template <typename ResultType>
+  constexpr SPECTRE_ALWAYS_INLINE double get_primary(
+      const ResultType& /*result_component*/,
+      const std::array<size_t, num_tensor_indices>& multi_index) const {
+    if (gsl::at(multi_index, 0) != gsl::at(multi_index, 1)) {
+      return 0.0;
+    } else {
+      return 1.0;
+    }
+  }
+
+  // This expression is a leaf but does not store any information related to the
+  // sizing of the tensor components because it does not represent an actual
+  // `Tensor`. Therefore, this expression should never be used to initialize a
+  // LHS result tensor component. We would run into trouble if e.g. the tensor
+  // components in the equations are `DataVector`s, but then we initialize a LHS
+  // component using a Kronecker delta element stored in this leaf expression on
+  // the primary path.
+  template <typename ResultType>
+  void evaluate_primary_subtree(
+      ResultType&,
+      const std::array<size_t, num_tensor_indices>&) const = delete;
+
+ private:
+  /// Kronecker delta represented by this expression
+  const K* k_ = nullptr;
+};
+}  // namespace tenex

--- a/src/DataStructures/Tensor/Expressions/Negate.hpp
+++ b/src/DataStructures/Tensor/Expressions/Negate.hpp
@@ -103,7 +103,7 @@ struct Negate
   template <typename LhsTensor>
   SPECTRE_ALWAYS_INLINE void assert_lhs_tensor_not_in_rhs_expression(
       const gsl::not_null<LhsTensor*> lhs_tensor) const {
-    if constexpr (not std::is_base_of_v<NumberAsExpression, T>) {
+    if constexpr (not std::is_base_of_v<MarkAsNonTensorLeafExpression, T>) {
       t_.assert_lhs_tensor_not_in_rhs_expression(lhs_tensor);
     }
   }
@@ -117,7 +117,7 @@ struct Negate
   template <typename LhsTensorIndices, typename LhsTensor>
   SPECTRE_ALWAYS_INLINE void assert_lhs_tensorindices_same_in_rhs(
       const gsl::not_null<LhsTensor*> lhs_tensor) const {
-    if constexpr (not std::is_base_of_v<NumberAsExpression, T>) {
+    if constexpr (not std::is_base_of_v<MarkAsNonTensorLeafExpression, T>) {
       t_.template assert_lhs_tensorindices_same_in_rhs<LhsTensorIndices>(
           lhs_tensor);
     }

--- a/src/DataStructures/Tensor/Expressions/NumberAsExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/NumberAsExpression.hpp
@@ -20,7 +20,9 @@ namespace tenex {
 /// documentation for `TensorExpression`.
 struct NumberAsExpression
     : public TensorExpression<NumberAsExpression, double, tmpl::list<>,
-                              tmpl::list<>, tmpl::list<>> {
+                              tmpl::list<>, tmpl::list<>>,
+      MarkAsDoubleValuedLeafExpression,
+      MarkAsNonTensorLeafExpression {
   // === Index properties ===
   /// The type of the data being stored in the result of the expression
   using type = double;

--- a/src/DataStructures/Tensor/Expressions/Product.hpp
+++ b/src/DataStructures/Tensor/Expressions/Product.hpp
@@ -72,10 +72,11 @@ struct OuterProduct<T1, T2, IndexList1<Indices1...>, IndexList2<Indices2...>,
           typename detail::OuterProductType<T1, T2>::symmetry,
           typename detail::OuterProductType<T1, T2>::index_list,
           typename detail::OuterProductType<T1, T2>::tensorindex_list> {
-  static_assert(std::is_same<typename T1::type, typename T2::type>::value or
-                    std::is_same<T1, NumberAsExpression>::value or
-                    std::is_same<T2, NumberAsExpression>::value,
-                "Cannot product Tensors holding different data types.");
+  static_assert(
+      std::is_same<typename T1::type, typename T2::type>::value or
+          std::is_base_of<MarkAsDoubleValuedLeafExpression, T1>::value or
+          std::is_base_of<MarkAsDoubleValuedLeafExpression, T2>::value,
+      "Cannot product Tensors holding different data types.");
   // === Index properties ===
   /// The type of the data being stored in the result of the expression
   using type = typename detail::OuterProductType<T1, T2>::type;
@@ -170,10 +171,10 @@ struct OuterProduct<T1, T2, IndexList1<Indices1...>, IndexList2<Indices2...>,
   template <typename LhsTensor>
   SPECTRE_ALWAYS_INLINE void assert_lhs_tensor_not_in_rhs_expression(
       const gsl::not_null<LhsTensor*> lhs_tensor) const {
-    if constexpr (not std::is_base_of_v<NumberAsExpression, T1>) {
+    if constexpr (not std::is_base_of_v<MarkAsNonTensorLeafExpression, T1>) {
       t1_.assert_lhs_tensor_not_in_rhs_expression(lhs_tensor);
     }
-    if constexpr (not std::is_base_of_v<NumberAsExpression, T2>) {
+    if constexpr (not std::is_base_of_v<MarkAsNonTensorLeafExpression, T2>) {
       t2_.assert_lhs_tensor_not_in_rhs_expression(lhs_tensor);
     }
   }
@@ -187,11 +188,11 @@ struct OuterProduct<T1, T2, IndexList1<Indices1...>, IndexList2<Indices2...>,
   template <typename LhsTensorIndices, typename LhsTensor>
   SPECTRE_ALWAYS_INLINE void assert_lhs_tensorindices_same_in_rhs(
       const gsl::not_null<LhsTensor*> lhs_tensor) const {
-    if constexpr (not std::is_base_of_v<NumberAsExpression, T1>) {
+    if constexpr (not std::is_base_of_v<MarkAsNonTensorLeafExpression, T1>) {
       t1_.template assert_lhs_tensorindices_same_in_rhs<LhsTensorIndices>(
           lhs_tensor);
     }
-    if constexpr (not std::is_base_of_v<NumberAsExpression, T2>) {
+    if constexpr (not std::is_base_of_v<MarkAsNonTensorLeafExpression, T2>) {
       t2_.template assert_lhs_tensorindices_same_in_rhs<LhsTensorIndices>(
           lhs_tensor);
     }

--- a/src/DataStructures/Tensor/Expressions/SquareRoot.hpp
+++ b/src/DataStructures/Tensor/Expressions/SquareRoot.hpp
@@ -112,7 +112,7 @@ struct SquareRoot
   template <typename LhsTensor>
   SPECTRE_ALWAYS_INLINE void assert_lhs_tensor_not_in_rhs_expression(
       const gsl::not_null<LhsTensor*> lhs_tensor) const {
-    if constexpr (not std::is_base_of_v<NumberAsExpression, T>) {
+    if constexpr (not std::is_base_of_v<MarkAsNonTensorLeafExpression, T>) {
       t_.assert_lhs_tensor_not_in_rhs_expression(lhs_tensor);
     }
   }
@@ -126,7 +126,7 @@ struct SquareRoot
   template <typename LhsTensorIndices, typename LhsTensor>
   SPECTRE_ALWAYS_INLINE void assert_lhs_tensorindices_same_in_rhs(
       const gsl::not_null<LhsTensor*> lhs_tensor) const {
-    if constexpr (not std::is_base_of_v<NumberAsExpression, T>) {
+    if constexpr (not std::is_base_of_v<MarkAsNonTensorLeafExpression, T>) {
       t_.template assert_lhs_tensorindices_same_in_rhs<LhsTensorIndices>(
           lhs_tensor);
     }

--- a/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
@@ -312,6 +312,24 @@ TensorExpression<Derived, DataType, Symm, tmpl::list<Indices...>,
 /// @}
 
 namespace tenex {
+/// \ingroup TensorExpressionsGroup
+/// \brief Marks a class as being a derived TensorExpression type that is a
+/// leaf of expression trees but does not internally contain a `Tensor`
+///
+/// \details
+/// The empty base class provides a simple means for checking if a type fits
+/// this description
+struct MarkAsNonTensorLeafExpression {};
+
+/// \ingroup TensorExpressionsGroup
+/// \brief Marks a class as being a derived TensorExpression type that is a
+/// leaf of expression trees and whose data type is always `double`
+///
+/// \details
+/// The empty base class provides a simple means for checking if a type fits
+/// this description
+struct MarkAsDoubleValuedLeafExpression {};
+
 namespace detail {
 /// @{
 /// \brief The maximum number of arithmetic tensor operations allowed in a

--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -20,6 +20,8 @@
 #include "DataStructures/Tensor/Expressions/Divide.hpp"
 #include "DataStructures/Tensor/Expressions/Evaluate.hpp"
 #include "DataStructures/Tensor/Expressions/IndexPropertyCheck.hpp"
+#include "DataStructures/Tensor/Expressions/KroneckerDelta.hpp"
+#include "DataStructures/Tensor/Expressions/KroneckerDeltaAsExpression.hpp"
 #include "DataStructures/Tensor/Expressions/LhsTensorSymmAndIndices.hpp"
 #include "DataStructures/Tensor/Expressions/Negate.hpp"
 #include "DataStructures/Tensor/Expressions/NumberAsExpression.hpp"

--- a/tests/Unit/DataStructures/Tensor/Expressions/CMakeLists.txt
+++ b/tests/Unit/DataStructures/Tensor/Expressions/CMakeLists.txt
@@ -14,6 +14,7 @@ set(LIBRARY_SOURCES
   Test_EvaluateRank4.cpp
   Test_EvaluateSpatialSpacetimeIndex.cpp
   Test_EvaluateTimeIndex.cpp
+  Test_KroneckerDelta.cpp
   Test_MixedOperations.cpp
   Test_Negate.cpp
   Test_Product.cpp

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_KroneckerDelta.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_KroneckerDelta.cpp
@@ -1,0 +1,44 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.KroneckerDelta",
+                  "[DataStructures][Unit]") {
+  static_assert(kdelta1.dim == 1, "kdelta1 dimension should be 1");
+  static_assert(kdelta2.dim == 2, "kdelta2 dimension should be 2");
+  static_assert(kdelta3.dim == 3, "kdelta3 dimension should be 3");
+  static_assert(kdelta4.dim == 4, "kdelta4 dimension should be 4");
+
+  // dimension 1
+  const auto kdeltaIj = kdelta1(ti::I, ti::j);
+  CHECK(kdeltaIj.get({{0}}) == 1.0);
+
+  // dimension 2
+  const auto kdeltakJ = kdelta2(ti::k, ti::J);
+  CHECK(kdeltakJ.get({{0, 0}}) == 1.0);
+  CHECK(kdeltakJ.get({{1, 0}}) == 0.0);
+  CHECK(kdeltakJ.get({{0, 1}}) == 0.0);
+  CHECK(kdeltakJ.get({{1, 1}}) == 1.0);
+
+  // dimension 3 contracted
+  const auto kdeltaJj = kdelta3(ti::J, ti::j);
+  CHECK(kdeltaJj.get({{}}) == 3.0);
+
+  // dimension 4, spacetime
+  const auto kdeltaAb = kdelta4(ti::A, ti::b);
+  for (size_t a = 0; a < 4; a++) {
+    for (size_t b = 0; b < 4; b++) {
+      if (a == b) {
+        CHECK(kdeltaAb.get({{a, b}}) == 1.0);
+      } else {
+        CHECK(kdeltaAb.get({{a, b}}) == 0.0);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Proposed changes

This PR adds a derived `TensorExpression` type for the Kronecker delta

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
