### PR TITLE
Work towards eliding unnecessary DG-FD projects

### DIFF
--- a/src/Domain/Domain.hpp
+++ b/src/Domain/Domain.hpp
@@ -35,6 +35,11 @@ class CoordinateMapBase;
 /// \endcond
 
 /*!
+ * \brief Holds entities related to the computational domain.
+ */
+namespace domain {}
+
+/*!
  *  \ingroup ComputationalDomainGroup
  *  \brief A wrapper around a vector of Blocks that represent the computational
  * domain.

--- a/src/Domain/Structure/CMakeLists.txt
+++ b/src/Domain/Structure/CMakeLists.txt
@@ -46,6 +46,7 @@ spectre_target_headers(
   OrientationMapHelpers.hpp
   SegmentId.hpp
   Side.hpp
+  TrimMap.hpp
   )
 
 target_link_libraries(

--- a/src/Domain/Structure/TrimMap.hpp
+++ b/src/Domain/Structure/TrimMap.hpp
@@ -1,0 +1,51 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <boost/functional/hash.hpp>
+#include <cstddef>
+#include <utility>
+
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/MaxNumberOfNeighbors.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace domain {
+/*!
+ * \brief Remove entries in `map_to_trim` that aren't face neighbors of the
+ * `element`
+ */
+template <size_t Dim, typename T>
+void remove_nonexistent_neighbors(
+    const gsl::not_null<
+        FixedHashMap<maximum_number_of_neighbors(Dim),
+                     std::pair<Direction<Dim>, ElementId<Dim>>, T,
+                     boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>*>
+        map_to_trim,
+    const Element<Dim>& element) {
+  std::array<std::pair<Direction<Dim>, ElementId<Dim>>,
+             maximum_number_of_neighbors(Dim)>
+      ids_to_remove{};
+  size_t ids_index = 0;
+  for (const auto& [neighbor_id, mesh] : *map_to_trim) {
+    const auto& neighbors = element.neighbors();
+    if (const auto neighbors_it = neighbors.find(neighbor_id.first);
+        neighbors_it != neighbors.end()) {
+      if (const auto neighbor_it =
+              neighbors_it->second.ids().find(neighbor_id.second);
+          neighbor_it == neighbors_it->second.ids().end()) {
+        gsl::at(ids_to_remove, ids_index) = neighbor_id;
+        ++ids_index;
+      }
+    } else {
+      gsl::at(ids_to_remove, ids_index) = neighbor_id;
+      ++ids_index;
+    }
+  }
+  for (size_t i = 0; i < ids_index; ++i) {
+    map_to_trim->erase(gsl::at(ids_to_remove, i));
+  }
+}
+}  // namespace domain

--- a/src/Evolution/DgSubcell/Matrices.hpp
+++ b/src/Evolution/DgSubcell/Matrices.hpp
@@ -4,6 +4,8 @@
 
 #include <cstddef>
 
+#include "Domain/Structure/Side.hpp"
+
 /// \cond
 class DataVector;
 template <size_t Dim>
@@ -73,4 +75,20 @@ const Matrix& projection_matrix(const Mesh<1>& dg_mesh, size_t subcell_extents);
 template <size_t Dim>
 const Matrix& reconstruction_matrix(const Mesh<Dim>& dg_mesh,
                                     const Index<Dim>& subcell_extents);
+
+/*!
+ * \ingroup DgSubcellGroup
+ * \brief Computes the projection matrix in 1 dimension going from a DG
+ * mesh to a conservative finite difference subcell mesh for only the ghost
+ * zones.
+ *
+ * This is used when a neighbor sends DG volume data and we need to switch to
+ * FD. In this case we need to project the DG volume data onto the ghost zone
+ * cells.
+ *
+ * \note Currently assumes a max ghost zone size of `5` and a minimum ghost zone
+ * size of 2.
+ */
+const Matrix& projection_matrix(const Mesh<1>& dg_mesh, size_t subcell_extents,
+                                size_t ghost_zone_size, Side side);
 }  // namespace evolution::dg::subcellfd

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
@@ -300,17 +300,17 @@ CREATE_GET_TYPE_ALIAS_OR_DEFAULT(dg_step_choosers)
  * - Modifies:
  *   - `evolution::dg::Tags::MortarData<Dim>`
  */
-template <typename Metavariables>
+template <size_t Dim, typename EvolutionSystem>
 struct ComputeTimeDerivative {
-  using inbox_tags =
-      tmpl::list<evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<
-          Metavariables::volume_dim>>;
-  using const_global_cache_tags = tmpl::append<tmpl::list<
-      ::dg::Tags::Formulation,
-      evolution::Tags::BoundaryCorrection<typename Metavariables::system>>>;
+  using inbox_tags = tmpl::list<
+      evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<Dim>>;
+  using const_global_cache_tags = tmpl::append<
+      tmpl::list<::dg::Tags::Formulation,
+                 evolution::Tags::BoundaryCorrection<EvolutionSystem>>>;
 
   template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
-            typename ActionList, typename ParallelComponent>
+            typename ActionList, typename ParallelComponent,
+            typename Metavariables>
   static Parallel::iterable_action_return_t apply(
       db::DataBox<DbTagsList>& box,
       tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
@@ -319,31 +319,32 @@ struct ComputeTimeDerivative {
       const ParallelComponent* /*meta*/);  // NOLINT const
 
  private:
-  template <typename ParallelComponent, typename DbTagsList>
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables>
   static void send_data_for_fluxes(
       gsl::not_null<Parallel::GlobalCache<Metavariables>*> cache,
       gsl::not_null<db::DataBox<DbTagsList>*> box);
 };
 
-template <typename Metavariables>
+template <size_t Dim, typename EvolutionSystem>
 template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
-          typename ActionList, typename ParallelComponent>
-Parallel::iterable_action_return_t ComputeTimeDerivative<Metavariables>::apply(
+          typename ActionList, typename ParallelComponent,
+          typename Metavariables>
+Parallel::iterable_action_return_t
+ComputeTimeDerivative<Dim, EvolutionSystem>::apply(
     db::DataBox<DbTagsList>& box,
     tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
     Parallel::GlobalCache<Metavariables>& cache,
     const ArrayIndex& /*array_index*/, ActionList /*meta*/,
     const ParallelComponent* const /*meta*/) {  // NOLINT const
-  static constexpr size_t volume_dim = Metavariables::volume_dim;
-  using system = typename Metavariables::system;
-  using variables_tag = typename system::variables_tag;
+  using variables_tag = typename EvolutionSystem::variables_tag;
   using dt_variables_tag = db::add_tag_prefix<::Tags::dt, variables_tag>;
-  using partial_derivative_tags = typename system::gradient_variables;
-  using flux_variables = typename system::flux_variables;
+  using partial_derivative_tags = typename EvolutionSystem::gradient_variables;
+  using flux_variables = typename EvolutionSystem::flux_variables;
   using compute_volume_time_derivative_terms =
-      typename system::compute_volume_time_derivative_terms;
+      typename EvolutionSystem::compute_volume_time_derivative_terms;
 
-  const Mesh<volume_dim>& mesh = db::get<::domain::Tags::Mesh<volume_dim>>(box);
+  const Mesh<Dim>& mesh = db::get<::domain::Tags::Mesh<Dim>>(box);
   const ::dg::Formulation dg_formulation =
       db::get<::dg::Tags::Formulation>(box);
   ASSERT(alg::all_of(mesh.basis(),
@@ -377,14 +378,13 @@ Parallel::iterable_action_return_t ComputeTimeDerivative<Metavariables>::apply(
       Variables<typename compute_volume_time_derivative_terms::temporary_tags>;
   using VarsFluxes =
       Variables<db::wrap_tags_in<::Tags::Flux, flux_variables,
-                                 tmpl::size_t<volume_dim>, Frame::Inertial>>;
+                                 tmpl::size_t<Dim>, Frame::Inertial>>;
   using VarsPartialDerivatives =
       Variables<db::wrap_tags_in<::Tags::deriv, partial_derivative_tags,
-                                 tmpl::size_t<volume_dim>, Frame::Inertial>>;
+                                 tmpl::size_t<Dim>, Frame::Inertial>>;
   using VarsDivFluxes = Variables<db::wrap_tags_in<
-      ::Tags::div,
-      db::wrap_tags_in<::Tags::Flux, flux_variables, tmpl::size_t<volume_dim>,
-                       Frame::Inertial>>>;
+      ::Tags::div, db::wrap_tags_in<::Tags::Flux, flux_variables,
+                                    tmpl::size_t<Dim>, Frame::Inertial>>>;
   const size_t number_of_grid_points = mesh.number_of_grid_points();
   auto buffer = cpp20::make_unique_for_overwrite<double[]>(
       (VarsTemporaries::number_of_independent_components +
@@ -427,12 +427,12 @@ Parallel::iterable_action_return_t ComputeTimeDerivative<Metavariables>::apply(
        &div_mesh_velocity = db::get<::domain::Tags::DivMeshVelocity>(box),
        &evolved_variables = db::get<variables_tag>(box),
        &inertial_coordinates =
-           db::get<domain::Tags::Coordinates<volume_dim, Frame::Inertial>>(box),
+           db::get<domain::Tags::Coordinates<Dim, Frame::Inertial>>(box),
        &logical_to_inertial_inv_jacobian =
            db::get<::domain::Tags::InverseJacobian<
-               volume_dim, Frame::ElementLogical, Frame::Inertial>>(box),
+               Dim, Frame::ElementLogical, Frame::Inertial>>(box),
        &mesh,
-       &mesh_velocity = db::get<::domain::Tags::MeshVelocity<volume_dim>>(box),
+       &mesh_velocity = db::get<::domain::Tags::MeshVelocity<Dim>>(box),
        &partial_derivs, &temporaries, &volume_fluxes](
           const gsl::not_null<Variables<
               db::wrap_tags_in<::Tags::dt, typename variables_tag::tags_list>>*>
@@ -449,14 +449,15 @@ Parallel::iterable_action_return_t ComputeTimeDerivative<Metavariables>::apply(
       make_not_null(&box));
 
   const auto& boundary_correction =
-      db::get<evolution::Tags::BoundaryCorrection<system>>(box);
+      db::get<evolution::Tags::BoundaryCorrection<EvolutionSystem>>(box);
   using derived_boundary_corrections =
       typename std::decay_t<decltype(boundary_correction)>::creatable_classes;
 
-  const Variables<detail::get_primitive_vars_tags_from_system<system>>*
+  const Variables<detail::get_primitive_vars_tags_from_system<EvolutionSystem>>*
       primitive_vars{nullptr};
-  if constexpr (system::has_primitive_and_conservative_vars) {
-    primitive_vars = &db::get<typename system::primitive_variables_tag>(box);
+  if constexpr (EvolutionSystem::has_primitive_and_conservative_vars) {
+    primitive_vars =
+        &db::get<typename EvolutionSystem::primitive_variables_tag>(box);
   }
 
   static_assert(
@@ -475,15 +476,15 @@ Parallel::iterable_action_return_t ComputeTimeDerivative<Metavariables>::apply(
           // Note: this call mutates:
           //  - evolution::dg::Tags::NormalCovectorAndMagnitude<Dim>,
           //  - evolution::dg::Tags::MortarData<Dim>
-          detail::internal_mortar_data<system, volume_dim>(
+          detail::internal_mortar_data<EvolutionSystem, Dim>(
               make_not_null(&box),
               dynamic_cast<const DerivedCorrection&>(boundary_correction),
               db::get<variables_tag>(box), volume_fluxes, temporaries,
               primitive_vars,
               typename DerivedCorrection::dg_package_data_volume_tags{});
 
-          detail::apply_boundary_conditions_on_all_external_faces<system,
-                                                                  volume_dim>(
+          detail::apply_boundary_conditions_on_all_external_faces<
+              EvolutionSystem, Dim>(
               make_not_null(&box),
               dynamic_cast<const DerivedCorrection&>(boundary_correction),
               temporaries, volume_fluxes, partial_derivs, primitive_vars);
@@ -501,28 +502,28 @@ Parallel::iterable_action_return_t ComputeTimeDerivative<Metavariables>::apply(
   return {Parallel::AlgorithmExecution::Continue, std::nullopt};
 }
 
-template <typename Metavariables>
-template <typename ParallelComponent, typename DbTagsList>
-void ComputeTimeDerivative<Metavariables>::send_data_for_fluxes(
+template <size_t Dim, typename EvolutionSystem>
+template <typename ParallelComponent, typename DbTagsList,
+          typename Metavariables>
+void ComputeTimeDerivative<Dim, EvolutionSystem>::send_data_for_fluxes(
     const gsl::not_null<Parallel::GlobalCache<Metavariables>*> cache,
     const gsl::not_null<db::DataBox<DbTagsList>*> box) {
-  constexpr size_t volume_dim = Metavariables::volume_dim;
   auto& receiver_proxy =
       Parallel::get_parallel_component<ParallelComponent>(*cache);
-  const auto& element = db::get<domain::Tags::Element<volume_dim>>(*box);
+  const auto& element = db::get<domain::Tags::Element<Dim>>(*box);
 
     const auto& time_step_id = db::get<::Tags::TimeStepId>(*box);
     const auto& all_mortar_data =
-        db::get<evolution::dg::Tags::MortarData<volume_dim>>(*box);
+        db::get<evolution::dg::Tags::MortarData<Dim>>(*box);
     const auto& mortar_meshes =
-        get<evolution::dg::Tags::MortarMesh<volume_dim>>(*box);
+        get<evolution::dg::Tags::MortarMesh<Dim>>(*box);
 
-    std::optional<DirectionMap<volume_dim, std::vector<double>>>
+    std::optional<DirectionMap<Dim, std::vector<double>>>
         all_neighbor_data_for_reconstruction = std::nullopt;
     // Set ghost_cell_mesh to the DG mesh, then update it below if we did a
     // projection.
-    Mesh<volume_dim> ghost_cell_mesh =
-        db::get<domain::Tags::Mesh<volume_dim>>(*box);
+    Mesh<Dim> ghost_cell_mesh =
+        db::get<domain::Tags::Mesh<Dim>>(*box);
     if constexpr (using_subcell_v<Metavariables>) {
       all_neighbor_data_for_reconstruction =
           evolution::dg::subcell::prepare_neighbor_data<Metavariables>(box);
@@ -544,7 +545,7 @@ void ComputeTimeDerivative<Metavariables>::send_data_for_fluxes(
       for (const auto& neighbor : neighbors) {
         const std::pair mortar_id{direction, neighbor};
 
-        std::pair<Mesh<volume_dim - 1>, std::vector<double>>
+        std::pair<Mesh<Dim - 1>, std::vector<double>>
             neighbor_boundary_data_on_mortar{};
         ASSERT(time_step_id == all_mortar_data.at(mortar_id).time_step_id(),
                "The current time step id of the volume is "
@@ -574,7 +575,7 @@ void ComputeTimeDerivative<Metavariables>::send_data_for_fluxes(
           }
         }();
 
-        std::tuple<Mesh<volume_dim>, Mesh<volume_dim - 1>,
+        std::tuple<Mesh<Dim>, Mesh<Dim - 1>,
                    std::optional<std::vector<double>>,
                    std::optional<std::vector<double>>, ::TimeStepId>
             data{ghost_cell_mesh,
@@ -586,7 +587,7 @@ void ComputeTimeDerivative<Metavariables>::send_data_for_fluxes(
         // Send mortar data (the `std::tuple` named `data`) to neighbor
         Parallel::receive_data<
             evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<
-                volume_dim>>(
+                Dim>>(
             receiver_proxy[neighbor], time_step_id,
             std::make_pair(std::pair{direction_from_neighbor, element.id()},
                            data));
@@ -594,13 +595,13 @@ void ComputeTimeDerivative<Metavariables>::send_data_for_fluxes(
     }
 
     if constexpr (Metavariables::local_time_stepping) {
-      using variables_tag = typename Metavariables::system::variables_tag;
+      using variables_tag = typename EvolutionSystem::variables_tag;
       using dt_variables_tag = db::add_tag_prefix<::Tags::dt, variables_tag>;
       // We assume isotropic quadrature, i.e. the quadrature is the same in
       // all directions.
       const bool using_gauss_points =
-          db::get<domain::Tags::Mesh<volume_dim>>(*box).quadrature() ==
-          make_array<volume_dim>(Spectral::Quadrature::Gauss);
+          db::get<domain::Tags::Mesh<Dim>>(*box).quadrature() ==
+          make_array<Dim>(Spectral::Quadrature::Gauss);
 
       const Scalar<DataVector> volume_det_inv_jacobian{};
       if (using_gauss_points) {
@@ -620,33 +621,33 @@ void ComputeTimeDerivative<Metavariables>::send_data_for_fluxes(
       // using the `NormalDotNumericalFlux` prefix tag. This is because the
       // returned quantity is more a `dt` quantity than a
       // `NormalDotNormalDotFlux` since it's been lifted to the volume.
-      using Key = std::pair<Direction<volume_dim>, ElementId<volume_dim>>;
+      using Key = std::pair<Direction<Dim>, ElementId<Dim>>;
       const auto integration_order =
           db::get<::Tags::HistoryEvolvedVariables<>>(*box).integration_order();
-      db::mutate<evolution::dg::Tags::MortarData<volume_dim>,
+      db::mutate<evolution::dg::Tags::MortarData<Dim>,
                  evolution::dg::Tags::MortarDataHistory<
-                     volume_dim, typename dt_variables_tag::type>>(
+                     Dim, typename dt_variables_tag::type>>(
           box,
           [&element, integration_order, &time_step_id, using_gauss_points,
            &volume_det_inv_jacobian](
               const gsl::not_null<
-                  std::unordered_map<Key, evolution::dg::MortarData<volume_dim>,
+                  std::unordered_map<Key, evolution::dg::MortarData<Dim>,
                                      boost::hash<Key>>*>
                   mortar_data,
               const gsl::not_null<
                   std::unordered_map<Key,
                                      TimeSteppers::BoundaryHistory<
-                                         evolution::dg::MortarData<volume_dim>,
-                                         evolution::dg::MortarData<volume_dim>,
+                                         evolution::dg::MortarData<Dim>,
+                                         evolution::dg::MortarData<Dim>,
                                          typename dt_variables_tag::type>,
                                      boost::hash<Key>>*>
                   boundary_data_history,
-              const Mesh<volume_dim>& volume_mesh,
+              const Mesh<Dim>& volume_mesh,
               const DirectionMap<
-                  volume_dim,
+                  Dim,
                   std::optional<Variables<tmpl::list<
                       evolution::dg::Tags::MagnitudeOfNormal,
-                      evolution::dg::Tags::NormalCovector<volume_dim>>>>>&
+                      evolution::dg::Tags::NormalCovector<Dim>>>>>&
                   normal_covector_and_magnitude) {
             Scalar<DataVector> volume_det_jacobian{};
             Scalar<DataVector> face_det_jacobian{};
@@ -667,7 +668,7 @@ void ComputeTimeDerivative<Metavariables>::send_data_for_fluxes(
               if (using_gauss_points) {
                 const Matrix identity{};
                 auto interpolation_matrices =
-                    make_array<Metavariables::volume_dim>(std::cref(identity));
+                    make_array<Dim>(std::cref(identity));
                 const std::pair<Matrix, Matrix>& matrices =
                     Spectral::boundary_interpolation_matrices(
                         volume_mesh.slice_through(direction.dimension()));
@@ -704,13 +705,12 @@ void ComputeTimeDerivative<Metavariables>::send_data_for_fluxes(
                     time_step_id, std::move(mortar_data->at(mortar_id)));
                 boundary_data_history->at(mortar_id).integration_order(
                     integration_order);
-                mortar_data->at(mortar_id) =
-                    MortarData<Metavariables::volume_dim>{};
+                mortar_data->at(mortar_id) = MortarData<Dim>{};
               }
             }
           },
-          db::get<domain::Tags::Mesh<volume_dim>>(*box),
-          db::get<evolution::dg::Tags::NormalCovectorAndMagnitude<volume_dim>>(
+          db::get<domain::Tags::Mesh<Dim>>(*box),
+          db::get<evolution::dg::Tags::NormalCovectorAndMagnitude<Dim>>(
               *box));
   }
 }

--- a/src/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -27,3 +27,4 @@ spectre_target_sources(
 add_subdirectory(Actions)
 add_subdirectory(Initialization)
 add_subdirectory(Limiters)
+add_subdirectory(Tags)

--- a/src/Evolution/DiscontinuousGalerkin/InboxTags.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/InboxTags.hpp
@@ -114,7 +114,6 @@ struct BoundaryCorrectionAndGhostCellsInbox {
     auto& [volume_mesh_of_ghost_cell_data, face_mesh, ghost_cell_data,
            boundary_data, boundary_data_validity_range] = data.second;
     (void)ghost_cell_data;
-    (void)volume_mesh_of_ghost_cell_data; // Need to use when optimizing subcell
 
     if (auto it = current_inbox.find(data.first); it != current_inbox.end()) {
       auto& [current_volume_mesh_of_ghost_cell_data, current_face_mesh,
@@ -144,6 +143,14 @@ struct BoundaryCorrectionAndGhostCellsInbox {
              "The mesh being received for the fluxes is different than the "
              "mesh received for the ghost cells. Mesh for fluxes: "
                  << face_mesh << " mesh for ghost cells " << current_face_mesh);
+      ASSERT(current_volume_mesh_of_ghost_cell_data ==
+                 volume_mesh_of_ghost_cell_data,
+             "The mesh being received for the ghost cell data is different "
+             "than the mesh received previously. Mesh for received when we got "
+             "fluxes: "
+                 << volume_mesh_of_ghost_cell_data
+                 << " mesh received when we got ghost cells "
+                 << current_volume_mesh_of_ghost_cell_data);
 
       // We always move here since we take ownership of the data and moves
       // implicitly decay to copies

--- a/src/Evolution/DiscontinuousGalerkin/Tags/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/Tags/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  NeighborMesh.hpp
+  )

--- a/src/Evolution/DiscontinuousGalerkin/Tags/NeighborMesh.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Tags/NeighborMesh.hpp
@@ -1,0 +1,32 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <boost/functional/hash.hpp>
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/FixedHashMap.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/MaxNumberOfNeighbors.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+
+namespace evolution::dg::Tags {
+/*!
+ * \brief Holds the mesh of each neighboring element.
+ *
+ * This is ultimately necessary to determine what numerical method the neighbor
+ * is using. This knowledge can be used for optimizing code when using a DG-FD
+ * hybrid method, but might also be useful more generally..
+ */
+template <size_t Dim>
+struct NeighborMesh : db::SimpleTag {
+  using type =
+      FixedHashMap<maximum_number_of_neighbors(Dim),
+                   std::pair<Direction<Dim>, ElementId<Dim>>, Mesh<Dim>,
+                   boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>;
+};
+}  // namespace evolution::dg::Tags

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -230,7 +230,8 @@ struct EvolutionMetavars {
           tmpl::at<typename factory_creation::factory_classes, Event>>>>;
 
   using dg_step_actions = tmpl::flatten<tmpl::list<
-      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system>,
+      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
+                                                    AllStepChoosers>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<
@@ -250,7 +251,8 @@ struct EvolutionMetavars {
   using dg_subcell_step_actions = tmpl::flatten<tmpl::list<
       evolution::dg::subcell::Actions::SelectNumericalMethod,
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginDg>,
-      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system>,
+      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
+                                                    AllStepChoosers>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
           EvolutionMetavars>,
       tmpl::conditional_t<

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -230,7 +230,7 @@ struct EvolutionMetavars {
           tmpl::at<typename factory_creation::factory_classes, Event>>>>;
 
   using dg_step_actions = tmpl::flatten<tmpl::list<
-      evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
+      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<
@@ -250,7 +250,7 @@ struct EvolutionMetavars {
   using dg_subcell_step_actions = tmpl::flatten<tmpl::list<
       evolution::dg::subcell::Actions::SelectNumericalMethod,
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginDg>,
-      evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
+      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
           EvolutionMetavars>,
       tmpl::conditional_t<

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -249,7 +249,7 @@ struct EvolutionMetavars {
       tmpl::conditional_t<domain::enable_time_dependent_maps,
                           CurvedScalarWave::Actions::CalculateGrVars<system>,
                           tmpl::list<>>,
-      evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
+      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -249,7 +249,8 @@ struct EvolutionMetavars {
       tmpl::conditional_t<domain::enable_time_dependent_maps,
                           CurvedScalarWave::Actions::CalculateGrVars<system>,
                           tmpl::list<>>,
-      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system>,
+      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
+                                                    AllStepChoosers>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -370,7 +370,8 @@ struct EvolutionMetavars {
        Parallel::Phase::Evolve, Parallel::Phase::Exit}};
 
   using step_actions = tmpl::list<
-      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system>,
+      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
+                                                    AllStepChoosers>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -370,7 +370,7 @@ struct EvolutionMetavars {
        Parallel::Phase::Evolve, Parallel::Phase::Exit}};
 
   using step_actions = tmpl::list<
-      evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
+      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -317,7 +317,8 @@ struct GeneralizedHarmonicTemplateBase<
       detail::make_default_phase_order<initial_data>();
 
   using step_actions = tmpl::list<
-      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system>,
+      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
+                                                    AllStepChoosers>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -317,7 +317,7 @@ struct GeneralizedHarmonicTemplateBase<
       detail::make_default_phase_order<initial_data>();
 
   using step_actions = tmpl::list<
-      evolution::dg::Actions::ComputeTimeDerivative<derived_metavars>,
+      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -356,7 +356,7 @@ struct GhValenciaDivCleanTemplateBase<
       detail::make_default_phase_order<initial_data>();
 
   using step_actions = tmpl::flatten<tmpl::list<
-      evolution::dg::Actions::ComputeTimeDerivative<derived_metavars>,
+      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::dg::Actions::ApplyLtsBoundaryCorrections<

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -356,7 +356,8 @@ struct GhValenciaDivCleanTemplateBase<
       detail::make_default_phase_order<initial_data>();
 
   using step_actions = tmpl::flatten<tmpl::list<
-      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system>,
+      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
+                                                    AllStepChoosers>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::dg::Actions::ApplyLtsBoundaryCorrections<

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -335,7 +335,8 @@ struct EvolutionMetavars {
   };
 
   using dg_step_actions = tmpl::flatten<tmpl::list<
-      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system>,
+      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
+                                                    AllStepChoosers>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
@@ -365,7 +366,8 @@ struct EvolutionMetavars {
       evolution::dg::subcell::Actions::SelectNumericalMethod,
 
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginDg>,
-      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system>,
+      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
+                                                    AllStepChoosers>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
           EvolutionMetavars>,
       tmpl::conditional_t<

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -335,7 +335,7 @@ struct EvolutionMetavars {
   };
 
   using dg_step_actions = tmpl::flatten<tmpl::list<
-      evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
+      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
@@ -365,7 +365,7 @@ struct EvolutionMetavars {
       evolution::dg::subcell::Actions::SelectNumericalMethod,
 
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginDg>,
-      evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
+      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
           EvolutionMetavars>,
       tmpl::conditional_t<

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -277,7 +277,7 @@ struct EvolutionMetavars {
       Initialization::Actions::RemoveOptionsAndTerminatePhase>>;
 
   using dg_step_actions = tmpl::flatten<tmpl::list<
-      evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
+      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
@@ -325,7 +325,7 @@ struct EvolutionMetavars {
       evolution::dg::subcell::Actions::SelectNumericalMethod,
 
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginDg>,
-      evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
+      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
           EvolutionMetavars>,
       tmpl::conditional_t<

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -277,7 +277,8 @@ struct EvolutionMetavars {
       Initialization::Actions::RemoveOptionsAndTerminatePhase>>;
 
   using dg_step_actions = tmpl::flatten<tmpl::list<
-      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system>,
+      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
+                                                    AllStepChoosers>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
@@ -325,7 +326,8 @@ struct EvolutionMetavars {
       evolution::dg::subcell::Actions::SelectNumericalMethod,
 
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginDg>,
-      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system>,
+      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
+                                                    AllStepChoosers>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
           EvolutionMetavars>,
       tmpl::conditional_t<

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -188,7 +188,8 @@ struct EvolutionMetavars {
           tmpl::at<typename factory_creation::factory_classes, Event>>>>;
 
   using step_actions = tmpl::flatten<tmpl::list<
-      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system>,
+      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
+                                                    AllStepChoosers>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -188,7 +188,7 @@ struct EvolutionMetavars {
           tmpl::at<typename factory_creation::factory_classes, Event>>>>;
 
   using step_actions = tmpl::flatten<tmpl::list<
-      evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
+      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -202,7 +202,7 @@ struct EvolutionMetavars {
           tmpl::at<typename factory_creation::factory_classes, Event>>>>;
 
   using step_actions = tmpl::flatten<tmpl::list<
-      evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
+      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -202,7 +202,8 @@ struct EvolutionMetavars {
           tmpl::at<typename factory_creation::factory_classes, Event>>>>;
 
   using step_actions = tmpl::flatten<tmpl::list<
-      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system>,
+      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
+                                                    AllStepChoosers>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -235,7 +235,7 @@ struct EvolutionMetavars {
           tmpl::at<typename factory_creation::factory_classes, Event>>>>;
 
   using dg_step_actions = tmpl::flatten<tmpl::list<
-      evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
+      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
           EvolutionMetavars>,
       tmpl::conditional_t<
@@ -251,7 +251,7 @@ struct EvolutionMetavars {
       evolution::dg::subcell::Actions::SelectNumericalMethod,
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginDg>,
 
-      evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
+      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
           EvolutionMetavars>,
       tmpl::conditional_t<

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -235,7 +235,8 @@ struct EvolutionMetavars {
           tmpl::at<typename factory_creation::factory_classes, Event>>>>;
 
   using dg_step_actions = tmpl::flatten<tmpl::list<
-      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system>,
+      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
+                                                    AllStepChoosers>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
           EvolutionMetavars>,
       tmpl::conditional_t<
@@ -251,7 +252,8 @@ struct EvolutionMetavars {
       evolution::dg::subcell::Actions::SelectNumericalMethod,
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginDg>,
 
-      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system>,
+      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
+                                                    AllStepChoosers>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
           EvolutionMetavars>,
       tmpl::conditional_t<

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -212,7 +212,8 @@ struct EvolutionMetavars {
   static constexpr bool use_filtering = (2 == volume_dim);
 
   using step_actions = tmpl::flatten<tmpl::list<
-      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system>,
+      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system,
+                                                    AllStepChoosers>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -212,7 +212,7 @@ struct EvolutionMetavars {
   static constexpr bool use_filtering = (2 == volume_dim);
 
   using step_actions = tmpl::flatten<tmpl::list<
-      evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
+      evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<

--- a/tests/Unit/Domain/Structure/CMakeLists.txt
+++ b/tests/Unit/Domain/Structure/CMakeLists.txt
@@ -20,6 +20,7 @@ set(LIBRARY_SOURCES
   Test_OrientationMapHelpers.cpp
   Test_SegmentId.cpp
   Test_Side.cpp
+  Test_TrimMap.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Domain/Structure/Test_SegmentId.cpp
+++ b/tests/Unit/Domain/Structure/Test_SegmentId.cpp
@@ -15,6 +15,29 @@
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/GetOutput.hpp"
 
+namespace {
+void test_errors() {
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(SegmentId(3, 8), Catch::Matchers::Contains(
+                                         "index = 8, refinement_level = 3"));
+  CHECK_THROWS_WITH(SegmentId(0, 0).id_of_parent(),
+                    Catch::Matchers::Contains("on root refinement level!"));
+  CHECK_THROWS_WITH(
+      SegmentId(0, 0).id_of_sibling(),
+      Catch::Matchers::Contains(
+          "The segment on the root refinement level has no sibling"));
+  CHECK_THROWS_WITH(
+      SegmentId(0, 0).id_of_abutting_nibling(),
+      Catch::Matchers::Contains(
+          "The segment on the root refinement level has no abutting nibling"));
+  CHECK_THROWS_WITH(
+      SegmentId(0, 0).side_of_sibling(),
+      Catch::Matchers::Contains(
+          "The segment on the root refinement level has no sibling"));
+#endif
+}
+}  // namespace
+
 SPECTRE_TEST_CASE("Unit.Domain.Structure.SegmentId", "[Domain][Unit]") {
   // Test equality operator:
   SegmentId segment_one(4, 3);
@@ -80,60 +103,6 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.SegmentId", "[Domain][Unit]") {
                                         SegmentId{3, 2}} ==
           std::unordered_set<SegmentId>{SegmentId{3, 2}, SegmentId{2, 3}});
   }
-}
 
-// [[OutputRegex, index = 8, refinement_level = 3]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Structure.SegmentId.BadIndex",
-                               "[Domain][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  auto failed_segment_id = SegmentId(3, 8);
-  static_cast<void>(failed_segment_id);
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// [[OutputRegex, on root refinement level!]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Structure.SegmentId.NoParent",
-                               "[Domain][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  auto root_segment_id = SegmentId(0, 0);
-  root_segment_id.id_of_parent();
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// [[OutputRegex, The segment on the root refinement level has no sibling]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Structure.SegmentId.NoSibling",
-                               "[Domain][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  auto root_segment_id = SegmentId(0, 0);
-  root_segment_id.id_of_sibling();
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// [[OutputRegex, The segment on the root refinement level has no abutting
-// nibling]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Structure.SegmentId.NoNibling",
-                               "[Domain][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  auto root_segment_id = SegmentId(0, 0);
-  root_segment_id.id_of_abutting_nibling();
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// [[OutputRegex, The segment on the root refinement level has no sibling]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Structure.SegmentId.NoSibling2",
-                               "[Domain][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  auto root_segment_id = SegmentId(0, 0);
-  root_segment_id.side_of_sibling();
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
+  test_errors();
 }

--- a/tests/Unit/Domain/Structure/Test_TrimMap.cpp
+++ b/tests/Unit/Domain/Structure/Test_TrimMap.cpp
@@ -1,0 +1,57 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <boost/functional/hash.hpp>
+#include <cstddef>
+#include <utility>
+
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/MaxNumberOfNeighbors.hpp"
+#include "Domain/Structure/TrimMap.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+template <size_t Dim>
+void test_remove_nonexistent_neighbors() {
+  FixedHashMap<maximum_number_of_neighbors(Dim),
+               std::pair<Direction<Dim>, ElementId<Dim>>, int,
+               boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>
+      map_to_trim{};
+
+  DirectionMap<Dim, Neighbors<Dim>> neighbors{};
+  for (size_t i = 0; i < 2 * Dim; ++i) {
+    ElementId<Dim> id{i + 1, {}};
+    neighbors[gsl::at(Direction<Dim>::all_directions(), i)] =
+        Neighbors<Dim>{{id}, {}};
+    map_to_trim[std::pair{gsl::at(Direction<Dim>::all_directions(), i), id}] =
+        i * i + 10;  // Assign some number
+  }
+  const Element<Dim> element{ElementId<Dim>{0, {}}, neighbors};
+  // Add extra neighbors that will be removed
+  for (size_t i = 0; i < 2 * Dim and Dim > 1; ++i) {
+    ElementId<Dim> id{i + 100, {}};
+    map_to_trim[std::pair{gsl::at(Direction<Dim>::all_directions(), i), id}] =
+        i * i + 1000;  // Assign some number
+  }
+  REQUIRE(map_to_trim.size() == (Dim == 1 ? 2 : 4) * Dim);
+  domain::remove_nonexistent_neighbors(make_not_null(&map_to_trim), element);
+
+  // Check that all expected neighbors are there
+  for (const auto& [direction, neighbors_in_direction] : element.neighbors()) {
+    for (const auto& neighbor : neighbors_in_direction) {
+      CHECK(map_to_trim.contains(std::pair{direction, neighbor}));
+    }
+  }
+  CHECK(map_to_trim.size() == 2 * Dim);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.Structure.TrimMap", "[Domain][Unit]") {
+  test_remove_nonexistent_neighbors<1>();
+  test_remove_nonexistent_neighbors<2>();
+  test_remove_nonexistent_neighbors<3>();
+}

--- a/tests/Unit/Evolution/Actions/Test_RunEventsAndDenseTriggers.cpp
+++ b/tests/Unit/Evolution/Actions/Test_RunEventsAndDenseTriggers.cpp
@@ -23,7 +23,9 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "DataStructures/VariablesTag.hpp"
+#include "Domain/Tags.hpp"
 #include "Evolution/Actions/RunEventsAndDenseTriggers.hpp"
+#include "Evolution/DiscontinuousGalerkin/Tags/NeighborMesh.hpp"
 #include "Evolution/EventsAndDenseTriggers/DenseTrigger.hpp"
 #include "Evolution/EventsAndDenseTriggers/EventsAndDenseTriggers.hpp"
 #include "Evolution/EventsAndDenseTriggers/Tags.hpp"
@@ -251,7 +253,9 @@ struct Component {
       tmpl::push_front<extra_data, Tags::TimeStepId, Tags::TimeStep, Tags::Time,
                        evolution::Tags::PreviousTriggerTime, variables_tag,
                        Tags::HistoryEvolvedVariables<variables_tag>,
-                       evolution::Tags::EventsAndDenseTriggers>;
+                       evolution::Tags::EventsAndDenseTriggers,
+                       evolution::dg::Tags::NeighborMesh<1>,
+                       domain::Tags::Element<1>>;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       Parallel::Phase::Testing,
@@ -351,6 +355,8 @@ void test(const bool time_runs_forward) {
               std::optional<double>{}, initial_vars, std::move(history),
               evolution::EventsAndDenseTriggers(
                   std::move(events_and_dense_triggers)),
+              typename evolution::dg::Tags::NeighborMesh<1>::type{},
+              Element<1>{ElementId<1>{0}, {}},
               get<tmpl::type_from<decltype(tags_v)>>(initial_extra_data)...);
         });
         ActionTesting::set_phase(runner, Parallel::Phase::Testing);

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBRARY_SOURCES
   Actions/Test_NormalCovectorAndMagnitude.cpp
   Initialization/Test_Mortars.cpp
   Initialization/Test_QuadratureTag.cpp
+  Tags/Test_NeighborMesh.cpp
   Test_BoundaryCorrectionsHelper.cpp
   Test_InboxTags.cpp
   Test_InterpolateFromBoundary.cpp

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Tags/Test_NeighborMesh.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Tags/Test_NeighborMesh.cpp
@@ -1,0 +1,16 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Evolution/DiscontinuousGalerkin/Tags/NeighborMesh.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Evolution.DG.Tags.NeighborMesh", "[Unit][Evolution]") {
+  TestHelpers::db::test_simple_tag<evolution::dg::Tags::NeighborMesh<1>>(
+      "NeighborMesh");
+  TestHelpers::db::test_simple_tag<evolution::dg::Tags::NeighborMesh<2>>(
+      "NeighborMesh");
+  TestHelpers::db::test_simple_tag<evolution::dg::Tags::NeighborMesh<3>>(
+      "NeighborMesh");
+}

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InboxTags.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InboxTags.cpp
@@ -158,6 +158,7 @@ void test_with_ghost_cells() {
   bc_tag::insert_into_inbox(make_not_null(&inbox), time_step_id_a,
                             std::make_pair(nhbr_key, send_data_a));
   Type send_flux_data_a;
+  get<0>(send_flux_data_a) = get<0>(send_data_a);
   get<1>(send_flux_data_a) = get<1>(send_data_a);
   get<3>(send_flux_data_a) = std::vector<double>(
       get<1>(send_data_a).number_of_grid_points() * number_of_components);

--- a/tests/Unit/Evolution/Initialization/Test_DgDomain.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_DgDomain.cpp
@@ -228,6 +228,11 @@ void test(const Spectral::Quadrature quadrature) {
   CHECK(ActionTesting::get_next_action_index<component>(runner, self_id) == 0);
   ActionTesting::next_action<component>(make_not_null(&runner), self_id);
 
+  CHECK(ActionTesting::get_databox_tag<component,
+                                       evolution::dg::Tags::NeighborMesh<Dim>>(
+            runner, self_id)
+            .empty());
+
   // Set up data to be used for checking correctness
   const auto logical_to_grid_map =
       create_affine_map<Dim, Frame::ElementLogical, Frame::Grid>();

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -830,7 +830,8 @@ struct component {
       Parallel::PhaseActions<
           Parallel::Phase::Testing,
           tmpl::list<::evolution::dg::Actions::ComputeTimeDerivative<
-              Metavariables::volume_dim, typename Metavariables::system>>>>;
+              Metavariables::volume_dim, typename Metavariables::system,
+              AllStepChoosers>>>>;
 };
 
 template <size_t Dim, SystemType SystemTypeIn, bool LocalTimeStepping,

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -829,8 +829,8 @@ struct component {
                   Metavariables::volume_dim, typename Metavariables::system>>>>,
       Parallel::PhaseActions<
           Parallel::Phase::Testing,
-          tmpl::list<
-              ::evolution::dg::Actions::ComputeTimeDerivative<Metavariables>>>>;
+          tmpl::list<::evolution::dg::Actions::ComputeTimeDerivative<
+              Metavariables::volume_dim, typename Metavariables::system>>>>;
 };
 
 template <size_t Dim, SystemType SystemTypeIn, bool LocalTimeStepping,

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SemidiscretizedDg.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SemidiscretizedDg.cpp
@@ -132,7 +132,7 @@ struct Component {
       Parallel::PhaseActions<
           Parallel::Phase, Parallel::Phase::Testing,
           tmpl::list<
-              evolution::dg::Actions::ComputeTimeDerivative<Metavariables>,
+              evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system>,
               dg::Actions::ReceiveDataForFluxes<boundary_scheme>,
               Actions::MutateApply<boundary_scheme>>>>;
 };

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SemidiscretizedDg.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SemidiscretizedDg.cpp
@@ -131,10 +131,10 @@ struct Component {
 
       Parallel::PhaseActions<
           Parallel::Phase, Parallel::Phase::Testing,
-          tmpl::list<
-              evolution::dg::Actions::ComputeTimeDerivative<volume_dim, system>,
-              dg::Actions::ReceiveDataForFluxes<boundary_scheme>,
-              Actions::MutateApply<boundary_scheme>>>>;
+          tmpl::list<evolution::dg::Actions::ComputeTimeDerivative<
+                         volume_dim, system, AllStepChoosers>,
+                     dg::Actions::ReceiveDataForFluxes<boundary_scheme>,
+                     Actions::MutateApply<boundary_scheme>>>>;
 };
 
 struct Metavariables {


### PR DESCRIPTION
## Proposed changes

Projecting from DG to FD adds a non-negligible amount of work to the executables. This work can be avoided by sending the DG volume data to neighboring elements instead of projecting and slicing FD data. This PR adds most of the bookkeeping capabilities necessary for eliding the projections. The missing parts are (1) having the FD receiving code check whether DG volume or FD ghost data was sent, then doing any projections as necessary, and (2) changing the DG sending code to not project and send ghost data if none of our neighbors are doing FD. That will be submitted in a separate PR.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
