### PR TITLE
Treat deadlock/hangs in iterable actions as failed execution

### DIFF
--- a/src/Parallel/Algorithms/AlgorithmArray.ci
+++ b/src/Parallel/Algorithms/AlgorithmArray.ci
@@ -80,5 +80,7 @@ module AlgorithmArray {
 
     template <typename ThisAction, typename PhaseIndex, typename DataBoxIndex>
     entry[local] bool invoke_iterable_action();
+
+    entry void contribute_termination_status_to_main();
   }
 }

--- a/src/Parallel/Algorithms/AlgorithmGroup.ci
+++ b/src/Parallel/Algorithms/AlgorithmGroup.ci
@@ -36,5 +36,7 @@ module AlgorithmGroup {
                                      bool enable_if_disabled = false);
 
     entry void set_terminate(bool);
+
+    entry void contribute_termination_status_to_main();
   }
 }

--- a/src/Parallel/Algorithms/AlgorithmNodegroup.ci
+++ b/src/Parallel/Algorithms/AlgorithmNodegroup.ci
@@ -42,5 +42,7 @@ module AlgorithmNodegroup {
                                      bool enable_if_disabled = false);
 
     entry void set_terminate(bool);
+
+    entry void contribute_termination_status_to_main();
   }
 }

--- a/src/Parallel/Algorithms/AlgorithmSingleton.ci
+++ b/src/Parallel/Algorithms/AlgorithmSingleton.ci
@@ -37,5 +37,7 @@ module AlgorithmSingleton {
                                      bool enable_if_disabled = false);
 
     entry void set_terminate(bool);
+
+    entry void contribute_termination_status_to_main();
   }
 }

--- a/src/Parallel/Main.ci
+++ b/src/Parallel/Main.ci
@@ -22,6 +22,9 @@ module Main {
             std::index_sequence<>>>
             reduction_data);
 
+    entry [reductiontarget] void did_all_elements_terminate(
+        bool all_elements_terminated);
+
     entry void execute_next_phase();
     entry void start_load_balance();
     entry void start_write_checkpoint();

--- a/src/Parallel/Main.ci
+++ b/src/Parallel/Main.ci
@@ -29,6 +29,7 @@ module Main {
     entry void start_load_balance();
     entry void start_write_checkpoint();
     entry void add_exception_message(std::string exception_message);
+    entry void post_deadlock_analysis_termination();
   }
 
   namespace detail {

--- a/src/Parallel/Main.hpp
+++ b/src/Parallel/Main.hpp
@@ -38,6 +38,7 @@
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/FileSystem.hpp"
 #include "Utilities/Formaline.hpp"
+#include "Utilities/MakeString.hpp"
 #include "Utilities/Overloader.hpp"
 #include "Utilities/StdHelpers.hpp"
 #include "Utilities/System/Exit.hpp"
@@ -119,6 +120,14 @@ class Main : public CBase_Main<Metavariables> {
   /// quiescence occurs soon after the exception is reported.
   void add_exception_message(std::string exception_message);
 
+  /// A reduction target used to determine if all the elements of the array,
+  /// group, nodegroup, or singleton parallel components terminated
+  /// successfully.
+  ///
+  /// This allows detecting deadlocks in iterable actions, but not simple or
+  /// reduction action.
+  void did_all_elements_terminate(bool all_elements_terminated);
+
  private:
   // Return the dir name for the next Charm++ checkpoint as well as the pieces
   // from which the name is built up: the basename and the padding. This is a
@@ -132,6 +141,11 @@ class Main : public CBase_Main<Metavariables> {
 
   // Check if future checkpoint dirs are available; error if any already exist.
   void check_future_checkpoint_dirs_available() const;
+
+  // Starts a reduction on the component specified by
+  // the current_termination_check_index_ member variable, then increment
+  // current_termination_check_index_
+  void check_if_component_terminated_correctly();
 
   template <typename ParallelComponent>
   using parallel_component_options =
@@ -175,6 +189,10 @@ class Main : public CBase_Main<Metavariables> {
   Parallel::ResourceInfo<Metavariables> resource_info_{};
   // All exception errors we've received so far.
   std::vector<std::string> exception_messages_{};
+  // Used to keep track of which parallel component we are checking has
+  // successfully terminated.
+  size_t current_termination_check_index_{0};
+  std::vector<std::string> components_that_did_not_terminate_{};
 };
 
 namespace detail {
@@ -568,6 +586,8 @@ void Main<Metavariables>::pup(PUP::er& p) {  // NOLINT
   p | checkpoint_dir_counter_;
   p | resource_info_;
   p | exception_messages_;
+  p | current_termination_check_index_;
+  p | components_that_did_not_terminate_;
   if (p.isUnpacking()) {
     check_future_checkpoint_dirs_available();
   }
@@ -713,8 +733,8 @@ void Main<Metavariables>::execute_next_phase() {
   }
 
   if (Parallel::Phase::Exit == current_phase_) {
-    Informer::print_exit_info();
-    sys::exit();
+    check_if_component_terminated_correctly();
+    return;
   }
   tmpl::for_each<component_list>([this](auto parallel_component) {
     tmpl::type_from<decltype(parallel_component)>::execute_next_phase(
@@ -797,6 +817,59 @@ void Main<Metavariables>::add_exception_message(std::string exception_message) {
         Parallel::get_parallel_component<component_tag>(*global_cache)
             .set_terminate(true);
       });
+}
+
+template <typename Metavariables>
+void Main<Metavariables>::did_all_elements_terminate(
+    const bool all_elements_terminated) {
+  if (not all_elements_terminated) {
+    tmpl::for_each<component_list>([this](auto component_tag_v) {
+      using component_tag = tmpl::type_from<decltype(component_tag_v)>;
+      if (tmpl::index_of<component_list, component_tag>::value ==
+          current_termination_check_index_ - 1) {
+        components_that_did_not_terminate_.push_back(
+            pretty_type::name<component_tag>());
+      }
+    });
+  }
+  if (current_termination_check_index_ == tmpl::size<component_list>::value) {
+    if (not components_that_did_not_terminate_.empty()) {
+      using ::operator<<;
+      // Need the MakeString to avoid GCC compilation failure that it can't
+      // print out the vector...
+      Parallel::printf(
+          "\n############ ERROR ############\n"
+          "The following components did not terminate cleanly:\n"
+          "%s\n\n"
+          "This means the executable stopped because of a hang/deadlock.\n"
+          "############ ERROR ############\n\n",
+          std::string{MakeString{} << components_that_did_not_terminate_});
+    }
+    Informer::print_exit_info();
+    if (not components_that_did_not_terminate_.empty()) {
+      sys::abort("");
+    } else {
+      sys::exit();
+    }
+  }
+
+  check_if_component_terminated_correctly();
+}
+
+template <typename Metavariables>
+void Main<Metavariables>::check_if_component_terminated_correctly() {
+  auto* global_cache = Parallel::local_branch(global_cache_proxy_);
+  ASSERT(global_cache != nullptr, "Could not retrieve the local global cache.");
+
+  tmpl::for_each<component_list>([global_cache, this](auto component_tag_v) {
+    using component_tag = tmpl::type_from<decltype(component_tag_v)>;
+    if (tmpl::index_of<component_list, component_tag>::value ==
+        current_termination_check_index_) {
+      Parallel::get_parallel_component<component_tag>(*global_cache)
+          .contribute_termination_status_to_main();
+    }
+  });
+  current_termination_check_index_++;
 }
 
 template <typename Metavariables>

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -100,6 +100,12 @@ add_algorithm_test("AlgorithmNodelock")
 add_algorithm_test("AlgorithmParallel")
 add_algorithm_test("AlgorithmReduction")
 add_algorithm_test("Callback")
+add_algorithm_test("DetectHangArray"
+  REGEX_TO_MATCH
+  "The following components did not terminate cleanly:(.|\r|\n)*"
+  "\(ArrayComponent,SingletonComponent,GroupComponent,NodegroupComponent\)"
+  "(.|\r|\n)*"
+  "This means the executable stopped because of a hang/deadlock\.")
 add_algorithm_test("DynamicInsertion")
 add_algorithm_test("PhaseChangeMain")
 add_algorithm_test(

--- a/tests/Unit/Parallel/Test_AlgorithmLocalSyncAction.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmLocalSyncAction.cpp
@@ -27,6 +27,7 @@
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
+#include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MemoryHelpers.hpp"
@@ -221,6 +222,7 @@ struct ArrayComponent {
         Parallel::get_parallel_component<ArrayComponent>(local_cache);
     // we only want one array component for this test.
     array_proxy[0].insert(global_cache, tuples::TaggedTuple<>{}, 0);
+    array_proxy.doneInserting();
   }
 
   static void execute_next_phase(
@@ -249,7 +251,8 @@ struct TestMetavariables {
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{
-    &setup_error_handling, &setup_memory_allocation_failure_reporting};
+    &setup_error_handling, &setup_memory_allocation_failure_reporting,
+    &disable_openblas_multithreading};
 static const std::vector<void (*)()> charm_init_proc_funcs{
     &enable_floating_point_exceptions};
 

--- a/tests/Unit/Parallel/Test_DetectHangArray.cpp
+++ b/tests/Unit/Parallel/Test_DetectHangArray.cpp
@@ -1,0 +1,172 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#define CATCH_CONFIG_RUNNER
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <optional>
+#include <tuple>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Parallel/AlgorithmExecution.hpp"
+#include "Parallel/Algorithms/AlgorithmArray.hpp"
+#include "Parallel/Algorithms/AlgorithmGroup.hpp"
+#include "Parallel/Algorithms/AlgorithmNodegroup.hpp"
+#include "Parallel/Algorithms/AlgorithmSingleton.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/Local.hpp"
+#include "Parallel/Main.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Utilities/Blas.hpp"
+#include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MemoryHelpers.hpp"
+#include "Utilities/System/ParallelInfo.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace PUP {
+class er;
+}  // namespace PUP
+
+namespace DetectHang {
+struct Hang {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTagsList>& /*box*/,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    return {Parallel::AlgorithmExecution::Retry, std::nullopt};
+  }
+};
+
+template <class Metavariables>
+struct NodegroupComponent {
+  using chare_type = Parallel::Algorithms::Nodegroup;
+  using metavariables = Metavariables;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Evolve, tmpl::list<Hang>>>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+
+  static void execute_next_phase(
+      const Parallel::Phase next_phase,
+      const Parallel::CProxy_GlobalCache<Metavariables>& global_cache) {
+    auto& local_cache = *Parallel::local_branch(global_cache);
+    Parallel::get_parallel_component<NodegroupComponent>(local_cache)
+        .start_phase(next_phase);
+  }
+};
+
+template <class Metavariables>
+struct GroupComponent {
+  using chare_type = Parallel::Algorithms::Group;
+  using metavariables = Metavariables;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Evolve, tmpl::list<Hang>>>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+
+  static void execute_next_phase(
+      const Parallel::Phase next_phase,
+      const Parallel::CProxy_GlobalCache<Metavariables>& global_cache) {
+    auto& local_cache = *Parallel::local_branch(global_cache);
+    Parallel::get_parallel_component<GroupComponent>(local_cache)
+        .start_phase(next_phase);
+  }
+};
+
+template <class Metavariables>
+struct SingletonComponent {
+  using chare_type = Parallel::Algorithms::Singleton;
+  using metavariables = Metavariables;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Evolve, tmpl::list<Hang>>>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+
+  static void execute_next_phase(
+      const Parallel::Phase next_phase,
+      const Parallel::CProxy_GlobalCache<Metavariables>& global_cache) {
+    auto& local_cache = *Parallel::local_branch(global_cache);
+    Parallel::get_parallel_component<SingletonComponent>(local_cache)
+        .start_phase(next_phase);
+  }
+};
+
+template <class Metavariables>
+struct ArrayComponent {
+  using chare_type = Parallel::Algorithms::Array;
+  using metavariables = Metavariables;
+  using array_index = int;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Evolve, tmpl::list<Hang>>>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+
+  static void allocate_array(
+      Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
+      const tuples::tagged_tuple_from_typelist<initialization_tags>&
+      /*initialization_items*/,
+      const std::unordered_set<size_t>& /*procs_to_ignore*/ = {}) {
+    auto& local_cache = *Parallel::local_branch(global_cache);
+    auto& array_proxy =
+        Parallel::get_parallel_component<ArrayComponent>(local_cache);
+    // we only want one array component for this test.
+    array_proxy[0].insert(global_cache, tuples::TaggedTuple<>{}, 0);
+    array_proxy.doneInserting();
+  }
+
+  static void execute_next_phase(
+      const Parallel::Phase next_phase,
+      const Parallel::CProxy_GlobalCache<Metavariables>& global_cache) {
+    auto& local_cache = *Parallel::local_branch(global_cache);
+    Parallel::get_parallel_component<ArrayComponent>(local_cache)
+        .start_phase(next_phase);
+  }
+};
+}  // namespace DetectHang
+
+struct TestMetavariables {
+  using component_list =
+      tmpl::list<DetectHang::ArrayComponent<TestMetavariables>,
+                 DetectHang::SingletonComponent<TestMetavariables>,
+                 DetectHang::GroupComponent<TestMetavariables>,
+                 DetectHang::NodegroupComponent<TestMetavariables>>;
+
+  static constexpr Options::String help = "";
+
+  static constexpr std::array<Parallel::Phase, 3> default_phase_order{
+      {Parallel::Phase::Initialization, Parallel::Phase::Evolve,
+       Parallel::Phase::Exit}};
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) {}
+};
+
+static const std::vector<void (*)()> charm_init_node_funcs{
+    &setup_error_handling, &setup_memory_allocation_failure_reporting,
+    &disable_openblas_multithreading};
+static const std::vector<void (*)()> charm_init_proc_funcs{
+    &enable_floating_point_exceptions};
+
+using charmxx_main_component = Parallel::Main<TestMetavariables>;
+
+#include "Parallel/CharmMain.tpp"  // IWYU pragma: keep


### PR DESCRIPTION
## Proposed changes

Only commit `Check that all components have terminated before exiting` is new.

Does a reduction over each component to check that `terminate` is set to `true` (the component has explicitly acknowledged it is done). All components are checked and it is reported which ones did not terminate cleanly. Currently a component is marked as `terminate==true` if there are no iterable actions in the algorithm. Since all simple, threaded, and reduction actions are guaranteed to have completed before we enter the `Exit` phase, this really can only check against deadlocks of iterable actions. However, this covers most use-cases.

Update:
I've added a commit that allows running simple actions to analyze why a deadlock occurs.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
