### PR TITLE
Add spherical torus coordinate map

### DIFF
--- a/src/Domain/CoordinateMaps/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/CMakeLists.txt
@@ -31,6 +31,7 @@ spectre_target_sources(
   KerrHorizonConforming.cpp
   Rotation.cpp
   SpecialMobius.cpp
+  SphericalTorus.cpp
   UniformCylindricalEndcap.cpp
   Wedge.cpp
   )
@@ -68,6 +69,7 @@ spectre_target_headers(
   ProductMaps.tpp
   Rotation.hpp
   SpecialMobius.hpp
+  SphericalTorus.hpp
   Tags.hpp
   TimeDependentHelpers.hpp
   UniformCylindricalEndcap.hpp

--- a/src/Domain/CoordinateMaps/SphericalTorus.cpp
+++ b/src/Domain/CoordinateMaps/SphericalTorus.cpp
@@ -1,0 +1,357 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/SphericalTorus.hpp"
+
+#include <pup.h>
+
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace domain::CoordinateMaps {
+
+SphericalTorus::SphericalTorus(const double r_min, const double r_max,
+                               const double min_polar_angle,
+                               const double fraction_of_torus,
+                               const Options::Context& context)
+    : r_min_(r_min),
+      r_max_(r_max),
+      pi_over_2_minus_theta_min_(M_PI_2 - min_polar_angle),
+      fraction_of_torus_(fraction_of_torus) {
+  if (r_min_ <= 0.0) {
+    PARSE_ERROR(context, "Minimum radius must be positive.");
+  }
+  if (r_max_ <= r_min_) {
+    PARSE_ERROR(context, "Maximum radius must be greater than minimum radius.");
+  }
+  if (pi_over_2_minus_theta_min_ <= 0.0) {
+    PARSE_ERROR(context, "Minimum polar angle should be less than pi/2.");
+  }
+  if (pi_over_2_minus_theta_min_ >= 0.5 * M_PI) {
+    PARSE_ERROR(context, "Minimum polar angle should be positive.");
+  }
+  if (fraction_of_torus_ <= 0.0) {
+    PARSE_ERROR(context, "Fraction of torus included must be positive.");
+  }
+  if (fraction_of_torus_ > 1.0) {
+    PARSE_ERROR(context, "Fraction of torus included must be at most 1.");
+  }
+}
+
+SphericalTorus::SphericalTorus(const std::array<double, 2>& radial_range,
+                               const double min_polar_angle,
+                               const double fraction_of_torus,
+                               const Options::Context& context)
+    : SphericalTorus(radial_range[0], radial_range[1], min_polar_angle,
+                     fraction_of_torus, context) {}
+
+//
+// **** WARNING : below we are using the following convention for naming
+//                spherical coordinate variables internally
+//  * r     : radius
+//  * theta : azimuthal angle
+//  * phi   : elevation angle measured from equator, which is equal to (\pi/2 -
+//            polar angle) where the polar angle is measured from +z axis.
+//
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, 3> SphericalTorus::operator()(
+    const std::array<T, 3>& source_coords) const {
+  const auto r = radius(source_coords[0]);
+  const auto theta = M_PI * fraction_of_torus_ * source_coords[2];
+  const auto phi = pi_over_2_minus_theta_min_ * source_coords[1];
+
+  return {{r * cos(theta) * cos(phi), r * sin(theta) * cos(phi), r * sin(phi)}};
+}
+
+std::optional<std::array<double, 3>> SphericalTorus::inverse(
+    const std::array<double, 3>& target_coords) const {
+  const double r =
+      std::hypot(target_coords[0], target_coords[1], target_coords[2]);
+  const double theta = std::atan2(target_coords[1], target_coords[0]);
+  const double phi = std::atan2(target_coords[2],
+                                std::hypot(target_coords[0], target_coords[1]));
+
+  return {{radius_inverse(r), phi / pi_over_2_minus_theta_min_,
+           theta / (M_PI * fraction_of_torus_)}};
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>
+SphericalTorus::jacobian(const std::array<T, 3>& source_coords) const {
+  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
+  auto jacobian = make_with_value<tnsr::Ij<UnwrappedT, 3, Frame::NoFrame>>(
+      dereference_wrapper(source_coords[0]), 0.0);
+
+  // In order to reduce number of memory allocations we use some slots of
+  // jacobian for storing temp variables as below.
+
+  auto& sin_theta = get<1, 1>(jacobian);
+  auto& cos_theta = get<1, 2>(jacobian);
+  get<2, 2>(jacobian) = M_PI * fraction_of_torus_ * source_coords[2];
+  cos_theta = cos(get<2, 2>(jacobian));
+  sin_theta = sin(get<2, 2>(jacobian));
+
+  auto& sin_phi = get<2, 0>(jacobian);
+  auto& cos_phi = get<2, 1>(jacobian);
+  get<2, 2>(jacobian) = pi_over_2_minus_theta_min_ * source_coords[1];
+  cos_phi = cos(get<2, 2>(jacobian));
+  sin_phi = sin(get<2, 2>(jacobian));
+
+  auto& r = get<2, 2>(jacobian);
+  radius(make_not_null(&r), source_coords[0]);
+
+  // Note : execution order matters here since we are overwriting each temp
+  // variables with jacobian values corresponding to the slot.
+  get<0, 0>(jacobian) = 0.5 * (r_max_ - r_min_) * cos_theta * cos_phi;
+  get<0, 1>(jacobian) = -pi_over_2_minus_theta_min_ * r * cos_theta * sin_phi;
+  get<0, 2>(jacobian) = -M_PI * fraction_of_torus_ * r * sin_theta * cos_phi;
+  get<1, 0>(jacobian) = 0.5 * (r_max_ - r_min_) * sin_theta * cos_phi;
+  get<1, 1>(jacobian) = -pi_over_2_minus_theta_min_ * r * sin_theta * sin_phi;
+  get<1, 2>(jacobian) = M_PI * fraction_of_torus_ * r * cos_theta * cos_phi;
+  get<2, 0>(jacobian) = 0.5 * (r_max_ - r_min_) * sin_phi;
+  get<2, 1>(jacobian) = pi_over_2_minus_theta_min_ * r * cos_phi;
+  get<2, 2>(jacobian) = 0.0;
+
+  return jacobian;
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>
+SphericalTorus::inv_jacobian(const std::array<T, 3>& source_coords) const {
+  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
+  auto inv_jacobian = make_with_value<tnsr::Ij<UnwrappedT, 3, Frame::NoFrame>>(
+      dereference_wrapper(source_coords[0]), 0.0);
+
+  // In order to reduce number of memory allocations we use some slots of
+  // jacobian for storing temp variables as below.
+
+  auto& sin_theta = get<1, 1>(inv_jacobian);
+  auto& cos_theta = get<2, 1>(inv_jacobian);
+  get<2, 2>(inv_jacobian) = M_PI * fraction_of_torus_ * source_coords[2];
+  cos_theta = cos(get<2, 2>(inv_jacobian));
+  sin_theta = sin(get<2, 2>(inv_jacobian));
+
+  auto& sin_phi = get<0, 2>(inv_jacobian);
+  auto& cos_phi = get<1, 2>(inv_jacobian);
+  get<2, 2>(inv_jacobian) = pi_over_2_minus_theta_min_ * source_coords[1];
+  cos_phi = cos(get<2, 2>(inv_jacobian));
+  sin_phi = sin(get<2, 2>(inv_jacobian));
+
+  auto& r = get<2, 2>(inv_jacobian);
+  radius(make_not_null(&r), source_coords[0]);
+
+  // Note : execution order matters here since we are overwriting each temp
+  // variables with jacobian values corresponding to the slot.
+  get<0, 0>(inv_jacobian) = 2.0 / (r_max_ - r_min_) * cos_theta * cos_phi;
+  get<0, 1>(inv_jacobian) = 2.0 / (r_max_ - r_min_) * sin_theta * cos_phi;
+  get<1, 0>(inv_jacobian) =
+      -(1.0 / pi_over_2_minus_theta_min_) * cos_theta * sin_phi / r;
+  get<2, 0>(inv_jacobian) =
+      -(1.0 / (M_PI * fraction_of_torus_)) * sin_theta / (r * cos_phi);
+  get<1, 1>(inv_jacobian) =
+      -(1.0 / pi_over_2_minus_theta_min_) * sin_theta * sin_phi / r;
+  get<2, 1>(inv_jacobian) =
+      (1.0 / (M_PI * fraction_of_torus_)) * cos_theta / (r * cos_phi);
+  get<0, 2>(inv_jacobian) = 2.0 / (r_max_ - r_min_) * sin_phi;
+  get<1, 2>(inv_jacobian) = (1.0 / pi_over_2_minus_theta_min_) * cos_phi / r;
+  get<2, 2>(inv_jacobian) = 0.0;
+
+  return inv_jacobian;
+}
+
+template <typename T>
+tnsr::Ijj<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>
+SphericalTorus::hessian(const std::array<T, 3>& source_coords) const {
+  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
+  auto hessian = make_with_value<tnsr::Ijj<UnwrappedT, 3, Frame::NoFrame>>(
+      dereference_wrapper(source_coords[0]), 0.0);
+
+  // In order to reduce number of memory allocations we use some slots of
+  // hessian for storing temp variables as below.
+
+  // these two slots are zeros (not used)
+  auto& theta_factor = get<2, 0, 0>(hessian);
+  auto& phi_factor = get<2, 0, 2>(hessian);
+  theta_factor = M_PI * fraction_of_torus_;
+  phi_factor = pi_over_2_minus_theta_min_;
+
+  // these two slots are zeros (not used)
+  auto& cos_theta = get<2, 1, 2>(hessian);
+  auto& sin_theta = get<2, 2, 2>(hessian);
+  get<0, 0, 0>(hessian) = theta_factor * source_coords[2];
+  cos_theta = cos(get<0, 0, 0>(hessian));
+  sin_theta = sin(get<0, 0, 0>(hessian));
+
+  // these two slots are NOT zeros, but will be overwritten with hessian later
+  auto& cos_phi = get<2, 0, 1>(hessian);
+  auto& sin_phi = get<2, 1, 1>(hessian);
+  get<0, 0, 0>(hessian) = phi_factor * source_coords[1];
+  cos_phi = cos(get<0, 0, 0>(hessian));
+  sin_phi = sin(get<0, 0, 0>(hessian));
+
+  // these two slots are zeros (not used)
+  auto& r_factor = get<0, 0, 0>(hessian);
+  auto& r = get<1, 0, 0>(hessian);
+  r_factor = 0.5 * (r_max_ - r_min_);
+  radius(make_not_null(&r), source_coords[0]);
+
+  // Note : execution order matters here
+  get<0, 0, 1>(hessian) = -r_factor * phi_factor * cos_theta * sin_phi;
+  get<0, 0, 2>(hessian) = -r_factor * theta_factor * sin_theta * cos_phi;
+  get<0, 1, 1>(hessian) = -square(phi_factor) * r * cos_theta * cos_phi;
+  get<0, 1, 2>(hessian) = phi_factor * theta_factor * r * sin_theta * sin_phi;
+  get<0, 2, 2>(hessian) = -square(theta_factor) * r * cos_theta * cos_phi;
+  get<1, 0, 1>(hessian) = -r_factor * phi_factor * sin_theta * sin_phi;
+  get<1, 0, 2>(hessian) = r_factor * theta_factor * cos_theta * cos_phi;
+  get<1, 1, 1>(hessian) = -square(phi_factor) * r * sin_theta * cos_phi;
+  get<1, 1, 2>(hessian) = -phi_factor * theta_factor * r * cos_theta * sin_phi;
+  get<1, 2, 2>(hessian) = -square(theta_factor) * r * sin_theta * cos_phi;
+  get<2, 0, 1>(hessian) = r_factor * phi_factor * cos_phi;
+  get<2, 1, 1>(hessian) = -square(phi_factor) * r * sin_phi;
+
+  // remove temp vars and restore to zero
+  get<0, 0, 0>(hessian) = 0.0;
+  get<1, 0, 0>(hessian) = 0.0;
+  get<2, 0, 0>(hessian) = 0.0;
+  get<2, 0, 2>(hessian) = 0.0;
+  get<2, 1, 2>(hessian) = 0.0;
+  get<2, 2, 2>(hessian) = 0.0;
+
+  return hessian;
+}
+
+template <typename T>
+tnsr::Ijk<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>
+SphericalTorus::derivative_of_inv_jacobian(
+    const std::array<T, 3>& source_coords) const {
+  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
+  auto result = make_with_value<tnsr::Ijk<UnwrappedT, 3, Frame::NoFrame>>(
+      dereference_wrapper(source_coords[0]), 0.0);
+
+  // In order to reduce number of memory allocations we use some slots of
+  // `result` for storing temp variables as below.
+
+  auto& cos_theta = get<1, 2, 2>(result);
+  auto& sin_theta = get<2, 2, 0>(result);
+  get<0, 0, 0>(result) = M_PI * fraction_of_torus_ * source_coords[2];
+  cos_theta = cos(get<0, 0, 0>(result));
+  sin_theta = sin(get<0, 0, 0>(result));
+
+  auto& cos_phi = get<2, 2, 1>(result);
+  auto& sin_phi = get<2, 2, 2>(result);
+  get<0, 0, 0>(result) = pi_over_2_minus_theta_min_ * source_coords[1];
+  cos_phi = cos(get<0, 0, 0>(result));
+  sin_phi = sin(get<0, 0, 0>(result));
+
+  auto& theta_factor = get<0, 2, 0>(result);
+  auto& phi_factor = get<0, 2, 2>(result);
+  theta_factor = M_PI * fraction_of_torus_;
+  phi_factor = pi_over_2_minus_theta_min_;
+
+  auto& r = get<0, 0, 0>(result);
+  auto& r_factor = get<0, 1, 0>(result);
+  radius(make_not_null(&r), source_coords[0]);
+  r_factor = 0.5 * (r_max_ - r_min_);
+
+  get<0, 0, 1>(result) = -phi_factor / r_factor * cos_theta * sin_phi;
+  get<0, 0, 2>(result) = -theta_factor / r_factor * sin_theta * cos_phi;
+  get<0, 1, 1>(result) = -phi_factor / r_factor * sin_theta * sin_phi;
+  get<0, 1, 2>(result) = theta_factor / r_factor * cos_theta * cos_phi;
+  get<0, 2, 1>(result) = phi_factor / r_factor * cos_phi;
+  get<1, 0, 0>(result) =
+      r_factor / phi_factor * cos_theta * sin_phi / square(r);
+  get<1, 0, 1>(result) = -cos_theta * cos_phi / r;
+  get<1, 0, 2>(result) = theta_factor / phi_factor * sin_theta * sin_phi / r;
+  get<1, 1, 0>(result) =
+      r_factor / phi_factor * sin_theta * sin_phi / square(r);
+  get<1, 1, 1>(result) = -sin_theta * cos_phi / r;
+  get<1, 1, 2>(result) = -theta_factor / phi_factor * cos_theta * sin_phi / r;
+  get<1, 2, 0>(result) = -r_factor / phi_factor * cos_phi / square(r);
+  get<1, 2, 1>(result) = -sin_phi / r;
+  get<2, 0, 0>(result) =
+      r_factor / theta_factor * sin_theta / (square(r) * cos_phi);
+  get<2, 0, 1>(result) =
+      -phi_factor / theta_factor * sin_theta * sin_phi / (r * square(cos_phi));
+  get<2, 0, 2>(result) = -cos_theta / (r * cos_phi);
+
+  get<2, 1, 0>(result) =
+      -r_factor / theta_factor * cos_theta / (square(r) * cos_phi);
+  get<2, 1, 1>(result) =
+      phi_factor / theta_factor * cos_theta * sin_phi / (r * square(cos_phi));
+  get<2, 1, 2>(result) = -sin_theta / (r * cos_phi);
+
+  // remove temp vars and restore to zero
+  get<0, 0, 0>(result) = 0.0;
+  get<0, 1, 0>(result) = 0.0;
+  get<0, 2, 0>(result) = 0.0;
+  get<0, 2, 2>(result) = 0.0;
+  get<1, 2, 2>(result) = 0.0;
+  get<2, 2, 0>(result) = 0.0;
+  get<2, 2, 1>(result) = 0.0;
+  get<2, 2, 2>(result) = 0.0;
+
+  return result;
+}
+
+void SphericalTorus::pup(PUP::er& p) {
+  p | r_min_;
+  p | r_max_;
+  p | pi_over_2_minus_theta_min_;
+  p | fraction_of_torus_;
+}
+
+template <typename T>
+tt::remove_cvref_wrap_t<T> SphericalTorus::radius(const T& x) const {
+  return 0.5 * r_min_ * (1.0 - x) + 0.5 * r_max_ * (1.0 + x);
+}
+
+template <typename T>
+void SphericalTorus::radius(const gsl::not_null<tt::remove_cvref_wrap_t<T>*> r,
+                            const T& x) const {
+  *r = 0.5 * r_min_ * (1.0 - x) + 0.5 * r_max_ * (1.0 + x);
+}
+
+template <typename T>
+tt::remove_cvref_wrap_t<T> SphericalTorus::radius_inverse(const T& r) const {
+  return ((r - r_min_) - (r_max_ - r)) / (r_max_ - r_min_);
+}
+
+bool operator==(const SphericalTorus& lhs, const SphericalTorus& rhs) {
+  return lhs.r_min_ == rhs.r_min_ and lhs.r_max_ == rhs.r_max_ and
+         lhs.pi_over_2_minus_theta_min_ == rhs.pi_over_2_minus_theta_min_ and
+         lhs.fraction_of_torus_ == rhs.fraction_of_torus_;
+}
+
+bool operator!=(const SphericalTorus& lhs, const SphericalTorus& rhs) {
+  return not(lhs == rhs);
+}
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                  \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>                \
+  SphericalTorus::operator()(const std::array<DTYPE(data), 3>& source_coords) \
+      const;                                                                  \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame>  \
+  SphericalTorus::jacobian(const std::array<DTYPE(data), 3>& source_coords)   \
+      const;                                                                  \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame>  \
+  SphericalTorus::inv_jacobian(                                               \
+      const std::array<DTYPE(data), 3>& source_coords) const;                 \
+  template tnsr::Ijj<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame> \
+  SphericalTorus::hessian(const std::array<DTYPE(data), 3>& source_coords)    \
+      const;                                                                  \
+  template tnsr::Ijk<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame> \
+  SphericalTorus::derivative_of_inv_jacobian(                                 \
+      const std::array<DTYPE(data), 3>& source_coords) const;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
+                                      std::reference_wrapper<const double>,
+                                      std::reference_wrapper<const DataVector>))
+#undef INSTANTIATE
+#undef DTYPE
+
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/SphericalTorus.hpp
+++ b/src/Domain/CoordinateMaps/SphericalTorus.hpp
@@ -1,0 +1,156 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <optional>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace domain::CoordinateMaps {
+/*!
+ * \ingroup CoordinateMapsGroup
+ *
+ * \brief Torus made by removing two polar cones from a spherical shell
+ *
+ * Maps source coordinates \f$(\xi, \eta, \zeta)\f$ to
+ * \f{align}
+ * \vec{x}(\xi, \eta, \zeta) =
+ * \begin{bmatrix}
+ *  r \sin\theta\cos\phi \\
+ *  r \sin\theta\sin\phi \\
+ *  r \cos\theta
+ * \end{bmatrix}
+ * \f}
+ *
+ * where
+ * \f{align}
+ *  r & = r_\mathrm{min}\frac{1-\xi}{2} + r_\mathrm{max}\frac{1+\xi}{2}, \\
+ *  \theta & = \pi/2 - (\pi/2 - \theta_\mathrm{min}) \eta, \\
+ *  \phi   & = f_\mathrm{torus} \pi \zeta.
+ * \f}
+ *
+ *  - $r_\mathrm{min}$ and $r_\mathrm{max}$ are inner and outer radius of torus.
+ *  - $\theta_\mathrm{min}\in(0,\pi/2)$ is the minimum polar angle (measured
+ *    from +z axis) of torus, which is equal to the half of the apex angle of
+ *    the removed polar cones.
+ *  - $f_\mathrm{torus}\in(0, 1)$ is azimuthal fraction that the torus covers.
+ *
+ * \warning Internal namings of code variables in `SphericalTorus.cpp` uses
+ * a different convention of angular variables for spherical coordinates.
+ * Therein `theta` denotes the azimuthal angle, and `phi` denotes the elevation
+ * angle measured from equator, which is equal to (\f$\pi/2\f$ - polar angle)
+ * with the polar angle being measured from +z axis.
+ *
+ */
+class SphericalTorus {
+ public:
+  static constexpr size_t dim = 3;
+
+  struct RadialRange {
+    using type = std::array<double, 2>;
+    static constexpr Options::String help =
+        "Radial extent of the torus, "
+        "[min_radius, max_radius] ";
+  };
+
+  struct MinPolarAngle {
+    using type = double;
+    static constexpr Options::String help =
+        "Half of the apex angle of excised polar cones. "
+        "Polar angle (measured from +z axis) of torus has range "
+        "[MinPolarAngle, pi - MinPolarAngle]";
+    static type lower_bound() { return 0.0; }
+    static type upper_bound() { return 0.5 * M_PI; }
+  };
+
+  struct FractionOfTorus {
+    using type = double;
+    static constexpr Options::String help =
+        "Fraction of (azimuthal) orbit covered. Azimuthal angle has range "
+        "[- pi * FractionOfTorus, pi * FractionOfTorus].";
+    static type lower_bound() { return 0.0; }
+    static type upper_bound() { return 1.0; }
+  };
+
+  static constexpr Options::String help =
+      "Torus made by removing polar cones from a spherical shell";
+
+  using options = tmpl::list<RadialRange, MinPolarAngle, FractionOfTorus>;
+
+  SphericalTorus(const std::array<double, 2>& radial_range,
+                 const double min_polar_angle, const double fraction_of_torus,
+                 const Options::Context& context = {});
+
+  SphericalTorus(double r_min, double r_max, double min_polar_angle,
+                 double fraction_of_torus = 1.0,
+                 const Options::Context& context = {});
+
+  SphericalTorus() = default;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(
+      const std::array<T, 3>& source_coords) const;
+
+  std::optional<std::array<double, 3>> inverse(
+      const std::array<double, 3>& target_coords) const;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> jacobian(
+      const std::array<T, 3>& source_coords) const;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> inv_jacobian(
+      const std::array<T, 3>& source_coords) const;
+
+  template <typename T>
+  tnsr::Ijj<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> hessian(
+      const std::array<T, 3>& source_coords) const;
+
+  template <typename T>
+  tnsr::Ijk<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>
+  derivative_of_inv_jacobian(const std::array<T, 3>& source_coords) const;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p);
+
+  bool is_identity() const { return false; }
+
+ private:
+  template <typename T>
+  tt::remove_cvref_wrap_t<T> radius(const T& x) const;
+
+  template <typename T>
+  void radius(const gsl::not_null<tt::remove_cvref_wrap_t<T>*> r,
+              const T& x) const;
+
+  template <typename T>
+  tt::remove_cvref_wrap_t<T> radius_inverse(const T& r) const;
+
+  friend bool operator==(const SphericalTorus& lhs, const SphericalTorus& rhs);
+
+  double r_min_ = std::numeric_limits<double>::signaling_NaN();
+  double r_max_ = std::numeric_limits<double>::signaling_NaN();
+  double pi_over_2_minus_theta_min_ =
+      std::numeric_limits<double>::signaling_NaN();
+  double fraction_of_torus_ = std::numeric_limits<double>::signaling_NaN();
+};
+
+bool operator!=(const SphericalTorus& lhs, const SphericalTorus& rhs);
+}  // namespace domain::CoordinateMaps

--- a/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
@@ -22,6 +22,7 @@ set(LIBRARY_SOURCES
   Test_ProductMaps.cpp
   Test_Rotation.cpp
   Test_SpecialMobius.cpp
+  Test_SphericalTorus.cpp
   Test_Tags.cpp
   Test_TimeDependentHelpers.cpp
   Test_UniformCylindricalEndcap.cpp

--- a/tests/Unit/Domain/CoordinateMaps/Test_SphericalTorus.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_SphericalTorus.cpp
@@ -1,0 +1,120 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <random>
+
+#include "Domain/CoordinateMaps/SphericalTorus.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp"
+#include "Utilities/StdArrayHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.SphericalTorus",
+                  "[Domain][Unit]") {
+  // check parse errors first
+  CHECK_THROWS_WITH(
+      ([]() { domain::CoordinateMaps::SphericalTorus(-1.0, 2.0, 0.1, 0.5); })(),
+      Catch::Contains("Minimum radius must be positive."));
+  CHECK_THROWS_WITH(
+      ([]() { domain::CoordinateMaps::SphericalTorus(3.0, 2.0, 0.1, 0.5); })(),
+      Catch::Contains("Maximum radius must be greater than minimum radius."));
+  CHECK_THROWS_WITH(
+      ([]() { domain::CoordinateMaps::SphericalTorus(1.0, 2.0, 10.0, 0.5); })(),
+      Catch::Contains("Minimum polar angle should be less than pi/2."));
+  CHECK_THROWS_WITH(
+      ([]() { domain::CoordinateMaps::SphericalTorus(1.0, 2.0, -0.1, 0.5); })(),
+      Catch::Contains("Minimum polar angle should be positive"));
+  CHECK_THROWS_WITH(
+      ([]() { domain::CoordinateMaps::SphericalTorus(1.0, 2.0, 0.1, -0.5); })(),
+      Catch::Contains("Fraction of torus included must be positive."));
+  CHECK_THROWS_WITH(
+      ([]() { domain::CoordinateMaps::SphericalTorus(1.0, 2.0, 0.1, 2.0); })(),
+      Catch::Contains("Fraction of torus included must be at most 1."));
+
+  // check constructor
+  CHECK(domain::CoordinateMaps::SphericalTorus(std::array<double, 2>{1.0, 2.0},
+                                               0.1, 0.5) ==
+        domain::CoordinateMaps::SphericalTorus(1.0, 2.0, 0.1, 0.5));
+
+  MAKE_GENERATOR(gen);
+  const double r_min = std::uniform_real_distribution<>(1.0, 2.0)(gen);
+  const double r_max = std::uniform_real_distribution<>(3.0, 4.0)(gen);
+  const double phi_max = std::uniform_real_distribution<>(0.5, 1.0)(gen);
+  const double fraction_of_torus =
+      std::uniform_real_distribution<>(0.1, 1.0)(gen);
+
+  const domain::CoordinateMaps::SphericalTorus full_torus(r_min, r_max,
+                                                          phi_max);
+  const domain::CoordinateMaps::SphericalTorus partial_torus(
+      r_min, r_max, phi_max, fraction_of_torus);
+
+  // Can't do for full_torus because it is not invertable on the boundary.
+  test_suite_for_map_on_unit_cube(partial_torus);
+
+  {
+    const double x = std::uniform_real_distribution<>(-1.0, 1.0)(gen);
+    const double y = std::uniform_real_distribution<>(-1.0, 1.0)(gen);
+    CHECK_ITERABLE_APPROX(full_torus(std::array{x, y, -1.0}),
+                          full_torus(std::array{x, y, 1.0}));
+  }
+  {
+    const double x = std::uniform_real_distribution<>(-1.0, 1.0)(gen);
+    const double y1 = std::uniform_real_distribution<>(-1.0, 1.0)(gen);
+    const double y2 = std::uniform_real_distribution<>(-1.0, 1.0)(gen);
+    const double z1 = std::uniform_real_distribution<>(-1.0, 1.0)(gen);
+    const double z2 = std::uniform_real_distribution<>(-1.0, 1.0)(gen);
+    CHECK(magnitude(partial_torus(std::array{x, y1, z1})) ==
+          approx(magnitude(partial_torus(std::array{x, y2, z2}))));
+  }
+
+  test_coordinate_map_implementation(full_torus);
+  test_coordinate_map_implementation(partial_torus);
+
+  CHECK(full_torus == full_torus);
+  CHECK_FALSE(full_torus != full_torus);
+  CHECK(partial_torus == partial_torus);
+  CHECK_FALSE(partial_torus != partial_torus);
+  CHECK_FALSE(full_torus == partial_torus);
+  CHECK(full_torus != partial_torus);
+
+  CHECK(full_torus !=
+        domain::CoordinateMaps::SphericalTorus(r_min + 0.1, r_max, phi_max));
+  CHECK(full_torus !=
+        domain::CoordinateMaps::SphericalTorus(r_min, r_max + 0.1, phi_max));
+  CHECK(full_torus !=
+        domain::CoordinateMaps::SphericalTorus(r_min, r_max, phi_max + 0.1));
+
+  CHECK(not full_torus.is_identity());
+  CHECK(not partial_torus.is_identity());
+
+  {
+    std::uniform_real_distribution<> dist(-1.0, 1.0);
+    const auto test_point = make_with_random_values<std::array<double, 3>>(
+        make_not_null(&gen), make_not_null(&dist), double{});
+
+    const auto analytic = partial_torus.hessian(test_point);
+    const auto analytic_inverse =
+        partial_torus.derivative_of_inv_jacobian(test_point);
+    for (size_t i = 0; i < 3; ++i) {
+      CAPTURE(i);
+      for (size_t j = 0; j < 3; ++j) {
+        CAPTURE(j);
+        for (size_t k = 0; k < 3; ++k) {
+          CAPTURE(k);
+          const auto numerical = numerical_derivative(
+              [&i, &j, &partial_torus](const std::array<double, 3>& x) {
+                return std::array{partial_torus.jacobian(x).get(i, j),
+                                  partial_torus.inv_jacobian(x).get(i, j)};
+              },
+              test_point, k, 1e-2);
+          auto deriv_approx = Approx::custom().epsilon(1.0e-9).scale(1.0);
+          CHECK(analytic.get(i, j, k) == deriv_approx(numerical[0]));
+          CHECK(analytic_inverse.get(i, j, k) == deriv_approx(numerical[1]));
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Proposed changes

Merging spherical torus map written by @wthrowe [(original commit)](https://github.com/wthrowe/spectre/commit/de93cca0ac817cda0e857726af97b89adb7deea6?diff=unified) in accretion disk branch.

The first commit is same as the old commit only with removing `noexcepts`. All the additional changes I made is included in the second commit. Added docs and renamed `PhiMax` to `MinPolarAngle` to avoid confusion in spherical coordinate notation in user level. Once review is finished I'll squash these two commits into one.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
