### PR TITLE
Split boundary conditions out of Domain

### DIFF
--- a/src/Domain/Block.hpp
+++ b/src/Domain/Block.hpp
@@ -11,10 +11,9 @@
 #include <memory>
 #include <unordered_set>
 
-#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
-#include "Domain/CoordinateMaps/CoordinateMap.hpp"  // IWYU pragma: keep
-#include "Domain/Structure/BlockNeighbor.hpp"       // IWYU pragma: keep
-#include "Domain/Structure/Direction.hpp"           // IWYU pragma: keep
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/Structure/BlockNeighbor.hpp"
+#include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 
 /// \cond
@@ -48,16 +47,9 @@ class Block {
   /// \param id a unique ID.
   /// \param neighbors info about the Blocks that share a codimension 1
   /// boundary with this Block.
-  /// \param external_boundary_conditions the boundary conditions to be applied
-  ///        at external boundaries. Can be either empty or one per each
-  ///        external boundary
   Block(std::unique_ptr<domain::CoordinateMapBase<
             Frame::BlockLogical, Frame::Inertial, VolumeDim>>&& stationary_map,
-        size_t id, DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbors,
-        DirectionMap<
-            VolumeDim,
-            std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>
-            external_boundary_conditions = {});
+        size_t id, DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbors);
 
   Block() = default;
   ~Block() = default;
@@ -143,14 +135,6 @@ class Block {
     return external_boundaries_;
   }
 
-  /// The boundary conditions to apply at the external boundaries of the Block.
-  const DirectionMap<
-      VolumeDim,
-      std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>&
-  external_boundary_conditions() const {
-    return external_boundary_conditions_;
-  }
-
   /// Serialization for Charm++
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p);
@@ -180,9 +164,6 @@ class Block {
   size_t id_{0};
   DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbors_;
   std::unordered_set<Direction<VolumeDim>> external_boundaries_;
-  DirectionMap<VolumeDim,
-               std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>
-      external_boundary_conditions_;
 };
 
 template <size_t VolumeDim>

--- a/src/Domain/Creators/AlignedLattice.hpp
+++ b/src/Domain/Creators/AlignedLattice.hpp
@@ -13,8 +13,9 @@
 #include "DataStructures/Index.hpp"
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Domain/BoundaryConditions/GetBoundaryConditionsBase.hpp"
-#include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
+#include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Domain.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/TMPL.hpp"
@@ -211,6 +212,11 @@ class AlignedLattice : public DomainCreator<VolumeDim> {
   ~AlignedLattice() override = default;
 
   Domain<VolumeDim> create_domain() const override;
+
+  std::vector<DirectionMap<
+      VolumeDim,
+      std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
+  external_boundary_conditions() const override;
 
   std::vector<std::array<size_t, VolumeDim>> initial_extents() const override;
 

--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -21,6 +21,7 @@
 #include "Domain/CoordinateMaps/Distribution.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Domain.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
 #include "Options/Auto.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
@@ -645,6 +646,10 @@ class BinaryCompactObject : public DomainCreator<3> {
   ~BinaryCompactObject() override = default;
 
   Domain<3> create_domain() const override;
+
+  std::vector<DirectionMap<
+      3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
+  external_boundary_conditions() const override;
 
   std::vector<std::array<size_t, 3>> initial_extents() const override {
     return initial_number_of_grid_points_;

--- a/src/Domain/Creators/Brick.hpp
+++ b/src/Domain/Creators/Brick.hpp
@@ -16,6 +16,7 @@
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Creators/TimeDependence/TimeDependence.hpp"
 #include "Domain/Domain.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/TMPL.hpp"
@@ -133,6 +134,10 @@ class Brick : public DomainCreator<3> {
   ~Brick() override = default;
 
   Domain<3> create_domain() const override;
+
+  std::vector<DirectionMap<
+      3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
+  external_boundary_conditions() const override;
 
   std::vector<std::array<size_t, 3>> initial_extents() const override;
 

--- a/src/Domain/Creators/CMakeLists.txt
+++ b/src/Domain/Creators/CMakeLists.txt
@@ -60,6 +60,7 @@ target_link_libraries(
   PUBLIC
   CoordinateMaps
   DataStructures
+  DomainBoundaryConditions
   DomainTimeDependence
   INTERFACE
   Domain

--- a/src/Domain/Creators/Cylinder.hpp
+++ b/src/Domain/Creators/Cylinder.hpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cstddef>
+#include <memory>
 #include <unordered_map>
 #include <unordered_set>
 #include <variant>
@@ -15,6 +16,7 @@
 #include "Domain/CoordinateMaps/Distribution.hpp"
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Domain.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -273,6 +275,10 @@ class Cylinder : public DomainCreator<3> {
   ~Cylinder() override = default;
 
   Domain<3> create_domain() const override;
+
+  std::vector<DirectionMap<
+      3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
+  external_boundary_conditions() const override;
 
   std::vector<std::array<size_t, 3>> initial_extents() const override;
 

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
@@ -18,6 +18,7 @@
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/TimeDependence/TimeDependence.hpp"
 #include "Domain/Domain.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -284,6 +285,10 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
   ~CylindricalBinaryCompactObject() override = default;
 
   Domain<3> create_domain() const override;
+
+  std::vector<DirectionMap<
+      3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
+  external_boundary_conditions() const override;
 
   std::vector<std::array<size_t, 3>> initial_extents() const override;
 

--- a/src/Domain/Creators/Disk.hpp
+++ b/src/Domain/Creators/Disk.hpp
@@ -12,6 +12,7 @@
 #include "Domain/BoundaryConditions/GetBoundaryConditionsBase.hpp"
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Domain.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -127,6 +128,10 @@ class Disk : public DomainCreator<2> {
   ~Disk() override = default;
 
   Domain<2> create_domain() const override;
+
+  std::vector<DirectionMap<
+      2, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
+  external_boundary_conditions() const override;
 
   std::vector<std::array<size_t, 2>> initial_extents() const override;
 

--- a/src/Domain/Creators/DomainCreator.hpp
+++ b/src/Domain/Creators/DomainCreator.hpp
@@ -15,10 +15,14 @@
 #include <vector>
 
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
 
 /// \cond
 template <size_t>
 class Domain;
+namespace domain::BoundaryConditions {
+class BoundaryCondition;
+}
 /// \endcond
 
 namespace domain {
@@ -40,6 +44,12 @@ class DomainCreator {
   virtual ~DomainCreator() = default;
 
   virtual Domain<VolumeDim> create_domain() const = 0;
+
+  /// The set of external boundary condition for every block in the domain
+  virtual std::vector<DirectionMap<
+      VolumeDim,
+      std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
+  external_boundary_conditions() const = 0;
 
   /// A human-readable name for every block, or empty if the domain creator
   /// doesn't support block names (yet).

--- a/src/Domain/Creators/FrustalCloak.hpp
+++ b/src/Domain/Creators/FrustalCloak.hpp
@@ -15,6 +15,7 @@
 #include "Domain/BoundaryConditions/GetBoundaryConditionsBase.hpp"
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Domain.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -144,6 +145,10 @@ class FrustalCloak : public DomainCreator<3> {
   ~FrustalCloak() override = default;
 
   Domain<3> create_domain() const override;
+
+  std::vector<DirectionMap<
+      3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
+  external_boundary_conditions() const override;
 
   std::vector<std::array<size_t, 3>> initial_extents() const override;
 

--- a/src/Domain/Creators/Interval.hpp
+++ b/src/Domain/Creators/Interval.hpp
@@ -16,6 +16,7 @@
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Creators/TimeDependence/TimeDependence.hpp"
 #include "Domain/Domain.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/TMPL.hpp"
@@ -140,6 +141,10 @@ class Interval : public DomainCreator<1> {
   ~Interval() override = default;
 
   Domain<1> create_domain() const override;
+
+  std::vector<DirectionMap<
+      1, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
+  external_boundary_conditions() const override;
 
   std::vector<std::array<size_t, 1>> initial_extents() const override;
 

--- a/src/Domain/Creators/Rectangle.hpp
+++ b/src/Domain/Creators/Rectangle.hpp
@@ -16,6 +16,7 @@
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Creators/TimeDependence/TimeDependence.hpp"
 #include "Domain/Domain.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/TMPL.hpp"
@@ -130,6 +131,10 @@ class Rectangle : public DomainCreator<2> {
   ~Rectangle() override = default;
 
   Domain<2> create_domain() const override;
+
+  std::vector<DirectionMap<
+      2, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
+  external_boundary_conditions() const override;
 
   std::vector<std::array<size_t, 2>> initial_extents() const override;
 

--- a/src/Domain/Creators/RotatedBricks.hpp
+++ b/src/Domain/Creators/RotatedBricks.hpp
@@ -13,6 +13,7 @@
 #include "Domain/BoundaryConditions/GetBoundaryConditionsBase.hpp"
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Domain.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -191,6 +192,10 @@ class RotatedBricks : public DomainCreator<3> {
   ~RotatedBricks() override = default;
 
   Domain<3> create_domain() const override;
+
+  std::vector<DirectionMap<
+      3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
+  external_boundary_conditions() const override;
 
   std::vector<std::array<size_t, 3>> initial_extents() const override;
 

--- a/src/Domain/Creators/RotatedIntervals.hpp
+++ b/src/Domain/Creators/RotatedIntervals.hpp
@@ -16,6 +16,7 @@
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Creators/TimeDependence/TimeDependence.hpp"
 #include "Domain/Domain.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -164,6 +165,10 @@ class RotatedIntervals : public DomainCreator<1> {
   ~RotatedIntervals() override = default;
 
   Domain<1> create_domain() const override;
+
+  std::vector<DirectionMap<
+      1, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
+  external_boundary_conditions() const override;
 
   std::vector<std::array<size_t, 1>> initial_extents() const override;
 

--- a/src/Domain/Creators/RotatedRectangles.hpp
+++ b/src/Domain/Creators/RotatedRectangles.hpp
@@ -13,6 +13,7 @@
 #include "Domain/BoundaryConditions/GetBoundaryConditionsBase.hpp"
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Domain.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -151,6 +152,10 @@ class RotatedRectangles : public DomainCreator<2> {
   ~RotatedRectangles() override = default;
 
   Domain<2> create_domain() const override;
+
+  std::vector<DirectionMap<
+      2, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
+  external_boundary_conditions() const override;
 
   std::vector<std::array<size_t, 2>> initial_extents() const override;
 

--- a/src/Domain/Creators/Shell.hpp
+++ b/src/Domain/Creators/Shell.hpp
@@ -5,14 +5,16 @@
 
 #include <array>
 #include <cstddef>
+#include <memory>
 #include <vector>
 
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Domain/BoundaryConditions/GetBoundaryConditionsBase.hpp"
-#include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
+#include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/TimeDependence/TimeDependence.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -226,6 +228,10 @@ class Shell : public DomainCreator<3> {
   ~Shell() override = default;
 
   Domain<3> create_domain() const override;
+
+  std::vector<DirectionMap<
+      3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
+  external_boundary_conditions() const override;
 
   std::vector<std::array<size_t, 3>> initial_extents() const override;
 

--- a/src/Domain/Creators/Sphere.hpp
+++ b/src/Domain/Creators/Sphere.hpp
@@ -13,6 +13,7 @@
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/TimeDependence/TimeDependence.hpp"
 #include "Domain/Domain.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -161,6 +162,10 @@ class Sphere : public DomainCreator<3> {
   ~Sphere() override = default;
 
   Domain<3> create_domain() const override;
+
+  std::vector<DirectionMap<
+      3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
+  external_boundary_conditions() const override;
 
   std::vector<std::array<size_t, 3>> initial_extents() const override;
 

--- a/src/Domain/Domain.cpp
+++ b/src/Domain/Domain.cpp
@@ -29,30 +29,14 @@ Domain<VolumeDim>::Domain(
     std::vector<std::unique_ptr<domain::CoordinateMapBase<
         Frame::BlockLogical, Frame::Inertial, VolumeDim>>>
         maps,
-    std::vector<DirectionMap<
-        VolumeDim,
-        std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
-        boundary_conditions,
-    std::unordered_map<std::string, ExcisionSphere<VolumeDim>>
-        excision_spheres)
+    std::unordered_map<std::string, ExcisionSphere<VolumeDim>> excision_spheres)
     : excision_spheres_(std::move(excision_spheres)) {
-  ASSERT(
-      boundary_conditions.size() == maps.size() or boundary_conditions.empty(),
-      "There must be either one set of boundary conditions per block or none "
-      "at all specified.");
-
   std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>
       neighbors_of_all_blocks;
   set_internal_boundaries<VolumeDim>(&neighbors_of_all_blocks, maps);
   for (size_t i = 0; i < maps.size(); i++) {
-    if (boundary_conditions.empty()) {
-      blocks_.emplace_back(std::move(maps[i]), i,
-                           std::move(neighbors_of_all_blocks[i]));
-    } else {
-      blocks_.emplace_back(std::move(maps[i]), i,
-                           std::move(neighbors_of_all_blocks[i]),
-                           std::move(boundary_conditions[i]));
-    }
+    blocks_.emplace_back(std::move(maps[i]), i,
+                         std::move(neighbors_of_all_blocks[i]));
   }
 }
 
@@ -64,22 +48,13 @@ Domain<VolumeDim>::Domain(
     const std::vector<std::array<size_t, two_to_the(VolumeDim)>>&
         corners_of_all_blocks,
     const std::vector<PairOfFaces>& identifications,
-    std::vector<DirectionMap<
-        VolumeDim,
-        std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
-        boundary_conditions,
-    std::unordered_map<std::string, ExcisionSphere<VolumeDim>>
-        excision_spheres)
+    std::unordered_map<std::string, ExcisionSphere<VolumeDim>> excision_spheres)
     : excision_spheres_(std::move(excision_spheres)) {
   ASSERT(
       maps.size() == corners_of_all_blocks.size(),
       "Must pass same number of maps as block corner sets, but maps.size() == "
           << maps.size() << " and corners_of_all_blocks.size() == "
           << corners_of_all_blocks.size());
-  ASSERT(
-      boundary_conditions.size() == maps.size() or boundary_conditions.empty(),
-      "There must be either one set of boundary conditions per block or none "
-      "at all specified.");
   std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>
       neighbors_of_all_blocks;
   set_internal_boundaries<VolumeDim>(&neighbors_of_all_blocks,
@@ -87,14 +62,8 @@ Domain<VolumeDim>::Domain(
   set_identified_boundaries<VolumeDim>(identifications, corners_of_all_blocks,
                                        &neighbors_of_all_blocks);
   for (size_t i = 0; i < corners_of_all_blocks.size(); i++) {
-    if (boundary_conditions.empty()) {
-      blocks_.emplace_back(std::move(maps[i]), i,
-                           std::move(neighbors_of_all_blocks[i]));
-    } else {
-      blocks_.emplace_back(std::move(maps[i]), i,
-                           std::move(neighbors_of_all_blocks[i]),
-                           std::move(boundary_conditions[i]));
-    }
+    blocks_.emplace_back(std::move(maps[i]), i,
+                         std::move(neighbors_of_all_blocks[i]));
   }
 }
 

--- a/src/Domain/Domain.cpp
+++ b/src/Domain/Domain.cpp
@@ -11,6 +11,7 @@
 #include "Domain/Structure/BlockNeighbor.hpp"  // IWYU pragma: keep
 #include "Domain/Structure/Direction.hpp"      // IWYU pragma: keep
 #include "Domain/Structure/DirectionMap.hpp"   // IWYU pragma: keep
+#include "Utilities/Algorithm.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
@@ -117,6 +118,13 @@ void Domain<VolumeDim>::inject_time_dependent_map_for_block(
       std::move(moving_mesh_grid_to_inertial_map),
       std::move(moving_mesh_grid_to_distorted_map),
       std::move(moving_mesh_distorted_to_inertial_map));
+}
+
+template <size_t VolumeDim>
+bool Domain<VolumeDim>::is_time_dependent() const {
+  return alg::any_of(blocks_, [](const Block<VolumeDim>& block) {
+    return block.is_time_dependent();
+  });
 }
 
 template <size_t VolumeDim>

--- a/src/Domain/Domain.hpp
+++ b/src/Domain/Domain.hpp
@@ -130,6 +130,8 @@ class Domain {
 
   const std::vector<Block<VolumeDim>>& blocks() const { return blocks_; }
 
+  bool is_time_dependent() const;
+
   const std::unordered_map<std::string, ExcisionSphere<VolumeDim>>&
   excision_spheres() const {
     return excision_spheres_;

--- a/src/Domain/Domain.hpp
+++ b/src/Domain/Domain.hpp
@@ -15,7 +15,6 @@
 #include <vector>
 
 #include "Domain/Block.hpp"  // IWYU pragma: keep
-#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Domain/DomainHelpers.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/ExcisionSphere.hpp"
@@ -61,20 +60,12 @@ class Domain {
    * until all pairs of abutting Blocks have had their Orientations
    * determined. For more information on setting up domains, see the
    * [domain creation tutorial](\ref tutorial_domain_creation).
-   *
-   * Can specify either one set of boundary conditions for each Block or no
-   * boundary conditions at all.
    */
-  explicit Domain(
-      std::vector<std::unique_ptr<domain::CoordinateMapBase<
-          Frame::BlockLogical, Frame::Inertial, VolumeDim>>>
-          maps,
-      std::vector<DirectionMap<
-          VolumeDim,
-          std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
-          boundary_conditions = {},
-      std::unordered_map<std::string, ExcisionSphere<VolumeDim>>
-          excision_spheres = {});
+  explicit Domain(std::vector<std::unique_ptr<domain::CoordinateMapBase<
+                      Frame::BlockLogical, Frame::Inertial, VolumeDim>>>
+                      maps,
+                  std::unordered_map<std::string, ExcisionSphere<VolumeDim>>
+                      excision_spheres = {});
 
   /*!
    * Create a Domain using a corner numbering scheme to encode the Orientations,
@@ -92,9 +83,6 @@ class Domain {
    *
    * \requires `maps.size() == corners_of_all_blocks.size()`, and
    * `identifications.size()` is even.
-   *
-   * Can specify either one set of boundary conditions for each Block or no
-   * boundary conditions at all.
    */
   Domain(std::vector<std::unique_ptr<domain::CoordinateMapBase<
              Frame::BlockLogical, Frame::Inertial, VolumeDim>>>
@@ -102,10 +90,6 @@ class Domain {
          const std::vector<std::array<size_t, two_to_the(VolumeDim)>>&
              corners_of_all_blocks,
          const std::vector<PairOfFaces>& identifications = {},
-         std::vector<DirectionMap<
-             VolumeDim,
-             std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
-             boundary_conditions = {},
          std::unordered_map<std::string, ExcisionSphere<VolumeDim>>
              excision_spheres = {});
 

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -1305,10 +1305,6 @@ template <size_t VolumeDim>
 Domain<VolumeDim> rectilinear_domain(
     const Index<VolumeDim>& domain_extents,
     const std::array<std::vector<double>, VolumeDim>& block_demarcations,
-    std::vector<DirectionMap<
-        VolumeDim,
-        std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
-        boundary_conditions,
     const std::vector<Index<VolumeDim>>& block_indices_to_exclude,
     const std::vector<OrientationMap<VolumeDim>>& orientations_of_all_blocks,
     const std::array<bool, VolumeDim>& dimension_is_periodic,
@@ -1339,20 +1335,9 @@ Domain<VolumeDim> rectilinear_domain(
   set_cartesian_periodic_boundaries<VolumeDim>(
       dimension_is_periodic, corners_of_all_blocks, rotations_of_all_blocks,
       &neighbors_of_all_blocks);
-  ASSERT(
-      boundary_conditions.size() == maps.size() or boundary_conditions.empty(),
-      "There must be either one boundary condition per block or none at all "
-      "specified. Boundary conditions: "
-          << boundary_conditions.size() << " total blocks: " << maps.size());
   for (size_t i = 0; i < corners_of_all_blocks.size(); i++) {
-    if (boundary_conditions.empty()) {
-      blocks.emplace_back(std::move(maps[i]), i,
-                          std::move(neighbors_of_all_blocks[i]));
-    } else {
-      blocks.emplace_back(std::move(maps[i]), i,
-                          std::move(neighbors_of_all_blocks[i]),
-                          std::move(boundary_conditions[i]));
-    }
+    blocks.emplace_back(std::move(maps[i]), i,
+                        std::move(neighbors_of_all_blocks[i]));
   }
   return Domain<VolumeDim>(std::move(blocks));
 }
@@ -1489,10 +1474,6 @@ INSTANTIATE_MAPS_FUNCTIONS(((Affine2d), (Affine3d), (Equiangular3d),
   template Domain<DIM(data)> rectilinear_domain(                            \
       const Index<DIM(data)>& domain_extents,                               \
       const std::array<std::vector<double>, DIM(data)>& block_demarcations, \
-      std::vector<DirectionMap<                                             \
-          DIM(data),                                                        \
-          std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>  \
-          boundary_conditions,                                              \
       const std::vector<Index<DIM(data)>>& block_indices_to_exclude,        \
       const std::vector<OrientationMap<DIM(data)>>&                         \
           orientations_of_all_blocks,                                       \

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -15,7 +15,6 @@
 
 #include "DataStructures/Index.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Domain/CoordinateMaps/Distribution.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/Side.hpp"
@@ -359,10 +358,6 @@ template <size_t VolumeDim>
 Domain<VolumeDim> rectilinear_domain(
     const Index<VolumeDim>& domain_extents,
     const std::array<std::vector<double>, VolumeDim>& block_demarcations,
-    std::vector<DirectionMap<
-        VolumeDim,
-        std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
-        boundary_conditions = {},
     const std::vector<Index<VolumeDim>>& block_indices_to_exclude = {},
     const std::vector<OrientationMap<VolumeDim>>& orientations_of_all_blocks =
         {},

--- a/src/Domain/Tags/CMakeLists.txt
+++ b/src/Domain/Tags/CMakeLists.txt
@@ -5,6 +5,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  ExternalBoundaryConditions.hpp
   BlockNamesAndGroups.hpp
   FaceNormal.hpp
   Faces.hpp

--- a/src/Domain/Tags/ExternalBoundaryConditions.hpp
+++ b/src/Domain/Tags/ExternalBoundaryConditions.hpp
@@ -1,0 +1,35 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/OptionTags.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+
+namespace domain::Tags {
+
+/*!
+ * The boundary conditions to be applied at external boundaries. Holds an entry
+ * per block, and a boundary condition per external direction.
+ */
+template <size_t Dim>
+struct ExternalBoundaryConditions : db::SimpleTag {
+  using type = std::vector<DirectionMap<
+      Dim, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>;
+  using option_tags = tmpl::list<domain::OptionTags::DomainCreator<Dim>>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(
+      const std::unique_ptr<::DomainCreator<Dim>>& domain_creator) {
+    return domain_creator->external_boundary_conditions();
+  }
+};
+
+}  // namespace domain::Tags

--- a/src/Elliptic/SubdomainPreconditioners/MinusLaplacian.hpp
+++ b/src/Elliptic/SubdomainPreconditioners/MinusLaplacian.hpp
@@ -17,6 +17,7 @@
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Tags.hpp"
+#include "Domain/Tags/ExternalBoundaryConditions.hpp"
 #include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
 #include "Elliptic/BoundaryConditions/BoundaryConditionType.hpp"
 #include "Elliptic/DiscontinuousGalerkin/SubdomainOperator/SubdomainOperator.hpp"
@@ -241,11 +242,12 @@ class MinusLaplacian
       return *bc_signatures_;
     }
     bc_signatures_ = std::vector<BoundaryConditionsSignature>{};
-    const auto& blocks = db::get<domain::Tags::Domain<Dim>>(box).blocks();
+    const auto& all_boundary_conditions =
+        db::get<domain::Tags::ExternalBoundaryConditions<Dim>>(box);
     const auto collect_bc_signatures = [&bc_signatures = *bc_signatures_,
                                         &override_boundary_condition_type =
                                             boundary_condition_type_,
-                                        &blocks](
+                                        &all_boundary_conditions](
                                            const BoundaryId& boundary_id) {
       if (not bc_signatures.empty() and
           bc_signatures[0].find(boundary_id) != bc_signatures[0].end()) {
@@ -260,10 +262,7 @@ class MinusLaplacian
       const auto& [block_id, direction] = boundary_id;
       const auto original_boundary_condition = dynamic_cast<
           const elliptic::BoundaryConditions::BoundaryCondition<Dim>*>(
-          blocks.at(block_id)
-              .external_boundary_conditions()
-              .at(direction)
-              .get());
+          all_boundary_conditions.at(block_id).at(direction).get());
       ASSERT(original_boundary_condition != nullptr,
              "The boundary condition in block "
                  << block_id << ", direction " << direction

--- a/src/Evolution/DiscontinuousGalerkin/Actions/BoundaryConditionsImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/BoundaryConditionsImpl.hpp
@@ -31,6 +31,7 @@
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Tags.hpp"
+#include "Domain/Tags/ExternalBoundaryConditions.hpp"
 #include "Domain/TagsTimeDependent.hpp"
 #include "Evolution/BoundaryConditions/Type.hpp"
 #include "Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeHelpers.hpp"
@@ -689,9 +690,8 @@ void apply_boundary_conditions_on_all_external_faces(
   }
 
   const auto& external_boundary_conditions =
-      db::get<domain::Tags::Domain<Dim>>(*box)
-          .blocks()[element.id().block_id()]
-          .external_boundary_conditions();
+      db::get<domain::Tags::ExternalBoundaryConditions<Dim>>(*box).at(
+          element.id().block_id());
   tmpl::for_each<derived_boundary_conditions>(
       [&boundary_correction, &box, &element, &external_boundary_conditions,
        &number_of_boundaries_left, &partial_derivs, &primitive_vars,

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
@@ -22,6 +22,7 @@
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/OrientationMapHelpers.hpp"
 #include "Domain/Tags.hpp"
+#include "Domain/Tags/ExternalBoundaryConditions.hpp"
 #include "Domain/TagsTimeDependent.hpp"
 #include "Evolution/BoundaryCorrectionTags.hpp"
 #include "Evolution/DiscontinuousGalerkin/Actions/BoundaryConditionsImpl.hpp"
@@ -302,7 +303,8 @@ struct ComputeTimeDerivative {
       evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<Dim>>;
   using const_global_cache_tags = tmpl::append<
       tmpl::list<::dg::Tags::Formulation,
-                 evolution::Tags::BoundaryCorrection<EvolutionSystem>>>;
+                 evolution::Tags::BoundaryCorrection<EvolutionSystem>,
+                 domain::Tags::ExternalBoundaryConditions<Dim>>>;
 
   template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
             typename ActionList, typename ParallelComponent,

--- a/src/Evolution/Systems/Burgers/FiniteDifference/BoundaryConditionGhostData.hpp
+++ b/src/Evolution/Systems/Burgers/FiniteDifference/BoundaryConditionGhostData.hpp
@@ -22,6 +22,7 @@
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Tags.hpp"
+#include "Domain/Tags/ExternalBoundaryConditions.hpp"
 #include "Domain/TagsTimeDependent.hpp"
 #include "Evolution/BoundaryConditions/Type.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
@@ -77,9 +78,9 @@ void BoundaryConditionGhostData::apply(
     const gsl::not_null<db::DataBox<DbTagsList>*> box,
     const Element<1>& element,
     const Burgers::fd::Reconstructor& reconstructor) {
-  const ::Domain<1>& domain = db::get<domain::Tags::Domain<1>>(*box);
   const auto& external_boundary_condition =
-      domain.blocks()[element.id().block_id()].external_boundary_conditions();
+      db::get<domain::Tags::ExternalBoundaryConditions<1>>(*box).at(
+          element.id().block_id());
 
   // Check if the element is on the external boundary. If not, the caller is
   // doing something wrong (e.g. trying to compute FD ghost data with boundary
@@ -94,11 +95,6 @@ void BoundaryConditionGhostData::apply(
   const size_t ghost_zone_size{reconstructor.ghost_zone_size()};
 
   for (const auto& direction : element.external_boundaries()) {
-    ASSERT(external_boundary_condition.at(direction) != nullptr,
-           "Boundary condition is not set (the pointer is null) in block "
-               << element.id().block_id() << ", direction: " << direction
-               << " (Burgers::fd::BoundaryConditionGhostData)");
-
     const auto& boundary_condition_at_direction =
         *external_boundary_condition.at(direction);
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/BoundaryConditionGhostData.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/BoundaryConditionGhostData.hpp
@@ -21,6 +21,7 @@
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Tags.hpp"
+#include "Domain/Tags/ExternalBoundaryConditions.hpp"
 #include "Domain/TagsTimeDependent.hpp"
 #include "Evolution/BoundaryConditions/Type.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
@@ -75,9 +76,9 @@ template <typename DbTagsList>
 void BoundaryConditionGhostData::apply(
     const gsl::not_null<db::DataBox<DbTagsList>*> box,
     const Element<3>& element, const Reconstructor& reconstructor) {
-  const ::Domain<3>& domain = db::get<domain::Tags::Domain<3>>(*box);
   const auto& external_boundary_condition =
-      domain.blocks()[element.id().block_id()].external_boundary_conditions();
+      db::get<domain::Tags::ExternalBoundaryConditions<3>>(*box).at(
+          element.id().block_id());
 
   // Check if the element is on the external boundary. If not, the caller is
   // doing something wrong (e.g. trying to compute FD ghost data with boundary
@@ -113,11 +114,6 @@ void BoundaryConditionGhostData::apply(
   });
 
   for (const auto& direction : element.external_boundaries()) {
-    ASSERT(external_boundary_condition.at(direction) != nullptr,
-           "Boundary condition is not set (the pointer is null) in block "
-               << element.id().block_id() << ", direction: " << direction
-               << " (ValenciaDivClean::fd::BoundaryConditionGhostData)");
-
     const auto& boundary_condition_at_direction =
         *external_boundary_condition.at(direction);
 

--- a/src/ParallelAlgorithms/Interpolation/Actions/VerifyTemporalIdsAndSendPoints.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/VerifyTemporalIdsAndSendPoints.hpp
@@ -4,6 +4,8 @@
 #pragma once
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/Tags.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
@@ -234,8 +236,9 @@ struct VerifyTemporalIdsAndSendPoints {
           InterpolationTargetTag, ParallelComponent>(make_not_null(&box),
                                                      cache);
     } else {
-      if (InterpolationTarget_detail::maps_are_time_dependent<
-              InterpolationTargetTag>(cache)) {
+      const auto& domain =
+          get<domain::Tags::Domain<Metavariables::volume_dim>>(cache);
+      if (domain.is_time_dependent()) {
         if constexpr (Parallel::is_in_mutable_global_cache<
                           Metavariables, domain::Tags::FunctionsOfTime>) {
           detail::verify_temporal_ids_and_send_points_time_dependent<

--- a/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
+++ b/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
@@ -281,18 +281,6 @@ bool have_data_at_all_points(const db::DataBox<DbTags>& box,
   return (invalid_size + filled_size == interp_size);
 }
 
-/// Returns true if at least one Block in the Domain has
-/// time-dependent maps.
-template <typename InterpolationTargetTag, typename Metavariables>
-bool maps_are_time_dependent(
-    const Parallel::GlobalCache<Metavariables>& cache) {
-  const auto& domain =
-      get<domain::Tags::Domain<Metavariables::volume_dim>>(cache);
-  return alg::any_of(domain.blocks(), [](const auto& block) {
-    return block.is_time_dependent();
-  });
-}
-
 /// Tells an InterpolationTarget that it should interpolate at
 /// the supplied temporal_ids.  Changes the InterpolationTarget's DataBox
 /// accordingly.
@@ -492,7 +480,7 @@ auto block_logical_coords(
     return ::block_logical_coordinates(domain, coords);
   }
 
-  if (maps_are_time_dependent<InterpolationTargetTag>(cache)) {
+  if (domain.is_time_dependent()) {
     if constexpr (Parallel::is_in_mutable_global_cache<
                       Metavariables, domain::Tags::FunctionsOfTime>) {
       // Whoever calls block_logical_coords when the maps are

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Shape.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Shape.cpp
@@ -120,7 +120,6 @@ void test_shape_control_error() {
   // Fake domain
   Domain<3> fake_domain{
       {},
-      {},
       {{excision_sphere_A_name,
         ExcisionSphere<3>{excision_radius,
                           origin,

--- a/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
@@ -91,6 +91,11 @@ class TestCreator : public DomainCreator<1> {
   explicit TestCreator(const bool add_controlled)
       : add_controlled_(add_controlled) {}
   Domain<1> create_domain() const override { ERROR(""); }
+  std::vector<DirectionMap<
+      1, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
+  external_boundary_conditions() const override {
+    ERROR("");
+  }
   std::vector<std::array<size_t, 1>> initial_extents() const override {
     ERROR("");
   }
@@ -156,6 +161,11 @@ class TestCreator : public DomainCreator<1> {
 class BadCreator : public DomainCreator<1> {
  public:
   Domain<1> create_domain() const override { ERROR(""); }
+  std::vector<DirectionMap<
+      1, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
+  external_boundary_conditions() const override {
+    ERROR("");
+  }
   std::vector<std::array<size_t, 1>> initial_extents() const override {
     ERROR("");
   }

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -836,7 +836,7 @@ void test_parse_errors() {
 }  // namespace
 
 // [[TimeOut, 30]]
-SPECTRE_TEST_CASE("Unit.Domain.Creators.BinaryCompactObject.FactoryTests",
+SPECTRE_TEST_CASE("Unit.Domain.Creators.BinaryCompactObject",
                   "[Domain][Unit]") {
   test_connectivity();
   test_bbh_time_dependent_factory(true, true);

--- a/tests/Unit/Domain/Creators/Test_Disk.cpp
+++ b/tests/Unit/Domain/Creators/Test_Disk.cpp
@@ -312,8 +312,7 @@ void test_disk_factory_equidistant() {
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.Disk.Factory.Equidistant",
-                  "[Domain][Unit]") {
+SPECTRE_TEST_CASE("Unit.Domain.Creators.Disk", "[Domain][Unit]") {
   test_disk_boundaries_equiangular();
   test_disk_factory_equiangular();
   test_disk_boundaries_equidistant();

--- a/tests/Unit/Domain/Creators/Test_Interval.cpp
+++ b/tests/Unit/Domain/Creators/Test_Interval.cpp
@@ -398,7 +398,7 @@ void test_interval_factory() {
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.Interval.Factory", "[Domain][Unit]") {
+SPECTRE_TEST_CASE("Unit.Domain.Creators.Interval", "[Domain][Unit]") {
   test_interval();
   test_interval_factory();
 }

--- a/tests/Unit/Domain/Creators/Test_Rectangle.cpp
+++ b/tests/Unit/Domain/Creators/Test_Rectangle.cpp
@@ -62,12 +62,11 @@ void test_rectangle_construction(
         expected_functions_of_time = {},
     const std::vector<std::unique_ptr<domain::CoordinateMapBase<
         Frame::Grid, Frame::Inertial, 2>>>& expected_grid_to_inertial_maps = {},
-    const std::vector<DirectionMap<
-        2, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>&
-        expected_boundary_conditions = {},
+    const bool expect_boundary_conditions = false,
     const std::unordered_map<std::string, double>& initial_expiration_times =
         {}) {
-  const auto domain = rectangle.create_domain();
+  const auto domain = TestHelpers::domain::creators::test_domain_creator(
+      rectangle, expect_boundary_conditions);
 
   CHECK(rectangle.initial_extents() == expected_extents);
   CHECK(rectangle.initial_refinement_levels() == expected_refinement_level);
@@ -80,15 +79,9 @@ void test_rectangle_construction(
                                       Frame::Inertial, Frame::Grid>>(
           Affine2D{Affine{-1., 1., lower_bound[0], upper_bound[0]},
                    Affine{-1., 1., lower_bound[1], upper_bound[1]}})),
-      10.0, rectangle.functions_of_time(), expected_grid_to_inertial_maps,
-      expected_boundary_conditions);
-  test_initial_domain(domain, rectangle.initial_refinement_levels());
+      10.0, rectangle.functions_of_time(), expected_grid_to_inertial_maps);
   TestHelpers::domain::creators::test_functions_of_time(
       rectangle, expected_functions_of_time, initial_expiration_times);
-
-  domain::creators::register_derived_with_charm();
-  domain::creators::time_dependence::register_derived_with_charm();
-  test_serialization(domain);
 }
 
 void test_rectangle() {
@@ -137,7 +130,7 @@ void test_rectangle() {
              {Direction<2>::upper_xi()},
              {Direction<2>::lower_eta()},
              {Direction<2>::upper_eta()}}},
-        {}, {}, expected_boundary_conditions);
+        {}, {}, true);
   }
 
   {
@@ -194,7 +187,7 @@ void test_rectangle() {
              {Direction<2>::upper_xi(), {0, aligned_orientation}},
              {Direction<2>::lower_eta(), {0, aligned_orientation}},
              {Direction<2>::upper_eta(), {0, aligned_orientation}}}},
-        std::vector<std::unordered_set<Direction<2>>>{{}});
+        std::vector<std::unordered_set<Direction<2>>>{{}}, {}, {}, true);
   }
   CHECK_THROWS_WITH(
       creators::Rectangle(
@@ -274,7 +267,7 @@ void test_rectangle_factory() {
         std::vector<std::unordered_set<Direction<2>>>{
             {{Direction<2>::lower_xi(), Direction<2>::upper_xi(),
               Direction<2>::lower_eta(), Direction<2>::upper_eta()}}},
-        {}, {}, expected_boundary_conditions);
+        {}, {}, true);
   }
   {
     INFO("Rectangle factory time dependent");
@@ -331,7 +324,7 @@ void test_rectangle_factory() {
                  initial_expiration_times[f_of_t_name]}}),
         make_vector_coordinate_map_base<Frame::Grid, Frame::Inertial>(
             Translation2D{f_of_t_name}),
-        {}, initial_expiration_times);
+        false, initial_expiration_times);
   }
   {
     INFO("Rectangle factory time dependent, with boundary conditions");
@@ -377,7 +370,7 @@ void test_rectangle_factory() {
                  std::numeric_limits<double>::infinity()}}),
         make_vector_coordinate_map_base<Frame::Grid, Frame::Inertial>(
             Translation2D{f_of_t_name}),
-        expected_boundary_conditions);
+        true);
     // with expiration times
     test_rectangle_construction(
         *rectangle_creator, {{0., 0.}}, {{1., 2.}}, {{{3, 4}}}, {{{2, 3}}},
@@ -394,7 +387,7 @@ void test_rectangle_factory() {
                  initial_expiration_times[f_of_t_name]}}),
         make_vector_coordinate_map_base<Frame::Grid, Frame::Inertial>(
             Translation2D{f_of_t_name}),
-        expected_boundary_conditions, initial_expiration_times);
+        true, initial_expiration_times);
   }
 }  // namespace domain
 }  // namespace

--- a/tests/Unit/Domain/Creators/Test_Rectangle.cpp
+++ b/tests/Unit/Domain/Creators/Test_Rectangle.cpp
@@ -399,7 +399,7 @@ void test_rectangle_factory() {
 }  // namespace domain
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.Rectangle.Factory", "[Domain][Unit]") {
+SPECTRE_TEST_CASE("Unit.Domain.Creators.Rectangle", "[Domain][Unit]") {
   test_rectangle();
   test_rectangle_factory();
 }

--- a/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
@@ -482,8 +482,7 @@ void test_rotated_bricks_factory() {
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.RotatedBricks.Factory",
-                  "[Domain][Unit]") {
+SPECTRE_TEST_CASE("Unit.Domain.Creators.RotatedBricks", "[Domain][Unit]") {
   test_rotated_bricks();
   test_rotated_bricks_factory();
 }

--- a/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
@@ -55,15 +55,13 @@ void test_rotated_intervals_construction(
     const std::vector<std::unique_ptr<
         domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, 1>>>&
         expected_grid_to_inertial_maps,
-    const std::vector<DirectionMap<
-        1, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>&
-        expected_boundary_conditions,
+    const bool expect_boundary_conditions = false,
+    const bool is_periodic = false,
     const std::unordered_map<std::string, double>& initial_expiration_times =
         {}) {
-  const auto domain = rotated_intervals.create_domain();
+  const auto domain = TestHelpers::domain::creators::test_domain_creator(
+      rotated_intervals, expect_boundary_conditions, is_periodic);
 
-  CHECK(domain.blocks().size() == expected_extents.size());
-  CHECK(domain.blocks().size() == expected_refinement_level.size());
   CHECK(rotated_intervals.initial_extents() == expected_extents);
   CHECK(rotated_intervals.initial_refinement_levels() ==
         expected_refinement_level);
@@ -84,15 +82,9 @@ void test_rotated_intervals_construction(
                   std::array<Direction<1>, 1>{{Direction<1>::lower_xi()}}}},
               CoordinateMaps::Affine{-1., 1., midpoint[0], upper_bound[0]})),
       10.0, rotated_intervals.functions_of_time(),
-      expected_grid_to_inertial_maps, expected_boundary_conditions);
-  test_initial_domain(domain, rotated_intervals.initial_refinement_levels());
+      expected_grid_to_inertial_maps);
   TestHelpers::domain::creators::test_functions_of_time(
       rotated_intervals, expected_functions_of_time, initial_expiration_times);
-
-  Parallel::register_classes_with_charm(
-      typename domain::creators::RotatedIntervals::maps_list{});
-  domain::creators::time_dependence::register_derived_with_charm();
-  test_serialization(domain);
 }
 
 void test_rotated_intervals() {
@@ -104,13 +96,11 @@ void test_rotated_intervals() {
   const std::array<double, 1> upper_bound{{0.8}};
   const OrientationMap<1> flipped{
       std::array<Direction<1>, 1>{{Direction<1>::lower_xi()}}};
-  using BcVector = std::vector<DirectionMap<
-      1, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>;
 
   const auto check_nonperiodic =
       [&lower_bound, &midpoint, &upper_bound, &grid_points, &refinement_level,
        &flipped](const creators::RotatedIntervals& rotated_intervals,
-                 const BcVector& expected_bcs) {
+                 const bool expect_bcs) {
         test_rotated_intervals_construction(
             rotated_intervals, lower_bound, midpoint, upper_bound, grid_points,
             refinement_level,
@@ -119,13 +109,13 @@ void test_rotated_intervals() {
                 {{Direction<1>::upper_xi(), {0, flipped}}}},
             std::vector<std::unordered_set<Direction<1>>>{
                 {Direction<1>::lower_xi()}, {Direction<1>::lower_xi()}},
-            std::tuple<>{}, {}, expected_bcs);
-        test_physical_separation(rotated_intervals.create_domain().blocks());
+            std::tuple<>{}, {}, expect_bcs);
       };
 
   const auto check_periodic =
       [&lower_bound, &midpoint, &upper_bound, &grid_points, &refinement_level,
-       &flipped](const creators::RotatedIntervals& periodic_rotated_intervals) {
+       &flipped](const creators::RotatedIntervals& periodic_rotated_intervals,
+                 const bool expect_bcs) {
         test_rotated_intervals_construction(
             periodic_rotated_intervals, lower_bound, midpoint, upper_bound,
             grid_points, refinement_level,
@@ -135,7 +125,7 @@ void test_rotated_intervals() {
                 {{Direction<1>::lower_xi(), {0, flipped}},
                  {Direction<1>::upper_xi(), {0, flipped}}}},
             std::vector<std::unordered_set<Direction<1>>>{{}, {}},
-            std::tuple<>{}, {}, {});
+            std::tuple<>{}, {}, expect_bcs, true);
       };
 
   {
@@ -145,8 +135,9 @@ void test_rotated_intervals() {
                        upper_bound,
                        refinement_level[0],
                        {{{{grid_points[0][0], grid_points[1][0]}}}},
-                       std::array<bool, 1>{{false}}, nullptr},
-                      {});
+                       std::array<bool, 1>{{false}},
+                       nullptr},
+                      false);
   }
 
   {
@@ -156,29 +147,29 @@ void test_rotated_intervals() {
                     upper_bound,
                     refinement_level[0],
                     {{{{grid_points[0][0], grid_points[1][0]}}}},
-                    std::array<bool, 1>{{true}}, nullptr});
+                    std::array<bool, 1>{{true}},
+                    nullptr},
+                   false);
   }
 
   // Test with boundary conditions
-  BcVector expected_boundary_conditions{2};
-  expected_boundary_conditions[0][Direction<1>::lower_xi()] = std::make_unique<
+  const auto lower_bc = std::make_unique<
       TestHelpers::domain::BoundaryConditions::TestBoundaryCondition<1>>(
       Direction<1>::lower_xi(), 0);
-  expected_boundary_conditions[1][Direction<1>::lower_xi()] = std::make_unique<
+  const auto upper_bc = std::make_unique<
       TestHelpers::domain::BoundaryConditions::TestBoundaryCondition<1>>(
       Direction<1>::upper_xi(), 1);
   {
     INFO("Check non-periodic with boundary conditions");
-    check_nonperiodic(
-        {lower_bound,
-         midpoint,
-         upper_bound,
-         refinement_level[0],
-         {{{{grid_points[0][0], grid_points[1][0]}}}},
-         expected_boundary_conditions[0][Direction<1>::lower_xi()]->get_clone(),
-         expected_boundary_conditions[1][Direction<1>::lower_xi()]->get_clone(),
-         nullptr},
-        expected_boundary_conditions);
+    check_nonperiodic({lower_bound,
+                       midpoint,
+                       upper_bound,
+                       refinement_level[0],
+                       {{{{grid_points[0][0], grid_points[1][0]}}}},
+                       lower_bc->get_clone(),
+                       upper_bc->get_clone(),
+                       nullptr},
+                      true);
   }
 
   const std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
@@ -193,16 +184,15 @@ void test_rotated_intervals() {
                     {{{{grid_points[0][0], grid_points[1][0]}}}},
                     periodic->get_clone(),
                     periodic->get_clone(),
-                    nullptr});
+                    nullptr},
+                   true);
   }
 
   // Test parse error
   CHECK_THROWS_WITH(
       creators::RotatedIntervals(
           lower_bound, midpoint, upper_bound, refinement_level[0],
-          {{{{grid_points[0][0], grid_points[1][0]}}}},
-          expected_boundary_conditions[0][Direction<1>::lower_xi()]
-              ->get_clone(),
+          {{{{grid_points[0][0], grid_points[1][0]}}}}, lower_bc->get_clone(),
           periodic->get_clone(), nullptr, Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains("Both the upper and lower boundary condition "
                                 "must be set to periodic if"));
@@ -210,9 +200,7 @@ void test_rotated_intervals() {
       creators::RotatedIntervals(
           lower_bound, midpoint, upper_bound, refinement_level[0],
           {{{{grid_points[0][0], grid_points[1][0]}}}}, periodic->get_clone(),
-          expected_boundary_conditions[0][Direction<1>::lower_xi()]
-              ->get_clone(),
-          nullptr, Options::Context{false, {}, 1, 1}),
+          lower_bc->get_clone(), nullptr, Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains("Both the upper and lower boundary condition "
                                 "must be set to periodic if"));
   CHECK_THROWS_WITH(
@@ -221,18 +209,14 @@ void test_rotated_intervals() {
           {{{{grid_points[0][0], grid_points[1][0]}}}},
           std::make_unique<TestHelpers::domain::BoundaryConditions::
                                TestNoneBoundaryCondition<3>>(),
-          expected_boundary_conditions[0][Direction<1>::lower_xi()]
-              ->get_clone(),
-          nullptr, Options::Context{false, {}, 1, 1}),
+          lower_bc->get_clone(), nullptr, Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "None boundary condition is not supported. If you would like "
           "an outflow-type boundary condition, you must use that."));
   CHECK_THROWS_WITH(
       creators::RotatedIntervals(
           lower_bound, midpoint, upper_bound, refinement_level[0],
-          {{{{grid_points[0][0], grid_points[1][0]}}}},
-          expected_boundary_conditions[0][Direction<1>::lower_xi()]
-              ->get_clone(),
+          {{{{grid_points[0][0], grid_points[1][0]}}}}, lower_bc->get_clone(),
           std::make_unique<TestHelpers::domain::BoundaryConditions::
                                TestNoneBoundaryCondition<3>>(),
           nullptr, Options::Context{false, {}, 1, 1}),
@@ -244,15 +228,12 @@ void test_rotated_intervals() {
 void test_rotated_intervals_factory() {
   const OrientationMap<1> flipped{
       std::array<Direction<1>, 1>{{Direction<1>::lower_xi()}}};
-  std::vector<DirectionMap<
-      1, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
-      expected_boundary_conditions{2};
-  expected_boundary_conditions[0][Direction<1>::lower_xi()] = std::make_unique<
+  const auto lower_bc = std::make_unique<
       TestHelpers::domain::BoundaryConditions::TestBoundaryCondition<1>>(
       Direction<1>::lower_xi(), 0);
-  expected_boundary_conditions[1][Direction<1>::lower_xi()] = std::make_unique<
+  const auto upper_bc = std::make_unique<
       TestHelpers::domain::BoundaryConditions::TestBoundaryCondition<1>>(
-      Direction<1>::lower_xi(), 1);
+      Direction<1>::upper_xi(), 1);
   const std::vector<std::unordered_set<Direction<1>>>
       expected_external_boundaries{{Direction<1>::lower_xi()},
                                    {Direction<1>::lower_xi()}};
@@ -281,8 +262,8 @@ void test_rotated_intervals_factory() {
              {Direction<1>::upper_xi(), {1, flipped}}},
             {{Direction<1>::lower_xi(), {0, flipped}},
              {Direction<1>::upper_xi(), {0, flipped}}}},
-        std::vector<std::unordered_set<Direction<1>>>{{}, {}}, {},
-        {}, {});
+        std::vector<std::unordered_set<Direction<1>>>{{}, {}}, {}, {}, false,
+        true);
   }
   {
     INFO("Rotated intervals factory time independent, with boundary condition");
@@ -315,7 +296,7 @@ void test_rotated_intervals_factory() {
         std::vector<DirectionMap<1, BlockNeighbor<1>>>{
             {{Direction<1>::upper_xi(), {1, flipped}}},
             {{Direction<1>::upper_xi(), {0, flipped}}}},
-        expected_external_boundaries, {}, {}, expected_boundary_conditions);
+        expected_external_boundaries, {}, {}, true);
   }
   {
     INFO("Rotated intervals factory time dependent, no boundary condition");
@@ -363,7 +344,7 @@ void test_rotated_intervals_factory() {
         make_vector_coordinate_map_base<Frame::Grid, Frame::Inertial>(
             CoordinateMaps::TimeDependent::Translation<1>{f_of_t_name},
             CoordinateMaps::TimeDependent::Translation<1>{f_of_t_name}),
-        {});
+        false, true);
     // with expiration times
     test_rotated_intervals_construction(
         *rotated_intervals_creator, {{0.0}}, {{0.5}}, {{1.0}}, {{{3}}, {{2}}},
@@ -384,7 +365,7 @@ void test_rotated_intervals_factory() {
         make_vector_coordinate_map_base<Frame::Grid, Frame::Inertial>(
             CoordinateMaps::TimeDependent::Translation<1>{f_of_t_name},
             CoordinateMaps::TimeDependent::Translation<1>{f_of_t_name}),
-        {}, initial_expiration_times);
+        false, true, initial_expiration_times);
   }
   {
     INFO("Rotated intervals factory time dependent, with boundary condition");
@@ -438,7 +419,7 @@ void test_rotated_intervals_factory() {
         make_vector_coordinate_map_base<Frame::Grid, Frame::Inertial>(
             CoordinateMaps::TimeDependent::Translation<1>{f_of_t_name},
             CoordinateMaps::TimeDependent::Translation<1>{f_of_t_name}),
-        expected_boundary_conditions);
+        true);
     // with expiration times
     test_rotated_intervals_construction(
         *rotated_intervals_creator, {{0.0}}, {{0.5}}, {{1.0}}, {{{3}}, {{2}}},
@@ -457,7 +438,7 @@ void test_rotated_intervals_factory() {
         make_vector_coordinate_map_base<Frame::Grid, Frame::Inertial>(
             CoordinateMaps::TimeDependent::Translation<1>{f_of_t_name},
             CoordinateMaps::TimeDependent::Translation<1>{f_of_t_name}),
-        expected_boundary_conditions, initial_expiration_times);
+        true, false, initial_expiration_times);
   }
 }
 }  // namespace

--- a/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
@@ -462,8 +462,7 @@ void test_rotated_intervals_factory() {
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.RotatedIntervals.Factory",
-                  "[Domain][Unit]") {
+SPECTRE_TEST_CASE("Unit.Domain.Creators.RotatedIntervals", "[Domain][Unit]") {
   test_rotated_intervals();
   test_rotated_intervals_factory();
 }

--- a/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
@@ -365,8 +365,7 @@ void test_rotated_rectangles_factory() {
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.RotatedRectangles.Factory",
-                  "[Domain][Unit]") {
+SPECTRE_TEST_CASE("Unit.Domain.Creators.RotatedRectangles", "[Domain][Unit]") {
   test_rotated_rectangles();
   test_rotated_rectangles_factory();
 }

--- a/tests/Unit/Domain/FunctionsOfTime/Test_ReadSpecPiecewisePolynomial.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_ReadSpecPiecewisePolynomial.cpp
@@ -48,6 +48,11 @@ class FakeCreator : public DomainCreator<3> {
  public:
   explicit FakeCreator() {}
   Domain<3> create_domain() const override { ERROR(""); }
+  std::vector<DirectionMap<
+      3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
+  external_boundary_conditions() const override {
+    ERROR("");
+  }
   std::vector<std::array<size_t, 3>> initial_extents() const override {
     ERROR("");
   }

--- a/tests/Unit/Domain/Tags/CMakeLists.txt
+++ b/tests/Unit/Domain/Tags/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_DomainTags")
 
 set(LIBRARY_SOURCES
   Test_BlockNamesAndGroups.cpp
+  Test_ExternalBoundaryConditions.cpp
   Test_Faces.cpp
   Test_SurfaceJacobian.cpp
   )

--- a/tests/Unit/Domain/Tags/Test_ExternalBoundaryConditions.cpp
+++ b/tests/Unit/Domain/Tags/Test_ExternalBoundaryConditions.cpp
@@ -1,0 +1,19 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "Domain/Tags/ExternalBoundaryConditions.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+
+namespace domain {
+
+SPECTRE_TEST_CASE("Unit.Domain.Tags.ExternalBoundaryConditions",
+                  "[Unit][Domain]") {
+  TestHelpers::db::test_simple_tag<Tags::ExternalBoundaryConditions<3>>(
+      "ExternalBoundaryConditions");
+}
+
+}  // namespace domain

--- a/tests/Unit/Domain/Test_Domain.cpp
+++ b/tests/Unit/Domain/Test_Domain.cpp
@@ -101,6 +101,7 @@ void test_1d_domains() {
                                            CoordinateMaps::Affine>>(
                 make_coordinate_map<Frame::BlockLogical, Frame::Inertial>(
                     CoordinateMaps::Affine{-1., 1., 2., 0.}))));
+    CHECK_FALSE(domain_no_corners.is_time_dependent());
 
     const OrientationMap<1> unaligned_orientation{{{Direction<1>::lower_xi()}},
                                                   {{Direction<1>::upper_xi()}}};
@@ -177,6 +178,7 @@ void test_1d_domains() {
             Translation{"Translation1"}),
         translation_grid_to_distorted_map.get_clone(),
         translation_distorted_to_inertial_map.get_clone());
+    CHECK(domain_no_corners.is_time_dependent());
 
     const auto expected_logical_to_grid_maps =
         make_vector(make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
@@ -470,19 +472,17 @@ SPECTRE_TEST_CASE("Unit.Domain.Domain", "[Domain][Unit]") {
   test_1d_rectilinear_domains();
   test_2d_rectilinear_domains();
   test_3d_rectilinear_domains();
-}
-// [[OutputRegex, Must pass same number of maps as block corner sets]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Domain.BadArgs", "[Domain][Unit]") {
-  ASSERTION_TEST();
+
 #ifdef SPECTRE_DEBUG
-  // NOLINTNEXTLINE(bugprone-unused-raii)
-  Domain<1>(make_vector(
-                make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
-                    CoordinateMaps::Affine{-1., 1., -1., 1.}),
-                make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
-                    CoordinateMaps::Affine{-1., 1., -1., 1.})),
-            std::vector<std::array<size_t, 2>>{{{1, 2}}});
-  ERROR("Failed to trigger ASSERT in an assertion test");
+  CHECK_THROWS_WITH(
+      Domain<1>(
+          make_vector(
+              make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+                  CoordinateMaps::Affine{-1., 1., -1., 1.}),
+              make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+                  CoordinateMaps::Affine{-1., 1., -1., 1.})),
+          std::vector<std::array<size_t, 2>>{{{1, 2}}}),
+      Catch::Contains("Must pass same number of maps as block corner sets"));
 #endif
 }
 }  // namespace domain

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
@@ -33,6 +33,7 @@
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Structure/InitialElementIds.hpp"
 #include "Domain/Tags.hpp"
+#include "Domain/Tags/ExternalBoundaryConditions.hpp"
 #include "Elliptic/Actions/InitializeBackgroundFields.hpp"
 #include "Elliptic/BoundaryConditions/AnalyticSolution.hpp"
 #include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
@@ -477,6 +478,7 @@ void test_subdomain_operator(
     // Re-create the domain in every iteration of this loop because it's not
     // copyable
     auto domain = domain_creator.create_domain();
+    auto boundary_conditions = domain_creator.external_boundary_conditions();
     const auto initial_ref_levs = domain_creator.initial_refinement_levels();
     const auto initial_extents = domain_creator.initial_extents();
     const auto element_ids = ::initial_element_ids(initial_ref_levs);
@@ -484,11 +486,13 @@ void test_subdomain_operator(
 
     ActionTesting::MockRuntimeSystem<metavariables> runner{tuples::TaggedTuple<
         domain::Tags::Domain<Dim>,
+        domain::Tags::ExternalBoundaryConditions<Dim>,
         elliptic::Tags::Background<elliptic::analytic_data::Background>,
         LinearSolver::Schwarz::Tags::MaxOverlap<DummyOptionsGroup>,
         elliptic::dg::Tags::PenaltyParameter, elliptic::dg::Tags::Massive>{
-        std::move(domain), std::make_unique<RandomBackground<Dim>>(), overlap,
-        penalty_parameter, use_massive_dg_operator}};
+        std::move(domain), std::move(boundary_conditions),
+        std::make_unique<RandomBackground<Dim>>(), overlap, penalty_parameter,
+        use_massive_dg_operator}};
 
     // Initialize all elements, generating random subdomain data
     for (const auto& element_id : element_ids) {

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
@@ -18,6 +18,7 @@
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/FaceNormal.hpp"
 #include "Domain/Structure/InitialElementIds.hpp"
+#include "Domain/Tags/ExternalBoundaryConditions.hpp"
 #include "Elliptic/Actions/InitializeAnalyticSolution.hpp"
 #include "Elliptic/Actions/InitializeFixedSources.hpp"
 #include "Elliptic/BoundaryConditions/AnalyticSolution.hpp"
@@ -199,6 +200,7 @@ void test_dg_operator(
 
   // Get a list of all elements in the domain
   auto domain = domain_creator.create_domain();
+  auto boundary_conditions = domain_creator.external_boundary_conditions();
   const auto initial_ref_levs = domain_creator.initial_refinement_levels();
   const auto initial_extents = domain_creator.initial_extents();
   std::unordered_set<ElementId<Dim>> all_element_ids{};
@@ -210,13 +212,12 @@ void test_dg_operator(
     }
   }
 
-  ActionTesting::MockRuntimeSystem<Metavars> runner{
-      tuples::TaggedTuple<domain::Tags::Domain<Dim>,
-                          ::elliptic::dg::Tags::PenaltyParameter,
-                          ::elliptic::dg::Tags::Massive,
-                          ::Tags::AnalyticSolution<AnalyticSolution>>{
-          std::move(domain), penalty_parameter, use_massive_dg_operator,
-          analytic_solution}};
+  ActionTesting::MockRuntimeSystem<Metavars> runner{tuples::TaggedTuple<
+      domain::Tags::Domain<Dim>, domain::Tags::ExternalBoundaryConditions<Dim>,
+      ::elliptic::dg::Tags::PenaltyParameter, ::elliptic::dg::Tags::Massive,
+      ::Tags::AnalyticSolution<AnalyticSolution>>{
+      std::move(domain), std::move(boundary_conditions), penalty_parameter,
+      use_massive_dg_operator, analytic_solution}};
 
   // DataBox shortcuts
   const auto get_tag = [&runner](

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -57,6 +57,7 @@ target_link_libraries(
   Framework
   GeneralRelativityHelpers
   GrMhdAnalyticData
+  GrMhdSolutions
   HydroHelpers
   ValenciaDivClean
   )

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
@@ -104,7 +104,6 @@ double test(const size_t num_dg_pts) {
                                                 Frame::Inertial>(
                    Affine3D{affine_map, affine_map, affine_map}),
                0,
-               {},
                {}},
       std::vector<std::array<size_t, 3>>{std::array<size_t, 3>{{3, 3, 3}}});
 

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TimeDerivative.cpp
@@ -126,7 +126,6 @@ std::array<double, 5> test(const size_t num_dg_pts) {
                                                 Frame::Inertial>(
                    Affine3D{affine_map, affine_map, affine_map}),
                0,
-               {},
                {}},
       std::vector<std::array<size_t, 3>>{std::array<size_t, 3>{{3, 3, 3}}});
 

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_NeighborPackagedData.cpp
@@ -100,7 +100,6 @@ auto make_element<1>() {
       Block<1>{domain::make_coordinate_map_base<Frame::BlockLogical,
                                                 Frame::Inertial>(affine_map),
                0,
-               {},
                {}},
       std::vector<std::array<size_t, 1>>{std::array<size_t, 1>{{3}}});
 }
@@ -114,7 +113,6 @@ auto make_element<2>() {
                                                 Frame::Inertial>(
                    Affine2D{affine_map, affine_map}),
                0,
-               {},
                {}},
       std::vector<std::array<size_t, 2>>{std::array<size_t, 2>{{3, 3}}});
 }
@@ -128,7 +126,6 @@ auto make_element<3>() {
                                                 Frame::Inertial>(
                    Affine3D{affine_map, affine_map, affine_map}),
                0,
-               {},
                {}},
       std::vector<std::array<size_t, 3>>{std::array<size_t, 3>{{3, 3, 3}}});
 }

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TimeDerivative.cpp
@@ -89,7 +89,6 @@ auto make_element<1>() {
       Block<1>{domain::make_coordinate_map_base<Frame::BlockLogical,
                                                 Frame::Inertial>(affine_map),
                0,
-               {},
                {}},
       std::vector<std::array<size_t, 1>>{std::array<size_t, 1>{{3}}});
 }
@@ -103,7 +102,6 @@ auto make_element<2>() {
                                                 Frame::Inertial>(
                    Affine2D{affine_map, affine_map}),
                0,
-               {},
                {}},
       std::vector<std::array<size_t, 2>>{std::array<size_t, 2>{{3, 3}}});
 }
@@ -117,7 +115,6 @@ auto make_element<3>() {
                                                 Frame::Inertial>(
                    Affine3D{affine_map, affine_map, affine_map}),
                0,
-               {},
                {}},
       std::vector<std::array<size_t, 3>>{std::array<size_t, 3>{{3, 3, 3}}});
 }

--- a/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
+++ b/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
@@ -105,6 +105,11 @@ class FakeCreator : public DomainCreator<3> {
       : num_components_map_(num_components_map) {}
 
   Domain<3> create_domain() const override { ERROR(""); }
+  std::vector<DirectionMap<
+      3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
+  external_boundary_conditions() const override {
+    ERROR("");
+  }
   std::vector<std::array<size_t, 3>> initial_extents() const override {
     ERROR("");
   }
@@ -475,7 +480,7 @@ struct SystemHelper {
   }
 
   void reset() {
-    domain_ = Domain<3>{{}, {}, stored_excision_spheres_};
+    domain_ = Domain<3>{{}, stored_excision_spheres_};
     initial_functions_of_time_ =
         clone_unique_ptrs(stored_initial_functions_of_time_);
     initial_measurement_timescales_ =
@@ -564,7 +569,7 @@ struct SystemHelper {
                                 {3, Direction<3>::lower_zeta()},
                                 {4, Direction<3>::lower_zeta()},
                                 {5, Direction<3>::lower_zeta()}}}}};
-    domain_ = Domain<3>{{}, {}, stored_excision_spheres_};
+    domain_ = Domain<3>{{}, stored_excision_spheres_};
 
     stored_initial_functions_of_time_ =
         clone_unique_ptrs(initial_functions_of_time_);

--- a/tests/Unit/Helpers/Domain/DomainTestHelpers.hpp
+++ b/tests/Unit/Helpers/Domain/DomainTestHelpers.hpp
@@ -62,11 +62,7 @@ void test_domain_construction(
         functions_of_time = {},
     const std::vector<std::unique_ptr<
         domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, VolumeDim>>>&
-        expected_grid_to_inertial_maps = {},
-    const std::vector<DirectionMap<
-        VolumeDim,
-        std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>&
-        expected_boundary_conditions = {});
+        expected_grid_to_inertial_maps = {});
 
 // Test that two neighboring Blocks abut each other.
 template <size_t VolumeDim>

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -991,11 +991,11 @@ void test_impl(const Spectral::Quadrature quadrature,
     blocks[0] = Block<Dim>{
         domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             domain::CoordinateMaps::Identity<Dim>{}),
-        0, neighbors_block0, std::move(boundary_conditions[0])};
+        0, neighbors_block0};
     blocks[1] = Block<Dim>{
         domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             domain::CoordinateMaps::Identity<Dim>{}),
-        1, neighbors_block1, std::move(boundary_conditions[1])};
+        1, neighbors_block1};
     Domain<Dim> domain{std::move(blocks)};
     domain.inject_time_dependent_map_for_block(
         0, grid_to_inertial_map->get_clone());
@@ -1007,7 +1007,8 @@ void test_impl(const Spectral::Quadrature quadrature,
                                               make_array<Dim>(3_st)},
          typename metavars::normal_dot_numerical_flux::type{},
          std::move(domain), dg_formulation,
-         std::make_unique<BoundaryTerms<Dim, HasPrims>>()}};
+         std::make_unique<BoundaryTerms<Dim, HasPrims>>(),
+         std::move(boundary_conditions)}};
   }();
   const auto get_tag = [&runner, &self_id](auto tag_v) -> decltype(auto) {
     using tag = std::decay_t<decltype(tag_v)>;


### PR DESCRIPTION
## Proposed changes

- Store boundary conditions in a separate tag in the global cache.
- Allows to serialize the domain into volume data files and read it back in with another executable.
- Also clean up the domain creator tests. Removing some tests that only duplicate src code and adding tests that check consistency of domain creators.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Boundary conditions have moved. They are not stored in the `Domain` anymore but separately in `domain::Tags::ExternalBoundaryConditions` in the global cache.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
