### PR TITLE
Tabulated equation of state

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/MultiLinearSpanInterpolation.hpp
+++ b/src/NumericalAlgorithms/Interpolation/MultiLinearSpanInterpolation.hpp
@@ -130,6 +130,8 @@ class MultiLinearSpanInterpolation {
                        std::make_index_sequence<Dimension>{});
   }
 
+  MultiLinearSpanInterpolation() = default;
+
   MultiLinearSpanInterpolation(
       std::array<gsl::span<const double>, Dimension> x_,
       gsl::span<const double> y_, Index<Dimension> number_of_points__);
@@ -221,7 +223,7 @@ size_t MultiLinearSpanInterpolation<
   // Use linear extrapolation based of the lowest
   // two points in the table
   ASSERT(allow_extrapolation_below_data_[which_dimension] or
-             UNLIKELY(relative_coordinate > 0.),
+             UNLIKELY(relative_coordinate >= 0.),
          "Interpolation exceeds lower table bounds.");
 
   // We are exceeding the table bounds:

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/CMakeLists.txt
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/CMakeLists.txt
@@ -12,6 +12,7 @@ spectre_target_sources(
   PolytropicFluid.cpp
   RegisterDerivedWithCharm.cpp
   Spectral.cpp
+  Tabulated3d.cpp
   )
 
 spectre_target_headers(
@@ -28,6 +29,7 @@ spectre_target_headers(
   PolytropicFluid.hpp
   RegisterDerivedWithCharm.hpp
   Spectral.hpp
+  Tabulated3d.hpp
   )
 
 add_subdirectory(Python)

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Tabulated3d.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Tabulated3d.cpp
@@ -1,0 +1,440 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/Hydro/EquationsOfState/Tabulated3d.hpp"
+
+#include <limits>
+
+#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "NumericalAlgorithms/RootFinding/TOMS748.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace EquationsOfState {
+
+EQUATION_OF_STATE_MEMBER_DEFINITIONS(template <bool IsRelativistic>,
+                                     Tabulated3D<IsRelativistic>, double, 3)
+EQUATION_OF_STATE_MEMBER_DEFINITIONS(template <bool IsRelativistic>,
+                                     Tabulated3D<IsRelativistic>, DataVector, 3)
+template <bool IsRelativistic>
+std::unique_ptr<EquationOfState<IsRelativistic, 3>>
+Tabulated3D<IsRelativistic>::get_clone() const {
+  auto clone = std::make_unique<Tabulated3D<IsRelativistic>>(*this);
+  return std::unique_ptr<EquationOfState<IsRelativistic, 3>>(std::move(clone));
+}
+
+template <bool IsRelativistic>
+void Tabulated3D<IsRelativistic>::initialize(
+    std::vector<double> electron_fraction, std::vector<double> log_density,
+    std::vector<double> log_temperature, std::vector<double> table_data,
+    double energy_shift, double enthalpy_minimum) {
+  energy_shift_ = energy_shift;
+  enthalpy_minimum_ = enthalpy_minimum;
+  table_electron_fraction_ = std::move(electron_fraction);
+  table_log_density_ = std::move(log_density);
+  table_log_temperature_ = std::move(log_temperature);
+  table_data_ = std::move(table_data);
+  // Need to table
+
+  Index<3> num_x_points;
+
+  // The order is T, rho, Ye
+  num_x_points[0] = table_log_temperature_.size();
+  num_x_points[1] = table_log_density_.size();
+  num_x_points[2] = table_electron_fraction_.size();
+
+  std::array<gsl::span<double const>, 3> independent_data_view;
+
+  independent_data_view[0] =
+      gsl::span<double const>{table_log_temperature_.data(), num_x_points[0]};
+
+  independent_data_view[1] =
+      gsl::span<double const>{table_log_density_.data(), num_x_points[1]};
+
+  independent_data_view[2] =
+      gsl::span<double const>{table_electron_fraction_.data(), num_x_points[2]};
+
+  interpolator_ = intrp::UniformMultiLinearSpanInterpolation<3, NumberOfVars>(
+      independent_data_view, {table_data_.data(), table_data_.size()},
+      num_x_points);
+}
+
+template <bool IsRelativistic>
+bool Tabulated3D<IsRelativistic>::is_equal(
+    const EquationOfState<IsRelativistic, 3>& rhs) const {
+  const auto& derived_ptr =
+      dynamic_cast<const Tabulated3D<IsRelativistic>* const>(&rhs);
+  return derived_ptr != nullptr and *derived_ptr == *this;
+}
+
+template <bool IsRelativistic>
+bool Tabulated3D<IsRelativistic>::operator==(
+    const Tabulated3D<IsRelativistic>& rhs) const {
+  bool result = true;
+  result &= (rhs.enthalpy_minimum_ == this->enthalpy_minimum_);
+  result &= (rhs.energy_shift_ == this->energy_shift_);
+  result &= (rhs.table_electron_fraction_ == this->table_electron_fraction_);
+  result &= (rhs.table_log_density_ == this->table_log_density_);
+  result &= (rhs.table_log_temperature_ == this->table_log_temperature_);
+  result &= (rhs.table_data_ == this->table_data_);
+
+  return result;
+}
+
+template <bool IsRelativistic>
+bool Tabulated3D<IsRelativistic>::operator!=(
+    const Tabulated3D<IsRelativistic>& rhs) const {
+  return not(*this == rhs);
+}
+
+template <bool IsRelativistic>
+Tabulated3D<IsRelativistic>::Tabulated3D(CkMigrateMessage* msg)
+    : EquationOfState<IsRelativistic, 3>(msg) {}
+template <bool IsRelativistic>
+template <class DataType>
+void Tabulated3D<IsRelativistic>::enforce_physicality(
+    Scalar<DataType>& electron_fraction, Scalar<DataType>& rest_mass_density,
+    Scalar<DataType>& temperature) const {
+  if constexpr (std::is_same_v<DataType, double>) {
+    get(rest_mass_density) = std::max(
+        std::min(get(rest_mass_density), rest_mass_density_upper_bound()),
+        rest_mass_density_lower_bound());
+
+    get(electron_fraction) = std::max(
+        std::min(get(electron_fraction), electron_fraction_upper_bound()),
+        electron_fraction_lower_bound());
+
+    get(temperature) =
+        std::max(std::min(get(temperature), temperature_upper_bound()),
+                 temperature_lower_bound());
+
+  } else if constexpr (std::is_same_v<DataType, DataVector>) {
+    for (size_t s = 0; s < electron_fraction.size(); ++s) {
+      get(rest_mass_density)[s] = std::max(
+          std::min(get(rest_mass_density)[s], rest_mass_density_upper_bound()),
+          rest_mass_density_lower_bound());
+
+      get(electron_fraction)[s] = std::max(
+          std::min(get(electron_fraction)[s], electron_fraction_upper_bound()),
+          electron_fraction_lower_bound());
+
+      get(temperature)[s] =
+          std::max(std::min(get(temperature)[s], temperature_upper_bound()),
+                   temperature_lower_bound());
+    }
+  }
+}
+
+
+template <bool IsRelativistic>
+template <class DataType>
+Scalar<DataType>
+Tabulated3D<IsRelativistic>::pressure_from_density_and_energy_impl(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& specific_internal_energy,
+    const Scalar<DataType>& electron_fraction) const {
+  auto temperature = temperature_from_density_and_energy_impl(
+      rest_mass_density, specific_internal_energy, electron_fraction);
+
+  return pressure_from_density_and_temperature_impl(
+      rest_mass_density, temperature, electron_fraction);
+}
+
+template <bool IsRelativistic>
+template <class DataType>
+Scalar<DataType>
+Tabulated3D<IsRelativistic>::pressure_from_density_and_temperature_impl(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& temperature,
+    const Scalar<DataType>& electron_fraction) const {
+  Scalar<DataType> converted_electron_fraction;
+  Scalar<DataType> log_rest_mass_density;
+  Scalar<DataType> log_temperature;
+
+  convert_to_table_quantities(
+      make_not_null(&converted_electron_fraction),
+      make_not_null(&log_rest_mass_density), make_not_null(&log_temperature),
+      electron_fraction, rest_mass_density, temperature);
+
+  Scalar<DataType> pressure =
+      make_with_value<Scalar<DataType>>(get(rest_mass_density), 0.0);
+
+  if constexpr (std::is_same_v<DataType, double>) {
+    auto weights = interpolator_.get_weights(get(log_temperature),
+                                             get(log_rest_mass_density),
+                                             get(converted_electron_fraction));
+    auto interpolated_state =
+        interpolator_.template interpolate<Pressure>(weights);
+    get(pressure) = std::exp(interpolated_state[0]);
+
+  } else if constexpr (std::is_same_v<DataType, DataVector>) {
+    for (size_t s = 0; s < electron_fraction.size(); ++s) {
+      auto weights = interpolator_.get_weights(
+          get(log_temperature)[s], get(log_rest_mass_density)[s],
+          get(converted_electron_fraction)[s]);
+      auto interpolated_state =
+          interpolator_.template interpolate<Pressure>(weights);
+      get(pressure)[s] = std::exp(interpolated_state[0]);
+    }
+  }
+
+  return pressure;
+}
+
+
+template <bool IsRelativistic>
+void Tabulated3D<IsRelativistic>::pup(PUP::er& p) {
+  EquationOfState<IsRelativistic, 3>::pup(p);
+  p | energy_shift_;
+  p | enthalpy_minimum_;
+  p | table_electron_fraction_;
+  p | table_log_density_;
+  p | table_log_temperature_;
+  p | table_data_;
+}
+
+template <bool IsRelativistic>
+template <class DataType>
+Scalar<DataType>
+Tabulated3D<IsRelativistic>::temperature_from_density_and_energy_impl(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& specific_internal_energy,
+    const Scalar<DataType>& electron_fraction) const {
+  Scalar<DataType> converted_electron_fraction;
+  Scalar<DataType> log_rest_mass_density;
+
+  Scalar<DataType> log_temperature;
+  Scalar<DataType> temperature;
+
+  temperature = make_with_value<Scalar<DataType>>(rest_mass_density,
+                                                  temperature_lower_bound());
+
+  convert_to_table_quantities(
+      make_not_null(&converted_electron_fraction),
+      make_not_null(&log_rest_mass_density), make_not_null(&log_temperature),
+      electron_fraction, rest_mass_density, temperature);
+
+  // Check bounds on eps, note that eps may be negative
+  Scalar<DataType> log_specific_internal_energy = specific_internal_energy;
+
+  if constexpr (std::is_same_v<DataType, double>) {
+    get(log_specific_internal_energy) =
+        std::max(std::min(get(specific_internal_energy),
+                          specific_internal_energy_upper_bound(
+                              get(rest_mass_density), get(electron_fraction))),
+                 specific_internal_energy_lower_bound(get(rest_mass_density),
+                                                      get(electron_fraction)));
+  } else if constexpr (std::is_same_v<DataType, DataVector>) {
+    for (size_t s = 0; s < electron_fraction.size(); ++s) {
+      get(log_specific_internal_energy)[s] = std::max(
+          std::min(get(specific_internal_energy)[s],
+                   specific_internal_energy_upper_bound(
+                       get(rest_mass_density)[s], get(electron_fraction)[s])),
+          specific_internal_energy_lower_bound(get(rest_mass_density)[s],
+                                               get(electron_fraction)[s]));
+    }
+  }
+
+  // Correct for negative eps
+  get(log_specific_internal_energy) -= energy_shift_;
+  get(log_specific_internal_energy) = log(get(log_specific_internal_energy));
+
+  if constexpr (std::is_same_v<DataType, double>) {
+    const auto& log_eps = get(log_specific_internal_energy);
+    const auto& log_rho = get(log_rest_mass_density);
+    const auto& ye = get(converted_electron_fraction);
+
+    // Root-finding appropriate between reference density and maximum density
+    // We can use x=0 and x=x_max as bounds
+    const auto f = [this, log_eps, log_rho, ye](const double log_T) {
+
+      const auto weights = interpolator_.get_weights(log_T, log_rho, ye);
+      const auto interpolated_values =
+          interpolator_.template interpolate<Epsilon>(weights);
+
+      return log_eps - interpolated_values[0];
+    };
+
+    const auto root_from_lambda = RootFinder::toms748(
+        f, table_log_temperature_.front(),
+        upper_bound_tolerance_ * table_log_temperature_.back(), 1.0e-14,
+        1.0e-15);
+
+    get(temperature) = exp(root_from_lambda);
+
+  } else if constexpr (std::is_same_v<DataType, DataVector>) {
+    for (size_t s = 0; s < electron_fraction.size(); ++s) {
+      const auto& log_eps = get(log_specific_internal_energy)[s];
+      const auto& log_rho = get(log_rest_mass_density)[s];
+      const auto& ye = get(converted_electron_fraction)[s];
+
+      // Root-finding appropriate between reference density and maximum density
+      // We can use x=0 and x=x_max as bounds
+      const auto f = [this, log_eps, log_rho, ye](const double log_T) {
+
+        const auto weights = interpolator_.get_weights(log_T, log_rho, ye);
+        const auto interpolated_values =
+            interpolator_.template interpolate<Epsilon>(weights);
+
+        return log_eps - interpolated_values[0];
+      };
+      const auto root_from_lambda = RootFinder::toms748(
+          f, table_log_temperature_.front(),
+          upper_bound_tolerance_ * table_log_temperature_.back(), 1.0e-14,
+          1.0e-15);
+
+      get(temperature)[s] = exp(root_from_lambda);
+    }
+  }
+  return temperature;
+}
+
+template <bool IsRelativistic>
+template <class DataType>
+Scalar<DataType> Tabulated3D<IsRelativistic>::
+    specific_internal_energy_from_density_and_temperature_impl(
+        const Scalar<DataType>& rest_mass_density,
+        const Scalar<DataType>& temperature,
+        const Scalar<DataType>& electron_fraction) const {
+  Scalar<DataType> converted_electron_fraction;
+  Scalar<DataType> log_rest_mass_density;
+  Scalar<DataType> log_temperature;
+
+  convert_to_table_quantities(
+      make_not_null(&converted_electron_fraction),
+      make_not_null(&log_rest_mass_density), make_not_null(&log_temperature),
+      electron_fraction, rest_mass_density, temperature);
+
+  Scalar<DataType> specific_internal_energy =
+      make_with_value<Scalar<DataType>>(get(rest_mass_density), 0.0);
+
+  if constexpr (std::is_same_v<DataType, double>) {
+    auto weights = interpolator_.get_weights(get(log_temperature),
+                                             get(log_rest_mass_density),
+                                             get(converted_electron_fraction));
+    auto interpolated_state =
+        interpolator_.template interpolate<Epsilon>(weights);
+    get(specific_internal_energy) =
+        std::exp(interpolated_state[0]) + energy_shift_;
+  } else if constexpr (std::is_same_v<DataType, DataVector>) {
+    for (size_t s = 0; s < electron_fraction.size(); ++s) {
+      auto weights = interpolator_.get_weights(
+          get(log_temperature)[s], get(log_rest_mass_density)[s],
+          get(converted_electron_fraction)[s]);
+      auto interpolated_state =
+          interpolator_.template interpolate<Epsilon>(weights);
+      get(specific_internal_energy)[s] =
+          std::exp(interpolated_state[0]) + energy_shift_;
+    }
+  }
+
+  return specific_internal_energy;
+}
+
+template <bool IsRelativistic>
+template <class DataType>
+Scalar<DataType> Tabulated3D<IsRelativistic>::
+    sound_speed_squared_from_density_and_temperature_impl(
+        const Scalar<DataType>& rest_mass_density,
+        const Scalar<DataType>& temperature,
+        const Scalar<DataType>& electron_fraction) const {
+  Scalar<DataType> converted_electron_fraction;
+  Scalar<DataType> log_rest_mass_density;
+  Scalar<DataType> log_temperature;
+
+  convert_to_table_quantities(
+      make_not_null(&converted_electron_fraction),
+      make_not_null(&log_rest_mass_density), make_not_null(&log_temperature),
+      electron_fraction, rest_mass_density, temperature);
+
+  Scalar<DataType> cs2 =
+      make_with_value<Scalar<DataType>>(get(rest_mass_density), 0.0);
+
+  if constexpr (std::is_same_v<DataType, double>) {
+    auto weights = interpolator_.get_weights(get(log_temperature),
+                                             get(log_rest_mass_density),
+                                             get(converted_electron_fraction));
+    auto interpolated_state =
+        interpolator_.template interpolate<CsSquared>(weights);
+    get(cs2) = interpolated_state[0];
+
+  } else if constexpr (std::is_same_v<DataType, DataVector>) {
+    for (size_t s = 0; s < electron_fraction.size(); ++s) {
+      auto weights = interpolator_.get_weights(
+          get(log_temperature)[s], get(log_rest_mass_density)[s],
+          get(converted_electron_fraction)[s]);
+      auto interpolated_state =
+          interpolator_.template interpolate<CsSquared>(weights);
+      get(cs2)[s] = interpolated_state[0];
+    }
+  }
+
+  return cs2;
+}
+
+template <bool IsRelativistic>
+double Tabulated3D<IsRelativistic>::specific_internal_energy_lower_bound(
+    const double rest_mass_density, const double electron_fraction) const {
+  double converted_electron_fraction =
+      std::min(std::max(electron_fraction_lower_bound(), electron_fraction),
+               electron_fraction_upper_bound());
+
+  double log_rest_mass_density =
+      std::min(std::max(rest_mass_density_lower_bound(), rest_mass_density),
+               rest_mass_density_upper_bound());
+
+  log_rest_mass_density = log(log_rest_mass_density);
+
+  auto weights = interpolator_.get_weights(log(temperature_lower_bound()),
+                                           log_rest_mass_density,
+                                           converted_electron_fraction);
+  auto interpolated_state =
+      interpolator_.template interpolate<Epsilon>(weights);
+
+  return exp(interpolated_state[0]) + energy_shift_;
+}
+
+template <bool IsRelativistic>
+double Tabulated3D<IsRelativistic>::specific_internal_energy_upper_bound(
+    const double rest_mass_density, const double electron_fraction) const {
+  double converted_electron_fraction =
+      std::min(std::max(electron_fraction_lower_bound(), electron_fraction),
+               electron_fraction_upper_bound());
+
+  double log_rest_mass_density =
+      std::min(std::max(rest_mass_density_lower_bound(), rest_mass_density),
+               rest_mass_density_upper_bound());
+
+  log_rest_mass_density = log(log_rest_mass_density);
+
+  auto weights = interpolator_.get_weights(
+      log(upper_bound_tolerance_ * temperature_upper_bound()),
+      log_rest_mass_density, converted_electron_fraction);
+  auto interpolated_state =
+      interpolator_.template interpolate<Epsilon>(weights);
+
+  return exp(interpolated_state[0]) + energy_shift_;
+}
+
+template <bool IsRelativistic>
+Tabulated3D<IsRelativistic>::
+    Tabulated3D(  // NOLINTNEXTLINE(performance-unnecessary-value-param)
+        std::vector<double> electron_fraction,
+        // NOLINTNEXTLINE(performance-unnecessary-value-param)
+        std::vector<double> log_density,
+        // NOLINTNEXTLINE(performance-unnecessary-value-param)
+        std::vector<double> log_temperature,
+        // NOLINTNEXTLINE(performance-unnecessary-value-param)
+        std::vector<double> table_data, double energy_shift,
+        double enthalpy_minimum) {
+  initialize(std::move(electron_fraction), std::move(log_density),
+             std::move(log_temperature), std::move(table_data), energy_shift,
+             enthalpy_minimum);
+}
+}  // namespace EquationsOfState
+
+template class EquationsOfState::Tabulated3D<true>;
+template class EquationsOfState::Tabulated3D<false>;
+

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Tabulated3d.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Tabulated3d.hpp
@@ -1,0 +1,199 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <boost/preprocessor/arithmetic/dec.hpp>
+#include <boost/preprocessor/arithmetic/inc.hpp>
+#include <boost/preprocessor/control/expr_iif.hpp>
+#include <boost/preprocessor/list/adt.hpp>
+#include <boost/preprocessor/repetition/for.hpp>
+#include <boost/preprocessor/repetition/repeat.hpp>
+#include <boost/preprocessor/tuple/to_list.hpp>
+#include <limits>
+#include <pup.h>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "NumericalAlgorithms/Interpolation/MultiLinearSpanInterpolation.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"  // IWYU pragma: keep
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+/// \endcond
+
+namespace EquationsOfState {
+/*!
+ * \ingroup EquationsOfStateGroup
+ * \brief Nuclear matter equation of state in tabulated form.
+ *
+ * The equation of state takes the form
+ *
+ * \f[
+ * p = p (T, rho, Y_e)
+ * \f]
+ *
+ * where \f$\rho\f$ is the rest mass density, \f$T\f$ is the
+ * temperature, and \f$Y_e\f$ is the electron fraction.
+ * The temperature is given in units of MeV.
+ */
+template <bool IsRelativistic>
+class Tabulated3D : public EquationOfState<IsRelativistic, 3> {
+ public:
+  static constexpr size_t thermodynamic_dim = 3;
+  static constexpr bool is_relativistic = IsRelativistic;
+
+  static constexpr Options::String help = {
+      "A tabulated three-dimensional equation of state.\n"
+      "The energy density, pressure and sound speed "
+      "are tabulated as a function of density, electron_fraction and "
+      "temperature."};
+
+  /// Fields stored in the table
+  enum : size_t { Epsilon = 0, Pressure, CsSquared, NumberOfVars };
+
+  Tabulated3D() = default;
+  Tabulated3D(const Tabulated3D&) = default;
+  Tabulated3D& operator=(const Tabulated3D&) = default;
+  Tabulated3D(Tabulated3D&&) = default;
+  Tabulated3D& operator=(Tabulated3D&&) = default;
+  ~Tabulated3D() override = default;
+
+  //  explicit Tabulated3D(std::string filename);
+
+  explicit Tabulated3D(std::vector<double> electron_fraction,
+                       std::vector<double> log_density,
+                       std::vector<double> log_temperature,
+                       std::vector<double> table_data, double energy_shift,
+                       double enthalpy_minimum);
+
+  EQUATION_OF_STATE_FORWARD_DECLARE_MEMBERS(Tabulated3D, 3)
+
+  template <class DataType>
+  void convert_to_table_quantities(
+      const gsl::not_null<Scalar<DataType>*> converted_electron_fraction,
+      const gsl::not_null<Scalar<DataType>*> log_rest_mass_density,
+      const gsl::not_null<Scalar<DataType>*> log_temperature,
+      const Scalar<DataType>& electron_fraction,
+      const Scalar<DataType>& rest_mass_density,
+      const Scalar<DataType>& temperature) const {
+    get(*converted_electron_fraction) = get(electron_fraction);
+    get(*log_rest_mass_density) = get(rest_mass_density);
+    get(*log_temperature) = get(temperature);
+
+    // Enforce physicality of input
+    // We reuse the same variables here, these are not log yet.
+    enforce_physicality(*converted_electron_fraction, *log_rest_mass_density,
+                        *log_temperature);
+
+    // Table uses log T and log rho
+    get(*log_rest_mass_density) = log(get(*log_rest_mass_density));
+    get(*log_temperature) = log(get(*log_temperature));
+  }
+
+  std::unique_ptr<EquationOfState<IsRelativistic, 3>> get_clone()
+      const override;
+
+  void initialize(std::vector<double> electron_fraction,
+                  std::vector<double> log_density,
+                  std::vector<double> log_temperature,
+                  std::vector<double> table_data, double energy_shift,
+                  double enthalpy_minimum);
+
+  bool is_equal(const EquationOfState<IsRelativistic, 3>& rhs) const override;
+
+  bool operator==(const Tabulated3D<IsRelativistic>& rhs) const;
+
+  bool operator!=(const Tabulated3D<IsRelativistic>& rhs) const;
+
+  template <typename DataType>
+  void enforce_physicality(Scalar<DataType>& electron_fraction,
+                           Scalar<DataType>& density,
+                           Scalar<DataType>& temperature) const;
+
+  WRAPPED_PUPable_decl_base_template(  // NOLINT
+      SINGLE_ARG(EquationOfState<IsRelativistic, 3>), Tabulated3D);
+
+
+  /// The lower bound of the electron fraction that is valid for this EOS
+  double electron_fraction_lower_bound() const override {
+    return table_electron_fraction_.front();
+  }
+
+  /// The upper bound of the electron fraction that is valid for this EOS
+  double electron_fraction_upper_bound() const override {
+    return table_electron_fraction_.back();
+  }
+
+  /// The lower bound of the rest mass density that is valid for this EOS
+  double rest_mass_density_lower_bound() const override {
+    return std::exp((table_log_density_.front()));
+  }
+
+  /// The upper bound of the rest mass density that is valid for this EOS
+  double rest_mass_density_upper_bound() const override {
+    return std::exp((table_log_density_.back()));
+  }
+
+  /// The lower bound of the temperature that is valid for this EOS
+  double temperature_lower_bound() const override {
+    return std::exp((table_log_temperature_.front()));
+  }
+
+  /// The upper bound of the temperature that is valid for this EOS
+  double temperature_upper_bound() const override {
+    return std::exp((table_log_temperature_.back()));
+  }
+
+  /// The lower bound of the specific internal energy that is valid for this EOS
+  /// at the given rest mass density \f$\rho\f$ and electron fraction \f$Y_e\f$
+  double specific_internal_energy_lower_bound(
+      const double rest_mass_density,
+      const double electron_fraction) const override;
+
+  /// The upper bound of the specific internal energy that is valid for this EOS
+  /// at the given rest mass density \f$\rho\f$
+  double specific_internal_energy_upper_bound(
+      const double rest_mass_density,
+      const double electron_fraction) const override;
+
+  /// The lower bound of the specific enthalpy that is valid for this EOS
+  double specific_enthalpy_lower_bound() const override {
+    return enthalpy_minimum_;
+  }
+
+ private:
+  EQUATION_OF_STATE_FORWARD_DECLARE_MEMBER_IMPLS(3)
+
+  /// Energy shift used to account for negative specific internal energies,
+  /// which are only stored logarithmically
+  double energy_shift_ = 0.;
+
+  /// Enthalpy minium  across the table
+  double enthalpy_minimum_ = 1.;
+
+  /// Main interpolator for the EoS.
+  /// The ordering is  \f$(\log T. \log \rho, Y_e)\f$.
+  /// Assumed to be sorted in ascending order.
+  intrp::UniformMultiLinearSpanInterpolation<3, NumberOfVars> interpolator_{};
+  /// Electron fraction
+  std::vector<double> table_electron_fraction_{};
+  /// Logarithmic rest-mass denisty
+  std::vector<double> table_log_density_{};
+  /// Logarithmic temperature
+  std::vector<double> table_log_temperature_{};
+  /// Tabulate data. Entries are stated in the enum
+  std::vector<double> table_data_{};
+
+  /// Tolerance on upper bound for root finding
+  static constexpr double upper_bound_tolerance_ = 0.9999;
+};
+
+/// \cond
+template <bool IsRelativistic>
+PUP::able::PUP_ID EquationsOfState::Tabulated3D<IsRelativistic>::my_PUP_ID = 0;
+/// \endcond
+
+}  // namespace EquationsOfState

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIBRARY_SOURCES
   Test_PiecewisePolytropicFluid.cpp
   Test_PolytropicFluid.cpp
   Test_SpectralEoS.cpp
+  Test_Tabulated3D.cpp
   )
 
 add_test_library(

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Tabulated3D.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Tabulated3D.cpp
@@ -1,0 +1,205 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <limits>
+#include <pup.h>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Tabulated3d.hpp"
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.Tabulated3D",
+                  "[Unit][EquationsOfState]") {
+  namespace EoS = EquationsOfState;
+
+  using TEoS = EoS::Tabulated3D<true>;
+
+  // We do not test proper registration, yet.
+  // Will do this once we have the EoS reader setup.
+  // For now, we will construct the internal state of
+  // the EoS manually.
+
+  // Parallel::register_derived_classes_with_charm<
+  //     EoS::EquationOfState<true, 2>>();
+  // Parallel::register_derived_classes_with_charm<
+  //     EoS::EquationOfState<false, 2>>();
+  // pypp::SetupLocalPythonEnvironment local_python_env{
+  //     "PointwiseFunctions/Hydro/EquationsOfState/"};
+  //
+  MAKE_GENERATOR(gen);
+
+  std::uniform_int_distribution<size_t> dist_int(3, 5);
+
+  constexpr int Dim = 3;
+  constexpr int NumVar = TEoS::NumberOfVars;
+
+  std::array<double, Dim> lower_bounds{{
+      -3 * std::log(10),  // TEMP
+      -5 * std::log(10),  // RHO
+      0.01                // YE
+  }};
+
+  std::array<double, Dim> upper_bounds{{1 * std::log(10),   // TEMP
+                                        -1 * std::log(10),  // RHO
+                                        0.5}};
+
+  // Create data data structures
+  std::array<std::vector<double>, Dim> X_data;
+  Index<Dim> num_x_points;
+
+  size_t total_num_points = 1;
+  for (size_t n = 0; n < Dim; ++n) {
+    num_x_points[n] = dist_int(gen);
+    total_num_points *= num_x_points[n];
+
+    X_data[n].resize(num_x_points[n]);
+
+    for (size_t m = 0; m < num_x_points[n]; m++) {
+      X_data[n][m] =
+          lower_bounds[n] + m * (upper_bounds[n] - lower_bounds[n]) /
+                                static_cast<double>(num_x_points[n] - 1);
+    }
+  }
+
+  // Correct for NumVars
+  total_num_points *= TEoS::NumberOfVars;
+
+  // Allocate storage for main table
+  std::vector<double> dependent_variables;
+  dependent_variables.resize(total_num_points);
+
+  // Fill dependent_variables
+  //
+  double energy_shift = 0;  // Will test this later
+
+  double eps_min = std::exp(lower_bounds[0]);
+
+  if (eps_min < 0) {
+    energy_shift = 2. * eps_min;
+  }
+
+  auto test_eos = [&](auto state) {
+
+    enum TableIndex { Temp = 0, Rho = 1, Ye = 2 };
+
+    // We use a simple ideal fluid like EOS with a Ye variable Gamma:
+    // p = (rho*eps)*Ye = rho T
+
+    std::array<double, TEoS::NumberOfVars> vars;
+
+    // This is not consistent, but better keep this simple
+    vars[TEoS::Epsilon] = state[TableIndex::Temp];
+    vars[TEoS::Pressure] = state[TableIndex::Temp] + state[TableIndex::Rho];
+    vars[TEoS::CsSquared] = state[TableIndex::Ye];
+
+    return vars;
+  };
+
+  for (size_t ijk = 0; ijk < total_num_points / NumVar; ++ijk) {
+    Index<Dim> index;
+    auto tmp = std::array<double, Dim>{};
+
+    // Uncompress index
+    size_t myind = ijk;
+    for (size_t nn = 0; nn < Dim - 1; ++nn) {
+      index[nn] = myind % num_x_points[nn];
+      myind = (myind - index[nn]) / num_x_points[nn];
+      tmp[nn] = X_data[nn][index[nn]];
+    }
+    index[Dim - 1] = myind;
+    tmp[Dim - 1] = X_data[Dim - 1][index[Dim - 1]];
+
+    for (size_t nv = 0; nv < NumVar; ++nv) {
+      std::array<double, NumVar> Fx = test_eos(tmp);
+      dependent_variables[nv + NumVar * ijk] = Fx[nv];
+    }
+  }
+
+  // Construct EOS
+
+  double enthalpy_minimum = 1.;
+
+  TEoS eos = TEoS(X_data[2], X_data[1], X_data[0], dependent_variables,
+                  energy_shift, enthalpy_minimum);
+
+  CHECK(std::abs(std::exp(lower_bounds[0]) - eos.temperature_lower_bound()) <
+        1.e-12);
+  CHECK(std::abs(std::exp(lower_bounds[1]) -
+                 eos.rest_mass_density_lower_bound()) < 1.e-12);
+  CHECK(std::abs((lower_bounds[2]) - eos.electron_fraction_lower_bound()) <
+        1.e-12);
+
+  CHECK(std::abs(std::exp(upper_bounds[0]) - eos.temperature_upper_bound()) <
+        1.e-12);
+  CHECK(std::abs(std::exp(upper_bounds[1]) -
+                 eos.rest_mass_density_upper_bound()) < 1.e-12);
+  CHECK(std::abs((upper_bounds[2]) - eos.electron_fraction_upper_bound()) <
+        1.e-12);
+
+  // Construct a test state
+  std::array<double, 3> pure_state{{1., 1.e-2, 0.3}};
+
+  std::array<Scalar<double>, 3> state{};
+  std::array<Scalar<DataVector>, 3> vector_state{};
+
+  for (size_t n = 0; n < 3; ++n) {
+    get(state[n]) = pure_state[n];
+    get(vector_state[n]) = DataVector{1, pure_state[n]};
+  }
+
+  pure_state[0] = std::log(pure_state[0]);
+  pure_state[1] = std::log(pure_state[1]);
+
+  const auto output = test_eos(pure_state);
+
+  CHECK(std::abs((std::exp(output[TEoS::Epsilon]) + energy_shift) -
+                 get(eos.specific_internal_energy_from_density_and_temperature(
+                     state[1], state[0], state[2]))) < 1.e-12);
+  CHECK(std::abs((std::exp(output[TEoS::Pressure])) -
+                 get(eos.pressure_from_density_and_temperature(
+                     state[1], state[0], state[2]))) < 1.e-12);
+  CHECK(std::abs(output[TEoS::CsSquared]) -
+            get(eos.sound_speed_squared_from_density_and_temperature(
+                state[1], state[0], state[2])) <
+        1.e-12);
+
+  const auto eps_interp =
+      eos.specific_internal_energy_from_density_and_temperature(
+          vector_state[1], vector_state[0], vector_state[2]);
+
+  CHECK(std::abs(std::exp(pure_state[0]) -
+                 get(eos.temperature_from_density_and_energy(
+                     vector_state[1], eps_interp, vector_state[2]))[0]) <
+        1.e-12);
+
+  CHECK(std::abs((std::exp(output[TEoS::Epsilon]) + energy_shift) -
+                 get(eos.specific_internal_energy_from_density_and_temperature(
+                     vector_state[1], vector_state[0], vector_state[2]))[0]) <
+        1.e-12);
+  CHECK(std::abs((std::exp(output[TEoS::Pressure])) -
+                 get(eos.pressure_from_density_and_temperature(
+                     vector_state[1], vector_state[0], vector_state[2]))[0]) <
+        1.e-12);
+  CHECK(std::abs(output[TEoS::CsSquared] -
+                 get(eos.sound_speed_squared_from_density_and_temperature(
+                     vector_state[1], vector_state[0], vector_state[2]))[0]) <
+        1.e-12);
+
+  const auto eps_interp_vector =
+      eos.specific_internal_energy_from_density_and_temperature(
+          vector_state[1], vector_state[0], vector_state[2]);
+
+  CHECK(std::abs(std::exp(pure_state[0]) -
+                 get(eos.temperature_from_density_and_energy(
+                     vector_state[1], eps_interp_vector, vector_state[2]))[0]) <
+        1.e-12);
+}


### PR DESCRIPTION
This is a draft of the tabulated equation of state class.

This PR extends the EquationOfState class to three thermodyn. dimensions and adds example routines for the Nuclear EOS class.

TODO: Define speed of sound interface and add tests.

This PR depends on #4243  

What's not included: Actual read in of the HDF5 table. Need to couples this to the existing infrastructure.
