### PR TITLE
Add make_with_value implementation for Rational

### DIFF
--- a/src/Utilities/Rational.hpp
+++ b/src/Utilities/Rational.hpp
@@ -8,6 +8,8 @@
 #include <functional>
 #include <iosfwd>
 
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/MakeWithValue.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TypeTraits/IsInteger.hpp"
 
@@ -80,3 +82,14 @@ struct hash<Rational> {
   size_t operator()(const Rational& r) const;
 };
 }  // namespace std
+
+namespace MakeWithValueImpls {
+template <typename T>
+struct MakeWithValueImpl<Rational, T> {
+  static Rational apply(const T& /*input*/, double value) {
+    ASSERT(static_cast<std::int32_t>(value) == value,
+           "Only integer-valued Rationals can be created with MakeWithValue.");
+    return Rational(static_cast<std::int32_t>(value));
+  }
+};
+}  // namespace MakeWithValueImpls

--- a/tests/Unit/Utilities/Test_Rational.cpp
+++ b/tests/Unit/Utilities/Test_Rational.cpp
@@ -64,10 +64,10 @@ SPECTRE_TEST_CASE("Unit.Utilities.Rational", "[Unit][Utilities]") {
   CHECK(make_with_value<Rational>(ArbitraryType{}, 1.0) == Rational(1));
   CHECK(make_with_value<Rational>(ArbitraryType{}, -1.0) == Rational(-1));
   CHECK(make_with_value<Rational>(ArbitraryType{}, 1234.0) == Rational(1234));
-}
 
-SPECTRE_TEST_CASE("Unit.Utilities.Rational.internal_overflow",
-                  "[Unit][Utilities]") {
+  // Check that the internal implementation does not cause overflow
+  // when the results can be correctly represented.
+
   CHECK(Rational(6000000, 8000000) == Rational(3, 4));
 
   check_cmp(Rational(5, 1 << 16), Rational(1 << 16));
@@ -80,76 +80,25 @@ SPECTRE_TEST_CASE("Unit.Utilities.Rational.internal_overflow",
            Rational(1 << 17, (1 << 10) + 1), Rational((1 << 10) - 1, 1 << 3));
   CHECK_OP(Rational((1 << 20) - 1, 1 << 20), /,
            Rational((1 << 10) + 1, 1 << 17), Rational((1 << 10) - 1, 1 << 3));
-}
 
-// [[OutputRegex, Division by zero]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Utilities.Rational.denominator_zero",
-                               "[Unit][Utilities]") {
-  ASSERTION_TEST();
+  // Check assertions
 #ifdef SPECTRE_DEBUG
-  Rational(1, 0);
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// [[OutputRegex, Division by zero]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Utilities.Rational.invert_zero",
-                               "[Unit][Utilities]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  Rational(0).inverse();
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// [[OutputRegex, Division by zero]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Utilities.Rational.divide_zero",
-                               "[Unit][Utilities]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  Rational(1) / 0;
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// [[OutputRegex, Division by zero]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Utilities.Rational.divide_equal_zero",
-                               "[Unit][Utilities]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  Rational r(1);
-  r /= 0;
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// [[OutputRegex, Rational overflow: 1000000000000/1]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Utilities.Rational.overflow_numerator",
-                               "[Unit][Utilities]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  Rational(1000000) * Rational(1000000);
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// [[OutputRegex, Rational overflow: 1/1000000000000]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Utilities.Rational.overflow_denominator",
-                               "[Unit][Utilities]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  Rational(1, 1000000) * Rational(1, 1000000);
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// [[OutputRegex, Only integer-valued Rationals can be created with
-// MakeWithValue]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Utilities.Rational.BadMakeWithValue",
-                               "[Unit][Utilities]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  make_with_value<Rational>(1, 1.5);
-  ERROR("Failed to trigger ASSERT in an assertion test");
+  CHECK_THROWS_WITH(Rational(1, 0), Catch::Contains("Division by zero"));
+  CHECK_THROWS_WITH(Rational(0).inverse(), Catch::Contains("Division by zero"));
+  CHECK_THROWS_WITH(Rational(1) / 0, Catch::Contains("Division by zero"));
+  CHECK_THROWS_WITH(
+      []() {
+        Rational r(1);
+        r /= 0;
+      }(),
+      Catch::Contains("Division by zero"));
+  CHECK_THROWS_WITH(Rational(1000000) * Rational(1000000),
+                    Catch::Contains("Rational overflow: 1000000000000/1"));
+  CHECK_THROWS_WITH(Rational(1, 1000000) * Rational(1, 1000000),
+                    Catch::Contains("Rational overflow: 1/1000000000000"));
+  CHECK_THROWS_WITH(
+      make_with_value<Rational>(1, 1.5),
+      Catch::Contains(
+          "Only integer-valued Rationals can be created with MakeWithValue"));
 #endif
 }

--- a/tests/Unit/Utilities/Test_Rational.cpp
+++ b/tests/Unit/Utilities/Test_Rational.cpp
@@ -9,6 +9,7 @@
 #include "Framework/TestHelpers.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/GetOutput.hpp"
+#include "Utilities/MakeWithValue.hpp"
 #include "Utilities/Rational.hpp"
 
 SPECTRE_TEST_CASE("Unit.Utilities.Rational", "[Unit][Utilities]") {
@@ -57,6 +58,12 @@ SPECTRE_TEST_CASE("Unit.Utilities.Rational", "[Unit][Utilities]") {
   CHECK(get_output(Rational(-3, 4)) == "-3/4");
 
   test_serialization(Rational(3, 4));
+
+  struct ArbitraryType {};
+  CHECK(make_with_value<Rational>(ArbitraryType{}, 0.0) == Rational(0));
+  CHECK(make_with_value<Rational>(ArbitraryType{}, 1.0) == Rational(1));
+  CHECK(make_with_value<Rational>(ArbitraryType{}, -1.0) == Rational(-1));
+  CHECK(make_with_value<Rational>(ArbitraryType{}, 1234.0) == Rational(1234));
 }
 
 SPECTRE_TEST_CASE("Unit.Utilities.Rational.internal_overflow",
@@ -132,6 +139,17 @@ SPECTRE_TEST_CASE("Unit.Utilities.Rational.internal_overflow",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Rational(1, 1000000) * Rational(1, 1000000);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Only integer-valued Rationals can be created with
+// MakeWithValue]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Utilities.Rational.BadMakeWithValue",
+                               "[Unit][Utilities]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  make_with_value<Rational>(1, 1.5);
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }


### PR DESCRIPTION
This is mostly useful for generating tables of coefficients to print out, not for numerical work.  Modifications to AdamsBashforthN to make calculating such tables easier will be in a later PR.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
