### PR TITLE
Add more overloads of to_different_frame

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/Transform.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Transform.cpp
@@ -13,12 +13,12 @@
 
 namespace transform {
 
-template <size_t VolumeDim, typename SrcFrame, typename DestFrame>
+template <typename DataType, size_t VolumeDim, typename SrcFrame,
+          typename DestFrame>
 void to_different_frame(
-    const gsl::not_null<tnsr::ii<DataVector, VolumeDim, DestFrame>*> dest,
-    const tnsr::ii<DataVector, VolumeDim, SrcFrame>& src,
-    const Jacobian<DataVector, VolumeDim, DestFrame, SrcFrame>& jacobian) {
-  destructive_resize_components(dest, src.begin()->size());
+    const gsl::not_null<tnsr::ii<DataType, VolumeDim, DestFrame>*> dest,
+    const tnsr::ii<DataType, VolumeDim, SrcFrame>& src,
+    const Jacobian<DataType, VolumeDim, DestFrame, SrcFrame>& jacobian) {
   for (size_t i = 0; i < VolumeDim; ++i) {
     for (size_t j = i; j < VolumeDim; ++j) {  // symmetry
       // To avoid initializing to zero, split out k=0 here, and start
@@ -38,14 +38,241 @@ void to_different_frame(
   }
 }
 
-template <size_t VolumeDim, typename SrcFrame, typename DestFrame>
+template <typename DataType, size_t VolumeDim, typename SrcFrame,
+          typename DestFrame>
 auto to_different_frame(
-    const tnsr::ii<DataVector, VolumeDim, SrcFrame>& src,
-    const Jacobian<DataVector, VolumeDim, DestFrame, SrcFrame>& jacobian)
-    -> tnsr::ii<DataVector, VolumeDim, DestFrame> {
-  auto dest = make_with_value<tnsr::ii<DataVector, VolumeDim, DestFrame>>(
+    const tnsr::ii<DataType, VolumeDim, SrcFrame>& src,
+    const Jacobian<DataType, VolumeDim, DestFrame, SrcFrame>& jacobian)
+    -> tnsr::ii<DataType, VolumeDim, DestFrame> {
+  auto dest = make_with_value<tnsr::ii<DataType, VolumeDim, DestFrame>>(
       src, std::numeric_limits<double>::signaling_NaN());
   to_different_frame(make_not_null(&dest), src, jacobian);
+  return dest;
+}
+
+template <typename DataType, size_t VolumeDim, typename SrcFrame,
+          typename DestFrame>
+void to_different_frame(
+    const gsl::not_null<Scalar<DataType>*> dest, const Scalar<DataType>& src,
+    const Jacobian<DataType, VolumeDim, DestFrame, SrcFrame>& /*jacobian*/,
+    const InverseJacobian<DataType, VolumeDim, DestFrame, SrcFrame>&
+    /*inv_jacobian*/) {
+  *dest = src;
+}
+
+template <typename DataType, size_t VolumeDim, typename SrcFrame,
+          typename DestFrame>
+auto to_different_frame(
+    Scalar<DataType> src,
+    const Jacobian<DataType, VolumeDim, DestFrame, SrcFrame>& /*jacobian*/,
+    const InverseJacobian<DataType, VolumeDim, DestFrame, SrcFrame>&
+    /*inv_jacobian*/) -> Scalar<DataType> {
+  return src;
+}
+
+template <typename DataType, size_t VolumeDim, typename SrcFrame,
+          typename DestFrame>
+void to_different_frame(
+    const gsl::not_null<tnsr::I<DataType, VolumeDim, DestFrame>*> dest,
+    const tnsr::I<DataType, VolumeDim, SrcFrame>& src,
+    const Jacobian<DataType, VolumeDim, DestFrame, SrcFrame>& /*jacobian*/,
+    const InverseJacobian<DataType, VolumeDim, DestFrame, SrcFrame>&
+        inv_jacobian) {
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    dest->get(i) = inv_jacobian.get(i, 0) * src.get(0);
+    for (size_t p = 1; p < VolumeDim; ++p) {
+      dest->get(i) += inv_jacobian.get(i, p) * src.get(p);
+    }
+  }
+}
+
+template <typename DataType, size_t VolumeDim, typename SrcFrame,
+          typename DestFrame>
+auto to_different_frame(
+    const tnsr::I<DataType, VolumeDim, SrcFrame>& src,
+    const Jacobian<DataType, VolumeDim, DestFrame, SrcFrame>& jacobian,
+    const InverseJacobian<DataType, VolumeDim, DestFrame, SrcFrame>&
+        inv_jacobian) -> tnsr::I<DataType, VolumeDim, DestFrame> {
+  auto dest = make_with_value<tnsr::I<DataType, VolumeDim, DestFrame>>(
+      src, std::numeric_limits<double>::signaling_NaN());
+  to_different_frame(make_not_null(&dest), src, jacobian, inv_jacobian);
+  return dest;
+}
+
+template <typename DataType, size_t VolumeDim, typename SrcFrame,
+          typename DestFrame>
+void to_different_frame(
+    const gsl::not_null<tnsr::i<DataType, VolumeDim, DestFrame>*> dest,
+    const tnsr::i<DataType, VolumeDim, SrcFrame>& src,
+    const Jacobian<DataType, VolumeDim, DestFrame, SrcFrame>& jacobian,
+    const InverseJacobian<DataType, VolumeDim, DestFrame, SrcFrame>&
+    /*inv_jacobian*/) {
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    dest->get(i) = jacobian.get(0, i) * src.get(0);
+    for (size_t p = 1; p < VolumeDim; ++p) {
+      dest->get(i) += jacobian.get(p, i) * src.get(p);
+    }
+  }
+}
+
+template <typename DataType, size_t VolumeDim, typename SrcFrame,
+          typename DestFrame>
+auto to_different_frame(
+    const tnsr::i<DataType, VolumeDim, SrcFrame>& src,
+    const Jacobian<DataType, VolumeDim, DestFrame, SrcFrame>& jacobian,
+    const InverseJacobian<DataType, VolumeDim, DestFrame, SrcFrame>&
+        inv_jacobian) -> tnsr::i<DataType, VolumeDim, DestFrame> {
+  auto dest = make_with_value<tnsr::i<DataType, VolumeDim, DestFrame>>(
+      src, std::numeric_limits<double>::signaling_NaN());
+  to_different_frame(make_not_null(&dest), src, jacobian, inv_jacobian);
+  return dest;
+}
+
+template <typename DataType, size_t VolumeDim, typename SrcFrame,
+          typename DestFrame>
+void to_different_frame(
+    const gsl::not_null<tnsr::iJ<DataType, VolumeDim, DestFrame>*> dest,
+    const tnsr::iJ<DataType, VolumeDim, SrcFrame>& src,
+    const Jacobian<DataType, VolumeDim, DestFrame, SrcFrame>& jacobian,
+    const InverseJacobian<DataType, VolumeDim, DestFrame, SrcFrame>&
+        inv_jacobian) {
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    for (size_t j = 0; j < VolumeDim; ++j) {
+      // To avoid initializing to zero, split out k=0 here, and start
+      // k loop below at k=1.
+      dest->get(i, j) =
+          jacobian.get(0, i) * inv_jacobian.get(j, 0) * src.get(0, 0);
+      for (size_t p = 1; p < VolumeDim; ++p) {
+        dest->get(i, j) +=
+            jacobian.get(0, i) * inv_jacobian.get(j, p) * src.get(0, p);
+      }
+      for (size_t k = 1; k < VolumeDim; ++k) {
+        for (size_t p = 0; p < VolumeDim; ++p) {
+          dest->get(i, j) +=
+              jacobian.get(k, i) * inv_jacobian.get(j, p) * src.get(k, p);
+        }
+      }
+    }
+  }
+}
+
+template <typename DataType, size_t VolumeDim, typename SrcFrame,
+          typename DestFrame>
+auto to_different_frame(
+    const tnsr::iJ<DataType, VolumeDim, SrcFrame>& src,
+    const Jacobian<DataType, VolumeDim, DestFrame, SrcFrame>& jacobian,
+    const InverseJacobian<DataType, VolumeDim, DestFrame, SrcFrame>&
+        inv_jacobian) -> tnsr::iJ<DataType, VolumeDim, DestFrame> {
+  auto dest = make_with_value<tnsr::iJ<DataType, VolumeDim, DestFrame>>(
+      src, std::numeric_limits<double>::signaling_NaN());
+  to_different_frame(make_not_null(&dest), src, jacobian, inv_jacobian);
+  return dest;
+}
+
+template <typename DataType, size_t VolumeDim, typename SrcFrame,
+          typename DestFrame>
+void to_different_frame(
+    const gsl::not_null<tnsr::ii<DataType, VolumeDim, DestFrame>*> dest,
+    const tnsr::ii<DataType, VolumeDim, SrcFrame>& src,
+    const Jacobian<DataType, VolumeDim, DestFrame, SrcFrame>& jacobian,
+    const InverseJacobian<DataType, VolumeDim, DestFrame, SrcFrame>&
+    /*inv_jacobian*/) {
+  to_different_frame(dest, src, jacobian);
+}
+
+template <typename DataType, size_t VolumeDim, typename SrcFrame,
+          typename DestFrame>
+auto to_different_frame(
+    const tnsr::ii<DataType, VolumeDim, SrcFrame>& src,
+    const Jacobian<DataType, VolumeDim, DestFrame, SrcFrame>& jacobian,
+    const InverseJacobian<DataType, VolumeDim, DestFrame, SrcFrame>&
+        inv_jacobian) -> tnsr::ii<DataType, VolumeDim, DestFrame> {
+  auto dest = make_with_value<tnsr::ii<DataType, VolumeDim, DestFrame>>(
+      src, std::numeric_limits<double>::signaling_NaN());
+  to_different_frame(make_not_null(&dest), src, jacobian, inv_jacobian);
+  return dest;
+}
+
+template <typename DataType, size_t VolumeDim, typename SrcFrame,
+          typename DestFrame>
+void to_different_frame(
+    const gsl::not_null<tnsr::II<DataType, VolumeDim, DestFrame>*> dest,
+    const tnsr::II<DataType, VolumeDim, SrcFrame>& src,
+    const Jacobian<DataType, VolumeDim, DestFrame, SrcFrame>& /*jacobian*/,
+    const InverseJacobian<DataType, VolumeDim, DestFrame, SrcFrame>&
+        inv_jacobian) {
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    for (size_t j = i; j < VolumeDim; ++j) {  // symmetry
+      // To avoid initializing to zero, split out k=0 here, and start
+      // k loop below at k=1.
+      dest->get(i, j) =
+          inv_jacobian.get(i, 0) * inv_jacobian.get(j, 0) * src.get(0, 0);
+      for (size_t p = 1; p < VolumeDim; ++p) {
+        dest->get(i, j) +=
+            inv_jacobian.get(i, 0) * inv_jacobian.get(j, p) * src.get(0, p);
+      }
+      for (size_t k = 1; k < VolumeDim; ++k) {
+        for (size_t p = 0; p < VolumeDim; ++p) {
+          dest->get(i, j) +=
+              inv_jacobian.get(i, k) * inv_jacobian.get(j, p) * src.get(k, p);
+        }
+      }
+    }
+  }
+}
+
+template <typename DataType, size_t VolumeDim, typename SrcFrame,
+          typename DestFrame>
+auto to_different_frame(
+    const tnsr::II<DataType, VolumeDim, SrcFrame>& src,
+    const Jacobian<DataType, VolumeDim, DestFrame, SrcFrame>& jacobian,
+    const InverseJacobian<DataType, VolumeDim, DestFrame, SrcFrame>&
+        inv_jacobian) -> tnsr::II<DataType, VolumeDim, DestFrame> {
+  auto dest = make_with_value<tnsr::II<DataType, VolumeDim, DestFrame>>(
+      src, std::numeric_limits<double>::signaling_NaN());
+  to_different_frame(make_not_null(&dest), src, jacobian, inv_jacobian);
+  return dest;
+}
+
+template <typename DataType, size_t VolumeDim, typename SrcFrame,
+          typename DestFrame>
+void to_different_frame(
+    const gsl::not_null<tnsr::ijj<DataType, VolumeDim, DestFrame>*> dest,
+    const tnsr::ijj<DataType, VolumeDim, SrcFrame>& src,
+    const Jacobian<DataType, VolumeDim, DestFrame, SrcFrame>& jacobian,
+    const InverseJacobian<DataType, VolumeDim, DestFrame, SrcFrame>&
+    /*inv_jacobian*/) {
+  for (size_t q = 0; q < VolumeDim; ++q) {
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      for (size_t j = i; j < VolumeDim; ++j) {  // symmetry
+        dest->get(q, i, j) = jacobian.get(0, q) * jacobian.get(0, i) *
+                             jacobian.get(0, j) * src.get(0, 0, 0);
+        for (size_t r = 0; r < VolumeDim; ++r) {
+          for (size_t k = 0; k < VolumeDim; ++k) {
+            for (size_t p = 0; p < VolumeDim; ++p) {
+              if (r == 0 and k == 0 and p == 0) {
+                continue;
+              }
+              dest->get(q, i, j) += jacobian.get(r, q) * jacobian.get(k, i) *
+                                    jacobian.get(p, j) * src.get(r, k, p);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+template <typename DataType, size_t VolumeDim, typename SrcFrame,
+          typename DestFrame>
+auto to_different_frame(
+    const tnsr::ijj<DataType, VolumeDim, SrcFrame>& src,
+    const Jacobian<DataType, VolumeDim, DestFrame, SrcFrame>& jacobian,
+    const InverseJacobian<DataType, VolumeDim, DestFrame, SrcFrame>&
+        inv_jacobian) -> tnsr::ijj<DataType, VolumeDim, DestFrame> {
+  auto dest = make_with_value<tnsr::ijj<DataType, VolumeDim, DestFrame>>(
+      src, std::numeric_limits<double>::signaling_NaN());
+  to_different_frame(make_not_null(&dest), src, jacobian, inv_jacobian);
   return dest;
 }
 
@@ -89,24 +316,79 @@ auto first_index_to_different_frame(
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define SRCFRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define DESTFRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(3, data)
 
-#define INSTANTIATE(_, data)                                                  \
-  template void transform::to_different_frame(                                \
-      const gsl::not_null<tnsr::ii<DataVector, DIM(data), DESTFRAME(data)>*>  \
-          dest,                                                               \
-      const tnsr::ii<DataVector, DIM(data), SRCFRAME(data)>& src,             \
-      const Jacobian<DataVector, DIM(data), DESTFRAME(data), SRCFRAME(data)>& \
-          jacobian);                                                          \
-  template auto transform::to_different_frame(                                \
-      const tnsr::ii<DataVector, DIM(data), SRCFRAME(data)>& src,             \
-      const Jacobian<DataVector, DIM(data), DESTFRAME(data), SRCFRAME(data)>& \
-          jacobian)                                                           \
-      ->tnsr::ii<DataVector, DIM(data), DESTFRAME(data)>;
-GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid),
-                        (Frame::Inertial))
+#define INSTANTIATE(_, data)                                                   \
+  template void transform::to_different_frame(                                 \
+      const gsl::not_null<tnsr::ii<DTYPE(data), DIM(data), DESTFRAME(data)>*>  \
+          dest,                                                                \
+      const tnsr::ii<DTYPE(data), DIM(data), SRCFRAME(data)>& src,             \
+      const Jacobian<DTYPE(data), DIM(data), DESTFRAME(data), SRCFRAME(data)>& \
+          jacobian);                                                           \
+  template auto transform::to_different_frame(                                 \
+      const tnsr::ii<DTYPE(data), DIM(data), SRCFRAME(data)>& src,             \
+      const Jacobian<DTYPE(data), DIM(data), DESTFRAME(data), SRCFRAME(data)>& \
+          jacobian)                                                            \
+      ->tnsr::ii<DTYPE(data), DIM(data), DESTFRAME(data)>;                     \
+  template void transform::to_different_frame(                                 \
+      const gsl::not_null<Scalar<DTYPE(data)>*> dest,                          \
+      const Scalar<DTYPE(data)>& src,                                          \
+      const Jacobian<DTYPE(data), DIM(data), DESTFRAME(data), SRCFRAME(data)>& \
+          jacobian,                                                            \
+      const InverseJacobian<DTYPE(data), DIM(data), DESTFRAME(data),           \
+                            SRCFRAME(data)>& inv_jacobian);                    \
+  template auto transform::to_different_frame(                                 \
+      Scalar<DTYPE(data)> src,                                                 \
+      const Jacobian<DTYPE(data), DIM(data), DESTFRAME(data), SRCFRAME(data)>& \
+          jacobian,                                                            \
+      const InverseJacobian<DTYPE(data), DIM(data), DESTFRAME(data),           \
+                            SRCFRAME(data)>& inv_jacobian)                     \
+      ->Scalar<DTYPE(data)>;
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3),
+                        (Frame::BlockLogical, Frame::ElementLogical,
+                         Frame::Grid),
+                        (Frame::Inertial), (double, DataVector))
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Inertial),
-                        (Frame::Grid))
+                        (Frame::BlockLogical, Frame::ElementLogical,
+                         Frame::Grid),
+                        (double, DataVector))
 #undef INSTANTIATE
+
+#define TENSOR(data) BOOST_PP_TUPLE_ELEM(4, data)
+
+#define INSTANTIATE(_, data)                                                   \
+  template void transform::to_different_frame(                                 \
+      const gsl::not_null<tnsr::TENSOR(data) < DTYPE(data), DIM(data),         \
+                          DESTFRAME(data)>* > dest,                            \
+      const tnsr::TENSOR(data) < DTYPE(data), DIM(data),                       \
+      SRCFRAME(data) > &src,                                                   \
+      const Jacobian<DTYPE(data), DIM(data), DESTFRAME(data), SRCFRAME(data)>& \
+          jacobian,                                                            \
+      const InverseJacobian<DTYPE(data), DIM(data), DESTFRAME(data),           \
+                            SRCFRAME(data)>& inv_jacobian);                    \
+  template auto transform::to_different_frame(                                 \
+      const tnsr::TENSOR(data) < DTYPE(data), DIM(data),                       \
+      SRCFRAME(data) > &src,                                                   \
+      const Jacobian<DTYPE(data), DIM(data), DESTFRAME(data), SRCFRAME(data)>& \
+          jacobian,                                                            \
+      const InverseJacobian<DTYPE(data), DIM(data), DESTFRAME(data),           \
+                            SRCFRAME(data)>& inv_jacobian)                     \
+      ->tnsr::TENSOR(data)<DTYPE(data), DIM(data), DESTFRAME(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3),
+                        (Frame::BlockLogical, Frame::ElementLogical,
+                         Frame::Grid),
+                        (Frame::Inertial), (double, DataVector),
+                        (I, i, iJ, ii, II, ijj))
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Inertial),
+                        (Frame::BlockLogical, Frame::ElementLogical,
+                         Frame::Grid),
+                        (double, DataVector), (I, i, iJ, ii, II, ijj))
+
+#undef INSTANTIATE
+
+#undef TENSOR
+#undef DTYPE
 
 #define INSTANTIATE(_, data)                                                  \
   template void transform::first_index_to_different_frame(                    \
@@ -130,7 +412,8 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Inertial),
       const Jacobian<DataVector, DIM(data), DESTFRAME(data), SRCFRAME(data)>& \
           jacobian)                                                           \
       ->tnsr::ijj<DataVector, DIM(data), DESTFRAME(data)>;
-GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::ElementLogical),
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3),
+                        (Frame::BlockLogical, Frame::ElementLogical),
                         (Frame::Grid))
 
 #undef DIM

--- a/src/PointwiseFunctions/GeneralRelativity/Transform.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Transform.hpp
@@ -32,21 +32,150 @@ namespace transform {
  * Note that `Jacobian<DestFrame,SrcFrame>` is the same type as
  * `InverseJacobian<SrcFrame,DestFrame>` and represents
  * \f$\partial x^i/\partial x^{\bar{\jmath}}\f$.
- *
- * In principle `to_different_frame` can be extended/generalized to
- * other tensor types if needed.
  */
-template <size_t VolumeDim, typename SrcFrame, typename DestFrame>
+template <typename DataType, size_t VolumeDim, typename SrcFrame,
+          typename DestFrame>
 void to_different_frame(
-    const gsl::not_null<tnsr::ii<DataVector, VolumeDim, DestFrame>*> dest,
-    const tnsr::ii<DataVector, VolumeDim, SrcFrame>& src,
-    const Jacobian<DataVector, VolumeDim, DestFrame, SrcFrame>& jacobian);
+    const gsl::not_null<tnsr::ii<DataType, VolumeDim, DestFrame>*> dest,
+    const tnsr::ii<DataType, VolumeDim, SrcFrame>& src,
+    const Jacobian<DataType, VolumeDim, DestFrame, SrcFrame>& jacobian);
 
-template <size_t VolumeDim, typename SrcFrame, typename DestFrame>
+template <typename DataType, size_t VolumeDim, typename SrcFrame,
+          typename DestFrame>
 auto to_different_frame(
-    const tnsr::ii<DataVector, VolumeDim, SrcFrame>& src,
-    const Jacobian<DataVector, VolumeDim, DestFrame, SrcFrame>& jacobian)
-    -> tnsr::ii<DataVector, VolumeDim, DestFrame>;
+    const tnsr::ii<DataType, VolumeDim, SrcFrame>& src,
+    const Jacobian<DataType, VolumeDim, DestFrame, SrcFrame>& jacobian)
+    -> tnsr::ii<DataType, VolumeDim, DestFrame>;
+/// @}
+
+/// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Transforms a tensor to a different frame.
+ *
+ * The tensor being transformed is always assumed to have density zero. In
+ * particular `Scalar` is assumed to be invariant under transformations.
+ *
+ * \warning The \p jacobian argument is the derivative of the *source*
+ * coordinates with respect to the *destination* coordinates.
+ */
+template <typename DataType, size_t VolumeDim, typename SrcFrame,
+          typename DestFrame>
+void to_different_frame(
+    const gsl::not_null<Scalar<DataType>*> dest, const Scalar<DataType>& src,
+    const Jacobian<DataType, VolumeDim, DestFrame, SrcFrame>& jacobian,
+    const InverseJacobian<DataType, VolumeDim, DestFrame, SrcFrame>&
+        inv_jacobian);
+
+template <typename DataType, size_t VolumeDim, typename SrcFrame,
+          typename DestFrame>
+auto to_different_frame(
+    Scalar<DataType> src,
+    const Jacobian<DataType, VolumeDim, DestFrame, SrcFrame>& jacobian,
+    const InverseJacobian<DataType, VolumeDim, DestFrame, SrcFrame>&
+        inv_jacobian) -> Scalar<DataType>;
+
+template <typename DataType, size_t VolumeDim, typename SrcFrame,
+          typename DestFrame>
+void to_different_frame(
+    const gsl::not_null<tnsr::I<DataType, VolumeDim, DestFrame>*> dest,
+    const tnsr::I<DataType, VolumeDim, SrcFrame>& src,
+    const Jacobian<DataType, VolumeDim, DestFrame, SrcFrame>& jacobian,
+    const InverseJacobian<DataType, VolumeDim, DestFrame, SrcFrame>&
+        inv_jacobian);
+
+template <typename DataType, size_t VolumeDim, typename SrcFrame,
+          typename DestFrame>
+auto to_different_frame(
+    const tnsr::I<DataType, VolumeDim, SrcFrame>& src,
+    const Jacobian<DataType, VolumeDim, DestFrame, SrcFrame>& jacobian,
+    const InverseJacobian<DataType, VolumeDim, DestFrame, SrcFrame>&
+        inv_jacobian) -> tnsr::I<DataType, VolumeDim, DestFrame>;
+
+template <typename DataType, size_t VolumeDim, typename SrcFrame,
+          typename DestFrame>
+void to_different_frame(
+    const gsl::not_null<tnsr::i<DataType, VolumeDim, DestFrame>*> dest,
+    const tnsr::i<DataType, VolumeDim, SrcFrame>& src,
+    const Jacobian<DataType, VolumeDim, DestFrame, SrcFrame>& jacobian,
+    const InverseJacobian<DataType, VolumeDim, DestFrame, SrcFrame>&
+        inv_jacobian);
+
+template <typename DataType, size_t VolumeDim, typename SrcFrame,
+          typename DestFrame>
+auto to_different_frame(
+    const tnsr::i<DataType, VolumeDim, SrcFrame>& src,
+    const Jacobian<DataType, VolumeDim, DestFrame, SrcFrame>& jacobian,
+    const InverseJacobian<DataType, VolumeDim, DestFrame, SrcFrame>&
+        inv_jacobian) -> tnsr::i<DataType, VolumeDim, DestFrame>;
+
+template <typename DataType, size_t VolumeDim, typename SrcFrame,
+          typename DestFrame>
+void to_different_frame(
+    const gsl::not_null<tnsr::iJ<DataType, VolumeDim, DestFrame>*> dest,
+    const tnsr::iJ<DataType, VolumeDim, SrcFrame>& src,
+    const Jacobian<DataType, VolumeDim, DestFrame, SrcFrame>& jacobian,
+    const InverseJacobian<DataType, VolumeDim, DestFrame, SrcFrame>&
+        inv_jacobian);
+
+template <typename DataType, size_t VolumeDim, typename SrcFrame,
+          typename DestFrame>
+auto to_different_frame(
+    const tnsr::iJ<DataType, VolumeDim, SrcFrame>& src,
+    const Jacobian<DataType, VolumeDim, DestFrame, SrcFrame>& jacobian,
+    const InverseJacobian<DataType, VolumeDim, DestFrame, SrcFrame>&
+        inv_jacobian) -> tnsr::iJ<DataType, VolumeDim, DestFrame>;
+
+template <typename DataType, size_t VolumeDim, typename SrcFrame,
+          typename DestFrame>
+void to_different_frame(
+    const gsl::not_null<tnsr::ii<DataType, VolumeDim, DestFrame>*> dest,
+    const tnsr::ii<DataType, VolumeDim, SrcFrame>& src,
+    const Jacobian<DataType, VolumeDim, DestFrame, SrcFrame>& jacobian,
+    const InverseJacobian<DataType, VolumeDim, DestFrame, SrcFrame>&
+        inv_jacobian);
+
+template <typename DataType, size_t VolumeDim, typename SrcFrame,
+          typename DestFrame>
+auto to_different_frame(
+    const tnsr::ii<DataType, VolumeDim, SrcFrame>& src,
+    const Jacobian<DataType, VolumeDim, DestFrame, SrcFrame>& jacobian,
+    const InverseJacobian<DataType, VolumeDim, DestFrame, SrcFrame>&
+        inv_jacobian) -> tnsr::ii<DataType, VolumeDim, DestFrame>;
+
+template <typename DataType, size_t VolumeDim, typename SrcFrame,
+          typename DestFrame>
+void to_different_frame(
+    const gsl::not_null<tnsr::II<DataType, VolumeDim, DestFrame>*> dest,
+    const tnsr::II<DataType, VolumeDim, SrcFrame>& src,
+    const Jacobian<DataType, VolumeDim, DestFrame, SrcFrame>& jacobian,
+    const InverseJacobian<DataType, VolumeDim, DestFrame, SrcFrame>&
+        inv_jacobian);
+
+template <typename DataType, size_t VolumeDim, typename SrcFrame,
+          typename DestFrame>
+auto to_different_frame(
+    const tnsr::II<DataType, VolumeDim, SrcFrame>& src,
+    const Jacobian<DataType, VolumeDim, DestFrame, SrcFrame>& jacobian,
+    const InverseJacobian<DataType, VolumeDim, DestFrame, SrcFrame>&
+        inv_jacobian) -> tnsr::II<DataType, VolumeDim, DestFrame>;
+
+template <typename DataType, size_t VolumeDim, typename SrcFrame,
+          typename DestFrame>
+void to_different_frame(
+    const gsl::not_null<tnsr::ijj<DataType, VolumeDim, DestFrame>*> dest,
+    const tnsr::ijj<DataType, VolumeDim, SrcFrame>& src,
+    const Jacobian<DataType, VolumeDim, DestFrame, SrcFrame>& jacobian,
+    const InverseJacobian<DataType, VolumeDim, DestFrame, SrcFrame>&
+        inv_jacobian);
+
+template <typename DataType, size_t VolumeDim, typename SrcFrame,
+          typename DestFrame>
+auto to_different_frame(
+    const tnsr::ijj<DataType, VolumeDim, SrcFrame>& src,
+    const Jacobian<DataType, VolumeDim, DestFrame, SrcFrame>& jacobian,
+    const InverseJacobian<DataType, VolumeDim, DestFrame, SrcFrame>&
+        inv_jacobian) -> tnsr::ijj<DataType, VolumeDim, DestFrame>;
 /// @}
 
 /// @{

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Transform.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Transform.py
@@ -9,6 +9,44 @@ def to_different_frame(src, jacobian):
     return np.einsum("ab,ac,bd", src, jacobian, jacobian)
 
 
+def to_different_frame_Scalar(src, jacobian):
+    # Jacobian here is d^x_src/d^x_dest
+    return src
+
+
+def to_different_frame_I(src, jacobian):
+    # Jacobian here is d^x_src/d^x_dest
+    inv_jacobian = np.linalg.inv(jacobian)
+    return np.einsum("a,ca", src, inv_jacobian)
+
+
+def to_different_frame_i(src, jacobian):
+    # Jacobian here is d^x_src/d^x_dest
+    return np.einsum("a,ac", src, jacobian)
+
+
+def to_different_frame_iJ(src, jacobian):
+    # Jacobian here is d^x_src/d^x_dest
+    inv_jacobian = np.linalg.inv(jacobian)
+    return np.einsum("ab,ac,db", src, jacobian, inv_jacobian)
+
+
+def to_different_frame_ii(src, jacobian):
+    # Jacobian here is d^x_src/d^x_dest
+    return np.einsum("ab,ac,bd", src, jacobian, jacobian)
+
+
+def to_different_frame_II(src, jacobian):
+    # Jacobian here is d^x_src/d^x_dest
+    inv_jacobian = np.linalg.inv(jacobian)
+    return np.einsum("ab,ca,db", src, inv_jacobian, inv_jacobian)
+
+
+def to_different_frame_ijj(src, jacobian):
+    # Jacobian here is d^x_src/d^x_dest
+    return np.einsum("abe,ac,bd,ef", src, jacobian, jacobian, jacobian)
+
+
 def first_index_to_different_frame(src, jacobian):
     # Jacobian here is d^x_src/d^x_dest
     return np.einsum("abc,ad->dbc", src, jacobian)


### PR DESCRIPTION
## Proposed changes

* Add overloads of `to_different_frame()` function for `Scalar`, `tnsr::i`, `tnsr::I`, `tnsr::ii`, `tnsr::iJ`, `tnsr::II`, and `tnsr::ijj` type.
* Add overloads for `double` in addition to DataVector.
* Add more instantiations with different source/target frames.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
