### PR TITLE
Support cleanup on termination

### DIFF
--- a/src/Parallel/Main.ci
+++ b/src/Parallel/Main.ci
@@ -3,6 +3,8 @@
 
 module Main {
 
+  include "string";
+
   include "Parallel/ReductionDeclare.hpp";
   include "Utilities/Functional.hpp";
   include "Utilities/TaggedTuple.hpp";
@@ -23,6 +25,7 @@ module Main {
     entry void execute_next_phase();
     entry void start_load_balance();
     entry void start_write_checkpoint();
+    entry void add_exception_message(std::string exception_message);
   }
 
   namespace detail {

--- a/src/Parallel/Main.hpp
+++ b/src/Parallel/Main.hpp
@@ -135,11 +135,6 @@ class Main : public CBase_Main<Metavariables> {
       Parallel::get_option_tags<mutable_global_cache_tags, Metavariables>,
       tmpl::transform<component_list,
                       tmpl::bind<parallel_component_options, tmpl::_1>>>>>;
-  using parallel_component_tag_list = tmpl::transform<
-      component_list,
-      tmpl::bind<
-          tmpl::type_,
-          tmpl::bind<Parallel::proxy_from_parallel_component, tmpl::_1>>>;
   // Lists of all parallel component types
   using group_component_list =
       tmpl::filter<component_list, tmpl::or_<Parallel::is_group<tmpl::_1>,
@@ -450,6 +445,11 @@ Main<Metavariables>::Main(CkArgMsg* msg) {
   at_sync_indicator_proxy_[0].insert(this->thisProxy, sys::my_proc());
   at_sync_indicator_proxy_.doneInserting();
 
+  using parallel_component_tag_list = tmpl::transform<
+      component_list,
+      tmpl::bind<
+          tmpl::type_,
+          tmpl::bind<Parallel::proxy_from_parallel_component, tmpl::_1>>>;
   tuples::tagged_tuple_from_typelist<parallel_component_tag_list>
       the_parallel_components;
 

--- a/src/Parallel/Phase.cpp
+++ b/src/Parallel/Phase.cpp
@@ -24,6 +24,7 @@ std::vector<Phase> known_phases() {
           Phase::InitializeInitialDataDependentQuantities,
           Phase::InitializeTimeStepperHistory,
           Phase::LoadBalancing,
+          Phase::PostFailureCleanup,
           Phase::Register,
           Phase::RegisterWithElementDataReader,
           Phase::Solve,
@@ -51,6 +52,8 @@ std::ostream& operator<<(std::ostream& os, const Phase& phase) {
       return os << "InitializeTimeStepperHistory";
     case Parallel::Phase::LoadBalancing:
       return os << "LoadBalancing";
+    case Parallel::Phase::PostFailureCleanup:
+      return os << "PostFailureCleanup";
     case Parallel::Phase::Register:
       return os << "Register";
     case Parallel::Phase::RegisterWithElementDataReader:

--- a/src/Parallel/Phase.hpp
+++ b/src/Parallel/Phase.hpp
@@ -67,6 +67,9 @@ enum class Phase {
   InitializeTimeStepperHistory,
   ///  phase in which components are migrated
   LoadBalancing,
+  ///  phase in which components know an error occurred and they need to do some
+  ///  sort of cleanup, such as dumping data to disk.
+  PostFailureCleanup,
   ///  phase in which components register with other components
   Register,
   ///  phase in which components register with the data importer components


### PR DESCRIPTION
## Proposed changes

We want to be able to dump data when a simulation fails (or do some other sort of postmortem analysis). The changes in this PR make it so that we delay terminating from an uncaught exception until quiescence is detected (we tell all components to stop so quiescence will occur). A `PostFailureCleanup` phase is also added that can be used to do a more complete cleanup if desired, but simple actions can be used for cleanup even without that (e.g. to have the AH finder tell the interpolators to dump data).

I will add support for verifying that deadlock didn't occur in a separate PR.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
