### PR TITLE
Add orient functions for DataVectors

### DIFF
--- a/src/Domain/Structure/OrientationMap.hpp
+++ b/src/Domain/Structure/OrientationMap.hpp
@@ -38,6 +38,8 @@ class OrientationMap {
   /// The default orientation is the identity map on directions.
   /// The bool `is_aligned_` is correspondingly set to `true`.
   OrientationMap();
+  /// Mapped directions relative to the positive (`Side::Upper`) direction in
+  /// each logical direction.
   explicit OrientationMap(
       std::array<Direction<VolumeDim>, VolumeDim> mapped_directions);
   OrientationMap(


### PR DESCRIPTION
## Proposed changes

- Add `DataVector` orient overloads and have the existing ones call that implementation. This makes it easier to orient views (non-owning DataVectors), allowing for eliding memcpy and allocs.
- Document `OrientationMap` constructor

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
