### PR TITLE
Assume frustum not invertible below lower bound

### DIFF
--- a/src/Domain/CoordinateMaps/Frustum.cpp
+++ b/src/Domain/CoordinateMaps/Frustum.cpp
@@ -216,8 +216,10 @@ std::optional<std::array<double, 3>> Frustum::inverse(
     // larger than radius_ due to roundoff error, this 1.0e-4 margin
     // allows these points to still be inverted. Points much further outside
     // of this value are likely to not be invertible, so we return
-    // std::nullopt instead.
-    if (magnitude(physical_coords) > radius_ + 1.0e-4) {
+    // std::nullopt instead. Also, points below the lower bound are likely not
+    // invertible, so return std::nullopt in that case as well.
+    if (magnitude(physical_coords) > radius_ + 1.0e-4 or
+        physical_coords[2] < (sigma_z_ - delta_z_zeta_)) {
       return std::nullopt;
     }
     const double absolute_tolerance = 1.0e-12;

--- a/tests/Unit/Domain/CoordinateMaps/Test_Frustum.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Frustum.cpp
@@ -522,10 +522,12 @@ void test_frustum_fail_equiangular() {
       {{{-2.0, -2.0}}, {{2.0, 2.0}}, {{-4.0, -4.0}}, {{4.0, 4.0}}}};
   const std::array<double, 3> test_mapped_point1{{0.0, 50.0, 9.0}};
   const std::array<double, 3> test_mapped_point2{{4.0, 4.0, 1.0}};
+  const std::array<double, 3> test_mapped_point3{{3.0, 3.0, 1.99}};
   const CoordinateMaps::Frustum equiangular_map(
       face_vertices, 2.0, 5.0, OrientationMap<3>{}, true, 1.0, false, 1.0, 1.0);
   CHECK(not equiangular_map.inverse(test_mapped_point1).has_value());
   CHECK(not equiangular_map.inverse(test_mapped_point2).has_value());
+  CHECK(not equiangular_map.inverse(test_mapped_point3).has_value());
 }
 }  // namespace
 


### PR DESCRIPTION
## Proposed changes

In BBH runs using sphericity==1 in the BinaryCompactObject domain, I found that runs would fail when the interpolator attempted to compute the frustum inverse map for points below the frustum lower bound. This PR updates the frustum inverse so that when a point is below the frustum lower bound (and thus likely not invertible) the inverse function returns `std::noopt`. I verified that this change enabled the BBH run that had been failing at t=3M to succeed, running beyond t=250M.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
