### PR TITLE
Add xsimd support

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -312,6 +312,7 @@ jobs:
           - gcc-11
         build_type: [Debug, Release]
         use_pch: [ON]
+        use_xsimd: [ON]
         charm_name: ["Charm 7.0.0"]
         include:
           # Configure ccache sizes. The cache becomes ineffective if it can't
@@ -369,6 +370,7 @@ jobs:
             use_pch: ON
             build_type: Release
             BUILD_SHARED_LIBS: OFF
+            use_xsimd: OFF
             MEMORY_ALLOCATOR: JEMALLOC
           # Test compatibility with oldest supported CMake version
           - compiler: clang-13
@@ -467,6 +469,7 @@ ${{ env.CACHE_KEY_SUFFIX }}"
           UBSAN_UNDEFINED=${{ matrix.UBSAN_UNDEFINED }}
           UBSAN_INTEGER=${{ matrix.UBSAN_INTEGER }}
           USE_PCH=${{ matrix.use_pch }}
+          USE_XSIMD=${{ matrix.use_xsimd }}
           COVERAGE=${{ matrix.COVERAGE }}
           TEST_TIMEOUT_FACTOR=${{ matrix.TEST_TIMEOUT_FACTOR }}
 
@@ -484,6 +487,7 @@ ${{ env.CACHE_KEY_SUFFIX }}"
           -D STUB_EXECUTABLE_OBJECT_FILES=ON
           -D STUB_LIBRARY_OBJECT_FILES=ON
           -D USE_PCH=${USE_PCH}
+          -D USE_XSIMD=${USE_XSIMD}
           -D USE_CCACHE=ON
           -D COVERAGE=${COVERAGE:-'OFF'}
           -D BUILD_PYTHON_BINDINGS=${BUILD_PYTHON_BINDINGS:-'ON'}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ include(SetupPapi)
 include(SetupPybind11)
 include(SetupStl)
 include(SetupLibsharp)
+include(SetupXsimd)
 include(SetupYamlCpp)
 
 include(SetupLIBCXXCharm)

--- a/cmake/SetupXsimd.cmake
+++ b/cmake/SetupXsimd.cmake
@@ -1,0 +1,36 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# QUIET silences warning
+find_package(xsimd 8.1.0 QUIET)
+
+option(USE_XSIMD "Use xsimd if it is available" ON)
+
+if(USE_XSIMD AND xsimd_FOUND)
+  message(STATUS "xsimd incld: ${xsimd_INCLUDE_DIRS}")
+  message(STATUS "xsimd vers: ${xsimd_VERSION}")
+
+  file(APPEND
+    "${CMAKE_BINARY_DIR}/BuildInfo.txt"
+    "xsimd version: ${xsimd_VERSION}\n"
+    )
+
+  add_interface_lib_headers(
+    TARGET xsimd
+    HEADERS
+    xsimd/xsimd.hpp
+    )
+
+  # As long as we want xsimd support to be optional we need to be
+  # able to figure out if we have it available.
+  set_property(TARGET xsimd
+    APPEND PROPERTY
+    INTERFACE_COMPILE_OPTIONS
+    -DSPECTRE_USE_XSIMD
+    )
+
+  set_property(
+    GLOBAL APPEND PROPERTY SPECTRE_THIRD_PARTY_LIBS
+    xsimd
+    )
+endif()

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -225,6 +225,18 @@ RUN wget https://github.com/include-what-you-use/include-what-you-use/archive/cl
     && cd /work \
     && rm -rf /work/include-what-you-use-clang_10
 
+# Install xsimd https://github.com/xtensor-stack/xsimd
+RUN wget http://github.com/xtensor-stack/xsimd/archive/refs/tags/8.1.0.tar.gz \
+    && tar -xzf 8.1.0.tar.gz \
+    && cd ./xsimd-8.1.0  \
+    && mkdir build \
+    && cd ./build \
+    && cmake -D CMAKE_BUILD_TYPE=Release -D BUILD_TESTS=OFF \
+             -D CMAKE_INSTALL_PREFIX=/usr/local ../ \
+    && make install \
+    && cd /work \
+    && rm -rf /work/8.1.0.tar.gz /work/xsimd-8.1.0
+
 # Download and build the Charm++ version used by SpECTRE
 # We build both Clang and GCC versions of Charm++ so that all our tests can
 # use the same build environment.

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -108,6 +108,7 @@ all of these dependencies.
 * [Scotch](https://gitlab.inria.fr/scotch/scotch) - to build the `ScotchLB`
   graph partition based load balancer in charm++.
 * [ffmpeg](https://www.ffmpeg.org/) - for animating 1d simulations with matplotlib
+* [xsimd](https://github.com/xtensor-stack/xsimd) - for manual vectorization
 
 ## Clone the SpECTRE repository
 


### PR DESCRIPTION
## Proposed changes

- xsimd allows for easy manual vectorization, including vectorizing trig-type functions. I have a PR submitted to Blaze (since March) that adds support for using xsimd with Blaze. This will allow vectorizing things like the GH Gaussian damping functions.
- xsimd will also allow us to vectorize the primitive recovery
- xsimd is currently an optional dependency. If it turns out to be a big performance win than we can always make it required later.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
