### PR TITLE
Factor out detail namespace in ComputeHorizonVolumeQuantities

### DIFF
--- a/src/DataStructures/CMakeLists.txt
+++ b/src/DataStructures/CMakeLists.txt
@@ -54,6 +54,7 @@ spectre_target_headers(
   StaticMatrix.hpp
   StaticVector.hpp
   StripeIterator.hpp
+  TaggedContainers.hpp
   Tags.hpp
   TempBuffer.hpp
   Transpose.hpp

--- a/src/DataStructures/TaggedContainers.hpp
+++ b/src/DataStructures/TaggedContainers.hpp
@@ -1,0 +1,80 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <type_traits>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/TempBuffer.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits/IsA.hpp"
+
+/// @{
+/*!
+ * \ingroup DataStructuresGroup
+ * \brief Retrieves a desired tag from data structures containing tags.
+ *
+ * \details Given multiple containers retrieve a desired tag from the first
+ * container in which it is found. The containers are searched in the order
+ * in which they are supplied (i.e. `first_vars` is checked before `vars`).
+ * An error will be emitted if the tag cannot be found in any container.
+ */
+template <typename Tag, typename... TagsOrTagsList, typename... Ts,
+          template <class...> class U,
+          Requires<(not tt::is_a_v<gsl::not_null, U<TagsOrTagsList...>>)and not(
+              ... and tt::is_a_v<gsl::not_null, std::decay_t<Ts>>)> = nullptr>
+const typename Tag::type& get(const U<TagsOrTagsList...>& first_vars,
+                              const Ts&... vars) {
+  if constexpr (tt::is_a_v<db::DataBox, U<TagsOrTagsList...>>) {
+    if constexpr (not db::tag_is_retrievable_v<Tag, U<TagsOrTagsList...>> and
+                  sizeof...(Ts) != 0) {
+      return get<Tag>(vars...);
+    } else {
+      return get<Tag>(first_vars);
+    }
+  } else {
+    if constexpr (not tmpl::list_contains_v<
+                      tmpl::flatten<tmpl::list<TagsOrTagsList...>>, Tag> and
+                  sizeof...(Ts) != 0) {
+      return get<Tag>(vars...);
+    } else {
+      return get<Tag>(first_vars);
+    }
+  }
+}
+
+template <typename Tag, typename... TagsOrTagsList, typename... Ts,
+          template <class...> class U>
+gsl::not_null<typename Tag::type*> get(
+    const gsl::not_null<U<TagsOrTagsList...>*> first_vars,
+    const gsl::not_null<Ts>... vars) {
+  if constexpr (tt::is_a_v<db::DataBox, U<TagsOrTagsList...>>) {
+    if constexpr (not db::tag_is_retrievable_v<Tag, U<TagsOrTagsList...>> and
+                  sizeof...(Ts) != 0) {
+      if constexpr (sizeof...(Ts) == 1) {
+        return make_not_null(&get<Tag>(*vars...));
+      } else {
+        return get<Tag>(vars...);
+      }
+    } else {
+      return make_not_null(&get<Tag>(*first_vars));
+    }
+  } else {
+    if constexpr (not tmpl::list_contains_v<
+                      tmpl::flatten<tmpl::list<TagsOrTagsList...>>, Tag> and
+                  sizeof...(Ts) != 0) {
+      (void)first_vars;
+      if constexpr (sizeof...(Ts) == 1) {
+        return make_not_null(&get<Tag>(*vars...));
+      } else {
+        return get<Tag>(vars...);
+      }
+    } else {
+      return make_not_null(&get<Tag>(*first_vars));
+    }
+  }
+}
+/// @}

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -38,6 +38,7 @@ set(LIBRARY_SOURCES
   Test_SliceVariables.cpp
   Test_SpinWeighted.cpp
   Test_StripeIterator.cpp
+  Test_TaggedContainers.cpp
   Test_Tags.cpp
   Test_TempBuffer.cpp
   Test_Transpose.cpp

--- a/tests/Unit/DataStructures/Test_TaggedContainers.cpp
+++ b/tests/Unit/DataStructures/Test_TaggedContainers.cpp
@@ -1,0 +1,72 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/TaggedContainers.hpp"
+#include "DataStructures/Tags.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+namespace Tags {
+struct MyDouble : db::SimpleTag {
+  using type = double;
+};
+struct MyScalar : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+struct MyDouble2 : db::SimpleTag {
+  using type = double;
+};
+}  // namespace Tags
+
+// Test that desired tags are retrieved.
+void test_tagged_containers() {
+  const auto box = db::create<db::AddSimpleTags<Tags::MyDouble>>(1.2);
+  tuples::TaggedTuple<Tags::MyDouble2> tuple(4.4);
+  Variables<tmpl::list<Tags::MyScalar>> vars(10ul, 3.2);
+
+  CHECK(get<Tags::MyDouble>(box) == 1.2);
+  CHECK(get<Tags::MyDouble2>(tuple) == 4.4);
+  CHECK(get<Tags::MyScalar>(vars).get() == 3.2);
+
+  // Note: tests do not pass if DataVector only has a single component!
+  const auto box2 = db::create<db::AddSimpleTags<Tags::MyScalar>>(
+      Scalar<DataVector>{10ul, 1.2});
+
+  CHECK(get<Tags::MyScalar>(vars, box2).get() == 3.2);
+  CHECK(get<Tags::MyScalar>(box2, vars).get() == 1.2);
+
+  CHECK(get<Tags::MyScalar>(tuple, box2, vars).get() == 1.2);
+  CHECK(get<Tags::MyScalar>(box2, tuple, vars).get() == 1.2);
+  CHECK(get<Tags::MyScalar>(box2, vars, tuple).get() == 1.2);
+
+  CHECK(get<Tags::MyDouble>(box, tuple) == 1.2);
+  CHECK(get<Tags::MyDouble2>(tuple, vars) == 4.4);
+  CHECK(get<Tags::MyScalar>(vars, box).get() == 3.2);
+
+  CHECK(get<Tags::MyDouble>(tuple, box) == 1.2);
+  CHECK(get<Tags::MyDouble2>(vars, tuple) == 4.4);
+  CHECK(get<Tags::MyScalar>(box, vars).get() == 3.2);
+
+  CHECK(get<Tags::MyDouble>(box, tuple, vars) == 1.2);
+  CHECK(get<Tags::MyDouble2>(tuple, vars, box) == 4.4);
+  CHECK(get<Tags::MyScalar>(vars, box, tuple).get() == 3.2);
+
+  CHECK(get<Tags::MyDouble>(box, vars, tuple) == 1.2);
+  CHECK(get<Tags::MyDouble2>(tuple, box, vars) == 4.4);
+  CHECK(get<Tags::MyScalar>(vars, tuple, box).get() == 3.2);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DataStructures.TaggedContainers",
+                  "[Unit][DataStructures]") {
+  test_tagged_containers();
+}


### PR DESCRIPTION
## Proposed changes

This is the first in a series of PRs to add interpolation targets for ExcisionBoundaryA and ExcisionBoundaryB similar to how targets exist for AhA and AhB. A future PR will use the
factored out namespace in a new ComputeExcisionBoundaryVolumeQuantities hpp that will be used by the target.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
