### PR TITLE
Fix formatting in post-release workflow

### DIFF
--- a/.github/workflows/PostRelease.yaml
+++ b/.github/workflows/PostRelease.yaml
@@ -74,9 +74,15 @@ jobs:
           with open(package_file, 'w') as open_package_file:
             for line in package_file_lines:
               open_package_file.write(line)
-              if line.strip().startswith("version('develop'"):
+              if line.strip().startswith('version("develop"'):
                 for version_line in version_lines:
                   open_package_file.write(version_line + "\n")
+      - name: Fix code formatting
+        run: |
+          spack style --fix `git diff --name-only`
+        # Formatting can also be fixed later by Spack maintainers in the PR, so
+        # it's fine if it fails here for some reason
+        continue-on-error: true
       - name: Print diff
         run: |
           git diff


### PR DESCRIPTION
## Proposed changes

Spack is using `black` for code formatting now, so make sure the added code is formatted correctly.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
