### PR TITLE
Add LinearRegression.

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -14,6 +14,7 @@ spectre_target_sources(
   CubicSpline.cpp
   IrregularInterpolant.cpp
   LinearLeastSquares.cpp
+  LinearRegression.cpp
   LinearSpanInterpolator.cpp
   PolynomialInterpolation.cpp
   PredictedZeroCrossing.cpp
@@ -32,6 +33,7 @@ spectre_target_headers(
   IrregularInterpolant.hpp
   LagrangePolynomial.hpp
   LinearLeastSquares.hpp
+  LinearRegression.hpp
   LinearSpanInterpolator.hpp
   PolynomialInterpolation.hpp
   PredictedZeroCrossing.hpp

--- a/src/NumericalAlgorithms/Interpolation/LinearRegression.cpp
+++ b/src/NumericalAlgorithms/Interpolation/LinearRegression.cpp
@@ -1,0 +1,41 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Interpolation/LinearRegression.hpp"
+
+#include <cmath>
+#include <gsl/gsl_fit.h>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace intrp {
+template <typename T>
+LinearRegressionResult linear_regression(const T& x_values, const T& y_values) {
+  ASSERT(x_values.size() == y_values.size(),
+         "Size mismatch: " << x_values.size() << " vs " << y_values.size());
+  LinearRegressionResult result{0.0, 0.0, 0.0, 0.0};
+  double cov01 = 0.0;  // Off-diagonal component of covariance matrix.
+  double sumsq = 0.0;  // Sum of the squares of residuals of the best fit.
+  gsl_fit_linear(x_values.data(), 1, y_values.data(), 1, x_values.size(),
+                 &result.intercept, &result.slope, &result.delta_intercept,
+                 &cov01, &result.delta_slope, &sumsq);
+  // After gsl_fit_linear is called, result.delta_intercept and
+  // result.delta_slope hold diagonal components of the covariance matrix.  But
+  // the error bars are the sqrt of those diagonal components, so take those
+  // sqrts here.
+  result.delta_intercept = sqrt(result.delta_intercept);
+  result.delta_slope = sqrt(result.delta_slope);
+  return result;
+}
+}  // namespace intrp
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define INSTANTIATE(_, data)                                       \
+  template intrp::LinearRegressionResult intrp::linear_regression( \
+      const DTYPE(data) & x_values, const DTYPE(data) & y_values);
+GENERATE_INSTANTIATIONS(INSTANTIATE, (std::vector<double>, DataVector))
+#undef INSTANTIATE
+#undef DTYPE

--- a/src/NumericalAlgorithms/Interpolation/LinearRegression.hpp
+++ b/src/NumericalAlgorithms/Interpolation/LinearRegression.hpp
@@ -1,0 +1,33 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace intrp {
+
+struct LinearRegressionResult {
+  double intercept;
+  double slope;
+  double delta_intercept;
+  double delta_slope;
+};
+
+/*!
+ * \ingroup NumericalAlgorithmsGroup
+ * \brief A linear regression function.
+ *
+ * A wrapper for gsl linear regression.
+ * Fits the data to \f$y = m x + b\f$. Returns a struct
+ * containing \f$(b, m, \delta b, \delta m)\f$, where
+ * \f$\delta b\f$ and \f$\delta m\f$ are the error bars in \f$b\f$ and
+ * \f$m\f$.  The error bars are computed assuming unknown errors in \f$y\f$.
+ *
+ * linear_regression could be implemented by calling
+ * LinearLeastSquares using Order=1, but we choose instead to
+ * implement linear_regression in a simpler way, by calling a simpler gsl
+ * function that involves no memory allocations, no copying, and no
+ * `pow` functions.
+ */
+template <typename T>
+LinearRegressionResult linear_regression(const T& x_values, const T& y_values);
+}  // namespace intrp

--- a/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIBRARY_SOURCES
   Test_IrregularInterpolant.cpp
   Test_LagrangePolynomial.cpp
   Test_LinearLeastSquares.cpp
+  Test_LinearRegression.cpp
   Test_PolynomialInterpolation.cpp
   Test_PredictedZeroCrossing.cpp
   Test_RegularGridInterpolant.cpp

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_LinearRegression.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_LinearRegression.cpp
@@ -1,0 +1,78 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <random>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/Interpolation/LinearRegression.hpp"
+
+namespace {
+
+void test_linear_regression_datavector(const double expected_intercept,
+                                       const double expected_slope) {
+  const DataVector x_values{1.0, 2.0, 3.0, 4.0, 5.0};
+  const DataVector y_values = expected_slope * x_values + expected_intercept;
+  const auto result = intrp::linear_regression(x_values, y_values);
+
+  CHECK(result.intercept == approx(expected_intercept));
+  CHECK(result.slope == approx(expected_slope));
+  // Error bars are zero because we have exactly a straight line.
+  CHECK(result.delta_intercept == approx(0.0));
+  CHECK(result.delta_slope == approx(0.0));
+}
+
+void test_linear_regression_stdvectordouble(const double expected_intercept,
+                                            const double expected_slope) {
+  const std::vector<double> x_values{1.0, 2.0, 3.0, 4.0, 5.0};
+  std::vector<double> y_values;
+  for (size_t i = 0; i < x_values.size(); ++i) {
+    y_values.push_back(expected_slope * x_values[i] + expected_intercept);
+  }
+  const auto result = intrp::linear_regression(x_values, y_values);
+
+  CHECK(result.intercept == approx(expected_intercept));
+  CHECK(result.slope == approx(expected_slope));
+  // Error bars are zero because we have exactly a straight line.
+  CHECK(result.delta_intercept == approx(0.0));
+  CHECK(result.delta_slope == approx(0.0));
+}
+
+void test_linear_regression_error_bars() {
+  const DataVector x_values{1.0, 2.0, 3.0};
+  const DataVector y_values{2.0, 4.0, 5.0};
+
+  const auto result = intrp::linear_regression(x_values, y_values);
+  // The values below were worked out by hand for the above 3 points.
+  CHECK(result.intercept == approx(2.0 / 3.0));
+  CHECK(result.slope == approx(3.0 / 2.0));
+  CHECK(result.delta_intercept == approx(sqrt(7.0 / 18.0)));
+  CHECK(result.delta_slope == approx(sqrt(1.0 / 12.0)));
+}
+
+void test_linear_regression() {
+  // Set up random number generator
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> coeff_dis(-10.0, 10.0);
+
+  const double intercept = coeff_dis(gen);
+  CAPTURE(intercept);
+  const double slope = coeff_dis(gen);
+  CAPTURE(slope);
+
+  test_linear_regression_stdvectordouble(intercept, slope);
+  test_linear_regression_datavector(intercept, slope);
+  test_linear_regression_error_bars();
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Numerical.Interpolation.LinearRegression",
+                  "[Unit][NumericalAlgorithms]") {
+  test_linear_regression();
+}


### PR DESCRIPTION
## Proposed changes

Add a linear_regression function that wraps a gsl function.
This will be used for the zero crossing predictor.
This is simpler than using LinearLeastSquares, which does more memory allocations, pow functions,
and so on because it uses a more general algorithm for arbitrary polynomial fits.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
