### PR TITLE
Add size control logic and test.

### DIFF
--- a/src/ControlSystem/ControlErrors/CMakeLists.txt
+++ b/src/ControlSystem/ControlErrors/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+add_subdirectory(Size)
+
 spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src

--- a/src/ControlSystem/ControlErrors/Size/AhSpeed.cpp
+++ b/src/ControlSystem/ControlErrors/Size/AhSpeed.cpp
@@ -1,0 +1,128 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ControlSystem/ControlErrors/Size/AhSpeed.hpp"
+
+#include <cmath>
+#include <memory>
+
+#include "ControlSystem/ControlErrors/Size/DeltaR.hpp"
+
+namespace control_system::size::States {
+
+std::unique_ptr<State> AhSpeed::get_clone() const {
+  return std::make_unique<AhSpeed>(*this);
+}
+
+void AhSpeed::update(const gsl::not_null<Info*> info,
+                     const StateUpdateArgs& update_args,
+                     const CrossingTimeInfo& crossing_time_info) const {
+  const double min_char_speed = update_args.min_char_speed;
+  const double min_comoving_char_speed = update_args.min_comoving_char_speed;
+
+  // Note that delta_radius_is_in_danger and char_speed_is_in_danger
+  // can be different for different States.
+  //
+  // The value of 20 causes the control system to panic easily if
+  // delta_radius is decreasing quickly.  The value 20 was chosen
+  // by trial-and-error in SpEC.
+  constexpr double time_tolerance_for_delta_r_in_danger = 20.0;
+  const bool delta_radius_is_in_danger =
+      crossing_time_info.horizon_will_hit_excision_boundary_first and
+      crossing_time_info.t_delta_radius <
+          info->damping_time * time_tolerance_for_delta_r_in_danger;
+
+  const bool char_speed_is_in_danger = [&crossing_time_info, &info,
+                                        &delta_radius_is_in_danger,
+                                        &min_char_speed]() {
+    // speed_tolerance_for_char_speed_in_danger is slightly greater
+    // than unity so that we don't panic if the actual char speed is
+    // large enough compared to the target char speed.  The value 1.1
+    // was chosen in SpEC and we haven't had to change it; the behavior
+    // should not be sensitive to small changes in this value.
+    constexpr double speed_tolerance_for_char_speed_in_danger = 1.1;
+    // We don't want to panic unless crossing time is less than
+    // the current damping time. The value 0.99 was chosen in SpEC and we
+    // haven't had to change it; the behavior should not be sensitive to
+    // small changes in this value.
+    constexpr double time_tolerance_for_char_speed_in_danger = 0.99;
+    return (not delta_radius_is_in_danger) and
+           (crossing_time_info.char_speed_will_hit_zero_first and
+            crossing_time_info.t_char_speed <
+                info->damping_time * time_tolerance_for_char_speed_in_danger and
+            min_char_speed < info->target_char_speed *
+                                 speed_tolerance_for_char_speed_in_danger);
+  }();
+
+  const bool comoving_decreasing_slower_than_char_speeds =
+      not(crossing_time_info.t_char_speed > 0.0 and
+          crossing_time_info.t_comoving_char_speed > 0.0 and
+          update_args.min_comoving_char_speed > 0.0 and
+          update_args.min_comoving_char_speed /
+                  crossing_time_info.t_comoving_char_speed >
+              update_args.min_char_speed / crossing_time_info.t_char_speed);
+  // The value of 5.0 was chosen by trial and error in SpEC
+  constexpr double comoving_char_speed_to_damping_time_limit = 5.0;
+  if (char_speed_is_in_danger) {
+    if (info->target_char_speed < min_char_speed) {
+      // The value of 1.01 below was chosen by trial and error in
+      // SpEC.  The value needs to be greater than unity, and something
+      // that doesn't drive min_char_speed too quickly.
+      constexpr double min_char_speed_increase_factor = 1.01;
+      // We are already in state AhSpeed, and we are in danger.
+      // But target_char_speed is less than min_char_speed, so we don't want
+      // to continue to push min_char_speed downward.  Instead, increase
+      // target_char_speed to be above min_char_speed.
+      // We don't do this if delta_radius_is_in_danger, because for that
+      // case we might need to drive min_char_speed to a smaller value.
+      info->target_char_speed = min_char_speed * min_char_speed_increase_factor;
+    }
+    info->suggested_time_scale = crossing_time_info.t_char_speed;
+  } else if (delta_radius_is_in_danger) {
+    // The values of target_speed_decrease_factor and
+    // time_tolerance_for_delta_r were chosen by trial and error in SpEC.
+    constexpr double target_speed_decrease_factor = 0.125;
+    constexpr double time_tolerance_for_delta_r =
+        0.25 * time_tolerance_for_delta_r_in_danger;
+    if ((crossing_time_info.t_char_speed > 0.0 and
+         crossing_time_info.t_delta_radius >
+             info->damping_time * time_tolerance_for_delta_r) or
+        update_args.min_comoving_char_speed < 0.0) {
+      info->discontinuous_change_has_occurred = true;
+      info->target_char_speed = min_char_speed * target_speed_decrease_factor;
+      info->suggested_time_scale =
+          std::min(info->damping_time, crossing_time_info.t_delta_radius);
+    } else {
+      info->discontinuous_change_has_occurred = true;
+      info->state = std::make_unique<States::DeltaR>();
+      info->suggested_time_scale = crossing_time_info.t_delta_radius;
+      // Here is where possible transition to State DeltaRDriftInward will go.
+    }
+  } else if (update_args.min_comoving_char_speed > 0.0 and
+             update_args.min_char_speed > 0.0 and
+             (crossing_time_info.t_comoving_char_speed == 0.0 or
+              (crossing_time_info.t_comoving_char_speed >
+                   comoving_char_speed_to_damping_time_limit *
+                       info->damping_time and
+               comoving_decreasing_slower_than_char_speeds)) and
+             (update_args.min_char_speed >= info->target_char_speed or
+              min_comoving_char_speed > min_char_speed)) {
+    info->discontinuous_change_has_occurred = true;
+    info->state = std::make_unique<States::DeltaR>();
+    // Here is where possible transition to State DeltaRDriftInward
+    // will go.
+  }
+  // If no 'if's are encountered above, then all the info parameters stay
+  // the same as they were.
+}
+
+double AhSpeed::control_signal(
+    const Info& info,
+    const ControlSignalArgs& control_signal_args) const {
+  const double Y00 = sqrt(0.25 / M_PI);
+  return (info.target_char_speed - control_signal_args.min_char_speed) /
+         (Y00 * control_signal_args.avg_distorted_normal_dot_unit_coord_vector);
+}
+
+PUP::able::PUP_ID AhSpeed::my_PUP_ID = 0;
+}  // namespace control_system::size::States

--- a/src/ControlSystem/ControlErrors/Size/AhSpeed.hpp
+++ b/src/ControlSystem/ControlErrors/Size/AhSpeed.hpp
@@ -1,0 +1,28 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pup.h>
+
+#include "ControlSystem/ControlErrors/Size/Info.hpp"
+#include "ControlSystem/ControlErrors/Size/State.hpp"
+#include "Parallel/CharmPupable.hpp"
+
+namespace control_system::size::States {
+class AhSpeed : public State {
+ public:
+  AhSpeed() = default;
+  std::unique_ptr<State> get_clone() const override;
+  void update(const gsl::not_null<Info*> info,
+              const StateUpdateArgs& update_args,
+              const CrossingTimeInfo& crossing_time_info) const override;
+  /// The return value is Q from Eq. 92 of \cite Hemberger2012jz.
+  double control_signal(
+      const Info& info,
+      const ControlSignalArgs& control_signal_args) const override;
+
+  WRAPPED_PUPable_decl_template(AhSpeed); // NOLINT
+  explicit AhSpeed(CkMigrateMessage* const /*msg*/) {}
+};
+}  // namespace control_system::size::States

--- a/src/ControlSystem/ControlErrors/Size/CMakeLists.txt
+++ b/src/ControlSystem/ControlErrors/Size/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY SizeControlErrors)
+
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  Info.cpp
+  AhSpeed.cpp
+  DeltaR.cpp
+  Initial.cpp
+  RegisterDerivedWithCharm.cpp
+  )
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Info.hpp
+  State.hpp
+  AhSpeed.hpp
+  DeltaR.hpp
+  Initial.hpp
+  RegisterDerivedWithCharm.hpp
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  Boost::boost
+  DataStructures
+  ErrorHandling
+  GSL::gsl
+  Parallel
+  )

--- a/src/ControlSystem/ControlErrors/Size/DeltaR.cpp
+++ b/src/ControlSystem/ControlErrors/Size/DeltaR.cpp
@@ -1,0 +1,90 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ControlSystem/ControlErrors/Size/DeltaR.hpp"
+
+#include <memory>
+
+#include "ControlSystem/ControlErrors/Size/AhSpeed.hpp"
+
+namespace control_system::size::States {
+
+std::unique_ptr<State> DeltaR::get_clone() const {
+  return std::make_unique<DeltaR>(*this);
+}
+
+void DeltaR::update(const gsl::not_null<Info*> info,
+                    const StateUpdateArgs& update_args,
+                    const CrossingTimeInfo& crossing_time_info) const {
+  // If update_args.control_error_delta_r is larger than
+  // delta_r_control_signal_threshold (and neither char speed nor
+  // delta radius is in danger), then the timescale is decreased to
+  // keep the control error small. This behavior is similar to what
+  // TimecaleTuners do, but is triggered only in some situations. The
+  // value of 1e-3 was chosen by trial and error in SpEC but it might
+  // be helpful to decrease this value in the future if size control
+  // needs to be very tight.
+  constexpr double delta_r_control_signal_threshold = 1.e-3;
+
+  // Note that delta_radius_is_in_danger and char_speed_is_in_danger
+  // can be different for different States.
+
+  // The value of 0.99 was chosen by trial and error in SpEC.
+  // It should be slightly less than unity but nothing should be
+  // sensitive to small changes in this value.
+  constexpr double time_tolerance_for_delta_r_in_danger = 0.99;
+  const bool delta_radius_is_in_danger =
+      crossing_time_info.horizon_will_hit_excision_boundary_first and
+      crossing_time_info.t_delta_radius <
+          info->damping_time * time_tolerance_for_delta_r_in_danger;
+  const bool char_speed_is_in_danger =
+      crossing_time_info.char_speed_will_hit_zero_first and
+      crossing_time_info.t_char_speed < info->damping_time and
+      not delta_radius_is_in_danger;
+
+  if (char_speed_is_in_danger) {
+    if (crossing_time_info.t_comoving_char_speed > 0.0 or
+        update_args.min_comoving_char_speed < 0.0) {
+      // Comoving char speed is negative or threatening to cross zero, so
+      // staying in DeltaR mode will not work.  So switch to AhSpeed mode.
+
+      // This factor prevents oscillating between states Initial and
+      // AhSpeed.  It needs to be slightly greater than unity, but the
+      // control system should not be sensitive to the exact
+      // value. The value of 1.01 was chosen arbitrarily in SpEC and
+      // never needed to be changed.
+      constexpr double non_oscillation_factor = 1.01;
+      info->discontinuous_change_has_occurred = true;
+      info->state = std::make_unique<States::AhSpeed>();
+      info->target_char_speed =
+          update_args.min_char_speed * non_oscillation_factor;
+    }
+    // If the comoving char speed is positive and is not about to
+    // cross zero, staying in DeltaR mode will rescue the speed
+    // automatically (since it drives char speed to comoving char
+    // speed).  But we should decrease the timescale in any case.
+    info->suggested_time_scale = crossing_time_info.t_char_speed;
+  } else if (delta_radius_is_in_danger) {
+    info->suggested_time_scale = crossing_time_info.t_delta_radius;
+  } else if (update_args.min_comoving_char_speed > 0.0 and
+             std::abs(update_args.control_error_delta_r) >
+                 delta_r_control_signal_threshold) {
+    // delta_r_state_decrease_factor should be slightly less than unity.
+    // The value of 0.99 below was chosen arbitrarily in SpEC and never
+    // needed to be changed.
+    constexpr double delta_r_state_decrease_factor = 0.99;
+    info->suggested_time_scale =
+        info->damping_time * delta_r_state_decrease_factor;
+  }
+  // Here is where possible transitions to states DeltaRDriftInward and
+  // state DeltaRDriftOutward will go.
+}
+
+double DeltaR::control_signal(
+    const Info& /*info*/,
+    const ControlSignalArgs& control_signal_args) const {
+  return control_signal_args.control_error_delta_r;
+}
+
+PUP::able::PUP_ID DeltaR::my_PUP_ID = 0;
+}  // namespace control_system::size::States

--- a/src/ControlSystem/ControlErrors/Size/DeltaR.hpp
+++ b/src/ControlSystem/ControlErrors/Size/DeltaR.hpp
@@ -1,0 +1,28 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pup.h>
+
+#include "ControlSystem/ControlErrors/Size/Info.hpp"
+#include "ControlSystem/ControlErrors/Size/State.hpp"
+#include "Parallel/CharmPupable.hpp"
+
+namespace control_system::size::States {
+class DeltaR : public State {
+ public:
+  DeltaR() = default;
+  std::unique_ptr<State> get_clone() const override;
+  void update(const gsl::not_null<Info*> info,
+              const StateUpdateArgs& update_args,
+              const CrossingTimeInfo& crossing_time_info) const override;
+  /// The return value is Q from Eq. 96 of \cite Hemberger2012jz.
+  double control_signal(
+      const Info& info,
+      const ControlSignalArgs& control_signal_args) const override;
+
+  WRAPPED_PUPable_decl_template(DeltaR); // NOLINT
+  explicit DeltaR(CkMigrateMessage* const /*msg*/) {}
+};
+}  // namespace control_system::size::States

--- a/src/ControlSystem/ControlErrors/Size/Info.cpp
+++ b/src/ControlSystem/ControlErrors/Size/Info.cpp
@@ -1,0 +1,40 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ControlSystem/ControlErrors/Size/Info.hpp"
+
+#include <pup.h>
+#include <pup_stl.h>
+
+#include "ControlSystem/ControlErrors/Size/State.hpp"
+#include "Parallel/CharmPupable.hpp"
+
+namespace control_system::size {
+
+void Info::pup(PUP::er& p) {
+  p | state;
+  p | damping_time;
+  p | target_char_speed;
+  p | target_drift_velocity;
+  p | suggested_time_scale;
+  p | discontinuous_change_has_occurred;
+}
+
+CrossingTimeInfo::CrossingTimeInfo(
+    const double char_speed_crossing_time,
+    const double comoving_char_speed_crossing_time,
+    const double delta_radius_crossing_time)
+    : t_char_speed(char_speed_crossing_time),
+      t_comoving_char_speed(comoving_char_speed_crossing_time),
+      t_delta_radius(delta_radius_crossing_time) {
+  if (t_char_speed > 0.0) {
+    if (t_delta_radius > 0.0 and t_delta_radius <= t_char_speed) {
+      horizon_will_hit_excision_boundary_first = true;
+    } else {
+      char_speed_will_hit_zero_first = true;
+    }
+  } else if (t_delta_radius > 0.0) {
+    horizon_will_hit_excision_boundary_first = true;
+  }
+}
+}  // namespace control_system::size

--- a/src/ControlSystem/ControlErrors/Size/Info.hpp
+++ b/src/ControlSystem/ControlErrors/Size/Info.hpp
@@ -1,0 +1,68 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <pup.h>
+
+/// \cond
+namespace control_system::size {
+struct State;
+}  // namespace control_system::size
+/// \endcond
+
+namespace control_system::size {
+
+/// Holds information that is saved between calls of SizeControl.
+struct Info {
+  // Info needs to be serializable because it will be
+  // stored inside of a ControlError.
+  void pup(PUP::er& p);
+
+  /// The current state of size control.
+  std::unique_ptr<State> state;
+  /// The current damping time associated with size control.
+  double damping_time;
+  /// target_char_speed is what the characteristic speed is driven
+  /// toward in state Label::AhSpeed.
+  double target_char_speed;
+  /// target_drift_velocity is what dr/dt (where r and t are distorted frame
+  /// variables) of the excision boundary is driven toward in state
+  /// Label::Initial.
+  double target_drift_velocity;
+  /// Sometimes State::update will request that damping_time
+  /// be changed; the new suggested value is suggested_time_scale.
+  double suggested_time_scale;
+  /// discontinuous_change_has_occurred is set to true by
+  /// State::update if it changes anything in such a way that
+  /// the control signal jumps discontinuously in time.
+  bool discontinuous_change_has_occurred;
+};
+
+/// Holds information about crossing times, as computed by
+/// ZeroCrossingPredictors.
+struct CrossingTimeInfo {
+  CrossingTimeInfo(const double char_speed_crossing_time,
+                   const double comoving_char_speed_crossing_time,
+                   const double delta_radius_crossing_time);
+  /// t_char_speed is the time (relative to the current time) when the
+  /// minimum characteristic speed is predicted to cross zero (or zero if
+  /// the minimum characteristic speed is increasing).
+  double t_char_speed;
+  /// t_comoving_char_speed is the time (relative to the current time) when the
+  /// minimum comoving characteristic speed is predicted to cross zero
+  /// (or zero if the minimum comoving characteristic speed is increasing).
+  double t_comoving_char_speed;
+  /// t_delta_radius is the time (relative to the current time) when the
+  /// minimum distance between the horizon and the excision boundary is
+  /// predicted to cross zero (or zero if the minimum distance is
+  /// increasing).
+  double t_delta_radius;
+  /// Extra variables to simplify the logic; these indicate whether
+  /// the characteristic speed or the excision boundary (or neither) are
+  /// expected to cross zero soon.
+  bool char_speed_will_hit_zero_first{false};
+  bool horizon_will_hit_excision_boundary_first{false};
+};
+}  // namespace control_system::size

--- a/src/ControlSystem/ControlErrors/Size/Initial.cpp
+++ b/src/ControlSystem/ControlErrors/Size/Initial.cpp
@@ -1,0 +1,67 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ControlSystem/ControlErrors/Size/Initial.hpp"
+
+#include <memory>
+
+#include "ControlSystem/ControlErrors/Size/AhSpeed.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaR.hpp"
+
+namespace control_system::size::States {
+
+std::unique_ptr<State> Initial::get_clone() const {
+  return std::make_unique<Initial>(*this);
+}
+
+void Initial::update(const gsl::not_null<Info*> info,
+                     const StateUpdateArgs& update_args,
+                     const CrossingTimeInfo& crossing_time_info) const {
+  // Note that delta_radius_is_in_danger and char_speed_is_in_danger
+  // can be different for different States.
+  const bool char_speed_is_in_danger =
+      crossing_time_info.char_speed_will_hit_zero_first and
+      crossing_time_info.t_char_speed < info->damping_time;
+  const bool delta_radius_is_in_danger =
+      crossing_time_info.horizon_will_hit_excision_boundary_first and
+      crossing_time_info.t_delta_radius < info->damping_time and
+      not char_speed_is_in_danger;
+
+  // This factor is present in SpEC, but it probably isn't necessary
+  // (but it doesn't hurt either).  We keep it here to facilitate
+  // comparison with SpEC.  The value of 1.01 was chosen in SpEC, but
+  // nothing should be sensitive to small changes in this value as long
+  // as it is something slightly greater than unity.
+  constexpr double non_oscillation_factor = 1.01;
+
+  if (char_speed_is_in_danger) {
+    info->discontinuous_change_has_occurred = true;
+    info->state = std::make_unique<States::AhSpeed>();
+    info->target_char_speed =
+        update_args.min_char_speed * non_oscillation_factor;
+    info->suggested_time_scale = crossing_time_info.t_char_speed;
+  } else if (delta_radius_is_in_danger) {
+    info->discontinuous_change_has_occurred = true;
+    info->state = std::make_unique<States::DeltaR>();
+    info->suggested_time_scale = crossing_time_info.t_delta_radius;
+    // Here is where transition to State DeltaRDriftInward will go.
+  } else if (update_args.min_comoving_char_speed > 0.0) {
+    // Here the comoving speed is positive, so prefer DeltaR control.
+    info->discontinuous_change_has_occurred = true;
+    info->state = std::make_unique<States::DeltaR>();
+    // Here is where transition to State DeltaRDriftInward will go.
+  }
+  // Otherwise, no change.
+}
+
+double Initial::control_signal(
+    const Info& info,
+    const ControlSignalArgs& control_signal_args) const {
+  // The return value is the Q that directly controls the speed of the
+  // excision boundary in the distorted frame relative to the grid frame.
+  return info.target_drift_velocity -
+         control_signal_args.time_deriv_of_lambda_00;
+}
+
+PUP::able::PUP_ID Initial::my_PUP_ID = 0;
+}  // namespace control_system::size::States

--- a/src/ControlSystem/ControlErrors/Size/Initial.hpp
+++ b/src/ControlSystem/ControlErrors/Size/Initial.hpp
@@ -1,0 +1,27 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pup.h>
+
+#include "ControlSystem/ControlErrors/Size/Info.hpp"
+#include "ControlSystem/ControlErrors/Size/State.hpp"
+#include "Parallel/CharmPupable.hpp"
+
+namespace control_system::size::States {
+class Initial : public State {
+ public:
+  Initial() = default;
+  std::unique_ptr<State> get_clone() const override;
+  void update(const gsl::not_null<Info*> info,
+              const StateUpdateArgs& update_args,
+              const CrossingTimeInfo& crossing_time_info) const override;
+  double control_signal(
+      const Info& info,
+      const ControlSignalArgs& control_signal_args) const override;
+
+  WRAPPED_PUPable_decl_template(Initial); // NOLINT
+  explicit Initial(CkMigrateMessage* const /*msg*/) {}
+};
+}  // namespace control_system::size::States

--- a/src/ControlSystem/ControlErrors/Size/RegisterDerivedWithCharm.cpp
+++ b/src/ControlSystem/ControlErrors/Size/RegisterDerivedWithCharm.cpp
@@ -1,0 +1,17 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <memory>
+#include <pup.h>
+
+#include "ControlSystem/ControlErrors/Size/AhSpeed.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaR.hpp"
+#include "ControlSystem/ControlErrors/Size/Initial.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+
+namespace control_system::size {
+void register_derived_with_charm() {
+  Parallel::register_classes_with_charm<States::Initial, States::AhSpeed,
+                                        States::DeltaR>();
+}
+}  // namespace control_system::size

--- a/src/ControlSystem/ControlErrors/Size/RegisterDerivedWithCharm.hpp
+++ b/src/ControlSystem/ControlErrors/Size/RegisterDerivedWithCharm.hpp
@@ -1,0 +1,8 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace control_system::size {
+void register_derived_with_charm();
+}  // namespace control_system::size

--- a/src/ControlSystem/ControlErrors/Size/State.hpp
+++ b/src/ControlSystem/ControlErrors/Size/State.hpp
@@ -1,0 +1,136 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <pup.h>
+
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+namespace control_system::size {
+struct Info;
+}  // namespace control_system::size
+/// \endcond
+
+namespace control_system::size {
+
+/// Packages some of the inputs to the State::update, so
+/// that State::update doesn't need a large number of
+/// arguments.
+struct StateUpdateArgs {
+  /// min_char_speed is the minimum over the excision boundary
+  /// of Eq. 89 of \cite Hemberger2012jz.
+  double min_char_speed;
+  /// min_comoving_char_speed is the minimum over the excision boundary
+  /// of Eq. 28 of \cite Hemberger2012jz.
+  double min_comoving_char_speed;
+  /// control_error_delta_r is the control error when the control system
+  /// is in state Label::DeltaR.
+  /// This is Q in Eq. 96 of \cite Hemberger2012jz.
+  double control_error_delta_r;
+};
+
+/// Packages some of the inputs to the State::control_signal, so
+/// that State::control_signal doesn't need a large number of
+/// arguments.
+struct ControlSignalArgs {
+  double min_char_speed;
+  double control_error_delta_r;
+  /// avg_distorted_normal_dot_unit_coord_vector is the average of
+  /// distorted_normal_dot_unit_coord_vector over the excision
+  /// boundary.  Here distorted_normal_dot_unit_coord_vector is Eq. 93
+  /// of \cite Hemberger2012jz.  distorted_normal_dot_unit_coord_vector is
+  /// \f$\hat{n}_i x^i/r\f$ where \f$\nat{n}_i\f$ is the
+  /// distorted-frame unit normal to the excision boundary (pointing
+  /// INTO the hole, i.e. out of the domain), and \f$x^i/r\f$ is the
+  /// distorted-frame (or equivalently the grid frame because it is
+  /// invariant between these two frames because of the required
+  /// limiting behavior of the map we choose) Euclidean normal vector
+  /// from the center of the excision-boundary Strahlkorper to each
+  /// point on the excision-boundary Strahlkorper.
+  double avg_distorted_normal_dot_unit_coord_vector;
+  /// time_deriv_of_lambda_00 is the time derivative of the quantity lambda_00
+  /// that appears in \cite Hemberger2012jz.  time_deriv_of_lambda_00 is (minus)
+  /// the radial velocity of the excision boundary in the distorted frame with
+  /// respect to the grid frame.
+  double time_deriv_of_lambda_00;
+};
+
+/// Represents a 'state' of the size control system.
+///
+/// Each 'state' of the size control system has a different control
+/// signal, which has a different purpose, even though each state
+/// controls the same map quantity, namely the Y00 coefficient of the
+/// shape map.  For example, state Label::AhSpeed controls
+/// the Y00 coefficient of the shape map so that the minimum
+/// characteristic speed is driven towards a target value, and state
+/// Label::DeltaR controls the Y00 coefficient of the shape
+/// map (or the Y00 coefficient of a separate spherically-symmetric size
+/// map) so that the minimum difference between the horizon radius and
+/// the excision boundary radius is driven towards a constant.
+///
+/// Each state has its own logic (the 'update' function) that
+/// determines values of certain parameters (i.e. the things in
+/// Info), including whether the control system should
+/// transition to a different state.
+///
+/// The different states are:
+/// - Initial: drives dr/dt of the excision boundary to
+///   Info::target_drift_velocity.
+/// - AhSpeed: drives the minimum characteristic speed on the excision boundary
+///   to Info::target_char_speed.
+/// - DeltaR: drives the minimum distance between the horizon and the excision
+///   boundary to be constant in time.
+/// - DeltaRDriftInward: Same as DeltaR but the excision boundary has a small
+///   velocity inward.  This state is triggered when it is deemed that the
+///   excision boundary and the horizon are too close to each other; the
+///   small velocity makes the excision boundary and the horizon drift apart.
+/// - DeltaRDriftOutward: Same as DeltaR but the excision boundary has a small
+///   velocity outward.  This state is triggered when it is deemed that the
+///   excision boundary and the horizon are too far apart.
+/// - DeltaRTransition: Same as DeltaR except for the logic that
+///   determines how DeltaRTransition changes to other states.
+///   DeltaRTransition is allowed (under some circumstances) to change
+///   to state DeltaR, but DeltaRDriftOutward and DeltaRDriftInward
+///   are never allowed to change to state DeltaR.  Instead
+///   DeltaRDriftOutward and DeltaRDriftInward are allowed (under
+///   some circumstances) to change to state DeltaRTransition.
+///
+/// The reason that DeltaRDriftInward, DeltaRDriftOutward, and
+/// DeltaRTransition are separate states is to simplify the logic.  In
+/// principle, all 3 of those states could be merged with state
+/// DeltaR, because the control error is the same for all four states
+/// (except for a velocity term that could be set to zero).  But if that
+/// were done, then there would need to be additional complicated
+/// logic in determining transitions between different states, and
+/// that logic would depend not only on the current state, but also on
+/// the previous state.
+class State : public PUP::able {
+ public:
+  State() = default;
+  State(const State& /*rhs*/) = default;
+  State& operator=(const State& /*rhs*/) = default;
+  State(State&& /*rhs*/) = default;
+  State& operator=(State&& /*rhs*/) = default;
+  virtual ~State() override = default;
+
+  virtual std::unique_ptr<State> get_clone() const = 0;
+  /// Updates the Info in `info`.  Notice that `info`
+  /// includes a state, which might be different than the current
+  /// state upon return. It is the caller's responsibility to check
+  /// if the current state has changed.
+  virtual void update(const gsl::not_null<Info*> info,
+                      const StateUpdateArgs& update_args,
+                      const CrossingTimeInfo& crossing_time_info) const = 0;
+  /// Returns the control signal, but does not modify the state or any
+  /// parameters.
+  virtual double control_signal(
+      const Info& info, const ControlSignalArgs& control_signal_args) const = 0;
+
+  WRAPPED_PUPable_abstract(State);  // NOLINT
+  explicit State(CkMigrateMessage* msg) : PUP::able(msg) {}
+};
+}  // namespace control_system::size

--- a/tests/Unit/ControlSystem/CMakeLists.txt
+++ b/tests/Unit/ControlSystem/CMakeLists.txt
@@ -39,5 +39,7 @@ target_link_libraries(
   EventsAndDenseTriggers
   FunctionsOfTime
   ObserverHelpers
+  Parallel
+  SizeControlErrors
   Utilities
 )

--- a/tests/Unit/ControlSystem/ControlErrors/CMakeLists.txt
+++ b/tests/Unit/ControlSystem/ControlErrors/CMakeLists.txt
@@ -5,5 +5,6 @@ set(LIBRARY_SOURCES
   ${LIBRARY_SOURCES}
   ControlErrors/Test_Expansion.cpp
   ControlErrors/Test_Rotation.cpp
+  ControlErrors/Test_SizeControlStates.cpp
   ControlErrors/Test_Translation.cpp
   PARENT_SCOPE)

--- a/tests/Unit/ControlSystem/ControlErrors/Test_SizeControlStates.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_SizeControlStates.cpp
@@ -1,0 +1,404 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cmath>
+#include <memory>
+
+#include "ControlSystem/ControlErrors/Size/AhSpeed.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaR.hpp"
+#include "ControlSystem/ControlErrors/Size/Info.hpp"
+#include "ControlSystem/ControlErrors/Size/Initial.hpp"
+#include "ControlSystem/ControlErrors/Size/RegisterDerivedWithCharm.hpp"
+#include "ControlSystem/ControlErrors/Size/State.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+
+// Params passed into each test.
+struct TestParams {
+  // These are reasonable values for quantities that won't change in
+  // the various logic tests.
+  const double original_target_char_speed{0.011};
+  const double damping_time{0.1};
+  // Defaults are values for quantities that we will vary so that the
+  // logic makes different decisions.
+  double min_char_speed{0.01};
+  double min_comoving_char_speed{-0.02};
+  double control_err_delta_r{0.03};
+  control_system::size::CrossingTimeInfo crossing_time_info{0.0, 0.0, 0.0};
+};
+
+template <typename InitialState, typename FinalState>
+void do_test(const TestParams& test_params,
+             const bool expected_discontinuous_change_has_occurred,
+             const double expected_suggested_time_scale,
+             const double expected_target_char_speed) {
+  // Set reasonable values for quantities that won't change in the various
+  // logic tests.
+  const double target_drift_velocity = 0.001;
+  const double original_suggested_time_scale = 0.0;
+  const bool original_discontinuous_change_has_occurred = false;
+
+  const control_system::size::StateUpdateArgs update_args{
+      test_params.min_char_speed, test_params.min_comoving_char_speed,
+      test_params.control_err_delta_r};
+  control_system::size::Info info{std::make_unique<InitialState>(),
+                                  test_params.damping_time,
+                                  test_params.original_target_char_speed,
+                                  target_drift_velocity,
+                                  original_suggested_time_scale,
+                                  original_discontinuous_change_has_occurred};
+
+  // Check serialization of info
+  const auto info_copy = serialize_and_deserialize(info);
+  // Note that there is no equality operator for info.state, because the
+  // state contains no data; so here we check that the state can be cast to
+  // the type it should be.
+  CHECK(dynamic_cast<InitialState*>(info_copy.state.get()) != nullptr);
+  CHECK(info_copy.damping_time == info.damping_time);
+  CHECK(info_copy.target_char_speed == info.target_char_speed);
+  CHECK(info_copy.target_drift_velocity == info.target_drift_velocity);
+  CHECK(info_copy.suggested_time_scale == info.suggested_time_scale);
+  CHECK(info_copy.discontinuous_change_has_occurred ==
+        info.discontinuous_change_has_occurred);
+
+  auto state = info.state->get_clone();
+  state->update(make_not_null(&info), update_args,
+                test_params.crossing_time_info);
+
+  CHECK(dynamic_cast<FinalState*>(info.state.get()) != nullptr);
+  CHECK(info.damping_time == test_params.damping_time);
+  CHECK(info.target_char_speed == expected_target_char_speed);
+  CHECK(info.target_drift_velocity == target_drift_velocity);
+  CHECK(info.suggested_time_scale == expected_suggested_time_scale);
+  CHECK(info.discontinuous_change_has_occurred ==
+        expected_discontinuous_change_has_occurred);
+}
+
+void test_size_control_update() {
+  TestParams test_params;  // With reasonable default values.
+
+  // The parameters of the tests below are chosen by hand so that the
+  // union of all the tests hit all of the 'if' statements in all of
+  // the control_system::size::State::update functions.
+  //
+  // Each of the tests below is also done in SpEC (with the same input
+  // parameters and the same expected results), to ensure that SpEC
+  // and SpECTRE have the same size control logic.
+
+  // First we do tests of state control_system::size::Label::Initial.
+
+  // should do nothing
+  do_test<control_system::size::States::Initial,
+          control_system::size::States::Initial>(
+      test_params, false, 0.0, test_params.original_target_char_speed);
+
+  // should go into DeltaR state
+  test_params.min_comoving_char_speed = 0.02;
+  do_test<control_system::size::States::Initial,
+          control_system::size::States::DeltaR>(
+      test_params, true, 0.0, test_params.original_target_char_speed);
+
+  // Make deltar cross zero after damping time.
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      0.0, 0.0, 1.1 * test_params.damping_time);
+  do_test<control_system::size::States::Initial,
+          control_system::size::States::DeltaR>(
+      test_params, true, 0.0, test_params.original_target_char_speed);
+
+  // Make deltar cross zero before damping time.
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      0.0, 0.0, 0.9 * test_params.damping_time);
+  do_test<control_system::size::States::Initial,
+          control_system::size::States::DeltaR>(
+      test_params, true, 0.9 * test_params.damping_time,
+      test_params.original_target_char_speed);
+
+  // Make deltar cross zero before damping time, faster than char speed.
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      0.91 * test_params.damping_time, 0.0, 0.9 * test_params.damping_time);
+  do_test<control_system::size::States::Initial,
+          control_system::size::States::DeltaR>(
+      test_params, true, 0.9 * test_params.damping_time,
+      test_params.original_target_char_speed);
+
+  // Make deltar cross zero before damping time, same as char speed.
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      0.9 * test_params.damping_time, 0.0, 0.9 * test_params.damping_time);
+  do_test<control_system::size::States::Initial,
+          control_system::size::States::DeltaR>(
+      test_params, true, 0.9 * test_params.damping_time,
+      test_params.original_target_char_speed);
+
+  // Make deltar cross zero before damping time, slower than char speed.
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      0.89 * test_params.damping_time, 0.0, 0.9 * test_params.damping_time);
+  do_test<control_system::size::States::Initial,
+          control_system::size::States::AhSpeed>(
+      test_params, true, 0.89 * test_params.damping_time,
+      test_params.min_char_speed * 1.01);
+
+  // Now do DeltaR tests
+  test_params.min_comoving_char_speed = -0.02;
+  test_params.crossing_time_info =
+      control_system::size::CrossingTimeInfo(0.0, 0.0, 0.0);
+
+  // Should do nothing
+  do_test<control_system::size::States::DeltaR,
+          control_system::size::States::DeltaR>(
+      test_params, false, 0.0, test_params.original_target_char_speed);
+
+  // Should change suggested time scale
+  test_params.min_comoving_char_speed = 0.02;
+  do_test<control_system::size::States::DeltaR,
+          control_system::size::States::DeltaR>(
+      test_params, false, 0.99 * test_params.damping_time,
+      test_params.original_target_char_speed);
+
+  // Should do nothing
+  test_params.control_err_delta_r = 1.e-4;
+  do_test<control_system::size::States::DeltaR,
+          control_system::size::States::DeltaR>(
+      test_params, false, 0.0, test_params.original_target_char_speed);
+
+  // Make deltar cross zero *slightly* before damping time; should do
+  // nothing (depends on tolerance in control_system::size::StateDeltaR).
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      0.0, 0.0, 0.999 * test_params.damping_time);
+  do_test<control_system::size::States::DeltaR,
+          control_system::size::States::DeltaR>(
+      test_params, false, 0.0, test_params.original_target_char_speed);
+
+  // Make deltar cross zero before damping time.
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      0.0, 0.0, 0.9 * test_params.damping_time);
+  do_test<control_system::size::States::DeltaR,
+          control_system::size::States::DeltaR>(
+      test_params, false, 0.9 * test_params.damping_time,
+      test_params.original_target_char_speed);
+
+  // Make deltar cross zero before damping time, faster than char speed.
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      0.91 * test_params.damping_time, 0.0, 0.9 * test_params.damping_time);
+  do_test<control_system::size::States::DeltaR,
+          control_system::size::States::DeltaR>(
+      test_params, false, 0.9 * test_params.damping_time,
+      test_params.original_target_char_speed);
+
+  // Make deltar cross zero before damping time, same as char speed.
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      0.9 * test_params.damping_time, 0.0, 0.9 * test_params.damping_time);
+  do_test<control_system::size::States::DeltaR,
+          control_system::size::States::DeltaR>(
+      test_params, false, 0.9 * test_params.damping_time,
+      test_params.original_target_char_speed);
+
+  // Make deltar cross zero before damping time, slower than char speed.
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      0.89 * test_params.damping_time, 0.0, 0.9 * test_params.damping_time);
+  do_test<control_system::size::States::DeltaR,
+          control_system::size::States::DeltaR>(
+      test_params, false, 0.89 * test_params.damping_time,
+      test_params.original_target_char_speed);
+
+  // Same crossing_time_info, but comoving_char_speed is negative.
+  // Should have different result as previous test.
+  test_params.min_comoving_char_speed = -0.02;
+  do_test<control_system::size::States::DeltaR,
+          control_system::size::States::AhSpeed>(
+      test_params, true, 0.89 * test_params.damping_time,
+      test_params.min_char_speed * 1.01);
+
+  // Same as 2 tests ago, but comoving_char_speed will cross zero far
+  // in the future.  Should be same result as previous test.
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      0.89 * test_params.damping_time, 1.e12, 0.9 * test_params.damping_time);
+  test_params.min_comoving_char_speed = 0.02;
+  do_test<control_system::size::States::DeltaR,
+          control_system::size::States::AhSpeed>(
+      test_params, true, 0.89 * test_params.damping_time,
+      test_params.min_char_speed * 1.01);
+
+  // Now do AhSpeed tests
+  test_params.min_comoving_char_speed = -0.02;
+  test_params.control_err_delta_r = 0.03;
+  test_params.crossing_time_info =
+      control_system::size::CrossingTimeInfo(0.0, 0.0, 0.0);
+
+  // Should do nothing.
+  do_test<control_system::size::States::AhSpeed,
+          control_system::size::States::AhSpeed>(
+      test_params, false, 0.0, test_params.original_target_char_speed);
+
+  // Should change to DeltaR state.
+  test_params.min_comoving_char_speed = 0.02;
+  do_test<control_system::size::States::AhSpeed,
+          control_system::size::States::DeltaR>(
+      test_params, true, 0.0, test_params.original_target_char_speed);
+
+  // Should do nothing because min_comoving_char_speed is smaller than
+  // min_char_speed.
+  test_params.min_comoving_char_speed = 0.99 * test_params.min_char_speed;
+  do_test<control_system::size::States::AhSpeed,
+          control_system::size::States::AhSpeed>(
+      test_params, false, 0.0, test_params.original_target_char_speed);
+
+  // Now should change to DeltaR state if min_char_speed is larger than
+  // target_char_speed
+  test_params.min_char_speed = 0.012;
+  do_test<control_system::size::States::AhSpeed,
+          control_system::size::States::DeltaR>(
+      test_params, true, 0.0, test_params.original_target_char_speed);
+
+  // Now it should do nothing because comoving crossing time is very small.
+  test_params.min_char_speed = 0.01;
+  test_params.min_comoving_char_speed = 0.02;
+  test_params.crossing_time_info =
+      control_system::size::CrossingTimeInfo(0.0, 1.e-10, 0.0);
+  do_test<control_system::size::States::AhSpeed,
+          control_system::size::States::AhSpeed>(
+      test_params, false, 0.0, test_params.original_target_char_speed);
+
+  // Now it should go to DeltaR because comoving crossing time is large.
+  test_params.crossing_time_info =
+      control_system::size::CrossingTimeInfo(0.0, 100.0, 0.0);
+  do_test<control_system::size::States::AhSpeed,
+          control_system::size::States::DeltaR>(
+      test_params, true, 0.0, test_params.original_target_char_speed);
+
+  // Now it should do nothing because comoving is decreasing faster than
+  // charspeeds.
+  test_params.crossing_time_info =
+      control_system::size::CrossingTimeInfo(1000.0, 100.0, 0.0);
+  do_test<control_system::size::States::AhSpeed,
+          control_system::size::States::AhSpeed>(
+      test_params, false, 0.0, test_params.original_target_char_speed);
+
+  // Now it should think delta_r is in danger,
+  // and it should go to DeltaR state.
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      0.0, 0.0, 19.0 * test_params.damping_time);
+  do_test<control_system::size::States::AhSpeed,
+          control_system::size::States::DeltaR>(
+      test_params, true, 19.0 * test_params.damping_time,
+      test_params.original_target_char_speed);
+
+  // But now with comoving_char_speed negative it should stay in AhSpeed
+  // state, but with a change in target speed.
+  test_params.min_comoving_char_speed = -0.02;
+  do_test<control_system::size::States::AhSpeed,
+          control_system::size::States::AhSpeed>(
+      test_params, true, test_params.damping_time,
+      0.125 * test_params.min_char_speed);
+
+  // With min_comoving_char_speed positive, it should still stay in
+  // AhSpeed state if char_speed has a positive crossing time.
+  test_params.min_comoving_char_speed = 0.02;
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      1.e10, 0.0, 19.0 * test_params.damping_time);
+  do_test<control_system::size::States::AhSpeed,
+          control_system::size::States::AhSpeed>(
+      test_params, true, test_params.damping_time,
+      0.125 * test_params.min_char_speed);
+
+  // .. but not if the delta_r crossing time is small enough.
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      1.e10, 0.0, 4.99 * test_params.damping_time);
+  do_test<control_system::size::States::AhSpeed,
+          control_system::size::States::DeltaR>(
+      test_params, true, 4.99 * test_params.damping_time,
+      test_params.original_target_char_speed);
+
+  // If it thinks char speed is in danger, and the target char speed is
+  // greater than the char speed, it changes the timescale and
+  // nothing else.
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      0.89 * test_params.damping_time, 0.0, 0.9 * test_params.damping_time);
+  do_test<control_system::size::States::AhSpeed,
+          control_system::size::States::AhSpeed>(
+      test_params, false, 0.89 * test_params.damping_time,
+      test_params.original_target_char_speed);
+
+  // ...but in the same situation, if char speed is greater than the
+  // target speed, it resets the target speed too.
+  test_params.min_char_speed = test_params.original_target_char_speed * 1.0001;
+  do_test<control_system::size::States::AhSpeed,
+          control_system::size::States::AhSpeed>(
+      test_params, false, 0.89 * test_params.damping_time,
+      test_params.min_char_speed * 1.01);
+
+  // Same situation as previous, but char speed is *barely* in danger.
+  test_params.min_char_speed = test_params.original_target_char_speed * 1.09999;
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      0.98999 * test_params.damping_time, 0.0, 0.99 * test_params.damping_time);
+  do_test<control_system::size::States::AhSpeed,
+          control_system::size::States::AhSpeed>(
+      test_params, false, 0.98999 * test_params.damping_time,
+      test_params.min_char_speed * 1.01);
+
+  // Same situation as previous, but char speed is *barely not* in danger,
+  // and DeltaR is also not in danger.  Should go to DeltaR state.
+  test_params.min_char_speed = test_params.original_target_char_speed * 1.10001;
+  do_test<control_system::size::States::AhSpeed,
+          control_system::size::States::DeltaR>(
+      test_params, true, 0.0, test_params.original_target_char_speed);
+
+  // Again char speed is *barely not* in danger, but for a different reason.
+  test_params.min_char_speed = test_params.original_target_char_speed * 1.09999;
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      0.99001 * test_params.damping_time, 0.0,
+      0.992 * test_params.damping_time);
+  do_test<control_system::size::States::AhSpeed,
+          control_system::size::States::DeltaR>(
+      test_params, true, 0.0, test_params.original_target_char_speed);
+}
+
+void test_size_control_signal() {
+  // This is a very rudimentary test.  It just computes
+  // the same thing as the thing it is testing, but coded differently.
+  const control_system::size::ControlSignalArgs args{0.01, 0.03, 1.2, 0.33};
+  const control_system::size::Info info{
+      std::make_unique<control_system::size::States::Initial>(),
+      1.1,
+      0.011,
+      1.e-3,
+      2.e-3,
+      false};
+  CHECK(control_system::size::States::Initial{}.control_signal(info, args) ==
+        -0.329);
+  CHECK(control_system::size::States::AhSpeed{}.control_signal(info, args) ==
+        approx(0.001 * sqrt(4.0 * M_PI) / 1.2));
+  CHECK(control_system::size::States::DeltaR{}.control_signal(info, args) ==
+        0.03);
+}
+
+template<typename State>
+void test_clone_and_serialization() {
+  std::unique_ptr<control_system::size::State> state =
+      std::make_unique<State>();
+
+  // Note that we don't check equality here.  None of the derived
+  // classes of control_system::size::State actually have data.
+  // We just check that the types are correct.
+  CHECK(dynamic_cast<State*>(serialize_and_deserialize(state).get()) !=
+        nullptr);
+
+  // Note that we don't check equality here.  None of the derived
+  // classes of control_system::size::State actually have data.
+  // We just check that the types are correct.
+  CHECK(dynamic_cast<State*>(state->get_clone().get()) != nullptr);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ControlSystem.SizeControlStates", "[Domain][Unit]") {
+  control_system::size::register_derived_with_charm();
+  test_size_control_update();
+  test_size_control_signal();
+  test_clone_and_serialization<control_system::size::States::Initial>();
+  test_clone_and_serialization<control_system::size::States::AhSpeed>();
+  test_clone_and_serialization<control_system::size::States::DeltaR>();
+}


### PR DESCRIPTION
## Proposed changes

Adds the logic and control parameter computation for size control.

This is done via an abstract base class SizeControlState
that has derived classes for each concrete state of the size
control system.

The logic (and control errors) are added in such a way that the
code can be tested independently.  There is (intentionally) no
dependence on Strahlkorpers, FunctionsOfTime, ZeroCrossingPredictors,
or the control system framework itself.

The thing that calls the SizeControlState member functions
(and thus needs to know about Strahlkorpers, FunctionsOfTime, etc so
that it can compute the arguments to those member functions)
will be added in a later PR.

*Note:*  The logic currently lacks some of the size control states that are present in SpEC.  Those states will be added in a later PR.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
