### PR TITLE
Make all TimeStepper methods add to their results

### DIFF
--- a/src/Evolution/DgSubcell/Actions/Initialize.hpp
+++ b/src/Evolution/DgSubcell/Actions/Initialize.hpp
@@ -29,6 +29,7 @@
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Parallel/AlgorithmExecution.hpp"
 #include "Parallel/GlobalCache.hpp"
+#include "Time/Tags.hpp"
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -94,6 +95,7 @@ struct Initialize {
 
   using simple_tags =
       tmpl::list<Tags::Mesh<Dim>, Tags::ActiveGrid, Tags::DidRollback,
+                 ::Tags::RollbackValue<typename System::variables_tag>,
                  Tags::TciGridHistory, Tags::NeighborDataForReconstruction<Dim>,
                  Tags::TciStatus, Tags::DataForRdmpTci,
                  fd::Tags::InverseJacobianLogicalToGrid<Dim>,

--- a/src/Evolution/DgSubcell/Actions/TciAndRollback.hpp
+++ b/src/Evolution/DgSubcell/Actions/TciAndRollback.hpp
@@ -139,25 +139,25 @@ struct TciAndRollback {
               const auto active_vars_ptr, const auto active_history_ptr,
               const gsl::not_null<ActiveGrid*> active_grid_ptr,
               const gsl::not_null<bool*> did_rollback_ptr,
-              const gsl::not_null<Scalar<DataVector>*> tci_status_ptr) {
+              const gsl::not_null<Scalar<DataVector>*> tci_status_ptr,
+              const typename variables_tag::type& rollback_value) {
             ASSERT(
                 active_history_ptr->size() > 0,
                 "We cannot have an empty history when unwinding, that's just "
                 "nutty. Did you call the action too early in the action "
                 "list?");
-            // Rollback u^{n+1}* to u^n (undoing the candidate solution) by
-            // using the time stepper history.
+            // Rollback u^{n+1}* to u^n (undoing the candidate solution).
             //
             // Note: strictly speaking, to be conservative this should project
             // uJ instead of u.
             *active_vars_ptr =
-                fd::project(active_history_ptr->most_recent_value(), dg_mesh,
-                            subcell_mesh.extents());
+                fd::project(rollback_value, dg_mesh, subcell_mesh.extents());
 
             // Project the time stepper history to the subcells, excluding the
             // most recent inadmissible history.
-            TimeSteppers::History<typename variables_tag::type> subcell_history{
-                active_history_ptr->integration_order()};
+            TimeSteppers::History<
+                typename db::add_tag_prefix<::Tags::dt, variables_tag>::type>
+                subcell_history{active_history_ptr->integration_order()};
             const auto end_it =
                 std::prev(active_history_ptr->derivatives_end());
             for (auto it = active_history_ptr->derivatives_begin();
@@ -178,7 +178,8 @@ struct TciAndRollback {
             destructive_resize_components(tci_status_ptr,
                                           subcell_mesh.number_of_grid_points());
             get(*tci_status_ptr) = static_cast<double>(tci_status);
-          });
+          },
+          db::get<::Tags::RollbackValue<variables_tag>>(box));
 
       if (UNLIKELY(db::get<::Tags::TimeStepId>(box).slab_number() < 0)) {
         // If we are doing self start, then we need to project the initial

--- a/src/Evolution/DgSubcell/Actions/TciAndSwitchToDg.hpp
+++ b/src/Evolution/DgSubcell/Actions/TciAndSwitchToDg.hpp
@@ -248,8 +248,9 @@ struct TciAndSwitchToDg {
 
             // Reconstruct the DG solution for each time in the time stepper
             // history
-            TimeSteppers::History<typename variables_tag::type> dg_history{
-                active_history_ptr->integration_order()};
+            TimeSteppers::History<
+                typename db::add_tag_prefix<::Tags::dt, variables_tag>::type>
+                dg_history{active_history_ptr->integration_order()};
             const auto end_it = active_history_ptr->derivatives_end();
             for (auto it = active_history_ptr->derivatives_begin();
                  it != end_it; ++it) {
@@ -258,10 +259,6 @@ struct TciAndSwitchToDg {
                   fd::reconstruct(*it, dg_mesh, subcell_mesh.extents(),
                                   subcell_options.reconstruction_method()));
             }
-            dg_history.most_recent_value() =
-                fd::reconstruct(active_history_ptr->most_recent_value(),
-                                dg_mesh, subcell_mesh.extents(),
-                                subcell_options.reconstruction_method()),
             *active_history_ptr = std::move(dg_history);
             *active_grid_ptr = ActiveGrid::Dg;
 

--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -172,10 +172,11 @@ struct TimeStepperHistory {
   using error_variables_tag =
       db::add_tag_prefix<::Tags::StepperError, variables_tag>;
 
-  using simple_tags =
-      tmpl::list<dt_variables_tag,
-                 ::Tags::HistoryEvolvedVariables<variables_tag>,
-                 error_variables_tag, ::Tags::StepperErrorUpdated>;
+  using simple_tags = tmpl::flatten<tmpl::list<
+      dt_variables_tag, ::Tags::HistoryEvolvedVariables<variables_tag>,
+      tmpl::conditional_t<Metavariables::local_time_stepping,
+                          ::Tags::RollbackValue<variables_tag>, tmpl::list<>>,
+      error_variables_tag, ::Tags::StepperErrorUpdated>>;
 
   using compute_tags = db::AddComputeTags<>;
 
@@ -206,7 +207,9 @@ struct TimeStepperHistory {
       error_vars = ErrorVars{num_grid_points};
     }
 
-    Initialization::mutate_assign<simple_tags>(
+    Initialization::mutate_assign<tmpl::list<
+        dt_variables_tag, ::Tags::HistoryEvolvedVariables<variables_tag>,
+        error_variables_tag, ::Tags::StepperErrorUpdated>>(
         make_not_null(&box), std::move(dt_vars), std::move(history),
         std::move(error_vars), false);
 

--- a/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
@@ -81,6 +81,8 @@ struct InitializeCharacteristicEvolutionTime {
       ::Tags::Next<::Tags::TimeStep>, ::Tags::Time,
       ::Tags::HistoryEvolvedVariables<EvolvedCoordinatesVariablesTag>,
       ::Tags::HistoryEvolvedVariables<evolved_swsh_variables_tag>,
+      ::Tags::RollbackValue<EvolvedCoordinatesVariablesTag>,
+      ::Tags::RollbackValue<evolved_swsh_variables_tag>,
       ::Tags::StepperErrorUpdated>;
   using compute_tags = tmpl::list<>;
 
@@ -123,7 +125,12 @@ struct InitializeCharacteristicEvolutionTime {
 
     typename ::Tags::HistoryEvolvedVariables<evolved_swsh_variables_tag>::type
         swsh_history(starting_order);
-    Initialization::mutate_assign<simple_tags>(
+    Initialization::mutate_assign<tmpl::list<
+        ::Tags::TimeStepId, ::Tags::Next<::Tags::TimeStepId>, ::Tags::TimeStep,
+        ::Tags::Next<::Tags::TimeStep>, ::Tags::Time,
+        ::Tags::HistoryEvolvedVariables<EvolvedCoordinatesVariablesTag>,
+        ::Tags::HistoryEvolvedVariables<evolved_swsh_variables_tag>,
+        ::Tags::StepperErrorUpdated>>(
         make_not_null(&box), TimeStepId{},
         TimeStepId{true,
                    -static_cast<int64_t>(time_stepper.number_of_past_steps()),

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -107,7 +107,8 @@ struct HistoryEvolvedVariables<> : db::BaseTag {};
 
 template <typename Tag>
 struct HistoryEvolvedVariables : HistoryEvolvedVariables<>, db::SimpleTag {
-  using type = TimeSteppers::History<typename Tag::type>;
+  using type =
+      TimeSteppers::History<typename db::add_tag_prefix<::Tags::dt, Tag>::type>;
 };
 /// \endcond
 
@@ -117,6 +118,13 @@ struct HistoryEvolvedVariables : HistoryEvolvedVariables<>, db::SimpleTag {
 template <typename TagList>
 using get_all_history_tags =
     tmpl::filter<TagList, tt::is_a<::Tags::HistoryEvolvedVariables, tmpl::_1>>;
+
+/// \ingroup TimeGroup
+/// \brief Tag containing a previous value for time step rollback.
+template <typename VariablesTag>
+struct RollbackValue : db::SimpleTag {
+  using type = typename VariablesTag::type;
+};
 
 /// \ingroup DataBoxTagsGroup
 /// \ingroup TimeGroup

--- a/src/Time/TimeSteppers/AdamsBashforthN.cpp
+++ b/src/Time/TimeSteppers/AdamsBashforthN.cpp
@@ -247,6 +247,7 @@ bool AdamsBashforthN::update_u_impl(
       history->end() -
       static_cast<typename decltype(history->end())::difference_type>(
           history->integration_order()));
+  *u_error = *u;
   update_u_common(u, *history, time_step, history->integration_order());
   // the error estimate is only useful once the history has enough elements to
   // do more than one order of step
@@ -282,7 +283,6 @@ void AdamsBashforthN::update_u_common(const gsl::not_null<T*> u,
   const auto coefficients =
       get_coefficients(history_start, history.end(), time_step);
 
-  *u = *history.untyped_most_recent_value();
   auto coefficient = coefficients.rbegin();
   for (auto history_entry = history_start;
        history_entry != history.end();

--- a/src/Time/TimeSteppers/RungeKutta.cpp
+++ b/src/Time/TimeSteppers/RungeKutta.cpp
@@ -142,7 +142,6 @@ void update_u_impl_with_tableau(const gsl::not_null<T*> u,
   ASSERT(number_of_substeps > 1,
          "Implementing Euler's method is not supported by RungeKutta.");
 
-  *u = *history->untyped_most_recent_value();
   if (substep == 0) {
     ASSERT(tableau.substep_coefficients[0].size() == 1,
            "First substep should use one derivative.");
@@ -199,8 +198,6 @@ bool RungeKutta::update_u_impl(const gsl::not_null<T*> u,
   // would require more extensive changes to the action loop.
   if (substep < number_of_substeps) {
     update_u_impl_with_tableau(u, history, time_step, tableau);
-  } else {
-    *u = *history->untyped_most_recent_value();
   }
 
   if (substep < number_of_substeps_for_error - 1) {
@@ -242,7 +239,6 @@ bool RungeKutta::dense_update_u_impl(const gsl::not_null<T*> u,
   if (time == step_end) {
     // Special case necessary for dense output at the initial time,
     // before taking a step.
-    *u = *history.untyped_most_recent_value();
     return true;
   }
   const evolution_less<double> before{step_end > step_start};
@@ -279,7 +275,6 @@ bool RungeKutta::dense_update_u_impl(const gsl::not_null<T*> u,
   ASSERT(tableau.dense_coefficients.size() <= history.size(),
          "Insufficient history for dense output.  Most likely there are too "
          "many coefficient polynomials in the tableau.");
-  *u = *history.untyped_most_recent_value();
   for (size_t i = 0; i < std::max(tableau.dense_coefficients.size(),
                                   tableau.result_coefficients.size());
        ++i) {

--- a/src/Time/TimeSteppers/TimeStepper.hpp
+++ b/src/Time/TimeSteppers/TimeStepper.hpp
@@ -8,6 +8,8 @@
 #include <pup.h>
 #include <type_traits>
 
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/MathWrapper.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "Time/History.hpp"
@@ -85,9 +87,12 @@ class TimeStepper : public PUP::able {
   ///                    const TimeDelta& time_step) const;
   /// ```
   template <typename Vars>
-  void update_u(const gsl::not_null<Vars*> u,
-                const gsl::not_null<TimeSteppers::History<Vars>*> history,
-                const TimeDelta& time_step) const {
+  void update_u(
+      const gsl::not_null<Vars*> u,
+      const gsl::not_null<
+          TimeSteppers::History<db::prefix_variables<::Tags::dt, Vars>>*>
+          history,
+      const TimeDelta& time_step) const {
     return update_u_forward(&*make_math_wrapper(u), &*history, time_step);
   }
 
@@ -109,10 +114,12 @@ class TimeStepper : public PUP::able {
   ///                    const TimeDelta& time_step) const;
   /// ```
   template <typename Vars, typename ErrVars>
-  bool update_u(const gsl::not_null<Vars*> u,
-                const gsl::not_null<ErrVars*> u_error,
-                const gsl::not_null<TimeSteppers::History<Vars>*> history,
-                const TimeDelta& time_step) const {
+  bool update_u(
+      const gsl::not_null<Vars*> u, const gsl::not_null<ErrVars*> u_error,
+      const gsl::not_null<
+          TimeSteppers::History<db::prefix_variables<::Tags::dt, Vars>>*>
+          history,
+      const TimeDelta& time_step) const {
     static_assert(
         std::is_same_v<math_wrapper_type<Vars>, math_wrapper_type<ErrVars>>);
     return update_u_forward(&*make_math_wrapper(u),
@@ -134,9 +141,11 @@ class TimeStepper : public PUP::able {
   ///     const UntypedHistory<T>& history, double time) const;
   /// ```
   template <typename Vars>
-  bool dense_update_u(const gsl::not_null<Vars*> u,
-                      const TimeSteppers::History<Vars>& history,
-                      const double time) const {
+  bool dense_update_u(
+      const gsl::not_null<Vars*> u,
+      const TimeSteppers::History<db::prefix_variables<::Tags::dt, Vars>>&
+          history,
+      const double time) const {
     return dense_update_u_forward(&*make_math_wrapper(u), history, time);
   }
 
@@ -185,9 +194,10 @@ class TimeStepper : public PUP::able {
   /// bool can_change_step_size_impl(const TimeStepId& time_id,
   ///                                const UntypedHistory<T>& history) const;
   /// ```
-  template <typename Vars>
-  bool can_change_step_size(const TimeStepId& time_id,
-                            const TimeSteppers::History<Vars>& history) const {
+  template <typename DerivVars>
+  bool can_change_step_size(
+      const TimeStepId& time_id,
+      const TimeSteppers::History<DerivVars>& history) const {
     return can_change_step_size_forward(time_id, history);
   }
 };

--- a/tests/Unit/Evolution/Actions/Test_RunEventsAndDenseTriggers.cpp
+++ b/tests/Unit/Evolution/Actions/Test_RunEventsAndDenseTriggers.cpp
@@ -306,7 +306,7 @@ void test(const bool time_runs_forward) {
   using VarsType = typename variables_tag::type;
   using DtVarsType =
       typename db::add_tag_prefix<::Tags::dt, variables_tag>::type;
-  using History = TimeSteppers::History<VarsType>;
+  using History = TimeSteppers::History<DtVarsType>;
 
   const Slab slab(0.0, 4.0);
   const TimeStepId time_step_id(time_runs_forward, 0,
@@ -331,7 +331,6 @@ void test(const bool time_runs_forward) {
               triggers) {
         History history(1);
         history.insert(time_step_id, deriv_vars);
-        history.most_recent_value() = initial_vars;
 
         evolution::EventsAndDenseTriggers::ConstructionType
             events_and_dense_triggers{};

--- a/tests/Unit/Helpers/Time/TimeSteppers/TimeStepperTestUtils.hpp
+++ b/tests/Unit/Helpers/Time/TimeSteppers/TimeStepperTestUtils.hpp
@@ -25,7 +25,7 @@ void check_substep_properties(const TimeStepper& stepper);
 
 void integrate_test(const TimeStepper& stepper, size_t order,
                     size_t number_of_past_steps, double integration_time,
-                    double epsilon, bool test_apply_twice = false);
+                    double epsilon);
 
 void integrate_test_explicit_time_dependence(const TimeStepper& stepper,
                                              size_t order,
@@ -38,8 +38,8 @@ void integrate_variable_test(const TimeStepper& stepper, size_t order,
 
 void integrate_error_test(const TimeStepper& stepper, size_t order,
                           size_t number_of_past_steps, double integration_time,
-                          double epsilon, size_t num_steps, double error_factor,
-                          bool test_apply_twice = false);
+                          double epsilon, size_t num_steps,
+                          double error_factor);
 
 template <typename F1, typename F2, typename EvolvedType>
 void initialize_history(
@@ -61,9 +61,6 @@ void initialize_history(
     history->insert_initial(
         TimeStepId(step_size.is_positive(), slab_number, time),
         rhs(analytic(time.value()), time.value()));
-    if (j == 0) {
-      history->most_recent_value() = analytic(time.value());
-    }
   }
 }
 

--- a/tests/Unit/Time/Actions/Test_UpdateU.cpp
+++ b/tests/Unit/Time/Actions/Test_UpdateU.cpp
@@ -140,7 +140,6 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.UpdateU", "[Unit][Time][Actions]") {
           const Time& time = gsl::at(substep_times, substep);
           history->insert(TimeStepId(true, 0, substep_times[0], substep, time),
                           rhs(time.value(), vars));
-          history->most_recent_value() = vars;
         },
         db::get<variables_tag>(before_box));
 
@@ -157,7 +156,6 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.UpdateU", "[Unit][Time][Actions]") {
           alternative_history->insert(
               TimeStepId(true, 0, substep_times[0], substep, time),
               rhs(time.value(), alternative_vars));
-          alternative_history->most_recent_value() = alternative_vars;
         },
         db::get<alternative_variables_tag>(alternative_before_box));
 

--- a/tests/Unit/Time/Test_History.cpp
+++ b/tests/Unit/Time/Test_History.cpp
@@ -16,8 +16,6 @@
 
 namespace {
 
-constexpr double test_most_recent_value = 1234.56;
-
 Time make_time(const double t) { return Slab(t, t + 0.5).start(); }
 
 TimeStepId make_time_id(const double t) {
@@ -97,8 +95,6 @@ void check_history_state(const HistoryType& hist) {
 
   CHECK(hist.front() == hist[0]);
   CHECK(hist.back() == hist[3]);
-
-  CHECK(hist.most_recent_value() == test_most_recent_value);
 }
 }  // namespace
 
@@ -109,8 +105,6 @@ SPECTRE_TEST_CASE("Unit.Time.History", "[Unit][Time]") {
   CHECK(std::as_const(history).integration_order() == 3);
   history.integration_order(2);
   CHECK(history.integration_order() == 2);
-
-  history.most_recent_value() = test_most_recent_value;
 
   CHECK(history.size() == 0);
   CHECK(history.capacity() == 0);

--- a/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
@@ -38,7 +38,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN", "[Unit][Time]") {
       CAPTURE(start_points);
       const double epsilon = std::max(std::pow(1e-3, start_points + 1), 1e-14);
       TimeStepperTestUtils::integrate_test(stepper, start_points + 1,
-                                           start_points, 1., epsilon, true);
+                                           start_points, 1., epsilon);
       TimeStepperTestUtils::integrate_test_explicit_time_dependence(
           stepper, start_points + 1, start_points, 1., epsilon);
 
@@ -122,7 +122,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN.Backwards",
       const double epsilon = std::max(std::pow(1e-3, start_points + 1), 1e-14);
       TimeStepperTestUtils::integrate_test(
           TimeSteppers::AdamsBashforthN(order), start_points + 1, start_points,
-          -1., epsilon, true);
+          -1., epsilon);
       TimeStepperTestUtils::integrate_test_explicit_time_dependence(
           TimeSteppers::AdamsBashforthN(order), start_points + 1, start_points,
           -1., epsilon);
@@ -398,9 +398,8 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN.Reversal",
 
   const Slab slab(0., 1.);
   TimeSteppers::History<double> history{3};
-  const auto add_history = [&df, &f, &history](const Time& time) {
+  const auto add_history = [&df, &history](const Time& time) {
     history.insert(TimeStepId(true, 0, time), df(time.value()));
-    history.most_recent_value() = f(time.value());
   };
   add_history(slab.start());
   add_history(slab.end());


### PR DESCRIPTION
This makes the interface more consistent and removes the value from the History object that was almost always the same as the evolved variables.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
