### PR TITLE
Add time dependence to `CSW` system

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
+++ b/src/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
@@ -21,6 +21,7 @@ spectre_target_headers(
   HEADERS
   BackgroundSpacetime.hpp
   Characteristics.hpp
+  CalculateGrVars.hpp
   Constraints.hpp
   Equations.hpp
   Initialize.hpp

--- a/src/Evolution/Systems/CurvedScalarWave/CalculateGrVars.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/CalculateGrVars.hpp
@@ -1,0 +1,63 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Initialization/InitialData.hpp"
+#include "Evolution/Initialization/Tags.hpp"
+#include "Evolution/Systems/CurvedScalarWave/BackgroundSpacetime.hpp"
+#include "Evolution/Systems/CurvedScalarWave/System.hpp"
+#include "PointwiseFunctions/AnalyticData/Tags.hpp"
+
+namespace CurvedScalarWave::Actions {
+
+/// \ingroup ActionsGroup
+/// \brief Action that initializes or updates items related to the
+/// spacetime background of the CurvedScalarWave system
+///
+/// DataBox changes:
+/// - Adds:
+///   * `CurvedScalarWave::System::spacetime_tag_list`
+/// - Removes: nothing
+/// - Modifies: nothing
+
+template <typename System>
+struct CalculateGrVars {
+  static constexpr size_t Dim = System::volume_dim;
+  using simple_tags = db::AddSimpleTags<typename System::spacetime_tag_list>;
+  using compute_tags = db::AddComputeTags<>;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    auto initial_data = evolution::Initialization::initial_data(
+        db::get<CurvedScalarWave::Tags::BackgroundSpacetime<
+            typename Metavariables::background_spacetime>>(box),
+        db::get<domain::Tags::Coordinates<Dim, Frame::Inertial>>(box),
+        db::get<::Tags::Time>(box), typename System::spacetime_tag_list{});
+    tmpl::for_each<typename System::spacetime_tag_list>(
+        [&box, &initial_data](auto spacetime_tag_v) {
+          using spacetime_tag = tmpl::type_from<decltype(spacetime_tag_v)>;
+          db::mutate<spacetime_tag>(
+              make_not_null(&box),
+              [&initial_data](const auto spacetime_tag_ptr) {
+                *spacetime_tag_ptr =
+                    std::move(get<spacetime_tag>(initial_data));
+              });
+        });
+
+    return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+  }
+};
+}  // namespace CurvedScalarWave::Actions

--- a/src/Evolution/Systems/CurvedScalarWave/Initialize.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Initialize.hpp
@@ -132,37 +132,4 @@ struct InitializeEvolvedVariables {
   }
 };
 
-/// \ingroup InitializationGroup
-/// \brief Mutator meant to be used with
-/// `Initialization::Actions::AddSimpleTags` to initialize items related to the
-/// spacetime background of the CurvedScalarWave system
-///
-/// DataBox changes:
-/// - Adds:
-///   * `CurvedScalarWave::System::spacetime_variables_tag`
-/// - Removes: nothing
-/// - Modifies: nothing
-
-template <typename BackgroundSpacetime>
-struct InitializeGrVars {
-  static constexpr size_t Dim = BackgroundSpacetime::volume_dim;
-  using gr_vars_tag =
-      typename CurvedScalarWave::System<Dim>::spacetime_variables_tag;
-  using GrVars = typename gr_vars_tag::type;
-  using return_tags = tmpl::list<gr_vars_tag>;
-  using argument_tags = tmpl::list<
-      ::Initialization::Tags::InitialTime,
-      domain::Tags::Coordinates<Dim, Frame::Inertial>,
-      CurvedScalarWave::Tags::BackgroundSpacetime<BackgroundSpacetime>>;
-  static void apply(
-      const gsl::not_null<GrVars*> gr_vars, const double initial_time,
-      const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords,
-      const BackgroundSpacetime& background_spacetime) {
-    gr_vars->initialize(get<0>(inertial_coords).size());
-    // Set initial data from analytic solution
-    gr_vars->assign_subset(evolution::Initialization::initial_data(
-        background_spacetime, inertial_coords, initial_time,
-        typename GrVars::tags_list{}));
-  }
-};
 }  // namespace CurvedScalarWave::Initialization

--- a/src/Evolution/Systems/CurvedScalarWave/System.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/System.hpp
@@ -41,7 +41,7 @@ struct System {
   // convert to using dg::ComputeTimeDerivative
   using gradients_tags = gradient_variables;
 
-  using spacetime_variables_tag = ::Tags::Variables<tmpl::list<
+  using spacetime_tag_list = tmpl::list<
       gr::Tags::Lapse<DataVector>,
       ::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<Dim>,
                     Frame::Inertial>,
@@ -52,7 +52,7 @@ struct System {
       gr::Tags::InverseSpatialMetric<volume_dim, Frame::Inertial, DataVector>,
       gr::Tags::TraceSpatialChristoffelSecondKind<volume_dim, Frame::Inertial,
                                                   DataVector>,
-      gr::Tags::TraceExtrinsicCurvature<DataVector>>>;
+      gr::Tags::TraceExtrinsicCurvature<DataVector>>;
 
   using compute_volume_time_derivative_terms = TimeDerivative<Dim>;
   using normal_dot_fluxes = ComputeNormalDotFluxes<Dim>;

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   BoundaryConditions/Test_ConstraintPreservingSphericalRadiation.cpp
   BoundaryConditions/Test_Outflow.cpp
   Test_BackgroundSpacetime.cpp
+  Test_CalculateGrVars.cpp
   Test_Constraints.cpp
   Test_Characteristics.cpp
   Test_InitializeConstraintDampingGammas.cpp
@@ -34,6 +35,7 @@ target_link_libraries(
   GeneralRelativityHelpers
   GeneralRelativitySolutions
   MathFunctions
+  GeneralRelativitySolutions
   Utilities
   WaveEquationSolutions
 )

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_CalculateGrVars.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_CalculateGrVars.cpp
@@ -1,0 +1,98 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cmath>
+#include <limits>
+#include <random>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Initialization/NonconservativeSystem.hpp"
+#include "Evolution/Systems/CurvedScalarWave/BackgroundSpacetime.hpp"
+#include "Evolution/Systems/CurvedScalarWave/CalculateGrVars.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Parallel/Phase.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+
+template <size_t Dim, typename Metavariables>
+struct component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+
+  using initial_tags =
+      tmpl::list<CurvedScalarWave::Tags::BackgroundSpacetime<
+                     typename Metavariables::background_spacetime>,
+                 domain::Tags::Coordinates<Dim, Frame::Inertial>, ::Tags::Time>;
+
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      Parallel::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<initial_tags>,
+                 CurvedScalarWave::Actions::CalculateGrVars<
+                     typename Metavariables::system>>>>;
+};
+
+template <size_t Dim, typename System, typename BackgroundSpacetime>
+struct Metavariables {
+  using background_spacetime = BackgroundSpacetime;
+  using component_list = tmpl::list<component<Dim, Metavariables>>;
+  using system = System;
+  using const_global_cache_tag_list = tmpl::list<>;
+};
+
+template <typename BackgroundSpacetime>
+void test(const BackgroundSpacetime& background_spacetime,
+          const gsl::not_null<std::mt19937*> generator) {
+  static constexpr size_t Dim = BackgroundSpacetime::volume_dim;
+  using system = CurvedScalarWave::System<Dim>;
+  using metavars = Metavariables<Dim, system, BackgroundSpacetime>;
+  using comp = component<Dim, metavars>;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
+  MockRuntimeSystem runner{{}};
+  const size_t num_points = 42;
+  std::uniform_real_distribution dist{-10., 10.};
+  const auto random_coords = make_with_random_values<tnsr::I<DataVector, Dim>>(
+      generator, make_not_null(&dist), DataVector{num_points});
+  const double time = 0.;
+  ActionTesting::emplace_component_and_initialize<comp>(
+      &runner, 0, {background_spacetime, random_coords, time});
+  // invoke CalculateGrVars
+  ActionTesting::next_action<comp>(make_not_null(&runner), 0);
+  const auto solution_at_coords = background_spacetime.variables(
+      random_coords, time, typename system::spacetime_tag_list{});
+  // check that each tag corresponds to analytic solution now
+  tmpl::for_each<typename system::spacetime_tag_list>(
+      [&runner, &solution_at_coords](auto spacetime_tag_v) {
+        using spacetime_tag = tmpl::type_from<decltype(spacetime_tag_v)>;
+        CHECK(ActionTesting::get_databox_tag<comp, spacetime_tag>(runner, 0) ==
+              get<spacetime_tag>(solution_at_coords));
+      });
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.CalculateGrVars",
+                  "[Unit][Evolution]") {
+  MAKE_GENERATOR(generator);
+  test(gr::Solutions::Minkowski<1>(), make_not_null(&generator));
+  test(gr::Solutions::Minkowski<2>(), make_not_null(&generator));
+  test(gr::Solutions::Minkowski<3>(), make_not_null(&generator));
+  test(gr::Solutions::KerrSchild(1., {0.5, 0., 0.1}, {0.2, 0.5, -0.7}),
+       make_not_null(&generator));
+}
+}  // namespace


### PR DESCRIPTION
Adds time dependence to the CurvedScalarWave system by re-calculating the background spacetime tags every time step.

This PR changes the background tags so that they are no longer in a variables tag. This is because the background solution's `variables` method can only compute these tags by value and this way we can `std::move` them instead of copying them over into the variables which showed up in profiling as a large bottle neck.

~~Even so, enabling the time dependence incurs a large performance loss (Minkowski 40 %, KerrSchild 200 %) but profiling says that almost all of this comes from the background solution `variables` method. For `KerrSchild` I will probably add some special case optimizations for solutions without spin or spin aligned with the z-axis since the calculations are hugely simplified then.~~

**Update**: With the ScalarWaveGr fix, the performance loss is down to a few percent for Minkowski and ~15% for KerrSchild

Ideally, the `variables` method of the background solution would be able to return by reference but this would be a very large change, especially for `KerrSchild` which uses a `CachedTempBuffer` for most of the calculation.

~~depends on #4149 #4157~~