### PR TITLE
Cleanup some simple Actions

### DIFF
--- a/src/ControlSystem/UpdateControlSystem.hpp
+++ b/src/ControlSystem/UpdateControlSystem.hpp
@@ -85,152 +85,128 @@ struct UpdateControlSystem {
                     Parallel::GlobalCache<Metavariables>& cache,
                     const ArrayIndex& /*array_index*/, const double time,
                     tuples::TaggedTuple<TupleTags...> data) {
-    if constexpr (db::tag_is_retrievable_v<
-                      control_system::Tags::Averager<ControlSystem>,
-                      db::DataBox<DbTags>> and
-                  db::tag_is_retrievable_v<
-                      control_system::Tags::Controller<ControlSystem>,
-                      db::DataBox<DbTags>> and
-                  db::tag_is_retrievable_v<
-                      control_system::Tags::TimescaleTuner<ControlSystem>,
-                      db::DataBox<DbTags>> and
-                  db::tag_is_retrievable_v<
-                      control_system::Tags::ControlError<ControlSystem>,
-                      db::DataBox<DbTags>> and
-                  db::tag_is_retrievable_v<
-                      ::control_system::Tags::WriteDataToDisk,
-                      db::DataBox<DbTags>>) {
-      // Begin step 1
-      // If this control system isn't active, don't do anything
-      if (not get<control_system::Tags::IsActive<ControlSystem>>(*box)) {
-        return;
-      }
+    // Begin step 1
+    // If this control system isn't active, don't do anything
+    if (not get<control_system::Tags::IsActive<ControlSystem>>(*box)) {
+      return;
+    }
 
-      // Begin step 2
-      const auto& functions_of_time =
-          Parallel::get<::domain::Tags::FunctionsOfTime>(cache);
-      const auto& measurement_timescales =
-          Parallel::get<Tags::MeasurementTimescales>(cache);
-      const std::string& function_of_time_name = ControlSystem::name();
-      const auto& function_of_time =
-          functions_of_time.at(function_of_time_name);
+    // Begin step 2
+    const auto& functions_of_time =
+        Parallel::get<::domain::Tags::FunctionsOfTime>(cache);
+    const auto& measurement_timescales =
+        Parallel::get<Tags::MeasurementTimescales>(cache);
+    const std::string& function_of_time_name = ControlSystem::name();
+    const auto& function_of_time = functions_of_time.at(function_of_time_name);
 
-      const double current_expiration_time = function_of_time->time_bounds()[1];
-      // We need the min over all functions of time because that's when the next
-      // measurement will be
-      double current_min_time_between_measurements{
-          std::numeric_limits<double>::max()};
-      for (const auto& [name, measurement_timescale_fot] :
-           measurement_timescales) {
-        // Avoid compiler warning with gcc-7
-        (void)name;
-        current_min_time_between_measurements =
-            std::min(current_min_time_between_measurements,
-                     min(measurement_timescale_fot->func(time)[0]));
-      }
+    const double current_expiration_time = function_of_time->time_bounds()[1];
+    // We need the min over all functions of time because that's when the next
+    // measurement will be
+    double current_min_time_between_measurements{
+        std::numeric_limits<double>::max()};
+    for (const auto& [name, measurement_timescale_fot] :
+         measurement_timescales) {
+      // Avoid compiler warning with gcc-7
+      (void)name;
+      current_min_time_between_measurements =
+          std::min(current_min_time_between_measurements,
+                   min(measurement_timescale_fot->func(time)[0]));
+    }
 
-      // If the next time we are going to measure is after the current
-      // expiration time, we have to update things now
-      const bool need_to_update_now =
-          current_expiration_time <
-          time + current_min_time_between_measurements;
+    // If the next time we are going to measure is after the current
+    // expiration time, we have to update things now
+    const bool need_to_update_now =
+        current_expiration_time < time + current_min_time_between_measurements;
 
-      // Begin step 3
-      // Get the averager, controller, tuner, and control error from the box
-      auto& averager = db::get_mutable_reference<
-          control_system::Tags::Averager<ControlSystem>>(box);
-      auto& controller = db::get_mutable_reference<
-          control_system::Tags::Controller<ControlSystem>>(box);
-      auto& tuner = db::get_mutable_reference<
-          control_system::Tags::TimescaleTuner<ControlSystem>>(box);
-      auto& control_error = db::get_mutable_reference<
-          control_system::Tags::ControlError<ControlSystem>>(box);
-      const DataVector& current_timescale = tuner.current_timescale();
+    // Begin step 3
+    // Get the averager, controller, tuner, and control error from the box
+    auto& averager = db::get_mutable_reference<
+        control_system::Tags::Averager<ControlSystem>>(box);
+    auto& controller = db::get_mutable_reference<
+        control_system::Tags::Controller<ControlSystem>>(box);
+    auto& tuner = db::get_mutable_reference<
+        control_system::Tags::TimescaleTuner<ControlSystem>>(box);
+    auto& control_error = db::get_mutable_reference<
+        control_system::Tags::ControlError<ControlSystem>>(box);
+    const DataVector& current_timescale = tuner.current_timescale();
 
-      // Check if we actually need to use the measurement. If a control system
-      // is on a longer timescale, we don't need to store frequent measurements
-      if (not(averager.is_ready(time) or need_to_update_now)) {
-        return;
-      }
+    // Check if we actually need to use the measurement. If a control system
+    // is on a longer timescale, we don't need to store frequent measurements
+    if (not(averager.is_ready(time) or need_to_update_now)) {
+      return;
+    }
 
-      // Begin step 4
-      // Compute control error
-      const DataVector Q =
-          control_error(cache, time, function_of_time_name, data);
+    // Begin step 4
+    // Compute control error
+    const DataVector Q =
+        control_error(cache, time, function_of_time_name, data);
 
-      // Update the averager. We do this before we call controller.is_ready()
-      // because we still want the averager to be up to date even if we aren't
-      // updating at this time
-      averager.update(time, Q, current_timescale);
+    // Update the averager. We do this before we call controller.is_ready()
+    // because we still want the averager to be up to date even if we aren't
+    // updating at this time
+    averager.update(time, Q, current_timescale);
 
-      // Begin step 5
-      // Check if it is time to update
-      if (not(controller.is_ready(time) or need_to_update_now)) {
-        return;
-      }
+    // Begin step 5
+    // Check if it is time to update
+    if (not(controller.is_ready(time) or need_to_update_now)) {
+      return;
+    }
 
-      // Begin step 6
-      // Get the averaged values of the control error and its derivatives
-      const auto& opt_avg_values = averager(time);
+    // Begin step 6
+    // Get the averaged values of the control error and its derivatives
+    const auto& opt_avg_values = averager(time);
 
-      const double time_offset =
-          averager.last_time_updated() - averager.average_time(time);
-      const double time_offset_0th =
-          averager.using_average_0th_deriv_of_q() ? time_offset : 0.0;
+    const double time_offset =
+        averager.last_time_updated() - averager.average_time(time);
+    const double time_offset_0th =
+        averager.using_average_0th_deriv_of_q() ? time_offset : 0.0;
 
-      // Calculate the control signal which will be used to update the highest
-      // derivative of the FunctionOfTime
-      const DataVector control_signal =
-          controller(time, current_timescale, opt_avg_values.value(),
-                     time_offset_0th, time_offset);
+    // Calculate the control signal which will be used to update the highest
+    // derivative of the FunctionOfTime
+    const DataVector control_signal =
+        controller(time, current_timescale, opt_avg_values.value(),
+                   time_offset_0th, time_offset);
 
-      // Begin step 7
-      // Calculate the next expiration time based on the current one
-      const double new_expiration_time =
-          controller.next_expiration_time(current_expiration_time);
+    // Begin step 7
+    // Calculate the next expiration time based on the current one
+    const double new_expiration_time =
+        controller.next_expiration_time(current_expiration_time);
 
-      // Begin step 8
-      // Actually update the FunctionOfTime
-      Parallel::mutate<::domain::Tags::FunctionsOfTime, UpdateFunctionOfTime>(
-          cache, function_of_time_name, current_expiration_time, control_signal,
-          new_expiration_time);
+    // Begin step 8
+    // Actually update the FunctionOfTime
+    Parallel::mutate<::domain::Tags::FunctionsOfTime, UpdateFunctionOfTime>(
+        cache, function_of_time_name, current_expiration_time, control_signal,
+        new_expiration_time);
 
-      // Begin step 9
-      // Update the damping timescales with the newly calculated control error
-      // and its derivative
-      std::array<DataVector, 2> q_and_dtq{
-          {(*opt_avg_values)[0], {(*opt_avg_values)[0].size(), 0.0}}};
-      if constexpr (deriv_order > 1) {
-        q_and_dtq[1] = (*opt_avg_values)[1];
-      }
-      tuner.update_timescale(q_and_dtq);
+    // Begin step 9
+    // Update the damping timescales with the newly calculated control error
+    // and its derivative
+    std::array<DataVector, 2> q_and_dtq{
+        {(*opt_avg_values)[0], {(*opt_avg_values)[0].size(), 0.0}}};
+    if constexpr (deriv_order > 1) {
+      q_and_dtq[1] = (*opt_avg_values)[1];
+    }
+    tuner.update_timescale(q_and_dtq);
 
-      // Begin step 10
-      // Calculate new measurement timescales with updated damping timescales
-      const DataVector new_measurement_timescale =
-          calculate_measurement_timescales(controller, tuner);
+    // Begin step 10
+    // Calculate new measurement timescales with updated damping timescales
+    const DataVector new_measurement_timescale =
+        calculate_measurement_timescales(controller, tuner);
 
-      // Begin step 11
-      // Update the measurement timescales
-      Parallel::mutate<Tags::MeasurementTimescales, UpdateFunctionOfTime>(
-          cache, function_of_time_name, current_expiration_time,
-          new_measurement_timescale, new_expiration_time);
+    // Begin step 11
+    // Update the measurement timescales
+    Parallel::mutate<Tags::MeasurementTimescales, UpdateFunctionOfTime>(
+        cache, function_of_time_name, current_expiration_time,
+        new_measurement_timescale, new_expiration_time);
 
-      // Now that the measurement timescales have been updated, tell the
-      // averager when to expect the next measurement
-      averager.assign_time_between_measurements(min(new_measurement_timescale));
+    // Now that the measurement timescales have been updated, tell the
+    // averager when to expect the next measurement
+    averager.assign_time_between_measurements(min(new_measurement_timescale));
 
-      // Begin step 12
-      if (db::get<control_system::Tags::WriteDataToDisk>(*box)) {
-        write_components_to_disk<ControlSystem>(
-            time, cache, function_of_time, *opt_avg_values, control_signal);
-      }
-    } else {
-      (void)(box);
-      (void)(cache);
-      (void)(time);
-      (void)(data);
-      ERROR("Wrong DataBox. Expecting a DataBox from a ControlComponent.");
+    // Begin step 12
+    if (db::get<control_system::Tags::WriteDataToDisk>(*box)) {
+      write_components_to_disk<ControlSystem>(time, cache, function_of_time,
+                                              *opt_avg_values, control_signal);
     }
   }
 };

--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -106,21 +106,8 @@ struct TimeAndTimeStep {
                       ::Tags::Next<::Tags::TimeStep>>;
   using compute_tags = tmpl::list<>;
 
-  template <
-      typename DbTagsList, typename... InboxTags, typename ArrayIndex,
-      typename ActionList, typename ParallelComponent,
-      Requires<tmpl::list_contains_v<
-                   typename db::DataBox<DbTagsList>::mutable_item_tags,
-                   Initialization::Tags::InitialTime> and
-
-               tmpl::list_contains_v<
-                   typename db::DataBox<DbTagsList>::mutable_item_tags,
-                   Initialization::Tags::InitialTimeDelta> and
-
-               tmpl::list_contains_v<
-                   typename db::DataBox<DbTagsList>::mutable_item_tags,
-                   Tags::InitialSlabSize<Metavariables::local_time_stepping>>> =
-          nullptr>
+  template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
+            typename ActionList, typename ParallelComponent>
   static auto apply(db::DataBox<DbTagsList>& box,
                     const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
@@ -160,35 +147,6 @@ struct TimeAndTimeStep {
         initial_dt, initial_dt);
     return std::make_tuple(std::move(box));
   }
-
-  template <
-      typename DbTagsList, typename... InboxTags, typename ArrayIndex,
-      typename ActionList, typename ParallelComponent,
-      Requires<
-          not(tmpl::list_contains_v<
-                  typename db::DataBox<DbTagsList>::mutable_item_tags,
-                  Initialization::Tags::InitialTime> and
-
-              tmpl::list_contains_v<
-                  typename db::DataBox<DbTagsList>::mutable_item_tags,
-                  Initialization::Tags::InitialTimeDelta> and
-
-              tmpl::list_contains_v<
-                  typename db::DataBox<DbTagsList>::mutable_item_tags,
-                  Tags::InitialSlabSize<Metavariables::local_time_stepping>>)> =
-          nullptr>
-  static std::tuple<db::DataBox<DbTagsList>&&> apply(
-      db::DataBox<DbTagsList>& /*box*/,
-      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-      const Parallel::GlobalCache<Metavariables>& /*cache*/,
-      const ArrayIndex& /*array_index*/, ActionList /*meta*/,
-      const ParallelComponent* const /*meta*/) {
-    ERROR(
-        "Could not find dependency 'Initialization::Tags::InitialTime', "
-        "'Initialization::Tags::InitialTimeDelta', or "
-        "'Tags::InitialSlabSize<Metavariables::local_time_stepping>' in "
-        "DataBox.");
-  }
 };
 
 /// \ingroup InitializationGroup
@@ -219,14 +177,7 @@ struct TimeStepperHistory {
   using compute_tags = db::AddComputeTags<>;
 
   template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
-            typename ActionList, typename ParallelComponent,
-            Requires<tmpl::list_contains_v<
-                         typename db::DataBox<DbTagsList>::mutable_item_tags,
-                         domain::Tags::Mesh<dim>> and
-
-                     tmpl::list_contains_v<
-                         typename db::DataBox<DbTagsList>::mutable_item_tags,
-                         variables_tag>> = nullptr>
+            typename ActionList, typename ParallelComponent>
   static auto apply(db::DataBox<DbTagsList>& box,
                     const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
@@ -256,27 +207,6 @@ struct TimeStepperHistory {
         std::move(error_vars), false);
 
     return std::make_tuple(std::move(box));
-  }
-
-  template <
-      typename DbTagsList, typename... InboxTags, typename ArrayIndex,
-      typename ActionList, typename ParallelComponent,
-      Requires<not(tmpl::list_contains_v<
-                       typename db::DataBox<DbTagsList>::mutable_item_tags,
-                       domain::Tags::Mesh<dim>> and
-
-                   tmpl::list_contains_v<
-                       typename db::DataBox<DbTagsList>::mutable_item_tags,
-                       variables_tag>)> = nullptr>
-  static std::tuple<db::DataBox<DbTagsList>&&> apply(
-      db::DataBox<DbTagsList>& /*box*/,
-      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-      const Parallel::GlobalCache<Metavariables>& /*cache*/,
-      const ArrayIndex& /*array_index*/, ActionList /*meta*/,
-      const ParallelComponent* const /*meta*/) {
-    ERROR(
-        "Could not find dependency '::Tags::Mesh<dim>' or "
-        "'Metavariables::system::variables_tag' in DataBox.");
   }
 };
 }  // namespace Actions

--- a/src/Evolution/Initialization/SetVariables.hpp
+++ b/src/Evolution/Initialization/SetVariables.hpp
@@ -61,15 +61,7 @@ struct SetVariables {
       const Parallel::GlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/, ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
-    if constexpr (tmpl::list_contains_v<
-                      typename db::DataBox<DbTagsList>::mutable_item_tags,
-                      ::Initialization::Tags::InitialTime>) {
-      impl<Metavariables>(make_not_null(&box));
-    } else {
-      ERROR(
-          "Could not find dependency 'Initialization::Tags::InitialTime' in "
-          "DataBox.");
-    }
+    impl<Metavariables>(make_not_null(&box));
     return {std::move(box)};
   }
 

--- a/src/Evolution/Systems/Cce/Actions/BoundaryComputeAndSendToEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Actions/BoundaryComputeAndSendToEvolution.hpp
@@ -89,11 +89,7 @@ struct SendToEvolution;
 template <typename Metavariables, typename EvolutionComponent>
 struct BoundaryComputeAndSendToEvolution<H5WorldtubeBoundary<Metavariables>,
                                          EvolutionComponent> {
-  template <typename ParallelComponent, typename... DbTags, typename ArrayIndex,
-            Requires<tmpl2::flat_any_v<std::is_same_v<
-                ::Tags::Variables<
-                    typename Metavariables::cce_boundary_communication_tags>,
-                DbTags>...>> = nullptr>
+  template <typename ParallelComponent, typename... DbTags, typename ArrayIndex>
   static void apply(db::DataBox<tmpl::list<DbTags...>>& box,
                     Parallel::GlobalCache<Metavariables>& cache,
                     const ArrayIndex& /*array_index*/, const TimeStepId& time) {
@@ -156,42 +152,33 @@ struct BoundaryComputeAndSendToEvolution<
   static void apply(db::DataBox<DbTagList>& box,
                     Parallel::GlobalCache<Metavariables>& cache,
                     const ArrayIndex& /*array_index*/, const TimeStepId& time) {
-    if constexpr (tmpl::list_contains_v<
-                      DbTagList,
-                      ::Tags::Variables<typename Metavariables::
-                                            cce_boundary_communication_tags>>) {
-      bool successfully_populated = false;
-      db::mutate<Tags::AnalyticBoundaryDataManager,
-                 ::Tags::Variables<
-                     typename Metavariables::cce_boundary_communication_tags>>(
-          make_not_null(&box),
-          [&successfully_populated, &time](
-              const gsl::not_null<Cce::AnalyticBoundaryDataManager*>
-                  worldtube_data_manager,
-              const gsl::not_null<Variables<
-                  typename Metavariables::cce_boundary_communication_tags>*>
-                  boundary_variables) {
-            successfully_populated =
-                (*worldtube_data_manager)
-                    .populate_hypersurface_boundary_data(
-                        boundary_variables, time.substep_time().value());
-          });
+    bool successfully_populated = false;
+    db::mutate<Tags::AnalyticBoundaryDataManager,
+               ::Tags::Variables<
+                   typename Metavariables::cce_boundary_communication_tags>>(
+        make_not_null(&box),
+        [&successfully_populated, &time](
+            const gsl::not_null<Cce::AnalyticBoundaryDataManager*>
+                worldtube_data_manager,
+            const gsl::not_null<Variables<
+                typename Metavariables::cce_boundary_communication_tags>*>
+                boundary_variables) {
+          successfully_populated =
+              (*worldtube_data_manager)
+                  .populate_hypersurface_boundary_data(
+                      boundary_variables, time.substep_time().value());
+        });
 
-      if (not successfully_populated) {
-        ERROR("Insufficient boundary data to proceed, exiting early at time "
-              << time.substep_time().value());
-      }
-      Parallel::receive_data<Cce::ReceiveTags::BoundaryData<
-          typename Metavariables::cce_boundary_communication_tags>>(
-          Parallel::get_parallel_component<EvolutionComponent>(cache), time,
-          db::get<::Tags::Variables<
-              typename Metavariables::cce_boundary_communication_tags>>(box),
-          true);
-    } else {
-      ERROR(
-          "Did not find required tag `::Tags::Variables<typename "
-          "Metavariables::cce_boundary_communication_tags>` in the DataBox");
+    if (not successfully_populated) {
+      ERROR("Insufficient boundary data to proceed, exiting early at time "
+            << time.substep_time().value());
     }
+    Parallel::receive_data<Cce::ReceiveTags::BoundaryData<
+        typename Metavariables::cce_boundary_communication_tags>>(
+        Parallel::get_parallel_component<EvolutionComponent>(cache), time,
+        db::get<::Tags::Variables<
+            typename Metavariables::cce_boundary_communication_tags>>(box),
+        true);
   }
 };
 
@@ -220,11 +207,7 @@ struct BoundaryComputeAndSendToEvolution<
 template <typename Metavariables, typename EvolutionComponent>
 struct BoundaryComputeAndSendToEvolution<GhWorldtubeBoundary<Metavariables>,
                                          EvolutionComponent> {
-  template <typename ParallelComponent, typename... DbTags, typename ArrayIndex,
-            Requires<tmpl2::flat_any_v<std::is_same_v<
-                ::Tags::Variables<
-                    typename Metavariables::cce_boundary_communication_tags>,
-                DbTags>...>> = nullptr>
+  template <typename ParallelComponent, typename... DbTags, typename ArrayIndex>
   static void apply(db::DataBox<tmpl::list<DbTags...>>& box,
                     Parallel::GlobalCache<Metavariables>& cache,
                     const ArrayIndex& /*array_index*/, const TimeStepId& time) {
@@ -256,11 +239,7 @@ struct BoundaryComputeAndSendToEvolution<GhWorldtubeBoundary<Metavariables>,
 /// \cond
 template <typename Metavariables, typename EvolutionComponent>
 struct SendToEvolution<GhWorldtubeBoundary<Metavariables>, EvolutionComponent> {
-  template <typename ParallelComponent, typename... DbTags, typename ArrayIndex,
-            Requires<tmpl2::flat_any_v<std::is_same_v<
-                ::Tags::Variables<
-                    typename Metavariables::cce_boundary_communication_tags>,
-                DbTags>...>> = nullptr>
+  template <typename ParallelComponent, typename... DbTags, typename ArrayIndex>
   static void apply(
       db::DataBox<tmpl::list<DbTags...>>& box,
       Parallel::GlobalCache<Metavariables>& cache,

--- a/src/Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp
@@ -74,19 +74,13 @@ struct InitializeWorldtubeBoundaryBase {
         }
       }
     }
-    if constexpr (tmpl::list_contains_v<DataBoxTagsList,
-                                        tmpl::front<ManagerTags>>) {
-      const size_t l_max = db::get<Tags::LMax>(box);
-      Variables<BoundaryCommunicationTagsList> boundary_variables{
-          Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
+    const size_t l_max = db::get<Tags::LMax>(box);
+    Variables<BoundaryCommunicationTagsList> boundary_variables{
+        Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
 
-      Initialization::mutate_assign<simple_tags>(make_not_null(&box),
-                                                 std::move(boundary_variables));
-      return std::make_tuple(std::move(box));
-    } else {
-      ERROR(MakeString{} << "Missing required boundary manager tag : "
-            << db::tag_name<tmpl::front<ManagerTags>>);
-    }
+    Initialization::mutate_assign<simple_tags>(make_not_null(&box),
+                                               std::move(boundary_variables));
+    return std::make_tuple(std::move(box));
   }
 };
 }  // namespace detail

--- a/src/IO/Importers/Actions/ReadVolumeData.hpp
+++ b/src/IO/Importers/Actions/ReadVolumeData.hpp
@@ -163,12 +163,8 @@ struct ReadVolumeData {
 template <typename ImporterOptionsGroup, typename FieldTagsList,
           typename ReceiveComponent>
 struct ReadAllVolumeDataAndDistribute {
-  template <
-      typename ParallelComponent, typename DataBox, typename Metavariables,
-      typename ArrayIndex,
-      Requires<db::tag_is_retrievable_v<Tags::RegisteredElements, DataBox> and
-               db::tag_is_retrievable_v<Tags::ElementDataAlreadyRead,
-                                        DataBox>> = nullptr>
+  template <typename ParallelComponent, typename DataBox,
+            typename Metavariables, typename ArrayIndex>
   static void apply(DataBox& box, Parallel::GlobalCache<Metavariables>& cache,
                     const ArrayIndex& /*array_index*/,
                     tuples::tagged_tuple_from_typelist<

--- a/src/IO/Importers/Actions/RegisterWithElementDataReader.hpp
+++ b/src/IO/Importers/Actions/RegisterWithElementDataReader.hpp
@@ -76,11 +76,9 @@ struct RegisterWithElementDataReader {
  * \see Dev guide on \ref dev_guide_importing
  */
 struct RegisterElementWithSelf {
-  template <
-      typename ParallelComponent, typename DbTagsList, typename Metavariables,
-      typename ArrayIndex, typename DataBox = db::DataBox<DbTagsList>,
-      Requires<db::tag_is_retrievable_v<Tags::RegisteredElements, DataBox>> =
-          nullptr>
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables, typename ArrayIndex,
+            typename DataBox = db::DataBox<DbTagsList>>
   static void apply(db::DataBox<DbTagsList>& box,
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/,

--- a/src/IO/Observer/Actions/GetLockPointer.hpp
+++ b/src/IO/Observer/Actions/GetLockPointer.hpp
@@ -28,22 +28,15 @@ struct GetLockPointer {
   template <typename ParallelComponent, typename DbTagList>
   static return_type apply(db::DataBox<DbTagList>& box,
                            const gsl::not_null<Parallel::NodeLock*> node_lock) {
-    if constexpr (tmpl::list_contains_v<DbTagList, LockTag>) {
-      Parallel::NodeLock* result_lock;
-      node_lock->lock();
-      db::mutate<LockTag>(
-          make_not_null(&box),
-          [&result_lock](const gsl::not_null<Parallel::NodeLock*> lock) {
-            result_lock = lock;
-          });
-      node_lock->unlock();
-      return result_lock;
-    } else {
-      // silence 'unused variable' warnings
-      (void)node_lock;
-      ERROR("Could not find required tag " << pretty_type::get_name<LockTag>()
-                                           << " in the databox");
-    }
+    Parallel::NodeLock* result_lock;
+    node_lock->lock();
+    db::mutate<LockTag>(
+        make_not_null(&box),
+        [&result_lock](const gsl::not_null<Parallel::NodeLock*> lock) {
+          result_lock = lock;
+        });
+    node_lock->unlock();
+    return result_lock;
   }
 };
 }  // namespace observers::Actions

--- a/src/IO/Observer/Actions/ObserverRegistration.hpp
+++ b/src/IO/Observer/Actions/ObserverRegistration.hpp
@@ -44,40 +44,28 @@ struct RegisterVolumeContributorWithObserverWriter {
                     const ArrayIndex& /*array_index*/,
                     const observers::ObservationKey& observation_key,
                     const ArrayComponentId& id_of_caller) {
-    if constexpr (tmpl::list_contains_v<
-                      DbTagsList, Tags::ExpectedContributorsForObservations>) {
-      db::mutate<Tags::ExpectedContributorsForObservations>(
-          make_not_null(&box),
-          [&id_of_caller, &observation_key](
-              const gsl::not_null<std::unordered_map<
-                  ObservationKey, std::unordered_set<ArrayComponentId>>*>
-                  volume_observers_registered) {
-            if (volume_observers_registered->find(observation_key) ==
-                volume_observers_registered->end()) {
-              (*volume_observers_registered)[observation_key] =
-                  std::unordered_set<ArrayComponentId>{};
-            }
+    db::mutate<Tags::ExpectedContributorsForObservations>(
+        make_not_null(&box),
+        [&id_of_caller, &observation_key](
+            const gsl::not_null<std::unordered_map<
+                ObservationKey, std::unordered_set<ArrayComponentId>>*>
+                volume_observers_registered) {
+          if (volume_observers_registered->find(observation_key) ==
+              volume_observers_registered->end()) {
+            (*volume_observers_registered)[observation_key] =
+                std::unordered_set<ArrayComponentId>{};
+          }
 
-            if (UNLIKELY(
-                    volume_observers_registered->at(observation_key)
-                        .find(id_of_caller) !=
-                    volume_observers_registered->at(observation_key).end())) {
-              ERROR("Trying to insert a Observer component more than once: "
-                    << id_of_caller);
-            }
+          if (UNLIKELY(
+                  volume_observers_registered->at(observation_key)
+                      .find(id_of_caller) !=
+                  volume_observers_registered->at(observation_key).end())) {
+            ERROR("Trying to insert a Observer component more than once: "
+                  << id_of_caller);
+          }
 
-            volume_observers_registered->at(observation_key)
-                .insert(id_of_caller);
-          });
-    } else {
-      (void)box;
-      (void)observation_key;
-      (void)id_of_caller;
-      ERROR(
-          "Could not find tag "
-          "observers::Tags::ExpectedContributorsForObservations in the "
-          "DataBox.");
-    }
+          volume_observers_registered->at(observation_key).insert(id_of_caller);
+        });
   }
 };
 
@@ -97,47 +85,35 @@ struct DeregisterVolumeContributorWithObserverWriter {
                     const ArrayIndex& /*array_index*/,
                     const observers::ObservationKey& observation_key,
                     const ArrayComponentId& id_of_caller) {
-    if constexpr (tmpl::list_contains_v<
-                      DbTagsList, Tags::ExpectedContributorsForObservations>) {
-      db::mutate<Tags::ExpectedContributorsForObservations>(
-          make_not_null(&box),
-          [&id_of_caller, &observation_key](
-              const gsl::not_null<std::unordered_map<
-                  ObservationKey, std::unordered_set<ArrayComponentId>>*>
-                  volume_observers_registered) {
-            if (UNLIKELY(volume_observers_registered->find(observation_key) ==
-                         volume_observers_registered->end())) {
-              ERROR(
-                  "Trying to deregister a component associated with an "
-                  "unregistered observation key: "
-                  << observation_key);
-            }
+    db::mutate<Tags::ExpectedContributorsForObservations>(
+        make_not_null(&box),
+        [&id_of_caller, &observation_key](
+            const gsl::not_null<std::unordered_map<
+                ObservationKey, std::unordered_set<ArrayComponentId>>*>
+                volume_observers_registered) {
+          if (UNLIKELY(volume_observers_registered->find(observation_key) ==
+                       volume_observers_registered->end())) {
+            ERROR(
+                "Trying to deregister a component associated with an "
+                "unregistered observation key: "
+                << observation_key);
+          }
 
-            if (UNLIKELY(
-                    volume_observers_registered->at(observation_key)
-                        .find(id_of_caller) ==
-                    volume_observers_registered->at(observation_key).end())) {
-              ERROR("Trying to deregister an unregistered component: "
-                    << id_of_caller);
-            }
+          if (UNLIKELY(
+                  volume_observers_registered->at(observation_key)
+                      .find(id_of_caller) ==
+                  volume_observers_registered->at(observation_key).end())) {
+            ERROR("Trying to deregister an unregistered component: "
+                  << id_of_caller);
+          }
 
-            volume_observers_registered->at(observation_key)
-                .erase(id_of_caller);
-            if (UNLIKELY(
-                    volume_observers_registered->at(observation_key).size() ==
-                    0)) {
-              volume_observers_registered->erase(observation_key);
-            }
-          });
-    } else {
-      (void)box;
-      (void)observation_key;
-      (void)id_of_caller;
-      ERROR(
-          "Could not find tag "
-          "observers::Tags::ExpectedContributorsForObservations in the "
-          "DataBox.");
-    }
+          volume_observers_registered->at(observation_key).erase(id_of_caller);
+          if (UNLIKELY(
+                  volume_observers_registered->at(observation_key).size() ==
+                  0)) {
+            volume_observers_registered->erase(observation_key);
+          }
+        });
   }
 };
 
@@ -152,46 +128,33 @@ struct RegisterReductionNodeWithWritingNode {
                     const ArrayIndex& /*array_index*/,
                     const observers::ObservationKey& observation_key,
                     const size_t caller_node_id) {
-    if constexpr (tmpl::list_contains_v<
-                      DbTagsList, Tags::NodesExpectedToContributeReductions>) {
-      auto& my_proxy =
-          Parallel::get_parallel_component<ParallelComponent>(cache);
-      const auto node_id =
-          Parallel::my_node<size_t>(*Parallel::local_branch(my_proxy));
-      ASSERT(node_id == 0, "Only node zero, not node "
-                               << node_id
-                               << ", should be called from another node");
+    auto& my_proxy = Parallel::get_parallel_component<ParallelComponent>(cache);
+    const auto node_id =
+        Parallel::my_node<size_t>(*Parallel::local_branch(my_proxy));
+    ASSERT(node_id == 0, "Only node zero, not node "
+                             << node_id
+                             << ", should be called from another node");
 
-      db::mutate<Tags::NodesExpectedToContributeReductions>(
-          make_not_null(&box),
-          [&caller_node_id, &observation_key](
-              const gsl::not_null<
-                  std::unordered_map<ObservationKey, std::set<size_t>>*>
-                  reduction_observers_registered_nodes) {
-            if (reduction_observers_registered_nodes->find(observation_key) ==
-                reduction_observers_registered_nodes->end()) {
-              (*reduction_observers_registered_nodes)[observation_key] =
-                  std::set<size_t>{};
-            }
-            auto& registered_nodes_for_key =
-                reduction_observers_registered_nodes->at(observation_key);
-            if (UNLIKELY(registered_nodes_for_key.find(caller_node_id) !=
-                         registered_nodes_for_key.end())) {
-              ERROR("Already registered node "
-                    << caller_node_id << " for reduction observations.");
-            }
-            registered_nodes_for_key.insert(caller_node_id);
-          });
-    } else {
-      (void)box;
-      (void)observation_key;
-      (void)caller_node_id;
-      ERROR(
-          "Do not have tag "
-          "observers::Tags::NodesExpectedToContributeReductions "
-          "in the DataBox. This means components are registering for "
-          "reductions before initialization is complete.");
-    }
+    db::mutate<Tags::NodesExpectedToContributeReductions>(
+        make_not_null(&box),
+        [&caller_node_id, &observation_key](
+            const gsl::not_null<
+                std::unordered_map<ObservationKey, std::set<size_t>>*>
+                reduction_observers_registered_nodes) {
+          if (reduction_observers_registered_nodes->find(observation_key) ==
+              reduction_observers_registered_nodes->end()) {
+            (*reduction_observers_registered_nodes)[observation_key] =
+                std::set<size_t>{};
+          }
+          auto& registered_nodes_for_key =
+              reduction_observers_registered_nodes->at(observation_key);
+          if (UNLIKELY(registered_nodes_for_key.find(caller_node_id) !=
+                       registered_nodes_for_key.end())) {
+            ERROR("Already registered node " << caller_node_id
+                                             << " for reduction observations.");
+          }
+          registered_nodes_for_key.insert(caller_node_id);
+        });
   }
 };
 
@@ -207,53 +170,39 @@ struct DeregisterReductionNodeWithWritingNode {
                     const ArrayIndex& /*array_index*/,
                     const observers::ObservationKey& observation_key,
                     const size_t caller_node_id) {
-    if constexpr (tmpl::list_contains_v<
-                      DbTagsList, Tags::NodesExpectedToContributeReductions>) {
-      auto& my_proxy =
-          Parallel::get_parallel_component<ParallelComponent>(cache);
-      const auto node_id =
-          Parallel::my_node<size_t>(*Parallel::local_branch(my_proxy));
-      ASSERT(node_id == 0,
-             "Only node zero, not node "
-                 << node_id
-                 << " should deregister other nodes in the reduction");
+    auto& my_proxy = Parallel::get_parallel_component<ParallelComponent>(cache);
+    const auto node_id =
+        Parallel::my_node<size_t>(*Parallel::local_branch(my_proxy));
+    ASSERT(node_id == 0,
+           "Only node zero, not node "
+               << node_id << " should deregister other nodes in the reduction");
 
-      db::mutate<Tags::NodesExpectedToContributeReductions>(
-          make_not_null(&box),
-          [&caller_node_id, &observation_key](
-              const gsl::not_null<
-                  std::unordered_map<ObservationKey, std::set<size_t>>*>
-                  reduction_observers_registered_nodes) {
-            if (UNLIKELY(reduction_observers_registered_nodes->find(
-                             observation_key) ==
-                         reduction_observers_registered_nodes->end())) {
-              ERROR(
-                  "Trying to deregister a node associated with an unregistered "
-                  "observation key: "
-                  << observation_key);
-            }
-            auto& registered_nodes_for_key =
-                reduction_observers_registered_nodes->at(observation_key);
-            if (UNLIKELY(registered_nodes_for_key.find(caller_node_id) ==
-                         registered_nodes_for_key.end())) {
-              ERROR("Trying to deregister an unregistered node: "
-                    << caller_node_id);
-            }
-            registered_nodes_for_key.erase(caller_node_id);
-            if (UNLIKELY(registered_nodes_for_key.size() == 0)) {
-              reduction_observers_registered_nodes->erase(observation_key);
-            }
-          });
-    } else {
-      (void)box;
-      (void)observation_key;
-      (void)caller_node_id;
-      ERROR(
-          "Do not have tag "
-          "observers::Tags::NodesExpectedToContributeReductions "
-          "in the DataBox. This means components are registering for "
-          "reductions before initialization is complete.");
-    }
+    db::mutate<Tags::NodesExpectedToContributeReductions>(
+        make_not_null(&box),
+        [&caller_node_id, &observation_key](
+            const gsl::not_null<
+                std::unordered_map<ObservationKey, std::set<size_t>>*>
+                reduction_observers_registered_nodes) {
+          if (UNLIKELY(
+                  reduction_observers_registered_nodes->find(observation_key) ==
+                  reduction_observers_registered_nodes->end())) {
+            ERROR(
+                "Trying to deregister a node associated with an unregistered "
+                "observation key: "
+                << observation_key);
+          }
+          auto& registered_nodes_for_key =
+              reduction_observers_registered_nodes->at(observation_key);
+          if (UNLIKELY(registered_nodes_for_key.find(caller_node_id) ==
+                       registered_nodes_for_key.end())) {
+            ERROR("Trying to deregister an unregistered node: "
+                  << caller_node_id);
+          }
+          registered_nodes_for_key.erase(caller_node_id);
+          if (UNLIKELY(registered_nodes_for_key.size() == 0)) {
+            reduction_observers_registered_nodes->erase(observation_key);
+          }
+        });
   }
 };
 
@@ -273,51 +222,38 @@ struct RegisterReductionContributorWithObserverWriter {
                     const ArrayIndex& /*array_index*/,
                     const observers::ObservationKey& observation_key,
                     const ArrayComponentId& id_of_caller) {
-    if constexpr (tmpl::list_contains_v<
-                      DbTagsList, Tags::ExpectedContributorsForObservations>) {
-      auto& my_proxy =
-          Parallel::get_parallel_component<ParallelComponent>(cache);
-      const auto node_id =
-          Parallel::my_node<size_t>(*Parallel::local_branch(my_proxy));
-      db::mutate<Tags::ExpectedContributorsForObservations>(
-          make_not_null(&box),
-          [&cache, &id_of_caller, &node_id, &observation_key](
-              const gsl::not_null<std::unordered_map<
-                  ObservationKey, std::unordered_set<ArrayComponentId>>*>
-                  reduction_observers_registered) {
-            if (reduction_observers_registered->find(observation_key) ==
-                reduction_observers_registered->end()) {
-              (*reduction_observers_registered)[observation_key] =
-                  std::unordered_set<ArrayComponentId>{};
-              Parallel::simple_action<
-                  Actions::RegisterReductionNodeWithWritingNode>(
-                  Parallel::get_parallel_component<
-                      ObserverWriter<Metavariables>>(cache)[0],
-                  observation_key, node_id);
-            }
+    auto& my_proxy = Parallel::get_parallel_component<ParallelComponent>(cache);
+    const auto node_id =
+        Parallel::my_node<size_t>(*Parallel::local_branch(my_proxy));
+    db::mutate<Tags::ExpectedContributorsForObservations>(
+        make_not_null(&box),
+        [&cache, &id_of_caller, &node_id, &observation_key](
+            const gsl::not_null<std::unordered_map<
+                ObservationKey, std::unordered_set<ArrayComponentId>>*>
+                reduction_observers_registered) {
+          if (reduction_observers_registered->find(observation_key) ==
+              reduction_observers_registered->end()) {
+            (*reduction_observers_registered)[observation_key] =
+                std::unordered_set<ArrayComponentId>{};
+            Parallel::simple_action<
+                Actions::RegisterReductionNodeWithWritingNode>(
+                Parallel::get_parallel_component<ObserverWriter<Metavariables>>(
+                    cache)[0],
+                observation_key, node_id);
+          }
 
-            if (LIKELY(reduction_observers_registered->at(observation_key)
-                           .find(id_of_caller) ==
-                       reduction_observers_registered->at(observation_key)
-                           .end())) {
-              reduction_observers_registered->at(observation_key)
-                  .insert(id_of_caller);
-            } else {
-              ERROR("Trying to insert a Observer component more than once: "
-                    << id_of_caller
-                    << " with observation key: " << observation_key);
-            }
-          });
-    } else {
-      (void)box;
-      (void)cache;
-      (void)observation_key;
-      (void)id_of_caller;
-      ERROR(
-          "Could not find tag "
-          "observers::Tags::ExpectedContributorsForObservations in the "
-          "DataBox.");
-    }
+          if (LIKELY(
+                  reduction_observers_registered->at(observation_key)
+                      .find(id_of_caller) ==
+                  reduction_observers_registered->at(observation_key).end())) {
+            reduction_observers_registered->at(observation_key)
+                .insert(id_of_caller);
+          } else {
+            ERROR("Trying to insert a Observer component more than once: "
+                  << id_of_caller
+                  << " with observation key: " << observation_key);
+          }
+        });
   }
 };
 
@@ -338,54 +274,40 @@ struct DeregisterReductionContributorWithObserverWriter {
                     const ArrayIndex& /*array_index*/,
                     const observers::ObservationKey& observation_key,
                     const ArrayComponentId& id_of_caller) {
-    if constexpr (tmpl::list_contains_v<
-                      DbTagsList, Tags::ExpectedContributorsForObservations>) {
-      auto& my_proxy =
-          Parallel::get_parallel_component<ParallelComponent>(cache);
-      const auto node_id =
-          Parallel::my_node<size_t>(*Parallel::local_branch(my_proxy));
-      db::mutate<Tags::ExpectedContributorsForObservations>(
-          make_not_null(&box),
-          [&cache, &id_of_caller, &node_id, &observation_key](
-              const gsl::not_null<std::unordered_map<
-                  ObservationKey, std::unordered_set<ArrayComponentId>>*>
-                  reduction_observers_registered) {
-            if (UNLIKELY(
-                    reduction_observers_registered->find(observation_key) ==
-                    reduction_observers_registered->end())) {
-              ERROR(
-                  "Trying to deregister a component associated with an "
-                  "unregistered observation key: "
-                  << observation_key);
-            }
-            auto& contributors_for_key =
-                reduction_observers_registered->at(observation_key);
-            if (UNLIKELY(contributors_for_key.find(id_of_caller) ==
-                         contributors_for_key.end())) {
-              ERROR("Trying to deregister an unregistered component: "
-                    << id_of_caller
-                    << " with observation key: " << observation_key);
-            }
-            contributors_for_key.erase(id_of_caller);
-            if (UNLIKELY(contributors_for_key.size() == 0)) {
-              Parallel::simple_action<
-                  Actions::DeregisterReductionNodeWithWritingNode>(
-                  Parallel::get_parallel_component<
-                      ObserverWriter<Metavariables>>(cache)[0],
-                  observation_key, node_id);
-              reduction_observers_registered->erase(observation_key);
-            }
-          });
-    } else {
-      (void)box;
-      (void)cache;
-      (void)observation_key;
-      (void)id_of_caller;
-      ERROR(
-          "Could not find tag "
-          "observers::Tags::ExpectedContributorsForObservations in the "
-          "DataBox.");
-    }
+    auto& my_proxy = Parallel::get_parallel_component<ParallelComponent>(cache);
+    const auto node_id =
+        Parallel::my_node<size_t>(*Parallel::local_branch(my_proxy));
+    db::mutate<Tags::ExpectedContributorsForObservations>(
+        make_not_null(&box),
+        [&cache, &id_of_caller, &node_id, &observation_key](
+            const gsl::not_null<std::unordered_map<
+                ObservationKey, std::unordered_set<ArrayComponentId>>*>
+                reduction_observers_registered) {
+          if (UNLIKELY(reduction_observers_registered->find(observation_key) ==
+                       reduction_observers_registered->end())) {
+            ERROR(
+                "Trying to deregister a component associated with an "
+                "unregistered observation key: "
+                << observation_key);
+          }
+          auto& contributors_for_key =
+              reduction_observers_registered->at(observation_key);
+          if (UNLIKELY(contributors_for_key.find(id_of_caller) ==
+                       contributors_for_key.end())) {
+            ERROR("Trying to deregister an unregistered component: "
+                  << id_of_caller
+                  << " with observation key: " << observation_key);
+          }
+          contributors_for_key.erase(id_of_caller);
+          if (UNLIKELY(contributors_for_key.size() == 0)) {
+            Parallel::simple_action<
+                Actions::DeregisterReductionNodeWithWritingNode>(
+                Parallel::get_parallel_component<ObserverWriter<Metavariables>>(
+                    cache)[0],
+                observation_key, node_id);
+            reduction_observers_registered->erase(observation_key);
+          }
+        });
   }
 };
 
@@ -404,72 +326,60 @@ struct RegisterContributorWithObserver {
                     const observers::ObservationKey& observation_key,
                     const observers::ArrayComponentId& component_id,
                     const TypeOfObservation& type_of_observation) {
-    if constexpr (tmpl::list_contains_v<
-                      DbTagList,
-                      observers::Tags::ExpectedContributorsForObservations>) {
-      bool observation_key_already_registered = true;
-      db::mutate<observers::Tags::ExpectedContributorsForObservations>(
-          make_not_null(&box),
-          [&component_id, &observation_key,
-           &observation_key_already_registered](
-              const gsl::not_null<std::unordered_map<
-                  ObservationKey, std::unordered_set<ArrayComponentId>>*>
-                  array_component_ids) {
-            observation_key_already_registered =
-                (array_component_ids->find(observation_key) !=
-                 array_component_ids->end());
-            if (UNLIKELY(observation_key_already_registered and
-                         array_component_ids->at(observation_key)
-                                 .find(component_id) !=
-                             array_component_ids->at(observation_key).end())) {
-              ERROR(
-                  "Trying to insert a component_id more than once for "
-                  "observation. This means an element is registering itself "
-                  "with the observers more than once. The component_id is "
-                  << component_id << " and the observation key is "
-                  << observation_key);
-            }
-            array_component_ids->operator[](observation_key)
-                .insert(component_id);
-          });
+    bool observation_key_already_registered = true;
+    db::mutate<observers::Tags::ExpectedContributorsForObservations>(
+        make_not_null(&box),
+        [&component_id, &observation_key, &observation_key_already_registered](
+            const gsl::not_null<std::unordered_map<
+                ObservationKey, std::unordered_set<ArrayComponentId>>*>
+                array_component_ids) {
+          observation_key_already_registered =
+              (array_component_ids->find(observation_key) !=
+               array_component_ids->end());
+          if (UNLIKELY(
+                  observation_key_already_registered and
+                  array_component_ids->at(observation_key).find(component_id) !=
+                      array_component_ids->at(observation_key).end())) {
+            ERROR(
+                "Trying to insert a component_id more than once for "
+                "observation. This means an element is registering itself "
+                "with the observers more than once. The component_id is "
+                << component_id << " and the observation key is "
+                << observation_key);
+          }
+          array_component_ids->operator[](observation_key).insert(component_id);
+        });
 
-      if (observation_key_already_registered) {
-        // We only need to register with the observer writer on the first call
-        // of this action. Later calls will have already been registered.
-        return;
-      }
-
-      auto& observer_writer = *Parallel::local_branch(
-          Parallel::get_parallel_component<
-              observers::ObserverWriter<Metavariables>>(cache));
-
-      switch (type_of_observation) {
-        case TypeOfObservation::Reduction:
-          Parallel::simple_action<
-              Actions::RegisterReductionContributorWithObserverWriter>(
-              observer_writer, observation_key,
-              ArrayComponentId{std::add_pointer_t<ParallelComponent>{nullptr},
-                               Parallel::ArrayIndex<ArrayIndex>(array_index)});
-          return;
-        case TypeOfObservation::Volume:
-          Parallel::simple_action<
-              Actions::RegisterVolumeContributorWithObserverWriter>(
-              observer_writer, observation_key,
-              ArrayComponentId{std::add_pointer_t<ParallelComponent>{nullptr},
-                               Parallel::ArrayIndex<ArrayIndex>(array_index)});
-          return;
-        default:
-          ERROR(
-              "Registering an unknown TypeOfObservation. Should be one of "
-              "'Reduction' or 'Volume'");
-      };
-    } else {
-      ERROR(
-          "The DataBox must contain the tag "
-          "observers::Tags::ExpectedContributorsForObservations when the "
-          "action "
-          "RegisterContributorWithObserver is called.");
+    if (observation_key_already_registered) {
+      // We only need to register with the observer writer on the first call
+      // of this action. Later calls will have already been registered.
+      return;
     }
+
+    auto& observer_writer = *Parallel::local_branch(
+        Parallel::get_parallel_component<
+            observers::ObserverWriter<Metavariables>>(cache));
+
+    switch (type_of_observation) {
+      case TypeOfObservation::Reduction:
+        Parallel::simple_action<
+            Actions::RegisterReductionContributorWithObserverWriter>(
+            observer_writer, observation_key,
+            ArrayComponentId{std::add_pointer_t<ParallelComponent>{nullptr},
+                             Parallel::ArrayIndex<ArrayIndex>(array_index)});
+        return;
+      case TypeOfObservation::Volume:
+        Parallel::simple_action<
+            Actions::RegisterVolumeContributorWithObserverWriter>(
+            observer_writer, observation_key,
+            ArrayComponentId{std::add_pointer_t<ParallelComponent>{nullptr},
+                             Parallel::ArrayIndex<ArrayIndex>(array_index)});
+        return;
+      default:
+        ERROR(
+            "Registering an unknown TypeOfObservation. Should be one of "
+            "'Reduction' or 'Volume'");
+    };
   }
 };
 
@@ -489,75 +399,66 @@ struct DeregisterContributorWithObserver {
                     const observers::ObservationKey& observation_key,
                     const observers::ArrayComponentId& component_id,
                     const TypeOfObservation& type_of_observation) {
-    if constexpr (tmpl::list_contains_v<
-                      DbTagList,
-                      observers::Tags::ExpectedContributorsForObservations>) {
-      bool all_array_components_have_been_deregistered = false;
-      db::mutate<observers::Tags::ExpectedContributorsForObservations>(
-          make_not_null(&box),
-          [&component_id, &observation_key,
-           &all_array_components_have_been_deregistered](
-              const gsl::not_null<std::unordered_map<
-                  ObservationKey, std::unordered_set<ArrayComponentId>>*>
-                  array_component_ids) {
-            if (UNLIKELY(array_component_ids->find(observation_key) ==
-                         array_component_ids->end())) {
-              ERROR(
-                  "Trying to deregister a component associated with an "
-                  "unregistered observation key: "
-                  << observation_key);
-            }
-            auto& component_ids_for_key =
-                array_component_ids->at(observation_key);
-            if (UNLIKELY(component_ids_for_key.find(component_id) ==
-                         array_component_ids->at(observation_key).end())) {
-              ERROR("Trying to deregister an unregistered component: "
-                    << component_id
-                    << " with observation key: " << observation_key);
-            }
-            component_ids_for_key.erase(component_id);
-            if (UNLIKELY(component_ids_for_key.size() == 0)) {
-              array_component_ids->erase(observation_key);
-              all_array_components_have_been_deregistered = true;
-            }
-          });
+    bool all_array_components_have_been_deregistered = false;
+    db::mutate<observers::Tags::ExpectedContributorsForObservations>(
+        make_not_null(&box),
+        [&component_id, &observation_key,
+         &all_array_components_have_been_deregistered](
+            const gsl::not_null<std::unordered_map<
+                ObservationKey, std::unordered_set<ArrayComponentId>>*>
+                array_component_ids) {
+          if (UNLIKELY(array_component_ids->find(observation_key) ==
+                       array_component_ids->end())) {
+            ERROR(
+                "Trying to deregister a component associated with an "
+                "unregistered observation key: "
+                << observation_key);
+          }
+          auto& component_ids_for_key =
+              array_component_ids->at(observation_key);
+          if (UNLIKELY(component_ids_for_key.find(component_id) ==
+                       array_component_ids->at(observation_key).end())) {
+            ERROR("Trying to deregister an unregistered component: "
+                  << component_id
+                  << " with observation key: " << observation_key);
+          }
+          component_ids_for_key.erase(component_id);
+          if (UNLIKELY(component_ids_for_key.size() == 0)) {
+            array_component_ids->erase(observation_key);
+            all_array_components_have_been_deregistered = true;
+          }
+        });
 
-      if (not all_array_components_have_been_deregistered) {
-        // Only deregister with the observer writer if this deregistration
-        // removes the last component for the provided `observation_key`.
-        return;
-      }
-
-      auto& observer_writer = *Parallel::local_branch(
-          Parallel::get_parallel_component<
-              observers::ObserverWriter<Metavariables>>(cache));
-
-      switch (type_of_observation) {
-        case TypeOfObservation::Reduction:
-          Parallel::simple_action<
-              Actions::DeregisterReductionContributorWithObserverWriter>(
-              observer_writer, observation_key,
-              ArrayComponentId{std::add_pointer_t<ParallelComponent>{nullptr},
-                               Parallel::ArrayIndex<ArrayIndex>(array_index)});
-          return;
-        case TypeOfObservation::Volume:
-          Parallel::simple_action<
-              Actions::DeregisterVolumeContributorWithObserverWriter>(
-              observer_writer, observation_key,
-              ArrayComponentId{std::add_pointer_t<ParallelComponent>{nullptr},
-                               Parallel::ArrayIndex<ArrayIndex>(array_index)});
-          return;
-        default:
-          ERROR(
-              "Attempting to deregister an unknown TypeOfObservation. "
-              "Should be one of 'Reduction' or 'Volume'");
-      };
-    } else {
-      ERROR(
-          "The DataBox must contain the tag "
-          "observers::Tags::ExpectedContributorsForObservations when the "
-          "action DeregisterContributorWithObserver is called.");
+    if (not all_array_components_have_been_deregistered) {
+      // Only deregister with the observer writer if this deregistration
+      // removes the last component for the provided `observation_key`.
+      return;
     }
+
+    auto& observer_writer = *Parallel::local_branch(
+        Parallel::get_parallel_component<
+            observers::ObserverWriter<Metavariables>>(cache));
+
+    switch (type_of_observation) {
+      case TypeOfObservation::Reduction:
+        Parallel::simple_action<
+            Actions::DeregisterReductionContributorWithObserverWriter>(
+            observer_writer, observation_key,
+            ArrayComponentId{std::add_pointer_t<ParallelComponent>{nullptr},
+                             Parallel::ArrayIndex<ArrayIndex>(array_index)});
+        return;
+      case TypeOfObservation::Volume:
+        Parallel::simple_action<
+            Actions::DeregisterVolumeContributorWithObserverWriter>(
+            observer_writer, observation_key,
+            ArrayComponentId{std::add_pointer_t<ParallelComponent>{nullptr},
+                             Parallel::ArrayIndex<ArrayIndex>(array_index)});
+        return;
+      default:
+        ERROR(
+            "Attempting to deregister an unknown TypeOfObservation. "
+            "Should be one of 'Reduction' or 'Volume'");
+    };
   }
 };
 }  // namespace Actions

--- a/src/IO/Observer/VolumeActions.hpp
+++ b/src/IO/Observer/VolumeActions.hpp
@@ -50,10 +50,8 @@ namespace Actions {
  * to be written to disk, and an `Index<Dim>` of the extents of the volume.
  */
 struct ContributeVolumeData {
-  template <
-      typename ParallelComponent, typename DbTagsList, typename Metavariables,
-      typename ArrayIndex, size_t Dim,
-      Requires<tmpl::list_contains_v<DbTagsList, Tags::TensorData>> = nullptr>
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables, typename ArrayIndex, size_t Dim>
   static void apply(
       db::DataBox<DbTagsList>& box, Parallel::GlobalCache<Metavariables>& cache,
       const ArrayIndex& array_index,
@@ -184,164 +182,146 @@ struct ContributeVolumeDataToWriter {
       ArrayComponentId observer_group_id, const std::string& subfile_name,
       std::unordered_map<observers::ArrayComponentId, ElementVolumeData>&&
           received_volume_data) {
-    if constexpr (tmpl::list_contains_v<DbTagsList, Tags::TensorData> and
-                  tmpl::list_contains_v<DbTagsList,
-                                        Tags::ContributorsOfTensorData> and
-                  tmpl::list_contains_v<DbTagsList, Tags::VolumeDataLock> and
-                  tmpl::list_contains_v<DbTagsList, Tags::H5FileLock>) {
-      // The below gymnastics with pointers is done in order to minimize the
-      // time spent locking the entire node, which is necessary because the
-      // DataBox does not allow any functions calls, both get and mutate, during
-      // a mutate. This design choice in DataBox is necessary to guarantee a
-      // consistent state throughout mutation. Here, however, we need to be
-      // reasonable efficient in parallel and so we manually guarantee that
-      // consistent state. To this end, we create pointers and assign to them
-      // the data in the DataBox which is guaranteed to be pointer stable. The
-      // data itself is guaranteed to be stable inside the VolumeDataLock.
-      std::unordered_map<
-          observers::ObservationId,
-          std::unordered_map<observers::ArrayComponentId, ElementVolumeData>>*
-          all_volume_data = nullptr;
-      std::unordered_map<observers::ArrayComponentId, ElementVolumeData>
-          volume_data;
-      Parallel::NodeLock* volume_file_lock = nullptr;
-      std::unordered_map<ObservationId, std::unordered_set<ArrayComponentId>>*
-          volume_observers_contributed = nullptr;
-      Parallel::NodeLock* volume_data_lock = nullptr;
-      size_t observations_registered_with_id =
-          std::numeric_limits<size_t>::max();
+    // The below gymnastics with pointers is done in order to minimize the
+    // time spent locking the entire node, which is necessary because the
+    // DataBox does not allow any functions calls, both get and mutate, during
+    // a mutate. This design choice in DataBox is necessary to guarantee a
+    // consistent state throughout mutation. Here, however, we need to be
+    // reasonable efficient in parallel and so we manually guarantee that
+    // consistent state. To this end, we create pointers and assign to them
+    // the data in the DataBox which is guaranteed to be pointer stable. The
+    // data itself is guaranteed to be stable inside the VolumeDataLock.
+    std::unordered_map<observers::ObservationId,
+                       std::unordered_map<observers::ArrayComponentId,
+                                          ElementVolumeData>>* all_volume_data =
+        nullptr;
+    std::unordered_map<observers::ArrayComponentId, ElementVolumeData>
+        volume_data;
+    Parallel::NodeLock* volume_file_lock = nullptr;
+    std::unordered_map<ObservationId, std::unordered_set<ArrayComponentId>>*
+        volume_observers_contributed = nullptr;
+    Parallel::NodeLock* volume_data_lock = nullptr;
+    size_t observations_registered_with_id = std::numeric_limits<size_t>::max();
 
-      node_lock->lock();
-      db::mutate<Tags::TensorData, Tags::ContributorsOfTensorData,
-                 Tags::VolumeDataLock, Tags::H5FileLock>(
-          make_not_null(&box),
-          [&observation_id, &observations_registered_with_id,
-           &observer_group_id, &all_volume_data, &volume_observers_contributed,
-           &volume_data_lock, &volume_file_lock](
-              const gsl::not_null<std::unordered_map<
-                  observers::ObservationId,
-                  std::unordered_map<observers::ArrayComponentId,
-                                     ElementVolumeData>>*>
-                  volume_data_ptr,
-              const gsl::not_null<std::unordered_map<
-                  ObservationId, std::unordered_set<ArrayComponentId>>*>
-                  volume_observers_contributed_ptr,
-              const gsl::not_null<Parallel::NodeLock*> volume_data_lock_ptr,
-              const gsl::not_null<Parallel::NodeLock*> volume_file_lock_ptr,
-              const std::unordered_map<ObservationKey,
-                                       std::unordered_set<ArrayComponentId>>&
-                  observations_registered) {
-            const ObservationKey& key{observation_id.observation_key()};
-            const auto& registered_group_ids = observations_registered.at(key);
-            if (UNLIKELY(registered_group_ids.find(observer_group_id) ==
-                         registered_group_ids.end())) {
-              ERROR("The observer group id "
-                    << observer_group_id
-                    << " was not registered for the observation id "
-                    << observation_id);
-            }
-
-            all_volume_data = &*volume_data_ptr;
-            volume_observers_contributed = &*volume_observers_contributed_ptr;
-            volume_data_lock = &*volume_data_lock_ptr;
-            observations_registered_with_id =
-                observations_registered.at(key).size();
-            volume_file_lock = &*volume_file_lock_ptr;
-          },
-          db::get<Tags::ExpectedContributorsForObservations>(box));
-      node_lock->unlock();
-
-      ASSERT(all_volume_data != nullptr,
-             "Failed to set all_volume_data in the mutate");
-      ASSERT(volume_file_lock != nullptr,
-             "Failed to set volume_file_lock in the mutate");
-      ASSERT(volume_observers_contributed != nullptr,
-             "Failed to set volume_observers_contributed in the mutate");
-      ASSERT(volume_data_lock != nullptr,
-             "Failed to set volume_data_lock in the mutate");
-      ASSERT(
-          observations_registered_with_id != std::numeric_limits<size_t>::max(),
-          "Failed to set observations_registered_with_id when mutating the "
-          "DataBox. This is a bug in the code.");
-
-      volume_data_lock->lock();
-      auto& contributed_group_ids =
-          (*volume_observers_contributed)[observation_id];
-
-      if (UNLIKELY(contributed_group_ids.find(observer_group_id) !=
-                   contributed_group_ids.end())) {
-        ERROR("Already received reduction data to observation id "
-              << observation_id << " from array component id "
-              << observer_group_id);
-      }
-      contributed_group_ids.insert(observer_group_id);
-
-      if (all_volume_data->find(observation_id) == all_volume_data->end()) {
-        // We haven't been called before on this processing element.
-        all_volume_data->operator[](observation_id) =
-            std::move(received_volume_data);
-      } else {
-        auto& current_data = all_volume_data->at(observation_id);
-        current_data.insert(
-            std::make_move_iterator(received_volume_data.begin()),
-            std::make_move_iterator(received_volume_data.end()));
-      }
-      // Check if we have received all "volume" data from the Observer
-      // group. If so we write to disk.
-      bool perform_write = false;
-      if (volume_observers_contributed->at(observation_id).size() ==
-          observations_registered_with_id) {
-        perform_write = true;
-        volume_data = std::move(all_volume_data->operator[](observation_id));
-        all_volume_data->erase(observation_id);
-        volume_observers_contributed->erase(observation_id);
-      }
-      volume_data_lock->unlock();
-
-      if (perform_write) {
-        ASSERT(not volume_data.empty(),
-               "Failed to populate volume_data before trying to write it.");
-        // Write to file. We use a separate node lock because writing can be
-        // very time consuming (it's network dependent, depends on how full the
-        // disks are, what other users are doing, etc.) and we want to be able
-        // to continue to work on the nodegroup while we are writing data to
-        // disk.
-        volume_file_lock->lock();
-        {
-          // Scoping is for closing HDF5 file before we release the lock.
-          const auto& file_prefix = Parallel::get<Tags::VolumeFileName>(cache);
-          auto& my_proxy =
-              Parallel::get_parallel_component<ParallelComponent>(cache);
-          h5::H5File<h5::AccessType::ReadWrite> h5file(
-              file_prefix +
-                  std::to_string(Parallel::my_node<int>(
-                      *Parallel::local_branch(my_proxy))) +
-                  ".h5",
-              true, observers::input_source_from_cache(cache));
-          constexpr size_t version_number = 0;
-          auto& volume_file =
-              h5file.try_insert<h5::VolumeData>(subfile_name, version_number);
-          std::vector<ElementVolumeData> dg_elements;
-          dg_elements.reserve(volume_data.size());
-          for (const auto& id_and_element : volume_data) {
-            dg_elements.push_back(id_and_element.second);
+    node_lock->lock();
+    db::mutate<Tags::TensorData, Tags::ContributorsOfTensorData,
+               Tags::VolumeDataLock, Tags::H5FileLock>(
+        make_not_null(&box),
+        [&observation_id, &observations_registered_with_id, &observer_group_id,
+         &all_volume_data, &volume_observers_contributed, &volume_data_lock,
+         &volume_file_lock](
+            const gsl::not_null<std::unordered_map<
+                observers::ObservationId,
+                std::unordered_map<observers::ArrayComponentId,
+                                   ElementVolumeData>>*>
+                volume_data_ptr,
+            const gsl::not_null<std::unordered_map<
+                ObservationId, std::unordered_set<ArrayComponentId>>*>
+                volume_observers_contributed_ptr,
+            const gsl::not_null<Parallel::NodeLock*> volume_data_lock_ptr,
+            const gsl::not_null<Parallel::NodeLock*> volume_file_lock_ptr,
+            const std::unordered_map<ObservationKey,
+                                     std::unordered_set<ArrayComponentId>>&
+                observations_registered) {
+          const ObservationKey& key{observation_id.observation_key()};
+          const auto& registered_group_ids = observations_registered.at(key);
+          if (UNLIKELY(registered_group_ids.find(observer_group_id) ==
+                       registered_group_ids.end())) {
+            ERROR("The observer group id "
+                  << observer_group_id
+                  << " was not registered for the observation id "
+                  << observation_id);
           }
-          // Write the data to the file
-          volume_file.write_volume_data(observation_id.hash(),
-                                        observation_id.value(), dg_elements);
-        }
-        volume_file_lock->unlock();
-      }
+
+          all_volume_data = &*volume_data_ptr;
+          volume_observers_contributed = &*volume_observers_contributed_ptr;
+          volume_data_lock = &*volume_data_lock_ptr;
+          observations_registered_with_id =
+              observations_registered.at(key).size();
+          volume_file_lock = &*volume_file_lock_ptr;
+        },
+        db::get<Tags::ExpectedContributorsForObservations>(box));
+    node_lock->unlock();
+
+    ASSERT(all_volume_data != nullptr,
+           "Failed to set all_volume_data in the mutate");
+    ASSERT(volume_file_lock != nullptr,
+           "Failed to set volume_file_lock in the mutate");
+    ASSERT(volume_observers_contributed != nullptr,
+           "Failed to set volume_observers_contributed in the mutate");
+    ASSERT(volume_data_lock != nullptr,
+           "Failed to set volume_data_lock in the mutate");
+    ASSERT(
+        observations_registered_with_id != std::numeric_limits<size_t>::max(),
+        "Failed to set observations_registered_with_id when mutating the "
+        "DataBox. This is a bug in the code.");
+
+    volume_data_lock->lock();
+    auto& contributed_group_ids =
+        (*volume_observers_contributed)[observation_id];
+
+    if (UNLIKELY(contributed_group_ids.find(observer_group_id) !=
+                 contributed_group_ids.end())) {
+      ERROR("Already received reduction data to observation id "
+            << observation_id << " from array component id "
+            << observer_group_id);
+    }
+    contributed_group_ids.insert(observer_group_id);
+
+    if (all_volume_data->find(observation_id) == all_volume_data->end()) {
+      // We haven't been called before on this processing element.
+      all_volume_data->operator[](observation_id) =
+          std::move(received_volume_data);
     } else {
-      (void)node_lock;
-      (void)observation_id;
-      (void)observer_group_id;
-      (void)subfile_name;
-      (void)received_volume_data;
-      ERROR(
-          "Could not find one of the tags TensorData, "
-          "ContributorsOfTensorData, "
-          "VolumeDataLock, or H5FileLock in the DataBox.");
+      auto& current_data = all_volume_data->at(observation_id);
+      current_data.insert(std::make_move_iterator(received_volume_data.begin()),
+                          std::make_move_iterator(received_volume_data.end()));
+    }
+    // Check if we have received all "volume" data from the Observer
+    // group. If so we write to disk.
+    bool perform_write = false;
+    if (volume_observers_contributed->at(observation_id).size() ==
+        observations_registered_with_id) {
+      perform_write = true;
+      volume_data = std::move(all_volume_data->operator[](observation_id));
+      all_volume_data->erase(observation_id);
+      volume_observers_contributed->erase(observation_id);
+    }
+    volume_data_lock->unlock();
+
+    if (perform_write) {
+      ASSERT(not volume_data.empty(),
+             "Failed to populate volume_data before trying to write it.");
+      // Write to file. We use a separate node lock because writing can be
+      // very time consuming (it's network dependent, depends on how full the
+      // disks are, what other users are doing, etc.) and we want to be able
+      // to continue to work on the nodegroup while we are writing data to
+      // disk.
+      volume_file_lock->lock();
+      {
+        // Scoping is for closing HDF5 file before we release the lock.
+        const auto& file_prefix = Parallel::get<Tags::VolumeFileName>(cache);
+        auto& my_proxy =
+            Parallel::get_parallel_component<ParallelComponent>(cache);
+        h5::H5File<h5::AccessType::ReadWrite> h5file(
+            file_prefix +
+                std::to_string(
+                    Parallel::my_node<int>(*Parallel::local_branch(my_proxy))) +
+                ".h5",
+            true, observers::input_source_from_cache(cache));
+        constexpr size_t version_number = 0;
+        auto& volume_file =
+            h5file.try_insert<h5::VolumeData>(subfile_name, version_number);
+        std::vector<ElementVolumeData> dg_elements;
+        dg_elements.reserve(volume_data.size());
+        for (const auto& id_and_element : volume_data) {
+          dg_elements.push_back(id_and_element.second);
+        }
+        // Write the data to the file
+        volume_file.write_volume_data(observation_id.hash(),
+                                      observation_id.value(), dg_elements);
+      }
+      volume_file_lock->unlock();
     }
   }
 };
@@ -366,11 +346,9 @@ struct ContributeVolumeDataToWriter {
  * - `volume_data`: the volume data to be written.
  */
 struct WriteVolumeData {
-  template <
-      typename ParallelComponent, typename DbTagsList, typename Metavariables,
-      typename ArrayIndex, typename... Ts,
-      typename DataBox = db::DataBox<DbTagsList>,
-      Requires<db::tag_is_retrievable_v<Tags::H5FileLock, DataBox>> = nullptr>
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables, typename ArrayIndex, typename... Ts,
+            typename DataBox = db::DataBox<DbTagsList>>
   static void apply(db::DataBox<DbTagsList>& box,
                     Parallel::GlobalCache<Metavariables>& cache,
                     const ArrayIndex& /*array_index*/,

--- a/src/IO/Observer/WriteSimpleData.hpp
+++ b/src/IO/Observer/WriteSimpleData.hpp
@@ -31,10 +31,8 @@ namespace ThreadedActions {
  * appending `data_row` to the end of the dat.
  */
 struct WriteSimpleData {
-  template <
-      typename ParallelComponent, typename DbTagsList, typename Metavariables,
-      typename ArrayIndex,
-      Requires<tmpl::list_contains_v<DbTagsList, Tags::H5FileLock>> = nullptr>
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables, typename ArrayIndex>
   static void apply(db::DataBox<DbTagsList>& box,
                     Parallel::GlobalCache<Metavariables>& cache,
                     const ArrayIndex& /*array_index*/,

--- a/src/ParallelAlgorithms/Actions/SetData.hpp
+++ b/src/ParallelAlgorithms/Actions/SetData.hpp
@@ -33,11 +33,8 @@ struct SetData;
 /// \cond
 template <typename... Tags>
 struct SetData<tmpl::list<Tags...>> {
-  template <
-      typename ParallelComponent, typename DataBox, typename Metavariables,
-      typename ArrayIndex,
-      Requires<std::conjunction_v<db::tag_is_retrievable<Tags, DataBox>...>> =
-          nullptr>
+  template <typename ParallelComponent, typename DataBox,
+            typename Metavariables, typename ArrayIndex>
   static void apply(DataBox& box,
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/,

--- a/src/ParallelAlgorithms/Actions/UpdateMessageQueue.hpp
+++ b/src/ParallelAlgorithms/Actions/UpdateMessageQueue.hpp
@@ -40,22 +40,12 @@ struct UpdateMessageQueue {
       const LinkedMessageId<typename LinkedMessageQueueTag::type::IdType>&
           id_and_previous,
       typename QueueTag::type message) {
-    if constexpr (db::tag_is_retrievable_v<LinkedMessageQueueTag,
-                                           db::DataBox<DbTags>>) {
-      auto& queue =
-          db::get_mutable_reference<LinkedMessageQueueTag>(make_not_null(&box));
-      queue.template insert<QueueTag>(id_and_previous, std::move(message));
-      while (auto id = queue.next_ready_id()) {
-        Processor::apply(make_not_null(&box), cache, array_index, *id,
-                         queue.extract());
-      }
-    } else {
-      (void)box;
-      (void)cache;
-      (void)array_index;
-      (void)id_and_previous;
-      (void)message;
-      ERROR("LinkedMessageQueueTag not found in DataBox");  // LCOV_EXCL_LINE
+    auto& queue =
+        db::get_mutable_reference<LinkedMessageQueueTag>(make_not_null(&box));
+    queue.template insert<QueueTag>(id_and_previous, std::move(message));
+    while (auto id = queue.next_ready_id()) {
+      Processor::apply(make_not_null(&box), cache, array_index, *id,
+                       queue.extract());
     }
   }
 };

--- a/src/ParallelAlgorithms/Interpolation/Actions/AddTemporalIdsToInterpolationTarget.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/AddTemporalIdsToInterpolationTarget.hpp
@@ -48,11 +48,8 @@ namespace Actions {
 ///   - `Tags::TemporalIds<TemporalId>`
 template <typename InterpolationTargetTag>
 struct AddTemporalIdsToInterpolationTarget {
-  template <
-      typename ParallelComponent, typename DbTags, typename Metavariables,
-      typename ArrayIndex, typename TemporalId,
-      Requires<tmpl::list_contains_v<DbTags, Tags::TemporalIds<TemporalId>>> =
-          nullptr>
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex, typename TemporalId>
   static void apply(db::DataBox<DbTags>& box,
                     Parallel::GlobalCache<Metavariables>& cache,
                     const ArrayIndex& /*array_index*/,

--- a/src/ParallelAlgorithms/Interpolation/Actions/CleanUpInterpolator.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/CleanUpInterpolator.hpp
@@ -59,10 +59,8 @@ namespace Actions {
 /// For requirements on InterpolationTargetTag, see InterpolationTarget
 template <typename InterpolationTargetTag>
 struct CleanUpInterpolator {
-  template <
-      typename ParallelComponent, typename DbTags, typename Metavariables,
-      typename ArrayIndex,
-      Requires<tmpl::list_contains_v<DbTags, Tags::NumberOfElements>> = nullptr>
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
   static void apply(
       db::DataBox<DbTags>& box,  // HorizonManager's box
       const Parallel::GlobalCache<Metavariables>& /*cache*/,

--- a/src/ParallelAlgorithms/Interpolation/Actions/ElementReceiveInterpPoints.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/ElementReceiveInterpPoints.hpp
@@ -31,9 +31,7 @@ namespace Actions {
 template <typename InterpolationTargetTag>
 struct ElementReceiveInterpPoints {
   template <typename ParallelComponent, typename DbTags, typename Metavariables,
-            typename ArrayIndex,
-            Requires<tmpl::list_contains_v<
-                DbTags, intrp::Tags::InterpPointInfo<Metavariables>>> = nullptr>
+            typename ArrayIndex>
   static void apply(
       db::DataBox<DbTags>& box,
       const Parallel::GlobalCache<Metavariables>& /*cache*/,

--- a/src/ParallelAlgorithms/Interpolation/Actions/InterpolationTargetReceiveVars.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/InterpolationTargetReceiveVars.hpp
@@ -75,11 +75,8 @@ namespace Actions {
 template <typename InterpolationTargetTag>
 struct InterpolationTargetReceiveVars {
   /// For requirements on Metavariables, see InterpolationTarget
-  template <
-      typename ParallelComponent, typename DbTags, typename Metavariables,
-      typename ArrayIndex, typename TemporalId,
-      Requires<tmpl::list_contains_v<DbTags, Tags::TemporalIds<TemporalId>>> =
-          nullptr>
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex, typename TemporalId>
   static void apply(
       db::DataBox<DbTags>& box, Parallel::GlobalCache<Metavariables>& cache,
       const ArrayIndex& /*array_index*/,

--- a/src/ParallelAlgorithms/Interpolation/Actions/InterpolationTargetVarsFromElement.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/InterpolationTargetVarsFromElement.hpp
@@ -63,11 +63,8 @@ namespace Actions {
 template <typename InterpolationTargetTag>
 struct InterpolationTargetVarsFromElement {
   /// For requirements on Metavariables, see InterpolationTarget
-  template <
-      typename ParallelComponent, typename DbTags, typename Metavariables,
-      typename ArrayIndex, typename TemporalId,
-      Requires<tmpl::list_contains_v<DbTags, Tags::TemporalIds<TemporalId>>> =
-          nullptr>
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex, typename TemporalId>
   static void apply(
       db::DataBox<DbTags>& box, Parallel::GlobalCache<Metavariables>& cache,
       const ArrayIndex& /*array_index*/,

--- a/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorReceivePoints.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorReceivePoints.hpp
@@ -60,11 +60,8 @@ namespace Actions {
 /// For requirements on InterpolationTargetTag, see InterpolationTarget
 template <typename InterpolationTargetTag>
 struct ReceivePoints {
-  template <
-      typename ParallelComponent, typename DbTags, typename Metavariables,
-      typename ArrayIndex, size_t VolumeDim,
-      Requires<tmpl::list_contains_v<DbTags, ::intrp::Tags::NumberOfElements>> =
-          nullptr>
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex, size_t VolumeDim>
   static void apply(
       db::DataBox<DbTags>& box, Parallel::GlobalCache<Metavariables>& cache,
       const ArrayIndex& /*array_index*/,

--- a/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorReceiveVolumeData.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorReceiveVolumeData.hpp
@@ -41,10 +41,8 @@ namespace Actions {
 ///   - `Tags::InterpolatedVarsHolders<Metavariables>`
 template <typename TemporalId>
 struct InterpolatorReceiveVolumeData {
-  template <
-      typename ParallelComponent, typename DbTags, typename Metavariables,
-      typename ArrayIndex, size_t VolumeDim,
-      Requires<tmpl::list_contains_v<DbTags, Tags::NumberOfElements>> = nullptr>
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex, size_t VolumeDim>
   static void apply(
       db::DataBox<DbTags>& box, Parallel::GlobalCache<Metavariables>& cache,
       const ArrayIndex& /*array_index*/,

--- a/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorRegisterElement.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorRegisterElement.hpp
@@ -43,9 +43,7 @@ namespace Actions {
 /// For requirements on Metavariables, see `InterpolationTarget`.
 struct RegisterElement {
   template <typename ParallelComponent, typename DbTags, typename Metavariables,
-            typename ArrayIndex,
-            Requires<db::tag_is_retrievable_v<Tags::NumberOfElements,
-                                              db::DataBox<DbTags>>> = nullptr>
+            typename ArrayIndex>
   static void apply(db::DataBox<DbTags>& box,
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/) {
@@ -72,9 +70,7 @@ struct RegisterElement {
 /// For requirements on Metavariables, see `InterpolationTarget`.
 struct DeregisterElement {
   template <typename ParallelComponent, typename DbTags, typename Metavariables,
-            typename ArrayIndex,
-            Requires<db::tag_is_retrievable_v<Tags::NumberOfElements,
-                                              db::DataBox<DbTags>>> = nullptr>
+            typename ArrayIndex>
   static void apply(db::DataBox<DbTags>& box,
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/) {

--- a/src/ParallelAlgorithms/Interpolation/Actions/SendPointsToInterpolator.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/SendPointsToInterpolator.hpp
@@ -33,11 +33,8 @@ namespace Actions {
 /// For requirements on InterpolationTargetTag, see InterpolationTarget
 template <typename InterpolationTargetTag>
 struct SendPointsToInterpolator {
-  template <
-      typename ParallelComponent, typename DbTags, typename Metavariables,
-      typename ArrayIndex, typename TemporalId,
-      Requires<tmpl::list_contains_v<DbTags, Tags::TemporalIds<TemporalId>>> =
-          nullptr>
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex, typename TemporalId>
   static void apply(db::DataBox<DbTags>& box,
                     Parallel::GlobalCache<Metavariables>& cache,
                     const ArrayIndex& /*array_index*/,

--- a/src/ParallelAlgorithms/Interpolation/Actions/VerifyTemporalIdsAndSendPoints.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/VerifyTemporalIdsAndSendPoints.hpp
@@ -223,10 +223,7 @@ void verify_temporal_ids_and_send_points_time_dependent(
 template <typename InterpolationTargetTag>
 struct VerifyTemporalIdsAndSendPoints {
   template <typename ParallelComponent, typename DbTags, typename Metavariables,
-            typename ArrayIndex,
-            Requires<tmpl::list_contains_v<
-                DbTags, Tags::TemporalIds<typename InterpolationTargetTag::
-                                              temporal_id::type>>> = nullptr>
+            typename ArrayIndex>
   static void apply(db::DataBox<DbTags>& box,
                     Parallel::GlobalCache<Metavariables>& cache,
                     const ArrayIndex& /*array_index*/) {

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp
@@ -47,9 +47,7 @@ struct InitializeResidual {
  public:
   template <typename ParallelComponent, typename DbTagsList,
             typename Metavariables, typename ArrayIndex,
-            typename DataBox = db::DataBox<DbTagsList>,
-            Requires<db::tag_is_retrievable_v<residual_square_tag, DataBox>> =
-                nullptr>
+            typename DataBox = db::DataBox<DbTagsList>>
   static void apply(db::DataBox<DbTagsList>& box,
                     Parallel::GlobalCache<Metavariables>& cache,
                     const ArrayIndex& /*array_index*/,
@@ -104,9 +102,7 @@ struct ComputeAlpha {
  public:
   template <typename ParallelComponent, typename DbTagsList,
             typename Metavariables, typename ArrayIndex,
-            typename DataBox = db::DataBox<DbTagsList>,
-            Requires<db::tag_is_retrievable_v<residual_square_tag, DataBox>> =
-                nullptr>
+            typename DataBox = db::DataBox<DbTagsList>>
   static void apply(db::DataBox<DbTagsList>& box,
                     Parallel::GlobalCache<Metavariables>& cache,
                     const ArrayIndex& /*array_index*/,
@@ -131,9 +127,7 @@ struct UpdateResidual {
  public:
   template <typename ParallelComponent, typename DbTagsList,
             typename Metavariables, typename ArrayIndex,
-            typename DataBox = db::DataBox<DbTagsList>,
-            Requires<db::tag_is_retrievable_v<residual_square_tag, DataBox>> =
-                nullptr>
+            typename DataBox = db::DataBox<DbTagsList>>
   static void apply(db::DataBox<DbTagsList>& box,
                     Parallel::GlobalCache<Metavariables>& cache,
                     const ArrayIndex& /*array_index*/,

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitorActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitorActions.hpp
@@ -47,9 +47,7 @@ struct InitializeResidualMagnitude {
  public:
   template <typename ParallelComponent, typename DbTagsList,
             typename Metavariables, typename ArrayIndex,
-            typename DataBox = db::DataBox<DbTagsList>,
-            Requires<db::tag_is_retrievable_v<initial_residual_magnitude_tag,
-                                              DataBox>> = nullptr>
+            typename DataBox = db::DataBox<DbTagsList>>
   static void apply(db::DataBox<DbTagsList>& box,
                     Parallel::GlobalCache<Metavariables>& cache,
                     const ArrayIndex& /*array_index*/,
@@ -104,9 +102,7 @@ struct StoreOrthogonalization {
  public:
   template <typename ParallelComponent, typename DbTagsList,
             typename Metavariables, typename ArrayIndex,
-            typename DataBox = db::DataBox<DbTagsList>,
-            Requires<db::tag_is_retrievable_v<orthogonalization_history_tag,
-                                              DataBox>> = nullptr>
+            typename DataBox = db::DataBox<DbTagsList>>
   static void apply(db::DataBox<DbTagsList>& box,
                     Parallel::GlobalCache<Metavariables>& cache,
                     const ArrayIndex& /*array_index*/,

--- a/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/ResidualMonitorActions.hpp
+++ b/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/ResidualMonitorActions.hpp
@@ -46,26 +46,11 @@ struct CheckResidualMagnitude {
   template <typename ParallelComponent, typename DataBox,
             typename Metavariables, typename ArrayIndex, typename... Args>
   static void apply(DataBox& box, Parallel::GlobalCache<Metavariables>& cache,
-                    const ArrayIndex& /*array_index*/, Args&&... args) {
-    if constexpr (db::tag_is_retrievable_v<residual_magnitude_square_tag,
-                                           DataBox>) {
-      apply_impl<ParallelComponent>(box, cache, std::forward<Args>(args)...);
-    } else {
-      ERROR(
-          "The residual monitor is not yet initialized. This is a bug, so "
-          "please file an issue.");
-    }
-  }
-
- private:
-  template <typename ParallelComponent, typename DbTagsList,
-            typename Metavariables>
-  static void apply_impl(db::DataBox<DbTagsList>& box,
-                         Parallel::GlobalCache<Metavariables>& cache,
-                         const size_t iteration_id,
-                         const size_t globalization_iteration_id,
-                         const double next_residual_magnitude_square,
-                         const double step_length) {
+                    const ArrayIndex& /*array_index*/,
+                    const size_t iteration_id,
+                    const size_t globalization_iteration_id,
+                    const double next_residual_magnitude_square,
+                    const double step_length) {
     const double residual_magnitude = sqrt(next_residual_magnitude_square);
 
     NonlinearSolver::observe_detail::contribute_to_reduction_observer<

--- a/tests/Unit/Parallel/Test_MemoryMonitor.cpp
+++ b/tests/Unit/Parallel/Test_MemoryMonitor.cpp
@@ -302,18 +302,6 @@ void run_group_actions(
   check_output<Component>(*runner, time, static_cast<size_t>(num_nodes), sizes);
 }
 
-void test_wrong_box() {
-  CHECK_THROWS_WITH(
-      ([]() {
-        db::DataBox<tmpl::list<>> empty_box{};
-        Parallel::GlobalCache<metavars> cache{};
-
-        mem_monitor::ContributeMemoryData<group_comp<metavars>>::template apply<
-            mem_mon_comp<metavars>>(empty_box, cache, 0, 0.0, 0_st, 0.0);
-      }()),
-      Catch::Contains("Expected the DataBox for the MemoryMonitor"));
-}
-
 // Contribute memory data can only be used with groups or nodegroups
 template <typename Gen>
 void test_contribute_memory_data(const gsl::not_null<Gen*> gen,
@@ -669,7 +657,6 @@ void test_monitor_memory_event() {
 SPECTRE_TEST_CASE("Unit.Parallel.MemoryMonitor", "[Unit][Parallel]") {
   MAKE_GENERATOR(gen);
   test_tags();
-  test_wrong_box();
   // First only test the ContributeMemoryData action (second arg false)
   test_contribute_memory_data(make_not_null(&gen), false);
   // Then test the Process(Node)Group actions (second arg true)


### PR DESCRIPTION
With the change to a single DataBox in a DistributedObject, there
no longer to need to be run-time checks or template specializations
based on whether or not a particular tag is in the DataBox.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
