### PR TITLE
Update gfortran in cmake kit

### DIFF
--- a/support/DevEnvironments/.devcontainer/cmake-kits.json
+++ b/support/DevEnvironments/.devcontainer/cmake-kits.json
@@ -4,7 +4,7 @@
         "compilers": {
             "C": "/usr/bin/clang-10",
             "CXX": "/usr/bin/clang++-10",
-            "Fortran": "/usr/bin/gfortran-8"
+            "Fortran": "/usr/bin/gfortran-9"
         },
         "cmakeSettings": {
             "CHARM_ROOT": "/work/charm_7_0_0/multicore-linux-x86_64-clang",


### PR DESCRIPTION
We removed GCC-8 from the dev container but forgot to update the cmake kit.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
