### PR TITLE
Find Python more consistently, fix macOS CI issues

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -676,7 +676,7 @@ ${{ env.CACHE_KEY_SUFFIX }}"
       # We install some low-level dependencies with Homebrew. They get picked up
       # by `spack external find`.
       SPECTRE_BREW_DEPS: >-  # Line breaks are spaces, no trailing newline
-        autoconf automake ccache cmake pkg-config python
+        autoconf automake ccache cmake pkg-config
       # We install these packages with Spack and cache them. The full specs are
       # listed in support/DevEnvironments/spack.yaml. This list is only needed
       # to create the cache.
@@ -693,6 +693,9 @@ ${{ env.CACHE_KEY_SUFFIX }}"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3.0.1
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
       - name: Install Homebrew dependencies
         run: |
           brew install $SPECTRE_BREW_DEPS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,12 @@ unset(${SPECTRE_NAME}_VERSION_PATCH)
 if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.19)
   cmake_policy(SET CMP0110 NEW)
 endif ()
+# - Prefer finding Python by location (NEW behavior) instead of always choosing
+#   the latest version installed on the system (OLD behavior). This allows to
+#   set `Python_ROOT_DIR` on the command line, like for any other package.
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.15)
+  cmake_policy(SET CMP0094 NEW)
+endif()
 
 # Define standard installation directories
 include(GNUInstallDirs)


### PR DESCRIPTION
## Proposed changes

This makes the `Python_ROOT_DIR` CMake variable consistent with others. Before, CMake would always pick the latest available Python on the system, even if `Python_ROOT_DIR` is specified on the command line.

See docs for details: https://cmake.org/cmake/help/latest/module/FindPython.html#hints

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
