### PR TITLE
Fix finding Python on macOS CI

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -676,7 +676,7 @@ ${{ env.CACHE_KEY_SUFFIX }}"
       # We install some low-level dependencies with Homebrew. They get picked up
       # by `spack external find`.
       SPECTRE_BREW_DEPS: >-  # Line breaks are spaces, no trailing newline
-        autoconf automake ccache cmake pkg-config
+        autoconf automake ccache cmake pkg-config python
       # We install these packages with Spack and cache them. The full specs are
       # listed in support/DevEnvironments/spack.yaml. This list is only needed
       # to create the cache.
@@ -725,7 +725,7 @@ ${{ env.CACHE_KEY_SUFFIX }}"
           source $HOME/spack/share/spack/setup-env.sh
           spack debug report
           spack compiler find && spack compiler list
-          spack external find && spack external find perl
+          spack external find && spack external find perl python
           spack config get packages
           spack mirror add dependencies file://$HOME/dependencies/spack
       # Install the remaining dependencies from source with Spack. We install

--- a/support/DevEnvironments/spack.yaml
+++ b/support/DevEnvironments/spack.yaml
@@ -67,5 +67,6 @@ spack:
   - py-pyyaml
   - py-scipy
   - yaml-cpp@0.6.3
-  concretization: together
+  concretizer:
+    unify: true
   view: true


### PR DESCRIPTION
For some reason the system Python was found before, which got recently
upgraded and broke CI builds.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
