### PR TITLE
Update conditions in TimescaleTuner

### DIFF
--- a/src/ControlSystem/TimescaleTuner.cpp
+++ b/src/ControlSystem/TimescaleTuner.cpp
@@ -142,8 +142,7 @@ void TimescaleTuner::update_timescale(
     }
     // check whether we need to increase the timescale:
     else if (fabs(q[i]) < increase_timescale_threshold_ and
-             fabs(dtq[i] * timescale_[i]) <
-                 (increase_timescale_threshold_ - fabs(q[i]))) {
+             fabs(dtq[i] * timescale_[i]) < increase_timescale_threshold_) {
       // if Q `and` dtQ are below the minimum required threshold
       timescale_[i] *= increase_factor_;
     }

--- a/src/ControlSystem/TimescaleTuner.hpp
+++ b/src/ControlSystem/TimescaleTuner.hpp
@@ -44,9 +44,8 @@ class er;
  * - the error is sufficiently small: \f$|Q|<\f$ `increase_timescale_threshold`
  * \n
  * AND \n
- * - the expected change in \f$Q\f$ is less than the difference between the
- * current error and the threshold:
- * \f$|\dot{Q}|\tau < \f$ (`increase_timescale_threshold` \f$-|Q|\f$)
+ * - the expected change in \f$Q\f$ is less than the threshold:
+ * \f$|\dot{Q}|\tau < \f$ `increase_timescale_threshold`
  */
 
 class TimescaleTuner {

--- a/tests/Unit/ControlSystem/Test_TimescaleTuner.cpp
+++ b/tests/Unit/ControlSystem/Test_TimescaleTuner.cpp
@@ -161,11 +161,10 @@ void test_increase_or_decrease() {
 
     // There is only one case which triggers an increase in the timescale
     // (4) |Q| < increase_timescale_threshold
-    //     |\dot{Q}| < (increase_timescale_threshold-|Q|)/timescale
+    //     |\dot{Q}| < increase_timescale_threshold/timescale
     // the error and time derivative are sufficiently small: increase timescale
     q = sign_of_q * less_than_one * increase_timescale_threshold;
-    qdot = sign_of_q * less_than_one *
-           (increase_timescale_threshold - fabs(q)) / tscale;
+    qdot = sign_of_q * less_than_one * increase_timescale_threshold / tscale;
     tscale *= increase_factor;
     tst.update_timescale({{q, qdot}});
     CHECK(tst.current_timescale() ==


### PR DESCRIPTION
## Proposed changes

The condition for increasing the timescale was slightly different than the condition in SpEC. This changes the condition to match SpEC.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
