### PR TITLE
Add clone methods to `MathFunction`

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.cpp
@@ -26,6 +26,23 @@ PlaneWave<Dim>::PlaneWave(
       omega_(magnitude(wave_vector_)) {}
 
 template <size_t Dim>
+PlaneWave<Dim>::PlaneWave(const PlaneWave& other)
+    : evolution::initial_data::InitialData(other),
+      wave_vector_(other.wave_vector_),
+      center_(other.center_),
+      profile_(other.profile_->get_clone()),
+      omega_(magnitude(wave_vector_)) {}
+
+template <size_t Dim>
+PlaneWave<Dim>& PlaneWave<Dim>::operator=(const PlaneWave& other) {
+  wave_vector_ = other.wave_vector_;
+  center_ = other.center_;
+  omega_ = magnitude(wave_vector_);
+  profile_ = other.profile_->get_clone();
+  return *this;
+}
+
+template <size_t Dim>
 PlaneWave<Dim>::PlaneWave(CkMigrateMessage* msg) : InitialData(msg) {}
 
 template <size_t Dim>
@@ -120,6 +137,17 @@ void PlaneWave<Dim>::pup(PUP::er& p) {
   p | profile_;
   p | omega_;
 }
+template <size_t Dim>
+bool operator==(const PlaneWave<Dim>& lhs, const PlaneWave<Dim>& rhs) {
+  return (lhs.wave_vector_ == rhs.wave_vector_) and
+         (lhs.center_ == rhs.center_) and
+         (*(lhs.profile_) == *(rhs.profile_)) and (lhs.omega_ == rhs.omega_);
+}
+
+template <size_t Dim>
+bool operator!=(const PlaneWave<Dim>& lhs, const PlaneWave<Dim>& rhs) {
+  return not(lhs == rhs);
+}
 
 template <size_t Dim>
 template <typename T>
@@ -134,6 +162,21 @@ T PlaneWave<Dim>::u(const tnsr::I<T, Dim>& x, const double t) const {
 template <size_t Dim>
 PUP::able::PUP_ID PlaneWave<Dim>::my_PUP_ID = 0;
 }  // namespace ScalarWave::Solutions
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                   \
+  template class ScalarWave::Solutions::PlaneWave<DIM(data)>;  \
+  template bool ScalarWave::Solutions::operator==(             \
+      const ScalarWave::Solutions::PlaneWave<DIM(data)>& lhs,  \
+      const ScalarWave::Solutions::PlaneWave<DIM(data)>& rhs); \
+  template bool ScalarWave::Solutions::operator!=(             \
+      const ScalarWave::Solutions::PlaneWave<DIM(data)>& lhs,  \
+      const ScalarWave::Solutions::PlaneWave<DIM(data)>& rhs);
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef DIM
+#undef INSTANTIATE
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
@@ -165,7 +208,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector))
 #undef DIM
 #undef DTYPE
 #undef INSTANTIATE
-
-template class ScalarWave::Solutions::PlaneWave<1>;
-template class ScalarWave::Solutions::PlaneWave<2>;
-template class ScalarWave::Solutions::PlaneWave<3>;

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
@@ -85,8 +85,8 @@ class PlaneWave : public evolution::initial_data::InitialData,
   PlaneWave() = default;
   PlaneWave(std::array<double, Dim> wave_vector, std::array<double, Dim> center,
             std::unique_ptr<MathFunction<1, Frame::Inertial>> profile);
-  PlaneWave(const PlaneWave&) = delete;
-  PlaneWave& operator=(const PlaneWave&) = delete;
+  PlaneWave(const PlaneWave&);
+  PlaneWave& operator=(const PlaneWave&);
   PlaneWave(PlaneWave&&) = default;
   PlaneWave& operator=(PlaneWave&&) = default;
   ~PlaneWave() = default;
@@ -141,6 +141,15 @@ class PlaneWave : public evolution::initial_data::InitialData,
   void pup(PUP::er& p);
 
  private:
+  template <size_t LocalDim>
+  // NOLINTNEXTLINE(readability-redundant-declaration)
+  friend bool operator==(const PlaneWave<LocalDim>& lhs,
+                         const PlaneWave<LocalDim>& rhs);
+  template <size_t LocalDim>
+  // NOLINTNEXTLINE(readability-redundant-declaration)
+  friend bool operator!=(const PlaneWave<LocalDim>& lhs,
+                         const PlaneWave<LocalDim>& rhs);
+
   template <typename T>
   T u(const tnsr::I<T, Dim>& x, double t) const;
 

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.cpp
@@ -28,6 +28,16 @@ RegularSphericalWave::RegularSphericalWave(
 RegularSphericalWave::RegularSphericalWave(CkMigrateMessage* msg)
     : InitialData(msg) {}
 
+RegularSphericalWave::RegularSphericalWave(const RegularSphericalWave& other)
+    : evolution::initial_data::InitialData(other),
+      profile_(other.profile_->get_clone()) {}
+
+RegularSphericalWave& RegularSphericalWave::operator=(
+    const RegularSphericalWave& other) {
+  profile_ = other.profile_->get_clone();
+  return *this;
+}
+
 tuples::TaggedTuple<Tags::Psi, Tags::Pi, Tags::Phi<3>>
 RegularSphericalWave::variables(
     const tnsr::I<DataVector, 3>& x, double t,
@@ -108,6 +118,14 @@ RegularSphericalWave::variables(
   return dt_variables;
 }
 
+bool operator==(const RegularSphericalWave& lhs,
+                const RegularSphericalWave& rhs) {
+  return *(lhs.profile_) == *(rhs.profile_);
+}
+bool operator!=(const RegularSphericalWave& lhs,
+                const RegularSphericalWave& rhs) {
+  return not(lhs == rhs);
+}
 void RegularSphericalWave::pup(PUP::er& p) {
   InitialData::pup(p);
   p | profile_;

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp
@@ -87,8 +87,8 @@ class RegularSphericalWave : public evolution::initial_data::InitialData,
   RegularSphericalWave() = default;
   explicit RegularSphericalWave(
       std::unique_ptr<MathFunction<1, Frame::Inertial>> profile);
-  RegularSphericalWave(const RegularSphericalWave&) = delete;
-  RegularSphericalWave& operator=(const RegularSphericalWave&) = delete;
+  RegularSphericalWave(const RegularSphericalWave& other);
+  RegularSphericalWave& operator=(const RegularSphericalWave& other);
   RegularSphericalWave(RegularSphericalWave&&) = default;
   RegularSphericalWave& operator=(RegularSphericalWave&&) = default;
   ~RegularSphericalWave() = default;
@@ -113,6 +113,12 @@ class RegularSphericalWave : public evolution::initial_data::InitialData,
   void pup(PUP::er& p);
 
  private:
+  // NOLINTNEXTLINE(readability-redundant-declaration)
+  friend bool operator==(const RegularSphericalWave& lhs,
+                         const RegularSphericalWave& rhs);
+  // NOLINTNEXTLINE(readability-redundant-declaration)
+  friend bool operator!=(const RegularSphericalWave& lhs,
+                         const RegularSphericalWave& rhs);
   std::unique_ptr<MathFunction<1, Frame::Inertial>> profile_;
 };
 }  // namespace ScalarWave::Solutions

--- a/src/PointwiseFunctions/MathFunctions/Gaussian.hpp
+++ b/src/PointwiseFunctions/MathFunctions/Gaussian.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <array>
+#include <memory>
 #include <pup.h>
 
 #include "Options/Options.hpp"
@@ -63,11 +64,7 @@ class Gaussian<1, Fr> : public MathFunction<1, Fr> {
   Gaussian(double amplitude, double width, const std::array<double, 1>& center);
 
   Gaussian() = default;
-  ~Gaussian() override = default;
-  Gaussian(const Gaussian& /*rhs*/) = delete;
-  Gaussian& operator=(const Gaussian& /*rhs*/) = delete;
-  Gaussian(Gaussian&& /*rhs*/) = default;
-  Gaussian& operator=(Gaussian&& /*rhs*/) = default;
+  std::unique_ptr<MathFunction<1, Fr>> get_clone() const override;
 
   double operator()(const double& x) const override;
   DataVector operator()(const DataVector& x) const override;
@@ -85,6 +82,8 @@ class Gaussian<1, Fr> : public MathFunction<1, Fr> {
   DataVector third_deriv(const DataVector& x) const override;
   using MathFunction<1, Fr>::third_deriv;
 
+  bool operator==(const MathFunction<1, Fr>& other) const override;
+  bool operator!=(const MathFunction<1, Fr>& other) const override;
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p) override;
 
@@ -92,12 +91,6 @@ class Gaussian<1, Fr> : public MathFunction<1, Fr> {
   double amplitude_{};
   double inverse_width_{};
   double center_{};
-  friend bool operator==(const Gaussian<1, Fr>& lhs,
-                         const Gaussian<1, Fr>& rhs) {
-    return lhs.amplitude_ == rhs.amplitude_ and
-           lhs.inverse_width_ == rhs.inverse_width_ and
-           lhs.center_ == rhs.center_;
-  }
 
   template <typename T>
   T apply_call_operator(const T& x) const;
@@ -150,13 +143,8 @@ class Gaussian : public MathFunction<VolumeDim, Fr> {
 
   Gaussian(double amplitude, double width,
            const std::array<double, VolumeDim>& center);
-
   Gaussian() = default;
-  ~Gaussian() override = default;
-  Gaussian(const Gaussian& /*rhs*/) = delete;
-  Gaussian& operator=(const Gaussian& /*rhs*/) = delete;
-  Gaussian(Gaussian&& /*rhs*/) = default;
-  Gaussian& operator=(Gaussian&& /*rhs*/) = default;
+  std::unique_ptr<MathFunction<VolumeDim, Fr>> get_clone() const override;
 
   Scalar<double> operator()(
       const tnsr::I<double, VolumeDim, Fr>& x) const override;
@@ -178,6 +166,8 @@ class Gaussian : public MathFunction<VolumeDim, Fr> {
   tnsr::iii<DataVector, VolumeDim, Fr> third_deriv(
       const tnsr::I<DataVector, VolumeDim, Fr>& x) const override;
 
+  bool operator==(const MathFunction<VolumeDim, Fr>& other) const override;
+  bool operator!=(const MathFunction<VolumeDim, Fr>& other) const override;
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p) override;
 
@@ -185,11 +175,6 @@ class Gaussian : public MathFunction<VolumeDim, Fr> {
   double amplitude_{};
   double inverse_width_{};
   std::array<double, VolumeDim> center_{};
-  friend bool operator==(const Gaussian& lhs, const Gaussian& rhs) {
-    return lhs.amplitude_ == rhs.amplitude_ and
-           lhs.inverse_width_ == rhs.inverse_width_ and
-           lhs.center_ == rhs.center_;
-  }
 
   template <typename T>
   tnsr::I<T, VolumeDim, Fr> centered_coordinates(

--- a/src/PointwiseFunctions/MathFunctions/MathFunction.hpp
+++ b/src/PointwiseFunctions/MathFunctions/MathFunction.hpp
@@ -36,13 +36,8 @@ class MathFunction : public PUP::able {
   using frame = Fr;
 
   WRAPPED_PUPable_abstract(MathFunction);  // NOLINT
-
   MathFunction() = default;
-  MathFunction(const MathFunction& /*rhs*/) = delete;
-  MathFunction& operator=(const MathFunction& /*rhs*/) = delete;
-  MathFunction(MathFunction&& /*rhs*/) = default;
-  MathFunction& operator=(MathFunction&& /*rhs*/) = default;
-  ~MathFunction() override = default;
+  virtual std::unique_ptr<MathFunction> get_clone() const = 0;
 
   /// @{
   /// Returns the value of the function at the coordinate 'x'.
@@ -75,6 +70,9 @@ class MathFunction : public PUP::able {
   virtual tnsr::iii<DataVector, VolumeDim, Fr> third_deriv(
       const tnsr::I<DataVector, VolumeDim, Fr>& x) const = 0;
   /// @}
+
+  virtual bool operator==(const MathFunction<VolumeDim, Fr>& other) const = 0;
+  virtual bool operator!=(const MathFunction<VolumeDim, Fr>& other) const = 0;
 };
 
 /*!
@@ -90,13 +88,8 @@ class MathFunction<1, Fr> : public PUP::able {
   using frame = Fr;
 
   WRAPPED_PUPable_abstract(MathFunction);  // NOLINT
-
   MathFunction() = default;
-  MathFunction(const MathFunction& /*rhs*/) = delete;
-  MathFunction& operator=(const MathFunction& /*rhs*/) = delete;
-  MathFunction(MathFunction&& /*rhs*/) = default;
-  MathFunction& operator=(MathFunction&& /*rhs*/) = default;
-  ~MathFunction() override = default;
+  virtual std::unique_ptr<MathFunction> get_clone() const = 0;
 
   /// Returns the function value at the coordinate 'x'
   virtual double operator()(const double& x) const = 0;
@@ -152,4 +145,6 @@ class MathFunction<1, Fr> : public PUP::able {
     get<0, 0, 0>(result) = third_deriv(get<0>(x));
     return result;
   }
+  virtual bool operator==(const MathFunction<1, Fr>& other) const = 0;
+  virtual bool operator!=(const MathFunction<1, Fr>& other) const = 0;
 };

--- a/src/PointwiseFunctions/MathFunctions/PowX.cpp
+++ b/src/PointwiseFunctions/MathFunctions/PowX.cpp
@@ -13,6 +13,11 @@ template <typename Fr>
 PowX<1, Fr>::PowX(const int power) : power_(power) {}
 
 template <typename Fr>
+std::unique_ptr<MathFunction<1, Fr>> PowX<1, Fr>::get_clone() const {
+  return std::make_unique<PowX<1, Fr>>(*this);
+}
+
+template <typename Fr>
 double PowX<1, Fr>::operator()(const double& x) const {
   return apply_call_operator(x);
 }
@@ -81,32 +86,31 @@ T PowX<1, Fr>::apply_third_deriv(const T& x) const {
 }
 
 template <typename Fr>
+bool PowX<1, Fr>::operator==(const MathFunction<1, Fr>& other) const {
+  const auto* derived_other = dynamic_cast<const PowX<1, Fr>*>(&other);
+  if (derived_other != nullptr) {
+    return this->power_ == derived_other->power_;
+  }
+  return false;
+}
+
+template <typename Fr>
+bool PowX<1, Fr>::operator!=(const MathFunction<1, Fr>& other) const {
+  return not(*this == other);
+}
+template <typename Fr>
 void PowX<1, Fr>::pup(PUP::er& p) {
   MathFunction<1, Fr>::pup(p);
   p | power_;
 }
 
-template MathFunctions::PowX<1, Frame::Grid>::PowX(const int power);
-template MathFunctions::PowX<1, Frame::Inertial>::PowX(const int power);
-template void MathFunctions::PowX<1, Frame::Grid>::pup(PUP::er& p);
-template void MathFunctions::PowX<1, Frame::Inertial>::pup(PUP::er& p);
+template class MathFunctions::PowX<1, Frame::Grid>;
+template class MathFunctions::PowX<1, Frame::Inertial>;
 
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 
 #define INSTANTIATE(_, data)                                                   \
-  template DTYPE(data)                                                         \
-      MathFunctions::PowX<1, FRAME(data)>::operator()(const DTYPE(data) & x)   \
-          const;                                                               \
-  template DTYPE(data)                                                         \
-      MathFunctions::PowX<1, FRAME(data)>::first_deriv(const DTYPE(data) & x)  \
-          const;                                                               \
-  template DTYPE(data)                                                         \
-      MathFunctions::PowX<1, FRAME(data)>::second_deriv(const DTYPE(data) & x) \
-          const;                                                               \
-  template DTYPE(data)                                                         \
-      MathFunctions::PowX<1, FRAME(data)>::third_deriv(const DTYPE(data) & x)  \
-          const;                                                               \
   template DTYPE(data)                                                         \
       MathFunctions::PowX<1, FRAME(data)>::apply_call_operator(                \
           const DTYPE(data) & x) const;                                        \

--- a/src/PointwiseFunctions/MathFunctions/PowX.hpp
+++ b/src/PointwiseFunctions/MathFunctions/PowX.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <memory>
 #include <pup.h>
 
 #include "Options/Options.hpp"
@@ -37,16 +38,11 @@ class PowX<1, Fr> : public MathFunction<1, Fr> {
 
   static constexpr Options::String help = {
       "Raises the input value to a given power"};
-
   PowX() = default;
-  ~PowX() override = default;
-  PowX(const PowX& /*rhs*/) = delete;
-  PowX& operator=(const PowX& /*rhs*/) = delete;
-  PowX(PowX&& /*rhs*/) = default;
-  PowX& operator=(PowX&& /*rhs*/) = default;
 
   WRAPPED_PUPable_decl_base_template(SINGLE_ARG(MathFunction<1, Fr>),
                                      PowX);  // NOLINT
+  std::unique_ptr<MathFunction<1, Fr>> get_clone() const override;
 
   explicit PowX(int power);
 
@@ -64,14 +60,14 @@ class PowX<1, Fr> : public MathFunction<1, Fr> {
   double third_deriv(const double& x) const override;
   DataVector third_deriv(const DataVector& x) const override;
 
+  bool operator==(const MathFunction<1, Fr>& other) const override;
+  bool operator!=(const MathFunction<1, Fr>& other) const override;
+
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p) override;
 
  private:
   double power_{};
-  friend bool operator==(const PowX& lhs, const PowX& rhs) {
-    return lhs.power_ == rhs.power_;
-  }
 
   template <typename T>
   T apply_call_operator(const T& x) const;
@@ -83,10 +79,6 @@ class PowX<1, Fr> : public MathFunction<1, Fr> {
   T apply_third_deriv(const T& x) const;
 };
 
-template <typename Fr>
-bool operator!=(const PowX<1, Fr>& lhs, const PowX<1, Fr>& rhs) {
-  return not(lhs == rhs);
-}
 }  // namespace MathFunctions
 
 /// \cond

--- a/src/PointwiseFunctions/MathFunctions/Sinusoid.cpp
+++ b/src/PointwiseFunctions/MathFunctions/Sinusoid.cpp
@@ -14,6 +14,12 @@ template <typename Fr>
 Sinusoid<1, Fr>::Sinusoid(const double amplitude, const double wavenumber,
                           const double phase)
     : amplitude_(amplitude), wavenumber_(wavenumber), phase_(phase) {}
+
+template <typename Fr>
+std::unique_ptr<MathFunction<1, Fr>> Sinusoid<1, Fr>::get_clone() const {
+  return std::make_unique<Sinusoid<1, Fr>>(*this);
+}
+
 template <typename Fr>
 double Sinusoid<1, Fr>::operator()(const double& x) const {
   return apply_call_operator(x);
@@ -79,6 +85,22 @@ T Sinusoid<1, Fr>::apply_third_deriv(const T& x) const {
 }
 
 template <typename Fr>
+bool Sinusoid<1, Fr>::operator==(const MathFunction<1, Fr>& other) const {
+  const auto* derived_other = dynamic_cast<const Sinusoid<1, Fr>*>(&other);
+  if (derived_other != nullptr) {
+    return (this->amplitude_ == derived_other->amplitude_) and
+           (this->wavenumber_ == derived_other->wavenumber_) and
+           (this->phase_ == derived_other->phase_);
+  }
+  return false;
+}
+
+template <typename Fr>
+bool Sinusoid<1, Fr>::operator!=(const MathFunction<1, Fr>& other) const {
+  return not(*this == other);
+}
+
+template <typename Fr>
 void Sinusoid<1, Fr>::pup(PUP::er& p) {
   MathFunction<1, Fr>::pup(p);
   p | amplitude_;
@@ -87,36 +109,24 @@ void Sinusoid<1, Fr>::pup(PUP::er& p) {
 }
 }  // namespace MathFunctions
 
-template MathFunctions::Sinusoid<1, Frame::Grid>::Sinusoid(
-    const double amplitude, const double wavenumber, const double phase);
-template MathFunctions::Sinusoid<1, Frame::Inertial>::Sinusoid(
-    const double amplitude, const double wavenumber, const double phase);
-template void MathFunctions::Sinusoid<1, Frame::Grid>::pup(PUP::er& p);
-template void MathFunctions::Sinusoid<1, Frame::Inertial>::pup(PUP::er& p);
+template class MathFunctions::Sinusoid<1, Frame::Grid>;
+template class MathFunctions::Sinusoid<1, Frame::Inertial>;
 
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define INSTANTIATE(_, data)                                                  \
-  template DTYPE(data) MathFunctions::Sinusoid<1, FRAME(data)>::operator()(   \
-      const DTYPE(data) & x) const;                                           \
-  template DTYPE(data) MathFunctions::Sinusoid<1, FRAME(data)>::first_deriv(  \
-      const DTYPE(data) & x) const;                                           \
-  template DTYPE(data) MathFunctions::Sinusoid<1, FRAME(data)>::second_deriv( \
-      const DTYPE(data) & x) const;                                           \
-  template DTYPE(data) MathFunctions::Sinusoid<1, FRAME(data)>::third_deriv(  \
-      const DTYPE(data) & x) const;                                           \
-  template DTYPE(data)                                                        \
-      MathFunctions::Sinusoid<1, FRAME(data)>::apply_call_operator(           \
-          const DTYPE(data) & x) const;                                       \
-  template DTYPE(data)                                                        \
-      MathFunctions::Sinusoid<1, FRAME(data)>::apply_first_deriv(             \
-          const DTYPE(data) & x) const;                                       \
-  template DTYPE(data)                                                        \
-      MathFunctions::Sinusoid<1, FRAME(data)>::apply_second_deriv(            \
-          const DTYPE(data) & x) const;                                       \
-  template DTYPE(data)                                                        \
-      MathFunctions::Sinusoid<1, FRAME(data)>::apply_third_deriv(             \
+#define INSTANTIATE(_, data)                                        \
+  template DTYPE(data)                                              \
+      MathFunctions::Sinusoid<1, FRAME(data)>::apply_call_operator( \
+          const DTYPE(data) & x) const;                             \
+  template DTYPE(data)                                              \
+      MathFunctions::Sinusoid<1, FRAME(data)>::apply_first_deriv(   \
+          const DTYPE(data) & x) const;                             \
+  template DTYPE(data)                                              \
+      MathFunctions::Sinusoid<1, FRAME(data)>::apply_second_deriv(  \
+          const DTYPE(data) & x) const;                             \
+  template DTYPE(data)                                              \
+      MathFunctions::Sinusoid<1, FRAME(data)>::apply_third_deriv(   \
           const DTYPE(data) & x) const;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (Frame::Grid, Frame::Inertial),
@@ -124,4 +134,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (Frame::Grid, Frame::Inertial),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-

--- a/src/PointwiseFunctions/MathFunctions/Sinusoid.hpp
+++ b/src/PointwiseFunctions/MathFunctions/Sinusoid.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <memory>
 #include <pup.h>
 
 #include "Options/Options.hpp"
@@ -50,13 +51,8 @@ class Sinusoid<1, Fr> : public MathFunction<1, Fr> {
       "Applies a Sinusoid function to the input value"};
 
   Sinusoid(double amplitude, double wavenumber, double phase);
-
   Sinusoid() = default;
-  ~Sinusoid() override = default;
-  Sinusoid(const Sinusoid& /*rhs*/) = delete;
-  Sinusoid& operator=(const Sinusoid& /*rhs*/) = delete;
-  Sinusoid(Sinusoid&& /*rhs*/) = default;
-  Sinusoid& operator=(Sinusoid&& /*rhs*/) = default;
+  std::unique_ptr<MathFunction<1, Fr>> get_clone() const override;
 
   WRAPPED_PUPable_decl_base_template(SINGLE_ARG(MathFunction<1, Fr>),
                                      Sinusoid);  // NOLINT
@@ -75,14 +71,12 @@ class Sinusoid<1, Fr> : public MathFunction<1, Fr> {
   double third_deriv(const double& x) const override;
   DataVector third_deriv(const DataVector& x) const override;
 
+  bool operator==(const MathFunction<1, Fr>& other) const override;
+  bool operator!=(const MathFunction<1, Fr>& other) const override;
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p) override;
 
  private:
-  friend bool operator==(const Sinusoid& lhs, const Sinusoid& rhs) {
-    return lhs.amplitude_ == rhs.amplitude_ and
-           lhs.wavenumber_ == rhs.wavenumber_ and lhs.phase_ == rhs.phase_;
-  }
   double amplitude_{};
   double wavenumber_{};
   double phase_{};
@@ -97,10 +91,6 @@ class Sinusoid<1, Fr> : public MathFunction<1, Fr> {
   T apply_third_deriv(const T& x) const;
 };
 
-template <typename Fr>
-bool operator!=(const Sinusoid<1, Fr>& lhs, const Sinusoid<1, Fr>& rhs) {
-  return not(lhs == rhs);
-}
 }  // namespace MathFunctions
 
 /// \cond

--- a/src/PointwiseFunctions/MathFunctions/TensorProduct.hpp
+++ b/src/PointwiseFunctions/MathFunctions/TensorProduct.hpp
@@ -23,10 +23,10 @@ class TensorProduct {
   TensorProduct(double scale,
                 std::array<std::unique_ptr<MathFunction<1, Frame::Inertial>>,
                            Dim>&& functions);
-
-  TensorProduct(const TensorProduct&) = delete;
+  TensorProduct() = default;
+  TensorProduct(const TensorProduct& other);
   TensorProduct(TensorProduct&&) = default;
-  TensorProduct& operator=(const TensorProduct&) = delete;
+  TensorProduct& operator=(const TensorProduct& other);
   TensorProduct& operator=(TensorProduct&&) = default;
   ~TensorProduct() = default;
 
@@ -43,6 +43,14 @@ class TensorProduct {
   tnsr::ii<T, Dim> second_derivatives(const tnsr::I<T, Dim>& x) const;
 
  private:
+  template <size_t LocalDim>
+  // NOLINTNEXTLINE(readability-redundant-declaration)
+  friend bool operator==(const TensorProduct<LocalDim>& lhs,
+                         const TensorProduct<LocalDim>& rhs);
+  template <size_t LocalDim>
+  // NOLINTNEXTLINE(readability-redundant-declaration)
+  friend bool operator!=(const TensorProduct<LocalDim>& lhs,
+                         const TensorProduct<LocalDim>& rhs);
   double scale_{1.0};
   std::array<std::unique_ptr<MathFunction<1, Frame::Inertial>>, Dim> functions_;
 };

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_PlaneWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_PlaneWave.cpp
@@ -69,6 +69,10 @@ void check_solution(
     const std::array<DataVector, Dim + 1>& expected_second_derivs,
     const ScalarWave::Solutions::PlaneWave<DimSolution>& pw,
     const tnsr::I<DataVector, DimSolution>& x, const double t) {
+  CHECK_FALSE(pw != pw);
+  test_copy_semantics(pw);
+  auto pw_for_move = pw;
+  test_move_semantics(std::move(pw_for_move), pw);
   // expected_second_derivs is:
   // 0 -> d^2 psi / dt dx^(Dim-1)
   // 1-3 -> d^2 psi / dx^(Dim - 1) dx^i where i is in [0, 2]

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_RegularSphericalWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_RegularSphericalWave.cpp
@@ -42,6 +42,10 @@ SPECTRE_TEST_CASE("Unit.AnalyticSolutions.WaveEquation.RegularSphericalWave",
   const ScalarWave::Solutions::RegularSphericalWave solution{
       std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(1., 1.,
                                                                     0.)};
+  CHECK_FALSE(solution != solution);
+  test_copy_semantics(solution);
+  auto solution_for_move = solution;
+  test_move_semantics(std::move(solution_for_move), solution);
 
   const tnsr::I<DataVector, 3> x{std::array<DataVector, 3>{
       {DataVector({0., 1., 2., 3.}), DataVector({0., 0., 0., 0.}),

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_Gaussian.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_Gaussian.cpp
@@ -50,6 +50,11 @@ void test_gaussian_random(const DataType& used_for_size) {
   }
 
   MathFunctions::Gaussian<VolumeDim, Fr> gauss{amplitude, width, center};
+  CHECK(gauss == *(gauss.get_clone()));
+  CHECK_FALSE(gauss != gauss);
+  test_copy_semantics(gauss);
+  auto gauss_for_move = gauss;
+  test_move_semantics(std::move(gauss_for_move), gauss);
 
   TestHelpers::MathFunctions::check(std::move(gauss), "gaussian", used_for_size,
                                     {{{-1.0, 1.0}}}, amplitude, width, center);

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_PowX.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_PowX.cpp
@@ -14,6 +14,7 @@
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/PointwiseFunctions/MathFunctions/TestHelpers.hpp"
 #include "Parallel/PupStlCpp11.hpp"
+#include "PointwiseFunctions/MathFunctions/Sinusoid.hpp"
 #include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
 #include "PointwiseFunctions/MathFunctions/PowX.hpp"
 #include "Utilities/TMPL.hpp"
@@ -31,8 +32,17 @@ template <size_t VolumeDim, typename DataType, typename Fr>
 void test_pow_x_random(const DataType& used_for_size) {
   Parallel::register_classes_with_charm<MathFunctions::PowX<VolumeDim, Fr>>();
 
+  MathFunctions::Sinusoid<VolumeDim, Fr> sinusoid{};
   for (int power = -5; power < 6; ++power) {
     MathFunctions::PowX<VolumeDim, Fr> pow_x{power};
+
+    CHECK(pow_x == *(pow_x.get_clone()));
+    CHECK(pow_x != *(sinusoid.get_clone()));
+    CHECK_FALSE(pow_x != pow_x);
+    test_copy_semantics(pow_x);
+    auto pow_for_move = pow_x;
+    test_move_semantics(std::move(pow_for_move), pow_x);
+
     TestHelpers::MathFunctions::check(std::move(pow_x), "pow_x", used_for_size,
                                       {{{-5.0, 5.0}}},
                                       static_cast<double>(power));

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_Sinusoid.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_Sinusoid.cpp
@@ -13,6 +13,7 @@
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/PointwiseFunctions/MathFunctions/TestHelpers.hpp"
 #include "Parallel/PupStlCpp11.hpp"
+#include "PointwiseFunctions/MathFunctions/Gaussian.hpp"
 #include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
 #include "PointwiseFunctions/MathFunctions/Sinusoid.hpp"
 
@@ -43,6 +44,13 @@ void test_sinusoid_random(const DataType& used_for_size) {
   const double phase = real_dis(gen);
 
   MathFunctions::Sinusoid<VolumeDim, Fr> sinusoid{amplitude, wavenumber, phase};
+  const MathFunctions::Gaussian<VolumeDim, Fr> gaussian{};
+  CHECK_FALSE(sinusoid == *(gaussian.get_clone()));
+  CHECK(sinusoid == *(sinusoid.get_clone()));
+  CHECK_FALSE(sinusoid != sinusoid);
+  test_copy_semantics(sinusoid);
+  auto sinusoid_for_move = sinusoid;
+  test_move_semantics(std::move(sinusoid_for_move), sinusoid);
 
   TestHelpers::MathFunctions::check(std::move(sinusoid), "sinusoid",
                                     used_for_size, {{{-1.0, 1.0}}}, amplitude,

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_TensorProduct.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_TensorProduct.cpp
@@ -20,6 +20,7 @@
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/LogicalCoordinates.hpp"
+#include "Framework/TestHelpers.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
@@ -140,6 +141,12 @@ void test_tensor_product(
   const auto coordinate_map = make_affine_map<VolumeDim>();
   const auto x = coordinate_map(logical_coordinates(mesh));
   MathFunctions::TensorProduct<VolumeDim> f(scale, std::move(functions));
+
+  CHECK_FALSE(f != f);
+  test_copy_semantics(f);
+  auto f_for_move = f;
+  test_move_semantics(std::move(f_for_move), f);
+
   CHECK_ITERABLE_APPROX(f(x), expected_value(x, powers, scale));
   CHECK_ITERABLE_APPROX(f.first_derivatives(x),
                         expected_first_derivs(x, powers, scale));


### PR DESCRIPTION
This makes `MathFunctions` and derived objects clonable. Classes that hold these are made copiable and comparable.