### PR TITLE
Avoid roundoff error in boost odeint in QuatFoT

### DIFF
--- a/tests/Unit/Domain/FunctionsOfTime/Test_QuaternionFunctionOfTime.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_QuaternionFunctionOfTime.cpp
@@ -331,4 +331,37 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.QuaternionFunctionOfTime",
                                    custom_approx);
     }
   }
+  {
+    INFO("QuaternionFunctionOfTime: No updates");
+    const double initial_time = 0.0;
+    const double final_time = 100.0;
+
+    DataVector init_quat{1.0, 0.0, 0.0, 0.0};
+    // We use zero because we are only concerned about checking the quaternion
+    // at late times when it hasn't been updated
+    DataVector three_zero{3, 0.0};
+    // Construct QuaternionFunctionOfTime
+    domain::FunctionsOfTime::QuaternionFunctionOfTime<3> qfot{
+        initial_time, std::array<DataVector, 1>{init_quat},
+        std::array<DataVector, 4>{three_zero, three_zero, three_zero,
+                                  three_zero},
+        std::numeric_limits<double>::infinity()};
+
+    const std::array<DataVector, 3> quat_func_and_2_derivs =
+        qfot.func_and_2_derivs(final_time);
+
+    DataVector four_zero{4, 0.0};
+    {
+      INFO("  Compare quaternion");
+      CHECK_ITERABLE_APPROX(quat_func_and_2_derivs[0], init_quat);
+    }
+    {
+      INFO("  Compare derivative of quaternion");
+      CHECK_ITERABLE_APPROX(quat_func_and_2_derivs[1], four_zero);
+    }
+    {
+      INFO("  Compare second derivative of quaternion");
+      CHECK_ITERABLE_APPROX(quat_func_and_2_derivs[2], four_zero);
+    }
+  }
 }


### PR DESCRIPTION
## Proposed changes

Internally, boost does a `t - t0 < numeric_limits::epsilon` which doesn't account for relative error, forcing us to deal with it.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
