### PR TITLE
Assign integer values to TCI status in ValenciaDivClean subcell

### DIFF
--- a/src/Evolution/DgSubcell/Actions/Initialize.hpp
+++ b/src/Evolution/DgSubcell/Actions/Initialize.hpp
@@ -161,7 +161,7 @@ struct Initialize {
           // Now check if the DG solution is admissible. We call the TCI even if
           // the cell is at the boundary since the TCI must also set the past
           // RDMP data.
-          std::tuple<bool, RdmpTciData> tci_result = TciMutator::apply(
+          std::tuple<int, RdmpTciData> tci_result = TciMutator::apply(
               *active_vars_ptr, subcell_options.initial_data_rdmp_delta0(),
               subcell_options.initial_data_rdmp_epsilon(),
               subcell_options.initial_data_persson_exponent(), args_for_tci...);

--- a/src/Evolution/DgSubcell/Actions/TciAndSwitchToDg.hpp
+++ b/src/Evolution/DgSubcell/Actions/TciAndSwitchToDg.hpp
@@ -190,6 +190,16 @@ struct TciAndSwitchToDg {
                                      subcell_options.persson_exponent() + 1.0);
     const int tci_status = std::get<0>(tci_result);
     const bool cell_is_troubled = static_cast<bool>(tci_status);
+
+    if (cell_is_troubled) {
+      db::mutate<Tags::TciStatus>(
+          make_not_null(&box),
+          [&tci_status](
+              const gsl::not_null<Scalar<DataVector>*> tci_status_ptr) {
+            get(*tci_status_ptr) = static_cast<double>(tci_status);
+          });
+    }
+
     db::mutate<evolution::dg::subcell::Tags::DataForRdmpTci>(
         make_not_null(&box), [&tci_result](const auto rdmp_data_ptr) {
           *rdmp_data_ptr = std::move(std::get<1>(std::move(tci_result)));

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/InitialDataTci.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/InitialDataTci.cpp
@@ -17,7 +17,7 @@
 
 namespace grmhd::ValenciaDivClean::subcell {
 namespace detail {
-std::tuple<bool, evolution::dg::subcell::RdmpTciData> initial_data_tci_work(
+std::tuple<int, evolution::dg::subcell::RdmpTciData> initial_data_tci_work(
     const Scalar<DataVector>& dg_tilde_d,
     const Scalar<DataVector>& dg_tilde_tau,
     const Scalar<DataVector>& dg_tilde_b_magnitude,
@@ -38,26 +38,28 @@ std::tuple<bool, evolution::dg::subcell::RdmpTciData> initial_data_tci_work(
       min(min(get(dg_tilde_tau)), min(get(subcell_tilde_tau))),
       min(min(get(dg_tilde_b_magnitude)), min(get(subcell_tilde_b_magnitude)))};
 
-  return {min(get(dg_tilde_d)) <
-                  tci_options.minimum_rest_mass_density_times_lorentz_factor or
-              min(get(subcell_tilde_d)) <
-                  tci_options.minimum_rest_mass_density_times_lorentz_factor or
-              min(get(dg_tilde_tau)) < tci_options.minimum_tilde_tau or
-              min(get(subcell_tilde_tau)) < tci_options.minimum_tilde_tau or
-              evolution::dg::subcell::persson_tci(dg_tilde_d, dg_mesh,
-                                                  persson_exponent) or
-              evolution::dg::subcell::persson_tci(dg_tilde_tau, dg_mesh,
-                                                  persson_exponent) or
-              (tci_options.magnetic_field_cutoff.has_value() and
-               max(get(dg_tilde_b_magnitude)) >
-                   tci_options.magnetic_field_cutoff.value() and
-               evolution::dg::subcell::persson_tci(dg_tilde_b_magnitude,
-                                                   dg_mesh, persson_exponent)),
-          std::move(rdmp_tci_data)};
+  const bool cell_troubled =
+      min(get(dg_tilde_d)) <
+          tci_options.minimum_rest_mass_density_times_lorentz_factor or
+      min(get(subcell_tilde_d)) <
+          tci_options.minimum_rest_mass_density_times_lorentz_factor or
+      min(get(dg_tilde_tau)) < tci_options.minimum_tilde_tau or
+      min(get(subcell_tilde_tau)) < tci_options.minimum_tilde_tau or
+      evolution::dg::subcell::persson_tci(dg_tilde_d, dg_mesh,
+                                          persson_exponent) or
+      evolution::dg::subcell::persson_tci(dg_tilde_tau, dg_mesh,
+                                          persson_exponent) or
+      (tci_options.magnetic_field_cutoff.has_value() and
+       max(get(dg_tilde_b_magnitude)) >
+           tci_options.magnetic_field_cutoff.value() and
+       evolution::dg::subcell::persson_tci(dg_tilde_b_magnitude, dg_mesh,
+                                           persson_exponent));
+
+  return {static_cast<int>(cell_troubled), std::move(rdmp_tci_data)};
 }
 }  // namespace detail
 
-std::tuple<bool, evolution::dg::subcell::RdmpTciData> DgInitialDataTci::apply(
+std::tuple<int, evolution::dg::subcell::RdmpTciData> DgInitialDataTci::apply(
     const Variables<tmpl::list<
         ValenciaDivClean::Tags::TildeD, ValenciaDivClean::Tags::TildeTau,
         ValenciaDivClean::Tags::TildeS<>, ValenciaDivClean::Tags::TildeB<>,
@@ -78,9 +80,9 @@ std::tuple<bool, evolution::dg::subcell::RdmpTciData> DgInitialDataTci::apply(
       get<ValenciaDivClean::Tags::TildeD>(subcell_vars),
       get<ValenciaDivClean::Tags::TildeTau>(subcell_vars),
       subcell_tilde_b_magnitude, persson_exponent, dg_mesh, tci_options);
-  return {std::get<0>(result) or
-              evolution::dg::subcell::two_mesh_rdmp_tci(
-                  dg_vars, subcell_vars, rdmp_delta0, rdmp_epsilon),
+  return {static_cast<bool>(std::get<0>(result)) or
+              static_cast<bool>(evolution::dg::subcell::two_mesh_rdmp_tci(
+                  dg_vars, subcell_vars, rdmp_delta0, rdmp_epsilon)),
           std::move(std::get<1>(result))};
 }
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/InitialDataTci.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/InitialDataTci.cpp
@@ -38,24 +38,30 @@ std::tuple<int, evolution::dg::subcell::RdmpTciData> initial_data_tci_work(
       min(min(get(dg_tilde_tau)), min(get(subcell_tilde_tau))),
       min(min(get(dg_tilde_b_magnitude)), min(get(subcell_tilde_b_magnitude)))};
 
-  const bool cell_troubled =
-      min(get(dg_tilde_d)) <
+  if (min(get(dg_tilde_d)) <
           tci_options.minimum_rest_mass_density_times_lorentz_factor or
       min(get(subcell_tilde_d)) <
-          tci_options.minimum_rest_mass_density_times_lorentz_factor or
-      min(get(dg_tilde_tau)) < tci_options.minimum_tilde_tau or
-      min(get(subcell_tilde_tau)) < tci_options.minimum_tilde_tau or
-      evolution::dg::subcell::persson_tci(dg_tilde_d, dg_mesh,
+          tci_options.minimum_rest_mass_density_times_lorentz_factor) {
+    return {-1, std::move(rdmp_tci_data)};
+  }
+  if (min(get(dg_tilde_tau)) < tci_options.minimum_tilde_tau or
+      min(get(subcell_tilde_tau)) < tci_options.minimum_tilde_tau) {
+    return {-2, std::move(rdmp_tci_data)};
+  }
+  if (evolution::dg::subcell::persson_tci(dg_tilde_d, dg_mesh,
                                           persson_exponent) or
       evolution::dg::subcell::persson_tci(dg_tilde_tau, dg_mesh,
-                                          persson_exponent) or
-      (tci_options.magnetic_field_cutoff.has_value() and
-       max(get(dg_tilde_b_magnitude)) >
-           tci_options.magnetic_field_cutoff.value() and
-       evolution::dg::subcell::persson_tci(dg_tilde_b_magnitude, dg_mesh,
-                                           persson_exponent));
-
-  return {static_cast<int>(cell_troubled), std::move(rdmp_tci_data)};
+                                          persson_exponent)) {
+    return {-5, std::move(rdmp_tci_data)};
+  }
+  if (tci_options.magnetic_field_cutoff.has_value() and
+      max(get(dg_tilde_b_magnitude)) >
+          tci_options.magnetic_field_cutoff.value() and
+      evolution::dg::subcell::persson_tci(dg_tilde_b_magnitude, dg_mesh,
+                                          persson_exponent)) {
+    return {-6, std::move(rdmp_tci_data)};
+  }
+  return {0, std::move(rdmp_tci_data)};
 }
 }  // namespace detail
 
@@ -80,10 +86,17 @@ std::tuple<int, evolution::dg::subcell::RdmpTciData> DgInitialDataTci::apply(
       get<ValenciaDivClean::Tags::TildeD>(subcell_vars),
       get<ValenciaDivClean::Tags::TildeTau>(subcell_vars),
       subcell_tilde_b_magnitude, persson_exponent, dg_mesh, tci_options);
-  return {static_cast<bool>(std::get<0>(result)) or
-              static_cast<bool>(evolution::dg::subcell::two_mesh_rdmp_tci(
-                  dg_vars, subcell_vars, rdmp_delta0, rdmp_epsilon)),
-          std::move(std::get<1>(result))};
+
+  const int tci_status = std::get<0>(result);
+
+  if (static_cast<bool>(tci_status)) {
+    return {tci_status, std::move(std::get<1>(result))};
+  }
+  if (static_cast<bool>(evolution::dg::subcell::two_mesh_rdmp_tci(
+          dg_vars, subcell_vars, rdmp_delta0, rdmp_epsilon))) {
+    return {-7, std::move(std::get<1>(result))};
+  }
+  return {0, std::move(std::get<1>(result))};
 }
 
 void SetInitialRdmpData::apply(

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/InitialDataTci.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/InitialDataTci.hpp
@@ -44,14 +44,48 @@ std::tuple<int, evolution::dg::subcell::RdmpTciData> initial_data_tci_work(
  *
  * The following checks are done in the order they are listed:
  *
- * - if `TildeD` (`TildeTau`) on the DG or subcell grid (projected from the DG
- *   grid, not initialized to the initial data) is less than
- *   `tci_options.minimum_rest_mass_density_times_lorentz_factor`
- *   (`tci_options.minimum_tilde_tau`), then the element is flagged as troubled.
- * - apply the Persson TCI to \f$\tilde{D}\f$ and \f$\tilde{\tau}\f$.
- * - apply the Persson TCI to the magnitude of \f$\tilde{B}\f$ if its magnitude
- *   on the DG grid is greater than `tci_options.magnetic_field_cutoff`.
- * - apply the two-mesh relaxed discrete maximum principle TCI
+ * <table>
+ * <caption>List of checks</caption>
+ * <tr><th> Description <th> TCI status
+ *
+ * <tr><td> if `TildeD` on the DG or subcell grid (projected from the DG grid,
+ * not initialized to the initial data) is less than
+ * `tci_options.minimum_rest_mass_density_times_lorentz_factor` then the element
+ * is flagged as troubled.
+ * <td> `-1`
+ *
+ * <tr><td> if `TildeTau` on the DG or subcell grid (projected from
+ * the DG grid, not initialized to the initial data) is less than
+ * `tci_options.minimum_tilde_tau` then the element is flagged as troubled
+ * <td> `-2`
+ *
+ * <tr><td> apply the Persson TCI to \f$\tilde{D}\f$ and \f$\tilde{\tau}\f$.
+ * <td> `-5`
+ *
+ * <tr><td> apply the Persson TCI to the magnitude of \f$\tilde{B}\f$ if its
+ * magnitude on the DG grid is greater than `tci_options.magnetic_field_cutoff`.
+ * <td> `-6`
+ *
+ * <tr><td>
+ * apply the two-mesh relaxed discrete maximum principle TCI to `TildeD`,
+ * `TildeTau`, `TildeS`, `TildeB`, and `TildePhi`
+ * <td> `-7`
+ *
+ * </table>
+ *
+ * The second column of the table above denotes the value of an integer stored
+ * as the first element of the returned `std::tuple`, which indicates the
+ * particular kind of check that failed. For example, if the third check
+ * (Persson TCI to TildeD and TildeTau) fails and cell is marked as troubled,
+ * an integer with value `-5` is stored in the first slot of the returned tuple.
+ * Note that this integer is marking only the _first_ check to fail, since
+ * checks are done in a particular sequence as listed above. If all checks are
+ * passed and cell is not troubled, it is returned with the value `0`.
+ *
+ * Somewhat seemingly irregular prescription of TCI status values is due to
+ * matching those with TciOnDgGrid as much as possible (see the documentation of
+ * TciOnDgGrid).
+ *
  */
 struct DgInitialDataTci {
   using argument_tags =

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/InitialDataTci.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/InitialDataTci.hpp
@@ -27,7 +27,7 @@ class Variables;
 
 namespace grmhd::ValenciaDivClean::subcell {
 namespace detail {
-std::tuple<bool, evolution::dg::subcell::RdmpTciData> initial_data_tci_work(
+std::tuple<int, evolution::dg::subcell::RdmpTciData> initial_data_tci_work(
     const Scalar<DataVector>& dg_tilde_d,
     const Scalar<DataVector>& dg_tilde_tau,
     const Scalar<DataVector>& dg_tilde_b_magnitude,
@@ -58,7 +58,7 @@ struct DgInitialDataTci {
       tmpl::list<domain::Tags::Mesh<3>, evolution::dg::subcell::Tags::Mesh<3>,
                  Tags::TciOptions>;
 
-  static std::tuple<bool, evolution::dg::subcell::RdmpTciData> apply(
+  static std::tuple<int, evolution::dg::subcell::RdmpTciData> apply(
       const Variables<tmpl::list<
           ValenciaDivClean::Tags::TildeD, ValenciaDivClean::Tags::TildeTau,
           ValenciaDivClean::Tags::TildeS<>, ValenciaDivClean::Tags::TildeB<>,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.cpp
@@ -30,7 +30,7 @@
 namespace grmhd::ValenciaDivClean::subcell {
 template <typename RecoveryScheme>
 template <size_t ThermodynamicDim>
-std::tuple<bool, evolution::dg::subcell::RdmpTciData>
+std::tuple<int, evolution::dg::subcell::RdmpTciData>
 TciOnDgGrid<RecoveryScheme>::apply(
     const gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*> dg_prim_vars,
     const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau,
@@ -226,7 +226,7 @@ GENERATE_INSTANTIATIONS(
 
 #define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define INSTANTIATION(r, data)                                                \
-  template std::tuple<bool, evolution::dg::subcell::RdmpTciData>              \
+  template std::tuple<int, evolution::dg::subcell::RdmpTciData>               \
   TciOnDgGrid<RECOVERY(data)>::apply<THERMO_DIM(data)>(                       \
       const gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*>          \
           dg_prim_vars,                                                       \

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.cpp
@@ -101,13 +101,13 @@ TciOnDgGrid<RecoveryScheme>::apply(
           tci_options.minimum_rest_mass_density_times_lorentz_factor or
       min(get(subcell_tilde_d)) / average_sqrt_det_spatial_metric <
           tci_options.minimum_rest_mass_density_times_lorentz_factor) {
-    return {true, std::move(rdmp_tci_data)};
+    return {-1, std::move(rdmp_tci_data)};
   }
 
   // require: tilde_tau >= 0.0 (or some positive user-specified value)
   if (min(get(tilde_tau)) < tci_options.minimum_tilde_tau or
       min(get(subcell_tilde_tau)) < tci_options.minimum_tilde_tau) {
-    return {true, std::move(rdmp_tci_data)};
+    return {-2, std::move(rdmp_tci_data)};
   }
 
   // Check if we are in atmosphere (but not negative tildeD), and if so, then
@@ -141,7 +141,7 @@ TciOnDgGrid<RecoveryScheme>::apply(
       if (get(tilde_b_squared)[i] >
           (1.0 - tci_options.safety_factor_for_magnetic_field) * 2.0 *
               get(tilde_tau)[i] * get(sqrt_det_spatial_metric)[i]) {
-        return {true, std::move(rdmp_tci_data)};
+        return {-3, std::move(rdmp_tci_data)};
       }
     }
   }
@@ -177,7 +177,7 @@ TciOnDgGrid<RecoveryScheme>::apply(
                   &get<hydro::Tags::SpecificEnthalpy<DataVector>>(temp_prims)),
               tilde_d, tilde_tau, tilde_s, tilde_b, tilde_phi, spatial_metric,
               inv_spatial_metric, sqrt_det_spatial_metric, eos)) {
-    return {true, std::move(rdmp_tci_data)};
+    return {-4, std::move(rdmp_tci_data)};
   }
 
   // Check if we are in atmosphere after recovery. Unlikely we'd hit this and
@@ -192,23 +192,23 @@ TciOnDgGrid<RecoveryScheme>::apply(
   if (evolution::dg::subcell::persson_tci(tilde_d, dg_mesh, persson_exponent) or
       evolution::dg::subcell::persson_tci(tilde_tau, dg_mesh,
                                           persson_exponent)) {
-    return {true, std::move(rdmp_tci_data)};
+    return {-5, std::move(rdmp_tci_data)};
   }
   // Check Cartesian magnitude of magnetic field satisfies the Persson TCI
   if (tci_options.magnetic_field_cutoff.has_value() and
       max_mag_tilde_b > tci_options.magnetic_field_cutoff.value() and
       evolution::dg::subcell::persson_tci(mag_tilde_b, dg_mesh,
                                           persson_exponent)) {
-    return {true, std::move(rdmp_tci_data)};
+    return {-6, std::move(rdmp_tci_data)};
   }
 
-  if (evolution::dg::subcell::rdmp_tci(rdmp_tci_data.max_variables_values,
-                                       rdmp_tci_data.min_variables_values,
-                                       past_rdmp_tci_data.max_variables_values,
-                                       past_rdmp_tci_data.min_variables_values,
-                                       subcell_options.rdmp_delta0(),
-                                       subcell_options.rdmp_epsilon())) {
-    return {true, std::move(rdmp_tci_data)};
+  if (const int rdmp_tci_status = evolution::dg::subcell::rdmp_tci(
+          rdmp_tci_data.max_variables_values,
+          rdmp_tci_data.min_variables_values,
+          past_rdmp_tci_data.max_variables_values,
+          past_rdmp_tci_data.min_variables_values,
+          subcell_options.rdmp_delta0(), subcell_options.rdmp_epsilon())) {
+    return {-(6 + rdmp_tci_status), std::move(rdmp_tci_data)};
   }
 
   *dg_prim_vars = std::move(temp_prims);

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.hpp
@@ -50,32 +50,76 @@ namespace grmhd::ValenciaDivClean::subcell {
  *
  * The following checks are done in the order they are listed:
  *
- * - if \f$\min(\tilde{D}^{n+1}/\textrm{avg}(\sqrt{\gamma^{n}}))\f$ is less than
- *   `tci_options.minimum_rest_mass_density_times_lorentz_factor` then we have a
- *   negative (or extremely small) density and the cell is troubled. Note that
- *   if this `tci_option` is approximately equal to or larger than the
- *   `atmosphere_density`, the atmosphere will be flagged as troubled.
- * - if \f$\tilde{\tau}\f$ is less than `tci_options.minimum_tilde_tau` then we
- *   have a negative (or extremely small) energy and the cell is troubled.
- * - if \f$\max(\tilde{D}^{n+1}/(\sqrt{\gamma^n}W^n))\f$ and \f$\max(\rho^n)\f$
- *   are less than `tci_options.atmosphere_density` then the entire DG element
- *   is in atmosphere and it is _not_ troubled.
- * - if
- *   \f$(\tilde{B}^{n+1})^2>2\sqrt{\gamma^n}(1-\epsilon_B)\tilde{\tau}^{n+1}\f$
- *   at any grid point, then the cell is troubled
- * - attempt a primitive recovery using the `RecoveryScheme` from the template
- *   parameter. The cell is marked as troubled if the primitive recovery fails
- *   at any grid point.
- * - if \f$\max(\rho^{n+1})\f$ is below `tci_options.atmosphere_density` then
- *   the cell is in atmosphere and not marked as troubled. Note that the
- *   magnetic field is still freely evolved.
- * - apply the Persson TCI to \f$\tilde{D}^{n+1}\f$ and \f$\tilde{\tau}^{n+1}\f$
- * - apply the Persson TCI to the magnitude of \f$\tilde{B}^{n+1}\f$ if its
- *   magnitude is greater than `tci_options.magnetic_field_cutoff`.
- * - apply the RDMP TCI to `TildeD`, `TildeTau` and `TildeB`.
+ * <table>
+ * <caption>List of checks</caption>
+ * <tr><th> Description <th> TCI status
+ *
+ * <tr><td> if \f$\min(\tilde{D}^{n+1}/\textrm{avg}(\sqrt{\gamma^{n}}))\f$
+ * is less than `tci_options.minimum_rest_mass_density_times_lorentz_factor`
+ * then we have a negative (or extremely small) density and the cell is
+ * troubled. Note that if this `tci_option` is approximately equal to or larger
+ * than the `atmosphere_density`, the atmosphere will be flagged as troubled.
+ * <td> `-1`
+ *
+ * <tr><td> if \f$\tilde{\tau}\f$ is less than `tci_options.minimum_tilde_tau`
+ * then we have a negative (or extremely small) energy and the cell is troubled.
+ * <td> `-2`
+ *
+ * <tr><td> if \f$\max(\tilde{D}^{n+1}/(\sqrt{\gamma^n}W^n))\f$ and
+ * \f$\max(\rho^n)\f$ are less than `tci_options.atmosphere_density` then the
+ * entire DG element is in atmosphere and it is _not_ troubled.
+ * <td> `0`
+ *
+ * <tr><td> if
+ * \f$(\tilde{B}^{n+1})^2>2\sqrt{\gamma^n}(1-\epsilon_B)\tilde{\tau}^{n+1}\f$ at
+ * any grid point, then the cell is troubled.
+ * <td> `-3`
+ *
+ * <tr><td> attempt a primitive recovery using the `RecoveryScheme` from the
+ * template parameter. The cell is marked as troubled if the primitive recovery
+ * fails at any grid point.
+ * <td> `-4`
+ *
+ * <tr><td> if \f$\max(\rho^{n+1})\f$ is below `tci_options.atmosphere_density`
+ * then the cell is in atmosphere and not marked as troubled. Note that the
+ * magnetic field is still freely evolved.
+ * <td> `0`
+ *
+ * <tr><td> apply the Persson TCI to \f$\tilde{D}^{n+1}\f$ and
+ * \f$\tilde{\tau}^{n+1}\f$
+ * <td> `-5`
+ *
+ * <tr><td> apply the Persson TCI to the magnitude of \f$\tilde{B}^{n+1}\f$ if
+ * its magnitude is greater than `tci_options.magnetic_field_cutoff`
+ * <td> `-6`
+ *
+ * <tr><td> apply the RDMP TCI to `TildeD`
+ * <td> `-7`
+ *
+ * <tr><td> apply the RDMP TCI to `TildeTau`
+ * <td> `-8`
+ *
+ * <tr><td> apply the RDMP TCI to `TildeB`
+ * <td> `-9`
+ *
+ * </table>
  *
  * If the cell is not flagged as troubled then the primitives are computed at
  * time level `n+1`.
+ *
+ * The second column of the table above denotes the value of an integer stored
+ * as the first element of the returned `std::tuple`, which indicates the
+ * particular kind of check that failed. For example, if the fifth check
+ * (primitive recovery) fails and cell is marked as troubled, an integer with
+ * value `-4` is stored in the first slot of the returned tuple. Note that this
+ * integer is marking only the _first_ check to fail, since checks are done in a
+ * particular sequence as listed above. If all checks are passed and cell is not
+ * troubled, it is returned with the value `0`.
+ *
+ * \note We adopt negative integers to mark TCI status from DG grid returned by
+ * TciOnDgGrid class. Positive integers are used for TCIs on FD grid; see
+ * TciOnFdGrid and its documentation.
+ *
  */
 template <typename RecoveryScheme>
 class TciOnDgGrid {

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.hpp
@@ -96,7 +96,7 @@ class TciOnDgGrid {
                  evolution::dg::subcell::Tags::SubcellOptions>;
 
   template <size_t ThermodynamicDim>
-  static std::tuple<bool, evolution::dg::subcell::RdmpTciData> apply(
+  static std::tuple<int, evolution::dg::subcell::RdmpTciData> apply(
       gsl::not_null<Variables<hydro::grmhd_tags<DataVector>>*> dg_prim_vars,
       const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau,
       const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.cpp
@@ -15,7 +15,7 @@
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 
 namespace grmhd::ValenciaDivClean::subcell {
-std::tuple<bool, evolution::dg::subcell::RdmpTciData> TciOnFdGrid::apply(
+std::tuple<int, evolution::dg::subcell::RdmpTciData> TciOnFdGrid::apply(
     const Scalar<DataVector>& subcell_tilde_d,
     const Scalar<DataVector>& subcell_tilde_tau,
     const tnsr::I<DataVector, 3, Frame::Inertial>& subcell_tilde_b,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.cpp
@@ -63,20 +63,21 @@ std::tuple<int, evolution::dg::subcell::RdmpTciData> TciOnFdGrid::apply(
       subcell_mesh.extents(),
       evolution::dg::subcell::fd::ReconstructionMethod::DimByDim);
 
-  // Note: `or` is short-circuiting, so if any of the first tests fail, we won't
-  // do the more expensive Persson TCI test.
-  bool cell_is_troubled =
-      vars_needed_fixing or
-      min(get(dg_tilde_d)) <
+  if (vars_needed_fixing) {
+    return {+1, rdmp_tci_data};
+  }
+
+  if (min(get(dg_tilde_d)) <
           tci_options.minimum_rest_mass_density_times_lorentz_factor or
-      min(get(dg_tilde_tau)) < tci_options.minimum_tilde_tau or
-      evolution::dg::subcell::persson_tci(dg_tilde_d, dg_mesh,
+      min(get(dg_tilde_tau)) < tci_options.minimum_tilde_tau) {
+    return {+2, rdmp_tci_data};
+  }
+
+  if (evolution::dg::subcell::persson_tci(dg_tilde_d, dg_mesh,
                                           persson_exponent) or
       evolution::dg::subcell::persson_tci(dg_tilde_tau, dg_mesh,
-                                          persson_exponent);
-
-  if (cell_is_troubled) {
-    return {cell_is_troubled, rdmp_tci_data};
+                                          persson_exponent)) {
+    return {+3, rdmp_tci_data};
   }
 
   Scalar<DataVector> dg_mag_tilde_b{};
@@ -100,20 +101,22 @@ std::tuple<int, evolution::dg::subcell::RdmpTciData> TciOnFdGrid::apply(
       min(min(get(dg_tilde_tau)), rdmp_tci_data.min_variables_values[1]),
       min(min(get(dg_mag_tilde_b)), rdmp_tci_data.min_variables_values[2])};
 
-  cell_is_troubled |= evolution::dg::subcell::rdmp_tci(
-      rdmp_tci_data_for_check.max_variables_values,
-      rdmp_tci_data_for_check.min_variables_values,
-      past_rdmp_tci_data.max_variables_values,
-      past_rdmp_tci_data.min_variables_values, subcell_options.rdmp_delta0(),
-      subcell_options.rdmp_epsilon());
-
-  if (tci_options.magnetic_field_cutoff.has_value() and not cell_is_troubled) {
-    cell_is_troubled = (max(get(dg_mag_tilde_b)) >
-                            tci_options.magnetic_field_cutoff.value() and
-                        evolution::dg::subcell::persson_tci(
-                            dg_mag_tilde_b, dg_mesh, persson_exponent));
+  if (const int rdmp_tci_status = evolution::dg::subcell::rdmp_tci(
+          rdmp_tci_data_for_check.max_variables_values,
+          rdmp_tci_data_for_check.min_variables_values,
+          past_rdmp_tci_data.max_variables_values,
+          past_rdmp_tci_data.min_variables_values,
+          subcell_options.rdmp_delta0(), subcell_options.rdmp_epsilon())) {
+    return {+3 + rdmp_tci_status, rdmp_tci_data};
   }
 
-  return {cell_is_troubled, rdmp_tci_data};
+  if (tci_options.magnetic_field_cutoff.has_value() and
+      (max(get(dg_mag_tilde_b)) > tci_options.magnetic_field_cutoff.value() and
+       evolution::dg::subcell::persson_tci(dg_mag_tilde_b, dg_mesh,
+                                           persson_exponent))) {
+    return {+7, rdmp_tci_data};
+  }
+
+  return {false, rdmp_tci_data};
 }
 }  // namespace grmhd::ValenciaDivClean::subcell

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.hpp
@@ -56,7 +56,7 @@ struct TciOnFdGrid {
                  domain::Tags::Mesh<3>, evolution::dg::subcell::Tags::Mesh<3>,
                  evolution::dg::subcell::Tags::DataForRdmpTci, Tags::TciOptions,
                  evolution::dg::subcell::Tags::SubcellOptions>;
-  static std::tuple<bool, evolution::dg::subcell::RdmpTciData> apply(
+  static std::tuple<int, evolution::dg::subcell::RdmpTciData> apply(
       const Scalar<DataVector>& subcell_tilde_d,
       const Scalar<DataVector>& subcell_tilde_tau,
       const tnsr::I<DataVector, 3, Frame::Inertial>& subcell_tilde_b,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.hpp
@@ -33,18 +33,52 @@ namespace grmhd::ValenciaDivClean::subcell {
  *
  * The following checks are done in the order they are listed:
  *
- * - if `grmhd::ValenciaDivClean::Tags::VariablesNeededFixing` is `true` then we
- *   remain on FD. (Note: this could be relaxed in the future if we need to
- *   allow switching from FD to DG in the atmosphere and the current approach
- *   isn't working.)
- * - if `min(tilde_d)` is less than
+ * <table>
+ * <caption>List of checks</caption>
+ * <tr><th> Description <th> TCI status
+ *
+ * <tr><td> if `grmhd::ValenciaDivClean::Tags::VariablesNeededFixing` is `true`
+ * then we remain on FD. (Note: this could be relaxed in the future if we need
+ * to allow switching from FD to DG in the atmosphere and the current approach
+ * isn't working.)
+ * <td> `+1`
+ *
+ * <tr><td> if `min(tilde_d)` is less than
  *   `tci_options.minimum_rest_mass_density_times_lorentz_factor` or if
  *   `min(tilde_tau)` is less than `tci_options.minimum_tilde_tau` then the we
  *   remain on FD.
- * - apply the Persson TCI to \f$\tilde{D}\f$ and \f$\tilde{\tau}\f$
- * - apply the RDMP TCI to `TildeD`, `TildeTau` and `magnitude(TildeB)`.
- * - apply the Persson TCI to the magnitude of \f$\tilde{B}^{n+1}\f$ if its
- *   magnitude is greater than `tci_options.magnetic_field_cutoff`.
+ * <td> `+2`
+ *
+ * <tr><td> apply the Persson TCI to \f$\tilde{D}\f$ and \f$\tilde{\tau}\f$
+ * <td> `+3`
+ *
+ * <tr><td> apply the RDMP TCI to `TildeD`
+ * <td> `+4`
+ *
+ * <tr><td> apply the RDMP TCI to `TildeTau`
+ * <td> `+5`
+ *
+ * <tr><td> apply the RDMP TCI to `TildeB`
+ * <td> `+6`
+ *
+ * <tr><td> apply the Persson TCI to the magnitude of \f$\tilde{B}^{n+1}\f$ if
+ * its magnitude is greater than `tci_options.magnetic_field_cutoff`. <td> `+7`
+ *
+ * </table>
+ *
+ * The second column of the table above denotes the value of an integer stored
+ * as the first element of the returned `std::tuple`, which indicates the
+ * particular kind of check that failed. For example, if the fifth check
+ * (RDMP TCI to TildeTau) fails and cell is marked as troubled, an integer with
+ * value `+5` is stored in the first slot of the returned tuple. Note that this
+ * integer is marking only the _first_ check to fail, since checks are done in a
+ * particular sequence as listed above. If all checks are passed and cell is not
+ * troubled, it is returned with the value `0`.
+ *
+ * \note We adopt positive integers to mark TCI status from FD grid returned by
+ * TciOnFdGrid class. Negative integers are reserved for TCIs on DG grid; see
+ * TciOnDgGrid and its documentation.
+ *
  */
 struct TciOnFdGrid {
   using return_tags = tmpl::list<>;

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_Initialize.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_Initialize.cpp
@@ -134,7 +134,7 @@ struct Metavariables {
         tmpl::list<domain::Tags::Mesh<volume_dim>,
                    evolution::dg::subcell::Tags::Mesh<volume_dim>>;
 
-    static std::tuple<bool, evolution::dg::subcell::RdmpTciData> apply(
+    static std::tuple<int, evolution::dg::subcell::RdmpTciData> apply(
         const Variables<tmpl::list<Var1>>& dg_vars, const double rdmp_delta0,
         const double rdmp_epsilon, const double persson_exponent,
         const Mesh<volume_dim>& dg_mesh, const Mesh<volume_dim>& subcell_mesh) {
@@ -158,7 +158,7 @@ struct Metavariables {
           std::vector<double>{min(min(get(get<Var1>(dg_vars))),
                                   min(get(get<Var1>(projected_dg_vars))))};
       invoked = true;
-      return {TciFails, std::move(rdmp_data)};
+      return {static_cast<int>(TciFails), std::move(rdmp_data)};
     }
   };
 };

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndRollback.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndRollback.cpp
@@ -138,7 +138,7 @@ struct Metavariables {
                    evolution::dg::subcell::Tags::DataForRdmpTci,
                    evolution::dg::subcell::Tags::SubcellOptions>;
 
-    static std::tuple<bool, evolution::dg::subcell::RdmpTciData> apply(
+    static std::tuple<int, evolution::dg::subcell::RdmpTciData> apply(
         const Variables<tmpl::list<Var1>>& dg_vars, const Mesh<Dim>& dg_mesh,
         const Mesh<Dim>& subcell_mesh,
         const evolution::dg::subcell::RdmpTciData& past_rdmp_data,
@@ -253,8 +253,8 @@ void test_impl(const bool rdmp_fails, const bool tci_fails,
   get(get<PrimVar1>(prim_vars)) = get<0>(logical_coordinates(dg_mesh)) + 1000.0;
 
   constexpr size_t history_size = 5;
-  TimeSteppers::History<Variables<evolved_vars_tags>>
-      time_stepper_history{history_size};
+  TimeSteppers::History<Variables<evolved_vars_tags>> time_stepper_history{
+      history_size};
   for (size_t i = 0; i < history_size; ++i) {
     Variables<db::wrap_tags_in<Tags::dt, evolved_vars_tags>> dt_vars{
         dg_mesh.number_of_grid_points()};
@@ -340,9 +340,8 @@ void test_impl(const bool rdmp_fails, const bool tci_fails,
     for (auto it = time_stepper_history.derivatives_begin(); it != end_it;
          ++it) {
       time_stepper_history_subcells.insert(
-          it.time_step_id(),
-          evolution::dg::subcell::fd::project(*it, dg_mesh,
-                                              subcell_mesh.extents()));
+          it.time_step_id(), evolution::dg::subcell::fd::project(
+                                 *it, dg_mesh, subcell_mesh.extents()));
     }
     REQUIRE(time_stepper_history_subcells.size() ==
             time_stepper_history_from_box.size());
@@ -354,10 +353,9 @@ void test_impl(const bool rdmp_fails, const bool tci_fails,
       CHECK(*it == *expected_it);
     }
 
-    CHECK(active_vars_from_box ==
-          evolution::dg::subcell::fd::project(
-              time_stepper_history.most_recent_value(), dg_mesh,
-              subcell_mesh.extents()));
+    CHECK(active_vars_from_box == evolution::dg::subcell::fd::project(
+                                      time_stepper_history.most_recent_value(),
+                                      dg_mesh, subcell_mesh.extents()));
 
     if (self_starting) {
       CHECK(initial_value_evolved_vars_from_box ==

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndSwitchToDg.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndSwitchToDg.cpp
@@ -115,7 +115,7 @@ struct Metavariables {
                    evolution::dg::subcell::Tags::DataForRdmpTci,
                    evolution::dg::subcell::Tags::SubcellOptions>;
 
-    static std::tuple<bool, evolution::dg::subcell::RdmpTciData> apply(
+    static std::tuple<int, evolution::dg::subcell::RdmpTciData> apply(
         const Variables<tmpl::list<Var1>>& subcell_vars,
         const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
         const evolution::dg::subcell::SubcellOptions& subcell_options,

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_InitialDataTci.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_InitialDataTci.cpp
@@ -71,8 +71,7 @@ SPECTRE_TEST_CASE(
         grmhd::ValenciaDivClean::subcell::DgInitialDataTci::apply(
             dg_vars, delta0, epsilon, exponent, dg_mesh, subcell_mesh,
             tci_options);
-    CHECK_FALSE(std::get<0>(result));
-
+    CHECK(std::get<0>(result) == 0);
     CHECK(std::get<1>(result) == compute_expected_rdmp_tci_data());
   }
 
@@ -87,28 +86,27 @@ SPECTRE_TEST_CASE(
         grmhd::ValenciaDivClean::subcell::DgInitialDataTci::apply(
             dg_vars, 1.0e-100, 1.0e-18, exponent, dg_mesh, subcell_mesh,
             tci_options);
-    CHECK(std::get<0>(result));
+    CHECK(std::get<0>(result) == -7);
     CHECK(std::get<1>(result) == compute_expected_rdmp_tci_data());
     get(get<grmhd::ValenciaDivClean::Tags::TildeD>(
         dg_vars))[dg_mesh.number_of_grid_points() / 2] /=
         1.0 + std::numeric_limits<double>::epsilon() * 2.0;
 
     // Verify TCI passes after restoring value
-    CHECK_FALSE(
-        std::get<0>(grmhd::ValenciaDivClean::subcell::DgInitialDataTci::apply(
-            dg_vars, delta0, epsilon, exponent, dg_mesh, subcell_mesh,
-            tci_options)));
+    CHECK(std::get<0>(grmhd::ValenciaDivClean::subcell::DgInitialDataTci::apply(
+              dg_vars, delta0, epsilon, exponent, dg_mesh, subcell_mesh,
+              tci_options)) == 0);
   }
 
   {
     INFO("Persson TCI TildeD fails");
     get(get<grmhd::ValenciaDivClean::Tags::TildeD>(
-        dg_vars))[dg_mesh.number_of_grid_points() / 2] += 2.0e10;
+        dg_vars))[dg_mesh.number_of_grid_points() / 2] += 2.0;
     const auto result =
         grmhd::ValenciaDivClean::subcell::DgInitialDataTci::apply(
             dg_vars, 1.0e100, epsilon, exponent, dg_mesh, subcell_mesh,
             tci_options);
-    CHECK(std::get<0>(result));
+    CHECK(std::get<0>(result) == -5);
     CHECK(std::get<1>(result) == compute_expected_rdmp_tci_data());
     get(get<grmhd::ValenciaDivClean::Tags::TildeD>(
         dg_vars))[dg_mesh.number_of_grid_points() / 2] = 1.0;
@@ -124,7 +122,7 @@ SPECTRE_TEST_CASE(
         grmhd::ValenciaDivClean::subcell::DgInitialDataTci::apply(
             dg_vars, 1.0e100, epsilon, exponent, dg_mesh, subcell_mesh,
             tci_options);
-    CHECK(std::get<0>(result));
+    CHECK(std::get<0>(result) == -6);
     CHECK(std::get<1>(result) == compute_expected_rdmp_tci_data());
     for (size_t i = 0; i < 3; ++i) {
       get<grmhd::ValenciaDivClean::Tags::TildeB<>>(dg_vars).get(
@@ -135,11 +133,12 @@ SPECTRE_TEST_CASE(
   {
     INFO("Persson TCI TildeTau fails");
     get(get<grmhd::ValenciaDivClean::Tags::TildeTau>(
-        dg_vars))[dg_mesh.number_of_grid_points() / 2] += 2.0e10;
+        dg_vars))[dg_mesh.number_of_grid_points() / 2] += 2.0;
     const auto result =
         grmhd::ValenciaDivClean::subcell::DgInitialDataTci::apply(
-            dg_vars, 1.0e100, epsilon, 1.0, dg_mesh, subcell_mesh, tci_options);
-    CHECK(std::get<0>(result));
+            dg_vars, 1.0e100, epsilon, exponent, dg_mesh, subcell_mesh,
+            tci_options);
+    CHECK(std::get<0>(result) == -5);
     CHECK(std::get<1>(result) == compute_expected_rdmp_tci_data());
     get(get<grmhd::ValenciaDivClean::Tags::TildeTau>(
         dg_vars))[dg_mesh.number_of_grid_points() / 2] = 1.0;
@@ -151,7 +150,7 @@ SPECTRE_TEST_CASE(
         dg_vars))[dg_mesh.number_of_grid_points() / 2] = -1.0e-20;
     auto result = grmhd::ValenciaDivClean::subcell::DgInitialDataTci::apply(
         dg_vars, 1.0e100, epsilon, 1.0, dg_mesh, subcell_mesh, tci_options);
-    CHECK(std::get<0>(result));
+    CHECK(std::get<0>(result) == -1);
     CHECK(std::get<1>(result) == compute_expected_rdmp_tci_data());
     get(get<grmhd::ValenciaDivClean::Tags::TildeD>(
         dg_vars))[dg_mesh.number_of_grid_points() / 2] = 1.0;
@@ -169,9 +168,8 @@ SPECTRE_TEST_CASE(
     get(get<grmhd::ValenciaDivClean::Tags::TildeTau>(
         dg_vars))[dg_mesh.number_of_grid_points() / 2] = -1.0e-20;
     auto result = grmhd::ValenciaDivClean::subcell::DgInitialDataTci::apply(
-        dg_vars, 1.0e100, epsilon, exponent, dg_mesh, subcell_mesh,
-        tci_options);
-    CHECK(std::get<0>(result));
+        dg_vars, 1.0e100, epsilon, 1.0, dg_mesh, subcell_mesh, tci_options);
+    CHECK(std::get<0>(result) == -2);
     CHECK(std::get<1>(result) == compute_expected_rdmp_tci_data());
     get(get<grmhd::ValenciaDivClean::Tags::TildeTau>(
         dg_vars))[dg_mesh.number_of_grid_points() / 2] = 1.0;

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnDgGrid.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnDgGrid.cpp
@@ -263,7 +263,7 @@ void test(const TestThis test_this) {
         }
       });
 
-  const std::tuple<bool, evolution::dg::subcell::RdmpTciData> result =
+  const std::tuple<int, evolution::dg::subcell::RdmpTciData> result =
       db::mutate_apply<grmhd::ValenciaDivClean::subcell::TciOnDgGrid<
           grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin>>(
           make_not_null(&box), persson_exponent);

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnDgGrid.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnDgGrid.cpp
@@ -50,8 +50,9 @@ enum class TestThis {
   RdmpMagnitudeTildeB
 };
 
-void test(const TestThis test_this) {
+void test(const TestThis test_this, const int expected_tci_status) {
   CAPTURE(test_this);
+  CAPTURE(expected_tci_status);
   const EquationsOfState::PolytropicFluid<true> eos{100.0, 2.0};
   const Mesh<3> mesh{6, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto};
@@ -162,20 +163,11 @@ void test(const TestThis test_this) {
           get<2>(*tilde_b_ptr)[point_to_change] = 1.0e4;
         });
   } else if (test_this == TestThis::PrimRecoveryFailed) {
-    db::mutate<grmhd::ValenciaDivClean::Tags::TildeB<Frame::Inertial>,
-               grmhd::ValenciaDivClean::Tags::TildeTau>(
-        make_not_null(&box),
-        [point_to_change, &tci_options](const auto tilde_b_ptr,
-                                        const auto tilde_tau_ptr) {
-          // The values here are chosen specifically so that the Newman-Hamlin
-          // recovery scheme fails to obtain a solution.
-          get(*tilde_tau_ptr)[point_to_change] = 4.32044e-24;
-
-          get<0>(*tilde_b_ptr)[point_to_change] =
-              sqrt(2.0 * (1.0 - tci_options.safety_factor_for_magnetic_field) *
-                   get(*tilde_tau_ptr)[point_to_change]);
-          get<1>(*tilde_b_ptr)[point_to_change] = 0.0;
-          get<2>(*tilde_b_ptr)[point_to_change] = 0.0;
+    db::mutate<grmhd::ValenciaDivClean::Tags::TildeS<Frame::Inertial>>(
+        make_not_null(&box), [point_to_change](const auto tilde_s_ptr) {
+          // Manipulate one of the conserved variable in an (very) inconsistent
+          // way so that primitive recovery fails.
+          get<0>(*tilde_s_ptr)[point_to_change] = 1e3;
         });
   } else if (test_this == TestThis::PerssonTildeTau) {
     db::mutate<grmhd::ValenciaDivClean::Tags::TildeTau>(
@@ -278,21 +270,25 @@ void test(const TestThis test_this) {
     CHECK(db::get<hydro::Tags::DivergenceCleaningField<DataVector>>(box) ==
           get<hydro::Tags::DivergenceCleaningField<DataVector>>(prim_vars));
   } else {
-    CHECK(get<0>(result));
+    CHECK(get<0>(result) == expected_tci_status);
   }
 }
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.ValenciaDivClean.Subcell.TciOnDgGrid",
                   "[Unit][Evolution]") {
-  for (const TestThis& test_this :
-       {TestThis::AllGood, TestThis::SmallTildeD, TestThis::InAtmosphere,
-        TestThis::TildeB2TooBig, TestThis::PrimRecoveryFailed,
-        TestThis::PerssonTildeD, TestThis::PerssonTildeTau,
-        TestThis::PerssonTildeB, TestThis::NegativeTildeDSubcell,
-        TestThis::NegativeTildeTauSubcell, TestThis::NegativeTildeTau,
-        TestThis::RdmpTildeD, TestThis::RdmpTildeTau,
-        TestThis::RdmpMagnitudeTildeB}) {
-    test(test_this);
-  }
+  test(TestThis::AllGood, 0);
+  test(TestThis::InAtmosphere, 0);
+  test(TestThis::SmallTildeD, -1);
+  test(TestThis::NegativeTildeDSubcell, -1);
+  test(TestThis::NegativeTildeTau, -2);
+  test(TestThis::NegativeTildeTauSubcell, -2);
+  test(TestThis::TildeB2TooBig, -3);
+  test(TestThis::PrimRecoveryFailed, -4);
+  test(TestThis::PerssonTildeD, -5);
+  test(TestThis::PerssonTildeTau, -5);
+  test(TestThis::PerssonTildeB, -6);
+  test(TestThis::RdmpTildeD, -7);
+  test(TestThis::RdmpTildeTau, -8);
+  test(TestThis::RdmpMagnitudeTildeB, -9);
 }

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnFdGrid.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnFdGrid.cpp
@@ -35,7 +35,7 @@ enum class TestThis {
   RdmpMagnitudeTildeB
 };
 
-void test(const TestThis test_this) {
+void test(const TestThis test_this, const int expected_tci_status) {
   const Mesh<3> mesh{6, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto};
   const Mesh<3> subcell_mesh = evolution::dg::subcell::fd::mesh(mesh);
@@ -174,19 +174,21 @@ void test(const TestThis test_this) {
   if (test_this == TestThis::AllGood) {
     CHECK_FALSE(get<0>(result));
   } else {
-    CHECK(get<0>(result));
+    CHECK(get<0>(result) == expected_tci_status);
   }
 }
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.ValenciaDivClean.Subcell.TciOnFdGrid",
                   "[Unit][Evolution]") {
-  for (const TestThis& test_this :
-       {TestThis::AllGood, TestThis::NeededFixing, TestThis::PerssonTildeD,
-        TestThis::PerssonTildeTau, TestThis::PerssonTildeB,
-        TestThis::NegativeTildeD, TestThis::NegativeTildeTau,
-        TestThis::RdmpTildeD, TestThis::RdmpTildeTau,
-        TestThis::RdmpMagnitudeTildeB}) {
-    test(test_this);
-  }
+  test(TestThis::AllGood, 0);
+  test(TestThis::NeededFixing, 1);
+  test(TestThis::NegativeTildeD, 2);
+  test(TestThis::NegativeTildeTau, 2);
+  test(TestThis::PerssonTildeD, 3);
+  test(TestThis::PerssonTildeTau, 3);
+  test(TestThis::RdmpTildeD, 4);
+  test(TestThis::RdmpTildeTau, 5);
+  test(TestThis::RdmpMagnitudeTildeB, 6);
+  test(TestThis::PerssonTildeB, 7);
 }

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnFdGrid.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnFdGrid.cpp
@@ -166,7 +166,7 @@ void test(const TestThis test_this) {
         }
       });
 
-  const std::tuple<bool, evolution::dg::subcell::RdmpTciData> result =
+  const std::tuple<int, evolution::dg::subcell::RdmpTciData> result =
       db::mutate_apply<grmhd::ValenciaDivClean::subcell::TciOnFdGrid>(
           make_not_null(&box), persson_exponent);
   CHECK(get<1>(result) == expected_rdmp_tci_data);


### PR DESCRIPTION
## Proposed changes


Make TCIs (Initial data TCI, TCI on DG grid, TCI on FD grid) in ValenciaDivClean system return certain prescribed integers rather than `bool`. This integer tells the particular check that marked an element as troubled.
* e.g. TciStatus is set to `-3` if an element switched from DG to FD because `TildeB` is too large
* e.g. TciStatus is set to `+4` if an element didn't switch to DG from FD because `TildeD` failed the RDMP TCI.

A table of checks and corresponding values of prescribed integers are described in documentations of each ValenciaDivClean TCI classes.


Dependent on 

- [x] #4212 (first 3 commits)



### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

