### PR TITLE
Change PredictedZeroCrossing algorithm.

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/PredictedZeroCrossing.cpp
+++ b/src/NumericalAlgorithms/Interpolation/PredictedZeroCrossing.cpp
@@ -3,18 +3,49 @@
 
 #include "NumericalAlgorithms/Interpolation/PredictedZeroCrossing.hpp"
 
+#include <algorithm>
 #include <deque>
 #include <vector>
 
-#include "NumericalAlgorithms/Interpolation/LinearLeastSquares.hpp"
+#include "NumericalAlgorithms/Interpolation/LinearRegression.hpp"
 
 namespace intrp {
 
 double predicted_zero_crossing_value(const std::vector<double>& x_values,
                                      const std::vector<double>& y_values) {
-  intrp::LinearLeastSquares<1> predictor{x_values.size()};
-  const auto coefficients = predictor.fit_coefficients(x_values, y_values);
-  return -coefficients[0]/coefficients[1];
+  ASSERT(*std::max_element(x_values.begin(), x_values.end()) <= 0.0,
+         "predicted_zero_crossing_value assumes that the x values are "
+         "non-positive. This assumption is not necessary for the fit, but "
+         "it is necessary to make sense of the special treatment of the "
+         "return type for when the error bars are large.");
+
+  const auto [intercept, slope, delta_intercept, delta_slope] =
+      linear_regression(x_values, y_values);
+
+  // See the doxygen comments for details of the implementation.
+  // For now, set all the x's to zero if denominators are zero.
+  const double x_best_fit = slope == 0.0 ? 0.0 : -intercept / slope;
+  const double x0 =
+      slope + delta_slope == 0.0
+          ? 0.0
+          : -(intercept - delta_intercept) / (slope + delta_slope);
+  const double x1 =
+      slope + delta_slope == 0.0
+          ? 0.0
+          : -(intercept + delta_intercept) / (slope + delta_slope);
+  const double x2 =
+      slope - delta_slope == 0.0
+          ? 0.0
+          : -(intercept - delta_intercept) / (slope - delta_slope);
+  const double x3 =
+      slope - delta_slope == 0.0
+          ? 0.0
+          : -(intercept + delta_intercept) / (slope - delta_slope);
+  if ((x_best_fit > 0.0 and x1 > 0.0 and x2 > 0.0 and x3 > 0.0 and x0 > 0.0) or
+      (x_best_fit < 0.0 and x1 < 0.0 and x2 < 0.0 and x3 < 0.0 and x0 < 0.0)) {
+    return x_best_fit;
+  }
+  return 0.0;  // That is, assign no crossing value at all
 }
 
 DataVector predicted_zero_crossing_value(
@@ -22,17 +53,15 @@ DataVector predicted_zero_crossing_value(
     const std::deque<DataVector>& y_values) {
   ASSERT(x_values.size() == y_values.size(),
          "The x_values and y_values must be of the same size");
-  intrp::LinearLeastSquares<1> predictor{x_values.size()};
-
   DataVector result(y_values.front().size());
-  std::deque<double> tmp_y_values(x_values.size());
+
+  const std::vector<double> tmp_x_values(x_values.begin(), x_values.end());
+  std::vector<double> tmp_y_values(x_values.size());
   for (size_t i = 0; i < result.size(); i++) {
     for (size_t j = 0; j < tmp_y_values.size(); j++) {
       tmp_y_values[j] = y_values[j][i];
     }
-    const auto coefficients =
-        predictor.fit_coefficients(x_values, tmp_y_values);
-    result[i] = -coefficients[0] / coefficients[1];
+    result[i] = predicted_zero_crossing_value(tmp_x_values, tmp_y_values);
   }
 
   return result;

--- a/src/NumericalAlgorithms/Interpolation/PredictedZeroCrossing.hpp
+++ b/src/NumericalAlgorithms/Interpolation/PredictedZeroCrossing.hpp
@@ -15,28 +15,46 @@ namespace intrp {
  *
  * Fits a linear function to a set of y_values at different x_values
  * and uses the fit to predict what x_value the y_value zero will be crossed.
+ *
+ * predicted_zero_crossing treats x=0 in a special way: All of the
+ * x_values must be non-positive; one of the x_values is typically (but
+ * is not required to be) zero.  In typical usage, x is time, and x=0
+ * is the current time, and we are interested in whether the function
+ * crosses zero in the past or in the future. If it cannot be
+ * determined (within the error bars of the fit) whether the zero
+ * crossing occurs for x < 0 versus x > 0, then we return zero.
+ * Otherwise we return the best-fit x for when the function crosses
+ * zero.
+ *
+ * \details We fit to a straight line: y = intercept + slope*x.
+ * So our best guess is that the function will cross zero at
+ * x_best_fit = -intercept/slope.
+ *
+ * However, the data are assumed to be noisy.  The fit gives us error
+ * bars for the slope and the intercept.  Given the error bars, we can
+ * compute four limiting crossing values x0, x1, x2, and x3 by using
+ * the maximum and minimum possible values of slope and intercept.
+ * For example, if we assume slope<0 and intercept>0, then the
+ * earliest possible crossing consistent with the error bars is
+ * x3=(-intercept+delta_intercept)/(slope-delta_slope) and the latest
+ * possible crossing consistent with the error bars is
+ * x0=(-intercept-delta_intercept)/(slope+delta_slope).
+ *
+ * We compute all four crossing values and demand that all of them
+ * are either at x>0 (i.e. in the future if x is time) or at x<0
+ * (i.e. in the past if x is time).  Otherwise we conclude that we
+ * cannot determine even the sign of the crossing value, so we return
+ * zero.
  */
 double predicted_zero_crossing_value(const std::vector<double>& x_values,
                                      const std::vector<double>& y_values);
 
 /*!
- * \brief Predicts the zero crossing of multiple functions contained in a deque
- * of DataVectors.
+ * \brief Predicts the zero crossing of multiple functions.
  *
- * Fits a set of N linear functions, where N is the size of the returned
- * DataVector and the size of each DataVector in the y_values.
- * Each linear function is fit by M points, where M is the size of x_values and
- * y_values. The Nth point in the returned DataVector is the value of x for
- * which the linear fit to the points (x[:], y[:][N]) [using python notation]
- * crosses y = 0. The x_values contain M points in the independent variable,
- * while the y_values contain M DataVectors that each contain (for example) the
- * set of points on a Strahlkorper. Each element of y_values is a DataVector of
- * size N. The first index to y_values selects a DataVector of points
- * corresponding to an x_value, and the second index selects a point in the
- * DataVector, so the y_values are indexed by
- * [x_value_index][point_in_datavector]. The x_values and y_values must be of
- * size M. Each fit determines the zero-crossing for one of the sets of points
- * in the y_values.
+ * For the ith element of the DataVector inside y_values, calls
+ * predicted_zero_crossing_value(x_values,y_values[:][i]), where we
+ * have used python-like notation.
  */
 DataVector predicted_zero_crossing_value(
     const std::deque<double>& x_values, const std::deque<DataVector>& y_values);

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_PredictedZeroCrossing.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_PredictedZeroCrossing.cpp
@@ -36,7 +36,7 @@ void test_predicted_zero_crossing_datavector() {
     y_intercept.push_back(-slope[i] * expected_zero_crossing_value[i]);
   }
 
-  std::deque<double> x_values{0., 1., 2., 3., 4., 5., 6., 7., 8., 9.};
+  std::deque<double> x_values{0., -1., -2., -3., -4., -5., -6., -7., -8., -9.};
   std::deque<DataVector> y_values{};
 
   for (size_t i = 0; i < x_values.size(); i++) {
@@ -55,6 +55,15 @@ void test_predicted_zero_crossing_datavector() {
                                expected_zero_crossing_value, custom_approx);
 }
 
+void test_predicted_zero_crossing_indeterminate() {
+  // Here we set up points so that the error bars are large enough
+  // that it is not clear whether the zero crossing is in the
+  // past or in the future.
+  std::vector<double> x_values{0.0, -1.0, -2.0, -3.0};
+  std::vector<double> y_values{1.0, 2.1, 1.0, 2.0};
+  CHECK(intrp::predicted_zero_crossing_value(x_values, y_values) == 0.0);
+}
+
 }  // namespace
 
 SPECTRE_TEST_CASE(
@@ -70,7 +79,8 @@ SPECTRE_TEST_CASE(
   const double slope = dist(gen);
   CAPTURE(slope);
 
-  std::vector<double> x_values = {0., 1., 2., 3., 4., 5., 6., 7., 8., 9.};
+  std::vector<double> x_values = {0.,  -1., -2., -3., -4.,
+                                  -5., -6., -7., -8., -9.};
   std::vector<double> y_values{};
   double b = -slope * expected_zero_crossing_value;
   for (size_t i = 0; i < x_values.size(); i++) {
@@ -87,4 +97,6 @@ SPECTRE_TEST_CASE(
 
   // Test the zero crossing value for a set of datavectors
   test_predicted_zero_crossing_datavector();
+
+  test_predicted_zero_crossing_indeterminate();
 }


### PR DESCRIPTION
## Proposed changes

The new algorithm (the same one as in SpEC), assumes noisy data.
If it cannot be determined (within the error bars of the linear fit) whether the zero crossing
is in the past or in the future, then it returns zero as the crossing time.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
