### PR TITLE
Allow assigning a subset of tags to a Variables

### DIFF
--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -271,24 +271,33 @@ class Variables<tmpl::list<Tags...>> {
 
   /// @{
   /// \brief Assign a subset of the `Tensor`s from another Variables or a
-  /// tuples::TaggedTuple
+  /// tuples::TaggedTuple. Any tags that aren't in both containers are
+  /// ignored.
   ///
   /// \note There is no need for an rvalue overload because we need to copy into
   /// the contiguous array anyway
-  template <typename... SubsetOfTags,
-            Requires<tmpl2::flat_all<tmpl::list_contains_v<
-                tmpl::list<Tags...>, SubsetOfTags>...>::value> = nullptr>
+  template <typename... SubsetOfTags>
   void assign_subset(const Variables<tmpl::list<SubsetOfTags...>>& vars) {
-    EXPAND_PACK_LEFT_TO_RIGHT(
-        (get<SubsetOfTags>(*this) = get<SubsetOfTags>(vars)));
+    EXPAND_PACK_LEFT_TO_RIGHT([this, &vars]() {
+      if constexpr (tmpl::list_contains_v<tmpl::list<Tags...>, SubsetOfTags>) {
+        get<SubsetOfTags>(*this) = get<SubsetOfTags>(vars);
+      } else {
+        (void)this;
+        (void)vars;
+      }
+    }());
   }
 
-  template <typename... SubsetOfTags,
-            Requires<tmpl2::flat_all<tmpl::list_contains_v<
-                tmpl::list<Tags...>, SubsetOfTags>...>::value> = nullptr>
+  template <typename... SubsetOfTags>
   void assign_subset(const tuples::TaggedTuple<SubsetOfTags...>& vars) {
-    EXPAND_PACK_LEFT_TO_RIGHT(
-        (get<SubsetOfTags>(*this) = get<SubsetOfTags>(vars)));
+    EXPAND_PACK_LEFT_TO_RIGHT([this, &vars]() {
+      if constexpr (tmpl::list_contains_v<tmpl::list<Tags...>, SubsetOfTags>) {
+        get<SubsetOfTags>(*this) = get<SubsetOfTags>(vars);
+      } else {
+        (void)this;
+        (void)vars;
+      }
+    }());
   }
   /// @}
 

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -9,6 +9,7 @@
 #include <random>
 #include <string>
 #include <tuple>
+#include <type_traits>
 #include <utility>
 
 #include "DataStructures/ComplexDataVector.hpp"
@@ -973,6 +974,29 @@ void test_variables_assign_subset() {
               number_of_grid_points, values_in_variables[2]}),
       values_in_variables[1], values_in_variables[2]);
 
+  test_assign_to_vars_with_two_tags(
+      Variables<tmpl::list<TestHelpers::Tags::Vector<VectorType>,
+                           TestHelpers::Tags::OneForm<VectorType>>>(
+          number_of_grid_points, values_in_variables[1]),
+      Variables<tmpl::list<TestHelpers::Tags::Scalar<VectorType>,
+                           TestHelpers::Tags::OneForm<VectorType>>>(
+          number_of_grid_points, values_in_variables[2]),
+      values_in_variables[1], values_in_variables[2]);
+  test_assign_to_vars_with_two_tags(
+      tuples::TaggedTuple<TestHelpers::Tags::Vector<VectorType>,
+                          TestHelpers::Tags::OneForm<VectorType>>(
+          typename TestHelpers::Tags::Vector<VectorType>::type{
+              number_of_grid_points, values_in_variables[1]},
+          typename TestHelpers::Tags::OneForm<VectorType>::type{
+              number_of_grid_points, values_in_variables[0]}),
+      tuples::TaggedTuple<TestHelpers::Tags::Scalar<VectorType>,
+                          TestHelpers::Tags::OneForm<VectorType>>(
+          typename TestHelpers::Tags::Scalar<VectorType>::type{
+              number_of_grid_points, values_in_variables[2]},
+          typename TestHelpers::Tags::OneForm<VectorType>::type{
+              number_of_grid_points, values_in_variables[0]}),
+      values_in_variables[1], values_in_variables[2]);
+
   // Test assigning a single tag to a Variables with three tags, either from a
   // Variables or a TaggedTuple
   const auto test_assign_to_vars_with_three_tags = [&number_of_grid_points,
@@ -1025,6 +1049,29 @@ void test_variables_assign_subset() {
               number_of_grid_points, values_in_variables[2]}),
       values_in_variables[1], values_in_variables[2]);
 
+  test_assign_to_vars_with_three_tags(
+      Variables<tmpl::list<TestHelpers::Tags::Vector<VectorType>,
+                           TestHelpers::Tags::OneForm<VectorType>>>(
+          number_of_grid_points, values_in_variables[1]),
+      Variables<tmpl::list<TestHelpers::Tags::Scalar<VectorType>,
+                           TestHelpers::Tags::OneForm<VectorType>>>(
+          number_of_grid_points, values_in_variables[2]),
+      values_in_variables[1], values_in_variables[2]);
+  test_assign_to_vars_with_three_tags(
+      tuples::TaggedTuple<TestHelpers::Tags::Vector<VectorType>,
+                          TestHelpers::Tags::OneForm<VectorType>>(
+          typename TestHelpers::Tags::Vector<VectorType>::type{
+              number_of_grid_points, values_in_variables[1]},
+          typename TestHelpers::Tags::OneForm<VectorType>::type{
+              number_of_grid_points, values_in_variables[0]}),
+      tuples::TaggedTuple<TestHelpers::Tags::Scalar<VectorType>,
+                          TestHelpers::Tags::OneForm<VectorType>>(
+          typename TestHelpers::Tags::Scalar<VectorType>::type{
+              number_of_grid_points, values_in_variables[2]},
+          typename TestHelpers::Tags::OneForm<VectorType>::type{
+              number_of_grid_points, values_in_variables[0]}),
+      values_in_variables[1], values_in_variables[2]);
+
   // Test assignment to a Variables with a single tag either from a Variables or
   // a TaggedTuple
   const auto test_assign_to_vars_with_one_tag =
@@ -1048,6 +1095,20 @@ void test_variables_assign_subset() {
       tuples::TaggedTuple<TestHelpers::Tags::Vector<VectorType>>(
           typename TestHelpers::Tags::Vector<VectorType>::type{
               number_of_grid_points, values_in_variables[1]}),
+      values_in_variables[1]);
+
+  test_assign_to_vars_with_one_tag(
+      Variables<tmpl::list<TestHelpers::Tags::Vector<VectorType>,
+                           TestHelpers::Tags::OneForm<VectorType>>>(
+          number_of_grid_points, values_in_variables[1]),
+      values_in_variables[1]);
+  test_assign_to_vars_with_one_tag(
+      tuples::TaggedTuple<TestHelpers::Tags::Vector<VectorType>,
+                          TestHelpers::Tags::OneForm<VectorType>>(
+          typename TestHelpers::Tags::Vector<VectorType>::type{
+              number_of_grid_points, values_in_variables[1]},
+          typename TestHelpers::Tags::OneForm<VectorType>::type{
+              number_of_grid_points, values_in_variables[0]}),
       values_in_variables[1]);
 }
 


### PR DESCRIPTION
## Proposed changes

Allows assigning only some tags from another container to the vars. This is helpful in GH+GRMHD where I get both theGH and the GRMHD primitive tags from the analytic solution/data and need to assign them to separate variables.

Most of this PR is just adding tests...

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
