### PR TITLE
Parse ElementId from string representation

### DIFF
--- a/src/Domain/Python/ElementId.cpp
+++ b/src/Domain/Python/ElementId.cpp
@@ -25,6 +25,7 @@ void bind_element_id_impl(py::module& m) {  // NOLINT
       .def(py::init<size_t>(), py::arg("block_id"))
       .def(py::init<size_t, std::array<SegmentId, Dim>>(), py::arg("block_id"),
            py::arg("segment_ids"))
+      .def(py::init<const std::string&>(), py::arg("grid_name"))
       .def_property("block_id", &ElementId<Dim>::block_id, nullptr)
       .def_property("segment_ids", &ElementId<Dim>::segment_ids, nullptr)
       .def_static("external_boundary_id", &ElementId<Dim>::external_boundary_id)

--- a/src/Domain/Structure/ElementId.hpp
+++ b/src/Domain/Structure/ElementId.hpp
@@ -82,6 +82,9 @@ class ElementId {
   ElementId(size_t block_id, std::array<SegmentId, VolumeDim> segment_ids,
             size_t grid_index = 0);
 
+  /// Create an ElementId from its string representation (see `operator<<`).
+  ElementId(const std::string& grid_name);
+
   ElementId<VolumeDim> id_of_child(size_t dim, Side side) const;
 
   ElementId<VolumeDim> id_of_parent(size_t dim) const;

--- a/tests/Unit/Domain/Python/Test_ElementId.py
+++ b/tests/Unit/Domain/Python/Test_ElementId.py
@@ -13,6 +13,11 @@ class TestElementId(unittest.TestCase):
         element_id = ElementId1D(block_id=1, segment_ids=[SegmentId(1, 0)])
         self.assertEqual(element_id.block_id, 1)
         self.assertEqual(element_id.segment_ids, [SegmentId(1, 0)])
+        self.assertEqual(
+            ElementId2D("[B2,(L0I0,L2I3)]"),
+            ElementId2D(block_id=2,
+                        segment_ids=[SegmentId(0, 0),
+                                     SegmentId(2, 3)]))
 
     def test_repr(self):
         self.assertEqual(repr(ElementId1D(0)), "[B0,(L0I0)]")


### PR DESCRIPTION
## Proposed changes

Create ElementIds from the human-readable grid names that we store in H5 files.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
