### PR TITLE
Support for reading single and double precision HDF5 volume data

### DIFF
--- a/src/IO/H5/Helpers.cpp
+++ b/src/IO/H5/Helpers.cpp
@@ -10,7 +10,7 @@
 #include <ostream>
 #include <string>
 
-#include "DataStructures/BoostMultiArray.hpp"  // IWYU pragma: keep
+#include "DataStructures/BoostMultiArray.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "IO/H5/AccessType.hpp"
 #include "IO/H5/CheckH5.hpp"
@@ -22,14 +22,10 @@
 #include "Utilities/ErrorHandling/StaticAssert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
-#include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
+#include "Utilities/StdHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits.hpp"
 #include "Utilities/TypeTraits/GetFundamentalType.hpp"
-
-// IWYU pragma: no_include <boost/multi_array.hpp>
-// IWYU pragma: no_include <boost/multi_array/base.hpp>
-// IWYU pragma: no_include <boost/multi_array/extent_gen.hpp>
 
 namespace {
 // Converts input data (either a std::vector or DataVector) to a T. Depending
@@ -109,6 +105,12 @@ struct VectorTo<3, boost::multi_array<T, 3>> {
 }  // namespace
 
 namespace h5 {
+bool types_equal(const hid_t dtype1, const hid_t dtype2) {
+  const htri_t equal = H5Tequal(dtype1, dtype2);
+  CHECK_H5(equal, "Unable to compare H5 data types.");
+  return equal > 0;
+}
+
 template <typename T>
 void write_data(const hid_t group_id, const std::vector<T>& data,
                 const std::vector<size_t>& extents, const std::string& name) {

--- a/src/IO/H5/Helpers.cpp
+++ b/src/IO/H5/Helpers.cpp
@@ -59,6 +59,14 @@ struct VectorTo<2, DataVector> {
   }
 };
 
+template <>
+struct VectorTo<2, std::vector<float>> {
+  static std::vector<float> apply(std::vector<float> raw_data,
+                                  const std::array<hsize_t, 2>& /*size*/) {
+    return raw_data;
+  }
+};
+
 template <typename T>
 struct VectorTo<2, boost::multi_array<T, 2>> {
   static boost::multi_array<T, 2> apply(const std::vector<T>& raw_data,
@@ -80,6 +88,14 @@ template <>
 struct VectorTo<3, DataVector> {
   static DataVector apply(DataVector raw_data,
                           const std::array<hsize_t, 3>& /*size*/) {
+    return raw_data;
+  }
+};
+
+template <>
+struct VectorTo<3, std::vector<float>> {
+  static std::vector<float> apply(std::vector<float> raw_data,
+                                  const std::array<hsize_t, 3>& /*size*/) {
     return raw_data;
   }
 };
@@ -609,6 +625,15 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_READ_VECTOR,
                         (float, double, int, unsigned int, long, unsigned long,
                          long long, unsigned long long, char),
                         (1))
+
+#undef INSTANTIATE_READ_VECTOR
+
+#define INSTANTIATE_READ_VECTOR(_, DATA)          \
+  template std::vector<TYPE(DATA)>                \
+  read_data<RANK(DATA), std::vector<TYPE(DATA)>>( \
+      const hid_t group_id, const std::string& dataset_name);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_READ_VECTOR, (float), (2, 3))
 
 #define INSTANTIATE_READ_MULTIARRAY(_, DATA)                         \
   template boost::multi_array<TYPE(DATA), RANK(DATA)>                \

--- a/src/IO/H5/Helpers.hpp
+++ b/src/IO/H5/Helpers.hpp
@@ -21,6 +21,12 @@ class DataVector;
 namespace h5 {
 /*!
  * \ingroup HDF5Group
+ * \brief Check if `dtype1` and `dtype2` are the same HDF5 data type.
+ */
+bool types_equal(hid_t dtype1, hid_t dtype2);
+
+/*!
+ * \ingroup HDF5Group
  * \brief Write a std::vector named `name` to the group `group_id`
  */
 template <typename T>

--- a/src/IO/H5/VolumeData.hpp
+++ b/src/IO/H5/VolumeData.hpp
@@ -129,8 +129,8 @@ class VolumeData : public h5::Object {
 
   /// Read a tensor component with name `tensor_component` at observation id
   /// `observation_id` from all grids in the file
-  DataVector get_tensor_component(size_t observation_id,
-                                  const std::string& tensor_component) const;
+  TensorComponent get_tensor_component(
+      size_t observation_id, const std::string& tensor_component) const;
 
   /// Read the extents of all the grids stored in the file at the observation id
   /// `observation_id`

--- a/src/IO/Importers/Actions/ReadVolumeData.hpp
+++ b/src/IO/Importers/Actions/ReadVolumeData.hpp
@@ -253,10 +253,13 @@ struct ReadAllVolumeDataAndDistribute {
         }
         auto& tensor_data = get<field_tag>(all_tensor_data);
         for (size_t i = 0; i < tensor_data.size(); i++) {
-          tensor_data[i] = volume_file.get_tensor_component(
-              observation_id,
-              selection.value() + tensor_data.component_suffix(
-                                      tensor_data.get_tensor_index(i)));
+          tensor_data[i] = std::get<DataVector>(
+              volume_file
+                  .get_tensor_component(
+                      observation_id,
+                      selection.value() + tensor_data.component_suffix(
+                                              tensor_data.get_tensor_index(i)))
+                  .data);
         }
       });
       // Retrieve the information needed to reconstruct which element the data

--- a/src/Visualization/Python/InterpolateVolumeData.py
+++ b/src/Visualization/Python/InterpolateVolumeData.py
@@ -143,8 +143,8 @@ def interpolate_h5_file(source_file_path,
 
         # pre-load all tensors to avoid loading the full tensor for each element
         tensors = [
-            np.array(source_vol.get_tensor_component(obs, name), copy=False)
-            for name in tensor_names
+            np.array(source_vol.get_tensor_component(obs, name).data,
+                     copy=False) for name in tensor_names
         ]
 
         source_file.close()

--- a/tests/Unit/Helpers/IO/VolumeData.cpp
+++ b/tests/Unit/Helpers/IO/VolumeData.cpp
@@ -117,14 +117,16 @@ void check_volume_data(
   // file, find the data which was written by the grid whose extents are
   // found at position `grid_index` in the vector of extents.
   const auto get_grid_data = [&element_num_points, &read_points_by_element](
-                                 const DataVector& all_data,
+                                 const auto& all_data,
                                  const size_t grid_index) {
     DataType result(element_num_points[grid_index]);
     // clang-tidy: do not use pointer arithmetic
-    std::copy(&all_data[read_points_by_element[grid_index]],
-              &all_data[read_points_by_element[grid_index]] +  // NOLINT
-                  element_num_points[grid_index],
-              result.begin());
+    std::copy(
+        &std::get<DataType>(all_data.data)[read_points_by_element[grid_index]],
+        &std::get<DataType>(
+            all_data.data)[read_points_by_element[grid_index]] +  // NOLINT
+            element_num_points[grid_index],
+        result.begin());
     return result;
   };
   // The tensor components can be written in any order to the file, we loop
@@ -187,12 +189,7 @@ void check_volume_data(
                            return tensor_component.name == component;
                          });
         REQUIRE(component_data_it != volume_data_it->tensor_components.end());
-        DataVector expected_component_data{expected_data.size()};
-        for (size_t k = 0; k < expected_component_data.size(); ++k) {
-          expected_component_data[k] = expected_data[k];
-        }
-        CHECK(std::get<DataVector>(component_data_it->data) ==
-              expected_component_data);
+        CHECK(std::get<DataType>(component_data_it->data) == expected_data);
       }
     }
   }

--- a/tests/Unit/IO/H5/Test_H5.cpp
+++ b/tests/Unit/IO/H5/Test_H5.cpp
@@ -26,6 +26,7 @@
 #include "IO/H5/Helpers.hpp"
 #include "IO/H5/OpenGroup.hpp"
 #include "IO/H5/SourceArchive.hpp"
+#include "IO/H5/Type.hpp"
 #include "IO/H5/Version.hpp"
 #include "IO/H5/Wrappers.hpp"
 #include "Informer/InfoFromBuild.hpp"
@@ -37,6 +38,13 @@
 
 // Test that we can read scalar, rank-1, rank-2, and rank-3 datasets
 namespace {
+void test_types_equal() {
+  CHECK(h5::types_equal(h5::h5_type<double>(), h5::h5_type<double>()));
+  CHECK_FALSE(h5::types_equal(h5::h5_type<double>(), h5::h5_type<float>()));
+  CHECK_FALSE(h5::types_equal(h5::h5_type<char>(), h5::h5_type<float>()));
+  CHECK_FALSE(h5::types_equal(h5::h5_type<int>(), h5::h5_type<float>()));
+}
+
 void test_read_data() {
   const std::string h5_file_name("Unit.IO.H5.ReadData.h5");
   if (file_system::check_if_file_exists(h5_file_name)) {
@@ -200,6 +208,7 @@ void test_errors() {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.IO.H5", "[Unit][IO][H5]") {
+  test_types_equal();
   test_read_data();
   test_check_if_object_exists();
   test_contains_attribute_false();

--- a/tests/Unit/IO/H5/Test_VolumeData.py
+++ b/tests/Unit/IO/H5/Test_VolumeData.py
@@ -161,8 +161,8 @@ class TestVolumeData(unittest.TestCase):
                 np.asarray(
                     self.vol_file.get_tensor_component(
                         observation_id=obs_id,
-                        tensor_component=expected_tensor_component_names[i]))
-                [0:8], expected_tensor_component_data)
+                        tensor_component=expected_tensor_component_names[i]).
+                    data)[0:8], expected_tensor_component_data)
 
     def test_get_data_by_element(self):
         obs_id = 0

--- a/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
@@ -294,8 +294,8 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.VolumeObserver", "[Unit][Observers]") {
   std::unordered_map<std::string, DataVector> read_tensor_data;
   for (const auto& tensor_name :
        volume_file.list_tensor_components(temporal_id)) {
-    read_tensor_data[tensor_name] =
-        volume_file.get_tensor_component(temporal_id, tensor_name);
+    read_tensor_data[tensor_name] = std::get<DataVector>(
+        volume_file.get_tensor_component(temporal_id, tensor_name).data);
   }
   // Read the extents that were written to file
   const std::vector<std::vector<size_t>> read_extents =

--- a/tests/Unit/Visualization/Python/Test_InterpolateVolumeData.py
+++ b/tests/Unit/Visualization/Python/Test_InterpolateVolumeData.py
@@ -168,11 +168,15 @@ class TestInterpolateH5(unittest.TestCase):
             self.assertEqual(vol.get_bases(obs), [["Legendre"] * 3] * 2)
             self.assertEqual(vol.get_quadratures(obs), [["Gauss"] * 3] * 2)
 
-        tensor1_obs_1 = np.asarray(vol.get_tensor_component(42, 'tensor1'))
-        tensor2_obs_1 = np.asarray(vol.get_tensor_component(42, 'tensor2'))
+        tensor1_obs_1 = np.asarray(
+            vol.get_tensor_component(42, 'tensor1').data)
+        tensor2_obs_1 = np.asarray(
+            vol.get_tensor_component(42, 'tensor2').data)
 
-        tensor1_obs_2 = np.asarray(vol.get_tensor_component(1000, 'tensor1'))
-        tensor2_obs_2 = np.asarray(vol.get_tensor_component(1000, 'tensor2'))
+        tensor1_obs_2 = np.asarray(
+            vol.get_tensor_component(1000, 'tensor1').data)
+        tensor2_obs_2 = np.asarray(
+            vol.get_tensor_component(1000, 'tensor2').data)
 
         file.close()
 


### PR DESCRIPTION
## Proposed changes

- Add ability to compare HDF5 types so we can figure out what type something is in a file.
- Add support for reading single-precision data

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
