### PR TITLE
Add largest char speed for GH+GRMHD

### DIFF
--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
@@ -16,6 +16,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  Characteristics.hpp
   Constraints.hpp
   System.hpp
   StressEnergy.hpp

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Characteristics.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Characteristics.hpp
@@ -1,0 +1,43 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace grmhd::GhValenciaDivClean::Tags {
+struct LargestCharacteristicSpeed : db::SimpleTag {
+  using type = double;
+};
+
+/*!
+ * \brief Computes the largest magnitude of the characteristic speeds.
+ *
+ * \warning Assumes \f$-1\le\gamma_1\le0\f$.
+ */
+template <typename Frame = Frame::Inertial>
+struct ComputeLargestCharacteristicSpeed : db::ComputeTag,
+                                           LargestCharacteristicSpeed {
+  using argument_tags =
+      tmpl::list<gr::Tags::Lapse<DataVector>,
+                 gr::Tags::Shift<3, Frame, DataVector>,
+                 gr::Tags::SpatialMetric<3, Frame, DataVector>>;
+  using return_type = double;
+  using base = LargestCharacteristicSpeed;
+  static void function(const gsl::not_null<double*> speed,
+                       const Scalar<DataVector>& lapse,
+                       const tnsr::I<DataVector, 3, Frame>& shift,
+                       const tnsr::ii<DataVector, 3, Frame>& spatial_metric) {
+    const auto shift_magnitude = magnitude(shift, spatial_metric);
+    *speed = max(get(shift_magnitude) + get(lapse));
+  }
+};
+}  // namespace grmhd::GhValenciaDivClean::Tags

--- a/tests/Unit/Evolution/Systems/ForceFree/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ForceFree/CMakeLists.txt
@@ -23,5 +23,6 @@ target_link_libraries(
   DataStructures
   Domain
   ForceFree
+  GeneralRelativityHelpers
   Utilities
   )

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBRARY_SOURCES
   Subcell/Test_PrimitiveGhostData.cpp
   Subcell/Test_PrimsAfterRollback.cpp
   Subcell/Test_ResizeAndComputePrimitives.cpp
+  Test_Characteristics.cpp
   Test_Constraints.cpp
   Test_Tags.cpp
   Test_StressEnergy.cpp

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Test_Characteristics.cpp
@@ -1,0 +1,42 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <limits>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/Characteristics.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/PointwiseFunctions/GeneralRelativity/TestHelpers.hpp"
+
+namespace {
+void check_max_char_speed(const DataVector& used_for_size) {
+  MAKE_GENERATOR(gen);
+
+  const Scalar<DataVector> gamma_1{used_for_size.size(), 0.0};
+  const auto lapse = TestHelpers::gr::random_lapse(&gen, used_for_size);
+  const auto shift = TestHelpers::gr::random_shift<3>(&gen, used_for_size);
+  const auto spatial_metric =
+      TestHelpers::gr::random_spatial_metric<3>(&gen, used_for_size);
+
+  double max_char_speed = std::numeric_limits<double>::signaling_NaN();
+  grmhd::GhValenciaDivClean::Tags::ComputeLargestCharacteristicSpeed<
+      Frame::Inertial>::function(make_not_null(&max_char_speed), lapse, shift,
+                                 spatial_metric);
+
+  double gh_max_char_speed = std::numeric_limits<double>::signaling_NaN();
+  GeneralizedHarmonic::Tags::ComputeLargestCharacteristicSpeed<
+      3, Frame::Inertial>::function(make_not_null(&gh_max_char_speed), gamma_1,
+                                    lapse, shift, spatial_metric);
+  CHECK(max_char_speed == gh_max_char_speed);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.GrMhd.GhValenciaDivClean.MaxCharSpeed",
+    "[Unit][Evolution]") {
+  check_max_char_speed(DataVector(5));
+}


### PR DESCRIPTION
## Proposed changes

This assumes -1<gamma_1<=0 which in our normal simulations it always is. I think the condition where this check is sufficient is more relaxed than that, but values of gamma_1 outside that range probably shouldn't be used anyway. Or at least not far outside that range.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
