### PR TITLE
Add missing target link libraries to SetupPch.cmake

### DIFF
--- a/cmake/SetupPch.cmake
+++ b/cmake/SetupPch.cmake
@@ -179,6 +179,9 @@ if (USE_PCH)
     PUBLIC
     Blaze
     Brigand
+    Charmxx::charmxx
+    Charmxx::pup
+    hdf5::hdf5
     )
   target_include_directories(
     ${SPECTRE_PCH_LIB}


### PR DESCRIPTION
## Proposed changes

Add missing libraries to SetupPch.cmake to avoid potential trouble building with precompiled headers. I encountered such problems on ocean. Thanks @nilsdeppe for suggesting the actual fixes!

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
