### PR TITLE
Add spectre h5 table reader

### DIFF
--- a/src/IO/H5/CMakeLists.txt
+++ b/src/IO/H5/CMakeLists.txt
@@ -6,6 +6,7 @@ spectre_target_sources(
   PRIVATE
   AccessType.cpp
   Dat.cpp
+  EosTable.cpp
   File.cpp
   Header.cpp
   Helpers.cpp
@@ -24,6 +25,7 @@ spectre_target_headers(
   AccessType.hpp
   CheckH5.hpp
   Dat.hpp
+  EosTable.hpp
   File.hpp
   Header.hpp
   Helpers.hpp

--- a/src/IO/H5/EosTable.cpp
+++ b/src/IO/H5/EosTable.cpp
@@ -1,0 +1,114 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "IO/H5/EosTable.hpp"
+
+#include <array>
+#include <cstddef>
+#include <ostream>
+#include <string>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "IO/H5/Header.hpp"
+#include "IO/H5/Helpers.hpp"
+#include "IO/H5/Version.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+
+namespace h5 {
+EosTable::EosTable(
+    const bool subfile_exists, detail::OpenGroup&& group,
+    const hid_t /*location*/, const std::string& name,
+    std::vector<std::string> independent_variable_names,
+    std::vector<std::array<double, 2>> independent_variable_bounds,
+    std::vector<size_t> independent_variable_number_of_points,
+    std::vector<bool> independent_variable_uses_log_spacing,
+    const bool beta_equilibrium, const uint32_t version)
+    : group_(std::move(group)),
+      name_(name.size() > extension().size()
+                ? (extension() == name.substr(name.size() - extension().size())
+                       ? name
+                       : name + extension())
+                : name + extension()),
+      path_(group_.group_path_with_trailing_slash() + name),
+      version_(version),
+      eos_table_group_(group_.id(), name_, h5::AccessType::ReadWrite),
+      independent_variable_names_(std::move(independent_variable_names)),
+      independent_variable_bounds_(std::move(independent_variable_bounds)),
+      independent_variable_number_of_points_(
+          std::move(independent_variable_number_of_points)),
+      independent_variable_uses_log_spacing_(
+          std::move(independent_variable_uses_log_spacing)),
+      beta_equilibrium_(beta_equilibrium) {
+  if (subfile_exists) {
+    ERROR(
+        "Opening an equation of state table with the constructor for writing a "
+        "table, but the subfile "
+        << name << " already exists");
+  }
+  // Subfiles are closed as they go out of scope, so we have the extra
+  // braces here to add the necessary scope
+  {
+    Version open_version(false, detail::OpenGroup{}, eos_table_group_.id(),
+                         "version", version_);
+  }
+  {
+    Header header(false, detail::OpenGroup{}, eos_table_group_.id(), "header");
+    header_ = header.get_header();
+  }
+
+  h5::write_to_attribute(eos_table_group_.id(), "independent variable names",
+                         independent_variable_names_);
+  h5::write_to_attribute(eos_table_group_.id(), "independent variable bounds",
+                         independent_variable_bounds_);
+  h5::write_to_attribute(eos_table_group_.id(), "number of points",
+                         independent_variable_number_of_points_);
+  h5::write_to_attribute(eos_table_group_.id(), "uses log spacing",
+                         independent_variable_uses_log_spacing_);
+  h5::write_to_attribute(eos_table_group_.id(), "beta equilibium",
+                         beta_equilibrium_);
+}
+
+EosTable::EosTable(const bool /*subfile_exists*/, detail::OpenGroup&& group,
+                   const hid_t /*location*/, const std::string& name)
+    : group_(std::move(group)),
+      name_(name.size() > extension().size()
+                ? (extension() == name.substr(name.size() - extension().size())
+                       ? name
+                       : name + extension())
+                : name + extension()),
+      path_(group_.group_path_with_trailing_slash() + name),
+      eos_table_group_(group_.id(), name_, h5::AccessType::ReadOnly) {
+  // We treat this as an internal version for now. We'll need to deal with
+  // proper versioning later.
+  const Version open_version(true, detail::OpenGroup{}, eos_table_group_.id(),
+                             "version");
+  version_ = open_version.get_version();
+  const Header header(true, detail::OpenGroup{}, eos_table_group_.id(),
+                      "header");
+  header_ = header.get_header();
+
+  independent_variable_names_ = h5::read_rank1_attribute<std::string>(
+      eos_table_group_.id(), "independent variable names");
+  independent_variable_bounds_ = h5::read_rank1_array_attribute<double, 2>(
+      eos_table_group_.id(), "independent variable bounds");
+  independent_variable_number_of_points_ = h5::read_rank1_attribute<size_t>(
+      eos_table_group_.id(), "number of points");
+  independent_variable_uses_log_spacing_ =
+      h5::read_rank1_attribute<bool>(eos_table_group_.id(), "uses log spacing");
+  beta_equilibrium_ =
+      h5::read_value_attribute<bool>(eos_table_group_.id(), "beta equilibium");
+  // Note: if we start writing more datasets than just the dependent variables,
+  // this list will need to be pruned.
+  available_quantities_ = h5::get_group_names(eos_table_group_.id(), {});
+}
+
+void EosTable::write_quantity(std::string name, const DataVector& data) {
+  h5::write_data(eos_table_group_.id(), data, name);
+  available_quantities_.push_back(std::move(name));
+}
+
+DataVector EosTable::read_quantity(const std::string& name) const {
+  return h5::read_data<1, DataVector>(eos_table_group_.id(), name);
+}
+}  // namespace h5

--- a/src/IO/H5/EosTable.hpp
+++ b/src/IO/H5/EosTable.hpp
@@ -1,0 +1,130 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <hdf5.h>
+#include <string>
+#include <vector>
+
+#include "IO/H5/Object.hpp"
+#include "IO/H5/OpenGroup.hpp"
+
+/// \cond
+class DataVector;
+/// \endcond
+
+namespace h5 {
+/*!
+ * \ingroup HDF5Group
+ * \brief An equation of state table subfile written inside an H5 file.
+ *
+ * ### Data Layout
+ *
+ * To be consistent with the CompOSE ASCII table format, the data is stored in a
+ * last independent variable varies fastest. For example, if you had independent
+ * variables \f$\rho\f$, \f$T\f$, and \f$Y_e\f$, then \f$Y_e\f$ varies fastest
+ * while \f$\rho\f$ varies slowest.
+ */
+class EosTable : public h5::Object {
+ public:
+  static std::string extension() { return ".eos"; }
+
+  /// Constructor used when writing a new equation of state.
+  EosTable(bool subfile_exists, detail::OpenGroup&& group, hid_t location,
+           const std::string& name,
+           std::vector<std::string> independent_variable_names,
+           std::vector<std::array<double, 2>> independent_variable_bounds,
+           std::vector<size_t> independent_variable_number_of_points,
+           std::vector<bool> independent_variable_uses_log_spacing,
+           bool beta_equilibrium, uint32_t version = 1);
+
+  /// Constructor used when reading in an equation of state.
+  EosTable(bool subfile_exists, detail::OpenGroup&& group, hid_t location,
+           const std::string& name);
+
+  EosTable(const EosTable& /*rhs*/) = delete;
+  EosTable& operator=(const EosTable& /*rhs*/) = delete;
+  EosTable(EosTable&& /*rhs*/) = delete;             // NOLINT
+  EosTable& operator=(EosTable&& /*rhs*/) = delete;  // NOLINT
+
+  ~EosTable() override = default;
+
+  /*!
+   * \returns the header of the EosTable file
+   */
+  const std::string& get_header() const { return header_; }
+
+  /*!
+   * \returns the user-specified version number of the EosTable file
+   *
+   * \note h5::Version returns a uint32_t, so we return one here too for the
+   * version
+   */
+  uint32_t get_version() const { return version_; }
+
+  const std::string& subfile_path() const override { return path_; }
+
+  /*!
+   * \brief Write a thermodynamic quantity to disk.
+   */
+  void write_quantity(std::string name, const DataVector& data);
+
+  /*!
+   * \brief Read a thermodynamic quantity to disk.
+   */
+  DataVector read_quantity(const std::string& name) const;
+
+  /// The available thermodynamic quantities.
+  const std::vector<std::string> available_quantities() const {
+    return available_quantities_;
+  }
+
+  /// Number of independent variables.
+  size_t number_of_independent_variables() const {
+    return independent_variable_names_.size();
+  }
+
+  /// Names of the independent variables.
+  const std::vector<std::string>& independent_variable_names() const {
+    return independent_variable_names_;
+  }
+
+  /// Lower and upper bounds of the independent variables.
+  const std::vector<std::array<double, 2>>& independent_variable_bounds()
+      const {
+    return independent_variable_bounds_;
+  }
+
+  /// The number of points for each of the independent variables.
+  const std::vector<size_t>& independent_variable_number_of_points() const {
+    return independent_variable_number_of_points_;
+  }
+
+  /// Whether each independent variable is in log spacing. Linear spacing is
+  /// used if `false`.
+  const std::vector<bool>& independent_variable_uses_log_spacing() const {
+    return independent_variable_uses_log_spacing_;
+  }
+
+  /// `true` if the EOS is in beta equilibrium.
+  bool beta_equilibrium() const { return beta_equilibrium_; }
+
+ private:
+  detail::OpenGroup group_{};
+  std::string name_{};
+  std::string path_{};
+  uint32_t version_{};
+  detail::OpenGroup eos_table_group_{};
+  std::string header_{};
+
+  std::vector<std::string> independent_variable_names_{};
+  std::vector<std::array<double, 2>> independent_variable_bounds_{};
+  std::vector<size_t> independent_variable_number_of_points_{};
+  std::vector<bool> independent_variable_uses_log_spacing_{};
+  bool beta_equilibrium_ = false;
+  std::vector<std::string> available_quantities_{};
+};
+}  // namespace h5

--- a/src/IO/H5/Helpers.cpp
+++ b/src/IO/H5/Helpers.cpp
@@ -282,6 +282,7 @@ bool contains_dataset_or_group(const hid_t id, const std::string& group_name,
 }
 
 template <typename Type>
+// NOLINTNEXTLINE(readability-avoid-const-params-in-decls)
 void write_to_attribute(const hid_t location_id, const std::string& name,
                         const Type& value) {
   const hid_t space_id = H5Screate(H5S_SCALAR);
@@ -462,6 +463,21 @@ std::vector<std::string> read_rank1_attribute<std::string>(
   return result;
 }
 
+template <>
+void write_to_attribute<bool>(const hid_t group_id, const std::string& name,
+                              const std::vector<bool>& data) {
+  std::vector<unsigned short> temp(data.begin(), data.end());
+  write_to_attribute(group_id, name, temp);
+}
+
+template <>
+std::vector<bool> read_rank1_attribute<bool>(const hid_t group_id,
+                                             const std::string& name) {
+  const std::vector<unsigned short> temp =
+      read_rank1_attribute<unsigned short>(group_id, name);
+  return std::vector<bool>(temp.begin(), temp.end());
+}
+
 std::vector<std::string> get_attribute_names(const hid_t file_id,
                                              const std::string& group_name) {
   // Opens the group, loads the group info and then loops over all the
@@ -618,6 +634,11 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_ATTRIBUTE,
 
 template std::string read_value_attribute<std::string>(const hid_t location_id,
                                                        const std::string& name);
+// std::vector<bool> is annoying, so we instantiate single bools separately
+template void write_to_attribute(const hid_t location_id,
+                                 const std::string& name, const bool& value);
+template bool read_value_attribute<bool>(const hid_t location_id,
+                                         const std::string& name);
 
 #define INSTANTIATE_READ_SCALAR(_, DATA)                 \
   template TYPE(DATA) read_data<RANK(DATA), TYPE(DATA)>( \

--- a/src/IO/H5/Helpers.cpp
+++ b/src/IO/H5/Helpers.cpp
@@ -478,6 +478,79 @@ std::vector<bool> read_rank1_attribute<bool>(const hid_t group_id,
   return std::vector<bool>(temp.begin(), temp.end());
 }
 
+template <typename T, size_t Size>
+void write_to_attribute(const hid_t group_id, const std::string& name,
+                        const std::vector<std::array<T, Size>>& data) {
+  static_assert(std::is_fundamental_v<T>);
+  const hsize_t size = data.size() * Size;
+  const hid_t space_id = H5Screate_simple(1, &size, nullptr);
+  CHECK_H5(space_id,
+           "Failed to create dataspace for attribute  '" << name << "'");
+  const hid_t att_id = H5Acreate2(group_id, name.c_str(), h5::h5_type<T>(),
+                                  space_id, h5p_default(), h5p_default());
+  CHECK_H5(att_id, "Failed to create attribute '" << name << "'");
+  CHECK_H5(
+      H5Awrite(att_id, h5::h5_type<T>(), static_cast<const void*>(data.data())),
+      "Failed to write extents into attribute '" << name << "'");
+  CHECK_H5(H5Sclose(space_id),
+           "Failed to close dataspace when writing attribute '" << name << "'");
+  CHECK_H5(H5Aclose(att_id),
+           "Failed to close attribute '" << name << "' when writing it.");
+}
+
+template <typename T, size_t Size>
+std::vector<std::array<T, Size>> read_rank1_array_attribute(
+    const hid_t group_id, const std::string& name) {
+  static_assert(std::is_fundamental_v<T>);
+  const hid_t attr_id = H5Aopen(group_id, name.c_str(), h5p_default());
+  CHECK_H5(attr_id, "Failed to open attribute");
+  {  // Check that the datatype in the file matches what we are reading.
+    const hid_t datatype_id = H5Aget_type(attr_id);
+    CHECK_H5(datatype_id, "Failed to get datatype from attribute " << name);
+    if (UNLIKELY(not h5::types_equal(datatype_id, h5::h5_type<T>()))) {
+      ERROR("Expected to read type " << pretty_type::short_name<T>()
+                                     << " for attribute " << name);
+    }
+    CHECK_H5(H5Tclose(datatype_id),
+             "Failed to close datatype while reading attribute " << name);
+  }
+  const auto size = [&attr_id, &name] {
+    const hid_t dataspace_id = H5Aget_space(attr_id);
+    const auto rank_of_space = H5Sget_simple_extent_ndims(dataspace_id);
+    if (UNLIKELY(rank_of_space < 0)) {
+      ERROR("Failed to get the rank of the dataspace inside the attribute "
+            << name);
+    }
+    if (UNLIKELY(rank_of_space != 1)) {
+      ERROR(
+          "The rank of the dataspace being read by read_rank1_attribute should "
+          "be 1 but is "
+          << rank_of_space);
+    }
+    std::array<hsize_t, 1> dims{};
+    if (UNLIKELY(H5Sget_simple_extent_dims(dataspace_id, dims.data(),
+                                           nullptr) != 1)) {
+      ERROR(
+          "The rank of the dataspace has changed after checking its rank. "
+          "Checked rank was "
+          << rank_of_space);
+    }
+    H5Sclose(dataspace_id);
+    if (UNLIKELY(dims[0] % Size != 0)) {
+      ERROR("The read size, " << dims[0]
+                              << ", must be a multiple of the number of "
+                                 "elements in the std::array, "
+                              << Size);
+    }
+    return dims[0] / Size;
+  }();
+  std::vector<std::array<T, Size>> data(size);
+  CHECK_H5(H5Aread(attr_id, h5::h5_type<T>(), data.data()),
+           "Failed to read data from attribute " << name);
+  H5Aclose(attr_id);
+  return data;
+}
+
 std::vector<std::string> get_attribute_names(const hid_t file_id,
                                              const std::string& group_name) {
   // Opens the group, loads the group info and then loops over all the
@@ -639,6 +712,24 @@ template void write_to_attribute(const hid_t location_id,
                                  const std::string& name, const bool& value);
 template bool read_value_attribute<bool>(const hid_t location_id,
                                          const std::string& name);
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE_ATTRIBUTE_ARRAY(_, DATA)                        \
+  template void write_to_attribute<TYPE(DATA), DIM(DATA)>(          \
+      hid_t group_id, const std::string& name,                      \
+      const std::vector<std::array<TYPE(DATA), DIM(DATA)>>& data);  \
+  template std::vector<std::array<TYPE(DATA), DIM(DATA)>>           \
+  read_rank1_array_attribute<TYPE(DATA), DIM(DATA)>(hid_t group_id, \
+                                                    const std::string& name);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_ATTRIBUTE_ARRAY,
+                        (float, double, int, unsigned int, long, unsigned long,
+                         long long, unsigned long long, char),
+                        (1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
+
+#undef INSTANTIATE_ATTRIBUTE_ARRAY
+#undef DIM
 
 #define INSTANTIATE_READ_SCALAR(_, DATA)                 \
   template TYPE(DATA) read_data<RANK(DATA), TYPE(DATA)>( \

--- a/src/IO/H5/Helpers.hpp
+++ b/src/IO/H5/Helpers.hpp
@@ -69,6 +69,15 @@ void write_to_attribute(hid_t group_id, const std::string& name,
 
 /*!
  * \ingroup HDF5Group
+ * \brief Write the `vector<array<fundamental, size>>` `data` to the attribute
+ * `name` in the group `group_id`.
+ */
+template <typename T, size_t Size>
+void write_to_attribute(hid_t group_id, const std::string& name,
+                        const std::vector<std::array<T, Size>>& data);
+
+/*!
+ * \ingroup HDF5Group
  * \brief Read a value of type `Type` from an HDF5 attribute named `name`
  */
 template <typename Type>
@@ -80,6 +89,15 @@ Type read_value_attribute(hid_t location_id, const std::string& name);
  */
 template <typename Type>
 std::vector<Type> read_rank1_attribute(hid_t group_id, const std::string& name);
+
+/*!
+ * \ingroup HDF5Group
+ * \brief Read the `vector<array<fundamental, size>>` from the attribute
+ * `name` in the group `group_id`.
+ */
+template <typename T, size_t Size>
+std::vector<std::array<T, Size>> read_rank1_array_attribute(
+    hid_t group_id, const std::string& name);
 
 /*!
  * \ingroup HDF5Group

--- a/src/IO/H5/Type.hpp
+++ b/src/IO/H5/Type.hpp
@@ -36,6 +36,14 @@ SPECTRE_ALWAYS_INLINE hid_t h5_type<double>() {
   return H5T_NATIVE_DOUBLE;  // LCOV_EXCL_LINE
 }
 template <>
+SPECTRE_ALWAYS_INLINE hid_t h5_type<short>() {
+  return H5T_NATIVE_SHORT;  // LCOV_EXCL_LINE
+}
+template <>
+SPECTRE_ALWAYS_INLINE hid_t h5_type<unsigned short>() {
+  return H5T_NATIVE_USHORT;  // LCOV_EXCL_LINE
+}
+template <>
 SPECTRE_ALWAYS_INLINE hid_t h5_type<int>() {
   return H5T_NATIVE_INT;  // LCOV_EXCL_LINE
 }
@@ -62,6 +70,10 @@ SPECTRE_ALWAYS_INLINE hid_t h5_type<unsigned long long>() {
 template <>
 SPECTRE_ALWAYS_INLINE hid_t h5_type<char>() {
   return H5T_NATIVE_CHAR;  // LCOV_EXCL_LINE
+}
+template <>
+SPECTRE_ALWAYS_INLINE hid_t h5_type<bool>() {
+  return H5T_NATIVE_HBOOL;  // LCOV_EXCL_LINE
 }
 template <>
 SPECTRE_ALWAYS_INLINE hid_t h5_type<std::string>() {

--- a/tests/Unit/IO/CMakeLists.txt
+++ b/tests/Unit/IO/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY "Test_IO")
 
 set(LIBRARY_SOURCES
   H5/Test_Dat.cpp
+  H5/Test_EosTable.cpp
   H5/Test_H5.cpp
   H5/Test_H5File.cpp
   H5/Test_OpenGroup.cpp

--- a/tests/Unit/IO/H5/Test_EosTable.cpp
+++ b/tests/Unit/IO/H5/Test_EosTable.cpp
@@ -1,0 +1,140 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <hdf5.h>
+#include <memory>
+#include <regex>
+#include <sstream>
+#include <string>
+#include <typeinfo>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/BoostMultiArray.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "IO/Connectivity.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/CheckH5.hpp"
+#include "IO/H5/EosTable.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/H5/Header.hpp"
+#include "IO/H5/Helpers.hpp"
+#include "IO/H5/OpenGroup.hpp"
+#include "IO/H5/SourceArchive.hpp"
+#include "IO/H5/Version.hpp"
+#include "IO/H5/Wrappers.hpp"
+#include "Informer/InfoFromBuild.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/Formaline.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+void test() {
+  const DataVector expected_pressure{
+      3.2731420000000011e-12, 3.1893989140625013e-12, 3.1999981000000014e-12,
+      1.2155360915010773e-9,  8.3016422052875601e-10, 2.1627258654874539e-9,
+      3.2099012875311601e-5,  2.4468017331204212e-4,  6.1349624337516350e-4,
+      2210.6053143615190,     2354.6115554098865,     2538.9119061115266,
+      52.861468710971884,     52.861468705720966,     52.861468710893689,
+      52.861692578286011,     52.861692577931898,     52.861692577582062,
+      52.861449400505300,     52.861440607424719,     52.861463344038555,
+      5535.2247866186935,     6793.9338434046485,     6544.9524934507153};
+  const DataVector expected_specific_internal_energy{
+      1.1372398000000006e-2,  3.5346163132812542e-3,  3.3070626000000045e-3,
+      -1.0169032790344480e-4, -7.7663669049909921e-3, -7.6041533773714091e-3,
+      1.2234741042710821e-4,  -2.9897660752421736e-3, 4.4546614168404601e-3,
+      0.77921157405081587,    0.86947269803694438,    1.0634124481653968,
+      193541104778.35413,     193541104733.22195,     193541104777.67715,
+      15626334.678079225,     15626334.678358778,     15626334.912313508,
+      1260.6482389767325,     1260.6475515928282,     1260.6487573789184,
+      1.1740182149625666,     -7.8404943805046665,    -6.7725747751703373};
+
+  const std::vector<std::string> expected_independent_variable_names{
+      "number density", "temperature", "electron fraction"};
+  const std::vector<std::array<double, 2>> expected_independent_variable_bounds{
+      {0.10000000000000001, 158.0}, {1.0e-12, 1.9}, {0.01, 0.6}};
+  const std::vector<size_t> expected_independent_variable_number_of_points{2, 4,
+                                                                           3};
+  const std::vector<bool> expected_independent_variable_uses_log_spacing{
+      true, true, false};
+  const bool expected_beta_equilibrium = false;
+
+  const std::string h5_file_name{"Unit.IO.H5.EosTable.h5"};
+  const uint32_t version_number = 4;
+  if (file_system::check_if_file_exists(h5_file_name)) {
+    file_system::rm(h5_file_name, true);
+  }
+
+  const auto check_table =
+      [&expected_independent_variable_names,
+       &expected_independent_variable_number_of_points,
+       &expected_specific_internal_energy, &expected_pressure,
+       &expected_beta_equilibrium,
+       &expected_independent_variable_uses_log_spacing,
+       &expected_independent_variable_bounds](const auto& eos_table) {
+        CHECK(eos_table.available_quantities() ==
+              std::vector<std::string>{"pressure", "specific internal energy"});
+        CHECK(eos_table.number_of_independent_variables() ==
+              expected_independent_variable_names.size());
+        CHECK(eos_table.independent_variable_names() ==
+              expected_independent_variable_names);
+        CHECK(eos_table.independent_variable_bounds() ==
+              expected_independent_variable_bounds);
+        CHECK(eos_table.independent_variable_number_of_points() ==
+              expected_independent_variable_number_of_points);
+        CHECK(eos_table.independent_variable_uses_log_spacing() ==
+              expected_independent_variable_uses_log_spacing);
+        CHECK(eos_table.beta_equilibrium() == expected_beta_equilibrium);
+        CHECK(eos_table.read_quantity("pressure") == expected_pressure);
+        CHECK(eos_table.read_quantity("specific internal energy") ==
+              expected_specific_internal_energy);
+        CHECK(eos_table.subfile_path() == "/sfo");
+      };
+
+  {
+    h5::H5File<h5::AccessType::ReadWrite> eos_file{h5_file_name};
+
+    auto& eos_table_written = eos_file.insert<h5::EosTable>(
+        "/sfo", expected_independent_variable_names,
+        expected_independent_variable_bounds,
+        expected_independent_variable_number_of_points,
+        expected_independent_variable_uses_log_spacing,
+        expected_beta_equilibrium, version_number);
+    eos_table_written.write_quantity("pressure", expected_pressure);
+    eos_table_written.write_quantity("specific internal energy",
+                                     expected_specific_internal_energy);
+    check_table(eos_table_written);
+    eos_file.close_current_object();
+
+    CHECK_THROWS_WITH(eos_file.get<h5::EosTable>(
+                          "/sfo", expected_independent_variable_names,
+                          expected_independent_variable_bounds,
+                          expected_independent_variable_number_of_points,
+                          expected_independent_variable_uses_log_spacing,
+                          expected_beta_equilibrium, version_number),
+                      Catch::Matchers::Contains(
+                          "Opening an equation of state table with the "
+                          "constructor for writing a table, but the subfile "));
+  }
+  {
+    h5::H5File<h5::AccessType::ReadOnly> eos_file{h5_file_name};
+    check_table(eos_file.get<h5::EosTable>("/sfo"));
+    eos_file.close_current_object();
+  }
+
+  if (file_system::check_if_file_exists(h5_file_name)) {
+    file_system::rm(h5_file_name, true);
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.IO.H5.EosTable", "[Unit][IO][H5]") { test(); }


### PR DESCRIPTION
## Proposed changes

- Extend our HDF5 library wrappers
- Add an EOS table H5 subfile. This allows fairly aggressive compression that we can control, and also gives us the ability to maintain a format that will easily interoperate with our table class(es). Since we can compress tables by quite a bit, this should also allow us to store the generated tables somewhere where we can download them to supercomputers to use.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
