### PR TITLE
Add support for receiving DG volume data

### DIFF
--- a/src/Evolution/DgSubcell/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/CMakeLists.txt
@@ -17,6 +17,7 @@ spectre_target_headers(
   GhostZoneLogicalCoordinates.hpp
   Matrices.hpp
   Mesh.hpp
+  NeighborRdmpAndVolumeData.hpp
   NeighborReconstructedFaceSolution.hpp
   PerssonTci.hpp
   PrepareNeighborData.hpp
@@ -40,6 +41,7 @@ spectre_target_sources(
   GhostZoneLogicalCoordinates.cpp
   Matrices.cpp
   Mesh.cpp
+  NeighborRdmpAndVolumeData.cpp
   PerssonTci.cpp
   Projection.cpp
   RdmpTci.cpp

--- a/src/Evolution/DgSubcell/NeighborRdmpAndVolumeData.cpp
+++ b/src/Evolution/DgSubcell/NeighborRdmpAndVolumeData.cpp
@@ -1,0 +1,238 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/DgSubcell/NeighborRdmpAndVolumeData.hpp"
+
+#include <algorithm>
+#include <boost/functional/hash.hpp>
+#include <functional>
+#include <iterator>
+
+#include "DataStructures/ApplyMatrices.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/OrientationMapHelpers.hpp"
+#include "Evolution/DgSubcell/Matrices.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeArray.hpp"
+
+namespace evolution::dg::subcell {
+template <bool InsertIntoMap, size_t Dim>
+void insert_or_update_neighbor_volume_data(
+    const gsl::not_null<FixedHashMap<
+        maximum_number_of_neighbors(Dim),
+        std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
+        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>*>
+        neighbor_data_ptr,
+    const std::vector<double>& neighbor_subcell_data,
+    const size_t number_of_rdmp_vars_in_buffer,
+    const std::pair<Direction<Dim>, ElementId<Dim>>& directional_element_id,
+    const Mesh<Dim>& neighbor_mesh, const Element<Dim>& element,
+    const Mesh<Dim>& subcell_mesh, const size_t number_of_ghost_zones) {
+  ASSERT(neighbor_mesh == Mesh<Dim>(neighbor_mesh.extents(0),
+                                    neighbor_mesh.basis(0),
+                                    neighbor_mesh.quadrature(0)),
+         "The neighbor mesh must be uniform but is " << neighbor_mesh);
+  ASSERT(not neighbor_subcell_data.empty(),
+         "neighbor_subcell_data must be non-empty");
+  const size_t end_of_volume_data =
+      neighbor_subcell_data.size() - 2 * number_of_rdmp_vars_in_buffer;
+
+  std::vector<double> ghost_data{};
+  if (neighbor_mesh.basis(0) == Spectral::Basis::FiniteDifference) {
+    ASSERT(neighbor_mesh == subcell_mesh,
+           "Neighbor mesh ("
+               << neighbor_mesh << ") and my mesh (" << subcell_mesh
+               << ") must be the same if we are both doing subcell.");
+    if (not InsertIntoMap and
+        neighbor_subcell_data.data() ==
+            neighbor_data_ptr->at(directional_element_id).data()) {
+      // Short-circuit if we are already doing FD and we would be
+      // self-assigning, so elide copy and move.
+      return;
+    }
+    // Copy over the ghost cell data for subcell reconstruction. In this case
+    // the neighbor would have reoriented the data for us.
+    ghost_data = std::vector<double>{
+        neighbor_subcell_data.begin(),
+        std::prev(
+            neighbor_subcell_data.end(),
+            2 * static_cast<typename std::iterator_traits<
+                    typename std::vector<double>::iterator>::difference_type>(
+                    number_of_rdmp_vars_in_buffer))};
+  } else {
+    ASSERT(evolution::dg::subcell::fd::mesh(neighbor_mesh) == subcell_mesh,
+           "Neighbor subcell mesh computed from the neighbor DG mesh ("
+               << evolution::dg::subcell::fd::mesh(neighbor_mesh)
+               << ") and my mesh (" << subcell_mesh << ") must be the same.");
+    const Direction<Dim>& direction = directional_element_id.first;
+    const auto& orientation = element.neighbors().at(direction).orientation();
+    const auto& neighbor_orientation_map = orientation.inverse_map();
+    const size_t total_number_of_ghost_zones =
+        number_of_ghost_zones *
+        subcell_mesh.extents().slice_away(direction.dimension()).product();
+    ASSERT(
+        end_of_volume_data % neighbor_mesh.number_of_grid_points() == 0,
+        "The number of DG volume grid points times the number of variables "
+        "sent for reconstruction ("
+            << end_of_volume_data
+            << ") must be a multiple of the number of DG volume grid points: "
+            << neighbor_mesh.number_of_grid_points());
+    const size_t number_of_vars =
+        end_of_volume_data / neighbor_mesh.number_of_grid_points();
+    const auto project_to_ghost_data =
+        [&direction, &ghost_data, &number_of_ghost_zones, &subcell_mesh](
+            const Mesh<Dim>& neighbor_mesh_for_projection,
+            const DataVector& neighbor_data_for_projection) {
+          // Project to ghosts
+          Matrix empty{};
+          auto ghost_projection_mat = make_array<Dim>(std::cref(empty));
+          for (size_t i = 0; i < Dim; ++i) {
+            if (i == direction.dimension()) {
+              gsl::at(ghost_projection_mat, i) =
+                  std::cref(evolution::dg::subcell::fd::projection_matrix(
+                      neighbor_mesh_for_projection.slice_through(i),
+                      subcell_mesh.extents(i), number_of_ghost_zones,
+                      direction.opposite().side()));
+            } else {
+              gsl::at(ghost_projection_mat, i) =
+                  std::cref(evolution::dg::subcell::fd::projection_matrix(
+                      neighbor_mesh_for_projection.slice_through(i),
+                      subcell_mesh.extents(i)));
+            }
+          }
+          DataVector view_ghost_data(ghost_data.data(), ghost_data.size());
+          apply_matrices(make_not_null(&view_ghost_data), ghost_projection_mat,
+                         neighbor_data_for_projection,
+                         neighbor_mesh_for_projection.extents());
+        };
+    // Note: Once we have fully unstructured mesh support we could completely
+    // elide projection, instead treating DG neighbors as unstructured meshes.
+    // Whether this would actually be cheaper than projecting and using uniform
+    // meshes will need to be profiled.
+    ghost_data.resize(total_number_of_ghost_zones * number_of_vars);
+    const DataVector neighbor_data_as_data_vector(
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+        const_cast<double*>(neighbor_subcell_data.data()), end_of_volume_data);
+    if (LIKELY(orientation.is_aligned())) {
+      project_to_ghost_data(neighbor_mesh, neighbor_data_as_data_vector);
+    } else {
+      // The neighbor sent DG data, so we need to project it to the ghost cells.
+      //
+      // We do not reorient the data on send, since this could add a lot of
+      // unnecessary orientations in smooth regions. Instead, we reorient on
+      // receive here.
+      const Mesh<Dim> reoriented_neighbor_mesh =
+          neighbor_orientation_map(neighbor_mesh);
+      DataVector temp_oriented_volume_data{end_of_volume_data};
+      orient_variables(make_not_null(&temp_oriented_volume_data),
+                       neighbor_data_as_data_vector, neighbor_mesh.extents(),
+                       neighbor_orientation_map);
+      project_to_ghost_data(reoriented_neighbor_mesh,
+                            temp_oriented_volume_data);
+    }
+  }
+  if constexpr (InsertIntoMap) {
+    [[maybe_unused]] const auto insert_result = neighbor_data_ptr->insert(
+        std::pair{directional_element_id, std::move(ghost_data)});
+    ASSERT(insert_result.second,
+           "Failed to insert the neighbor data in direction "
+               << directional_element_id.first << " from neighbor "
+               << directional_element_id.second);
+  } else {
+    neighbor_data_ptr->at(directional_element_id) = std::move(ghost_data);
+  }
+}
+
+template <size_t Dim>
+void insert_neighbor_rdmp_and_volume_data(
+    const gsl::not_null<RdmpTciData*> rdmp_tci_data_ptr,
+    const gsl::not_null<FixedHashMap<
+        maximum_number_of_neighbors(Dim),
+        std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
+        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>*>
+        neighbor_data_ptr,
+    const std::vector<double>& received_neighbor_subcell_data,
+    const size_t number_of_rdmp_vars,
+    const std::pair<Direction<Dim>, ElementId<Dim>>& directional_element_id,
+    const Mesh<Dim>& neighbor_mesh, const Element<Dim>& element,
+    const Mesh<Dim>& subcell_mesh, const size_t number_of_ghost_zones) {
+  ASSERT(not received_neighbor_subcell_data.empty(),
+         "received_neighbor_subcell_data must be non-empty");
+  // Note: since we determine the starting point of the RDMP vars
+  // from how many RDMP vars there are, we don't need to account for
+  // the mesh the neighbor sent (DG or FD)
+  const size_t max_offset =
+      received_neighbor_subcell_data.size() - 2 * number_of_rdmp_vars;
+  const size_t min_offset =
+      received_neighbor_subcell_data.size() - number_of_rdmp_vars;
+  for (size_t var_index = 0; var_index < number_of_rdmp_vars; ++var_index) {
+    rdmp_tci_data_ptr->max_variables_values[var_index] =
+        std::max(rdmp_tci_data_ptr->max_variables_values[var_index],
+                 received_neighbor_subcell_data[max_offset + var_index]);
+    rdmp_tci_data_ptr->min_variables_values[var_index] =
+        std::min(rdmp_tci_data_ptr->min_variables_values[var_index],
+                 received_neighbor_subcell_data[min_offset + var_index]);
+  }
+  // Note: it would be good to assert that the neighbor is at the same
+  // refinement level as us, but such a function does not yet exist.
+
+  insert_or_update_neighbor_volume_data<true>(
+      neighbor_data_ptr, received_neighbor_subcell_data, number_of_rdmp_vars,
+      directional_element_id, neighbor_mesh, element, subcell_mesh,
+      number_of_ghost_zones);
+}
+
+#define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data)                                             \
+  template void insert_neighbor_rdmp_and_volume_data(                      \
+      gsl::not_null<RdmpTciData*> rdmp_tci_data_ptr,                       \
+      gsl::not_null<FixedHashMap<                                          \
+          maximum_number_of_neighbors(GET_DIM(data)),                      \
+          std::pair<Direction<GET_DIM(data)>, ElementId<GET_DIM(data)>>,   \
+          std::vector<double>,                                             \
+          boost::hash<std::pair<Direction<GET_DIM(data)>,                  \
+                                ElementId<GET_DIM(data)>>>>*>              \
+          neighbor_data_ptr,                                               \
+      const std::vector<double>& neighbor_subcell_data,                    \
+      size_t number_of_rdmp_vars,                                          \
+      const std::pair<Direction<GET_DIM(data)>, ElementId<GET_DIM(data)>>& \
+          directional_element_id,                                          \
+      const Mesh<GET_DIM(data)>& neighbor_mesh,                            \
+      const Element<GET_DIM(data)>& element,                               \
+      const Mesh<GET_DIM(data)>& subcell_mesh, size_t number_of_ghost_zones);
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+
+#define GET_INSERT(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATION(r, data)                                             \
+  template void insert_or_update_neighbor_volume_data<GET_INSERT(data)>(   \
+      gsl::not_null<FixedHashMap<                                          \
+          maximum_number_of_neighbors(GET_DIM(data)),                      \
+          std::pair<Direction<GET_DIM(data)>, ElementId<GET_DIM(data)>>,   \
+          std::vector<double>,                                             \
+          boost::hash<std::pair<Direction<GET_DIM(data)>,                  \
+                                ElementId<GET_DIM(data)>>>>*>              \
+          neighbor_data_ptr,                                               \
+      const std::vector<double>& received_neighbor_subcell_data,           \
+      size_t number_of_rdmp_vars_in_buffer,                                \
+      const std::pair<Direction<GET_DIM(data)>, ElementId<GET_DIM(data)>>& \
+          directional_element_id,                                          \
+      const Mesh<GET_DIM(data)>& neighbor_mesh,                            \
+      const Element<GET_DIM(data)>& element,                               \
+      const Mesh<GET_DIM(data)>& subcell_mesh, size_t number_of_ghost_zones);
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (true, false))
+
+#undef INSTANTIATION
+#undef GET_DIM
+}  // namespace evolution::dg::subcell

--- a/src/Evolution/DgSubcell/NeighborRdmpAndVolumeData.hpp
+++ b/src/Evolution/DgSubcell/NeighborRdmpAndVolumeData.hpp
@@ -1,0 +1,66 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <boost/functional/hash.hpp>
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/FixedHashMap.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/MaxNumberOfNeighbors.hpp"
+#include "Evolution/DgSubcell/RdmpTciData.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+template <size_t Dim>
+class Element;
+template <size_t Dim>
+class Mesh;
+/// \endcond
+
+namespace evolution::dg::subcell {
+/*!
+ * \brief Check whether `neighbor_subcell_data` is FD or DG, and either insert
+ * or copy into `neighbor_data_ptr` the FD data (projecting if
+ * `neighbor_subcell_data` is DG data).
+ *
+ * This is intended to be used during a rollback from DG to make sure neighbor
+ * data is projected to the FD grid.
+ */
+template <bool InsertIntoMap, size_t Dim>
+void insert_or_update_neighbor_volume_data(
+    gsl::not_null<FixedHashMap<
+        maximum_number_of_neighbors(Dim),
+        std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
+        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>*>
+        neighbor_data_ptr,
+    const std::vector<double>& neighbor_subcell_data,
+    const size_t number_of_rdmp_vars_in_buffer,
+    const std::pair<Direction<Dim>, ElementId<Dim>>& directional_element_id,
+    const Mesh<Dim>& neighbor_mesh, const Element<Dim>& element,
+    const Mesh<Dim>& subcell_mesh, size_t number_of_ghost_zones);
+
+/*!
+ * \brief Check whether the neighbor sent is DG volume or FD ghost data, and
+ * orient project DG volume data if necessary.
+ *
+ * This is intended to be used by the `ReceiveDataForReconstruction` action.
+ */
+template <size_t Dim>
+void insert_neighbor_rdmp_and_volume_data(
+    gsl::not_null<RdmpTciData*> rdmp_tci_data_ptr,
+    gsl::not_null<FixedHashMap<
+        maximum_number_of_neighbors(Dim),
+        std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
+        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>*>
+        neighbor_data_ptr,
+    const std::vector<double>& received_neighbor_subcell_data,
+    size_t number_of_rdmp_vars,
+    const std::pair<Direction<Dim>, ElementId<Dim>>& directional_element_id,
+    const Mesh<Dim>& neighbor_mesh, const Element<Dim>& element,
+    const Mesh<Dim>& subcell_mesh, size_t number_of_ghost_zones);
+}  // namespace evolution::dg::subcell

--- a/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
+++ b/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
@@ -17,6 +17,7 @@ set(LIBRARY_SOURCES
   Test_GhostZoneLogicalCoordinates.cpp
   Test_Matrices.cpp
   Test_Mesh.cpp
+  Test_NeighborRdmpAndVolumeData.cpp
   Test_NeighborReconstructedFaceSolution.cpp
   Test_PerssonTci.cpp
   Test_PrepareNeighborData.cpp

--- a/tests/Unit/Evolution/DgSubcell/Test_NeighborRdmpAndVolumeData.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_NeighborRdmpAndVolumeData.cpp
@@ -1,0 +1,443 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <boost/functional/hash.hpp>
+#include <cstddef>
+#include <functional>
+#include <limits>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/ApplyMatrices.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Domain/Structure/OrientationMap.hpp"
+#include "Domain/Structure/OrientationMapHelpers.hpp"
+#include "Evolution/DgSubcell/Matrices.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
+#include "Evolution/DgSubcell/NeighborRdmpAndVolumeData.hpp"
+#include "Evolution/DgSubcell/RdmpTciData.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+template <size_t Dim>
+void test() {
+  CAPTURE(Dim);
+  // Have upper xi neighbor do DG and lower xi neighbor do FD. For eta do
+  // reverse, and zeta do same as xi.
+  const Mesh<Dim> dg_mesh{6, Spectral::Basis::Legendre,
+                          Spectral::Quadrature::GaussLobatto};
+  const Mesh<Dim> subcell_mesh = evolution::dg::subcell::fd::mesh(dg_mesh);
+  const size_t number_of_rdmp_vars = 2;
+  const size_t number_of_ghost_zones = 3;  // 5th order method
+
+  const std::pair upper_xi_id{Direction<Dim>::upper_xi(), ElementId<Dim>{1}};
+  const std::pair lower_xi_id{Direction<Dim>::lower_xi(), ElementId<Dim>{2}};
+
+  DirectionMap<Dim, Neighbors<Dim>> neighbors{};
+  // aligned with neighbor so default construct
+  neighbors.insert(std::pair{Direction<Dim>::upper_xi(),
+                             Neighbors<Dim>{{upper_xi_id.second}, {}}});
+  if constexpr (Dim == 1) {
+    neighbors.insert(std::pair{
+        Direction<Dim>::lower_xi(),
+        Neighbors<Dim>{{lower_xi_id.second},
+                       OrientationMap<Dim>{{{Direction<Dim>::lower_xi()}}}}});
+  } else if constexpr (Dim == 2) {
+    neighbors.insert(std::pair{
+        Direction<Dim>::lower_xi(),
+        Neighbors<Dim>{{lower_xi_id.second},
+                       OrientationMap<Dim>{{{Direction<Dim>::lower_xi(),
+                                             Direction<Dim>::lower_eta()}}}}});
+    neighbors.insert(std::pair{Direction<Dim>::upper_eta(),
+                               Neighbors<Dim>{{ElementId<Dim>{3}}, {}}});
+  } else if constexpr (Dim == 3) {
+    neighbors.insert(std::pair{
+        Direction<Dim>::lower_xi(),
+        Neighbors<Dim>{{lower_xi_id.second},
+                       OrientationMap<Dim>{{{Direction<Dim>::lower_xi(),
+                                             Direction<Dim>::lower_eta(),
+                                             Direction<Dim>::upper_zeta()}}}}});
+    neighbors.insert(std::pair{Direction<Dim>::upper_eta(),
+                               Neighbors<Dim>{{ElementId<Dim>{3}}, {}}});
+
+    neighbors.insert(std::pair{
+        Direction<Dim>::lower_zeta(),
+        Neighbors<Dim>{{ElementId<Dim>{4}},
+                       OrientationMap<Dim>{{{Direction<Dim>::lower_xi(),
+                                             Direction<Dim>::lower_eta(),
+                                             Direction<Dim>::upper_zeta()}}}}});
+    neighbors.insert(std::pair{Direction<Dim>::upper_zeta(),
+                               Neighbors<Dim>{{ElementId<Dim>{5}}, {}}});
+  }
+  std::vector<double> received_fd_data(subcell_mesh.number_of_grid_points() +
+                                       2 * number_of_rdmp_vars);
+  alg::iota(received_fd_data, 0.0);
+  std::vector<double> received_dg_data(dg_mesh.number_of_grid_points() +
+                                       2 * number_of_rdmp_vars);
+  alg::iota(received_dg_data, received_fd_data.back() + 1.0);
+
+  const Element<Dim> element{ElementId<Dim>{0}, neighbors};
+
+  const std::vector<double> expected_neighbor_data_from_upper_xi{
+      received_fd_data.begin(),
+      std::prev(received_fd_data.end(), 2 * number_of_rdmp_vars)};
+  const std::vector<double> expected_neighbor_data_from_lower_xi =
+      [&dg_mesh, &neighbors, &number_of_rdmp_vars, &received_dg_data,
+       &subcell_mesh]() {
+        (void)number_of_rdmp_vars;  // workaround clang bug unused warning
+        const DataVector view_received_data(
+            received_dg_data.data(),
+            received_dg_data.size() - 2 * number_of_rdmp_vars);
+        DataVector oriented_data(view_received_data.size());
+        orient_variables(make_not_null(&oriented_data), view_received_data,
+                         dg_mesh.extents(),
+                         neighbors.at(Direction<Dim>::lower_xi())
+                             .orientation()
+                             .inverse_map());
+        // We've now got the data in the local orientation, so now we need to
+        // project it to the ghost cells.
+        // Note: assume isotropic meshes
+        auto projection_matrices = make_array<Dim>(
+            std::cref(evolution::dg::subcell::fd::projection_matrix(
+                dg_mesh.slice_through(0), subcell_mesh.extents(0))));
+        projection_matrices[0] =
+            std::cref(evolution::dg::subcell::fd::projection_matrix(
+                dg_mesh.slice_through(0), subcell_mesh.extents(0),
+                number_of_ghost_zones, Side::Upper));
+
+        std::vector<double> expected_data(
+            subcell_mesh.extents().slice_away(0).product() *
+            number_of_ghost_zones);
+        DataVector expected_data_view{expected_data.data(),
+                                      expected_data.size()};
+        apply_matrices(make_not_null(&expected_data_view), projection_matrices,
+                       oriented_data, dg_mesh.extents());
+        return expected_data;
+      }();
+
+  FixedHashMap<maximum_number_of_neighbors(Dim),
+               std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
+               boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>
+      neighbor_data{};
+  evolution::dg::subcell::RdmpTciData rdmp_tci_data{
+      std::vector{std::numeric_limits<double>::min(),
+                  std::numeric_limits<double>::min()},
+      std::vector{std::numeric_limits<double>::max(),
+                  std::numeric_limits<double>::max()}};
+  // Do upper-xi neighbor first. This is just aligned FD
+  evolution::dg::subcell::insert_neighbor_rdmp_and_volume_data(
+      make_not_null(&rdmp_tci_data), make_not_null(&neighbor_data),
+      received_fd_data, number_of_rdmp_vars, upper_xi_id,
+      subcell_mesh,  // neighbor mesh is the same as my mesh since both are
+                     // doing subcell
+      element, subcell_mesh, number_of_ghost_zones);
+  {
+    const std::vector<double> expected_max_rdmp_tci_data{
+        std::prev(received_fd_data.end(), 2 * number_of_rdmp_vars),
+        std::prev(received_fd_data.end(), number_of_rdmp_vars)};
+    const std::vector<double> expected_min_rdmp_tci_data{
+        std::prev(received_fd_data.end(), number_of_rdmp_vars),
+        received_fd_data.end()};
+    CHECK(rdmp_tci_data.max_variables_values == expected_max_rdmp_tci_data);
+    CHECK(rdmp_tci_data.min_variables_values == expected_min_rdmp_tci_data);
+
+    REQUIRE(neighbor_data.size() == 1);
+    REQUIRE(neighbor_data.find(upper_xi_id) != neighbor_data.end());
+    CHECK(neighbor_data.at(upper_xi_id) ==
+          expected_neighbor_data_from_upper_xi);
+  }
+
+  // Do lower-xi neighbor. This is unaligned DG.
+  evolution::dg::subcell::insert_neighbor_rdmp_and_volume_data(
+      make_not_null(&rdmp_tci_data), make_not_null(&neighbor_data),
+      received_dg_data, number_of_rdmp_vars, lower_xi_id, dg_mesh, element,
+      subcell_mesh, number_of_ghost_zones);
+
+  {
+    const std::vector<double> expected_max_rdmp_tci_data{
+        std::prev(received_dg_data.end(), 2 * number_of_rdmp_vars),
+        std::prev(received_dg_data.end(), number_of_rdmp_vars)};
+    const std::vector<double> expected_min_rdmp_tci_data{
+        std::prev(received_fd_data.end(), number_of_rdmp_vars),
+        received_fd_data.end()};
+    CHECK(rdmp_tci_data.max_variables_values == expected_max_rdmp_tci_data);
+    CHECK(rdmp_tci_data.min_variables_values == expected_min_rdmp_tci_data);
+
+    REQUIRE(neighbor_data.size() == 2);
+    REQUIRE(neighbor_data.find(upper_xi_id) != neighbor_data.end());
+    REQUIRE(neighbor_data.find(lower_xi_id) != neighbor_data.end());
+    CHECK(neighbor_data.at(upper_xi_id) ==
+          expected_neighbor_data_from_upper_xi);
+    CHECK(neighbor_data.at(lower_xi_id) ==
+          expected_neighbor_data_from_lower_xi);
+  }
+
+  if constexpr (Dim > 1) {
+    // Do upper-eta neighbor. This is aligned DG.
+    const std::pair upper_eta_id{Direction<Dim>::upper_eta(),
+                                 ElementId<Dim>{3}};
+
+    std::vector<double> aligned_received_dg_data(
+        dg_mesh.number_of_grid_points() + 2 * number_of_rdmp_vars);
+    alg::iota(aligned_received_dg_data, received_dg_data.back() + 1.0);
+    evolution::dg::subcell::insert_neighbor_rdmp_and_volume_data(
+        make_not_null(&rdmp_tci_data), make_not_null(&neighbor_data),
+        aligned_received_dg_data, number_of_rdmp_vars, upper_eta_id, dg_mesh,
+        element, subcell_mesh, number_of_ghost_zones);
+
+    const std::vector<double> expected_max_rdmp_tci_data{
+        std::prev(aligned_received_dg_data.end(), 2 * number_of_rdmp_vars),
+        std::prev(aligned_received_dg_data.end(), number_of_rdmp_vars)};
+    const std::vector<double> expected_min_rdmp_tci_data{
+        std::prev(received_fd_data.end(), number_of_rdmp_vars),
+        received_fd_data.end()};
+    CHECK(rdmp_tci_data.max_variables_values == expected_max_rdmp_tci_data);
+    CHECK(rdmp_tci_data.min_variables_values == expected_min_rdmp_tci_data);
+
+    REQUIRE(neighbor_data.size() == 3);
+    REQUIRE(neighbor_data.find(upper_xi_id) != neighbor_data.end());
+    REQUIRE(neighbor_data.find(lower_xi_id) != neighbor_data.end());
+    REQUIRE(neighbor_data.find(upper_eta_id) != neighbor_data.end());
+    CHECK(neighbor_data.at(upper_xi_id) ==
+          expected_neighbor_data_from_upper_xi);
+    CHECK(neighbor_data.at(lower_xi_id) ==
+          expected_neighbor_data_from_lower_xi);
+
+    auto projection_matrices =
+        make_array<Dim>(std::cref(evolution::dg::subcell::fd::projection_matrix(
+            dg_mesh.slice_through(0), subcell_mesh.extents(0))));
+    projection_matrices[1] =
+        std::cref(evolution::dg::subcell::fd::projection_matrix(
+            dg_mesh.slice_through(0), subcell_mesh.extents(0),
+            number_of_ghost_zones, Side::Lower));
+
+    DataVector view_aligned_received_dg_data(aligned_received_dg_data.data(),
+                                             dg_mesh.number_of_grid_points());
+    std::vector<double> expected_data(
+        subcell_mesh.extents().slice_away(0).product() * number_of_ghost_zones);
+    DataVector expected_data_view{expected_data.data(), expected_data.size()};
+    apply_matrices(make_not_null(&expected_data_view), projection_matrices,
+                   view_aligned_received_dg_data, dg_mesh.extents());
+    CHECK(neighbor_data.at(upper_eta_id) == expected_data);
+  }
+
+  {
+    // Check that not inserting but updating in a direction that already has FD
+    // data does nothing. That is, even the pointer should stay the same.
+    const double* expected_pointer = neighbor_data.at(lower_xi_id).data();
+    evolution::dg::subcell::insert_or_update_neighbor_volume_data<false>(
+        make_not_null(&neighbor_data), neighbor_data.at(lower_xi_id),
+        number_of_rdmp_vars, lower_xi_id, subcell_mesh, element, subcell_mesh,
+        number_of_ghost_zones);
+    CHECK(neighbor_data.at(lower_xi_id).data() == expected_pointer);
+  }
+
+  if constexpr (Dim > 2) {
+    // Check that a neighbor being aligned DG and unaligned DG both work when
+    // not inserting.
+
+    // Do upper-zeta neighbor. This is aligned DG.
+    const std::pair upper_zeta_id{Direction<Dim>::upper_zeta(),
+                                  ElementId<Dim>{5}};
+    std::vector<double> aligned_received_dg_data(
+        dg_mesh.number_of_grid_points());
+    alg::iota(aligned_received_dg_data, received_dg_data.back() + 1.0);
+    neighbor_data.insert(std::pair{upper_zeta_id, aligned_received_dg_data});
+    evolution::dg::subcell::insert_or_update_neighbor_volume_data<false>(
+        make_not_null(&neighbor_data), neighbor_data.at(upper_zeta_id), 0,
+        upper_zeta_id, dg_mesh, element, subcell_mesh, number_of_ghost_zones);
+
+    auto projection_matrices =
+        make_array<Dim>(std::cref(evolution::dg::subcell::fd::projection_matrix(
+            dg_mesh.slice_through(0), subcell_mesh.extents(0))));
+    projection_matrices[2] =
+        std::cref(evolution::dg::subcell::fd::projection_matrix(
+            dg_mesh.slice_through(0), subcell_mesh.extents(0),
+            number_of_ghost_zones, Side::Lower));
+
+    DataVector view_aligned_received_dg_data(aligned_received_dg_data.data(),
+                                             dg_mesh.number_of_grid_points());
+    std::vector<double> expected_data(
+        subcell_mesh.extents().slice_away(0).product() * number_of_ghost_zones);
+    DataVector expected_data_view{expected_data.data(), expected_data.size()};
+    apply_matrices(make_not_null(&expected_data_view), projection_matrices,
+                   view_aligned_received_dg_data, dg_mesh.extents());
+    CHECK(neighbor_data.at(upper_zeta_id) == expected_data);
+
+    // Do lower-zeta neighbor. This is unaligned DG.
+    const std::pair lower_zeta_id{Direction<Dim>::lower_zeta(),
+                                  ElementId<Dim>{4}};
+    std::vector<double> unaligned_received_dg_data(
+        dg_mesh.number_of_grid_points());
+    alg::iota(unaligned_received_dg_data,
+              aligned_received_dg_data.back() + 1.0);
+    neighbor_data.insert(std::pair{lower_zeta_id, unaligned_received_dg_data});
+    evolution::dg::subcell::insert_or_update_neighbor_volume_data<false>(
+        make_not_null(&neighbor_data), neighbor_data.at(lower_zeta_id), 0,
+        lower_zeta_id, dg_mesh, element, subcell_mesh, number_of_ghost_zones);
+
+    projection_matrices[2] =
+        std::cref(evolution::dg::subcell::fd::projection_matrix(
+            dg_mesh.slice_through(0), subcell_mesh.extents(0),
+            number_of_ghost_zones, Side::Upper));
+
+    DataVector view_received_data(unaligned_received_dg_data.data(),
+                                  unaligned_received_dg_data.size());
+    DataVector oriented_data(view_received_data.size());
+    orient_variables(
+        make_not_null(&oriented_data), view_received_data, dg_mesh.extents(),
+        neighbors.at(Direction<Dim>::lower_zeta()).orientation().inverse_map());
+    expected_data.resize(subcell_mesh.extents().slice_away(0).product() *
+                         number_of_ghost_zones);
+    expected_data_view.set_data_ref(expected_data.data(), expected_data.size());
+    apply_matrices(make_not_null(&expected_data_view), projection_matrices,
+                   oriented_data, dg_mesh.extents());
+    CHECK(neighbor_data.at(lower_zeta_id) == expected_data);
+  }
+
+#ifdef SPECTRE_DEBUG
+  // Test ASSERTs
+  CHECK_THROWS_WITH(
+      evolution::dg::subcell::insert_neighbor_rdmp_and_volume_data(
+          make_not_null(&rdmp_tci_data), make_not_null(&neighbor_data),
+          std::vector<double>{}, number_of_rdmp_vars,
+          std::pair{Direction<Dim>::upper_xi(), ElementId<Dim>{1}},
+          subcell_mesh, element, subcell_mesh, number_of_ghost_zones),
+      Catch::Matchers::Contains(
+          "received_neighbor_subcell_data must be non-empty"));
+
+  CHECK_THROWS_WITH(
+      evolution::dg::subcell::insert_or_update_neighbor_volume_data<true>(
+          make_not_null(&neighbor_data), std::vector<double>{},
+          number_of_rdmp_vars,
+          std::pair{Direction<Dim>::upper_xi(), ElementId<Dim>{1}},
+          subcell_mesh, element, subcell_mesh, number_of_ghost_zones),
+      Catch::Matchers::Contains("neighbor_subcell_data must be non-empty"));
+  CHECK_THROWS_WITH(
+      evolution::dg::subcell::insert_or_update_neighbor_volume_data<false>(
+          make_not_null(&neighbor_data), std::vector<double>{},
+          number_of_rdmp_vars,
+          std::pair{Direction<Dim>::upper_xi(), ElementId<Dim>{1}},
+          subcell_mesh, element, subcell_mesh, number_of_ghost_zones),
+      Catch::Matchers::Contains("neighbor_subcell_data must be non-empty"));
+
+  CHECK_THROWS_WITH(
+      evolution::dg::subcell::insert_or_update_neighbor_volume_data<true>(
+          make_not_null(&neighbor_data), received_fd_data, number_of_rdmp_vars,
+          upper_xi_id,
+          Mesh<Dim>{5, Spectral::Basis::FiniteDifference,
+                    Spectral::Quadrature::CellCentered},
+          element, subcell_mesh, number_of_ghost_zones),
+      Catch::Matchers::Contains(
+          "must be the same if we are both doing subcell."));
+  CHECK_THROWS_WITH(
+      evolution::dg::subcell::insert_or_update_neighbor_volume_data<false>(
+          make_not_null(&neighbor_data), received_fd_data, number_of_rdmp_vars,
+          upper_xi_id,
+          Mesh<Dim>{5, Spectral::Basis::FiniteDifference,
+                    Spectral::Quadrature::CellCentered},
+          element, subcell_mesh, number_of_ghost_zones),
+      Catch::Matchers::Contains(
+          "must be the same if we are both doing subcell."));
+
+  CHECK_THROWS_WITH(
+      evolution::dg::subcell::insert_or_update_neighbor_volume_data<true>(
+          make_not_null(&neighbor_data), received_dg_data, number_of_rdmp_vars,
+          lower_xi_id, dg_mesh, element,
+          Mesh<Dim>{4, Spectral::Basis::Legendre,
+                    Spectral::Quadrature::GaussLobatto},
+          number_of_ghost_zones),
+      Catch::Matchers::Contains(
+          "Neighbor subcell mesh computed from the neighbor DG mesh "));
+  CHECK_THROWS_WITH(
+      evolution::dg::subcell::insert_or_update_neighbor_volume_data<false>(
+          make_not_null(&neighbor_data), received_dg_data, number_of_rdmp_vars,
+          lower_xi_id, dg_mesh, element,
+          Mesh<Dim>{4, Spectral::Basis::Legendre,
+                    Spectral::Quadrature::GaussLobatto},
+          number_of_ghost_zones),
+      Catch::Matchers::Contains(
+          "Neighbor subcell mesh computed from the neighbor DG mesh "));
+
+  CHECK_THROWS_WITH(
+      evolution::dg::subcell::insert_or_update_neighbor_volume_data<true>(
+          make_not_null(&neighbor_data),
+          std::vector<double>(2 * number_of_rdmp_vars + 1, 0.0),
+          number_of_rdmp_vars, lower_xi_id, dg_mesh, element, subcell_mesh,
+          number_of_ghost_zones),
+      Catch::Matchers::Contains(
+          "The number of DG volume grid points times the number of variables"));
+  CHECK_THROWS_WITH(
+      evolution::dg::subcell::insert_or_update_neighbor_volume_data<false>(
+          make_not_null(&neighbor_data),
+          std::vector<double>(2 * number_of_rdmp_vars + 1, 0.0),
+          number_of_rdmp_vars, lower_xi_id, dg_mesh, element, subcell_mesh,
+          number_of_ghost_zones),
+      Catch::Matchers::Contains(
+          "The number of DG volume grid points times the number of variables"));
+
+  CHECK_THROWS_WITH(
+      evolution::dg::subcell::insert_neighbor_rdmp_and_volume_data(
+          make_not_null(&rdmp_tci_data), make_not_null(&neighbor_data),
+          received_fd_data, number_of_rdmp_vars, upper_xi_id,
+          subcell_mesh,  // neighbor mesh is the same as my mesh since both are
+                         // doing subcell
+          element, subcell_mesh, number_of_ghost_zones),
+      Catch::Matchers::Contains(
+          "Failed to insert the neighbor data in direction "));
+  CHECK_THROWS_WITH(
+      evolution::dg::subcell::insert_or_update_neighbor_volume_data<true>(
+          make_not_null(&neighbor_data), received_fd_data, number_of_rdmp_vars,
+          upper_xi_id,
+          subcell_mesh,  // neighbor mesh is the same as my mesh since both are
+                         // doing subcell
+          element, subcell_mesh, number_of_ghost_zones),
+      Catch::Matchers::Contains(
+          "Failed to insert the neighbor data in direction "));
+
+  if constexpr (Dim > 1) {
+    Mesh<Dim> non_uniform_mesh{};
+    if constexpr (Dim == 2) {
+      non_uniform_mesh = Mesh<2>{{{4, 5}},
+                                 Spectral::Basis::Legendre,
+                                 Spectral::Quadrature::GaussLobatto};
+    } else if constexpr (Dim == 3) {
+      non_uniform_mesh = Mesh<3>{{{4, 5, 6}},
+                                 Spectral::Basis::Legendre,
+                                 Spectral::Quadrature::GaussLobatto};
+    }
+    CHECK_THROWS_WITH(
+        evolution::dg::subcell::insert_or_update_neighbor_volume_data<true>(
+            make_not_null(&neighbor_data), received_fd_data,
+            number_of_rdmp_vars,
+            std::pair{Direction<Dim>::upper_xi(), ElementId<Dim>{1}},
+            non_uniform_mesh, element, subcell_mesh, number_of_ghost_zones),
+        Catch::Matchers::Contains("The neighbor mesh must be uniform but is"));
+    CHECK_THROWS_WITH(
+        evolution::dg::subcell::insert_or_update_neighbor_volume_data<false>(
+            make_not_null(&neighbor_data), received_fd_data,
+            number_of_rdmp_vars,
+            std::pair{Direction<Dim>::upper_xi(), ElementId<Dim>{1}},
+            non_uniform_mesh, element, subcell_mesh, number_of_ghost_zones),
+        Catch::Matchers::Contains("The neighbor mesh must be uniform but is"));
+  }
+#endif
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Subcell.NeighborRdmpAndVolumeData",
+                  "[Evolution][Unit]") {
+  test<1>();
+  test<2>();
+  test<3>();
+}


### PR DESCRIPTION
## Proposed changes

Projecting and slicing subcell data is a non-negligible overhead. This PR adds support for receiving DG volume data instead of neighboring subcell data. A few upcoming PRs will actually change the executables to take advantage of this.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
