### PR TITLE
Add missing documentations on electron fraction

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -21,6 +21,21 @@
   SLACcitation   = "%%CITATION = GR-QC/0305023;%%"
 }
 
+@article{Anton2006,
+  author    = {Luis Antón and Olindo Zanotti and Juan A. Miralles
+               and José M. Martí and José M. Ibáñez and José A. Font
+               and José A. Pons},
+  doi       = {10.1086/498238},
+  journal   = {The Astrophysical Journal},
+  month     = {jan},
+  pages     = {296},
+  title     = {Numerical 3+1 General Relativistic Magnetohydrodynamics:
+               A Local Characteristic Approach},
+  url       = {https://dx.doi.org/10.1086/498238},
+  volume    = {637},
+  year      = {2006}
+}
+
 @article{Ayachour2003,
   author    = "Ayachour, E.H.",
   title     = "A fast implementation for {GMRES} method",
@@ -526,6 +541,23 @@ eprint = {https://doi.org/10.1137/0916035}
   pages    = "445-473",
   doi      = "10.1137/0909030",
   url      = "https://doi.org/10.1137/0909030"
+}
+
+@article{Deaton2013,
+  author    = {M. Brett Deaton and Matthew D. Duez and Francois Foucart
+               and Evan O'Connor and Christian D. Ott and Lawrence E. Kidder
+               and Curran D. Muhlberger and Mark A. Scheel and Bela Szilagyi},
+  doi       = {10.1088/0004-637X/776/1/47},
+  journal   = {The Astrophysical Journal},
+  month     = {sep},
+  pages     = {47},
+  publisher = {The American Astronomical Society},
+  title     = {BLACK HOLE–NEUTRON STAR MERGERS WITH A HOT NUCLEAR EQUATION OF
+               STATE: OUTFLOW AND NEUTRINO-COOLED DISK FOR A LOW-MASS,
+               HIGH-SPIN CASE},
+  url       = {https://dx.doi.org/10.1088/0004-637X/776/1/47},
+  volume    = {776},
+  year      = {2013}
 }
 
 @article{Dedner2002,
@@ -1364,6 +1396,23 @@ eprint = {https://doi.org/10.1137/0916035}
   volume =       "31",
   pages =        "015005",
   year =         "2014"
+}
+
+@article{Moesta2014,
+  author    = {Philipp Mösta and Bruno C Mundim and Joshua A Faber
+               and Roland Haas and Scott C Noble and Tanja Bode
+               and Frank Löffler and Christian D Ott and Christian Reisswig
+               and Erik Schnetter},
+  doi       = {10.1088/0264-9381/31/1/015005},
+  journal   = {Classical and Quantum Gravity},
+  month     = {nov},
+  pages     = {015005},
+  publisher = {IOP Publishing},
+  title     = {GRHydro: a new open-source general-relativistic
+               magnetohydrodynamics code for the Einstein toolkit},
+  url       = {https://dx.doi.org/10.1088/0264-9381/31/1/015005},
+  volume    = {31},
+  year      = {2013}
 }
 
 @article{Moldenhauer2014yaa,

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/PrimitiveGhostData.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/PrimitiveGhostData.hpp
@@ -22,11 +22,11 @@ class Variables;
 
 namespace grmhd::GhValenciaDivClean::subcell {
 /*!
- * \brief Computes the rest mass density \f$\rho\f$, pressure \f$p\f$,
- * Lorentz factor times the spatial velocity \f$W v^i\f$, magnetic field
- * \f$B^i\f$, the divergence cleaning field \f$\Phi\f$, and the generalized
- * harmonic evolved variables \f$g_{ab}\f$, \f$\Phi_{iab}\f$ and \f$\Pi_{ab}\f$
- * on the subcells so they can be used for reconstruction.
+ * \brief Computes the rest mass density \f$\rho\f$, electron fraction
+ * \f$Y_e\f$, pressure \f$p\f$, Lorentz factor times the spatial velocity \f$W
+ * v^i\f$, magnetic field \f$B^i\f$, the divergence cleaning field \f$\Phi\f$,
+ * and the generalized harmonic evolved variables \f$g_{ab}\f$, \f$\Phi_{iab}\f$
+ * and \f$\Pi_{ab}\f$ on the subcells so they can be used for reconstruction.
  *
  * The computation copies the data from the primitive variables to a new
  * Variables and computes \f$W v^i\f$. In the future we will likely want to
@@ -66,10 +66,10 @@ class PrimitiveGhostDataOnSubcells {
 };
 
 /*!
- * \brief Projects the rest mass density \f$\rho\f$, pressure \f$p\f$, Lorentz
- * factor times the spatial velocity \f$W v^i\f$, magnetic field \f$B^i\f$, and
- * the divergence cleaning field \f$\Phi\f$ so they can be sent to neighbors
- * for subcell reconstruction.
+ * \brief Projects the rest mass density \f$\rho\f$, electron fraction
+ * \f$Y_e\f$, pressure \f$p\f$, Lorentz factor times the spatial velocity \f$W
+ * v^i\f$, magnetic field \f$B^i\f$, and the divergence cleaning field
+ * \f$\Phi\f$ so they can be sent to neighbors for subcell reconstruction.
  *
  * The computation copies the data from the primitive variables to a new
  * Variables and computes \f$W v^i\f$, then does the projection. In the future

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/FreeOutflow.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/FreeOutflow.cpp
@@ -226,10 +226,9 @@ void FreeOutflow::fd_ghost(
 
     get<RestMassDensity>(outermost_prim_vars) =
         get_boundary_val(interior_rest_mass_density);
-
-    get<Pressure>(outermost_prim_vars) = get_boundary_val(interior_pressure);
     get<ElectronFraction>(outermost_prim_vars) =
         get_boundary_val(interior_electron_fraction);
+    get<Pressure>(outermost_prim_vars) = get_boundary_val(interior_pressure);
 
     // Kill ingoing components of spatial velocity and compute Wv^i
     //

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.hpp
@@ -32,6 +32,7 @@ namespace ValenciaDivClean {
  *
  * \f{align*}
  * {\tilde D} = & \sqrt{\gamma} \rho W \\
+ * {\tilde Y}_e = & \sqrt{\gamma} \rho Y_e W \\
  * {\tilde S}_i = & \sqrt{\gamma} \left( \rho h W^2 v_i + B^m B_m v_i - B^m v_m
  * B_i \right) \\
  * {\tilde \tau} = & \sqrt{\gamma} \left[ \rho h W^2 - p - \rho W - \frac{1}{2}
@@ -40,15 +41,16 @@ namespace ValenciaDivClean {
  * {\tilde \Phi} = & \sqrt{\gamma} \Phi
  * \f}
  *
- * where the conserved variables \f${\tilde D}\f$, \f${\tilde S}_i\f$,
- * \f${\tilde \tau}\f$, \f${\tilde B}^i\f$, and \f${\tilde \Phi}\f$ are a
- * generalized mass-energy density, momentum density, specific internal energy
- * density, magnetic field, and divergence cleaning field.  Furthermore
- * \f$\gamma\f$ is the determinant of the spatial metric, \f$\rho\f$ is the rest
- * mass density, \f$W = 1/\sqrt{1-v_i v^i}\f$ is the Lorentz factor, \f$h = 1 +
- * \epsilon + \frac{p}{\rho}\f$ is the specific enthalpy, \f$v^i\f$ is the
- * spatial velocity, \f$\epsilon\f$ is the specific internal energy, \f$p\f$ is
- * the pressure, \f$B^i\f$ is the spatial magnetic field measured by an Eulerian
+ * where the conserved variables \f${\tilde D}\f$, \f$\tilde{Y}_e\f$, \f${\tilde
+ * S}_i\f$, \f${\tilde \tau}\f$, \f${\tilde B}^i\f$, and \f${\tilde \Phi}\f$ are
+ * a generalized mass-energy density, electron fraction, momentum density,
+ * specific internal energy density, magnetic field, and divergence cleaning
+ * field.  Furthermore \f$\gamma\f$ is the determinant of the spatial metric,
+ * \f$\rho\f$ is the rest mass density, \f$Y_e\f$ is the electron fraction,
+ * \f$W = 1/\sqrt{1-v_i v^i}\f$ is the Lorentz factor, \f$h = 1 + \epsilon +
+ * \frac{p}{\rho}\f$ is the specific enthalpy, \f$v^i\f$ is the spatial
+ * velocity, \f$\epsilon\f$ is the specific internal energy, \f$p\f$ is the
+ * pressure, \f$B^i\f$ is the spatial magnetic field measured by an Eulerian
  * observer, and \f$\Phi\f$ is a divergence cleaning field.
  *
  * The quantity \f${\tilde \tau}\f$ is rewritten as in `RelativisticEuler`

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.hpp
@@ -53,7 +53,7 @@ namespace grmhd::ValenciaDivClean::fd {
  * \brief Positivity-preserving adaptive order reconstruction. See
  * ::fd::reconstruction::positivity_preserving_adaptive_order() for details.
  *
- * The rest mass density and the pressure are kept positive.
+ * The rest mass density, electron fraction, and the pressure are kept positive.
  */
 class PositivityPreservingAdaptiveOrderPrim : public Reconstructor {
  private:

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp
@@ -35,6 +35,7 @@ namespace ValenciaDivClean {
  *
  * \f{align*}
  * F^i({\tilde D}) = &~ {\tilde D} v^i_{tr} \\
+ * F^i({\tilde Y}_e) = &~ {\tilde Y}_e v^i_{tr} \\
  * F^i({\tilde S}_j) = &~  {\tilde S}_j v^i_{tr} + \sqrt{\gamma} \alpha \left( p
  * + p_m \right) \delta^i_j - \frac{B_j {\tilde B}^i}{W^2} - v_j {\tilde B}^i
  * B^m v_m\\
@@ -45,13 +46,14 @@ namespace ValenciaDivClean {
  * F^i({\tilde \Phi}) = &~ \alpha {\tilde B^i} - \beta^i {\tilde \Phi}
  * \f}
  *
- * where the conserved variables \f${\tilde D}\f$, \f${\tilde S}_i\f$,
- * \f${\tilde \tau}\f$, \f${\tilde B}^i\f$, and \f${\tilde \Phi}\f$ are a
- * generalized mass-energy density, momentum density, specific internal energy
- * density, magnetic field, and divergence cleaning field.  Furthermore,
- * \f$v^i_{tr} = \alpha v^i - \beta^i\f$ is the transport velocity, \f$\alpha\f$
- * is the lapse, \f$\beta^i\f$ is the shift, \f$\gamma\f$ is the determinant of
- * the spatial metric \f$\gamma_{ij}\f$,  \f$v^i\f$ is the spatial velocity,
+ * where the conserved variables \f${\tilde D}\f$, \f${\tilde Y}_e\f$,
+ * \f${\tilde S}_i\f$, \f${\tilde \tau}\f$, \f${\tilde B}^i\f$, and \f${\tilde
+ * \Phi}\f$ are a generalized mass-energy density, electron fraction, momentum
+ * density, specific internal energy density, magnetic field, and divergence
+ * cleaning field. Furthermore, \f$v^i_{tr} = \alpha v^i - \beta^i\f$ is the
+ * transport velocity, \f$\alpha\f$ is the lapse, \f$\beta^i\f$ is the shift,
+ * \f$\gamma\f$ is the determinant of the spatial metric \f$\gamma_{ij}\f$,
+ * \f$Y_e\f$ is the electron fraction, \f$v^i\f$ is the spatial velocity,
  * \f$B^i\f$ is the spatial magnetic field measured by an Eulerian observer,
  * \f$p\f$ is the fluid pressure, and \f$p_m = \frac{1}{2} \left[ \left( B^n v_n
  * \right)^2 + B^n B_n / W^2 \right]\f$ is the magnetic pressure.

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Sources.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Sources.hpp
@@ -32,8 +32,8 @@ namespace ValenciaDivClean {
 
 /*!
  * \brief Compute the source terms for the flux-conservative Valencia
- * formulation of GRMHD with divergence cleaning.
- *
+ * formulation of GRMHD with divergence cleaning, coupled with electron
+ * fraction.
  *
  * A flux-conservative system has the generic form:
  * \f[
@@ -80,6 +80,12 @@ namespace ValenciaDivClean {
  * \f$K_{ij}\f$, and \f$\kappa\f$ is a damping parameter that damps violations
  * of the divergence-free (no-monopole) condition \f$\Phi = \partial_i {\tilde
  * B}^i = 0\f$ .
+ *
+ * \note For the electron fraction side, the source term is currently set to
+ * \f$S(\tilde{Y}_e) = 0\f$ where the conserved variable \f$\tilde{Y}_e\f$ is a
+ * generalized electron fraction. Implementing the source term using neutrino
+ * scheme is in progress (Last update : Oct 2022).
+ *
  */
 struct ComputeSources {
   using return_tags =

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/InitialDataTci.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/InitialDataTci.hpp
@@ -49,10 +49,11 @@ std::tuple<int, evolution::dg::subcell::RdmpTciData> initial_data_tci_work(
  * <caption>List of checks</caption>
  * <tr><th> Description <th> TCI status
  *
- * <tr><td> if `TildeD` on the DG or subcell grid (projected from the DG grid,
- * not initialized to the initial data) is less than
- * `tci_options.minimum_rest_mass_density_times_lorentz_factor` then the element
- * is flagged as troubled.
+ * <tr><td> if `TildeD` and `TildeYe` on the DG or subcell grid (projected from
+ * the DG grid, not initialized to the initial data) is less than
+ * `tci_options.minimum_rest_mass_density_times_lorentz_factor` and
+ * `tci_options.minimum_rest_mass_density_times_lorentz_factor` times
+ * `tci_options.minimum_ye`, respectively, the element is flagged as troubled.
  * <td> `-1`
  *
  * <tr><td> if `TildeTau` on the DG or subcell grid (projected from

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/PrimitiveGhostData.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/PrimitiveGhostData.hpp
@@ -19,10 +19,10 @@ class Variables;
 
 namespace grmhd::ValenciaDivClean::subcell {
 /*!
- * \brief Computes the rest mass density \f$\rho\f$, pressure \f$p\f$,
- * Lorentz factor times the spatial velocity \f$W v^i\f$, magnetic field
- * \f$B^i\f$, and the divergence cleaning field \f$\Phi\f$ on the subcells so
- * they can be used for reconstruction.
+ * \brief Computes the rest mass density \f$\rho\f$, electron fraction
+ * \f$Y_e\f$, pressure \f$p\f$, Lorentz factor times the spatial velocity \f$W
+ * v^i\f$, magnetic field \f$B^i\f$, and the divergence cleaning field
+ * \f$\Phi\f$ on the subcells so they can be used for reconstruction.
  *
  * The computation copies the data from the primitive variables to a new
  * Variables and computes \f$W v^i\f$. In the future we will likely want to
@@ -51,10 +51,11 @@ class PrimitiveGhostDataOnSubcells {
 };
 
 /*!
- * \brief Projects the rest mass density \f$\rho\f$, pressure \f$p\f$, Lorentz
- * factor times the spatial velocity \f$W v^i\f$, magnetic field \f$B^i\f$, and
- * the divergence cleaning field \f$\Phi\f$ so they can be projected to the
- * subcells and sent to neighbors for subcell reconstruction.
+ * \brief Projects the rest mass density \f$\rho\f$, electron fraction
+ * \f$Y_e\f$, pressure \f$p\f$, Lorentz factor times the spatial velocity \f$W
+ * v^i\f$, magnetic field \f$B^i\f$, and the divergence cleaning field
+ * \f$\Phi\f$ so they can be projected to the subcells and sent to neighbors for
+ * subcell reconstruction.
  *
  * The computation copies the data from the primitive variables to a new
  * Variables and computes \f$W v^i\f$, then does the projection. In the future

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.hpp
@@ -56,9 +56,12 @@ namespace grmhd::ValenciaDivClean::subcell {
  *
  * <tr><td> if \f$\min(\tilde{D}^{n+1}/\textrm{avg}(\sqrt{\gamma^{n}}))\f$
  * is less than `tci_options.minimum_rest_mass_density_times_lorentz_factor`
- * then we have a negative (or extremely small) density and the cell is
- * troubled. Note that if this `tci_option` is approximately equal to or larger
- * than the `atmosphere_density`, the atmosphere will be flagged as troubled.
+ * or if \f$\min(\tilde{Y}_e^{n+1}/\textrm{avg}(\sqrt{\gamma^{n}}))\f$ is less
+ * than `tci_options.minimum_rest_mass_density_times_lorentz_factor` times
+ * `tci_options.minimum_ye`, we have a negative (or extremely small) density or
+ * electron fraction and the cell is troubled. Note that if this `tci_option` is
+ * approximately equal to or larger than the `atmosphere_density`, the
+ * atmosphere will be flagged as troubled.
  * <td> `-1`
  *
  * <tr><td> if \f$\tilde{\tau}\f$ is less than `tci_options.minimum_tilde_tau`
@@ -85,8 +88,8 @@ namespace grmhd::ValenciaDivClean::subcell {
  * magnetic field is still freely evolved.
  * <td> `0`
  *
- * <tr><td> apply the Persson TCI to \f$\tilde{D}^{n+1}\f$ and
- * \f$\tilde{\tau}^{n+1}\f$
+ * <tr><td> apply the Persson TCI to \f$\tilde{D}^{n+1}\f$,
+ * \f$\tilde{Y}_e^{n+1}\f$, and \f$\tilde{\tau}^{n+1}\f$
  * <td> `-5`
  *
  * <tr><td> apply the Persson TCI to the magnitude of \f$\tilde{B}^{n+1}\f$ if

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.hpp
@@ -44,12 +44,15 @@ namespace grmhd::ValenciaDivClean::subcell {
  * <td> `+1`
  *
  * <tr><td> if `min(tilde_d)` is less than
- *   `tci_options.minimum_rest_mass_density_times_lorentz_factor` or if
- *   `min(tilde_tau)` is less than `tci_options.minimum_tilde_tau` then the we
- *   remain on FD.
+ *  `tci_options.minimum_rest_mass_density_times_lorentz_factor`, or if
+ *  `min(tilde_ye)` is less than
+ *  `tci_options.minimum_rest_mass_density_times_lorentz_factor` times
+ *  `tci_options.minimum_ye`, or if `min(tilde_tau)` is less than
+ *  `tci_options.minimum_tilde_tau`, then the we remain on FD.
  * <td> `+2`
  *
- * <tr><td> apply the Persson TCI to \f$\tilde{D}\f$ and \f$\tilde{\tau}\f$
+ * <tr><td> apply the Persson TCI to \f$\tilde{D}\f$, \f$\tilde{Y}_e\f$, and
+ * \f$\tilde{\tau}\f$
  * <td> `+3`
  *
  * <tr><td> apply the RDMP TCI to `TildeD`

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp
@@ -21,14 +21,18 @@
 /// \ingroup EvolutionSystemsGroup
 /// \brief Items related to general relativistic magnetohydrodynamics (GRMHD)
 namespace grmhd {
-/// The Valencia formulation of ideal GRMHD with divergence cleaning.
+/// The Valencia formulation of ideal GRMHD with divergence cleaning coupled
+/// with electron fraction.
 ///
 /// References:
-/// - [Numerical 3+1 General Relativistic Magnetohydrodynamics: A Local
-/// Characteristic Approach](http://iopscience.iop.org/article/10.1086/498238)
-/// - [GRHydro: a new open-source general-relativistic magnetohydrodynamics code
-/// for the Einstein toolkit]
-/// (http://iopscience.iop.org/article/10.1088/0264-9381/31/1/015005)
+/// - Numerical 3+1 General Relativistic Magnetohydrodynamics: A Local
+/// Characteristic Approach \cite Anton2006
+/// - GRHydro: a new open-source general-relativistic magnetohydrodynamics code
+/// for the Einstein toolkit \cite Moesta2014
+/// - Black hole-neutron star mergers with a hot nuclear equation of state:
+/// outflow and neutrino-cooled disk for a low-mass, high-spin case
+/// \cite Deaton2013
+///
 namespace ValenciaDivClean {
 
 struct System {

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp
@@ -32,7 +32,8 @@ struct TildeD : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 
-/// The densitized electron_fraction \f${\tilde Ye}\f$
+/// The densitized electron number density times the baryon mass
+/// \f$\tilde{Y}_e = {\tilde D} Y_e\f$
 struct TildeYe : db::SimpleTag {
   using type = Scalar<DataVector>;
 };


### PR DESCRIPTION
## Proposed changes

As a follow up of #4163, this PR fills some missing docs with a couple of minor fixes.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
