### PR TITLE
Replace spin_vector function with new version.

### DIFF
--- a/src/ApparentHorizons/StrahlkorperGr.hpp
+++ b/src/ApparentHorizons/StrahlkorperGr.hpp
@@ -415,13 +415,15 @@ double dimensionful_spin_magnitude(
  * \ingroup SurfacesGroup
  * \brief Spin vector of a 2D `Strahlkorper`.
  *
- * \details Computes the spin vector of a `Strahlkorper` in a `Frame`, such as
- * `Frame::Inertial`. The result is a `std::array<double, 3>` containing the
- * Cartesian components of the spin vector, whose magnitude is
- * `spin_magnitude`. This function will return the dimensionless spin
- * components if `spin_magnitude` is the dimensionless spin magnitude, and
- * it will return the dimensionful spin components if `spin_magnitude` is
- * the dimensionful spin magnitude. The spin vector is given by
+ * \details Computes the spin vector of a `Strahlkorper` in a
+ * `MeasurementFrame`, such as `Frame::Inertial`. The result is a
+ * `std::array<double, 3>` containing the Cartesian components (in
+ * `MeasurementFrame`) of the spin vector whose magnitude is
+ * `spin_magnitude`. `spin_vector` will return the dimensionless spin
+ * components if `spin_magnitude` is the dimensionless spin magnitude,
+ * and it will return the dimensionful spin components if
+ * `spin_magnitude` is the dimensionful spin magnitude. The spin
+ * vector is given by
  * a surface integral over the horizon \f$\mathcal{H}\f$ [Eq. (25) of
  * \cite Owen2017yaj]:
  * \f$S^i = \frac{S}{N} \oint_\mathcal{H} dA \Omega (x^i - x^i_0 - x^i_R) \f$,
@@ -429,34 +431,55 @@ double dimensionful_spin_magnitude(
  * \f$N\f$ is a normalization factor enforcing \f$\delta_{ij}S^iS^j = S\f$,
  * \f$dA\f$ is the area element (via `StrahlkorperGr::area_element`),
  * \f$\Omega\f$ is the "spin function" (via `StrahlkorperGr::spin_function`),
- * \f$x^i\f$ are the `Frame` coordinates of points on the `Strahlkorper`,
- * \f$x^i_0\f$ are the `Frame` coordinates of the center of the Strahlkorper,
+ * \f$x^i\f$ are the `MeasurementFrame` coordinates of points on
+ * the `Strahlkorper`,
+ * \f$x^i_0\f$ are the `MeasurementFrame` coordinates of the center
+ * of the Strahlkorper,
  * \f$x^i_R = \frac{1}{8\pi}\oint_\mathcal{H} dA (x^i - x^i_0) R \f$,
  * and \f$R\f$ is the intrinsic Ricci scalar of the `Strahlkorper`
  * (via `StrahlkorperGr::ricci_scalar`).
  * Note that measuring positions on the horizon relative to
  * \f$x^i_0 + x^i_R\f$ instead of \f$x^i_0\f$ ensures that the mass dipole
- * moment vanishes. Also note that \f$x^i - x^i_0\f$ is
- * is the product of `StrahlkorperTags::Rhat` and `StrahlkorperTags::Radius`.
+ * moment vanishes.
+ *
+ * \param result The computed spin vector in `MeasurementFrame`.
+ * \param spin_magnitude The spin magnitude.
+ * \param area_element The area element on `strahlkorper`'s
+ *        collocation points.
+ * \param ricci_scalar The intrinsic ricci scalar on `strahlkorper`'s
+ *        collocation points.
+ * \param spin_function The spin function on `strahlkorper`'s
+ *        collocation points.
+ * \param strahlkorper The Strahlkorper in the `MetricDataFrame` frame.
+ * \param measurement_frame_coords The Cartesian coordinates of `strahlkorper`'s
+ * collocation points, mapped to `MeasurementFrame`.
+ *
+ * Note that `spin_vector` uses two frames: the Strahlkorper and all of the
+ * metric quantities are in `MetricDataFrame` and are used for doing integrals,
+ * but the `measurement_frame_coordinates` are in `MeasurementFrame` and are
+ * used for making sure the result is in the appropriate frame.  The two frames
+ * `MeasurementFrame` and `MetricDataFrame` may or may not be the same.
+ * In principle, spin_vector could be written using only a single frame
+ * (`MeasurementFrame`) but that would require that the metric quantities
+ * are known on the collocation points of a Strahlkorper in `MeasurementFrame`,
+ * which would involve more interpolation.
  */
+template <typename MetricDataFrame, typename MeasurementFrame>
+void spin_vector(
+    const gsl::not_null<std::array<double, 3>*> result, double spin_magnitude,
+    const Scalar<DataVector>& area_element,
+    const Scalar<DataVector>& ricci_scalar,
+    const Scalar<DataVector>& spin_function,
+    const Strahlkorper<MetricDataFrame>& strahlkorper,
+    const tnsr::I<DataVector, 3, MeasurementFrame>& measurement_frame_coords);
 
-template <typename Frame>
-void spin_vector(const gsl::not_null<std::array<double, 3>*> result,
-                 double spin_magnitude, const Scalar<DataVector>& area_element,
-                 const Scalar<DataVector>& radius,
-                 const tnsr::i<DataVector, 3, Frame>& r_hat,
-                 const Scalar<DataVector>& ricci_scalar,
-                 const Scalar<DataVector>& spin_function,
-                 const Strahlkorper<Frame>& strahlkorper);
-
-template <typename Frame>
-std::array<double, 3> spin_vector(double spin_magnitude,
-                                  const Scalar<DataVector>& area_element,
-                                  const Scalar<DataVector>& radius,
-                                  const tnsr::i<DataVector, 3, Frame>& r_hat,
-                                  const Scalar<DataVector>& ricci_scalar,
-                                  const Scalar<DataVector>& spin_function,
-                                  const Strahlkorper<Frame>& strahlkorper);
+template <typename MetricDataFrame, typename MeasurementFrame>
+std::array<double, 3> spin_vector(
+    double spin_magnitude, const Scalar<DataVector>& area_element,
+    const Scalar<DataVector>& ricci_scalar,
+    const Scalar<DataVector>& spin_function,
+    const Strahlkorper<MetricDataFrame>& strahlkorper,
+    const tnsr::I<DataVector, 3, MeasurementFrame>& measurement_frame_coords);
 
 /*!
  * \ingroup SurfacesGroup

--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -462,22 +462,22 @@ struct DimensionfulSpinVector : db::SimpleTag {
 };
 
 /// Computes the dimensionful spin angular momentum vector.
-template <typename Frame>
-struct DimensionfulSpinVectorCompute : DimensionfulSpinVector<Frame>,
+template <typename MeasurementFrame, typename MetricDataFrame>
+struct DimensionfulSpinVectorCompute : DimensionfulSpinVector<MeasurementFrame>,
                                        db::ComputeTag {
-  using base = DimensionfulSpinVector<Frame>;
+  using base = DimensionfulSpinVector<MeasurementFrame>;
   using return_type = std::array<double, 3>;
   static constexpr auto function = static_cast<void (*)(
       const gsl::not_null<std::array<double, 3>*>, double,
       const Scalar<DataVector>&, const Scalar<DataVector>&,
-      const tnsr::i<DataVector, 3, Frame>&, const Scalar<DataVector>&,
-      const Scalar<DataVector>&, const Strahlkorper<Frame>&)>(
-      &StrahlkorperGr::spin_vector);
+      const Scalar<DataVector>&, const Strahlkorper<MetricDataFrame>&,
+      const tnsr::I<DataVector, 3, MeasurementFrame>&)>(
+      &StrahlkorperGr::spin_vector<MetricDataFrame, MeasurementFrame>);
   using argument_tags =
-      tmpl::list<DimensionfulSpinMagnitude, AreaElement<Frame>,
-                 StrahlkorperTags::Radius<Frame>, StrahlkorperTags::Rhat<Frame>,
+      tmpl::list<DimensionfulSpinMagnitude, AreaElement<MetricDataFrame>,
                  StrahlkorperTags::RicciScalar, SpinFunction,
-                 StrahlkorperTags::Strahlkorper<Frame>>;
+                 StrahlkorperTags::Strahlkorper<MetricDataFrame>,
+                 StrahlkorperTags::CartesianCoords<MeasurementFrame>>;
 };
 
 /// The Christodoulou mass, which is a function of the dimensionful spin

--- a/src/ApparentHorizons/TagsDeclarations.hpp
+++ b/src/ApparentHorizons/TagsDeclarations.hpp
@@ -66,4 +66,8 @@ template <typename Frame>
 struct DimensionlessSpinMagnitude;
 template <typename Frame>
 struct DimensionlessSpinMagnitudeCompute;
+template <typename Frame>
+struct DimensionfulSpinVector;
+template <typename MeasurementFrame, typename MetricDataFrame>
+struct DimensionfulSpinVectorCompute;
 }  // namespace StrahlkorperGr::Tags

--- a/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
+++ b/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
@@ -777,11 +777,10 @@ void test_spin_vector(
       horizon_radius_with_spin_on_z_axis, ylm_with_spin_on_z_axis, ylm, mass,
       dimensionless_spin);
 
-  const auto spin_vector = StrahlkorperGr::spin_vector(
-      magnitude(dimensionless_spin), area_element, std::move(radius), r_hat,
-      ricci_scalar, spin_function, strahlkorper);
-
-  CHECK_ITERABLE_APPROX(spin_vector, dimensionless_spin);
+  const auto spin_vector_taking_coords = StrahlkorperGr::spin_vector(
+      magnitude(dimensionless_spin), area_element, ricci_scalar, spin_function,
+      strahlkorper, cart_coords);
+  CHECK_ITERABLE_APPROX(spin_vector_taking_coords, dimensionless_spin);
 }
 
 template <typename Solution, typename Fr>

--- a/tests/Unit/ApparentHorizons/Test_Tags.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Tags.cpp
@@ -151,6 +151,9 @@ void test_dimensionful_spin_vector_compute_tag() {
       make_not_null(&generator), dist, used_for_size);
   const auto spin_function = make_with_random_values<Scalar<DataVector>>(
       make_not_null(&generator), dist, used_for_size);
+  const auto strahlkorper_cartesian_coords =
+      make_with_random_values<tnsr::I<DataVector, 3, Frame::Inertial>>(
+          make_not_null(&generator), dist, used_for_size);
   const auto box = db::create<
       db::AddSimpleTags<StrahlkorperGr::Tags::DimensionfulSpinMagnitude,
                         StrahlkorperGr::Tags::AreaElement<Frame::Inertial>,
@@ -158,18 +161,20 @@ void test_dimensionful_spin_vector_compute_tag() {
                         StrahlkorperTags::Rhat<Frame::Inertial>,
                         StrahlkorperTags::RicciScalar,
                         StrahlkorperGr::Tags::SpinFunction,
-                        StrahlkorperTags::Strahlkorper<Frame::Inertial>>,
+                        StrahlkorperTags::Strahlkorper<Frame::Inertial>,
+                        StrahlkorperTags::CartesianCoords<Frame::Inertial>>,
       db::AddComputeTags<StrahlkorperGr::Tags::DimensionfulSpinVectorCompute<
-          Frame::Inertial>>>(dimensionful_spin_magnitude, area_element, radius,
-                             r_hat, ricci_scalar, spin_function, strahlkorper);
+          Frame::Inertial, Frame::Inertial>>>(
+      dimensionful_spin_magnitude, area_element, radius, r_hat, ricci_scalar,
+      spin_function, strahlkorper,strahlkorper_cartesian_coords);
   // LHS of the == in the CHECK is retrieving the computed dimensionful spin
   // vector from your DimensionfulSpinVectorCompute tag and RHS of ==
   // should be same logic as DimensionfulSpinVectorCompute::function
   CHECK(db::get<StrahlkorperGr::Tags::DimensionfulSpinVector<Frame::Inertial>>(
             box) ==
-        StrahlkorperGr::spin_vector<Frame::Inertial>(
-            dimensionful_spin_magnitude, area_element, radius, r_hat,
-            ricci_scalar, spin_function, strahlkorper));
+        StrahlkorperGr::spin_vector<Frame::Inertial, Frame::Inertial>(
+            dimensionful_spin_magnitude, area_element, ricci_scalar,
+            spin_function, strahlkorper, strahlkorper_cartesian_coords));
 }
 
 void test_dimensionless_spin_magnitude_compute_tag() {
@@ -320,7 +325,8 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
       StrahlkorperGr::Tags::ChristodoulouMassCompute<Frame::Inertial>>(
       "ChristodoulouMass");
   TestHelpers::db::test_compute_tag<
-      StrahlkorperGr::Tags::DimensionfulSpinVectorCompute<Frame::Inertial>>(
+      StrahlkorperGr::Tags::DimensionfulSpinVectorCompute<Frame::Inertial,
+                                                          Frame::Inertial>>(
       "DimensionfulSpinVector");
   TestHelpers::db::test_compute_tag<
       StrahlkorperGr::Tags::DimensionlessSpinMagnitudeCompute<Frame::Inertial>>(


### PR DESCRIPTION
## Proposed changes

The old spin_vector used a single frame, and assumes that 1) the Strahlkorper is in that frame, 2) that the metric quantities
are in that frame, and 3) that the metric quantities are evaluated at the collocation points of the Strahlkorper.

Those assumptions turn out to be difficult and expensive
to achieve in practice when observing the spin_vector in a frame different
than the frame that the Strahlkorper is computed in.
Especially 3) would require an additional interpolation.
See issue #4132 for details.

The new spin_vector uses two frames.  It also assumes 1), 2), and
3) for one of those frames ('MetricDataFrame'), but it also takes as
an argument the Cartesian coordinates of the Strahlkorper in a
different frame ('MeasurementFrame'), evaluated on the MetricDataFrame
collocation points of the Strahlkorper.  The resulting spin vector
is returned in MeasurementFrame.

Now when computing spin_vector
in a frame different than the frame that the Strahlkorper is computed
in, there is now no need to transform the Strahlkorper into a different
frame, and there is no need for extra interpolation of metric
quantities.

DimensionfulSpinVectorCompute has also changed appropriately. A later PR will ensure that `strahlkorper_coords_in_different_frame` (See #4158)
will be put in the DataBox upon a successful horizon find, and thus will be available for
DimensionfulSpinVectorCompute to use.

### Upgrade instructions

<!-- UPGRADE INSTRUCTIONS -->
* spin_vector now takes different arguments than previously, and it has an additional template parameter.
* DimensionfulSpinVectorCompute now takes different Tags, and has an additional template parameter.

Neither one of these functions were actually being used in any of the executables.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
