### PR TITLE
Add SetPiFromGauge mutator to GH system

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/CMakeLists.txt
@@ -14,6 +14,7 @@ spectre_target_sources(
   Harmonic.cpp
   InitializeDampedHarmonic.cpp
   RegisterDerived.cpp
+  SetPiFromGauge.cpp
   )
 
 spectre_target_headers(
@@ -31,6 +32,7 @@ spectre_target_headers(
   Harmonic.hpp
   InitializeDampedHarmonic.hpp
   RegisterDerived.hpp
+  SetPiFromGauge.hpp
   )
 
 add_subdirectory(Tags)

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/SetPiFromGauge.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/SetPiFromGauge.cpp
@@ -1,0 +1,172 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/SetPiFromGauge.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Dispatch.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Gauges.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/DerivSpatialMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ExtrinsicCurvature.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/GaugeSource.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Pi.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpacetimeDerivativeOfSpacetimeMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfLapse.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfShift.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfSpatialMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivativeOfSpacetimeMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/InverseSpacetimeMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Lapse.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Shift.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalOneForm.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace GeneralizedHarmonic::gauges {
+template <size_t Dim>
+void SetPiFromGauge<Dim>::apply(
+    const gsl::not_null<tnsr::aa<DataVector, Dim, Frame::Inertial>*> pi,
+    const double time, const Mesh<Dim>& mesh,
+    const ElementMap<Dim, Frame::Grid>& logical_to_grid_map,
+    const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, Dim>&
+        grid_to_inertial_map,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
+    const tnsr::I<DataVector, Dim, Frame::ElementLogical>& logical_coordinates,
+    const tnsr::aa<DataVector, Dim, Frame::Inertial>& spacetime_metric,
+    const tnsr::iaa<DataVector, Dim, Frame::Inertial>& phi,
+    const gauges::GaugeCondition& gauge_condition) {
+  const auto grid_coords = logical_to_grid_map(logical_coordinates);
+  const auto inv_jac_logical_to_grid =
+      logical_to_grid_map.inv_jacobian(logical_coordinates);
+  const auto [inertial_coords, inv_jac_grid_to_inertial, jac_grid_to_inertial,
+              mesh_velocity] =
+      grid_to_inertial_map.coords_frame_velocity_jacobians(grid_coords, time,
+                                                           functions_of_time);
+
+  InverseJacobian<DataVector, Dim, Frame::ElementLogical, Frame::Inertial>
+      inverse_jacobian{};
+
+  for (size_t logical_i = 0; logical_i < Dim; ++logical_i) {
+    for (size_t inertial_i = 0; inertial_i < Dim; ++inertial_i) {
+      inverse_jacobian.get(logical_i, inertial_i) =
+          inv_jac_logical_to_grid.get(logical_i, 0) *
+          inv_jac_grid_to_inertial.get(0, inertial_i);
+      for (size_t grid_i = 1; grid_i < Dim; ++grid_i) {
+        inverse_jacobian.get(logical_i, inertial_i) +=
+            inv_jac_logical_to_grid.get(logical_i, grid_i) *
+            inv_jac_grid_to_inertial.get(grid_i, inertial_i);
+      }
+    }
+  }
+
+  Variables<tmpl::list<
+      gr::Tags::SpatialMetric<Dim>, gr::Tags::SqrtDetSpatialMetric<>,
+      gr::Tags::InverseSpatialMetric<Dim>, gr::Tags::Lapse<>,
+      gr::Tags::Shift<Dim>, gr::Tags::InverseSpacetimeMetric<Dim>,
+      gr::Tags::SpacetimeNormalOneForm<Dim>,
+      gr::Tags::SpacetimeNormalVector<Dim>,
+      ::Tags::deriv<gr::Tags::Lapse<>, tmpl::size_t<Dim>, Frame::Inertial>,
+      ::Tags::deriv<gr::Tags::Shift<Dim>, tmpl::size_t<Dim>, Frame::Inertial>,
+      ::Tags::deriv<gr::Tags::SpatialMetric<Dim>, tmpl::size_t<Dim>,
+                    Frame::Inertial>,
+      gr::Tags::ExtrinsicCurvature<Dim>, gr::Tags::TraceExtrinsicCurvature<>,
+      gr::Tags::SpatialChristoffelFirstKind<Dim>,
+      gr::Tags::TraceSpatialChristoffelFirstKind<Dim>,
+      GeneralizedHarmonic::Tags::GaugeH<Dim>,
+      GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<Dim>,
+      ::Tags::dt<gr::Tags::Lapse<>>, ::Tags::dt<gr::Tags::Shift<Dim>>,
+      ::Tags::dt<gr::Tags::SpatialMetric<Dim>>>>
+      buffer(get<0, 0>(spacetime_metric).size());
+
+  auto& [spatial_metric, sqrt_det_spatial_metric, inverse_spatial_metric, lapse,
+         shift, inverse_spacetime_metric, spacetime_unit_normal_one_form,
+         spacetime_unit_normal_vector, d_lapse, d_shift, d_spatial_metric,
+         ex_curvature, trace_ex_curvature, spatial_christoffel_first,
+         trace_spatial_christoffel_first, gauge_h, d4_gauge_h, dt_lapse,
+         dt_shift, dt_spatial_metric] = buffer;
+
+  gr::spatial_metric(make_not_null(&spatial_metric), spacetime_metric);
+  determinant_and_inverse(make_not_null(&sqrt_det_spatial_metric),
+                          make_not_null(&inverse_spatial_metric),
+                          spatial_metric);
+  get(sqrt_det_spatial_metric) = sqrt(get(sqrt_det_spatial_metric));
+  gr::shift(make_not_null(&shift), spacetime_metric, inverse_spatial_metric);
+  gr::lapse(make_not_null(&lapse), shift, spacetime_metric);
+  gr::inverse_spacetime_metric(make_not_null(&inverse_spacetime_metric), lapse,
+                               shift, inverse_spatial_metric);
+  gr::spacetime_normal_one_form<Dim, Frame::Inertial>(
+      make_not_null(&spacetime_unit_normal_one_form), lapse);
+  gr::spacetime_normal_vector(make_not_null(&spacetime_unit_normal_vector),
+                              lapse, shift);
+
+  spatial_deriv_of_lapse(make_not_null(&d_lapse), lapse,
+                         spacetime_unit_normal_vector, phi);
+  spatial_deriv_of_shift(make_not_null(&d_shift), lapse,
+                         inverse_spacetime_metric, spacetime_unit_normal_vector,
+                         phi);
+  deriv_spatial_metric(make_not_null(&d_spatial_metric), phi);
+
+  extrinsic_curvature(make_not_null(&ex_curvature),
+                      spacetime_unit_normal_vector, *pi, phi);
+  trace(make_not_null(&trace_ex_curvature), ex_curvature,
+        inverse_spatial_metric);
+  gr::christoffel_first_kind(make_not_null(&spatial_christoffel_first),
+                             d_spatial_metric);
+  trace_last_indices(make_not_null(&trace_spatial_christoffel_first),
+                     spatial_christoffel_first, inverse_spatial_metric);
+
+  // Note: we pass in pi to compute d4_gauge_h, but we don't use d4_gauge_h. We
+  // actually reset pi from gauge_h below.
+  dispatch(make_not_null(&gauge_h), make_not_null(&d4_gauge_h), lapse, shift,
+           spacetime_unit_normal_one_form, sqrt_det_spatial_metric,
+           inverse_spatial_metric, spacetime_metric, *pi, phi, mesh, time,
+           inertial_coords, inverse_jacobian, gauge_condition);
+
+  // Compute lapse and shift time derivatives
+  get(dt_lapse) =
+      -get(lapse) * (get<0>(gauge_h) + get(lapse) * get(trace_ex_curvature));
+  for (size_t i = 0; i < Dim; ++i) {
+    get(dt_lapse) +=
+        shift.get(i) * (d_lapse.get(i) + get(lapse) * gauge_h.get(i + 1));
+  }
+
+  for (size_t i = 0; i < Dim; ++i) {
+    dt_shift.get(i) = get<0>(shift) * d_shift.get(0, i);
+    for (size_t k = 1; k < Dim; ++k) {
+      dt_shift.get(i) += shift.get(k) * d_shift.get(k, i);
+    }
+    for (size_t j = 0; j < Dim; ++j) {
+      dt_shift.get(i) +=
+          get(lapse) * inverse_spatial_metric.get(i, j) *
+          (get(lapse) *
+               (gauge_h.get(j + 1) + trace_spatial_christoffel_first.get(j)) -
+           d_lapse.get(j));
+    }
+  }
+
+  time_deriv_of_spatial_metric(make_not_null(&dt_spatial_metric), lapse, shift,
+                               phi, *pi);
+  GeneralizedHarmonic::pi(pi, lapse, dt_lapse, shift, dt_shift, spatial_metric,
+                          dt_spatial_metric, phi);
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data) template class SetPiFromGauge<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATE
+#undef DIM
+}  // namespace GeneralizedHarmonic::gauges

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/SetPiFromGauge.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/SetPiFromGauge.hpp
@@ -1,0 +1,69 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <random>
+#include <string>
+#include <unordered_map>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/TagsTimeDependent.hpp"
+#include "Evolution/Initialization/Tags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Tags/GaugeCondition.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace GeneralizedHarmonic::gauges {
+/*!
+ * \brief Set \f$\Pi_{ab}\f$ from the gauge source function.
+ *
+ * This is necessary to ensure the initial data is in the desired evolution
+ * gauge.
+ */
+template <size_t Dim>
+struct SetPiFromGauge {
+ public:
+  using return_tags =
+      tmpl::list<GeneralizedHarmonic::Tags::Pi<Dim, Frame::Inertial>>;
+  using argument_tags =
+      tmpl::list<::Tags::Time, domain::Tags::Mesh<Dim>,
+                 domain::Tags::ElementMap<Dim, Frame::Grid>,
+                 domain::CoordinateMaps::Tags::CoordinateMap<Dim, Frame::Grid,
+                                                             Frame::Inertial>,
+                 domain::Tags::FunctionsOfTime,
+                 domain::Tags::Coordinates<Dim, Frame::ElementLogical>,
+                 gr::Tags::SpacetimeMetric<Dim, Frame::Inertial, DataVector>,
+                 GeneralizedHarmonic::Tags::Phi<Dim, Frame::Inertial>,
+                 GeneralizedHarmonic::gauges::Tags::GaugeCondition>;
+
+  using const_global_cache_tags =
+      tmpl::list<GeneralizedHarmonic::gauges::Tags::GaugeCondition>;
+
+  static void apply(
+      gsl::not_null<tnsr::aa<DataVector, Dim, Frame::Inertial>*> pi,
+      double time, const Mesh<Dim>& mesh,
+      const ElementMap<Dim, Frame::Grid>& logical_to_grid_map,
+      const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, Dim>&
+          grid_to_inertial_map,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time,
+      const tnsr::I<DataVector, Dim, Frame::ElementLogical>&
+          logical_coordinates,
+      const tnsr::aa<DataVector, Dim, Frame::Inertial>& spacetime_metric,
+      const tnsr::iaa<DataVector, Dim, Frame::Inertial>& phi,
+      const gauges::GaugeCondition& gauge_condition);
+};
+}  // namespace GeneralizedHarmonic::gauges

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBRARY_SOURCES
   Test_HalfPiPhiTwoNormals.cpp
   Test_Harmonic.cpp
   Test_InitializeDampedHarmonic.cpp
+  Test_SetPiFromGauge.cpp
   Test_Tags.cpp
   )
 

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_SetPiFromGauge.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_SetPiFromGauge.cpp
@@ -1,0 +1,165 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <random>
+#include <string>
+#include <unordered_map>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/Tags.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Initialization/Tags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Constraints.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Dispatch.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Gauges.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/SetPiFromGauge.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Tags/GaugeCondition.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/GeneralRelativity/InverseSpacetimeMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Lapse.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Shift.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalOneForm.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+template <size_t Dim>
+void test(const gsl::not_null<std::mt19937*> generator) {
+  CAPTURE(Dim);
+  std::uniform_real_distribution<> metric_dist(0.1, 1.);
+  std::uniform_real_distribution<> deriv_dist(-1.e-5, 1.e-5);
+
+  using evolved_vars_tags =
+      tmpl::list<gr::Tags::SpacetimeMetric<Dim, Frame::Inertial, DataVector>,
+                 GeneralizedHarmonic::Tags::Pi<Dim, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Phi<Dim, Frame::Inertial>>;
+
+  const Mesh<Dim> mesh{5, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto};
+  const size_t num_points = mesh.number_of_grid_points();
+  Variables<evolved_vars_tags> evolved_vars{mesh.number_of_grid_points()};
+  get<GeneralizedHarmonic::Tags::Pi<Dim, Frame::Inertial>>(evolved_vars) =
+      make_with_random_values<tnsr::aa<DataVector, Dim, Frame::Inertial>>(
+          generator, make_not_null(&deriv_dist), num_points);
+  get<GeneralizedHarmonic::Tags::Phi<Dim, Frame::Inertial>>(evolved_vars) =
+      make_with_random_values<tnsr::iaa<DataVector, Dim, Frame::Inertial>>(
+          generator, make_not_null(&deriv_dist), num_points);
+  get<gr::Tags::SpacetimeMetric<Dim, Frame::Inertial, DataVector>>(
+      evolved_vars) =
+      make_with_random_values<tnsr::aa<DataVector, Dim, Frame::Inertial>>(
+          generator, make_not_null(&metric_dist), num_points);
+  get<0, 0>(get<gr::Tags::SpacetimeMetric<Dim, Frame::Inertial, DataVector>>(
+      evolved_vars)) += -2.0;
+  for (size_t i = 0; i < Dim; ++i) {
+    get<gr::Tags::SpacetimeMetric<Dim, Frame::Inertial, DataVector>>(
+        evolved_vars)
+        .get(i + 1, i + 1) += 4.0;
+    get<gr::Tags::SpacetimeMetric<Dim, Frame::Inertial, DataVector>>(
+        evolved_vars)
+        .get(i + 1, 0) *= 0.01;
+  }
+
+  auto box = db::create<db::AddSimpleTags<
+      ::Tags::Time, ::Tags::Variables<evolved_vars_tags>,
+      domain::Tags::Mesh<Dim>, domain::Tags::ElementMap<Dim, Frame::Grid>,
+      domain::CoordinateMaps::Tags::CoordinateMap<Dim, Frame::Grid,
+                                                  Frame::Inertial>,
+      domain::Tags::FunctionsOfTimeInitialize,
+      domain::Tags::Coordinates<Dim, Frame::ElementLogical>,
+      GeneralizedHarmonic::gauges::Tags::GaugeCondition>>(
+      0., evolved_vars, mesh,
+      ElementMap<Dim, Frame::Grid>{
+          ElementId<Dim>{0},
+          domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
+              domain::CoordinateMaps::Identity<Dim>{})},
+      domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+          domain::CoordinateMaps::Identity<Dim>{}),
+      std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{},
+      logical_coordinates(mesh),
+      std::unique_ptr<GeneralizedHarmonic::gauges::GaugeCondition>(
+          std::make_unique<GeneralizedHarmonic::gauges::DampedHarmonic>(
+              100., std::array{1.2, 1.5, 1.7}, std::array{2, 4, 6})));
+  db::mutate_apply<GeneralizedHarmonic::gauges::SetPiFromGauge<Dim>>(
+      make_not_null(&box));
+
+  // Verify that the gauge constraint is satisfied
+  const auto& spacetime_metric =
+      db::get<gr::Tags::SpacetimeMetric<Dim, Frame::Inertial, DataVector>>(box);
+  const auto& pi =
+      db::get<GeneralizedHarmonic::Tags::Pi<Dim, Frame::Inertial>>(box);
+  const auto& phi =
+      db::get<GeneralizedHarmonic::Tags::Phi<Dim, Frame::Inertial>>(box);
+
+  const auto spatial_metric = gr::spatial_metric(spacetime_metric);
+  auto [sqrt_det_spatial_metric, inverse_spatial_metric] =
+      determinant_and_inverse(spatial_metric);
+  get(sqrt_det_spatial_metric) = sqrt(get(sqrt_det_spatial_metric));
+  const auto shift = gr::shift(spacetime_metric, inverse_spatial_metric);
+  const auto lapse = gr::lapse(shift, spacetime_metric);
+  const auto inverse_spacetime_metric =
+      gr::inverse_spacetime_metric(lapse, shift, inverse_spatial_metric);
+  const auto spacetime_normal_one_form =
+      gr::spacetime_normal_one_form<Dim, Frame::Inertial>(lapse);
+  const auto spacetime_normal_vector =
+      gr::spacetime_normal_vector(lapse, shift);
+
+  tnsr::a<DataVector, Dim, Frame::Inertial> gauge_h(num_points);
+  tnsr::ab<DataVector, Dim, Frame::Inertial> d4_gauge_h(num_points);
+  GeneralizedHarmonic::gauges::dispatch(
+      make_not_null(&gauge_h), make_not_null(&d4_gauge_h), lapse, shift,
+      spacetime_normal_one_form, sqrt_det_spatial_metric,
+      inverse_spatial_metric, spacetime_metric, pi, phi, mesh,
+      db::get<::Tags::Time>(box),
+      db::get<domain::CoordinateMaps::Tags::CoordinateMap<Dim, Frame::Grid,
+                                                          Frame::Inertial>>(
+          box)(db::get<domain::Tags::ElementMap<Dim, Frame::Grid>>(box)(
+          db::get<domain::Tags::Coordinates<Dim, Frame::ElementLogical>>(box))),
+      {}, db::get<GeneralizedHarmonic::gauges::Tags::GaugeCondition>(box));
+
+  const auto gauge_constraint = GeneralizedHarmonic::gauge_constraint(
+      gauge_h, spacetime_normal_one_form, spacetime_normal_vector,
+      inverse_spatial_metric, inverse_spacetime_metric, pi, phi);
+  const tnsr::a<DataVector, Dim, Frame::Inertial> expected_gauge_constraint{
+      get<0>(gauge_constraint).size(), 0.};
+
+  Approx local_approx = Approx::custom().epsilon(1.e-10).scale(1.);
+  CHECK_ITERABLE_CUSTOM_APPROX(gauge_constraint, expected_gauge_constraint,
+                               local_approx);
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.GH.Gauge.SetPiFromGauge",
+                  "[Unit][Evolution][Actions]") {
+  MAKE_GENERATOR(generator);
+  test<1>(make_not_null(&generator));
+  test<2>(make_not_null(&generator));
+  test<3>(make_not_null(&generator));
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

This will replace the current DH gauge initialization action. This sets Pi in the initial data so we are in whatever evolution gauge is specified by H_a.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
