### PR TITLE
Add CombineH5 executable

### DIFF
--- a/src/Executables/CMakeLists.txt
+++ b/src/Executables/CMakeLists.txt
@@ -2,6 +2,7 @@
 # See LICENSE.txt for details.
 
 add_subdirectory(Benchmark)
+add_subdirectory(CombineH5)
 add_subdirectory(DebugPreprocessor)
 add_subdirectory(Examples)
 add_subdirectory(ExportCoordinates)

--- a/src/Executables/CombineH5/CMakeLists.txt
+++ b/src/Executables/CombineH5/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(EXECUTABLE CombineH5)
+
+add_spectre_executable(
+  ${EXECUTABLE}
+  EXCLUDE_FROM_ALL
+  CombineH5.cpp
+  )
+
+target_link_libraries(
+  ${EXECUTABLE}
+  PRIVATE
+  Boost::boost
+  Boost::program_options
+  DataStructures
+  IO
+  Parallel
+  Utilities
+  )

--- a/src/Executables/CombineH5/CombineH5.cpp
+++ b/src/Executables/CombineH5/CombineH5.cpp
@@ -1,0 +1,161 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <boost/program_options.hpp>
+#include <cstddef>
+#include <iterator>
+#include <string>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/CheckH5PropertiesMatch.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/H5/SourceArchive.hpp"
+#include "IO/H5/VolumeData.hpp"
+#include "Parallel/Printf.hpp"
+#include "Utilities/FileSystem.hpp"
+
+// Charm looks for this function but since we build without a main function or
+// main module we just have it be empty
+extern "C" void CkRegisterMainModule(void) {}
+
+// Returns all the observation_ids stored in the volume files. Assumes all
+// volume files have the same observation ids
+std::vector<size_t> get_observation_ids(const std::string& file_prefix,
+                                        const std::string& subfile_name) {
+  const h5::H5File<h5::AccessType::ReadOnly> initial_file(file_prefix + "0.h5",
+                                                          false);
+  const auto& initial_volume_file =
+      initial_file.get<h5::VolumeData>("/" + subfile_name);
+  return initial_volume_file.list_observation_ids();
+}
+
+// Returns total number of elements for an observation id across all volume data
+// files
+size_t get_number_of_elements(const std::vector<std::string>& input_filenames,
+                              const std::string& subfile_name,
+                              const size_t& observation_id) {
+  size_t total_elements = 0;
+  for (const auto& input_filename : input_filenames) {
+    const h5::H5File<h5::AccessType::ReadOnly> original_file(input_filename,
+                                                             false);
+    const auto& original_volume_file =
+        original_file.get<h5::VolumeData>("/" + subfile_name);
+    total_elements += original_volume_file.get_extents(observation_id).size();
+  }
+  return total_elements;
+}
+
+void combine_h5(const std::string& file_prefix, const std::string& subfile_name,
+                const std::string& output) {
+  // Parses for and stores all input files to be looped over
+  const std::vector<std::string>& file_names =
+      file_system::glob(file_prefix + "*.h5");
+
+  // Checks that volume data was generated with identical versions of SpECTRE
+  if (!h5::check_src_files_match(file_names)) {
+    ERROR(
+        "One or more of your files were found to have differing src.tar.gz "
+        "files, meaning that they may be from differing versions of SpECTRE.");
+  }
+
+  // Checks that volume data files contain the same observation ids
+  if (!h5::check_observation_ids_match(file_names, subfile_name)) {
+    ERROR(
+        "One or more of your files were found to have differing observation "
+        "ids, meaning they may be from different runs of your SpECTRE "
+        "executable or were corrupted.");
+  }
+
+  // Braces to specify scope for H5 file
+  {
+    // Instantiates the output file and the .vol subfile to be filled with the
+    // combined data later
+    h5::H5File<h5::AccessType::ReadWrite> new_file(output + "0.h5", true);
+    new_file.insert<h5::VolumeData>("/" + subfile_name + ".vol");
+    new_file.close_current_object();
+  }  // End of scope for H5 file
+
+  // Obtains list of observation ids to loop over
+  const std::vector<size_t> observation_ids =
+      get_observation_ids(file_prefix, subfile_name);
+
+  // Loops over observation ids to write volume data by observation id
+  for (const auto& obs_id : observation_ids) {
+    // Pre-calculates size of vector to store element data and allocates
+    // corresponding memory
+    const size_t vector_dim =
+        get_number_of_elements(file_names, subfile_name, obs_id);
+    std::vector<ElementVolumeData> element_data;
+    element_data.reserve(vector_dim);
+
+    double obs_val = 0.0;
+
+    // Loops over input files to append element data into a single vector to be
+    // stored in a single H5
+    for (auto const& file_name : file_names) {
+      const h5::H5File<h5::AccessType::ReadOnly> original_file(file_name,
+                                                               false);
+      const auto& original_volume_file =
+          original_file.get<h5::VolumeData>("/" + subfile_name);
+      obs_val = original_volume_file.get_observation_value(obs_id);
+
+      // Get vector of element data for this `obs_id` and `file_name`
+      std::vector<ElementVolumeData> data_by_element =
+          std::move(std::get<2>(original_volume_file.get_data_by_element(
+              obs_val * (1.0 - 4.0 * std::numeric_limits<double>::epsilon()),
+              obs_val * (1.0 + 4.0 * std::numeric_limits<double>::epsilon()),
+              std::nullopt)[0]));
+
+      // Append vector to total vector of element data for this `obs_id`
+      element_data.insert(element_data.end(),
+                          std::make_move_iterator(data_by_element.begin()),
+                          std::make_move_iterator(data_by_element.end()));
+      data_by_element.clear();
+      original_file.close_current_object();
+    }
+
+    h5::H5File<h5::AccessType::ReadWrite> new_file(output + "0.h5", true);
+    auto& new_volume_file = new_file.get<h5::VolumeData>("/" + subfile_name);
+    new_volume_file.write_volume_data(obs_id, obs_val, element_data);
+    new_file.close_current_object();
+  }
+}
+
+/*
+ * This executable is used for combining a series of HDF5 volume files into one
+ * continuous dataset to be stored in a single HDF5 volume file.
+ */
+int main(int argc, char** argv) {
+  boost::program_options::positional_options_description pos_desc;
+
+  boost::program_options::options_description desc("Options");
+  desc.add_options()("help,h,", "show this help message")(
+      "file_prefix", boost::program_options::value<std::string>()->required(),
+      "prefix of the files to be combined (omit number and file extension)")(
+      "subfile_name", boost::program_options::value<std::string>()->required(),
+      "subfile name shared for each volume file in each H5 file (omit file "
+      "extension)")("output",
+                    boost::program_options::value<std::string>()->required(),
+                    "combined output filename (omit file extension)");
+
+  boost::program_options::variables_map vars;
+
+  boost::program_options::store(
+      boost::program_options::command_line_parser(argc, argv)
+          .positional(pos_desc)
+          .options(desc)
+          .run(),
+      vars);
+
+  if (vars.count("help") != 0u or vars.count("file_prefix") == 0u or
+      vars.count("subfile_name") == 0u or vars.count("output") == 0u) {
+    Parallel::printf("%s\n", desc);
+    return 1;
+  }
+
+  combine_h5(vars["file_prefix"].as<std::string>(),
+             vars["subfile_name"].as<std::string>(),
+             vars["output"].as<std::string>());
+}

--- a/src/IO/H5/CMakeLists.txt
+++ b/src/IO/H5/CMakeLists.txt
@@ -5,6 +5,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   AccessType.cpp
+  CheckH5PropertiesMatch.cpp
   Dat.cpp
   EosTable.cpp
   File.cpp
@@ -24,6 +25,7 @@ spectre_target_headers(
   HEADERS
   AccessType.hpp
   CheckH5.hpp
+  CheckH5PropertiesMatch.hpp
   Dat.hpp
   EosTable.hpp
   File.hpp

--- a/src/IO/H5/CheckH5PropertiesMatch.cpp
+++ b/src/IO/H5/CheckH5PropertiesMatch.cpp
@@ -1,0 +1,91 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "IO/H5/CheckH5PropertiesMatch.hpp"
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/H5/SourceArchive.hpp"
+#include "IO/H5/VolumeData.hpp"
+
+namespace h5 {
+bool check_src_files_match(const std::vector<std::string>& input_filenames) {
+  // Holds source archive data of first file
+  std::vector<char> src_tar_initial;
+
+  // Braces to specify scope for H5 file
+  {
+    // Reads the 0th volume file to compare against
+    const h5::H5File<h5::AccessType::ReadOnly> initial_file(input_filenames[0],
+                                                            false);
+
+    // Obtains the source archive of the 0th volume file to compare against
+    const auto& src_archive_object_initial =
+        initial_file.get<h5::SourceArchive>("/src");
+    src_tar_initial = src_archive_object_initial.get_archive();
+  }  // End of scope for H5 file
+
+  // Iterates through each of the other files and compares source archives
+  for (size_t i = 1; i < input_filenames.size(); ++i) {
+    // Reads the i-th volume file to compare with
+    const h5::H5File<h5::AccessType::ReadOnly> comparison_file(
+        input_filenames[i], false);
+
+    // Obtains the source archive of the i-th volume file to compare with
+    const auto& src_archive_object_compare =
+        comparison_file.get<h5::SourceArchive>("/src");
+    const std::vector<char>& src_tar_compare =
+        src_archive_object_compare.get_archive();
+
+    // Returns false if the source archive data does not match
+    if (src_tar_initial != src_tar_compare) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool check_observation_ids_match(
+    const std::vector<std::string>& input_filenames,
+    const std::string& subfile_name) {
+  // Holds observation id data of first file
+  std::vector<size_t> obs_id_initial;
+
+  // Braces to specify scope for H5 file
+  {
+    // Reads the 0th volume file to compare against
+    const h5::H5File<h5::AccessType::ReadOnly> initial_file(input_filenames[0],
+                                                            false);
+
+    // Obtains the list of observation ids of the 0th volume file to compare
+    // against
+    const auto& volume_data_initial =
+        initial_file.get<h5::VolumeData>("/" + subfile_name);
+    obs_id_initial = volume_data_initial.list_observation_ids();
+  }  // End of scope for H5 file
+
+  // Iterates through each of the other files and compares observation id lists
+  for (size_t i = 1; i < input_filenames.size(); ++i) {
+    // Reads the i-th volume file to compare against
+    const h5::H5File<h5::AccessType::ReadOnly> comparison_file(
+        input_filenames[i], false);
+
+    // Obtains the observation id list of the i-th volume file to compare with
+    const auto& volume_data_compare =
+        comparison_file.get<h5::VolumeData>("/" + subfile_name);
+    const std::vector<size_t>& obs_id_compare =
+        volume_data_compare.list_observation_ids();
+
+    // Returns false if an observation id does not match
+    if (obs_id_initial != obs_id_compare) {
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace h5

--- a/src/IO/H5/CheckH5PropertiesMatch.hpp
+++ b/src/IO/H5/CheckH5PropertiesMatch.hpp
@@ -1,0 +1,26 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace h5 {
+/*!
+ * \ingroup HDF5Group
+ * \brief Check if all files within `input_filenames` have the same source
+ * archive.
+ */
+bool check_src_files_match(const std::vector<std::string>& input_filenames);
+
+/*!
+ * \ingroup HDF5Group
+ * \brief Check if all files within `input_filenames` with volume subfile
+ * `subfile_name` have the same set of observation ids.
+ */
+bool check_observation_ids_match(
+    const std::vector<std::string>& input_filenames,
+    const std::string& subfile_name);
+
+}  // namespace h5

--- a/tests/Unit/IO/CMakeLists.txt
+++ b/tests/Unit/IO/CMakeLists.txt
@@ -7,6 +7,7 @@ add_subdirectory(Logging)
 set(LIBRARY "Test_IO")
 
 set(LIBRARY_SOURCES
+  H5/Test_CheckH5PropertiesMatch.cpp
   H5/Test_Dat.cpp
   H5/Test_EosTable.cpp
   H5/Test_H5.cpp

--- a/tests/Unit/IO/H5/Test_CheckH5PropertiesMatch.cpp
+++ b/tests/Unit/IO/H5/Test_CheckH5PropertiesMatch.cpp
@@ -1,0 +1,134 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/TensorData.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/CheckH5PropertiesMatch.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/H5/VolumeData.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/FileSystem.hpp"
+
+namespace {
+
+// Helper function to set up test files
+template <typename DataType>
+void setup_test_files(const std::vector<std::string>& h5_file_names) {
+  REQUIRE(h5_file_names.size() == 3);
+
+  // Sample volume data
+  const std::string grid_name{"AhA"};
+  const std::vector<DataType> tensor_components_and_coords{{0.0, 1.0},
+                                                           {-78.9, -7.6}};
+  const std::vector<TensorComponent> tensor_components{
+      {"InertialCoordinates_1D", tensor_components_and_coords[0]},
+      {"TestScalar", tensor_components_and_coords[1]}};
+
+  const std::vector<size_t> observation_ids{2345, 3456, 4567};
+  const std::vector<double> observation_values{1.0, 2.0, 3.0};
+  const std::vector<Spectral::Basis> bases{Spectral::Basis::Legendre};
+  const std::vector<Spectral::Quadrature> quadratures{
+      Spectral::Quadrature::Gauss};
+  const std::vector<size_t> extents{2};
+
+  const uint32_t version_number = 4;
+
+  // Set up files with same observation ids and source archives
+  for (const auto& file_name : h5_file_names) {
+    // Remove any pre-existing file with the same name
+    if (file_system::check_if_file_exists(file_name)) {
+      file_system::rm(file_name, true);
+    }
+
+    // Create a new file with the given name
+    h5::H5File<h5::AccessType::ReadWrite> h5_file{file_name};
+    auto& volume_file =
+        h5_file.insert<h5::VolumeData>("/element_data", version_number);
+
+    // Write volume data to new file
+    for (size_t j = 0; j < 3; j++) {
+      volume_file.write_volume_data(
+          observation_ids[j], observation_values[j],
+          std::vector<ElementVolumeData>{
+              {extents, tensor_components, bases, quadratures, grid_name}});
+    }
+    h5_file.close_current_object();
+  }
+
+  // Braces to specify scope for H5 file
+  {
+    // Set up last file with additional observation id and data
+    h5::H5File<h5::AccessType::ReadWrite> h5_file{h5_file_names[2], true};
+    auto& volume_file =
+        h5_file.get<h5::VolumeData>("/element_data", version_number);
+    volume_file.write_volume_data(
+        5678, 4.0,
+        std::vector<ElementVolumeData>{
+            {extents, tensor_components, bases, quadratures, grid_name}});
+  }  // End of scope for H5 file
+}
+
+template <typename DataType>
+void test_check_src_files_match() {
+  const std::vector<std::string> h5_file_names{
+      "Unit.IO.H5.CheckH5PropertiesMatch0.h5",
+      "Unit.IO.H5.CheckH5PropertiesMatch1.h5",
+      "Unit.IO.H5.CheckH5PropertiesMatch2.h5"};
+
+  setup_test_files<DataType>(h5_file_names);
+
+  // Check function for files with same source archive
+  CHECK(h5::check_src_files_match(h5_file_names) == true);
+
+  // Remove files after test
+  for (const auto& file_name : h5_file_names) {
+    if (file_system::check_if_file_exists(file_name)) {
+      file_system::rm(file_name, true);
+    }
+  }
+}
+
+template <typename DataType>
+void test_check_observation_ids_match() {
+  // List of filenames whose ids all match
+  const std::vector<std::string> h5_file_names_match{
+      "Unit.IO.H5.CheckH5PropertiesMatch0.h5",
+      "Unit.IO.H5.CheckH5PropertiesMatch1.h5"};
+
+  // List of filenames whose ids do not all match
+  const std::vector<std::string> h5_file_names_diff{
+      "Unit.IO.H5.CheckH5PropertiesMatch0.h5",
+      "Unit.IO.H5.CheckH5PropertiesMatch1.h5",
+      "Unit.IO.H5.CheckH5PropertiesMatch2.h5"};
+
+  setup_test_files<DataType>(h5_file_names_diff);
+
+  // Check function for files with same observation ids
+  CHECK(h5::check_observation_ids_match(h5_file_names_match, "/element_data") ==
+        true);
+  // Check function for files with different observation ids
+  CHECK(h5::check_observation_ids_match(h5_file_names_diff, "/element_data") ==
+        false);
+
+  // Remove files after test
+  for (const auto& file_name : h5_file_names_diff) {
+    if (file_system::check_if_file_exists(file_name)) {
+      file_system::rm(file_name, true);
+    }
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.IO.H5.CheckH5PropertiesMatch", "[Unit][IO][H5]") {
+  test_check_src_files_match<DataVector>();
+  test_check_src_files_match<std::vector<float>>();
+  test_check_observation_ids_match<DataVector>();
+  test_check_observation_ids_match<std::vector<float>>();
+}


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

- Add `CombineH5` executable to combine multiple H5 volume files into a new, single H5 file. To be used primarily for visualisation.
  - Note: Uses current source archive for H5 output, not source archive of the input files


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
