### PR TITLE
Add TensorExpression support for std::complex<double> and ComplexDataVector

### DIFF
--- a/src/DataStructures/ComplexDataVector.hpp
+++ b/src/DataStructures/ComplexDataVector.hpp
@@ -61,8 +61,10 @@ class ComplexDataVector
   ComplexDataVector& operator=(ComplexDataVector&&) = default;
   ~ComplexDataVector() = default;
 
-  using VectorImpl<std::complex<double>, ComplexDataVector>::operator=;
-  using VectorImpl<std::complex<double>, ComplexDataVector>::VectorImpl;
+  using BaseType = VectorImpl<std::complex<double>, ComplexDataVector>;
+
+  using BaseType::operator=;
+  using BaseType::VectorImpl;
 };
 
 namespace blaze {

--- a/src/DataStructures/ComplexDiagonalModalOperator.hpp
+++ b/src/DataStructures/ComplexDiagonalModalOperator.hpp
@@ -68,10 +68,11 @@ class ComplexDiagonalModalOperator
       default;
   ~ComplexDiagonalModalOperator() = default;
 
-  using VectorImpl<std::complex<double>, ComplexDiagonalModalOperator>::
-  operator=;
-  using VectorImpl<std::complex<double>,
-                   ComplexDiagonalModalOperator>::VectorImpl;
+  using BaseType =
+      VectorImpl<std::complex<double>, ComplexDiagonalModalOperator>;
+
+  using BaseType::operator=;
+  using BaseType::VectorImpl;
 };
 
 namespace blaze {

--- a/src/DataStructures/ComplexModalVector.hpp
+++ b/src/DataStructures/ComplexModalVector.hpp
@@ -49,8 +49,10 @@ class ComplexModalVector
   ComplexModalVector& operator=(ComplexModalVector&&) = default;
   ~ComplexModalVector() = default;
 
-  using VectorImpl<std::complex<double>, ComplexModalVector>::operator=;
-  using VectorImpl<std::complex<double>, ComplexModalVector>::VectorImpl;
+  using BaseType = VectorImpl<std::complex<double>, ComplexModalVector>;
+
+  using BaseType::operator=;
+  using BaseType::VectorImpl;
 };
 
 namespace blaze {

--- a/src/DataStructures/DataVector.hpp
+++ b/src/DataStructures/DataVector.hpp
@@ -54,8 +54,10 @@ class DataVector : public VectorImpl<double, DataVector> {
   DataVector& operator=(DataVector&&) = default;
   ~DataVector() = default;
 
-  using VectorImpl<double, DataVector>::operator=;
-  using VectorImpl<double, DataVector>::VectorImpl;
+  using BaseType = VectorImpl<double, DataVector>;
+
+  using BaseType::operator=;
+  using BaseType::VectorImpl;
 };
 
 // Specialize the Blaze type traits to correctly handle DataVector

--- a/src/DataStructures/DiagonalModalOperator.hpp
+++ b/src/DataStructures/DiagonalModalOperator.hpp
@@ -46,8 +46,10 @@ class DiagonalModalOperator : public VectorImpl<double, DiagonalModalOperator> {
   DiagonalModalOperator& operator=(DiagonalModalOperator&&) = default;
   ~DiagonalModalOperator() = default;
 
-  using VectorImpl<double, DiagonalModalOperator>::operator=;
-  using VectorImpl<double, DiagonalModalOperator>::VectorImpl;
+  using BaseType = VectorImpl<double, DiagonalModalOperator>;
+
+  using BaseType::operator=;
+  using BaseType::VectorImpl;
 };
 
 namespace blaze {

--- a/src/DataStructures/ModalVector.hpp
+++ b/src/DataStructures/ModalVector.hpp
@@ -40,8 +40,10 @@ class ModalVector : public VectorImpl<double, ModalVector> {
   ModalVector& operator=(ModalVector&&) = default;
   ~ModalVector() = default;
 
-  using VectorImpl<double, ModalVector>::operator=;
-  using VectorImpl<double, ModalVector>::VectorImpl;
+  using BaseType = VectorImpl<double, ModalVector>;
+
+  using BaseType::operator=;
+  using BaseType::VectorImpl;
 };
 
 namespace blaze {

--- a/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
+++ b/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
@@ -14,6 +14,7 @@
 #include <utility>
 
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Expressions/DataTypeSupport.hpp"
 #include "DataStructures/Tensor/Expressions/IndexPropertyCheck.hpp"
 #include "DataStructures/Tensor/Expressions/NumberAsExpression.hpp"
 #include "DataStructures/Tensor/Expressions/SpatialSpacetimeIndex.hpp"
@@ -253,9 +254,7 @@ struct AddSubType {
                     std::is_base_of_v<Expression, T2>,
                 "Parameters to AddSubType must be TensorExpressions");
   using type =
-      tmpl::conditional_t<std::is_same_v<typename T1::type, DataVector> or
-                              std::is_same_v<typename T2::type, DataVector>,
-                          DataVector, double>;
+      typename get_binop_datatype<typename T1::type, typename T2::type>::type;
   using symmetry =
       typename AddSubSymmetry<typename T1::symmetry, typename T2::symmetry,
                                    typename T1::args_list,
@@ -294,10 +293,11 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
           typename detail::AddSubType<T1, T2>::symmetry,
           typename detail::AddSubType<T1, T2>::index_list,
           typename detail::AddSubType<T1, T2>::tensorindex_list> {
-  static_assert(std::is_same<typename T1::type, typename T2::type>::value or
-                    std::is_same<T1, NumberAsExpression>::value or
-                    std::is_same<T2, NumberAsExpression>::value,
-                "Cannot add or subtract Tensors holding different data types.");
+  static_assert(
+      detail::tensorexpression_binop_datatypes_are_supported_v<T1, T2>,
+      "Cannot add or subtract the given TensorExpression types with the given "
+      "data types. This can occur from e.g. trying to add a Tensor with data "
+      "type double and a Tensor with data type DataVector.");
   static_assert(
       detail::IndexPropertyCheck<typename T1::index_list,
                                  typename T2::index_list, ArgsList1<Args1...>,
@@ -436,10 +436,10 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
   template <typename LhsTensor>
   SPECTRE_ALWAYS_INLINE void assert_lhs_tensor_not_in_rhs_expression(
       const gsl::not_null<LhsTensor*> lhs_tensor) const {
-    if constexpr (not std::is_base_of_v<NumberAsExpression, T1>) {
+    if constexpr (not std::is_base_of_v<MarkAsNumberAsExpression, T1>) {
       t1_.assert_lhs_tensor_not_in_rhs_expression(lhs_tensor);
     }
-    if constexpr (not std::is_base_of_v<NumberAsExpression, T2>) {
+    if constexpr (not std::is_base_of_v<MarkAsNumberAsExpression, T2>) {
       t2_.assert_lhs_tensor_not_in_rhs_expression(lhs_tensor);
     }
   }
@@ -453,11 +453,11 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
   template <typename LhsTensorIndices, typename LhsTensor>
   SPECTRE_ALWAYS_INLINE void assert_lhs_tensorindices_same_in_rhs(
       const gsl::not_null<LhsTensor*> lhs_tensor) const {
-    if constexpr (not std::is_base_of_v<NumberAsExpression, T1>) {
+    if constexpr (not std::is_base_of_v<MarkAsNumberAsExpression, T1>) {
       t1_.template assert_lhs_tensorindices_same_in_rhs<LhsTensorIndices>(
           lhs_tensor);
     }
-    if constexpr (not std::is_base_of_v<NumberAsExpression, T2>) {
+    if constexpr (not std::is_base_of_v<MarkAsNumberAsExpression, T2>) {
       t2_.template assert_lhs_tensorindices_same_in_rhs<LhsTensorIndices>(
           lhs_tensor);
     }
@@ -662,8 +662,9 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
   /// operand of the sum or difference to evaluate
   /// \param op2_multi_index the multi-index of the component of the second
   /// operand of the sum or difference to evaluate
+  template <typename ResultType>
   SPECTRE_ALWAYS_INLINE void add_or_subtract_primary_children(
-      type& result_component,
+      ResultType& result_component,
       const std::array<size_t, num_tensor_indices>& op1_multi_index,
       const std::array<size_t, num_tensor_indices_op2>& op2_multi_index) const {
     if constexpr (Sign == 1) {
@@ -678,7 +679,8 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
         // We haven't yet evaluated the whole subtree of the primary child, so
         // first assign the result component to be the result of computing the
         // primary child's subtree
-        result_component = t1_.get_primary(result_component, op1_multi_index);
+        result_component =
+            t1_.template get_primary(result_component, op1_multi_index);
         // Now that the primary child's subtree has been computed, add the
         // result of evaluating the other child's subtree to the current result
         result_component += t2_.get(op2_multi_index);
@@ -695,7 +697,8 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
         // We haven't yet evaluated the whole subtree of the primary child, so
         // first assign the result component to be the result of computing the
         // primary child's subtree
-        result_component = t1_.get_primary(result_component, op1_multi_index);
+        result_component =
+            t1_.template get_primary(result_component, op1_multi_index);
         // Now that the primary child's subtree has been computed, subtract the
         // result of evaluating the other child's subtree from the current
         // result
@@ -714,8 +717,9 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
   /// \param result_component the LHS tensor component to evaluate
   /// \param result_multi_index the multi-index of the component of the result
   /// tensor to evaluate
+  template <typename ResultType>
   SPECTRE_ALWAYS_INLINE void evaluate_primary_children(
-      type& result_component,
+      ResultType& result_component,
       const std::array<size_t, num_tensor_indices>& result_multi_index) const {
     add_or_subtract_primary_children(result_component, result_multi_index,
                                      get_op2_multi_index(result_multi_index));
@@ -737,8 +741,9 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
   /// \param op2_multi_index the multi-index of the component of the second
   /// operand
   /// \return the sum of or difference between the two components' values
+  template <typename ResultType>
   SPECTRE_ALWAYS_INLINE decltype(auto) add_or_subtract_primary(
-      const type& result_component,
+      const ResultType& result_component,
       const std::array<size_t, num_tensor_indices>& op1_multi_index,
       const std::array<size_t, num_tensor_indices_op2>& op2_multi_index) const {
     if constexpr (Sign == 1) {
@@ -752,7 +757,7 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
       } else {
         // We haven't yet evaluated the whole subtree for this expression, so
         // return the sum of the results of the two operands' subtrees
-        return t1_.get_primary(result_component, op1_multi_index) +
+        return t1_.template get_primary(result_component, op1_multi_index) +
                t2_.get(op2_multi_index);
       }
     } else {
@@ -767,7 +772,7 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
         // We haven't yet evaluated the whole subtree for this expression, so
         // return the difference between the results of the two operands'
         // subtrees
-        return t1_.get_primary(result_component, op1_multi_index) -
+        return t1_.template get_primary(result_component, op1_multi_index) -
                t2_.get(op2_multi_index);
       }
     }
@@ -788,8 +793,9 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
   /// tensor to retrieve
   /// \return the value of the component at `result_multi_index` in the result
   /// tensor
+  template <typename ResultType>
   SPECTRE_ALWAYS_INLINE decltype(auto) get_primary(
-      const type& result_component,
+      const ResultType& result_component,
       const std::array<size_t, num_tensor_indices>& result_multi_index) const {
     return add_or_subtract_primary(result_component, result_multi_index,
                                    get_op2_multi_index(result_multi_index));
@@ -808,13 +814,15 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
   /// \param result_component the LHS tensor component to evaluate
   /// \param result_multi_index the multi-index of the component of the result
   /// tensor to evaluate
+  template <typename ResultType>
   SPECTRE_ALWAYS_INLINE void evaluate_primary_subtree(
-      type& result_component,
+      ResultType& result_component,
       const std::array<size_t, num_tensor_indices>& result_multi_index) const {
     if constexpr (primary_child_subtree_contains_primary_start) {
       // The primary child's subtree contains at least one leg, so recurse down
       // and evaluate that first
-      t1_.evaluate_primary_subtree(result_component, result_multi_index);
+      t1_.template evaluate_primary_subtree(result_component,
+                                            result_multi_index);
     }
 
     if constexpr (is_primary_start) {
@@ -868,7 +876,7 @@ SPECTRE_ALWAYS_INLINE auto operator+(
 /// @{
 /// \ingroup TensorExpressionsGroup
 /// \brief Returns the tensor expression representing the sum of a tensor
-/// expression and a `double`
+/// expression and a number
 ///
 /// \details
 /// The tensor expression operand must represent an expression that, when
@@ -880,25 +888,16 @@ SPECTRE_ALWAYS_INLINE auto operator+(
 /// - `(R(ti::A, ti::B) * S(ti::a, ti::b))`
 /// - `R(ti::t, ti::t)`
 ///
-/// \tparam T the derived TensorExpression type of the tensor expression operand
-/// of the sum
-/// \tparam X the type of data stored in the tensor expression operand of the
-/// sum
-/// \tparam Symm the ::Symmetry of the derived TensorExpression type of the
-/// tensor expression operand of the sum
-/// \tparam IndexList the \ref SpacetimeIndex "TensorIndexType"s of the derived
-/// TensorExpression type of the tensor expression operand of the sum
-/// \tparam Args the comma-separated list of generic indices of the derived
-/// TensorExpression type of the tensor expression operand of the sum
 /// \param t the tensor expression operand of the sum
-/// \param number the `double` operand of the sum
-/// \return the tensor expression representing the sum of a tensor expression
-/// and a `double`
+/// \param number the numeric operand of the sum
+/// \return the tensor expression representing the sum of the tensor expression
+/// and the number
 template <typename T, typename X, typename Symm, typename IndexList,
-          typename... Args>
+          typename... Args, typename N,
+          Requires<std::is_arithmetic_v<N>> = nullptr>
 SPECTRE_ALWAYS_INLINE auto operator+(
     const TensorExpression<T, X, Symm, IndexList, tmpl::list<Args...>>& t,
-    const double number) {
+    const N number) {
   static_assert(
       (... and tt::is_time_index<Args>::value),
       "Can only add a number to a tensor expression that evaluates to a rank 0"
@@ -906,9 +905,10 @@ SPECTRE_ALWAYS_INLINE auto operator+(
   return t + tenex::NumberAsExpression(number);
 }
 template <typename T, typename X, typename Symm, typename IndexList,
-          typename... Args>
+          typename... Args, typename N,
+          Requires<std::is_arithmetic_v<N>> = nullptr>
 SPECTRE_ALWAYS_INLINE auto operator+(
-    const double number,
+    const N number,
     const TensorExpression<T, X, Symm, IndexList, tmpl::list<Args...>>& t) {
   static_assert(
       (... and tt::is_time_index<Args>::value),
@@ -945,7 +945,7 @@ SPECTRE_ALWAYS_INLINE auto operator-(
 /// @{
 /// \ingroup TensorExpressionsGroup
 /// \brief Returns the tensor expression representing the difference of a tensor
-/// expression and a `double`
+/// expression and a number
 ///
 /// \details
 /// The tensor expression operand must represent an expression that, when
@@ -957,25 +957,16 @@ SPECTRE_ALWAYS_INLINE auto operator-(
 /// - `(R(ti::A, ti::B) * S(ti::a, ti::b))`
 /// - `R(ti::t, ti::t)`
 ///
-/// \tparam T the derived TensorExpression type of the tensor expression operand
-/// of the difference
-/// \tparam X the type of data stored in the tensor expression operand of the
-/// difference
-/// \tparam Symm the ::Symmetry of the derived TensorExpression type of the
-/// tensor expression operand of the difference
-/// \tparam IndexList the \ref SpacetimeIndex "TensorIndexType"s of the derived
-/// TensorExpression type of the tensor expression operand of the difference
-/// \tparam Args the comma-separated list of generic indices of the derived
-/// TensorExpression type of the tensor expression operand of the difference
 /// \param t the tensor expression operand of the difference
-/// \param number the `double` operand of the difference
-/// \return the tensor expression representing the difference of a tensor
-/// expression and a `double`
+/// \param number the numeric operand of the difference
+/// \return the tensor expression representing the difference of the tensor
+/// expression and the number
 template <typename T, typename X, typename Symm, typename IndexList,
-          typename... Args>
+          typename... Args, typename N,
+          Requires<std::is_arithmetic_v<N>> = nullptr>
 SPECTRE_ALWAYS_INLINE auto operator-(
     const TensorExpression<T, X, Symm, IndexList, tmpl::list<Args...>>& t,
-    const double number) {
+    const N number) {
   static_assert(
       (... and tt::is_time_index<Args>::value),
       "Can only subtract a number from a tensor expression that evaluates to a "
@@ -983,9 +974,10 @@ SPECTRE_ALWAYS_INLINE auto operator-(
   return t + tenex::NumberAsExpression(-number);
 }
 template <typename T, typename X, typename Symm, typename IndexList,
-          typename... Args>
+          typename... Args, typename N,
+          Requires<std::is_arithmetic_v<N>> = nullptr>
 SPECTRE_ALWAYS_INLINE auto operator-(
-    const double number,
+    const N number,
     const TensorExpression<T, X, Symm, IndexList, tmpl::list<Args...>>& t) {
   static_assert(
       (... and tt::is_time_index<Args>::value),

--- a/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
+++ b/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <array>
+#include <complex>
 #include <cstddef>
 #include <iterator>
 #include <limits>
@@ -298,6 +299,15 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
       "Cannot add or subtract the given TensorExpression types with the given "
       "data types. This can occur from e.g. trying to add a Tensor with data "
       "type double and a Tensor with data type DataVector.");
+  static_assert(
+      not((std::is_same_v<T1, NumberAsExpression<std::complex<double>>> and
+           std::is_same_v<typename T2::type, DataVector>) or
+          (std::is_same_v<T2, NumberAsExpression<std::complex<double>>> and
+           std::is_same_v<typename T1::type, DataVector>)),
+      "Cannot perform addition and subtraction between a std::complex<double> "
+      "and a TensorExpression whose data type is DataVector because Blaze does "
+      "not support addition and subtraction between std::complex<double> and "
+      "DataVector.");
   static_assert(
       detail::IndexPropertyCheck<typename T1::index_list,
                                  typename T2::index_list, ArgsList1<Args1...>,
@@ -916,6 +926,28 @@ SPECTRE_ALWAYS_INLINE auto operator+(
       "tensor.");
   return t + tenex::NumberAsExpression(number);
 }
+template <typename T, typename X, typename Symm, typename IndexList,
+          typename... Args, typename N>
+SPECTRE_ALWAYS_INLINE auto operator+(
+    const TensorExpression<T, X, Symm, IndexList, tmpl::list<Args...>>& t,
+    const std::complex<N>& number) {
+  static_assert(
+      (... and tt::is_time_index<Args>::value),
+      "Can only add a number to a tensor expression that evaluates to a rank 0"
+      "tensor.");
+  return t + tenex::NumberAsExpression(number);
+}
+template <typename T, typename X, typename Symm, typename IndexList,
+          typename... Args, typename N>
+SPECTRE_ALWAYS_INLINE auto operator+(
+    const std::complex<N>& number,
+    const TensorExpression<T, X, Symm, IndexList, tmpl::list<Args...>>& t) {
+  static_assert(
+      (... and tt::is_time_index<Args>::value),
+      "Can only add a number to a tensor expression that evaluates to a rank 0"
+      "tensor.");
+  return t + tenex::NumberAsExpression(number);
+}
 /// @}
 
 /*!
@@ -978,6 +1010,28 @@ template <typename T, typename X, typename Symm, typename IndexList,
           Requires<std::is_arithmetic_v<N>> = nullptr>
 SPECTRE_ALWAYS_INLINE auto operator-(
     const N number,
+    const TensorExpression<T, X, Symm, IndexList, tmpl::list<Args...>>& t) {
+  static_assert(
+      (... and tt::is_time_index<Args>::value),
+      "Can only subtract a number from a tensor expression that evaluates to a "
+      "rank 0 tensor.");
+  return tenex::NumberAsExpression(number) - t;
+}
+template <typename T, typename X, typename Symm, typename IndexList,
+          typename... Args, typename N>
+SPECTRE_ALWAYS_INLINE auto operator-(
+    const TensorExpression<T, X, Symm, IndexList, tmpl::list<Args...>>& t,
+    const std::complex<N>& number) {
+  static_assert(
+      (... and tt::is_time_index<Args>::value),
+      "Can only subtract a number from a tensor expression that evaluates to a "
+      "rank 0 tensor.");
+  return t + tenex::NumberAsExpression(-number);
+}
+template <typename T, typename X, typename Symm, typename IndexList,
+          typename... Args, typename N>
+SPECTRE_ALWAYS_INLINE auto operator-(
+    const std::complex<N>& number,
     const TensorExpression<T, X, Symm, IndexList, tmpl::list<Args...>>& t) {
   static_assert(
       (... and tt::is_time_index<Args>::value),

--- a/src/DataStructures/Tensor/Expressions/CMakeLists.txt
+++ b/src/DataStructures/Tensor/Expressions/CMakeLists.txt
@@ -7,6 +7,7 @@ spectre_target_headers(
   HEADERS
   AddSubtract.hpp
   Contract.hpp
+  DataTypeSupport.hpp
   Divide.hpp
   Evaluate.hpp
   IndexPropertyCheck.hpp

--- a/src/DataStructures/Tensor/Expressions/DataTypeSupport.hpp
+++ b/src/DataStructures/Tensor/Expressions/DataTypeSupport.hpp
@@ -1,0 +1,389 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines which types are allowed, whether operations with certain types are
+/// allowed, and other type-specific properties and configuration for
+/// `TensorExpression`s
+///
+/// \details
+/// To add support for a data type, modify the templates in this file and the
+/// arithmetic operator overloads as necessary. Then, add tests as appropriate.
+
+#pragma once
+
+#include <cstddef>
+#include <limits>
+#include <type_traits>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "DataStructures/VectorImpl.hpp"
+#include "Utilities/NoSuchType.hpp"
+
+namespace tenex {
+template <typename DataType>
+struct NumberAsExpression;
+
+namespace detail {
+/// @{
+/// \brief Whether or not `TensorExpression`s supports using a given type as a
+/// numeric term
+///
+/// \details
+/// To make it possible to use a new numeric data type as a term in
+/// `TensorExpression`s, add the type to this alias and adjust other templates
+/// in this file, as necessary.
+///
+/// \tparam X the arithmetic data type
+template <typename X>
+struct is_supported_number_datatype : std::is_same<X, double> {};
+
+template <typename X>
+constexpr bool is_supported_number_datatype_v =
+    is_supported_number_datatype<X>::value;
+/// @}
+
+/// @{
+/// \brief Whether or not `Tensor`s with the given data type are currently
+/// supported by `TensorExpression`s
+///
+/// \details
+/// To make it possible to use a new data type in a `Tensor` term in
+/// `TensorExpression`s, add the type to this alias and adjust other templates
+/// in this file, as necessary.
+///
+/// \tparam X the `Tensor` data type
+template <typename X>
+struct is_supported_tensor_datatype
+    : std::disjunction<std::is_same<X, double>, std::is_same<X, DataVector>> {};
+
+template <typename X>
+constexpr bool is_supported_tensor_datatype_v =
+    is_supported_tensor_datatype<X>::value;
+/// @}
+
+/// \brief If the given type is a derived `VectorImpl` type, get the base
+/// `VectorImpl` type, else return the given type
+///
+/// \tparam T the given type
+/// \tparam IsVector whether or not the given type is a `VectorImpl` type
+template <typename T, bool IsVector = is_derived_of_vector_impl_v<T>>
+struct upcast_if_derived_vector_type;
+
+/// If `T` is not a `VectorImpl`, the `type` is just the input
+template <typename T>
+struct upcast_if_derived_vector_type<T, false> {
+  using type = T;
+};
+/// If `T` is a `VectorImpl`, the `type` is the base `VectorImpl` type
+template <typename T>
+struct upcast_if_derived_vector_type<T, true> {
+  using upcasted_type = typename T::BaseType;
+  // if we have a derived VectorImpl, get base type, else T is a base VectorImpl
+  // and we use that
+  using type =
+      tmpl::conditional_t<std::is_base_of_v<MarkAsVectorImpl, upcasted_type>,
+                          upcasted_type, T>;
+};
+
+/// \brief Whether or not a given type is assignable to another within
+/// `TensorExpression`s
+///
+/// \details
+/// This is used to define which types can be assigned to which when evaluating
+/// the result of a `TensorExpression`. For example, you can assign a
+/// `DataVector` to a `double`, but not vice versa.
+///
+/// To enable assignment between two types that is not yet supported, modify a
+/// current template specialization or add a new one.
+///
+/// \tparam LhsDataType the type being assigned
+/// \tparam RhsDataType the type to assign the `LhsDataType` to
+template <typename LhsDataType, typename RhsDataType>
+struct is_assignable;
+
+/// Can assign a type to itself
+template <typename LhsDataType, typename RhsDataType>
+struct is_assignable : std::is_same<LhsDataType, RhsDataType> {};
+/// Can assign a `VectorImpl` to its value type, e.g. can assign a `DataVector`
+/// to a `double`
+template <typename ValueType, typename VectorType>
+struct is_assignable<VectorImpl<ValueType, VectorType>, ValueType>
+    : std::true_type {};
+
+/// \brief Whether or not a given type is assignable to another within
+/// `TensorExpression`s
+///
+/// \details
+/// See `is_assignable` for which assignments are permitted
+template <typename LhsDataType, typename RhsDataType>
+constexpr bool is_assignable_v = is_assignable<
+    typename upcast_if_derived_vector_type<LhsDataType>::type,
+    typename upcast_if_derived_vector_type<RhsDataType>::type>::value;
+
+/// \brief Get the data type of a binary operation between two data types
+/// that may occur in a `TensorExpression`
+///
+/// \details
+/// This is used to define the resulting types of binary arithmetic operations
+/// within `TensorExpression`s, e.g. `double OP double = double` and
+/// `double OP DataVector = DataVector`.
+///
+/// To enable binary operations between two types that is not yet supported,
+/// modify a current template specialization or add a new one.
+///
+/// \tparam X1 the data type of one operand
+/// \tparam X2 the data type of the other operand
+template <typename X1, typename X2>
+struct get_binop_datatype_impl;
+
+/// No template specialization was matched, so it's not a known pairing
+template <typename X1, typename X2>
+struct get_binop_datatype_impl {
+  using type = NoSuchType;
+};
+/// A binary operation between two terms of the same type will yield a result
+/// with that type
+template <typename X>
+struct get_binop_datatype_impl<X, X> {
+  using type = X;
+};
+/// A binary operation between two `VectorImpl`s of the same type will
+/// yield the shared derived `VectorImpl`, e.g.
+/// `DataVector OP DataVector = DataVector`
+template <typename ValueType, typename VectorType>
+struct get_binop_datatype_impl<VectorImpl<ValueType, VectorType>,
+                               VectorImpl<ValueType, VectorType>> {
+  using type = VectorType;
+};
+/// @{
+/// A binary operation between a `VectorImpl` and its underlying value type
+/// yields the `VectorImpl`, e.g. `DataVector OP double = DataVector`
+template <typename ValueType, typename VectorType>
+struct get_binop_datatype_impl<VectorImpl<ValueType, VectorType>, ValueType> {
+  using type = VectorType;
+};
+template <typename ValueType, typename VectorType>
+struct get_binop_datatype_impl<ValueType, VectorImpl<ValueType, VectorType>> {
+  using type = VectorType;
+};
+/// @}
+
+/// \brief Get the data type of a binary operation between two data types
+/// that may occur in a `TensorExpression`
+///
+/// \details
+/// See `get_binop_datatype_impl` for which data type combinations have a
+/// defined result type
+///
+/// \tparam X1 the data type of one operand
+/// \tparam X2 the data type of the other operand
+template <typename X1, typename X2>
+struct get_binop_datatype {
+  using type = typename get_binop_datatype_impl<
+      typename upcast_if_derived_vector_type<X1>::type,
+      typename upcast_if_derived_vector_type<X2>::type>::type;
+
+  static_assert(
+      not std::is_same_v<type, NoSuchType>,
+      "You are attempting to perform a binary arithmetic operation between "
+      "two data types, but the data type of the result is not known within "
+      "TensorExpressions. See tenex::detail::get_binop_datatype_impl.");
+};
+
+/// @{
+/// \brief Whether or not it is permitted to perform binary arithmetic
+/// operations with the given types within `TensorExpression`
+///
+/// \details
+/// See `get_binop_datatype_impl` for which data type combinations have a
+/// defined result type
+///
+/// \tparam X1 the data type of one operand
+/// \tparam X2 the data type of the other operand
+template <typename X1, typename X2>
+struct binop_datatypes_are_supported
+    : std::negation<std::is_same<
+          typename get_binop_datatype_impl<
+              typename upcast_if_derived_vector_type<X1>::type,
+              typename upcast_if_derived_vector_type<X2>::type>::type,
+          NoSuchType>> {};
+
+template <typename X1, typename X2>
+constexpr bool binop_datatypes_are_supported_v =
+    binop_datatypes_are_supported<X1, X2>::value;
+/// @}
+
+/// \brief Whether or not it is permitted to perform binary arithmetic
+/// operations with `Tensor`s with the given types within `TensorExpression`s
+///
+/// \details
+/// This is used to define which data types can be contained by the two
+/// `Tensor`s in a binary operation, e.g.
+/// `Tensor<DataVector>() OP Tensor<DataVector>()` is permitted, but
+/// `Tensor<DataVector>() OP Tensor<double>()` is not.
+///
+/// To enable binary operations between `Tensor`s with types that are not yet
+/// supported, modify a current template specialization or add a new one.
+///
+/// \tparam X1 the data type of one `Tensor` operand
+/// \tparam X2 the data type of the other `Tensor` operand
+template <typename X1, typename X2>
+struct tensor_binop_datatypes_are_supported_impl;
+
+/// No template specialization was matched, so `Tensor`s with these data types
+/// cannot be together in a binary operation
+template <typename X1, typename X2>
+struct tensor_binop_datatypes_are_supported_impl : std::false_type {};
+/// Can do binary operations on two `Tensor`s that have the same data type
+template <typename X>
+struct tensor_binop_datatypes_are_supported_impl<X, X> : std::true_type {};
+
+/// @{
+/// \brief Whether or not it is permitted to perform binary arithmetic
+/// operations with `Tensor`s with the given types within `TensorExpression`s
+///
+/// \details
+/// See `tensor_binop_datatypes_are_supported_impl` for which data type
+/// combinations are permitted
+///
+/// \tparam X1 the data type of one `Tensor` operand
+/// \tparam X2 the data type of the other `Tensor` operand
+template <typename X1, typename X2>
+struct tensor_binop_datatypes_are_supported
+    : tensor_binop_datatypes_are_supported_impl<X1, X2> {
+  static_assert(
+      is_supported_tensor_datatype_v<X1> and is_supported_tensor_datatype_v<X2>,
+      "Cannot perform binary operations between the two Tensors with the "
+      "given data types because at least one of the data types is not "
+      "supported by TensorExpressions. See "
+      "tenex::detail::is_supported_tensor_datatype.");
+};
+
+template <typename X1, typename X2>
+constexpr bool tensor_binop_datatypes_are_supported_v =
+    tensor_binop_datatypes_are_supported<X1, X2>::value;
+/// @}
+
+/// \brief Whether or not it is permitted to perform binary arithmetic
+/// operations with `TensorExpression`s, based on their data types
+///
+/// \details
+/// This is used to define which data types can be contained by the two
+/// `TensorExpression`s in a binary operation, e.g.
+/// `Tensor<DataVector>() OP double` is permitted, but
+/// `Tensor<DataVector>() OP Tensor<double>()` is not. This differs from
+/// `tensor_binop_datatypes_are_supported` in that
+/// `tensorexpression_binop_datatypes_are_supported_impl` handles all derived
+/// `TensorExpression` types, whether they represent `Tensor`s or numbers.
+/// `tensor_binop_datatypes_are_supported` only handles the cases where both
+/// `TensorExpression`s represent `Tensor`s.
+///
+/// To enable binary operations between `TensorExpression`s with types that
+/// are not yet supported, modify a current template specialization or add a
+/// new one.
+///
+/// \tparam T1 the first `TensorExpression` operand
+/// \tparam T2 the second `TensorExpression` operand
+template <typename T1, typename T2>
+struct tensorexpression_binop_datatypes_are_supported_impl;
+
+/// Since `T1` and `T2` represent `Tensor`s, check if we can do
+/// `Tensor<T1::type>() OP Tensor<T2::type>()`
+template <typename T1, typename T2>
+struct tensorexpression_binop_datatypes_are_supported_impl
+    : tensor_binop_datatypes_are_supported_impl<typename T1::type,
+                                                typename T2::type> {};
+/// @{
+/// Can do `Tensor<X>() OP NUMBER` if we can do `X OP NUMBER`
+template <typename TensorExpressionType, typename NumberType>
+struct tensorexpression_binop_datatypes_are_supported_impl<
+    TensorExpressionType, NumberAsExpression<NumberType>>
+    : binop_datatypes_are_supported<typename TensorExpressionType::type,
+                                    NumberType> {
+  static_assert(
+      is_supported_tensor_datatype_v<typename TensorExpressionType::type> and
+          is_supported_number_datatype_v<NumberType>,
+      "Cannot perform binary operations between Tensor and number with the "
+      "given data types because at least one of the data types is not "
+      "supported by TensorExpressions. See "
+      "tenex::detail::is_supported_number_datatype and "
+      "tenex::detail::is_supported_tensor_datatype.");
+};
+template <typename NumberType, typename TensorExpressionType>
+struct tensorexpression_binop_datatypes_are_supported_impl<
+    NumberAsExpression<NumberType>, TensorExpressionType>
+    : tensorexpression_binop_datatypes_are_supported_impl<
+          TensorExpressionType, NumberAsExpression<NumberType>> {};
+/// @}
+
+/// @{
+/// \brief Whether or not it is permitted to perform binary arithmetic
+/// operations with `TensorExpression`s, based on their data types
+///
+/// \details
+/// See `tensorexpression_binop_datatypes_are_supported_impl` for which data
+/// type combinations are permitted
+///
+/// \tparam T1 the first `TensorExpression` operand
+/// \tparam T2 the second `TensorExpression` operand
+template <typename T1, typename T2>
+struct tensorexpression_binop_datatypes_are_supported
+    : tensorexpression_binop_datatypes_are_supported_impl<T1, T2> {
+  static_assert(
+      std::is_base_of_v<Expression, T1> and std::is_base_of_v<Expression, T2>,
+      "Template arguments to "
+      "tenex::detail::tensorexpression_binop_datatypes_are_supported must be "
+      "TensorExpressions.");
+};
+
+template <typename X1, typename X2>
+constexpr bool tensorexpression_binop_datatypes_are_supported_v =
+    tensorexpression_binop_datatypes_are_supported<X1, X2>::value;
+/// @}
+
+/// \brief The maximum number of arithmetic tensor operations allowed in a
+/// `TensorExpression` subtree before having it be a splitting point in the
+/// overall RHS expression, according to the data type held by the `Tensor`s in
+/// the expression
+///
+/// \details
+/// To enable splitting for `TensorExpression`s with data type, define a
+/// template specialization below for your data type and set the `value`.
+///
+/// Before defining a max operations cap for some data type, the change should
+/// first be justified by benchmarking many different tensor expressions before
+/// and after introducing the new cap. The optimal cap will likely be
+/// hardware-dependent, so fine-tuning this would ideally involve benchmarking
+/// on each hardware architecture and then controling the value based on the
+/// hardware.
+template <typename DataType>
+struct max_num_ops_in_sub_expression_impl {
+  // effectively, no splitting for any unspecialized template type
+  static constexpr size_t value = std::numeric_limits<size_t>::max();
+};
+
+/// \brief When the data type of the result of a `TensorExpression` is
+/// `DataVector`, the maximum number of arithmetic tensor operations allowed in
+/// a subtree before having it be a splitting point in the overall RHS
+/// expression
+///
+/// \details
+/// The current value set for when the data type is `DataVector` was benchmarked
+/// by compiling with clang-10 Release and running on Intel(R) Xeon(R)
+/// CPU E5-2630 v4 @ 2.20GHz.
+template <>
+struct max_num_ops_in_sub_expression_impl<DataVector> {
+  static constexpr size_t value = 8;
+};
+
+/// \brief Get maximum number of arithmetic tensor operations allowed in a
+/// `TensorExpression` subtree before having it be a splitting point in the
+/// overall RHS expression, according to the `DataType` held by the `Tensor`s in
+/// the expression
+template <typename DataType>
+inline constexpr size_t max_num_ops_in_sub_expression =
+    max_num_ops_in_sub_expression_impl<DataType>::value;
+}  // namespace detail
+}  // namespace tenex

--- a/src/DataStructures/Tensor/Expressions/Divide.hpp
+++ b/src/DataStructures/Tensor/Expressions/Divide.hpp
@@ -12,12 +12,14 @@
 #include <type_traits>
 #include <utility>
 
+#include "DataStructures/Tensor/Expressions/DataTypeSupport.hpp"
 #include "DataStructures/Tensor/Expressions/NumberAsExpression.hpp"
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/Expressions/TimeIndex.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
+#include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace tenex {
@@ -35,28 +37,26 @@ namespace tenex {
 /// \tparam T2 the denominator operand expression of the division expression
 /// \tparam Args2 the generic indices of the denominator expression
 template <typename T1, typename T2, typename... Args2>
-struct Divide : public TensorExpression<
-                    Divide<T1, T2, Args2...>,
-                    typename std::conditional_t<
-                        std::is_same<typename T1::type, DataVector>::value or
-                            std::is_same<typename T2::type, DataVector>::value,
-                        DataVector, double>,
-                    typename T1::symmetry, typename T1::index_list,
-                    typename T1::args_list> {
-  static_assert(std::is_same<typename T1::type, typename T2::type>::value or
-                    std::is_same<T1, NumberAsExpression>::value,
-                "Cannot divide TensorExpressions holding different data types");
+struct Divide
+    : public TensorExpression<Divide<T1, T2, Args2...>,
+                              typename detail::get_binop_datatype<
+                                  typename T1::type, typename T2::type>::type,
+                              typename T1::symmetry, typename T1::index_list,
+                              typename T1::args_list> {
+  static_assert(
+      detail::tensorexpression_binop_datatypes_are_supported_v<T1, T2>,
+      "Cannot divide the given TensorExpressions with the given data types. "
+      "This can occur from e.g. trying to divide a Tensor with data type "
+      "double and a Tensor with data type DataVector.");
   static_assert((... and tt::is_time_index<Args2>::value),
-                "Can only divide a tensor expression by a double or a tensor "
+                "Can only divide a tensor expression by a number or a tensor "
                 "expression that evaluates to "
                 "a rank 0 tensor.");
 
   // === Index properties ===
   /// The type of the data being stored in the result of the expression
-  using type =
-      std::conditional_t<std::is_same<typename T1::type, DataVector>::value or
-                             std::is_same<typename T2::type, DataVector>::value,
-                         DataVector, double>;
+  using type = typename detail::get_binop_datatype<typename T1::type,
+                                                   typename T2::type>::type;
   /// The ::Symmetry of the result of the expression
   using symmetry = typename T1::symmetry;
   /// The list of \ref SpacetimeIndex "TensorIndexType"s of the result of the
@@ -154,10 +154,10 @@ struct Divide : public TensorExpression<
   template <typename LhsTensor>
   SPECTRE_ALWAYS_INLINE void assert_lhs_tensor_not_in_rhs_expression(
       const gsl::not_null<LhsTensor*> lhs_tensor) const {
-    if constexpr (not std::is_base_of_v<NumberAsExpression, T1>) {
+    if constexpr (not std::is_base_of_v<MarkAsNumberAsExpression, T1>) {
       t1_.assert_lhs_tensor_not_in_rhs_expression(lhs_tensor);
     }
-    if constexpr (not std::is_base_of_v<NumberAsExpression, T2>) {
+    if constexpr (not std::is_base_of_v<MarkAsNumberAsExpression, T2>) {
       t2_.assert_lhs_tensor_not_in_rhs_expression(lhs_tensor);
     }
   }
@@ -171,10 +171,10 @@ struct Divide : public TensorExpression<
   template <typename LhsTensorIndices, typename LhsTensor>
   SPECTRE_ALWAYS_INLINE void assert_lhs_tensorindices_same_in_rhs(
       const gsl::not_null<LhsTensor*> lhs_tensor) const {
-    if constexpr (not std::is_base_of_v<NumberAsExpression, T1>) {
+    if constexpr (not std::is_base_of_v<MarkAsNumberAsExpression, T1>) {
       t1_.assert_lhs_tensorindices_same_in_rhs(lhs_tensor);
     }
-    if constexpr (not std::is_base_of_v<NumberAsExpression, T2>) {
+    if constexpr (not std::is_base_of_v<MarkAsNumberAsExpression, T2>) {
       t2_.assert_lhs_tensorindices_same_in_rhs(lhs_tensor);
     }
   }
@@ -220,8 +220,9 @@ struct Divide : public TensorExpression<
   //// tensor to retrieve
   /// \return the value of the component in the quotient tensor at
   /// `result_multi_index`
+  template <typename ResultType>
   SPECTRE_ALWAYS_INLINE decltype(auto) get_primary(
-      const type& result_component,
+      const ResultType& result_component,
       const std::array<size_t, num_tensor_indices>& result_multi_index) const {
     if constexpr (is_primary_end) {
       (void)result_multi_index;
@@ -232,7 +233,7 @@ struct Divide : public TensorExpression<
     } else {
       // We haven't yet evaluated the whole subtree for this expression, so
       // return the quotient of the results of the two operands' subtrees
-      return t1_.get_primary(result_component, result_multi_index) /
+      return t1_.template get_primary(result_component, result_multi_index) /
              t2_.get(op2_multi_index);
     }
   }
@@ -257,8 +258,9 @@ struct Divide : public TensorExpression<
   /// \param result_component the LHS tensor component to evaluate
   /// \param result_multi_index the multi-index of the component of the result
   /// tensor to evaluate
+  template <typename ResultType>
   SPECTRE_ALWAYS_INLINE void evaluate_primary_children(
-      type& result_component,
+      ResultType& result_component,
       const std::array<size_t, num_tensor_indices>& result_multi_index) const {
     if constexpr (is_primary_end) {
       (void)result_multi_index;
@@ -270,7 +272,8 @@ struct Divide : public TensorExpression<
       // We haven't yet evaluated the whole subtree of the primary child, so
       // first assign the result component to be the result of computing the
       // primary child's subtree
-      result_component = t1_.get_primary(result_component, result_multi_index);
+      result_component =
+          t1_.template get_primary(result_component, result_multi_index);
       // Now that the primary child's subtree has been computed, divide the
       // current result by the result of evaluating the other child's subtree
       result_component /= t2_.get(op2_multi_index);
@@ -289,13 +292,15 @@ struct Divide : public TensorExpression<
   /// \param result_component the LHS tensor component to evaluate
   /// \param result_multi_index the multi-index of the component of the result
   /// tensor to evaluate
+  template <typename ResultType>
   SPECTRE_ALWAYS_INLINE void evaluate_primary_subtree(
-      type& result_component,
+      ResultType& result_component,
       const std::array<size_t, num_tensor_indices>& result_multi_index) const {
     if constexpr (primary_child_subtree_contains_primary_start) {
       // The primary child's subtree contains at least one leg, so recurse down
       // and evaluate that first
-      t1_.evaluate_primary_subtree(result_component, result_multi_index);
+      t1_.template evaluate_primary_subtree(result_component,
+                                            result_multi_index);
     }
     if constexpr (is_primary_start) {
       // We want to evaluate the subtree for this expression
@@ -343,33 +348,33 @@ SPECTRE_ALWAYS_INLINE auto operator/(
 
 /// \ingroup TensorExpressionsGroup
 /// \brief Returns the tensor expression representing the quotient of a tensor
-/// expression over a `double`
+/// expression over a number
 ///
 /// \note The implementation instead uses the operation, `t * (1.0 / number)`
 ///
 /// \param t the tensor expression operand of the quotient
-/// \param number the `double` operand of the quotient
-/// \return the tensor expression representing the quotient of a tensor
-/// expression and a `double`
-template <typename T>
+/// \param number the numeric operand of the quotient
+/// \return the tensor expression representing the quotient of the tensor
+/// expression over the number
+template <typename T, typename N, Requires<std::is_arithmetic_v<N>> = nullptr>
 SPECTRE_ALWAYS_INLINE auto operator/(
     const TensorExpression<T, typename T::type, typename T::symmetry,
                            typename T::index_list, typename T::args_list>& t,
-    const double number) {
+    const N number) {
   return t * tenex::NumberAsExpression(1.0 / number);
 }
 
 /// \ingroup TensorExpressionsGroup
-/// \brief Returns the tensor expression representing the quotient of a `double`
+/// \brief Returns the tensor expression representing the quotient of a number
 /// over a tensor expression that evaluates to a rank 0 tensor
 ///
-/// \param number the `double` numerator of the quotient
+/// \param number the numeric numerator of the quotient
 /// \param t the tensor expression denominator of the quotient
-/// \return the tensor expression representing the quotient of a `double` over a
-/// tensor expression that evaluates to a rank 0 tensor
-template <typename T>
+/// \return the tensor expression representing the quotient of the number over
+/// the tensor expression
+template <typename T, typename N, Requires<std::is_arithmetic_v<N>> = nullptr>
 SPECTRE_ALWAYS_INLINE auto operator/(
-    const double number,
+    const N number,
     const TensorExpression<T, typename T::type, typename T::symmetry,
                            typename T::index_list, typename T::args_list>& t) {
   return tenex::NumberAsExpression(number) / t;

--- a/src/DataStructures/Tensor/Expressions/Evaluate.hpp
+++ b/src/DataStructures/Tensor/Expressions/Evaluate.hpp
@@ -10,6 +10,8 @@
 #include <cstddef>
 #include <type_traits>
 
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Expressions/DataTypeSupport.hpp"
 #include "DataStructures/Tensor/Expressions/IndexPropertyCheck.hpp"
 #include "DataStructures/Tensor/Expressions/LhsTensorSymmAndIndices.hpp"
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
@@ -139,13 +141,14 @@ struct CheckNoLhsAntiSymmetries<SymmList<Symm...>> {
  * @param lhs_tensor pointer to the resultant LHS `Tensor` to fill
  * @param rhs_tensorexpression the RHS TensorExpression to be evaluated
  */
-template <bool EvaluateSubtrees, auto&... LhsTensorIndices, typename X,
-          typename LhsSymmetry, typename LhsIndexList, typename Derived,
-          typename RhsSymmetry, typename RhsIndexList,
-          typename... RhsTensorIndices>
+template <bool EvaluateSubtrees, auto&... LhsTensorIndices,
+          typename LhsDataType, typename LhsSymmetry, typename LhsIndexList,
+          typename Derived, typename RhsDataType, typename RhsSymmetry,
+          typename RhsIndexList, typename... RhsTensorIndices>
 void evaluate_impl(
-    const gsl::not_null<Tensor<X, LhsSymmetry, LhsIndexList>*> lhs_tensor,
-    const TensorExpression<Derived, X, RhsSymmetry, RhsIndexList,
+    const gsl::not_null<Tensor<LhsDataType, LhsSymmetry, LhsIndexList>*>
+        lhs_tensor,
+    const TensorExpression<Derived, RhsDataType, RhsSymmetry, RhsIndexList,
                            tmpl::list<RhsTensorIndices...>>&
         rhs_tensorexpression) {
   constexpr size_t num_lhs_indices = sizeof...(LhsTensorIndices);
@@ -155,10 +158,18 @@ void evaluate_impl(
       tmpl::list<std::decay_t<decltype(LhsTensorIndices)>...>;
   using rhs_tensorindex_list = tmpl::list<RhsTensorIndices...>;
 
-  static_assert(std::is_same_v<double, X> or std::is_same_v<DataVector, X>,
+  using lhs_tensor_type = typename std::decay_t<decltype(*lhs_tensor)>;
+
+  static_assert(is_supported_tensor_datatype_v<LhsDataType> and
+                    is_supported_tensor_datatype_v<RhsDataType>,
                 "TensorExpressions currently only support Tensors whose data "
                 "type is double or DataVector. It is possible to add support "
                 "for other data types that are supported by Tensor.");
+  static_assert(
+      is_assignable_v<LhsDataType, RhsDataType>,
+      "Assignment of the LHS Tensor's data type to the RHS TensorExpression's "
+      "data type is not supported. This happens from doing something like e.g. "
+      "trying to assign a Tensor<double> to a Tensor<DataVector>.");
   // `Symmetry` currently prevents this because antisymmetries are not currently
   // supported for `Tensor`s. This check is repeated here because if
   // antisymmetries are later supported for `Tensor`, using antisymmetries in
@@ -220,14 +231,14 @@ void evaluate_impl(
   if constexpr (EvaluateSubtrees) {
     // Make sure the LHS tensor doesn't also appear in the RHS tensor expression
     (~rhs_tensorexpression).assert_lhs_tensor_not_in_rhs_expression(lhs_tensor);
-    // If the data type is `DataVector`, size the LHS tensor components if their
+    // If the LHS data type is a vector, size the LHS tensor components if their
     // size does not match the size from a `Tensor` in the RHS expression
-    if constexpr (std::is_same_v<DataVector, X>) {
+    if constexpr (is_derived_of_vector_impl_v<LhsDataType>) {
       const size_t rhs_component_size =
           (~rhs_tensorexpression).get_rhs_tensor_component_size();
       if (rhs_component_size != (*lhs_tensor)[0].size()) {
         for (auto& lhs_component : *lhs_tensor) {
-          lhs_component = DataVector(rhs_component_size);
+          lhs_component = LhsDataType(rhs_component_size);
         }
       }
     }
@@ -253,7 +264,6 @@ void evaluate_impl(
   constexpr auto lhs_time_index_positions =
       get_time_index_positions<lhs_tensorindex_list>();
 
-  using lhs_tensor_type = typename std::decay_t<decltype(*lhs_tensor)>;
   using rhs_expression_type =
       typename std::decay_t<decltype(~rhs_tensorexpression)>;
 
@@ -303,7 +313,7 @@ void evaluate_impl(
 
 /*!
  * \ingroup TensorExpressionsGroup
- * \brief Assign a `double` value to components of the LHS tensor
+ * \brief Assign a value to components of the LHS tensor
  *
  * \details This is for internal use only and should never be directly called.
  * See `tenex::evaluate` and use it, instead.
@@ -317,19 +327,24 @@ void evaluate_impl(
  * @param rhs_value the RHS value to assigned
  */
 template <auto&... LhsTensorIndices, typename X, typename LhsSymmetry,
-          typename LhsIndexList>
+          typename LhsIndexList, typename NumberType>
 void evaluate_impl(
     const gsl::not_null<Tensor<X, LhsSymmetry, LhsIndexList>*> lhs_tensor,
-    const double rhs_value) {
+    const NumberType& rhs_value) {
+  using lhs_tensor_type = typename std::decay_t<decltype(*lhs_tensor)>;
   constexpr size_t num_lhs_indices = sizeof...(LhsTensorIndices);
-
   using lhs_tensorindex_list =
       tmpl::list<std::decay_t<decltype(LhsTensorIndices)>...>;
 
-  static_assert(std::is_same_v<double, X> or std::is_same_v<DataVector, X>,
+  static_assert(is_supported_tensor_datatype_v<X> and
                 "TensorExpressions currently only support Tensors whose data "
                 "type is double or DataVector. It is possible to add support "
                 "for other data types that are supported by Tensor.");
+  static_assert(
+      is_assignable_v<X, NumberType>,
+      "Assignment of the LHS Tensor's data type to the RHS number's data type "
+      "is not supported within TensorExpressions. This happens from doing "
+      "something like e.g. trying to assign a Tensor<double> to an int.");
   // `Symmetry` currently prevents this because antisymmetries are not currently
   // supported for `Tensor`s. This check is repeated here because if
   // antisymmetries are later supported for `Tensor`, using antisymmetries in
@@ -351,6 +366,13 @@ void evaluate_impl(
       "Cannot assign a tensor expression to a LHS tensor with generic "
       "indices that would be contracted, e.g. evaluate<ti::A, ti::a>.");
 
+  if constexpr (is_derived_of_vector_impl_v<X>) {
+    ASSERT(get_size((*lhs_tensor)[0]) > 0,
+           "Tensors with vector components must be sized before calling "
+           "\ntenex::evaluate<...>("
+           "\n\tgsl::not_null<Tensor<VectorType, ...>*>, number).");
+  }
+
   // positions of indices in LHS tensor where generic spatial indices are used
   // for spacetime indices
   constexpr auto lhs_spatial_spacetime_index_positions =
@@ -360,8 +382,6 @@ void evaluate_impl(
   // positions of indices in LHS tensor where concrete time indices are used
   constexpr auto lhs_time_index_positions =
       get_time_index_positions<lhs_tensorindex_list>();
-
-  using lhs_tensor_type = typename std::decay_t<decltype(*lhs_tensor)>;
 
   for (size_t i = 0; i < lhs_tensor_type::size(); i++) {
     auto lhs_multi_index =
@@ -416,12 +436,14 @@ void evaluate_impl(
  * @param lhs_tensor pointer to the resultant LHS `Tensor` to fill
  * @param rhs_tensorexpression the RHS TensorExpression to be evaluated
  */
-template <auto&... LhsTensorIndices, typename X, typename LhsSymmetry,
-          typename LhsIndexList, typename Derived, typename RhsSymmetry,
-          typename RhsIndexList, typename... RhsTensorIndices>
+template <auto&... LhsTensorIndices, typename LhsDataType, typename LhsSymmetry,
+          typename LhsIndexList, typename Derived, typename RhsDataType,
+          typename RhsSymmetry, typename RhsIndexList,
+          typename... RhsTensorIndices>
 void evaluate(
-    const gsl::not_null<Tensor<X, LhsSymmetry, LhsIndexList>*> lhs_tensor,
-    const TensorExpression<Derived, X, RhsSymmetry, RhsIndexList,
+    const gsl::not_null<Tensor<LhsDataType, LhsSymmetry, LhsIndexList>*>
+        lhs_tensor,
+    const TensorExpression<Derived, RhsDataType, RhsSymmetry, RhsIndexList,
                            tmpl::list<RhsTensorIndices...>>&
         rhs_tensorexpression) {
   using rhs_expression_type =
@@ -434,7 +456,7 @@ void evaluate(
 
 /*!
  * \ingroup TensorExpressionsGroup
- * \brief Assign a `double` to components of a tensor with the LHS index order
+ * \brief Assign a number to components of a tensor with the LHS index order
  * set in the template parameters
  *
  * \details
@@ -453,17 +475,11 @@ void evaluate(
  * @param rhs_value the RHS value to assign
  */
 template <auto&... LhsTensorIndices, typename X, typename LhsSymmetry,
-          typename LhsIndexList>
+          typename LhsIndexList, typename N,
+          Requires<std::is_arithmetic_v<N>> = nullptr>
 void evaluate(
     const gsl::not_null<Tensor<X, LhsSymmetry, LhsIndexList>*> lhs_tensor,
-    const double rhs_value) {
-  if constexpr (std::is_same_v<X, DataVector>) {
-    ASSERT(get_size((*lhs_tensor)[0]) > 0,
-           "Tensors with DataVector components must be sized before calling "
-           "tenex::evaluate<...>("
-           "\tgsl::not_null<Tensor<DataVector, ...>*>, double).");
-  }
-
+    const N rhs_value) {
   detail::evaluate_impl<LhsTensorIndices...>(lhs_tensor, rhs_value);
 }
 
@@ -576,12 +592,14 @@ auto evaluate(const RhsTE& rhs_tensorexpression) {
  * @param lhs_tensor pointer to the resultant LHS Tensor to fill
  * @param rhs_tensorexpression the RHS TensorExpression to be evaluated
  */
-template <auto&... LhsTensorIndices, typename X, typename LhsSymmetry,
-          typename LhsIndexList, typename Derived, typename RhsSymmetry,
-          typename RhsIndexList, typename... RhsTensorIndices>
+template <auto&... LhsTensorIndices, typename LhsDataType, typename RhsDataType,
+          typename LhsSymmetry, typename LhsIndexList, typename Derived,
+          typename RhsSymmetry, typename RhsIndexList,
+          typename... RhsTensorIndices>
 void update(
-    const gsl::not_null<Tensor<X, LhsSymmetry, LhsIndexList>*> lhs_tensor,
-    const TensorExpression<Derived, X, RhsSymmetry, RhsIndexList,
+    const gsl::not_null<Tensor<LhsDataType, LhsSymmetry, LhsIndexList>*>
+        lhs_tensor,
+    const TensorExpression<Derived, RhsDataType, RhsSymmetry, RhsIndexList,
                            tmpl::list<RhsTensorIndices...>>&
         rhs_tensorexpression) {
   using lhs_tensorindex_list =

--- a/src/DataStructures/Tensor/Expressions/Evaluate.hpp
+++ b/src/DataStructures/Tensor/Expressions/Evaluate.hpp
@@ -10,6 +10,7 @@
 #include <cstddef>
 #include <type_traits>
 
+#include "DataStructures/ComplexDataVector.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Expressions/DataTypeSupport.hpp"
 #include "DataStructures/Tensor/Expressions/IndexPropertyCheck.hpp"
@@ -163,13 +164,15 @@ void evaluate_impl(
   static_assert(is_supported_tensor_datatype_v<LhsDataType> and
                     is_supported_tensor_datatype_v<RhsDataType>,
                 "TensorExpressions currently only support Tensors whose data "
-                "type is double or DataVector. It is possible to add support "
-                "for other data types that are supported by Tensor.");
+                "type is double, DataVector, or ComplexDataVector. It is "
+                "possible to add support for other data types that are "
+                "supported by Tensor.");
   static_assert(
       is_assignable_v<LhsDataType, RhsDataType>,
       "Assignment of the LHS Tensor's data type to the RHS TensorExpression's "
       "data type is not supported. This happens from doing something like e.g. "
-      "trying to assign a Tensor<double> to a Tensor<DataVector>.");
+      "trying to assign a Tensor<double> to a Tensor<DataVector> or a "
+      "Tensor<DataVector> to a Tensor<ComplexDataVector>.");
   // `Symmetry` currently prevents this because antisymmetries are not currently
   // supported for `Tensor`s. This check is repeated here because if
   // antisymmetries are later supported for `Tensor`, using antisymmetries in
@@ -338,13 +341,15 @@ void evaluate_impl(
 
   static_assert(is_supported_tensor_datatype_v<X> and
                 "TensorExpressions currently only support Tensors whose data "
-                "type is double or DataVector. It is possible to add support "
-                "for other data types that are supported by Tensor.");
+                "type is double, DataVector, or ComplexDataVector. It is "
+                "possible to add support for other data types that are "
+                "supported by Tensor.");
   static_assert(
       is_assignable_v<X, NumberType>,
       "Assignment of the LHS Tensor's data type to the RHS number's data type "
       "is not supported within TensorExpressions. This happens from doing "
-      "something like e.g. trying to assign a Tensor<double> to an int.");
+      "something like e.g. trying to assign a double to a DataVector or a "
+      "DataVector to a ComplexDataVector.");
   // `Symmetry` currently prevents this because antisymmetries are not currently
   // supported for `Tensor`s. This check is repeated here because if
   // antisymmetries are later supported for `Tensor`, using antisymmetries in

--- a/src/DataStructures/Tensor/Expressions/Evaluate.hpp
+++ b/src/DataStructures/Tensor/Expressions/Evaluate.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <array>
+#include <complex>
 #include <cstddef>
 #include <type_traits>
 
@@ -164,9 +165,9 @@ void evaluate_impl(
   static_assert(is_supported_tensor_datatype_v<LhsDataType> and
                     is_supported_tensor_datatype_v<RhsDataType>,
                 "TensorExpressions currently only support Tensors whose data "
-                "type is double, DataVector, or ComplexDataVector. It is "
-                "possible to add support for other data types that are "
-                "supported by Tensor.");
+                "type is double, std::complex<double>, DataVector, or "
+                "ComplexDataVector. It is possible to add support for other "
+                "data types that are supported by Tensor.");
   static_assert(
       is_assignable_v<LhsDataType, RhsDataType>,
       "Assignment of the LHS Tensor's data type to the RHS TensorExpression's "
@@ -341,9 +342,9 @@ void evaluate_impl(
 
   static_assert(is_supported_tensor_datatype_v<X> and
                 "TensorExpressions currently only support Tensors whose data "
-                "type is double, DataVector, or ComplexDataVector. It is "
-                "possible to add support for other data types that are "
-                "supported by Tensor.");
+                "type is double, std::complex<double>, DataVector, or "
+                "ComplexDataVector. It is possible to add support for other "
+                "data types that are supported by Tensor.");
   static_assert(
       is_assignable_v<X, NumberType>,
       "Assignment of the LHS Tensor's data type to the RHS number's data type "
@@ -459,6 +460,7 @@ void evaluate(
       lhs_tensor, rhs_tensorexpression);
 }
 
+/// @{
 /*!
  * \ingroup TensorExpressionsGroup
  * \brief Assign a number to components of a tensor with the LHS index order
@@ -487,6 +489,14 @@ void evaluate(
     const N rhs_value) {
   detail::evaluate_impl<LhsTensorIndices...>(lhs_tensor, rhs_value);
 }
+template <auto&... LhsTensorIndices, typename X, typename LhsSymmetry,
+          typename LhsIndexList, typename N>
+void evaluate(
+    const gsl::not_null<Tensor<X, LhsSymmetry, LhsIndexList>*> lhs_tensor,
+    const std::complex<N>& rhs_value) {
+  detail::evaluate_impl<LhsTensorIndices...>(lhs_tensor, rhs_value);
+}
+/// @}
 
 /*!
  * \ingroup TensorExpressionsGroup

--- a/src/DataStructures/Tensor/Expressions/NumberAsExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/NumberAsExpression.hpp
@@ -7,24 +7,40 @@
 #include <cstddef>
 #include <limits>
 
+#include "DataStructures/Tensor/Expressions/DataTypeSupport.hpp"
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace tenex {
 /// \ingroup TensorExpressionsGroup
-/// \brief Defines an expression representing a `double`
+/// \brief Marks a class as being a `NumberAsExpression<DataType>`
+///
+/// \details
+/// The empty base class provides a simple means for checking if a type is a
+/// `NumberAsExpression<DataType>`.
+struct MarkAsNumberAsExpression {};
+
+/// \ingroup TensorExpressionsGroup
+/// \brief Defines an expression representing a number
 ///
 /// \details
 /// For details on aliases and members defined in this class, as well as general
 /// `TensorExpression` terminology used in its members' documentation, see
 /// documentation for `TensorExpression`.
+template <typename DataType>
 struct NumberAsExpression
-    : public TensorExpression<NumberAsExpression, double, tmpl::list<>,
-                              tmpl::list<>, tmpl::list<>> {
+    : public TensorExpression<NumberAsExpression<DataType>, DataType,
+                              tmpl::list<>, tmpl::list<>, tmpl::list<>>,
+      MarkAsNumberAsExpression {
+  static_assert(detail::is_supported_number_datatype_v<DataType>,
+                "TensorExpressions currently only support numeric terms whose "
+                "type is double. It is possible to add support for more "
+                "numeric types.");
+
   // === Index properties ===
   /// The type of the data being stored in the result of the expression
-  using type = double;
+  using type = DataType;
   /// The list of \ref SpacetimeIndex "TensorIndexType"s of the result of the
   /// expression
   using symmetry = tmpl::list<>;
@@ -87,12 +103,12 @@ struct NumberAsExpression
   static constexpr bool primary_subtree_contains_primary_start =
       is_primary_start;
 
-  NumberAsExpression(const double number) : number_(number) {}
+  NumberAsExpression(const type& number) : number_(number) {}
   ~NumberAsExpression() override = default;
 
   // This expression does not represent a tensor, nor does it have any children,
   // so we should never need to assert that the LHS `Tensor` is not equal to the
-  // `double` stored by this expression
+  // number stored by this expression
   template <typename LhsTensor>
   void assert_lhs_tensor_not_in_rhs_expression(
       const gsl::not_null<LhsTensor*>) const = delete;
@@ -109,8 +125,8 @@ struct NumberAsExpression
   /// \brief Returns the number represented by the expression
   ///
   /// \return the number represented by this expression
-  SPECTRE_ALWAYS_INLINE double get(
-      const std::array<size_t, num_tensor_indices>& /*multi_index*/) const {
+  SPECTRE_ALWAYS_INLINE type
+  get(const std::array<size_t, num_tensor_indices>& /*multi_index*/) const {
     return number_;
   }
 
@@ -118,7 +134,7 @@ struct NumberAsExpression
   ///
   /// \return the number represented by this expression
   template <typename ResultType>
-  SPECTRE_ALWAYS_INLINE double get_primary(
+  SPECTRE_ALWAYS_INLINE type get_primary(
       const ResultType& /*result_component*/,
       const std::array<size_t, num_tensor_indices>& /*multi_index*/) const {
     return number_;
@@ -135,6 +151,6 @@ struct NumberAsExpression
 
  private:
   /// Number represented by this expression
-  double number_;
+  type number_;
 };
 }  // namespace tenex

--- a/src/DataStructures/Tensor/Expressions/NumberAsExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/NumberAsExpression.hpp
@@ -35,8 +35,8 @@ struct NumberAsExpression
       MarkAsNumberAsExpression {
   static_assert(detail::is_supported_number_datatype_v<DataType>,
                 "TensorExpressions currently only support numeric terms whose "
-                "type is double. It is possible to add support for more "
-                "numeric types.");
+                "type is double or std::complex<double>. It is possible to add "
+                "support for more numeric types.");
 
   // === Index properties ===
   /// The type of the data being stored in the result of the expression

--- a/src/DataStructures/Tensor/Expressions/Product.hpp
+++ b/src/DataStructures/Tensor/Expressions/Product.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <array>
+#include <complex>
 #include <cstddef>
 #include <limits>
 #include <type_traits>
@@ -486,6 +487,20 @@ SPECTRE_ALWAYS_INLINE auto operator*(
 template <typename T, typename N, Requires<std::is_arithmetic_v<N>> = nullptr>
 SPECTRE_ALWAYS_INLINE auto operator*(
     const N number,
+    const TensorExpression<T, typename T::type, typename T::symmetry,
+                           typename T::index_list, typename T::args_list>& t) {
+  return t * tenex::NumberAsExpression(number);
+}
+template <typename T, typename N>
+SPECTRE_ALWAYS_INLINE auto operator*(
+    const TensorExpression<T, typename T::type, typename T::symmetry,
+                           typename T::index_list, typename T::args_list>& t,
+    const std::complex<N>& number) {
+  return t * tenex::NumberAsExpression(number);
+}
+template <typename T, typename N>
+SPECTRE_ALWAYS_INLINE auto operator*(
+    const std::complex<N>& number,
     const TensorExpression<T, typename T::type, typename T::symmetry,
                            typename T::index_list, typename T::args_list>& t) {
   return t * tenex::NumberAsExpression(number);

--- a/src/DataStructures/Tensor/Expressions/Product.hpp
+++ b/src/DataStructures/Tensor/Expressions/Product.hpp
@@ -13,11 +13,13 @@
 #include <utility>
 
 #include "DataStructures/Tensor/Expressions/Contract.hpp"
+#include "DataStructures/Tensor/Expressions/DataTypeSupport.hpp"
 #include "DataStructures/Tensor/Expressions/NumberAsExpression.hpp"
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/Symmetry.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace tenex {
@@ -31,9 +33,7 @@ template <typename T1, typename T2, template <typename...> class SymmList1,
           typename... Symm2>
 struct OuterProductType<T1, T2, SymmList1<Symm1...>, SymmList2<Symm2...>> {
   using type =
-      std::conditional_t<std::is_same<typename T1::type, DataVector>::value or
-                             std::is_same<typename T2::type, DataVector>::value,
-                         DataVector, double>;
+      typename get_binop_datatype<typename T1::type, typename T2::type>::type;
   using symmetry =
       Symmetry<(Symm1::value + sizeof...(Symm2))..., Symm2::value...>;
   using index_list =
@@ -73,10 +73,11 @@ struct OuterProduct<T1, T2, IndexList1<Indices1...>, IndexList2<Indices2...>,
           typename detail::OuterProductType<T1, T2>::symmetry,
           typename detail::OuterProductType<T1, T2>::index_list,
           typename detail::OuterProductType<T1, T2>::tensorindex_list> {
-  static_assert(std::is_same<typename T1::type, typename T2::type>::value or
-                    std::is_same<T1, NumberAsExpression>::value or
-                    std::is_same<T2, NumberAsExpression>::value,
-                "Cannot product Tensors holding different data types.");
+  static_assert(
+      detail::tensorexpression_binop_datatypes_are_supported_v<T1, T2>,
+      "Cannot multiply the given TensorExpressions with the given data types. "
+      "This can occur from e.g. trying to multiply a Tensor with data type "
+      "double and a Tensor with data type DataVector.");
   // === Index properties ===
   /// The type of the data being stored in the result of the expression
   using type = typename detail::OuterProductType<T1, T2>::type;
@@ -181,10 +182,10 @@ struct OuterProduct<T1, T2, IndexList1<Indices1...>, IndexList2<Indices2...>,
   template <typename LhsTensor>
   SPECTRE_ALWAYS_INLINE void assert_lhs_tensor_not_in_rhs_expression(
       const gsl::not_null<LhsTensor*> lhs_tensor) const {
-    if constexpr (not std::is_base_of_v<NumberAsExpression, T1>) {
+    if constexpr (not std::is_base_of_v<MarkAsNumberAsExpression, T1>) {
       t1_.assert_lhs_tensor_not_in_rhs_expression(lhs_tensor);
     }
-    if constexpr (not std::is_base_of_v<NumberAsExpression, T2>) {
+    if constexpr (not std::is_base_of_v<MarkAsNumberAsExpression, T2>) {
       t2_.assert_lhs_tensor_not_in_rhs_expression(lhs_tensor);
     }
   }
@@ -198,11 +199,11 @@ struct OuterProduct<T1, T2, IndexList1<Indices1...>, IndexList2<Indices2...>,
   template <typename LhsTensorIndices, typename LhsTensor>
   SPECTRE_ALWAYS_INLINE void assert_lhs_tensorindices_same_in_rhs(
       const gsl::not_null<LhsTensor*> lhs_tensor) const {
-    if constexpr (not std::is_base_of_v<NumberAsExpression, T1>) {
+    if constexpr (not std::is_base_of_v<MarkAsNumberAsExpression, T1>) {
       t1_.template assert_lhs_tensorindices_same_in_rhs<LhsTensorIndices>(
           lhs_tensor);
     }
-    if constexpr (not std::is_base_of_v<NumberAsExpression, T2>) {
+    if constexpr (not std::is_base_of_v<MarkAsNumberAsExpression, T2>) {
       t2_.template assert_lhs_tensorindices_same_in_rhs<LhsTensorIndices>(
           lhs_tensor);
     }
@@ -295,8 +296,9 @@ struct OuterProduct<T1, T2, IndexList1<Indices1...>, IndexList2<Indices2...>,
   /// operand of the product to retrieve
   /// \param op2_multi_index the multi-index of the component of the second
   /// operand of the product to retrieve
+  template <typename ResultType>
   SPECTRE_ALWAYS_INLINE decltype(auto) get_primary(
-      const type& result_component,
+      const ResultType& result_component,
       const std::array<size_t, op1_num_tensor_indices>& op1_multi_index,
       const std::array<size_t, op2_num_tensor_indices>& op2_multi_index) const {
     if constexpr (is_primary_end) {
@@ -308,7 +310,7 @@ struct OuterProduct<T1, T2, IndexList1<Indices1...>, IndexList2<Indices2...>,
     } else {
       // We haven't yet evaluated the whole subtree for this expression, so
       // return the product of the results of the two operands' subtrees
-      return t1_.get_primary(result_component, op1_multi_index) *
+      return t1_.template get_primary(result_component, op1_multi_index) *
              t2_.get(op2_multi_index);
     }
   }
@@ -328,8 +330,9 @@ struct OuterProduct<T1, T2, IndexList1<Indices1...>, IndexList2<Indices2...>,
   /// product tensor to retrieve
   /// \return the value of the component at `result_multi_index` in the outer
   /// product tensor
+  template <typename ResultType>
   SPECTRE_ALWAYS_INLINE decltype(auto) get_primary(
-      const type& result_component,
+      const ResultType& result_component,
       const std::array<size_t, num_tensor_indices>& result_multi_index) const {
     return get_primary(result_component,
                        get_op1_multi_index(result_multi_index),
@@ -358,8 +361,9 @@ struct OuterProduct<T1, T2, IndexList1<Indices1...>, IndexList2<Indices2...>,
   /// operand of the product to evaluate
   /// \param op2_multi_index the multi-index of the component of the second
   /// operand of the product to evaluate
+  template <typename ResultType>
   SPECTRE_ALWAYS_INLINE void evaluate_primary_children(
-      type& result_component,
+      ResultType& result_component,
       const std::array<size_t, op1_num_tensor_indices>& op1_multi_index,
       const std::array<size_t, op2_num_tensor_indices>& op2_multi_index) const {
     if constexpr (is_primary_end) {
@@ -372,7 +376,8 @@ struct OuterProduct<T1, T2, IndexList1<Indices1...>, IndexList2<Indices2...>,
       // We haven't yet evaluated the whole subtree of the primary child, so
       // first assign the result component to be the result of computing the
       // primary child's subtree
-      result_component = t1_.get_primary(result_component, op1_multi_index);
+      result_component =
+          t1_.template get_primary(result_component, op1_multi_index);
       // Now that the primary child's subtree has been computed, multiply the
       // current result by the result of evaluating the other child's subtree
       result_component *= t2_.get(op2_multi_index);
@@ -391,15 +396,16 @@ struct OuterProduct<T1, T2, IndexList1<Indices1...>, IndexList2<Indices2...>,
   /// \param result_component the LHS tensor component to evaluate
   /// \param result_multi_index the multi-index of the component of the outer
   /// product tensor to evaluate
+  template <typename ResultType>
   SPECTRE_ALWAYS_INLINE void evaluate_primary_subtree(
-      type& result_component,
+      ResultType& result_component,
       const std::array<size_t, num_tensor_indices>& result_multi_index) const {
     const std::array<size_t, op1_num_tensor_indices> op1_multi_index =
         get_op1_multi_index(result_multi_index);
     if constexpr (primary_child_subtree_contains_primary_start) {
       // The primary child's subtree contains at least one leg, so recurse down
       // and evaluate that first
-      t1_.evaluate_primary_subtree(result_component, op1_multi_index);
+      t1_.template evaluate_primary_subtree(result_component, op1_multi_index);
     }
 
     if constexpr (is_primary_start) {
@@ -464,30 +470,24 @@ SPECTRE_ALWAYS_INLINE auto operator*(
 /// @{
 /// \ingroup TensorExpressionsGroup
 /// \brief Returns the tensor expression representing the product of a tensor
-/// expression and a `double`
+/// expression and a number
 ///
-/// \tparam T the derived TensorExpression type of the tensor expression operand
-/// of the product
-/// \tparam X the type of data stored in the tensor expression operand of the
-/// product
-/// \tparam ArgsList the TensorIndexs of the tensor expression operand of the
-/// product
 /// \param t the tensor expression operand of the product
-/// \param number the `double` operand of the product
-/// \return the tensor expression representing the product of a tensor
-/// expression and a `double`
-template <typename T, typename X, typename ArgsList>
+/// \param number the numeric operand of the product
+/// \return the tensor expression representing the product of the tensor
+/// expression and the number
+template <typename T, typename N, Requires<std::is_arithmetic_v<N>> = nullptr>
 SPECTRE_ALWAYS_INLINE auto operator*(
-    const TensorExpression<T, X, typename T::symmetry, typename T::index_list,
-                           ArgsList>& t,
-    const double number) {
+    const TensorExpression<T, typename T::type, typename T::symmetry,
+                           typename T::index_list, typename T::args_list>& t,
+    const N number) {
   return t * tenex::NumberAsExpression(number);
 }
-template <typename T, typename X, typename ArgsList>
+template <typename T, typename N, Requires<std::is_arithmetic_v<N>> = nullptr>
 SPECTRE_ALWAYS_INLINE auto operator*(
-    const double number,
-    const TensorExpression<T, X, typename T::symmetry, typename T::index_list,
-                           ArgsList>& t) {
+    const N number,
+    const TensorExpression<T, typename T::type, typename T::symmetry,
+                           typename T::index_list, typename T::args_list>& t) {
   return t * tenex::NumberAsExpression(number);
 }
 /// @}

--- a/src/DataStructures/Tensor/Expressions/SquareRoot.hpp
+++ b/src/DataStructures/Tensor/Expressions/SquareRoot.hpp
@@ -10,6 +10,7 @@
 #include <type_traits>
 #include <utility>
 
+#include "DataStructures/Tensor/Expressions/NumberAsExpression.hpp"
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/Expressions/TimeIndex.hpp"
 #include "Utilities/ForceInline.hpp"
@@ -120,7 +121,7 @@ struct SquareRoot
   template <typename LhsTensor>
   SPECTRE_ALWAYS_INLINE void assert_lhs_tensor_not_in_rhs_expression(
       const gsl::not_null<LhsTensor*> lhs_tensor) const {
-    if constexpr (not std::is_base_of_v<NumberAsExpression, T>) {
+    if constexpr (not std::is_base_of_v<MarkAsNumberAsExpression, T>) {
       t_.assert_lhs_tensor_not_in_rhs_expression(lhs_tensor);
     }
   }
@@ -134,7 +135,7 @@ struct SquareRoot
   template <typename LhsTensorIndices, typename LhsTensor>
   SPECTRE_ALWAYS_INLINE void assert_lhs_tensorindices_same_in_rhs(
       const gsl::not_null<LhsTensor*> lhs_tensor) const {
-    if constexpr (not std::is_base_of_v<NumberAsExpression, T>) {
+    if constexpr (not std::is_base_of_v<MarkAsNumberAsExpression, T>) {
       t_.template assert_lhs_tensorindices_same_in_rhs<LhsTensorIndices>(
           lhs_tensor);
     }
@@ -183,8 +184,9 @@ struct SquareRoot
   /// square root
   /// \return the square root of the component of the tensor evaluated from the
   /// contained tensor expression
+  template <typename ResultType>
   SPECTRE_ALWAYS_INLINE decltype(auto) get_primary(
-      const type& result_component,
+      const ResultType& result_component,
       const std::array<size_t, num_tensor_indices>& multi_index) const {
     if constexpr (is_primary_end) {
       (void)multi_index;
@@ -194,7 +196,7 @@ struct SquareRoot
     } else {
       // We haven't yet evaluated the whole subtree for this expression, so
       // return the square root of this expression's subtree
-      return sqrt(t_.get_primary(result_component, multi_index));
+      return sqrt(t_.template get_primary(result_component, multi_index));
     }
   }
 
@@ -210,13 +212,14 @@ struct SquareRoot
   /// \param result_component the LHS tensor component to evaluate
   /// \param multi_index the multi-index of the component of the result tensor
   /// to evaluate
+  template <typename ResultType>
   SPECTRE_ALWAYS_INLINE void evaluate_primary_subtree(
-      type& result_component,
+      ResultType& result_component,
       const std::array<size_t, num_tensor_indices>& multi_index) const {
     if constexpr (primary_child_subtree_contains_primary_start) {
       // The primary child's subtree contains at least one leg, so recurse down
       // and evaluate that first
-      t_.evaluate_primary_subtree(result_component, multi_index);
+      t_.template evaluate_primary_subtree(result_component, multi_index);
     }
 
     if constexpr (is_primary_start) {

--- a/src/DataStructures/Tensor/Expressions/TensorAsExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorAsExpression.hpp
@@ -12,6 +12,7 @@
 #include <type_traits>
 #include <utility>
 
+#include "DataStructures/Tensor/Expressions/DataTypeSupport.hpp"
 #include "DataStructures/Tensor/Expressions/SpatialSpacetimeIndex.hpp"
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -187,6 +188,10 @@ struct TensorAsExpression<Tensor<X, Symm<SymmValues...>, IndexList<Indices...>>,
                                   Symm<SymmValues...>, IndexList<Indices...>,
                                   ArgsList<Args...>>::type,
                               IndexList<Indices...>, ArgsList<Args...>> {
+  static_assert(detail::is_supported_tensor_datatype_v<X>,
+                "TensorExpressions currently only support Tensors whose data "
+                "type is double or DataVector. It is possible to add support "
+                "for other data types that are supported by Tensor.");
   // `Symmetry` currently prevents this because antisymmetries are not currently
   // supported for `Tensor`s. This check is repeated here because if
   // antisymmetries are later supported for `Tensor`, using antisymmetries in
@@ -319,8 +324,9 @@ struct TensorAsExpression<Tensor<X, Symm<SymmValues...>, IndexList<Indices...>>,
   ///
   /// \param multi_index the multi-index of the tensor component to retrieve
   /// \return the value of the component at `multi_index` in the tensor
+  template <typename ResultType>
   SPECTRE_ALWAYS_INLINE decltype(auto) get_primary(
-      const type& /*result_component*/,
+      const ResultType& /*result_component*/,
       const std::array<size_t, num_tensor_indices>& multi_index) const {
     return t_->get(multi_index);
   }
@@ -329,8 +335,10 @@ struct TensorAsExpression<Tensor<X, Symm<SymmValues...>, IndexList<Indices...>>,
   // to evaluate in a split tree, which is enforced by
   // `is_primary_start == false`. Therefore, this function should never be
   // called on this expression type.
-  void evaluate_primary_subtree(
-      type&, const std::array<size_t, num_tensor_indices>&) const = delete;
+  template <typename ResultType>
+  SPECTRE_ALWAYS_INLINE void evaluate_primary_subtree(
+      ResultType& result_component,
+      const std::array<size_t, num_tensor_indices>&) const = delete;
 
   /// Retrieve the i'th entry of the Tensor being held
   SPECTRE_ALWAYS_INLINE type operator[](const size_t i) const {

--- a/src/DataStructures/Tensor/Expressions/TensorAsExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorAsExpression.hpp
@@ -190,8 +190,9 @@ struct TensorAsExpression<Tensor<X, Symm<SymmValues...>, IndexList<Indices...>>,
                               IndexList<Indices...>, ArgsList<Args...>> {
   static_assert(detail::is_supported_tensor_datatype_v<X>,
                 "TensorExpressions currently only support Tensors whose data "
-                "type is double or DataVector. It is possible to add support "
-                "for other data types that are supported by Tensor.");
+                "type is double, DataVector, or ComplexDataVector. It is "
+                "possible to add support for other data types that are "
+                "supported by Tensor.");
   // `Symmetry` currently prevents this because antisymmetries are not currently
   // supported for `Tensor`s. This check is repeated here because if
   // antisymmetries are later supported for `Tensor`, using antisymmetries in

--- a/src/DataStructures/Tensor/Expressions/TensorAsExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorAsExpression.hpp
@@ -190,9 +190,9 @@ struct TensorAsExpression<Tensor<X, Symm<SymmValues...>, IndexList<Indices...>>,
                               IndexList<Indices...>, ArgsList<Args...>> {
   static_assert(detail::is_supported_tensor_datatype_v<X>,
                 "TensorExpressions currently only support Tensors whose data "
-                "type is double, DataVector, or ComplexDataVector. It is "
-                "possible to add support for other data types that are "
-                "supported by Tensor.");
+                "type is double, std::complex<double>, DataVector, or "
+                "ComplexDataVector. It is possible to add support for other "
+                "data types that are supported by Tensor.");
   // `Symmetry` currently prevents this because antisymmetries are not currently
   // supported for `Tensor`s. This check is repeated here because if
   // antisymmetries are later supported for `Tensor`, using antisymmetries in

--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -17,6 +17,7 @@
 #include "DataStructures/SpinWeighted.hpp"
 #include "DataStructures/Tensor/Expressions/AddSubtract.hpp"
 #include "DataStructures/Tensor/Expressions/Contract.hpp"
+#include "DataStructures/Tensor/Expressions/DataTypeSupport.hpp"
 #include "DataStructures/Tensor/Expressions/Divide.hpp"
 #include "DataStructures/Tensor/Expressions/Evaluate.hpp"
 #include "DataStructures/Tensor/Expressions/IndexPropertyCheck.hpp"

--- a/src/DataStructures/VectorImpl.hpp
+++ b/src/DataStructures/VectorImpl.hpp
@@ -33,6 +33,14 @@
 #include "Utilities/StdArrayHelpers.hpp"
 #include "Utilities/TypeTraits/IsComplexOfFundamental.hpp"
 
+/// \ingroup TensorExpressionsGroup
+/// \brief Marks a class as being a `VectorImpl`
+///
+/// \details
+/// The empty base class provides a simple means for checking if a type is a
+/// `VectorImpl`
+struct MarkAsVectorImpl {};
+
 /*!
  * \ingroup DataStructuresGroup
  * \brief Base class template for various DataVector and related types
@@ -78,7 +86,8 @@ template <typename T, typename VectorType>
 class VectorImpl
     : public blaze::CustomVector<
           T, blaze::AlignmentFlag::unaligned, blaze::PaddingFlag::unpadded,
-          blaze::defaultTransposeFlag, blaze::GroupTag<0>, VectorType> {
+          blaze::defaultTransposeFlag, blaze::GroupTag<0>, VectorType>,
+      MarkAsVectorImpl {
  public:
   using value_type = T;
   using size_type = size_t;

--- a/src/DataStructures/VectorImpl.hpp
+++ b/src/DataStructures/VectorImpl.hpp
@@ -33,6 +33,48 @@
 #include "Utilities/StdArrayHelpers.hpp"
 #include "Utilities/TypeTraits/IsComplexOfFundamental.hpp"
 
+class ComplexDataVector;
+class ComplexModalVector;
+class DataVector;
+class ModalVector;
+
+namespace VectorImpl_detail {
+/// \brief Whether or not a given vector type is assignable to another
+///
+/// \details
+/// This is used to define which types can be assigned to one another. For
+/// example, you can assign a `ComplexDataVector` to a `DataVector`, but not
+/// vice versa.
+///
+/// To enable assignments between more types, modify a current template
+/// specialization or add a new one.
+///
+/// \tparam LhsDataType the type being assigned
+/// \tparam RhsDataType the type to convert to `LhsDataType`
+template <typename LhsDataType, typename RhsDataType>
+struct is_assignable;
+
+/// No template specialization was matched, so LHS is not assignable to RHS
+template <typename LhsDataType, typename RhsDataType>
+struct is_assignable : std::false_type {};
+/// Can assign a type to itself
+template <typename RhsDataType>
+struct is_assignable<RhsDataType, RhsDataType> : std::true_type {};
+/// Can assign a `ComplexDataVector` to a `DataVector`
+template <>
+struct is_assignable<ComplexDataVector, DataVector> : std::true_type {};
+/// Can assign a `ComplexModalVector` to a `ModalVector`
+template <>
+struct is_assignable<ComplexModalVector, ModalVector> : std::true_type {};
+
+/// \brief Whether or not a given vector type is assignable to another
+///
+/// \details
+/// See `is_assignable` for which assignments are permitted
+template <typename LhsDataType, typename RhsDataType>
+constexpr bool is_assignable_v = is_assignable<LhsDataType, RhsDataType>::value;
+}  // namespace VectorImpl_detail
+
 /// \ingroup TensorExpressionsGroup
 /// \brief Marks a class as being a `VectorImpl`
 ///
@@ -181,9 +223,9 @@ class VectorImpl
   // This is a converting constructor. clang-tidy complains that it's not
   // explicit, but we want it to allow conversion.
   // clang-tidy: mark as explicit (we want conversion to VectorImpl type)
-  template <
-      typename VT, bool VF,
-      Requires<std::is_same_v<typename VT::ResultType, VectorType>> = nullptr>
+  template <typename VT, bool VF,
+            Requires<VectorImpl_detail::is_assignable_v<
+                VectorType, typename VT::ResultType>> = nullptr>
   VectorImpl(const blaze::DenseVector<VT, VF>& expression);  // NOLINT
 
   template <typename VT, bool VF>
@@ -337,15 +379,15 @@ VectorImpl<T, VectorType>& VectorImpl<T, VectorType>::operator=(
 // clang-tidy: mark as explicit (we want conversion to VectorImpl)
 template <typename T, typename VectorType>
 template <typename VT, bool VF,
-          Requires<std::is_same_v<typename VT::ResultType, VectorType>>>
+          Requires<VectorImpl_detail::is_assignable_v<VectorType,
+                                                      typename VT::ResultType>>>
 VectorImpl<T, VectorType>::VectorImpl(
     const blaze::DenseVector<VT, VF>& expression)  // NOLINT
     : owned_data_(cpp20::make_unique_for_overwrite<value_type[]>(
           (*expression).size())) {
-  static_assert(std::is_same_v<typename VT::ResultType, VectorType>,
-                "You are attempting to assign the result of an expression "
-                "that is not consistent with the VectorImpl type you are "
-                "assigning to.");
+  static_assert(
+      VectorImpl_detail::is_assignable_v<VectorType, typename VT::ResultType>,
+      "Cannot construct the VectorImpl type from the given expression type.");
   reset_pointer_vector((*expression).size());
   **this = expression;
 }
@@ -354,10 +396,9 @@ template <typename T, typename VectorType>
 template <typename VT, bool VF>
 VectorImpl<T, VectorType>& VectorImpl<T, VectorType>::operator=(
     const blaze::DenseVector<VT, VF>& expression) {
-  static_assert(std::is_same_v<typename VT::ResultType, VectorType>,
-                "You are attempting to assign the result of an expression "
-                "that is not consistent with the VectorImpl type you are "
-                "assigning to.");
+  static_assert(
+      VectorImpl_detail::is_assignable_v<VectorType, typename VT::ResultType>,
+      "Cannot assign to the VectorImpl type from the given expression type.");
   if (owning_ and (*expression).size() != size()) {
     owned_data_ =
         cpp20::make_unique_for_overwrite<value_type[]>((*expression).size());

--- a/tests/Unit/DataStructures/Tensor/Expressions/CMakeLists.txt
+++ b/tests/Unit/DataStructures/Tensor/Expressions/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBRARY_SOURCES
   Test_DataTypeSupport.cpp
   Test_Divide.cpp
   Test_Evaluate.cpp
+  Test_EvaluateComplex.cpp
   Test_EvaluateRank3NonSymmetric.cpp
   Test_EvaluateRank3Symmetric.cpp
   Test_EvaluateRank4.cpp

--- a/tests/Unit/DataStructures/Tensor/Expressions/CMakeLists.txt
+++ b/tests/Unit/DataStructures/Tensor/Expressions/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_AddSubSymmetry.cpp
   Test_AddSubtract.cpp
   Test_Contract.cpp
+  Test_DataTypeSupport.cpp
   Test_Divide.cpp
   Test_Evaluate.cpp
   Test_EvaluateRank3NonSymmetric.cpp

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_AddSubtract.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_AddSubtract.cpp
@@ -4,6 +4,7 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <climits>
+#include <complex>
 #include <cstddef>
 #include <random>
 #include <type_traits>
@@ -341,6 +342,10 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
   test_tensor_ops_properties();
   test_addsub(make_not_null(&generator),
               std::numeric_limits<double>::signaling_NaN());
+  test_addsub(
+      make_not_null(&generator),
+      std::complex<double>(std::numeric_limits<double>::signaling_NaN(),
+                           std::numeric_limits<double>::signaling_NaN()));
   test_addsub(make_not_null(&generator),
               DataVector(5, std::numeric_limits<double>::signaling_NaN()));
   test_addsub(

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_AddSubtract.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_AddSubtract.cpp
@@ -5,37 +5,20 @@
 
 #include <climits>
 #include <cstddef>
-#include <iterator>
-#include <numeric>
+#include <random>
 #include <type_traits>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Symmetry.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/ComponentPlaceholder.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
 namespace {
-template <typename... Ts>
-void assign_unique_values_to_tensor(
-    const gsl::not_null<Tensor<double, Ts...>*> tensor) {
-  std::iota(tensor->begin(), tensor->end(), 0.0);
-}
-
-template <typename... Ts>
-void assign_unique_values_to_tensor(
-    const gsl::not_null<Tensor<DataVector, Ts...>*> tensor) {
-  double value = 0.0;
-  for (auto index_it = tensor->begin(); index_it != tensor->end(); index_it++) {
-    for (auto vector_it = index_it->begin(); vector_it != index_it->end();
-         vector_it++) {
-      *vector_it = value;
-      value += 1.0;
-    }
-  }
-}
-
 // Checks that the number of ops in the expressions match what is expected
 void test_tensor_ops_properties() {
   const Scalar<double> G{};
@@ -74,21 +57,15 @@ void test_tensor_ops_properties() {
 //
 // \tparam DataType the type of data being stored in the tensor expression
 // operand of the sums and differences
-template <typename DataType>
-void test_addsub_double(const DataType& used_for_size) {
-  Tensor<DataType> S{{{used_for_size}}};
-  if (std::is_same_v<DataType, double>) {
-    // Replace tensor's value from `used_for_size` to a proper test value
-    S.get() = 2.4;
-  } else {
-    assign_unique_values_to_tensor(make_not_null(&S));
-  }
+template <typename Generator, typename DataType>
+void test_addsub_double(const gsl::not_null<Generator*> generator,
+                        const DataType& used_for_size) {
+  std::uniform_real_distribution<> distribution(-1.0, 1.0);
 
-  Tensor<DataType, Symmetry<2, 1>,
-         index_list<SpatialIndex<3, UpLo::Up, Frame::Grid>,
-                    SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
-      G(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&G));
+  const auto S = make_with_random_values<Scalar<DataType>>(
+      generator, distribution, used_for_size);
+  const auto G = make_with_random_values<tnsr::Ij<DataType, 3, Frame::Grid>>(
+      generator, distribution, used_for_size);
 
   DataType G_trace = make_with_value<DataType>(used_for_size, 0.0);
   for (size_t i = 0; i < 3; i++) {
@@ -111,131 +88,97 @@ void test_addsub_double(const DataType& used_for_size) {
 
   CHECK(R_plus_S.get() == 5.6 + S.get());
   CHECK(R_minus_S.get() == 1.1 - S.get());
-  CHECK(G_plus_R.get() == G_trace + 8.2);
-  CHECK(G_minus_R.get() == G_trace - 3.5);
+  CHECK_ITERABLE_APPROX(G_plus_R.get(), G_trace + 8.2);
+  CHECK_ITERABLE_APPROX(G_minus_R.get(), G_trace - 3.5);
   CHECK(R_plus_S_plus_T.get() == 0.7 + S.get() + 9.8);
-  CHECK(R_minus_G_plus_T.get() == 5.9 - G_trace + 4.7);
+  CHECK_ITERABLE_APPROX(R_minus_G_plus_T.get(), 5.9 - G_trace + 4.7);
 }
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
-                  "[DataStructures][Unit]") {
-  test_tensor_ops_properties();
+template <typename Generator, typename DataType>
+void test_addsub_tensor(const gsl::not_null<Generator*> generator,
+                        const DataType& used_for_size) {
+  std::uniform_real_distribution<> distribution(-1.0, 1.0);
 
-  // Test adding and subtracting `double`s
-  test_addsub_double(std::numeric_limits<double>::signaling_NaN());
-  test_addsub_double(
-      DataVector(5, std::numeric_limits<double>::signaling_NaN()));
+  // Test scalars
+  const auto scalar_1 = make_with_random_values<Scalar<DataType>>(
+      generator, distribution, used_for_size);
+  const auto scalar_2 = make_with_random_values<Scalar<DataType>>(
+      generator, distribution, used_for_size);
 
-  // Test adding scalars
-  const Tensor<double> scalar_1{{{2.1}}};
-  const Tensor<double> scalar_2{{{-0.8}}};
-  Tensor<double> lhs_scalar = tenex::evaluate(scalar_1() + scalar_2());
-  CHECK(lhs_scalar.get() == 1.3);
+  Tensor<DataType> lhs_scalar = tenex::evaluate(scalar_1() + scalar_2());
+  CHECK(lhs_scalar.get() == get(scalar_1) + get(scalar_2));
 
-  Tensor<double, Symmetry<1, 1>,
-         index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      All{};
-  std::iota(All.begin(), All.end(), 0.0);
-  Tensor<double, Symmetry<2, 1>,
-         index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Hll{};
-  std::iota(Hll.begin(), Hll.end(), 0.0);
+  // Test rank 2
+  const auto All = make_with_random_values<tnsr::aa<DataType, 3, Frame::Grid>>(
+      generator, distribution, used_for_size);
+  const auto Hll = make_with_random_values<tnsr::ab<DataType, 3, Frame::Grid>>(
+      generator, distribution, used_for_size);
+
   // [use_tensor_index]
-  const Tensor<double, Symmetry<2, 1>,
-               index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Gll =
-          tenex::evaluate<ti::a, ti::b>(All(ti::a, ti::b) + Hll(ti::a, ti::b));
-  const Tensor<double, Symmetry<2, 1>,
-               index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Gll2 =
-          tenex::evaluate<ti::a, ti::b>(All(ti::a, ti::b) + Hll(ti::b, ti::a));
-  const Tensor<double, Symmetry<2, 1>,
-               index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Gll3 =
-          tenex::evaluate<ti::a, ti::b>(All(ti::a, ti::b) + Hll(ti::b, ti::a) +
-                                        All(ti::b, ti::a) - Hll(ti::b, ti::a));
+  const tnsr::ab<DataType, 3, Frame::Grid> Gll =
+      tenex::evaluate<ti::a, ti::b>(All(ti::a, ti::b) + Hll(ti::a, ti::b));
+  const tnsr::ab<DataType, 3, Frame::Grid> Gll2 =
+      tenex::evaluate<ti::a, ti::b>(All(ti::a, ti::b) + Hll(ti::b, ti::a));
+  const tnsr::ab<DataType, 3, Frame::Grid> Gll3 =
+      tenex::evaluate<ti::a, ti::b>(All(ti::a, ti::b) + Hll(ti::b, ti::a) +
+                                    All(ti::b, ti::a) - Hll(ti::b, ti::a));
+
   // [use_tensor_index]
   for (int i = 0; i < 4; ++i) {
     for (int j = 0; j < 4; ++j) {
       CHECK(Gll.get(i, j) == All.get(i, j) + Hll.get(i, j));
       CHECK(Gll2.get(i, j) == All.get(i, j) + Hll.get(j, i));
-      CHECK(Gll3.get(i, j) == 2.0 * All.get(i, j));
+      CHECK_ITERABLE_APPROX(Gll3.get(i, j), 2.0 * All.get(i, j));
     }
   }
-  // Test 3 indices add subtract
-  Tensor<double, Symmetry<1, 1, 2>,
-         index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Alll{};
-  std::iota(Alll.begin(), Alll.end(), 0.0);
-  Tensor<double, Symmetry<1, 2, 3>,
-         index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Hlll{};
-  std::iota(Hlll.begin(), Hlll.end(), 0.0);
-  Tensor<double, Symmetry<2, 1, 1>,
-         index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Rlll{};
-  std::iota(Rlll.begin(), Rlll.end(), 0.0);
-  Tensor<double, Symmetry<1, 2, 1>,
-         index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpatialIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Slll{};
-  std::iota(Slll.begin(), Slll.end(), 0.0);
 
-  const Tensor<double, Symmetry<3, 2, 1>,
-               index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Glll = tenex::evaluate<ti::a, ti::b, ti::c>(Alll(ti::a, ti::b, ti::c) +
-                                                  Hlll(ti::a, ti::b, ti::c));
-  const Tensor<double, Symmetry<3, 2, 1>,
-               index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Glll2 = tenex::evaluate<ti::a, ti::b, ti::c>(Alll(ti::a, ti::b, ti::c) +
-                                                   Hlll(ti::b, ti::a, ti::c));
-  const Tensor<double, Symmetry<3, 2, 1>,
-               index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Glll3 = tenex::evaluate<ti::a, ti::b, ti::c>(
+  // Test rank 3
+  const auto Alll = make_with_random_values<
+      Tensor<DataType, Symmetry<1, 1, 2>,
+             index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                        SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                        SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>>(
+      generator, distribution, used_for_size);
+  const auto Hlll =
+      make_with_random_values<tnsr::abc<DataType, 3, Frame::Grid>>(
+          generator, distribution, used_for_size);
+  const auto Rlll =
+      make_with_random_values<tnsr::abb<DataType, 3, Frame::Grid>>(
+          generator, distribution, used_for_size);
+  const auto Slll = make_with_random_values<
+      Tensor<DataType, Symmetry<1, 2, 1>,
+             index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                        SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                        SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>>(
+      generator, distribution, used_for_size);
+
+  const tnsr::abc<DataType, 3, Frame::Grid> Glll =
+      tenex::evaluate<ti::a, ti::b, ti::c>(Alll(ti::a, ti::b, ti::c) +
+                                           Hlll(ti::a, ti::b, ti::c));
+  const tnsr::abc<DataType, 3, Frame::Grid> Glll2 =
+      tenex::evaluate<ti::a, ti::b, ti::c>(Alll(ti::a, ti::b, ti::c) +
+                                           Hlll(ti::b, ti::a, ti::c));
+  const tnsr::abc<DataType, 3, Frame::Grid> Glll3 =
+      tenex::evaluate<ti::a, ti::b, ti::c>(
           Alll(ti::a, ti::b, ti::c) + Hlll(ti::b, ti::a, ti::c) +
           Alll(ti::b, ti::a, ti::c) - Hlll(ti::b, ti::a, ti::c));
   // testing LHS symmetry is nonsymmetric when RHS operands do not have
   // symmetries in common
-  const Tensor<double, Symmetry<3, 2, 1>,
-               index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Glll4 = tenex::evaluate<ti::a, ti::b, ti::c>(Alll(ti::b, ti::c, ti::a) +
-                                                   Rlll(ti::c, ti::a, ti::b));
+  const tnsr::abc<DataType, 3, Frame::Grid> Glll4 =
+      tenex::evaluate<ti::a, ti::b, ti::c>(Alll(ti::b, ti::c, ti::a) +
+                                           Rlll(ti::c, ti::a, ti::b));
   // testing LHS symmetry preserves shared RHS symmetry when RHS operands have
   // symmetries in common
-  const Tensor<double, Symmetry<2, 1, 1>,
-               index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Glll5 = tenex::evaluate<ti::a, ti::b, ti::c>(Alll(ti::b, ti::c, ti::a) -
-                                                   Rlll(ti::a, ti::c, ti::b));
+  const tnsr::abb<DataType, 3, Frame::Grid> Glll5 =
+      tenex::evaluate<ti::a, ti::b, ti::c>(Alll(ti::b, ti::c, ti::a) -
+                                           Rlll(ti::a, ti::c, ti::b));
 
   for (int i = 0; i < 4; ++i) {
     for (int j = 0; j < 4; ++j) {
       for (int k = 0; k < 4; ++k) {
         CHECK(Glll.get(i, j, k) == Alll.get(i, j, k) + Hlll.get(i, j, k));
         CHECK(Glll2.get(i, j, k) == Alll.get(i, j, k) + Hlll.get(j, i, k));
-        CHECK(Glll3.get(i, j, k) == 2.0 * Alll.get(i, j, k));
+        CHECK_ITERABLE_APPROX(Glll3.get(i, j, k), 2.0 * Alll.get(i, j, k));
         CHECK(Glll4.get(i, j, k) == Alll.get(j, k, i) + Rlll.get(k, i, j));
         CHECK(Glll5.get(i, j, k) == Alll.get(j, k, i) - Rlll.get(i, k, j));
       }
@@ -243,17 +186,13 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
   }
 
   // testing with expressions having spatial indices for spacetime indices
-  const Tensor<double, Symmetry<3, 2, 1>,
+  const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpatialIndex<3, UpLo::Lo, Frame::Grid>,
                           SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
       Glll6 = tenex::evaluate<ti::a, ti::j, ti::k>(Rlll(ti::a, ti::j, ti::k) +
                                                    Slll(ti::a, ti::j, ti::k));
-  Tensor<double, Symmetry<3, 2, 1>,
-         index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Glll7{};
+  tnsr::iab<DataType, 3, Frame::Grid> Glll7{};
   tenex::evaluate<ti::j, ti::a, ti::k>(
       make_not_null(&Glll7),
       Slll(ti::j, ti::k, ti::a) - Rlll(ti::k, ti::a, ti::j));
@@ -270,11 +209,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
   }
 
   // testing with operands having time indices for spacetime indices
-  const Tensor<double, Symmetry<2, 1>,
-               index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Gll7 = tenex::evaluate<ti::c, ti::b>(Alll(ti::c, ti::t, ti::b) +
-                                           Hlll(ti::b, ti::c, ti::t));
+  const tnsr::ab<DataType, 3, Frame::Grid> Gll7 = tenex::evaluate<ti::c, ti::b>(
+      Alll(ti::c, ti::t, ti::b) + Hlll(ti::b, ti::c, ti::t));
 
   for (int c = 0; c < 4; ++c) {
     for (int b = 0; b < 4; ++b) {
@@ -282,11 +218,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
     }
   }
 
-  const Tensor<double, Symmetry<1, 1>,
-               index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Gll8 = tenex::evaluate<ti::d, ti::c>(Alll(ti::c, ti::d, ti::t) -
-                                           All(ti::d, ti::c));
+  const tnsr::aa<DataType, 3, Frame::Grid> Gll8 = tenex::evaluate<ti::d, ti::c>(
+      Alll(ti::c, ti::d, ti::t) - All(ti::d, ti::c));
 
   for (int d = 0; d < 4; ++d) {
     for (int c = 0; c < 4; ++c) {
@@ -294,11 +227,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
     }
   }
 
-  const Tensor<double, Symmetry<1, 1>,
-               index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Gll9 = tenex::evaluate<ti::a, ti::b>(All(ti::b, ti::a) +
-                                           Alll(ti::b, ti::a, ti::t));
+  const tnsr::aa<DataType, 3, Frame::Grid> Gll9 = tenex::evaluate<ti::a, ti::b>(
+      All(ti::b, ti::a) + Alll(ti::b, ti::a, ti::t));
 
   for (int a = 0; a < 4; ++a) {
     for (int b = 0; b < 4; ++b) {
@@ -309,16 +239,16 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
   // Assign a placeholder to the LHS tensor's components before it is computed
   // so that when test expressions below only compute time components, we can
   // check that LHS spatial components haven't changed
-  const double spatial_component_placeholder =
-      std::numeric_limits<double>::max();
+  const auto spatial_component_placeholder_value =
+      TestHelpers::tenex::component_placeholder_value<DataType>::value;
 
   auto Gll10 = make_with_value<
-      Tensor<double, Symmetry<4, 3, 2, 1>,
+      Tensor<DataType, Symmetry<4, 3, 2, 1>,
              index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                         SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                         SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                         SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>>(
-      0.0, spatial_component_placeholder);
+      used_for_size, spatial_component_placeholder_value);
   tenex::evaluate<ti::t, ti::d, ti::b, ti::T>(
       make_not_null(&Gll10), All(ti::b, ti::d) - Hll(ti::b, ti::d));
 
@@ -327,18 +257,19 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
       CHECK(Gll10.get(0, d, b, 0) == All.get(b, d) - Hll.get(b, d));
       for (size_t i = 0; i < 3; ++i) {
         for (size_t j = 0; j < 3; ++j) {
-          CHECK(Gll10.get(i + 1, d, b, j + 1) == spatial_component_placeholder);
+          CHECK(Gll10.get(i + 1, d, b, j + 1) ==
+                spatial_component_placeholder_value);
         }
       }
     }
   }
 
   auto Gll11 = make_with_value<
-      Tensor<double, Symmetry<2, 2, 1>,
+      Tensor<DataType, Symmetry<2, 2, 1>,
              index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                         SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                         SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>>(
-      0.0, spatial_component_placeholder);
+      used_for_size, spatial_component_placeholder_value);
   tenex::evaluate<ti::a, ti::c, ti::t>(
       make_not_null(&Gll11), Rlll(ti::t, ti::c, ti::a) + All(ti::a, ti::c));
 
@@ -346,17 +277,13 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
     for (int c = 0; c < 4; ++c) {
       CHECK(Gll11.get(a, c, 0) == Rlll.get(0, c, a) + All.get(a, c));
       for (size_t i = 0; i < 3; ++i) {
-        CHECK(Gll11.get(a, c, i + 1) == spatial_component_placeholder);
+        CHECK(Gll11.get(a, c, i + 1) == spatial_component_placeholder_value);
       }
     }
   }
 
-  auto Gll12 = make_with_value<
-      Tensor<double, Symmetry<3, 2, 1>,
-             index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                        SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                        SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>>(
-      0.0, spatial_component_placeholder);
+  auto Gll12 = make_with_value<tnsr::abc<DataType, 3, Frame::Grid>>(
+      used_for_size, spatial_component_placeholder_value);
   tenex::evaluate<ti::g, ti::t, ti::h>(
       make_not_null(&Gll12), Hll(ti::h, ti::g) - Alll(ti::g, ti::t, ti::h));
 
@@ -364,33 +291,28 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
     for (int h = 0; h < 4; ++h) {
       CHECK(Gll12.get(g, 0, h) == Hll.get(h, g) - Alll.get(g, 0, h));
       for (size_t i = 0; i < 3; ++i) {
-        CHECK(Gll12.get(g, i + 1, h) == spatial_component_placeholder);
+        CHECK(Gll12.get(g, i + 1, h) == spatial_component_placeholder_value);
       }
     }
   }
 
-  auto Gll13 = make_with_value<
-      Tensor<double, Symmetry<2, 1>,
-             index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                        SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>>(
-      0.0, spatial_component_placeholder);
+  auto Gll13 = make_with_value<tnsr::ab<DataType, 3, Frame::Grid>>(
+      used_for_size, spatial_component_placeholder_value);
   tenex::evaluate<ti::t, ti::f>(make_not_null(&Gll13),
                                 Rlll(ti::t, ti::t, ti::f) - Hll(ti::f, ti::t));
 
   for (int f = 0; f < 4; ++f) {
     CHECK(Gll13.get(0, f) == Rlll.get(0, 0, f) - Hll.get(f, 0));
     for (size_t i = 0; i < 3; ++i) {
-      CHECK(Gll13.get(i + 1, f) == spatial_component_placeholder);
+      CHECK(Gll13.get(i + 1, f) == spatial_component_placeholder_value);
     }
   }
 
-  const Tensor<double> T{{{-3.2}}};
+  const auto T = make_with_random_values<Scalar<DataType>>(
+      generator, distribution, used_for_size);
 
-  auto Gll14 = make_with_value<
-      Tensor<double, Symmetry<2, 1>,
-             index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
-                        SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>>(
-      0.0, spatial_component_placeholder);
+  auto Gll14 = make_with_value<tnsr::Ab<DataType, 3, Frame::Grid>>(
+      used_for_size, spatial_component_placeholder_value);
   tenex::evaluate<ti::T, ti::t>(
       make_not_null(&Gll14),
       Hll(ti::t, ti::t) - T() - Rlll(ti::t, ti::t, ti::t) + 9.1);
@@ -398,7 +320,26 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
   CHECK(Gll14.get(0, 0) == Hll.get(0, 0) - get(T) - Rlll.get(0, 0, 0) + 9.1);
   for (size_t i = 0; i < 3; ++i) {
     for (size_t j = 0; j < 3; ++j) {
-      CHECK(Gll14.get(i + 1, j + 1) == spatial_component_placeholder);
+      CHECK(Gll14.get(i + 1, j + 1) == spatial_component_placeholder_value);
     }
   }
+}
+
+template <typename Generator, typename DataType>
+void test_addsub(const gsl::not_null<Generator*> generator,
+                 const DataType& used_for_size) {
+  test_addsub_double(generator, used_for_size);
+  test_addsub_tensor(generator, used_for_size);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
+                  "[DataStructures][Unit]") {
+  MAKE_GENERATOR(generator);
+
+  test_tensor_ops_properties();
+  test_addsub(make_not_null(&generator),
+              std::numeric_limits<double>::signaling_NaN());
+  test_addsub(make_not_null(&generator),
+              DataVector(5, std::numeric_limits<double>::signaling_NaN()));
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_AddSubtract.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_AddSubtract.cpp
@@ -8,6 +8,7 @@
 #include <random>
 #include <type_traits>
 
+#include "DataStructures/ComplexDataVector.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Symmetry.hpp"
@@ -342,4 +343,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
               std::numeric_limits<double>::signaling_NaN());
   test_addsub(make_not_null(&generator),
               DataVector(5, std::numeric_limits<double>::signaling_NaN()));
+  test_addsub(
+      make_not_null(&generator),
+      ComplexDataVector(5, std::numeric_limits<double>::signaling_NaN()));
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Contract.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Contract.cpp
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <random>
 
+#include "DataStructures/ComplexDataVector.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Symmetry.hpp"
@@ -840,4 +841,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Contract",
   test_contractions(
       make_not_null(&generator),
       DataVector(5, std::numeric_limits<double>::signaling_NaN()));
+  test_contractions(
+      make_not_null(&generator),
+      ComplexDataVector(5, std::numeric_limits<double>::signaling_NaN()));
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Contract.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Contract.cpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <climits>
+#include <complex>
 #include <cstddef>
 #include <random>
 
@@ -838,6 +839,10 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Contract",
   test_contraction_summation_consistency();
   test_contractions(make_not_null(&generator),
                     std::numeric_limits<double>::signaling_NaN());
+  test_contractions(
+      make_not_null(&generator),
+      std::complex<double>(std::numeric_limits<double>::signaling_NaN(),
+                           std::numeric_limits<double>::signaling_NaN()));
   test_contractions(
       make_not_null(&generator),
       DataVector(5, std::numeric_limits<double>::signaling_NaN()));

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Contract.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Contract.cpp
@@ -6,33 +6,19 @@
 #include <array>
 #include <climits>
 #include <cstddef>
-#include <iterator>
-#include <numeric>
+#include <random>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Symmetry.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/ComponentPlaceholder.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
 namespace {
-template <typename... Ts>
-void create_tensor(gsl::not_null<Tensor<double, Ts...>*> tensor) {
-  std::iota(tensor->begin(), tensor->end(), 0.0);
-}
-
-template <typename... Ts>
-void create_tensor(gsl::not_null<Tensor<DataVector, Ts...>*> tensor) {
-  double value = 0.0;
-  for (auto index_it = tensor->begin(); index_it != tensor->end(); index_it++) {
-    for (auto vector_it = index_it->begin(); vector_it != index_it->end();
-         vector_it++) {
-      *vector_it = value;
-      value += 1.0;
-    }
-  }
-}
 
 // Checks that the number of ops in the expressions match what is expected
 void test_tensor_ops_properties() {
@@ -91,16 +77,17 @@ void test_contraction_summation_consistency() {
   }
 }
 
-template <typename DataType>
-void test_contractions_rank2(const DataType& used_for_size) {
+template <typename Generator, typename DataType>
+void test_contractions_rank2(const gsl::not_null<Generator*> generator,
+                             const DataType& used_for_size) {
+  std::uniform_real_distribution<> distribution(-1.0, 1.0);
+
   // Contract (upper, lower) tensor
   // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
   // return type of `evaluate`
-  Tensor<DataType, Symmetry<2, 1>,
-         index_list<SpatialIndex<3, UpLo::Up, Frame::Inertial>,
-                    SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>
-      Rul(used_for_size);
-  create_tensor(make_not_null(&Rul));
+  const auto Rul =
+      make_with_random_values<tnsr::Ij<DataType, 3, Frame::Inertial>>(
+          generator, distribution, used_for_size);
 
   const Tensor<DataType> RIi_contracted = tenex::evaluate(Rul(ti::I, ti::i));
 
@@ -108,14 +95,11 @@ void test_contractions_rank2(const DataType& used_for_size) {
   for (size_t i = 0; i < 3; i++) {
     expected_RIi_sum += Rul.get(i, i);
   }
-  CHECK(RIi_contracted.get() == expected_RIi_sum);
+  CHECK_ITERABLE_APPROX(RIi_contracted.get(), expected_RIi_sum);
 
   // Contract (lower, upper) tensor
-  Tensor<DataType, Symmetry<2, 1>,
-         index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>
-      Rlu(used_for_size);
-  create_tensor(make_not_null(&Rlu));
+  const auto Rlu = make_with_random_values<tnsr::aB<DataType, 3, Frame::Grid>>(
+      generator, distribution, used_for_size);
 
   const Tensor<DataType> RgG_contracted = tenex::evaluate(Rlu(ti::g, ti::G));
 
@@ -123,40 +107,40 @@ void test_contractions_rank2(const DataType& used_for_size) {
   for (size_t g = 0; g < 4; g++) {
     expected_RgG_sum += Rlu.get(g, g);
   }
-  CHECK(RgG_contracted.get() == expected_RgG_sum);
+  CHECK_ITERABLE_APPROX(RgG_contracted.get(), expected_RgG_sum);
 }
 
-template <typename DataType>
-void test_contractions_rank3(const DataType& used_for_size) {
+template <typename Generator, typename DataType>
+void test_contractions_rank3(const gsl::not_null<Generator*> generator,
+                             const DataType& used_for_size) {
+  std::uniform_real_distribution<> distribution(-1.0, 1.0);
+
   // Contract first and second indices of (lower, upper, lower) tensor
   // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
   // return type of `evaluate`
-  Tensor<DataType, Symmetry<3, 2, 1>,
-         index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpatialIndex<3, UpLo::Up, Frame::Grid>,
-                    SpatialIndex<4, UpLo::Lo, Frame::Grid>>>
-      Rlul(used_for_size);
-  create_tensor(make_not_null(&Rlul));
+  const auto Rlul = make_with_random_values<
+      Tensor<DataType, Symmetry<3, 2, 1>,
+             index_list<SpatialIndex<2, UpLo::Lo, Frame::Grid>,
+                        SpatialIndex<2, UpLo::Up, Frame::Grid>,
+                        SpatialIndex<3, UpLo::Lo, Frame::Grid>>>>(
+      generator, distribution, used_for_size);
 
   const Tensor<DataType, Symmetry<1>,
-               index_list<SpatialIndex<4, UpLo::Lo, Frame::Grid>>>
+               index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
       RiIj_contracted = tenex::evaluate<ti::j>(Rlul(ti::i, ti::I, ti::j));
 
-  for (size_t j = 0; j < 4; j++) {
+  for (size_t j = 0; j < 3; j++) {
     DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
-    for (size_t i = 0; i < 3; i++) {
+    for (size_t i = 0; i < 2; i++) {
       expected_sum += Rlul.get(i, i, j);
     }
-    CHECK(RiIj_contracted.get(j) == expected_sum);
+    CHECK_ITERABLE_APPROX(RiIj_contracted.get(j), expected_sum);
   }
 
   // Contract first and third indices of (upper, upper, lower) tensor
-  Tensor<DataType, Symmetry<2, 2, 1>,
-         index_list<SpatialIndex<3, UpLo::Up, Frame::Grid>,
-                    SpatialIndex<3, UpLo::Up, Frame::Grid>,
-                    SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
-      Ruul(used_for_size);
-  create_tensor(make_not_null(&Ruul));
+  const auto Ruul =
+      make_with_random_values<tnsr::IJk<DataType, 3, Frame::Grid>>(
+          generator, distribution, used_for_size);
 
   const Tensor<DataType, Symmetry<1>,
                index_list<SpatialIndex<3, UpLo::Up, Frame::Grid>>>
@@ -167,16 +151,16 @@ void test_contractions_rank3(const DataType& used_for_size) {
     for (size_t j = 0; j < 3; j++) {
       expected_sum += Ruul.get(j, l, j);
     }
-    CHECK(RJLj_contracted.get(l) == expected_sum);
+    CHECK_ITERABLE_APPROX(RJLj_contracted.get(l), expected_sum);
   }
 
   // Contract second and third indices of (upper, lower, upper) tensor
-  Tensor<DataType, Symmetry<2, 1, 2>,
-         index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
-                    SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
-                    SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>>
-      Rulu(used_for_size);
-  create_tensor(make_not_null(&Rulu));
+  const auto Rulu = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1, 2>,
+             index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                        SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                        SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>>>(
+      generator, distribution, used_for_size);
 
   const Tensor<DataType, Symmetry<1>,
                index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>>
@@ -187,17 +171,17 @@ void test_contractions_rank3(const DataType& used_for_size) {
     for (size_t f = 0; f < 4; f++) {
       expected_sum += Rulu.get(b, f, f);
     }
-    CHECK(RBfF_contracted.get(b) == expected_sum);
+    CHECK_ITERABLE_APPROX(RBfF_contracted.get(b), expected_sum);
   }
 
   // Contract first and third indices of (lower, lower, upper) tensor with mixed
   // TensorIndexTypes
-  Tensor<DataType, Symmetry<3, 2, 1>,
-         index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpatialIndex<3, UpLo::Up, Frame::Grid>>>
-      Rllu(used_for_size);
-  create_tensor(make_not_null(&Rllu));
+  const auto Rllu = make_with_random_values<
+      Tensor<DataType, Symmetry<3, 2, 1>,
+             index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                        SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                        SpatialIndex<3, UpLo::Up, Frame::Grid>>>>(
+      generator, distribution, used_for_size);
 
   const Tensor<DataType, Symmetry<1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
@@ -208,101 +192,104 @@ void test_contractions_rank3(const DataType& used_for_size) {
     for (size_t i = 0; i < 3; i++) {
       expected_sum += Rllu.get(i, a, i);
     }
-    CHECK(RiaI_contracted.get(a) == expected_sum);
+    CHECK_ITERABLE_APPROX(RiaI_contracted.get(a), expected_sum);
   }
 }
 
-template <typename DataType>
-void test_contractions_rank4(const DataType& used_for_size) {
+template <typename Generator, typename DataType>
+void test_contractions_rank4(const gsl::not_null<Generator*> generator,
+                             const DataType& used_for_size) {
+  std::uniform_real_distribution<> distribution(-1.0, 1.0);
+
   // Contract first and second indices of (lower, upper, upper, lower) tensor to
   // rank 2 tensor
   // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
   // return type of `evaluate`
-  Tensor<DataType, Symmetry<4, 3, 2, 1>,
-         index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
-                    SpatialIndex<3, UpLo::Up, Frame::Inertial>,
-                    SpatialIndex<4, UpLo::Up, Frame::Inertial>,
-                    SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>
-      Rluul(used_for_size);
-  create_tensor(make_not_null(&Rluul));
+  const auto Rluul = make_with_random_values<
+      Tensor<DataType, Symmetry<4, 3, 2, 1>,
+             index_list<SpatialIndex<2, UpLo::Lo, Frame::Inertial>,
+                        SpatialIndex<2, UpLo::Up, Frame::Inertial>,
+                        SpatialIndex<3, UpLo::Up, Frame::Inertial>,
+                        SpatialIndex<2, UpLo::Lo, Frame::Inertial>>>>(
+      generator, distribution, used_for_size);
 
   const Tensor<DataType, Symmetry<2, 1>,
-               index_list<SpatialIndex<4, UpLo::Up, Frame::Inertial>,
-                          SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>
+               index_list<SpatialIndex<3, UpLo::Up, Frame::Inertial>,
+                          SpatialIndex<2, UpLo::Lo, Frame::Inertial>>>
       RiIKj_contracted =
           tenex::evaluate<ti::K, ti::j>(Rluul(ti::i, ti::I, ti::K, ti::j));
 
-  for (size_t k = 0; k < 4; k++) {
-    for (size_t j = 0; j < 3; j++) {
+  for (size_t k = 0; k < 3; k++) {
+    for (size_t j = 0; j < 2; j++) {
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
-      for (size_t i = 0; i < 3; i++) {
+      for (size_t i = 0; i < 2; i++) {
         expected_sum += Rluul.get(i, i, k, j);
       }
-      CHECK(RiIKj_contracted.get(k, j) == expected_sum);
+      CHECK_ITERABLE_APPROX(RiIKj_contracted.get(k, j), expected_sum);
     }
   }
 
   // Contract first and third indices of (upper, upper, lower, lower) tensor to
   // rank 2 tensor
-  Tensor<DataType, Symmetry<4, 3, 2, 1>,
-         index_list<SpacetimeIndex<4, UpLo::Up, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
-                    SpacetimeIndex<4, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<4, UpLo::Lo, Frame::Grid>>>
-      Ruull(used_for_size);
-  create_tensor(make_not_null(&Ruull));
+  const auto Ruull = make_with_random_values<
+      Tensor<DataType, Symmetry<4, 3, 2, 1>,
+             index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                        SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
+                        SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                        SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>>(
+      generator, distribution, used_for_size);
 
   const Tensor<DataType, Symmetry<2, 1>,
-               index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
-                          SpacetimeIndex<4, UpLo::Lo, Frame::Grid>>>
+               index_list<SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
+                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
       RABac_contracted =
           tenex::evaluate<ti::B, ti::c>(Ruull(ti::A, ti::B, ti::a, ti::c));
 
-  for (size_t b = 0; b < 4; b++) {
-    for (size_t c = 0; c < 5; c++) {
+  for (size_t b = 0; b < 3; b++) {
+    for (size_t c = 0; c < 4; c++) {
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
-      for (size_t a = 0; a < 5; a++) {
+      for (size_t a = 0; a < 4; a++) {
         expected_sum += Ruull.get(a, b, a, c);
       }
-      CHECK(RABac_contracted.get(b, c) == expected_sum);
+      CHECK_ITERABLE_APPROX(RABac_contracted.get(b, c), expected_sum);
     }
   }
 
   // Contract first and fourth indices of (upper, upper, upper, lower) tensor to
   // rank 2 tensor
-  Tensor<DataType, Symmetry<3, 2, 3, 1>,
-         index_list<SpatialIndex<3, UpLo::Up, Frame::Grid>,
-                    SpatialIndex<4, UpLo::Up, Frame::Grid>,
-                    SpatialIndex<3, UpLo::Up, Frame::Grid>,
-                    SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
-      Ruuul(used_for_size);
-  create_tensor(make_not_null(&Ruuul));
+  const auto Ruuul = make_with_random_values<
+      Tensor<DataType, Symmetry<3, 2, 3, 1>,
+             index_list<SpatialIndex<2, UpLo::Up, Frame::Grid>,
+                        SpatialIndex<3, UpLo::Up, Frame::Grid>,
+                        SpatialIndex<2, UpLo::Up, Frame::Grid>,
+                        SpatialIndex<2, UpLo::Lo, Frame::Grid>>>>(
+      generator, distribution, used_for_size);
 
   const Tensor<DataType, Symmetry<2, 1>,
-               index_list<SpatialIndex<4, UpLo::Up, Frame::Grid>,
-                          SpatialIndex<3, UpLo::Up, Frame::Grid>>>
+               index_list<SpatialIndex<3, UpLo::Up, Frame::Grid>,
+                          SpatialIndex<2, UpLo::Up, Frame::Grid>>>
       RLJIl_contracted =
           tenex::evaluate<ti::J, ti::I>(Ruuul(ti::L, ti::J, ti::I, ti::l));
 
-  for (size_t j = 0; j < 4; j++) {
-    for (size_t i = 0; i < 3; i++) {
+  for (size_t j = 0; j < 3; j++) {
+    for (size_t i = 0; i < 2; i++) {
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
-      for (size_t l = 0; l < 3; l++) {
+      for (size_t l = 0; l < 2; l++) {
         expected_sum += Ruuul.get(l, j, i, l);
       }
-      CHECK(RLJIl_contracted.get(j, i) == expected_sum);
+      CHECK_ITERABLE_APPROX(RLJIl_contracted.get(j, i), expected_sum);
     }
   }
 
   // Contract second and third indices of (upper, upper, lower, upper) tensor to
   // rank 2 tensor
-  Tensor<DataType, Symmetry<2, 2, 1, 2>,
-         index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>
-      Ruulu(used_for_size);
-  create_tensor(make_not_null(&Ruulu));
+  const auto Ruulu = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 2, 1, 2>,
+             index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                        SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                        SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                        SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>>(
+      generator, distribution, used_for_size);
 
   const Tensor<DataType, Symmetry<1, 1>,
                index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
@@ -316,71 +303,71 @@ void test_contractions_rank4(const DataType& used_for_size) {
       for (size_t d = 0; d < 4; d++) {
         expected_sum += Ruulu.get(e, d, d, a);
       }
-      CHECK(REDdA_contracted.get(e, a) == expected_sum);
+      CHECK_ITERABLE_APPROX(REDdA_contracted.get(e, a), expected_sum);
     }
   }
 
   // Contract second and fourth indices of (lower, upper, lower, lower) tensor
   // to rank 2 tensor
-  Tensor<DataType, Symmetry<4, 3, 2, 1>,
-         index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
-                    SpatialIndex<3, UpLo::Up, Frame::Inertial>,
-                    SpatialIndex<4, UpLo::Lo, Frame::Inertial>,
-                    SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>
-      Rlull(used_for_size);
-  create_tensor(make_not_null(&Rlull));
+  const auto Rlull = make_with_random_values<
+      Tensor<DataType, Symmetry<4, 3, 2, 1>,
+             index_list<SpatialIndex<2, UpLo::Lo, Frame::Inertial>,
+                        SpatialIndex<2, UpLo::Up, Frame::Inertial>,
+                        SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                        SpatialIndex<2, UpLo::Lo, Frame::Inertial>>>>(
+      generator, distribution, used_for_size);
 
   const Tensor<DataType, Symmetry<2, 1>,
-               index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
-                          SpatialIndex<4, UpLo::Lo, Frame::Inertial>>>
+               index_list<SpatialIndex<2, UpLo::Lo, Frame::Inertial>,
+                          SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>
       RkJij_contracted =
           tenex::evaluate<ti::k, ti::i>(Rlull(ti::k, ti::J, ti::i, ti::j));
 
-  for (size_t k = 0; k < 3; k++) {
-    for (size_t i = 0; i < 4; i++) {
+  for (size_t k = 0; k < 2; k++) {
+    for (size_t i = 0; i < 3; i++) {
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
-      for (size_t j = 0; j < 3; j++) {
+      for (size_t j = 0; j < 2; j++) {
         expected_sum += Rlull.get(k, j, i, j);
       }
-      CHECK(RkJij_contracted.get(k, i) == expected_sum);
+      CHECK_ITERABLE_APPROX(RkJij_contracted.get(k, i), expected_sum);
     }
   }
 
   // Contract third and fourth indices of (upper, lower, lower, upper) tensor to
   // rank 2 tensor
-  Tensor<DataType, Symmetry<3, 2, 2, 1>,
-         index_list<SpacetimeIndex<4, UpLo::Up, Frame::Inertial>,
-                    SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
-                    SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
-                    SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>>
-      Rullu(used_for_size);
-  create_tensor(make_not_null(&Rullu));
+  const auto Rullu = make_with_random_values<
+      Tensor<DataType, Symmetry<3, 2, 2, 1>,
+             index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                        SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>,
+                        SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>,
+                        SpacetimeIndex<2, UpLo::Up, Frame::Inertial>>>>(
+      generator, distribution, used_for_size);
 
   const Tensor<DataType, Symmetry<2, 1>,
-               index_list<SpacetimeIndex<4, UpLo::Up, Frame::Inertial>,
-                          SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>
+               index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                          SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>>>
       RFcgG_contracted =
           tenex::evaluate<ti::F, ti::c>(Rullu(ti::F, ti::c, ti::g, ti::G));
 
-  for (size_t f = 0; f < 5; f++) {
-    for (size_t c = 0; c < 4; c++) {
+  for (size_t f = 0; f < 4; f++) {
+    for (size_t c = 0; c < 3; c++) {
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
-      for (size_t g = 0; g < 4; g++) {
+      for (size_t g = 0; g < 3; g++) {
         expected_sum += Rullu.get(f, c, g, g);
       }
-      CHECK(RFcgG_contracted.get(f, c) == expected_sum);
+      CHECK_ITERABLE_APPROX(RFcgG_contracted.get(f, c), expected_sum);
     }
   }
 
   // Contract first and second indices of (upper, lower, upper, upper) tensor to
   // rank 2 tensor and reorder indices
-  Tensor<DataType, Symmetry<3, 2, 3, 1>,
-         index_list<SpatialIndex<3, UpLo::Up, Frame::Grid>,
-                    SpatialIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpatialIndex<3, UpLo::Up, Frame::Grid>,
-                    SpatialIndex<2, UpLo::Up, Frame::Grid>>>
-      Ruluu(used_for_size);
-  create_tensor(make_not_null(&Ruluu));
+  const auto Ruluu = make_with_random_values<
+      Tensor<DataType, Symmetry<3, 2, 3, 1>,
+             index_list<SpatialIndex<3, UpLo::Up, Frame::Grid>,
+                        SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                        SpatialIndex<3, UpLo::Up, Frame::Grid>,
+                        SpatialIndex<2, UpLo::Up, Frame::Grid>>>>(
+      generator, distribution, used_for_size);
 
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<2, UpLo::Up, Frame::Grid>,
@@ -394,19 +381,19 @@ void test_contractions_rank4(const DataType& used_for_size) {
       for (size_t k = 0; k < 3; k++) {
         expected_sum += Ruluu.get(k, k, i, j);
       }
-      CHECK(RKkIJ_contracted_to_JI.get(j, i) == expected_sum);
+      CHECK_ITERABLE_APPROX(RKkIJ_contracted_to_JI.get(j, i), expected_sum);
     }
   }
 
   // Contract first and third indices of (lower, upper, upper, upper) tensor to
   // rank 2 tensor and reorder indices
-  Tensor<DataType, Symmetry<3, 2, 1, 2>,
-         index_list<SpacetimeIndex<2, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
-                    SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
-                    SpacetimeIndex<2, UpLo::Up, Frame::Grid>>>
-      Rluuu(used_for_size);
-  create_tensor(make_not_null(&Rluuu));
+  const auto Rluuu = make_with_random_values<
+      Tensor<DataType, Symmetry<3, 2, 1, 2>,
+             index_list<SpacetimeIndex<2, UpLo::Lo, Frame::Grid>,
+                        SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
+                        SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
+                        SpacetimeIndex<2, UpLo::Up, Frame::Grid>>>>(
+      generator, distribution, used_for_size);
 
   const Tensor<DataType, Symmetry<1, 1>,
                index_list<SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
@@ -420,19 +407,19 @@ void test_contractions_rank4(const DataType& used_for_size) {
       for (size_t b = 0; b < 3; b++) {
         expected_sum += Rluuu.get(b, c, b, e);
       }
-      CHECK(RbCBE_contracted_to_EC.get(e, c) == expected_sum);
+      CHECK_ITERABLE_APPROX(RbCBE_contracted_to_EC.get(e, c), expected_sum);
     }
   }
 
   // Contract first and fourth indices of (upper, lower, lower, lower) tensor to
   // rank 2 tensor and reorder indices
-  Tensor<DataType, Symmetry<2, 1, 1, 1>,
-         index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Rulll(used_for_size);
-  create_tensor(make_not_null(&Rulll));
+  const auto Rulll = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1, 1, 1>,
+             index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                        SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                        SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                        SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>>(
+      generator, distribution, used_for_size);
 
   const Tensor<DataType, Symmetry<1, 1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
@@ -446,45 +433,45 @@ void test_contractions_rank4(const DataType& used_for_size) {
       for (size_t a = 0; a < 4; a++) {
         expected_sum += Rulll.get(a, d, b, a);
       }
-      CHECK(RAdba_contracted_to_bd.get(b, d) == expected_sum);
+      CHECK_ITERABLE_APPROX(RAdba_contracted_to_bd.get(b, d), expected_sum);
     }
   }
 
   // Contract second and third indices of (lower, lower, upper, lower) tensor to
   // rank 2 tensor and reorder indices
-  Tensor<DataType, Symmetry<4, 3, 2, 1>,
-         index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpatialIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpatialIndex<3, UpLo::Up, Frame::Grid>,
-                    SpatialIndex<4, UpLo::Lo, Frame::Grid>>>
-      Rllul(used_for_size);
-  create_tensor(make_not_null(&Rllul));
+  const auto Rllul = make_with_random_values<
+      Tensor<DataType, Symmetry<4, 3, 2, 1>,
+             index_list<SpatialIndex<2, UpLo::Lo, Frame::Grid>,
+                        SpatialIndex<2, UpLo::Lo, Frame::Grid>,
+                        SpatialIndex<2, UpLo::Up, Frame::Grid>,
+                        SpatialIndex<3, UpLo::Lo, Frame::Grid>>>>(
+      generator, distribution, used_for_size);
 
   const Tensor<DataType, Symmetry<2, 1>,
-               index_list<SpatialIndex<4, UpLo::Lo, Frame::Grid>,
-                          SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
+               index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                          SpatialIndex<2, UpLo::Lo, Frame::Grid>>>
       RljJi_contracted_to_il =
           tenex::evaluate<ti::i, ti::l>(Rllul(ti::l, ti::j, ti::J, ti::i));
 
-  for (size_t i = 0; i < 4; i++) {
-    for (size_t l = 0; l < 3; l++) {
+  for (size_t i = 0; i < 3; i++) {
+    for (size_t l = 0; l < 2; l++) {
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
-      for (size_t j = 0; j < 3; j++) {
+      for (size_t j = 0; j < 2; j++) {
         expected_sum += Rllul.get(l, j, j, i);
       }
-      CHECK(RljJi_contracted_to_il.get(i, l) == expected_sum);
+      CHECK_ITERABLE_APPROX(RljJi_contracted_to_il.get(i, l), expected_sum);
     }
   }
 
   // Contract second and fourth indices of (lower, lower, upper, upper) tensor
   // to rank 2 tensor and reorder indices
-  Tensor<DataType, Symmetry<2, 2, 1, 1>,
-         index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
-                    SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
-                    SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
-                    SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>>
-      Rlluu(used_for_size);
-  create_tensor(make_not_null(&Rlluu));
+  const auto Rlluu = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 2, 1, 1>,
+             index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                        SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                        SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                        SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>>>(
+      generator, distribution, used_for_size);
 
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
@@ -498,19 +485,19 @@ void test_contractions_rank4(const DataType& used_for_size) {
       for (size_t g = 0; g < 4; g++) {
         expected_sum += Rlluu.get(a, g, d, g);
       }
-      CHECK(RagDG_contracted_to_Da.get(d, a) == expected_sum);
+      CHECK_ITERABLE_APPROX(RagDG_contracted_to_Da.get(d, a), expected_sum);
     }
   }
 
   // Contract third and fourth indices of (lower, upper, lower, upper) tensor to
   // rank 2 tensor and reorder indices
-  Tensor<DataType, Symmetry<2, 1, 2, 1>,
-         index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
-                    SpatialIndex<3, UpLo::Up, Frame::Inertial>,
-                    SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
-                    SpatialIndex<3, UpLo::Up, Frame::Inertial>>>
-      Rlulu(used_for_size);
-  create_tensor(make_not_null(&Rlulu));
+  const auto Rlulu = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1, 2, 1>,
+             index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                        SpatialIndex<3, UpLo::Up, Frame::Inertial>,
+                        SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                        SpatialIndex<3, UpLo::Up, Frame::Inertial>>>>(
+      generator, distribution, used_for_size);
 
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<3, UpLo::Up, Frame::Inertial>,
@@ -524,30 +511,30 @@ void test_contractions_rank4(const DataType& used_for_size) {
       for (size_t i = 0; i < 3; i++) {
         expected_sum += Rlulu.get(l, j, i, i);
       }
-      CHECK(RlJiI_contracted_to_Jl.get(j, l) == expected_sum);
+      CHECK_ITERABLE_APPROX(RlJiI_contracted_to_Jl.get(j, l), expected_sum);
     }
   }
 
   // Contract first and second indices AND third and fourth indices to rank 0
   // tensor
-  Tensor<DataType, Symmetry<4, 3, 2, 1>,
-         index_list<SpatialIndex<3, UpLo::Up, Frame::Grid>,
-                    SpatialIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpatialIndex<4, UpLo::Up, Frame::Grid>,
-                    SpatialIndex<4, UpLo::Lo, Frame::Grid>>>
-      Rulul(used_for_size);
-  create_tensor(make_not_null(&Rulul));
+  const auto Rulul = make_with_random_values<
+      Tensor<DataType, Symmetry<4, 3, 2, 1>,
+             index_list<SpatialIndex<2, UpLo::Up, Frame::Grid>,
+                        SpatialIndex<2, UpLo::Lo, Frame::Grid>,
+                        SpatialIndex<3, UpLo::Up, Frame::Grid>,
+                        SpatialIndex<3, UpLo::Lo, Frame::Grid>>>>(
+      generator, distribution, used_for_size);
 
   const Tensor<DataType> RKkLl_contracted =
       tenex::evaluate(Rulul(ti::K, ti::k, ti::L, ti::l));
 
   DataType expected_RKkLl_sum = make_with_value<DataType>(used_for_size, 0.0);
-  for (size_t k = 0; k < 3; k++) {
-    for (size_t l = 0; l < 4; l++) {
+  for (size_t k = 0; k < 2; k++) {
+    for (size_t l = 0; l < 3; l++) {
       expected_RKkLl_sum += Rulul.get(k, k, l, l);
     }
   }
-  CHECK(RKkLl_contracted.get() == expected_RKkLl_sum);
+  CHECK_ITERABLE_APPROX(RKkLl_contracted.get(), expected_RKkLl_sum);
 
   // Contract first and third indices and second and fourth indices to rank 0
   // tensor
@@ -560,7 +547,7 @@ void test_contractions_rank4(const DataType& used_for_size) {
       expected_RcaCA_sum += Rlluu.get(c, a, c, a);
     }
   }
-  CHECK(RcaCA_contracted.get() == expected_RcaCA_sum);
+  CHECK_ITERABLE_APPROX(RcaCA_contracted.get(), expected_RcaCA_sum);
 
   // Contract first and fourth indices and second and third indices to rank 0
   // tensor
@@ -573,36 +560,35 @@ void test_contractions_rank4(const DataType& used_for_size) {
       expected_RjIiJ_sum += Rlulu.get(j, i, i, j);
     }
   }
-  CHECK(RjIiJ_contracted.get() == expected_RjIiJ_sum);
+  CHECK_ITERABLE_APPROX(RjIiJ_contracted.get(), expected_RjIiJ_sum);
 }
 
-template <typename DataType>
-void test_spatial_spacetime_index(const DataType& used_for_size) {
+template <typename Generator, typename DataType>
+void test_spatial_spacetime_index(const gsl::not_null<Generator*> generator,
+                                  const DataType& used_for_size) {
+  std::uniform_real_distribution<> distribution(-1.0, 1.0);
+
   // Contract (spatial, spacetime) tensor
   // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
   // return type of `evaluate`
-  Tensor<DataType, Symmetry<2, 1>,
-         index_list<SpatialIndex<3, UpLo::Up, Frame::Inertial>,
-                    SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>
-
-      R(used_for_size);
-  create_tensor(make_not_null(&R));
+  const auto R = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<SpatialIndex<3, UpLo::Up, Frame::Inertial>,
+                        SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>>(
+      generator, distribution, used_for_size);
   const Tensor<DataType> R_contracted = tenex::evaluate(R(ti::I, ti::i));
 
   // Contract (spacetime, spatial) tensor
-  Tensor<DataType, Symmetry<2, 1>,
-         index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
-                    SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>
-      S(used_for_size);
-  create_tensor(make_not_null(&S));
+  const auto S = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                        SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>>(
+      generator, distribution, used_for_size);
   const Tensor<DataType> S_contracted = tenex::evaluate(S(ti::K, ti::k));
 
   // Contract (spacetime, spacetime) tensor using generic spatial indices
-  Tensor<DataType, Symmetry<2, 1>,
-         index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>
-      T(used_for_size);
-  create_tensor(make_not_null(&T));
+  const auto T = make_with_random_values<tnsr::aB<DataType, 3, Frame::Grid>>(
+      generator, distribution, used_for_size);
   const Tensor<DataType> T_contracted = tenex::evaluate(T(ti::j, ti::J));
 
   DataType expected_R_sum = make_with_value<DataType>(used_for_size, 0.0);
@@ -617,13 +603,13 @@ void test_spatial_spacetime_index(const DataType& used_for_size) {
   CHECK_ITERABLE_APPROX(S_contracted.get(), expected_S_sum);
   CHECK_ITERABLE_APPROX(T_contracted.get(), expected_T_sum);
 
-  Tensor<DataType, Symmetry<4, 3, 2, 1>,
-         index_list<SpatialIndex<3, UpLo::Up, Frame::Grid>,
-                    SpatialIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>
-      G(used_for_size);
-  create_tensor(make_not_null(&G));
+  const auto G = make_with_random_values<
+      Tensor<DataType, Symmetry<4, 3, 2, 1>,
+             index_list<SpatialIndex<3, UpLo::Up, Frame::Grid>,
+                        SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                        SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                        SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>>(
+      generator, distribution, used_for_size);
 
   // Contract one (spatial, spacetime) pair of indices of a tensor that also
   // takes a generic spatial index for a single non-contracted spacetime index
@@ -670,13 +656,13 @@ void test_spatial_spacetime_index(const DataType& used_for_size) {
   }
   CHECK_ITERABLE_APPROX(G_contracted_3.get(), expected_G_sum_3);
 
-  Tensor<DataType, Symmetry<4, 3, 2, 1>,
-         index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>
-      H(used_for_size);
-  create_tensor(make_not_null(&H));
+  const auto H = make_with_random_values<
+      Tensor<DataType, Symmetry<4, 3, 2, 1>,
+             index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                        SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                        SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                        SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>>(
+      generator, distribution, used_for_size);
 
   // Contract one (spacetime, spacetime) pair of indices using generic spacetime
   // indices and then one (spacetime, spacetime) pair of indices using generic
@@ -706,15 +692,18 @@ void test_spatial_spacetime_index(const DataType& used_for_size) {
   CHECK_ITERABLE_APPROX(H_contracted_2.get(), expected_H_sum_2);
 }
 
-template <typename DataType>
-void test_time_index(const DataType& used_for_size) {
-  Tensor<DataType, Symmetry<4, 3, 2, 1>,
-         index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
-                    SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
-                    SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
-                    SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>
-      R(used_for_size);
-  create_tensor(make_not_null(&R));
+template <typename Generator, typename DataType>
+void test_time_index(const gsl::not_null<Generator*> generator,
+                     const DataType& used_for_size) {
+  std::uniform_real_distribution<> distribution(-1.0, 1.0);
+
+  const auto R = make_with_random_values<
+      Tensor<DataType, Symmetry<4, 3, 2, 1>,
+             index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                        SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                        SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                        SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>>(
+      generator, distribution, used_for_size);
   // Contract RHS tensor with time index to a LHS tensor without a time index
   // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
   // return type of `evaluate`
@@ -746,24 +735,24 @@ void test_time_index(const DataType& used_for_size) {
   }
   CHECK_ITERABLE_APPROX(R_contracted_2.get(), expected_R_sum_2);
 
-  Tensor<DataType, Symmetry<3, 2, 1>,
-         index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
-                    SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
-                    SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>
-      S(used_for_size);
-  create_tensor(make_not_null(&S));
+  const auto S = make_with_random_values<
+      Tensor<DataType, Symmetry<3, 2, 1>,
+             index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                        SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                        SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>>(
+      generator, distribution, used_for_size);
   // Assign a placeholder to the LHS tensor's components before it is computed
   // so that when test expressions below only compute time components, we can
   // check that LHS spatial components haven't changed
-  const double spatial_component_placeholder =
-      std::numeric_limits<double>::max();
+  const auto spatial_component_placeholder_value =
+      TestHelpers::tenex::component_placeholder_value<DataType>::value;
   auto S_contracted = make_with_value<
       Tensor<DataType, Symmetry<4, 3, 2, 1>,
              index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
                         SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
                         SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
                         SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>>>(
-      used_for_size, spatial_component_placeholder);
+      used_for_size, spatial_component_placeholder_value);
 
   // Contract a RHS tensor without time indices to a LHS tensor with time
   // indices
@@ -788,25 +777,25 @@ void test_time_index(const DataType& used_for_size) {
       for (size_t j = 0; j < 3; j++) {
         for (size_t k = 0; k < 3; k++) {
           CHECK(S_contracted.get(i + 1, j + 1, b, k + 1) ==
-                spatial_component_placeholder);
+                spatial_component_placeholder_value);
         }
       }
     }
   }
 
-  Tensor<DataType, Symmetry<4, 3, 2, 1>,
-         index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>
-      T(used_for_size);
-  create_tensor(make_not_null(&T));
+  const auto T = make_with_random_values<
+      Tensor<DataType, Symmetry<4, 3, 2, 1>,
+             index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                        SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                        SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                        SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>>(
+      generator, distribution, used_for_size);
   auto T_contracted = make_with_value<
       Tensor<DataType, Symmetry<3, 2, 1>,
              index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                         SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                         SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>>(
-      used_for_size, spatial_component_placeholder);
+      used_for_size, spatial_component_placeholder_value);
 
   // Contract a RHS tensor with time indices to a LHS tensor with time indices
   // \f$L^{tb}{}_{t} = R_{at}{}^{ab}\f$
@@ -823,27 +812,32 @@ void test_time_index(const DataType& used_for_size) {
     for (size_t i = 0; i < 3; i++) {
       for (size_t j = 0; j < 3; j++) {
         CHECK(T_contracted.get(i + 1, b, j + 1) ==
-              spatial_component_placeholder);
+              spatial_component_placeholder_value);
       }
     }
   }
 }
 
-template <typename DataType>
-void test_contractions(const DataType& used_for_size) {
-  test_contractions_rank2(used_for_size);
-  test_contractions_rank3(used_for_size);
-  test_contractions_rank4(used_for_size);
-  test_spatial_spacetime_index(used_for_size);
-  test_time_index(used_for_size);
+template <typename Generator, typename DataType>
+void test_contractions(const gsl::not_null<Generator*> generator,
+                       const DataType& used_for_size) {
+  test_contractions_rank2(generator, used_for_size);
+  test_contractions_rank3(generator, used_for_size);
+  test_contractions_rank4(generator, used_for_size);
+  test_spatial_spacetime_index(generator, used_for_size);
+  test_time_index(generator, used_for_size);
 }
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Contract",
                   "[DataStructures][Unit]") {
+  MAKE_GENERATOR(generator);
+
   test_tensor_ops_properties();
   test_contraction_summation_consistency();
-  test_contractions(std::numeric_limits<double>::signaling_NaN());
+  test_contractions(make_not_null(&generator),
+                    std::numeric_limits<double>::signaling_NaN());
   test_contractions(
+      make_not_null(&generator),
       DataVector(5, std::numeric_limits<double>::signaling_NaN()));
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_DataTypeSupport.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_DataTypeSupport.cpp
@@ -113,21 +113,22 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.DataTypeSupport",
   // Test which numeric types can and can't appear as terms in
   // `TensorExpression`s
 
-  test_is_supported_number_datatype<true, tmpl::list<double>>();
+  test_is_supported_number_datatype<true,
+                                    tmpl::list<double, std::complex<double>>>();
   test_is_supported_number_datatype<
-      false, tmpl::list<int, float, std::complex<double>, std::complex<int>,
-                        std::complex<float>, DataVector, ComplexDataVector,
-                        ModalVector, ComplexModalVector, ArbitraryType>>();
+      false, tmpl::list<int, float, std::complex<int>, std::complex<float>,
+                        DataVector, ComplexDataVector, ModalVector,
+                        ComplexModalVector, ArbitraryType>>();
 
   // Test which types can and can't appear as a `Tensor`s data type in a
   // `TensorExpression`
 
   test_is_supported_tensor_datatype<
-      true, tmpl::list<double, DataVector, ComplexDataVector>>();
+      true, tmpl::list<double, std::complex<double>, DataVector,
+                       ComplexDataVector>>();
   test_is_supported_tensor_datatype<
-      false, tmpl::list<int, float, std::complex<double>, std::complex<int>,
-                        std::complex<float>, ModalVector, ComplexModalVector,
-                        ArbitraryType>>();
+      false, tmpl::list<int, float, std::complex<int>, std::complex<float>,
+                        ModalVector, ComplexModalVector, ArbitraryType>>();
 
   // Test helper function that upcasts derived `VectorImpl` types to their
   // base `VectorImpl` types
@@ -226,21 +227,31 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.DataTypeSupport",
   // Test whether the first data type is assignable to the second data type
 
   test_is_assignable<double, double>(true);
+  test_is_assignable<double, std::complex<double>>(false);
   test_is_assignable<double, DataVector>(false);
   test_is_assignable<double, ComplexDataVector>(false);
   test_is_assignable<double, ArbitraryType>(false);
 
+  test_is_assignable<std::complex<double>, double>(true);
+  test_is_assignable<std::complex<double>, std::complex<double>>(true);
+  test_is_assignable<std::complex<double>, DataVector>(false);
+  test_is_assignable<std::complex<double>, ComplexDataVector>(false);
+  test_is_assignable<std::complex<double>, ArbitraryType>(false);
+
   test_is_assignable<DataVector, double>(true);
+  test_is_assignable<DataVector, std::complex<double>>(false);
   test_is_assignable<DataVector, DataVector>(true);
   test_is_assignable<DataVector, ComplexDataVector>(false);
   test_is_assignable<DataVector, ArbitraryType>(false);
 
   test_is_assignable<ComplexDataVector, double>(true);
+  test_is_assignable<ComplexDataVector, std::complex<double>>(true);
   test_is_assignable<ComplexDataVector, DataVector>(true);
   test_is_assignable<ComplexDataVector, ComplexDataVector>(true);
   test_is_assignable<ComplexDataVector, ArbitraryType>(false);
 
   test_is_assignable<ArbitraryType, double>(false);
+  test_is_assignable<ArbitraryType, std::complex<double>>(false);
   test_is_assignable<ArbitraryType, DataVector>(false);
   test_is_assignable<ArbitraryType, ComplexDataVector>(false);
   // true because is_assignable does not check if the types are supported types
@@ -250,12 +261,28 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.DataTypeSupport",
   // between two types
 
   test_binop_datatype_support<double, double, double>();
+  test_binop_datatype_support<double, std::complex<double>,
+                              std::complex<double>>();
   test_binop_datatype_support<double, DataVector, DataVector>();
   test_binop_datatype_support<double, ComplexDataVector, ComplexDataVector>();
   test_binop_datatype_support<double, ArbitraryType, NoSuchType>();
   test_binop_datatype_support<double, NoSuchType, NoSuchType>();
 
+  test_binop_datatype_support<std::complex<double>, double,
+                              std::complex<double>>();
+  test_binop_datatype_support<std::complex<double>, std::complex<double>,
+                              std::complex<double>>();
+  test_binop_datatype_support<std::complex<double>, DataVector,
+                              ComplexDataVector>();
+  test_binop_datatype_support<std::complex<double>, ComplexDataVector,
+                              ComplexDataVector>();
+  test_binop_datatype_support<std::complex<double>, ArbitraryType,
+                              NoSuchType>();
+  test_binop_datatype_support<std::complex<double>, NoSuchType, NoSuchType>();
+
   test_binop_datatype_support<DataVector, double, DataVector>();
+  test_binop_datatype_support<DataVector, std::complex<double>,
+                              ComplexDataVector>();
   test_binop_datatype_support<DataVector, DataVector, DataVector>();
   test_binop_datatype_support<DataVector, ComplexDataVector,
                               ComplexDataVector>();
@@ -263,6 +290,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.DataTypeSupport",
   test_binop_datatype_support<DataVector, NoSuchType, NoSuchType>();
 
   test_binop_datatype_support<ComplexDataVector, double, ComplexDataVector>();
+  test_binop_datatype_support<ComplexDataVector, std::complex<double>,
+                              ComplexDataVector>();
   test_binop_datatype_support<ComplexDataVector, DataVector,
                               ComplexDataVector>();
   test_binop_datatype_support<ComplexDataVector, ComplexDataVector,
@@ -271,6 +300,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.DataTypeSupport",
   test_binop_datatype_support<ComplexDataVector, NoSuchType, NoSuchType>();
 
   test_binop_datatype_support<ArbitraryType, double, NoSuchType>();
+  test_binop_datatype_support<ArbitraryType, std::complex<double>,
+                              NoSuchType>();
   test_binop_datatype_support<ArbitraryType, DataVector, NoSuchType>();
   test_binop_datatype_support<ArbitraryType, ComplexDataVector, NoSuchType>();
   // ArbitraryType is result because get_binop_datatype_impl does not check if
@@ -279,6 +310,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.DataTypeSupport",
   test_binop_datatype_support<ArbitraryType, NoSuchType, NoSuchType>();
 
   test_binop_datatype_support<NoSuchType, double, NoSuchType>();
+  test_binop_datatype_support<NoSuchType, std::complex<double>, NoSuchType>();
   test_binop_datatype_support<NoSuchType, DataVector, NoSuchType>();
   test_binop_datatype_support<NoSuchType, ComplexDataVector, NoSuchType>();
   test_binop_datatype_support<NoSuchType, ArbitraryType, NoSuchType>();
@@ -288,17 +320,32 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.DataTypeSupport",
   // the given data types
 
   test_tensor_binop_datatypes_are_supported<double, double>(true);
+  test_tensor_binop_datatypes_are_supported<double, std::complex<double>>(true);
   test_tensor_binop_datatypes_are_supported<double, DataVector>(false);
   test_tensor_binop_datatypes_are_supported<double, ComplexDataVector>(false);
   test_tensor_binop_datatypes_are_supported<double, ArbitraryType>(false);
 
+  test_tensor_binop_datatypes_are_supported<std::complex<double>, double>(true);
+  test_tensor_binop_datatypes_are_supported<std::complex<double>,
+                                            std::complex<double>>(true);
+  test_tensor_binop_datatypes_are_supported<std::complex<double>, DataVector>(
+      false);
+  test_tensor_binop_datatypes_are_supported<std::complex<double>,
+                                            ComplexDataVector>(false);
+  test_tensor_binop_datatypes_are_supported<std::complex<double>,
+                                            ArbitraryType>(false);
+
   test_tensor_binop_datatypes_are_supported<DataVector, double>(false);
+  test_tensor_binop_datatypes_are_supported<DataVector, std::complex<double>>(
+      false);
   test_tensor_binop_datatypes_are_supported<DataVector, DataVector>(true);
   test_tensor_binop_datatypes_are_supported<DataVector, ComplexDataVector>(
       true);
   test_tensor_binop_datatypes_are_supported<DataVector, ArbitraryType>(false);
 
   test_tensor_binop_datatypes_are_supported<ComplexDataVector, double>(false);
+  test_tensor_binop_datatypes_are_supported<ComplexDataVector,
+                                            std::complex<double>>(false);
   test_tensor_binop_datatypes_are_supported<ComplexDataVector, DataVector>(
       true);
   test_tensor_binop_datatypes_are_supported<ComplexDataVector,
@@ -307,6 +354,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.DataTypeSupport",
       false);
 
   test_tensor_binop_datatypes_are_supported<ArbitraryType, double>(false);
+  test_tensor_binop_datatypes_are_supported<ArbitraryType,
+                                            std::complex<double>>(false);
   test_tensor_binop_datatypes_are_supported<ArbitraryType, DataVector>(false);
   test_tensor_binop_datatypes_are_supported<ArbitraryType, ComplexDataVector>(
       false);
@@ -320,23 +369,64 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.DataTypeSupport",
   test_tensorexpression_binop_datatypes_are_supported<
       number_expression<double>, tensor_expression<double>>(true);
   test_tensorexpression_binop_datatypes_are_supported<
+      number_expression<double>, tensor_expression<std::complex<double>>>(true);
+  test_tensorexpression_binop_datatypes_are_supported<
       number_expression<double>, tensor_expression<DataVector>>(true);
   test_tensorexpression_binop_datatypes_are_supported<
       number_expression<double>, tensor_expression<ComplexDataVector>>(true);
 
   test_tensorexpression_binop_datatypes_are_supported<
+      number_expression<std::complex<double>>, tensor_expression<double>>(true);
+  test_tensorexpression_binop_datatypes_are_supported<
+      number_expression<std::complex<double>>,
+      tensor_expression<std::complex<double>>>(true);
+  test_tensorexpression_binop_datatypes_are_supported<
+      number_expression<std::complex<double>>, tensor_expression<DataVector>>(
+      true);
+  test_tensorexpression_binop_datatypes_are_supported<
+      number_expression<std::complex<double>>,
+      tensor_expression<ComplexDataVector>>(true);
+
+  test_tensorexpression_binop_datatypes_are_supported<
       tensor_expression<double>, number_expression<double>>(true);
   test_tensorexpression_binop_datatypes_are_supported<
+      tensor_expression<double>, number_expression<std::complex<double>>>(true);
+  test_tensorexpression_binop_datatypes_are_supported<
       tensor_expression<double>, tensor_expression<double>>(true);
+  test_tensorexpression_binop_datatypes_are_supported<
+      tensor_expression<double>, tensor_expression<std::complex<double>>>(true);
   test_tensorexpression_binop_datatypes_are_supported<
       tensor_expression<double>, tensor_expression<DataVector>>(false);
   test_tensorexpression_binop_datatypes_are_supported<
       tensor_expression<double>, tensor_expression<ComplexDataVector>>(false);
 
   test_tensorexpression_binop_datatypes_are_supported<
+      tensor_expression<std::complex<double>>, number_expression<double>>(true);
+  test_tensorexpression_binop_datatypes_are_supported<
+      tensor_expression<std::complex<double>>,
+      number_expression<std::complex<double>>>(true);
+  test_tensorexpression_binop_datatypes_are_supported<
+      tensor_expression<std::complex<double>>, tensor_expression<double>>(true);
+  test_tensorexpression_binop_datatypes_are_supported<
+      tensor_expression<std::complex<double>>,
+      tensor_expression<std::complex<double>>>(true);
+  test_tensorexpression_binop_datatypes_are_supported<
+      tensor_expression<std::complex<double>>, tensor_expression<DataVector>>(
+      false);
+  test_tensorexpression_binop_datatypes_are_supported<
+      tensor_expression<std::complex<double>>,
+      tensor_expression<ComplexDataVector>>(false);
+
+  test_tensorexpression_binop_datatypes_are_supported<
       tensor_expression<DataVector>, number_expression<double>>(true);
   test_tensorexpression_binop_datatypes_are_supported<
+      tensor_expression<DataVector>, number_expression<std::complex<double>>>(
+      true);
+  test_tensorexpression_binop_datatypes_are_supported<
       tensor_expression<DataVector>, tensor_expression<double>>(false);
+  test_tensorexpression_binop_datatypes_are_supported<
+      tensor_expression<DataVector>, tensor_expression<std::complex<double>>>(
+      false);
   test_tensorexpression_binop_datatypes_are_supported<
       tensor_expression<DataVector>, tensor_expression<DataVector>>(true);
   test_tensorexpression_binop_datatypes_are_supported<
@@ -346,7 +436,13 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.DataTypeSupport",
   test_tensorexpression_binop_datatypes_are_supported<
       tensor_expression<ComplexDataVector>, number_expression<double>>(true);
   test_tensorexpression_binop_datatypes_are_supported<
+      tensor_expression<ComplexDataVector>,
+      number_expression<std::complex<double>>>(true);
+  test_tensorexpression_binop_datatypes_are_supported<
       tensor_expression<ComplexDataVector>, tensor_expression<double>>(false);
+  test_tensorexpression_binop_datatypes_are_supported<
+      tensor_expression<ComplexDataVector>,
+      tensor_expression<std::complex<double>>>(false);
   test_tensorexpression_binop_datatypes_are_supported<
       tensor_expression<ComplexDataVector>, tensor_expression<DataVector>>(
       true);

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_DataTypeSupport.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_DataTypeSupport.cpp
@@ -1,0 +1,228 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+// \file
+// Tests data-type specific properties and configuration within
+// `TensorExpression`s
+
+#include "Framework/TestingFramework.hpp"
+
+#include <complex>
+#include <type_traits>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/ComplexModalVector.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/ModalVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct ArbitraryType {};
+
+template <typename ValueType>
+using number_expression = tenex::NumberAsExpression<ValueType>;
+template <typename ValueType>
+using tensor_expression =
+    tenex::TensorAsExpression<Scalar<ValueType>, tmpl::list<>>;
+
+template <bool Expected, typename DataTypes>
+void test_is_supported_number_datatype() {
+  tmpl::for_each<DataTypes>([](auto datatype_value) {
+    using datatype = tmpl::type_from<decltype(datatype_value)>;
+    // Tested at compile time so other tests can use this
+    static_assert(
+        tenex::detail::is_supported_number_datatype_v<datatype> == Expected,
+        "Test for tenex::detail::test_is_supported_number_datatype failed.");
+  });
+}
+
+template <bool Expected, typename DataTypes>
+void test_is_supported_tensor_datatype() {
+  tmpl::for_each<DataTypes>([](auto datatype_value) {
+    using datatype = tmpl::type_from<decltype(datatype_value)>;
+    // Tested at compile time so other tests can use this
+    static_assert(
+        tenex::detail::is_supported_tensor_datatype_v<datatype> == Expected,
+        "Test for tenex::detail::test_is_supported_tensor_datatype failed.");
+  });
+}
+
+template <typename T, typename Expected>
+void test_upcast_if_derived_vector_type() {
+  // Tested at compile time so other tests can use this
+  static_assert(
+      std::is_same_v<
+          typename tenex::detail::upcast_if_derived_vector_type<T>::type,
+          Expected>,
+      "Test for tenex::detail::upcast_if_derived_vector_type failed.");
+}
+
+template <typename LhsDataType, typename RhsDataType>
+void test_is_assignable(const bool support_expected) {
+  CHECK(tenex::detail::is_assignable_v<LhsDataType, RhsDataType> ==
+        support_expected);
+}
+
+template <typename X1, typename X2, typename ExpectedBinOpDataType>
+void test_binop_datatype_support() {
+  if constexpr (not std::is_same_v<ExpectedBinOpDataType, NoSuchType>) {
+    CHECK(tenex::detail::binop_datatypes_are_supported_v<X1, X2> == true);
+  } else {
+    CHECK(tenex::detail::binop_datatypes_are_supported_v<X1, X2> == false);
+  }
+
+  CHECK(std::is_same_v<
+        typename tenex::detail::get_binop_datatype_impl<
+            typename tenex::detail::upcast_if_derived_vector_type<X1>::type,
+            typename tenex::detail::upcast_if_derived_vector_type<X2>::type>::
+            type,
+        ExpectedBinOpDataType>);
+}
+
+template <typename X1, typename X2>
+void test_tensor_binop_datatypes_are_supported(const bool support_expected) {
+  CHECK(
+      tenex::detail::tensor_binop_datatypes_are_supported_impl<X1, X2>::value ==
+      support_expected);
+}
+
+template <typename T1, typename T2>
+void test_tensorexpression_binop_datatypes_are_supported(
+    const bool support_expected) {
+  CHECK(tenex::detail::tensorexpression_binop_datatypes_are_supported_impl<
+            T1, T2>::value == support_expected);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.DataTypeSupport",
+                  "[DataStructures][Unit]") {
+  // Test which numeric types can and can't appear as terms in
+  // `TensorExpression`s
+
+  test_is_supported_number_datatype<true, tmpl::list<double>>();
+  test_is_supported_number_datatype<
+      false, tmpl::list<int, float, std::complex<double>, std::complex<int>,
+                        std::complex<float>, DataVector, ComplexDataVector,
+                        ModalVector, ComplexModalVector, ArbitraryType>>();
+
+  // Test which types can and can't appear as a `Tensor`s data type in a
+  // `TensorExpression`
+
+  test_is_supported_tensor_datatype<true, tmpl::list<double, DataVector>>();
+  test_is_supported_tensor_datatype<
+      false, tmpl::list<int, float, std::complex<double>, std::complex<int>,
+                        std::complex<float>, ComplexDataVector, ModalVector,
+                        ComplexModalVector, ArbitraryType>>();
+
+  // Test helper function that upcasts derived `VectorImpl` types to their
+  // base `VectorImpl` types
+
+  test_upcast_if_derived_vector_type<double, double>();
+  test_upcast_if_derived_vector_type<int, int>();
+  test_upcast_if_derived_vector_type<float, float>();
+  test_upcast_if_derived_vector_type<std::complex<double>,
+                                     std::complex<double>>();
+  test_upcast_if_derived_vector_type<std::complex<int>, std::complex<int>>();
+  test_upcast_if_derived_vector_type<std::complex<float>,
+                                     std::complex<float>>();
+  test_upcast_if_derived_vector_type<DataVector,
+                                     VectorImpl<double, DataVector>>();
+  test_upcast_if_derived_vector_type<VectorImpl<double, DataVector>,
+                                     VectorImpl<double, DataVector>>();
+  test_upcast_if_derived_vector_type<
+      ComplexDataVector, VectorImpl<std::complex<double>, ComplexDataVector>>();
+  test_upcast_if_derived_vector_type<
+      VectorImpl<std::complex<double>, ComplexDataVector>,
+      VectorImpl<std::complex<double>, ComplexDataVector>>();
+  test_upcast_if_derived_vector_type<ModalVector,
+                                     VectorImpl<double, ModalVector>>();
+  test_upcast_if_derived_vector_type<VectorImpl<double, ModalVector>,
+                                     VectorImpl<double, ModalVector>>();
+  test_upcast_if_derived_vector_type<
+      ComplexModalVector,
+      VectorImpl<std::complex<double>, ComplexModalVector>>();
+  test_upcast_if_derived_vector_type<
+      VectorImpl<std::complex<double>, ComplexModalVector>,
+      VectorImpl<std::complex<double>, ComplexModalVector>>();
+  test_upcast_if_derived_vector_type<ArbitraryType, ArbitraryType>();
+
+  // Test whether the first data type is assignable to the second data type
+
+  test_is_assignable<double, double>(true);
+  test_is_assignable<double, DataVector>(false);
+  test_is_assignable<double, ArbitraryType>(false);
+
+  test_is_assignable<DataVector, double>(true);
+  test_is_assignable<DataVector, DataVector>(true);
+  test_is_assignable<DataVector, ArbitraryType>(false);
+
+  test_is_assignable<ArbitraryType, double>(false);
+  test_is_assignable<ArbitraryType, DataVector>(false);
+  // true because is_assignable does not check if the types are supported types
+  test_is_assignable<ArbitraryType, ArbitraryType>(true);
+
+  // Test the type resulting from performing a binary arithmetic operation
+  // between two types
+
+  test_binop_datatype_support<double, double, double>();
+  test_binop_datatype_support<double, DataVector, DataVector>();
+  test_binop_datatype_support<double, ArbitraryType, NoSuchType>();
+  test_binop_datatype_support<double, NoSuchType, NoSuchType>();
+
+  test_binop_datatype_support<DataVector, double, DataVector>();
+  test_binop_datatype_support<DataVector, DataVector, DataVector>();
+  test_binop_datatype_support<DataVector, ArbitraryType, NoSuchType>();
+  test_binop_datatype_support<DataVector, NoSuchType, NoSuchType>();
+
+  test_binop_datatype_support<ArbitraryType, double, NoSuchType>();
+  test_binop_datatype_support<ArbitraryType, DataVector, NoSuchType>();
+  // ArbitraryType is result because get_binop_datatype_impl does not check if
+  // the types are supported types
+  test_binop_datatype_support<ArbitraryType, ArbitraryType, ArbitraryType>();
+  test_binop_datatype_support<ArbitraryType, NoSuchType, NoSuchType>();
+
+  test_binop_datatype_support<NoSuchType, double, NoSuchType>();
+  test_binop_datatype_support<NoSuchType, DataVector, NoSuchType>();
+  test_binop_datatype_support<NoSuchType, ArbitraryType, NoSuchType>();
+  test_binop_datatype_support<NoSuchType, NoSuchType, NoSuchType>();
+
+  // Test whether binary operations can be performed between two `Tensor`s with
+  // the given data types
+
+  test_tensor_binop_datatypes_are_supported<double, double>(true);
+  test_tensor_binop_datatypes_are_supported<double, DataVector>(false);
+  test_tensor_binop_datatypes_are_supported<double, ArbitraryType>(false);
+
+  test_tensor_binop_datatypes_are_supported<DataVector, double>(false);
+  test_tensor_binop_datatypes_are_supported<DataVector, DataVector>(true);
+  test_tensor_binop_datatypes_are_supported<DataVector, ArbitraryType>(false);
+
+  test_tensor_binop_datatypes_are_supported<ArbitraryType, double>(false);
+  test_tensor_binop_datatypes_are_supported<ArbitraryType, DataVector>(false);
+  // true because tensor_binop_datatypes_are_supported_impl does not check if
+  // the types are supported types
+  test_tensor_binop_datatypes_are_supported<ArbitraryType, ArbitraryType>(true);
+
+  // Test whether binary operations can be performed between two
+  // `TensorExpression`s with the given data types
+
+  test_tensorexpression_binop_datatypes_are_supported<
+      number_expression<double>, tensor_expression<double>>(true);
+  test_tensorexpression_binop_datatypes_are_supported<
+      number_expression<double>, tensor_expression<DataVector>>(true);
+
+  test_tensorexpression_binop_datatypes_are_supported<
+      tensor_expression<double>, number_expression<double>>(true);
+  test_tensorexpression_binop_datatypes_are_supported<
+      tensor_expression<double>, tensor_expression<double>>(true);
+  test_tensorexpression_binop_datatypes_are_supported<
+      tensor_expression<double>, tensor_expression<DataVector>>(false);
+
+  test_tensorexpression_binop_datatypes_are_supported<
+      tensor_expression<DataVector>, number_expression<double>>(true);
+  test_tensorexpression_binop_datatypes_are_supported<
+      tensor_expression<DataVector>, tensor_expression<double>>(false);
+  test_tensorexpression_binop_datatypes_are_supported<
+      tensor_expression<DataVector>, tensor_expression<DataVector>>(true);
+}

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Divide.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Divide.cpp
@@ -6,6 +6,7 @@
 #include <climits>
 #include <cmath>
 #include <cstddef>
+#include <random>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Divide.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Divide.cpp
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <random>
 
+#include "DataStructures/ComplexDataVector.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Framework/TestHelpers.hpp"
@@ -318,4 +319,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Divide",
               std::numeric_limits<double>::signaling_NaN());
   test_divide(make_not_null(&generator),
               DataVector(5, std::numeric_limits<double>::signaling_NaN()));
+  test_divide(
+      make_not_null(&generator),
+      ComplexDataVector(5, std::numeric_limits<double>::signaling_NaN()));
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Divide.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Divide.cpp
@@ -5,6 +5,7 @@
 
 #include <climits>
 #include <cmath>
+#include <complex>
 #include <cstddef>
 #include <random>
 
@@ -317,6 +318,10 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Divide",
   test_tensor_ops_properties();
   test_divide(make_not_null(&generator),
               std::numeric_limits<double>::signaling_NaN());
+  test_divide(
+      make_not_null(&generator),
+      std::complex<double>(std::numeric_limits<double>::signaling_NaN(),
+                           std::numeric_limits<double>::signaling_NaN()));
   test_divide(make_not_null(&generator),
               DataVector(5, std::numeric_limits<double>::signaling_NaN()));
   test_divide(

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateComplex.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateComplex.cpp
@@ -1,0 +1,462 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+// \file
+// Tests evaluation of `TensorExpression`s with complex-valued LHS `Tensor`s
+// and RHS expressions that may contain real-valued terms, complex-valued terms,
+// or both
+//
+// \details
+// The tests in this file are designed to test that these fundamentally work:
+// - Using `evaluate` with complex types on the RHS and/or LHS
+// - Using `TensorExpression` mathematical operations with complex types
+// - Evaluating expressions with both real-valued and complex-valued terms
+
+#include "Framework/TestingFramework.hpp"
+
+#include <climits>
+#include <complex>
+#include <cstddef>
+#include <random>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace {
+template <typename T1, typename T2>
+void check_values_equal(const T1& lhs_value, const T2& rhs_value) {
+  CHECK_ITERABLE_APPROX(lhs_value, rhs_value);
+}
+
+template <>
+void check_values_equal<ComplexDataVector, double>(
+    const ComplexDataVector& lhs_value, const double& rhs_value) {
+  for (size_t i = 0; i < lhs_value.size(); i++) {
+    CHECK(std::imag(lhs_value[i]) == 0.0);
+    CHECK_ITERABLE_APPROX(std::real(lhs_value[i]), rhs_value);
+  }
+}
+
+template <>
+void check_values_equal<ComplexDataVector, DataVector>(
+    const ComplexDataVector& lhs_value, const DataVector& rhs_value) {
+  for (size_t i = 0; i < lhs_value.size(); i++) {
+    CHECK(std::imag(lhs_value[i]) == 0.0);
+    CHECK_ITERABLE_APPROX(std::real(lhs_value[i]), rhs_value[i]);
+  }
+}
+
+// \brief Test assignment of LHS `Tensor` to single RHS term
+//
+// \tparam LhsDataType the data type of LHS `Tensor`
+// \tparam RhsDataType the data type of the RHS term
+template <typename Generator, typename LhsDataType, typename RhsDataType>
+void test_assignment_to_single_term(const gsl::not_null<Generator*> generator,
+                                    const LhsDataType& used_for_size_lhs,
+                                    const RhsDataType& used_for_size_rhs) {
+  std::uniform_real_distribution<> distribution(-1.0, 1.0);
+
+  // if the RHS is a number, also test the assignment of LHS to the number
+  if constexpr (tenex::detail::is_supported_number_datatype_v<RhsDataType>) {
+    const auto R1 = make_with_random_values<RhsDataType>(
+        generator, distribution, used_for_size_rhs);
+    Scalar<LhsDataType> L1{used_for_size_lhs};
+    tenex::evaluate(make_not_null(&L1), R1);
+    check_values_equal(get(L1), R1);
+  }
+
+  // assign Scalar<LhsDataType> to Scalar<RhsDataType>
+  const auto R2 = make_with_random_values<Scalar<RhsDataType>>(
+      generator, distribution, used_for_size_rhs);
+  Scalar<LhsDataType> L2{used_for_size_lhs};
+  tenex::evaluate(make_not_null(&L2), R2());
+  check_values_equal(get(L2), get(R2));
+
+  // assign Tensor<LhsDataType, ...> to Tensor<RhsDataType, ...>
+  const auto R3 = make_with_random_values<tnsr::ij<RhsDataType, 3>>(
+      generator, distribution, used_for_size_rhs);
+  tnsr::ii<LhsDataType, 3> L3{used_for_size_lhs};
+  tenex::evaluate<ti::j, ti::i>(make_not_null(&L3), R3(ti::i, ti::j));
+  for (size_t i = 0; i < 3; i++) {
+    for (size_t j = i; j < 3; j++) {
+      check_values_equal(L3.get(j, i), R3.get(i, j));
+    }
+  }
+}
+
+// \brief Test assignment of LHS `Tensor` to a RHS expression containing
+// mathematical operations
+//
+// \tparam LhsDataType the data type of LHS `Tensor`
+// \tparam RhsDataType the data type of the RHS term
+template <typename Generator, typename LhsDataType, typename RhsDataType>
+void test_evaluate_ops(const gsl::not_null<Generator*> generator,
+                       const LhsDataType& used_for_size_lhs,
+                       const RhsDataType& used_for_size_rhs) {
+  std::uniform_real_distribution<> distribution(0.1, 1.0);
+
+  const auto R =
+      make_with_random_values<tnsr::Ab<RhsDataType, 3, Frame::Inertial>>(
+          generator, distribution, used_for_size_rhs);
+  const auto S =
+      make_with_random_values<tnsr::aB<RhsDataType, 3, Frame::Inertial>>(
+          generator, distribution, used_for_size_rhs);
+  const auto T = make_with_random_values<Scalar<RhsDataType>>(
+      generator, distribution, used_for_size_rhs);
+
+  // test evaluation of unary ops
+  Scalar<LhsDataType> L_contraction{used_for_size_lhs};
+  tenex::evaluate(make_not_null(&L_contraction), R(ti::A, ti::a));
+  RhsDataType expected_L_contraction =
+      make_with_value<RhsDataType>(used_for_size_rhs, 0.0);
+  for (size_t a = 0; a < 4; a++) {
+    expected_L_contraction += R.get(a, a);
+  }
+  check_values_equal(get(L_contraction), expected_L_contraction);
+
+  tnsr::Ab<LhsDataType, 3, Frame::Inertial> L_negation{used_for_size_lhs};
+  tenex::evaluate<ti::B, ti::a>(make_not_null(&L_negation), -S(ti::a, ti::B));
+  for (size_t a = 0; a < 4; a++) {
+    for (size_t b = 0; b < 4; b++) {
+      check_values_equal(L_negation.get(b, a), -S.get(a, b));
+    }
+  }
+
+  Scalar<LhsDataType> L_square_root{used_for_size_lhs};
+  tenex::evaluate(make_not_null(&L_square_root), sqrt(T()));
+  check_values_equal(get(L_square_root), sqrt(get(T)));
+
+  // test evaluation of binary ops
+  tnsr::Ab<LhsDataType, 3, Frame::Inertial> L_addition{used_for_size_lhs};
+  tnsr::Ab<LhsDataType, 3, Frame::Inertial> L_subtraction{used_for_size_lhs};
+  tenex::evaluate<ti::A, ti::b>(make_not_null(&L_addition),
+                                R(ti::A, ti::b) + S(ti::b, ti::A));
+  tenex::evaluate<ti::B, ti::a>(make_not_null(&L_subtraction),
+                                S(ti::a, ti::B) - R(ti::B, ti::a));
+  for (size_t a = 0; a < 4; a++) {
+    for (size_t b = 0; b < 4; b++) {
+      check_values_equal(L_addition.get(a, b), R.get(a, b) + S.get(b, a));
+      check_values_equal(L_subtraction.get(b, a), S.get(a, b) - R.get(b, a));
+    }
+  }
+
+  tnsr::aB<LhsDataType, 3, Frame::Inertial> L_product{used_for_size_lhs};
+  tenex::evaluate<ti::a, ti::B>(make_not_null(&L_product),
+                                R(ti::C, ti::a) * S(ti::c, ti::B));
+  for (size_t a = 0; a < 4; a++) {
+    for (size_t b = 0; b < 4; b++) {
+      RhsDataType expected_sum =
+          make_with_value<RhsDataType>(used_for_size_rhs, 0.0);
+      for (size_t c = 0; c < 4; c++) {
+        expected_sum += R.get(c, a) * S.get(c, b);
+      }
+      check_values_equal(L_product.get(a, b), expected_sum);
+    }
+  }
+
+  tnsr::aB<LhsDataType, 3, Frame::Inertial> L_division{used_for_size_lhs};
+  tenex::evaluate<ti::a, ti::B>(make_not_null(&L_division),
+                                S(ti::a, ti::B) / T());
+  for (size_t a = 0; a < 4; a++) {
+    for (size_t b = 0; b < 4; b++) {
+      check_values_equal(L_division.get(a, b), S.get(a, b) / get(T));
+    }
+  }
+}
+
+// \brief Test evaluation of RHS binary operations between real-valued and
+// complex-valued terms
+//
+// \details
+// Tests when (1) the terms are both `Tensor`s and (2) when one term is a
+// `Tensor` and the other is a number
+//
+// \tparam ComplexDataType the data type of the complex-valued operand
+// \tparam RhsDataType the data type of the real-valued operand
+template <typename Generator, typename ComplexDataType, typename RealDataType>
+void test_bin_ops_with_real_and_complex(
+    const gsl::not_null<Generator*> generator,
+    const ComplexDataType& used_for_size_complex,
+    const RealDataType& used_for_size_real,
+    const double used_for_random_real_number) {
+  std::uniform_real_distribution<> distribution(0.1, 1.0);
+  constexpr size_t Dim = 2;
+
+  // Operands for test expressions
+
+  const auto real_Ij =
+      make_with_random_values<tnsr::Ij<RealDataType, Dim, Frame::Grid>>(
+          generator, distribution, used_for_size_real);
+  const auto complex_Ij =
+      make_with_random_values<tnsr::Ij<ComplexDataType, Dim, Frame::Grid>>(
+          generator, distribution, used_for_size_complex);
+  const auto real_iJ =
+      make_with_random_values<tnsr::iJ<RealDataType, Dim, Frame::Grid>>(
+          generator, distribution, used_for_size_real);
+  const auto complex_iJ =
+      make_with_random_values<tnsr::iJ<ComplexDataType, Dim, Frame::Grid>>(
+          generator, distribution, used_for_size_complex);
+  const auto real_scalar = make_with_random_values<Scalar<RealDataType>>(
+      generator, distribution, used_for_size_real);
+  const auto complex_scalar = make_with_random_values<Scalar<ComplexDataType>>(
+      generator, distribution, used_for_size_complex);
+  const auto real_number = make_with_random_values<double>(
+      generator, distribution, used_for_random_real_number);
+
+  // Tested expressions
+
+  // addition
+  const Scalar<ComplexDataType> complex_tensor_plus_real_number =
+      tenex::evaluate(complex_scalar() + real_number);
+  const Scalar<ComplexDataType> real_number_plus_complex_tensor =
+      tenex::evaluate(real_number + complex_scalar());
+  const tnsr::iJ<ComplexDataType, Dim, Frame::Grid>
+      complex_tensor_plus_real_tensor = tenex::evaluate<ti::i, ti::J>(
+          complex_iJ(ti::i, ti::J) + real_iJ(ti::i, ti::J));
+  const tnsr::iJ<ComplexDataType, Dim, Frame::Grid>
+      real_tensor_plus_complex_tensor = tenex::evaluate<ti::i, ti::J>(
+          real_Ij(ti::J, ti::i) + complex_Ij(ti::J, ti::i));
+
+  // subtraction
+  const Scalar<ComplexDataType> complex_tensor_minus_real_number =
+      tenex::evaluate(complex_scalar() - real_number);
+  const Scalar<ComplexDataType> real_number_minus_complex_tensor =
+      tenex::evaluate(real_number - complex_scalar());
+  const tnsr::iJ<ComplexDataType, Dim, Frame::Grid>
+      complex_tensor_minus_real_tensor = tenex::evaluate<ti::i, ti::J>(
+          complex_iJ(ti::i, ti::J) - real_iJ(ti::i, ti::J));
+  const tnsr::iJ<ComplexDataType, Dim, Frame::Grid>
+      real_tensor_minus_complex_tensor = tenex::evaluate<ti::i, ti::J>(
+          real_Ij(ti::J, ti::i) - complex_Ij(ti::J, ti::i));
+
+  // multiplication
+  const tnsr::iJ<ComplexDataType, Dim, Frame::Grid>
+      complex_tensor_times_real_number =
+          tenex::evaluate<ti::i, ti::J>(complex_iJ(ti::i, ti::J) * real_number);
+  const tnsr::iJ<ComplexDataType, Dim, Frame::Grid>
+      real_number_times_complex_tensor =
+          tenex::evaluate<ti::i, ti::J>(real_number * complex_Ij(ti::J, ti::i));
+  const tnsr::iJ<ComplexDataType, Dim, Frame::Grid>
+      complex_tensor_times_real_tensor = tenex::evaluate<ti::i, ti::J>(
+          complex_iJ(ti::i, ti::K) * real_iJ(ti::k, ti::J));
+  const tnsr::iJ<ComplexDataType, Dim, Frame::Grid>
+      real_tensor_times_complex_tensor = tenex::evaluate<ti::i, ti::J>(
+          real_Ij(ti::K, ti::i) * complex_Ij(ti::J, ti::k));
+
+  // division
+  const tnsr::iJ<ComplexDataType, Dim, Frame::Grid>
+      complex_tensor_over_real_number =
+          tenex::evaluate<ti::i, ti::J>(complex_iJ(ti::i, ti::J) / real_number);
+  const Scalar<ComplexDataType> real_number_over_complex_tensor =
+      tenex::evaluate(real_number / complex_scalar());
+  const tnsr::iJ<ComplexDataType, Dim, Frame::Grid>
+      complex_tensor_over_real_tensor = tenex::evaluate<ti::i, ti::J>(
+          complex_iJ(ti::i, ti::J) / real_scalar());
+  const tnsr::iJ<ComplexDataType, Dim, Frame::Grid>
+      real_tensor_over_complex_tensor = tenex::evaluate<ti::i, ti::J>(
+          real_Ij(ti::J, ti::i) / complex_scalar());
+
+  // Check rank == 0 results
+
+  // addition
+  CHECK(get(complex_tensor_plus_real_number) ==
+        get(complex_scalar) + real_number);
+  CHECK(get(real_number_plus_complex_tensor) ==
+        real_number + get(complex_scalar));
+
+  // subtraction
+  CHECK(get(complex_tensor_minus_real_number) ==
+        get(complex_scalar) - real_number);
+  CHECK(get(real_number_minus_complex_tensor) ==
+        real_number - get(complex_scalar));
+
+  // division
+  CHECK(get(real_number_over_complex_tensor) ==
+        real_number / get(complex_scalar));
+
+  // Check rank > 0 results
+  for (size_t i = 0; i < Dim; i++) {
+    for (size_t j = 0; j < Dim; j++) {
+      ComplexDataType expected_sum_complex_tensor_times_real_tensor =
+          complex_iJ.get(i, 0) * real_iJ.get(0, j);
+      ComplexDataType expected_sum_real_tensor_times_complex_tensor =
+          real_Ij.get(0, i) * complex_Ij.get(j, 0);
+      for (size_t k = 1; k < Dim; k++) {
+        expected_sum_complex_tensor_times_real_tensor +=
+            complex_iJ.get(i, k) * real_iJ.get(k, j);
+        expected_sum_real_tensor_times_complex_tensor +=
+            real_Ij.get(k, i) * complex_Ij.get(j, k);
+      }
+
+      // addition
+      CHECK(complex_tensor_plus_real_tensor.get(i, j) ==
+            complex_iJ.get(i, j) + real_iJ.get(i, j));
+      CHECK(real_tensor_plus_complex_tensor.get(i, j) ==
+            real_Ij.get(j, i) + complex_Ij.get(j, i));
+
+      // subtraction
+      CHECK(complex_tensor_minus_real_tensor.get(i, j) ==
+            complex_iJ.get(i, j) - real_iJ.get(i, j));
+      CHECK(real_tensor_minus_complex_tensor.get(i, j) ==
+            real_Ij.get(j, i) - complex_Ij.get(j, i));
+
+      // multiplication
+      CHECK(complex_tensor_times_real_number.get(i, j) ==
+            complex_iJ.get(i, j) * real_number);
+      CHECK(real_number_times_complex_tensor.get(i, j) ==
+            real_number * complex_Ij.get(j, i));
+      CHECK_ITERABLE_APPROX(complex_tensor_times_real_tensor.get(i, j),
+                            expected_sum_complex_tensor_times_real_tensor);
+      CHECK_ITERABLE_APPROX(real_tensor_times_complex_tensor.get(i, j),
+                            expected_sum_real_tensor_times_complex_tensor);
+
+      // division
+      CHECK_ITERABLE_APPROX(complex_tensor_over_real_number.get(i, j),
+                            complex_iJ.get(i, j) / real_number);
+      CHECK(complex_tensor_over_real_tensor.get(i, j) ==
+            complex_iJ.get(i, j) / get(real_scalar));
+      CHECK(real_tensor_over_complex_tensor.get(i, j) ==
+            real_Ij.get(j, i) / get(complex_scalar));
+    }
+  }
+}
+
+// \brief Test evaluation of large RHS `TensorExpression`s
+//
+// \details
+// Test cases include large expressions with:
+// - only real-valued `Tensor`s
+// - only complex-valued `Tensor`s
+// - real-valued and complex-valued `Tensor`s
+// - real-valued `Tensor`s and a real-valued number
+// - complex-valued `Tensor`s and a real-valued number
+//
+// \tparam ComplexDataType the data type of the complex-valued operand
+// \tparam RhsDataType the data type of the real-valued operand
+template <typename Generator, typename ComplexDataType, typename RealDataType>
+void test_evaluate_large_expressions(
+    const gsl::not_null<Generator*> generator,
+    const ComplexDataType& used_for_size_complex,
+    const RealDataType& used_for_size_real,
+    const double used_for_random_real_number) {
+  std::uniform_real_distribution<> distribution(0.1, 1.0);
+
+  // Operands for test expressions
+
+  const auto real_scalar = make_with_random_values<Scalar<RealDataType>>(
+      generator, distribution, used_for_size_real);
+  const auto complex_scalar = make_with_random_values<Scalar<ComplexDataType>>(
+      generator, distribution, used_for_size_complex);
+  const auto real_number = make_with_random_values<double>(
+      generator, distribution, used_for_random_real_number);
+
+  // Tested expressions
+
+  const auto real_scalar_times_8 =
+      real_scalar() + real_scalar() + real_scalar() + real_scalar() +
+      real_scalar() + real_scalar() + real_scalar() + real_scalar();
+  const auto real_scalar_times_64 = real_scalar_times_8 + real_scalar_times_8 +
+                                    real_scalar_times_8 + real_scalar_times_8 +
+                                    real_scalar_times_8 + real_scalar_times_8 +
+                                    real_scalar_times_8 + real_scalar_times_8;
+
+  const auto complex_scalar_times_8 = complex_scalar() + complex_scalar() +
+                                      complex_scalar() + complex_scalar() +
+                                      complex_scalar() + complex_scalar() +
+                                      complex_scalar() + complex_scalar();
+  const auto complex_scalar_times_64 =
+      complex_scalar_times_8 + complex_scalar_times_8 + complex_scalar_times_8 +
+      complex_scalar_times_8 + complex_scalar_times_8 + complex_scalar_times_8 +
+      complex_scalar_times_8 + complex_scalar_times_8;
+
+  // large expressions of `Tensor`s
+  const Scalar<RealDataType> real_tensor_times_real_tensor_result =
+      tenex::evaluate(real_scalar_times_64);
+  const Scalar<ComplexDataType> complex_tensor_times_complex_tensor_result =
+      tenex::evaluate(complex_scalar_times_64);
+  const Scalar<ComplexDataType> complex_tensor_times_real_tensor_result =
+      tenex::evaluate(complex_scalar_times_64 * real_scalar_times_64);
+  const Scalar<ComplexDataType> real_tensor_times_complex_tensor_result =
+      tenex::evaluate(real_scalar_times_64 * complex_scalar_times_64);
+
+  // large expressions of `Tensor`s and a number
+  const Scalar<RealDataType> real_tensor_times_real_number_result =
+      tenex::evaluate(real_scalar_times_64 * real_number);
+  const Scalar<RealDataType> real_number_times_real_tensor_result =
+      tenex::evaluate(real_number * real_scalar_times_64);
+  const Scalar<ComplexDataType> complex_tensor_times_real_number_result =
+      tenex::evaluate(complex_scalar_times_64 * real_number);
+  const Scalar<ComplexDataType> real_number_times_complex_tensor_result =
+      tenex::evaluate(real_number * complex_scalar_times_64);
+
+  // check expressions with only `Tensor`s
+  CHECK_ITERABLE_APPROX(get(real_tensor_times_real_tensor_result),
+                        64.0 * get(real_scalar));
+  CHECK_ITERABLE_APPROX(get(complex_tensor_times_complex_tensor_result),
+                        64.0 * get(complex_scalar));
+  CHECK_ITERABLE_APPROX(get(complex_tensor_times_real_tensor_result),
+                        64.0 * 64.0 * (get(complex_scalar) * get(real_scalar)));
+  CHECK_ITERABLE_APPROX(get(real_tensor_times_complex_tensor_result),
+                        64.0 * 64.0 * (get(complex_scalar) * get(real_scalar)));
+
+  // check expressions with `Tensor`s and numbers
+  CHECK_ITERABLE_APPROX(get(real_tensor_times_real_number_result),
+                        64.0 * get(real_scalar) * real_number);
+  CHECK_ITERABLE_APPROX(get(real_number_times_real_tensor_result),
+                        64.0 * get(real_scalar) * real_number);
+  CHECK_ITERABLE_APPROX(get(complex_tensor_times_real_number_result),
+                        64.0 * get(complex_scalar) * real_number);
+  CHECK_ITERABLE_APPROX(get(real_number_times_complex_tensor_result),
+                        64.0 * get(complex_scalar) * real_number);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateComplex",
+                  "[Unit][DataStructures]") {
+  MAKE_GENERATOR(generator);
+
+  const size_t vector_size = 2;
+
+  const double used_for_size_real_double =
+      std::numeric_limits<double>::signaling_NaN();
+  const DataVector used_for_size_real_datavector =
+      DataVector(vector_size, std::numeric_limits<double>::signaling_NaN());
+  const ComplexDataVector used_for_size_complex_datavector = ComplexDataVector(
+      vector_size, std::numeric_limits<double>::signaling_NaN());
+
+  // Test assignment of complex-valued LHS `Tensor` to single RHS term
+  test_assignment_to_single_term(make_not_null(&generator),
+                                 used_for_size_complex_datavector,
+                                 used_for_size_real_double);
+  test_assignment_to_single_term(make_not_null(&generator),
+                                 used_for_size_complex_datavector,
+                                 used_for_size_real_datavector);
+  test_assignment_to_single_term(make_not_null(&generator),
+                                 used_for_size_complex_datavector,
+                                 used_for_size_complex_datavector);
+
+  // Test assignment of a complex-valued LHS `Tensor` to a RHS expression
+  // containing mathematical operations
+  test_evaluate_ops(make_not_null(&generator), used_for_size_complex_datavector,
+                    used_for_size_real_double);
+  test_evaluate_ops(make_not_null(&generator), used_for_size_complex_datavector,
+                    used_for_size_real_datavector);
+  test_evaluate_ops(make_not_null(&generator), used_for_size_complex_datavector,
+                    used_for_size_complex_datavector);
+
+  // Test evaluation of RHS binary operations between real-valued and
+  // complex-valued terms
+  test_bin_ops_with_real_and_complex(
+      make_not_null(&generator), used_for_size_complex_datavector,
+      used_for_size_real_datavector, used_for_size_real_double);
+
+  // Test evaluation of large RHS `TensorExpression`s
+  test_evaluate_large_expressions(
+      make_not_null(&generator), used_for_size_complex_datavector,
+      used_for_size_real_datavector, used_for_size_real_double);
+}

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateSpatialSpacetimeIndex.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateSpatialSpacetimeIndex.cpp
@@ -3,6 +3,7 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <complex>
 #include <cstddef>
 #include <random>
 
@@ -245,6 +246,9 @@ SPECTRE_TEST_CASE(
     "[DataStructures][Unit]") {
   test_evaluate_spatial_spacetime_index(
       std::numeric_limits<double>::signaling_NaN());
+  test_evaluate_spatial_spacetime_index(
+      std::complex<double>(std::numeric_limits<double>::signaling_NaN(),
+                           std::numeric_limits<double>::signaling_NaN()));
   test_evaluate_spatial_spacetime_index(
       DataVector(5, std::numeric_limits<double>::signaling_NaN()));
   test_evaluate_spatial_spacetime_index(

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateSpatialSpacetimeIndex.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateSpatialSpacetimeIndex.cpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <random>
 
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Symmetry.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateSpatialSpacetimeIndex.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateSpatialSpacetimeIndex.cpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <random>
 
+#include "DataStructures/ComplexDataVector.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Symmetry.hpp"
@@ -246,4 +247,6 @@ SPECTRE_TEST_CASE(
       std::numeric_limits<double>::signaling_NaN());
   test_evaluate_spatial_spacetime_index(
       DataVector(5, std::numeric_limits<double>::signaling_NaN()));
+  test_evaluate_spatial_spacetime_index(
+      ComplexDataVector(5, std::numeric_limits<double>::signaling_NaN()));
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateTimeIndex.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateTimeIndex.cpp
@@ -3,6 +3,7 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <complex>
 #include <cstddef>
 #include <random>
 
@@ -150,6 +151,9 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateTimeIndex",
                   "[DataStructures][Unit]") {
   test_evaluate_spatial_spacetime_index(
       std::numeric_limits<double>::signaling_NaN());
+  test_evaluate_spatial_spacetime_index(
+      std::complex<double>(std::numeric_limits<double>::signaling_NaN(),
+                           std::numeric_limits<double>::signaling_NaN()));
   test_evaluate_spatial_spacetime_index(
       DataVector(5, std::numeric_limits<double>::signaling_NaN()));
   test_evaluate_spatial_spacetime_index(

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateTimeIndex.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateTimeIndex.cpp
@@ -6,16 +6,16 @@
 #include <cstddef>
 #include <random>
 
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Symmetry.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/ComponentPlaceholder.hpp"
 #include "Utilities/Gsl.hpp"
 
 namespace {
-const double spatial_component_placeholder = std::numeric_limits<double>::max();
-
 // \brief Test evaluation of tensors where concrete time indices are used for
 // RHS spacetime indices
 //
@@ -71,13 +71,15 @@ void test_lhs(const gsl::not_null<Generator*> generator,
       Tensor<DataType, Symmetry<2, 1>,
              index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
                         SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>>(
-      used_for_size, spatial_component_placeholder);
+      used_for_size,
+      TestHelpers::tenex::component_placeholder_value<DataType>::value);
   tenex::evaluate<ti::a, ti::t>(make_not_null(&Lat_from_R_a), R(ti::a));
 
   for (size_t a = 0; a < dim + 1; a++) {
     CHECK(Lat_from_R_a.get(a, 0) == R.get(a));
     for (size_t i = 0; i < dim; i++) {
-      CHECK(Lat_from_R_a.get(a, i + 1) == spatial_component_placeholder);
+      CHECK(Lat_from_R_a.get(a, i + 1) ==
+            TestHelpers::tenex::component_placeholder_value<DataType>::value);
     }
   }
 }
@@ -113,7 +115,8 @@ void test_rhs_and_lhs(const gsl::not_null<Generator*> generator,
                         SpacetimeIndex<dim, UpLo::Up, Frame::Grid>,
                         SpacetimeIndex<dim, UpLo::Lo, Frame::Grid>,
                         SpacetimeIndex<dim, UpLo::Lo, Frame::Grid>>>>(
-      used_for_size, spatial_component_placeholder);
+      used_for_size,
+      TestHelpers::tenex::component_placeholder_value<DataType>::value);
   tenex::evaluate<ti::a, ti::T, ti::t, ti::b>(make_not_null(&LaTtb_from_R_tba),
                                               R(ti::t, ti::b, ti::a));
 
@@ -123,8 +126,9 @@ void test_rhs_and_lhs(const gsl::not_null<Generator*> generator,
 
       for (size_t i = 0; i < 3; i++) {
         for (size_t j = 0; j < 3; j++) {
-          CHECK(LaTtb_from_R_tba.get(a, i + 1, j + 1, b) ==
-                spatial_component_placeholder);
+          CHECK(
+              LaTtb_from_R_tba.get(a, i + 1, j + 1, b) ==
+              TestHelpers::tenex::component_placeholder_value<DataType>::value);
         }
       }
     }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateTimeIndex.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateTimeIndex.cpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <random>
 
+#include "DataStructures/ComplexDataVector.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Symmetry.hpp"
@@ -151,4 +152,6 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateTimeIndex",
       std::numeric_limits<double>::signaling_NaN());
   test_evaluate_spatial_spacetime_index(
       DataVector(5, std::numeric_limits<double>::signaling_NaN()));
+  test_evaluate_spatial_spacetime_index(
+      ComplexDataVector(5, std::numeric_limits<double>::signaling_NaN()));
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_MixedOperations.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_MixedOperations.cpp
@@ -8,6 +8,7 @@
 #include <random>
 #include <type_traits>
 
+#include "DataStructures/ComplexDataVector.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tags/TempTensor.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -964,4 +965,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.MixedOperations",
   test_mixed_operations(
       make_not_null(&generator),
       DataVector(5, std::numeric_limits<double>::signaling_NaN()));
+  test_mixed_operations(
+      make_not_null(&generator),
+      ComplexDataVector(5, std::numeric_limits<double>::signaling_NaN()));
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_MixedOperations.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_MixedOperations.cpp
@@ -5,14 +5,14 @@
 
 #include <climits>
 #include <cstddef>
-#include <iterator>
-#include <numeric>
+#include <random>
 #include <type_traits>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tags/TempTensor.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "DataStructures/VectorImpl.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Utilities/Gsl.hpp"
@@ -196,18 +196,18 @@ result_tensor_type<DataType, Dim> compute_expected_large_equation(
 
       for (size_t delta = 0; delta < Dim + 1; ++delta) {
         expected_result.get(mu, nu) +=
-            2 * christoffel_second_kind.get(delta, mu, nu) *
+            2.0 * christoffel_second_kind.get(delta, mu, nu) *
                 gauge_function.get(delta) -
-            2 * pi.get(mu, delta) * pi_2_up.get(nu, delta);
+            2.0 * pi.get(mu, delta) * pi_2_up.get(nu, delta);
 
         for (size_t n = 0; n < Dim; ++n) {
           expected_result.get(mu, nu) +=
-              2 * phi_1_up.get(n, mu, delta) * phi_3_up.get(n, nu, delta);
+              2.0 * phi_1_up.get(n, mu, delta) * phi_3_up.get(n, nu, delta);
         }
 
         for (size_t alpha = 0; alpha < Dim + 1; ++alpha) {
           expected_result.get(mu, nu) -=
-              2. * christoffel_first_kind_3_up.get(mu, alpha, delta) *
+              2.0 * christoffel_first_kind_3_up.get(mu, alpha, delta) *
               christoffel_first_kind_3_up.get(nu, delta, alpha);
         }
       }
@@ -283,7 +283,7 @@ void test_mixed_arithmetic_ops(const gsl::not_null<Generator*> generator,
   }
 
   // Test with TempTensor for LHS tensor
-  if constexpr (not std::is_same_v<DataType, double>) {
+  if constexpr (is_derived_of_vector_impl_v<DataType>) {
     Variables<tmpl::list<::Tags::TempTensor<1, result_tensor_type>>>
         actual_result_tensor_temp_var{used_for_size.size()};
     result_tensor_type& actual_result_tensor_temp =
@@ -346,7 +346,7 @@ void test_rhs_spacetime_index_subsets(const gsl::not_null<Generator*> generator,
                         expected_result_tensor.get());
 
   // Test with TempTensor for LHS tensor
-  if constexpr (not std::is_same_v<DataType, double>) {
+  if constexpr (is_derived_of_vector_impl_v<DataType>) {
     Variables<tmpl::list<::Tags::TempTensor<1, Tensor<DataType>>>>
         actual_result_tensor_temp_var{used_for_size.size()};
     Scalar<DataType>& actual_result_tensor_temp =
@@ -413,7 +413,7 @@ void test_lhs_spacetime_index_subsets(const gsl::not_null<Generator*> generator,
   }
 
   // Test with TempTensor for LHS tensor
-  if constexpr (not std::is_same_v<DataType, double>) {
+  if constexpr (is_derived_of_vector_impl_v<DataType>) {
     Variables<tmpl::list<::Tags::TempTensor<1, result_tensor_type>>>
         actual_result_tensor_temp_var{used_for_size.size()};
     result_tensor_type& actual_result_tensor_temp =
@@ -677,10 +677,12 @@ void test_large_equation(const gsl::not_null<Generator*> generator,
           shift(ti::J) * d_pi(ti::j, ti::a, ti::b));
   // [use_update]
 
-  CHECK_ITERABLE_APPROX(actual_result_tensor_filled, expected_result_tensor);
+  Approx approx = Approx::custom().epsilon(1e-12).scale(1.0);
+  CHECK_ITERABLE_CUSTOM_APPROX(actual_result_tensor_filled,
+                               expected_result_tensor, approx);
 
   // Test with TempTensor for LHS tensor
-  if constexpr (not std::is_same_v<DataType, double>) {
+  if constexpr (is_derived_of_vector_impl_v<DataType>) {
     Variables<tmpl::list<
         ::Tags::TempTensor<0, result_tensor_type>,
         ::Tags::TempTensor<1, spacetime_deriv_gauge_function_type>,
@@ -850,7 +852,8 @@ void test_large_equation(const gsl::not_null<Generator*> generator,
                 shift_dot_three_index_constraint_temp(ti::a, ti::b) +
             shift_temp(ti::J) * d_pi_temp(ti::j, ti::a, ti::b));
 
-    CHECK_ITERABLE_APPROX(actual_result_tensor_temp, expected_result_tensor);
+    CHECK_ITERABLE_CUSTOM_APPROX(actual_result_tensor_temp,
+                                 expected_result_tensor, approx);
   }
 }
 
@@ -896,7 +899,7 @@ void test_assign_double(const DataType& used_for_size) {
   }
 
   // Test with TempTensor for LHS tensor
-  if constexpr (not std::is_same_v<DataType, double>) {
+  if constexpr (is_derived_of_vector_impl_v<DataType>) {
     Variables<tmpl::list<
         ::Tags::TempTensor<1, tnsr::iab<DataType, 3, Frame::Inertial>>>>
         L_temp_var{used_for_size.size()};

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_MixedOperations.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_MixedOperations.cpp
@@ -4,6 +4,7 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <climits>
+#include <complex>
 #include <cstddef>
 #include <random>
 #include <type_traits>
@@ -962,6 +963,10 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.MixedOperations",
 
   test_mixed_operations(make_not_null(&generator),
                         std::numeric_limits<double>::signaling_NaN());
+  test_mixed_operations(
+      make_not_null(&generator),
+      std::complex<double>(std::numeric_limits<double>::signaling_NaN(),
+                           std::numeric_limits<double>::signaling_NaN()));
   test_mixed_operations(
       make_not_null(&generator),
       DataVector(5, std::numeric_limits<double>::signaling_NaN()));

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Negate.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Negate.cpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <random>
 
+#include "DataStructures/ComplexDataVector.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Framework/TestHelpers.hpp"
@@ -87,4 +88,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Negate",
               std::numeric_limits<double>::signaling_NaN());
   test_negate(make_not_null(&generator),
               DataVector(5, std::numeric_limits<double>::signaling_NaN()));
+  test_negate(
+      make_not_null(&generator),
+      ComplexDataVector(5, std::numeric_limits<double>::signaling_NaN()));
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Negate.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Negate.cpp
@@ -5,6 +5,7 @@
 
 #include <climits>
 #include <cstddef>
+#include <random>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Negate.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Negate.cpp
@@ -4,6 +4,7 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <climits>
+#include <complex>
 #include <cstddef>
 #include <random>
 
@@ -86,6 +87,10 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Negate",
   test_tensor_ops_properties();
   test_negate(make_not_null(&generator),
               std::numeric_limits<double>::signaling_NaN());
+  test_negate(
+      make_not_null(&generator),
+      std::complex<double>(std::numeric_limits<double>::signaling_NaN(),
+                           std::numeric_limits<double>::signaling_NaN()));
   test_negate(make_not_null(&generator),
               DataVector(5, std::numeric_limits<double>::signaling_NaN()));
   test_negate(

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Product.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Product.cpp
@@ -5,38 +5,23 @@
 
 #include <climits>
 #include <cstddef>
-#include <iterator>
-#include <numeric>
+#include <random>
 #include <type_traits>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Symmetry.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/ComponentPlaceholder.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace {
-template <typename... Ts>
-void assign_unique_values_to_tensor(
-    gsl::not_null<Tensor<double, Ts...>*> tensor) {
-  std::iota(tensor->begin(), tensor->end(), 0.0);
-}
 
 template <typename... Ts>
-void assign_unique_values_to_tensor(
-    gsl::not_null<Tensor<DataVector, Ts...>*> tensor) {
-  double value = 0.0;
-  for (auto index_it = tensor->begin(); index_it != tensor->end(); index_it++) {
-    for (auto vector_it = index_it->begin(); vector_it != index_it->end();
-         vector_it++) {
-      *vector_it = value;
-      value += 1.0;
-    }
-  }
-}
-
 // Checks that the number of ops in the expressions match what is expected
 void test_tensor_ops_properties() {
   const Scalar<double> G{5.0};
@@ -90,16 +75,19 @@ void test_tensor_ops_properties() {
 //
 // \tparam DataType the type of data being stored in the tensor operand of the
 // products
-template <typename DataType>
-void test_outer_product_double(const DataType& used_for_size) {
+template <typename Generator, typename DataType>
+void test_outer_product_double(const gsl::not_null<Generator*> generator,
+                               const DataType& used_for_size) {
   constexpr size_t dim = 3;
   using tensor_type =
       Tensor<DataType, Symmetry<1, 1>,
              index_list<SpatialIndex<dim, UpLo::Lo, Frame::Inertial>,
                         SpatialIndex<dim, UpLo::Lo, Frame::Inertial>>>;
 
-  tensor_type S(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&S));
+  std::uniform_real_distribution<> distribution(-1.0, 1.0);
+
+  const auto S = make_with_random_values<tensor_type>(generator, distribution,
+                                                      used_for_size);
 
   // \f$L_{ij} = R * S_{ij}\f$
   // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
@@ -137,25 +125,22 @@ void test_outer_product_double(const DataType& used_for_size) {
 // both LHS index orderings are tested.
 //
 // \tparam DataType the type of data being stored in the product operands
-template <typename DataType>
-void test_outer_product_rank_0_operand(const DataType& used_for_size) {
-  Tensor<DataType> R{{{used_for_size}}};
-  if constexpr (std::is_same_v<DataType, double>) {
-    // Replace tensor's value from `used_for_size` to a proper test value
-    R.get() = -3.7;
-  } else {
-    assign_unique_values_to_tensor(make_not_null(&R));
-  }
+template <typename Generator, typename DataType>
+void test_outer_product_rank_0_operand(
+    const gsl::not_null<Generator*> generator, const DataType& used_for_size) {
+  std::uniform_real_distribution<> distribution(-1.0, 1.0);
+
+  const auto R = make_with_random_values<Scalar<DataType>>(
+      generator, distribution, used_for_size);
 
   // \f$L = R * R\f$
   CHECK(tenex::evaluate(R() * R()).get() == R.get() * R.get());
   // \f$L = R * R * R\f$
   CHECK(tenex::evaluate(R() * R() * R()).get() == R.get() * R.get() * R.get());
 
-  Tensor<DataType, Symmetry<1>,
-         index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>>
-      Su(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&Su));
+  const auto Su =
+      make_with_random_values<tnsr::A<DataType, 3, Frame::Inertial>>(
+          generator, distribution, used_for_size);
 
   // \f$L^{a} = R * S^{a}\f$
   // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
@@ -169,35 +154,35 @@ void test_outer_product_rank_0_operand(const DataType& used_for_size) {
     CHECK(LA_from_SA_R.get(a) == Su.get(a) * R.get());
   }
 
-  Tensor<DataType, Symmetry<2, 1>,
-         index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
-                    SpatialIndex<4, UpLo::Lo, Frame::Inertial>>>
-      Tll(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&Tll));
+  const auto Tll = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>,
+                        SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>>(
+      generator, distribution, used_for_size);
 
   // \f$L_{ai} = R * T_{ai}\f$
   const Tensor<DataType, Symmetry<2, 1>,
-               index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
-                          SpatialIndex<4, UpLo::Lo, Frame::Inertial>>>
+               index_list<SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>,
+                          SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>
       Lai_from_R_Tai = tenex::evaluate<ti::a, ti::i>(R() * Tll(ti::a, ti::i));
   // \f$L_{ia} = R * T_{ai}\f$
   const Tensor<DataType, Symmetry<2, 1>,
-               index_list<SpatialIndex<4, UpLo::Lo, Frame::Inertial>,
-                          SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>
+               index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                          SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>>>
       Lia_from_R_Tai = tenex::evaluate<ti::i, ti::a>(R() * Tll(ti::a, ti::i));
   // \f$L_{ai} = T_{ai} * R\f$
   const Tensor<DataType, Symmetry<2, 1>,
-               index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
-                          SpatialIndex<4, UpLo::Lo, Frame::Inertial>>>
+               index_list<SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>,
+                          SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>
       Lai_from_Tai_R = tenex::evaluate<ti::a, ti::i>(Tll(ti::a, ti::i) * R());
   // \f$L_{ia} = T_{ai} * R\f$
   const Tensor<DataType, Symmetry<2, 1>,
-               index_list<SpatialIndex<4, UpLo::Lo, Frame::Inertial>,
-                          SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>
+               index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                          SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>>>
       Lia_from_Tai_R = tenex::evaluate<ti::i, ti::a>(Tll(ti::a, ti::i) * R());
 
-  for (size_t a = 0; a < 4; a++) {
-    for (size_t i = 0; i < 4; i++) {
+  for (size_t a = 0; a < 3; a++) {
+    for (size_t i = 0; i < 3; i++) {
       const DataType expected_R_Tai_product = R.get() * Tll.get(a, i);
       CHECK(Lai_from_R_Tai.get(a, i) == expected_R_Tai_product);
       CHECK(Lia_from_R_Tai.get(i, a) == expected_R_Tai_product);
@@ -223,17 +208,16 @@ void test_outer_product_rank_0_operand(const DataType& used_for_size) {
 // operands.
 //
 // \tparam DataType the type of data being stored in the product operands
-template <typename DataType>
-void test_outer_product_rank_1_operand(const DataType& used_for_size) {
-  Tensor<DataType, Symmetry<1>,
-         index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
-      Rl(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&Rl));
+template <typename Generator, typename DataType>
+void test_outer_product_rank_1_operand(
+    const gsl::not_null<Generator*> generator, const DataType& used_for_size) {
+  std::uniform_real_distribution<> distribution(-1.0, 1.0);
 
-  Tensor<DataType, Symmetry<1>,
-         index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>
-      Su(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&Su));
+  const auto Rl = make_with_random_values<tnsr::i<DataType, 3, Frame::Grid>>(
+      generator, distribution, used_for_size);
+
+  const auto Su = make_with_random_values<tnsr::A<DataType, 3, Frame::Grid>>(
+      generator, distribution, used_for_size);
 
   // \f$L^{a}{}_{i} = R_{i} * S^{a}\f$
   // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
@@ -249,10 +233,8 @@ void test_outer_product_rank_1_operand(const DataType& used_for_size) {
     }
   }
 
-  Tensor<DataType, Symmetry<1>,
-         index_list<SpatialIndex<3, UpLo::Up, Frame::Grid>>>
-      Tu(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&Tu));
+  const auto Tu = make_with_random_values<tnsr::I<DataType, 3, Frame::Grid>>(
+      generator, distribution, used_for_size);
 
   // \f$L^{ja}{}_{i} = R_{i} * S^{a} * T^{j}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
@@ -265,36 +247,36 @@ void test_outer_product_rank_1_operand(const DataType& used_for_size) {
   for (size_t j = 0; j < 3; j++) {
     for (size_t a = 0; a < 4; a++) {
       for (size_t i = 0; i < 3; i++) {
-        CHECK(LJAi_from_Ri_SA_TJ.get(j, a, i) ==
-              Rl.get(i) * Su.get(a) * Tu.get(j));
+        CHECK_ITERABLE_APPROX(LJAi_from_Ri_SA_TJ.get(j, a, i),
+                              Rl.get(i) * Su.get(a) * Tu.get(j));
       }
     }
   }
 
-  Tensor<DataType, Symmetry<2, 1>,
-         index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpatialIndex<4, UpLo::Lo, Frame::Grid>>>
-      Gll(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&Gll));
+  const auto Gll = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<SpacetimeIndex<2, UpLo::Lo, Frame::Grid>,
+                        SpatialIndex<3, UpLo::Lo, Frame::Grid>>>>(
+      generator, distribution, used_for_size);
 
   // \f$L_{k}{}^{c}{}_{d} = S^{c} * G_{dk}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
-               index_list<SpatialIndex<4, UpLo::Lo, Frame::Grid>,
+               index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
-                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
+                          SpacetimeIndex<2, UpLo::Lo, Frame::Grid>>>
       LkCd_from_SC_Gdk =
           tenex::evaluate<ti::k, ti::C, ti::d>(Su(ti::C) * Gll(ti::d, ti::k));
   // \f$L^{c}{}_{dk} = G_{dk} * S^{c}\f$
   const Tensor<DataType, Symmetry<3, 2, 1>,
                index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
-                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                          SpatialIndex<4, UpLo::Lo, Frame::Grid>>>
+                          SpacetimeIndex<2, UpLo::Lo, Frame::Grid>,
+                          SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
       LCdk_from_Gdk_SC =
           tenex::evaluate<ti::C, ti::d, ti::k>(Gll(ti::d, ti::k) * Su(ti::C));
 
-  for (size_t k = 0; k < 4; k++) {
+  for (size_t k = 0; k < 3; k++) {
     for (size_t c = 0; c < 4; c++) {
-      for (size_t d = 0; d < 4; d++) {
+      for (size_t d = 0; d < 3; d++) {
         CHECK(LkCd_from_SC_Gdk.get(k, c, d) == Su.get(c) * Gll.get(d, k));
         CHECK(LCdk_from_Gdk_SC.get(c, d, k) == Gll.get(d, k) * Su.get(c));
       }
@@ -309,18 +291,21 @@ void test_outer_product_rank_1_operand(const DataType& used_for_size) {
 // \f$L_{abc}{}^{i} = R_{ab} * S^{i}{}_{c}\f$
 //
 // \tparam DataType the type of data being stored in the product operands
-template <typename DataType>
-void test_outer_product_rank_2x2_operands(const DataType& used_for_size) {
+template <typename Generator, typename DataType>
+void test_outer_product_rank_2x2_operands(
+    const gsl::not_null<Generator*> generator, const DataType& used_for_size) {
   using R_index = SpacetimeIndex<3, UpLo::Lo, Frame::Grid>;
   using S_first_index = SpatialIndex<4, UpLo::Up, Frame::Grid>;
   using S_second_index = SpacetimeIndex<2, UpLo::Lo, Frame::Grid>;
 
-  Tensor<DataType, Symmetry<1, 1>, index_list<R_index, R_index>> Rll(
-      used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&Rll));
-  Tensor<DataType, Symmetry<2, 1>, index_list<S_first_index, S_second_index>>
-      Sul(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&Sul));
+  std::uniform_real_distribution<> distribution(-1.0, 1.0);
+
+  const auto Rll = make_with_random_values<
+      Tensor<DataType, Symmetry<1, 1>, index_list<R_index, R_index>>>(
+      generator, distribution, used_for_size);
+  const auto Sul = make_with_random_values<Tensor<
+      DataType, Symmetry<2, 1>, index_list<S_first_index, S_second_index>>>(
+      generator, distribution, used_for_size);
 
   // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
   // return type of `evaluate`
@@ -471,26 +456,24 @@ void test_outer_product_rank_2x2_operands(const DataType& used_for_size) {
 // Each case represents an ordering for the operands and the LHS indices.
 //
 // \tparam DataType the type of data being stored in the product operands
-template <typename DataType>
-void test_outer_product_rank_0x1x2_operands(const DataType& used_for_size) {
-  Tensor<DataType> R{{{used_for_size}}};
-  if constexpr (std::is_same_v<DataType, double>) {
-    // Replace tensor's value from `used_for_size` to a proper test value
-    R.get() = 4.5;
-  } else {
-    assign_unique_values_to_tensor(make_not_null(&R));
-  }
+template <typename Generator, typename DataType>
+void test_outer_product_rank_0x1x2_operands(
+    const gsl::not_null<Generator*> generator, const DataType& used_for_size) {
+  std::uniform_real_distribution<> distribution(-1.0, 1.0);
+
+  const auto R = make_with_random_values<Scalar<DataType>>(
+      generator, distribution, used_for_size);
 
   using S_index = SpacetimeIndex<3, UpLo::Up, Frame::Inertial>;
   using T_first_index = SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>;
   using T_second_index = SpatialIndex<4, UpLo::Lo, Frame::Inertial>;
 
-  Tensor<DataType, Symmetry<1>, index_list<S_index>> Su(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&Su));
-
-  Tensor<DataType, Symmetry<2, 1>, index_list<T_first_index, T_second_index>>
-      Tll(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&Tll));
+  const auto Su = make_with_random_values<
+      Tensor<DataType, Symmetry<1>, index_list<S_index>>>(
+      generator, distribution, used_for_size);
+  const auto Tll = make_with_random_values<Tensor<
+      DataType, Symmetry<2, 1>, index_list<T_first_index, T_second_index>>>(
+      generator, distribution, used_for_size);
 
   // \f$R * S^{a} * T_{bi}\f$
   const auto R_SA_Tbi_expr = R() * Su(ti::A) * Tll(ti::b, ti::i);
@@ -661,47 +644,83 @@ void test_outer_product_rank_0x1x2_operands(const DataType& used_for_size) {
       for (size_t i = 0; i < T_second_index::dim; i++) {
         const DataType expected_product = R.get() * Su.get(a) * Tll.get(b, i);
 
-        CHECK(LAbi_from_R_SA_Tbi.get(a, b, i) == expected_product);
-        CHECK(LAib_from_R_SA_Tbi.get(a, i, b) == expected_product);
-        CHECK(LbAi_from_R_SA_Tbi.get(b, a, i) == expected_product);
-        CHECK(LbiA_from_R_SA_Tbi.get(b, i, a) == expected_product);
-        CHECK(LiAb_from_R_SA_Tbi.get(i, a, b) == expected_product);
-        CHECK(LibA_from_R_SA_Tbi.get(i, b, a) == expected_product);
+        CHECK_ITERABLE_APPROX(LAbi_from_R_SA_Tbi.get(a, b, i),
+                              expected_product);
+        CHECK_ITERABLE_APPROX(LAib_from_R_SA_Tbi.get(a, i, b),
+                              expected_product);
+        CHECK_ITERABLE_APPROX(LbAi_from_R_SA_Tbi.get(b, a, i),
+                              expected_product);
+        CHECK_ITERABLE_APPROX(LbiA_from_R_SA_Tbi.get(b, i, a),
+                              expected_product);
+        CHECK_ITERABLE_APPROX(LiAb_from_R_SA_Tbi.get(i, a, b),
+                              expected_product);
+        CHECK_ITERABLE_APPROX(LibA_from_R_SA_Tbi.get(i, b, a),
+                              expected_product);
 
-        CHECK(LAbi_from_R_Tbi_SA.get(a, b, i) == expected_product);
-        CHECK(LAib_from_R_Tbi_SA.get(a, i, b) == expected_product);
-        CHECK(LbAi_from_R_Tbi_SA.get(b, a, i) == expected_product);
-        CHECK(LbiA_from_R_Tbi_SA.get(b, i, a) == expected_product);
-        CHECK(LiAb_from_R_Tbi_SA.get(i, a, b) == expected_product);
-        CHECK(LibA_from_R_Tbi_SA.get(i, b, a) == expected_product);
+        CHECK_ITERABLE_APPROX(LAbi_from_R_Tbi_SA.get(a, b, i),
+                              expected_product);
+        CHECK_ITERABLE_APPROX(LAib_from_R_Tbi_SA.get(a, i, b),
+                              expected_product);
+        CHECK_ITERABLE_APPROX(LbAi_from_R_Tbi_SA.get(b, a, i),
+                              expected_product);
+        CHECK_ITERABLE_APPROX(LbiA_from_R_Tbi_SA.get(b, i, a),
+                              expected_product);
+        CHECK_ITERABLE_APPROX(LiAb_from_R_Tbi_SA.get(i, a, b),
+                              expected_product);
+        CHECK_ITERABLE_APPROX(LibA_from_R_Tbi_SA.get(i, b, a),
+                              expected_product);
 
-        CHECK(LAbi_from_SA_R_Tbi.get(a, b, i) == expected_product);
-        CHECK(LAib_from_SA_R_Tbi.get(a, i, b) == expected_product);
-        CHECK(LbAi_from_SA_R_Tbi.get(b, a, i) == expected_product);
-        CHECK(LbiA_from_SA_R_Tbi.get(b, i, a) == expected_product);
-        CHECK(LiAb_from_SA_R_Tbi.get(i, a, b) == expected_product);
-        CHECK(LibA_from_SA_R_Tbi.get(i, b, a) == expected_product);
+        CHECK_ITERABLE_APPROX(LAbi_from_SA_R_Tbi.get(a, b, i),
+                              expected_product);
+        CHECK_ITERABLE_APPROX(LAib_from_SA_R_Tbi.get(a, i, b),
+                              expected_product);
+        CHECK_ITERABLE_APPROX(LbAi_from_SA_R_Tbi.get(b, a, i),
+                              expected_product);
+        CHECK_ITERABLE_APPROX(LbiA_from_SA_R_Tbi.get(b, i, a),
+                              expected_product);
+        CHECK_ITERABLE_APPROX(LiAb_from_SA_R_Tbi.get(i, a, b),
+                              expected_product);
+        CHECK_ITERABLE_APPROX(LibA_from_SA_R_Tbi.get(i, b, a),
+                              expected_product);
 
-        CHECK(LAbi_from_SA_Tbi_R.get(a, b, i) == expected_product);
-        CHECK(LAib_from_SA_Tbi_R.get(a, i, b) == expected_product);
-        CHECK(LbAi_from_SA_Tbi_R.get(b, a, i) == expected_product);
-        CHECK(LbiA_from_SA_Tbi_R.get(b, i, a) == expected_product);
-        CHECK(LiAb_from_SA_Tbi_R.get(i, a, b) == expected_product);
-        CHECK(LibA_from_SA_Tbi_R.get(i, b, a) == expected_product);
+        CHECK_ITERABLE_APPROX(LAbi_from_SA_Tbi_R.get(a, b, i),
+                              expected_product);
+        CHECK_ITERABLE_APPROX(LAib_from_SA_Tbi_R.get(a, i, b),
+                              expected_product);
+        CHECK_ITERABLE_APPROX(LbAi_from_SA_Tbi_R.get(b, a, i),
+                              expected_product);
+        CHECK_ITERABLE_APPROX(LbiA_from_SA_Tbi_R.get(b, i, a),
+                              expected_product);
+        CHECK_ITERABLE_APPROX(LiAb_from_SA_Tbi_R.get(i, a, b),
+                              expected_product);
+        CHECK_ITERABLE_APPROX(LibA_from_SA_Tbi_R.get(i, b, a),
+                              expected_product);
 
-        CHECK(LAbi_from_Tbi_R_SA.get(a, b, i) == expected_product);
-        CHECK(LAib_from_Tbi_R_SA.get(a, i, b) == expected_product);
-        CHECK(LbAi_from_Tbi_R_SA.get(b, a, i) == expected_product);
-        CHECK(LbiA_from_Tbi_R_SA.get(b, i, a) == expected_product);
-        CHECK(LiAb_from_Tbi_R_SA.get(i, a, b) == expected_product);
-        CHECK(LibA_from_Tbi_R_SA.get(i, b, a) == expected_product);
+        CHECK_ITERABLE_APPROX(LAbi_from_Tbi_R_SA.get(a, b, i),
+                              expected_product);
+        CHECK_ITERABLE_APPROX(LAib_from_Tbi_R_SA.get(a, i, b),
+                              expected_product);
+        CHECK_ITERABLE_APPROX(LbAi_from_Tbi_R_SA.get(b, a, i),
+                              expected_product);
+        CHECK_ITERABLE_APPROX(LbiA_from_Tbi_R_SA.get(b, i, a),
+                              expected_product);
+        CHECK_ITERABLE_APPROX(LiAb_from_Tbi_R_SA.get(i, a, b),
+                              expected_product);
+        CHECK_ITERABLE_APPROX(LibA_from_Tbi_R_SA.get(i, b, a),
+                              expected_product);
 
-        CHECK(LAbi_from_Tbi_SA_R.get(a, b, i) == expected_product);
-        CHECK(LAib_from_Tbi_SA_R.get(a, i, b) == expected_product);
-        CHECK(LbAi_from_Tbi_SA_R.get(b, a, i) == expected_product);
-        CHECK(LbiA_from_Tbi_SA_R.get(b, i, a) == expected_product);
-        CHECK(LiAb_from_Tbi_SA_R.get(i, a, b) == expected_product);
-        CHECK(LibA_from_Tbi_SA_R.get(i, b, a) == expected_product);
+        CHECK_ITERABLE_APPROX(LAbi_from_Tbi_SA_R.get(a, b, i),
+                              expected_product);
+        CHECK_ITERABLE_APPROX(LAib_from_Tbi_SA_R.get(a, i, b),
+                              expected_product);
+        CHECK_ITERABLE_APPROX(LbAi_from_Tbi_SA_R.get(b, a, i),
+                              expected_product);
+        CHECK_ITERABLE_APPROX(LbiA_from_Tbi_SA_R.get(b, i, a),
+                              expected_product);
+        CHECK_ITERABLE_APPROX(LiAb_from_Tbi_SA_R.get(i, a, b),
+                              expected_product);
+        CHECK_ITERABLE_APPROX(LibA_from_Tbi_SA_R.get(i, b, a),
+                              expected_product);
       }
     }
   }
@@ -715,17 +734,15 @@ void test_outer_product_rank_0x1x2_operands(const DataType& used_for_size) {
 // - \f$L = S_{a} * R^{a}\f$
 //
 // \tparam DataType the type of data being stored in the product operands
-template <typename DataType>
-void test_inner_product_rank_1x1_operands(const DataType& used_for_size) {
-  Tensor<DataType, Symmetry<1>,
-         index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>
-      Ru(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&Ru));
+template <typename Generator, typename DataType>
+void test_inner_product_rank_1x1_operands(
+    const gsl::not_null<Generator*> generator, const DataType& used_for_size) {
+  std::uniform_real_distribution<> distribution(-1.0, 1.0);
 
-  Tensor<DataType, Symmetry<1>,
-         index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      Sl(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&Sl));
+  const auto Ru = make_with_random_values<tnsr::A<DataType, 3, Frame::Grid>>(
+      generator, distribution, used_for_size);
+  const auto Sl = make_with_random_values<tnsr::a<DataType, 3, Frame::Grid>>(
+      generator, distribution, used_for_size);
 
   // \f$L = R^{a} * S_{a}\f$
   const Tensor<DataType> L_from_RA_Sa = tenex::evaluate(Ru(ti::A) * Sl(ti::a));
@@ -736,8 +753,8 @@ void test_inner_product_rank_1x1_operands(const DataType& used_for_size) {
   for (size_t a = 0; a < 4; a++) {
     expected_sum += (Ru.get(a) * Sl.get(a));
   }
-  CHECK(L_from_RA_Sa.get() == expected_sum);
-  CHECK(L_from_Sa_RA.get() == expected_sum);
+  CHECK_ITERABLE_APPROX(L_from_RA_Sa.get(), expected_sum);
+  CHECK_ITERABLE_APPROX(L_from_Sa_RA.get(), expected_sum);
 }
 
 // \brief Test the inner product of two rank 2 tensors is correctly evaluated
@@ -750,49 +767,52 @@ void test_inner_product_rank_1x1_operands(const DataType& used_for_size) {
 // case: \f$L = R_{ai} * S^{ai}\f$
 //
 // \tparam DataType the type of data being stored in the product operands
-template <typename DataType>
-void test_inner_product_rank_2x2_operands(const DataType& used_for_size) {
+template <typename Generator, typename DataType>
+void test_inner_product_rank_2x2_operands(
+    const gsl::not_null<Generator*> generator, const DataType& used_for_size) {
   using lower_spacetime_index = SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>;
   using upper_spacetime_index = SpacetimeIndex<3, UpLo::Up, Frame::Inertial>;
   using lower_spatial_index = SpatialIndex<2, UpLo::Lo, Frame::Inertial>;
   using upper_spatial_index = SpatialIndex<2, UpLo::Up, Frame::Inertial>;
 
+  std::uniform_real_distribution<> distribution(-1.0, 1.0);
+
   // All tensor variables starting with 'R' refer to tensors whose first index
   // is a spacetime index and whose second index is a spatial index. Conversely,
   // all tensor variables starting with 'S' refer to tensors whose first index
   // is a spatial index and whose second index is a spacetime index.
-  Tensor<DataType, Symmetry<2, 1>,
-         index_list<lower_spacetime_index, lower_spatial_index>>
-      Rll(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&Rll));
-  Tensor<DataType, Symmetry<2, 1>,
-         index_list<lower_spatial_index, lower_spacetime_index>>
-      Sll(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&Sll));
-  Tensor<DataType, Symmetry<2, 1>,
-         index_list<upper_spacetime_index, upper_spatial_index>>
-      Ruu(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&Ruu));
-  Tensor<DataType, Symmetry<2, 1>,
-         index_list<upper_spatial_index, upper_spacetime_index>>
-      Suu(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&Suu));
-  Tensor<DataType, Symmetry<2, 1>,
-         index_list<lower_spacetime_index, upper_spatial_index>>
-      Rlu(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&Rlu));
-  Tensor<DataType, Symmetry<2, 1>,
-         index_list<lower_spatial_index, upper_spacetime_index>>
-      Slu(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&Slu));
-  Tensor<DataType, Symmetry<2, 1>,
-         index_list<upper_spacetime_index, lower_spatial_index>>
-      Rul(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&Rul));
-  Tensor<DataType, Symmetry<2, 1>,
-         index_list<upper_spatial_index, lower_spacetime_index>>
-      Sul(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&Sul));
+  const auto Rll = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<lower_spacetime_index, lower_spatial_index>>>(
+      generator, distribution, used_for_size);
+  const auto Sll = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<lower_spatial_index, lower_spacetime_index>>>(
+      generator, distribution, used_for_size);
+  const auto Ruu = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<upper_spacetime_index, upper_spatial_index>>>(
+      generator, distribution, used_for_size);
+  const auto Suu = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<upper_spatial_index, upper_spacetime_index>>>(
+      generator, distribution, used_for_size);
+  const auto Rlu = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<lower_spacetime_index, upper_spatial_index>>>(
+      generator, distribution, used_for_size);
+  const auto Slu = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<lower_spatial_index, upper_spacetime_index>>>(
+      generator, distribution, used_for_size);
+  const auto Rul = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<upper_spacetime_index, lower_spatial_index>>>(
+      generator, distribution, used_for_size);
+  const auto Sul = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<upper_spatial_index, lower_spacetime_index>>>(
+      generator, distribution, used_for_size);
 
   // \f$L = Rll_{ai} * Ruu^{ai}\f$
   const Tensor<DataType> L_aiAI_product =
@@ -848,14 +868,14 @@ void test_inner_product_rank_2x2_operands(const DataType& used_for_size) {
       L_AiIa_expected_product += (Rul.get(a, i) * Sul.get(i, a));
     }
   }
-  CHECK(L_aiAI_product.get() == L_aiAI_expected_product);
-  CHECK(L_aiIA_product.get() == L_aiIA_expected_product);
-  CHECK(L_AIai_product.get() == L_AIai_expected_product);
-  CHECK(L_AIia_product.get() == L_AIia_expected_product);
-  CHECK(L_aIAi_product.get() == L_aIAi_expected_product);
-  CHECK(L_aIiA_product.get() == L_aIiA_expected_product);
-  CHECK(L_AiaI_product.get() == L_AiaI_expected_product);
-  CHECK(L_AiIa_product.get() == L_AiIa_expected_product);
+  CHECK_ITERABLE_APPROX(L_aiAI_product.get(), L_aiAI_expected_product);
+  CHECK_ITERABLE_APPROX(L_aiIA_product.get(), L_aiIA_expected_product);
+  CHECK_ITERABLE_APPROX(L_AIai_product.get(), L_AIai_expected_product);
+  CHECK_ITERABLE_APPROX(L_AIia_product.get(), L_AIia_expected_product);
+  CHECK_ITERABLE_APPROX(L_aIAi_product.get(), L_aIAi_expected_product);
+  CHECK_ITERABLE_APPROX(L_aIiA_product.get(), L_aIiA_expected_product);
+  CHECK_ITERABLE_APPROX(L_AiaI_product.get(), L_AiaI_expected_product);
+  CHECK_ITERABLE_APPROX(L_AiIa_product.get(), L_AiIa_expected_product);
 }
 
 // \brief Test the product of two tensors with one pair of indices to contract
@@ -871,16 +891,20 @@ void test_inner_product_rank_2x2_operands(const DataType& used_for_size) {
 // and the ordering of the LHS indices.
 //
 // \tparam DataType the type of data being stored in the product operands
-template <typename DataType>
-void test_two_term_inner_outer_product(const DataType& used_for_size) {
+template <typename Generator, typename DataType>
+void test_two_term_inner_outer_product(
+    const gsl::not_null<Generator*> generator, const DataType& used_for_size) {
   using R_index = SpacetimeIndex<3, UpLo::Lo, Frame::Grid>;
   using T_index = SpacetimeIndex<3, UpLo::Up, Frame::Grid>;
 
-  Tensor<DataType, Symmetry<1, 1>, index_list<R_index, R_index>> Rll(
-      used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&Rll));
-  Tensor<DataType, Symmetry<1>, index_list<T_index>> Tu(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&Tu));
+  std::uniform_real_distribution<> distribution(-1.0, 1.0);
+
+  const auto Rll = make_with_random_values<
+      Tensor<DataType, Symmetry<1, 1>, index_list<R_index, R_index>>>(
+      generator, distribution, used_for_size);
+  const auto Tu = make_with_random_values<
+      Tensor<DataType, Symmetry<1>, index_list<T_index>>>(
+      generator, distribution, used_for_size);
 
   // \f$L_{b} = R_{ab} * T^{a}\f$
   // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
@@ -903,21 +927,23 @@ void test_two_term_inner_outer_product(const DataType& used_for_size) {
     for (size_t a = 0; a < T_index::dim; a++) {
       expected_product += (Rll.get(a, b) * Tu.get(a));
     }
-    CHECK(Lb_from_Rab_TA.get(b) == expected_product);
-    CHECK(Lb_from_Rba_TA.get(b) == expected_product);
-    CHECK(Lb_from_TA_Rab.get(b) == expected_product);
-    CHECK(Lb_from_TA_Rba.get(b) == expected_product);
+    CHECK_ITERABLE_APPROX(Lb_from_Rab_TA.get(b), expected_product);
+    CHECK_ITERABLE_APPROX(Lb_from_Rba_TA.get(b), expected_product);
+    CHECK_ITERABLE_APPROX(Lb_from_TA_Rab.get(b), expected_product);
+    CHECK_ITERABLE_APPROX(Lb_from_TA_Rba.get(b), expected_product);
   }
 
   using S_lower_index = SpacetimeIndex<2, UpLo::Lo, Frame::Grid>;
   using S_upper_index = SpacetimeIndex<3, UpLo::Up, Frame::Grid>;
 
-  Tensor<DataType, Symmetry<2, 1>, index_list<S_upper_index, S_lower_index>>
-      Sul(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&Sul));
-  Tensor<DataType, Symmetry<2, 1>, index_list<S_lower_index, S_upper_index>>
-      Slu(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&Slu));
+  const auto Sul =
+      make_with_random_values<Tensor<DataType, Symmetry<2, 1>,
+                                     index_list<S_upper_index, S_lower_index>>>(
+          generator, distribution, used_for_size);
+  const auto Slu =
+      make_with_random_values<Tensor<DataType, Symmetry<2, 1>,
+                                     index_list<S_lower_index, S_upper_index>>>(
+          generator, distribution, used_for_size);
 
   // \f$L_{ac} = R_{ab} * S^{b}_{c}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<R_index, S_lower_index>>
@@ -968,14 +994,14 @@ void test_two_term_inner_outer_product(const DataType& used_for_size) {
         L_baBc_expected_product += (Rll.get(b, a) * Sul.get(b, c));
         L_bacB_expected_product += (Rll.get(b, a) * Slu.get(c, b));
       }
-      CHECK(L_abBc_to_ac.get(a, c) == L_abBc_expected_product);
-      CHECK(L_abBc_to_ca.get(c, a) == L_abBc_expected_product);
-      CHECK(L_abcB_to_ac.get(a, c) == L_abcB_expected_product);
-      CHECK(L_abcB_to_ca.get(c, a) == L_abcB_expected_product);
-      CHECK(L_baBc_to_ac.get(a, c) == L_baBc_expected_product);
-      CHECK(L_baBc_to_ca.get(c, a) == L_baBc_expected_product);
-      CHECK(L_bacB_to_ac.get(a, c) == L_bacB_expected_product);
-      CHECK(L_bacB_to_ca.get(c, a) == L_bacB_expected_product);
+      CHECK_ITERABLE_APPROX(L_abBc_to_ac.get(a, c), L_abBc_expected_product);
+      CHECK_ITERABLE_APPROX(L_abBc_to_ca.get(c, a), L_abBc_expected_product);
+      CHECK_ITERABLE_APPROX(L_abcB_to_ac.get(a, c), L_abcB_expected_product);
+      CHECK_ITERABLE_APPROX(L_abcB_to_ca.get(c, a), L_abcB_expected_product);
+      CHECK_ITERABLE_APPROX(L_baBc_to_ac.get(a, c), L_baBc_expected_product);
+      CHECK_ITERABLE_APPROX(L_baBc_to_ca.get(c, a), L_baBc_expected_product);
+      CHECK_ITERABLE_APPROX(L_bacB_to_ac.get(a, c), L_bacB_expected_product);
+      CHECK_ITERABLE_APPROX(L_bacB_to_ca.get(c, a), L_bacB_expected_product);
     }
   }
 }
@@ -992,20 +1018,20 @@ void test_two_term_inner_outer_product(const DataType& used_for_size) {
 // both LHS index orderings are also tested.
 //
 // \tparam DataType the type of data being stored in the product operands
-template <typename DataType>
-void test_three_term_inner_outer_product(const DataType& used_for_size) {
-  Tensor<DataType, Symmetry<1>,
-         index_list<SpatialIndex<3, UpLo::Up, Frame::Inertial>>>
-      Ru(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&Ru));
-  Tensor<DataType, Symmetry<1>,
-         index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>
-      Sl(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&Sl));
-  Tensor<DataType, Symmetry<1>,
-         index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>
-      Tl(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&Tl));
+template <typename Generator, typename DataType>
+void test_three_term_inner_outer_product(
+    const gsl::not_null<Generator*> generator, const DataType& used_for_size) {
+  std::uniform_real_distribution<> distribution(-1.0, 1.0);
+
+  const auto Ru =
+      make_with_random_values<tnsr::I<DataType, 3, Frame::Inertial>>(
+          generator, distribution, used_for_size);
+  const auto Sl =
+      make_with_random_values<tnsr::i<DataType, 3, Frame::Inertial>>(
+          generator, distribution, used_for_size);
+  const auto Tl =
+      make_with_random_values<tnsr::i<DataType, 3, Frame::Inertial>>(
+          generator, distribution, used_for_size);
 
   // \f$L_{i} = R^{j} * S_{j} * T_{i}\f$
   const decltype(Tl) Li_from_Jji =
@@ -1022,17 +1048,17 @@ void test_three_term_inner_outer_product(const DataType& used_for_size) {
     for (size_t j = 0; j < 3; j++) {
       expected_product += (Ru.get(j) * Sl.get(j) * Tl.get(i));
     }
-    CHECK(Li_from_Jji.get(i) == expected_product);
-    CHECK(Li_from_Jij.get(i) == expected_product);
-    CHECK(Li_from_ijJ.get(i) == expected_product);
+    CHECK_ITERABLE_APPROX(Li_from_Jji.get(i), expected_product);
+    CHECK_ITERABLE_APPROX(Li_from_Jij.get(i), expected_product);
+    CHECK_ITERABLE_APPROX(Li_from_ijJ.get(i), expected_product);
   }
 
   using T_index = tmpl::front<typename decltype(Tl)::index_list>;
   using G_index = SpatialIndex<3, UpLo::Up, Frame::Inertial>;
 
-  Tensor<DataType, Symmetry<2, 1>, index_list<G_index, G_index>> Guu(
-      used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&Guu));
+  const auto Guu = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>, index_list<G_index, G_index>>>(
+      generator, distribution, used_for_size);
 
   // \f$L_{i}{}^{k} = S_{j} * T_{i} * G^{jk}\f$
   const Tensor<DataType, Symmetry<2, 1>, index_list<T_index, G_index>>
@@ -1090,18 +1116,18 @@ void test_three_term_inner_outer_product(const DataType& used_for_size) {
       for (size_t j = 0; j < G_index::dim; j++) {
         expected_product += (Sl.get(j) * Tl.get(i) * Guu.get(j, k));
       }
-      CHECK(LiK_from_Sj_Ti_GJK.get(i, k) == expected_product);
-      CHECK(LKi_from_Sj_Ti_GJK.get(k, i) == expected_product);
-      CHECK(LiK_from_Sj_GJK_Ti.get(i, k) == expected_product);
-      CHECK(LKi_from_Sj_GJK_Ti.get(k, i) == expected_product);
-      CHECK(LiK_from_Ti_Sj_GJK.get(i, k) == expected_product);
-      CHECK(LKi_from_Ti_Sj_GJK.get(k, i) == expected_product);
-      CHECK(LiK_from_Ti_GJK_Sj.get(i, k) == expected_product);
-      CHECK(LKi_from_Ti_GJK_Sj.get(k, i) == expected_product);
-      CHECK(LiK_from_GJK_Sj_Ti.get(i, k) == expected_product);
-      CHECK(LKi_from_GJK_Sj_Ti.get(k, i) == expected_product);
-      CHECK(LiK_from_GJK_Ti_Sj.get(i, k) == expected_product);
-      CHECK(LKi_from_GJK_Ti_Sj.get(k, i) == expected_product);
+      CHECK_ITERABLE_APPROX(LiK_from_Sj_Ti_GJK.get(i, k), expected_product);
+      CHECK_ITERABLE_APPROX(LKi_from_Sj_Ti_GJK.get(k, i), expected_product);
+      CHECK_ITERABLE_APPROX(LiK_from_Sj_GJK_Ti.get(i, k), expected_product);
+      CHECK_ITERABLE_APPROX(LKi_from_Sj_GJK_Ti.get(k, i), expected_product);
+      CHECK_ITERABLE_APPROX(LiK_from_Ti_Sj_GJK.get(i, k), expected_product);
+      CHECK_ITERABLE_APPROX(LKi_from_Ti_Sj_GJK.get(k, i), expected_product);
+      CHECK_ITERABLE_APPROX(LiK_from_Ti_GJK_Sj.get(i, k), expected_product);
+      CHECK_ITERABLE_APPROX(LKi_from_Ti_GJK_Sj.get(k, i), expected_product);
+      CHECK_ITERABLE_APPROX(LiK_from_GJK_Sj_Ti.get(i, k), expected_product);
+      CHECK_ITERABLE_APPROX(LKi_from_GJK_Sj_Ti.get(k, i), expected_product);
+      CHECK_ITERABLE_APPROX(LiK_from_GJK_Ti_Sj.get(i, k), expected_product);
+      CHECK_ITERABLE_APPROX(LKi_from_GJK_Ti_Sj.get(k, i), expected_product);
     }
   }
 }
@@ -1122,22 +1148,17 @@ void test_three_term_inner_outer_product(const DataType& used_for_size) {
 //
 // \tparam DataType the type of data being stored in the tensor operand of the
 // products
-template <typename DataType>
-void test_spatial_spacetime_index(const DataType& used_for_size) {
-  std::uniform_real_distribution<> distribution(0.1, 1.0);
+template <typename Generator, typename DataType>
+void test_spatial_spacetime_index(const gsl::not_null<Generator*> generator,
+                                  const DataType& used_for_size) {
+  std::uniform_real_distribution<> distribution(-1.0, 1.0);
 
-  Tensor<DataType, Symmetry<1>,
-         index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>
-      R(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&R));
-  Tensor<DataType, Symmetry<1>,
-         index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
-      S(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&S));
-  Tensor<DataType, Symmetry<1>,
-         index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      T(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&T));
+  const auto R = make_with_random_values<tnsr::A<DataType, 3, Frame::Grid>>(
+      generator, distribution, used_for_size);
+  const auto S = make_with_random_values<tnsr::i<DataType, 3, Frame::Grid>>(
+      generator, distribution, used_for_size);
+  const auto T = make_with_random_values<tnsr::a<DataType, 3, Frame::Grid>>(
+      generator, distribution, used_for_size);
 
   // \f$L = R^{i} * S_{i}\f$
   // (spatial) * (spacetime) inner product with generic spatial indices
@@ -1157,16 +1178,12 @@ void test_spatial_spacetime_index(const DataType& used_for_size) {
   CHECK_ITERABLE_APPROX(RS.get(), expected_RS_product);
   CHECK_ITERABLE_APPROX(RT.get(), expected_RT_product);
 
-  Tensor<DataType, Symmetry<1, 1>,
-         index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
-                    SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>
-      G(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&G));
-  Tensor<DataType, Symmetry<2, 1>,
-         index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
-                    SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>>
-      H(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&H));
+  const auto G =
+      make_with_random_values<tnsr::aa<DataType, 3, Frame::Inertial>>(
+          generator, distribution, used_for_size);
+  const auto H =
+      make_with_random_values<tnsr::iA<DataType, 3, Frame::Inertial>>(
+          generator, distribution, used_for_size);
 
   // \f$L_{j, a, i}{}^{b} = G_{i, a} * H_{j}{}^{b}\f$
   // rank 2 x rank 2 outer product containing a spacetime index with a generic
@@ -1219,37 +1236,24 @@ void test_spatial_spacetime_index(const DataType& used_for_size) {
 //
 // \tparam DataType the type of data being stored in the tensor operand of the
 // products
-template <typename DataType>
-void test_time_index(const DataType& used_for_size) {
-  Tensor<DataType, Symmetry<1>,
-         index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      R(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&R));
+template <typename Generator, typename DataType>
+void test_time_index(const gsl::not_null<Generator*> generator,
+                     const DataType& used_for_size) {
+  std::uniform_real_distribution<> distribution(-1.0, 1.0);
 
-  Tensor<DataType> S{{{used_for_size}}};
-  if constexpr (std::is_same_v<DataType, double>) {
-    // Replace tensor's value from `used_for_size` to a proper test value
-    S.get() = -2.2;
-  } else {
-    assign_unique_values_to_tensor(make_not_null(&S));
-  }
+  const auto R = make_with_random_values<tnsr::a<DataType, 3, Frame::Grid>>(
+      generator, distribution, used_for_size);
+  const auto S = make_with_random_values<Scalar<DataType>>(
+      generator, distribution, used_for_size);
 
   // \f$L = R_{t} * S * R_{t}\f$
   const Tensor<DataType> L = tenex::evaluate(R(ti::t) * S() * R(ti::t));
-  CHECK(L.get() == R.get(0) * S.get() * R.get(0));
+  CHECK_ITERABLE_APPROX(L.get(), R.get(0) * S.get() * R.get(0));
 
-  Tensor<DataType, Symmetry<2, 1>,
-         index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>
-      G(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&G));
-
-  Tensor<DataType, Symmetry<3, 2, 1>,
-         index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
-                    SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>
-      H(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&H));
+  const auto G = make_with_random_values<tnsr::aB<DataType, 3, Frame::Grid>>(
+      generator, distribution, used_for_size);
+  const auto H = make_with_random_values<tnsr::aBC<DataType, 3, Frame::Grid>>(
+      generator, distribution, used_for_size);
 
   // \f$L^{b} = G_{t}{}^{a} * H_{a}{}^{tb}\f$
   const Tensor<DataType, Symmetry<1>,
@@ -1267,14 +1271,14 @@ void test_time_index(const DataType& used_for_size) {
   // Assign a placeholder to the LHS tensor's components before it is computed
   // so that when test expressions below only compute time components, we can
   // check that LHS spatial components haven't changed
-  const double spatial_component_placeholder =
-      std::numeric_limits<double>::max();
+  const auto spatial_component_placeholder_value =
+      TestHelpers::tenex::component_placeholder_value<DataType>::value;
   auto L_Tba = make_with_value<
       Tensor<DataType, Symmetry<2, 1, 1>,
              index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                         SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                         SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>>(
-      used_for_size, spatial_component_placeholder);
+      used_for_size, spatial_component_placeholder_value);
   // \f$L^{T}{}_{ba} = R_{a} * R_{b}\f$
   tenex::evaluate<ti::T, ti::b, ti::a>(make_not_null(&L_Tba),
                                        R(ti::a) * R(ti::b));
@@ -1283,7 +1287,7 @@ void test_time_index(const DataType& used_for_size) {
     for (size_t a = 0; a < 4; a++) {
       CHECK_ITERABLE_APPROX(L_Tba.get(0, b, a), R.get(a) * R.get(b));
       for (size_t i = 0; i < 3; i++) {
-        CHECK(L_Tba.get(i + 1, b, a) == spatial_component_placeholder);
+        CHECK(L_Tba.get(i + 1, b, a) == spatial_component_placeholder_value);
       }
     }
   }
@@ -1292,7 +1296,7 @@ void test_time_index(const DataType& used_for_size) {
       Tensor<DataType, Symmetry<2, 1>,
              index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                         SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>>(
-      used_for_size, spatial_component_placeholder);
+      used_for_size, spatial_component_placeholder_value);
   // \f$L_^{ct} = G_{t}{}^{b} * R_{b} * H_{t}^{ta}\f$
   tenex::evaluate<ti::C, ti::T>(
       make_not_null(&L_CT),
@@ -1308,40 +1312,45 @@ void test_time_index(const DataType& used_for_size) {
     CHECK_ITERABLE_APPROX(L_CT.get(c, 0), expected_product);
 
     for (size_t i = 0; i < 3; i++) {
-      CHECK(L_CT.get(c, i + 1) == spatial_component_placeholder);
+      CHECK(L_CT.get(c, i + 1) == spatial_component_placeholder_value);
     }
   }
 }
 
-template <typename DataType>
-void test_products(const DataType& used_for_size) {
+template <typename Generator, typename DataType>
+void test_products(const gsl::not_null<Generator*> generator,
+                   const DataType& used_for_size) {
   // Test evaluation of outer products
-  test_outer_product_double(used_for_size);
-  test_outer_product_rank_0_operand(used_for_size);
-  test_outer_product_rank_1_operand(used_for_size);
-  test_outer_product_rank_2x2_operands(used_for_size);
-  test_outer_product_rank_0x1x2_operands(used_for_size);
+  test_outer_product_double(generator, used_for_size);
+  test_outer_product_rank_0_operand(generator, used_for_size);
+  test_outer_product_rank_1_operand(generator, used_for_size);
+  test_outer_product_rank_2x2_operands(generator, used_for_size);
+  test_outer_product_rank_0x1x2_operands(generator, used_for_size);
 
   // Test evaluation of inner products
-  test_inner_product_rank_1x1_operands(used_for_size);
-  test_inner_product_rank_2x2_operands(used_for_size);
+  test_inner_product_rank_1x1_operands(generator, used_for_size);
+  test_inner_product_rank_2x2_operands(generator, used_for_size);
 
   // Test evaluation of expressions involving both inner and outer products
-  test_two_term_inner_outer_product(used_for_size);
-  test_three_term_inner_outer_product(used_for_size);
+  test_two_term_inner_outer_product(generator, used_for_size);
+  test_three_term_inner_outer_product(generator, used_for_size);
 
   // Test product expressions where generic spatial indices are used for
   // spacetime indices
-  test_spatial_spacetime_index(used_for_size);
+  test_spatial_spacetime_index(generator, used_for_size);
 
   // Test product expressions where time indices are used for spacetime indices
-  test_time_index(used_for_size);
+  test_time_index(generator, used_for_size);
 }
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Product",
                   "[DataStructures][Unit]") {
+  MAKE_GENERATOR(generator);
+
   test_tensor_ops_properties();
-  test_products(std::numeric_limits<double>::signaling_NaN());
-  test_products(DataVector(5, std::numeric_limits<double>::signaling_NaN()));
+  test_products(make_not_null(&generator),
+                std::numeric_limits<double>::signaling_NaN());
+  test_products(make_not_null(&generator),
+                DataVector(5, std::numeric_limits<double>::signaling_NaN()));
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Product.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Product.cpp
@@ -4,6 +4,7 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <climits>
+#include <complex>
 #include <cstddef>
 #include <random>
 #include <type_traits>
@@ -1352,6 +1353,10 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Product",
   test_tensor_ops_properties();
   test_products(make_not_null(&generator),
                 std::numeric_limits<double>::signaling_NaN());
+  test_products(
+      make_not_null(&generator),
+      std::complex<double>(std::numeric_limits<double>::signaling_NaN(),
+                           std::numeric_limits<double>::signaling_NaN()));
   test_products(make_not_null(&generator),
                 DataVector(5, std::numeric_limits<double>::signaling_NaN()));
   test_products(

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Product.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Product.cpp
@@ -8,6 +8,7 @@
 #include <random>
 #include <type_traits>
 
+#include "DataStructures/ComplexDataVector.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Symmetry.hpp"
@@ -1353,4 +1354,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Product",
                 std::numeric_limits<double>::signaling_NaN());
   test_products(make_not_null(&generator),
                 DataVector(5, std::numeric_limits<double>::signaling_NaN()));
+  test_products(
+      make_not_null(&generator),
+      ComplexDataVector(5, std::numeric_limits<double>::signaling_NaN()));
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_SquareRoot.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_SquareRoot.cpp
@@ -8,6 +8,7 @@
 #include <random>
 #include <type_traits>
 
+#include "DataStructures/ComplexDataVector.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Symmetry.hpp"
@@ -114,4 +115,6 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.SquareRoot",
             std::numeric_limits<double>::signaling_NaN());
   test_sqrt(make_not_null(&generator),
             DataVector(5, std::numeric_limits<double>::signaling_NaN()));
+  test_sqrt(make_not_null(&generator),
+            ComplexDataVector(5, std::numeric_limits<double>::signaling_NaN()));
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_SquareRoot.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_SquareRoot.cpp
@@ -5,37 +5,19 @@
 
 #include <climits>
 #include <cstddef>
-#include <iterator>
-#include <numeric>
+#include <random>
 #include <type_traits>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Symmetry.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
 namespace {
-template <typename... Ts>
-void assign_unique_values_to_tensor(
-    const gsl::not_null<Tensor<double, Ts...>*> tensor) {
-  std::iota(tensor->begin(), tensor->end(), 0.0);
-}
-
-template <typename... Ts>
-void assign_unique_values_to_tensor(
-    const gsl::not_null<Tensor<DataVector, Ts...>*> tensor) {
-  double value = 0.0;
-  for (auto index_it = tensor->begin(); index_it != tensor->end(); index_it++) {
-    for (auto vector_it = index_it->begin(); vector_it != index_it->end();
-         vector_it++) {
-      *vector_it = value;
-      value += 1.0;
-    }
-  }
-}
-
 // Checks that the number of ops in the expressions match what is expected
 void test_tensor_ops_properties() {
   const Scalar<double> G{5.0};
@@ -65,25 +47,21 @@ void test_tensor_ops_properties() {
 //
 // \tparam DataType the type of data being stored in the tensor operands of the
 // expressions tested
-template <typename DataType>
-void test_sqrt(const DataType& used_for_size) {
-  Tensor<DataType> R{{{used_for_size}}};
-  if (std::is_same_v<DataType, double>) {
-    // Replace tensor's value from `used_for_size` to a proper test value
-    R.get() = 5.7;
-  } else {
-    assign_unique_values_to_tensor(make_not_null(&R));
-  }
+template <typename Generator, typename DataType>
+void test_sqrt(const gsl::not_null<Generator*> generator,
+               const DataType& used_for_size) {
+  std::uniform_real_distribution<> distribution(0.1, 1.0);
+
+  const auto R = make_with_random_values<Scalar<DataType>>(
+      generator, distribution, used_for_size);
 
   // \f$L = \sqrt{R}\f$
   Tensor<DataType> sqrt_R = tenex::evaluate(sqrt(R()));
   CHECK(sqrt_R.get() == sqrt(R.get()));
 
-  Tensor<DataType, Symmetry<2, 1>,
-         index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
-                    SpatialIndex<3, UpLo::Up, Frame::Inertial>>>
-      S(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&S));
+  const auto S =
+      make_with_random_values<tnsr::iJ<DataType, 3, Frame::Inertial>>(
+          generator, distribution, used_for_size);
 
   DataType S_trace = make_with_value<DataType>(used_for_size, 0.0);
   for (size_t i = 0; i < 3; i++) {
@@ -95,21 +73,16 @@ void test_sqrt(const DataType& used_for_size) {
   // \f$L = \sqrt{S_{k}{}^{k} * T}\f$
   const Tensor<DataType> sqrt_S_T =
       tenex::evaluate(sqrt(S(ti::k, ti::K) * 3.6));
-  CHECK(sqrt_S.get() == sqrt(S_trace));
-  CHECK(sqrt_S_T.get() == sqrt(S_trace * 3.6));
+  CHECK_ITERABLE_APPROX(sqrt_S.get(), sqrt(S_trace));
+  CHECK_ITERABLE_APPROX(sqrt_S_T.get(), sqrt(S_trace * 3.6));
 
-  Tensor<DataType, Symmetry<1>,
-         index_list<SpatialIndex<4, UpLo::Up, Frame::Grid>>>
-      G(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&G));
-
-  Tensor<DataType, Symmetry<1>,
-         index_list<SpacetimeIndex<4, UpLo::Lo, Frame::Grid>>>
-      H(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&H));
+  const auto G = make_with_random_values<tnsr::I<DataType, 3, Frame::Grid>>(
+      generator, distribution, used_for_size);
+  const auto H = make_with_random_values<tnsr::a<DataType, 3, Frame::Grid>>(
+      generator, distribution, used_for_size);
 
   DataType GH_product = make_with_value<DataType>(used_for_size, 0.0);
-  for (size_t i = 0; i < 4; i++) {
+  for (size_t i = 0; i < 3; i++) {
     GH_product += G.get(i) * H.get(i + 1);
   }
 
@@ -117,13 +90,13 @@ void test_sqrt(const DataType& used_for_size) {
   // \f$L = \sqrt{G^{j} H_{j}\f$
   const Tensor<DataType> sqrt_GH_product =
       tenex::evaluate(sqrt(G(ti::J) * H(ti::j)));
-  CHECK(sqrt_GH_product.get() == sqrt(GH_product));
+  CHECK_ITERABLE_APPROX(sqrt_GH_product.get(), sqrt(GH_product));
 
-  Tensor<DataType, Symmetry<2, 1>,
-         index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
-                    SpacetimeIndex<4, UpLo::Lo, Frame::Inertial>>>
-      T(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&T));
+  const auto T = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>,
+                        SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>>(
+      generator, distribution, used_for_size);
 
   // Test expression that uses concrete time index for a spacetime index
   // \f$L = \sqrt{T_{t, t}\f$
@@ -134,7 +107,11 @@ void test_sqrt(const DataType& used_for_size) {
 
 SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.SquareRoot",
                   "[DataStructures][Unit]") {
+  MAKE_GENERATOR(generator);
+
   test_tensor_ops_properties();
-  test_sqrt(std::numeric_limits<double>::signaling_NaN());
-  test_sqrt(DataVector(5, std::numeric_limits<double>::signaling_NaN()));
+  test_sqrt(make_not_null(&generator),
+            std::numeric_limits<double>::signaling_NaN());
+  test_sqrt(make_not_null(&generator),
+            DataVector(5, std::numeric_limits<double>::signaling_NaN()));
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_SquareRoot.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_SquareRoot.cpp
@@ -4,6 +4,7 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <climits>
+#include <complex>
 #include <cstddef>
 #include <random>
 #include <type_traits>
@@ -113,6 +114,9 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.SquareRoot",
   test_tensor_ops_properties();
   test_sqrt(make_not_null(&generator),
             std::numeric_limits<double>::signaling_NaN());
+  test_sqrt(make_not_null(&generator),
+            std::complex<double>(std::numeric_limits<double>::signaling_NaN(),
+                                 std::numeric_limits<double>::signaling_NaN()));
   test_sqrt(make_not_null(&generator),
             DataVector(5, std::numeric_limits<double>::signaling_NaN()));
   test_sqrt(make_not_null(&generator),

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/ComponentPlaceholder.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/ComponentPlaceholder.hpp
@@ -1,0 +1,39 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <complex>
+#include <limits>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataVector.hpp"
+
+namespace TestHelpers::tenex {
+// Get a placeholder value for a Tensor component based on the data type of its
+// components
+template <typename DataType>
+struct component_placeholder_value;
+
+template <>
+struct component_placeholder_value<double> {
+  static constexpr double value = std::numeric_limits<double>::max();
+};
+
+template <>
+struct component_placeholder_value<std::complex<double>> {
+  static constexpr std::complex<double> value = std::complex<double>(
+      std::numeric_limits<double>::max(), std::numeric_limits<double>::max());
+};
+
+template <>
+struct component_placeholder_value<DataVector> {
+  static constexpr double value = component_placeholder_value<double>::value;
+};
+
+template <>
+struct component_placeholder_value<ComplexDataVector> {
+  static constexpr std::complex<double> value =
+      component_placeholder_value<std::complex<double>>::value;
+};
+}  // namespace TestHelpers::tenex


### PR DESCRIPTION
## Proposed changes

This PR (1) refactors `TensorExpression` code and tests to be more easily extendable to other types and (2) adds support for using `std::complex<double>`, `Tensor<std::complex<double>>`, and `Tensor<ComplexDataVector>` terms in `TensorExpression`s.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
