### PR TITLE
Choose if control systems are active at runtime

### DIFF
--- a/src/ControlSystem/Tags/MeasurementTimescales.hpp
+++ b/src/ControlSystem/Tags/MeasurementTimescales.hpp
@@ -62,6 +62,10 @@ namespace Tags {
 /// Each function of time associated with a control system has a corresponding
 /// set of timescales here, represented as `PiecewisePolynomial<0>` with the
 /// same components as the function itself.
+///
+/// If the control system isn't active or the function of time is being
+/// overridden from inputs, then the measurement timescale and expiration time
+/// are `std::numeric_limits<double>::infinity()`.
 struct MeasurementTimescales : db::SimpleTag {
   using type = std::unordered_map<
       std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>;
@@ -134,6 +138,15 @@ struct MeasurementTimescales : db::SimpleTag {
                       std::numeric_limits<double>::infinity();
                 }
               }
+            }
+          }
+
+          // If the control system isn't active, set measurement timescale to be
+          // infinity. The expiration time is already infinity in that case
+          if (not option_holder.is_active) {
+            for (size_t i = 0; i < measurement_timescales.size(); i++) {
+              measurement_timescales[i] =
+                  std::numeric_limits<double>::infinity();
             }
           }
 

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -250,6 +250,7 @@ ApparentHorizons:
 ControlSystems:
   WriteDataToDisk: true
   Expansion:
+    IsActive: true
     Averager:
       AverageTimescaleFraction: 0.25
       Average0thDeriv: false
@@ -265,6 +266,7 @@ ControlSystems:
       DecreaseFactor: 0.98
     ControlError:
   Rotation:
+    IsActive: true
     Averager:
       AverageTimescaleFraction: 0.25
       Average0thDeriv: false

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
@@ -42,6 +42,7 @@ void test_expansion_control_error() {
       "ControlSystems:\n"
       "  WriteDataToDisk: false\n"
       "  Expansion:\n"
+      "    IsActive: true\n"
       "    Averager:\n"
       "      AverageTimescaleFraction: 0.25\n"
       "      Average0thDeriv: true\n"

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
@@ -47,6 +47,7 @@ void test_rotation_control_error() {
       "ControlSystems:\n"
       "  WriteDataToDisk: false\n"
       "  Rotation:\n"
+      "    IsActive: true\n"
       "    Averager:\n"
       "      AverageTimescaleFraction: 0.25\n"
       "      Average0thDeriv: true\n"

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Translation.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Translation.cpp
@@ -48,6 +48,7 @@ void test_translation_control_error() {
       "ControlSystems:\n"
       "  WriteDataToDisk: false\n"
       "  Translation:\n"
+      "    IsActive: true\n"
       "    Averager:\n"
       "      AverageTimescaleFraction: 0.25\n"
       "      Average0thDeriv: true\n"

--- a/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
@@ -65,6 +65,7 @@ void test_expansion_control_system() {
       "ControlSystems:\n"
       "  WriteDataToDisk: false\n"
       "  Expansion:\n"
+      "    IsActive: true\n"
       "    Averager:\n"
       "      AverageTimescaleFraction: 0.25\n"
       "      Average0thDeriv: true\n"

--- a/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
@@ -47,6 +47,7 @@ using CoordMap =
 std::string create_input_string(const std::string& name) {
   const std::string name_str = "  "s + name + ":\n"s;
   const std::string base_string1{
+      "    IsActive: true\n"
       "    Averager:\n"
       "      AverageTimescaleFraction: 0.25\n"
       "      Average0thDeriv: true\n"

--- a/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
@@ -66,6 +66,7 @@ void test_rotation_control_system(const bool newtonian) {
       "ControlSystems:\n"
       "  WriteDataToDisk: false\n"
       "  Rotation:\n"
+      "    IsActive: true\n"
       "    Averager:\n"
       "      AverageTimescaleFraction: 0.25\n"
       "      Average0thDeriv: true\n"

--- a/tests/Unit/ControlSystem/Systems/Test_Shape.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Shape.cpp
@@ -242,6 +242,7 @@ void test_suite(const gsl::not_null<Generator*> generator, const size_t l_max,
       "ControlSystems:\n"
       "  WriteDataToDisk: false\n"
       "  ShapeA:\n"
+      "    IsActive: true\n"
       "    Averager:\n"
       "      AverageTimescaleFraction: 0.25\n"
       "      Average0thDeriv: true\n"

--- a/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
@@ -72,6 +72,7 @@ void test_translation_control_system() {
       "ControlSystems:\n"
       "  WriteDataToDisk: false\n"
       "  Translation:\n"
+      "    IsActive: true\n"
       "    Averager:\n"
       "      AverageTimescaleFraction: 0.25\n"
       "      Average0thDeriv: true\n"

--- a/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
@@ -211,9 +211,12 @@ void test_functions_of_time_tag() {
   const Controller<2> controller(update_fraction);
   const control_system::TestHelpers::ControlError control_error{};
 
-  OptionHolder<1> option_holder1(averager, controller, tuner1, control_error);
-  OptionHolder<2> option_holder2(averager, controller, tuner1, control_error);
-  OptionHolder<3> option_holder3(averager, controller, tuner2, control_error);
+  OptionHolder<1> option_holder1(false, averager, controller, tuner1,
+                                 control_error);
+  OptionHolder<2> option_holder2(true, averager, controller, tuner1,
+                                 control_error);
+  OptionHolder<3> option_holder3(true, averager, controller, tuner2,
+                                 control_error);
 
   // First test construction with only control systems and no
   // override_functions_of_time
@@ -223,7 +226,7 @@ void test_functions_of_time_tag() {
       option_holder3);
 
   CHECK(functions_of_time.at("Controlled1")->time_bounds()[1] ==
-        initial_time + update_fraction * timescale);
+        std::numeric_limits<double>::infinity());
   CHECK(functions_of_time.at("Controlled2")->time_bounds()[1] ==
         initial_time + update_fraction * timescale);
   CHECK(functions_of_time.at("Controlled3")->time_bounds()[1] ==
@@ -326,7 +329,7 @@ void test_functions_of_time_tag() {
             creator, std::nullopt, test_name_map, initial_time,
             initial_time_step, option_holder1, option_holder2, option_holder3);
     CHECK(no_replace_functions_of_time.at("Controlled1")->time_bounds()[1] ==
-          initial_time + update_fraction * timescale);
+          std::numeric_limits<double>::infinity());
     CHECK(no_replace_functions_of_time.at("Controlled2")->time_bounds()[1] ==
           initial_time + update_fraction * timescale);
     CHECK(no_replace_functions_of_time.at("Controlled3")->time_bounds()[1] ==
@@ -407,13 +410,13 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Tags.FunctionsOfTimeInitialize",
         const Controller<2> controller(update_fraction);
         const control_system::TestHelpers::ControlError control_error{};
 
-        OptionHolder<1> option_holder1(averager, controller, tuner,
+        OptionHolder<1> option_holder1(true, averager, controller, tuner,
                                        control_error);
-        OptionHolder<2> option_holder2(averager, controller, tuner,
+        OptionHolder<2> option_holder2(true, averager, controller, tuner,
                                        control_error);
-        OptionHolder<3> option_holder3(averager, controller, tuner,
+        OptionHolder<3> option_holder3(true, averager, controller, tuner,
                                        control_error);
-        OptionHolder<4> option_holder4(averager, controller, tuner,
+        OptionHolder<4> option_holder4(true, averager, controller, tuner,
                                        control_error);
 
         const double initial_time_step = 1.0;
@@ -438,11 +441,11 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Tags.FunctionsOfTimeInitialize",
         const Controller<2> controller(update_fraction);
         const control_system::TestHelpers::ControlError control_error{};
 
-        OptionHolder<1> option_holder1(averager, controller, tuner,
+        OptionHolder<1> option_holder1(true, averager, controller, tuner,
                                        control_error);
-        OptionHolder<2> option_holder2(averager, controller, tuner,
+        OptionHolder<2> option_holder2(true, averager, controller, tuner,
                                        control_error);
-        OptionHolder<3> option_holder3(averager, controller, tuner,
+        OptionHolder<3> option_holder3(true, averager, controller, tuner,
                                        control_error);
 
         const double initial_time_step = 1.0;

--- a/tests/Unit/ControlSystem/Test_InitialExpirationTimes.cpp
+++ b/tests/Unit/ControlSystem/Test_InitialExpirationTimes.cpp
@@ -3,6 +3,7 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <limits>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -70,9 +71,12 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.ConstructInitialExpirationTimes",
   const Controller<2> controller(update_fraction);
   const control_system::TestHelpers::ControlError control_error{};
 
-  OptionHolder<1> option_holder1(averager, controller, tuner1, control_error);
-  OptionHolder<2> option_holder2(averager, controller, tuner1, control_error);
-  OptionHolder<3> option_holder3(averager, controller, tuner2, control_error);
+  OptionHolder<1> option_holder1(true, averager, controller, tuner1,
+                                 control_error);
+  OptionHolder<2> option_holder2(false, averager, controller, tuner1,
+                                 control_error);
+  OptionHolder<3> option_holder3(true, averager, controller, tuner2,
+                                 control_error);
 
   using FakeCreator = control_system::TestHelpers::FakeCreator;
 
@@ -125,7 +129,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.ConstructInitialExpirationTimes",
             {FakeControlSystem<1>::name(),
              initial_time + update_fraction * timescale},
             {FakeControlSystem<2>::name(),
-             initial_time + update_fraction * timescale},
+             std::numeric_limits<double>::infinity()},
             {FakeControlSystem<3>::name(), initial_time + initial_time_step}};
 
     check_expiration_times(expected_initial_expiration_times,


### PR DESCRIPTION
## Proposed changes

This allows us to turn on and off control systems without recompiling. If all control systems are inactive, then no measurements should happen. This is very useful for debugging.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
