### PR TITLE
Fix sign error in ErrorControl

### DIFF
--- a/src/Time/StepChoosers/ErrorControl.hpp
+++ b/src/Time/StepChoosers/ErrorControl.hpp
@@ -87,8 +87,8 @@ struct PreviousStepError : db::SimpleTag {
  * \f[
  * h_{\text{new}} = h \cdot \min\left(F_{\text{max}},
  * \max\left(F_{\text{min}},
- * \frac{F_{\text{safety}}}{E^{0.7 / (q + 1)}
- *  E_{\text{prev}}^{0.4 / (q + 1)}}\right)\right),
+ * F_{\text{safety}} E^{-0.7 / (q + 1)}
+ * E_{\text{prev}}^{0.4 / (q + 1)}\right)\right),
  * \f]
  *
  * where \f$E_{\text{prev}}\f$ is the error computed in the previous step.
@@ -208,12 +208,11 @@ class ErrorControl : public StepChooser<StepChooserUse::LtsStep> {
       const double beta_factor = 0.4 / (stepper.error_estimate_order() + 1);
       new_step =
           previous_step *
-          std::clamp(
-              safety_factor_ *
-                  pow(1.0 / std::max(l_inf_error, 1e-14), alpha_factor) *
-                  pow(1.0 / std::max(previous_step_error->value(), 1e-14),
-                      beta_factor),
-              min_factor_, max_factor_);
+          std::clamp(safety_factor_ *
+                         pow(1.0 / std::max(l_inf_error, 1e-14), alpha_factor) *
+                         pow(std::max(previous_step_error->value(), 1e-14),
+                             beta_factor),
+                     min_factor_, max_factor_);
     }
     *previous_step_error = l_inf_error;
     return std::make_pair(new_step, l_inf_error <= 1.0);

--- a/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
@@ -36,8 +36,8 @@ Evolution:
     - ElementSizeCfl:
         SafetyFactor: 0.5
     - ErrorControl:
-        AbsoluteTolerance: 1e-8
-        RelativeTolerance: 1e-6
+        AbsoluteTolerance: 1e-6
+        RelativeTolerance: 1e-4
         MaxFactor: 2
         MinFactor: 0.25
         SafetyFactor: 0.95


### PR DESCRIPTION
It now correctly adjusts the step size to be smaller if the slope of the error is positive, instead of larger.  This matches the cited reference.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
