### PR TITLE
Conditionally resize LHS Tensors before RHS TensorExpression evaluation

### DIFF
--- a/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
+++ b/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
@@ -350,7 +350,7 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
       generic_indices_at_same_positions<tmpl::list<Args1...>,
                                         tmpl::list<Args2...>>::value;
 
-  // === Arithmetic tensor operations properties ===
+  // === Expression subtree properties ===
   /// The number of arithmetic tensor operations done in the subtree for the
   /// left operand
   static constexpr size_t num_ops_left_child = T1::num_ops_subtree;
@@ -367,6 +367,16 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
   /// whole subtree
   static constexpr size_t num_ops_subtree =
       num_ops_left_child + num_ops_right_child + 1;
+  /// The height of this expression's node in the expression tree relative to
+  /// the closest `TensorAsExpression` leaf in its subtree
+  static constexpr size_t height_relative_to_closest_tensor_leaf_in_subtree =
+      T2::height_relative_to_closest_tensor_leaf_in_subtree <=
+              T1::height_relative_to_closest_tensor_leaf_in_subtree
+          ? (T2::height_relative_to_closest_tensor_leaf_in_subtree !=
+                     std::numeric_limits<size_t>::max()
+                 ? T2::height_relative_to_closest_tensor_leaf_in_subtree + 1
+                 : T2::height_relative_to_closest_tensor_leaf_in_subtree)
+          : T1::height_relative_to_closest_tensor_leaf_in_subtree + 1;
 
   // === Properties for splitting up subexpressions along the primary path ===
   // These definitions only have meaning if this expression actually ends up

--- a/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
+++ b/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
@@ -463,6 +463,20 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
     }
   }
 
+  /// \brief Get the size of a component from a `Tensor` in this expression's
+  /// subtree of the RHS `TensorExpression`
+  ///
+  /// \return the size of a component from a `Tensor` in this expression's
+  /// subtree of the RHS `TensorExpression`
+  SPECTRE_ALWAYS_INLINE size_t get_rhs_tensor_component_size() const {
+    if constexpr (T1::height_relative_to_closest_tensor_leaf_in_subtree <=
+                  T2::height_relative_to_closest_tensor_leaf_in_subtree) {
+      return t1_.get_rhs_tensor_component_size();
+    } else {
+      return t2_.get_rhs_tensor_component_size();
+    }
+  }
+
   /// \brief Return the second operand's multi-index given the first operand's
   /// multi-index
   ///

--- a/src/DataStructures/Tensor/Expressions/Contract.hpp
+++ b/src/DataStructures/Tensor/Expressions/Contract.hpp
@@ -451,7 +451,7 @@ struct TensorContract
   /// The number of terms to sum for this expression's contraction
   static constexpr size_t num_terms_summed = contracted_type::num_terms_summed;
 
-  // === Arithmetic tensor operations properties ===
+  // === Expression subtree properties ===
   /// The number of arithmetic tensor operations done in the subtree for the
   /// left operand
   static constexpr size_t num_ops_left_child =
@@ -463,6 +463,13 @@ struct TensorContract
   /// The total number of arithmetic tensor operations done in this expression's
   /// whole subtree
   static constexpr size_t num_ops_subtree = num_ops_left_child;
+  /// The height of this expression's node in the expression tree relative to
+  /// the closest `TensorAsExpression` leaf in its subtree
+  static constexpr size_t height_relative_to_closest_tensor_leaf_in_subtree =
+      T::height_relative_to_closest_tensor_leaf_in_subtree !=
+              std::numeric_limits<size_t>::max()
+          ? T::height_relative_to_closest_tensor_leaf_in_subtree + 1
+          : T::height_relative_to_closest_tensor_leaf_in_subtree;
 
   // === Properties for splitting up subexpressions along the primary path ===
   // These definitions only have meaning if this expression actually ends up

--- a/src/DataStructures/Tensor/Expressions/Contract.hpp
+++ b/src/DataStructures/Tensor/Expressions/Contract.hpp
@@ -585,6 +585,15 @@ struct TensorContract
     }
   }
 
+  /// \brief Get the size of a component from a `Tensor` in this expression's
+  /// subtree of the RHS `TensorExpression`
+  ///
+  /// \return the size of a component from a `Tensor` in this expression's
+  /// subtree of the RHS `TensorExpression`
+  SPECTRE_ALWAYS_INLINE size_t get_rhs_tensor_component_size() const {
+    return t_.get_rhs_tensor_component_size();
+  }
+
   /// \brief Return the highest multi-index between the components being summed
   /// in the contraction
   ///

--- a/src/DataStructures/Tensor/Expressions/Divide.hpp
+++ b/src/DataStructures/Tensor/Expressions/Divide.hpp
@@ -8,6 +8,7 @@
 
 #include <array>
 #include <cstddef>
+#include <limits>
 #include <type_traits>
 #include <utility>
 
@@ -73,7 +74,7 @@ struct Divide : public TensorExpression<
   static constexpr auto op2_multi_index =
       make_array<op2_num_tensor_indices, size_t>(0);
 
-  // === Arithmetic tensor operations properties ===
+  // === Expression subtree properties ===
   /// The number of arithmetic tensor operations done in the subtree for the
   /// left operand
   static constexpr size_t num_ops_left_child = T1::num_ops_subtree;
@@ -84,6 +85,16 @@ struct Divide : public TensorExpression<
   /// whole subtree
   static constexpr size_t num_ops_subtree =
       num_ops_left_child + num_ops_right_child + 1;
+  /// The height of this expression's node in the expression tree relative to
+  /// the closest `TensorAsExpression` leaf in its subtree
+  static constexpr size_t height_relative_to_closest_tensor_leaf_in_subtree =
+      T2::height_relative_to_closest_tensor_leaf_in_subtree <=
+              T1::height_relative_to_closest_tensor_leaf_in_subtree
+          ? (T2::height_relative_to_closest_tensor_leaf_in_subtree !=
+                     std::numeric_limits<size_t>::max()
+                 ? T2::height_relative_to_closest_tensor_leaf_in_subtree + 1
+                 : T2::height_relative_to_closest_tensor_leaf_in_subtree)
+          : T1::height_relative_to_closest_tensor_leaf_in_subtree + 1;
 
   // === Properties for splitting up subexpressions along the primary path ===
   // These definitions only have meaning if this expression actually ends up

--- a/src/DataStructures/Tensor/Expressions/Divide.hpp
+++ b/src/DataStructures/Tensor/Expressions/Divide.hpp
@@ -179,6 +179,20 @@ struct Divide : public TensorExpression<
     }
   }
 
+  /// \brief Get the size of a component from a `Tensor` in this expression's
+  /// subtree of the RHS `TensorExpression`
+  ///
+  /// \return the size of a component from a `Tensor` in this expression's
+  /// subtree of the RHS `TensorExpression`
+  SPECTRE_ALWAYS_INLINE size_t get_rhs_tensor_component_size() const {
+    if constexpr (T1::height_relative_to_closest_tensor_leaf_in_subtree <=
+                  T2::height_relative_to_closest_tensor_leaf_in_subtree) {
+      return t1_.get_rhs_tensor_component_size();
+    } else {
+      return t2_.get_rhs_tensor_component_size();
+    }
+  }
+
   /// \brief Return the value of the component of the quotient tensor at a given
   /// multi-index
   ///

--- a/src/DataStructures/Tensor/Expressions/Evaluate.hpp
+++ b/src/DataStructures/Tensor/Expressions/Evaluate.hpp
@@ -203,10 +203,30 @@ void evaluate_impl(
       "e.g. evaluate<ti::a, ti::b>(L, R(ti::b, ti::a));, where R's first "
       "index has 2 spatial dimensions but L's second index has 3 spatial "
       "dimensions. Check RHS and LHS indices that use the same generic index.");
+  static_assert(Derived::height_relative_to_closest_tensor_leaf_in_subtree <
+                    std::numeric_limits<size_t>::max(),
+                "Either no Tensors were found in the RHS TensorExpression or "
+                "the depth of the tree exceeded the maximum size_t value (very "
+                "unlikely). If there is indeed a Tensor in the RHS expression "
+                "and assuming the tree's height is not actually the maximum "
+                "size_t value, then there is a flaw in the logic for computing "
+                "the derived TensorExpression types' member, "
+                "height_relative_to_closest_tensor_leaf_in_subtree.");
 
   if constexpr (EvaluateSubtrees) {
     // Make sure the LHS tensor doesn't also appear in the RHS tensor expression
     (~rhs_tensorexpression).assert_lhs_tensor_not_in_rhs_expression(lhs_tensor);
+    // If the data type is `DataVector`, size the LHS tensor components if their
+    // size does not match the size from a `Tensor` in the RHS expression
+    if constexpr (std::is_same_v<DataVector, X>) {
+      const size_t rhs_component_size =
+          (~rhs_tensorexpression).get_rhs_tensor_component_size();
+      if (rhs_component_size != (*lhs_tensor)[0].size()) {
+        for (auto& lhs_component : *lhs_tensor) {
+          lhs_component = DataVector(rhs_component_size);
+        }
+      }
+    }
   }
 
   constexpr std::array<size_t, num_rhs_indices> index_transformation =

--- a/src/DataStructures/Tensor/Expressions/Evaluate.hpp
+++ b/src/DataStructures/Tensor/Expressions/Evaluate.hpp
@@ -155,6 +155,10 @@ void evaluate_impl(
       tmpl::list<std::decay_t<decltype(LhsTensorIndices)>...>;
   using rhs_tensorindex_list = tmpl::list<RhsTensorIndices...>;
 
+  static_assert(std::is_same_v<double, X> or std::is_same_v<DataVector, X>,
+                "TensorExpressions currently only support Tensors whose data "
+                "type is double or DataVector. It is possible to add support "
+                "for other data types that are supported by Tensor.");
   // `Symmetry` currently prevents this because antisymmetries are not currently
   // supported for `Tensor`s. This check is repeated here because if
   // antisymmetries are later supported for `Tensor`, using antisymmetries in
@@ -322,6 +326,10 @@ void evaluate_impl(
   using lhs_tensorindex_list =
       tmpl::list<std::decay_t<decltype(LhsTensorIndices)>...>;
 
+  static_assert(std::is_same_v<double, X> or std::is_same_v<DataVector, X>,
+                "TensorExpressions currently only support Tensors whose data "
+                "type is double or DataVector. It is possible to add support "
+                "for other data types that are supported by Tensor.");
   // `Symmetry` currently prevents this because antisymmetries are not currently
   // supported for `Tensor`s. This check is repeated here because if
   // antisymmetries are later supported for `Tensor`, using antisymmetries in

--- a/src/DataStructures/Tensor/Expressions/Negate.hpp
+++ b/src/DataStructures/Tensor/Expressions/Negate.hpp
@@ -8,6 +8,7 @@
 
 #include <array>
 #include <cstddef>
+#include <limits>
 #include <utility>
 
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
@@ -43,7 +44,7 @@ struct Negate
   /// The number of tensor indices in the result of the expression
   static constexpr auto num_tensor_indices = tmpl::size<index_list>::value;
 
-  // === Arithmetic tensor operations properties ===
+  // === Expression subtree properties ===
   /// The number of arithmetic tensor operations done in the subtree for the
   /// left operand
   static constexpr size_t num_ops_left_child = T::num_ops_subtree;
@@ -54,6 +55,13 @@ struct Negate
   /// The total number of arithmetic tensor operations done in this expression's
   /// whole subtree
   static constexpr size_t num_ops_subtree = num_ops_left_child + 1;
+  /// The height of this expression's node in the expression tree relative to
+  /// the closest `TensorAsExpression` leaf in its subtree
+  static constexpr size_t height_relative_to_closest_tensor_leaf_in_subtree =
+      T::height_relative_to_closest_tensor_leaf_in_subtree !=
+              std::numeric_limits<size_t>::max()
+          ? T::height_relative_to_closest_tensor_leaf_in_subtree + 1
+          : T::height_relative_to_closest_tensor_leaf_in_subtree;
 
   // === Properties for splitting up subexpressions along the primary path ===
   // These definitions only have meaning if this expression actually ends up

--- a/src/DataStructures/Tensor/Expressions/Negate.hpp
+++ b/src/DataStructures/Tensor/Expressions/Negate.hpp
@@ -131,6 +131,15 @@ struct Negate
     }
   }
 
+  /// \brief Get the size of a component from a `Tensor` in this expression's
+  /// subtree of the RHS `TensorExpression`
+  ///
+  /// \return the size of a component from a `Tensor` in this expression's
+  /// subtree of the RHS `TensorExpression`
+  SPECTRE_ALWAYS_INLINE size_t get_rhs_tensor_component_size() const {
+    return t_.get_rhs_tensor_component_size();
+  }
+
   /// \brief Return the value of the component of the negated tensor expression
   /// at a given multi-index
   ///

--- a/src/DataStructures/Tensor/Expressions/NumberAsExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/NumberAsExpression.hpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cstddef>
+#include <limits>
 
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "Utilities/ForceInline.hpp"
@@ -35,7 +36,7 @@ struct NumberAsExpression
   /// The number of tensor indices in the result of the expression
   static constexpr auto num_tensor_indices = 0;
 
-  // === Arithmetic tensor operations properties ===
+  // === Expression subtree properties ===
   /// The number of arithmetic tensor operations done in the subtree for the
   /// left operand, which is 0 because this is a leaf expression
   static constexpr size_t num_ops_left_child = 0;
@@ -45,6 +46,12 @@ struct NumberAsExpression
   /// The total number of arithmetic tensor operations done in this expression's
   /// whole subtree, which is 0 because this is a leaf expression
   static constexpr size_t num_ops_subtree = 0;
+  /// The height of this expression's node in the expression tree relative to
+  /// the closest `TensorAsExpression` leaf in its subtree. Because this
+  /// expression type is leaf, the height for this type is set to the maximum
+  /// `size_t` value to encode a sense of maximal height.
+  static constexpr size_t height_relative_to_closest_tensor_leaf_in_subtree =
+      std::numeric_limits<size_t>::max();
 
   // === Properties for splitting up subexpressions along the primary path ===
   // These definitions only have meaning if this expression actually ends up

--- a/src/DataStructures/Tensor/Expressions/NumberAsExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/NumberAsExpression.hpp
@@ -75,16 +75,8 @@ struct NumberAsExpression
   /// we will have already computed the subtree at the next lowest leg's
   /// starting point. This is just 0 because this expression is a leaf.
   static constexpr size_t num_ops_to_evaluate_primary_subtree = 0;
-  /// \brief If on the primary path, whether or not the expression is a starting
-  /// point of a leg
-  ///
-  /// \details
-  /// Note: it's especially important for `NumberAsExpression` to define this as
-  /// `false` because if we have a case where this kind of an expression is the
-  /// leaf of the first leg being evaluated in the overall tree, we don't want
-  /// to use a `double` to initialize/size one of our LHS tensor's components,
-  /// because things would break if the LHS tensor components are supposed to
-  /// be e.g. a `DataVector` with a specific size.
+  /// If on the primary path, whether or not the expression is a starting point
+  /// of a leg
   static constexpr bool is_primary_start = false;
   /// If on the primary path, whether or not the expression's child along the
   /// primary path is a subtree that contains a starting point of a leg along
@@ -110,6 +102,9 @@ struct NumberAsExpression
   template <typename LhsTensorIndices, typename LhsTensor>
   void assert_lhs_tensorindices_same_in_rhs(
       const gsl::not_null<LhsTensor*> lhs_tensor) const = delete;
+  // This expression is a non-`Tensor` leaf, so we should never try to get the
+  // size of a `Tensor` component from this expression.
+  size_t get_rhs_tensor_component_size() const = delete;
 
   /// \brief Returns the number represented by the expression
   ///
@@ -129,13 +124,10 @@ struct NumberAsExpression
     return number_;
   }
 
-  // This expression is a leaf but does not store any information related to the
-  // sizing of the tensor components, because it does not represent an actual
-  // expression with tensors. Therefore, this expression should never be used to
-  // initialize a LHS result tensor component. We would run into trouble if e.g.
-  // the tensor components in the equations are `DataVector`s, but then we
-  // initialize a LHS component using the `double` stored in this leaf
-  // expression on the primary path.
+  // This expression is a leaf and therefore will never be the start of a leg
+  // to evaluate in a split tree, which is enforced by
+  // `is_primary_start == false`. Therefore, this function should never be
+  // called on this expression type.
   template <typename ResultType>
   void evaluate_primary_subtree(
       ResultType&,

--- a/src/DataStructures/Tensor/Expressions/Product.hpp
+++ b/src/DataStructures/Tensor/Expressions/Product.hpp
@@ -8,6 +8,7 @@
 
 #include <array>
 #include <cstddef>
+#include <limits>
 #include <type_traits>
 #include <utility>
 
@@ -96,7 +97,7 @@ struct OuterProduct<T1, T2, IndexList1<Indices1...>, IndexList2<Indices2...>,
   static constexpr auto op2_num_tensor_indices =
       num_tensor_indices - op1_num_tensor_indices;
 
-  // === Arithmetic tensor operations properties ===
+  // === Expression subtree properties ===
   /// The number of arithmetic tensor operations done in the subtree for the
   /// left operand
   static constexpr size_t num_ops_left_child = T1::num_ops_subtree;
@@ -111,6 +112,16 @@ struct OuterProduct<T1, T2, IndexList1<Indices1...>, IndexList2<Indices2...>,
   /// whole subtree
   static constexpr size_t num_ops_subtree =
       num_ops_left_child + num_ops_right_child + 1;
+  /// The height of this expression's node in the expression tree relative to
+  /// the closest `TensorAsExpression` leaf in its subtree
+  static constexpr size_t height_relative_to_closest_tensor_leaf_in_subtree =
+      T2::height_relative_to_closest_tensor_leaf_in_subtree <=
+              T1::height_relative_to_closest_tensor_leaf_in_subtree
+          ? (T2::height_relative_to_closest_tensor_leaf_in_subtree !=
+                     std::numeric_limits<size_t>::max()
+                 ? T2::height_relative_to_closest_tensor_leaf_in_subtree + 1
+                 : T2::height_relative_to_closest_tensor_leaf_in_subtree)
+          : T1::height_relative_to_closest_tensor_leaf_in_subtree + 1;
 
   // === Properties for splitting up subexpressions along the primary path ===
   // These definitions only have meaning if this expression actually ends up

--- a/src/DataStructures/Tensor/Expressions/Product.hpp
+++ b/src/DataStructures/Tensor/Expressions/Product.hpp
@@ -208,6 +208,20 @@ struct OuterProduct<T1, T2, IndexList1<Indices1...>, IndexList2<Indices2...>,
     }
   }
 
+  /// \brief Get the size of a component from a `Tensor` in this expression's
+  /// subtree of the RHS `TensorExpression`
+  ///
+  /// \return the size of a component from a `Tensor` in this expression's
+  /// subtree of the RHS `TensorExpression`
+  SPECTRE_ALWAYS_INLINE size_t get_rhs_tensor_component_size() const {
+    if constexpr (T1::height_relative_to_closest_tensor_leaf_in_subtree <=
+                  T2::height_relative_to_closest_tensor_leaf_in_subtree) {
+      return t1_.get_rhs_tensor_component_size();
+    } else {
+      return t2_.get_rhs_tensor_component_size();
+    }
+  }
+
   /// \brief Return the first operand's multi-index given the outer product's
   /// multi-index
   ///

--- a/src/DataStructures/Tensor/Expressions/SquareRoot.hpp
+++ b/src/DataStructures/Tensor/Expressions/SquareRoot.hpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cmath>
 #include <cstddef>
+#include <limits>
 #include <type_traits>
 #include <utility>
 
@@ -52,7 +53,7 @@ struct SquareRoot
   /// The number of tensor indices in the result of the expression
   static constexpr auto num_tensor_indices = sizeof...(Args);
 
-  // === Arithmetic tensor operations properties ===
+  // === Expression subtree properties ===
   /// The number of arithmetic tensor operations done in the subtree for the
   /// left operand
   static constexpr size_t num_ops_left_child = T::num_ops_subtree;
@@ -63,6 +64,13 @@ struct SquareRoot
   /// The total number of arithmetic tensor operations done in this expression's
   /// whole subtree
   static constexpr size_t num_ops_subtree = num_ops_left_child + 1;
+  /// The height of this expression's node in the expression tree relative to
+  /// the closest `TensorAsExpression` leaf in its subtree
+  static constexpr size_t height_relative_to_closest_tensor_leaf_in_subtree =
+      T::height_relative_to_closest_tensor_leaf_in_subtree !=
+              std::numeric_limits<size_t>::max()
+          ? T::height_relative_to_closest_tensor_leaf_in_subtree + 1
+          : T::height_relative_to_closest_tensor_leaf_in_subtree;
 
   // === Properties for splitting up subexpressions along the primary path ===
   // These definitions only have meaning if this expression actually ends up

--- a/src/DataStructures/Tensor/Expressions/SquareRoot.hpp
+++ b/src/DataStructures/Tensor/Expressions/SquareRoot.hpp
@@ -140,6 +140,15 @@ struct SquareRoot
     }
   }
 
+  /// \brief Get the size of a component from a `Tensor` in this expression's
+  /// subtree of the RHS `TensorExpression`
+  ///
+  /// \return the size of a component from a `Tensor` in this expression's
+  /// subtree of the RHS `TensorExpression`
+  SPECTRE_ALWAYS_INLINE size_t get_rhs_tensor_component_size() const {
+    return t_.get_rhs_tensor_component_size();
+  }
+
   /// \brief Returns the square root of the component of the tensor evaluated
   /// from the contained tensor expression
   ///

--- a/src/DataStructures/Tensor/Expressions/TensorAsExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorAsExpression.hpp
@@ -212,7 +212,7 @@ struct TensorAsExpression<Tensor<X, Symm<SymmValues...>, IndexList<Indices...>>,
   /// The number of tensor indices in the result of the expression
   static constexpr auto num_tensor_indices = tmpl::size<index_list>::value;
 
-  // === Arithmetic tensor operations properties ===
+  // === Expression subtree properties ===
   /// The number of arithmetic tensor operations done in the subtree for the
   /// left operand, which is 0 because this is a leaf expression
   static constexpr size_t num_ops_left_child = 0;
@@ -222,6 +222,10 @@ struct TensorAsExpression<Tensor<X, Symm<SymmValues...>, IndexList<Indices...>>,
   /// The total number of arithmetic tensor operations done in this expression's
   /// whole subtree, which is 0 because this is a leaf expression
   static constexpr size_t num_ops_subtree = 0;
+  /// The height of this expression's node in the expression tree relative to
+  /// the closest `TensorAsExpression` leaf in its subtree. Because this
+  /// expression type is that leaf, the height for this type will always be 0.
+  static constexpr size_t height_relative_to_closest_tensor_leaf_in_subtree = 0;
 
   // === Properties for splitting up subexpressions along the primary path ===
   // These definitions only have meaning if this expression actually ends up

--- a/src/DataStructures/Tensor/Expressions/TensorAsExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorAsExpression.hpp
@@ -16,6 +16,7 @@
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/Algorithm.hpp"
+#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/Gsl.hpp"
@@ -296,6 +297,15 @@ struct TensorAsExpression<Tensor<X, Symm<SymmValues...>, IndexList<Indices...>>,
     }
   }
 
+  /// \brief Get the size of a component from the `Tensor` contained by this
+  /// expression
+  ///
+  /// \return the size of a component from the `Tensor` contained by this
+  /// expression
+  SPECTRE_ALWAYS_INLINE size_t get_rhs_tensor_component_size() const {
+    return get_size((*t_)[0]);
+  }
+
   /// \brief Returns the value of the contained tensor's multi-index
   ///
   /// \param multi_index the multi-index of the tensor component to retrieve
@@ -315,21 +325,12 @@ struct TensorAsExpression<Tensor<X, Symm<SymmValues...>, IndexList<Indices...>>,
     return t_->get(multi_index);
   }
 
-  /// \brief If this expression is the start of a leg, update the LHS result
-  /// component to be the value of the component at the given multi-index of the
-  /// `Tensor` represented by the expression
-  ///
-  /// \param result_component the LHS tensor component to evaluate
-  /// \param multi_index the multi-index of the component of the `Tensor`
-  /// represented by the expression
-  SPECTRE_ALWAYS_INLINE void evaluate_primary_subtree(
-      type& result_component,
-      const std::array<size_t, num_tensor_indices>& multi_index) const {
-    if constexpr (is_primary_start) {
-      // We want to evaluate the subtree for this expression
-      result_component = get(multi_index);
-    }
-  }
+  // This expression is a leaf and therefore will never be the start of a leg
+  // to evaluate in a split tree, which is enforced by
+  // `is_primary_start == false`. Therefore, this function should never be
+  // called on this expression type.
+  void evaluate_primary_subtree(
+      type&, const std::array<size_t, num_tensor_indices>&) const = delete;
 
   /// Retrieve the i'th entry of the Tensor being held
   SPECTRE_ALWAYS_INLINE type operator[](const size_t i) const {

--- a/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
@@ -140,7 +140,18 @@ struct Expression {};
 /// - variable `static constexpr size_t
 /// height_relative_to_closest_tensor_leaf_in_subtree` : The height of an
 /// expression's node in the overall expression tree relative to the closest
-/// `TensorAsExpression` leaf in its subtree
+/// `TensorAsExpression` leaf in its subtree. This is stored so that we can
+/// traverse from the root along the shortest path to a `Tensor` when
+/// retrieving the size of a component from the RHS expression (see
+/// `get_rhs_tensor_component_size()` below). Non-`Tensor` leaves (e.g.
+/// `NumberAsExpression`) are defined to have maximum height
+/// `std::numeric_limits<size_t>::max()` to encode that they are maximally
+/// far away from their nearest `Tensor` descendant, since the expression's
+/// subtree (a leaf) can never have a `TensorAsExpression` descedant from it.
+/// This maximal height is leveraged by `get_rhs_tensor_component_size()` so
+/// that in traversing the expression tree to find a `Tensor`, it will never
+/// take the path that ends in a non-`Tensor` leaf because it is the worst path
+/// option.
 /// - function `decltype(auto) get(const std::array<size_t, num_tensor_indices>&
 /// result_multi_index) const`: Accepts a multi-index for the result tensor
 /// represented by the expression and returns the computed result of the
@@ -166,6 +177,11 @@ struct Expression {};
 /// be used instead of `tenex::evaluate`. See the documentation for
 /// `tenex::update` for more details and `tenex::detail::evaluate_impl` for why
 /// this is safe to do.
+/// - function `size_t get_rhs_tensor_component_size() const`: Gets the size of
+/// a component from a `Tensor` in an expression's subtree of the RHS
+/// expression. This is used to size LHS components, if needed. Utilizes
+/// `height_relative_to_closest_tensor_leaf_in_subtree` to recursively find the
+/// nearest `TensorAsExpression` descendant leaf.
 ///
 /// Each derived `TensorExpression` class must also define the following
 /// members, which have real meaning for the expression *only* if it ends up

--- a/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
@@ -137,6 +137,10 @@ struct Expression {};
 /// `num_ops_left_child + num_ops_right_child + 1`, the sum of the number of
 /// operations in each operand's subtrees plus one for the operation done for
 /// the expression, itself.
+/// - variable `static constexpr size_t
+/// height_relative_to_closest_tensor_leaf_in_subtree` : The height of an
+/// expression's node in the overall expression tree relative to the closest
+/// `TensorAsExpression` leaf in its subtree
 /// - function `decltype(auto) get(const std::array<size_t, num_tensor_indices>&
 /// result_multi_index) const`: Accepts a multi-index for the result tensor
 /// represented by the expression and returns the computed result of the

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Divide.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Divide.cpp
@@ -83,6 +83,7 @@ void test_divide_double_denominator(const gsl::not_null<Generator*> generator,
 // The cases tested are:
 // - \f$L = R / S\f$
 // - \f$L = R / \sqrt{T^j{}_j}\f$
+// - \f$L = 1.0 / (R + R + R + R + R + R + R + R + R)\f$
 //
 // where \f$R\f$ is a `double` and \f$S\f$, \f$T\f$, and \f$L\f$ are tensors
 // with data type `double` or DataVector.
@@ -114,6 +115,14 @@ void test_divide_double_numerator(const gsl::not_null<Generator*> generator,
     trace_T += T.get(j, j);
   }
   CHECK_ITERABLE_APPROX(get(result2), -5.7 / sqrt(trace_T));
+
+  const Scalar<DataVector> R{{{{1.0}}}};
+  Scalar<DataVector> result3{};
+
+  // \f$L = 1.0 / (R + R + R + R + R + R + R + R + R)\f$
+  tenex::evaluate(make_not_null(&result3),
+                  1.0 / (R() + R() + R() + R() + R() + R() + R() + R() + R()));
+  CHECK(get(result3) == 1.0 / (9.0 * get(R)));
 }
 
 // \brief Test the division of a tensor expression over a rank 0 tensor


### PR DESCRIPTION
fixes #4155 

## Proposed changes

In the case where the data type of the `Tensor`s are `DataVector` and `TensorExpression` splitting is used to evaluate subexpressions of the RHS, this PR makes it so that LHS `Tensor`s are sized before starting RHS `TensorExpression` evaluation instead of depending on an assignment with `=` from the result of a RHS subtree.

In almost every case, the result of a subtree will be a `DataVector` expression that can be directly assigned to the LHS component, which is why the current method of assigning to a result from a subexpression has worked. However, the example in #4155 is a case where the LHS `Tensor` components were being assigned to the result of the subexpression containing only a `NumberAsExpression` leaf - it was using the numerator `1.0` to initialize the LHS components, which can't properly size the LHS components with `=` assignment. This case could be specifically handled, but I chose the safer route of just sizing the LHS components at the outset (if necessary) and not depending on a RHS subexpression result to avoid running into another edge case like #4155 that I hadn't considered.
 
### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
