### PR TITLE
Add TimeAndPrevious tag

### DIFF
--- a/tests/Unit/Time/Test_Tags.cpp
+++ b/tests/Unit/Time/Test_Tags.cpp
@@ -31,6 +31,9 @@ SPECTRE_TEST_CASE("Unit.Time.Tags", "[Unit][Time]") {
   TestHelpers::db::test_simple_tag<Tags::TimeStepId>("TimeStepId");
   TestHelpers::db::test_simple_tag<Tags::TimeStep>("TimeStep");
   TestHelpers::db::test_simple_tag<Tags::Time>("Time");
+  TestHelpers::db::test_simple_tag<Tags::TimeAndPrevious>("TimeAndPrevious");
+  TestHelpers::db::test_compute_tag<Tags::TimeAndPreviousCompute>(
+      "TimeAndPrevious");
   TestHelpers::db::test_simple_tag<
       Tags::HistoryEvolvedVariables<DummyVariablesTag>>(
       "HistoryEvolvedVariables");


### PR DESCRIPTION
## Proposed changes

This can only be used with dense triggers because the previous time is computed with the `evolution::Tags::PreviousTriggerTime` tag which is only set by dense triggers.

This is also something in https://github.com/sxs-collaboration/spectre/pull/4109 that is stand-alone and that @Sizheng-Ma needs while he is updating his CCM branch.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
