### PR TITLE
Change default InitializeJ in input file for CharacteristicExtract

### DIFF
--- a/docs/Tutorials/CCE.md
+++ b/docs/Tutorials/CCE.md
@@ -28,20 +28,17 @@ CCE using external data are:
     don't need the extra points, best just set it to 1.
   - If you're extracting at 100M or less, best to reduce the `TargetStepSize`,
     to around .5 at 100M and lower yet for nearer extraction.
-  - The `InitializeJ` in the example file uses `InverseCubic` which is a pretty
-    primitive scheme, but early tests indicate that it gives the best results
-    for most systems.
-    If initial data is a concern, you can also try replacing the `InverseCubic`
-    entry with:
-  ```
-    NoIncomingRadiation:
-      AngularCoordTolerance: 1.0e-13
-      MaxIterations: 500
-      RequireConvergence: true
-  ```
-  which are probably pretty good choices for those parameters,
-  and the `RequireConvergence: true` will cause the iterative solve in
-  this version to error out if it doesn't find a good frame.
+  - The `InitializeJ` in the example file uses `ConformalFactor` which has been
+    found to perform better than the other schemes implemented so far.
+    Other schemes for `InitializeJ` can be found in namespace
+    \link Cce::InitializeJ \endlink.  Some of these are:
+    - `ZeroNonSmooth`: Make `J` vanish
+    - `NoIncomingRadiation`: Make \f$\Psi_0 = 0\f$; this does not actually lead
+      to no incoming radiation, since \f$\Psi_0\f$ and \f$\Psi_4\f$ both include
+      incoming and outgoing radiation.
+    - `InverseCubic`: Ansatz where \f$J = A/r + B/r^3\f$
+    - `ConformalFactor`: Try to make initial time coordinate as inertial as
+      possible at \f$\mathscr{I}^+\f$.
 
 - An example of an appropriate submission command for slurm systems is:
   ```

--- a/tests/InputFiles/Cce/CharacteristicExtract.yaml
+++ b/tests/InputFiles/Cce/CharacteristicExtract.yaml
@@ -50,7 +50,15 @@ Cce:
   ObservationLMax: 8
 
   InitializeJ:
-    InverseCubic
+    ConformalFactor:
+      AngularCoordTolerance: 1e-13
+      MaxIterations: 1000
+      RequireConvergence: False
+      OptimizeL0Mode: True
+      UseBetaIntegralEstimate: False
+      ConformalFactorIterationHeuristic: SpinWeight1CoordPerturbation
+      UseInputModes: False
+      InputModes: []
 
   StartTime: 0.0
   EndTime: 1000.0


### PR DESCRIPTION
## Proposed changes

Keefe and Jordan found that the `ConformalFactor` method for `InitializeJ` works best.

Here we update the input file in `tests/InputFiles/Cce/CharacteristicExtract.yaml` to reflect good default settings for `InitializeJ`.

This PR partially addresses #4209.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
