### PR TITLE
Remove deprecated `std::binary_function`

### DIFF
--- a/src/Utilities/Array.hpp
+++ b/src/Utilities/Array.hpp
@@ -96,7 +96,7 @@ struct array {
 };
 namespace detail {
 template <typename T = void>
-struct Equal : std::binary_function<T, T, bool> {
+struct Equal {
   constexpr bool inline operator()(const T& lhs, const T& rhs) const {
     return lhs == rhs;
   }


### PR DESCRIPTION
Removes one occurrence of `std::binary_function` which has been deprecated since C++11. This threw a warning for me with g++-12 .