### PR TITLE
Run a checkpoint test in its own directory

### DIFF
--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -42,17 +42,20 @@ function(add_algorithm_test_with_restart_from_checkpoint TEST_NAME)
     "${ALGORITHM_TEST_LINK_LIBRARIES}")
   # Executable writes checkpoint file into the dir where it runs:
   set(CHECKPOINT
-    "${CMAKE_BINARY_DIR}/tests/Unit/Parallel/SpectreCheckpoint000000")
+    "${CMAKE_BINARY_DIR}/tests/Unit/Parallel/${TEST_NAME}/SpectreCheckpoint000000")
   add_test(
     NAME "Unit.Parallel.${TEST_NAME}"
     COMMAND
     ${SHELL_EXECUTABLE}
     -c
-    "rm -rf ${CHECKPOINT} \
+    "mkdir -p ${TEST_NAME} \
+    && cd ${TEST_NAME} \
+    && rm -rf ${CHECKPOINT} \
     && ${SPECTRE_TEST_RUNNER} ${CMAKE_BINARY_DIR}/bin/Test_${TEST_NAME} 2>&1 \
     && ${SPECTRE_TEST_RUNNER} ${CMAKE_BINARY_DIR}/bin/Test_${TEST_NAME} \
        +restart ${CHECKPOINT} 2>&1 \
-    && rm -rf ${CHECKPOINT}"
+    && rm -rf ${CHECKPOINT} \
+    && cd .."
     )
   set_standalone_test_properties("Unit.Parallel.${TEST_NAME}")
 endfunction()


### PR DESCRIPTION
This prevents checkpoint tests from clashing with each other when
run in parallel.

It also prevents executables that check for the existence of
checkpoint files from failing.

## Proposed changes

Modify the cmake function `add_algorithm_test_with_restart_from_checkpoint` to run the test in its own directory.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
