### PR TITLE
Support yaml-cpp 0.7.0

### DIFF
--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -75,8 +75,8 @@ all of these dependencies.
   support disabled for openmp and mpi, as we want all of our parallelism to
   be accomplished via Charm++.
 * [LIBXSMM](https://github.com/hfp/libxsmm) version 1.16.1 or later
-* [yaml-cpp](https://github.com/jbeder/yaml-cpp) version 0.6.3 is
-  recommended. Building with shared library support is also recommended.
+* [yaml-cpp](https://github.com/jbeder/yaml-cpp) version 0.6.3 or later.
+  Building with shared library support is also recommended.
 * [Python](https://www.python.org/) 2.7, or 3.5 or later
 * [NumPy](http://www.numpy.org/) 1.10 or later
 * [SciPy](https://www.scipy.org)

--- a/tests/Unit/Options/Test_Options.cpp
+++ b/tests/Unit/Options/Test_Options.cpp
@@ -954,19 +954,6 @@ SPECTRE_TEST_CASE("Unit.Options.Format.UnorderedMap.Error", "[Unit][Options]") {
   opts.get<FormatUnorderedMap>();
 }
 
-// At line 3 column 1:.Unable to correctly parse the
-// input file because of a syntax error]]
-SPECTRE_TEST_CASE("Unit.Options.bad_colon", "[Unit][Options]") {
-  CHECK_THROWS_WITH(
-      []() {
-        Options::Parser<tmpl::list<>> opts("");
-        opts.parse("\n\n:");
-      }(),
-      Catch::Contains("At line 3 column 1:\nUnable to correctly parse the "
-                      "input file because of "
-                      "a syntax error"));
-}
-
 struct ExplicitObject {
   explicit ExplicitObject() = default;
 };


### PR DESCRIPTION
Submitted for testing.  If this works I have to update the docs and we need to decide which version we want on CI and in the containers.  I don't see a reason to drop support for 0.6.3 at the present time.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
