### PR TITLE
Make AlgorithmArray patch work with macOS 13

### DIFF
--- a/cmake/SetupCharmModuleFunctions.cmake
+++ b/cmake/SetupCharmModuleFunctions.cmake
@@ -11,7 +11,11 @@ function(add_charm_module MODULE)
     add_custom_target(module_All)
   endif()
 
-  set(_VERSION_SUFFIX "_v${CHARM_VERSION}")
+  if(APPLE)
+    set(_VERSION_SUFFIX "_macOS_v${CHARM_VERSION}")
+  else()
+    set(_VERSION_SUFFIX "_v${CHARM_VERSION}")
+  endif()
 
   add_custom_command(
     OUTPUT ${MODULE}.decl.h ${MODULE}.def.h

--- a/tools/CharmModulePatches/src/Parallel/Algorithms/AlgorithmArray_macOS_v7.0.0.def.h.patch
+++ b/tools/CharmModulePatches/src/Parallel/Algorithms/AlgorithmArray_macOS_v7.0.0.def.h.patch
@@ -1,0 +1,11 @@
+--- ./AlgorithmArray_orig.def.h	2022-06-16 14:42:37.978886843 -0700
++++ src/Parallel/Algorithms/AlgorithmArray.def.h	2022-06-16 14:43:04.995671535 -0700
+@@ -592,7 +592,7 @@
+   envelope env;
+   env.setMsgtype(ForArrayEltMsg);
+   env.setTotalsize(0);
+-  _TRACE_CREATION_DETAILED(&env, CkIndex_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::template idx_invoke_iterable_action_void<ThisAction, PhaseIndex, DataBoxIndex>());
++  _TRACE_CREATION_DETAILED(&env, (CkIndex_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::template idx_invoke_iterable_action_void<ThisAction, PhaseIndex, DataBoxIndex>()));
+   _TRACE_CREATION_DONE(1);
+   _TRACE_BEGIN_EXECUTE_DETAILED(CpvAccess(curPeEvent),ForArrayEltMsg,(CkIndex_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::template idx_invoke_iterable_action_void<ThisAction, PhaseIndex, DataBoxIndex>()),CkMyPe(), 0, ((CkArrayIndex&)ckGetIndex()).getProjectionID(), obj);
+ #if CMK_LBDB_ON


### PR DESCRIPTION
## Proposed changes

After upgrading to the macOS 13 public beta, I found that the charm patch for `AlgorithmArray.def.h` no longer worked; instead, I would get an error from the patch command that applying the patch failed.

The patch simply adds a pair of () on one line in `AlgorithmArray.def.h.`

I find that the following equivalent patch, differing only in updating the line numbers and in adding 3 lines of context on either side of the change, works for me on macOS 13.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
