### PR TITLE
Ensure random_lapse is not too close to zero

### DIFF
--- a/tests/Unit/Helpers/PointwiseFunctions/GeneralRelativity/TestHelpers.cpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/GeneralRelativity/TestHelpers.cpp
@@ -13,7 +13,7 @@ namespace TestHelpers::gr {
 template <typename DataType>
 Scalar<DataType> random_lapse(const gsl::not_null<std::mt19937*> generator,
                               const DataType& used_for_size) {
-  std::uniform_real_distribution<> distribution(0.0, 3.0);
+  std::uniform_real_distribution<> distribution(0.1, 3.0);
   return make_with_random_values<Scalar<DataType>>(
       generator, make_not_null(&distribution), used_for_size);
 }


### PR DESCRIPTION
## Proposed changes

Ensure that the random lapse used in unit tests is not too close to zero, because some quantities we would like to test (such as the spacetime normal vector) scale as 1/lapse. Fixes #4379.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
