### PR TITLE
Fix possible roundoff error in MC reconstructor

### DIFF
--- a/src/NumericalAlgorithms/FiniteDifference/MonotonisedCentral.hpp
+++ b/src/NumericalAlgorithms/FiniteDifference/MonotonisedCentral.hpp
@@ -27,15 +27,21 @@ struct MonotonisedCentralReconstructor {
   SPECTRE_ALWAYS_INLINE static std::array<double, 2> pointwise(
       const double* const q, const int stride) {
     using std::abs;
-    using std::min;
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+
     const double a = q[stride] - q[0];
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     const double b = q[0] - q[-stride];
-    const double slope = 0.5 * (sgn(a) + sgn(b)) *
-                         min(0.5 * abs(a + b), 2.0 * min(abs(a), abs(b)));
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    return {{q[0] - 0.5 * slope, q[0] + 0.5 * slope}};
+
+    if (sgn(a) != sgn(b)) {
+      return {{q[0], q[0]}};
+    }
+    if (3.0 * abs(a) <= abs(b)) {
+      return {{q[0] - a, q[stride]}};
+    } else if (3.0 * abs(b) <= abs(a)) {
+      return {{q[-stride], q[0] + b}};
+    } else {
+      const double slope = 0.5 * (q[stride] - q[-stride]);
+      return {{q[0] - 0.5 * slope, q[0] + 0.5 * slope}};
+    }
   }
 
   SPECTRE_ALWAYS_INLINE static constexpr size_t stencil_width() { return 3; }

--- a/tests/Unit/Helpers/NumericalAlgorithms/FiniteDifference/Roundoff.hpp
+++ b/tests/Unit/Helpers/NumericalAlgorithms/FiniteDifference/Roundoff.hpp
@@ -1,0 +1,80 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace TestHelpers::fd::reconstruction {
+/*!
+ * Test that the reconstruction procedure produces positive results in
+ * the presence of a very large jump which may cause roundoff error.
+ */
+template <typename F>
+void test_positivity_with_roundoff(const size_t stencil_width,
+                                   const F& invoke_recons) {
+  const size_t num_fd_points = 4;
+  const Mesh<1> mesh{num_fd_points, Spectral::Basis::FiniteDifference,
+                     Spectral::Quadrature::CellCentered};
+  const auto logical_coords = logical_coordinates(mesh);
+
+  std::vector<double> volume_vars(mesh.number_of_grid_points(), 0.0);
+  DataVector var(volume_vars.data(), mesh.number_of_grid_points());
+
+  const double small_value = 1.0e-16;
+  const double large_value = 1.0e10;
+  for (size_t i = 0; i < mesh.number_of_grid_points(); ++i) {
+    const double x = get<0>(logical_coords)[i];
+    var[i] = x > 0.0 ? x * large_value : small_value;
+  }
+
+  const size_t number_of_ghost_zones = (stencil_width - 1) / 2 + 1;
+  DirectionMap<1, std::vector<double>> neighbor_data{};
+  neighbor_data[Direction<1>::upper_xi()] =
+      std::vector<double>(number_of_ghost_zones, large_value);
+  neighbor_data[Direction<1>::lower_xi()] =
+      std::vector<double>(number_of_ghost_zones, small_value);
+
+  std::vector<double> reconstructed_upper_side_of_face_vars(
+      mesh.number_of_grid_points() + 1);
+  std::vector<double> reconstructed_lower_side_of_face_vars(
+      mesh.number_of_grid_points() + 1);
+
+  std::array<gsl::span<double>, 1> recons_upper_side_of_face{
+      gsl::make_span(reconstructed_upper_side_of_face_vars.data(),
+                     reconstructed_upper_side_of_face_vars.size())};
+  std::array<gsl::span<double>, 1> recons_lower_side_of_face{
+      gsl::make_span(reconstructed_lower_side_of_face_vars.data(),
+                     reconstructed_lower_side_of_face_vars.size())};
+
+  DirectionMap<1, gsl::span<const double>> ghost_cell_vars{};
+  for (const auto& [direction, data] : neighbor_data) {
+    ghost_cell_vars[direction] = gsl::make_span(data.data(), data.size());
+  }
+
+  invoke_recons(make_not_null(&recons_upper_side_of_face),
+                make_not_null(&recons_lower_side_of_face),
+                gsl::make_span(volume_vars.data(), volume_vars.size()),
+                ghost_cell_vars, mesh.extents(), 1);
+
+  for (const auto reconstructed : reconstructed_upper_side_of_face_vars) {
+    CHECK(reconstructed > 0.0);
+  }
+  for (const auto reconstructed : reconstructed_lower_side_of_face_vars) {
+    CHECK(reconstructed > 0.0);
+  }
+}
+}  // namespace TestHelpers::fd::reconstruction

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_Minmod.cpp
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_Minmod.cpp
@@ -12,6 +12,7 @@
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "Helpers/NumericalAlgorithms/FiniteDifference/Exact.hpp"
 #include "Helpers/NumericalAlgorithms/FiniteDifference/Python.hpp"
+#include "Helpers/NumericalAlgorithms/FiniteDifference/Roundoff.hpp"
 #include "NumericalAlgorithms/FiniteDifference/Minmod.hpp"
 
 namespace {
@@ -53,6 +54,9 @@ void test() {
       Dim>(1, 4, 3, recons, recons_neighbor_data);
   TestHelpers::fd::reconstruction::test_with_python(
       Index<Dim>{4}, 3, "Minmod", "test_minmod", recons, recons_neighbor_data);
+  if constexpr (Dim == 1) {
+    TestHelpers::fd::reconstruction::test_positivity_with_roundoff(3, recons);
+  }
 }
 }  // namespace
 

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_MonotonisedCentral.cpp
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_MonotonisedCentral.cpp
@@ -12,6 +12,7 @@
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "Helpers/NumericalAlgorithms/FiniteDifference/Exact.hpp"
 #include "Helpers/NumericalAlgorithms/FiniteDifference/Python.hpp"
+#include "Helpers/NumericalAlgorithms/FiniteDifference/Roundoff.hpp"
 #include "NumericalAlgorithms/FiniteDifference/MonotonisedCentral.hpp"
 
 namespace {
@@ -56,6 +57,9 @@ void test() {
   TestHelpers::fd::reconstruction::test_with_python(
       Index<Dim>{4}, 3, "MonotonisedCentral", "test_monotonised_central",
       recons, recons_neighbor_data);
+  if constexpr (Dim == 1) {
+    TestHelpers::fd::reconstruction::test_positivity_with_roundoff(3, recons);
+  }
 }
 }  // namespace
 


### PR DESCRIPTION
## Proposed changes

Porting [Will's original commit](https://github.com/wthrowe/spectre/commit/7a23ef672e27b464ee3ec2676bf9b00a85d5e08b), making sure a large jump in value doesn't make reconstructed value zero due to roundoff error. This helps the MonotonisedCentral reconstructor returns positive reconstructed values given positive cell-centered value inputs.

I excluded the roundoff error test for `AoWeno53` from the original commit, even though the test passes, to keep this test applied only to low-order reconstructions.



### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
