### PR TITLE
Make db::const_item_type public, add observer tags for Jacobians and mesh velocity

### DIFF
--- a/src/DataStructures/DataBox/DataBoxTag.hpp
+++ b/src/DataStructures/DataBox/DataBoxTag.hpp
@@ -119,9 +119,9 @@ struct const_item_type_impl<Tag, TagsList, true> {
   using type = typename db::detail::ConvertToConst<std::decay_t<
       typename db::detail::first_matching_tag<TagsList, Tag>::type>>::type;
 };
+}  // namespace detail
 
 template <typename Tag, typename TagsList>
-using const_item_type = typename const_item_type_impl<Tag, TagsList>::type;
-
-}  // namespace detail
+using const_item_type =
+    typename detail::const_item_type_impl<Tag, TagsList>::type;
 }  // namespace db

--- a/src/Domain/InterfaceHelpers.hpp
+++ b/src/Domain/InterfaceHelpers.hpp
@@ -191,19 +191,17 @@ struct InterfaceApplyImpl<DirectionsTag, tmpl::list<ArgumentTags...>,
                           VolumeTagsList> {
   static constexpr size_t volume_dim = DirectionsTag::volume_dim;
 
-  template <typename InterfaceInvokable, typename DbTagsList,
-            typename... ExtraArgs,
-            Requires<is_apply_callable_v<
-                InterfaceInvokable,
-                db::detail::const_item_type<ArgumentTags, DbTagsList>...,
-                ExtraArgs...>> = nullptr>
+  template <
+      typename InterfaceInvokable, typename DbTagsList, typename... ExtraArgs,
+      Requires<is_apply_callable_v<
+          InterfaceInvokable, db::const_item_type<ArgumentTags, DbTagsList>...,
+          ExtraArgs...>> = nullptr>
   static constexpr auto apply(InterfaceInvokable&& interface_invokable,
                               const db::DataBox<DbTagsList>& box,
                               ExtraArgs&&... extra_args) {
     using interface_return_type =
         std::decay_t<decltype(InterfaceInvokable::apply(
-            std::declval<
-                db::detail::const_item_type<ArgumentTags, DbTagsList>>()...,
+            std::declval<db::const_item_type<ArgumentTags, DbTagsList>>()...,
             std::declval<ExtraArgs&&>()...))>;
     return DispatchInterfaceInvokable<true, interface_return_type,
                                       DirectionsTag, VolumeTagsList,
@@ -212,18 +210,16 @@ struct InterfaceApplyImpl<DirectionsTag, tmpl::list<ArgumentTags...>,
               std::forward<ExtraArgs>(extra_args)...);
   }
 
-  template <typename InterfaceInvokable, typename DbTagsList,
-            typename... ExtraArgs,
-            Requires<not is_apply_callable_v<
-                InterfaceInvokable,
-                db::detail::const_item_type<ArgumentTags, DbTagsList>...,
-                ExtraArgs...>> = nullptr>
+  template <
+      typename InterfaceInvokable, typename DbTagsList, typename... ExtraArgs,
+      Requires<not is_apply_callable_v<
+          InterfaceInvokable, db::const_item_type<ArgumentTags, DbTagsList>...,
+          ExtraArgs...>> = nullptr>
   static constexpr auto apply(InterfaceInvokable&& interface_invokable,
                               const db::DataBox<DbTagsList>& box,
                               ExtraArgs&&... extra_args) {
     using interface_return_type = std::decay_t<decltype(interface_invokable(
-        std::declval<
-            db::detail::const_item_type<ArgumentTags, DbTagsList>>()...,
+        std::declval<db::const_item_type<ArgumentTags, DbTagsList>>()...,
         std::declval<ExtraArgs&&>()...))>;
     return DispatchInterfaceInvokable<false, interface_return_type,
                                       DirectionsTag, VolumeTagsList,

--- a/src/ParallelAlgorithms/Events/Tags.hpp
+++ b/src/ParallelAlgorithms/Events/Tags.hpp
@@ -4,12 +4,14 @@
 #pragma once
 
 #include <cstddef>
+#include <optional>
 #include <string>
 
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Tags.hpp"
+#include "Domain/TagsTimeDependent.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
@@ -66,6 +68,154 @@ struct ObserverCoordinatesCompute : ObserverCoordinates<Dim, Fr>,
       observer_coords->get(i).set_data_ref(
           // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
           make_not_null(&const_cast<DataVector&>(coords.get(i))));
+    }
+  }
+};
+
+/*!
+ * \brief The inverse Jacobian used for observation.
+ *
+ * In methods like DG-FD the mesh and inverse Jacobian change throughout the
+ * simulation, so we need to always grab the right ones.
+ */
+template <size_t Dim, typename SourceFrame, typename TargetFrame>
+struct ObserverInverseJacobian : db::SimpleTag {
+  static std::string name() {
+    return "InverseJacobian(" + get_output(SourceFrame{}) + "," +
+           get_output(TargetFrame{}) + ")";
+  }
+  using type = ::InverseJacobian<DataVector, Dim, SourceFrame, TargetFrame>;
+};
+
+/// \brief Sets the `ObserverInverseJacobian` to `domain::Tags::InverseJacobian`
+///
+/// This is what you would use for a single numerical method simulation. Hybrid
+/// methods will supply their own tags.
+template <size_t Dim, typename SourceFrame, typename TargetFrame>
+struct ObserverInverseJacobianCompute
+    : ObserverInverseJacobian<Dim, SourceFrame, TargetFrame>,
+      db::ComputeTag {
+  using base = ObserverInverseJacobian<Dim, SourceFrame, TargetFrame>;
+  using return_type = typename base::type;
+  using argument_tags = tmpl::list<
+      ::domain::Tags::InverseJacobian<Dim, SourceFrame, TargetFrame>>;
+  static void function(
+      const gsl::not_null<return_type*> observer_inverse_jacobian,
+      const return_type& inverse_jacobian) {
+    for (size_t i = 0; i < inverse_jacobian.size(); ++i) {
+      (*observer_inverse_jacobian)[i].set_data_ref(
+          // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+          make_not_null(&const_cast<DataVector&>(inverse_jacobian[i])));
+    }
+  }
+};
+
+/*!
+ * \brief The Jacobian used for observation.
+ *
+ * In methods like DG-FD the mesh and  Jacobian change throughout the
+ * simulation, so we need to always grab the right ones.
+ */
+template <size_t Dim, typename SourceFrame, typename TargetFrame>
+struct ObserverJacobian : db::SimpleTag {
+  static std::string name() {
+    return "Jacobian(" + get_output(SourceFrame{}) + "," +
+           get_output(TargetFrame{}) + ")";
+  }
+  using type = ::Jacobian<DataVector, Dim, SourceFrame, TargetFrame>;
+};
+
+/// \brief Sets the `ObserverJacobian` to `domain::Tags::Jacobian`
+///
+/// This is what you would use for a single numerical method simulation. Hybrid
+/// methods will supply their own tags.
+template <size_t Dim, typename SourceFrame, typename TargetFrame>
+struct ObserverJacobianCompute
+    : ObserverJacobian<Dim, SourceFrame, TargetFrame>,
+      db::ComputeTag {
+  using base = ObserverJacobian<Dim, SourceFrame, TargetFrame>;
+  using return_type = typename base::type;
+  using argument_tags =
+      tmpl::list<::domain::Tags::Jacobian<Dim, SourceFrame, TargetFrame>>;
+  static void function(const gsl::not_null<return_type*> observer_jacobian,
+                       const return_type& jacobian) {
+    for (size_t i = 0; i < jacobian.size(); ++i) {
+      (*observer_jacobian)[i].set_data_ref(
+          // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+          make_not_null(&const_cast<DataVector&>(jacobian[i])));
+    }
+  }
+};
+
+/*!
+ * \brief The determinant of the inverse Jacobian used for observation.
+ *
+ * In methods like DG-FD the mesh and inverse Jacobian change throughout the
+ * simulation, so we need to always grab the right ones.
+ */
+template <typename SourceFrame, typename TargetFrame>
+struct ObserverDetInvJacobian : db::SimpleTag {
+  static std::string name() {
+    return "DetInvJacobian(" + get_output(SourceFrame{}) + "," +
+           get_output(TargetFrame{}) + ")";
+  }
+  using type = Scalar<DataVector>;
+};
+
+/// \brief Sets the `ObserverDetInvJacobian` to `domain::Tags::DetInvJacobian`
+///
+/// This is what you would use for a single numerical method simulation. Hybrid
+/// methods will supply their own tags.
+template <typename SourceFrame, typename TargetFrame>
+struct ObserverDetInvJacobianCompute
+    : ObserverDetInvJacobian<SourceFrame, TargetFrame>,
+      db::ComputeTag {
+  using base = ObserverDetInvJacobian<SourceFrame, TargetFrame>;
+  using return_type = typename base::type;
+  using argument_tags =
+      tmpl::list<::domain::Tags::DetInvJacobian<SourceFrame, TargetFrame>>;
+  static void function(
+      const gsl::not_null<return_type*> observer_det_inverse_jacobian,
+      const return_type& det_inverse_jacobian) {
+    for (size_t i = 0; i < det_inverse_jacobian.size(); ++i) {
+      (*observer_det_inverse_jacobian)[i].set_data_ref(
+          // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+          make_not_null(&const_cast<DataVector&>(det_inverse_jacobian[i])));
+    }
+  }
+};
+
+/// \brief The mesh velocity used for observations
+///
+/// The type is a `std::optional`, which when it is not set indicates that the
+/// mesh is not moving.
+template <size_t Dim, typename Frame = ::Frame::Inertial>
+struct ObserverMeshVelocity : db::SimpleTag {
+  static std::string name() { return get_output(Frame{}) + "MeshVelocity"; }
+  using type = std::optional<tnsr::I<DataVector, Dim, Frame>>;
+};
+
+/// \brief Sets the `ObserverMeshVelocty` to `domain::Tags::MeshVelocty`
+///
+/// This is what you would use for a single numerical method simulation. Hybrid
+/// methods will supply their own tags.
+template <size_t Dim, typename Frame = ::Frame::Inertial>
+struct ObserverMeshVelocityCompute : ObserverMeshVelocity<Dim, Frame>,
+                                     db::ComputeTag {
+  using base = ObserverMeshVelocity<Dim, Frame>;
+  using return_type = typename base::type;
+  using argument_tags = tmpl::list<::domain::Tags::MeshVelocity<Dim, Frame>>;
+  static void function(const gsl::not_null<return_type*> observer_mesh_velocity,
+                       const return_type& mesh_velocity) {
+    if (mesh_velocity.has_value()) {
+      *observer_mesh_velocity = tnsr::I<DataVector, Dim, Frame>{};
+      for (size_t i = 0; i < mesh_velocity->size(); ++i) {
+        observer_mesh_velocity->value()[i].set_data_ref(
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+            make_not_null(&const_cast<DataVector&>(mesh_velocity.value()[i])));
+      }
+    } else {
+      *observer_mesh_velocity = std::nullopt;
     }
   }
 };

--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -372,63 +372,61 @@ void test_databox() {
         std::make_unique<int>(3));
     using DbTags = decltype(box)::tags_list;
     static_assert(
-        std::is_same_v<
-            db::detail::const_item_type<test_databox_tags::Pointer, DbTags>,
-            const int&>,
+        std::is_same_v<db::const_item_type<test_databox_tags::Pointer, DbTags>,
+                       const int&>,
         "Wrong type for const_item_type on unique_ptr simple item");
     static_assert(
-        std::is_same_v<
-            decltype(db::get<test_databox_tags::Pointer>(box)),
-            db::detail::const_item_type<test_databox_tags::Pointer, DbTags>>,
+        std::is_same_v<decltype(db::get<test_databox_tags::Pointer>(box)),
+                       db::const_item_type<test_databox_tags::Pointer, DbTags>>,
         "Wrong type for get on unique_ptr simple item");
     CHECK(db::get<test_databox_tags::Pointer>(box) == 3);
 
     static_assert(
         std::is_same_v<
-            db::detail::const_item_type<test_databox_tags::PointerBase, DbTags>,
+            db::const_item_type<test_databox_tags::PointerBase, DbTags>,
             const int&>,
         "Wrong type for const_item_type on unique_ptr simple item by base");
     static_assert(
-        std::is_same_v<decltype(db::get<test_databox_tags::PointerBase>(box)),
-                       db::detail::const_item_type<
-                           test_databox_tags::PointerBase, DbTags>>,
+        std::is_same_v<
+            decltype(db::get<test_databox_tags::PointerBase>(box)),
+            db::const_item_type<test_databox_tags::PointerBase, DbTags>>,
         "Wrong type for get on unique_ptr simple item by base");
     CHECK(db::get<test_databox_tags::PointerBase>(box) == 3);
 
     static_assert(
-        std::is_same_v<db::detail::const_item_type<
-                           test_databox_tags::PointerToCounter, DbTags>,
-                       const int&>,
+        std::is_same_v<
+            db::const_item_type<test_databox_tags::PointerToCounter, DbTags>,
+            const int&>,
         "Wrong type for const_item_type on unique_ptr compute item");
     static_assert(
         std::is_same_v<
             decltype(db::get<test_databox_tags::PointerToCounter>(box)),
-            db::detail::const_item_type<test_databox_tags::PointerToCounter,
-                                        DbTags>>,
+            db::const_item_type<test_databox_tags::PointerToCounter, DbTags>>,
         "Wrong type for get on unique_ptr compute item");
     CHECK(db::get<test_databox_tags::PointerToCounter>(box) == 4);
 
     static_assert(
-        std::is_same_v<db::detail::const_item_type<
+        std::is_same_v<db::const_item_type<
                            test_databox_tags::PointerToCounterBase, DbTags>,
                        const int&>,
         "Wrong type for const_item_type on unique_ptr compute item by base");
     static_assert(
         std::is_same_v<
             decltype(db::get<test_databox_tags::PointerToCounterBase>(box)),
-            db::detail::const_item_type<test_databox_tags::PointerToCounterBase,
-                                        DbTags>>,
+            db::const_item_type<test_databox_tags::PointerToCounterBase,
+                                DbTags>>,
         "Wrong type for get on unique_ptr compute item by base");
     CHECK(db::get<test_databox_tags::PointerToCounterBase>(box) == 4);
 
-    static_assert(std::is_same_v<db::detail::const_item_type<
-                                     test_databox_tags::PointerToSum, DbTags>,
-                                 const int&>,
-                  "Wrong type for const_item_type on unique_ptr");
     static_assert(
-        std::is_same_v<decltype(db::get<test_databox_tags::PointerToSum>(box)),
-                       db::detail::const_item_type<
-                           test_databox_tags::PointerToSum, DbTags>>,
+        std::is_same_v<
+            db::const_item_type<test_databox_tags::PointerToSum, DbTags>,
+            const int&>,
+        "Wrong type for const_item_type on unique_ptr");
+    static_assert(
+        std::is_same_v<
+            decltype(db::get<test_databox_tags::PointerToSum>(box)),
+            db::const_item_type<test_databox_tags::PointerToSum, DbTags>>,
         "Wrong type for get on unique_ptr");
     CHECK(db::get<test_databox_tags::PointerToSum>(box) == 8);
   }

--- a/tests/Unit/ParallelAlgorithms/Events/Test_Tags.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_Tags.cpp
@@ -4,6 +4,7 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <cstddef>
+#include <optional>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataVector.hpp"
@@ -20,20 +21,50 @@ template <size_t Dim>
 void test(const Mesh<Dim>& mesh) {
   const tnsr::I<DataVector, Dim, Frame::Grid> grid_coords{5_st, 7.2};
   const tnsr::I<DataVector, Dim, Frame::Inertial> inertial_coords{5_st, 7.2};
+  const InverseJacobian<DataVector, Dim, Frame::ElementLogical, Frame::Inertial>
+      inv_jac{5_st, 9.3};
+  const Jacobian<DataVector, Dim, Frame::ElementLogical, Frame::Inertial> jac{
+      5_st, 10.3};
+  const Scalar<DataVector> det_inv_jac{5_st, 11.3};
+  const tnsr::I<DataVector, Dim, Frame::Inertial> mesh_velocity{5_st, 8.3};
   const auto box = db::create<
-      db::AddSimpleTags<domain::Tags::Mesh<Dim>,
-                        domain::Tags::Coordinates<Dim, Frame::Grid>,
-                        domain::Tags::Coordinates<Dim, Frame::Inertial>>,
+      db::AddSimpleTags<
+          domain::Tags::Mesh<Dim>, domain::Tags::Coordinates<Dim, Frame::Grid>,
+          domain::Tags::Coordinates<Dim, Frame::Inertial>,
+          domain::Tags::InverseJacobian<Dim, Frame::ElementLogical,
+                                        Frame::Inertial>,
+          domain::Tags::Jacobian<Dim, Frame::ElementLogical, Frame::Inertial>,
+          domain::Tags::DetInvJacobian<Frame::ElementLogical, Frame::Inertial>,
+          domain::Tags::MeshVelocity<Dim, Frame::Inertial>>,
       db::AddComputeTags<
           ::Events::Tags::ObserverMeshCompute<Dim>,
           Events::Tags::ObserverCoordinatesCompute<Dim, Frame::Grid>,
-          Events::Tags::ObserverCoordinatesCompute<Dim, Frame::Inertial>>>(
-      mesh, grid_coords, inertial_coords);
+          Events::Tags::ObserverCoordinatesCompute<Dim, Frame::Inertial>,
+          Events::Tags::ObserverInverseJacobianCompute<
+              Dim, Frame::ElementLogical, Frame::Inertial>,
+          Events::Tags::ObserverJacobianCompute<Dim, Frame::ElementLogical,
+                                                Frame::Inertial>,
+          Events::Tags::ObserverDetInvJacobianCompute<Frame::ElementLogical,
+                                                      Frame::Inertial>,
+          Events::Tags::ObserverMeshVelocityCompute<Dim, Frame::Inertial>>>(
+      mesh, grid_coords, inertial_coords, inv_jac, jac, det_inv_jac,
+      std::optional{mesh_velocity});
   CHECK(db::get<Events::Tags::ObserverMesh<Dim>>(box) == mesh);
   CHECK(db::get<Events::Tags::ObserverCoordinates<Dim, Frame::Grid>>(box) ==
         grid_coords);
   CHECK(db::get<Events::Tags::ObserverCoordinates<Dim, Frame::Inertial>>(box) ==
         inertial_coords);
+  CHECK(
+      db::get<Events::Tags::ObserverInverseJacobian<Dim, Frame::ElementLogical,
+                                                    Frame::Inertial>>(box) ==
+      inv_jac);
+  CHECK(db::get<Events::Tags::ObserverJacobian<Dim, Frame::ElementLogical,
+                                               Frame::Inertial>>(box) == jac);
+  CHECK(db::get<Events::Tags::ObserverDetInvJacobian<Frame::ElementLogical,
+                                                     Frame::Inertial>>(box) ==
+        det_inv_jac);
+  CHECK(db::get<Events::Tags::ObserverMeshVelocity<Dim, Frame::Inertial>>(
+            box) == mesh_velocity);
   TestHelpers::db::test_simple_tag<Events::Tags::ObserverMesh<Dim>>(
       "ObserverMesh");
   TestHelpers::db::test_compute_tag<::Events::Tags::ObserverMeshCompute<Dim>>(
@@ -49,6 +80,31 @@ void test(const Mesh<Dim>& mesh) {
   TestHelpers::db::test_compute_tag<
       Events::Tags::ObserverCoordinatesCompute<Dim, Frame::Inertial>>(
       "InertialCoordinates");
+  TestHelpers::db::test_simple_tag<Events::Tags::ObserverInverseJacobian<
+      Dim, Frame::ElementLogical, Frame::Inertial>>(
+      "InverseJacobian(ElementLogical,Inertial)");
+  TestHelpers::db::test_compute_tag<
+      Events::Tags::ObserverInverseJacobianCompute<Dim, Frame::ElementLogical,
+                                                   Frame::Inertial>>(
+      "InverseJacobian(ElementLogical,Inertial)");
+  TestHelpers::db::test_simple_tag<Events::Tags::ObserverJacobian<
+      Dim, Frame::ElementLogical, Frame::Inertial>>(
+      "Jacobian(ElementLogical,Inertial)");
+  TestHelpers::db::test_compute_tag<Events::Tags::ObserverJacobianCompute<
+      Dim, Frame::ElementLogical, Frame::Inertial>>(
+      "Jacobian(ElementLogical,Inertial)");
+  TestHelpers::db::test_simple_tag<Events::Tags::ObserverDetInvJacobian<
+      Frame::ElementLogical, Frame::Inertial>>(
+      "DetInvJacobian(ElementLogical,Inertial)");
+  TestHelpers::db::test_compute_tag<Events::Tags::ObserverDetInvJacobianCompute<
+      Frame::ElementLogical, Frame::Inertial>>(
+      "DetInvJacobian(ElementLogical,Inertial)");
+  TestHelpers::db::test_simple_tag<
+      Events::Tags::ObserverMeshVelocity<Dim, Frame::Inertial>>(
+      "InertialMeshVelocity");
+  TestHelpers::db::test_compute_tag<
+      Events::Tags::ObserverMeshVelocityCompute<Dim, Frame::Inertial>>(
+      "InertialMeshVelocity");
 }
 }  // namespace
 


### PR DESCRIPTION
## Proposed changes

Both are needed for runtime gauge conditions with subcell.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
