### PR TITLE
Add build type to info at compile time

### DIFF
--- a/src/Informer/InfoAtCompile.cpp
+++ b/src/Informer/InfoAtCompile.cpp
@@ -25,5 +25,10 @@ std::string info_from_build() {
   os << "Compiled on git branch:       " << git_branch() << "\n";
   os << "Compiled on git revision:     " << git_description() << "\n";
   os << "Linked on:                    " << link_date() << "\n";
+#ifdef SPECTRE_DEBUG
+  os << "Build type:                   Debug\n";
+#else
+  os << "Build type:                   Release\n";
+#endif
   return os.str();
 }


### PR DESCRIPTION
## Proposed changes

I got burned by this because I didn't realize I was running in Debug mode when I thought I was running in Release mode. Now the build type is printed with all the other useful info.

Also clean up the singleton info that's printed early on.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
