### PR TITLE
Allow TimescaleTuner to be initialized with arbitary number of timescales

### DIFF
--- a/src/ControlSystem/CMakeLists.txt
+++ b/src/ControlSystem/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_sources(
   Averager.cpp
   Controller.cpp
   DataVectorHelpers.cpp
+  Tags.cpp
   TimescaleTuner.cpp
   )
 

--- a/src/ControlSystem/Tags.cpp
+++ b/src/ControlSystem/Tags.cpp
@@ -1,0 +1,39 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ControlSystem/Tags.hpp"
+
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace control_system::Tags::detail {
+template <size_t Dim>
+void initialize_tuner(
+    const gsl::not_null<::TimescaleTuner*> tuner,
+    const std::unique_ptr<::DomainCreator<Dim>>& domain_creator,
+    const double initial_time, const std::string& name) {
+  if (not tuner->timescales_have_been_set()) {
+    // We get the functions of time in order to get the number of components
+    // so we can resize the number of timescales. Since we are only concerned
+    // with the number of components, we don't care about the initial
+    // expiration times.
+    const auto functions_of_time = domain_creator->functions_of_time();
+    const size_t num_components =
+        functions_of_time.at(name)->func(initial_time)[0].size();
+    tuner->resize_timescales(num_components);
+  }
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                             \
+  template void initialize_tuner(                                        \
+      const gsl::not_null<::TimescaleTuner*> tuner,                      \
+      const std::unique_ptr<::DomainCreator<DIM(data)>>& domain_creator, \
+      const double initial_time, const std::string& name);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATE
+#undef DIM
+
+}  // namespace control_system::Tags::detail

--- a/tests/Unit/ControlSystem/Actions/Test_Initialization.cpp
+++ b/tests/Unit/ControlSystem/Actions/Test_Initialization.cpp
@@ -9,6 +9,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "ControlSystem/Actions/Initialization.hpp"
 #include "ControlSystem/Averager.hpp"
@@ -90,7 +91,8 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Initialization",
 
   Averager<order - 1> averager{0.5, true};
   const double damping_time = 1.0;
-  TimescaleTuner tuner{{damping_time}, 10.0, 0.1, 2.0, 0.1, 1.01, 0.99};
+  TimescaleTuner tuner{
+      std::vector<double>{damping_time}, 10.0, 0.1, 2.0, 0.1, 1.01, 0.99};
   Controller<order> controller{0.3};
   bool write_data = false;
   const control_system::TestHelpers::ControlError control_error{};

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
@@ -35,6 +35,10 @@ void test_expansion_control_error() {
   const std::string input_options =
       "Evolution:\n"
       "  InitialTime: 0.0\n"
+      "DomainCreator:\n"
+      "  FakeCreator:\n"
+      "    NumberOfComponents:\n"
+      "      Expansion: 1\n"
       "ControlSystems:\n"
       "  WriteDataToDisk: false\n"
       "  Expansion:\n"

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
@@ -40,6 +40,10 @@ void test_rotation_control_error() {
   const std::string input_options =
       "Evolution:\n"
       "  InitialTime: 0.0\n"
+      "DomainCreator:\n"
+      "  FakeCreator:\n"
+      "    NumberOfComponents:\n"
+      "      Rotation: 3\n"
       "ControlSystems:\n"
       "  WriteDataToDisk: false\n"
       "  Rotation:\n"

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Translation.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Translation.cpp
@@ -41,6 +41,10 @@ void test_translation_control_error() {
   const std::string input_options =
       "Evolution:\n"
       "  InitialTime: 0.0\n"
+      "DomainCreator:\n"
+      "  FakeCreator:\n"
+      "    NumberOfComponents:\n"
+      "      Translation: 3\n"
       "ControlSystems:\n"
       "  WriteDataToDisk: false\n"
       "  Translation:\n"

--- a/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
@@ -58,6 +58,10 @@ void test_expansion_control_system() {
   const std::string input_options =
       "Evolution:\n"
       "  InitialTime: 0.0\n"
+      "DomainCreator:\n"
+      "  FakeCreator:\n"
+      "    NumberOfComponents:\n"
+      "      Expansion: 1\n"
       "ControlSystems:\n"
       "  WriteDataToDisk: false\n"
       "  Expansion:\n"

--- a/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
@@ -109,6 +109,12 @@ void test_rotscaletrans_control_system(const double rotation_eps = 5.0e-5) {
   std::string input_options =
       "Evolution:\n"
       "  InitialTime: 0.0\n"
+      "DomainCreator:\n"
+      "  FakeCreator:\n"
+      "    NumberOfComponents:\n"
+      "      Translation: 3\n"
+      "      Rotation: 3\n"
+      "      Expansion: 1\n"
       "ControlSystems:\n"
       "  WriteDataToDisk: false\n";
   input_options += create_input_string(translation_name);

--- a/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
@@ -59,6 +59,10 @@ void test_rotation_control_system(const bool newtonian) {
   const std::string input_options =
       "Evolution:\n"
       "  InitialTime: 0.0\n"
+      "DomainCreator:\n"
+      "  FakeCreator:\n"
+      "    NumberOfComponents:\n"
+      "      Rotation: 3\n"
       "ControlSystems:\n"
       "  WriteDataToDisk: false\n"
       "  Rotation:\n"

--- a/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
@@ -65,6 +65,10 @@ void test_translation_control_system() {
   const std::string input_options =
       "Evolution:\n"
       "  InitialTime: 0.0\n"
+      "DomainCreator:\n"
+      "  FakeCreator:\n"
+      "    NumberOfComponents:\n"
+      "      Translation: 3\n"
       "ControlSystems:\n"
       "  WriteDataToDisk: false\n"
       "  Translation:\n"

--- a/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
@@ -201,9 +201,10 @@ void test_functions_of_time_tag() {
   // Controller. This value for the timescale was chosen to give an expiration
   // time between the two expiration times used above in the TestCreator
   const double timescale = 27.0;
-  const TimescaleTuner tuner1({timescale}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01,
-                              0.99);
-  const TimescaleTuner tuner2({0.1}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01, 0.99);
+  const TimescaleTuner tuner1(std::vector<double>{timescale}, 10.0, 1.0e-3,
+                              1.0e-2, 1.0e-4, 1.01, 0.99);
+  const TimescaleTuner tuner2(std::vector<double>{0.1}, 10.0, 1.0e-3, 1.0e-2,
+                              1.0e-4, 1.01, 0.99);
   const Averager<1> averager(0.25, true);
   const double update_fraction = 0.3;
   const Controller<2> controller(update_fraction);
@@ -398,8 +399,8 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Tags.FunctionsOfTimeInitialize",
       []() {
         const Creator creator = std::make_unique<TestCreator>(true);
 
-        const TimescaleTuner tuner({1.0}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01,
-                                   0.99);
+        const TimescaleTuner tuner(std::vector<double>{1.0}, 10.0, 1.0e-3,
+                                   1.0e-2, 1.0e-4, 1.01, 0.99);
         const Averager<1> averager(0.25, true);
         const double update_fraction = 0.3;
         const Controller<2> controller(update_fraction);
@@ -429,8 +430,8 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Tags.FunctionsOfTimeInitialize",
       []() {
         const Creator creator = std::make_unique<BadCreator>();
 
-        const TimescaleTuner tuner({1.0}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01,
-                                   0.99);
+        const TimescaleTuner tuner(std::vector<double>{1.0}, 10.0, 1.0e-3,
+                                   1.0e-2, 1.0e-4, 1.01, 0.99);
         const Averager<1> averager(0.25, true);
         const double update_fraction = 0.3;
         const Controller<2> controller(update_fraction);

--- a/tests/Unit/ControlSystem/Tags/Test_MeasurementTimescales.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_MeasurementTimescales.cpp
@@ -8,6 +8,7 @@
 #include <limits>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "ControlSystem/Averager.hpp"
 #include "ControlSystem/Component.hpp"
@@ -64,8 +65,8 @@ template <size_t DerivOrder>
 void test_calculate_measurement_timescales() {
   INFO("Test calculate measurement timescales");
   const double timescale = 20.0;
-  const TimescaleTuner tuner({timescale}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01,
-                             0.99);
+  const TimescaleTuner tuner(std::vector<double>{timescale}, 10.0, 1.0e-3,
+                             1.0e-2, 1.0e-4, 1.01, 0.99);
   const double update_fraction = 0.25;
   const Controller<DerivOrder> controller(update_fraction);
 
@@ -94,11 +95,11 @@ void test_measurement_tag() {
   const double time_step = 0.2;
   {
     const double timescale1 = 27.0;
-    const TimescaleTuner tuner1({timescale1}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4,
-                                1.01, 0.99);
+    const TimescaleTuner tuner1(std::vector<double>{timescale1}, 10.0, 1.0e-3,
+                                1.0e-2, 1.0e-4, 1.01, 0.99);
     const double timescale2 = 0.5;
-    const TimescaleTuner tuner2({timescale2}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4,
-                                1.01, 0.99);
+    const TimescaleTuner tuner2(std::vector<double>{timescale2}, 10.0, 1.0e-3,
+                                1.0e-2, 1.0e-4, 1.01, 0.99);
     const double averaging_fraction = 0.25;
     const Averager<1> averager(averaging_fraction, true);
     const double update_fraction = 0.3;
@@ -176,10 +177,10 @@ void test_measurement_tag() {
 
   CHECK_THROWS_WITH(
       ([]() {
-        const TimescaleTuner tuner1({27.0}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01,
-                                    0.99);
-        const TimescaleTuner tuner2({0.1}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01,
-                                    0.99);
+        const TimescaleTuner tuner1(std::vector<double>{27.0}, 10.0, 1.0e-3,
+                                    1.0e-2, 1.0e-4, 1.01, 0.99);
+        const TimescaleTuner tuner2(std::vector<double>{0.1}, 10.0, 1.0e-3,
+                                    1.0e-2, 1.0e-4, 1.01, 0.99);
         const Averager<1> averager(0.25, true);
         const Controller<2> controller(0.3);
         const control_system::TestHelpers::ControlError control_error{};

--- a/tests/Unit/ControlSystem/Test_Controller.cpp
+++ b/tests/Unit/ControlSystem/Test_Controller.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <cstddef>
 #include <memory>
+#include <vector>
 
 #include "ControlSystem/Controller.hpp"
 #include "ControlSystem/TimescaleTuner.hpp"
@@ -28,9 +29,10 @@ void test_controller() {
   const double min_timescale = 1.0e-3;
   const double initial_timescale = 1.0e-2;
 
-  TimescaleTuner tst({initial_timescale}, max_timescale, min_timescale,
-                     decrease_timescale_threshold, increase_timescale_threshold,
-                     increase_factor, decrease_factor);
+  TimescaleTuner tst(std::vector<double>{initial_timescale}, max_timescale,
+                     min_timescale, decrease_timescale_threshold,
+                     increase_timescale_threshold, increase_factor,
+                     decrease_factor);
 
   // test following a sinusoidal target function
   double t = 0.1;
@@ -99,9 +101,10 @@ void test_timeoffsets() {
   const double min_timescale = 1.0e-3;
   const double initial_timescale = 1.0e-2;
 
-  TimescaleTuner tst({initial_timescale}, max_timescale, min_timescale,
-                     decrease_timescale_threshold, increase_timescale_threshold,
-                     increase_factor, decrease_factor);
+  TimescaleTuner tst(std::vector<double>{initial_timescale}, max_timescale,
+                     min_timescale, decrease_timescale_threshold,
+                     increase_timescale_threshold, increase_factor,
+                     decrease_factor);
 
   // test following a sinusoidal target function
   double t = 0.1;
@@ -190,9 +193,10 @@ void test_timeoffsets_noaverageq() {
   const double min_timescale = 1.0e-3;
   const double initial_timescale = 1.0e-2;
 
-  TimescaleTuner tst({initial_timescale}, max_timescale, min_timescale,
-                     decrease_timescale_threshold, increase_timescale_threshold,
-                     increase_factor, decrease_factor);
+  TimescaleTuner tst(std::vector<double>{initial_timescale}, max_timescale,
+                     min_timescale, decrease_timescale_threshold,
+                     increase_timescale_threshold, increase_factor,
+                     decrease_factor);
 
   // test following a sinusoidal target function
   double t = 0.1;

--- a/tests/Unit/ControlSystem/Test_InitialExpirationTimes.cpp
+++ b/tests/Unit/ControlSystem/Test_InitialExpirationTimes.cpp
@@ -6,6 +6,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "ControlSystem/InitialExpirationTimes.hpp"
 #include "ControlSystem/Protocols/ControlSystem.hpp"
@@ -59,9 +60,10 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.ConstructInitialExpirationTimes",
   const double initial_time_step = 0.1;
 
   const double timescale = 2.0;
-  const TimescaleTuner tuner1({timescale}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01,
-                              0.99);
-  const TimescaleTuner tuner2({0.1}, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01, 0.99);
+  const TimescaleTuner tuner1(std::vector<double>{timescale}, 10.0, 1.0e-3,
+                              1.0e-2, 1.0e-4, 1.01, 0.99);
+  const TimescaleTuner tuner2(std::vector<double>{0.1}, 10.0, 1.0e-3, 1.0e-2,
+                              1.0e-4, 1.01, 0.99);
   const Averager<1> averager(0.25, true);
   const double update_fraction = 0.3;
   const Controller<2> controller(update_fraction);

--- a/tests/Unit/ControlSystem/Test_Tags.cpp
+++ b/tests/Unit/ControlSystem/Test_Tags.cpp
@@ -20,7 +20,9 @@
 #include "ControlSystem/Tags/FunctionsOfTimeInitialize.hpp"
 #include "ControlSystem/Tags/MeasurementTimescales.hpp"
 #include "ControlSystem/TimescaleTuner.hpp"
+#include "Domain/Creators/DomainCreator.hpp"
 #include "Framework/TestCreation.hpp"
+#include "Helpers/ControlSystem/SystemHelpers.hpp"
 #include "Helpers/ControlSystem/TestStructs.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 
@@ -29,7 +31,11 @@ struct LabelA {};
 using system = control_system::TestHelpers::System<
     2, LabelA, control_system::TestHelpers::Measurement<LabelA>>;
 
-struct MetavarsEmpty {};
+struct MetavarsEmpty {
+  static constexpr size_t volume_dim = 3;
+};
+
+using FakeCreator = control_system::TestHelpers::FakeCreator;
 
 void test_all_tags() {
   INFO("Test all tags");
@@ -72,8 +78,9 @@ void test_control_sys_inputs() {
   const double max_timescale = 10.0;
   const double min_timescale = 1.0e-3;
   const TimescaleTuner expected_tuner(
-      {1.}, max_timescale, min_timescale, decrease_timescale_threshold,
-      increase_timescale_threshold, increase_factor, decrease_factor);
+      std::vector<double>{1.}, max_timescale, min_timescale,
+      decrease_timescale_threshold, increase_timescale_threshold,
+      increase_factor, decrease_factor);
   const Averager<1> expected_averager(0.25, true);
   const Controller<2> expected_controller(0.3);
   const std::string expected_name{"LabelA"};
@@ -108,9 +115,63 @@ void test_control_sys_inputs() {
   // doesn't have a comparison operator. Once a control error is added that
   // contains member data (and thus, options), then it can be tested
 }
+
+void test_individual_tags() {
+  const double decrease_timescale_threshold = 1.0e-2;
+  const double increase_timescale_threshold = 1.0e-4;
+  const double increase_factor = 1.01;
+  const double decrease_factor = 0.99;
+  const double max_timescale = 10.0;
+  const double min_timescale = 1.0e-3;
+  const TimescaleTuner expected_tuner(
+      std::vector<double>{1.0, 1.0}, max_timescale, min_timescale,
+      decrease_timescale_threshold, increase_timescale_threshold,
+      increase_factor, decrease_factor);
+
+  const auto holder = TestHelpers::test_option_tag<
+      control_system::OptionTags::ControlSystemInputs<system>>(
+      "Averager:\n"
+      "  AverageTimescaleFraction: 0.25\n"
+      "  Average0thDeriv: true\n"
+      "Controller:\n"
+      "  UpdateFraction: 0.3\n"
+      "TimescaleTuner:\n"
+      "  InitialTimescales: 1.\n"
+      "  MinTimescale: 1e-3\n"
+      "  MaxTimescale: 10.\n"
+      "  DecreaseThreshold: 1e-2\n"
+      "  IncreaseThreshold: 1e-4\n"
+      "  IncreaseFactor: 1.01\n"
+      "  DecreaseFactor: 0.99\n"
+      "ControlError:\n");
+
+  using tuner_tag = control_system::Tags::TimescaleTuner<system>;
+
+  const std::unique_ptr<DomainCreator<3>> creator =
+      std::make_unique<FakeCreator>(
+          std::unordered_map<std::string, size_t>{{system::name(), 2}});
+
+  const TimescaleTuner created_tuner =
+      tuner_tag::create_from_options<MetavarsEmpty>(holder, creator, 0.0);
+
+  CHECK(created_tuner == expected_tuner);
+
+  using controller_tag = control_system::Tags::Controller<system>;
+
+  Controller<2> expected_controller(0.3);
+  expected_controller.set_initial_update_time(0.0);
+  expected_controller.assign_time_between_updates(
+      min(created_tuner.current_timescale()));
+
+  const Controller<2> created_controller =
+      controller_tag::create_from_options<MetavarsEmpty>(holder, creator, 0.0);
+
+  CHECK(created_controller == expected_controller);
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.ControlSystem.Tags", "[ControlSystem][Unit]") {
   test_all_tags();
   test_control_sys_inputs();
+  test_individual_tags();
 }


### PR DESCRIPTION
## Proposed changes

This will be necessary when we have shape control so we don't have to type out a bunch of the same number in an input file.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
