### PR TITLE
Link Parallel in MinimalExample executable

### DIFF
--- a/src/Executables/Examples/ParallelTutorial/CMakeLists.txt
+++ b/src/Executables/Examples/ParallelTutorial/CMakeLists.txt
@@ -5,6 +5,7 @@
 set(LIBS_TO_LINK
   Informer
   Options
+  Parallel
   Utilities
   )
 


### PR DESCRIPTION
## Proposed changes

`MinimalExample` Executable is currently broken because `Parallel` is not linked.  This PR fixes this

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
