### PR TITLE
Allow sizing with non-owning vector

### DIFF
--- a/src/DataStructures/VectorImpl.hpp
+++ b/src/DataStructures/VectorImpl.hpp
@@ -375,7 +375,8 @@ VectorImpl<T, VectorType>& VectorImpl<T, VectorType>::operator=(const T& rhs) {
 
 template <typename T, typename VectorType>
 void VectorImpl<T, VectorType>::pup(PUP::er& p) {  // NOLINT
-  ASSERT(owning_, "Cannot pup a non-owning vector!");
+  ASSERT(owning_ or p.isSizing(),
+         "Cannot pup a non-owning vector unless you are sizing!");
   auto my_size = size();
   p | my_size;
   if (my_size > 0) {

--- a/tests/Unit/Helpers/DataStructures/VectorImplTestHelper.hpp
+++ b/tests/Unit/Helpers/DataStructures/VectorImplTestHelper.hpp
@@ -194,6 +194,12 @@ void vector_test_serialize(tt::get_fundamental_type_t<ValueType> low =
   CHECK(serialized_vector_test.is_owning());
   CHECK(serialized_vector_test.data() != vector_test.data());
   CHECK(vector_test.is_owning());
+
+  // check that the pup function doesn't error while sizing
+  const size_t size_in_bytes = size_of_object_in_bytes(vector_test);
+  const size_t serialized_size_in_bytes =
+      size_of_object_in_bytes(serialized_vector_test);
+  CHECK(size_in_bytes == serialized_size_in_bytes);
 }
 
 /// \ingroup TestingFrameworkGroup


### PR DESCRIPTION
## Proposed changes

A couple times while using the memory monitor on the DgElementArray, I got an error that `Cannot pup a non-owning vector!`. So this allows sizing while the vector is non-owning.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
