### PR TITLE
Fix GenerateXdmf for 2D non-surface output

### DIFF
--- a/src/Visualization/Python/GenerateXdmf.py
+++ b/src/Visualization/Python/GenerateXdmf.py
@@ -138,7 +138,7 @@ def generate_xdmf(file_prefix, output, subfile_name, start_time, stop_time,
                 elif is_2d_surface_in_3d_space:
                     # Number_of_cells == l * (2*l + 1)
                     number_of_cells = sum((extents_x - 1) * extents_y)
-                elif dimensionality == 3:
+                else:
                     number_of_cells = sum(
                         (extents_x - 1) * (extents_y - 1) *
                         (extents_z - 1 if dimensionality == 3 else 1))


### PR DESCRIPTION
## Proposed changes

#3973 broke visualizing 2D non-surface output. Paraview would just immediately crash when you opened the `.xmf` file.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
