### PR TITLE
Gauge observer tags

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
@@ -53,6 +53,7 @@ target_link_libraries(
   Spectral
   Utilities
   INTERFACE
+  Events # For observer tags
   Initialization
   Parallel
   )

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/CMakeLists.txt
@@ -8,6 +8,7 @@ spectre_target_sources(
   DampedHarmonic.cpp
   DampedWaveHelpers.cpp
   DhGaugeParameters.cpp
+  Dispatch.cpp
   Gauges.cpp
   HalfPiPhiTwoNormals.cpp
   Harmonic.cpp
@@ -23,6 +24,7 @@ spectre_target_headers(
   DampedHarmonic.hpp
   DampedWaveHelpers.hpp
   DhGaugeParameters.hpp
+  Dispatch.hpp
   Factory.hpp
   Gauges.hpp
   HalfPiPhiTwoNormals.hpp

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Dispatch.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Dispatch.cpp
@@ -1,0 +1,88 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Dispatch.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/AnalyticChristoffel.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Gauges.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Harmonic.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace GeneralizedHarmonic::gauges {
+template <size_t Dim>
+void dispatch(
+    const gsl::not_null<tnsr::a<DataVector, Dim, Frame::Inertial>*> gauge_h,
+    const gsl::not_null<tnsr::ab<DataVector, Dim, Frame::Inertial>*> d4_gauge_h,
+    const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& shift,
+    const tnsr::a<DataVector, Dim, Frame::Inertial>&
+        spacetime_unit_normal_one_form,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const tnsr::II<DataVector, Dim, Frame::Inertial>& inverse_spatial_metric,
+    const tnsr::aa<DataVector, Dim, Frame::Inertial>& spacetime_metric,
+    const tnsr::aa<DataVector, Dim, Frame::Inertial>& pi,
+    const tnsr::iaa<DataVector, Dim, Frame::Inertial>& phi,
+    const Mesh<Dim>& mesh, double time,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords,
+    const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                          Frame::Inertial>& inverse_jacobian,
+    const GaugeCondition& gauge_condition) {
+  if (const auto* harmonic_gauge =
+          dynamic_cast<const Harmonic*>(&gauge_condition);
+      harmonic_gauge != nullptr) {
+    harmonic_gauge->gauge_and_spacetime_derivative(gauge_h, d4_gauge_h, time,
+                                                   inertial_coords);
+  } else if (const auto* damped_harmonic_gauge =
+                 dynamic_cast<const DampedHarmonic*>(&gauge_condition);
+             damped_harmonic_gauge != nullptr) {
+    damped_harmonic_gauge->gauge_and_spacetime_derivative(
+        gauge_h, d4_gauge_h, lapse, shift, spacetime_unit_normal_one_form,
+        sqrt_det_spatial_metric, inverse_spatial_metric, spacetime_metric, pi,
+        phi, time, inertial_coords);
+  } else if (const auto* analytic_gauge =
+                 dynamic_cast<const AnalyticChristoffel*>(&gauge_condition);
+             analytic_gauge != nullptr) {
+    analytic_gauge->gauge_and_spacetime_derivative(
+        gauge_h, d4_gauge_h, mesh, time, inertial_coords, inverse_jacobian);
+  } else {
+    ERROR(
+        "Failed to dispatch to Harmonic, DampedHarmonic, or Analytic gauge "
+        "condition.");
+  }
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                   \
+  template void dispatch(                                                      \
+      gsl::not_null<tnsr::a<DataVector, DIM(data), Frame::Inertial>*> gauge_h, \
+      gsl::not_null<tnsr::ab<DataVector, DIM(data), Frame::Inertial>*>         \
+          d4_gauge_h,                                                          \
+      const Scalar<DataVector>& lapse,                                         \
+      const tnsr::I<DataVector, DIM(data), Frame::Inertial>& shift,            \
+      const tnsr::a<DataVector, DIM(data), Frame::Inertial>&                   \
+          spacetime_unit_normal_one_form,                                      \
+      const Scalar<DataVector>& sqrt_det_spatial_metric,                       \
+      const tnsr::II<DataVector, DIM(data), Frame::Inertial>&                  \
+          inverse_spatial_metric,                                              \
+      const tnsr::aa<DataVector, DIM(data), Frame::Inertial>&                  \
+          spacetime_metric,                                                    \
+      const tnsr::aa<DataVector, DIM(data), Frame::Inertial>& pi,              \
+      const tnsr::iaa<DataVector, DIM(data), Frame::Inertial>& phi,            \
+      const Mesh<DIM(data)>& mesh, double time,                                \
+      const tnsr::I<DataVector, DIM(data), Frame::Inertial>& inertial_coords,  \
+      const InverseJacobian<DataVector, DIM(data), Frame::ElementLogical,      \
+                            Frame::Inertial>& inverse_jacobian,                \
+      const GaugeCondition& gauge_condition);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATE
+#undef DIM
+}  // namespace GeneralizedHarmonic::gauges

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Dispatch.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Dispatch.hpp
@@ -1,0 +1,42 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Gauges.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+class DataVector;
+template <size_t Dim>
+class Mesh;
+/// \endcond
+
+namespace GeneralizedHarmonic::gauges {
+/*!
+ * \brief Dispatch to the derived gauge condition.
+ *
+ * Which of the arguments to this function are used will depend on the gauge
+ * condition, but since that is a runtime choice we need support for all gauge
+ * conditions.
+ */
+template <size_t Dim>
+void dispatch(
+    gsl::not_null<tnsr::a<DataVector, Dim, Frame::Inertial>*> gauge_h,
+    gsl::not_null<tnsr::ab<DataVector, Dim, Frame::Inertial>*> d4_gauge_h,
+    const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& shift,
+    const tnsr::a<DataVector, Dim, Frame::Inertial>&
+        spacetime_unit_normal_one_form,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const tnsr::II<DataVector, Dim, Frame::Inertial>& inverse_spatial_metric,
+    const tnsr::aa<DataVector, Dim, Frame::Inertial>& spacetime_metric,
+    const tnsr::aa<DataVector, Dim, Frame::Inertial>& pi,
+    const tnsr::iaa<DataVector, Dim, Frame::Inertial>& phi,
+    const Mesh<Dim>& mesh, double time,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords,
+    const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                          Frame::Inertial>& inverse_jacobian,
+    const GaugeCondition& gauge_condition);
+}  // namespace GeneralizedHarmonic::gauges

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Tags/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Tags/CMakeLists.txt
@@ -1,6 +1,12 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  GaugeCondition.cpp
+  )
+
 spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Tags/GaugeCondition.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Tags/GaugeCondition.cpp
@@ -1,0 +1,60 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Tags/GaugeCondition.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Dispatch.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Gauges.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace GeneralizedHarmonic::gauges::Tags {
+template <size_t Dim>
+void GaugeAndDerivativeCompute<Dim>::function(
+    const gsl::not_null<return_type*> gauge_and_deriv,
+    const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& shift,
+    const tnsr::a<DataVector, Dim, Frame::Inertial>&
+        spacetime_unit_normal_one_form,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const tnsr::II<DataVector, Dim, Frame::Inertial>& inverse_spatial_metric,
+    const tnsr::aa<DataVector, Dim, Frame::Inertial>& spacetime_metric,
+    const tnsr::aa<DataVector, Dim, Frame::Inertial>& pi,
+    const tnsr::iaa<DataVector, Dim, Frame::Inertial>& phi,
+    const Mesh<Dim>& mesh, const double time,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords,
+    const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                          Frame::Inertial>& inverse_jacobian,
+    const gauges::GaugeCondition& gauge_condition) {
+  if (const size_t num_points = mesh.number_of_grid_points();
+      UNLIKELY(gauge_and_deriv->number_of_grid_points() != num_points)) {
+    gauge_and_deriv->initialize(num_points);
+  }
+  dispatch(make_not_null(
+               &get<::GeneralizedHarmonic::Tags::GaugeH<Dim, Frame::Inertial>>(
+                   *gauge_and_deriv)),
+           make_not_null(&get<::GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<
+                             Dim, Frame::Inertial>>(*gauge_and_deriv)),
+           lapse, shift, spacetime_unit_normal_one_form,
+           sqrt_det_spatial_metric, inverse_spatial_metric, spacetime_metric,
+           pi, phi, mesh, time, inertial_coords, inverse_jacobian,
+           gauge_condition);
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data) \
+  template class GaugeAndDerivativeCompute<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+#undef DIM
+}  // namespace GeneralizedHarmonic::gauges::Tags

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_AnalyticChristoffel.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_AnalyticChristoffel.cpp
@@ -16,6 +16,7 @@
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/AnalyticChristoffel.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Dispatch.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Gauges.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/RegisterDerived.hpp"
 #include "Framework/TestCreation.hpp"
@@ -100,11 +101,12 @@ void test_gauge_wave(const Mesh<Dim>& mesh) {
 
   tnsr::a<DataVector, Dim, Frame::Inertial> gauge_h(num_points);
   tnsr::ab<DataVector, Dim, Frame::Inertial> d4_gauge_h(num_points);
-  dynamic_cast<const GeneralizedHarmonic::gauges::AnalyticChristoffel&>(
-      *gauge_condition)
-      .gauge_and_spacetime_derivative(make_not_null(&gauge_h),
-                                      make_not_null(&d4_gauge_h), mesh, time,
-                                      inertial_coords, inverse_jacobian);
+  // Used dispatch with defaulted arguments that we don't need for Analytic
+  // gauge.
+  GeneralizedHarmonic::gauges::dispatch(
+      make_not_null(&gauge_h), make_not_null(&d4_gauge_h), {}, {}, {}, {}, {},
+      {}, {}, {}, mesh, time, inertial_coords, inverse_jacobian,
+      *gauge_condition);
 
   CHECK_ITERABLE_APPROX(
       gauge_h, (tnsr::a<DataVector, Dim, Frame::Inertial>(num_points, 0.0)));
@@ -135,11 +137,12 @@ void test_ks(const Mesh<3>& mesh) {
 
   tnsr::a<DataVector, 3, Frame::Inertial> gauge_h(num_points);
   tnsr::ab<DataVector, 3, Frame::Inertial> d4_gauge_h(num_points);
-  dynamic_cast<const GeneralizedHarmonic::gauges::AnalyticChristoffel&>(
-      *gauge_condition)
-      .gauge_and_spacetime_derivative(make_not_null(&gauge_h),
-                                      make_not_null(&d4_gauge_h), mesh, time,
-                                      inertial_coords, inverse_jacobian);
+  // Used dispatch with defaulted arguments that we don't need for Analytic
+  // gauge.
+  GeneralizedHarmonic::gauges::dispatch(
+      make_not_null(&gauge_h), make_not_null(&d4_gauge_h), {}, {}, {}, {}, {},
+      {}, {}, {}, mesh, time, inertial_coords, inverse_jacobian,
+      *gauge_condition);
 
   const GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::KerrSchild>
       kerr_schild{1.2, {0.1, 0.2, 0.3}, {-0.1, -0.2, -0.4}};

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonic.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonic.cpp
@@ -17,6 +17,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedWaveHelpers.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Dispatch.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Gauges.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/RegisterDerived.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
@@ -239,6 +240,14 @@ void test_derived_class(const Mesh<Dim>& mesh) {
           spacetime_normal_one_form, sqrt_det_spatial_metric,
           inverse_spatial_metric, spacetime_metric, pi, phi, time,
           inertial_coords);
+
+  // Used dispatch with defaulted arguments that we don't need for Analytic
+  // gauge.
+  GeneralizedHarmonic::gauges::dispatch(
+      make_not_null(&gauge_h), make_not_null(&d4_gauge_h), lapse, shift,
+      spacetime_normal_one_form, sqrt_det_spatial_metric,
+      inverse_spatial_metric, spacetime_metric, pi, phi, mesh, time,
+      inertial_coords, {}, *gauge_condition);
 
   tnsr::a<DataVector, Dim, Frame::Inertial> expected_gauge_h(num_points);
   tnsr::ab<DataVector, Dim, Frame::Inertial> expected_d4_gauge_h(num_points);

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_Harmonic.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_Harmonic.cpp
@@ -9,11 +9,13 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Dispatch.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Gauges.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Harmonic.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/RegisterDerived.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
@@ -42,10 +44,12 @@ void test() {
 
   const double time = std::numeric_limits<double>::signaling_NaN();
   const tnsr::I<DataVector, Dim, Frame::Inertial> inertial_coords(num_points);
-  dynamic_cast<const GeneralizedHarmonic::gauges::Harmonic&>(*gauge_condition)
-      .gauge_and_spacetime_derivative(make_not_null(&gauge_h),
-                                      make_not_null(&d4_gauge_h), time,
-                                      inertial_coords);
+
+  // Used dispatch with defaulted arguments that we don't need for Harmonic
+  // gauge.
+  GeneralizedHarmonic::gauges::dispatch(
+      make_not_null(&gauge_h), make_not_null(&d4_gauge_h), {}, {}, {}, {}, {},
+      {}, {}, {}, Mesh<Dim>{}, time, inertial_coords, {}, *gauge_condition);
   CHECK(gauge_h == tnsr::a<DataVector, Dim, Frame::Inertial>(num_points, 0.0));
   CHECK(d4_gauge_h ==
         tnsr::ab<DataVector, Dim, Frame::Inertial>(num_points, 0.0));

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_Tags.cpp
@@ -3,11 +3,77 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <cstddef>
+#include <memory>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Gauges.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Harmonic.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Tags/GaugeCondition.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "ParallelAlgorithms/Events/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/Tags.hpp"
+
+namespace {
+template <size_t Dim>
+void test() {
+  TestHelpers::db::test_compute_tag<
+      GeneralizedHarmonic::gauges::Tags::GaugeAndDerivativeCompute<Dim>>(
+      "Variables(GaugeH,SpacetimeDerivGaugeH)");
+
+  // Use Harmonic gauge since then we don't need to set any values and we can
+  // still check that the compute tag works correctly.
+
+  auto box = db::create<
+      db::AddSimpleTags<
+          gr::Tags::Lapse<>, gr::Tags::Shift<Dim>,
+          gr::Tags::SpacetimeNormalOneForm<Dim>,
+          gr::Tags::SqrtDetSpatialMetric<>, gr::Tags::InverseSpatialMetric<Dim>,
+          gr::Tags::SpacetimeMetric<Dim>, GeneralizedHarmonic::Tags::Pi<Dim>,
+          GeneralizedHarmonic::Tags::Phi<Dim>,
+          ::Events::Tags::ObserverMesh<Dim>, ::Tags::Time,
+          ::Events::Tags::ObserverCoordinates<Dim, Frame::Inertial>,
+          domain::Tags::InverseJacobian<Dim, Frame::ElementLogical,
+                                        Frame::Inertial>,
+          GeneralizedHarmonic::gauges::Tags::GaugeCondition>,
+      db::AddComputeTags<
+          GeneralizedHarmonic::gauges::Tags::GaugeAndDerivativeCompute<Dim>>>(
+      Scalar<DataVector>{}, tnsr::I<DataVector, Dim, Frame::Inertial>{},
+      tnsr::a<DataVector, Dim, Frame::Inertial>{}, Scalar<DataVector>{},
+      tnsr::II<DataVector, Dim, Frame::Inertial>{},
+      tnsr::aa<DataVector, Dim, Frame::Inertial>{},
+      tnsr::aa<DataVector, Dim, Frame::Inertial>{},
+      tnsr::iaa<DataVector, Dim, Frame::Inertial>{},
+      Mesh<Dim>{5, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, 1.3,
+      tnsr::I<DataVector, Dim, Frame::Inertial>{},
+      InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                      Frame::Inertial>{},
+      std::unique_ptr<GeneralizedHarmonic::gauges::GaugeCondition>{
+          std::make_unique<GeneralizedHarmonic::gauges::Harmonic>()});
+
+  const size_t num_points =
+      db::get<::Events::Tags::ObserverMesh<Dim>>(box).number_of_grid_points();
+
+  CHECK(db::get<GeneralizedHarmonic::Tags::GaugeH<Dim, Frame::Inertial>>(box) ==
+        tnsr::a<DataVector, Dim, Frame::Inertial>(num_points, 0.0));
+  CHECK(db::get<GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<
+            Dim, Frame::Inertial>>(box) ==
+        tnsr::ab<DataVector, Dim, Frame::Inertial>(num_points, 0.0));
+}
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.Gauge.Tags",
                   "[Evolution][Unit]") {
   TestHelpers::db::test_simple_tag<
       GeneralizedHarmonic::gauges::Tags::GaugeCondition>("GaugeCondition");
+
+  test<1>();
+  test<2>();
+  test<3>();
 }


### PR DESCRIPTION
## Proposed changes

Only `Add observer tags for computing H_a and d_b H_a` is new

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
