### PR TITLE
Validate release name in specified timezone

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -38,6 +38,13 @@ on:
           Enter a version name YYYY.MM.DD[.TWEAK] to create a release on success
         required: false
         default: ''
+      timezone:
+        description: >
+          Timezone used for validating the version name. The release must be
+          approved by the end of the day in the specified timezone. See
+          /usr/share/zoneinfo for a list of possible values.
+        required: false
+        default: 'America/Los_Angeles'
       clear_ccache:
         description: >
           Enter 'yes' without quotes to clear ccache before running
@@ -871,6 +878,8 @@ ${{ env.CACHE_KEY_SUFFIX }}"
       - check_files_and_formatting
       - doc_check
       - unit_tests
+    env:
+      TZ: ${{ github.event.inputs.timezone }}
     steps:
       - uses: actions/checkout@v3.0.1
         with:


### PR DESCRIPTION
## Proposed changes

Allows to set the time zone when dispatching the release workflow. The release must be approved by the end of the day in the specified time zone.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
