### PR TITLE
Have VectorImpl use static allocation for small sizes

### DIFF
--- a/src/DataStructures/DynamicBuffer.hpp
+++ b/src/DataStructures/DynamicBuffer.hpp
@@ -8,7 +8,6 @@
 #include <vector>
 
 #include "DataStructures/DataVector.hpp"
-#include "Utilities/TypeTraits/GetFundamentalType.hpp"
 
 /// \cond
 namespace PUP {
@@ -28,14 +27,14 @@ class er;
  * size of the vector is known at compile time, a `TempBuffer` object should be
  * used instead.
  *
- * If needed it should be fairly straightforward to generalize to
- * `ComplexDataVector`.
+ * Currently this can only be used for `DataVector`s, but if needed, it should
+ * be fairly straightforward to generalize to `ComplexDataVector`.
  */
 template <typename T>
 class DynamicBuffer {
  public:
-  static constexpr bool is_data_vector_type =
-      std::is_base_of_v<VectorImpl<tt::get_fundamental_type_t<T>, T>, T>;
+  // Only vector type supported is DataVector
+  static constexpr bool is_data_vector_type = std::is_same_v<DataVector, T>;
 
   DynamicBuffer() = default;
 

--- a/src/DataStructures/Tensor/Expressions/DataTypeSupport.hpp
+++ b/src/DataStructures/Tensor/Expressions/DataTypeSupport.hpp
@@ -172,22 +172,23 @@ template <typename X>
 struct is_assignable<std::complex<X>, X> : std::true_type {};
 /// Can assign the LHS `VectorImpl` to the RHS `VectorImpl` if `VectorImpl`
 /// allows it
-template <typename ValueType1, typename VectorType1, typename ValueType2,
-          typename VectorType2>
-struct is_assignable<VectorImpl<ValueType1, VectorType1>,
-                     VectorImpl<ValueType2, VectorType2>>
+template <typename ValueType1, typename VectorType1, size_t StaticSize1,
+          typename ValueType2, typename VectorType2, size_t StaticSize2>
+struct is_assignable<VectorImpl<ValueType1, VectorType1, StaticSize1>,
+                     VectorImpl<ValueType2, VectorType2, StaticSize2>>
     : ::VectorImpl_detail::is_assignable<VectorType1, VectorType2> {};
 /// Can assign a `VectorImpl` to its value type, e.g. can assign a `DataVector`
 /// to a `double`
-template <typename ValueType, typename VectorType>
-struct is_assignable<VectorImpl<ValueType, VectorType>, ValueType>
+template <typename ValueType, typename VectorType, size_t StaticSize>
+struct is_assignable<VectorImpl<ValueType, VectorType, StaticSize>, ValueType>
     : std::true_type {};
 /// Can assign a complex-valued `VectorImpl` to its real component's type, e.g.
 /// can assign a `ComplexDataVector` to a `double` because the underlying type
 /// of `ComplexDataVector` is `std::complex<double>`, whose real component is a
 /// `double`
-template <typename ValueType, typename VectorType>
-struct is_assignable<VectorImpl<std::complex<ValueType>, VectorType>, ValueType>
+template <typename ValueType, typename VectorType, size_t StaticSize>
+struct is_assignable<
+    VectorImpl<std::complex<ValueType>, VectorType, StaticSize>, ValueType>
     : std::true_type {};
 
 /// \brief Whether or not a given type is assignable to another within
@@ -230,9 +231,9 @@ struct get_binop_datatype_impl<X, X> {
 /// A binary operation between two `VectorImpl`s of the same type will
 /// yield the shared derived `VectorImpl`, e.g.
 /// `DataVector OP DataVector = DataVector`
-template <typename ValueType, typename VectorType>
-struct get_binop_datatype_impl<VectorImpl<ValueType, VectorType>,
-                               VectorImpl<ValueType, VectorType>> {
+template <typename ValueType, typename VectorType, size_t StaticSize>
+struct get_binop_datatype_impl<VectorImpl<ValueType, VectorType, StaticSize>,
+                               VectorImpl<ValueType, VectorType, StaticSize>> {
   using type = VectorType;
 };
 /// @{
@@ -250,12 +251,14 @@ struct get_binop_datatype_impl<std::complex<T>, T> {
 /// @{
 /// A binary operation between a `VectorImpl` and its underlying value type
 /// yields the `VectorImpl`, e.g. `DataVector OP double = DataVector`
-template <typename ValueType, typename VectorType>
-struct get_binop_datatype_impl<VectorImpl<ValueType, VectorType>, ValueType> {
+template <typename ValueType, typename VectorType, size_t StaticSize>
+struct get_binop_datatype_impl<VectorImpl<ValueType, VectorType, StaticSize>,
+                               ValueType> {
   using type = VectorType;
 };
-template <typename ValueType, typename VectorType>
-struct get_binop_datatype_impl<ValueType, VectorImpl<ValueType, VectorType>> {
+template <typename ValueType, typename VectorType, size_t StaticSize>
+struct get_binop_datatype_impl<ValueType,
+                               VectorImpl<ValueType, VectorType, StaticSize>> {
   using type = VectorType;
 };
 /// @}
@@ -263,14 +266,14 @@ struct get_binop_datatype_impl<ValueType, VectorImpl<ValueType, VectorType>> {
 /// A binary operation between a complex-valued `VectorImpl` and its real
 /// component's type yields the `VectorImpl`, e.g.
 /// `ComplexDataVector OP double = ComplexDataVector`
-template <typename ValueType, typename VectorType>
-struct get_binop_datatype_impl<VectorImpl<std::complex<ValueType>, VectorType>,
-                               ValueType> {
+template <typename ValueType, typename VectorType, size_t StaticSize>
+struct get_binop_datatype_impl<
+    VectorImpl<std::complex<ValueType>, VectorType, StaticSize>, ValueType> {
   using type = VectorType;
 };
-template <typename ValueType, typename VectorType>
+template <typename ValueType, typename VectorType, size_t StaticSize>
 struct get_binop_datatype_impl<
-    ValueType, VectorImpl<std::complex<ValueType>, VectorType>> {
+    ValueType, VectorImpl<std::complex<ValueType>, VectorType, StaticSize>> {
   using type = VectorType;
 };
 /// @}
@@ -289,14 +292,14 @@ struct get_binop_datatype_impl<
 /// disallow this type combination in their class definitions to prevent these
 /// operations. That way, if Blaze support is later added for e.g. division,
 /// we simply need to remove the assert in `Divide` that prevents it.
-template <typename ValueType, typename VectorType>
-struct get_binop_datatype_impl<VectorImpl<ValueType, VectorType>,
+template <typename ValueType, typename VectorType, size_t StaticSize>
+struct get_binop_datatype_impl<VectorImpl<ValueType, VectorType, StaticSize>,
                                std::complex<ValueType>> {
   using type = typename get_complex_datatype<VectorType>::type;
 };
-template <typename ValueType, typename VectorType>
+template <typename ValueType, typename VectorType, size_t StaticSize>
 struct get_binop_datatype_impl<std::complex<ValueType>,
-                               VectorImpl<ValueType, VectorType>> {
+                               VectorImpl<ValueType, VectorType, StaticSize>> {
   using type = typename get_complex_datatype<VectorType>::type;
 };
 /// @}

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -53,7 +53,7 @@ template <typename X, typename Symm, typename IndexList>
 class Tensor;
 template <typename TagsList>
 class Variables;
-template <typename T, typename VectorType>
+template <typename T, typename VectorType, size_t StaticSize>
 class VectorImpl;
 namespace Tags {
 template <typename TagsList>
@@ -376,10 +376,10 @@ class Variables<tmpl::list<Tags...>> {
 
   // Prevent the previous two declarations from implicitly converting
   // DataVectors and similar to Variables.
-  template <typename T, typename VectorType>
-  Variables(const VectorImpl<T, VectorType>&) = delete;
-  template <typename T, typename VectorType>
-  Variables& operator=(const VectorImpl<T, VectorType>&) = delete;
+  template <typename T, typename VectorType, size_t StaticSize>
+  Variables(const VectorImpl<T, VectorType, StaticSize>&) = delete;
+  template <typename T, typename VectorType, size_t StaticSize>
+  Variables& operator=(const VectorImpl<T, VectorType, StaticSize>&) = delete;
 
   template <typename... WrappedTags,
             Requires<tmpl2::flat_all<std::is_same_v<

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -32,6 +32,7 @@ set(LIBRARY_SOURCES
   Test_ModalVectorInhomogeneousOperations.cpp
   Test_MoreComplexDiagonalModalOperatorMath.cpp
   Test_MoreDiagonalModalOperatorMath.cpp
+  Test_NonZeroStaticSizeVector.cpp
   Test_SliceIterator.cpp
   Test_SliceTensorToVariables.cpp
   Test_SliceVariables.cpp

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_DataTypeSupport.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_DataTypeSupport.cpp
@@ -15,6 +15,8 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/ModalVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/VectorImpl.hpp"
+#include "Helpers/DataStructures/CustomStaticSizeVector.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace {
@@ -25,6 +27,9 @@ using number_expression = tenex::NumberAsExpression<ValueType>;
 template <typename ValueType>
 using tensor_expression =
     tenex::TensorAsExpression<Scalar<ValueType>, tmpl::list<>>;
+
+constexpr size_t custom_vector_static_size =
+    CustomComplexStaticSizeVector::static_size;
 
 template <bool Expected, typename DataTypes>
 void test_is_supported_number_datatype() {
@@ -160,6 +165,15 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.DataTypeSupport",
   test_upcast_if_derived_vector_type<
       VectorImpl<std::complex<double>, ComplexModalVector>,
       VectorImpl<std::complex<double>, ComplexModalVector>>();
+  test_upcast_if_derived_vector_type<
+      CustomComplexStaticSizeVector,
+      VectorImpl<std::complex<double>, CustomComplexStaticSizeVector,
+                 custom_vector_static_size>>();
+  test_upcast_if_derived_vector_type<
+      VectorImpl<std::complex<double>, CustomComplexStaticSizeVector,
+                 custom_vector_static_size>,
+      VectorImpl<std::complex<double>, CustomComplexStaticSizeVector,
+                 custom_vector_static_size>>();
   test_upcast_if_derived_vector_type<ArbitraryType, ArbitraryType>();
 
   // Test that we correctly get the complex-valued partner type to another type
@@ -172,6 +186,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.DataTypeSupport",
   test_get_complex_datatype<std::complex<float>, NoSuchType>();
   test_get_complex_datatype<DataVector, ComplexDataVector>();
   test_get_complex_datatype<ComplexDataVector, NoSuchType>();
+  test_get_complex_datatype<CustomComplexStaticSizeVector, NoSuchType>();
   test_get_complex_datatype<ArbitraryType, NoSuchType>();
   test_get_complex_datatype<NoSuchType, NoSuchType>();
 
@@ -230,30 +245,44 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.DataTypeSupport",
   test_is_assignable<double, std::complex<double>>(false);
   test_is_assignable<double, DataVector>(false);
   test_is_assignable<double, ComplexDataVector>(false);
+  test_is_assignable<double, CustomComplexStaticSizeVector>(false);
   test_is_assignable<double, ArbitraryType>(false);
 
   test_is_assignable<std::complex<double>, double>(true);
   test_is_assignable<std::complex<double>, std::complex<double>>(true);
   test_is_assignable<std::complex<double>, DataVector>(false);
   test_is_assignable<std::complex<double>, ComplexDataVector>(false);
+  test_is_assignable<std::complex<double>, CustomComplexStaticSizeVector>(
+      false);
   test_is_assignable<std::complex<double>, ArbitraryType>(false);
 
   test_is_assignable<DataVector, double>(true);
   test_is_assignable<DataVector, std::complex<double>>(false);
   test_is_assignable<DataVector, DataVector>(true);
   test_is_assignable<DataVector, ComplexDataVector>(false);
+  test_is_assignable<DataVector, CustomComplexStaticSizeVector>(false);
   test_is_assignable<DataVector, ArbitraryType>(false);
 
   test_is_assignable<ComplexDataVector, double>(true);
   test_is_assignable<ComplexDataVector, std::complex<double>>(true);
   test_is_assignable<ComplexDataVector, DataVector>(true);
   test_is_assignable<ComplexDataVector, ComplexDataVector>(true);
+  test_is_assignable<ComplexDataVector, CustomComplexStaticSizeVector>(false);
   test_is_assignable<ComplexDataVector, ArbitraryType>(false);
+
+  test_is_assignable<CustomComplexStaticSizeVector, double>(true);
+  test_is_assignable<CustomComplexStaticSizeVector, std::complex<double>>(true);
+  test_is_assignable<CustomComplexStaticSizeVector, DataVector>(false);
+  test_is_assignable<CustomComplexStaticSizeVector, ComplexDataVector>(false);
+  test_is_assignable<CustomComplexStaticSizeVector,
+                     CustomComplexStaticSizeVector>(true);
+  test_is_assignable<CustomComplexStaticSizeVector, ArbitraryType>(false);
 
   test_is_assignable<ArbitraryType, double>(false);
   test_is_assignable<ArbitraryType, std::complex<double>>(false);
   test_is_assignable<ArbitraryType, DataVector>(false);
   test_is_assignable<ArbitraryType, ComplexDataVector>(false);
+  test_is_assignable<ArbitraryType, CustomComplexStaticSizeVector>(false);
   // true because is_assignable does not check if the types are supported types
   test_is_assignable<ArbitraryType, ArbitraryType>(true);
 
@@ -265,6 +294,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.DataTypeSupport",
                               std::complex<double>>();
   test_binop_datatype_support<double, DataVector, DataVector>();
   test_binop_datatype_support<double, ComplexDataVector, ComplexDataVector>();
+  test_binop_datatype_support<double, CustomComplexStaticSizeVector,
+                              CustomComplexStaticSizeVector>();
   test_binop_datatype_support<double, ArbitraryType, NoSuchType>();
   test_binop_datatype_support<double, NoSuchType, NoSuchType>();
 
@@ -276,6 +307,9 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.DataTypeSupport",
                               ComplexDataVector>();
   test_binop_datatype_support<std::complex<double>, ComplexDataVector,
                               ComplexDataVector>();
+  test_binop_datatype_support<std::complex<double>,
+                              CustomComplexStaticSizeVector,
+                              CustomComplexStaticSizeVector>();
   test_binop_datatype_support<std::complex<double>, ArbitraryType,
                               NoSuchType>();
   test_binop_datatype_support<std::complex<double>, NoSuchType, NoSuchType>();
@@ -286,6 +320,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.DataTypeSupport",
   test_binop_datatype_support<DataVector, DataVector, DataVector>();
   test_binop_datatype_support<DataVector, ComplexDataVector,
                               ComplexDataVector>();
+  test_binop_datatype_support<DataVector, CustomComplexStaticSizeVector,
+                              NoSuchType>();
   test_binop_datatype_support<DataVector, ArbitraryType, NoSuchType>();
   test_binop_datatype_support<DataVector, NoSuchType, NoSuchType>();
 
@@ -296,14 +332,35 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.DataTypeSupport",
                               ComplexDataVector>();
   test_binop_datatype_support<ComplexDataVector, ComplexDataVector,
                               ComplexDataVector>();
+  test_binop_datatype_support<ComplexDataVector, CustomComplexStaticSizeVector,
+                              NoSuchType>();
   test_binop_datatype_support<ComplexDataVector, ArbitraryType, NoSuchType>();
   test_binop_datatype_support<ComplexDataVector, NoSuchType, NoSuchType>();
+
+  test_binop_datatype_support<CustomComplexStaticSizeVector, double,
+                              CustomComplexStaticSizeVector>();
+  test_binop_datatype_support<CustomComplexStaticSizeVector,
+                              std::complex<double>,
+                              CustomComplexStaticSizeVector>();
+  test_binop_datatype_support<CustomComplexStaticSizeVector, DataVector,
+                              NoSuchType>();
+  test_binop_datatype_support<CustomComplexStaticSizeVector, ComplexDataVector,
+                              NoSuchType>();
+  test_binop_datatype_support<CustomComplexStaticSizeVector, ArbitraryType,
+                              NoSuchType>();
+  test_binop_datatype_support<CustomComplexStaticSizeVector,
+                              CustomComplexStaticSizeVector,
+                              CustomComplexStaticSizeVector>();
+  test_binop_datatype_support<CustomComplexStaticSizeVector, NoSuchType,
+                              NoSuchType>();
 
   test_binop_datatype_support<ArbitraryType, double, NoSuchType>();
   test_binop_datatype_support<ArbitraryType, std::complex<double>,
                               NoSuchType>();
   test_binop_datatype_support<ArbitraryType, DataVector, NoSuchType>();
   test_binop_datatype_support<ArbitraryType, ComplexDataVector, NoSuchType>();
+  test_binop_datatype_support<ArbitraryType, CustomComplexStaticSizeVector,
+                              NoSuchType>();
   // ArbitraryType is result because get_binop_datatype_impl does not check if
   // the types are supported types
   test_binop_datatype_support<ArbitraryType, ArbitraryType, ArbitraryType>();
@@ -314,6 +371,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.DataTypeSupport",
   test_binop_datatype_support<NoSuchType, DataVector, NoSuchType>();
   test_binop_datatype_support<NoSuchType, ComplexDataVector, NoSuchType>();
   test_binop_datatype_support<NoSuchType, ArbitraryType, NoSuchType>();
+  test_binop_datatype_support<NoSuchType, CustomComplexStaticSizeVector,
+                              NoSuchType>();
   test_binop_datatype_support<NoSuchType, NoSuchType, NoSuchType>();
 
   // Test whether binary operations can be performed between two `Tensor`s with

--- a/tests/Unit/DataStructures/Test_NonZeroStaticSizeVector.cpp
+++ b/tests/Unit/DataStructures/Test_NonZeroStaticSizeVector.cpp
@@ -1,0 +1,185 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <complex>
+#include <tuple>
+
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/CustomStaticSizeVector.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/DataStructures/VectorImplTestHelper.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Math.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+namespace {
+void test_vector_unary_math() {
+  const TestHelpers::VectorImpl::Bound generic{{-100.0, 100.0}};
+  const TestHelpers::VectorImpl::Bound mone_one{{-1.0, 1.0}};
+  const TestHelpers::VectorImpl::Bound gt_one{{1.0, 100.0}};
+  const TestHelpers::VectorImpl::Bound positive{{0.01, 100.0}};
+  const auto unary_ops = std::make_tuple(
+      std::make_tuple(funcl::Abs<>{}, std::make_tuple(generic)),
+      std::make_tuple(funcl::Acos<>{}, std::make_tuple(mone_one)),
+      std::make_tuple(funcl::Acosh<>{}, std::make_tuple(gt_one)),
+      std::make_tuple(funcl::Asin<>{}, std::make_tuple(mone_one)),
+      std::make_tuple(funcl::Asinh<>{}, std::make_tuple(generic)),
+      std::make_tuple(funcl::Atan<>{}, std::make_tuple(generic)),
+      std::make_tuple(funcl::Atanh<>{}, std::make_tuple(mone_one)),
+      std::make_tuple(funcl::Cbrt<>{}, std::make_tuple(generic)),
+      std::make_tuple(funcl::Cos<>{}, std::make_tuple(generic)),
+      std::make_tuple(funcl::Cosh<>{}, std::make_tuple(generic)),
+      std::make_tuple(funcl::Erf<>{}, std::make_tuple(generic)),
+      std::make_tuple(funcl::Exp<>{}, std::make_tuple(generic)),
+      std::make_tuple(funcl::Exp2<>{}, std::make_tuple(generic)),
+      std::make_tuple(funcl::Fabs<>{}, std::make_tuple(generic)),
+      std::make_tuple(funcl::InvCbrt<>{}, std::make_tuple(generic)),
+      std::make_tuple(funcl::InvSqrt<>{}, std::make_tuple(positive)),
+      std::make_tuple(funcl::Log<>{}, std::make_tuple(positive)),
+      std::make_tuple(funcl::Log10<>{}, std::make_tuple(positive)),
+      std::make_tuple(funcl::Log2<>{}, std::make_tuple(positive)),
+      std::make_tuple(funcl::Sin<>{}, std::make_tuple(generic)),
+      std::make_tuple(funcl::Sinh<>{}, std::make_tuple(generic)),
+      std::make_tuple(funcl::StepFunction<>{}, std::make_tuple(generic)),
+      std::make_tuple(funcl::Square<>{}, std::make_tuple(generic)),
+      std::make_tuple(funcl::Sqrt<>{}, std::make_tuple(positive)),
+      std::make_tuple(funcl::Tan<>{}, std::make_tuple(generic)),
+      std::make_tuple(funcl::Tanh<>{}, std::make_tuple(generic)),
+      std::make_tuple(funcl::UnaryPow<1>{}, std::make_tuple(generic)),
+      std::make_tuple(funcl::UnaryPow<-2>{}, std::make_tuple(generic)),
+      std::make_tuple(funcl::UnaryPow<3>{}, std::make_tuple(generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Normal, CustomStaticSizeVector>(
+      unary_ops);
+}
+
+void test_asserts() {
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(
+      ([]() {
+        TestHelpers::VectorImpl::vector_ref_test_size_error<
+            CustomStaticSizeVector>(
+            TestHelpers::VectorImpl::RefSizeErrorTestKind::ExpressionAssign);
+      }()),
+      Catch::Contains("Must copy into same size"));
+
+  CHECK_THROWS_WITH(([]() {
+                      TestHelpers::VectorImpl::vector_ref_test_size_error<
+                          CustomStaticSizeVector>(
+                          TestHelpers::VectorImpl::RefSizeErrorTestKind::Copy);
+                    }()),
+                    Catch::Contains("Must copy into same size"));
+
+  CHECK_THROWS_WITH(([]() {
+                      TestHelpers::VectorImpl::vector_ref_test_size_error<
+                          CustomStaticSizeVector>(
+                          TestHelpers::VectorImpl::RefSizeErrorTestKind::Move);
+                    }()),
+                    Catch::Contains("Must copy into same size"));
+#endif
+}
+
+void test_vector_multiple_operand_math() {
+  const TestHelpers::VectorImpl::Bound generic{{-10.0, 10.0}};
+  const TestHelpers::VectorImpl::Bound positive{{0.1, 10.0}};
+
+  const auto binary_ops = std::make_tuple(
+      std::make_tuple(funcl::Divides<>{}, std::make_tuple(generic, positive)),
+      std::make_tuple(funcl::Minus<>{}, std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::Multiplies<>{}, std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::Plus<>{}, std::make_tuple(generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Normal, CustomStaticSizeVector>(
+      binary_ops);
+
+  const auto inplace_binary_ops = std::make_tuple(
+      std::make_tuple(funcl::DivAssign<>{}, std::make_tuple(generic, positive)),
+      std::make_tuple(funcl::MinusAssign<>{},
+                      std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::MultAssign<>{}, std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::PlusAssign<>{},
+                      std::make_tuple(generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Inplace, CustomStaticSizeVector>(
+      inplace_binary_ops);
+
+  const auto strict_binary_ops = std::make_tuple(
+      std::make_tuple(funcl::Atan2<>{}, std::make_tuple(generic, positive)),
+      std::make_tuple(funcl::Hypot<>{}, std::make_tuple(generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Strict, CustomStaticSizeVector>(
+      strict_binary_ops);
+
+  const auto cascaded_ops = std::make_tuple(
+      std::make_tuple(funcl::Multiplies<funcl::Plus<>, funcl::Identity>{},
+                      std::make_tuple(generic, generic, generic)),
+      std::make_tuple(funcl::Multiplies<funcl::Exp<>, funcl::Sin<>>{},
+                      std::make_tuple(generic, generic)),
+      std::make_tuple(
+          funcl::Plus<funcl::Atan<funcl::Tan<>>, funcl::Divides<>>{},
+          std::make_tuple(generic, generic, positive)),
+      // step function with multiplication should be tested due to resolved
+      // [issue 1122](https://github.com/sxs-collaboration/spectre/issues/1122)
+      std::make_tuple(funcl::StepFunction<
+                          funcl::Plus<funcl::Multiplies<>, funcl::Identity>>{},
+                      std::make_tuple(generic, generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Strict, CustomStaticSizeVector>(
+      cascaded_ops);
+
+  const auto array_binary_ops = std::make_tuple(
+      std::make_tuple(funcl::Minus<>{}, std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::Plus<>{}, std::make_tuple(generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Strict,
+      std::array<CustomStaticSizeVector, 2>>(array_binary_ops);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DataStructures.NonZeroStaticSizeVector",
+                  "[DataStructures][Unit]") {
+  {
+    INFO("test construct and assign");
+    TestHelpers::VectorImpl::vector_test_construct_and_assign<
+        CustomStaticSizeVector, double>();
+  }
+  {
+    INFO("test serialize and deserialize");
+    TestHelpers::VectorImpl::vector_test_serialize<CustomStaticSizeVector,
+                                                   double>();
+  }
+  {
+    INFO("test set_data_ref functionality");
+    TestHelpers::VectorImpl::vector_test_ref<CustomStaticSizeVector, double>();
+  }
+  {
+    INFO("test math after move");
+    TestHelpers::VectorImpl::vector_test_math_after_move<CustomStaticSizeVector,
+                                                         double>();
+  }
+  {
+    INFO("test CustomStaticSizeVector math operations");
+    test_vector_unary_math();
+  }
+  {
+    INFO("test asserts of CustomStaticSizeVectors");
+    test_asserts();
+  }
+  {
+    INFO("test CustomStaticSizeVectors multiple operand math");
+    test_vector_multiple_operand_math();
+  }
+}

--- a/tests/Unit/Helpers/DataStructures/CustomStaticSizeVector.hpp
+++ b/tests/Unit/Helpers/DataStructures/CustomStaticSizeVector.hpp
@@ -1,0 +1,79 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <complex>
+
+#include "DataStructures/VectorImpl.hpp"
+
+// A VectorImpl whose static size limit is different than the default value
+class CustomStaticSizeVector;
+namespace blaze {
+DECLARE_GENERAL_VECTOR_BLAZE_TRAITS(CustomStaticSizeVector);
+}  // namespace blaze
+class CustomStaticSizeVector
+    : public VectorImpl<double, CustomStaticSizeVector, 3> {
+ public:
+  CustomStaticSizeVector() = default;
+  CustomStaticSizeVector(const CustomStaticSizeVector&) = default;
+  CustomStaticSizeVector(CustomStaticSizeVector&&) = default;
+  CustomStaticSizeVector& operator=(const CustomStaticSizeVector&) = default;
+  CustomStaticSizeVector& operator=(CustomStaticSizeVector&&) = default;
+  ~CustomStaticSizeVector() = default;
+
+  using BaseType = VectorImpl<double, CustomStaticSizeVector, static_size>;
+
+  using BaseType::operator=;
+  using BaseType::VectorImpl;
+};
+
+namespace blaze {
+VECTOR_BLAZE_TRAIT_SPECIALIZE_ARITHMETIC_TRAITS(CustomStaticSizeVector);
+VECTOR_BLAZE_TRAIT_SPECIALIZE_ALL_MAP_TRAITS(CustomStaticSizeVector);
+}  // namespace blaze
+
+SPECTRE_ALWAYS_INLINE auto fabs(const CustomStaticSizeVector& t) {
+  return abs(*t);
+}
+
+MAKE_STD_ARRAY_VECTOR_BINOPS(CustomStaticSizeVector)
+
+MAKE_WITH_VALUE_IMPL_DEFINITION_FOR(CustomStaticSizeVector)
+
+class CustomComplexStaticSizeVector;
+namespace blaze {
+DECLARE_GENERAL_VECTOR_BLAZE_TRAITS(CustomComplexStaticSizeVector);
+}  // namespace blaze
+class CustomComplexStaticSizeVector
+    : public VectorImpl<std::complex<double>, CustomComplexStaticSizeVector,
+                        3> {
+ public:
+  CustomComplexStaticSizeVector() = default;
+  CustomComplexStaticSizeVector(const CustomComplexStaticSizeVector&) = default;
+  CustomComplexStaticSizeVector(CustomComplexStaticSizeVector&&) = default;
+  CustomComplexStaticSizeVector& operator=(
+      const CustomComplexStaticSizeVector&) = default;
+  CustomComplexStaticSizeVector& operator=(CustomComplexStaticSizeVector&&) =
+      default;
+  ~CustomComplexStaticSizeVector() = default;
+
+  using BaseType = VectorImpl<std::complex<double>,
+                              CustomComplexStaticSizeVector, static_size>;
+
+  using BaseType::operator=;
+  using BaseType::VectorImpl;
+};
+
+namespace blaze {
+VECTOR_BLAZE_TRAIT_SPECIALIZE_ARITHMETIC_TRAITS(CustomComplexStaticSizeVector);
+VECTOR_BLAZE_TRAIT_SPECIALIZE_ALL_MAP_TRAITS(CustomComplexStaticSizeVector);
+}  // namespace blaze
+
+SPECTRE_ALWAYS_INLINE auto fabs(const CustomComplexStaticSizeVector& t) {
+  return abs(*t);
+}
+
+MAKE_STD_ARRAY_VECTOR_BINOPS(CustomComplexStaticSizeVector)
+
+MAKE_WITH_VALUE_IMPL_DEFINITION_FOR(CustomComplexStaticSizeVector)


### PR DESCRIPTION
## Proposed changes

Note to reviewers: The test is mostly whitespace changes, so hiding whitespace changes may be useful.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
