### PR TITLE
Add momentum density to scalar wave

### DIFF
--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -34,6 +34,7 @@
 #include "Evolution/Systems/ScalarWave/EnergyDensity.hpp"
 #include "Evolution/Systems/ScalarWave/Equations.hpp"
 #include "Evolution/Systems/ScalarWave/Initialize.hpp"
+#include "Evolution/Systems/ScalarWave/MomentumDensity.hpp"
 #include "Evolution/Systems/ScalarWave/System.hpp"
 #include "IO/Observer/Actions/RegisterEvents.hpp"
 #include "IO/Observer/Helpers.hpp"            // IWYU pragma: keep
@@ -141,6 +142,7 @@ struct EvolutionMetavars {
       tmpl::append<typename system::variables_tag::tags_list,
                    typename deriv_compute::type::tags_list, error_tags>,
       ScalarWave::Tags::EnergyDensityCompute<volume_dim>,
+      ScalarWave::Tags::MomentumDensityCompute<volume_dim>,
       ScalarWave::Tags::OneIndexConstraintCompute<volume_dim>,
       ScalarWave::Tags::TwoIndexConstraintCompute<volume_dim>,
       ::Tags::PointwiseL2NormCompute<

--- a/src/Evolution/Systems/ScalarWave/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarWave/CMakeLists.txt
@@ -12,6 +12,7 @@ spectre_target_sources(
   Constraints.cpp
   EnergyDensity.cpp
   Equations.cpp
+  MomentumDensity.cpp
   TimeDerivative.cpp
   VolumeTermsInstantiation.cpp
   )
@@ -25,6 +26,7 @@ spectre_target_headers(
   EnergyDensity.hpp
   Equations.hpp
   Initialize.hpp
+  MomentumDensity.hpp
   System.hpp
   Tags.hpp
   TagsDeclarations.hpp

--- a/src/Evolution/Systems/ScalarWave/MomentumDensity.cpp
+++ b/src/Evolution/Systems/ScalarWave/MomentumDensity.cpp
@@ -1,0 +1,52 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarWave/MomentumDensity.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace ScalarWave {
+template <size_t SpatialDim>
+void momentum_density(
+    const gsl::not_null<tnsr::i<DataVector, SpatialDim, Frame::Inertial>*>
+        result,
+    const Scalar<DataVector>& pi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi) {
+  for (size_t i = 0; i < SpatialDim; i++) {
+    result->get(i) = get(pi) * phi.get(i);
+  }
+}
+
+template <size_t SpatialDim>
+tnsr::i<DataVector, SpatialDim, Frame::Inertial> momentum_density(
+    const Scalar<DataVector>& pi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi) {
+  tnsr::i<DataVector, SpatialDim, Frame::Inertial> result{get(pi).size()};
+  momentum_density(make_not_null(&result), pi, phi);
+  return result;
+}
+
+}  // namespace ScalarWave
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                \
+  template void ScalarWave::momentum_density(                               \
+      const gsl::not_null<tnsr::i<DataVector, DIM(data), Frame::Inertial>*> \
+          result,                                                           \
+      const Scalar<DataVector>& pi,                                         \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& phi);          \
+  template tnsr::i<DataVector, DIM(data), Frame::Inertial>                  \
+  ScalarWave::momentum_density(                                             \
+      const Scalar<DataVector>& pi,                                         \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& phi);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATE
+#undef DIM

--- a/src/Evolution/Systems/ScalarWave/MomentumDensity.hpp
+++ b/src/Evolution/Systems/ScalarWave/MomentumDensity.hpp
@@ -1,0 +1,61 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace ScalarWave {
+/// @{
+/*!
+ * \brief Computes the momentum density of the scalar wave system.
+ *
+ * Below is the function used to calculate the momentum density.
+ *
+ * \f{align*}
+ * P_i = \Pi \times \Phi_i
+ * \f}
+ */
+template <size_t SpatialDim>
+void momentum_density(
+    gsl::not_null<tnsr::i<DataVector, SpatialDim, Frame::Inertial>*> result,
+    const Scalar<DataVector>& pi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi);
+
+template <size_t SpatialDim>
+tnsr::i<DataVector, SpatialDim, Frame::Inertial> momentum_density(
+    const Scalar<DataVector>& pi,
+    const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi);
+/// @}
+
+namespace Tags {
+/// \brief Computes the momentum density using ScalarWave::momentum_density()
+template <size_t SpatialDim>
+struct MomentumDensityCompute : MomentumDensity<SpatialDim>, db::ComputeTag {
+  using argument_tags = tmpl::list<Pi, Phi<SpatialDim>>;
+
+  using return_type = tnsr::i<DataVector, SpatialDim, Frame::Inertial>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<tnsr::i<DataVector, SpatialDim, Frame::Inertial>*> result,
+      const Scalar<DataVector>&,
+      const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&)>(
+      &momentum_density<SpatialDim>);
+
+  using base = MomentumDensity<SpatialDim>;
+};
+}  // namespace Tags
+}  // namespace ScalarWave

--- a/src/Evolution/Systems/ScalarWave/Tags.hpp
+++ b/src/Evolution/Systems/ScalarWave/Tags.hpp
@@ -112,4 +112,10 @@ struct EnergyDensity : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 
+/// The momentum density of the scalar wave
+template <size_t Dim>
+struct MomentumDensity : db::SimpleTag {
+  using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
+};
+
 }  // namespace ScalarWave::Tags

--- a/src/Evolution/Systems/ScalarWave/Tags.hpp
+++ b/src/Evolution/Systems/ScalarWave/Tags.hpp
@@ -22,7 +22,6 @@ namespace ScalarWave::Tags {
  */
 struct Psi : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() { return "Psi"; }
 };
 
 /*!
@@ -33,7 +32,6 @@ struct Psi : db::SimpleTag {
  */
 struct Pi : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() { return "Pi"; }
 };
 
 /*!
@@ -45,12 +43,10 @@ struct Pi : db::SimpleTag {
 template <size_t Dim>
 struct Phi : db::SimpleTag {
   using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
-  static std::string name() { return "Phi"; }
 };
 
 struct ConstraintGamma2 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() { return "ConstraintGamma2"; }
 };
 
 /*!
@@ -82,39 +78,32 @@ struct TwoIndexConstraint : db::SimpleTag {
 /// CharacteristicSpeedsCompute
 struct VPsi : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() { return "VPsi"; }
 };
 template <size_t Dim>
 struct VZero : db::SimpleTag {
   using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
-  static std::string name() { return "VZero"; }
 };
 struct VPlus : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() { return "VPlus"; }
 };
 struct VMinus : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static std::string name() { return "VMinus"; }
 };
 /// @}
 
 template <size_t Dim>
 struct CharacteristicSpeeds : db::SimpleTag {
   using type = std::array<DataVector, 4>;
-  static std::string name() { return "CharacteristicSpeeds"; }
 };
 
 template <size_t Dim>
 struct CharacteristicFields : db::SimpleTag {
   using type = Variables<tmpl::list<VPsi, VZero<Dim>, VPlus, VMinus>>;
-  static std::string name() { return "CharacteristicFields"; }
 };
 
 template <size_t Dim>
 struct EvolvedFieldsFromCharacteristicFields : db::SimpleTag {
   using type = Variables<tmpl::list<Psi, Pi, Phi<Dim>>>;
-  static std::string name() { return "EvolvedFieldsFromCharacteristicFields"; }
 };
 
 /// The energy density of the scalar wave
@@ -122,4 +111,5 @@ template <size_t Dim>
 struct EnergyDensity : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
+
 }  // namespace ScalarWave::Tags

--- a/src/Evolution/Systems/ScalarWave/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/ScalarWave/TagsDeclarations.hpp
@@ -33,4 +33,6 @@ template <size_t Dim>
 struct EvolvedFieldsFromCharacteristicFields;
 template <size_t Dim>
 struct EnergyDensity;
+template <size_t Dim>
+struct MomentumDensity;
 }  // namespace ScalarWave::Tags

--- a/tests/Unit/Evolution/Systems/ScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarWave/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBRARY_SOURCES
   Test_Constraints.cpp
   Test_EnergyDensity.cpp
   Test_Equations.cpp
+  Test_Tags.cpp
   Test_TimeDerivative.cpp
   )
 

--- a/tests/Unit/Evolution/Systems/ScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarWave/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBRARY_SOURCES
   Test_Constraints.cpp
   Test_EnergyDensity.cpp
   Test_Equations.cpp
+  Test_MomentumDensity.cpp
   Test_Tags.cpp
   Test_TimeDerivative.cpp
   )

--- a/tests/Unit/Evolution/Systems/ScalarWave/MomentumDensity.py
+++ b/tests/Unit/Evolution/Systems/ScalarWave/MomentumDensity.py
@@ -1,0 +1,13 @@
+#Distributed under the MIT License.
+#See LICENSE.txt for details.
+
+import numpy as np
+
+#Functions for testing MomentumDensity.cpp
+
+
+def momentum_density(pi, phi):
+    return pi * phi
+
+
+#End functions for testing MomentumDensity.cpp

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_MomentumDensity.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_MomentumDensity.cpp
@@ -1,0 +1,70 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <random>
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/ScalarWave/MomentumDensity.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+
+namespace {
+template <size_t SpatialDim, typename DataType>
+void test_compute_item_in_databox(const DataType& used_for_size) {
+  TestHelpers::db::test_compute_tag<
+      ScalarWave::Tags::MomentumDensityCompute<SpatialDim>>("MomentumDensity");
+
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> dist(-1.0, 1.0);
+
+  const Scalar<DataVector> pi = make_with_random_values<Scalar<DataVector>>(
+      make_not_null(&generator), dist, used_for_size);
+
+  const tnsr::i<DataVector, SpatialDim, Frame::Inertial> phi =
+      make_with_random_values<tnsr::i<DataVector, SpatialDim, Frame::Inertial>>(
+          make_not_null(&generator), dist, used_for_size);
+
+  const auto box = db::create<
+      db::AddSimpleTags<ScalarWave::Tags::Pi,
+                        ScalarWave::Tags::Phi<SpatialDim>>,
+      db::AddComputeTags<ScalarWave::Tags::MomentumDensityCompute<SpatialDim>>>(
+      pi, phi);
+
+  const auto expected = ScalarWave::momentum_density(pi, phi);
+
+  CHECK_ITERABLE_APPROX(
+      (db::get<ScalarWave::Tags::MomentumDensity<SpatialDim>>(box)), expected);
+}
+
+template <size_t SpatialDim>
+void test_momentum_density(const DataVector& used_for_size) {
+  void (*f)(
+      const gsl::not_null<tnsr::i<DataVector, SpatialDim, Frame::Inertial>*>,
+      const Scalar<DataVector>&,
+      const tnsr::i<DataVector, SpatialDim, Frame::Inertial>&) =
+      &ScalarWave::momentum_density<SpatialDim>;
+  pypp::check_with_random_values<1>(f, "MomentumDensity", {"momentum_density"},
+                                    {{{-1., 1.}}}, used_for_size);
+  test_compute_item_in_databox<SpatialDim>(used_for_size);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarWave.MomentumDensity",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env(
+      "Evolution/Systems/ScalarWave/");
+
+  const DataVector used_for_size(5);
+  test_momentum_density<1>(used_for_size);
+  test_momentum_density<2>(used_for_size);
+  test_momentum_density<3>(used_for_size);
+}

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_Tags.cpp
@@ -8,9 +8,9 @@
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarWave.Tags",
                   "[Unit][Evolution]") {
-  TestHelpers::db::test_simple_tag<ScalarWave::Psi>("Psi");
-  TestHelpers::db::test_simple_tag<ScalarWave::Pi>("Pi");
-  TestHelpers::db::test_simple_tag<ScalarWave::Phi<3>>("Phi");
+  TestHelpers::db::test_simple_tag<ScalarWave::Tags::Psi>("Psi");
+  TestHelpers::db::test_simple_tag<ScalarWave::Tags::Pi>("Pi");
+  TestHelpers::db::test_simple_tag<ScalarWave::Tags::Phi<3>>("Phi");
   TestHelpers::db::test_simple_tag<ScalarWave::Tags::ConstraintGamma2>(
       "ConstraintGamma2");
   TestHelpers::db::test_simple_tag<ScalarWave::Tags::OneIndexConstraint<3>>(
@@ -28,6 +28,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarWave.Tags",
   TestHelpers::db::test_simple_tag<
       ScalarWave::Tags::EvolvedFieldsFromCharacteristicFields<3>>(
       "EvolvedFieldsFromCharacteristicFields");
-  TestHelpers::db::test_simple_tag<ScalarWave::Tags::EnergyDensity<SpatialDim>>(
+  TestHelpers::db::test_simple_tag<ScalarWave::Tags::EnergyDensity<3>>(
       "EnergyDensity");
 }

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_Tags.cpp
@@ -30,4 +30,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarWave.Tags",
       "EvolvedFieldsFromCharacteristicFields");
   TestHelpers::db::test_simple_tag<ScalarWave::Tags::EnergyDensity<3>>(
       "EnergyDensity");
+  TestHelpers::db::test_simple_tag<ScalarWave::Tags::MomentumDensity<3>>(
+      "MomentumDensity");
 }


### PR DESCRIPTION
## Proposed changes

Add <code>Test_Tags.cpp</code>  to <code>CMakeLists.txt</code> and fix namespace of Psi, Pi and Phi. 
Add in the function that calculates the momentum density over the domain of a scalar wave system. 

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
