### PR TITLE
Initialize background metric variables when using runtime initial data

### DIFF
--- a/src/Evolution/Initialization/GrTagsForHydro.hpp
+++ b/src/Evolution/Initialization/GrTagsForHydro.hpp
@@ -16,6 +16,12 @@
 #include "Parallel/AlgorithmExecution.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
+#include "PointwiseFunctions/AnalyticData/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/Tags/InitialData.hpp"
+#include "Utilities/CallWithDynamicType.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -75,7 +81,7 @@ struct GrTagsForHydro {
   static Parallel::iterable_action_return_t apply(
       db::DataBox<DbTagsList>& box,
       const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-      const Parallel::GlobalCache<Metavariables>& cache,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/, ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
     const double initial_time = db::get<Initialization::Tags::InitialTime>(box);
@@ -92,11 +98,39 @@ struct GrTagsForHydro {
                     box)),
             initial_time, db::get<domain::Tags::FunctionsOfTime>(box));
 
+    constexpr bool initial_data_in_box =
+        db::tag_is_retrievable_v<evolution::initial_data::Tags::InitialData,
+                                 db::DataBox<DbTagsList>>;
+    constexpr bool analytic_soln_or_data_in_box =
+        db::tag_is_retrievable_v<::Tags::AnalyticSolutionOrData,
+                                 db::DataBox<DbTagsList>>;
+
+    static_assert(initial_data_in_box or analytic_soln_or_data_in_box,
+                  "Either ::Tags::AnalyticSolutionOrData or "
+                  "evolution::initial_data::Tags::InitialData must be in the"
+                  "DataBox.");
+
     // Set initial data from analytic solution
     GrVars gr_vars{num_grid_points};
-    gr_vars.assign_subset(evolution::Initialization::initial_data(
-        Parallel::get<::Tags::AnalyticSolutionOrData>(cache), inertial_coords,
-        initial_time, typename GrVars::tags_list{}));
+
+    if constexpr (initial_data_in_box) {
+      using derived_classes =
+          tmpl::at<typename Metavariables::factory_creation::factory_classes,
+                   evolution::initial_data::InitialData>;
+      call_with_dynamic_type<void, derived_classes>(
+          &db::get<evolution::initial_data::Tags::InitialData>(box),
+          [&gr_vars, &initial_time,
+           &inertial_coords](const auto* const data_or_solution) {
+            gr_vars.assign_subset(evolution::Initialization::initial_data(
+                *data_or_solution, inertial_coords, initial_time,
+                typename GrVars::tags_list{}));
+          });
+    } else if constexpr (analytic_soln_or_data_in_box) {
+      gr_vars.assign_subset(evolution::Initialization::initial_data(
+          db::get<::Tags::AnalyticSolutionOrData>(box), inertial_coords,
+          initial_time, typename GrVars::tags_list{}));
+    }
+
     Initialization::mutate_assign<simple_tags>(make_not_null(&box),
                                                std::move(gr_vars));
 


### PR DESCRIPTION
## Proposed changes

Enable evolution systems which uses runtime initial data (the `evolution::initial_data::InitialData` class) to properly initialize background GR variables in the initialization phase. Examples are GRMHD, CurvedScalarWave, ForceFree.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
