### PR TITLE
Remove unused template parameter for DgDomain initializer

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -422,8 +422,7 @@ struct EvolutionMetavars {
 
   using initialization_actions = tmpl::list<
       Initialization::Actions::TimeAndTimeStep<EvolutionMetavars>,
-      evolution::dg::Initialization::Domain<
-          volume_dim, override_functions_of_time, use_control_systems>,
+      evolution::dg::Initialization::Domain<volume_dim, use_control_systems>,
       Initialization::Actions::NonconservativeSystem<system>,
       Initialization::Actions::AddComputeTags<::Tags::DerivCompute<
           typename system::variables_tag,

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -182,10 +182,6 @@ struct GeneralizedHarmonicTemplateBase<
       dg::Formulation::StrongInertial;
   using temporal_id = Tags::TimeStepId;
   static constexpr bool local_time_stepping = false;
-  // Set override_functions_of_time to true to override the
-  // 2nd or 3rd order piecewise polynomial functions of time using
-  // `read_spec_piecewise_polynomial()`
-  static constexpr bool override_functions_of_time = false;
 
   using analytic_solution_fields = typename system::variables_tag::tags_list;
 
@@ -346,8 +342,7 @@ struct GeneralizedHarmonicTemplateBase<
 
   using initialization_actions = tmpl::list<
       Initialization::Actions::TimeAndTimeStep<derived_metavars>,
-      evolution::dg::Initialization::Domain<volume_dim,
-                                            override_functions_of_time>,
+      evolution::dg::Initialization::Domain<volume_dim>,
       Initialization::Actions::NonconservativeSystem<system>,
       std::conditional_t<
           UseNumericalInitialData, tmpl::list<>,

--- a/src/Evolution/Initialization/DgDomain.hpp
+++ b/src/Evolution/Initialization/DgDomain.hpp
@@ -84,12 +84,8 @@ namespace Initialization {
  *   - `domain::Tags::MinimumGridSpacingCompute<Dim, Frame::Inertial>>`
  * - Removes: nothing
  * - Modifies: nothing
- *
- * \note If OverrideCubicFunctionsOfTime == true, then cubic functions
- * of time are overriden via `read_spec_piecewise_polynomial()`
  */
-template <size_t Dim, bool OverrideCubicFunctionsOfTime = false,
-          bool UseControlSystems = false>
+template <size_t Dim, bool UseControlSystems = false>
 struct Domain {
   using initialization_tags =
       tmpl::list<::domain::Tags::InitialExtents<Dim>,

--- a/tests/Unit/Evolution/Initialization/Test_DgDomain.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_DgDomain.cpp
@@ -169,7 +169,7 @@ void test(const Spectral::Quadrature quadrature) {
                      tmpl::list<::domain::Tags::FunctionsOfTimeInitialize>>);
   static_assert(std::is_same_v<
                 typename evolution::dg::Initialization::Domain<
-                    Dim, false, true>::mutable_global_cache_tags,
+                    Dim, true>::mutable_global_cache_tags,
                 tmpl::list<control_system::Tags::FunctionsOfTimeInitialize>>);
 
   PUPable_reg(SINGLE_ARG(


### PR DESCRIPTION
## Proposed changes

Remove unused template parameter `OverrideCubicFunctionsOfTime` from `evolution::dg::Initialization::Domain`

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
If you passed in two or more template parameters to `evolution::dg::Initialization::Domain`, eliminate the second one.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
