### PR TITLE
Update sphere domain creator

### DIFF
--- a/src/Domain/Creators/Python/Sphere.cpp
+++ b/src/Domain/Creators/Python/Sphere.cpp
@@ -17,9 +17,10 @@ namespace py = pybind11;
 namespace domain::creators::py_bindings {
 void bind_sphere(py::module& m) {
   py::class_<Sphere, DomainCreator<3>>(m, "Sphere")
-      .def(py::init<double, double, size_t, std::array<size_t, 2>, bool>(),
+      .def(py::init<double, double, double, size_t, std::array<size_t, 2>,
+                    bool>(),
            py::arg("inner_radius"), py::arg("outer_radius"),
-           py::arg("initial_refinement"),
+           py::arg("inner_cube_sphericity"), py::arg("initial_refinement"),
            py::arg("initial_number_of_grid_points"),
            py::arg("use_equiangular_map"));
 }

--- a/src/Domain/Creators/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/Creators/RegisterDerivedWithCharm.cpp
@@ -7,6 +7,7 @@
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/BulgedCube.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/CylindricalEndcap.hpp"

--- a/src/Domain/Creators/Sphere.cpp
+++ b/src/Domain/Creators/Sphere.cpp
@@ -6,7 +6,7 @@
 #include <cmath>
 #include <memory>
 
-#include "Domain/Block.hpp"  // IWYU pragma: keep
+#include "Domain/Block.hpp"
 #include "Domain/BoundaryConditions/None.hpp"
 #include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
@@ -16,16 +16,16 @@
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/Wedge.hpp"
-#include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
+#include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"
-#include "Domain/Structure/BlockNeighbor.hpp"  // IWYU pragma: keep
+#include "Domain/Structure/BlockNeighbor.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/MakeArray.hpp"
 
 namespace Frame {
-struct Inertial;  // IWYU pragma: keep
-struct BlockLogical;  // IWYU pragma: keep
+struct Inertial;
+struct BlockLogical;
 }  // namespace Frame
 
 namespace domain::creators {

--- a/src/Domain/Creators/Sphere.hpp
+++ b/src/Domain/Creators/Sphere.hpp
@@ -10,16 +10,10 @@
 
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Domain/BoundaryConditions/GetBoundaryConditionsBase.hpp"
-#include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
+#include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Domain.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
-
-// IWYU wants to include things we definitely don't need...
-// IWYU pragma: no_include <memory> // Needed in cpp file
-// IWYU pragma: no_include <pup.h>  // Not needed
-
-// IWYU pragma: no_include "DataStructures/Tensor/Tensor.hpp" // Not needed
 
 /// \cond
 namespace domain {

--- a/src/Domain/Creators/Sphere.hpp
+++ b/src/Domain/Creators/Sphere.hpp
@@ -20,6 +20,7 @@
 namespace domain {
 namespace CoordinateMaps {
 class Affine;
+class BulgedCube;
 class Equiangular;
 template <typename Map1, typename Map2, typename Map3>
 class ProductOf3Maps;
@@ -37,6 +38,10 @@ namespace creators {
 /// Create a 3D Domain in the shape of a sphere consisting of six wedges
 /// and a central cube. For an image showing how the wedges are aligned in
 /// this Domain, see the documentation for Shell.
+///
+/// The inner cube is a BulgedCube except if the inner cube sphericity is
+/// exactly 0. Then an Equiangular or Affine map is used (depending on if it's
+/// equiangular or not) to avoid a root find in the BulgedCube map.
 class Sphere : public DomainCreator<3> {
  private:
   using Affine = CoordinateMaps::Affine;
@@ -44,9 +49,11 @@ class Sphere : public DomainCreator<3> {
   using Equiangular = CoordinateMaps::Equiangular;
   using Equiangular3D =
       CoordinateMaps::ProductOf3Maps<Equiangular, Equiangular, Equiangular>;
+  using BulgedCube = CoordinateMaps::BulgedCube;
 
  public:
   using maps_list = tmpl::list<
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial, BulgedCube>,
       domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial, Affine3D>,
       domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                             Equiangular3D>,
@@ -62,6 +69,16 @@ class Sphere : public DomainCreator<3> {
   struct OuterRadius {
     using type = double;
     static constexpr Options::String help = {"Radius of the Sphere."};
+  };
+
+  struct InnerCubeSphericity {
+    using type = double;
+    static constexpr Options::String help = {
+        "Sphericity of inner cube. A sphericity of 0 uses a product of 1D maps "
+        "as the map in the center. A sphericity > 0 uses a BulgedCube. A "
+        "sphericity of exactly 1 is not allowed. See BulgedCube docs for why."};
+    static double lower_bound() { return 0.0; }
+    static double upper_bound() { return 1.0; }
   };
 
   struct InitialRefinement {
@@ -98,8 +115,9 @@ class Sphere : public DomainCreator<3> {
   };
 
   using basic_options =
-      tmpl::list<InnerRadius, OuterRadius, InitialRefinement, InitialGridPoints,
-                 UseEquiangularMap, TimeDependence>;
+      tmpl::list<InnerRadius, OuterRadius, InnerCubeSphericity,
+                 InitialRefinement, InitialGridPoints, UseEquiangularMap,
+                 TimeDependence>;
 
   template <typename Metavariables>
   using options = tmpl::conditional_t<
@@ -125,7 +143,7 @@ class Sphere : public DomainCreator<3> {
       "spacings in the center block."};
 
   Sphere(typename InnerRadius::type inner_radius,
-         typename OuterRadius::type outer_radius,
+         typename OuterRadius::type outer_radius, double inner_cube_sphericity,
          typename InitialRefinement::type initial_refinement,
          typename InitialGridPoints::type initial_number_of_grid_points,
          typename UseEquiangularMap::type use_equiangular_map,
@@ -157,6 +175,7 @@ class Sphere : public DomainCreator<3> {
  private:
   typename InnerRadius::type inner_radius_{};
   typename OuterRadius::type outer_radius_{};
+  double inner_cube_sphericity_{};
   typename InitialRefinement::type initial_refinement_{};
   typename InitialGridPoints::type initial_number_of_grid_points_{};
   typename UseEquiangularMap::type use_equiangular_map_ = false;

--- a/tests/Unit/Domain/Creators/Python/Test_Sphere.py
+++ b/tests/Unit/Domain/Creators/Python/Test_Sphere.py
@@ -9,6 +9,7 @@ class TestSphere(unittest.TestCase):
     def test_construction(self):
         sphere = Sphere(inner_radius=1.,
                         outer_radius=2.,
+                        inner_cube_sphericity=0.,
                         initial_refinement=1,
                         initial_number_of_grid_points=[3, 3],
                         use_equiangular_map=False)

--- a/tests/Unit/Domain/Creators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/Creators/Test_Sphere.cpp
@@ -9,6 +9,7 @@
 #include <limits>
 #include <memory>
 #include <pup.h>
+#include <string>
 #include <unordered_set>
 #include <vector>
 
@@ -23,10 +24,15 @@
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/CoordinateMaps/TimeDependent/Translation.hpp"
 #include "Domain/CoordinateMaps/Wedge.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/Sphere.hpp"
+#include "Domain/Creators/TimeDependence/None.hpp"
+#include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
+#include "Domain/Creators/TimeDependence/UniformTranslation.hpp"
 #include "Domain/Domain.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Domain/OptionTags.hpp"
 #include "Domain/Structure/BlockNeighbor.hpp"
 #include "Domain/Structure/Direction.hpp"
@@ -35,6 +41,7 @@
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Helpers/Domain/Creators/TestHelpers.hpp"
 #include "Helpers/Domain/DomainTestHelpers.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/CloneUniquePtrs.hpp"
@@ -44,6 +51,7 @@ namespace domain {
 namespace {
 using BoundaryCondVector = std::vector<DirectionMap<
     3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>;
+using Translation3D = CoordinateMaps::TimeDependent::Translation<3>;
 
 std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
 create_boundary_condition() {
@@ -70,12 +78,22 @@ auto create_boundary_conditions() {
   return boundary_conditions_all_blocks;
 }
 
+template <typename... FuncsOfTime>
 void test_sphere_construction(
     const creators::Sphere& sphere, const double inner_radius,
     const double outer_radius, const bool use_equiangular_map,
     const std::array<size_t, 2>& expected_sphere_extents,
     const std::vector<std::array<size_t, 3>>& expected_refinement_level,
-    const BoundaryCondVector& expected_boundary_conditions = {}) {
+    const BoundaryCondVector& expected_boundary_conditions = {},
+    const std::tuple<std::pair<std::string, FuncsOfTime>...>&
+        expected_functions_of_time = {},
+    const std::vector<std::unique_ptr<domain::CoordinateMapBase<
+        Frame::Grid, Frame::Inertial, 3>>>& expected_grid_to_inertial_maps = {},
+    const std::vector<
+        std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>>&
+        time_dependencies = {},
+    const std::unordered_map<std::string, double>& initial_expiration_times =
+        {}) {
   const auto domain = sphere.create_domain();
   const OrientationMap<3> aligned_orientation{};
   const OrientationMap<3> quarter_turn_ccw_about_zeta(
@@ -176,71 +194,104 @@ void test_sphere_construction(
   using Equiangular3D =
       CoordinateMaps::ProductOf3Maps<Equiangular, Equiangular, Equiangular>;
 
+  const auto make_coord_maps = [&inner_radius, &outer_radius,
+                                &use_equiangular_map](const auto frame) {
+    using TargetFrame = std::decay_t<decltype(frame)>;
+    auto local_coord_maps = make_vector_coordinate_map_base<Frame::BlockLogical,
+                                                            TargetFrame>(
+        Wedge3DMap{inner_radius, outer_radius, 0.0, 1.0, OrientationMap<3>{},
+                   use_equiangular_map},
+        Wedge3DMap{inner_radius, outer_radius, 0.0, 1.0,
+                   OrientationMap<3>{std::array<Direction<3>, 3>{
+                       {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
+                        Direction<3>::lower_zeta()}}},
+                   use_equiangular_map},
+        Wedge3DMap{inner_radius, outer_radius, 0.0, 1.0,
+                   OrientationMap<3>{std::array<Direction<3>, 3>{
+                       {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
+                        Direction<3>::lower_eta()}}},
+                   use_equiangular_map},
+        Wedge3DMap{inner_radius, outer_radius, 0.0, 1.0,
+                   OrientationMap<3>{std::array<Direction<3>, 3>{
+                       {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
+                        Direction<3>::upper_eta()}}},
+                   use_equiangular_map},
+        Wedge3DMap{inner_radius, outer_radius, 0.0, 1.0,
+                   OrientationMap<3>{std::array<Direction<3>, 3>{
+                       {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
+                        Direction<3>::upper_eta()}}},
+                   use_equiangular_map},
+        Wedge3DMap{inner_radius, outer_radius, 0.0, 1.0,
+                   OrientationMap<3>{std::array<Direction<3>, 3>{
+                       {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
+                        Direction<3>::upper_eta()}}},
+                   use_equiangular_map});
+    if (use_equiangular_map) {
+      local_coord_maps.emplace_back(
+          make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
+              Equiangular3D{
+                  Equiangular(-1.0, 1.0, -1.0 * inner_radius / sqrt(3.0),
+                              inner_radius / sqrt(3.0)),
+                  Equiangular(-1.0, 1.0, -1.0 * inner_radius / sqrt(3.0),
+                              inner_radius / sqrt(3.0)),
+                  Equiangular(-1.0, 1.0, -1.0 * inner_radius / sqrt(3.0),
+                              inner_radius / sqrt(3.0))}));
+    } else {
+      local_coord_maps.emplace_back(
+          make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
+              Affine3D{Affine(-1.0, 1.0, -1.0 * inner_radius / sqrt(3.0),
+                              inner_radius / sqrt(3.0)),
+                       Affine(-1.0, 1.0, -1.0 * inner_radius / sqrt(3.0),
+                              inner_radius / sqrt(3.0)),
+                       Affine(-1.0, 1.0, -1.0 * inner_radius / sqrt(3.0),
+                              inner_radius / sqrt(3.0))}));
+    }
+    return local_coord_maps;
+  };
+
   auto coord_maps =
-      make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
-          Wedge3DMap{inner_radius, outer_radius, 0.0, 1.0, OrientationMap<3>{},
-                     use_equiangular_map},
-          Wedge3DMap{inner_radius, outer_radius, 0.0, 1.0,
-                     OrientationMap<3>{std::array<Direction<3>, 3>{
-                         {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
-                          Direction<3>::lower_zeta()}}},
-                     use_equiangular_map},
-          Wedge3DMap{inner_radius, outer_radius, 0.0, 1.0,
-                     OrientationMap<3>{std::array<Direction<3>, 3>{
-                         {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
-                          Direction<3>::lower_eta()}}},
-                     use_equiangular_map},
-          Wedge3DMap{inner_radius, outer_radius, 0.0, 1.0,
-                     OrientationMap<3>{std::array<Direction<3>, 3>{
-                         {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
-                          Direction<3>::upper_eta()}}},
-                     use_equiangular_map},
-          Wedge3DMap{inner_radius, outer_radius, 0.0, 1.0,
-                     OrientationMap<3>{std::array<Direction<3>, 3>{
-                         {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
-                          Direction<3>::upper_eta()}}},
-                     use_equiangular_map},
-          Wedge3DMap{inner_radius, outer_radius, 0.0, 1.0,
-                     OrientationMap<3>{std::array<Direction<3>, 3>{
-                         {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
-                          Direction<3>::upper_eta()}}},
-                     use_equiangular_map});
-  if (use_equiangular_map) {
-    coord_maps.emplace_back(
-        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
-            Equiangular3D{
-                Equiangular(-1.0, 1.0, -1.0 * inner_radius / sqrt(3.0),
-                            inner_radius / sqrt(3.0)),
-                Equiangular(-1.0, 1.0, -1.0 * inner_radius / sqrt(3.0),
-                            inner_radius / sqrt(3.0)),
-                Equiangular(-1.0, 1.0, -1.0 * inner_radius / sqrt(3.0),
-                            inner_radius / sqrt(3.0))}));
-  } else {
-    coord_maps.emplace_back(
-        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
-            Affine3D{Affine(-1.0, 1.0, -1.0 * inner_radius / sqrt(3.0),
-                            inner_radius / sqrt(3.0)),
-                     Affine(-1.0, 1.0, -1.0 * inner_radius / sqrt(3.0),
-                            inner_radius / sqrt(3.0)),
-                     Affine(-1.0, 1.0, -1.0 * inner_radius / sqrt(3.0),
-                            inner_radius / sqrt(3.0))}));
-  }
-  test_domain_construction(domain, expected_block_neighbors,
-                           expected_external_boundaries, coord_maps,
-                           std::numeric_limits<double>::signaling_NaN(), {}, {},
-                           expected_boundary_conditions);
+      make_coord_maps(tmpl::conditional_t<sizeof...(FuncsOfTime) == 0,
+                                          Frame::Inertial, Frame::Grid>{});
+  test_domain_construction(
+      domain, expected_block_neighbors, expected_external_boundaries,
+      coord_maps, 10.0, sphere.functions_of_time(),
+      expected_grid_to_inertial_maps, expected_boundary_conditions);
   const auto coord_maps_copy = clone_unique_ptrs(coord_maps);
 
   Domain<3> domain_no_corners =
       expected_boundary_conditions.empty()
-          ? Domain<3>{std::move(coord_maps)}
-          : Domain<3>{std::move(coord_maps), create_boundary_conditions()};
+          ? Domain<3>{make_coord_maps(Frame::Inertial{})}
+          : Domain<3>{make_coord_maps(Frame::Inertial{}),
+                      create_boundary_conditions()};
+
+  if (sizeof...(FuncsOfTime) != 0) {
+    for (const auto& time_dependence : time_dependencies) {
+      const size_t number_of_blocks = domain_no_corners.blocks().size();
+      auto block_maps_grid_to_inertial =
+          time_dependence->block_maps_grid_to_inertial(number_of_blocks);
+      auto block_maps_grid_to_distorted =
+          time_dependence->block_maps_grid_to_distorted(number_of_blocks);
+      auto block_maps_distorted_to_inertial =
+          time_dependence->block_maps_distorted_to_inertial(number_of_blocks);
+      for (size_t block_id = 0; block_id < number_of_blocks; ++block_id) {
+        domain_no_corners.inject_time_dependent_map_for_block(
+            block_id, std::move(block_maps_grid_to_inertial[block_id]),
+            std::move(block_maps_grid_to_distorted[block_id]),
+            std::move(block_maps_distorted_to_inertial[block_id]));
+      }
+    }
+  }
 
   test_domain_construction(domain_no_corners, expected_block_neighbors,
-                           expected_external_boundaries, coord_maps_copy);
+                           expected_external_boundaries, coord_maps_copy, 10.0,
+                           sphere.functions_of_time(),
+                           expected_grid_to_inertial_maps);
 
   test_initial_domain(domain, sphere.initial_refinement_levels());
   test_initial_domain(domain_no_corners, sphere.initial_refinement_levels());
+
+  TestHelpers::domain::creators::test_functions_of_time(
+      sphere, expected_functions_of_time, initial_expiration_times);
 
   Parallel::register_classes_with_charm(
       typename domain::creators::Sphere::maps_list{});
@@ -264,9 +315,13 @@ void test_sphere_boundaries_equiangular() {
                            grid_points_r_angular,
                            {7, make_array<3>(refinement)});
 
-  const creators::Sphere sphere_boundary_condition{
-      inner_radius,          outer_radius, refinement,
-      grid_points_r_angular, true,         create_boundary_condition()};
+  const creators::Sphere sphere_boundary_condition{inner_radius,
+                                                   outer_radius,
+                                                   refinement,
+                                                   grid_points_r_angular,
+                                                   true,
+                                                   nullptr,
+                                                   create_boundary_condition()};
   test_physical_separation(sphere_boundary_condition.create_domain().blocks());
 
   test_sphere_construction(sphere_boundary_condition, inner_radius,
@@ -277,6 +332,7 @@ void test_sphere_boundaries_equiangular() {
   CHECK_THROWS_WITH(
       creators::Sphere(
           inner_radius, outer_radius, refinement, grid_points_r_angular, true,
+          nullptr,
           std::make_unique<TestHelpers::domain::BoundaryConditions::
                                TestPeriodicBoundaryCondition<3>>(),
           Options::Context{false, {}, 1, 1}),
@@ -285,6 +341,7 @@ void test_sphere_boundaries_equiangular() {
   CHECK_THROWS_WITH(
       creators::Sphere(
           inner_radius, outer_radius, refinement, grid_points_r_angular, true,
+          nullptr,
           std::make_unique<TestHelpers::domain::BoundaryConditions::
                                TestNoneBoundaryCondition<3>>(),
           Options::Context{false, {}, 1, 1}),
@@ -311,7 +368,8 @@ void test_sphere_factory_equiangular() {
         "  OuterRadius: 3\n"
         "  InitialRefinement: 2\n"
         "  InitialGridPoints: [2,3]\n"
-        "  UseEquiangularMap: true\n" +
+        "  UseEquiangularMap: true\n"
+        "  TimeDependence: None\n" +
         (expected_boundary_conditions.empty() ? std::string{}
                                               : boundary_conditions_string()));
     const double inner_radius = 1.0;
@@ -342,9 +400,13 @@ void test_sphere_boundaries_equidistant() {
                            grid_points_r_angular,
                            {7, make_array<3>(refinement)});
 
-  const creators::Sphere sphere_boundary_condition{
-      inner_radius,          outer_radius, refinement,
-      grid_points_r_angular, false,        create_boundary_condition()};
+  const creators::Sphere sphere_boundary_condition{inner_radius,
+                                                   outer_radius,
+                                                   refinement,
+                                                   grid_points_r_angular,
+                                                   false,
+                                                   nullptr,
+                                                   create_boundary_condition()};
   test_physical_separation(sphere_boundary_condition.create_domain().blocks());
 
   test_sphere_construction(sphere_boundary_condition, inner_radius,
@@ -371,7 +433,8 @@ void test_sphere_factory_equidistant() {
         "  OuterRadius: 3\n"
         "  InitialRefinement: 2\n"
         "  InitialGridPoints: [2,3]\n"
-        "  UseEquiangularMap: false\n" +
+        "  UseEquiangularMap: false\n"
+        "  TimeDependence: None\n" +
         (expected_boundary_conditions.empty() ? std::string{}
                                               : boundary_conditions_string()));
     const double inner_radius = 1.0;
@@ -386,12 +449,82 @@ void test_sphere_factory_equidistant() {
   helper(BoundaryCondVector{}, std::false_type{});
   helper(create_boundary_conditions(), std::true_type{});
 }
+
+void test_sphere_factory_time_dependent() {
+  INFO("Sphere factory time dependent");
+  // This name must match the hard coded one in UniformTranslation
+  const std::string f_of_t_name = "Translation";
+  const auto helper = [&f_of_t_name](
+                          const std::unordered_map<std::string, double>&
+                              expiration_times) {
+    const auto domain_creator =
+        TestHelpers::test_option_tag<domain::OptionTags::DomainCreator<3>,
+                                     TestHelpers::domain::BoundaryConditions::
+                                         MetavariablesWithoutBoundaryConditions<
+                                             3, domain::creators::Sphere>>(
+            "Sphere:\n"
+            "  InnerRadius: 1\n"
+            "  OuterRadius: 3\n"
+            "  InitialRefinement: 2\n"
+            "  InitialGridPoints: [2,3]\n"
+            "  UseEquiangularMap: false\n"
+            "  TimeDependence:\n"
+            "    UniformTranslation:\n"
+            "      InitialTime: 1.0\n"
+            "      Velocity: [2.3, -0.3, 0.5]\n");
+    const auto* sphere =
+        dynamic_cast<const creators::Sphere*>(domain_creator.get());
+    const double initial_time = 1.0;
+    const double inner_radius = 1.0;
+    const double outer_radius = 3.0;
+    const size_t refinement_level = 2;
+    const std::array<size_t, 2> grid_points_r_angular{{2, 3}};
+    const bool use_equiangular_map = false;
+    const DataVector velocity{{2.3, -0.3, 0.5}};
+    std::vector<
+        std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>>
+        time_dependencies{1};
+    time_dependencies[0] = std::make_unique<
+        domain::creators::time_dependence::UniformTranslation<3>>(
+        initial_time, std::array{velocity[0], velocity[1], velocity[2]});
+    auto grid_to_inertial_maps =
+        make_vector_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+            Translation3D{f_of_t_name});
+    for (size_t i = 1; i < sphere->create_domain().blocks().size(); i++) {
+      grid_to_inertial_maps.emplace_back(
+          make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+              Translation3D{f_of_t_name}));
+    }
+
+    test_sphere_construction(
+        dynamic_cast<const creators::Sphere&>(*sphere), inner_radius,
+        outer_radius, use_equiangular_map, grid_points_r_angular,
+        {7, make_array<3>(refinement_level)}, BoundaryCondVector{},
+        std::make_tuple(
+            std::pair<std::string,
+                      domain::FunctionsOfTime::PiecewisePolynomial<2>>{
+                f_of_t_name,
+                {initial_time,
+                 std::array<DataVector, 3>{{{3, 0.0}, velocity, {3, 0.0}}},
+                 expiration_times.at(f_of_t_name)}}),
+        std::move(grid_to_inertial_maps), std::move(time_dependencies),
+        expiration_times);
+  };
+
+  std::unordered_map<std::string, double> initial_expiration_times{
+      {f_of_t_name, std::numeric_limits<double>::infinity()}};
+  helper(initial_expiration_times);
+  initial_expiration_times.at(f_of_t_name) = 10.0;
+  helper(initial_expiration_times);
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.Creators.Sphere", "[Domain][Unit]") {
+  domain::creators::time_dependence::register_derived_with_charm();
   test_sphere_boundaries_equiangular();
   test_sphere_factory_equiangular();
   test_sphere_boundaries_equidistant();
   test_sphere_factory_equidistant();
+  test_sphere_factory_time_dependent();
 }
 }  // namespace domain

--- a/tests/Unit/Domain/Creators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/Creators/Test_Sphere.cpp
@@ -13,7 +13,7 @@
 #include <vector>
 
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Domain/Block.hpp"  // IWYU pragma: keep
+#include "Domain/Block.hpp"
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
@@ -28,7 +28,7 @@
 #include "Domain/Creators/Sphere.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/OptionTags.hpp"
-#include "Domain/Structure/BlockNeighbor.hpp"  // IWYU pragma: keep
+#include "Domain/Structure/BlockNeighbor.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/OrientationMap.hpp"


### PR DESCRIPTION
## Proposed changes

Does two things to the sphere domain creator:

1. Adds time dependence
2. Uses a BulgedCube map for the inner cube. If the inner cube sphericity is exactly 0, reverts to using an Equiangular or Affine map to avoid the root find in the BulgedCube.

In my testing of scalar wave, I wanted to be able to run on a sphere that was rotating which is why I added the time dependence. Then I noticed my constraint violations were (understandably) larger around the central cube boundary so I wanted to see if smoothing out the boundary helped at all which is why I opted for a BulgedCube as the central block.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
