### PR TITLE
Store number of indices in Tensor class

### DIFF
--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -132,6 +132,8 @@ class Tensor<X, Symm, IndexList<Indices...>> {
   /// Typelist of the \ref SpacetimeIndex "TensorIndexType"'s that the
   /// Tensor has
   using index_list = tmpl::list<Indices...>;
+  /// The number of indices that the Tensor has
+  static constexpr size_t num_tensor_indices = sizeof...(Indices);
   /// The Tensor_detail::Structure for the particular tensor index structure
   ///
   /// Each tensor index structure, e.g. \f$T_{ab}\f$, \f$T_a{}^b\f$ or


### PR DESCRIPTION
## Proposed changes

This PR updates the `Tensor` class to store the number of indices. The motivation of this PR is convenience of accessing the number of indices from outside the class. i.e. You can do `T::num_tensor_indices` rather than doing e.g. `tmpl::size<T::symmetry>::value`.

The name `num_tensor_indices` was chosen because it is consistent with what `TensorExpression`s use, which is useful because it allows for using `T::num_tensor_indices` whether `T` is a `Tensor` or `TensorExpression`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
