### PR TITLE
New epsilon in ZeroCrossingPredictor test.

### DIFF
--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ZeroCrossingPredictor.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ZeroCrossingPredictor.cpp
@@ -66,7 +66,7 @@ void test_zero_crossing_predictor() {
   CHECK(predictor == serialize_and_deserialize(predictor));
   CHECK_FALSE(predictor != serialize_and_deserialize(predictor));
 
-  Approx custom_approx = Approx::custom().epsilon(1e-6);
+  Approx custom_approx = Approx::custom().epsilon(5e-6).scale(1.0);
   CHECK_ITERABLE_CUSTOM_APPROX(
       predictor.zero_crossing_time(x_values.back()),
       SINGLE_ARG(DataVector{expected_zero_crossing_value1,


### PR DESCRIPTION
The scale is now set to unity, since the data points are spread over a range of order unity.

Previously the test failed on crossing values near zero because the epsilon wanted many many digits in that case.

Also, increased the value of epsilon slightly, because the test also failed occasionally for larger values.

Fixes #4301

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

