### PR TITLE
Print pretty wall time in ERROR and Informer

### DIFF
--- a/src/Informer/Informer.cpp
+++ b/src/Informer/Informer.cpp
@@ -27,7 +27,7 @@ void Informer::print_exit_info() {
   Parallel::printf(
       "\n"
       "Done!\n"
-      "Wall time in seconds: %f\n"
+      "Wall time: %s\n"
       "Date and time at completion: %s\n",
-      sys::wall_time(), current_date_and_time());
+      sys::pretty_wall_time(), current_date_and_time());
 }

--- a/src/Utilities/ErrorHandling/AbortWithErrorMessage.cpp
+++ b/src/Utilities/ErrorHandling/AbortWithErrorMessage.cpp
@@ -79,7 +79,8 @@ template <bool ShowTrace>
     os << "Shortened stack trace is:\n"
        << FillBacktrace{} << "End shortened stack trace.\n\n";
   }
-  os << "Node: " << sys::my_node() << " Proc: " << sys::my_proc() << "\n"
+  os << "Wall time: " << sys::pretty_wall_time() << "\n"
+     << "Node: " << sys::my_node() << " Proc: " << sys::my_proc() << "\n"
      << "Line: " << line << " of " << file << "\n"
      << "Function: " << pretty_function << "\n"
      << message << "\n"
@@ -98,6 +99,7 @@ void abort_with_error_message(const char* expression, const char* file,
      << "############ ASSERT FAILED ############\n"
      << "Shortened stack trace is:\n"
      << FillBacktrace{} << "End shortened stack trace.\n\n"
+     << "Wall time: " << sys::pretty_wall_time() << "\n"
      << "Node: " << sys::my_node() << " Proc: " << sys::my_proc() << "\n"
      << "Line: " << line << " of " << file << "\n"
      << "'" << expression << "' violated!\n"

--- a/src/Utilities/System/CMakeLists.txt
+++ b/src/Utilities/System/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   Abort.cpp
+  ParallelInfo.cpp
   )
 
 spectre_target_headers(

--- a/src/Utilities/System/ParallelInfo.cpp
+++ b/src/Utilities/System/ParallelInfo.cpp
@@ -1,0 +1,40 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <iomanip>
+#include <sstream>
+
+#include "Utilities/System/ParallelInfo.hpp"
+
+namespace sys {
+
+std::string pretty_wall_time(const double total_seconds) {
+  // Subseconds don't really matter so just ignore them. This gives nice round
+  // numbers.
+  int total = static_cast<int>(total_seconds);
+  const int day = total / (24 * 3600);
+
+  total %= (24 * 3600);
+  const int hour = total / 3600;
+
+  total %= 3600;
+  const int minutes = total / 60;
+
+  total %= 60;
+  const int seconds = total;
+
+  std::stringstream ss{};
+  ss << std::setfill('0');
+  if (day > 0) {
+    ss << std::setw(2) << day << "-";
+  }
+
+  // std::setw() isn't sticky so it has to be used for every insertion
+  ss << std::setw(2) << hour << ":";
+  ss << std::setw(2) << minutes << ":";
+  ss << std::setw(2) << seconds;
+  return ss.str();
+}
+
+std::string pretty_wall_time() { return pretty_wall_time(sys::wall_time()); }
+}  // namespace sys

--- a/src/Utilities/System/ParallelInfo.hpp
+++ b/src/Utilities/System/ParallelInfo.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <charm++.h>
+#include <string>
 
 namespace sys {
 /*!
@@ -92,4 +93,14 @@ inline int local_rank_of(const int proc_index) {
  * \brief The elapsed wall time in seconds.
  */
 inline double wall_time() { return CkWallTimer(); }
+
+/// @{
+/// \ingroup UtilitiesGroup
+/// \brief Format the wall time in DD-HH:MM:SS format.
+///
+/// If the walltime is shorter than a day, omit the `DD-` part.
+std::string pretty_wall_time(double total_seconds);
+
+std::string pretty_wall_time();
+/// @}
 }  // namespace sys

--- a/tests/Unit/Utilities/CMakeLists.txt
+++ b/tests/Unit/Utilities/CMakeLists.txt
@@ -29,6 +29,7 @@ set(LIBRARY_SOURCES
   Test_Numeric.cpp
   Test_OptionalHelpers.cpp
   Test_Overloader.cpp
+  Test_ParallelInfo.cpp
   Test_PrettyType.cpp
   Test_ProtocolHelpers.cpp
   Test_Rational.cpp

--- a/tests/Unit/Utilities/Test_FileSystem.cpp
+++ b/tests/Unit/Utilities/Test_FileSystem.cpp
@@ -135,6 +135,7 @@ void test() {
                                            "Test_FileSystem.cpp",
                                            "Test_Gsl.cpp",
                                            "Test_Requires.cpp",
+                                           "Test_ParallelInfo.cpp",
                                            "Test_CachedFunction.cpp",
                                            "Test_EqualWithinRoundoff.cpp",
                                            "Test_Numeric.cpp",

--- a/tests/Unit/Utilities/Test_ParallelInfo.cpp
+++ b/tests/Unit/Utilities/Test_ParallelInfo.cpp
@@ -1,0 +1,30 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "Utilities/System/ParallelInfo.hpp"
+
+namespace sys {
+namespace {
+
+void test_time(const double seconds, const std::string& expected) {
+  const std::string result = sys::pretty_wall_time(seconds);
+  CHECK(result == expected);
+}
+
+void test() {
+  test_time(43.0, "00:00:43");
+  test_time(43.9, "00:00:43");
+  test_time(2589.3, "00:43:09");
+  test_time(10001.5, "02:46:41");
+  test_time(123456.7, "01-10:17:36");
+}
+
+SPECTRE_TEST_CASE("Unit.Utilities.ParallelInfo", "[Unit][Utilities]") {
+  test();
+}
+}  // namespace
+}  // namespace sys


### PR DESCRIPTION
## Proposed changes

Previously, if we had encountered a runtime error, we wouldn't know how long a run actually took because the Informer was never called (or you'd have to look in the Slurm job history). Now we do.

Also make the wall time that's printed pretty instead of just the number of seconds. This is nice for long runs.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
