### PR TITLE
Gh mesh velocity damping

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.cpp
@@ -422,7 +422,7 @@ void ConstraintPreservingBjorhus<Dim>::compute_intermediate_vars(
     const gsl::not_null<std::array<DataVector, 4>*> char_speeds,
 
     const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
-    /* face_mesh_velocity */,
+        face_mesh_velocity,
     const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
     const tnsr::aa<DataVector, Dim, Frame::Inertial>& pi,
     const tnsr::iaa<DataVector, Dim, Frame::Inertial>& phi,
@@ -540,7 +540,8 @@ void ConstraintPreservingBjorhus<Dim>::compute_intermediate_vars(
     }
   }
 
-  characteristic_speeds(char_speeds, gamma1, lapse, shift, normal_covector);
+  characteristic_speeds(char_speeds, gamma1, lapse, shift, normal_covector,
+                        face_mesh_velocity);
 }
 
 template <size_t Dim>

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DemandOutgoingCharSpeeds.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DemandOutgoingCharSpeeds.cpp
@@ -50,7 +50,8 @@ DemandOutgoingCharSpeeds<Dim>::dg_demand_outgoing_char_speeds(
     const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, Dim, Frame::Inertial>& shift) {
   const auto char_speeds = characteristic_speeds(
-      gamma_1, lapse, shift, outward_directed_normal_covector);
+      gamma_1, lapse, shift, outward_directed_normal_covector,
+      face_mesh_velocity);
   Scalar<DataVector> normal_dot_mesh_velocity;
   if (face_mesh_velocity.has_value()) {
     normal_dot_mesh_velocity = dot_product(outward_directed_normal_covector,

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/UpwindPenalty.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/UpwindPenalty.cpp
@@ -83,7 +83,8 @@ double UpwindPenalty<Dim>::dg_package_data(
   }
 
   if (normal_dot_mesh_velocity.has_value()) {
-    get<0>(*packaged_char_speeds) -= get(*normal_dot_mesh_velocity);
+    get<0>(*packaged_char_speeds) -=
+        get(*normal_dot_mesh_velocity) * (1. + get(constraint_gamma1));
     get<1>(*packaged_char_speeds) -= get(*normal_dot_mesh_velocity);
     get<2>(*packaged_char_speeds) -= get(*normal_dot_mesh_velocity);
     get<3>(*packaged_char_speeds) -= get(*normal_dot_mesh_velocity);

--- a/src/Evolution/Systems/GeneralizedHarmonic/DuDtTempTags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/DuDtTempTags.hpp
@@ -50,6 +50,12 @@ struct ShiftDotThreeIndexConstraint : db::SimpleTag {
   using type = tnsr::aa<DataVector, Dim, Frame::Inertial>;
 };
 
+/// \f$\v^i_g \mathcal{C}_{iab}\f$
+template <size_t Dim>
+struct MeshVelocityDotThreeIndexConstraint : db::SimpleTag {
+  using type = tnsr::aa<DataVector, Dim, Frame::Inertial>;
+};
+
 /// \f$\Phi_{iab}n^a\f$
 template <size_t Dim>
 struct PhiOneNormal : db::SimpleTag {

--- a/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/TagsTimeDependent.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/DuDtTempTags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"  // IWYU pragma: keep
@@ -44,12 +45,14 @@ namespace GeneralizedHarmonic {
  *
  * \f{align}{
  *   \partial_t g_{ab}-
- *   &\left(1+\gamma_1\right)\beta^k\partial_k g_{ab} =
+ *   &\left(1+\gamma_1\right)\beta^k\partial_k g_{ab} - \gamma_1 v^i_g
+ * \mathcal{C}_{iab} =
  *     -\alpha \Pi_{ab}-\gamma_1\beta^i\Phi_{iab}, \\
  *
  *   \partial_t\Pi_{ab}-
  *   &\beta^k\partial_k\Pi_{ab} + \alpha \gamma^{ki}\partial_k\Phi_{iab}
- *     - \gamma_1\gamma_2\beta^k\partial_kg_{ab} \notag \\
+ *     - \gamma_1\gamma_2\beta^k\partial_kg_{ab} - \gamma_1 \gamma_2 v^i_g
+ * \mathcal{C}_{iab} \notag\\
  *   =&2\alpha g^{cd}\left(\gamma^{ij}\Phi_{ica}\Phi_{jdb}
  *      - \Pi_{ca}\Pi_{db} - g^{ef}\Gamma_{ace}\Gamma_{bdf}\right) \notag \\
  *   &-2\alpha \nabla_{(a}H_{b)}
@@ -73,8 +76,10 @@ namespace GeneralizedHarmonic {
  *   &-\alpha \gamma_2\Phi_{iab},
  * \f}
  *
- * where \f$H_a\f$ is the gauge source function and
- * \f$\mathcal{C}_a=H_a+\Gamma_a\f$ is the gauge constraint. The constraint
+ * where \f$H_a\f$ is the gauge source function,
+ * \f$\mathcal{C}_a=H_a+\Gamma_a\f$ is the gauge constraint,
+ * \f$\mathcal{C}_{iab}\f$ is the 3-index constraint, and
+ * \f$v^i_g\f$ is the mesh velocity. The constraint
  * damping parameters \f$\gamma_0\f$ \f$\gamma_1\f$, \f$\gamma_2\f$,
  * \f$\gamma_3\f$, \f$\gamma_4\f$, and \f$\gamma_5\f$ have units of inverse time
  * and control the time scales on which the constraints are damped to zero.
@@ -82,6 +87,11 @@ namespace GeneralizedHarmonic {
  * \note We have not coded up the constraint damping terms for \f$\gamma_3\f$,
  * \f$\gamma_4\f$, and \f$\gamma_5\f$. \f$\gamma_3\f$ was found to be essential
  * for evolutions of black strings by Pretorius and Lehner \cite Lehner2010pn.
+ *
+ * \note Here the only terms dependent on mesh velocity are constraint damping
+ * terms added to this implementation of the generalized harmonic system.
+ * Mesh-velocity corrections that are applicable to all systems are made in
+ * `evolution::dg::Actions::detail::volume_terms()`.
  */
 template <size_t Dim>
 struct TimeDerivative {
@@ -93,7 +103,8 @@ struct TimeDerivative {
       Tags::PiTwoNormals, Tags::NormalDotOneIndexConstraint, Tags::Gamma1Plus1,
       Tags::PiOneNormal<Dim>, Tags::GaugeConstraint<Dim, Frame::Inertial>,
       Tags::PhiTwoNormals<Dim>, Tags::ShiftDotThreeIndexConstraint<Dim>,
-      Tags::PhiOneNormal<Dim>, Tags::PiSecondIndexUp<Dim>,
+      Tags::MeshVelocityDotThreeIndexConstraint<Dim>, Tags::PhiOneNormal<Dim>,
+      Tags::PiSecondIndexUp<Dim>,
       Tags::ThreeIndexConstraint<Dim, Frame::Inertial>,
       Tags::PhiFirstIndexUp<Dim>, Tags::PhiThirdIndexUp<Dim>,
       Tags::SpacetimeChristoffelFirstKindThirdIndexUp<Dim>,
@@ -116,7 +127,8 @@ struct TimeDerivative {
       ::GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma0,
       ::GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1,
       ::GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma2,
-      Tags::GaugeH<Dim>, Tags::SpacetimeDerivGaugeH<Dim>>;
+      Tags::GaugeH<Dim>, Tags::SpacetimeDerivGaugeH<Dim>,
+      domain::Tags::MeshVelocity<Dim, Frame::Inertial>>;
 
   static void apply(
       gsl::not_null<tnsr::aa<DataVector, Dim>*> dt_spacetime_metric,
@@ -136,6 +148,8 @@ struct TimeDerivative {
       gsl::not_null<tnsr::i<DataVector, Dim>*> phi_two_normals,
       gsl::not_null<tnsr::aa<DataVector, Dim>*>
           shift_dot_three_index_constraint,
+      gsl::not_null<tnsr::aa<DataVector, Dim>*>
+          mesh_velocity_dot_three_index_constraint,
       gsl::not_null<tnsr::ia<DataVector, Dim>*> phi_one_normal,
       gsl::not_null<tnsr::aB<DataVector, Dim>*> pi_2_up,
       gsl::not_null<tnsr::iaa<DataVector, Dim>*> three_index_constraint,
@@ -162,6 +176,8 @@ struct TimeDerivative {
       const tnsr::iaa<DataVector, Dim>& phi, const Scalar<DataVector>& gamma0,
       const Scalar<DataVector>& gamma1, const Scalar<DataVector>& gamma2,
       const tnsr::a<DataVector, Dim>& gauge_function,
-      const tnsr::ab<DataVector, Dim>& spacetime_deriv_gauge_function);
+      const tnsr::ab<DataVector, Dim>& spacetime_deriv_gauge_function,
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+          mesh_velocity);
 };
 }  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/VolumeTermsInstantiation.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/VolumeTermsInstantiation.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include <optional>
+
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "Evolution/DiscontinuousGalerkin/Actions/VolumeTermsImpl.tpp"
@@ -57,7 +59,9 @@ namespace evolution::dg::Actions::detail {
       const Scalar<DataVector>& gamma0, const Scalar<DataVector>& gamma1,     \
       const Scalar<DataVector>& gamma2,                                       \
       const tnsr::a<DataVector, DIM(data)>& gauge_function,                   \
-      const tnsr::ab<DataVector, DIM(data)>& spacetime_deriv_gauge_function);
+      const tnsr::ab<DataVector, DIM(data)>& spacetime_deriv_gauge_function,  \
+      const std::optional<tnsr::I<DataVector, DIM(data), Frame::Inertial>>&   \
+          mesh_velocity_from_time_deriv_args);
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/TimeDerivativeTerms.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/TimeDerivativeTerms.hpp
@@ -118,6 +118,8 @@ struct TimeDerivativeTermsImpl<
       const Scalar<DataVector>& /*gamma2*/,
       const tnsr::a<DataVector, 3_st>& /*gauge_function*/,
       const tnsr::ab<DataVector, 3_st>& /*spacetime_deriv_gauge_function*/,
+      const std::optional<
+          tnsr::I<DataVector, 3_st, Frame::Inertial>>& /*mesh_velocity*/,
       const TupleType& args) {
     trace_reversed_stress_energy(
         local_stress_energy, four_velocity_buffer_one_form,

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/VolumeTermsInstantiation.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/VolumeTermsInstantiation.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include <optional>
+
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "Evolution/DiscontinuousGalerkin/Actions/VolumeTermsImpl.tpp"
@@ -52,6 +54,8 @@ template void volume_terms<::grmhd::GhValenciaDivClean::TimeDerivativeTerms>(
     const Scalar<DataVector>& gamma2,
     const tnsr::a<DataVector, 3>& gauge_function,
     const tnsr::ab<DataVector, 3>& spacetime_deriv_gauge_function,
+    const std::optional<tnsr::I<DataVector, 3, Frame::Inertial>>&
+        mesh_velocity_gh,
     // GRMHD argument tags
     const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_ye,
     const Scalar<DataVector>& tilde_tau,

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.py
@@ -331,6 +331,7 @@ def error(face_mesh_velocity, normal_covector, normal_vector, spacetime_metric,
              spacetime_deriv_gauge_source, dt_pi, dt_phi, dt_spacetime_metric,
              d_pi, d_phi, d_spacetime_metric)
         char_speeds = char_speeds - np.dot(normal_covector, face_mesh_velocity)
+        char_speeds[0] -= np.dot(normal_covector, face_mesh_velocity) * gamma1
         if (np.amin(char_speeds) < 0.0) and (np.dot(face_mesh_velocity,
                                                     normal_covector) > 0.0):
             return (
@@ -367,6 +368,7 @@ def dt_corrs_ConstraintPreserving(
          dt_pi, dt_phi, dt_spacetime_metric, d_pi, d_phi, d_spacetime_metric)
     if face_mesh_velocity is not None:
         char_speeds = char_speeds - np.dot(normal_covector, face_mesh_velocity)
+        char_speeds[0] -= np.dot(normal_covector, face_mesh_velocity) * gamma1
     if np.amin(char_speeds) >= 0.:
         return (pi * 0, phi * 0, pi * 0, pi * 0)
     dt_v_psi = constraint_preserving_bjorhus_corrections_dt_v_psi(
@@ -411,6 +413,7 @@ def dt_corrs_ConstraintPreservingPhysical(
          dt_pi, dt_phi, dt_spacetime_metric, d_pi, d_phi, d_spacetime_metric)
     if face_mesh_velocity is not None:
         char_speeds = char_speeds - np.dot(normal_covector, face_mesh_velocity)
+        char_speeds[0] -= np.dot(normal_covector, face_mesh_velocity) * gamma1
     if np.amin(char_speeds) >= 0.:
         return (pi * 0, phi * 0, pi * 0, pi * 0)
     dt_v_psi = constraint_preserving_bjorhus_corrections_dt_v_psi(

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DemandOutgoingCharSpeeds.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DemandOutgoingCharSpeeds.py
@@ -20,6 +20,8 @@ def error(face_mesh_velocity, outward_directed_normal_covector,
         if face_mesh_velocity is not None:
             speeds[i] -= np.dot(outward_directed_normal_covector,
                                 face_mesh_velocity)
+            speeds[0] -= np.dot(outward_directed_normal_covector,
+                                face_mesh_velocity) * gamma_1
         if speeds[i] < 0.0:
             return ("DemandOutgoingCharSpeeds boundary condition violated")
     return None

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/UpwindPenalty.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/UpwindPenalty.py
@@ -15,7 +15,8 @@ def dg_package_data_char_speed_v_spacetime_metric(spacetime_metric, pi, phi,
             shift, normal_covector) * spacetime_metric
     else:
         return (-(1.0 + constraint_gamma1) * np.dot(shift, normal_covector) -
-                normal_dot_mesh_velocity) * spacetime_metric
+                normal_dot_mesh_velocity *
+                (1.0 + constraint_gamma1)) * spacetime_metric
 
 
 def dg_package_data_char_speed_v_zero(spacetime_metric, pi, phi,
@@ -98,7 +99,8 @@ def dg_package_data_char_speed_gamma2_v_spacetime_metric(
     else:
         return (
             -(1.0 + constraint_gamma1) * np.dot(shift, normal_covector) -
-            normal_dot_mesh_velocity) * spacetime_metric * constraint_gamma2
+            normal_dot_mesh_velocity *
+            (1.0 + constraint_gamma1)) * spacetime_metric * constraint_gamma2
 
 
 def dg_package_data_char_speeds(spacetime_metric, pi, phi, constraint_gamma1,
@@ -113,6 +115,7 @@ def dg_package_data_char_speeds(spacetime_metric, pi, phi, constraint_gamma1,
     if not (normal_dot_mesh_velocity is None):
         for i in range(4):
             result[i] -= normal_dot_mesh_velocity
+        result[0] -= normal_dot_mesh_velocity * constraint_gamma1
     return result
 
 

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/TestFunctions.py
@@ -187,6 +187,12 @@ def char_speed_upsi(gamma1, lapse, shift, unit_normal):
     return -(1. + gamma1) * np.dot(shift, unit_normal)
 
 
+def char_speed_upsi_moving_mesh(gamma1, lapse, shift, unit_normal,
+                                mesh_velocity):
+    return -(1. + gamma1) * np.dot(shift, unit_normal) - gamma1 * np.dot(
+        mesh_velocity, unit_normal)
+
+
 def char_speed_uzero(gamma1, lapse, shift, unit_normal):
     return -np.dot(shift, unit_normal)
 

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_DuDtTempTags.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_DuDtTempTags.cpp
@@ -27,6 +27,9 @@ void test_simple_tags() {
       GeneralizedHarmonic::Tags::ShiftDotThreeIndexConstraint<Dim>>(
       "ShiftDotThreeIndexConstraint");
   TestHelpers::db::test_simple_tag<
+      GeneralizedHarmonic::Tags::MeshVelocityDotThreeIndexConstraint<Dim>>(
+      "MeshVelocityDotThreeIndexConstraint");
+  TestHelpers::db::test_simple_tag<
       GeneralizedHarmonic::Tags::PhiOneNormal<Dim>>("PhiOneNormal");
   TestHelpers::db::test_simple_tag<
       GeneralizedHarmonic::Tags::PiSecondIndexUp<Dim>>("PiSecondIndexUp");

--- a/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/VerifyGrSolution.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/VerifyGrSolution.hpp
@@ -7,6 +7,7 @@
 
 #include <array>
 #include <cstddef>
+#include <optional>
 
 #include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
 #include "DataStructures/DataVector.hpp"        // IWYU pragma: keep
@@ -255,6 +256,7 @@ void verify_time_independent_einstein_solution(
       GeneralizedHarmonic::Tags::GaugeConstraint<3, Frame::Inertial>,
       GeneralizedHarmonic::Tags::PhiTwoNormals<3>,
       GeneralizedHarmonic::Tags::ShiftDotThreeIndexConstraint<3>,
+      GeneralizedHarmonic::Tags::MeshVelocityDotThreeIndexConstraint<3>,
       GeneralizedHarmonic::Tags::PhiOneNormal<3>,
       GeneralizedHarmonic::Tags::PiSecondIndexUp<3>,
       GeneralizedHarmonic::Tags::ThreeIndexConstraint<3, Frame::Inertial>,
@@ -300,6 +302,9 @@ void verify_time_independent_einstein_solution(
       make_not_null(
           &get<GeneralizedHarmonic::Tags::ShiftDotThreeIndexConstraint<3>>(
               buffer)),
+      make_not_null(
+          &get<GeneralizedHarmonic::Tags::MeshVelocityDotThreeIndexConstraint<
+              3>>(buffer)),
       make_not_null(&get<GeneralizedHarmonic::Tags::PhiOneNormal<3>>(buffer)),
       make_not_null(
           &get<GeneralizedHarmonic::Tags::PiSecondIndexUp<3>>(buffer)),
@@ -341,7 +346,7 @@ void verify_time_independent_einstein_solution(
           &get<gr::Tags::DerivativesOfSpacetimeMetric<3, Frame::Inertial,
                                                       DataVector>>(buffer)),
       d_psi, d_pi, d_phi, psi, pi, phi, gamma0, gamma1, gamma2, gauge_function,
-      d4_H);
+      d4_H, std::nullopt);
 
   // Make sure the RHS is zero.
   CHECK_ITERABLE_CUSTOM_APPROX(


### PR DESCRIPTION
## Proposed changes

Adds previously unpublished constraint damping terms to the generalized harmonic system. These terms are included in SpEC. This PR only adds the constraint-damping mesh-velocity terms; other mesh-velocity corrections, universally applicable to any system, are already implemented elsewhere in spectre.

### Upgrade instructions

<!-- UPGRADE INSTRUCTIONS -->
The generalized-harmonic time derivative and characteristic speeds now take additional parameters because of the newly introduced dependence on the mesh velocity.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
