### PR TITLE
GH+CCE for a gauge wave

### DIFF
--- a/src/Evolution/Executables/Cce/CharacteristicExtract.hpp
+++ b/src/Evolution/Executables/Cce/CharacteristicExtract.hpp
@@ -54,7 +54,8 @@ class er;
 /// \endcond
 
 template <template <typename> class BoundaryComponent>
-struct EvolutionMetavars : CharacteristicExtractDefaults {
+struct EvolutionMetavars : CharacteristicExtractDefaults<false> {
+  using system = Cce::System<uses_partially_flat_cartesian_coordinates>;
   static constexpr bool local_time_stepping = true;
   using cce_boundary_component = BoundaryComponent<EvolutionMetavars>;
 

--- a/src/Evolution/Executables/Cce/CharacteristicExtractBase.hpp
+++ b/src/Evolution/Executables/Cce/CharacteristicExtractBase.hpp
@@ -17,18 +17,19 @@
 #include "Time/StepChoosers/Increase.hpp"
 #include "Utilities/TMPL.hpp"
 
+template <bool UsesPartiallyFlatCartesianCoordinates>
 struct CharacteristicExtractDefaults {
-  static constexpr bool uses_partially_flat_cartesian_coordinates = false;
-  using system = Cce::System<uses_partially_flat_cartesian_coordinates>;
+  static constexpr bool uses_partially_flat_cartesian_coordinates =
+      UsesPartiallyFlatCartesianCoordinates;
   using evolved_swsh_tag = Cce::Tags::BondiJ;
   using evolved_swsh_dt_tag = Cce::Tags::BondiH;
   using evolved_coordinates_variables_tag = Tags::Variables<
-      std::conditional_t<uses_partially_flat_cartesian_coordinates,
-                         tmpl::list<Cce::Tags::CauchyCartesianCoords,
-                                    Cce::Tags::PartiallyFlatCartesianCoords,
-                                    Cce::Tags::InertialRetardedTime>,
-                         tmpl::list<Cce::Tags::CauchyCartesianCoords,
-                                    Cce::Tags::InertialRetardedTime>>>;
+      tmpl::conditional_t<uses_partially_flat_cartesian_coordinates,
+                          tmpl::list<Cce::Tags::CauchyCartesianCoords,
+                                     Cce::Tags::PartiallyFlatCartesianCoords,
+                                     Cce::Tags::InertialRetardedTime>,
+                          tmpl::list<Cce::Tags::CauchyCartesianCoords,
+                                     Cce::Tags::InertialRetardedTime>>>;
 
   struct swsh_vars_selector {
     static std::string name() { return "SwshVars"; }
@@ -52,7 +53,7 @@ struct CharacteristicExtractDefaults {
       Cce::Tags::BondiUAtScri, Cce::Tags::PartiallyFlatGaugeC,
       Cce::Tags::PartiallyFlatGaugeD, Cce::Tags::PartiallyFlatGaugeOmega,
       Cce::Tags::Du<Cce::Tags::PartiallyFlatGaugeOmega>,
-      std::conditional_t<
+      tmpl::conditional_t<
           uses_partially_flat_cartesian_coordinates,
           tmpl::list<
               Cce::Tags::CauchyGaugeC, Cce::Tags::CauchyGaugeD,
@@ -96,10 +97,10 @@ struct CharacteristicExtractDefaults {
   using cce_transform_buffer_tags = Cce::all_transform_buffer_tags;
   using cce_swsh_derivative_tags = Cce::all_swsh_derivative_tags;
   using cce_angular_coordinate_tags =
-      std::conditional_t<uses_partially_flat_cartesian_coordinates,
-                         tmpl::list<Cce::Tags::CauchyAngularCoords,
-                                    Cce::Tags::PartiallyFlatAngularCoords>,
-                         tmpl::list<Cce::Tags::CauchyAngularCoords>>;
+      tmpl::conditional_t<uses_partially_flat_cartesian_coordinates,
+                          tmpl::list<Cce::Tags::CauchyAngularCoords,
+                                     Cce::Tags::PartiallyFlatAngularCoords>,
+                          tmpl::list<Cce::Tags::CauchyAngularCoords>>;
   using cce_step_choosers = tmpl::list<
       StepChoosers::Constant<StepChooserUse::LtsStep>,
       StepChoosers::Increase<StepChooserUse::LtsStep>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
@@ -12,6 +12,17 @@ function(add_generalized_harmonic_executable_without_horizon
     )
 endfunction(add_generalized_harmonic_executable_without_horizon)
 
+function(add_generalized_harmonic_cce_executable_without_horizon
+  EXECUTABLE_NAME INITIAL_DATA LIBS_TO_LINK)
+  add_spectre_parallel_executable(
+    "EvolveGhCce${EXECUTABLE_NAME}"
+    EvolveGeneralizedHarmonicCce
+    Evolution/Executables/GeneralizedHarmonic
+    "EvolutionMetavars<3, ${INITIAL_DATA}>"
+    "${LIBS_TO_LINK}"
+    )
+endfunction(add_generalized_harmonic_cce_executable_without_horizon)
+
 set(LIBS_TO_LINK
   CoordinateMaps
   DiscontinuousGalerkin
@@ -72,4 +83,16 @@ add_spectre_parallel_executable(
   Evolution/Executables/GeneralizedHarmonic
   "EvolutionMetavars"
   "${LIBS_TO_LINK};ControlSystem;GeneralRelativitySolutions;Importers"
+)
+
+add_generalized_harmonic_cce_executable_without_horizon(
+  GaugeWave
+  false
+  "${LIBS_TO_LINK};Cce;GeneralRelativitySolutions"
+)
+
+add_generalized_harmonic_cce_executable_without_horizon(
+  GaugeWaveNumericInitialData
+  true
+  "${LIBS_TO_LINK};Cce;GeneralRelativitySolutions;Importers"
 )

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicCce.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicCce.hpp
@@ -1,0 +1,272 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+#include "Evolution/Executables/Cce/CharacteristicExtractBase.hpp"
+#include "Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp"
+#include "Evolution/Systems/Cce/Actions/SendGhVarsToCce.hpp"
+#include "Evolution/Systems/Cce/Callbacks/SendGhWorldtubeData.hpp"
+#include "Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp"
+#include "Evolution/Systems/Cce/Components/WorldtubeBoundary.hpp"
+#include "Evolution/Systems/Cce/Initialize/ConformalFactor.hpp"
+#include "Evolution/Systems/Cce/Initialize/InitializeJ.hpp"
+#include "Evolution/Systems/Cce/Initialize/InverseCubic.hpp"
+#include "Evolution/Systems/Cce/Initialize/NoIncomingRadiation.hpp"
+#include "Evolution/Systems/Cce/Initialize/RegisterInitializeJWithCharm.hpp"
+#include "Evolution/Systems/Cce/Initialize/ZeroNonSmooth.hpp"
+#include "Evolution/Systems/Cce/IntegrandInputSteps.hpp"
+#include "Evolution/Systems/Cce/InterfaceManagers/GhInterfaceManager.hpp"
+#include "Evolution/Systems/Cce/InterfaceManagers/GhLocalTimeStepping.hpp"
+#include "Evolution/Systems/Cce/InterfaceManagers/GhLockstep.hpp"
+#include "Evolution/Systems/Cce/OptionTags.hpp"
+#include "Evolution/Systems/Cce/System.hpp"
+#include "Evolution/Systems/Cce/Tags.hpp"
+#include "Evolution/Systems/Cce/WorldtubeBufferUpdater.hpp"
+#include "Evolution/Systems/Cce/WorldtubeDataManager.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/RegisterDerived.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/RegisterDerivedWithCharm.hpp"
+#include "NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.hpp"
+#include "NumericalAlgorithms/Interpolation/CubicSpanInterpolator.hpp"
+#include "NumericalAlgorithms/Interpolation/LinearSpanInterpolator.hpp"
+#include "NumericalAlgorithms/Interpolation/SpanInterpolator.hpp"
+#include "Options/FactoryHelpers.hpp"
+#include "Options/Options.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/PhaseControl/PhaseControlTags.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "ParallelAlgorithms/Interpolation/Actions/CleanUpInterpolator.hpp"
+#include "ParallelAlgorithms/Interpolation/Actions/ElementInitInterpPoints.hpp"
+#include "ParallelAlgorithms/Interpolation/Actions/InitializeInterpolationTarget.hpp"
+#include "ParallelAlgorithms/Interpolation/Actions/InterpolationTargetReceiveVars.hpp"
+#include "ParallelAlgorithms/Interpolation/Actions/InterpolatorReceivePoints.hpp"
+#include "ParallelAlgorithms/Interpolation/Actions/InterpolatorReceiveVolumeData.hpp"
+#include "ParallelAlgorithms/Interpolation/Actions/InterpolatorRegisterElement.hpp"
+#include "ParallelAlgorithms/Interpolation/Actions/TryToInterpolate.hpp"
+#include "ParallelAlgorithms/Interpolation/Events/Interpolate.hpp"
+#include "ParallelAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp"
+#include "ParallelAlgorithms/Interpolation/InterpolationTarget.hpp"
+#include "ParallelAlgorithms/Interpolation/Interpolator.hpp"
+#include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
+#include "ParallelAlgorithms/Interpolation/Targets/KerrHorizon.hpp"
+#include "ParallelAlgorithms/Interpolation/Targets/Sphere.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/GaugeWave.hpp"
+#include "Time/StepControllers/Factory.hpp"
+#include "Utilities/Blas.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+
+/// \cond
+namespace Frame {
+// IWYU pragma: no_forward_declare MathFunction
+struct Inertial;
+}  // namespace Frame
+namespace Parallel {
+template <typename Metavariables>
+class CProxy_GlobalCache;
+}  // namespace Parallel
+/// \endcond
+
+template <size_t VolumeDim, bool UseNumericalInitialData>
+struct EvolutionMetavars
+    : public GeneralizedHarmonicTemplateBase<
+          EvolutionMetavars<VolumeDim, UseNumericalInitialData>>,
+          public CharacteristicExtractDefaults<false> {
+  using gh_base = GeneralizedHarmonicTemplateBase<
+      EvolutionMetavars<VolumeDim, UseNumericalInitialData>>;
+  using typename gh_base::initialize_initial_data_dependent_quantities_actions;
+  using cce_boundary_component = Cce::GhWorldtubeBoundary<EvolutionMetavars>;
+
+  static constexpr bool local_time_stepping = gh_base::local_time_stepping;
+
+  template <bool DuringSelfStart>
+  struct CceWorldtubeTarget;
+
+  using interpolator_source_vars = tmpl::list<
+      ::gr::Tags::SpacetimeMetric<VolumeDim, Frame::Inertial>,
+      ::GeneralizedHarmonic::Tags::Phi<VolumeDim, Frame::Inertial>,
+      ::GeneralizedHarmonic::Tags::Pi<VolumeDim, Frame::Inertial>>;
+
+  using dg_registration_list =
+      tmpl::push_back<typename gh_base::dg_registration_list,
+                      intrp::Actions::RegisterElementWithInterpolator>;
+
+  using typename gh_base::system;
+
+  template <bool DuringSelfStart>
+  using step_actions = tmpl::list<
+      tmpl::conditional_t<
+          DuringSelfStart,
+          Cce::Actions::SendGhVarsToCce<CceWorldtubeTarget<true>>,
+          Cce::Actions::SendGhVarsToCce<CceWorldtubeTarget<false>>>,
+      evolution::dg::Actions::ComputeTimeDerivative<
+          VolumeDim, system, AllStepChoosers, local_time_stepping>,
+      tmpl::conditional_t<
+          local_time_stepping,
+          tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<
+                         tmpl::list<evolution::dg::ApplyBoundaryCorrections<
+                             local_time_stepping, EvolutionMetavars, true>>>,
+                     evolution::dg::Actions::ApplyLtsBoundaryCorrections<
+                         system, VolumeDim>>,
+          tmpl::list<
+              evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
+                  system, VolumeDim>,
+              Actions::RecordTimeStepperData<>,
+              evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
+              Actions::UpdateU<>,
+              dg::Actions::Filter<
+                  Filters::Exponential<0>,
+                  tmpl::list<
+                      gr::Tags::SpacetimeMetric<VolumeDim, Frame::Inertial,
+                                                DataVector>,
+                      GeneralizedHarmonic::Tags::Pi<VolumeDim, Frame::Inertial>,
+                      GeneralizedHarmonic::Tags::Phi<VolumeDim,
+                                                     Frame::Inertial>>>>>>;
+
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = Options::add_factory_classes<
+        typename gh_base::factory_creation::factory_classes,
+        tmpl::pair<StepChooser<StepChooserUse::LtsStep>, cce_step_choosers>>;
+  };
+
+  static constexpr bool override_functions_of_time = false;
+
+  // initialization actions are the same as the default, with the single
+  // addition of initializing the interpolation points (second-to-last action).
+  using initialization_actions = tmpl::list<
+      Initialization::Actions::TimeAndTimeStep<EvolutionMetavars>,
+      evolution::dg::Initialization::Domain<VolumeDim,
+                                            override_functions_of_time>,
+      Initialization::Actions::NonconservativeSystem<system>,
+      std::conditional_t<
+          UseNumericalInitialData, tmpl::list<>,
+          evolution::Initialization::Actions::SetVariables<
+              domain::Tags::Coordinates<VolumeDim, Frame::ElementLogical>>>,
+      Initialization::Actions::AddComputeTags<::Tags::DerivCompute<
+          typename system::variables_tag,
+          domain::Tags::InverseJacobian<VolumeDim, Frame::ElementLogical,
+                                        Frame::Inertial>,
+          typename system::gradient_variables>>,
+      Initialization::Actions::TimeStepperHistory<EvolutionMetavars>,
+      GeneralizedHarmonic::Actions::InitializeGhAnd3Plus1Variables<VolumeDim>,
+      Initialization::Actions::AddComputeTags<
+          tmpl::push_back<StepChoosers::step_chooser_compute_tags<
+              EvolutionMetavars, local_time_stepping>>>,
+      ::evolution::dg::Initialization::Mortars<VolumeDim, system>,
+      evolution::Actions::InitializeRunEventsAndDenseTriggers,
+      intrp::Actions::ElementInitInterpPoints<
+          intrp::Tags::InterpPointInfo<EvolutionMetavars>>,
+      Parallel::Actions::TerminatePhase>;
+
+  using gh_dg_element_array = DgElementArray<
+      EvolutionMetavars,
+      tmpl::flatten<tmpl::list<
+          Parallel::PhaseActions<Parallel::Phase::Initialization,
+                                 initialization_actions>,
+          tmpl::conditional_t<
+              UseNumericalInitialData,
+              tmpl::list<
+                  Parallel::PhaseActions<
+                      Parallel::Phase::RegisterWithElementDataReader,
+                      tmpl::list<
+                          importers::Actions::RegisterWithElementDataReader,
+                          Parallel::Actions::TerminatePhase>>,
+                  Parallel::PhaseActions<
+                      Parallel::Phase::ImportInitialData,
+                      tmpl::list<
+                          GeneralizedHarmonic::Actions::ReadNumericInitialData<
+                              evolution::OptionTags::NumericInitialData>,
+                          GeneralizedHarmonic::Actions::SetNumericInitialData<
+                              evolution::OptionTags::NumericInitialData>,
+                          Parallel::Actions::TerminatePhase>>>,
+              tmpl::list<>>,
+          Parallel::PhaseActions<
+              Parallel::Phase::InitializeInitialDataDependentQuantities,
+              initialize_initial_data_dependent_quantities_actions>,
+          Parallel::PhaseActions<
+              Parallel::Phase::InitializeTimeStepperHistory,
+              SelfStart::self_start_procedure<step_actions<true>, system>>,
+          Parallel::PhaseActions<Parallel::Phase::Register,
+                                 tmpl::list<dg_registration_list,
+                                            Parallel::Actions::TerminatePhase>>,
+          Parallel::PhaseActions<
+              Parallel::Phase::Evolve,
+              tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
+                         step_actions<false>, Actions::AdvanceTime,
+                         PhaseControl::Actions::ExecutePhaseChange>>>>>;
+
+  template <bool DuringSelfStart>
+  struct CceWorldtubeTarget
+      : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
+    using temporal_id = ::Tags::TimeStepId;
+
+    static std::string name() {
+      return DuringSelfStart ? "SelfStartCceWorldtubeTarget"
+                             : "CceWorldtubeTarget";
+    }
+    using compute_items_on_source = tmpl::list<>;
+    using compute_items_on_target = tmpl::list<>;
+    using compute_target_points =
+        intrp::TargetPoints::Sphere<CceWorldtubeTarget, ::Frame::Inertial>;
+    using post_interpolation_callback = intrp::callbacks::SendGhWorldtubeData<
+        Cce::CharacteristicEvolution<EvolutionMetavars>, CceWorldtubeTarget,
+        DuringSelfStart, local_time_stepping>;
+    using vars_to_interpolate_to_target = interpolator_source_vars;
+    template <typename Metavariables>
+    using interpolating_component = gh_dg_element_array;
+  };
+
+  using interpolation_target_tags =
+      tmpl::list<CceWorldtubeTarget<false>, CceWorldtubeTarget<true>>;
+
+  template <typename ParallelComponent>
+  struct registration_list {
+    using type = std::conditional_t<
+        std::is_same_v<ParallelComponent, gh_dg_element_array>,
+        dg_registration_list, tmpl::list<>>;
+  };
+
+  using component_list = tmpl::flatten<tmpl::list<
+      observers::Observer<EvolutionMetavars>,
+      observers::ObserverWriter<EvolutionMetavars>,
+      std::conditional_t<UseNumericalInitialData,
+                         importers::ElementDataReader<EvolutionMetavars>,
+                         tmpl::list<>>,
+      gh_dg_element_array, intrp::Interpolator<EvolutionMetavars>,
+      tmpl::transform<interpolation_target_tags,
+                      tmpl::bind<intrp::InterpolationTarget,
+                                 tmpl::pin<EvolutionMetavars>, tmpl::_1>>,
+      cce_boundary_component, Cce::CharacteristicEvolution<EvolutionMetavars>>>;
+
+  static constexpr Options::String help{
+      "Evolve the Einstein field equations using the Generalized Harmonic "
+      "formulation\n"
+      "with a coupled CCE evolution for asymptotic wave data output.\n"
+      "The system shouldn't have black holes."};
+
+};
+
+static const std::vector<void (*)()> charm_init_node_funcs{
+    &setup_error_handling, &setup_memory_allocation_failure_reporting,
+    &disable_openblas_multithreading,
+    &domain::creators::time_dependence::register_derived_with_charm,
+    &domain::FunctionsOfTime::register_derived_with_charm,
+    &domain::creators::register_derived_with_charm,
+    &GeneralizedHarmonic::BoundaryCorrections::register_derived_with_charm,
+    &GeneralizedHarmonic::ConstraintDamping::register_derived_with_charm,
+    &Cce::register_initialize_j_with_charm<
+        metavariables::uses_partially_flat_cartesian_coordinates,
+        metavariables::cce_boundary_component>,
+    &Parallel::register_derived_classes_with_charm<Cce::WorldtubeDataManager>,
+    &Parallel::register_derived_classes_with_charm<intrp::SpanInterpolator>,
+    &Parallel::register_factory_classes_with_charm<metavariables>};
+
+static const std::vector<void (*)()> charm_init_proc_funcs{
+    &enable_floating_point_exceptions};

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicCceFwd.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicCceFwd.hpp
@@ -1,0 +1,29 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+/// \cond
+namespace GeneralizedHarmonic {
+template <size_t Dim>
+struct System;
+namespace Solutions {
+template <typename GrSolution>
+struct WrappedGr;
+}  // namespace Solutions
+}  // namespace GeneralizedHarmonic
+namespace gr {
+namespace Solutions {
+template <size_t Dim>
+struct GaugeWave;
+}  // namespace Solutions
+}  // namespace gr
+namespace evolution {
+struct NumericInitialData;
+}  // namespace evolution
+
+template <size_t VolumeDim, bool UseNumericalInitialData>
+struct EvolutionMetavars;
+/// \endcond

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -152,19 +152,21 @@ namespace detail {
 template <bool UseNumericalInitialData>
 constexpr auto make_default_phase_order() {
   if constexpr (UseNumericalInitialData) {
+    // Register needs to be before InitializeTimeStepperHistory so that CCE is
+    // properly registered when the self-start happens
     return std::array{Parallel::Phase::Initialization,
                       Parallel::Phase::RegisterWithElementDataReader,
                       Parallel::Phase::ImportInitialData,
                       Parallel::Phase::InitializeInitialDataDependentQuantities,
-                      Parallel::Phase::InitializeTimeStepperHistory,
                       Parallel::Phase::Register,
+                      Parallel::Phase::InitializeTimeStepperHistory,
                       Parallel::Phase::Evolve,
                       Parallel::Phase::Exit};
   } else {
     return std::array{Parallel::Phase::Initialization,
                       Parallel::Phase::InitializeInitialDataDependentQuantities,
-                      Parallel::Phase::InitializeTimeStepperHistory,
                       Parallel::Phase::Register,
+                      Parallel::Phase::InitializeTimeStepperHistory,
                       Parallel::Phase::Evolve,
                       Parallel::Phase::Exit};
   }

--- a/src/Evolution/Systems/Cce/Actions/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/Actions/CMakeLists.txt
@@ -21,11 +21,11 @@ spectre_target_headers(
   InitializeFirstHypersurface.hpp
   InitializeWorldtubeBoundary.hpp
   InsertInterpolationScriData.hpp
-  InterpolateDuringSelfStart.hpp
   ReceiveGhWorldtubeData.hpp
   ReceiveWorldtubeData.hpp
   RequestBoundaryData.hpp
   ScriObserveInterpolated.hpp
+  SendGhVarsToCce.hpp
   TimeManagement.hpp
   UpdateGauge.hpp
   )

--- a/src/Evolution/Systems/Cce/Actions/SendGhVarsToCce.hpp
+++ b/src/Evolution/Systems/Cce/Actions/SendGhVarsToCce.hpp
@@ -35,7 +35,7 @@ namespace Actions {
 /// of a locally-stepped CCE system and the events and dense triggers
 /// during the self start procedure.
 template <typename CceWorltubeTargetTag>
-struct InterpolateDuringSelfStart {
+struct SendGhVarsToCce {
   template <typename DbTags, typename Metavariables, typename... InboxTags,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>

--- a/tests/Unit/Evolution/Systems/Cce/Actions/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/CMakeLists.txt
@@ -14,7 +14,7 @@ set(LIBRARY_SOURCES
   Test_H5BoundaryCommunication.cpp
   Test_InitializeCharacteristicEvolution.cpp
   Test_InitializeWorldtubeBoundary.cpp
-  Test_InterpolateDuringSelfStart.cpp
+  Test_SendGhVarsToCce.cpp
   Test_RequestBoundaryData.cpp
   Test_ScriObserveInterpolated.cpp
   Test_TimeManagement.cpp

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_SendGhVarsToCce.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_SendGhVarsToCce.cpp
@@ -9,7 +9,7 @@
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Domain.hpp"
-#include "Evolution/Systems/Cce/Actions/InterpolateDuringSelfStart.hpp"
+#include "Evolution/Systems/Cce/Actions/SendGhVarsToCce.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/ParallelAlgorithms/Interpolation/InterpolateOnElementTestHelpers.hpp"
@@ -43,7 +43,7 @@ struct mock_element {
                                  simple_tags, compute_tags>>>,
       Parallel::PhaseActions<
           Parallel::Phase::Testing,
-          tmpl::list<Cce::Actions::InterpolateDuringSelfStart<
+          tmpl::list<Cce::Actions::SendGhVarsToCce<
               typename Metavariables::InterpolationTargetA>>>>;
 };
 
@@ -145,7 +145,7 @@ void run_test() {
 }
 
 SPECTRE_TEST_CASE(
-    "Unit.Evolution.Systems.Cce.Actions.InterpolateDuringSelfStart",
+    "Unit.Evolution.Systems.Cce.Actions.SendGhVarsToCce",
     "[Unit][Cce]") {
   domain::creators::register_derived_with_charm();
   run_test<MockMetavariables>();


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

This PR adds a GH+CCE executable for a gauge wave (without horizons). It lays the foundation for CCM. The system is **not** compatible with the local time stepping.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
I add one more template to `SendGhWorldtubeData` so that it can distinguish between `LTS` and `GTS`. Please remember to update your `CceWorldtubeTarget` @knelli2 
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
