### PR TITLE
Add absolute cutoff to ScalarAdvection subcell TCI

### DIFF
--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -53,6 +53,7 @@
 #include "Evolution/Systems/ScalarAdvection/Subcell/NeighborPackagedData.hpp"
 #include "Evolution/Systems/ScalarAdvection/Subcell/TciOnDgGrid.hpp"
 #include "Evolution/Systems/ScalarAdvection/Subcell/TciOnFdGrid.hpp"
+#include "Evolution/Systems/ScalarAdvection/Subcell/TciOptions.hpp"
 #include "Evolution/Systems/ScalarAdvection/Subcell/TimeDerivative.hpp"
 #include "Evolution/Systems/ScalarAdvection/Subcell/VelocityAtFace.hpp"
 #include "Evolution/Systems/ScalarAdvection/System.hpp"
@@ -281,7 +282,8 @@ struct EvolutionMetavars {
       tmpl::list<initial_data_tag,
                  tmpl::conditional_t<
                      use_dg_subcell,
-                     tmpl::list<ScalarAdvection::fd::Tags::Reconstructor<Dim>>,
+                     tmpl::list<ScalarAdvection::fd::Tags::Reconstructor<Dim>,
+                                ScalarAdvection::subcell::Tags::TciOptions>,
                      tmpl::list<>>>;
 
   using dg_registration_list =

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/CMakeLists.txt
@@ -8,6 +8,7 @@ spectre_target_sources(
   InitialDataTci.cpp
   TciOnDgGrid.cpp
   TciOnFdGrid.cpp
+  TciOptions.cpp
   )
 
 spectre_target_headers(
@@ -21,6 +22,7 @@ spectre_target_headers(
   Subcell.hpp
   TciOnDgGrid.hpp
   TciOnFdGrid.hpp
+  TciOptions.hpp
   TimeDerivative.hpp
   VelocityAtFace.hpp
   )

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/InitialDataTci.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/InitialDataTci.hpp
@@ -11,6 +11,7 @@
 #include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
 #include "Evolution/DgSubcell/Tags/DataForRdmpTci.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/Systems/ScalarAdvection/Subcell/TciOptions.hpp"
 #include "Evolution/Systems/ScalarAdvection/Tags.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -27,18 +28,24 @@ namespace ScalarAdvection::subcell {
  * \brief The troubled-cell indicator run on DG initial data to see if we need
  * to switch to subcell.
  *
- * Uses the two-mesh relaxed discrete maximum principle as well as the Persson
- * TCI applied to the scalar field \f$U\f$.
+ * Apply
+ * 1) the two-mesh relaxed discrete maximum principle to the scalar field
+ * \f$U\f$, and
+ * 2) the Persson TCI to the scalar field \f$U\f$ if the \f$\max(|U|)\f$ on the
+ * DG grid is greater than `tci_options.u_cutoff`.
+ *
  */
 template <size_t Dim>
 struct DgInitialDataTci {
-  using argument_tags = tmpl::list<domain::Tags::Mesh<Dim>,
-                                   evolution::dg::subcell::Tags::Mesh<Dim>>;
+  using argument_tags =
+      tmpl::list<domain::Tags::Mesh<Dim>,
+                 evolution::dg::subcell::Tags::Mesh<Dim>, Tags::TciOptions>;
 
   static std::tuple<bool, evolution::dg::subcell::RdmpTciData> apply(
       const Variables<tmpl::list<ScalarAdvection::Tags::U>>& dg_vars,
       double rdmp_delta0, double rdmp_epsilon, double persson_exponent,
-      const Mesh<Dim>& dg_mesh, const Mesh<Dim>& subcell_mesh);
+      const Mesh<Dim>& dg_mesh, const Mesh<Dim>& subcell_mesh,
+      const TciOptions& tci_options);
 };
 
 /// \brief Sets the initial RDMP data.

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/TciOnDgGrid.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/TciOnDgGrid.cpp
@@ -6,9 +6,11 @@
 #include <algorithm>
 #include <cstddef>
 
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/DgSubcell/PerssonTci.hpp"
 #include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/DgSubcell/RdmpTci.hpp"
+#include "Evolution/Systems/ScalarAdvection/Subcell/TciOptions.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
 namespace ScalarAdvection::subcell {
@@ -18,7 +20,7 @@ std::tuple<bool, evolution::dg::subcell::RdmpTciData> TciOnDgGrid<Dim>::apply(
     const Mesh<Dim>& subcell_mesh,
     const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
     const evolution::dg::subcell::SubcellOptions& subcell_options,
-    const double persson_exponent) {
+    const TciOptions& tci_options, const double persson_exponent) {
   // Don't use buffer since we have only one memory allocation right now (until
   // persson_tci can use a buffer)
   const Scalar<DataVector> subcell_u{::evolution::dg::subcell::fd::project(
@@ -30,6 +32,8 @@ std::tuple<bool, evolution::dg::subcell::RdmpTciData> TciOnDgGrid<Dim>::apply(
       {max(max(get(dg_u)), max(get(subcell_u)))},
       {min(min(get(dg_u)), min(get(subcell_u)))}};
 
+  const double max_abs_u = max(abs(get(dg_u)));
+
   const bool cell_is_troubled =
       evolution::dg::subcell::rdmp_tci(rdmp_tci_data.max_variables_values,
                                        rdmp_tci_data.min_variables_values,
@@ -37,7 +41,8 @@ std::tuple<bool, evolution::dg::subcell::RdmpTciData> TciOnDgGrid<Dim>::apply(
                                        past_rdmp_tci_data.min_variables_values,
                                        subcell_options.rdmp_delta0(),
                                        subcell_options.rdmp_epsilon()) or
-      ::evolution::dg::subcell::persson_tci(dg_u, dg_mesh, persson_exponent);
+      ((max_abs_u > tci_options.u_cutoff) and
+       ::evolution::dg::subcell::persson_tci(dg_u, dg_mesh, persson_exponent));
 
   return {cell_is_troubled, std::move(rdmp_tci_data)};
 }

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/TciOnDgGrid.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/TciOnDgGrid.hpp
@@ -12,6 +12,7 @@
 #include "Evolution/DgSubcell/Tags/DataForRdmpTci.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
+#include "Evolution/Systems/ScalarAdvection/Subcell/TciOptions.hpp"
 #include "Evolution/Systems/ScalarAdvection/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -26,7 +27,8 @@ namespace ScalarAdvection::subcell {
  * \brief The troubled-cell indicator run on the DG grid to check if the
  * solution is admissible.
  *
- * Applies the Persson and RDMP TCI to \f$U\f$.
+ * Applies 1) the RDMP TCI to \f$U\f$ and 2) the Persson TCI to \f$U\f$ if the
+ * \f$\max(|U|)\f$ on the DG grid is greater than `tci_options.u_cutoff`.
  */
 template <size_t Dim>
 struct TciOnDgGrid {
@@ -36,13 +38,14 @@ struct TciOnDgGrid {
       tmpl::list<ScalarAdvection::Tags::U, ::domain::Tags::Mesh<Dim>,
                  evolution::dg::subcell::Tags::Mesh<Dim>,
                  evolution::dg::subcell::Tags::DataForRdmpTci,
-                 evolution::dg::subcell::Tags::SubcellOptions>;
+                 evolution::dg::subcell::Tags::SubcellOptions,
+                 Tags::TciOptions>;
 
   static std::tuple<bool, evolution::dg::subcell::RdmpTciData> apply(
       const Scalar<DataVector>& dg_u, const Mesh<Dim>& dg_mesh,
       const Mesh<Dim>& subcell_mesh,
       const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
       const evolution::dg::subcell::SubcellOptions& subcell_options,
-      double persson_exponent);
+      const TciOptions& tci_options, double persson_exponent);
 };
 }  // namespace ScalarAdvection::subcell

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/TciOnFdGrid.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/TciOnFdGrid.cpp
@@ -6,9 +6,11 @@
 #include <algorithm>
 #include <cstddef>
 
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/DgSubcell/PerssonTci.hpp"
 #include "Evolution/DgSubcell/RdmpTci.hpp"
 #include "Evolution/DgSubcell/Reconstruction.hpp"
+#include "Evolution/Systems/ScalarAdvection/Subcell/TciOptions.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
 namespace ScalarAdvection::subcell {
@@ -18,7 +20,7 @@ std::tuple<bool, evolution::dg::subcell::RdmpTciData> TciOnFdGrid<Dim>::apply(
     const Mesh<Dim>& subcell_mesh,
     const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
     const evolution::dg::subcell::SubcellOptions& subcell_options,
-    const double persson_exponent) {
+    const TciOptions& tci_options, const double persson_exponent) {
   const Scalar<DataVector> dg_u{evolution::dg::subcell::fd::reconstruct(
       get(subcell_u), dg_mesh, subcell_mesh.extents(),
       evolution::dg::subcell::fd::ReconstructionMethod::DimByDim)};
@@ -29,6 +31,8 @@ std::tuple<bool, evolution::dg::subcell::RdmpTciData> TciOnFdGrid<Dim>::apply(
       {max(max(get(dg_u)), max(get(subcell_u)))},
       {min(min(get(dg_u)), min(get(subcell_u)))}};
 
+  const double max_abs_u = max(abs(get(dg_u)));
+
   const bool cell_is_troubled = evolution::dg::subcell::rdmp_tci(
       rdmp_data_for_tci.max_variables_values,
       rdmp_data_for_tci.min_variables_values,
@@ -36,8 +40,9 @@ std::tuple<bool, evolution::dg::subcell::RdmpTciData> TciOnFdGrid<Dim>::apply(
       past_rdmp_tci_data.min_variables_values, subcell_options.rdmp_delta0(),
       subcell_options.rdmp_epsilon());
 
-  return {cell_is_troubled or ::evolution::dg::subcell::persson_tci(
-                                  dg_u, dg_mesh, persson_exponent),
+  return {cell_is_troubled or ((max_abs_u > tci_options.u_cutoff) and
+                               ::evolution::dg::subcell::persson_tci(
+                                   dg_u, dg_mesh, persson_exponent)),
           {{max(get(subcell_u))}, {min(get(subcell_u))}}};
 }
 

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/TciOnFdGrid.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/TciOnFdGrid.hpp
@@ -12,6 +12,7 @@
 #include "Evolution/DgSubcell/Tags/DataForRdmpTci.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
+#include "Evolution/Systems/ScalarAdvection/Subcell/TciOptions.hpp"
 #include "Evolution/Systems/ScalarAdvection/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -26,7 +27,8 @@ namespace ScalarAdvection::subcell {
  * \brief Troubled-cell indicator applied to the finite difference subcell
  * solution to check if the corresponding DG solution is admissible.
  *
- * Applies the Persson and RDMP TCI to \f$U\f$.
+ * Applies 1) the RDMP TCI to \f$U\f$ and 2) the Persson TCI to \f$U\f$ if the
+ * \f$\max(|U|)\f$ on the DG grid is greater than `tci_options.u_cutoff`.
  */
 template <size_t Dim>
 struct TciOnFdGrid {
@@ -35,13 +37,14 @@ struct TciOnFdGrid {
       tmpl::list<ScalarAdvection::Tags::U, ::domain::Tags::Mesh<Dim>,
                  evolution::dg::subcell::Tags::Mesh<Dim>,
                  evolution::dg::subcell::Tags::DataForRdmpTci,
-                 evolution::dg::subcell::Tags::SubcellOptions>;
+                 evolution::dg::subcell::Tags::SubcellOptions,
+                 Tags::TciOptions>;
 
   static std::tuple<bool, evolution::dg::subcell::RdmpTciData> apply(
       const Scalar<DataVector>& subcell_u, const Mesh<Dim>& dg_mesh,
       const Mesh<Dim>& subcell_mesh,
       const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
       const evolution::dg::subcell::SubcellOptions& subcell_options,
-      double persson_exponent);
+      const TciOptions& tci_options, double persson_exponent);
 };
 }  // namespace ScalarAdvection::subcell

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/TciOptions.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/TciOptions.cpp
@@ -1,0 +1,12 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarAdvection/Subcell/TciOptions.hpp"
+
+#include <pup.h>
+
+#include "Parallel/PupStlCpp17.hpp"
+
+namespace ScalarAdvection::subcell {
+void TciOptions::pup(PUP::er& p) { p | u_cutoff; }
+}  // namespace ScalarAdvection::subcell

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/TciOptions.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/TciOptions.hpp
@@ -1,0 +1,64 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <limits>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags/OptionsGroup.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace ScalarAdvection::subcell {
+struct TciOptions {
+  /*!
+   * \brief The cutoff of the absolute value of the scalar field \f$U\f$ in an
+   * element to use the Persson TCI. Below this value the Persson TCI is not
+   * applied.
+   */
+  struct UCutoff {
+    using type = double;
+    static type lower_bound() { return 0.0; }
+    static constexpr Options::String help = {
+        "The cutoff of the absolute value of the scalar field U in an "
+        "element to use Persson TCI."};
+  };
+
+  using options = tmpl::list<UCutoff>;
+  static constexpr Options::String help = {
+      "Options for the troubled-cell indicator"};
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/);
+
+  double u_cutoff{std::numeric_limits<double>::signaling_NaN()};
+};
+
+namespace OptionTags {
+struct TciOptions {
+  using type = subcell::TciOptions;
+  static constexpr Options::String help =
+      "ScalarAdvection-specific options for the TCI";
+  using group = ::dg::OptionTags::DiscontinuousGalerkinGroup;
+};
+}  // namespace OptionTags
+
+namespace Tags {
+struct TciOptions : db::SimpleTag {
+  using type = subcell::TciOptions;
+  using option_tags = tmpl::list<typename OptionTags::TciOptions>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& tci_options) {
+    return tci_options;
+  }
+};
+}  // namespace Tags
+}  // namespace ScalarAdvection::subcell

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/TimeDerivative.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/TimeDerivative.hpp
@@ -136,7 +136,7 @@ struct TimeDerivative {
 
         // copy over the face values of the velocity field
         {
-          using tag = Tags::VelocityField<Dim>;
+          using tag = ::ScalarAdvection::Tags::VelocityField<Dim>;
           const auto& velocity_on_face =
               db::get<evolution::dg::subcell::Tags::OnSubcellFaces<tag, Dim>>(
                   *box);
@@ -235,7 +235,8 @@ struct TimeDerivative {
               &fd_boundary_corrections, &subcell_mesh,
               &one_over_delta_xi](const auto dt_vars_ptr) {
           dt_vars_ptr->initialize(num_pts, 0.0);
-          auto& dt_u = get<::Tags::dt<Tags::U>>(*dt_vars_ptr);
+          auto& dt_u =
+              get<::Tags::dt<::ScalarAdvection::Tags::U>>(*dt_vars_ptr);
 
           for (size_t dim = 0; dim < Dim; ++dim) {
             Scalar<DataVector>& u_correction = get<::ScalarAdvection ::Tags::U>(

--- a/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
@@ -43,6 +43,8 @@ SpatialDiscretization:
         PerssonExponent: 4.0
       AlwaysUseSubcells: false
       SubcellToDgReconstructionMethod: DimByDim
+    TciOptions:
+      UCutoff: 1.0e-10
   SubcellSolver:
     Reconstructor:
       MonotonisedCentral
@@ -64,7 +66,7 @@ EventsAndTriggers:
         VariablesToObserve: [U, TciStatus]
         InterpolateToMesh: None
         CoordinatesFloatingPointType: Double
-        FloatingPointTypes: [Double, Float]
+        FloatingPointTypes: [Float, Float]
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
@@ -41,6 +41,8 @@ SpatialDiscretization:
         PerssonExponent: 4.0
       AlwaysUseSubcells: false
       SubcellToDgReconstructionMethod: DimByDim
+    TciOptions:
+      UCutoff: 1.0e-10
   SubcellSolver:
     Reconstructor:
       MonotonisedCentral
@@ -62,7 +64,7 @@ EventsAndTriggers:
         VariablesToObserve: [U, TciStatus]
         InterpolateToMesh: None
         CoordinatesFloatingPointType: Double
-        FloatingPointTypes: [Double, Float]
+        FloatingPointTypes: [Float, Float]
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
@@ -43,6 +43,8 @@ SpatialDiscretization:
         PerssonExponent: 4.0
       AlwaysUseSubcells: false
       SubcellToDgReconstructionMethod: DimByDim
+    TciOptions:
+      UCutoff: 1.0e-10
   SubcellSolver:
     Reconstructor:
       MonotonisedCentral
@@ -64,7 +66,7 @@ EventsAndTriggers:
         VariablesToObserve: [U, TciStatus]
         InterpolateToMesh: None
         CoordinatesFloatingPointType: Double
-        FloatingPointTypes: [Double, Float]
+        FloatingPointTypes: [Float, Float]
 
 EventsAndDenseTriggers:
 

--- a/tests/Unit/Evolution/Systems/ScalarAdvection/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarAdvection/CMakeLists.txt
@@ -15,6 +15,7 @@ set(LIBRARY_SOURCES
   Subcell/Test_NeighborPackagedData.cpp
   Subcell/Test_TciOnDgGrid.cpp
   Subcell/Test_TciOnFdGrid.cpp
+  Subcell/Test_TciOptions.cpp
   Subcell/Test_TimeDerivative.cpp
   Subcell/Test_VelocityAtFace.cpp
   Test_Characteristics.cpp

--- a/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_TciOnDgGrid.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_TciOnDgGrid.cpp
@@ -10,12 +10,13 @@
 #include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/Systems/ScalarAdvection/Subcell/TciOnDgGrid.hpp"
+#include "Evolution/Systems/ScalarAdvection/Subcell/TciOptions.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 
 namespace {
 // test cases to be covered
-enum class TestThis { AllGood, PerssonU, RdmpU };
+enum class TestThis { AllGood, PerssonU, BelowCutoff, RdmpU };
 
 template <size_t Dim>
 void test(const TestThis& test_this) {
@@ -27,9 +28,16 @@ void test(const TestThis& test_this) {
   const size_t number_of_points{dg_mesh.number_of_grid_points()};
   Scalar<DataVector> u{number_of_points, 1.0};
 
+  const ScalarAdvection::subcell::TciOptions tci_options{1.0e-8};
+
   if (test_this == TestThis::PerssonU) {
     // make a troubled cell
     get(u)[number_of_points / 2] += 1.0;
+  }
+  if (test_this == TestThis::BelowCutoff) {
+    // make a troubled cell, but scale it to be smaller than the absolute cutoff
+    get(u)[number_of_points / 2] += 1.0;
+    get(u) *= 1.0e-10;
   }
 
   // Set the RDMP TCI past data.
@@ -63,11 +71,11 @@ void test(const TestThis& test_this) {
   const std::tuple<bool, evolution::dg::subcell::RdmpTciData> result =
       ScalarAdvection::subcell::TciOnDgGrid<Dim>::apply(
           u, dg_mesh, subcell_mesh, past_rdmp_tci_data, subcell_options,
-          persson_exponent);
+          tci_options, persson_exponent);
 
   CHECK(std::get<1>(result) == expected_rdmp_data);
 
-  if (test_this == TestThis::AllGood) {
+  if (test_this == TestThis::AllGood or test_this == TestThis::BelowCutoff) {
     CHECK_FALSE(std::get<0>(result));
   } else {
     CHECK(std::get<0>(result));
@@ -77,8 +85,8 @@ void test(const TestThis& test_this) {
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarAdvection.Subcell.TciOnDgGrid",
                   "[Unit][Evolution]") {
-  for (const auto test_this :
-       {TestThis::AllGood, TestThis::PerssonU, TestThis::RdmpU}) {
+  for (const auto test_this : {TestThis::AllGood, TestThis::PerssonU,
+                               TestThis::RdmpU, TestThis::BelowCutoff}) {
     test<1>(test_this);
     test<2>(test_this);
   }

--- a/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_TciOptions.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarAdvection/Subcell/Test_TciOptions.cpp
@@ -1,0 +1,16 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Evolution/Systems/ScalarAdvection/Subcell/TciOptions.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Evolution.ScalarAdvection.Subcell.TciOptions",
+                  "[Unit][Evolution]") {
+  const auto tci_options_from_opts = TestHelpers::test_option_tag<
+      ScalarAdvection::subcell::OptionTags::TciOptions>("UCutoff: 1.0e-10\n");
+  const auto tci_options = serialize_and_deserialize(tci_options_from_opts);
+  CHECK(tci_options.u_cutoff == 1.0e-10);
+}


### PR DESCRIPTION
## Proposed changes

Add a TCI option `UCutoff` to the ScalarAdvection subcell. If the max magnitude of the scalar field U on the DG grid is smaller than this `double` type value, Persson TCI is ignored. This fixes "trailing" trouble cells not switching back to DG on the region with U being very small or zero.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
