### PR TITLE
Stop fixing atmosphere from blocking switch back to DG

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.cpp
@@ -19,6 +19,7 @@ std::tuple<int, evolution::dg::subcell::RdmpTciData> TciOnFdGrid::apply(
     const Scalar<DataVector>& subcell_tilde_d,
     const Scalar<DataVector>& subcell_tilde_tau,
     const tnsr::I<DataVector, 3, Frame::Inertial>& subcell_tilde_b,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
     const bool vars_needed_fixing, const Mesh<3>& dg_mesh,
     const Mesh<3>& subcell_mesh,
     const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
@@ -27,12 +28,14 @@ std::tuple<int, evolution::dg::subcell::RdmpTciData> TciOnFdGrid::apply(
     const double persson_exponent) {
   const size_t num_dg_pts = dg_mesh.number_of_grid_points();
   const size_t num_subcell_pts = subcell_mesh.number_of_grid_points();
-  DataVector temp_buffer{num_subcell_pts + 3 * num_dg_pts};
+  DataVector temp_buffer{num_subcell_pts + 4 * num_dg_pts};
   size_t offset_into_temp_buffer = 0;
   const auto assign_data =
       [&temp_buffer, &offset_into_temp_buffer](
           const gsl::not_null<Scalar<DataVector>*> to_assign,
           const size_t size) {
+        ASSERT(offset_into_temp_buffer + size <= temp_buffer.size(),
+               "Trying to assign data out of allocated memory size");
         get(*to_assign)
             .set_data_ref(temp_buffer.data() + offset_into_temp_buffer, size);
         offset_into_temp_buffer += size;
@@ -63,7 +66,18 @@ std::tuple<int, evolution::dg::subcell::RdmpTciData> TciOnFdGrid::apply(
       subcell_mesh.extents(),
       evolution::dg::subcell::fd::ReconstructionMethod::DimByDim);
 
-  if (vars_needed_fixing) {
+  Scalar<DataVector> dg_sqrt_det_spatial_metric{};
+  assign_data(make_not_null(&dg_sqrt_det_spatial_metric), num_dg_pts);
+  evolution::dg::subcell::fd::reconstruct(
+      make_not_null(&get(dg_sqrt_det_spatial_metric)),
+      get(sqrt_det_spatial_metric), dg_mesh, subcell_mesh.extents(),
+      evolution::dg::subcell::fd::ReconstructionMethod::DimByDim);
+
+  if (vars_needed_fixing and
+      (max(get(dg_tilde_d) / get(dg_sqrt_det_spatial_metric)) >
+       tci_options.atmosphere_density) and
+      (max(get(subcell_tilde_d) / get(sqrt_det_spatial_metric)) >
+       tci_options.atmosphere_density)) {
     return {+1, rdmp_tci_data};
   }
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.hpp
@@ -15,6 +15,7 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOptions.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
 #include "Evolution/VariableFixing/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -38,9 +39,8 @@ namespace grmhd::ValenciaDivClean::subcell {
  * <tr><th> Description <th> TCI status
  *
  * <tr><td> if `grmhd::ValenciaDivClean::Tags::VariablesNeededFixing` is `true`
- * then we remain on FD. (Note: this could be relaxed in the future if we need
- * to allow switching from FD to DG in the atmosphere and the current approach
- * isn't working.)
+ *  and the maximum of \f$\tilde{D}/\sqrt{\gamma}\f$ is greater than
+ * `tci_options.atmosphere_density` on DG and FD grid, then we remain on FD.
  * <td> `+1`
  *
  * <tr><td> if `min(tilde_d)` is less than
@@ -86,6 +86,7 @@ struct TciOnFdGrid {
       tmpl::list<grmhd::ValenciaDivClean::Tags::TildeD,
                  grmhd::ValenciaDivClean::Tags::TildeTau,
                  grmhd::ValenciaDivClean::Tags::TildeB<>,
+                 gr::Tags::SqrtDetSpatialMetric<>,
                  grmhd::ValenciaDivClean::Tags::VariablesNeededFixing,
                  domain::Tags::Mesh<3>, evolution::dg::subcell::Tags::Mesh<3>,
                  evolution::dg::subcell::Tags::DataForRdmpTci, Tags::TciOptions,
@@ -94,6 +95,7 @@ struct TciOnFdGrid {
       const Scalar<DataVector>& subcell_tilde_d,
       const Scalar<DataVector>& subcell_tilde_tau,
       const tnsr::I<DataVector, 3, Frame::Inertial>& subcell_tilde_b,
+      const Scalar<DataVector>& sqrt_det_spatial_metric,
       bool vars_needed_fixing, const Mesh<3>& dg_mesh,
       const Mesh<3>& subcell_mesh,
       const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnFdGrid.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnFdGrid.cpp
@@ -19,11 +19,13 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/Gsl.hpp"
 
 namespace {
 enum class TestThis {
   AllGood,
+  Atmosphere,
   NeededFixing,
   PerssonTildeD,
   PerssonTildeTau,
@@ -58,7 +60,7 @@ void test(const TestThis test_this, const int expected_tci_status) {
   auto box = db::create<db::AddSimpleTags<
       grmhd::ValenciaDivClean::Tags::TildeD,
       grmhd::ValenciaDivClean::Tags::TildeTau,
-      grmhd::ValenciaDivClean::Tags::TildeB<>,
+      grmhd::ValenciaDivClean::Tags::TildeB<>, gr::Tags::SqrtDetSpatialMetric<>,
       grmhd::ValenciaDivClean::Tags::VariablesNeededFixing,
       domain::Tags::Mesh<3>, ::evolution::dg::subcell::Tags::Mesh<3>,
       grmhd::ValenciaDivClean::subcell::Tags::TciOptions,
@@ -68,6 +70,7 @@ void test(const TestThis test_this, const int expected_tci_status) {
       Scalar<DataVector>(subcell_mesh.number_of_grid_points(), 1.0),
       tnsr::I<DataVector, 3, Frame::Inertial>(
           subcell_mesh.number_of_grid_points(), 1.0),
+      Scalar<DataVector>(subcell_mesh.number_of_grid_points(), 1.0),
       test_this == TestThis::NeededFixing, mesh, subcell_mesh, tci_options,
       subcell_options, evolution::dg::subcell::RdmpTciData{});
 
@@ -98,6 +101,16 @@ void test(const TestThis test_this, const int expected_tci_status) {
     db::mutate<grmhd::ValenciaDivClean::Tags::TildeTau>(
         make_not_null(&box), [point_to_change](const auto tilde_tau_ptr) {
           get(*tilde_tau_ptr)[point_to_change] = -1.0e-20;
+        });
+  } else if (test_this == TestThis::Atmosphere) {
+    db::mutate<grmhd::ValenciaDivClean::Tags::TildeD,
+               grmhd::ValenciaDivClean::Tags::VariablesNeededFixing>(
+        make_not_null(&box),
+        [](const auto tilde_d_ptr, const auto variables_needed_fixing_ptr) {
+          *variables_needed_fixing_ptr = true;
+          get(*tilde_d_ptr) =
+              5.0e-12;  // smaller than atmosphere density but
+                        // bigger than the Min(TildeD) TCI option
         });
   }
 
@@ -182,6 +195,7 @@ void test(const TestThis test_this, const int expected_tci_status) {
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.ValenciaDivClean.Subcell.TciOnFdGrid",
                   "[Unit][Evolution]") {
   test(TestThis::AllGood, 0);
+  test(TestThis::Atmosphere, 0);
   test(TestThis::NeededFixing, 1);
   test(TestThis::NegativeTildeD, 2);
   test(TestThis::NegativeTildeTau, 2);


### PR DESCRIPTION
## Proposed changes

Porting [Will's commit](https://github.com/wthrowe/spectre/commit/e23c4961c65896f20cf41e75d83fdcd69c2e15b9) that resolves atmosphere elements not switching back to DG. Updated docs and the test.


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
