### PR TITLE
Allow TOV executables to use generic equations of state

### DIFF
--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivClean.hpp
@@ -20,6 +20,7 @@
 #include "ParallelAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolationTarget.hpp"
 #include "ParallelAlgorithms/Interpolation/Tags.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/RegisterDerivedWithCharm.hpp"
 #include "Utilities/TMPL.hpp"
 
 template <typename InitialData, typename... InterpolationTargetTags>
@@ -53,6 +54,7 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &domain::FunctionsOfTime::register_derived_with_charm,
     &grmhd::GhValenciaDivClean::BoundaryCorrections::
         register_derived_with_charm,
+    &EquationsOfState::register_derived_with_charm,
     &GeneralizedHarmonic::ConstraintDamping::register_derived_with_charm,
     &Parallel::register_factory_classes_with_charm<metavariables>};
 

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -263,7 +263,9 @@ struct GhValenciaDivCleanTemplateBase<
       "analytic_solution, or externally provided numerical initial data");
   // note: numeric initial data not yet fully supported; I think it will need a
   // new wrapping class around the numeric initial data class.
-  using equation_of_state_type = typename initial_data::equation_of_state_type;
+  using eos_base = EquationsOfState::get_eos_base<
+      typename initial_data::equation_of_state_type>;
+  using equation_of_state_type = typename std::unique_ptr<eos_base>;
   using equation_of_state_tag =
       hydro::Tags::EquationOfState<equation_of_state_type>;
 
@@ -274,7 +276,7 @@ struct GhValenciaDivCleanTemplateBase<
 
   using interpolator_source_vars =
       tmpl::remove_duplicates<tmpl::flatten<tmpl::list<
-      typename InterpolationTargetTags::vars_to_interpolate_to_target...>>>;
+          typename InterpolationTargetTags::vars_to_interpolate_to_target...>>>;
 
   using analytic_compute =
       evolution::Tags::AnalyticSolutionsCompute<volume_dim,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -148,6 +148,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/RegisterDerivedWithCharm.hpp"
 #include "PointwiseFunctions/Hydro/MassFlux.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
@@ -197,7 +198,9 @@ struct EvolutionMetavars {
   static_assert(
       is_analytic_data_v<initial_data> xor is_analytic_solution_v<initial_data>,
       "initial_data must be either an analytic_data or an analytic_solution");
-  using equation_of_state_type = typename initial_data::equation_of_state_type;
+  using eos_base = typename EquationsOfState::get_eos_base<
+      typename initial_data::equation_of_state_type>;
+  using equation_of_state_type = typename std::unique_ptr<eos_base>;
   using system = grmhd::ValenciaDivClean::System;
   using temporal_id = Tags::TimeStepId;
   static constexpr bool local_time_stepping = false;
@@ -588,6 +591,7 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &domain::FunctionsOfTime::register_derived_with_charm,
     &grmhd::ValenciaDivClean::BoundaryCorrections::register_derived_with_charm,
     &grmhd::ValenciaDivClean::fd::register_derived_with_charm,
+    &EquationsOfState::register_derived_with_charm,
     &Parallel::register_factory_classes_with_charm<metavariables>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -98,6 +98,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/NewtonianEuler/SmoothFlow.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/RegisterDerivedWithCharm.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
 #include "Time/Actions/ChangeSlabSize.hpp"
@@ -145,7 +146,9 @@ struct EvolutionMetavars {
       is_analytic_data_v<initial_data> xor is_analytic_solution_v<initial_data>,
       "initial_data must be either an analytic_data or an analytic_solution");
 
-  using equation_of_state_type = typename initial_data::equation_of_state_type;
+  using eos_base = EquationsOfState::get_eos_base<
+      typename initial_data::equation_of_state_type>;
+  using equation_of_state_type = typename std::unique_ptr<eos_base>;
 
   using source_term_type = typename initial_data::source_term_type;
 
@@ -415,6 +418,7 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &domain::creators::register_derived_with_charm,
     &domain::creators::time_dependence::register_derived_with_charm,
     &domain::FunctionsOfTime::register_derived_with_charm,
+    &EquationsOfState::register_derived_with_charm,
     &NewtonianEuler::BoundaryCorrections::register_derived_with_charm,
     &NewtonianEuler::fd::register_derived_with_charm,
     &Parallel::register_factory_classes_with_charm<metavariables>};

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -73,6 +73,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/RegisterDerivedWithCharm.hpp"
 #include "PointwiseFunctions/Hydro/SoundSpeedSquared.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
@@ -121,7 +122,9 @@ struct EvolutionMetavars {
       is_analytic_data_v<initial_data> xor is_analytic_solution_v<initial_data>,
       "initial_data must be either an analytic_data or an analytic_solution");
 
-  using equation_of_state_type = typename initial_data::equation_of_state_type;
+ using eos_base = typename EquationsOfState::get_eos_base<
+      typename initial_data::equation_of_state_type>;
+  using equation_of_state_type = typename std::unique_ptr<eos_base>;
 
   using system = RelativisticEuler::Valencia::System<Dim>;
 
@@ -301,6 +304,7 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &domain::creators::register_derived_with_charm,
     &domain::creators::time_dependence::register_derived_with_charm,
     &domain::FunctionsOfTime::register_derived_with_charm,
+    &EquationsOfState::register_derived_with_charm,
     &RelativisticEuler::Valencia::BoundaryCorrections::
         register_derived_with_charm,
     &Parallel::register_factory_classes_with_charm<metavariables>};

--- a/src/Evolution/Initialization/ConservativeSystem.hpp
+++ b/src/Evolution/Initialization/ConservativeSystem.hpp
@@ -109,8 +109,9 @@ struct ConservativeSystem {
 
       PrimitiveVars primitive_vars{
           db::get<domain::Tags::Mesh<dim>>(box).number_of_grid_points()};
-      auto equation_of_state =
-          db::get<::Tags::AnalyticSolutionOrData>(box).equation_of_state();
+      auto equation_of_state = db::get<::Tags::AnalyticSolutionOrData>(box)
+                                   .equation_of_state()
+                                   .get_clone();
       Initialization::mutate_assign<simple_tags>(
           make_not_null(&box), std::move(vars), std::move(primitive_vars),
           std::move(equation_of_state));

--- a/src/NumericalAlgorithms/Interpolation/CubicSpline.cpp
+++ b/src/NumericalAlgorithms/Interpolation/CubicSpline.cpp
@@ -27,6 +27,23 @@ CubicSpline::CubicSpline(std::vector<double> x_values,
   initialize_interpolant();
 }
 
+CubicSpline::CubicSpline(const CubicSpline& rhs)
+    : x_values_(rhs.x_values_), y_values_(rhs.y_values_) {
+  // potential optimization -- copy the interpolant rather than recomputing
+  initialize_interpolant();
+}
+bool CubicSpline::operator==(const CubicSpline& rhs) const {
+  return x_values_ == rhs.x_values_ and y_values_ == rhs.y_values_;
+}
+
+CubicSpline& CubicSpline::operator=(const CubicSpline& rhs) {
+  x_values_ = rhs.x_values_;
+  y_values_ = rhs.y_values_;
+  // potential optimization -- copy the interpolant rather than recomputing
+  initialize_interpolant();
+  return *this;
+}
+
 void CubicSpline::gsl_interp_accel_deleter::operator()(
     gsl_interp_accel* const acc) const {
   gsl_interp_accel_free(acc);

--- a/src/NumericalAlgorithms/Interpolation/CubicSpline.hpp
+++ b/src/NumericalAlgorithms/Interpolation/CubicSpline.hpp
@@ -31,11 +31,13 @@ class CubicSpline {
   CubicSpline(std::vector<double> x_values, std::vector<double> y_values);
 
   CubicSpline() = default;
-  CubicSpline(const CubicSpline& /*rhs*/) = delete;
-  CubicSpline& operator=(const CubicSpline& /*rhs*/) = delete;
+  CubicSpline(const CubicSpline& /*rhs*/);
+  CubicSpline& operator=(const CubicSpline& /*rhs*/);
   CubicSpline(CubicSpline&& /*rhs*/) = default;
   CubicSpline& operator=(CubicSpline&& rhs) = default;
   ~CubicSpline() = default;
+
+  bool operator==(const CubicSpline& rhs) const;
 
   double operator()(double x_to_interp_to) const;
 

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.cpp
@@ -14,7 +14,7 @@
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
-#include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ContainerHelpers.hpp"
@@ -24,16 +24,17 @@
 
 namespace grmhd::AnalyticData {
 MagnetizedTovStar::MagnetizedTovStar(
-    const double central_rest_mass_density, const double polytropic_constant,
-    const double polytropic_exponent,
+    const double central_rest_mass_density,
+    std::unique_ptr<MagnetizedTovStar::equation_of_state_type>
+        equation_of_state,
     const RelativisticEuler::Solutions::TovCoordinates coordinate_system,
     const size_t pressure_exponent, const double cutoff_pressure_fraction,
     const double vector_potential_amplitude)
-    : tov_star(central_rest_mass_density, polytropic_constant,
-               polytropic_exponent, coordinate_system),
+    : tov_star(central_rest_mass_density, std::move(equation_of_state),
+               coordinate_system),
       pressure_exponent_(pressure_exponent),
       cutoff_pressure_(cutoff_pressure_fraction *
-                       get(equation_of_state().pressure_from_density(
+                       get(this->equation_of_state().pressure_from_density(
                            Scalar<double>{central_rest_mass_density}))),
       vector_potential_amplitude_(vector_potential_amplitude) {}
 

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.hpp
@@ -12,7 +12,7 @@
 #include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
 #include "PointwiseFunctions/AnalyticData/GrMhd/AnalyticData.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp"
-#include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
 #include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "Utilities/TMPL.hpp"
@@ -49,7 +49,7 @@ struct MagnetizedTovVariables
   MagnetizedTovVariables(
       const tnsr::I<DataType, 3>& local_x, const DataType& local_radius,
       const RelativisticEuler::Solutions::TovSolution& local_radial_solution,
-      const EquationsOfState::PolytropicFluid<true>& local_eos,
+      const EquationsOfState::EquationOfState<true, 1>& local_eos,
       size_t local_pressure_exponent, double local_cutoff_pressure,
       double local_vector_potential_amplitude)
       : Base(local_x, local_radius, local_radial_solution, local_eos),
@@ -234,10 +234,10 @@ class MagnetizedTovStar : public virtual evolution::initial_data::InitialData,
   MagnetizedTovStar(MagnetizedTovStar&& /*rhs*/) = default;
   MagnetizedTovStar& operator=(MagnetizedTovStar&& /*rhs*/) = default;
   ~MagnetizedTovStar() = default;
-
   MagnetizedTovStar(
-      double central_rest_mass_density, double polytropic_constant,
-      double polytropic_exponent,
+      double central_rest_mass_density,
+      std::unique_ptr<EquationsOfState::EquationOfState<true, 1>>
+          equation_of_state,
       RelativisticEuler::Solutions::TovCoordinates coordinate_system,
       size_t pressure_exponent, double cutoff_pressure_fraction,
       double vector_potential_amplitude);

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Tov.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Tov.hpp
@@ -7,6 +7,7 @@
 #include <ostream>
 
 #include "NumericalAlgorithms/Interpolation/BarycentricRational.hpp"
+#include "NumericalAlgorithms/Interpolation/CubicSpline.hpp"
 #include "Options/Options.hpp"
 #include "Options/ParseOptions.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
@@ -248,8 +249,8 @@ class TovSolution {
   double outer_radius_{std::numeric_limits<double>::signaling_NaN()};
   double total_mass_{std::numeric_limits<double>::signaling_NaN()};
   double injection_energy_{std::numeric_limits<double>::signaling_NaN()};
-  intrp::BarycentricRational mass_over_radius_interpolant_;
-  intrp::BarycentricRational log_enthalpy_interpolant_;
+  intrp::CubicSpline mass_over_radius_interpolant_;
+  intrp::CubicSpline log_enthalpy_interpolant_;
   intrp::BarycentricRational conformal_factor_interpolant_;
 };
 

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/CMakeLists.txt
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   HybridEos.cpp
   IdealFluid.cpp
   PolytropicFluid.cpp
+  RegisterDerivedWithCharm.cpp
   Spectral.cpp
   )
 
@@ -17,13 +18,14 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   DarkEnergyFluid.hpp
+  Enthalpy.hpp
   EquationOfState.hpp
   Factory.hpp
   HybridEos.hpp
   IdealFluid.hpp
   PolytropicFluid.hpp
+  RegisterDerivedWithCharm.hpp
   Spectral.hpp
-  Enthalpy.hpp
   )
 
 add_subdirectory(Python)

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.cpp
@@ -26,6 +26,33 @@ EQUATION_OF_STATE_MEMBER_DEFINITIONS(template <bool IsRelativistic>,
                                      DataVector, 2)
 
 template <bool IsRelativistic>
+std::unique_ptr<EquationOfState<IsRelativistic, 2>>
+DarkEnergyFluid<IsRelativistic>::get_clone() const {
+  auto clone = std::make_unique<DarkEnergyFluid<IsRelativistic>>(*this);
+  return std::unique_ptr<EquationOfState<IsRelativistic, 2>>(std::move(clone));
+}
+
+template <bool IsRelativistic>
+bool DarkEnergyFluid<IsRelativistic>::is_equal(
+    const EquationOfState<IsRelativistic, 2>& rhs) const {
+  const auto& derived_ptr =
+      dynamic_cast<const DarkEnergyFluid<IsRelativistic>* const>(&rhs);
+  return derived_ptr != nullptr and *derived_ptr == *this;
+}
+
+template <bool IsRelativistic>
+bool DarkEnergyFluid<IsRelativistic>::operator==(
+    const DarkEnergyFluid<IsRelativistic>& rhs) const {
+  return parameter_w_ == rhs.parameter_w_;
+}
+
+template <bool IsRelativistic>
+bool DarkEnergyFluid<IsRelativistic>::operator!=(
+    const DarkEnergyFluid<IsRelativistic>& rhs) const {
+  return not(*this == rhs);
+}
+
+template <bool IsRelativistic>
 DarkEnergyFluid<IsRelativistic>::DarkEnergyFluid(CkMigrateMessage* msg)
     : EquationOfState<IsRelativistic, 2>(msg) {}
 

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.hpp
@@ -49,9 +49,18 @@ class DarkEnergyFluid : public EquationOfState<IsRelativistic, 2> {
  public:
   static constexpr size_t thermodynamic_dim = 2;
   static constexpr bool is_relativistic = IsRelativistic;
-  static_assert(IsRelativistic,
+  static_assert(is_relativistic,
                 "Dark energy fluid equation of state only makes sense in a "
                 "relativistic setting.");
+
+  std::unique_ptr<EquationOfState<IsRelativistic, 2>> get_clone()
+      const override;
+
+  bool is_equal(const EquationOfState<IsRelativistic, 2>& rhs) const override;
+
+  bool operator==(const DarkEnergyFluid<IsRelativistic>& rhs) const;
+
+  bool operator!=(const DarkEnergyFluid<IsRelativistic>& rhs) const;
 
   struct ParameterW {
     using type = double;

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.hpp
@@ -119,6 +119,7 @@ class Enthalpy : public EquationOfState<true, 1> {
                  double in_reference_density,
                  double in_exponential_constant =
                      std::numeric_limits<double>::quiet_NaN());
+    bool operator==(const Coefficients& rhs) const;
 
     Enthalpy<LowDensityEoS>::Coefficients compute_exponential_integral(
         const std::pair<double, double>& initial_condition);
@@ -217,6 +218,14 @@ class Enthalpy : public EquationOfState<true, 1> {
            const std::vector<double>& cos_coefficients,
            const LowDensityEoS& low_density_eos,
            const double transition_delta_epsilon);
+
+  std::unique_ptr<EquationOfState<true, 1>> get_clone() const override;
+
+  bool is_equal(const EquationOfState<true, 1>& rhs) const override;
+
+  bool operator==(const Enthalpy<LowDensityEoS>& rhs) const;
+
+  bool operator!=(const Enthalpy<LowDensityEoS>& rhs) const;
 
   EQUATION_OF_STATE_FORWARD_DECLARE_MEMBERS(Enthalpy, 1)
 

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.cpp
@@ -12,8 +12,8 @@
 
 namespace EquationsOfState {
 template <typename ColdEquationOfState>
-HybridEos<ColdEquationOfState>::HybridEos(
-    ColdEquationOfState cold_eos, const double thermal_adiabatic_index)
+HybridEos<ColdEquationOfState>::HybridEos(ColdEquationOfState cold_eos,
+                                          const double thermal_adiabatic_index)
     : cold_eos_(std::move(cold_eos)),
       thermal_adiabatic_index_(thermal_adiabatic_index) {}
 
@@ -22,6 +22,35 @@ EQUATION_OF_STATE_MEMBER_DEFINITIONS(template <typename ColdEquationOfState>,
 EQUATION_OF_STATE_MEMBER_DEFINITIONS(template <typename ColdEquationOfState>,
                                      HybridEos<ColdEquationOfState>, DataVector,
                                      2)
+
+template <typename ColdEquationOfState>
+std::unique_ptr<
+    EquationOfState<HybridEos<ColdEquationOfState>::is_relativistic, 2>>
+HybridEos<ColdEquationOfState>::get_clone() const {
+  auto clone = std::make_unique<HybridEos<ColdEquationOfState>>(*this);
+  return std::unique_ptr<EquationOfState<is_relativistic, 2>>(std::move(clone));
+}
+
+template <typename ColdEquationOfState>
+bool HybridEos<ColdEquationOfState>::operator==(
+    const HybridEos<ColdEquationOfState>& rhs) const {
+  return cold_eos_ == rhs.cold_eos_ and
+         thermal_adiabatic_index_ == rhs.thermal_adiabatic_index_;
+}
+
+template <typename ColdEquationOfState>
+bool HybridEos<ColdEquationOfState>::operator!=(
+    const HybridEos<ColdEquationOfState>& rhs) const {
+  return not(*this == rhs);
+}
+
+template <typename ColdEquationOfState>
+bool HybridEos<ColdEquationOfState>::is_equal(
+    const EquationOfState<is_relativistic, 2>& rhs) const {
+  const auto& derived_ptr =
+      dynamic_cast<const HybridEos<ColdEquationOfState>* const>(&rhs);
+  return derived_ptr != nullptr and *derived_ptr == *this;
+}
 
 template <typename ColdEquationOfState>
 HybridEos<ColdEquationOfState>::HybridEos(CkMigrateMessage* msg)

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.hpp
@@ -85,13 +85,21 @@ class HybridEos
   HybridEos& operator=(HybridEos&&) = default;
   ~HybridEos() override = default;
 
-  HybridEos(ColdEquationOfState cold_eos,
-            double thermal_adiabatic_index);
+  HybridEos(ColdEquationOfState cold_eos, double thermal_adiabatic_index);
 
   EQUATION_OF_STATE_FORWARD_DECLARE_MEMBERS(HybridEos, 2)
 
   WRAPPED_PUPable_decl_base_template(  // NOLINT
       SINGLE_ARG(EquationOfState<is_relativistic, 2>), HybridEos);
+
+  std::unique_ptr<EquationOfState<is_relativistic, 2>> get_clone()
+      const override;
+
+  bool operator==(const HybridEos<ColdEquationOfState>& rhs) const;
+
+  bool operator!=(const HybridEos<ColdEquationOfState>& rhs) const;
+
+  bool is_equal(const EquationOfState<is_relativistic, 2>& rhs) const override;
 
   /// The lower bound of the rest mass density that is valid for this EOS
   double rest_mass_density_lower_bound() const override {

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.cpp
@@ -20,6 +20,32 @@ EQUATION_OF_STATE_MEMBER_DEFINITIONS(template <bool IsRelativistic>,
                                      IdealFluid<IsRelativistic>, double, 2)
 EQUATION_OF_STATE_MEMBER_DEFINITIONS(template <bool IsRelativistic>,
                                      IdealFluid<IsRelativistic>, DataVector, 2)
+template <bool IsRelativistic>
+std::unique_ptr<EquationOfState<IsRelativistic, 2>>
+IdealFluid<IsRelativistic>::get_clone() const {
+  auto clone = std::make_unique<IdealFluid<IsRelativistic>>(*this);
+  return std::unique_ptr<EquationOfState<IsRelativistic, 2>>(std::move(clone));
+}
+
+template <bool IsRelativistic>
+bool IdealFluid<IsRelativistic>::is_equal(
+    const EquationOfState<IsRelativistic, 2>& rhs) const {
+  const auto& derived_ptr =
+      dynamic_cast<const IdealFluid<IsRelativistic>* const>(&rhs);
+  return derived_ptr != nullptr and *derived_ptr == *this;
+}
+
+template <bool IsRelativistic>
+bool IdealFluid<IsRelativistic>::operator==(
+    const IdealFluid<IsRelativistic>& rhs) const {
+  return adiabatic_index_ == rhs.adiabatic_index_;
+}
+
+template <bool IsRelativistic>
+bool IdealFluid<IsRelativistic>::operator!=(
+    const IdealFluid<IsRelativistic>& rhs) const {
+  return not(*this == rhs);
+}
 
 template <bool IsRelativistic>
 IdealFluid<IsRelativistic>::IdealFluid(CkMigrateMessage* msg)

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp
@@ -75,6 +75,15 @@ class IdealFluid : public EquationOfState<IsRelativistic, 2> {
 
   EQUATION_OF_STATE_FORWARD_DECLARE_MEMBERS(IdealFluid, 2)
 
+  std::unique_ptr<EquationOfState<IsRelativistic, 2>> get_clone()
+      const override;
+
+  bool operator==(const IdealFluid<IsRelativistic>& rhs) const;
+
+  bool operator!=(const IdealFluid<IsRelativistic>& rhs) const;
+
+  bool is_equal(const EquationOfState<IsRelativistic, 2>& rhs) const override;
+
   WRAPPED_PUPable_decl_base_template(  // NOLINT
       SINGLE_ARG(EquationOfState<IsRelativistic, 2>), IdealFluid);
 

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.cpp
@@ -26,6 +26,34 @@ EQUATION_OF_STATE_MEMBER_DEFINITIONS(template <bool IsRelativistic>,
                                      DataVector, 1)
 
 template <bool IsRelativistic>
+bool PolytropicFluid<IsRelativistic>::operator==(
+    const PolytropicFluid<IsRelativistic>& rhs) const {
+  return (polytropic_constant_ == rhs.polytropic_constant_) and
+         (polytropic_exponent_ == rhs.polytropic_exponent_);
+}
+
+template <bool IsRelativistic>
+bool PolytropicFluid<IsRelativistic>::operator!=(
+    const PolytropicFluid<IsRelativistic>& rhs) const {
+  return not(*this == rhs);
+}
+
+template <bool IsRelativistic>
+bool PolytropicFluid<IsRelativistic>::is_equal(
+    const EquationOfState<IsRelativistic, 1>& rhs) const {
+  const auto& derived_ptr =
+      dynamic_cast<const PolytropicFluid<IsRelativistic>* const>(&rhs);
+  return derived_ptr != nullptr and *derived_ptr == *this;
+}
+
+template <bool IsRelativistic>
+std::unique_ptr<EquationOfState<IsRelativistic, 1>>
+PolytropicFluid<IsRelativistic>::get_clone() const {
+  auto clone = std::make_unique<PolytropicFluid<IsRelativistic>>(*this);
+  return std::unique_ptr<EquationOfState<IsRelativistic, 1>>(std::move(clone));
+}
+
+template <bool IsRelativistic>
 PolytropicFluid<IsRelativistic>::PolytropicFluid(CkMigrateMessage* msg)
     : EquationOfState<IsRelativistic, 1>(msg) {}
 

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp
@@ -71,6 +71,15 @@ class PolytropicFluid : public EquationOfState<IsRelativistic, 1> {
 
   PolytropicFluid(double polytropic_constant, double polytropic_exponent);
 
+  std::unique_ptr<EquationOfState<IsRelativistic, 1>> get_clone()
+      const override;
+
+  bool is_equal(const EquationOfState<IsRelativistic, 1>& rhs) const override;
+
+  bool operator==(const PolytropicFluid<IsRelativistic>& rhs) const;
+
+  bool operator!=(const PolytropicFluid<IsRelativistic>& rhs) const;
+
   EQUATION_OF_STATE_FORWARD_DECLARE_MEMBERS(PolytropicFluid, 1)
 
   WRAPPED_PUPable_decl_base_template(  // NOLINT

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/RegisterDerivedWithCharm.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/RegisterDerivedWithCharm.cpp
@@ -1,0 +1,26 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <cstddef>
+
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
+namespace EquationsOfState {
+
+template <bool IsRelativistic, size_t ThermodynamicDim>
+void register_derived_subset_with_charm() {
+  using derived_equations_of_state =
+      typename EquationsOfState::detail::DerivedClasses<IsRelativistic,
+                                                        ThermodynamicDim>::type;
+  Parallel::register_classes_with_charm(derived_equations_of_state{});
+}
+
+void register_derived_with_charm() {
+  register_derived_subset_with_charm<true, 1>();
+  register_derived_subset_with_charm<false, 1>();
+  register_derived_subset_with_charm<true, 2>();
+  // The next one doesn't exist yet
+  // register_derived_subset_with_charm<false, 2>();
+}
+}  // namespace EquationsOfState

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/RegisterDerivedWithCharm.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/RegisterDerivedWithCharm.hpp
@@ -1,0 +1,8 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace EquationsOfState {
+void register_derived_with_charm();
+}  // namespace EquationsOfState

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Spectral.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Spectral.cpp
@@ -72,8 +72,26 @@ Spectral::Spectral(const double reference_density,
 EQUATION_OF_STATE_MEMBER_DEFINITIONS(, Spectral, double, 1)
 EQUATION_OF_STATE_MEMBER_DEFINITIONS(, Spectral, DataVector, 1)
 
-Spectral::Spectral(CkMigrateMessage* msg) : EquationOfState<true, 1>(msg) {}
+std::unique_ptr<EquationOfState<true, 1>> Spectral::get_clone() const {
+  auto clone = std::make_unique<Spectral>(*this);
+  return std::unique_ptr<EquationOfState<true, 1>>(std::move(clone));
+}
 
+bool Spectral::operator==(const Spectral& rhs) const {
+  return reference_density_ == rhs.reference_density_ and
+         reference_pressure_ == rhs.reference_pressure_;
+}
+
+bool Spectral::operator!=(const Spectral& rhs) const {
+  return not(*this == rhs);
+}
+
+bool Spectral::is_equal(const EquationOfState<true, 1>& rhs) const {
+  const auto& derived_ptr = dynamic_cast<const Spectral* const>(&rhs);
+  return derived_ptr != nullptr and *derived_ptr == *this;
+}
+
+Spectral::Spectral(CkMigrateMessage* msg) : EquationOfState<true, 1>(msg) {}
 
 void Spectral::pup(PUP::er& p) {
   EquationOfState<true, 1>::pup(p);

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp
@@ -106,6 +106,14 @@ class Spectral : public EquationOfState<true, 1> {
 
   EQUATION_OF_STATE_FORWARD_DECLARE_MEMBERS(Spectral, 1)
 
+  std::unique_ptr<EquationOfState<true, 1>> get_clone() const override;
+
+  bool operator==(const Spectral& rhs) const;
+
+  bool operator!=(const Spectral& rhs) const;
+
+  bool is_equal(const EquationOfState<true, 1>& rhs) const override;
+
   WRAPPED_PUPable_decl_base_template(  // NOLINT
       SINGLE_ARG(EquationOfState<true, 1>), Spectral);
 

--- a/src/PointwiseFunctions/Hydro/Tags.hpp
+++ b/src/PointwiseFunctions/Hydro/Tags.hpp
@@ -9,6 +9,8 @@
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
 #include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
 
 /// \ingroup EvolutionSystemsGroup
@@ -211,4 +213,17 @@ struct MassFlux : db::SimpleTag {
   static std::string name() { return Frame::prefix<Fr>() + "MassFlux"; }
 };
 }  // namespace Tags
+
+/// %Tags for options of hydrodynamic systems.
+namespace OptionTags {
+
+/// The equation of state of the fluid.
+template <bool IsRelativistic, size_t ThermoDim>
+struct EquationOfState {
+  using type = std::unique_ptr<
+      EquationsOfState::EquationOfState<IsRelativistic, ThermoDim>>;
+  static constexpr Options::String help = {"The equation of state to use"};
+};
+}  // namespace OptionTags
+
 }  // namespace hydro

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -42,8 +42,10 @@ DomainCreator:
 AnalyticSolution:
   TovStar:
     CentralDensity: 1.28e-3
-    PolytropicConstant: 100.0
-    PolytropicExponent: 2.0
+    EquationOfState:
+        PolytropicFluid:
+            PolytropicConstant: 100.0
+            PolytropicExponent: 2.0
     Coordinates: Schwarzschild
 
 VariableFixing:

--- a/tests/Unit/Evolution/Initialization/CMakeLists.txt
+++ b/tests/Unit/Evolution/Initialization/CMakeLists.txt
@@ -15,7 +15,7 @@ add_test_library(
   ${LIBRARY}
   "Evolution/Initialization/"
   "${LIBRARY_SOURCES}"
-  "DataStructures;Domain;Evolution;Utilities"
+  "DataStructures;Domain;Evolution;Hydro;Utilities"
   )
 
 add_dependencies(

--- a/tests/Unit/Evolution/Initialization/Test_SetVariables.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_SetVariables.cpp
@@ -33,6 +33,7 @@
 #include "PointwiseFunctions/AnalyticData/Tags.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
 #include "Utilities/CloneUniquePtrs.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
@@ -57,7 +58,7 @@ struct PrimVar : db::SimpleTag {
 };
 
 struct EquationOfStateTag : db::SimpleTag {
-  using type = double;
+  using type = std::unique_ptr<EquationsOfState::EquationOfState<true, 1>>;
 };
 
 struct SystemAnalyticSolution : public MarkAsAnalyticSolution {
@@ -107,7 +108,10 @@ struct SystemAnalyticSolution : public MarkAsAnalyticSolution {
   }
 
   // EoS just needs to be a dummy place holder
-  static double equation_of_state() { return 7.0; }
+  static auto equation_of_state() {
+    EquationsOfState::PolytropicFluid<true> equation_of_state_{100.0, 2.0};
+    return equation_of_state_;
+  }
 
   // clang-tidy: do not use references
   void pup(PUP::er& /*p*/) {}  // NOLINT
@@ -156,9 +160,9 @@ struct SystemAnalyticData : public MarkAsAnalyticData {
     }
     return vars;
   }
-
+  EquationsOfState::PolytropicFluid<true> equation_of_state_{100.0, 2.0};
   // EoS just needs to be a dummy place holder
-  static double equation_of_state() { return 7.0; }
+  const auto& equation_of_state() { return equation_of_state_; }
 
   // clang-tidy: do not use references
   void pup(PUP::er& /*p*/) {}  // NOLINT

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_GrTagsForHydro.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_GrTagsForHydro.cpp
@@ -60,8 +60,10 @@ SPECTRE_TEST_CASE(
   constexpr double central_density = 1.28e-3;
   constexpr double polytropic_constant = 100.0;
   constexpr double polytropic_exponent = 2.0;
-  const Solution solution{central_density, polytropic_constant,
-                          polytropic_exponent};
+  const Solution solution{
+      central_density,
+      std::make_unique<EquationsOfState::PolytropicFluid<true>>(
+          polytropic_constant, polytropic_exponent)};
 
   std::unordered_map<std::string,
                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
@@ -88,7 +90,9 @@ SPECTRE_TEST_CASE(
                                                                 Identity2D>(
               Translation{"Translation"}, Identity2D{})),
       clone_unique_ptrs(functions_of_time), logical_coords,
-      Solution{central_density, polytropic_constant, polytropic_exponent},
+      Solution{central_density,
+               std::make_unique<EquationsOfState::PolytropicFluid<true>>(
+                   polytropic_constant, polytropic_exponent)},
       SubcellGrVars{}, std::array<FaceGrVars, 3>{});
 
   db::mutate_apply<Initialization::subcell::GrTagsForHydro<System, 3>>(

--- a/tests/Unit/Helpers/PointwiseFunctions/Hydro/EquationsOfState/TestHelpers.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/Hydro/EquationsOfState/TestHelpers.hpp
@@ -226,5 +226,15 @@ void check(EosType in_eos, const std::string& python_file_name,
                      member_args...);
 }
 /// @}
+
+/// Test that cloning is correct, and that the equality operator is implemented
+/// correctly
+template <bool IsRelativistic, size_t ThermodynamicDim>
+void test_get_clone(
+    const ::EquationsOfState::EquationOfState<IsRelativistic, ThermodynamicDim>&
+        in_eos) {
+  auto cloned_eos = in_eos.get_clone();
+  CHECK(*cloned_eos == in_eos);
+}
 }  // namespace EquationsOfState
 }  // namespace TestHelpers

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_CubicSpline.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_CubicSpline.cpp
@@ -55,6 +55,7 @@ void test_cubic_spline(const F& function, const double lower_bound,
   // tolerance. Also check that the serialized-and-deserialized interpolant does
   // the same.
   const auto deserialized_interpolant = serialize_and_deserialize(interpolant);
+  CHECK(deserialized_interpolant == interpolant);
   double max_error = 0.;
   double max_error_x_value = std::numeric_limits<double>::signaling_NaN();
   double max_error_interior = 0.;
@@ -66,6 +67,7 @@ void test_cubic_spline(const F& function, const double lower_bound,
     const double y_value = function(x_value);
     const double interpolated_y_value = interpolant(x_value);
     CHECK(interpolated_y_value == custom_approx(y_value));
+    // Test the == operator
     CHECK(deserialized_interpolant(x_value) == interpolated_y_value);
     // Record max error for better test failure reports
     const double error = abs(interpolated_y_value - y_value);
@@ -85,6 +87,16 @@ void test_cubic_spline(const F& function, const double lower_bound,
         max_error_interior_x_value = x_value;
       }
     }
+  }
+  // Check the copy constructors
+  {
+    intrp::CubicSpline interpolant_copy_assigned{{-1.0, 0.0, 1.0, 2.0},
+                                                 {0.0, 0.0, 0.0, 6.0}};
+    interpolant_copy_assigned = interpolant;
+    const auto interpolant_copy_constructed{interpolant};
+
+    CHECK(interpolant_copy_assigned == interpolant);
+    CHECK(interpolant_copy_constructed == interpolant);
   }
   // Output information on the precision the interpolation achieved when it
   // failed to stay within the given tolerances

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
@@ -350,7 +350,9 @@ void test_tov() {
         ElementId<3>{0}, cube.stationary_map().get_clone()};
     const auto x = element_map(xi);
 
-    RelativisticEuler::Solutions::TovStar tov_star(central_density, 100.0, 2.0);
+    RelativisticEuler::Solutions::TovStar tov_star(
+        central_density,
+        std::make_unique<EquationsOfState::PolytropicFluid<true>>(100.0, 2.0));
 
     using rho_tag = hydro::Tags::RestMassDensity<DataVector>;
     auto vars = variables_from_tagged_tuple(

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagnetizedTovStar.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagnetizedTovStar.cpp
@@ -34,46 +34,71 @@ static_assert(
 using TovCoordinates = RelativisticEuler::Solutions::TovCoordinates;
 
 void test_equality() {
+  Parallel::register_classes_with_charm<
+      grmhd::AnalyticData::MagnetizedTovStar>();
+  Parallel::register_classes_with_charm<
+      EquationsOfState::PolytropicFluid<true>>();
   const MagnetizedTovStar mag_tov_original{
-      1.28e-3, 100.0, 2.0, TovCoordinates::Schwarzschild, 2, 0.04, 2500.0};
+      1.28e-3,
+      std::make_unique<EquationsOfState::PolytropicFluid<true>>(100.0, 2.0),
+      TovCoordinates::Schwarzschild,
+      2,
+      0.04,
+      2500.0};
   const auto mag_tov = serialize_and_deserialize(mag_tov_original);
-  CHECK(mag_tov == MagnetizedTovStar(1.28e-3, 100.0, 2.0,
-                                     TovCoordinates::Schwarzschild, 2, 0.04,
-                                     2500.0));
-  CHECK(mag_tov != MagnetizedTovStar(2.28e-3, 100.0, 2.0,
-                                     TovCoordinates::Schwarzschild, 2, 0.04,
-                                     2500.0));
-  CHECK(mag_tov != MagnetizedTovStar(1.28e-3, 200.0, 2.0,
-                                     TovCoordinates::Schwarzschild, 2, 0.04,
-                                     2500.0));
-  CHECK(mag_tov != MagnetizedTovStar(1.28e-3, 100.0, 3.0,
-                                     TovCoordinates::Schwarzschild, 2, 0.04,
-                                     2500.0));
-  CHECK(mag_tov != MagnetizedTovStar(1.28e-3, 100.0, 2.0,
-                                     TovCoordinates::Isotropic, 2, 0.04,
-                                     2500.0));
-  CHECK(mag_tov != MagnetizedTovStar(1.28e-3, 100.0, 2.0,
-                                     TovCoordinates::Schwarzschild, 3, 0.04,
-                                     2500.0));
-  CHECK(mag_tov != MagnetizedTovStar(1.28e-3, 100.0, 2.0,
-                                     TovCoordinates::Schwarzschild, 2, 0.05,
-                                     2500.0));
-  CHECK(mag_tov != MagnetizedTovStar(1.28e-3, 100.0, 2.0,
-                                     TovCoordinates::Schwarzschild, 2, 0.04,
-                                     3500.0));
+  CHECK(
+      mag_tov ==
+      MagnetizedTovStar(
+          1.28e-3,
+          std::make_unique<EquationsOfState::PolytropicFluid<true>>(100.0, 2.0),
+          TovCoordinates::Schwarzschild, 2, 0.04, 2500.0));
+  CHECK(
+      mag_tov !=
+      MagnetizedTovStar(
+          2.28e-3,
+          std::make_unique<EquationsOfState::PolytropicFluid<true>>(100.0, 2.0),
+          TovCoordinates::Schwarzschild, 2, 0.04, 2500.0));
+  CHECK(
+      mag_tov !=
+      MagnetizedTovStar(
+          1.28e-3,
+          std::make_unique<EquationsOfState::PolytropicFluid<true>>(100.0, 2.0),
+          TovCoordinates::Isotropic, 2, 0.04, 2500.0));
+  CHECK(
+      mag_tov !=
+      MagnetizedTovStar(
+          1.28e-3,
+          std::make_unique<EquationsOfState::PolytropicFluid<true>>(100.0, 2.0),
+          TovCoordinates::Schwarzschild, 3, 0.04, 2500.0));
+  CHECK(
+      mag_tov !=
+      MagnetizedTovStar(
+          1.28e-3,
+          std::make_unique<EquationsOfState::PolytropicFluid<true>>(100.0, 2.0),
+          TovCoordinates::Schwarzschild, 2, 0.05, 2500.0));
+  CHECK(
+      mag_tov !=
+      MagnetizedTovStar(
+          1.28e-3,
+          std::make_unique<EquationsOfState::PolytropicFluid<true>>(100.0, 2.0),
+          TovCoordinates::Schwarzschild, 2, 0.04, 3500.0));
 }
 
 void test_magnetized_tov_star(const TovCoordinates coord_system) {
   Parallel::register_classes_with_charm<
       grmhd::AnalyticData::MagnetizedTovStar>();
+  Parallel::register_classes_with_charm<
+      EquationsOfState::PolytropicFluid<true>>();
   const std::unique_ptr<evolution::initial_data::InitialData> option_solution =
       TestHelpers::test_option_tag_factory_creation<
           evolution::initial_data::OptionTags::InitialData,
           grmhd::AnalyticData::MagnetizedTovStar>(
           "MagnetizedTovStar:\n"
           "  CentralDensity: 1.28e-3\n"
-          "  PolytropicConstant: 100.0\n"
-          "  PolytropicExponent: 2.0\n"
+          "  EquationOfState:\n"
+          "    PolytropicFluid:\n"
+          "      PolytropicConstant: 100.0\n"
+          "      PolytropicExponent: 2.0\n"
           "  Coordinates: " +
           get_output(coord_system) +
           "\n"
@@ -86,8 +111,10 @@ void test_magnetized_tov_star(const TovCoordinates coord_system) {
       dynamic_cast<const grmhd::AnalyticData::MagnetizedTovStar&>(
           *deserialized_option_solution);
 
-  const RelativisticEuler::Solutions::TovStar tov{1.28e-3, 100.0, 2.0,
-                                                  coord_system};
+  const RelativisticEuler::Solutions::TovStar tov{
+      1.28e-3,
+      std::make_unique<EquationsOfState::PolytropicFluid<true>>(100.0, 2.0),
+      coord_system};
 
   std::unique_ptr<EquationsOfState::EquationOfState<true, 1>> eos =
       std::make_unique<EquationsOfState::PolytropicFluid<true>>(100.0, 2.0);

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GhRelativisticEuler/Test_InstantiateWrappedGr.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GhRelativisticEuler/Test_InstantiateWrappedGr.cpp
@@ -6,6 +6,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Helpers/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CheckWrappedGrConsistency.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.hpp"
@@ -21,10 +22,11 @@ SPECTRE_TEST_CASE(
   const tnsr::I<DataVector, 1, Frame::Inertial> x_1d{DataVector{3.0, 4.0}};
   check_wrapped_gr_solution_consistency(
       GeneralizedHarmonic::Solutions::WrappedGr<
-      RelativisticEuler::Solutions::FishboneMoncriefDisk>{
-        1.0, 0.23, 6.0, 12.0, 0.001, 1.4},
-      RelativisticEuler::Solutions::FishboneMoncriefDisk{
-        1.0, 0.23, 6.0, 12.0, 0.001, 1.4}, x_3d, t);
+          RelativisticEuler::Solutions::FishboneMoncriefDisk>{1.0, 0.23, 6.0,
+                                                              12.0, 0.001, 1.4},
+      RelativisticEuler::Solutions::FishboneMoncriefDisk{1.0, 0.23, 6.0, 12.0,
+                                                         0.001, 1.4},
+      x_3d, t);
 
   check_wrapped_gr_solution_consistency(
       GeneralizedHarmonic::Solutions::WrappedGr<
@@ -55,9 +57,13 @@ SPECTRE_TEST_CASE(
           std::array<double, 3>{-0.3, 0.1, -0.002},
           std::array<double, 3>{0.4, -0.24, 0.054}, 1.23, 1.334, 0.78},
       x_3d, t);
-
   check_wrapped_gr_solution_consistency(
       GeneralizedHarmonic::Solutions::WrappedGr<
-          RelativisticEuler::Solutions::TovStar>{1.e-3, 8.0, 2.0},
-      RelativisticEuler::Solutions::TovStar{1.e-3, 8.0, 2.0}, x_3d, t);
+          RelativisticEuler::Solutions::TovStar>{
+          1.e-3,
+          std::make_unique<EquationsOfState::PolytropicFluid<true>>(8.0, 2.0)},
+      RelativisticEuler::Solutions::TovStar{
+          1.e-3,
+          std::make_unique<EquationsOfState::PolytropicFluid<true>>(8.0, 2.0)},
+      x_3d, t);
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Python/Test_Tov.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Python/Test_Tov.py
@@ -34,9 +34,11 @@ class TestTov(unittest.TestCase):
         # Testing `log_specific_enthalpy` only at outer radius because we
         # haven't wrapped any EOS functions yet, so it's not trivial to compute
         # the specific enthalpy at other points
-        npt.assert_allclose(
-            tov.log_specific_enthalpy(np.array([outer_radius, outer_radius])),
-            np.array([0., 0.]))
+        npt.assert_allclose(tov.log_specific_enthalpy(
+            np.array([outer_radius, outer_radius])),
+                            np.array([0., 0.]),
+                            atol=1e-14,
+                            rtol=0.0)
 
 
 if __name__ == '__main__':

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_DarkEnergyFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_DarkEnergyFluid.cpp
@@ -37,6 +37,14 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.DarkEnergyFluid",
       "PointwiseFunctions/Hydro/EquationsOfState/"};
   const double d_for_size = std::numeric_limits<double>::signaling_NaN();
   const DataVector dv_for_size(5);
+  const auto eos = EoS::DarkEnergyFluid<true>{1.0};
+  const auto other_eos = EoS::DarkEnergyFluid<true>{0.5};
+  const auto other_type_eos = EoS::PolytropicFluid<true>{100.0, 2.0};
+  CHECK(eos == eos);
+  CHECK(eos != other_eos);
+  CHECK(eos != other_type_eos);
+  TestHelpers::EquationsOfState::test_get_clone(
+      EoS::DarkEnergyFluid<true>(1.0));
 
   TestHelpers::EquationsOfState::check(EoS::DarkEnergyFluid<true>(1.0),
                                        "DarkEnergyFluid", "dark_energy_fluid",

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Enthalpy.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Enthalpy.cpp
@@ -43,6 +43,45 @@ void check_exact() {
 
   const Enthalpy<Spectral>& eos =
       dynamic_cast<const Enthalpy<Spectral>&>(*eos_pointer);
+  TestHelpers::EquationsOfState::test_get_clone(eos);
+
+  const auto other_eos = Enthalpy<Spectral>{
+      1.0,
+      2.0,
+      1.5,
+      1.0,
+      std::vector<double>{1.0, 1.0},
+      std::vector<double>{0.1},
+      std::vector<double>{0.1},
+      Spectral{.5, .3, std::vector<double>{1.4, 0.0, 0.0}, 1.0},
+      0.0};
+  const auto other_low_eos =
+      Enthalpy<PolytropicFluid<true>>{1.0,
+                                      2.0,
+                                      1.5,
+                                      1.0,
+                                      std::vector<double>{1.0, 1.0},
+                                      std::vector<double>{0.1},
+                                      std::vector<double>{0.1},
+                                      PolytropicFluid<true>{100.0, 2.0},
+                                      0.0};
+  const auto other_hi_eos = Enthalpy<Spectral>{
+      1.0,
+      2.0,
+      1.5,
+      1.0,
+      std::vector<double>{1.0, .95},
+      std::vector<double>{0.05},
+      std::vector<double>{0.05},
+      Spectral{.5, .3, std::vector<double>{1.4, 0.0, 0.0}, 1.0},
+      0.0};
+  const auto other_type_eos = PolytropicFluid<true>{100.0, 2.0};
+  CHECK(eos == eos);
+  CHECK(other_eos != other_low_eos);
+  CHECK(other_eos != other_hi_eos);
+  CHECK(eos != other_eos);
+  CHECK(eos != other_type_eos);
+  CHECK(other_low_eos != other_type_eos);
   // Test DataVector functions
   {
     const Scalar<DataVector> rho{DataVector{1.5 * exp(1.0), 1.5 * exp(2.0),

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_HybridEos.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_HybridEos.cpp
@@ -61,6 +61,15 @@ void check_exact_polytrope() {
   CHECK(c_s_sq == (IsRelativistic ? 0.96 : 1.0));
   EquationsOfState::HybridEos<EquationsOfState::PolytropicFluid<IsRelativistic>>
       eos{cold_eos, 1.5};
+  TestHelpers::EquationsOfState::test_get_clone(eos);
+
+  const EquationsOfState::HybridEos<EquationsOfState::PolytropicFluid<true>>
+      other_eos{{100.0, 2.0}, 1.4};
+  const auto other_type_eos =
+      EquationsOfState::PolytropicFluid<true>{100.0, 2.0};
+  CHECK(eos == eos);
+  CHECK(eos != other_eos);
+  CHECK(eos != other_type_eos);
   const Scalar<double> eps{5.0};
   const auto p = eos.pressure_from_density_and_energy(rho, eps);
   CHECK(get(p) == 34.0);

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_IdealFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_IdealFluid.cpp
@@ -69,6 +69,15 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.IdealFluid",
       "PointwiseFunctions/Hydro/EquationsOfState/"};
   const double d_for_size = std::numeric_limits<double>::signaling_NaN();
   const DataVector dv_for_size(5);
+  TestHelpers::EquationsOfState::test_get_clone(
+      EoS::IdealFluid<true>(5.0 / 3.0));
+  const auto eos = EoS::IdealFluid<true>{5.0 / 3.0};
+  const auto other_eos = EoS::IdealFluid<true>{4.0 / 3.0};
+  const auto other_type_eos = EoS::PolytropicFluid<true>{100.0, 2.0};
+  CHECK(eos == eos);
+  CHECK(eos != other_eos);
+  CHECK(eos != other_type_eos);
+
   TestHelpers::EquationsOfState::check(EoS::IdealFluid<true>{5.0 / 3.0},
                                        "IdealFluid", "ideal_fluid", d_for_size,
                                        5.0 / 3.0);

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_PolytropicFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_PolytropicFluid.cpp
@@ -32,8 +32,8 @@ void check_dominant_energy_condition_at_bound() {
   const Scalar<double> rest_mass_density{eos.rest_mass_density_upper_bound()};
   const double specific_internal_energy =
       get(eos.specific_internal_energy_from_density(rest_mass_density));
-  const double pressure = get(eos.pressure_from_density(
-      Scalar<double>{rest_mass_density}));
+  const double pressure =
+      get(eos.pressure_from_density(Scalar<double>{rest_mass_density}));
   const double energy_density =
       get(rest_mass_density) * (1.0 + specific_internal_energy);
   CAPTURE(rest_mass_density);
@@ -67,6 +67,15 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.PolytropicFluid",
       EoS::EquationOfState<false, 1>>();
   pypp::SetupLocalPythonEnvironment local_python_env{
       "PointwiseFunctions/Hydro/EquationsOfState/"};
+  TestHelpers::EquationsOfState::test_get_clone(
+      EoS::PolytropicFluid<true>(100.0, 2.0));
+
+  const auto eos = EoS::PolytropicFluid<true>{100.0, 2.0};
+  const auto other_eos = EoS::PolytropicFluid<true>{4.0, 2.0};
+  const auto other_type_eos = EoS::DarkEnergyFluid<true>{0.5};
+  CHECK(eos == eos);
+  CHECK(eos != other_eos);
+  CHECK(eos != other_type_eos);
   const double d_for_size = std::numeric_limits<double>::signaling_NaN();
   const DataVector dv_for_size(5);
   TestHelpers::EquationsOfState::check(EoS::PolytropicFluid<true>{100.0, 2.0},

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_SpectralEoS.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_SpectralEoS.cpp
@@ -25,12 +25,20 @@ void check_exact() {
   TestHelpers::test_creation<std::unique_ptr<EoS::EquationOfState<true, 1>>>(
       {"Spectral:\n"
        "  ReferenceDensity: 2.0\n"
-       "  ReferencePressure: 4.0  \n"
+       "  ReferencePressure: 4.0\n"
        "  Coefficients: [3.0,0.25,0.375,0.5]\n"
        "  UpperDensity: 15.0\n"});
 
   EquationsOfState::Spectral eos(2.0, 4.0, {3.0, 0.25, 0.375, 0.5},
                                  2.0 * exp(2.0));
+  TestHelpers::EquationsOfState::test_get_clone(eos);
+
+  EquationsOfState::Spectral other_eos(1.0, 4.0, {3.0, 0.25, 0.375, 0.5},
+                                       2.0 * exp(2.0));
+  const auto other_type_eos = EoS::PolytropicFluid<true>{100.0, 2.0};
+  CHECK(eos == eos);
+  CHECK(eos != other_eos);
+  CHECK(eos != other_type_eos);
   // Test DataVector functions
   {
     const Scalar<DataVector> rho{DataVector{


### PR DESCRIPTION
## Proposed changes

This PR changes the structure of the EoS creation from input files and the structure of the TOV initial data for GRMHD to allow for use of generic equations of state implemented in spectre rather than just a polytropic equation of state.  This framework can be extended to allow any executable to use a generic equation of state in the input file.  

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

Currently the EoS is specified in the input file as a subset of the initial data, therefore changing the EoS to be generic only required changing the initial data.  In addition, most likely, the EoS used in the simulation should be made independent of the EoS used to generate the initial data and should be specified separately.  For example, it will become valuable to use 1-D EoSs in the initial data generation  while using a 2-D or 3-D EoS in the evolution.  This can be or can not be added to this pull request.  (Also need to fix merge conflicts with recent changes)