### PR TITLE
Fix a check in CubicScale.

### DIFF
--- a/src/Domain/CoordinateMaps/TimeDependent/CubicScale.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/CubicScale.cpp
@@ -135,8 +135,8 @@ std::optional<std::array<double, Dim>> CubicScale<Dim>::inverse(
     ERROR("We require expansion_a > 0 for invertibility, however expansion_a = "
           << a_of_t << ".");
   }
-  if (b_of_t < 2.0 / 3.0 * a_of_t or b_of_t <= 0.0) {
-    ERROR("The map is invertible only if 0 < expansion_b < expansion_a*2/3, "
+  if (b_of_t < 2.0 / 3.0 * a_of_t) {
+    ERROR("The map is invertible only if expansion_b >= expansion_a*2/3, "
           << " but expansion_b = " << b_of_t << " and expansion_a = " << a_of_t
           << ".");
   }

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_CubicScale.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_CubicScale.cpp
@@ -258,42 +258,17 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.TimeDependent.CubicScale",
   }
   test_boundaries();
   CHECK(not CoordinateMaps::TimeDependent::CubicScale<1>{}.is_identity());
-}
 
-// [[OutputRegex, The map is invertible only if 0 < expansion_b <
-// expansion_a\*2/3]]
-SPECTRE_TEST_CASE(
-    "Unit.Domain.CoordinateMaps.TimeDependent.CubicScale.NonInvertible1",
-    "[Domain][Unit]") {
-  ERROR_TEST();
-  // the two expansion factors are chosen such that the map is non-invertible
-  cubic_scale_non_invertible(0.96, 0.58, 20.0);
-}
-
-// [[OutputRegex, We require expansion_a > 0 for invertibility]]
-SPECTRE_TEST_CASE(
-    "Unit.Domain.CoordinateMaps.TimeDependent.CubicScale.NonInvertible2",
-    "[Domain][Unit]") {
-  ERROR_TEST();
-  // Make a<0
-  cubic_scale_non_invertible(-0.0001, 1.0, 20.0);
-}
-
-// [[OutputRegex, The map is invertible only if 0 < expansion_b <
-// expansion_a\*2/3]]
-SPECTRE_TEST_CASE(
-    "Unit.Domain.CoordinateMaps.TimeDependent.CubicScale.NonInvertible3",
-    "[Domain][Unit]") {
-  ERROR_TEST();
-  // Make b==0
-  cubic_scale_non_invertible(0.96, 0.0, 20.0);
-}
-
-// [[OutputRegex, For invertability, we require outer_boundary to be positive]]
-SPECTRE_TEST_CASE(
-    "Unit.Domain.CoordinateMaps.TimeDependent.CubicScale.NonInvertible4",
-    "[Domain][Unit]") {
-  ERROR_TEST();
-  cubic_scale_non_invertible(0.96, 1.0, 0.0);
+  CHECK_THROWS_WITH(
+      cubic_scale_non_invertible(0.96, 0.58, 20.0),
+      Catch::Contains(
+          "The map is invertible only if expansion_b >= expansion_a*2/3"));
+  CHECK_THROWS_WITH(
+      cubic_scale_non_invertible(-0.0001, 1.0, 20.0),
+      Catch::Contains("We require expansion_a > 0 for invertibility"));
+  CHECK_THROWS_WITH(
+      cubic_scale_non_invertible(0.96, 1.0, 0.0),
+      Catch::Contains(
+          "For invertability, we require outer_boundary to be positive"));
 }
 }  // namespace domain


### PR DESCRIPTION
Fixes #4171

While I was at it, I replaced the ERROR_TESTS in the test
with CHECK_THROWS_WITHs.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
