### PR TITLE
Limit step size to foft expiration times in BBH runs with global timestepping

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -117,6 +117,7 @@
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
 #include "Time/Actions/ChangeSlabSize.hpp"
+#include "Time/Actions/LimitTimeStepToExpirationTimes.hpp"
 #include "Time/Actions/RecordTimeStepperData.hpp"
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/Actions/UpdateU.hpp"
@@ -383,7 +384,7 @@ struct EvolutionMetavars {
                   EvolutionMetavars>,
               Actions::RecordTimeStepperData<>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
-              Actions::UpdateU<>>>,
+              Actions::LimitTimeStepToExpirationTimes, Actions::UpdateU<>>>,
       dg::Actions::Filter<
           Filters::Exponential<0>,
           tmpl::list<

--- a/src/Time/Actions/CMakeLists.txt
+++ b/src/Time/Actions/CMakeLists.txt
@@ -14,6 +14,7 @@ spectre_target_headers(
   AdvanceTime.hpp
   ChangeSlabSize.hpp
   ChangeStepSize.hpp
+  LimitTimeStepToExpirationTimes.hpp
   RecordTimeStepperData.hpp
   SelfStartActions.hpp
   UpdateU.hpp

--- a/src/Time/Actions/LimitTimeStepToExpirationTimes.hpp
+++ b/src/Time/Actions/LimitTimeStepToExpirationTimes.hpp
@@ -1,0 +1,175 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines action AdvanceTime
+
+#pragma once
+
+#include <cmath>
+#include <iomanip>
+#include <limits>
+#include <optional>
+#include <tuple>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Parallel/AlgorithmExecution.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Time/Tags.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Time/Utilities.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/FractionUtilities.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+#include "Evolution/EventsAndDenseTriggers/Tags.hpp"
+#include "Parallel/Printf.hpp"
+#include "Time/Tags.hpp"
+
+/// \cond
+namespace Parallel {
+template <typename Metavariables>
+class GlobalCache;
+}  // namespace Parallel
+namespace Tags {
+template <typename Tag>
+struct Next;
+}  // namespace Tags
+// IWYU pragma: no_forward_declare db::DataBox
+/// \endcond
+
+namespace Actions {
+/// \ingroup ActionsGroup
+/// \ingroup TimeGroup
+/// \brief Make sure step size does not exceed FunctionOfTime expiration times
+///
+/// \details For time steppers with substeps, functions of time might expire
+/// at a time earlier than one of the substeps; however, the functions of time
+/// are both needed at each substep and updated only after taking a full step.
+/// This can result in quiescence, i.e., in waiting to complete the next
+/// substep until the functions of time are updated, but the functions of time
+/// will only be updated after the next step is taken. To avoid this situation,
+/// at the start of each full step, this action checks whether the current
+/// step size exceeds the time remaining before the first function of time
+/// expires. If it does, then the step size is adjusted to be earlier than
+/// the expiration time of the next function of time to expire. Note that
+/// if the time stepper does not use substeps, this action does nothing.
+///
+/// Uses:
+/// - DataBox:
+///   - Tags::Time
+///   - Tags::TimeStep
+///   - Tags::TimeStepId
+///   - Tags::TimeStepper<>
+///   - domain::Tags::FunctionsOfTime
+///
+/// DataBox changes:
+/// - Adds: nothing
+/// - Removes: nothing
+/// - Modifies:
+///   - Tags::TimeStep
+struct LimitTimeStepToExpirationTimes {
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTags>& box, tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/, ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {  // NOLINT const
+    // First, check whether the time stepper uses substeps
+    const TimeStepper& time_stepper = db::get<Tags::TimeStepper<>>(box);
+    if (time_stepper.number_of_substeps() > 0) {
+      // Next, check if the current time step is at the beginning of a full step
+      const auto& time_step_id = db::get<Tags::TimeStepId>(box);
+      if (time_step_id.substep() == 0) {
+        // Get the functions of time and, if not empty, loop over them,
+        // finding the minimum expiration time
+        const auto& functions_of_time =
+            get<domain::Tags::FunctionsOfTime>(cache);
+        if (not functions_of_time.empty()) {
+          double min_expiration_time{std::numeric_limits<double>::max()};
+          for (const auto& [name, f_of_t] : functions_of_time) {
+            if (f_of_t->time_bounds()[1] < min_expiration_time) {
+              min_expiration_time = f_of_t->time_bounds()[1];
+            }
+          }
+
+          ASSERT(db::get<Tags::Time>(box) <= min_expiration_time,
+                 "Time (" << std::setprecision(20) << db::get<Tags::Time>(box)
+                          << ") is greater than expiration time ("
+                          << min_expiration_time << ") by an amount of "
+                          << db::get<Tags::Time>(box) - min_expiration_time);
+          if (db::get<Tags::Time>(box) == min_expiration_time) {
+            return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+          }
+
+          const auto& initial_time_step{db::get<Tags::TimeStep>(box)};
+          const double step_end =
+              (time_step_id.step_time() + initial_time_step).value();
+          if (time_step_id.step_time().value() +
+                  2.0 * initial_time_step.value() <=
+              min_expiration_time) {
+            // The expiration times are far in the future (more than
+            // two steps).  No need to adjust anything.
+            return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+          }
+
+          const double start{initial_time_step.slab().start().value()};
+          Slab new_slab{};
+          if (step_end + slab_rounding_error(time_step_id.step_time()) >=
+              min_expiration_time) {
+            // The minimum expiration time is within the next step (or
+            // within roundoff).  Step to it.
+            new_slab = Slab(start, min_expiration_time);
+          } else {
+            // The minimum expiration time is not within the next
+            // step, but is within two steps.  Shrink the step size to
+            // avoid taking a tiny step after this one.
+
+            // new_slab = initial_time_step.slab().with_duration_to_end(
+            //     0.51 * (min_expiration_time - start));
+            // Note: 0.51 instead of 0.5 to guarantee no roundoff affecting
+            // what happens on the next step.
+            new_slab = Slab(start, 0.51 * min_expiration_time + 0.49 * start);
+          }
+
+          ASSERT(initial_time_step.fraction() == 1,
+                 "This action does not currently support local time stepping, "
+                 "but the time step fraction is "
+                     << initial_time_step.fraction() << " instead of 1");
+          const TimeDelta new_time_step = new_slab.duration();
+          const TimeStepId new_time_step_id{
+              time_step_id.time_runs_forward(), time_step_id.slab_number(),
+              time_step_id.step_time().with_slab(new_slab)};
+          const TimeStepId new_next_time_step_id =
+              time_stepper.next_time_id(new_time_step_id, new_time_step);
+          const TimeDelta new_next_time_step{
+              new_next_time_step_id.step_time().slab(),
+              initial_time_step.fraction()};
+
+          db::mutate<::Tags::TimeStep, ::Tags::Next<::Tags::TimeStep>,
+                     ::Tags::TimeStepId, ::Tags::Next<::Tags::TimeStepId>>(
+              make_not_null(&box),
+              [&new_time_step, &new_next_time_step, &new_time_step_id,
+               &new_next_time_step_id](
+                  const gsl::not_null<TimeDelta*> time_step,
+                  const gsl::not_null<TimeDelta*> next_time_step,
+                  const gsl::not_null<TimeStepId*> time_step_id,
+                  const gsl::not_null<TimeStepId*> next_time_step_id) {
+                *time_step = new_time_step;
+                *next_time_step = new_next_time_step;
+                *time_step_id = new_time_step_id;
+                *next_time_step_id = new_next_time_step_id;
+              });
+        }
+      }
+    }
+    return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+  }
+};
+}  // namespace Actions

--- a/tests/Unit/Time/Actions/CMakeLists.txt
+++ b/tests/Unit/Time/Actions/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY_SOURCES
   Actions/Test_AdvanceTime.cpp
   Actions/Test_ChangeSlabSize.cpp
   Actions/Test_ChangeStepSize.cpp
+  Actions/Test_LimitTimeStepToExpirationTimes.cpp
   Actions/Test_RecordTimeStepperData.cpp
   Actions/Test_SelfStartActions.cpp
   Actions/Test_UpdateU.cpp

--- a/tests/Unit/Time/Actions/Test_LimitTimeStepToExpirationTimes.cpp
+++ b/tests/Unit/Time/Actions/Test_LimitTimeStepToExpirationTimes.cpp
@@ -1,0 +1,175 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <memory>
+#include <random>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "Time/Actions/LimitTimeStepToExpirationTimes.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Tags.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Time/TimeSteppers/DormandPrince5.hpp"
+#include "Time/TimeSteppers/RungeKutta4.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+class TimeStepper;
+
+namespace {
+template <typename Metavariables>
+struct Component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using const_global_cache_tags = tmpl::list<Tags::TimeStepper<TimeStepper>>;
+  using mutable_global_cache_tags =
+      tmpl::list<domain::Tags::FunctionsOfTimeInitialize>;
+
+  using simple_tags = db::AddSimpleTags<Tags::TimeStepId, Tags::TimeStep,
+                                        Tags::Time, Tags::Next<Tags::TimeStep>,
+                                        Tags::Next<Tags::TimeStepId>>;
+
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<
+                     Parallel::Phase::Initialization,
+                     tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
+                 Parallel::PhaseActions<
+                     Parallel::Phase::Testing,
+                     tmpl::list<Actions::LimitTimeStepToExpirationTimes>>>;
+};
+
+struct Metavariables {
+  using component_list = tmpl::list<Component<Metavariables>>;
+};
+
+template <typename TimeStepper>
+void check(const Time& start, const Time& end, const TimeDelta& time_step) {
+  MAKE_GENERATOR(generator);
+  const double eps = 1.e-10;
+  std::uniform_real_distribution<double> expiration_times_before_next_time_dist{
+      start.value() + eps, start.value() + time_step.value() - eps};
+  std::uniform_real_distribution<double> expiration_times_after_next_time_dist{
+      start.value() + time_step.value() + eps, end.value() - eps};
+  const std::array<double, 2> before_expiration_times =
+      make_with_random_values<std::array<double, 2>>(
+          make_not_null(&generator), expiration_times_before_next_time_dist,
+          std::array<double, 2>{});
+  const std::array<double, 1> after_expiration_times =
+      make_with_random_values<std::array<double, 1>>(
+          make_not_null(&generator), expiration_times_after_next_time_dist,
+          std::array<double, 1>{});
+  const double min_expiration_time{*std::min_element(
+      before_expiration_times.begin(), before_expiration_times.end())};
+
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time{};
+  std::array<DataVector, 4> initial_expansion{
+      {{{1.0}}, {{0.2}}, {{0.03}}, {{0.004}}}};
+  std::array<DataVector, 4> initial_unity{{{{1.0}}, {{0.0}}, {{0.0}}, {{0.0}}}};
+  const std::array<DataVector, 4> initial_rotation{{{3, 0.0},
+                                                    {{0.0, 0.0, -0.1}},
+                                                    {{0.0, 0.0, -0.02}},
+                                                    {{0.0, 0.0, -0.003}}}};
+  const std::array<DataVector, 1> initial_quaternion{{{1.0, 0.0, 0.0, 0.0}}};
+  functions_of_time.insert(
+      {"CubicScaleA",
+       std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<3>>(
+           start.value(), initial_expansion, before_expiration_times[0])});
+  functions_of_time.insert(
+      {"CubicScaleB",
+       std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<3>>(
+           start.value(), initial_unity, after_expiration_times[0])});
+  functions_of_time.insert(
+      {"Rotation",
+       std::make_unique<domain::FunctionsOfTime::QuaternionFunctionOfTime<3>>(
+           start.value(), initial_quaternion, initial_rotation,
+           before_expiration_times[1])});
+
+  using component = Component<Metavariables>;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
+  MockRuntimeSystem runner{{std::make_unique<TimeStepper>()},
+                           {std::move(functions_of_time)}};
+  const TimeStepId& time_step_id{time_step.is_positive(), 8, start};
+  const TimeStepId& next_time_step_id{time_step.is_positive(), 9,
+                                      start + time_step};
+  ActionTesting::emplace_component_and_initialize<component>(
+      &runner, 0,
+      {time_step_id, time_step, start.value(), time_step, next_time_step_id});
+  ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
+
+  runner.next_action<component>(0);
+
+  const auto& box = ActionTesting::get_databox<component>(runner, 0);
+  const auto& new_time_step = db::get<Tags::TimeStep>(box);
+  const auto& new_next_time_step = db::get<Tags::Next<Tags::TimeStep>>(box);
+  const auto& new_time_step_id = db::get<Tags::TimeStepId>(box);
+  const auto& new_next_time_step_id =
+      db::get<Tags::Next<Tags::TimeStepId>>(box);
+  const double new_slab_start_value{new_time_step.slab().start().value()};
+  const double new_slab_end_value{new_time_step.slab().end().value()};
+
+  CHECK(new_slab_start_value == time_step.slab().start().value());
+  CHECK((min_expiration_time == new_slab_end_value));
+
+  CHECK(new_slab_start_value + time_step.value() > min_expiration_time);
+  CHECK(new_slab_start_value + new_time_step.value() == min_expiration_time);
+
+  CHECK(new_time_step.fraction() == Rational{1, 1});
+  CHECK(new_time_step.slab().start().value() == new_slab_start_value);
+  CHECK(new_time_step.slab().end().value() == new_slab_end_value);
+
+  CHECK(new_time_step_id.time_runs_forward() ==
+        time_step_id.time_runs_forward());
+  CHECK(new_time_step_id.slab_number() == time_step_id.slab_number());
+  CHECK(new_time_step_id.step_time().fraction() ==
+        time_step_id.step_time().fraction());
+  CHECK(new_time_step_id.substep() == time_step_id.substep());
+  CHECK(new_time_step_id.substep_time().fraction() ==
+        time_step_id.substep_time().fraction());
+  CHECK(new_time_step_id.step_time().slab().start().value() ==
+        new_slab_start_value);
+  CHECK(new_time_step_id.step_time().slab().end().value() ==
+        new_slab_end_value);
+  CHECK(new_time_step_id.substep_time().slab().start().value() ==
+        new_slab_start_value);
+  CHECK(new_time_step_id.substep_time().slab().end().value() ==
+        new_slab_end_value);
+
+  CHECK(new_next_time_step_id == db::get<Tags::TimeStepper<>>(box).next_time_id(
+                                     new_time_step_id, new_time_step));
+  CHECK(new_next_time_step.fraction() == time_step.fraction());
+  CHECK(new_next_time_step.slab() == new_next_time_step_id.step_time().slab());
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Time.Actions.LimitTimeStepToExpirationTimes",
+                  "[Unit][Time][Actions]") {
+  Parallel::register_classes_with_charm<
+      TimeSteppers::DormandPrince5, TimeSteppers::RungeKutta4,
+      domain::FunctionsOfTime::PiecewisePolynomial<3>,
+      domain::FunctionsOfTime::QuaternionFunctionOfTime<3>>();
+  const Slab slab(0.1, 1.1);
+  check<TimeSteppers::DormandPrince5>(slab.start(), slab.end(),
+                                      slab.duration());
+  check<TimeSteppers::RungeKutta4>(slab.start(), slab.end(), slab.duration());
+}


### PR DESCRIPTION
## Proposed changes

When using global time stepping in a binary-black-hole evolution, insert an action just after dense triggers run that ensures that the step never exceeds the expiration time of the functions of time. This is necessary to evolve binary black holes with substep time steppers such as DormandPrince5 and RungeKutta4 with global timestepping.

### Upgrade instructions

<!-- UPGRADE INSTRUCTIONS -->

After this PR, evolutions of binary black holes that use global timestepping must also use adaptivity. The action that avoids stepping beyond the expiration times of the functions of time sometimes shrinks the step size. Without some adaptive condition to enlarge the step size again (such as a CFL-based condition), the step size of a binary-black-hole evolution will steadily shrink.

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
