### PR TITLE
Find AH quantities in grid frame

### DIFF
--- a/src/ApparentHorizons/HorizonAliases.hpp
+++ b/src/ApparentHorizons/HorizonAliases.hpp
@@ -34,44 +34,43 @@ using vars_to_interpolate_to_target =
                gr::Tags::SpatialChristoffelSecondKind<Dim, Frame>,
                gr::Tags::SpatialRicci<Dim, Frame>>;
 
-using tags_for_observing = tmpl::list<
-    StrahlkorperGr::Tags::AreaCompute<::Frame::Inertial>,
-    StrahlkorperGr::Tags::IrreducibleMassCompute<::Frame::Inertial>,
-    StrahlkorperTags::MaxRicciScalarCompute,
-    StrahlkorperTags::MinRicciScalarCompute,
-    StrahlkorperGr::Tags::ChristodoulouMassCompute<::Frame::Inertial>,
-    StrahlkorperGr::Tags::DimensionlessSpinMagnitudeCompute<::Frame::Inertial>>;
+template <typename Frame>
+using tags_for_observing =
+    tmpl::list<StrahlkorperGr::Tags::AreaCompute<Frame>,
+               StrahlkorperGr::Tags::IrreducibleMassCompute<Frame>,
+               StrahlkorperTags::MaxRicciScalarCompute,
+               StrahlkorperTags::MinRicciScalarCompute,
+               StrahlkorperGr::Tags::ChristodoulouMassCompute<Frame>,
+               StrahlkorperGr::Tags::DimensionlessSpinMagnitudeCompute<Frame>>;
 
 using surface_tags_for_observing = tmpl::list<StrahlkorperTags::RicciScalar>;
 
-template <size_t Dim>
+template <size_t Dim, typename Frame>
 using compute_items_on_target = tmpl::append<
-    tmpl::list<
-        StrahlkorperTags::ThetaPhiCompute<::Frame::Inertial>,
-        StrahlkorperTags::RadiusCompute<::Frame::Inertial>,
-        StrahlkorperTags::RhatCompute<::Frame::Inertial>,
-        StrahlkorperTags::InvJacobianCompute<::Frame::Inertial>,
-        StrahlkorperTags::InvHessianCompute<::Frame::Inertial>,
-        StrahlkorperTags::JacobianCompute<::Frame::Inertial>,
-        StrahlkorperTags::DxRadiusCompute<::Frame::Inertial>,
-        StrahlkorperTags::D2xRadiusCompute<::Frame::Inertial>,
-        StrahlkorperTags::NormalOneFormCompute<::Frame::Inertial>,
-        StrahlkorperTags::OneOverOneFormMagnitudeCompute<Dim, ::Frame::Inertial,
-                                                         DataVector>,
-        StrahlkorperTags::TangentsCompute<::Frame::Inertial>,
-        StrahlkorperTags::UnitNormalOneFormCompute<::Frame::Inertial>,
-        StrahlkorperTags::UnitNormalVectorCompute<::Frame::Inertial>,
-        StrahlkorperTags::GradUnitNormalOneFormCompute<::Frame::Inertial>,
-        // Note that StrahlkorperTags::ExtrinsicCurvatureCompute is the
-        // 2d extrinsic curvature of the strahlkorper embedded in the 3d
-        // slice, whereas gr::tags::ExtrinsicCurvature is the 3d extrinsic
-        // curvature of the slice embedded in 4d spacetime.  Both quantities
-        // are in the DataBox.
-        StrahlkorperGr::Tags::AreaElementCompute<::Frame::Inertial>,
-        StrahlkorperTags::ExtrinsicCurvatureCompute<::Frame::Inertial>,
-        StrahlkorperTags::RicciScalarCompute<::Frame::Inertial>,
-        StrahlkorperGr::Tags::SpinFunctionCompute<::Frame::Inertial>,
-        StrahlkorperGr::Tags::DimensionfulSpinMagnitudeCompute<
-            ::Frame::Inertial>>,
-    tags_for_observing>;
+    tmpl::list<StrahlkorperTags::ThetaPhiCompute<Frame>,
+               StrahlkorperTags::RadiusCompute<Frame>,
+               StrahlkorperTags::RhatCompute<Frame>,
+               StrahlkorperTags::InvJacobianCompute<Frame>,
+               StrahlkorperTags::InvHessianCompute<Frame>,
+               StrahlkorperTags::JacobianCompute<Frame>,
+               StrahlkorperTags::DxRadiusCompute<Frame>,
+               StrahlkorperTags::D2xRadiusCompute<Frame>,
+               StrahlkorperTags::NormalOneFormCompute<Frame>,
+               StrahlkorperTags::OneOverOneFormMagnitudeCompute<Dim, Frame,
+                                                                DataVector>,
+               StrahlkorperTags::TangentsCompute<Frame>,
+               StrahlkorperTags::UnitNormalOneFormCompute<Frame>,
+               StrahlkorperTags::UnitNormalVectorCompute<Frame>,
+               StrahlkorperTags::GradUnitNormalOneFormCompute<Frame>,
+               // Note that StrahlkorperTags::ExtrinsicCurvatureCompute is the
+               // 2d extrinsic curvature of the strahlkorper embedded in the 3d
+               // slice, whereas gr::tags::ExtrinsicCurvature is the 3d
+               // extrinsic curvature of the slice embedded in 4d spacetime.
+               // Both quantities are in the DataBox.
+               StrahlkorperGr::Tags::AreaElementCompute<Frame>,
+               StrahlkorperTags::ExtrinsicCurvatureCompute<Frame>,
+               StrahlkorperTags::RicciScalarCompute<Frame>,
+               StrahlkorperGr::Tags::SpinFunctionCompute<Frame>,
+               StrahlkorperGr::Tags::DimensionfulSpinMagnitudeCompute<Frame>>,
+    tags_for_observing<Frame>>;
 }  // namespace ah

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
@@ -73,12 +73,13 @@ struct EvolutionMetavars<3, InitialData, BoundaryConditions>
 
   struct AhA : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
     using temporal_id = ::Tags::Time;
-    using tags_to_observe = ::ah::tags_for_observing;
+    using tags_to_observe = ::ah::tags_for_observing<Frame::Inertial>;
     using surface_tags_to_observe = ::ah::surface_tags_for_observing;
     using compute_vars_to_interpolate = ah::ComputeHorizonVolumeQuantities;
     using vars_to_interpolate_to_target =
         ::ah::vars_to_interpolate_to_target<volume_dim, ::Frame::Inertial>;
-    using compute_items_on_target = ::ah::compute_items_on_target<volume_dim>;
+    using compute_items_on_target =
+        ::ah::compute_items_on_target<volume_dim, Frame::Inertial>;
     using compute_target_points =
         intrp::TargetPoints::ApparentHorizon<AhA, ::Frame::Inertial>;
     using post_interpolation_callback =

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -192,9 +192,10 @@ struct EvolutionMetavars {
         ::ah::vars_to_interpolate_to_target<volume_dim, ::Frame::Grid>,
         ::ah::vars_to_interpolate_to_target<volume_dim, ::Frame::Inertial>>;
     using compute_vars_to_interpolate = ah::ComputeHorizonVolumeQuantities;
-    using tags_to_observe = ::ah::tags_for_observing;
+    using tags_to_observe = ::ah::tags_for_observing<Frame::Grid>;
     using surface_tags_to_observe = ::ah::surface_tags_for_observing;
-    using compute_items_on_target = ::ah::compute_items_on_target<volume_dim>;
+    using compute_items_on_target =
+        ::ah::compute_items_on_target<volume_dim, Frame::Grid>;
     using compute_target_points =
         intrp::TargetPoints::ApparentHorizon<AhA, ::Frame::Grid>;
     using post_interpolation_callback =
@@ -213,9 +214,10 @@ struct EvolutionMetavars {
         ::ah::vars_to_interpolate_to_target<volume_dim, ::Frame::Grid>,
         ::ah::vars_to_interpolate_to_target<volume_dim, ::Frame::Inertial>>;
     using compute_vars_to_interpolate = ah::ComputeHorizonVolumeQuantities;
-    using tags_to_observe = ::ah::tags_for_observing;
+    using tags_to_observe = ::ah::tags_for_observing<Frame::Grid>;
     using surface_tags_to_observe = ::ah::surface_tags_for_observing;
-    using compute_items_on_target = ::ah::compute_items_on_target<volume_dim>;
+    using compute_items_on_target =
+        ::ah::compute_items_on_target<volume_dim, Frame::Grid>;
     using compute_target_points =
         intrp::TargetPoints::ApparentHorizon<AhB, ::Frame::Grid>;
     using post_interpolation_callback =


### PR DESCRIPTION
## Proposed changes

In BBH runs, currently there's something wrong with AH quantities when computing in the inertial frame on a horizon found in the grid frame; I suspect a bug that hasn't been tracked down yet ([#4132](https://github.com/sxs-collaboration/spectre/issues/4132)). AH quantities computed in the grid frame on an AH found in the grid frame behave sensibly.

I have not observed this issue with single-black-hole executable, presumably because the grid and inertial frames are identical in that case.

At least until this is understood, I would like to just compute AH quantities in the grid frame for BBHs; this PR makes that change. The single-BH executable behavior remains unchanged.

Here's a plot showing the areal mass for a non spinning BBH for one of the horizons. The green curve measures the areal mass in the grid frame; the others measure it in the inertial frame.

<img width="1011" alt="image" src="https://user-images.githubusercontent.com/867015/180645199-b023375c-042c-4119-88b8-4c163768db5f.png">


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
After this change, binary black hole evolutions will observe apparent horizon quantities in the grid frame instead of the inertial frame.

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
