### PR TITLE
Remove db::remove

### DIFF
--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -250,15 +250,6 @@ class DataBox<tmpl::list<Tags...>> : private detail::Item<Tags>... {
   template <typename Tag>
   const auto& get() const;
 
-  /// \brief Removes the items with tags `TagsToRemove` by resetting them to
-  /// their default initialized values, should be called by the free function
-  /// db::remove
-  ///
-  /// \details In a debug build, attempting to use a removed item throws an
-  /// exception.
-  template <typename Tag>
-  void remove();
-
   /// Retrieve a mutable reference to the tag `Tag`, should be called
   /// by the free function db::get_mutable_reference
   template <typename Tag>
@@ -553,7 +544,7 @@ void DataBox<tmpl::list<Tags...>>::pup_impl(
     (void)this;  // Compiler bug warning this capture is not used
     using tag = decltype(current_tag);
     get_item<tag>().pup(p);
-    if (p.isUnpacking() and get_item<tag>().valid()) {
+    if (p.isUnpacking()) {
       add_mutable_subitems_to_box<tag>(typename Subitems<tag>::type{});
     }
   };
@@ -697,15 +688,6 @@ decltype(auto) mutate(const gsl::not_null<DataBox<TagList>*> box,
       tmpl::append<detail::expand_subitems<mutate_tags_list>,
                    extra_mutated_tags>;
 
-#ifdef SPECTRE_DEBUG
-  tmpl::for_each<full_mutated_items>([&box](auto tag) {
-    using Tag = tmpl::type_from<decltype(tag)>;
-    ASSERT(box->template get_item<Tag>().valid(),
-           "Cannot mutate '" << db::tag_name<Tag>()
-                             << "' as it has been removed from the DataBox.");
-  });
-#endif  // ifdef SPECTRE_DEBUG
-
   using first_compute_items_to_reset = tmpl::remove_duplicates<
       tmpl::transform<tmpl::filter<typename DataBox<TagList>::edge_list,
                                    tmpl::bind<tmpl::list_contains,
@@ -779,13 +761,6 @@ const auto& DataBox<tmpl::list<Tags...>>::get() const {
           evaluate_compute_item<item_tag>(typename item_tag::argument_tags{});
         }
       }
-      if constexpr (detail::Item<item_tag>::item_type ==
-                    detail::ItemType::Mutable) {
-        ASSERT(get_item<item_tag>().valid(),
-               "Unable to retrieve item '"
-                   << db::tag_name<item_tag>()
-                   << "' as it has been removed from the DataBox.");
-      }
       if constexpr (tt::is_a_v<std::unique_ptr, typename item_tag::type>) {
         return *(get_item<item_tag>().get());
       } else {
@@ -807,53 +782,6 @@ const auto& DataBox<tmpl::list<Tags...>>::get() const {
 template <typename Tag, typename TagList>
 SPECTRE_ALWAYS_INLINE const auto& get(const DataBox<TagList>& box) {
   return box.template get<Tag>();
-}
-
-  ///\cond
-template <typename... Tags>
-template <typename Tag>
-void DataBox<tmpl::list<Tags...>>::remove() {
-  DEBUG_STATIC_ASSERT(
-      not detail::has_no_matching_tag_v<tmpl::list<Tags...>, Tag>,
-      "Found no tags in the DataBox that match the tag being removed.");
-  DEBUG_STATIC_ASSERT(
-      detail::has_unique_matching_tag_v<tmpl::list<Tags...>, Tag>,
-      "Found more than one tag in the DataBox that matches the tag "
-      "being removed. This happens because more than one tag with the same "
-      "base (class) tag was added to the DataBox.");
-
-  using item_tag = detail::first_matching_tag<tmpl::list<Tags...>, Tag>;
-
-  DEBUG_STATIC_ASSERT(tmpl::list_contains_v<mutable_item_tags, item_tag>,
-                      "Can only remove mutable items");
-
-  DEBUG_STATIC_ASSERT(not tmpl::list_contains_v<mutable_subitem_tags, item_tag>,
-                      "Cannot remove subitems");
-  DEBUG_STATIC_ASSERT(not detail::has_subitems_v<item_tag>,
-                      "Cannot remove an item with subitems.");
-
-  DEBUG_STATIC_ASSERT(
-      tmpl::none<edge_list, std::is_same<tmpl::pin<item_tag>,
-                                         tmpl::get_source<tmpl::_1>>>::value,
-      "Cannot remove an item used by compute items.");
-
-  get_item<item_tag>().invalidate();
-}
-/// \endcond
-
-/*!
- * \ingroup DataBoxGroup
- * \brief Remove the item with `Tag` from the DataBox
- * \requires Type `Tag` is one of the tags corresponding to an object stored in
- * the DataBox
- *
- * \details The item is reset to its default value.  In a Debug build, an
- * attempt to use a removed item throws an exception.
- */
-  template <typename Tag, typename TagsList>
-SPECTRE_ALWAYS_INLINE constexpr void remove(
-    const gsl::not_null<db::DataBox<TagsList>*> box) {
-  box->template remove<Tag>();
 }
 
 template <typename... Tags>

--- a/src/DataStructures/DataBox/Item.hpp
+++ b/src/DataStructures/DataBox/Item.hpp
@@ -40,9 +40,6 @@ class Item {
 // Its value may be fetched by calling db::get (which calls get)
 //
 // Its value may be changed by calling db::mutate (which calls mutate)
-//
-// It may be "removed" by calling db::remove (which calls invalidate)
-// after which time any calls to mutate or get will throw an error
 template <typename Tag>
 class Item<Tag, ItemType::Mutable> {
  public:
@@ -63,24 +60,11 @@ class Item<Tag, ItemType::Mutable> {
 
   value_type& mutate() { return value_; }
 
-  bool valid() const { return valid_; }
-
-  void invalidate() {
-    valid_ = false;
-    value_ = {};
-  }
-
   // NOLINTNEXTLINE(google-runtime-references)
-  void pup(PUP::er& p) {
-    p | valid_;
-    if (valid_) {
-      p | value_;
-    }
-  }
+  void pup(PUP::er& p) { p | value_; }
 
  private:
   value_type value_{};
-  bool valid_{true};
 };
 
 // A compute item in a DataBox

--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -2707,64 +2707,6 @@ void test_output() {
   CHECK(output_stream == expected_stream);
 }
 
-void test_remove_item() {
-  INFO("test mutate apply");
-  auto box = db::create<
-      db::AddSimpleTags<
-          test_databox_tags::Tag0, test_databox_tags::Tag1,
-          test_databox_tags::Tag2,
-          Tags::Variables<tmpl::list<test_databox_tags::ScalarTag,
-                                     test_databox_tags::VectorTag>>,
-          test_databox_tags::Pointer>,
-      db::AddComputeTags<test_databox_tags::Tag4Compute,
-                         test_databox_tags::Tag5Compute,
-                         test_databox_tags::MultiplyScalarByTwoCompute,
-                         test_databox_tags::PointerToCounterCompute,
-                         test_databox_tags::PointerToSumCompute>>(
-      3.14, std::vector<double>{8.7, 93.2, 84.7}, "My Sample String"s,
-      Variables<tmpl::list<test_databox_tags::ScalarTag,
-                           test_databox_tags::VectorTag>>(2, 3.),
-      std::make_unique<int>(3));
-
-  db::remove<test_databox_tags::Tag1>(make_not_null(&box));
-#ifdef SPECTRE_DEBUG
-  CHECK_THROWS_WITH(db::get<test_databox_tags::Tag1>(box),
-                    Catch::Contains("Unable to retrieve item 'Tag1' as "
-                                    "it has been removed from the DataBox."));
-  CHECK_THROWS_WITH(
-      ([&box]() {
-        db::mutate<test_databox_tags::Tag0, test_databox_tags::Tag1>(
-            make_not_null(&box),
-            [](const gsl::not_null<double*> tag0,
-               const gsl::not_null<std::vector<double>*> tag1) {
-              *tag0 = 10.32;
-              (*tag1)[0] = 837.2;
-            });
-      }()),
-      Catch::Contains(
-          "Cannot mutate 'Tag1' as it has been removed from the DataBox."));
-#endif
-  auto new_box = serialize_and_deserialize(box);
-  CHECK(db::get<test_databox_tags::Tag0>(new_box) == 3.14);
-#ifdef SPECTRE_DEBUG
-  CHECK_THROWS_WITH(db::get<test_databox_tags::Tag1>(new_box),
-                    Catch::Contains("Unable to retrieve item 'Tag1' as "
-                                    "it has been removed from the DataBox."));
-  CHECK_THROWS_WITH(
-      ([&new_box]() {
-        db::mutate<test_databox_tags::Tag0, test_databox_tags::Tag1>(
-            make_not_null(&new_box),
-            [](const gsl::not_null<double*> tag0,
-               const gsl::not_null<std::vector<double>*> tag1) {
-              *tag0 = 10.32;
-              (*tag1)[0] = 837.2;
-            });
-      }()),
-      Catch::Contains(
-          "Cannot mutate 'Tag1' as it has been removed from the DataBox."));
-#endif
-}
-
 void test_exception_safety() {
   struct FakeError {};
 
@@ -2869,7 +2811,6 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox", "[Unit][DataStructures]") {
   test_reference_item();
   test_get_mutable_reference();
   test_output();
-  test_remove_item();
   test_exception_safety();
 }
 


### PR DESCRIPTION
This is no longer used as items persist in the DataBox.  If it is desirable to remove the memory footprint of an Item, make the Item a std::optional and mutate it to std::nullopt when it is no longer needed.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
