### PR TITLE
Dump Interpolator volume data on failure

### DIFF
--- a/src/IO/Observer/Initialize.hpp
+++ b/src/IO/Observer/Initialize.hpp
@@ -69,7 +69,8 @@ struct InitializeWriter {
       tmpl::list<Tags::ExpectedContributorsForObservations,
                  Tags::ContributorsOfReductionData, Tags::ReductionDataLock,
                  Tags::ContributorsOfTensorData, Tags::VolumeDataLock,
-                 Tags::TensorData, Tags::NodesExpectedToContributeReductions,
+                 Tags::TensorData, Tags::InterpolatorTensorData,
+                 Tags::NodesExpectedToContributeReductions,
                  Tags::NodesThatContributedReductions, Tags::H5FileLock>,
       typename Metavariables::observed_reduction_data_tags,
       tmpl::transform<

--- a/src/IO/Observer/Tags.hpp
+++ b/src/IO/Observer/Tags.hpp
@@ -100,10 +100,17 @@ struct VolumeDataLock : db::SimpleTag {
 
 /// Volume tensor data to be written to disk.
 struct TensorData : db::SimpleTag {
+  using type = std::unordered_map<
+      observers::ObservationId,
+      std::unordered_map<observers::ArrayComponentId, ElementVolumeData>>;
+};
+
+/// Volume tensor data to be written to disk from the Interpolator
+struct InterpolatorTensorData : db::SimpleTag {
   using type =
       std::unordered_map<observers::ObservationId,
                          std::unordered_map<observers::ArrayComponentId,
-                                            ElementVolumeData>>;
+                                            std::vector<ElementVolumeData>>>;
 };
 
 /// \cond

--- a/src/ParallelAlgorithms/Interpolation/Actions/DumpInterpolatorVolumeData.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/DumpInterpolatorVolumeData.hpp
@@ -71,6 +71,9 @@ ElementVolumeData construct_element_volume_data(
  */
 template <typename AllTemporalIds>
 struct DumpInterpolatorVolumeData {
+  using const_global_cache_tags =
+      tmpl::list<intrp::Tags::DumpVolumeDataOnFailure>;
+
   template <typename DbTagList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>
@@ -80,6 +83,10 @@ struct DumpInterpolatorVolumeData {
       Parallel::GlobalCache<Metavariables>& cache,
       const ArrayIndex& array_index, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
+    if (not Parallel::get<intrp::Tags::DumpVolumeDataOnFailure>(cache)) {
+      return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+    }
+
     auto& observer_writer = *Parallel::local_branch(
         Parallel::get_parallel_component<
             observers::ObserverWriter<Metavariables>>(cache));

--- a/src/ParallelAlgorithms/Interpolation/Actions/DumpInterpolatorVolumeData.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/DumpInterpolatorVolumeData.hpp
@@ -12,6 +12,7 @@
 #include "Domain/Tags.hpp"
 #include "IO/H5/TensorData.hpp"
 #include "IO/Observer/Actions/ObserverRegistration.hpp"
+#include "IO/Observer/ArrayComponentId.hpp"
 #include "IO/Observer/ObservationId.hpp"
 #include "IO/Observer/ObserverComponent.hpp"
 #include "IO/Observer/Tags.hpp"
@@ -25,6 +26,7 @@
 #include "Parallel/Local.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp"
 #include "ParallelAlgorithms/Interpolation/Tags.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "Utilities/MakeString.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -76,19 +78,18 @@ struct DumpInterpolatorVolumeData {
       db::DataBox<DbTagList>& box,
       const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
       Parallel::GlobalCache<Metavariables>& cache,
-      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ArrayIndex& array_index, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
-    auto& observer_writer = Parallel::get_parallel_component<
-        observers::ObserverWriter<Metavariables>>(cache);
-    auto& my_proxy = Parallel::get_parallel_component<ParallelComponent>(cache);
-    const auto& file_prefix =
-        Parallel::get<observers::Tags::VolumeFileName>(cache);
-    const size_t my_node =
-        Parallel::my_node<size_t>(*Parallel::local_branch(my_proxy));
-    const std::string filename{file_prefix + std::to_string(my_node)};
+    auto& observer_writer = *Parallel::local_branch(
+        Parallel::get_parallel_component<
+            observers::ObserverWriter<Metavariables>>(cache));
 
-    tmpl::for_each<AllTemporalIds>([&box, &observer_writer, &my_node,
-                                    &filename](auto temporal_id_v) {
+    const observers::ArrayComponentId array_component_id{
+        std::add_pointer_t<ParallelComponent>{nullptr},
+        Parallel::ArrayIndex<std::decay_t<ArrayIndex>>(array_index)};
+
+    tmpl::for_each<AllTemporalIds>([&box, &observer_writer,
+                                    &array_component_id](auto temporal_id_v) {
       using temporal_id_t =
           tmpl::type_from<std::decay_t<decltype(temporal_id_v)>>;
       const auto& volume_vars_info =
@@ -106,14 +107,16 @@ struct DumpInterpolatorVolumeData {
                                                                    info));
         }
 
-        // To speed up writing, call this on our own node which is guaranteed to
-        // exist because...we are on it...
-        Parallel::threaded_action<observers::ThreadedActions::WriteVolumeData>(
-            observer_writer[my_node], filename, subfile_name,
+        Parallel::threaded_action<
+            observers::ThreadedActions::ContributeVolumeDataToWriter>(
+            observer_writer,
             observers::ObservationId{
                 InterpolationTarget_detail::get_temporal_id_value(temporal_id),
                 subfile_name},
-            std::move(element_volume_data));
+            array_component_id, subfile_name,
+            std::unordered_map<observers::ArrayComponentId,
+                               std::vector<ElementVolumeData>>{
+                {array_component_id, std::move(element_volume_data)}});
       }
     });
 

--- a/src/ParallelAlgorithms/Interpolation/Interpolator.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Interpolator.hpp
@@ -4,6 +4,12 @@
 #pragma once
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/TagName.hpp"
+#include "IO/Observer/Actions/ObserverRegistration.hpp"
+#include "IO/Observer/Actions/RegisterWithObservers.hpp"
+#include "IO/Observer/ArrayComponentId.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/TypeOfObservation.hpp"
 #include "Parallel/Algorithms/AlgorithmGroup.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Local.hpp"
@@ -13,10 +19,43 @@
 #include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/DumpInterpolatorVolumeData.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InitializeInterpolator.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits/IsA.hpp"
 
 namespace intrp {
+namespace Actions {
+template <typename TemporalIdTag>
+struct RegisterWithObserverWriter {
+  template <typename DbTagList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTagList>& /*box*/,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& array_index, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    // This has to be the local observer writer or else registration will be
+    // messed up
+    auto& observer_writer = *Parallel::local_branch(
+        Parallel::get_parallel_component<
+            observers::ObserverWriter<Metavariables>>(cache));
+
+    const observers::ObservationKey observation_key{
+        "/InterpolatorVolumeData_"s + db::tag_name<TemporalIdTag>()};
+    const observers::ArrayComponentId array_component_id{
+        std::add_pointer_t<ParallelComponent>{nullptr},
+        Parallel::ArrayIndex<std::decay_t<ArrayIndex>>(array_index)};
+
+    Parallel::simple_action<
+        observers::Actions::RegisterVolumeContributorWithObserverWriter>(
+        observer_writer, observation_key, array_component_id);
+
+    return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+  }
+};
+}  // namespace Actions
 
 namespace detail {
 template <typename InterpolationTarget>
@@ -43,15 +82,27 @@ struct Interpolator {
       detail::get_interpolation_target_tag<tmpl::_1>>;
   using all_temporal_ids = tmpl::remove_duplicates<tmpl::transform<
       all_interpolation_target_tags, detail::get_temporal_id<tmpl::_1>>>;
-  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      Parallel::Phase::Initialization,
-      tmpl::list<
-          Actions::InitializeInterpolator<
-              tmpl::transform<all_temporal_ids,
-                              tmpl::bind<Tags::VolumeVarsInfo,
-                                         tmpl::pin<Metavariables>, tmpl::_1>>,
-              Tags::InterpolatedVarsHolders<Metavariables>>,
-          Parallel::Actions::TerminatePhase>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          Parallel::Phase::Initialization,
+          tmpl::list<Actions::InitializeInterpolator<
+                         tmpl::transform<
+                             all_temporal_ids,
+                             tmpl::bind<Tags::VolumeVarsInfo,
+                                        tmpl::pin<Metavariables>, tmpl::_1>>,
+                         Tags::InterpolatedVarsHolders<Metavariables>>,
+                     Parallel::Actions::TerminatePhase>>,
+      Parallel::PhaseActions<
+          Parallel::Phase::Register,
+          tmpl::flatten<tmpl::list<
+              tmpl::transform<
+                  all_temporal_ids,
+                  tmpl::bind<Actions::RegisterWithObserverWriter, tmpl::_1>>,
+              Parallel::Actions::TerminatePhase>>>,
+      Parallel::PhaseActions<
+          Parallel::Phase::PostFailureCleanup,
+          tmpl::list<Actions::DumpInterpolatorVolumeData<all_temporal_ids>,
+                     Parallel::Actions::TerminatePhase>>>;
   using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
   static void execute_next_phase(

--- a/src/ParallelAlgorithms/Interpolation/Tags.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Tags.hpp
@@ -33,11 +33,40 @@ namespace OptionTags {
 struct InterpolationTargets {
   static constexpr Options::String help{"Options for interpolation targets"};
 };
+
+/*!
+ * \ingroup OptionGroupsGroup
+ * \brief Groups option tags for the Interpolator.
+ */
+struct Interpolator {
+  static constexpr Options::String help{
+      "Options related to the Interpolator parallel component"};
+};
+
+/// Option tag that determines if volume data will be dumped from the
+/// Interpolator upon a failure.
+struct DumpVolumeDataOnFailure {
+  using type = bool;
+  static constexpr Options::String help{
+      "Whether or not to dump all volume data currently stored by the "
+      "interpolator. Volume data is written to the file corresponding to the "
+      "node it was collected on."};
+  using group = Interpolator;
+};
 }  // namespace OptionTags
 
 /// Tags for items held in the `DataBox` of `InterpolationTarget` or
 /// `Interpolator`.
 namespace Tags {
+/// Tag that determines if volume data will be dumped form the Interpolator upon
+/// failure
+struct DumpVolumeDataOnFailure : db::SimpleTag {
+  using type = bool;
+  using option_tags = tmpl::list<OptionTags::DumpVolumeDataOnFailure>;
+  static constexpr bool pass_metavariables = false;
+
+  static bool create_from_options(const bool input) { return input; }
+};
 
 /// Keeps track of which points have been filled with interpolated data.
 template <typename TemporalId>

--- a/tests/InputFiles/FindHorizons/FindHorizons3D.yaml
+++ b/tests/InputFiles/FindHorizons/FindHorizons3D.yaml
@@ -51,3 +51,6 @@ Observers:
   VolumeFileName: "FindHorizons3DVolume"
   ReductionFileName: "FindHorizons3DReductions"
   SurfaceFileName: "FindHorizons3DSurfaces"
+
+Interpolator:
+  DumpVolumeDataOnFailure: false

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -225,6 +225,9 @@ Observers:
   ReductionFileName: "GhBinaryBlackHoleReductionData"
   SurfaceFileName: "GhBinaryBlackHoleSurfacesData"
 
+Interpolator:
+  DumpVolumeDataOnFailure: false
+
 ApparentHorizons:
   AhA: &AhA
     InitialGuess:

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -173,6 +173,9 @@ Observers:
   ReductionFileName: "GhKerrSchildReductions"
   SurfaceFileName: "GhKerrSchildSurfaces"
 
+Interpolator:
+  DumpVolumeDataOnFailure: false
+
 ApparentHorizons:
   AhA:
     InitialGuess:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -214,3 +214,6 @@ ApparentHorizons:
 Observers:
   VolumeFileName: "GhMhdBondiMichelVolume"
   ReductionFileName: "GhMhdBondiMichelReductions"
+
+Interpolator:
+  DumpVolumeDataOnFailure: false

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -180,3 +180,6 @@ EventsAndTriggers:
 Observers:
   VolumeFileName: "GhMhdTovStarVolume"
   ReductionFileName: "GhMhdTovStarReductions"
+
+Interpolator:
+  DumpVolumeDataOnFailure: false

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -95,6 +95,9 @@ Observers:
   VolumeFileName: "ValenciaDivCleanBlastWaveVolume"
   ReductionFileName: "ValenciaDivCleanBlastWaveReductions"
 
+Interpolator:
+  DumpVolumeDataOnFailure: false
+
 EventsAndTriggers:
   - - Slabs:
         Specified:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -128,6 +128,9 @@ Observers:
   VolumeFileName: "ValenciaDivCleanFishboneMoncriefDiskVolume"
   ReductionFileName: "ValenciaDivCleanFishboneMoncriefDiskReductions"
 
+Interpolator:
+  DumpVolumeDataOnFailure: false
+
 InterpolationTargets:
   KerrHorizon:
     Lmax: 10

--- a/tests/Unit/IO/Observers/Test_RegisterElements.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterElements.cpp
@@ -90,6 +90,10 @@ void check_observer_registration() {
   CHECK(ActionTesting::get_databox_tag<obs_writer, observers::Tags::TensorData>(
             runner, 0)
             .empty());
+  CHECK(ActionTesting::get_databox_tag<obs_writer,
+                                       observers::Tags::InterpolatorTensorData>(
+            runner, 0)
+            .empty());
   CHECK(ActionTesting::get_databox_tag<
             obs_writer, observers::Tags::NodesExpectedToContributeReductions>(
             runner, 0)
@@ -166,6 +170,10 @@ void check_observer_registration() {
             obs_writer, observers::Tags::ContributorsOfTensorData>(runner, 0)
             .empty());
   CHECK(ActionTesting::get_databox_tag<obs_writer, observers::Tags::TensorData>(
+            runner, 0)
+            .empty());
+  CHECK(ActionTesting::get_databox_tag<obs_writer,
+                                       observers::Tags::InterpolatorTensorData>(
             runner, 0)
             .empty());
 

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceiveAndDumpVolumeData.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceiveAndDumpVolumeData.cpp
@@ -273,6 +273,8 @@ struct mock_interpolator {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockGroupChare;
   using array_index = int;
+  using const_global_cache_tags =
+      tmpl::list<intrp::Tags::DumpVolumeDataOnFailure>;
   using simple_tags = typename intrp::Actions::InitializeInterpolator<
       intrp::Tags::VolumeVarsInfo<Metavariables, ::Tags::TimeStepId>,
       intrp::Tags::InterpolatedVarsHolders<Metavariables>>::simple_tags;
@@ -380,9 +382,7 @@ void create_volume_data_and_send_it_to_interpolator(
   }
 }
 
-SPECTRE_TEST_CASE(
-    "Unit.NumericalAlgorithms.Interpolator.ReceiveAndDumpVolumeData",
-    "[Unit]") {
+void test(const bool dump_vol_data) {
   domain::creators::register_derived_with_charm();
 
   using metavars = MockMetavariables;
@@ -431,7 +431,7 @@ SPECTRE_TEST_CASE(
   }
 
   ActionTesting::MockRuntimeSystem<metavars> runner{
-      {domain_creator.create_domain(), filename}};
+      {domain_creator.create_domain(), dump_vol_data, filename}};
   ActionTesting::emplace_group_component_and_initialize<interp_component>(
       &runner,
       {0_st,
@@ -530,43 +530,50 @@ SPECTRE_TEST_CASE(
                            Parallel::Phase::PostFailureCleanup);
 
   ActionTesting::next_action<interp_component>(make_not_null(&runner), 0);
-  // Only one threaded action because we only have one temporal Id type and one
-  // time
-  ActionTesting::invoke_queued_threaded_action<observer_writer>(
-      make_not_null(&runner), 0);
 
-  {
-    const h5::H5File<h5::AccessType::ReadOnly> h5file{filename + "0.h5"s};
-    const auto& vol_file =
-        h5file.get<h5::VolumeData>("/InterpolatorVolumeData_TimeStepId", 0);
-    const auto written_data = vol_file.get_data_by_element(
-        std::nullopt, std::nullopt,
-        std::vector<std::string>{db::tag_name<gr::Tags::Lapse<DataVector>>()});
-    // Only wrote data for one time
-    CHECK(written_data.size() == 1);
-    const auto& written_tuple = written_data[0];
-    const auto& observation_value = get<1>(written_tuple);
-    const auto& vec_element_vol_data = get<2>(written_tuple);
+  CHECK(ActionTesting::number_of_queued_threaded_actions<observer_writer>(
+            runner, 0) == (dump_vol_data ? 1 : 0));
 
-    CHECK(
-        observation_value ==
-        intrp::InterpolationTarget_detail::get_temporal_id_value(temporal_id));
+  if (dump_vol_data) {
+    // Only one threaded action because we only have one temporal Id type and
+    // one time
+    ActionTesting::invoke_queued_threaded_action<observer_writer>(
+        make_not_null(&runner), 0);
 
-    for (const auto& [temporal_id_val, info_map] : volume_vars_info) {
-      for (const auto& [element_id, info] : info_map) {
-        const std::string element_name = MakeString{} << element_id;
+    {
+      const h5::H5File<h5::AccessType::ReadOnly> h5file{filename + "0.h5"s};
+      const auto& vol_file =
+          h5file.get<h5::VolumeData>("/InterpolatorVolumeData_TimeStepId", 0);
+      const auto written_data = vol_file.get_data_by_element(
+          std::nullopt, std::nullopt,
+          std::vector<std::string>{
+              db::tag_name<gr::Tags::Lapse<DataVector>>()});
+      // Only wrote data for one time
+      CHECK(written_data.size() == 1);
+      const auto& written_tuple = written_data[0];
+      const auto& observation_value = get<1>(written_tuple);
+      const auto& vec_element_vol_data = get<2>(written_tuple);
 
-        const ElementVolumeData written_element_vol_data = *alg::find_if(
-            vec_element_vol_data,
-            [&element_name](const ElementVolumeData& volume_data) {
-              return volume_data.element_name == element_name;
-            });
+      CHECK(observation_value ==
+            intrp::InterpolationTarget_detail::get_temporal_id_value(
+                temporal_id));
 
-        const ElementVolumeData element_vol_data =
-            intrp::Actions::detail::construct_element_volume_data<
-                ::Tags::TimeStepId, metavars>(element_id, info);
+      for (const auto& [temporal_id_val, info_map] : volume_vars_info) {
+        for (const auto& [element_id, info] : info_map) {
+          const std::string element_name = MakeString{} << element_id;
 
-        CHECK(element_vol_data == written_element_vol_data);
+          const ElementVolumeData written_element_vol_data = *alg::find_if(
+              vec_element_vol_data,
+              [&element_name](const ElementVolumeData& volume_data) {
+                return volume_data.element_name == element_name;
+              });
+
+          const ElementVolumeData element_vol_data =
+              intrp::Actions::detail::construct_element_volume_data<
+                  ::Tags::TimeStepId, metavars>(element_id, info);
+
+          CHECK(element_vol_data == written_element_vol_data);
+        }
       }
     }
   }
@@ -607,4 +614,12 @@ SPECTRE_TEST_CASE(
     file_system::rm(filename + "0.h5", true);
   }
 }
+
+SPECTRE_TEST_CASE(
+    "Unit.NumericalAlgorithms.Interpolator.ReceiveAndDumpVolumeData",
+    "[Unit]") {
+  test(true);
+  test(false);
+}
+
 }  // namespace

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_Tags.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_Tags.cpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 
+#include "Framework/TestCreation.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "ParallelAlgorithms/Interpolation/PointInfoTag.hpp"
 #include "ParallelAlgorithms/Interpolation/Tags.hpp"
@@ -26,6 +27,8 @@ struct InterpolationTargetTag {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Interpolation.Tags", "[Unit][NumericalAlgorithms]") {
+  TestHelpers::db::test_simple_tag<intrp::Tags::DumpVolumeDataOnFailure>(
+      "DumpVolumeDataOnFailure");
   TestHelpers::db::test_simple_tag<
       intrp::Tags::IndicesOfFilledInterpPoints<Metavars>>(
       "IndicesOfFilledInterpPoints");
@@ -48,4 +51,11 @@ SPECTRE_TEST_CASE("Unit.Interpolation.Tags", "[Unit][NumericalAlgorithms]") {
       "NumberOfElements");
   TestHelpers::db::test_simple_tag<intrp::Tags::InterpPointInfo<Metavars>>(
       "InterpPointInfo");
+
+  CHECK(
+      TestHelpers::test_option_tag<intrp::OptionTags::DumpVolumeDataOnFailure>(
+          "true"));
+  CHECK_FALSE(
+      TestHelpers::test_option_tag<intrp::OptionTags::DumpVolumeDataOnFailure>(
+          "false"));
 }


### PR DESCRIPTION
## Proposed changes

I fixed the issues I was having with this before that prompted me to disable the feature before in #4404.

I added an overload to ContributeVolumeDataToWriter that allows it to be used from the Interpolator.

I also added a tag that allows you to toggle this feature just in case it causes issues in the future, so users can easily disable it.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
If your executable uses the Interpolator parallel component, you'll need to add the following block to your input file:
```yaml
Interpolator:
  DumpVolumeDataOnFailure: false
```
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
