### PR TITLE
Low-level performance improvements

### DIFF
--- a/src/DataStructures/ApplyMatrices.cpp
+++ b/src/DataStructures/ApplyMatrices.cpp
@@ -6,8 +6,9 @@
 #include <array>
 #include <complex>
 #include <cstddef>
-#include <vector>
+#include <memory>
 
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Index.hpp"
 #include "DataStructures/Matrix.hpp"
 #include "DataStructures/Transpose.hpp"
@@ -41,7 +42,8 @@ void do_transpose(const gsl::not_null<double*> result, const double* const data,
 }
 
 struct Scratch {
-  std::vector<double> buffer;
+  // NOLINTNEXTLINE(modernize-avoid-c-arrays)
+  std::unique_ptr<double[]> buffer;
   double* a;
   double* b;
 };
@@ -64,7 +66,8 @@ Scratch get_scratch(const std::array<MatrixType, Dim>& matrices,
     }
   }
   Scratch result{};
-  result.buffer.resize(2 * size);
+  // NOLINTNEXTLINE(modernize-avoid-c-arrays)
+  result.buffer = cpp20::make_unique_for_overwrite<double[]>(2 * size);
   result.a = &result.buffer[0];
   result.b = &result.buffer[size];
   return result;

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -556,8 +556,11 @@ template <>
 class Variables<tmpl::list<>> {
  public:
   using tags_list = tmpl::list<>;
+  static constexpr size_t number_of_independent_components = 0;
   Variables() = default;
-  explicit Variables(const size_t /*number_of_grid_points*/){};
+  explicit Variables(const size_t /*number_of_grid_points*/) {}
+  template <typename T>
+  Variables(const T* /*pointer*/, const size_t /*size*/) {}
   static constexpr size_t size() { return 0; }
 };
 

--- a/src/Evolution/DiscontinuousGalerkin/Actions/VolumeTermsImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/VolumeTermsImpl.hpp
@@ -12,6 +12,7 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "DataStructures/Variables.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Utilities/Gsl.hpp"
@@ -74,6 +75,10 @@ void volume_terms(
     [[maybe_unused]] const gsl::not_null<
         Variables<tmpl::list<TemporaryTags...>>*>
         temporaries,
+    [[maybe_unused]] const gsl::not_null<
+        Variables<tmpl::list<::Tags::div<::Tags::Flux<
+            FluxVariablesTags, tmpl::size_t<Dim>, Frame::Inertial>>...>>*>
+        div_fluxes,
     const Variables<tmpl::list<VariablesTags...>>& evolved_vars,
     const ::dg::Formulation dg_formulation, const Mesh<Dim>& mesh,
     [[maybe_unused]] const tnsr::I<DataVector, Dim, Frame::Inertial>&

--- a/src/Evolution/Executables/NewtonianEuler/VolumeTermsInstantiation.cpp
+++ b/src/Evolution/Executables/NewtonianEuler/VolumeTermsInstantiation.cpp
@@ -38,6 +38,12 @@ namespace evolution::dg::Actions::detail {
       const gsl::not_null<Variables<typename SYSTEM(                          \
           data)::compute_volume_time_derivative_terms::temporary_tags>*>      \
           temporaries,                                                        \
+      const gsl::not_null<Variables<db::wrap_tags_in<                         \
+          ::Tags::div,                                                        \
+          db::wrap_tags_in<::Tags::Flux,                                      \
+                           typename SYSTEM(data)::flux_variables,             \
+                           tmpl::size_t<DIM(data)>, Frame::Inertial>>>*>      \
+          div_fluxes,                                                         \
       const Variables<typename SYSTEM(data)::variables_tag::tags_list>&       \
           evolved_vars,                                                       \
       const ::dg::Formulation dg_formulation, const Mesh<DIM(data)>& mesh,    \
@@ -90,6 +96,12 @@ template void volume_terms<::NewtonianEuler::TimeDerivativeTerms<
         Variables<isentropic_vortex_3d_system::
                       compute_volume_time_derivative_terms::temporary_tags>*>
         temporaries,
+    const gsl::not_null<Variables<db::wrap_tags_in<
+        ::Tags::div,
+        db::wrap_tags_in<::Tags::Flux,
+                         isentropic_vortex_3d_system::flux_variables,
+                         tmpl::size_t<3>, Frame::Inertial>>>*>
+        div_fluxes,
     const Variables<isentropic_vortex_3d_system::variables_tag::tags_list>&
         evolved_vars,
     const ::dg::Formulation dg_formulation, const Mesh<3>& mesh,
@@ -129,6 +141,12 @@ template void volume_terms<::NewtonianEuler::TimeDerivativeTerms<
         Variables<typename lane_emden_star_system::
                       compute_volume_time_derivative_terms::temporary_tags>*>
         temporaries,
+    const gsl::not_null<Variables<db::wrap_tags_in<
+        ::Tags::div,
+        db::wrap_tags_in<::Tags::Flux,
+                         typename lane_emden_star_system::flux_variables,
+                         tmpl::size_t<3>, Frame::Inertial>>>*>
+        div_fluxes,
     const Variables<typename lane_emden_star_system::variables_tag::tags_list>&
         evolved_vars,
     const ::dg::Formulation dg_formulation, const Mesh<3>& mesh,

--- a/src/Evolution/Systems/Burgers/VolumeTermsInstantiation.cpp
+++ b/src/Evolution/Systems/Burgers/VolumeTermsInstantiation.cpp
@@ -24,6 +24,12 @@ template void volume_terms<::Burgers::TimeDerivativeTerms>(
         Variables<typename ::Burgers::System::
                       compute_volume_time_derivative_terms::temporary_tags>*>
         temporaries,
+    const gsl::not_null<Variables<db::wrap_tags_in<
+        ::Tags::div,
+        db::wrap_tags_in<::Tags::Flux,
+                         typename ::Burgers::System::flux_variables,
+                         tmpl::size_t<1>, Frame::Inertial>>>*>
+        div_fluxes,
     const Variables<typename ::Burgers::System::variables_tag::tags_list>&
         evolved_vars,
     const ::dg::Formulation dg_formulation, const Mesh<1>& mesh,

--- a/src/Evolution/Systems/CurvedScalarWave/VolumeTermsInstantiation.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/VolumeTermsInstantiation.cpp
@@ -30,6 +30,13 @@ namespace evolution::dg::Actions::detail {
       const gsl::not_null<Variables<typename ::CurvedScalarWave::System<DIM(  \
           data)>::compute_volume_time_derivative_terms::temporary_tags>*>     \
           temporaries,                                                        \
+      const gsl::not_null<Variables<db::wrap_tags_in<                         \
+          ::Tags::div,                                                        \
+          db::wrap_tags_in<                                                   \
+              ::Tags::Flux,                                                   \
+              typename ::CurvedScalarWave::System<DIM(data)>::flux_variables, \
+              tmpl::size_t<DIM(data)>, Frame::Inertial>>>*>                   \
+          div_fluxes,                                                         \
       const Variables<typename ::CurvedScalarWave::System<DIM(                \
           data)>::variables_tag::tags_list>& evolved_vars,                    \
       const ::dg::Formulation dg_formulation, const Mesh<DIM(data)>& mesh,    \

--- a/src/Evolution/Systems/GeneralizedHarmonic/VolumeTermsInstantiation.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/VolumeTermsInstantiation.cpp
@@ -32,6 +32,13 @@ namespace evolution::dg::Actions::detail {
       const gsl::not_null<Variables<typename ::GeneralizedHarmonic::System<   \
           DIM(data)>::compute_volume_time_derivative_terms::temporary_tags>*> \
           temporaries,                                                        \
+      const gsl::not_null<Variables<db::wrap_tags_in<                         \
+          ::Tags::div,                                                        \
+          db::wrap_tags_in<::Tags::Flux,                                      \
+                           typename ::GeneralizedHarmonic::System<DIM(        \
+                               data)>::flux_variables,                        \
+                           tmpl::size_t<DIM(data)>, Frame::Inertial>>>*>      \
+          div_fluxes,                                                         \
       const Variables<typename ::GeneralizedHarmonic::System<DIM(             \
           data)>::variables_tag::tags_list>& evolved_vars,                    \
       const ::dg::Formulation dg_formulation, const Mesh<DIM(data)>& mesh,    \

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/VolumeTermsInstantiation.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/VolumeTermsInstantiation.cpp
@@ -27,6 +27,12 @@ template void volume_terms<::grmhd::GhValenciaDivClean::TimeDerivativeTerms>(
         Variables<typename ::grmhd::GhValenciaDivClean::System::
                       compute_volume_time_derivative_terms::temporary_tags>*>
         temporaries,
+    const gsl::not_null<Variables<db::wrap_tags_in<
+        ::Tags::div, db::wrap_tags_in<::Tags::Flux,
+                                      typename ::grmhd::GhValenciaDivClean::
+                                          System::flux_variables,
+                                      tmpl::size_t<3>, Frame::Inertial>>>*>
+        div_fluxes,
     const Variables<
         typename ::grmhd::GhValenciaDivClean::System::variables_tag::tags_list>&
         evolved_vars,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/VolumeTermsInstantiation.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/VolumeTermsInstantiation.cpp
@@ -27,6 +27,12 @@ template void volume_terms<::grmhd::ValenciaDivClean::TimeDerivativeTerms>(
         Variables<typename ::grmhd::ValenciaDivClean::System::
                       compute_volume_time_derivative_terms::temporary_tags>*>
         temporaries,
+    [[maybe_unused]] const gsl::not_null<Variables<db::wrap_tags_in<
+        ::Tags::div, db::wrap_tags_in<::Tags::Flux,
+                                      typename ::grmhd::ValenciaDivClean::
+                                          System::flux_variables,
+                                      tmpl::size_t<3>, Frame::Inertial>>>*>
+        div_fluxes,
     const Variables<
         typename ::grmhd::ValenciaDivClean::System::variables_tag::tags_list>&
         evolved_vars,

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/VolumeTermsInstantiation.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/VolumeTermsInstantiation.cpp
@@ -29,6 +29,12 @@ namespace evolution::dg::Actions::detail {
       const gsl::not_null<Variables<typename SYSTEM(                           \
           data)::compute_volume_time_derivative_terms::temporary_tags>*>       \
           temporaries,                                                         \
+      const gsl::not_null<Variables<db::wrap_tags_in<                          \
+          ::Tags::div,                                                         \
+          db::wrap_tags_in<::Tags::Flux,                                       \
+                           typename SYSTEM(data)::flux_variables,              \
+                           tmpl::size_t<DIM(data)>, Frame::Inertial>>>*>       \
+          div_fluxes,                                                          \
       const Variables<typename SYSTEM(data)::variables_tag::tags_list>&        \
           evolved_vars,                                                        \
       const ::dg::Formulation dg_formulation, const Mesh<DIM(data)>& mesh,     \

--- a/src/Evolution/Systems/ScalarAdvection/VolumeTermsInstantiation.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/VolumeTermsInstantiation.cpp
@@ -31,6 +31,13 @@ namespace evolution::dg::Actions::detail {
       const gsl::not_null<Variables<typename ::ScalarAdvection::System<DIM(   \
           data)>::compute_volume_time_derivative_terms::temporary_tags>*>     \
           temporaries,                                                        \
+      const gsl::not_null<Variables<db::wrap_tags_in<                         \
+          ::Tags::div,                                                        \
+          db::wrap_tags_in<                                                   \
+              ::Tags::Flux,                                                   \
+              typename ::ScalarAdvection::System<DIM(data)>::flux_variables,  \
+              tmpl::size_t<DIM(data)>, Frame::Inertial>>>*>                   \
+          div_fluxes,                                                         \
       const Variables<typename ::ScalarAdvection::System<DIM(                 \
           data)>::variables_tag::tags_list>& evolved_vars,                    \
       const ::dg::Formulation dg_formulation, const Mesh<DIM(data)>& mesh,    \

--- a/src/Evolution/Systems/ScalarWave/VolumeTermsInstantiation.cpp
+++ b/src/Evolution/Systems/ScalarWave/VolumeTermsInstantiation.cpp
@@ -30,6 +30,13 @@ namespace evolution::dg::Actions::detail {
       const gsl::not_null<Variables<typename ::ScalarWave::System<DIM(        \
           data)>::compute_volume_time_derivative_terms::temporary_tags>*>     \
           temporaries,                                                        \
+      const gsl::not_null<Variables<db::wrap_tags_in<                         \
+          ::Tags::div,                                                        \
+          db::wrap_tags_in<                                                   \
+              ::Tags::Flux,                                                   \
+              typename ::ScalarWave::System<DIM(data)>::flux_variables,       \
+              tmpl::size_t<DIM(data)>, Frame::Inertial>>>*>                   \
+          div_fluxes,                                                         \
       const Variables<typename ::ScalarWave::System<DIM(                      \
           data)>::variables_tag::tags_list>& evolved_vars,                    \
       const ::dg::Formulation dg_formulation, const Mesh<DIM(data)>& mesh,    \


### PR DESCRIPTION
## Proposed changes

Mostly just combining allocations and avoiding the use of `std::vector` since that zeros the data as opposed to just allocating it.

The biggest bottleneck is our use of parameter marshalling and not inlining entry methods (we can re-enable this now). We should also switch to Charm++ messages. I've been thinking about this a bit and have some scratch code. Charm++ messages will allow us to elide all memory copies and allocations for any elements within a node, at the expense of some manual memory management. It's a bit tough to estimate how much of an improvement we will get, because removing some allocations and copies that showed up at 0.1% overhead in HPCToolkit actually reduced runtime by 5% or more.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
