### PR TITLE
Enable catch STL printing

### DIFF
--- a/tests/Unit/Framework/TestingFramework.hpp
+++ b/tests/Unit/Framework/TestingFramework.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#define CATCH_CONFIG_ENABLE_ALL_STRINGMAKERS
+
 #include <blaze/math/typetraits/IsColumnMajorMatrix.h>
 #include <blaze/math/typetraits/IsDenseMatrix.h>
 #include <catch.hpp>


### PR DESCRIPTION
This enables display in catch failures of the following types:
* std::pair
* std::tuple
* std::optional
* std::variant
* various std::chrono::*

Note that sequence containers were already supported.

Maps previously attempted to print their contents but mostly failed because their contents were key-value pairs.  This now works.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
