### PR TITLE
Add UniformCylindricalSide.

### DIFF
--- a/docs/Images/Domain/CoordinateMaps/UniformCylSide.svg
+++ b/docs/Images/Domain/CoordinateMaps/UniformCylSide.svg
@@ -1,0 +1,456 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="127.26459mm"
+   height="127.26459mm"
+   viewBox="0 0 127.26459 127.26459"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="UniformCylSide.svg">
+  <defs
+     id="defs2">
+    <marker
+       inkscape:stockid="Arrow2Lend"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="marker5148"
+       style="overflow:visible;"
+       inkscape:isstock="true">
+      <path
+         id="path5146"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         transform="scale(1.1) rotate(180) translate(1,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Mend"
+       style="overflow:visible;"
+       inkscape:isstock="true">
+      <path
+         id="path860"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.4) rotate(180) translate(10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Lend"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow2Lend"
+       style="overflow:visible;"
+       inkscape:isstock="true">
+      <path
+         id="path872"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         transform="scale(1.1) rotate(180) translate(1,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Lend"
+       style="overflow:visible;"
+       inkscape:isstock="true">
+      <path
+         id="path854"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) rotate(180) translate(12.5,0)" />
+    </marker>
+    <linearGradient
+       id="linearGradient6115"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop6113" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4526"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4524" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1"
+     inkscape:cx="177.85777"
+     inkscape:cy="316.91051"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:window-width="2279"
+     inkscape:window-height="1107"
+     inkscape:window-x="209"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3713"
+       originx="158.88229"
+       originy="-137.45104" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(158.8823,-32.284369)">
+    <circle
+       id="path3717"
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26458332;stroke-opacity:1"
+       cy="106.49999"
+       cx="-84.666664"
+       r="37.041668" />
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6040-6"
+       cx="-84.666664"
+       cy="106.49999"
+       rx="1.2427398"
+       ry="1.1926293" />
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6040-7"
+       cx="-95.25"
+       cy="95.916664"
+       rx="1.0924084"
+       ry="1.1425189" />
+    <g
+       id="g4746">
+      <text
+         id="text6223"
+         y="53.658447"
+         x="-43.202892"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="53.658447"
+           x="-43.202892"
+           id="tspan6221"
+           sodipodi:role="line">z</tspan></text>
+      <text
+         id="text6227"
+         y="55.565598"
+         x="-39.481693"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="55.565598"
+           x="-39.481693"
+           id="tspan6225"
+           sodipodi:role="line">P2</tspan></text>
+    </g>
+    <g
+       id="g893"
+       transform="translate(-175.58712,29.665404)">
+      <text
+         id="text6153-9"
+         y="73.250671"
+         x="70.257866"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="73.250671"
+           x="70.257866"
+           id="tspan6151-2"
+           sodipodi:role="line">C</tspan></text>
+      <text
+         id="text6157-5"
+         y="68.771202"
+         x="75.586967"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           id="tspan6163-4"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="68.771202"
+           x="75.586967"
+           sodipodi:role="line">i</tspan></text>
+      <text
+         id="text6247"
+         y="75.010567"
+         x="75.265945"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="75.010567"
+           x="75.265945"
+           id="tspan6245"
+           sodipodi:role="line">2</tspan></text>
+    </g>
+    <g
+       id="g883"
+       transform="translate(-126.46759,25.818148)">
+      <text
+         id="text6243"
+         y="89.843269"
+         x="48.907825"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="89.843269"
+           x="48.907825"
+           id="tspan6241"
+           sodipodi:role="line">1</tspan></text>
+      <text
+         id="text6153-9-9"
+         y="87.80143"
+         x="44.581596"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="87.80143"
+           x="44.581596"
+           id="tspan6151-2-2"
+           sodipodi:role="line">C</tspan></text>
+      <text
+         id="text6157-5-5"
+         y="83.566628"
+         x="49.266769"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           id="tspan6163-4-4"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="83.566628"
+           x="49.266769"
+           sodipodi:role="line">i</tspan></text>
+    </g>
+    <circle
+       r="63.500004"
+       cx="-95.25"
+       cy="95.916664"
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26458332;stroke-opacity:1"
+       id="circle885" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m -124.35417,80.041663 h 79.375003"
+       id="path895"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M -156.10417,48.291663 H -34.395834"
+       inkscape:connector-curvature="0"
+       id="path897" />
+    <g
+       transform="translate(-150.54791,-69.45312)"
+       id="g925">
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="80.622108"
+         y="155.39073"
+         id="text919"><tspan
+           sodipodi:role="line"
+           id="tspan917"
+           x="80.622108"
+           y="155.39073"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">z</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="84.343307"
+         y="157.29788"
+         id="text923"><tspan
+           sodipodi:role="line"
+           id="tspan921"
+           x="84.343307"
+           y="157.29788"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">P1</tspan></text>
+    </g>
+    <text
+       id="text953"
+       y="75.572258"
+       x="-77.505714"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         y="75.572258"
+         x="-77.505714"
+         id="tspan951"
+         sodipodi:role="line">α</tspan></text>
+    <path
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.30000001;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker5148)"
+       id="path973"
+       sodipodi:type="arc"
+       sodipodi:cx="-58.737511"
+       sodipodi:cy="80.041664"
+       sodipodi:rx="14.552083"
+       sodipodi:ry="14.552083"
+       sodipodi:start="3.2670729"
+       sodipodi:end="4.6972928"
+       sodipodi:open="true"
+       d="M -73.175181,78.220453 A 14.552083,14.552083 0 0 1 -58.957183,65.491239" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="-39.746273"
+       y="51.067684"
+       id="text6227-3"><tspan
+         sodipodi:role="line"
+         id="tspan6225-8"
+         x="-39.746273"
+         y="51.067684"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">+</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="-212.98959"
+       y="41.677078"
+       id="text4618"><tspan
+         sodipodi:role="line"
+         id="tspan4616"
+         x="-212.98959"
+         y="47.91959"
+         style="stroke-width:0.26458332" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="-66.469193"
+       y="83.611435"
+       id="text6227-3-4"><tspan
+         sodipodi:role="line"
+         id="tspan6225-8-0"
+         x="-66.469193"
+         y="83.611435"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">+</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m -128.32293,136.92708 h 79.375008"
+       id="path895-0"
+       inkscape:connector-curvature="0" />
+    <g
+       transform="translate(-155.17812,-21.761974)"
+       id="g925-4">
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="80.622108"
+         y="155.39073"
+         id="text919-6"><tspan
+           sodipodi:role="line"
+           id="tspan917-2"
+           x="80.622108"
+           y="155.39073"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">z</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="84.343307"
+         y="157.29788"
+         id="text923-6"><tspan
+           sodipodi:role="line"
+           id="tspan921-7"
+           x="84.343307"
+           y="157.29788"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">P1</tspan></text>
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="-70.305649"
+       y="129.11977"
+       id="text6227-6-5"><tspan
+         sodipodi:role="line"
+         id="tspan4698"
+         x="-70.305649"
+         y="129.11977">_</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="-42.656685"
+       y="148.83122"
+       id="text6227-6-5-8"><tspan
+         style="stroke-width:0.26458332"
+         sodipodi:role="line"
+         id="tspan4698-2"
+         x="-42.656685"
+         y="148.83122">_</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M -156.10418,147.51041 H -34.395843"
+       inkscape:connector-curvature="0"
+       id="path897-9" />
+    <g
+       transform="translate(-3.9687504,99.483332)"
+       id="g4746-9">
+      <text
+         id="text6223-6"
+         y="53.658447"
+         x="-43.202892"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="53.658447"
+           x="-43.202892"
+           id="tspan6221-0"
+           sodipodi:role="line">z</tspan></text>
+      <text
+         id="text6227-2"
+         y="55.565598"
+         x="-39.481693"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="55.565598"
+           x="-39.481693"
+           id="tspan6225-7"
+           sodipodi:role="line">P2</tspan></text>
+    </g>
+    <path
+       style="opacity:0.98999999;fill:#000000;fill-opacity:0.39215687;stroke:#000000;stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m -132.50547,147.60246 c -15.71092,-11.32454 -25.41806,-29.18027 -26.37935,-48.523336 -0.96129,-19.343062 6.92763,-38.07327 21.43832,-50.89973 l 26.93077,31.789264 c -7.89157,7.68863 -11.95087,18.491239 -11.07553,29.474212 0.87534,10.98297 6.59445,21.00625 15.60422,27.34785 z"
+       id="path4793"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csccscc" />
+    <path
+       style="opacity:0.98999999;fill:#000000;fill-opacity:0.39215687;stroke:#000000;stroke-width:0.30000001;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m -58.227935,147.34459 c 15.617006,-11.24241 25.279459,-28.97203 26.262831,-48.189614 0.983371,-19.217588 -6.81889,-37.840881 -21.206775,-50.618654 l -5.637516,31.440362 c 7.885864,7.687841 11.941888,18.486044 11.06744,29.464436 -0.87445,10.97839 -6.588678,20.99837 -15.592087,27.34095 z"
+       id="path4811"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csccscc" />
+  </g>
+</svg>

--- a/src/Domain/CoordinateMaps/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/CMakeLists.txt
@@ -32,6 +32,7 @@ spectre_target_sources(
   Rotation.cpp
   SpecialMobius.cpp
   UniformCylindricalEndcap.cpp
+  UniformCylindricalSide.cpp
   Wedge.cpp
   )
 
@@ -71,6 +72,7 @@ spectre_target_headers(
   Tags.hpp
   TimeDependentHelpers.hpp
   UniformCylindricalEndcap.hpp
+  UniformCylindricalSide.hpp
   Wedge.hpp
   )
 

--- a/src/Domain/CoordinateMaps/UniformCylindricalSide.cpp
+++ b/src/Domain/CoordinateMaps/UniformCylindricalSide.cpp
@@ -1,0 +1,782 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/UniformCylindricalSide.hpp"
+
+#include <cmath>
+#include <limits>
+#include <optional>
+#include <pup.h>
+#include <utility>
+
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "NumericalAlgorithms/RootFinding/TOMS748.hpp"
+#include "Parallel/PupStlCpp11.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace domain::CoordinateMaps {
+
+namespace {
+// FunctionEvalTempVariables exists to remove code duplication between
+// function_to_zero and deriv_function_to_zero.
+struct FunctionEvalTempVariables {
+  FunctionEvalTempVariables(double lambda,
+                            const std::array<double, 3>& target_coords,
+                            const std::array<double, 3>& center_one,
+                            const std::array<double, 3>& center_two,
+                            double radius_one, double radius_two,
+                            double z_plane_minus_one, double z_plane_minus_two,
+                            double z_plane_plus_one, double z_plane_plus_two);
+  double one_plus_zbar_over_two;
+  double r_one_cos_theta_one;
+  double r_two_cos_theta_two;
+  double r_one_sin_theta_one;
+  double r_two_sin_theta_two;
+};
+
+FunctionEvalTempVariables::FunctionEvalTempVariables(
+    const double lambda, const std::array<double, 3>& target_coords,
+    const std::array<double, 3>& center_one,
+    const std::array<double, 3>& center_two, const double radius_one,
+    const double radius_two, const double z_plane_minus_one,
+    const double z_plane_minus_two, const double z_plane_plus_one,
+    const double z_plane_plus_two)
+    : one_plus_zbar_over_two(
+          (target_coords[2] + lambda * (z_plane_minus_one - z_plane_minus_two) -
+           z_plane_minus_one) /
+          ((1.0 - lambda) * (z_plane_plus_one - z_plane_minus_one) +
+           lambda * (z_plane_plus_two - z_plane_minus_two))),
+      r_one_cos_theta_one(z_plane_minus_one - center_one[2] +
+                          (z_plane_plus_one - z_plane_minus_one) *
+                              one_plus_zbar_over_two),
+      r_two_cos_theta_two(z_plane_minus_two - center_two[2] +
+                          (z_plane_plus_two - z_plane_minus_two) *
+                              one_plus_zbar_over_two),
+      r_one_sin_theta_one(
+          sqrt(square(radius_one) - square(r_one_cos_theta_one))),
+      r_two_sin_theta_two(
+          sqrt(square(radius_two) - square(r_two_cos_theta_two))) {}
+}  // namespace
+
+UniformCylindricalSide::UniformCylindricalSide(
+    const std::array<double, 3>& center_one,
+    const std::array<double, 3>& center_two, double radius_one,
+    double radius_two, double z_plane_plus_one, double z_plane_minus_one,
+    double z_plane_plus_two, double z_plane_minus_two)
+    : center_one_(center_one),
+      center_two_(center_two),
+      radius_one_([&radius_one]() {
+        // The equal_within_roundoff below has an implicit scale of 1,
+        // so the ASSERT may trigger in the case where we really
+        // want an entire domain that is very small.
+        ASSERT(not equal_within_roundoff(radius_one, 0.0),
+               "Cannot have zero radius_one");
+        ASSERT(radius_one > 0.0, "Cannot have negative radius_one");
+        return radius_one;
+                  }()), // LCOV_EXCL_LINE
+      radius_two_([&radius_two]() {
+        // The equal_within_roundoff below has an implicit scale of 1,
+        // so the ASSERT may trigger in the case where we really
+        // want an entire domain that is very small.
+        ASSERT(not equal_within_roundoff(radius_two, 0.0),
+               "Cannot have zero radius_two");
+        ASSERT(radius_two > 0.0, "Cannot have negative radius_two");
+        return radius_two;
+      }()), // LCOV_EXCL_LINE
+      z_plane_plus_one_(z_plane_plus_one),
+      z_plane_minus_one_(z_plane_minus_one),
+      z_plane_plus_two_(z_plane_plus_two),
+      z_plane_minus_two_(z_plane_minus_two) {
+  // Assumptions made in the map.  Some of these can be relaxed,
+  // as long as the unit test is changed to test them.
+  // The ASSERTS here match the ones in UniformCylindricalEndcap.
+  ASSERT(radius_one >= 0.08 * radius_two,
+         "Radius_one = " << radius_one << " must be >= 0.08 * radius_two ="
+                         << 0.08 * radius_two);
+  ASSERT(z_plane_plus_two == z_plane_plus_one or
+             z_plane_plus_two >= z_plane_plus_one + 0.03 * radius_two,
+         "z_plane_plus_two must be >= z_plane_plus_one "
+         "+ 0.03 * radius_two, or exactly equal to z_plane_plus_one, not "
+             << z_plane_plus_two << " " << z_plane_plus_one << " "
+             << z_plane_plus_one + 0.03 * radius_two);
+  ASSERT(z_plane_minus_two == z_plane_minus_one or
+             z_plane_minus_two <= z_plane_minus_one - 0.03 * radius_two,
+         "z_plane_minus_two must be >= z_plane_minus_one "
+         "- 0.03 * radius_two, or exactly equal to z_plane_minus_one, but "
+         "z_plane_minus_two = "
+             << z_plane_minus_two
+             << ", z_plane_minus_one = " << z_plane_minus_one
+             << ", and z_plane_minus_one - 0.03 * radius_two = "
+             << z_plane_minus_one - 0.03 * radius_two);
+  ASSERT(z_plane_minus_two != z_plane_minus_one or
+             z_plane_plus_two != z_plane_plus_one,
+         "Not tested if both the positive z-planes and the negative z-planes "
+         "are equal");
+
+  // The code below defines several variables that are used only in ASSERTs.
+  // We put that code in a #ifdef SPECTRE_DEBUG to avoid clang-tidy complaining
+  // about unused variables in release mode.
+#ifdef SPECTRE_DEBUG
+  const double cos_theta_min_one =
+      (z_plane_plus_one - center_one[2]) / radius_one;
+  const double cos_theta_max_one =
+      (z_plane_minus_one - center_one[2]) / radius_one;
+  const double cos_theta_min_two =
+      (z_plane_plus_two - center_two[2]) / radius_two;
+  const double cos_theta_max_two =
+      (z_plane_minus_two - center_two[2]) / radius_two;
+
+  ASSERT(cos_theta_min_one > cos(M_PI * 0.4),
+         "z_plane_plus_one is too close to the center of sphere_one: "
+         "cos_theta_min_one must be > "
+             << cos(M_PI * 0.4) << " but is " << cos_theta_min_one
+             << " instead.");
+  ASSERT(cos_theta_max_one < cos(M_PI * 0.6),
+         "z_plane_minus_one is too close to the center of sphere_one: "
+         "cos_theta_max_one must be < "
+             << cos(M_PI * 0.6) << " but is " << cos_theta_max_one
+             << " instead.");
+  ASSERT(cos_theta_min_one < cos(M_PI * 0.15),
+         "z_plane_plus_one is too far from the center of sphere_one: "
+         "cos_theta_min_one must be < "
+             << cos(M_PI * 0.15) << " but is " << cos_theta_min_one
+             << " instead.");
+  ASSERT(cos_theta_max_one > cos(M_PI * 0.85),
+         "z_plane_minus_one is too far from the center of sphere_one: "
+         "cos_theta_max_one must be > "
+             << cos(M_PI * 0.85) << " but is " << cos_theta_max_one
+             << " instead.");
+  ASSERT(cos_theta_min_two > (z_plane_plus_one_ == z_plane_plus_two_
+                                  ? cos(M_PI * 0.75)
+                                  : cos(M_PI * 0.4)),
+         "z_plane_plus_two is too close to the south pole: theta/pi="
+             << acos(cos_theta_min_two) / M_PI);
+  ASSERT(cos_theta_max_two < (z_plane_minus_one_ == z_plane_minus_two_
+                                  ? cos(M_PI * 0.25)
+                                  : cos(M_PI * 0.6)),
+         "z_plane_minus_two is too close to the north pole: theta/pi="
+             << acos(cos_theta_max_two) / M_PI);
+  ASSERT(cos_theta_min_two < cos(M_PI * 0.15),
+         "z_plane_plus_two is too close to the north pole: theta_min_two/pi="
+             << acos(cos_theta_min_two) / M_PI << " but it should be < 0.15");
+  ASSERT(cos_theta_max_two > cos(M_PI * 0.85),
+         "z_plane_minus_two is too close to the south pole: theta_max_two/pi="
+             << acos(cos_theta_max_two) / M_PI << " but it should be > 0.85");
+
+  const double dist_spheres = sqrt(square(center_one[0] - center_two[0]) +
+                                   square(center_one[1] - center_two[1]) +
+                                   square(center_one[2] - center_two[2]));
+
+  ASSERT(dist_spheres + radius_one <= 0.98 * radius_two,
+         "The map has been tested only for the case when "
+         "sphere_one is sufficiently contained inside sphere_two, without the "
+         "two spheres almost touching. Radius_one = "
+             << radius_one << ", radius_two = " << radius_two
+             << ", dist_spheres = " << dist_spheres
+             << ", (dist_spheres+radius_one)/radius_two="
+             << (dist_spheres + radius_one) / radius_two);
+
+  const double horizontal_dist_spheres =
+      sqrt(square(center_one[0] - center_two[0]) +
+           square(center_one[1] - center_two[1]));
+
+  if (z_plane_plus_two != z_plane_plus_one and
+      z_plane_minus_two != z_plane_minus_one) {
+    ASSERT(center_one[2] - radius_one <= center_two[2] + 0.2 * radius_two and
+               center_one[2] + radius_one >= center_two[2] - 0.2 * radius_two,
+           "The map has been tested only for the case when "
+           "sphere_one is not a tiny thing at the top or bottom of sphere_two. "
+           " Radius_one = "
+               << radius_one << ", radius_two = " << radius_two
+               << " center_one[2] = " << center_one[2]
+               << " center_two[2] = " << center_two[2]);
+  }
+
+  if (z_plane_plus_two == z_plane_plus_one) {
+    ASSERT(z_plane_minus_two <= z_plane_plus_two - 0.18 * radius_two,
+           "The map has been tested only if the sphere_two planes are far "
+           "enough apart. z_plane_plus_two="
+               << z_plane_plus_two << " z_plane_minus_two=" << z_plane_minus_two
+               << " radius_two=" << radius_two);
+  }
+
+  if (z_plane_minus_two == z_plane_minus_one) {
+    ASSERT(z_plane_plus_two >= z_plane_minus_two + 0.18 * radius_two,
+           "The map has been tested only if the sphere_two planes are far "
+           "enough apart. z_plane_plus_two="
+               << z_plane_plus_two << " z_plane_minus_two=" << z_plane_minus_two
+               << " radius_two=" << radius_two);
+  }
+
+  ASSERT(horizontal_dist_spheres <=
+             (z_plane_plus_two == z_plane_plus_one or
+                      z_plane_minus_two == z_plane_minus_one
+                  ? 0.0
+                  : std::min(radius_one,
+                             std::max(0.0, 0.95 * radius_two - radius_one))),
+         "The map has been tested only for the case when "
+         "sphere_one intersects the polar axis of sphere_two and is not "
+         "too far from the edge of sphere_two (or in the "
+         "case of equal plus or minus z_planes, when the two spheres have the "
+         "same x and y centers)."
+         " Radius_one = "
+             << radius_one << ", radius_two = " << radius_two
+             << ", dist_spheres = " << dist_spheres
+             << ", horizontal_dist_spheres = " << horizontal_dist_spheres);
+
+  const double theta_min_one = acos(cos_theta_min_one);
+  const double theta_max_one = acos(cos_theta_max_one);
+  const double theta_min_two = acos(cos_theta_min_two);
+  const double theta_max_two = acos(cos_theta_max_two);
+
+  // max_horizontal_dist_between_circles can be either sign;
+  // therefore alpha can be in either the first or second quadrant.
+  const double max_horizontal_dist_between_circles_plus =
+      horizontal_dist_spheres + radius_one_ * sin(theta_min_one) -
+      radius_two_ * sin(theta_min_two);
+  const double max_horizontal_dist_between_circles_minus =
+      horizontal_dist_spheres + radius_one_ * sin(theta_max_one) -
+      radius_two_ * sin(theta_max_two);
+
+  const double alpha_plus = atan2(z_plane_plus_two - z_plane_plus_one,
+                                  max_horizontal_dist_between_circles_plus);
+  ASSERT(alpha_plus > 1.1 * theta_min_one and alpha_plus > 1.1 * theta_min_two,
+         "Angle alpha_plus is too small: alpha_plus = "
+             << alpha_plus << ", theta_min_one = " << theta_min_one
+             << ", theta_min_two = " << theta_min_two
+             << ", max_horizontal_dist_between_circles_plus = "
+             << max_horizontal_dist_between_circles_plus
+             << ", horizontal_dist_spheres = " << horizontal_dist_spheres);
+
+  const double alpha_minus = atan2(z_plane_minus_one - z_plane_minus_two,
+                                   max_horizontal_dist_between_circles_minus);
+  ASSERT(alpha_minus > 1.1 * (M_PI - theta_max_one) and
+             alpha_minus > 1.1 * (M_PI - theta_max_two),
+         "Angle alpha_minus is too small: alpha_minus = "
+             << alpha_minus << ", theta_max_one = " << theta_max_one
+             << ", theta_max_two = " << theta_max_two
+             << ", max_horizontal_dist_between_circles_minus = "
+             << max_horizontal_dist_between_circles_minus
+             << ", horizontal_dist_spheres = " << horizontal_dist_spheres);
+#endif
+}
+
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, 3> UniformCylindricalSide::operator()(
+    const std::array<T, 3>& source_coords) const {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+  const ReturnType& xbar = source_coords[0];
+  const ReturnType& ybar = source_coords[1];
+  const ReturnType& zbar = source_coords[2];
+  std::array<ReturnType, 3> target_coords{};
+  ReturnType& x = target_coords[0];
+  ReturnType& y = target_coords[1];
+  ReturnType& z = target_coords[2];
+
+  // Use y and z as temporary storage to avoid allocations,
+  // before setting them to their actual values.
+  z = sqrt(square(xbar) + square(ybar));  // z is rhobar = lambda+1 in the dox
+  // y is temporarily R1 sin(theta_1)(1-lambda) + R2 sin(theta_2) lambda
+  // Here R1 sin(theta_1) is calculated from R1 cos(theta_1) as
+  // expressed in the dox
+  y = sqrt(square(radius_two_) -
+           square(z_plane_minus_two_ - center_two_[2] +
+                  0.5 * (zbar + 1.0) *
+                      (z_plane_plus_two_ - z_plane_minus_two_))) *
+          (z - 1.0) +
+      sqrt(square(radius_one_) -
+           square(z_plane_minus_one_ - center_one_[2] +
+                  0.5 * (zbar + 1.0) *
+                      (z_plane_plus_one_ - z_plane_minus_one_))) *
+          (2.0 - z);
+  // Now compute actual x,y,z.
+  x = y * xbar / z + center_two_[0] * (z - 1.0) + center_one_[0] * (2.0 - z);
+  y = y * ybar / z + center_two_[1] * (z - 1.0) + center_one_[1] * (2.0 - z);
+  z = (z_plane_minus_two_ +
+       0.5 * (zbar + 1.0) * (z_plane_plus_two_ - z_plane_minus_two_)) *
+          (z - 1.0) +
+      (z_plane_minus_one_ +
+       0.5 * (zbar + 1.0) * (z_plane_plus_one_ - z_plane_minus_one_)) *
+          (2.0 - z);
+  return target_coords;
+}
+
+std::optional<std::array<double, 3>> UniformCylindricalSide::inverse(
+    const std::array<double, 3>& target_coords) const {
+  // First do some easy checks that target_coords is in the range
+  // of the map.  Need to accept points that are out of range by roundoff.
+
+  // check z <= z_plane_plus_two_
+  if (target_coords[2] > z_plane_plus_two_ and
+      not equal_within_roundoff(target_coords[2], z_plane_plus_two_)) {
+    return std::nullopt;
+  }
+
+  // check z >= z_plane_minus_two_
+  if (target_coords[2] < z_plane_minus_two_ and
+      not equal_within_roundoff(target_coords[2], z_plane_minus_two_)) {
+    return std::nullopt;
+  }
+
+  // check that point is in or on sphere_two
+  const double r_minus_center_two =
+      sqrt(square(target_coords[0] - center_two_[0]) +
+           square(target_coords[1] - center_two_[1]) +
+           square(target_coords[2] - center_two_[2]));
+  if (r_minus_center_two > radius_two_ and
+      not equal_within_roundoff(r_minus_center_two, radius_two_)) {
+    return std::nullopt;
+  }
+
+  // check that point is outside or on sphere_one_
+  const double r_minus_center_one =
+      sqrt(square(target_coords[0] - center_one_[0]) +
+           square(target_coords[1] - center_one_[1]) +
+           square(target_coords[2] - center_one_[2]));
+  if (r_minus_center_one < radius_one_ and
+      not equal_within_roundoff(r_minus_center_one, radius_one_)) {
+    return std::nullopt;
+  }
+
+  // Check if the point is inside the cone
+  auto point_inside_cone =
+      [this, &target_coords](const double z_one, const double z_two) {
+        const double lambda_tilde =
+            (target_coords[2] - z_one) / (z_two - z_one);
+        const double rho_tilde =
+            sqrt(square(target_coords[0] - center_one_[0] -
+                        lambda_tilde * (center_two_[0] - center_one_[0])) +
+                 square(target_coords[1] - center_one_[1] -
+                        lambda_tilde * (center_two_[1] - center_one_[1])));
+        const double circle_radius =
+            sqrt(square(radius_one_) -
+                 square(z_one - center_one_[2])) *
+                (1.0 - lambda_tilde) +
+            sqrt(square(radius_two_) -
+                 square(z_two - center_two_[2])) *
+                lambda_tilde;
+        return rho_tilde < circle_radius and
+               not equal_within_roundoff(
+                   rho_tilde, circle_radius,
+                   std::numeric_limits<double>::epsilon() * 100.0, radius_two_);
+      };
+  if ((target_coords[2] >= z_plane_plus_one_ and
+       z_plane_plus_one_ != z_plane_plus_two_ and
+       point_inside_cone(z_plane_plus_one_, z_plane_plus_two_)) or
+      (target_coords[2] <= z_plane_minus_one_ and
+       z_plane_minus_one_ != z_plane_minus_two_ and
+       point_inside_cone(z_plane_minus_one_, z_plane_minus_two_))) {
+    return std::nullopt;
+  }
+
+  // To find lambda we will do numerical root finding.
+  // function_to_zero is the function that is zero when lambda has the
+  // correct value.
+  const auto function_to_zero = [this, &target_coords](const double lambda) {
+    const FunctionEvalTempVariables tmp(lambda, target_coords, center_one_,
+                                        center_two_, radius_one_, radius_two_,
+                                        z_plane_minus_one_, z_plane_minus_two_,
+                                        z_plane_plus_one_, z_plane_plus_two_);
+    return square(target_coords[0] - center_one_[0] -
+                  lambda * (center_two_[0] - center_one_[0])) +
+           square(target_coords[1] - center_one_[1] -
+                  lambda * (center_two_[1] - center_one_[1])) -
+           square((1.0 - lambda) * tmp.r_one_sin_theta_one +
+                  lambda * tmp.r_two_sin_theta_two);
+  };
+
+  // Derivative with respect to lambda of function_to_zero.
+  const auto deriv_function_to_zero = [this,
+                                       &target_coords](const double lambda) {
+    const FunctionEvalTempVariables tmp(lambda, target_coords, center_one_,
+                                        center_two_, radius_one_, radius_two_,
+                                        z_plane_minus_one_, z_plane_minus_two_,
+                                        z_plane_plus_one_, z_plane_plus_two_);
+    const double d_zbar_d_lambda_over_two =
+        ((1.0 - tmp.one_plus_zbar_over_two) *
+             (z_plane_minus_one_ - z_plane_minus_two_) -
+         tmp.one_plus_zbar_over_two * (z_plane_plus_two_ - z_plane_plus_one_)) /
+        ((1.0 - lambda) * (z_plane_plus_one_ - z_plane_minus_one_) +
+         lambda * (z_plane_plus_two_ - z_plane_minus_two_));
+    const double half_deriv_of_func_to_zero =
+        (center_one_[0] - center_two_[0]) *
+            (target_coords[0] - center_one_[0] -
+             lambda * (center_two_[0] - center_one_[0])) +
+        (center_one_[1] - center_two_[1]) *
+            (target_coords[1] - center_one_[1] -
+             lambda * (center_two_[1] - center_one_[1])) +
+        -(tmp.r_one_sin_theta_one * (1.0 - lambda) +
+          lambda * tmp.r_two_sin_theta_two) *
+            (tmp.r_two_sin_theta_two - tmp.r_one_sin_theta_one -
+             d_zbar_d_lambda_over_two *
+                 (lambda * tmp.r_two_cos_theta_two *
+                      (z_plane_plus_two_ - z_plane_minus_two_) /
+                      tmp.r_two_sin_theta_two +
+                  (1.0 - lambda) * tmp.r_one_cos_theta_one *
+                      (z_plane_plus_one_ - z_plane_minus_one_) /
+                      tmp.r_one_sin_theta_one));
+    return 2.0 * half_deriv_of_func_to_zero;
+  };
+
+  // If we get here, then lambda is not near unity or near zero.
+  // So let's find lambda.
+  double lambda = std::numeric_limits<double>::signaling_NaN();
+
+  // Choose the minimum value of lambda.  Max value is always one.
+  // These are not const because they can change with re-bracketing
+  // below.
+  double lambda_min =
+      std::max({0.0,
+                z_plane_plus_two_ == z_plane_plus_one_
+                    ? 0.0
+                    : (target_coords[2] - z_plane_plus_one_) /
+                          (z_plane_plus_two_ - z_plane_plus_one_),
+                z_plane_minus_two_ == z_plane_minus_one_
+                    ? 0.0
+                    : (z_plane_minus_one_ - target_coords[2]) /
+                          (z_plane_minus_one_ - z_plane_minus_two_)});
+  double lambda_max = 1.0;
+
+  // The root should always be bracketed.  However, if
+  // lambda==lambda_min or lambda==lambda_max, the function may not be
+  // exactly zero because of roundoff and then the root might not be
+  // bracketed.
+  double function_at_lambda_min = function_to_zero(lambda_min);
+  double function_at_lambda_max = function_to_zero(lambda_max);
+
+  if (1.0 - lambda_min <
+             std::numeric_limits<double>::epsilon() * 100.0) {
+    // lambda_min is within roundoff of lambda_max, meaning that the
+    // point must be within roundoff of a point on the outer sphere
+    // where there is only one possible value of lambda.  Here we
+    // treat this case as if lambda is exactly 1.0.
+    lambda = 1.0;
+  } else {
+    // Here we do a root find.
+    if (function_at_lambda_min * function_at_lambda_max > 0.0) {
+      // Root not bracketed.
+      // If the bracketing failure is due to roundoff, then
+      // slightly adjust the bounds to increase the range. Otherwise, error.
+      //
+      // roundoff_ratio is the limiting ratio of the two function values
+      // for which we should attempt to adjust the bounds.  It is ok for
+      // roundoff_ratio to be much larger than actual roundoff, since it
+      // doesn't hurt to expand the interval and try again when
+      // otherwise we would just error.
+      constexpr double roundoff_ratio = 1.e-3;
+      if (abs(function_at_lambda_min) / abs(function_at_lambda_max) <
+          roundoff_ratio) {
+        // Slightly decrease lambda_min.  How far do we decrease it?
+        // Figure that out by looking at the deriv of the function.
+        const double deriv_function_at_lambda_min =
+            deriv_function_to_zero(lambda_min);
+        const double trial_lambda_min_increment =
+            -2.0 * function_at_lambda_min / deriv_function_at_lambda_min;
+        // new_lambda_min = lambda_min + trial_lambda_min_increment would be
+        // a Newton-Raphson step except for the factor of 2 in
+        // trial_lambda_min_increment. The factor of 2 is there to
+        // over-compensate so that the new lambda_min brackets the
+        // root.
+        //
+        // But sometimes the factor of 2 is not enough when
+        // trial_lambda_min_increment is roundoff-small so that the
+        // change in new_lambda_min is zero or only in the last one or
+        // two bits.  If this is the case, then we set
+        // lambda_min_increment to some small roundoff value with the
+        // same sign as trial_lambda_min_increment.
+        // Note that lambda is always between zero and one, so it is
+        // ok to use an absolute epsilon.
+        const double lambda_min_increment =
+            abs(trial_lambda_min_increment) >
+                    1000.0 * std::numeric_limits<double>::epsilon()
+                ? trial_lambda_min_increment
+                : std::copysign(1000.0 * std::numeric_limits<double>::epsilon(),
+                                trial_lambda_min_increment);
+        const double new_lambda_min = lambda_min + lambda_min_increment;
+        const double function_at_new_lambda_min =
+            function_to_zero(new_lambda_min);
+        if (function_at_new_lambda_min * function_at_lambda_min > 0.0) {
+          // Excluding code coverage, because it is not clear how to make
+          // this error actually occur.
+          // LCOV_EXCL_START
+          ERROR(
+              "Cannot find bracket after trying to adjust bracketing "
+              "lambda_min due to roundoff : lambda_min="
+              << lambda_min << " f(lambda_min)=" << function_at_lambda_min
+              << " lambda_max=" << lambda_max << " f(lambda_max)="
+              << function_at_lambda_max << " new_lambda_min=" << new_lambda_min
+              << " f(new_lambda_min)=" << function_at_new_lambda_min
+              << " df(new_lambda_min)=" << deriv_function_at_lambda_min
+              << " new_lambda_min-lambda_min=" << new_lambda_min - lambda_min
+              << "\n");
+          // LCOV_EXCL_STOP
+        }
+        // Now the root is bracketed between lambda_min and new_lambda_min,
+        // so replace lambda_max and lambda_min and then fall through to the
+        // root finder.
+        lambda_max = lambda_min;
+        function_at_lambda_max = function_at_lambda_min;
+        lambda_min = new_lambda_min;
+        function_at_lambda_min = function_at_new_lambda_min;
+      } else if (abs(function_at_lambda_max) / abs(function_at_lambda_min) <
+                 roundoff_ratio) {
+        // Slightly increase lambda_max.  How far do we increase it?
+        // Figure that out by looking at the deriv of the function.
+        const double deriv_function_at_lambda_max =
+            deriv_function_to_zero(lambda_max);
+        const double trial_lambda_max_increment =
+            -2.0 * function_at_lambda_max / deriv_function_at_lambda_max;
+        // new_lambda_max = lambda_max + trial_lambda_max_increment would be
+        // a Newton-Raphson step except for the factor of 2 in
+        // trial_lambda_max_increment. The factor of 2 is there to
+        // over-compensate so that the new lambda_max brackets the
+        // root.
+        //
+        // But sometimes the factor of 2 is not enough when
+        // trial_lambda_max_increment is roundoff-small so that the
+        // change in new_lambda_max is zero or only in the last one or
+        // two bits.  If this is the case, then we set
+        // lambda_max_increment to some small roundoff value with the
+        // same sign as trial_lambda_max_increment.
+        // Note that lambda is always between zero and one, so it is
+        // ok to use an absolute epsilon.
+        const double lambda_max_increment =
+            abs(trial_lambda_max_increment) >
+                    1000.0 * std::numeric_limits<double>::epsilon()
+                ? trial_lambda_max_increment
+                : std::copysign(1000.0 * std::numeric_limits<double>::epsilon(),
+                                trial_lambda_max_increment);
+        const double new_lambda_max = lambda_max + lambda_max_increment;
+        const double function_at_new_lambda_max =
+            function_to_zero(new_lambda_max);
+        if (function_at_new_lambda_max * function_at_lambda_max > 0.0) {
+          // Excluding code coverage, because it is not clear how to make
+          // this error actually occur.
+          // LCOV_EXCL_START
+          ERROR(
+              "Cannot find bracket after trying to adjust bracketing "
+              "lambda_max due to roundoff : lambda_min="
+              << lambda_min << " f(lambda_min)=" << function_at_lambda_min
+              << " lambda_max=" << lambda_max << " f(lambda_max)="
+              << function_at_lambda_max << " new_lambda_max=" << new_lambda_max
+              << " f(new_lambda_max)=" << function_at_new_lambda_max
+              << " df(new_lambda_max)=" << deriv_function_at_lambda_max
+              << " new_lambda_max-lambda_max=" << new_lambda_max - lambda_min
+              << "\n");
+          // LCOV_EXCL_STOP
+        }
+        // Now the root is bracketed between lambda_max and new_lambda_max,
+        // so replace lambda_max and lambda_min and then fall through to the
+        // root finder.
+        lambda_min = lambda_max;
+        function_at_lambda_min = function_at_lambda_max;
+        lambda_max = new_lambda_max;
+        function_at_lambda_max = function_at_new_lambda_max;
+      } else {
+        // Excluding code coverage, because it is not clear how to make
+        // this error actually occur.
+        // LCOV_EXCL_START
+        ERROR(
+            "Root is not bracketed: "
+            "lambda_min="
+            << lambda_min << " f(lambda_min)=" << function_at_lambda_min
+            << " lambda_max=" << lambda_max
+            << " f(lambda_max)=" << function_at_lambda_max);
+        // LCOV_EXCL_STOP
+      }
+    }
+    // If we get here, root is bracketed. Use toms748, and use the
+    // function evaluations that we have already done.
+
+    // Lambda is between zero and 1, so the scale is unity, so therefore
+    // abs and rel tolerance are equal.
+    constexpr double abs_tol = 1.e-15;
+    constexpr double rel_tol = 1.e-15;
+
+    try {
+      lambda =
+          // NOLINTNEXTLINE(clang-analyzer-core)
+          RootFinder::toms748(function_to_zero, lambda_min, lambda_max,
+                              function_at_lambda_min, function_at_lambda_max,
+                              abs_tol, rel_tol);
+    } catch (std::exception&) { // LCOV_EXCL_LINE
+      // This should never happen unless something is really wrong with
+      // the root finder, so excluding this from code coverage.
+      // LCOV_EXCL_START
+      ERROR("Cannot find root after bracketing: lambda_min="
+            << lambda_min << " f(lambda_min)=" << function_at_lambda_min
+            << " lambda_max=" << lambda_max
+            << " f(lambda_max)=" << function_at_lambda_max);
+      // LCOV_EXCL_STOP
+    }
+  }
+
+  // Now that we have lambda, construct inverse.
+  const double one_plus_zbar_over_two =
+      (target_coords[2] + lambda * (z_plane_minus_one_ - z_plane_minus_two_) -
+       z_plane_minus_one_) /
+      ((1.0 - lambda) * (z_plane_plus_one_ - z_plane_minus_one_) +
+       lambda * (z_plane_plus_two_ - z_plane_minus_two_));
+  const double rhobar = 1.0 + lambda;
+  const double r_one_cos_theta_one =
+      z_plane_minus_one_ - center_one_[2] +
+      (z_plane_plus_one_ - z_plane_minus_one_) * one_plus_zbar_over_two;
+  const double r_two_cos_theta_two =
+      z_plane_minus_two_ - center_two_[2] +
+      (z_plane_plus_two_ - z_plane_minus_two_) * one_plus_zbar_over_two;
+  const double r_one_sin_theta_one =
+      sqrt(square(radius_one_) - square(r_one_cos_theta_one));
+  const double r_two_sin_theta_two =
+      sqrt(square(radius_two_) - square(r_two_cos_theta_two));
+  const double denom = 1.0 / ((1.0 - lambda) * r_one_sin_theta_one +
+                              lambda * r_two_sin_theta_two);
+  return {{rhobar *
+               (target_coords[0] - center_one_[0] -
+                lambda * (center_two_[0] - center_one_[0])) *
+               denom,
+           rhobar *
+               (target_coords[1] - center_one_[1] -
+                lambda * (center_two_[1] - center_one_[1])) *
+               denom,
+           2.0 * one_plus_zbar_over_two - 1.0}};
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>
+UniformCylindricalSide::jacobian(const std::array<T, 3>& source_coords) const {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+  const ReturnType& xbar = source_coords[0];
+  const ReturnType& ybar = source_coords[1];
+  const ReturnType& zbar = source_coords[2];
+
+  auto jac =
+      make_with_value<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>>(
+          dereference_wrapper(source_coords[0]), 0.0);
+
+  // Use jacobian components as temporary storage to avoid extra
+  // memory allocations.
+  // jac(2,2)=rhobar
+  get<2, 2>(jac) = sqrt(square(xbar) + square(ybar));
+  // jac(2,1)=R1 sin(theta1)
+  get<2, 1>(jac) = sqrt(
+      square(radius_one_) -
+      square(z_plane_minus_one_ - center_one_[2] +
+             0.5 * (zbar + 1.0) * (z_plane_plus_one_ - z_plane_minus_one_)));
+  // jac(0,2)=cot theta1/rho
+  get<0, 2>(jac) =
+      (z_plane_minus_one_ - center_one_[2] +
+       0.5 * (zbar + 1.0) * (z_plane_plus_one_ - z_plane_minus_one_)) /
+      (get<2, 1>(jac) * get<2, 2>(jac));
+  // jac(2,1)=R1 sin(theta1)/rho^3
+  get<2, 1>(jac) /= cube(get<2, 2>(jac));
+  // jac(2,0)=R2 sin(theta2)
+  get<2, 0>(jac) = sqrt(
+      square(radius_two_) -
+      square(z_plane_minus_two_ - center_two_[2] +
+             0.5 * (zbar + 1.0) * (z_plane_plus_two_ - z_plane_minus_two_)));
+  // jac(1,2)=cot theta2/rho
+  get<1, 2>(jac) =
+      (z_plane_minus_two_ - center_two_[2] +
+       0.5 * (zbar + 1.0) * (z_plane_plus_two_ - z_plane_minus_two_)) /
+      (get<2, 0>(jac) * get<2, 2>(jac));
+  // jac(2,0)=R2 sin(theta2)/rho^3
+  get<2, 0>(jac) /= cube(get<2, 2>(jac));
+  // jac(1,1)=lambda rho^2
+  get<1, 1>(jac) = square(get<2, 2>(jac)) * (get<2, 2>(jac) - 1.0);
+
+  // Now fill Jacobian values
+  get<0, 0>(jac) =
+      square(ybar) * get<2, 1>(jac) +
+      (get<1, 1>(jac) + square(xbar)) * (get<2, 0>(jac) - get<2, 1>(jac)) +
+      xbar * (center_two_[0] - center_one_[0]) / get<2, 2>(jac);
+  get<1, 1>(jac) =
+      square(xbar) * get<2, 1>(jac) +
+      (get<1, 1>(jac) + square(ybar)) * (get<2, 0>(jac) - get<2, 1>(jac)) +
+      ybar * (center_two_[1] - center_one_[1]) / get<2, 2>(jac);
+  get<0, 1>(jac) = xbar * ybar * (get<2, 0>(jac) - 2.0 * get<2, 1>(jac)) +
+                   ybar * (center_two_[0] - center_one_[0]) / get<2, 2>(jac);
+  get<1, 0>(jac) = xbar * ybar * (get<2, 0>(jac) - 2.0 * get<2, 1>(jac)) +
+                   xbar * (center_two_[1] - center_one_[1]) / get<2, 2>(jac);
+  get<1, 2>(jac) =
+      0.5 * (get<0, 2>(jac) * (z_plane_plus_one_ - z_plane_minus_one_) *
+                 (get<2, 2>(jac) - 2.0) +
+             get<1, 2>(jac) * (z_plane_plus_two_ - z_plane_minus_two_) *
+                 (1.0 - get<2, 2>(jac)));
+  get<0, 2>(jac) = get<1, 2>(jac) * xbar;
+  get<1, 2>(jac) *= ybar;
+  get<2, 1>(jac) = (z_plane_minus_two_ - z_plane_minus_one_ +
+                    0.5 * (zbar + 1) *
+                        (z_plane_plus_two_ - z_plane_minus_two_ -
+                         z_plane_plus_one_ + z_plane_minus_one_)) /
+                   get<2, 2>(jac);
+  get<2, 0>(jac) = xbar * get<2, 1>(jac);
+  get<2, 1>(jac) *= ybar;
+  get<2, 2>(jac) =
+      0.5 * ((2.0 - get<2, 2>(jac)) * (z_plane_plus_one_ - z_plane_minus_one_) +
+             (get<2, 2>(jac) - 1.0) * (z_plane_plus_two_ - z_plane_minus_two_));
+  return jac;
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>
+UniformCylindricalSide::inv_jacobian(
+    const std::array<T, 3>& source_coords) const {
+  return determinant_and_inverse(jacobian(source_coords)).second;
+}
+
+void UniformCylindricalSide::pup(PUP::er& p) {
+  p | center_one_;
+  p | center_two_;
+  p | radius_one_;
+  p | radius_two_;
+  p | z_plane_plus_one_;
+  p | z_plane_minus_one_;
+  p | z_plane_plus_two_;
+  p | z_plane_minus_two_;
+}
+
+bool operator==(const UniformCylindricalSide& lhs,
+                const UniformCylindricalSide& rhs) {
+  // don't need to compare theta_max_one_ or theta_max_two_
+  // because they are uniquely determined from the other variables.
+  return lhs.center_one_ == rhs.center_one_ and
+         lhs.radius_one_ == rhs.radius_one_ and
+         lhs.z_plane_plus_one_ == rhs.z_plane_plus_one_ and
+         lhs.z_plane_minus_one_ == rhs.z_plane_minus_one_ and
+         lhs.center_two_ == rhs.center_two_ and
+         lhs.radius_two_ == rhs.radius_two_ and
+         lhs.z_plane_plus_two_ == rhs.z_plane_plus_two_ and
+         lhs.z_plane_minus_two_ == rhs.z_plane_minus_two_;
+}
+
+bool operator!=(const UniformCylindricalSide& lhs,
+                const UniformCylindricalSide& rhs) {
+  return not(lhs == rhs);
+}
+
+// Explicit instantiations
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                 \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>               \
+  UniformCylindricalSide::operator()(                                        \
+      const std::array<DTYPE(data), 3>& source_coords) const;                \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame> \
+  UniformCylindricalSide::jacobian(                                          \
+      const std::array<DTYPE(data), 3>& source_coords) const;                \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame> \
+  UniformCylindricalSide::inv_jacobian(                                      \
+      const std::array<DTYPE(data), 3>& source_coords) const;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
+                                      std::reference_wrapper<const double>,
+                                      std::reference_wrapper<const DataVector>))
+
+#undef DTYPE
+#undef INSTANTIATE
+
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/UniformCylindricalSide.hpp
+++ b/src/Domain/CoordinateMaps/UniformCylindricalSide.hpp
@@ -1,0 +1,659 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines the class UniformCylindricalSide.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <optional>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace domain::CoordinateMaps {
+
+/*!
+ * \ingroup CoordinateMapsGroup
+ *
+ * \brief Map from 3D unit right cylindrical shell to a volume that connects
+ *  portions of two spherical surfaces.
+ *
+ * \image html UniformCylSide.svg "A hollow cylinder maps to the shaded region."
+ *
+ * \details Consider two spheres with centers \f$C_1\f$ and \f$C_2\f$,
+ * and radii \f$R_1\f$ and \f$R_2\f$. Sphere 1 is assumed to be contained
+ * inside Sphere 2.
+ * Let sphere 1 be intersected by two
+ * planes normal to the \f$z\f$ axis and located at
+ * \f$z = z^{\pm}_{\mathrm{P}1}\f$,
+ * and let sphere 2 be intersected by two planes normal to the \f$z\f$ axis and
+ * located at \f$z = z^{\pm}_{\mathrm{P}2}\f$.  Here we assume that
+ * \f$z^{-}_{\mathrm{P}2} \leq z^{-}_{\mathrm{P}1}<
+ * z^{+}_{\mathrm{P}1} \leq z^{+}_{\mathrm{P}2}\f$.
+ *
+ * UniformCylindricalSide maps a 3D unit right cylindrical shell (with
+ * coordinates \f$(\bar{x},\bar{y},\bar{z})\f$ such that
+ * \f$-1\leq\bar{z}\leq 1\f$ and \f$1 \leq \bar{x}^2+\bar{y}^2 \leq 4\f$, where
+ * the values of 1 and 2 for the inner and outer cylindrical radii
+ * are arbitrary choices but are required by UniformCylindricalSide)
+ * to the shaded area in the figure above (with coordinates
+ * \f$(x,y,z)\f$).  The "inner surface" of the cylindrical shell
+ * \f$\bar{x}^2+\bar{y}^2=1\f$ is mapped to the portion of sphere 1
+ * that has \f$z^{-}_{\mathrm{P}1} \leq z \leq z^{+}_{\mathrm{P}1} \f$,
+ * and on this portion of the sphere the cosine of the polar angular coordinate
+ * \f$\cos\theta_1 =(z-C_1^z)/R_1\f$ is uniform in \f$\bar{z}\f$,
+ * and the angular coordinate \f$\phi_1 = \atan((y-C_1^y)/(x-C_1^x))\f$
+ * is the same as \f$\phi = \atan(\bar{y}/\bar{x})\f$.
+ * Likewise, the "outer surface" of the cylindrical shell
+ * \f$\bar{x}^2+\bar{y}^2=4\f$ is mapped to the portion of sphere 2
+ * that has \f$z^{-}_{\mathrm{P}2} \leq z \leq z^{+}_{\mathrm{P}2}
+ * \f$, and on this portion of the sphere the cosine of the azimuthal
+ * angular coordinate
+ * \f$\cos\theta_2 = (z-C_2^z)/R_2\f$ is uniform in \f$\bar{z}\f$,
+ * and the angular coordinate \f$\phi_2 =
+ * \atan((y-C_2^y)/(x-C_2^x))\f$ is the same as \f$\phi\f$.
+ *
+ * UniformCylindricalSide is different from CylindricalSide
+ * because of the distribution of points on the spheres, and because
+ * for UniformCylindricalSide the mapped portion of both Sphere 1
+ * and Sphere 2 are bounded by planes of constant \f$z\f$, whereas for
+ * CylindricalSide only one of the mapped portions is bounded by a
+ * plane (except for specially chosen map parameters).  Note that
+ * UniformCylindricalSide can be used to construct maps that connect
+ * an arbitrary number of nested spheres; this is not possible for
+ * CylindricalSide for more than 3 nested spheres because of this
+ * asymmetry between CylindricalSide's two spherical surfaces.
+ *
+ * Note that the entire region between Sphere 1 and Sphere 2 can be covered
+ * by a single cylindrical shell (mapped using UniformCylindricalSide) and
+ * two cylinders (each mapped by UniformCylindricalEndcap).
+ *
+ * UniformCylindricalSide is intended to be composed with `Wedge<2>` maps to
+ * construct a portion of a cylindrical domain for a binary system.
+ *
+ * UniformCylindricalSide can be used to construct a domain that is similar
+ * to, but not identical to, the one described briefly in the Appendix of
+ * \cite Buchman:2012dw.
+ * UniformCylindricalSide is used to construct the Blocks analogous to
+ * those labeled 'CA cylinder', 'EA cylinder', 'CB cylinder', 'EE cylinder',
+ * and 'EB cylinder' in Figure 20 of that paper.
+ *
+ * UniformCylindricalSide provides the following functions:
+ *
+ * ## operator()
+ *
+ * `operator()` maps \f$(\bar{x},\bar{y},\bar{z})\f$ to \f$(x,y,z)\f$
+ * according to
+ *
+ * \f{align}
+ * x &= C_1^x+\lambda(C_2^x-C_1^x) +
+ *        \cos\phi\left(R_1\sin\theta_1 +
+ *        \lambda(R_2\sin\theta_2-R_1\sin\theta_1)\right), \label{eq:x0} \\
+ * y &= C_1^y+\lambda(C_2^y-C_1^y) +
+ *        \sin\phi\left(R_1\sin\theta_1 +
+ *        \lambda(R_2\sin\theta_2-R_1\sin\theta_1)\right), \label{eq:x1} \\
+ * z &= C_1^z+\lambda(C_2^z-C_1^z) +
+ *        R_1\cos\theta_1 +
+ *        \lambda(R_2\cos\theta_2-R_1\cos\theta_1) \label{eq:x2}.
+ * \f}
+ *
+ * Here
+ * \f{align}
+ * \lambda  &= \bar{\rho}-1,\label{eq:lambdafromrhobar}\\
+ * \cos\theta_1 &= \cos\theta_{1 \mathrm{max}} +
+ *         \left(\cos\theta_{1 \mathrm{min}}-\cos\theta_{1 \mathrm{max}}\right)
+ *             \frac{\bar{z}+1}{2}\label{eq:deftheta1}\\
+ * \cos\theta_2 &= \cos\theta_{2 \mathrm{max}} +
+ *             \left(\cos\theta_{2 \mathrm{min}}-
+ *                   \cos\theta_{2 \mathrm{max}}\right)
+ *             \frac{\bar{z}+1}{2}\label{eq:deftheta2}\\
+ * \phi     &= \atan(\bar{y}/\bar{x})\label{eq:defphi},
+ * \f}
+ * where \f$\theta_{1 \mathrm{min}}\f$, \f$\theta_{2 \mathrm{min}}\f$,
+ * \f$\theta_{1 \mathrm{max}}\f$, and \f$\theta_{2 \mathrm{max}}\f$
+ * are defined by
+ * \f{align}
+ *   \label{eq:deftheta1min}
+ *   \cos(\theta_{1\mathrm{min}}) &= (z^{+}_{\mathrm{P}1}-C_1^z)/R_1,\\
+ *   \cos(\theta_{1\mathrm{max}}) &= (z^{-}_{\mathrm{P}1}-C_1^z)/R_1,\\
+ *   \cos(\theta_{2\mathrm{min}}) &= (z^{+}_{\mathrm{P}2}-C_2^z)/R_2,\\
+ *   \label{eq:deftheta2max}
+ *   \cos(\theta_{2\mathrm{max}}) &= (z^{-}_{\mathrm{P}2}-C_2^z)/R_2,
+ * \f}
+ * and
+ * \f{align}
+ * \bar{\rho} &= \sqrt{\bar{x}^2+\bar{y}^2}/\bar{R} \label{eq:defrhobar},
+ * \f}
+ * where \f$\bar{R}\f$ is the inner radius of the cylindrical shell in barred
+ * coordinates, which is always unity.
+ *
+ * Note that \f$\theta_{1\mathrm{min}}<\theta_{1\mathrm{max}}\f$ but
+ * \f$\cos\theta_{1\mathrm{min}}>\cos\theta_{1\mathrm{max}}\f$ (and same
+ * for sphere 2).
+ *
+ * Also note that Eqs. (\f$\ref{eq:deftheta1}\f$) and
+ * (\f$\ref{eq:deftheta2}\f$) can be simplified using Eqs.
+ * (\f$\ref{eq:deftheta1min}\f$-\f$\ref{eq:deftheta2max}\f$):
+ * \f{align}
+ * R_1\cos\theta_1 &= z^{-}_{\mathrm{P}1}-C_1^z
+ *        +(z^{+}_{\mathrm{P}1}-z^{-}_{\mathrm{P}1})
+ *             \frac{\bar{z}+1}{2}\label{eq:deftheta1alt}\\
+ * R_2\cos\theta_2 &= z^{-}_{\mathrm{P}2}-C_2^z
+ *        +(z^{+}_{\mathrm{P}2}-z^{-}_{\mathrm{P}2})
+ *             \frac{\bar{z}+1}{2}\label{eq:deftheta2alt}\\
+ * \f}
+ *
+ * ## inverse
+ *
+ * Given \f$(x,y,z)\f$ we want to find \f$(\bar{x},\bar{y},\bar{z})\f$.
+ * From Eqs. (\f$\ref{eq:x2}\f$), (\f$\ref{eq:deftheta1alt}\f$), and
+ * (\f$\ref{eq:deftheta2alt}\f$) we can write \f$\bar{z}\f$ as a function
+ * of \f$\lambda\f$:
+ *
+ * \f{align}
+ * \frac{1+\bar{z}}{2} &=
+ *   \frac{z +
+ *     \lambda (z^{-}_{\mathrm{P}1}-z^{-}_{\mathrm{P}2}) - z^{-}_{\mathrm{P}1}}
+ *   {(1-\lambda)(z^{+}_{\mathrm{P}1}-z^{-}_{\mathrm{P}1})
+ *    + \lambda(z^{+}_{\mathrm{P}2}-z^{-}_{\mathrm{P}2})}
+ *                 \label{eq:zbar_from_lambda},
+ * \f}
+ * Note that the denominator of
+ * Eq. (\f$\ref{eq:zbar_from_lambda}\f$) is always positive because
+ * \f$0\leq\lambda\leq 1\f$, \f$z^{+}_{\mathrm{P}1}>z^{-}_{\mathrm{P}1}\f$,
+ * and \f$z^{+}_{\mathrm{P}2}>z^{-}_{\mathrm{P}2}\f$.
+ *
+ * By eliminating \f$\phi\f$ from Eqs. (\f$\ref{eq:x0}\f$) and
+ * (\f$\ref{eq:x1}\f$) we find that \f$\lambda\f$ is the solution
+ * of \f$Q(\lambda)=0\f$, where
+ *
+ * \f{align}
+ * Q(\lambda) &= \left(x-C_1^x-\lambda(C_2^x-C_1^x)\right)^2+
+ *               \left(y-C_1^y-\lambda(C_2^y-C_1^y)\right)^2-
+ *               \left((1-\lambda)R_1\sin\theta_1 +
+ *               \lambda R_2\sin\theta_2\right)^2.\label{eq:defQ}
+ * \f}
+ * Here \f$\theta_1\f$ and \f$\theta_2\f$ are functions
+ * of \f$\bar{z}\f$ through Eqs. (\f$\ref{eq:deftheta1alt}\f$) and
+ * (\f$\ref{eq:deftheta2alt}\f$), and \f$\bar{z}\f$ is a function of
+ * \f$\lambda\f$ through Eq. (\f$\ref{eq:zbar_from_lambda}\f$).
+ *
+ * We solve \f$Q(\lambda)=0\f$ numerically; it is a one-dimensional
+ * root-finding problem.
+ *
+ * Once we have determined \f$\lambda\f$, we then obtain \f$\bar{z}\f$
+ * from Eq. (\f$\ref{eq:zbar_from_lambda}\f$), and we obtain \f$\phi\f$ from
+ *
+ * \f{align}
+ *  \tan\phi &=
+ *  \frac{y-C_1^y-\lambda(C_2^y-C_1^y)}{x-C_1^x-\lambda(C_2^x-C_1^x)}.
+ * \f}
+ *
+ * Then \f$\bar{\rho}\f$ is obtained from Eq. (\f$\ref{eq:lambdafromrhobar}\f$)
+ * and \f$\bar{x}\f$ and \f$\bar{y}\f$ are obtained from
+ *
+ * \f{align}
+ *   \bar{x} &= \bar{\rho}\bar{R}\cos\phi,\\
+ *   \bar{y} &= \bar{\rho}\bar{R}\sin\phi.
+ * \f}
+ *
+ * ### Considerations when root-finding.
+ *
+ * We solve \f$Q(\lambda)=0\f$ numerically for \f$\lambda\f$,
+ * where \f$Q(\lambda)\f$ is given by Eq. (\f$\ref{eq:defQ}\f$).
+ *
+ * ##### min/max values of \f$\lambda\f$:
+ *
+ * Note that the root we care about must have \f$-1\leq\bar{z}\leq 1\f$;
+ * therefore from Eq. (\f$\ref{eq:zbar_from_lambda}\f$) we have
+ *
+ * \f{align}
+ *   \lambda_{\mathrm{min}} &=
+ *   \mathrm{max}\left\{0,
+ *              \frac{z-z^{+}_{\mathrm{P}1}}
+ *                 {(z^{+}_{\mathrm{P}2}-z^{+}_{\mathrm{P}1})},
+ *              \frac{z^{-}_{\mathrm{P}1}-z}
+ *                 {(z^{-}_{\mathrm{P}1}-z^{-}_{\mathrm{P}2})}
+ *      \right\}\label{eq:lambdamin}
+ * \f}
+ * In the case where \f$z^{+}_{\mathrm{P}2}=z^{+}_{\mathrm{P}1}\f$
+ * we treat the middle term in Eq.(\f$\ref{eq:lambdamin}\f$) as zero since
+ * in that case \f$z-z^{+}_{\mathrm{P}1}\f$ can never be positive for
+ * \f$x^2\f$ in the range of the map, and for
+ * \f$z=z^{+}_{\mathrm{P}2}=z^{+}_{\mathrm{P}1}\f$
+ * it turns out that
+ * (\f$\ref{eq:zbar_from_lambda}\f$) places no restriction on
+ * \f$\lambda_{\mathrm{min}}\f$.  For the same reason, if
+ * \f$z^{-}_{\mathrm{P}2}=z^{-}_{\mathrm{P}1}\f$ we treat
+ * the last term in Eq.(\f$\ref{eq:lambdamin}\f$) as zero.
+ *
+ * We look for a root only between \f$\lambda_{\mathrm{min}}\f$
+ * and \f$\lambda_{\mathrm{max}}=1\f$.
+ *
+ * ##### Roots within roundoff of min or max \f$\lambda\f$
+ *
+ * Sometimes a root is within roundoff of \f$\lambda_{\mathrm{min}}\f$.
+ * In this case, the root might not be bracketed by
+ * \f$[\lambda_{\mathrm{min}},\lambda_{\mathrm{max}}]\f$ if the root
+ * is slightly outside that interval by roundoff error.  If we find that
+ * \f$Q(\lambda_{\mathrm{min}})\f$ is near zero but has the wrong sign,
+ * then we slightly expand the interval as follows:
+ *
+ * \f{align}
+ *    \lambda_{\mathrm{min}} \to \lambda_{\mathrm{min}}
+ *  - 2 \frac{Q(\lambda_{\mathrm{min}})}{Q'(\lambda_{\mathrm{min}})},
+ * \f}
+ *
+ * where \f$Q'(\lambda_{\mathrm{min}})\f$ is the derivative of the function
+ * in Eq. (\f$\ref{eq:defQ}\f$). Note that without the factor of 2, this is
+ * a Newton-Raphson step; the factor of 2 is there to overcompensate so that
+ * the new \f$\lambda_{\mathrm{min}}\f$ brackets the root.
+ *
+ * Note that by differentiating Eqs. (\f$\ref{eq:defQ}\f$) and
+ * (\f$\ref{eq:zbar_from_lambda}\f$), one obtains
+ *
+ * \f{align}
+ * Q'(\lambda) =& -2 \left[
+ *      \left(x-C_1^x-\lambda(C_2^x-C_1^x)\right)(C_2^x-C_1^x)+
+ *      \left(y-C_1^y-\lambda(C_2^y-C_1^y)\right)(C_2^y-C_1^y)
+ *      \right]\nonumber \\
+ *     &
+ *    -\left[
+ *    2(R_2\sin\theta_2-R_1\sin\theta_1)
+ *    -(1-\lambda)\cot\theta_1 (z^{+}_{\mathrm{P}1}-z^{-}_{\mathrm{P}1})
+ *     \frac{d\bar{z}}{d\lambda} \right. \nonumber \\
+ *     & \left.\qquad
+ *    -\lambda \cot\theta_2 (z^{+}_{\mathrm{P}2}-z^{-}_{\mathrm{P}2})
+ *     \frac{d\bar{z}}{d\lambda}
+ *    \right]
+ *    \left((1-\lambda)R_1\sin\theta_1 +
+ *                \lambda R_2\sin\theta_2\right), \label{eq:defQderiv}
+ * \f}
+ *
+ * where
+ * \f{align}
+ *  \frac{d\bar{z}}{d\lambda} &=
+ *  \frac{(1-\bar{z})(z^{-}_{\mathrm{P}1}-z^{-}_{\mathrm{P}2})
+ *       -(1+\bar{z})(z^{+}_{\mathrm{P}2}-z^{+}_{\mathrm{P}1})}
+ *        {(1-\lambda)(z^{+}_{\mathrm{P}1}-z^{-}_{\mathrm{P}1})
+ *       + \lambda(z^{+}_{\mathrm{P}2}-z^{-}_{\mathrm{P}2})}
+ *  \label{eq:dzbar_dlambda}.
+ * \f}
+ *
+ * A root within roundoff of \f$\lambda_{\mathrm{max}}\f$ is treated
+ * similarly.
+ *
+ * #### Special cases:
+ *
+ * For some points on the boundary of the mapped domain,
+ * \f$\lambda_{\mathrm{min}}\f$ will be within roundoff of
+ * \f$\lambda=1\f$. We check explicitly for this case, and we
+ * compute the root as exactly \f$\lambda=1\f$.
+ *
+ * ### Quick rejection of points out of range of the map.
+ *
+ * It is expected that `inverse()` will often be passed points
+ * \f$(x,y,z)\f$ that are out of the range of the map; in this case
+ * `inverse()` returns a `std::nullopt`. To avoid the difficulty and
+ * expense of attempting to solve \f$Q(\lambda)=0\f$ numerically
+ * for such points (and then having this solution fail), it is useful
+ * to quickly reject points \f$(x,y,z)\f$ that are outside the range
+ * of the map.
+ *
+ * Any point in the range of the map must be inside or on
+ * sphere 2, and it must be outside or on sphere 1, so the inverse map
+ * can immediately return a default-constructed
+ * `std::optional<std::array<double, 3>>` for a point that does not
+ * satisfy these conditions.
+ *
+ * Likewise, the inverse map can immediately reject any point with
+ * \f$z < z^{-}_{\mathrm{P}2}\f$ or \f$z > z^{+}_{\mathrm{P}2}\f$.
+ *
+ * Finally, for \f$z^{+}_{\mathrm{P}2}\neq z^{+}_{\mathrm{P}1}\f$,
+ * consider the circle \f$S^{+}_1\f$
+ * defining the intersection of sphere 1
+ * and the plane \f$z = z^{+}_{\mathrm{P}1}\f$; this circle has radius
+ * \f$r_1 = R_1 \sin\theta_{1\mathrm{min}}\f$.  Similarly, the circle
+ * \f$S^{+}_2\f$ defining the intersection of sphere 2 and the plane \f$z =
+ * z^{+}_{\mathrm{P}2}\f$ has radius \f$r_2 = R_2
+ * \sin\theta_{2\mathrm{min}}\f$.  Now consider the cone that passes
+ * through these two circles.  A point in the range of the map must be outside
+ * (where "outside" means farther from the \f$z\f$ axis) or on this cone.
+ * The cone can be defined parametrically as
+ *
+ * \f{align}
+ * x_c &= C_1^x + \tilde{\lambda}(C_2^x-C_1^x) +
+ *      \cos\varphi (r_1 + \tilde{\lambda} (r_2 -r_1)),\\
+ * y_c &= C_1^y + \tilde{\lambda}(C_2^y-C_1^y),+
+ *      \sin\varphi (r_1 + \tilde{\lambda} (r_2 -r_1)),\\
+ * z_c &= z^{+}_{\mathrm{P}1} +
+ *        \tilde{\lambda}(z^{+}_{\mathrm{P}2}-z^{+}_{\mathrm{P}1}),
+ * \f}
+ *
+ * where \f$(x_c,y_c,z_c)\f$ is a point on the cone, and the two
+ * parameters defining a point on the cone are the angle \f$\varphi\f$
+ * around the cone and the parameter \f$\tilde{\lambda}\f$, which is
+ * defined to be zero on \f$S^{+}_1\f$ and unity on \f$S^{+}_2\f$.
+ *
+ * Given an arbitrary point \f$(x, y, z)\f$, we can determine whether
+ * or not that point is inside the cone as follows.  First determine
+ *
+ * \f{align}
+ *  \tilde{\lambda} &= \frac{z - z^{+}_{\mathrm{P}1}}
+ *   {z^{+}_{\mathrm{P}2}-z^{+}_{\mathrm{P}1}}, \\
+ *  \tilde{x} &= x - C_1^x - \tilde{\lambda} (C_2^x-C_1^x),\\
+ *  \tilde{y} &= y - C_1^y - \tilde{\lambda} (C_2^y-C_1^y).\\
+ * \f}
+ *
+ * Then the condition for the point to be outside or on the cone is
+ * \f{align}
+ * \sqrt{\tilde{x}^2+\tilde{y}^2} \ge r_1 + (r_2-r_1)\tilde{\lambda}.
+ * \f}
+ *
+ * The inverse map therefore rejects any points that do
+ * not satisfy this criterion. The cone criterion makes sense only
+ * for points with \f$z\geq z^{+}_{\mathrm{P}1}\f$.
+ *
+ * For \f$z^{-}_{\mathrm{P}2} \neq z^{-}_{\mathrm{P}1}\f$,
+ * a similar cone can be constructed for the southern hemisphere. That
+ * cone passes through
+ * the circle \f$S^{-}_1\f$
+ * defining the intersection of sphere 1
+ * and the plane \f$z = z^{-}_{\mathrm{P}1}\f$ and the circle
+ * \f$S^{-}_2\f$ defining the intersection of sphere 2 and the plane \f$z =
+ * z^{-}_{\mathrm{P}2}\f$.  The inverse map rejects any point that is inside
+ * that cone as well, provided that the point has
+ * \f$z\leq z^{-}_{\mathrm{P}1}\f$.  For points with
+ * \f$z > z^{-}_{\mathrm{P}1}\f$ checking the cone criterion
+ * does not make sense.
+ *
+ * ## jacobian
+ *
+ * From Eqs. (\f$\ref{eq:deftheta1alt}\f$) and (\f$\ref{eq:deftheta2alt}\f$)
+ * we see that \f$\theta_1\f$ and \f$\theta_2\f$ depend on \f$\bar{z}\f$ and
+ * are independent of \f$\bar{x}\f$ and \f$\bar{y}\f$, and that
+ * \f{align}
+ * \frac{\partial (R_1\cos\theta_1)}{\partial\bar{z}}
+ * &= \frac{1}{2}(z^{+}_{\mathrm{P}1}-z^{-}_{\mathrm{P}1}),
+ *     \label{eq:dcostheta1} \\
+ * \frac{\partial (R_2\cos\theta_2)}{\partial\bar{z}}
+ * &= \frac{1}{2}(z^{+}_{\mathrm{P}2}-z^{-}_{\mathrm{P}2}),
+ *     \label{eq:dcostheta2} \\
+ * \frac{\partial (R_1\sin\theta_1)}{\partial\bar{z}}
+ * &= -\frac{1}{2}\cot\theta_1 (z^{+}_{\mathrm{P}1}-z^{-}_{\mathrm{P}1}),
+ *     \label{eq:dsintheta1} \\
+ * \frac{\partial (R_2\sin\theta_2)}{\partial\bar{z}}
+ * &= -\frac{1}{2}\cot\theta_2(z^{+}_{\mathrm{P}2}-z^{-}_{\mathrm{P}2}),
+ *     \label{eq:dsintheta2}
+ * \f}
+ *
+ * Also, from Eqs. (\f$\ref{eq:defphi}\f$) and (\f$\ref{eq:defrhobar}\f$)
+ * we have
+ * \f{align}
+ * \frac{\partial\cos\phi}{\partial\bar{x}}
+ *  &= \frac{\bar{y}^2}{\bar{R}^3\bar{\rho}^3},
+ *  \label{eq:dcosphidxbar} \\
+ * \frac{\partial\cos\phi}{\partial\bar{y}}
+ *  &= -\frac{\bar{x}\bar{y}}{\bar{R}^3\bar{\rho}^3},
+ *  \label{eq:dcosphidybar} \\
+ * \frac{\partial\sin\phi}{\partial\bar{x}}
+ *  &= -\frac{\bar{x}\bar{y}}{\bar{R}^3\bar{\rho}^3},
+ *  \label{eq:dsinphidxbar} \\
+ * \frac{\partial\sin\phi}{\partial\bar{y}}
+ *  &= \frac{\bar{x}^2}{\bar{R}^3\bar{\rho}^3},
+ *  \label{eq:dsinphidybar}
+ * \f}
+ * and we know that \f$\phi\f$ is independent of \f$\bar{z}\f$.
+ *
+ * Finally, from Eqs. (\f$\ref{eq:defrhobar}\f$) and
+ * (\f$\ref{eq:lambdafromrhobar}\f$) we have
+ *
+ * \f{align}
+ * \frac{\partial\lambda}{\partial\bar{x}}
+ *  &= \frac{\bar{x}}{\bar{R}^2\bar{\rho}},
+ *  \label{eq:dlambdadxbar} \\
+ * \frac{\partial\lambda}{\partial\bar{y}}
+ *  &= \frac{\bar{y}}{\bar{R}^2\bar{\rho}},
+ *  \label{eq:dlambdadybar}
+ * \f}
+ * with no dependence on \f$\bar{z}\f$.
+ *
+ * Putting these results together yields
+ * \f{align}
+ * \frac{\partial x^0}{\partial \bar{x}} &=
+ * \frac{\bar{y}^2}{\bar{\rho}^3\bar{R}^3}R_1\sin\theta_1 +
+ *        (R_2\sin\theta_2-R_1\sin\theta_1)
+ *        \frac{\lambda \bar{R}^2\bar\rho^2+\bar{x}^2}{\bar\rho^3\bar{R}^3}
+ *  + \frac{\bar{x}}{\bar\rho\bar{R}^2}(C_2^x-C_1^x),\\
+ * \frac{\partial x^0}{\partial \bar{y}} &=
+ * \frac{\bar{x}\bar{y}}{\bar{\rho}^3\bar{R}^3}
+ *        (R_2\sin\theta_2-2 R_1\sin\theta_1)
+ *  + \frac{\bar{y}}{\bar\rho\bar{R}^2}(C_2^x-C_1^x),\\
+ * \frac{\partial x^0}{\partial \bar{z}} &=
+ * -\frac{1}{2}\frac{\bar{x}}{\bar\rho\bar{R}}\left[
+ *   \cot\theta_1(1-\lambda)(z^{+}_{\mathrm{P}1}-z^{-}_{\mathrm{P}1})+
+ *   \cot\theta_2\lambda(z^{+}_{\mathrm{P}2}-z^{-}_{\mathrm{P}2})\right],\\
+ * \frac{\partial x^1}{\partial \bar{x}} &=
+ * \frac{\bar{x}\bar{y}}{\bar{\rho}^3\bar{R}^3}
+ *        (R_2\sin\theta_2-2 R_1\sin\theta_1)
+ *  + \frac{\bar{x}}{\bar\rho\bar{R}^2}(C_2^y-C_1^y),\\
+ * \frac{\partial x^1}{\partial \bar{y}} &=
+ * \frac{\bar{x}^2}{\bar{\rho}^3\bar{R}^3}R_1\sin\theta_1 +
+ *        (R_2\sin\theta_2-R_1\sin\theta_1)
+ *        \frac{\lambda \bar{R}^2\bar\rho^2+\bar{y}^2}{\bar\rho^3\bar{R}^3}
+ *  + \frac{\bar{y}}{\bar\rho\bar{R}^2}(C_2^y-C_1^y),\\
+ * \frac{\partial x^1}{\partial \bar{z}} &=
+ * -\frac{1}{2}\frac{\bar{y}}{\bar\rho\bar{R}}\left[
+ *   \cot\theta_1(1-\lambda)(z^{+}_{\mathrm{P}1}-z^{-}_{\mathrm{P}1})+
+ *   \cot\theta_2\lambda(z^{+}_{\mathrm{P}2}-z^{-}_{\mathrm{P}2})\right],\\
+ * \frac{\partial x^2}{\partial \bar{x}} &=
+ *  \frac{\bar{x}}{\bar\rho\bar{R}^2}\left(
+ *        C_2^z-C_1^z + R_2\cos\theta_2-R_1\cos\theta_1\right),\\
+ * \frac{\partial x^2}{\partial \bar{y}} &=
+ *  \frac{\bar{y}}{\bar\rho\bar{R}^2}\left(
+ *        C_2^z-C_1^z + R_2\cos\theta_2-R_1\cos\theta_1\right),\\
+ * \frac{\partial x^2}{\partial \bar{z}} &=
+ * \frac{1}{2}(1-\lambda)(z^{+}_{\mathrm{P}1}-z^{-}_{\mathrm{P}1})+
+ * \frac{1}{2}\lambda(z^{+}_{\mathrm{P}2}-z^{-}_{\mathrm{P}2}).
+ * \f}
+ *
+ * ## inv_jacobian
+ *
+ * The inverse Jacobian is computed by numerically inverting the
+ * Jacobian.
+ *
+ * ## Restrictions on map parameters
+ *
+ * We demand that Sphere 1 is fully contained inside Sphere 2, and
+ * that the two spheres have at least some small separation between
+ * them. In particular, we demand that
+ * \f{align}
+ *  0.98 R_2 &\geq R_1 + |C_1-C_2|, \label{eq:spherecontained}
+ * \f}
+ * where 0.98 is a safety factor. It is possible to construct a valid
+ * map without this assumption, but the assumption simplifies the
+ * code, and the expected use cases obey this restriction.
+ *
+ * We also demand that \f$R_1 \geq 0.08 R_2\f$.  Again, this assumption
+ * is made for accuracy purposes and might be relaxed.
+ *
+ * ### Invertibility condition
+ *
+ * Consider the line segment \f$L^+_1\f$ that connects a point on the
+ * circle \f$S^+_1\f$ (the circle formed by the intersection of sphere 1
+ * and the plane \f$z=z^+_{\mathrm{P}1}\f$) with the center of the
+ * circle \f$S^+_1\f$.  Consider another line segment \f$L^+_2\f$ that
+ * connects the same point on the circle \f$S^+_1\f$ with the
+ * corresponding point on the circle \f$S^+_2\f$ (the circle formed by
+ * the intersection of sphere 2 and the plane
+ * \f$z=z^+_{\mathrm{P}2}\f$). Now consider the angle between \f$L^+_1\f$
+ * and \f$L^+_2\f$, as measured from the interior of sphere 1, and Let
+ * \f$\alpha^+\f$ be the minimum value of this angle over the circle.
+ * \f$\alpha^+\f$ is shown in the figure above. If
+ * \f$\alpha^+ < \theta_{1 \mathrm{min}}\f$, then the line segment \f$L^+_2\f$
+ * twice intersects the unmapped portion of sphere 1 near the north pole,
+ * so the map is ill-defined.
+ * Similarly, if \f$\alpha^+ < \theta_{2 \mathrm{min}}\f$,
+ * then the line segment \f$L^+_2\f$ twice intersects the mapped portion of
+ * sphere 2 near the north pole, and again the map is poorly defined.
+ * Therefore we demand that the map parameters satisfy
+ * - \f$\alpha^+ > 1.1 \theta_{1 \mathrm{min}}\f$
+ * - \f$\alpha^+ > 1.1 \theta_{2 \mathrm{min}}\f$
+ *
+ * where 1.1 is a safety factor.
+ *
+ * Similarly, one can define an angle \f$\alpha^-\f$ for the region
+ * near the south pole, and we require similar restrictions on that angle.
+ *
+ * ### Restrictions on z-planes
+ *
+ * We also demand that either
+ * \f$z^+_{\mathrm{P}1} = z^+_{\mathrm{P}2}\f$
+ * or that \f$z^+_{\mathrm{P}1} <= z^+_{\mathrm{P}2} -0.03 R_2\f$.
+ * Similarly, we demand that either \f$z^-_{\mathrm{P}1} = z^-_{\mathrm{P}2}\f$
+ * or \f$z^-_{\mathrm{P}1} >= z^-_{\mathrm{P}2} + 0.03 R_2\f$.
+ * These restrictions follow expected use cases and avoid extreme distortions.
+ *
+ * ### Restrictions for unequal z planes
+ * For \f$z^+_{\mathrm{P}1} \neq z^+_{\mathrm{P}2}\f$ and
+ * \f$z^-_{\mathrm{P}1} \neq z^-_{\mathrm{P}2}\f$, we assume the following
+ * restrictions on other parameters:
+ *
+ * We prohibit a tiny Sphere 1 near the edge of Sphere 2 by demanding that
+ * \f{align}
+ *  C^z_1 - R_1 &\leq C^z_2 + R_2/5,\\
+ *  C^z_1 + R_1 &\geq C^z_2 - R_2/5.
+ * \f}
+ * We also demand that the polar axis of Sphere 2 intersects Sphere 1
+ * somewhere:
+ * \f{align}
+ * \sqrt{(C^x_1-C^x_2)^2 + (C^y_1-C^y_2)^2} &\leq R_1.
+ * \f}
+ * and we demand that Sphere 1 is not too close to the edge of Sphere 2
+ * in the \f$x\f$ or \f$y\f$ directions:
+ * \f{align}
+ * \sqrt{(C^y_1-C^y_2)^2 + (C^y_1-C^y_2)^2} &\leq \mathrm{max}(0,0.95 R_2-R_1),
+ * \f}
+ * where the max avoids problems when \f$0.95 R_2-R_1\f$ is negative
+ * (which, if it occurs, means that the \f$x\f$ and \f$y\f$ centers of the
+ * two spheres are equal).
+ *
+ * We require that the z planes in the above figures lie above/below
+ * the centers of the corresponding spheres and are not too close to
+ * the centers or edges of those spheres; specificially, we demand
+ * that
+ * \f{align}
+ *   \label{eq:theta_1_min_res}
+ *   0.15\pi &< \theta_{1 \mathrm{min}} < 0.4\pi \\
+ *   \label{eq:theta_1_max_res}
+ *   0.6\pi &< \theta_{1 \mathrm{max}} < 0.85\pi \\
+ *   \label{eq:theta_2_min_res}
+ *   0.15\pi &< \theta_{2 \mathrm{min}} < 0.4\pi \\
+ *   \label{eq:theta_2_max_res}
+ *   0.6\pi &< \theta_{2 \mathrm{max}} < 0.85\pi .
+ * \f}
+ *
+ * Here the numerical values are safety factors.
+ * These restrictions are not strictly necessary but are made for simplicity.
+ * Increasing the range will make the maps less accurate because the domain
+ * is more distorted. These parameters
+ * can be changed provided the unit tests are changed to test the
+ * appropriate parameter ranges.
+ *
+ * ### Restrictions for equal z planes
+ *
+ * If \f$z^+_{\mathrm{P}1} = z^+_{\mathrm{P}2}\f$ or
+ * \f$z^-_{\mathrm{P}1} = z^-_{\mathrm{P}2}\f$ we demand that
+ * \f$C_1^x=C_2^x\f$ and \f$C_1^y=C_2^y\f$, which simplifies the cases
+ * we need to test and agrees with our expected use cases.
+ * We also demand
+ * \f{align}
+ *   z^+_{\mathrm{P}2} &\geq z^-_{\mathrm{P}2} + 0.18 R_2
+ * \f}
+ * This condition is necessary because for unequal z planes,
+ * \f$\theta_{2 \mathrm{min}}\f$ and
+ * \f$\theta_{2 \mathrm{max}}\f$ are no longer required
+ * to be on opposite sides of the equator of sphere 2 (see the paragraph below).
+ *
+ * As in the case with unequal z planes, we require that the
+ * z planes in the above figures lie above/below
+ * the centers of the corresponding spheres and are not too close to
+ * the centers or edges of those spheres, but some of the restrictions are
+ * relaxed because of expected use cases.  The conditions are the
+ * same as Eqs. (\f$\ref{eq:theta_1_min_res}\f$--\f$\ref{eq:theta_2_max_res}\f$)
+ * except if \f$z^+_{\mathrm{P}1} = z^+_{\mathrm{P}2}\f$
+ * we replace Eq. (\f$\ref{eq:theta_2_min_res}\f$) with
+ * \f{align}
+ *   0.15\pi &< \theta_{2 \mathrm{min}} < 0.75\pi ,
+ * \f}
+ * and if \f$z^-_{\mathrm{P}1} = z^-_{\mathrm{P}2}\f$ we replace
+ * Eq. (\f$\ref{eq:theta_2_max_res}\f$) with
+ * \f{align}
+ *   0.25\pi &< \theta_{2 \mathrm{max}} < 0.85\pi .
+ * \f}
+ */
+class UniformCylindricalSide {
+ public:
+  static constexpr size_t dim = 3;
+  UniformCylindricalSide(const std::array<double, 3>& center_one,
+                         const std::array<double, 3>& center_two,
+                         double radius_one, double radius_two,
+                         double z_plane_plus_one, double z_plane_minus_one,
+                         double z_plane_plus_two, double z_plane_minus_two);
+  UniformCylindricalSide() = default;
+  ~UniformCylindricalSide() = default;
+  UniformCylindricalSide(UniformCylindricalSide&&) = default;
+  UniformCylindricalSide(const UniformCylindricalSide&) = default;
+  UniformCylindricalSide& operator=(const UniformCylindricalSide&) = default;
+  UniformCylindricalSide& operator=(UniformCylindricalSide&&) = default;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(
+      const std::array<T, 3>& source_coords) const;
+
+  /// The inverse function is only callable with doubles because the inverse
+  /// might fail if called for a point out of range, and it is unclear
+  /// what should happen if the inverse were to succeed for some points in a
+  /// DataVector but fail for other points.
+  std::optional<std::array<double, 3>> inverse(
+      const std::array<double, 3>& target_coords) const;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> jacobian(
+      const std::array<T, 3>& source_coords) const;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> inv_jacobian(
+      const std::array<T, 3>& source_coords) const;
+
+  // clang-tidy: google runtime references
+  void pup(PUP::er& p);  // NOLINT
+
+  static bool is_identity() { return false; }
+
+ private:
+  friend bool operator==(const UniformCylindricalSide& lhs,
+                         const UniformCylindricalSide& rhs);
+  std::array<double, 3> center_one_{};
+  std::array<double, 3> center_two_{};
+  double radius_one_{std::numeric_limits<double>::signaling_NaN()};
+  double radius_two_{std::numeric_limits<double>::signaling_NaN()};
+  double z_plane_plus_one_{std::numeric_limits<double>::signaling_NaN()};
+  double z_plane_minus_one_{std::numeric_limits<double>::signaling_NaN()};
+  double z_plane_plus_two_{std::numeric_limits<double>::signaling_NaN()};
+  double z_plane_minus_two_{std::numeric_limits<double>::signaling_NaN()};
+};
+
+bool operator!=(const UniformCylindricalSide& lhs,
+                const UniformCylindricalSide& rhs);
+}  // namespace domain::CoordinateMaps

--- a/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
@@ -25,6 +25,7 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   Test_TimeDependentHelpers.cpp
   Test_UniformCylindricalEndcap.cpp
+  Test_UniformCylindricalSide.cpp
   Test_Wedge2D.cpp
   Test_Wedge3D.cpp
   )

--- a/tests/Unit/Domain/CoordinateMaps/Test_UniformCylindricalSide.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_UniformCylindricalSide.cpp
@@ -1,0 +1,518 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <optional>
+#include <random>
+
+#include "Domain/CoordinateMaps/UniformCylindricalSide.hpp"
+#include "Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp"
+#include "NumericalAlgorithms/RootFinding/TOMS748.hpp"
+
+namespace domain {
+
+namespace {
+
+void test_uniform_cylindrical_side_planes_equal(
+    const bool flip_z_axis = false) {
+  INFO("UniformCylindricalSidePlanesEqual");
+
+  // Set up random number generator
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> unit_dis(0.0, 1.0);
+  std::uniform_real_distribution<> interval_dis(-1.0, 1.0);
+  std::uniform_real_distribution<> angle_dis(0.0, 2.0 * M_PI);
+
+  // Choose some random center for sphere_two
+  const std::array<double, 3> center_two = {
+      interval_dis(gen), interval_dis(gen), interval_dis(gen)};
+  CAPTURE(center_two);
+
+  // Choose a random radius of sphere_two, reasonably large.
+  const double radius_two = 6.0 * (unit_dis(gen) + 1.0);
+  CAPTURE(radius_two);
+
+  // Choose an angle for the positive z-plane
+  const double min_angle_shared = 0.15;
+  const double max_angle_shared = 0.75;
+  const double z_plane_plus_two =
+      center_two[2] +
+      cos((min_angle_shared +
+           (max_angle_shared - min_angle_shared) * unit_dis(gen)) *
+          M_PI) *
+          radius_two;
+  const double z_plane_plus_one = z_plane_plus_two;
+  CAPTURE(z_plane_plus_two);
+  CAPTURE(z_plane_plus_one);
+
+  // Choose an angle for the negative z-plane for sphere 2
+  // Note that min_angle_two must be < 1-max_angle_shared
+  // (otherwise we cannot fit a sphere_one)
+  // max_angle_two comes from the requirement that
+  // z_plane_minus_two < z_plane_plus_two - 0.18 radius_two.
+  const double min_angle_two = 0.15;
+  const double max_angle_two =
+      center_two[2] < z_plane_plus_two
+          ? 0.4
+          : std::min(0.4, acos((center_two[2] - z_plane_plus_two) / radius_two +
+                               0.18) /
+                              M_PI);
+  CHECK(min_angle_two < max_angle_two);
+
+  const double z_plane_minus_two =
+      center_two[2] -
+      cos((min_angle_two + (max_angle_two - min_angle_two) * unit_dis(gen)) *
+          M_PI) *
+          radius_two;
+  CAPTURE(z_plane_minus_two);
+
+  // Choose z_plane_frac_minus_one=(z_plane_minus_one-center_one[2])/radius_one
+  // (note that this quantity is < 0).
+  const double min_angle = 0.15;
+  const double max_angle = 0.4;
+  const double z_plane_frac_minus_one =
+      -cos((min_angle + (max_angle - min_angle) * unit_dis(gen)) * M_PI);
+
+  // Choose z_plane_frac_plus_one=(z_plane_plus_one-center_one[2])/radius_one
+  const double z_plane_frac_plus_one =
+      cos((min_angle + (max_angle - min_angle) * unit_dis(gen)) * M_PI);
+
+  // Choose radius of sphere_one.
+  const double radius_one = [&z_plane_frac_plus_one, &z_plane_frac_minus_one,
+                             &radius_two, &center_two, &z_plane_plus_one,
+                             &z_plane_minus_two, &unit_dis, &gen]() {
+    // max_radius_one_planes is determined by the condition
+    // z_plane_minus_one >= z_plane_minus_two + 0.03 * radius_two
+    // The expression below is derived by
+    // evaluating z_plane_minus_one using the formula for
+    // z_plane_frac_minus_one, and eliminating center_one[2] using the formula
+    // for z_plane_frac_plus_one.
+    const double max_radius_one_planes =
+        (z_plane_plus_one - z_plane_minus_two - 0.03 * radius_two) /
+        (z_plane_frac_plus_one - z_plane_frac_minus_one);
+
+    // max_radius_one_fit is determined by the condition that
+    // 0.98 radius_two >= radius_one + |C_1-C_2|,
+    // eliminating center_one[2] using the formula
+    // for z_plane_frac_plus_one.
+    const double max_radius_one_fit =
+        std::min((0.98 * radius_two - center_two[2] + z_plane_plus_one) /
+                     (1.0 + z_plane_frac_plus_one),
+                 (0.98 * radius_two + center_two[2] - z_plane_plus_one) /
+                     (1.0 - z_plane_frac_plus_one));
+
+    // Compute the minimum allowed value of the angle alpha_minus.
+    // (these quantities are measured from zero; note the minus signs)
+    const double theta_max_minus_one = acos(-z_plane_frac_minus_one);
+    const double theta_max_minus_two =
+        acos(-(z_plane_minus_two - center_two[2]) / radius_two);
+    const double min_alpha_minus = 1.1 * theta_max_minus_one;
+    // max_radius_one_from_alpha comes from the restriction
+    // that alpha > min_alpha_minus
+    // and the expression for z_plane_frac_plus_one (used to eliminate
+    // center_one[2]) and the expression for z_plane_frac_minus_one.
+    const double max_radius_one_from_alpha =
+        (z_plane_plus_one - z_plane_minus_two +
+         radius_two * tan(min_alpha_minus) * sin(theta_max_minus_two)) /
+        (tan(min_alpha_minus) * sin(theta_max_minus_one) +
+         z_plane_frac_plus_one - z_plane_frac_minus_one);
+    const double max_radius_one = std::min(
+        {max_radius_one_planes, max_radius_one_fit, max_radius_one_from_alpha});
+    const double min_radius_one = 0.08 * radius_two;
+    CHECK(max_radius_one >= min_radius_one);
+    return min_radius_one + unit_dis(gen) * (max_radius_one - min_radius_one);
+  }();
+  CAPTURE(radius_one);
+
+  const std::array<double, 3> center_one = {
+      center_two[0], center_two[1],
+      z_plane_plus_two - z_plane_frac_plus_one * radius_one};
+  CAPTURE(center_one);
+
+  const double z_plane_minus_one =
+      center_one[2] + radius_one * z_plane_frac_minus_one;
+  CAPTURE(z_plane_minus_one);
+
+  if (flip_z_axis) {
+    // Here we test the map with z_plane_minus_one equal to
+    // z_plane_minus_two.  We do this by simply flipping the map
+    // parameters about the z axis (and exchanging parameters named
+    // plus and minus).  This way we don't need to rewrite the entire
+    // test for z_plane_minus_one==z_plane_minus_two.
+    const CoordinateMaps::UniformCylindricalSide map(
+        {{center_one[0], center_one[1], -center_one[2]}},
+        {{center_two[0], center_two[1], -center_two[2]}},
+        radius_one,
+        radius_two, -z_plane_minus_one, -z_plane_plus_one, -z_plane_minus_two,
+        -z_plane_plus_two);
+    test_suite_for_map_on_cylinder(map, 1.0, 2.0, true, true);
+  } else {
+    const CoordinateMaps::UniformCylindricalSide map(
+        center_one, center_two, radius_one, radius_two, z_plane_plus_one,
+        z_plane_minus_one, z_plane_plus_two, z_plane_minus_two);
+    test_suite_for_map_on_cylinder(map, 1.0, 2.0, true, true);
+  }
+}
+
+void test_uniform_cylindrical_side() {
+  INFO("UniformCylindricalSide");
+
+  // Set up random number generator
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> unit_dis(0.0, 1.0);
+  std::uniform_real_distribution<> interval_dis(-1.0, 1.0);
+  std::uniform_real_distribution<> angle_dis(0.0, 2.0 * M_PI);
+
+  // Choose some random center for sphere_two
+  const std::array<double, 3> center_two = {
+      interval_dis(gen), interval_dis(gen), interval_dis(gen)};
+  CAPTURE(center_two);
+
+  // Choose a random radius of sphere_two, reasonably large.
+  const double radius_two = 6.0 * (unit_dis(gen) + 1.0);
+  CAPTURE(radius_two);
+
+  // These angles describe how close the z-planes can be to the
+  // centers or edges of the spheres.
+  const double min_angle = 0.15;
+  const double max_angle = 0.4;
+
+  // Make sure z_plane_plus_two intersects sphere_two on the +z side of the
+  // center. We don't allow the plane to be too close to the center or
+  // too close to the edge.
+  const double z_plane_plus_two =
+      center_two[2] +
+      cos((min_angle + (max_angle - min_angle) * unit_dis(gen)) * M_PI) *
+          radius_two;
+  CAPTURE(z_plane_plus_two);
+
+  // Make sure z_plane_minus_two intersects sphere_two on the -z side of the
+  // center. We don't allow the plane to be too close to the center or
+  // too close to the edge.
+  const double z_plane_minus_two =
+      center_two[2] -
+      cos((min_angle + (max_angle - min_angle) * unit_dis(gen)) * M_PI) *
+          radius_two;
+  CAPTURE(z_plane_minus_two);
+
+  // Choose z_plane_frac_plus_one=(z_plane_plus_one-center_one[2])/radius_one
+  const double z_plane_frac_plus_one =
+      cos((min_angle + (max_angle - min_angle) * unit_dis(gen)) * M_PI);
+
+  // Choose
+  // z_plane_frac_minus_one=(z_plane_minus_one-center_one[2])/radius_one (note
+  // that this quantity is < 0).
+  const double z_plane_frac_minus_one =
+      -cos((min_angle + (max_angle - min_angle) * unit_dis(gen)) * M_PI);
+
+  // Compute the minimum allowed value of the angle alpha_plus.
+  const double theta_max_plus_one = acos(z_plane_frac_plus_one);
+  const double theta_max_plus_two =
+      acos((z_plane_plus_two - center_two[2]) / radius_two);
+  const double min_alpha_plus =
+      1.1 * std::max(theta_max_plus_one, theta_max_plus_two);
+
+  // Compute the minimum allowed value of the angle alpha_minus.
+  // (these quantities are measured from zero; note the minus signs)
+  const double theta_max_minus_one = acos(-z_plane_frac_minus_one);
+  const double theta_max_minus_two =
+      acos(-(z_plane_minus_two - center_two[2]) / radius_two);
+  const double min_alpha_minus =
+      1.1 * std::max(theta_max_minus_one, theta_max_minus_two);
+
+  // Choose a random radius of sphere_one, not too small and not larger
+  // than sphere_two.
+  const double radius_one = [&center_two, &radius_two, &z_plane_frac_plus_one,
+                             &z_plane_plus_two, &min_alpha_plus,
+                             &theta_max_plus_one, &theta_max_plus_two,
+                             &z_plane_frac_minus_one, &z_plane_minus_two,
+                             &min_alpha_minus, &theta_max_minus_one,
+                             &theta_max_minus_two, &unit_dis, &gen]() {
+    const double z_upper_separation = 0.03;
+    const double z_lower_separation = 0.03;
+    // max_radius_one_to_fit_inside_sphere_two_plus is the largest that
+    // radius_one can be and still satisfy both
+    // 0.98 radius_two >= radius_one + |C_1-C_2| and
+    // z_plane_plus_two >= z_plane_plus_one + z_upper_separation*radius_two
+    // when center_one_z is unknown and z_plane_plus_one is unknown
+    // (but the quantity z_plane_frac_plus_one is known).
+    // This value comes about when center_one and center_two have the
+    // same x and y components, and when center_one_z < center_two_z, and
+    // when center_one_z takes on its largest possible value consistent with
+    // 0.98 radius_two >= radius_one + |C_1-C_2|.
+    // The latter condition is C^z_1 >= radius_one + C^z_2 - 0.98 radius_two.
+    //
+    // Similarly, max_radius_one_to_fit_inside_sphere_two_minus
+    // is the largest that radius_one can be and still satisfy both
+    // 0.98 radius_two >= radius_one + |C_1-C_2| and
+    // z_plane_minus_two <= z_plane_minus_one - z_lower_separation*radius_two
+    // when center_one_z is unknown and z_plane_minus_one is unknown
+    // (but the quantity z_plane_frac_minus_one is known).
+    // This value comes about when center_one and center_two have the
+    // same x and y components, and when center_one_z > center_two_z, and
+    // when center_one_z takes on its smallest possible value consistent with
+    // 0.98 radius_two >= radius_one + |C_1-C_2|.
+    // The latter condition is C^z_1 <= -radius_one + C^z_2 + 0.98 radius_two.
+    //
+    // Here we take the min of both of the above quantities.
+    const double max_radius_one_to_fit_inside_sphere_two =
+        std::min((z_plane_plus_two - center_two[2] +
+                  (0.98 - z_upper_separation) * radius_two) /
+                     (z_plane_frac_plus_one + 1.0),
+                 (z_plane_minus_two - center_two[2] -
+                  (0.98 - z_lower_separation) * radius_two) /
+                     (z_plane_frac_minus_one - 1.0));
+    // max_radius_one_for_alpha_minus is the largest that radius_one can be
+    // and still satisfy alpha_minus > min_alpha_minus.  For
+    // tan(min_alpha_minus) > 0, if max_radius_one_to_fit_inside_sphere_two is
+    // satisfied, then alpha_minus > min_alpha_minus imposes no additional
+    // restriction on radius.
+    const double max_radius_one_for_alpha_plus =
+        min_alpha_plus > 0.5 * M_PI
+            ? std::numeric_limits<double>::max()
+            : std::min(
+                  radius_two * sin(theta_max_plus_two) /
+                      sin(theta_max_plus_one),
+                  (0.98 * radius_two - z_plane_plus_two + center_two[2] -
+                   radius_two * sin(theta_max_plus_two) * tan(min_alpha_plus)) /
+                      (1.0 - cos(theta_max_plus_one) -
+                       sin(theta_max_plus_one) * tan(min_alpha_plus)));
+    const double max_radius_one_for_alpha_minus =
+        min_alpha_minus > 0.5 * M_PI
+            ? std::numeric_limits<double>::max()
+            : std::min(radius_two * sin(theta_max_minus_two) /
+                           sin(theta_max_minus_one),
+                       (0.98 * radius_two + z_plane_minus_two - center_two[2] -
+                        radius_two * sin(theta_max_minus_two) *
+                            tan(min_alpha_minus)) /
+                           (1.0 - cos(theta_max_minus_one) -
+                            sin(theta_max_minus_one) * tan(min_alpha_minus)));
+    CHECK(max_radius_one_for_alpha_minus > 0.0);
+    CHECK(max_radius_one_for_alpha_plus > 0.0);
+    // max_radius_one_to_fit_between_plane_twos is the maximum radius_one
+    // that satisfies the two conditions
+    // z_plane_plus_two >= z_plane_plus_one + z_upper_separation*radius_two
+    // z_plane_minus_two <= z_plane_minus_one - z_lower_separation*radius_two
+    //
+    // This condition is derived from noting that
+    // z_plane_plus_one = center_one[2]+radius_one*z_plane_frac_plus_one
+    // and z_plane_minus_one = center_one[2]+radius_one*z_plane_frac_minus_one
+    // (recall z_plane_frac_minus_one is negative)
+    // and noting that the max value of center_one[2] is >= the min value
+    // of center_one[2].
+    const double max_radius_one_to_fit_between_plane_twos =
+        (z_plane_plus_two - z_plane_minus_two -
+         (z_upper_separation + z_lower_separation) * radius_two) /
+        (z_plane_frac_plus_one - z_plane_frac_minus_one);
+    CHECK(max_radius_one_to_fit_between_plane_twos > 0.0);
+
+    double max_radius_one = std::min(
+        {0.98 * radius_two, max_radius_one_to_fit_inside_sphere_two,
+         max_radius_one_to_fit_between_plane_twos,
+         max_radius_one_for_alpha_minus, max_radius_one_for_alpha_plus});
+    double min_radius_one = 0.08 * radius_two;
+
+    CHECK(max_radius_one >= min_radius_one);
+    return min_radius_one + unit_dis(gen) * (max_radius_one - min_radius_one);
+  }();
+  CAPTURE(radius_one);
+
+  // Choose a random z-center of sphere_one.
+  const double center_one_z = [&radius_two, &radius_one, &center_two,
+                               &z_plane_frac_plus_one, &z_plane_plus_two,
+                               &min_alpha_plus, &theta_max_plus_one,
+                               &theta_max_plus_two, &z_plane_frac_minus_one,
+                               &z_plane_minus_two, &min_alpha_minus,
+                               &theta_max_minus_one, &theta_max_minus_two,
+                               &unit_dis, &gen]() {
+    const double max_center_one_z_from_alpha_plus =
+        (tan(min_alpha_plus) <= 0.0 or radius_one * sin(theta_max_plus_one) <=
+                                           radius_two * sin(theta_max_plus_two))
+            ? std::numeric_limits<double>::max()
+            : (radius_two * sin(theta_max_plus_two) -
+               radius_one * sin(theta_max_plus_one)) *
+                  tan(min_alpha_plus);
+    // Note minus sign in min_center_one_z_from_alpha_minus
+    const double min_center_one_z_from_alpha_minus =
+        (tan(min_alpha_minus) <= 0.0 or
+         radius_one * sin(theta_max_minus_one) <=
+             radius_two * sin(theta_max_minus_two))
+            ? std::numeric_limits<double>::lowest()
+            : -(radius_two * sin(theta_max_minus_two) -
+                radius_one * sin(theta_max_minus_one)) *
+                  tan(min_alpha_minus);
+    CHECK(min_center_one_z_from_alpha_minus <=
+          max_center_one_z_from_alpha_plus);
+    // max_center_one_z comes from the restriction
+    // z_plane_plus_two >= z_plane_plus_one + 0.03*radius_two,
+    // and the restriction
+    // 0.98 r_2 >= r_1 + | C_1 - C_2 |
+    // and the restriction
+    // C^z_1 < C^z_2 + r_1 + r_2/5
+    // which is designed to not allow a tiny sphere 1 at the edge of
+    // a large sphere 2.
+    const double max_center_one_z =
+        std::min({max_center_one_z_from_alpha_plus,
+                  z_plane_plus_two - z_plane_frac_plus_one * radius_one -
+                      0.03 * radius_two,
+                  center_two[2] + radius_one + 0.2 * radius_two,
+                  center_two[2] + 0.98 * radius_two - radius_one});
+    // min_center_one_z comes from the restriction
+    // z_plane_minus_two <= z_plane_minus_one - 0.03*radius_two,
+    // and the restriction
+    // 0.98 r_2 >= r_1 + |C_1 - C_2 |
+    // and the restriction
+    // C^z_1 > C^z_2 - r_1 - r_2/5
+    // which is designed to not allow a tiny sphere 1 at the edge of
+    // a large sphere 2.
+    const double min_center_one_z =
+        std::max({min_center_one_z_from_alpha_minus,
+                  z_plane_minus_two - z_plane_frac_minus_one * radius_one +
+                      0.03 * radius_two,
+                  center_two[2] - radius_one - 0.2 * radius_two,
+                  center_two[2] - 0.98 * radius_two + radius_one});
+    CHECK(min_center_one_z <= max_center_one_z);
+    return min_center_one_z +
+           unit_dis(gen) * (max_center_one_z - min_center_one_z);
+  }();
+  CAPTURE(center_one_z);
+
+  // Now we can compute z_plane_plus_one and z_plane_minus_one
+  const double z_plane_plus_one =
+      center_one_z + radius_one * z_plane_frac_plus_one;
+  CAPTURE(z_plane_plus_one);
+  const double z_plane_minus_one =
+      center_one_z + radius_one * z_plane_frac_minus_one;
+  CAPTURE(z_plane_minus_one);
+
+  // Only thing remaining are the x and y centers of sphere_one.
+  const double horizontal_distance_spheres =
+      [&z_plane_plus_one, &z_plane_plus_two, &theta_max_plus_one,
+       &theta_max_plus_two, &min_alpha_plus, &z_plane_minus_one,
+       &z_plane_minus_two, &theta_max_minus_one, &theta_max_minus_two,
+       &min_alpha_minus, &center_one_z, &center_two, &radius_one, &radius_two,
+       &unit_dis, &gen]() {
+        // Let rho be the horizontal (x-y) distance between the centers of
+        // the spheres.
+
+        // maximum rho obeying the condition
+        // 0.98 R_2 <= R_1 + |C_1-C_2|
+        const double max_rho_sphere =
+            sqrt(square(0.98 * radius_two - radius_one) -
+                 square(center_one_z - center_two[2]));
+
+        // We don't want a tiny sphere 1 all the way on the edge of sphere 2.
+        // So demand that at least some of sphere_one lies along the polar
+        // axis of sphere_two.
+        const double max_rho_sphere2 = radius_one;
+
+        // We demand that the edge of sphere 1 is not too close to the
+        // edge of sphere 2.  But don't let max_rho_sphere3 be negative.
+        const double max_rho_sphere3 =
+            std::max(0.0, radius_two * 0.95 - radius_one);
+
+        // Alpha always gets smaller when rho gets larger (for other
+        // quantities fixed). So if alpha < min_alpha even when rho=0, then
+        // there is no hope.  We always fail.
+        const double alpha_plus_if_rho_is_zero =
+            atan2(z_plane_plus_two - z_plane_plus_one,
+                  radius_one * sin(theta_max_plus_one) -
+                      radius_two * sin(theta_max_plus_two));
+        CHECK(alpha_plus_if_rho_is_zero >= min_alpha_plus);
+        const double alpha_minus_if_rho_is_zero =
+            atan2(z_plane_minus_one - z_plane_minus_two,
+                  radius_one * sin(theta_max_minus_one) -
+                      radius_two * sin(theta_max_minus_two));
+        CHECK(alpha_minus_if_rho_is_zero >= min_alpha_minus);
+
+        const double max_rho_alpha_plus_first_term =
+            abs(min_alpha_plus - 0.5 * M_PI) < 1.e-4
+                ? 0.0
+                : (z_plane_plus_two - z_plane_plus_one) / tan(min_alpha_plus);
+
+        const double max_rho_alpha_minus_first_term =
+            abs(min_alpha_minus - 0.5 * M_PI) < 1.e-4
+                ? 0.0
+                : (z_plane_minus_one - z_plane_minus_two) /
+                      tan(min_alpha_minus);
+
+        // maximum rho so that the alpha condition is satisfied
+        const double max_rho_alpha_plus = max_rho_alpha_plus_first_term -
+                                          radius_one * sin(theta_max_plus_one) +
+                                          radius_two * sin(theta_max_plus_two);
+        const double max_rho_alpha_minus =
+            max_rho_alpha_minus_first_term -
+            radius_one * sin(theta_max_minus_one) +
+            radius_two * sin(theta_max_minus_two);
+        const double max_rho =
+            std::min({max_rho_sphere, max_rho_sphere2, max_rho_sphere3,
+                      max_rho_alpha_plus, max_rho_alpha_minus});
+        CHECK(max_rho >= 0.0);
+        return unit_dis(gen) * max_rho;
+      }();
+
+  const double phi = angle_dis(gen);
+  const std::array<double, 3> center_one = {
+      center_two[0] + horizontal_distance_spheres * cos(phi),
+      center_two[1] + horizontal_distance_spheres * sin(phi), center_one_z};
+  CAPTURE(center_one);
+
+  const CoordinateMaps::UniformCylindricalSide map(
+      center_one, center_two, radius_one, radius_two, z_plane_plus_one,
+      z_plane_minus_one, z_plane_plus_two, z_plane_minus_two);
+  test_suite_for_map_on_cylinder(map, 1.0, 2.0, true, true);
+
+  // The following are tests that the inverse function correctly
+  // returns an invalid std::optional when called for a point that is
+  // outside the range of the map.
+
+  // Point with z > z_plane_plus_two.
+  CHECK_FALSE(map.inverse({{0.0, 0.0, z_plane_plus_two + 1.0}}).has_value());
+
+  // Point with z < z_plane_minus_two.
+  CHECK_FALSE(map.inverse({{0.0, 0.0, z_plane_minus_two - 1.0}}).has_value());
+
+  // Point outside sphere_two
+  CHECK_FALSE(map.inverse({{center_two[0], center_two[1] + 1.01 * radius_two,
+                            center_two[2]}})
+                  .has_value());
+
+  // Point inside sphere_one (but z_plane_minus_one<z<z_plane_plus_one
+  // intersects sphere_one)
+  CHECK_FALSE(map.inverse({{center_one[0], center_one[1],
+                            0.5 * (z_plane_plus_one + z_plane_minus_one)}})
+                  .has_value());
+
+  // Point inside the northern cone
+  if (z_plane_plus_two != z_plane_plus_one) {
+    CHECK_FALSE(map.inverse({{center_two[0],
+                              center_two[1] +
+                                  radius_two * sin(theta_max_plus_two) * 0.98,
+                              z_plane_plus_two -
+                                  (z_plane_plus_two - center_two[2]) * 1.e-5}})
+                    .has_value());
+  }
+
+  // Point inside the southern cone
+  if (z_plane_minus_two != z_plane_minus_one) {
+    CHECK_FALSE(map.inverse({{center_two[0],
+                              center_two[1] +
+                                  radius_two * sin(theta_max_minus_two) * 0.98,
+                              z_plane_minus_two +
+                                  (center_two[2] - z_plane_minus_two) * 1.e-5}})
+                    .has_value());
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.UniformCylindricalSide",
+                  "[Domain][Unit]") {
+  test_uniform_cylindrical_side();
+  test_uniform_cylindrical_side_planes_equal(false);
+  test_uniform_cylindrical_side_planes_equal(true);
+  CHECK(not CoordinateMaps::UniformCylindricalSide{}.is_identity());
+}
+}  // namespace domain


### PR DESCRIPTION
## Proposed changes

Add a new map that maps a hollow cylinder to a portion of the region between two spheres.
This map works in concert with UniformCylindricalEndcap to produce a full "cylindered spherical shell"

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
