### PR TITLE
Disallow antisymmetries in TensorExpressions

### DIFF
--- a/src/DataStructures/Tensor/Expressions/Evaluate.hpp
+++ b/src/DataStructures/Tensor/Expressions/Evaluate.hpp
@@ -91,6 +91,14 @@ constexpr bool is_evaluated_lhs_multi_index(
   return true;
 }
 
+template <typename SymmList>
+struct CheckNoLhsAntiSymmetries;
+
+template <template <typename...> class SymmList, typename... Symm>
+struct CheckNoLhsAntiSymmetries<SymmList<Symm...>> {
+  static constexpr bool value = (... and (Symm::value > 0));
+};
+
 /*!
  * \ingroup TensorExpressionsGroup
  * \brief Evaluate subtrees of the RHS expression or the RHS expression as a
@@ -147,6 +155,16 @@ void evaluate_impl(
       tmpl::list<std::decay_t<decltype(LhsTensorIndices)>...>;
   using rhs_tensorindex_list = tmpl::list<RhsTensorIndices...>;
 
+  // `Symmetry` currently prevents this because antisymmetries are not currently
+  // supported for `Tensor`s. This check is repeated here because if
+  // antisymmetries are later supported for `Tensor`, using antisymmetries in
+  // `TensorExpression`s will not automatically work. The implementations of the
+  // derived `TensorExpression` types assume no antisymmetries (assume positive
+  // `Symmetry` values), so support for antisymmetries in `TensorExpression`s
+  // will still need to be implemented.
+  static_assert(CheckNoLhsAntiSymmetries<LhsSymmetry>::value,
+                "Anti-symmetric Tensors are not currently supported by "
+                "TensorExpressions.");
   static_assert(
       tmpl::equal_members<
           typename remove_time_indices<lhs_tensorindex_list>::type,
@@ -284,6 +302,16 @@ void evaluate_impl(
   using lhs_tensorindex_list =
       tmpl::list<std::decay_t<decltype(LhsTensorIndices)>...>;
 
+  // `Symmetry` currently prevents this because antisymmetries are not currently
+  // supported for `Tensor`s. This check is repeated here because if
+  // antisymmetries are later supported for `Tensor`, using antisymmetries in
+  // `TensorExpression`s will not automatically work. The implementations of the
+  // derived `TensorExpression` types assume no antisymmetries (assume positive
+  // `Symmetry` values), so support for antisymmetries in `TensorExpression`s
+  // will still need to be implemented.
+  static_assert(CheckNoLhsAntiSymmetries<LhsSymmetry>::value,
+                "Anti-symmetric Tensors are not currently supported by "
+                "TensorExpressions.");
   static_assert(
       tensorindex_list_is_valid<lhs_tensorindex_list>::value,
       "Cannot assign a tensor expression to a LHS tensor with a repeated "


### PR DESCRIPTION
## Proposed changes

This PR prevents someone from using antisymmetric `Tensor`s in `TensorExpression`s

Although Symmetry currently prevents the creation of antisymmetric `Tensor`s, this change is being added so that if antisymmetries are later supported for `Tensor`s, it will be made known that `TensorExpression`s will not automatically work with them and support there will be needed if you want to use them in `TensorExpression`s.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
