### PR TITLE
Add extra use case to UniformCylindricalSide

### DIFF
--- a/src/Domain/CoordinateMaps/UniformCylindricalSide.cpp
+++ b/src/Domain/CoordinateMaps/UniformCylindricalSide.cpp
@@ -148,15 +148,43 @@ UniformCylindricalSide::UniformCylindricalSide(
   };
   // LCOV_EXCL_STOP
 
-  ASSERT(cos_theta_min_one > cos(M_PI * 0.4),
+  const double cos_theta_min_one_lower_limit =
+      z_plane_plus_one_ == z_plane_plus_two_
+          ? cos(M_PI * 0.59)
+          : (z_plane_minus_one_ == z_plane_minus_two_ and
+                     cos_theta_max_one > cos(M_PI * 0.6)
+                 ? cos(M_PI * 0.3)
+                 : cos(M_PI * 0.4));
+
+  const double cos_theta_max_one_upper_limit =
+      z_plane_minus_one_ == z_plane_minus_two_
+          ? cos(M_PI * 0.41)
+          : (z_plane_plus_one_ == z_plane_plus_two_ and
+                     cos_theta_min_one < cos(M_PI * 0.4)
+                 ? cos(M_PI * 0.7)
+                 : cos(M_PI * 0.6));
+
+  const double cos_theta_min_two_upper_limit =
+      z_plane_plus_one_ == z_plane_plus_two_ and
+              cos_theta_min_one < cos(M_PI * 0.4)
+          ? cos(M_PI * 0.25)
+          : cos(M_PI * 0.15);
+
+  const double cos_theta_max_two_lower_limit =
+      z_plane_minus_one_ == z_plane_minus_two_ and
+              cos_theta_max_one > cos(M_PI * 0.6)
+          ? cos(M_PI * 0.75)
+          : cos(M_PI * 0.85);
+
+  ASSERT(cos_theta_min_one > cos_theta_min_one_lower_limit,
          "z_plane_plus_one is too close to the center of sphere_one: "
          "cos_theta_min_one must be > "
-             << cos(M_PI * 0.4) << " but is " << cos_theta_min_one
+             << cos_theta_min_one_lower_limit << " but is " << cos_theta_min_one
              << " instead." << param_string());
-  ASSERT(cos_theta_max_one < cos(M_PI * 0.6),
+  ASSERT(cos_theta_max_one < cos_theta_max_one_upper_limit,
          "z_plane_minus_one is too close to the center of sphere_one: "
          "cos_theta_max_one must be < "
-             << cos(M_PI * 0.6) << " but is " << cos_theta_max_one
+             << cos_theta_max_one_upper_limit << " but is " << cos_theta_max_one
              << " instead." << param_string());
   ASSERT(cos_theta_min_one < cos(M_PI * 0.15),
          "z_plane_plus_one is too far from the center of sphere_one: "
@@ -178,14 +206,14 @@ UniformCylindricalSide::UniformCylindricalSide(
                                   : cos(M_PI * 0.6)),
          "z_plane_minus_two is too close to the north pole: theta/pi="
              << acos(cos_theta_max_two) / M_PI << param_string());
-  ASSERT(cos_theta_min_two < cos(M_PI * 0.15),
+  ASSERT(cos_theta_min_two < cos_theta_min_two_upper_limit,
          "z_plane_plus_two is too close to the north pole: theta_min_two/pi="
-             << acos(cos_theta_min_two) / M_PI << " but it should be < 0.15"
-             << param_string());
-  ASSERT(cos_theta_max_two > cos(M_PI * 0.85),
+             << acos(cos_theta_min_two) / M_PI << " but it should be >"
+             << acos(cos_theta_min_two_upper_limit) / M_PI << param_string());
+  ASSERT(cos_theta_max_two > cos_theta_max_two_lower_limit,
          "z_plane_minus_two is too close to the south pole: theta_max_two/pi="
-             << acos(cos_theta_max_two) / M_PI << " but it should be > 0.85"
-             << param_string());
+             << acos(cos_theta_max_two) / M_PI << " but it should be < "
+             << acos(cos_theta_max_two_lower_limit) / M_PI << param_string());
 
   const double dist_spheres = sqrt(square(center_one[0] - center_two[0]) +
                                    square(center_one[1] - center_two[1]) +

--- a/src/Domain/CoordinateMaps/UniformCylindricalSide.cpp
+++ b/src/Domain/CoordinateMaps/UniformCylindricalSide.cpp
@@ -7,6 +7,7 @@
 #include <limits>
 #include <optional>
 #include <pup.h>
+#include <sstream>
 #include <utility>
 
 #include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
@@ -130,42 +131,61 @@ UniformCylindricalSide::UniformCylindricalSide(
   const double cos_theta_max_two =
       (z_plane_minus_two - center_two[2]) / radius_two;
 
+  // For some reason, codecov thinks that the following lambda never
+  // gets called, even though it is used in all of the ASSERT messages
+  // below.
+  // LCOV_EXCL_START
+  const auto param_string = [this]() -> std::string {
+    std::ostringstream buffer;
+    buffer << "\nParameters to UniformCylindricalSide:\nradius_one="
+           << radius_one_ << "\nradius_two=" << radius_two_
+           << "\ncenter_one=" << center_one_ << "\ncenter_two=" << center_two_
+           << "\nz_plane_plus_one=" << z_plane_plus_one_
+           << "\nz_plane_plus_two=" << z_plane_plus_two_
+           << "\nz_plane_minus_one=" << z_plane_minus_one_
+           << "\nz_plane_minus_two=" << z_plane_minus_two_;
+    return buffer.str();
+  };
+  // LCOV_EXCL_STOP
+
   ASSERT(cos_theta_min_one > cos(M_PI * 0.4),
          "z_plane_plus_one is too close to the center of sphere_one: "
          "cos_theta_min_one must be > "
              << cos(M_PI * 0.4) << " but is " << cos_theta_min_one
-             << " instead.");
+             << " instead." << param_string());
   ASSERT(cos_theta_max_one < cos(M_PI * 0.6),
          "z_plane_minus_one is too close to the center of sphere_one: "
          "cos_theta_max_one must be < "
              << cos(M_PI * 0.6) << " but is " << cos_theta_max_one
-             << " instead.");
+             << " instead." << param_string());
   ASSERT(cos_theta_min_one < cos(M_PI * 0.15),
          "z_plane_plus_one is too far from the center of sphere_one: "
          "cos_theta_min_one must be < "
              << cos(M_PI * 0.15) << " but is " << cos_theta_min_one
-             << " instead.");
+             << " instead." << param_string());
   ASSERT(cos_theta_max_one > cos(M_PI * 0.85),
          "z_plane_minus_one is too far from the center of sphere_one: "
          "cos_theta_max_one must be > "
              << cos(M_PI * 0.85) << " but is " << cos_theta_max_one
-             << " instead.");
+             << " instead." << param_string());
   ASSERT(cos_theta_min_two > (z_plane_plus_one_ == z_plane_plus_two_
                                   ? cos(M_PI * 0.75)
                                   : cos(M_PI * 0.4)),
          "z_plane_plus_two is too close to the south pole: theta/pi="
-             << acos(cos_theta_min_two) / M_PI);
+             << acos(cos_theta_min_two) / M_PI << param_string());
   ASSERT(cos_theta_max_two < (z_plane_minus_one_ == z_plane_minus_two_
                                   ? cos(M_PI * 0.25)
                                   : cos(M_PI * 0.6)),
          "z_plane_minus_two is too close to the north pole: theta/pi="
-             << acos(cos_theta_max_two) / M_PI);
+             << acos(cos_theta_max_two) / M_PI << param_string());
   ASSERT(cos_theta_min_two < cos(M_PI * 0.15),
          "z_plane_plus_two is too close to the north pole: theta_min_two/pi="
-             << acos(cos_theta_min_two) / M_PI << " but it should be < 0.15");
+             << acos(cos_theta_min_two) / M_PI << " but it should be < 0.15"
+             << param_string());
   ASSERT(cos_theta_max_two > cos(M_PI * 0.85),
          "z_plane_minus_two is too close to the south pole: theta_max_two/pi="
-             << acos(cos_theta_max_two) / M_PI << " but it should be > 0.85");
+             << acos(cos_theta_max_two) / M_PI << " but it should be > 0.85"
+             << param_string());
 
   const double dist_spheres = sqrt(square(center_one[0] - center_two[0]) +
                                    square(center_one[1] - center_two[1]) +
@@ -178,7 +198,7 @@ UniformCylindricalSide::UniformCylindricalSide(
              << radius_one << ", radius_two = " << radius_two
              << ", dist_spheres = " << dist_spheres
              << ", (dist_spheres+radius_one)/radius_two="
-             << (dist_spheres + radius_one) / radius_two);
+             << (dist_spheres + radius_one) / radius_two << param_string());
 
   const double horizontal_dist_spheres =
       sqrt(square(center_one[0] - center_two[0]) +
@@ -193,7 +213,7 @@ UniformCylindricalSide::UniformCylindricalSide(
            " Radius_one = "
                << radius_one << ", radius_two = " << radius_two
                << " center_one[2] = " << center_one[2]
-               << " center_two[2] = " << center_two[2]);
+               << " center_two[2] = " << center_two[2] << param_string());
   }
 
   if (z_plane_plus_two == z_plane_plus_one) {
@@ -201,7 +221,7 @@ UniformCylindricalSide::UniformCylindricalSide(
            "The map has been tested only if the sphere_two planes are far "
            "enough apart. z_plane_plus_two="
                << z_plane_plus_two << " z_plane_minus_two=" << z_plane_minus_two
-               << " radius_two=" << radius_two);
+               << " radius_two=" << radius_two << param_string());
   }
 
   if (z_plane_minus_two == z_plane_minus_one) {
@@ -209,7 +229,7 @@ UniformCylindricalSide::UniformCylindricalSide(
            "The map has been tested only if the sphere_two planes are far "
            "enough apart. z_plane_plus_two="
                << z_plane_plus_two << " z_plane_minus_two=" << z_plane_minus_two
-               << " radius_two=" << radius_two);
+               << " radius_two=" << radius_two << param_string());
   }
 
   ASSERT(horizontal_dist_spheres <=
@@ -226,7 +246,8 @@ UniformCylindricalSide::UniformCylindricalSide(
          " Radius_one = "
              << radius_one << ", radius_two = " << radius_two
              << ", dist_spheres = " << dist_spheres
-             << ", horizontal_dist_spheres = " << horizontal_dist_spheres);
+             << ", horizontal_dist_spheres = " << horizontal_dist_spheres
+             << param_string());
 
   const double theta_min_one = acos(cos_theta_min_one);
   const double theta_max_one = acos(cos_theta_max_one);
@@ -250,7 +271,8 @@ UniformCylindricalSide::UniformCylindricalSide(
              << ", theta_min_two = " << theta_min_two
              << ", max_horizontal_dist_between_circles_plus = "
              << max_horizontal_dist_between_circles_plus
-             << ", horizontal_dist_spheres = " << horizontal_dist_spheres);
+             << ", horizontal_dist_spheres = " << horizontal_dist_spheres
+             << param_string());
 
   const double alpha_minus = atan2(z_plane_minus_one - z_plane_minus_two,
                                    max_horizontal_dist_between_circles_minus);
@@ -261,7 +283,8 @@ UniformCylindricalSide::UniformCylindricalSide(
              << ", theta_max_two = " << theta_max_two
              << ", max_horizontal_dist_between_circles_minus = "
              << max_horizontal_dist_between_circles_minus
-             << ", horizontal_dist_spheres = " << horizontal_dist_spheres);
+             << ", horizontal_dist_spheres = " << horizontal_dist_spheres
+             << param_string());
 #endif
 }
 

--- a/src/Domain/CoordinateMaps/UniformCylindricalSide.hpp
+++ b/src/Domain/CoordinateMaps/UniformCylindricalSide.hpp
@@ -584,21 +584,66 @@ namespace domain::CoordinateMaps {
  * \f$\theta_{2 \mathrm{min}}\f$ and
  * \f$\theta_{2 \mathrm{max}}\f$ are no longer required
  * to be on opposite sides of the equator of sphere 2 (see the paragraph below).
+ * Note that for unequal z planes \f$\theta_{1 \mathrm{min}}\f$ and
+ * \f$\theta_{1 \mathrm{max}}\f$ are no longer required
+ * to be on opposite sides of the equator of sphere 1, but the conditions
+ * in the paragraph below guarantee that
+ * \f$z^+_{\mathrm{P}1} \geq z^-_{\mathrm{P}1}\f$.
  *
- * As in the case with unequal z planes, we require that the
+ * Unlike the case with unequal z planes, we no longer require that the
  * z planes in the above figures lie above/below
- * the centers of the corresponding spheres and are not too close to
- * the centers or edges of those spheres, but some of the restrictions are
- * relaxed because of expected use cases.  The conditions are the
- * same as Eqs. (\f$\ref{eq:theta_1_min_res}\f$--\f$\ref{eq:theta_2_max_res}\f$)
- * except if \f$z^+_{\mathrm{P}1} = z^+_{\mathrm{P}2}\f$
- * we replace Eq. (\f$\ref{eq:theta_2_min_res}\f$) with
+ * the centers of the corresponding spheres, but we still require that
+ * the z planes are not too close to the edges of those spheres.
+ * The restrictions are the same as
+ * Eqs. (\f$\ref{eq:theta_1_min_res}\f$--\f$\ref{eq:theta_2_max_res}\f$)
+ * except for the following changes:
+ * If \f$z^+_{\mathrm{P}1} = z^+_{\mathrm{P}2}\f$,
+ * then we replace Eq. (\f$\ref{eq:theta_1_min_res}\f$) with
  * \f{align}
- *   0.15\pi &< \theta_{2 \mathrm{min}} < 0.75\pi ,
+ *   \label{eq:equal_plus_theta_1_min_res}
+ *   0.15\pi &< \theta_{1 \mathrm{min}} < 0.59\pi,
  * \f}
- * and if \f$z^-_{\mathrm{P}1} = z^-_{\mathrm{P}2}\f$ we replace
- * Eq. (\f$\ref{eq:theta_2_max_res}\f$) with
+ * and furthermore, if \f$z^+_{\mathrm{P}1} = z^+_{\mathrm{P}2}\f$ and
+ * \f$\theta_{1 \mathrm{min}} > 0.4\pi\f$ we replace
+ * Eqs. (\f$\ref{eq:theta_1_max_res}\f$--\f$\ref{eq:theta_2_min_res}\f$)
+ * with
  * \f{align}
+ *   \label{eq:equal_plus_high_theta_1_max_res}
+ *   0.7\pi &< \theta_{1 \mathrm{max}} < 0.85\pi \\
+ *   \label{eq:equal_plus_high_theta_2_min_res}
+ *   0.25\pi &< \theta_{2 \mathrm{min}} < 0.75\pi,
+ * \f}
+ * but if \f$z^+_{\mathrm{P}1} = z^+_{\mathrm{P}2}\f$ and
+ * \f$\theta_{1 \mathrm{min}} \leq 0.4\pi\f$ we replace
+ * Eq. (\f$\ref{eq:theta_2_min_res}\f$)
+ * with
+ * \f{align}
+ *   \label{eq:equal_plus_low_theta_2_min_res}
+ *   0.15\pi &< \theta_{2 \mathrm{min}} < 0.75\pi.
+ * \f}
+ *
+ * Similarly, if \f$z^-_{\mathrm{P}1} = z^-_{\mathrm{P}2}\f$ we replace
+ * (\f$\ref{eq:theta_1_max_res}\f$) with
+ * \f{align}
+ *   \label{eq:equal_minus_theta_1_max_res}
+ *   0.41\pi &< \theta_{1 \mathrm{max}} < 0.85\pi,
+ * \f}
+ * and furthermore, if \f$z^-_{\mathrm{P}1} = z^-_{\mathrm{P}2}\f$ and
+ * \f$\theta_{1 \mathrm{max}} < 0.6\pi\f$ we replace
+ * Eqs. (\f$\ref{eq:theta_1_min_res}\f$) and (\f$\ref{eq:theta_2_max_res}\f$)
+ * with
+ * \f{align}
+ *   \label{eq:equal_minus_high_theta_1_min_res}
+ *   0.15\pi &< \theta_{1 \mathrm{min}} < 0.3\pi \\
+ *   \label{eq:equal_minus_high_theta_2_max_res}
+ *   0.25\pi &< \theta_{2 \mathrm{max}} < 0.75\pi,
+ * \f}
+ * but if \f$z^-_{\mathrm{P}1} = z^-_{\mathrm{P}2}\f$ and
+ * \f$\theta_{1 \mathrm{max}} \geq 0.6\pi\f$ we replace
+ * Eq. (\f$\ref{eq:theta_2_max_res}\f$)
+ * with
+ * \f{align}
+ *   \label{eq:equal_minus_low_theta_2_max_res}
  *   0.25\pi &< \theta_{2 \mathrm{max}} < 0.85\pi .
  * \f}
  */

--- a/tests/Unit/Domain/CoordinateMaps/Test_UniformCylindricalSide.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_UniformCylindricalSide.cpp
@@ -35,8 +35,33 @@ void test_uniform_cylindrical_side_planes_equal(
   const double radius_two = 6.0 * (unit_dis(gen) + 1.0);
   CAPTURE(radius_two);
 
+  // Choose z_plane_frac_plus_one=(z_plane_plus_one-center_one[2])/radius_one
+  // Note here that max_angle_one_plus is > 0.5, so that
+  // z_plane_plus_one can be at a lower value of z than center_one[2],
+  // and thus z_plane_frac_plus_one may be positive or negative.
+  const double min_angle_one_plus = 0.15;
+  const double max_angle_one_plus = 0.59;
+  const double angle_one_plus =
+      min_angle_one_plus +
+      (max_angle_one_plus - min_angle_one_plus) * unit_dis(gen);
+  const double z_plane_frac_plus_one = cos(angle_one_plus * M_PI);
+
+  // Choose z_plane_frac_minus_one=(z_plane_minus_one-center_one[2])/radius_one
+  // (note that this quantity is < 0).
+  const double min_angle_one_minus = 0.15;
+  const double max_angle_one_minus = angle_one_plus > 0.4 ? 0.3 : 0.4;
+  // Note that we deliberately choose max_angle_one_plus +
+  // max_angle_one_minus < 1.  This ensures that z_plane_frac_plus_one
+  // > z_plane_frac_minus_one, which is important for
+  // max_radius_one_planes below.
+  const double z_plane_frac_minus_one =
+      -cos((min_angle_one_minus +
+            (max_angle_one_minus - min_angle_one_minus) * unit_dis(gen)) *
+           M_PI);
+
   // Choose an angle for the positive z-plane
-  const double min_angle_shared = 0.15;
+  // Don't go too close to the edge if angle_one_plus is large.
+  const double min_angle_shared = angle_one_plus > 0.4 ? 0.25 : 0.15;
   const double max_angle_shared = 0.75;
   const double z_plane_plus_two =
       center_two[2] +
@@ -68,17 +93,6 @@ void test_uniform_cylindrical_side_planes_equal(
           M_PI) *
           radius_two;
   CAPTURE(z_plane_minus_two);
-
-  // Choose z_plane_frac_minus_one=(z_plane_minus_one-center_one[2])/radius_one
-  // (note that this quantity is < 0).
-  const double min_angle = 0.15;
-  const double max_angle = 0.4;
-  const double z_plane_frac_minus_one =
-      -cos((min_angle + (max_angle - min_angle) * unit_dis(gen)) * M_PI);
-
-  // Choose z_plane_frac_plus_one=(z_plane_plus_one-center_one[2])/radius_one
-  const double z_plane_frac_plus_one =
-      cos((min_angle + (max_angle - min_angle) * unit_dis(gen)) * M_PI);
 
   // Choose radius of sphere_one.
   const double radius_one = [&z_plane_frac_plus_one, &z_plane_frac_minus_one,


### PR DESCRIPTION
## Proposed changes

 In the case where z_plane_plus_one=z_plane_plus_two or z_plane_minus_one=z_plane_minus_two, no longer demand that z_plane_plus_one and z_plane_minus_one are on the opposite sides of the equator of sphere_one.
    
 This is important for the case of the BBH cylindrical domain where there are extra cylindrical outer shells (what SpEC calls "SphereC"s).  We cannot make SphereCs without this PR.
    
This PR does not change the map at all: it changes only the set of allowed input parameters, the parameters that are used in the test, and the documentation. (Sorry I didn't realize I needed this use case until after UniformCylindricalSide was merged).

The first commit improves the error-message handling in UniformCylindricalSide, before making the larger changes.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
