### PR TITLE
Fix a typo in the comment of GaugeUpdateInertialTimeDerivatives

### DIFF
--- a/src/Evolution/Systems/Cce/GaugeTransformBoundaryData.cpp
+++ b/src/Evolution/Systems/Cce/GaugeTransformBoundaryData.cpp
@@ -587,8 +587,7 @@ void GaugeUpdateInertialTimeDerivatives::apply(
       l_max, 1, make_not_null(&eth_x_inertial), make_not_null(&eth_y_inertial),
       make_not_null(&eth_z_inertial), x_inertial, y_inertial, z_inertial);
 
-  // Interpolate evolution_gauge_u_at_scri and omega to the partially flat
-  // Bondi-like coordinates
+  // Interpolate evolution_gauge_u_at_scri and omega to the Cauchy coordinates
   auto& original_u_at_scri =
       get(get<::Tags::SpinWeighted<::Tags::TempScalar<6, ComplexDataVector>,
                                    std::integral_constant<int, 1>>>(


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

A comment in `GaugeUpdateInertialTimeDerivatives` is wrong.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
