### PR TITLE
Split IO libs

### DIFF
--- a/src/ApparentHorizons/CMakeLists.txt
+++ b/src/ApparentHorizons/CMakeLists.txt
@@ -45,4 +45,6 @@ target_link_libraries(
   PRIVATE
   CoordinateMaps
   Domain
+  INTERFACE
+  Observer
   )

--- a/src/ControlSystem/CMakeLists.txt
+++ b/src/ControlSystem/CMakeLists.txt
@@ -44,7 +44,8 @@ target_link_libraries(
   Domain
   ErrorHandling
   FunctionsOfTime
-  IO
+  INTERFACE
+  Observer
   )
 
 add_subdirectory(Actions)

--- a/src/Domain/FunctionsOfTime/CMakeLists.txt
+++ b/src/Domain/FunctionsOfTime/CMakeLists.txt
@@ -44,5 +44,5 @@ target_link_libraries(
   Utilities
   PRIVATE
   ErrorHandling
-  IO
+  H5
   )

--- a/src/Elliptic/Executables/Elasticity/CMakeLists.txt
+++ b/src/Elliptic/Executables/Elasticity/CMakeLists.txt
@@ -18,8 +18,8 @@ set(LIBS_TO_LINK
   Events
   EventsAndTriggers
   Informer
-  IO
   LinearOperators
+  Observer
   Options
   Parallel
   ParallelLinearSolver

--- a/src/Elliptic/Executables/Poisson/CMakeLists.txt
+++ b/src/Elliptic/Executables/Poisson/CMakeLists.txt
@@ -12,9 +12,9 @@ set(LIBS_TO_LINK
   Events
   EventsAndTriggers
   Informer
-  IO
   LinearOperators
   MathFunctions
+  Observer
   Options
   Parallel
   ParallelLinearSolver

--- a/src/Elliptic/Executables/Xcts/CMakeLists.txt
+++ b/src/Elliptic/Executables/Xcts/CMakeLists.txt
@@ -17,9 +17,9 @@ set(LIBS_TO_LINK
   EventsAndTriggers
   Informer
   Initialization
-  IO
   LinearOperators
   MathFunctions
+  Observer
   Options
   Parallel
   ParallelLinearSolver

--- a/src/Evolution/CMakeLists.txt
+++ b/src/Evolution/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(
   PRIVATE
   LinearOperators
   INTERFACE
+  Observer
   SystemUtilities
   )
 

--- a/src/Evolution/DgSubcell/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/CMakeLists.txt
@@ -57,7 +57,6 @@ target_link_libraries(
   PUBLIC
   DataStructures
   Domain
-  IO
   Spectral
 
   INTERFACE

--- a/src/Evolution/Executables/Burgers/CMakeLists.txt
+++ b/src/Evolution/Executables/Burgers/CMakeLists.txt
@@ -12,10 +12,10 @@ set(LIBS_TO_LINK
   EventsAndTriggers
   Evolution
   FiniteDifference
-  IO
   Informer
   Limiters
   LinearOperators
+  Observer
   Options
   Parallel
   PhaseControl

--- a/src/Evolution/Executables/Cce/CMakeLists.txt
+++ b/src/Evolution/Executables/Cce/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBS_TO_LINK
   Informer
   Spectral
   LinearOperators
+  Observer
   Options
   Parallel
   Utilities

--- a/src/Evolution/Executables/CurvedScalarWave/CMakeLists.txt
+++ b/src/Evolution/Executables/CurvedScalarWave/CMakeLists.txt
@@ -12,14 +12,14 @@ set(LIBS_TO_LINK
   EventsAndTriggers
   Evolution
   GeneralRelativity
-  IO
   Informer
   LinearOperators
   MathFunctions
-  Time
+  Observer
   Options
   Parallel
   PhaseControl
+  Time
   Utilities
   WaveEquationSolutions
 )

--- a/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
@@ -33,11 +33,11 @@ set(LIBS_TO_LINK
   Evolution
   GeneralRelativity
   GeneralizedHarmonic
-  IO
   Informer
   Interpolation
   LinearOperators
   MathFunctions
+  Observer
   Options
   Parallel
   ParallelInterpolation

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/CMakeLists.txt
@@ -36,11 +36,11 @@ set(LIBS_TO_LINK
   GrMhdAnalyticData
   GrMhdSolutions
   Hydro
-  IO
   Informer
   Limiters
   LinearOperators
   MathFunctions
+  Observer
   Options
   Parallel
   RelativisticEulerSolutions

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -24,13 +24,13 @@ set(LIBS_TO_LINK
   GrMhdAnalyticData
   GrMhdSolutions
   Hydro
-  IO
   Informer
   Limiters
   LinearOperators
   MathFunctions
   ParallelInterpolation
   RelativisticEulerSolutions
+  Observer
   Options
   Parallel
   PhaseControl

--- a/src/Evolution/Executables/NewtonianEuler/CMakeLists.txt
+++ b/src/Evolution/Executables/NewtonianEuler/CMakeLists.txt
@@ -40,7 +40,6 @@ set(LIBS_TO_LINK
   EventsAndTriggers
   Evolution
   Hydro
-  IO
   Informer
   Limiters
   LinearOperators
@@ -51,6 +50,7 @@ set(LIBS_TO_LINK
   NewtonianEulerLimiters
   NewtonianEulerSolutions
   NewtonianEulerSources
+  Observer
   Options
   Parallel
   PhaseControl

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/CMakeLists.txt
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/CMakeLists.txt
@@ -10,13 +10,13 @@ set(LIBS_TO_LINK
   Evolution
   GeneralRelativitySolutions
   Hydro
-  IO
   Informer
   Limiters
   LinearOperators
   MathFunctions
   M1Grey
   M1GreySolutions
+  Observer
   Options
   Parallel
   PhaseControl

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/CMakeLists.txt
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/CMakeLists.txt
@@ -10,16 +10,16 @@ set(LIBS_TO_LINK
   Evolution
   GeneralRelativitySolutions
   Hydro
-  IO
   Informer
   Limiters
   LinearOperators
   MathFunctions
   RelativisticEulerSolutions
-  Time
+  Observer
   Options
   Parallel
   PhaseControl
+  Time
   Utilities
   Valencia
   )

--- a/src/Evolution/Executables/ScalarAdvection/CMakeLists.txt
+++ b/src/Evolution/Executables/ScalarAdvection/CMakeLists.txt
@@ -9,10 +9,10 @@ set(LIBS_TO_LINK
   EventsAndTriggers
   Evolution
   FiniteDifference
-  IO
   Informer
   Limiters
   LinearOperators
+  Observer
   Options
   Parallel
   PhaseControl

--- a/src/Evolution/Executables/ScalarWave/CMakeLists.txt
+++ b/src/Evolution/Executables/ScalarWave/CMakeLists.txt
@@ -9,15 +9,15 @@ set(LIBS_TO_LINK
   EventsAndDenseTriggers
   EventsAndTriggers
   Evolution
-  IO
   Informer
   LinearOperators
   MathFunctions
   ScalarWave
-  Time
+  Observer
   Options
   Parallel
   PhaseControl
+  Time
   Utilities
   WaveEquationSolutions
   )

--- a/src/Evolution/Systems/Cce/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/CMakeLists.txt
@@ -62,9 +62,10 @@ target_link_libraries(
   ErrorHandling
   GeneralizedHarmonic
   GeneralRelativity
-  IO
+  H5
   Interpolation
   LinearOperators
+  Observer
   Options
   Spectral
   Utilities

--- a/src/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
@@ -41,7 +41,7 @@ target_link_libraries(
   FunctionsOfTime
   GeneralRelativity
   GeneralRelativitySolutions
-  IO
+  Importers
   Initialization
   LinearOperators
   Options

--- a/src/Executables/CombineH5/CMakeLists.txt
+++ b/src/Executables/CombineH5/CMakeLists.txt
@@ -15,7 +15,7 @@ target_link_libraries(
   Boost::boost
   Boost::program_options
   DataStructures
-  IO
+  H5
   Parallel
   Utilities
   )

--- a/src/Executables/ConvertComposeTable/CMakeLists.txt
+++ b/src/Executables/ConvertComposeTable/CMakeLists.txt
@@ -15,5 +15,7 @@ target_link_libraries(
   Boost::boost
   Boost::program_options
   DataStructures
+  H5
+  Informer
   IO
   )

--- a/src/Executables/ExportCoordinates/CMakeLists.txt
+++ b/src/Executables/ExportCoordinates/CMakeLists.txt
@@ -7,8 +7,8 @@ set(LIBS_TO_LINK
   EventsAndTriggers
   Evolution
   Informer
-  IO
   LinearOperators
+  Observer
   Options
   Parallel
   Time

--- a/src/Executables/FindHorizons/CMakeLists.txt
+++ b/src/Executables/FindHorizons/CMakeLists.txt
@@ -9,8 +9,8 @@ set(LIBS_TO_LINK
   GeneralRelativity
   Informer
   Importers
-  IO
   LinearOperators
+  Observer
   Options
   Parallel
   ParallelInterpolation

--- a/src/Executables/ReduceCceWorldtube/CMakeLists.txt
+++ b/src/Executables/ReduceCceWorldtube/CMakeLists.txt
@@ -16,7 +16,6 @@ target_link_libraries(
   Boost::program_options
   Cce
   GeneralRelativity
-  IO
   Informer
   Spectral
   )

--- a/src/IO/CMakeLists.txt
+++ b/src/IO/CMakeLists.txt
@@ -20,25 +20,20 @@ spectre_target_headers(
   Connectivity.hpp
   )
 
+# Notes:
+# - The H5 lib depends in IO for the connectivity. Keep that in mind when adding
+#   dependencies here.
 target_link_libraries(
   ${LIBRARY}
   PUBLIC
-  Boost::boost
   DataStructures
   ErrorHandling
-  EventsAndTriggers
-  hdf5::hdf5
-  Options
-  Spectral
   Utilities
-  PRIVATE
-  Informer
-  INTERFACE
-  Spectral
-  SystemUtilities
   )
 
 add_subdirectory(H5)
-add_subdirectory(Importers)
 add_subdirectory(Logging)
+
+# These two libraries should move to ParallelAlgorithms
+add_subdirectory(Importers)
 add_subdirectory(Observer)

--- a/src/IO/H5/CMakeLists.txt
+++ b/src/IO/H5/CMakeLists.txt
@@ -1,6 +1,10 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+set(LIBRARY H5)
+
+add_spectre_library(${LIBRARY})
+
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
@@ -40,6 +44,20 @@ spectre_target_headers(
   Version.hpp
   VolumeData.hpp
   Wrappers.hpp
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  Boost::boost
+  DataStructures
+  ErrorHandling
+  hdf5::hdf5
+  Utilities
+  Spectral
+  PRIVATE
+  Informer
+  IO
   )
 
 add_subdirectory(Python)

--- a/src/IO/H5/Python/CMakeLists.txt
+++ b/src/IO/H5/Python/CMakeLists.txt
@@ -21,7 +21,7 @@ spectre_python_link_libraries(
   PRIVATE
   Boost::boost
   DataStructures
-  IO
+  H5
   pybind11::module
   )
 

--- a/src/IO/Importers/CMakeLists.txt
+++ b/src/IO/Importers/CMakeLists.txt
@@ -24,11 +24,12 @@ target_link_libraries(
   ${LIBRARY}
   PUBLIC
   ErrorHandling
+  H5
+  Observer
   Options
   INTERFACE
   DataStructures
   DomainStructure
-  IO
   Initialization
   Parallel
   Utilities

--- a/src/IO/Observer/CMakeLists.txt
+++ b/src/IO/Observer/CMakeLists.txt
@@ -1,6 +1,10 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+set(LIBRARY Observer)
+
+add_spectre_library(${LIBRARY})
+
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
@@ -26,6 +30,22 @@ spectre_target_headers(
   TypeOfObservation.hpp
   VolumeActions.hpp
   WriteSimpleData.hpp
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  Boost::boost
+  Charmxx::pup
+  DataStructures
+  Domain
+  ErrorHandling
+  H5
+  Options
+  Parallel
+  Utilities
+  INTERFACE
+  EventsAndTriggers
   )
 
 add_subdirectory(Actions)

--- a/src/ParallelAlgorithms/Events/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Events/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(
   EventsAndTriggers
   Interpolation
   LinearOperators
+  Observer
   Options
   Parallel
   Spectral

--- a/src/ParallelAlgorithms/Interpolation/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Interpolation/CMakeLists.txt
@@ -53,7 +53,7 @@ target_link_libraries(
   DgSubcell
   EventsAndTriggers
   GeneralizedHarmonic
-  IO
+  Observer
   )
 
 add_subdirectory(Actions)

--- a/src/ParallelAlgorithms/LinearSolver/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/CMakeLists.txt
@@ -19,9 +19,9 @@ target_link_libraries(
   Convergence
   DataStructures
   Initialization
-  IO
   LinearSolver
   Logging
+  Observer
   Parallel
   SystemUtilities
   Utilities

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/CMakeLists.txt
@@ -34,8 +34,8 @@ target_link_libraries(
   DataStructures
   Domain
   Initialization
-  IO
   Logging
+  Observer
   Options
   Parallel
   ParallelLinearSolver

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/CMakeLists.txt
@@ -38,10 +38,10 @@ target_link_libraries(
   Convergence
   DiscontinuousGalerkin
   Domain
-  IO
   Initialization
   LinearSolver
   Logging
+  Observer
   Options
   Parallel
   ParallelLinearSolver

--- a/src/ParallelAlgorithms/NonlinearSolver/CMakeLists.txt
+++ b/src/ParallelAlgorithms/NonlinearSolver/CMakeLists.txt
@@ -22,9 +22,9 @@ target_link_libraries(
   Convergence
   DataStructures
   Initialization
-  IO
   LinearSolver
   Logging
+  Observer
   Options
   Parallel
   ParallelLinearSolver

--- a/tests/Unit/ControlSystem/CMakeLists.txt
+++ b/tests/Unit/ControlSystem/CMakeLists.txt
@@ -39,6 +39,8 @@ target_link_libraries(
   ControlSystem
   EventsAndDenseTriggers
   FunctionsOfTime
+  H5
+  Observer
   ObserverHelpers
   Parallel
   SizeControlErrors

--- a/tests/Unit/Domain/FunctionsOfTime/CMakeLists.txt
+++ b/tests/Unit/Domain/FunctionsOfTime/CMakeLists.txt
@@ -19,5 +19,17 @@ add_test_library(
   ${LIBRARY}
   "Domain/FunctionsOfTime"
   "${LIBRARY_SOURCES}"
-  "DataStructures;DomainCreators;FunctionsOfTime;IO;Informer;Options;Utilities"
+  ""
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  DataStructures
+  DomainCreators
+  FunctionsOfTime
+  H5
+  Informer
+  Options
+  Utilities
   )

--- a/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
+++ b/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
@@ -49,7 +49,6 @@ target_link_libraries(
   DgSubcell
   DgSubcellHelpers
   ErrorHandling
-  IO
   Parallel
   Spectral
   )

--- a/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
@@ -32,5 +32,18 @@ add_test_library(
   ${LIBRARY}
   "Evolution/Systems/Cce/"
   "${LIBRARY_SOURCES}"
-  "Boost::boost;Cce;CceHelpers;DataStructures;IO;Options;Spectral;GeneralRelativitySolutions"
+  ""
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  Boost::boost
+  Cce
+  CceHelpers
+  DataStructures
+  Observer
+  Options
+  Spectral
+  GeneralRelativitySolutions
   )

--- a/tests/Unit/Helpers/ControlSystem/CMakeLists.txt
+++ b/tests/Unit/Helpers/ControlSystem/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(
   ControlSystem
   Domain
   DataStructures
+  Observer
   Parallel
   Time
   Utilities

--- a/tests/Unit/Helpers/Evolution/Systems/Cce/CMakeLists.txt
+++ b/tests/Unit/Helpers/Evolution/Systems/Cce/CMakeLists.txt
@@ -16,6 +16,7 @@ target_link_libraries(
   PUBLIC
   Cce
   DataStructures
+  H5
   Spectral
   Utilities
   )

--- a/tests/Unit/Helpers/IO/CMakeLists.txt
+++ b/tests/Unit/Helpers/IO/CMakeLists.txt
@@ -23,9 +23,9 @@ target_link_libraries(
   PRIVATE
   Boost::boost
   DataStructures
-  IO
   ErrorHandling
   Framework
+  H5
   Utilities
   )
 

--- a/tests/Unit/Helpers/IO/Observers/CMakeLists.txt
+++ b/tests/Unit/Helpers/IO/Observers/CMakeLists.txt
@@ -26,7 +26,7 @@ target_link_libraries(
   DataStructures
   Domain
   Framework
-  IO
+  Observer
   Parallel
   Utilities
   )

--- a/tests/Unit/IO/CMakeLists.txt
+++ b/tests/Unit/IO/CMakeLists.txt
@@ -1,33 +1,9 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-add_subdirectory(Importers)
-add_subdirectory(Logging)
-
 set(LIBRARY "Test_IO")
 
 set(LIBRARY_SOURCES
-  H5/Test_CheckH5PropertiesMatch.cpp
-  H5/Test_Dat.cpp
-  H5/Test_EosTable.cpp
-  H5/Test_H5.cpp
-  H5/Test_H5File.cpp
-  H5/Test_OpenGroup.cpp
-  H5/Test_StellarCollapseEos.cpp
-  H5/Test_Version.cpp
-  H5/Test_VolumeData.cpp
-  Observers/Test_ArrayComponentId.cpp
-  Observers/Test_GetLockPointer.cpp
-  Observers/Test_Initialize.cpp
-  Observers/Test_ObservationId.cpp
-  Observers/Test_ReductionObserver.cpp
-  Observers/Test_RegisterElements.cpp
-  Observers/Test_RegisterEvents.cpp
-  Observers/Test_RegisterSingleton.cpp
-  Observers/Test_Tags.cpp
-  Observers/Test_TypeOfObservation.cpp
-  Observers/Test_VolumeObserver.cpp
-  Observers/Test_WriteSimpleData.cpp
   Test_ComposeTable.cpp
   Test_Connectivity.cpp
   )
@@ -42,38 +18,13 @@ add_test_library(
 target_link_libraries(
   ${LIBRARY}
   PRIVATE
-  Boost::boost
   DataStructures
-  DomainStructure
-  EventsAndTriggers
   IO
-  IoTestHelpers
-  ObserverHelpers
-  Parallel
-  SphericalHarmonics
+  Informer
   Utilities
   )
 
-add_dependencies(
-  ${LIBRARY}
-  module_GlobalCache
-  )
-
-spectre_add_python_bindings_test(
-  "Unit.IO.H5.Python"
-  "H5/Test_H5.py"
-  "unit;IO;H5;python"
-  PyH5)
-
-spectre_add_python_bindings_test(
-  "Unit.IO.H5.VolumeData.Python"
-  "H5/Test_VolumeData.py"
-  "unit;IO;H5;Python"
-  PyH5
-  )
-
-spectre_add_python_bindings_test(
-  "Unit.IO.H5.Python.ExtractDatFromH5"
-  "H5/Python/Test_ExtractDatFromH5.py"
-  "unit;DataStructures;IO;H5;python"
-  PyH5)
+add_subdirectory(H5)
+add_subdirectory(Importers)
+add_subdirectory(Logging)
+add_subdirectory(Observers)

--- a/tests/Unit/IO/H5/CMakeLists.txt
+++ b/tests/Unit/IO/H5/CMakeLists.txt
@@ -1,0 +1,57 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_H5")
+
+set(LIBRARY_SOURCES
+  Test_CheckH5PropertiesMatch.cpp
+  Test_Dat.cpp
+  Test_EosTable.cpp
+  Test_H5.cpp
+  Test_H5File.cpp
+  Test_OpenGroup.cpp
+  Test_StellarCollapseEos.cpp
+  Test_Version.cpp
+  Test_VolumeData.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "IO/H5/"
+  "${LIBRARY_SOURCES}"
+  ""
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  Boost::boost
+  DataStructures
+  H5
+  Informer
+  IO
+  IoTestHelpers
+  Spectral
+  Utilities
+  )
+
+spectre_add_python_bindings_test(
+  "Unit.IO.H5.Python"
+  "Test_H5.py"
+  "unit;IO;H5;python"
+  PyH5
+  )
+
+spectre_add_python_bindings_test(
+  "Unit.IO.H5.VolumeData.Python"
+  "Test_VolumeData.py"
+  "unit;IO;H5;Python"
+  PyH5
+  )
+
+spectre_add_python_bindings_test(
+  "Unit.IO.H5.Python.ExtractDatFromH5"
+  "Python/Test_ExtractDatFromH5.py"
+  "unit;DataStructures;IO;H5;python"
+  PyH5
+  )

--- a/tests/Unit/IO/Observers/CMakeLists.txt
+++ b/tests/Unit/IO/Observers/CMakeLists.txt
@@ -1,0 +1,44 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_Observer")
+
+set(LIBRARY_SOURCES
+  Test_ArrayComponentId.cpp
+  Test_GetLockPointer.cpp
+  Test_Initialize.cpp
+  Test_ObservationId.cpp
+  Test_ReductionObserver.cpp
+  Test_RegisterElements.cpp
+  Test_RegisterEvents.cpp
+  Test_RegisterSingleton.cpp
+  Test_Tags.cpp
+  Test_TypeOfObservation.cpp
+  Test_VolumeObserver.cpp
+  Test_WriteSimpleData.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "IO/Observers/"
+  "${LIBRARY_SOURCES}"
+  ""
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  Boost::boost
+  DataStructures
+  DataStructuresHelpers
+  DomainStructure
+  EventsAndTriggers
+  ErrorHandling
+  IoTestHelpers
+  Observer
+  ObserverHelpers
+  Options
+  Parallel
+  Utilities
+  Spectral
+  )

--- a/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -38,7 +38,6 @@ target_link_libraries(
   DomainStructure
   GeneralRelativitySolutions
   Interpolation
-  IO
   Logging
   MathFunctions
   RelativisticEulerSolutions

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -10,8 +10,9 @@ set(ALGORITHM_TEST_LINK_LIBRARIES
   Boost::program_options
   Charmxx::main
   ErrorHandling
+  H5
   Informer
-  IO
+  Observer
   Options
   Parallel
   ParallelHelpers
@@ -147,8 +148,22 @@ add_test_library(
   ${LIBRARY}
   "Parallel"
   "${LIBRARY_SOURCES}"
-  "IO;Options;Parallel;SystemUtilities"
+  ""
   )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  Actions
+  DataStructures
+  DataStructuresHelpers
+  DomainStructure
+  ObserverHelpers
+  Options
+  Parallel
+  SystemUtilities
+  Utilities
+)
 
 add_dependencies(
   ${LIBRARY}

--- a/tests/Unit/ParallelAlgorithms/Events/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Events/CMakeLists.txt
@@ -27,7 +27,7 @@ target_link_libraries(
   Events
   EventsAndTriggers
   Interpolation
-  IO
+  Observer
   Spectral
   Time
   Utilities

--- a/tests/Unit/ParallelAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/CMakeLists.txt
@@ -46,11 +46,12 @@ target_link_libraries(
   DomainCreators
   DomainStructure
   GeneralRelativitySolutions
+  H5
   Interpolation
-  IO
   IoTestHelpers
   Logging
   MathFunctions
+  Observer
   ParallelInterpolation
   RelativisticEulerSolutions
   Spectral

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/CMakeLists.txt
@@ -19,6 +19,6 @@ target_link_libraries(
   PRIVATE
   Convergence
   DataStructures
-  IO
+  H5
   ParallelLinearSolver
   )

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/CMakeLists.txt
@@ -11,7 +11,16 @@ add_test_library(
   ${LIBRARY}
   "ParallelAlgorithms/LinearSolver/"
   "${LIBRARY_SOURCES}"
-  "Convergence;DataStructures;Options;ParallelLinearSolver"
+  ""
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  Convergence
+  DataStructures
+  Options
+  ParallelLinearSolver
   )
 
 add_dependencies(
@@ -26,8 +35,8 @@ set(INTEGRATION_TEST_LINK_LIBRARIES
   Charmxx::main
   DataStructures
   ErrorHandling
-  IO
   Informer
+  Observer
   Parallel
   ParallelLinearSolver
   )

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/CMakeLists.txt
@@ -20,8 +20,8 @@ target_link_libraries(
   PRIVATE
   Convergence
   DataStructures
-  IO
   Logging
+  Observer
   ParallelLinearSolver
 )
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/CMakeLists.txt
@@ -20,8 +20,8 @@ target_link_libraries(
   PRIVATE
   Convergence
   DataStructures
-  IO
   Logging
+  Observer
   ParallelLinearSolver
 )
 

--- a/tests/Unit/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/CMakeLists.txt
@@ -23,7 +23,6 @@ set(INTEGRATION_TEST_LINK_LIBRARIES
   DataStructures
   ErrorHandling
   Informer
-  IO
   ParallelLinearSolver
   ParallelNonlinearSolver
   )


### PR DESCRIPTION
## Proposed changes

`H5` and `Observer` are separate libs now.

This helps decouple some code. In particular, `Observer` will need to depend on `Domain` somehow, but `H5` should probably remain lower-level.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Instead of linking with `IO`, check if you should link with `H5` or `Observer` instead.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
