### PR TITLE
Fix vector size bug in FreeOutflow boundary condition

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/FreeOutflow.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/FreeOutflow.hpp
@@ -91,9 +91,7 @@ class FreeOutflow final : public BoundaryCondition {
       gr::Tags::Shift<3, Frame::Inertial, DataVector>,
       gr::Tags::Lapse<DataVector>,
       gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>>;
-  using dg_gridless_tags =
-      tmpl::list<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
-                 gr::Tags::SqrtDetSpatialMetric<DataVector>>;
+  using dg_gridless_tags = tmpl::list<>;
 
   static std::optional<std::string> dg_ghost(
       const gsl::not_null<Scalar<DataVector>*> tilde_d,
@@ -136,9 +134,6 @@ class FreeOutflow final : public BoundaryCondition {
       const tnsr::I<DataVector, 3, Frame::Inertial>& interior_shift,
       const Scalar<DataVector>& interior_lapse,
       const tnsr::II<DataVector, 3, Frame::Inertial>&
-          interior_inv_spatial_metric,
-
-      const tnsr::ii<DataVector, 3, Frame::Inertial>& interior_spatial_metric,
-      const Scalar<DataVector>& interior_sqrt_det_spatial_metric);
+          interior_inv_spatial_metric);
 };
 }  // namespace grmhd::ValenciaDivClean::BoundaryConditions

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/FreeOutflow.py
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/FreeOutflow.py
@@ -18,12 +18,15 @@ def _exterior_spatial_velocity(outward_directed_normal_covector,
         outward_directed_normal_vector * dot_interior_spatial_velocity)
 
 
+def _spatial_metric(inv_spatial_metric):
+    return np.linalg.inv(inv_spatial_metric)
+
+
 def error(face_mesh_velocity, outward_directed_normal_covector,
           outward_directed_normal_vector, interior_rest_mass_density,
           interior_specific_internal_energy, interior_spatial_velocity,
           interior_magnetic_field, interior_lorentz_factor, interior_pressure,
-          interior_specific_enthalpy, shift, lapse, inv_spatial_metric,
-          spatial_metric, sqrt_det_spatial_metric):
+          interior_specific_enthalpy, shift, lapse, inv_spatial_metric):
     return None
 
 
@@ -32,11 +35,13 @@ def tilde_d(face_mesh_velocity, outward_directed_normal_covector,
             interior_specific_internal_energy, interior_spatial_velocity,
             interior_magnetic_field, interior_lorentz_factor,
             interior_pressure, interior_specific_enthalpy, shift, lapse,
-            inv_spatial_metric, spatial_metric, sqrt_det_spatial_metric):
+            inv_spatial_metric):
 
     exterior_spatial_velocity = _exterior_spatial_velocity(
         outward_directed_normal_covector, outward_directed_normal_vector,
         interior_spatial_velocity)
+    spatial_metric = _spatial_metric(inv_spatial_metric)
+    sqrt_det_spatial_metric = np.linalg.det(spatial_metric)
 
     return cons.tilde_d(interior_rest_mass_density,
                         interior_specific_internal_energy,
@@ -51,11 +56,13 @@ def tilde_tau(face_mesh_velocity, outward_directed_normal_covector,
               interior_specific_internal_energy, interior_spatial_velocity,
               interior_magnetic_field, interior_lorentz_factor,
               interior_pressure, interior_specific_enthalpy, shift, lapse,
-              inv_spatial_metric, spatial_metric, sqrt_det_spatial_metric):
+              inv_spatial_metric):
 
     exterior_spatial_velocity = _exterior_spatial_velocity(
         outward_directed_normal_covector, outward_directed_normal_vector,
         interior_spatial_velocity)
+    spatial_metric = _spatial_metric(inv_spatial_metric)
+    sqrt_det_spatial_metric = np.linalg.det(spatial_metric)
 
     return cons.tilde_tau(interior_rest_mass_density,
                           interior_specific_internal_energy,
@@ -70,11 +77,13 @@ def tilde_s(face_mesh_velocity, outward_directed_normal_covector,
             interior_specific_internal_energy, interior_spatial_velocity,
             interior_magnetic_field, interior_lorentz_factor,
             interior_pressure, interior_specific_enthalpy, shift, lapse,
-            inv_spatial_metric, spatial_metric, sqrt_det_spatial_metric):
+            inv_spatial_metric):
 
     exterior_spatial_velocity = _exterior_spatial_velocity(
         outward_directed_normal_covector, outward_directed_normal_vector,
         interior_spatial_velocity)
+    spatial_metric = _spatial_metric(inv_spatial_metric)
+    sqrt_det_spatial_metric = np.linalg.det(spatial_metric)
 
     return cons.tilde_s(interior_rest_mass_density,
                         interior_specific_internal_energy,
@@ -89,11 +98,13 @@ def tilde_b(face_mesh_velocity, outward_directed_normal_covector,
             interior_specific_internal_energy, interior_spatial_velocity,
             interior_magnetic_field, interior_lorentz_factor,
             interior_pressure, interior_specific_enthalpy, shift, lapse,
-            inv_spatial_metric, spatial_metric, sqrt_det_spatial_metric):
+            inv_spatial_metric):
 
     exterior_spatial_velocity = _exterior_spatial_velocity(
         outward_directed_normal_covector, outward_directed_normal_vector,
         interior_spatial_velocity)
+    spatial_metric = _spatial_metric(inv_spatial_metric)
+    sqrt_det_spatial_metric = np.linalg.det(spatial_metric)
 
     return cons.tilde_b(interior_rest_mass_density,
                         interior_specific_internal_energy,
@@ -108,11 +119,13 @@ def tilde_phi(face_mesh_velocity, outward_directed_normal_covector,
               interior_specific_internal_energy, interior_spatial_velocity,
               interior_magnetic_field, interior_lorentz_factor,
               interior_pressure, interior_specific_enthalpy, shift, lapse,
-              inv_spatial_metric, spatial_metric, sqrt_det_spatial_metric):
+              inv_spatial_metric):
 
     exterior_spatial_velocity = _exterior_spatial_velocity(
         outward_directed_normal_covector, outward_directed_normal_vector,
         interior_spatial_velocity)
+    spatial_metric = _spatial_metric(inv_spatial_metric)
+    sqrt_det_spatial_metric = np.linalg.det(spatial_metric)
 
     return cons.tilde_phi(interior_rest_mass_density,
                           interior_specific_internal_energy,
@@ -127,8 +140,7 @@ def _return_cons_vars(
     outward_directed_normal_vector, interior_rest_mass_density,
     interior_specific_internal_energy, interior_spatial_velocity,
     interior_magnetic_field, interior_lorentz_factor, interior_pressure,
-    interior_specific_enthalpy, shift, lapse, inv_spatial_metric,
-    spatial_metric, sqrt_det_spatial_metric):
+    interior_specific_enthalpy, shift, lapse, inv_spatial_metric):
     return {
         "tilde_d":
         tilde_d(face_mesh_velocity, outward_directed_normal_covector,
@@ -136,35 +148,35 @@ def _return_cons_vars(
                 interior_specific_internal_energy, interior_spatial_velocity,
                 interior_magnetic_field, interior_lorentz_factor,
                 interior_pressure, interior_specific_enthalpy, shift, lapse,
-                inv_spatial_metric, spatial_metric, sqrt_det_spatial_metric),
+                inv_spatial_metric),
         "tilde_tau":
         tilde_tau(face_mesh_velocity, outward_directed_normal_covector,
                   outward_directed_normal_vector, interior_rest_mass_density,
                   interior_specific_internal_energy, interior_spatial_velocity,
                   interior_magnetic_field, interior_lorentz_factor,
                   interior_pressure, interior_specific_enthalpy, shift, lapse,
-                  inv_spatial_metric, spatial_metric, sqrt_det_spatial_metric),
+                  inv_spatial_metric),
         "tilde_s":
         tilde_s(face_mesh_velocity, outward_directed_normal_covector,
                 outward_directed_normal_vector, interior_rest_mass_density,
                 interior_specific_internal_energy, interior_spatial_velocity,
                 interior_magnetic_field, interior_lorentz_factor,
                 interior_pressure, interior_specific_enthalpy, shift, lapse,
-                inv_spatial_metric, spatial_metric, sqrt_det_spatial_metric),
+                inv_spatial_metric),
         "tilde_b":
         tilde_b(face_mesh_velocity, outward_directed_normal_covector,
                 outward_directed_normal_vector, interior_rest_mass_density,
                 interior_specific_internal_energy, interior_spatial_velocity,
                 interior_magnetic_field, interior_lorentz_factor,
                 interior_pressure, interior_specific_enthalpy, shift, lapse,
-                inv_spatial_metric, spatial_metric, sqrt_det_spatial_metric),
+                inv_spatial_metric),
         "tilde_phi":
         tilde_phi(face_mesh_velocity, outward_directed_normal_covector,
                   outward_directed_normal_vector, interior_rest_mass_density,
                   interior_specific_internal_energy, interior_spatial_velocity,
                   interior_magnetic_field, interior_lorentz_factor,
                   interior_pressure, interior_specific_enthalpy, shift, lapse,
-                  inv_spatial_metric, spatial_metric, sqrt_det_spatial_metric),
+                  inv_spatial_metric),
     }
 
 
@@ -173,19 +185,20 @@ def flux_tilde_d(face_mesh_velocity, outward_directed_normal_covector,
                  interior_specific_internal_energy, interior_spatial_velocity,
                  interior_magnetic_field, interior_lorentz_factor,
                  interior_pressure, interior_specific_enthalpy, shift, lapse,
-                 inv_spatial_metric, spatial_metric, sqrt_det_spatial_metric):
+                 inv_spatial_metric):
 
     exterior_spatial_velocity = _exterior_spatial_velocity(
         outward_directed_normal_covector, outward_directed_normal_vector,
         interior_spatial_velocity)
+    spatial_metric = _spatial_metric(inv_spatial_metric)
+    sqrt_det_spatial_metric = np.linalg.det(spatial_metric)
 
     cons_vars = _return_cons_vars(
         face_mesh_velocity, outward_directed_normal_covector,
         outward_directed_normal_vector, interior_rest_mass_density,
         interior_specific_internal_energy, interior_spatial_velocity,
         interior_magnetic_field, interior_lorentz_factor, interior_pressure,
-        interior_specific_enthalpy, shift, lapse, inv_spatial_metric,
-        spatial_metric, sqrt_det_spatial_metric)
+        interior_specific_enthalpy, shift, lapse, inv_spatial_metric)
 
     return fluxes.tilde_d_flux(
         cons_vars["tilde_d"], cons_vars["tilde_tau"], cons_vars["tilde_s"],
@@ -201,20 +214,20 @@ def flux_tilde_tau(face_mesh_velocity, outward_directed_normal_covector,
                    interior_spatial_velocity, interior_magnetic_field,
                    interior_lorentz_factor, interior_pressure,
                    interior_specific_enthalpy, shift, lapse,
-                   inv_spatial_metric, spatial_metric,
-                   sqrt_det_spatial_metric):
+                   inv_spatial_metric):
 
     exterior_spatial_velocity = _exterior_spatial_velocity(
         outward_directed_normal_covector, outward_directed_normal_vector,
         interior_spatial_velocity)
+    spatial_metric = _spatial_metric(inv_spatial_metric)
+    sqrt_det_spatial_metric = np.linalg.det(spatial_metric)
 
     cons_vars = _return_cons_vars(
         face_mesh_velocity, outward_directed_normal_covector,
         outward_directed_normal_vector, interior_rest_mass_density,
         interior_specific_internal_energy, interior_spatial_velocity,
         interior_magnetic_field, interior_lorentz_factor, interior_pressure,
-        interior_specific_enthalpy, shift, lapse, inv_spatial_metric,
-        spatial_metric, sqrt_det_spatial_metric)
+        interior_specific_enthalpy, shift, lapse, inv_spatial_metric)
 
     return fluxes.tilde_tau_flux(
         cons_vars["tilde_d"], cons_vars["tilde_tau"], cons_vars["tilde_s"],
@@ -229,19 +242,20 @@ def flux_tilde_s(face_mesh_velocity, outward_directed_normal_covector,
                  interior_specific_internal_energy, interior_spatial_velocity,
                  interior_magnetic_field, interior_lorentz_factor,
                  interior_pressure, interior_specific_enthalpy, shift, lapse,
-                 inv_spatial_metric, spatial_metric, sqrt_det_spatial_metric):
+                 inv_spatial_metric):
 
     exterior_spatial_velocity = _exterior_spatial_velocity(
         outward_directed_normal_covector, outward_directed_normal_vector,
         interior_spatial_velocity)
+    spatial_metric = _spatial_metric(inv_spatial_metric)
+    sqrt_det_spatial_metric = np.linalg.det(spatial_metric)
 
     cons_vars = _return_cons_vars(
         face_mesh_velocity, outward_directed_normal_covector,
         outward_directed_normal_vector, interior_rest_mass_density,
         interior_specific_internal_energy, interior_spatial_velocity,
         interior_magnetic_field, interior_lorentz_factor, interior_pressure,
-        interior_specific_enthalpy, shift, lapse, inv_spatial_metric,
-        spatial_metric, sqrt_det_spatial_metric)
+        interior_specific_enthalpy, shift, lapse, inv_spatial_metric)
 
     return fluxes.tilde_s_flux(
         cons_vars["tilde_d"], cons_vars["tilde_tau"], cons_vars["tilde_s"],
@@ -256,19 +270,20 @@ def flux_tilde_b(face_mesh_velocity, outward_directed_normal_covector,
                  interior_specific_internal_energy, interior_spatial_velocity,
                  interior_magnetic_field, interior_lorentz_factor,
                  interior_pressure, interior_specific_enthalpy, shift, lapse,
-                 inv_spatial_metric, spatial_metric, sqrt_det_spatial_metric):
+                 inv_spatial_metric):
 
     exterior_spatial_velocity = _exterior_spatial_velocity(
         outward_directed_normal_covector, outward_directed_normal_vector,
         interior_spatial_velocity)
+    spatial_metric = _spatial_metric(inv_spatial_metric)
+    sqrt_det_spatial_metric = np.linalg.det(spatial_metric)
 
     cons_vars = _return_cons_vars(
         face_mesh_velocity, outward_directed_normal_covector,
         outward_directed_normal_vector, interior_rest_mass_density,
         interior_specific_internal_energy, interior_spatial_velocity,
         interior_magnetic_field, interior_lorentz_factor, interior_pressure,
-        interior_specific_enthalpy, shift, lapse, inv_spatial_metric,
-        spatial_metric, sqrt_det_spatial_metric)
+        interior_specific_enthalpy, shift, lapse, inv_spatial_metric)
 
     return fluxes.tilde_b_flux(
         cons_vars["tilde_d"], cons_vars["tilde_tau"], cons_vars["tilde_s"],
@@ -284,20 +299,20 @@ def flux_tilde_phi(face_mesh_velocity, outward_directed_normal_covector,
                    interior_spatial_velocity, interior_magnetic_field,
                    interior_lorentz_factor, interior_pressure,
                    interior_specific_enthalpy, shift, lapse,
-                   inv_spatial_metric, spatial_metric,
-                   sqrt_det_spatial_metric):
+                   inv_spatial_metric):
 
     exterior_spatial_velocity = _exterior_spatial_velocity(
         outward_directed_normal_covector, outward_directed_normal_vector,
         interior_spatial_velocity)
+    spatial_metric = _spatial_metric(inv_spatial_metric)
+    sqrt_det_spatial_metric = np.linalg.det(spatial_metric)
 
     cons_vars = _return_cons_vars(
         face_mesh_velocity, outward_directed_normal_covector,
         outward_directed_normal_vector, interior_rest_mass_density,
         interior_specific_internal_energy, interior_spatial_velocity,
         interior_magnetic_field, interior_lorentz_factor, interior_pressure,
-        interior_specific_enthalpy, shift, lapse, inv_spatial_metric,
-        spatial_metric, sqrt_det_spatial_metric)
+        interior_specific_enthalpy, shift, lapse, inv_spatial_metric)
 
     return fluxes.tilde_phi_flux(
         cons_vars["tilde_d"], cons_vars["tilde_tau"], cons_vars["tilde_s"],
@@ -311,8 +326,7 @@ def lapse(face_mesh_velocity, outward_directed_normal_covector,
           outward_directed_normal_vector, interior_rest_mass_density,
           interior_specific_internal_energy, interior_spatial_velocity,
           interior_magnetic_field, interior_lorentz_factor, interior_pressure,
-          interior_specific_enthalpy, shift, lapse, inv_spatial_metric,
-          spatial_metric, sqrt_det_spatial_metric):
+          interior_specific_enthalpy, shift, lapse, inv_spatial_metric):
     return lapse
 
 
@@ -320,8 +334,7 @@ def shift(face_mesh_velocity, outward_directed_normal_covector,
           outward_directed_normal_vector, interior_rest_mass_density,
           interior_specific_internal_energy, interior_spatial_velocity,
           interior_magnetic_field, interior_lorentz_factor, interior_pressure,
-          interior_specific_enthalpy, shift, lapse, inv_spatial_metric,
-          spatial_metric, sqrt_det_spatial_metric):
+          interior_specific_enthalpy, shift, lapse, inv_spatial_metric):
     return shift
 
 
@@ -330,6 +343,5 @@ def inv_spatial_metric(
     outward_directed_normal_vector, interior_rest_mass_density,
     interior_specific_internal_energy, interior_spatial_velocity,
     interior_magnetic_field, interior_lorentz_factor, interior_pressure,
-    interior_specific_enthalpy, shift, lapse, inv_spatial_metric,
-    spatial_metric, sqrt_det_spatial_metric):
+    interior_specific_enthalpy, shift, lapse, inv_spatial_metric):
     return inv_spatial_metric


### PR DESCRIPTION
## Proposed changes

Current implementation of DG FreeOutflow condition in GRMHD is loading spatial metric and its sqrt determinant from Databox as gridless tags, which means they are retrieved without being projected to an element face. This raises 'Vector size does not match` type of bug when computing conservatives from primitives.


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
