### PR TITLE
Remove Newton-Raphson from UniformCylindricalEndcap

### DIFF
--- a/src/Domain/CoordinateMaps/UniformCylindricalEndcap.cpp
+++ b/src/Domain/CoordinateMaps/UniformCylindricalEndcap.cpp
@@ -180,20 +180,20 @@ UniformCylindricalEndcap::UniformCylindricalEndcap(
       }()) {
   // Assumptions made in the map.  Some of these can be relaxed,
   // as long as the unit test is changed to test them.
-  ASSERT(z_plane_two >= z_plane_one + 0.03 * radius_one,
-         "z_plane_two must be >= z_plane_one + 0.03 * radius_one, not "
+  ASSERT(z_plane_two >= z_plane_one + 0.04 * radius_two,
+         "z_plane_two must be >= z_plane_one + 0.04 * radius_two, not "
              << z_plane_two << " " << z_plane_one << " "
-             << z_plane_one + 0.03 * radius_one);
+             << z_plane_one + 0.04 * radius_two);
   ASSERT(theta_max_one_ < M_PI * 0.45,
          "z_plane_one is too close to the center of sphere_one: theta/pi = "
              << theta_max_one_ / M_PI);
-  ASSERT(theta_max_one_ > M_PI * 0.05,
+  ASSERT(theta_max_one_ > M_PI * 0.075,
          "z_plane_one is too far from the center of sphere_one: theta/pi = "
              << theta_max_one_ / M_PI);
   ASSERT(theta_max_two_ < M_PI * 0.45,
          "z_plane_two is too close to the center of sphere_two: theta/pi = "
              << theta_max_two_ / M_PI);
-  ASSERT(theta_max_two_ > M_PI * 0.05,
+  ASSERT(theta_max_two_ > M_PI * 0.075,
          "z_plane_two is too far from the center of sphere_two: theta/pi = "
              << theta_max_two_ / M_PI);
 

--- a/src/Domain/CoordinateMaps/UniformCylindricalEndcap.cpp
+++ b/src/Domain/CoordinateMaps/UniformCylindricalEndcap.cpp
@@ -568,7 +568,7 @@ std::optional<std::array<double, 3>> UniformCylindricalEndcap::inverse(
     // roundoff_ratio to be much larger than actual roundoff, since it
     // doesn't hurt to expand the interval and try again when
     // otherwise we would just error.
-    constexpr double roundoff_ratio = 1.e-6;
+    constexpr double roundoff_ratio = 1.e-3;
     if (abs(function_at_rhobar_min) / abs(function_at_rhobar_max) <
         roundoff_ratio) {
       // Slightly decrease rhobar_min.  How far do we decrease it?

--- a/src/Domain/CoordinateMaps/UniformCylindricalEndcap.cpp
+++ b/src/Domain/CoordinateMaps/UniformCylindricalEndcap.cpp
@@ -12,7 +12,6 @@
 #include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/CylindricalEndcapHelpers.hpp"
-#include "NumericalAlgorithms/RootFinding/NewtonRaphson.hpp"
 #include "NumericalAlgorithms/RootFinding/TOMS748.hpp"
 #include "Parallel/PupStlCpp11.hpp"
 #include "Utilities/ConstantExpressions.hpp"
@@ -407,7 +406,8 @@ std::optional<std::array<double, 3>> UniformCylindricalEndcap::inverse(
         return std::make_pair(func_to_zero, deriv_of_func_to_zero);
       };
 
-  const auto [rhobar_min, rhobar_max] =
+  // Non-const because might be changed below.
+  auto [rhobar_min, rhobar_max] =
       rhobar_min_max(center_one_, center_two_, radius_one_, radius_two_,
                      theta_max_one_, theta_max_two_, target_coords);
 
@@ -575,84 +575,121 @@ std::optional<std::array<double, 3>> UniformCylindricalEndcap::inverse(
       // Figure that out by looking at the deriv of the function.
       const double deriv_function_at_rhobar_min =
           function_and_deriv_to_zero(rhobar_min).second;
-      // The formula below would be Newton-Raphson except for the
-      // factor of 2. The factor of 2 is there to over-compensate so that
-      // the new rhobar_min brackets the root.
-      const double new_rhobar_min =
-          rhobar_min -
-          2.0 * function_at_rhobar_min / deriv_function_at_rhobar_min;
-      try {
-        // We have a good guess, so use newton_raphson
-        const size_t digits = 14;
-        // use rhobar_min as maximum value, since that brackets the root.
-        rhobar =
-            RootFinder::newton_raphson(function_and_deriv_to_zero, rhobar_min,
-                                       new_rhobar_min, rhobar_min, digits);
-      } catch (std::exception&) {
-        const double function_at_new_rhobar_min =
-            function_to_zero(new_rhobar_min);
+      const double trial_rhobar_min_increment =
+          -2.0 * function_at_rhobar_min / deriv_function_at_rhobar_min;
+      // new_rhobar_min = rhobar_min + trial_rhobar_min_increment would be
+      // a Newton-Raphson step except for the factor of 2 in
+      // trial_rhobar_min_increment. The factor of 2 is there to
+      // over-compensate so that the new rhobar_min brackets the
+      // root.
+      //
+      // But sometimes the factor of 2 is not enough when
+      // trial_rhobar_min_increment is roundoff-small so that the
+      // change in new_rhobar_min is zero or only in the last one or
+      // two bits.  If this is the case, then we set
+      // rhobar_min_increment to some small roundoff value with the
+      // same sign as trial_rhobar_min_increment.
+      // Note that rhobar is always between zero and one, so it is
+      // ok to use an absolute epsilon.
+      const double rhobar_min_increment =
+          abs(trial_rhobar_min_increment) >
+                  100.0 * std::numeric_limits<double>::epsilon()
+              ? trial_rhobar_min_increment
+              : std::copysign(100.0 * std::numeric_limits<double>::epsilon(),
+                              trial_rhobar_min_increment);
+      const double new_rhobar_min = rhobar_min + rhobar_min_increment;
+      const double function_at_new_rhobar_min =
+          function_to_zero(new_rhobar_min);
+      if (function_at_new_rhobar_min * function_at_rhobar_min > 0.0) {
         ERROR(
-            "Cannot find root after trying to adjust bracketing rhobar_min due "
+            "Cannot find bracket after trying to adjust bracketing "
+            "rhobar_min due "
             "to roundoff : "
             << rhobar_min << " " << function_at_rhobar_min << " " << rhobar_max
             << " " << function_at_rhobar_max << " " << new_rhobar_min << " "
-            << function_at_new_rhobar_min);
+            << function_at_new_rhobar_min << " " << deriv_function_at_rhobar_min
+            << " " << new_rhobar_min - rhobar_min << "\n");
       }
+      // Now the root is bracketed between rhobar_min and new_rhobar_min,
+      // so replace rhobar_max and rhobar_min and then fall through to the
+      // root finder.
+      rhobar_max = rhobar_min;
+      function_at_rhobar_max = function_at_rhobar_min;
+      rhobar_min = new_rhobar_min;
+      function_at_rhobar_min = function_at_new_rhobar_min;
     } else if (abs(function_at_rhobar_max) / abs(function_at_rhobar_min) <
                roundoff_ratio) {
       // Slightly increase rhobar_max.  How far do we increase it?
       // Figure that out by looking at the deriv of the function.
       const double deriv_function_at_rhobar_max =
           function_and_deriv_to_zero(rhobar_max).second;
-      // The formula below would be Newton-Raphson except for the
-      // factor of 2. The factor of 2 is there to over-compensate so that
-      // the new rhobar_max brackets the root.
-      const double new_rhobar_max =
-          rhobar_max -
-          2.0 * function_at_rhobar_max / deriv_function_at_rhobar_max;
-      try {
-        // We have a good guess, so use newton_raphson
-        const size_t digits = 14;
-        // use rhobar_max as minimum value, since that brackets the root.
-        rhobar =
-            RootFinder::newton_raphson(function_and_deriv_to_zero, rhobar_max,
-                                       rhobar_max, new_rhobar_max, digits);
-      } catch (std::exception&) {
-        const double function_at_new_rhobar_max =
-            function_to_zero(new_rhobar_max);
+      const double trial_rhobar_max_increment =
+          -2.0 * function_at_rhobar_max / deriv_function_at_rhobar_max;
+      // new_rhobar_max = rhobar_max + trial_rhobar_max_increment would be
+      // a Newton-Raphson step except for the factor of 2 in
+      // trial_rhobar_max_increment. The factor of 2 is there to
+      // over-compensate so that the new rhobar_max brackets the
+      // root.
+      //
+      // But sometimes the factor of 2 is not enough when
+      // trial_rhobar_max_increment is roundoff-small so that the
+      // change in new_rhobar_max is zero or only in the last one or
+      // two bits.  If this is the case, then we set
+      // rhobar_max_increment to some small roundoff value with the
+      // same sign as trial_rhobar_max_increment.
+      // Note that rhobar is always between zero and one, so it is
+      // ok to use an absolute epsilon.
+      const double rhobar_max_increment =
+          abs(trial_rhobar_max_increment) >
+                  100.0 * std::numeric_limits<double>::epsilon()
+              ? trial_rhobar_max_increment
+              : boost::math::copysign(
+                    100.0 * std::numeric_limits<double>::epsilon(),
+                    trial_rhobar_max_increment);
+      const double new_rhobar_max = rhobar_max + rhobar_max_increment;
+      const double function_at_new_rhobar_max =
+          function_to_zero(new_rhobar_max);
+      if (function_at_new_rhobar_max * function_at_rhobar_max > 0.0) {
         ERROR(
-            "Cannot find root after trying to adjust bracketing rhobar_max due "
+            "Cannot find bracket after trying to adjust bracketing "
+            "rhobar_max due "
             "to roundoff : "
-            << rhobar_min << " " << function_at_rhobar_min << " " << rhobar_max
+            << rhobar_max << " " << function_at_rhobar_max << " " << rhobar_max
             << " " << function_at_rhobar_max << " " << new_rhobar_max << " "
-            << function_at_new_rhobar_max);
+            << function_at_new_rhobar_max << " " << deriv_function_at_rhobar_max
+            << " " << new_rhobar_max - rhobar_max << "\n");
       }
+      // Now the root is bracketed between rhobar_max and new_rhobar_max,
+      // so replace rhobar_max and rhobar_min and then fall through to the
+      // root finder.
+      rhobar_min = rhobar_max;
+      function_at_rhobar_min = function_at_rhobar_max;
+      rhobar_max = new_rhobar_max;
+      function_at_rhobar_max = function_at_new_rhobar_max;
     } else {
       ERROR("Root is not bracketed: "
             << rhobar_min << " " << function_at_rhobar_min << " " << rhobar_max
             << " " << function_at_rhobar_max);
     }
-  } else {
-    // If we get here, root is bracketed. We don't really have a good
-    // guess, so use toms748, and use the function evaluations that we
-    // have already done.
+  }
+  // If we get here, root is bracketed. Use toms748, and use the
+  // function evaluations that we have already done.
 
-    // Rhobar is between zero and 1, so the scale is unity, so therefore
-    // abs and rel tolerance are equal.
-    constexpr double abs_tol = 1.e-15;
-    constexpr double rel_tol = 1.e-15;
+  // Rhobar is between zero and 1, so the scale is unity, so therefore
+  // abs and rel tolerance are equal.
+  constexpr double abs_tol = 1.e-15;
+  constexpr double rel_tol = 1.e-15;
 
-    try {
-      rhobar =
-          // NOLINTNEXTLINE(clang-analyzer-core)
-          RootFinder::toms748(function_to_zero, rhobar_min, rhobar_max,
-                              function_at_rhobar_min, function_at_rhobar_max,
-                              abs_tol, rel_tol);
-    } catch (std::exception&) {
-      ERROR("Cannot find root after bracketing: "
-            << rhobar_min << " " << function_at_rhobar_min << " " << rhobar_max
-            << " " << function_at_rhobar_max);
-    }
+  try {
+    rhobar =
+        // NOLINTNEXTLINE(clang-analyzer-core)
+        RootFinder::toms748(function_to_zero, rhobar_min, rhobar_max,
+                            function_at_rhobar_min, function_at_rhobar_max,
+                            abs_tol, rel_tol);
+  } catch (std::exception&) {
+    ERROR("Cannot find root after bracketing: "
+          << rhobar_min << " " << function_at_rhobar_min << " " << rhobar_max
+          << " " << function_at_rhobar_max);
   }
 
   // Now that we have rhobar, construct inverse.
@@ -669,9 +706,8 @@ std::optional<std::array<double, 3>> UniformCylindricalEndcap::inverse(
                (target_coords[0] - center_one_[0] -
                 lambda * (center_two_[0] - center_one_[0])) *
                denom,
-           rhobar *
-               (target_coords[1] - center_one_[1] -
-                lambda * (center_two_[1] - center_one_[1])) *
+           rhobar*(target_coords[1] - center_one_[1] -
+                   lambda * (center_two_[1] - center_one_[1])) *
                denom,
            2.0 * lambda - 1.0}};
 }

--- a/src/Domain/CoordinateMaps/UniformCylindricalEndcap.hpp
+++ b/src/Domain/CoordinateMaps/UniformCylindricalEndcap.hpp
@@ -453,15 +453,17 @@ namespace domain::CoordinateMaps {
  * map without this assumption, but the assumption simplifies the
  * code, and the expected use cases obey this restriction.
  *
- * We also demand that \f$z_{\mathrm{P}1} <= z_{\mathrm{P}2} -0.03 R_1\f$, and
+ * We also demand that \f$z_{\mathrm{P}1} <= z_{\mathrm{P}2} -0.04 R_2\f$, and
  * that the z planes in the above figures lie above the centers of the
  * corresponding spheres and are not too close to the centers or edges of
  * those spheres; specificially, we demand that
- * - \f$ 0.05\pi < \theta_{1 \mathrm{max}} < 0.45\pi\f$
- * - \f$ 0.05\pi < \theta_{2 \mathrm{max}} < 0.45\pi\f$
+ * - \f$ 0.075\pi < \theta_{1 \mathrm{max}} < 0.45\pi\f$
+ * - \f$ 0.075\pi < \theta_{2 \mathrm{max}} < 0.45\pi\f$
  *
- * Here 0.05 and 0.45 are safety factors. These restrictions are not
- * strictly necessary but are made for simplicity.
+ * Here 0.075 and 0.45 are safety factors. These restrictions are not
+ * strictly necessary but are made for simplicity and to ensure the
+ * accuracy of the inverse map (the inverse map becomes less accurate if
+ * the map parameters are extreme).
  *
  * Consider the line segment \f$L\f$ that connects a point on the
  * circle \f$S_1\f$ (the circle formed by the intersection of sphere 1

--- a/tests/Unit/Domain/CoordinateMaps/Test_UniformCylindricalEndcap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_UniformCylindricalEndcap.cpp
@@ -71,15 +71,23 @@ void test_uniform_cylindrical_endcap() {
   const double radius_two = 6.0 * (unit_dis(gen) + 1.0);
   CAPTURE(radius_two);
 
+  // These angles describe how close the z-planes can be to the
+  // centers or edges of the spheres.
+  constexpr double min_angle = 0.075;
+  constexpr double max_angle_increment = 0.45 - min_angle;
+
   // Make sure z_plane_two intersects sphere_two on the +z side of the
   // center. We don't allow the plane to be too close to the center or
   // too close to the edge.
   const double z_plane_two =
-      center_two[2] + cos((0.05 + 0.4 * unit_dis(gen)) * M_PI) * radius_two;
+      center_two[2] +
+      cos((min_angle + max_angle_increment * unit_dis(gen)) * M_PI) *
+          radius_two;
   CAPTURE(z_plane_two);
 
   // Choose z_plane_frac_one = (z_plane_one - center_one[2])/radius_one
-  const double z_plane_frac_one = cos((0.05 + 0.4 * unit_dis(gen)) * M_PI);
+  const double z_plane_frac_one =
+      cos((min_angle + max_angle_increment * unit_dis(gen)) * M_PI);
 
   // Compute the minimum allowed value of the angle alpha.
   const double theta_max_one = acos(z_plane_frac_one);
@@ -94,12 +102,12 @@ void test_uniform_cylindrical_endcap() {
     // max_radius_one_to_fit_inside_sphere_two is the largest that
     // radius_one can be and still satisfy both
     // 0.98 radius_two >= radius_one + |C_1-C_2| and
-    // z_plane_two >= z_plane_one + 0.03*r_2.
+    // z_plane_two >= z_plane_one + 0.04*r_2.
     // If radius_one takes on that value, then center_one-center_two
     // must point in the minus-z direction, and only one value of
     // center_one[2] is allowed.
     const double max_radius_one_to_fit_inside_sphere_two =
-        (0.95 * radius_two + z_plane_two - center_two[2]) /
+        (0.94 * radius_two + z_plane_two - center_two[2]) /
         (1.0 + z_plane_frac_one);
 
     // max_radius_one_for_alpha is the largest that radius_one can be
@@ -139,11 +147,11 @@ void test_uniform_cylindrical_endcap() {
                    radius_one * sin(theta_max_one)) *
                       tan(min_alpha);
         // max_center_one_z comes from the restriction
-        // z_plane_two >= z_plane_one + 0.03*radius_two, and the restriction
+        // z_plane_two >= z_plane_one + 0.04*radius_two, and the restriction
         // 0.98 r_2 >= r_1 + | C_1 - C_2 |
         const double max_center_one_z = std::min(
             {max_center_one_z_from_alpha,
-             z_plane_two - z_plane_frac_one * radius_one - 0.03 * radius_two,
+             z_plane_two - z_plane_frac_one * radius_one - 0.04 * radius_two,
              center_two[2] + 0.98 * radius_two - radius_one});
         // min_center_one_z comes from the restriction 0.98 r_2 >= r_1 +
         // |C_1-C_2|


### PR DESCRIPTION
## Proposed changes

Newton-Raphson is going away, so this PR removes it from UniformCylindricalEndcap.

Newton-Raphson was previously used only for corner cases where the root was barely bracketed.
Now those cases are handled differently.

Also does a few small tweaks of restrictions on map parameters that make the unit tests more robust
(I ran them 20k times without encountering an error)

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
