### PR TITLE
Dynamical creation and destruction of array element chares

### DIFF
--- a/src/Parallel/Algorithms/AlgorithmArray.ci
+++ b/src/Parallel/Algorithms/AlgorithmArray.ci
@@ -5,6 +5,7 @@ module AlgorithmArray {
 
   include "DataStructures/DataBox/DataBox.hpp";
   include "Utilities/TaggedTuple.hpp";
+  include "Parallel/Callback.hpp";
   include "Parallel/GlobalCache.decl.h";
   include "Parallel/MaxInlineMethodsReached.hpp";
   include "Parallel/Phase.hpp";
@@ -27,6 +28,11 @@ module AlgorithmArray {
         tuples::tagged_tuple_from_typelist<
             typename ParallelComponent::initialization_tags>
             initialization_items);
+
+    entry AlgorithmArray(
+        Parallel::CProxy_GlobalCache<typename ParallelComponent::metavariables>,
+        Parallel::Phase, std::unique_ptr<Parallel::Callback>,
+        std::deque<typename ParallelComponent::array_index>);
 
     // Ordinarily, indiscriminate use of [inline] has the danger of arbitrarily
     // deep recursive function calls, which then exceed the stack limits of the

--- a/src/Parallel/Algorithms/AlgorithmSingleton.ci
+++ b/src/Parallel/Algorithms/AlgorithmSingleton.ci
@@ -1,0 +1,39 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+module AlgorithmSingleton {
+
+  include "Utilities/TaggedTuple.hpp";
+  include "Parallel/GlobalCache.decl.h";
+  include "Parallel/Phase.hpp";
+
+  template <typename ParallelComponent, typename SpectreArrayIndex>
+  array [SpectreIndex_detail::ArrayIndex<SpectreArrayIndex>] AlgorithmSingleton{
+    entry AlgorithmSingleton(
+        Parallel::CProxy_GlobalCache<typename ParallelComponent::metavariables>,
+        tuples::tagged_tuple_from_typelist<
+            typename ParallelComponent::initialization_tags>
+            initialization_items);
+
+    template <typename Action, typename... Args>
+    entry void simple_action(std::tuple<Args...> & args);
+
+    template <typename Action>
+    entry void simple_action();
+
+    template <typename Action, typename Arg>
+    entry [reductiontarget] void reduction_action(Arg arg);
+
+    entry void perform_algorithm();
+
+    entry void perform_algorithm(bool);
+
+    entry void start_phase(Parallel::Phase);
+
+    template <typename ReceiveTag, typename ReceiveData_t>
+    entry void receive_data(typename ReceiveTag::temporal_id&, ReceiveData_t&,
+                            bool enable_if_disabled = false);
+
+    entry void set_terminate(bool);
+  }
+}

--- a/src/Parallel/Algorithms/AlgorithmSingleton.hpp
+++ b/src/Parallel/Algorithms/AlgorithmSingleton.hpp
@@ -41,4 +41,6 @@ class AlgorithmSingleton
                              phase_dependent_action_list>::DistributedObject;
 };
 
-#include "Parallel/Algorithms/AlgorithmArray.hpp"
+#define CK_TEMPLATES_ONLY
+#include "Algorithms/AlgorithmSingleton.def.h"
+#undef CK_TEMPLATES_ONLY

--- a/src/Parallel/Algorithms/AlgorithmSingletonDeclarations.hpp
+++ b/src/Parallel/Algorithms/AlgorithmSingletonDeclarations.hpp
@@ -5,7 +5,7 @@
 
 #include "Parallel/ArrayIndex.hpp"
 
-#include "Parallel/Algorithms/AlgorithmArray.decl.h"
+#include "Parallel/Algorithms/AlgorithmSingleton.decl.h"
 
 namespace Parallel {
 namespace Algorithms {
@@ -30,16 +30,19 @@ namespace Algorithms {
  */
 struct Singleton {
   template <typename ParallelComponent, typename SpectreArrayIndex>
-  using cproxy = CProxy_AlgorithmArray<ParallelComponent, SpectreArrayIndex>;
+  using cproxy =
+      CProxy_AlgorithmSingleton<ParallelComponent, SpectreArrayIndex>;
 
   template <typename ParallelComponent, typename SpectreArrayIndex>
-  using cbase = CBase_AlgorithmArray<ParallelComponent, SpectreArrayIndex>;
+  using cbase = CBase_AlgorithmSingleton<ParallelComponent, SpectreArrayIndex>;
 
   template <typename ParallelComponent, typename SpectreArrayIndex>
-  using algorithm_type = AlgorithmArray<ParallelComponent, SpectreArrayIndex>;
+  using algorithm_type =
+      AlgorithmSingleton<ParallelComponent, SpectreArrayIndex>;
 
   template <typename ParallelComponent, typename SpectreArrayIndex>
-  using ckindex = CkIndex_AlgorithmArray<ParallelComponent, SpectreArrayIndex>;
+  using ckindex =
+      CkIndex_AlgorithmSingleton<ParallelComponent, SpectreArrayIndex>;
 
   template <typename ParallelComponent, typename SpectreArrayIndex>
   using cproxy_section = void;

--- a/src/Parallel/Algorithms/CMakeLists.txt
+++ b/src/Parallel/Algorithms/CMakeLists.txt
@@ -4,7 +4,7 @@
 add_charm_module(AlgorithmArray)
 add_charm_module(AlgorithmGroup)
 add_charm_module(AlgorithmNodegroup)
-# No Singleton because Spectre's Singleton is built on Charm++'s Array
+add_charm_module(AlgorithmSingleton)
 
 spectre_target_headers(
   ${LIBRARY}
@@ -25,5 +25,5 @@ add_dependencies(
   module_AlgorithmArray
   module_AlgorithmGroup
   module_AlgorithmNodegroup
-  # No Singleton because Spectre's Singleton is built on Charm++'s Array
+  module_AlgorithmSingleton
   )

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -100,6 +100,7 @@ add_algorithm_test("AlgorithmNodelock")
 add_algorithm_test("AlgorithmParallel")
 add_algorithm_test("AlgorithmReduction")
 add_algorithm_test("Callback")
+add_algorithm_test("DynamicInsertion")
 add_algorithm_test("PhaseChangeMain")
 add_algorithm_test(
   "SectionReductions"

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -99,6 +99,7 @@ function is not invoked via a proxy, which we do not allow.")
 add_algorithm_test("AlgorithmNodelock")
 add_algorithm_test("AlgorithmParallel")
 add_algorithm_test("AlgorithmReduction")
+add_algorithm_test("Callback")
 add_algorithm_test("PhaseChangeMain")
 add_algorithm_test(
   "SectionReductions"

--- a/tests/Unit/Parallel/Test_AlgorithmLocalSyncAction.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmLocalSyncAction.cpp
@@ -220,7 +220,7 @@ struct ArrayComponent {
     auto& array_proxy =
         Parallel::get_parallel_component<ArrayComponent>(local_cache);
     // we only want one array component for this test.
-    array_proxy[0].insert(global_cache, {}, 0);
+    array_proxy[0].insert(global_cache, tuples::TaggedTuple<>{}, 0);
   }
 
   static void execute_next_phase(

--- a/tests/Unit/Parallel/Test_AlgorithmPhaseControl.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmPhaseControl.cpp
@@ -146,7 +146,7 @@ struct ComponentAlpha {
     auto& array_proxy =
         Parallel::get_parallel_component<ComponentAlpha>(local_cache);
 
-    array_proxy[0].insert(global_cache, {}, 0);
+    array_proxy[0].insert(global_cache, tuples::TaggedTuple<>{}, 0);
     array_proxy.doneInserting();
   }
 

--- a/tests/Unit/Parallel/Test_Callback.cpp
+++ b/tests/Unit/Parallel/Test_Callback.cpp
@@ -1,0 +1,271 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+// Need CATCH_CONFIG_RUNNER to avoid linking errors with Catch2
+#define CATCH_CONFIG_RUNNER
+
+#include "Framework/TestingFramework.hpp"
+
+#include <memory>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Parallel/RoundRobinArrayElements.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/AlgorithmExecution.hpp"
+#include "Parallel/Algorithms/AlgorithmArray.hpp"
+#include "Parallel/Algorithms/AlgorithmSingleton.hpp"
+#include "Parallel/Callback.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
+#include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/MemoryHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct Value : db::SimpleTag {
+  using type = double;
+};
+
+struct TimesIterableActionCalled : db::SimpleTag {
+  using type = int;
+};
+
+struct InitializeValue {
+  using simple_tags = tmpl::list<Value, TimesIterableActionCalled>;
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& array_index, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    Initialization::mutate_assign<simple_tags>(make_not_null(&box),
+                                               array_index + 1.0, 0);
+    return {Parallel::AlgorithmExecution::Halt, std::nullopt};
+  }
+};
+
+struct IncrementValue {
+  template <typename ParallelComponent, typename DbTagList,
+            typename Metavariables, typename ArrayIndex>
+  static void apply(db::DataBox<DbTagList>& box,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/) {
+    db::mutate<Value>(
+        make_not_null(&box),
+        [](const gsl::not_null<double*> value) { *value += 1.0; });
+  }
+};
+
+struct MultiplyValueByFactor {
+  template <typename ParallelComponent, typename DbTagList,
+            typename Metavariables, typename ArrayIndex>
+  static void apply(db::DataBox<DbTagList>& box,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/, const double factor) {
+    db::mutate<Value>(
+        make_not_null(&box),
+        [&factor](const gsl::not_null<double*> value) { *value *= factor; });
+  }
+};
+
+struct DoubleValueOfElement0 {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& array_index, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    db::mutate<TimesIterableActionCalled>(
+        make_not_null(&box),
+        [](const gsl::not_null<int*> counter) { ++(*counter); });
+    if (array_index == 0) {
+      db::mutate<Value>(
+          make_not_null(&box),
+          [](const gsl::not_null<double*> value) { *value *= 2.0; });
+      if (db::get<TimesIterableActionCalled>(box) < 5) {
+        return {Parallel::AlgorithmExecution::Retry, std::nullopt};
+      }
+    }
+    return {Parallel::AlgorithmExecution::Halt, std::nullopt};
+  }
+};
+
+struct CheckValue {
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
+  static void apply(db::DataBox<DbTags>& box,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& array_index) {
+    const double value = db::get<Value>(box);
+    const int counter = db::get<TimesIterableActionCalled>(box);
+    if (array_index == 0) {
+      SPECTRE_PARALLEL_REQUIRE(value == 32.0);
+      SPECTRE_PARALLEL_REQUIRE(counter == 5);
+    } else {
+      SPECTRE_PARALLEL_REQUIRE(counter == 1);
+      SPECTRE_PARALLEL_REQUIRE(value == (array_index == 1 ? 6.0 : 27.0));
+    }
+  }
+};
+
+template <class Metavariables>
+struct TestArray {
+  using chare_type = Parallel::Algorithms::Array;
+  using metavariables = Metavariables;
+  using array_index = int;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
+                                        tmpl::list<InitializeValue>>,
+                 Parallel::PhaseActions<Parallel::Phase::Execute,
+                                        tmpl::list<DoubleValueOfElement0>>>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+
+  static void allocate_array(
+      Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
+      const tuples::tagged_tuple_from_typelist<initialization_tags>&
+      /*initialization_items*/,
+      const std::unordered_set<size_t>& procs_to_ignore = {}) {
+    auto& local_cache = *Parallel::local_branch(global_cache);
+    auto& array_proxy =
+        Parallel::get_parallel_component<TestArray>(local_cache);
+    size_t number_of_elements = 3;
+    TestHelpers::Parallel::assign_array_elements_round_robin_style(
+        array_proxy, number_of_elements,
+        static_cast<size_t>(sys::number_of_procs()), {}, global_cache,
+        procs_to_ignore);
+  }
+
+  static void execute_next_phase(
+      const Parallel::Phase next_phase,
+      Parallel::CProxy_GlobalCache<Metavariables>& global_cache) {
+    auto& local_cache = *Parallel::local_branch(global_cache);
+    auto& my_proxy = Parallel::get_parallel_component<TestArray>(local_cache);
+    my_proxy.start_phase(next_phase);
+    if (next_phase == Parallel::Phase::Testing) {
+      Parallel::simple_action<CheckValue>(my_proxy);
+    }
+  }
+};
+
+struct RunCallbacks {
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
+  static void apply(db::DataBox<DbTags>& /*box*/,
+                    const Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/) {
+    auto& array_proxy =
+        Parallel::get_parallel_component<TestArray<Metavariables>>(cache);
+    auto proxy_0 = array_proxy[0];
+    auto proxy_1 = array_proxy[1];
+    auto proxy_2 = array_proxy[2];
+    Parallel::PerformAlgorithmCallback<decltype(proxy_0)> callback_0(proxy_0);
+    Parallel::SimpleActionCallback<IncrementValue, decltype(proxy_1)>
+        callback_1(proxy_1);
+    Parallel::SimpleActionCallback<MultiplyValueByFactor, decltype(proxy_2),
+                                   double>
+        callback_2(proxy_2, 1.5);
+    callback_0.invoke();
+    callback_1.invoke();
+    callback_2.invoke();
+    auto callback_3 = serialize_and_deserialize(callback_0);
+    auto callback_4 = serialize_and_deserialize(callback_1);
+    auto callback_5 = serialize_and_deserialize(callback_2);
+    callback_3.invoke();
+    callback_4.invoke();
+    callback_5.invoke();
+    std::vector<std::unique_ptr<Parallel::Callback>> callbacks;
+    callbacks.emplace_back(
+        std::make_unique<Parallel::PerformAlgorithmCallback<decltype(proxy_0)>>(
+            proxy_0));
+    callbacks.emplace_back(
+        std::make_unique<
+            Parallel::SimpleActionCallback<IncrementValue, decltype(proxy_1)>>(
+            proxy_1));
+    callbacks.emplace_back(
+        std::make_unique<Parallel::SimpleActionCallback<
+            MultiplyValueByFactor, decltype(proxy_2), double>>(proxy_2, 2.0));
+    for (const auto& callback : callbacks) {
+      callback->invoke();
+    }
+    auto pupped_callbacks = serialize_and_deserialize(callbacks);
+    for (const auto& callback : pupped_callbacks) {
+      callback->invoke();
+    }
+  }
+};
+
+template <class Metavariables>
+struct TestSingleton {
+  using chare_type = Parallel::Algorithms::Singleton;
+  using array_index = int;
+  using metavariables = Metavariables;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+
+  static void execute_next_phase(
+      const Parallel::Phase next_phase,
+      const Parallel::CProxy_GlobalCache<Metavariables>& global_cache) {
+    auto& local_cache = *Parallel::local_branch(global_cache);
+    auto& my_proxy =
+        Parallel::get_parallel_component<TestSingleton>(local_cache);
+    my_proxy.start_phase(next_phase);
+    if (next_phase == Parallel::Phase::Execute) {
+      Parallel::simple_action<RunCallbacks>(my_proxy);
+    }
+  }
+};
+
+struct TestMetavariables {
+  using component_list = tmpl::list<TestSingleton<TestMetavariables>,
+                                    TestArray<TestMetavariables>>;
+
+  static constexpr Options::String help =
+      "An executable for testing Paralell::Callbacks";
+
+  static constexpr std::array<Parallel::Phase, 4> default_phase_order{
+      {Parallel::Phase::Initialization, Parallel::Phase::Execute,
+       Parallel::Phase::Testing, Parallel::Phase::Exit}};
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) {}
+};
+
+void register_callbacks() {
+  Parallel::register_classes_with_charm(
+      tmpl::list<
+          Parallel::PerformAlgorithmCallback<
+              CProxyElement_AlgorithmArray<TestArray<TestMetavariables>, int>>,
+          Parallel::SimpleActionCallback<
+              IncrementValue,
+              CProxyElement_AlgorithmArray<TestArray<TestMetavariables>, int>>,
+          Parallel::SimpleActionCallback<
+              MultiplyValueByFactor,
+              CProxyElement_AlgorithmArray<TestArray<TestMetavariables>, int>,
+              double>>{});
+}
+}  //  namespace
+
+static const std::vector<void (*)()> charm_init_node_funcs{
+    &setup_error_handling, &setup_memory_allocation_failure_reporting,
+    &register_callbacks};
+static const std::vector<void (*)()> charm_init_proc_funcs{
+    &enable_floating_point_exceptions};
+
+using charmxx_main_component = Parallel::Main<TestMetavariables>;
+
+#include "Parallel/CharmMain.tpp"

--- a/tests/Unit/Parallel/Test_DynamicInsertion.cpp
+++ b/tests/Unit/Parallel/Test_DynamicInsertion.cpp
@@ -1,0 +1,348 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+// Need CATCH_CONFIG_RUNNER to avoid linking errors with Catch2
+#define CATCH_CONFIG_RUNNER
+
+#include "Framework/TestingFramework.hpp"
+
+#include <deque>
+#include <memory>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Helpers/Parallel/RoundRobinArrayElements.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/AlgorithmExecution.hpp"
+#include "Parallel/Algorithms/AlgorithmArray.hpp"
+#include "Parallel/Algorithms/AlgorithmSingleton.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Reduction.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
+#include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
+#include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/MemoryHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+// This executable tests dynamic insertion and deletion of array chare elements.
+//
+// In Parallel::Phase::Initialization 92 elements are created with the simple
+// item Value.  The action InitializeValue is called which sets the Value to be
+// the array index of the element plus one.
+//
+// In Parallel::Phase::Execute, the simple action ChangeArray is called.
+//    - Elements with array index 0 and 1 and prime numbers > 46 are unchanged
+//    - Each element with an array index that is a power of 2 is split into a
+//      number of children equal to the array index.  Each child will eventually
+//      set Value to be (array index / number of children) while the parent will
+//      eventually be deleted.
+//    - Each element with an array index that is a prime number in the range
+//      [3,46] will be joined with those elements whose array index has prime
+//      factors less than or equal to it (e.g. 3 will join any element whose
+//      array index is 2^m 3^n for some (m,n)).  The newly created parent
+//      element will eventually set its Value to the sum of the Values of the
+//      children, while the children will eventually be deleted.
+//
+//   An element that is split will create its children sequentially, with the
+//   last created child element executing the callback of the simple action
+//   SendDataToChildren.  SendDataToChildren sends each child its share of Value
+//   by calling the simple action SetValue and then deletes the parent element.
+//
+//   The prime member of joining elements will create the new parent element and
+//   execute the callback CollectDataFromChildren on the prime member.
+//   CollectDataFromChildren will collect data from the child, either call
+//   CollectDataFromChildren on the next child or (when executing on the last
+//   child) call SetValue on the new parent element, and then delete the child
+//   element.
+//
+// In Parallel::Phase::Testing, the Values are summed over all the array
+// elements via the reduction action ArrayReduce which executes the
+// CheckReduction action on the singleton component.  The test succeeds if the
+// sum over values of the array has been preserved.
+
+namespace {
+static constexpr int initial_number_of_1d_array_elements = 92;
+static const double expected_value = 0.5 * initial_number_of_1d_array_elements *
+                                     (initial_number_of_1d_array_elements + 1);
+
+struct CheckReduction {
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
+  static void apply(db::DataBox<DbTags>& /*box*/,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/, const double& value) {
+    SPECTRE_PARALLEL_REQUIRE(expected_value == value);
+  }
+};
+
+struct Value : db::SimpleTag {
+  using type = double;
+};
+
+template <class Metavariables>
+struct TestSingleton {
+  using chare_type = Parallel::Algorithms::Singleton;
+  using array_index = int;
+  using metavariables = Metavariables;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+
+  static void execute_next_phase(
+      const Parallel::Phase /*next_phase*/,
+      const Parallel::CProxy_GlobalCache<Metavariables>& /*global_cache*/) {}
+};
+
+struct InitializeValue {
+  using simple_tags = tmpl::list<Value>;
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& array_index, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    Initialization::mutate_assign<simple_tags>(make_not_null(&box),
+                                               array_index + 1.0);
+    return {Parallel::AlgorithmExecution::Halt, std::nullopt};
+  }
+};
+
+struct ArrayReduce {
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
+  static void apply(const db::DataBox<DbTags>& box,
+                    const Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& array_index) {
+    const auto& my_proxy =
+        Parallel::get_parallel_component<ParallelComponent>(cache)[array_index];
+    const auto& singleton_proxy =
+        Parallel::get_parallel_component<TestSingleton<Metavariables>>(cache);
+    Parallel::ReductionData<Parallel::ReductionDatum<double, funcl::Plus<>>>
+        reduction_data{db::get<Value>(box)};
+    Parallel::contribute_to_reduction<CheckReduction>(reduction_data, my_proxy,
+                                                      singleton_proxy);
+  }
+};
+
+struct SetValue {
+  template <typename ParallelComponent, typename DbTagList,
+            typename Metavariables, typename ArrayIndex>
+  static void apply(db::DataBox<DbTagList>& box,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/, const double value) {
+    db::mutate<Value>(make_not_null(&box),
+                      [&value](const gsl::not_null<double*> box_value) {
+                        *box_value = value;
+                      });
+  }
+};
+
+struct SendDataToChildren {
+  template <typename ParallelComponent, typename DbTagList,
+            typename Metavariables, typename ArrayIndex>
+  static void apply(db::DataBox<DbTagList>& box,
+                    const Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& array_index,
+                    const std::vector<ArrayIndex>& new_ids) {
+    const double value = db::get<Value>(box) / new_ids.size();
+    auto& array_proxy =
+        Parallel::get_parallel_component<ParallelComponent>(cache);
+    for (const auto& new_id : new_ids) {
+      Parallel::simple_action<SetValue>(array_proxy[new_id], value);
+    }
+    array_proxy[array_index].ckDestroy();
+  }
+};
+
+struct CollectDataFromChildren {
+  template <typename ParallelComponent, typename DbTagList,
+            typename Metavariables, typename ArrayIndex>
+  static void apply(db::DataBox<DbTagList>& box,
+                    const Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& array_index,
+                    const ArrayIndex& parent_index,
+                    std::deque<ArrayIndex> additional_children_ids,
+                    double accumulated_value) {
+    accumulated_value += db::get<Value>(box);
+    auto& array_proxy =
+        Parallel::get_parallel_component<ParallelComponent>(cache);
+    if (additional_children_ids.empty()) {
+      Parallel::simple_action<SetValue>(array_proxy[parent_index],
+                                        accumulated_value);
+    } else {
+      const auto next_child_id = additional_children_ids.front();
+      additional_children_ids.pop_front();
+      Parallel::simple_action<CollectDataFromChildren>(
+          array_proxy[next_child_id], parent_index, additional_children_ids,
+          accumulated_value);
+    }
+    array_proxy[array_index].ckDestroy();
+  }
+};
+
+struct ChangeArray {
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
+  static void apply(const db::DataBox<DbTags>& /*box*/,
+                    const Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& array_index) {
+    auto& array_proxy =
+        Parallel::get_parallel_component<ParallelComponent>(cache);
+    auto my_proxy = array_proxy[array_index];
+    auto create_children = [&cache, &array_index, &array_proxy,
+                            &my_proxy](const size_t number_of_new_elements) {
+      std::vector<int> new_ids(number_of_new_elements);
+      std::iota(new_ids.begin(), new_ids.end(), 100 * array_index);
+      std::deque<int> other_ids_to_create(new_ids.begin(), new_ids.end());
+      other_ids_to_create.pop_front();
+      array_proxy(new_ids.front())
+          .insert(
+              cache.thisProxy, Parallel::Phase::Execute,
+              std::make_unique<Parallel::SimpleActionCallback<
+                  SendDataToChildren, decltype(my_proxy), std::vector<int>>>(
+                  my_proxy, std::move(new_ids)),
+              other_ids_to_create);
+    };
+
+    auto create_parent = [&cache, &array_proxy,
+                          &my_proxy](std::deque<int> ids_to_join) {
+      int id_of_first_child = ids_to_join.front();
+      ids_to_join.pop_front();
+      int parent_id = 100 * id_of_first_child;
+      array_proxy(parent_id).insert(
+          cache.thisProxy, Parallel::Phase::Execute,
+          std::make_unique<Parallel::SimpleActionCallback<
+              CollectDataFromChildren, decltype(my_proxy), int, std::deque<int>,
+              double>>(my_proxy, std::move(parent_id), std::move(ids_to_join),
+                       0.0),
+          std::deque<int>{});
+    };
+
+    std::vector<size_t> ids_to_split{2, 4, 8, 16, 32, 64};
+    std::vector<size_t> ids_to_join{3,  5,  7,  11, 13, 17, 19,
+                                    23, 29, 31, 37, 41, 43};
+
+    for (const auto id_to_split : ids_to_split) {
+      if (id_to_split == static_cast<size_t>(array_index)) {
+        create_children(id_to_split);
+      }
+    }
+
+    if (3 == array_index) {
+      create_parent({3, 6, 9, 12, 18, 24, 27, 36, 48, 54, 72, 81});
+    } else if (5 == array_index) {
+      create_parent({5, 10, 15, 20, 25, 30, 40, 45, 50, 60, 75, 80, 90});
+    } else if (7 == array_index) {
+      create_parent({7, 14, 21, 28, 35, 42, 49, 56, 63, 70, 84});
+    } else if (11 == array_index) {
+      create_parent({11, 22, 33, 44, 55, 66, 77, 88});
+    } else if (13 == array_index) {
+      create_parent({13, 26, 39, 52, 65, 78, 91});
+    } else if (17 == array_index) {
+      create_parent({17, 34, 51, 68, 85});
+    } else if (19 == array_index) {
+      create_parent({19, 38, 57, 76});
+    } else if (23 == array_index) {
+      create_parent({23, 46, 69});
+    } else if (29 == array_index) {
+      create_parent({29, 58, 87});
+    } else if (31 == array_index) {
+      create_parent({31, 62});
+    } else if (37 == array_index) {
+      create_parent({37, 74});
+    } else if (41 == array_index) {
+      create_parent({41, 82});
+    } else if (43 == array_index) {
+      create_parent({43, 86});
+    }
+  }
+};
+
+template <class Metavariables>
+struct TestArray {
+  using chare_type = Parallel::Algorithms::Array;
+  using metavariables = Metavariables;
+  using array_index = int;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
+                                        tmpl::list<InitializeValue>>>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+
+  static void allocate_array(
+      Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
+      const tuples::tagged_tuple_from_typelist<initialization_tags>&
+      /*initialization_items*/,
+      const std::unordered_set<size_t>& procs_to_ignore = {}) {
+    auto& local_cache = *Parallel::local_branch(global_cache);
+    auto& array_proxy =
+        Parallel::get_parallel_component<TestArray>(local_cache);
+
+    TestHelpers::Parallel::assign_array_elements_round_robin_style(
+        array_proxy, static_cast<size_t>(initial_number_of_1d_array_elements),
+        static_cast<size_t>(sys::number_of_procs()), {}, global_cache,
+        procs_to_ignore);
+  }
+
+  static void execute_next_phase(
+      const Parallel::Phase next_phase,
+      Parallel::CProxy_GlobalCache<Metavariables>& global_cache) {
+    auto& local_cache = *Parallel::local_branch(global_cache);
+    auto& my_proxy = Parallel::get_parallel_component<TestArray>(local_cache);
+    my_proxy.start_phase(next_phase);
+    if (next_phase == Parallel::Phase::Execute) {
+      Parallel::simple_action<ChangeArray>(my_proxy);
+    }
+    if (next_phase == Parallel::Phase::Testing) {
+      Parallel::simple_action<ArrayReduce>(my_proxy);
+    }
+  }
+};
+
+struct TestMetavariables {
+  using component_list = tmpl::list<TestSingleton<TestMetavariables>,
+                                    TestArray<TestMetavariables>>;
+
+  static constexpr Options::String help =
+      "An executable for testing the dynamic insertion and deletion of "
+      "elements of an array parallel component";
+
+  static constexpr std::array<Parallel::Phase, 4> default_phase_order{
+      {Parallel::Phase::Initialization, Parallel::Phase::Execute,
+       Parallel::Phase::Testing, Parallel::Phase::Exit}};
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) {}
+};
+
+void register_callback() {
+  Parallel::register_classes_with_charm(
+      tmpl::list<
+          Parallel::SimpleActionCallback<
+              SendDataToChildren,
+              CProxyElement_AlgorithmArray<TestArray<TestMetavariables>, int>,
+              std::vector<int>>,
+          Parallel::SimpleActionCallback<
+              CollectDataFromChildren,
+              CProxyElement_AlgorithmArray<TestArray<TestMetavariables>, int>,
+              int, std::deque<int>, double>>{});
+}
+}  //  namespace
+
+static const std::vector<void (*)()> charm_init_node_funcs{
+    &setup_error_handling, &setup_memory_allocation_failure_reporting,
+    &register_callback};
+static const std::vector<void (*)()> charm_init_proc_funcs{
+    &enable_floating_point_exceptions};
+
+using charmxx_main_component = Parallel::Main<TestMetavariables>;
+
+#include "Parallel/CharmMain.tpp"

--- a/tests/Unit/Parallel/Test_TypeTraits.cpp
+++ b/tests/Unit/Parallel/Test_TypeTraits.cpp
@@ -35,6 +35,7 @@ struct ArrayParallelComponent {
   using metavariables = Metavariables;
   using initialization_tags = tmpl::list<>;
   using chare_type = Parallel::Algorithms::Array;
+  using array_index = int;
 };
 struct GroupParallelComponent {
   using metavariables = Metavariables;
@@ -47,10 +48,9 @@ struct NodegroupParallelComponent {
   using chare_type = Parallel::Algorithms::Nodegroup;
 };
 
-// If passing proxy to a full array, we expect it to be from a
-// Parallel::Algorithms::Singleton. If passing proxy to an element, we expect it
-// to be from a Parallel::Algorithms::Array.
-using array_proxy = CProxy_AlgorithmArray<SingletonParallelComponent, int>;
+using singleton_proxy =
+    CProxy_AlgorithmSingleton<SingletonParallelComponent, int>;
+using array_proxy = CProxy_AlgorithmArray<ArrayParallelComponent, int>;
 using array_element_proxy =
     CProxyElement_AlgorithmArray<ArrayParallelComponent, int>;
 using group_proxy = CProxy_AlgorithmGroup<GroupParallelComponent, int>;
@@ -58,67 +58,48 @@ using nodegroup_proxy =
     CProxy_AlgorithmNodegroup<NodegroupParallelComponent, int>;
 }  // namespace
 
-static_assert(Parallel::is_array_proxy<array_proxy>::value,
-              "Failed testing type trait is_array_proxy");
-static_assert(not Parallel::is_array_proxy<array_element_proxy>::value,
-              "Failed testing type trait is_array_proxy");
-static_assert(not Parallel::is_array_proxy<group_proxy>::value,
-              "Failed testing type trait is_array_proxy");
-static_assert(not Parallel::is_array_proxy<nodegroup_proxy>::value,
-              "Failed testing type trait is_array_proxy");
+static_assert(Parallel::is_array_proxy<singleton_proxy>::value);
+static_assert(Parallel::is_array_proxy<array_proxy>::value);
+static_assert(not Parallel::is_array_proxy<array_element_proxy>::value);
+static_assert(not Parallel::is_array_proxy<group_proxy>::value);
+static_assert(not Parallel::is_array_proxy<nodegroup_proxy>::value);
 
-static_assert(not Parallel::is_array_element_proxy<array_proxy>::value,
-              "Failed testing type trait is_array_element_proxy");
-static_assert(Parallel::is_array_element_proxy<array_element_proxy>::value,
-              "Failed testing type trait is_array_element_proxy");
-static_assert(not Parallel::is_array_element_proxy<group_proxy>::value,
-              "Failed testing type trait is_array_element_proxy");
-static_assert(not Parallel::is_array_element_proxy<nodegroup_proxy>::value,
-              "Failed testing type trait is_array_element_proxy");
+static_assert(not Parallel::is_array_element_proxy<singleton_proxy>::value);
+static_assert(not Parallel::is_array_element_proxy<array_proxy>::value);
+static_assert(Parallel::is_array_element_proxy<array_element_proxy>::value);
+static_assert(not Parallel::is_array_element_proxy<group_proxy>::value);
+static_assert(not Parallel::is_array_element_proxy<nodegroup_proxy>::value);
 
-static_assert(not Parallel::is_group_proxy<array_proxy>::value,
-              "Failed testing type trait is_group_proxy");
-static_assert(not Parallel::is_group_proxy<array_element_proxy>::value,
-              "Failed testing type trait is_group_proxy");
-static_assert(Parallel::is_group_proxy<group_proxy>::value,
-              "Failed testing type trait is_group_proxy");
-static_assert(not Parallel::is_group_proxy<nodegroup_proxy>::value,
-              "Failed testing type trait is_group_proxy");
+static_assert(not Parallel::is_group_proxy<singleton_proxy>::value);
+static_assert(not Parallel::is_group_proxy<array_proxy>::value);
+static_assert(not Parallel::is_group_proxy<array_element_proxy>::value);
+static_assert(Parallel::is_group_proxy<group_proxy>::value);
+static_assert(not Parallel::is_group_proxy<nodegroup_proxy>::value);
 
-static_assert(not Parallel::is_node_group_proxy<array_proxy>::value,
-              "Failed testing type trait is_node_group_proxy");
-static_assert(not Parallel::is_node_group_proxy<array_element_proxy>::value,
-              "Failed testing type trait is_node_group_proxy");
-static_assert(not Parallel::is_node_group_proxy<group_proxy>::value,
-              "Failed testing type trait is_node_group_proxy");
-static_assert(Parallel::is_node_group_proxy<nodegroup_proxy>::value,
-              "Failed testing type trait is_node_group_proxy");
+static_assert(not Parallel::is_node_group_proxy<singleton_proxy>::value);
+static_assert(not Parallel::is_node_group_proxy<array_proxy>::value);
+static_assert(not Parallel::is_node_group_proxy<array_element_proxy>::value);
+static_assert(not Parallel::is_node_group_proxy<group_proxy>::value);
+static_assert(Parallel::is_node_group_proxy<nodegroup_proxy>::value);
 
 // [has_pup_member_example]
-static_assert(Parallel::has_pup_member<PupableClass>::value,
-              "Failed testing type trait has_pup_member");
-static_assert(Parallel::has_pup_member_t<PupableClass>::value,
-              "Failed testing type trait has_pup_member");
-static_assert(Parallel::has_pup_member_v<PupableClass>,
-              "Failed testing type trait has_pup_member");
-static_assert(not Parallel::has_pup_member<NonpupableClass>::value,
-              "Failed testing type trait has_pup_member");
+static_assert(Parallel::has_pup_member<PupableClass>::value);
+static_assert(Parallel::has_pup_member_t<PupableClass>::value);
+static_assert(Parallel::has_pup_member_v<PupableClass>);
+static_assert(not Parallel::has_pup_member<NonpupableClass>::value);
 // [has_pup_member_example]
 
 // [is_pupable_example]
-static_assert(Parallel::is_pupable<PupableClass>::value,
-              "Failed testing type trait is_pupable");
-static_assert(Parallel::is_pupable_t<PupableClass>::value,
-              "Failed testing type trait is_pupable");
-static_assert(Parallel::is_pupable_v<PupableClass>,
-              "Failed testing type trait is_pupable");
-static_assert(not Parallel::is_pupable<NonpupableClass>::value,
-              "Failed testing type trait is_pupable");
+static_assert(Parallel::is_pupable<PupableClass>::value);
+static_assert(Parallel::is_pupable_t<PupableClass>::value);
+static_assert(Parallel::is_pupable_v<PupableClass>);
+static_assert(not Parallel::is_pupable<NonpupableClass>::value);
 // [is_pupable_example]
 
-static_assert(std::is_same_v<
-              SingletonParallelComponent,
-              Parallel::get_parallel_component_from_proxy<array_proxy>::type>);
+static_assert(
+    std::is_same_v<
+        SingletonParallelComponent,
+        Parallel::get_parallel_component_from_proxy<singleton_proxy>::type>);
 static_assert(std::is_same_v<ArrayParallelComponent,
                              Parallel::get_parallel_component_from_proxy<
                                  array_element_proxy>::type>);


### PR DESCRIPTION
## Proposed changes

- Fix pupping of Parallel::Callback and add a test.
- Bring back the charm module AlgorithmSingleton.  It still implements singletons in terms of a one-element array chare, but this allows only arrays to have an additional constructor to add elements
- Add a constructor to DistributedObject to create a new element.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
If you create an array element on a specified chare, you may have to add the type of to the constructor call to disambiguate from the newly added constructor.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

- In order to create, destroy, and send data from parent to children (or vice versa) in an asynchronus environment, it is necessary to chain a sequence of calls to ensure that an element is created before data is sent to it, or sends its data to new elements before it is destroyed, as well as avoiding destroying an element more than once (which leads to a hang)
- The charm v6.10.2 build fails both on CI and my desktop.  Run in gdb, it seems that charm gets hung in an infinite loop while pupping the proxy contained in a concrete Parallel::Callback.  Unless someone sees something I am obviously doing wrong, this may be the point where we abandon supporting Charm v6.10.2.  Since we have not encountered any problems with v7, and we want to use some new features of v7 (and since charm isn't going to fix any bugs in v6.10.2), I don't think this is a big deal.
