### PR TITLE
fix a mistake in the CCE tutorial

### DIFF
--- a/docs/Tutorials/CCE.md
+++ b/docs/Tutorials/CCE.md
@@ -121,11 +121,11 @@ import h5py as h5
 
 
 def spectre_real_mode_index(l, m):
-    return 2 * (l**2 + l + m)
+    return 2 * (l**2 + l + m) + 1
 
 
 def spectre_imag_mode_index(l, m):
-    return 2 * (l**2 + l + m) + 1
+    return 2 * (l**2 + l + m) + 2
 
 
 def get_modes_from_block_output(filename, dataset, modes=[[2, 2], [3, 3]]):


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

There is a mistake in the CCE tutorial. The first column in the CCE output is supposed to be the time rather than the real part of `(l=0,m=0)`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
