### PR TITLE
Replace CSW compute tags

### DIFF
--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -273,16 +273,6 @@ struct EvolutionMetavars {
   using dg_registration_list =
       tmpl::list<observers::Actions::RegisterEventsWithObservers>;
 
-  using gr_compute_tags =
-      tmpl::list<gr::Tags::SpatialChristoffelFirstKindCompute<
-                     Dim, Frame::Inertial, DataVector>,
-                 gr::Tags::SpatialChristoffelSecondKindCompute<
-                     Dim, Frame::Inertial, DataVector>,
-                 gr::Tags::TraceSpatialChristoffelSecondKindCompute<
-                     Dim, Frame::Inertial, DataVector>,
-                 GeneralizedHarmonic::Tags::TraceExtrinsicCurvatureCompute<
-                     Dim, Frame::Inertial>>;
-
   using initialization_actions = tmpl::list<
       Initialization::Actions::TimeAndTimeStep<EvolutionMetavars>,
       evolution::dg::Initialization::Domain<volume_dim>,
@@ -294,9 +284,8 @@ struct EvolutionMetavars {
           CurvedScalarWave::Initialization::InitializeConstraintDampingGammas<
               volume_dim>,
           CurvedScalarWave::Initialization::InitializeGrVars<volume_dim>>,
-      Initialization::Actions::AddComputeTags<tmpl::flatten<
-          tmpl::list<StepChoosers::step_chooser_compute_tags<EvolutionMetavars>,
-                     gr_compute_tags>>>,
+      Initialization::Actions::AddComputeTags<tmpl::flatten<tmpl::list<
+          StepChoosers::step_chooser_compute_tags<EvolutionMetavars>>>>,
       ::evolution::dg::Initialization::Mortars<volume_dim, system>,
       intrp::Actions::ElementInitInterpPoints<
           intrp::Tags::InterpPointInfo<EvolutionMetavars>>,

--- a/src/Evolution/Systems/CurvedScalarWave/System.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/System.hpp
@@ -42,21 +42,17 @@ struct System {
   using gradients_tags = gradient_variables;
 
   using spacetime_variables_tag = ::Tags::Variables<tmpl::list<
-      gr::Tags::Lapse<DataVector>, ::Tags::dt<gr::Tags::Lapse<DataVector>>,
+      gr::Tags::Lapse<DataVector>,
       ::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<Dim>,
                     Frame::Inertial>,
       gr::Tags::Shift<volume_dim, Frame::Inertial, DataVector>,
-      ::Tags::dt<gr::Tags::Shift<volume_dim, Frame::Inertial, DataVector>>,
       ::Tags::deriv<gr::Tags::Shift<Dim, Frame::Inertial, DataVector>,
                     tmpl::size_t<Dim>, Frame::Inertial>,
       gr::Tags::SpatialMetric<volume_dim, Frame::Inertial, DataVector>,
-      ::Tags::dt<
-          gr::Tags::SpatialMetric<volume_dim, Frame::Inertial, DataVector>>,
-      ::Tags::deriv<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataVector>,
-                    tmpl::size_t<Dim>, Frame::Inertial>,
-      gr::Tags::SqrtDetSpatialMetric<DataVector>,
-      gr::Tags::ExtrinsicCurvature<volume_dim, Frame::Inertial, DataVector>,
-      gr::Tags::InverseSpatialMetric<volume_dim, Frame::Inertial, DataVector>>>;
+      gr::Tags::InverseSpatialMetric<volume_dim, Frame::Inertial, DataVector>,
+      gr::Tags::TraceSpatialChristoffelSecondKind<volume_dim, Frame::Inertial,
+                                                  DataVector>,
+      gr::Tags::TraceExtrinsicCurvature<DataVector>>>;
 
   using compute_volume_time_derivative_terms = TimeDerivative<Dim>;
   using normal_dot_fluxes = ComputeNormalDotFluxes<Dim>;


### PR DESCRIPTION
Replaces the `gr_compute_tags` by directly computing them from the KS solution.

~~depends on #4148 and #4150~~
