### PR TITLE
Fix bug causing events to be improperly rerun

### DIFF
--- a/src/Evolution/EventsAndDenseTriggers/EventsAndDenseTriggers.hpp
+++ b/src/Evolution/EventsAndDenseTriggers/EventsAndDenseTriggers.hpp
@@ -238,7 +238,9 @@ void EventsAndDenseTriggers::run_events(
                 std::numeric_limits<double>::signaling_NaN();
           });
     }
-    trigger_entry.is_triggered.reset();
+    // Mark this trigger as handled so we will not reprocess it if
+    // this method or is_ready is called again.
+    trigger_entry.is_triggered = false;
   }
 }
 
@@ -266,6 +268,7 @@ bool EventsAndDenseTriggers::reschedule(
     if (before_(trigger_entry.next_check, new_next_check)) {
       new_next_check = trigger_entry.next_check;
     }
+    trigger_entry.is_triggered.reset();
   }
 
   next_check_ = new_next_check;

--- a/tests/Unit/Evolution/EventsAndDenseTriggers/Test_EventsAndDenseTriggers.cpp
+++ b/tests/Unit/Evolution/EventsAndDenseTriggers/Test_EventsAndDenseTriggers.cpp
@@ -219,9 +219,19 @@ void do_test(const bool time_runs_forward, const bool add_event) {
   CHECK(not events_and_dense_triggers.reschedule(box, cache, array_index,
                                                  component));
   set_tag(TriggerA::NextCheck{}, 2.0 * time_sign);
+  CHECK(events_and_dense_triggers.next_trigger(box) == -1.0 * time_sign);
+  CHECK(events_and_dense_triggers.is_ready(
+            box, cache, array_index, component) == TriggeringState::Ready);
+  events_and_dense_triggers.run_events(box, cache, array_index, component);
+  check_events(false, false, false);
   CHECK(not events_and_dense_triggers.reschedule(box, cache, array_index,
                                                  component));
   set_tag(TriggerB::NextCheck{}, 3.0 * time_sign);
+  CHECK(events_and_dense_triggers.next_trigger(box) == -1.0 * time_sign);
+  CHECK(events_and_dense_triggers.is_ready(
+            box, cache, array_index, component) == TriggeringState::Ready);
+  events_and_dense_triggers.run_events(box, cache, array_index, component);
+  check_events(false, false, false);
   CHECK(
       events_and_dense_triggers.reschedule(box, cache, array_index, component));
   CHECK(events_and_dense_triggers.next_trigger(box) == 2.0 * time_sign);
@@ -232,7 +242,7 @@ void do_test(const bool time_runs_forward, const bool add_event) {
   CHECK(events_and_dense_triggers.is_ready(
             box, cache, array_index, component) == TriggeringState::NotReady);
   set_tag(TriggerA::IsTriggered{}, true);
-  set_tag(TriggerA::NextCheck{}, 3.0 * time_sign);
+  set_tag(TriggerA::NextCheck{}, std::nullopt);
   CHECK(events_and_dense_triggers.next_trigger(box) == 2.0 * time_sign);
   CHECK(events_and_dense_triggers.is_ready(
             box, cache, array_index, component) == TriggeringState::NotReady);
@@ -246,7 +256,19 @@ void do_test(const bool time_runs_forward, const bool add_event) {
   check_events(false, false, false);
   CHECK(EventA::time_during_event == 2.0 * time_sign);
   CHECK(EventA::previous_time_during_event == std::nullopt);
-
+  CHECK(not events_and_dense_triggers.reschedule(box, cache, array_index,
+                                                 component));
+  CHECK(events_and_dense_triggers.next_trigger(box) == 2.0 * time_sign);
+  CHECK(events_and_dense_triggers.is_ready(
+            box, cache, array_index, component) == TriggeringState::Ready);
+  events_and_dense_triggers.run_events(box, cache, array_index, component);
+  check_events(false, false, false);
+  set_tag(TriggerA::NextCheck{}, 3.0 * time_sign);
+  CHECK(events_and_dense_triggers.next_trigger(box) == 2.0 * time_sign);
+  CHECK(events_and_dense_triggers.is_ready(
+            box, cache, array_index, component) == TriggeringState::Ready);
+  events_and_dense_triggers.run_events(box, cache, array_index, component);
+  check_events(false, false, false);
   CHECK(
       events_and_dense_triggers.reschedule(box, cache, array_index, component));
   set_tag(TriggerA::NextCheck{}, 4.0 * time_sign);


### PR DESCRIPTION
Introduced in 7ce002f346c9613309a743e87b83a8feb41d7ba0.  The flag that events had been run was cleared after running the events instead of after rescheduling, so if rescheduling failed the events could be rerun on a subsequent attempt.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
