### PR TITLE
Start adding support for specifying the initial data in the input file

### DIFF
--- a/src/PointwiseFunctions/AnalyticData/Burgers/Sinusoid.cpp
+++ b/src/PointwiseFunctions/AnalyticData/Burgers/Sinusoid.cpp
@@ -20,6 +20,11 @@ Scalar<T> Sinusoid::u(const tnsr::I<T, 1>& x) const {
   return Scalar<T>{sin(get<0>(x))};
 }
 
+std::unique_ptr<evolution::initial_data::InitialData> Sinusoid::get_clone()
+    const {
+  return std::make_unique<Sinusoid>(*this);
+}
+
 Sinusoid::Sinusoid(CkMigrateMessage* msg) : InitialData(msg) {}
 
 tuples::TaggedTuple<Tags::U> Sinusoid::variables(

--- a/src/PointwiseFunctions/AnalyticData/Burgers/Sinusoid.hpp
+++ b/src/PointwiseFunctions/AnalyticData/Burgers/Sinusoid.hpp
@@ -104,6 +104,9 @@ class Sinusoid : public evolution::initial_data::InitialData,
   Sinusoid& operator=(Sinusoid&&) = default;
   ~Sinusoid() override = default;
 
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override;
+
   /// \cond
   explicit Sinusoid(CkMigrateMessage* msg);
   using PUP::able::register_constructor;

--- a/src/PointwiseFunctions/AnalyticData/Burgers/Sinusoid.hpp
+++ b/src/PointwiseFunctions/AnalyticData/Burgers/Sinusoid.hpp
@@ -102,7 +102,7 @@ class Sinusoid : public evolution::initial_data::InitialData,
   Sinusoid& operator=(const Sinusoid&) = default;
   Sinusoid(Sinusoid&&) = default;
   Sinusoid& operator=(Sinusoid&&) = default;
-  ~Sinusoid() = default;
+  ~Sinusoid() override = default;
 
   /// \cond
   explicit Sinusoid(CkMigrateMessage* msg);
@@ -117,7 +117,7 @@ class Sinusoid : public evolution::initial_data::InitialData,
                                          tmpl::list<Tags::U> /*meta*/) const;
 
   // NOLINTNEXTLINE(google-runtime-references)
-  void pup(PUP::er& p);
+  void pup(PUP::er& p) override;
 };
 
 bool operator==(const Sinusoid& /*lhs*/, const Sinusoid& /*rhs*/);

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/BlastWave.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/BlastWave.cpp
@@ -80,6 +80,11 @@ BlastWave::BlastWave(const double inner_radius, const double outer_radius,
   }
 }
 
+std::unique_ptr<evolution::initial_data::InitialData> BlastWave::get_clone()
+    const {
+  return std::make_unique<BlastWave>(*this);
+}
+
 BlastWave::BlastWave(CkMigrateMessage* msg) : InitialData(msg) {}
 
 void BlastWave::pup(PUP::er& p) {

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/BlastWave.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/BlastWave.hpp
@@ -149,6 +149,9 @@ class BlastWave : public evolution::initial_data::InitialData,
             const std::array<double, 3>& magnetic_field, double adiabatic_index,
             Geometry geometry, const Options::Context& context = {});
 
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override;
+
   /// \cond
   explicit BlastWave(CkMigrateMessage* msg);
   using PUP::able::register_constructor;

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/BlastWave.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/BlastWave.hpp
@@ -142,7 +142,7 @@ class BlastWave : public evolution::initial_data::InitialData,
   BlastWave& operator=(const BlastWave& /*rhs*/) = default;
   BlastWave(BlastWave&& /*rhs*/) = default;
   BlastWave& operator=(BlastWave&& /*rhs*/) = default;
-  ~BlastWave() = default;
+  ~BlastWave() override = default;
 
   BlastWave(double inner_radius, double outer_radius, double inner_density,
             double outer_density, double inner_pressure, double outer_pressure,
@@ -227,8 +227,8 @@ class BlastWave : public evolution::initial_data::InitialData,
     return equation_of_state_;
   }
 
-  // clang-tidy: no runtime references
-  void pup(PUP::er& /*p*/);  //  NOLINT
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) override;
 
  private:
   double inner_radius_ = std::numeric_limits<double>::signaling_NaN();

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.cpp
@@ -37,6 +37,11 @@ BondiHoyleAccretion::BondiHoyleAccretion(const double bh_mass,
           bh_mass, {{0.0, 0.0, bh_dimless_spin}}, {{0.0, 0.0, 0.0}}},
       kerr_schild_coords_{bh_mass, bh_dimless_spin} {}
 
+std::unique_ptr<evolution::initial_data::InitialData>
+BondiHoyleAccretion::get_clone() const {
+  return std::make_unique<BondiHoyleAccretion>(*this);
+}
+
 BondiHoyleAccretion::BondiHoyleAccretion(CkMigrateMessage* msg)
     : InitialData(msg) {}
 

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.hpp
@@ -151,6 +151,9 @@ class BondiHoyleAccretion : public evolution::initial_data::InitialData,
                       double magnetic_field_strength,
                       double polytropic_constant, double polytropic_exponent);
 
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override;
+
   /// \cond
   explicit BondiHoyleAccretion(CkMigrateMessage* msg);
   using PUP::able::register_constructor;

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.hpp
@@ -144,7 +144,7 @@ class BondiHoyleAccretion : public evolution::initial_data::InitialData,
   BondiHoyleAccretion& operator=(const BondiHoyleAccretion& /*rhs*/) = default;
   BondiHoyleAccretion(BondiHoyleAccretion&& /*rhs*/) = default;
   BondiHoyleAccretion& operator=(BondiHoyleAccretion&& /*rhs*/) = default;
-  ~BondiHoyleAccretion() = default;
+  ~BondiHoyleAccretion() override = default;
 
   BondiHoyleAccretion(double bh_mass, double bh_dimless_spin,
                       double rest_mass_density, double flow_speed,
@@ -228,8 +228,8 @@ class BondiHoyleAccretion : public evolution::initial_data::InitialData,
         x, dummy_time, gr::Solutions::KerrSchild::tags<DataType>{})))};
   }
 
-  // clang-tidy: no runtime references
-  void pup(PUP::er& /*p*/);  //  NOLINT
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) override;
 
   const EquationsOfState::PolytropicFluid<true>& equation_of_state() const {
     return equation_of_state_;

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/KhInstability.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/KhInstability.cpp
@@ -56,6 +56,11 @@ KhInstability::KhInstability(
              << strip_thickness << ".");
 }
 
+std::unique_ptr<evolution::initial_data::InitialData> KhInstability::get_clone()
+    const {
+  return std::make_unique<KhInstability>(*this);
+}
+
 KhInstability::KhInstability(CkMigrateMessage* msg) : InitialData(msg) {}
 
 void KhInstability::pup(PUP::er& p) {

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/KhInstability.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/KhInstability.hpp
@@ -184,6 +184,9 @@ class KhInstability : public evolution::initial_data::InitialData,
                 double perturbation_amplitude, double perturbation_width,
                 const std::array<double, 3>& magnetic_field);
 
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override;
+
   /// \cond
   explicit KhInstability(CkMigrateMessage* msg);
   using PUP::able::register_constructor;

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/KhInstability.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/KhInstability.hpp
@@ -175,7 +175,7 @@ class KhInstability : public evolution::initial_data::InitialData,
   KhInstability& operator=(const KhInstability& /*rhs*/) = default;
   KhInstability(KhInstability&& /*rhs*/) = default;
   KhInstability& operator=(KhInstability&& /*rhs*/) = default;
-  ~KhInstability() = default;
+  ~KhInstability() override = default;
 
   KhInstability(double adiabatic_index, double strip_bimedian_height,
                 double strip_thickness, double strip_density,
@@ -262,8 +262,8 @@ class KhInstability : public evolution::initial_data::InitialData,
     return equation_of_state_;
   }
 
-  // clang-tidy: no runtime references
-  void pup(PUP::er& /*p*/);  //  NOLINT
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) override;
 
  private:
   double adiabatic_index_ = std::numeric_limits<double>::signaling_NaN();

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.cpp
@@ -52,6 +52,11 @@ MagneticFieldLoop::MagneticFieldLoop(
   }
 }
 
+std::unique_ptr<evolution::initial_data::InitialData>
+MagneticFieldLoop::get_clone() const {
+  return std::make_unique<MagneticFieldLoop>(*this);
+}
+
 MagneticFieldLoop::MagneticFieldLoop(CkMigrateMessage* msg)
     : InitialData(msg) {}
 

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.hpp
@@ -138,6 +138,9 @@ class MagneticFieldLoop : public evolution::initial_data::InitialData,
                     double magnetic_field_magnitude, double inner_radius,
                     double outer_radius, const Options::Context& context = {});
 
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override;
+
   /// \cond
   explicit MagneticFieldLoop(CkMigrateMessage* msg);
   using PUP::able::register_constructor;

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.hpp
@@ -130,7 +130,7 @@ class MagneticFieldLoop : public evolution::initial_data::InitialData,
   MagneticFieldLoop& operator=(const MagneticFieldLoop& /*rhs*/) = default;
   MagneticFieldLoop(MagneticFieldLoop&& /*rhs*/) = default;
   MagneticFieldLoop& operator=(MagneticFieldLoop&& /*rhs*/) = default;
-  ~MagneticFieldLoop() = default;
+  ~MagneticFieldLoop() override = default;
 
   MagneticFieldLoop(double pressure, double rest_mass_density,
                     double adiabatic_index,
@@ -216,8 +216,8 @@ class MagneticFieldLoop : public evolution::initial_data::InitialData,
     return equation_of_state_;
   }
 
-  // clang-tidy: no runtime references
-  void pup(PUP::er& /*p*/);  //  NOLINT
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) override;
 
  private:
   double pressure_ = std::numeric_limits<double>::signaling_NaN();

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticRotor.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticRotor.cpp
@@ -59,6 +59,11 @@ MagneticRotor::MagneticRotor(
   }
 }
 
+std::unique_ptr<evolution::initial_data::InitialData> MagneticRotor::get_clone()
+    const {
+  return std::make_unique<MagneticRotor>(*this);
+}
+
 MagneticRotor::MagneticRotor(CkMigrateMessage* msg) : InitialData(msg) {}
 
 void MagneticRotor::pup(PUP::er& p) {

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticRotor.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticRotor.hpp
@@ -136,6 +136,9 @@ class MagneticRotor : public evolution::initial_data::InitialData,
                 const std::array<double, 3>& magnetic_field,
                 double adiabatic_index, const Options::Context& context = {});
 
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override;
+
   /// \cond
   explicit MagneticRotor(CkMigrateMessage* msg);
   using PUP::able::register_constructor;

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticRotor.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticRotor.hpp
@@ -128,7 +128,7 @@ class MagneticRotor : public evolution::initial_data::InitialData,
   MagneticRotor& operator=(const MagneticRotor& /*rhs*/) = default;
   MagneticRotor(MagneticRotor&& /*rhs*/) = default;
   MagneticRotor& operator=(MagneticRotor&& /*rhs*/) = default;
-  ~MagneticRotor() = default;
+  ~MagneticRotor() override = default;
 
   MagneticRotor(double rotor_radius, double rotor_density,
                 double background_density, double pressure,
@@ -214,8 +214,8 @@ class MagneticRotor : public evolution::initial_data::InitialData,
     return equation_of_state_;
   }
 
-  // clang-tidy: no runtime references
-  void pup(PUP::er& /*p*/);  //  NOLINT
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) override;
 
  private:
   double rotor_radius_ = std::numeric_limits<double>::signaling_NaN();

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.cpp
@@ -115,6 +115,11 @@ MagnetizedFmDisk::MagnetizedFmDisk(
            inverse_plasma_beta_ / b_squared_max);
 }
 
+std::unique_ptr<evolution::initial_data::InitialData>
+MagnetizedFmDisk::get_clone() const {
+  return std::make_unique<MagnetizedFmDisk>(*this);
+}
+
 MagnetizedFmDisk::MagnetizedFmDisk(CkMigrateMessage* msg)
     : FishboneMoncriefDisk(msg) {}
 

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.hpp
@@ -132,7 +132,7 @@ class MagnetizedFmDisk
   MagnetizedFmDisk& operator=(const MagnetizedFmDisk& /*rhs*/) = default;
   MagnetizedFmDisk(MagnetizedFmDisk&& /*rhs*/) = default;
   MagnetizedFmDisk& operator=(MagnetizedFmDisk&& /*rhs*/) = default;
-  ~MagnetizedFmDisk() = default;
+  ~MagnetizedFmDisk() override = default;
 
   MagnetizedFmDisk(
       double bh_mass, double bh_dimless_spin, double inner_edge_radius,
@@ -199,8 +199,8 @@ class MagnetizedFmDisk
   }
   /// @}
 
-  // clang-tidy: no runtime references
-  void pup(PUP::er& /*p*/);  //  NOLINT
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) override;
 
  private:
   template <typename DataType, bool NeedSpacetime>

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.hpp
@@ -141,6 +141,9 @@ class MagnetizedFmDisk
       double inverse_plasma_beta,
       size_t normalization_grid_res = BFieldNormGridRes::suggested_value());
 
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override;
+
   /// \cond
   explicit MagnetizedFmDisk(CkMigrateMessage* msg);
   using PUP::able::register_constructor;

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.cpp
@@ -38,6 +38,11 @@ MagnetizedTovStar::MagnetizedTovStar(
                            Scalar<double>{central_rest_mass_density}))),
       vector_potential_amplitude_(vector_potential_amplitude) {}
 
+std::unique_ptr<evolution::initial_data::InitialData>
+MagnetizedTovStar::get_clone() const {
+  return std::make_unique<MagnetizedTovStar>(*this);
+}
+
 MagnetizedTovStar::MagnetizedTovStar(CkMigrateMessage* msg) : tov_star(msg) {}
 
 void MagnetizedTovStar::pup(PUP::er& p) {

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.hpp
@@ -243,6 +243,9 @@ class MagnetizedTovStar : public virtual evolution::initial_data::InitialData,
       size_t pressure_exponent, double cutoff_pressure_fraction,
       double vector_potential_amplitude);
 
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override;
+
   /// \cond
   explicit MagnetizedTovStar(CkMigrateMessage* msg);
   using PUP::able::register_constructor;

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.hpp
@@ -233,7 +233,8 @@ class MagnetizedTovStar : public virtual evolution::initial_data::InitialData,
   MagnetizedTovStar& operator=(const MagnetizedTovStar& /*rhs*/) = default;
   MagnetizedTovStar(MagnetizedTovStar&& /*rhs*/) = default;
   MagnetizedTovStar& operator=(MagnetizedTovStar&& /*rhs*/) = default;
-  ~MagnetizedTovStar() = default;
+  ~MagnetizedTovStar() override = default;
+
   MagnetizedTovStar(
       double central_rest_mass_density,
       std::unique_ptr<EquationsOfState::EquationOfState<true, 1>>
@@ -260,7 +261,8 @@ class MagnetizedTovStar : public virtual evolution::initial_data::InitialData,
         vector_potential_amplitude_);
   }
 
-  void pup(PUP::er& p);  //  NOLINT
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override;
 
  private:
   friend bool operator==(const MagnetizedTovStar& lhs,

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/OrszagTangVortex.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/OrszagTangVortex.cpp
@@ -19,6 +19,11 @@ namespace grmhd::AnalyticData {
 
 OrszagTangVortex::OrszagTangVortex() = default;
 
+std::unique_ptr<evolution::initial_data::InitialData>
+OrszagTangVortex::get_clone() const {
+  return std::make_unique<OrszagTangVortex>(*this);
+}
+
 OrszagTangVortex::OrszagTangVortex(CkMigrateMessage* msg) : InitialData(msg) {}
 
 void OrszagTangVortex::pup(PUP::er& p) {

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/OrszagTangVortex.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/OrszagTangVortex.hpp
@@ -73,7 +73,7 @@ class OrszagTangVortex : public evolution::initial_data::InitialData,
   OrszagTangVortex& operator=(const OrszagTangVortex& /*rhs*/) = default;
   OrszagTangVortex(OrszagTangVortex&& /*rhs*/) = default;
   OrszagTangVortex& operator=(OrszagTangVortex&& /*rhs*/) = default;
-  ~OrszagTangVortex() = default;
+  ~OrszagTangVortex() override = default;
 
   /// \cond
   explicit OrszagTangVortex(CkMigrateMessage* msg);
@@ -156,7 +156,8 @@ class OrszagTangVortex : public evolution::initial_data::InitialData,
     return equation_of_state_;
   }
 
-  void pup(PUP::er& /*p*/);  //  NOLINT(google-runtime-references)
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) override;
 
  private:
   EquationsOfState::IdealFluid<true> equation_of_state_{5. / 3.};

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/OrszagTangVortex.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/OrszagTangVortex.hpp
@@ -75,6 +75,9 @@ class OrszagTangVortex : public evolution::initial_data::InitialData,
   OrszagTangVortex& operator=(OrszagTangVortex&& /*rhs*/) = default;
   ~OrszagTangVortex() override = default;
 
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override;
+
   /// \cond
   explicit OrszagTangVortex(CkMigrateMessage* msg);
   using PUP::able::register_constructor;

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/RiemannProblem.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/RiemannProblem.cpp
@@ -40,6 +40,11 @@ RiemannProblem::RiemannProblem(
       lapse_(lapse),
       shift_(shift) {}
 
+std::unique_ptr<evolution::initial_data::InitialData>
+RiemannProblem::get_clone() const {
+  return std::make_unique<RiemannProblem>(*this);
+}
+
 RiemannProblem::RiemannProblem(CkMigrateMessage* msg) : InitialData(msg) {}
 
 void RiemannProblem::pup(PUP::er& p) {

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/RiemannProblem.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/RiemannProblem.hpp
@@ -205,7 +205,7 @@ class RiemannProblem : public evolution::initial_data::InitialData,
   RiemannProblem& operator=(const RiemannProblem& /*rhs*/) = default;
   RiemannProblem(RiemannProblem&& /*rhs*/) = default;
   RiemannProblem& operator=(RiemannProblem&& /*rhs*/) = default;
-  ~RiemannProblem() = default;
+  ~RiemannProblem() override = default;
 
   RiemannProblem(double adiabatic_index, double left_rest_mass_density,
                  double right_rest_mass_density, double left_pressure,
@@ -304,8 +304,8 @@ class RiemannProblem : public evolution::initial_data::InitialData,
     return equation_of_state_;
   }
 
-  // clang-tidy: no runtime references
-  void pup(PUP::er& /*p*/);  //  NOLINT
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) override;
 
  private:
   friend bool operator==(const RiemannProblem& lhs, const RiemannProblem& rhs);

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/RiemannProblem.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/RiemannProblem.hpp
@@ -216,6 +216,9 @@ class RiemannProblem : public evolution::initial_data::InitialData,
                  const std::array<double, 3>& right_magnetic_field,
                  double lapse, double shift);
 
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override;
+
   /// \cond
   explicit RiemannProblem(CkMigrateMessage* msg);
   using PUP::able::register_constructor;

--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/Bump.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/Bump.cpp
@@ -18,6 +18,10 @@ namespace Burgers::Solutions {
 Bump::Bump(const double half_width, const double height, const double center)
     : half_width_(half_width), height_(height), center_(center) {}
 
+std::unique_ptr<evolution::initial_data::InitialData> Bump::get_clone() const {
+  return std::make_unique<Bump>(*this);
+}
+
 Bump::Bump(CkMigrateMessage* msg) : InitialData(msg) {}
 
 template <typename T>

--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/Bump.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/Bump.hpp
@@ -64,9 +64,12 @@ class Bump : public evolution::initial_data::InitialData,
   Bump& operator=(const Bump&) = default;
   Bump(Bump&&) = default;
   Bump& operator=(Bump&&) = default;
-  ~Bump() = default;
+  ~Bump() override = default;
 
   Bump(double half_width, double height, double center = 0.);
+
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override;
 
   /// \cond
   explicit Bump(CkMigrateMessage* msg);
@@ -89,7 +92,7 @@ class Bump : public evolution::initial_data::InitialData,
       tmpl::list<::Tags::dt<Tags::U>> /*meta*/) const;
 
   // NOLINTNEXTLINE(google-runtime-references)
-  void pup(PUP::er& p);
+  void pup(PUP::er& p) override;
 
  private:
   double half_width_ = std::numeric_limits<double>::signaling_NaN();

--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/Linear.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/Linear.cpp
@@ -16,6 +16,11 @@ namespace Burgers::Solutions {
 
 Linear::Linear(const double shock_time) : shock_time_(shock_time) {}
 
+std::unique_ptr<evolution::initial_data::InitialData> Linear::get_clone()
+    const {
+  return std::make_unique<Linear>(*this);
+}
+
 Linear::Linear(CkMigrateMessage* msg) : InitialData(msg) {}
 
 template <typename T>

--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/Linear.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/Linear.hpp
@@ -43,9 +43,12 @@ class Linear : public evolution::initial_data::InitialData,
   Linear& operator=(const Linear&) = default;
   Linear(Linear&&) = default;
   Linear& operator=(Linear&&) = default;
-  ~Linear() = default;
+  ~Linear() override = default;
 
   explicit Linear(double shock_time);
+
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override;
 
   /// \cond
   explicit Linear(CkMigrateMessage* msg);
@@ -68,7 +71,7 @@ class Linear : public evolution::initial_data::InitialData,
       tmpl::list<::Tags::dt<Tags::U>> /*meta*/) const;
 
   // NOLINTNEXTLINE(google-runtime-references)
-  void pup(PUP::er& p);
+  void pup(PUP::er& p) override;
 
  private:
   double shock_time_ = std::numeric_limits<double>::signaling_NaN();

--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/Step.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/Step.cpp
@@ -27,6 +27,10 @@ Step::Step(const double left_value, const double right_value,
 
 Step::Step(CkMigrateMessage* msg) : InitialData(msg) {}
 
+std::unique_ptr<evolution::initial_data::InitialData> Step::get_clone() const {
+  return std::make_unique<Step>(*this);
+}
+
 template <typename T>
 Scalar<T> Step::u(const tnsr::I<T, 1>& x, const double t) const {
   const double current_shock_position =

--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/Step.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/Step.hpp
@@ -66,7 +66,10 @@ class Step : public evolution::initial_data::InitialData,
   Step& operator=(const Step&) = default;
   Step(Step&&) = default;
   Step& operator=(Step&&) = default;
-  ~Step() = default;
+  ~Step() override = default;
+
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override;
 
   /// \cond
   explicit Step(CkMigrateMessage* msg);
@@ -89,7 +92,7 @@ class Step : public evolution::initial_data::InitialData,
       tmpl::list<::Tags::dt<Tags::U>> /*meta*/) const;
 
   // NOLINTNEXTLINE(google-runtime-references)
-  void pup(PUP::er& p);
+  void pup(PUP::er& p) override;
 
  private:
   double left_value_ = std::numeric_limits<double>::signaling_NaN();

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.cpp
@@ -74,6 +74,11 @@ AlfvenWave::AlfvenWave(const double wavenumber, const double pressure,
   fluid_speed_ = -auxiliary_speed_b1 * one_over_speed_denominator;
 }
 
+std::unique_ptr<evolution::initial_data::InitialData> AlfvenWave::get_clone()
+    const {
+  return std::make_unique<AlfvenWave>(*this);
+}
+
 AlfvenWave::AlfvenWave(CkMigrateMessage* msg) : InitialData(msg) {}
 
 void AlfvenWave::pup(PUP::er& p) {

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.hpp
@@ -168,6 +168,9 @@ class AlfvenWave : public evolution::initial_data::InitialData,
              const std::array<double, 3>& background_magnetic_field,
              const std::array<double, 3>& wave_magnetic_field);
 
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override;
+
   /// \cond
   explicit AlfvenWave(CkMigrateMessage* msg);
   using PUP::able::register_constructor;

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.hpp
@@ -161,7 +161,7 @@ class AlfvenWave : public evolution::initial_data::InitialData,
   AlfvenWave& operator=(const AlfvenWave& /*rhs*/) = default;
   AlfvenWave(AlfvenWave&& /*rhs*/) = default;
   AlfvenWave& operator=(AlfvenWave&& /*rhs*/) = default;
-  ~AlfvenWave() = default;
+  ~AlfvenWave() override = default;
 
   AlfvenWave(double wavenumber, double pressure, double rest_mass_density,
              double electron_fraction, double adiabatic_index,
@@ -242,8 +242,8 @@ class AlfvenWave : public evolution::initial_data::InitialData,
     return background_spacetime_.variables(x, t, tmpl::list<Tag>{});
   }
 
-  // clang-tidy: no runtime references
-  void pup(PUP::er& /*p*/);  //  NOLINT
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) override;
 
   const EquationsOfState::IdealFluid<true>& equation_of_state() const {
     return equation_of_state_;

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.cpp
@@ -75,6 +75,11 @@ BondiMichel::BondiMichel(const double mass, const double sonic_radius,
                            1.0 / gamma_minus_one);
 }
 
+std::unique_ptr<evolution::initial_data::InitialData> BondiMichel::get_clone()
+    const {
+  return std::make_unique<BondiMichel>(*this);
+}
+
 BondiMichel::BondiMichel(CkMigrateMessage* msg) : InitialData(msg) {}
 
 void BondiMichel::pup(PUP::er& p) {

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.hpp
@@ -223,7 +223,7 @@ class BondiMichel : public virtual evolution::initial_data::InitialData,
   BondiMichel& operator=(const BondiMichel& /*rhs*/) = default;
   BondiMichel(BondiMichel&& /*rhs*/) = default;
   BondiMichel& operator=(BondiMichel&& /*rhs*/) = default;
-  ~BondiMichel() = default;
+  ~BondiMichel() override = default;
 
   BondiMichel(double mass, double sonic_radius, double sonic_density,
               double polytropic_exponent, double mag_field_strength);
@@ -273,8 +273,8 @@ class BondiMichel : public virtual evolution::initial_data::InitialData,
             background_spacetime_});
   }
 
-  // clang-tidy: no runtime references
-  void pup(PUP::er& /*p*/);  //  NOLINT
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) override;
   const EquationsOfState::PolytropicFluid<true>& equation_of_state() const {
     return equation_of_state_;
   }

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.hpp
@@ -228,6 +228,9 @@ class BondiMichel : public virtual evolution::initial_data::InitialData,
   BondiMichel(double mass, double sonic_radius, double sonic_density,
               double polytropic_exponent, double mag_field_strength);
 
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override;
+
   /// \cond
   explicit BondiMichel(CkMigrateMessage* msg);
   using PUP::able::register_constructor;

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.cpp
@@ -68,6 +68,11 @@ KomissarovShock::KomissarovShock(
       right_magnetic_field_(right_magnetic_field),
       shock_speed_(shock_speed) {}
 
+std::unique_ptr<evolution::initial_data::InitialData>
+KomissarovShock::get_clone() const {
+  return std::make_unique<KomissarovShock>(*this);
+}
+
 KomissarovShock::KomissarovShock(CkMigrateMessage* msg) : InitialData(msg) {}
 
 void KomissarovShock::pup(PUP::er& p) {

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.hpp
@@ -141,7 +141,7 @@ class KomissarovShock : public evolution::initial_data::InitialData,
   KomissarovShock& operator=(const KomissarovShock& /*rhs*/) = default;
   KomissarovShock(KomissarovShock&& /*rhs*/) = default;
   KomissarovShock& operator=(KomissarovShock&& /*rhs*/) = default;
-  ~KomissarovShock() = default;
+  ~KomissarovShock() override = default;
 
   KomissarovShock(double adiabatic_index, double left_rest_mass_density,
                   double right_rest_mass_density, double left_electron_fraction,
@@ -231,8 +231,8 @@ class KomissarovShock : public evolution::initial_data::InitialData,
     return equation_of_state_;
   }
 
-  // clang-tidy: no runtime references
-  void pup(PUP::er& /*p*/);  //  NOLINT
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) override;
 
  protected:
   EquationsOfState::IdealFluid<true> equation_of_state_{};

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.hpp
@@ -153,6 +153,9 @@ class KomissarovShock : public evolution::initial_data::InitialData,
                   const std::array<double, 3>& right_magnetic_field,
                   double shock_speed);
 
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override;
+
   /// \cond
   explicit KomissarovShock(CkMigrateMessage* msg);
   using PUP::able::register_constructor;

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.cpp
@@ -21,6 +21,11 @@ SmoothFlow::SmoothFlow(const std::array<double, 3>& mean_velocity,
                                                   pressure, adiabatic_index,
                                                   perturbation_size) {}
 
+std::unique_ptr<evolution::initial_data::InitialData> SmoothFlow::get_clone()
+    const {
+  return std::make_unique<SmoothFlow>(*this);
+}
+
 SmoothFlow::SmoothFlow(CkMigrateMessage* msg)
     : RelativisticEuler::Solutions::SmoothFlow<3>(msg) {}
 

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.hpp
@@ -57,6 +57,9 @@ class SmoothFlow : virtual public MarkAsAnalyticSolution,
              const std::array<double, 3>& wavevector, double pressure,
              double adiabatic_index, double perturbation_size);
 
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override;
+
   /// \cond
   explicit SmoothFlow(CkMigrateMessage* msg);
   using PUP::able::register_constructor;

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.hpp
@@ -51,7 +51,7 @@ class SmoothFlow : virtual public MarkAsAnalyticSolution,
   SmoothFlow& operator=(const SmoothFlow& /*rhs*/) = default;
   SmoothFlow(SmoothFlow&& /*rhs*/) = default;
   SmoothFlow& operator=(SmoothFlow&& /*rhs*/) = default;
-  ~SmoothFlow() = default;
+  ~SmoothFlow() override = default;
 
   SmoothFlow(const std::array<double, 3>& mean_velocity,
              const std::array<double, 3>& wavevector, double pressure,
@@ -99,8 +99,8 @@ class SmoothFlow : virtual public MarkAsAnalyticSolution,
     return {get<Tags>(variables(x, t, tmpl::list<Tags>{}))...};
   }
 
-  // clang-tidy: no runtime references
-  void pup(PUP::er& /*p*/);  //  NOLINT
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) override;
 
  protected:
   friend bool operator==(const SmoothFlow& lhs, const SmoothFlow& rhs);

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.cpp
@@ -58,6 +58,11 @@ FishboneMoncriefDisk::FishboneMoncriefDisk(const double bh_mass,
        (rmax - 3.0 * bh_mass_) * rmax_squared);
 }
 
+std::unique_ptr<evolution::initial_data::InitialData>
+FishboneMoncriefDisk::get_clone() const {
+  return std::make_unique<FishboneMoncriefDisk>(*this);
+}
+
 void FishboneMoncriefDisk::pup(PUP::er& p) {
   InitialData::pup(p);
   p | bh_mass_;

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp
@@ -214,11 +214,14 @@ class FishboneMoncriefDisk
       default;
   FishboneMoncriefDisk(FishboneMoncriefDisk&& /*rhs*/) = default;
   FishboneMoncriefDisk& operator=(FishboneMoncriefDisk&& /*rhs*/) = default;
-  ~FishboneMoncriefDisk() = default;
+  ~FishboneMoncriefDisk() override = default;
 
   FishboneMoncriefDisk(double bh_mass, double bh_dimless_spin,
                        double inner_edge_radius, double max_pressure_radius,
                        double polytropic_constant, double polytropic_exponent);
+
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override;
 
   /// \cond
   explicit FishboneMoncriefDisk(CkMigrateMessage* msg);
@@ -307,7 +310,7 @@ class FishboneMoncriefDisk
   /// @}
 
   // NOLINTNEXTLINE(google-runtime-references)
-  void pup(PUP::er& p);
+  void pup(PUP::er& p) override;
 
   const EquationsOfState::PolytropicFluid<true>& equation_of_state() const {
     return equation_of_state_;

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/RotatingStar.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/RotatingStar.cpp
@@ -356,7 +356,15 @@ RotatingStar::RotatingStar(std::string rot_ns_filename,
       polytropic_exponent_{1.0 + 1.0 / cst_solution_.polytropic_index()},
       equation_of_state_(polytropic_constant_, polytropic_exponent_) {}
 
+RotatingStar::RotatingStar(CkMigrateMessage* msg) : InitialData(msg) {}
+
+std::unique_ptr<evolution::initial_data::InitialData> RotatingStar::get_clone()
+    const {
+  return std::make_unique<RotatingStar>(*this);
+}
+
 void RotatingStar::pup(PUP::er& p) {
+  InitialData::pup(p);
   p | rot_ns_filename_;
   p | cst_solution_;
   p | polytropic_constant_;
@@ -861,6 +869,8 @@ auto RotatingStar::variables(
       get<DerivSpatialMetric<DataType>>(
           variables(vars, x, tmpl::list<DerivSpatialMetric<DataType>>{})));
 }
+
+PUP::able::PUP_ID RotatingStar::my_PUP_ID = 0;
 
 bool operator==(const RotatingStar& lhs, const RotatingStar& rhs) {
   // The equation of state and CST solution aren't explicitly checked. However,

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/RotatingStar.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/RotatingStar.hpp
@@ -14,6 +14,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Solutions.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -300,7 +301,9 @@ class CstSolution {
  * polynomial fits might improve the situation but is a decent about of work to
  * implement.
  */
-class RotatingStar : public MarkAsAnalyticSolution, public AnalyticSolution<3> {
+class RotatingStar : public virtual evolution::initial_data::InitialData,
+                     public MarkAsAnalyticSolution,
+                     public AnalyticSolution<3> {
   template <typename DataType>
   struct IntermediateVariables {
     IntermediateVariables(
@@ -379,9 +382,18 @@ class RotatingStar : public MarkAsAnalyticSolution, public AnalyticSolution<3> {
   RotatingStar& operator=(const RotatingStar& /*rhs*/) = default;
   RotatingStar(RotatingStar&& /*rhs*/) = default;
   RotatingStar& operator=(RotatingStar&& /*rhs*/) = default;
-  ~RotatingStar() = default;
+  ~RotatingStar() override = default;
 
   RotatingStar(std::string rot_ns_filename, double polytropic_constant);
+
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override;
+
+  /// \cond
+  explicit RotatingStar(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(RotatingStar);
+  /// \endcond
 
   /// Retrieve a collection of variables at `(x, t)`
   template <typename DataType, typename... Tags>
@@ -395,7 +407,7 @@ class RotatingStar : public MarkAsAnalyticSolution, public AnalyticSolution<3> {
   }
 
   // NOLINTNEXTLINE(google-runtime-references)
-  void pup(PUP::er& p);
+  void pup(PUP::er& p) override;
 
   const EquationsOfState::PolytropicFluid<true>& equation_of_state() const {
     return equation_of_state_;

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.cpp
@@ -28,6 +28,12 @@ SmoothFlow<Dim>::SmoothFlow(const std::array<double, Dim>& mean_velocity,
                   perturbation_size} {}
 
 template <size_t Dim>
+std::unique_ptr<evolution::initial_data::InitialData>
+SmoothFlow<Dim>::get_clone() const {
+  return std::make_unique<SmoothFlow<Dim>>(*this);
+}
+
+template <size_t Dim>
 SmoothFlow<Dim>::SmoothFlow(CkMigrateMessage* msg)
     : InitialData(msg), smooth_flow(msg) {}
 

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.hpp
@@ -77,6 +77,9 @@ class SmoothFlow : public evolution::initial_data::InitialData,
              const std::array<double, Dim>& wavevector, double pressure,
              double adiabatic_index, double perturbation_size);
 
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override;
+
   /// \cond
   explicit SmoothFlow(CkMigrateMessage* msg);
   using PUP::able::register_constructor;
@@ -118,8 +121,8 @@ class SmoothFlow : public evolution::initial_data::InitialData,
       tmpl::list<hydro::Tags::DivergenceCleaningField<DataType>> /*meta*/)
       const;
 
-  // clang-tidy: no runtime references
-  void pup(PUP::er& /*p*/);  //  NOLINT
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) override;
 
  private:
   template <size_t SpatialDim>

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.cpp
@@ -47,6 +47,11 @@ TovStar& TovStar::operator=(const TovStar& rhs) {
   return *this;
 }
 
+std::unique_ptr<evolution::initial_data::InitialData> TovStar::get_clone()
+    const {
+  return std::make_unique<TovStar>(*this);
+}
+
 void TovStar::pup(PUP::er& p) {
   InitialData::pup(p);
   p | central_rest_mass_density_;

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp
@@ -349,12 +349,15 @@ class TovStar : public virtual evolution::initial_data::InitialData,
   TovStar& operator=(const TovStar& /*rhs*/);
   TovStar(TovStar&& /*rhs*/) = default;
   TovStar& operator=(TovStar&& /*rhs*/) = default;
-  ~TovStar() = default;
+  ~TovStar() override = default;
   TovStar(double central_rest_mass_density,
           std::unique_ptr<EquationsOfState::EquationOfState<true, 1>>
               equation_of_state,
           const RelativisticEuler::Solutions::TovCoordinates coordinate_system =
               RelativisticEuler::Solutions::TovCoordinates::Schwarzschild);
+
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override;
 
   /// \cond
   explicit TovStar(CkMigrateMessage* msg);
@@ -371,7 +374,7 @@ class TovStar : public virtual evolution::initial_data::InitialData,
   }
 
   /// NOLINTNEXTLINE(google-runtime-references)
-  void pup(PUP::er& /*p*/);
+  void pup(PUP::er& /*p*/) override;
 
   const EquationsOfState::EquationOfState<true, 1>& equation_of_state() const {
     return *equation_of_state_;

--- a/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Krivodonova.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Krivodonova.cpp
@@ -16,6 +16,11 @@
 
 namespace ScalarAdvection::Solutions {
 
+std::unique_ptr<evolution::initial_data::InitialData> Krivodonova::get_clone()
+    const {
+  return std::make_unique<Krivodonova>(*this);
+}
+
 template <typename DataType>
 tuples::TaggedTuple<ScalarAdvection::Tags::U> Krivodonova::variables(
     const tnsr::I<DataType, 1>& x, double t,

--- a/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Krivodonova.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Krivodonova.hpp
@@ -72,6 +72,9 @@ class Krivodonova : public evolution::initial_data::InitialData,
   Krivodonova& operator=(Krivodonova&&) = default;
   ~Krivodonova() override = default;
 
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override;
+
   template <typename DataType>
   tuples::TaggedTuple<ScalarAdvection::Tags::U> variables(
       const tnsr::I<DataType, 1>& x, double t,

--- a/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Krivodonova.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Krivodonova.hpp
@@ -70,7 +70,7 @@ class Krivodonova : public evolution::initial_data::InitialData,
   Krivodonova& operator=(const Krivodonova&) = default;
   Krivodonova(Krivodonova&&) = default;
   Krivodonova& operator=(Krivodonova&&) = default;
-  ~Krivodonova() = default;
+  ~Krivodonova() override = default;
 
   template <typename DataType>
   tuples::TaggedTuple<ScalarAdvection::Tags::U> variables(
@@ -78,7 +78,7 @@ class Krivodonova : public evolution::initial_data::InitialData,
       tmpl::list<ScalarAdvection::Tags::U> /*meta*/) const;
 
   // NOLINTNEXTLINE(google-runtime-references)
-  void pup(PUP::er& p);
+  void pup(PUP::er& p) override;
 
   /// \cond
   explicit Krivodonova(CkMigrateMessage* msg);

--- a/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Kuzmin.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Kuzmin.cpp
@@ -16,6 +16,11 @@
 
 namespace ScalarAdvection::Solutions {
 
+std::unique_ptr<evolution::initial_data::InitialData> Kuzmin::get_clone()
+    const {
+  return std::make_unique<Kuzmin>(*this);
+}
+
 template <typename DataType>
 tuples::TaggedTuple<ScalarAdvection::Tags::U> Kuzmin::variables(
     const tnsr::I<DataType, 2>& x, double t,

--- a/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Kuzmin.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Kuzmin.hpp
@@ -66,7 +66,7 @@ class Kuzmin : public evolution::initial_data::InitialData,
   Kuzmin& operator=(const Kuzmin&) = default;
   Kuzmin(Kuzmin&&) = default;
   Kuzmin& operator=(Kuzmin&&) = default;
-  ~Kuzmin() = default;
+  ~Kuzmin() override = default;
 
   template <typename DataType>
   tuples::TaggedTuple<ScalarAdvection::Tags::U> variables(
@@ -74,7 +74,7 @@ class Kuzmin : public evolution::initial_data::InitialData,
       tmpl::list<ScalarAdvection::Tags::U> /*meta*/) const;
 
   // NOLINTNEXTLINE(google-runtime-references)
-  void pup(PUP::er& p);
+  void pup(PUP::er& p) override;
 
   /// \cond
   explicit Kuzmin(CkMigrateMessage* msg);

--- a/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Kuzmin.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Kuzmin.hpp
@@ -68,6 +68,9 @@ class Kuzmin : public evolution::initial_data::InitialData,
   Kuzmin& operator=(Kuzmin&&) = default;
   ~Kuzmin() override = default;
 
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override;
+
   template <typename DataType>
   tuples::TaggedTuple<ScalarAdvection::Tags::U> variables(
       const tnsr::I<DataType, 2>& x, double t,

--- a/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Sinusoid.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Sinusoid.cpp
@@ -13,6 +13,11 @@
 
 namespace ScalarAdvection::Solutions {
 
+std::unique_ptr<evolution::initial_data::InitialData> Sinusoid::get_clone()
+    const {
+  return std::make_unique<Sinusoid>(*this);
+}
+
 template <typename DataType>
 tuples::TaggedTuple<ScalarAdvection::Tags::U> Sinusoid::variables(
     const tnsr::I<DataType, 1>& x, double t,

--- a/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Sinusoid.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Sinusoid.hpp
@@ -46,7 +46,7 @@ class Sinusoid : public evolution::initial_data::InitialData,
   Sinusoid& operator=(const Sinusoid&) = default;
   Sinusoid(Sinusoid&&) = default;
   Sinusoid& operator=(Sinusoid&&) = default;
-  ~Sinusoid() = default;
+  ~Sinusoid() override = default;
 
   template <typename DataType>
   tuples::TaggedTuple<ScalarAdvection::Tags::U> variables(
@@ -54,7 +54,7 @@ class Sinusoid : public evolution::initial_data::InitialData,
       tmpl::list<ScalarAdvection::Tags::U> /*meta*/) const;
 
   // NOLINTNEXTLINE(google-runtime-references)
-  void pup(PUP::er& p);
+  void pup(PUP::er& p) override;
 
   /// \cond
   explicit Sinusoid(CkMigrateMessage* msg);

--- a/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Sinusoid.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Sinusoid.hpp
@@ -48,6 +48,9 @@ class Sinusoid : public evolution::initial_data::InitialData,
   Sinusoid& operator=(Sinusoid&&) = default;
   ~Sinusoid() override = default;
 
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override;
+
   template <typename DataType>
   tuples::TaggedTuple<ScalarAdvection::Tags::U> variables(
       const tnsr::I<DataType, 1>& x, double t,

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.cpp
@@ -43,6 +43,12 @@ PlaneWave<Dim>& PlaneWave<Dim>::operator=(const PlaneWave& other) {
 }
 
 template <size_t Dim>
+std::unique_ptr<evolution::initial_data::InitialData>
+PlaneWave<Dim>::get_clone() const {
+  return std::make_unique<PlaneWave<Dim>>(*this);
+}
+
+template <size_t Dim>
 PlaneWave<Dim>::PlaneWave(CkMigrateMessage* msg) : InitialData(msg) {}
 
 template <size_t Dim>

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
@@ -89,7 +89,7 @@ class PlaneWave : public evolution::initial_data::InitialData,
   PlaneWave& operator=(const PlaneWave&);
   PlaneWave(PlaneWave&&) = default;
   PlaneWave& operator=(PlaneWave&&) = default;
-  ~PlaneWave() = default;
+  ~PlaneWave() override = default;
 
   /// \cond
   explicit PlaneWave(CkMigrateMessage* msg);
@@ -138,7 +138,7 @@ class PlaneWave : public evolution::initial_data::InitialData,
                        ::Tags::dt<Tags::Phi<Dim>>> /*meta*/) const;
 
   // NOLINTNEXTLINE(google-runtime-references)
-  void pup(PUP::er& p);
+  void pup(PUP::er& p) override;
 
  private:
   template <size_t LocalDim>

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
@@ -91,6 +91,9 @@ class PlaneWave : public evolution::initial_data::InitialData,
   PlaneWave& operator=(PlaneWave&&) = default;
   ~PlaneWave() override = default;
 
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override;
+
   /// \cond
   explicit PlaneWave(CkMigrateMessage* msg);
   using PUP::able::register_constructor;

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.cpp
@@ -25,6 +25,11 @@ RegularSphericalWave::RegularSphericalWave(
     std::unique_ptr<MathFunction<1, Frame::Inertial>> profile)
     : profile_(std::move(profile)) {}
 
+std::unique_ptr<evolution::initial_data::InitialData>
+RegularSphericalWave::get_clone() const {
+  return std::make_unique<RegularSphericalWave>(*this);
+}
+
 RegularSphericalWave::RegularSphericalWave(CkMigrateMessage* msg)
     : InitialData(msg) {}
 

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp
@@ -91,7 +91,7 @@ class RegularSphericalWave : public evolution::initial_data::InitialData,
   RegularSphericalWave& operator=(const RegularSphericalWave& other);
   RegularSphericalWave(RegularSphericalWave&&) = default;
   RegularSphericalWave& operator=(RegularSphericalWave&&) = default;
-  ~RegularSphericalWave() = default;
+  ~RegularSphericalWave() override = default;
 
   /// \cond
   explicit RegularSphericalWave(CkMigrateMessage* msg);
@@ -110,7 +110,7 @@ class RegularSphericalWave : public evolution::initial_data::InitialData,
                        ::Tags::dt<Tags::Phi<3>>> /*meta*/) const;
 
   // NOLINTNEXTLINE(google-runtime-references)
-  void pup(PUP::er& p);
+  void pup(PUP::er& p) override;
 
  private:
   // NOLINTNEXTLINE(readability-redundant-declaration)

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp
@@ -93,6 +93,9 @@ class RegularSphericalWave : public evolution::initial_data::InitialData,
   RegularSphericalWave& operator=(RegularSphericalWave&&) = default;
   ~RegularSphericalWave() override = default;
 
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override;
+
   /// \cond
   explicit RegularSphericalWave(CkMigrateMessage* msg);
   using PUP::able::register_constructor;

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/SemidiscretizedDg.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/SemidiscretizedDg.cpp
@@ -23,6 +23,11 @@ SemidiscretizedDg::SemidiscretizedDg(const int harmonic,
                                      const std::array<double, 4>& amplitudes)
     : harmonic_(harmonic), amplitudes_(amplitudes) {}
 
+std::unique_ptr<evolution::initial_data::InitialData>
+SemidiscretizedDg::get_clone() const {
+  return std::make_unique<SemidiscretizedDg>(*this);
+}
+
 SemidiscretizedDg::SemidiscretizedDg(CkMigrateMessage* msg)
     : InitialData(msg) {}
 

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/SemidiscretizedDg.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/SemidiscretizedDg.hpp
@@ -62,6 +62,7 @@ class SemidiscretizedDg : public evolution::initial_data::InitialData,
   SemidiscretizedDg(int harmonic, const std::array<double, 4>& amplitudes);
 
   SemidiscretizedDg() = default;
+  ~SemidiscretizedDg() override = default;
 
   /// \cond
   explicit SemidiscretizedDg(CkMigrateMessage* msg);
@@ -96,7 +97,7 @@ class SemidiscretizedDg : public evolution::initial_data::InitialData,
   /// \endcond
 
   // NOLINTNEXTLINE(google-runtime-references)
-  void pup(PUP::er& p);
+  void pup(PUP::er& p) override;
 
  private:
   int harmonic_{std::numeric_limits<int>::max()};

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/SemidiscretizedDg.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/SemidiscretizedDg.hpp
@@ -64,6 +64,9 @@ class SemidiscretizedDg : public evolution::initial_data::InitialData,
   SemidiscretizedDg() = default;
   ~SemidiscretizedDg() override = default;
 
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override;
+
   /// \cond
   explicit SemidiscretizedDg(CkMigrateMessage* msg);
   using PUP::able::register_constructor;

--- a/src/PointwiseFunctions/InitialDataUtilities/InitialData.hpp
+++ b/src/PointwiseFunctions/InitialDataUtilities/InitialData.hpp
@@ -25,6 +25,8 @@ class InitialData : public PUP::able {
  public:
   ~InitialData() override = default;
 
+  virtual auto get_clone() const -> std::unique_ptr<InitialData> = 0;
+
   /// \cond
   explicit InitialData(CkMigrateMessage* msg) : PUP::able(msg) {}
   WRAPPED_PUPable_abstract(InitialData);

--- a/tests/Unit/Evolution/Initialization/Test_SetVariables.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_SetVariables.cpp
@@ -34,6 +34,8 @@
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/Tags/InitialData.hpp"
 #include "Utilities/CloneUniquePtrs.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
@@ -61,7 +63,19 @@ struct EquationOfStateTag : db::SimpleTag {
   using type = std::unique_ptr<EquationsOfState::EquationOfState<true, 1>>;
 };
 
-struct SystemAnalyticSolution : public MarkAsAnalyticSolution {
+struct SystemAnalyticSolution : public MarkAsAnalyticSolution,
+                                public evolution::initial_data::InitialData {
+  SystemAnalyticSolution() = default;
+  ~SystemAnalyticSolution() override = default;
+
+  explicit SystemAnalyticSolution(CkMigrateMessage* msg)
+      : evolution::initial_data::InitialData(msg) {}
+  using PUP::able::register_constructor;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+  WRAPPED_PUPable_decl_template(SystemAnalyticSolution);
+#pragma GCC diagnostic pop
+
   template <size_t Dim>
   tuples::TaggedTuple<Var, NonConservativeVar> variables(
       const tnsr::I<DataVector, Dim>& x, const double t,
@@ -113,11 +127,27 @@ struct SystemAnalyticSolution : public MarkAsAnalyticSolution {
     return equation_of_state_;
   }
 
-  // clang-tidy: do not use references
-  void pup(PUP::er& /*p*/) {}  // NOLINT
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override {
+    evolution::initial_data::InitialData::pup(p);
+  }
 };
 
-struct SystemAnalyticData : public MarkAsAnalyticData {
+PUP::able::PUP_ID SystemAnalyticSolution::my_PUP_ID = 0;
+
+struct SystemAnalyticData : public MarkAsAnalyticData,
+                            public evolution::initial_data::InitialData {
+  SystemAnalyticData() = default;
+  ~SystemAnalyticData() override = default;
+
+  explicit SystemAnalyticData(CkMigrateMessage* msg)
+      : evolution::initial_data::InitialData(msg) {}
+  using PUP::able::register_constructor;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+  WRAPPED_PUPable_decl_template(SystemAnalyticData);
+#pragma GCC diagnostic pop
+
   template <size_t Dim>
   tuples::TaggedTuple<Var, NonConservativeVar> variables(
       const tnsr::I<DataVector, Dim>& x,
@@ -164,9 +194,11 @@ struct SystemAnalyticData : public MarkAsAnalyticData {
   // EoS just needs to be a dummy place holder
   const auto& equation_of_state() { return equation_of_state_; }
 
-  // clang-tidy: do not use references
-  void pup(PUP::er& /*p*/) {}  // NOLINT
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override { InitialData::pup(p); }
 };
+
+PUP::able::PUP_ID SystemAnalyticData::my_PUP_ID = 0;
 
 template <size_t Dim, bool HasPrimitiveAndConservativeVars>
 struct System {
@@ -247,7 +279,7 @@ auto emplace_component(
       initial_time, functions_of_time);
 }
 
-template <size_t Dim, bool HasPrimitives>
+template <size_t Dim, bool HasPrimitives, bool UseInitialDataTag>
 struct MetavariablesAnalyticSolution {
   static constexpr size_t volume_dim = Dim;
   using analytic_solution = SystemAnalyticSolution;
@@ -260,16 +292,32 @@ struct MetavariablesAnalyticSolution {
                           typename system::primitive_variables_tag::tags_list,
                           typename system::variables_tag::tags_list>;
   using temporal_id = TimeId;
-  using const_global_cache_tags =
-      tmpl::list<Tags::AnalyticSolution<analytic_solution>>;
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes =
+        tmpl::map<tmpl::pair<evolution::initial_data::InitialData,
+                             tmpl::list<SystemAnalyticSolution>>>;
+  };
+  using const_global_cache_tags = tmpl::list<tmpl::conditional_t<
+      UseInitialDataTag, evolution::initial_data::Tags::InitialData,
+      Tags::AnalyticSolution<analytic_solution>>>;
 };
 
-template <size_t Dim, bool HasPrimitives>
+template <size_t Dim, bool HasPrimitives, bool UseInitialDataTag>
 void test_analytic_solution() {
-  using metavars = MetavariablesAnalyticSolution<Dim, HasPrimitives>;
+  using metavars =
+      MetavariablesAnalyticSolution<Dim, HasPrimitives, UseInitialDataTag>;
   using comp = component<Dim, metavars>;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
-  MockRuntimeSystem runner{{SystemAnalyticSolution{}}};
+  MockRuntimeSystem runner = []() {
+    if constexpr (UseInitialDataTag) {
+      return MockRuntimeSystem{
+          {std::unique_ptr<evolution::initial_data::InitialData>(
+              std::make_unique<SystemAnalyticSolution>())}};
+    } else {
+      return MockRuntimeSystem{{SystemAnalyticSolution{}}};
+    }
+  }();
   const double initial_time = 1.3;
   const double expiration_time = 2.5;
   const auto inertial_coords = emplace_component<Dim>(
@@ -297,7 +345,7 @@ void test_analytic_solution() {
         get<PrimVar>(prim_var));
 }
 
-template <size_t Dim, bool HasPrimitives>
+template <size_t Dim, bool HasPrimitives, bool UseInitialDataTag>
 struct MetavariablesAnalyticData {
   static constexpr size_t volume_dim = Dim;
   using analytic_data = SystemAnalyticData;
@@ -309,15 +357,33 @@ struct MetavariablesAnalyticData {
                           typename system::primitive_variables_tag::tags_list,
                           typename system::variables_tag::tags_list>;
   using temporal_id = TimeId;
-  using const_global_cache_tags = tmpl::list<Tags::AnalyticData<analytic_data>>;
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes =
+        tmpl::map<tmpl::pair<evolution::initial_data::InitialData,
+                             tmpl::list<SystemAnalyticData>>>;
+  };
+  using const_global_cache_tags =
+      tmpl::list<tmpl::conditional_t<UseInitialDataTag,
+                                     evolution::initial_data::Tags::InitialData,
+                                     Tags::AnalyticData<analytic_data>>>;
 };
 
-template <size_t Dim, bool HasPrimitives>
+template <size_t Dim, bool HasPrimitives, bool UseInitialDataTag>
 void test_analytic_data() {
-  using metavars = MetavariablesAnalyticData<Dim, HasPrimitives>;
+  using metavars =
+      MetavariablesAnalyticData<Dim, HasPrimitives, UseInitialDataTag>;
   using comp = component<Dim, metavars>;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
-  MockRuntimeSystem runner{{SystemAnalyticData{}}};
+  MockRuntimeSystem runner = []() {
+    if constexpr (UseInitialDataTag) {
+      return MockRuntimeSystem{
+          {std::unique_ptr<evolution::initial_data::InitialData>(
+              std::make_unique<SystemAnalyticData>())}};
+    } else {
+      return MockRuntimeSystem{{SystemAnalyticData{}}};
+    }
+  }();
   const double initial_time = 1.3;
   const double expiration_time = 2.5;
   const auto inertial_coords = emplace_component<Dim>(
@@ -345,40 +411,36 @@ void test_analytic_data() {
         get<PrimVar>(prim_var));
 }
 
+template <size_t Dim, bool HasPrimitives>
+void test_impl() {
+  // Test setting variables from analytic solution
+  test_analytic_solution<Dim, HasPrimitives, true>();
+  test_analytic_solution<Dim, HasPrimitives, false>();
+  // Test setting variables from analytic data
+  test_analytic_data<Dim, HasPrimitives, true>();
+  test_analytic_data<Dim, HasPrimitives, false>();
+}
+
+template <size_t Dim>
+void test() {
+  Parallel::register_classes_with_charm<
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Grid,
+                            domain::CoordinateMaps::Identity<Dim>>,
+      domain::CoordinateMap<
+          Frame::Grid, Frame::Inertial,
+          domain::CoordinateMaps::TimeDependent::CubicScale<Dim>>>();
+
+  test_impl<Dim, true>();
+  test_impl<Dim, false>();
+}
+
 SPECTRE_TEST_CASE("Unit.Evolution.Initialization.SetVariables",
                   "[Unit][Evolution][Actions]") {
   domain::FunctionsOfTime::register_derived_with_charm();
-  Parallel::register_classes_with_charm<
-      domain::CoordinateMap<Frame::BlockLogical, Frame::Grid,
-                            domain::CoordinateMaps::Identity<1>>,
-      domain::CoordinateMap<Frame::BlockLogical, Frame::Grid,
-                            domain::CoordinateMaps::Identity<2>>,
-      domain::CoordinateMap<Frame::BlockLogical, Frame::Grid,
-                            domain::CoordinateMaps::Identity<3>>,
-      domain::CoordinateMap<
-          Frame::Grid, Frame::Inertial,
-          domain::CoordinateMaps::TimeDependent::CubicScale<1>>,
-      domain::CoordinateMap<
-          Frame::Grid, Frame::Inertial,
-          domain::CoordinateMaps::TimeDependent::CubicScale<2>>,
-      domain::CoordinateMap<
-          Frame::Grid, Frame::Inertial,
-          domain::CoordinateMaps::TimeDependent::CubicScale<3>>>();
-
-  // Test setting variables from analytic solution
-  test_analytic_solution<1, false>();
-  test_analytic_solution<1, true>();
-  test_analytic_solution<2, false>();
-  test_analytic_solution<2, true>();
-  test_analytic_solution<3, false>();
-  test_analytic_solution<3, true>();
-
-  // Test setting variables from analytic data
-  test_analytic_data<1, false>();
-  test_analytic_data<1, true>();
-  test_analytic_data<2, false>();
-  test_analytic_data<2, true>();
-  test_analytic_data<3, false>();
-  test_analytic_data<3, true>();
+  Parallel::register_classes_with_charm<SystemAnalyticData,
+                                        SystemAnalyticSolution>();
+  test<1>();
+  test<2>();
+  test<3>();
 }
 }  // namespace

--- a/tests/Unit/Evolution/Initialization/Test_SetVariables.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_SetVariables.cpp
@@ -76,6 +76,11 @@ struct SystemAnalyticSolution : public MarkAsAnalyticSolution,
   WRAPPED_PUPable_decl_template(SystemAnalyticSolution);
 #pragma GCC diagnostic pop
 
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override {
+    return std::make_unique<SystemAnalyticSolution>(*this);
+  }
+
   template <size_t Dim>
   tuples::TaggedTuple<Var, NonConservativeVar> variables(
       const tnsr::I<DataVector, Dim>& x, const double t,
@@ -147,6 +152,11 @@ struct SystemAnalyticData : public MarkAsAnalyticData,
 #pragma GCC diagnostic ignored "-Wunused-function"
   WRAPPED_PUPable_decl_template(SystemAnalyticData);
 #pragma GCC diagnostic pop
+
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override {
+    return std::make_unique<SystemAnalyticData>(*this);
+  }
 
   template <size_t Dim>
   tuples::TaggedTuple<Var, NonConservativeVar> variables(

--- a/tests/Unit/Evolution/Test_ComputeTags.cpp
+++ b/tests/Unit/Evolution/Test_ComputeTags.cpp
@@ -34,6 +34,11 @@ struct TestAnalyticSolution : public MarkAsAnalyticSolution,
   TestAnalyticSolution() = default;
   ~TestAnalyticSolution() override = default;
 
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override {
+    return std::make_unique<TestAnalyticSolution>(*this);
+  }
+
   explicit TestAnalyticSolution(CkMigrateMessage* msg) : InitialData(msg) {}
   using PUP::able::register_constructor;
 #pragma GCC diagnostic push
@@ -56,6 +61,12 @@ struct TestAnalyticData : public MarkAsAnalyticData,
                           public evolution::initial_data::InitialData {
   TestAnalyticData() = default;
   ~TestAnalyticData() override = default;
+
+
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override {
+    return std::make_unique<TestAnalyticData>(*this);
+  }
 
   explicit TestAnalyticData(CkMigrateMessage* msg) : InitialData(msg) {}
   using PUP::able::register_constructor;

--- a/tests/Unit/PointwiseFunctions/AnalyticData/Burgers/Test_Sinusoid.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/Burgers/Test_Sinusoid.cpp
@@ -40,7 +40,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticData.Burgers.Sinusoid",
   const std::unique_ptr<evolution::initial_data::InitialData> option_solution =
       TestHelpers::test_option_tag_factory_creation<
           evolution::initial_data::OptionTags::InitialData,
-          Burgers::AnalyticData::Sinusoid>("Sinusoid:\n");
+          Burgers::AnalyticData::Sinusoid>("Sinusoid:\n")
+          ->get_clone();
   const auto deserialized_option_solution =
       serialize_and_deserialize(option_solution);
   const auto& sinusoid = dynamic_cast<const Burgers::AnalyticData::Sinusoid&>(

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_BlastWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_BlastWave.cpp
@@ -78,7 +78,8 @@ void test_create_from_options() {
           "  OuterPressure: 5.0e-4\n"
           "  MagneticField: [0.1, 0.0, 0.0]\n"
           "  AdiabaticIndex: 1.3333333333333333333\n"
-          "  Geometry: Cylindrical\n");
+          "  Geometry: Cylindrical\n")
+          ->get_clone();
   const auto deserialized_option_solution =
       serialize_and_deserialize(option_solution);
   const auto& cylindrical_blast_wave =

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_BondiHoyleAccretion.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_BondiHoyleAccretion.cpp
@@ -72,7 +72,8 @@ void test_create_from_options() {
           "  FlowSpeed: 0.34\n"
           "  MagFieldStrength: 5.76\n"
           "  PolytropicConstant: 30.0\n"
-          "  PolytropicExponent: 1.5");
+          "  PolytropicExponent: 1.5")
+          ->get_clone();
   const auto deserialized_option_solution =
       serialize_and_deserialize(option_solution);
   const auto& accretion =

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_KhInstability.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_KhInstability.cpp
@@ -72,7 +72,8 @@ void test(const DataType& used_for_size) {
           "  Pressure: 1.1\n"
           "  PerturbAmplitude: 0.1\n"
           "  PerturbWidth: 0.01\n"
-          "  MagneticField: [1.0e-3, 0.0, 0.0]\n");
+          "  MagneticField: [1.0e-3, 0.0, 0.0]\n")
+          ->get_clone();
   const auto deserialized_option_solution =
       serialize_and_deserialize(option_solution);
   const auto& kh_instability =

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagneticFieldLoop.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagneticFieldLoop.cpp
@@ -75,7 +75,8 @@ void test_create_from_options() {
           "  AdvectionVelocity: [0.5, 0.04166666666666667, 0.0]\n"
           "  MagFieldStrength: 0.001\n"
           "  InnerRadius: 0.06\n"
-          "  OuterRadius: 0.3\n");
+          "  OuterRadius: 0.3\n")
+          ->get_clone();
   const auto deserialized_option_solution =
       serialize_and_deserialize(option_solution);
   const auto& magnetic_field_loop =

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagneticRotor.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagneticRotor.cpp
@@ -73,7 +73,8 @@ void test_create_from_options() {
           "  Pressure: 1.0\n"
           "  AngularVelocity: 9.95\n"
           "  MagneticField: [3.5449077018, 0.0, 0.0]\n"
-          "  AdiabaticIndex: 1.6666666666666666");
+          "  AdiabaticIndex: 1.6666666666666666")
+          ->get_clone();
   const auto deserialized_option_solution =
       serialize_and_deserialize(option_solution);
   const auto& magnetic_rotor =

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagnetizedFmDisk.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagnetizedFmDisk.cpp
@@ -85,7 +85,8 @@ void test_create_from_options() {
           "  PolytropicExponent: 1.654\n"
           "  ThresholdDensity: 0.42\n"
           "  InversePlasmaBeta: 85.0\n"
-          "  BFieldNormGridRes: 6");
+          "  BFieldNormGridRes: 6")
+          ->get_clone();
   const auto deserialized_option_solution =
       serialize_and_deserialize(option_solution);
   const auto& disk = dynamic_cast<const grmhd::AnalyticData::MagnetizedFmDisk&>(

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagnetizedTovStar.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagnetizedTovStar.cpp
@@ -104,7 +104,8 @@ void test_magnetized_tov_star(const TovCoordinates coord_system) {
           "\n"
           "  PressureExponent: 2\n"
           "  VectorPotentialAmplitude: 2500\n"
-          "  CutoffPressureFraction: 0.04\n");
+          "  CutoffPressureFraction: 0.04\n")
+          ->get_clone();
   const auto deserialized_option_solution =
       serialize_and_deserialize(option_solution);
   const auto& mag_tov =

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_OrszagTangVortex.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_OrszagTangVortex.cpp
@@ -84,7 +84,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticData.GrMhd.OrszagTangVortex",
   const std::unique_ptr<evolution::initial_data::InitialData> option_solution =
       TestHelpers::test_option_tag_factory_creation<
           evolution::initial_data::OptionTags::InitialData,
-          grmhd::AnalyticData::OrszagTangVortex>("OrszagTangVortex:\n");
+          grmhd::AnalyticData::OrszagTangVortex>("OrszagTangVortex:\n")
+          ->get_clone();
   const auto deserialized_option_solution =
       serialize_and_deserialize(option_solution);
   const auto& solution =

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_RiemannProblem.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_RiemannProblem.cpp
@@ -75,7 +75,8 @@ void test_create_from_options() {
           "  RightVelocity: [0.0, 0.0, 0.0]\n"
           "  RightMagneticField: [0.5, -1.0, 0.0]\n"
           "  Lapse: 2.0\n"
-          "  ShiftX: 0.4\n");
+          "  ShiftX: 0.4\n")
+          ->get_clone();
   const auto deserialized_option_solution =
       serialize_and_deserialize(option_solution);
   const auto& riemann_problem =

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/Test_Bump.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/Test_Bump.cpp
@@ -48,7 +48,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Burgers.Bump",
           "Bump:\n"
           "  HalfWidth: 5.\n"
           "  Height: 3.\n"
-          "  Center: -8.\n");
+          "  Center: -8.\n")
+          ->get_clone();
   const auto deserialized_option_solution =
       serialize_and_deserialize(option_solution);
   const auto& created_solution = dynamic_cast<const Burgers::Solutions::Bump&>(

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/Test_Linear.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/Test_Linear.cpp
@@ -42,7 +42,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Burgers.Linear",
           evolution::initial_data::OptionTags::InitialData,
           Burgers::Solutions::Linear>(
           "Linear:\n"
-          "  ShockTime: 1.5\n");
+          "  ShockTime: 1.5\n")
+          ->get_clone();
   const auto deserialized_option_solution =
       serialize_and_deserialize(option_solution);
   const auto& created_solution =

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/Test_Step.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/Test_Step.cpp
@@ -58,7 +58,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Burgers.Step",
           "Step:\n"
           "  LeftValue: 2.3\n"
           "  RightValue: 1.2\n"
-          "  InitialPosition: -0.5\n");
+          "  InitialPosition: -0.5\n")
+          ->get_clone();
   const auto deserialized_option_solution =
       serialize_and_deserialize(option_solution);
   const auto& created_solution = dynamic_cast<const Burgers::Solutions::Step&>(

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_AlfvenWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_AlfvenWave.cpp
@@ -187,7 +187,8 @@ void test_solution() {
           "  ElectronFraction: 0.1\n"
           "  AdiabaticIndex: 1.4\n"
           "  BkgdMagneticField: [0.0, 0.0, 2.0]\n"
-          "  WaveMagneticField: [0.75, 0.0, 0.0]\n");
+          "  WaveMagneticField: [0.75, 0.0, 0.0]\n")
+          ->get_clone();
   const auto deserialized_option_solution =
       serialize_and_deserialize(option_solution);
   const auto& solution = dynamic_cast<const grmhd::Solutions::AlfvenWave&>(

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_BondiMichel.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_BondiMichel.cpp
@@ -137,7 +137,8 @@ void test_solution() {
           "  SonicRadius: 50.0\n"
           "  SonicDensity: 1.3\n"
           "  PolytropicExponent: 1.5\n"
-          "  MagFieldStrength: 0.24\n");
+          "  MagFieldStrength: 0.24\n")
+          ->get_clone();
   const auto deserialized_option_solution =
       serialize_and_deserialize(option_solution);
   const auto& solution = dynamic_cast<const grmhd::Solutions::BondiMichel&>(

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_KomissarovShock.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_KomissarovShock.cpp
@@ -215,7 +215,8 @@ void test_solution() {
           "  RightVelocity: [0.62, -0.44, 0.]\n"
           "  LeftMagneticField: [10., 18.28, 0.]\n"
           "  RightMagneticField: [10., 14.49, 0.]\n"
-          "  ShockSpeed: 0.5\n");
+          "  ShockSpeed: 0.5\n")
+          ->get_clone();
   const auto deserialized_option_solution =
       serialize_and_deserialize(option_solution);
   const auto& solution = dynamic_cast<const grmhd::Solutions::KomissarovShock&>(

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_SmoothFlow.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_SmoothFlow.cpp
@@ -170,7 +170,8 @@ void test_solution() {
           "  WaveVector: [-0.13, -0.54, 0.04]\n"
           "  Pressure: 1.23\n"
           "  AdiabaticIndex: 1.4\n"
-          "  PerturbationSize: 0.75\n");
+          "  PerturbationSize: 0.75\n")
+          ->get_clone();
   const auto deserialized_option_solution =
       serialize_and_deserialize(option_solution);
   const auto& solution = dynamic_cast<const grmhd::Solutions::SmoothFlow&>(

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_FishboneMoncriefDisk.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_FishboneMoncriefDisk.cpp
@@ -195,7 +195,8 @@ void test_solution() {
           "  InnerEdgeRadius: 6.0\n"
           "  MaxPressureRadius: 12.0\n"
           "  PolytropicConstant: 0.001\n"
-          "  PolytropicExponent: 1.33333333333333333\n");
+          "  PolytropicExponent: 1.33333333333333333\n")
+          ->get_clone();
   const auto deserialized_option_solution =
       serialize_and_deserialize(option_solution);
   const auto& solution =

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_RotatingStar.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_RotatingStar.cpp
@@ -4,6 +4,7 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <array>
+#include <pup.h>
 
 #include "Domain/Creators/Brick.hpp"
 #include "Domain/Domain.hpp"
@@ -35,6 +36,7 @@ void verify_solution(const RelativisticEuler::Solutions::RotatingStar& solution,
 SPECTRE_TEST_CASE(
     "Unit.PointwiseFunctions.AnalyticSolutions.RelEuler.RotatingStar",
     "[Unit][PointwiseFunctions]") {
+  PUPable_reg(RelativisticEuler::Solutions::RotatingStar);
   // You can uncomment the cst_solution code below, include <iostream>,
   // and update the path to the `dat` file in order to figure out what the
   // central rest mass density is.
@@ -47,12 +49,15 @@ SPECTRE_TEST_CASE(
   // tolerance. However, Nils Deppe verified on Jan. 5, 2022 that increasing the
   // RotNS code resolution allows for a stricter tolerance.
   const double error_tolerance = 4.e-6;
-  const auto solution =
-      serialize_and_deserialize(RelativisticEuler::Solutions::RotatingStar(
-          unit_test_src_path() +
-              "/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/"
-              "RotatingStarId.dat",
-          100));
+  const RelativisticEuler::Solutions::RotatingStar solution(
+      dynamic_cast<const RelativisticEuler::Solutions::RotatingStar&>(
+          *serialize_and_deserialize(
+              RelativisticEuler::Solutions::RotatingStar(
+                  unit_test_src_path() +
+                      "/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/"
+                      "RotatingStarId.dat",
+                  100)
+                  .get_clone())));
 
   // Near the center the finite difference derivatives cause "large" errors
   // (1e-8) and so the check fails.

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_SmoothFlow.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_SmoothFlow.cpp
@@ -119,7 +119,8 @@ void test_solution(const DataType& used_for_size,
           "\n"
           "  Pressure: 1.23\n"
           "  AdiabaticIndex: 1.3334\n"
-          "  PerturbationSize: 0.78\n");
+          "  PerturbationSize: 0.78\n")
+          ->get_clone();
   const auto deserialized_option_solution =
       serialize_and_deserialize(option_solution);
   const auto& solution_from_options =

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_TovStar.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_TovStar.cpp
@@ -60,7 +60,8 @@ void test_tov_star(const TovCoordinates coord_system) {
           "      PolytropicConstant: 100.0\n"
           "      PolytropicExponent: 2.0\n"
           "  Coordinates: " +
-          get_output(coord_system));
+          get_output(coord_system))
+          ->get_clone();
   const auto deserialized_option_solution =
       serialize_and_deserialize(option_solution);
   const auto& solution =

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Test_Krivodonova.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Test_Krivodonova.cpp
@@ -44,7 +44,7 @@ void test_derived() {
   const std::unique_ptr<InitialData> initial_data_ptr =
       std::make_unique<Krivodonova>();
   const std::unique_ptr<InitialData> deserialized_initial_data_ptr =
-      serialize_and_deserialize(initial_data_ptr);
+      serialize_and_deserialize(initial_data_ptr)->get_clone();
   CHECK(dynamic_cast<Krivodonova*>(deserialized_initial_data_ptr.get()) !=
         nullptr);
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Test_Kuzmin.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Test_Kuzmin.cpp
@@ -44,7 +44,7 @@ void test_derived() {
   const std::unique_ptr<InitialData> initial_data_ptr =
       std::make_unique<Kuzmin>();
   const std::unique_ptr<InitialData> deserialized_initial_data_ptr =
-      serialize_and_deserialize(initial_data_ptr);
+      serialize_and_deserialize(initial_data_ptr)->get_clone();
   CHECK(dynamic_cast<Kuzmin*>(deserialized_initial_data_ptr.get()) != nullptr);
 }
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Test_Sinusoid.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Test_Sinusoid.cpp
@@ -44,7 +44,7 @@ void test_derived() {
   const std::unique_ptr<InitialData> initial_data_ptr =
       std::make_unique<Sinusoid>();
   const std::unique_ptr<InitialData> deserialized_initial_data_ptr =
-      serialize_and_deserialize(initial_data_ptr);
+      serialize_and_deserialize(initial_data_ptr)->get_clone();
   CHECK(dynamic_cast<Sinusoid*>(deserialized_initial_data_ptr.get()) !=
         nullptr);
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_PlaneWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_PlaneWave.cpp
@@ -187,7 +187,8 @@ void test_1d() {
           "  Center: [2.4]\n"
           "  Profile:\n"
           "    PowX:\n"
-          "      Power: 3");
+          "      Power: 3")
+          ->get_clone();
   const auto deserialized_option_solution =
       serialize_and_deserialize(option_solution);
   const auto& created_solution =

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_RegularSphericalWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_RegularSphericalWave.cpp
@@ -99,7 +99,8 @@ SPECTRE_TEST_CASE("Unit.AnalyticSolutions.WaveEquation.RegularSphericalWave",
           "    Gaussian:\n"
           "      Amplitude: 1.\n"
           "      Width: 1.\n"
-          "      Center: 0.\n");
+          "      Center: 0.\n")
+          ->get_clone();
   const auto deserialized_option_solution =
       serialize_and_deserialize(option_solution);
   const auto& created_solution =

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SemidiscretizedDg.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SemidiscretizedDg.cpp
@@ -304,7 +304,7 @@ SPECTRE_TEST_CASE(
           "  Harmonic: 1\n"
           "  Amplitudes: [1.2, 2.3, 3.4, 4.5]\n");
   const auto deserialized_option_solution =
-      serialize_and_deserialize(option_solution);
+      serialize_and_deserialize(option_solution->get_clone());
   const auto& solution =
       dynamic_cast<const ScalarWave::Solutions::SemidiscretizedDg&>(
           *deserialized_option_solution);


### PR DESCRIPTION
## Proposed changes

This PR focuses on changes to generic code to support both the current hard-coded ID and to also support reading from the input file. Once the individual systems are converted we will have significant fewer executables and can much more easily add input file tests to CI since they won't increase build costs.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
