### PR TITLE
Add 7th & 9th order FD reconstruction for PPAO

### DIFF
--- a/src/NumericalAlgorithms/FiniteDifference/PositivityPreservingAdaptiveOrder.cpp
+++ b/src/NumericalAlgorithms/FiniteDifference/PositivityPreservingAdaptiveOrder.cpp
@@ -24,48 +24,54 @@ namespace fd::reconstruction {
 namespace {
 // use type alias for the function pointer return type for brevity
 template <size_t Dim>
-using pointer_return_type =
-    std::tuple<void (*)(gsl::not_null<std::array<gsl::span<double>, Dim>*>,
-                        gsl::not_null<std::array<gsl::span<double>, Dim>*>,
-                        const gsl::span<const double>&,
-                        const DirectionMap<Dim, gsl::span<const double>>&,
-                        const Index<Dim>&, size_t, double),
-               void (*)(gsl::not_null<DataVector*>, const DataVector&,
-                        const DataVector&, const Index<Dim>&, const Index<Dim>&,
-                        const Direction<Dim>&, const double&),
-               void (*)(gsl::not_null<DataVector*>, const DataVector&,
-                        const DataVector&, const Index<Dim>&, const Index<Dim>&,
-                        const Direction<Dim>&, const double&)>;
+using pointer_return_type = std::tuple<
+    void (*)(gsl::not_null<std::array<gsl::span<double>, Dim>*>,
+             gsl::not_null<std::array<gsl::span<double>, Dim>*>,
+             const gsl::span<const double>&,
+             const DirectionMap<Dim, gsl::span<const double>>&,
+             const Index<Dim>&, size_t, double, double, double),
+    void (*)(gsl::not_null<DataVector*>, const DataVector&, const DataVector&,
+             const Index<Dim>&, const Index<Dim>&, const Direction<Dim>&,
+             const double&, const double&, const double&),
+    void (*)(gsl::not_null<DataVector*>, const DataVector&, const DataVector&,
+             const Index<Dim>&, const Index<Dim>&, const Direction<Dim>&,
+             const double&, const double&, const double&)>;
 
-template <typename LowOrderReconstructor, bool PositivityPreserving, size_t Dim>
+template <typename LowOrderReconstructor, bool PositivityPreserving,
+          bool Use9thOrder, bool Use7thOrder, size_t Dim>
 pointer_return_type<Dim> function_pointer() {
   return {&positivity_preserving_adaptive_order<LowOrderReconstructor,
-                                                PositivityPreserving, Dim>,
+                                                PositivityPreserving,
+                                                Use9thOrder, Use7thOrder, Dim>,
           &::fd::reconstruction::reconstruct_neighbor<
               Side::Lower,
               ::fd::reconstruction::detail::
                   PositivityPreservingAdaptiveOrderReconstructor<
-                      LowOrderReconstructor, PositivityPreserving>,
+                      LowOrderReconstructor, PositivityPreserving, Use9thOrder,
+                      Use7thOrder>,
               Dim>,
           &::fd::reconstruction::reconstruct_neighbor<
               Side::Upper,
               ::fd::reconstruction::detail::
                   PositivityPreservingAdaptiveOrderReconstructor<
-                      LowOrderReconstructor, PositivityPreserving>,
+                      LowOrderReconstructor, PositivityPreserving, Use9thOrder,
+                      Use7thOrder>,
               Dim>};
 }
 
-template <bool PositivityPreserving, size_t Dim>
+template <bool PositivityPreserving, bool Use9thOrder, bool Use7thOrder,
+          size_t Dim>
 pointer_return_type<Dim>
 positivity_preserving_adaptive_order_function_pointers_select_recons(
     const FallbackReconstructorType fallback_recons) {
   switch (fallback_recons) {
     case FallbackReconstructorType::Minmod:
       return function_pointer<detail::MinmodReconstructor, PositivityPreserving,
-                              Dim>();
+                              Use9thOrder, Use7thOrder, Dim>();
     case FallbackReconstructorType::MonotonisedCentral:
       return function_pointer<detail::MonotonisedCentralReconstructor,
-                              PositivityPreserving, Dim>();
+                              PositivityPreserving, Use9thOrder, Use7thOrder,
+                              Dim>();
     case FallbackReconstructorType::None:
       ERROR(
           "Can't have None as the low-order reconstructor in "
@@ -78,46 +84,68 @@ positivity_preserving_adaptive_order_function_pointers_select_recons(
   }
 }
 
-template <size_t Dim>
+template <size_t Dim, bool Use9thOrder, bool Use7thOrder>
 pointer_return_type<Dim>
 positivity_preserving_adaptive_order_function_pointers_select_positivity(
     const bool positivity_preserving,
     const FallbackReconstructorType fallback_recons) {
   if (positivity_preserving) {
     return positivity_preserving_adaptive_order_function_pointers_select_recons<
-        true, Dim>(fallback_recons);
+        true, Use9thOrder, Use7thOrder, Dim>(fallback_recons);
   }
   return positivity_preserving_adaptive_order_function_pointers_select_recons<
-      false, Dim>(fallback_recons);
+      false, Use9thOrder, Use7thOrder, Dim>(fallback_recons);
 }
 }  // namespace
 
 template <size_t Dim>
 pointer_return_type<Dim> positivity_preserving_adaptive_order_function_pointers(
-    const bool positivity_preserving,
-    const FallbackReconstructorType fallback_recons) {
-  return
-      positivity_preserving_adaptive_order_function_pointers_select_positivity<
-      Dim>(positivity_preserving, fallback_recons);
+    const bool positivity_preserving, const bool use_9th_order,
+    const bool use_7th_order, const FallbackReconstructorType fallback_recons) {
+  if (use_7th_order) {
+    if (use_9th_order) {
+      return
+       positivity_preserving_adaptive_order_function_pointers_select_positivity<
+         Dim, true, true>(positivity_preserving, fallback_recons);
+    } else {
+      return
+       positivity_preserving_adaptive_order_function_pointers_select_positivity<
+         Dim, false, true>(positivity_preserving, fallback_recons);
+    }
+  } else {
+    if (use_9th_order) {
+      return
+       positivity_preserving_adaptive_order_function_pointers_select_positivity<
+         Dim, true, false>(positivity_preserving, fallback_recons);
+    } else {
+      return
+       positivity_preserving_adaptive_order_function_pointers_select_positivity<
+         Dim, false, false>(positivity_preserving, fallback_recons);
+    }
+  }
 }
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATION(r, data)                            \
-  template pointer_return_type<DIM(data)>                 \
-  positivity_preserving_adaptive_order_function_pointers( \
-      bool positivity_preserving, FallbackReconstructorType fallback_recons);
+#define INSTANTIATION(r, data)                                            \
+  template pointer_return_type<DIM(data)>                                 \
+  positivity_preserving_adaptive_order_function_pointers(                 \
+      bool positivity_preserving, bool use_9th_order, bool use_7th_order, \
+      FallbackReconstructorType fallback_recons);
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
 #undef INSTANTIATION
 
 #define POSITIVITY_PRESERVING(data) BOOST_PP_TUPLE_ELEM(1, data)
-#define FALLBACK_RECONSTRUCTOR(data) BOOST_PP_TUPLE_ELEM(2, data)
+#define USE_9TH_ORDER(data) BOOST_PP_TUPLE_ELEM(2, data)
+#define USE_7TH_ORDER(data) BOOST_PP_TUPLE_ELEM(3, data)
+#define FALLBACK_RECONSTRUCTOR(data) BOOST_PP_TUPLE_ELEM(4, data)
 
 #define INSTANTIATION(r, data)                                                 \
   template void reconstruct<PositivityPreservingAdaptiveOrderReconstructor<    \
-      FALLBACK_RECONSTRUCTOR(data), POSITIVITY_PRESERVING(data)>>(             \
+      FALLBACK_RECONSTRUCTOR(data), POSITIVITY_PRESERVING(data),               \
+      USE_9TH_ORDER(data), USE_7TH_ORDER(data)>>(                              \
       gsl::not_null<std::array<gsl::span<double>, DIM(data)>*>                 \
           reconstructed_upper_side_of_face_vars,                               \
       gsl::not_null<std::array<gsl::span<double>, DIM(data)>*>                 \
@@ -125,29 +153,34 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
       const gsl::span<const double>& volume_vars,                              \
       const DirectionMap<DIM(data), gsl::span<const double>>& ghost_cell_vars, \
       const Index<DIM(data)>& volume_extents,                                  \
-      const size_t number_of_variables, const double& four_to_the_alpha_5);
+      const size_t number_of_variables, const double& four_to_the_alpha_5,     \
+      const double& six_to_the_alpha_7, const double& eight_to_the_alpha_9);
 
 namespace detail {
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (true, false),
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (true, false), (true, false),
+                        (true, false),
                         (MinmodReconstructor, MonotonisedCentralReconstructor))
 }  // namespace detail
 
 #undef INSTANTIATION
 
-#define SIDE(data) BOOST_PP_TUPLE_ELEM(3, data)
+#define SIDE(data) BOOST_PP_TUPLE_ELEM(5, data)
 
 #define INSTANTIATION(r, data)                                                 \
   template void reconstruct_neighbor<                                          \
       SIDE(data),                                                              \
       detail::PositivityPreservingAdaptiveOrderReconstructor<                  \
-          FALLBACK_RECONSTRUCTOR(data), POSITIVITY_PRESERVING(data)>>(         \
+          FALLBACK_RECONSTRUCTOR(data), POSITIVITY_PRESERVING(data),           \
+          USE_9TH_ORDER(data), USE_7TH_ORDER(data)>>(                          \
       gsl::not_null<DataVector*> face_data, const DataVector& volume_data,     \
       const DataVector& neighbor_data, const Index<DIM(data)>& volume_extents, \
       const Index<DIM(data)>& ghost_data_extents,                              \
       const Direction<DIM(data)>& direction_to_reconstruct,                    \
-      const double& four_to_the_alpha_5);
+      const double& four_to_the_alpha_5, const double& six_to_the_alpha_7,     \
+      const double& eight_to_the_alpha_9);
 
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (true, false),
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (true, false), (true, false),
+                        (true, false),
                         (detail::MinmodReconstructor,
                          detail::MonotonisedCentralReconstructor),
                         (Side::Upper, Side::Lower))

--- a/src/NumericalAlgorithms/FiniteDifference/PositivityPreservingAdaptiveOrder.hpp
+++ b/src/NumericalAlgorithms/FiniteDifference/PositivityPreservingAdaptiveOrder.hpp
@@ -29,11 +29,136 @@ class Index;
 
 namespace fd::reconstruction {
 namespace detail {
-template <typename LowOrderReconstructor, bool PositivityPreserving>
+template <typename LowOrderReconstructor, bool PositivityPreserving,
+          bool Use9thOrder, bool Use7thOrder>
 struct PositivityPreservingAdaptiveOrderReconstructor {
   SPECTRE_ALWAYS_INLINE static std::array<double, 2> pointwise(
-      const double* const u, const int stride,
-      const double four_to_the_alpha_5) {
+      const double* const u, const int stride, const double four_to_the_alpha_5,
+      // GCC9 complains that six_to_the_alpha_7 and eight_to_the_alpha_9 are
+      // unused because if-constexpr
+      [[maybe_unused]] const double six_to_the_alpha_7,
+      [[maybe_unused]] const double eight_to_the_alpha_9) {
+    if constexpr (Use9thOrder) {
+      const std::array order_9_result =
+          UnlimitedReconstructor<8>::pointwise(u, stride);
+
+      if (not PositivityPreserving or
+          LIKELY(order_9_result[0] > 0.0 and order_9_result[1] > 0.0)) {
+        const double order_9_norm_of_top_modal_coefficient = square(
+            -1.593380762005595 * u[stride] +
+            0.7966903810027975 * u[2 * stride] -
+            0.22762582314365648 * u[3 * stride] +
+            0.02845322789295706 * u[4 * stride] -
+            1.593380762005595 * u[-stride] +
+            0.7966903810027975 * u[-2 * stride] -
+            0.22762582314365648 * u[-3 * stride] +
+            0.02845322789295706 * u[-4 * stride] + 1.991725952506994 * u[0]);
+
+        const double order_9_norm_of_polynomial =
+            u[stride] * (25.393963433621668 * u[stride] -
+                         31.738453392103736 * u[2 * stride] +
+                         14.315575523531798 * u[3 * stride] -
+                         5.422933317103013 * u[4 * stride] +
+                         45.309550145164756 * u[-stride] -
+                         25.682667845756164 * u[-2 * stride] +
+                         10.394184200706238 * u[-3 * stride] -
+                         3.5773996341558414 * u[-4 * stride] -
+                         56.63693768145594 * u[0]) +
+            u[2 * stride] * (10.664627625179254 * u[2 * stride] -
+                             9.781510753231265 * u[3 * stride] +
+                             3.783820939683476 * u[4 * stride] -
+                             25.682667845756164 * u[-stride] +
+                             13.59830711617153 * u[-2 * stride] -
+                             5.064486634342602 * u[-3 * stride] +
+                             1.5850428636128617 * u[-4 * stride] +
+                             33.99576779042882 * u[0]) +
+            u[3 * stride] * (2.5801312593878514 * u[3 * stride] -
+                             1.812843724346584 * u[4 * stride] +
+                             10.394184200706238 * u[-stride] -
+                             5.064486634342602 * u[-2 * stride] +
+                             1.6716163773782988 * u[-3 * stride] -
+                             0.4380794296257583 * u[-4 * stride] -
+                             14.626643302060115 * u[0]) +
+            u[4 * stride] * (0.5249097623867759 * u[4 * stride] -
+                             3.5773996341558414 * u[-stride] +
+                             1.5850428636128617 * u[-2 * stride] -
+                             0.4380794296257583 * u[-3 * stride] +
+                             0.07624062080823268 * u[-4 * stride] +
+                             5.336843456576288 * u[0]) +
+            u[-stride] * (25.393963433621668 * u[-stride] -
+                          31.738453392103736 * u[-2 * stride] +
+                          14.315575523531798 * u[-3 * stride] -
+                          5.422933317103013 * u[-4 * stride] -
+                          56.63693768145594 * u[0]) +
+            u[-2 * stride] * (10.664627625179254 * u[-2 * stride] -
+                              9.781510753231265 * u[-3 * stride] +
+                              3.783820939683476 * u[-4 * stride] +
+                              33.99576779042882 * u[0]) +
+            u[-3 * stride] * (2.5801312593878514 * u[-3 * stride] -
+                              1.812843724346584 * u[-4 * stride] -
+                              14.626643302060115 * u[0]) +
+            u[-4 * stride] * (0.5249097623867759 * u[-4 * stride] +
+                              5.336843456576288 * u[0]) +
+            33.758463458609164 * square(u[0]);
+        if (square(eight_to_the_alpha_9) *
+                order_9_norm_of_top_modal_coefficient <=
+            order_9_norm_of_polynomial) {
+          return order_9_result;
+        }
+      }
+    }
+
+    if constexpr (Use7thOrder) {
+      const std::array order_7_result =
+          UnlimitedReconstructor<6>::pointwise(u, stride);
+
+      if (not PositivityPreserving or
+          LIKELY(order_7_result[0] > 0.0 and order_7_result[1] > 0.0)) {
+        const double order_7_norm_of_top_modal_coefficient =
+            square(0.06936287633138594 * u[-3 * stride] -
+                   0.4161772579883155 * u[-2 * stride] +
+                   1.040443144970789 * u[-stride] -  //
+                   1.3872575266277185 * u[0] +       //
+                   1.040443144970789 * u[stride] -
+                   0.4161772579883155 * u[2 * stride] +  //
+                   0.06936287633138594 * u[3 * stride]);
+
+        const double order_7_norm_of_polynomial =
+            u[stride] * (3.93094886671763 * u[stride] -
+                         4.4887583031366605 * u[2 * stride] +
+                         2.126671427664419 * u[3 * stride] +
+                         6.081742742499426 * u[-stride] -
+                         3.1180508323787337 * u[-2 * stride] +
+                         1.2660604719155235 * u[-3 * stride] -
+                         8.108990323332568 * u[0]) +
+            u[2 * stride] * (1.7504056695205172 * u[2 * stride] -
+                             1.402086588589091 * u[3 * stride] -
+                             3.1180508323787337 * u[-stride] +
+                             1.384291080027286 * u[-2 * stride] -
+                             0.46498946172145633 * u[-3 * stride] +
+                             4.614303600090953 * u[0]) +
+            u[3 * stride] * (0.5786954880513824 * u[3 * stride] +
+                             1.2660604719155235 * u[-stride] -
+                             0.46498946172145633 * u[-2 * stride] +
+                             0.10352871936656591 * u[-3 * stride] -
+                             2.0705743873313183 * u[0]) +
+            u[-stride] * (3.93094886671763 * u[-stride] -
+                          4.4887583031366605 * u[-2 * stride] +
+                          2.126671427664419 * u[-3 * stride] -
+                          8.108990323332568 * u[0]) +
+            u[-2 * stride] * (1.7504056695205172 * u[-2 * stride] -
+                              1.402086588589091 * u[-3 * stride] +
+                              4.614303600090953 * u[0]) +
+            u[-3 * stride] * (0.5786954880513824 * u[-3 * stride] -
+                              2.0705743873313183 * u[0]) +
+            5.203166203165525 * square(u[0]);
+        if (square(six_to_the_alpha_7) *
+                order_7_norm_of_top_modal_coefficient <=
+            order_7_norm_of_polynomial) {
+          return order_7_result;
+        }
+      }
+    }
     const std::array order_5_result =
         UnlimitedReconstructor<4>::pointwise(u, stride);
     if (not PositivityPreserving or
@@ -88,7 +213,9 @@ struct PositivityPreservingAdaptiveOrderReconstructor {
     return {{u[0], u[0]}};
   }
 
-  SPECTRE_ALWAYS_INLINE static constexpr size_t stencil_width() { return 5; }
+  SPECTRE_ALWAYS_INLINE static constexpr size_t stencil_width() {
+    return Use9thOrder ? 9 : (Use7thOrder ? 7 : 5);
+  }
 };
 }  // namespace detail
 
@@ -111,8 +238,43 @@ struct PositivityPreservingAdaptiveOrderReconstructor {
  * If `PositivityPreserving` is `true` then if the low-order reconstructed
  * solution isn't positive we use first-order (constant in space)
  * reconstruction.
+ *
+ * If `Use9thOrder` is `true` then first a ninth-order reconstruction is used,
+ * followed by fifth-order. If `Use7thOrder` is `true` then seventh-order
+ * reconstruction is used before fifth-order (but after ninth-order if
+ * `Use9thOrder` is also `true`). This allows using the highest possible order
+ * locally for reconstruction.
+ *
+ * Fifth order unlimited reconstruction is:
+ *
+ * \f{align}{
+ *   \hat{u}_{i+1/2}=\frac{3}{128}u_{i-2} - \frac{5}{32}u_{i-1}
+ *     + \frac{45}{64}u_{i} + \frac{15}{32}u_{i+1} - \frac{5}{128}u_{i+2}
+ * \f}
+ *
+ * Seventh order unlimited reconstruction is:
+ *
+ * \f{align}{
+ *    \hat{u}_{i+1/2}&=-\frac{5}{1024}u_{i-3} + \frac{21}{512}u_{i-2}
+ *         - \frac{175}{1024}u_{i-1} + \frac{175}{256}u_{i} \\
+ *         &+ \frac{525}{1024}u_{i+1} - \frac{35}{512}u_{i+2}
+ *         + \frac{7}{1024}u_{i+3}
+ * \f}
+ *
+ * Ninth order unlimited reconstruction is:
+ *
+ * \f{align}{
+ *   \hat{u}_{i+1/2}&=\frac{35}{32768}u_{i-4} - \frac{45}{4096}u_{i-3}
+ *         + \frac{441}{8291}u_{i-2} - \frac{735}{4096}u_{i-1} \\
+ *         &+ \frac{11025}{16384}u_{i}
+ *         + \frac{2205}{4096}u_{i+1} - \frac{735}{8192}u_{i+2}
+ *         + \frac{63}{4096}u_{i+3} \\
+ *         &- \frac{45}{32768}u_{i+4}
+ * \f}
+ *
  */
-template <typename LowOrderReconstructor, bool PositivityPreserving, size_t Dim>
+template <typename LowOrderReconstructor, bool PositivityPreserving,
+          bool Use9thOrder, bool Use7thOrder, size_t Dim>
 void positivity_preserving_adaptive_order(
     const gsl::not_null<std::array<gsl::span<double>, Dim>*>
         reconstructed_upper_side_of_face_vars,
@@ -121,12 +283,14 @@ void positivity_preserving_adaptive_order(
     const gsl::span<const double>& volume_vars,
     const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
     const Index<Dim>& volume_extents, const size_t number_of_variables,
-    const double four_to_the_alpha_5) {
+    const double four_to_the_alpha_5, const double six_to_the_alpha_7,
+    const double eight_to_the_alpha_9) {
   detail::reconstruct<detail::PositivityPreservingAdaptiveOrderReconstructor<
-      LowOrderReconstructor, PositivityPreserving>>(
+      LowOrderReconstructor, PositivityPreserving, Use9thOrder, Use7thOrder>>(
       reconstructed_upper_side_of_face_vars,
       reconstructed_lower_side_of_face_vars, volume_vars, ghost_cell_vars,
-      volume_extents, number_of_variables, four_to_the_alpha_5);
+      volume_extents, number_of_variables, four_to_the_alpha_5,
+      six_to_the_alpha_7, eight_to_the_alpha_9);
 }
 
 /*!
@@ -136,17 +300,19 @@ void positivity_preserving_adaptive_order(
  */
 template <size_t Dim>
 auto positivity_preserving_adaptive_order_function_pointers(
-    bool positivity_preserving, FallbackReconstructorType fallback_recons)
-    -> std::tuple<
-        void (*)(gsl::not_null<std::array<gsl::span<double>, Dim>*>,
-                 gsl::not_null<std::array<gsl::span<double>, Dim>*>,
-                 const gsl::span<const double>&,
-                 const DirectionMap<Dim, gsl::span<const double>>&,
-                 const Index<Dim>&, size_t, double),
-        void (*)(gsl::not_null<DataVector*>, const DataVector&,
-                 const DataVector&, const Index<Dim>&, const Index<Dim>&,
-                 const Direction<Dim>&, const double&),
-        void (*)(gsl::not_null<DataVector*>, const DataVector&,
-                 const DataVector&, const Index<Dim>&, const Index<Dim>&,
-                 const Direction<Dim>&, const double&)>;
+    bool positivity_preserving, bool use_9th_order, bool use_7th_order,
+    FallbackReconstructorType fallback_recons)
+    -> std::tuple<void (*)(gsl::not_null<std::array<gsl::span<double>, Dim>*>,
+                           gsl::not_null<std::array<gsl::span<double>, Dim>*>,
+                           const gsl::span<const double>&,
+                           const DirectionMap<Dim, gsl::span<const double>>&,
+                           const Index<Dim>&, size_t, double, double, double),
+                  void (*)(gsl::not_null<DataVector*>, const DataVector&,
+                           const DataVector&, const Index<Dim>&,
+                           const Index<Dim>&, const Direction<Dim>&,
+                           const double&, const double&, const double&),
+                  void (*)(gsl::not_null<DataVector*>, const DataVector&,
+                           const DataVector&, const Index<Dim>&,
+                           const Index<Dim>&, const Direction<Dim>&,
+                           const double&, const double&, const double&)>;
 }  // namespace fd::reconstruction

--- a/src/NumericalAlgorithms/FiniteDifference/Reconstruct.tpp
+++ b/src/NumericalAlgorithms/FiniteDifference/Reconstruct.tpp
@@ -19,6 +19,62 @@
 
 namespace fd::reconstruction {
 namespace detail {
+template <size_t Index, size_t DimToReplace, size_t... Is,
+          size_t Dim = sizeof...(Is)>
+auto generate_index_for_u_to_reconstruct_impl(
+    const std::array<size_t, sizeof...(Is)>& indices,
+    std::index_sequence<Is...>) -> ::Index<Dim> {
+  return ::Index<Dim>{(DimToReplace != Is ? indices[Is] : Index)...};
+}
+
+template <size_t Index, size_t DimToReplace, size_t NumberOfNeighborCells,
+          size_t... Is, size_t Dim = sizeof...(Is)>
+auto generate_upper_volume_index_for_u_to_reconstruct_impl(
+    const std::array<size_t, sizeof...(Is)>& indices,
+    const ::Index<Dim>& volume_extents, std::index_sequence<Is...>)
+    -> ::Index<Dim> {
+  return ::Index<Dim>{
+      (DimToReplace != Is
+           ? indices[Is]
+           : (volume_extents[Is] - (NumberOfNeighborCells - Index)))...};
+}
+
+template <Side UpperLower, size_t DimToReplace, size_t Dim,
+          size_t... VolumeIndices, size_t... GhostIndices>
+auto u_to_reconstruct_impl(const DataVector& volume_data,
+                           const DataVector& neighbor_data,
+                           const std::array<size_t, Dim>& indices,
+                           const Index<Dim>& volume_extents,
+                           const Index<Dim>& ghost_data_extents,
+                           std::index_sequence<VolumeIndices...> /*unused*/,
+                           std::index_sequence<GhostIndices...> /*unused*/) {
+  if constexpr (UpperLower == Side::Lower) {
+    return std::array{
+        neighbor_data[collapsed_index(
+            generate_index_for_u_to_reconstruct_impl<GhostIndices,
+                                                     DimToReplace>(
+                indices, std::make_index_sequence<Dim>{}),
+            ghost_data_extents)]...,
+        volume_data[collapsed_index(
+            generate_index_for_u_to_reconstruct_impl<VolumeIndices,
+                                                     DimToReplace>(
+                indices, std::make_index_sequence<Dim>{}),
+            volume_extents)]...};
+  } else {
+    return std::array{
+        volume_data[collapsed_index(
+            generate_upper_volume_index_for_u_to_reconstruct_impl<
+                VolumeIndices, DimToReplace, sizeof...(VolumeIndices)>(
+                indices, volume_extents, std::make_index_sequence<Dim>{}),
+            volume_extents)]...,
+        neighbor_data[collapsed_index(
+            generate_index_for_u_to_reconstruct_impl<GhostIndices,
+                                                     DimToReplace>(
+                indices, std::make_index_sequence<Dim>{}),
+            ghost_data_extents)]...};
+  }
+}
+
 template <typename Reconstructor, size_t Dim, typename... ArgsForReconstructor>
 void reconstruct_impl(const gsl::not_null<gsl::span<double>*> recons_upper,
                       const gsl::not_null<gsl::span<double>*> recons_lower,
@@ -308,8 +364,6 @@ void reconstruct_neighbor(
                 "currently only support stencil widths of 3 and 5.");
 
   constexpr size_t index_of_pointwise = LowerOrUpperSide == Side::Upper ? 0 : 1;
-  constexpr size_t neighbor_ghost_size =
-      (Reconstructor::stencil_width() + 1) / 2;
   constexpr size_t offset_into_u_to_reconstruct =
       (Reconstructor::stencil_width() - 1) / 2;
   std::array<double, Reconstructor::stencil_width()> u_to_reconstruct{};
@@ -331,6 +385,26 @@ void reconstruct_neighbor(
           upper_side ? neighbor_data[0] : neighbor_data[2],
           upper_side ? neighbor_data[1] : volume_data[volume_index],
           upper_side ? neighbor_data[2] : volume_data[volume_index + 1]};
+    } else if constexpr (Reconstructor::stencil_width() == 7) {
+      u_to_reconstruct = std::array{
+          upper_side ? volume_data[volume_index - 2] : neighbor_data[0],
+          upper_side ? volume_data[volume_index - 1] : neighbor_data[1],
+          upper_side ? volume_data[volume_index] : neighbor_data[2],
+          upper_side ? neighbor_data[0] : neighbor_data[3],
+          upper_side ? neighbor_data[1] : volume_data[volume_index],
+          upper_side ? neighbor_data[2] : volume_data[volume_index + 1],
+          upper_side ? neighbor_data[3] : volume_data[volume_index + 2]};
+    } else if constexpr (Reconstructor::stencil_width() == 9) {
+      u_to_reconstruct = std::array{
+          upper_side ? volume_data[volume_index - 3] : neighbor_data[0],
+          upper_side ? volume_data[volume_index - 2] : neighbor_data[1],
+          upper_side ? volume_data[volume_index - 1] : neighbor_data[2],
+          upper_side ? volume_data[volume_index] : neighbor_data[3],
+          upper_side ? neighbor_data[0] : neighbor_data[4],
+          upper_side ? neighbor_data[1] : volume_data[volume_index],
+          upper_side ? neighbor_data[2] : volume_data[volume_index + 1],
+          upper_side ? neighbor_data[3] : volume_data[volume_index + 2],
+          upper_side ? neighbor_data[4] : volume_data[volume_index + 3]};
     }
     (*face_data)[0] = Reconstructor::pointwise(
         u_to_reconstruct.data() + offset_into_u_to_reconstruct, 1,
@@ -339,78 +413,44 @@ void reconstruct_neighbor(
     (void)ghost_data_extents;
     if (direction_to_reconstruct == Direction<Dim>::lower_xi()) {
       for (size_t j = 0; j < volume_extents[1]; ++j) {
-        if constexpr (Reconstructor::stencil_width() == 3) {
-          u_to_reconstruct = std::array{
-              neighbor_data[j * neighbor_ghost_size],
-              neighbor_data[j * neighbor_ghost_size + 1],
-              volume_data[collapsed_index(Index<Dim>(0, j), volume_extents)]};
-        } else if constexpr (Reconstructor::stencil_width() == 5) {
-          u_to_reconstruct = std::array{
-              neighbor_data[j * neighbor_ghost_size],
-              neighbor_data[j * neighbor_ghost_size + 1],
-              neighbor_data[j * neighbor_ghost_size + 2],
-              volume_data[collapsed_index(Index<Dim>(0, j), volume_extents)],
-              volume_data[collapsed_index(Index<Dim>(1, j), volume_extents)]};
-        }
+        u_to_reconstruct = detail::u_to_reconstruct_impl<Side::Lower, 0, Dim>(
+            volume_data, neighbor_data, {std::numeric_limits<size_t>::max(), j},
+            volume_extents, ghost_data_extents,
+            std::make_index_sequence<Reconstructor::stencil_width() / 2>{},
+            std::make_index_sequence<Reconstructor::stencil_width() / 2 + 1>{});
         (*face_data)[j] = Reconstructor::pointwise(
             u_to_reconstruct.data() + offset_into_u_to_reconstruct, 1,
             args_for_reconstructor...)[index_of_pointwise];
       }
     } else if (direction_to_reconstruct == Direction<Dim>::upper_xi()) {
       for (size_t j = 0; j < volume_extents[1]; ++j) {
-        if constexpr (Reconstructor::stencil_width() == 3) {
-          u_to_reconstruct = std::array{
-              volume_data[collapsed_index(Index<Dim>(volume_extents[0] - 1, j),
-                                          volume_extents)],
-              neighbor_data[j * neighbor_ghost_size],
-              neighbor_data[j * neighbor_ghost_size + 1]};
-        } else if constexpr (Reconstructor::stencil_width() == 5) {
-          u_to_reconstruct = std::array{
-              volume_data[collapsed_index(Index<Dim>(volume_extents[0] - 2, j),
-                                          volume_extents)],
-              volume_data[collapsed_index(Index<Dim>(volume_extents[0] - 1, j),
-                                          volume_extents)],
-              neighbor_data[j * neighbor_ghost_size],
-              neighbor_data[j * neighbor_ghost_size + 1],
-              neighbor_data[j * neighbor_ghost_size + 2]};
-        }
+        u_to_reconstruct = detail::u_to_reconstruct_impl<Side::Upper, 0, Dim>(
+            volume_data, neighbor_data, {std::numeric_limits<size_t>::max(), j},
+            volume_extents, ghost_data_extents,
+            std::make_index_sequence<Reconstructor::stencil_width() / 2>{},
+            std::make_index_sequence<Reconstructor::stencil_width() / 2 + 1>{});
         (*face_data)[j] = Reconstructor::pointwise(
             u_to_reconstruct.data() + offset_into_u_to_reconstruct, 1,
             args_for_reconstructor...)[index_of_pointwise];
       }
     } else if (direction_to_reconstruct == Direction<Dim>::lower_eta()) {
       for (size_t i = 0; i < volume_extents[0]; ++i) {
-        if constexpr (Reconstructor::stencil_width() == 3) {
-          u_to_reconstruct = std::array{
-              neighbor_data[i], neighbor_data[i + volume_extents[0]],
-              volume_data[collapsed_index(Index<Dim>(i, 0), volume_extents)]};
-        } else if constexpr (Reconstructor::stencil_width() == 5) {
-          u_to_reconstruct = std::array{
-              neighbor_data[i], neighbor_data[i + volume_extents[0]],
-              neighbor_data[i + 2 * volume_extents[0]],
-              volume_data[collapsed_index(Index<Dim>(i, 0), volume_extents)],
-              volume_data[collapsed_index(Index<Dim>(i, 1), volume_extents)]};
-        }
+        u_to_reconstruct = detail::u_to_reconstruct_impl<Side::Lower, 1, Dim>(
+            volume_data, neighbor_data, {i, std::numeric_limits<size_t>::max()},
+            volume_extents, ghost_data_extents,
+            std::make_index_sequence<Reconstructor::stencil_width() / 2>{},
+            std::make_index_sequence<Reconstructor::stencil_width() / 2 + 1>{});
         (*face_data)[i] = Reconstructor::pointwise(
             u_to_reconstruct.data() + offset_into_u_to_reconstruct, 1,
             args_for_reconstructor...)[index_of_pointwise];
       }
     } else if (direction_to_reconstruct == Direction<Dim>::upper_eta()) {
       for (size_t i = 0; i < volume_extents[0]; ++i) {
-        if constexpr (Reconstructor::stencil_width() == 3) {
-          u_to_reconstruct = std::array{
-              volume_data[collapsed_index(Index<Dim>(i, volume_extents[1] - 1),
-                                          volume_extents)],
-              neighbor_data[i], neighbor_data[i + volume_extents[0]]};
-        } else if constexpr (Reconstructor::stencil_width() == 5) {
-          u_to_reconstruct = std::array{
-              volume_data[collapsed_index(Index<Dim>(i, volume_extents[1] - 2),
-                                          volume_extents)],
-              volume_data[collapsed_index(Index<Dim>(i, volume_extents[1] - 1),
-                                          volume_extents)],
-              neighbor_data[i], neighbor_data[i + volume_extents[0]],
-              neighbor_data[i + 2 * volume_extents[0]]};
-        }
+        u_to_reconstruct = detail::u_to_reconstruct_impl<Side::Upper, 1, Dim>(
+            volume_data, neighbor_data, {i, std::numeric_limits<size_t>::max()},
+            volume_extents, ghost_data_extents,
+            std::make_index_sequence<Reconstructor::stencil_width() / 2>{},
+            std::make_index_sequence<Reconstructor::stencil_width() / 2 + 1>{});
         (*face_data)[i] = Reconstructor::pointwise(
             u_to_reconstruct.data() + offset_into_u_to_reconstruct, 1,
             args_for_reconstructor...)[index_of_pointwise];
@@ -421,27 +461,13 @@ void reconstruct_neighbor(
       const Index<Dim - 1> face_extents = volume_extents.slice_away(0);
       for (size_t k = 0; k < volume_extents[2]; ++k) {
         for (size_t j = 0; j < volume_extents[1]; ++j) {
-          if constexpr (Reconstructor::stencil_width() == 3) {
-            u_to_reconstruct =
-                std::array{neighbor_data[collapsed_index(Index<Dim>(0, j, k),
-                                                         ghost_data_extents)],
-                           neighbor_data[collapsed_index(Index<Dim>(1, j, k),
-                                                         ghost_data_extents)],
-                           volume_data[collapsed_index(Index<Dim>(0, j, k),
-                                                       volume_extents)]};
-          } else if constexpr (Reconstructor::stencil_width() == 5) {
-            u_to_reconstruct =
-                std::array{neighbor_data[collapsed_index(Index<Dim>(0, j, k),
-                                                         ghost_data_extents)],
-                           neighbor_data[collapsed_index(Index<Dim>(1, j, k),
-                                                         ghost_data_extents)],
-                           neighbor_data[collapsed_index(Index<Dim>(2, j, k),
-                                                         ghost_data_extents)],
-                           volume_data[collapsed_index(Index<Dim>(0, j, k),
-                                                       volume_extents)],
-                           volume_data[collapsed_index(Index<Dim>(1, j, k),
-                                                       volume_extents)]};
-          }
+          u_to_reconstruct = detail::u_to_reconstruct_impl<Side::Lower, 0, Dim>(
+              volume_data, neighbor_data,
+              {std::numeric_limits<size_t>::max(), j, k}, volume_extents,
+              ghost_data_extents,
+              std::make_index_sequence<Reconstructor::stencil_width() / 2>{},
+              std::make_index_sequence<Reconstructor::stencil_width() / 2 +
+                                       1>{});
           (*face_data)[collapsed_index(Index<Dim - 1>(j, k), face_extents)] =
               Reconstructor::pointwise(
                   u_to_reconstruct.data() + offset_into_u_to_reconstruct, 1,
@@ -452,27 +478,13 @@ void reconstruct_neighbor(
       const Index<Dim - 1> face_extents = volume_extents.slice_away(0);
       for (size_t k = 0; k < volume_extents[2]; ++k) {
         for (size_t j = 0; j < volume_extents[1]; ++j) {
-          if constexpr (Reconstructor::stencil_width() == 3) {
-            u_to_reconstruct = std::array{
-                volume_data[collapsed_index(
-                    Index<Dim>(volume_extents[0] - 1, j, k), volume_extents)],
-                neighbor_data[collapsed_index(Index<Dim>(0, j, k),
-                                              ghost_data_extents)],
-                neighbor_data[collapsed_index(Index<Dim>(1, j, k),
-                                              ghost_data_extents)]};
-          } else if constexpr (Reconstructor::stencil_width() == 5) {
-            u_to_reconstruct = std::array{
-                volume_data[collapsed_index(
-                    Index<Dim>(volume_extents[0] - 2, j, k), volume_extents)],
-                volume_data[collapsed_index(
-                    Index<Dim>(volume_extents[0] - 1, j, k), volume_extents)],
-                neighbor_data[collapsed_index(Index<Dim>(0, j, k),
-                                              ghost_data_extents)],
-                neighbor_data[collapsed_index(Index<Dim>(1, j, k),
-                                              ghost_data_extents)],
-                neighbor_data[collapsed_index(Index<Dim>(2, j, k),
-                                              ghost_data_extents)]};
-          }
+          u_to_reconstruct = detail::u_to_reconstruct_impl<Side::Upper, 0, Dim>(
+              volume_data, neighbor_data,
+              {std::numeric_limits<size_t>::max(), j, k}, volume_extents,
+              ghost_data_extents,
+              std::make_index_sequence<Reconstructor::stencil_width() / 2>{},
+              std::make_index_sequence<Reconstructor::stencil_width() / 2 +
+                                       1>{});
           (*face_data)[collapsed_index(Index<Dim - 1>(j, k), face_extents)] =
               Reconstructor::pointwise(
                   u_to_reconstruct.data() + offset_into_u_to_reconstruct, 1,
@@ -483,27 +495,13 @@ void reconstruct_neighbor(
       const Index<Dim - 1> face_extents = volume_extents.slice_away(1);
       for (size_t k = 0; k < volume_extents[2]; ++k) {
         for (size_t i = 0; i < volume_extents[0]; ++i) {
-          if constexpr (Reconstructor::stencil_width() == 3) {
-            u_to_reconstruct =
-                std::array{neighbor_data[collapsed_index(Index<Dim>(i, 0, k),
-                                                         ghost_data_extents)],
-                           neighbor_data[collapsed_index(Index<Dim>(i, 1, k),
-                                                         ghost_data_extents)],
-                           volume_data[collapsed_index(Index<Dim>(i, 0, k),
-                                                       volume_extents)]};
-          } else if constexpr (Reconstructor::stencil_width() == 5) {
-            u_to_reconstruct =
-                std::array{neighbor_data[collapsed_index(Index<Dim>(i, 0, k),
-                                                         ghost_data_extents)],
-                           neighbor_data[collapsed_index(Index<Dim>(i, 1, k),
-                                                         ghost_data_extents)],
-                           neighbor_data[collapsed_index(Index<Dim>(i, 2, k),
-                                                         ghost_data_extents)],
-                           volume_data[collapsed_index(Index<Dim>(i, 0, k),
-                                                       volume_extents)],
-                           volume_data[collapsed_index(Index<Dim>(i, 1, k),
-                                                       volume_extents)]};
-          }
+          u_to_reconstruct = detail::u_to_reconstruct_impl<Side::Lower, 1, Dim>(
+              volume_data, neighbor_data,
+              {i, std::numeric_limits<size_t>::max(), k}, volume_extents,
+              ghost_data_extents,
+              std::make_index_sequence<Reconstructor::stencil_width() / 2>{},
+              std::make_index_sequence<Reconstructor::stencil_width() / 2 +
+                                       1>{});
           (*face_data)[collapsed_index(Index<Dim - 1>(i, k), face_extents)] =
               Reconstructor::pointwise(
                   u_to_reconstruct.data() + offset_into_u_to_reconstruct, 1,
@@ -514,27 +512,13 @@ void reconstruct_neighbor(
       const Index<Dim - 1> face_extents = volume_extents.slice_away(1);
       for (size_t k = 0; k < volume_extents[2]; ++k) {
         for (size_t i = 0; i < volume_extents[0]; ++i) {
-          if constexpr (Reconstructor::stencil_width() == 3) {
-            u_to_reconstruct = std::array{
-                volume_data[collapsed_index(
-                    Index<Dim>(i, volume_extents[1] - 1, k), volume_extents)],
-                neighbor_data[collapsed_index(Index<Dim>(i, 0, k),
-                                              ghost_data_extents)],
-                neighbor_data[collapsed_index(Index<Dim>(i, 1, k),
-                                              ghost_data_extents)]};
-          } else if constexpr (Reconstructor::stencil_width() == 5) {
-            u_to_reconstruct = std::array{
-                volume_data[collapsed_index(
-                    Index<Dim>(i, volume_extents[1] - 2, k), volume_extents)],
-                volume_data[collapsed_index(
-                    Index<Dim>(i, volume_extents[1] - 1, k), volume_extents)],
-                neighbor_data[collapsed_index(Index<Dim>(i, 0, k),
-                                              ghost_data_extents)],
-                neighbor_data[collapsed_index(Index<Dim>(i, 1, k),
-                                              ghost_data_extents)],
-                neighbor_data[collapsed_index(Index<Dim>(i, 2, k),
-                                              ghost_data_extents)]};
-          }
+          u_to_reconstruct = detail::u_to_reconstruct_impl<Side::Upper, 1, Dim>(
+              volume_data, neighbor_data,
+              {i, std::numeric_limits<size_t>::max(), k}, volume_extents,
+              ghost_data_extents,
+              std::make_index_sequence<Reconstructor::stencil_width() / 2>{},
+              std::make_index_sequence<Reconstructor::stencil_width() / 2 +
+                                       1>{});
           (*face_data)[collapsed_index(Index<Dim - 1>(i, k), face_extents)] =
               Reconstructor::pointwise(
                   u_to_reconstruct.data() + offset_into_u_to_reconstruct, 1,
@@ -545,27 +529,13 @@ void reconstruct_neighbor(
       const Index<Dim - 1> face_extents = volume_extents.slice_away(2);
       for (size_t j = 0; j < volume_extents[1]; ++j) {
         for (size_t i = 0; i < volume_extents[0]; ++i) {
-          if constexpr (Reconstructor::stencil_width() == 3) {
-            u_to_reconstruct =
-                std::array{neighbor_data[collapsed_index(Index<Dim>(i, j, 0),
-                                                         ghost_data_extents)],
-                           neighbor_data[collapsed_index(Index<Dim>(i, j, 1),
-                                                         ghost_data_extents)],
-                           volume_data[collapsed_index(Index<Dim>(i, j, 0),
-                                                       volume_extents)]};
-          } else if constexpr (Reconstructor::stencil_width() == 5) {
-            u_to_reconstruct =
-                std::array{neighbor_data[collapsed_index(Index<Dim>(i, j, 0),
-                                                         ghost_data_extents)],
-                           neighbor_data[collapsed_index(Index<Dim>(i, j, 1),
-                                                         ghost_data_extents)],
-                           neighbor_data[collapsed_index(Index<Dim>(i, j, 2),
-                                                         ghost_data_extents)],
-                           volume_data[collapsed_index(Index<Dim>(i, j, 0),
-                                                       volume_extents)],
-                           volume_data[collapsed_index(Index<Dim>(i, j, 1),
-                                                       volume_extents)]};
-          }
+          u_to_reconstruct = detail::u_to_reconstruct_impl<Side::Lower, 2, Dim>(
+              volume_data, neighbor_data,
+              {i, j, std::numeric_limits<size_t>::max()}, volume_extents,
+              ghost_data_extents,
+              std::make_index_sequence<Reconstructor::stencil_width() / 2>{},
+              std::make_index_sequence<Reconstructor::stencil_width() / 2 +
+                                       1>{});
           (*face_data)[collapsed_index(Index<Dim - 1>(i, j), face_extents)] =
               Reconstructor::pointwise(
                   u_to_reconstruct.data() + offset_into_u_to_reconstruct, 1,
@@ -576,27 +546,13 @@ void reconstruct_neighbor(
       const Index<Dim - 1> face_extents = volume_extents.slice_away(2);
       for (size_t j = 0; j < volume_extents[1]; ++j) {
         for (size_t i = 0; i < volume_extents[0]; ++i) {
-          if constexpr (Reconstructor::stencil_width() == 3) {
-            u_to_reconstruct = std::array{
-                volume_data[collapsed_index(
-                    Index<Dim>(i, j, volume_extents[2] - 1), volume_extents)],
-                neighbor_data[collapsed_index(Index<Dim>(i, j, 0),
-                                              ghost_data_extents)],
-                neighbor_data[collapsed_index(Index<Dim>(i, j, 1),
-                                              ghost_data_extents)]};
-          } else if constexpr (Reconstructor::stencil_width() == 5) {
-            u_to_reconstruct = std::array{
-                volume_data[collapsed_index(
-                    Index<Dim>(i, j, volume_extents[2] - 2), volume_extents)],
-                volume_data[collapsed_index(
-                    Index<Dim>(i, j, volume_extents[2] - 1), volume_extents)],
-                neighbor_data[collapsed_index(Index<Dim>(i, j, 0),
-                                              ghost_data_extents)],
-                neighbor_data[collapsed_index(Index<Dim>(i, j, 1),
-                                              ghost_data_extents)],
-                neighbor_data[collapsed_index(Index<Dim>(i, j, 2),
-                                              ghost_data_extents)]};
-          }
+          u_to_reconstruct = detail::u_to_reconstruct_impl<Side::Upper, 2, Dim>(
+              volume_data, neighbor_data,
+              {i, j, std::numeric_limits<size_t>::max()}, volume_extents,
+              ghost_data_extents,
+              std::make_index_sequence<Reconstructor::stencil_width() / 2>{},
+              std::make_index_sequence<Reconstructor::stencil_width() / 2 +
+                                       1>{});
           (*face_data)[collapsed_index(Index<Dim - 1>(i, j), face_extents)] =
               Reconstructor::pointwise(
                   u_to_reconstruct.data() + offset_into_u_to_reconstruct, 1,

--- a/src/NumericalAlgorithms/FiniteDifference/Reconstruct.tpp
+++ b/src/NumericalAlgorithms/FiniteDifference/Reconstruct.tpp
@@ -360,8 +360,10 @@ void reconstruct_neighbor(
              << ". Note that we pass the Side in as a template parameter to "
                 "avoid runtime branches in tight loops.");
   static_assert(Reconstructor::stencil_width() == 3 or
-                    Reconstructor::stencil_width() == 5,
-                "currently only support stencil widths of 3 and 5.");
+                    Reconstructor::stencil_width() == 5 or
+                    Reconstructor::stencil_width() == 7 or
+                    Reconstructor::stencil_width() == 9,
+                "currently only support stencil widths of 3, 5, 7, and 9.");
 
   constexpr size_t index_of_pointwise = LowerOrUpperSide == Side::Upper ? 0 : 1;
   constexpr size_t offset_into_u_to_reconstruct =

--- a/src/NumericalAlgorithms/FiniteDifference/Unlimited.cpp
+++ b/src/NumericalAlgorithms/FiniteDifference/Unlimited.cpp
@@ -23,7 +23,7 @@ namespace fd::reconstruction {
       const size_t number_of_variables);
 
 namespace detail {
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (2, 4))
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (2, 4, 6, 8))
 }  // namespace detail
 
 #undef INSTANTIATION
@@ -38,7 +38,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (2, 4))
       const Index<DIM(data)>& ghost_data_extents,                              \
       const Direction<DIM(data)>& direction_to_reconstruct);
 
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (2, 4),
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (2, 4, 6, 8),
                         (Side::Upper, Side::Lower))
 
 #undef INSTANTIATION

--- a/src/NumericalAlgorithms/FiniteDifference/Unlimited.hpp
+++ b/src/NumericalAlgorithms/FiniteDifference/Unlimited.hpp
@@ -21,7 +21,7 @@ namespace fd::reconstruction {
 namespace detail {
 template <size_t Degree>
 struct UnlimitedReconstructor {
-  static_assert(Degree == 2 or Degree == 4);
+  static_assert(Degree == 2 or Degree == 4 or Degree == 6 or Degree == 8);
   SPECTRE_ALWAYS_INLINE static std::array<double, 2> pointwise(
       const double* const q, const int stride) {
     if constexpr (Degree == 2) {
@@ -36,6 +36,29 @@ struct UnlimitedReconstructor {
                0.0234375 * q[-2 * stride] - 0.15625 * q[-stride] +
                0.703125 * q[0] + 0.46875 * q[stride] -
                0.0390625 * q[2 * stride]}};
+    } else if constexpr (Degree == 6) {
+      return {{-0.1708984375 * q[stride] + 0.041015625 * q[2 * stride] -
+                   0.0048828125 * q[3 * stride] + 0.5126953125 * q[-stride] -
+                   0.068359375 * q[-2 * stride] +
+                   0.0068359375 * q[-3 * stride] + 0.68359375 * q[0],
+               0.5126953125 * q[stride] - 0.068359375 * q[2 * stride] +
+                   0.0068359375 * q[3 * stride] - 0.1708984375 * q[-stride] +
+                   0.041015625 * q[-2 * stride] -
+                   0.0048828125 * q[-3 * stride] + 0.68359375 * q[0]}};
+    } else if constexpr (Degree == 8) {
+      return {
+          {-0.179443359375 * q[stride] + 0.0538330078125 * q[2 * stride] -
+               0.010986328125 * q[3 * stride] +
+               0.001068115234375 * q[4 * stride] + 0.538330078125 * q[-stride] -
+               0.0897216796875 * q[-2 * stride] +
+               0.015380859375 * q[-3 * stride] -
+               0.001373291015625 * q[-4 * stride] + 0.67291259765625 * q[0],
+           0.538330078125 * q[stride] - 0.0897216796875 * q[2 * stride] +
+               0.015380859375 * q[3 * stride] -
+               0.001373291015625 * q[4 * stride] - 0.179443359375 * q[-stride] +
+               0.0538330078125 * q[-2 * stride] -
+               0.010986328125 * q[-3 * stride] +
+               0.001068115234375 * q[-4 * stride] + 0.67291259765625 * q[0]}};
     }
   }
 
@@ -65,6 +88,8 @@ struct UnlimitedReconstructor {
  *  u_{j+1/2} &= \frac{3}{128}u_{j-2} - \frac{5}{32}u_{j-1} + \frac{45}{64}u_{j}
  *            + \frac{15}{32}u_{j+1} - \frac{5}{128}u_{j+2}.
  * \f}
+ *
+ * Degree 6 and 8 reconstruction is also supported.
  */
 template <size_t Degree, size_t Dim>
 void unlimited(

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_PositivityPreservingAdaptiveOrder.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_PositivityPreservingAdaptiveOrder.cpp
@@ -15,34 +15,85 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GrMhd.ValenciaDivClean.Fd.PpaoPrim",
   namespace helpers = TestHelpers::grmhd::ValenciaDivClean::fd;
   auto mc = fd::reconstruction::FallbackReconstructorType::MonotonisedCentral;
 
-  const grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim
-      PositivityPreservingAdaptiveOrder_recons{4.0, mc};
-  helpers::test_prim_reconstructor(4, PositivityPreservingAdaptiveOrder_recons);
+  helpers::test_prim_reconstructor(
+      6, grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim{
+             4.0, 4.0, std::nullopt, mc});
+  helpers::test_prim_reconstructor(
+      8, grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim{
+             4.0, std::nullopt, 4.0, mc});
+  helpers::test_prim_reconstructor(
+      8, grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim{
+             4.0, 4.0, 4.0, mc});
 
-  const auto PositivityPreservingAdaptiveOrder_from_options_base =
-      TestHelpers::test_factory_creation<
-          grmhd::ValenciaDivClean::fd::Reconstructor,
-          grmhd::ValenciaDivClean::fd::OptionTags::Reconstructor>(
-          "PositivityPreservingAdaptiveOrderPrim:\n"
-          "  Alpha5: 4.0\n"
-          "  LowOrderReconstructor: MonotonisedCentral\n");
-  auto* const PositivityPreservingAdaptiveOrder_from_options =
+  const grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim
+      ppao_recons{4.0, std::nullopt, std::nullopt, mc};
+  helpers::test_prim_reconstructor(4, ppao_recons);
+
+  const auto ppao_from_options_base = TestHelpers::test_factory_creation<
+      grmhd::ValenciaDivClean::fd::Reconstructor,
+      grmhd::ValenciaDivClean::fd::OptionTags::Reconstructor>(
+      "PositivityPreservingAdaptiveOrderPrim:\n"
+      "  Alpha5: 4.0\n"
+      "  Alpha7: None\n"
+      "  Alpha9: None\n"
+      "  LowOrderReconstructor: MonotonisedCentral\n");
+  auto* const ppao_from_options =
       dynamic_cast<const grmhd::ValenciaDivClean::fd::
                        PositivityPreservingAdaptiveOrderPrim*>(
-          PositivityPreservingAdaptiveOrder_from_options_base.get());
-  REQUIRE(PositivityPreservingAdaptiveOrder_from_options != nullptr);
-  CHECK(*PositivityPreservingAdaptiveOrder_from_options ==
-        PositivityPreservingAdaptiveOrder_recons);
+          ppao_from_options_base.get());
+  REQUIRE(ppao_from_options != nullptr);
+  CHECK(*ppao_from_options == ppao_recons);
 
-  CHECK(PositivityPreservingAdaptiveOrder_recons !=
-        grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(4.5,
-                                                                           mc));
-  CHECK(PositivityPreservingAdaptiveOrder_recons !=
+  CHECK(ppao_recons !=
         grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
-            4.0, fd::reconstruction::FallbackReconstructorType::Minmod));
+            4.5, std::nullopt, std::nullopt, mc));
+  CHECK(ppao_recons !=
+        grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
+            4.0, 4.0, std::nullopt, mc));
+  CHECK(grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
+            4.0, 4.0, std::nullopt, mc) !=
+        grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
+            4.0, 4.1, std::nullopt, mc));
+  CHECK(ppao_recons !=
+        grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
+            4.0, std::nullopt, 4.0, mc));
+  CHECK(grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
+            4.0, std::nullopt, 4.0, mc) !=
+        grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
+            4.0, std::nullopt, 4.1, mc));
+  CHECK(grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
+            5.0, std::nullopt, 4.0, mc) ==
+        grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
+            5.0, std::nullopt, 4.0, mc));
+  CHECK(grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
+            5.0, 6.0, 4.0, mc) ==
+        grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
+            5.0, 6.0, 4.0, mc));
+  CHECK(grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
+            5.0, 6.0, 4.0, mc) !=
+        grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
+            5.1, 6.0, 4.0, mc));
+  CHECK(grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
+            5.0, 6.0, 4.0, mc) !=
+        grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
+            5.0, 6.1, 4.0, mc));
+  CHECK(grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
+            5.0, 6.0, 4.0, mc) !=
+        grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
+            5.0, 6.0, 4.1, mc));
+  CHECK(grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
+            5.0, 6.0, 4.0, mc) !=
+        grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
+            5.0, 6.0, 4.0,
+            fd::reconstruction::FallbackReconstructorType::Minmod));
+  CHECK(ppao_recons !=
+        grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
+            4.0, std::nullopt, std::nullopt,
+            fd::reconstruction::FallbackReconstructorType::Minmod));
 
   CHECK_THROWS_WITH(
       grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
-          4.5, fd::reconstruction::FallbackReconstructorType::None),
+          4.5, std::nullopt, std::nullopt,
+          fd::reconstruction::FallbackReconstructorType::None),
       Catch::Contains("None is not an allowed low-order reconstructor."));
 }

--- a/tests/Unit/Helpers/NumericalAlgorithms/FiniteDifference/Exact.hpp
+++ b/tests/Unit/Helpers/NumericalAlgorithms/FiniteDifference/Exact.hpp
@@ -45,6 +45,7 @@ void test_reconstruction_is_exact_if_in_basis(
     const size_t max_degree, const size_t points_per_dimension,
     const size_t stencil_width, const F& invoke_recons,
     const F1& invoke_reconstruct_neighbor) {
+  CAPTURE(Dim);
   const size_t number_of_vars = 2;  // arbitrary, 2 is "cheap but not trivial"
 
   const Mesh<Dim> mesh{points_per_dimension, Spectral::Basis::FiniteDifference,

--- a/tests/Unit/Helpers/NumericalAlgorithms/FiniteDifference/Python.hpp
+++ b/tests/Unit/Helpers/NumericalAlgorithms/FiniteDifference/Python.hpp
@@ -49,12 +49,14 @@ namespace TestHelpers::fd::reconstruction {
  *  const Index<Dim>& volume_extents, const size_t number_of_variables)
  * \endcode
  */
-template <size_t Dim, typename ReconsFunction, typename F1>
+template <size_t Dim, typename ReconsFunction, typename F1,
+          typename... ExtraPyArgs>
 void test_with_python(const Index<Dim>& extents, const size_t stencil_width,
                       const std::string& python_test_file,
                       const std::string& python_function,
                       const ReconsFunction& recons_function,
-                      const F1& invoke_reconstruct_neighbor) {
+                      const F1& invoke_reconstruct_neighbor,
+                      const ExtraPyArgs&... extra_py_args) {
   CAPTURE(extents);
   CAPTURE(Dim);
   MAKE_GENERATOR(gen);
@@ -203,7 +205,7 @@ void test_with_python(const Index<Dim>& extents, const size_t stencil_width,
     const auto result =
         pypp::call<std::vector<std::vector<std::vector<double>>>>(
             python_test_file, python_function, var, extents_with_ghosts_vector,
-            Dim);
+            Dim, extra_py_args...);
 
     const std::vector<std::vector<double>>& python_recons_on_lower = result[0];
     const std::vector<std::vector<double>>& python_recons_on_upper = result[1];

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/PositivityPreservingAdaptiveOrder.py
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/PositivityPreservingAdaptiveOrder.py
@@ -22,9 +22,100 @@ def _mc(q):
     return [q[j] - 0.5 * slope, q[j] + 0.5 * slope]
 
 
-def _adaptive_order_5(q, keep_positive, low_order_recons):
-    j = 2
-    alpha_5 = 4.0
+def _adaptive_order_5(q, keep_positive, low_order_recons, use_9th_order,
+                      use_7th_order, four_to_the_alpha_5, six_to_the_alpha_7,
+                      eight_to_the_alpha_9):
+    j = 4 if use_9th_order else (3 if use_7th_order else 2)
+
+    if use_9th_order:
+        norm_top = (
+            -1.593380762005595 * q[j + 1] + 0.7966903810027975 * q[j + 2] -
+            0.22762582314365648 * q[j + 3] + 0.02845322789295706 * q[j + 4] -
+            1.593380762005595 * q[j - 1] + 0.7966903810027975 * q[j - 2] -
+            0.22762582314365648 * q[j - 3] + 0.02845322789295706 * q[j - 4] +
+            1.991725952506994 * q[j])**2
+        norm_full = (
+            q[j + 1] *
+            (25.393963433621668 * q[j + 1] - 31.738453392103736 * q[j + 2] +
+             14.315575523531798 * q[j + 3] - 5.422933317103013 * q[j + 4] +
+             45.309550145164756 * q[j - 1] - 25.682667845756164 * q[j - 2] +
+             10.394184200706238 * q[j - 3] - 3.5773996341558414 * q[j - 4] -
+             56.63693768145594 * q[j]) + q[j + 2] *
+            (10.664627625179254 * q[j + 2] - 9.781510753231265 * q[j + 3] +
+             3.783820939683476 * q[j + 4] - 25.682667845756164 * q[j - 1] +
+             13.59830711617153 * q[j - 2] - 5.064486634342602 * q[j - 3] +
+             1.5850428636128617 * q[j - 4] + 33.99576779042882 * q[j]) +
+            q[j + 3] *
+            (2.5801312593878514 * q[j + 3] - 1.812843724346584 * q[j + 4] +
+             10.394184200706238 * q[j - 1] - 5.064486634342602 * q[j - 2] +
+             1.6716163773782988 * q[j - 3] - 0.4380794296257583 * q[j - 4] -
+             14.626643302060115 * q[j]) + q[j + 4] *
+            (0.5249097623867759 * q[j + 4] - 3.5773996341558414 * q[j - 1] +
+             1.5850428636128617 * q[j - 2] - 0.4380794296257583 * q[j - 3] +
+             0.07624062080823268 * q[j - 4] + 5.336843456576288 * q[j]) +
+            q[j - 1] *
+            (25.393963433621668 * q[j - 1] - 31.738453392103736 * q[j - 2] +
+             14.315575523531798 * q[j - 3] - 5.422933317103013 * q[j - 4] -
+             56.63693768145594 * q[j]) + q[j - 2] *
+            (10.664627625179254 * q[j - 2] - 9.781510753231265 * q[j - 3] +
+             3.783820939683476 * q[j - 4] + 33.99576779042882 * q[j]) +
+            q[j - 3] *
+            (2.5801312593878514 * q[j - 3] - 1.812843724346584 * q[j - 4] -
+             14.626643302060115 * q[j]) + q[j - 4] *
+            (0.5249097623867759 * q[j - 4] + 5.336843456576288 * q[j]) +
+            33.758463458609164 * q[j]**2)
+        if (eight_to_the_alpha_9**2 * norm_top <= norm_full):
+            result = [
+                -0.179443359375 * q[j + 1] + 0.0538330078125 * q[j + 2] -
+                0.010986328125 * q[j + 3] + 0.001068115234375 * q[j + 4] +
+                0.538330078125 * q[j - 1] - 0.0897216796875 * q[j - 2] +
+                0.015380859375 * q[j - 3] - 0.001373291015625 * q[j - 4] +
+                0.67291259765625 * q[j], 0.538330078125 * q[j + 1] -
+                0.0897216796875 * q[j + 2] + 0.015380859375 * q[j + 3] -
+                0.001373291015625 * q[j + 4] - 0.179443359375 * q[j - 1] +
+                0.0538330078125 * q[j - 2] - 0.010986328125 * q[j - 3] +
+                0.001068115234375 * q[j - 4] + 0.67291259765625 * q[j]
+            ]
+            if (not keep_positive) or (result[0] > 0.0 and result[1] > 0.0):
+                return result
+
+    if use_7th_order:
+        norm_top = 2 * (16807 * q[j - 3] / 95040 - 16807 * q[j - 2] / 15840 +
+                        16807 * q[j - 1] / 6336 - 16807 * q[j] / 4752 +
+                        16807 * q[j + 1] / 6336 - 16807 * q[j + 2] / 15840 +
+                        16807 * q[j + 3] / 95040)**2 / 13
+        norm_full = (
+            q[j + 1] *
+            (3.93094886671763 * q[j + 1] - 4.4887583031366605 * q[j + 2] +
+             2.126671427664419 * q[j + 3] + 6.081742742499426 * q[j - 1] -
+             3.1180508323787337 * q[j - 2] + 1.2660604719155235 * q[j - 3] -
+             8.108990323332568 * q[j]) + q[j + 2] *
+            (1.7504056695205172 * q[j + 2] - 1.402086588589091 * q[j + 3] -
+             3.1180508323787337 * q[j - 1] + 1.384291080027286 * q[j - 2] -
+             0.46498946172145633 * q[j - 3] + 4.614303600090953 * q[j]) +
+            q[j + 3] *
+            (0.5786954880513824 * q[j + 3] + 1.2660604719155235 * q[j - 1] -
+             0.46498946172145633 * q[j - 2] + 0.10352871936656591 * q[j - 3] -
+             2.0705743873313183 * q[j]) + q[j - 1] *
+            (3.93094886671763 * q[j - 1] - 4.4887583031366605 * q[j - 2] +
+             2.126671427664419 * q[j - 3] - 8.108990323332568 * q[j]) +
+            q[j - 2] *
+            (1.7504056695205172 * q[j - 2] - 1.402086588589091 * q[j - 3] +
+             4.614303600090953 * q[j]) + q[j - 3] *
+            (0.5786954880513824 * q[j - 3] - 2.0705743873313183 * q[j]) +
+            5.203166203165525 * q[j]**2)
+        if (six_to_the_alpha_7**2 * norm_top <= norm_full):
+            result = [
+                -175 * q[j + 1] / 1024 + 21 * q[j + 2] / 512 -
+                5 * q[j + 3] / 1024 + 525 * q[j - 1] / 1024 -
+                35 * q[j - 2] / 512 + 7 * q[j - 3] / 1024 + 175 * q[j] / 256,
+                525 * q[j + 1] / 1024 - 35 * q[j + 2] / 512 +
+                7 * q[j + 3] / 1024 - 175 * q[j - 1] / 1024 +
+                21 * q[j - 2] / 512 - 5 * q[j - 3] / 1024 + 175 * q[j] / 256
+            ]
+            if (not keep_positive) or (result[0] > 0.0 and result[1] > 0.0):
+                return result
+
     norm_top = 0.2222222222222222 * (
         -1.4880952380952381 * q[j + 1] + 0.37202380952380953 * q[j + 2] -
         1.4880952380952381 * q[j - 1] + 0.37202380952380953 * q[j - 2] +
@@ -40,7 +131,7 @@ def _adaptive_order_5(q, keep_positive, low_order_recons):
          1.6356130125661377 * q[j]) + q[j - 2] *
         (0.6699388830329586 * q[j - 2] + 0.927411437665344 * q[j]) +
         1.4061182415674602 * q[j]**2)
-    if (4.0**alpha_5 * norm_top <= norm_full):
+    if (four_to_the_alpha_5 * norm_top <= norm_full):
         result = [
             -0.15625 * q[j + 1] + 0.0234375 * q[j + 2] + 0.46875 * q[j - 1] -
             0.0390625 * q[j - 2] + 0.703125 * q[j],
@@ -57,72 +148,116 @@ def _adaptive_order_5(q, keep_positive, low_order_recons):
 
 
 def compute_face_values_t(recons_upper_of_cell, recons_lower_of_cell, v, i, j,
-                          k, dim_to_recons, keep_positive, low_order_recons):
+                          k, dim_to_recons, keep_positive, low_order_recons,
+                          use_9th_order, use_7th_order, four_to_the_alpha_5,
+                          six_to_the_alpha_7, eight_to_the_alpha_9):
+    stencil_half_width = 4 if use_9th_order else (3 if use_7th_order else 2)
+    v_stencil = []
+
     if dim_to_recons == 0:
-        lower, upper = _adaptive_order_5(
-            np.asarray([
-                v[i - 2, j, k], v[i - 1, j, k], v[i, j, k], v[i + 1, j, k],
-                v[i + 2, j, k]
-            ]), keep_positive, low_order_recons)
+        for l in range(-stencil_half_width, stencil_half_width + 1):
+            v_stencil.append(v[i + l, j, k])
+
+        lower, upper = _adaptive_order_5(np.asarray(v_stencil), keep_positive,
+                                         low_order_recons, use_9th_order,
+                                         use_7th_order, four_to_the_alpha_5,
+                                         six_to_the_alpha_7,
+                                         eight_to_the_alpha_9)
         recons_lower_of_cell.append(lower)
         recons_upper_of_cell.append(upper)
     if dim_to_recons == 1:
-        lower, upper = _adaptive_order_5(
-            np.asarray([
-                v[i, j - 2, k], v[i, j - 1, k], v[i, j, k], v[i, j + 1, k],
-                v[i, j + 2, k]
-            ]), keep_positive, low_order_recons)
+        for l in range(-stencil_half_width, stencil_half_width + 1):
+            v_stencil.append(v[i, j + l, k])
+
+        lower, upper = _adaptive_order_5(np.asarray(v_stencil), keep_positive,
+                                         low_order_recons, use_9th_order,
+                                         use_7th_order, four_to_the_alpha_5,
+                                         six_to_the_alpha_7,
+                                         eight_to_the_alpha_9)
         recons_lower_of_cell.append(lower)
         recons_upper_of_cell.append(upper)
     if dim_to_recons == 2:
-        lower, upper = _adaptive_order_5(
-            np.asarray([
-                v[i, j, k - 2], v[i, j, k - 1], v[i, j, k], v[i, j, k + 1],
-                v[i, j, k + 2]
-            ]), keep_positive, low_order_recons)
+        for l in range(-stencil_half_width, stencil_half_width + 1):
+            v_stencil.append(v[i, j, k + l])
+
+        lower, upper = _adaptive_order_5(np.asarray(v_stencil), keep_positive,
+                                         low_order_recons, use_9th_order,
+                                         use_7th_order, four_to_the_alpha_5,
+                                         six_to_the_alpha_7,
+                                         eight_to_the_alpha_9)
         recons_lower_of_cell.append(lower)
         recons_upper_of_cell.append(upper)
 
 
-def test_adaptive_order_with_mc(u, extents, dim):
+def test_adaptive_order_with_mc(u, extents, dim, use_9th_order, use_7th_order,
+                                four_to_the_alpha_5, six_to_the_alpha_7,
+                                eight_to_the_alpha_9):
+    ghost_zone = 4 if use_9th_order else (3 if use_7th_order else 2)
+
     def compute_face_values(recons_upper_of_cell, recons_lower_of_cell, v, i,
                             j, k, dim_to_recons):
         return compute_face_values_t(recons_upper_of_cell,
                                      recons_lower_of_cell, v, i, j, k,
-                                     dim_to_recons, False, _mc)
+                                     dim_to_recons, False, _mc, use_9th_order,
+                                     use_7th_order, four_to_the_alpha_5,
+                                     six_to_the_alpha_7, eight_to_the_alpha_9)
 
-    return Reconstruction.reconstruct(u, extents, dim, [2, 2, 2],
+    return Reconstruction.reconstruct(u, extents, dim,
+                                      [ghost_zone, ghost_zone, ghost_zone],
                                       compute_face_values)
 
 
-def test_adaptive_order_with_minmod(u, extents, dim):
+def test_adaptive_order_with_minmod(u, extents, dim, use_9th_order,
+                                    use_7th_order, four_to_the_alpha_5,
+                                    six_to_the_alpha_7, eight_to_the_alpha_9):
+    ghost_zone = 4 if use_9th_order else (3 if use_7th_order else 2)
+
     def compute_face_values(recons_upper_of_cell, recons_lower_of_cell, v, i,
                             j, k, dim_to_recons):
         return compute_face_values_t(recons_upper_of_cell,
                                      recons_lower_of_cell, v, i, j, k,
-                                     dim_to_recons, False, _minmod)
+                                     dim_to_recons, False, _minmod,
+                                     use_9th_order, use_7th_order,
+                                     four_to_the_alpha_5, six_to_the_alpha_7,
+                                     eight_to_the_alpha_9)
 
-    return Reconstruction.reconstruct(u, extents, dim, [2, 2, 2],
+    return Reconstruction.reconstruct(u, extents, dim,
+                                      [ghost_zone, ghost_zone, ghost_zone],
                                       compute_face_values)
 
 
-def test_positivity_preserving_adaptive_order_with_mc(u, extents, dim):
+def test_positivity_preserving_adaptive_order_with_mc(
+    u, extents, dim, use_9th_order, use_7th_order, four_to_the_alpha_5,
+    six_to_the_alpha_7, eight_to_the_alpha_9):
+    ghost_zone = 4 if use_9th_order else (3 if use_7th_order else 2)
+
     def compute_face_values(recons_upper_of_cell, recons_lower_of_cell, v, i,
                             j, k, dim_to_recons):
         return compute_face_values_t(recons_upper_of_cell,
                                      recons_lower_of_cell, v, i, j, k,
-                                     dim_to_recons, True, _mc)
+                                     dim_to_recons, True, _mc, use_9th_order,
+                                     use_7th_order, four_to_the_alpha_5,
+                                     six_to_the_alpha_7, eight_to_the_alpha_9)
 
-    return Reconstruction.reconstruct(u, extents, dim, [2, 2, 2],
+    return Reconstruction.reconstruct(u, extents, dim,
+                                      [ghost_zone, ghost_zone, ghost_zone],
                                       compute_face_values)
 
 
-def test_positivity_preserving_adaptive_order_with_minmod(u, extents, dim):
+def test_positivity_preserving_adaptive_order_with_minmod(
+    u, extents, dim, use_9th_order, use_7th_order, four_to_the_alpha_5,
+    six_to_the_alpha_7, eight_to_the_alpha_9):
+    ghost_zone = 4 if use_9th_order else (3 if use_7th_order else 2)
+
     def compute_face_values(recons_upper_of_cell, recons_lower_of_cell, v, i,
                             j, k, dim_to_recons):
         return compute_face_values_t(recons_upper_of_cell,
                                      recons_lower_of_cell, v, i, j, k,
-                                     dim_to_recons, True, _minmod)
+                                     dim_to_recons, True, _minmod,
+                                     use_9th_order, use_7th_order,
+                                     four_to_the_alpha_5, six_to_the_alpha_7,
+                                     eight_to_the_alpha_9)
 
-    return Reconstruction.reconstruct(u, extents, dim, [2, 2, 2],
+    return Reconstruction.reconstruct(u, extents, dim,
+                                      [ghost_zone, ghost_zone, ghost_zone],
                                       compute_face_values)

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_PositivityPreservingAdaptiveOrder.cpp
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_PositivityPreservingAdaptiveOrder.cpp
@@ -22,25 +22,28 @@
 
 namespace fd::reconstruction {
 namespace {
-template <size_t Dim, typename FallbackReconstructor, bool PositivityPreserving>
+template <size_t Dim, typename FallbackReconstructor, bool PositivityPreserving,
+          bool Use9thOrder, bool Use7thOrder>
 void test_function_pointers(const FallbackReconstructorType fallback_recons) {
   const auto function_ptrs = fd::reconstruction::
       positivity_preserving_adaptive_order_function_pointers<Dim>(
-          PositivityPreserving, fallback_recons);
+          PositivityPreserving, Use9thOrder, Use7thOrder, fallback_recons);
   CHECK(get<0>(function_ptrs) ==
         &positivity_preserving_adaptive_order<FallbackReconstructor,
-                                              PositivityPreserving, Dim>);
+                                              PositivityPreserving, Use9thOrder,
+                                              Use7thOrder, Dim>);
   using function_type =
       void (*)(gsl::not_null<DataVector*>, const DataVector&, const DataVector&,
                const Index<Dim>&, const Index<Dim>&, const Direction<Dim>&,
-               const double&);
+               const double&, const double&, const double&);
   CHECK(get<1>(function_ptrs) ==
         static_cast<function_type>(
             &reconstruct_neighbor<
                 Side::Lower,
                 ::fd::reconstruction::detail::
                     PositivityPreservingAdaptiveOrderReconstructor<
-                        FallbackReconstructor, PositivityPreserving>,
+                        FallbackReconstructor, PositivityPreserving,
+                        Use9thOrder, Use7thOrder>,
                 Dim>));
   CHECK(get<2>(function_ptrs) ==
         static_cast<function_type>(
@@ -48,65 +51,80 @@ void test_function_pointers(const FallbackReconstructorType fallback_recons) {
                 Side::Upper,
                 ::fd::reconstruction::detail::
                     PositivityPreservingAdaptiveOrderReconstructor<
-                        FallbackReconstructor, PositivityPreserving>,
+                        FallbackReconstructor, PositivityPreserving,
+                        Use9thOrder, Use7thOrder>,
                 Dim>));
 }
 
-template <size_t Dim, class FallbackReconstructor, bool PositivityPreserving>
+template <size_t Dim, class FallbackReconstructor, bool PositivityPreserving,
+          bool Use9thOrder, bool Use7thOrder>
 void test_impl(const FallbackReconstructorType fallback_recons) {
   CAPTURE(PositivityPreserving);
+  CAPTURE(Use9thOrder);
+  CAPTURE(Use7thOrder);
   CAPTURE(fallback_recons);
+  using Recons = fd::reconstruction::detail::
+      PositivityPreservingAdaptiveOrderReconstructor<FallbackReconstructor,
+                                                     PositivityPreserving,
+                                                     Use9thOrder, Use7thOrder>;
+
+  const size_t num_points = Recons::stencil_width();
+
+  // Non-const because we want different values if we are checking exact
+  // reconstruction or matching to python
+  double four_to_the_alpha_5 = pow(4.0, 1.0);
+  double six_to_the_alpha_7 = pow(6.0, 1.0);
+  double eight_to_the_alpha_9 = pow(8.0, 1.0);
 
   const auto recons =
-      [](const gsl::not_null<std::array<gsl::span<double>, Dim>*>
-             reconstructed_upper_side_of_face_vars,
-         const gsl::not_null<std::array<gsl::span<double>, Dim>*>
-             reconstructed_lower_side_of_face_vars,
-         const gsl::span<const double>& volume_vars,
-         const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
-         const Index<Dim>& volume_extents, const size_t number_of_variables) {
-        const double four_to_the_alpha_5 = pow(4.0, 4.0);
-
+      [&four_to_the_alpha_5, &six_to_the_alpha_7, &eight_to_the_alpha_9](
+          const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+              reconstructed_upper_side_of_face_vars,
+          const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+              reconstructed_lower_side_of_face_vars,
+          const gsl::span<const double>& volume_vars,
+          const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
+          const Index<Dim>& volume_extents, const size_t number_of_variables) {
         fd::reconstruction::positivity_preserving_adaptive_order<
-            FallbackReconstructor, PositivityPreserving>(
-            reconstructed_upper_side_of_face_vars,
-            reconstructed_lower_side_of_face_vars, volume_vars, ghost_cell_vars,
-            volume_extents, number_of_variables, four_to_the_alpha_5);
+            FallbackReconstructor, PositivityPreserving, Use9thOrder,
+            Use7thOrder>(reconstructed_upper_side_of_face_vars,
+                         reconstructed_lower_side_of_face_vars, volume_vars,
+                         ghost_cell_vars, volume_extents, number_of_variables,
+                         four_to_the_alpha_5, six_to_the_alpha_7,
+                         eight_to_the_alpha_9);
       };
-  const auto recons_neighbor_data = [](const gsl::not_null<DataVector*>
-                                           face_data,
-                                       const DataVector& volume_data,
-                                       const DataVector& neighbor_data,
-                                       const Index<Dim>& volume_extents,
-                                       const Index<Dim>& ghost_data_extents,
-                                       const Direction<Dim>&
-                                           direction_to_reconstruct) {
-    const double four_to_the_alpha_5 = pow(4.0, 4.0);
-
-    if (direction_to_reconstruct.side() == Side::Upper) {
-      fd::reconstruction::reconstruct_neighbor<
-          Side::Upper, fd::reconstruction::detail::
-                           PositivityPreservingAdaptiveOrderReconstructor<
-                               FallbackReconstructor, PositivityPreserving>>(
-          face_data, volume_data, neighbor_data, volume_extents,
-          ghost_data_extents, direction_to_reconstruct, four_to_the_alpha_5);
-    }
-    if (direction_to_reconstruct.side() == Side::Lower) {
-      fd::reconstruction::reconstruct_neighbor<
-          Side::Lower, fd::reconstruction::detail::
-                           PositivityPreservingAdaptiveOrderReconstructor<
-                               FallbackReconstructor, PositivityPreserving>>(
-          face_data, volume_data, neighbor_data, volume_extents,
-          ghost_data_extents, direction_to_reconstruct, four_to_the_alpha_5);
-    }
-  };
+  const auto recons_neighbor_data =
+      [&four_to_the_alpha_5, &six_to_the_alpha_7, &eight_to_the_alpha_9](
+          const gsl::not_null<DataVector*> face_data,
+          const DataVector& volume_data, const DataVector& neighbor_data,
+          const Index<Dim>& volume_extents,
+          const Index<Dim>& ghost_data_extents,
+          const Direction<Dim>& direction_to_reconstruct) {
+        if (direction_to_reconstruct.side() == Side::Upper) {
+          fd::reconstruction::reconstruct_neighbor<Side::Upper, Recons>(
+              face_data, volume_data, neighbor_data, volume_extents,
+              ghost_data_extents, direction_to_reconstruct, four_to_the_alpha_5,
+              six_to_the_alpha_7, eight_to_the_alpha_9);
+        }
+        if (direction_to_reconstruct.side() == Side::Lower) {
+          fd::reconstruction::reconstruct_neighbor<Side::Lower, Recons>(
+              face_data, volume_data, neighbor_data, volume_extents,
+              ghost_data_extents, direction_to_reconstruct, four_to_the_alpha_5,
+              six_to_the_alpha_7, eight_to_the_alpha_9);
+        }
+      };
 
   if constexpr (not PositivityPreserving) {
     // Since the solution is negative, doing positivity preservation drops the
     // order.
     TestHelpers::fd::reconstruction::test_reconstruction_is_exact_if_in_basis<
-        Dim>(2, 5, 5, recons, recons_neighbor_data);
+        Dim>(Recons::stencil_width() - 1, num_points, Recons::stencil_width(),
+             recons, recons_neighbor_data);
   }
+
+  four_to_the_alpha_5 = pow(4.0, 4.0);
+  six_to_the_alpha_7 = pow(6.0, 4.3);
+  eight_to_the_alpha_9 = pow(8.0, 4.6);
 
   const std::string ao_name =
       PositivityPreserving
@@ -115,32 +133,51 @@ void test_impl(const FallbackReconstructorType fallback_recons) {
 
   if (fallback_recons == FallbackReconstructorType::Minmod) {
     TestHelpers::fd::reconstruction::test_with_python(
-        Index<Dim>{5}, 5, "PositivityPreservingAdaptiveOrder",
-        ao_name + "_with_minmod", recons, recons_neighbor_data);
+        Index<Dim>{num_points}, Recons::stencil_width(),
+        "PositivityPreservingAdaptiveOrder", ao_name + "_with_minmod", recons,
+        recons_neighbor_data, Use9thOrder, Use7thOrder, four_to_the_alpha_5,
+        six_to_the_alpha_7, eight_to_the_alpha_9);
   } else if (fallback_recons == FallbackReconstructorType::MonotonisedCentral) {
     TestHelpers::fd::reconstruction::test_with_python(
-        Index<Dim>{5}, 5, "PositivityPreservingAdaptiveOrder",
-        ao_name + "_with_mc", recons, recons_neighbor_data);
+        Index<Dim>{num_points}, Recons::stencil_width(),
+        "PositivityPreservingAdaptiveOrder", ao_name + "_with_mc", recons,
+        recons_neighbor_data, Use9thOrder, Use7thOrder, four_to_the_alpha_5,
+        six_to_the_alpha_7, eight_to_the_alpha_9);
   } else {
     ERROR("Fallback not yet implemented.");
   }
 
-  test_function_pointers<Dim, FallbackReconstructor, true>(fallback_recons);
-  test_function_pointers<Dim, FallbackReconstructor, false>(fallback_recons);
+  test_function_pointers<Dim, FallbackReconstructor, PositivityPreserving,
+                         Use9thOrder, Use7thOrder>(fallback_recons);
 }
 
 template <class FallbackReconstructor>
 void test(const FallbackReconstructorType fallback_recons) {
-  test_impl<1, FallbackReconstructor, true>(fallback_recons);
-  test_impl<2, FallbackReconstructor, true>(fallback_recons);
-  test_impl<3, FallbackReconstructor, true>(fallback_recons);
+  const auto order_helper = [&fallback_recons](auto use_order_9,
+                                               auto use_order_7) {
+    test_impl<1, FallbackReconstructor, true, decltype(use_order_9)::value,
+              decltype(use_order_7)::value>(fallback_recons);
+    test_impl<2, FallbackReconstructor, true, decltype(use_order_9)::value,
+              decltype(use_order_7)::value>(fallback_recons);
+    test_impl<3, FallbackReconstructor, true, decltype(use_order_9)::value,
+              decltype(use_order_7)::value>(fallback_recons);
 
-  test_impl<1, FallbackReconstructor, false>(fallback_recons);
-  test_impl<2, FallbackReconstructor, false>(fallback_recons);
-  test_impl<3, FallbackReconstructor, false>(fallback_recons);
+    test_impl<1, FallbackReconstructor, false, decltype(use_order_9)::value,
+              decltype(use_order_7)::value>(fallback_recons);
+    test_impl<2, FallbackReconstructor, false, decltype(use_order_9)::value,
+              decltype(use_order_7)::value>(fallback_recons);
+    test_impl<3, FallbackReconstructor, false, decltype(use_order_9)::value,
+              decltype(use_order_7)::value>(fallback_recons);
+  };
+
+  order_helper(std::false_type{}, std::false_type{});
+  order_helper(std::false_type{}, std::true_type{});
+  order_helper(std::true_type{}, std::false_type{});
+  order_helper(std::true_type{}, std::true_type{});
 }
 }  // namespace
 
+// [[Timeout, 10]]
 SPECTRE_TEST_CASE("Unit.FiniteDifference.PositivityPreservingAdaptiveOrder",
                   "[Unit][NumericalAlgorithms]") {
   pypp::SetupLocalPythonEnvironment local_python_env(
@@ -153,7 +190,7 @@ SPECTRE_TEST_CASE("Unit.FiniteDifference.PositivityPreservingAdaptiveOrder",
   CHECK_THROWS_WITH(
       fd::reconstruction::
           positivity_preserving_adaptive_order_function_pointers<1>(
-              true, FallbackReconstructorType::None),
+              true, false, false, FallbackReconstructorType::None),
       Catch::Contains("Can't have None as the low-order reconstructor in "
                       "positivity_preserving_adaptive_order."));
 }

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_Unlimited.cpp
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_Unlimited.cpp
@@ -18,7 +18,7 @@
 namespace {
 
 template <size_t Degree, size_t Dim>
-void test() {
+void test_impl() {
   CAPTURE(Degree);
   CAPTURE(Dim);
   const auto recons =
@@ -60,14 +60,19 @@ void test() {
   // coefficients are correct because there are non-linear terms to deal with
   // shocks.
 }
+
+template <size_t Degree>
+void test() {
+  test_impl<Degree, 1>();
+  test_impl<Degree, 2>();
+  test_impl<Degree, 3>();
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.FiniteDifference.Unlimited",
                   "[Unit][NumericalAlgorithms]") {
-  test<2, 1>();
-  test<2, 2>();
-  test<2, 3>();
-  test<4, 1>();
-  test<4, 2>();
-  test<4, 3>();
+  test<2>();
+  test<4>();
+  test<6>();
+  test<8>();
 }


### PR DESCRIPTION
## Proposed changes

- Add 7th&9th order to PPAO and the places that use PPAO.
- Add high-order recons support to FD in general
- Make passing extra args to FD python tests easy

This completes the PPAO reconstruction code from my thesis. This does not enable changing the order of the derivatives. That will be done separately. We could add more low-order reconstructors, but I don't see this being worth the effort since we ultimately need some sort of unstructured mesh reconstruction, which means we need to do something PPM-ish or WENO-ish anyway, so no reason to do things like WCNS3-z. Phrased differently, curved meshes and AMR is difficult :)

~Depends on #4167~

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
