### PR TITLE
Add Christoffel and ExtrinsicCurvatureFunctions to KerrSchild, Minkowski and SphericalKerrschild

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.cpp
@@ -154,6 +154,26 @@ Minkowski<Dim>::variables(
     const {
   return {make_with_value<Scalar<DataType>>(x, 0.)};
 }
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTuple<gr::Tags::TraceExtrinsicCurvature<DataType>>
+Minkowski<Dim>::variables(
+    const tnsr::I<DataType, Dim>& x, double /*t*/,
+    tmpl::list<gr::Tags::TraceExtrinsicCurvature<DataType>> /*meta*/) const {
+  return {make_with_value<Scalar<DataType>>(x, 0.)};
+}
+
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTuple<
+    gr::Tags::TraceSpatialChristoffelSecondKind<Dim, Frame::Inertial, DataType>>
+Minkowski<Dim>::variables(
+    const tnsr::I<DataType, Dim>& x, double /*t*/,
+    tmpl::list<gr::Tags::TraceSpatialChristoffelSecondKind<
+        Dim, Frame::Inertial, DataType>> /*meta*/) const {
+  return {make_with_value<tnsr::I<DataType, Dim>>(x, 0.)};
+}
+
 }  // namespace gr::Solutions
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
@@ -239,6 +259,17 @@ Minkowski<Dim>::variables(
       const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/,                  \
       tmpl::list<                                                              \
           ::Tags::dt<gr::Tags::SqrtDetSpatialMetric<DTYPE(data)>>> /*meta*/)   \
+      const;                                                                   \
+  template tuples::TaggedTuple<gr::Tags::TraceSpatialChristoffelSecondKind<    \
+      DIM(data), Frame::Inertial, DTYPE(data)>>                                \
+  gr::Solutions::Minkowski<DIM(data)>::variables(                              \
+      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/,                  \
+      tmpl::list<gr::Tags::TraceSpatialChristoffelSecondKind<                  \
+          DIM(data), Frame::Inertial, DTYPE(data)>> /*meta*/) const;           \
+  template tuples::TaggedTuple<gr::Tags::TraceExtrinsicCurvature<DTYPE(data)>> \
+  gr::Solutions::Minkowski<DIM(data)>::variables(                              \
+      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/,                  \
+      tmpl::list<gr::Tags::TraceExtrinsicCurvature<DTYPE(data)>> /*meta*/)     \
       const;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector))

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.cpp
@@ -154,6 +154,17 @@ Minkowski<Dim>::variables(
     const {
   return {make_with_value<Scalar<DataType>>(x, 0.)};
 }
+
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTuple<
+    gr::Tags::DerivDetSpatialMetric<Dim, Frame::Inertial, DataType>>
+Minkowski<Dim>::variables(const tnsr::I<DataType, Dim>& x, double /*t*/,
+                          tmpl::list<gr::Tags::DerivDetSpatialMetric<
+                              Dim, Frame::Inertial, DataType>> /*meta*/) const {
+  return {make_with_value<tnsr::i<DataType, Dim>>(x, 0.)};
+}
+
 template <size_t Dim>
 template <typename DataType>
 tuples::TaggedTuple<gr::Tags::TraceExtrinsicCurvature<DataType>>
@@ -161,6 +172,26 @@ Minkowski<Dim>::variables(
     const tnsr::I<DataType, Dim>& x, double /*t*/,
     tmpl::list<gr::Tags::TraceExtrinsicCurvature<DataType>> /*meta*/) const {
   return {make_with_value<Scalar<DataType>>(x, 0.)};
+}
+
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTuple<
+    gr::Tags::SpatialChristoffelFirstKind<Dim, Frame::Inertial, DataType>>
+Minkowski<Dim>::variables(const tnsr::I<DataType, Dim>& x, double /*t*/,
+                          tmpl::list<gr::Tags::SpatialChristoffelFirstKind<
+                              Dim, Frame::Inertial, DataType>> /*meta*/) const {
+  return {make_with_value<tnsr::ijj<DataType, Dim>>(x, 0.)};
+}
+
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTuple<
+    gr::Tags::SpatialChristoffelSecondKind<Dim, Frame::Inertial, DataType>>
+Minkowski<Dim>::variables(const tnsr::I<DataType, Dim>& x, double /*t*/,
+                          tmpl::list<gr::Tags::SpatialChristoffelSecondKind<
+                              Dim, Frame::Inertial, DataType>> /*meta*/) const {
+  return {make_with_value<tnsr::Ijj<DataType, Dim>>(x, 0.)};
 }
 
 template <size_t Dim>
@@ -260,6 +291,25 @@ Minkowski<Dim>::variables(
       tmpl::list<                                                              \
           ::Tags::dt<gr::Tags::SqrtDetSpatialMetric<DTYPE(data)>>> /*meta*/)   \
       const;                                                                   \
+  template tuples::TaggedTuple<gr::Tags::DerivDetSpatialMetric<                \
+      DIM(data), Frame::Inertial, DTYPE(data)>>                                \
+  gr::Solutions::Minkowski<DIM(data)>::variables(                              \
+      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/,                  \
+      tmpl::list<gr::Tags::DerivDetSpatialMetric<DIM(data), Frame::Inertial,   \
+                                                 DTYPE(data)>> /*meta*/)       \
+      const;                                                                   \
+  template tuples::TaggedTuple<gr::Tags::SpatialChristoffelFirstKind<          \
+      DIM(data), Frame::Inertial, DTYPE(data)>>                                \
+  gr::Solutions::Minkowski<DIM(data)>::variables(                              \
+      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/,                  \
+      tmpl::list<gr::Tags::SpatialChristoffelFirstKind<                        \
+          DIM(data), Frame::Inertial, DTYPE(data)>> /*meta*/) const;           \
+  template tuples::TaggedTuple<gr::Tags::SpatialChristoffelSecondKind<         \
+      DIM(data), Frame::Inertial, DTYPE(data)>>                                \
+  gr::Solutions::Minkowski<DIM(data)>::variables(                              \
+      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/,                  \
+      tmpl::list<gr::Tags::SpatialChristoffelSecondKind<                       \
+          DIM(data), Frame::Inertial, DTYPE(data)>> /*meta*/) const;           \
   template tuples::TaggedTuple<gr::Tags::TraceSpatialChristoffelSecondKind<    \
       DIM(data), Frame::Inertial, DTYPE(data)>>                                \
   gr::Solutions::Minkowski<DIM(data)>::variables(                              \

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp
@@ -42,6 +42,7 @@ class Minkowski : public AnalyticSolution<Dim>, public MarkAsAnalyticSolution {
   static constexpr Options::String help{
       "Minkowski solution to Einstein's Equations"};
 
+
   Minkowski() = default;
   Minkowski(const Minkowski& /*rhs*/) = default;
   Minkowski& operator=(const Minkowski& /*rhs*/) = default;
@@ -60,27 +61,26 @@ class Minkowski : public AnalyticSolution<Dim>, public MarkAsAnalyticSolution {
   using DerivSpatialMetric =
       ::Tags::deriv<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>,
                     tmpl::size_t<Dim>, Frame::Inertial>;
-  template <typename DataType>
-  using tags = tmpl::list<
-      gr::Tags::Lapse<DataType>, ::Tags::dt<gr::Tags::Lapse<DataType>>,
-      DerivLapse<DataType>, gr::Tags::Shift<Dim, Frame::Inertial, DataType>,
-      ::Tags::dt<gr::Tags::Shift<Dim, Frame::Inertial, DataType>>,
-      DerivShift<DataType>,
-      gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>,
-      ::Tags::dt<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>>,
-      DerivSpatialMetric<DataType>, gr::Tags::SqrtDetSpatialMetric<DataType>,
-      gr::Tags::ExtrinsicCurvature<Dim, Frame::Inertial, DataType>,
-      gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataType>,
+
+  template <typename DataType, typename Frame = Frame::Inertial>
+  using tags = tmpl::flatten<tmpl::list<
+      typename AnalyticSolution<Dim>::template tags<DataType, Frame>,
+      gr::Tags::DerivDetSpatialMetric<Dim, Frame, DataType>,
       gr::Tags::TraceExtrinsicCurvature<DataType>,
-      gr::Tags::TraceSpatialChristoffelSecondKind<Dim, Frame::Inertial,
-                                                  DataType>>;
+      gr::Tags::SpatialChristoffelFirstKind<Dim, Frame, DataType>,
+      gr::Tags::SpatialChristoffelSecondKind<Dim, Frame, DataType>,
+      gr::Tags::TraceSpatialChristoffelSecondKind<Dim, Frame, DataType>>>;
+
   template <typename DataType, typename... Tags>
   tuples::TaggedTuple<Tags...> variables(const tnsr::I<DataType, Dim>& x,
                                          double t,
                                          tmpl::list<Tags...> /*meta*/) const {
-    static_assert(sizeof...(Tags) > 1,
-                  "Unrecognized tag requested.  See the function parameters "
-                  "for the tag.");
+    static_assert(
+        tmpl2::flat_all_v<
+            tmpl::list_contains_v<tags<DataType>, Tags>...>,
+        "At least one of the requested tags is not supported. The requested "
+        "tags are listed as template parameters of the `variables` function.");
+
     return {get<Tags>(variables(x, t, tmpl::list<Tags>{}))...};
   }
 
@@ -171,6 +171,13 @@ class Minkowski : public AnalyticSolution<Dim>, public MarkAsAnalyticSolution {
       tmpl::list<gr::Tags::SqrtDetSpatialMetric<DataType>> /*meta*/) const;
 
   template <typename DataType>
+  tuples::TaggedTuple<
+      gr::Tags::DerivDetSpatialMetric<Dim, Frame::Inertial, DataType>>
+  variables(const tnsr::I<DataType, Dim>& x, double /*t*/,
+            tmpl::list<gr::Tags::DerivDetSpatialMetric<
+                Dim, Frame::Inertial, DataType>> /*meta*/) const;
+
+  template <typename DataType>
   tuples::TaggedTuple<::Tags::dt<gr::Tags::SqrtDetSpatialMetric<DataType>>>
   variables(
       const tnsr::I<DataType, Dim>& x, double /*t*/,
@@ -181,6 +188,20 @@ class Minkowski : public AnalyticSolution<Dim>, public MarkAsAnalyticSolution {
   tuples::TaggedTuple<gr::Tags::TraceExtrinsicCurvature<DataType>> variables(
       const tnsr::I<DataType, Dim>& x, double /*t*/,
       tmpl::list<gr::Tags::TraceExtrinsicCurvature<DataType>> /*meta*/) const;
+
+  template <typename DataType>
+  tuples::TaggedTuple<
+      gr::Tags::SpatialChristoffelFirstKind<Dim, Frame::Inertial, DataType>>
+  variables(const tnsr::I<DataType, Dim>& x, double /*t*/,
+            tmpl::list<gr::Tags::SpatialChristoffelFirstKind<
+                Dim, Frame::Inertial, DataType>> /*meta*/) const;
+
+  template <typename DataType>
+  tuples::TaggedTuple<
+      gr::Tags::SpatialChristoffelSecondKind<Dim, Frame::Inertial, DataType>>
+  variables(const tnsr::I<DataType, Dim>& x, double /*t*/,
+            tmpl::list<gr::Tags::SpatialChristoffelSecondKind<
+                Dim, Frame::Inertial, DataType>> /*meta*/) const;
 
   template <typename DataType>
   tuples::TaggedTuple<gr::Tags::TraceSpatialChristoffelSecondKind<

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp
@@ -70,7 +70,10 @@ class Minkowski : public AnalyticSolution<Dim>, public MarkAsAnalyticSolution {
       ::Tags::dt<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>>,
       DerivSpatialMetric<DataType>, gr::Tags::SqrtDetSpatialMetric<DataType>,
       gr::Tags::ExtrinsicCurvature<Dim, Frame::Inertial, DataType>,
-      gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataType>>;
+      gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataType>,
+      gr::Tags::TraceExtrinsicCurvature<DataType>,
+      gr::Tags::TraceSpatialChristoffelSecondKind<Dim, Frame::Inertial,
+                                                  DataType>>;
   template <typename DataType, typename... Tags>
   tuples::TaggedTuple<Tags...> variables(const tnsr::I<DataType, Dim>& x,
                                          double t,
@@ -174,6 +177,17 @@ class Minkowski : public AnalyticSolution<Dim>, public MarkAsAnalyticSolution {
       tmpl::list<::Tags::dt<gr::Tags::SqrtDetSpatialMetric<DataType>>> /*meta*/)
       const;
 
+  template <typename DataType>
+  tuples::TaggedTuple<gr::Tags::TraceExtrinsicCurvature<DataType>> variables(
+      const tnsr::I<DataType, Dim>& x, double /*t*/,
+      tmpl::list<gr::Tags::TraceExtrinsicCurvature<DataType>> /*meta*/) const;
+
+  template <typename DataType>
+  tuples::TaggedTuple<gr::Tags::TraceSpatialChristoffelSecondKind<
+      Dim, Frame::Inertial, DataType>>
+  variables(const tnsr::I<DataType, Dim>& x, double /*t*/,
+            tmpl::list<gr::Tags::TraceSpatialChristoffelSecondKind<
+                Dim, Frame::Inertial, DataType>> /*meta*/) const;
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/) {}
 };

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_KerrSchild.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_KerrSchild.cpp
@@ -13,6 +13,7 @@
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/Determinant.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
@@ -54,17 +55,21 @@ tnsr::I<DataType, 3, Frame> spatial_coords(const DataType& used_for_size) {
 
 template <typename Frame, typename DataType>
 void test_schwarzschild(const DataType& used_for_size) {
-  // Schwarzschild solution is:
-  // H        = M/r
-  // l_mu     = (1,x/r,y/r,z/r)
-  // lapse    = (1+2M/r)^{-1/2}
-  // d_lapse  = (1+2M/r)^{-3/2}(Mx^i/r^3)
-  // shift^i  = (2Mx^i/r^2) / lapse^2
-  // g_{ij}   = delta_{ij} + 2 M x_i x_j/r^3
-  // d_i H    = -Mx_i/r^3
-  // d_i l_j  = delta_{ij}/r - x^i x^j/r^3
-  // d_k g_ij = -6M x_i x_j x_k/r^5 + 2 M x_i delta_{kj}/r^3
+  // Schwarzschild solution is (with x_i = delta_{ij} x^i):
+  // H                    = M/r
+  // l_mu                 = (1,x/r,y/r,z/r)
+  // lapse                = (1+2M/r)^{-1/2}
+  // d_i lapse            = (1+2M/r)^{-3/2}(Mx^i/r^3)
+  // shift^i              = (2Mx^i/r^2) / lapse^2
+  // g_{ij}               = delta_{ij} + 2 M x_i x_j/r^3
+  // d_i H                = -Mx_i/r^3
+  // d_i l_j              = delta_{ij}/r - x^i x^j/r^3
+  // d_k g_ij             = -6M x_i x_j x_k/r^5 + 2 M x_i delta_{kj}/r^3
   //                                + 2 M x_j delta_{ki}/r^3
+  // Gamma_{ijk}          = M x_i(2r^2 delta_{jk} - 3 x_j x_k) / r^5
+  // Gamma^i_{jk}         = M x^i(2r^2 delta_{jk} - 3 x_j x_k) / (2Mr^4 + r^5)
+  // g^{ij} Gamma^k_{ij}  = M(8M + 3r) x^k / (r(2M+3r))^2
+  // g^{ij} K_{ij}        = 2M(3M + r) * ((2M+r)r)^(-3/2)
 
   // Parameters for KerrSchild solution
   const double mass = 1.01;
@@ -90,11 +95,25 @@ void test_schwarzschild(const DataType& used_for_size) {
   const auto& dt_shift =
       get<Tags::dt<gr::Tags::Shift<3, Frame, DataType>>>(vars);
   const auto& g = get<gr::Tags::SpatialMetric<3, Frame, DataType>>(vars);
+  const auto& ig =
+      get<gr::Tags::InverseSpatialMetric<3, Frame, DataType>>(vars);
+
   const auto& dt_g =
       get<Tags::dt<gr::Tags::SpatialMetric<3, Frame, DataType>>>(vars);
   const auto& d_g = get<
       typename gr::Solutions::KerrSchild::DerivSpatialMetric<DataType, Frame>>(
       vars);
+  const auto& christoffel_first_kind =
+      get<typename gr::Tags::SpatialChristoffelFirstKind<3, Frame, DataType>>(
+          vars);
+  const auto& christoffel_second_kind =
+      get<typename gr::Tags::SpatialChristoffelSecondKind<3, Frame, DataType>>(
+          vars);
+  const auto& trace_christoffel = get<
+      typename gr::Tags::TraceSpatialChristoffelSecondKind<3, Frame, DataType>>(
+      vars);
+  const auto& trace_extrinsic_curvature =
+      get<typename gr::Tags::TraceExtrinsicCurvature<DataType>>(vars);
 
   // Check those quantities that should be zero.
   const auto zero = make_with_value<DataType>(x, 0.);
@@ -149,6 +168,7 @@ void test_schwarzschild(const DataType& used_for_size) {
     expected_g.get(i, i) += 1.0;
   }
   CHECK_ITERABLE_APPROX(g, expected_g);
+  CHECK_ITERABLE_APPROX(ig, determinant_and_inverse(expected_g).second);
 
   auto expected_d_g = make_with_value<tnsr::ijj<DataType, 3, Frame>>(x, 0.0);
   for (size_t k = 0; k < 3; ++k) {
@@ -166,6 +186,53 @@ void test_schwarzschild(const DataType& used_for_size) {
     }
   }
   CHECK_ITERABLE_APPROX(d_g, expected_d_g);
+
+  auto expected_christoffel_first_kind =
+      make_with_value<tnsr::ijj<DataType, 3, Frame>>(x, 0.0);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      for (size_t k = j; k < 3; ++k) {
+        const double delta_jk = j == k ? 1. : 0.;
+        expected_christoffel_first_kind.get(i, j, k) =
+            mass * x.get(i) *
+            (-3. * x.get(j) * x.get(k) + 2. * square(r) * delta_jk) / pow(r, 5);
+      }
+    }
+  }
+  CHECK_ITERABLE_APPROX(christoffel_first_kind,
+                        expected_christoffel_first_kind);
+
+  auto expected_christoffel_second_kind =
+      make_with_value<tnsr::Ijj<DataType, 3, Frame>>(x, 0.0);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      for (size_t k = j; k < 3; ++k) {
+        const double delta_jk = j == k ? 1. : 0.;
+        expected_christoffel_second_kind.get(i, j, k) =
+            x.get(i) * mass *
+            (-3. * x.get(j) * x.get(k) + 2. * square(r) * delta_jk) /
+            (2. * mass * pow(r, 4) + pow(r, 5));
+      }
+    }
+  }
+  CHECK_ITERABLE_APPROX(christoffel_second_kind,
+                        expected_christoffel_second_kind);
+
+  auto expected_trace_christoffel =
+      make_with_value<tnsr::I<DataType, 3, Frame>>(x, 0.0);
+  DataType factor =
+      mass * (8. * mass + 3. * r) / (2. * mass + r) / (2. * mass + r) / r / r;
+  for (size_t i = 0; i < 3; ++i) {
+    expected_trace_christoffel.get(i) = factor * x.get(i);
+  }
+  CHECK_ITERABLE_APPROX(trace_christoffel, expected_trace_christoffel);
+
+  auto expected_trace_extrinsic_curvature =
+      make_with_value<Scalar<DataType>>(x, 0.0);
+  expected_trace_extrinsic_curvature.get() =
+      2. * mass * (3. * mass + r) * pow((2. * mass + r) * r, -1.5);
+  CHECK_ITERABLE_APPROX(trace_extrinsic_curvature,
+                        expected_trace_extrinsic_curvature);
 }
 
 template <typename FrameType>

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_Minkowski.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_Minkowski.cpp
@@ -52,8 +52,9 @@ void test_minkowski(const T& value) {
   const auto d_shift = get<Tags::deriv<gr::Tags::Shift<Dim, Frame::Inertial, T>,
                                        tmpl::size_t<Dim>, Frame::Inertial>>(
       minkowski.variables(
-          x, t, tmpl::list<Tags::deriv<gr::Tags::Shift<Dim, Frame::Inertial, T>,
-                                       tmpl::size_t<Dim>, Frame::Inertial>>{}));
+          x, t,
+          tmpl::list<Tags::deriv<gr::Tags::Shift<Dim, Frame::Inertial, T>,
+                                 tmpl::size_t<Dim>, Frame::Inertial>>{}));
   const auto g =
       get<gr::Tags::SpatialMetric<Dim, Frame::Inertial, T>>(minkowski.variables(
           x, t,
@@ -61,8 +62,9 @@ void test_minkowski(const T& value) {
   const auto dt_g =
       get<Tags::dt<gr::Tags::SpatialMetric<Dim, Frame::Inertial, T>>>(
           minkowski.variables(
-              x, t, tmpl::list<Tags::dt<
-                        gr::Tags::SpatialMetric<Dim, Frame::Inertial, T>>>{}));
+              x, t,
+              tmpl::list<Tags::dt<
+                  gr::Tags::SpatialMetric<Dim, Frame::Inertial, T>>>{}));
   const auto d_g =
       get<Tags::deriv<gr::Tags::SpatialMetric<Dim, Frame::Inertial, T>,
                       tmpl::size_t<Dim>, Frame::Inertial>>(
@@ -88,16 +90,28 @@ void test_minkowski(const T& value) {
       get<Tags::dt<gr::Tags::SqrtDetSpatialMetric<T>>>(minkowski.variables(
           x, t, tmpl::list<Tags::dt<gr::Tags::SqrtDetSpatialMetric<T>>>{}));
 
+  const auto trace_christoffel =
+      get<gr::Tags::TraceSpatialChristoffelSecondKind<Dim, Frame::Inertial, T>>(
+          minkowski.variables(
+              x, t,
+              tmpl::list<gr::Tags::TraceSpatialChristoffelSecondKind<
+                  Dim, Frame::Inertial, T>>{}));
+  const auto trace_extrinsic_curvature =
+      get<gr::Tags::TraceExtrinsicCurvature<T>>(minkowski.variables(
+          x, t, tmpl::list<gr::Tags::TraceExtrinsicCurvature<T>>{}));
+
   CHECK(lapse.get() == one);
   CHECK(dt_lapse.get() == zero);
   CHECK(det_g.get() == one);
   CHECK(dt_det_g.get() == zero);
+  CHECK(trace_extrinsic_curvature.get() == zero);
   for (size_t i = 0; i < Dim; ++i) {
     CHECK(shift.get(i) == zero);
     CHECK(dt_shift.get(i) == zero);
     CHECK(d_lapse.get(i) == zero);
     CHECK(g.get(i, i) == one);
     CHECK(inv_g.get(i, i) == one);
+    CHECK(trace_christoffel.get(i) == zero);
     for (size_t j = 0; j < i; ++j) {
       CHECK(g.get(i, j) == zero);
       CHECK(inv_g.get(i, j) == zero);

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_Minkowski.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_Minkowski.cpp
@@ -89,7 +89,22 @@ void test_minkowski(const T& value) {
   const auto dt_det_g =
       get<Tags::dt<gr::Tags::SqrtDetSpatialMetric<T>>>(minkowski.variables(
           x, t, tmpl::list<Tags::dt<gr::Tags::SqrtDetSpatialMetric<T>>>{}));
-
+  const auto d_det_g =
+      get<gr::Tags::DerivDetSpatialMetric<Dim, Frame::Inertial, T>>(
+          minkowski.variables(
+              x, t,
+              tmpl::list<
+                  gr::Tags::DerivDetSpatialMetric<Dim, Frame::Inertial, T>>{}));
+  const auto christoffel_first_kind =
+      get<gr::Tags::SpatialChristoffelFirstKind<Dim, Frame::Inertial, T>>(
+          minkowski.variables(x, t,
+                              tmpl::list<gr::Tags::SpatialChristoffelFirstKind<
+                                  Dim, Frame::Inertial, T>>{}));
+  const auto christoffel_second_kind =
+      get<gr::Tags::SpatialChristoffelSecondKind<Dim, Frame::Inertial, T>>(
+          minkowski.variables(x, t,
+                              tmpl::list<gr::Tags::SpatialChristoffelSecondKind<
+                                  Dim, Frame::Inertial, T>>{}));
   const auto trace_christoffel =
       get<gr::Tags::TraceSpatialChristoffelSecondKind<Dim, Frame::Inertial, T>>(
           minkowski.variables(
@@ -111,6 +126,7 @@ void test_minkowski(const T& value) {
     CHECK(d_lapse.get(i) == zero);
     CHECK(g.get(i, i) == one);
     CHECK(inv_g.get(i, i) == one);
+    CHECK(d_det_g.get(i) == zero);
     CHECK(trace_christoffel.get(i) == zero);
     for (size_t j = 0; j < i; ++j) {
       CHECK(g.get(i, j) == zero);
@@ -121,6 +137,8 @@ void test_minkowski(const T& value) {
       CHECK(dt_g.get(i, j) == zero);
       CHECK(extrinsic_curvature.get(i, j) == zero);
       for (size_t k = 0; k < Dim; ++k) {
+        CHECK(christoffel_first_kind.get(i, j, k) == zero);
+        CHECK(christoffel_second_kind.get(i, j, k) == zero);
         CHECK(d_g.get(i, j, k) == zero);
       }
     }


### PR DESCRIPTION
These quantities are needed for the CSW system evolution and I will replace the way this is currently handled (with a large amount of unnecessary compute tags in the DataBox) with a follow-up PR.
The Schwarzschild quantities are computed analytically and added to the unit test.