### PR TITLE
Switch away from Boost Newton-Raphson implementation

### DIFF
--- a/src/Domain/CoordinateMaps/TimeDependent/CubicScale.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/CubicScale.cpp
@@ -187,12 +187,9 @@ std::optional<std::array<double, Dim>> CubicScale<Dim>::inverse(
   // the CubicEquation solver: ~ 480 ns
   // boost implemented Newton-Raphson: ~ 280 ns
   // minimal Newton-Raphson from Numerical Recipes: ~ 255 ns
-  // Despite the minimal Newton-Raphson being more efficient than the boost
-  // version, here we utilize the boost implementation, as it includes
-  // additional checks for zero derivative, checks on bounds, and can implement
-  // bisection if necessary.
   const double scale_factor =
-      RootFinder::newton_raphson(cubic_and_deriv, initial_guess, 0.0, 1.0, 14) /
+      RootFinder::newton_raphson(cubic_and_deriv, initial_guess, 0.0, 1.0,
+                                 1.0e-14, 1.0e-14, 0.0) /
       target_dimensionless_radius;
 
   std::array<double, Dim> result{};

--- a/src/Domain/CoordinateMaps/UniformCylindricalEndcap.cpp
+++ b/src/Domain/CoordinateMaps/UniformCylindricalEndcap.cpp
@@ -566,11 +566,11 @@ std::optional<std::array<double, 3>> UniformCylindricalEndcap::inverse(
           2.0 * function_at_rhobar_min / deriv_function_at_rhobar_min;
       try {
         // We have a good guess, so use newton_raphson
-        const size_t digits = 14;
         // use rhobar_min as maximum value, since that brackets the root.
         rhobar =
             RootFinder::newton_raphson(function_and_deriv_to_zero, rhobar_min,
-                                       new_rhobar_min, rhobar_min, digits);
+                                       new_rhobar_min, rhobar_min, 0.0, 1.0e-14,
+                                       0.0);
       } catch (std::exception&) {
         const double function_at_new_rhobar_min =
             function_to_zero(new_rhobar_min);
@@ -595,11 +595,11 @@ std::optional<std::array<double, 3>> UniformCylindricalEndcap::inverse(
           2.0 * function_at_rhobar_max / deriv_function_at_rhobar_max;
       try {
         // We have a good guess, so use newton_raphson
-        const size_t digits = 14;
         // use rhobar_max as minimum value, since that brackets the root.
         rhobar =
             RootFinder::newton_raphson(function_and_deriv_to_zero, rhobar_max,
-                                       rhobar_max, new_rhobar_max, digits);
+                                       rhobar_max, new_rhobar_max, 0.0, 1.0e-14,
+                                       0.0);
       } catch (std::exception&) {
         const double function_at_new_rhobar_max =
             function_to_zero(new_rhobar_max);

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/M1Closure.cpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/M1Closure.cpp
@@ -64,9 +64,8 @@ void compute_closure_impl(
   static constexpr double small_velocity = 1.e-15;
   // Dimension of spatial tensors
   constexpr size_t spatial_dim = 3;
-  // Number of significant digits used in the rootfinding rooting
-  // used to find the closure factor
-  constexpr size_t root_find_number_of_digits = 6;
+  // Tolerance used in the root finding used to find the closure
+  // factor
   constexpr double root_find_tolerance = 1.e-6;
   Variables<
       tmpl::list<hydro::Tags::LorentzFactorSquared<DataVector>, MomentumSquared,
@@ -244,8 +243,8 @@ void compute_closure_impl(
         get(*closure_factor)[s] = 1.;
       } else {
         get(*closure_factor)[s] = RootFinder::newton_raphson(
-            zeta_j_sqr_minus_h_sqr, zeta_guess, 1.e-15, 1.,
-            root_find_number_of_digits);
+            zeta_j_sqr_minus_h_sqr, zeta_guess, 1.e-15, 1., 0.0,
+            root_find_tolerance, 0.0);
       }
 
       // Assemble output quantities:

--- a/src/NumericalAlgorithms/Spectral/Legendre.cpp
+++ b/src/NumericalAlgorithms/Spectral/Legendre.cpp
@@ -134,8 +134,10 @@ compute_collocation_points_and_weights<Basis::Legendre, Quadrature::Gauss>(
             newton_raphson_step,
             // Initial guess
             -cos((2. * j + 1.) * M_PI / (2. * poly_degree + 2.)),
-            // Lower and upper bound, and number of desired base-10 digits
-            -1., 1., 14);
+            -cos((2. * j) * M_PI / (2. * poly_degree + 2.)),
+            -cos((2. * j + 2.) * M_PI / (2. * poly_degree + 2.)),
+            // Tolerances
+            0.0, 1.0e-14, 0.0);
         const LegendrePolynomialAndDerivative L_and_dL(poly_degree + 1,
                                                        logical_coord);
         x[j] = logical_coord;
@@ -223,8 +225,8 @@ std::pair<DataVector, DataVector> compute_collocation_points_and_weights<
             // Initial guess
             -cos((j + 0.25) * M_PI / poly_degree -
                  0.375 / (poly_degree * M_PI * (j + 0.25))),
-            // Lower and upper bound, and number of desired base-10 digits
-            -1., 1., 14);
+            // Lower and upper bound, and tolerances.
+            -1., 1., 0.0, 1.0e-14, 0.0);
         const EvaluateQandL q_and_L(poly_degree, logical_coord);
         x[j] = logical_coord;
         x[poly_degree - j] = -logical_coord;

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/RiemannProblem.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/RiemannProblem.cpp
@@ -180,7 +180,7 @@ RiemannProblem<Dim>::RiemannProblem(
     try {
       pressure_star_ = RootFinder::newton_raphson(
           f_of_p_and_deriv, guess_for_pressure_star, pressure_lower,
-          pressure_upper, -log10(pressure_star_tol_));
+          pressure_upper, 0.0, pressure_star_tol_, 0.0);
     } catch (std::exception& exception) {
       ERROR(
           "Failed to find p_* with Newton-Raphson root finder. Got "

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/RiemannProblem.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/RiemannProblem.cpp
@@ -144,38 +144,51 @@ RiemannProblem<Dim>::RiemannProblem(
   const double f_max =
       f_of_p_left(p_minmax.second) + f_of_p_right(p_minmax.second) + delta_u;
 
-  double pressure_lower = std::numeric_limits<double>::signaling_NaN();
-  double pressure_upper = std::numeric_limits<double>::signaling_NaN();
   if (f_min > 0.0 and f_max > 0.0) {
-    pressure_lower = 0.0;
-    pressure_upper = p_minmax.first;
-  } else if (f_min < 0.0 and f_max > 0.0) {
-    pressure_lower = p_minmax.first;
-    pressure_upper = p_minmax.second;
+    const double exponent = 0.5 * (adiabatic_index_ - 1.0) / adiabatic_index_;
+    pressure_star_ = std::pow(
+        (left_initial_data_.sound_speed_ + right_initial_data_.sound_speed_ -
+         0.5 * (adiabatic_index_ - 1.0) * delta_u) /
+            (left_initial_data_.sound_speed_ *
+                 std::pow(left_initial_data_.pressure_, -exponent) +
+             right_initial_data_.sound_speed_ *
+                 std::pow(right_initial_data_.pressure_, -exponent)),
+        1.0 / exponent);
+    ASSERT(std::abs(f_of_p_left(pressure_star_) + f_of_p_right(pressure_star_) +
+                    delta_u) < 1.0e-8,
+           "Failed to analytically solve correctly.");
   } else {
-    pressure_lower = p_minmax.second;
-    pressure_upper = 10.0 * pressure_lower;  // Arbitrary upper bound < \infty
-  }
+    double pressure_lower = std::numeric_limits<double>::signaling_NaN();
+    double pressure_upper = std::numeric_limits<double>::signaling_NaN();
+    if (f_min < 0.0 and f_max > 0.0) {
+      pressure_lower = p_minmax.first;
+      pressure_upper = p_minmax.second;
+    } else {
+      pressure_lower = p_minmax.second;
+      pressure_upper = 10.0 * pressure_lower;  // Arbitrary upper bound < \infty
+    }
 
-  // Now get pressure by solving transcendental equation. Newton-Raphson is OK.
-  const auto f_of_p_and_deriv = [&f_of_p_left, &f_of_p_right,
-                                 &delta_u](const double pressure) {
-    // Function of pressure in Eqn. (4.5) of Toro.
-    return std::make_pair(
-        f_of_p_left(pressure) + f_of_p_right(pressure) + delta_u,
-        f_of_p_left.deriv(pressure) + f_of_p_right.deriv(pressure));
-  };
-  try {
-    pressure_star_ = RootFinder::newton_raphson(
-        f_of_p_and_deriv, guess_for_pressure_star, pressure_lower,
-        pressure_upper, -log10(pressure_star_tol_));
-  } catch (std::exception& exception) {
-    ERROR(
-        "Failed to find p_* with Newton-Raphson root finder. Got "
-        "exception message:\n"
-        << exception.what()
-        << "\nIf the residual is small you can change the tolerance for the "
-           "root finder in the input file.");
+    // Now get pressure by solving transcendental
+    // equation. Newton-Raphson is OK.
+    const auto f_of_p_and_deriv = [&f_of_p_left, &f_of_p_right,
+                                   &delta_u](const double pressure) {
+      // Function of pressure in Eqn. (4.5) of Toro.
+      return std::make_pair(
+          f_of_p_left(pressure) + f_of_p_right(pressure) + delta_u,
+          f_of_p_left.deriv(pressure) + f_of_p_right.deriv(pressure));
+    };
+    try {
+      pressure_star_ = RootFinder::newton_raphson(
+          f_of_p_and_deriv, guess_for_pressure_star, pressure_lower,
+          pressure_upper, -log10(pressure_star_tol_));
+    } catch (std::exception& exception) {
+      ERROR(
+          "Failed to find p_* with Newton-Raphson root finder. Got "
+          "exception message:\n"
+          << exception.what()
+          << "\nIf the residual is small you can change the tolerance for the "
+             "root finder in the input file.");
+    }
   }
 
   // Calculated p_*, u_* is obtained from Eqn. (4.9) in Toro.

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/RiemannProblem.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/RiemannProblem.cpp
@@ -35,7 +35,6 @@ struct FunctionOfPressureAndData {
     prefactor_ = 2.0 * data.sound_speed_ / (adiabatic_index_ - 1.0);
     prefactor_deriv_ = data.sound_speed_ / adiabatic_index_ / state_pressure_;
     exponent_ = 0.5 * (adiabatic_index_ - 1.0) / adiabatic_index_;
-    exponent_deriv_ = -0.5 * (adiabatic_index_ + 1.0) / adiabatic_index_;
   }
 
   double operator()(const double pressure) const {
@@ -55,7 +54,8 @@ struct FunctionOfPressureAndData {
                ? 0.5 * sqrt(constant_a_) *
                      (pressure + state_pressure_ + 2.0 * constant_b_) /
                      pow(pressure + constant_b_, 1.5)
-               : prefactor_deriv_ * pow(pressure / state_pressure_, exponent_);
+               : prefactor_deriv_ *
+                     pow(pressure / state_pressure_, exponent_ - 1.0);
   }
 
  private:
@@ -68,7 +68,6 @@ struct FunctionOfPressureAndData {
   double prefactor_ = std::numeric_limits<double>::signaling_NaN();
   double prefactor_deriv_ = std::numeric_limits<double>::signaling_NaN();
   double exponent_ = std::numeric_limits<double>::signaling_NaN();
-  double exponent_deriv_ = std::numeric_limits<double>::signaling_NaN();
 };
 
 }  // namespace

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/ConstantDensityStar.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/ConstantDensityStar.cpp
@@ -40,9 +40,9 @@ double compute_alpha(const double density, const double radius) {
                 pow<2>(pow_2_one_plus_a_square)};
       },
       // Choose initial guess for no particular reason
-      2. * sqrt(5.), sqrt(5.), std::numeric_limits<double>::max(),
+      1.0 / alpha_source, sqrt(5.), 1.0 / alpha_source,
       // Choose a precision of 14 base-10 digits for no particular reason
-      14);
+      0.0, 1.0e-14, 0.0);
 }
 
 template <typename DataType>

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.cpp
@@ -101,7 +101,8 @@ double kerr_schild_areal_radius_from_isotropic(const double isotropic_radius,
                 isotropic_radius,
             kerr_schild_isotropic_radius_from_areal_deriv(areal_radius, mass));
       },
-      isotropic_radius, 0., std::numeric_limits<double>::max(), 12);
+      isotropic_radius, isotropic_radius, isotropic_radius + mass, 0.0, 1.0e-12,
+      0.0);
 }
 
 DataVector kerr_schild_areal_radius_from_isotropic(
@@ -113,10 +114,8 @@ DataVector kerr_schild_areal_radius_from_isotropic(
                 isotropic_radius[i],
             kerr_schild_isotropic_radius_from_areal_deriv(areal_radius, mass));
       },
-      isotropic_radius, make_with_value<DataVector>(isotropic_radius, 0.),
-      make_with_value<DataVector>(isotropic_radius,
-                                  std::numeric_limits<double>::max()),
-      12);
+      isotropic_radius, isotropic_radius, isotropic_radius + mass, 0.0, 1.0e-12,
+      0.0);
 }
 }  // namespace
 

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.cpp
@@ -442,11 +442,11 @@ double Enthalpy<LowDensityEoS>::rest_mass_density_from_enthalpy(
           1.0 / density * evaluate_coefficients(derivative_coefficients_, x);
       return std::make_pair(f, df);
     };
-    const size_t digits = 14;
+    const double tolerance = 1.0e-14;
     const double intial_guess = 0.5 * (minimum_density_ + maximum_density_);
     const auto root_from_lambda = RootFinder::newton_raphson(
-        f_df_lambda, intial_guess, reference_density_, maximum_density_,
-        digits);
+        f_df_lambda, intial_guess, reference_density_, maximum_density_, 0.0,
+        tolerance, 0.0);
     return root_from_lambda;
   }
 }

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Spectral.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Spectral.cpp
@@ -281,10 +281,11 @@ double Spectral::rest_mass_density_from_enthalpy(
                         (density * density) * this->gamma(x);
       return std::make_pair(f, df);
     };
-    const size_t digits = 14;
+    const double tolerance = 1.0e-14;
     const double intial_guess = 0.5 * (reference_density_ + upper_density);
     const auto root_from_lambda = RootFinder::newton_raphson(
-        f_df_lambda, intial_guess, reference_density_, upper_density, digits);
+        f_df_lambda, intial_guess, reference_density_, upper_density, 0.0,
+        tolerance, 0.0);
     return root_from_lambda;
   }
 }

--- a/tests/Unit/NumericalAlgorithms/RootFinding/Test_NewtonRaphson.cpp
+++ b/tests/Unit/NumericalAlgorithms/RootFinding/Test_NewtonRaphson.cpp
@@ -3,7 +3,6 @@
 
 #include "Framework/TestingFramework.hpp"
 
-#include <boost/math/tools/roots.hpp>
 #include <cmath>
 #include <cstddef>
 #include <utility>
@@ -14,8 +13,6 @@
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/ErrorHandling/Exceptions.hpp"
-#include "Utilities/Gsl.hpp"
-#include "Utilities/MakeString.hpp"
 
 namespace {
 std::pair<double, double> func_and_deriv_free(double x) {
@@ -29,7 +26,9 @@ struct FuncAndDeriv {
 
 void test_simple() {
   // [double_newton_raphson_root_find]
-  const size_t digits = 8;
+  const double residual_tolerance = 1.0e-14;
+  const double step_absolute_tolerance = 1.0e-8;
+  const double step_relative_tolerance = 0.0;
   const double correct = sqrt(2.);
   const double guess = 1.5;
   const double lower = 1.;
@@ -38,20 +37,25 @@ void test_simple() {
     return std::make_pair(2. - square(x), -2. * x);
   };
   const auto root_from_lambda = RootFinder::newton_raphson(
-      func_and_deriv_lambda, guess, lower, upper, digits);
+      func_and_deriv_lambda, guess, lower, upper, residual_tolerance,
+      step_absolute_tolerance, step_relative_tolerance);
   // [double_newton_raphson_root_find]
   const auto root_from_free = RootFinder::newton_raphson(
-      func_and_deriv_free, guess, lower, upper, digits);
+      func_and_deriv_free, guess, lower, upper, residual_tolerance,
+      step_absolute_tolerance, step_relative_tolerance);
   const FuncAndDeriv func_and_deriv_functor{};
   const auto root_from_functor = RootFinder::newton_raphson(
-      func_and_deriv_functor, guess, lower, upper, digits);
-  CHECK(std::abs(root_from_lambda - correct) < 1.0 / std::pow(10, digits));
+      func_and_deriv_functor, guess, lower, upper, residual_tolerance,
+      step_absolute_tolerance, step_relative_tolerance);
+  CHECK(std::abs(root_from_lambda - correct) <= step_absolute_tolerance);
   CHECK(root_from_free == root_from_lambda);
   CHECK(root_from_free == root_from_functor);
 }
 
 void test_bounds() {
-  const size_t digits = 8;
+  const double residual_tolerance = 1.0e-14;
+  const double step_absolute_tolerance = 1.0e-8;
+  const double step_relative_tolerance = 0.0;
   const double guess = 1.5;
   double upper = 2.;
   double lower = sqrt(2.);
@@ -59,23 +63,27 @@ void test_bounds() {
     return std::make_pair(2. - square(x), -2. * x);
   };
 
-  auto root = RootFinder::newton_raphson(func_and_deriv_lambda, guess, lower,
-                                         upper, digits);
+  auto root = RootFinder::newton_raphson(
+      func_and_deriv_lambda, guess, lower, upper, residual_tolerance,
+      step_absolute_tolerance, step_relative_tolerance);
   const double correct = sqrt(2.);
 
-  CHECK(std::abs(root - correct) < 1.0 / std::pow(10, digits));
+  CHECK(std::abs(root - correct) < step_absolute_tolerance);
 
   lower = 0.;
   upper = sqrt(2.);
 
   root = RootFinder::newton_raphson(func_and_deriv_lambda, guess, lower, upper,
-                                    digits);
-  CHECK(std::abs(root - correct) < 1.0 / std::pow(10, digits));
+                                    residual_tolerance, step_absolute_tolerance,
+                                    step_relative_tolerance);
+  CHECK(std::abs(root - correct) < step_absolute_tolerance);
 }
 
 void test_datavector() {
   // [datavector_newton_raphson_root_find]
-  const size_t digits = 8;
+  const double residual_tolerance = 1.0e-14;
+  const double step_absolute_tolerance = 1.0e-8;
+  const double step_relative_tolerance = 0.0;
   const DataVector guess{1.6, 1.9, -1.6, -1.9};
   const DataVector lower{sqrt(2.), sqrt(2.), -2., -3.};
   const DataVector upper{2., 3., -sqrt(2.), -sqrt(2.)};
@@ -86,97 +94,176 @@ void test_datavector() {
     return std::make_pair(constant[i] - square(x), -2. * x);
   };
 
-  const auto root = RootFinder::newton_raphson(func_and_deriv_lambda, guess,
-                                               lower, upper, digits);
+  const auto root = RootFinder::newton_raphson(
+      func_and_deriv_lambda, guess, lower, upper, residual_tolerance,
+      step_absolute_tolerance, step_relative_tolerance);
   // [datavector_newton_raphson_root_find]
 
   const DataVector correct{sqrt(2.), 2., -sqrt(2.), -2.};
 
   for (size_t i = 0; i < guess.size(); i++) {
-    CHECK(std::abs(root[i] - correct[i]) < 1.0 / std::pow(10, digits));
+    CHECK(std::abs(root[i] - correct[i]) < step_absolute_tolerance);
   }
 }
 
 void test_convergence_error_double() {
   const size_t max_iterations = 2;
-  const size_t digits = 8;
+  const double residual_tolerance = 1.0e-14;
+  const double step_absolute_tolerance = 1.0e-8;
+  const double step_relative_tolerance = 0.0;
   const double guess = 1.5;
   const double lower = 1.;
   const double upper = 2.;
-  boost::uintmax_t max_iters = max_iterations;
 
   const auto func_and_deriv = [](double x) {
     return std::make_pair(2. - square(x), -2. * x);
   };
 
-  // Exception message is expected to print the "best" result, so here
-  // we obtain that result directly with boost, as RootFinder::newton_raphson
-  // would throw an exception.
-  // clang-tidy: internal boost warning, can't fix it.
-  const auto best_result =
-      boost::math::tools::newton_raphson_iterate(  // NOLINT
-          func_and_deriv, guess, lower, upper,
-          std::round(std::log2(std::pow(10, digits))), max_iters);
-  test_throw_exception(
-      [&func_and_deriv, &guess, &lower, &upper, &max_iters]() {
-        RootFinder::newton_raphson(func_and_deriv, guess, lower, upper, digits,
-                                   max_iters);
-      },
-      convergence_error(MakeString{}
-                        << "newton_raphson reached max iterations of "
-                        << max_iterations
-                        << " without converging. Best result is: "
-                        << best_result << " with residual "
-                        << func_and_deriv(best_result).first));
+  CHECK_THROWS_AS(
+      RootFinder::newton_raphson(func_and_deriv, guess, lower, upper,
+                                 residual_tolerance, step_absolute_tolerance,
+                                 step_relative_tolerance, max_iterations),
+      convergence_error);
 }
 
-void test_convergence_error_datavector() {
-  const size_t max_iterations = 2;
-  const size_t digits = 8;
-  const auto digits_binary = std::round(std::log2(std::pow(10, digits)));
-  const DataVector lower{sqrt(2.), sqrt(2.), -2., -3.};
-  const DataVector upper{2., 3., -sqrt(2.), -sqrt(2.)};
-  const DataVector constant{2., 4., 2., 4.};
+void test_bad_guess() {
+  // We switched away from the Boost implementation because it failed in
+  // some cases where the guess was bad.  This is one such case.
+  {
+    const auto quartic = [](const double x) {
+      return std::make_pair((x * x - 1.0) * (x * x + 0.1),
+                            2.0 * x * ((x * x - 1.0) + (x * x + 0.1)));
+    };
 
-  const auto func_and_deriv = [&constant](const double x, const size_t i) {
-    return std::make_pair(constant[i] - square(x), -2. * x);
-  };
+    const double result =
+        RootFinder::newton_raphson(quartic, 0.5, 0.1, 1.1, 0.0, 1.0e-5, 0.0);
+    CHECK(std::abs(result - 1.0) < 1.0e-5);
+  }
 
-  // We test with different guesses, the difference being the location of the
-  // element in the DataVector expected to throw the exception.
-  const std::array<DataVector, 4> guess{{{1.6, 1.9, -1.6, -1.9},
-                                         {sqrt(2.), 1.9, -1.6, -1.9},
-                                         {sqrt(2.), 2.0, -1.6, -1.9},
-                                         {sqrt(2.), 2.0, -sqrt(2.), -1.9}}};
-  for (size_t i = 0; i < guess.size(); ++i) {
-    const DataVector& current_guess = gsl::at(guess, i);
-    // Exception message is expected to print the "best" result, so here
-    // we obtain that result directly with boost, as RootFinder::newton_raphson
-    // would throw an exception.
-    DataVector best_result_vector{lower.size()};
-    for (size_t s = 0; s < best_result_vector.size(); ++s) {
-      boost::uintmax_t max_iters = max_iterations;
-      // clang-tidy: internal boost warning, can't fix it.
-      best_result_vector[s] =
-          boost::math::tools::newton_raphson_iterate(  // NOLINT
-              [&func_and_deriv, s](double x) { return func_and_deriv(x, s); },
-              current_guess[s], lower[s], upper[s], digits_binary, max_iters);
-    }
-    for (size_t s = 0; s < best_result_vector.size(); ++s) {
-      boost::uintmax_t max_iters = max_iterations;
-      test_throw_exception(
-          [&func_and_deriv, &current_guess, &lower, &upper, &max_iters]() {
-            RootFinder::newton_raphson(func_and_deriv, current_guess, lower,
-                                       upper, digits, max_iters);
-          },
-          convergence_error(MakeString{}
-                            << "newton_raphson reached max iterations of "
-                            << max_iterations
-                            << " without converging. Best result is: "
-                            << best_result_vector[i] << " with residual "
-                            << func_and_deriv(best_result_vector[i], i).first));
+  // Verify that a really ugly function works.
+  {
+    const auto ugly = [](const double x) {
+      const double a = x * x - 20.0;
+      const double da = 2.0 * x;
+      const double b = sin(6.0 * x) + 1.1;
+      const double db = 6.0 * cos(6.0 * x);
+      return std::make_pair(a * b, a * db + da * b);
+    };
+    const double correct = sqrt(20.0);
+    const double tolerance = 1.0e-6;
+    Approx ugly_approx = Approx::custom().epsilon(tolerance).scale(1.0);
+
+    const double trials = 101.0;
+    for (double i = 0.0; i <= trials; ++i) {
+      CHECK(RootFinder::newton_raphson(ugly, i / trials, 0.0, 10.0, 0.0,
+                                       tolerance, 0.0) == ugly_approx(correct));
     }
   }
+}
+
+void test_convergence_reasons() {
+  double correct = 0.5;
+  const auto f = [&correct](const double x) {
+    const double x_off = x - correct + sqrt(2.0);
+    return std::make_pair(x_off * x_off - 2.0, 2.0 * x_off);
+  };
+
+  // Convergence: Absolute tolerance
+  {
+    const double root_from_small_tolerance =
+        RootFinder::newton_raphson(f, 1.0, 0.0, 5.0, 0.0, 1.0e-10, 0.0);
+    const double root_from_large_tolerance =
+        RootFinder::newton_raphson(f, 1.0, 0.0, 5.0, 0.0, 1.0e-1, 0.0);
+    CHECK(std::abs(root_from_small_tolerance - correct) < 1.0e-10);
+    CHECK(std::abs(root_from_large_tolerance - correct) < 1.0e-1);
+    // The convergence tolerances checked are usually good estimates
+    // of the error in the /previous/ step, so the actual returned
+    // value is often much more accurate than required.  Check that
+    // the smaller tolerance gave a more accurate result, without
+    // worrying about exactly how accurate.
+    CHECK(std::abs(root_from_small_tolerance - correct) <
+          std::abs(root_from_large_tolerance - correct));
+  }
+
+  // Convergence: Relative tolerance (and comparing to absolute)
+  {
+    correct = 1.0e-2;
+    const double large_absolute =
+        RootFinder::newton_raphson(f, 0.5, -1.0, 1.0, 0.0, 1.0e-1, 0.0);
+    const double small_absolute =
+        RootFinder::newton_raphson(f, 0.5, -1.0, 1.0, 0.0, 1.0e-6, 0.0);
+    const double large_relative =
+        RootFinder::newton_raphson(f, 0.5, -1.0, 1.0, 0.0, 0.0, 1.0e-1);
+    const double small_relative =
+        RootFinder::newton_raphson(f, 0.5, -1.0, 1.0, 0.0, 0.0, 1.0e-10);
+    CHECK(std::abs(large_absolute - correct) < 1.0e-1);
+    CHECK(std::abs(small_absolute - correct) < 1.0e-6);
+    CHECK(std::abs(large_relative - correct) < 1.0e-3);
+    CHECK(std::abs(small_relative - correct) < 1.0e-12);
+    // The convergence tolerances checked are usually good estimates
+    // of the error in the /previous/ step, so the actual returned
+    // value is often much more accurate than required.  Check that
+    // the smaller tolerance gave a more accurate result, without
+    // worrying about exactly how accurate.
+    CHECK(std::abs(small_absolute - correct) <
+          std::abs(large_absolute - correct));
+    CHECK(std::abs(small_relative - correct) <
+          std::abs(large_relative - correct));
+  }
+
+  // Residual
+  {
+    correct = 1.0;
+    const double large_residual =
+        RootFinder::newton_raphson(f, 0.5, 0.0, 5.0, 1.0e-1, 0.0, 0.0);
+    const double small_residual =
+        RootFinder::newton_raphson(f, 0.5, 0.0, 5.0, 1.0e-8, 0.0, 0.0);
+    CHECK(std::abs(f(large_residual).first) < 1.0e-1);
+    CHECK(std::abs(f(large_residual).first) > 1.0e-8);
+    CHECK(std::abs(f(small_residual).first) < 1.0e-8);
+  }
+}
+
+void test_convergence_rate() {
+  int call_count = 0;
+  const auto smooth_f = [&call_count](const double x) {
+    ++call_count;
+    return std::make_pair(x * x - 2.0, 2.0 * x);
+  };
+  const double correct = sqrt(2.0);
+
+  // Find the correction to counts from assertion checks to make sure
+  // the test gives the same behavior in both build modes.
+
+  // Finding the root with a huge residual tolerance should only
+  // require one evaluation.
+  call_count = 0;
+  RootFinder::newton_raphson(smooth_f, 2.0, 0.0, 5.0, 1000.0, 0.0, 0.0);
+  const int assertion_correction = call_count - 1;
+#ifdef SPECTRE_DEBUG
+  CHECK(assertion_correction != 0);
+#else   // SPECTRE_DEBUG
+  CHECK(assertion_correction == 0);
+#endif  // SPECTRE_DEBUG
+
+  call_count = 0;
+  const double inaccurate =
+      RootFinder::newton_raphson(smooth_f, 2.0, 0.0, 5.0, 1e-3, 0.0, 0.0);
+  const int inaccurate_calls = call_count - assertion_correction;
+
+  call_count = 0;
+  const double accurate =
+      RootFinder::newton_raphson(smooth_f, 2.0, 0.0, 5.0, 1.0e-8, 0.0, 0.0);
+  const int accurate_calls = call_count - assertion_correction;
+  CHECK(accurate_calls > inaccurate_calls);
+  // Try to avoid being roundoff-dominated.
+  REQUIRE(std::abs(accurate - correct) > 1.0e-14);
+
+  // error_{n+1} ~ error_n^p  with  p ~ 2
+  CHECK(pow(log(std::abs(accurate - correct)) /
+                log(std::abs(inaccurate - correct)),
+            1.0 / (accurate_calls - inaccurate_calls)) ==
+        Approx::custom().margin(0.1)(2.0));
 }
 
 SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.NewtonRaphson",
@@ -185,49 +272,8 @@ SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.NewtonRaphson",
   test_bounds();
   test_datavector();
   test_convergence_error_double();
-  test_convergence_error_datavector();
-}
-
-// [[OutputRegex, The desired accuracy of 100 base-10 digits must be smaller]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.Numerical.RootFinding.NewtonRaphson.Digits.Double",
-    "[NumericalAlgorithms][RootFinding][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  const size_t digits = 100;
-  const double guess = 1.5;
-  double lower = 1.;
-  double upper = 2.;
-  const auto func_and_deriv_lambda = [](double x) {
-    return std::make_pair(2. - square(x), -2. * x);
-  };
-
-  RootFinder::newton_raphson(func_and_deriv_lambda, guess, lower, upper,
-                             digits);
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// [[OutputRegex, The desired accuracy of 100 base-10 digits must be smaller]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.Numerical.RootFinding.NewtonRaphson.Digits.DataVector",
-    "[NumericalAlgorithms][RootFinding][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  const size_t digits = 100;
-  const DataVector guess{1.6, 1.9, -1.6, -1.9};
-  const DataVector lower{sqrt(2.), sqrt(2.), -2., -3.};
-  const DataVector upper{2., 3., -sqrt(2.), -sqrt(2.)};
-  const DataVector constant{2., 4., 2., 4.};
-
-  const auto func_and_deriv_lambda = [&constant](const double x,
-                                                 const size_t i) {
-    return std::make_pair(constant[i] - square(x), -2. * x);
-  };
-
-  RootFinder::newton_raphson(func_and_deriv_lambda, guess, lower, upper,
-                             digits);
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
+  test_bad_guess();
+  test_convergence_reasons();
+  test_convergence_rate();
 }
 }  // namespace

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/RiemannProblem.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/RiemannProblem.py
@@ -72,8 +72,8 @@ def shock(x_shifted, t, quantity, quantity_star, adiabatic_index,
 def mass_density(x, t, adiabatic_index, initial_pos, l_mass_density,
                  l_velocity, l_pressure, r_mass_density, r_velocity,
                  r_pressure):
-    velocity_star = 0.9274526526
-    pressure_star = 0.3031302631
+    velocity_star = 0.927452620048950
+    pressure_star = 0.303130178050647
 
     # density in star region for shock
     gamma_mm_over_gamma_pp = (adiabatic_index - 1.0) / (adiabatic_index + 1.0)
@@ -98,8 +98,8 @@ def mass_density(x, t, adiabatic_index, initial_pos, l_mass_density,
 
 def velocity(x, t, adiabatic_index, initial_pos, l_mass_density, l_velocity,
              l_pressure, r_mass_density, r_velocity, r_pressure):
-    velocity_star = 0.9274526526
-    pressure_star = 0.3031302631
+    velocity_star = 0.927452620048950
+    pressure_star = 0.303130178050647
 
     velocity = np.zeros(x.size)
     x_shifted = x[0] - initial_pos
@@ -121,8 +121,8 @@ def velocity(x, t, adiabatic_index, initial_pos, l_mass_density, l_velocity,
 
 def pressure(x, t, adiabatic_index, initial_pos, l_mass_density, l_velocity,
              l_pressure, r_mass_density, r_velocity, r_pressure):
-    velocity_star = 0.9274526526
-    pressure_star = 0.3031302631
+    velocity_star = 0.927452620048950
+    pressure_star = 0.303130178050647
 
     x_shifted = x[0] - initial_pos
     return (rarefaction(x_shifted, t, l_pressure, pressure_star,

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_RiemannProblem.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_RiemannProblem.cpp
@@ -203,21 +203,3 @@ SPECTRE_TEST_CASE(
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
-
-// [[OutputRegex, newton_raphson reached max iterations of 50 without
-// converging.]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticSolutions.NewtEuler.RiemannProblem.RootF",
-    "[Unit][PointwiseFunctions]") {
-  ERROR_TEST();
-  TestHelpers::test_creation<NewtonianEuler::Solutions::RiemannProblem<1>>(
-      "AdiabaticIndex: 1.4\n"
-      "InitialPosition: 0.25\n"
-      "LeftMassDensity: 10.0\n"
-      "LeftVelocity: [0.0]\n"
-      "LeftPressure: 100.0\n"
-      "RightMassDensity: 1.0\n"
-      "RightVelocity: [0.0]\n"
-      "RightPressure: 1.0\n"
-      "PressureStarTol: 1.e-10");
-}

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_RiemannProblem.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_RiemannProblem.cpp
@@ -52,7 +52,7 @@ void test_solution(const std::array<double, Dim> left_velocity,
   // Member variables correspond to Sod tube test. For other test cases,
   // new parameters in the star region must be given in the python modules.
   RiemannProblemProxy<Dim> solution(1.4, 0.5, 1.0, left_velocity, 1.0, 0.125,
-                                    right_velocity, 0.1, 1.e-6);
+                                    right_velocity, 0.1, 1.e-9);
   pypp::check_with_random_values<1>(
       &RiemannProblemProxy<Dim>::template primitive_variables<DataType>,
       solution, "RiemannProblem",
@@ -76,11 +76,11 @@ void test_solution(const std::array<double, Dim> left_velocity,
       right_velocity_opt +
       "\n"
       "RightPressure: 0.1\n"
-      "PressureStarTol: 1.e-6");
+      "PressureStarTol: 1.e-9");
   CHECK(solution_from_options == solution);
 
   RiemannProblemProxy<Dim> solution_to_move(1.4, 0.5, 1.0, left_velocity, 1.0,
-                                            0.125, right_velocity, 0.1, 1.e-6);
+                                            0.125, right_velocity, 0.1, 1.e-9);
   test_move_semantics(std::move(solution_to_move), solution);  //  NOLINT
   test_serialization(solution);
   test_copy_semantics(solution);


### PR DESCRIPTION
The boost implementation [does not fall back to bisection correctly](https://github.com/boostorg/math/issues/808).  (I believe it only works properly for monotonic functions.)  This replaces it with an `rtsafe`-like one.  Since we can't use NR code directly, I've taken the decision criteria from there, but otherwise redone the implementation.  The biggest difference from `rtsafe` is this version defers constructing a bisection bracket until necessary, which for good initial guesses is likely never.  (The passed bracket is checked for validity in Debug builds.)

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
