### PR TITLE
Cce data in separate file

### DIFF
--- a/docs/Tutorials/CCE.md
+++ b/docs/Tutorials/CCE.md
@@ -81,13 +81,13 @@ CCE using external data are:
   have the time value followed by the real and imaginary parts
   of the complex modes in m-varies-fastest order.
 
-Once you have the volume data output file from a successful CCE run, you can
+Once you have the reduction data output file from a successful CCE run, you can
 confirm the integrity of the h5 file and its contents by running
 ```
-h5ls CharacteristicExtractVolumeData0.h5
+h5ls CharacteristicExtractReductionData.h5/Cce.dir
 ```
 
-For the volume file produced by a successful run, the output of the `h5ls`
+For the reduction file produced by a successful run, the output of the `h5ls`
 should resemble
 ```
 EthInertialRetardedTime.dat Dataset {3995/Inf, 163}
@@ -140,7 +140,7 @@ def get_modes_from_block_output(filename, dataset, modes=[[2, 2], [3, 3]]):
 
 plot_quantities = ["Strain", "News", "Psi0", "Psi1", "Psi2", "Psi3", "Psi4"]
 mode_set = [[2, 2], [3, 3]]
-filename = "CharacteristicExtractVolume0.h5"
+filename = "CharacteristicExtractReductionData.h5"
 output_plot_filename = "CCE_plot.pdf"
 
 legend = []

--- a/src/Evolution/Systems/Cce/Actions/ScriObserveInterpolated.hpp
+++ b/src/Evolution/Systems/Cce/Actions/ScriObserveInterpolated.hpp
@@ -16,7 +16,7 @@
 #include "Evolution/Systems/Cce/OptionTags.hpp"
 #include "Evolution/Systems/Cce/ScriPlusInterpolationManager.hpp"
 #include "Evolution/Systems/Cce/Tags.hpp"
-#include "IO/Observer/WriteSimpleData.hpp"
+#include "IO/Observer/ReductionActions.hpp"
 #include "NumericalAlgorithms/Spectral/SwshCoefficients.hpp"
 #include "NumericalAlgorithms/Spectral/SwshTransform.hpp"
 #include "Parallel/AlgorithmExecution.hpp"
@@ -252,13 +252,12 @@ struct ScriObserveInterpolated {
       (*data_to_write_buffer)[2 * i + 1] = real(goldberg_modes.data()[i]);
       (*data_to_write_buffer)[2 * i + 2] = imag(goldberg_modes.data()[i]);
     }
-    auto& my_proxy = Parallel::get_parallel_component<ParallelComponent>(cache);
     auto observer_proxy =
-        Parallel::get_parallel_component<ObserverWriterComponent>(
-            cache)[Parallel::my_node<size_t>(*Parallel::local(my_proxy))];
-    Parallel::threaded_action<observers::ThreadedActions::WriteSimpleData>(
-        observer_proxy, legend, *data_to_write_buffer,
-        "/" + detail::ScriOutput<Tag>::name());
+        Parallel::get_parallel_component<ObserverWriterComponent>(cache)[0];
+    Parallel::threaded_action<
+        observers::ThreadedActions::WriteReductionDataRow>(
+        observer_proxy, "/Cce/" + detail::ScriOutput<Tag>::name(), legend,
+        std::make_tuple(*data_to_write_buffer));
   }
 };
 }  // namespace Actions

--- a/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
@@ -5,12 +5,12 @@
 # Check: parse;execute_check_output
 # Timeout: 10
 # ExpectedOutput:
-#   CharacteristicExtractVolume0.h5
+#   CharacteristicExtractReduction.h5
 # OutputFileChecks:
 #   - Label: "check_news"
-#     Subfile: "/News.dat"
-#     FileGlob: "CharacteristicExtractVolume*.h5"
-#     ExpectedDataSubfile: "/News_expected.dat"
+#     Subfile: "/Cce/News.dat"
+#     FileGlob: "CharacteristicExtractReduction.h5"
+#     ExpectedDataSubfile: "/Cce/News_expected.dat"
 #     AbsoluteTolerance: 5e-5
 
 Evolution:
@@ -27,8 +27,8 @@ ResourceInfo:
       Exclusive: false
 
 Observers:
-  VolumeFileName: "CharacteristicExtractVolume"
-  ReductionFileName: "CharacteristicExtractUnusedReduction"
+  VolumeFileName: "CharacteristicExtractUnusedVolume"
+  ReductionFileName: "CharacteristicExtractReduction"
 
 Cce:
   Evolution:

--- a/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
@@ -5,12 +5,12 @@
 # Check: parse;execute_check_output
 # Timeout: 10
 # ExpectedOutput:
-#   CharacteristicExtractVolume0.h5
+#   CharacteristicExtractReduction.h5
 # OutputFileChecks:
 #   - Label: "check_news"
-#     Subfile: "/News.dat"
-#     FileGlob: "CharacteristicExtractVolume*.h5"
-#     ExpectedDataSubfile: "/News_expected.dat"
+#     Subfile: "/Cce/News.dat"
+#     FileGlob: "CharacteristicExtractReduction.h5"
+#     ExpectedDataSubfile: "/Cce/News_expected.dat"
 #     AbsoluteTolerance: 5e-10
 
 Evolution:
@@ -27,8 +27,8 @@ ResourceInfo:
       Exclusive: false
 
 Observers:
-  VolumeFileName: "CharacteristicExtractVolume"
-  ReductionFileName: "CharacteristicExtractUnusedReduction"
+  VolumeFileName: "CharacteristicExtractUnusedVolume"
+  ReductionFileName: "CharacteristicExtractReduction"
 
 Cce:
   Evolution:

--- a/tests/InputFiles/Cce/AnalyticTestLinearizedBondiSachs.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestLinearizedBondiSachs.yaml
@@ -5,12 +5,12 @@
 # Check: parse;execute_check_output
 # Timeout: 10
 # ExpectedOutput:
-#   CharacteristicExtractVolume0.h5
+#   CharacteristicExtractReduction.h5
 # OutputFileChecks:
 #   - Label: "check_news"
-#     Subfile: "/News.dat"
-#     FileGlob: "CharacteristicExtractVolume*.h5"
-#     ExpectedDataSubfile: "/News_expected.dat"
+#     Subfile: "/Cce/News.dat"
+#     FileGlob: "CharacteristicExtractReduction.h5"
+#     ExpectedDataSubfile: "/Cce/News_expected.dat"
 #     AbsoluteTolerance: 1e-2
 
 Evolution:
@@ -27,8 +27,8 @@ ResourceInfo:
       Exclusive: false
 
 Observers:
-  VolumeFileName: "CharacteristicExtractVolume"
-  ReductionFileName: "CharacteristicExtractUnusedReduction"
+  VolumeFileName: "CharacteristicExtractUnusedVolume"
+  ReductionFileName: "CharacteristicExtractReduction"
 
 Cce:
   Evolution:

--- a/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
@@ -5,12 +5,12 @@
 # Check: parse;execute_check_output
 # Timeout: 10
 # ExpectedOutput:
-#   CharacteristicExtractVolume0.h5
+#   CharacteristicExtractReduction.h5
 # OutputFileChecks:
 #   - Label: "check_news"
-#     Subfile: "/News.dat"
-#     FileGlob: "CharacteristicExtractVolume*.h5"
-#     ExpectedDataSubfile: "/News_expected.dat"
+#     Subfile: "/Cce/News.dat"
+#     FileGlob: "CharacteristicExtractReduction.h5"
+#     ExpectedDataSubfile: "/Cce/News_expected.dat"
 #     AbsoluteTolerance: 1e-11
 
 Evolution:
@@ -27,8 +27,8 @@ ResourceInfo:
       Exclusive: false
 
 Observers:
-  VolumeFileName: "CharacteristicExtractVolume"
-  ReductionFileName: "CharacteristicExtractUnusedReduction"
+  VolumeFileName: "CharacteristicExtractUnusedVolume"
+  ReductionFileName: "CharacteristicExtractReduction"
 
 Cce:
   Evolution:

--- a/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
@@ -5,12 +5,12 @@
 # Check: parse;execute_check_output
 # Timeout: 10
 # ExpectedOutput:
-#   CharacteristicExtractVolume0.h5
+#   CharacteristicExtractReduction.h5
 # OutputFileChecks:
 #   - Label: "check_news"
-#     Subfile: "/News.dat"
-#     FileGlob: "CharacteristicExtractVolume*.h5"
-#     ExpectedDataSubfile: "/News_expected.dat"
+#     Subfile: "/Cce/News.dat"
+#     FileGlob: "CharacteristicExtractReduction.h5"
+#     ExpectedDataSubfile: "/Cce/News_expected.dat"
 #     AbsoluteTolerance: 5e-10
 
 Evolution:
@@ -27,8 +27,8 @@ ResourceInfo:
       Exclusive: false
 
 Observers:
-  VolumeFileName: "CharacteristicExtractVolume"
-  ReductionFileName: "CharacteristicExtractUnusedReduction"
+  VolumeFileName: "CharacteristicExtractUnusedVolume"
+  ReductionFileName: "CharacteristicExtractReduction"
 
 Cce:
   Evolution:

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
@@ -97,7 +97,7 @@ struct mock_observer {
   using with_these_simple_actions = tmpl::list<>;
 
   using const_global_cache_tags =
-      tmpl::list<observers::Tags::VolumeFileName, Tags::ObservationLMax>;
+      tmpl::list<observers::Tags::ReductionFileName, Tags::ObservationLMax>;
   using initialize_action_list =
       tmpl::list<observers::Actions::InitializeWriter<Metavariables>>;
   using initialization_tags =
@@ -255,7 +255,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.ScriObserveInterpolated",
   const size_t number_of_radial_points = 4;
   const size_t l_max = 4;
   const size_t scri_output_density = 1;
-  const std::string filename = "ScriObserveInterpolatedTest_CceVolumeOutput";
+  const std::string filename = "ScriObserveInterpolatedTest_CceOutput";
 
   const double start_time = 0.0;
   const double target_step_size = 0.1;
@@ -285,8 +285,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.ScriObserveInterpolated",
           std::make_unique<StepControllers::BinaryFraction>()),
       target_step_size, scri_interpolation_size,
       serialize_and_deserialize(analytic_manager));
-  if (file_system::check_if_file_exists(filename + "0.h5")) {
-    file_system::rm(filename + "0.h5", true);
+  if (file_system::check_if_file_exists(filename + ".h5")) {
+    file_system::rm(filename + ".h5", true);
   }
 
   ActionTesting::emplace_component<observation_component>(&runner, 0);
@@ -378,7 +378,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.ScriObserveInterpolated",
 
   // scoped to close the file
   {
-    h5::H5File<h5::AccessType::ReadOnly> read_file{filename + "0.h5"};
+    h5::H5File<h5::AccessType::ReadOnly> read_file{filename + ".h5"};
     Approx interpolation_approx =
         Approx::custom()
             .epsilon(std::numeric_limits<double>::epsilon() * 1.0e5)
@@ -389,7 +389,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.ScriObserveInterpolated",
           using tag = typename decltype(tag_v)::type;
           read_file.close_current_object();
           const auto& dataset = read_file.get<h5::Dat>(
-              "/" + Actions::detail::ScriOutput<tag>::name());
+              "/Cce/" + Actions::detail::ScriOutput<tag>::name());
           const Matrix data_matrix = dataset.get_data();
           CHECK(data_matrix.rows() > 20);
           // skip the first time because the extrapolation will make that value
@@ -414,7 +414,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.ScriObserveInterpolated",
           }
         });
     read_file.close_current_object();
-    const auto& dataset = read_file.get<h5::Dat>("/News_expected");
+    const auto& dataset = read_file.get<h5::Dat>("/Cce/News_expected");
     const Matrix data_matrix = dataset.get_data();
     for (size_t i = 1; i < data_matrix.rows(); ++i) {
       const ComplexModalVector analytic_news_modes =
@@ -432,8 +432,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.ScriObserveInterpolated",
       }
     }
   }
-  if (file_system::check_if_file_exists(filename + "0.h5")) {
-    file_system::rm(filename + "0.h5", true);
+  if (file_system::check_if_file_exists(filename + ".h5")) {
+    file_system::rm(filename + ".h5", true);
   }
 }
 }  // namespace Cce


### PR DESCRIPTION
## Proposed changes

This PR outputs CCE data to the reduction file instead of to a volume data file.


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Cce output will now be written to the reductions file instead of to a volume data file.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
