### PR TITLE
Add more atmosphere treatments to TCI for GRMHD

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.cpp
@@ -20,17 +20,16 @@ std::tuple<int, evolution::dg::subcell::RdmpTciData> TciOnFdGrid::apply(
     const Scalar<DataVector>& subcell_tilde_ye,
     const Scalar<DataVector>& subcell_tilde_tau,
     const tnsr::I<DataVector, 3, Frame::Inertial>& subcell_tilde_b,
-    const Scalar<DataVector>& subcell_pressure,
-    const Scalar<DataVector>& sqrt_det_spatial_metric,
-    const bool vars_needed_fixing, const Mesh<3>& dg_mesh,
-    const Mesh<3>& subcell_mesh,
+    const Scalar<DataVector>& subcell_rest_mass_density,
+    const Scalar<DataVector>& subcell_pressure, const bool vars_needed_fixing,
+    const Mesh<3>& dg_mesh, const Mesh<3>& subcell_mesh,
     const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
     const TciOptions& tci_options,
     const evolution::dg::subcell::SubcellOptions& subcell_options,
     const double persson_exponent) {
   const size_t num_dg_pts = dg_mesh.number_of_grid_points();
   const size_t num_subcell_pts = subcell_mesh.number_of_grid_points();
-  DataVector temp_buffer{num_subcell_pts + 6 * num_dg_pts};
+  DataVector temp_buffer{num_subcell_pts + 5 * num_dg_pts};
   size_t offset_into_temp_buffer = 0;
   const auto assign_data =
       [&temp_buffer, &offset_into_temp_buffer](
@@ -75,27 +74,19 @@ std::tuple<int, evolution::dg::subcell::RdmpTciData> TciOnFdGrid::apply(
       subcell_mesh.extents(),
       evolution::dg::subcell::fd::ReconstructionMethod::DimByDim);
 
-  Scalar<DataVector> dg_sqrt_det_spatial_metric{};
-  assign_data(make_not_null(&dg_sqrt_det_spatial_metric), num_dg_pts);
-  evolution::dg::subcell::fd::reconstruct(
-      make_not_null(&get(dg_sqrt_det_spatial_metric)),
-      get(sqrt_det_spatial_metric), dg_mesh, subcell_mesh.extents(),
-      evolution::dg::subcell::fd::ReconstructionMethod::DimByDim);
-
-  if (vars_needed_fixing and
-      (max(get(dg_tilde_d) / get(dg_sqrt_det_spatial_metric)) >
-       tci_options.atmosphere_density) and
-      (max(get(subcell_tilde_d) / get(sqrt_det_spatial_metric)) >
-       tci_options.atmosphere_density)) {
-    return {+1, rdmp_tci_data};
-  }
-
   if (min(get(dg_tilde_d)) <
           tci_options.minimum_rest_mass_density_times_lorentz_factor or
       min(get(dg_tilde_ye)) <
           tci_options.minimum_rest_mass_density_times_lorentz_factor *
               tci_options.minimum_ye or
       min(get(dg_tilde_tau)) < tci_options.minimum_tilde_tau) {
+    return {+1, rdmp_tci_data};
+  }
+
+  const bool in_atmosphere =
+      max(get(subcell_rest_mass_density)) < tci_options.atmosphere_density;
+
+  if (not(in_atmosphere) and vars_needed_fixing) {
     return {+2, rdmp_tci_data};
   }
 
@@ -106,12 +97,12 @@ std::tuple<int, evolution::dg::subcell::RdmpTciData> TciOnFdGrid::apply(
       subcell_mesh.extents(),
       evolution::dg::subcell::fd::ReconstructionMethod::DimByDim);
 
-  if (evolution::dg::subcell::persson_tci(dg_tilde_d, dg_mesh,
-                                          persson_exponent) or
-      evolution::dg::subcell::persson_tci(dg_tilde_ye, dg_mesh,
-                                          persson_exponent) or
-      evolution::dg::subcell::persson_tci(dg_pressure, dg_mesh,
-                                          persson_exponent)) {
+  if (not(in_atmosphere) and (evolution::dg::subcell::persson_tci(
+                                  dg_tilde_d, dg_mesh, persson_exponent) or
+                              evolution::dg::subcell::persson_tci(
+                                  dg_tilde_ye, dg_mesh, persson_exponent) or
+                              evolution::dg::subcell::persson_tci(
+                                  dg_pressure, dg_mesh, persson_exponent))) {
     return {+3, rdmp_tci_data};
   }
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.cpp
@@ -151,7 +151,7 @@ std::tuple<int, evolution::dg::subcell::RdmpTciData> TciOnFdGrid::apply(
       (max(get(dg_mag_tilde_b)) > tci_options.magnetic_field_cutoff.value() and
        evolution::dg::subcell::persson_tci(dg_mag_tilde_b, dg_mesh,
                                            persson_exponent))) {
-    return {+7, rdmp_tci_data};
+    return {+8, rdmp_tci_data};
   }
 
   return {false, rdmp_tci_data};

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.hpp
@@ -39,21 +39,22 @@ namespace grmhd::ValenciaDivClean::subcell {
  * <caption>List of checks</caption>
  * <tr><th> Description <th> TCI status
  *
- * <tr><td> if `grmhd::ValenciaDivClean::Tags::VariablesNeededFixing` is `true`
- *  and the maximum of \f$\tilde{D}/\sqrt{\gamma}\f$ is greater than
- * `tci_options.atmosphere_density` on DG and FD grid, then we remain on FD.
- * <td> `+1`
- *
  * <tr><td> if `min(tilde_d)` is less than
  *  `tci_options.minimum_rest_mass_density_times_lorentz_factor`, or if
  *  `min(tilde_ye)` is less than
  *  `tci_options.minimum_rest_mass_density_times_lorentz_factor` times
  *  `tci_options.minimum_ye`, or if `min(tilde_tau)` is less than
  *  `tci_options.minimum_tilde_tau`, then the we remain on FD.
+ * <td> `+1`
+ *
+ * <tr><td> if `grmhd::ValenciaDivClean::Tags::VariablesNeededFixing` is `true`
+ *  and the maximum of rest mass density on FD grid is greater than
+ * `tci_options.atmosphere_density`, then we remain on FD.
  * <td> `+2`
  *
  * <tr><td> apply the Persson TCI to \f$\tilde{D}\f$, \f$\tilde{Y}_e\f$, and
- * pressure.
+ * pressure if the maximum of rest mass density on FD grid is greater than
+ * `tci_options.atmosphere_density`.
  * <td> `+3`
  *
  * <tr><td> apply the RDMP TCI to `TildeD`
@@ -95,8 +96,8 @@ struct TciOnFdGrid {
                  grmhd::ValenciaDivClean::Tags::TildeYe,
                  grmhd::ValenciaDivClean::Tags::TildeTau,
                  grmhd::ValenciaDivClean::Tags::TildeB<>,
+                 hydro::Tags::RestMassDensity<DataVector>,
                  hydro::Tags::Pressure<DataVector>,
-                 gr::Tags::SqrtDetSpatialMetric<>,
                  grmhd::ValenciaDivClean::Tags::VariablesNeededFixing,
                  domain::Tags::Mesh<3>, evolution::dg::subcell::Tags::Mesh<3>,
                  evolution::dg::subcell::Tags::DataForRdmpTci, Tags::TciOptions,
@@ -106,10 +107,9 @@ struct TciOnFdGrid {
       const Scalar<DataVector>& subcell_tilde_ye,
       const Scalar<DataVector>& subcell_tilde_tau,
       const tnsr::I<DataVector, 3, Frame::Inertial>& subcell_tilde_b,
-      const Scalar<DataVector>& subcell_pressure,
-      const Scalar<DataVector>& sqrt_det_spatial_metric,
-      bool vars_needed_fixing, const Mesh<3>& dg_mesh,
-      const Mesh<3>& subcell_mesh,
+      const Scalar<DataVector>& subcell_rest_mass_density,
+      const Scalar<DataVector>& subcell_pressure, bool vars_needed_fixing,
+      const Mesh<3>& dg_mesh, const Mesh<3>& subcell_mesh,
       const evolution::dg::subcell::RdmpTciData& past_rdmp_tci_data,
       const TciOptions& tci_options,
       const evolution::dg::subcell::SubcellOptions& subcell_options,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.hpp
@@ -59,14 +59,18 @@ namespace grmhd::ValenciaDivClean::subcell {
  * <tr><td> apply the RDMP TCI to `TildeD`
  * <td> `+4`
  *
- * <tr><td> apply the RDMP TCI to `TildeTau`
+ * <tr><td> apply the RDMP TCI to `TildeYe`
  * <td> `+5`
  *
- * <tr><td> apply the RDMP TCI to `TildeB`
+ * <tr><td> apply the RDMP TCI to `TildeTau`
  * <td> `+6`
  *
+ * <tr><td> apply the RDMP TCI to `TildeB`
+ * <td> `+7`
+ *
  * <tr><td> apply the Persson TCI to the magnitude of \f$\tilde{B}^{n+1}\f$ if
- * its magnitude is greater than `tci_options.magnetic_field_cutoff`. <td> `+7`
+ * its magnitude is greater than `tci_options.magnetic_field_cutoff`.
+ * <td> `+8`
  *
  * </table>
  *

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnFdGrid.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnFdGrid.cpp
@@ -29,11 +29,14 @@ enum class TestThis {
   Atmosphere,
   NeededFixing,
   PerssonTildeD,
+  PerssonTildeYe,
   PerssonPressure,
   PerssonTildeB,
   NegativeTildeD,
+  NegativeTildeYe,
   NegativeTildeTau,
   RdmpTildeD,
+  RdmpTildeYe,
   RdmpTildeTau,
   RdmpMagnitudeTildeB
 };
@@ -94,6 +97,11 @@ void test(const TestThis test_this, const int expected_tci_status) {
         make_not_null(&box), [point_to_change](const auto tilde_d_ptr) {
           get(*tilde_d_ptr)[point_to_change] *= 2.0;
         });
+  } else if (test_this == TestThis::PerssonTildeYe) {
+    db::mutate<grmhd::ValenciaDivClean::Tags::TildeYe>(
+        make_not_null(&box), [point_to_change](const auto tilde_d_ptr) {
+          get(*tilde_d_ptr)[point_to_change] *= 2.0;
+        });
   } else if (test_this == TestThis::PerssonTildeB) {
     db::mutate<grmhd::ValenciaDivClean::Tags::TildeB<>>(
         make_not_null(&box), [point_to_change](const auto tilde_b_ptr) {
@@ -103,6 +111,11 @@ void test(const TestThis test_this, const int expected_tci_status) {
         });
   } else if (test_this == TestThis::NegativeTildeD) {
     db::mutate<grmhd::ValenciaDivClean::Tags::TildeD>(
+        make_not_null(&box), [point_to_change](const auto tilde_d_ptr) {
+          get(*tilde_d_ptr)[point_to_change] = -1.0e-20;
+        });
+  } else if (test_this == TestThis::NegativeTildeYe) {
+    db::mutate<grmhd::ValenciaDivClean::Tags::TildeYe>(
         make_not_null(&box), [point_to_change](const auto tilde_d_ptr) {
           get(*tilde_d_ptr)[point_to_change] = -1.0e-20;
         });
@@ -191,12 +204,15 @@ void test(const TestThis test_this, const int expected_tci_status) {
         if (test_this == TestThis::RdmpTildeD) {
           // Assumes min is positive, increase it so we fail the TCI
           rdmp_tci_data_ptr->min_variables_values[0] *= 1.01;
-        } else if (test_this == TestThis::RdmpTildeTau) {
+        } else if (test_this == TestThis::RdmpTildeYe) {
           // Assumes min is positive, increase it so we fail the TCI
           rdmp_tci_data_ptr->min_variables_values[1] *= 1.01;
-        } else if (test_this == TestThis::RdmpMagnitudeTildeB) {
+        } else if (test_this == TestThis::RdmpTildeTau) {
           // Assumes min is positive, increase it so we fail the TCI
           rdmp_tci_data_ptr->min_variables_values[2] *= 1.01;
+        } else if (test_this == TestThis::RdmpMagnitudeTildeB) {
+          // Assumes min is positive, increase it so we fail the TCI
+          rdmp_tci_data_ptr->min_variables_values[3] *= 1.01;
         }
       });
 
@@ -219,11 +235,14 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ValenciaDivClean.Subcell.TciOnFdGrid",
   test(TestThis::Atmosphere, 0);
   test(TestThis::NeededFixing, 1);
   test(TestThis::NegativeTildeD, 2);
+  test(TestThis::NegativeTildeYe, 2);
   test(TestThis::NegativeTildeTau, 2);
   test(TestThis::PerssonTildeD, 3);
+  test(TestThis::PerssonTildeYe, 3);
   test(TestThis::PerssonPressure, 3);
   test(TestThis::RdmpTildeD, 4);
-  test(TestThis::RdmpTildeTau, 5);
-  test(TestThis::RdmpMagnitudeTildeB, 6);
-  test(TestThis::PerssonTildeB, 7);
+  test(TestThis::RdmpTildeYe, 5);
+  test(TestThis::RdmpTildeTau, 6);
+  test(TestThis::RdmpMagnitudeTildeB, 7);
+  test(TestThis::PerssonTildeB, 8);
 }

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnFdGrid.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnFdGrid.cpp
@@ -70,7 +70,8 @@ void test(const TestThis test_this, const int expected_tci_status) {
       grmhd::ValenciaDivClean::Tags::TildeYe,
       grmhd::ValenciaDivClean::Tags::TildeTau,
       grmhd::ValenciaDivClean::Tags::TildeB<>,
-      hydro::Tags::Pressure<DataVector>, gr::Tags::SqrtDetSpatialMetric<>,
+      hydro::Tags::RestMassDensity<DataVector>,
+      hydro::Tags::Pressure<DataVector>,
       grmhd::ValenciaDivClean::Tags::VariablesNeededFixing,
       domain::Tags::Mesh<3>, ::evolution::dg::subcell::Tags::Mesh<3>,
       grmhd::ValenciaDivClean::subcell::Tags::TciOptions,
@@ -125,12 +126,12 @@ void test(const TestThis test_this, const int expected_tci_status) {
           get(*tilde_tau_ptr)[point_to_change] = -1.0e-20;
         });
   } else if (test_this == TestThis::Atmosphere) {
-    db::mutate<grmhd::ValenciaDivClean::Tags::TildeD,
+    db::mutate<hydro::Tags::RestMassDensity<DataVector>,
                grmhd::ValenciaDivClean::Tags::VariablesNeededFixing>(
-        make_not_null(&box),
-        [](const auto tilde_d_ptr, const auto variables_needed_fixing_ptr) {
+        make_not_null(&box), [](const auto rest_mass_density_ptr,
+                                const auto variables_needed_fixing_ptr) {
           *variables_needed_fixing_ptr = true;
-          get(*tilde_d_ptr) =
+          get(*rest_mass_density_ptr) =
               5.0e-12;  // smaller than atmosphere density but
                         // bigger than the Min(TildeD) TCI option
         });
@@ -233,10 +234,10 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ValenciaDivClean.Subcell.TciOnFdGrid",
                   "[Unit][Evolution]") {
   test(TestThis::AllGood, 0);
   test(TestThis::Atmosphere, 0);
-  test(TestThis::NeededFixing, 1);
-  test(TestThis::NegativeTildeD, 2);
-  test(TestThis::NegativeTildeYe, 2);
-  test(TestThis::NegativeTildeTau, 2);
+  test(TestThis::NegativeTildeD, 1);
+  test(TestThis::NegativeTildeYe, 1);
+  test(TestThis::NegativeTildeTau, 1);
+  test(TestThis::NeededFixing, 2);
   test(TestThis::PerssonTildeD, 3);
   test(TestThis::PerssonTildeYe, 3);
   test(TestThis::PerssonPressure, 3);


### PR DESCRIPTION
## Proposed changes

* Change the order of TCI checks. Positivity of `tilde_d`, `tilde_ye`, `tilde_tau` is checked as the first, then do the VariableFixing check.
* Ignore VariableFixing and Persson TCI in atmosphere

Dependent on
- [x] #4314 


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
