### PR TITLE
Drop Python 2 support

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -338,12 +338,12 @@ jobs:
             COVERAGE: ON
             TEST_TIMEOUT_FACTOR: 3
             ccache_max_size: 2.3G
-          # Test with Python 2 so that we retain backwards compatibility. We
+          # Test with Python 3.7 so that we retain backwards compatibility. We
           # keep track of Python versions on supercomputers in this issue:
           # https://github.com/sxs-collaboration/spectre/issues/442
           - compiler: gcc-11
             build_type: Debug
-            PYTHON_EXECUTABLE: /usr/bin/python2
+            PYTHON_EXECUTABLE: /usr/bin/python3.7
           # Add a test without PCH to the build matrix, which only builds core
           # libraries. Building all the tests without the PCH takes very long
           # and the most we would catch is a missing include of something that's

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,10 @@ set(CMAKE_VERBOSE_MAKEFILE OFF)
 include(SpectreGetGitHash)
 include(SpectreSetSiteName)
 
+# We need Python in the build system and throughout the code. Setting it up
+# early so we can rely on a consistent Python version in the build system.
+find_package(Python 3.7 REQUIRED)
+
 option(BUILD_DOCS "Enable building documentation" ON)
 option(
   DOCS_ONLY

--- a/cmake/AddInputFileTests.cmake
+++ b/cmake/AddInputFileTests.cmake
@@ -3,8 +3,6 @@
 
 spectre_define_test_timeout_factor_option(INPUT_FILE "input file")
 
-find_package(Python REQUIRED)
-
 # Environment variables for test
 set(_TEST_ENV_VARS "")
 # - Disable ASAN's leak sanitizer because Charm++ has false positives

--- a/cmake/FindNumPy.cmake
+++ b/cmake/FindNumPy.cmake
@@ -1,8 +1,6 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-find_package(Python REQUIRED)
-
 execute_process(COMMAND "${Python_EXECUTABLE}" "-c"
   "import numpy as n; print(n.__version__); print(n.get_include());"
   RESULT_VARIABLE RESULT

--- a/cmake/FindYapf.cmake
+++ b/cmake/FindYapf.cmake
@@ -7,7 +7,6 @@ if(NOT YAPF_ROOT)
   set(YAPF_ROOT $ENV{YAPF_ROOT})
 endif()
 
-find_package(Python)
 get_filename_component(PYTHON_BIN_DIR ${Python_EXECUTABLE} DIRECTORY)
 
 # Look for an executable called yapf

--- a/cmake/SetupDoxygen.cmake
+++ b/cmake/SetupDoxygen.cmake
@@ -1,8 +1,6 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-find_package(Python REQUIRED)
-
 # Targets to preprocess the documentation
 # - Convert all `.ipynb` files in `docs/` to markdown, so they get picked up by
 #   Doxygen.

--- a/cmake/SetupGitHooks.cmake
+++ b/cmake/SetupGitHooks.cmake
@@ -2,10 +2,7 @@
 # See LICENSE.txt for details.
 
 # Allow disabling the Git hooks because if you are running the code in a
-# container the host may not have all the right things installed. For example,
-# if you are using python2 in the container, the host may not have python2
-# installed and we should instead be setting up hooks from the host or an
-# environment suitably similar to where the commits will be made.
+# container the host may not have all the right things installed.
 option(
   USE_GIT_HOOKS
   "Set up the git hooks for sanity checks."
@@ -19,8 +16,6 @@ if(USE_GIT_HOOKS)
 
   # The logic is inverted because shell
   if(NOT CHECK_SOURCE_DIR_WRITABLE_RESULT AND EXISTS ${CMAKE_SOURCE_DIR}/.git)
-    find_package(Python REQUIRED)
-
     # We use several client-side git hooks to ensure commits are correct as
     # early as possible.
     configure_file(

--- a/cmake/SetupPybind11.cmake
+++ b/cmake/SetupPybind11.cmake
@@ -5,7 +5,7 @@ option(BUILD_PYTHON_BINDINGS "Build the python bindings for SpECTRE" OFF)
 
 if(BUILD_PYTHON_BINDINGS)
   # Make sure to find Python first so it's consistent with pybind11
-  find_package(Python COMPONENTS Interpreter Development)
+  find_package(Python REQUIRED COMPONENTS Interpreter Development)
 
   # Try to find the pybind11-config tool to find pybind11's CMake config files
   find_program(PYBIND11_CONFIG_TOOL pybind11-config)

--- a/cmake/SpectreAddCatchTests.cmake
+++ b/cmake/SpectreAddCatchTests.cmake
@@ -41,8 +41,6 @@ add_custom_target(unit-tests)
 
 spectre_define_test_timeout_factor_option(UNIT "unit")
 
-find_package(Python REQUIRED)
-
 # Environment variables for test
 set(_TEST_ENV_VARS "")
 # - Disable ASAN's leak sanitizer because Charm++ has false positives

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -99,7 +99,7 @@ RUN apt-get update -y \
 # - We need `coverxygen`, `beautifulsoup4` and `pybtex` to build documentation
 #   on CI. `nbconvert` is used to process ipynb files.
 # - We need `yapf` so the CI can check Python formatting. We use a specific
-# version of it in order to avoid formatting differences between versions.
+#   version of it in order to avoid formatting differences between versions.
 RUN add-apt-repository universe \
     && apt-get update -y \
     && apt-get install -y python3-pip python-is-python3 \
@@ -295,7 +295,7 @@ RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
     && add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main' \
     && apt-get update -y && apt-get install -y clang-13
 
-# python2 for backwards compatibility
+# python2 for backwards compatibility (can be removed once PRs are rebased)
 RUN apt-get update -y \
     && apt-get install -y curl python2 python2-dev \
     && curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py \
@@ -303,6 +303,12 @@ RUN apt-get update -y \
     && pip2 --no-cache-dir install pybind11~=2.6.1 numpy scipy h5py matplotlib \
       pyyaml \
     && pip2 --no-cache-dir install unittest2
+
+# Python 3.7 for backwards compatibility
+RUN add-apt-repository ppa:deadsnakes/ppa && apt-get update -y \
+    && apt-get install -y python3.7 python3.7-dev python3.7-distutils \
+    && python3.7 -m pip --no-cache-dir install \
+        pybind11~=2.6.1 numpy scipy h5py matplotlib pyyaml
 
 # Also install our minimum required CMake version so we can test it on CI.
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.12.4/cmake-3.12.4.tar.gz \

--- a/docs/DevGuide/BuildSystem.md
+++ b/docs/DevGuide/BuildSystem.md
@@ -310,14 +310,10 @@ cmake -D FLAG1=OPT1 ... -D FLAGN=OPTN <SPECTRE_ROOT>
     reproducibility of results.
     (default is `ON`)
 - USE_GIT_HOOKS
-  - Use git hooks to perform certain sanity checks so that small goofs are
-    caught before getting to CI. Most situations where the hooks can cause
-    problems are handled automatically. The exception is when the build
-    directory is inside a (Singularity) container, we use Python 2 and the host
-    machine (where we make the commits) does not have Python 2. Except for these
-    types of cases, we strongly encourage you to keep the hooks enabled since
-    the same checks are performed during CI and there is a good reason why the
-    checks exist in the first place.
+  - Use git hooks to perform some sanity checks so that small goofs are caught
+    before they are committed. These checks are particularly useful because they
+    also run automatically on \ref github_actions_guide "CI" and must pass
+    before pull requests are merged.
     (default is `ON`)
 - USE_IWYU
   - Enable [include-what-you-use (IWYU)](https://github.com/include-what-you-use/include-what-you-use)

--- a/docs/DevGuide/PythonBindings.md
+++ b/docs/DevGuide/PythonBindings.md
@@ -110,8 +110,7 @@ above).
 
 The `DataVector` bindings serve as an example with code comments on how to write
 bindings for a class. There is also extensive documentation available directly
-from [pybind11](https://pybind11.readthedocs.io/). SpECTRE currently aims to
-support both Python 2.7 and Python 3 and as such all bindings must support both.
+from [pybind11](https://pybind11.readthedocs.io/).
 
 \note Exceptions should be allowed to propagate through the bindings so that
 error handling via exceptions is possible from python rather than having the

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -77,7 +77,7 @@ all of these dependencies.
 * [LIBXSMM](https://github.com/hfp/libxsmm) version 1.16.1 or later
 * [yaml-cpp](https://github.com/jbeder/yaml-cpp) version 0.6.3 or later.
   Building with shared library support is also recommended.
-* [Python](https://www.python.org/) 2.7, or 3.5 or later
+* [Python](https://www.python.org/) 3.7 or later.
 * [NumPy](http://www.numpy.org/) 1.10 or later
 * [SciPy](https://www.scipy.org)
 * [matplotlib](https://matplotlib.org/)

--- a/src/DataStructures/Python/DataVector.cpp
+++ b/src/DataStructures/Python/DataVector.cpp
@@ -163,11 +163,6 @@ void bind_datavector(py::module& m) {
            +[](const DataVector& self, const double other) {
              return DataVector{other * self};
            })
-      // Need __div__ for python 2 and __truediv__ for python 3.
-      .def("__div__",
-           +[](const DataVector& self, const double other) {
-             return DataVector{self / other};
-           })
       .def("__truediv__",
            +[](const DataVector& self, const double other) {
              return DataVector{self / other};

--- a/src/IO/H5/Python/ExtractDatFromH5.py
+++ b/src/IO/H5/Python/ExtractDatFromH5.py
@@ -38,8 +38,7 @@ def extract_dat_files(filename, **kwargs):
         dat_dir = out_dir + "/".join(split_path[:-1])
         dat_filename = out_dir + dat_path
 
-        if not os.path.exists(dat_dir):
-            os.makedirs(dat_dir)
+        os.makedirs(dat_dir, exist_ok=True)
 
         dat_file = h5file.get_dat(dat_path[:-4])
 

--- a/src/Visualization/Python/GenerateXdmf.py
+++ b/src/Visualization/Python/GenerateXdmf.py
@@ -7,7 +7,6 @@ import glob
 import h5py
 import logging
 import numpy as np
-import sys
 
 
 def generate_xdmf(file_prefix, output, subfile_name, start_time, stop_time,
@@ -16,12 +15,6 @@ def generate_xdmf(file_prefix, output, subfile_name, start_time, stop_time,
     Generate one XDMF file that ParaView and VisIt can use to load the data
     out of the HDF5 files.
     """
-    if sys.version_info < (3, 0):
-        logging.warning("You are attempting to run this script with "
-                        "python 2, which is deprecated. GenerateXdmf.py might "
-                        "hang or run very slowly using python 2. Please use "
-                        "python 3 instead.")
-
     h5files = [(h5py.File(filename, 'r'), filename)
                for filename in glob.glob(file_prefix + "[0-9]*.h5")]
 

--- a/tests/Unit/IO/H5/Python/Test_ExtractDatFromH5.py
+++ b/tests/Unit/IO/H5/Python/Test_ExtractDatFromH5.py
@@ -23,8 +23,7 @@ class TestExtractDatFromH5(unittest.TestCase):
                                                 "extracted_DatTestData")
         self.created_dir_input = os.path.join(self.test_dir, "WinterIsComing")
 
-        if not os.path.exists(self.test_dir):
-            os.makedirs(self.test_dir)
+        os.makedirs(self.test_dir, exist_ok=True)
         if os.path.exists(self.created_dir_default):
             shutil.rmtree(self.created_dir_default)
         if os.path.exists(self.created_dir_input):

--- a/tests/Unit/IO/H5/Test_H5.py
+++ b/tests/Unit/IO/H5/Test_H5.py
@@ -7,11 +7,6 @@ import unittest
 import numpy as np
 import os
 import numpy.testing as npt
-# For Py2 compatibility
-try:
-    unittest.TestCase.assertRaisesRegex
-except AttributeError:
-    unittest.TestCase.assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
 
 
 class TestIOH5File(unittest.TestCase):

--- a/tests/Unit/Informer/Test_InfoAtCompile.py
+++ b/tests/Unit/Informer/Test_InfoAtCompile.py
@@ -2,11 +2,8 @@
 # See LICENSE.txt for details.
 
 from spectre import Informer
-try:
-    # Fallback for Py2 that provides `assertRegex`
-    import unittest2 as unittest
-except:
-    import unittest
+
+import unittest
 
 VERSION_PATTERN = r'\d{4}\.\d{2}\.\d{2}(\.\d+)?'
 

--- a/tests/Unit/NumericalAlgorithms/Spectral/Python/Test_Mesh.py
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Python/Test_Mesh.py
@@ -3,12 +3,9 @@
 
 from spectre.Spectral import Mesh1D, Mesh2D, Mesh3D
 from spectre.Spectral import Basis, Quadrature
-try:
-    import cPickle as pickle  # Use cPickle on Python 2.7
-except ImportError:
-    import pickle
 
 import numpy as np
+import pickle
 import unittest
 import random
 
@@ -77,8 +74,7 @@ class TestMesh(unittest.TestCase):
                 ]
 
                 mesh = Mesh(extents, bases, quadratures)
-                # Use pickle protocol 2 for Py2 compatibility
-                mesh = pickle.loads(pickle.dumps(mesh, protocol=2))
+                mesh = pickle.loads(pickle.dumps(mesh))
                 self.check_extents(mesh, extents)
                 self.check_basis(mesh, bases)
                 self.check_quadrature(mesh, quadratures)

--- a/tests/Unit/Options/Python/Test_ExtractInputSourceYamlFromH5.py
+++ b/tests/Unit/Options/Python/Test_ExtractInputSourceYamlFromH5.py
@@ -10,12 +10,6 @@ import unittest
 import os
 import h5py
 
-# For Py2 compatibility
-try:
-    unittest.TestCase.assertRaisesRegex
-except AttributeError:
-    unittest.TestCase.assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
-
 
 class TestExtractInputSourceYAMLFromH5(unittest.TestCase):
     def test_read_input_source_from_h5(self):

--- a/tests/Unit/Visualization/Python/Test_GenerateXdmf.py
+++ b/tests/Unit/Visualization/Python/Test_GenerateXdmf.py
@@ -7,12 +7,6 @@ import spectre.Informer as spectre_informer
 import unittest
 import os
 
-# For Py2 compatibility
-try:
-    unittest.TestCase.assertRaisesRegex
-except AttributeError:
-    unittest.TestCase.assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
-
 
 class TestGenerateXdmf(unittest.TestCase):
     def test_generate_xdmf(self):

--- a/tests/Unit/Visualization/Python/Test_InterpolateVolumeData.py
+++ b/tests/Unit/Visualization/Python/Test_InterpolateVolumeData.py
@@ -147,14 +147,7 @@ class TestInterpolateH5(unittest.TestCase):
         vol = file.get_vol(target_volume_name)
 
         self.assertEqual(vol.get_dimension(), 3)
-
-        #python2 support...
-        try:
-            self.assertItemsEqual(vol.list_observation_ids(),
-                                  self.observation_ids)
-        except AttributeError:
-            self.assertCountEqual(vol.list_observation_ids(),
-                                  self.observation_ids)
+        self.assertCountEqual(vol.list_observation_ids(), self.observation_ids)
 
         for i, obs in enumerate(self.observation_ids):
             self.assertEqual(vol.get_grid_names(obs), self.element_names)

--- a/tests/Unit/Visualization/Python/Test_PlotDatFile.py
+++ b/tests/Unit/Visualization/Python/Test_PlotDatFile.py
@@ -8,12 +8,6 @@ import numpy as np
 import os
 import unittest
 
-# For Py2 compatibility
-try:
-    unittest.TestCase.assertRaisesRegex
-except AttributeError:
-    unittest.TestCase.assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
-
 
 class TestPlotDatFile(unittest.TestCase):
     def test_available_subfiles(self):

--- a/tools/CheckOutputFiles.py
+++ b/tools/CheckOutputFiles.py
@@ -8,13 +8,8 @@ import logging
 import numpy as np
 import numpy.testing as npt
 import os
+import unittest
 import yaml
-
-# For Py2 compatibility
-try:
-    import unittest2 as unittest
-except:
-    import unittest
 
 
 class H5Check:


### PR DESCRIPTION
## Proposed changes

Python 2 is dead. The oldest supported Python version is now 3.7 (released June 2018, EOL June 2023). It is the oldest officially maintained version and is available on all supercomputers that we run on (see #442). Allows us to use popular Py3 features like f-strings, dataclasses, type annotations, unittest features, exception chaining, enums, etc, and to stop maintaining backwards compatibility with Py2.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
If you're using Python 2, stop doing that. Upgrade to Python 3.7+ and never look back.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
