### PR TITLE
Disable HDF5 default initialize datasets

### DIFF
--- a/src/IO/H5/Helpers.cpp
+++ b/src/IO/H5/Helpers.cpp
@@ -182,6 +182,10 @@ void write_data(const hid_t group_id, const std::vector<T>& data,
              "Failed to enable gzip filter on dataset " << name);
     CHECK_H5(H5Pset_chunk(property_list, chunk_size.size(), chunk_size.data()),
              "Failed to set chunk size on dataset " << name);
+    CHECK_H5(H5Pset_fill_time(property_list, H5D_FILL_TIME_NEVER),
+             "Failed to disable setting default values on dataset creation for "
+             "dataset "
+                 << name);
   }
 
   const hid_t dataset_id =
@@ -799,6 +803,10 @@ hid_t create_extensible_dataset(const hid_t group_id, const std::string& name,
   CHECK_H5(property_list, "Failed to create property list");
   CHECK_H5(H5Pset_chunk(property_list, Dims, chunk_size.data()),
            "Failed to set chunk size");
+  CHECK_H5(H5Pset_fill_time(property_list, H5D_FILL_TIME_NEVER),
+           "Failed to disable setting default values on dataset creation for "
+           "dataset "
+               << name);
 
   const hid_t dataset_id =
       H5Dcreate2(group_id, name.c_str(), h5_type<double>(), dataspace_id,


### PR DESCRIPTION
## Proposed changes

We should generally be initializing the datasets with our data. This avoids a
complete write to all data from zeroing it out.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
