### PR TITLE
Write domain into H5 volume files

### DIFF
--- a/src/Executables/CombineH5/CombineH5.cpp
+++ b/src/Executables/CombineH5/CombineH5.cpp
@@ -91,6 +91,8 @@ void combine_h5(const std::string& file_prefix, const std::string& subfile_name,
     element_data.reserve(vector_dim);
 
     double obs_val = 0.0;
+    std::optional<std::vector<char>> serialized_domain{};
+    std::optional<std::vector<char>> serialized_functions_of_time{};
 
     // Loops over input files to append element data into a single vector to be
     // stored in a single H5
@@ -100,6 +102,9 @@ void combine_h5(const std::string& file_prefix, const std::string& subfile_name,
       const auto& original_volume_file =
           original_file.get<h5::VolumeData>("/" + subfile_name);
       obs_val = original_volume_file.get_observation_value(obs_id);
+      serialized_domain = original_volume_file.get_domain(obs_id);
+      serialized_functions_of_time =
+          original_volume_file.get_functions_of_time(obs_id);
 
       // Get vector of element data for this `obs_id` and `file_name`
       std::vector<ElementVolumeData> data_by_element =
@@ -118,7 +123,9 @@ void combine_h5(const std::string& file_prefix, const std::string& subfile_name,
 
     h5::H5File<h5::AccessType::ReadWrite> new_file(output + "0.h5", true);
     auto& new_volume_file = new_file.get<h5::VolumeData>("/" + subfile_name);
-    new_volume_file.write_volume_data(obs_id, obs_val, element_data);
+    new_volume_file.write_volume_data(obs_id, obs_val, element_data,
+                                      serialized_domain,
+                                      serialized_functions_of_time);
     new_file.close_current_object();
   }
 }

--- a/src/IO/H5/Python/VolumeData.cpp
+++ b/src/IO/H5/Python/VolumeData.cpp
@@ -19,7 +19,10 @@ void bind_h5vol(py::module& m) {  // NOLINT
       .def("get_header", &h5::VolumeData::get_header)
       .def("get_version", &h5::VolumeData::get_version)
       .def("get_dimension", &h5::VolumeData::get_dimension)
-      .def("write_volume_data", &h5::VolumeData::write_volume_data)
+      .def("write_volume_data", &h5::VolumeData::write_volume_data,
+           py::arg("observation_id"), py::arg("observation_value"),
+           py::arg("elements"), py::arg("serialized_domain") = std::nullopt,
+           py::arg("serialized_functions_of_time") = std::nullopt)
       .def("list_observation_ids", &h5::VolumeData::list_observation_ids)
       .def("get_observation_value", &h5::VolumeData::get_observation_value,
            py::arg("observation_id"))
@@ -34,6 +37,9 @@ void bind_h5vol(py::module& m) {  // NOLINT
       .def("get_quadratures", &h5::VolumeData::get_quadratures,
            py::arg("observation_id"))
       .def("get_bases", &h5::VolumeData::get_bases, py::arg("observation_id"))
+      .def("get_domain", &h5::VolumeData::get_domain, py::arg("observation_id"))
+      .def("get_functions_of_time", &h5::VolumeData::get_functions_of_time,
+           py::arg("observation_id"))
       .def("get_data_by_element", &h5::VolumeData::get_data_by_element,
            py::arg("start_observation_value"), py::arg("end_observation_value"),
            py::arg("components_to_retrieve") = std::nullopt);

--- a/src/ParallelAlgorithms/Interpolation/Callbacks/ObserveLineSegment.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Callbacks/ObserveLineSegment.hpp
@@ -11,7 +11,7 @@
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/TagName.hpp"
-#include "DataStructures/Tensor/TensorData.hpp"
+#include "IO/H5/TensorData.hpp"
 #include "IO/Observer/ObserverComponent.hpp"
 #include "IO/Observer/Tags.hpp"
 #include "IO/Observer/VolumeActions.hpp"
@@ -106,9 +106,9 @@ struct ObserveLineSegment
     Parallel::threaded_action<observers::ThreadedActions::WriteVolumeData>(
         proxy[0], Parallel::get<observers::Tags::ReductionFileName>(cache),
         subfile_path, observation_id,
-        std::vector<ElementVolumeData>{{extents_vector, tensor_components,
-                                        bases_vector, quadratures_vector,
-                                        name}});
+        std::vector<ElementVolumeData>{{name, std::move(tensor_components),
+                                        extents_vector, bases_vector,
+                                        quadratures_vector}});
   }
 };
 }  // namespace callbacks

--- a/tests/Unit/Helpers/IO/Observers/ObserverHelpers.hpp
+++ b/tests/Unit/Helpers/IO/Observers/ObserverHelpers.hpp
@@ -5,7 +5,10 @@
 
 #include <functional>
 
+#include "Domain/Domain.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
 #include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "IO/Observer/Helpers.hpp"
 #include "IO/Observer/Initialize.hpp"         // IWYU pragma: keep
@@ -51,6 +54,9 @@ struct element_component {
   using phase_dependent_action_list =
       tmpl::list<Parallel::PhaseActions<Parallel::Phase::Register,
                                         RegistrationActionsList>>;
+  using const_global_cache_tags =
+      tmpl::list<domain::Tags::Domain<3>,
+                 domain::Tags::FunctionsOfTimeInitialize>;
 };
 
 template <typename Metavariables>
@@ -115,6 +121,8 @@ using reduction_data_from_ds_and_vs = Parallel::ReductionData<
 
 template <typename RegistrationActionsList>
 struct Metavariables {
+  static constexpr size_t volume_dim = 3;
+
   using component_list =
       tmpl::list<element_component<Metavariables, RegistrationActionsList>,
                  observer_component<Metavariables>,

--- a/tests/Unit/Helpers/IO/VolumeData.cpp
+++ b/tests/Unit/Helpers/IO/VolumeData.cpp
@@ -89,12 +89,16 @@ void check_volume_data(
   CHECK(target_bases == read_bases);
   CHECK(target_quadratures == read_quadratures);
 
-  const auto read_components =
-      volume_file.list_tensor_components(observation_id);
-  CHECK(alg::all_of(read_components,
-                    [&expected_components](const std::string& id) {
-                      return alg::found(expected_components, id);
-                    }));
+  {
+    const auto read_components =
+        volume_file.list_tensor_components(observation_id);
+    CAPTURE(read_components);
+    CAPTURE(expected_components);
+    CHECK(alg::all_of(read_components,
+                      [&expected_components](const std::string& id) {
+                        return alg::found(expected_components, id);
+                      }));
+  }
   // Helper Function to get number of points on a particular grid
   const auto accumulate_extents = [](const std::vector<size_t>& grid_extents) {
     return alg::accumulate(grid_extents, 1, std::multiplies<>{});

--- a/tests/Unit/IO/H5/CMakeLists.txt
+++ b/tests/Unit/IO/H5/CMakeLists.txt
@@ -28,10 +28,13 @@ target_link_libraries(
   PRIVATE
   Boost::boost
   DataStructures
+  Domain
+  DomainCreators
   H5
   Informer
   IO
   IoTestHelpers
+  Parallel
   Spectral
   Utilities
   )


### PR DESCRIPTION
## Proposed changes

Reconstructing the domain from volume data files is needed for accurate interpolation onto another set of points (see #3937).

- [x] The first commit is #4376 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
