### PR TITLE
ObserveCenters: use Euclidean area element.

### DIFF
--- a/src/ApparentHorizons/HorizonAliases.hpp
+++ b/src/ApparentHorizons/HorizonAliases.hpp
@@ -68,6 +68,7 @@ using compute_items_on_target = tmpl::append<
                // extrinsic curvature of the slice embedded in 4d spacetime.
                // Both quantities are in the DataBox.
                StrahlkorperGr::Tags::AreaElementCompute<Frame>,
+               StrahlkorperTags::EuclideanAreaElementCompute<Frame>,
                StrahlkorperTags::ExtrinsicCurvatureCompute<Frame>,
                StrahlkorperTags::RicciScalarCompute<Frame>,
                StrahlkorperGr::Tags::SpinFunctionCompute<Frame>,

--- a/src/ApparentHorizons/TagsDeclarations.hpp
+++ b/src/ApparentHorizons/TagsDeclarations.hpp
@@ -6,6 +6,8 @@
 namespace StrahlkorperTags {
 template <typename Frame>
 struct EuclideanAreaElement;
+template <typename Frame>
+struct EuclideanAreaElementCompute;
 template <typename IntegrandTag, typename Frame>
 struct EuclideanSurfaceIntegral;
 struct OneOverOneFormMagnitude;

--- a/tests/Unit/ApparentHorizons/Test_ObserveCenters.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ObserveCenters.cpp
@@ -62,7 +62,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.ObserveCenters",
 
   db::DataBox<tmpl::list<StrahlkorperTags::Strahlkorper<Frame::Grid>,
                          StrahlkorperTags::CartesianCoords<Frame::Inertial>,
-                         StrahlkorperGr::Tags::AreaElement<Frame::Grid>>>
+                         StrahlkorperTags::EuclideanAreaElement<Frame::Grid>>>
       box{};
 
   const auto update_stored_centers = [&make_center, &grid_centers,
@@ -75,7 +75,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.ObserveCenters",
 
     db::mutate<StrahlkorperTags::Strahlkorper<Frame::Grid>,
                StrahlkorperTags::CartesianCoords<Frame::Inertial>,
-               StrahlkorperGr::Tags::AreaElement<Frame::Grid>>(
+               StrahlkorperTags::EuclideanAreaElement<Frame::Grid>>(
         make_not_null(&box),
         [&grid_center, &inertial_center](
             gsl::not_null<Strahlkorper<Frame::Grid>*> box_grid_horizon,


### PR DESCRIPTION
## Proposed changes

Uses the Euclidean area element in computation of the Strahlkorper center in the inertial frame.
The center is computed by averaging the coords over the Strahlkorper, where the averaging
is done by a surface integral (with the Euclidean area element).

The Euclidean area element is probably more appropriate, and matches better the behavior of other algorithms to compute the Strahlkorper center in a different frame (such as computing a full Strahlkorper in a different frame and then computing the center; that process is independent of the metric).

Also fixes a bug in how centers were computed, and adds Tags declarations that were missing.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
