### PR TITLE
UniformCylindricalEndcap: make clang-tidy happy.

### DIFF
--- a/src/Domain/CoordinateMaps/UniformCylindricalEndcap.cpp
+++ b/src/Domain/CoordinateMaps/UniformCylindricalEndcap.cpp
@@ -179,6 +179,21 @@ UniformCylindricalEndcap::UniformCylindricalEndcap(
          "z_plane_two is too far from the center of sphere_two: theta/pi = "
              << theta_max_two_ / M_PI);
 
+
+  ASSERT(is_uniform_cylindrical_endcap_invertible_on_sphere_one(
+             center_one_, center_two_, radius_one_, radius_two_, theta_max_one_,
+             theta_max_two_),
+         "The map is not invertible at at least one point on sphere_one."
+         " center_one = "
+             << center_one_ << " center_two = " << center_two_
+             << " radius_one = " << radius_one_ << " radius_two = "
+             << radius_two_ << " theta_max_one = " << theta_max_one_
+             << " theta_max_two = " << theta_max_two_);
+
+  // The code below defines several variables that are used only in ASSERTs.
+  // We put that code in a #ifdef SPECTRE_DEBUG to avoid clang-tidy complaining
+  // about unused variables in release mode.
+#ifdef SPECTRE_DEBUG
   const double dist_spheres = sqrt(square(center_one[0] - center_two[0]) +
                                    square(center_one[1] - center_two[1]) +
                                    square(center_one[2] - center_two[2]));
@@ -211,16 +226,7 @@ UniformCylindricalEndcap::UniformCylindricalEndcap(
              << ", max_horizontal_dist_between_circles = "
              << max_horizontal_dist_between_circles
              << ", horizontal_dist_spheres = " << horizontal_dist_spheres);
-
-  ASSERT(is_uniform_cylindrical_endcap_invertible_on_sphere_one(
-             center_one_, center_two_, radius_one_, radius_two_, theta_max_one_,
-             theta_max_two_),
-         "The map is not invertible at at least one point on sphere_one."
-         " center_one = "
-             << center_one_ << " center_two = " << center_two_
-             << " radius_one = " << radius_one_ << " radius_two = "
-             << radius_two_ << " theta_max_one = " << theta_max_one_
-             << " theta_max_two = " << theta_max_two_);
+#endif
 }
 
 template <typename T>


### PR DESCRIPTION
Some variables are used only in ASSERTs, and that made
clang-tidy complain in release mode.

Fixes #4138


### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
