### PR TITLE
Fix unsigned-integer bug in FastFlow.

### DIFF
--- a/src/ApparentHorizons/FastFlow.cpp
+++ b/src/ApparentHorizons/FastFlow.cpp
@@ -234,7 +234,7 @@ FastFlow::iterate_horizon_finder(
 
   // Treat the case in which residual_mesh_norm is increasing
   if (residual_mesh_norm > divergence_tol_ * min_residual_mesh_norm_ and
-      iter_at_min_residual_mesh_norm_ <= current_iter_ - divergence_iter_) {
+      iter_at_min_residual_mesh_norm_ + divergence_iter_ <= current_iter_) {
     // clang-tidy: std::move of trivially-copyable type
     return std::make_pair(Status::DivergenceError,
                           std::move(iter_info));  // NOLINT


### PR DESCRIPTION
Previously it did the wrong thing when
current_iter_ < divergence_iter_ because of
unsigned-integer underflow.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
