### PR TITLE
Fix bug in `test_copy_semantics` where constructor instead of assignment operator is called

### DIFF
--- a/tests/Unit/Framework/TestHelpers.hpp
+++ b/tests/Unit/Framework/TestHelpers.hpp
@@ -91,13 +91,19 @@ void test_serialization_via_base(Args&&... args) {
 }
 
 /// Test for copy semantics assuming operator== is implement correctly
-template <typename T, Requires<tt::has_equivalence<T>::value> = nullptr>
+template <typename T>
 void test_copy_semantics(const T& a) {
+  static_assert(tt::has_equivalence_v<T>,
+                "Class has no operator== implemented");
   static_assert(std::is_copy_assignable<T>::value,
                 "Class is not copy assignable.");
   static_assert(std::is_copy_constructible<T>::value,
                 "Class is not copy constructible.");
-  T b = a;
+  static_assert(std::is_default_constructible_v<T>,
+                "Class needs to be default constructible to check copy "
+                "assignment operator");
+  T b{};
+  b = a;
   CHECK(b == a);
   // clang-tidy: intentionally not a reference to force invocation of copy
   // constructor

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_SpherepackIterator.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_SpherepackIterator.cpp
@@ -93,7 +93,6 @@ SPECTRE_TEST_CASE("Unit.SphericalHarmonics.SpherepackIterator",
   CHECK(iter4 != iter);
   CHECK(iter != iter4);
 
-  test_copy_semantics(iter);
   const auto iter_copy = iter;
   CHECK(iter_copy == iter);
   test_move_semantics(std::move(iter), iter_copy, 3_st, 2_st, 3_st);

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_YlmSpherepack.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_YlmSpherepack.cpp
@@ -797,7 +797,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.YlmSpherepack",
   test_prolong_restrict();
 
   YlmSpherepack s(4, 4);
-  test_copy_semantics(s);
-  auto s_copy = s;
+  auto s_copy(s);
+  CHECK(s_copy == s);
   test_move_semantics(std::move(s), s_copy, 6_st, 5_st);
 }


### PR DESCRIPTION
I think the test helper is supposed to check both copy assignment and copy construction but it currently does not because `T b = a` does not call the assignment operator, see https://stackoverflow.com/questions/29154814/when-is-the-copy-assignment-operator-called 
