### PR TITLE
Combine registration phases

### DIFF
--- a/src/Domain/Structure/ElementId.cpp
+++ b/src/Domain/Structure/ElementId.cpp
@@ -157,6 +157,11 @@ bool is_zeroth_element(const ElementId<Dim>& id,
              : base_checks;
 }
 
+template <size_t Dim>
+bool is_zeroth_element(const ElementId<Dim>& id) {
+  return is_zeroth_element(id, std::nullopt);
+}
+
 // LCOV_EXCL_START
 template <size_t VolumeDim>
 size_t hash_value(const ElementId<VolumeDim>& id) {
@@ -188,6 +193,7 @@ size_t hash<ElementId<VolumeDim>>::operator()(
                           const ElementId<GET_DIM(data)>& rhs);             \
   template bool is_zeroth_element(const ElementId<GET_DIM(data)>& id,       \
                                   const std::optional<size_t>& grid_index); \
+  template bool is_zeroth_element(const ElementId<GET_DIM(data)>& id);      \
   template size_t hash_value(const ElementId<GET_DIM(data)>&);              \
   namespace std { /* NOLINT */                                              \
   template struct hash<ElementId<GET_DIM(data)>>;                           \

--- a/src/Domain/Structure/ElementId.hpp
+++ b/src/Domain/Structure/ElementId.hpp
@@ -182,6 +182,7 @@ bool operator>=(const ElementId<VolumeDim>& lhs,
   return !(lhs < rhs);
 }
 
+/// @{
 /// \brief Returns a bool if the element is the zeroth element in the domain.
 ///
 /// \details An element is considered to be the zeroth element if its ElementId
@@ -213,8 +214,14 @@ bool operator>=(const ElementId<VolumeDim>& lhs,
 /// \endparblock
 template <size_t Dim>
 bool is_zeroth_element(const ElementId<Dim>& id,
-                       const std::optional<size_t>& grid_index = std::nullopt);
+                       const std::optional<size_t>& grid_index);
 
+// This overload is added (instead of adding a default value for grid_index)
+// in order to avoid adding DomainStructures as a dependency of Parallel
+// by using a forward declaration in Parallel/DistributedObject.hpp
+template <size_t Dim>
+bool is_zeroth_element(const ElementId<Dim>& id);
+/// @}
 // ######################################################################
 // INLINE DEFINITIONS
 // ######################################################################

--- a/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
+++ b/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
@@ -271,11 +271,11 @@ struct Metavariables {
 
   using dg_element_array = elliptic::DgElementArray<
       Metavariables,
-      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
-                                        initialization_actions>,
-                 Parallel::PhaseActions<Parallel::Phase::RegisterWithObserver,
-                                        register_actions>,
-                 Parallel::PhaseActions<Parallel::Phase::Solve, solve_actions>>,
+      tmpl::list<
+          Parallel::PhaseActions<Parallel::Phase::Initialization,
+                                 initialization_actions>,
+          Parallel::PhaseActions<Parallel::Phase::Register, register_actions>,
+          Parallel::PhaseActions<Parallel::Phase::Solve, solve_actions>>,
       LinearSolver::multigrid::ElementsAllocator<
           volume_dim, typename multigrid::options_group>>;
 
@@ -288,7 +288,7 @@ struct Metavariables {
                  observers::ObserverWriter<Metavariables>>>;
 
   static constexpr std::array<Parallel::Phase, 4> default_phase_order{
-      {Parallel::Phase::Initialization, Parallel::Phase::RegisterWithObserver,
+      {Parallel::Phase::Initialization, Parallel::Phase::Register,
        Parallel::Phase::Solve, Parallel::Phase::Exit}};
 
   // NOLINTNEXTLINE(google-runtime-references)

--- a/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
@@ -252,11 +252,11 @@ struct Metavariables {
 
   using dg_element_array = elliptic::DgElementArray<
       Metavariables,
-      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
-                                        initialization_actions>,
-                 Parallel::PhaseActions<Parallel::Phase::RegisterWithObserver,
-                                        register_actions>,
-                 Parallel::PhaseActions<Parallel::Phase::Solve, solve_actions>>,
+      tmpl::list<
+          Parallel::PhaseActions<Parallel::Phase::Initialization,
+                                 initialization_actions>,
+          Parallel::PhaseActions<Parallel::Phase::Register, register_actions>,
+          Parallel::PhaseActions<Parallel::Phase::Solve, solve_actions>>,
       LinearSolver::multigrid::ElementsAllocator<
           volume_dim, typename multigrid::options_group>>;
 
@@ -269,7 +269,7 @@ struct Metavariables {
                  observers::ObserverWriter<Metavariables>>>;
 
   static constexpr std::array<Parallel::Phase, 4> default_phase_order{
-      {Parallel::Phase::Initialization, Parallel::Phase::RegisterWithObserver,
+      {Parallel::Phase::Initialization, Parallel::Phase::Register,
        Parallel::Phase::Solve, Parallel::Phase::Exit}};
 
   // NOLINTNEXTLINE(google-runtime-references)

--- a/src/Elliptic/Executables/Xcts/SolveXcts.hpp
+++ b/src/Elliptic/Executables/Xcts/SolveXcts.hpp
@@ -318,11 +318,11 @@ struct Metavariables {
 
   using dg_element_array = elliptic::DgElementArray<
       Metavariables,
-      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
-                                        initialization_actions>,
-                 Parallel::PhaseActions<Parallel::Phase::RegisterWithObserver,
-                                        register_actions>,
-                 Parallel::PhaseActions<Parallel::Phase::Solve, solve_actions>>,
+      tmpl::list<
+          Parallel::PhaseActions<Parallel::Phase::Initialization,
+                                 initialization_actions>,
+          Parallel::PhaseActions<Parallel::Phase::Register, register_actions>,
+          Parallel::PhaseActions<Parallel::Phase::Solve, solve_actions>>,
       LinearSolver::multigrid::ElementsAllocator<
           volume_dim, typename multigrid::options_group>>;
 
@@ -336,7 +336,7 @@ struct Metavariables {
                  observers::ObserverWriter<Metavariables>>>;
 
   static constexpr std::array<Parallel::Phase, 4> default_phase_order{
-      {Parallel::Phase::Initialization, Parallel::Phase::RegisterWithObserver,
+      {Parallel::Phase::Initialization, Parallel::Phase::Register,
        Parallel::Phase::Solve, Parallel::Phase::Exit}};
 
   // NOLINTNEXTLINE(google-runtime-references)

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -316,7 +316,7 @@ struct EvolutionMetavars {
           Parallel::PhaseActions<Parallel::Phase::Initialization,
                                  initialization_actions>,
 
-          Parallel::PhaseActions<Parallel::Phase::RegisterWithObserver,
+          Parallel::PhaseActions<Parallel::Phase::Register,
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,
 
@@ -349,9 +349,8 @@ struct EvolutionMetavars {
 
   static constexpr std::array<Parallel::Phase, 5> default_phase_order{
       {Parallel::Phase::Initialization,
-       Parallel::Phase::InitializeTimeStepperHistory,
-       Parallel::Phase::RegisterWithObserver, Parallel::Phase::Evolve,
-       Parallel::Phase::Exit}};
+       Parallel::Phase::InitializeTimeStepperHistory, Parallel::Phase::Register,
+       Parallel::Phase::Evolve, Parallel::Phase::Exit}};
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/) {}

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -364,9 +364,8 @@ struct EvolutionMetavars {
        Parallel::Phase::RegisterWithElementDataReader,
        Parallel::Phase::ImportInitialData,
        Parallel::Phase::InitializeInitialDataDependentQuantities,
-       Parallel::Phase::RegisterWithObserver,
-       Parallel::Phase::InitializeTimeStepperHistory, Parallel::Phase::Evolve,
-       Parallel::Phase::Exit}};
+       Parallel::Phase::Register, Parallel::Phase::InitializeTimeStepperHistory,
+       Parallel::Phase::Evolve, Parallel::Phase::Exit}};
 
   using step_actions = tmpl::list<
       evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
@@ -429,7 +428,7 @@ struct EvolutionMetavars {
           Parallel::PhaseActions<
               Parallel::Phase::InitializeInitialDataDependentQuantities,
               initialize_initial_data_dependent_quantities_actions>,
-          Parallel::PhaseActions<Parallel::Phase::RegisterWithObserver,
+          Parallel::PhaseActions<Parallel::Phase::Register,
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -242,7 +242,7 @@ struct EvolutionMetavars {
               Parallel::Phase::InitializeTimeStepperHistory,
               SelfStart::self_start_procedure<step_actions, system>>,
 
-          Parallel::PhaseActions<Parallel::Phase::RegisterWithObserver,
+          Parallel::PhaseActions<Parallel::Phase::Register,
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,
 
@@ -271,9 +271,8 @@ struct EvolutionMetavars {
 
   static constexpr std::array<Parallel::Phase, 5> default_phase_order{
       {Parallel::Phase::Initialization,
-       Parallel::Phase::InitializeTimeStepperHistory,
-       Parallel::Phase::RegisterWithObserver, Parallel::Phase::Evolve,
-       Parallel::Phase::Exit}};
+       Parallel::Phase::InitializeTimeStepperHistory, Parallel::Phase::Register,
+       Parallel::Phase::Evolve, Parallel::Phase::Exit}};
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/) {}

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -257,7 +257,7 @@ struct EvolutionMetavars {
               Parallel::Phase::InitializeTimeStepperHistory,
               SelfStart::self_start_procedure<step_actions, system>>,
 
-          Parallel::PhaseActions<Parallel::Phase::RegisterWithObserver,
+          Parallel::PhaseActions<Parallel::Phase::Register,
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,
 
@@ -289,9 +289,8 @@ struct EvolutionMetavars {
 
   static constexpr std::array<Parallel::Phase, 5> default_phase_order{
       {Parallel::Phase::Initialization,
-       Parallel::Phase::InitializeTimeStepperHistory,
-       Parallel::Phase::RegisterWithObserver, Parallel::Phase::Evolve,
-       Parallel::Phase::Exit}};
+       Parallel::Phase::InitializeTimeStepperHistory, Parallel::Phase::Register,
+       Parallel::Phase::Evolve, Parallel::Phase::Exit}};
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/) {}

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -323,7 +323,7 @@ struct EvolutionMetavars {
           Parallel::PhaseActions<Parallel::Phase::Initialization,
                                  initialization_actions>,
 
-          Parallel::PhaseActions<Parallel::Phase::RegisterWithObserver,
+          Parallel::PhaseActions<Parallel::Phase::Register,
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,
 
@@ -354,9 +354,8 @@ struct EvolutionMetavars {
 
   static constexpr std::array<Parallel::Phase, 5> default_phase_order{
       {Parallel::Phase::Initialization,
-       Parallel::Phase::InitializeTimeStepperHistory,
-       Parallel::Phase::RegisterWithObserver, Parallel::Phase::Evolve,
-       Parallel::Phase::Exit}};
+       Parallel::Phase::InitializeTimeStepperHistory, Parallel::Phase::Register,
+       Parallel::Phase::Evolve, Parallel::Phase::Exit}};
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/) {}

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -261,7 +261,7 @@ struct EvolutionMetavars {
               Parallel::Phase::InitializeTimeStepperHistory,
               SelfStart::self_start_procedure<step_actions, system>>,
 
-          Parallel::PhaseActions<Parallel::Phase::RegisterWithObserver,
+          Parallel::PhaseActions<Parallel::Phase::Register,
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,
 
@@ -289,9 +289,8 @@ struct EvolutionMetavars {
 
   static constexpr std::array<Parallel::Phase, 5> default_phase_order{
       {Parallel::Phase::Initialization,
-       Parallel::Phase::InitializeTimeStepperHistory,
-       Parallel::Phase::RegisterWithObserver, Parallel::Phase::Evolve,
-       Parallel::Phase::Exit}};
+       Parallel::Phase::InitializeTimeStepperHistory, Parallel::Phase::Register,
+       Parallel::Phase::Evolve, Parallel::Phase::Exit}};
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/) {}

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -246,7 +246,7 @@ struct Metavariables {
                       ::Initialization::Actions::
                           RemoveOptionsAndTerminatePhase>>,
               Parallel::PhaseActions<
-                  Parallel::Phase::RegisterWithObserver,
+                  Parallel::Phase::Register,
                   tmpl::list<observers::Actions::RegisterWithObservers<
                                  Actions::ExportCoordinates<Dim>>,
                              observers::Actions::RegisterWithObservers<
@@ -265,7 +265,7 @@ struct Metavariables {
       tmpl::list<MinGridSpacingReductionData>>;
 
   static constexpr std::array<Parallel::Phase, 4> default_phase_order{
-      {Parallel::Phase::Initialization, Parallel::Phase::RegisterWithObserver,
+      {Parallel::Phase::Initialization, Parallel::Phase::Register,
        Parallel::Phase::Execute, Parallel::Phase::Exit}};
 
   // NOLINTNEXTLINE(google-runtime-references)

--- a/src/Parallel/Phase.cpp
+++ b/src/Parallel/Phase.cpp
@@ -26,7 +26,6 @@ std::vector<Phase> known_phases() {
           Phase::LoadBalancing,
           Phase::Register,
           Phase::RegisterWithElementDataReader,
-          Phase::RegisterWithObserver,
           Phase::Solve,
           Phase::Testing,
           Phase::WriteCheckpoint};
@@ -56,8 +55,6 @@ std::ostream& operator<<(std::ostream& os, const Phase& phase) {
       return os << "Register";
     case Parallel::Phase::RegisterWithElementDataReader:
       return os << "RegisterWithElementDataReader";
-    case Parallel::Phase::RegisterWithObserver:
-      return os << "RegisterWithObserver";
     case Parallel::Phase::Solve:
       return os << "Solve";
     case Parallel::Phase::Testing:

--- a/src/Parallel/Phase.hpp
+++ b/src/Parallel/Phase.hpp
@@ -71,8 +71,6 @@ enum class Phase {
   Register,
   ///  phase in which components register with the data importer components
   RegisterWithElementDataReader,
-  ///  phase in which components register with the observer components
-  RegisterWithObserver,
   ///  phase in which something is solved
   Solve,
   ///  phase in which something is tested

--- a/tests/Unit/Helpers/IO/Observers/ObserverHelpers.hpp
+++ b/tests/Unit/Helpers/IO/Observers/ObserverHelpers.hpp
@@ -50,7 +50,7 @@ struct element_component {
   using array_index = ElementIdType;
 
   using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<Parallel::Phase::RegisterWithObserver,
+      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Register,
                                         RegistrationActionsList>>;
 };
 

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
@@ -355,7 +355,7 @@ using ElementArray = elliptic::DgElementArray<
     Metavariables,
     tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
                                       initialization_actions<Metavariables>>,
-               Parallel::PhaseActions<Parallel::Phase::RegisterWithObserver,
+               Parallel::PhaseActions<Parallel::Phase::Register,
                                       register_actions<Metavariables>>,
                Parallel::PhaseActions<Parallel::Phase::Solve,
                                       solve_actions<Metavariables>>,

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
@@ -277,7 +277,7 @@ struct ElementArray {
                      detail::init_preconditioner<preconditioner>,
                      Parallel::Actions::TerminatePhase>>,
       Parallel::PhaseActions<
-          Parallel::Phase::RegisterWithObserver,
+          Parallel::Phase::Register,
           tmpl::list<typename linear_solver::register_element,
                      detail::register_preconditioner<preconditioner>,
                      Parallel::Actions::TerminatePhase>>,
@@ -371,7 +371,7 @@ struct OutputCleaner {
 
 // [default_phase_order_array]
 static constexpr std::array<Parallel::Phase, 6> default_phase_order{
-    {Parallel::Phase::Initialization, Parallel::Phase::RegisterWithObserver,
+    {Parallel::Phase::Initialization, Parallel::Phase::Register,
      Parallel::Phase::Solve, Parallel::Phase::Testing, Parallel::Phase::Cleanup,
      Parallel::Phase::Exit}};
 // [default_phase_order_array]

--- a/tests/Unit/Helpers/ParallelAlgorithms/NonlinearSolver/Algorithm.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/NonlinearSolver/Algorithm.hpp
@@ -136,7 +136,7 @@ struct ElementArray {
                      typename linear_solver::initialize_element,
                      Parallel::Actions::TerminatePhase>>,
       Parallel::PhaseActions<
-          Parallel::Phase::RegisterWithObserver,
+          Parallel::Phase::Register,
           tmpl::list<typename nonlinear_solver::register_element,
                      typename linear_solver::register_element,
                      Parallel::Actions::TerminatePhase>>,
@@ -185,9 +185,8 @@ template <typename Metavariables>
 using OutputCleaner =
     LinearSolverAlgorithmTestHelpers::OutputCleaner<Metavariables>;
 
-
 static constexpr std::array<Parallel::Phase, 6> default_phase_order = {
-    {Parallel::Phase::Initialization, Parallel::Phase::RegisterWithObserver,
+    {Parallel::Phase::Initialization, Parallel::Phase::Register,
      Parallel::Phase::Solve, Parallel::Phase::Testing, Parallel::Phase::Cleanup,
      Parallel::Phase::Exit}};
 

--- a/tests/Unit/IO/Observers/Test_ReductionObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_ReductionObserver.cpp
@@ -114,8 +114,7 @@ void test_reduction_observer(const bool observe_per_core) {
         &runner, ActionTesting::NodeId{get_node_id(id)},
         ActionTesting::LocalCoreId{get_local_core_id(id)}, id);
   }
-  ActionTesting::set_phase(make_not_null(&runner),
-                           Parallel::Phase::RegisterWithObserver);
+  ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Register);
 
   // Register elements
   for (const auto& id : element_ids) {

--- a/tests/Unit/IO/Observers/Test_RegisterElements.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterElements.cpp
@@ -57,8 +57,7 @@ void check_observer_registration() {
   for (const auto& id : element_ids) {
     ActionTesting::emplace_component<element_comp>(&runner, id);
   }
-  ActionTesting::set_phase(make_not_null(&runner),
-                           Parallel::Phase::RegisterWithObserver);
+  ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Register);
 
   // Check observer component
   CHECK(

--- a/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
@@ -193,8 +193,7 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.VolumeObserver", "[Unit][Observers]") {
   for (const auto& id : element_ids) {
     ActionTesting::emplace_component<element_comp>(&runner, id);
   }
-  ActionTesting::set_phase(make_not_null(&runner),
-                           Parallel::Phase::RegisterWithObserver);
+  ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Register);
 
   // Register elements
   for (const auto& id : element_ids) {

--- a/tests/Unit/Parallel/PhaseControl/Test_ExecutePhaseChange.cpp
+++ b/tests/Unit/Parallel/PhaseControl/Test_ExecutePhaseChange.cpp
@@ -133,7 +133,7 @@ struct Metavariables {
       tmpl::list<PhaseControl::Tags::PhaseChangeAndTriggers>;
 
   static constexpr std::array<Parallel::Phase, 7> default_phase_order{
-      {Parallel::Phase::Register, Parallel::Phase::RegisterWithObserver,
+      {Parallel::Phase::Register, Parallel::Phase::Testing,
        Parallel::Phase::Solve, Parallel::Phase::ImportInitialData,
        Parallel::Phase::Evolve, Parallel::Phase::Execute,
        Parallel::Phase::Cleanup}};
@@ -206,7 +206,7 @@ SPECTRE_TEST_CASE("Unit.Parallel.PhaseControl.ExecutePhaseChange",
   {
     INFO("Arbitrate based on phase change decision data");
     // if used, the phase change objects correspond to phases:
-    // RegisterWithObserver, Solve, ImportInitialData, Evolve, Cleanup  (in that
+    // Testing, Solve, ImportInitialData, Evolve, Cleanup  (in that
     // order)
     phase_change_data = phase_change_decision_data_type{false, false, false,
                                                         false, false, false};
@@ -230,14 +230,14 @@ SPECTRE_TEST_CASE("Unit.Parallel.PhaseControl.ExecutePhaseChange",
     // those phases without evaluating the other phase change objects
     CHECK(SINGLE_ARG(PhaseControl::arbitrate_phase_change(
               make_not_null(&phase_change_data), Parallel::Phase::Register,
-              global_cache)) == Parallel::Phase::RegisterWithObserver);
+              global_cache)) == Parallel::Phase::Testing);
     CHECK(phase_change_data == SINGLE_ARG(phase_change_decision_data_type{
                                    false, false, true, true, false, false}));
     phase_change_data =
         phase_change_decision_data_type{true, false, true, true, false, true};
     CHECK(SINGLE_ARG(PhaseControl::arbitrate_phase_change(
               make_not_null(&phase_change_data), Parallel::Phase::Register,
-              global_cache)) == Parallel::Phase::RegisterWithObserver);
+              global_cache)) == Parallel::Phase::Testing);
     CHECK(phase_change_data == SINGLE_ARG(phase_change_decision_data_type{
                                    false, false, true, true, false, false}));
     CHECK(SINGLE_ARG(PhaseControl::arbitrate_phase_change(

--- a/tests/Unit/Parallel/Test_AlgorithmCore.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmCore.cpp
@@ -218,7 +218,7 @@ struct NoOpsComponent {
     Parallel::get_parallel_component<NoOpsComponent>(local_cache)
         .start_phase(next_phase);
     // [start_phase]
-    if (next_phase == Parallel::Phase::RegisterWithObserver) {
+    if (next_phase == Parallel::Phase::Testing) {
       Parallel::simple_action<no_op_test::finalize>(
           Parallel::get_parallel_component<NoOpsComponent>(local_cache));
     }
@@ -688,7 +688,7 @@ struct TestMetavariables {
 
   static constexpr std::array<Parallel::Phase, 10> default_phase_order{
       {Parallel::Phase::Initialization, Parallel::Phase::Register,
-       Parallel::Phase::RegisterWithObserver, Parallel::Phase::Solve,
+       Parallel::Phase::Testing, Parallel::Phase::Solve,
        Parallel::Phase::Evolve, Parallel::Phase::ImportInitialData,
        Parallel::Phase::InitializeInitialDataDependentQuantities,
        Parallel::Phase::Execute, Parallel::Phase::Cleanup,

--- a/tests/Unit/Parallel/Test_AlgorithmCore.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmCore.cpp
@@ -72,7 +72,7 @@ struct hash<TestAlgorithmArrayInstance> {
 };
 }  // namespace std
 
-struct ElementId {};
+struct ElementIndex {};
 
 struct CountActionsCalled : db::SimpleTag {
   static std::string name() { return "CountActionsCalled"; }
@@ -362,7 +362,7 @@ template <class Metavariables>
 struct MutateComponent {
   using chare_type = Parallel::Algorithms::Singleton;
   using metavariables = Metavariables;
-  using array_index = ElementId;  // Just to test nothing breaks
+  using array_index = ElementIndex;  // Just to test nothing breaks
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization,
                              tmpl::list<add_remove_test::initialize>>,
@@ -531,7 +531,7 @@ template <class Metavariables>
 struct ReceiveComponent {
   using chare_type = Parallel::Algorithms::Singleton;
   using metavariables = Metavariables;
-  using array_index = ElementId;  // Just to test nothing breaks
+  using array_index = ElementIndex;  // Just to test nothing breaks
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization,
                              tmpl::list<receive_data_test::initialize>>,
@@ -640,7 +640,7 @@ template <class Metavariables>
 struct AnyOrderComponent {
   using chare_type = Parallel::Algorithms::Singleton;
   using metavariables = Metavariables;
-  using array_index = ElementId;  // Just to test nothing breaks
+  using array_index = ElementIndex;  // Just to test nothing breaks
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization,

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithm.cpp
@@ -117,7 +117,7 @@ struct Metavariables {
           tmpl::list<
               Parallel::PhaseActions<Parallel::Phase::Initialization,
                                      initialization_actions>,
-              Parallel::PhaseActions<Parallel::Phase::RegisterWithObserver,
+              Parallel::PhaseActions<Parallel::Phase::Register,
                                      register_actions>,
               Parallel::PhaseActions<Parallel::Phase::Solve, solve_actions>,
               Parallel::PhaseActions<Parallel::Phase::Testing, test_actions>>,

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridPreconditionedGmresAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridPreconditionedGmresAlgorithm.cpp
@@ -150,7 +150,7 @@ struct Metavariables {
           tmpl::list<
               Parallel::PhaseActions<Parallel::Phase::Initialization,
                                      initialization_actions>,
-              Parallel::PhaseActions<Parallel::Phase::RegisterWithObserver,
+              Parallel::PhaseActions<Parallel::Phase::Register,
                                      register_actions>,
               Parallel::PhaseActions<Parallel::Phase::Solve, solve_actions>,
               Parallel::PhaseActions<Parallel::Phase::Testing, test_actions>>,


### PR DESCRIPTION
## Proposed changes

Remove Parallel::Phase::RegisterWithObserver.

Add a message that is printed if you have a Parallel::Phase in a PhaseAction that is not in metavariables::default_phase_order

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

If you are using Parallel::Phase::RegisterWithObserver, instead use Parallel::Phase::Register

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
