### PR TITLE
Only print phase control phase change if phase is actually different

### DIFF
--- a/src/Parallel/Main.hpp
+++ b/src/Parallel/Main.hpp
@@ -647,7 +647,12 @@ void Main<Metavariables>::execute_next_phase() {
       make_not_null(&phase_change_decision_data_), current_phase_,
       *Parallel::local_branch(global_cache_proxy_));
   if (next_phase.has_value()) {
-    current_phase_ = next_phase.value();
+    // Only print info if there was an actual phase change.
+    if (current_phase_ != next_phase.value()) {
+      Parallel::printf("Entering phase from phase control: %s\n",
+                       next_phase.value());
+      current_phase_ = next_phase.value();
+    }
   } else {
     const auto& default_order = Metavariables::default_phase_order;
     auto it = alg::find(default_order, current_phase_);
@@ -665,9 +670,9 @@ void Main<Metavariables>::execute_next_phase() {
             << default_order << "\n");
     }
     current_phase_ = *std::next(it);
-  }
 
-  Parallel::printf("Entering phase: %s\n", current_phase_);
+    Parallel::printf("Entering phase: %s\n", current_phase_);
+  }
 
   if (Parallel::Phase::Exit == current_phase_) {
     Informer::print_exit_info();


### PR DESCRIPTION
## Proposed changes

This is to avoid lots of output whenever the phase change trigger is checked often. Previously in release mode, my output file looks like:

```
ControlSystemAhA: t=0: its=27: -7.0e-07<R<9e-07, |R|=1e-09, |R_grid|=2e-07, 0.4835<r<0.4868
ControlSystemAhB: t=0: its=27: -7.1e-07<R<9e-07, |R|=1e-09, |R_grid|=2e-07, 0.4835<r<0.4868
Entering phase: Evolve
Entering phase: Evolve
Entering phase: Evolve
Entering phase: Evolve
Entering phase: Evolve
Entering phase: Evolve
Entering phase: Evolve
Entering phase: Evolve
Entering phase: Evolve
Entering phase: Evolve
Entering phase: Evolve
Entering phase: Evolve
Entering phase: Evolve
Entering phase: Evolve
Entering phase: Evolve
ControlSystemAhA: t=0.015: its=9: -6.5e-07<R<8e-07, |R|=1e-09, |R_grid|=2e-07, 0.4835<r<0.4868
ControlSystemAhB: t=0.015: its=9: -6.5e-07<R<8e-07, |R|=1e-09, |R_grid|=2e-07, 0.4835<r<0.4868
```

Now, it'll only print if the phase control actually changed phases.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
