### PR TITLE
Raise SIGTRAP in Blaze when in debug mode

### DIFF
--- a/cmake/SetupPch.cmake
+++ b/cmake/SetupPch.cmake
@@ -235,11 +235,11 @@ if (USE_PCH)
 
   # Set the compiler-dependent flags needed to use precompiled headers
   if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    set(SPECTRE_PCH_FLAG "-include;${SPECTRE_PCH_HEADER_PATH}")
+    set(SPECTRE_PCH_FLAG "-include ${SPECTRE_PCH_HEADER_PATH}")
   elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    set(SPECTRE_PCH_FLAG "-include-pch;${SPECTRE_PCH_PATH}")
+    set(SPECTRE_PCH_FLAG "-include-pch ${SPECTRE_PCH_PATH}")
   elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
-    set(SPECTRE_PCH_FLAG "-include-pch;${SPECTRE_PCH_PATH}")
+    set(SPECTRE_PCH_FLAG "-include-pch ${SPECTRE_PCH_PATH}")
   else()
     message(
       STATUS "Precompiled headers have not been configured for"
@@ -247,9 +247,9 @@ if (USE_PCH)
       )
   endif()
 
-  set_property(TARGET ${SPECTRE_PCH}
-    APPEND PROPERTY INTERFACE_COMPILE_OPTIONS
-    $<$<COMPILE_LANGUAGE:CXX>:${SPECTRE_PCH_FLAG}>
+  target_compile_options(${SPECTRE_PCH}
+    INTERFACE
+    "$<$<COMPILE_LANGUAGE:CXX>:SHELL:${SPECTRE_PCH_FLAG}>"
     )
 
   # Have `make clean` (and `ninja clean` on CMake v3.15 and newer) remove


### PR DESCRIPTION
## Proposed changes

Since the option parser uses exceptions quite a bit, using 'catch throw' in GDB is not the best experience. Blaze has support for custom error handling, so we will now raise SIGTRAP before throwing. This is analogous to what we do with our own errors. It also disables error checks in Blaze in release mode, consistent with how we disable all error checks in SpECTRE in release mode.

@nikwit this should fix the annoyance you were facing while debugging.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
