### PR TITLE
Make RunEventsAndDenseTriggers more generic

### DIFF
--- a/src/Evolution/Actions/RunEventsAndDenseTriggers.hpp
+++ b/src/Evolution/Actions/RunEventsAndDenseTriggers.hpp
@@ -8,7 +8,8 @@
 #include <tuple>
 
 #include "DataStructures/DataBox/DataBox.hpp"
-#include "Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
 #include "Evolution/EventsAndDenseTriggers/EventsAndDenseTriggers.hpp"
 #include "Evolution/EventsAndDenseTriggers/Tags.hpp"
 #include "Parallel/AlgorithmExecution.hpp"
@@ -19,8 +20,11 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
+#include "Utilities/TypeTraits/CreateIsCallable.hpp"
+#include "Utilities/TypeTraits/IsA.hpp"
 
 /// \cond
+class DataVector;
 namespace Parallel {
 template <typename Metavariables>
 class GlobalCache;
@@ -35,20 +39,66 @@ namespace evolution::Actions {
 /// \ingroup EventsAndTriggersGroup
 /// \brief Run the events and dense triggers
 ///
+/// If dense output is required, each `postprocessor` in the \p
+/// Postprocessors list will be called as
+/// `postprocessor::is_ready(make_not_null(&box),
+/// make_not_null(&inboxes))` if that is a valid expression.  If it
+/// returns false, the algorithm will be stopped to wait for more
+/// data.  After performing dense output, each of the \p
+/// Postprocessors will be passed to `db::mutate_apply` on the
+/// DataBox.
+///
+/// At the end of the action, the values of the time, evolved
+/// variables, and anything appearing in the `return_tags` of the \p
+/// Postprocessors will be restored to their initial values.
+///
 /// Uses:
-/// - DataBox: EventsAndDenseTriggers, as required by events and triggers
+/// - DataBox: EventsAndDenseTriggers and as required by events,
+///   triggers, and postprocessors
 ///
 /// DataBox changes:
 /// - Adds: nothing
 /// - Removes: nothing
-/// - Modifies: nothing
-template <typename PrimFromCon = void>
+/// - Modifies: as performed by the postprocessor `is_ready` functions
+template <typename Postprocessors>
 struct RunEventsAndDenseTriggers {
  private:
+  static_assert(tt::is_a_v<tmpl::list, Postprocessors>);
+
   // RAII object to restore the time and variables changed by dense
   // output.
-  template <typename DbTags, typename Tag>
+  template <typename DbTags, typename Tags>
   class StateRestorer {
+    template <typename Tag, bool IsVariables>
+    struct expand_variables_impl {
+      using type = typename Tag::tags_list;
+    };
+
+    template <typename Tag>
+    struct expand_variables_impl<Tag, false> {
+      using type = tmpl::list<Tag>;
+    };
+
+    template <typename Tag>
+    struct expand_variables
+        : expand_variables_impl<Tag,
+                                tt::is_a_v<Variables, typename Tag::type>> {};
+
+    using expanded_tags = tmpl::remove_duplicates<
+        tmpl::join<tmpl::transform<Tags, expand_variables<tmpl::_1>>>>;
+    using tensors_and_non_tensors = tmpl::partition<
+        expanded_tags,
+        tmpl::bind<
+            tmpl::apply,
+            tmpl::if_<tt::is_a<Tensor, tmpl::bind<tmpl::type_from, tmpl::_1>>,
+                      tmpl::defer<tmpl::parent<std::is_same<
+                          tmpl::bind<tmpl::type_from,
+                                     tmpl::bind<tmpl::type_from, tmpl::_1>>,
+                          DataVector>>>,
+                      std::false_type>>>;
+    using tensor_tags = tmpl::front<tensors_and_non_tensors>;
+    using non_tensor_tags = tmpl::back<tensors_and_non_tensors>;
+
    public:
     StateRestorer(const gsl::not_null<db::DataBox<DbTags>*> box) : box_(box) {}
 
@@ -56,31 +106,56 @@ struct RunEventsAndDenseTriggers {
       // Only store the value the first time, because after that we
       // are seeing the value after the previous change instead of the
       // original.
-      if (not value_.has_value()) {
-        value_ = db::get<Tag>(*box_);
+      if (not non_tensors_.has_value()) {
+        if constexpr (not std::is_same_v<tensor_tags, tmpl::list<>>) {
+          tensors_.initialize(
+              db::get<tmpl::front<tensor_tags>>(*box_).begin()->size());
+          tmpl::for_each<tensor_tags>([this](auto tag_v) {
+            using tag = tmpl::type_from<decltype(tag_v)>;
+            get<tag>(tensors_) = db::get<tag>(*box_);
+          });
+        }
+        tmpl::as_pack<non_tensor_tags>([this](auto... tags_v) {
+          non_tensors_.emplace(
+              db::get<tmpl::type_from<decltype(tags_v)>>(*box_)...);
+        });
       }
     }
 
     ~StateRestorer() {
-      if (value_.has_value()) {
-        db::mutate<Tag>(box_,
-                        [this](const gsl::not_null<typename Tag::type*> value) {
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 11
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif  // defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 11
-                          *value = *value_;
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 11
-#pragma GCC diagnostic pop
-#endif  // defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 11
-                        });
+      if (non_tensors_.has_value()) {
+        tmpl::for_each<tensor_tags>([this](auto tag_v) {
+          using tag = tmpl::type_from<decltype(tag_v)>;
+          db::mutate<tag>(
+              box_, [this](const gsl::not_null<typename tag::type*> value) {
+                *value = get<tag>(tensors_);
+              });
+        });
+        tmpl::for_each<non_tensor_tags>([this](auto tag_v) {
+          using tag = tmpl::type_from<decltype(tag_v)>;
+          db::mutate<tag>(
+              box_, [this](const gsl::not_null<typename tag::type*> value) {
+                *value = std::move(tuples::get<tag>(*non_tensors_));
+              });
+        });
       }
     }
 
    private:
     gsl::not_null<db::DataBox<DbTags>*> box_ = nullptr;
-    std::optional<typename Tag::type> value_{};
+    // Store all tensors in a single allocation.
+    Variables<tensor_tags> tensors_{};
+    std::optional<tuples::tagged_tuple_from_typelist<non_tensor_tags>>
+        non_tensors_;
   };
+
+  template <typename T>
+  struct get_return_tags {
+    using type = typename T::return_tags;
+  };
+
+  CREATE_IS_CALLABLE(is_ready)
+  CREATE_IS_CALLABLE_V(is_ready)
 
  public:
   template <typename DbTags, typename... InboxTags, typename Metavariables,
@@ -108,19 +183,21 @@ struct RunEventsAndDenseTriggers {
         time_step_id.step_time() + db::get<::Tags::TimeStep>(box);
     const evolution_less<double> before{time_step_id.time_runs_forward()};
 
-    StateRestorer<DbTags, ::Tags::Time> time_restorer(make_not_null(&box));
-    StateRestorer<DbTags, variables_tag> variables_restorer(
+    using postprocessor_return_tags =
+        tmpl::join<tmpl::transform<Postprocessors, get_return_tags<tmpl::_1>>>;
+    // The evolved variables will be restored anyway, so no reason to
+    // copy them twice.
+    using postprocessor_restore_tags =
+        tmpl::list_difference<postprocessor_return_tags,
+                              typename variables_tag::tags_list>;
+
+    StateRestorer<DbTags, tmpl::list<::Tags::Time>> time_restorer(
         make_not_null(&box));
-    auto primitives_restorer = [&box]() {
-      if constexpr (system::has_primitive_and_conservative_vars) {
-        return StateRestorer<DbTags, typename system::primitive_variables_tag>(
-            make_not_null(&box));
-      } else {
-        (void)box;
-        return 0;
-      }
-    }();
-    (void)primitives_restorer;
+    StateRestorer<DbTags, tmpl::list<variables_tag>> variables_restorer(
+        make_not_null(&box));
+    StateRestorer<DbTags, postprocessor_restore_tags> postprocessor_restorer(
+        make_not_null(&box));
+
     for (;;) {
       const double next_trigger = events_and_dense_triggers.next_trigger(box);
       if (before(step_end.value(), next_trigger)) {
@@ -150,12 +227,22 @@ struct RunEventsAndDenseTriggers {
           return {Parallel::AlgorithmExecution::Retry, std::nullopt};
         case TriggeringState::NeedsEvolvedVariables:
           if (not already_at_correct_time) {
-            if constexpr (Metavariables::local_time_stepping) {
-              if (not dg::ApplyBoundaryCorrections<
-                      Metavariables, true>::is_ready(make_not_null(&box),
-                                                     make_not_null(&inboxes))) {
-                return {Parallel::AlgorithmExecution::Retry, std::nullopt};
+            bool ready = true;
+            tmpl::for_each<Postprocessors>([&](auto postprocessor_v) {
+              using postprocessor = tmpl::type_from<decltype(postprocessor_v)>;
+              if constexpr (is_is_ready_callable_v<
+                                postprocessor, decltype(make_not_null(&box)),
+                                decltype(make_not_null(&inboxes))>) {
+                if (ready) {
+                  if (not postprocessor::is_ready(make_not_null(&box),
+                                                  make_not_null(&inboxes))) {
+                    ready = false;
+                  }
+                }
               }
+            });
+            if (not ready) {
+              return {Parallel::AlgorithmExecution::Retry, std::nullopt};
             }
 
             using history_tag = ::Tags::HistoryEvolvedVariables<variables_tag>;
@@ -176,19 +263,11 @@ struct RunEventsAndDenseTriggers {
               return {Parallel::AlgorithmExecution::Continue, std::nullopt};
             }
 
-            if constexpr (Metavariables::local_time_stepping) {
-              db::mutate_apply<
-                  dg::ApplyBoundaryCorrections<Metavariables, true>>(
-                  make_not_null(&box));
-            }
-
-            static_assert(system::has_primitive_and_conservative_vars !=
-                              std::is_same_v<PrimFromCon, void>,
-                          "Primitive update scheme not provided.");
-            if constexpr (system::has_primitive_and_conservative_vars) {
-              primitives_restorer.save();
-              db::mutate_apply<PrimFromCon>(make_not_null(&box));
-            }
+            postprocessor_restorer.save();
+            tmpl::for_each<Postprocessors>([&box](auto postprocessor_v) {
+              using postprocessor = tmpl::type_from<decltype(postprocessor_v)>;
+              db::mutate_apply<postprocessor>(make_not_null(&box));
+            });
           }
           [[fallthrough]];
         default:

--- a/src/Evolution/Actions/RunEventsAndDenseTriggers.hpp
+++ b/src/Evolution/Actions/RunEventsAndDenseTriggers.hpp
@@ -151,9 +151,9 @@ struct RunEventsAndDenseTriggers {
         case TriggeringState::NeedsEvolvedVariables:
           if (not already_at_correct_time) {
             if constexpr (Metavariables::local_time_stepping) {
-              if (not dg::receive_boundary_data_local_time_stepping<
-                      Metavariables, true>(make_not_null(&box),
-                                           make_not_null(&inboxes))) {
+              if (not dg::ApplyBoundaryCorrections<
+                      Metavariables, true>::is_ready(make_not_null(&box),
+                                                     make_not_null(&inboxes))) {
                 return {Parallel::AlgorithmExecution::Retry, std::nullopt};
               }
             }
@@ -178,7 +178,7 @@ struct RunEventsAndDenseTriggers {
 
             if constexpr (Metavariables::local_time_stepping) {
               db::mutate_apply<
-                  dg::ApplyBoundaryCorrections<system, true, true>>(
+                  dg::ApplyBoundaryCorrections<Metavariables, true>>(
                   make_not_null(&box));
             }
 

--- a/src/Evolution/Actions/RunEventsAndDenseTriggers.hpp
+++ b/src/Evolution/Actions/RunEventsAndDenseTriggers.hpp
@@ -177,7 +177,8 @@ struct RunEventsAndDenseTriggers {
             }
 
             if constexpr (Metavariables::local_time_stepping) {
-              dg::apply_boundary_corrections<system, true, true>(
+              db::mutate_apply<
+                  dg::ApplyBoundaryCorrections<system, true, true>>(
                   make_not_null(&box));
             }
 

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
@@ -40,6 +40,8 @@
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
 #include "Time/TimeStepId.hpp"
+#include "Time/TimeSteppers/LtsTimeStepper.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/CallWithDynamicType.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
@@ -282,24 +284,6 @@ bool receive_boundary_data_local_time_stepping(
       });
 }
 
-namespace apply_boundary_corrections_detail {
-template <typename... BoundaryCorrectionTags, typename... Tags,
-          typename BoundaryCorrection>
-void boundary_correction(
-    const gsl::not_null<Variables<tmpl::list<BoundaryCorrectionTags...>>*>
-        boundary_corrections_on_mortar,
-    const Variables<tmpl::list<Tags...>>& local_boundary_data,
-    const Variables<tmpl::list<Tags...>>& neighbor_boundary_data,
-    const BoundaryCorrection& boundary_correction,
-    const ::dg::Formulation dg_formulation) {
-  boundary_correction.dg_boundary_terms(
-      make_not_null(
-          &get<BoundaryCorrectionTags>(*boundary_corrections_on_mortar))...,
-      get<Tags>(local_boundary_data)..., get<Tags>(neighbor_boundary_data)...,
-      dg_formulation);
-}
-}  // namespace apply_boundary_corrections_detail
-
 /// Apply corrections from boundary communication.
 ///
 /// If \p LocalTimeStepping is false, updates the derivative of the
@@ -310,357 +294,412 @@ void boundary_correction(
 /// Setting \p DenseOutput to true receives data required for output
 /// at ::Tags::Time instead of performing a full step.  This is only
 /// used for local time-stepping.
-template <typename System, bool LocalTimeStepping, bool DenseOutput = false,
-          typename DbTagsList, typename... InboxTags>
-void apply_boundary_corrections(
-    const gsl::not_null<db::DataBox<DbTagsList>*> box) {
-  constexpr size_t volume_dim = System::volume_dim;
+template <typename System, bool LocalTimeStepping, bool DenseOutput = false>
+struct ApplyBoundaryCorrections {
+  static_assert(LocalTimeStepping or not DenseOutput,
+                "GTS does not use ApplyBoundaryCorrections for dense output.");
 
+  static constexpr size_t volume_dim = System::volume_dim;
   using variables_tag = typename System::variables_tag;
   using dt_variables_tag = db::add_tag_prefix<::Tags::dt, variables_tag>;
   using DtVariables = typename dt_variables_tag::type;
 
-  // Set up helper lambda that will compute and lift the boundary corrections
-  const Mesh<volume_dim>& volume_mesh =
-      db::get<domain::Tags::Mesh<volume_dim>>(*box);
-  ASSERT(
-      volume_mesh.quadrature() ==
-          make_array<volume_dim>(volume_mesh.quadrature(0)),
-      "Must have isotropic quadrature, but got volume mesh: " << volume_mesh);
-  const bool using_gauss_lobatto_points =
-      volume_mesh.quadrature(0) == Spectral::Quadrature::GaussLobatto;
+  using TimeStepperType =
+      tmpl::conditional_t<LocalTimeStepping, LtsTimeStepper, TimeStepper>;
 
-  static_assert(LocalTimeStepping or not DenseOutput,
-                "GTS does not use apply_boundary_corrections for dense "
-                "output.");
+  using tag_to_update =
+      tmpl::conditional_t<LocalTimeStepping, variables_tag, dt_variables_tag>;
+  using mortar_data_tag = tmpl::conditional_t<
+      LocalTimeStepping,
+      evolution::dg::Tags::MortarDataHistory<volume_dim, DtVariables>,
+      evolution::dg::Tags::MortarData<volume_dim>>;
+  using MortarDataType =
+      tmpl::conditional_t<DenseOutput, const typename mortar_data_tag::type,
+                          typename mortar_data_tag::type>;
 
-  Scalar<DataVector> volume_det_inv_jacobian{};
-  Scalar<DataVector> volume_det_jacobian{};
-  if constexpr (not LocalTimeStepping) {
-    if (not using_gauss_lobatto_points) {
-      get(volume_det_inv_jacobian)
-          .set_data_ref(make_not_null(&const_cast<DataVector&>(get(
-              db::get<domain::Tags::DetInvJacobian<Frame::ElementLogical,
-                                                   Frame::Inertial>>(*box)))));
-      get(volume_det_jacobian) = 1.0 / get(volume_det_inv_jacobian);
-    }
+  using return_tags =
+      tmpl::conditional_t<DenseOutput, tmpl::list<tag_to_update>,
+                          tmpl::list<tag_to_update, mortar_data_tag>>;
+  using argument_tags = tmpl::flatten<tmpl::list<
+      tmpl::conditional_t<DenseOutput, mortar_data_tag, tmpl::list<>>,
+      domain::Tags::Mesh<volume_dim>, Tags::MortarMesh<volume_dim>,
+      Tags::MortarSize<volume_dim>, ::dg::Tags::Formulation,
+      evolution::dg::Tags::NormalCovectorAndMagnitude<volume_dim>,
+      ::Tags::TimeStepper<>, evolution::Tags::BoundaryCorrection<System>,
+      tmpl::conditional_t<DenseOutput, ::Tags::Time, ::Tags::TimeStep>,
+      tmpl::conditional_t<LocalTimeStepping, tmpl::list<>,
+                          domain::Tags::DetInvJacobian<Frame::ElementLogical,
+                                                       Frame::Inertial>>>>;
+
+  // full step
+  static void apply(
+      const gsl::not_null<typename tag_to_update::type*> vars_to_update,
+      const gsl::not_null<MortarDataType*> mortar_data,
+      const Mesh<volume_dim>& volume_mesh,
+      const typename Tags::MortarMesh<volume_dim>::type& mortar_meshes,
+      const typename Tags::MortarSize<volume_dim>::type& mortar_sizes,
+      const ::dg::Formulation dg_formulation,
+      const DirectionMap<
+          volume_dim, std::optional<Variables<tmpl::list<
+                          evolution::dg::Tags::MagnitudeOfNormal,
+                          evolution::dg::Tags::NormalCovector<volume_dim>>>>>&
+          face_normal_covector_and_magnitude,
+      const TimeStepperType& time_stepper,
+      const typename System::boundary_correction_base& boundary_correction,
+      const TimeDelta& time_step,
+      const Scalar<DataVector>& gts_det_inv_jacobian = {}) {
+    apply_impl(vars_to_update, mortar_data, volume_mesh, mortar_meshes,
+               mortar_sizes, dg_formulation, face_normal_covector_and_magnitude,
+               time_stepper, boundary_correction, time_step,
+               std::numeric_limits<double>::signaling_NaN(),
+               gts_det_inv_jacobian);
   }
 
-  const auto& mortar_meshes = db::get<Tags::MortarMesh<volume_dim>>(*box);
-  const auto& mortar_sizes = db::get<Tags::MortarSize<volume_dim>>(*box);
-  const ::dg::Formulation dg_formulation =
-      db::get<::dg::Tags::Formulation>(*box);
+  // dense output (LTS only)
+  static void apply(
+      const gsl::not_null<typename variables_tag::type*> vars_to_update,
+      const MortarDataType& mortar_data, const Mesh<volume_dim>& volume_mesh,
+      const typename Tags::MortarMesh<volume_dim>::type& mortar_meshes,
+      const typename Tags::MortarSize<volume_dim>::type& mortar_sizes,
+      const ::dg::Formulation dg_formulation,
+      const DirectionMap<
+          volume_dim, std::optional<Variables<tmpl::list<
+                          evolution::dg::Tags::MagnitudeOfNormal,
+                          evolution::dg::Tags::NormalCovector<volume_dim>>>>>&
+          face_normal_covector_and_magnitude,
+      const LtsTimeStepper& time_stepper,
+      const typename System::boundary_correction_base& boundary_correction,
+      const double dense_output_time) {
+    apply_impl(vars_to_update, &mortar_data, volume_mesh, mortar_meshes,
+               mortar_sizes, dg_formulation, face_normal_covector_and_magnitude,
+               time_stepper, boundary_correction, TimeDelta{},
+               dense_output_time, {});
+  }
 
-  const DirectionMap<volume_dim,
-                     std::optional<Variables<tmpl::list<
-                         evolution::dg::Tags::MagnitudeOfNormal,
-                         evolution::dg::Tags::NormalCovector<volume_dim>>>>>&
-      face_normal_covector_and_magnitude =
-          db::get<evolution::dg::Tags::NormalCovectorAndMagnitude<volume_dim>>(
-              *box);
+ private:
+  static void apply_impl(
+      const gsl::not_null<typename tag_to_update::type*> vars_to_update,
+      const gsl::not_null<MortarDataType*> mortar_data,
+      const Mesh<volume_dim>& volume_mesh,
+      const typename Tags::MortarMesh<volume_dim>::type& mortar_meshes,
+      const typename Tags::MortarSize<volume_dim>::type& mortar_sizes,
+      const ::dg::Formulation dg_formulation,
+      const DirectionMap<
+          volume_dim, std::optional<Variables<tmpl::list<
+                          evolution::dg::Tags::MagnitudeOfNormal,
+                          evolution::dg::Tags::NormalCovector<volume_dim>>>>>&
+          face_normal_covector_and_magnitude,
+      const TimeStepperType& time_stepper,
+      const typename System::boundary_correction_base& boundary_correction,
+      const TimeDelta& time_step, const double dense_output_time,
+      const Scalar<DataVector>& gts_det_inv_jacobian) {
+    // Set up helper lambda that will compute and lift the boundary corrections
+    ASSERT(
+        volume_mesh.quadrature() ==
+            make_array<volume_dim>(volume_mesh.quadrature(0)),
+        "Must have isotropic quadrature, but got volume mesh: " << volume_mesh);
+    const bool using_gauss_lobatto_points =
+        volume_mesh.quadrature(0) == Spectral::Quadrature::GaussLobatto;
 
-  const auto& time_stepper = db::get<::Tags::TimeStepper<>>(*box);
-  const auto time_step_and_dense_output_time = [&box]() {
-    if constexpr (DenseOutput) {
-      return std::pair{TimeDelta{}, db::get<::Tags::Time>(*box)};
-    } else {
-      return std::pair{db::get<::Tags::TimeStep>(*box),
-                       std::numeric_limits<double>::signaling_NaN()};
-    };
-  }();
-  const auto& time_step = time_step_and_dense_output_time.first;
-  const auto& dense_output_time = time_step_and_dense_output_time.second;
+    Scalar<DataVector> volume_det_inv_jacobian{};
+    Scalar<DataVector> volume_det_jacobian{};
+    if constexpr (not LocalTimeStepping) {
+      if (not using_gauss_lobatto_points) {
+        get(volume_det_inv_jacobian)
+            .set_data_ref(make_not_null(
+                &const_cast<DataVector&>(get(gts_det_inv_jacobian))));
+        get(volume_det_jacobian) = 1.0 / get(volume_det_inv_jacobian);
+      }
+    }
 
-  const auto compute_and_lift_boundary_corrections =
-      [&dense_output_time, &dg_formulation, &face_normal_covector_and_magnitude,
-       &mortar_meshes, &mortar_sizes, &time_step, &time_stepper,
-       using_gauss_lobatto_points, &volume_det_jacobian,
-       &volume_det_inv_jacobian, &volume_mesh](
-          const auto variables_or_dt_variables_ptr, const auto mortar_data_ptr,
-          const auto& boundary_correction) {
-        using mortar_tags_list = typename std::decay_t<decltype(
-            boundary_correction)>::dg_package_field_tags;
+    using derived_boundary_corrections =
+        typename std::decay_t<decltype(boundary_correction)>::creatable_classes;
 
-        // Variables for reusing allocations.  The actual values are
-        // not reused.
-        DtVariables dt_boundary_correction_on_mortar{};
-        DtVariables volume_dt_correction{};
-        // These variables may change size for each mortar and require
-        // a new memory allocation, but they may also happen to need
-        // to be the same size twice in a row, in which case holding
-        // on to the allocation is a win.
-        Scalar<DataVector> face_det_jacobian{};
-        Variables<mortar_tags_list> local_data_on_mortar{};
-        Variables<mortar_tags_list> neighbor_data_on_mortar{};
+    static_assert(
+        tmpl::all<derived_boundary_corrections, std::is_final<tmpl::_1>>::value,
+        "All createable classes for boundary corrections must be marked "
+        "final.");
+    call_with_dynamic_type<void, derived_boundary_corrections>(
+        &boundary_correction,
+        [&dense_output_time, &dg_formulation,
+         &face_normal_covector_and_magnitude, &mortar_data, &mortar_meshes,
+         &mortar_sizes, &time_step, &time_stepper, using_gauss_lobatto_points,
+         &vars_to_update, &volume_det_jacobian, &volume_det_inv_jacobian,
+         &volume_mesh](auto* typed_boundary_correction) {
+          // Compute internal boundary quantities on the mortar for sides of
+          // the element that have neighbors, i.e. they are not an external
+          // side.
+          using mortar_tags_list = typename std::decay_t<
+              decltype(*typed_boundary_correction)>::dg_package_field_tags;
 
-        for (auto& mortar_id_and_data : *mortar_data_ptr) {
-          const auto& mortar_id = mortar_id_and_data.first;
-          const auto& direction = mortar_id.first;
-          if (UNLIKELY(mortar_id.second ==
-                       ElementId<volume_dim>::external_boundary_id())) {
-            ERROR(
-                "Cannot impose boundary conditions on external boundary in "
-                "direction "
-                << direction
-                << " in the ApplyBoundaryCorrections action. Boundary "
-                   "conditions are applied in the ComputeTimeDerivative "
-                   "action "
-                   "instead. You may have unintentionally added external "
-                   "mortars in one of the initialization actions.");
-          }
+          // Variables for reusing allocations.  The actual values are
+          // not reused.
+          DtVariables dt_boundary_correction_on_mortar{};
+          DtVariables volume_dt_correction{};
+          // These variables may change size for each mortar and require
+          // a new memory allocation, but they may also happen to need
+          // to be the same size twice in a row, in which case holding
+          // on to the allocation is a win.
+          Scalar<DataVector> face_det_jacobian{};
+          Variables<mortar_tags_list> local_data_on_mortar{};
+          Variables<mortar_tags_list> neighbor_data_on_mortar{};
 
-          const Mesh<volume_dim - 1> face_mesh =
-              volume_mesh.slice_away(direction.dimension());
-
-          const auto compute_correction_coupling =
-              [&boundary_correction, &direction, dg_formulation,
-               &dt_boundary_correction_on_mortar, &face_det_jacobian,
-               &face_mesh, &face_normal_covector_and_magnitude,
-               &local_data_on_mortar, &mortar_id, &mortar_meshes, &mortar_sizes,
-               &neighbor_data_on_mortar, using_gauss_lobatto_points,
-               &volume_det_jacobian, &volume_det_inv_jacobian,
-               &volume_dt_correction,
-               &volume_mesh](const MortarData<volume_dim>& local_mortar_data,
-                             const MortarData<volume_dim>& neighbor_mortar_data)
-              -> DtVariables {
-            if (LocalTimeStepping and not using_gauss_lobatto_points) {
-              // This needs to be updated every call because the Jacobian may be
-              // time-dependent. In the case of time-independent maps and local
-              // time stepping we could first perform the integral on the
-              // boundaries, and then lift to the volume. This is left as a
-              // future optimization.
-              local_mortar_data.get_local_volume_det_inv_jacobian(
-                  make_not_null(&volume_det_inv_jacobian));
-              get(volume_det_jacobian) = 1.0 / get(volume_det_inv_jacobian);
+          for (auto& mortar_id_and_data : *mortar_data) {
+            const auto& mortar_id = mortar_id_and_data.first;
+            const auto& direction = mortar_id.first;
+            if (UNLIKELY(mortar_id.second ==
+                         ElementId<volume_dim>::external_boundary_id())) {
+              ERROR(
+                  "Cannot impose boundary conditions on external boundary in "
+                  "direction "
+                  << direction
+                  << " in the ApplyBoundaryCorrections action. Boundary "
+                     "conditions are applied in the ComputeTimeDerivative "
+                     "action "
+                     "instead. You may have unintentionally added external "
+                     "mortars in one of the initialization actions.");
             }
-            const auto& mortar_mesh = mortar_meshes.at(mortar_id);
 
-            // Extract local and neighbor data, copy into Variables because
-            // we store them in a std::vector for type erasure.
-            const std::pair<Mesh<volume_dim - 1>, std::vector<double>>&
-                local_mesh_and_data = *local_mortar_data.local_mortar_data();
-            const std::pair<Mesh<volume_dim - 1>, std::vector<double>>&
-                neighbor_mesh_and_data =
-                    *neighbor_mortar_data.neighbor_mortar_data();
-            local_data_on_mortar.initialize(
-                mortar_mesh.number_of_grid_points());
-            neighbor_data_on_mortar.initialize(
-                mortar_mesh.number_of_grid_points());
-            std::copy(std::get<1>(local_mesh_and_data).begin(),
-                      std::get<1>(local_mesh_and_data).end(),
-                      local_data_on_mortar.data());
-            std::copy(std::get<1>(neighbor_mesh_and_data).begin(),
-                      std::get<1>(neighbor_mesh_and_data).end(),
-                      neighbor_data_on_mortar.data());
+            const Mesh<volume_dim - 1> face_mesh =
+                volume_mesh.slice_away(direction.dimension());
 
-            // The boundary computations and lifting can be further
-            // optimized by in the h-refinement case having only one
-            // allocation for the face and having the projection from the
-            // mortar to the face be done in place. E.g.
-            // local_data_on_mortar and neighbor_data_on_mortar could be
-            // allocated fewer times, as well as `needs_projection` section
-            // below could do an in-place projection.
-            dt_boundary_correction_on_mortar.initialize(
-                mortar_mesh.number_of_grid_points());
-
-            apply_boundary_corrections_detail::boundary_correction(
-                make_not_null(&dt_boundary_correction_on_mortar),
-                local_data_on_mortar, neighbor_data_on_mortar,
-                boundary_correction, dg_formulation);
-
-            const std::array<Spectral::MortarSize, volume_dim - 1>&
-                mortar_size = mortar_sizes.at(mortar_id);
-
-            // This cannot reuse an allocation because it is initialized
-            // via move-assignment.  (If it is used at all.)
-            DtVariables dt_boundary_correction_projected_onto_face{};
-            auto& dt_boundary_correction =
-                [&dt_boundary_correction_on_mortar,
-                 &dt_boundary_correction_projected_onto_face, &face_mesh,
-                 &mortar_mesh, &mortar_size]() -> DtVariables& {
-              if (Spectral::needs_projection(face_mesh, mortar_mesh,
-                                             mortar_size)) {
-                dt_boundary_correction_projected_onto_face =
-                    ::dg::project_from_mortar(dt_boundary_correction_on_mortar,
-                                              face_mesh, mortar_mesh,
-                                              mortar_size);
-                return dt_boundary_correction_projected_onto_face;
+            const auto compute_correction_coupling =
+                [&typed_boundary_correction, &direction, dg_formulation,
+                 &dt_boundary_correction_on_mortar, &face_det_jacobian,
+                 &face_mesh, &face_normal_covector_and_magnitude,
+                 &local_data_on_mortar, &mortar_id, &mortar_meshes,
+                 &mortar_sizes, &neighbor_data_on_mortar,
+                 using_gauss_lobatto_points, &volume_det_jacobian,
+                 &volume_det_inv_jacobian, &volume_dt_correction, &volume_mesh](
+                    const MortarData<volume_dim>& local_mortar_data,
+                    const MortarData<volume_dim>& neighbor_mortar_data)
+                -> DtVariables {
+              if (LocalTimeStepping and not using_gauss_lobatto_points) {
+                // This needs to be updated every call because the Jacobian
+                // may be time-dependent. In the case of time-independent maps
+                // and local time stepping we could first perform the integral
+                // on the boundaries, and then lift to the volume. This is
+                // left as a future optimization.
+                local_mortar_data.get_local_volume_det_inv_jacobian(
+                    make_not_null(&volume_det_inv_jacobian));
+                get(volume_det_jacobian) = 1.0 / get(volume_det_inv_jacobian);
               }
-              return dt_boundary_correction_on_mortar;
-            }();
+              const auto& mortar_mesh = mortar_meshes.at(mortar_id);
 
-            // Both paths initialize this to be non-owning.
-            Scalar<DataVector> magnitude_of_face_normal{};
-            if constexpr (LocalTimeStepping) {
-              (void)face_normal_covector_and_magnitude;
-              local_mortar_data.get_local_face_normal_magnitude(
-                  &magnitude_of_face_normal);
-            } else {
-              ASSERT(
-                  face_normal_covector_and_magnitude.count(direction) == 1 and
-                      face_normal_covector_and_magnitude.at(direction)
-                          .has_value(),
-                  "Face normal covector and magnitude not set in "
-                  "direction: "
-                      << direction);
-              get(magnitude_of_face_normal)
-                  .set_data_ref(make_not_null(&const_cast<DataVector&>(
-                      get(get<evolution::dg::Tags::MagnitudeOfNormal>(
-                          *face_normal_covector_and_magnitude.at(
-                              direction))))));
-            }
+              // Extract local and neighbor data, copy into Variables because
+              // we store them in a std::vector for type erasure.
+              const std::pair<Mesh<volume_dim - 1>, std::vector<double>>&
+                  local_mesh_and_data = *local_mortar_data.local_mortar_data();
+              const std::pair<Mesh<volume_dim - 1>, std::vector<double>>&
+                  neighbor_mesh_and_data =
+                      *neighbor_mortar_data.neighbor_mortar_data();
+              local_data_on_mortar.initialize(
+                  mortar_mesh.number_of_grid_points());
+              neighbor_data_on_mortar.initialize(
+                  mortar_mesh.number_of_grid_points());
+              std::copy(std::get<1>(local_mesh_and_data).begin(),
+                        std::get<1>(local_mesh_and_data).end(),
+                        local_data_on_mortar.data());
+              std::copy(std::get<1>(neighbor_mesh_and_data).begin(),
+                        std::get<1>(neighbor_mesh_and_data).end(),
+                        neighbor_data_on_mortar.data());
 
-            if (using_gauss_lobatto_points) {
-              // The lift_flux function lifts only on the slice, it does not add
-              // the contribution to the volume.
-              ::dg::lift_flux(make_not_null(&dt_boundary_correction),
-                              volume_mesh.extents(direction.dimension()),
-                              magnitude_of_face_normal);
-              return std::move(dt_boundary_correction);
-            } else {
-              // We are using Gauss points.
-              //
-              // Notes:
-              // - We should really lift both sides simultaneously since this
-              //   reduces memory accesses. Lifting all sides at the same time
-              //   is unlikely to improve performance since we lift by jumping
-              //   through slices. There may also be compatibility issues with
-              //   local time stepping.
-              // - If we lift both sides at the same time we first need to deal
-              //   with projecting from mortars to the face, then lift off the
-              //   faces. With non-owning Variables memory allocations could be
-              //   significantly reduced in this code.
+              // The boundary computations and lifting can be further
+              // optimized by in the h-refinement case having only one
+              // allocation for the face and having the projection from the
+              // mortar to the face be done in place. E.g.
+              // local_data_on_mortar and neighbor_data_on_mortar could be
+              // allocated fewer times, as well as `needs_projection` section
+              // below could do an in-place projection.
+              dt_boundary_correction_on_mortar.initialize(
+                  mortar_mesh.number_of_grid_points());
+
+              call_boundary_correction(
+                  make_not_null(&dt_boundary_correction_on_mortar),
+                  local_data_on_mortar, neighbor_data_on_mortar,
+                  *typed_boundary_correction, dg_formulation);
+
+              const std::array<Spectral::MortarSize, volume_dim - 1>&
+                  mortar_size = mortar_sizes.at(mortar_id);
+
+              // This cannot reuse an allocation because it is initialized
+              // via move-assignment.  (If it is used at all.)
+              DtVariables dt_boundary_correction_projected_onto_face{};
+              auto& dt_boundary_correction =
+                  [&dt_boundary_correction_on_mortar,
+                   &dt_boundary_correction_projected_onto_face, &face_mesh,
+                   &mortar_mesh, &mortar_size]() -> DtVariables& {
+                if (Spectral::needs_projection(face_mesh, mortar_mesh,
+                                               mortar_size)) {
+                  dt_boundary_correction_projected_onto_face =
+                      ::dg::project_from_mortar(
+                          dt_boundary_correction_on_mortar, face_mesh,
+                          mortar_mesh, mortar_size);
+                  return dt_boundary_correction_projected_onto_face;
+                }
+                return dt_boundary_correction_on_mortar;
+              }();
+
+              // Both paths initialize this to be non-owning.
+              Scalar<DataVector> magnitude_of_face_normal{};
               if constexpr (LocalTimeStepping) {
-                ASSERT(get(volume_det_inv_jacobian).size() > 0,
-                       "For local time stepping the volume determinant of the "
-                       "inverse Jacobian has not been set.");
-
-                local_mortar_data.get_local_face_det_jacobian(
-                    make_not_null(&face_det_jacobian));
+                (void)face_normal_covector_and_magnitude;
+                local_mortar_data.get_local_face_normal_magnitude(
+                    &magnitude_of_face_normal);
               } else {
-                // Project the determinant of the Jacobian to the face. This
-                // could be optimized by caching in the time-independent case.
-                get(face_det_jacobian)
-                    .destructive_resize(face_mesh.number_of_grid_points());
-                const Matrix identity{};
-                auto interpolation_matrices =
-                    make_array<volume_dim>(std::cref(identity));
-                const std::pair<Matrix, Matrix>& matrices =
-                    Spectral::boundary_interpolation_matrices(
-                        volume_mesh.slice_through(direction.dimension()));
-                gsl::at(interpolation_matrices, direction.dimension()) =
-                    direction.side() == Side::Upper ? matrices.second
-                                                    : matrices.first;
-                apply_matrices(make_not_null(&get(face_det_jacobian)),
-                               interpolation_matrices, get(volume_det_jacobian),
-                               volume_mesh.extents());
+                ASSERT(
+                    face_normal_covector_and_magnitude.count(direction) == 1 and
+                        face_normal_covector_and_magnitude.at(direction)
+                            .has_value(),
+                    "Face normal covector and magnitude not set in "
+                    "direction: "
+                        << direction);
+                get(magnitude_of_face_normal)
+                    .set_data_ref(make_not_null(&const_cast<DataVector&>(
+                        get(get<evolution::dg::Tags::MagnitudeOfNormal>(
+                            *face_normal_covector_and_magnitude.at(
+                                direction))))));
               }
 
-              volume_dt_correction.initialize(
-                  volume_mesh.number_of_grid_points(), 0.0);
-              evolution::dg::lift_boundary_terms_gauss_points(
-                  make_not_null(&volume_dt_correction), volume_det_inv_jacobian,
-                  volume_mesh, direction, dt_boundary_correction,
-                  magnitude_of_face_normal, face_det_jacobian);
-              return std::move(volume_dt_correction);
-            }
-          };
+              if (using_gauss_lobatto_points) {
+                // The lift_flux function lifts only on the slice, it does not
+                // add the contribution to the volume.
+                ::dg::lift_flux(make_not_null(&dt_boundary_correction),
+                                volume_mesh.extents(direction.dimension()),
+                                magnitude_of_face_normal);
+                return std::move(dt_boundary_correction);
+              } else {
+                // We are using Gauss points.
+                //
+                // Notes:
+                // - We should really lift both sides simultaneously since this
+                //   reduces memory accesses. Lifting all sides at the same
+                //   time is unlikely to improve performance since we lift by
+                //   jumping through slices. There may also be compatibility
+                //   issues with local time stepping.
+                // - If we lift both sides at the same time we first need to
+                //   deal with projecting from mortars to the face, then lift
+                //   off the faces. With non-owning Variables memory
+                //   allocations could be significantly reduced in this code.
+                if constexpr (LocalTimeStepping) {
+                  ASSERT(get(volume_det_inv_jacobian).size() > 0,
+                         "For local time stepping the volume determinant of "
+                         "the inverse Jacobian has not been set.");
 
-          if constexpr (LocalTimeStepping) {
-            typename variables_tag::type lgl_lifted_data{};
-            auto& lifted_data = using_gauss_lobatto_points
-                                    ? lgl_lifted_data
-                                    : *variables_or_dt_variables_ptr;
-            if (using_gauss_lobatto_points) {
-              lifted_data.initialize(face_mesh.number_of_grid_points(), 0.0);
-            }
+                  local_mortar_data.get_local_face_det_jacobian(
+                      make_not_null(&face_det_jacobian));
+                } else {
+                  // Project the determinant of the Jacobian to the face. This
+                  // could be optimized by caching in the time-independent case.
+                  get(face_det_jacobian)
+                      .destructive_resize(face_mesh.number_of_grid_points());
+                  const Matrix identity{};
+                  auto interpolation_matrices =
+                      make_array<volume_dim>(std::cref(identity));
+                  const std::pair<Matrix, Matrix>& matrices =
+                      Spectral::boundary_interpolation_matrices(
+                          volume_mesh.slice_through(direction.dimension()));
+                  gsl::at(interpolation_matrices, direction.dimension()) =
+                      direction.side() == Side::Upper ? matrices.second
+                                                      : matrices.first;
+                  apply_matrices(make_not_null(&get(face_det_jacobian)),
+                                 interpolation_matrices,
+                                 get(volume_det_jacobian),
+                                 volume_mesh.extents());
+                }
 
-            auto& mortar_data_history = mortar_id_and_data.second;
-            if constexpr (DenseOutput) {
+                volume_dt_correction.initialize(
+                    volume_mesh.number_of_grid_points(), 0.0);
+                evolution::dg::lift_boundary_terms_gauss_points(
+                    make_not_null(&volume_dt_correction),
+                    volume_det_inv_jacobian, volume_mesh, direction,
+                    dt_boundary_correction, magnitude_of_face_normal,
+                    face_det_jacobian);
+                return std::move(volume_dt_correction);
+              }
+            };
+
+            if constexpr (LocalTimeStepping) {
+              typename variables_tag::type lgl_lifted_data{};
+              auto& lifted_data = using_gauss_lobatto_points ? lgl_lifted_data
+                                                             : *vars_to_update;
+              if (using_gauss_lobatto_points) {
+                lifted_data.initialize(face_mesh.number_of_grid_points(), 0.0);
+              }
+
+              auto& mortar_data_history = mortar_id_and_data.second;
+              if constexpr (DenseOutput) {
+                (void)time_step;
+                time_stepper.boundary_dense_output(
+                    &lifted_data, mortar_data_history, dense_output_time,
+                    compute_correction_coupling);
+              } else {
+                (void)dense_output_time;
+                time_stepper.add_boundary_delta(
+                    &lifted_data, make_not_null(&mortar_data_history),
+                    time_step, compute_correction_coupling);
+              }
+
+              if (using_gauss_lobatto_points) {
+                // Add the flux contribution to the volume data
+                add_slice_to_data(
+                    vars_to_update, lifted_data, volume_mesh.extents(),
+                    direction.dimension(),
+                    index_to_slice_at(volume_mesh.extents(), direction));
+              }
+            } else {
               (void)time_step;
-              time_stepper.boundary_dense_output(
-                  &lifted_data, mortar_data_history, dense_output_time,
-                  compute_correction_coupling);
-            } else {
+              (void)time_stepper;
               (void)dense_output_time;
-              time_stepper.add_boundary_delta(
-                  &lifted_data, make_not_null(&mortar_data_history), time_step,
-                  compute_correction_coupling);
-            }
 
-            if (using_gauss_lobatto_points) {
-              // Add the flux contribution to the volume data
-              add_slice_to_data(
-                  variables_or_dt_variables_ptr, lifted_data,
-                  volume_mesh.extents(), direction.dimension(),
-                  index_to_slice_at(volume_mesh.extents(), direction));
-            }
-          } else {
-            (void)time_step;
-            (void)time_stepper;
-            (void)dense_output_time;
+              // Choose an allocation cache that may be empty, so we
+              // might be able to reuse the allocation obtained for the
+              // lifted data.  This may result in a self assignment,
+              // depending on the code paths taken, but handling the
+              // results this way makes the GTS and LTS paths more
+              // similar because the LTS code always stores the result
+              // in the history and so sometimes benefits from moving
+              // into the return value of compute_correction_coupling.
+              auto& lifted_data = using_gauss_lobatto_points
+                                      ? dt_boundary_correction_on_mortar
+                                      : volume_dt_correction;
+              lifted_data = compute_correction_coupling(
+                  mortar_id_and_data.second, mortar_id_and_data.second);
+              // Remove data since it's tagged with the time. In the future we
+              // _might_ be able to reuse allocations, but this optimization
+              // should only be done after profiling.
+              mortar_id_and_data.second.extract();
 
-            const auto& mortar_data = mortar_id_and_data.second;
-
-            // Choose an allocation cache that may be empty, so we
-            // might be able to reuse the allocation obtained for the
-            // lifted data.  This may result in a self assignment,
-            // depending on the code paths taken, but handling the
-            // results this way makes the GTS and LTS paths more
-            // similar because the LTS code always stores the result
-            // in the history and so sometimes benefits from moving
-            // into the return value of compute_correction_coupling.
-            auto& lifted_data = using_gauss_lobatto_points
-                                    ? dt_boundary_correction_on_mortar
-                                    : volume_dt_correction;
-            lifted_data = compute_correction_coupling(mortar_data, mortar_data);
-            // Remove data since it's tagged with the time. In the future we
-            // _might_ be able to reuse allocations, but this optimization
-            // should only be done after profiling.
-            mortar_id_and_data.second.extract();
-
-            if (using_gauss_lobatto_points) {
-              // Add the flux contribution to the volume data
-              add_slice_to_data(
-                  variables_or_dt_variables_ptr, lifted_data,
-                  volume_mesh.extents(), direction.dimension(),
-                  index_to_slice_at(volume_mesh.extents(), direction));
-            } else {
-              *variables_or_dt_variables_ptr += lifted_data;
+              if (using_gauss_lobatto_points) {
+                // Add the flux contribution to the volume data
+                add_slice_to_data(
+                    vars_to_update, lifted_data, volume_mesh.extents(),
+                    direction.dimension(),
+                    index_to_slice_at(volume_mesh.extents(), direction));
+              } else {
+                *vars_to_update += lifted_data;
+              }
             }
           }
-        }
-      };
+        });
+  }
 
-  // Now compute the boundary contribution to this element using the helper
-  // lambda
-  const auto& boundary_correction =
-      db::get<evolution::Tags::BoundaryCorrection<System>>(*box);
-  using derived_boundary_corrections =
-      typename std::decay_t<decltype(boundary_correction)>::creatable_classes;
-
-  static_assert(
-      tmpl::all<derived_boundary_corrections, std::is_final<tmpl::_1>>::value,
-      "All createable classes for boundary corrections must be marked "
-      "final.");
-  call_with_dynamic_type<void, derived_boundary_corrections>(
-      &boundary_correction, [&box, &compute_and_lift_boundary_corrections](
-                                auto* typed_boundary_correction) {
-        // Compute internal boundary quantities on the mortar for sides of
-        // the element that have neighbors, i.e. they are not an external
-        // side.
-        using tag_to_update =
-            tmpl::conditional_t<LocalTimeStepping, variables_tag,
-                                dt_variables_tag>;
-        using mortar_data_tag = tmpl::conditional_t<
-            LocalTimeStepping,
-            evolution::dg::Tags::MortarDataHistory<volume_dim, DtVariables>,
-            evolution::dg::Tags::MortarData<volume_dim>>;
-        db::mutate<tag_to_update, mortar_data_tag>(
-            box, compute_and_lift_boundary_corrections,
-            *typed_boundary_correction);
-      });
-}
+  template <typename... BoundaryCorrectionTags, typename... Tags,
+            typename BoundaryCorrection>
+  static void call_boundary_correction(
+      const gsl::not_null<Variables<tmpl::list<BoundaryCorrectionTags...>>*>
+          boundary_corrections_on_mortar,
+      const Variables<tmpl::list<Tags...>>& local_boundary_data,
+      const Variables<tmpl::list<Tags...>>& neighbor_boundary_data,
+      const BoundaryCorrection& boundary_correction,
+      const ::dg::Formulation dg_formulation) {
+    boundary_correction.dg_boundary_terms(
+        make_not_null(
+            &get<BoundaryCorrectionTags>(*boundary_corrections_on_mortar))...,
+        get<Tags>(local_boundary_data)..., get<Tags>(neighbor_boundary_data)...,
+        dg_formulation);
+  }
+};
 
 namespace Actions {
 /*!
@@ -701,8 +740,8 @@ struct ApplyBoundaryCorrectionsToTimeDerivative {
       return {Parallel::AlgorithmExecution::Retry, std::nullopt};
     }
 
-    apply_boundary_corrections<typename Metavariables::system,
-                               Metavariables::local_time_stepping>(
+    db::mutate_apply<ApplyBoundaryCorrections<
+        typename Metavariables::system, Metavariables::local_time_stepping>>(
         make_not_null(&box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
@@ -753,8 +792,8 @@ struct ApplyLtsBoundaryCorrections {
       return {Parallel::AlgorithmExecution::Retry, std::nullopt};
     }
 
-    apply_boundary_corrections<typename Metavariables::system,
-                               Metavariables::local_time_stepping>(
+    db::mutate_apply<ApplyBoundaryCorrections<
+        typename Metavariables::system, Metavariables::local_time_stepping>>(
         make_not_null(&box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -233,14 +233,16 @@ struct EvolutionMetavars {
       evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
       tmpl::conditional_t<
           local_time_stepping,
-          tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<>,
+          tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<
+                         tmpl::list<evolution::dg::ApplyBoundaryCorrections<
+                             EvolutionMetavars, true>>>,
                      evolution::dg::Actions::ApplyLtsBoundaryCorrections<
                          EvolutionMetavars>>,
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
                   EvolutionMetavars>,
               Actions::RecordTimeStepperData<>,
-              evolution::Actions::RunEventsAndDenseTriggers<>,
+              evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               Actions::UpdateU<>>>,
       Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>>>;
@@ -253,9 +255,10 @@ struct EvolutionMetavars {
           EvolutionMetavars>,
       tmpl::conditional_t<
           local_time_stepping, tmpl::list<>,
-          tmpl::list<Actions::RecordTimeStepperData<>,
-                     evolution::Actions::RunEventsAndDenseTriggers<>,
-                     Actions::UpdateU<>>>,
+          tmpl::list<
+              Actions::RecordTimeStepperData<>,
+              evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
+              Actions::UpdateU<>>>,
       evolution::dg::subcell::Actions::TciAndRollback<
           Burgers::subcell::TciOnDgGrid>,
       Actions::Goto<evolution::dg::subcell::Actions::Labels::EndOfSolvers>,
@@ -268,7 +271,8 @@ struct EvolutionMetavars {
       evolution::dg::subcell::fd::Actions::TakeTimeStep<
           Burgers::subcell::TimeDerivative>,
       Actions::RecordTimeStepperData<>,
-      evolution::Actions::RunEventsAndDenseTriggers<>, Actions::UpdateU<>,
+      evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
+      Actions::UpdateU<>,
       evolution::dg::subcell::Actions::TciAndSwitchToDg<
           Burgers::subcell::TciOnFdGrid>,
       Actions::Label<evolution::dg::subcell::Actions::Labels::EndOfSolvers>>>;

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -244,14 +244,16 @@ struct EvolutionMetavars {
       evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
       tmpl::conditional_t<
           local_time_stepping,
-          tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<>,
+          tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<
+                         tmpl::list<evolution::dg::ApplyBoundaryCorrections<
+                             EvolutionMetavars, true>>>,
                      evolution::dg::Actions::ApplyLtsBoundaryCorrections<
                          EvolutionMetavars>>,
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
                   EvolutionMetavars>,
               Actions::RecordTimeStepperData<>,
-              evolution::Actions::RunEventsAndDenseTriggers<>,
+              evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               Actions::UpdateU<>>>,
       tmpl::conditional_t<
           use_filtering,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -373,14 +373,16 @@ struct EvolutionMetavars {
       evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
       tmpl::conditional_t<
           local_time_stepping,
-          tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<>,
+          tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<
+                         tmpl::list<evolution::dg::ApplyBoundaryCorrections<
+                             EvolutionMetavars, true>>>,
                      evolution::dg::Actions::ApplyLtsBoundaryCorrections<
                          EvolutionMetavars>>,
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
                   EvolutionMetavars>,
               Actions::RecordTimeStepperData<>,
-              evolution::Actions::RunEventsAndDenseTriggers<>,
+              evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               Actions::UpdateU<>>>,
       dg::Actions::Filter<
           Filters::Exponential<0>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -320,14 +320,16 @@ struct GeneralizedHarmonicTemplateBase<
       evolution::dg::Actions::ComputeTimeDerivative<derived_metavars>,
       tmpl::conditional_t<
           local_time_stepping,
-          tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<>,
+          tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<
+                         tmpl::list<evolution::dg::ApplyBoundaryCorrections<
+                             derived_metavars, true>>>,
                      evolution::dg::Actions::ApplyLtsBoundaryCorrections<
                          derived_metavars>>,
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
                   derived_metavars>,
               Actions::RecordTimeStepperData<>,
-              evolution::Actions::RunEventsAndDenseTriggers<>,
+              evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               Actions::UpdateU<>,
               dg::Actions::Filter<
                   Filters::Exponential<0>,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -335,9 +335,11 @@ struct EvolutionMetavars {
       evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
       tmpl::conditional_t<
           local_time_stepping,
-          tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<
+          tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
+                         evolution::dg::ApplyBoundaryCorrections<
+                             EvolutionMetavars, true>,
                          system::primitive_from_conservative<
-                             ordered_list_of_primitive_recovery_schemes>>,
+                             ordered_list_of_primitive_recovery_schemes>>>,
                      evolution::dg::Actions::ApplyLtsBoundaryCorrections<
                          EvolutionMetavars>>,
           tmpl::list<
@@ -345,8 +347,8 @@ struct EvolutionMetavars {
                   EvolutionMetavars>,
               Actions::RecordTimeStepperData<>,
               evolution::Actions::RunEventsAndDenseTriggers<
-                  system::primitive_from_conservative<
-                      ordered_list_of_primitive_recovery_schemes>>,
+                  tmpl::list<system::primitive_from_conservative<
+                      ordered_list_of_primitive_recovery_schemes>>>,
               Actions::UpdateU<>>>,
       Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>,
@@ -366,10 +368,10 @@ struct EvolutionMetavars {
       tmpl::conditional_t<
           local_time_stepping, tmpl::list<>,
           tmpl::list<Actions::RecordTimeStepperData<>,
-                     evolution::Actions::RunEventsAndDenseTriggers<
+                     evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
                          grmhd::ValenciaDivClean::subcell::
                              FixConservativesAndComputePrims<
-                                 ordered_list_of_primitive_recovery_schemes>>,
+                                 ordered_list_of_primitive_recovery_schemes>>>,
                      Actions::UpdateU<>>>,
       // Note: The primitive variables are computed as part of the TCI.
       evolution::dg::subcell::Actions::TciAndRollback<
@@ -393,9 +395,9 @@ struct EvolutionMetavars {
       evolution::dg::subcell::fd::Actions::TakeTimeStep<
           grmhd::ValenciaDivClean::subcell::TimeDerivative>,
       Actions::RecordTimeStepperData<>,
-      evolution::Actions::RunEventsAndDenseTriggers<
+      evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
           grmhd::ValenciaDivClean::subcell::FixConservativesAndComputePrims<
-              ordered_list_of_primitive_recovery_schemes>>,
+              ordered_list_of_primitive_recovery_schemes>>>,
       Actions::UpdateU<>,
       Actions::MutateApply<
           grmhd::ValenciaDivClean::subcell::FixConservativesAndComputePrims<

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -277,8 +277,10 @@ struct EvolutionMetavars {
       evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
       tmpl::conditional_t<
           local_time_stepping,
-          tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<
-                         typename system::primitive_from_conservative>,
+          tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
+                         evolution::dg::ApplyBoundaryCorrections<
+                             EvolutionMetavars, true>,
+                         typename system::primitive_from_conservative>>,
                      evolution::dg::Actions::ApplyLtsBoundaryCorrections<
                          EvolutionMetavars>>,
           tmpl::list<
@@ -286,7 +288,7 @@ struct EvolutionMetavars {
                   EvolutionMetavars>,
               Actions::RecordTimeStepperData<>,
               evolution::Actions::RunEventsAndDenseTriggers<
-                  typename system::primitive_from_conservative>,
+                  tmpl::list<typename system::primitive_from_conservative>>,
               Actions::UpdateU<>>>,
       Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>,

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -191,14 +191,16 @@ struct EvolutionMetavars {
       evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
       tmpl::conditional_t<
           local_time_stepping,
-          tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<>,
+          tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<
+                         tmpl::list<evolution::dg::ApplyBoundaryCorrections<
+                             EvolutionMetavars, true>>>,
                      evolution::dg::Actions::ApplyLtsBoundaryCorrections<
                          EvolutionMetavars>>,
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
                   EvolutionMetavars>,
               Actions::RecordTimeStepperData<>,
-              evolution::Actions::RunEventsAndDenseTriggers<>,
+              evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               Actions::UpdateU<>>>,
       Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>,

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -202,8 +202,10 @@ struct EvolutionMetavars {
       evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
       tmpl::conditional_t<
           local_time_stepping,
-          tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<
-                         typename system::primitive_from_conservative>,
+          tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
+                         evolution::dg::ApplyBoundaryCorrections<
+                             EvolutionMetavars, true>,
+                         typename system::primitive_from_conservative>>,
                      evolution::dg::Actions::ApplyLtsBoundaryCorrections<
                          EvolutionMetavars>>,
           tmpl::list<
@@ -211,7 +213,7 @@ struct EvolutionMetavars {
                   EvolutionMetavars>,
               Actions::RecordTimeStepperData<>,
               evolution::Actions::RunEventsAndDenseTriggers<
-                  typename system::primitive_from_conservative>,
+                  tmpl::list<typename system::primitive_from_conservative>>,
               Actions::UpdateU<>>>,
       Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>,

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -240,9 +240,10 @@ struct EvolutionMetavars {
           EvolutionMetavars>,
       tmpl::conditional_t<
           local_time_stepping, tmpl::list<>,
-          tmpl::list<Actions::RecordTimeStepperData<>,
-                     evolution::Actions::RunEventsAndDenseTriggers<>,
-                     Actions::UpdateU<>>>,
+          tmpl::list<
+              Actions::RecordTimeStepperData<>,
+              evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
+              Actions::UpdateU<>>>,
       Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>>>;
 
@@ -255,9 +256,10 @@ struct EvolutionMetavars {
           EvolutionMetavars>,
       tmpl::conditional_t<
           local_time_stepping, tmpl::list<>,
-          tmpl::list<Actions::RecordTimeStepperData<>,
-                     evolution::Actions::RunEventsAndDenseTriggers<>,
-                     Actions::UpdateU<>>>,
+          tmpl::list<
+              Actions::RecordTimeStepperData<>,
+              evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
+              Actions::UpdateU<>>>,
       evolution::dg::subcell::Actions::TciAndRollback<
           ScalarAdvection::subcell::TciOnDgGrid<Dim>>,
       Actions::Goto<evolution::dg::subcell::Actions::Labels::EndOfSolvers>,

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -215,14 +215,16 @@ struct EvolutionMetavars {
       evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
       tmpl::conditional_t<
           local_time_stepping,
-          tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<>,
+          tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<
+                         tmpl::list<evolution::dg::ApplyBoundaryCorrections<
+                             EvolutionMetavars, true>>>,
                      evolution::dg::Actions::ApplyLtsBoundaryCorrections<
                          EvolutionMetavars>>,
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
                   EvolutionMetavars>,
               Actions::RecordTimeStepperData<>,
-              evolution::Actions::RunEventsAndDenseTriggers<>,
+              evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               Actions::UpdateU<>>>,
       tmpl::conditional_t<
           use_filtering,


### PR DESCRIPTION
LTS and primitive reconstruction are no longer hardcoded.  Additional
things like IMEX can now be supported without modifying the action.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
