### PR TITLE
Add actions for evaluating AMR criteria and updating AMR decisions based on neighbor decisions

### DIFF
--- a/src/Parallel/Printf.hpp
+++ b/src/Parallel/Printf.hpp
@@ -47,6 +47,7 @@ inline std::string stream_object_to_string(T&& t) {
                 "Cannot stream type and therefore it cannot be printed. Please "
                 "define a stream operator for the type.");
   std::stringstream ss;
+  using ::operator<<;
   ss << std::setprecision(std::numeric_limits<double>::digits10 + 4)
      << std::scientific << t;
   return ss.str();

--- a/src/ParallelAlgorithms/Amr/Actions/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/Actions/CMakeLists.txt
@@ -6,6 +6,8 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Actions.hpp
+  EvaluateRefinementCriteria.hpp
   Initialization.hpp
   Initialize.hpp
+  UpdateAmrDecision.hpp
   )

--- a/src/ParallelAlgorithms/Amr/Actions/EvaluateRefinementCriteria.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/EvaluateRefinementCriteria.hpp
@@ -1,0 +1,135 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <tuple>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
+#include "DataStructures/DataBox/TagTraits.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Amr/Tags/Flags.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Domain/Tags.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "ParallelAlgorithms/Amr/Actions/UpdateAmrDecision.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace tuples {
+template <class... Tags>
+class TaggedTuple;
+}  // namespace tuples
+/// \endcond
+
+namespace detail {
+template <typename Criterion>
+struct get_tags {
+  using type = typename Criterion::compute_tags_for_observation_box;
+};
+
+}  // namespace detail
+
+namespace amr::Actions {
+/// \brief Evaluates the refinement criteria in order to set the
+/// amr::domain::Flag%s of an Element and sends this information to the
+/// neighbors of the Element.
+///
+/// DataBox:
+/// - Uses:
+///   * domain::Tags::Element<volume_dim>
+///   * amr::domain::Tags::NeighborFlags<volume_dim>
+///   * amr::Criteria::Tags::Criteria (from GlobalCache)
+///   * any tags requested by the refinement criteria
+/// - Modifies:
+///   * amr::domain::Tags::Flags<volume_dim>
+///
+/// Invokes:
+/// - UpdateAmrDecision on all neighboring Element%s
+///
+/// \details
+/// - Evaluates each refinement criteria held by amr::Criteria::Tags::Criteria,
+///   and in each dimension selects the amr::domain::Flag with the highest
+///   priority (i.e the highest integral value).
+/// - Checks if any neighbors have sent their AMR decision, and if so, calls
+///   amr:::domain::update_amr_decision with the decision of each neighbor in
+///   order to see if the current decision needs to be updated
+/// - Sends the (possibly updated) decision to all of the neighboring Elements
+struct EvaluateRefinementCriteria {
+  template <typename ParallelComponent, typename DbTagList,
+            typename Metavariables, typename ArrayIndex>
+  static void apply(db::DataBox<DbTagList>& box,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& array_index) {
+    constexpr size_t volume_dim = Metavariables::volume_dim;
+    ElementId<volume_dim> element_id{array_index};
+    auto overall_decision =
+        make_array<volume_dim>(amr::domain::Flag::Undefined);
+
+    using compute_tags = tmpl::remove_duplicates<tmpl::filter<
+        tmpl::flatten<tmpl::transform<
+            tmpl::at<typename Metavariables::factory_creation::factory_classes,
+                     Criterion>,
+            detail::get_tags<tmpl::_1>>>,
+        db::is_compute_tag<tmpl::_1>>>;
+    auto observation_box = make_observation_box<compute_tags>(box);
+
+    const auto& refinement_criteria =
+        db::get<amr::Criteria::Tags::Criteria>(box);
+    for (const auto& criterion : refinement_criteria) {
+      auto decision = criterion->evaluate(observation_box, cache, array_index);
+      for (size_t d = 0; d < volume_dim; ++d) {
+        overall_decision[d] = std::max(overall_decision[d], decision[d]);
+      }
+    }
+
+    // Check if we received any neighbor flags prior to determining our own
+    // flags.  If yes, then possible update our flags (e.g. sibling doesn't want
+    // to join, maintain 2:1 balance, etc.)
+    const auto& my_element = get<::domain::Tags::Element<volume_dim>>(box);
+    const auto& my_neighbors_amr_flags =
+        get<amr::domain::Tags::NeighborFlags<volume_dim>>(box);
+    if (not my_neighbors_amr_flags.empty()) {
+      for (const auto& [neighbor_id, neighbor_amr_flags] :
+           my_neighbors_amr_flags) {
+        amr::domain::update_amr_decision(make_not_null(&overall_decision),
+                                         my_element, neighbor_id,
+                                         neighbor_amr_flags);
+      }
+    }
+
+    db::mutate<amr::domain::Tags::Flags<Metavariables::volume_dim>>(
+        make_not_null(&box),
+        [&overall_decision](
+            const gsl::not_null<std::array<amr::domain::Flag, volume_dim>*>
+                amr_flags) { *amr_flags = overall_decision; });
+
+    auto& amr_element_array =
+        Parallel::get_parallel_component<ParallelComponent>(cache);
+
+    const std::array<amr::domain::Flag, Metavariables::volume_dim>& my_flags =
+        get<amr::domain::Tags::Flags<volume_dim>>(box);
+    for (const auto& [direction, neighbors] : my_element.neighbors()) {
+      (void)direction;
+      for (const auto& neighbor_id : neighbors.ids()) {
+        Parallel::simple_action<UpdateAmrDecision>(
+            amr_element_array[neighbor_id], element_id, my_flags);
+      }
+    }
+  }
+};
+}  // namespace amr::Actions

--- a/src/ParallelAlgorithms/Amr/Actions/UpdateAmrDecision.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/UpdateAmrDecision.hpp
@@ -1,0 +1,108 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <unordered_map>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Amr/Tags/Flags.hpp"
+#include "Domain/Amr/Tags/NeighborFlags.hpp"
+#include "Domain/Amr/UpdateAmrDecision.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Domain/Tags.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace amr::Actions {
+/// \brief Given the AMR decision of a neighboring Element, potentially update
+/// the AMR decision of the target Element.
+///
+/// DataBox:
+/// - Uses:
+///   * domain::Tags::Element<volume_dim>
+/// - Modifies:
+///   * amr::domain::Tags::NeighborFlags
+///   * amr::domain::Tags::Flags (if AMR decision is updated)
+///
+/// Invokes:
+/// - amr::Actions::UpdateAmrDecision on all neighboring Element%s (if AMR
+///   decision is updated)
+///
+/// \details This Element calls amr::domain::update_amr_decision to see if its
+/// AMR decision needs to be updated.  If it does, the Element will call
+/// amr::Actions::UpdateAmrDecision on its neighbors.
+///
+struct UpdateAmrDecision {
+  template <typename ParallelComponent, typename DbTagList,
+            typename Metavariables, typename ArrayIndex>
+  static void apply(
+      db::DataBox<DbTagList>& box, Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/,
+      const ElementId<Metavariables::volume_dim>& neighbor_id,
+      const std::array<amr::domain::Flag, Metavariables::volume_dim>&
+          neighbor_amr_flags) {
+    constexpr size_t volume_dim = Metavariables::volume_dim;
+    auto& my_amr_flags =
+        db::get_mutable_reference<amr::domain::Tags::Flags<volume_dim>>(
+            make_not_null(&box));
+    auto& my_neighbors_amr_flags =
+        db::get_mutable_reference<amr::domain::Tags::NeighborFlags<volume_dim>>(
+            make_not_null(&box));
+
+    // Actions can be executed in any order.  Therefore we need to check:
+    // - If we received flags from a neighbor multiple times, but not in the
+    //   order they were sent.  Neighbor flags should only be sent again if
+    //   they have changed to a higher priority (i.e. higher integral value of
+    //   the flag).
+    if (1 == my_neighbors_amr_flags.count(neighbor_id)) {
+      const auto& previously_received_flags =
+          my_neighbors_amr_flags.at(neighbor_id);
+      if (not std::lexicographical_compare(previously_received_flags.begin(),
+                                           previously_received_flags.end(),
+                                           neighbor_amr_flags.begin(),
+                                           neighbor_amr_flags.end())) {
+        return;
+      }
+    }
+
+    my_neighbors_amr_flags.insert_or_assign(neighbor_id, neighbor_amr_flags);
+
+    // Actions can be executed in any order.  Therefore we need to check:
+    // - If we have evaluated our own AMR decision.  If not, return.
+    if (amr::domain::Flag::Undefined == my_amr_flags[0]) {
+      ASSERT(
+          volume_dim == alg::count(my_amr_flags, amr::domain::Flag::Undefined),
+          "Flags should be all Undefined, not " << my_amr_flags);
+      return;
+    }
+
+    const auto& element = get<::domain::Tags::Element<volume_dim>>(box);
+
+    const bool my_amr_decision_changed = amr::domain::update_amr_decision(
+        make_not_null(&my_amr_flags), element, neighbor_id, neighbor_amr_flags);
+
+    if (my_amr_decision_changed) {
+      auto& amr_element_array =
+          Parallel::get_parallel_component<ParallelComponent>(cache);
+      for (const auto& direction_neighbors : element.neighbors()) {
+        for (const auto& id : direction_neighbors.second.ids()) {
+          Parallel::simple_action<UpdateAmrDecision>(
+              amr_element_array[id], element.id(), my_amr_flags);
+        }
+      }
+    }
+  }
+};
+}  // namespace amr::Actions

--- a/src/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -15,3 +15,4 @@ target_link_libraries(
   )
 
 add_subdirectory(Actions)
+add_subdirectory(Criteria)

--- a/src/ParallelAlgorithms/Amr/Criteria/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/Criteria/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY AmrCriteria)
+
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  Random.cpp
+  )
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Criteria.hpp
+  Criterion.hpp
+  Random.hpp
+  )
+
+add_dependencies(
+  ${LIBRARY}
+  module_GlobalCache
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  Amr
+  DomainStructure
+  Options
+  Parallel
+  Utilities
+  )
+
+add_subdirectory(Tags)

--- a/src/ParallelAlgorithms/Amr/Criteria/Criteria.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Criteria.hpp
@@ -1,0 +1,10 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace amr {
+/// \ingroup AmrGroup
+/// Criteria for deciding how a mesh should be adapted
+namespace Criteria {}
+}  // namespace amr

--- a/src/ParallelAlgorithms/Amr/Criteria/Criterion.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Criterion.hpp
@@ -1,0 +1,57 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <pup.h>
+#include <type_traits>
+
+#include "DataStructures/DataBox/ObservationBox.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Tags/Metavariables.hpp"
+#include "Utilities/CallWithDynamicType.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace amr {
+/// \ingroup AmrGroup
+/// \brief Base class for something that determines how an adaptive mesh should
+/// be changed
+///
+/// \details When AMR criteria are evaluated for each element, they should
+/// return a std::aray<amr::domain::Flag, Dim> containing the recommended
+/// refinement choice in each logical dimension of the Element.
+class Criterion : public PUP::able {
+ protected:
+  /// \cond
+  Criterion() = default;
+  Criterion(const Criterion&) = default;
+  Criterion(Criterion&&) = default;
+  Criterion& operator=(const Criterion&) = default;
+  Criterion& operator=(Criterion&&) = default;
+  /// \endcond
+
+ public:
+  ~Criterion() override = default;
+  explicit Criterion(CkMigrateMessage* msg) : PUP::able(msg) {}
+
+  WRAPPED_PUPable_abstract(Criterion);  // NOLINT
+
+  template <typename ComputeTagsList, typename DataBoxType,
+            typename Metavariables, typename ArrayIndex>
+  auto evaluate(const ObservationBox<ComputeTagsList, DataBoxType>& box,
+                Parallel::GlobalCache<Metavariables>& cache,
+                const ArrayIndex& array_index) const {
+    using factory_classes =
+        typename std::decay_t<Metavariables>::factory_creation::factory_classes;
+    return call_with_dynamic_type<
+        std::array<amr::domain::Flag, Metavariables::volume_dim>,
+        tmpl::at<factory_classes, Criterion>>(
+        this, [&box, &cache, &array_index](auto* const criterion) {
+          return apply(*criterion, box, cache, array_index);
+        });
+  }
+};
+}  // namespace amr

--- a/src/ParallelAlgorithms/Amr/Criteria/Random.cpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Random.cpp
@@ -1,0 +1,45 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ParallelAlgorithms/Amr/Criteria/Random.hpp"
+
+#include <random>
+
+#include "Domain/Amr/Flag.hpp"
+
+namespace amr::Criteria {
+Random::Random(const double do_something_fraction,
+               const size_t maximum_refinement_level)
+    : do_something_fraction_(do_something_fraction),
+      maximum_refinement_level_(maximum_refinement_level) {}
+
+Random::Random(CkMigrateMessage* msg) : Criterion(msg) {}
+
+// NOLINTNEXTLINE(google-runtime-references)
+void Random::pup(PUP::er& p) {
+  Criterion::pup(p);
+  p | do_something_fraction_;
+  p | maximum_refinement_level_;
+}
+
+amr::domain::Flag Random::random_flag(
+    const size_t current_refinement_level) const {
+  static std::random_device r;
+  static const auto seed = r();
+  static std::mt19937 generator(seed);
+  static std::uniform_real_distribution<> distribution(0.0, 1.0);
+
+  const double random_number = distribution(generator);
+  if (random_number > do_something_fraction_) {
+    return amr::domain::Flag::DoNothing;
+  }
+  const double join_fraction =
+      current_refinement_level / static_cast<double>(maximum_refinement_level_);
+  if (random_number < join_fraction * do_something_fraction_) {
+    return amr::domain::Flag::Join;
+  }
+  return amr::domain::Flag::Split;
+}
+
+PUP::able::PUP_ID Random::my_PUP_ID = 0;  // NOLINT
+}  // namespace amr::Criteria

--- a/src/ParallelAlgorithms/Amr/Criteria/Random.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Random.hpp
@@ -1,0 +1,97 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <pup.h>
+
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace amr::Criteria {
+/*!
+ * \brief Randomly h-refine (or coarsen) an Element in each dimension.
+ *
+ * \details Let \f$f\f$ be `ChangeRefinementFraction`, \f$L_{max}\f$ be
+ * `MaximumRefinementLevel`, and \f$L_d\f$ be the current refinement level
+ * of an Element in a particular dimension.  In each dimension, a random
+ * number \f$r_d \in [0, 1]\f$ is generated.  If \f$r_d > f\f$ the refinement
+ * flag is set to amr::Domain::Flags::DoNothing.  If \f$r_d < f L_d / L_{max}\f$
+ * the refinement flag is set to amr::Domain::Flags::Join.  Otherwise the
+ * refinement flag is set to amr::Domain::Flag::Split.
+ *
+ * \note This criterion is primarily useful for testing the mechanics of
+ * h-refinement
+ */
+class Random : public Criterion {
+ public:
+  /// The fraction of the time random refinement does changes the grid
+  struct ChangeRefinementFraction {
+    using type = double;
+    static constexpr Options::String help = {
+        "The fraction of the time that random refinement will change the "
+        "grid."};
+    static double lower_bound() { return 0.0; }
+    static double upper_bound() { return 1.0; }
+  };
+
+  /// The maximum allowed refinement level
+  struct MaximumRefinementLevel {
+    using type = size_t;
+    static constexpr Options::String help = {
+        "The maximum allowed refinement level."};
+    static size_t upper_bound() { return ElementId<3>::max_refinement_level; }
+  };
+
+  using options = tmpl::list<ChangeRefinementFraction, MaximumRefinementLevel>;
+
+  static constexpr Options::String help = {
+      "Randomly h-refine (or coarsen) the grid"};
+
+  Random() = default;
+
+  Random(const double do_something_fraction,
+         const size_t maximum_refinement_level);
+
+  /// \cond
+  explicit Random(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Random);  // NOLINT
+  /// \endcond
+
+  using compute_tags_for_observation_box = tmpl::list<>;
+
+  using argument_tags = tmpl::list<>;
+
+  template <typename ArrayIndex, typename Metavariables>
+  auto operator()(Parallel::GlobalCache<Metavariables>& /*cache*/,
+                  const ArrayIndex& array_index) const;
+
+  void pup(PUP::er& p) override;
+
+ private:
+  amr::domain::Flag random_flag(size_t current_refinement_level) const;
+
+  double do_something_fraction_{0.0};
+  size_t maximum_refinement_level_{0};
+};
+
+template <typename ArrayIndex, typename Metavariables>
+auto Random::operator()(Parallel::GlobalCache<Metavariables>& /*cache*/,
+                        const ArrayIndex& array_index) const {
+  constexpr size_t volume_dim = Metavariables::volume_dim;
+  auto result = make_array<volume_dim>(amr::domain::Flag::Undefined);
+  const ElementId<volume_dim> element_id{array_index};
+  for (size_t d = 0; d < volume_dim; ++d) {
+    result[d] = random_flag(element_id.segment_ids()[d].refinement_level());
+  }
+  return result;
+}
+}  // namespace amr::Criteria

--- a/src/ParallelAlgorithms/Amr/Criteria/Tags/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/Criteria/Tags/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Criteria.hpp
+  Tags.hpp
+  )

--- a/src/ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp
@@ -1,0 +1,38 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <unordered_set>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/Serialize.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Criteria.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace amr::Criteria {
+/// Option tags for AMR criteria
+namespace OptionTags {
+/// \ingroup OptionTagsGroup
+/// Options for AMR criteria
+struct Criteria {
+  static constexpr Options::String help = "Options for AMR criteria";
+  using type = std::vector<std::unique_ptr<amr::Criterion>>;
+};
+}  // namespace OptionTags
+
+namespace Tags {
+/// The set of adaptive mesh refinement criteria
+struct Criteria : db::SimpleTag {
+  using type = std::vector<std::unique_ptr<amr::Criterion>>;
+  using option_tags = tmpl::list<amr::Criteria::OptionTags::Criteria>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& value) {
+    return {deserialize<type>(serialize<type>(value).data())};
+  }
+};
+}  // namespace Tags
+}  // namespace amr::Criteria

--- a/src/ParallelAlgorithms/Amr/Criteria/Tags/Tags.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Tags/Tags.hpp
@@ -1,0 +1,10 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+/// \ingroup AmrGroup
+namespace amr::Criteria {
+/// \brief %Tags for adaptive mesh refinement criteria
+namespace Tags {}
+}  // namespace amr::Criteria

--- a/tests/Unit/Framework/MockRuntimeSystem.hpp
+++ b/tests/Unit/Framework/MockRuntimeSystem.hpp
@@ -499,6 +499,29 @@ class MockRuntimeSystem {
   /// @}
 
   /// @{
+  /// Queue the simple action `Action` on the `Component` labeled by
+  /// `array_index`.
+  template <typename Component, typename Action, typename Arg0,
+            typename... Args>
+  void queue_simple_action(const typename Component::array_index& array_index,
+                           Arg0&& arg0, Args&&... args) {
+    mock_distributed_objects<Component>()
+        .at(array_index)
+        .template simple_action<Action>(
+            std::make_tuple(std::forward<Arg0>(arg0),
+                            std::forward<Args>(args)...),
+            false);
+  }
+
+  template <typename Component, typename Action>
+  void queue_simple_action(const typename Component::array_index& array_index) {
+    mock_distributed_objects<Component>()
+        .at(array_index)
+        .template simple_action<Action>(false);
+  }
+  /// @}
+
+  /// @{
   /// Invoke the threaded action `Action` on the `Component` labeled by
   /// `array_index` immediately.
   template <typename Component, typename Action, typename Arg0,

--- a/tests/Unit/Framework/MockRuntimeSystemFreeFunctions.hpp
+++ b/tests/Unit/Framework/MockRuntimeSystemFreeFunctions.hpp
@@ -290,6 +290,17 @@ void simple_action(
       array_index, std::forward<Args>(args)...);
 }
 
+/// Queues the simple action `Action` on the `array_index`th element of the
+/// parallel component `Component`.
+template <typename Component, typename Action, typename Metavariables,
+          typename... Args>
+void queue_simple_action(
+    const gsl::not_null<MockRuntimeSystem<Metavariables>*> runner,
+    const typename Component::array_index& array_index, Args&&... args) {
+  runner->template queue_simple_action<Component, Action>(
+      array_index, std::forward<Args>(args)...);
+}
+
 /// Runs the simple action `Action` on the `array_index`th element of the
 /// parallel component `Component`.
 template <typename Component, typename Action, typename Metavariables,

--- a/tests/Unit/Framework/Tests/Test_ActionTesting.cpp
+++ b/tests/Unit/Framework/Tests/Test_ActionTesting.cpp
@@ -275,8 +275,13 @@ SPECTRE_TEST_CASE("Unit.ActionTesting.MockSimpleAction", "[Unit]") {
   // [invoke queued simple action]
   CHECK(db::get<PassedToB>(box) == 2);
   CHECK(db::get<ValueTag>(box) == 25);
-  runner.simple_action<component_for_simple_action_mock<metavars>,
-                       simple_action_b>(0, 1);
+  REQUIRE(runner.is_simple_action_queue_empty<
+          component_for_simple_action_mock<metavars>>(0));
+  runner.queue_simple_action<component_for_simple_action_mock<metavars>,
+                             simple_action_b>(0, 1);
+  runner
+      .invoke_queued_simple_action<component_for_simple_action_mock<metavars>>(
+          0);
   REQUIRE(not runner.is_simple_action_queue_empty<
               component_for_simple_action_mock<metavars>>(0));
   runner
@@ -527,7 +532,9 @@ SPECTRE_TEST_CASE("Unit.ActionTesting.MockComponent", "[Unit]") {
   ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
   CHECK(ActionTesting::get_databox_tag<component_b_mock, ValueTag>(runner, 0) ==
         0);
-  ActionTesting::simple_action<component_a, CallActionOnComponentB>(
+  ActionTesting::queue_simple_action<component_a, CallActionOnComponentB>(
+      make_not_null(&runner), 0);
+  ActionTesting::invoke_queued_simple_action<component_a>(
       make_not_null(&runner), 0);
   // [component b mock checks]
   CHECK(not ActionTesting::is_simple_action_queue_empty<component_b_mock>(

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_EvaluateRefinementCriteria.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_EvaluateRefinementCriteria.cpp
@@ -1,0 +1,233 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <unordered_set>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Domain/Structure/OrientationMap.hpp"
+#include "Domain/Tags.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "ParallelAlgorithms/Amr/Actions/EvaluateRefinementCriteria.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Random.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/StdHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+
+// when called on the specified refinement level, this criteria
+// always will choose to join
+auto create_always_join(const size_t refinement_level) {
+  return std::make_unique<amr::Criteria::Random>(1.0, refinement_level);
+}
+
+// when called on any refinement level, this criteria always will choose to do
+// nothing
+auto create_always_do_nothing() {
+  return std::make_unique<amr::Criteria::Random>(
+      0.0, ElementId<3>::max_refinement_level);
+}
+
+template <typename Metavariables>
+struct Component {
+  using metavariables = Metavariables;
+  static constexpr size_t volume_dim = Metavariables::volume_dim;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementId<volume_dim>;
+  using const_global_cache_tags = tmpl::list<amr::Criteria::Tags::Criteria>;
+  using simple_tags = tmpl::list<domain::Tags::Element<volume_dim>,
+                                 amr::domain::Tags::Flags<volume_dim>,
+                                 amr::domain::Tags::NeighborFlags<volume_dim>>;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      Parallel::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>>;
+};
+
+struct Metavariables {
+  static constexpr size_t volume_dim = 1;
+
+  using component_list = tmpl::list<Component<Metavariables>>;
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<amr::Criterion, tmpl::list<amr::Criteria::Random>>>;
+  };
+};
+
+// When AMR is run, the simple action EvaluateAmrCriteria is run on each
+// Element.  EvaluateAmrCriteria evaluates the criteria which set its own
+// amr::domain::Tags::Flags and then calls the simple action UpdateAmrDecision
+// on each neighboring Element of the Element sending the Flags.
+// UpdateAmrDecision checks to see if an Elements Flags need to change based on
+// the received NeighborFlags (e.g. if and element wants to join, but its
+// sibling does not the element must change its decision to do nothing).  If the
+// element's Flags are changed, then it calls UpdateAmrDecision on its
+// neighbors, and the process continues until no Element wants to change its
+// decision.   This test manually runs this process on three elements until
+// EvaluateAmrCriteria has been called on each Element.  Note in a asynchronus
+// parallel environment, it is possible for an Element to execute
+// UpdateAmrDecision (triggered by a neighboring Element) prior to executing
+// EvaluateAmrCriteria
+void evaluate_criteria(std::vector<std::unique_ptr<amr::Criterion>> criteria,
+                       const std::array<amr::domain::Flag, 1> expected_flags) {
+  using my_component = Component<Metavariables>;
+
+  const ElementId<1> self_id(0, {{{1, 1}}});
+  const ElementId<1> lo_id(0, {{{1, 0}}});
+  const ElementId<1> up_id(1, {{{1, 0}}});
+
+  std::unordered_map<ElementId<1>, std::array<amr::domain::Flag, 1>>
+      initial_neighbor_flags;
+
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{{std::move(criteria)}};
+
+  const Element<1> self(self_id, {{{Direction<1>::lower_xi(), {{lo_id}, {}}},
+                                   {Direction<1>::upper_xi(), {{up_id}, {}}}}});
+  ActionTesting::emplace_component_and_initialize<my_component>(
+      &runner, self_id,
+      {self, std::array{amr::domain::Flag::Undefined}, initial_neighbor_flags});
+
+  const auto emplace_neighbor = [&self_id, &runner, &initial_neighbor_flags](
+                                    const ElementId<1>& id,
+                                    const Direction<1>& direction) {
+    const Element<1> element(id, {{direction, {{self_id}, {}}}});
+    ActionTesting::emplace_component_and_initialize<my_component>(
+        &runner, id,
+        {element, std::array{amr::domain::Flag::Undefined},
+         initial_neighbor_flags});
+  };
+
+  emplace_neighbor(up_id, Direction<1>::lower_xi());
+  emplace_neighbor(lo_id, Direction<1>::upper_xi());
+
+  runner.set_phase(Parallel::Phase::Testing);
+
+  for (const auto& id : {self_id, lo_id, up_id}) {
+    CHECK(ActionTesting::get_databox_tag<my_component,
+                                         amr::domain::Tags::Flags<1>>(
+              runner, id) == std::array{amr::domain::Flag::Undefined});
+    CHECK(ActionTesting::get_databox_tag<my_component,
+                                         amr::domain::Tags::NeighborFlags<1>>(
+              runner, id) == initial_neighbor_flags);
+    CHECK(
+        ActionTesting::is_simple_action_queue_empty<my_component>(runner, id));
+  }
+
+  // self runs EvaluateAmrCriteria, queueing UpdateAmrDecision on lo and hi
+  ActionTesting::simple_action<my_component,
+                               amr::Actions::EvaluateRefinementCriteria>(
+      make_not_null(&runner), self_id);
+
+  for (const auto& id : {self_id, lo_id, up_id}) {
+    CHECK(ActionTesting::get_databox_tag<my_component,
+                                         amr::domain::Tags::Flags<1>>(
+              runner, id) == (id == self_id
+                                  ? expected_flags
+                                  : std::array{amr::domain::Flag::Undefined}));
+    CHECK(ActionTesting::get_databox_tag<my_component,
+                                         amr::domain::Tags::NeighborFlags<1>>(
+              runner, id) == initial_neighbor_flags);
+    CHECK(ActionTesting::number_of_queued_simple_actions<my_component>(
+              runner, id) == (id == self_id ? 0 : 1));
+  }
+
+  // lo runs EvaluateAmrCriteria, queuing UpdateAmrDecision on self
+  ActionTesting::simple_action<my_component,
+                               amr::Actions::EvaluateRefinementCriteria>(
+      make_not_null(&runner), lo_id);
+
+  for (const auto& id : {self_id, lo_id, up_id}) {
+    CHECK(ActionTesting::get_databox_tag<my_component,
+                                         amr::domain::Tags::Flags<1>>(
+              runner, id) == (id == up_id
+                                  ? std::array{amr::domain::Flag::Undefined}
+                                  : expected_flags));
+    CHECK(ActionTesting::get_databox_tag<my_component,
+                                         amr::domain::Tags::NeighborFlags<1>>(
+              runner, id) == initial_neighbor_flags);
+    CHECK(ActionTesting::number_of_queued_simple_actions<my_component>(
+              runner, id) == 1);
+  }
+
+  // up runs UpdateAmrDecision, which queues nothing
+  ActionTesting::invoke_queued_simple_action<my_component>(
+      make_not_null(&runner), up_id);
+  for (const auto& id : {self_id, lo_id, up_id}) {
+    CHECK(ActionTesting::get_databox_tag<my_component,
+                                         amr::domain::Tags::Flags<1>>(
+              runner, id) == (id == up_id
+                                  ? std::array{amr::domain::Flag::Undefined}
+                                  : expected_flags));
+    CHECK(
+        ActionTesting::get_databox_tag<my_component,
+                                       amr::domain::Tags::NeighborFlags<1>>(
+            runner, id) ==
+        (id == up_id
+             ? std::unordered_map<ElementId<1>, std::array<amr::domain::Flag,
+                                                           1>>{{self_id,
+                                                                expected_flags}}
+             : initial_neighbor_flags));
+    CHECK(ActionTesting::number_of_queued_simple_actions<my_component>(
+              runner, id) == (id == up_id ? 0 : 1));
+  }
+
+  // up runs EvaluateAmrCriteria, queueing UpdateAmrDecision on self
+  ActionTesting::simple_action<my_component,
+                               amr::Actions::EvaluateRefinementCriteria>(
+      make_not_null(&runner), up_id);
+
+  for (const auto& id : {self_id, lo_id, up_id}) {
+    CHECK(ActionTesting::get_databox_tag<my_component,
+                                         amr::domain::Tags::Flags<1>>(
+              runner, id) == expected_flags);
+    CHECK(
+        ActionTesting::get_databox_tag<my_component,
+                                       amr::domain::Tags::NeighborFlags<1>>(
+            runner, id) ==
+        (id == up_id
+             ? std::unordered_map<ElementId<1>, std::array<amr::domain::Flag,
+                                                           1>>{{self_id,
+                                                                expected_flags}}
+             : initial_neighbor_flags));
+    CHECK(ActionTesting::number_of_queued_simple_actions<my_component>(
+              runner, id) == (id == self_id ? 2 : (id == lo_id ? 1 : 0)));
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Amr.Actions.EvaluateRefinementCriteria",
+                  "[Unit][ParallelAlgorithms]") {
+  Parallel::register_factory_classes_with_charm<Metavariables>();
+  std::vector<std::unique_ptr<amr::Criterion>> criteria;
+  // Run the test 3 times, twice with a single criterion that give known
+  // decisions, and then once with two criteria, one of which always produces
+  // flags of a higher priority than the other
+  criteria.emplace_back(create_always_join(1));
+  evaluate_criteria(std::move(criteria), std::array{amr::domain::Flag::Join});
+  criteria.clear();
+  criteria.emplace_back(create_always_do_nothing());
+  criteria.emplace_back(create_always_join(1));
+  evaluate_criteria(std::move(criteria),
+                    std::array{amr::domain::Flag::DoNothing});
+  criteria.clear();
+  criteria.emplace_back(create_always_join(1));
+  criteria.emplace_back(create_always_do_nothing());
+  evaluate_criteria(std::move(criteria),
+                    std::array{amr::domain::Flag::DoNothing});
+}

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_UpdateAmrDecision.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_UpdateAmrDecision.cpp
@@ -1,0 +1,267 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <unordered_set>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Domain/Structure/OrientationMap.hpp"
+#include "Domain/Tags.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "ParallelAlgorithms/Amr/Actions/UpdateAmrDecision.hpp"
+#include "Utilities/StdHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+
+template <typename Metavariables>
+struct Component {
+  using metavariables = Metavariables;
+  static constexpr size_t volume_dim = Metavariables::volume_dim;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementId<volume_dim>;
+  using const_global_cache_tags = tmpl::list<>;
+  using simple_tags = tmpl::list<domain::Tags::Element<volume_dim>,
+                                 amr::domain::Tags::Flags<volume_dim>,
+                                 amr::domain::Tags::NeighborFlags<volume_dim>>;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      Parallel::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>>;
+};
+
+struct Metavariables {
+  static constexpr size_t volume_dim = 1;
+  using component_list = tmpl::list<Component<Metavariables>>;
+};
+
+void check(
+    const ActionTesting::MockRuntimeSystem<Metavariables>& runner,
+    const ElementId<1>& id,
+    const std::array<amr::domain::Flag, 1>& expected_flags,
+    const std::unordered_map<ElementId<1>, std::array<amr::domain::Flag, 1>>&
+        expected_neighbor_flags,
+    const size_t expected_queued_actions) {
+  using my_component = Component<Metavariables>;
+  CHECK(
+      ActionTesting::get_databox_tag<my_component, amr::domain::Tags::Flags<1>>(
+          runner, id) == expected_flags);
+  CHECK(ActionTesting::get_databox_tag<my_component,
+                                       amr::domain::Tags::NeighborFlags<1>>(
+            runner, id) == expected_neighbor_flags);
+  CHECK(ActionTesting::number_of_queued_simple_actions<my_component>(
+            runner, id) == expected_queued_actions);
+}
+
+// When AMR is run, the simple action EvaluateAmrCriteria is run on each
+// Element.  EvaluateAmrCriteria evaluates the criteria which determine the
+// amr::domain::Tags::Flags of the Element, and then calls the simple action
+// UpdateAmrDecision on each neighboring Element of the Element sending the
+// Flags. UpdateAmrDecision checks to see if an Elements Flags need to change
+// based on the received NeighborFlags (e.g. if and element wants to join, but
+// its sibling does not the element must change its decision to do nothing).  If
+// the element's Flags are changed, then it calls UpdateAmrDecision on its
+// neighbors, and the process continues until no Element wants to change its
+// decision.   This test manually runs this process on three elements assuming
+// each Element has already evaluted its own Flags with the ones passed to
+// emplace_component_and_initialize.
+void test() {
+  using my_component = Component<Metavariables>;
+
+  const ElementId<1> self_id(0, {{{2, 1}}});
+  const ElementId<1> sibling_id(0, {{{2, 0}}});
+  const ElementId<1> cousin_id(1, {{{2, 2}}});
+
+  std::unordered_map<ElementId<1>, std::array<amr::domain::Flag, 1>>
+      initial_neighbor_flags{};
+
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{{}};
+
+  const Element<1> self(self_id,
+                        {{{Direction<1>::lower_xi(), {{sibling_id}, {}}},
+                          {Direction<1>::upper_xi(), {{cousin_id}, {}}}}});
+  ActionTesting::emplace_component_and_initialize<my_component>(
+      &runner, self_id,
+      {self, std::array{amr::domain::Flag::Join}, initial_neighbor_flags});
+
+  const Element<1> sibling(sibling_id,
+                           {{{Direction<1>::upper_xi(), {{self_id}, {}}}}});
+  ActionTesting::emplace_component_and_initialize<my_component>(
+      &runner, sibling_id,
+      {sibling, std::array{amr::domain::Flag::Join}, initial_neighbor_flags});
+
+  const Element<1> cousin(cousin_id,
+                          {{{Direction<1>::lower_xi(), {{self_id}, {}}}}});
+  ActionTesting::emplace_component_and_initialize<my_component>(
+      &runner, cousin_id,
+      {cousin, std::array{amr::domain::Flag::Split}, initial_neighbor_flags});
+
+  check(runner, self_id, {{amr::domain::Flag::Join}}, {}, 0);
+  check(runner, sibling_id, {{amr::domain::Flag::Join}}, {}, 0);
+  check(runner, cousin_id, {{amr::domain::Flag::Split}}, {}, 0);
+
+  ActionTesting::simple_action<my_component, amr::Actions::UpdateAmrDecision>(
+      make_not_null(&runner), self_id, sibling_id,
+      std::array{amr::domain::Flag::Join});
+  // sibling told self it wants to join, no further action triggered
+  check(runner, self_id, {{amr::domain::Flag::Join}},
+        {{sibling_id, {{amr::domain::Flag::Join}}}}, 0);
+  check(runner, sibling_id, {{amr::domain::Flag::Join}}, {}, 0);
+  check(runner, cousin_id, {{amr::domain::Flag::Split}}, {}, 0);
+
+  ActionTesting::simple_action<my_component, amr::Actions::UpdateAmrDecision>(
+      make_not_null(&runner), sibling_id, self_id,
+      std::array{amr::domain::Flag::Join});
+  // self told sibling it wants to join, no further action triggered
+  check(runner, self_id, {{amr::domain::Flag::Join}},
+        {{sibling_id, {{amr::domain::Flag::Join}}}}, 0);
+  check(runner, sibling_id, {{amr::domain::Flag::Join}},
+        {{self_id, {{amr::domain::Flag::Join}}}}, 0);
+  check(runner, cousin_id, {{amr::domain::Flag::Split}}, {}, 0);
+
+  ActionTesting::simple_action<my_component, amr::Actions::UpdateAmrDecision>(
+      make_not_null(&runner), cousin_id, self_id,
+      std::array{amr::domain::Flag::Join});
+  // self told cousin it wants to join, no further action triggered
+  check(runner, self_id, {{amr::domain::Flag::Join}},
+        {{sibling_id, {{amr::domain::Flag::Join}}}}, 0);
+  check(runner, sibling_id, {{amr::domain::Flag::Join}},
+        {{self_id, {{amr::domain::Flag::Join}}}}, 0);
+  check(runner, cousin_id, {{amr::domain::Flag::Split}},
+        {{self_id, {{amr::domain::Flag::Join}}}}, 0);
+
+  ActionTesting::simple_action<my_component, amr::Actions::UpdateAmrDecision>(
+      make_not_null(&runner), self_id, cousin_id,
+      std::array{amr::domain::Flag::Split});
+  // cousin told self it wants to split; in order to maintain 2:1 refinement,
+  // self changes its decision to DoNothing and triggers actions to notify its
+  // neighbors
+  check(runner, self_id, {{amr::domain::Flag::DoNothing}},
+        {{sibling_id, {{amr::domain::Flag::Join}}},
+         {cousin_id, {{amr::domain::Flag::Split}}}},
+        0);
+  check(runner, sibling_id, {{amr::domain::Flag::Join}},
+        {{self_id, {{amr::domain::Flag::Join}}}}, 1);
+  check(runner, cousin_id, {{amr::domain::Flag::Split}},
+        {{self_id, {{amr::domain::Flag::Join}}}}, 1);
+
+  ActionTesting::invoke_queued_simple_action<my_component>(
+      make_not_null(&runner), sibling_id);
+  // self told sibling it wants to DoNothing, so sibling changes its decision to
+  // DoNothing and triggers actions to notify its neighbors
+  check(runner, self_id, {{amr::domain::Flag::DoNothing}},
+        {{sibling_id, {{amr::domain::Flag::Join}}},
+         {cousin_id, {{amr::domain::Flag::Split}}}},
+        1);
+  check(runner, sibling_id, {{amr::domain::Flag::DoNothing}},
+        {{self_id, {{amr::domain::Flag::DoNothing}}}}, 0);
+  check(runner, cousin_id, {{amr::domain::Flag::Split}},
+        {{self_id, {{amr::domain::Flag::Join}}}}, 1);
+
+  ActionTesting::invoke_queued_simple_action<my_component>(
+      make_not_null(&runner), cousin_id);
+  // self told cousin it wants to DoNothing, no further action triggered
+  check(runner, self_id, {{amr::domain::Flag::DoNothing}},
+        {{sibling_id, {{amr::domain::Flag::Join}}},
+         {cousin_id, {{amr::domain::Flag::Split}}}},
+        1);
+  check(runner, sibling_id, {{amr::domain::Flag::DoNothing}},
+        {{self_id, {{amr::domain::Flag::DoNothing}}}}, 0);
+  check(runner, cousin_id, {{amr::domain::Flag::Split}},
+        {{self_id, {{amr::domain::Flag::DoNothing}}}}, 0);
+
+  ActionTesting::invoke_queued_simple_action<my_component>(
+      make_not_null(&runner), self_id);
+  // sibling told self it wants to DoNothing, no further action triggered
+  check(runner, self_id, {{amr::domain::Flag::DoNothing}},
+        {{sibling_id, {{amr::domain::Flag::DoNothing}}},
+         {cousin_id, {{amr::domain::Flag::Split}}}},
+        0);
+  check(runner, sibling_id, {{amr::domain::Flag::DoNothing}},
+        {{self_id, {{amr::domain::Flag::DoNothing}}}}, 0);
+  check(runner, cousin_id, {{amr::domain::Flag::Split}},
+        {{self_id, {{amr::domain::Flag::DoNothing}}}}, 0);
+}
+
+// This test checks that asynchronus execution of simple actions is handled
+// correctly in case UpdateAmrDecision is called on an Element before
+// EvaluateAmrCriteria, or if two calls to UpdateAmrDecision are triggered by
+// receiving messages from a neighbor in the opposite order in which they were
+// sent
+void test_race_conditions() {
+  using my_component = Component<Metavariables>;
+
+  const ElementId<1> self_id(0, {{{2, 1}}});
+  const ElementId<1> sibling_id(0, {{{2, 0}}});
+  const ElementId<1> cousin_id(1, {{{2, 2}}});
+
+  std::unordered_map<ElementId<1>, std::array<amr::domain::Flag, 1>>
+      initial_neighbor_flags{};
+
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{{}};
+
+  const Element<1> self(self_id,
+                        {{{Direction<1>::lower_xi(), {{sibling_id}, {}}},
+                          {Direction<1>::upper_xi(), {{cousin_id}, {}}}}});
+  ActionTesting::emplace_component_and_initialize<my_component>(
+      &runner, self_id,
+      {self, std::array{amr::domain::Flag::Split},
+       std::unordered_map<ElementId<1>, std::array<amr::domain::Flag, 1>>{
+           {cousin_id, {{amr::domain::Flag::Split}}}}});
+
+  const Element<1> sibling(sibling_id,
+                           {{{Direction<1>::upper_xi(), {{self_id}, {}}}}});
+  ActionTesting::emplace_component_and_initialize<my_component>(
+      &runner, sibling_id,
+      {sibling, std::array{amr::domain::Flag::Undefined},
+       initial_neighbor_flags});
+
+  const Element<1> cousin(cousin_id,
+                          {{{Direction<1>::lower_xi(), {{self_id}, {}}}}});
+  ActionTesting::emplace_component_and_initialize<my_component>(
+      &runner, cousin_id,
+      {cousin, std::array{amr::domain::Flag::Split}, initial_neighbor_flags});
+
+  ActionTesting::simple_action<my_component, amr::Actions::UpdateAmrDecision>(
+      make_not_null(&runner), sibling_id, self_id,
+      std::array{amr::domain::Flag::Split});
+  // self told sibling it wants to split, but sibling hasn't evaluated its own
+  // flags, store the received flags and exit
+  check(runner, sibling_id, {{amr::domain::Flag::Undefined}},
+        {{self_id, {{amr::domain::Flag::Split}}}}, 0);
+  check(runner, self_id, {{amr::domain::Flag::Split}},
+        {{cousin_id, {{amr::domain::Flag::Split}}}}, 0);
+  check(runner, cousin_id, {{amr::domain::Flag::Split}}, initial_neighbor_flags,
+        0);
+
+  ActionTesting::simple_action<my_component, amr::Actions::UpdateAmrDecision>(
+      make_not_null(&runner), self_id, cousin_id,
+      std::array{amr::domain::Flag::DoNothing});
+  // cousin first chose to do nothing, then chose to split, but the messages
+  // were received in the reverse order. Therefore we ignore the lower priority
+  // message of doing nothing.
+  check(runner, sibling_id, {{amr::domain::Flag::Undefined}},
+        {{self_id, {{amr::domain::Flag::Split}}}}, 0);
+  check(runner, self_id, {{amr::domain::Flag::Split}},
+        {{cousin_id, {{amr::domain::Flag::Split}}}}, 0);
+  check(runner, cousin_id, {{amr::domain::Flag::Split}}, initial_neighbor_flags,
+        0);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Amr.Actions.UpdateAmrDecision",
+                  "[Unit][ParallelAlgorithms]") {
+  test();
+  test_race_conditions();
+}

--- a/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -4,7 +4,9 @@
 set(LIBRARY "Test_ParallelAmr")
 
 set(LIBRARY_SOURCES
+  Actions/Test_EvaluateRefinementCriteria.cpp
   Actions/Test_Initialize.cpp
+  Actions/Test_UpdateAmrDecision.cpp
   Criteria/Test_Random.cpp
   )
 

--- a/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_ParallelAmr")
 
 set(LIBRARY_SOURCES
   Actions/Test_Initialize.cpp
+  Criteria/Test_Random.cpp
   )
 
 add_test_library(
@@ -18,6 +19,7 @@ target_link_libraries(
   ${LIBRARY}
   PRIVATE
   Amr
+  AmrCriteria
   DomainStructure
   Utilities
   )

--- a/tests/Unit/ParallelAlgorithms/Amr/Criteria/Test_Random.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Criteria/Test_Random.cpp
@@ -1,0 +1,135 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <memory>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/SegmentId.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Random.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+template <size_t VolumeDim>
+struct Metavariables {
+  static constexpr size_t volume_dim = VolumeDim;
+  using component_list = tmpl::list<>;
+  using const_global_cache_tags = tmpl::list<>;
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<amr::Criterion, tmpl::list<amr::Criteria::Random>>>;
+  };
+};
+struct TestComponent {};
+
+template <size_t VolumeDim>
+void test_criterion(const amr::Criterion& criterion) {
+  Parallel::GlobalCache<Metavariables<VolumeDim>> empty_cache{};
+  ObservationBox<tmpl::list<>, db::DataBox<tmpl::list<>>> empty_box{};
+
+  ElementId<VolumeDim> root_id{0};
+  auto flags = criterion.evaluate(empty_box, empty_cache, root_id);
+  for (size_t d = 0; d < VolumeDim; ++d) {
+    CHECK((flags[d] == amr::domain::Flag::Split or
+           flags[d] == amr::domain::Flag::DoNothing));
+  }
+  for (size_t level = 1; level < 5; ++level) {
+    ElementId<VolumeDim> id{0, make_array<VolumeDim>(SegmentId(level, 1))};
+    flags = criterion.evaluate(empty_box, empty_cache, id);
+    for (size_t d = 0; d < VolumeDim; ++d) {
+      CHECK((flags[d] == amr::domain::Flag::Split or
+             flags[d] == amr::domain::Flag::DoNothing or
+             flags[d] == amr::domain::Flag::Join));
+    }
+  }
+  ElementId<VolumeDim> id{0, make_array<VolumeDim>(SegmentId(5, 1))};
+  flags = criterion.evaluate(empty_box, empty_cache, id);
+  for (size_t d = 0; d < VolumeDim; ++d) {
+    CHECK((flags[d] == amr::domain::Flag::Join or
+           flags[d] == amr::domain::Flag::DoNothing));
+  }
+}
+
+template <size_t VolumeDim>
+void test_always_change_refinement() {
+  const amr::Criteria::Random criterion(1.0, 5);
+  Parallel::GlobalCache<Metavariables<VolumeDim>> empty_cache{};
+  ObservationBox<tmpl::list<>, db::DataBox<tmpl::list<>>> empty_box{};
+
+  ElementId<VolumeDim> root_id{0};
+  auto flags = criterion.evaluate(empty_box, empty_cache, root_id);
+  for (size_t d = 0; d < VolumeDim; ++d) {
+    CHECK(flags[d] == amr::domain::Flag::Split);
+  }
+  for (size_t level = 1; level < 5; ++level) {
+    ElementId<VolumeDim> id{0, make_array<VolumeDim>(SegmentId(level, 1))};
+    flags = criterion.evaluate(empty_box, empty_cache, id);
+    for (size_t d = 0; d < VolumeDim; ++d) {
+      CHECK((flags[d] == amr::domain::Flag::Split or
+             flags[d] == amr::domain::Flag::Join));
+    }
+  }
+  ElementId<VolumeDim> id{0, make_array<VolumeDim>(SegmentId(5, 1))};
+  flags = criterion.evaluate(empty_box, empty_cache, id);
+  for (size_t d = 0; d < VolumeDim; ++d) {
+    CHECK(flags[d] == amr::domain::Flag::Join);
+  }
+}
+
+template <size_t VolumeDim>
+void test_always_do_nothing() {
+  const amr::Criteria::Random criterion(0.0, 5);
+
+  Parallel::GlobalCache<Metavariables<VolumeDim>> empty_cache{};
+  ObservationBox<tmpl::list<>, db::DataBox<tmpl::list<>>> empty_box{};
+
+  for (size_t level = 0; level <= 5; ++level) {
+    ElementId<VolumeDim> id{0, make_array<VolumeDim>(SegmentId(level, 0))};
+    auto flags = criterion.evaluate(empty_box, empty_cache, id);
+    for (size_t d = 0; d < VolumeDim; ++d) {
+      CHECK(flags[d] == amr::domain::Flag::DoNothing);
+    }
+  }
+}
+
+template <size_t VolumeDim>
+void test() {
+  Parallel::register_factory_classes_with_charm<Metavariables<VolumeDim>>();
+  test_always_change_refinement<VolumeDim>();
+  test_always_do_nothing<VolumeDim>();
+  const amr::Criteria::Random random_criterion(0.8, 5);
+  test_criterion<VolumeDim>(random_criterion);
+  test_criterion<VolumeDim>(serialize_and_deserialize(random_criterion));
+
+  const auto criterion =
+      TestHelpers::test_creation<std::unique_ptr<amr::Criterion>,
+                                 Metavariables<VolumeDim>>(
+          "Random:\n"
+          "  ChangeRefinementFraction: 0.8\n"
+          "  MaximumRefinementLevel: 5\n");
+  test_criterion<VolumeDim>(*criterion);
+  test_criterion<VolumeDim>(*serialize_and_deserialize(criterion));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Amr.Criteria.Random", "[Unit][ParallelAlgorithms]") {
+  TestHelpers::db::test_simple_tag<amr::Criteria::Tags::Criteria>("Criteria");
+  test<1>();
+  test<2>();
+  test<3>();
+}


### PR DESCRIPTION
## Proposed changes

- Add a base class for AMR criteria and a derived class that randomly chooses a decision (useful for testing)
- Add an action that will evaluate all chosen AMR criteria and make a unique decision on an Element
- Add an action that will receive the AMR decision of a neighbor, and if necessary, update the decision of an Element

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
