### PR TITLE
Fix the AnalyticTestCharacteristicExtract bug when inertial coordinates are evolved

### DIFF
--- a/src/Evolution/Executables/Cce/CharacteristicExtract.hpp
+++ b/src/Evolution/Executables/Cce/CharacteristicExtract.hpp
@@ -95,7 +95,8 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_memory_allocation_failure_reporting,
     &disable_openblas_multithreading,
     &Cce::register_initialize_j_with_charm<
-        metavariables::uses_partially_flat_cartesian_coordinates>,
+        metavariables::uses_partially_flat_cartesian_coordinates,
+        metavariables::cce_boundary_component>,
     &Parallel::register_derived_classes_with_charm<
         Cce::WorldtubeBufferUpdater<Cce::cce_metric_input_tags>>,
     &Parallel::register_derived_classes_with_charm<

--- a/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
@@ -133,10 +133,15 @@ struct CharacteristicEvolution {
           std::is_same_v<BondiTag, Tags::BondiU>,
           tmpl::list<
               ::Actions::MutateApply<GaugeUpdateTimeDerivatives>,
-              std::conditional_t<
-                  Metavariables::uses_partially_flat_cartesian_coordinates,
-                  ::Actions::MutateApply<GaugeUpdateInertialTimeDerivatives>,
-                  tmpl::list<>>,
+              tmpl::conditional_t<
+                  tt::is_a_v<AnalyticWorldtubeBoundary,
+                             typename Metavariables::cce_boundary_component>,
+                  tmpl::list<>,
+                  tmpl::conditional_t<
+                      Metavariables::uses_partially_flat_cartesian_coordinates,
+                      ::Actions::MutateApply<
+                          GaugeUpdateInertialTimeDerivatives>,
+                      tmpl::list<>>>,
               ::Actions::MutateApply<
                   GaugeAdjustedBoundaryValue<Tags::DuRDividedByR>>,
               ::Actions::MutateApply<PrecomputeCceDependencies<
@@ -177,9 +182,14 @@ struct CharacteristicEvolution {
       // note that the initialization will only actually happen on the
       // iterations immediately following restarts
       Actions::InitializeFirstHypersurface<
-          Metavariables::uses_partially_flat_cartesian_coordinates>,
-      Actions::UpdateGauge<
-          Metavariables::uses_partially_flat_cartesian_coordinates>,
+          Metavariables::uses_partially_flat_cartesian_coordinates,
+          typename Metavariables::cce_boundary_component>,
+      tmpl::conditional_t<
+          tt::is_a_v<AnalyticWorldtubeBoundary,
+                     typename Metavariables::cce_boundary_component>,
+          Actions::UpdateGauge<false>,
+          Actions::UpdateGauge<
+              Metavariables::uses_partially_flat_cartesian_coordinates>>,
       Actions::PrecomputeGlobalCceDependencies,
       tmpl::transform<bondi_hypersurface_step_tags,
                       tmpl::bind<hypersurface_computation, tmpl::_1>>,
@@ -199,9 +209,14 @@ struct CharacteristicEvolution {
       ::Actions::Label<CceEvolutionLabelTag>,
       Actions::ReceiveWorldtubeData<Metavariables>,
       Actions::InitializeFirstHypersurface<
-          Metavariables::uses_partially_flat_cartesian_coordinates>,
-      Actions::UpdateGauge<
-          Metavariables::uses_partially_flat_cartesian_coordinates>,
+          Metavariables::uses_partially_flat_cartesian_coordinates,
+          typename Metavariables::cce_boundary_component>,
+      tmpl::conditional_t<
+          tt::is_a_v<AnalyticWorldtubeBoundary,
+                     typename Metavariables::cce_boundary_component>,
+          Actions::UpdateGauge<false>,
+          Actions::UpdateGauge<
+              Metavariables::uses_partially_flat_cartesian_coordinates>>,
       Actions::PrecomputeGlobalCceDependencies,
       tmpl::transform<bondi_hypersurface_step_tags,
                       tmpl::bind<hypersurface_computation, tmpl::_1>>,

--- a/src/Evolution/Systems/Cce/Initialize/RegisterInitializeJWithCharm.hpp
+++ b/src/Evolution/Systems/Cce/Initialize/RegisterInitializeJWithCharm.hpp
@@ -16,11 +16,18 @@ struct LinearizedBondiSachs;
 
 /// A function for registering all of the InitializeJ derived classes with
 /// charm, including the ones not intended to be directly option-creatable
-template <bool uses_partially_flat_cartesian_coordinates>
+template <bool UsesPartiallyFlatCartesianCoordinates,
+          typename BoundaryComponent>
 void register_initialize_j_with_charm() {
   PUPable_reg(SINGLE_ARG(Solutions::LinearizedBondiSachs_detail::InitializeJ::
                          LinearizedBondiSachs));
-  Parallel::register_derived_classes_with_charm<Cce::InitializeJ::InitializeJ<
-      uses_partially_flat_cartesian_coordinates>>();
+
+  if constexpr (tt::is_a_v<AnalyticWorldtubeBoundary, BoundaryComponent>) {
+    Parallel::register_derived_classes_with_charm<
+        Cce::InitializeJ::InitializeJ<false>>();
+  } else {
+    Parallel::register_derived_classes_with_charm<Cce::InitializeJ::InitializeJ<
+        UsesPartiallyFlatCartesianCoordinates>>();
+  }
 }
 }  // namespace Cce

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
@@ -76,6 +76,9 @@ struct mock_observer_writer {
 };
 
 template <typename Metavariables>
+struct DummyBoundary {};
+
+template <typename Metavariables>
 struct mock_characteristic_evolution {
   using component_being_mocked = CharacteristicEvolution<Metavariables>;
   using replace_these_simple_actions = tmpl::list<>;
@@ -89,7 +92,8 @@ struct mock_characteristic_evolution {
       // advance the time so that the current `TimeStepId` is valid without
       // having to perform self-start.
       ::Actions::AdvanceTime, Actions::ReceiveWorldtubeData<Metavariables>,
-      Actions::InitializeFirstHypersurface<false>,
+      Actions::InitializeFirstHypersurface<false,
+                                           DummyBoundary<Metavariables>>,
       ::Actions::MutateApply<InitializeGauge>,
       ::Actions::MutateApply<GaugeUpdateAngularFromCartesian<
           Tags::CauchyAngularCoords, Tags::CauchyCartesianCoords>>,

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeFirstHypersurface.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeFirstHypersurface.cpp
@@ -109,7 +109,8 @@ struct mock_characteristic_evolution {
           Parallel::Phase::Testing,
           tmpl::list<
               Actions::InitializeFirstHypersurface<
-                  metavariables::uses_partially_flat_cartesian_coordinates>,
+                  metavariables::uses_partially_flat_cartesian_coordinates,
+                  dummy_boundary<Metavariables>>,
               ::Actions::MutateApply<GaugeUpdateAngularFromCartesian<
                   Tags::CauchyAngularCoords, Tags::CauchyCartesianCoords>>,
               ::Actions::MutateApply<GaugeUpdateJacobianFromCoordinates<


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

There is a bug in the executable of `AnalyticTestCharacteristicExtract`. It shares the same metavariable as `CharacteristicExtract`, where the Boolean variable `uses_partially_flat_cartesian_coordinates` is free to be `true` or `false`. When this option is on, the partially flat coordinates are evolved with respect to the GH coordinates. This is needed by CCM. However, `uses_partially_flat_cartesian_coordinates` is hard-coded to be `false` in the actions of `AnalyticTestCharacteristicExtract`, which make the actions imcompatible with its metavariable.

We still want `uses_partially_flat_cartesian_coordinates` to be hard-coded in `AnalyticTestCharacteristicExtract` because additional variables are not used by this executable at all. So I add a few `if` statements at several places to distinguish `AnalyticTestCharacteristicExtract` from `CharacteristicExtract`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
