### PR TITLE
Add Shape TimeDependence to Creators

### DIFF
--- a/src/Domain/Creators/TimeDependence/CMakeLists.txt
+++ b/src/Domain/Creators/TimeDependence/CMakeLists.txt
@@ -13,6 +13,7 @@ spectre_target_sources(
   ScalingAndZRotation.cpp
   RegisterDerivedWithCharm.cpp
   RotationAboutZAxis.cpp
+  Shape.cpp
   SphericalCompression.cpp
   UniformTranslation.cpp
   )
@@ -27,6 +28,7 @@ spectre_target_headers(
   RegisterDerivedWithCharm.hpp
   RotationAboutZAxis.hpp
   ScalingAndZRotation.hpp
+  Shape.hpp
   SphericalCompression.hpp
   TimeDependence.hpp
   UniformTranslation.hpp
@@ -40,6 +42,7 @@ target_link_libraries(
   Options
   Utilities
   PRIVATE
+  GeneralRelativitySolutions
   ErrorHandling
   INTERFACE
   Domain

--- a/src/Domain/Creators/TimeDependence/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/Creators/TimeDependence/RegisterDerivedWithCharm.cpp
@@ -18,6 +18,7 @@
 #include "Domain/Creators/TimeDependence/None.hpp"
 #include "Domain/Creators/TimeDependence/RotationAboutZAxis.hpp"
 #include "Domain/Creators/TimeDependence/ScalingAndZRotation.hpp"
+#include "Domain/Creators/TimeDependence/Shape.hpp"
 #include "Domain/Creators/TimeDependence/SphericalCompression.hpp"
 #include "Domain/Creators/TimeDependence/TimeDependence.hpp"
 #include "Domain/Creators/TimeDependence/UniformTranslation.hpp"

--- a/src/Domain/Creators/TimeDependence/Shape.cpp
+++ b/src/Domain/Creators/TimeDependence/Shape.cpp
@@ -1,0 +1,149 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Creators/TimeDependence/Shape.hpp"
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <ostream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/MapInstantiationMacros.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/ShapeMapTransitionFunction.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.hpp"
+#include "Domain/Creators/TimeDependence/TimeDependence.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/StdArrayHelpers.hpp"
+
+namespace domain {
+namespace creators::time_dependence {
+using SphereTransition =
+    domain::CoordinateMaps::ShapeMapTransitionFunctions::SphereTransition;
+
+Shape::Shape(const double initial_time, const size_t l_max, const double mass,
+             const std::array<double, 3> spin,
+             const std::array<double, 3> center, const double inner_radius,
+             const double outer_radius, const Options::Context& context)
+    : initial_time_(initial_time),
+      l_max_(l_max),
+      mass_(mass),
+      spin_(spin),
+      center_(center),
+      inner_radius_(inner_radius),
+      outer_radius_(outer_radius),
+      transition_func_(std::make_unique<SphereTransition>(
+          SphereTransition{inner_radius, outer_radius})) {
+  if (mass <= 0.0) {
+    PARSE_ERROR(context,
+                "Tried to create a Shape TimeDependence, but "
+                "the mass ("
+                    << mass << ") must be strictly positive.");
+  }
+  if (magnitude(spin) >= 1.0) {
+    PARSE_ERROR(context,
+                "Tried to create a Shape TimeDependence, but "
+                "the magnitude of the spin ("
+                    << spin << ") is greater than one.");
+  }
+  // There is no PARSE_ERROR for the `inner_radius` < `outer_radius` condition
+  // because the SphereTransition already checks for this condition.
+}
+
+std::unique_ptr<TimeDependence<3>> Shape::get_clone() const {
+  return std::make_unique<Shape>(initial_time_, l_max_, mass_, spin_, center_,
+                                 inner_radius_, outer_radius_);
+}
+
+std::vector<
+    std::unique_ptr<domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, 3>>>
+Shape::block_maps_grid_to_inertial(
+    const size_t number_of_blocks) const {
+  ASSERT(number_of_blocks > 0,
+         "Must have at least one block on which to create a map.");
+
+  std::vector<std::unique_ptr<
+      domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, 3>>>
+      result{number_of_blocks};
+  result[0] = std::make_unique<GridToInertialMap>(grid_to_inertial_map());
+  for (size_t i = 1; i < number_of_blocks; ++i) {
+    result[i] = result[0]->get_clone();
+  }
+  return result;
+}
+
+std::unordered_map<std::string,
+                   std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+Shape::functions_of_time(
+    const std::unordered_map<std::string, double>& initial_expiration_times)
+    const {
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      result{};
+
+  // Functions of time don't expire by default
+  double expiration_time = std::numeric_limits<double>::infinity();
+
+  // If we have control systems, overwrite the expiration time with the one
+  // supplied by the control system
+  if (initial_expiration_times.count(function_of_time_name_) == 1) {
+    expiration_time = initial_expiration_times.at(function_of_time_name_);
+  }
+
+  const YlmSpherepack ylm{l_max_, l_max_};
+  const DataVector radial_distortion =
+      1.0 - get(gr::Solutions::kerr_schild_radius_from_boyer_lindquist(
+                inner_radius_, ylm.theta_phi_points(), mass_, spin_)) /
+                inner_radius_;
+  const auto radial_distortion_coefs = ylm.phys_to_spec(radial_distortion);
+  const DataVector zeros =
+    make_with_value<DataVector>(radial_distortion_coefs, 0.0);
+  result[function_of_time_name_] =
+      std::make_unique<FunctionsOfTime::PiecewisePolynomial<3>>(
+          initial_time_,
+          std::array<DataVector, 4>{{
+            radial_distortion_coefs, zeros, zeros, zeros}},
+          expiration_time);
+  return result;
+}
+
+auto Shape::grid_to_inertial_map() const -> GridToInertialMap {
+  return GridToInertialMap{ShapeMap{center_, l_max_, l_max_,
+                                    transition_func_->get_clone(),
+                                    function_of_time_name_}};
+}
+
+bool operator==(const Shape& lhs,
+                const Shape& rhs) {
+  return lhs.initial_time_ == rhs.initial_time_ and lhs.l_max_ == rhs.l_max_ and
+         lhs.mass_ == rhs.mass_ and lhs.spin_ == rhs.spin_ and
+         lhs.center_ == rhs.center_ and
+         lhs.inner_radius_ == rhs.inner_radius_ and
+         lhs.outer_radius_ == rhs.outer_radius_;
+}
+
+bool operator!=(const Shape& lhs,
+                const Shape& rhs) {
+  return not(lhs == rhs);
+}
+}  // namespace creators::time_dependence
+
+using ShapeMap3d = CoordinateMaps::TimeDependent::Shape;
+
+INSTANTIATE_MAPS_FUNCTIONS(((ShapeMap3d)), (Frame::Grid),
+                           (Frame::Inertial), (double, DataVector))
+
+}  // namespace domain

--- a/src/Domain/Creators/TimeDependence/Shape.hpp
+++ b/src/Domain/Creators/TimeDependence/Shape.hpp
@@ -1,0 +1,189 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/Shape.hpp"
+#include "Domain/Creators/TimeDependence/GenerateCoordinateMap.hpp"
+#include "Domain/Creators/TimeDependence/TimeDependence.hpp"
+#include "Options/Auto.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace domain::FunctionsOfTime {
+class FunctionOfTime;
+}  // namespace domain::FunctionsOfTime
+namespace domain::CoordinateMaps::TimeDependent {
+class Shape;
+}  // namespace domain::CoordinateMaps::TimeDependent
+namespace domain {
+template <typename SourceFrame, typename TargetFrame, typename... Maps>
+class CoordinateMap;
+}  // namespace domain
+
+namespace Frame {
+struct Distorted;
+struct Grid;
+struct Inertial;
+}  // namespace Frame
+/// \endcond
+
+namespace domain::creators::time_dependence {
+/*!
+ * \brief A Shape whose inner surface conforms to a surface of constant
+ * Boyer-Lindquist radius, in Kerr-Schild coordinates as given by
+ * domain::CoordinateMaps::TimeDependent::Shape.
+ *
+ * \details This TimeDependence is suitable for use on a spherical shell,
+ * where LMax is the number of l and m spherical harmonics to use in
+ * approximating the Kerr horizon, of mass `Mass` and spin `Spin`. The value
+ * of the Boyer-Lindquist radius to which the inner surface conforms is given
+ * by the value of `inner_radius`. If the user wants the inner surface of the
+ * Shape to conform to a Kerr horizon for a given mass and spin, `inner_radius`
+ * should be the Boyer-Lindquist radius of the outer horizon.
+ */
+class Shape final : public TimeDependence<3> {
+ private:
+  using ShapeMap =
+      domain::CoordinateMaps::TimeDependent::Shape;
+
+ public:
+  using maps_list =
+      tmpl::list<domain::CoordinateMap<Frame::Grid, Frame::Inertial,
+                                       ShapeMap>>;
+
+  static constexpr size_t mesh_dim = 3;
+
+  /// \brief The initial time of the function of time.
+  struct InitialTime {
+    using type = double;
+    static constexpr Options::String help = {
+        "The initial time of the function of time"};
+  };
+  /// \brief The max angular resolution `l` of the Shape.
+  struct LMax {
+    using type = size_t;
+    static constexpr Options::String help = {
+        "The max l value of the Ylms used by the Shape map."};
+  };
+  /// \brief The mass of the Kerr black hole.
+  struct Mass {
+    using type = double;
+    static constexpr Options::String help = {
+        "The mass of the Kerr BH."};
+  };
+   /// \brief The dimensionless spin of the Kerr black hole.
+  struct Spin {
+    using type = std::array<double, 3>;
+    static constexpr Options::String help = {
+        "The dim'less spin of the Kerr BH."};
+  };
+  /// \brief Center for the Shape map
+  struct Center {
+    using type = std::array<double, 3>;
+    static constexpr Options::String help = {
+        "Center for the Shape map."};
+  };
+  /// \brief The inner radius of the Shape map, the radius at which
+  /// to begin applying the map.
+  struct InnerRadius {
+    using type = double;
+    static constexpr Options::String help = {
+        "The inner radius of the Shape map."};
+  };
+  /// \brief The outer radius of the Shape map, beyond which
+  /// it is no longer applied.
+  struct OuterRadius {
+    using type = double;
+    static constexpr Options::String help = {
+        "The outer radius of the Shape map."};
+  };
+
+  using GridToInertialMap =
+        detail::generate_coordinate_map_t<Frame::Grid, Frame::Inertial,
+                                          tmpl::list<ShapeMap>>;
+
+  using options = tmpl::list<InitialTime, LMax, Mass, Spin, Center, InnerRadius,
+                             OuterRadius>;
+
+  static constexpr Options::String help = {
+      "Creates a Shape that conforms to a Kerr horizon of given mass and "
+      "spin."};
+
+  Shape() = default;
+  ~Shape() override = default;
+  Shape(const Shape&) = delete;
+  Shape(Shape&&) = default;
+  Shape& operator=(const Shape&) = delete;
+  Shape& operator=(Shape&&) = default;
+
+  Shape(double initial_time, size_t l_max, double mass,
+        std::array<double, 3> spin, std::array<double, 3> center,
+        double inner_radius, double outer_radius,
+        const Options::Context& context = {});
+
+  auto get_clone() const -> std::unique_ptr<TimeDependence<mesh_dim>> override;
+
+  auto block_maps_grid_to_inertial(size_t number_of_blocks) const
+      -> std::vector<std::unique_ptr<domain::CoordinateMapBase<
+          Frame::Grid, Frame::Inertial, mesh_dim>>> override;
+
+  auto block_maps_grid_to_distorted(size_t number_of_blocks) const
+      -> std::vector<std::unique_ptr<domain::CoordinateMapBase<
+          Frame::Grid, Frame::Distorted, mesh_dim>>> override {
+    using ptr_type =
+        domain::CoordinateMapBase<Frame::Grid, Frame::Distorted, mesh_dim>;
+    return std::vector<std::unique_ptr<ptr_type>>(number_of_blocks);
+  }
+
+  auto block_maps_distorted_to_inertial(size_t number_of_blocks) const
+      -> std::vector<std::unique_ptr<domain::CoordinateMapBase<
+          Frame::Distorted, Frame::Inertial, mesh_dim>>> override {
+    using ptr_type =
+        domain::CoordinateMapBase<Frame::Distorted, Frame::Inertial, mesh_dim>;
+    return std::vector<std::unique_ptr<ptr_type>>(number_of_blocks);
+  }
+
+  auto functions_of_time(const std::unordered_map<std::string, double>&
+                             initial_expiration_times = {}) const
+      -> std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override;
+
+ private:
+  // NOLINTNEXTLINE(readability-redundant-declaration)
+  friend bool operator==(const Shape& lhs,
+                         const Shape& rhs);
+
+  using TransitionFunction = domain::CoordinateMaps::
+      ShapeMapTransitionFunctions::ShapeMapTransitionFunction;
+
+  GridToInertialMap grid_to_inertial_map() const;
+  double initial_time_{std::numeric_limits<double>::signaling_NaN()};
+  size_t l_max_{2};
+  double mass_{std::numeric_limits<double>::signaling_NaN()};
+  std::array<double, 3> spin_{
+      make_array<3>(std::numeric_limits<double>::signaling_NaN())};
+  std::array<double, 3> center_{
+      make_array<3>(std::numeric_limits<double>::signaling_NaN())};
+  inline static const std::string function_of_time_name_{"Shape"};
+  double inner_radius_{std::numeric_limits<double>::signaling_NaN()};
+  double outer_radius_{std::numeric_limits<double>::signaling_NaN()};
+  std::unique_ptr<TransitionFunction> transition_func_;
+};
+
+bool operator!=(const Shape& lhs,
+                const Shape& rhs);
+}  // namespace domain::creators::time_dependence

--- a/src/Domain/Creators/TimeDependence/TimeDependence.hpp
+++ b/src/Domain/Creators/TimeDependence/TimeDependence.hpp
@@ -32,6 +32,7 @@ template <size_t MeshDim>
 class None;
 template <size_t MeshDim>
 class ScalingAndZRotation;
+class Shape;
 class SphericalCompression;
 template <size_t MeshDim>
 class RotationAboutZAxis;
@@ -59,7 +60,7 @@ struct TimeDependence {
   using creatable_classes_2d =
       tmpl::list<RotationAboutZAxis<2>, ScalingAndZRotation<2>>;
   using creatable_classes_3d =
-      tmpl::list<SphericalCompression, RotationAboutZAxis<3>,
+      tmpl::list<Shape, SphericalCompression, RotationAboutZAxis<3>,
                  ScalingAndZRotation<3>>;
   using creatable_classes_any_dim =
       tmpl::list<CubicScale<MeshDim>, None<MeshDim>,
@@ -129,5 +130,6 @@ TimeDependence<MeshDim>::~TimeDependence() = default;
 #include "Domain/Creators/TimeDependence/None.hpp"
 #include "Domain/Creators/TimeDependence/RotationAboutZAxis.hpp"
 #include "Domain/Creators/TimeDependence/ScalingAndZRotation.hpp"
+#include "Domain/Creators/TimeDependence/Shape.hpp"
 #include "Domain/Creators/TimeDependence/SphericalCompression.hpp"
 #include "Domain/Creators/TimeDependence/UniformTranslation.hpp"

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.cpp
@@ -11,49 +11,15 @@
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
 
-namespace gr {
-namespace Solutions {
+namespace gr::Solutions {
 
 template <typename DataType>
 Scalar<DataType> kerr_horizon_radius(
     const std::array<DataType, 2>& theta_phi, const double mass,
     const std::array<double, 3>& dimensionless_spin) {
-  const double spin_magnitude_squared = square(magnitude(dimensionless_spin));
-  const double mass_squared = square(mass);
-
-  const double equatorial_radius_squared =
-      2.0 * mass_squared * (1.0 + sqrt(1.0 - spin_magnitude_squared));
-  const double polar_radius_squared =
-      mass_squared * square(1.0 + sqrt(1.0 - spin_magnitude_squared));
-
-  const auto& theta = theta_phi[0];
-  const auto& phi = theta_phi[1];
-  const DataType sin_theta = sin(theta);
-  const DataType cos_theta = cos(theta);
-  const DataType sin_phi = sin(phi);
-  const DataType cos_phi = cos(phi);
-
-  auto denominator =
-      make_with_value<DataType>(theta_phi[0], polar_radius_squared);
-  denominator += mass_squared * dimensionless_spin[0] * dimensionless_spin[0] *
-                 square(sin_theta * cos_phi);
-  denominator += mass_squared * dimensionless_spin[1] * dimensionless_spin[1] *
-                 square(sin_theta * sin_phi);
-  denominator += mass_squared * dimensionless_spin[2] * dimensionless_spin[2] *
-                 square(cos_theta);
-  denominator += 2.0 * mass_squared * dimensionless_spin[0] *
-                 dimensionless_spin[1] * square(sin_theta) * sin_phi * cos_phi;
-  denominator += 2.0 * mass_squared * dimensionless_spin[0] *
-                 dimensionless_spin[2] * sin_theta * cos_theta * cos_phi;
-  denominator += 2.0 * mass_squared * dimensionless_spin[1] *
-                 dimensionless_spin[2] * sin_theta * cos_theta * sin_phi;
-
-  auto radius_squared =
-      make_with_value<DataType>(theta_phi[0], polar_radius_squared);
-  radius_squared *= equatorial_radius_squared;
-  radius_squared /= denominator;
-
-  return Scalar<DataType>{sqrt(radius_squared)};
+  return kerr_schild_radius_from_boyer_lindquist(
+      mass * (1.0 + sqrt(1.0 - square(magnitude(dimensionless_spin)))),
+      theta_phi, mass, dimensionless_spin);
 }
 
 template Scalar<DataVector> kerr_horizon_radius(
@@ -64,6 +30,38 @@ template Scalar<double> kerr_horizon_radius(
     const std::array<double, 2>& theta_phi, const double mass,
     const std::array<double, 3>& dimensionless_spin);
 
-}  // namespace Solutions
-}  // namespace gr
+template <typename DataType>
+Scalar<DataType> kerr_schild_radius_from_boyer_lindquist(
+    const double boyer_lindquist_radius,
+    const std::array<DataType, 2>& theta_phi, const double mass,
+    const std::array<double, 3>& dimensionless_spin) {
+  const double spin_magnitude_squared = square(magnitude(dimensionless_spin));
+  const double mass_squared = square(mass);
 
+  const auto& theta = theta_phi[0];
+  const auto& phi = theta_phi[1];
+  const DataType sin_theta = sin(theta);
+  const DataType cos_theta = cos(theta);
+  const DataType sin_phi = sin(phi);
+  const DataType cos_phi = cos(phi);
+  const DataType spin_dot_unit = dimensionless_spin[0] * sin_theta * cos_phi +
+                                 dimensionless_spin[1] * sin_theta * sin_phi +
+                                 dimensionless_spin[2] * cos_theta;
+
+  return Scalar<DataType>{boyer_lindquist_radius *
+                          sqrt(square(boyer_lindquist_radius) +
+                               mass_squared * spin_magnitude_squared) /
+                          sqrt(square(boyer_lindquist_radius) +
+                               mass_squared * square(spin_dot_unit))};
+}
+
+template Scalar<DataVector> kerr_schild_radius_from_boyer_lindquist(
+    const double boyer_lindquist_radius,
+    const std::array<DataVector, 2>& theta_phi, const double mass,
+    const std::array<double, 3>& dimensionless_spin);
+
+template Scalar<double> kerr_schild_radius_from_boyer_lindquist(
+    const double boyer_lindquist_radius, const std::array<double, 2>& theta_phi,
+    const double mass, const std::array<double, 3>& dimensionless_spin);
+
+}  // namespace gr::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.hpp
@@ -7,21 +7,17 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 
-namespace gr {
-namespace Solutions {
+namespace gr::Solutions {
 
 /*!
- * \brief Radius of Kerr horizon in Kerr-Schild coordinates.
+ * \brief The Kerr-Schild radius corresponding to a Boyer-Lindquist radius.
  *
- * \details Computes the radius of a Kerr black hole as a function of
- * angles.  The input argument `theta_phi` is typically the output of
- * the `theta_phi_points()` method of a `YlmSpherepack` object; i.e.,
+ * \details Computes the radius of a surface of constant Boyer-Lindquist radius
+ * as a function of angles.  The input argument `theta_phi` is typically the
+ * output of the `theta_phi_points()` method of a `YlmSpherepack` object; i.e.,
  * a std::array of two DataVectors containing the values of theta and
  * phi at each point on a Strahlkorper.
  *
- * \note If the spin is nearly extremal, this function has accuracy
- *       limited to roughly \f$10^{-8}\f$, because of roundoff amplification
- *       from computing \f$M + \sqrt{M^2-a^2}\f$.
  *
  * Derivation:
  *
@@ -39,8 +35,7 @@ namespace Solutions {
  * \f$\hat{x}\f$ means \f$(x/r,y/r,z/r)\f$, and the dot product is
  * taken as in flat space.
  *
- * The horizon is a surface of constant \f$r_{BL}\f$. Therefore
- * we can solve the above equation for \f$r^2\f$ as a function of angles,
+ * We solve the above equation for \f$r^2\f$ as a function of angles,
  * yielding
  * \f[
  *     r^2 = \frac{r_{BL}^2 (r_{BL}^2 + a^2)}
@@ -48,19 +43,30 @@ namespace Solutions {
  * \f]
  * where the angles are encoded in \f$\hat x\f$ and everything else on the
  * right-hand side is constant.
+ */
+template <typename DataType>
+Scalar<DataType> kerr_schild_radius_from_boyer_lindquist(
+    const double boyer_lindquist_radius,
+    const std::array<DataType, 2>& theta_phi, double mass,
+    const std::array<double, 3>& dimensionless_spin);
+/*!
+ * \brief The Kerr-Schild radius corresponding to a Kerr horizon.
  *
- * `kerr_horizon_radius` evaluates \f$r\f$ using the above equation, and
+ * \details `kerr_horizon_radius` evaluates \f$r\f$ using the above equation in
+ * the documentation for `kerr_schild_radius_from_boyer_lindquist`, and
  * using the standard expression for the Boyer-Lindquist radius of the
  * Kerr horizon:
  * \f[
  *   r_{BL} = r_+ = M + \sqrt{M^2-a^2}.
  * \f]
  *
+ * \note If the spin is nearly extremal, this function has accuracy
+ *       limited to roughly \f$10^{-8}\f$, because of roundoff amplification
+ *       from computing \f$M + \sqrt{M^2-a^2}\f$.
  */
 template <typename DataType>
 Scalar<DataType> kerr_horizon_radius(
     const std::array<DataType, 2>& theta_phi, double mass,
     const std::array<double, 3>& dimensionless_spin);
 
-}  // namespace Solutions
-}  // namespace gr
+}  // namespace gr::Solutions

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Test_SphereTransition.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Test_SphereTransition.cpp
@@ -14,6 +14,8 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Shape.SphereTransition",
   SphereTransition sphere_transition{2., 4.};
   const std::array<double, 3> lower_bound{{2., 0., 0.}};
   CHECK(sphere_transition(lower_bound) == approx(1.));
+  const std::array<double, 3> midpoint{{3., 0., 0.}};
+  CHECK(sphere_transition(midpoint) == approx(1. / 3.));
   const std::array<double, 3> upper_bound{{4., 0., 0.}};
   CHECK(sphere_transition(upper_bound) == approx(0.));
 }

--- a/tests/Unit/Domain/Creators/TimeDependence/CMakeLists.txt
+++ b/tests/Unit/Domain/Creators/TimeDependence/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_None.cpp
   Test_RotationAboutZAxis.cpp
   Test_ScalingAndZRotation.cpp
+  Test_Shape.cpp
   Test_SphericalCompression.cpp
   Test_UniformTranslation.cpp
   )

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_Shape.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_Shape.cpp
@@ -1,0 +1,343 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+#include <random>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/ShapeMapTransitionFunction.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.hpp"
+#include "Domain/Creators/TimeDependence/Shape.hpp"
+#include "Domain/Creators/TimeDependence/TimeDependence.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/Domain/Creators/TimeDependence/TestHelpers.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace domain::creators::time_dependence {
+
+namespace {
+using ShapeMap = domain::CoordinateMaps::TimeDependent::Shape;
+
+using ConcreteMap =
+    domain::CoordinateMap<Frame::Grid, Frame::Inertial, ShapeMap>;
+
+using Transition =
+    domain::CoordinateMaps::ShapeMapTransitionFunctions::SphereTransition;
+
+ConcreteMap create_coord_map(
+    const std::string& f_of_t_name, const size_t l_max,
+    const std::array<double, 3>& center,
+    std::unique_ptr<domain::CoordinateMaps::ShapeMapTransitionFunctions::
+                        ShapeMapTransitionFunction>
+        transition_func) {
+  return ConcreteMap{{ShapeMap{center, l_max, l_max,
+                               transition_func->get_clone(), f_of_t_name}}};
+}
+
+template <typename Frame>
+std::array<double, 3> r_theta_phi(const tnsr::I<double, 3, Frame>& input) {
+  const double input_rho = sqrt(square(input.get(0)) + square(input.get(1)));
+  return {{magnitude(input).get(), atan2(input_rho, input.get(2)),
+           atan2(input.get(1), input.get(0))}};
+}
+
+// Takes an input point in Frame::Grid and an output point in Frame::Inertial
+// produced by a Shape CoordinateMap and compares it to an expected output
+// point corresponding to what one would obtain if an analytic mapping were
+// used instead of an expansion over spherical harmonics, as is used by the
+// Shape map. For an `l_max` of 16, this test can be expected to pass for any
+// random point mapped for a Shape map with dim'less spin magnitude < 0.65.
+void test_r_theta_phi(const tnsr::I<double, 3, Frame::Grid>& input,
+                      const tnsr::I<double, 3, Frame::Inertial>& output,
+                      const double inner_radius, const double outer_radius,
+                      const double mass, const std::array<double, 3>& spin,
+                      const std::array<double, 3>& center) {
+  auto input_centered =
+      make_with_value<tnsr::I<double, 3, Frame::Grid>>(input, 0.0);
+  auto output_centered =
+      make_with_value<tnsr::I<double, 3, Frame::Inertial>>(output, 0.0);
+  for (size_t i = 0; i < 3; i++) {
+    input_centered.get(i) = input.get(i) - gsl::at(center, i);
+    output_centered.get(i) = output.get(i) - gsl::at(center, i);
+  }
+  const auto input_centered_spherical = r_theta_phi(input_centered);
+  const auto output_centered_spherical = r_theta_phi(output_centered);
+  const std::array<double, 2> input_theta_phi = {
+      {input_centered_spherical[1], input_centered_spherical[2]}};
+  CHECK(input_theta_phi[0] == approx(output_centered_spherical[1]));
+  CHECK(input_theta_phi[1] == approx(output_centered_spherical[2]));
+  const double kerr_schild_radius =
+      gr::Solutions::kerr_schild_radius_from_boyer_lindquist(
+          inner_radius, input_theta_phi, mass, spin)
+          .get();
+  const double transition_factor =
+      std::make_unique<Transition>(Transition{inner_radius, outer_radius})
+          ->
+          operator()({{magnitude(input_centered).get(), 0.0, 0.0}});
+  const double expected_output_centered_spherical =
+      input_centered_spherical[0] *
+      (1.0 +
+       transition_factor * (kerr_schild_radius - inner_radius) / inner_radius);
+  CHECK(output_centered_spherical[0] ==
+        approx(expected_output_centered_spherical));
+}
+
+void test(const std::unique_ptr<TimeDependence<3>>& time_dep_unique_ptr,
+          const double initial_time, const std::string& f_of_t_name,
+          const size_t l_max,
+          std::unique_ptr<domain::CoordinateMaps::ShapeMapTransitionFunctions::
+                              ShapeMapTransitionFunction>
+              transition_func,
+          const double inner_radius, const double outer_radius,
+          const double mass, const std::array<double, 3>& spin,
+          const std::array<double, 3>& center) {
+  MAKE_GENERATOR(gen);
+  CAPTURE(initial_time);
+  CAPTURE(f_of_t_name);
+  CAPTURE(l_max);
+  CAPTURE(spin);
+  CAPTURE(center);
+
+  CHECK_FALSE(time_dep_unique_ptr->is_none());
+
+  // We downcast to the expected derived class to make sure that factory
+  // creation worked correctly. In order to maximize code reuse this check is
+  // done here as opposed to separately elsewhere.
+  const auto* const time_dep =
+      dynamic_cast<const Shape*>(time_dep_unique_ptr.get());
+  REQUIRE(time_dep != nullptr);
+
+  // Test coordinate maps
+  UniformCustomDistribution<size_t> dist_size_t{1, 10};
+  const size_t num_blocks = dist_size_t(gen);
+  CAPTURE(num_blocks);
+  const auto expected_block_map = create_coord_map(
+      f_of_t_name, l_max, center, transition_func->get_clone());
+  const auto block_maps =
+      time_dep_unique_ptr->block_maps_grid_to_inertial(num_blocks);
+  for (const auto& block_map_unique_ptr : block_maps) {
+    const auto* const block_map =
+        dynamic_cast<const ConcreteMap*>(block_map_unique_ptr.get());
+    REQUIRE(block_map != nullptr);
+    CHECK(*block_map == expected_block_map);
+  }
+
+  // Check that maps involving distorted frame are empty.
+  CHECK(time_dep_unique_ptr->block_maps_grid_to_distorted(1)[0].get() ==
+        nullptr);
+  CHECK(time_dep_unique_ptr->block_maps_distorted_to_inertial(1)[0].get() ==
+        nullptr);
+
+  // Test functions of time without expiration times
+  {
+    const auto functions_of_time = time_dep_unique_ptr->functions_of_time();
+    REQUIRE(functions_of_time.size() == 1);
+    CHECK(functions_of_time.count(f_of_t_name) == 1);
+    CHECK(functions_of_time.at(f_of_t_name)->time_bounds()[1] ==
+          std::numeric_limits<double>::infinity());
+  }
+  // Test functions of time with expiration times
+  {
+    const double init_expr_time = 5.0;
+    std::unordered_map<std::string, double> init_expr_times{};
+    init_expr_times[f_of_t_name] = init_expr_time;
+    const auto functions_of_time =
+        time_dep_unique_ptr->functions_of_time(init_expr_times);
+    REQUIRE(functions_of_time.size() == 1);
+    CHECK(functions_of_time.count(f_of_t_name) == 1);
+    CHECK(functions_of_time.at(f_of_t_name)->time_bounds()[1] ==
+          init_expr_time);
+  }
+
+  const auto functions_of_time = time_dep_unique_ptr->functions_of_time();
+
+  // For a random point at a random time check that the values agree. This is
+  // to check that the internals were assigned the correct function of times.
+  // The points are are drawn from the positive x/y/z quadrant such that their
+  // radii lie between inner_radius and outer_radius.
+  TIME_DEPENDENCE_GENERATE_COORDS(make_not_null(&gen), 3,
+                                  inner_radius / sqrt(3.0),
+                                  outer_radius / sqrt(3.0));
+
+  for (const auto& block_map : block_maps) {
+    // We've checked equivalence above
+    // (CHECK(*block_map == expected_block_map);), but have sometimes been
+    // burned by incorrect operator== implementations so we check that the
+    // mappings behave as expected.
+    const double check_time = initial_time + dist(gen) + 1.2;
+    CHECK_ITERABLE_APPROX(
+        expected_block_map(grid_coords_dv, check_time, functions_of_time),
+        (*block_map)(grid_coords_dv, check_time, functions_of_time));
+    CHECK_ITERABLE_APPROX(
+        expected_block_map(grid_coords_double, check_time, functions_of_time),
+        (*block_map)(grid_coords_double, check_time, functions_of_time));
+
+    CHECK_ITERABLE_APPROX(
+        *expected_block_map.inverse(inertial_coords_double, check_time,
+                                    functions_of_time),
+        *block_map->inverse(inertial_coords_double, check_time,
+                            functions_of_time));
+
+    CHECK_ITERABLE_APPROX(
+        expected_block_map.inv_jacobian(grid_coords_dv, check_time,
+                                        functions_of_time),
+        block_map->inv_jacobian(grid_coords_dv, check_time, functions_of_time));
+    CHECK_ITERABLE_APPROX(
+        expected_block_map.inv_jacobian(grid_coords_double, check_time,
+                                        functions_of_time),
+        block_map->inv_jacobian(grid_coords_double, check_time,
+                                functions_of_time));
+
+    CHECK_ITERABLE_APPROX(
+        expected_block_map.jacobian(grid_coords_dv, check_time,
+                                    functions_of_time),
+        block_map->jacobian(grid_coords_dv, check_time, functions_of_time));
+    CHECK_ITERABLE_APPROX(
+        expected_block_map.jacobian(grid_coords_double, check_time,
+                                    functions_of_time),
+        block_map->jacobian(grid_coords_double, check_time, functions_of_time));
+    // Initialize a non spherical shape and make sure the values match
+    // kerr map takes mass and spin, gives radius at different theta phis
+    // get modal coefficients from SPHEREPACK (ylms corresponding to r(theta,
+    // phi) keep in mind how this interacts with r==0, consider an assert.
+    const auto output_point =
+        (*block_map)(grid_coords_double, check_time, functions_of_time);
+    test_r_theta_phi(grid_coords_double, output_point, inner_radius,
+                     outer_radius, mass, spin, center);
+  }
+}
+
+void test_equivalence() {
+  const double mass = 1.0;
+  const std::array<double, 3> spin1 = {{0.0, 0.5, 0.1}};
+  const std::array<double, 3> spin2 = {{0.3, 0.2, 0.0}};
+  const std::array<double, 3> center1 = {{-0.2, 1.3, 2.4}};
+  const std::array<double, 3> center2 = {{0.2, -1.3, 2.4}};
+  const double inner_radius = 1.0;
+  const double outer_radius1 = 10.0;
+  const double outer_radius2 = 20.0;
+
+  Shape sc0{1.0, 4, mass, spin1, center1, inner_radius, outer_radius1};
+  Shape sc1{1.0, 4, mass, spin1, center1, inner_radius, outer_radius1};
+  Shape sc2{1.0, 4, mass, spin2, center1, inner_radius, outer_radius1};
+  Shape sc3{1.0, 4, mass, spin2, center1, inner_radius, outer_radius1};
+  Shape sc4{1.0, 4, mass, spin1, center2, inner_radius, outer_radius2};
+  Shape sc5{1.0, 4, mass, spin1, center2, inner_radius, outer_radius2};
+  Shape sc6{1.0, 4, mass, spin2, center2, inner_radius, outer_radius2};
+  Shape sc7{1.0, 4, mass, spin2, center2, inner_radius, outer_radius2};
+
+  CHECK(sc0 == sc0);
+  CHECK_FALSE(sc0 != sc0);
+  CHECK(sc0 == sc1);
+  CHECK_FALSE(sc0 != sc1);
+  CHECK(sc0 != sc2);
+  CHECK_FALSE(sc0 == sc2);
+  CHECK(sc0 != sc3);
+  CHECK_FALSE(sc0 == sc3);
+  CHECK(sc0 != sc4);
+  CHECK_FALSE(sc0 == sc4);
+  CHECK(sc0 != sc5);
+  CHECK_FALSE(sc0 == sc5);
+  CHECK(sc0 != sc6);
+  CHECK_FALSE(sc0 == sc6);
+  CHECK(sc0 != sc7);
+  CHECK_FALSE(sc0 == sc7);
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependence.Shape",
+                  "[Domain][Unit]") {
+  constexpr double initial_time{1.3};
+  // l_max of 16 needed to pass tests using `approx` as tests
+  // compare ylm output with analytic solution.
+  constexpr size_t l_max{16};
+  constexpr double mass{1.0};
+  const std::array<double, 3> spin{{0.1, 0.4, -0.5}};
+  const std::array<double, 3> center{{-0.02, 0.013, 0.024}};
+  const double inner_radius = 2.0;
+  const double outer_radius = 100;
+  const Transition sphere_transition{inner_radius, outer_radius};
+  // This name must match the hard coded one in Shape
+  const std::string f_of_t_name = "Shape";
+
+  const std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
+      time_dep = std::make_unique<Shape>(initial_time, l_max, mass, spin,
+                                         center, inner_radius, outer_radius);
+  test(time_dep, initial_time, f_of_t_name, l_max,
+       std::make_unique<Transition>(sphere_transition), inner_radius,
+       outer_radius, mass, spin, center);
+  test(time_dep->get_clone(), initial_time, f_of_t_name, l_max,
+       std::make_unique<Transition>(sphere_transition), inner_radius,
+       outer_radius, mass, spin, center);
+
+  test(TestHelpers::test_creation<std::unique_ptr<TimeDependence<3>>>(
+           "Shape:\n"
+           "  InitialTime: 1.3\n"
+           "  LMax: 16\n"
+           "  Mass: 1.0\n"
+           "  Spin: [0.1, 0.4, -0.5]\n"
+           "  Center: [-0.02, 0.013, 0.024]\n"
+           "  InnerRadius: 2.0\n"
+           "  OuterRadius: 100.0\n"),
+       initial_time, f_of_t_name, l_max,
+       std::make_unique<Transition>(sphere_transition), inner_radius,
+       outer_radius, mass, spin, center);
+  test_equivalence();
+
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<std::unique_ptr<TimeDependence<3>>>(
+          "Shape:\n"
+          "  InitialTime: 1.3\n"
+          "  LMax: 4\n"
+          "  Mass: 1.0\n"
+          "  Spin: [0.0, 1.0, 0.1]\n"
+          "  Center: [-0.01, 0.02, 0.01]\n"
+          "  InnerRadius: 1.0\n"
+          "  OuterRadius: 10.0\n"),
+      Catch::Contains("Tried to create a Shape TimeDependence, but the "
+                      "magnitude of the spin"));
+
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<std::unique_ptr<TimeDependence<3>>>(
+          "Shape:\n"
+          "  InitialTime: 1.3\n"
+          "  LMax: 4\n"
+          "  Mass: 1.0\n"
+          "  Spin: [0.0, 1.0, 0.1]\n"
+          "  Center: [-0.01, 0.02, 0.01]\n"
+          "  InnerRadius: 10.0\n"
+          "  OuterRadius: 1.0\n"),
+      Catch::Contains(
+          "The maximum radius must be greater than the minimum radius"));
+
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<std::unique_ptr<TimeDependence<3>>>(
+          "Shape:\n"
+          "  InitialTime: 1.3\n"
+          "  LMax: 4\n"
+          "  Mass: -1.0\n"
+          "  Spin: [0.0, 1.0, 0.1]\n"
+          "  Center: [-0.01, 0.02, 0.01]\n"
+          "  InnerRadius: 1.0\n"
+          "  OuterRadius: 10.0\n"),
+      Catch::Contains("Tried to create a Shape TimeDependence, but the mass"));
+}
+
+}  // namespace
+}  // namespace domain::creators::time_dependence

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_KerrHorizon.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_KerrHorizon.cpp
@@ -13,8 +13,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 
-namespace gr {
-namespace Solutions {
+namespace gr::Solutions {
 namespace {
 
 // This wraps the kerr_horizon_radius function with
@@ -95,6 +94,19 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Gr.KerrHorizon",
           {{acos(0.3 / sqrt(0.14)) + M_PI_2, atan2(0.2, 0.1)}}, 2.0,
           {{one_minus_eps * 0.1 / sqrt(0.14), one_minus_eps * 0.2 / sqrt(0.14),
             one_minus_eps * 0.3 / sqrt(0.14)}})));
+
+  {
+    const double mass = 0.45;
+    const std::array<double, 3> dimless_spin{{0., 0.3, 0.5}};
+    const double r_plus =
+        mass * (1. + sqrt(1. - dot(dimless_spin, dimless_spin)));
+    const DataVector theta{0., M_PI_4 * 0.34, M_PI_4, M_PI_2 * 0.67, M_PI_2};
+    const DataVector phi{M_PI_2 * 0.4, M_PI * 0.55, M_PI_4, M_PI_4 * 1.2, M_PI};
+    const std::array<DataVector, 2> theta_phi{
+        {std::move(theta), std::move(phi)}};
+    CHECK_ITERABLE_APPROX(kerr_schild_radius_from_boyer_lindquist(
+                              r_plus, theta_phi, mass, dimless_spin),
+                          kerr_horizon_radius(theta_phi, mass, dimless_spin));
+  }
 }
-}  // namespace Solutions
-}  // namespace gr
+}  // namespace gr::Solutions


### PR DESCRIPTION
## Proposed changes

Adds to Domain/Creators/TimeDependence a Shape creator so that existing domains (e.g. Shell) can add as an additional option a Shape that takes in Kerr parameters and produces maps with the corresponding ylms to produce the Kerr shape. The linear falloff is hard-coded in this Creator.

Also included is an additional test to Test_SphereTransition that I thought was missing.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->