### PR TITLE
Fix magnetic field sign error in MagnetizedTovStar analytic data

### DIFF
--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.cpp
@@ -90,19 +90,19 @@ void MagnetizedTovVariables<DataType, Region>::operator()(
           dr_pressure;
 
       get_element(get<0>(*magnetic_field), i) =
-          x * z / radius_i * deriv_pressure_term;
+          -x * z / radius_i * deriv_pressure_term;
 
       get_element(get<1>(*magnetic_field), i) =
-          y * z / radius_i * deriv_pressure_term;
+          -y * z / radius_i * deriv_pressure_term;
 
       get_element(get<2>(*magnetic_field), i) =
-          (-2.0 * pressure_term +
-           (square(x) + square(y)) / radius_i * deriv_pressure_term);
+          2.0 * pressure_term +
+          (square(x) + square(y)) / radius_i * deriv_pressure_term;
     } else {
       get_element(get<0>(*magnetic_field), i) = 0.0;
       get_element(get<1>(*magnetic_field), i) = 0.0;
       get_element(get<2>(*magnetic_field), i) =
-          (-2.0 * pow(pressure - cutoff_pressure, pressure_exponent));
+          2.0 * pow(pressure - cutoff_pressure, pressure_exponent);
     }
   }
   for (size_t i = 0; i < 3; ++i) {

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.hpp
@@ -101,15 +101,15 @@ struct MagnetizedTovVariables
  *
  * \f{align*}{
  *   B^i&=n_a\epsilon^{aijk}\partial_jA_k \\
- *      &=-\frac{1}{\sqrt{\gamma}}[ijk]\partial_j A_k,
+ *      &=\frac{1}{\sqrt{\gamma}}[ijk]\partial_j A_k,
  * \f}
  *
  * where \f$[ijk]\f$ is the total anti-symmetric symbol. This means that
  *
  * \f{align*}{
- *   B^x&=\frac{1}{\sqrt{\gamma}} (\partial_z A_y-\partial_y A_z), \\
- *   B^y&=\frac{1}{\sqrt{\gamma}} (\partial_x A_z - \partial_z A_x), \\
- *   B^z&=\frac{1}{\sqrt{\gamma}} (\partial_y A_x - \partial_x A_y).
+ *   B^x&=\frac{1}{\sqrt{\gamma}} (\partial_y A_z - \partial_z A_y), \\
+ *   B^y&=\frac{1}{\sqrt{\gamma}} (\partial_z A_x - \partial_x A_z), \\
+ *   B^z&=\frac{1}{\sqrt{\gamma}} (\partial_x A_y - \partial_y A_x).
  * \f}
  *
  * Focusing on the region where the field is non-zero we have:
@@ -130,11 +130,11 @@ struct MagnetizedTovVariables
  * The magnetic field is given by:
  *
  * \f{align*}{
- *   B^x&=\frac{1}{\sqrt{\gamma}}\frac{xz}{r}
+ *   B^x&=-\frac{1}{\sqrt{\gamma}}\frac{xz}{r}
  *        A_bn_s(p-p_{\mathrm{cut}})^{n_s-1}\partial_rp \\
- *   B^y&=\frac{1}{\sqrt{\gamma}}\frac{yz}{r}
+ *   B^y&=-\frac{1}{\sqrt{\gamma}}\frac{yz}{r}
  *        A_bn_s(p-p_{\mathrm{cut}})^{n_s-1}\partial_rp \\
- *   B^z&=-\frac{A_b}{\sqrt{\gamma}}\left[
+ *   B^z&=\frac{A_b}{\sqrt{\gamma}}\left[
  *        2(p-p_{\mathrm{cut}})^{n_s} \phantom{\frac{a}{b}}\right. \\
  *      &\left.+\frac{x^2+y^2}{r}
  *        n_s(p-p_{\mathrm{cut}})^{n_s-1}\partial_r p
@@ -146,7 +146,7 @@ struct MagnetizedTovVariables
  * \f{align*}{
  *   B^x&=0, \\
  *   B^y&=0, \\
- *   B^z&=-\frac{A_b}{\sqrt{\gamma}}
+ *   B^z&=\frac{A_b}{\sqrt{\gamma}}
  *        2(p-p_{\mathrm{cut}})^{n_s}.
  * \f}
  *


### PR DESCRIPTION
## Proposed changes

There were
* missing minus sign at the term with pressure derivative in the B_z (see the line 99 of cpp file)
* Overall extra (-) sign for computing B field from the potential

The first bug hasn't been caught by test since it goes to zero at the origin and the test was done only around the origin.


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
