### PR TITLE
Move functions into anonymous namespaces and similar

### DIFF
--- a/cmake/EnableWarnings.cmake
+++ b/cmake/EnableWarnings.cmake
@@ -20,6 +20,7 @@ if(${ENABLE_WARNINGS})
 -Wformat-y2k;\
 -Wformat=2;\
 -Winvalid-pch;\
+-Wmissing-declarations;\
 -Wmissing-field-initializers;\
 -Wmissing-format-attribute;\
 -Wmissing-include-dirs;\

--- a/cmake/FindCharm.cmake
+++ b/cmake/FindCharm.cmake
@@ -363,8 +363,9 @@ configure_file(
   ${CMAKE_BINARY_DIR}
   )
 add_library(CharmModuleInit OBJECT ${CMAKE_BINARY_DIR}/CharmModuleInit.C)
+# -w -- suppress all warnings because this is charm-generated source
 set_property(TARGET CharmModuleInit
-  APPEND PROPERTY COMPILE_OPTIONS $<$<COMPILE_LANGUAGE:CXX>:-fPIC>)
+  APPEND PROPERTY COMPILE_OPTIONS $<$<COMPILE_LANGUAGE:CXX>:-fPIC -w>)
 
 # Use the charm building blocks to construct imported targets
 # - Imported target with all Charm libs

--- a/cmake/SpectreSetupPythonPackage.cmake
+++ b/cmake/SpectreSetupPythonPackage.cmake
@@ -366,6 +366,18 @@ function(SPECTRE_PYTHON_ADD_MODULE MODULE_NAME)
   endwhile(NOT ${CURRENT_MODULE} STREQUAL ${SPECTRE_PYTHON_PREFIX})
 endfunction()
 
+# Add headers if Python bindings are being built
+function (spectre_python_headers LIBRARY_NAME)
+  if(NOT BUILD_PYTHON_BINDINGS)
+    return()
+  endif()
+spectre_target_headers(
+    ${LIBRARY_NAME}
+    # Forward all remaining arguments
+    ${ARGN}
+    )
+endfunction()
+
 # Link with the LIBRARIES if Python bindings are being built
 function (spectre_python_link_libraries LIBRARY_NAME)
   if(NOT BUILD_PYTHON_BINDINGS)

--- a/src/ControlSystem/ControlErrors/Size/RegisterDerivedWithCharm.cpp
+++ b/src/ControlSystem/ControlErrors/Size/RegisterDerivedWithCharm.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "ControlSystem/ControlErrors/Size/RegisterDerivedWithCharm.hpp"
+
 #include <memory>
 #include <pup.h>
 

--- a/src/DataStructures/Python/Bindings.cpp
+++ b/src/DataStructures/Python/Bindings.cpp
@@ -3,12 +3,8 @@
 
 #include <pybind11/pybind11.h>
 
-namespace py = pybind11;
-
-namespace py_bindings {
-void bind_datavector(py::module& m);  // NOLINT
-void bind_matrix(py::module& m);      // NOLINT
-}  // namespace py_bindings
+#include "DataStructures/Python/DataVector.hpp"
+#include "DataStructures/Python/Matrix.hpp"
 
 PYBIND11_MODULE(_PyDataStructures, m) {  // NOLINT
   py_bindings::bind_datavector(m);

--- a/src/DataStructures/Python/CMakeLists.txt
+++ b/src/DataStructures/Python/CMakeLists.txt
@@ -12,6 +12,14 @@ spectre_python_add_module(
   Matrix.cpp
   )
 
+spectre_python_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  DataVector.hpp
+  Matrix.hpp
+  )
+
 spectre_python_link_libraries(
   ${LIBRARY}
   PRIVATE

--- a/src/DataStructures/Python/DataVector.cpp
+++ b/src/DataStructures/Python/DataVector.cpp
@@ -29,7 +29,7 @@ void bind_datavector(py::module& m) {
              return result;
            }),
            py::arg("values"))
-      .def(py::init([](py::buffer buffer, const bool copy) {
+      .def(py::init([](const py::buffer& buffer, const bool copy) {
              py::buffer_info info = buffer.request();
              // Sanity-check the buffer
              if (info.format != py::format_descriptor<double>::format()) {

--- a/src/DataStructures/Python/DataVector.cpp
+++ b/src/DataStructures/Python/DataVector.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "DataStructures/Python/DataVector.hpp"
+
 #include <memory>
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
@@ -16,7 +18,7 @@
 namespace py = pybind11;
 
 namespace py_bindings {
-void bind_datavector(py::module& m) {  // NOLINT
+void bind_datavector(py::module& m) {
   // Wrapper for basic DataVector operations
   py::class_<DataVector>(m, "DataVector", py::buffer_protocol())
       .def(py::init<size_t>(), py::arg("size"))

--- a/src/DataStructures/Python/DataVector.hpp
+++ b/src/DataStructures/Python/DataVector.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_datavector(pybind11::module& m);
+}  // namespace py_bindings

--- a/src/DataStructures/Python/Matrix.cpp
+++ b/src/DataStructures/Python/Matrix.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "DataStructures/Python/Matrix.hpp"
+
 #include <array>
 #include <cstddef>
 #include <pybind11/pybind11.h>
@@ -18,7 +20,7 @@ namespace py = pybind11;
 
 namespace py_bindings {
 
-void bind_matrix(py::module& m) {  // NOLINT
+void bind_matrix(py::module& m) {
   // Wrapper for basic Matrix operations
   py::class_<Matrix>(m, "Matrix", py::buffer_protocol())
       .def(py::init<size_t, size_t>(), py::arg("rows"), py::arg("columns"))

--- a/src/DataStructures/Python/Matrix.cpp
+++ b/src/DataStructures/Python/Matrix.cpp
@@ -24,7 +24,7 @@ void bind_matrix(py::module& m) {
   // Wrapper for basic Matrix operations
   py::class_<Matrix>(m, "Matrix", py::buffer_protocol())
       .def(py::init<size_t, size_t>(), py::arg("rows"), py::arg("columns"))
-      .def(py::init([](py::buffer buffer) {
+      .def(py::init([](const py::buffer& buffer) {
              py::buffer_info info = buffer.request();
              // Sanity-check the buffer
              if (info.format != py::format_descriptor<double>::format()) {

--- a/src/DataStructures/Python/Matrix.hpp
+++ b/src/DataStructures/Python/Matrix.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_matrix(pybind11::module& m);
+}  // namespace py_bindings

--- a/src/Domain/Creators/Python/Bindings.cpp
+++ b/src/Domain/Creators/Python/Bindings.cpp
@@ -11,8 +11,7 @@
 #include "Domain/Creators/Python/Shell.hpp"
 #include "Domain/Creators/Python/Sphere.hpp"
 
-namespace domain {
-namespace creators {
+namespace domain::creators {
 
 PYBIND11_MODULE(_PyDomainCreators, m) {  // NOLINT
   // Order is important: The base class `DomainCreator` needs to have its
@@ -26,5 +25,4 @@ PYBIND11_MODULE(_PyDomainCreators, m) {  // NOLINT
   py_bindings::bind_sphere(m);
 }
 
-}  // namespace creators
-}  // namespace domain
+}  // namespace domain::creators

--- a/src/Domain/Creators/Python/Bindings.cpp
+++ b/src/Domain/Creators/Python/Bindings.cpp
@@ -3,20 +3,16 @@
 
 #include <pybind11/pybind11.h>
 
-namespace py = pybind11;
+#include "Domain/Creators/Python/Brick.hpp"
+#include "Domain/Creators/Python/Cylinder.hpp"
+#include "Domain/Creators/Python/DomainCreator.hpp"
+#include "Domain/Creators/Python/Interval.hpp"
+#include "Domain/Creators/Python/Rectangle.hpp"
+#include "Domain/Creators/Python/Shell.hpp"
+#include "Domain/Creators/Python/Sphere.hpp"
 
 namespace domain {
 namespace creators {
-
-namespace py_bindings {
-void bind_brick(py::module& m);           // NOLINT
-void bind_cylinder(py::module& m);        // NOLINT
-void bind_domain_creator(py::module& m);  // NOLINT
-void bind_interval(py::module& m);        // NOLINT
-void bind_rectangle(py::module& m);       // NOLINT
-void bind_shell(py::module& m);           // NOLINT
-void bind_sphere(py::module& m);          // NOLINT
-}  // namespace py_bindings
 
 PYBIND11_MODULE(_PyDomainCreators, m) {  // NOLINT
   // Order is important: The base class `DomainCreator` needs to have its

--- a/src/Domain/Creators/Python/Brick.cpp
+++ b/src/Domain/Creators/Python/Brick.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "Domain/Creators/Python/Brick.hpp"
+
 #include <array>
 #include <cstddef>
 #include <pybind11/pybind11.h>
@@ -13,7 +15,7 @@
 namespace py = pybind11;
 
 namespace domain::creators::py_bindings {
-void bind_brick(py::module& m) {  // NOLINT
+void bind_brick(py::module& m) {
   py::class_<Brick, DomainCreator<3>>(m, "Brick")
       .def(py::init<std::array<double, 3>, std::array<double, 3>,
                     std::array<size_t, 3>, std::array<size_t, 3>,

--- a/src/Domain/Creators/Python/Brick.hpp
+++ b/src/Domain/Creators/Python/Brick.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace domain::creators::py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_brick(pybind11::module& m);
+}  // namespace domain::creators::py_bindings

--- a/src/Domain/Creators/Python/CMakeLists.txt
+++ b/src/Domain/Creators/Python/CMakeLists.txt
@@ -18,6 +18,19 @@ spectre_python_add_module(
   Sphere.cpp
   )
 
+spectre_python_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Brick.hpp
+  Cylinder.hpp
+  DomainCreator.hpp
+  Interval.hpp
+  Rectangle.hpp
+  Shell.hpp
+  Sphere.hpp
+  )
+
 spectre_python_link_libraries(
   ${LIBRARY}
   PRIVATE

--- a/src/Domain/Creators/Python/Cylinder.cpp
+++ b/src/Domain/Creators/Python/Cylinder.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "Domain/Creators/Python/Cylinder.hpp"
+
 #include <array>
 #include <cstddef>
 #include <pybind11/pybind11.h>
@@ -15,7 +17,7 @@ namespace py = pybind11;
 namespace domain {
 namespace creators {
 namespace py_bindings {
-void bind_cylinder(py::module& m) {  // NOLINT
+void bind_cylinder(py::module& m) {
   py::class_<Cylinder, DomainCreator<3>>(m, "Cylinder")
       .def(py::init<double, double, double, double, bool, size_t,
                     std::array<size_t, 3>, bool>(),

--- a/src/Domain/Creators/Python/Cylinder.cpp
+++ b/src/Domain/Creators/Python/Cylinder.cpp
@@ -14,9 +14,7 @@
 
 namespace py = pybind11;
 
-namespace domain {
-namespace creators {
-namespace py_bindings {
+namespace domain::creators::py_bindings {
 void bind_cylinder(py::module& m) {
   py::class_<Cylinder, DomainCreator<3>>(m, "Cylinder")
       .def(py::init<double, double, double, double, bool, size_t,
@@ -27,6 +25,4 @@ void bind_cylinder(py::module& m) {
            py::arg("initial_number_of_grid_points"),
            py::arg("use_equiangular_map"));
 }
-}  // namespace py_bindings
-}  // namespace creators
-}  // namespace domain
+}  // namespace domain::creators::py_bindings

--- a/src/Domain/Creators/Python/Cylinder.hpp
+++ b/src/Domain/Creators/Python/Cylinder.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace domain::creators::py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_cylinder(pybind11::module& m);
+}  // namespace domain::creators::py_bindings

--- a/src/Domain/Creators/Python/DomainCreator.cpp
+++ b/src/Domain/Creators/Python/DomainCreator.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "Domain/Creators/Python/DomainCreator.hpp"
+
 #include <pybind11/pybind11.h>
 #include <string>
 
@@ -11,7 +13,7 @@ namespace py = pybind11;
 namespace domain {
 namespace creators {
 namespace py_bindings {
-void bind_domain_creator(py::module& m) {  // NOLINT
+void bind_domain_creator(py::module& m) {
   py::class_<DomainCreator<1>>(m, "DomainCreator1D");  // NOLINT
   py::class_<DomainCreator<2>>(m, "DomainCreator2D");  // NOLINT
   py::class_<DomainCreator<3>>(m, "DomainCreator3D");  // NOLINT

--- a/src/Domain/Creators/Python/DomainCreator.cpp
+++ b/src/Domain/Creators/Python/DomainCreator.cpp
@@ -10,14 +10,10 @@
 
 namespace py = pybind11;
 
-namespace domain {
-namespace creators {
-namespace py_bindings {
+namespace domain::creators::py_bindings {
 void bind_domain_creator(py::module& m) {
   py::class_<DomainCreator<1>>(m, "DomainCreator1D");  // NOLINT
   py::class_<DomainCreator<2>>(m, "DomainCreator2D");  // NOLINT
   py::class_<DomainCreator<3>>(m, "DomainCreator3D");  // NOLINT
 }
-}  // namespace py_bindings
-}  // namespace creators
-}  // namespace domain
+}  // namespace domain::creators::py_bindings

--- a/src/Domain/Creators/Python/DomainCreator.hpp
+++ b/src/Domain/Creators/Python/DomainCreator.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace domain::creators::py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_domain_creator(pybind11::module& m);
+}  // namespace domain::creators::py_bindings

--- a/src/Domain/Creators/Python/Interval.cpp
+++ b/src/Domain/Creators/Python/Interval.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "Domain/Creators/Python/Interval.hpp"
+
 #include <array>
 #include <cstddef>
 #include <pybind11/pybind11.h>
@@ -13,7 +15,7 @@
 namespace py = pybind11;
 
 namespace domain::creators::py_bindings {
-void bind_interval(py::module& m) {  // NOLINT
+void bind_interval(py::module& m) {
   py::class_<Interval, DomainCreator<1>>(m, "Interval")
       .def(
           py::init(

--- a/src/Domain/Creators/Python/Interval.hpp
+++ b/src/Domain/Creators/Python/Interval.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace domain::creators::py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_interval(pybind11::module& m);
+}  // namespace domain::creators::py_bindings

--- a/src/Domain/Creators/Python/Rectangle.cpp
+++ b/src/Domain/Creators/Python/Rectangle.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "Domain/Creators/Python/Rectangle.hpp"
+
 #include <array>
 #include <cstddef>
 #include <pybind11/pybind11.h>
@@ -13,7 +15,7 @@
 namespace py = pybind11;
 
 namespace domain::creators::py_bindings {
-void bind_rectangle(py::module& m) {  // NOLINT
+void bind_rectangle(py::module& m) {
   py::class_<Rectangle, DomainCreator<2>>(m, "Rectangle")
       .def(py::init<std::array<double, 2>, std::array<double, 2>,
                     std::array<size_t, 2>, std::array<size_t, 2>,

--- a/src/Domain/Creators/Python/Rectangle.hpp
+++ b/src/Domain/Creators/Python/Rectangle.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace domain::creators::py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_rectangle(pybind11::module& m);
+}  // namespace domain::creators::py_bindings

--- a/src/Domain/Creators/Python/Shell.cpp
+++ b/src/Domain/Creators/Python/Shell.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "Domain/Creators/Python/Shell.hpp"
+
 #include <array>
 #include <cstddef>
 #include <pybind11/pybind11.h>
@@ -14,7 +16,7 @@ namespace py = pybind11;
 
 namespace domain::creators::py_bindings {
 
-void bind_shell(py::module& m) {  // NOLINT
+void bind_shell(py::module& m) {
   py::class_<Shell, DomainCreator<3>>(m, "Shell")
       .def(
           py::init([](const double inner_radius, const double outer_radius,

--- a/src/Domain/Creators/Python/Shell.hpp
+++ b/src/Domain/Creators/Python/Shell.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace domain::creators::py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_shell(pybind11::module& m);
+}  // namespace domain::creators::py_bindings

--- a/src/Domain/Creators/Python/Sphere.cpp
+++ b/src/Domain/Creators/Python/Sphere.cpp
@@ -14,9 +14,7 @@
 
 namespace py = pybind11;
 
-namespace domain {
-namespace creators {
-namespace py_bindings {
+namespace domain::creators::py_bindings {
 void bind_sphere(py::module& m) {
   py::class_<Sphere, DomainCreator<3>>(m, "Sphere")
       .def(py::init<double, double, size_t, std::array<size_t, 2>, bool>(),
@@ -25,6 +23,4 @@ void bind_sphere(py::module& m) {
            py::arg("initial_number_of_grid_points"),
            py::arg("use_equiangular_map"));
 }
-}  // namespace py_bindings
-}  // namespace creators
-}  // namespace domain
+}  // namespace domain::creators::py_bindings

--- a/src/Domain/Creators/Python/Sphere.cpp
+++ b/src/Domain/Creators/Python/Sphere.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "Domain/Creators/Python/Sphere.hpp"
+
 #include <array>
 #include <cstddef>
 #include <pybind11/pybind11.h>
@@ -15,7 +17,7 @@ namespace py = pybind11;
 namespace domain {
 namespace creators {
 namespace py_bindings {
-void bind_sphere(py::module& m) {  // NOLINT
+void bind_sphere(py::module& m) {
   py::class_<Sphere, DomainCreator<3>>(m, "Sphere")
       .def(py::init<double, double, size_t, std::array<size_t, 2>, bool>(),
            py::arg("inner_radius"), py::arg("outer_radius"),

--- a/src/Domain/Creators/Python/Sphere.hpp
+++ b/src/Domain/Creators/Python/Sphere.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace domain::creators::py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_sphere(pybind11::module& m);
+}  // namespace domain::creators::py_bindings

--- a/src/Domain/Creators/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/Creators/RegisterDerivedWithCharm.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+
 #include <cstddef>
 
 #include "DataStructures/Tensor/Tensor.hpp"

--- a/src/Domain/Creators/TimeDependence/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/Creators/TimeDependence/RegisterDerivedWithCharm.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
+
 #include <cstddef>
 #include <memory>
 #include <pup.h>

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -550,6 +550,7 @@ void set_identified_boundaries(
   }
 }
 
+namespace {
 // A Block or Blocks can be wrapped in an outer layer of Blocks surrounding
 // the original Block(s). In the BBH Domain, this occurs several times, using
 // both Wedges and Frustums. The simplest example in which wrapping is used is
@@ -581,7 +582,6 @@ std::array<OrientationMap<3>, 6> orientations_for_wrappings() {
   }};
 }
 
-namespace {
 size_t which_wedge_index(const ShellWedges& which_wedges) {
   switch (which_wedges) {
     case ShellWedges::All:

--- a/src/Domain/FunctionsOfTime/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/FunctionsOfTime/RegisterDerivedWithCharm.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+
 #include <cstddef>
 #include <memory>
 #include <pup.h>

--- a/src/Domain/Python/Bindings.cpp
+++ b/src/Domain/Python/Bindings.cpp
@@ -3,14 +3,10 @@
 
 #include <pybind11/pybind11.h>
 
-namespace py = pybind11;
+#include "Domain/Python/ElementId.hpp"
+#include "Domain/Python/SegmentId.hpp"
 
 namespace domain {
-
-namespace py_bindings {
-void bind_segment_id(py::module& m);  // NOLINT
-void bind_element_id(py::module& m);  // NOLINT
-}  // namespace py_bindings
 
 PYBIND11_MODULE(_PyDomain, m) {  // NOLINT
   py_bindings::bind_segment_id(m);

--- a/src/Domain/Python/CMakeLists.txt
+++ b/src/Domain/Python/CMakeLists.txt
@@ -12,6 +12,14 @@ spectre_python_add_module(
   SegmentId.cpp
   )
 
+spectre_python_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  ElementId.hpp
+  SegmentId.hpp
+  )
+
 spectre_python_link_libraries(
   ${LIBRARY}
   PRIVATE

--- a/src/Domain/Python/ElementId.cpp
+++ b/src/Domain/Python/ElementId.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "Domain/Python/ElementId.hpp"
+
 #include <array>
 #include <cstddef>
 #include <pybind11/operators.h>
@@ -16,7 +18,7 @@ namespace py = pybind11;
 
 namespace domain::py_bindings {
 
-namespace detail {
+namespace {
 template <size_t Dim>
 void bind_element_id_impl(py::module& m) {  // NOLINT
   // These bindings don't cover the full public interface yet. More bindings
@@ -37,12 +39,12 @@ void bind_element_id_impl(py::module& m) {  // NOLINT
       // NOLINTNEXTLINE(misc-redundant-expression)
       .def(py::self != py::self);
 }
-}  // namespace detail
+}  // namespace
 
-void bind_element_id(py::module& m) {  // NOLINT
-  detail::bind_element_id_impl<1>(m);
-  detail::bind_element_id_impl<2>(m);
-  detail::bind_element_id_impl<3>(m);
+void bind_element_id(py::module& m) {
+  bind_element_id_impl<1>(m);
+  bind_element_id_impl<2>(m);
+  bind_element_id_impl<3>(m);
 }
 
 }  // namespace domain::py_bindings

--- a/src/Domain/Python/ElementId.hpp
+++ b/src/Domain/Python/ElementId.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace domain::py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_element_id(pybind11::module& m);
+}  // namespace domain::py_bindings

--- a/src/Domain/Python/SegmentId.cpp
+++ b/src/Domain/Python/SegmentId.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "Domain/Python/SegmentId.hpp"
+
 #include <array>
 #include <cstddef>
 #include <pybind11/operators.h>
@@ -15,7 +17,7 @@ namespace py = pybind11;
 
 namespace domain::py_bindings {
 
-void bind_segment_id(py::module& m) {  // NOLINT
+void bind_segment_id(py::module& m) {
   // These bindings don't cover the full public interface yet. More bindings
   // can be added as needed.
   py::class_<SegmentId>(m, "SegmentId")

--- a/src/Domain/Python/SegmentId.hpp
+++ b/src/Domain/Python/SegmentId.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace domain::py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_segment_id(pybind11::module& m);
+}  // namespace domain::py_bindings

--- a/src/Domain/Structure/OrientationMapHelpers.cpp
+++ b/src/Domain/Structure/OrientationMapHelpers.cpp
@@ -200,9 +200,6 @@ std::vector<size_t> compute_offset_permutation(
   return oriented_offsets;
 }
 
-}  // namespace
-
-namespace OrientationMapHelpers_detail {
 std::vector<size_t> oriented_offset(
     const Index<1>& extents, const OrientationMap<1>& orientation_of_neighbor) {
   const Direction<1> neighbor_axis =
@@ -316,16 +313,7 @@ void orient_each_component(
     }
   }
 }
-
-template void orient_each_component(
-    const gsl::not_null<gsl::span<double>*> oriented_variables,
-    const gsl::span<const double>& variables, const size_t num_pts,
-    const std::vector<size_t>& oriented_offset);
-template void orient_each_component(
-    const gsl::not_null<gsl::span<std::complex<double>>*> oriented_variables,
-    const gsl::span<const std::complex<double>>& variables,
-    const size_t num_pts, const std::vector<size_t>& oriented_offset);
-}  // namespace OrientationMapHelpers_detail
+}  // namespace
 
 template <size_t VolumeDim>
 void orient_variables(
@@ -346,13 +334,12 @@ void orient_variables(
     return;
   }
 
-  const auto oriented_offset = OrientationMapHelpers_detail::oriented_offset(
-      extents, orientation_of_neighbor);
+  const auto oriented_extents =
+      oriented_offset(extents, orientation_of_neighbor);
   auto oriented_vars_view = gsl::make_span(result->data(), result->size());
-  OrientationMapHelpers_detail::orient_each_component(
-      make_not_null(&oriented_vars_view),
-      gsl::make_span(variables.data(), variables.size()), number_of_grid_points,
-      oriented_offset);
+  orient_each_component(make_not_null(&oriented_vars_view),
+                        gsl::make_span(variables.data(), variables.size()),
+                        number_of_grid_points, oriented_extents);
 }
 
 template <size_t VolumeDim>
@@ -376,12 +363,11 @@ void orient_variables_on_slice(
     return;
   }
 
-  const auto oriented_offset =
-      OrientationMapHelpers_detail::oriented_offset_on_slice(
-          slice_extents, sliced_dim, orientation_of_neighbor);
+  const auto oriented_offset = oriented_offset_on_slice(
+      slice_extents, sliced_dim, orientation_of_neighbor);
 
   auto oriented_vars_view = gsl::make_span(result->data(), result->size());
-  OrientationMapHelpers_detail::orient_each_component(
+  orient_each_component(
       make_not_null(&oriented_vars_view),
       gsl::make_span(variables_on_slice.data(), variables_on_slice.size()),
       number_of_grid_points, oriented_offset);

--- a/src/Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.cpp
+++ b/src/Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.cpp
@@ -45,6 +45,7 @@ ApparentHorizon<ConformalGeometry>::ApparentHorizon(
           // NOLINTNEXTLINE(performance-move-const-arg)
           std::move(solution_for_negative_expansion)) {}
 
+namespace {
 // This sets the output buffer to: \bar{m}^{ij} \bar{\nabla}_i n_j
 void normal_gradient_term_flat_cartesian(
     const gsl::not_null<Scalar<DataVector>*> n_dot_conformal_factor_gradient,
@@ -487,6 +488,7 @@ void linearized_apparent_horizon_impl(
     get(*n_dot_lapse_times_conformal_factor_gradient_correction) = 0.;
   }
 }
+}  // namespace
 
 template <Xcts::Geometry ConformalGeometry>
 void ApparentHorizon<ConformalGeometry>::apply(

--- a/src/Evolution/DiscontinuousGalerkin/LiftFromBoundary.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/LiftFromBoundary.cpp
@@ -15,6 +15,7 @@
 #include "Utilities/Gsl.hpp"
 
 namespace evolution::dg::detail {
+namespace {
 // We use a separate function in the  xi direction to avoid the expensive
 // SliceIterator
 void lift_boundary_terms_gauss_points_impl_xi_dir(
@@ -102,6 +103,7 @@ void lift_boundary_terms_gauss_points_impl_xi_dir(
     }
   }
 }
+}  // namespace
 
 template <size_t Dim>
 void lift_boundary_terms_gauss_points_impl(

--- a/src/Evolution/Systems/Burgers/BoundaryCorrections/RegisterDerived.cpp
+++ b/src/Evolution/Systems/Burgers/BoundaryCorrections/RegisterDerived.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "Evolution/Systems/Burgers/BoundaryCorrections/RegisterDerived.hpp"
+
 #include "Evolution/Systems/Burgers/BoundaryCorrections/Factory.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachs.cpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachs.cpp
@@ -111,6 +111,7 @@ LinearizedBondiSachs::get_clone() const {
 PUP::able::PUP_ID LinearizedBondiSachs::my_PUP_ID = 0;
 }  // namespace InitializeJ
 
+namespace {
 const size_t z_harmonics_maximum_l_max = 64_st;
 const ComplexDataVector& cached_z_harmonics(const size_t l_max, const size_t l,
                                             const int spin) {
@@ -141,6 +142,7 @@ const ComplexDataVector& cached_z_harmonics(const size_t l_max, const size_t l,
           });
   return lazy_z_harmonics_cache(l_max, l, spin);
 }
+}  // namespace
 
 template <int Spin, typename FactorType>
 void assign_components_from_l_factors(

--- a/src/Evolution/Systems/Cce/Initialize/ConformalFactor.cpp
+++ b/src/Evolution/Systems/Cce/Initialize/ConformalFactor.cpp
@@ -32,7 +32,7 @@
 #include "Utilities/TMPL.hpp"
 
 namespace Cce::InitializeJ {
-namespace detail {
+namespace {
 void read_modes_from_input_file(
     const gsl::not_null<ComplexModalVector*> input_modes,
     const std::string& input_filename) {
@@ -94,7 +94,7 @@ void only_vary_gauge_d_heuristic(
                          gauge_d.data();
   gauge_c_step->data() = 0;
 }
-}  // namespace detail
+}  // namespace
 
 ConformalFactor::ConformalFactor(CkMigrateMessage* msg)
     : InitializeJ<false>(msg) {}
@@ -196,9 +196,8 @@ void ConformalFactor::operator()(
   if (use_input_modes_) {
     if (input_mode_filename_.has_value()) {
       hdf5_lock->lock();
-      detail::read_modes_from_input_file(
-          make_not_null(&(goldberg_modes.data())),
-          input_mode_filename_.value());
+      read_modes_from_input_file(make_not_null(&(goldberg_modes.data())),
+                                 input_mode_filename_.value());
       hdf5_lock->unlock();
     } else {
       ASSERT(input_modes_.size() <= goldberg_modes.size(),
@@ -275,12 +274,11 @@ void ConformalFactor::operator()(
   if (iteration_heuristic_ ==
       ::Cce::InitializeJ::ConformalFactorIterationHeuristic::
           SpinWeight1CoordPerturbation) {
-    iteration_heuristic_function =
-        &detail::spin_weight_1_coord_perturbation_heuristic;
+    iteration_heuristic_function = &spin_weight_1_coord_perturbation_heuristic;
   } else if (iteration_heuristic_ ==
              ::Cce::InitializeJ::ConformalFactorIterationHeuristic::
                  OnlyVaryGaugeD) {
-    iteration_heuristic_function = &detail::only_vary_gauge_d_heuristic;
+    iteration_heuristic_function = &only_vary_gauge_d_heuristic;
   } else {  // LCOV_EXCL_LINE
     // LCOV_EXCL_START
     ERROR("Unknown ConformalFactorIterationHeuristic");

--- a/src/Evolution/Systems/Cce/Initialize/NoIncomingRadiation.cpp
+++ b/src/Evolution/Systems/Cce/Initialize/NoIncomingRadiation.cpp
@@ -19,7 +19,7 @@
 #include "Utilities/TMPL.hpp"
 
 namespace Cce::InitializeJ {
-namespace detail {
+namespace {
 
 void radial_evolve_psi0_condition(
     const gsl::not_null<SpinWeighted<ComplexDataVector, 2>*> volume_j_id,
@@ -94,7 +94,7 @@ void radial_evolve_psi0_condition(
     angular_view = state_buffer[0];
   }
 }
-}  // namespace detail
+}  // namespace
 
 NoIncomingRadiation::NoIncomingRadiation(
     const double angular_coordinate_tolerance, const size_t max_iterations,
@@ -121,9 +121,9 @@ void NoIncomingRadiation::operator()(
     const gsl::not_null<Parallel::NodeLock*> /*hdf5_lock*/) const {
   const size_t number_of_angular_points =
       Spectral::Swsh::number_of_swsh_collocation_points(l_max);
-  detail::radial_evolve_psi0_condition(make_not_null(&get(*j)), get(boundary_j),
-                                       get(boundary_dr_j), get(r), l_max,
-                                       number_of_radial_points);
+  radial_evolve_psi0_condition(make_not_null(&get(*j)), get(boundary_j),
+                               get(boundary_dr_j), get(r), l_max,
+                               number_of_radial_points);
   const SpinWeighted<ComplexDataVector, 2> j_at_scri_view;
   make_const_view(make_not_null(&j_at_scri_view), get(*j),
                   (number_of_radial_points - 1) * number_of_angular_points,

--- a/src/Evolution/Systems/Cce/NewmanPenrose.cpp
+++ b/src/Evolution/Systems/Cce/NewmanPenrose.cpp
@@ -11,7 +11,7 @@
 #include "Utilities/TMPL.hpp"
 
 namespace Cce {
-
+namespace {
 void weyl_psi0_impl(
     const gsl::not_null<SpinWeighted<ComplexDataVector, 2>*> psi_0,
     const SpinWeighted<ComplexDataVector, 2>& bondi_j,
@@ -35,6 +35,7 @@ void weyl_psi0_impl(
              0.5 * bondi_j * (1.0 + square(bondi_k)) * dy_j * conj(dy_j)) /
                 square(bondi_k));
 }
+}  // namespace
 
 void VolumeWeyl<Tags::Psi0>::apply(
     const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*> psi_0,

--- a/src/Evolution/Systems/Cce/SpecBoundaryData.cpp
+++ b/src/Evolution/Systems/Cce/SpecBoundaryData.cpp
@@ -1,7 +1,7 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-#include "Evolution/Systems/Cce/BoundaryData.hpp"
+#include "Evolution/Systems/Cce/SpecBoundaryData.hpp"
 
 #include <cstddef>
 

--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryCorrections/RegisterDerived.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryCorrections/RegisterDerived.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "Evolution/Systems/CurvedScalarWave/BoundaryCorrections/RegisterDerived.hpp"
+
 #include "Evolution/Systems/CurvedScalarWave/BoundaryCorrections/Factory.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.cpp
@@ -28,7 +28,7 @@
 #include "Utilities/Gsl.hpp"
 
 namespace GeneralizedHarmonic::BoundaryConditions {
-namespace helpers {
+namespace {
 double min_characteristic_speed(const std::array<DataVector, 4>& char_speeds) {
   std::array<double, 4> min_speeds{{min(char_speeds[0]), min(char_speeds[1]),
                                     min(char_speeds[2]), min(char_speeds[3])}};
@@ -45,7 +45,7 @@ void set_bc_corr_zero_when_char_speed_is_positive(
     }
   }
 }
-}  // namespace helpers
+}  // namespace
 
 namespace detail {
 ConstraintPreservingBjorhusType
@@ -290,7 +290,7 @@ std::optional<std::string> ConstraintPreservingBjorhus<Dim>::dg_time_derivative(
   }
 
   // If no point on the boundary has any incoming characteristic, return here
-  if (helpers::min_characteristic_speed(char_speeds) >= 0.) {
+  if (min_characteristic_speed(char_speeds) >= 0.) {
     std::fill(dt_spacetime_metric_correction->begin(),
               dt_spacetime_metric_correction->end(), 0.);
     std::fill(dt_pi_correction->begin(), dt_pi_correction->end(), 0.);
@@ -341,14 +341,14 @@ std::optional<std::string> ConstraintPreservingBjorhus<Dim>::dg_time_derivative(
   }
 
   // Only add corrections at grid points where the char speeds are negative
-  helpers::set_bc_corr_zero_when_char_speed_is_positive(
-      make_not_null(&bc_dt_v_psi), char_speeds[0]);
-  helpers::set_bc_corr_zero_when_char_speed_is_positive(
-      make_not_null(&bc_dt_v_zero), char_speeds[1]);
-  helpers::set_bc_corr_zero_when_char_speed_is_positive(
-      make_not_null(&bc_dt_v_plus), char_speeds[2]);
-  helpers::set_bc_corr_zero_when_char_speed_is_positive(
-      make_not_null(&bc_dt_v_minus), char_speeds[3]);
+  set_bc_corr_zero_when_char_speed_is_positive(make_not_null(&bc_dt_v_psi),
+                                               char_speeds[0]);
+  set_bc_corr_zero_when_char_speed_is_positive(make_not_null(&bc_dt_v_zero),
+                                               char_speeds[1]);
+  set_bc_corr_zero_when_char_speed_is_positive(make_not_null(&bc_dt_v_plus),
+                                               char_speeds[2]);
+  set_bc_corr_zero_when_char_speed_is_positive(make_not_null(&bc_dt_v_minus),
+                                               char_speeds[3]);
 
   // The boundary conditions here are imposed as corrections to the projections
   // of the right-hand-sides of the GH evolution equations (i.e. using Bjorhus'

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/RegisterDerived.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/RegisterDerived.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/RegisterDerived.hpp"
+
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/Factory.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/RegisterDerivedWithCharm.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/RegisterDerivedWithCharm.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/RegisterDerivedWithCharm.hpp"
+
 #include <cstddef>
 
 #include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/DampingFunction.hpp"

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TimeDependentTripleGaussian.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TimeDependentTripleGaussian.hpp
@@ -180,4 +180,7 @@ class TimeDependentTripleGaussian : public DampingFunction<3, Frame::Grid> {
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           functions_of_time) const;
 };
+
+bool operator!=(const TimeDependentTripleGaussian& lhs,
+                const TimeDependentTripleGaussian& rhs);
 }  // namespace GeneralizedHarmonic::ConstraintDamping

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
@@ -283,5 +283,13 @@ class DampedHarmonic final : public GaugeCondition {
                                  std::numeric_limits<int>::max(),
                                  std::numeric_limits<int>::max()}};
 };
+
+namespace DampedHarmonicGauge_detail {
+// Used in the test
+double roll_on_function(double time, double t_start, double sigma_t);
+
+double time_deriv_of_roll_on_function(double time, double t_start,
+                                      double sigma_t);
+}  // namespace DampedHarmonicGauge_detail
 }  // namespace gauges
 }  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/RegisterDerived.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/RegisterDerived.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/RegisterDerived.hpp"
+
 #include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Factory.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryCorrections/RegisterDerived.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryCorrections/RegisterDerived.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryCorrections/RegisterDerived.hpp"
+
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryCorrections/Factory.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/RegisterDerived.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/RegisterDerived.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/RegisterDerived.hpp"
+
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Factory.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp
@@ -29,6 +29,31 @@ class DataVector;
 
 namespace grmhd {
 namespace ValenciaDivClean {
+namespace detail {
+void fluxes_impl(
+    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_d_flux,
+    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_ye_flux,
+    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_tau_flux,
+    gsl::not_null<tnsr::Ij<DataVector, 3, Frame::Inertial>*> tilde_s_flux,
+    gsl::not_null<tnsr::IJ<DataVector, 3, Frame::Inertial>*> tilde_b_flux,
+    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_phi_flux,
+
+    // Temporaries
+    gsl::not_null<Scalar<DataVector>*> transport_velocity,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& lapse_b_over_w,
+    const Scalar<DataVector>& magnetic_field_dot_spatial_velocity,
+    const Scalar<DataVector>& pressure_star_lapse_sqrt_det_spatial_metric,
+
+    // Extra args
+    const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_ye,
+    const Scalar<DataVector>& tilde_tau,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
+    const Scalar<DataVector>& tilde_phi, const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
+    const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity);
+}  // namespace detail
 
 /*!
  * \brief The fluxes of the conservative variables

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Sources.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Sources.hpp
@@ -29,6 +29,44 @@ struct Source;
 
 namespace grmhd {
 namespace ValenciaDivClean {
+namespace detail {
+void sources_impl(
+    gsl::not_null<Scalar<DataVector>*> source_tilde_tau,
+    gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*> source_tilde_s,
+    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> source_tilde_b,
+    gsl::not_null<Scalar<DataVector>*> source_tilde_phi,
+
+    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_s_up,
+    gsl::not_null<tnsr::II<DataVector, 3, Frame::Inertial>*> densitized_stress,
+    gsl::not_null<Scalar<DataVector>*> h_rho_w_squared_plus_b_squared,
+
+    const Scalar<DataVector>& magnetic_field_dot_spatial_velocity,
+    const Scalar<DataVector>& magnetic_field_squared,
+    const Scalar<DataVector>& one_over_w_squared,
+    const Scalar<DataVector>& pressure_star,
+    const tnsr::I<DataVector, 3, Frame::Inertial>&
+        trace_spatial_christoffel_second,
+
+    const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_ye,
+    const Scalar<DataVector>& tilde_tau,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
+    const Scalar<DataVector>& tilde_phi, const Scalar<DataVector>& lapse,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& d_lapse,
+    const tnsr::iJ<DataVector, 3, Frame::Inertial>& d_shift,
+    const tnsr::ijj<DataVector, 3, Frame::Inertial>& d_spatial_metric,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,
+    const Scalar<DataVector>& lorentz_factor,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& magnetic_field,
+
+    const Scalar<DataVector>& rest_mass_density,
+    const Scalar<DataVector>& electron_fraction,
+    const Scalar<DataVector>& specific_enthalpy,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& extrinsic_curvature,
+    double constraint_damping_parameter);
+}  // namespace detail
 
 /*!
  * \brief Compute the source terms for the flux-conservative Valencia

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/TimeDerivativeTerms.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/TimeDerivativeTerms.cpp
@@ -9,6 +9,8 @@
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Sources.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
 #include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
@@ -18,69 +20,6 @@
 #include "Utilities/Gsl.hpp"
 
 namespace grmhd::ValenciaDivClean {
-namespace detail {
-void fluxes_impl(
-    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_d_flux,
-    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_ye_flux,
-    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_tau_flux,
-    gsl::not_null<tnsr::Ij<DataVector, 3, Frame::Inertial>*> tilde_s_flux,
-    gsl::not_null<tnsr::IJ<DataVector, 3, Frame::Inertial>*> tilde_b_flux,
-    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_phi_flux,
-
-    // Temporaries
-    gsl::not_null<Scalar<DataVector>*> transport_velocity,
-    const tnsr::i<DataVector, 3, Frame::Inertial>& lapse_b_over_w,
-    const Scalar<DataVector>& magnetic_field_dot_spatial_velocity,
-    const Scalar<DataVector>& pressure_star_lapse_sqrt_det_spatial_metric,
-
-    // Extra args
-    const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_ye,
-    const Scalar<DataVector>& tilde_tau,
-    const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
-    const Scalar<DataVector>& tilde_phi, const Scalar<DataVector>& lapse,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
-    const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity);
-
-void sources_impl(
-    gsl::not_null<Scalar<DataVector>*> source_tilde_tau,
-    gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*> source_tilde_s,
-    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> source_tilde_b,
-    gsl::not_null<Scalar<DataVector>*> source_tilde_phi,
-
-    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_s_up,
-    gsl::not_null<tnsr::II<DataVector, 3, Frame::Inertial>*> densitized_stress,
-    gsl::not_null<Scalar<DataVector>*> h_rho_w_squared_plus_b_squared,
-
-    const Scalar<DataVector>& magnetic_field_dot_spatial_velocity,
-    const Scalar<DataVector>& magnetic_field_squared,
-    const Scalar<DataVector>& one_over_w_squared,
-    const Scalar<DataVector>& pressure_star,
-    const tnsr::I<DataVector, 3, Frame::Inertial>&
-        trace_spatial_christoffel_second,
-
-    const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_ye,
-    const Scalar<DataVector>& tilde_tau,
-    const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
-    const Scalar<DataVector>& tilde_phi, const Scalar<DataVector>& lapse,
-    const Scalar<DataVector>& sqrt_det_spatial_metric,
-    const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
-    const tnsr::i<DataVector, 3, Frame::Inertial>& d_lapse,
-    const tnsr::iJ<DataVector, 3, Frame::Inertial>& d_shift,
-    const tnsr::ijj<DataVector, 3, Frame::Inertial>& d_spatial_metric,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,
-    const Scalar<DataVector>& lorentz_factor,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& magnetic_field,
-
-    const Scalar<DataVector>& rest_mass_density,
-    const Scalar<DataVector>& electron_fraction,
-    const Scalar<DataVector>& specific_enthalpy,
-    const tnsr::ii<DataVector, 3, Frame::Inertial>& extrinsic_curvature,
-    double constraint_damping_parameter);
-}  // namespace detail
-
 void TimeDerivativeTerms::apply(
     const gsl::not_null<Scalar<DataVector>*> /*non_flux_terms_dt_tilde_d*/,
     const gsl::not_null<Scalar<DataVector>*> /*non_flux_terms_dt_tilde_ye*/,

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/RegisterDerived.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/RegisterDerived.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "Evolution/Systems/NewtonianEuler/BoundaryCorrections/RegisterDerived.hpp"
+
 #include "Evolution/Systems/NewtonianEuler/BoundaryCorrections/Factory.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryCorrections/RegisterDerived.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryCorrections/RegisterDerived.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "Evolution/Systems/RelativisticEuler/Valencia/BoundaryCorrections/RegisterDerived.hpp"
+
 #include "Evolution/Systems/RelativisticEuler/Valencia/BoundaryCorrections/Factory.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 

--- a/src/Evolution/Systems/ScalarAdvection/BoundaryCorrections/RegisterDerived.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/BoundaryCorrections/RegisterDerived.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "Evolution/Systems/ScalarAdvection/BoundaryCorrections/RegisterDerived.hpp"
+
 #include "Evolution/Systems/ScalarAdvection/BoundaryCorrections/Factory.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 

--- a/src/Evolution/Systems/ScalarWave/BoundaryCorrections/RegisterDerived.cpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryCorrections/RegisterDerived.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "Evolution/Systems/ScalarWave/BoundaryCorrections/RegisterDerived.hpp"
+
 #include "Evolution/Systems/ScalarWave/BoundaryCorrections/Factory.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 

--- a/src/Executables/ConvertComposeTable/ConvertComposeTable.cpp
+++ b/src/Executables/ConvertComposeTable/ConvertComposeTable.cpp
@@ -15,6 +15,7 @@
 // main module we just have it be empty
 extern "C" void CkRegisterMainModule(void) {}
 
+namespace {
 void convert_file(const std::string& compose_directory,
                   const std::string& spectre_eos_filename,
                   const std::string& spectre_eos_subfile) {
@@ -40,6 +41,7 @@ void convert_file(const std::string& compose_directory,
     spectre_eos.write_quantity(quantity_name, quantity_data);
   }
 }
+}  // namespace
 
 int main(int argc, char** argv) {
   namespace bpo = boost::program_options;

--- a/src/Executables/ParallelInfo/ParallelInfo.cpp
+++ b/src/Executables/ParallelInfo/ParallelInfo.cpp
@@ -63,6 +63,7 @@ void ParallelInfo::start_node_group_check() const {
   sys::exit();
 }
 
+namespace {
 // Helper print function so that both node and pe group prints can be changed
 // easily.
 void print_info() {
@@ -85,6 +86,7 @@ void print_info() {
       sys::my_local_rank(), sys::first_proc_on_node(sys::my_node()),
       sys::node_of(sys::my_proc()), sys::local_rank_of(sys::my_proc()));
 }
+}  // namespace
 
 PeGroupReporter::PeGroupReporter(const CkCallback& cb_start_node_group_check) {
   print_info();

--- a/src/Executables/ReduceCceWorldtube/ReduceCceWorldtube.cpp
+++ b/src/Executables/ReduceCceWorldtube/ReduceCceWorldtube.cpp
@@ -26,6 +26,7 @@
 // main module we just have it be empty
 extern "C" void CkRegisterMainModule(void) {}
 
+namespace {
 // from a time-varies-fastest set of buffers provided by
 // `MetricWorldtubeH5BufferUpdater` extract the set of coefficients for a
 // particular time given by `buffer_time_offset` into the `time_span` size of
@@ -274,6 +275,7 @@ void perform_cce_worldtube_reduction(
   }
   Parallel::printf("\n");
 }
+}  // namespace
 
 /*
  * This executable is used for converting the unnecessarily large SpEC worldtube

--- a/src/IO/Connectivity.cpp
+++ b/src/IO/Connectivity.cpp
@@ -24,6 +24,7 @@ std::ostream& operator<<(std::ostream& os, const Topology& topology) {
   }
 }
 
+namespace {
 std::vector<CellInTopology> cells_in_i1(const size_t number_of_points_in_i1) {
   // The number of cells in an I1 with N collocation points is N-1. Each cell
   // goes from the ith to the i+1th collocation point. This is stored in a
@@ -94,6 +95,7 @@ std::vector<CellInTopology> tensor_product_cells(
   }
   return result;
 }
+}  // namespace
 
 template <size_t Dim>
 std::vector<CellInTopology> compute_cells(const Index<Dim>& extents) {

--- a/src/IO/H5/Python/Bindings.cpp
+++ b/src/IO/H5/Python/Bindings.cpp
@@ -3,14 +3,12 @@
 
 #include <pybind11/pybind11.h>
 
-namespace py = pybind11;
+#include "IO/H5/Python/Dat.hpp"
+#include "IO/H5/Python/File.hpp"
+#include "IO/H5/Python/TensorData.hpp"
+#include "IO/H5/Python/VolumeData.hpp"
 
-namespace py_bindings {
-void bind_h5file(py::module& m);  // NOLINT
-void bind_h5dat(py::module& m);   // NOLINT
-void bind_h5vol(py::module& m);   // NOLINT
-void bind_tensordata(py::module& m);  // NOLINT
-}  // namespace py_bindings
+namespace py = pybind11;
 
 PYBIND11_MODULE(_PyH5, m) {  // NOLINT
   py::module_::import("spectre.DataStructures");

--- a/src/IO/H5/Python/CMakeLists.txt
+++ b/src/IO/H5/Python/CMakeLists.txt
@@ -17,6 +17,16 @@ spectre_python_add_module(
   MODULE_PATH "IO"
   )
 
+spectre_python_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Dat.hpp
+  File.hpp
+  TensorData.hpp
+  VolumeData.hpp
+  )
+
 spectre_python_link_libraries(
   ${LIBRARY}
   PRIVATE

--- a/src/IO/H5/Python/Dat.cpp
+++ b/src/IO/H5/Python/Dat.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "IO/H5/Python/Dat.hpp"
+
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <string>
@@ -12,7 +14,7 @@
 namespace py = pybind11;
 
 namespace py_bindings {
-void bind_h5dat(py::module& m) {  // NOLINT
+void bind_h5dat(py::module& m) {
   // Wrapper for basic H5Dat operations
   py::class_<h5::Dat>(m, "H5Dat")
       .def("append",

--- a/src/IO/H5/Python/Dat.hpp
+++ b/src/IO/H5/Python/Dat.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_h5dat(pybind11::module& m);
+}  // namespace py_bindings

--- a/src/IO/H5/Python/File.cpp
+++ b/src/IO/H5/Python/File.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "IO/H5/Python/File.hpp"
+
 #include <boost/algorithm/string/join.hpp>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -15,6 +17,7 @@
 namespace py = pybind11;
 
 namespace py_bindings {
+namespace {
 template <h5::AccessType Access_t>
 void bind_h5file_impl(py::module& m) {  // NOLINT
   // Wrapper for basic H5File operations
@@ -83,7 +86,9 @@ void bind_h5file_impl(py::module& m) {  // NOLINT
             py::arg("version"));
   }
 }
-void bind_h5file(py::module& m) {  // NOLINT
+}  // namespace
+
+void bind_h5file(py::module& m) {
   bind_h5file_impl<h5::AccessType::ReadOnly>(m);
   bind_h5file_impl<h5::AccessType::ReadWrite>(m);
 

--- a/src/IO/H5/Python/File.hpp
+++ b/src/IO/H5/Python/File.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_h5file(pybind11::module& m);
+}  // namespace py_bindings

--- a/src/IO/H5/Python/TensorData.cpp
+++ b/src/IO/H5/Python/TensorData.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "IO/H5/Python/TensorData.hpp"
+
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -16,7 +18,7 @@
 namespace py = pybind11;
 
 namespace py_bindings {
-void bind_tensordata(py::module& m) {  // NOLINT
+void bind_tensordata(py::module& m) {
   // Wrapper for TensorComponent
   py::class_<TensorComponent>(m, "TensorComponent")
       .def(py::init<std::string, DataVector>(), py::arg("name"),

--- a/src/IO/H5/Python/TensorData.hpp
+++ b/src/IO/H5/Python/TensorData.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_tensordata(pybind11::module& m);
+}  // namespace py_bindings

--- a/src/IO/H5/Python/VolumeData.cpp
+++ b/src/IO/H5/Python/VolumeData.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "IO/H5/Python/VolumeData.hpp"
+
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <string>
@@ -12,7 +14,7 @@
 namespace py = pybind11;
 
 namespace py_bindings {
-void bind_h5vol(py::module& m) {  // NOLINT
+void bind_h5vol(py::module& m) {
   // Wrapper for basic H5VolumeData operations
   py::class_<h5::VolumeData>(m, "H5Vol")
       .def_static("extension", &h5::VolumeData::extension)

--- a/src/IO/H5/Python/VolumeData.hpp
+++ b/src/IO/H5/Python/VolumeData.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_h5vol(pybind11::module& m);
+}  // namespace py_bindings

--- a/src/Informer/Python/Bindings.cpp
+++ b/src/Informer/Python/Bindings.cpp
@@ -3,11 +3,7 @@
 
 #include <pybind11/pybind11.h>
 
-namespace py = pybind11;
-
-namespace py_bindings {
-void bind_info_at_compile(py::module& m);  // NOLINT
-}  // namespace py_bindings
+#include "Informer/Python/InfoAtCompile.hpp"
 
 PYBIND11_MODULE(_PyInformer, m) {  // NOLINT
   py_bindings::bind_info_at_compile(m);

--- a/src/Informer/Python/CMakeLists.txt
+++ b/src/Informer/Python/CMakeLists.txt
@@ -11,6 +11,13 @@ spectre_python_add_module(
   InfoAtCompile.cpp
 )
 
+spectre_python_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  InfoAtCompile.hpp
+  )
+
 spectre_python_link_libraries(
   ${LIBRARY}
   PRIVATE

--- a/src/Informer/Python/InfoAtCompile.cpp
+++ b/src/Informer/Python/InfoAtCompile.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "Informer/Python/InfoAtCompile.hpp"
+
 #include <pybind11/pybind11.h>
 #include <string>
 
@@ -9,7 +11,7 @@
 namespace py = pybind11;
 
 namespace py_bindings {
-void bind_info_at_compile(py::module& m) {  // NOLINT
+void bind_info_at_compile(py::module& m) {
   // Wrapper to make Build Info available from python
   m.def("spectre_version", &spectre_version);
   m.def("unit_test_src_path", &unit_test_src_path);

--- a/src/Informer/Python/InfoAtCompile.hpp
+++ b/src/Informer/Python/InfoAtCompile.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_info_at_compile(pybind11::module& m);
+}  // namespace py_bindings

--- a/src/NumericalAlgorithms/Interpolation/Python/Bindings.cpp
+++ b/src/NumericalAlgorithms/Interpolation/Python/Bindings.cpp
@@ -3,11 +3,7 @@
 
 #include <pybind11/pybind11.h>
 
-namespace py = pybind11;
-
-namespace intrp::py_bindings {
-void bind_regular_grid(py::module& m);  // NOLINT
-}  // namespace intrp::py_bindings
+#include "NumericalAlgorithms/Interpolation/Python/RegularGridInterpolant.hpp"
 
 PYBIND11_MODULE(_PyInterpolation, m) {  // NOLINT
   intrp::py_bindings::bind_regular_grid(m);

--- a/src/NumericalAlgorithms/Interpolation/Python/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Interpolation/Python/CMakeLists.txt
@@ -11,6 +11,13 @@ spectre_python_add_module(
   RegularGridInterpolant.cpp
 )
 
+spectre_python_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  RegularGridInterpolant.hpp
+  )
+
 spectre_python_link_libraries(
   ${LIBRARY}
   PRIVATE

--- a/src/NumericalAlgorithms/Interpolation/Python/RegularGridInterpolant.cpp
+++ b/src/NumericalAlgorithms/Interpolation/Python/RegularGridInterpolant.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "NumericalAlgorithms/Interpolation/Python/RegularGridInterpolant.hpp"
+
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
@@ -11,7 +13,7 @@
 namespace py = pybind11;
 
 namespace intrp::py_bindings {
-
+namespace {
 template <size_t Dim>
 void bind_regular_grid_impl(py::module& m) {  // NOLINT
   // the bindings are not complete and can be extended
@@ -28,8 +30,9 @@ void bind_regular_grid_impl(py::module& m) {  // NOLINT
            py::arg("input"))
       .def("interpolation_matrices", &RegularGrid<Dim>::interpolation_matrices);
 }
+}  // namespace
 
-void bind_regular_grid(py::module& m) {  // NOLINT
+void bind_regular_grid(py::module& m) {
   bind_regular_grid_impl<1>(m);
   bind_regular_grid_impl<2>(m);
   bind_regular_grid_impl<3>(m);

--- a/src/NumericalAlgorithms/Interpolation/Python/RegularGridInterpolant.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Python/RegularGridInterpolant.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace intrp::py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_regular_grid(pybind11::module& m);
+}  // namespace intrp::py_bindings

--- a/src/NumericalAlgorithms/Spectral/Python/Bindings.cpp
+++ b/src/NumericalAlgorithms/Spectral/Python/Bindings.cpp
@@ -3,19 +3,8 @@
 
 #include <pybind11/pybind11.h>
 
-namespace py = pybind11;
-
-namespace Spectral::py_bindings {
-void bind_basis(py::module& m);                  // NOLINT
-void bind_quadrature(py::module& m);             // NOLINT
-void bind_nodal_to_modal_matrix(py::module& m);  // NOLINT
-void bind_modal_to_nodal_matrix(py::module& m);  // NOLINT
-void bind_collocation_points(py::module& m);     // NOLINT
-}  // namespace Spectral::py_bindings
-
-namespace py_bindings {
-void bind_mesh(py::module& m);  // NOLINT
-}  // namespace py_bindings
+#include "NumericalAlgorithms/Spectral/Python/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Python/Spectral.hpp"
 
 PYBIND11_MODULE(_PySpectral, m) {  // NOLINT
   Spectral::py_bindings::bind_basis(m);

--- a/src/NumericalAlgorithms/Spectral/Python/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Spectral/Python/CMakeLists.txt
@@ -12,6 +12,14 @@ spectre_python_add_module(
   Spectral.cpp
 )
 
+spectre_python_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Mesh.hpp
+  Spectral.hpp
+  )
+
 spectre_python_link_libraries(
   ${LIBRARY}
   PRIVATE

--- a/src/NumericalAlgorithms/Spectral/Python/Mesh.cpp
+++ b/src/NumericalAlgorithms/Spectral/Python/Mesh.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "NumericalAlgorithms/Spectral/Python/Mesh.hpp"
+
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -12,7 +14,7 @@
 namespace py = pybind11;
 
 namespace py_bindings {
-
+namespace {
 template <size_t Dim>
 void bind_mesh_impl(py::module& m) {  // NOLINT
   // the bindings here are not complete
@@ -77,8 +79,9 @@ void bind_mesh_impl(py::module& m) {  // NOLINT
                 state[2].cast<std::array<Spectral::Quadrature, Dim>>());
           }));
 }
+}  // namespace
 
-void bind_mesh(py::module& m) {  // NOLINT
+void bind_mesh(py::module& m) {
   bind_mesh_impl<1>(m);
   bind_mesh_impl<2>(m);
   bind_mesh_impl<3>(m);

--- a/src/NumericalAlgorithms/Spectral/Python/Mesh.hpp
+++ b/src/NumericalAlgorithms/Spectral/Python/Mesh.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_mesh(pybind11::module& m);
+}  // namespace py_bindings

--- a/src/NumericalAlgorithms/Spectral/Python/Spectral.cpp
+++ b/src/NumericalAlgorithms/Spectral/Python/Spectral.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "NumericalAlgorithms/Spectral/Python/Spectral.hpp"
+
 #include <pybind11/pybind11.h>
 
 #include "DataStructures/DataVector.hpp"
@@ -12,21 +14,21 @@ namespace py = pybind11;
 
 namespace Spectral::py_bindings {
 
-void bind_basis(py::module& m) {  // NOLINT
+void bind_basis(py::module& m) {
   py::enum_<Spectral::Basis>(m, "Basis")
       .value("Legendre", Spectral::Basis::Legendre)
       .value("Chebyshev", Spectral::Basis::Chebyshev)
       .value("FiniteDifference", Spectral::Basis::FiniteDifference);
 }
 
-void bind_quadrature(py::module& m) {  // NOLINT
+void bind_quadrature(py::module& m) {
   py::enum_<Spectral::Quadrature>(m, "Quadrature")
       .value("Gauss", Spectral::Quadrature::Gauss)
       .value("GaussLobatto", Spectral::Quadrature::GaussLobatto)
       .value("CellCentered", Spectral::Quadrature::CellCentered)
       .value("FaceCentered", Spectral::Quadrature::FaceCentered);
 }
-void bind_modal_to_nodal_matrix(py::module& m) {  // NOLINT
+void bind_modal_to_nodal_matrix(py::module& m) {
   m.def("modal_to_nodal_matrix",
         static_cast<const Matrix& (*)(const Mesh<1>&)>(
             &Spectral::modal_to_nodal_matrix),
@@ -34,7 +36,7 @@ void bind_modal_to_nodal_matrix(py::module& m) {  // NOLINT
         "Transformation matrix from modal to nodal coefficients for a "
         "one-dimensional mesh.");
 }
-void bind_nodal_to_modal_matrix(py::module& m) {  // NOLINT
+void bind_nodal_to_modal_matrix(py::module& m) {
   m.def("nodal_to_modal_matrix",
         static_cast<const Matrix& (*)(const Mesh<1>&)>(
             &Spectral::nodal_to_modal_matrix),
@@ -43,7 +45,7 @@ void bind_nodal_to_modal_matrix(py::module& m) {  // NOLINT
         "one-dimensional mesh.");
 }
 
-void bind_collocation_points(py::module& m) {  // NOLINT
+void bind_collocation_points(py::module& m) {
   m.def("collocation_points",
         static_cast<const DataVector& (*)(const Mesh<1>&)>(
             &Spectral::collocation_points),

--- a/src/NumericalAlgorithms/Spectral/Python/Spectral.hpp
+++ b/src/NumericalAlgorithms/Spectral/Python/Spectral.hpp
@@ -1,0 +1,15 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace Spectral::py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_basis(pybind11::module& m);
+void bind_quadrature(pybind11::module& m);
+void bind_modal_to_nodal_matrix(pybind11::module& m);
+void bind_nodal_to_modal_matrix(pybind11::module& m);
+void bind_collocation_points(pybind11::module& m);
+}  // namespace Spectral::py_bindings

--- a/src/NumericalAlgorithms/Spectral/SwshInterpolation.cpp
+++ b/src/NumericalAlgorithms/Spectral/SwshInterpolation.cpp
@@ -156,6 +156,7 @@ void SpinWeightedSphericalHarmonic::pup(PUP::er& p) {
   p | r_prefactors_;
 }
 
+namespace {
 // A function for indexing a desired element in one of the caches stored
 // in `ClenshawRecurrenceConstants`.
 // Useful for accessing the `beta_constant`, `alpha_constant`, or
@@ -326,6 +327,7 @@ const ClenshawRecurrenceConstants<Spin>& cached_clenshaw_factors(
           });
   return lazy_clenshaw_cache(l_max);
 }
+}  // namespace
 
 SwshInterpolator::SwshInterpolator(const DataVector& theta,
                                    const DataVector& phi, const size_t l_max)
@@ -618,9 +620,6 @@ void SwshInterpolator::pup(PUP::er& p) {
 #define GET_SPIN(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INTERPOLATION_INSTANTIATION(r, data)                                  \
-  template struct ClenshawRecurrenceConstants<GET_SPIN(data)>;                \
-  template const ClenshawRecurrenceConstants<GET_SPIN(data)>&                 \
-  cached_clenshaw_factors<GET_SPIN(data)>(const size_t l_max);                \
   template void SwshInterpolator::interpolate<GET_SPIN(data)>(                \
       const gsl::not_null<SpinWeighted<ComplexDataVector, GET_SPIN(data)>*>   \
           interpolated,                                                       \

--- a/src/Parallel/CharmMain.tpp
+++ b/src/Parallel/CharmMain.tpp
@@ -34,7 +34,7 @@ std::unordered_map<size_t, CkReduction::reducerType> charm_reducer_functions{};
  * \ingroup CharmExtensionsGroup
  * \brief Registers parallel components and their entry methods with Charm++
  */
-void register_parallel_components() {
+inline void register_parallel_components() {
   static bool done_registration{false};
   if (done_registration) {
     return;  // LCOV_EXCL_LINE
@@ -86,7 +86,7 @@ void register_parallel_components() {
  *
  * \see Parallel::contribute_to_reduction()
  */
-void register_custom_reducer_functions() {
+inline void register_custom_reducer_functions() {
   for (size_t i = 0; i < charm_reducer_functions_size; ++i) {
     // clang-tidy: do not use pointer arithmetic
     charm_reducer_functions.emplace(
@@ -103,7 +103,7 @@ void register_custom_reducer_functions() {
  * \note The function that registers the custom reducers is the first init_node
  * function registered.
  */
-void register_init_node_and_proc() {
+inline void register_init_node_and_proc() {
   static bool done_registration{false};
   if (done_registration) {
     return;  // LCOV_EXCL_LINE

--- a/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/LineSearch.cpp
+++ b/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/LineSearch.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "ParallelAlgorithms/NonlinearSolver/NewtonRaphson/LineSearch.hpp"
+
 #include <cmath>
 #include <cstddef>
 

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/SphericalKerrSchild.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/SphericalKerrSchild.cpp
@@ -62,6 +62,7 @@ SphericalKerrSchild::IntermediateComputer<
                                            const tnsr::I<DataType, 3, Frame>& x)
     : solution_(solution), x_(x) {}
 
+namespace {
 auto dimensionful_spin(const SphericalKerrSchild& solution) {
   return solution.dimensionless_spin() * solution.mass();
 }
@@ -72,6 +73,7 @@ auto spin_a_and_squared(const SphericalKerrSchild& solution) {
       std::inner_product(spin_a.begin(), spin_a.end(), spin_a.begin(), 0.);
   return std::make_tuple(spin_a, a_squared);
 }
+}  // namespace
 
 template <typename DataType, typename Frame>
 void SphericalKerrSchild::IntermediateComputer<DataType, Frame>::operator()(

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Python/Bindings.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Python/Bindings.cpp
@@ -3,11 +3,7 @@
 
 #include <pybind11/pybind11.h>
 
-namespace py = pybind11;
-
-namespace RelativisticEuler::Solutions::py_bindings {
-void bind_tov(py::module& m);  // NOLINT
-}  // namespace RelativisticEuler::Solutions::py_bindings
+#include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Python/Tov.hpp"
 
 PYBIND11_MODULE(_PyRelativisticEulerSolutions, m) {  // NOLINT
   RelativisticEuler::Solutions::py_bindings::bind_tov(m);

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Python/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Python/CMakeLists.txt
@@ -12,6 +12,13 @@ spectre_python_add_module(
   Tov.cpp
   )
 
+spectre_python_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Tov.hpp
+  )
+
 spectre_python_link_libraries(
   ${LIBRARY}
   PRIVATE

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Python/Tov.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Python/Tov.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Python/Tov.hpp"
+
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <string>
@@ -12,7 +14,7 @@ namespace py = pybind11;
 
 namespace RelativisticEuler::Solutions::py_bindings {
 
-void bind_tov(py::module& m) {  // NOLINT
+void bind_tov(py::module& m) {
   py::enum_<TovCoordinates>(m, "TovCoordinates")
       .value("Schwarzschild", TovCoordinates::Schwarzschild)
       .value("Isotropic", TovCoordinates::Isotropic);

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Python/Tov.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Python/Tov.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace RelativisticEuler::Solutions::py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_tov(pybind11::module& m);
+}  // namespace RelativisticEuler::Solutions::py_bindings

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Python/Bindings.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Python/Bindings.cpp
@@ -3,14 +3,8 @@
 
 #include <pybind11/pybind11.h>
 
-namespace py = pybind11;
-
-namespace EquationsOfState {
-namespace py_bindings {
-void bind_equation_of_state(py::module& m);  // NOLINT
-void bind_polytropic_fluid(py::module& m);   // NOLINT
-}  // namespace py_bindings
-}  // namespace EquationsOfState
+#include "PointwiseFunctions/Hydro/EquationsOfState/Python/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Python/PolytropicFluid.hpp"
 
 PYBIND11_MODULE(_PyEquationsOfState, m) {  // NOLINT
   EquationsOfState::py_bindings::bind_equation_of_state(m);

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Python/CMakeLists.txt
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Python/CMakeLists.txt
@@ -13,6 +13,14 @@ spectre_python_add_module(
   PolytropicFluid.cpp
   )
 
+spectre_python_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  EquationOfState.hpp
+  PolytropicFluid.hpp
+  )
+
 spectre_python_link_libraries(
   ${LIBRARY}
   PRIVATE

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Python/EquationOfState.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Python/EquationOfState.cpp
@@ -10,8 +10,7 @@
 
 namespace py = pybind11;
 
-namespace EquationsOfState {
-namespace py_bindings {
+namespace EquationsOfState::py_bindings {
 
 void bind_equation_of_state(py::module& m) {
   // This is a virtual base class, so we expose it only to use it in Python
@@ -19,5 +18,4 @@ void bind_equation_of_state(py::module& m) {
   py::class_<EquationOfState<true, 1>>(m, "RelativisticEquationOfState1D");
 }
 
-}  // namespace py_bindings
-}  // namespace EquationsOfState
+}  // namespace EquationsOfState::py_bindings

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Python/EquationOfState.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Python/EquationOfState.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "PointwiseFunctions/Hydro/EquationsOfState/Python/EquationOfState.hpp"
+
 #include <pybind11/pybind11.h>
 #include <string>
 
@@ -11,7 +13,7 @@ namespace py = pybind11;
 namespace EquationsOfState {
 namespace py_bindings {
 
-void bind_equation_of_state(py::module& m) {  // NOLINT
+void bind_equation_of_state(py::module& m) {
   // This is a virtual base class, so we expose it only to use it in Python
   // wrappers of derived classes.
   py::class_<EquationOfState<true, 1>>(m, "RelativisticEquationOfState1D");

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Python/EquationOfState.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Python/EquationOfState.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace EquationsOfState::py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_equation_of_state(pybind11::module& m);
+}  // namespace EquationsOfState::py_bindings

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Python/PolytropicFluid.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Python/PolytropicFluid.cpp
@@ -10,8 +10,7 @@
 
 namespace py = pybind11;
 
-namespace EquationsOfState {
-namespace py_bindings {
+namespace EquationsOfState::py_bindings {
 
 void bind_polytropic_fluid(py::module& m) {
   // We can't expose any member functions without wrapping tensors in Python,
@@ -22,5 +21,4 @@ void bind_polytropic_fluid(py::module& m) {
            py::arg("polytropic_exponent"));
 }
 
-}  // namespace py_bindings
-}  // namespace EquationsOfState
+}  // namespace EquationsOfState::py_bindings

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Python/PolytropicFluid.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Python/PolytropicFluid.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "PointwiseFunctions/Hydro/EquationsOfState/Python/PolytropicFluid.hpp"
+
 #include <pybind11/pybind11.h>
 #include <string>
 
@@ -11,7 +13,7 @@ namespace py = pybind11;
 namespace EquationsOfState {
 namespace py_bindings {
 
-void bind_polytropic_fluid(py::module& m) {  // NOLINT
+void bind_polytropic_fluid(py::module& m) {
   // We can't expose any member functions without wrapping tensors in Python,
   // so we only expose the initializer for now.
   py::class_<PolytropicFluid<true>, EquationOfState<true, 1>>(

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Python/PolytropicFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Python/PolytropicFluid.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace EquationsOfState::py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_polytropic_fluid(pybind11::module& m);
+}  // namespace EquationsOfState::py_bindings

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/RegisterDerivedWithCharm.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/RegisterDerivedWithCharm.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "PointwiseFunctions/Hydro/EquationsOfState/RegisterDerivedWithCharm.hpp"
+
 #include <cstddef>
 
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"

--- a/src/PythonBindings/CharmCompatibility.cpp
+++ b/src/PythonBindings/CharmCompatibility.cpp
@@ -3,4 +3,7 @@
 
 // Charm looks for this function but since we build without a main function or
 // main module we just have it be empty
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-declarations"
 extern "C" void CkRegisterMainModule(void) {}
+#pragma GCC diagnostic pop

--- a/tests/Unit/DataStructures/Test_ComplexDataVector.cpp
+++ b/tests/Unit/DataStructures/Test_ComplexDataVector.cpp
@@ -15,6 +15,7 @@
 #include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
 #include "Utilities/TypeTraits.hpp"  // IWYU pragma: keep
 
+namespace {
 void test_complex_data_vector_math() {
   const TestHelpers::VectorImpl::Bound generic{{-100.0, 100.0}};
   const TestHelpers::VectorImpl::Bound mone_one{{-1.0, 1.0}};
@@ -62,6 +63,7 @@ void test_complex_data_vector_math() {
   // `Test_ComplexDataVectorBinaryOperations.cpp` in an effort to better
   // parallelize the build.
 }
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.DataStructures.ComplexDataVector",
                   "[DataStructures][Unit]") {

--- a/tests/Unit/DataStructures/Test_ComplexDataVectorBinaryOperations.cpp
+++ b/tests/Unit/DataStructures/Test_ComplexDataVectorBinaryOperations.cpp
@@ -18,6 +18,7 @@
 #include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
 #include "Utilities/TypeTraits.hpp"  // IWYU pragma: keep
 
+namespace {
 void test_complex_data_vector_multiple_operand_math() {
   const TestHelpers::VectorImpl::Bound generic{{-10.0, 10.0}};
   const TestHelpers::VectorImpl::Bound positive{{0.1, 10.0}};
@@ -74,6 +75,7 @@ void test_complex_data_vector_multiple_operand_math() {
       std::array<ComplexDataVector, 2>, std::array<ComplexDataVector, 2>>(
       array_binary_ops);
 }
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.DataStructures.ComplexDataVector.MultipleOperands",
                   "[DataStructures][Unit]") {

--- a/tests/Unit/DataStructures/Test_ComplexDiagonalModalOperator.cpp
+++ b/tests/Unit/DataStructures/Test_ComplexDiagonalModalOperator.cpp
@@ -57,6 +57,7 @@
 #endif
 }
 
+namespace {
 void test_complex_diagonal_modal_operator_math() {
   const TestHelpers::VectorImpl::Bound generic{{-100.0, 100.0}};
   const TestHelpers::VectorImpl::Bound positive{{0.01, 100.0}};
@@ -102,6 +103,7 @@ void test_complex_diagonal_modal_operator_math() {
   // to `Test_MoreComplexDiagonalModalOperatorMath.cpp` in an effort to better
   // parallelize the build.
 }
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.DataStructures.ComplexDiagonalModalOperator",
                   "[DataStructures][Unit]") {

--- a/tests/Unit/DataStructures/Test_ComplexModalVector.cpp
+++ b/tests/Unit/DataStructures/Test_ComplexModalVector.cpp
@@ -54,6 +54,7 @@
 #endif
 }
 
+namespace {
 void test_complex_modal_vector_math() {
   const TestHelpers::VectorImpl::Bound generic{{-100.0, 100.0}};
 
@@ -101,6 +102,7 @@ void test_complex_modal_vector_math() {
   // `Test_ComplexModalVectorInhomogeneousOperations.cpp` in an effort to better
   // parallelize the build.
 }
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.DataStructures.ComplexModalVector",
                   "[DataStructures][Unit]") {

--- a/tests/Unit/DataStructures/Test_ComplexModalVectorInhomogeneousOperations.cpp
+++ b/tests/Unit/DataStructures/Test_ComplexModalVectorInhomogeneousOperations.cpp
@@ -20,6 +20,7 @@
 
 // IWYU pragma: no_include <algorithm>
 
+namespace {
 void test_complex_modal_vector_inhomogeneous_binary_math() {
   const TestHelpers::VectorImpl::Bound generic{{-10.0, 10.0}};
   const TestHelpers::VectorImpl::Bound positive{{0.1, 10.0}};
@@ -65,6 +66,7 @@ void test_complex_modal_vector_inhomogeneous_binary_math() {
       TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly,
       ComplexModalVector, ModalVector>(just_modal_vector_with_modal_vector_ops);
 }
+}  // namespace
 
 SPECTRE_TEST_CASE(
     "Unit.DataStructures.ComplexModalVector.InhomogeneousOperations",

--- a/tests/Unit/DataStructures/Test_DataVector.cpp
+++ b/tests/Unit/DataStructures/Test_DataVector.cpp
@@ -19,6 +19,7 @@
 
 // IWYU pragma: no_include <algorithm>
 
+namespace {
 void test_data_vector_unary_math() {
   // [test_functions_with_vector_arguments_example]
   const TestHelpers::VectorImpl::Bound generic{{-100.0, 100.0}};
@@ -65,7 +66,6 @@ void test_data_vector_unary_math() {
   // the build.
 }
 
-namespace {
 void test_norms() {
   // Test l1Norm and l2Norm:
   MAKE_GENERATOR(gen);

--- a/tests/Unit/DataStructures/Test_DataVectorBinaryOperations.cpp
+++ b/tests/Unit/DataStructures/Test_DataVectorBinaryOperations.cpp
@@ -19,6 +19,7 @@
 
 // IWYU pragma: no_include <algorithm>
 
+namespace {
 void test_data_vector_multiple_operand_math() {
   const TestHelpers::VectorImpl::Bound generic{{-10.0, 10.0}};
   const TestHelpers::VectorImpl::Bound positive{{0.1, 10.0}};
@@ -92,6 +93,7 @@ void test_data_vector_multiple_operand_math() {
   // Check Blaze implementation of cross product
   CHECK(cross(dv1, dv2) == test_cross(dv1, dv2));
 }
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.MultipleOperands",
                   "[DataStructures][Unit]") {

--- a/tests/Unit/DataStructures/Test_DiagonalModalOperator.cpp
+++ b/tests/Unit/DataStructures/Test_DiagonalModalOperator.cpp
@@ -51,6 +51,7 @@
 #endif
 }
 
+namespace {
 void test_diagonal_modal_operator_math() {
   const TestHelpers::VectorImpl::Bound generic{{-100.0, 100.0}};
   const TestHelpers::VectorImpl::Bound positive{{0.01, 100.0}};
@@ -82,6 +83,7 @@ void test_diagonal_modal_operator_math() {
   // `Test_MoreDiagonalModalOperatorMath.cpp` in an effort to better
   // parallelize the build.
 }
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.DataStructures.DiagonalModalOperator",
                   "[DataStructures][Unit]") {

--- a/tests/Unit/DataStructures/Test_ModalVector.cpp
+++ b/tests/Unit/DataStructures/Test_ModalVector.cpp
@@ -52,6 +52,7 @@
 #endif
 }
 
+namespace {
 void test_modal_vector_math() {
   const TestHelpers::VectorImpl::Bound generic{{-100.0, 100.0}};
 
@@ -87,6 +88,7 @@ void test_modal_vector_math() {
   // have been moved to `Test_ModalVectorInhomogeneousOperations.cpp` in an
   // effort to better parallelize the build.
 }
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.DataStructures.ModalVector", "[DataStructures][Unit]") {
   {

--- a/tests/Unit/DataStructures/Test_ModalVectorInhomogeneousOperations.cpp
+++ b/tests/Unit/DataStructures/Test_ModalVectorInhomogeneousOperations.cpp
@@ -18,6 +18,7 @@
 
 // IWYU pragma: no_include <algorithm>
 
+namespace {
 void test_modal_vector_inhomogeneous_binary_math() {
   const TestHelpers::VectorImpl::Bound generic{{-10.0, 10.0}};
   const TestHelpers::VectorImpl::Bound positive{{0.1, 10.0}};
@@ -48,6 +49,7 @@ void test_modal_vector_inhomogeneous_binary_math() {
       TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly, ModalVector,
       ModalVector>(just_modal_vector_with_modal_vector_ops);
 }
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.DataStructures.ModalVector.InhomogeneousOperations",
                   "[DataStructures][Unit]") {

--- a/tests/Unit/DataStructures/Test_MoreComplexDiagonalModalOperatorMath.cpp
+++ b/tests/Unit/DataStructures/Test_MoreComplexDiagonalModalOperatorMath.cpp
@@ -21,6 +21,7 @@
 
 // IWYU pragma: no_include <algorithm>
 
+namespace {
 void test_additional_complex_diagonal_modal_operator_math() {
   const TestHelpers::VectorImpl::Bound generic{{-100.0, 100.0}};
 
@@ -69,6 +70,7 @@ void test_additional_complex_diagonal_modal_operator_math() {
       TestHelpers::VectorImpl::TestKind::Strict,
       std::array<ComplexDiagonalModalOperator, 2>>(array_binary_ops);
 }
+}  // namespace
 
 SPECTRE_TEST_CASE(
     "Unit.DataStructures.ComplexDiagonalModalOperator.AdditionalMath",

--- a/tests/Unit/DataStructures/Test_MoreDiagonalModalOperatorMath.cpp
+++ b/tests/Unit/DataStructures/Test_MoreDiagonalModalOperatorMath.cpp
@@ -19,6 +19,7 @@
 
 // IWYU pragma: no_include <algorithm>
 
+namespace {
 void test_additional_diagonal_modal_operator_math() {
   const TestHelpers::VectorImpl::Bound generic{{-100.0, 100.0}};
 
@@ -55,6 +56,7 @@ void test_additional_diagonal_modal_operator_math() {
       TestHelpers::VectorImpl::TestKind::Strict,
       std::array<DiagonalModalOperator, 2>>(array_binary_ops);
 }
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.DataStructures.DiagonalModalOperator.AdditionalMath",
                   "[DataStructures][Unit]") {

--- a/tests/Unit/Domain/Test_InterfaceItems.cpp
+++ b/tests/Unit/Domain/Test_InterfaceItems.cpp
@@ -731,7 +731,6 @@ struct ComputeDerived : ComputeBase, db::ComputeTag {
   }
   using argument_tags = tmpl::list<SimpleBase>;
 };
-}  // namespace
 
 void test_interface_base_tags() {
   const auto interface = [](const auto xi_value, const auto eta_value) {
@@ -747,7 +746,7 @@ void test_interface_base_tags() {
   CHECK(get<Tags::Interface<Dirs, SimpleBase>>(box) == interface(4, 5));
   CHECK(get<Tags::Interface<Dirs, ComputeBase>>(box) == interface(5.5, 6.5));
 }
-
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.InterfaceItems", "[Unit][Domain]") {
   test_interface_items();

--- a/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/Test_BouncingBlackHole.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/Test_BouncingBlackHole.cpp
@@ -33,7 +33,7 @@
 #include "Utilities/Gsl.hpp"
 
 namespace Cce {
-
+namespace {
 tnsr::A<DataVector, 3> bouncing_bh_mapped_coordinates(
     const tnsr::A<DataVector, 3>& unmapped_coordinates, const double amplitude,
     const double period) {
@@ -74,6 +74,7 @@ tnsr::aaB<DataVector, 3> bouncing_bh_mapped_hessian(
        cos(8.0 * M_PI * get<0>(unmapped_coordinates) / period));
   return result;
 }
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.BouncingBlackHole",
                   "[Unit][Cce]") {

--- a/tests/Unit/Evolution/Systems/Cce/Test_NewmanPenrose.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_NewmanPenrose.cpp
@@ -12,7 +12,7 @@
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 
 namespace Cce {
-
+namespace {
 void pypp_test_volume_weyl() {
   pypp::SetupLocalPythonEnvironment local_python_env{"Evolution/Systems/Cce/"};
 
@@ -22,6 +22,7 @@ void pypp_test_volume_weyl() {
                                     "NewmanPenrose", {"psi0"}, {{{1.0, 5.0}}},
                                     DataVector{num_pts});
 }
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.NewmanPenrose", "[Unit][Cce]") {
   pypp_test_volume_weyl();

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_TimeDerivative.cpp
@@ -1239,7 +1239,6 @@ void test_kerrschild(const Ccz4::EvolveShift evolve_shift,
   CHECK_ITERABLE_CUSTOM_APPROX(dt_field_p_actual, dt_field_p_expected,
                                approx_12m);
 }
-}  // namespace
 
 // Test first order CCZ4 against Minkowski and KerrSchild
 void test(const Ccz4::EvolveShift evolve_shift,
@@ -1247,6 +1246,7 @@ void test(const Ccz4::EvolveShift evolve_shift,
   test_minkowski(evolve_shift, slicing_condition_type);
   test_kerrschild(evolve_shift, slicing_condition_type);
 }
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.TimeDerivative",
                   "[Unit][Evolution]") {

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Actions/Test_NumericInitialData.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Actions/Test_NumericInitialData.cpp
@@ -144,8 +144,6 @@ struct Metavariables {
                                     MockVolumeDataReader<Metavariables>>;
 };
 
-}  // namespace
-
 void test_numeric_initial_data(
     const typename detail::Tags::NumericInitialDataVariables<
         TestOptionGroup>::type& selected_vars,
@@ -258,6 +256,7 @@ void test_numeric_initial_data(
       get_element_tag(Tags::Phi<3, Frame::Inertial>{}),
       (get<Tags::Phi<3, Frame::Inertial>>(kerr_gh_vars)), custom_approx);
 }
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Gh.NumericInitialData",
                   "[Unit][Evolution]") {

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Test_TimeDependentTripleGaussian.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Test_TimeDependentTripleGaussian.cpp
@@ -122,6 +122,7 @@ SPECTRE_TEST_CASE(
       "  Width: 1.0\n"
       "  Center: [7.7, -8.8, 9.9]");
   CHECK(created_triple_gauss == triple_gauss_3d);
+  CHECK_FALSE(created_triple_gauss != triple_gauss_3d);
   const auto created_triple_gauss_gh_damping_function =
       TestHelpers::test_creation<
           std::unique_ptr<GeneralizedHarmonic::ConstraintDamping::

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonic.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonic.cpp
@@ -34,7 +34,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
-namespace GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail {
+namespace {
 // The return-by-value implementations of spatial_weight_function and
 // spacetime_deriv_of_spatial_weight_function are intentionally only available
 // in the test because while convenient the additional allocations are bad for
@@ -58,13 +58,6 @@ tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_spatial_weight_function(
   return d4_weight;
 }
 
-double roll_on_function(double time, double t_start, double sigma_t);
-
-double time_deriv_of_roll_on_function(double time, double t_start,
-                                      double sigma_t);
-}  // namespace GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail
-
-namespace {
 template <size_t SpatialDim, typename Frame, typename DataType>
 void test_rollon_function(const DataType& used_for_size) {
   INFO("Test rollon function");

--- a/tests/Unit/Framework/TestingFramework.hpp
+++ b/tests/Unit/Framework/TestingFramework.hpp
@@ -34,7 +34,10 @@
 // add_test_library CMake function. It is used to make a call into a translation
 // unit so that static variables for Catch are properly initialized.
 #ifdef SPECTRE_TEST_REGISTER_FUNCTION
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-declarations"
 void SPECTRE_TEST_REGISTER_FUNCTION() {}  // NOLINT
+#pragma GCC diagnostic pop
 #endif  // SPECTRE_TEST_REGISTER_FUNCTION
 /// \endcond
 

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorIndexTransformationRank0.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorIndexTransformationRank0.hpp
@@ -16,7 +16,7 @@ namespace TestHelpers::tenex {
 /// \details The functions tested are:
 /// - `tenex::compute_tensorindex_transformation`
 /// - `tenex::transform_multi_index`
-void test_tensor_index_transformation_rank_0() {
+inline void test_tensor_index_transformation_rank_0() {
   const std::array<size_t, 0> index_order = {};
 
   const std::array<size_t, 0> actual_transformation =

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorIndexTransformationTimeIndex.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorIndexTransformationTimeIndex.hpp
@@ -18,7 +18,7 @@ namespace TestHelpers::tenex {
 /// \details The functions tested are:
 /// - `tenex::compute_tensorindex_transformation`
 /// - `tenex::transform_multi_index`
-void test_tensor_index_transformation_with_time_indices() {
+inline void test_tensor_index_transformation_with_time_indices() {
   const std::array<size_t, 0> index_order_empty = {};
   const std::array<size_t, 1> index_order_t = {ti::t.value};
   const std::array<size_t, 3> index_order_atb = {ti::a.value, ti::t.value,

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
@@ -127,7 +127,7 @@ using operator_applied_to_fields_tag =
 // entry of the vectors provided in the input file. This function translates the
 // element to an index into these vectors. We assume the domain is composed of a
 // single block.
-size_t get_index(const ElementId<1>& element_id) {
+inline size_t get_index(const ElementId<1>& element_id) {
   return element_id.segment_id(0).index();
 }
 

--- a/tests/Unit/Helpers/Tests/Test_MakeRandomVectorInMagnitudeRange.cpp
+++ b/tests/Unit/Helpers/Tests/Test_MakeRandomVectorInMagnitudeRange.cpp
@@ -11,6 +11,7 @@
 #include "Helpers/DataStructures/MakeRandomVectorInMagnitudeRange.hpp"
 #include "Helpers/PointwiseFunctions/GeneralRelativity/TestHelpers.hpp"
 
+namespace {
 void check_random_values(const double v, const double bound1,
                          const double bound2) {
   CHECK(approx(v) >= std::min(bound1, bound2));
@@ -109,6 +110,7 @@ void test_range(const gsl::not_null<std::mt19937*> generator,
 
   check_random_values(vector_mag, r1, r2);
 }
+}  // namespace
 
 SPECTRE_TEST_CASE("Test.TestHelpers.MakeRandomVectorInMagnitudeRange",
                   "[Unit]") {

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderActions.cpp
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderActions.cpp
@@ -89,8 +89,6 @@ struct Metavariables {
                                     MockVolumeDataReader<Metavariables>>;
 };
 
-}  // namespace
-
 void test_actions(const std::variant<double, importers::ObservationSelector>&
                       observation_selection) {
   using reader_component = MockVolumeDataReader<Metavariables>;
@@ -234,6 +232,7 @@ void test_actions(const std::variant<double, importers::ObservationSelector>&
     }
   }
 }
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.IO.Importers.VolumeDataReaderActions", "[Unit][IO]") {
   test_actions(0.);

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm.hpp
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm.hpp
@@ -69,7 +69,7 @@ struct VectorFieldTag : db::SimpleTag {
 
 enum class Grid { Fine, Coarse };
 
-std::ostream& operator<<(std::ostream& os, Grid grid) {
+inline std::ostream& operator<<(std::ostream& os, Grid grid) {
   switch (grid) {
     case Grid::Fine:
       return os << "Fine";

--- a/tests/Unit/IO/Observers/Test_ReductionObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_ReductionObserver.cpp
@@ -56,7 +56,6 @@ struct FormatErrors
 // [formatter_example]
 static_assert(tt::assert_conforms_to_v<
               FormatErrors, observers::protocols::ReductionDataFormatter>);
-}  // namespace
 
 void test_reduction_observer(const bool observe_per_core) {
   using registration_list = tmpl::list<
@@ -380,6 +379,7 @@ void test_reduction_observer(const bool observe_per_core) {
     }
   });
 }
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.IO.Observers.ReductionObserver", "[Unit][Observers]") {
   test_reduction_observer(false);

--- a/tests/Unit/Parallel/Test_AlgorithmCore.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmCore.cpp
@@ -43,6 +43,8 @@ namespace db {
 template <typename TagsList>
 class DataBox;
 }  // namespace db
+
+namespace {
 struct TestMetavariables;
 template <class Metavariables>
 struct NoOpsComponent;
@@ -64,6 +66,7 @@ TestAlgorithmArrayInstance& operator++(TestAlgorithmArrayInstance& instance) {
   instance.i++;
   return instance;
 }
+}  // namespace
 
 namespace std {
 template <>
@@ -74,6 +77,7 @@ struct hash<TestAlgorithmArrayInstance> {
 };
 }  // namespace std
 
+namespace {
 struct ElementIndex {};
 
 struct CountActionsCalled : db::SimpleTag {
@@ -678,6 +682,7 @@ struct TestMetavariables {
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/) {}
 };
+}  // namespace
 
 // [charm_init_funcs_example]
 static const std::vector<void (*)()> charm_init_node_funcs{

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
@@ -56,7 +56,6 @@ struct MockMetavariables {
                      MockMetavariables, InterpolationTargetA>,
                  InterpTargetTestHelpers::mock_interpolator<MockMetavariables>>;
 };
-}  // namespace
 
 void test_interpolation_target_kerr_horizon(
     const intrp::AngularOrdering angular_ordering) {
@@ -165,6 +164,7 @@ void test_interpolation_target_kerr_horizon(
       intrp::Tags::KerrHorizon<MockMetavariables::InterpolationTargetA>>(
       domain_creator, kerr_horizon_opts, expected_block_coord_holders);
 }
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.KerrHorizon",
                   "[Unit]") {

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetSphere.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetSphere.cpp
@@ -54,7 +54,6 @@ struct MockMetavariables {
                      MockMetavariables, InterpolationTargetA>,
                  InterpTargetTestHelpers::mock_interpolator<MockMetavariables>>;
 };
-}  // namespace
 
 void test_interpolation_target_sphere(
     const intrp::AngularOrdering angular_ordering) {
@@ -133,6 +132,7 @@ void test_interpolation_target_sphere(
       intrp::Tags::Sphere<MockMetavariables::InterpolationTargetA>>(
       domain_creator, sphere_opts, expected_block_coord_holders);
 }
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.Sphere",
                   "[Unit]") {

--- a/tools/Formaline.sh
+++ b/tools/Formaline.sh
@@ -34,6 +34,8 @@ formaline_object_output=${formaline_dir}/${formaline_archive_name}.o
 formaline_output=@CMAKE_BINARY_DIR@/tmp/${formaline_archive_name}.cpp
 rm -f ${formaline_output}
 cat >${formaline_output} <<EOF
+#include "Utilities/Formaline.hpp"
+
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
This is based on gcc's `-Wmissing-declarations`, which is for catching global functions that are defined without a declaration in the header (or anywhere else, but declarations are rarely other places).  clang also accepts the flag, but it doesn't seem to work, at least in a simple test.

I've tried to split things up by type of change, and also to separate out anything I could imagine people might object to.

This does not enable the warning in our build system or silence the warning in two places where it is expected, but I can do that if people like the idea.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
