### PR TITLE
Make electron fraction cutoff and min value as an input file option

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FixConservatives.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FixConservatives.hpp
@@ -27,6 +27,9 @@ namespace ValenciaDivClean {
  * \brief Fix conservative variables using method developed by Foucart.
  *
  * Adjusts the conservative variables as follows:
+ * - If the electron fraction \f$Y_e\f$ is below the value of the option
+ *   `CutoffYe`, change \f$\tilde{Y}_e\f$ to \f$\tilde{D}\f$ times the value of
+ *   the option `MinimumValueOfYe`.
  * - Changes \f${\tilde D}\f$, the generalized mass-energy density, such
  *   that \f$D\f$, the product of the rest mass density \f$\rho\f$ and the
  *   Lorentz factor \f$W\f$, is set to value of the option `MinimumValueOfD`,
@@ -102,7 +105,20 @@ class FixConservatives {
     static constexpr Options::String help = {
         "Cutoff below which D is set to MinimumValueOfD"};
   };
-
+  /// \brief Minimum value of electron fraction \f$Y_e\f$
+  struct MinimumValueOfYe {
+    using type = double;
+    static type lower_bound() { return 0.0; }
+    static constexpr Options::String help = {
+        "Minimum value of electron fraction"};
+  };
+  /// \brief Cutoff below which \f$Y_e\f$ is set to MinimumValueOfYe
+  struct CutoffYe {
+    using type = double;
+    static type lower_bound() { return 0.0; }
+    static constexpr Options::String help = {
+        "Cutoff below which Y_e is set to MinimumValueOfYe"};
+  };
   /// \brief Safety factor \f$\epsilon_B\f$.
   struct SafetyFactorForB {
     using type = double;
@@ -117,13 +133,15 @@ class FixConservatives {
     static constexpr Options::String help = {
         "Safety factor for momentum density bound."};
   };
-  using options =
-      tmpl::list<MinimumValueOfD, CutoffD, SafetyFactorForB, SafetyFactorForS>;
+  using options = tmpl::list<MinimumValueOfD, CutoffD, MinimumValueOfYe,
+                             CutoffYe, SafetyFactorForB, SafetyFactorForS>;
   static constexpr Options::String help = {
       "Variable fixing used in Foucart's thesis.\n"};
 
   FixConservatives(double minimum_rest_mass_density_times_lorentz_factor,
                    double rest_mass_density_times_lorentz_factor_cutoff,
+                   double minimum_electron_fraction,
+                   double electron_fraction_cutoff,
                    double safety_factor_for_magnetic_field,
                    double safety_factor_for_momentum_density,
                    const Options::Context& context = {});
@@ -165,6 +183,10 @@ class FixConservatives {
   double minimum_rest_mass_density_times_lorentz_factor_{
       std::numeric_limits<double>::signaling_NaN()};
   double rest_mass_density_times_lorentz_factor_cutoff_{
+      std::numeric_limits<double>::signaling_NaN()};
+  double minimum_electron_fraction_{
+      std::numeric_limits<double>::signaling_NaN()};
+  double electron_fraction_cutoff_{
       std::numeric_limits<double>::signaling_NaN()};
   double one_minus_safety_factor_for_magnetic_field_{
       std::numeric_limits<double>::signaling_NaN()};

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -63,6 +63,8 @@ VariableFixing:
   FixConservatives:
     CutoffD: 1.0e-12
     MinimumValueOfD: 1.0e-12
+    CutoffYe: 0.0
+    MinimumValueOfYe: 0.0
     SafetyFactorForB: 1.0e-12
     SafetyFactorForS: 1.0e-12
   FixToAtmosphere:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -52,6 +52,8 @@ VariableFixing:
   FixConservatives:
     CutoffD: 1.0e-12
     MinimumValueOfD: 1.0e-12
+    CutoffYe: 0.0
+    MinimumValueOfYe: 0.0
     SafetyFactorForB: 1.0e-12
     SafetyFactorForS: 1.0e-12
   FixToAtmosphere:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -81,6 +81,8 @@ VariableFixing:
   FixConservatives:
     CutoffD: 1.0e-12
     MinimumValueOfD: 1.0e-12
+    CutoffYe: 0.0
+    MinimumValueOfYe: 0.0
     SafetyFactorForB: 1.0e-12
     SafetyFactorForS: 1.0e-12
   FixToAtmosphere:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -90,6 +90,8 @@ VariableFixing:
   FixConservatives:
     CutoffD: 1.0e-12
     MinimumValueOfD: 1.0e-12
+    CutoffYe: 0.0
+    MinimumValueOfYe: 0.0
     SafetyFactorForB: 1.0e-12
     SafetyFactorForS: 1.0e-12
   FixToAtmosphere:

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_FixConservativesAndComputePrims.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_FixConservativesAndComputePrims.cpp
@@ -47,8 +47,8 @@ SPECTRE_TEST_CASE(
   const Scalar<DataVector> sqrt_det_spatial_metric{
       sqrt(get(determinant(spatial_metric)))};
 
-  const grmhd::ValenciaDivClean::FixConservatives variable_fixer{1.e-7, 1.0e-7,
-                                                                 0.0, 0.0};
+  const grmhd::ValenciaDivClean::FixConservatives variable_fixer{
+      1.e-7, 1.0e-7, 1.0e-10, 1.0e-10, 0.0, 0.0};
   typename System::variables_tag::type cons_vars{num_pts, 0.0};
   get(get<grmhd::ValenciaDivClean::Tags::TildeD>(cons_vars))[0] = 2.e-12;
   get(get<grmhd::ValenciaDivClean::Tags::TildeYe>(cons_vars))[0] = 2.e-13;

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_FixConservativesAndComputePrims.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_FixConservativesAndComputePrims.cpp
@@ -32,8 +32,8 @@ SPECTRE_TEST_CASE(
     inverse_spatial_metric.get(i, i) = 1.0;
   }
   const Scalar<DataVector> sqrt_det_spatial_metric{num_pts, 1.0};
-  const grmhd::ValenciaDivClean::FixConservatives variable_fixer{1.e-7, 1.0e-7,
-                                                                 0.0, 0.0};
+  const grmhd::ValenciaDivClean::FixConservatives variable_fixer{
+      1.e-7, 1.0e-7, 1.0e-10, 1.0e-10, 0.0, 0.0};
   typename System::variables_tag::type cons_vars{num_pts, 0.0};
   get(get<grmhd::ValenciaDivClean::Tags::TildeD>(cons_vars))[0] = 2.e-12;
   get(get<grmhd::ValenciaDivClean::Tags::TildeYe>(cons_vars))[0] = 2.e-13;

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_FixConservatives.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_FixConservatives.cpp
@@ -23,34 +23,39 @@ namespace {
 
 void test_variable_fixer(
     const grmhd::ValenciaDivClean::FixConservatives& variable_fixer) {
-  // Call variable fixer at four points
+  // Call variable fixer at five points
   // [0]:  tilde_d is too small, should be raised to limit
-  // [1]:  tilde_tau is too small, raise to level of needed, which also
+  // [1]:  tilde_ye is too small, should be raised to limit
+  // [2]:  tilde_tau is too small, raise to level of needed, which also
   //       causes tilde_s to be zeroed
-  // [2]:  tilde_S is too big, so it is lowered
-  // [3]:  all values are good, no changes
+  // [3]:  tilde_S is too big, so it is lowered
+  // [4]:  all values are good, no changes
 
-  Scalar<DataVector> tilde_d{DataVector{2.e-12, 1.0, 1.0, 1.0}};
+  Scalar<DataVector> tilde_d{DataVector{2.e-12, 1.0, 1.0, 1.0, 1.0}};
   // We assume that ye = 0.1
-  Scalar<DataVector> tilde_ye{DataVector{2.e-13, 1.0, 1.0, 1.0}};
-  Scalar<DataVector> tilde_tau{DataVector{4.5, 1.5, 4.5, 4.5}};
+  Scalar<DataVector> tilde_ye{DataVector{2.e-13, 2.0e-10, 1.0, 1.0, 1.0}};
+  Scalar<DataVector> tilde_tau{DataVector{4.5, 4.5, 1.5, 4.5, 4.5}};
   auto tilde_s =
       make_with_value<tnsr::i<DataVector, 3, Frame::Inertial>>(tilde_d, 0.0);
   auto tilde_b =
       make_with_value<tnsr::I<DataVector, 3, Frame::Inertial>>(tilde_d, 0.0);
   for (size_t d = 0; d < 3; ++d) {
-    tilde_s.get(0) = DataVector{3.0, 0.0, 6.0, 5.0};
-    tilde_b.get(1) = DataVector{2.0, 2.0, 2.0, 2.0};
+    tilde_s.get(0) = DataVector{3.0, 3.0, 0.0, 6.0, 5.0};
+    tilde_b.get(1) = DataVector{2.0, 2.0, 2.0, 2.0, 2.0};
   }
 
   auto expected_tilde_d = tilde_d;
   get(expected_tilde_d)[0] = 1.e-12;
+
   auto expected_tilde_ye = tilde_ye;
-  get(expected_tilde_ye)[0] = 1.e-13;
+  get(expected_tilde_ye)[0] = 1.e-13; // since Y_e = 0.1
+  get(expected_tilde_ye)[1] = 1.e-10;
+
   auto expected_tilde_tau = tilde_tau;
-  get(expected_tilde_tau)[1] = 2.0;
+  get(expected_tilde_tau)[2] = 2.0;
+
   auto expected_tilde_s = tilde_s;
-  expected_tilde_s.get(0)[2] = sqrt(27.0);
+  expected_tilde_s.get(0)[3] = sqrt(27.0);
 
   auto spatial_metric =
       make_with_value<tnsr::ii<DataVector, 3, Frame::Inertial>>(tilde_d, 0.0);
@@ -76,8 +81,8 @@ void test_variable_fixer(
 
 SPECTRE_TEST_CASE("Unit.Evolution.GrMhd.ValenciaDivClean.FixConservatives",
                   "[VariableFixing][Unit]") {
-  grmhd::ValenciaDivClean::FixConservatives variable_fixer{1.e-12, 1.0e-11, 0.0,
-                                                           0.0};
+  grmhd::ValenciaDivClean::FixConservatives variable_fixer{
+      1.e-12, 1.0e-11, 1.0e-10, 1.0e-9, 0.0, 0.0};
   test_variable_fixer(variable_fixer);
   test_serialization(variable_fixer);
 
@@ -85,6 +90,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.GrMhd.ValenciaDivClean.FixConservatives",
       TestHelpers::test_creation<grmhd::ValenciaDivClean::FixConservatives>(
           "MinimumValueOfD: 1.0e-12\n"
           "CutoffD: 1.0e-11\n"
+          "MinimumValueOfYe: 1.0e-10\n"
+          "CutoffYe: 1.0e-9\n"
           "SafetyFactorForB: 0.0\n"
           "SafetyFactorForS: 0.0\n");
   test_variable_fixer(fixer_from_options);


### PR DESCRIPTION
## Proposed changes

Since we have TCI criteria on the minimum value of the electron fraction Y_e, `FixConservatives` action should be fixing Y_e to a value bigger than the TCI threshold. Rather than using the hard-coded value `0.0`, this PR enables to specify the cutoff and minimum value of Y_e in input files.

### Upgrade instructions

In the `FixConservatives:` option group in the input file for GRMHD executables, add following two options
```
CutoffYe: <some double value>
MinimumValueOfYe: <some double value>
```
`CutoffYe` must be bigger than or equal to `MinimumValueOfYe`.

