### PR TITLE
Interpolate initial data to evolution domain

### DIFF
--- a/docs/DevGuide/ImportingData.md
+++ b/docs/DevGuide/ImportingData.md
@@ -11,9 +11,9 @@ written by the `observers`.
 ## Importing volume data
 
 The `importers::ElementDataReader` parallel component is responsible for loading
-volume data and distributing it to elements of one or multiple array parallel
-components. As a first step, make sure you have added the
-`importers::ElementDataReader` to your `Metavariables::component_list`. Also
+volume data, interpolating it, and distributing it to elements of one or
+multiple array parallel components. As a first step, make sure you have added
+the `importers::ElementDataReader` to your `Metavariables::component_list`. Also
 make sure you have a `Parallel::Phase` in which you will perform
 registration with the importer, and another in which you want to load the data.
 Here's an example for such `Metavariables`:

--- a/src/Domain/BlockLogicalCoordinates.hpp
+++ b/src/Domain/BlockLogicalCoordinates.hpp
@@ -10,18 +10,15 @@
 #include <unordered_map>
 #include <vector>
 
+#include "DataStructures/IdPair.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/Structure/BlockId.hpp"
 
 /// \cond
-namespace domain {
-class BlockId;
-}  // namespace domain
 class DataVector;
 template <size_t VolumeDim>
 class Domain;
-template <typename IdType, typename DataType>
-class IdPair;
 /// \endcond
 
 /// \ingroup ComputationalDomainGroup

--- a/src/Evolution/Systems/GeneralizedHarmonic/Actions/NumericInitialData.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Actions/NumericInitialData.hpp
@@ -129,6 +129,7 @@ struct ReadNumericInitialData {
       importers::Tags::FileGlob<ImporterOptionsGroup>,
       importers::Tags::Subgroup<ImporterOptionsGroup>,
       importers::Tags::ObservationValue<ImporterOptionsGroup>,
+      importers::Tags::EnableInterpolation<ImporterOptionsGroup>,
       detail::Tags::NumericInitialDataVariables<ImporterOptionsGroup>>;
 
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,

--- a/src/Evolution/Systems/GeneralizedHarmonic/Actions/NumericInitialData.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Actions/NumericInitialData.hpp
@@ -170,7 +170,8 @@ struct ReadNumericInitialData {
     auto& reader_component = Parallel::get_parallel_component<
         importers::ElementDataReader<Metavariables>>(cache);
     Parallel::simple_action<importers::Actions::ReadAllVolumeDataAndDistribute<
-        ImporterOptionsGroup, detail::all_numeric_vars, ParallelComponent>>(
+        Metavariables::volume_dim, ImporterOptionsGroup,
+        detail::all_numeric_vars, ParallelComponent>>(
         reader_component, std::move(selected_fields));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }

--- a/src/IO/H5/VolumeData.hpp
+++ b/src/IO/H5/VolumeData.hpp
@@ -16,7 +16,9 @@
 #include "IO/H5/Object.hpp"
 #include "IO/H5/OpenGroup.hpp"
 #include "IO/H5/TensorData.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/Algorithm.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 
 /// \cond
@@ -240,5 +242,13 @@ std::pair<size_t, size_t> offset_and_length_for_grid(
     const std::string& grid_name,
     const std::vector<std::string>& all_grid_names,
     const std::vector<std::vector<size_t>>& all_extents);
+
+template <size_t Dim>
+Mesh<Dim> mesh_for_grid(
+    const std::string& grid_name,
+    const std::vector<std::string>& all_grid_names,
+    const std::vector<std::vector<size_t>>& all_extents,
+    const std::vector<std::vector<Spectral::Basis>>& all_bases,
+    const std::vector<std::vector<Spectral::Quadrature>>& all_quadratures);
 
 }  // namespace h5

--- a/src/IO/Importers/Actions/ReadVolumeData.hpp
+++ b/src/IO/Importers/Actions/ReadVolumeData.hpp
@@ -40,7 +40,7 @@ namespace importers {
 template <typename Metavariables>
 struct ElementDataReader;
 namespace Actions {
-template <typename ImporterOptionsGroup, typename FieldTagsList,
+template <size_t Dim, typename ImporterOptionsGroup, typename FieldTagsList,
           typename ReceiveComponent>
 struct ReadAllVolumeDataAndDistribute;
 }  // namespace Actions
@@ -100,20 +100,19 @@ struct ReadVolumeData {
                  Tags::ObservationValue<ImporterOptionsGroup>>;
 
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
-            typename ArrayIndex, typename ActionList,
-            typename ParallelComponent>
+            size_t Dim, typename ActionList, typename ParallelComponent>
   static Parallel::iterable_action_return_t apply(
       db::DataBox<DbTagsList>& /*box*/,
       const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
       Parallel::GlobalCache<Metavariables>& cache,
-      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ElementId<Dim>& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
     // Not using `ckLocalBranch` here to make sure the simple action invocation
     // is asynchronous.
     auto& reader_component = Parallel::get_parallel_component<
         importers::ElementDataReader<Metavariables>>(cache);
     Parallel::simple_action<importers::Actions::ReadAllVolumeDataAndDistribute<
-        ImporterOptionsGroup, FieldTagsList, ParallelComponent>>(
+        Dim, ImporterOptionsGroup, FieldTagsList, ParallelComponent>>(
         reader_component);
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
@@ -161,7 +160,7 @@ struct ReadVolumeData {
  *
  * \see Dev guide on \ref dev_guide_importing
  */
-template <typename ImporterOptionsGroup, typename FieldTagsList,
+template <size_t Dim, typename ImporterOptionsGroup, typename FieldTagsList,
           typename ReceiveComponent>
 struct ReadAllVolumeDataAndDistribute {
   template <typename ParallelComponent, typename DataBox,

--- a/src/IO/Importers/Actions/ReadVolumeData.hpp
+++ b/src/IO/Importers/Actions/ReadVolumeData.hpp
@@ -15,6 +15,9 @@
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/ElementLogicalCoordinates.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "IO/H5/AccessType.hpp"
 #include "IO/H5/File.hpp"
@@ -22,10 +25,15 @@
 #include "IO/Importers/ObservationSelector.hpp"
 #include "IO/Importers/Tags.hpp"
 #include "IO/Observer/ArrayComponentId.hpp"
+#include "NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "Parallel/AlgorithmExecution.hpp"
 #include "Parallel/ArrayIndex.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
+#include "Parallel/Serialize.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/FileSystem.hpp"
 #include "Utilities/Gsl.hpp"
@@ -35,8 +43,9 @@
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
-/// \cond
 namespace importers {
+
+/// \cond
 template <typename Metavariables>
 struct ElementDataReader;
 namespace Actions {
@@ -44,10 +53,9 @@ template <size_t Dim, typename ImporterOptionsGroup, typename FieldTagsList,
           typename ReceiveComponent>
 struct ReadAllVolumeDataAndDistribute;
 }  // namespace Actions
-}  // namespace importers
 /// \endcond
 
-namespace importers::Tags {
+namespace Tags {
 /*!
  * \brief Indicates an available tensor field is selected for importing, along
  * with the name of the dataset in the volume data file.
@@ -63,13 +71,178 @@ template <typename FieldTag>
 struct Selected : db::SimpleTag {
   using type = std::optional<std::string>;
 };
-}  // namespace importers::Tags
+}  // namespace Tags
 
-namespace importers::Actions {
+namespace detail {
+
+// Read the single `tensor_name` from the `volume_file`, taking care of suffixes
+// like "_x" etc for its components.
+template <typename TensorType>
+void read_tensor_data(const gsl::not_null<TensorType*> tensor_data,
+                      const std::string& tensor_name,
+                      const h5::VolumeData& volume_file,
+                      const size_t observation_id) {
+  for (size_t i = 0; i < tensor_data->size(); ++i) {
+    (*tensor_data)[i] = std::get<DataVector>(
+        volume_file
+            .get_tensor_component(
+                observation_id,
+                tensor_name + tensor_data->component_suffix(
+                                  tensor_data->get_tensor_index(i)))
+            .data);
+  }
+}
+
+// Read the `selected_fields` from the `volume_file`. Reads the data
+// for all elements in the `volume_file` at once. Invoked lazily when data
+// for an element in the volume file is needed.
+template <typename FieldTagsList>
+tuples::tagged_tuple_from_typelist<FieldTagsList> read_tensor_data(
+    const h5::VolumeData& volume_file, const size_t observation_id,
+    const tuples::tagged_tuple_from_typelist<
+        db::wrap_tags_in<Tags::Selected, FieldTagsList>>& selected_fields) {
+  tuples::tagged_tuple_from_typelist<FieldTagsList> all_tensor_data{};
+  tmpl::for_each<FieldTagsList>([&all_tensor_data, &volume_file,
+                                 &observation_id,
+                                 &selected_fields](auto field_tag_v) {
+    using field_tag = tmpl::type_from<decltype(field_tag_v)>;
+    const auto& selection = get<Tags::Selected<field_tag>>(selected_fields);
+    if (not selection.has_value()) {
+      return;
+    }
+    read_tensor_data(make_not_null(&get<field_tag>(all_tensor_data)),
+                     selection.value(), volume_file, observation_id);
+  });
+  return all_tensor_data;
+}
+
+// Extract this element's data from the read-in dataset
+template <typename FieldTagsList>
+tuples::tagged_tuple_from_typelist<FieldTagsList> extract_element_data(
+    const std::pair<size_t, size_t>& element_data_offset_and_length,
+    const tuples::tagged_tuple_from_typelist<FieldTagsList>& all_tensor_data,
+    const tuples::tagged_tuple_from_typelist<
+        db::wrap_tags_in<Tags::Selected, FieldTagsList>>& selected_fields) {
+  tuples::tagged_tuple_from_typelist<FieldTagsList> element_data{};
+  tmpl::for_each<FieldTagsList>(
+      [&element_data, &offset = element_data_offset_and_length.first,
+       &num_points = element_data_offset_and_length.second, &all_tensor_data,
+       &selected_fields](auto field_tag_v) {
+        using field_tag = tmpl::type_from<decltype(field_tag_v)>;
+        const auto& selection = get<Tags::Selected<field_tag>>(selected_fields);
+        if (not selection.has_value()) {
+          return;
+        }
+        auto& element_tensor_data = get<field_tag>(element_data);
+        // Iterate independent components of the tensor
+        for (size_t i = 0; i < element_tensor_data.size(); ++i) {
+          const DataVector& data_tensor_component =
+              get<field_tag>(all_tensor_data)[i];
+          DataVector element_tensor_component{num_points};
+          // Retrieve data from slice of the contigious dataset
+          for (size_t j = 0; j < element_tensor_component.size(); ++j) {
+            element_tensor_component[j] = data_tensor_component[offset + j];
+          }
+          element_tensor_data[i] = element_tensor_component;
+        }
+      });
+  return element_data;
+}
+
+// Check that the source and target points are the same in case interpolation is
+// disabled. This is important to avoid hard-to-find bugs where data is loaded
+// to the wrong coordinates. For example, if the evolution domain deforms the
+// excision surfaces a bit but the initial data doesn't, then it would be wrong
+// to load the initial data to the evolution grid without an interpolation.
+template <size_t Dim>
+void verify_inertial_coordinates(
+    const std::pair<size_t, size_t>& source_element_data_offset_and_length,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& source_inertial_coords,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& target_inertial_coords,
+    const std::string& grid_name) {
+  for (size_t d = 0; d < Dim; ++d) {
+    const DataVector& source_coord = source_inertial_coords[d];
+    const DataVector& target_coord = target_inertial_coords[d];
+    if (target_coord.size() != source_element_data_offset_and_length.second) {
+      ERROR_NO_TRACE(
+          "The source and target coordinates don't match on grid "
+          << grid_name << ". The source coordinates stored in the file have "
+          << source_element_data_offset_and_length.second
+          << " points, but the target grid has " << target_coord.size()
+          << " points. Set 'Interpolate: True' to enable interpolation between "
+             "the grids.");
+    }
+    for (size_t j = 0; j < source_element_data_offset_and_length.second; ++j) {
+      if (not equal_within_roundoff(
+              target_coord[j],
+              source_coord[source_element_data_offset_and_length.first + j])) {
+        ERROR_NO_TRACE(
+            "The source and target coordinates don't match on grid "
+            << grid_name << " in dimension " << d << " at point " << j
+            << " (plus offset " << source_element_data_offset_and_length.first
+            << " in the data file). Source coordinate: "
+            << source_coord[source_element_data_offset_and_length.first + j]
+            << ", target coordinate: " << target_coord[j]
+            << ". Set 'Interpolate: True' to enable interpolation between the "
+               "grids.");
+      }
+    }
+  }
+}
+
+// Interpolate only the `selected_fields` in `source_element_data` to the
+// `target_logical_coords`.
+template <typename FieldTagsList, size_t Dim>
+void interpolate_selected_fields(
+    const gsl::not_null<tuples::tagged_tuple_from_typelist<FieldTagsList>*>
+        target_element_data,
+    const tuples::tagged_tuple_from_typelist<FieldTagsList>&
+        source_element_data,
+    const Mesh<Dim>& source_mesh,
+    const tnsr::I<DataVector, Dim, Frame::ElementLogical>&
+        target_logical_coords,
+    const std::vector<size_t>& offsets,
+    const tuples::tagged_tuple_from_typelist<
+        db::wrap_tags_in<Tags::Selected, FieldTagsList>>& selected_fields) {
+  const intrp::Irregular<Dim> interpolator{source_mesh, target_logical_coords};
+  const size_t target_num_points = target_logical_coords.begin()->size();
+  ASSERT(target_num_points == offsets.size(),
+         "The number of target points ("
+             << target_num_points << ") must match the number of offsets ("
+             << offsets.size() << ").");
+  DataVector target_tensor_component_buffer{target_num_points};
+  tmpl::for_each<FieldTagsList>([&source_element_data, &target_element_data,
+                                 &interpolator, &target_tensor_component_buffer,
+                                 &selected_fields, &offsets](auto field_tag_v) {
+    using field_tag = tmpl::type_from<decltype(field_tag_v)>;
+    const auto& selection = get<Tags::Selected<field_tag>>(selected_fields);
+    if (not selection.has_value()) {
+      return;
+    }
+    const auto& source_tensor_data = get<field_tag>(source_element_data);
+    auto& target_tensor_data = get<field_tag>(*target_element_data);
+    // Iterate independent components of the tensor
+    for (size_t i = 0; i < source_tensor_data.size(); ++i) {
+      const DataVector& source_tensor_component = source_tensor_data[i];
+      DataVector& target_tensor_component = target_tensor_data[i];
+      // Interpolate
+      interpolator.interpolate(make_not_null(&target_tensor_component_buffer),
+                               source_tensor_component);
+      // Fill target element data at corresponding offsets
+      for (size_t j = 0; j < target_tensor_component_buffer.size(); ++j) {
+        target_tensor_component[offsets[j]] = target_tensor_component_buffer[j];
+      }
+    }
+  });
+}
+
+}  // namespace detail
+
+namespace Actions {
 
 /*!
  * \brief Read a volume data file and distribute the data to all registered
- * elements.
+ * elements, interpolating to the target points if needed.
  *
  * Invoke this action on the elements of an array parallel component to dispatch
  * reading the volume data file specified by the options in
@@ -97,7 +270,8 @@ struct ReadVolumeData {
   using const_global_cache_tags =
       tmpl::list<Tags::FileGlob<ImporterOptionsGroup>,
                  Tags::Subgroup<ImporterOptionsGroup>,
-                 Tags::ObservationValue<ImporterOptionsGroup>>;
+                 Tags::ObservationValue<ImporterOptionsGroup>,
+                 Tags::EnableInterpolation<ImporterOptionsGroup>>;
 
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             size_t Dim, typename ActionList, typename ParallelComponent>
@@ -120,7 +294,7 @@ struct ReadVolumeData {
 
 /*!
  * \brief Read a volume data file and distribute the data to all registered
- * elements.
+ * elements, interpolating to the target points if needed.
  *
  * This action can be invoked on the `importers::ElementDataReader` component
  * once all elements have been registered with it. It opens the data file, reads
@@ -142,6 +316,7 @@ struct ReadVolumeData {
  *   - `importers::OptionTags::FileGlob`
  *   - `importers::OptionTags::Subgroup`
  *   - `importers::OptionTags::ObservationValue`
+ *   - `importers::OptionTags::EnableInterpolation`
  * - The `FieldTagsList` parameter specifies a typelist of tensor tags that
  * can be read from the file and provided to each element. The subset of tensors
  * that will actually be read and distributed can be selected at runtime with
@@ -158,6 +333,25 @@ struct ReadVolumeData {
  * that was encoded into the `observers::ArrayComponentId` used to register the
  * elements.
  *
+ * \par Memory consumption
+ * This action runs once on every node. It reads all volume data files on the
+ * node, but doesn't keep them all in memory at once. The following items
+ * contribute primarily to memory consumption and can be reconsidered if we run
+ * into memory issues:
+ *
+ * - `all_tensor_data`: All requested tensor components in the volume data file
+ *   at the specified observation ID. Only data from one volume data file is
+ *   held in memory at any time. Only data from files that overlap with target
+ *   elements on this node are read in.
+ * - `target_element_data_buffer`: Holds incomplete interpolated data for each
+ *   (target) element that resides on this node. In the worst case, when all
+ *   target elements need data from the last source element in the last volume
+ *   data file, the memory consumption of this buffer can grow to hold all
+ *   requested tensor components on all elements that reside on this node.
+ *   However, elements are erased from this buffer once their interpolated data
+ *   is complete (and sent to the target element), so the memory consumption
+ *   should remain much lower in practice.
+ *
  * \see Dev guide on \ref dev_guide_importing
  */
 template <size_t Dim, typename ImporterOptionsGroup, typename FieldTagsList,
@@ -170,6 +364,9 @@ struct ReadAllVolumeDataAndDistribute {
                     tuples::tagged_tuple_from_typelist<
                         db::wrap_tags_in<Tags::Selected, FieldTagsList>>
                         selected_fields = select_all_fields(FieldTagsList{})) {
+    const bool enable_interpolation =
+        db::get<Tags::EnableInterpolation<ImporterOptionsGroup>>(box);
+
     // Only read and distribute the volume data once
     // This action will be invoked by `importers::Actions::ReadVolumeData` from
     // every element on the node, but only the first invocation reads the file
@@ -193,13 +390,59 @@ struct ReadAllVolumeDataAndDistribute {
           local_has_read_volume_data->insert(std::move(volume_data_id));
         });
 
+    // This is the subset of elements that reside on this node. They have
+    // registered themselves before. Our job is to fill them with volume data.
+    std::unordered_set<ElementId<Dim>> target_element_ids{};
+    for (const auto& target_element : get<Tags::RegisteredElements<Dim>>(box)) {
+      const auto& element_array_component_id = target_element.first;
+      const CkArrayIndex& raw_element_index =
+          element_array_component_id.array_index();
+      // Check if the parallel component of the registered element matches the
+      // callback, because it's possible that elements from other components
+      // with the same index are also registered.
+      // Since the way the component is encoded in `ArrayComponentId` is
+      // private to that class, we construct one and compare.
+      if (element_array_component_id !=
+          observers::ArrayComponentId(
+              std::add_pointer_t<ReceiveComponent>{nullptr},
+              raw_element_index)) {
+        continue;
+      }
+      const auto target_element_id =
+          Parallel::ArrayIndex<typename ReceiveComponent::array_index>(
+              raw_element_index)
+              .get_index();
+      target_element_ids.insert(target_element_id);
+    }
+    if (UNLIKELY(target_element_ids.empty())) {
+      return;
+    }
+
+    // Temporary buffer for data on target elements. These variables get filled
+    // with interpolated data while we're reading in volume files. Once data on
+    // an element is complete, the data is sent to that element and removed from
+    // this list.
+    std::unordered_map<ElementId<Dim>,
+                       tuples::tagged_tuple_from_typelist<FieldTagsList>>
+        target_element_data_buffer{};
+    std::unordered_map<ElementId<Dim>, std::vector<size_t>>
+        all_indices_of_filled_interp_points{};
+
     // Resolve the file glob
     const std::string& file_glob =
         Parallel::get<Tags::FileGlob<ImporterOptionsGroup>>(cache);
     const std::vector<std::string> file_paths = file_system::glob(file_glob);
+    if (file_paths.empty()) {
+      ERROR_NO_TRACE("The file glob '" << file_glob << "' matches no files.");
+    }
 
     // Open every file in turn
     std::optional<size_t> prev_observation_id{};
+    double observation_value = std::numeric_limits<double>::signaling_NaN();
+    std::optional<Domain<Dim>> source_domain{};
+    std::unordered_map<std::string,
+                       std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+        source_domain_functions_of_time{};
     for (const std::string& file_name : file_paths) {
       // Open the volume data file
       h5::H5File<h5::AccessType::ReadOnly> h5file(file_name);
@@ -235,102 +478,269 @@ struct ReadAllVolumeDataAndDistribute {
               << ". Make sure all files select the same observation ID.");
       }
       prev_observation_id = observation_id;
+      observation_value = volume_file.get_observation_value(observation_id);
 
-      // Read the tensor data for all elements at once, since that's how it's
-      // stored in the file
-      tuples::tagged_tuple_from_typelist<FieldTagsList> all_tensor_data{};
-      tmpl::for_each<FieldTagsList>([&all_tensor_data, &volume_file,
-                                     &observation_id,
-                                     &selected_fields](auto field_tag_v) {
-        using field_tag = tmpl::type_from<decltype(field_tag_v)>;
-        const auto& selection = get<Tags::Selected<field_tag>>(selected_fields);
-        if (not selection.has_value()) {
-          return;
-        }
-        auto& tensor_data = get<field_tag>(all_tensor_data);
-        for (size_t i = 0; i < tensor_data.size(); i++) {
-          tensor_data[i] = std::get<DataVector>(
-              volume_file
-                  .get_tensor_component(
-                      observation_id,
-                      selection.value() + tensor_data.component_suffix(
-                                              tensor_data.get_tensor_index(i)))
-                  .data);
-        }
-      });
+      // Memory buffer for the tensor data stored in this file. The data is
+      // loaded lazily when it is needed. We may find that we can skip loading
+      // some files because none of their data is needed to fill the elements on
+      // this node.
+      std::optional<tuples::tagged_tuple_from_typelist<FieldTagsList>>
+          all_tensor_data{};
+      std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>
+          source_inertial_coords{};
+
       // Retrieve the information needed to reconstruct which element the data
       // belongs to
-      const auto all_grid_names = volume_file.get_grid_names(observation_id);
-      const auto all_extents = volume_file.get_extents(observation_id);
-      // Distribute the tensor data to the registered elements
-      for (auto& [element_array_component_id, grid_name] :
-           get<Tags::RegisteredElements>(box)) {
-        const CkArrayIndex& raw_element_index =
-            element_array_component_id.array_index();
-        // Check if the parallel component of the registered element matches the
-        // callback, because it's possible that elements from other components
-        // with the same index are also registered.
-        // Since the way the component is encoded in `ArrayComponentId` is
-        // private to that class, we construct one and compare.
-        if (element_array_component_id !=
+      const auto source_grid_names = volume_file.get_grid_names(observation_id);
+      const auto source_extents = volume_file.get_extents(observation_id);
+      const auto source_bases = volume_file.get_bases(observation_id);
+      const auto source_quadratures =
+          volume_file.get_quadratures(observation_id);
+      std::vector<ElementId<Dim>> source_element_ids{};
+      if (enable_interpolation) {
+        // Need to parse all source grid names to element IDs only if
+        // interpolation is enabled
+        source_element_ids.reserve(source_grid_names.size());
+        for (const auto& grid_name : source_grid_names) {
+          source_element_ids.push_back(ElementId<Dim>(grid_name));
+        }
+        // Reconstruct domain from volume data file
+        const std::optional<std::vector<char>> serialized_domain =
+            volume_file.get_domain(observation_id);
+        if (not serialized_domain.has_value()) {
+          ERROR_NO_TRACE("No serialized domain found in file '"
+                         << file_name << volume_file.subfile_path()
+                         << "'. The domain is needed for interpolation.");
+        }
+        if (source_domain.has_value()) {
+#ifdef SPECTRE_DEBUG
+          // Check that the domain is the same in all files (only in debug mode)
+          const auto deserialized_domain =
+              deserialize<Domain<Dim>>(serialized_domain->data());
+          if (*source_domain != deserialized_domain) {
+            ERROR_NO_TRACE(
+                "The domain in all volume files must be the same. Domain in "
+                "file '"
+                << file_name << volume_file.subfile_path()
+                << "' differs from a previously read file.");
+          }
+#endif
+        } else {
+          source_domain = deserialize<Domain<Dim>>(serialized_domain->data());
+        }
+        // Reconstruct functions of time from volume data file
+        if (source_domain_functions_of_time.empty() and
+            alg::any_of(source_domain->blocks(), [](const auto& block) {
+              return block.is_time_dependent();
+            })) {
+          const std::optional<std::vector<char>> serialized_functions_of_time =
+              volume_file.get_functions_of_time(observation_id);
+          if (not serialized_functions_of_time.has_value()) {
+            ERROR_NO_TRACE("No domain functions of time found in file '"
+                           << file_name << volume_file.subfile_path()
+                           << "'. The functions of time are needed for "
+                              "interpolating with time-dependent maps.");
+          }
+          source_domain_functions_of_time = deserialize<std::unordered_map<
+              std::string,
+              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>>(
+              serialized_functions_of_time->data());
+        }
+      }
+
+      // Distribute the tensor data to the registered (target) elements. We
+      // erase target elements when they are complete. This allows us to search
+      // only for incomplete elements in subsequent volume files, and to stop
+      // early when all registered elements are complete.
+      std::unordered_set<ElementId<Dim>> completed_target_elements{};
+      for (const auto& target_element_id : target_element_ids) {
+        const auto& target_points = get<Tags::RegisteredElements<Dim>>(box).at(
             observers::ArrayComponentId(
                 std::add_pointer_t<ReceiveComponent>{nullptr},
-                raw_element_index)) {
-          continue;
-        }
-        // Proceed with the registered element only if it's included in the
+                Parallel::ArrayIndex<ElementId<Dim>>(target_element_id)));
+        const auto target_grid_name = get_output(target_element_id);
+
+        // Proceed with the registered element only if it overlaps with the
         // volume file. It's possible that the volume file only contains data
         // for a subset of elements, e.g., when each node of a simulation wrote
         // volume data for its elements to a separate file.
-        if (std::find(all_grid_names.begin(), all_grid_names.end(),
-                      grid_name) == all_grid_names.end()) {
-          continue;
+        std::vector<ElementId<Dim>> overlapping_source_element_ids{};
+        std::unordered_map<ElementId<Dim>, ElementLogicalCoordHolder<Dim>>
+            source_element_logical_coords{};
+        if (enable_interpolation) {
+          // Transform the target points to block logical coords in the source
+          // domain
+          const auto source_block_logical_coords = block_logical_coordinates(
+              *source_domain, target_points, observation_value,
+              source_domain_functions_of_time);
+          // Find the target points in the subset of source elements contained
+          // in this volume file
+          source_element_logical_coords = element_logical_coordinates(
+              source_element_ids, source_block_logical_coords);
+          overlapping_source_element_ids.reserve(
+              source_element_logical_coords.size());
+          for (const auto& source_element_id_and_coords :
+               source_element_logical_coords) {
+            overlapping_source_element_ids.push_back(
+                source_element_id_and_coords.first);
+          }
+        } else {
+          // When interpolation is disabled we process only volume files that
+          // contain the exact element
+          if (std::find(source_grid_names.begin(), source_grid_names.end(),
+                        target_grid_name) == source_grid_names.end()) {
+            continue;
+          }
+          overlapping_source_element_ids.push_back(target_element_id);
         }
-        // Find the data offset that corresponds to this element
-        const auto element_data_offset_and_length =
-            h5::offset_and_length_for_grid(grid_name, all_grid_names,
-                                           all_extents);
-        // Extract this element's data from the read-in dataset
-        tuples::tagged_tuple_from_typelist<FieldTagsList> element_data{};
-        tmpl::for_each<FieldTagsList>([&element_data,
-                                       &element_data_offset_and_length,
-                                       &all_tensor_data,
-                                       &selected_fields](auto field_tag_v) {
-          using field_tag = tmpl::type_from<decltype(field_tag_v)>;
-          const auto& selection =
-              get<Tags::Selected<field_tag>>(selected_fields);
-          if (not selection.has_value()) {
-            return;
-          }
-          auto& element_tensor_data = get<field_tag>(element_data);
-          // Iterate independent components of the tensor
-          for (size_t i = 0; i < element_tensor_data.size(); i++) {
-            const DataVector& data_tensor_component =
-                get<field_tag>(all_tensor_data)[i];
-            DataVector element_tensor_component{
-                element_data_offset_and_length.second};
-            // Retrieve data from slice of the contigious dataset
-            for (size_t j = 0; j < element_tensor_component.size(); j++) {
-              element_tensor_component[j] =
-                  data_tensor_component[element_data_offset_and_length.first +
-                                        j];
+
+        // Lazily load the tensor data from the file if needed
+        if (not overlapping_source_element_ids.empty() and
+            not all_tensor_data.has_value()) {
+          all_tensor_data = detail::read_tensor_data<FieldTagsList>(
+              volume_file, observation_id, selected_fields);
+        }
+
+        // Iterate over the source elements in this volume file that overlap
+        // with the target element
+        for (const auto& source_element_id : overlapping_source_element_ids) {
+          const auto source_grid_name = get_output(source_element_id);
+          // Find the data offset that corresponds to this element
+          const auto element_data_offset_and_length =
+              h5::offset_and_length_for_grid(source_grid_name,
+                                             source_grid_names, source_extents);
+          // Extract this element's data from the read-in dataset
+          auto source_element_data =
+              detail::extract_element_data<FieldTagsList>(
+                  element_data_offset_and_length, *all_tensor_data,
+                  selected_fields);
+
+          if (enable_interpolation) {
+            const auto source_mesh = h5::mesh_for_grid<Dim>(
+                source_grid_name, source_grid_names, source_extents,
+                source_bases, source_quadratures);
+            const size_t target_num_points = target_points.begin()->size();
+
+            // Get and resize target buffer
+            auto& target_element_data =
+                target_element_data_buffer[target_element_id];
+            tmpl::for_each<FieldTagsList>([&target_element_data,
+                                           &target_num_points,
+                                           &selected_fields](auto field_tag_v) {
+              using field_tag = tmpl::type_from<decltype(field_tag_v)>;
+              if (get<Tags::Selected<field_tag>>(selected_fields).has_value()) {
+                for (auto& component : get<field_tag>(target_element_data)) {
+                  component.destructive_resize(target_num_points);
+                }
+              }
+            });
+            auto& indices_of_filled_interp_points =
+                all_indices_of_filled_interp_points[target_element_id];
+
+            // Interpolate!
+            const auto& source_logical_coords_of_target_points =
+                source_element_logical_coords.at(source_element_id);
+            detail::interpolate_selected_fields<FieldTagsList>(
+                make_not_null(&target_element_data), source_element_data,
+                source_mesh,
+                source_logical_coords_of_target_points.element_logical_coords,
+                source_logical_coords_of_target_points.offsets,
+                selected_fields);
+            indices_of_filled_interp_points.insert(
+                indices_of_filled_interp_points.end(),
+                source_logical_coords_of_target_points.offsets.begin(),
+                source_logical_coords_of_target_points.offsets.end());
+
+            if (indices_of_filled_interp_points.size() == target_num_points) {
+              // Pass the (interpolated) data to the element. Now it can proceed
+              // in parallel with transforming the data, taking derivatives on
+              // the grid, etc.
+              Parallel::receive_data<
+                  Tags::VolumeData<ImporterOptionsGroup, FieldTagsList>>(
+                  Parallel::get_parallel_component<ReceiveComponent>(
+                      cache)[target_element_id],
+                  // Using `0` for the temporal ID since we only read the volume
+                  // data once, so there's no need to keep track of the temporal
+                  // ID.
+                  0_st, std::move(target_element_data));
+              completed_target_elements.insert(target_element_id);
+              target_element_data_buffer.erase(target_element_id);
+              all_indices_of_filled_interp_points.erase(target_element_id);
             }
-            element_tensor_data[i] = element_tensor_component;
+          } else {
+            // Verify that the inertial coordinates of the source and target
+            // elements match. To do so we retrieve the inertial coordinates
+            // that are written alongside the tensor data in the file. This is
+            // an important check. It avoids nasty bugs where tensor data is
+            // read in to points that don't exactly match the input. Therefore
+            // we DON'T restrict this check to Debug mode.
+            if (not source_inertial_coords.has_value()) {
+              tnsr::I<DataVector, Dim, Frame::Inertial> inertial_coords{};
+              detail::read_tensor_data(make_not_null(&inertial_coords),
+                                       "InertialCoordinates", volume_file,
+                                       observation_id);
+              source_inertial_coords = std::move(inertial_coords);
+            }
+            detail::verify_inertial_coordinates(
+                element_data_offset_and_length, *source_inertial_coords,
+                target_points, source_grid_name);
+            // Pass data directly to the element when interpolation is disabled
+            Parallel::receive_data<
+                Tags::VolumeData<ImporterOptionsGroup, FieldTagsList>>(
+                Parallel::get_parallel_component<ReceiveComponent>(
+                    cache)[target_element_id],
+                // Using `0` for the temporal ID since we only read the volume
+                // data once, so there's no need to keep track of the temporal
+                // ID.
+                0_st, std::move(source_element_data));
+            completed_target_elements.insert(target_element_id);
           }
-        });
-        // Pass the data to the element
-        const auto element_index =
-            Parallel::ArrayIndex<typename ReceiveComponent::array_index>(
-                raw_element_index)
-                .get_index();
-        Parallel::receive_data<
-            Tags::VolumeData<ImporterOptionsGroup, FieldTagsList>>(
-            Parallel::get_parallel_component<ReceiveComponent>(
-                cache)[element_index],
-            // Using `0` for the temporal ID since we only read the volume data
-            // once, so there's no need to keep track of the temporal ID.
-            0_st, std::move(element_data));
+        }  // loop over overlapping source elements
+      }    // loop over registered elements
+      for (const auto& completed_element_id : completed_target_elements) {
+        target_element_ids.erase(completed_element_id);
       }
+      // Stop early when all target elements are complete
+      if (target_element_ids.empty()) {
+        break;
+      }
+    }  // loop over volume files
+
+    // Have we completed all target elements? If we haven't, the target domain
+    // probably extends outside the source domain. In that case we report the
+    // coordinates that couldn't be filled.
+    if (not target_element_ids.empty()) {
+      std::unordered_map<ElementId<Dim>, std::vector<std::array<double, Dim>>>
+          missing_coords{};
+      size_t num_missing_points = 0;
+      for (const auto& target_element_id : target_element_ids) {
+        const auto& target_inertial_coords =
+            get<Tags::RegisteredElements<Dim>>(box).at(
+                observers::ArrayComponentId(
+                    std::add_pointer_t<ReceiveComponent>{nullptr},
+                    Parallel::ArrayIndex<ElementId<Dim>>(target_element_id)));
+        const size_t target_num_points = target_inertial_coords.begin()->size();
+        const auto& indices_of_filled_interp_points =
+            all_indices_of_filled_interp_points[target_element_id];
+        for (size_t i = 0; i < target_num_points; ++i) {
+          if (alg::find(indices_of_filled_interp_points, i) ==
+              indices_of_filled_interp_points.end()) {
+            missing_coords[target_element_id].push_back(
+                [&target_inertial_coords, &i]() {
+                  std::array<double, Dim> x{};
+                  for (size_t d = 0; d < Dim; ++d) {
+                    x[d] = target_inertial_coords[d][i];
+                  }
+                  return x;
+                }());
+            ++num_missing_points;
+          }
+        }
+      }
+      ERROR_NO_TRACE("The following " << num_missing_points << " point(s) in "
+                                      << missing_coords.size()
+                                      << " element(s) could not be filled:\n"
+                                      << missing_coords);
     }
   }
 
@@ -342,4 +752,5 @@ struct ReadAllVolumeDataAndDistribute {
   }
 };
 
-}  // namespace importers::Actions
+}  // namespace Actions
+}  // namespace importers

--- a/src/IO/Importers/CMakeLists.txt
+++ b/src/IO/Importers/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(
   DataStructures
   DomainStructure
   Initialization
+  Interpolation
   Parallel
   Utilities
   )

--- a/src/IO/Importers/ElementDataReader.hpp
+++ b/src/IO/Importers/ElementDataReader.hpp
@@ -19,6 +19,7 @@
 namespace importers {
 
 namespace detail {
+template <size_t Dim>
 struct InitializeElementDataReader;
 }  // namespace detail
 
@@ -38,11 +39,13 @@ struct InitializeElementDataReader;
  */
 template <typename Metavariables>
 struct ElementDataReader {
+  static constexpr size_t Dim = Metavariables::volume_dim;
+
   using chare_type = Parallel::Algorithms::Nodegroup;
   using metavariables = Metavariables;
-  using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<Parallel::Phase::Initialization,
-                             tmpl::list<detail::InitializeElementDataReader>>>;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      Parallel::Phase::Initialization,
+      tmpl::list<detail::InitializeElementDataReader<Dim>>>>;
   using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
@@ -59,6 +62,7 @@ struct ElementDataReader {
 };
 
 namespace detail {
+template <size_t Dim>
 struct InitializeElementDataReader {
   using simple_tags =
       tmpl::list<Tags::RegisteredElements, Tags::ElementDataAlreadyRead>;

--- a/src/IO/Importers/ElementDataReader.hpp
+++ b/src/IO/Importers/ElementDataReader.hpp
@@ -65,7 +65,7 @@ namespace detail {
 template <size_t Dim>
 struct InitializeElementDataReader {
   using simple_tags =
-      tmpl::list<Tags::RegisteredElements, Tags::ElementDataAlreadyRead>;
+      tmpl::list<Tags::RegisteredElements<Dim>, Tags::ElementDataAlreadyRead>;
   using compute_tags = tmpl::list<>;
 
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,

--- a/src/IO/Importers/Tags.hpp
+++ b/src/IO/Importers/Tags.hpp
@@ -77,6 +77,28 @@ struct ObservationValue {
       "The observation value at which to read data";
   using group = ImporterOptionsGroup;
 };
+
+/*!
+ * \brief Toggle interpolation of numeric data to the target domain
+ */
+template <typename ImporterOptionsGroup>
+struct EnableInterpolation {
+  static std::string name() { return "Interpolate"; }
+  static_assert(
+      std::is_same_v<typename ImporterOptionsGroup::group, Group>,
+      "The importer options should be placed in the 'Importers' option "
+      "group. Add a type alias `using group = importers::OptionTags::Group`.");
+  using type = bool;
+  static constexpr Options::String help =
+      "Enable to interpolate the volume data to the target domain. Disable to "
+      "load volume data directly into elements with the same name. "
+      "For example, you can disable interpolation if you have generated data "
+      "on the target points, or if you have already interpolated your data. "
+      "When interpolation is disabled, datasets "
+      "'InertialCoordinates(_x,_y,_z)' must exist in the files. They are used "
+      "to verify that the target points indeed match the source data.";
+  using group = ImporterOptionsGroup;
+};
 }  // namespace OptionTags
 
 /// The \ref DataBoxGroup tags associated with the data importer
@@ -130,6 +152,25 @@ struct ObservationValue : db::SimpleTag {
   static constexpr bool pass_metavariables = false;
   static type create_from_options(const type& observation_value) {
     return observation_value;
+  }
+};
+
+/*!
+ * \brief Toggle interpolation of numeric data to the target domain
+ */
+template <typename ImporterOptionsGroup>
+struct EnableInterpolation : db::SimpleTag {
+  static std::string name() {
+    return "EnableInterpolation(" + pretty_type::name<ImporterOptionsGroup>() +
+           ")";
+  }
+  using type = bool;
+  using option_tags =
+      tmpl::list<OptionTags::EnableInterpolation<ImporterOptionsGroup>>;
+
+  static constexpr bool pass_metavariables = false;
+  static bool create_from_options(const bool enable_interpolation) {
+    return enable_interpolation;
   }
 };
 

--- a/src/IO/Importers/Tags.hpp
+++ b/src/IO/Importers/Tags.hpp
@@ -6,10 +6,12 @@
 #include <cstddef>
 #include <map>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <variant>
 
 #include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
 #include "IO/Importers/ObservationSelector.hpp"
 #include "IO/Observer/ArrayComponentId.hpp"
 #include "Options/Options.hpp"
@@ -179,10 +181,13 @@ struct EnableInterpolation : db::SimpleTag {
  *
  * \details Identifiers for elements from multiple parallel components can be
  * stored. Each element is identified by an `observers::ArrayComponentId` and
- * also needs to provide the `std::string` that identifies it in the data file.
+ * also needs to provide the inertial coordinates of its grid points. The
+ * imported data will be interpolated to these grid points.
  */
+template <size_t Dim>
 struct RegisteredElements : db::SimpleTag {
-  using type = std::unordered_map<observers::ArrayComponentId, std::string>;
+  using type = std::unordered_map<observers::ArrayComponentId,
+                                  tnsr::I<DataVector, Dim, Frame::Inertial>>;
 };
 
 /// Indicates which volume data files have already been read.

--- a/src/Utilities/TaggedTuple.hpp
+++ b/src/Utilities/TaggedTuple.hpp
@@ -675,7 +675,7 @@ TaggedTuple<OutputTags...> reorder_impl(TaggedTuple<InputTags...>&& input,
           std::is_same_v<tmpl::list_difference<tmpl::list<InputTags...>,
                                                tmpl::list<OutputTags...>>,
                          tmpl::list<>>,
-      "The input and output TaggedTuples must be the same except"
+      "The input and output TaggedTuples must be the same except "
       "for ordering.");
   return TaggedTuple<OutputTags...>(std::move(get<OutputTags>(input))...);
 }

--- a/tests/InputFiles/FindHorizons/FindHorizons3D.yaml
+++ b/tests/InputFiles/FindHorizons/FindHorizons3D.yaml
@@ -29,6 +29,7 @@ Importers:
     FileGlob: "KerrVolume*.h5"
     Subgroup: "VolumeData"
     ObservationValue: Last
+    Interpolate: False
 
 ApparentHorizons:
   AhA:

--- a/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/BinaryBlackHole.yaml
@@ -290,8 +290,8 @@ ControlSystems:
       DecreaseFactor: 0.98
     ControlError:
 
-# initial_data.h5 should contain numerical initial data
-# on the same grid as specified by the domain given above
+# initial_data.h5 should contain numerical initial data on a grid that covers
+# the domain given above
 # - One way to produce initial data is with the `SolveXcts` executable. See the
 #   example in `docs/Examples/BbhInitialData`.
 # - You can also produce initial data with SpEC, interpolate it (using SpEC) to
@@ -299,11 +299,14 @@ ControlSystems:
 #   coordinates of all grid points in the domain), and then load it here by
 #   selecting either the GH variables (`SpacetimeMetric`, `Pi`, `Phi`) or the
 #   ADM variables (`Lapse`, `Shift`, `SpatialMetric`, `ExtrinsicCurvature`).
+#   In this case, set `Interpolate: False` because the data is already given
+#   on this exact grid.
 Importers:
   NumericInitialData:
     FileGlob: "/path/to/initial_data.h5"
     Subgroup: "VolumeData"
     ObservationValue: Last
+    Interpolate: True
     Variables:
       Lapse: Lapse
       # Load a shift that is not corotating. See `docs/Examples/BbhInitialData`

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Actions/Test_NumericInitialData.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Actions/Test_NumericInitialData.cpp
@@ -160,8 +160,9 @@ void test_numeric_initial_data(
       importers::Tags::FileGlob<TestOptionGroup>,
       importers::Tags::Subgroup<TestOptionGroup>,
       importers::Tags::ObservationValue<TestOptionGroup>,
+      importers::Tags::EnableInterpolation<TestOptionGroup>,
       detail::Tags::NumericInitialDataVariables<TestOptionGroup>>{
-      "TestInitialData.h5", "VolumeData", 0., selected_vars}};
+      "TestInitialData.h5", "VolumeData", 0., false, selected_vars}};
 
   // Setup mock data file reader
   ActionTesting::emplace_nodegroup_component<reader_component>(

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Actions/Test_NumericInitialData.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Actions/Test_NumericInitialData.cpp
@@ -134,12 +134,13 @@ struct MockVolumeDataReader {
       Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
   using replace_these_simple_actions =
       tmpl::list<importers::Actions::ReadAllVolumeDataAndDistribute<
-          TestOptionGroup, detail::all_numeric_vars,
+          metavariables::volume_dim, TestOptionGroup, detail::all_numeric_vars,
           MockElementArray<Metavariables>>>;
   using with_these_simple_actions = tmpl::list<MockReadVolumeData>;
 };
 
 struct Metavariables {
+  static constexpr size_t volume_dim = 3;
   using component_list = tmpl::list<MockElementArray<Metavariables>,
                                     MockVolumeDataReader<Metavariables>>;
 };

--- a/tests/Unit/IO/H5/Test_VolumeData.cpp
+++ b/tests/Unit/IO/H5/Test_VolumeData.cpp
@@ -273,6 +273,25 @@ void test() {
     CHECK(last_grid_offset_and_length.second == 8);
   }
 
+  {
+    INFO("mesh_for_grid");
+    const size_t observation_id = observation_ids.front();
+    const auto all_grid_names = volume_file.get_grid_names(observation_id);
+    const auto all_extents = volume_file.get_extents(observation_id);
+    const auto all_bases = volume_file.get_bases(observation_id);
+    const auto all_quadratures = volume_file.get_quadratures(observation_id);
+    const auto first_mesh =
+        h5::mesh_for_grid<3>(grid_names.front(), all_grid_names, all_extents,
+                             all_bases, all_quadratures);
+    CHECK(first_mesh ==
+          Mesh<3>(2, Spectral::Basis::Chebyshev, Spectral::Quadrature::Gauss));
+    const auto last_mesh =
+        h5::mesh_for_grid<3>(grid_names.back(), all_grid_names, all_extents,
+                             all_bases, all_quadratures);
+    CHECK(last_mesh == Mesh<3>(2, Spectral::Basis::Legendre,
+                               Spectral::Quadrature::GaussLobatto));
+  }
+
   if (file_system::check_if_file_exists(h5_file_name)) {
     file_system::rm(h5_file_name, true);
   }

--- a/tests/Unit/IO/Importers/CMakeLists.txt
+++ b/tests/Unit/IO/Importers/CMakeLists.txt
@@ -51,6 +51,8 @@ function(add_algorithm_test TEST_NAME DIM)
     ${EXECUTABLE_NAME}
     PRIVATE
     DataStructures
+    Domain
+    DomainCreators
     DomainStructure
     ErrorHandling
     Importers

--- a/tests/Unit/IO/Importers/Test_Tags.cpp
+++ b/tests/Unit/IO/Importers/Test_Tags.cpp
@@ -33,18 +33,23 @@ SPECTRE_TEST_CASE("Unit.IO.Importers.Tags", "[Unit][IO]") {
   TestHelpers::db::test_simple_tag<
       importers::Tags::ObservationValue<ExampleVolumeData>>(
       "ObservationValue(ExampleVolumeData)");
+  TestHelpers::db::test_simple_tag<
+      importers::Tags::EnableInterpolation<ExampleVolumeData>>(
+      "EnableInterpolation(ExampleVolumeData)");
 
   Options::Parser<
       tmpl::list<importers::OptionTags::FileGlob<ExampleVolumeData>,
                  importers::OptionTags::Subgroup<ExampleVolumeData>,
-                 importers::OptionTags::ObservationValue<ExampleVolumeData>>>
+                 importers::OptionTags::ObservationValue<ExampleVolumeData>,
+                 importers::OptionTags::EnableInterpolation<ExampleVolumeData>>>
       opts("");
   opts.parse(
       "Importers:\n"
       "  ExampleVolumeData:\n"
       "    FileGlob: File.name\n"
       "    Subgroup: data.group\n"
-      "    ObservationValue: 1.");
+      "    ObservationValue: 1.\n"
+      "    Interpolate: True");
   CHECK(opts.get<importers::OptionTags::FileGlob<ExampleVolumeData>>() ==
         "File.name");
   CHECK(opts.get<importers::OptionTags::Subgroup<ExampleVolumeData>>() ==
@@ -54,6 +59,8 @@ SPECTRE_TEST_CASE("Unit.IO.Importers.Tags", "[Unit][IO]") {
           opts.get<
               importers::OptionTags::ObservationValue<ExampleVolumeData>>()) ==
       1.);
+  CHECK(opts.get<
+        importers::OptionTags::EnableInterpolation<ExampleVolumeData>>());
 
   CHECK(std::get<importers::ObservationSelector>(
             TestHelpers::test_option_tag<

--- a/tests/Unit/IO/Importers/Test_Tags.cpp
+++ b/tests/Unit/IO/Importers/Test_Tags.cpp
@@ -3,6 +3,7 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <cstddef>
 #include <string>
 
 #include "DataStructures/DataBox/TagName.hpp"
@@ -20,7 +21,7 @@ struct ExampleVolumeData {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.IO.Importers.Tags", "[Unit][IO]") {
-  TestHelpers::db::test_simple_tag<importers::Tags::RegisteredElements>(
+  TestHelpers::db::test_simple_tag<importers::Tags::RegisteredElements<3>>(
       "RegisteredElements");
   TestHelpers::db::test_simple_tag<importers::Tags::ElementDataAlreadyRead>(
       "ElementDataAlreadyRead");

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderActions.cpp
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderActions.cpp
@@ -81,10 +81,12 @@ struct MockVolumeDataReader {
   using array_index = size_t;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       Parallel::Phase::Initialization,
-      tmpl::list<importers::detail::InitializeElementDataReader>>>;
+      tmpl::list<importers::detail::InitializeElementDataReader<
+          metavariables::volume_dim>>>>;
 };
 
 struct Metavariables {
+  static constexpr size_t volume_dim = 2;
   using component_list = tmpl::list<MockElementArray<Metavariables>,
                                     MockVolumeDataReader<Metavariables>>;
 };

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm.hpp
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm.hpp
@@ -382,6 +382,8 @@ struct ElementArray {
 /// [metavars]
 template <size_t Dim>
 struct Metavariables {
+  static constexpr size_t volume_dim = Dim;
+
   using component_list =
       tmpl::list<ElementArray<Dim, Grid::Fine, Metavariables>,
                  ElementArray<Dim, Grid::Coarse, Metavariables>,

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm.hpp
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm.hpp
@@ -1,6 +1,15 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+/*!
+ * \file
+ * \brief Test reading in and interpolating volume data from H5 files
+ *
+ * Input files specify a source domain and a target domain. Test data on the
+ * source domain is constructed and written to H5 files, then read back in and
+ * interpolated to the target domain.
+ */
+
 #pragma once
 
 #define CATCH_CONFIG_RUNNER
@@ -8,6 +17,7 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <cstddef>
+#include <memory>
 #include <optional>
 #include <ostream>
 #include <string>
@@ -17,8 +27,21 @@
 
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/Creators/Factory1D.hpp"
+#include "Domain/Creators/Factory2D.hpp"
+#include "Domain/Creators/Factory3D.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+#include "Domain/Structure/CreateInitialMesh.hpp"
 #include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/InitialElementIds.hpp"
+#include "Evolution/DiscontinuousGalerkin/DgElementArray.hpp"
 #include "Helpers/Parallel/RoundRobinArrayElements.hpp"
 #include "IO/H5/AccessType.hpp"
 #include "IO/H5/File.hpp"
@@ -39,14 +62,18 @@
 #include "Parallel/Main.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/Phase.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "Parallel/Serialize.hpp"
 #include "ParallelAlgorithms/Actions/SetData.hpp"
 #include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/FileSystem.hpp"
 #include "Utilities/Functional.hpp"
 #include "Utilities/MakeString.hpp"
 #include "Utilities/MemoryHelpers.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/System/ParallelInfo.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -67,92 +94,93 @@ struct VectorFieldTag : db::SimpleTag {
   static std::string name() { return "VectorField"; }
 };
 
-enum class Grid { Fine, Coarse };
+/// The source or target of the interpolation
+enum class SourceOrTarget {
+  /// The domain to interpolate FROM
+  Source,
+  /// The domain to interpolate TO
+  Target
+};
 
-inline std::ostream& operator<<(std::ostream& os, Grid grid) {
-  switch (grid) {
-    case Grid::Fine:
-      return os << "Fine";
-    case Grid::Coarse:
-      return os << "Coarse";
+inline std::ostream& operator<<(std::ostream& os,
+                                SourceOrTarget source_or_target) {
+  switch (source_or_target) {
+    case SourceOrTarget::Source:
+      return os << "Source";
+    case SourceOrTarget::Target:
+      return os << "Target";
     default:
-      ERROR("Missing case for grid");
+      ERROR("Missing case for SourceOrTarget");
   }
 }
 
-template <Grid TheGrid>
-constexpr size_t number_of_elements = 2;
-template <>
-constexpr size_t number_of_elements<Grid::Coarse> = 1;
+// Tags for both the source and target domains of the interpolation
+
+namespace OptionTags {
+template <size_t Dim, SourceOrTarget WhichDomain>
+struct DomainCreator {
+  static std::string name() {
+    return MakeString{} << WhichDomain << "DomainCreator";
+  }
+  using type = std::unique_ptr<::DomainCreator<Dim>>;
+  static constexpr Options::String help = {"Choose a domain."};
+};
+}  // namespace OptionTags
+
+namespace Tags {
+template <size_t Dim, SourceOrTarget WhichDomain>
+struct Domain : db::SimpleTag {
+  using type = ::Domain<Dim>;
+  using option_tags = tmpl::list<OptionTags::DomainCreator<Dim, WhichDomain>>;
+  static constexpr bool pass_metavariables = false;
+  static ::Domain<Dim> create_from_options(
+      const std::unique_ptr<::DomainCreator<Dim>>& domain_creator) {
+    return domain_creator->create_domain();
+  }
+};
+
+template <size_t Dim, SourceOrTarget WhichDomain>
+struct FunctionsOfTime : db::SimpleTag {
+  using type = std::unordered_map<
+      std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>;
+  using option_tags = tmpl::list<OptionTags::DomainCreator<Dim, WhichDomain>>;
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(
+      const std::unique_ptr<::DomainCreator<Dim>>& domain_creator) {
+    return domain_creator->functions_of_time();
+  }
+};
+
+template <size_t Dim, SourceOrTarget WhichDomain>
+struct InitialExtents : db::SimpleTag {
+  using type = std::vector<std::array<size_t, Dim>>;
+  using option_tags = tmpl::list<OptionTags::DomainCreator<Dim, WhichDomain>>;
+  static constexpr bool pass_metavariables = false;
+  static std::vector<std::array<size_t, Dim>> create_from_options(
+      const std::unique_ptr<::DomainCreator<Dim>>& domain_creator) {
+    return domain_creator->initial_extents();
+  }
+};
+
+template <size_t Dim, SourceOrTarget WhichDomain>
+struct InitialRefinementLevels : db::SimpleTag {
+  using type = std::vector<std::array<size_t, Dim>>;
+  using option_tags = tmpl::list<OptionTags::DomainCreator<Dim, WhichDomain>>;
+  static constexpr bool pass_metavariables = false;
+  static std::vector<std::array<size_t, Dim>> create_from_options(
+      const std::unique_ptr<::DomainCreator<Dim>>& domain_creator) {
+    return domain_creator->initial_refinement_levels();
+  }
+};
+}  // namespace Tags
 
 /// [option_group]
-template <Grid TheGrid>
 struct VolumeDataOptions {
   using group = importers::OptionTags::Group;
-  static std::string name() { return MakeString{} << TheGrid << "VolumeData"; }
+  static std::string name() { return "VolumeData"; }
   static constexpr Options::String help = "Numeric volume data";
 };
 /// [option_group]
-
-template <size_t Dim, Grid TheGrid>
-struct TestVolumeData {
-  static constexpr size_t num_elements = number_of_elements<TheGrid>;
-  std::array<std::array<size_t, Dim>, num_elements> extents;
-  std::array<DataVector, num_elements> scalar_field_data;
-  std::array<std::array<DataVector, Dim>, num_elements> vector_field_data;
-};
-
-template <size_t Dim>
-const TestVolumeData<Dim, Grid::Fine> fine_volume_data{};
-template <>
-const TestVolumeData<1, Grid::Fine> fine_volume_data<1>{
-    {{// Grid extents on first element
-      {{2}},
-      // Grid extents on second element
-      {{3}}}},
-    {{// Field on first element
-      {{1., 2.}},
-      // Field on second element
-      {{3., 4., 5.}}}},
-    {{// Vector components on first element
-      {{{{1., 2.}}}},
-      // Vector components on second element
-      {{{{7., 8., 9.}}}}}}};
-template <>
-const TestVolumeData<2, Grid::Fine> fine_volume_data<2>{
-    {{{{2, 2}}, {{3, 2}}}},
-    {{{{1., 2., 3., 4.}}, {{3., 4., 5., 6., 7., 8.}}}},
-    {{{{{{1., 2., 3., 4.}}, {{3., 4., 5., 6.}}}},
-      {{{{7., 8., 9., 10., 11., 12.}}, {{10., 11., 12., 13., 14., 15.}}}}}}};
-template <>
-const TestVolumeData<3, Grid::Fine> fine_volume_data<3>{
-    {{{{2, 2, 2}}, {{3, 2, 2}}}},
-    {{{{1., 2., 3., 4., 5., 6., 7., 8.}},
-      {{3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14.}}}},
-    {{{{{{1., 2., 3., 4., 5., 6., 7., 8.}},
-        {{3., 4., 5., 6., 7., 8., 9., 10.}},
-        {{5., 6., 7., 8., 9., 10., 11., 12.}}}},
-      {{{{7., 8., 9., 10., 11., 12., 13., 14., 15., 16., 17., 18.}},
-        {{10., 11., 12., 13., 14., 15., 16., 17., 18., 19., 20., 21.}},
-        {{13., 14., 15., 16., 17., 18., 19., 20., 21., 22., 23., 24.}}}}}}};
-
-template <size_t Dim>
-const TestVolumeData<Dim, Grid::Coarse> coarse_volume_data{};
-template <>
-const TestVolumeData<1, Grid::Coarse> coarse_volume_data<1>{
-    {{{{2}}}}, {{{{17., 18.}}}}, {{{{{{19., 20.}}}}}}};
-template <>
-const TestVolumeData<2, Grid::Coarse> coarse_volume_data<2>{
-    {{{{2, 2}}}},
-    {{{{17., 18., 19., 20.}}}},
-    {{{{{{19., 20., 21., 22.}}, {{21., 22., 23., 24.}}}}}}};
-template <>
-const TestVolumeData<3, Grid::Coarse> coarse_volume_data<3>{
-    {{{{2, 2, 2}}}},
-    {{{{17., 18., 19., 20., 21., 22., 23., 24.}}}},
-    {{{{{{19., 20., 21., 22., 23., 24., 25., 26.}},
-        {{21., 22., 23., 24., 25., 26., 27., 28.}},
-        {{23., 24., 25., 26., 27., 28., 29., 30.}}}}}}};
 
 template <bool Check>
 void clean_test_data(const std::string& data_file_name) {
@@ -163,43 +191,84 @@ void clean_test_data(const std::string& data_file_name) {
   }
 }
 
-template <size_t Dim, Grid TheGrid>
-void write_test_data(const std::string& data_file_name,
-                     const std::string& subgroup,
-                     const double observation_value,
-                     const TestVolumeData<Dim, TheGrid>& test_data) {
+template <size_t Dim>
+DataVector gaussian(const tnsr::I<DataVector, Dim>& x) {
+  return exp(-get(dot_product(x, x)));
+}
+
+template <size_t Dim>
+tnsr::I<DataVector, Dim, Frame::Inertial> inertial_coordinates(
+    const ElementId<Dim>& element_id, const Mesh<Dim>& mesh,
+    const Block<Dim>& block, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) {
+  const auto logical_coords = logical_coordinates(mesh);
+  if (block.is_time_dependent()) {
+    const ElementMap<Dim, Frame::Grid> element_map{
+        element_id, block.moving_mesh_logical_to_grid_map().get_clone()};
+    const auto grid_coords = element_map(logical_coords);
+    const auto& grid_to_inertial_map = block.moving_mesh_grid_to_inertial_map();
+    return grid_to_inertial_map(grid_coords, time, functions_of_time);
+  } else {
+    const ElementMap<Dim, Frame::Inertial> element_map{
+        element_id, block.stationary_map().get_clone()};
+    return element_map(logical_coords);
+  }
+}
+
+template <size_t Dim>
+void write_test_data(
+    const std::string& data_file_name, const std::string& subgroup,
+    const double observation_value, const ::Domain<Dim>& domain,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
+    const std::vector<std::array<size_t, Dim>>& initial_refinement_levels,
+    const std::vector<std::array<size_t, Dim>>& initial_extents) {
   // Open file for test data
   h5::H5File<h5::AccessType::ReadWrite> data_file{data_file_name, true};
   auto& test_data_file = data_file.insert<h5::VolumeData>("/" + subgroup);
 
   // Construct test data for all elements
+  const auto element_ids = initial_element_ids(initial_refinement_levels);
   std::vector<ElementVolumeData> element_data{};
-  for (size_t i = 0; i < number_of_elements<TheGrid>; i++) {
-    const std::string element_name = MakeString{} << ElementId<Dim>{i};
+  for (const auto& element_id : element_ids) {
+    const auto mesh = domain::Initialization::create_initial_mesh(
+        initial_extents, element_id, Spectral::Quadrature::GaussLobatto);
+    const size_t num_points = mesh.number_of_grid_points();
+    const auto& block = domain.blocks()[element_id.block_id()];
+    const auto inertial_coords = inertial_coordinates(
+        element_id, mesh, block, observation_value, functions_of_time);
+
     std::vector<TensorComponent> tensor_components{};
-    std::vector<size_t> element_extents{};
-    std::vector<Spectral::Quadrature> element_quadratures{};
-    std::vector<Spectral::Basis> element_bases{};
-    tensor_components.push_back(
-        {"ScalarField", test_data.scalar_field_data[i]});
+    for (size_t d = 0; d < Dim; ++d) {
+      tensor_components.push_back(
+          {"InertialCoordinates" + inertial_coords.component_suffix(
+                                       inertial_coords.get_tensor_index(d)),
+           inertial_coords[d]});
+    }
+    tensor_components.push_back({"ScalarField", gaussian(inertial_coords)});
     for (size_t d = 0; d < Dim; d++) {
       static const std::array<std::string, 3> dim_suffix{{"x", "y", "z"}};
       tensor_components.push_back(
-          {"VectorField_" + dim_suffix[d], test_data.vector_field_data[i][d]});
-      element_extents.push_back(test_data.extents[i][d]);
-      element_quadratures.push_back(Spectral::Quadrature::Gauss);
-      element_bases.push_back(Spectral::Basis::Chebyshev);
+          {"VectorField_" + dim_suffix[d], DataVector(num_points, 0.)});
     }
-    element_data.push_back(
-        {element_name, std::move(tensor_components), std::move(element_extents),
-         std::move(element_bases), std::move(element_quadratures)});
+    element_data.push_back({element_id, std::move(tensor_components), mesh});
   }
   test_data_file.write_volume_data(0, observation_value,
-                                   std::move(element_data));
+                                   std::move(element_data), serialize(domain),
+                                   serialize(functions_of_time));
 }
 
 template <size_t Dim>
 struct WriteTestData {
+  using const_global_cache_tags =
+      tmpl::list<Tags::Domain<Dim, SourceOrTarget::Source>,
+                 Tags::FunctionsOfTime<Dim, SourceOrTarget::Source>,
+                 Tags::InitialRefinementLevels<Dim, SourceOrTarget::Source>,
+                 Tags::InitialExtents<Dim, SourceOrTarget::Source>>;
+
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>
@@ -209,23 +278,18 @@ struct WriteTestData {
       const Parallel::GlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
-    // The data may be in a shared file, so first clean both, then write both
     clean_test_data<false>(
-        get<importers::Tags::FileGlob<VolumeDataOptions<Grid::Fine>>>(box));
-    clean_test_data<false>(
-        get<importers::Tags::FileGlob<VolumeDataOptions<Grid::Coarse>>>(box));
+        get<importers::Tags::FileGlob<VolumeDataOptions>>(box));
     write_test_data<Dim>(
-        get<importers::Tags::FileGlob<VolumeDataOptions<Grid::Fine>>>(box),
-        get<importers::Tags::Subgroup<VolumeDataOptions<Grid::Fine>>>(box),
-        std::get<double>(get<importers::Tags::ObservationValue<
-                             VolumeDataOptions<Grid::Fine>>>(box)),
-        fine_volume_data<Dim>);
-    write_test_data<Dim>(
-        get<importers::Tags::FileGlob<VolumeDataOptions<Grid::Coarse>>>(box),
-        get<importers::Tags::Subgroup<VolumeDataOptions<Grid::Coarse>>>(box),
-        std::get<double>(get<importers::Tags::ObservationValue<
-                             VolumeDataOptions<Grid::Coarse>>>(box)),
-        coarse_volume_data<Dim>);
+        get<importers::Tags::FileGlob<VolumeDataOptions>>(box),
+        get<importers::Tags::Subgroup<VolumeDataOptions>>(box),
+        std::get<double>(
+            get<importers::Tags::ObservationValue<VolumeDataOptions>>(box)),
+        db::get<Tags::Domain<Dim, SourceOrTarget::Source>>(box),
+        db::get<Tags::FunctionsOfTime<Dim, SourceOrTarget::Source>>(box),
+        db::get<Tags::InitialRefinementLevels<Dim, SourceOrTarget::Source>>(
+            box),
+        db::get<Tags::InitialExtents<Dim, SourceOrTarget::Source>>(box));
     return {Parallel::AlgorithmExecution::Pause, std::nullopt};
   }
 };
@@ -241,12 +305,7 @@ struct CleanTestData {
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
     clean_test_data<true>(
-        get<importers::Tags::FileGlob<VolumeDataOptions<Grid::Fine>>>(box));
-    if (get<importers::Tags::FileGlob<VolumeDataOptions<Grid::Coarse>>>(box) !=
-        get<importers::Tags::FileGlob<VolumeDataOptions<Grid::Fine>>>(box)) {
-      clean_test_data<true>(
-          get<importers::Tags::FileGlob<VolumeDataOptions<Grid::Coarse>>>(box));
-    }
+        get<importers::Tags::FileGlob<VolumeDataOptions>>(box));
     return {Parallel::AlgorithmExecution::Pause, std::nullopt};
   }
 };
@@ -277,37 +336,42 @@ struct TestDataWriter {
 
 template <size_t Dim>
 struct InitializeElement {
-  using simple_tags = tmpl::list<ScalarFieldTag, VectorFieldTag<Dim>>;
+  using const_global_cache_tags =
+      tmpl::list<Tags::Domain<Dim, SourceOrTarget::Target>,
+                 Tags::FunctionsOfTime<Dim, SourceOrTarget::Target>,
+                 Tags::InitialRefinementLevels<Dim, SourceOrTarget::Target>,
+                 Tags::InitialExtents<Dim, SourceOrTarget::Target>>;
+  using simple_tags =
+      tmpl::list<domain::Tags::Coordinates<Dim, Frame::Inertial>,
+                 ScalarFieldTag, VectorFieldTag<Dim>>;
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ActionList, typename ParallelComponent>
   static Parallel::iterable_action_return_t apply(
-      db::DataBox<DbTagsList>& /*box*/,
+      db::DataBox<DbTagsList>& box,
       const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
       const Parallel::GlobalCache<Metavariables>& /*cache*/,
-      const ElementId<Dim>& /*array_index*/, const ActionList /*meta*/,
+      const ElementId<Dim>& element_id, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
-    return {Parallel::AlgorithmExecution::Pause, std::nullopt};
+    const auto& domain =
+        db::get<Tags::Domain<Dim, SourceOrTarget::Target>>(box);
+    const auto& functions_of_time =
+        db::get<Tags::FunctionsOfTime<Dim, SourceOrTarget::Target>>(box);
+    const double time = std::get<double>(
+        get<importers::Tags::ObservationValue<VolumeDataOptions>>(box));
+    const auto& initial_extents =
+        db::get<Tags::InitialExtents<Dim, SourceOrTarget::Target>>(box);
+    const auto mesh = domain::Initialization::create_initial_mesh(
+        initial_extents, element_id, Spectral::Quadrature::GaussLobatto);
+    const auto& block = domain.blocks()[element_id.block_id()];
+    Initialization::mutate_assign<
+        tmpl::list<domain::Tags::Coordinates<Dim, Frame::Inertial>>>(
+        make_not_null(&box),
+        inertial_coordinates(element_id, mesh, block, time, functions_of_time));
+    return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };
 
-template <size_t Dim, Grid TheGrid>
-void test_result(const ElementId<Dim>& element_index,
-                 const TestVolumeData<Dim, TheGrid>& test_data,
-                 const Scalar<DataVector>& scalar_field,
-                 const tnsr::I<DataVector, Dim>& vector_field) {
-  const size_t raw_element_index = ElementId<Dim>{element_index}.block_id();
-  Scalar<DataVector> expected_scalar_field{
-      test_data.scalar_field_data[raw_element_index]};
-  SPECTRE_PARALLEL_REQUIRE(scalar_field == expected_scalar_field);
-  tnsr::I<DataVector, Dim> expected_vector_field{};
-  for (size_t d = 0; d < Dim; d++) {
-    expected_vector_field[d] =
-        test_data.vector_field_data[raw_element_index][d];
-  }
-  SPECTRE_PARALLEL_REQUIRE(vector_field == expected_vector_field);
-}
-
-template <size_t Dim, Grid TheGrid>
+template <size_t Dim>
 struct TestResult {
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ActionList, typename ParallelComponent>
@@ -315,20 +379,19 @@ struct TestResult {
       db::DataBox<DbTagsList>& box,
       const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
       const Parallel::GlobalCache<Metavariables>& /*cache*/,
-      const ElementId<Dim>& array_index, const ActionList /*meta*/,
+      const ElementId<Dim>& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
-    if (TheGrid == Grid::Fine) {
-      test_result(array_index, fine_volume_data<Dim>, get<ScalarFieldTag>(box),
-                  get<VectorFieldTag<Dim>>(box));
-    } else {
-      test_result(array_index, coarse_volume_data<Dim>,
-                  get<ScalarFieldTag>(box), get<VectorFieldTag<Dim>>(box));
-    }
-    return {Parallel::AlgorithmExecution::Pause, std::nullopt};
+    const auto& inertial_coords =
+        get<domain::Tags::Coordinates<Dim, Frame::Inertial>>(box);
+    const auto& scalar_field = get<ScalarFieldTag>(box);
+    const auto expected_data = gaussian(inertial_coords);
+    SPECTRE_PARALLEL_REQUIRE(
+        equal_within_roundoff(get(scalar_field), expected_data, 1e-3));
+    return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };
 
-template <size_t Dim, Grid TheGrid, typename Metavariables>
+template <size_t Dim, typename Metavariables>
 struct ElementArray {
   using chare_type = Parallel::Algorithms::Array;
   using array_index = ElementId<Dim>;
@@ -339,35 +402,52 @@ struct ElementArray {
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization,
-                             tmpl::list<InitializeElement<Dim>>>,
+                             tmpl::list<InitializeElement<Dim>,
+                                        Parallel::Actions::TerminatePhase>>,
       /// [import_actions]
       Parallel::PhaseActions<
           Parallel::Phase::Register,
           tmpl::list<importers::Actions::RegisterWithElementDataReader,
                      Parallel::Actions::TerminatePhase>>,
-      Parallel::PhaseActions<
-          Parallel::Phase::ImportInitialData,
-          tmpl::list<importers::Actions::ReadVolumeData<
-                         VolumeDataOptions<TheGrid>, import_fields>,
-                     importers::Actions::ReceiveVolumeData<
-                         VolumeDataOptions<TheGrid>, import_fields>,
-                     Parallel::Actions::TerminatePhase>>,
+      Parallel::PhaseActions<Parallel::Phase::ImportInitialData,
+                             tmpl::list<importers::Actions::ReadVolumeData<
+                                            VolumeDataOptions, import_fields>,
+                                        importers::Actions::ReceiveVolumeData<
+                                            VolumeDataOptions, import_fields>,
+                                        Parallel::Actions::TerminatePhase>>,
       /// [import_actions]
-      Parallel::PhaseActions<Parallel::Phase::Testing,
-                             tmpl::list<TestResult<Dim, TheGrid>>>>;
+      Parallel::PhaseActions<
+          Parallel::Phase::Testing,
+          tmpl::list<TestResult<Dim>, Parallel::Actions::TerminatePhase>>>;
 
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
       const tuples::tagged_tuple_from_typelist<simple_tags_from_options>&
           initialization_items,
       const std::unordered_set<size_t>& procs_to_ignore = {}) {
-    auto& array_proxy = Parallel::get_parallel_component<ElementArray>(
-        *Parallel::local_branch(global_cache));
-
-    TestHelpers::Parallel::assign_array_elements_round_robin_style(
-        array_proxy, number_of_elements<TheGrid>,
-        static_cast<size_t>(sys::number_of_procs()), initialization_items,
-        global_cache, procs_to_ignore, ElementId<Dim>{});
+    auto& local_cache = *Parallel::local_branch(global_cache);
+    auto& element_array =
+        Parallel::get_parallel_component<ElementArray>(local_cache);
+    const auto& domain =
+        get<Tags::Domain<Dim, SourceOrTarget::Target>>(local_cache);
+    const auto& initial_refinement_levels =
+        get<Tags::InitialRefinementLevels<Dim, SourceOrTarget::Target>>(
+            local_cache);
+    const size_t num_procs = static_cast<size_t>(sys::number_of_procs());
+    size_t which_proc = 0;
+    for (const auto& block : domain.blocks()) {
+      const std::vector<ElementId<Dim>> element_ids = initial_element_ids(
+          block.id(), initial_refinement_levels[block.id()]);
+      for (const auto& element_id : element_ids) {
+        while (procs_to_ignore.find(which_proc) != procs_to_ignore.end()) {
+          which_proc = which_proc + 1 == num_procs ? 0 : which_proc + 1;
+        }
+        element_array(element_id)
+            .insert(global_cache, initialization_items, which_proc);
+        which_proc = which_proc + 1 == num_procs ? 0 : which_proc + 1;
+      }
+    }
+    element_array.doneInserting();
   }
 
   static void execute_next_phase(
@@ -383,10 +463,10 @@ struct ElementArray {
 template <size_t Dim>
 struct Metavariables {
   static constexpr size_t volume_dim = Dim;
+  struct system {};
 
   using component_list =
-      tmpl::list<ElementArray<Dim, Grid::Fine, Metavariables>,
-                 ElementArray<Dim, Grid::Coarse, Metavariables>,
+      tmpl::list<ElementArray<Dim, Metavariables>,
                  TestDataWriter<Dim, Metavariables>,
                  importers::ElementDataReader<Metavariables>>;
 
@@ -398,12 +478,23 @@ struct Metavariables {
        Parallel::Phase::ImportInitialData, Parallel::Phase::Testing,
        Parallel::Phase::Exit}};
 
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes =
+        tmpl::map<tmpl::pair<DomainCreator<Dim>, domain_creators<Dim>>>;
+  };
+
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/) {}
 };
 /// [metavars]
 
 static const std::vector<void (*)()> charm_init_node_funcs{
-    &setup_error_handling, &setup_memory_allocation_failure_reporting};
+    &setup_error_handling,
+    &setup_memory_allocation_failure_reporting,
+    &domain::creators::register_derived_with_charm,
+    &domain::creators::time_dependence::register_derived_with_charm,
+    &domain::FunctionsOfTime::register_derived_with_charm,
+    &Parallel::register_factory_classes_with_charm<metavariables>};
 static const std::vector<void (*)()> charm_init_proc_funcs{
     &enable_floating_point_exceptions};

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm1D.yaml
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm1D.yaml
@@ -1,15 +1,34 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+SourceDomainCreator:
+  Interval:
+    LowerBound: [0]
+    UpperBound: [4]
+    IsPeriodicIn: [False]
+    InitialRefinement: [2]
+    InitialGridPoints: [8]
+    TimeDependence:
+      None
+
+TargetDomainCreator:
+  Interval:
+    LowerBound: [-1]
+    UpperBound: [3]
+    IsPeriodicIn: [False]
+    InitialRefinement: [1]
+    InitialGridPoints: [6]
+    TimeDependence:
+      UniformTranslation:
+        InitialTime: 0.
+        Velocity: [1.]
+
 Importers:
-  FineVolumeData:
-    FileGlob: "Test_DataImporterAlgorithm1D_fine_data.h5"
-    Subgroup: "test_data"
-    ObservationValue: 3.
-  CoarseVolumeData:
-    FileGlob: "Test_DataImporterAlgorithm1D_coarse_data.h5"
-    Subgroup: "test_data"
-    ObservationValue: 2.
+  VolumeData:
+    FileGlob: "Test_DataImporterAlgorithm1D.h5"
+    Subgroup: "TestData"
+    ObservationValue: 1.
+    Interpolate: True
 
 ResourceInfo:
   AvoidGlobalProc0: false

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm2D.yaml
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm2D.yaml
@@ -1,16 +1,24 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+SourceDomainCreator: &source_domain
+  Disk:
+    InnerRadius: 1.
+    OuterRadius: 3.
+    InitialRefinement: 1
+    InitialGridPoints: [3, 3]
+    UseEquiangularMap: True
+
+# Load data directly onto the same domain without interpolation
+TargetDomainCreator: *source_domain
+
 # [importer_options]
 Importers:
-  FineVolumeData:
-    FileGlob: "Test_DataImporterAlgorithm2D_shared.h5"
-    Subgroup: "fine_data"
-    ObservationValue: 3.
-  CoarseVolumeData:
-    FileGlob: "Test_DataImporterAlgorithm2D_shared.h5"
-    Subgroup: "coarse_data"
+  VolumeData:
+    FileGlob: "Test_DataImporterAlgorithm2D.h5"
+    Subgroup: "TestData"
     ObservationValue: 2.
+    Interpolate: False
 # [importer_options]
 
 ResourceInfo:

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm3D.yaml
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm3D.yaml
@@ -1,15 +1,62 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+SourceDomainCreator:
+  BinaryCompactObject:
+    ObjectA:
+      InnerRadius: 0.45
+      OuterRadius: 4.
+      XCoord: &x_right 7.683
+      ExciseInterior: True
+      UseLogarithmicMap: True
+    ObjectB:
+      InnerRadius: 0.45
+      OuterRadius: 4.
+      XCoord: &x_left -7.683
+      ExciseInterior: True
+      UseLogarithmicMap: True
+    EnvelopingCube:
+      Radius: 60.
+      UseProjectiveMap: True
+      Sphericity: 1.
+    OuterShell:
+      InnerRadius: Auto
+      OuterRadius: 350.
+      RadialDistribution: Inverse
+    InitialRefinement: 1
+    InitialGridPoints: 7
+
+TargetDomainCreator:
+  BinaryCompactObject:
+    ObjectA:
+      InnerRadius: 0.46
+      OuterRadius: 6.
+      XCoord: *x_right
+      ExciseInterior: True
+      UseLogarithmicMap: true
+    ObjectB:
+      InnerRadius: 0.46
+      OuterRadius: 6.
+      XCoord: *x_left
+      ExciseInterior: True
+      UseLogarithmicMap: true
+    EnvelopingCube:
+      Radius: 100.
+      UseProjectiveMap: true
+      Sphericity: 1.
+    OuterShell:
+      InnerRadius: Auto
+      OuterRadius: 300.
+      RadialDistribution: Linear
+    InitialRefinement: 0
+    InitialGridPoints: 3
+
 Importers:
-  FineVolumeData:
-    FileGlob: "Test_DataImporterAlgorithm3D_shared.h5"
-    Subgroup: "fine_data"
+  VolumeData:
+    FileGlob: "Test_DataImporterAlgorithm3D.h5"
+    Subgroup: "TestData"
     ObservationValue: 3.
-  CoarseVolumeData:
-    FileGlob: "Test_DataImporterAlgorithm3D_shared.h5"
-    Subgroup: "coarse_data"
-    ObservationValue: 2.
+    Interpolate: True
 
 ResourceInfo:
   AvoidGlobalProc0: false


### PR DESCRIPTION
## Proposed changes

Add interpolation capabilities to the numeric data importer. The main use case at the moment is regridding from the initial data domain to the evolution domain.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
If you have an `Importers:` section in your input file, add `Interpolate: False` to it to keep the current behavior of just loading data directly to the grid points. Set `Interpolate: True` to interpolate the data to your domain.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
