### PR TITLE
Damped harmonic cleanups, part 1

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/DuDtTempTags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/DuDtTempTags.hpp
@@ -17,8 +17,8 @@ struct Gamma1Gamma2 : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 
-/// \f$\Pi_{ab}n^an^b\f$
-struct PiTwoNormals : db::SimpleTag {
+/// \f$0.5\Pi_{ab}n^an^b\f$
+struct HalfPiTwoNormals : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 
@@ -38,9 +38,9 @@ struct PiOneNormal : db::SimpleTag {
   using type = tnsr::a<DataVector, Dim, Frame::Inertial>;
 };
 
-/// \f$\Phi_{iab}n^an^b\f$
+/// \f$0.5\Phi_{iab}n^an^b\f$
 template <size_t Dim>
-struct PhiTwoNormals : db::SimpleTag {
+struct HalfPhiTwoNormals : db::SimpleTag {
   using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
 };
 

--- a/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.cpp
@@ -35,12 +35,12 @@ void TimeDerivative<Dim>::apply(
     const gsl::not_null<tnsr::ab<DataVector, Dim>*>
         temp_spacetime_deriv_gauge_function,
     const gsl::not_null<Scalar<DataVector>*> gamma1gamma2,
-    const gsl::not_null<Scalar<DataVector>*> pi_two_normals,
+    const gsl::not_null<Scalar<DataVector>*> half_pi_two_normals,
     const gsl::not_null<Scalar<DataVector>*> normal_dot_gauge_constraint,
     const gsl::not_null<Scalar<DataVector>*> gamma1_plus_1,
     const gsl::not_null<tnsr::a<DataVector, Dim>*> pi_one_normal,
     const gsl::not_null<tnsr::a<DataVector, Dim>*> gauge_constraint,
-    const gsl::not_null<tnsr::i<DataVector, Dim>*> phi_two_normals,
+    const gsl::not_null<tnsr::i<DataVector, Dim>*> half_phi_two_normals,
     const gsl::not_null<tnsr::aa<DataVector, Dim>*>
         shift_dot_three_index_constraint,
     const gsl::not_null<tnsr::aa<DataVector, Dim>*>
@@ -162,12 +162,13 @@ void TimeDerivative<Dim>::apply(
     }
   }
 
-  get(*pi_two_normals) =
+  get(*half_pi_two_normals) =
       get<0>(*normal_spacetime_vector) * get<0>(*pi_one_normal);
   for (size_t mu = 1; mu < Dim + 1; ++mu) {
-    get(*pi_two_normals) +=
+    get(*half_pi_two_normals) +=
         normal_spacetime_vector->get(mu) * pi_one_normal->get(mu);
   }
+  get(*half_pi_two_normals) *= 0.5;
 
   for (size_t n = 0; n < Dim; ++n) {
     for (size_t nu = 0; nu < Dim + 1; ++nu) {
@@ -181,12 +182,13 @@ void TimeDerivative<Dim>::apply(
   }
 
   for (size_t n = 0; n < Dim; ++n) {
-    phi_two_normals->get(n) =
+    half_phi_two_normals->get(n) =
         get<0>(*normal_spacetime_vector) * phi_one_normal->get(n, 0);
     for (size_t mu = 1; mu < Dim + 1; ++mu) {
-      phi_two_normals->get(n) +=
+      half_phi_two_normals->get(n) +=
           normal_spacetime_vector->get(mu) * phi_one_normal->get(n, mu);
     }
+    half_phi_two_normals->get(n) *= 0.5;
   }
 
   for (size_t n = 0; n < Dim; ++n) {
@@ -258,7 +260,7 @@ void TimeDerivative<Dim>::apply(
       dt_pi->get(mu, nu) =
           -spacetime_deriv_gauge_function.get(mu, nu) -
           spacetime_deriv_gauge_function.get(nu, mu) -
-          0.5 * get(*pi_two_normals) * pi.get(mu, nu) +
+          get(*half_pi_two_normals) * pi.get(mu, nu) +
           get(gamma0) *
               (normal_spacetime_one_form->get(mu) * gauge_constraint->get(nu) +
                normal_spacetime_one_form->get(nu) * gauge_constraint->get(mu)) -
@@ -313,7 +315,7 @@ void TimeDerivative<Dim>::apply(
     for (size_t mu = 0; mu < Dim + 1; ++mu) {
       for (size_t nu = mu; nu < Dim + 1; ++nu) {
         dt_phi->get(i, mu, nu) =
-            0.5 * pi.get(mu, nu) * phi_two_normals->get(i) -
+            pi.get(mu, nu) * half_phi_two_normals->get(i) -
             d_pi.get(i, mu, nu) +
             get(gamma2) * three_index_constraint->get(i, mu, nu);
         for (size_t n = 0; n < Dim; ++n) {

--- a/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.hpp
@@ -100,9 +100,10 @@ struct TimeDerivative {
       ::GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1,
       ::GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma2,
       Tags::GaugeH<Dim>, Tags::SpacetimeDerivGaugeH<Dim>, Tags::Gamma1Gamma2,
-      Tags::PiTwoNormals, Tags::NormalDotOneIndexConstraint, Tags::Gamma1Plus1,
-      Tags::PiOneNormal<Dim>, Tags::GaugeConstraint<Dim, Frame::Inertial>,
-      Tags::PhiTwoNormals<Dim>, Tags::ShiftDotThreeIndexConstraint<Dim>,
+      Tags::HalfPiTwoNormals, Tags::NormalDotOneIndexConstraint,
+      Tags::Gamma1Plus1, Tags::PiOneNormal<Dim>,
+      Tags::GaugeConstraint<Dim, Frame::Inertial>, Tags::HalfPhiTwoNormals<Dim>,
+      Tags::ShiftDotThreeIndexConstraint<Dim>,
       Tags::MeshVelocityDotThreeIndexConstraint<Dim>, Tags::PhiOneNormal<Dim>,
       Tags::PiSecondIndexUp<Dim>,
       Tags::ThreeIndexConstraint<Dim, Frame::Inertial>,
@@ -140,12 +141,12 @@ struct TimeDerivative {
       gsl::not_null<tnsr::ab<DataVector, Dim>*>
           temp_spacetime_deriv_gauge_function,
       gsl::not_null<Scalar<DataVector>*> gamma1gamma2,
-      gsl::not_null<Scalar<DataVector>*> pi_two_normals,
+      gsl::not_null<Scalar<DataVector>*> half_half_pi_two_normals,
       gsl::not_null<Scalar<DataVector>*> normal_dot_gauge_constraint,
       gsl::not_null<Scalar<DataVector>*> gamma1_plus_1,
       gsl::not_null<tnsr::a<DataVector, Dim>*> pi_one_normal,
       gsl::not_null<tnsr::a<DataVector, Dim>*> gauge_constraint,
-      gsl::not_null<tnsr::i<DataVector, Dim>*> phi_two_normals,
+      gsl::not_null<tnsr::i<DataVector, Dim>*> half_phi_two_normals,
       gsl::not_null<tnsr::aa<DataVector, Dim>*>
           shift_dot_three_index_constraint,
       gsl::not_null<tnsr::aa<DataVector, Dim>*>

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_DuDt.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_DuDt.cpp
@@ -573,12 +573,12 @@ void test_compute_dudt(const gsl::not_null<Generator*> generator) {
       GeneralizedHarmonic::Tags::GaugeH<Dim>,
       GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<Dim>,
       GeneralizedHarmonic::Tags::Gamma1Gamma2,
-      GeneralizedHarmonic::Tags::PiTwoNormals,
+      GeneralizedHarmonic::Tags::HalfPiTwoNormals,
       GeneralizedHarmonic::Tags::NormalDotOneIndexConstraint,
       GeneralizedHarmonic::Tags::Gamma1Plus1,
       GeneralizedHarmonic::Tags::PiOneNormal<Dim>,
       GeneralizedHarmonic::Tags::GaugeConstraint<Dim, Frame::Inertial>,
-      GeneralizedHarmonic::Tags::PhiTwoNormals<Dim>,
+      GeneralizedHarmonic::Tags::HalfPhiTwoNormals<Dim>,
       GeneralizedHarmonic::Tags::ShiftDotThreeIndexConstraint<Dim>,
       GeneralizedHarmonic::Tags::MeshVelocityDotThreeIndexConstraint<Dim>,
       GeneralizedHarmonic::Tags::PhiOneNormal<Dim>,
@@ -616,7 +616,7 @@ void test_compute_dudt(const gsl::not_null<Generator*> generator) {
       make_not_null(
           &get<GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<Dim>>(buffer)),
       make_not_null(&get<GeneralizedHarmonic::Tags::Gamma1Gamma2>(buffer)),
-      make_not_null(&get<GeneralizedHarmonic::Tags::PiTwoNormals>(buffer)),
+      make_not_null(&get<GeneralizedHarmonic::Tags::HalfPiTwoNormals>(buffer)),
       make_not_null(
           &get<GeneralizedHarmonic::Tags::NormalDotOneIndexConstraint>(buffer)),
       make_not_null(&get<GeneralizedHarmonic::Tags::Gamma1Plus1>(buffer)),
@@ -626,7 +626,7 @@ void test_compute_dudt(const gsl::not_null<Generator*> generator) {
               GeneralizedHarmonic::Tags::GaugeConstraint<Dim, Frame::Inertial>>(
               buffer)),
       make_not_null(
-          &get<GeneralizedHarmonic::Tags::PhiTwoNormals<Dim>>(buffer)),
+          &get<GeneralizedHarmonic::Tags::HalfPhiTwoNormals<Dim>>(buffer)),
       make_not_null(
           &get<GeneralizedHarmonic::Tags::ShiftDotThreeIndexConstraint<Dim>>(
               buffer)),
@@ -739,7 +739,7 @@ void test_compute_dudt(const gsl::not_null<Generator*> generator) {
       make_not_null(
           &get<GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<Dim>>(buffer)),
       make_not_null(&get<GeneralizedHarmonic::Tags::Gamma1Gamma2>(buffer)),
-      make_not_null(&get<GeneralizedHarmonic::Tags::PiTwoNormals>(buffer)),
+      make_not_null(&get<GeneralizedHarmonic::Tags::HalfPiTwoNormals>(buffer)),
       make_not_null(
           &get<GeneralizedHarmonic::Tags::NormalDotOneIndexConstraint>(buffer)),
       make_not_null(&get<GeneralizedHarmonic::Tags::Gamma1Plus1>(buffer)),
@@ -749,7 +749,7 @@ void test_compute_dudt(const gsl::not_null<Generator*> generator) {
               GeneralizedHarmonic::Tags::GaugeConstraint<Dim, Frame::Inertial>>(
               buffer)),
       make_not_null(
-          &get<GeneralizedHarmonic::Tags::PhiTwoNormals<Dim>>(buffer)),
+          &get<GeneralizedHarmonic::Tags::HalfPhiTwoNormals<Dim>>(buffer)),
       make_not_null(&shift_dot_three_index_constraint),
       make_not_null(&mesh_velocity_dot_three_index_constraint),
       make_not_null(&get<GeneralizedHarmonic::Tags::PhiOneNormal<Dim>>(buffer)),
@@ -812,7 +812,7 @@ void test_compute_dudt(const gsl::not_null<Generator*> generator) {
       make_not_null(
           &get<GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<Dim>>(buffer)),
       make_not_null(&get<GeneralizedHarmonic::Tags::Gamma1Gamma2>(buffer)),
-      make_not_null(&get<GeneralizedHarmonic::Tags::PiTwoNormals>(buffer)),
+      make_not_null(&get<GeneralizedHarmonic::Tags::HalfPiTwoNormals>(buffer)),
       make_not_null(
           &get<GeneralizedHarmonic::Tags::NormalDotOneIndexConstraint>(buffer)),
       make_not_null(&get<GeneralizedHarmonic::Tags::Gamma1Plus1>(buffer)),
@@ -822,7 +822,7 @@ void test_compute_dudt(const gsl::not_null<Generator*> generator) {
               GeneralizedHarmonic::Tags::GaugeConstraint<Dim, Frame::Inertial>>(
               buffer)),
       make_not_null(
-          &get<GeneralizedHarmonic::Tags::PhiTwoNormals<Dim>>(buffer)),
+          &get<GeneralizedHarmonic::Tags::HalfPhiTwoNormals<Dim>>(buffer)),
       make_not_null(&shift_dot_three_index_constraint),
       make_not_null(&mesh_velocity_dot_three_index_constraint),
       make_not_null(&get<GeneralizedHarmonic::Tags::PhiOneNormal<Dim>>(buffer)),

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_DuDtTempTags.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_DuDtTempTags.cpp
@@ -12,8 +12,8 @@ template <size_t Dim>
 void test_simple_tags() {
   TestHelpers::db::test_simple_tag<GeneralizedHarmonic::Tags::Gamma1Gamma2>(
       "Gamma1Gamma2");
-  TestHelpers::db::test_simple_tag<GeneralizedHarmonic::Tags::PiTwoNormals>(
-      "PiTwoNormals");
+  TestHelpers::db::test_simple_tag<GeneralizedHarmonic::Tags::HalfPiTwoNormals>(
+      "HalfPiTwoNormals");
   TestHelpers::db::test_simple_tag<
       GeneralizedHarmonic::Tags::NormalDotOneIndexConstraint>(
       "NormalDotOneIndexConstraint");
@@ -22,7 +22,7 @@ void test_simple_tags() {
   TestHelpers::db::test_simple_tag<GeneralizedHarmonic::Tags::PiOneNormal<Dim>>(
       "PiOneNormal");
   TestHelpers::db::test_simple_tag<
-      GeneralizedHarmonic::Tags::PhiTwoNormals<Dim>>("PhiTwoNormals");
+      GeneralizedHarmonic::Tags::HalfPhiTwoNormals<Dim>>("HalfPhiTwoNormals");
   TestHelpers::db::test_simple_tag<
       GeneralizedHarmonic::Tags::ShiftDotThreeIndexConstraint<Dim>>(
       "ShiftDotThreeIndexConstraint");

--- a/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/VerifyGrSolution.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/VerifyGrSolution.hpp
@@ -249,12 +249,12 @@ void verify_time_independent_einstein_solution(
       GeneralizedHarmonic::Tags::GaugeH<3>,
       GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<3>,
       GeneralizedHarmonic::Tags::Gamma1Gamma2,
-      GeneralizedHarmonic::Tags::PiTwoNormals,
+      GeneralizedHarmonic::Tags::HalfPiTwoNormals,
       GeneralizedHarmonic::Tags::NormalDotOneIndexConstraint,
       GeneralizedHarmonic::Tags::Gamma1Plus1,
       GeneralizedHarmonic::Tags::PiOneNormal<3>,
       GeneralizedHarmonic::Tags::GaugeConstraint<3, Frame::Inertial>,
-      GeneralizedHarmonic::Tags::PhiTwoNormals<3>,
+      GeneralizedHarmonic::Tags::HalfPhiTwoNormals<3>,
       GeneralizedHarmonic::Tags::ShiftDotThreeIndexConstraint<3>,
       GeneralizedHarmonic::Tags::MeshVelocityDotThreeIndexConstraint<3>,
       GeneralizedHarmonic::Tags::PhiOneNormal<3>,
@@ -290,7 +290,7 @@ void verify_time_independent_einstein_solution(
       make_not_null(
           &get<GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<3>>(buffer)),
       make_not_null(&get<GeneralizedHarmonic::Tags::Gamma1Gamma2>(buffer)),
-      make_not_null(&get<GeneralizedHarmonic::Tags::PiTwoNormals>(buffer)),
+      make_not_null(&get<GeneralizedHarmonic::Tags::HalfPiTwoNormals>(buffer)),
       make_not_null(
           &get<GeneralizedHarmonic::Tags::NormalDotOneIndexConstraint>(buffer)),
       make_not_null(&get<GeneralizedHarmonic::Tags::Gamma1Plus1>(buffer)),
@@ -298,7 +298,8 @@ void verify_time_independent_einstein_solution(
       make_not_null(
           &get<GeneralizedHarmonic::Tags::GaugeConstraint<3, Frame::Inertial>>(
               buffer)),
-      make_not_null(&get<GeneralizedHarmonic::Tags::PhiTwoNormals<3>>(buffer)),
+      make_not_null(
+          &get<GeneralizedHarmonic::Tags::HalfPhiTwoNormals<3>>(buffer)),
       make_not_null(
           &get<GeneralizedHarmonic::Tags::ShiftDotThreeIndexConstraint<3>>(
               buffer)),


### PR DESCRIPTION
## Proposed changes

- Refactor the test a bit so that it's much easier to test changes to the DH gauge. Specifically, the goal is to only specify metric, pi and phi and compute everything else from that.
- Refactor DH gauge a bit to eliminate a bunch of redundant work. The next PR in this series will do even more of that, basically taking things that the GH RHS already computing as arguments rather than recomputing them.
- Multiply phi & pi 2 two normals by 0.5 because this is what we need in the GH RHS and also the DH gauge. The GH gauge will use phi & pi two normals in a followup PR.
<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
