### PR TITLE
Fix uninitialized timescale tuners from options

### DIFF
--- a/src/ControlSystem/Tags/FunctionsOfTimeInitialize.hpp
+++ b/src/ControlSystem/Tags/FunctionsOfTimeInitialize.hpp
@@ -122,7 +122,7 @@ struct FunctionsOfTimeInitialize : domain::Tags::FunctionsOfTime,
       const OptionHolders&... option_holders) {
     const auto initial_expiration_times =
         control_system::initial_expiration_times(
-            initial_time, initial_time_step, option_holders...);
+            initial_time, initial_time_step, domain_creator, option_holders...);
 
     // We need to check the expiration times before we replace functions of
     // time (if we're going to do so) so we can ensure a proper domain creator

--- a/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
@@ -104,6 +104,8 @@ class TestCreator : public DomainCreator<1> {
           std::string,
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override {
     const std::array<DataVector, 3> initial_values{{{-1.0}, {-2.0}, {-3.0}}};
+    const std::array<DataVector, 3> initial_values3{
+        {{-1.0, 1.0}, {-2.0, 2.0}, {-3.0, 3.0}}};
 
     std::unordered_map<std::string, double> expiration_times{
         {"Uncontrolled", std::numeric_limits<double>::infinity()}};
@@ -136,7 +138,7 @@ class TestCreator : public DomainCreator<1> {
       result.insert(
           {"Controlled3",
            std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
-               initial_time, initial_values,
+               initial_time, initial_values3,
                expiration_times.at("Controlled3"))});
     }
     result.insert(
@@ -203,8 +205,7 @@ void test_functions_of_time_tag() {
   const double timescale = 27.0;
   const TimescaleTuner tuner1(std::vector<double>{timescale}, 10.0, 1.0e-3,
                               1.0e-2, 1.0e-4, 1.01, 0.99);
-  const TimescaleTuner tuner2(std::vector<double>{0.1}, 10.0, 1.0e-3, 1.0e-2,
-                              1.0e-4, 1.01, 0.99);
+  const TimescaleTuner tuner2(0.1, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01, 0.99);
   const Averager<1> averager(0.25, true);
   const double update_fraction = 0.3;
   const Controller<2> controller(update_fraction);

--- a/tests/Unit/ControlSystem/Test_InitialExpirationTimes.cpp
+++ b/tests/Unit/ControlSystem/Test_InitialExpirationTimes.cpp
@@ -11,6 +11,8 @@
 #include "ControlSystem/InitialExpirationTimes.hpp"
 #include "ControlSystem/Protocols/ControlSystem.hpp"
 #include "ControlSystem/Tags.hpp"
+#include "Domain/Creators/DomainCreator.hpp"
+#include "Helpers/ControlSystem/SystemHelpers.hpp"
 #include "Helpers/ControlSystem/TestStructs.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
@@ -56,14 +58,13 @@ void check_expiration_times(
 
 SPECTRE_TEST_CASE("Unit.ControlSystem.ConstructInitialExpirationTimes",
                   "[ControlSystem][Unit]") {
-  const double initial_time = 1.3;
+  const double initial_time = 0.9;
   const double initial_time_step = 0.1;
 
   const double timescale = 2.0;
   const TimescaleTuner tuner1(std::vector<double>{timescale}, 10.0, 1.0e-3,
                               1.0e-2, 1.0e-4, 1.01, 0.99);
-  const TimescaleTuner tuner2(std::vector<double>{0.1}, 10.0, 1.0e-3, 1.0e-2,
-                              1.0e-4, 1.01, 0.99);
+  const TimescaleTuner tuner2(0.1, 10.0, 1.0e-3, 1.0e-2, 1.0e-4, 1.01, 0.99);
   const Averager<1> averager(0.25, true);
   const double update_fraction = 0.3;
   const Controller<2> controller(update_fraction);
@@ -73,11 +74,24 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.ConstructInitialExpirationTimes",
   OptionHolder<2> option_holder2(averager, controller, tuner1, control_error);
   OptionHolder<3> option_holder3(averager, controller, tuner2, control_error);
 
+  using FakeCreator = control_system::TestHelpers::FakeCreator;
+
+  const std::unique_ptr<DomainCreator<3>> creator1 =
+      std::make_unique<FakeCreator>(std::unordered_map<std::string, size_t>{});
+  const std::unique_ptr<DomainCreator<3>> creator2 =
+      std::make_unique<FakeCreator>(std::unordered_map<std::string, size_t>{
+          {FakeControlSystem<1>::name(), 1}});
+  const std::unique_ptr<DomainCreator<3>> creator3 =
+      std::make_unique<FakeCreator>(std::unordered_map<std::string, size_t>{
+          {FakeControlSystem<1>::name(), 1},
+          {FakeControlSystem<2>::name(), 1},
+          {FakeControlSystem<3>::name(), 2}});
+
   {
     INFO("No control systems");
     const auto initial_expiration_times =
         control_system::initial_expiration_times(initial_time,
-                                                 initial_time_step);
+                                                 initial_time_step, creator1);
 
     const std::unordered_map<std::string, double>
         expected_initial_expiration_times{};
@@ -89,7 +103,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.ConstructInitialExpirationTimes",
     INFO("One control system");
     const auto initial_expiration_times =
         control_system::initial_expiration_times(
-            initial_time, initial_time_step, option_holder1);
+            initial_time, initial_time_step, creator2, option_holder1);
 
     const std::unordered_map<std::string, double>
         expected_initial_expiration_times{
@@ -103,8 +117,8 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.ConstructInitialExpirationTimes",
     INFO("Three control system");
     const auto initial_expiration_times =
         control_system::initial_expiration_times(
-            initial_time, initial_time_step, option_holder1, option_holder2,
-            option_holder3);
+            initial_time, initial_time_step, creator3, option_holder1,
+            option_holder2, option_holder3);
 
     const std::unordered_map<std::string, double>
         expected_initial_expiration_times{


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
