### PR TITLE
Add XSIMD and Blaze interoperability

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -803,6 +803,7 @@ ${{ env.CACHE_KEY_SUFFIX }}"
             -D SPECTRE_TEST_TIMEOUT_FACTOR=5 \
             -D CMAKE_INSTALL_PREFIX=../install \
             -D BUILD_DOCS=OFF \
+            -D USE_XSIMD=OFF \
             $GITHUB_WORKSPACE
       - name: Build unit tests
         working-directory: build

--- a/cmake/SetupXsimd.cmake
+++ b/cmake/SetupXsimd.cmake
@@ -1,12 +1,11 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-# QUIET silences warning
-find_package(xsimd 8.1.0 QUIET)
+option(USE_XSIMD "Use xsimd if it is available" OFF)
 
-option(USE_XSIMD "Use xsimd if it is available" ON)
+if(USE_XSIMD)
+  find_package(xsimd 8.1 REQUIRED)
 
-if(USE_XSIMD AND xsimd_FOUND)
   message(STATUS "xsimd incld: ${xsimd_INCLUDE_DIRS}")
   message(STATUS "xsimd vers: ${xsimd_VERSION}")
 
@@ -27,10 +26,17 @@ if(USE_XSIMD AND xsimd_FOUND)
     APPEND PROPERTY
     INTERFACE_COMPILE_OPTIONS
     -DSPECTRE_USE_XSIMD
+    -DBLAZE_USE_XSIMD=1
     )
 
   set_property(
     GLOBAL APPEND PROPERTY SPECTRE_THIRD_PARTY_LIBS
+    xsimd
+    )
+
+  target_link_libraries(
+    Blaze
+    INTERFACE
     xsimd
     )
 endif()

--- a/docs/DevGuide/BuildSystem.md
+++ b/docs/DevGuide/BuildSystem.md
@@ -335,6 +335,12 @@ cmake -D FLAG1=OPT1 ... -D FLAGN=OPTN <SPECTRE_ROOT>
     (default is `OFF`)
   - \note Blaze isn't tested super thoroughly across different architectures so
     there's unfortunately no guarantee that Blaze+Sleef will work everywhere.
+- USE_XSIMD
+  - Whether to use [xsimd](https://github.com/xtensor-stack/xsimd) with Blaze to
+    vectorize addition math functions like `sin`, `cos`, and `exp`.
+    Defines the macro `SPECTRE_USE_XSIMD`, which can be check to enable manual
+    vectorization where necessary.
+    (default is `OFF`)
 
 ## CMake targets
 


### PR DESCRIPTION
## Proposed changes

I have a PR to Blaze open that allows Blaze to use XSIMD. This PR allows us to use that feature. The state of the Blaze PR is that I will test thorough with Intel SDE and @knelli2 will do a BBH run as well. I've run our tests with XSIMD+Blaze and that seems to be fine. Once things are merged into Blaze we can look into enabling XSIMD by default.

A future project will be to have Blaze use XSIMD on ARM to enable vectorization there.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
