### PR TITLE
Add check for using removed DataBox item

### DIFF
--- a/src/ParallelAlgorithms/Actions/RemoveOptionsAndTerminatePhase.hpp
+++ b/src/ParallelAlgorithms/Actions/RemoveOptionsAndTerminatePhase.hpp
@@ -13,18 +13,17 @@
 
 namespace Initialization {
 namespace detail {
-template <typename... TagsToDefaultAssign, typename BoxTags>
-constexpr void default_assign(const gsl::not_null<db::DataBox<BoxTags>*> box,
-                              tmpl::list<TagsToDefaultAssign...> /*meta*/) {
-  db::mutate<TagsToDefaultAssign...>(box, [](const auto... args) {
-    EXPAND_PACK_LEFT_TO_RIGHT(*args = typename TagsToDefaultAssign::type{});
-  });
+template <typename... TagsToRemove, typename BoxTags>
+constexpr void remove(const gsl::not_null<db::DataBox<BoxTags>*> box,
+                      tmpl::list<TagsToRemove...> /*meta*/) {
+  EXPAND_PACK_LEFT_TO_RIGHT(db::remove<TagsToRemove>(box));
 }
 }  // namespace detail
 
 /// \ingroup InitializationGroup
-/// Removes an option from the DataBox by resetting its value to that given
-/// by default initialization.
+/// Removes an item from the DataBox by resetting its value to that given
+/// by default initialization.  In debug builds, using a removed item throws an
+/// exception.
 ///
 /// \snippet Test_RemoveOptionsAndTerminatePhase.cpp actions
 ///
@@ -48,7 +47,7 @@ struct RemoveOptionsAndTerminatePhase {
         tmpl::bind<tmpl::list_contains, tmpl::pin<initialization_tags_to_keep>,
                    tmpl::_1>>;
     if constexpr (tmpl::size<tags_to_remove>::value > 0) {
-      detail::default_assign(make_not_null(&box), tags_to_remove{});
+      detail::remove(make_not_null(&box), tags_to_remove{});
     }
     return std::make_tuple(std::move(box), true);
   }

--- a/tests/Unit/ParallelAlgorithms/Actions/Test_RemoveOptionsAndTerminatePhase.cpp
+++ b/tests/Unit/ParallelAlgorithms/Actions/Test_RemoveOptionsAndTerminatePhase.cpp
@@ -179,8 +179,14 @@ SPECTRE_TEST_CASE(
   CHECK(ActionTesting::tag_is_retrievable<component, DummyTime>(runner, 0));
   CHECK(ActionTesting::tag_is_retrievable<component, MultiplyByTwo<DummyTime>>(
       runner, 0));
-  CHECK(ActionTesting::get_databox_tag<component, InitialTime>(runner, 0) ==
-        0.0);
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(([&runner]() {
+                      ActionTesting::get_databox_tag<component, InitialTime>(
+                          runner, 0);
+                    }()),
+                    Catch::Contains("Unable to retrieve item 'InitialTime' as "
+                                    "it has been removed from the DataBox."));
+#endif
   CHECK(ActionTesting::get_databox_tag<component, InitialMass>(runner, 0) ==
         initial_mass);
   CHECK(ActionTesting::get_databox_tag<component, DummyTime>(runner, 0) ==


### PR DESCRIPTION
In a debug build, retrieving or mutating an item that was removed
(via RemoveOptionsAndTerminatePHase) will throw an exception.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
