### PR TITLE
Compute trace Christoffel from GH vars better

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/Constraints.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Constraints.cpp
@@ -8,6 +8,7 @@
 #include "DataStructures/LeviCivitaIterator.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Christoffel.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
@@ -987,32 +988,11 @@ void gauge_constraint(
     const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
     const tnsr::aa<DataType, SpatialDim, Frame>& pi,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi) {
+  trace_christoffel(constraint, spacetime_normal_one_form,
+                    spacetime_normal_vector, inverse_spatial_metric,
+                    inverse_spacetime_metric, pi, phi);
   for (size_t a = 0; a < SpatialDim + 1; ++a) {
-    (*constraint).get(a) = gauge_function.get(a);
-    for (size_t i = 0; i < SpatialDim; ++i) {
-      for (size_t j = 0; j < SpatialDim; ++j) {
-        (*constraint).get(a) +=
-            inverse_spatial_metric.get(i, j) * phi.get(i, j + 1, a);
-      }
-    }
-    for (size_t b = 0; b < SpatialDim + 1; ++b) {
-      (*constraint).get(a) += spacetime_normal_vector.get(b) * pi.get(b, a);
-      for (size_t c = 0; c < SpatialDim + 1; ++c) {
-        (*constraint).get(a) -= 0.5 * spacetime_normal_one_form.get(a) *
-                                pi.get(b, c) *
-                                inverse_spacetime_metric.get(b, c);
-        if (a > 0) {
-          (*constraint).get(a) -=
-              0.5 * phi.get(a - 1, b, c) * inverse_spacetime_metric.get(b, c);
-        }
-        for (size_t i = 0; i < SpatialDim; ++i) {
-          (*constraint).get(a) -= 0.5 * spacetime_normal_one_form.get(a) *
-                                  spacetime_normal_vector.get(i + 1) *
-                                  phi.get(i, b, c) *
-                                  inverse_spacetime_metric.get(b, c);
-        }
-      }
-    }
+    (*constraint).get(a) += gauge_function.get(a);
   }
 }
 

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Christoffel.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Christoffel.hpp
@@ -40,4 +40,40 @@ auto christoffel_second_kind(
     const tnsr::II<DataType, SpatialDim, Frame>& inv_metric)
     -> tnsr::Ijj<DataType, SpatialDim, Frame>;
 /// @}
+
+/// @{
+/*!
+ * \brief Compute \f$\Gamma_a\f$ from the generalized harmonic evolved
+ * variables.
+ *
+ * Starting from Eq. (40) of \cite Lindblom2005qh we get
+ *
+ * \f{align*}{
+ *  \Gamma_a &= \gamma^{ij}\Phi_{ija} + n^b \Pi_{ab} -
+ *   \frac{1}{2}\gamma^{i}{}_ag^{bc}\Phi_{ibc} - \frac{1}{2}n_ag^{bc}\Pi_{bc}
+ *   \\
+ *   \Gamma_a &= \gamma^{ij}\Phi_{ija} + n^b \Pi_{ab} -\frac{1}{2}
+ *               n_a g^{bc} \left(n^i \Phi_{ibc} + \Pi_{bc}\right)
+ *               - \frac{1}{2} \delta^i_a g^{bc} \Phi_{ibc}
+ * \f}
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::a<DataType, SpatialDim, Frame> trace_christoffel(
+    const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi);
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void trace_christoffel(
+    gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> trace,
+    const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi);
+/// @}
 }  // namespace GeneralizedHarmonic

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.py
@@ -203,3 +203,17 @@ def gh_spatial_ricci_tensor(phi, deriv_phi, inverse_spatial_metric):
             "ikl,jlk->ij", spatial_phi_ijK, spatial_phi_ijK) + 2 * np.einsum(
                 "kil,kjl->ij", spatial_phi_Ijj, spatial_phi_ijK
             ) - 2 * np.einsum("kli,lkj->ij", spatial_phi_Ijj, spatial_phi_Ijj)
+
+
+def trace_christoffel(spacetime_normal_one_form, spacetime_normal_vector,
+                      inverse_spatial_metric, inverse_spacetime_metric, pi,
+                      phi):
+    spatial_normal_vector = spacetime_normal_vector[1:]
+    # everything except delta^i_a term
+    result = (
+        np.einsum("ij,ija->a", inverse_spatial_metric, phi[:, 1:, :]) +
+        np.einsum("b,ba->a", spacetime_normal_vector, pi) - 0.5 * np.einsum(
+            "a,bc,bc->a", spacetime_normal_one_form, inverse_spacetime_metric,
+            np.einsum("i,ibc->bc", spatial_normal_vector, phi) + pi))
+    result[1:] -= 0.5 * np.einsum("bc,ibc->i", inverse_spacetime_metric, phi)
+    return result


### PR DESCRIPTION
## Proposed changes

- Add function that is optimized (doesn't do excessive FLOPs at least)
- Use it when computing the 1-index constraint for observing

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
