### PR TITLE
Remove support for Charm v6.10.2

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -377,8 +377,6 @@ jobs:
             use_pch: ON
             build_type: Debug
             CMAKE_EXECUTABLE: /opt/local/cmake/3.12.4/bin/cmake
-            CHARM_DIR: /work/charm_6_10_2/multicore-linux-x86_64-
-            charm_name: ["Charm 6.10.2"]
 
     container:
       image: sxscollaboration/spectrebuildenv:latest

--- a/cmake/FindCharm.cmake
+++ b/cmake/FindCharm.cmake
@@ -21,7 +21,7 @@
 # This module supports CMake "components" to load additional Charm++ modules.
 # You can load additional Charm++ modules like this:
 #
-#   find_package(Charm 6.10.2 COMPONENTS EveryLB)
+#   find_package(Charm 7.0.0 COMPONENTS EveryLB)
 #
 # This module exposes the following targets:
 #

--- a/cmake/SetupCharm.cmake
+++ b/cmake/SetupCharm.cmake
@@ -1,11 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-set(SPECTRE_REQUIRED_CHARM_VERSION 6.10.2)
-# Apple Silicon (arm64) Macs require charm 7.0.0 to run
-if(APPLE AND "${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "arm64")
-  set(SPECTRE_REQUIRED_CHARM_VERSION 7.0.0)
-endif()
+set(SPECTRE_REQUIRED_CHARM_VERSION 7.0.0)
 
 option(USE_SCOTCH_LB "Use the charm++ ScotchLB module" OFF)
 
@@ -45,10 +41,6 @@ find_package(Charm ${SPECTRE_REQUIRED_CHARM_VERSION} REQUIRED
 if(CHARM_VERSION VERSION_GREATER 7.0.0)
   message(WARNING "Builds with Charm++ versions greater than 7.0.0 are \
 considered experimental. Please file any issues you encounter.")
-endif()
-if(CHARM_VERSION VERSION_LESS 7.0.0)
-  message(STATUS "You are using a Charm++ version below the recommended \
-7.0.0. Please upgrade Charm++ if you run into issues.")
 endif()
 
 if (USE_SCOTCH_LB)

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -256,16 +256,6 @@ RUN ln -s $(which clang++-10) /usr/local/bin/clang++ \
 #
 # We build  with debug symbols to make debugging Charm++-interoperability
 # easier for people, and build with O2 to reduce build size.
-RUN git clone --single-branch --branch v6.10.2 --depth 1 \
-        https://github.com/UIUC-PPL/charm charm_6_10_2 \
-    && cd /work/charm_6_10_2 \
-    && git checkout v6.10.2 \
-    && ./build LIBS multicore-linux-x86_64 gcc \
-      ${PARALLEL_MAKE_ARG} -g -O2 --build-shared \
-    && ./build LIBS multicore-linux-x86_64 clang \
-      ${PARALLEL_MAKE_ARG} -g -O2 --build-shared\
-    && rm -r /work/charm_6_10_2/doc /work/charm_6_10_2/examples
-
 RUN wget https://raw.githubusercontent.com/sxs-collaboration/spectre/develop/support/Charm/v7.0.0.patch
 
 RUN git clone --single-branch --branch v7.0.0 --depth 1 \

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -58,7 +58,7 @@ all of these dependencies.
 * [GCC](https://gcc.gnu.org/) 9.1 or later,
 [Clang](https://clang.llvm.org/) 9.0 or later, or AppleClang 11.0.0 or later
 * [CMake](https://cmake.org/) 3.12.0 or later
-* [Charm++](http://charm.cs.illinois.edu/) 6.10.2, 7.0.0, or later (experimental)
+* [Charm++](http://charm.cs.illinois.edu/) 7.0.0, or later (experimental)
 * [Git](https://git-scm.com/)
 * BLAS (e.g. [OpenBLAS](http://www.openblas.net))
 * [Blaze](https://bitbucket.org/blaze-lib/blaze/overview) v3.8. It can be

--- a/support/DevEnvironments/spack.yaml
+++ b/support/DevEnvironments/spack.yaml
@@ -49,7 +49,7 @@ spack:
   # Charm++:
   # - The 'multicore' backend runs with shared memory on a single node. On
   #   clusters you should choose one of the multi-node backends instead.
-  - 'charmpp@6.10.2: backend=multicore'
+  - 'charmpp@7.0.0: backend=multicore'
   - 'cmake@3.12:'
   - doxygen
   - gsl


### PR DESCRIPTION
## Proposed changes

It is time to drop support for Charm v6.10.2
- we have successfully used v7.0.0 for several months
- we would like to use new features in v7.0.0
- v6.10.2 fails to compile changes made in #4151 with failure to pup a charm object

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
upgrade the version of charm++ you are using to v7.0.0
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

@nilsvu why does spack build v6.10.2?  Also someone will need to update the minerva environment.