### PR TITLE
AH finder computes inertial AH coords, not inertial Strahlkorper.

### DIFF
--- a/src/ApparentHorizons/ObserveCenters.hpp
+++ b/src/ApparentHorizons/ObserveCenters.hpp
@@ -3,22 +3,27 @@
 
 #pragma once
 
+#include <array>
+#include <cmath>
+#include <limits>
 #include <tuple>
 
+#include "ApparentHorizons/StrahlkorperGr.hpp"
+#include "ApparentHorizons/Tags.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "IO/Observer/ObserverComponent.hpp"
 #include "IO/Observer/ReductionActions.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Tags.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/YlmSpherepack.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/PrettyType.hpp"
 
 /// \cond
-namespace StrahlkorperTags {
-template <typename Frame>
-struct Strahlkorper;
-}  // namespace StrahlkorperTags
 namespace Frame {
 struct Grid;
 struct Inertial;
@@ -45,9 +50,10 @@ namespace callbacks {
  * - InertialCenter_y
  * - InertialCenter_z
  *
- * \note Requires StrahlkorperTags::Strahlkorper<Frame::Grid> and
- * StrahlkorperTags::Strahlkorper<Frame::Inertial> be in the DataBox of the
- * InterpolationTarget.
+ * \note Requires StrahlkorperTags::Strahlkorper<Frame::Grid>
+ * and StrahlkorperTags::CartesianCoords<Frame::Inertial> and
+ * StrahlkorperGr::Tags::AreaElement<Frame::Grid> to be in the DataBox
+ * of the InterpolationTarget.
  */
 template <typename InterpolationTargetTag>
 struct ObserveCenters {
@@ -56,14 +62,36 @@ struct ObserveCenters {
                     Parallel::GlobalCache<Metavariables>& cache,
                     const TemporalId& temporal_id) {
     using GridTag = StrahlkorperTags::Strahlkorper<Frame::Grid>;
-    using InertialTag = StrahlkorperTags::Strahlkorper<Frame::Inertial>;
+    using CoordsTag = StrahlkorperTags::CartesianCoords<Frame::Inertial>;
+    using AreaElementTag = StrahlkorperGr::Tags::AreaElement<Frame::Grid>;
+    static_assert(
+        db::tag_is_retrievable_v<GridTag, db::DataBox<DbTags>>,
+        "DataBox must contain StrahlkorperTags::Strahlkorper<Frame::Grid>");
+    static_assert(db::tag_is_retrievable_v<CoordsTag, db::DataBox<DbTags>>,
+                  "DataBox must contain "
+                  "StrahlkorperTags::CartesianCoords<Frame::Inertial>");
+    static_assert(db::tag_is_retrievable_v<AreaElementTag, db::DataBox<DbTags>>,
+                  "DataBox must contain "
+                  "StrahlkorperGr::Tags::AreaElement<Frame::Grid>");
 
     const auto& grid_horizon = db::get<GridTag>(box);
-    const auto& inertial_horizon = db::get<InertialTag>(box);
-
     const std::array<double, 3> grid_center = grid_horizon.physical_center();
-    const std::array<double, 3> inertial_center =
-        inertial_horizon.physical_center();
+
+    // computes the inertial center to be the average value of the
+    // inertial coordinates over the Strahlkorper, where the average is
+    // computed by a surface integral.
+    const auto& inertial_coords = db::get<CoordsTag>(box);
+    const auto& area_element = db::get<AreaElementTag>(box);
+    std::array<double, 3> inertial_center =
+        make_array<3>(std::numeric_limits<double>::signaling_NaN());
+    auto integrand = make_with_value<Scalar<DataVector>>(get(area_element), 0.);
+    for (size_t i = 0; i < 3; ++i) {
+      get(integrand) = get(area_element) * inertial_coords.get(i);
+      gsl::at(inertial_center, i) =
+          grid_horizon.ylm_spherepack().definite_integral(
+              get(integrand).data()) /
+          (4.0 * M_PI);
+    }
 
     // time, grid_x, grid_y, grid_z, inertial_x, inertial_y, inertial_z
     const auto center_tuple = std::make_tuple(

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
@@ -88,7 +88,8 @@ struct EvolutionMetavars<3, InitialData, BoundaryConditions>
         intrp::callbacks::IgnoreFailedApparentHorizon;
     using post_horizon_find_callbacks = tmpl::list<
         intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, AhA>,
-        intrp::callbacks::ObserveSurfaceData<surface_tags_to_observe, AhA>>;
+        intrp::callbacks::ObserveSurfaceData<surface_tags_to_observe, AhA,
+                                             ::Frame::Inertial>>;
   };
 
   using interpolation_target_tags = tmpl::list<AhA>;

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -188,9 +188,8 @@ struct EvolutionMetavars {
 
   struct AhA : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
     using temporal_id = ::Tags::Time;
-    using vars_to_interpolate_to_target = tmpl::append<
-        ::ah::vars_to_interpolate_to_target<volume_dim, ::Frame::Grid>,
-        ::ah::vars_to_interpolate_to_target<volume_dim, ::Frame::Inertial>>;
+    using vars_to_interpolate_to_target =
+        ::ah::vars_to_interpolate_to_target<volume_dim, ::Frame::Grid>;
     using compute_vars_to_interpolate = ah::ComputeHorizonVolumeQuantities;
     using tags_to_observe = ::ah::tags_for_observing<Frame::Grid>;
     using surface_tags_to_observe = ::ah::surface_tags_for_observing;
@@ -204,15 +203,15 @@ struct EvolutionMetavars {
         intrp::callbacks::IgnoreFailedApparentHorizon;
     using post_horizon_find_callbacks = tmpl::list<
         intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, AhA>,
-        intrp::callbacks::ObserveSurfaceData<surface_tags_to_observe, AhA>,
+        intrp::callbacks::ObserveSurfaceData<surface_tags_to_observe, AhA,
+                                             ::Frame::Grid>,
         ah::callbacks::ObserveCenters<AhA>>;
   };
 
   struct AhB : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
     using temporal_id = ::Tags::Time;
-    using vars_to_interpolate_to_target = tmpl::append<
-        ::ah::vars_to_interpolate_to_target<volume_dim, ::Frame::Grid>,
-        ::ah::vars_to_interpolate_to_target<volume_dim, ::Frame::Inertial>>;
+    using vars_to_interpolate_to_target =
+        ::ah::vars_to_interpolate_to_target<volume_dim, ::Frame::Grid>;
     using compute_vars_to_interpolate = ah::ComputeHorizonVolumeQuantities;
     using tags_to_observe = ::ah::tags_for_observing<Frame::Grid>;
     using surface_tags_to_observe = ::ah::surface_tags_for_observing;
@@ -226,7 +225,8 @@ struct EvolutionMetavars {
         intrp::callbacks::IgnoreFailedApparentHorizon;
     using post_horizon_find_callbacks = tmpl::list<
         intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, AhB>,
-        intrp::callbacks::ObserveSurfaceData<surface_tags_to_observe, AhB>,
+        intrp::callbacks::ObserveSurfaceData<surface_tags_to_observe, AhB,
+                                             ::Frame::Grid>,
         ah::callbacks::ObserveCenters<AhB>>;
   };
 

--- a/src/ParallelAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp
@@ -8,7 +8,7 @@
 #include <utility>
 
 #include "ApparentHorizons/FastFlow.hpp"
-#include "ApparentHorizons/StrahlkorperInDifferentFrame.hpp"
+#include "ApparentHorizons/StrahlkorperCoordsInDifferentFrame.hpp"
 #include "ApparentHorizons/Tags.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/VariablesTag.hpp"
@@ -317,16 +317,16 @@ struct FindApparentHorizon
           },
           box);
 
-      // Compute Strahlkorper in Inertial frame if the current frame
-      // is not inertial.
+      // Compute Strahlkorper Cartesian coordinates in Inertial frame
+      // if the current frame is not inertial.
       if constexpr (not std::is_same_v<Frame, ::Frame::Inertial>) {
         db::mutate_apply<
-            tmpl::list<StrahlkorperTags::Strahlkorper<::Frame::Inertial>>,
+            tmpl::list<StrahlkorperTags::CartesianCoords<::Frame::Inertial>>,
             tmpl::list<StrahlkorperTags::Strahlkorper<Frame>,
                        domain::Tags::Domain<Metavariables::volume_dim>>>(
             [&cache, &temporal_id](
-                const gsl::not_null<Strahlkorper<::Frame::Inertial>*>
-                    inertial_strahlkorper,
+                const gsl::not_null<tnsr::I<DataVector, 3, ::Frame::Inertial>*>
+                    inertial_strahlkorper_coords,
                 const Strahlkorper<Frame>& strahlkorper,
                 const Domain<Metavariables::volume_dim>& domain) {
               // Note that functions_of_time must already be up to
@@ -334,8 +334,8 @@ struct FindApparentHorizon
               // search above.
               const auto& functions_of_time =
                   get<domain::Tags::FunctionsOfTime>(*cache);
-              strahlkorper_in_different_frame(
-                  inertial_strahlkorper, strahlkorper, domain,
+              strahlkorper_coords_in_different_frame(
+                  inertial_strahlkorper_coords, strahlkorper, domain,
                   functions_of_time,
                   InterpolationTarget_detail::get_temporal_id_value(
                       temporal_id));

--- a/src/ParallelAlgorithms/Interpolation/Targets/ApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Targets/ApparentHorizon.hpp
@@ -158,7 +158,7 @@ struct ApparentHorizon : tt::ConformsTo<intrp::protocols::ComputeTargetPoints> {
       common_tags,
       tmpl::conditional_t<
           std::is_same_v<Frame, ::Frame::Inertial>, tmpl::list<>,
-          tmpl::list<StrahlkorperTags::Strahlkorper<::Frame::Inertial>>>>;
+          tmpl::list<StrahlkorperTags::CartesianCoords<::Frame::Inertial>>>>;
   using compute_tags = typename StrahlkorperTags::compute_items_tags<Frame>;
 
   template <typename DbTags, typename Metavariables>

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveTimeSeriesAndSurfaceData.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveTimeSeriesAndSurfaceData.cpp
@@ -293,8 +293,8 @@ struct MockMetavariables {
     using compute_target_points =
         intrp::TargetPoints::KerrHorizon<SurfaceD, ::Frame::Inertial>;
     using post_interpolation_callback =
-        intrp::callbacks::ObserveSurfaceData<tmpl::list<Tags::Square>,
-                                             SurfaceD>;
+        intrp::callbacks::ObserveSurfaceData<tmpl::list<Tags::Square>, SurfaceD,
+                                             ::Frame::Inertial>;
   };
 
   using observed_reduction_data_tags = tmpl::list<>;


### PR DESCRIPTION
## Proposed changes
   
We no longer need to compute the full Strahlkorper in the
inertial frame (when finding the Strahlkorper in a non-inertial frame).  Computing merely the inertial-frame coords
of the Strahlkorper collocation points will be sufficient.
See #4132 for details.

Fixes #4132

### Upgrade instructions

<!-- UPGRADE INSTRUCTIONS -->
The full Inertial-frame Strahlkorper is no longer available after horizon finds.  This is ok, because except for spin direction (see #4164) all observables are scalars should be computed in the frame that the Strahlkorper was found, which is more efficient and more straightforward.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
