### PR TITLE
Don't dump volume data from the interpolator upon failure

### DIFF
--- a/src/ParallelAlgorithms/Interpolation/Interpolator.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Interpolator.hpp
@@ -43,20 +43,15 @@ struct Interpolator {
       detail::get_interpolation_target_tag<tmpl::_1>>;
   using all_temporal_ids = tmpl::remove_duplicates<tmpl::transform<
       all_interpolation_target_tags, detail::get_temporal_id<tmpl::_1>>>;
-  using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<
-          Parallel::Phase::Initialization,
-          tmpl::list<Actions::InitializeInterpolator<
-                         tmpl::transform<
-                             all_temporal_ids,
-                             tmpl::bind<Tags::VolumeVarsInfo,
-                                        tmpl::pin<Metavariables>, tmpl::_1>>,
-                         Tags::InterpolatedVarsHolders<Metavariables>>,
-                     Parallel::Actions::TerminatePhase>>,
-      Parallel::PhaseActions<
-          Parallel::Phase::PostFailureCleanup,
-          tmpl::list<Actions::DumpInterpolatorVolumeData<all_temporal_ids>,
-                     Parallel::Actions::TerminatePhase>>>;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      Parallel::Phase::Initialization,
+      tmpl::list<
+          Actions::InitializeInterpolator<
+              tmpl::transform<all_temporal_ids,
+                              tmpl::bind<Tags::VolumeVarsInfo,
+                                         tmpl::pin<Metavariables>, tmpl::_1>>,
+              Tags::InterpolatedVarsHolders<Metavariables>>,
+          Parallel::Actions::TerminatePhase>>>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
   static void execute_next_phase(


### PR DESCRIPTION
## Proposed changes

Until I can figure out the issues that are occurring when dumping volume data form the interpolator during the cleanup phase, probably best to just remove it for now.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
