### PR TITLE
Remove FIXMEs from AnalyticData and AnalyticSolutions

### DIFF
--- a/src/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.cpp
@@ -126,7 +126,6 @@ tuples::TaggedTuple<hydro::Tags::ElectronFraction<DataType>>
 BondiHoyleAccretion::variables(
     const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::ElectronFraction<DataType>> /*meta*/) const {
-  // FIXME Add proper EoS call to get Ye
 
   return {make_with_value<Scalar<DataType>>(x, 0.1)};
 }

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/KhInstability.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/KhInstability.cpp
@@ -102,7 +102,6 @@ tuples::TaggedTuple<hydro::Tags::ElectronFraction<DataType>>
 KhInstability::variables(
     const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::ElectronFraction<DataType>> /*meta*/) const {
-  // FIXME Add proper EoS call to get Ye
 
 return {make_with_value<Scalar<DataType>>(x, 0.1)};
 }

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.cpp
@@ -86,7 +86,6 @@ tuples::TaggedTuple<hydro::Tags::ElectronFraction<DataType>>
 MagneticFieldLoop::variables(
     const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::ElectronFraction<DataType>> /*meta*/) const {
-  // FIXME Add proper EoS call to get Ye
 
   return {make_with_value<Scalar<DataType>>(x, 0.1)};
 }

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticRotor.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticRotor.cpp
@@ -93,7 +93,6 @@ tuples::TaggedTuple<hydro::Tags::ElectronFraction<DataType>>
 MagneticRotor::variables(
     const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::ElectronFraction<DataType>> /*meta*/) const {
-  // FIXME Add propoer EoS call to get Ye
 
   return {make_with_value<Scalar<DataType>>(x, 0.1)};
 }

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/OrszagTangVortex.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/OrszagTangVortex.cpp
@@ -44,7 +44,6 @@ tuples::TaggedTuple<hydro::Tags::ElectronFraction<DataType>>
 OrszagTangVortex::variables(
     const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::ElectronFraction<DataType>> /*meta*/) const {
-  // FIXME Need to add proper EoS call to Ye
   return {make_with_value<Scalar<DataType>>(x, 0.1)};
 }
 

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/RiemannProblem.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/RiemannProblem.cpp
@@ -85,8 +85,6 @@ tuples::TaggedTuple<hydro::Tags::ElectronFraction<DataType>>
 RiemannProblem::variables(
     const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::ElectronFraction<DataType>> /*meta*/) const {
-  // FIXME Either add EoS call or make electron fraction independent
-  // to test advection behavior
 
     return {make_with_value<Scalar<DataType>>(x, 0.1)};
 }

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.cpp
@@ -141,8 +141,7 @@ BondiMichel::IntermediateVars<DataType>::IntermediateVars(
                                           : sonic_bound,
             current_radius < sonic_radius ? sonic_bound : sonic_density, 1.e-15,
             1.e-15);
-    get_element(electron_fraction, i) =
-        0.4;  // FIXME Add correct EoS call to initialize Y_e
+    get_element(electron_fraction, i) = 0.4;
   }
   if (need_spacetime) {
     kerr_schild_soln = background_spacetime.variables(

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/RotatingStar.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/RotatingStar.cpp
@@ -642,8 +642,6 @@ RotatingStar::variables(
     const gsl::not_null<IntermediateVariables<DataType>*> /* vars */,
     const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::ElectronFraction<DataType>> /*meta*/) const {
-  // FIXME need to replace this with actual electron fraction
-  // consistent with the EoS used to construct the star.
 
   auto ye = make_with_value<Scalar<DataType>>(x, 0.1);
 

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.cpp
@@ -229,7 +229,7 @@ void TovVariables<DataType, Region>::operator()(
   if constexpr (Region == StarRegion::Exterior) {
     get(*electron_fraction) = 0.45;
   } else {
-    get(*electron_fraction) = 0.1;  // FIXME Need EOS call here
+    get(*electron_fraction) = 0.1;
   }
 }
 


### PR DESCRIPTION
This addresses left over FIXME's from a previous PR.