### PR TITLE
Add some resource info into the GlobalCache

### DIFF
--- a/src/Elliptic/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/DgElementArray.hpp
@@ -105,7 +105,9 @@ struct DgElementArray {
   using phase_dependent_action_list = PhaseDepActionList;
   using array_index = ElementId<volume_dim>;
 
-  using const_global_cache_tags = tmpl::list<domain::Tags::Domain<volume_dim>>;
+  using const_global_cache_tags =
+      tmpl::list<domain::Tags::Domain<volume_dim>,
+                 Parallel::Tags::ResourceInfo<Metavariables>>;
 
   using array_allocation_tags =
       typename ElementsAllocator::template array_allocation_tags<

--- a/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
@@ -54,7 +54,9 @@ struct DgElementArray {
   using phase_dependent_action_list = PhaseDepActionList;
   using array_index = ElementId<volume_dim>;
 
-  using const_global_cache_tags = tmpl::list<domain::Tags::Domain<volume_dim>>;
+  using const_global_cache_tags =
+      tmpl::list<domain::Tags::Domain<volume_dim>,
+                 Parallel::Tags::ResourceInfo<Metavariables>>;
 
   using array_allocation_tags =
       tmpl::list<domain::Tags::InitialRefinementLevels<volume_dim>>;

--- a/src/Parallel/GlobalCache.ci
+++ b/src/Parallel/GlobalCache.ci
@@ -6,6 +6,7 @@ module GlobalCache {
   include "optional";
   include "Parallel/GlobalCacheDeclare.hpp";
   include "Parallel/ParallelComponentHelpers.hpp";
+  include "Parallel/ResourceInfo.hpp";
   include "Utilities/TaggedTuple.hpp";
   include "Parallel/Main.decl.h";
 
@@ -37,6 +38,8 @@ module GlobalCache {
     template <typename GlobalCacheTag, typename Function, typename... Args>
     entry void mutate(std::tuple<Args...> & args);
     entry void compute_size_for_memory_monitor(double time);
+    entry void set_resource_info(
+        const Parallel::ResourceInfo<Metavariables>& resource_info);
   }
   }  // namespace Parallel
 }

--- a/src/Parallel/GlobalCacheDeclare.hpp
+++ b/src/Parallel/GlobalCacheDeclare.hpp
@@ -3,12 +3,15 @@
 
 /// \file
 /// Forward-declares CProxy_GlobalCache which MutableGlobalCache needs, but
-/// GlobalCache is defined after MutableGlobalCache.
+/// GlobalCache is defined after MutableGlobalCache. Also forward declares
+/// ResourceInfo which the GlobalCache has an entry method for.
 
 #pragma once
 
 /// \cond
 namespace Parallel {
+template <typename Metavariables>
+struct ResourceInfo;
 template <class Metavariables>
 class CProxy_GlobalCache;
 }  // namespace Parallel

--- a/src/Parallel/Main.hpp
+++ b/src/Parallel/Main.hpp
@@ -468,6 +468,14 @@ Main<Metavariables>::Main(CkArgMsg* msg) {
   resource_info_.build_singleton_map(
       *Parallel::local_branch(global_cache_proxy_));
 
+  // Now that the singleton map has been built, set the resource info in the
+  // GlobalCache (if the tags exist). Since this info will be constant
+  // throughout a simulation, we opt for directly editing the tags in the const
+  // GlobalCache before we pass it to any other parallel component rather than
+  // having the tags in the MutableGlobalCache and using a mutate call to set
+  // them.
+  global_cache_proxy_.set_resource_info(resource_info_);
+
   // Now that the singleton map has been built, we have to replace the
   // ResourceInfo that was created from options with the one that has all the
   // correct singleton assignments so simple tags can be created from options

--- a/src/Parallel/Tags/ResourceInfo.hpp
+++ b/src/Parallel/Tags/ResourceInfo.hpp
@@ -30,6 +30,10 @@ namespace Tags {
 /// \ingroup ParallelGroup
 /// Tag that tells whether to avoid placing Singleton and Array components
 /// on the global proc 0
+///
+/// We include this tag in addition to Parallel::Tags::ResourceInfo even though
+/// this tag's info is contained in Parallel::Tags::ResourceInfo because this
+/// tag will inform what the input file looks like
 struct AvoidGlobalProc0 : db::SimpleTag {
   using type = bool;
   template <typename Metavariables>
@@ -61,6 +65,33 @@ struct SingletonInfo : db::SimpleTag {
   static type create_from_options(
       const Parallel::ResourceInfo<Metavariables>& resource_info) {
     return resource_info.template get_singleton_info<ParallelComponent>();
+  }
+};
+
+/// \ingroup ParallelGroup
+/// Tag to retrieve the ResourceInfo.
+///
+/// \details This tag is meant to be used in the GlobalCache. It can be created
+/// from options, but since it must be specially created inside Main and
+/// assigned to the GlobalCache after all the global cache tags are created from
+/// options, the return of `create_from_options` is just a default constructed
+/// Parallel::ResourceInfo.
+template <typename Metavariables>
+struct ResourceInfo : db::SimpleTag {
+  using type = Parallel::ResourceInfo<Metavariables>;
+
+  static constexpr bool pass_metavariables = true;
+
+  // The option tag is needed to force it's inclusion in the input file, but we
+  // don't actually use its value to create from options. See docs for this tag
+  // for an explanation.
+  template <typename Metavars>
+  using option_tags = tmpl::list<Parallel::OptionTags::ResourceInfo<Metavars>>;
+
+  template <typename Metavars>
+  static type create_from_options(
+      const Parallel::ResourceInfo<Metavars>& /*resource_info*/) {
+    return type{};
   }
 };
 }  // namespace Tags

--- a/tests/Unit/Parallel/Test_GlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_GlobalCache.cpp
@@ -31,6 +31,8 @@
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "Parallel/ResourceInfo.hpp"
+#include "Parallel/Tags/ResourceInfo.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MemoryHelpers.hpp"
@@ -201,6 +203,8 @@ struct NodegroupParallelComponent {
 };
 
 struct TestMetavariables {
+  using const_global_cache_tags =
+      tmpl::list<Parallel::Tags::ResourceInfo<TestMetavariables>>;
   using component_list =
       tmpl::list<SingletonParallelComponent<TestMetavariables>,
                  ArrayParallelComponent<TestMetavariables>,
@@ -382,9 +386,11 @@ template <typename Metavariables>
 void Test_GlobalCache<Metavariables>::run_single_core_test() {
   using const_tag_list =
       typename Parallel::get_const_global_cache_tags<TestMetavariables>;
-  static_assert(std::is_same_v<const_tag_list,
-                               tmpl::list<name, age, height, shape_of_nametag>>,
-                "Wrong const_tag_list in GlobalCache test");
+  static_assert(
+      std::is_same_v<const_tag_list,
+                     tmpl::list<Parallel::Tags::ResourceInfo<TestMetavariables>,
+                                name, age, height, shape_of_nametag>>,
+      "Wrong const_tag_list in GlobalCache test");
 
   using mutable_tag_list =
       typename Parallel::get_mutable_global_cache_tags<TestMetavariables>;
@@ -393,7 +399,8 @@ void Test_GlobalCache<Metavariables>::run_single_core_test() {
       "Wrong mutable_tag_list in GlobalCache test");
 
   tuples::tagged_tuple_from_typelist<const_tag_list> const_data_to_be_cached(
-      "Nobody", 178, 2.2, std::make_unique<Square>());
+      Parallel::ResourceInfo<Metavariables>{}, "Nobody", 178, 2.2,
+      std::make_unique<Square>());
   tuples::tagged_tuple_from_typelist<mutable_tag_list>
       mutable_data_to_be_cached(160, std::make_unique<Arthropod>(6),
                                 "joe@somewhere.com");
@@ -443,7 +450,8 @@ void Test_GlobalCache<Metavariables>::run_single_core_test() {
 
   Parallel::GlobalCache<TestMetavariables> cache_with_serialized_mutable_cache(
       tuples::tagged_tuple_from_typelist<const_tag_list>{
-          "Nobody", 178, 2.2, std::make_unique<Square>()},
+          Parallel::ResourceInfo<Metavariables>{}, "Nobody", 178, 2.2,
+          std::make_unique<Square>()},
       &serialized_and_deserialized_mutable_cache);
   SPECTRE_PARALLEL_REQUIRE(
       150 == Parallel::get<weight>(cache_with_serialized_mutable_cache));
@@ -501,9 +509,11 @@ Test_GlobalCache<Metavariables>::Test_GlobalCache(CkArgMsg*
 
   using const_tag_list =
       typename Parallel::get_const_global_cache_tags<TestMetavariables>;
-  static_assert(std::is_same_v<const_tag_list,
-                               tmpl::list<name, age, height, shape_of_nametag>>,
-                "Wrong const_tag_list in GlobalCache test");
+  static_assert(
+      std::is_same_v<const_tag_list,
+                     tmpl::list<Parallel::Tags::ResourceInfo<TestMetavariables>,
+                                name, age, height, shape_of_nametag>>,
+      "Wrong const_tag_list in GlobalCache test");
   static_assert(
       Parallel::is_in_const_global_cache<TestMetavariables, shape_of_nametag>);
   static_assert(
@@ -519,15 +529,28 @@ Test_GlobalCache<Metavariables>::Test_GlobalCache(CkArgMsg*
                                                shape_of_nametag_base>);
 
   tuples::tagged_tuple_from_typelist<const_tag_list> const_data_to_be_cached(
-      "Nobody", 178, 2.2, std::make_unique<Square>());
+      Parallel::ResourceInfo<Metavariables>{}, "Nobody", 178, 2.2,
+      std::make_unique<Square>());
   global_cache_proxy_ = Parallel::CProxy_GlobalCache<TestMetavariables>::ckNew(
       const_data_to_be_cached, mutable_global_cache_proxy_, std::nullopt,
       &mutable_global_cache_dependency);
+
+  Parallel::ResourceInfo<TestMetavariables> resource_info{
+      false, Parallel::SingletonPack<tmpl::list<>>{}};
 
   const auto local_cache = Parallel::local_branch(global_cache_proxy_);
   auto mutable_global_cache_proxy = local_cache->mutable_global_cache_proxy();
   SPECTRE_PARALLEL_REQUIRE(mutable_global_cache_proxy ==
                            mutable_global_cache_proxy_);
+
+  resource_info.build_singleton_map(*local_cache);
+
+  local_cache->set_resource_info(resource_info);
+
+  const auto& cache_resource_info =
+      Parallel::get<Parallel::Tags::ResourceInfo<Metavariables>>(*local_cache);
+
+  SPECTRE_PARALLEL_REQUIRE(cache_resource_info == resource_info);
 
   CkEntryOptions global_cache_dependency;
   global_cache_dependency.setGroupDepID(global_cache_proxy_.ckGetGroupID());

--- a/tests/Unit/Parallel/Test_GlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_GlobalCache.cpp
@@ -286,10 +286,9 @@ void TestArrayChare<Metavariables>::run_test_two() {
           *Parallel::local_branch(global_cache_proxy_),
           [&callback](
               const double& weight_l) -> std::unique_ptr<Parallel::Callback> {
-            return weight_l == 150
-                       ? std::unique_ptr<Parallel::Callback>{}
-                       : std::unique_ptr<Parallel::Callback>(
-                             new UseCkCallbackAsCallback(callback));
+            return weight_l == 150 ? std::unique_ptr<Parallel::Callback>{}
+                                   : std::unique_ptr<Parallel::Callback>(
+                                         new UseCkCallbackAsCallback(callback));
           })) {
     auto& local_cache = *Parallel::local_branch(global_cache_proxy_);
     SPECTRE_PARALLEL_REQUIRE(150 == Parallel::get<weight>(local_cache));

--- a/tests/Unit/Parallel/Test_ResourceInfo.cpp
+++ b/tests/Unit/Parallel/Test_ResourceInfo.cpp
@@ -70,6 +70,12 @@ struct MetavariablesAvoidGlobalProc0 {
       tmpl::list<FakeSingletonAvoidGlobalProc0<MetavariablesAvoidGlobalProc0>>;
 };
 
+struct MetavariablesResourceInfoOnly {
+  using get_const_global_cache_tags =
+      tmpl::list<Parallel::Tags::ResourceInfo<MetavariablesResourceInfoOnly>>;
+  using component_list = tmpl::list<>;
+};
+
 struct EmptyMetavars {};
 
 template <size_t Index>
@@ -308,6 +314,14 @@ void test_single_core() {
         "AvoidGlobalProc0: false\n");
 
     CHECK_FALSE(resource_info.avoid_global_proc_0());
+  }
+  {
+    INFO("Only ResourceInfo tag");
+    const auto resource_info = TestHelpers::test_option_tag<
+        OptionTags::ResourceInfo<MetavariablesResourceInfoOnly>>("");
+
+    CHECK(resource_info ==
+          Parallel::ResourceInfo<MetavariablesResourceInfoOnly>{});
   }
 }
 

--- a/tests/Unit/Parallel/Test_ResourceInfo.cpp
+++ b/tests/Unit/Parallel/Test_ResourceInfo.cpp
@@ -180,6 +180,8 @@ void test_tags() {
   TestHelpers::db::test_simple_tag<
       Tags::SingletonInfo<FakeSingleton<metavars, 0>>>("FakeSingleton0");
   TestHelpers::db::test_simple_tag<Tags::AvoidGlobalProc0>("AvoidGlobalProc0");
+  TestHelpers::db::test_simple_tag<Tags::ResourceInfo<metavars>>(
+      "ResourceInfo");
 
   Parallel::MutableGlobalCache<metavars> mutable_cache{};
   Parallel::GlobalCache<metavars> cache{{}, &mutable_cache};
@@ -194,8 +196,10 @@ void test_tags() {
 
   const auto tag_info_holder = Tags::SingletonInfo<
       FakeSingleton<metavars, 0>>::create_from_options<metavars>(resource_info);
-  CHECK(info_holder.proc() == tag_info_holder.proc());
-  CHECK(info_holder.is_exclusive() == tag_info_holder.is_exclusive());
+  CHECK(tag_info_holder == info_holder);
+
+  CHECK(Tags::ResourceInfo<metavars>::create_from_options<metavars>(
+            resource_info) == Parallel::ResourceInfo<metavars>{});
 }
 
 void test_single_core() {


### PR DESCRIPTION
## Proposed changes

Adds the `Parallel::Tags::ResourceInfo` tag to the global cache.

To do this cleanly, I had to add an entry method to the global cache that will set the resource info tags. This entry method should only be called once, similar to `set_parallel_components`.

If any proc info is needed for #4293, this is where it will be stored.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
