### PR TITLE
Print walltime at phase change

### DIFF
--- a/src/Parallel/Main.hpp
+++ b/src/Parallel/Main.hpp
@@ -701,7 +701,8 @@ void Main<Metavariables>::execute_next_phase() {
 
     // Errored during execution. Go to cleanup
     current_phase_ = Parallel::Phase::PostFailureCleanup;
-    Parallel::printf("Entering phase: %s\n", current_phase_);
+    Parallel::printf("Entering phase: %s at time %s\n", current_phase_,
+                     sys::pretty_wall_time());
   } else {
     if (Parallel::Phase::Exit == current_phase_) {
       ERROR("Current phase is Exit, but program did not exit!");
@@ -719,8 +720,8 @@ void Main<Metavariables>::execute_next_phase() {
     if (next_phase.has_value()) {
       // Only print info if there was an actual phase change.
       if (current_phase_ != next_phase.value()) {
-        Parallel::printf("Entering phase from phase control: %s\n",
-                         next_phase.value());
+        Parallel::printf("Entering phase from phase control: %s at time %s\n",
+                         next_phase.value(), sys::pretty_wall_time());
         current_phase_ = next_phase.value();
       }
     } else {
@@ -741,7 +742,8 @@ void Main<Metavariables>::execute_next_phase() {
       }
       current_phase_ = *std::next(it);
 
-      Parallel::printf("Entering phase: %s\n", current_phase_);
+      Parallel::printf("Entering phase: %s at time %s\n", current_phase_,
+                       sys::pretty_wall_time());
     }
   }
 


### PR DESCRIPTION
## Proposed changes

This makes it easy to figure out how long a phase took to complete.

Sample output:
```
Entering phase: Register at time 00:00:00
```

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
