### PR TITLE
Use runtime initial data in ScalarAdvection and Burgers

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -588,10 +588,10 @@ ${{ env.CACHE_KEY_SUFFIX }}"
           # formaline injects data at the linking stage, which means we are
           # somewhat tied to the compiler version.
 
-          make EvolveBurgersStep -j2
+          make EvolveBurgers -j2
 
-          if [ ! -f ./bin/EvolveBurgersStep ]; then
-            echo "Could not find the executable EvolveBurgersStep";
+          if [ ! -f ./bin/EvolveBurgers ]; then
+            echo "Could not find the executable EvolveBurgers";
             echo "which we use for testing formaline";
             exit 1
           fi
@@ -600,7 +600,7 @@ ${{ env.CACHE_KEY_SUFFIX }}"
           # positives that would cause the build to fail. We disable
           # leak sanitizer for the ctest runs inside CMake anyway.
 
-          ASAN_OPTIONS=detect_leaks=0 ./bin/EvolveBurgersStep
+          ASAN_OPTIONS=detect_leaks=0 ./bin/EvolveBurgers
           --dump-source-tree-as spectre_src --dump-only
 
           mkdir spectre_src;
@@ -646,7 +646,7 @@ ${{ env.CACHE_KEY_SUFFIX }}"
           -D BUILD_DOCS=OFF
           ..
 
-          make EvolveBurgersStep -j2
+          make EvolveBurgers -j2
 
           ctest -j2 -R InputFiles.Burgers.Step.yaml
 

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -388,7 +388,7 @@ RUN mkdir spectre/build && cd spectre/build \
     -D MEMORY_ALLOCATOR=SYSTEM \
     .. \
   && make ${PARALLEL_MAKE_ARG} ExportTimeDependentCoordinates3D \
-  && make ${PARALLEL_MAKE_ARG} EvolveScalarAdvectionKuzmin2D \
+  && make ${PARALLEL_MAKE_ARG} EvolveScalarAdvection2D \
   && make ${PARALLEL_MAKE_ARG} all-pybindings
 
 RUN pip3 --no-cache-dir install jupyterlab

--- a/docs/Tutorials/BeginnersTutorial.md
+++ b/docs/Tutorials/BeginnersTutorial.md
@@ -361,7 +361,7 @@ can read [the paper](https://arxiv.org/abs/2109.11645) on the ArXiv.
 
 To demonstrate DG+FD, we will be evolving the \link
 ScalarAdvection::Solutions::Kuzmin Kuzmin \endlink problem using the
-`EvolveScalarAdvectionKuzmin2D` executable. This is a simple test problem that
+`EvolveScalarAdvection2D` executable. This is a simple test problem that
 rotates a set of geometric shapes with uniform angular velocity, which can be
 used to evaluate how well a numerical code can handle discontinuities stably
 over time. Inside the container make a new directory `/work/runs2` where you
@@ -446,7 +446,7 @@ of smaller elements, we distribute these over the available resources via a
 things up.
 
 ```
-EvolveScalarAdvectionKuzmin2D --input-file Kuzmin2D.yaml ++ppn 4
+EvolveScalarAdvection2D --input-file Kuzmin2D.yaml ++ppn 4
 ```
 
 ### Visualizing the Kuzmin Problem
@@ -575,7 +575,7 @@ guide.
 To build the Kuzmin executable, run
 
 ```
-make EvolveScalarAdvectionKuzmin2D
+make EvolveScalarAdvection2D
 ```
 
 This should be very fast because you only edited a `cpp` file. Congrats! You've

--- a/src/Evolution/Executables/Burgers/CMakeLists.txt
+++ b/src/Evolution/Executables/Burgers/CMakeLists.txt
@@ -23,32 +23,10 @@ set(LIBS_TO_LINK
   Utilities
   )
 
-function(add_burgers_executable INITIAL_DATA_NAME INITIAL_DATA)
-  add_spectre_parallel_executable(
-    "EvolveBurgers${INITIAL_DATA_NAME}"
-    EvolveBurgers
-    Evolution/Executables/Burgers
-    "EvolutionMetavars<${INITIAL_DATA}>"
-    "${LIBS_TO_LINK}"
-    )
-endfunction(add_burgers_executable)
-
-add_burgers_executable(
-  Bump
-  Burgers::Solutions::Bump
-  )
-
-add_burgers_executable(
-  Linear
-  Burgers::Solutions::Linear
-  )
-
-add_burgers_executable(
-  Step
-  Burgers::Solutions::Step
-  )
-
-add_burgers_executable(
-  Sinusoid
-  Burgers::AnalyticData::Sinusoid
+add_spectre_parallel_executable(
+  "EvolveBurgers"
+  EvolveBurgers
+  Evolution/Executables/Burgers
+  "EvolutionMetavars"
+  "${LIBS_TO_LINK}"
   )

--- a/src/Evolution/Executables/Burgers/EvolveBurgersFwd.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgersFwd.hpp
@@ -3,17 +3,4 @@
 
 #pragma once
 
-namespace Burgers {
-namespace AnalyticData {
-class Sinusoid;
-}  // namespace AnalyticData
-
-namespace Solutions {
-class Bump;
-class Linear;
-class Step;
-}  // namespace Solutions
-}  // namespace Burgers
-
-template <typename InitialData>
 struct EvolutionMetavars;

--- a/src/Evolution/Executables/ScalarAdvection/CMakeLists.txt
+++ b/src/Evolution/Executables/ScalarAdvection/CMakeLists.txt
@@ -22,40 +22,15 @@ set(LIBS_TO_LINK
   Utilities
   )
 
-function(add_scalar_advection_executable INITIAL_DATA_NAME DIM INITIAL_DATA)
+function(add_scalar_advection_executable DIM)
   add_spectre_parallel_executable(
-    "EvolveScalarAdvection${INITIAL_DATA_NAME}${DIM}D"
+    "EvolveScalarAdvection${DIM}D"
     EvolveScalarAdvection
     Evolution/Executables/ScalarAdvection
-    "EvolutionMetavars<${DIM},${INITIAL_DATA}>"
+    "EvolutionMetavars<${DIM}>"
     "${LIBS_TO_LINK}"
     )
 endfunction(add_scalar_advection_executable)
 
-function(add_sinusoid_executable)
-  add_scalar_advection_executable(
-    Sinusoid
-    1
-    ScalarAdvection::Solutions::Sinusoid
-    )
-endfunction(add_sinusoid_executable)
-
-function(add_krivodonova_executable)
-  add_scalar_advection_executable(
-    Krivodonova
-    1
-    ScalarAdvection::Solutions::Krivodonova
-    )
-endfunction(add_krivodonova_executable)
-
-function(add_kuzmin_executable)
-  add_scalar_advection_executable(
-    Kuzmin
-    2
-    ScalarAdvection::Solutions::Kuzmin
-    )
-endfunction(add_kuzmin_executable)
-
-add_sinusoid_executable()
-add_krivodonova_executable()
-add_kuzmin_executable()
+add_scalar_advection_executable(1)
+add_scalar_advection_executable(2)

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvectionFwd.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvectionFwd.hpp
@@ -5,13 +5,5 @@
 
 #include <cstddef>
 
-namespace ScalarAdvection {
-namespace Solutions {
-class Krivodonova;
-class Kuzmin;
-class Sinusoid;
-}  // namespace Solutions
-}  // namespace ScalarAdvection
-
-template <size_t Dim, typename InitialData>
+template <size_t Dim>
 struct EvolutionMetavars;

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/DirichletAnalytic.cpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/DirichletAnalytic.cpp
@@ -10,8 +10,26 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/Systems/Burgers/Fluxes.hpp"
+#include "PointwiseFunctions/AnalyticData/Burgers/Factory.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Burgers/Factory.hpp"
 
 namespace Burgers::BoundaryConditions {
+DirichletAnalytic::DirichletAnalytic(const DirichletAnalytic& rhs)
+    : BoundaryCondition{dynamic_cast<const BoundaryCondition&>(rhs)},
+      analytic_prescription_(rhs.analytic_prescription_->get_clone()) {}
+
+DirichletAnalytic& DirichletAnalytic::operator=(const DirichletAnalytic& rhs) {
+  if (&rhs == this) {
+    return *this;
+  }
+  analytic_prescription_ = rhs.analytic_prescription_->get_clone();
+  return *this;
+}
+
+DirichletAnalytic::DirichletAnalytic(
+    std::unique_ptr<evolution::initial_data::InitialData> analytic_prescription)
+    : analytic_prescription_(std::move(analytic_prescription)) {}
+
 DirichletAnalytic::DirichletAnalytic(CkMigrateMessage* const msg)
     : BoundaryCondition(msg) {}
 
@@ -20,7 +38,72 @@ DirichletAnalytic::get_clone() const {
   return std::make_unique<DirichletAnalytic>(*this);
 }
 
-void DirichletAnalytic::pup(PUP::er& p) { BoundaryCondition::pup(p); }
+std::optional<std::string> DirichletAnalytic::dg_ghost(
+    const gsl::not_null<Scalar<DataVector>*> u,
+    const gsl::not_null<tnsr::I<DataVector, 1, Frame::Inertial>*> flux_u,
+    const std::optional<
+        tnsr::I<DataVector, 1, Frame::Inertial>>& /*face_mesh_velocity*/,
+    const tnsr::i<DataVector, 1, Frame::Inertial>& /*normal_covector*/,
+    const tnsr::I<DataVector, 1, Frame::Inertial>& coords,
+    [[maybe_unused]] const double time) const {
+  call_with_dynamic_type<void, tmpl::append<Burgers::Solutions::all_solutions,
+                                            Burgers::AnalyticData::all_data>>(
+      analytic_prescription_.get(),
+      [&coords, &time, &u](const auto* const analytic_solution_or_data) {
+        if constexpr (is_analytic_solution_v<
+                          std::decay_t<decltype(*analytic_solution_or_data)>>) {
+          *u = get<Burgers::Tags::U>(analytic_solution_or_data->variables(
+              coords, time, tmpl::list<Burgers::Tags::U>{}));
+        } else {
+          *u = get<Burgers::Tags::U>(analytic_solution_or_data->variables(
+              coords, tmpl::list<Burgers::Tags::U>{}));
+          (void)time;
+        }
+      });
+  flux_impl(flux_u, *u);
+  return {};
+}
+
+void DirichletAnalytic::fd_ghost(
+    const gsl::not_null<Scalar<DataVector>*> u, const Direction<1>& direction,
+    const Mesh<1> subcell_mesh, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
+    const ElementMap<1, Frame::Grid>& logical_to_grid_map,
+    const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, 1>&
+        grid_to_inertial_map,
+    const fd::Reconstructor& reconstructor) const {
+  const size_t ghost_zone_size{reconstructor.ghost_zone_size()};
+
+  const auto ghost_logical_coords =
+      evolution::dg::subcell::fd::ghost_zone_logical_coordinates(
+          subcell_mesh, ghost_zone_size, direction);
+
+  const auto ghost_inertial_coords = grid_to_inertial_map(
+      logical_to_grid_map(ghost_logical_coords), time, functions_of_time);
+
+  call_with_dynamic_type<void, tmpl::append<Burgers::Solutions::all_solutions,
+                                            Burgers::AnalyticData::all_data>>(
+      analytic_prescription_.get(),
+      [&ghost_inertial_coords, &time,
+       &u](const auto* const analytic_solution_or_data) {
+        if constexpr (is_analytic_solution_v<
+                          std::decay_t<decltype(*analytic_solution_or_data)>>) {
+          *u = get<Burgers::Tags::U>(analytic_solution_or_data->variables(
+              ghost_inertial_coords, time, tmpl::list<Burgers::Tags::U>{}));
+        } else {
+          *u = get<Burgers::Tags::U>(analytic_solution_or_data->variables(
+              ghost_inertial_coords, tmpl::list<Burgers::Tags::U>{}));
+          (void)time;
+        }
+      });
+}
+
+void DirichletAnalytic::pup(PUP::er& p) {
+  BoundaryCondition::pup(p);
+  p | analytic_prescription_;
+}
 
 void DirichletAnalytic::flux_impl(
     const gsl::not_null<tnsr::I<DataVector, 1, Frame::Inertial>*> flux,

--- a/src/Evolution/Systems/Burgers/CMakeLists.txt
+++ b/src/Evolution/Systems/Burgers/CMakeLists.txt
@@ -40,6 +40,8 @@ target_link_libraries(
   Parallel
   Utilities
   PRIVATE
+  BurgersAnalyticData
+  BurgersSolutions
   LinearOperators
   )
 

--- a/src/PointwiseFunctions/AnalyticData/Burgers/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticData/Burgers/CMakeLists.txt
@@ -16,6 +16,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   AnalyticData.hpp
+  Factory.hpp
   Sinusoid.hpp
   )
 

--- a/src/PointwiseFunctions/AnalyticData/Burgers/Factory.hpp
+++ b/src/PointwiseFunctions/AnalyticData/Burgers/Factory.hpp
@@ -1,0 +1,12 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "PointwiseFunctions/AnalyticData/Burgers/Sinusoid.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Burgers::AnalyticData {
+/// \brief List of all analytic data
+using all_data = tmpl::list<Sinusoid>;
+}  // namespace Burgers::AnalyticData

--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/CMakeLists.txt
@@ -18,6 +18,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Bump.hpp
+  Factory.hpp
   Linear.hpp
   Solutions.hpp
   Step.hpp

--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/Factory.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/Factory.hpp
@@ -1,0 +1,14 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "PointwiseFunctions/AnalyticSolutions/Burgers/Bump.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Burgers/Linear.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Burgers/Step.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Burgers::Solutions {
+/// \brief List of all analytic solutions
+using all_solutions = tmpl::list<Bump, Linear, Step>;
+}  // namespace Burgers::Solutions

--- a/tests/InputFiles/Burgers/Step.yaml
+++ b/tests/InputFiles/Burgers/Step.yaml
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-# Executable: EvolveBurgersStep
+# Executable: EvolveBurgers
 # CommandLineArgs: +balancer RandCentLB +p2
 # Timeout: 5
 # Check: parse;execute
@@ -9,7 +9,7 @@
 ResourceInfo:
   AvoidGlobalProc0: false
 
-AnalyticSolution:
+InitialData: &InitialData
   Step:
     LeftValue: 2.
     RightValue: 1.
@@ -37,8 +37,12 @@ DomainCreator:
     InitialGridPoints: [7]
     TimeDependence: None
     BoundaryConditions:
-      LowerBoundary: DirichletAnalytic
-      UpperBoundary: DirichletAnalytic
+      LowerBoundary:
+        DirichletAnalytic:
+          AnalyticPrescription: *InitialData
+      UpperBoundary:
+        DirichletAnalytic:
+          AnalyticPrescription: *InitialData
 
 SpatialDiscretization:
   BoundaryCorrection:

--- a/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-# Executable: EvolveScalarAdvectionKrivodonova1D
+# Executable: EvolveScalarAdvection1D
 # Check: parse;execute
 # ExpectedOutput:
 #   ScalarAdvectionKrivodonova1DVolume0.h5
@@ -49,7 +49,7 @@ SpatialDiscretization:
     Reconstructor:
       MonotonisedCentral
 
-AnalyticSolution:
+InitialData:
   Krivodonova:
 
 EventsAndTriggers:

--- a/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-# Executable: EvolveScalarAdvectionKuzmin2D
+# Executable: EvolveScalarAdvection2D
 # Check: parse;execute
 # ExpectedOutput:
 #   ScalarAdvectionKuzmin2DVolume0.h5
@@ -47,7 +47,7 @@ SpatialDiscretization:
     Reconstructor:
       MonotonisedCentral
 
-AnalyticSolution:
+InitialData:
   Kuzmin:
 
 EventsAndTriggers:

--- a/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-# Executable: EvolveScalarAdvectionSinusoid1D
+# Executable: EvolveScalarAdvection1D
 # Check: parse;execute
 # ExpectedOutput:
 #   ScalarAdvectionSinusoid1DVolume0.h5
@@ -49,7 +49,7 @@ SpatialDiscretization:
     Reconstructor:
       MonotonisedCentral
 
-AnalyticSolution:
+InitialData:
   Sinusoid:
 
 EventsAndTriggers:

--- a/tests/Unit/Evolution/Systems/Burgers/FiniteDifference/Test_BoundaryConditionGhostData.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/FiniteDifference/Test_BoundaryConditionGhostData.cpp
@@ -326,7 +326,10 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Burgers.Fd.BCondGhostData",
     test(TestHelpers::test_creation<Burgers::BoundaryConditions::Dirichlet>(
              "U: 0.3\n"),
          test_this);
-    test(Burgers::BoundaryConditions::DirichletAnalytic{}, test_this);
+    test(
+        Burgers::BoundaryConditions::DirichletAnalytic{
+            std::make_unique<Burgers::Solutions::Linear>(-0.5)},
+        test_this);
     test(Burgers::BoundaryConditions::DemandOutgoingCharSpeeds{}, test_this);
   }
 


### PR DESCRIPTION
## Proposed changes

The other systems will follow in later PRs. I have all the systems without an EOS done. They basically all follow the same general format.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
