### PR TITLE
ObserveCenters doesn't use inertial-frame horizon

### DIFF
--- a/src/ApparentHorizons/CMakeLists.txt
+++ b/src/ApparentHorizons/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_sources(
   FastFlow.cpp
   ObjectLabel.cpp
   StrahlkorperGr.cpp
+  StrahlkorperCoordsInDifferentFrame.cpp
   StrahlkorperInDifferentFrame.cpp
   )
 
@@ -26,6 +27,7 @@ spectre_target_headers(
   ObjectLabel.hpp
   ObserveCenters.hpp
   StrahlkorperGr.hpp
+  StrahlkorperCoordsInDifferentFrame.hpp
   StrahlkorperInDifferentFrame.hpp
   Tags.hpp
   TagsDeclarations.hpp

--- a/src/ApparentHorizons/ObserveCenters.hpp
+++ b/src/ApparentHorizons/ObserveCenters.hpp
@@ -3,22 +3,27 @@
 
 #pragma once
 
+#include <array>
+#include <cmath>
+#include <limits>
 #include <tuple>
 
+#include "ApparentHorizons/StrahlkorperGr.hpp"
+#include "ApparentHorizons/Tags.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "IO/Observer/ObserverComponent.hpp"
 #include "IO/Observer/ReductionActions.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Tags.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/YlmSpherepack.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/PrettyType.hpp"
 
 /// \cond
-namespace StrahlkorperTags {
-template <typename Frame>
-struct Strahlkorper;
-}  // namespace StrahlkorperTags
 namespace Frame {
 struct Grid;
 struct Inertial;
@@ -45,9 +50,10 @@ namespace callbacks {
  * - InertialCenter_y
  * - InertialCenter_z
  *
- * \note Requires StrahlkorperTags::Strahlkorper<Frame::Grid> and
- * StrahlkorperTags::Strahlkorper<Frame::Inertial> be in the DataBox of the
- * InterpolationTarget.
+ * \note Requires StrahlkorperTags::Strahlkorper<Frame::Grid>
+ * and StrahlkorperTags::CartesianCoords<Frame::Inertial> and
+ * StrahlkorperGr::Tags::AreaElement<Frame::Grid> to be in the DataBox
+ * of the InterpolationTarget.
  */
 template <typename InterpolationTargetTag>
 struct ObserveCenters {
@@ -56,14 +62,27 @@ struct ObserveCenters {
                     Parallel::GlobalCache<Metavariables>& cache,
                     const TemporalId& temporal_id) {
     using GridTag = StrahlkorperTags::Strahlkorper<Frame::Grid>;
-    using InertialTag = StrahlkorperTags::Strahlkorper<Frame::Inertial>;
+    using CoordsTag = StrahlkorperTags::CartesianCoords<Frame::Inertial>;
+    using AreaElementTag = StrahlkorperGr::Tags::AreaElement<Frame::Grid>;
 
     const auto& grid_horizon = db::get<GridTag>(box);
-    const auto& inertial_horizon = db::get<InertialTag>(box);
-
     const std::array<double, 3> grid_center = grid_horizon.physical_center();
-    const std::array<double, 3> inertial_center =
-        inertial_horizon.physical_center();
+
+    // computes the inertial center to be the average value of the
+    // inertial coordinates over the Strahlkorper, where the average is
+    // computed by a surface integral.
+    const auto& inertial_coords = db::get<CoordsTag>(box);
+    const auto& area_element = db::get<AreaElementTag>(box);
+    std::array<double, 3> inertial_center =
+        make_array<3>(std::numeric_limits<double>::signaling_NaN());
+    auto integrand = make_with_value<Scalar<DataVector>>(get(area_element), 0.);
+    for (size_t i = 0; i < 3; ++i) {
+      get(integrand) = get(area_element) * inertial_coords.get(i);
+      gsl::at(inertial_center, i) =
+          grid_horizon.ylm_spherepack().definite_integral(
+              get(integrand).data()) /
+          (4.0 * M_PI);
+    }
 
     // time, grid_x, grid_y, grid_z, inertial_x, inertial_y, inertial_z
     const auto center_tuple = std::make_tuple(

--- a/src/ApparentHorizons/StrahlkorperCoordsInDifferentFrame.cpp
+++ b/src/ApparentHorizons/StrahlkorperCoordsInDifferentFrame.cpp
@@ -1,0 +1,114 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ApparentHorizons/StrahlkorperCoordsInDifferentFrame.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Block.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Tags.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/YlmSpherepack.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+template <typename SrcFrame, typename DestFrame>
+void strahlkorper_coords_in_different_frame(
+    const gsl::not_null<tnsr::I<DataVector, 3, DestFrame>*>
+        dest_cartesian_coords,
+    const Strahlkorper<SrcFrame>& src_strahlkorper, const Domain<3>& domain,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
+    const double time) {
+  destructive_resize_components(
+      dest_cartesian_coords, src_strahlkorper.ylm_spherepack().physical_size());
+
+  // Temporary storage; reduce the number of allocations.
+  Variables<tmpl::list<::Tags::Tempi<0, 2, ::Frame::Spherical<SrcFrame>>,
+                       ::Tags::Tempi<1, 3, SrcFrame>,
+                       ::Tags::TempI<2, 3, SrcFrame>, ::Tags::TempScalar<3>>>
+      temp_buffer(src_strahlkorper.ylm_spherepack().physical_size());
+  auto& src_theta_phi =
+      get<::Tags::Tempi<0, 2, ::Frame::Spherical<SrcFrame>>>(temp_buffer);
+  auto& r_hat = get<::Tags::Tempi<1, 3, SrcFrame>>(temp_buffer);
+  auto& src_cartesian_coords = get<Tags::TempI<2, 3, SrcFrame>>(temp_buffer);
+  auto& src_radius = get<::Tags::TempScalar<3>>(temp_buffer);
+
+  StrahlkorperTags::ThetaPhiCompute<SrcFrame>::function(
+      make_not_null(&src_theta_phi), src_strahlkorper);
+  StrahlkorperTags::RhatCompute<SrcFrame>::function(make_not_null(&r_hat),
+                                                    src_theta_phi);
+  StrahlkorperTags::RadiusCompute<SrcFrame>::function(
+      make_not_null(&src_radius), src_strahlkorper);
+  StrahlkorperTags::CartesianCoordsCompute<SrcFrame>::function(
+      make_not_null(&src_cartesian_coords), src_strahlkorper, src_radius,
+      r_hat);
+
+  // We now wish to map src_cartesian_coords to the destination frame.
+  // Each Block will have a different map, so the mapping must be done
+  // Block by Block.
+  for (const auto& block : domain.blocks()) {
+    // Once there are more possible source frames than the grid frame
+    // (i.e. the distorted frame), then this static_assert will change,
+    // and there will be an `if constexpr` below to treat the different
+    // possible source frames.
+    static_assert(std::is_same_v<SrcFrame, ::Frame::Grid>,
+                  "Source frame must currently be Grid frame");
+    static_assert(std::is_same_v<DestFrame, ::Frame::Inertial>,
+                  "Destination frame must currently be Inertial frame");
+    const auto& grid_to_inertial_map = block.moving_mesh_grid_to_inertial_map();
+    const auto& logical_to_grid_map = block.moving_mesh_logical_to_grid_map();
+    // Fill only those dest_cartesian_coords that are in this Block.
+    // Determine which coords are in this Block by checking if the
+    // inverse grid-to-logical map yields logical coords between -1 and 1.
+    for (size_t s = 0; s < get<0>(src_cartesian_coords).size(); ++s) {
+      const tnsr::I<double, 3, SrcFrame> x_src{
+          {get<0>(src_cartesian_coords)[s], get<1>(src_cartesian_coords)[s],
+           get<2>(src_cartesian_coords)[s]}};
+      const auto x_logical = logical_to_grid_map.inverse(x_src);
+      // x_logical might be an empty std::optional.
+      if (x_logical.has_value() and get<0>(x_logical.value()) <= 1.0 and
+          get<0>(x_logical.value()) >= -1.0 and
+          get<1>(x_logical.value()) <= 1.0 and
+          get<1>(x_logical.value()) >= -1.0 and
+          get<2>(x_logical.value()) <= 1.0 and
+          get<2>(x_logical.value()) >= -1.0) {
+        const auto x_dest =
+            grid_to_inertial_map(x_src, time, functions_of_time);
+        get<0>(*dest_cartesian_coords)[s] = get<0>(x_dest);
+        get<1>(*dest_cartesian_coords)[s] = get<1>(x_dest);
+        get<2>(*dest_cartesian_coords)[s] = get<2>(x_dest);
+        // Note that if a point is on the boundary of two or more
+        // Blocks, it might get filled twice, but that's ok.
+      }
+    }
+  }
+}
+
+#define SRCFRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DESTFRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                                         \
+  template void strahlkorper_coords_in_different_frame(              \
+      const gsl::not_null<tnsr::I<DataVector, 3, DESTFRAME(data)>*>  \
+          dest_cartesian_coords,                                     \
+      const Strahlkorper<SRCFRAME(data)>& src_strahlkorper,          \
+      const Domain<3>& domain,                                       \
+      const std::unordered_map<                                      \
+          std::string,                                               \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>& \
+          functions_of_time,                                         \
+      const double time);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (::Frame::Grid), (::Frame::Inertial))
+
+#undef INSTANTIATE
+#undef DESTFRAME
+#undef SRCFRAME

--- a/src/ApparentHorizons/StrahlkorperCoordsInDifferentFrame.hpp
+++ b/src/ApparentHorizons/StrahlkorperCoordsInDifferentFrame.hpp
@@ -1,0 +1,41 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+/// \cond
+template <typename Frame>
+class Strahlkorper;
+template <size_t Dim>
+class Domain;
+namespace domain::FunctionsOfTime {
+class FunctionOfTime;
+}  // namespace domain::FunctionsOfTime
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+/// \brief Maps (cartesian) collocation points of a Strahlkorper to
+/// a different frame.
+///
+/// Note that because the Blocks inside the Domain allow access to
+/// maps only between a selected subset of frames, we cannot use
+/// strahlkorper_in_different_frame to map between arbitrary frames;
+/// allowing strahlkorper_coords_in_different_frame to work on more frames
+/// requires adding member functions to Block.
+template <typename SrcFrame, typename DestFrame>
+void strahlkorper_coords_in_different_frame(
+    gsl::not_null<tnsr::I<DataVector, 3, DestFrame>*> dest_cartesian_coords,
+    const Strahlkorper<SrcFrame>& src_strahlkorper, const Domain<3>& domain,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
+    double time);

--- a/tests/Unit/ApparentHorizons/CMakeLists.txt
+++ b/tests/Unit/ApparentHorizons/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIBRARY_SOURCES
   Test_ObjectLabel.cpp
   Test_ObserveCenters.cpp
   Test_StrahlkorperGr.cpp
+  Test_StrahlkorperCoordsInDifferentFrame.cpp
   Test_StrahlkorperInDifferentFrame.cpp
   Test_Tags.cpp
   )

--- a/tests/Unit/ApparentHorizons/Test_StrahlkorperCoordsInDifferentFrame.cpp
+++ b/tests/Unit/ApparentHorizons/Test_StrahlkorperCoordsInDifferentFrame.cpp
@@ -1,0 +1,85 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <vector>
+
+#include "ApparentHorizons/StrahlkorperCoordsInDifferentFrame.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/Creators/Shell.hpp"
+#include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+
+void test_strahlkorper_coords_in_different_frame() {
+  const size_t grid_points_each_dimension = 5;
+
+  // Set up a Strahlkorper corresponding to a Schwarzschild hole of
+  // mass 1, in the grid frame.
+  // Center the Strahlkorper at (0.03,0.02,0.01) so that we test a
+  // nonzero center.
+  const std::array<double, 3> strahlkorper_grid_center = {0.03, 0.02, 0.01};
+  const size_t l_max = 8;
+  const Strahlkorper<Frame::Grid> strahlkorper_grid(l_max, 2.0,
+                                                    strahlkorper_grid_center);
+
+  // Create a Domain.
+  // We choose a spherical shell domain extending from radius 1.9M to
+  // 2.9M, so that the Strahlkorper is inside the domain. It gives a
+  // narrow domain so that we don't need a large number of grid points
+  // to resolve the horizon (which would make the test slower).
+  std::vector<double> radial_partitioning{};
+  std::vector<domain::CoordinateMaps::Distribution> radial_distribution{
+      domain::CoordinateMaps::Distribution::Linear};
+  domain::creators::Shell domain_creator(
+      1.9, 2.9, 1,
+      std::array<size_t, 2>{grid_points_each_dimension,
+                            grid_points_each_dimension},
+      false, {{1.0, 2}}, radial_partitioning, radial_distribution,
+      ShellWedges::All,
+      std::make_unique<
+          domain::creators::time_dependence::UniformTranslation<3>>(
+          0.0, std::array<double, 3>({{0.01, 0.02, 0.03}})));
+  Domain<3> domain = domain_creator.create_domain();
+  const auto functions_of_time = domain_creator.functions_of_time();
+
+  // Compute strahlkorper coords in the inertial frame.
+  const double time = 0.5;
+  tnsr::I<DataVector, 3, Frame::Inertial> inertial_coords{};
+
+  strahlkorper_coords_in_different_frame(make_not_null(&inertial_coords),
+                                         strahlkorper_grid, domain,
+                                         functions_of_time, time);
+
+  // Now compare with expected result, which is the grid-frame coords of
+  // the Strahlkorper translated by (0.005,0.01,0.015).
+  const auto grid_coords = StrahlkorperFunctions::cartesian_coords(
+      strahlkorper_grid, StrahlkorperFunctions::radius(strahlkorper_grid),
+      StrahlkorperFunctions::rhat(
+          StrahlkorperFunctions::theta_phi(strahlkorper_grid)));
+  CHECK_ITERABLE_APPROX(get<0>(grid_coords) + 0.005, get<0>(inertial_coords));
+  CHECK_ITERABLE_APPROX(get<1>(grid_coords) + 0.01, get<1>(inertial_coords));
+  CHECK_ITERABLE_APPROX(get<2>(grid_coords) + 0.015, get<2>(inertial_coords));
+}
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperCoordsInDifferentFrame",
+                  "[Unit]") {
+  domain::creators::register_derived_with_charm();
+  domain::creators::time_dependence::register_derived_with_charm();
+  domain::FunctionsOfTime::register_derived_with_charm();
+  test_strahlkorper_coords_in_different_frame();
+}
+
+}  // namespace


### PR DESCRIPTION
## Proposed changes

ObserveCenters now computes inertial-frame center differently.  The inertial-frame horizon is no longer in the DataBox so it needs to do something different. It takes an average.

Depends on (and includes) #4164.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
ObserveCenters now assumes different Tags in the DataBox.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
