### PR TITLE
Initialize tuners properly for rotation

### DIFF
--- a/src/ControlSystem/Tags.cpp
+++ b/src/ControlSystem/Tags.cpp
@@ -3,6 +3,7 @@
 
 #include "ControlSystem/Tags.hpp"
 
+#include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
 namespace control_system::Tags::detail {
@@ -15,10 +16,26 @@ void initialize_tuner(
     // We get the functions of time in order to get the number of components
     // so we can resize the number of timescales. Since we are only concerned
     // with the number of components, we don't care about the initial
-    // expiration times.
+    // expiration times. Rotation is special because the number of components in
+    // the function of time is 4 (quaternion) but the number of components
+    // controlled is 3 (omega), so we hardcode this value.
     const auto functions_of_time = domain_creator->functions_of_time();
-    const size_t num_components =
-        functions_of_time.at(name)->func(initial_time)[0].size();
+    const auto& function_of_time = functions_of_time.at(name);
+
+    const auto* casted_quat_fot_2 =
+        dynamic_cast<domain::FunctionsOfTime::QuaternionFunctionOfTime<2>*>(
+            function_of_time.get());
+    const auto* casted_quat_fot_3 =
+        dynamic_cast<domain::FunctionsOfTime::QuaternionFunctionOfTime<3>*>(
+            function_of_time.get());
+
+    size_t num_components = 0;
+    if (casted_quat_fot_2 != nullptr or casted_quat_fot_3 != nullptr) {
+      num_components = 3;
+    } else {
+      num_components = function_of_time->func(initial_time)[0].size();
+    }
+
     tuner->resize_timescales(num_components);
   }
 }

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
@@ -53,7 +53,7 @@ void test_rotation_control_error() {
       "    Controller:\n"
       "      UpdateFraction: 0.3\n"
       "    TimescaleTuner:\n"
-      "      InitialTimescales: [0.5, 0.5, 0.5]\n"
+      "      InitialTimescales: 0.5\n"
       "      MinTimescale: 0.1\n"
       "      MaxTimescale: 10.\n"
       "      DecreaseThreshold: 2.0\n"

--- a/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
@@ -45,15 +45,15 @@ using CoordMap =
                           RotationMap, TranslationMap>;
 
 std::string create_input_string(const std::string& name) {
-  const std::string base_string1{"  "s + name +
-                                 ":\n"
-                                 "    Averager:\n"
-                                 "      AverageTimescaleFraction: 0.25\n"
-                                 "      Average0thDeriv: true\n"
-                                 "    Controller:\n"
-                                 "      UpdateFraction: 0.3\n"
-                                 "    TimescaleTuner:\n"};
-  const std::string base_string2{
+  const std::string name_str = "  "s + name + ":\n"s;
+  const std::string base_string1{
+      "    Averager:\n"
+      "      AverageTimescaleFraction: 0.25\n"
+      "      Average0thDeriv: true\n"
+      "    Controller:\n"
+      "      UpdateFraction: 0.3\n"
+      "    TimescaleTuner:\n"
+      "      InitialTimescales: 0.5\n"
       "      MinTimescale: 0.1\n"
       "      MaxTimescale: 10.\n"
       "      DecreaseThreshold: 2.0\n"
@@ -62,12 +62,7 @@ std::string create_input_string(const std::string& name) {
       "      DecreaseFactor: 0.99\n"
       "    ControlError:\n"};
 
-  const std::string timescales =
-      (name == "Rotation"s or name == "Translation"s)
-          ? "      InitialTimescales: [0.5, 0.5, 0.5]\n"
-          : "      InitialTimescales: [0.5]\n";
-
-  return base_string1 + timescales + base_string2;
+  return name_str + base_string1;
 }
 
 template <size_t TranslationDerivOrder, size_t RotationDerivOrder,

--- a/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
@@ -72,7 +72,7 @@ void test_rotation_control_system(const bool newtonian) {
       "    Controller:\n"
       "      UpdateFraction: 0.3\n"
       "    TimescaleTuner:\n"
-      "      InitialTimescales: [0.5, 0.5, 0.5]\n"
+      "      InitialTimescales: 0.5\n"
       "      MinTimescale: 0.1\n"
       "      MaxTimescale: 10.\n"
       "      DecreaseThreshold: 2.0\n"

--- a/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
+++ b/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
@@ -127,9 +127,17 @@ class FakeCreator : public DomainCreator<3> {
         all_functions_of_time{};
 
     for (const auto& [name, num_components] : num_components_map_) {
-      all_functions_of_time[name] =
-          std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<0>>(
-              0.0, std::array<DataVector, 1>{{{num_components, 0.0}}}, 1.0);
+      if (name == "Rotation") {
+        // Rotation always has 3
+        all_functions_of_time[name] = std::make_unique<
+            domain::FunctionsOfTime::QuaternionFunctionOfTime<2>>(
+            0.0, std::array<DataVector, 1>{{{1.0, 0.0, 0.0, 0.0}}},
+            std::array<DataVector, 3>{{{3, 0.0}, {3, 0.0}, {3, 0.0}}}, 1.0);
+      } else {
+        all_functions_of_time[name] =
+            std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<0>>(
+                0.0, std::array<DataVector, 1>{{{num_components, 0.0}}}, 1.0);
+      }
     }
 
     return all_functions_of_time;


### PR DESCRIPTION
## Proposed changes

Previously from #4223, timescale tuners had their number of components chosen based on the number of components of the corresponding function of time. However, rotation is an exception to this because it has 4 components in its function of time (quaternion) but the rotation control system only expects 3 components (omega). This checks if the function of time is a QuaternionFunctionOfTime, and if it is, hardcodes the number of components for the timescale tuner to be 3 (the correct value).

In addition to adding a test for this specifically, I also updated some of the control system tests that use rotation so it will test this way of constructing the timescale tuners.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
