### PR TITLE
Make execution order of events deterministic

### DIFF
--- a/docs/Tutorials/EventsAndTriggers.md
+++ b/docs/Tutorials/EventsAndTriggers.md
@@ -52,16 +52,12 @@ consistently over the entire domain.
 ### Input file syntax
 
 The `%EventsAndTriggers` (and `%EventsAndDenseTriggers`) sections of
-the \ref dev_guide_option_parsing "input file" indicate structure
-using a collection of `?`, `:`, and `-` characters.  These are
-standard, if perhaps somewhat obscure, YAML syntax.  They are defining
-a map from triggers to lists of events.  The `?:` syntax defines an
-expanded key-value pair, which allows the key to be a complicated
-type, unlike the common `Key: Value` syntax.  The `-` is the expanded
-form of a list, which allows entries to have complicated types.
-Frequently only one event is associated with a trigger, so there will
-only be a single `-` after the `:`, but additional events introduced
-by more `-` characters can appear afterwards:
+the \ref dev_guide_option_parsing "input file" are parsed as several
+nested YAML lists representing vectors and pairs.  The outermost list
+is a vector with one entry for each trigger.  The entries in this
+vector are two-element lists representing pairs whose first elements
+are triggers and whose second elements are a third level of list
+containing the events.
 
 \snippet PlaneWave1DEventsAndTriggersExample.yaml multiple_events
 

--- a/src/Evolution/EventsAndDenseTriggers/EventsAndDenseTriggers.cpp
+++ b/src/Evolution/EventsAndDenseTriggers/EventsAndDenseTriggers.cpp
@@ -7,9 +7,13 @@
 #include <pup.h>
 #include <utility>
 
+#include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+
 namespace evolution {
 void EventsAndDenseTriggers::TriggerRecord::pup(PUP::er& p) {
   p | next_check;
+  p | is_triggered;
+  p | num_events_ready;
   p | trigger;
   p | events;
 }
@@ -17,13 +21,11 @@ void EventsAndDenseTriggers::TriggerRecord::pup(PUP::er& p) {
 EventsAndDenseTriggers::EventsAndDenseTriggers(
     ConstructionType events_and_triggers) {
   events_and_triggers_.reserve(events_and_triggers.size());
-  while (not events_and_triggers.empty()) {
-    auto events_and_trigger =
-        events_and_triggers.extract(events_and_triggers.begin());
-    events_and_triggers_.push_back(
-        TriggerRecord{std::numeric_limits<double>::signaling_NaN(),
-                      std::move(events_and_trigger.key()),
-                      std::move(events_and_trigger.mapped())});
+  for (auto& events_and_trigger : events_and_triggers) {
+    events_and_triggers_.push_back(TriggerRecord{
+        std::numeric_limits<double>::signaling_NaN(), std::optional<bool>{}, 0,
+        std::move(events_and_trigger.first),
+        std::move(events_and_trigger.second)});
   }
 }
 
@@ -32,67 +34,21 @@ void EventsAndDenseTriggers::add_trigger_and_events(
     std::vector<std::unique_ptr<Event>> events) {
   ASSERT(not initialized(), "Cannot add events after initialization");
   events_and_triggers_.reserve(events_and_triggers_.size() + 1);
-  events_and_triggers_.push_back(
-      TriggerRecord{std::numeric_limits<double>::signaling_NaN(),
-                    std::move(trigger), std::move(events)});
+  events_and_triggers_.push_back(TriggerRecord{
+      std::numeric_limits<double>::signaling_NaN(), std::optional<bool>{}, 0,
+      std::move(trigger), std::move(events)});
 }
 
 void EventsAndDenseTriggers::pup(PUP::er& p) {
   p | events_and_triggers_;
-  p | heap_size_;
-  p | to_run_position_;
-  p | processing_position_;
-  p | event_to_check_;
   p | next_check_;
-  p | next_check_after_;
+  p | before_;
 }
 
 bool EventsAndDenseTriggers::initialized() const {
-  return heap_size_ != std::numeric_limits<size_t>::max();
-}
-
-void EventsAndDenseTriggers::populate_active_triggers() {
-  ASSERT(not events_and_triggers_.empty(), "No triggers");
-  ASSERT(heap_end() == events_and_triggers_.end(),
-         "Triggers have not all been processed.");
-
-  next_check_ = events_and_triggers_.front().next_check;
-  while (heap_size_ > 0 and
-         events_and_triggers_.front().next_check == next_check_) {
-    std::pop_heap(events_and_triggers_.begin(), heap_end(), next_check_after_);
-    --heap_size_;
-  }
-  to_run_position_ = heap_size_;
-  processing_position_ = heap_size_;
-}
-
-void EventsAndDenseTriggers::reschedule_next_trigger(
-    const double next_check_time, const bool time_runs_forward) {
-  if (not evolution_greater<double>{time_runs_forward}(
-          next_check_time, heap_end()->next_check)) {
-    ERROR("Trigger at time " << heap_end()->next_check
-          << " rescheduled itself for earlier time "
-          << next_check_time);
-  }
-  heap_end()->next_check = next_check_time;
-  ++heap_size_;
-  std::push_heap(events_and_triggers_.begin(), heap_end(), next_check_after_);
-}
-
-EventsAndDenseTriggers::TriggerTimeAfter::TriggerTimeAfter(
-    const bool time_runs_forward)
-    : time_after_{time_runs_forward} {}
-
-bool EventsAndDenseTriggers::TriggerTimeAfter::operator()(
-    const TriggerRecord& a, const TriggerRecord& b) const {
-  return time_after_(a.next_check, b.next_check);
-}
-
-double EventsAndDenseTriggers::TriggerTimeAfter::infinite_future() const {
-  return time_after_.infinity();
-}
-
-void EventsAndDenseTriggers::TriggerTimeAfter::pup(PUP::er& p) {
-  p | time_after_;
+  disable_floating_point_exceptions();
+  const bool result = not std::isnan(next_check_);
+  enable_floating_point_exceptions();
+  return result;
 }
 }  // namespace evolution

--- a/src/ParallelAlgorithms/EventsAndTriggers/EventsAndTriggers.hpp
+++ b/src/ParallelAlgorithms/EventsAndTriggers/EventsAndTriggers.hpp
@@ -6,7 +6,6 @@
 #include <memory>
 #include <optional>
 #include <pup.h>  // IWYU pragma: keep
-#include <unordered_map>
 #include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
@@ -37,8 +36,8 @@ class EventsAndTriggers {
   };
 
  public:
-  using Storage = std::unordered_map<std::unique_ptr<Trigger>,
-                                     std::vector<std::unique_ptr<Event>>>;
+  using Storage = std::vector<
+      std::pair<std::unique_ptr<Trigger>, std::vector<std::unique_ptr<Event>>>>;
 
   EventsAndTriggers() = default;
   explicit EventsAndTriggers(Storage events_and_triggers)

--- a/tests/InputFiles/Burgers/Step.yaml
+++ b/tests/InputFiles/Burgers/Step.yaml
@@ -60,14 +60,14 @@ SpatialDiscretization:
     Reconstructor: MonotonisedCentral
 
 EventsAndTriggers:
-  ? Always
-  : - ChangeSlabSize:
-        DelayChange: 5
-        StepChoosers:
-          - Cfl:
-              SafetyFactor: 0.5
-          - Increase:
-              Factor: 2.0
+  - - Always
+    - - ChangeSlabSize:
+          DelayChange: 5
+          StepChoosers:
+            - Cfl:
+                SafetyFactor: 0.5
+            - Increase:
+                Factor: 2.0
 
 EventsAndDenseTriggers:
   ? Times:

--- a/tests/InputFiles/Burgers/Step.yaml
+++ b/tests/InputFiles/Burgers/Step.yaml
@@ -70,10 +70,10 @@ EventsAndTriggers:
                 Factor: 2.0
 
 EventsAndDenseTriggers:
-  ? Times:
-      Specified:
-        Values: [0.123456]
-  : - Completion
+  - - Times:
+        Specified:
+          Values: [0.123456]
+    - - Completion
 
 Observers:
   VolumeFileName: "BurgersStepVolume"

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski1D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski1D.yaml
@@ -62,10 +62,10 @@ Filtering:
     DisableForDebugging: true
 
 EventsAndTriggers:
-  ? Slabs:
-      Specified:
-        Values: [100]
-  : - Completion
+  - - Slabs:
+        Specified:
+          Values: [100]
+    - - Completion
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski2D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski2D.yaml
@@ -60,10 +60,10 @@ Filtering:
     DisableForDebugging: true
 
 EventsAndTriggers:
-  ? Slabs:
-      Specified:
-        Values: [100]
-  : - Completion
+  - - Slabs:
+        Specified:
+          Values: [100]
+    - - Completion
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
@@ -74,46 +74,46 @@ Filtering:
     DisableForDebugging: true
 
 EventsAndTriggers:
-  ? Slabs:
-      Specified:
-        Values: [30]
-  : - Completion
-  ? Slabs:
-      Specified:
-        Values: [0, 15]
-  : - ObserveFields:
-        SubfileName: VolumePsi0And25
-        VariablesToObserve: ["Psi"]
-        InterpolateToMesh: None
-        CoordinatesFloatingPointType: Double
-        FloatingPointTypes: [Double]
-  ? Slabs:
-      EvenlySpaced:
-        Interval: 10
-        Offset: 0
-  : - ObserveFields:
-        SubfileName: VolumeVarsConstraintsEvery10Slabs
-        VariablesToObserve:
-          - Psi
-          - Pi
-          - Phi
-          - PointwiseL2Norm(OneIndexConstraint)
-        InterpolateToMesh: None
-        CoordinatesFloatingPointType: Double
-        FloatingPointTypes: [Double]
-  ? Slabs:
-      EvenlySpaced:
-        Interval: 10
-        Offset: 0
-  : - ObserveNorms:
-        SubfileName: Norms
-        TensorsToObserve:
-          - Name: PointwiseL2Norm(OneIndexConstraint)
-            NormType: L2Norm
-            Components: Individual
-          - Name: PointwiseL2Norm(TwoIndexConstraint)
-            NormType: L2Norm
-            Components: Individual
+  - - Slabs:
+        Specified:
+          Values: [30]
+    - - Completion
+  - - Slabs:
+        Specified:
+          Values: [0, 15]
+    - - ObserveFields:
+          SubfileName: VolumePsi0And25
+          VariablesToObserve: ["Psi"]
+          InterpolateToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Double]
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 10
+          Offset: 0
+    - - ObserveFields:
+          SubfileName: VolumeVarsConstraintsEvery10Slabs
+          VariablesToObserve:
+            - Psi
+            - Pi
+            - Phi
+            - PointwiseL2Norm(OneIndexConstraint)
+          InterpolateToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Double]
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 10
+          Offset: 0
+    - - ObserveNorms:
+          SubfileName: Norms
+          TensorsToObserve:
+            - Name: PointwiseL2Norm(OneIndexConstraint)
+              NormType: L2Norm
+              Components: Individual
+            - Name: PointwiseL2Norm(TwoIndexConstraint)
+              NormType: L2Norm
+              Components: Individual
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/Elasticity/BentBeam.yaml
+++ b/tests/InputFiles/Elasticity/BentBeam.yaml
@@ -75,18 +75,18 @@ LinearSolver:
     ObservePerCoreReductions: False
 
 EventsAndTriggers:
-  ? HasConverged
-  : - ObserveNorms:
-        SubfileName: ErrorNorms
-        TensorsToObserve:
-          - Name: Error(Displacement)
-            NormType: L2Norm
-            Components: Sum
-    - ObserveFields:
-        SubfileName: VolumeData
-        VariablesToObserve:
-          - Displacement
-          - PotentialEnergyDensity
-        InterpolateToMesh: None
-        CoordinatesFloatingPointType: Double
-        FloatingPointTypes: [Double]
+  - - HasConverged
+    - - ObserveNorms:
+          SubfileName: ErrorNorms
+          TensorsToObserve:
+            - Name: Error(Displacement)
+              NormType: L2Norm
+              Components: Sum
+      - ObserveFields:
+          SubfileName: VolumeData
+          VariablesToObserve:
+            - Displacement
+            - PotentialEnergyDensity
+          InterpolateToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Double]

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -101,20 +101,20 @@ LinearSolver:
     ObservePerCoreReductions: False
 
 EventsAndTriggers:
-  ? HasConverged
-  : - ObserveNorms:
-        SubfileName: ErrorNorms
-        TensorsToObserve:
-          - Name: Error(Displacement)
-            NormType: L2Norm
-            Components: Sum
-    - ObserveVolumeIntegrals:
-        SubfileName: VolumeIntegrals
-    - ObserveFields:
-        SubfileName: VolumeData
-        VariablesToObserve:
-          - Displacement
-          - PotentialEnergyDensity
-        InterpolateToMesh: None
-        CoordinatesFloatingPointType: Double
-        FloatingPointTypes: [Double]
+  - - HasConverged
+    - - ObserveNorms:
+          SubfileName: ErrorNorms
+          TensorsToObserve:
+            - Name: Error(Displacement)
+              NormType: L2Norm
+              Components: Sum
+      - ObserveVolumeIntegrals:
+          SubfileName: VolumeIntegrals
+      - ObserveFields:
+          SubfileName: VolumeData
+          VariablesToObserve:
+            - Displacement
+            - PotentialEnergyDensity
+          InterpolateToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Double]

--- a/tests/InputFiles/ExportCoordinates/Input1D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input1D.yaml
@@ -27,10 +27,10 @@ SpatialDiscretization:
     Quadrature: GaussLobatto
 
 EventsAndTriggers:
-  ? TimeCompares:
-      Comparison: GreaterThanOrEqualTo
-      Value: 1.0
-  : - Completion
+  - - TimeCompares:
+        Comparison: GreaterThanOrEqualTo
+        Value: 1.0
+    - - Completion
 
 Evolution:
   InitialTime: 0.0

--- a/tests/InputFiles/ExportCoordinates/Input2D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input2D.yaml
@@ -27,10 +27,10 @@ SpatialDiscretization:
     Quadrature: GaussLobatto
 
 EventsAndTriggers:
-  ? TimeCompares:
-      Comparison: GreaterThanOrEqualTo
-      Value: 1.0
-  : - Completion
+  - - TimeCompares:
+        Comparison: GreaterThanOrEqualTo
+        Value: 1.0
+    - - Completion
 
 Evolution:
   InitialTime: 0.0

--- a/tests/InputFiles/ExportCoordinates/Input3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input3D.yaml
@@ -34,10 +34,10 @@ Evolution:
       Order: 1
 
 EventsAndTriggers:
-  ? TimeCompares:
-      Comparison: GreaterThanOrEqualTo
-      Value: 1.0
-  : - Completion
+  - - TimeCompares:
+        Comparison: GreaterThanOrEqualTo
+        Value: 1.0
+    - - Completion
 
 Observers:
   VolumeFileName: "ExportCoordinates3DVolume"

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -72,10 +72,10 @@ Evolution:
       Order: 1
 
 EventsAndTriggers:
-  ? TimeCompares:
-      Comparison: GreaterThanOrEqualTo
-      Value: 0.5
-  : - Completion
+  - - TimeCompares:
+        Comparison: GreaterThanOrEqualTo
+        Value: 0.5
+    - - Completion
 
 Observers:
   VolumeFileName: "ExportTimeDependentCoordinates3DVolume"

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -165,55 +165,55 @@ Filtering:
 
 
 EventsAndTriggers:
-  ? Slabs:
-      EvenlySpaced:
-        Interval: 1
-        Offset: 0
-  : - ObserveNorms:
-        SubfileName: Norms
-        TensorsToObserve:
-        - Name: Lapse
-          NormType: L2Norm
-          Components: Individual
-        - Name: PointwiseL2Norm(GaugeConstraint)
-          NormType: L2Norm
-          Components: Sum
-        - Name: PointwiseL2Norm(ThreeIndexConstraint)
-          NormType: L2Norm
-          Components: Sum
-        - Name: PointwiseL2Norm(FourIndexConstraint)
-          NormType: L2Norm
-          Components: Sum
-  ? Slabs:
-      EvenlySpaced:
-        Interval: 1000
-        Offset: 0
-  : - ObserveFields:
-        SubfileName: VolumeData
-        VariablesToObserve:
-          - Lapse
-          - PointwiseL2Norm(GaugeConstraint)
-          - PointwiseL2Norm(ThreeIndexConstraint)
-          - PointwiseL2Norm(FourIndexConstraint)
-        InterpolateToMesh: None
-        CoordinatesFloatingPointType: Double
-        FloatingPointTypes: [Double]
-  ? Slabs:
-      EvenlySpaced:
-        Interval: 1
-        Offset: 0
-  : - AhA
-    - AhB
-  ? Slabs:
-      EvenlySpaced:
-        Interval: 100
-        Offset: 0
-  : - MonitorMemory:
-        ComponentsToMonitor: All
-  ? TimeCompares:
-      Comparison: GreaterThan
-      Value: 0.02
-  : - Completion
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 1
+          Offset: 0
+    - - ObserveNorms:
+          SubfileName: Norms
+          TensorsToObserve:
+          - Name: Lapse
+            NormType: L2Norm
+            Components: Individual
+          - Name: PointwiseL2Norm(GaugeConstraint)
+            NormType: L2Norm
+            Components: Sum
+          - Name: PointwiseL2Norm(ThreeIndexConstraint)
+            NormType: L2Norm
+            Components: Sum
+          - Name: PointwiseL2Norm(FourIndexConstraint)
+            NormType: L2Norm
+            Components: Sum
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 1000
+          Offset: 0
+    - - ObserveFields:
+          SubfileName: VolumeData
+          VariablesToObserve:
+            - Lapse
+            - PointwiseL2Norm(GaugeConstraint)
+            - PointwiseL2Norm(ThreeIndexConstraint)
+            - PointwiseL2Norm(FourIndexConstraint)
+          InterpolateToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Double]
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 1
+          Offset: 0
+    - - AhA
+      - AhB
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 100
+          Offset: 0
+    - - MonitorMemory:
+          ComponentsToMonitor: All
+  - - TimeCompares:
+        Comparison: GreaterThan
+        Value: 0.02
+    - - Completion
 
 Observers:
   VolumeFileName: "GhBinaryBlackHoleVolumeData"

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
@@ -86,41 +86,41 @@ SpatialDiscretization:
     UpwindPenalty:
 
 EventsAndTriggers:
-  ? Slabs:
-      EvenlySpaced:
-        Interval: 2
-        Offset: 0
-  : - ObserveNorms:
-        SubfileName: Errors
-        TensorsToObserve:
-          - Name: Error(SpacetimeMetric)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(Pi)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(Phi)
-            NormType: L2Norm
-            Components: Sum
-  ? Slabs:
-      EvenlySpaced:
-        Interval: 5
-        Offset: 0
-  : - ObserveFields:
-        SubfileName: VolumeData
-        VariablesToObserve:
-          - SpacetimeMetric
-          - Pi
-          - Phi
-          - PointwiseL2Norm(GaugeConstraint)
-          - PointwiseL2Norm(ThreeIndexConstraint)
-        InterpolateToMesh: None
-        CoordinatesFloatingPointType: Double
-        FloatingPointTypes: [Double]
-  ? Slabs:
-      Specified:
-        Values: [5]
-  : - Completion
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 2
+          Offset: 0
+    - - ObserveNorms:
+          SubfileName: Errors
+          TensorsToObserve:
+            - Name: Error(SpacetimeMetric)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(Pi)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(Phi)
+              NormType: L2Norm
+              Components: Sum
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 5
+          Offset: 0
+    - - ObserveFields:
+          SubfileName: VolumeData
+          VariablesToObserve:
+            - SpacetimeMetric
+            - Pi
+            - Phi
+            - PointwiseL2Norm(GaugeConstraint)
+            - PointwiseL2Norm(ThreeIndexConstraint)
+          InterpolateToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Double]
+  - - Slabs:
+        Specified:
+          Values: [5]
+    - - Completion
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
@@ -80,42 +80,42 @@ SpatialDiscretization:
     UpwindPenalty:
 
 EventsAndTriggers:
-  ? Slabs:
-      EvenlySpaced:
-        Interval: 2
-        Offset: 0
-  : - ObserveNorms:
-        SubfileName: Errors
-        TensorsToObserve:
-          - Name: Error(SpacetimeMetric)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(Pi)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(Phi)
-            NormType: L2Norm
-            Components: Sum
-  ? Slabs:
-      EvenlySpaced:
-        Interval: 5
-        Offset: 0
-  : - ObserveFields:
-        SubfileName: VolumeData
-        VariablesToObserve:
-          - SpacetimeMetric
-          - Pi
-          - Phi
-          - PointwiseL2Norm(GaugeConstraint)
-          - PointwiseL2Norm(ThreeIndexConstraint)
-          - PointwiseL2Norm(FourIndexConstraint)
-        InterpolateToMesh: None
-        CoordinatesFloatingPointType: Double
-        FloatingPointTypes: [Double]
-  ? Slabs:
-      Specified:
-        Values: [2]
-  : - Completion
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 2
+          Offset: 0
+    - - ObserveNorms:
+          SubfileName: Errors
+          TensorsToObserve:
+            - Name: Error(SpacetimeMetric)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(Pi)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(Phi)
+              NormType: L2Norm
+              Components: Sum
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 5
+          Offset: 0
+    - - ObserveFields:
+          SubfileName: VolumeData
+          VariablesToObserve:
+            - SpacetimeMetric
+            - Pi
+            - Phi
+            - PointwiseL2Norm(GaugeConstraint)
+            - PointwiseL2Norm(ThreeIndexConstraint)
+            - PointwiseL2Norm(FourIndexConstraint)
+          InterpolateToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Double]
+  - - Slabs:
+        Specified:
+          Values: [2]
+    - - Completion
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -103,66 +103,66 @@ SpatialDiscretization:
     Quadrature: GaussLobatto
 
 EventsAndTriggers:
-  ? Slabs:
-      EvenlySpaced:
-        Interval: 2
-        Offset: 0
-  : - ObserveNorms:
-        SubfileName: Errors
-        TensorsToObserve:
-          - Name: Error(SpacetimeMetric)
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 2
+          Offset: 0
+    - - ObserveNorms:
+          SubfileName: Errors
+          TensorsToObserve:
+            - Name: Error(SpacetimeMetric)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(Pi)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(Phi)
+              NormType: L2Norm
+              Components: Sum
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 2
+          Offset: 0
+    - - ObserveNorms:
+          SubfileName: Norms
+          TensorsToObserve:
+          - Name: Lapse
+            NormType: L2Norm
+            Components: Individual
+          - Name: PointwiseL2Norm(GaugeConstraint)
             NormType: L2Norm
             Components: Sum
-          - Name: Error(Pi)
+          - Name: PointwiseL2Norm(ThreeIndexConstraint)
             NormType: L2Norm
             Components: Sum
-          - Name: Error(Phi)
+          - Name: PointwiseL2Norm(FourIndexConstraint)
             NormType: L2Norm
             Components: Sum
-  ? Slabs:
-      EvenlySpaced:
-        Interval: 2
-        Offset: 0
-  : - ObserveNorms:
-        SubfileName: Norms
-        TensorsToObserve:
-        - Name: Lapse
-          NormType: L2Norm
-          Components: Individual
-        - Name: PointwiseL2Norm(GaugeConstraint)
-          NormType: L2Norm
-          Components: Sum
-        - Name: PointwiseL2Norm(ThreeIndexConstraint)
-          NormType: L2Norm
-          Components: Sum
-        - Name: PointwiseL2Norm(FourIndexConstraint)
-          NormType: L2Norm
-          Components: Sum
-  ? Slabs:
-      EvenlySpaced:
-        Interval: 5
-        Offset: 0
-  : - ObserveFields:
-        SubfileName: VolumeData
-        VariablesToObserve:
-          - SpacetimeMetric
-          - Pi
-          - Phi
-          - PointwiseL2Norm(GaugeConstraint)
-          - PointwiseL2Norm(ThreeIndexConstraint)
-          - PointwiseL2Norm(FourIndexConstraint)
-        InterpolateToMesh: None
-        CoordinatesFloatingPointType: Double
-        FloatingPointTypes: [Double]
-  ? Slabs:
-      EvenlySpaced:
-        Interval: 5
-        Offset: 2
-  : - AhA
-  ? Slabs:
-      Specified:
-        Values: [3]
-  : - Completion
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 5
+          Offset: 0
+    - - ObserveFields:
+          SubfileName: VolumeData
+          VariablesToObserve:
+            - SpacetimeMetric
+            - Pi
+            - Phi
+            - PointwiseL2Norm(GaugeConstraint)
+            - PointwiseL2Norm(ThreeIndexConstraint)
+            - PointwiseL2Norm(FourIndexConstraint)
+          InterpolateToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Double]
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 5
+          Offset: 2
+    - - AhA
+  - - Slabs:
+        Specified:
+          Values: [3]
+    - - Completion
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -117,81 +117,81 @@ SpatialDiscretization:
       Rusanov:
 
 EventsAndTriggers:
-  ? Slabs:
-      EvenlySpaced:
-        Interval: 5
-        Offset: 0
-  : - ChangeSlabSize:
-        DelayChange: 5
-        StepChoosers:
-          - Cfl:
-              SafetyFactor: 0.6
-          - Increase:
-              Factor: 1.5
-  ? Slabs:
-      EvenlySpaced:
-        Interval: 1
-        Offset: 0
-  : - ObserveNorms:
-        SubfileName: Errors
-        TensorsToObserve:
-          - Name: Error(SpacetimeMetric)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(Pi)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(Phi)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(RestMassDensity)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(SpecificInternalEnergy)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(SpatialVelocity)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(MagneticField)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(DivergenceCleaningField)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(LorentzFactor)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(Pressure)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(SpecificEnthalpy)
-            NormType: L2Norm
-            Components: Sum
-  ? Slabs:
-      EvenlySpaced:
-        Interval: 2
-        Offset: 0
-  : - ObserveFields:
-        SubfileName: VolumeData
-        VariablesToObserve:
-          - SpacetimeMetric
-          - RestMassDensity
-          - Pressure
-          - MagneticField
-          - PointwiseL2Norm(GaugeConstraint)
-        InterpolateToMesh: None
-        CoordinatesFloatingPointType: Double
-        FloatingPointTypes: [Double, Double, Double, Double, Double]
-  ? Slabs:
-      EvenlySpaced:
-        Interval: 5
-        Offset: 3
-  : - AhA
-  ? Slabs:
-      Specified:
-        Values: [2]
-  : - Completion
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 5
+          Offset: 0
+    - - ChangeSlabSize:
+          DelayChange: 5
+          StepChoosers:
+            - Cfl:
+                SafetyFactor: 0.6
+            - Increase:
+                Factor: 1.5
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 1
+          Offset: 0
+    - - ObserveNorms:
+          SubfileName: Errors
+          TensorsToObserve:
+            - Name: Error(SpacetimeMetric)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(Pi)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(Phi)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(RestMassDensity)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(SpecificInternalEnergy)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(SpatialVelocity)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(MagneticField)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(DivergenceCleaningField)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(LorentzFactor)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(Pressure)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(SpecificEnthalpy)
+              NormType: L2Norm
+              Components: Sum
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 2
+          Offset: 0
+    - - ObserveFields:
+          SubfileName: VolumeData
+          VariablesToObserve:
+            - SpacetimeMetric
+            - RestMassDensity
+            - Pressure
+            - MagneticField
+            - PointwiseL2Norm(GaugeConstraint)
+          InterpolateToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Double, Double, Double, Double, Double]
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 5
+          Offset: 3
+    - - AhA
+  - - Slabs:
+        Specified:
+          Values: [2]
+    - - Completion
 
 ApparentHorizons:
   AhA:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -106,76 +106,76 @@ SpatialDiscretization:
       Rusanov:
 
 EventsAndTriggers:
-  ? Slabs:
-      EvenlySpaced:
-        Interval: 5
-        Offset: 0
-  : - ChangeSlabSize:
-        DelayChange: 5
-        StepChoosers:
-          - Cfl:
-              SafetyFactor: 0.6
-          - Increase:
-              Factor: 1.5
-  ? Slabs:
-      EvenlySpaced:
-        Interval: 1
-        Offset: 0
-  : - ObserveNorms:
-        SubfileName: Errors
-        TensorsToObserve:
-          - Name: Error(SpacetimeMetric)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(Pi)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(Phi)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(RestMassDensity)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(SpecificInternalEnergy)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(SpatialVelocity)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(MagneticField)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(DivergenceCleaningField)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(LorentzFactor)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(Pressure)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(SpecificEnthalpy)
-            NormType: L2Norm
-            Components: Sum
-  ? Slabs:
-      EvenlySpaced:
-        Interval: 2
-        Offset: 0
-  : - ObserveFields:
-        SubfileName: VolumeData
-        VariablesToObserve:
-          - SpacetimeMetric
-          - RestMassDensity
-          - Pressure
-          - MagneticField
-          - PointwiseL2Norm(GaugeConstraint)
-        InterpolateToMesh: None
-        CoordinatesFloatingPointType: Double
-        FloatingPointTypes: [Double, Double, Double, Double, Double]
-  ? Slabs:
-      Specified:
-        Values: [3]
-  : - Completion
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 5
+          Offset: 0
+    - - ChangeSlabSize:
+          DelayChange: 5
+          StepChoosers:
+            - Cfl:
+                SafetyFactor: 0.6
+            - Increase:
+                Factor: 1.5
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 1
+          Offset: 0
+    - - ObserveNorms:
+          SubfileName: Errors
+          TensorsToObserve:
+            - Name: Error(SpacetimeMetric)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(Pi)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(Phi)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(RestMassDensity)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(SpecificInternalEnergy)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(SpatialVelocity)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(MagneticField)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(DivergenceCleaningField)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(LorentzFactor)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(Pressure)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(SpecificEnthalpy)
+              NormType: L2Norm
+              Components: Sum
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 2
+          Offset: 0
+    - - ObserveFields:
+          SubfileName: VolumeData
+          VariablesToObserve:
+            - SpacetimeMetric
+            - RestMassDensity
+            - Pressure
+            - MagneticField
+            - PointwiseL2Norm(GaugeConstraint)
+          InterpolateToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Double, Double, Double, Double, Double]
+  - - Slabs:
+        Specified:
+          Values: [3]
+    - - Completion
 
 Observers:
   VolumeFileName: "GhMhdTovStarVolume"

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -93,9 +93,9 @@ Observers:
   ReductionFileName: "ValenciaDivCleanBlastWaveReductions"
 
 EventsAndTriggers:
-  ? Slabs:
-      Specified:
-        Values: [2]
-  : - Completion
+  - - Slabs:
+        Specified:
+          Values: [2]
+    - - Completion
 
 EventsAndDenseTriggers:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -98,26 +98,26 @@ VariableFixing:
     MaxVelocityMagnitude: 1.0e-4
 
 EventsAndTriggers:
-  ? Slabs:
-      Specified:
-        Values: [10]
-  : - Completion
-  ? Slabs:
-      EvenlySpaced:
-        Interval: 1
-        Offset: 0
-  : - ChangeSlabSize:
-        # DelayChange: 0 forces a synchronization after every slab.
-        # It is more efficient to use a higher value.  This is for
-        # testing.
-        DelayChange: 0
-        StepChoosers:
-          - Constant: 0.05
-          - Increase:
-              Factor: 2
-          - Cfl:
-              SafetyFactor: 0.2
-          - PreventRapidIncrease
+  - - Slabs:
+        Specified:
+          Values: [10]
+    - - Completion
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 1
+          Offset: 0
+    - - ChangeSlabSize:
+          # DelayChange: 0 forces a synchronization after every slab.
+          # It is more efficient to use a higher value.  This is for
+          # testing.
+          DelayChange: 0
+          StepChoosers:
+            - Constant: 0.05
+            - Increase:
+                Factor: 2
+            - Cfl:
+                SafetyFactor: 0.2
+            - PreventRapidIncrease
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
@@ -59,10 +59,10 @@ AnalyticSolution:
     PressureStarTol: 1e-9
 
 EventsAndTriggers:
-  ? Slabs:
-      Specified:
-        Values: [10]
-  : - Completion
+  - - Slabs:
+        Specified:
+          Values: [10]
+    - - Completion
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
@@ -57,10 +57,10 @@ AnalyticSolution:
     PressureStarTol: 1e-9
 
 EventsAndTriggers:
-  ? Slabs:
-      Specified:
-        Values: [10]
-  : - Completion
+  - - Slabs:
+        Specified:
+          Values: [10]
+    - - Completion
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
@@ -57,10 +57,10 @@ AnalyticSolution:
     PressureStarTol: 1e-9
 
 EventsAndTriggers:
-  ? Slabs:
-      Specified:
-        Values: [10]
-  : - Completion
+  - - Slabs:
+        Specified:
+          Values: [10]
+    - - Completion
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -72,16 +72,16 @@ LinearSolver:
     ObservePerCoreReductions: False
 
 EventsAndTriggers:
-  ? HasConverged
-  : - ObserveNorms:
-        SubfileName: ErrorNorms
-        TensorsToObserve:
-          - Name: Error(Field)
-            NormType: L2Norm
-            Components: Sum
-    - ObserveFields:
-        SubfileName: VolumeData
-        VariablesToObserve: [Field]
-        InterpolateToMesh: None
-        CoordinatesFloatingPointType: Double
-        FloatingPointTypes: [Double]
+  - - HasConverged
+    - - ObserveNorms:
+          SubfileName: ErrorNorms
+          TensorsToObserve:
+            - Name: Error(Field)
+              NormType: L2Norm
+              Components: Sum
+      - ObserveFields:
+          SubfileName: VolumeData
+          VariablesToObserve: [Field]
+          InterpolateToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Double]

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -68,16 +68,16 @@ LinearSolver:
     ObservePerCoreReductions: False
 
 EventsAndTriggers:
-  ? HasConverged
-  : - ObserveNorms:
-        SubfileName: ErrorNorms
-        TensorsToObserve:
-          - Name: Error(Field)
-            NormType: L2Norm
-            Components: Sum
-    - ObserveFields:
-        SubfileName: VolumeData
-        VariablesToObserve: [Field]
-        InterpolateToMesh: None
-        CoordinatesFloatingPointType: Double
-        FloatingPointTypes: [Double]
+  - - HasConverged
+    - - ObserveNorms:
+          SubfileName: ErrorNorms
+          TensorsToObserve:
+            - Name: Error(Field)
+              NormType: L2Norm
+              Components: Sum
+      - ObserveFields:
+          SubfileName: VolumeData
+          VariablesToObserve: [Field]
+          InterpolateToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Double]

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -69,16 +69,16 @@ LinearSolver:
     ObservePerCoreReductions: False
 
 EventsAndTriggers:
-  ? HasConverged
-  : - ObserveNorms:
-        SubfileName: ErrorNorms
-        TensorsToObserve:
-          - Name: Error(Field)
-            NormType: L2Norm
-            Components: Sum
-    - ObserveFields:
-        SubfileName: VolumeData
-        VariablesToObserve: [Field]
-        InterpolateToMesh: None
-        CoordinatesFloatingPointType: Double
-        FloatingPointTypes: [Double]
+  - - HasConverged
+    - - ObserveNorms:
+          SubfileName: ErrorNorms
+          TensorsToObserve:
+            - Name: Error(Field)
+              NormType: L2Norm
+              Components: Sum
+      - ObserveFields:
+          SubfileName: VolumeData
+          VariablesToObserve: [Field]
+          InterpolateToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Double]

--- a/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
+++ b/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
@@ -48,23 +48,23 @@ Limiter:
     DisableForDebugging: false
 
 EventsAndTriggers:
-  ? Slabs:
-      EvenlySpaced:
-        Interval: 3
-        Offset: 5
-  : - ObserveNorms:
-        SubfileName: Errors
-        TensorsToObserve:
-          - Name: Error(TildeE_ElectronNeutrinos1)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(TildeS_ElectronNeutrinos1)
-            NormType: L2Norm
-            Components: Sum
-  ? Slabs:
-      Specified:
-        Values: [10]
-  : - Completion
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 3
+          Offset: 5
+    - - ObserveNorms:
+          SubfileName: Errors
+          TensorsToObserve:
+            - Name: Error(TildeE_ElectronNeutrinos1)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(TildeS_ElectronNeutrinos1)
+              NormType: L2Norm
+              Components: Sum
+  - - Slabs:
+        Specified:
+          Values: [10]
+    - - Completion
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow1D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow1D.yaml
@@ -61,16 +61,16 @@ VariableFixing:
     MaxVelocityMagnitude: 1.0e-4
 
 EventsAndTriggers:
-  # ? Slabs:
-  #     EvenlySpaced:
-  #       Interval: 10
-  #       Offset: 0
-  # : - ObserveFields:
-  #       VariablesToObserve: [RestMassDensity]
-  ? Slabs:
-      Specified:
-        Values: [10]
-  : - Completion
+  # - - Slabs:
+  #       EvenlySpaced:
+  #         Interval: 10
+  #         Offset: 0
+  #   - - ObserveFields:
+  #         VariablesToObserve: [RestMassDensity]
+  - - Slabs:
+        Specified:
+          Values: [10]
+    - - Completion
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow2D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow2D.yaml
@@ -59,16 +59,16 @@ VariableFixing:
     MaxVelocityMagnitude: 1.0e-4
 
 EventsAndTriggers:
-  # ? Slabs:
-  #     EvenlySpaced:
-  #       Interval: 100
-  #       Offset: 0
-  # : - ObserveFields:
-  #       VariablesToObserve: [RestMassDensity]
-  ? Slabs:
-      Specified:
-        Values: [10]
-  : - Completion
+  # - - Slabs:
+  #       EvenlySpaced:
+  #         Interval: 100
+  #         Offset: 0
+  #   - - ObserveFields:
+  #         VariablesToObserve: [RestMassDensity]
+  - - Slabs:
+        Specified:
+          Values: [10]
+    - - Completion
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow3D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow3D.yaml
@@ -59,16 +59,16 @@ VariableFixing:
     MaxVelocityMagnitude: 1.0e-4
 
 EventsAndTriggers:
-  # ? Slabs:
-  #     EvenlySpaced:
-  #       Interval: 100
-  #       Offset: 0
-  # : - ObserveFields:
-  #       VariablesToObserve: [RestMassDensity]
-  ? Slabs:
-      Specified:
-        Values: [10]
-  : - Completion
+  # - - Slabs:
+  #       EvenlySpaced:
+  #         Interval: 100
+  #         Offset: 0
+  #   - - ObserveFields:
+  #         VariablesToObserve: [RestMassDensity]
+  - - Slabs:
+        Specified:
+          Values: [10]
+    - - Completion
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
@@ -53,20 +53,20 @@ AnalyticSolution:
   Krivodonova:
 
 EventsAndTriggers:
-  ? Slabs:
-      Specified:
-        Values: [10]
-  : - Completion
-  ? Slabs:
-      EvenlySpaced:
-        Interval: 10
-        Offset: 0
-  : - ObserveFields:
-        SubfileName: VolumeData
-        VariablesToObserve: [U, TciStatus]
-        InterpolateToMesh: None
-        CoordinatesFloatingPointType: Double
-        FloatingPointTypes: [Float, Float]
+  - - Slabs:
+        Specified:
+          Values: [10]
+    - - Completion
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 10
+          Offset: 0
+    - - ObserveFields:
+          SubfileName: VolumeData
+          VariablesToObserve: [U, TciStatus]
+          InterpolateToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Float, Float]
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
@@ -51,20 +51,20 @@ AnalyticSolution:
   Kuzmin:
 
 EventsAndTriggers:
-  ? Slabs:
-      Specified:
-        Values: [10]
-  : - Completion
-  ? Slabs:
-      EvenlySpaced:
-        Interval: 10
-        Offset: 0
-  : - ObserveFields:
-        SubfileName: VolumeData
-        VariablesToObserve: [U, TciStatus]
-        InterpolateToMesh: None
-        CoordinatesFloatingPointType: Double
-        FloatingPointTypes: [Float, Float]
+  - - Slabs:
+        Specified:
+          Values: [10]
+    - - Completion
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 10
+          Offset: 0
+    - - ObserveFields:
+          SubfileName: VolumeData
+          VariablesToObserve: [U, TciStatus]
+          InterpolateToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Float, Float]
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
@@ -53,20 +53,20 @@ AnalyticSolution:
   Sinusoid:
 
 EventsAndTriggers:
-  ? Slabs:
-      Specified:
-        Values: [10]
-  : - Completion
-  ? Slabs:
-      EvenlySpaced:
-        Interval: 10
-        Offset: 0
-  : - ObserveFields:
-        SubfileName: VolumeData
-        VariablesToObserve: [U, TciStatus]
-        InterpolateToMesh: None
-        CoordinatesFloatingPointType: Double
-        FloatingPointTypes: [Float, Float]
+  - - Slabs:
+        Specified:
+          Values: [10]
+    - - Completion
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 10
+          Offset: 0
+    - - ObserveFields:
+          SubfileName: VolumeData
+          VariablesToObserve: [U, TciStatus]
+          InterpolateToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Float, Float]
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
@@ -60,21 +60,21 @@ SpatialDiscretization:
 #     HalfPower: 32
 
 EventsAndTriggers:
-  ? Slabs:
-      Specified:
-        Values: [5]
-  : - Completion
-  ? Slabs:
-      EvenlySpaced:
-        Interval: 2
-        Offset: 0
-  : - ChangeSlabSize:
-        DelayChange: 3
-        StepChoosers:
-          # Based on the step size choices above, this should aim for
-          # about 100 steps per slab.
-          - Cfl:
-              SafetyFactor: 20
+  - - Slabs:
+        Specified:
+          Values: [5]
+    - - Completion
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 2
+          Offset: 0
+    - - ChangeSlabSize:
+          DelayChange: 3
+          StepChoosers:
+            # Based on the step size choices above, this should aim for
+            # about 100 steps per slab.
+            - Cfl:
+                SafetyFactor: 20
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
@@ -54,36 +54,36 @@ EventsAndDenseTriggers:
 
 # [multiple_events]
 EventsAndTriggers:
-  ? Slabs:
-      EvenlySpaced:
-        Interval: 10
-        Offset: 0
-  : - ObserveFields:
-        SubfileName: Fields
-        VariablesToObserve: [Psi]
-        InterpolateToMesh: None
-        CoordinatesFloatingPointType: Double
-        FloatingPointTypes: [Double]
-    - ObserveNorms:
-        SubfileName: Errors
-        TensorsToObserve:
-          - Name: Error(Psi)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(Phi)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(Pi)
-            NormType: L2Norm
-            Components: Sum
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 10
+          Offset: 0
+    - - ObserveFields:
+          SubfileName: Fields
+          VariablesToObserve: [Psi]
+          InterpolateToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Double]
+      - ObserveNorms:
+          SubfileName: Errors
+          TensorsToObserve:
+            - Name: Error(Psi)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(Phi)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(Pi)
+              NormType: L2Norm
+              Components: Sum
 # [multiple_events]
 
 # [no_arguments]
-  ? Always
-  : - Completion
+  - - Always
+    - - Completion
 # [no_arguments]
 # [no_arguments_single_line]
-  Always: [Completion]
+  - [Always, [Completion]]
 # [no_arguments_single_line]
 
 Observers:

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -66,21 +66,21 @@ SpatialDiscretization:
 
 # [observe_event_trigger]
 EventsAndDenseTriggers:
-  ? Times:
-      Specified:
-        Values: [0.0, 1.0]
-  : - ObserveNorms:
-        SubfileName: Errors
-        TensorsToObserve:
-          - Name: Error(Psi)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(Phi)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(Pi)
-            NormType: L2Norm
-            Components: Sum
+  - - Times:
+        Specified:
+          Values: [0.0, 1.0]
+    - - ObserveNorms:
+          SubfileName: Errors
+          TensorsToObserve:
+            - Name: Error(Psi)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(Phi)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(Pi)
+              NormType: L2Norm
+              Components: Sum
 
 EventsAndTriggers:
   - - Slabs:

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -83,20 +83,20 @@ EventsAndDenseTriggers:
             Components: Sum
 
 EventsAndTriggers:
-  ? Slabs:
-      Specified:
-        Values: [100]
-  : - Completion
-  ? Slabs:
-      EvenlySpaced:
-        Interval: 50
-        Offset: 0
-  : - ObserveFields:
-        SubfileName: VolumePsiPiPhiEvery50Slabs
-        VariablesToObserve: ["Psi", "Pi", "Phi"]
-        InterpolateToMesh: None
-        CoordinatesFloatingPointType: Double
-        FloatingPointTypes: [Double, Float, Float]
+  - - Slabs:
+        Specified:
+          Values: [100]
+    - - Completion
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 50
+          Offset: 0
+    - - ObserveFields:
+          SubfileName: VolumePsiPiPhiEvery50Slabs
+          VariablesToObserve: ["Psi", "Pi", "Phi"]
+          InterpolateToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Double, Float, Float]
 # [observe_event_trigger]
 
 Observers:

--- a/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
@@ -67,10 +67,10 @@ Filtering:
     DisableForDebugging: false
 
 EventsAndTriggers:
-  ? Slabs:
-      Specified:
-        Values: [5]
-  : - Completion
+  - - Slabs:
+        Specified:
+          Values: [5]
+    - - Completion
 
 EventsAndDenseTriggers:
   # Test LTS dense output at the initial time

--- a/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
@@ -74,21 +74,21 @@ EventsAndTriggers:
 
 EventsAndDenseTriggers:
   # Test LTS dense output at the initial time
-  ? Times:
-      Specified:
-        Values: [*initial_time]
-  : - ObserveNorms:
-        SubfileName: Errors
-        TensorsToObserve:
-          - Name: Error(Psi)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(Phi)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(Pi)
-            NormType: L2Norm
-            Components: Sum
+  - - Times:
+        Specified:
+          Values: [*initial_time]
+    - - ObserveNorms:
+          SubfileName: Errors
+          TensorsToObserve:
+            - Name: Error(Psi)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(Phi)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(Pi)
+              NormType: L2Norm
+              Components: Sum
 
 Observers:
   VolumeFileName: "ScalarWavePlaneWave2DVolume"

--- a/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
@@ -57,10 +57,10 @@ SpatialDiscretization:
 #     HalfPower: 32
 
 EventsAndTriggers:
-  ? Slabs:
-      Specified:
-        Values: [5]
-  : - Completion
+  - - Slabs:
+        Specified:
+          Values: [5]
+    - - Completion
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -156,36 +156,36 @@ LinearSolver:
     ObservePerCoreReductions: False
 
 EventsAndTriggers:
-  ? HasConverged
-  : - ObserveNorms:
-        SubfileName: Norms
-        TensorsToObserve:
-          - Name: ConformalFactor
-            NormType: Max
-            Components: Individual
-          - Name: Lapse
-            NormType: Min
-            Components: Individual
-          - Name: Magnitude(ShiftExcess)
-            NormType: Max
-            Components: Individual
-          - Name: HamiltonianConstraint
-            NormType: L2Norm
-            Components: Individual
-          - Name: MomentumConstraint
-            NormType: L2Norm
-            Components: Individual
-    - ObserveFields:
-        SubfileName: VolumeData
-        VariablesToObserve:
-          - ConformalFactor
-          - Lapse
-          - Shift
-          - ShiftExcess
-          - SpatialMetric
-          - ExtrinsicCurvature
-          - HamiltonianConstraint
-          - MomentumConstraint
-        InterpolateToMesh: None
-        CoordinatesFloatingPointType: Double
-        FloatingPointTypes: [Double]
+  - - HasConverged
+    - - ObserveNorms:
+          SubfileName: Norms
+          TensorsToObserve:
+            - Name: ConformalFactor
+              NormType: Max
+              Components: Individual
+            - Name: Lapse
+              NormType: Min
+              Components: Individual
+            - Name: Magnitude(ShiftExcess)
+              NormType: Max
+              Components: Individual
+            - Name: HamiltonianConstraint
+              NormType: L2Norm
+              Components: Individual
+            - Name: MomentumConstraint
+              NormType: L2Norm
+              Components: Individual
+      - ObserveFields:
+          SubfileName: VolumeData
+          VariablesToObserve:
+            - ConformalFactor
+            - Lapse
+            - Shift
+            - ShiftExcess
+            - SpatialMetric
+            - ExtrinsicCurvature
+            - HamiltonianConstraint
+            - MomentumConstraint
+          InterpolateToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Double]

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -108,47 +108,47 @@ LinearSolver:
     ObservePerCoreReductions: False
 
 EventsAndTriggers:
-  ? HasConverged
-  : - ObserveNorms:
-        SubfileName: ErrorNorms
-        TensorsToObserve:
-          - Name: Error(ConformalFactor)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(LapseTimesConformalFactor)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(ShiftExcess)
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(Flux(ConformalFactor))
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(Flux(LapseTimesConformalFactor))
-            NormType: L2Norm
-            Components: Sum
-          - Name: Error(LongitudinalShiftExcess)
-            NormType: L2Norm
-            Components: Sum
-    - ObserveNorms:
-        SubfileName: Norms
-        TensorsToObserve:
-          - Name: HamiltonianConstraint
-            NormType: L2Norm
-            Components: Individual
-          - Name: MomentumConstraint
-            NormType: L2Norm
-            Components: Individual
-    - ObserveFields:
-        SubfileName: VolumeData
-        VariablesToObserve:
-          - ConformalFactor
-          - Lapse
-          - Shift
-          - SpatialMetric
-          - ExtrinsicCurvature
-          - HamiltonianConstraint
-          - MomentumConstraint
-        InterpolateToMesh: None
-        CoordinatesFloatingPointType: Double
-        FloatingPointTypes: [Double]
+  - - HasConverged
+    - - ObserveNorms:
+          SubfileName: ErrorNorms
+          TensorsToObserve:
+            - Name: Error(ConformalFactor)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(LapseTimesConformalFactor)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(ShiftExcess)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(Flux(ConformalFactor))
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(Flux(LapseTimesConformalFactor))
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(LongitudinalShiftExcess)
+              NormType: L2Norm
+              Components: Sum
+      - ObserveNorms:
+          SubfileName: Norms
+          TensorsToObserve:
+            - Name: HamiltonianConstraint
+              NormType: L2Norm
+              Components: Individual
+            - Name: MomentumConstraint
+              NormType: L2Norm
+              Components: Individual
+      - ObserveFields:
+          SubfileName: VolumeData
+          VariablesToObserve:
+            - ConformalFactor
+            - Lapse
+            - Shift
+            - SpatialMetric
+            - ExtrinsicCurvature
+            - HamiltonianConstraint
+            - MomentumConstraint
+          InterpolateToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Double]

--- a/tests/Unit/Evolution/Actions/Test_RunEventsAndDenseTriggers.cpp
+++ b/tests/Unit/Evolution/Actions/Test_RunEventsAndDenseTriggers.cpp
@@ -335,9 +335,10 @@ void test(const bool time_runs_forward) {
 
         evolution::EventsAndDenseTriggers::ConstructionType
             events_and_dense_triggers{};
+        events_and_dense_triggers.reserve(triggers.size());
         for (auto [trigger_time, is_triggered, next_trigger,
                    needs_evolved_variables] : triggers) {
-          events_and_dense_triggers.emplace(
+          events_and_dense_triggers.emplace_back(
               std::make_unique<TestTrigger>(start_time, trigger_time,
                                             is_triggered, next_trigger),
               make_vector<std::unique_ptr<Event>>(

--- a/tests/Unit/Evolution/EventsAndDenseTriggers/Test_EventsAndDenseTriggers.cpp
+++ b/tests/Unit/Evolution/EventsAndDenseTriggers/Test_EventsAndDenseTriggers.cpp
@@ -151,13 +151,13 @@ void do_test(const bool time_runs_forward, const bool add_event) {
   const int* component = nullptr;
 
   std::string creation_string =
-      "BoxTrigger<A>:\n"
-      "  - TestEvent<A>\n";
+      "- - BoxTrigger<A>\n"
+      "  - - TestEvent<A>\n";
   if (not add_event) {
     creation_string +=
-        "BoxTrigger<B>:\n"
-        "  - TestEvent<B>\n"
-        "  - TestEvent<C>\n";
+        "- - BoxTrigger<B>\n"
+        "  - - TestEvent<B>\n"
+        "    - TestEvent<C>\n";
   }
 
   auto events_and_dense_triggers =

--- a/tests/Unit/Evolution/EventsAndDenseTriggers/Test_EventsAndDenseTriggers.cpp
+++ b/tests/Unit/Evolution/EventsAndDenseTriggers/Test_EventsAndDenseTriggers.cpp
@@ -250,6 +250,7 @@ void do_test(const bool time_runs_forward, const bool add_event) {
   CHECK(
       events_and_dense_triggers.reschedule(box, cache, array_index, component));
   set_tag(TriggerA::NextCheck{}, 4.0 * time_sign);
+  set_tag(EventA::IsReady{}, false);
   set_tag(TriggerB::IsTriggered{}, true);
   set_tag(TriggerB::NextCheck{}, 4.0 * time_sign);
   CHECK(events_and_dense_triggers.next_trigger(box) == 3.0 * time_sign);
@@ -260,6 +261,9 @@ void do_test(const bool time_runs_forward, const bool add_event) {
   CHECK(events_and_dense_triggers.is_ready(
             box, cache, array_index, component) == TriggeringState::NotReady);
   set_tag(EventC::IsReady{}, true);
+  CHECK(events_and_dense_triggers.is_ready(
+            box, cache, array_index, component) == TriggeringState::NotReady);
+  set_tag(EventA::IsReady{}, true);
   CHECK(
       events_and_dense_triggers.is_ready(box, cache, array_index, component) ==
       TriggeringState::NeedsEvolvedVariables);

--- a/tests/Unit/IO/Observers/Test_RegisterEvents.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterEvents.cpp
@@ -177,9 +177,9 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.RegisterEvents", "[Unit][Observers]") {
 
   const auto events_and_triggers =
       TestHelpers::test_creation<EventsAndTriggers, Metavariables>(
-          "? Not: Always\n"
-          ": - SomeEvent:\n"
-          "      SubfileName: element_data\n");
+          "- - Not: Always\n"
+          "  - - SomeEvent:\n"
+          "        SubfileName: element_data\n");
 
   using my_component = Component<Metavariables>;
   using obs_component = MockObserverComponent<Metavariables>;

--- a/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_EventsAndTriggers.cpp
+++ b/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_EventsAndTriggers.cpp
@@ -75,12 +75,12 @@ void check_trigger(const bool expected, const std::string& trigger_string) {
       TestHelpers::test_creation<std::unique_ptr<Trigger>, Metavariables>(
           trigger_string);
 
-  EventsAndTriggers::Storage events_and_triggers_map;
-  events_and_triggers_map.emplace(std::move(trigger),
-                                  make_vector<std::unique_ptr<Event>>(
-                                      std::make_unique<Events::Completion>()));
+  EventsAndTriggers::Storage events_and_triggers_input;
+  events_and_triggers_input.emplace_back(
+      std::move(trigger), make_vector<std::unique_ptr<Event>>(
+                              std::make_unique<Events::Completion>()));
   const EventsAndTriggers events_and_triggers(
-      std::move(events_and_triggers_map));
+      std::move(events_and_triggers_input));
 
   run_events_and_triggers(events_and_triggers, expected);
 }
@@ -149,15 +149,15 @@ SPECTRE_TEST_CASE("Unit.Evolution.EventsAndTriggers.creation",
                   "[Unit][Evolution]") {
   const auto events_and_triggers =
       TestHelpers::test_creation<EventsAndTriggers, Metavariables>(
-          "? Not: Always\n"
-          ": - Completion\n"
-          "? Or:\n"
-          "  - Not: Always\n"
-          "  - Always\n"
-          ": - Completion\n"
-          "  - Completion\n"
-          "? Not: Always\n"
-          ": - Completion\n");
+          "- - Not: Always\n"
+          "  - - Completion\n"
+          "- - Or:\n"
+          "    - Not: Always\n"
+          "    - Always\n"
+          "  - - Completion\n"
+          "    - Completion\n"
+          "- - Not: Always\n"
+          "  - - Completion\n");
 
   run_events_and_triggers(events_and_triggers, true);
 }


### PR DESCRIPTION
Note to reviewers: 760 of the changed lines are trivial input-file syntax changes.

This will hopefully solve lockups we have attributed to the ordering of reduction calls varying between nodes.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
The syntax for the `EventsAndTriggers` and `EventsAndDenseTriggers` input-file sections has changed.  Each `?:` entry should be changed from
```yaml
  ? Trigger
  : - Event
    - PossibleOtherEvents
```
to
```yaml
  - - Trigger
    - - Event
      - PossibleOtherEvents
```
This results in all event and trigger arguments indenting one additional level (typically two spaces). 
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
