### PR TITLE
catch2 installation updated for apple silicon installation guide

### DIFF
--- a/docs/Installation/InstallationOnAppleSilicon.md
+++ b/docs/Installation/InstallationOnAppleSilicon.md
@@ -76,7 +76,7 @@ run the following to install a fortran compiler and other dependencies:
 ```
 brew install gcc
 brew install openblas boost gsl cmake doxygen
-brew install ccache autoconf automake catch2 jemalloc hdf5 pybind11 yaml-cpp
+brew install ccache autoconf automake jemalloc hdf5 pybind11 yaml-cpp
 ```
 
 ### 4. Install remaining dependencies
@@ -131,6 +131,16 @@ git checkout v7.0.0
 ./build LIBS multicore-darwin-arm8 --with-production -g3 -j
 popd
 ```
+Lastly, install Catch2. Note that catch2 v2.13.7 is required, and homebrew
+can only install v3. Catch2 is a header only package, so no need to build
+separately.
+
+```
+git clone https://github.com/catchorg/Catch2.git
+pushd Catch2
+git checkout v2.13.7
+popd
+```
 
 ### 5. Clone, configure, and build SpECTRE.
 Next, clone SpECTRE, make a build directory, and configure. In whatever
@@ -156,6 +166,7 @@ CMAKE_Fortran_COMPILER=gfortran -D BUILD_PYTHON_BINDINGS=ON \
 -D BLAZE_ROOT=${SPECTRE_DEPS_ROOT}/blaze/ \
 -D BRIGAND_ROOT=${SPECTRE_DEPS_ROOT}/brigand/ \
 -D LIBSHARP_ROOT=${SPECTRE_DEPS_ROOT}/libsharp/ \
+-D CATCH_INCLUDE_DIR=${SPECTRE_DEPS_ROOT}/Catch2/include/ \
 -D Boost_ROOT=$(brew --prefix boost)/ \
 -D CLANG_TIDY_BIN=$(brew --prefix llvm)/bin/clang-tidy \
 -D MACOSX_MIN=12.0 -D BUILD_SHARED_LIBS=OFF \


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->
Update the apple silicon installation guide for v2.13.7 of catch2 through git as the new version of catch2 on brew doesn't work for spectre

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
