### PR TITLE
Use angular ordering in Sphere intrp target

### DIFF
--- a/src/ParallelAlgorithms/Interpolation/Targets/AngularOrdering.cpp
+++ b/src/ParallelAlgorithms/Interpolation/Targets/AngularOrdering.cpp
@@ -1,0 +1,37 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ParallelAlgorithms/Interpolation/Targets/AngularOrdering.hpp"
+
+#include <string>
+
+#include "Options/Options.hpp"
+#include "Options/ParseOptions.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+
+namespace intrp {
+std::ostream& operator<<(std::ostream& os, const AngularOrdering ordering) {
+  switch (ordering) {
+    case AngularOrdering::Strahlkorper:
+      return os << "Strahlkorper";
+    case AngularOrdering::Cce:
+      return os << "Cce";
+    default:
+      ERROR("Unknown AngularOrdering type");
+  }
+}
+}  // namespace intrp
+
+template <>
+intrp::AngularOrdering
+Options::create_from_yaml<intrp::AngularOrdering>::create<void>(
+    const Options::Option& options) {
+  const auto ordering = options.parse_as<std::string>();
+  if (ordering == "Strahlkorper") {
+    return intrp::AngularOrdering::Strahlkorper;
+  } else if (ordering == "Cce") {
+    return intrp::AngularOrdering::Cce;
+  }
+  PARSE_ERROR(options.context(),
+              "AngularOrdering must be 'Strahlkorper' or 'Cce'");
+}

--- a/src/ParallelAlgorithms/Interpolation/Targets/AngularOrdering.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Targets/AngularOrdering.hpp
@@ -1,0 +1,39 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <ostream>
+
+/// \cond
+namespace Options {
+class Option;
+template <typename T>
+struct create_from_yaml;
+}  // namespace Options
+/// \endcond
+
+namespace intrp {
+/*!
+ * \brief Label for the ordering of spherical harmonic points on a sphere
+ *
+ * \details `%Strahlkorper` refers to points on a sphere ordered by SPHEREPACK
+ * because `Strahlkorper`s hold YlmSpherePacks internally. `%Cce` refers to
+ * points on a sphere ordered by Libsharp because Cce uses Libsharp internally.
+ */
+enum class AngularOrdering { Strahlkorper, Cce };
+std::ostream& operator<<(std::ostream& os, AngularOrdering ordering);
+}  // namespace intrp
+
+template <>
+struct Options::create_from_yaml<intrp::AngularOrdering> {
+  template <typename Metavariables>
+  static intrp::AngularOrdering create(const Options::Option& options) {
+    return create<void>(options);
+  }
+};
+
+template <>
+intrp::AngularOrdering
+Options::create_from_yaml<intrp::AngularOrdering>::create<void>(
+    const Options::Option& options);

--- a/src/ParallelAlgorithms/Interpolation/Targets/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Interpolation/Targets/CMakeLists.txt
@@ -4,6 +4,7 @@
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  AngularOrdering.cpp
   ApparentHorizon.cpp
   KerrHorizon.cpp
   LineSegment.cpp
@@ -16,6 +17,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  AngularOrdering.hpp
   ApparentHorizon.hpp
   KerrHorizon.hpp
   LineSegment.hpp

--- a/src/ParallelAlgorithms/Interpolation/Targets/KerrHorizon.cpp
+++ b/src/ParallelAlgorithms/Interpolation/Targets/KerrHorizon.cpp
@@ -12,13 +12,13 @@ namespace intrp::OptionHolders {
 KerrHorizon::KerrHorizon(size_t l_max_in, std::array<double, 3> center_in,
                          double mass_in,
                          std::array<double, 3> dimensionless_spin_in,
-                         const bool theta_varies_fastest_in,
+                         const intrp::AngularOrdering angular_ordering_in,
                          const Options::Context& context)
     : l_max(l_max_in),
       center(center_in),
       mass(mass_in),
       dimensionless_spin(dimensionless_spin_in),
-      theta_varies_fastest_memory_layout{theta_varies_fastest_in} {
+      angular_ordering{angular_ordering_in} {
   // above NOLINTs for std::move of trivially copyable type.
   if (mass <= 0.0) {
     // Check here, rather than put a lower_bound on the Tag, because
@@ -36,15 +36,14 @@ void KerrHorizon::pup(PUP::er& p) {
   p | center;
   p | mass;
   p | dimensionless_spin;
-  p | theta_varies_fastest_memory_layout;
+  p | angular_ordering;
 }
 
 bool operator==(const KerrHorizon& lhs, const KerrHorizon& rhs) {
   return lhs.l_max == rhs.l_max and lhs.center == rhs.center and
          lhs.mass == rhs.mass and
          lhs.dimensionless_spin == rhs.dimensionless_spin and
-         lhs.theta_varies_fastest_memory_layout ==
-             rhs.theta_varies_fastest_memory_layout;
+         lhs.angular_ordering == rhs.angular_ordering;
 }
 
 bool operator!=(const KerrHorizon& lhs, const KerrHorizon& rhs) {

--- a/src/ParallelAlgorithms/Interpolation/Targets/Sphere.cpp
+++ b/src/ParallelAlgorithms/Interpolation/Targets/Sphere.cpp
@@ -11,18 +11,24 @@
 
 namespace intrp::OptionHolders {
 Sphere::Sphere(const size_t l_max_in, const std::array<double, 3> center_in,
-               const double radius_in)
-    : l_max(l_max_in), center(center_in), radius(radius_in) {}
+               const double radius_in,
+               const intrp::AngularOrdering angular_ordering_in)
+    : l_max(l_max_in),
+      center(center_in),
+      radius(radius_in),
+      angular_ordering(angular_ordering_in) {}
 
 void Sphere::pup(PUP::er& p) {
   p | l_max;
   p | center;
   p | radius;
+  p | angular_ordering;
 }
 
 bool operator==(const Sphere& lhs, const Sphere& rhs) {
   return lhs.l_max == rhs.l_max and lhs.center == rhs.center and
-         lhs.radius == rhs.radius;
+         lhs.radius == rhs.radius and
+         lhs.angular_ordering == rhs.angular_ordering;
 }
 
 bool operator!=(const Sphere& lhs, const Sphere& rhs) {

--- a/src/ParallelAlgorithms/Interpolation/Targets/Sphere.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Targets/Sphere.hpp
@@ -8,6 +8,7 @@
 #include <limits>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Transpose.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Tags.hpp"
 #include "Options/Options.hpp"
@@ -15,6 +16,7 @@
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/ComputeTargetPoints.hpp"
 #include "ParallelAlgorithms/Interpolation/Tags.hpp"
+#include "ParallelAlgorithms/Interpolation/Targets/AngularOrdering.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 
@@ -41,7 +43,11 @@ namespace OptionHolders {
 /// A spherical surface.
 ///
 /// \details The parameter `Lmax` controls the number of collocation points on
-/// the spherical surface equal to `(l_max + 1) * (2 * l_max + 1)`
+/// the spherical surface equal to `(l_max + 1) * (2 * l_max + 1)`. The
+/// parameter `AngularOrdering` encodes the collocation ordering. For example,
+/// the apparent horizon finder relies on spherepack routines that require
+/// `Strahlkorper` for `AngularOrdering`, and using this surface for a CCE
+/// worldtube requires `Cce` for `AngularOrdering`.
 struct Sphere {
   struct Lmax {
     using type = size_t;
@@ -58,10 +64,15 @@ struct Sphere {
     static constexpr Options::String help = {"Radius of the sphere"};
     static constexpr double lower_bound() { return 0.; }
   };
-  using options = tmpl::list<Lmax, Center, Radius>;
+  struct AngularOrdering {
+    using type = intrp::AngularOrdering;
+    static constexpr Options::String help = {
+        "Chooses theta,phi ordering in 2d array"};
+  };
+  using options = tmpl::list<Lmax, Center, Radius, AngularOrdering>;
   static constexpr Options::String help = {"A spherical surface."};
   Sphere(const size_t l_max_in, const std::array<double, 3> center_in,
-         const double radius_in);
+         const double radius_in, intrp::AngularOrdering angular_ordering_in);
 
   Sphere() = default;
 
@@ -71,6 +82,7 @@ struct Sphere {
   size_t l_max{0};
   std::array<double, 3> center{std::numeric_limits<double>::signaling_NaN()};
   double radius{std::numeric_limits<double>::signaling_NaN()};
+  intrp::AngularOrdering angular_ordering;
 };
 
 bool operator==(const Sphere& lhs, const Sphere& rhs);
@@ -138,15 +150,32 @@ struct Sphere : tt::ConformsTo<intrp::protocols::ComputeTargetPoints> {
   template <typename Metavariables, typename DbTags, typename TemporalId>
   static tnsr::I<DataVector, 3, Frame> points(
       const db::DataBox<DbTags>& box,
-      const tmpl::type_<Metavariables>& /*meta*/,
+      const tmpl::type_<Metavariables>& metavariables_v,
       const TemporalId& /*temporal_id*/) {
-    return db::get<StrahlkorperTags::CartesianCoords<Frame>>(box);
+    return points(box, metavariables_v);
   }
   template <typename Metavariables, typename DbTags>
   static tnsr::I<DataVector, 3, Frame> points(
       const db::DataBox<DbTags>& box,
       const tmpl::type_<Metavariables>& /*meta*/) {
-    return db::get<StrahlkorperTags::CartesianCoords<Frame>>(box);
+    const auto& sphere = db::get<Tags::Sphere<InterpolationTargetTag>>(box);
+    if (sphere.angular_ordering == intrp::AngularOrdering::Strahlkorper) {
+      return db::get<StrahlkorperTags::CartesianCoords<Frame>>(box);
+    } else {
+      const auto& strahlkorper =
+          db::get<StrahlkorperTags::Strahlkorper<Frame>>(box);
+      const auto& coords =
+          db::get<StrahlkorperTags::CartesianCoords<Frame>>(box);
+      const auto physical_extents =
+          strahlkorper.ylm_spherepack().physical_extents();
+      auto transposed_coords =
+          tnsr::I<DataVector, 3, Frame>(get<0>(coords).size());
+      for (size_t i = 0; i < 3; ++i) {
+        transpose(make_not_null(&transposed_coords.get(i)), coords.get(i),
+                  physical_extents[0], physical_extents[1]);
+      }
+      return transposed_coords;
+    }
   }
 };
 

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
@@ -122,6 +122,7 @@ InterpolationTargets:
     Lmax: 10
     Center: [0., 0., 0.]
     Radius: 1.
+    AngularOrdering: Strahlkorper
 
 Observers:
   VolumeFileName: "PlaneWaveMinkowski3DVolume"

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -131,4 +131,4 @@ InterpolationTargets:
     Center: [0.0, 0.0, 0.0]
     Mass: *BhMass
     DimensionlessSpin: [0.0, 0.0, *BhDimlessSpin]
-    ThetaVariesFastest: true
+    AngularOrdering: Strahlkorper

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_IndefiniteIntegral.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_IndefiniteIntegral.cpp
@@ -60,7 +60,7 @@ void check_integration(const size_t min_pts, const size_t max_pts) {
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.NumericalAlgoriths.Spectral.IndefiniteIntegral",
+SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.IndefiniteIntegral",
                   "[NumericalAlgorithms][Spectral][Unit]") {
   check_integration<Basis::Chebyshev, Quadrature::GaussLobatto>(
       2, maximum_number_of_points<Basis::Chebyshev>);

--- a/tests/Unit/ParallelAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_ParallelInterpolation")
 
 set(LIBRARY_SOURCES
   Test_AddTemporalIdsToInterpolationTarget.cpp
+  Test_AngularOrdering.cpp
   Test_CleanUpInterpolator.cpp
   Test_ElementReceiveInterpPoints.cpp
   Test_InitializeInterpolationTarget.cpp

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_AngularOrdering.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_AngularOrdering.cpp
@@ -1,0 +1,22 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "Framework/TestCreation.hpp"
+#include "ParallelAlgorithms/Interpolation/Targets/AngularOrdering.hpp"
+#include "Utilities/GetOutput.hpp"
+
+namespace intrp {
+SPECTRE_TEST_CASE(
+    "Unit.NumericalAlgorithms.InterpolationTarget.AngularOrdering", "[Unit]") {
+  CHECK(get_output(AngularOrdering::Cce) == "Cce");
+  CHECK(get_output(AngularOrdering::Strahlkorper) == "Strahlkorper");
+  CHECK(TestHelpers::test_creation<AngularOrdering>("Cce") ==
+        AngularOrdering::Cce);
+  CHECK(TestHelpers::test_creation<AngularOrdering>("Strahlkorper") ==
+        AngularOrdering::Strahlkorper);
+}
+}  // namespace intrp

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetSphere.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetSphere.cpp
@@ -21,10 +21,12 @@
 #include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
+#include "ParallelAlgorithms/Interpolation/Targets/AngularOrdering.hpp"
 #include "ParallelAlgorithms/Interpolation/Targets/Sphere.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Time/Tags.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeString.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/Spherepack.hpp"
 #include "Utilities/TMPL.hpp"
@@ -54,20 +56,24 @@ struct MockMetavariables {
 };
 }  // namespace
 
-void test_interpolation_target_sphere() {
+void test_interpolation_target_sphere(
+    const intrp::AngularOrdering angular_ordering) {
   const size_t l_max = 18;
   const double radius = 3.6;
   const std::array<double, 3> center = {{0.05, 0.06, 0.07}};
 
   // Options for Sphere
-  intrp::OptionHolders::Sphere sphere_opts(l_max, center, radius);
+  intrp::OptionHolders::Sphere sphere_opts(l_max, center, radius,
+                                           angular_ordering);
 
   // Test creation of options
   const auto created_opts =
       TestHelpers::test_creation<intrp::OptionHolders::Sphere>(
           "Center: [0.05, 0.06, 0.07]\n"
           "Radius: 3.6\n"
-          "Lmax: 18");
+          "Lmax: 18\n"
+          "AngularOrdering: " +
+          std::string(MakeString{} << angular_ordering));
   CHECK(created_opts == sphere_opts);
 
   const auto domain_creator =
@@ -76,8 +82,8 @@ void test_interpolation_target_sphere() {
   TestHelpers::db::test_simple_tag<
       intrp::Tags::Sphere<MockMetavariables::InterpolationTargetA>>("Sphere");
 
-  const auto expected_block_coord_holders = [&domain_creator, &radius,
-                                             &center]() {
+  const auto expected_block_coord_holders = [&domain_creator, &radius, &center,
+                                             &angular_ordering]() {
     // How many points are supposed to be in a Strahlkorper,
     // reproduced here by hand for the test.
     const size_t n_theta = l_max + 1;
@@ -97,14 +103,27 @@ void test_interpolation_target_sphere() {
     const double two_pi_over_n_phi = 2.0 * M_PI / n_phi;
     tnsr::I<DataVector, 3, Frame::Inertial> points(n_theta * n_phi);
     size_t s = 0;
-    for (size_t i_phi = 0; i_phi < n_phi; ++i_phi) {
-      const double phi = two_pi_over_n_phi * i_phi;
+    if (angular_ordering == intrp::AngularOrdering::Strahlkorper) {
+      for (size_t i_phi = 0; i_phi < n_phi; ++i_phi) {
+        const double phi = two_pi_over_n_phi * i_phi;
+        for (size_t i_theta = 0; i_theta < n_theta; ++i_theta) {
+          const double theta = theta_points[i_theta];
+          points.get(0)[s] = radius * sin(theta) * cos(phi) + center[0];
+          points.get(1)[s] = radius * sin(theta) * sin(phi) + center[1],
+          points.get(2)[s] = radius * cos(theta) + center[2];
+          ++s;
+        }
+      }
+    } else {
       for (size_t i_theta = 0; i_theta < n_theta; ++i_theta) {
-        const double theta = theta_points[i_theta];
-        points.get(0)[s] = radius * sin(theta) * cos(phi) + center[0];
-        points.get(1)[s] = radius * sin(theta) * sin(phi) + center[1],
-        points.get(2)[s] = radius * cos(theta) + center[2];
-        ++s;
+        for (size_t i_phi = 0; i_phi < n_phi; ++i_phi) {
+          const double phi = two_pi_over_n_phi * i_phi;
+          const double theta = theta_points[i_theta];
+          points.get(0)[s] = radius * sin(theta) * cos(phi) + center[0];
+          points.get(1)[s] = radius * sin(theta) * sin(phi) + center[1],
+          points.get(2)[s] = radius * cos(theta) + center[2];
+          ++s;
+        }
       }
     }
     return block_logical_coordinates(domain_creator.create_domain(), points);
@@ -118,5 +137,6 @@ void test_interpolation_target_sphere() {
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.Sphere",
                   "[Unit]") {
   domain::creators::register_derived_with_charm();
-  test_interpolation_target_sphere();
+  test_interpolation_target_sphere(intrp::AngularOrdering::Cce);
+  test_interpolation_target_sphere(intrp::AngularOrdering::Strahlkorper);
 }

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveTimeSeriesAndSurfaceData.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveTimeSeriesAndSurfaceData.cpp
@@ -57,6 +57,7 @@
 #include "ParallelAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/PostInterpolationCallback.hpp"
+#include "ParallelAlgorithms/Interpolation/Targets/AngularOrdering.hpp"
 #include "ParallelAlgorithms/Interpolation/Targets/KerrHorizon.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
@@ -361,14 +362,18 @@ SPECTRE_TEST_CASE(
   using obs_writer = MockObserverWriter<metavars>;
 
   // Options for all InterpolationTargets.
-  intrp::OptionHolders::KerrHorizon kerr_horizon_opts_A(10, {{0.0, 0.0, 0.0}},
-                                                        1.0, {{0.0, 0.0, 0.0}});
-  intrp::OptionHolders::KerrHorizon kerr_horizon_opts_B(10, {{0.0, 0.0, 0.0}},
-                                                        2.0, {{0.0, 0.0, 0.0}});
-  intrp::OptionHolders::KerrHorizon kerr_horizon_opts_C(10, {{0.0, 0.0, 0.0}},
-                                                        1.5, {{0.0, 0.0, 0.0}});
+  intrp::OptionHolders::KerrHorizon kerr_horizon_opts_A(
+      10, {{0.0, 0.0, 0.0}}, 1.0, {{0.0, 0.0, 0.0}},
+      intrp::AngularOrdering::Strahlkorper);
+  intrp::OptionHolders::KerrHorizon kerr_horizon_opts_B(
+      10, {{0.0, 0.0, 0.0}}, 2.0, {{0.0, 0.0, 0.0}},
+      intrp::AngularOrdering::Strahlkorper);
+  intrp::OptionHolders::KerrHorizon kerr_horizon_opts_C(
+      10, {{0.0, 0.0, 0.0}}, 1.5, {{0.0, 0.0, 0.0}},
+      intrp::AngularOrdering::Strahlkorper);
   intrp::OptionHolders::KerrHorizon kerr_horizon_opts_D(
-      10, {{0.01, 0.02, 0.03}}, 1.4, {{0.0, 0.0, 0.0}});
+      10, {{0.01, 0.02, 0.03}}, 1.4, {{0.0, 0.0, 0.0}},
+      intrp::AngularOrdering::Strahlkorper);
   const auto domain_creator =
       domain::creators::Shell(0.9, 4.9, 1, {{5, 5}}, false);
   tuples::TaggedTuple<

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
@@ -46,6 +46,7 @@
 #include "ParallelAlgorithms/Interpolation/Protocols/ComputeVarsToInterpolate.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/PostInterpolationCallback.hpp"
+#include "ParallelAlgorithms/Interpolation/Targets/AngularOrdering.hpp"
 #include "ParallelAlgorithms/Interpolation/Targets/KerrHorizon.hpp"
 #include "ParallelAlgorithms/Interpolation/Targets/LineSegment.hpp"
 #include "Time/Slab.hpp"
@@ -297,8 +298,9 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.Integration",
       {{1.0, 1.0, 1.0}}, {{2.4, 2.4, 2.4}}, 15);
   intrp::OptionHolders::LineSegment<3> line_segment_opts_B(
       {{1.1, 1.1, 1.1}}, {{2.5, 2.5, 2.5}}, 17);
-  intrp::OptionHolders::KerrHorizon kerr_horizon_opts_C(10, {{0.0, 0.0, 0.0}},
-                                                        1.0, {{0.0, 0.0, 0.0}});
+  intrp::OptionHolders::KerrHorizon kerr_horizon_opts_C(
+      10, {{0.0, 0.0, 0.0}}, 1.0, {{0.0, 0.0, 0.0}},
+      intrp::AngularOrdering::Strahlkorper);
   const auto domain_creator =
       domain::creators::Shell(0.9, 4.9, 1, {{5, 5}}, false);
   tuples::TaggedTuple<


### PR DESCRIPTION
## Proposed changes

Previously, only the `KerrHorizon` target was able to have a different ordering for it's spherical harmonic points, making it the only target that could be used with CCE. Now you can also choose the angular ordering of the `Sphere` target, so it can also be used with CCE.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
