### PR TITLE
Add Psi4 to GeneralRelativity 

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -113,8 +113,10 @@
 #include "PointwiseFunctions/GeneralRelativity/DetAndInverseSpatialMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ConstraintGammas.hpp"
 #include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Psi4Real.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/WeylElectric.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
 #include "Time/Actions/ChangeSlabSize.hpp"
 #include "Time/Actions/RecordTimeStepperData.hpp"
@@ -315,7 +317,15 @@ struct EvolutionMetavars {
                   GeneralizedHarmonic::Tags::FourIndexConstraint<
                       3, ::Frame::Inertial>>,
               GeneralizedHarmonic::Tags::ConstraintEnergyCompute<
-                  3, ::Frame::Inertial>>,
+                  3, ::Frame::Inertial>,
+              GeneralizedHarmonic::Tags::ExtrinsicCurvatureCompute<
+                  3, ::Frame::Inertial>,
+              ::Tags::DerivTensorCompute<
+                  gr::Tags::ExtrinsicCurvature<3, ::Frame::Inertial>,
+                  ::domain::Tags::InverseJacobian<
+                      volume_dim, Frame::ElementLogical, Frame::Inertial>>,
+              gr::Tags::WeylElectricCompute<3, Frame::Inertial, DataVector>,
+              gr::Tags::Psi4RealCompute<Frame::Inertial>>,
           tmpl::list<>>>;
   using non_tensor_compute_tags =
       tmpl::list<::Events::Tags::ObserverMeshCompute<volume_dim>>;

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -97,8 +97,10 @@
 #include "PointwiseFunctions/GeneralRelativity/DetAndInverseSpatialMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ConstraintGammas.hpp"
 #include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Psi4Real.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/WeylElectric.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/Tags/InitialData.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
 #include "Time/Actions/ChangeSlabSize.hpp"
@@ -247,16 +249,23 @@ struct GeneralizedHarmonicTemplateBase<
       // The 4-index constraint is only implemented in 3d
       tmpl::conditional_t<
           volume_dim == 3,
-          tmpl::list<GeneralizedHarmonic::Tags::FourIndexConstraintCompute<
-                         3, frame>,
-                     GeneralizedHarmonic::Tags::FConstraintCompute<3, frame>,
-                     ::Tags::PointwiseL2NormCompute<
-                         GeneralizedHarmonic::Tags::FConstraint<3, frame>>,
-                     ::Tags::PointwiseL2NormCompute<
-                         GeneralizedHarmonic::Tags::FourIndexConstraint<3,
-                                                                        frame>>,
-                     GeneralizedHarmonic::Tags::ConstraintEnergyCompute<3,
-                                                                        frame>>,
+          tmpl::list<
+              GeneralizedHarmonic::Tags::
+                  FourIndexConstraintCompute<3, frame>,
+              GeneralizedHarmonic::Tags::
+                  FConstraintCompute<3, frame>,
+              ::Tags::PointwiseL2NormCompute<
+                  GeneralizedHarmonic::Tags::FConstraint<3, frame>>,
+              ::Tags::PointwiseL2NormCompute<
+                  GeneralizedHarmonic::Tags::FourIndexConstraint<3, frame>>,
+              GeneralizedHarmonic::Tags::ConstraintEnergyCompute<3, frame>,
+              GeneralizedHarmonic::Tags::ExtrinsicCurvatureCompute<3, frame>,
+              ::Tags::DerivTensorCompute<
+                  gr::Tags::ExtrinsicCurvature<3, frame>,
+                  ::domain::Tags::InverseJacobian<
+                      volume_dim, Frame::ElementLogical, Frame::Inertial>>,
+              gr::Tags::WeylElectricCompute<3, Frame::Inertial, DataVector>,
+              gr::Tags::Psi4RealCompute<Frame::Inertial>>,
           tmpl::list<>>>;
   using non_tensor_compute_tags =
       tmpl::list<::Events::Tags::ObserverMeshCompute<volume_dim>,

--- a/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -19,6 +19,7 @@ spectre_target_sources(
   Lapse.cpp
   ProjectionOperators.cpp
   Psi4.cpp
+  Psi4Real.cpp
   Ricci.cpp
   Shift.cpp
   SpacetimeMetric.cpp
@@ -50,6 +51,7 @@ spectre_target_headers(
   ProjectionOperators.hpp
   Ricci.hpp
   Psi4.hpp
+  Psi4Real.hpp
   Shift.hpp
   SpacetimeMetric.hpp
   SpacetimeNormalOneForm.hpp

--- a/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -18,6 +18,7 @@ spectre_target_sources(
   KerrSchildCoords.cpp
   Lapse.cpp
   ProjectionOperators.cpp
+  Psi4.cpp
   Ricci.cpp
   Shift.cpp
   SpacetimeMetric.cpp
@@ -48,6 +49,7 @@ spectre_target_headers(
   Lapse.hpp
   ProjectionOperators.hpp
   Ricci.hpp
+  Psi4.hpp
   Shift.hpp
   SpacetimeMetric.hpp
   SpacetimeNormalOneForm.hpp

--- a/src/PointwiseFunctions/GeneralRelativity/Psi4.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Psi4.cpp
@@ -1,0 +1,143 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/GeneralRelativity/Psi4.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Expressions/Evaluate.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/Tags.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ProjectionOperators.hpp"
+#include "PointwiseFunctions/GeneralRelativity/WeylPropagating.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace gr {
+template <typename Frame>
+void psi_4(const gsl::not_null<Scalar<ComplexDataVector>*> psi_4_result,
+           const tnsr::ii<DataVector, 3, Frame>& spatial_ricci,
+           const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature,
+           const tnsr::ijj<DataVector, 3, Frame>& cov_deriv_extrinsic_curvature,
+           const tnsr::ii<DataVector, 3, Frame>& spatial_metric,
+           const tnsr::II<DataVector, 3, Frame>& inverse_spatial_metric,
+           const tnsr::I<DataVector, 3, Frame>& inertial_coords) {
+  Variables<tmpl::list<::Tags::TempScalar<0>, ::Tags::TempI<0, 3, Frame>,
+                       ::Tags::TempI<1, 3, Frame>, ::Tags::Tempi<0, 3, Frame>,
+                       ::Tags::Tempij<0, 3, Frame>, ::Tags::Tempii<0, 3, Frame>,
+                       ::Tags::Tempii<1, 3, Frame>, ::Tags::TempIj<0, 3, Frame>,
+                       ::Tags::TempII<0, 3, Frame>>>
+      temp_buffer{get<0>(inertial_coords).size()};
+  auto& magnitude_cartesian = get<::Tags::TempScalar<0>>(temp_buffer);
+  magnitude(make_not_null(&magnitude_cartesian), inertial_coords,
+            spatial_metric);
+  auto& r_hat = get<::Tags::TempI<0, 3, Frame>>(temp_buffer);
+  for (size_t j = 0; j < 3; j++) {
+    for (size_t i = 0; i < get(magnitude_cartesian).size(); i++) {
+      if (magnitude_cartesian.get()[i] != 0.0) {
+        r_hat.get(j)[i] =
+            inertial_coords.get(j)[i] / magnitude_cartesian.get()[i];
+      } else {
+        r_hat.get(j)[i] = 0.0;
+      }
+    }
+  }
+  auto& lower_r_hat = get<::Tags::Tempi<0, 3, Frame>>(temp_buffer);
+  tenex::evaluate<ti::i>(make_not_null(&lower_r_hat),
+                         r_hat(ti::J) * spatial_metric(ti::i, ti::j));
+  auto& projection_tensor = get<::Tags::Tempii<0, 3, Frame>>(temp_buffer);
+  transverse_projection_operator(make_not_null(&projection_tensor),
+                                 spatial_metric, lower_r_hat);
+  auto& inverse_projection_tensor =
+      get<::Tags::TempII<0, 3, Frame>>(temp_buffer);
+  transverse_projection_operator(make_not_null(&inverse_projection_tensor),
+                                 inverse_spatial_metric, r_hat);
+  auto& projection_up_lo = get<::Tags::TempIj<0, 3, Frame>>(temp_buffer);
+  tenex::evaluate<ti::K, ti::i>(
+      make_not_null(&projection_up_lo),
+      projection_tensor(ti::i, ti::j) * inverse_spatial_metric(ti::K, ti::J));
+
+  auto& u8_plus = get<::Tags::Tempii<1, 3, Frame>>(temp_buffer);
+  gr::weyl_propagating(
+      make_not_null(&u8_plus), spatial_ricci, extrinsic_curvature,
+      inverse_spatial_metric, cov_deriv_extrinsic_curvature, r_hat,
+      inverse_projection_tensor, projection_tensor, projection_up_lo, 1.0);
+
+  auto& x_coord = get<::Tags::TempI<0, 3, Frame>>(temp_buffer);
+  x_coord.get(0) = 1.0;
+  x_coord.get(1) = x_coord.get(2) = 0.0;
+  auto& magnitude_x = get<::Tags::TempScalar<0>>(temp_buffer);
+  magnitude(make_not_null(&magnitude_x), x_coord, spatial_metric);
+  auto& x_hat = get<::Tags::TempI<0, 3, Frame>>(temp_buffer);
+  tenex::evaluate<ti::I>(make_not_null(&x_hat), x_coord(ti::I) / magnitude_x());
+
+  Variables<tmpl::list<::Tags::TempI<0, 3, Frame, ComplexDataVector>,
+                       ::Tags::TempI<1, 3, Frame, ComplexDataVector>>>
+      y_hat_buffer{get<0>(inertial_coords).size()};
+  auto& y_coord = get<::Tags::TempI<1, 3, Frame>>(temp_buffer);
+  y_coord.get(1) = 1.0;
+  y_coord.get(0) = y_coord.get(2) = 0.0;
+  auto& magnitude_y = get<::Tags::TempScalar<0>>(temp_buffer);
+  magnitude(make_not_null(&magnitude_y), y_coord, spatial_metric);
+  const std::complex<double> imag = std::complex<double>(0.0, 1.0);
+  auto& y_hat =
+      get<::Tags::TempI<0, 3, Frame, ComplexDataVector>>(y_hat_buffer);
+  tenex::evaluate<ti::I>(make_not_null(&y_hat),
+                         imag * y_coord(ti::I) / magnitude_y());
+  auto& m_bar =
+      get<::Tags::TempI<1, 3, Frame, ComplexDataVector>>(y_hat_buffer);
+  tenex::evaluate<ti::I>(make_not_null(&m_bar), x_hat(ti::I) - y_hat(ti::I));
+
+  tenex::evaluate(psi_4_result,
+                  -0.5 * u8_plus(ti::i, ti::j) * m_bar(ti::I) * m_bar(ti::J));
+}
+
+template <typename Frame>
+Scalar<ComplexDataVector> psi_4(
+    const tnsr::ii<DataVector, 3, Frame>& spatial_ricci,
+    const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature,
+    const tnsr::ijj<DataVector, 3, Frame>& cov_deriv_extrinsic_curvature,
+    const tnsr::ii<DataVector, 3, Frame>& spatial_metric,
+    const tnsr::II<DataVector, 3, Frame>& inverse_spatial_metric,
+    const tnsr::I<DataVector, 3, Frame>& inertial_coords) {
+  auto psi_4_result = make_with_value<Scalar<ComplexDataVector>>(
+      get<0, 0>(inverse_spatial_metric),
+      std::numeric_limits<double>::signaling_NaN());
+  psi_4(make_not_null(&psi_4_result), spatial_ricci, extrinsic_curvature,
+        cov_deriv_extrinsic_curvature, spatial_metric, inverse_spatial_metric,
+        inertial_coords);
+  return psi_4_result;
+}
+}  // namespace gr
+
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                              \
+  template Scalar<ComplexDataVector> gr::psi_4(                           \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& spatial_ricci,          \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& extrinsic_curvature,    \
+      const tnsr::ijj<DataVector, 3, FRAME(data)>&                        \
+          cov_deriv_extrinsic_curvature,                                  \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& spatial_metric,         \
+      const tnsr::II<DataVector, 3, FRAME(data)>& inverse_spatial_metric, \
+      const tnsr::I<DataVector, 3, FRAME(data)>& inertial_coords);        \
+  template void gr::psi_4(                                                \
+      const gsl::not_null<Scalar<ComplexDataVector>*> psi_4_result,       \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& spatial_ricci,          \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& extrinsic_curvature,    \
+      const tnsr::ijj<DataVector, 3, FRAME(data)>&                        \
+          cov_deriv_extrinsic_curvature,                                  \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& spatial_metric,         \
+      const tnsr::II<DataVector, 3, FRAME(data)>& inverse_spatial_metric, \
+      const tnsr::I<DataVector, 3, FRAME(data)>& inertial_coords);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (Frame::Grid, Frame::Inertial))
+
+#undef FRAME
+#undef INSTANTIATE

--- a/src/PointwiseFunctions/GeneralRelativity/Psi4.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Psi4.hpp
@@ -1,0 +1,57 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/CoordinateMaps/Tags.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+
+/// \cond
+namespace gsl {
+template <typename>
+struct not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace gr {
+
+/// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes Newman Penrose quantity \f$\Psi_4\f$ using the characteristic
+ * field U\f$^{8+}\f$ and complex vector \f$\bar{m}^i\f$.
+ *
+ * \details Computes \f$\Psi_4\f$ as: \f$\Psi_4 =
+ * U^{8+}_{ij}\bar{m}^i\bar{m}^j\f$ with the characteristic field
+ * \f$U^{8+} = (P^{(a}_i P^{b)}_j - \frac{1}{2}P_{ij}P^{ab})
+ * (E_{ab} - \epsilon_a^{cd}n_dB_{cb}\f$)
+ * and \f$\bar{m}^i\f$ = \f$\frac{(x^i + iy^i)}{\sqrt{2}}\f$. \f$x^i\f$ and
+ * \f$y^i\f$ are normalized unit vectors in the frame Frame.
+ *
+ */
+template <typename Frame>
+void psi_4(const gsl::not_null<Scalar<ComplexDataVector>*> psi_4_result,
+           const tnsr::ii<DataVector, 3, Frame>& spatial_ricci,
+           const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature,
+           const tnsr::ijj<DataVector, 3, Frame>& cov_deriv_extrinsic_curvature,
+           const tnsr::ii<DataVector, 3, Frame>& spatial_metric,
+           const tnsr::II<DataVector, 3, Frame>& inverse_spatial_metric,
+           const tnsr::I<DataVector, 3, Frame>& inertial_coords);
+
+template <typename Frame>
+Scalar<ComplexDataVector> psi_4(
+    const tnsr::ii<DataVector, 3, Frame>& spatial_ricci,
+    const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature,
+    const tnsr::ijj<DataVector, 3, Frame>& cov_deriv_extrinsic_curvature,
+    const tnsr::ii<DataVector, 3, Frame>& spatial_metric,
+    const tnsr::II<DataVector, 3, Frame>& inverse_spatial_metric,
+    const tnsr::I<DataVector, 3, Frame>& inertial_coords);
+/// @}
+
+}  // namespace gr

--- a/src/PointwiseFunctions/GeneralRelativity/Psi4Real.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Psi4Real.cpp
@@ -1,0 +1,78 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/GeneralRelativity/Psi4Real.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/CoordinateMaps/Tags.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Psi4.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace gr {
+
+template <typename Frame>
+void psi_4_real(
+    const gsl::not_null<Scalar<DataVector>*> psi_4_real_result,
+    const tnsr::ii<DataVector, 3, Frame>& spatial_ricci,
+    const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature,
+    const tnsr::ijj<DataVector, 3, Frame>& cov_deriv_extrinsic_curvature,
+    const tnsr::ii<DataVector, 3, Frame>& spatial_metric,
+    const tnsr::II<DataVector, 3, Frame>& inverse_spatial_metric,
+    const tnsr::I<DataVector, 3, Frame>& inertial_coords) {
+  get(*psi_4_real_result) = real(get(
+      psi_4(spatial_ricci, extrinsic_curvature, cov_deriv_extrinsic_curvature,
+            spatial_metric, inverse_spatial_metric, inertial_coords)));
+}
+
+template <typename Frame>
+Scalar<DataVector> psi_4_real(
+    const tnsr::ii<DataVector, 3, Frame>& spatial_ricci,
+    const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature,
+    const tnsr::ijj<DataVector, 3, Frame>& cov_deriv_extrinsic_curvature,
+    const tnsr::ii<DataVector, 3, Frame>& spatial_metric,
+    const tnsr::II<DataVector, 3, Frame>& inverse_spatial_metric,
+    const tnsr::I<DataVector, 3, Frame>& inertial_coords) {
+  auto psi_4_real_result = make_with_value<Scalar<DataVector>>(
+      get<0, 0>(inverse_spatial_metric),
+      std::numeric_limits<double>::signaling_NaN());
+  psi_4_real(make_not_null(&psi_4_real_result), spatial_ricci,
+             extrinsic_curvature, cov_deriv_extrinsic_curvature, spatial_metric,
+             inverse_spatial_metric, inertial_coords);
+  return psi_4_real_result;
+}
+}  // namespace gr
+
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                              \
+  template Scalar<DataVector> gr::psi_4_real(                             \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& spatial_ricci,          \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& extrinsic_curvature,    \
+      const tnsr::ijj<DataVector, 3, FRAME(data)>&                        \
+          cov_deriv_extrinsic_curvature,                                  \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& spatial_metric,         \
+      const tnsr::II<DataVector, 3, FRAME(data)>& inverse_spatial_metric, \
+      const tnsr::I<DataVector, 3, FRAME(data)>& inertial_coords);        \
+  template void gr::psi_4_real(                                           \
+      const gsl::not_null<Scalar<DataVector>*> psi_4_real_result,         \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& spatial_ricci,          \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& extrinsic_curvature,    \
+      const tnsr::ijj<DataVector, 3, FRAME(data)>&                        \
+          cov_deriv_extrinsic_curvature,                                  \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& spatial_metric,         \
+      const tnsr::II<DataVector, 3, FRAME(data)>& inverse_spatial_metric, \
+      const tnsr::I<DataVector, 3, FRAME(data)>& inertial_coords);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (Frame::Grid, Frame::Inertial))
+
+#undef FRAME
+#undef INSTANTIATE

--- a/src/PointwiseFunctions/GeneralRelativity/Psi4Real.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Psi4Real.hpp
@@ -1,0 +1,77 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/CoordinateMaps/Tags.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Psi4.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+
+/// \cond
+namespace gsl {
+template <typename>
+struct not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace gr {
+
+/// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes the real part of the Newman Penrose quantity \f$\Psi_4\f$
+ * using  \f$\Psi_4[Real] = -0.5*U^{8+}_{ij}*(x^ix^j - y^iy^j)\f$.
+ */
+template <typename Frame>
+void psi_4_real(
+    const gsl::not_null<Scalar<DataVector>*> psi_4_real_result,
+    const tnsr::ii<DataVector, 3, Frame>& spatial_ricci,
+    const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature,
+    const tnsr::ijj<DataVector, 3, Frame>& cov_deriv_extrinsic_curvature,
+    const tnsr::ii<DataVector, 3, Frame>& spatial_metric,
+    const tnsr::II<DataVector, 3, Frame>& inverse_spatial_metric,
+    const tnsr::I<DataVector, 3, Frame>& inertial_coords);
+
+template <typename Frame>
+Scalar<DataVector> psi_4_real(
+    const tnsr::ii<DataVector, 3, Frame>& spatial_ricci,
+    const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature,
+    const tnsr::ijj<DataVector, 3, Frame>& cov_deriv_extrinsic_curvature,
+    const tnsr::ii<DataVector, 3, Frame>& spatial_metric,
+    const tnsr::II<DataVector, 3, Frame>& inverse_spatial_metric,
+    const tnsr::I<DataVector, 3, Frame>& inertial_coords);
+
+namespace Tags {
+/// Computes the real part of the Newman Penrose quantity \f$\Psi_4\f$ using
+/// \f$\Psi_4[Real] = -0.5*U^{8+}_{ij}*(x^ix^j - y^iy^j)\f$.
+///
+/// Can be retrieved using `gr::Tags::Psi4Real`
+template <typename Frame>
+struct Psi4RealCompute : Psi4Real<DataVector>, db::ComputeTag {
+  using argument_tags = tmpl::list<
+      gr::Tags::SpatialRicci<3, Frame, DataVector>,
+      gr::Tags::ExtrinsicCurvature<3, Frame, DataVector>,
+      ::Tags::deriv<gr::Tags::ExtrinsicCurvature<3, Frame, DataVector>,
+                    tmpl::size_t<3>, Frame>,
+      gr::Tags::SpatialMetric<3, Frame, DataVector>,
+      gr::Tags::InverseSpatialMetric<3, Frame, DataVector>,
+      domain::Tags::Coordinates<3, Frame>>;
+
+  using return_type = Scalar<DataVector>;
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<Scalar<DataVector>*>, const tnsr::ii<DataVector, 3, Frame>&,
+      const tnsr::ii<DataVector, 3, Frame>&,
+      const tnsr::ijj<DataVector, 3, Frame>&,
+      const tnsr::ii<DataVector, 3, Frame>&,
+      const tnsr::II<DataVector, 3, Frame>&,
+      const tnsr::I<DataVector, 3, Frame>&)>(&psi_4_real<Frame>);
+  using base = Psi4Real<DataVector>;
+};
+}  // namespace Tags
+}  // namespace gr

--- a/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
@@ -153,6 +153,14 @@ struct SpatialRicciScalar : db::SimpleTag {
 };
 
 /*!
+ * \brief Computes the real part of \f$\Psi_4\f$
+ */
+template <typename DataType>
+struct Psi4Real : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+/*!
  * \brief The energy density \f$E=n_a n_b T^{ab}\f$, where \f$n_a\f$ denotes the
  * normal to the spatial hypersurface
  */

--- a/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
@@ -86,6 +86,8 @@ struct SpatialRicci;
 template <typename DataType = DataVector>
 struct SpatialRicciScalar;
 template <typename DataType = DataVector>
+struct Psi4Real;
+template <typename DataType = DataVector>
 struct EnergyDensity;
 template <typename DataType = DataVector>
 struct StressTrace;
@@ -96,6 +98,8 @@ struct HamiltonianConstraint;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
 struct MomentumConstraint;
+template <size_t Dim, typename Frame, typename DataType>
+struct WeylElectric;
 template <typename Frame, typename DataType>
 struct WeylMagnetic;
 template <typename DataType>

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIBRARY_SOURCES
   Test_InterfaceNullNormal.cpp
   Test_KerrSchildCoords.cpp
   Test_ProjectionOperators.cpp
+  Test_Psi4.cpp
   Test_Ricci.cpp
   Test_Tags.cpp
   Test_Transform.cpp

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Psi4.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Psi4.py
@@ -1,0 +1,49 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+import math
+import cmath
+
+from .ProjectionOperators import transverse_projection_operator
+from .WeylPropagating import weyl_propagating_modes
+
+
+def psi_4(spatial_ricci, extrinsic_curvature, cov_deriv_extrinsic_curvature,
+          spatial_metric, inv_spatial_metric, inertial_coords):
+    magnitude_inertial = math.sqrt(
+        np.einsum("a,b,ab", inertial_coords, inertial_coords, spatial_metric))
+    if (magnitude_inertial != 0.0):
+        r_hat = np.einsum("a", inertial_coords / magnitude_inertial)
+    else:
+        r_hat = np.einsum("a", inertial_coords * 0.0)
+
+    lower_r_hat = np.einsum("a,ab", r_hat, spatial_metric)
+
+    inv_projection_tensor = transverse_projection_operator(
+        inv_spatial_metric, r_hat)
+    projection_tensor = transverse_projection_operator(spatial_metric,
+                                                       lower_r_hat)
+    projection_up_lo = np.einsum("ab,ac", inv_projection_tensor,
+                                 spatial_metric)
+
+    u8_plus = weyl_propagating_modes(spatial_ricci, extrinsic_curvature,
+                                     inv_spatial_metric,
+                                     cov_deriv_extrinsic_curvature, r_hat,
+                                     inv_projection_tensor, projection_tensor,
+                                     projection_up_lo, 1)
+
+    x_coord = np.zeros((3))
+    x_coord[0] = 1
+    magnitude_x = math.sqrt(
+        np.einsum("a,b,ab", x_coord, x_coord, spatial_metric))
+    x_hat = x_coord / magnitude_x
+    y_coord = np.zeros((3))
+    y_coord[1] = 1
+    magnitude_y = math.sqrt(
+        np.einsum("a,b,ab", y_coord, y_coord, spatial_metric))
+    y_hat = y_coord / magnitude_y
+
+    m_bar = x_hat - (y_hat * complex(0.0, 1.0))
+
+    return (-0.5 * np.einsum("ab,a,b", u8_plus, m_bar, m_bar))

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Psi4.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Psi4.cpp
@@ -24,6 +24,53 @@
 #include "PointwiseFunctions/GeneralRelativity/WeylPropagating.hpp"
 
 namespace {
+template <typename RealDataType>
+void test_compute_item_in_databox(const RealDataType& used_for_size_real) {
+  TestHelpers::db::test_compute_tag<gr::Tags::Psi4RealCompute<Frame::Inertial>>(
+      "Psi4Real");
+
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> distribution(0.1, 3.0);
+  const auto nn_generator = make_not_null(&generator);
+  const auto nn_distribution = make_not_null(&distribution);
+
+  const auto spatial_ricci =
+      make_with_random_values<tnsr::ii<RealDataType, 3, Frame::Inertial>>(
+          nn_generator, nn_distribution, used_for_size_real);
+  const auto extrinsic_curvature =
+      make_with_random_values<tnsr::ii<RealDataType, 3, Frame::Inertial>>(
+          nn_generator, nn_distribution, used_for_size_real);
+  const auto cov_deriv_extrinsic_curvature =
+      make_with_random_values<tnsr::ijj<RealDataType, 3, Frame::Inertial>>(
+          nn_generator, nn_distribution, used_for_size_real);
+  const auto spatial_metric =
+      TestHelpers::gr::random_spatial_metric<3, RealDataType, Frame::Inertial>(
+          nn_generator, used_for_size_real);
+  const auto inv_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+  const auto inertial_coords =
+      make_with_random_values<tnsr::I<RealDataType, 3, Frame::Inertial>>(
+          nn_generator, nn_distribution, used_for_size_real);
+
+  const auto box = db::create<
+      db::AddSimpleTags<
+          gr::Tags::SpatialRicci<3, Frame::Inertial, RealDataType>,
+          gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, RealDataType>,
+          ::Tags::deriv<
+              gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, RealDataType>,
+              tmpl::size_t<3>, Frame::Inertial>,
+          gr::Tags::SpatialMetric<3, Frame::Inertial, RealDataType>,
+          gr::Tags::InverseSpatialMetric<3, Frame::Inertial, RealDataType>,
+          domain::Tags::Coordinates<3, Frame::Inertial>>,
+      db::AddComputeTags<gr::Tags::Psi4RealCompute<Frame::Inertial>>>(
+      spatial_ricci, extrinsic_curvature, cov_deriv_extrinsic_curvature,
+      spatial_metric, inv_spatial_metric, inertial_coords);
+  const auto expected = gr::psi_4_real(
+      spatial_ricci, extrinsic_curvature, cov_deriv_extrinsic_curvature,
+      spatial_metric, inv_spatial_metric, inertial_coords);
+  CHECK((db::get<gr::Tags::Psi4Real<RealDataType>>(box)) == expected);
+}
+
 template <typename RealDataType, typename ComplexDataType>
 void test_psi_4(const RealDataType& used_for_size_real,
                 const ComplexDataType& /*used_for_size_complex*/) {
@@ -74,4 +121,5 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.Psi4.",
   const ComplexDataVector used_for_size_complex_dv =
       ComplexDataVector(size, std::numeric_limits<double>::signaling_NaN());
   test_psi_4(used_for_size_real_dv, used_for_size_complex_dv);
+  test_compute_item_in_databox(used_for_size_real_dv);
 }

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Psi4.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Psi4.cpp
@@ -1,0 +1,77 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <random>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Expressions/Evaluate.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/Tags.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/PointwiseFunctions/GeneralRelativity/TestHelpers.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Psi4.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Psi4Real.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
+#include "PointwiseFunctions/GeneralRelativity/WeylPropagating.hpp"
+
+namespace {
+template <typename RealDataType, typename ComplexDataType>
+void test_psi_4(const RealDataType& used_for_size_real,
+                const ComplexDataType& /*used_for_size_complex*/) {
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> distribution(0.1, 3.0);
+  const auto nn_generator = make_not_null(&generator);
+  const auto nn_distribution = make_not_null(&distribution);
+
+  const auto spatial_ricci =
+      make_with_random_values<tnsr::ii<RealDataType, 3, Frame::Inertial>>(
+          nn_generator, nn_distribution, used_for_size_real);
+  const auto extrinsic_curvature =
+      make_with_random_values<tnsr::ii<RealDataType, 3, Frame::Inertial>>(
+          nn_generator, nn_distribution, used_for_size_real);
+  const auto cov_deriv_extrinsic_curvature =
+      make_with_random_values<tnsr::ijj<RealDataType, 3, Frame::Inertial>>(
+          nn_generator, nn_distribution, used_for_size_real);
+  const auto spatial_metric =
+      TestHelpers::gr::random_spatial_metric<3, RealDataType, Frame::Inertial>(
+          nn_generator, used_for_size_real);
+  const auto inv_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+  auto inertial_coords =
+      make_with_random_values<tnsr::I<RealDataType, 3, Frame::Inertial>>(
+          nn_generator, nn_distribution, used_for_size_real);
+  for (size_t i = 0; i < 3; ++i) {
+    inertial_coords.get(i)[0] = 0.0;
+  }
+
+  const auto python_psi_4 = pypp::call<Scalar<ComplexDataType>>(
+      "GeneralRelativity.Psi4", "psi_4", spatial_ricci, extrinsic_curvature,
+      cov_deriv_extrinsic_curvature, spatial_metric, inv_spatial_metric,
+      inertial_coords);
+  const auto expected = gr::psi_4(spatial_ricci, extrinsic_curvature,
+                                  cov_deriv_extrinsic_curvature, spatial_metric,
+                                  inv_spatial_metric, inertial_coords);
+  CHECK_ITERABLE_APPROX(expected, python_psi_4);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.Psi4.",
+                  "[Unit][PointwiseFunctions]") {
+  pypp::SetupLocalPythonEnvironment local_python_env("PointwiseFunctions/");
+
+  const size_t size = 5;
+  const DataVector used_for_size_real_dv =
+      DataVector(size, std::numeric_limits<double>::signaling_NaN());
+  const ComplexDataVector used_for_size_complex_dv =
+      ComplexDataVector(size, std::numeric_limits<double>::signaling_NaN());
+  test_psi_4(used_for_size_real_dv, used_for_size_complex_dv);
+}


### PR DESCRIPTION
## Proposed changes

This pr is split up into 2 commits, one to add the files and functions needed for Psi4 and one to add the ability to observe the real portion of Psi4 in BBH and Kerrschild.


### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

I didn't include the imaginary portion in output, can if we would like that functionality as well.
