### PR TITLE
Fix new compilation errors on gcc 12

### DIFF
--- a/src/Options/ParseOptions.hpp
+++ b/src/Options/ParseOptions.hpp
@@ -344,7 +344,8 @@ class Parser {
   tuples::tagged_tuple_from_typelist<
       tmpl::transform<subgroups, tmpl::bind<SubgroupParser, tmpl::_1>>>
       subgroup_parsers_ =
-          tmpl::as_pack<subgroups>([](auto... subgroup_tags) {
+          tmpl::as_pack<subgroups>([this](auto... subgroup_tags) {
+            (void)this;  // gcc wants this for subgroup_parsers_
             return decltype(subgroup_parsers_)(
                 tmpl::type_from<decltype(subgroup_tags)>::help...);
           });

--- a/tests/Unit/Utilities/Test_TMPLDocumentation.cpp
+++ b/tests/Unit/Utilities/Test_TMPLDocumentation.cpp
@@ -154,7 +154,7 @@ using evens = tmpl::filter<
 // [metafunctions:maybe_first]
 template <typename L>
 using maybe_first = tmpl::apply<tmpl::apply<
-  tmpl::if_<tmpl::size<L>,
+  tmpl::if_<std::bool_constant<(tmpl::size<L>::value != 0)>,
             tmpl::defer<tmpl::bind<tmpl::front, tmpl::pin<L>>>,
             tmpl::no_such_type_>>>;
 // [metafunctions:maybe_first]
@@ -223,7 +223,7 @@ using factorial_recursion =
     tmpl::bind<  // recursive metalambda starts here
       tmpl::apply,
       tmpl::if_<
-        tmpl::_2,  // base case: zero is false
+        tmpl::not_equal_to<tmpl::_2, tmpl::size_t<0>>,
         tmpl::defer<  // prevent speculative recursion
           tmpl::parent<
             tmpl::times<
@@ -1144,7 +1144,7 @@ assert_same<tmpl::bitor_<tmpl::uint8_t<0b01100011>,
 assert_same<tmpl::bitxor_<tmpl::uint8_t<0b11000011>,
                           tmpl::uint8_t<0b00000110>>::type,
                           tmpl::uint8_t<0b11000101>>();
-assert_same<tmpl::shift_left<tmpl::uint8_t<0b10001110>, tmpl::size_t<3>>::type,
+assert_same<tmpl::shift_left<tmpl::uint8_t<0b00001110>, tmpl::size_t<3>>::type,
                              tmpl::uint8_t<0b01110000>>();
 assert_same<tmpl::shift_right<tmpl::uint8_t<0b10110011>, tmpl::size_t<4>>::type,
                               tmpl::uint8_t<0b00001011>>();


### PR DESCRIPTION
The TMPL-related changes are because gcc has become more strict about
narrowing conversions.  I believe this is in line with the standard.

I do not know whether the change to the option parser is correct
behavior or a new gcc bug.

This does not address the warning in #4139.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
